### PR TITLE
feat(cli): add k3s runtime backend for local Kubernetes sessions

### DIFF
--- a/charts/skuld/templates/ingress.yaml
+++ b/charts/skuld/templates/ingress.yaml
@@ -5,14 +5,36 @@ metadata:
   name: {{ include "skuld.fullname" . }}
   labels:
     {{- include "skuld.labels" . | nindent 4 }}
+  {{- if eq (default "host" .Values.ingress.mode) "path" }}
+  annotations:
+    traefik.ingress.kubernetes.io/router.middlewares: {{ .Release.Namespace }}-{{ include "skuld.fullname" . }}-strip@kubernetescrd
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- else }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
 spec:
   {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
+  {{- if eq (default "host" .Values.ingress.mode) "path" }}
+  {{/* Path-based routing: no host field, uses /s/{session-id} prefix */}}
+  rules:
+    - http:
+        paths:
+          - path: /s/{{ .Values.session.id }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "skuld.fullname" . }}
+                port:
+                  name: http
+  {{- else }}
+  {{/* Host-based routing (default): hostname-based with optional TLS */}}
   {{- if .Values.ingress.tls.enabled }}
   tls:
     - hosts:
@@ -31,4 +53,5 @@ spec:
                 name: {{ include "skuld.fullname" . }}
                 port:
                   name: http
+  {{- end }}
 {{- end }}

--- a/charts/skuld/templates/strip-prefix-middleware.yaml
+++ b/charts/skuld/templates/strip-prefix-middleware.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.ingress.enabled (eq (default "host" .Values.ingress.mode) "path") -}}
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ include "skuld.fullname" . }}-strip
+  labels:
+    {{- include "skuld.labels" . | nindent 4 }}
+spec:
+  stripPrefix:
+    prefixes:
+      - /s/{{ .Values.session.id }}
+{{- end }}

--- a/charts/skuld/values.yaml
+++ b/charts/skuld/values.yaml
@@ -152,6 +152,8 @@ service:
 ingress:
   # -- Enable ingress
   enabled: true
+  # -- Ingress routing mode: "host" (hostname-based, default) or "path" (path-prefix, for IP-only access)
+  mode: host
   # -- Ingress class name
   className: traefik
   # -- Ingress annotations (controller-specific)

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -39,6 +39,13 @@ type DockerConfig struct {
 	Network         string `yaml:"network"`
 }
 
+// K3sConfig holds k3s/k3d runtime settings.
+type K3sConfig struct {
+	Kubeconfig string `yaml:"kubeconfig"` // default: auto-detect
+	Namespace  string `yaml:"namespace"`  // default: volundr
+	Provider   string `yaml:"provider"`   // "auto", "k3d", "native" (default: auto)
+}
+
 // Config represents the full volundr configuration.
 type Config struct {
 	Runtime   string          `yaml:"runtime"`
@@ -47,6 +54,7 @@ type Config struct {
 	Database  DatabaseConfig  `yaml:"database"`
 	Anthropic AnthropicConfig `yaml:"anthropic"`
 	Docker    DockerConfig    `yaml:"docker,omitempty"`
+	K3s       K3sConfig       `yaml:"k3s,omitempty"`
 }
 
 // ListenConfig holds the listener settings.
@@ -136,6 +144,11 @@ func DefaultConfig() (*Config, error) {
 			CodeServerImage: "ghcr.io/niuu/code-server:latest",
 			TtydImage:       "ghcr.io/niuu/ttyd:latest",
 			Network:         "volundr-net",
+		},
+		K3s: K3sConfig{
+			Kubeconfig: "",
+			Namespace:  "volundr",
+			Provider:   "auto",
 		},
 	}, nil
 }

--- a/cli/internal/runtime/factory.go
+++ b/cli/internal/runtime/factory.go
@@ -7,8 +7,7 @@ func NewRuntime(runtimeType string) Runtime {
 	case "docker":
 		return NewDockerRuntime()
 	case "k3s":
-		// k3s not yet implemented
-		return NewLocalRuntime() // fallback for now
+		return NewK3sRuntime()
 	default:
 		return NewLocalRuntime()
 	}

--- a/cli/internal/runtime/k3s.go
+++ b/cli/internal/runtime/k3s.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -10,10 +11,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
-	"syscall"
-	"time"
+	"text/template"
+
 
 	"github.com/niuulabs/volundr/cli/internal/config"
 	"github.com/niuulabs/volundr/cli/internal/postgres"
@@ -38,13 +38,60 @@ const (
 	k3sHelmChart = "oci://ghcr.io/niuulabs/charts/skuld"
 	// k3sAPIInternalPort is the host port the API listens on in k3s mode.
 	k3sAPIInternalPort = 18080
-	// k3sAPIStartTimeout is the maximum time to wait for the API to start.
-	k3sAPIStartTimeout = 30 * time.Second
-	// k3sAPIHealthCheckInterval is the interval between API health checks.
-	k3sAPIHealthCheckInterval = 500 * time.Millisecond
-	// k3sProcessShutdownTimeout is the time to wait for graceful process shutdown.
-	k3sProcessShutdownTimeout = 5 * time.Second
 )
+
+// k3sComposeFileName is the generated compose file name for k3s mode.
+const k3sComposeFileName = "docker-compose.k3s.yaml"
+
+// k3sContainerName is the API container name in k3s mode.
+const k3sContainerName = "volundr-k3s-api"
+
+// k3sComposeTemplate is the Docker Compose template for the API in k3s mode.
+// It mounts the kubeconfig so the API can talk to the k3d cluster.
+var k3sComposeTemplate = template.Must(template.New("k3s-compose").Parse(`services:
+  api:
+    image: {{.APIImage}}
+    container_name: {{.ContainerName}}
+    ports:
+      - "127.0.0.1:{{.APIPort}}:8080"
+    environment:
+      DATABASE__HOST: "{{.DBHost}}"
+      DATABASE__PORT: "{{.DBPort}}"
+      DATABASE__USER: "{{.DBUser}}"
+      DATABASE__PASSWORD: "{{.DBPassword}}"
+      DATABASE__NAME: "{{.DBName}}"
+{{- if .AnthropicAPIKey}}
+      ANTHROPIC_API_KEY: "{{.AnthropicAPIKey}}"
+{{- end}}
+      KUBECONFIG: "/etc/volundr/kubeconfig"
+    volumes:
+      - "{{.ConfigPath}}:/etc/volundr/config.yaml:ro"
+      - "{{.KubeconfigPath}}:/etc/volundr/kubeconfig:ro"
+      - "{{.StorageDir}}:/volundr-storage"
+    networks:
+      - k3d-{{.ClusterName}}
+
+networks:
+  k3d-{{.ClusterName}}:
+    external: true
+`))
+
+// k3sComposeData holds the template data for the k3s compose file.
+type k3sComposeData struct {
+	APIImage        string
+	ContainerName   string
+	APIPort         int
+	DBHost          string
+	DBPort          int
+	DBUser          string
+	DBPassword      string
+	DBName          string
+	AnthropicAPIKey string
+	ConfigPath      string
+	KubeconfigPath  string
+	StorageDir      string
+	ClusterName     string
+}
 
 // k3sAPIConfig represents the Python API config file structure for k3s mode.
 type k3sAPIConfig struct {
@@ -59,10 +106,9 @@ type k3sAPIConfig struct {
 }
 
 // K3sRuntime manages the Volundr stack using k3s/k3d for Kubernetes
-// workloads with host-side services for PostgreSQL and the API.
+// workloads with a Docker container for the API and embedded PostgreSQL.
 type K3sRuntime struct {
 	pg       *postgres.EmbeddedPostgres
-	apiCmd   *exec.Cmd
 	proxyRtr *proxy.Router
 }
 
@@ -193,14 +239,13 @@ func (r *K3sRuntime) Up(ctx context.Context, cfg *config.Config) error {
 	}
 	fmt.Println("ok")
 
-	// Start the Python API on the host.
+	// Start the API in a Docker container connected to the k3d network.
 	fmt.Print("  Volundr API   ... ")
-	apiPort := cfg.Listen.Port + 1
-	if err := r.startAPI(ctx, cfg, apiPort); err != nil {
+	if err := r.startAPIContainer(ctx, cfg); err != nil {
 		fmt.Println("failed")
-		return fmt.Errorf("start API: %w", err)
+		return fmt.Errorf("start API container: %w", err)
 	}
-	fmt.Printf("started (port %d)\n", apiPort)
+	fmt.Printf("started (port %d)\n", k3sAPIInternalPort)
 
 	// Install/upgrade the skuld base Helm chart.
 	fmt.Print("  Skuld chart   ... ")
@@ -212,7 +257,7 @@ func (r *K3sRuntime) Up(ctx context.Context, cfg *config.Config) error {
 
 	// Start the reverse proxy.
 	fmt.Print("  Proxy         ... ")
-	apiURL := fmt.Sprintf("http://127.0.0.1:%d", apiPort)
+	apiURL := fmt.Sprintf("http://127.0.0.1:%d", k3sAPIInternalPort)
 	rtr, err := proxy.NewRouter(apiURL)
 	if err != nil {
 		fmt.Println("failed")
@@ -276,17 +321,19 @@ func (r *K3sRuntime) Down(_ context.Context) error {
 		}
 	}
 
-	// Stop API process.
-	if r.apiCmd != nil && r.apiCmd.Process != nil {
-		if err := r.apiCmd.Process.Signal(syscall.SIGTERM); err != nil {
-			errs = append(errs, fmt.Sprintf("stop API: %v", err))
-		}
-		done := make(chan error, 1)
-		go func() { done <- r.apiCmd.Wait() }()
-		select {
-		case <-done:
-		case <-time.After(k3sProcessShutdownTimeout):
-			_ = r.apiCmd.Process.Kill()
+	// Stop API container via docker compose.
+	if cfgDir, dirErr := config.ConfigDir(); dirErr == nil {
+		composePath := filepath.Join(cfgDir, k3sComposeFileName)
+		if _, statErr := os.Stat(composePath); statErr == nil {
+			if out, composeErr := exec.Command(
+				"docker", "compose",
+				"-f", composePath,
+				"-p", "volundr-k3s",
+				"down",
+			).CombinedOutput(); composeErr != nil {
+				errs = append(errs, fmt.Sprintf("docker compose down: %v\n%s", composeErr, out))
+			}
+			_ = os.Remove(composePath)
 		}
 	}
 
@@ -701,9 +748,14 @@ func (r *K3sRuntime) generateK3sConfig(cfg *config.Config) (string, error) {
 	namespace := r.namespace(cfg)
 	kubeconfig := r.resolveKubeconfig(cfg)
 
+	dbHost := cfg.Database.Host
+	if cfg.Database.Mode == "embedded" {
+		dbHost = "host.docker.internal"
+	}
+
 	apiCfg := k3sAPIConfig{
 		Database: map[string]interface{}{
-			"host":     "127.0.0.1",
+			"host":     dbHost,
 			"port":     cfg.Database.Port,
 			"user":     cfg.Database.User,
 			"password": cfg.Database.Password,
@@ -762,56 +814,107 @@ func (r *K3sRuntime) generateK3sConfig(cfg *config.Config) (string, error) {
 	return configPath, nil
 }
 
-// startAPI starts the Python API process on the host.
-func (r *K3sRuntime) startAPI(ctx context.Context, cfg *config.Config, port int) error {
+// startAPIContainer starts the Python API in a Docker container
+// connected to the k3d network so it can reach the cluster.
+func (r *K3sRuntime) startAPIContainer(_ context.Context, cfg *config.Config) error {
 	cfgDir, err := config.ConfigDir()
 	if err != nil {
 		return fmt.Errorf("get config dir: %w", err)
 	}
 
-	logFile, err := os.OpenFile(
-		filepath.Join(cfgDir, "logs", "api.log"),
-		os.O_CREATE|os.O_WRONLY|os.O_APPEND,
-		0o644,
-	)
+	// Resolve kubeconfig — for k3d we need the internal k3d kubeconfig
+	// that uses the Docker network DNS name instead of localhost.
+	kubeconfigPath, err := r.writeK3dKubeconfig(cfgDir)
 	if err != nil {
-		return fmt.Errorf("open API log file: %w", err)
+		return fmt.Errorf("write k3d kubeconfig: %w", err)
 	}
 
-	configPath := filepath.Join(cfgDir, k3sConfigFileName)
-
-	r.apiCmd = exec.CommandContext(ctx,
-		"python3", "-m", "uvicorn",
-		"volundr.main:app",
-		"--host", "127.0.0.1",
-		"--port", strconv.Itoa(port),
-	)
-
-	r.apiCmd.Stdout = logFile
-	r.apiCmd.Stderr = logFile
-
-	// Set environment variables.
-	r.apiCmd.Env = append(os.Environ(),
-		fmt.Sprintf("DATABASE__HOST=127.0.0.1"),
-		fmt.Sprintf("DATABASE__PORT=%d", cfg.Database.Port),
-		fmt.Sprintf("DATABASE__USER=%s", cfg.Database.User),
-		fmt.Sprintf("DATABASE__PASSWORD=%s", cfg.Database.Password),
-		fmt.Sprintf("DATABASE__NAME=%s", cfg.Database.Name),
-		fmt.Sprintf("VOLUNDR_CONFIG=%s", configPath),
-	)
-
-	if cfg.Anthropic.APIKey != "" {
-		r.apiCmd.Env = append(r.apiCmd.Env,
-			fmt.Sprintf("ANTHROPIC_API_KEY=%s", cfg.Anthropic.APIKey),
-		)
+	dbHost := cfg.Database.Host
+	if cfg.Database.Mode == "embedded" {
+		dbHost = "host.docker.internal"
 	}
 
-	if err := r.apiCmd.Start(); err != nil {
-		logFile.Close()
-		return fmt.Errorf("start uvicorn: %w", err)
+	data := k3sComposeData{
+		APIImage:        dockerImageOrDefault(cfg.Docker.APIImage, "ghcr.io/niuu/volundr-api:latest"),
+		ContainerName:   k3sContainerName,
+		APIPort:         k3sAPIInternalPort,
+		DBHost:          dbHost,
+		DBPort:          cfg.Database.Port,
+		DBUser:          cfg.Database.User,
+		DBPassword:      cfg.Database.Password,
+		DBName:          cfg.Database.Name,
+		AnthropicAPIKey: cfg.Anthropic.APIKey,
+		ConfigPath:      filepath.Join(cfgDir, k3sConfigFileName),
+		KubeconfigPath:  kubeconfigPath,
+		StorageDir:      cfgDir,
+		ClusterName:     k3sClusterName,
+	}
+
+	var buf bytes.Buffer
+	if err := k3sComposeTemplate.Execute(&buf, data); err != nil {
+		return fmt.Errorf("render compose template: %w", err)
+	}
+
+	composePath := filepath.Join(cfgDir, k3sComposeFileName)
+	if err := os.WriteFile(composePath, buf.Bytes(), 0o644); err != nil {
+		return fmt.Errorf("write compose file: %w", err)
+	}
+
+	// Start the container.
+	out, err := exec.Command(
+		"docker", "compose",
+		"-f", composePath,
+		"-p", "volundr-k3s",
+		"up", "-d",
+	).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("docker compose up: %w\n%s", err, out)
 	}
 
 	return nil
+}
+
+// writeK3dKubeconfig writes a kubeconfig suitable for use inside a Docker
+// container on the k3d network. The API server address is rewritten to
+// use the k3d server container name instead of localhost.
+func (r *K3sRuntime) writeK3dKubeconfig(cfgDir string) (string, error) {
+	// Get the k3d kubeconfig with internal server address.
+	out, err := exec.Command(
+		"k3d", "kubeconfig", "get", k3sClusterName,
+	).CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("get k3d kubeconfig: %w\n%s", err, out)
+	}
+
+	// The k3d kubeconfig points to localhost:<random-port>.
+	// Replace with the k3d server container's Docker DNS name
+	// so it works from inside the k3d Docker network.
+	kubeconfig := string(out)
+	// k3d server container is named k3d-<cluster>-server-0
+	// and listens on port 6443 internally.
+	serverDNS := fmt.Sprintf("https://k3d-%s-server-0:6443", k3sClusterName)
+	// Replace any https://0.0.0.0:<port> or https://127.0.0.1:<port>
+	// or https://localhost:<port> references.
+	for _, prefix := range []string{
+		"https://0.0.0.0:", "https://127.0.0.1:", "https://localhost:",
+	} {
+		if idx := strings.Index(kubeconfig, prefix); idx >= 0 {
+			end := strings.Index(kubeconfig[idx+len(prefix):], "\n")
+			if end < 0 {
+				end = len(kubeconfig[idx+len(prefix):])
+			}
+			old := kubeconfig[idx : idx+len(prefix)+end]
+			kubeconfig = strings.Replace(kubeconfig, old, serverDNS, 1)
+			break
+		}
+	}
+
+	kubeconfigPath := filepath.Join(cfgDir, "k3d-kubeconfig.yaml")
+	if err := os.WriteFile(kubeconfigPath, []byte(kubeconfig), 0o600); err != nil {
+		return "", fmt.Errorf("write kubeconfig: %w", err)
+	}
+
+	return kubeconfigPath, nil
 }
 
 // installSkuldChart installs or upgrades the skuld Helm chart.
@@ -838,15 +941,7 @@ func (r *K3sRuntime) installSkuldChart(cfg *config.Config) error {
 func (r *K3sRuntime) writeStateFile(cfg *config.Config) error {
 	services := []ServiceStatus{
 		{Name: "proxy", State: StateRunning, Port: cfg.Listen.Port},
-	}
-
-	if r.apiCmd != nil && r.apiCmd.Process != nil {
-		services = append(services, ServiceStatus{
-			Name:  "api",
-			State: StateRunning,
-			PID:   r.apiCmd.Process.Pid,
-			Port:  cfg.Listen.Port + 1,
-		})
+		{Name: "api", State: StateRunning, Port: k3sAPIInternalPort},
 	}
 
 	if cfg.Database.Mode == "embedded" {

--- a/cli/internal/runtime/k3s.go
+++ b/cli/internal/runtime/k3s.go
@@ -1,0 +1,819 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/niuulabs/volundr/cli/internal/config"
+	"github.com/niuulabs/volundr/cli/internal/postgres"
+	"github.com/niuulabs/volundr/cli/internal/proxy"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// k3sConfigFileName is the generated API config file name for k3s mode.
+	k3sConfigFileName = "k3s-config.yaml"
+	// k3sDefaultNamespace is the default Kubernetes namespace for Volundr.
+	k3sDefaultNamespace = "volundr"
+	// k3sClusterName is the k3d cluster name.
+	k3sClusterName = "volundr"
+	// k3sLoadBalancerHTTPPort is the HTTP port exposed by the k3d load balancer.
+	k3sLoadBalancerHTTPPort = "80:80@loadbalancer"
+	// k3sLoadBalancerHTTPSPort is the HTTPS port exposed by the k3d load balancer.
+	k3sLoadBalancerHTTPSPort = "443:443@loadbalancer"
+	// k3sHelmReleaseName is the Helm release name for the base Skuld chart.
+	k3sHelmReleaseName = "skuld-base"
+	// k3sHelmChart is the OCI chart reference for Skuld.
+	k3sHelmChart = "oci://ghcr.io/niuulabs/charts/skuld"
+	// k3sAPIInternalPort is the host port the API listens on in k3s mode.
+	k3sAPIInternalPort = 18080
+	// k3sAPIStartTimeout is the maximum time to wait for the API to start.
+	k3sAPIStartTimeout = 30 * time.Second
+	// k3sAPIHealthCheckInterval is the interval between API health checks.
+	k3sAPIHealthCheckInterval = 500 * time.Millisecond
+	// k3sProcessShutdownTimeout is the time to wait for graceful process shutdown.
+	k3sProcessShutdownTimeout = 5 * time.Second
+)
+
+// k3sAPIConfig represents the Python API config file structure for k3s mode.
+type k3sAPIConfig struct {
+	Database        map[string]interface{} `yaml:"database"`
+	PodManager      map[string]interface{} `yaml:"pod_manager"`
+	CredentialStore map[string]interface{} `yaml:"credential_store"`
+	Storage         map[string]interface{} `yaml:"storage"`
+	SecretInjection map[string]interface{} `yaml:"secret_injection"`
+	Identity        map[string]interface{} `yaml:"identity"`
+	Authorization   map[string]interface{} `yaml:"authorization"`
+	Gateway         map[string]interface{} `yaml:"gateway"`
+}
+
+// K3sRuntime manages the Volundr stack using k3s/k3d for Kubernetes
+// workloads with host-side services for PostgreSQL and the API.
+type K3sRuntime struct {
+	pg       *postgres.EmbeddedPostgres
+	apiCmd   *exec.Cmd
+	proxyRtr *proxy.Router
+}
+
+// NewK3sRuntime creates a new K3sRuntime.
+func NewK3sRuntime() *K3sRuntime {
+	return &K3sRuntime{}
+}
+
+// Init performs first-time setup for the k3s runtime.
+func (r *K3sRuntime) Init(ctx context.Context, cfg *config.Config) error {
+	cfgDir, err := config.ConfigDir()
+	if err != nil {
+		return fmt.Errorf("get config dir: %w", err)
+	}
+
+	// Create required directories.
+	dirs := []string{
+		filepath.Join(cfgDir, "data", "pg"),
+		filepath.Join(cfgDir, "logs"),
+		filepath.Join(cfgDir, "cache"),
+	}
+	for _, dir := range dirs {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return fmt.Errorf("create directory %s: %w", dir, err)
+		}
+	}
+
+	// Detect the k3s provider.
+	provider := r.detectProvider(cfg)
+	fmt.Printf("  Platform: %s\n", runtime.GOOS)
+	fmt.Printf("  K3s provider: %s\n", provider)
+
+	switch provider {
+	case "k3d":
+		if err := r.initK3d(ctx); err != nil {
+			return err
+		}
+	case "native":
+		if err := r.initNativeK3s(); err != nil {
+			return err
+		}
+	default:
+		return r.guideInstallation()
+	}
+
+	// Verify helm is available.
+	fmt.Print("  Helm            ... ")
+	if out, err := exec.Command("helm", "version", "--short").CombinedOutput(); err != nil {
+		fmt.Println("not found")
+		return fmt.Errorf("helm is required but not found. Install: https://helm.sh/docs/intro/install/\n%s", out)
+	}
+	fmt.Println("ok")
+
+	// Create the volundr namespace.
+	namespace := r.namespace(cfg)
+	fmt.Printf("  Namespace       ... ")
+	if err := r.ensureNamespace(namespace); err != nil {
+		fmt.Println("failed")
+		return fmt.Errorf("create namespace: %w", err)
+	}
+	fmt.Println("ok")
+
+	// Test embedded postgres if in embedded mode.
+	if cfg.Database.Mode == "embedded" {
+		fmt.Println("  Downloading PostgreSQL binary...")
+		pg := postgres.New(cfg)
+		if err := pg.Start(ctx); err != nil {
+			return fmt.Errorf("test embedded postgres: %w", err)
+		}
+		if err := pg.Stop(); err != nil {
+			return fmt.Errorf("stop test postgres: %w", err)
+		}
+		fmt.Println("  PostgreSQL binary    ... ok")
+	}
+
+	return nil
+}
+
+// Up starts all services in k3s mode.
+func (r *K3sRuntime) Up(ctx context.Context, cfg *config.Config) error {
+	if err := CheckNotRunning(); err != nil {
+		return err
+	}
+
+	// Start embedded PostgreSQL if configured.
+	if cfg.Database.Mode == "embedded" {
+		fmt.Print("  PostgreSQL    ... ")
+		r.pg = postgres.New(cfg)
+		if err := r.pg.Start(ctx); err != nil {
+			fmt.Println("failed")
+			return fmt.Errorf("start embedded postgres: %w", err)
+		}
+		fmt.Printf("started (port %d, data: %s)\n", cfg.Database.Port, cfg.Database.DataDir)
+
+		// Run migrations.
+		fmt.Print("  Migrations    ... ")
+		migrationsDir := findMigrationsDir()
+		if migrationsDir != "" {
+			applied, err := r.pg.RunMigrations(ctx, migrationsDir)
+			if err != nil {
+				fmt.Println("failed")
+				return fmt.Errorf("run migrations: %w", err)
+			}
+			fmt.Printf("applied (%d migrations)\n", applied)
+		} else {
+			fmt.Println("skipped (no migrations directory found)")
+		}
+	}
+
+	// Ensure k3s/k3d cluster is running.
+	fmt.Print("  K3s cluster   ... ")
+	if err := r.ensureClusterRunning(cfg); err != nil {
+		fmt.Println("failed")
+		return fmt.Errorf("ensure cluster running: %w", err)
+	}
+	fmt.Println("ok")
+
+	// Generate k3s-mode config for the Python API.
+	fmt.Print("  API config    ... ")
+	if _, err := r.generateK3sConfig(cfg); err != nil {
+		fmt.Println("failed")
+		return fmt.Errorf("generate k3s config: %w", err)
+	}
+	fmt.Println("ok")
+
+	// Start the Python API on the host.
+	fmt.Print("  Volundr API   ... ")
+	apiPort := cfg.Listen.Port + 1
+	if err := r.startAPI(ctx, cfg, apiPort); err != nil {
+		fmt.Println("failed")
+		return fmt.Errorf("start API: %w", err)
+	}
+	fmt.Printf("started (port %d)\n", apiPort)
+
+	// Install/upgrade the skuld base Helm chart.
+	fmt.Print("  Skuld chart   ... ")
+	if err := r.installSkuldChart(cfg); err != nil {
+		fmt.Println("failed")
+		return fmt.Errorf("install skuld chart: %w", err)
+	}
+	fmt.Println("ok")
+
+	// Start the reverse proxy.
+	fmt.Print("  Proxy         ... ")
+	apiURL := fmt.Sprintf("http://127.0.0.1:%d", apiPort)
+	rtr, err := proxy.NewRouter(apiURL)
+	if err != nil {
+		fmt.Println("failed")
+		return fmt.Errorf("create proxy: %w", err)
+	}
+	r.proxyRtr = rtr
+
+	listenAddr := fmt.Sprintf("%s:%d", cfg.Listen.Host, cfg.Listen.Port)
+	go func() {
+		if err := rtr.ListenAndServe(ctx, listenAddr); err != nil {
+			fmt.Fprintf(os.Stderr, "proxy error: %v\n", err)
+		}
+	}()
+	fmt.Printf("started (%s)\n", listenAddr)
+
+	// Write PID file.
+	if err := WritePIDFile(); err != nil {
+		return fmt.Errorf("write PID file: %w", err)
+	}
+
+	// Write state file.
+	if err := r.writeStateFile(cfg); err != nil {
+		return fmt.Errorf("write state file: %w", err)
+	}
+
+	return nil
+}
+
+// Down stops all services gracefully.
+// It does NOT stop k3s/k3d itself.
+func (r *K3sRuntime) Down(_ context.Context) error {
+	var errs []string
+
+	// Try to load config for namespace.
+	namespace := k3sDefaultNamespace
+	loadedCfg, loadErr := config.Load()
+	if loadErr == nil {
+		namespace = resolveNamespace(loadedCfg)
+	}
+
+	// Uninstall skuld Helm release.
+	if out, err := exec.Command(
+		"helm", "uninstall", k3sHelmReleaseName,
+		"--namespace", namespace,
+	).CombinedOutput(); err != nil {
+		outStr := string(out)
+		if !strings.Contains(outStr, "not found") {
+			errs = append(errs, fmt.Sprintf("helm uninstall: %v\n%s", err, outStr))
+		}
+	}
+
+	// Delete session pods/resources in the namespace (by label).
+	if out, err := exec.Command(
+		"kubectl", "delete", "all",
+		"--selector", "app.kubernetes.io/managed-by=volundr",
+		"--namespace", namespace,
+	).CombinedOutput(); err != nil {
+		outStr := string(out)
+		if !strings.Contains(outStr, "not found") && !strings.Contains(outStr, "No resources found") {
+			errs = append(errs, fmt.Sprintf("delete session resources: %v\n%s", err, outStr))
+		}
+	}
+
+	// Stop API process.
+	if r.apiCmd != nil && r.apiCmd.Process != nil {
+		if err := r.apiCmd.Process.Signal(syscall.SIGTERM); err != nil {
+			errs = append(errs, fmt.Sprintf("stop API: %v", err))
+		}
+		done := make(chan error, 1)
+		go func() { done <- r.apiCmd.Wait() }()
+		select {
+		case <-done:
+		case <-time.After(k3sProcessShutdownTimeout):
+			_ = r.apiCmd.Process.Kill()
+		}
+	}
+
+	// Stop embedded PostgreSQL.
+	if r.pg != nil {
+		if err := r.pg.Stop(); err != nil {
+			errs = append(errs, fmt.Sprintf("stop postgres: %v", err))
+		}
+	}
+
+	// Remove PID and state files.
+	_ = RemovePIDFile()
+	_ = RemoveStateFile()
+
+	if len(errs) > 0 {
+		return fmt.Errorf("errors during shutdown: %s", strings.Join(errs, "; "))
+	}
+
+	return nil
+}
+
+// Status returns the state of each service.
+func (r *K3sRuntime) Status(_ context.Context) (*StackStatus, error) {
+	cfgDir, err := config.ConfigDir()
+	if err != nil {
+		return nil, fmt.Errorf("get config dir: %w", err)
+	}
+
+	status := &StackStatus{
+		Runtime: "k3s",
+	}
+
+	// Check PID file.
+	pidPath := filepath.Join(cfgDir, PIDFile)
+	_, err = os.Stat(pidPath)
+	if os.IsNotExist(err) {
+		status.Services = []ServiceStatus{
+			{Name: "volundr", State: StateStopped},
+		}
+		return status, nil
+	}
+
+	// Try to load state file for detailed status.
+	stateFilePath := filepath.Join(cfgDir, StateFile)
+	data, err := os.ReadFile(stateFilePath)
+	if err != nil {
+		status.Services = []ServiceStatus{
+			{Name: "volundr", State: StateRunning},
+		}
+		return status, nil
+	}
+
+	var services []ServiceStatus
+	if err := json.Unmarshal(data, &services); err != nil {
+		status.Services = []ServiceStatus{
+			{Name: "volundr", State: StateRunning},
+		}
+		return status, nil
+	}
+
+	// Query k8s pod states and merge.
+	k8sServices := r.queryK8sPodStates()
+	services = append(services, k8sServices...)
+
+	status.Services = services
+	return status, nil
+}
+
+// Logs streams logs for a service.
+func (r *K3sRuntime) Logs(_ context.Context, service string, follow bool) (io.ReadCloser, error) {
+	// For host services (api, postgres), use log files.
+	if service == "api" || service == "postgres" {
+		cfgDir, err := config.ConfigDir()
+		if err != nil {
+			return nil, fmt.Errorf("get config dir: %w", err)
+		}
+		logPath := filepath.Join(cfgDir, "logs", service+".log")
+		f, err := os.Open(logPath)
+		if err != nil {
+			return nil, fmt.Errorf("open log file for %s: %w", service, err)
+		}
+		return f, nil
+	}
+
+	// For k8s services, use kubectl logs.
+	namespace := k3sDefaultNamespace
+	if loadedCfg, loadErr := config.Load(); loadErr == nil {
+		namespace = resolveNamespace(loadedCfg)
+	}
+
+	args := []string{"logs", "--namespace", namespace}
+	if follow {
+		args = append(args, "-f")
+	}
+
+	// Use label selector to find pods for the service.
+	args = append(args, "-l", fmt.Sprintf("app.kubernetes.io/name=%s", service))
+
+	cmd := exec.Command("kubectl", args...)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("get stdout pipe: %w", err)
+	}
+	cmd.Stderr = cmd.Stdout
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start kubectl logs: %w", err)
+	}
+
+	return &cmdReadCloser{cmd: cmd, ReadCloser: stdout}, nil
+}
+
+// detectProvider determines the k3s provider to use.
+func (r *K3sRuntime) detectProvider(cfg *config.Config) string {
+	// Check explicit config.
+	if cfg.K3s.Provider != "" && cfg.K3s.Provider != "auto" {
+		return cfg.K3s.Provider
+	}
+
+	// Check if k3d is available.
+	if err := exec.Command("k3d", "version").Run(); err == nil {
+		return "k3d"
+	}
+
+	// Check if native k3s is available (Linux only).
+	if runtime.GOOS == "linux" {
+		if err := exec.Command("k3s", "--version").Run(); err == nil {
+			return "native"
+		}
+	}
+
+	return "none"
+}
+
+// initK3d sets up k3d.
+func (r *K3sRuntime) initK3d(ctx context.Context) error {
+	fmt.Print("  k3d            ... ")
+
+	// Check if k3d is installed.
+	if out, err := exec.Command("k3d", "version").CombinedOutput(); err != nil {
+		fmt.Println("not found")
+		return fmt.Errorf("k3d is not installed: %w\n%s", err, out)
+	}
+	fmt.Println("ok")
+
+	// Check if cluster already exists.
+	fmt.Print("  k3d cluster    ... ")
+	out, err := exec.Command("k3d", "cluster", "list", "-o", "json").CombinedOutput()
+	if err != nil {
+		fmt.Println("failed")
+		return fmt.Errorf("list k3d clusters: %w\n%s", err, out)
+	}
+
+	if strings.Contains(string(out), k3sClusterName) {
+		fmt.Println("exists")
+		return nil
+	}
+
+	// Create the cluster.
+	fmt.Print("creating ... ")
+	createOut, err := exec.CommandContext(ctx,
+		"k3d", "cluster", "create", k3sClusterName,
+		"-p", k3sLoadBalancerHTTPPort,
+		"-p", k3sLoadBalancerHTTPSPort,
+	).CombinedOutput()
+	if err != nil {
+		fmt.Println("failed")
+		return fmt.Errorf("create k3d cluster: %w\n%s", err, createOut)
+	}
+	fmt.Println("ok")
+
+	return nil
+}
+
+// initNativeK3s verifies native k3s is running.
+func (r *K3sRuntime) initNativeK3s() error {
+	fmt.Print("  k3s            ... ")
+
+	out, err := exec.Command("kubectl", "get", "nodes").CombinedOutput()
+	if err != nil {
+		fmt.Println("not reachable")
+		return fmt.Errorf("k3s cluster not reachable. Ensure k3s is running: %w\n%s", err, out)
+	}
+	fmt.Println("ok")
+
+	return nil
+}
+
+// guideInstallation prints installation instructions.
+func (r *K3sRuntime) guideInstallation() error {
+	switch runtime.GOOS {
+	case "darwin":
+		return fmt.Errorf(
+			"no k3s provider found. Install k3d:\n" +
+				"  brew install k3d\n" +
+				"Then run 'volundr init' again",
+		)
+	case "linux":
+		return fmt.Errorf(
+			"no k3s provider found. Install one of:\n" +
+				"  k3d:    curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash\n" +
+				"  k3s:    curl -sfL https://get.k3s.io | sh -\n" +
+				"Then run 'volundr init' again",
+		)
+	default:
+		return fmt.Errorf(
+			"no k3s provider found. Install k3d: https://k3d.io\n" +
+				"Then run 'volundr init' again",
+		)
+	}
+}
+
+// ensureNamespace creates the Kubernetes namespace if it doesn't exist.
+func (r *K3sRuntime) ensureNamespace(namespace string) error {
+	// Check if namespace exists.
+	if err := exec.Command("kubectl", "get", "namespace", namespace).Run(); err == nil {
+		return nil
+	}
+
+	out, err := exec.Command("kubectl", "create", "namespace", namespace).CombinedOutput()
+	if err != nil {
+		// Ignore "already exists" errors.
+		if strings.Contains(string(out), "already exists") {
+			return nil
+		}
+		return fmt.Errorf("create namespace %s: %w\n%s", namespace, err, out)
+	}
+
+	return nil
+}
+
+// ensureClusterRunning makes sure the k3s/k3d cluster is up.
+func (r *K3sRuntime) ensureClusterRunning(cfg *config.Config) error {
+	provider := r.detectProvider(cfg)
+
+	switch provider {
+	case "k3d":
+		// Check if cluster is running.
+		out, err := exec.Command("k3d", "cluster", "list", "-o", "json").CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("list k3d clusters: %w\n%s", err, out)
+		}
+
+		// If cluster exists but isn't running, start it.
+		if strings.Contains(string(out), k3sClusterName) {
+			// Try to start it (no-op if already running).
+			startOut, err := exec.Command("k3d", "cluster", "start", k3sClusterName).CombinedOutput()
+			if err != nil {
+				return fmt.Errorf("start k3d cluster: %w\n%s", err, startOut)
+			}
+			return nil
+		}
+
+		return fmt.Errorf("k3d cluster %q not found. Run 'volundr init' first", k3sClusterName)
+
+	case "native":
+		// Check if nodes are ready.
+		out, err := exec.Command("kubectl", "get", "nodes").CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("k3s cluster not reachable: %w\n%s", err, out)
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("no k3s provider found. Run 'volundr init' first")
+	}
+}
+
+// generateK3sConfig creates a config.yaml for the Python API in k3s mode.
+func (r *K3sRuntime) generateK3sConfig(cfg *config.Config) (string, error) {
+	cfgDir, err := config.ConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("get config dir: %w", err)
+	}
+
+	namespace := r.namespace(cfg)
+	kubeconfig := r.resolveKubeconfig(cfg)
+
+	apiCfg := k3sAPIConfig{
+		Database: map[string]interface{}{
+			"host":     "127.0.0.1",
+			"port":     cfg.Database.Port,
+			"user":     cfg.Database.User,
+			"password": cfg.Database.Password,
+			"name":     cfg.Database.Name,
+		},
+		PodManager: map[string]interface{}{
+			"adapter": "volundr.adapters.outbound.direct_k8s_pod_manager.DirectK8sPodManager",
+			"kwargs": map[string]interface{}{
+				"namespace":    namespace,
+				"kubeconfig":   kubeconfig,
+				"base_path":    "/s",
+				"ingress_class": "traefik",
+				"db_host":      "host.k3d.internal",
+				"db_port":      cfg.Database.Port,
+				"db_user":      cfg.Database.User,
+				"db_password":  cfg.Database.Password,
+				"db_name":      cfg.Database.Name,
+			},
+		},
+		CredentialStore: map[string]interface{}{
+			"adapter": "volundr.adapters.outbound.file_credential_store.FileCredentialStore",
+			"kwargs": map[string]interface{}{
+				"base_dir": filepath.Join(cfgDir, "user-credentials"),
+			},
+		},
+		Storage: map[string]interface{}{
+			"adapter": "volundr.adapters.outbound.local_storage_adapter.LocalStorageAdapter",
+			"kwargs": map[string]interface{}{
+				"base_dir": cfgDir,
+			},
+		},
+		SecretInjection: map[string]interface{}{
+			"adapter": "volundr.adapters.outbound.memory_secret_injection.InMemorySecretInjectionAdapter",
+		},
+		Identity: map[string]interface{}{
+			"adapter": "volundr.adapters.outbound.identity.AllowAllIdentityAdapter",
+		},
+		Authorization: map[string]interface{}{
+			"adapter": "volundr.adapters.outbound.authorization.AllowAllAuthorizationAdapter",
+		},
+		Gateway: map[string]interface{}{
+			"adapter": "volundr.adapters.outbound.k8s_gateway.InMemoryGatewayAdapter",
+		},
+	}
+
+	data, err := yaml.Marshal(&apiCfg)
+	if err != nil {
+		return "", fmt.Errorf("marshal k3s config: %w", err)
+	}
+
+	configPath := filepath.Join(cfgDir, k3sConfigFileName)
+	if err := os.WriteFile(configPath, data, 0o644); err != nil {
+		return "", fmt.Errorf("write k3s config: %w", err)
+	}
+
+	return configPath, nil
+}
+
+// startAPI starts the Python API process on the host.
+func (r *K3sRuntime) startAPI(ctx context.Context, cfg *config.Config, port int) error {
+	cfgDir, err := config.ConfigDir()
+	if err != nil {
+		return fmt.Errorf("get config dir: %w", err)
+	}
+
+	logFile, err := os.OpenFile(
+		filepath.Join(cfgDir, "logs", "api.log"),
+		os.O_CREATE|os.O_WRONLY|os.O_APPEND,
+		0o644,
+	)
+	if err != nil {
+		return fmt.Errorf("open API log file: %w", err)
+	}
+
+	configPath := filepath.Join(cfgDir, k3sConfigFileName)
+
+	r.apiCmd = exec.CommandContext(ctx,
+		"python3", "-m", "uvicorn",
+		"volundr.main:app",
+		"--host", "127.0.0.1",
+		"--port", strconv.Itoa(port),
+	)
+
+	r.apiCmd.Stdout = logFile
+	r.apiCmd.Stderr = logFile
+
+	// Set environment variables.
+	r.apiCmd.Env = append(os.Environ(),
+		fmt.Sprintf("DATABASE__HOST=127.0.0.1"),
+		fmt.Sprintf("DATABASE__PORT=%d", cfg.Database.Port),
+		fmt.Sprintf("DATABASE__USER=%s", cfg.Database.User),
+		fmt.Sprintf("DATABASE__PASSWORD=%s", cfg.Database.Password),
+		fmt.Sprintf("DATABASE__NAME=%s", cfg.Database.Name),
+		fmt.Sprintf("VOLUNDR_CONFIG=%s", configPath),
+	)
+
+	if cfg.Anthropic.APIKey != "" {
+		r.apiCmd.Env = append(r.apiCmd.Env,
+			fmt.Sprintf("ANTHROPIC_API_KEY=%s", cfg.Anthropic.APIKey),
+		)
+	}
+
+	if err := r.apiCmd.Start(); err != nil {
+		logFile.Close()
+		return fmt.Errorf("start uvicorn: %w", err)
+	}
+
+	return nil
+}
+
+// installSkuldChart installs or upgrades the skuld Helm chart.
+func (r *K3sRuntime) installSkuldChart(cfg *config.Config) error {
+	namespace := r.namespace(cfg)
+
+	out, err := exec.Command(
+		"helm", "upgrade", "--install", k3sHelmReleaseName,
+		k3sHelmChart,
+		"--namespace", namespace,
+		"--set", "gateway.enabled=false",
+		"--set", "ingress.mode=path",
+		"--set", "ingress.enabled=false",
+		"--create-namespace",
+	).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("helm upgrade --install: %w\n%s", err, out)
+	}
+
+	return nil
+}
+
+// writeStateFile writes the service status to the state file.
+func (r *K3sRuntime) writeStateFile(cfg *config.Config) error {
+	services := []ServiceStatus{
+		{Name: "proxy", State: StateRunning, Port: cfg.Listen.Port},
+	}
+
+	if r.apiCmd != nil && r.apiCmd.Process != nil {
+		services = append(services, ServiceStatus{
+			Name:  "api",
+			State: StateRunning,
+			PID:   r.apiCmd.Process.Pid,
+			Port:  cfg.Listen.Port + 1,
+		})
+	}
+
+	if cfg.Database.Mode == "embedded" {
+		services = append(services, ServiceStatus{
+			Name:  "postgres",
+			State: StateRunning,
+			Port:  cfg.Database.Port,
+		})
+	}
+
+	services = append(services, ServiceStatus{
+		Name:  "k3s-cluster",
+		State: StateRunning,
+	})
+
+	return WriteStateFile(services)
+}
+
+// queryK8sPodStates queries Kubernetes for pod states in the volundr namespace.
+func (r *K3sRuntime) queryK8sPodStates() []ServiceStatus {
+	namespace := k3sDefaultNamespace
+	if loadedCfg, loadErr := config.Load(); loadErr == nil {
+		namespace = resolveNamespace(loadedCfg)
+	}
+
+	out, err := exec.Command(
+		"kubectl", "get", "pods",
+		"--namespace", namespace,
+		"-o", "json",
+	).CombinedOutput()
+	if err != nil {
+		return nil
+	}
+
+	var podList struct {
+		Items []struct {
+			Metadata struct {
+				Name   string            `json:"name"`
+				Labels map[string]string `json:"labels"`
+			} `json:"metadata"`
+			Status struct {
+				Phase string `json:"phase"`
+			} `json:"status"`
+		} `json:"items"`
+	}
+
+	if err := json.Unmarshal(out, &podList); err != nil {
+		return nil
+	}
+
+	var services []ServiceStatus
+	for _, pod := range podList.Items {
+		state := mapK8sPodPhase(pod.Status.Phase)
+		services = append(services, ServiceStatus{
+			Name:  pod.Metadata.Name,
+			State: state,
+		})
+	}
+
+	return services
+}
+
+// mapK8sPodPhase maps a Kubernetes pod phase to a ServiceState.
+func mapK8sPodPhase(phase string) ServiceState {
+	switch phase {
+	case "Running":
+		return StateRunning
+	case "Pending":
+		return StateStarting
+	case "Succeeded":
+		return StateStopped
+	case "Failed":
+		return StateError
+	default:
+		return StateError
+	}
+}
+
+// namespace returns the configured namespace or the default.
+func (r *K3sRuntime) namespace(cfg *config.Config) string {
+	if cfg.K3s.Namespace != "" {
+		return cfg.K3s.Namespace
+	}
+	return k3sDefaultNamespace
+}
+
+// resolveNamespace resolves the namespace from config, with default fallback.
+func resolveNamespace(cfg *config.Config) string {
+	if cfg.K3s.Namespace != "" {
+		return cfg.K3s.Namespace
+	}
+	return k3sDefaultNamespace
+}
+
+// resolveKubeconfig returns the kubeconfig path from config or auto-detects it.
+func (r *K3sRuntime) resolveKubeconfig(cfg *config.Config) string {
+	if cfg.K3s.Kubeconfig != "" {
+		return cfg.K3s.Kubeconfig
+	}
+
+	// Try standard locations.
+	if env := os.Getenv("KUBECONFIG"); env != "" {
+		return env
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+
+	return filepath.Join(home, ".kube", "config")
+}

--- a/cli/internal/runtime/k3s.go
+++ b/cli/internal/runtime/k3s.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -104,16 +105,21 @@ func (r *K3sRuntime) Init(ctx context.Context, cfg *config.Config) error {
 			return err
 		}
 	default:
-		return r.guideInstallation()
+		if err := r.offerInstallation(ctx); err != nil {
+			return err
+		}
 	}
 
-	// Verify helm is available.
+	// Verify helm is available, offer to install if not.
 	fmt.Print("  Helm            ... ")
-	if out, err := exec.Command("helm", "version", "--short").CombinedOutput(); err != nil {
+	if _, err := exec.Command("helm", "version", "--short").CombinedOutput(); err != nil {
 		fmt.Println("not found")
-		return fmt.Errorf("helm is required but not found. Install: https://helm.sh/docs/intro/install/\n%s", out)
+		if err := r.offerInstallHelm(); err != nil {
+			return err
+		}
+	} else {
+		fmt.Println("ok")
 	}
-	fmt.Println("ok")
 
 	// Create the volundr namespace.
 	namespace := r.namespace(cfg)
@@ -469,28 +475,164 @@ func (r *K3sRuntime) initNativeK3s() error {
 	return nil
 }
 
-// guideInstallation prints installation instructions.
-func (r *K3sRuntime) guideInstallation() error {
+// promptYesNo asks the user a yes/no question and returns true for yes.
+func promptYesNo(prompt string) bool {
+	fmt.Printf("%s [y/N]: ", prompt)
+	reader := bufio.NewReader(os.Stdin)
+	answer, _ := reader.ReadString('\n')
+	answer = strings.TrimSpace(strings.ToLower(answer))
+	return answer == "y" || answer == "yes"
+}
+
+// offerInstallation offers to install k3d (and k3s on Linux) interactively.
+func (r *K3sRuntime) offerInstallation(ctx context.Context) error {
+	fmt.Println("  No k3s provider found.")
+	fmt.Println()
+
 	switch runtime.GOOS {
 	case "darwin":
-		return fmt.Errorf(
-			"no k3s provider found. Install k3d:\n" +
-				"  brew install k3d\n" +
-				"Then run 'volundr init' again",
-		)
+		return r.offerInstallK3dDarwin(ctx)
 	case "linux":
-		return fmt.Errorf(
-			"no k3s provider found. Install one of:\n" +
-				"  k3d:    curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash\n" +
-				"  k3s:    curl -sfL https://get.k3s.io | sh -\n" +
-				"Then run 'volundr init' again",
-		)
+		return r.offerInstallLinux(ctx)
 	default:
 		return fmt.Errorf(
-			"no k3s provider found. Install k3d: https://k3d.io\n" +
-				"Then run 'volundr init' again",
+			"unsupported platform %q for k3s runtime. Install k3d manually: https://k3d.io",
+			runtime.GOOS,
 		)
 	}
+}
+
+// offerInstallK3dDarwin offers to install k3d via Homebrew on macOS.
+func (r *K3sRuntime) offerInstallK3dDarwin(ctx context.Context) error {
+	// Check if Homebrew is available.
+	if _, err := exec.Command("brew", "--version").CombinedOutput(); err != nil {
+		fmt.Println("  Homebrew is not installed. Install k3d manually:")
+		fmt.Println("    curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash")
+		if !promptYesNo("  Run the install script now?") {
+			return fmt.Errorf("k3d is required. Install it and run 'volundr init' again")
+		}
+		return r.installK3dScript(ctx)
+	}
+
+	if !promptYesNo("  Install k3d via Homebrew? (brew install k3d)") {
+		return fmt.Errorf("k3d is required. Install it and run 'volundr init' again")
+	}
+
+	fmt.Print("  Installing k3d  ... ")
+	out, err := exec.CommandContext(ctx, "brew", "install", "k3d").CombinedOutput()
+	if err != nil {
+		fmt.Println("failed")
+		return fmt.Errorf("brew install k3d: %w\n%s", err, out)
+	}
+	fmt.Println("ok")
+
+	// Now init the k3d cluster.
+	return r.initK3d(ctx)
+}
+
+// offerInstallLinux offers k3d or native k3s installation on Linux.
+func (r *K3sRuntime) offerInstallLinux(ctx context.Context) error {
+	fmt.Println("  Available options:")
+	fmt.Println("    1) k3d  - k3s in Docker (recommended if Docker is available)")
+	fmt.Println("    2) k3s  - native k3s (requires root, full GPU support)")
+	fmt.Println()
+	fmt.Print("  Choose [1/2]: ")
+
+	reader := bufio.NewReader(os.Stdin)
+	choice, _ := reader.ReadString('\n')
+	choice = strings.TrimSpace(choice)
+
+	switch choice {
+	case "1", "k3d", "":
+		return r.offerInstallK3dLinux(ctx)
+	case "2", "k3s":
+		return r.offerInstallNativeK3s(ctx)
+	default:
+		return fmt.Errorf("invalid choice. Run 'volundr init' again")
+	}
+}
+
+// offerInstallK3dLinux installs k3d via the install script on Linux.
+func (r *K3sRuntime) offerInstallK3dLinux(ctx context.Context) error {
+	if !promptYesNo("  Install k3d? (curl install script)") {
+		return fmt.Errorf("k3d is required. Install it and run 'volundr init' again")
+	}
+	if err := r.installK3dScript(ctx); err != nil {
+		return err
+	}
+	return r.initK3d(ctx)
+}
+
+// installK3dScript installs k3d using the official install script.
+func (r *K3sRuntime) installK3dScript(ctx context.Context) error {
+	fmt.Print("  Installing k3d  ... ")
+	cmd := exec.CommandContext(ctx, "bash", "-c",
+		"curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Println("failed")
+		return fmt.Errorf("install k3d: %w\n%s", err, out)
+	}
+	fmt.Println("ok")
+	return nil
+}
+
+// offerInstallNativeK3s installs k3s using the official install script.
+func (r *K3sRuntime) offerInstallNativeK3s(ctx context.Context) error {
+	if !promptYesNo("  Install k3s? (requires sudo, curl install script)") {
+		return fmt.Errorf("k3s is required. Install it and run 'volundr init' again")
+	}
+
+	fmt.Print("  Installing k3s  ... ")
+	cmd := exec.CommandContext(ctx, "bash", "-c",
+		"curl -sfL https://get.k3s.io | sh -",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Println("failed")
+		return fmt.Errorf("install k3s: %w\n%s", err, out)
+	}
+	fmt.Println("ok")
+
+	return r.initNativeK3s()
+}
+
+// offerInstallHelm offers to install Helm interactively.
+func (r *K3sRuntime) offerInstallHelm() error {
+	switch runtime.GOOS {
+	case "darwin":
+		if _, err := exec.Command("brew", "--version").CombinedOutput(); err == nil {
+			if !promptYesNo("  Install Helm via Homebrew? (brew install helm)") {
+				return fmt.Errorf("helm is required. Install: https://helm.sh/docs/intro/install/")
+			}
+			fmt.Print("  Installing Helm ... ")
+			out, err := exec.Command("brew", "install", "helm").CombinedOutput()
+			if err != nil {
+				fmt.Println("failed")
+				return fmt.Errorf("brew install helm: %w\n%s", err, out)
+			}
+			fmt.Println("ok")
+			return nil
+		}
+	}
+
+	// Fallback: use the official install script.
+	if !promptYesNo("  Install Helm? (official install script)") {
+		return fmt.Errorf("helm is required. Install: https://helm.sh/docs/intro/install/")
+	}
+
+	fmt.Print("  Installing Helm ... ")
+	cmd := exec.Command("bash", "-c",
+		"curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Println("failed")
+		return fmt.Errorf("install helm: %w\n%s", err, out)
+	}
+	fmt.Println("ok")
+	return nil
 }
 
 // ensureNamespace creates the Kubernetes namespace if it doesn't exist.

--- a/cli/internal/runtime/k3s_test.go
+++ b/cli/internal/runtime/k3s_test.go
@@ -19,9 +19,6 @@ func TestNewK3sRuntime(t *testing.T) {
 	if r.pg != nil {
 		t.Error("expected pg to be nil on new K3sRuntime")
 	}
-	if r.apiCmd != nil {
-		t.Error("expected apiCmd to be nil on new K3sRuntime")
-	}
 	if r.proxyRtr != nil {
 		t.Error("expected proxyRtr to be nil on new K3sRuntime")
 	}
@@ -185,8 +182,8 @@ func TestGenerateK3sConfig(t *testing.T) {
 	}
 
 	// Verify database settings.
-	if parsed.Database["host"] != "127.0.0.1" {
-		t.Errorf("expected database host 127.0.0.1, got %v", parsed.Database["host"])
+	if parsed.Database["host"] != "host.docker.internal" {
+		t.Errorf("expected database host host.docker.internal, got %v", parsed.Database["host"])
 	}
 	if parsed.Database["port"] != 5433 {
 		t.Errorf("expected database port 5433, got %v", parsed.Database["port"])

--- a/cli/internal/runtime/k3s_test.go
+++ b/cli/internal/runtime/k3s_test.go
@@ -1,0 +1,340 @@
+package runtime
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/niuulabs/volundr/cli/internal/config"
+	"gopkg.in/yaml.v3"
+)
+
+func TestNewK3sRuntime(t *testing.T) {
+	r := NewK3sRuntime()
+	if r == nil {
+		t.Fatal("expected non-nil K3sRuntime")
+	}
+	if r.pg != nil {
+		t.Error("expected pg to be nil on new K3sRuntime")
+	}
+	if r.apiCmd != nil {
+		t.Error("expected apiCmd to be nil on new K3sRuntime")
+	}
+	if r.proxyRtr != nil {
+		t.Error("expected proxyRtr to be nil on new K3sRuntime")
+	}
+}
+
+func TestK3sRuntime_Namespace(t *testing.T) {
+	r := NewK3sRuntime()
+
+	// Default namespace.
+	cfg := &config.Config{}
+	ns := r.namespace(cfg)
+	if ns != k3sDefaultNamespace {
+		t.Errorf("expected default namespace %q, got %q", k3sDefaultNamespace, ns)
+	}
+
+	// Configured namespace.
+	cfg.K3s.Namespace = "custom-ns"
+	ns = r.namespace(cfg)
+	if ns != "custom-ns" {
+		t.Errorf("expected namespace %q, got %q", "custom-ns", ns)
+	}
+}
+
+func TestResolveNamespace(t *testing.T) {
+	// Default.
+	cfg := &config.Config{}
+	ns := resolveNamespace(cfg)
+	if ns != k3sDefaultNamespace {
+		t.Errorf("expected %q, got %q", k3sDefaultNamespace, ns)
+	}
+
+	// Explicit.
+	cfg.K3s.Namespace = "test-ns"
+	ns = resolveNamespace(cfg)
+	if ns != "test-ns" {
+		t.Errorf("expected %q, got %q", "test-ns", ns)
+	}
+}
+
+func TestK3sRuntime_ResolveKubeconfig(t *testing.T) {
+	r := NewK3sRuntime()
+
+	// Explicit config.
+	cfg := &config.Config{}
+	cfg.K3s.Kubeconfig = "/custom/kubeconfig"
+	kc := r.resolveKubeconfig(cfg)
+	if kc != "/custom/kubeconfig" {
+		t.Errorf("expected /custom/kubeconfig, got %q", kc)
+	}
+
+	// From KUBECONFIG env.
+	cfg.K3s.Kubeconfig = ""
+	t.Setenv("KUBECONFIG", "/env/kubeconfig")
+	kc = r.resolveKubeconfig(cfg)
+	if kc != "/env/kubeconfig" {
+		t.Errorf("expected /env/kubeconfig, got %q", kc)
+	}
+
+	// Default ~/.kube/config.
+	t.Setenv("KUBECONFIG", "")
+	kc = r.resolveKubeconfig(cfg)
+	if !strings.HasSuffix(kc, filepath.Join(".kube", "config")) {
+		t.Errorf("expected path ending with .kube/config, got %q", kc)
+	}
+}
+
+func TestK3sRuntime_DetectProvider(t *testing.T) {
+	r := NewK3sRuntime()
+
+	// Explicit provider.
+	cfg := &config.Config{}
+	cfg.K3s.Provider = "k3d"
+	p := r.detectProvider(cfg)
+	if p != "k3d" {
+		t.Errorf("expected k3d, got %q", p)
+	}
+
+	cfg.K3s.Provider = "native"
+	p = r.detectProvider(cfg)
+	if p != "native" {
+		t.Errorf("expected native, got %q", p)
+	}
+
+	// Auto-detect falls through; result depends on what's installed.
+	cfg.K3s.Provider = "auto"
+	p = r.detectProvider(cfg)
+	// Just verify it returns something (k3d, native, or none).
+	if p != "k3d" && p != "native" && p != "none" {
+		t.Errorf("unexpected provider %q", p)
+	}
+}
+
+func TestMapK8sPodPhase(t *testing.T) {
+	tests := []struct {
+		phase    string
+		expected ServiceState
+	}{
+		{"Running", StateRunning},
+		{"Pending", StateStarting},
+		{"Succeeded", StateStopped},
+		{"Failed", StateError},
+		{"Unknown", StateError},
+		{"", StateError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.phase, func(t *testing.T) {
+			got := mapK8sPodPhase(tt.phase)
+			if got != tt.expected {
+				t.Errorf("mapK8sPodPhase(%q) = %q, want %q", tt.phase, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGenerateK3sConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	cfgDir := filepath.Join(tmpDir, config.DefaultConfigDir)
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("create config dir: %v", err)
+	}
+
+	r := NewK3sRuntime()
+	cfg := &config.Config{
+		Database: config.DatabaseConfig{
+			Mode:     "embedded",
+			Host:     "localhost",
+			Port:     5433,
+			User:     "volundr",
+			Password: "s3cr3t!@#$",
+			Name:     "volundr",
+		},
+		K3s: config.K3sConfig{
+			Kubeconfig: "/test/kubeconfig",
+			Namespace:  "test-ns",
+			Provider:   "k3d",
+		},
+	}
+
+	configPath, err := r.generateK3sConfig(cfg)
+	if err != nil {
+		t.Fatalf("generateK3sConfig: %v", err)
+	}
+
+	// Verify the file was created.
+	if _, err := os.Stat(configPath); err != nil {
+		t.Fatalf("config file not created at %s: %v", configPath, err)
+	}
+
+	// Read and parse.
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config file: %v", err)
+	}
+
+	var parsed k3sAPIConfig
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("unmarshal config: %v", err)
+	}
+
+	// Verify database settings.
+	if parsed.Database["host"] != "127.0.0.1" {
+		t.Errorf("expected database host 127.0.0.1, got %v", parsed.Database["host"])
+	}
+	if parsed.Database["port"] != 5433 {
+		t.Errorf("expected database port 5433, got %v", parsed.Database["port"])
+	}
+	if parsed.Database["password"] != "s3cr3t!@#$" {
+		t.Errorf("expected password preserved, got %v", parsed.Database["password"])
+	}
+
+	// Verify adapter class path.
+	if parsed.PodManager["adapter"] != "volundr.adapters.outbound.direct_k8s_pod_manager.DirectK8sPodManager" {
+		t.Errorf("unexpected pod_manager adapter: %v", parsed.PodManager["adapter"])
+	}
+
+	// Verify kwargs.
+	pmKwargs, ok := parsed.PodManager["kwargs"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected pod_manager kwargs to be a map")
+	}
+	if pmKwargs["namespace"] != "test-ns" {
+		t.Errorf("expected namespace test-ns, got %v", pmKwargs["namespace"])
+	}
+	if pmKwargs["kubeconfig"] != "/test/kubeconfig" {
+		t.Errorf("expected kubeconfig /test/kubeconfig, got %v", pmKwargs["kubeconfig"])
+	}
+	if pmKwargs["base_path"] != "/s" {
+		t.Errorf("expected base_path /s, got %v", pmKwargs["base_path"])
+	}
+	if pmKwargs["ingress_class"] != "traefik" {
+		t.Errorf("expected ingress_class traefik, got %v", pmKwargs["ingress_class"])
+	}
+
+	// Verify other adapters use dev-local defaults.
+	if parsed.Identity["adapter"] != "volundr.adapters.outbound.identity.AllowAllIdentityAdapter" {
+		t.Errorf("unexpected identity adapter: %v", parsed.Identity["adapter"])
+	}
+	if parsed.Authorization["adapter"] != "volundr.adapters.outbound.authorization.AllowAllAuthorizationAdapter" {
+		t.Errorf("unexpected authorization adapter: %v", parsed.Authorization["adapter"])
+	}
+}
+
+func TestGenerateK3sConfig_DefaultKubeconfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	// Clear KUBECONFIG so auto-detect picks up ~/.kube/config.
+	t.Setenv("KUBECONFIG", "")
+
+	cfgDir := filepath.Join(tmpDir, config.DefaultConfigDir)
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("create config dir: %v", err)
+	}
+
+	r := NewK3sRuntime()
+	cfg := &config.Config{
+		Database: config.DatabaseConfig{
+			Port:     5433,
+			User:     "volundr",
+			Password: "test",
+			Name:     "volundr",
+		},
+	}
+
+	configPath, err := r.generateK3sConfig(cfg)
+	if err != nil {
+		t.Fatalf("generateK3sConfig: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config file: %v", err)
+	}
+
+	var parsed k3sAPIConfig
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("unmarshal config: %v", err)
+	}
+
+	// Verify default kubeconfig path ends with .kube/config.
+	pmKwargs, ok := parsed.PodManager["kwargs"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected pod_manager kwargs to be a map")
+	}
+	kc, ok := pmKwargs["kubeconfig"].(string)
+	if !ok {
+		t.Fatal("expected kubeconfig to be a string")
+	}
+	if !strings.HasSuffix(kc, filepath.Join(".kube", "config")) {
+		t.Errorf("expected kubeconfig to end with .kube/config, got %q", kc)
+	}
+}
+
+func TestK3sWriteStateFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	volundrDir := filepath.Join(tmpDir, ".volundr")
+	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
+		t.Fatalf("create config dir: %v", err)
+	}
+
+	r := NewK3sRuntime()
+	cfg := &config.Config{
+		Listen: config.ListenConfig{Port: 8080},
+		Database: config.DatabaseConfig{
+			Mode: "embedded",
+			Port: 5433,
+		},
+	}
+
+	if err := r.writeStateFile(cfg); err != nil {
+		t.Fatalf("writeStateFile: %v", err)
+	}
+
+	// Read back state file and verify.
+	stateFilePath := filepath.Join(volundrDir, StateFile)
+	data, err := os.ReadFile(stateFilePath)
+	if err != nil {
+		t.Fatalf("read state file: %v", err)
+	}
+
+	var services []ServiceStatus
+	if err := json.Unmarshal(data, &services); err != nil {
+		t.Fatalf("parse state file: %v", err)
+	}
+
+	// Should have proxy, postgres, and k3s-cluster.
+	// API won't be there since apiCmd is nil.
+	expectedNames := map[string]bool{
+		"proxy":       false,
+		"postgres":    false,
+		"k3s-cluster": false,
+	}
+
+	for _, svc := range services {
+		if _, ok := expectedNames[svc.Name]; ok {
+			expectedNames[svc.Name] = true
+		}
+	}
+
+	for name, found := range expectedNames {
+		if !found {
+			t.Errorf("expected service %q in state file", name)
+		}
+	}
+}
+
+func TestNewRuntime_K3s(t *testing.T) {
+	rt := NewRuntime("k3s")
+	if _, ok := rt.(*K3sRuntime); !ok {
+		t.Errorf("expected *K3sRuntime, got %T", rt)
+	}
+}

--- a/src/volundr/adapters/outbound/direct_k8s_pod_manager.py
+++ b/src/volundr/adapters/outbound/direct_k8s_pod_manager.py
@@ -340,6 +340,30 @@ class DirectK8sPodManager(PodManager):
             },
         }
 
+    def _get_api_exception(self) -> type:
+        """Get the ApiException class from kubernetes_asyncio."""
+        from kubernetes_asyncio.client import rest
+
+        return rest.ApiException
+
+    def _get_api(self, api_class: str) -> Any:
+        """Get a kubernetes API instance by class name."""
+        from kubernetes_asyncio.client import (
+            AppsV1Api,
+            CoreV1Api,
+            CustomObjectsApi,
+            NetworkingV1Api,
+        )
+
+        api_map: dict[str, type] = {
+            "AppsV1Api": AppsV1Api,
+            "CoreV1Api": CoreV1Api,
+            "NetworkingV1Api": NetworkingV1Api,
+            "CustomObjectsApi": CustomObjectsApi,
+        }
+        cls = api_map[api_class]
+        return cls(self._api_client)
+
     async def _apply_resource(
         self,
         api_method_create: str,
@@ -349,19 +373,19 @@ class DirectK8sPodManager(PodManager):
         manifest: dict[str, Any],
     ) -> None:
         """Create or patch a Kubernetes resource via the async API."""
-        from kubernetes_asyncio import client
-
-        api_cls = getattr(client, api_class)
-        api = api_cls(self._api_client)
+        api = self._get_api(api_class)
+        api_exception = self._get_api_exception()
 
         create_fn = getattr(api, api_method_create)
         patch_fn = getattr(api, api_method_patch)
 
         try:
             await create_fn(namespace=self._namespace, body=manifest)
-        except client.exceptions.ApiException as exc:
+        except api_exception as exc:
             if exc.status == 409:
-                logger.info("%s %s already exists, patching", api_class, name)
+                logger.info(
+                    "%s %s already exists, patching", api_class, name,
+                )
                 await patch_fn(
                     name=name,
                     namespace=self._namespace,
@@ -370,11 +394,13 @@ class DirectK8sPodManager(PodManager):
             else:
                 raise
 
-    async def _apply_custom_resource(self, manifest: dict[str, Any]) -> None:
+    async def _apply_custom_resource(
+        self, manifest: dict[str, Any],
+    ) -> None:
         """Apply a custom resource (create or update)."""
-        from kubernetes_asyncio import client
+        api = self._get_api("CustomObjectsApi")
+        api_exception = self._get_api_exception()
 
-        api = client.CustomObjectsApi(self._api_client)
         api_version = manifest["apiVersion"]
         parts = api_version.split("/")
         group = parts[0]
@@ -382,7 +408,9 @@ class DirectK8sPodManager(PodManager):
         kind = manifest["kind"]
         plural = kind.lower() + "s"
         name = manifest["metadata"]["name"]
-        namespace = manifest["metadata"].get("namespace", self._namespace)
+        namespace = manifest["metadata"].get(
+            "namespace", self._namespace,
+        )
 
         try:
             await api.create_namespaced_custom_object(
@@ -392,7 +420,7 @@ class DirectK8sPodManager(PodManager):
                 plural=plural,
                 body=manifest,
             )
-        except client.exceptions.ApiException as exc:
+        except api_exception as exc:
             if exc.status == 409:
                 await api.patch_namespaced_custom_object(
                     group=group,
@@ -403,7 +431,9 @@ class DirectK8sPodManager(PodManager):
                     body=manifest,
                 )
             else:
-                logger.warning("Failed to apply %s %s: %s", kind, name, exc)
+                logger.warning(
+                    "Failed to apply %s %s: %s", kind, name, exc,
+                )
                 raise
 
     async def _delete_custom_resource(
@@ -414,9 +444,8 @@ class DirectK8sPodManager(PodManager):
         name: str,
     ) -> None:
         """Delete a custom resource, ignoring not-found errors."""
-        from kubernetes_asyncio import client
-
-        api = client.CustomObjectsApi(self._api_client)
+        api = self._get_api("CustomObjectsApi")
+        api_exception = self._get_api_exception()
 
         try:
             await api.delete_namespaced_custom_object(
@@ -426,9 +455,46 @@ class DirectK8sPodManager(PodManager):
                 plural=plural,
                 name=name,
             )
-        except client.exceptions.ApiException as exc:
+        except api_exception as exc:
             if exc.status != 404:
-                logger.warning("Failed to delete %s/%s: %s", plural, name, exc)
+                logger.warning(
+                    "Failed to delete %s/%s: %s", plural, name, exc,
+                )
+
+    async def _delete_resource(
+        self,
+        api_class: str,
+        api_method: str,
+        name: str,
+    ) -> bool:
+        """Delete a Kubernetes resource, returning True if deleted."""
+        api = self._get_api(api_class)
+        api_exception = self._get_api_exception()
+
+        try:
+            fn = getattr(api, api_method)
+            await fn(name=name, namespace=self._namespace)
+            return True
+        except api_exception as exc:
+            if exc.status != 404:
+                logger.error(
+                    "Failed to delete %s %s: %s", api_class, name, exc,
+                )
+            return False
+
+    async def _read_deployment(self, name: str) -> Any:
+        """Read a Deployment, returning None if not found."""
+        api = self._get_api("AppsV1Api")
+        api_exception = self._get_api_exception()
+
+        try:
+            return await api.read_namespaced_deployment(
+                name=name, namespace=self._namespace,
+            )
+        except api_exception as exc:
+            if exc.status == 404:
+                return None
+            raise
 
     async def start(
         self,
@@ -490,48 +556,24 @@ class DirectK8sPodManager(PodManager):
         """Delete Deployment, Service, Ingress, and Middleware."""
         await self._ensure_client()
 
-        from kubernetes_asyncio import client
-
         release_name = self._release_name(session)
-        deleted = False
 
-        # Delete Deployment.
-        try:
-            apps_api = client.AppsV1Api(self._api_client)
-            await apps_api.delete_namespaced_deployment(
-                name=release_name,
-                namespace=self._namespace,
-            )
-            deleted = True
-        except client.exceptions.ApiException as exc:
-            if exc.status != 404:
-                logger.error("Failed to delete deployment %s: %s", release_name, exc)
+        d1 = await self._delete_resource(
+            "AppsV1Api",
+            "delete_namespaced_deployment",
+            release_name,
+        )
+        d2 = await self._delete_resource(
+            "CoreV1Api",
+            "delete_namespaced_service",
+            release_name,
+        )
+        d3 = await self._delete_resource(
+            "NetworkingV1Api",
+            "delete_namespaced_ingress",
+            release_name,
+        )
 
-        # Delete Service.
-        try:
-            core_api = client.CoreV1Api(self._api_client)
-            await core_api.delete_namespaced_service(
-                name=release_name,
-                namespace=self._namespace,
-            )
-            deleted = True
-        except client.exceptions.ApiException as exc:
-            if exc.status != 404:
-                logger.error("Failed to delete service %s: %s", release_name, exc)
-
-        # Delete Ingress.
-        try:
-            networking_api = client.NetworkingV1Api(self._api_client)
-            await networking_api.delete_namespaced_ingress(
-                name=release_name,
-                namespace=self._namespace,
-            )
-            deleted = True
-        except client.exceptions.ApiException as exc:
-            if exc.status != 404:
-                logger.error("Failed to delete ingress %s: %s", release_name, exc)
-
-        # Delete Traefik middleware CR.
         await self._delete_custom_resource(
             group="traefik.io",
             version="v1alpha1",
@@ -539,8 +581,10 @@ class DirectK8sPodManager(PodManager):
             name=f"{release_name}-strip",
         )
 
-        if deleted:
-            logger.info("Deleted K8s resources for session %s", session.id)
+        if d1 or d2 or d3:
+            logger.info(
+                "Deleted K8s resources for session %s", session.id,
+            )
 
         return True
 
@@ -548,20 +592,11 @@ class DirectK8sPodManager(PodManager):
         """Get the current status of the session's pods."""
         await self._ensure_client()
 
-        from kubernetes_asyncio import client
-
         release_name = self._release_name(session)
-        apps_api = client.AppsV1Api(self._api_client)
+        deployment = await self._read_deployment(release_name)
 
-        try:
-            deployment = await apps_api.read_namespaced_deployment(
-                name=release_name,
-                namespace=self._namespace,
-            )
-        except client.exceptions.ApiException as exc:
-            if exc.status == 404:
-                return SessionStatus.STOPPED
-            raise
+        if deployment is None:
+            return SessionStatus.STOPPED
 
         return self._map_deployment_status(deployment)
 

--- a/src/volundr/adapters/outbound/direct_k8s_pod_manager.py
+++ b/src/volundr/adapters/outbound/direct_k8s_pod_manager.py
@@ -1,0 +1,617 @@
+"""Direct Kubernetes API adapter for pod management.
+
+Creates Deployment + Service + Ingress resources directly via the
+kubernetes-asyncio Python client. Designed for local k3s/k3d development
+where Flux is not available.
+
+Constructor accepts plain kwargs (dynamic adapter pattern):
+    adapter: "volundr.adapters.outbound.direct_k8s_pod_manager.DirectK8sPodManager"
+    namespace: "volundr"
+    kubeconfig: "~/.kube/config"
+    base_path: "/s"
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from volundr.domain.models import Session, SessionSpec, SessionStatus
+from volundr.domain.ports import CredentialStorePort, PodManager, PodStartResult
+
+logger = logging.getLogger(__name__)
+
+# Label applied to all resources managed by this adapter
+MANAGED_BY_LABEL = "app.kubernetes.io/managed-by"
+MANAGED_BY_VALUE = "volundr"
+SESSION_LABEL = "volundr.niuu.io/session"
+
+# Traefik strip-prefix middleware annotation key
+TRAEFIK_STRIP_PREFIX_ANNOTATION = "traefik.ingress.kubernetes.io/router.middlewares"
+
+# Service port for the session pod (nginx entry point)
+SESSION_SERVICE_PORT = 8080
+
+# Default poll interval for readiness checks in seconds
+DEFAULT_POLL_INTERVAL = 2.0
+
+# Default timeout for readiness checks in seconds
+DEFAULT_READINESS_TIMEOUT = 300.0
+
+
+class DirectK8sPodManager(PodManager):
+    """Direct Kubernetes API implementation of PodManager.
+
+    Creates Deployment + Service + Ingress resources for each session
+    using path-based routing without a host field. Suitable for local
+    k3s/k3d development where only an IP (no DNS) is available.
+
+    Constructor accepts plain kwargs (dynamic adapter pattern).
+    """
+
+    def __init__(
+        self,
+        *,
+        namespace: str = "volundr",
+        kubeconfig: str = "",
+        base_path: str = "/s",
+        ingress_class: str = "traefik",
+        skuld_image: str = "ghcr.io/niuulabs/skuld:latest",
+        code_server_image: str = "codercom/code-server:latest",
+        nginx_image: str = "nginx:alpine",
+        devrunner_image: str = "ghcr.io/niuulabs/devrunner:latest",
+        db_host: str = "host.k3d.internal",
+        db_port: int = 5433,
+        db_user: str = "volundr",
+        db_password: str = "",
+        db_name: str = "volundr",
+        poll_interval: float = DEFAULT_POLL_INTERVAL,
+        readiness_timeout: float = DEFAULT_READINESS_TIMEOUT,
+        **_extra: object,
+    ):
+        self._namespace = namespace
+        self._kubeconfig = kubeconfig
+        self._base_path = base_path
+        self._ingress_class = ingress_class
+        self._skuld_image = skuld_image
+        self._code_server_image = code_server_image
+        self._nginx_image = nginx_image
+        self._devrunner_image = devrunner_image
+        self._db_host = db_host
+        self._db_port = db_port
+        self._db_user = db_user
+        self._db_password = db_password
+        self._db_name = db_name
+        self._poll_interval = poll_interval
+        self._readiness_timeout = readiness_timeout
+        self._credential_store: CredentialStorePort | None = None
+        self._api_client = None
+
+    def set_credential_store(self, store: CredentialStorePort) -> None:
+        """Inject credential store for resolving envSecrets."""
+        self._credential_store = store
+
+    async def _ensure_client(self) -> None:
+        """Lazy-load kubernetes-asyncio API client."""
+        if self._api_client is not None:
+            return
+
+        from kubernetes_asyncio import client, config
+
+        if self._kubeconfig:
+            await config.load_kube_config(config_file=self._kubeconfig)
+        else:
+            try:
+                config.load_incluster_config()
+            except config.ConfigException:
+                await config.load_kube_config()
+
+        self._api_client = client.ApiClient()
+
+    def _release_name(self, session: Session) -> str:
+        """Generate the Kubernetes resource name for a session."""
+        return f"skuld-{session.id}"
+
+    def _session_path(self, session: Session) -> str:
+        """Generate the ingress path for a session."""
+        return f"{self._base_path}/{session.id}"
+
+    def _middleware_name(self, session: Session) -> str:
+        """Generate the Traefik middleware name for strip-prefix."""
+        return f"{self._namespace}-strip-{session.id}"
+
+    def _chat_endpoint(self, session: Session) -> str:
+        """Build the chat WebSocket endpoint URL."""
+        return f"{self._session_path(session)}/session"
+
+    def _code_endpoint(self, session: Session) -> str:
+        """Build the code-server endpoint URL."""
+        return f"{self._session_path(session)}/"
+
+    def _build_labels(self, session: Session) -> dict[str, str]:
+        """Build standard labels for Kubernetes resources."""
+        return {
+            MANAGED_BY_LABEL: MANAGED_BY_VALUE,
+            SESSION_LABEL: str(session.id),
+            "app.kubernetes.io/name": "skuld",
+            "app.kubernetes.io/instance": self._release_name(session),
+        }
+
+    def _build_env(self, session: Session, spec: SessionSpec) -> list[dict[str, str]]:
+        """Build environment variables for the skuld broker container."""
+        env: list[dict[str, str]] = [
+            {"name": "SESSION_ID", "value": str(session.id)},
+            {"name": "SESSION_NAME", "value": session.name},
+            {"name": "DATABASE__HOST", "value": self._db_host},
+            {"name": "DATABASE__PORT", "value": str(self._db_port)},
+            {"name": "DATABASE__USER", "value": self._db_user},
+            {"name": "DATABASE__PASSWORD", "value": self._db_password},
+            {"name": "DATABASE__NAME", "value": self._db_name},
+        ]
+
+        # Handle git config from spec values.
+        git_config = spec.values.get("git", {})
+        if git_config.get("cloneUrl"):
+            env.append({"name": "GIT_CLONE_URL", "value": git_config["cloneUrl"]})
+        if git_config.get("branch"):
+            env.append({"name": "GIT_BRANCH", "value": git_config["branch"]})
+
+        # Handle session metadata from spec values.
+        session_config = spec.values.get("session", {})
+        if session_config.get("model"):
+            env.append({"name": "SESSION_MODEL", "value": session_config["model"]})
+
+        # Handle extra env passthrough.
+        extra_env = spec.values.get("env", {})
+        if isinstance(extra_env, dict):
+            for k, v in extra_env.items():
+                env.append({"name": k, "value": str(v)})
+
+        return env
+
+    def _build_deployment_manifest(
+        self, session: Session, spec: SessionSpec,
+    ) -> dict[str, Any]:
+        """Build a Kubernetes Deployment manifest dict for the session."""
+        labels = self._build_labels(session)
+        release_name = self._release_name(session)
+        env_list = self._build_env(session, spec)
+
+        env_vars = [{"name": e["name"], "value": e["value"]} for e in env_list]
+
+        return {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {
+                "name": release_name,
+                "namespace": self._namespace,
+                "labels": labels,
+            },
+            "spec": {
+                "replicas": 1,
+                "selector": {
+                    "matchLabels": {
+                        "app.kubernetes.io/instance": release_name,
+                    },
+                },
+                "template": {
+                    "metadata": {"labels": labels},
+                    "spec": {
+                        "terminationGracePeriodSeconds": 30,
+                        "containers": [
+                            {
+                                "name": "nginx",
+                                "image": self._nginx_image,
+                                "ports": [{"containerPort": SESSION_SERVICE_PORT, "name": "http"}],
+                                "resources": {
+                                    "requests": {"memory": "32Mi", "cpu": "10m"},
+                                    "limits": {"memory": "128Mi", "cpu": "100m"},
+                                },
+                            },
+                            {
+                                "name": "skuld",
+                                "image": self._skuld_image,
+                                "ports": [{"containerPort": 8081, "name": "broker"}],
+                                "env": env_vars,
+                                "resources": {
+                                    "requests": {"memory": "256Mi", "cpu": "100m"},
+                                    "limits": {"memory": "1Gi", "cpu": "500m"},
+                                },
+                            },
+                            {
+                                "name": "code-server",
+                                "image": self._code_server_image,
+                                "ports": [{"containerPort": 8443, "name": "ide"}],
+                                "resources": {
+                                    "requests": {"memory": "256Mi", "cpu": "100m"},
+                                    "limits": {"memory": "2Gi", "cpu": "1000m"},
+                                },
+                            },
+                            {
+                                "name": "devrunner",
+                                "image": self._devrunner_image,
+                                "env": [
+                                    {"name": "SESSION_ID", "value": str(session.id)},
+                                    {"name": "TERMINAL_PORT", "value": "7681"},
+                                ],
+                                "resources": {
+                                    "requests": {"memory": "512Mi", "cpu": "100m"},
+                                    "limits": {"memory": "4Gi", "cpu": "2000m"},
+                                },
+                            },
+                        ],
+                    },
+                },
+            },
+        }
+
+    def _build_service_manifest(self, session: Session) -> dict[str, Any]:
+        """Build a Kubernetes Service manifest dict for the session."""
+        labels = self._build_labels(session)
+        release_name = self._release_name(session)
+
+        return {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "name": release_name,
+                "namespace": self._namespace,
+                "labels": labels,
+            },
+            "spec": {
+                "type": "ClusterIP",
+                "selector": {
+                    "app.kubernetes.io/instance": release_name,
+                },
+                "ports": [
+                    {
+                        "name": "http",
+                        "port": SESSION_SERVICE_PORT,
+                        "targetPort": SESSION_SERVICE_PORT,
+                    },
+                ],
+            },
+        }
+
+    def _build_ingress_manifest(self, session: Session) -> dict[str, Any]:
+        """Build a Kubernetes Ingress manifest with path-based routing.
+
+        Uses Traefik strip-prefix annotation so the path prefix is
+        removed before reaching the pod. No host field is set,
+        allowing IP-based access.
+        """
+        labels = self._build_labels(session)
+        release_name = self._release_name(session)
+        session_path = self._session_path(session)
+        middleware_ref = f"{self._namespace}-{release_name}-strip@kubernetescrd"
+
+        return {
+            "apiVersion": "networking.k8s.io/v1",
+            "kind": "Ingress",
+            "metadata": {
+                "name": release_name,
+                "namespace": self._namespace,
+                "labels": labels,
+                "annotations": {
+                    TRAEFIK_STRIP_PREFIX_ANNOTATION: middleware_ref,
+                },
+            },
+            "spec": {
+                "ingressClassName": self._ingress_class,
+                "rules": [
+                    {
+                        "http": {
+                            "paths": [
+                                {
+                                    "path": session_path,
+                                    "pathType": "Prefix",
+                                    "backend": {
+                                        "service": {
+                                            "name": release_name,
+                                            "port": {"number": SESSION_SERVICE_PORT},
+                                        },
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                ],
+            },
+        }
+
+    def _build_strip_prefix_middleware(self, session: Session) -> dict[str, Any]:
+        """Build a Traefik Middleware CR for stripping the session path prefix."""
+        release_name = self._release_name(session)
+        session_path = self._session_path(session)
+
+        return {
+            "apiVersion": "traefik.io/v1alpha1",
+            "kind": "Middleware",
+            "metadata": {
+                "name": f"{release_name}-strip",
+                "namespace": self._namespace,
+                "labels": self._build_labels(session),
+            },
+            "spec": {
+                "stripPrefix": {
+                    "prefixes": [session_path],
+                },
+            },
+        }
+
+    async def _apply_resource(
+        self,
+        api_method_create: str,
+        api_method_patch: str,
+        api_class: str,
+        name: str,
+        manifest: dict[str, Any],
+    ) -> None:
+        """Create or patch a Kubernetes resource via the async API."""
+        from kubernetes_asyncio import client
+
+        api_cls = getattr(client, api_class)
+        api = api_cls(self._api_client)
+
+        create_fn = getattr(api, api_method_create)
+        patch_fn = getattr(api, api_method_patch)
+
+        try:
+            await create_fn(namespace=self._namespace, body=manifest)
+        except client.exceptions.ApiException as exc:
+            if exc.status == 409:
+                logger.info("%s %s already exists, patching", api_class, name)
+                await patch_fn(
+                    name=name,
+                    namespace=self._namespace,
+                    body=manifest,
+                )
+            else:
+                raise
+
+    async def _apply_custom_resource(self, manifest: dict[str, Any]) -> None:
+        """Apply a custom resource (create or update)."""
+        from kubernetes_asyncio import client
+
+        api = client.CustomObjectsApi(self._api_client)
+        api_version = manifest["apiVersion"]
+        parts = api_version.split("/")
+        group = parts[0]
+        version = parts[1]
+        kind = manifest["kind"]
+        plural = kind.lower() + "s"
+        name = manifest["metadata"]["name"]
+        namespace = manifest["metadata"].get("namespace", self._namespace)
+
+        try:
+            await api.create_namespaced_custom_object(
+                group=group,
+                version=version,
+                namespace=namespace,
+                plural=plural,
+                body=manifest,
+            )
+        except client.exceptions.ApiException as exc:
+            if exc.status == 409:
+                await api.patch_namespaced_custom_object(
+                    group=group,
+                    version=version,
+                    namespace=namespace,
+                    plural=plural,
+                    name=name,
+                    body=manifest,
+                )
+            else:
+                logger.warning("Failed to apply %s %s: %s", kind, name, exc)
+                raise
+
+    async def _delete_custom_resource(
+        self,
+        group: str,
+        version: str,
+        plural: str,
+        name: str,
+    ) -> None:
+        """Delete a custom resource, ignoring not-found errors."""
+        from kubernetes_asyncio import client
+
+        api = client.CustomObjectsApi(self._api_client)
+
+        try:
+            await api.delete_namespaced_custom_object(
+                group=group,
+                version=version,
+                namespace=self._namespace,
+                plural=plural,
+                name=name,
+            )
+        except client.exceptions.ApiException as exc:
+            if exc.status != 404:
+                logger.warning("Failed to delete %s/%s: %s", plural, name, exc)
+
+    async def start(
+        self,
+        session: Session,
+        spec: SessionSpec,
+    ) -> PodStartResult:
+        """Start Deployment + Service + Ingress for the session."""
+        await self._ensure_client()
+
+        release_name = self._release_name(session)
+
+        # Create the Traefik strip-prefix middleware CR.
+        middleware = self._build_strip_prefix_middleware(session)
+        await self._apply_custom_resource(middleware)
+
+        # Create the Deployment.
+        deployment = self._build_deployment_manifest(session, spec)
+        await self._apply_resource(
+            api_method_create="create_namespaced_deployment",
+            api_method_patch="patch_namespaced_deployment",
+            api_class="AppsV1Api",
+            name=release_name,
+            manifest=deployment,
+        )
+
+        # Create the Service.
+        service = self._build_service_manifest(session)
+        await self._apply_resource(
+            api_method_create="create_namespaced_service",
+            api_method_patch="patch_namespaced_service",
+            api_class="CoreV1Api",
+            name=release_name,
+            manifest=service,
+        )
+
+        # Create the Ingress.
+        ingress = self._build_ingress_manifest(session)
+        await self._apply_resource(
+            api_method_create="create_namespaced_ingress",
+            api_method_patch="patch_namespaced_ingress",
+            api_class="NetworkingV1Api",
+            name=release_name,
+            manifest=ingress,
+        )
+
+        logger.info(
+            "Created K8s resources for session %s in namespace %s",
+            session.id,
+            self._namespace,
+        )
+
+        return PodStartResult(
+            chat_endpoint=self._chat_endpoint(session),
+            code_endpoint=self._code_endpoint(session),
+            pod_name=release_name,
+        )
+
+    async def stop(self, session: Session) -> bool:
+        """Delete Deployment, Service, Ingress, and Middleware."""
+        await self._ensure_client()
+
+        from kubernetes_asyncio import client
+
+        release_name = self._release_name(session)
+        deleted = False
+
+        # Delete Deployment.
+        try:
+            apps_api = client.AppsV1Api(self._api_client)
+            await apps_api.delete_namespaced_deployment(
+                name=release_name,
+                namespace=self._namespace,
+            )
+            deleted = True
+        except client.exceptions.ApiException as exc:
+            if exc.status != 404:
+                logger.error("Failed to delete deployment %s: %s", release_name, exc)
+
+        # Delete Service.
+        try:
+            core_api = client.CoreV1Api(self._api_client)
+            await core_api.delete_namespaced_service(
+                name=release_name,
+                namespace=self._namespace,
+            )
+            deleted = True
+        except client.exceptions.ApiException as exc:
+            if exc.status != 404:
+                logger.error("Failed to delete service %s: %s", release_name, exc)
+
+        # Delete Ingress.
+        try:
+            networking_api = client.NetworkingV1Api(self._api_client)
+            await networking_api.delete_namespaced_ingress(
+                name=release_name,
+                namespace=self._namespace,
+            )
+            deleted = True
+        except client.exceptions.ApiException as exc:
+            if exc.status != 404:
+                logger.error("Failed to delete ingress %s: %s", release_name, exc)
+
+        # Delete Traefik middleware CR.
+        await self._delete_custom_resource(
+            group="traefik.io",
+            version="v1alpha1",
+            plural="middlewares",
+            name=f"{release_name}-strip",
+        )
+
+        if deleted:
+            logger.info("Deleted K8s resources for session %s", session.id)
+
+        return True
+
+    async def status(self, session: Session) -> SessionStatus:
+        """Get the current status of the session's pods."""
+        await self._ensure_client()
+
+        from kubernetes_asyncio import client
+
+        release_name = self._release_name(session)
+        apps_api = client.AppsV1Api(self._api_client)
+
+        try:
+            deployment = await apps_api.read_namespaced_deployment(
+                name=release_name,
+                namespace=self._namespace,
+            )
+        except client.exceptions.ApiException as exc:
+            if exc.status == 404:
+                return SessionStatus.STOPPED
+            raise
+
+        return self._map_deployment_status(deployment)
+
+    @staticmethod
+    def _map_deployment_status(deployment: Any) -> SessionStatus:
+        """Map Deployment status to SessionStatus."""
+        status = deployment.status
+        if status is None:
+            return SessionStatus.STARTING
+
+        ready = status.ready_replicas or 0
+        desired = deployment.spec.replicas or 1
+
+        if ready >= desired:
+            return SessionStatus.RUNNING
+
+        # Check for failure conditions.
+        if status.conditions:
+            for condition in status.conditions:
+                if condition.type == "Available" and condition.status == "False":
+                    if condition.reason in ("MinimumReplicasUnavailable",):
+                        return SessionStatus.STARTING
+                if condition.type == "Progressing" and condition.status == "False":
+                    return SessionStatus.FAILED
+
+        return SessionStatus.STARTING
+
+    async def wait_for_ready(
+        self,
+        session: Session,
+        timeout: float,
+    ) -> SessionStatus:
+        """Poll status until RUNNING or FAILED/timeout."""
+        elapsed = 0.0
+        while elapsed < timeout:
+            current = await self.status(session)
+            if current == SessionStatus.RUNNING:
+                return SessionStatus.RUNNING
+            if current == SessionStatus.FAILED:
+                return SessionStatus.FAILED
+            await asyncio.sleep(self._poll_interval)
+            elapsed += self._poll_interval
+
+        logger.warning(
+            "Timed out waiting for session %s after %.1fs", session.id, timeout
+        )
+        return SessionStatus.FAILED
+
+    async def close(self) -> None:
+        """Close the Kubernetes API client."""
+        if self._api_client is not None:
+            await self._api_client.close()
+            self._api_client = None

--- a/tests/test_adapters/test_direct_k8s_pod_manager.py
+++ b/tests/test_adapters/test_direct_k8s_pod_manager.py
@@ -1,0 +1,493 @@
+"""Tests for DirectK8sPodManager adapter.
+
+Tests against the kubernetes-asyncio client with mocked API calls.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from tests.conftest import make_spec
+from volundr.adapters.outbound.direct_k8s_pod_manager import (
+    DEFAULT_POLL_INTERVAL,
+    DEFAULT_READINESS_TIMEOUT,
+    MANAGED_BY_LABEL,
+    MANAGED_BY_VALUE,
+    SESSION_LABEL,
+    SESSION_SERVICE_PORT,
+    DirectK8sPodManager,
+)
+from volundr.domain.models import Session, SessionStatus
+
+
+@pytest.fixture
+def sample_session() -> Session:
+    """Create a sample session for testing."""
+    return Session(
+        id=uuid4(),
+        name="Test K3s Session",
+        model="claude-sonnet-4-20250514",
+        repo="https://github.com/org/repo",
+        branch="main",
+    )
+
+
+@pytest.fixture
+def pod_manager() -> DirectK8sPodManager:
+    """Create a DirectK8sPodManager for testing."""
+    return DirectK8sPodManager(
+        namespace="test-ns",
+        kubeconfig="/test/kubeconfig",
+        base_path="/s",
+        ingress_class="traefik",
+        skuld_image="ghcr.io/niuulabs/skuld:test",
+        code_server_image="codercom/code-server:test",
+        nginx_image="nginx:test",
+        devrunner_image="ghcr.io/niuulabs/devrunner:test",
+        db_host="host.k3d.internal",
+        db_port=5433,
+        db_user="volundr",
+        db_password="testpass",
+        db_name="volundr",
+    )
+
+
+class TestConstructor:
+    """Test DirectK8sPodManager constructor."""
+
+    def test_default_values(self) -> None:
+        pm = DirectK8sPodManager()
+        assert pm._namespace == "volundr"
+        assert pm._kubeconfig == ""
+        assert pm._base_path == "/s"
+        assert pm._ingress_class == "traefik"
+        assert pm._poll_interval == DEFAULT_POLL_INTERVAL
+        assert pm._readiness_timeout == DEFAULT_READINESS_TIMEOUT
+
+    def test_custom_values(self, pod_manager: DirectK8sPodManager) -> None:
+        assert pod_manager._namespace == "test-ns"
+        assert pod_manager._kubeconfig == "/test/kubeconfig"
+        assert pod_manager._base_path == "/s"
+        assert pod_manager._skuld_image == "ghcr.io/niuulabs/skuld:test"
+        assert pod_manager._db_host == "host.k3d.internal"
+        assert pod_manager._db_port == 5433
+        assert pod_manager._db_password == "testpass"
+
+    def test_extra_kwargs_ignored(self) -> None:
+        pm = DirectK8sPodManager(
+            namespace="test",
+            unknown_key="should-not-fail",
+            another_key=42,
+        )
+        assert pm._namespace == "test"
+
+
+class TestResourceNames:
+    """Test resource name generation."""
+
+    def test_release_name(
+        self,
+        pod_manager: DirectK8sPodManager,
+        sample_session: Session,
+    ) -> None:
+        name = pod_manager._release_name(sample_session)
+        assert name == f"skuld-{sample_session.id}"
+
+    def test_session_path(
+        self,
+        pod_manager: DirectK8sPodManager,
+        sample_session: Session,
+    ) -> None:
+        path = pod_manager._session_path(sample_session)
+        assert path == f"/s/{sample_session.id}"
+
+    def test_chat_endpoint(
+        self,
+        pod_manager: DirectK8sPodManager,
+        sample_session: Session,
+    ) -> None:
+        endpoint = pod_manager._chat_endpoint(sample_session)
+        assert endpoint == f"/s/{sample_session.id}/session"
+
+    def test_code_endpoint(
+        self,
+        pod_manager: DirectK8sPodManager,
+        sample_session: Session,
+    ) -> None:
+        endpoint = pod_manager._code_endpoint(sample_session)
+        assert endpoint == f"/s/{sample_session.id}/"
+
+    def test_middleware_name(
+        self,
+        pod_manager: DirectK8sPodManager,
+        sample_session: Session,
+    ) -> None:
+        name = pod_manager._middleware_name(sample_session)
+        assert name == f"test-ns-strip-{sample_session.id}"
+
+
+class TestLabels:
+    """Test label generation."""
+
+    def test_build_labels(
+        self,
+        pod_manager: DirectK8sPodManager,
+        sample_session: Session,
+    ) -> None:
+        labels = pod_manager._build_labels(sample_session)
+        assert labels[MANAGED_BY_LABEL] == MANAGED_BY_VALUE
+        assert labels[SESSION_LABEL] == str(sample_session.id)
+        assert labels["app.kubernetes.io/name"] == "skuld"
+        assert labels["app.kubernetes.io/instance"] == f"skuld-{sample_session.id}"
+
+
+class TestEnvironment:
+    """Test environment variable building."""
+
+    def test_build_env_basic(
+        self,
+        pod_manager: DirectK8sPodManager,
+        sample_session: Session,
+    ) -> None:
+        spec = make_spec()
+        env = pod_manager._build_env(sample_session, spec)
+
+        env_dict = {e["name"]: e["value"] for e in env}
+        assert env_dict["SESSION_ID"] == str(sample_session.id)
+        assert env_dict["SESSION_NAME"] == sample_session.name
+        assert env_dict["DATABASE__HOST"] == "host.k3d.internal"
+        assert env_dict["DATABASE__PORT"] == "5433"
+        assert env_dict["DATABASE__USER"] == "volundr"
+        assert env_dict["DATABASE__PASSWORD"] == "testpass"
+        assert env_dict["DATABASE__NAME"] == "volundr"
+
+    def test_build_env_with_git(
+        self,
+        pod_manager: DirectK8sPodManager,
+        sample_session: Session,
+    ) -> None:
+        spec = make_spec(
+            git={"cloneUrl": "https://github.com/org/repo", "branch": "develop"},
+        )
+        env = pod_manager._build_env(sample_session, spec)
+
+        env_dict = {e["name"]: e["value"] for e in env}
+        assert env_dict["GIT_CLONE_URL"] == "https://github.com/org/repo"
+        assert env_dict["GIT_BRANCH"] == "develop"
+
+    def test_build_env_with_session_model(
+        self,
+        pod_manager: DirectK8sPodManager,
+        sample_session: Session,
+    ) -> None:
+        spec = make_spec(session={"model": "claude-opus-4-20250514"})
+        env = pod_manager._build_env(sample_session, spec)
+
+        env_dict = {e["name"]: e["value"] for e in env}
+        assert env_dict["SESSION_MODEL"] == "claude-opus-4-20250514"
+
+    def test_build_env_with_extra_env(
+        self,
+        pod_manager: DirectK8sPodManager,
+        sample_session: Session,
+    ) -> None:
+        spec = make_spec(env={"CUSTOM_VAR": "custom_value", "PORT": 3000})
+        env = pod_manager._build_env(sample_session, spec)
+
+        env_dict = {e["name"]: e["value"] for e in env}
+        assert env_dict["CUSTOM_VAR"] == "custom_value"
+        assert env_dict["PORT"] == "3000"
+
+
+class TestManifests:
+    """Test manifest generation."""
+
+    def test_build_deployment_manifest(
+        self,
+        pod_manager: DirectK8sPodManager,
+        sample_session: Session,
+    ) -> None:
+        spec = make_spec()
+        manifest = pod_manager._build_deployment_manifest(sample_session, spec)
+
+        assert manifest["apiVersion"] == "apps/v1"
+        assert manifest["kind"] == "Deployment"
+        assert manifest["metadata"]["name"] == f"skuld-{sample_session.id}"
+        assert manifest["metadata"]["namespace"] == "test-ns"
+        assert manifest["spec"]["replicas"] == 1
+
+        containers = manifest["spec"]["template"]["spec"]["containers"]
+        container_names = [c["name"] for c in containers]
+        assert "nginx" in container_names
+        assert "skuld" in container_names
+        assert "code-server" in container_names
+        assert "devrunner" in container_names
+
+        # Check skuld env vars.
+        skuld = next(c for c in containers if c["name"] == "skuld")
+        env_dict = {e["name"]: e["value"] for e in skuld["env"]}
+        assert env_dict["SESSION_ID"] == str(sample_session.id)
+        assert env_dict["DATABASE__HOST"] == "host.k3d.internal"
+
+    def test_build_service_manifest(
+        self,
+        pod_manager: DirectK8sPodManager,
+        sample_session: Session,
+    ) -> None:
+        manifest = pod_manager._build_service_manifest(sample_session)
+
+        assert manifest["apiVersion"] == "v1"
+        assert manifest["kind"] == "Service"
+        assert manifest["metadata"]["name"] == f"skuld-{sample_session.id}"
+        assert manifest["spec"]["type"] == "ClusterIP"
+        assert manifest["spec"]["ports"][0]["port"] == SESSION_SERVICE_PORT
+
+    def test_build_ingress_manifest(
+        self,
+        pod_manager: DirectK8sPodManager,
+        sample_session: Session,
+    ) -> None:
+        manifest = pod_manager._build_ingress_manifest(sample_session)
+
+        assert manifest["apiVersion"] == "networking.k8s.io/v1"
+        assert manifest["kind"] == "Ingress"
+        assert manifest["spec"]["ingressClassName"] == "traefik"
+
+        # Verify path-based routing with no host.
+        rule = manifest["spec"]["rules"][0]
+        assert "host" not in rule
+        path = rule["http"]["paths"][0]
+        assert path["path"] == f"/s/{sample_session.id}"
+        assert path["pathType"] == "Prefix"
+        assert path["backend"]["service"]["name"] == f"skuld-{sample_session.id}"
+        assert path["backend"]["service"]["port"]["number"] == SESSION_SERVICE_PORT
+
+        # Verify Traefik strip-prefix annotation.
+        annotations = manifest["metadata"]["annotations"]
+        expected_mw = f"test-ns-skuld-{sample_session.id}-strip@kubernetescrd"
+        assert annotations["traefik.ingress.kubernetes.io/router.middlewares"] == expected_mw
+
+
+class TestStripPrefixMiddleware:
+    """Test Traefik middleware generation."""
+
+    def test_build_strip_prefix_middleware(
+        self,
+        pod_manager: DirectK8sPodManager,
+        sample_session: Session,
+    ) -> None:
+        mw = pod_manager._build_strip_prefix_middleware(sample_session)
+
+        assert mw["apiVersion"] == "traefik.io/v1alpha1"
+        assert mw["kind"] == "Middleware"
+        assert mw["metadata"]["name"] == f"skuld-{sample_session.id}-strip"
+        assert mw["metadata"]["namespace"] == "test-ns"
+        assert mw["spec"]["stripPrefix"]["prefixes"] == [
+            f"/s/{sample_session.id}"
+        ]
+
+
+class TestDeploymentStatus:
+    """Test deployment status mapping."""
+
+    def test_running(self) -> None:
+        deployment = MagicMock()
+        deployment.spec.replicas = 1
+        deployment.status.ready_replicas = 1
+        deployment.status.conditions = []
+
+        status = DirectK8sPodManager._map_deployment_status(deployment)
+        assert status == SessionStatus.RUNNING
+
+    def test_starting_no_ready(self) -> None:
+        deployment = MagicMock()
+        deployment.spec.replicas = 1
+        deployment.status.ready_replicas = 0
+        deployment.status.conditions = []
+
+        status = DirectK8sPodManager._map_deployment_status(deployment)
+        assert status == SessionStatus.STARTING
+
+    def test_starting_none_ready(self) -> None:
+        deployment = MagicMock()
+        deployment.spec.replicas = 1
+        deployment.status.ready_replicas = None
+        deployment.status.conditions = []
+
+        status = DirectK8sPodManager._map_deployment_status(deployment)
+        assert status == SessionStatus.STARTING
+
+    def test_no_status(self) -> None:
+        deployment = MagicMock()
+        deployment.status = None
+
+        status = DirectK8sPodManager._map_deployment_status(deployment)
+        assert status == SessionStatus.STARTING
+
+    def test_failed_progressing_false(self) -> None:
+        condition = MagicMock()
+        condition.type = "Progressing"
+        condition.status = "False"
+
+        deployment = MagicMock()
+        deployment.spec.replicas = 1
+        deployment.status.ready_replicas = 0
+        deployment.status.conditions = [condition]
+
+        status = DirectK8sPodManager._map_deployment_status(deployment)
+        assert status == SessionStatus.FAILED
+
+
+class TestStart:
+    """Test the start method with mocked K8s client."""
+
+    @pytest.mark.asyncio
+    async def test_start_creates_resources(
+        self,
+        pod_manager: DirectK8sPodManager,
+        sample_session: Session,
+    ) -> None:
+        # Set up a fake api_client so _ensure_client is skipped.
+        pod_manager._api_client = MagicMock()
+
+        spec = make_spec()
+
+        with patch.object(pod_manager, "_apply_custom_resource", new_callable=AsyncMock) as mock_cr, \
+             patch.object(pod_manager, "_apply_resource", new_callable=AsyncMock) as mock_apply:
+            result = await pod_manager.start(sample_session, spec)
+
+        # Verify custom resource (middleware) was created.
+        mock_cr.assert_called_once()
+
+        # Verify Deployment, Service, Ingress were created (3 calls).
+        assert mock_apply.call_count == 3
+        call_args_list = [c.kwargs["api_class"] for c in mock_apply.call_args_list]
+        assert "AppsV1Api" in call_args_list
+        assert "CoreV1Api" in call_args_list
+        assert "NetworkingV1Api" in call_args_list
+
+        # Verify result.
+        assert result.chat_endpoint == f"/s/{sample_session.id}/session"
+        assert result.code_endpoint == f"/s/{sample_session.id}/"
+        assert result.pod_name == f"skuld-{sample_session.id}"
+
+
+class TestStop:
+    """Test the stop method with mocked K8s client."""
+
+    @pytest.mark.asyncio
+    async def test_stop_deletes_resources(
+        self,
+        pod_manager: DirectK8sPodManager,
+        sample_session: Session,
+    ) -> None:
+        from kubernetes_asyncio import client
+
+        mock_apps_api = AsyncMock()
+        mock_core_api = AsyncMock()
+        mock_networking_api = AsyncMock()
+
+        pod_manager._api_client = MagicMock()
+
+        with patch.object(client, "AppsV1Api", return_value=mock_apps_api), \
+             patch.object(client, "CoreV1Api", return_value=mock_core_api), \
+             patch.object(client, "NetworkingV1Api", return_value=mock_networking_api), \
+             patch.object(pod_manager, "_delete_custom_resource", new_callable=AsyncMock) as mock_delete_cr:
+            result = await pod_manager.stop(sample_session)
+
+        assert result is True
+        mock_apps_api.delete_namespaced_deployment.assert_called_once()
+        mock_core_api.delete_namespaced_service.assert_called_once()
+        mock_networking_api.delete_namespaced_ingress.assert_called_once()
+        mock_delete_cr.assert_called_once()
+
+
+class TestStatus:
+    """Test the status method with mocked K8s client."""
+
+    @pytest.mark.asyncio
+    async def test_status_running(
+        self,
+        pod_manager: DirectK8sPodManager,
+        sample_session: Session,
+    ) -> None:
+        from kubernetes_asyncio import client
+
+        deployment = MagicMock()
+        deployment.spec.replicas = 1
+        deployment.status.ready_replicas = 1
+        deployment.status.conditions = []
+
+        mock_apps_api = AsyncMock()
+        mock_apps_api.read_namespaced_deployment.return_value = deployment
+
+        pod_manager._api_client = MagicMock()
+
+        with patch.object(client, "AppsV1Api", return_value=mock_apps_api):
+            status = await pod_manager.status(sample_session)
+
+        assert status == SessionStatus.RUNNING
+
+    @pytest.mark.asyncio
+    async def test_status_not_found(
+        self,
+        pod_manager: DirectK8sPodManager,
+        sample_session: Session,
+    ) -> None:
+        from kubernetes_asyncio import client
+        from kubernetes_asyncio.client.exceptions import ApiException
+
+        mock_apps_api = AsyncMock()
+        mock_apps_api.read_namespaced_deployment.side_effect = ApiException(
+            status=404, reason="Not Found"
+        )
+
+        pod_manager._api_client = MagicMock()
+
+        with patch.object(client, "AppsV1Api", return_value=mock_apps_api):
+            status = await pod_manager.status(sample_session)
+
+        assert status == SessionStatus.STOPPED
+
+
+class TestCredentialStore:
+    """Test credential store injection."""
+
+    def test_set_credential_store(
+        self,
+        pod_manager: DirectK8sPodManager,
+    ) -> None:
+        assert pod_manager._credential_store is None
+
+        mock_store = MagicMock()
+        pod_manager.set_credential_store(mock_store)
+        assert pod_manager._credential_store is mock_store
+
+
+class TestClose:
+    """Test client cleanup."""
+
+    @pytest.mark.asyncio
+    async def test_close_clears_clients(
+        self,
+        pod_manager: DirectK8sPodManager,
+    ) -> None:
+        mock_client = AsyncMock()
+        pod_manager._api_client = mock_client
+
+        await pod_manager.close()
+
+        assert pod_manager._api_client is None
+        mock_client.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_close_noop_when_not_initialized(
+        self,
+        pod_manager: DirectK8sPodManager,
+    ) -> None:
+        # Should not raise.
+        await pod_manager.close()
+        assert pod_manager._api_client is None

--- a/tests/test_adapters/test_direct_k8s_pod_manager.py
+++ b/tests/test_adapters/test_direct_k8s_pod_manager.py
@@ -350,26 +350,28 @@ class TestStart:
         pod_manager: DirectK8sPodManager,
         sample_session: Session,
     ) -> None:
-        # Set up a fake api_client so _ensure_client is skipped.
         pod_manager._api_client = MagicMock()
-
         spec = make_spec()
 
-        with patch.object(pod_manager, "_apply_custom_resource", new_callable=AsyncMock) as mock_cr, \
-             patch.object(pod_manager, "_apply_resource", new_callable=AsyncMock) as mock_apply:
+        mock_cr = AsyncMock()
+        mock_apply = AsyncMock()
+        with patch.object(
+            pod_manager, "_apply_custom_resource", mock_cr,
+        ), patch.object(
+            pod_manager, "_apply_resource", mock_apply,
+        ):
             result = await pod_manager.start(sample_session, spec)
 
-        # Verify custom resource (middleware) was created.
         mock_cr.assert_called_once()
 
-        # Verify Deployment, Service, Ingress were created (3 calls).
         assert mock_apply.call_count == 3
-        call_args_list = [c.kwargs["api_class"] for c in mock_apply.call_args_list]
-        assert "AppsV1Api" in call_args_list
-        assert "CoreV1Api" in call_args_list
-        assert "NetworkingV1Api" in call_args_list
+        call_classes = [
+            c.kwargs["api_class"] for c in mock_apply.call_args_list
+        ]
+        assert "AppsV1Api" in call_classes
+        assert "CoreV1Api" in call_classes
+        assert "NetworkingV1Api" in call_classes
 
-        # Verify result.
         assert result.chat_endpoint == f"/s/{sample_session.id}/session"
         assert result.code_endpoint == f"/s/{sample_session.id}/"
         assert result.pod_name == f"skuld-{sample_session.id}"
@@ -384,24 +386,25 @@ class TestStop:
         pod_manager: DirectK8sPodManager,
         sample_session: Session,
     ) -> None:
-        from kubernetes_asyncio import client
-
-        mock_apps_api = AsyncMock()
-        mock_core_api = AsyncMock()
-        mock_networking_api = AsyncMock()
-
         pod_manager._api_client = MagicMock()
 
-        with patch.object(client, "AppsV1Api", return_value=mock_apps_api), \
-             patch.object(client, "CoreV1Api", return_value=mock_core_api), \
-             patch.object(client, "NetworkingV1Api", return_value=mock_networking_api), \
-             patch.object(pod_manager, "_delete_custom_resource", new_callable=AsyncMock) as mock_delete_cr:
+        mock_delete = AsyncMock(return_value=True)
+        mock_delete_cr = AsyncMock()
+        with patch.object(
+            pod_manager, "_delete_resource", mock_delete,
+        ), patch.object(
+            pod_manager, "_delete_custom_resource", mock_delete_cr,
+        ):
             result = await pod_manager.stop(sample_session)
 
         assert result is True
-        mock_apps_api.delete_namespaced_deployment.assert_called_once()
-        mock_core_api.delete_namespaced_service.assert_called_once()
-        mock_networking_api.delete_namespaced_ingress.assert_called_once()
+        assert mock_delete.call_count == 3
+        call_classes = [
+            c.args[0] for c in mock_delete.call_args_list
+        ]
+        assert "AppsV1Api" in call_classes
+        assert "CoreV1Api" in call_classes
+        assert "NetworkingV1Api" in call_classes
         mock_delete_cr.assert_called_once()
 
 
@@ -414,19 +417,18 @@ class TestStatus:
         pod_manager: DirectK8sPodManager,
         sample_session: Session,
     ) -> None:
-        from kubernetes_asyncio import client
-
         deployment = MagicMock()
         deployment.spec.replicas = 1
         deployment.status.ready_replicas = 1
         deployment.status.conditions = []
 
-        mock_apps_api = AsyncMock()
-        mock_apps_api.read_namespaced_deployment.return_value = deployment
-
         pod_manager._api_client = MagicMock()
 
-        with patch.object(client, "AppsV1Api", return_value=mock_apps_api):
+        with patch.object(
+            pod_manager, "_read_deployment",
+            new_callable=AsyncMock,
+            return_value=deployment,
+        ):
             status = await pod_manager.status(sample_session)
 
         assert status == SessionStatus.RUNNING
@@ -437,17 +439,13 @@ class TestStatus:
         pod_manager: DirectK8sPodManager,
         sample_session: Session,
     ) -> None:
-        from kubernetes_asyncio import client
-        from kubernetes_asyncio.client.exceptions import ApiException
-
-        mock_apps_api = AsyncMock()
-        mock_apps_api.read_namespaced_deployment.side_effect = ApiException(
-            status=404, reason="Not Found"
-        )
-
         pod_manager._api_client = MagicMock()
 
-        with patch.object(client, "AppsV1Api", return_value=mock_apps_api):
+        with patch.object(
+            pod_manager, "_read_deployment",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
             status = await pod_manager.status(sample_session)
 
         assert status == SessionStatus.STOPPED


### PR DESCRIPTION
## Summary

Closes NIU-132

- Add `K3sRuntime` to Go CLI with platform-aware k3d (macOS) / native k3s (Linux) support
- Add `DirectK8sPodManager` Python adapter using `kubernetes-asyncio` for direct K8s API session management (no Flux/Helm per session)
- Update skuld Helm chart with path-based ingress mode for Traefik (works with IPs, no hostname required)
- Add K3s config section (`kubeconfig`, `namespace`, `provider`) to CLI config
- Wire up runtime factory, init wizard, and up command

## Architecture

```
Host (Go CLI)
├── Embedded PostgreSQL
├── Python API (uvicorn)
├── Go Reverse Proxy
│
└── k3s cluster (k3d on macOS, native on Linux)
    ├── Traefik ingress (path-based: /s/{session-id}/*)
    └── skuld session pods
```

The Volundr API stays on the host and talks to k3s via kubeconfig. Only session pods run in the cluster.

## Changes

| File | Change |
|------|--------|
| `cli/internal/runtime/k3s.go` | Full K3sRuntime (Init/Up/Down/Status/Logs) |
| `cli/internal/runtime/k3s_test.go` | 10 Go tests |
| `cli/internal/config/config.go` | K3sConfig struct |
| `cli/internal/runtime/factory.go` | Wire k3s case |
| `src/volundr/adapters/outbound/direct_k8s_pod_manager.py` | DirectK8sPodManager adapter |
| `tests/test_adapters/test_direct_k8s_pod_manager.py` | 29 Python tests |
| `charts/skuld/values.yaml` | Add `ingress.mode` value |
| `charts/skuld/templates/ingress.yaml` | Path-prefix mode |
| `charts/skuld/templates/strip-prefix-middleware.yaml` | Traefik Middleware CR |

## Test plan

- [x] 10 Go tests pass (config gen, factory wiring, kubeconfig resolution, provider detection)
- [x] 29 Python tests pass (manifest generation, start/stop/status with mocked K8s client)
- [ ] Manual test: `volundr init --runtime k3s` on macOS with k3d
- [ ] Manual test: `volundr up` creates cluster, starts sessions accessible at `localhost/s/{id}`
- [ ] Manual test: `volundr down` cleans up session pods without stopping k3d
- [ ] Verify path-based ingress works with IP addresses (no hostname)

🤖 Generated with [Claude Code](https://claude.com/claude-code)