### PR TITLE
fix(ci): sign container images by tag instead of digest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -114,8 +114,7 @@ jobs:
         run: |
           IMAGE="${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.container }}"
           VERSION="${{ needs.version.outputs.version }}"
-          DIGEST=$(docker buildx imagetools inspect "${IMAGE}:${VERSION}" --format '{{.Manifest.Digest}}')
-          cosign sign --yes "${IMAGE}@${DIGEST}"
+          cosign sign --yes "${IMAGE}:${VERSION}"
 
   # Scan and generate SBOMs after manifests are published
   scan-containers:


### PR DESCRIPTION
## Summary
- Cosign can resolve tags to digests internally — no need for `docker buildx imagetools inspect`
- The `--format '{{.Manifest.Digest}}'` template doesn't work for manifest lists, producing verbose output that breaks `cosign sign`

## Test plan
- [ ] Release workflow manifest signing step passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)