### PR TITLE
fix(ci): add attestations permission to release job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -320,6 +320,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Add `attestations: write` permission to the release job so `actions/attest-build-provenance` can persist attestations

## Test plan
- [ ] Release workflow attestation step passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)