### PR TITLE
feat(cli): persistent terminal sessions with multi-tab support

### DIFF
--- a/charts/skuld/templates/deployment.yaml
+++ b/charts/skuld/templates/deployment.yaml
@@ -17,6 +17,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.session.name }}
+      hostname: {{ .Values.session.name | lower | trunc 63 | trimSuffix "-" | quote }}
+      {{- end }}
       {{- with .Values.runtimeClassName }}
       runtimeClassName: {{ . | quote }}
       {{- end }}
@@ -345,6 +348,8 @@ spec:
           env:
             - name: SESSION_ID
               value: {{ .Values.session.id | quote }}
+            - name: SESSION_NAME
+              value: {{ .Values.session.name | quote }}
             - name: WORKSPACE_DIR
               value: {{ include "skuld.workspacePath" . | quote }}
             - name: PERSISTENCE_MOUNT_PATH

--- a/cli/internal/api/session_pod.go
+++ b/cli/internal/api/session_pod.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -87,8 +88,23 @@ type FileEntry struct {
 
 // do executes an HTTP request to the session pod with token auth.
 func (s *SessionPodClient) do(method, path string) (*http.Response, error) {
+	return s.doWithBody(method, path, nil)
+}
+
+// doWithBody executes an HTTP request with an optional JSON body.
+func (s *SessionPodClient) doWithBody(method, path string, body any) (*http.Response, error) {
 	url := s.baseURL + path
-	req, err := http.NewRequest(method, url, nil)
+
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling request: %w", err)
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequest(method, url, bodyReader)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
@@ -221,6 +237,94 @@ func (s *SessionPodClient) ListFiles(dirPath string) ([]FileEntry, error) {
 		return nil, fmt.Errorf("decoding files: %w", err)
 	}
 	return result, nil
+}
+
+// CliSession represents a persistent tmux-backed terminal session on a session pod.
+// Maps to devrunner's terminal.py API response format.
+type CliSession struct {
+	TerminalID string `json:"terminalId"`
+	Label      string `json:"label"`
+	CliType    string `json:"cli_type"`
+	Status     string `json:"status"`
+	Persistent bool   `json:"persistent"`
+}
+
+// CliSessionList is the response from listing terminal sessions.
+type CliSessionList struct {
+	Sessions []CliSession `json:"sessions"`
+	Tmux     bool         `json:"tmux"`
+}
+
+// CreateCliSessionRequest holds parameters for spawning a terminal session.
+type CreateCliSessionRequest struct {
+	CliType string `json:"cli_type"`
+	Name    string `json:"name,omitempty"`
+	Label   string `json:"label,omitempty"`
+}
+
+// ListCliSessions returns all terminal sessions from the devrunner.
+func (s *SessionPodClient) ListCliSessions() (*CliSessionList, error) {
+	resp, err := s.do("GET", "/terminal/api/terminal/sessions")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("session pod error (HTTP %d): %s", resp.StatusCode, string(body))
+	}
+
+	var result CliSessionList
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding terminal sessions: %w", err)
+	}
+	return &result, nil
+}
+
+// CreateCliSession spawns a new persistent terminal session on the devrunner.
+func (s *SessionPodClient) CreateCliSession(req CreateCliSessionRequest) (*CliSession, error) {
+	resp, err := s.doWithBody("POST", "/terminal/api/terminal/spawn", req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("session pod error (HTTP %d): %s", resp.StatusCode, string(body))
+	}
+
+	var result CliSession
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding terminal session: %w", err)
+	}
+	return &result, nil
+}
+
+// KillCliSession kills a terminal session by ID.
+func (s *SessionPodClient) KillCliSession(terminalID string) error {
+	body := map[string]string{"terminalId": terminalID}
+	resp, err := s.doWithBody("POST", "/terminal/api/terminal/kill", body)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("session pod error (HTTP %d): %s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
+// CliSessionWSURL builds the WebSocket URL for attaching to a terminal session.
+// codeEndpoint is the session's HTTPS code_endpoint.
+func CliSessionWSURL(codeEndpoint, terminalID string) string {
+	base := strings.TrimRight(codeEndpoint, "/")
+	base = strings.Replace(base, "https://", "wss://", 1)
+	base = strings.Replace(base, "http://", "ws://", 1)
+	return base + "/terminal/ws/" + terminalID
 }
 
 // ChatWSURL returns the full WebSocket URL for chat on this session.

--- a/cli/internal/api/ws.go
+++ b/cli/internal/api/ws.go
@@ -273,28 +273,6 @@ func appendAccessToken(rawURL, token string) string {
 	return rawURL + sep + "access_token=" + url.QueryEscape(token)
 }
 
-// SessionWSURL builds a full WebSocket URL for a session pod endpoint.
-// codeEndpoint is the session's HTTPS code_endpoint, path is the WS path to append.
-func SessionWSURL(codeEndpoint, path string) string {
-	base := strings.TrimRight(codeEndpoint, "/")
-	base = strings.Replace(base, "https://", "wss://", 1)
-	base = strings.Replace(base, "http://", "ws://", 1)
-	return base + path
-}
-
-// TerminalWSURLFromChat derives the terminal WebSocket URL from the chat endpoint.
-// This matches the web UI pattern: strip /session or /api/session, append /terminal/ws.
-func TerminalWSURLFromChat(chatEndpoint string) string {
-	// Convert wss to wss (already ws), or https to wss
-	wsURL := strings.Replace(chatEndpoint, "https://", "wss://", 1)
-	wsURL = strings.Replace(wsURL, "http://", "ws://", 1)
-
-	// Strip /api/session or /session suffix (check longer suffix first).
-	wsURL = strings.TrimSuffix(wsURL, "/api/session")
-	wsURL = strings.TrimSuffix(wsURL, "/session")
-
-	return wsURL + "/terminal/ws"
-}
 
 // String returns a human-readable representation of the connection state.
 func (s WSState) String() string {

--- a/cli/internal/cli/tui.go
+++ b/cli/internal/cli/tui.go
@@ -200,7 +200,8 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Always forward async data messages to the right page,
 	// regardless of which page is active or whether help is showing.
 	switch msg.(type) {
-	case pages.TerminalOutputMsg, pages.TerminalConnectedMsg, pages.TerminalDisconnectedMsg:
+	case pages.TerminalOutputMsg, pages.TerminalConnectedMsg, pages.TerminalDisconnectedMsg,
+		pages.TerminalSessionsLoadedMsg, pages.TerminalSpawnedMsg:
 		m.terminal, cmd = m.terminal.Update(msg)
 		if cmd != nil {
 			cmds = append(cmds, cmd)
@@ -275,12 +276,13 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			key := keyMsg.String()
 			// Let these keys through to the app layer:
 			switch {
-			case key == "ctrl+c", key == "f11", key == "ctrl+f",
+			case key == "f11", key == "ctrl+f",
 				key == "?", key == "esc", key == "[":
 				// fall through to app
 			case len(key) == 1 && key >= "1" && key <= "7":
 				// number keys for page navigation
 			default:
+				// Forward everything else (including ctrl+c) to the terminal.
 				m.terminal, cmd = m.terminal.Update(msg)
 				if cmd != nil {
 					cmds = append(cmds, cmd)

--- a/cli/internal/tui/pages/terminal.go
+++ b/cli/internal/tui/pages/terminal.go
@@ -36,10 +36,23 @@ type TerminalDisconnectedMsg struct {
 	Err      error
 }
 
+// TerminalSessionsLoadedMsg carries discovered/spawned sessions from a goroutine
+// back into the Update loop so tabs can be created synchronously.
+type TerminalSessionsLoadedMsg struct {
+	Sessions []api.CliSession
+}
+
+// TerminalSpawnedMsg carries a single newly spawned session into the Update loop.
+type TerminalSpawnedMsg struct {
+	Session api.CliSession
+}
+
 // terminalTab represents a single terminal tab with its own vt emulator and WS connection.
 type terminalTab struct {
-	label     string
-	sessionID string
+	label      string
+	terminalID string // server-side tmux session ID (for kill calls)
+	sessionID  string
+	wsURL     string // WebSocket URL for reconnecting on tab switch
 	emulator  *vt.Emulator
 	ws        *api.TerminalWSClient
 	connState string
@@ -59,6 +72,10 @@ type TerminalPage struct {
 	pool       *tui.ClientPool
 	outputCh   chan TerminalOutputMsg
 	connCh     chan tea.Msg
+
+	// activeSession is stored so new tabs can be spawned from ctrl+t.
+	activeSession *api.Session
+	activeToken   string
 }
 
 // defaultTermWidth and defaultTermHeight are initial vt emulator dimensions
@@ -135,10 +152,20 @@ func (t TerminalPage) Update(msg tea.Msg) (TerminalPage, tea.Cmd) {
 		}
 		return t, t.waitForConn()
 
+	case TerminalSessionsLoadedMsg:
+		// Sessions discovered by the background goroutine — create tabs.
+		t.handleSessionsLoaded(msg.Sessions)
+		return t, t.waitForConn()
+
+	case TerminalSpawnedMsg:
+		// A single new session was spawned — create a tab and switch to it.
+		t.handleSpawned(msg.Session)
+		return t, t.waitForConn()
+
 	case tea.WindowSizeMsg:
 		t.width = msg.Width
 		t.height = msg.Height
-		t.resizeActiveEmulator()
+		t.resizeAllEmulators()
 		return t, nil
 
 	case tea.KeyMsg:
@@ -150,27 +177,34 @@ func (t TerminalPage) Update(msg tea.Msg) (TerminalPage, tea.Cmd) {
 
 // handleKey processes keyboard input.
 func (t TerminalPage) handleKey(msg tea.KeyMsg) (TerminalPage, tea.Cmd) {
-	key := msg.String()
+	// Use Keystroke() for matching — unlike String(), it always returns the
+	// canonical "ctrl+n" format regardless of whether the terminal sends
+	// the raw control character or enhanced key data.
+	key := msg.Key().Keystroke()
 
 	// Full-screen toggle: F11 or ctrl+f
 	if key == "f11" || key == "ctrl+f" {
 		t.fullScreen = !t.fullScreen
-		t.resizeActiveEmulator()
+		t.resizeAllEmulators()
 		return t, nil
 	}
 
 	// Tab management: ctrl+t to create new tab
 	if key == "ctrl+t" {
-		return t, nil // No-op without session; caller should set session first.
-	}
-
-	// Tab switching: ctrl+] for next, ctrl+[ for previous
-	if key == "ctrl+]" && len(t.tabs) > 1 {
-		t.activeTab = (t.activeTab + 1) % len(t.tabs)
+		t.spawnNewTab()
 		return t, nil
 	}
-	if key == "ctrl+\\" && len(t.tabs) > 1 {
+
+	// Tab switching: ctrl+n for next, ctrl+p for previous.
+	// Reconnects WebSocket since the server only supports one active connection.
+	if key == "ctrl+n" && len(t.tabs) > 1 {
+		t.activeTab = (t.activeTab + 1) % len(t.tabs)
+		t.connectTab(t.activeTab)
+		return t, nil
+	}
+	if key == "ctrl+p" && len(t.tabs) > 1 {
 		t.activeTab = (t.activeTab - 1 + len(t.tabs)) % len(t.tabs)
+		t.connectTab(t.activeTab)
 		return t, nil
 	}
 
@@ -186,6 +220,10 @@ func (t TerminalPage) handleKey(msg tea.KeyMsg) (TerminalPage, tea.Cmd) {
 	}
 
 	tab := t.tabs[t.activeTab]
+	if tab.ws == nil {
+		return t, nil
+	}
+
 	tab.mu.Lock()
 	connected := tab.connState == connStatusConnected
 	tab.mu.Unlock()
@@ -229,15 +267,15 @@ func (t *TerminalPage) ConnectSession(sess api.Session) {
 	// Close() fires OnStateChange which calls p.Send() and blocks
 	// when called from inside Update().
 	for _, tab := range t.tabs {
-		tab.ws.OnData = nil
-		tab.ws.OnStateChange = nil
-		tab.ws.OnError = nil
-		oldWS := tab.ws
+		if tab.ws != nil {
+			tab.ws.OnData = nil
+			tab.ws.OnStateChange = nil
+			tab.ws.OnError = nil
+			oldWS := tab.ws
+			go func() { _ = oldWS.Close() }()
+		}
 		oldEmu := tab.emulator
-		go func() {
-			_ = oldWS.Close()
-			_ = oldEmu.Close()
-		}()
+		go func() { _ = oldEmu.Close() }()
 	}
 	t.tabs = nil
 	t.activeTab = 0
@@ -248,44 +286,236 @@ func (t *TerminalPage) ConnectSession(sess api.Session) {
 	t.connectSessionWith(sess, t.serverURL, token)
 }
 
-// connectSessionWith creates a new terminal tab with the given server and token.
+// ConnectCliSession creates a new terminal tab connected to a persistent CLI session.
+// It derives the WebSocket URL from the Volundr session's chat or code endpoint
+// and connects to /terminal/ws/{terminalId} on the session pod via devrunner.
+func (t *TerminalPage) ConnectCliSession(sess api.Session, sessionName string) {
+	// Close existing tabs to prevent goroutine leaks.
+	for _, tab := range t.tabs {
+		if tab.ws != nil {
+			tab.ws.OnData = nil
+			tab.ws.OnStateChange = nil
+			tab.ws.OnError = nil
+			oldWS := tab.ws
+			go func() { _ = oldWS.Close() }()
+		}
+		oldEmu := tab.emulator
+		go func() { _ = oldEmu.Close() }()
+	}
+	t.tabs = nil
+	t.activeTab = 0
+
+	token := ""
+	if t.client != nil {
+		token = t.client.Token()
+	}
+
+	t.connectCliSessionWith(sess, t.serverURL, token, sessionName)
+}
+
+// ConnectCliSessionOnCluster creates a terminal tab for a CLI session using
+// the specified cluster's server and token.
+func (t *TerminalPage) ConnectCliSessionOnCluster(sess api.Session, contextKey, sessionName string) {
+	if t.pool == nil {
+		t.ConnectCliSession(sess, sessionName)
+		return
+	}
+
+	entry := t.pool.GetEntry(contextKey)
+	if entry == nil {
+		t.ConnectCliSession(sess, sessionName)
+		return
+	}
+
+	t.connectCliSessionWith(sess, entry.Server, entry.Client.Token(), sessionName)
+}
+
+// connectCliSessionWith creates a terminal tab connected to a CLI session WebSocket.
+func (t *TerminalPage) connectCliSessionWith(sess api.Session, serverURL, token, sessionName string) {
+	t.activeSession = &sess
+	t.activeToken = token
+
+	label := fmt.Sprintf("cli:%s", sessionName)
+	wsURL := api.CliSessionWSURL(sess.CodeEndpoint, sessionName)
+	t.createTab(sess.ID, label, sessionName, wsURL)
+	t.activeTab = len(t.tabs) - 1
+	t.connectTab(t.activeTab)
+}
+
+// connectSessionWith discovers existing terminal sessions (or spawns one) and
+// sends a message back to the Update loop to create tabs synchronously.
 func (t *TerminalPage) connectSessionWith(sess api.Session, serverURL, token string) {
+	// Store session context so ctrl+t can spawn additional tabs.
+	t.activeSession = &sess
+	t.activeToken = token
+
+	connCh := t.connCh
+
+	// Discover sessions in the background; Update will create the tabs.
+	go func() {
+		podClient := api.NewSessionPodClient(sess.CodeEndpoint, token)
+
+		var sessions []api.CliSession
+
+		// Try listing existing sessions first.
+		if list, err := podClient.ListCliSessions(); err == nil && len(list.Sessions) > 0 {
+			sessions = list.Sessions
+		} else {
+			// No existing sessions — spawn a fresh shell.
+			req := api.CreateCliSessionRequest{CliType: "shell"}
+			if created, err := podClient.CreateCliSession(req); err == nil {
+				sessions = []api.CliSession{*created}
+			}
+		}
+
+		if len(sessions) == 0 {
+			select {
+			case connCh <- TerminalDisconnectedMsg{TabIndex: 0, Err: fmt.Errorf("failed to resolve terminal sessions")}:
+			default:
+			}
+			return
+		}
+
+		select {
+		case connCh <- TerminalSessionsLoadedMsg{Sessions: sessions}:
+		default:
+		}
+	}()
+}
+
+// handleSessionsLoaded creates tabs for all discovered sessions.
+// Only the first tab's WebSocket is connected (server multiplexes all
+// connections to the active tmux window, so only one can be connected).
+// Called from Update so tab creation is synchronous with Bubble Tea.
+func (t *TerminalPage) handleSessionsLoaded(sessions []api.CliSession) {
+	if t.activeSession == nil || len(sessions) == 0 {
+		return
+	}
+
+	// Clear any stale tabs from a previous session.
+	for _, tab := range t.tabs {
+		if tab.ws != nil {
+			tab.ws.OnData = nil
+			tab.ws.OnStateChange = nil
+			tab.ws.OnError = nil
+			oldWS := tab.ws
+			go func() { _ = oldWS.Close() }()
+		}
+		_ = tab.emulator.Close()
+	}
+	t.tabs = nil
+	t.activeTab = 0
+
+	for _, s := range sessions {
+		label := s.Label
+		if label == "" {
+			label = s.TerminalID
+		}
+		wsURL := api.CliSessionWSURL(t.activeSession.CodeEndpoint, s.TerminalID)
+		t.createTab(t.activeSession.ID, label, s.TerminalID, wsURL)
+	}
+
+	// Connect only the first tab.
+	if len(t.tabs) > 0 {
+		t.connectTab(0)
+	}
+}
+
+// handleSpawned creates a tab for a newly spawned session and switches to it.
+// Called from Update so tab creation is synchronous with Bubble Tea.
+func (t *TerminalPage) handleSpawned(s api.CliSession) {
+	if t.activeSession == nil {
+		return
+	}
+
+	label := s.Label
+	if label == "" {
+		label = s.TerminalID
+	}
+	wsURL := api.CliSessionWSURL(t.activeSession.CodeEndpoint, s.TerminalID)
+	t.createTab(t.activeSession.ID, label, s.TerminalID, wsURL)
+	t.activeTab = len(t.tabs) - 1
+	t.connectTab(t.activeTab)
+}
+
+// createTab creates a terminal tab with an emulator but does NOT connect
+// the WebSocket. Call connectTab to start the WebSocket connection.
+// Must be called from the Update loop.
+func (t *TerminalPage) createTab(sessionID, label, terminalID, wsURL string) {
 	w, h := t.termDimensions()
 
 	tab := &terminalTab{
-		label:     fmt.Sprintf("term-%d", len(t.tabs)+1),
-		sessionID: sess.ID,
-		emulator:  vt.NewEmulator(w, h),
-		ws:        api.NewTerminalWSClient(serverURL, token),
-		connState: connStatusConnecting,
+		label:      label,
+		terminalID: terminalID,
+		sessionID:  sessionID,
+		wsURL:      wsURL,
+		emulator:   vt.NewEmulator(w, h),
+		connState:  connStatusDisconnected,
 	}
 
-	tabIndex := len(t.tabs)
 	t.tabs = append(t.tabs, tab)
-	t.activeTab = tabIndex
 
+	// Drain emulator responses to prevent pipe deadlock.
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			n, err := tab.emulator.Read(buf)
+			if err != nil {
+				return
+			}
+			// Forward terminal query responses back via WebSocket.
+			if n > 0 && tab.ws != nil && tab.ws.State() == api.WSConnected {
+				_ = tab.ws.SendRaw(buf[:n])
+			}
+		}
+	}()
+}
+
+// connectTab connects the WebSocket for the tab at the given index.
+// Any previously connected tab's WebSocket is disconnected first,
+// matching the web UI's single-connection-at-a-time approach
+// (the server multiplexes all connections to the active tmux window).
+func (t *TerminalPage) connectTab(index int) {
+	if index < 0 || index >= len(t.tabs) {
+		return
+	}
+
+	// Disconnect all other tabs' WebSockets.
+	for i, tab := range t.tabs {
+		if i == index {
+			continue
+		}
+		if tab.ws != nil && tab.ws.State() != api.WSDisconnected {
+			tab.ws.OnData = nil
+			tab.ws.OnStateChange = nil
+			tab.ws.OnError = nil
+			oldWS := tab.ws
+			tab.ws = nil
+			go func() { _ = oldWS.Close() }()
+			tab.mu.Lock()
+			tab.connState = connStatusDisconnected
+			tab.mu.Unlock()
+		}
+	}
+
+	tab := t.tabs[index]
 	outputCh := t.outputCh
 	connCh := t.connCh
+	wsURL := tab.wsURL
+	w, h := t.termDimensions()
 
-	// Derive terminal WS URL from chat endpoint (matches web UI pattern).
-	// Fallback to control-plane proxy if no endpoint is available.
-	var wsURL string
-	if sess.ChatEndpoint != "" {
-		wsURL = api.TerminalWSURLFromChat(sess.ChatEndpoint)
-	} else if sess.CodeEndpoint != "" {
-		wsURL = api.SessionWSURL(sess.CodeEndpoint, "/terminal/ws")
-	} else {
-		wsURL = fmt.Sprintf("/api/v1/volundr/sessions/%s/terminal", sess.ID)
-	}
+	// Create a fresh WebSocket client for this tab.
+	tab.ws = api.NewTerminalWSClient(t.serverURL, t.activeToken)
+	tab.mu.Lock()
+	tab.connState = connStatusConnecting
+	tab.mu.Unlock()
 
-	// Wire up WebSocket callbacks BEFORE Connect() so the readLoop goroutine
-	// (started inside Connect) can immediately deliver data and state changes.
 	tab.ws.OnData = func(data []byte) {
 		tab.mu.Lock()
 		_, _ = tab.emulator.Write(data)
 		tab.mu.Unlock()
 		select {
-		case outputCh <- TerminalOutputMsg{TabIndex: tabIndex}:
+		case outputCh <- TerminalOutputMsg{TabIndex: index}:
 		default:
 		}
 	}
@@ -294,12 +524,12 @@ func (t *TerminalPage) connectSessionWith(sess api.Session, serverURL, token str
 		switch state {
 		case api.WSConnected:
 			select {
-			case connCh <- TerminalConnectedMsg{TabIndex: tabIndex}:
+			case connCh <- TerminalConnectedMsg{TabIndex: index}:
 			default:
 			}
 		case api.WSDisconnected:
 			select {
-			case connCh <- TerminalDisconnectedMsg{TabIndex: tabIndex}:
+			case connCh <- TerminalDisconnectedMsg{TabIndex: index}:
 			default:
 			}
 		}
@@ -307,30 +537,12 @@ func (t *TerminalPage) connectSessionWith(sess api.Session, serverURL, token str
 
 	tab.ws.OnError = func(err error) {
 		select {
-		case connCh <- TerminalDisconnectedMsg{TabIndex: tabIndex, Err: err}:
+		case connCh <- TerminalDisconnectedMsg{TabIndex: index, Err: err}:
 		default:
 		}
 	}
 
-	// Read terminal responses from the vt emulator and send them back to the
-	// remote PTY. The emulator writes responses (CPR, color queries, device
-	// attributes, etc.) to its internal pipe when the remote application sends
-	// terminal queries. Without this reader the pipe blocks, deadlocking
-	// emulator.Write() and freezing the WebSocket reader goroutine.
-	go func() {
-		buf := make([]byte, 4096)
-		for {
-			n, err := tab.emulator.Read(buf)
-			if err != nil {
-				return // emulator closed
-			}
-			if n > 0 && tab.ws != nil {
-				_ = tab.ws.SendRaw(buf[:n])
-			}
-		}
-	}()
-
-	// Connect in the background with retries.
+	// Connect in the background.
 	go func() {
 		var err error
 		for attempt := 0; attempt < 5; attempt++ {
@@ -344,20 +556,64 @@ func (t *TerminalPage) connectSessionWith(sess api.Session, serverURL, token str
 			}
 		}
 		select {
-		case connCh <- TerminalDisconnectedMsg{TabIndex: tabIndex, Err: err}:
+		case connCh <- TerminalDisconnectedMsg{TabIndex: index, Err: err}:
 		default:
 		}
 	}()
 }
 
-// closeTab closes and removes the tab at the given index.
+// spawnNewTab spawns a new shell terminal tab via the REST API.
+func (t *TerminalPage) spawnNewTab() {
+	if t.activeSession == nil {
+		return
+	}
+	sess := *t.activeSession
+	token := t.activeToken
+	connCh := t.connCh
+
+	// Spawn in the background; Update will create the tab when the message arrives.
+	go func() {
+		podClient := api.NewSessionPodClient(sess.CodeEndpoint, token)
+		req := api.CreateCliSessionRequest{CliType: "shell"}
+		created, err := podClient.CreateCliSession(req)
+		if err != nil {
+			select {
+			case connCh <- TerminalDisconnectedMsg{TabIndex: 0, Err: fmt.Errorf("spawn failed: %w", err)}:
+			default:
+			}
+			return
+		}
+
+		select {
+		case connCh <- TerminalSpawnedMsg{Session: *created}:
+		default:
+		}
+	}()
+}
+
+// closeTab closes and removes the tab at the given index,
+// killing the server-side tmux session.
 func (t *TerminalPage) closeTab(index int) {
 	if index < 0 || index >= len(t.tabs) {
 		return
 	}
 
 	tab := t.tabs[index]
-	_ = tab.ws.Close()
+
+	// Kill server-side session in the background.
+	if tab.terminalID != "" && t.activeSession != nil {
+		sess := *t.activeSession
+		token := t.activeToken
+		termID := tab.terminalID
+		go func() {
+			podClient := api.NewSessionPodClient(sess.CodeEndpoint, token)
+			_ = podClient.KillCliSession(termID)
+		}()
+	}
+
+	if tab.ws != nil {
+		_ = tab.ws.Close()
+	}
 	_ = tab.emulator.Close()
 
 	t.tabs = append(t.tabs[:index], t.tabs[index+1:]...)
@@ -365,39 +621,50 @@ func (t *TerminalPage) closeTab(index int) {
 	if t.activeTab >= len(t.tabs) && t.activeTab > 0 {
 		t.activeTab = len(t.tabs) - 1
 	}
+
+	// Connect the new active tab if we closed the one that was connected.
+	if len(t.tabs) > 0 {
+		t.connectTab(t.activeTab)
+	}
 }
 
 // Close cleans up all terminal connections.
 func (t *TerminalPage) Close() {
 	for _, tab := range t.tabs {
-		_ = tab.ws.Close()
+		if tab.ws != nil {
+			_ = tab.ws.Close()
+		}
 		_ = tab.emulator.Close()
 	}
 	t.tabs = nil
 }
 
-// SetSize updates the page dimensions and resizes the active emulator.
+// SetSize updates the page dimensions and resizes all emulators.
 func (t *TerminalPage) SetSize(w, h int) {
 	t.width = w
 	t.height = h
-	t.resizeActiveEmulator()
+	t.resizeAllEmulators()
 }
 
-// resizeActiveEmulator updates the vt emulator size and sends a resize message.
-func (t *TerminalPage) resizeActiveEmulator() {
+// resizeAllEmulators updates all vt emulator sizes and notifies the
+// active tab's WebSocket so tmux redraws at the new size.
+func (t *TerminalPage) resizeAllEmulators() {
 	if len(t.tabs) == 0 {
 		return
 	}
 
 	w, h := t.termDimensions()
-	tab := t.tabs[t.activeTab]
 
-	tab.mu.Lock()
-	tab.emulator.Resize(w, h)
-	tab.mu.Unlock()
+	for _, tab := range t.tabs {
+		tab.mu.Lock()
+		tab.emulator.Resize(w, h)
+		tab.mu.Unlock()
+	}
 
-	if tab.connState == connStatusConnected {
-		_ = tab.ws.SendResize(w, h)
+	// Only the active tab has a WebSocket connection.
+	activeTab := t.tabs[t.activeTab]
+	if activeTab.ws != nil && activeTab.ws.State() == api.WSConnected {
+		_ = activeTab.ws.SendResize(w, h)
 	}
 }
 
@@ -444,9 +711,6 @@ func (t TerminalPage) View() string {
 	// Tab bar
 	tabBar := t.renderTabBar()
 
-	// Connection status line
-	statusLine := t.renderStatusLine(tab)
-
 	// Terminal content from vt emulator
 	tab.mu.Lock()
 	content := tab.emulator.Render()
@@ -459,7 +723,7 @@ func (t TerminalPage) View() string {
 
 	helpText := lipgloss.NewStyle().
 		Foreground(theme.TextMuted).
-		Render("  ctrl+t: new tab  ctrl+w: close  ctrl+]/\\: switch tabs  ctrl+f: fullscreen")
+		Render("  ctrl+t: new tab  ctrl+w: close  ctrl+n/p: switch tabs  ctrl+f: fullscreen")
 
 	return lipgloss.NewStyle().
 		Width(t.width).
@@ -467,7 +731,6 @@ func (t TerminalPage) View() string {
 		Padding(0, 1).
 		Render(lipgloss.JoinVertical(lipgloss.Left,
 			tabBar,
-			statusLine,
 			termStyle.Render(content),
 			helpText,
 		))
@@ -481,13 +744,22 @@ func (t TerminalPage) renderEmptyState() string {
 		Foreground(theme.TextPrimary).
 		Bold(true)
 
+	var statusText, instructionText string
+	if t.activeSession != nil {
+		statusText = "  Loading terminal sessions…"
+		instructionText = "  Connecting to session pod"
+	} else {
+		statusText = "  Select a running session to open a terminal"
+		instructionText = "  Press 1 to go to Sessions, select a session, then open terminal"
+	}
+
 	statusLine := lipgloss.NewStyle().
 		Foreground(theme.AccentAmber).
-		Render("  Select a running session to open a terminal")
+		Render(statusText)
 
 	instructions := lipgloss.NewStyle().
 		Foreground(theme.TextMuted).
-		Render("  Press 1 to go to Sessions, select a session, then open terminal")
+		Render(instructionText)
 
 	return lipgloss.NewStyle().
 		Width(t.width).
@@ -508,16 +780,11 @@ func (t TerminalPage) renderFullScreen(tab *terminalTab) string {
 	content := tab.emulator.Render()
 	tab.mu.Unlock()
 
-	statusLine := t.renderStatusLine(tab)
-
 	termStyle := lipgloss.NewStyle().
 		Width(t.width).
-		Height(t.height - 1)
+		Height(t.height)
 
-	return lipgloss.JoinVertical(lipgloss.Left,
-		termStyle.Render(content),
-		statusLine,
-	)
+	return termStyle.Render(content)
 }
 
 // renderTabBar renders the tab strip at the top of the terminal.
@@ -526,10 +793,9 @@ func (t TerminalPage) renderTabBar() string {
 	var tabs []string
 
 	for i, tab := range t.tabs {
+		tab.mu.Lock()
 		label := tab.label
-		if tab.sessionID != "" && len(tab.sessionID) > 8 {
-			label = tab.sessionID[:8]
-		}
+		tab.mu.Unlock()
 
 		var style lipgloss.Style
 		if i == t.activeTab {
@@ -565,51 +831,17 @@ func (t TerminalPage) renderTabBar() string {
 	return "  " + strings.Join(tabs, "  │  ")
 }
 
-// renderStatusLine renders the connection status at the bottom.
-func (t TerminalPage) renderStatusLine(tab *terminalTab) string {
-	theme := tui.DefaultTheme
-
-	tab.mu.Lock()
-	state := tab.connState
-	connErr := tab.connErr
-	sessionID := tab.sessionID
-	tab.mu.Unlock()
-
-	var status string
-	switch state {
-	case connStatusConnected:
-		status = lipgloss.NewStyle().
-			Foreground(theme.AccentEmerald).
-			Render("● Connected")
-	case connStatusConnecting:
-		status = lipgloss.NewStyle().
-			Foreground(theme.AccentAmber).
-			Render("◌ Connecting...")
-	default:
-		errMsg := "Disconnected"
-		if connErr != nil {
-			errMsg = fmt.Sprintf("Disconnected: %v", connErr)
-		}
-		status = lipgloss.NewStyle().
-			Foreground(theme.AccentRed).
-			Render("○ " + errMsg)
-	}
-
-	sessionInfo := lipgloss.NewStyle().
-		Foreground(theme.TextMuted).
-		Render(fmt.Sprintf("session: %s", sessionID))
-
-	w, h := t.termDimensions()
-	dims := lipgloss.NewStyle().
-		Foreground(theme.TextMuted).
-		Render(fmt.Sprintf("%dx%d", w, h))
-
-	return fmt.Sprintf("  %s  %s  %s", status, sessionInfo, dims)
-}
 
 // keyToBytes converts a bubbletea KeyMsg to raw bytes for the PTY.
 func keyToBytes(msg tea.KeyMsg) []byte {
-	key := msg.String()
+	// Use Keystroke() for matching — String() may return raw control chars
+	// that don't match our "ctrl+n" style case labels.
+	key := msg.Key().Keystroke()
+
+	// If the key has printable text and no modifier, return it directly.
+	if text := msg.Key().Text; len(text) > 0 && msg.Key().Mod == 0 {
+		return []byte(text)
+	}
 
 	// Map special keys to their ANSI escape sequences.
 	switch key {

--- a/containers/devrunner/Dockerfile
+++ b/containers/devrunner/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     lsb-release \
     inotify-tools \
     git \
+    tmux \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Node.js 20 LTS

--- a/containers/devrunner/devrunner.py
+++ b/containers/devrunner/devrunner.py
@@ -133,7 +133,9 @@ class Devrunner:
         if not self.pg_data_dir.exists():
             logger.info("Initializing PostgreSQL database cluster")
             proc = await asyncio.create_subprocess_exec(
-                str(pg_bin / "initdb"), "-D", str(self.pg_data_dir),
+                str(pg_bin / "initdb"),
+                "-D",
+                str(self.pg_data_dir),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
             )
@@ -165,7 +167,9 @@ class Devrunner:
         logger.info("Starting PostgreSQL")
         with open(log_file, "a") as lf:
             self._postgres = await asyncio.create_subprocess_exec(
-                str(pg_bin / "postgres"), "-D", str(self.pg_data_dir),
+                str(pg_bin / "postgres"),
+                "-D",
+                str(self.pg_data_dir),
                 stdout=lf,
                 stderr=asyncio.subprocess.STDOUT,
             )
@@ -245,13 +249,16 @@ class Devrunner:
         )
         self._services[name] = state
 
-        self._write_status(name, {
-            "status": "running",
-            "pid": proc.pid,
-            "port": spec.port,
-            "command": spec.command,
-            "started_at": state.started_at,
-        })
+        self._write_status(
+            name,
+            {
+                "status": "running",
+                "pid": proc.pid,
+                "port": spec.port,
+                "command": spec.command,
+                "started_at": state.started_at,
+            },
+        )
 
         logger.info(f"Service {name} started with PID {proc.pid}")
 
@@ -304,10 +311,7 @@ class Devrunner:
         for name in desired_names & running_names:
             svc_config = desired_services[name]
             state = self._services[name]
-            if (
-                state.spec.command != svc_config["command"]
-                or state.spec.port != svc_config["port"]
-            ):
+            if state.spec.command != svc_config["command"] or state.spec.port != svc_config["port"]:
                 logger.info(f"Service {name} config changed, restarting")
                 await self._stop_service(name)
                 spec = ServiceSpec(
@@ -341,21 +345,27 @@ class Devrunner:
                 logger.warning(f"Service {name} exited with code {exit_code}")
 
                 if state.spec.restart_policy == "never":
-                    self._write_status(name, {
-                        "status": "exited",
-                        "exit_code": exit_code,
-                    })
+                    self._write_status(
+                        name,
+                        {
+                            "status": "exited",
+                            "exit_code": exit_code,
+                        },
+                    )
                     continue
 
                 if state.restart_count >= state.spec.max_restarts:
                     logger.error(
                         f"Service {name} exceeded max restarts ({state.spec.max_restarts})"
                     )
-                    self._write_status(name, {
-                        "status": "failed",
-                        "exit_code": exit_code,
-                        "restart_count": state.restart_count,
-                    })
+                    self._write_status(
+                        name,
+                        {
+                            "status": "failed",
+                            "exit_code": exit_code,
+                            "restart_count": state.restart_count,
+                        },
+                    )
                     continue
 
                 # Restart the service
@@ -376,8 +386,11 @@ class Devrunner:
         while not self._shutting_down:
             try:
                 proc = await asyncio.create_subprocess_exec(
-                    "inotifywait", "-e", "modify,create,delete",
-                    "-q", str(self.config_path),
+                    "inotifywait",
+                    "-e",
+                    "modify,create,delete",
+                    "-q",
+                    str(self.config_path),
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )
@@ -436,7 +449,7 @@ class Devrunner:
             lines.append(f"    proxy_pass http://127.0.0.1:{port}/;")
             lines.append("    proxy_http_version 1.1;")
             lines.append("    proxy_set_header Upgrade $http_upgrade;")
-            lines.append("    proxy_set_header Connection \"upgrade\";")
+            lines.append('    proxy_set_header Connection "upgrade";')
             lines.append("    proxy_set_header Host $host;")
             lines.append("    proxy_set_header X-Real-IP $remote_addr;")
             lines.append("    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;")
@@ -484,10 +497,12 @@ async def main() -> None:
     """Entry point."""
     session_id = os.environ.get("SESSION_ID", "unknown")
     mount_path = os.environ.get("PERSISTENCE_MOUNT_PATH", "/volundr/sessions")
-    workspace_dir = Path(os.environ.get(
-        "WORKSPACE_DIR",
-        f"{mount_path}/{session_id}/workspace",
-    ))
+    workspace_dir = Path(
+        os.environ.get(
+            "WORKSPACE_DIR",
+            f"{mount_path}/{session_id}/workspace",
+        )
+    )
     services_dir = workspace_dir / ".services"
 
     logger.info(f"Devrunner starting for session {session_id}")

--- a/containers/devrunner/restricted-shell
+++ b/containers/devrunner/restricted-shell
@@ -65,7 +65,7 @@ def main() -> None:
     except (FileNotFoundError, PermissionError):
         pass
 
-    hostname = os.environ.get("SESSION_ID", "devrunner")
+    hostname = os.environ.get("SESSION_NAME", os.environ.get("SESSION_ID", "devrunner"))
     print(f"Restricted shell - {len(allowed)} commands available")
     print("Type 'help' for available commands\n")
 

--- a/containers/devrunner/terminal.py
+++ b/containers/devrunner/terminal.py
@@ -19,7 +19,6 @@ import signal
 import struct
 import subprocess
 import termios
-import uuid
 
 from aiohttp import web
 
@@ -156,10 +155,16 @@ class TerminalServer:
 
         # Create detached session with placeholder window
         _tmux_run(
-            "new-session", "-d",
-            "-s", TMUX_SERVER_NAME,
-            "-n", "__init__",
-            "-x", "200", "-y", "50",
+            "new-session",
+            "-d",
+            "-s",
+            TMUX_SERVER_NAME,
+            "-n",
+            "__init__",
+            "-x",
+            "200",
+            "-y",
+            "50",
         )
         self._apply_headless_config()
         self._tmux_ready = True
@@ -178,9 +183,7 @@ class TerminalServer:
 
     def _reload_sessions(self) -> None:
         """Reload session metadata from a running tmux server."""
-        result = _tmux_run(
-            "list-windows", "-t", TMUX_SERVER_NAME, "-F", "#{window_name}"
-        )
+        result = _tmux_run("list-windows", "-t", TMUX_SERVER_NAME, "-F", "#{window_name}")
         if result.returncode != 0:
             return
 
@@ -224,8 +227,10 @@ class TerminalServer:
         # Use terminal_id as the tmux window name for easy lookup
         _tmux_run(
             "new-window",
-            "-t", TMUX_SERVER_NAME,
-            "-n", terminal_id,
+            "-t",
+            TMUX_SERVER_NAME,
+            "-n",
+            terminal_id,
             full_cmd,
         )
 
@@ -255,7 +260,8 @@ class TerminalServer:
                 tmux,
                 _tmux_cmd(
                     "attach-session",
-                    "-t", f"{TMUX_SERVER_NAME}:{window_name}",
+                    "-t",
+                    f"{TMUX_SERVER_NAME}:{window_name}",
                 ),
                 env,
             )
@@ -327,12 +333,14 @@ class TerminalServer:
             terminal_id, label=label, cli_type=cli_type, command=command
         )
 
-        return web.json_response({
-            "terminalId": session.terminal_id,
-            "label": session.label,
-            "cli_type": session.cli_type,
-            "persistent": True,
-        })
+        return web.json_response(
+            {
+                "terminalId": session.terminal_id,
+                "label": session.label,
+                "cli_type": session.cli_type,
+                "persistent": True,
+            }
+        )
 
     async def _handle_kill(self, request: web.Request) -> web.Response:
         """Kill a terminal session by ID."""
@@ -358,16 +366,20 @@ class TerminalServer:
         sessions = []
         for s in self._sessions.values():
             alive = self._window_alive(s.window_name)
-            sessions.append({
-                "terminalId": s.terminal_id,
-                "label": s.label,
-                "cli_type": s.cli_type,
-                "status": "running" if alive else "exited",
-            })
-        return web.json_response({
-            "sessions": sessions,
-            "tmux": self._tmux_ready,
-        })
+            sessions.append(
+                {
+                    "terminalId": s.terminal_id,
+                    "label": s.label,
+                    "cli_type": s.cli_type,
+                    "status": "running" if alive else "exited",
+                }
+            )
+        return web.json_response(
+            {
+                "sessions": sessions,
+                "tmux": self._tmux_ready,
+            }
+        )
 
     # --- WebSocket Handler ---
 
@@ -381,19 +393,21 @@ class TerminalServer:
         if not terminal_id:
             self._session_counter += 1
             terminal_id = f"term-{self._session_counter}"
-            self._create_tmux_window(
-                terminal_id, label=terminal_id, cli_type="shell"
-            )
+            self._create_tmux_window(terminal_id, label=terminal_id, cli_type="shell")
 
         session = self._sessions.get(terminal_id)
         if not session:
             # Maybe the session exists in tmux but we don't have metadata
             # (e.g. after restart). Try to attach anyway.
             if not self._window_alive(terminal_id):
-                await ws.send_str(json.dumps({
-                    "type": "error",
-                    "data": f"Terminal session {terminal_id} not found",
-                }))
+                await ws.send_str(
+                    json.dumps(
+                        {
+                            "type": "error",
+                            "data": f"Terminal session {terminal_id} not found",
+                        }
+                    )
+                )
                 await ws.close()
                 return ws
             # Re-register it
@@ -467,10 +481,12 @@ class TerminalServer:
                     await ws.send_str(json.dumps({"type": "exit", "data": ""}))
                     break
                 await ws.send_str(
-                    json.dumps({
-                        "type": "output",
-                        "data": data.decode("utf-8", errors="replace"),
-                    })
+                    json.dumps(
+                        {
+                            "type": "output",
+                            "data": data.decode("utf-8", errors="replace"),
+                        }
+                    )
                 )
         except (OSError, ConnectionResetError):
             pass

--- a/containers/devrunner/terminal.py
+++ b/containers/devrunner/terminal.py
@@ -1,4 +1,12 @@
-"""WebSocket terminal server - spawns PTY shells per connection with multi-tab support."""
+"""WebSocket terminal server - tmux-backed persistent PTY sessions.
+
+Every terminal tab is a tmux window inside a single headless tmux server.
+Sessions survive WebSocket disconnects — reconnecting reattaches to the
+same tmux window with full scrollback preserved.
+
+Also supports launching specific CLI tools (claude, codex, aider, shell)
+via the REST API.
+"""
 
 import asyncio
 import fcntl
@@ -6,8 +14,10 @@ import json
 import logging
 import os
 import pty
+import shutil
 import signal
 import struct
+import subprocess
 import termios
 import uuid
 
@@ -22,6 +32,18 @@ PTY_READ_BUFFER_SIZE = 4096
 DEFAULT_ROWS = 24
 DEFAULT_COLS = 80
 
+TMUX_SERVER_NAME = "volundr"
+TMUX_SOCKET_DIR = "/tmp/volundr-tmux"
+TMUX_SCROLLBACK = 50000
+
+# CLI tool -> command mapping
+CLI_COMMANDS: dict[str, str] = {
+    "claude": "claude",
+    "codex": "codex",
+    "aider": "aider",
+    "shell": "/bin/bash",
+}
+
 
 def _set_pty_size(fd: int, rows: int, cols: int) -> None:
     """Set the terminal size on a PTY file descriptor."""
@@ -29,27 +51,53 @@ def _set_pty_size(fd: int, rows: int, cols: int) -> None:
     fcntl.ioctl(fd, termios.TIOCSWINSZ, winsize)
 
 
-class _PtySession:
-    """State for a single PTY session."""
+def _tmux_bin() -> str:
+    return shutil.which("tmux") or "tmux"
 
-    __slots__ = ("terminal_id", "master_fd", "child_pid", "restricted")
+
+def _tmux_cmd(*args: str) -> list[str]:
+    return [_tmux_bin(), "-S", f"{TMUX_SOCKET_DIR}/default", *args]
+
+
+def _tmux_run(*args: str) -> subprocess.CompletedProcess[str]:
+    """Run a tmux command synchronously, return CompletedProcess."""
+    return subprocess.run(
+        _tmux_cmd(*args),
+        capture_output=True,
+        text=True,
+    )
+
+
+class _TmuxSession:
+    """Metadata for a single tmux-backed terminal session."""
+
+    __slots__ = ("terminal_id", "label", "cli_type", "window_name")
 
     def __init__(
         self,
         terminal_id: str,
-        master_fd: int,
-        child_pid: int,
-        *,
-        restricted: bool,
+        label: str,
+        cli_type: str,
+        window_name: str,
     ) -> None:
         self.terminal_id = terminal_id
+        self.label = label
+        self.cli_type = cli_type
+        self.window_name = window_name
+
+
+class _AttachHandle:
+    """State for a single WebSocket-to-tmux-attach bridge."""
+
+    __slots__ = ("master_fd", "child_pid")
+
+    def __init__(self, master_fd: int, child_pid: int) -> None:
         self.master_fd = master_fd
         self.child_pid = child_pid
-        self.restricted = restricted
 
 
 class TerminalServer:
-    """WebSocket-to-PTY server with multi-tab and restricted/unrestricted mode."""
+    """WebSocket-to-tmux server with persistent multi-tab sessions."""
 
     def __init__(
         self,
@@ -61,7 +109,9 @@ class TerminalServer:
         self.shell_path = shell_path
         self.workspace_dir = workspace_dir
         self._restricted = os.environ.get("TERMINAL_RESTRICTED", "false").lower() != "false"
-        self._sessions: dict[str, _PtySession] = {}
+        self._sessions: dict[str, _TmuxSession] = {}
+        self._session_counter = 0
+        self._tmux_ready = False
         self._app = web.Application()
         self._app.router.add_get("/ws", self._handle_ws)
         self._app.router.add_get("/ws/{terminal_id}", self._handle_ws)
@@ -70,10 +120,12 @@ class TerminalServer:
         self._app.router.add_post("/api/terminal/kill", self._handle_kill)
         self._app.router.add_post("/api/terminal/mode", self._handle_mode)
         self._app.router.add_get("/api/terminal/mode", self._handle_get_mode)
+        self._app.router.add_get("/api/terminal/sessions", self._handle_list_sessions)
         self._runner: web.AppRunner | None = None
 
     async def start(self) -> None:
-        """Start the terminal WebSocket server."""
+        """Start the terminal WebSocket server and tmux."""
+        self._ensure_tmux_server()
         self._runner = web.AppRunner(self._app)
         await self._runner.setup()
         site = web.TCPSite(self._runner, "127.0.0.1", self.port)
@@ -81,40 +133,213 @@ class TerminalServer:
         logger.info(f"Terminal server listening on 127.0.0.1:{self.port}")
 
     async def stop(self) -> None:
-        """Stop the terminal server and clean up all sessions."""
-        for session in list(self._sessions.values()):
-            self._cleanup_session(session)
+        """Stop the terminal server. tmux sessions are left alive for reconnect."""
         self._sessions.clear()
         if self._runner:
             await self._runner.cleanup()
 
+    # --- tmux Management ---
+
+    def _ensure_tmux_server(self) -> None:
+        """Start the headless tmux server if not running."""
+        if self._tmux_ready:
+            return
+
+        os.makedirs(TMUX_SOCKET_DIR, exist_ok=True)
+
+        result = _tmux_run("has-session", "-t", TMUX_SERVER_NAME)
+        if result.returncode == 0:
+            logger.info("tmux server '%s' already running, reloading sessions", TMUX_SERVER_NAME)
+            self._reload_sessions()
+            self._tmux_ready = True
+            return
+
+        # Create detached session with placeholder window
+        _tmux_run(
+            "new-session", "-d",
+            "-s", TMUX_SERVER_NAME,
+            "-n", "__init__",
+            "-x", "200", "-y", "50",
+        )
+        self._apply_headless_config()
+        self._tmux_ready = True
+        logger.info("tmux server '%s' started (headless)", TMUX_SERVER_NAME)
+
+    def _apply_headless_config(self) -> None:
+        """Make tmux invisible — no status bar, no prefix key."""
+        for args in [
+            ("set-option", "-t", TMUX_SERVER_NAME, "-g", "status", "off"),
+            ("set-option", "-t", TMUX_SERVER_NAME, "-g", "prefix", "None"),
+            ("set-option", "-t", TMUX_SERVER_NAME, "-g", "history-limit", str(TMUX_SCROLLBACK)),
+            ("set-option", "-t", TMUX_SERVER_NAME, "-g", "mouse", "off"),
+            ("unbind-key", "-a"),
+        ]:
+            _tmux_run(*args)
+
+    def _reload_sessions(self) -> None:
+        """Reload session metadata from a running tmux server."""
+        result = _tmux_run(
+            "list-windows", "-t", TMUX_SERVER_NAME, "-F", "#{window_name}"
+        )
+        if result.returncode != 0:
+            return
+
+        for line in result.stdout.strip().split("\n"):
+            name = line.strip()
+            if not name or name == "__init__":
+                continue
+            if name not in self._sessions:
+                self._session_counter += 1
+                self._sessions[name] = _TmuxSession(
+                    terminal_id=name,
+                    label=name,
+                    cli_type="shell",
+                    window_name=name,
+                )
+        logger.info("Reloaded %d sessions from tmux", len(self._sessions))
+
+    def _create_tmux_window(
+        self,
+        terminal_id: str,
+        *,
+        label: str,
+        cli_type: str = "shell",
+        command: str | None = None,
+    ) -> _TmuxSession:
+        """Create a new tmux window and track it."""
+        self._ensure_tmux_server()
+
+        if command is None:
+            if self._restricted:
+                command = self.shell_path
+            else:
+                command = os.environ.get("SHELL", UNRESTRICTED_SHELL_PATH)
+
+        # Build the full command with workspace cd
+        if self.workspace_dir:
+            full_cmd = f"cd {self.workspace_dir} && {command}"
+        else:
+            full_cmd = command
+
+        # Use terminal_id as the tmux window name for easy lookup
+        _tmux_run(
+            "new-window",
+            "-t", TMUX_SERVER_NAME,
+            "-n", terminal_id,
+            full_cmd,
+        )
+
+        session = _TmuxSession(
+            terminal_id=terminal_id,
+            label=label,
+            cli_type=cli_type,
+            window_name=terminal_id,
+        )
+        self._sessions[terminal_id] = session
+        logger.info("Created tmux window: id=%s label=%s cli_type=%s", terminal_id, label, cli_type)
+        return session
+
+    def _attach_pty(self, window_name: str) -> _AttachHandle:
+        """Fork a PTY running ``tmux attach`` targeting a specific window.
+
+        Returns an AttachHandle with master_fd and child_pid. The caller
+        bridges the master fd to a WebSocket. When the WebSocket disconnects,
+        close the master fd and wait for the child — tmux keeps the window alive.
+        """
+        child_pid, master_fd = pty.fork()
+        if child_pid == 0:
+            env = os.environ.copy()
+            env["TERM"] = "xterm-256color"
+            tmux = _tmux_bin()
+            os.execve(
+                tmux,
+                _tmux_cmd(
+                    "attach-session",
+                    "-t", f"{TMUX_SERVER_NAME}:{window_name}",
+                ),
+                env,
+            )
+
+        # Make master non-blocking for asyncio
+        flags = fcntl.fcntl(master_fd, fcntl.F_GETFL)
+        fcntl.fcntl(master_fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+
+        return _AttachHandle(master_fd=master_fd, child_pid=child_pid)
+
+    @staticmethod
+    def _cleanup_attach(handle: _AttachHandle) -> None:
+        """Clean up an attach handle (close fd, reap child). tmux window stays alive."""
+        try:
+            os.close(handle.master_fd)
+        except OSError:
+            pass
+        try:
+            os.kill(handle.child_pid, signal.SIGTERM)
+            os.waitpid(handle.child_pid, 0)
+        except (ProcessLookupError, ChildProcessError, OSError):
+            pass
+
+    def _kill_session(self, terminal_id: str) -> bool:
+        """Kill a tmux window by terminal ID."""
+        session = self._sessions.pop(terminal_id, None)
+        if not session:
+            return False
+        _tmux_run("kill-window", "-t", f"{TMUX_SERVER_NAME}:{session.window_name}")
+        logger.info("Killed tmux window: id=%s", terminal_id)
+        return True
+
+    def _window_alive(self, window_name: str) -> bool:
+        """Check if a tmux window still exists."""
+        result = _tmux_run("has-session", "-t", f"{TMUX_SERVER_NAME}:{window_name}")
+        return result.returncode == 0
+
     # --- HTTP Handlers ---
 
     async def _handle_health(self, request: web.Request) -> web.Response:
-        return web.json_response({"status": "ok"})
+        return web.json_response({"status": "ok", "tmux": self._tmux_ready})
 
     async def _handle_spawn(self, request: web.Request) -> web.Response:
-        """Spawn a new PTY session and return its terminal ID."""
+        """Spawn a new persistent terminal session and return its ID."""
         body = await request.json() if request.can_read_body else {}
-        restricted = body.get("restricted", self._restricted)
-        terminal_id = str(uuid.uuid4())
-        session = self._create_pty_session(terminal_id, restricted=restricted)
-        self._sessions[terminal_id] = session
-        return web.json_response(
-            {
-                "terminalId": terminal_id,
-                "restricted": session.restricted,
-            }
+        cli_type = body.get("cli_type", "shell")
+        name = body.get("name")
+
+        # Resolve command for the CLI type
+        if cli_type in CLI_COMMANDS and cli_type != "shell":
+            command = CLI_COMMANDS[cli_type]
+        else:
+            cli_type = "shell"
+            command = None  # Will use default shell
+
+        self._session_counter += 1
+        terminal_id = name or f"{cli_type}-{self._session_counter}"
+        # Sanitise for tmux window name
+        terminal_id = "".join(c if c.isalnum() or c in "-_" else "-" for c in terminal_id)
+
+        # Check for duplicate
+        if terminal_id in self._sessions:
+            return web.json_response(
+                {"error": f"Session '{terminal_id}' already exists"}, status=409
+            )
+
+        label = body.get("label", terminal_id)
+        session = self._create_tmux_window(
+            terminal_id, label=label, cli_type=cli_type, command=command
         )
 
+        return web.json_response({
+            "terminalId": session.terminal_id,
+            "label": session.label,
+            "cli_type": session.cli_type,
+            "persistent": True,
+        })
+
     async def _handle_kill(self, request: web.Request) -> web.Response:
-        """Kill a PTY session by terminal ID."""
+        """Kill a terminal session by ID."""
         body = await request.json()
         terminal_id = body.get("terminalId", "")
-        session = self._sessions.pop(terminal_id, None)
-        if not session:
+        if not self._kill_session(terminal_id):
             return web.json_response({"error": "not found"}, status=404)
-        self._cleanup_session(session)
         return web.json_response({"ok": True})
 
     async def _handle_mode(self, request: web.Request) -> web.Response:
@@ -128,6 +353,22 @@ class TerminalServer:
         """Return current terminal restriction mode."""
         return web.json_response({"restricted": self._restricted})
 
+    async def _handle_list_sessions(self, request: web.Request) -> web.Response:
+        """List all persistent terminal sessions."""
+        sessions = []
+        for s in self._sessions.values():
+            alive = self._window_alive(s.window_name)
+            sessions.append({
+                "terminalId": s.terminal_id,
+                "label": s.label,
+                "cli_type": s.cli_type,
+                "status": "running" if alive else "exited",
+            })
+        return web.json_response({
+            "sessions": sessions,
+            "tmux": self._tmux_ready,
+        })
+
     # --- WebSocket Handler ---
 
     async def _handle_ws(self, request: web.Request) -> web.WebSocketResponse:
@@ -136,40 +377,42 @@ class TerminalServer:
 
         terminal_id = request.match_info.get("terminal_id")
 
-        # If no terminal_id in the path, create an ad-hoc session (backward compat)
+        # If no terminal_id, create a default shell session
         if not terminal_id:
-            terminal_id = str(uuid.uuid4())
-            session = self._create_pty_session(terminal_id, restricted=self._restricted)
-            self._sessions[terminal_id] = session
-            ad_hoc = True
-        else:
-            session = self._sessions.get(terminal_id)
-            ad_hoc = False
-
-        if not session:
-            await ws.send_str(
-                json.dumps(
-                    {
-                        "type": "error",
-                        "data": f"Terminal session {terminal_id} not found",
-                    }
-                )
+            self._session_counter += 1
+            terminal_id = f"term-{self._session_counter}"
+            self._create_tmux_window(
+                terminal_id, label=terminal_id, cli_type="shell"
             )
-            await ws.close()
-            return ws
 
-        logger.info(
-            "Terminal WebSocket opened: id=%s restricted=%s",
-            terminal_id,
-            session.restricted,
-        )
+        session = self._sessions.get(terminal_id)
+        if not session:
+            # Maybe the session exists in tmux but we don't have metadata
+            # (e.g. after restart). Try to attach anyway.
+            if not self._window_alive(terminal_id):
+                await ws.send_str(json.dumps({
+                    "type": "error",
+                    "data": f"Terminal session {terminal_id} not found",
+                }))
+                await ws.close()
+                return ws
+            # Re-register it
+            session = _TmuxSession(
+                terminal_id=terminal_id,
+                label=terminal_id,
+                cli_type="shell",
+                window_name=terminal_id,
+            )
+            self._sessions[terminal_id] = session
 
-        master_fd = session.master_fd
+        logger.info("Terminal WebSocket opened: id=%s cli_type=%s", terminal_id, session.cli_type)
+
+        handle = self._attach_pty(session.window_name)
         try:
-            _set_pty_size(master_fd, DEFAULT_ROWS, DEFAULT_COLS)
+            _set_pty_size(handle.master_fd, DEFAULT_ROWS, DEFAULT_COLS)
 
             loop = asyncio.get_running_loop()
-            read_task = asyncio.create_task(self._pty_to_ws(loop, master_fd, ws))
+            read_task = asyncio.create_task(self._pty_to_ws(loop, handle.master_fd, ws))
 
             async for msg in ws:
                 if msg.type == web.WSMsgType.TEXT:
@@ -177,14 +420,14 @@ class TerminalServer:
                     msg_type = data.get("type")
 
                     if msg_type == "input":
-                        os.write(master_fd, data["data"].encode())
+                        os.write(handle.master_fd, data["data"].encode())
                     elif msg_type == "resize":
                         cols = data.get("cols", DEFAULT_COLS)
                         rows = data.get("rows", DEFAULT_ROWS)
-                        _set_pty_size(master_fd, rows, cols)
+                        _set_pty_size(handle.master_fd, rows, cols)
 
                 elif msg.type == web.WSMsgType.BINARY:
-                    os.write(master_fd, msg.data)
+                    os.write(handle.master_fd, msg.data)
 
                 elif msg.type in (
                     web.WSMsgType.ERROR,
@@ -198,73 +441,15 @@ class TerminalServer:
         except Exception:
             logger.exception("Terminal session error: id=%s", terminal_id)
         finally:
-            # For ad-hoc sessions, clean up PTY when the WebSocket closes
-            if ad_hoc:
-                removed = self._sessions.pop(terminal_id, None)
-                if removed:
-                    self._cleanup_session(removed)
+            # Clean up the attach handle — tmux window stays alive
+            self._cleanup_attach(handle)
             if not ws.closed:
                 await ws.close()
-            logger.info("Terminal WebSocket closed: id=%s", terminal_id)
+            logger.info("Terminal WebSocket closed: id=%s (tmux window preserved)", terminal_id)
 
         return ws
 
-    # --- PTY Management ---
-
-    def _create_pty_session(
-        self,
-        terminal_id: str,
-        *,
-        restricted: bool,
-    ) -> _PtySession:
-        """Fork a PTY and return a session object."""
-        master_fd, child_pid = self._spawn_shell(restricted=restricted)
-
-        # Make master_fd non-blocking for asyncio
-        flags = fcntl.fcntl(master_fd, fcntl.F_GETFL)
-        fcntl.fcntl(master_fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
-
-        return _PtySession(
-            terminal_id=terminal_id,
-            master_fd=master_fd,
-            child_pid=child_pid,
-            restricted=restricted,
-        )
-
-    def _spawn_shell(self, *, restricted: bool) -> tuple[int, int]:
-        """Fork a PTY running the shell. Returns (master_fd, child_pid)."""
-        if restricted:
-            shell = self.shell_path
-        else:
-            shell = os.environ.get("SHELL", UNRESTRICTED_SHELL_PATH)
-
-        child_pid, master_fd = pty.fork()
-        if child_pid == 0:
-            # Child process - exec the shell
-            env = os.environ.copy()
-            env["TERM"] = "xterm-256color"
-            if self.workspace_dir:
-                env["WORKSPACE_DIR"] = self.workspace_dir
-                os.chdir(self.workspace_dir)
-            os.execve(
-                shell,
-                [shell],
-                env,
-            )
-        return master_fd, child_pid
-
-    @staticmethod
-    def _cleanup_session(session: _PtySession) -> None:
-        """Clean up a PTY session's file descriptor and child process."""
-        try:
-            os.close(session.master_fd)
-        except OSError:
-            pass
-        try:
-            os.kill(session.child_pid, signal.SIGTERM)
-            os.waitpid(session.child_pid, 0)
-        except (ProcessLookupError, ChildProcessError, OSError):
-            pass
+    # --- PTY I/O ---
 
     async def _pty_to_ws(
         self,
@@ -279,16 +464,13 @@ class TerminalServer:
                 if data is None:
                     continue
                 if not data:
-                    # EOF - process exited
                     await ws.send_str(json.dumps({"type": "exit", "data": ""}))
                     break
                 await ws.send_str(
-                    json.dumps(
-                        {
-                            "type": "output",
-                            "data": data.decode("utf-8", errors="replace"),
-                        }
-                    )
+                    json.dumps({
+                        "type": "output",
+                        "data": data.decode("utf-8", errors="replace"),
+                    })
                 )
         except (OSError, ConnectionResetError):
             pass
@@ -297,10 +479,7 @@ class TerminalServer:
 
     @staticmethod
     def _blocking_read(fd: int) -> bytes | None:
-        """Blocking read from file descriptor (runs in executor).
-
-        Returns data bytes, None on timeout, or b"" on EOF/error.
-        """
+        """Blocking read from file descriptor (runs in executor)."""
         import select
 
         ready, _, _ = select.select([fd], [], [], PTY_READ_TIMEOUT_SECONDS)

--- a/containers/skuld/Dockerfile
+++ b/containers/skuld/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     git \
     jq \
+    tmux \
     python3.12 \
     python3.12-venv \
     python3-pip \

--- a/src/volundr/adapters/outbound/direct_k8s_pod_manager.py
+++ b/src/volundr/adapters/outbound/direct_k8s_pod_manager.py
@@ -313,16 +313,18 @@ class DirectK8sPodManager(PodManager):
             {"envVar": "GITHUB_TOKEN", "secretName": "github-token", "secretKey": "token"},
         ]
         for es in env_secrets:
-            env.append({
-                "name": es["envVar"],
-                "valueFrom": {
-                    "secretKeyRef": {
-                        "name": es["secretName"],
-                        "key": es["secretKey"],
-                        "optional": True,
+            env.append(
+                {
+                    "name": es["envVar"],
+                    "valueFrom": {
+                        "secretKeyRef": {
+                            "name": es["secretName"],
+                            "key": es["secretKey"],
+                            "optional": True,
+                        },
                     },
-                },
-            })
+                }
+            )
 
         return env
 
@@ -347,7 +349,9 @@ class DirectK8sPodManager(PodManager):
         }
 
     def _build_init_containers(
-        self, session: Session, spec: SessionSpec,
+        self,
+        session: Session,
+        spec: SessionSpec,
     ) -> list[dict[str, Any]]:
         """Build init containers: permissions fix + optional git clone."""
         containers: list[dict[str, Any]] = [
@@ -392,33 +396,37 @@ else
   echo "Repository cloned successfully"
 fi
 """
-        containers.append({
-            "name": "git-clone",
-            "image": "alpine/git:latest",
-            "command": ["/bin/sh", "-c"],
-            "args": [clone_script],
-            "env": [
-                {
-                    "name": "GITHUB_TOKEN",
-                    "valueFrom": {
-                        "secretKeyRef": {
-                            "name": "github-token",
-                            "key": "token",
-                            "optional": True,
+        containers.append(
+            {
+                "name": "git-clone",
+                "image": "alpine/git:latest",
+                "command": ["/bin/sh", "-c"],
+                "args": [clone_script],
+                "env": [
+                    {
+                        "name": "GITHUB_TOKEN",
+                        "valueFrom": {
+                            "secretKeyRef": {
+                                "name": "github-token",
+                                "key": "token",
+                                "optional": True,
+                            },
                         },
                     },
-                },
-            ],
-            "securityContext": {"runAsUser": 1000, "allowPrivilegeEscalation": False},
-            "volumeMounts": [
-                {"name": "workspace", "mountPath": "/volundr"},
-            ],
-        })
+                ],
+                "securityContext": {"runAsUser": 1000, "allowPrivilegeEscalation": False},
+                "volumeMounts": [
+                    {"name": "workspace", "mountPath": "/volundr"},
+                ],
+            }
+        )
 
         return containers
 
     def _build_deployment_manifest(
-        self, session: Session, spec: SessionSpec,
+        self,
+        session: Session,
+        spec: SessionSpec,
     ) -> dict[str, Any]:
         """Build a Kubernetes Deployment manifest dict for the session."""
         labels = self._build_labels(session)
@@ -698,7 +706,9 @@ fi
         except api_exception as exc:
             if exc.status == 409:
                 logger.info(
-                    "%s %s already exists, patching", api_class, name,
+                    "%s %s already exists, patching",
+                    api_class,
+                    name,
                 )
                 await patch_fn(
                     name=name,
@@ -709,7 +719,8 @@ fi
                 raise
 
     async def _apply_custom_resource(
-        self, manifest: dict[str, Any],
+        self,
+        manifest: dict[str, Any],
     ) -> None:
         """Apply a custom resource (create or update)."""
         api = self._get_api("CustomObjectsApi")
@@ -723,7 +734,8 @@ fi
         plural = kind.lower() + "s"
         name = manifest["metadata"]["name"]
         namespace = manifest["metadata"].get(
-            "namespace", self._namespace,
+            "namespace",
+            self._namespace,
         )
 
         try:
@@ -746,7 +758,10 @@ fi
                 )
             else:
                 logger.warning(
-                    "Failed to apply %s %s: %s", kind, name, exc,
+                    "Failed to apply %s %s: %s",
+                    kind,
+                    name,
+                    exc,
                 )
                 raise
 
@@ -772,7 +787,10 @@ fi
         except api_exception as exc:
             if exc.status != 404:
                 logger.warning(
-                    "Failed to delete %s/%s: %s", plural, name, exc,
+                    "Failed to delete %s/%s: %s",
+                    plural,
+                    name,
+                    exc,
                 )
 
     async def _delete_resource(
@@ -792,7 +810,10 @@ fi
         except api_exception as exc:
             if exc.status != 404:
                 logger.error(
-                    "Failed to delete %s %s: %s", api_class, name, exc,
+                    "Failed to delete %s %s: %s",
+                    api_class,
+                    name,
+                    exc,
                 )
             return False
 
@@ -803,7 +824,8 @@ fi
 
         try:
             return await api.read_namespaced_deployment(
-                name=name, namespace=self._namespace,
+                name=name,
+                namespace=self._namespace,
             )
         except api_exception as exc:
             if exc.status == 404:
@@ -913,7 +935,8 @@ fi
 
         if d1 or d2 or d3 or d4:
             logger.info(
-                "Deleted K8s resources for session %s", session.id,
+                "Deleted K8s resources for session %s",
+                session.id,
             )
 
         return True
@@ -970,9 +993,7 @@ fi
             await asyncio.sleep(self._poll_interval)
             elapsed += self._poll_interval
 
-        logger.warning(
-            "Timed out waiting for session %s after %.1fs", session.id, timeout
-        )
+        logger.warning("Timed out waiting for session %s after %.1fs", session.id, timeout)
         return SessionStatus.FAILED
 
     async def close(self) -> None:

--- a/src/volundr/adapters/outbound/direct_k8s_pod_manager.py
+++ b/src/volundr/adapters/outbound/direct_k8s_pod_manager.py
@@ -445,6 +445,7 @@ fi
                 "template": {
                     "metadata": {"labels": labels},
                     "spec": {
+                        "hostname": session.name,
                         "terminationGracePeriodSeconds": 30,
                         "securityContext": {
                             "fsGroup": 1000,

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -1,4 +1,4 @@
-"""Tests for the devrunner terminal server."""
+"""Tests for the devrunner terminal server (tmux-based architecture)."""
 
 from __future__ import annotations
 
@@ -63,8 +63,9 @@ from terminal import (  # noqa: E402
     PTY_READ_TIMEOUT_SECONDS,
     UNRESTRICTED_SHELL_PATH,
     TerminalServer,
-    _PtySession,
+    _AttachHandle,
     _set_pty_size,
+    _TmuxSession,
 )
 
 
@@ -105,20 +106,29 @@ class TestTerminalServerInit:
         assert server._restricted is False
 
 
-class TestPtySession:
-    """Test _PtySession data class."""
+class TestTmuxSession:
+    """Test _TmuxSession data class."""
 
     def test_creation(self) -> None:
-        session = _PtySession(
+        session = _TmuxSession(
             terminal_id="test-id",
-            master_fd=5,
-            child_pid=1234,
-            restricted=True,
+            label="Test Terminal",
+            cli_type="shell",
+            window_name="test-id",
         )
         assert session.terminal_id == "test-id"
-        assert session.master_fd == 5
-        assert session.child_pid == 1234
-        assert session.restricted is True
+        assert session.label == "Test Terminal"
+        assert session.cli_type == "shell"
+        assert session.window_name == "test-id"
+
+
+class TestAttachHandle:
+    """Test _AttachHandle data class."""
+
+    def test_creation(self) -> None:
+        handle = _AttachHandle(master_fd=5, child_pid=1234)
+        assert handle.master_fd == 5
+        assert handle.child_pid == 1234
 
 
 class TestConstants:
@@ -153,46 +163,20 @@ class TestSetPtySize:
         mock_ioctl.assert_called_once()
 
 
-class TestSpawnShell:
-    """Test shell spawning logic."""
-
-    @patch("terminal.pty.fork", return_value=(1234, 5))
-    @patch("terminal.fcntl.fcntl")
-    def test_spawn_restricted_shell(self, mock_fcntl: MagicMock, mock_fork: MagicMock) -> None:
-        server = TerminalServer(shell_path="/usr/local/bin/restricted-shell")
-        session = server._create_pty_session("test-id", restricted=True)
-        assert session.terminal_id == "test-id"
-        assert session.child_pid == 1234
-        assert session.master_fd == 5
-        assert session.restricted is True
-
-    @patch("terminal.pty.fork", return_value=(1234, 5))
-    @patch("terminal.fcntl.fcntl")
-    def test_spawn_unrestricted_shell(self, mock_fcntl: MagicMock, mock_fork: MagicMock) -> None:
-        server = TerminalServer()
-        session = server._create_pty_session("test-id", restricted=False)
-        assert session.restricted is False
-
-
-class TestCleanupSession:
-    """Test session cleanup."""
+class TestCleanupAttach:
+    """Test attach handle cleanup."""
 
     @patch("terminal.os.waitpid")
     @patch("terminal.os.kill")
     @patch("terminal.os.close")
-    def test_cleanup_session(
+    def test_cleanup_attach(
         self,
         mock_close: MagicMock,
         mock_kill: MagicMock,
         mock_waitpid: MagicMock,
     ) -> None:
-        session = _PtySession(
-            terminal_id="test",
-            master_fd=5,
-            child_pid=1234,
-            restricted=True,
-        )
-        TerminalServer._cleanup_session(session)
+        handle = _AttachHandle(master_fd=5, child_pid=1234)
+        TerminalServer._cleanup_attach(handle)
         mock_close.assert_called_once_with(5)
         mock_kill.assert_called_once()
         mock_waitpid.assert_called_once()
@@ -200,20 +184,15 @@ class TestCleanupSession:
     @patch("terminal.os.waitpid", side_effect=ChildProcessError)
     @patch("terminal.os.kill", side_effect=ProcessLookupError)
     @patch("terminal.os.close", side_effect=OSError)
-    def test_cleanup_session_handles_errors(
+    def test_cleanup_attach_handles_errors(
         self,
         mock_close: MagicMock,
         mock_kill: MagicMock,
         mock_waitpid: MagicMock,
     ) -> None:
-        session = _PtySession(
-            terminal_id="test",
-            master_fd=5,
-            child_pid=1234,
-            restricted=True,
-        )
+        handle = _AttachHandle(master_fd=5, child_pid=1234)
         # Should not raise
-        TerminalServer._cleanup_session(session)
+        TerminalServer._cleanup_attach(handle)
 
 
 class TestBlockingRead:
@@ -241,12 +220,11 @@ class TestHandleSpawn:
     """Test the spawn endpoint."""
 
     @pytest.mark.asyncio
-    @patch("terminal.pty.fork", return_value=(1234, 5))
-    @patch("terminal.fcntl.fcntl")
-    async def test_spawn_returns_terminal_id(
-        self, mock_fcntl: MagicMock, mock_fork: MagicMock
-    ) -> None:
+    @patch("terminal._tmux_run")
+    async def test_spawn_returns_terminal_id(self, mock_tmux: MagicMock) -> None:
+        mock_tmux.return_value = MagicMock(returncode=0, stdout="")
         server = TerminalServer()
+        server._tmux_ready = True
         request = MagicMock()
         request.can_read_body = False
 
@@ -254,8 +232,44 @@ class TestHandleSpawn:
         body = json.loads(response.text)
 
         assert "terminalId" in body
-        assert body["restricted"] is False
+        assert body["cli_type"] == "shell"
+        assert body["persistent"] is True
         assert body["terminalId"] in server._sessions
+
+    @pytest.mark.asyncio
+    @patch("terminal._tmux_run")
+    async def test_spawn_with_cli_type(self, mock_tmux: MagicMock) -> None:
+        mock_tmux.return_value = MagicMock(returncode=0, stdout="")
+        server = TerminalServer()
+        server._tmux_ready = True
+        request = MagicMock()
+        request.can_read_body = True
+        request.json = AsyncMock(return_value={"cli_type": "claude"})
+
+        response = await server._handle_spawn(request)
+        body = json.loads(response.text)
+
+        assert body["cli_type"] == "claude"
+
+    @pytest.mark.asyncio
+    @patch("terminal._tmux_run")
+    async def test_spawn_duplicate_returns_409(self, mock_tmux: MagicMock) -> None:
+        mock_tmux.return_value = MagicMock(returncode=0, stdout="")
+        server = TerminalServer()
+        server._tmux_ready = True
+        server._sessions["my-session"] = _TmuxSession(
+            terminal_id="my-session",
+            label="my-session",
+            cli_type="shell",
+            window_name="my-session",
+        )
+
+        request = MagicMock()
+        request.can_read_body = True
+        request.json = AsyncMock(return_value={"name": "my-session"})
+
+        response = await server._handle_spawn(request)
+        assert response.status == 409
 
 
 class TestHandleKill:
@@ -271,14 +285,15 @@ class TestHandleKill:
         assert response.status == 404
 
     @pytest.mark.asyncio
-    @patch.object(TerminalServer, "_cleanup_session")
-    async def test_kill_existing_session(self, mock_cleanup: MagicMock) -> None:
+    @patch("terminal._tmux_run")
+    async def test_kill_existing_session(self, mock_tmux: MagicMock) -> None:
+        mock_tmux.return_value = MagicMock(returncode=0, stdout="")
         server = TerminalServer()
-        session = _PtySession(
+        session = _TmuxSession(
             terminal_id="test-id",
-            master_fd=5,
-            child_pid=1234,
-            restricted=True,
+            label="Test",
+            cli_type="shell",
+            window_name="test-id",
         )
         server._sessions["test-id"] = session
 
@@ -290,7 +305,6 @@ class TestHandleKill:
 
         assert body["ok"] is True
         assert "test-id" not in server._sessions
-        mock_cleanup.assert_called_once_with(session)
 
 
 class TestHandleMode:
@@ -325,21 +339,18 @@ class TestStop:
     """Test server shutdown."""
 
     @pytest.mark.asyncio
-    @patch.object(TerminalServer, "_cleanup_session")
-    async def test_stop_cleans_up_sessions(self, mock_cleanup: MagicMock) -> None:
+    async def test_stop_clears_sessions(self) -> None:
         server = TerminalServer()
-        session = _PtySession(
+        server._sessions["test"] = _TmuxSession(
             terminal_id="test",
-            master_fd=5,
-            child_pid=1234,
-            restricted=True,
+            label="Test",
+            cli_type="shell",
+            window_name="test",
         )
-        server._sessions["test"] = session
         server._runner = MagicMock()
         server._runner.cleanup = AsyncMock()
 
         await server.stop()
 
-        mock_cleanup.assert_called_once_with(session)
         assert len(server._sessions) == 0
         server._runner.cleanup.assert_called_once()

--- a/web/src/components/SessionGroupList/SessionGroupList.test.tsx
+++ b/web/src/components/SessionGroupList/SessionGroupList.test.tsx
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SessionGroupList } from './SessionGroupList';
+import type { VolundrSession } from '@/models';
+
+// Mock useLocalStorage
+const mockSetCollapsed = vi.fn();
+let mockCollapsedState: Record<string, boolean> = {};
+
+vi.mock('@/hooks', () => ({
+  useLocalStorage: vi.fn(() => [mockCollapsedState, mockSetCollapsed]),
+}));
+
+function makeSession(overrides: Partial<VolundrSession> = {}): VolundrSession {
+  return {
+    id: 'session-1',
+    name: 'test-session',
+    status: 'running',
+    repo: 'https://github.com/org/repo-a',
+    branch: 'main',
+    model: 'claude-sonnet-4-20250514',
+    createdAt: Date.now(),
+    lastActive: Date.now(),
+    totalCostUsd: 0,
+    ...overrides,
+  } as VolundrSession;
+}
+
+describe('SessionGroupList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCollapsedState = {};
+  });
+
+  it('groups sessions by repository', () => {
+    const sessions = [
+      makeSession({ id: 's1', name: 'S1', repo: 'https://github.com/org/repo-a' }),
+      makeSession({ id: 's2', name: 'S2', repo: 'https://github.com/org/repo-b' }),
+      makeSession({ id: 's3', name: 'S3', repo: 'https://github.com/org/repo-a' }),
+    ];
+
+    render(
+      <SessionGroupList
+        sessions={sessions}
+        searchQuery=""
+        renderSession={s => (
+          <div key={s.id} data-testid={`session-${s.id}`}>
+            {s.name}
+          </div>
+        )}
+      />
+    );
+
+    expect(screen.getByText('org/repo-a')).toBeInTheDocument();
+    expect(screen.getByText('org/repo-b')).toBeInTheDocument();
+  });
+
+  it('renders all sessions via renderSession prop', () => {
+    const sessions = [
+      makeSession({ id: 's1', name: 'Session One', repo: 'https://github.com/org/repo' }),
+      makeSession({ id: 's2', name: 'Session Two', repo: 'https://github.com/org/repo' }),
+    ];
+
+    render(
+      <SessionGroupList
+        sessions={sessions}
+        searchQuery=""
+        renderSession={s => <div key={s.id}>{s.name}</div>}
+      />
+    );
+
+    expect(screen.getByText('Session One')).toBeInTheDocument();
+    expect(screen.getByText('Session Two')).toBeInTheDocument();
+  });
+
+  it('shows active count badge for running sessions', () => {
+    const sessions = [
+      makeSession({ id: 's1', status: 'running', repo: 'https://github.com/org/repo' }),
+      makeSession({ id: 's2', status: 'stopped', repo: 'https://github.com/org/repo' }),
+      makeSession({ id: 's3', status: 'running', repo: 'https://github.com/org/repo' }),
+    ];
+
+    render(
+      <SessionGroupList
+        sessions={sessions}
+        searchQuery=""
+        renderSession={s => <div key={s.id}>{s.name}</div>}
+      />
+    );
+
+    // 2 active sessions
+    expect(screen.getByText('2')).toBeInTheDocument();
+    // 3 total sessions
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  it('toggles group collapse on header click', () => {
+    const sessions = [makeSession({ id: 's1', repo: 'https://github.com/org/my-repo' })];
+
+    render(
+      <SessionGroupList
+        sessions={sessions}
+        searchQuery=""
+        renderSession={s => <div key={s.id}>{s.name}</div>}
+      />
+    );
+
+    fireEvent.click(screen.getByText('org/my-repo'));
+
+    expect(mockSetCollapsed).toHaveBeenCalledWith(expect.objectContaining({ 'org/my-repo': true }));
+  });
+
+  it('groups sessions without repo URL under Ungrouped', () => {
+    const sessions = [makeSession({ id: 's1', name: 'No Repo', repo: '' })];
+
+    render(
+      <SessionGroupList
+        sessions={sessions}
+        searchQuery=""
+        renderSession={s => <div key={s.id}>{s.name}</div>}
+      />
+    );
+
+    expect(screen.getByText('Ungrouped')).toBeInTheDocument();
+  });
+
+  it('handles non-URL repo values', () => {
+    const sessions = [makeSession({ id: 's1', name: 'Plain Repo', repo: 'my-local-repo' })];
+
+    render(
+      <SessionGroupList
+        sessions={sessions}
+        searchQuery=""
+        renderSession={s => <div key={s.id}>{s.name}</div>}
+      />
+    );
+
+    expect(screen.getByText('my-local-repo')).toBeInTheDocument();
+  });
+
+  it('strips .git suffix from repo URLs', () => {
+    const sessions = [makeSession({ id: 's1', repo: 'https://github.com/org/repo.git' })];
+
+    render(
+      <SessionGroupList
+        sessions={sessions}
+        searchQuery=""
+        renderSession={s => <div key={s.id}>{s.name}</div>}
+      />
+    );
+
+    expect(screen.getByText('org/repo')).toBeInTheDocument();
+  });
+
+  it('does not collapse groups when searching', () => {
+    mockCollapsedState = { 'org/repo': true };
+
+    const sessions = [
+      makeSession({ id: 's1', name: 'Found It', repo: 'https://github.com/org/repo' }),
+    ];
+
+    render(
+      <SessionGroupList
+        sessions={sessions}
+        searchQuery="Found"
+        renderSession={s => <div key={s.id}>{s.name}</div>}
+      />
+    );
+
+    // Session should still be visible despite group being "collapsed"
+    expect(screen.getByText('Found It')).toBeInTheDocument();
+  });
+
+  it('sorts groups by most recently active', () => {
+    const sessions = [
+      makeSession({ id: 's1', repo: 'https://github.com/org/old-repo', lastActive: 1000 }),
+      makeSession({ id: 's2', repo: 'https://github.com/org/new-repo', lastActive: 2000 }),
+    ];
+
+    render(
+      <SessionGroupList
+        sessions={sessions}
+        searchQuery=""
+        renderSession={s => <div key={s.id}>{s.name}</div>}
+      />
+    );
+
+    const groupHeaders = screen.getAllByRole('button');
+    expect(groupHeaders[0]).toHaveTextContent('org/new-repo');
+    expect(groupHeaders[1]).toHaveTextContent('org/old-repo');
+  });
+
+  it('does not show active badge when no sessions are running', () => {
+    const sessions = [
+      makeSession({ id: 's1', status: 'stopped', repo: 'https://github.com/org/repo' }),
+    ];
+
+    render(
+      <SessionGroupList
+        sessions={sessions}
+        searchQuery=""
+        renderSession={s => <div key={s.id}>{s.name}</div>}
+      />
+    );
+
+    // Total count badge shows "1", but no active dot/badge
+    expect(screen.getByText('1')).toBeInTheDocument();
+  });
+});

--- a/web/src/components/SessionTerminal/SessionTerminal.test.tsx
+++ b/web/src/components/SessionTerminal/SessionTerminal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, act, fireEvent } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import { SessionTerminal } from './SessionTerminal';
 
 // Mock xterm.js — jsdom has no canvas support
@@ -115,7 +115,8 @@ describe('SessionTerminal', () => {
       await Promise.resolve();
     });
 
-    expect(useWebSocket).toHaveBeenCalledWith('ws://test-host/terminal/ws', expect.any(Object));
+    // With no active tab yet, the computed WS URL is null (tabs load async)
+    expect(useWebSocket).toHaveBeenCalledWith(null, expect.any(Object));
   });
 
   it('passes null url to useWebSocket when url is null', async () => {
@@ -145,30 +146,19 @@ describe('SessionTerminal', () => {
       await Promise.resolve();
     });
 
+    // Tab bar is always rendered, but with url=null no tabs are spawned
     expect(screen.getByRole('tablist')).toBeInTheDocument();
-    expect(screen.getByText('Terminal 1')).toBeInTheDocument();
   });
 
-  it('adds a new tab when add button is clicked', async () => {
-    render(<SessionTerminal url={null} />);
-
-    await act(async () => {
-      await Promise.resolve();
-    });
-
-    fireEvent.click(screen.getByRole('button', { name: /new terminal/i }));
-
-    expect(screen.getByText('Terminal 2')).toBeInTheDocument();
-  });
-
-  it('renders terminal container element', async () => {
+  it('renders empty terminal area when url is null', async () => {
     const { container } = render(<SessionTerminal url={null} />);
 
     await act(async () => {
       await Promise.resolve();
     });
 
+    // No tabs are created when url is null (no httpBase for REST calls)
     const terminalDiv = container.querySelector('[data-visible]');
-    expect(terminalDiv).toBeTruthy();
+    expect(terminalDiv).toBeNull();
   });
 });

--- a/web/src/components/SessionTerminal/SessionTerminal.test.tsx
+++ b/web/src/components/SessionTerminal/SessionTerminal.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { render, screen, act, fireEvent } from '@testing-library/react';
 import { SessionTerminal } from './SessionTerminal';
 
 // Mock xterm.js — jsdom has no canvas support
@@ -47,6 +47,11 @@ vi.mock('@/hooks/useIsTouchDevice', () => ({
   useIsTouchDevice: vi.fn(() => false),
 }));
 
+// Mock getAccessToken
+vi.mock('@/adapters/api/client', () => ({
+  getAccessToken: vi.fn(() => 'test-token'),
+}));
+
 // Mock document.fonts.load
 Object.defineProperty(document, 'fonts', {
   value: {
@@ -57,6 +62,7 @@ Object.defineProperty(document, 'fonts', {
 });
 
 import { useWebSocket } from '@/hooks/useWebSocket';
+import { useIsTouchDevice } from '@/hooks/useIsTouchDevice';
 
 // jsdom lacks ResizeObserver
 class MockResizeObserver {
@@ -69,12 +75,12 @@ vi.stubGlobal('ResizeObserver', MockResizeObserver);
 describe('SessionTerminal', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubGlobal('fetch', vi.fn());
   });
 
   it('renders with disconnected state when url is null', async () => {
     render(<SessionTerminal url={null} />);
 
-    // Wait for font loading to resolve
     await act(async () => {
       await Promise.resolve();
     });
@@ -108,15 +114,63 @@ describe('SessionTerminal', () => {
     expect(screen.getByText('Connected')).toBeInTheDocument();
   });
 
-  it('passes url to useWebSocket', async () => {
-    render(<SessionTerminal url="ws://test-host/terminal/ws" />);
+  it('sets connected=false on onClose', async () => {
+    let capturedCallbacks: Record<string, (...args: unknown[]) => void> = {};
+
+    vi.mocked(useWebSocket).mockImplementation((_url, options = {}) => {
+      capturedCallbacks = options as Record<string, (...args: unknown[]) => void>;
+      return {
+        send: vi.fn(),
+        sendJson: vi.fn(),
+        close: vi.fn(),
+        getSocket: vi.fn(() => null),
+      };
+    });
+
+    render(<SessionTerminal url="ws://test/terminal/ws" />);
 
     await act(async () => {
       await Promise.resolve();
     });
 
-    // With no active tab yet, the computed WS URL is null (tabs load async)
-    expect(useWebSocket).toHaveBeenCalledWith(null, expect.any(Object));
+    act(() => {
+      capturedCallbacks.onOpen?.();
+    });
+    expect(screen.getByText('Connected')).toBeInTheDocument();
+
+    act(() => {
+      capturedCallbacks.onClose?.();
+    });
+    expect(screen.getByText('Disconnected')).toBeInTheDocument();
+  });
+
+  it('sets connected=false on onError', async () => {
+    let capturedCallbacks: Record<string, (...args: unknown[]) => void> = {};
+
+    vi.mocked(useWebSocket).mockImplementation((_url, options = {}) => {
+      capturedCallbacks = options as Record<string, (...args: unknown[]) => void>;
+      return {
+        send: vi.fn(),
+        sendJson: vi.fn(),
+        close: vi.fn(),
+        getSocket: vi.fn(() => null),
+      };
+    });
+
+    render(<SessionTerminal url="ws://test/terminal/ws" />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    act(() => {
+      capturedCallbacks.onOpen?.();
+    });
+
+    act(() => {
+      capturedCallbacks.onError?.();
+    });
+    expect(screen.getByText('Disconnected')).toBeInTheDocument();
   });
 
   it('passes null url to useWebSocket when url is null', async () => {
@@ -146,7 +200,6 @@ describe('SessionTerminal', () => {
       await Promise.resolve();
     });
 
-    // Tab bar is always rendered, but with url=null no tabs are spawned
     expect(screen.getByRole('tablist')).toBeInTheDocument();
   });
 
@@ -157,8 +210,394 @@ describe('SessionTerminal', () => {
       await Promise.resolve();
     });
 
-    // No tabs are created when url is null (no httpBase for REST calls)
     const terminalDiv = container.querySelector('[data-visible]');
     expect(terminalDiv).toBeNull();
+  });
+
+  it('loads existing sessions from server and creates tabs', async () => {
+    const mockSessions = {
+      sessions: [
+        { terminalId: 'term-1', label: 'Shell 1', cli_type: 'shell', status: 'running' },
+        { terminalId: 'term-2', label: 'Claude', cli_type: 'claude', status: 'running' },
+      ],
+    };
+
+    (globalThis.fetch as Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockSessions,
+    });
+
+    render(<SessionTerminal url="ws://test-host/terminal/ws" />);
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 10));
+    });
+
+    expect(screen.getByText('Shell 1')).toBeInTheDocument();
+    expect(screen.getByText('Claude')).toBeInTheDocument();
+  });
+
+  it('spawns initial shell when no existing sessions', async () => {
+    // First call: listSessions returns empty
+    (globalThis.fetch as Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ sessions: [] }),
+    });
+    // Second call: spawnSession returns new terminal
+    (globalThis.fetch as Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ terminalId: 'shell-1', label: 'Shell 1' }),
+    });
+
+    render(<SessionTerminal url="ws://test-host/terminal/ws" />);
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 10));
+    });
+
+    expect(screen.getByText('Terminal 1')).toBeInTheDocument();
+  });
+
+  it('computes WebSocket URL from active tab', async () => {
+    (globalThis.fetch as Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        sessions: [{ terminalId: 'my-term', label: 'Shell', cli_type: 'shell', status: 'running' }],
+      }),
+    });
+
+    render(<SessionTerminal url="ws://test-host/terminal/ws" />);
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 10));
+    });
+
+    expect(useWebSocket).toHaveBeenCalledWith(
+      'ws://test-host/terminal/ws/my-term',
+      expect.any(Object)
+    );
+  });
+
+  it('handles spawn failure gracefully', async () => {
+    // listSessions returns empty
+    (globalThis.fetch as Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ sessions: [] }),
+    });
+    // spawnSession fails
+    (globalThis.fetch as Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: async () => 'Internal Server Error',
+    });
+
+    render(<SessionTerminal url="ws://test-host/terminal/ws" />);
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 10));
+    });
+
+    // Should not crash, just no tabs
+    expect(screen.getByRole('tablist')).toBeInTheDocument();
+  });
+
+  it('handles listSessions fetch error gracefully', async () => {
+    (globalThis.fetch as Mock).mockRejectedValueOnce(new Error('Network error'));
+
+    render(<SessionTerminal url="ws://test-host/terminal/ws" />);
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 10));
+    });
+
+    // Should not crash
+    expect(screen.getByRole('tablist')).toBeInTheDocument();
+  });
+
+  it('handles onMessage with output event', async () => {
+    let capturedCallbacks: Record<string, (...args: unknown[]) => void> = {};
+
+    vi.mocked(useWebSocket).mockImplementation((_url, options = {}) => {
+      capturedCallbacks = options as Record<string, (...args: unknown[]) => void>;
+      return {
+        send: vi.fn(),
+        sendJson: vi.fn(),
+        close: vi.fn(),
+        getSocket: vi.fn(() => null),
+      };
+    });
+
+    render(<SessionTerminal url="ws://test/terminal/ws" />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Should not crash when receiving output with no active terminal instance
+    act(() => {
+      capturedCallbacks.onMessage?.(JSON.stringify({ type: 'output', data: 'hello' }));
+    });
+  });
+
+  it('handles onMessage with exit event', async () => {
+    let capturedCallbacks: Record<string, (...args: unknown[]) => void> = {};
+
+    vi.mocked(useWebSocket).mockImplementation((_url, options = {}) => {
+      capturedCallbacks = options as Record<string, (...args: unknown[]) => void>;
+      return {
+        send: vi.fn(),
+        sendJson: vi.fn(),
+        close: vi.fn(),
+        getSocket: vi.fn(() => null),
+      };
+    });
+
+    render(<SessionTerminal url="ws://test/terminal/ws" />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    act(() => {
+      capturedCallbacks.onMessage?.(JSON.stringify({ type: 'exit', data: '' }));
+    });
+  });
+
+  it('handles onMessage with invalid JSON (raw text)', async () => {
+    let capturedCallbacks: Record<string, (...args: unknown[]) => void> = {};
+
+    vi.mocked(useWebSocket).mockImplementation((_url, options = {}) => {
+      capturedCallbacks = options as Record<string, (...args: unknown[]) => void>;
+      return {
+        send: vi.fn(),
+        sendJson: vi.fn(),
+        close: vi.fn(),
+        getSocket: vi.fn(() => null),
+      };
+    });
+
+    render(<SessionTerminal url="ws://test/terminal/ws" />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Should not crash on invalid JSON
+    act(() => {
+      capturedCallbacks.onMessage?.('not json at all');
+    });
+  });
+
+  it('derives https base URL from wss WebSocket URL', async () => {
+    (globalThis.fetch as Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ sessions: [] }),
+    });
+    (globalThis.fetch as Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ terminalId: 'shell-1', label: 'Shell' }),
+    });
+
+    render(<SessionTerminal url="wss://secure-host/terminal/ws" />);
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 10));
+    });
+
+    // The fetch should use https:// derived from wss://
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://secure-host/terminal/api/terminal/sessions',
+      expect.any(Object)
+    );
+  });
+
+  it('derives http base URL from ws WebSocket URL', async () => {
+    (globalThis.fetch as Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ sessions: [] }),
+    });
+    (globalThis.fetch as Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ terminalId: 'shell-1', label: 'Shell' }),
+    });
+
+    render(<SessionTerminal url="ws://local-host/terminal/ws" />);
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 10));
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'http://local-host/terminal/api/terminal/sessions',
+      expect.any(Object)
+    );
+  });
+
+  it('adds a new tab via CLI dropdown spawn', async () => {
+    // Load existing sessions
+    (globalThis.fetch as Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        sessions: [
+          { terminalId: 'term-1', label: 'Shell 1', cli_type: 'shell', status: 'running' },
+        ],
+      }),
+    });
+
+    render(<SessionTerminal url="ws://test-host/terminal/ws" />);
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 10));
+    });
+
+    expect(screen.getByText('Shell 1')).toBeInTheDocument();
+
+    // Mock the spawn response for adding a tab
+    (globalThis.fetch as Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ terminalId: 'claude-1', label: 'Claude' }),
+    });
+
+    // Click the add button to open dropdown
+    fireEvent.click(screen.getByRole('button', { name: /new terminal/i }));
+    // Click Claude option
+    fireEvent.click(screen.getByRole('menuitem', { name: /claude/i }));
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 10));
+    });
+
+    expect(screen.getByText('Claude')).toBeInTheDocument();
+  });
+
+  it('closes a tab and switches to adjacent tab', async () => {
+    (globalThis.fetch as Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        sessions: [
+          { terminalId: 'term-1', label: 'Tab 1', cli_type: 'shell', status: 'running' },
+          { terminalId: 'term-2', label: 'Tab 2', cli_type: 'shell', status: 'running' },
+        ],
+      }),
+    });
+
+    render(<SessionTerminal url="ws://test-host/terminal/ws" />);
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 10));
+    });
+
+    expect(screen.getByText('Tab 1')).toBeInTheDocument();
+    expect(screen.getByText('Tab 2')).toBeInTheDocument();
+
+    // Mock the kill fetch call
+    (globalThis.fetch as Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ ok: true }),
+    });
+
+    // Close first tab
+    const closeButtons = screen.getAllByRole('button', { name: /close/i });
+    fireEvent.click(closeButtons[0]);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByText('Tab 1')).toBeNull();
+    expect(screen.getByText('Tab 2')).toBeInTheDocument();
+  });
+
+  it('shows touch accessory bar on touch devices', async () => {
+    vi.mocked(useIsTouchDevice).mockReturnValue(true);
+
+    render(<SessionTerminal url={null} />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // The accessory bar should be rendered for touch devices
+    // It renders Tab, Ctrl, Esc buttons
+    expect(screen.getByText('Tab')).toBeInTheDocument();
+  });
+
+  it('handles non-ok listSessions response', async () => {
+    (globalThis.fetch as Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+    });
+
+    render(<SessionTerminal url="ws://test-host/terminal/ws" />);
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 10));
+    });
+
+    // Should not crash, no tabs
+    expect(screen.getByRole('tablist')).toBeInTheDocument();
+  });
+
+  it('selects a tab when clicked', async () => {
+    (globalThis.fetch as Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        sessions: [
+          { terminalId: 'term-1', label: 'Tab 1', cli_type: 'shell', status: 'running' },
+          { terminalId: 'term-2', label: 'Tab 2', cli_type: 'shell', status: 'running' },
+        ],
+      }),
+    });
+
+    render(<SessionTerminal url="ws://test-host/terminal/ws" />);
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 10));
+    });
+
+    // Click on the second tab
+    fireEvent.click(screen.getByText('Tab 2'));
+
+    // The second tab should now be active (aria-selected)
+    const allTabs = screen.getAllByRole('tab');
+    expect(allTabs[1]).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('does not close the last remaining tab', async () => {
+    (globalThis.fetch as Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        sessions: [
+          { terminalId: 'term-1', label: 'Only Tab', cli_type: 'shell', status: 'running' },
+        ],
+      }),
+    });
+
+    render(<SessionTerminal url="ws://test-host/terminal/ws" />);
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 10));
+    });
+
+    // With only one tab, close buttons should not be visible
+    expect(screen.queryAllByRole('button', { name: /close/i })).toHaveLength(0);
+  });
+
+  it('handles spawn network error gracefully', async () => {
+    (globalThis.fetch as Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ sessions: [] }),
+    });
+    // spawnSession network error
+    (globalThis.fetch as Mock).mockRejectedValueOnce(new Error('fetch failed'));
+
+    render(<SessionTerminal url="ws://test-host/terminal/ws" />);
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 10));
+    });
+
+    // Should not crash
+    expect(screen.getByRole('tablist')).toBeInTheDocument();
   });
 });

--- a/web/src/components/SessionTerminal/SessionTerminal.tsx
+++ b/web/src/components/SessionTerminal/SessionTerminal.tsx
@@ -5,6 +5,7 @@ import { WebLinksAddon } from '@xterm/addon-web-links';
 import { Wifi, WifiOff } from 'lucide-react';
 import { useWebSocket } from '@/hooks/useWebSocket';
 import { useIsTouchDevice } from '@/hooks/useIsTouchDevice';
+import { getAccessToken } from '@/adapters/api/client';
 import { cn } from '@/utils';
 import { TerminalTabBar } from '@/components/TerminalTabBar';
 import { TerminalAccessoryBar } from '@/components/TerminalAccessoryBar';
@@ -26,40 +27,141 @@ interface SessionTerminalProps {
   className?: string;
 }
 
-function makeTabLabel(index: number): string {
-  return `Terminal ${index + 1}`;
+/**
+ * Derive the REST base URL from the WebSocket base URL.
+ * e.g. wss://host/s/{id}/terminal/ws -> https://host/s/{id}/terminal
+ */
+function deriveHttpBase(wsUrl: string): string {
+  const httpProto = wsUrl.startsWith('wss:') ? 'https:' : 'http:';
+  const parsed = new URL(wsUrl);
+  const prefix = parsed.pathname.replace(/\/ws\/?$/, '');
+  return `${httpProto}//${parsed.host}${prefix}`;
+}
+
+interface ServerSession {
+  terminalId: string;
+  label: string;
+  cli_type: string;
+  status: string;
+}
+
+/**
+ * List existing terminal sessions from the server.
+ */
+async function listSessions(httpBase: string): Promise<ServerSession[]> {
+  const headers: Record<string, string> = {};
+  const token = getAccessToken();
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
+  try {
+    const resp = await fetch(`${httpBase}/api/terminal/sessions`, { headers });
+    if (!resp.ok) {
+      return [];
+    }
+    const data = (await resp.json()) as { sessions: ServerSession[] };
+    return data.sessions || [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Kill a terminal session via the REST API.
+ */
+async function killSession(httpBase: string, terminalId: string): Promise<void> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  const token = getAccessToken();
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
+  try {
+    await fetch(`${httpBase}/api/terminal/kill`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ terminalId }),
+    });
+  } catch {
+    // Best-effort — the tmux window will be cleaned up on pod restart regardless
+  }
+}
+
+/**
+ * Spawn a terminal session via the REST API.
+ * Returns the terminalId on success, null on failure.
+ */
+async function spawnSession(
+  httpBase: string,
+  cliType: string,
+  name?: string
+): Promise<{ terminalId: string; label: string } | null> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  const token = getAccessToken();
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
+  const body: Record<string, string> = { cli_type: cliType };
+  if (name) {
+    body.name = name;
+  }
+
+  try {
+    const resp = await fetch(`${httpBase}/api/terminal/spawn`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    });
+
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => '');
+      console.error(`Terminal spawn failed (${resp.status}):`, text);
+      return null;
+    }
+
+    const data = (await resp.json()) as { terminalId: string; label?: string };
+    return { terminalId: data.terminalId, label: data.label || data.terminalId };
+  } catch (err) {
+    console.error('Terminal spawn request failed:', err);
+    return null;
+  }
 }
 
 /**
  * Multi-tab interactive PTY terminal backed by xterm.js + WebSocket.
+ *
+ * All tabs are spawned via the REST API to get a stable tmux-backed terminal ID.
+ * WebSocket connects to /ws/{terminalId} so tab switches reattach to the same session.
  *
  * Protocol (both directions are JSON):
  *   Client -> Server: { type: "input", data: string } | { type: "resize", cols: number, rows: number }
  *   Server -> Client: { type: "output", data: string } | { type: "exit", data: string }
  */
 export function SessionTerminal({ url, className }: SessionTerminalProps) {
-  const [tabs, setTabs] = useState<TerminalTab[]>(() => [
-    { id: 'default', label: makeTabLabel(0), restricted: false },
-  ]);
-  const [activeTabId, setActiveTabId] = useState('default');
+  const [tabs, setTabs] = useState<TerminalTab[]>([]);
+  const [activeTabId, setActiveTabId] = useState<string | null>(null);
   const [connected, setConnected] = useState(false);
   const [fontReady, setFontReady] = useState(false);
 
   const containerRefs = useRef<Map<string, HTMLDivElement>>(new Map());
   const instanceRefs = useRef<Map<string, TerminalInstance>>(new Map());
-  const tabCounterRef = useRef(1);
   const isTouch = useIsTouchDevice();
+  const initialSpawnedRef = useRef(false);
+
+  // Derive HTTP base for REST calls
+  const httpBase = useMemo(() => (url ? deriveHttpBase(url) : null), [url]);
 
   // Compute the WebSocket URL for the active tab
   const activeWsUrl = useMemo(() => {
-    if (!url) {
+    if (!url || !activeTabId) {
       return null;
     }
-    // For the default ad-hoc tab, use the base URL (backward compat)
-    if (activeTabId === 'default') {
-      return url;
-    }
-    // For spawned tabs, append terminalId
     const base = url.replace(/\/ws\/?$/, '');
     return `${base}/ws/${activeTabId}`;
   }, [url, activeTabId]);
@@ -67,7 +169,9 @@ export function SessionTerminal({ url, className }: SessionTerminalProps) {
   // Stable reference so the WebSocket callbacks can write to xterm
   const writeToTerminal = useCallback(
     (data: string) => {
-      instanceRefs.current.get(activeTabId)?.term.write(data);
+      if (activeTabId) {
+        instanceRefs.current.get(activeTabId)?.term.write(data);
+      }
     },
     [activeTabId]
   );
@@ -75,9 +179,11 @@ export function SessionTerminal({ url, className }: SessionTerminalProps) {
   const { sendJson } = useWebSocket(activeWsUrl, {
     onOpen: () => {
       setConnected(true);
-      const inst = instanceRefs.current.get(activeTabId);
-      if (inst) {
-        sendJson({ type: 'resize', cols: inst.term.cols, rows: inst.term.rows });
+      if (activeTabId) {
+        const inst = instanceRefs.current.get(activeTabId);
+        if (inst) {
+          sendJson({ type: 'resize', cols: inst.term.cols, rows: inst.term.rows });
+        }
       }
     },
     onMessage: (raw: string) => {
@@ -112,6 +218,44 @@ export function SessionTerminal({ url, className }: SessionTerminalProps) {
       cancelled = true;
     };
   }, []);
+
+  // Load existing sessions or spawn an initial shell tab
+  useEffect(() => {
+    if (!httpBase || initialSpawnedRef.current) {
+      return;
+    }
+    initialSpawnedRef.current = true;
+
+    (async () => {
+      // Check for existing sessions (e.g. after tab switch re-mount)
+      const existing = await listSessions(httpBase);
+      if (existing.length > 0) {
+        const restoredTabs = existing.map((s, i) => ({
+          id: s.terminalId,
+          label: s.label || `Terminal ${i + 1}`,
+          restricted: false,
+          cliType: s.cli_type,
+        }));
+        setTabs(restoredTabs);
+        setActiveTabId(restoredTabs[0].id);
+        return;
+      }
+
+      // No existing sessions — spawn a fresh shell
+      const result = await spawnSession(httpBase, 'shell');
+      if (!result) {
+        return;
+      }
+      const tab: TerminalTab = {
+        id: result.terminalId,
+        label: 'Terminal 1',
+        restricted: false,
+        cliType: 'shell',
+      };
+      setTabs([tab]);
+      setActiveTabId(result.terminalId);
+    })();
+  }, [httpBase]);
 
   // Create xterm instance for a tab when its container mounts
   const mountTerminal = useCallback(
@@ -192,8 +336,12 @@ export function SessionTerminal({ url, className }: SessionTerminalProps) {
     };
   }, []);
 
-  // Forward terminal input to WebSocket for active tab
+  // Forward terminal input to WebSocket for active tab.
+  // Depends on fontReady so the effect re-runs after the xterm instance is created.
   useEffect(() => {
+    if (!activeTabId) {
+      return;
+    }
     const inst = instanceRefs.current.get(activeTabId);
     if (!inst) {
       return;
@@ -204,10 +352,13 @@ export function SessionTerminal({ url, className }: SessionTerminalProps) {
     });
 
     return () => disposable.dispose();
-  }, [activeTabId, sendJson]);
+  }, [activeTabId, sendJson, fontReady]);
 
   // Forward resize events
   useEffect(() => {
+    if (!activeTabId) {
+      return;
+    }
     const inst = instanceRefs.current.get(activeTabId);
     if (!inst) {
       return;
@@ -218,10 +369,13 @@ export function SessionTerminal({ url, className }: SessionTerminalProps) {
     });
 
     return () => disposable.dispose();
-  }, [activeTabId, sendJson]);
+  }, [activeTabId, sendJson, fontReady]);
 
   // Refit on container resize
   useEffect(() => {
+    if (!activeTabId) {
+      return;
+    }
     const container = containerRefs.current.get(activeTabId);
     if (!container) {
       return;
@@ -241,6 +395,9 @@ export function SessionTerminal({ url, className }: SessionTerminalProps) {
 
   // Refit when tab changes
   useEffect(() => {
+    if (!activeTabId) {
+      return;
+    }
     // Small delay to let display: none -> block settle
     const timer = setTimeout(() => {
       try {
@@ -260,21 +417,57 @@ export function SessionTerminal({ url, className }: SessionTerminalProps) {
     [sendJson]
   );
 
-  // Tab management
+  // Tab management — local-only fallback (should not normally be needed)
   const handleAddTab = useCallback(() => {
-    const index = tabCounterRef.current;
-    tabCounterRef.current += 1;
-    const newTab: TerminalTab = {
-      id: `tab-${index}`,
-      label: makeTabLabel(index),
-      restricted: false,
-    };
-    setTabs(prev => [...prev, newTab]);
-    setActiveTabId(newTab.id);
-  }, []);
+    if (!httpBase) {
+      return;
+    }
+    spawnSession(httpBase, 'shell').then(result => {
+      if (!result) {
+        return;
+      }
+      const newTab: TerminalTab = {
+        id: result.terminalId,
+        label: result.label,
+        restricted: false,
+        cliType: 'shell',
+      };
+      setTabs(prev => [...prev, newTab]);
+      setActiveTabId(result.terminalId);
+    });
+  }, [httpBase]);
+
+  // Spawn a CLI tab via the terminal REST API
+  const handleAddCliTab = useCallback(
+    async (cliType: string) => {
+      if (!httpBase) {
+        return;
+      }
+
+      const result = await spawnSession(httpBase, cliType);
+      if (!result) {
+        return;
+      }
+
+      const newTab: TerminalTab = {
+        id: result.terminalId,
+        label: result.label,
+        restricted: false,
+        cliType,
+      };
+      setTabs(prev => [...prev, newTab]);
+      setActiveTabId(result.terminalId);
+    },
+    [httpBase]
+  );
 
   const handleCloseTab = useCallback(
     (tabId: string) => {
+      // Kill the server-side tmux session
+      if (httpBase) {
+        killSession(httpBase, tabId);
+      }
+
       setTabs(prev => {
         if (prev.length <= 1) {
           return prev;
@@ -299,7 +492,7 @@ export function SessionTerminal({ url, className }: SessionTerminalProps) {
         return filtered;
       });
     },
-    [activeTabId]
+    [activeTabId, httpBase]
   );
 
   const handleSelectTab = useCallback((tabId: string) => {
@@ -321,10 +514,11 @@ export function SessionTerminal({ url, className }: SessionTerminalProps) {
 
       <TerminalTabBar
         tabs={tabs}
-        activeTabId={activeTabId}
+        activeTabId={activeTabId ?? ''}
         onSelectTab={handleSelectTab}
         onCloseTab={handleCloseTab}
         onAddTab={handleAddTab}
+        onAddCliTab={handleAddCliTab}
       />
 
       <div className={styles.terminalArea}>

--- a/web/src/components/TerminalTabBar/TerminalTabBar.module.css
+++ b/web/src/components/TerminalTabBar/TerminalTabBar.module.css
@@ -1,12 +1,15 @@
+.tabBarWrapper {
+  flex-shrink: 0;
+  background-color: var(--color-bg-secondary);
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
 .tabBar {
   display: flex;
   align-items: center;
   gap: var(--space-0);
   overflow-x: auto;
   scrollbar-width: none;
-  flex-shrink: 0;
-  background-color: var(--color-bg-secondary);
-  border-bottom: 1px solid var(--color-border-subtle);
   padding-left: var(--space-1);
 }
 
@@ -80,12 +83,17 @@
   height: 10px;
 }
 
+.addContainer {
+  position: relative;
+  margin-left: var(--space-1);
+}
+
 .addButton {
   display: flex;
   align-items: center;
   justify-content: center;
+  gap: 2px;
   padding: var(--space-1);
-  margin-left: var(--space-1);
   border: none;
   background: transparent;
   color: var(--color-text-faint);
@@ -101,4 +109,40 @@
 .addIcon {
   width: 14px;
   height: 14px;
+}
+
+.chevronIcon {
+  width: 10px;
+  height: 10px;
+}
+
+.dropdown {
+  z-index: 9999;
+  min-width: 120px;
+  padding: var(--space-1) 0;
+  background-color: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+.dropdownItem {
+  display: block;
+  width: 100%;
+  padding: var(--space-1) var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  transition:
+    color var(--transition-fast),
+    background-color var(--transition-fast);
+}
+
+.dropdownItem:hover {
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-elevated);
 }

--- a/web/src/components/TerminalTabBar/TerminalTabBar.test.tsx
+++ b/web/src/components/TerminalTabBar/TerminalTabBar.test.tsx
@@ -81,6 +81,60 @@ describe('TerminalTabBar', () => {
     expect(onClose).toHaveBeenCalledWith('tab-0');
   });
 
+  it('calls onCloseTab on Enter keydown on close button', () => {
+    const tabs = makeTabs(2);
+    const onClose = vi.fn();
+    render(
+      <TerminalTabBar
+        tabs={tabs}
+        activeTabId="tab-0"
+        onSelectTab={vi.fn()}
+        onCloseTab={onClose}
+        onAddTab={vi.fn()}
+      />
+    );
+
+    const closeButtons = screen.getAllByRole('button', { name: /close/i });
+    fireEvent.keyDown(closeButtons[0], { key: 'Enter' });
+    expect(onClose).toHaveBeenCalledWith('tab-0');
+  });
+
+  it('calls onCloseTab on Space keydown on close button', () => {
+    const tabs = makeTabs(2);
+    const onClose = vi.fn();
+    render(
+      <TerminalTabBar
+        tabs={tabs}
+        activeTabId="tab-0"
+        onSelectTab={vi.fn()}
+        onCloseTab={onClose}
+        onAddTab={vi.fn()}
+      />
+    );
+
+    const closeButtons = screen.getAllByRole('button', { name: /close/i });
+    fireEvent.keyDown(closeButtons[0], { key: ' ' });
+    expect(onClose).toHaveBeenCalledWith('tab-0');
+  });
+
+  it('does not call onCloseTab on other keydown on close button', () => {
+    const tabs = makeTabs(2);
+    const onClose = vi.fn();
+    render(
+      <TerminalTabBar
+        tabs={tabs}
+        activeTabId="tab-0"
+        onSelectTab={vi.fn()}
+        onCloseTab={onClose}
+        onAddTab={vi.fn()}
+      />
+    );
+
+    const closeButtons = screen.getAllByRole('button', { name: /close/i });
+    fireEvent.keyDown(closeButtons[0], { key: 'Escape' });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
   it('does not show close buttons when only one tab exists', () => {
     const tabs = makeTabs(1);
     render(
@@ -114,9 +168,99 @@ describe('TerminalTabBar', () => {
     fireEvent.click(screen.getByRole('button', { name: /new terminal/i }));
     expect(screen.getByRole('menu')).toBeInTheDocument();
 
+    // All CLI options should be visible
+    expect(screen.getByRole('menuitem', { name: /shell/i })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /claude/i })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /codex/i })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /aider/i })).toBeInTheDocument();
+
     // Click a menu item to spawn via onAddCliTab
     fireEvent.click(screen.getByRole('menuitem', { name: /shell/i }));
     expect(onAddCli).toHaveBeenCalledWith('shell');
+  });
+
+  it('closes dropdown when clicking add button again', () => {
+    const tabs = makeTabs(1);
+    render(
+      <TerminalTabBar
+        tabs={tabs}
+        activeTabId="tab-0"
+        onSelectTab={vi.fn()}
+        onCloseTab={vi.fn()}
+        onAddTab={vi.fn()}
+        onAddCliTab={vi.fn()}
+      />
+    );
+
+    const addButton = screen.getByRole('button', { name: /new terminal/i });
+
+    // Open
+    fireEvent.click(addButton);
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+
+    // Close by clicking again
+    fireEvent.click(addButton);
+    expect(screen.queryByRole('menu')).toBeNull();
+  });
+
+  it('falls back to onAddTab when onAddCliTab is not provided', () => {
+    const tabs = makeTabs(1);
+    const onAdd = vi.fn();
+    render(
+      <TerminalTabBar
+        tabs={tabs}
+        activeTabId="tab-0"
+        onSelectTab={vi.fn()}
+        onCloseTab={vi.fn()}
+        onAddTab={onAdd}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /new terminal/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /shell/i }));
+    expect(onAdd).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes dropdown when clicking outside', () => {
+    const tabs = makeTabs(1);
+    render(
+      <TerminalTabBar
+        tabs={tabs}
+        activeTabId="tab-0"
+        onSelectTab={vi.fn()}
+        onCloseTab={vi.fn()}
+        onAddTab={vi.fn()}
+        onAddCliTab={vi.fn()}
+      />
+    );
+
+    // Open dropdown
+    fireEvent.click(screen.getByRole('button', { name: /new terminal/i }));
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+
+    // Click outside
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByRole('menu')).toBeNull();
+  });
+
+  it('sets aria-expanded on the add button', () => {
+    const tabs = makeTabs(1);
+    render(
+      <TerminalTabBar
+        tabs={tabs}
+        activeTabId="tab-0"
+        onSelectTab={vi.fn()}
+        onCloseTab={vi.fn()}
+        onAddTab={vi.fn()}
+        onAddCliTab={vi.fn()}
+      />
+    );
+
+    const addButton = screen.getByRole('button', { name: /new terminal/i });
+    expect(addButton).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(addButton);
+    expect(addButton).toHaveAttribute('aria-expanded', 'true');
   });
 
   it('renders the tablist role on the container', () => {
@@ -132,5 +276,25 @@ describe('TerminalTabBar', () => {
     );
 
     expect(screen.getByRole('tablist')).toBeInTheDocument();
+  });
+
+  it('renders lock icon for restricted tabs and unlock for unrestricted', () => {
+    const tabs: TerminalTab[] = [
+      { id: 'r', label: 'Restricted', restricted: true },
+      { id: 'u', label: 'Unrestricted', restricted: false },
+    ];
+    render(
+      <TerminalTabBar
+        tabs={tabs}
+        activeTabId="r"
+        onSelectTab={vi.fn()}
+        onCloseTab={vi.fn()}
+        onAddTab={vi.fn()}
+      />
+    );
+
+    // Lock and Unlock are lucide SVGs; just verify both tabs render
+    expect(screen.getByText('Restricted')).toBeInTheDocument();
+    expect(screen.getByText('Unrestricted')).toBeInTheDocument();
   });
 });

--- a/web/src/components/TerminalTabBar/TerminalTabBar.test.tsx
+++ b/web/src/components/TerminalTabBar/TerminalTabBar.test.tsx
@@ -96,9 +96,10 @@ describe('TerminalTabBar', () => {
     expect(screen.queryAllByRole('button', { name: /close/i })).toHaveLength(0);
   });
 
-  it('calls onAddTab when the add button is clicked', () => {
+  it('opens dropdown when the add button is clicked', () => {
     const tabs = makeTabs(1);
     const onAdd = vi.fn();
+    const onAddCli = vi.fn();
     render(
       <TerminalTabBar
         tabs={tabs}
@@ -106,11 +107,16 @@ describe('TerminalTabBar', () => {
         onSelectTab={vi.fn()}
         onCloseTab={vi.fn()}
         onAddTab={onAdd}
+        onAddCliTab={onAddCli}
       />
     );
 
     fireEvent.click(screen.getByRole('button', { name: /new terminal/i }));
-    expect(onAdd).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+
+    // Click a menu item to spawn via onAddCliTab
+    fireEvent.click(screen.getByRole('menuitem', { name: /shell/i }));
+    expect(onAddCli).toHaveBeenCalledWith('shell');
   });
 
   it('renders the tablist role on the container', () => {

--- a/web/src/components/TerminalTabBar/TerminalTabBar.tsx
+++ b/web/src/components/TerminalTabBar/TerminalTabBar.tsx
@@ -1,6 +1,14 @@
-import { X, Plus, Lock, Unlock } from 'lucide-react';
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { X, Plus, Lock, Unlock, ChevronDown } from 'lucide-react';
 import type { TerminalTab } from '@/models';
 import styles from './TerminalTabBar.module.css';
+
+const CLI_OPTIONS = [
+  { id: 'shell', label: 'Shell' },
+  { id: 'claude', label: 'Claude' },
+  { id: 'codex', label: 'Codex' },
+  { id: 'aider', label: 'Aider' },
+];
 
 export interface TerminalTabBarProps {
   tabs: TerminalTab[];
@@ -8,6 +16,7 @@ export interface TerminalTabBarProps {
   onSelectTab: (id: string) => void;
   onCloseTab: (id: string) => void;
   onAddTab: () => void;
+  onAddCliTab?: (cliType: string) => void;
 }
 
 export function TerminalTabBar({
@@ -16,49 +25,123 @@ export function TerminalTabBar({
   onSelectTab,
   onCloseTab,
   onAddTab,
+  onAddCliTab,
 }: TerminalTabBarProps) {
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [dropdownPos, setDropdownPos] = useState<{ top: number; left: number } | null>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const addBtnRef = useRef<HTMLButtonElement>(null);
+
+  const handleOptionClick = useCallback(
+    (cliType: string) => {
+      setDropdownOpen(false);
+      // Always spawn via the server API so a tmux window is created
+      if (onAddCliTab) {
+        onAddCliTab(cliType);
+        return;
+      }
+      // Fallback if no spawn handler
+      onAddTab();
+    },
+    [onAddTab, onAddCliTab]
+  );
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    if (!dropdownOpen) {
+      return;
+    }
+
+    const handleClickOutside = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setDropdownOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [dropdownOpen]);
+
   return (
-    <div className={styles.tabBar} role="tablist">
-      {tabs.map(tab => (
-        <button
-          key={tab.id}
-          role="tab"
-          aria-selected={tab.id === activeTabId}
-          data-active={tab.id === activeTabId}
-          className={styles.tab}
-          onClick={() => onSelectTab(tab.id)}
-        >
-          {tab.restricted ? (
-            <Lock className={styles.modeIcon} />
-          ) : (
-            <Unlock className={styles.modeIcon} />
-          )}
-          <span className={styles.tabLabel}>{tab.label}</span>
-          {tabs.length > 1 && (
-            <span
-              role="button"
-              aria-label={`Close ${tab.label}`}
-              className={styles.closeButton}
-              onClick={e => {
-                e.stopPropagation();
-                onCloseTab(tab.id);
-              }}
-              onKeyDown={e => {
-                if (e.key === 'Enter' || e.key === ' ') {
+    <div className={styles.tabBarWrapper}>
+      <div className={styles.tabBar} role="tablist">
+        {tabs.map(tab => (
+          <button
+            key={tab.id}
+            role="tab"
+            aria-selected={tab.id === activeTabId}
+            data-active={tab.id === activeTabId}
+            className={styles.tab}
+            onClick={() => onSelectTab(tab.id)}
+          >
+            {tab.restricted ? (
+              <Lock className={styles.modeIcon} />
+            ) : (
+              <Unlock className={styles.modeIcon} />
+            )}
+            <span className={styles.tabLabel}>{tab.label}</span>
+            {tabs.length > 1 && (
+              <span
+                role="button"
+                aria-label={`Close ${tab.label}`}
+                className={styles.closeButton}
+                onClick={e => {
                   e.stopPropagation();
                   onCloseTab(tab.id);
+                }}
+                onKeyDown={e => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.stopPropagation();
+                    onCloseTab(tab.id);
+                  }
+                }}
+                tabIndex={0}
+              >
+                <X className={styles.closeIcon} />
+              </span>
+            )}
+          </button>
+        ))}
+        <div className={styles.addContainer} ref={dropdownRef}>
+          <button
+            ref={addBtnRef}
+            className={styles.addButton}
+            onClick={() => {
+              setDropdownOpen(prev => {
+                if (!prev && addBtnRef.current) {
+                  const rect = addBtnRef.current.getBoundingClientRect();
+                  setDropdownPos({ top: rect.bottom + 4, left: rect.left });
                 }
-              }}
-              tabIndex={0}
+                return !prev;
+              });
+            }}
+            aria-label="New terminal"
+            aria-expanded={dropdownOpen}
+            aria-haspopup="menu"
+          >
+            <Plus className={styles.addIcon} />
+            <ChevronDown className={styles.chevronIcon} />
+          </button>
+          {dropdownOpen && dropdownPos && (
+            <div
+              className={styles.dropdown}
+              role="menu"
+              style={{ position: 'fixed', top: dropdownPos.top, left: dropdownPos.left }}
             >
-              <X className={styles.closeIcon} />
-            </span>
+              {CLI_OPTIONS.map(option => (
+                <button
+                  key={option.id}
+                  role="menuitem"
+                  className={styles.dropdownItem}
+                  onClick={() => handleOptionClick(option.id)}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
           )}
-        </button>
-      ))}
-      <button className={styles.addButton} onClick={onAddTab} aria-label="New terminal">
-        <Plus className={styles.addIcon} />
-      </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/web/src/components/index.ts
+++ b/web/src/components/index.ts
@@ -79,7 +79,6 @@ export type { RealmDetailModalProps } from './organisms/RealmDetailModal';
 // Session components
 export { SessionTerminal } from './SessionTerminal';
 export { SessionChat } from './SessionChat';
-
 // Terminal sub-components
 export { TerminalTabBar } from './TerminalTabBar';
 export type { TerminalTabBarProps } from './TerminalTabBar';

--- a/web/src/hooks/useWebSocket.ts
+++ b/web/src/hooks/useWebSocket.ts
@@ -145,6 +145,13 @@ export function useWebSocket(
       ws.onclose = (event: CloseEvent) => {
         onCloseRef.current?.(event.code, event.reason);
 
+        // If this WS was replaced by a newer connection, ignore it.
+        // Prevents stale reconnect when URL changes and the old WS
+        // fires onclose after intentionalCloseRef was already reset.
+        if (wsRef.current !== ws) {
+          return;
+        }
+
         if (intentionalCloseRef.current) {
           return;
         }

--- a/web/src/models/volundr.model.ts
+++ b/web/src/models/volundr.model.ts
@@ -367,6 +367,7 @@ export interface TerminalTab {
   id: string;
   label: string;
   restricted: boolean;
+  cliType?: string;
 }
 
 export interface SkillConfig {

--- a/web/src/pages/Volundr/index.tsx
+++ b/web/src/pages/Volundr/index.tsx
@@ -436,6 +436,7 @@ export function VolundrPage() {
   const tabs: { id: TabId; label: string; icon: typeof MessageSquare }[] = [
     { id: 'chat', label: 'Chat', icon: MessageSquare },
     { id: 'terminal', label: 'Terminal', icon: Terminal },
+
     { id: 'code', label: isManualSession ? 'IDE' : 'Code', icon: Code },
     { id: 'diffs', label: 'Diffs', icon: GitCompareArrows },
     { id: 'chronicles', label: 'Chronicles', icon: ScrollText },


### PR DESCRIPTION
## Summary
- **Persistent tmux-backed terminal sessions** across web UI and TUI with full tab management (create, switch, close, kill server-side sessions)
- **TUI terminal page** with single-WebSocket-at-a-time architecture matching web UI behavior (server multiplexes all connections to the active tmux window)
- **Session pod REST API** for terminal spawn/list/kill operations with `doWithBody` helper
- **Web UI multi-tab terminal** with xterm.js, tab bar dropdown for spawning shell/CLI tabs, and proper session lifecycle management
- **Devrunner terminal.py** rewrite with tmux session management backend

## TUI Keybindings
- `ctrl+t` — spawn new terminal tab
- `ctrl+n` / `ctrl+p` — cycle between tabs
- `ctrl+w` — close active tab (kills server-side tmux session)
- `ctrl+f` / `F11` — toggle fullscreen
- `ctrl+c` — forwarded to remote PTY (no longer kills TUI)

## Test plan
- [x] Open TUI, select a session, verify terminal loads with tabs from server
- [x] Cycle tabs with ctrl+n/p — each tab should show different terminal content
- [x] Spawn new tab with ctrl+t — verify new shell appears
- [x] Close tab with ctrl+w — verify server-side session is killed
- [x] Verify ctrl+c sends SIGINT to remote process, not TUI
- [x] Web UI: verify tab bar dropdown, spawn shell/CLI tabs, close tabs
- [x] Verify web UI and TUI can coexist on same session (tab switching in one affects the other due to server multiplexing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)