### PR TITLE
fix(cli): enable terminal scrolling and fix popout resize

### DIFF
--- a/containers/devrunner/terminal.py
+++ b/containers/devrunner/terminal.py
@@ -199,7 +199,7 @@ class TerminalServer:
             ("set-option", "-t", TMUX_SERVER_NAME, "-g", "status", "off"),
             ("set-option", "-t", TMUX_SERVER_NAME, "-g", "prefix", "None"),
             ("set-option", "-t", TMUX_SERVER_NAME, "-g", "history-limit", str(TMUX_SCROLLBACK)),
-            ("set-option", "-t", TMUX_SERVER_NAME, "-g", "mouse", "off"),
+            ("set-option", "-t", TMUX_SERVER_NAME, "-g", "mouse", "on"),
             ("unbind-key", "-a"),
         ]:
             _tmux_run(*args)

--- a/web/src/pages/Volundr/VolundrPopout.module.css
+++ b/web/src/pages/Volundr/VolundrPopout.module.css
@@ -1,5 +1,5 @@
 .wrapper {
-  min-height: 100vh;
+  height: 100vh;
   background-color: var(--color-bg-primary);
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- **Enable tmux mouse mode** (`mouse on`) in the headless config so users can scroll the terminal buffer via mouse wheel. Previously all keybindings were unbound and mouse was off, leaving no way to scroll at all.
- **Fix popout terminal rendering at half height** by changing `min-height: 100vh` to `height: 100vh` on the popout wrapper. `min-height` doesn't establish a definite height, so the flex chain collapsed and xterm.js FitAddon calculated incorrect dimensions.

## Test plan
- [ ] Open a terminal session, run a command with long output, verify mouse wheel scrolling works
- [ ] Pop out a terminal tab, verify it fills the full window height
- [ ] Open new tabs in the popout, verify they also render at full height

🤖 Generated with [Claude Code](https://claude.com/claude-code)