### PR TITLE
feat(adapters): wire resource requests (cpu, memory, gpu) end-to-end

### DIFF
--- a/charts/volundr/templates/configmap.yaml
+++ b/charts/volundr/templates/configmap.yaml
@@ -183,6 +183,18 @@ data:
       secret_kwargs_env: {}
       {{- end }}
 
+    resource_provider:
+      adapter: {{ .Values.resourceProvider.adapter | quote }}
+      kwargs: {{ .Values.resourceProvider.kwargs | toJson }}
+      {{- if .Values.resourceProvider.secretKwargs }}
+      secret_kwargs_env:
+        {{- range .Values.resourceProvider.secretKwargs }}
+        {{ .kwarg }}: RESOURCE_PROVIDER_SK_{{ .kwarg | upper }}
+        {{- end }}
+      {{- else }}
+      secret_kwargs_env: {}
+      {{- end }}
+
     identity:
       adapter: {{ .Values.identity.adapter | quote }}
       kwargs: {{ .Values.identity.kwargs | toJson }}

--- a/charts/volundr/values.yaml
+++ b/charts/volundr/values.yaml
@@ -481,6 +481,25 @@ storageAdapter:
   # -- Secret kwargs from K8s Secrets, merged into kwargs at runtime
   secretKwargs: []
 
+# Resource provider (dynamic adapter pattern)
+# Discovers cluster resources, validates requests, and translates
+# user-friendly specs to K8s-native primitives (requests/limits,
+# nodeSelector, tolerations, runtimeClassName).
+#
+# ── Kubernetes (device-plugin) ─────────────────────────────────
+#   resourceProvider:
+#     adapter: "volundr.adapters.outbound.k8s_resource_provider.K8sResourceProvider"
+#     kwargs:
+#       namespace: "volundr-sessions"
+#
+resourceProvider:
+  # -- Fully-qualified class path for the ResourceProvider adapter
+  adapter: "volundr.adapters.outbound.static_resource_provider.StaticResourceProvider"
+  # -- All kwargs forwarded to the adapter constructor
+  kwargs: {}
+  # -- Secret kwargs from K8s Secrets, merged into kwargs at runtime
+  secretKwargs: []
+
 identity:
   # -- Fully-qualified class path for the IdentityPort adapter
   adapter: "volundr.adapters.outbound.identity.AllowAllIdentityAdapter"
@@ -622,6 +641,9 @@ sessionContributors:
     kwargs: {}
     secretKwargs: []
   - adapter: "volundr.adapters.outbound.contributors.gateway.GatewayContributor"
+    kwargs: {}
+    secretKwargs: []
+  - adapter: "volundr.adapters.outbound.contributors.resource.ResourceContributor"
     kwargs: {}
     secretKwargs: []
   - adapter: "volundr.adapters.outbound.contributors.isolation.IsolationContributor"

--- a/cli/internal/runtime/docker.go
+++ b/cli/internal/runtime/docker.go
@@ -83,6 +83,7 @@ type dockerAPIConfig struct {
 	Identity             map[string]interface{}   `yaml:"identity"`
 	Authorization        map[string]interface{}   `yaml:"authorization"`
 	Gateway              map[string]interface{}   `yaml:"gateway"`
+	ResourceProvider     map[string]interface{}   `yaml:"resource_provider,omitempty"`
 	LocalMounts          map[string]interface{}   `yaml:"local_mounts,omitempty"`
 	SessionContributors  []map[string]interface{} `yaml:"session_contributors,omitempty"`
 }
@@ -528,10 +529,16 @@ func (r *DockerRuntime) generateDockerConfig(cfg *config.Config) (string, error)
 		}
 	}
 
+	// Wire up resource provider (static defaults for local dev).
+	apiCfg.ResourceProvider = map[string]interface{}{
+		"adapter": "volundr.adapters.outbound.static_resource_provider.StaticResourceProvider",
+	}
+
 	// Wire up session contributors.
 	// LocalMountContributor is auto-wired by Python main.py from local_mounts config.
 	apiCfg.SessionContributors = []map[string]interface{}{
 		{"adapter": "volundr.adapters.outbound.contributors.git.GitContributor"},
+		{"adapter": "volundr.adapters.outbound.contributors.resource.ResourceContributor"},
 	}
 
 	data, err := yaml.Marshal(&apiCfg)

--- a/cli/internal/runtime/k3s.go
+++ b/cli/internal/runtime/k3s.go
@@ -110,6 +110,7 @@ type k3sAPIConfig struct {
 	Identity             map[string]interface{}   `yaml:"identity"`
 	Authorization        map[string]interface{}   `yaml:"authorization"`
 	Gateway              map[string]interface{}   `yaml:"gateway"`
+	ResourceProvider     map[string]interface{}   `yaml:"resource_provider,omitempty"`
 	Git                  map[string]interface{}   `yaml:"git,omitempty"`
 	LocalMounts          map[string]interface{}   `yaml:"local_mounts,omitempty"`
 	SessionContributors  []map[string]interface{} `yaml:"session_contributors,omitempty"`
@@ -1028,10 +1029,20 @@ func (r *K3sRuntime) generateK3sConfig(cfg *config.Config) (string, error) {
 		}
 	}
 
+	// Wire up resource provider — use K8sResourceProvider for real cluster data.
+	apiCfg.ResourceProvider = map[string]interface{}{
+		"adapter": "volundr.adapters.outbound.k8s_resource_provider.K8sResourceProvider",
+		"kwargs": map[string]interface{}{
+			"namespace":  namespace,
+			"kubeconfig": containerKubeconfigPath,
+		},
+	}
+
 	// Wire up session contributors.
 	// LocalMountContributor is auto-wired by Python main.py from local_mounts config.
 	apiCfg.SessionContributors = []map[string]interface{}{
 		{"adapter": "volundr.adapters.outbound.contributors.git.GitContributor"},
+		{"adapter": "volundr.adapters.outbound.contributors.resource.ResourceContributor"},
 	}
 
 	data, err := yaml.Marshal(&apiCfg)

--- a/src/volundr/adapters/inbound/rest.py
+++ b/src/volundr/adapters/inbound/rest.py
@@ -59,6 +59,7 @@ class SessionCreate(BaseModel):
     terminal_restricted: bool = Field(default=False)
     credential_names: list[str] = Field(default_factory=list)
     integration_ids: list[str] = Field(default_factory=list)
+    resource_config: dict = Field(default_factory=dict)
 
 
 class SessionUpdate(BaseModel):
@@ -630,6 +631,7 @@ def create_router(
                 terminal_restricted=data.terminal_restricted,
                 credential_names=data.credential_names,
                 integration_ids=data.integration_ids,
+                resource_config=data.resource_config or None,
             )
             return SessionResponse.from_session(started)
         except SessionStateError as e:

--- a/src/volundr/adapters/inbound/rest_resources.py
+++ b/src/volundr/adapters/inbound/rest_resources.py
@@ -1,0 +1,77 @@
+"""REST endpoint for cluster resource discovery."""
+
+import logging
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel, Field
+
+from volundr.domain.ports import ResourceProvider
+
+logger = logging.getLogger(__name__)
+
+
+class ResourceTypeResponse(BaseModel):
+    """A discoverable resource type."""
+
+    name: str
+    resource_key: str
+    display_name: str
+    unit: str
+    category: str
+
+
+class NodeResourceSummaryResponse(BaseModel):
+    """Resource availability for a node."""
+
+    name: str
+    labels: dict[str, str] = Field(default_factory=dict)
+    allocatable: dict[str, str] = Field(default_factory=dict)
+    allocated: dict[str, str] = Field(default_factory=dict)
+    available: dict[str, str] = Field(default_factory=dict)
+
+
+class ClusterResourceInfoResponse(BaseModel):
+    """Cluster resource discovery response."""
+
+    resource_types: list[ResourceTypeResponse] = Field(default_factory=list)
+    nodes: list[NodeResourceSummaryResponse] = Field(default_factory=list)
+
+
+def create_resources_router(
+    resource_provider: ResourceProvider,
+) -> APIRouter:
+    """Create the resources REST router."""
+
+    router = APIRouter(prefix="/api/v1/volundr", tags=["Resources"])
+
+    @router.get(
+        "/resources",
+        response_model=ClusterResourceInfoResponse,
+    )
+    async def get_cluster_resources(request: Request) -> ClusterResourceInfoResponse:
+        """Discover available cluster resource types and capacity."""
+        info = await resource_provider.discover()
+        return ClusterResourceInfoResponse(
+            resource_types=[
+                ResourceTypeResponse(
+                    name=rt.name,
+                    resource_key=rt.resource_key,
+                    display_name=rt.display_name,
+                    unit=rt.unit,
+                    category=rt.category.value,
+                )
+                for rt in info.resource_types
+            ],
+            nodes=[
+                NodeResourceSummaryResponse(
+                    name=n.name,
+                    labels=n.labels,
+                    allocatable=n.allocatable,
+                    allocated=n.allocated,
+                    available=n.available,
+                )
+                for n in info.nodes
+            ],
+        )
+
+    return router

--- a/src/volundr/adapters/outbound/contributors/resource.py
+++ b/src/volundr/adapters/outbound/contributors/resource.py
@@ -1,0 +1,88 @@
+"""Resource contributor — translates user-friendly resource config to K8s primitives."""
+
+import logging
+from typing import Any
+
+from volundr.domain.models import Session
+from volundr.domain.ports import (
+    ResourceProvider,
+    SessionContext,
+    SessionContribution,
+    SessionContributor,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ResourceContributor(SessionContributor):
+    """Translates ad-hoc resource config into K8s-native Helm values.
+
+    Reads ``resource_config`` from the SessionContext (user launch request)
+    and calls ResourceProvider.translate() to produce K8s-native values.
+    Template/profile resource configs are already K8s-native and pass through
+    directly via TemplateContributor.
+    """
+
+    def __init__(
+        self,
+        *,
+        resource_provider: ResourceProvider | None = None,
+        **_extra: object,
+    ) -> None:
+        self._resource_provider = resource_provider
+
+    @property
+    def name(self) -> str:
+        return "resource"
+
+    async def contribute(
+        self,
+        session: Session,
+        context: SessionContext,
+    ) -> SessionContribution:
+        if self._resource_provider is None:
+            return SessionContribution()
+
+        # Ad-hoc resource config from the launch request takes priority
+        resource_config = context.resource_config
+        if not resource_config:
+            return SessionContribution()
+
+        # Validate
+        errors = self._resource_provider.validate(resource_config)
+        if errors:
+            logger.warning(
+                "Resource validation warnings for session %s: %s",
+                session.id,
+                "; ".join(errors),
+            )
+
+        # Translate to K8s primitives
+        translated = self._resource_provider.translate(resource_config)
+
+        values: dict[str, Any] = {}
+
+        if translated.requests or translated.limits:
+            values["resources"] = {}
+            if translated.requests:
+                values["resources"]["requests"] = translated.requests
+            if translated.limits:
+                values["resources"]["limits"] = translated.limits
+
+        if translated.node_selector:
+            values["nodeSelector"] = translated.node_selector
+
+        if translated.tolerations:
+            values["tolerations"] = translated.tolerations
+
+        if translated.runtime_class_name:
+            values["runtimeClassName"] = translated.runtime_class_name
+
+        if values:
+            logger.info(
+                "Resource contributor: session %s → %s",
+                session.id,
+                {k: v for k, v in values.items() if k != "resources"},
+            )
+
+        return SessionContribution(values=values)

--- a/src/volundr/adapters/outbound/contributors/resource.py
+++ b/src/volundr/adapters/outbound/contributors/resource.py
@@ -62,13 +62,46 @@ class ResourceContributor(SessionContributor):
 
         values: dict[str, Any] = {}
 
-        if translated.requests or translated.limits:
-            values["resources"] = {}
-            if translated.requests:
-                values["resources"]["requests"] = translated.requests
-            if translated.limits:
-                values["resources"]["limits"] = translated.limits
+        # Build per-container resource overrides matching the Helm chart layout.
+        # CPU/memory requests+limits go to the workload containers (devrunner
+        # gets the full user budget, code-server and skuld keep defaults).
+        # GPU limits always go to devrunner; when gpu_timeslice is enabled,
+        # GPU limits are also set on skuld so both containers share the GPU
+        # via NVIDIA time-slicing.
+        gpu_timeslice = str(resource_config.get("gpu_timeslice", "")).lower() == "true"
 
+        if translated.requests or translated.limits:
+            # Separate CPU/memory from accelerator resources (GPU)
+            cpu_mem_requests = {
+                k: v for k, v in translated.requests.items() if k in ("cpu", "memory")
+            }
+            cpu_mem_limits = {k: v for k, v in translated.limits.items() if k in ("cpu", "memory")}
+            gpu_limits = {k: v for k, v in translated.limits.items() if k not in ("cpu", "memory")}
+
+            # Devrunner always gets user-specified CPU/memory + GPU
+            devrunner_resources: dict[str, Any] = {}
+            if cpu_mem_requests:
+                devrunner_resources["requests"] = cpu_mem_requests
+            if cpu_mem_limits or gpu_limits:
+                devrunner_resources["limits"] = {**cpu_mem_limits, **gpu_limits}
+            if devrunner_resources:
+                values.setdefault("localServices", {}).setdefault("devrunner", {})["resources"] = (
+                    devrunner_resources
+                )
+
+            # Top-level "resources" key (skuld broker)
+            skuld_limits = dict(cpu_mem_limits)
+            if gpu_timeslice and gpu_limits:
+                skuld_limits.update(gpu_limits)
+
+            if cpu_mem_requests or skuld_limits:
+                values["resources"] = {}
+                if cpu_mem_requests:
+                    values["resources"]["requests"] = cpu_mem_requests
+                if skuld_limits:
+                    values["resources"]["limits"] = skuld_limits
+
+        # Pod-level scheduling constraints
         if translated.node_selector:
             values["nodeSelector"] = translated.node_selector
 
@@ -82,7 +115,7 @@ class ResourceContributor(SessionContributor):
             logger.info(
                 "Resource contributor: session %s → %s",
                 session.id,
-                {k: v for k, v in values.items() if k != "resources"},
+                {k: v for k, v in values.items() if k not in ("resources", "localServices")},
             )
 
         return SessionContribution(values=values)

--- a/src/volundr/adapters/outbound/contributors/resource.py
+++ b/src/volundr/adapters/outbound/contributors/resource.py
@@ -81,7 +81,7 @@ class ResourceContributor(SessionContributor):
             # Devrunner always gets user-specified CPU/memory + GPU
             devrunner_resources: dict[str, Any] = {}
             if cpu_mem_requests:
-                devrunner_resources["requests"] = cpu_mem_requests
+                devrunner_resources["requests"] = dict(cpu_mem_requests)
             if cpu_mem_limits or gpu_limits:
                 devrunner_resources["limits"] = {**cpu_mem_limits, **gpu_limits}
             if devrunner_resources:

--- a/src/volundr/adapters/outbound/contributors/template.py
+++ b/src/volundr/adapters/outbound/contributors/template.py
@@ -75,7 +75,13 @@ class TemplateContributor(SessionContributor):
 
     @staticmethod
     def _apply(values: dict, source: WorkspaceTemplate | ForgeProfile) -> None:
-        """Merge runtime config from template or profile into values."""
+        """Merge runtime config from template or profile into values.
+
+        Template/profile resource configs are already in K8s-native format
+        (e.g. ``{"requests": {"cpu": "100m"}}``), so they pass through directly
+        as ``resources``.  Ad-hoc user configs from the launch request are
+        translated by ``ResourceContributor`` via the ``SessionContext``.
+        """
         if source.resource_config:
             values["resources"] = source.resource_config
         if source.env_vars:

--- a/src/volundr/adapters/outbound/direct_k8s_pod_manager.py
+++ b/src/volundr/adapters/outbound/direct_k8s_pod_manager.py
@@ -451,6 +451,127 @@ fi
         base_mounts = [{"name": "workspace", "mountPath": "/volundr"}]
         workload_mounts = base_mounts + extra_mounts
 
+        # Extract resource overrides from contributor spec values.
+        # These mirror the Helm chart values layout set by ResourceContributor.
+        skuld_resources = spec.values.get("resources", {})
+        devrunner_resources = (
+            spec.values.get("localServices", {}).get("devrunner", {}).get("resources", {})
+        )
+
+        # Default resources per container — overridden by user-specified values.
+        nginx_res = {
+            "requests": {"memory": "32Mi", "cpu": "10m"},
+            "limits": {"memory": "128Mi", "cpu": "100m"},
+        }
+        skuld_res = {
+            "requests": {"memory": "256Mi", "cpu": "100m"},
+            "limits": {"memory": "1Gi", "cpu": "500m"},
+        }
+        code_server_res = {
+            "requests": {"memory": "256Mi", "cpu": "100m"},
+            "limits": {"memory": "2Gi", "cpu": "1000m"},
+        }
+        devrunner_res = {
+            "requests": {"memory": "512Mi", "cpu": "100m"},
+            "limits": {"memory": "4Gi", "cpu": "2000m"},
+        }
+
+        # Apply user-specified skuld overrides
+        if skuld_resources.get("requests"):
+            skuld_res["requests"].update(skuld_resources["requests"])
+        if skuld_resources.get("limits"):
+            skuld_res["limits"].update(skuld_resources["limits"])
+
+        # Apply user-specified devrunner overrides (CPU, memory, GPU)
+        if devrunner_resources.get("requests"):
+            devrunner_res["requests"].update(devrunner_resources["requests"])
+        if devrunner_resources.get("limits"):
+            devrunner_res["limits"].update(devrunner_resources["limits"])
+
+        # Pod-level scheduling from contributor values
+        node_selector = spec.values.get("nodeSelector", {})
+        tolerations = spec.values.get("tolerations", [])
+        runtime_class_name = spec.values.get("runtimeClassName")
+
+        pod_spec: dict[str, Any] = {
+            "hostname": session.name,
+            "terminationGracePeriodSeconds": 30,
+            "securityContext": {
+                "fsGroup": 1000,
+            },
+            "initContainers": self._build_init_containers(session, spec),
+            "volumes": volumes,
+            "containers": [
+                {
+                    "name": "nginx",
+                    "image": self._nginx_image,
+                    "ports": [{"containerPort": SESSION_SERVICE_PORT, "name": "http"}],
+                    "volumeMounts": [
+                        {
+                            "name": "nginx-config",
+                            "mountPath": "/etc/nginx/nginx.conf",
+                            "subPath": "nginx.conf",
+                            "readOnly": True,
+                        },
+                        {"name": "workspace", "mountPath": "/volundr"},
+                    ],
+                    "resources": nginx_res,
+                },
+                {
+                    "name": "skuld",
+                    "image": self._skuld_image,
+                    "ports": [{"containerPort": 8081, "name": "broker"}],
+                    "env": env_vars,
+                    "securityContext": {
+                        "runAsUser": 1000,
+                        "allowPrivilegeEscalation": False,
+                    },
+                    "volumeMounts": workload_mounts,
+                    "resources": skuld_res,
+                },
+                {
+                    "name": "code-server",
+                    "image": self._code_server_image,
+                    "ports": [{"containerPort": 8443, "name": "ide"}],
+                    "command": ["dumb-init", "--", "/usr/bin/code-server"],
+                    "args": [
+                        "--bind-addr=0.0.0.0:8443",
+                        "--auth=none",
+                        "--disable-telemetry",
+                        f"/volundr/sessions/{session.id}/workspace",
+                    ],
+                    "securityContext": {
+                        "runAsUser": 1000,
+                        "allowPrivilegeEscalation": False,
+                    },
+                    "volumeMounts": workload_mounts,
+                    "resources": code_server_res,
+                },
+                {
+                    "name": "devrunner",
+                    "image": self._devrunner_image,
+                    "env": [
+                        {"name": "SESSION_ID", "value": str(session.id)},
+                        {"name": "TERMINAL_PORT", "value": "7681"},
+                        {"name": "HOME", "value": "/volundr/home"},
+                    ],
+                    "securityContext": {
+                        "runAsUser": 1000,
+                        "allowPrivilegeEscalation": False,
+                    },
+                    "volumeMounts": workload_mounts,
+                    "resources": devrunner_res,
+                },
+            ],
+        }
+
+        if node_selector:
+            pod_spec["nodeSelector"] = node_selector
+        if tolerations:
+            pod_spec["tolerations"] = tolerations
+        if runtime_class_name:
+            pod_spec["runtimeClassName"] = runtime_class_name
+
         return {
             "apiVersion": "apps/v1",
             "kind": "Deployment",
@@ -468,89 +589,7 @@ fi
                 },
                 "template": {
                     "metadata": {"labels": labels},
-                    "spec": {
-                        "hostname": session.name,
-                        "terminationGracePeriodSeconds": 30,
-                        "securityContext": {
-                            "fsGroup": 1000,
-                        },
-                        "initContainers": self._build_init_containers(session, spec),
-                        "volumes": volumes,
-                        "containers": [
-                            {
-                                "name": "nginx",
-                                "image": self._nginx_image,
-                                "ports": [{"containerPort": SESSION_SERVICE_PORT, "name": "http"}],
-                                "volumeMounts": [
-                                    {
-                                        "name": "nginx-config",
-                                        "mountPath": "/etc/nginx/nginx.conf",
-                                        "subPath": "nginx.conf",
-                                        "readOnly": True,
-                                    },
-                                    {"name": "workspace", "mountPath": "/volundr"},
-                                ],
-                                "resources": {
-                                    "requests": {"memory": "32Mi", "cpu": "10m"},
-                                    "limits": {"memory": "128Mi", "cpu": "100m"},
-                                },
-                            },
-                            {
-                                "name": "skuld",
-                                "image": self._skuld_image,
-                                "ports": [{"containerPort": 8081, "name": "broker"}],
-                                "env": env_vars,
-                                "securityContext": {
-                                    "runAsUser": 1000,
-                                    "allowPrivilegeEscalation": False,
-                                },
-                                "volumeMounts": workload_mounts,
-                                "resources": {
-                                    "requests": {"memory": "256Mi", "cpu": "100m"},
-                                    "limits": {"memory": "1Gi", "cpu": "500m"},
-                                },
-                            },
-                            {
-                                "name": "code-server",
-                                "image": self._code_server_image,
-                                "ports": [{"containerPort": 8443, "name": "ide"}],
-                                "command": ["dumb-init", "--", "/usr/bin/code-server"],
-                                "args": [
-                                    "--bind-addr=0.0.0.0:8443",
-                                    "--auth=none",
-                                    "--disable-telemetry",
-                                    f"/volundr/sessions/{session.id}/workspace",
-                                ],
-                                "securityContext": {
-                                    "runAsUser": 1000,
-                                    "allowPrivilegeEscalation": False,
-                                },
-                                "volumeMounts": workload_mounts,
-                                "resources": {
-                                    "requests": {"memory": "256Mi", "cpu": "100m"},
-                                    "limits": {"memory": "2Gi", "cpu": "1000m"},
-                                },
-                            },
-                            {
-                                "name": "devrunner",
-                                "image": self._devrunner_image,
-                                "env": [
-                                    {"name": "SESSION_ID", "value": str(session.id)},
-                                    {"name": "TERMINAL_PORT", "value": "7681"},
-                                    {"name": "HOME", "value": "/volundr/home"},
-                                ],
-                                "securityContext": {
-                                    "runAsUser": 1000,
-                                    "allowPrivilegeEscalation": False,
-                                },
-                                "volumeMounts": workload_mounts,
-                                "resources": {
-                                    "requests": {"memory": "512Mi", "cpu": "100m"},
-                                    "limits": {"memory": "4Gi", "cpu": "2000m"},
-                                },
-                            },
-                        ],
-                    },
+                    "spec": pod_spec,
                 },
             },
         }

--- a/src/volundr/adapters/outbound/k8s_resource_provider.py
+++ b/src/volundr/adapters/outbound/k8s_resource_provider.py
@@ -1,0 +1,125 @@
+"""Kubernetes resource provider — discovers cluster resources via K8s API."""
+
+import logging
+
+from volundr.domain.models import (
+    ClusterResourceInfo,
+    NodeResourceSummary,
+    ResourceCategory,
+    ResourceType,
+    TranslatedResources,
+)
+from volundr.domain.ports import ResourceProvider
+
+from .static_resource_provider import (
+    STANDARD_RESOURCE_TYPES,
+    translate_resource_config,
+    validate_resource_config,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class K8sResourceProvider(ResourceProvider):
+    """Resource provider that queries the Kubernetes API for node capacity.
+
+    Uses the device-plugin model (v1.30). The interface is designed so a
+    DRA-backed adapter can be swapped in for v1.31+ without changing callers.
+    """
+
+    def __init__(self, *, namespace: str = "volundr-sessions", **_extra: object) -> None:
+        self._namespace = namespace
+
+    async def discover(self) -> ClusterResourceInfo:
+        """List nodes, extract GPU labels/allocatable, build ClusterResourceInfo."""
+        try:
+            from kubernetes_asyncio import client, config
+
+            await config.load_incluster_config()
+            v1 = client.CoreV1Api()
+            nodes_resp = await v1.list_node()
+        except Exception:
+            logger.warning(
+                "Failed to query K8s API for node resources, falling back to static types",
+                exc_info=True,
+            )
+            return ClusterResourceInfo(
+                resource_types=list(STANDARD_RESOURCE_TYPES),
+                nodes=[],
+            )
+
+        resource_types = list(STANDARD_RESOURCE_TYPES)
+        seen_gpu_products: set[str] = set()
+        nodes: list[NodeResourceSummary] = []
+
+        for node in nodes_resp.items:
+            labels = node.metadata.labels or {}
+            allocatable = {k: str(v) for k, v in (node.status.allocatable or {}).items()}
+
+            # Discover GPU product types from node labels
+            gpu_product = labels.get("nvidia.com/gpu.product")
+            if gpu_product and gpu_product not in seen_gpu_products:
+                seen_gpu_products.add(gpu_product)
+
+            nodes.append(
+                NodeResourceSummary(
+                    name=node.metadata.name,
+                    labels=labels,
+                    allocatable=allocatable,
+                    allocated={},  # Would require metrics-server to compute
+                    available=allocatable,  # Approximate
+                )
+            )
+
+        # Add discovered GPU types as resource types
+        for product in sorted(seen_gpu_products):
+            resource_types.append(
+                ResourceType(
+                    name=f"gpu_{product.lower().replace(' ', '_')}",
+                    resource_key="nvidia.com/gpu",
+                    display_name=f"GPU ({product})",
+                    unit="devices",
+                    category=ResourceCategory.ACCELERATOR,
+                )
+            )
+
+        return ClusterResourceInfo(resource_types=resource_types, nodes=nodes)
+
+    def translate(self, resource_config: dict) -> TranslatedResources:
+        return translate_resource_config(resource_config)
+
+    def validate(
+        self,
+        resource_config: dict,
+        cluster_info: ClusterResourceInfo | None = None,
+    ) -> list[str]:
+        errors = validate_resource_config(resource_config)
+
+        if not cluster_info or not resource_config.get("gpu"):
+            return errors
+
+        # Check GPU availability across nodes
+        gpu_count = int(resource_config.get("gpu", 0))
+        gpu_type = resource_config.get("gpu_type")
+
+        any_gpu_node = False
+        for node in cluster_info.nodes:
+            node_gpus = int(node.allocatable.get("nvidia.com/gpu", "0"))
+            if node_gpus == 0:
+                continue
+            any_gpu_node = True
+            if gpu_type:
+                node_product = node.labels.get("nvidia.com/gpu.product", "")
+                if node_product != gpu_type:
+                    continue
+            if node_gpus >= gpu_count:
+                return errors  # Found a suitable node
+
+        if not any_gpu_node:
+            errors.append("no GPU nodes available in the cluster")
+        elif gpu_type:
+            errors.append(f"no nodes with GPU type '{gpu_type}' have {gpu_count} available GPUs")
+        else:
+            errors.append(f"no single node has {gpu_count} available GPUs")
+
+        return errors

--- a/src/volundr/adapters/outbound/k8s_resource_provider.py
+++ b/src/volundr/adapters/outbound/k8s_resource_provider.py
@@ -19,6 +19,51 @@ from .static_resource_provider import (
 
 logger = logging.getLogger(__name__)
 
+# Mapping of well-known K8s resource keys to display metadata
+_WELL_KNOWN_RESOURCES: dict[str, tuple[str, str, ResourceCategory]] = {
+    "ephemeral-storage": ("Ephemeral Storage", "bytes", ResourceCategory.COMPUTE),
+    "pods": ("Pods", "pods", ResourceCategory.COMPUTE),
+}
+
+
+def _resource_type_from_key(key: str) -> ResourceType:
+    """Build a ResourceType from an allocatable key."""
+    if key in _WELL_KNOWN_RESOURCES:
+        display, unit, category = _WELL_KNOWN_RESOURCES[key]
+        return ResourceType(
+            name=key.replace("/", "_").replace(".", "_"),
+            resource_key=key,
+            display_name=display,
+            unit=unit,
+            category=category,
+        )
+
+    # Vendor-prefixed resources (e.g. "nvidia.com/gpu") → accelerator
+    if "/" in key:
+        category = ResourceCategory.ACCELERATOR
+    else:
+        category = ResourceCategory.COMPUTE
+
+    # Derive a human-readable display name from the key
+    short = key.rsplit("/", 1)[-1]
+    display_name = short.replace("-", " ").replace("_", " ").title()
+
+    # Guess unit from name
+    if "storage" in key or "memory" in key:
+        unit = "bytes"
+    elif "gpu" in key:
+        unit = "devices"
+    else:
+        unit = ""
+
+    return ResourceType(
+        name=key.replace("/", "_").replace(".", "_"),
+        resource_key=key,
+        display_name=display_name,
+        unit=unit,
+        category=category,
+    )
+
 
 class K8sResourceProvider(ResourceProvider):
     """Resource provider that queries the Kubernetes API for node capacity.
@@ -27,15 +72,24 @@ class K8sResourceProvider(ResourceProvider):
     DRA-backed adapter can be swapped in for v1.31+ without changing callers.
     """
 
-    def __init__(self, *, namespace: str = "volundr-sessions", **_extra: object) -> None:
+    def __init__(
+        self, *, namespace: str = "volundr-sessions", kubeconfig: str = "", **_extra: object
+    ) -> None:
         self._namespace = namespace
+        self._kubeconfig = kubeconfig
 
     async def discover(self) -> ClusterResourceInfo:
         """List nodes, extract GPU labels/allocatable, build ClusterResourceInfo."""
         try:
             from kubernetes_asyncio import client, config
 
-            await config.load_incluster_config()
+            if self._kubeconfig:
+                await config.load_kube_config(config_file=self._kubeconfig)
+            else:
+                try:
+                    await config.load_incluster_config()
+                except config.ConfigException:
+                    await config.load_kube_config()
             v1 = client.CoreV1Api()
             nodes_resp = await v1.list_node()
         except Exception:
@@ -48,13 +102,16 @@ class K8sResourceProvider(ResourceProvider):
                 nodes=[],
             )
 
-        resource_types = list(STANDARD_RESOURCE_TYPES)
         seen_gpu_products: set[str] = set()
+        seen_resource_keys: set[str] = set()
         nodes: list[NodeResourceSummary] = []
 
         for node in nodes_resp.items:
             labels = node.metadata.labels or {}
             allocatable = {k: str(v) for k, v in (node.status.allocatable or {}).items()}
+
+            # Track all resource keys across nodes
+            seen_resource_keys.update(allocatable.keys())
 
             # Discover GPU product types from node labels
             gpu_product = labels.get("nvidia.com/gpu.product")
@@ -71,7 +128,11 @@ class K8sResourceProvider(ResourceProvider):
                 )
             )
 
-        # Add discovered GPU types as resource types
+        # Build resource types dynamically from what nodes actually report
+        resource_types = list(STANDARD_RESOURCE_TYPES)
+        standard_keys = {rt.resource_key for rt in STANDARD_RESOURCE_TYPES}
+
+        # Add discovered GPU product variants
         for product in sorted(seen_gpu_products):
             resource_types.append(
                 ResourceType(
@@ -82,6 +143,18 @@ class K8sResourceProvider(ResourceProvider):
                     category=ResourceCategory.ACCELERATOR,
                 )
             )
+
+        # Add any node-reported resources not covered by standard types
+        # Skip keys that are not useful as requestable session resources
+        ignored_keys = {"pods"}
+        for key in sorted(seen_resource_keys - standard_keys - ignored_keys):
+            # Skip hugepages with zero value across all nodes
+            if key.startswith("hugepages-"):
+                all_zero = all((int(node.allocatable.get(key, "0") or "0") == 0) for node in nodes)
+                if all_zero:
+                    continue
+
+            resource_types.append(_resource_type_from_key(key))
 
         return ClusterResourceInfo(resource_types=resource_types, nodes=nodes)
 

--- a/src/volundr/adapters/outbound/static_resource_provider.py
+++ b/src/volundr/adapters/outbound/static_resource_provider.py
@@ -1,0 +1,153 @@
+"""Static resource provider for dev/test environments."""
+
+from volundr.domain.models import (
+    ClusterResourceInfo,
+    ResourceCategory,
+    ResourceType,
+    TranslatedResources,
+)
+from volundr.domain.ports import ResourceProvider
+
+# Standard resource types always available
+STANDARD_RESOURCE_TYPES = [
+    ResourceType(
+        name="cpu",
+        resource_key="cpu",
+        display_name="CPU",
+        unit="cores",
+        category=ResourceCategory.COMPUTE,
+    ),
+    ResourceType(
+        name="memory",
+        resource_key="memory",
+        display_name="Memory",
+        unit="bytes",
+        category=ResourceCategory.COMPUTE,
+    ),
+    ResourceType(
+        name="gpu",
+        resource_key="nvidia.com/gpu",
+        display_name="GPU",
+        unit="devices",
+        category=ResourceCategory.ACCELERATOR,
+    ),
+]
+
+# Default GPU toleration for NVIDIA device plugin nodes
+_GPU_TOLERATION = {
+    "key": "nvidia.com/gpu",
+    "operator": "Exists",
+    "effect": "NoSchedule",
+}
+
+# Default runtime class for GPU workloads
+_GPU_RUNTIME_CLASS = "nvidia"
+
+
+class StaticResourceProvider(ResourceProvider):
+    """Resource provider returning hardcoded types without cluster access.
+
+    Translation still works correctly — only cluster-aware validation
+    and discovery are stubbed.
+    """
+
+    def __init__(self, **_extra: object) -> None:
+        pass
+
+    async def discover(self) -> ClusterResourceInfo:
+        return ClusterResourceInfo(
+            resource_types=list(STANDARD_RESOURCE_TYPES),
+            nodes=[],
+        )
+
+    def translate(self, resource_config: dict) -> TranslatedResources:
+        return translate_resource_config(resource_config)
+
+    def validate(
+        self,
+        resource_config: dict,
+        cluster_info: ClusterResourceInfo | None = None,
+    ) -> list[str]:
+        return validate_resource_config(resource_config)
+
+
+def translate_resource_config(resource_config: dict) -> TranslatedResources:
+    """Translate user-friendly resource config to K8s-native primitives.
+
+    Shared logic used by both Static and K8s providers.
+    """
+    if not resource_config:
+        return TranslatedResources()
+
+    requests: dict[str, str] = {}
+    limits: dict[str, str] = {}
+    node_selector: dict[str, str] = {}
+    tolerations: list[dict] = []
+    runtime_class_name: str | None = None
+
+    # CPU
+    cpu = resource_config.get("cpu")
+    if cpu:
+        requests["cpu"] = str(cpu)
+        limits["cpu"] = str(cpu)
+
+    # Memory
+    memory = resource_config.get("memory")
+    if memory:
+        requests["memory"] = str(memory)
+        limits["memory"] = str(memory)
+
+    # GPU
+    gpu = resource_config.get("gpu")
+    if gpu and str(gpu) != "0":
+        limits["nvidia.com/gpu"] = str(gpu)
+        tolerations.append(_GPU_TOLERATION)
+        runtime_class_name = _GPU_RUNTIME_CLASS
+
+    # GPU type → node selector
+    gpu_type = resource_config.get("gpu_type")
+    if gpu_type:
+        node_selector["nvidia.com/gpu.product"] = str(gpu_type)
+
+    return TranslatedResources(
+        requests=requests,
+        limits=limits,
+        node_selector=node_selector,
+        tolerations=tolerations,
+        runtime_class_name=runtime_class_name,
+    )
+
+
+def validate_resource_config(resource_config: dict) -> list[str]:
+    """Basic validation of resource config values."""
+    errors: list[str] = []
+
+    cpu = resource_config.get("cpu")
+    if cpu is not None:
+        try:
+            val = float(cpu)
+            if val <= 0:
+                errors.append("cpu must be positive")
+        except (ValueError, TypeError):
+            errors.append(f"invalid cpu value: {cpu}")
+
+    memory = resource_config.get("memory")
+    if memory is not None:
+        mem_str = str(memory)
+        if mem_str and not any(mem_str.endswith(s) for s in ("Ki", "Mi", "Gi", "Ti")):
+            # Allow plain numbers (bytes) or K8s suffixes
+            try:
+                float(mem_str)
+            except (ValueError, TypeError):
+                errors.append(f"invalid memory value: {memory} (use Ki, Mi, Gi, or Ti suffix)")
+
+    gpu = resource_config.get("gpu")
+    if gpu is not None:
+        try:
+            val = int(gpu)
+            if val < 0:
+                errors.append("gpu must be non-negative")
+        except (ValueError, TypeError):
+            errors.append(f"invalid gpu value: {gpu} (must be integer)")
+
+    return errors

--- a/src/volundr/adapters/outbound/static_resource_provider.py
+++ b/src/volundr/adapters/outbound/static_resource_provider.py
@@ -8,7 +8,8 @@ from volundr.domain.models import (
 )
 from volundr.domain.ports import ResourceProvider
 
-# Standard resource types always available
+# Standard resource types always available (CPU + Memory only;
+# GPU and other resources are discovered dynamically from node data)
 STANDARD_RESOURCE_TYPES = [
     ResourceType(
         name="cpu",
@@ -23,13 +24,6 @@ STANDARD_RESOURCE_TYPES = [
         display_name="Memory",
         unit="bytes",
         category=ResourceCategory.COMPUTE,
-    ),
-    ResourceType(
-        name="gpu",
-        resource_key="nvidia.com/gpu",
-        display_name="GPU",
-        unit="devices",
-        category=ResourceCategory.ACCELERATOR,
     ),
 ]
 

--- a/src/volundr/config.py
+++ b/src/volundr/config.py
@@ -480,6 +480,34 @@ class SecretInjectionConfig(BaseModel):
     )
 
 
+class ResourceProviderConfig(BaseModel):
+    """Dynamic resource provider adapter configuration.
+
+    The ``adapter`` key is a fully-qualified class path.  All other
+    fields in ``kwargs`` are forwarded to the constructor.
+
+    Example YAML::
+
+        resource_provider:
+          adapter: "volundr.adapters.outbound.k8s_resource_provider.K8sResourceProvider"
+          kwargs:
+            namespace: "volundr-sessions"
+    """
+
+    adapter: str = Field(
+        default="volundr.adapters.outbound.static_resource_provider.StaticResourceProvider",
+        description="Fully-qualified class path for the ResourceProvider adapter.",
+    )
+    kwargs: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Extra kwargs forwarded to the adapter constructor.",
+    )
+    secret_kwargs_env: dict[str, str] = Field(
+        default_factory=dict,
+        description="Mapping of kwarg names to env var names holding secret values.",
+    )
+
+
 class StorageConfig(BaseModel):
     """Dynamic storage adapter configuration.
 
@@ -731,6 +759,7 @@ class Settings(BaseSettings):
     credential_store: CredentialStoreConfig = Field(default_factory=CredentialStoreConfig)
     gateway: GatewayConfig = Field(default_factory=GatewayConfig)
     secret_injection: SecretInjectionConfig = Field(default_factory=SecretInjectionConfig)
+    resource_provider: ResourceProviderConfig = Field(default_factory=ResourceProviderConfig)
     storage: StorageConfig = Field(default_factory=StorageConfig)
     linear: LinearConfig = Field(default_factory=LinearConfig)
     auth_discovery: AuthDiscoveryConfig = Field(default_factory=AuthDiscoveryConfig)

--- a/src/volundr/domain/models.py
+++ b/src/volundr/domain/models.py
@@ -952,6 +952,55 @@ class WorkspaceTemplate(BaseModel):
     model_config = {"frozen": False}
 
 
+class ResourceCategory(StrEnum):
+    """Category of a resource type."""
+
+    COMPUTE = "compute"
+    ACCELERATOR = "accelerator"
+    CUSTOM = "custom"
+
+
+@dataclass(frozen=True)
+class ResourceType:
+    """A discoverable resource type available in the cluster."""
+
+    name: str
+    resource_key: str  # K8s resource key, e.g. "nvidia.com/gpu"
+    display_name: str
+    unit: str
+    category: ResourceCategory = ResourceCategory.COMPUTE
+
+
+@dataclass(frozen=True)
+class NodeResourceSummary:
+    """Resource availability summary for a single node."""
+
+    name: str
+    labels: dict[str, str] = field(default_factory=dict)
+    allocatable: dict[str, str] = field(default_factory=dict)
+    allocated: dict[str, str] = field(default_factory=dict)
+    available: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ClusterResourceInfo:
+    """Discovered cluster resource types and capacity."""
+
+    resource_types: list[ResourceType] = field(default_factory=list)
+    nodes: list[NodeResourceSummary] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class TranslatedResources:
+    """K8s-native resource specification translated from user-friendly config."""
+
+    requests: dict[str, str] = field(default_factory=dict)
+    limits: dict[str, str] = field(default_factory=dict)
+    node_selector: dict[str, str] = field(default_factory=dict)
+    tolerations: list[dict] = field(default_factory=list)
+    runtime_class_name: str | None = None
+
+
 @dataclass
 class SessionSpec:
     """Merged result from all contributors."""

--- a/src/volundr/domain/ports.py
+++ b/src/volundr/domain/ports.py
@@ -16,6 +16,7 @@ from uuid import UUID
 from volundr.domain.models import (
     Chronicle,
     CIStatus,
+    ClusterResourceInfo,
     ForgeProfile,
     GitProviderType,
     IntegrationConnection,
@@ -50,6 +51,7 @@ from volundr.domain.models import (
     TokenUsageRecord,
     TrackerConnectionStatus,
     TrackerIssue,
+    TranslatedResources,
     User,
     Workspace,
     WorkspaceStatus,
@@ -1367,6 +1369,46 @@ class SecretInjectionPort(ABC):
         ...
 
 
+class ResourceProvider(ABC):
+    """Port for discovering, validating, and translating cluster resources.
+
+    Adapters may query the K8s API (device-plugin or DRA) or return
+    static resource types for dev/test environments.
+    """
+
+    @abstractmethod
+    async def discover(self) -> ClusterResourceInfo:
+        """Discover available resource types and cluster capacity."""
+        ...
+
+    @abstractmethod
+    def translate(self, resource_config: dict) -> TranslatedResources:
+        """Translate user-friendly resource config to K8s-native primitives.
+
+        Args:
+            resource_config: User-friendly format, e.g.
+                {"cpu": "4", "memory": "8Gi", "gpu": "1", "gpu_type": "A100"}
+
+        Returns:
+            TranslatedResources with requests, limits, nodeSelector,
+            tolerations, and runtimeClassName.
+        """
+        ...
+
+    @abstractmethod
+    def validate(
+        self,
+        resource_config: dict,
+        cluster_info: ClusterResourceInfo | None = None,
+    ) -> list[str]:
+        """Validate resource config, optionally against cluster capacity.
+
+        Returns:
+            List of validation error messages (empty = valid).
+        """
+        ...
+
+
 @dataclass(frozen=True)
 class SessionContext:
     """Read-only context for contributors."""
@@ -1378,6 +1420,7 @@ class SessionContext:
     credential_names: tuple[str, ...] = ()
     integration_ids: tuple[str, ...] = ()
     integration_connections: tuple[IntegrationConnection, ...] = ()
+    resource_config: dict = field(default_factory=dict)
 
 
 @dataclass(frozen=True)

--- a/src/volundr/domain/services/session.py
+++ b/src/volundr/domain/services/session.py
@@ -411,6 +411,7 @@ class SessionService:
         terminal_restricted: bool = False,
         credential_names: list[str] | None = None,
         integration_ids: list[str] | None = None,
+        resource_config: dict | None = None,
     ) -> Session:
         """Start a session's pods via the contributor pipeline."""
         session = await self._repository.get(session_id)
@@ -437,6 +438,7 @@ class SessionService:
                 terminal_restricted,
                 credential_names=credential_names,
                 integration_ids=integration_ids,
+                resource_config=resource_config,
             )
 
             provisioning = (
@@ -473,6 +475,7 @@ class SessionService:
         terminal_restricted: bool,
         credential_names: list[str] | None = None,
         integration_ids: list[str] | None = None,
+        resource_config: dict | None = None,
     ):
         """Run the contributor pipeline and start pods with merged spec."""
         # Auto-include all enabled integrations when none are specified.
@@ -499,6 +502,7 @@ class SessionService:
             credential_names=tuple(credential_names or ()),
             integration_ids=tuple(c.id for c in resolved_connections),
             integration_connections=tuple(resolved_connections),
+            resource_config=resource_config or {},
         )
 
         contributions: list[SessionContribution] = []

--- a/src/volundr/main.py
+++ b/src/volundr/main.py
@@ -19,6 +19,7 @@ from volundr.adapters.inbound.rest_integrations import create_integrations_route
 from volundr.adapters.inbound.rest_presets import create_presets_router
 from volundr.adapters.inbound.rest_profiles import create_profiles_router
 from volundr.adapters.inbound.rest_prompts import create_prompts_router
+from volundr.adapters.inbound.rest_resources import create_resources_router
 from volundr.adapters.inbound.rest_secrets import create_secrets_router
 from volundr.adapters.inbound.rest_tenants import create_tenants_router
 from volundr.adapters.inbound.rest_tracker import create_tracker_router
@@ -195,6 +196,16 @@ def _create_secret_injection_adapter(settings: Settings) -> "SecretInjectionPort
     kwargs = _resolve_secret_kwargs(si_cfg.kwargs, si_cfg.secret_kwargs_env)
     instance = cls(**kwargs)
     logger.info("Secret injection: %s", si_cfg.adapter.rsplit(".", 1)[-1])
+    return instance
+
+
+def _create_resource_provider(settings: Settings) -> "ResourceProvider":  # noqa: F821
+    """Create the ResourceProvider adapter from dynamic config."""
+    rp_cfg = settings.resource_provider
+    cls = import_class(rp_cfg.adapter)
+    kwargs = _resolve_secret_kwargs(rp_cfg.kwargs, rp_cfg.secret_kwargs_env)
+    instance = cls(**kwargs)
+    logger.info("Resource provider: %s", rp_cfg.adapter.rsplit(".", 1)[-1])
     return instance
 
 
@@ -423,6 +434,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             tenant_repository = PostgresTenantRepository(pool)
             user_repository = PostgresUserRepository(pool)
 
+            resource_provider = _create_resource_provider(settings)
             storage_adapter = _create_storage_adapter(settings)
             identity_adapter = _create_identity_adapter(
                 settings,
@@ -504,6 +516,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 integration_repo=integration_repo,
                 integration_registry=integration_registry,
                 user_integration=user_integration_service,
+                resource_provider=resource_provider,
             )
 
             session_service = SessionService(
@@ -563,6 +576,11 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
             profiles_router = create_profiles_router(profile_service, template_service)
             app.include_router(profiles_router)
+
+            # Resource discovery endpoint
+            resources_router = create_resources_router(resource_provider)
+            app.include_router(resources_router)
+            app.state.resource_provider = resource_provider
 
             # MCP servers and secrets
             mcp_provider = ConfigMCPServerProvider(settings.mcp_servers)

--- a/tests/test_adapters/test_direct_k8s_pod_manager.py
+++ b/tests/test_adapters/test_direct_k8s_pod_manager.py
@@ -270,6 +270,118 @@ class TestManifests:
         assert annotations["traefik.ingress.kubernetes.io/router.middlewares"] == expected_mw
 
 
+class TestResourceOverrides:
+    """Test that user-specified resources are applied to the deployment manifest."""
+
+    def test_default_resources_when_no_overrides(
+        self,
+        pod_manager: DirectK8sPodManager,
+        sample_session: Session,
+    ) -> None:
+        spec = make_spec()
+        manifest = pod_manager._build_deployment_manifest(sample_session, spec)
+        containers = {c["name"]: c for c in manifest["spec"]["template"]["spec"]["containers"]}
+        # Defaults should be present
+        assert containers["devrunner"]["resources"]["requests"]["memory"] == "512Mi"
+        assert containers["devrunner"]["resources"]["limits"]["cpu"] == "2000m"
+        assert containers["skuld"]["resources"]["limits"]["memory"] == "1Gi"
+        assert containers["nginx"]["resources"]["requests"]["cpu"] == "10m"
+
+    def test_user_cpu_memory_applied_to_devrunner(
+        self,
+        pod_manager: DirectK8sPodManager,
+        sample_session: Session,
+    ) -> None:
+        spec = make_spec(
+            resources={
+                "requests": {"cpu": "4", "memory": "16Gi"},
+                "limits": {"cpu": "4", "memory": "16Gi"},
+            },
+            localServices={
+                "devrunner": {
+                    "resources": {
+                        "requests": {"cpu": "4", "memory": "16Gi"},
+                        "limits": {"cpu": "4", "memory": "16Gi"},
+                    }
+                }
+            },
+        )
+        manifest = pod_manager._build_deployment_manifest(sample_session, spec)
+        containers = {c["name"]: c for c in manifest["spec"]["template"]["spec"]["containers"]}
+        # Devrunner should have user-specified resources
+        assert containers["devrunner"]["resources"]["requests"]["cpu"] == "4"
+        assert containers["devrunner"]["resources"]["requests"]["memory"] == "16Gi"
+        assert containers["devrunner"]["resources"]["limits"]["cpu"] == "4"
+        assert containers["devrunner"]["resources"]["limits"]["memory"] == "16Gi"
+        # Skuld should also reflect the override (top-level resources)
+        assert containers["skuld"]["resources"]["requests"]["cpu"] == "4"
+        # Nginx stays at defaults
+        assert containers["nginx"]["resources"]["requests"]["cpu"] == "10m"
+
+    def test_gpu_applied_to_devrunner_limits(
+        self,
+        pod_manager: DirectK8sPodManager,
+        sample_session: Session,
+    ) -> None:
+        spec = make_spec(
+            localServices={
+                "devrunner": {
+                    "resources": {
+                        "limits": {"nvidia.com/gpu": "2"},
+                    }
+                }
+            },
+        )
+        manifest = pod_manager._build_deployment_manifest(sample_session, spec)
+        containers = {c["name"]: c for c in manifest["spec"]["template"]["spec"]["containers"]}
+        assert containers["devrunner"]["resources"]["limits"]["nvidia.com/gpu"] == "2"
+        # Other containers should not have GPU
+        assert "nvidia.com/gpu" not in containers["skuld"]["resources"]["limits"]
+
+    def test_node_selector_applied_to_pod_spec(
+        self,
+        pod_manager: DirectK8sPodManager,
+        sample_session: Session,
+    ) -> None:
+        spec = make_spec(nodeSelector={"nvidia.com/gpu.product": "A100"})
+        manifest = pod_manager._build_deployment_manifest(sample_session, spec)
+        pod_spec = manifest["spec"]["template"]["spec"]
+        assert pod_spec["nodeSelector"] == {"nvidia.com/gpu.product": "A100"}
+
+    def test_tolerations_applied_to_pod_spec(
+        self,
+        pod_manager: DirectK8sPodManager,
+        sample_session: Session,
+    ) -> None:
+        toleration = {"key": "nvidia.com/gpu", "operator": "Exists", "effect": "NoSchedule"}
+        spec = make_spec(tolerations=[toleration])
+        manifest = pod_manager._build_deployment_manifest(sample_session, spec)
+        pod_spec = manifest["spec"]["template"]["spec"]
+        assert pod_spec["tolerations"] == [toleration]
+
+    def test_runtime_class_name_applied_to_pod_spec(
+        self,
+        pod_manager: DirectK8sPodManager,
+        sample_session: Session,
+    ) -> None:
+        spec = make_spec(runtimeClassName="nvidia")
+        manifest = pod_manager._build_deployment_manifest(sample_session, spec)
+        pod_spec = manifest["spec"]["template"]["spec"]
+        assert pod_spec["runtimeClassName"] == "nvidia"
+
+    def test_no_scheduling_fields_when_not_specified(
+        self,
+        pod_manager: DirectK8sPodManager,
+        sample_session: Session,
+    ) -> None:
+        spec = make_spec()
+        manifest = pod_manager._build_deployment_manifest(sample_session, spec)
+        pod_spec = manifest["spec"]["template"]["spec"]
+        assert "nodeSelector" not in pod_spec
+        assert "tolerations" not in pod_spec
+        assert "runtimeClassName" not in pod_spec
+
+
 class TestStripPrefixMiddleware:
     """Test Traefik middleware generation."""
 

--- a/tests/test_adapters/test_flux.py
+++ b/tests/test_adapters/test_flux.py
@@ -324,6 +324,54 @@ class TestFluxPodManagerSpecValues:
         assert body["spec"]["values"]["gateway"]["name"] == "my-gw"
         assert body["spec"]["values"]["git"]["repoUrl"] == "https://github.com/org/repo"
 
+    async def test_resource_overrides_reach_devrunner_values(
+        self,
+        sample_session: Session,
+        mock_api,
+    ):
+        """Verify user resource config flows through to devrunner Helm values."""
+        pm = FluxPodManager(
+            namespace="test-ns",
+            base_domain="volundr.example.com",
+            session_defaults={
+                "localServices": {
+                    "devrunner": {
+                        "resources": {
+                            "requests": {"memory": "512Mi", "cpu": "100m"},
+                            "limits": {"memory": "4Gi", "cpu": "2000m"},
+                        }
+                    }
+                },
+            },
+        )
+        spec = make_spec(
+            localServices={
+                "devrunner": {
+                    "resources": {
+                        "requests": {"cpu": "8", "memory": "32Gi"},
+                        "limits": {"cpu": "8", "memory": "32Gi", "nvidia.com/gpu": "4"},
+                    }
+                }
+            },
+            nodeSelector={"nvidia.com/gpu.product": "H100"},
+            tolerations=[{"key": "nvidia.com/gpu", "operator": "Exists", "effect": "NoSchedule"}],
+            runtimeClassName="nvidia",
+        )
+        with patch.object(pm, "_get_api", return_value=mock_api):
+            await pm.start(sample_session, spec)
+
+        body = mock_api.create_namespaced_custom_object.call_args[1]["body"]
+        values = body["spec"]["values"]
+        # Devrunner resources should be overridden
+        dr = values["localServices"]["devrunner"]["resources"]
+        assert dr["requests"]["cpu"] == "8"
+        assert dr["requests"]["memory"] == "32Gi"
+        assert dr["limits"]["nvidia.com/gpu"] == "4"
+        # Pod-level scheduling
+        assert values["nodeSelector"]["nvidia.com/gpu.product"] == "H100"
+        assert len(values["tolerations"]) == 1
+        assert values["runtimeClassName"] == "nvidia"
+
     async def test_empty_spec_uses_only_defaults(
         self,
         sample_session: Session,

--- a/tests/test_adapters/test_resource_contributor.py
+++ b/tests/test_adapters/test_resource_contributor.py
@@ -1,0 +1,80 @@
+"""Tests for ResourceContributor."""
+
+
+import pytest
+
+from volundr.adapters.outbound.contributors.resource import ResourceContributor
+from volundr.adapters.outbound.static_resource_provider import StaticResourceProvider
+from volundr.domain.models import GitSource, Session
+from volundr.domain.ports import SessionContext
+
+
+def _make_session(**overrides) -> Session:
+    defaults = {
+        "name": "test-session",
+        "model": "claude-sonnet",
+        "source": GitSource(repo="github.com/org/repo", branch="main"),
+    }
+    defaults.update(overrides)
+    return Session(**defaults)
+
+
+class TestResourceContributor:
+    """Tests for the resource contributor."""
+
+    @pytest.mark.asyncio
+    async def test_no_provider_returns_empty(self):
+        contributor = ResourceContributor(resource_provider=None)
+        context = SessionContext(resource_config={"cpu": "4"})
+        result = await contributor.contribute(_make_session(), context)
+        assert result.values == {}
+
+    @pytest.mark.asyncio
+    async def test_empty_resource_config(self):
+        provider = StaticResourceProvider()
+        contributor = ResourceContributor(resource_provider=provider)
+        context = SessionContext(resource_config={})
+        result = await contributor.contribute(_make_session(), context)
+        assert result.values == {}
+
+    @pytest.mark.asyncio
+    async def test_cpu_memory_translation(self):
+        provider = StaticResourceProvider()
+        contributor = ResourceContributor(resource_provider=provider)
+        context = SessionContext(resource_config={"cpu": "4", "memory": "8Gi"})
+        result = await contributor.contribute(_make_session(), context)
+        assert result.values["resources"]["requests"] == {"cpu": "4", "memory": "8Gi"}
+        assert result.values["resources"]["limits"] == {"cpu": "4", "memory": "8Gi"}
+        assert "nodeSelector" not in result.values
+        assert "tolerations" not in result.values
+        assert "runtimeClassName" not in result.values
+
+    @pytest.mark.asyncio
+    async def test_gpu_translation(self):
+        provider = StaticResourceProvider()
+        contributor = ResourceContributor(resource_provider=provider)
+        context = SessionContext(resource_config={"gpu": "2", "gpu_type": "A100"})
+        result = await contributor.contribute(_make_session(), context)
+        assert result.values["resources"]["limits"]["nvidia.com/gpu"] == "2"
+        assert result.values["nodeSelector"] == {"nvidia.com/gpu.product": "A100"}
+        assert len(result.values["tolerations"]) == 1
+        assert result.values["runtimeClassName"] == "nvidia"
+
+    @pytest.mark.asyncio
+    async def test_full_config(self):
+        provider = StaticResourceProvider()
+        contributor = ResourceContributor(resource_provider=provider)
+        context = SessionContext(
+            resource_config={"cpu": "8", "memory": "32Gi", "gpu": "4", "gpu_type": "H100"}
+        )
+        result = await contributor.contribute(_make_session(), context)
+        res = result.values["resources"]
+        assert res["requests"]["cpu"] == "8"
+        assert res["requests"]["memory"] == "32Gi"
+        assert res["limits"]["nvidia.com/gpu"] == "4"
+        assert result.values["nodeSelector"]["nvidia.com/gpu.product"] == "H100"
+
+    @pytest.mark.asyncio
+    async def test_contributor_name(self):
+        contributor = ResourceContributor()
+        assert contributor.name == "resource"

--- a/tests/test_adapters/test_resource_contributor.py
+++ b/tests/test_adapters/test_resource_contributor.py
@@ -1,6 +1,5 @@
 """Tests for ResourceContributor."""
 
-
 import pytest
 
 from volundr.adapters.outbound.contributors.resource import ResourceContributor
@@ -43,8 +42,12 @@ class TestResourceContributor:
         contributor = ResourceContributor(resource_provider=provider)
         context = SessionContext(resource_config={"cpu": "4", "memory": "8Gi"})
         result = await contributor.contribute(_make_session(), context)
+        # CPU/memory goes to both skuld (top-level) and devrunner
         assert result.values["resources"]["requests"] == {"cpu": "4", "memory": "8Gi"}
         assert result.values["resources"]["limits"] == {"cpu": "4", "memory": "8Gi"}
+        devrunner_res = result.values["localServices"]["devrunner"]["resources"]
+        assert devrunner_res["requests"] == {"cpu": "4", "memory": "8Gi"}
+        assert devrunner_res["limits"] == {"cpu": "4", "memory": "8Gi"}
         assert "nodeSelector" not in result.values
         assert "tolerations" not in result.values
         assert "runtimeClassName" not in result.values
@@ -55,7 +58,10 @@ class TestResourceContributor:
         contributor = ResourceContributor(resource_provider=provider)
         context = SessionContext(resource_config={"gpu": "2", "gpu_type": "A100"})
         result = await contributor.contribute(_make_session(), context)
-        assert result.values["resources"]["limits"]["nvidia.com/gpu"] == "2"
+        # GPU goes to devrunner only, not top-level resources
+        devrunner_res = result.values["localServices"]["devrunner"]["resources"]
+        assert devrunner_res["limits"]["nvidia.com/gpu"] == "2"
+        assert "resources" not in result.values  # No CPU/memory → no top-level resources
         assert result.values["nodeSelector"] == {"nvidia.com/gpu.product": "A100"}
         assert len(result.values["tolerations"]) == 1
         assert result.values["runtimeClassName"] == "nvidia"
@@ -68,11 +74,56 @@ class TestResourceContributor:
             resource_config={"cpu": "8", "memory": "32Gi", "gpu": "4", "gpu_type": "H100"}
         )
         result = await contributor.contribute(_make_session(), context)
+        # Top-level resources has CPU/memory only (for skuld broker)
         res = result.values["resources"]
         assert res["requests"]["cpu"] == "8"
         assert res["requests"]["memory"] == "32Gi"
-        assert res["limits"]["nvidia.com/gpu"] == "4"
+        assert "nvidia.com/gpu" not in res.get("limits", {})
+        # Devrunner gets CPU/memory + GPU
+        devrunner_res = result.values["localServices"]["devrunner"]["resources"]
+        assert devrunner_res["requests"]["cpu"] == "8"
+        assert devrunner_res["limits"]["nvidia.com/gpu"] == "4"
         assert result.values["nodeSelector"]["nvidia.com/gpu.product"] == "H100"
+
+    @pytest.mark.asyncio
+    async def test_gpu_timeslice_shares_gpu_with_skuld(self):
+        provider = StaticResourceProvider()
+        contributor = ResourceContributor(resource_provider=provider)
+        context = SessionContext(resource_config={"gpu": "1", "gpu_timeslice": "true"})
+        result = await contributor.contribute(_make_session(), context)
+        # GPU should be on both skuld (top-level) and devrunner
+        assert result.values["resources"]["limits"]["nvidia.com/gpu"] == "1"
+        devrunner_res = result.values["localServices"]["devrunner"]["resources"]
+        assert devrunner_res["limits"]["nvidia.com/gpu"] == "1"
+
+    @pytest.mark.asyncio
+    async def test_gpu_no_timeslice_only_devrunner(self):
+        provider = StaticResourceProvider()
+        contributor = ResourceContributor(resource_provider=provider)
+        context = SessionContext(resource_config={"gpu": "1"})
+        result = await contributor.contribute(_make_session(), context)
+        # GPU should only be on devrunner, not skuld
+        devrunner_res = result.values["localServices"]["devrunner"]["resources"]
+        assert devrunner_res["limits"]["nvidia.com/gpu"] == "1"
+        assert "resources" not in result.values  # No CPU/memory → no top-level
+
+    @pytest.mark.asyncio
+    async def test_gpu_timeslice_with_cpu_memory(self):
+        provider = StaticResourceProvider()
+        contributor = ResourceContributor(resource_provider=provider)
+        context = SessionContext(
+            resource_config={"cpu": "4", "memory": "8Gi", "gpu": "2", "gpu_timeslice": "true"}
+        )
+        result = await contributor.contribute(_make_session(), context)
+        # Skuld gets CPU/memory + GPU (time-sliced)
+        skuld_res = result.values["resources"]
+        assert skuld_res["requests"] == {"cpu": "4", "memory": "8Gi"}
+        assert skuld_res["limits"]["nvidia.com/gpu"] == "2"
+        assert skuld_res["limits"]["cpu"] == "4"
+        # Devrunner also gets everything
+        devrunner_res = result.values["localServices"]["devrunner"]["resources"]
+        assert devrunner_res["limits"]["nvidia.com/gpu"] == "2"
+        assert devrunner_res["requests"]["cpu"] == "4"
 
     @pytest.mark.asyncio
     async def test_contributor_name(self):

--- a/tests/test_adapters/test_resource_provider.py
+++ b/tests/test_adapters/test_resource_provider.py
@@ -1,0 +1,137 @@
+"""Tests for resource provider adapters."""
+
+import pytest
+
+from volundr.adapters.outbound.static_resource_provider import (
+    StaticResourceProvider,
+    translate_resource_config,
+    validate_resource_config,
+)
+from volundr.domain.models import (
+    ClusterResourceInfo,
+    TranslatedResources,
+)
+
+
+class TestTranslateResourceConfig:
+    """Tests for translate_resource_config shared logic."""
+
+    def test_empty_config(self):
+        result = translate_resource_config({})
+        assert result == TranslatedResources()
+
+    def test_cpu_only(self):
+        result = translate_resource_config({"cpu": "4"})
+        assert result.requests == {"cpu": "4"}
+        assert result.limits == {"cpu": "4"}
+        assert result.node_selector == {}
+        assert result.tolerations == []
+        assert result.runtime_class_name is None
+
+    def test_memory_only(self):
+        result = translate_resource_config({"memory": "8Gi"})
+        assert result.requests == {"memory": "8Gi"}
+        assert result.limits == {"memory": "8Gi"}
+
+    def test_cpu_and_memory(self):
+        result = translate_resource_config({"cpu": "2", "memory": "4Gi"})
+        assert result.requests == {"cpu": "2", "memory": "4Gi"}
+        assert result.limits == {"cpu": "2", "memory": "4Gi"}
+
+    def test_gpu_adds_limits_tolerations_runtime(self):
+        result = translate_resource_config({"gpu": "1"})
+        assert result.limits == {"nvidia.com/gpu": "1"}
+        assert result.requests == {}
+        assert len(result.tolerations) == 1
+        assert result.tolerations[0]["key"] == "nvidia.com/gpu"
+        assert result.runtime_class_name == "nvidia"
+
+    def test_gpu_zero_ignored(self):
+        result = translate_resource_config({"gpu": "0"})
+        assert "nvidia.com/gpu" not in result.limits
+        assert result.tolerations == []
+        assert result.runtime_class_name is None
+
+    def test_gpu_type_sets_node_selector(self):
+        result = translate_resource_config({"gpu": "2", "gpu_type": "A100"})
+        assert result.limits == {"nvidia.com/gpu": "2"}
+        assert result.node_selector == {"nvidia.com/gpu.product": "A100"}
+
+    def test_full_config(self):
+        result = translate_resource_config({
+            "cpu": "8",
+            "memory": "32Gi",
+            "gpu": "4",
+            "gpu_type": "H100",
+        })
+        assert result.requests == {"cpu": "8", "memory": "32Gi"}
+        assert result.limits == {"cpu": "8", "memory": "32Gi", "nvidia.com/gpu": "4"}
+        assert result.node_selector == {"nvidia.com/gpu.product": "H100"}
+        assert len(result.tolerations) == 1
+        assert result.runtime_class_name == "nvidia"
+
+
+class TestValidateResourceConfig:
+    """Tests for validate_resource_config."""
+
+    def test_valid_config(self):
+        errors = validate_resource_config({"cpu": "4", "memory": "8Gi", "gpu": "1"})
+        assert errors == []
+
+    def test_empty_config(self):
+        errors = validate_resource_config({})
+        assert errors == []
+
+    def test_invalid_cpu(self):
+        errors = validate_resource_config({"cpu": "abc"})
+        assert len(errors) == 1
+        assert "invalid cpu" in errors[0]
+
+    def test_negative_cpu(self):
+        errors = validate_resource_config({"cpu": "-1"})
+        assert len(errors) == 1
+        assert "positive" in errors[0]
+
+    def test_invalid_memory_suffix(self):
+        errors = validate_resource_config({"memory": "8GB"})
+        assert len(errors) == 1
+        assert "memory" in errors[0]
+
+    def test_valid_memory_numeric(self):
+        errors = validate_resource_config({"memory": "1073741824"})
+        assert errors == []
+
+    def test_invalid_gpu(self):
+        errors = validate_resource_config({"gpu": "1.5"})
+        assert len(errors) == 1
+        assert "integer" in errors[0]
+
+    def test_negative_gpu(self):
+        errors = validate_resource_config({"gpu": "-1"})
+        assert len(errors) == 1
+        assert "non-negative" in errors[0]
+
+
+class TestStaticResourceProvider:
+    """Tests for StaticResourceProvider."""
+
+    @pytest.mark.asyncio
+    async def test_discover_returns_standard_types(self):
+        provider = StaticResourceProvider()
+        info = await provider.discover()
+        assert isinstance(info, ClusterResourceInfo)
+        assert len(info.resource_types) == 3
+        names = {rt.name for rt in info.resource_types}
+        assert names == {"cpu", "memory", "gpu"}
+        assert info.nodes == []
+
+    def test_translate_delegates(self):
+        provider = StaticResourceProvider()
+        result = provider.translate({"cpu": "4", "gpu": "1"})
+        assert result.limits["nvidia.com/gpu"] == "1"
+        assert result.requests["cpu"] == "4"
+
+    def test_validate_delegates(self):
+        provider = StaticResourceProvider()
+        errors = provider.validate({"cpu": "abc"})
+        assert len(errors) == 1

--- a/tests/test_adapters/test_resource_provider.py
+++ b/tests/test_adapters/test_resource_provider.py
@@ -1,7 +1,10 @@
 """Tests for resource provider adapters."""
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 
+from volundr.adapters.outbound.k8s_resource_provider import K8sResourceProvider
 from volundr.adapters.outbound.static_resource_provider import (
     StaticResourceProvider,
     translate_resource_config,
@@ -58,12 +61,14 @@ class TestTranslateResourceConfig:
         assert result.node_selector == {"nvidia.com/gpu.product": "A100"}
 
     def test_full_config(self):
-        result = translate_resource_config({
-            "cpu": "8",
-            "memory": "32Gi",
-            "gpu": "4",
-            "gpu_type": "H100",
-        })
+        result = translate_resource_config(
+            {
+                "cpu": "8",
+                "memory": "32Gi",
+                "gpu": "4",
+                "gpu_type": "H100",
+            }
+        )
         assert result.requests == {"cpu": "8", "memory": "32Gi"}
         assert result.limits == {"cpu": "8", "memory": "32Gi", "nvidia.com/gpu": "4"}
         assert result.node_selector == {"nvidia.com/gpu.product": "H100"}
@@ -120,9 +125,9 @@ class TestStaticResourceProvider:
         provider = StaticResourceProvider()
         info = await provider.discover()
         assert isinstance(info, ClusterResourceInfo)
-        assert len(info.resource_types) == 3
+        assert len(info.resource_types) == 2
         names = {rt.name for rt in info.resource_types}
-        assert names == {"cpu", "memory", "gpu"}
+        assert names == {"cpu", "memory"}
         assert info.nodes == []
 
     def test_translate_delegates(self):
@@ -135,3 +140,116 @@ class TestStaticResourceProvider:
         provider = StaticResourceProvider()
         errors = provider.validate({"cpu": "abc"})
         assert len(errors) == 1
+
+
+class TestK8sResourceProviderKubeconfig:
+    """Tests for K8sResourceProvider kubeconfig fallback logic."""
+
+    @pytest.mark.asyncio
+    async def test_kubeconfig_kwarg_triggers_load_kube_config(self):
+        """When kubeconfig is provided, load_kube_config(config_file=...) is called."""
+        provider = K8sResourceProvider(kubeconfig="/path/to/kubeconfig")
+
+        # Directly test via mocking kubernetes_asyncio imports
+        mock_config = AsyncMock()
+        mock_client = AsyncMock()
+        mock_v1 = AsyncMock()
+        mock_client.CoreV1Api.return_value = mock_v1
+        mock_v1.list_node.return_value = AsyncMock(items=[])
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "kubernetes_asyncio": AsyncMock(client=mock_client, config=mock_config),
+                "kubernetes_asyncio.client": mock_client,
+                "kubernetes_asyncio.config": mock_config,
+            },
+        ):
+            # Re-import to pick up mocked modules
+            import importlib
+
+            import volundr.adapters.outbound.k8s_resource_provider as mod
+
+            importlib.reload(mod)
+            provider = mod.K8sResourceProvider(kubeconfig="/path/to/kubeconfig")
+            info = await provider.discover()
+
+            mock_config.load_kube_config.assert_called_once_with(config_file="/path/to/kubeconfig")
+            mock_config.load_incluster_config.assert_not_called()
+            assert isinstance(info, ClusterResourceInfo)
+
+    @pytest.mark.asyncio
+    async def test_empty_kubeconfig_tries_incluster_first(self):
+        """When no kubeconfig is set, try load_incluster_config first."""
+        mock_config = AsyncMock()
+        mock_client = AsyncMock()
+        mock_v1 = AsyncMock()
+        mock_client.CoreV1Api.return_value = mock_v1
+        mock_v1.list_node.return_value = AsyncMock(items=[])
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "kubernetes_asyncio": AsyncMock(client=mock_client, config=mock_config),
+                "kubernetes_asyncio.client": mock_client,
+                "kubernetes_asyncio.config": mock_config,
+            },
+        ):
+            import importlib
+
+            import volundr.adapters.outbound.k8s_resource_provider as mod
+
+            importlib.reload(mod)
+            provider = mod.K8sResourceProvider()
+            info = await provider.discover()
+
+            mock_config.load_incluster_config.assert_called_once()
+            mock_config.load_kube_config.assert_not_called()
+            assert isinstance(info, ClusterResourceInfo)
+
+    @pytest.mark.asyncio
+    async def test_incluster_failure_falls_back_to_kube_config(self):
+        """When load_incluster_config fails, fall back to load_kube_config."""
+        mock_config = AsyncMock()
+        mock_config.ConfigException = type("ConfigException", (Exception,), {})
+        mock_config.load_incluster_config.side_effect = mock_config.ConfigException(
+            "not in cluster"
+        )
+        mock_client = AsyncMock()
+        mock_v1 = AsyncMock()
+        mock_client.CoreV1Api.return_value = mock_v1
+        mock_v1.list_node.return_value = AsyncMock(items=[])
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "kubernetes_asyncio": AsyncMock(client=mock_client, config=mock_config),
+                "kubernetes_asyncio.client": mock_client,
+                "kubernetes_asyncio.config": mock_config,
+            },
+        ):
+            import importlib
+
+            import volundr.adapters.outbound.k8s_resource_provider as mod
+
+            importlib.reload(mod)
+            provider = mod.K8sResourceProvider()
+            info = await provider.discover()
+
+            mock_config.load_incluster_config.assert_called_once()
+            mock_config.load_kube_config.assert_called_once_with()
+            assert isinstance(info, ClusterResourceInfo)
+
+    @pytest.mark.asyncio
+    async def test_all_failures_fall_back_to_static_types(self):
+        """When all config loading fails, return static resource types."""
+        provider = K8sResourceProvider(kubeconfig="/nonexistent/path")
+
+        # The discover method catches all exceptions and falls back
+        info = await provider.discover()
+
+        assert isinstance(info, ClusterResourceInfo)
+        assert len(info.resource_types) == 2
+        names = {rt.name for rt in info.resource_types}
+        assert names == {"cpu", "memory"}
+        assert info.nodes == []

--- a/tests/test_adapters/test_rest_resources.py
+++ b/tests/test_adapters/test_rest_resources.py
@@ -1,0 +1,66 @@
+"""Tests for the resource discovery REST endpoint."""
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from volundr.adapters.inbound.rest_resources import create_resources_router
+from volundr.adapters.outbound.static_resource_provider import StaticResourceProvider
+
+
+@pytest.fixture
+def app():
+    provider = StaticResourceProvider()
+    router = create_resources_router(provider)
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+@pytest.fixture
+async def client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+class TestResourceDiscoveryEndpoint:
+    """Tests for GET /api/v1/volundr/resources."""
+
+    @pytest.mark.asyncio
+    async def test_returns_resource_types(self, client):
+        response = await client.get("/api/v1/volundr/resources")
+        assert response.status_code == 200
+        data = response.json()
+        assert "resource_types" in data
+        assert "nodes" in data
+
+        types = data["resource_types"]
+        assert len(types) == 3
+
+        names = {t["name"] for t in types}
+        assert names == {"cpu", "memory", "gpu"}
+
+    @pytest.mark.asyncio
+    async def test_resource_type_structure(self, client):
+        response = await client.get("/api/v1/volundr/resources")
+        data = response.json()
+        cpu_type = next(t for t in data["resource_types"] if t["name"] == "cpu")
+        assert cpu_type["resource_key"] == "cpu"
+        assert cpu_type["display_name"] == "CPU"
+        assert cpu_type["unit"] == "cores"
+        assert cpu_type["category"] == "compute"
+
+    @pytest.mark.asyncio
+    async def test_gpu_type_structure(self, client):
+        response = await client.get("/api/v1/volundr/resources")
+        data = response.json()
+        gpu_type = next(t for t in data["resource_types"] if t["name"] == "gpu")
+        assert gpu_type["resource_key"] == "nvidia.com/gpu"
+        assert gpu_type["category"] == "accelerator"
+
+    @pytest.mark.asyncio
+    async def test_static_provider_returns_no_nodes(self, client):
+        response = await client.get("/api/v1/volundr/resources")
+        data = response.json()
+        assert data["nodes"] == []

--- a/tests/test_adapters/test_rest_resources.py
+++ b/tests/test_adapters/test_rest_resources.py
@@ -36,10 +36,10 @@ class TestResourceDiscoveryEndpoint:
         assert "nodes" in data
 
         types = data["resource_types"]
-        assert len(types) == 3
+        assert len(types) == 2
 
         names = {t["name"] for t in types}
-        assert names == {"cpu", "memory", "gpu"}
+        assert names == {"cpu", "memory"}
 
     @pytest.mark.asyncio
     async def test_resource_type_structure(self, client):
@@ -50,14 +50,6 @@ class TestResourceDiscoveryEndpoint:
         assert cpu_type["display_name"] == "CPU"
         assert cpu_type["unit"] == "cores"
         assert cpu_type["category"] == "compute"
-
-    @pytest.mark.asyncio
-    async def test_gpu_type_structure(self, client):
-        response = await client.get("/api/v1/volundr/resources")
-        data = response.json()
-        gpu_type = next(t for t in data["resource_types"] if t["name"] == "gpu")
-        assert gpu_type["resource_key"] == "nvidia.com/gpu"
-        assert gpu_type["category"] == "accelerator"
 
     @pytest.mark.asyncio
     async def test_static_provider_returns_no_nodes(self, client):

--- a/tests/test_domain/test_resource_validation.py
+++ b/tests/test_domain/test_resource_validation.py
@@ -1,0 +1,110 @@
+"""Tests for resource validation edge cases."""
+
+
+from volundr.adapters.outbound.k8s_resource_provider import K8sResourceProvider
+from volundr.adapters.outbound.static_resource_provider import validate_resource_config
+from volundr.domain.models import (
+    ClusterResourceInfo,
+    NodeResourceSummary,
+)
+
+
+class TestValidationEdgeCases:
+    """Edge cases for resource validation."""
+
+    def test_none_values_ignored(self):
+        errors = validate_resource_config({"cpu": None, "memory": None, "gpu": None})
+        assert errors == []
+
+    def test_zero_cpu_invalid(self):
+        errors = validate_resource_config({"cpu": "0"})
+        assert len(errors) == 1
+        assert "positive" in errors[0]
+
+    def test_zero_gpu_valid(self):
+        errors = validate_resource_config({"gpu": "0"})
+        assert errors == []
+
+    def test_memory_ki_suffix(self):
+        errors = validate_resource_config({"memory": "4096Ki"})
+        assert errors == []
+
+    def test_memory_mi_suffix(self):
+        errors = validate_resource_config({"memory": "512Mi"})
+        assert errors == []
+
+    def test_memory_ti_suffix(self):
+        errors = validate_resource_config({"memory": "1Ti"})
+        assert errors == []
+
+    def test_fractional_cpu_valid(self):
+        errors = validate_resource_config({"cpu": "0.5"})
+        assert errors == []
+
+    def test_multiple_errors(self):
+        errors = validate_resource_config({"cpu": "abc", "gpu": "xyz"})
+        assert len(errors) == 2
+
+
+class TestK8sResourceProviderValidation:
+    """Cluster-aware validation via K8sResourceProvider."""
+
+    def _make_cluster_info(
+        self, gpu_count: int = 0, gpu_product: str = ""
+    ) -> ClusterResourceInfo:
+        labels = {}
+        allocatable = {}
+        if gpu_count > 0:
+            allocatable["nvidia.com/gpu"] = str(gpu_count)
+            if gpu_product:
+                labels["nvidia.com/gpu.product"] = gpu_product
+        return ClusterResourceInfo(
+            resource_types=[],
+            nodes=[
+                NodeResourceSummary(
+                    name="node-1",
+                    labels=labels,
+                    allocatable=allocatable,
+                    allocated={},
+                    available=allocatable,
+                )
+            ],
+        )
+
+    def test_gpu_available(self):
+        provider = K8sResourceProvider()
+        cluster = self._make_cluster_info(gpu_count=4, gpu_product="A100")
+        errors = provider.validate({"gpu": "2", "gpu_type": "A100"}, cluster)
+        assert errors == []
+
+    def test_gpu_not_enough(self):
+        provider = K8sResourceProvider()
+        cluster = self._make_cluster_info(gpu_count=2, gpu_product="A100")
+        errors = provider.validate({"gpu": "4", "gpu_type": "A100"}, cluster)
+        assert len(errors) == 1
+        assert "4 available GPUs" in errors[0]
+
+    def test_gpu_wrong_type(self):
+        provider = K8sResourceProvider()
+        cluster = self._make_cluster_info(gpu_count=4, gpu_product="A100")
+        errors = provider.validate({"gpu": "1", "gpu_type": "H100"}, cluster)
+        assert len(errors) == 1
+        assert "H100" in errors[0]
+
+    def test_no_gpu_nodes(self):
+        provider = K8sResourceProvider()
+        cluster = self._make_cluster_info(gpu_count=0)
+        errors = provider.validate({"gpu": "1"}, cluster)
+        assert len(errors) == 1
+        assert "no GPU nodes" in errors[0]
+
+    def test_no_cluster_info_skips_gpu_check(self):
+        provider = K8sResourceProvider()
+        errors = provider.validate({"gpu": "1"}, None)
+        assert errors == []
+
+    def test_no_gpu_request_skips_check(self):
+        provider = K8sResourceProvider()
+        cluster = self._make_cluster_info(gpu_count=0)
+        errors = provider.validate({"cpu": "4"}, cluster)
+        assert errors == []

--- a/web/src/adapters/api/volundr.adapter.test.ts
+++ b/web/src/adapters/api/volundr.adapter.test.ts
@@ -405,6 +405,39 @@ describe('ApiVolundrService', () => {
       expect(createBody.model).toBe('claude-sonnet-4-20250514');
       expect(createBody.source).toEqual({ type: 'git', repo: 'odin/core', branch: 'main' });
     });
+
+    it('includes resource_config when resourceConfig is provided', async () => {
+      mockFetch.mockReturnValueOnce(mockResponse(mockApiSession, 201));
+
+      await service.startSession({
+        name: 'GPU Session',
+        source: { type: 'git', repo: 'odin/core', branch: 'main' },
+        model: 'claude-sonnet-4-20250514',
+        resourceConfig: { cpu: '4', memory: '8Gi', gpu: '1' },
+      });
+
+      const createBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(createBody.resource_config).toEqual({ cpu: '4', memory: '8Gi', gpu: '1' });
+    });
+  });
+
+  describe('getClusterResources', () => {
+    it('fetches and maps cluster resources', async () => {
+      mockFetch.mockReturnValueOnce(
+        mockResponse({
+          resource_types: [
+            { name: 'cpu', resource_key: 'cpu', display_name: 'CPU', unit: 'cores', category: 'compute' },
+          ],
+          nodes: [],
+        })
+      );
+
+      const result = await service.getClusterResources();
+      expect(result.resourceTypes).toHaveLength(1);
+      expect(result.resourceTypes[0].name).toBe('cpu');
+      expect(result.resourceTypes[0].displayName).toBe('CPU');
+      expect(result.nodes).toEqual([]);
+    });
   });
 
   describe('stopSession', () => {

--- a/web/src/adapters/api/volundr.adapter.test.ts
+++ b/web/src/adapters/api/volundr.adapter.test.ts
@@ -426,7 +426,13 @@ describe('ApiVolundrService', () => {
       mockFetch.mockReturnValueOnce(
         mockResponse({
           resource_types: [
-            { name: 'cpu', resource_key: 'cpu', display_name: 'CPU', unit: 'cores', category: 'compute' },
+            {
+              name: 'cpu',
+              resource_key: 'cpu',
+              display_name: 'CPU',
+              unit: 'cores',
+              category: 'compute',
+            },
           ],
           nodes: [],
         })

--- a/web/src/adapters/api/volundr.adapter.ts
+++ b/web/src/adapters/api/volundr.adapter.ts
@@ -8,6 +8,7 @@ import type {
   VolundrMessage,
   VolundrLog,
   SessionChronicle,
+  ClusterResourceInfo,
   DiffData,
   DiffBase,
   SessionStatus,
@@ -73,6 +74,7 @@ import type {
   ApiStoredCredentialListResponse,
   ApiSecretTypeInfoResponse,
   ApiWorkspaceResponse,
+  ApiClusterResourceInfo,
 } from './volundr.types';
 
 /**
@@ -679,6 +681,26 @@ export class ApiVolundrService implements IVolundrService {
     return api.post<ApiCreateSecretResponse>('/secrets', { name, data });
   }
 
+  async getClusterResources(): Promise<ClusterResourceInfo> {
+    const response = await api.get<ApiClusterResourceInfo>('/resources');
+    return {
+      resourceTypes: response.resource_types.map(rt => ({
+        name: rt.name,
+        resourceKey: rt.resource_key,
+        displayName: rt.display_name,
+        unit: rt.unit,
+        category: rt.category,
+      })),
+      nodes: response.nodes.map(n => ({
+        name: n.name,
+        labels: n.labels,
+        allocatable: n.allocatable,
+        allocated: n.allocated,
+        available: n.available,
+      })),
+    };
+  }
+
   async startSession(config: {
     name: string;
     source: import('@/models').SessionSource;
@@ -689,6 +711,7 @@ export class ApiVolundrService implements IVolundrService {
     workspaceId?: string;
     credentialNames?: string[];
     integrationIds?: string[];
+    resourceConfig?: Record<string, string | undefined>;
   }): Promise<VolundrSession> {
     const createRequest: ApiSessionCreate = {
       name: config.name,
@@ -700,6 +723,7 @@ export class ApiVolundrService implements IVolundrService {
       workspace_id: config.workspaceId ?? null,
       credential_names: config.credentialNames?.length ? config.credentialNames : undefined,
       integration_ids: config.integrationIds?.length ? config.integrationIds : undefined,
+      resource_config: config.resourceConfig,
     };
 
     const response = await api.post<ApiSessionResponse>('/sessions', createRequest);

--- a/web/src/adapters/api/volundr.types.ts
+++ b/web/src/adapters/api/volundr.types.ts
@@ -97,6 +97,37 @@ export interface ApiSessionCreate {
   workspace_id?: string | null;
   credential_names?: string[];
   integration_ids?: string[];
+  resource_config?: Record<string, string | undefined>;
+}
+
+/**
+ * Resource type from cluster discovery
+ */
+export interface ApiResourceType {
+  name: string;
+  resource_key: string;
+  display_name: string;
+  unit: string;
+  category: string;
+}
+
+/**
+ * Node resource summary from cluster discovery
+ */
+export interface ApiNodeResourceSummary {
+  name: string;
+  labels: Record<string, string>;
+  allocatable: Record<string, string>;
+  allocated: Record<string, string>;
+  available: Record<string, string>;
+}
+
+/**
+ * Cluster resource discovery response
+ */
+export interface ApiClusterResourceInfo {
+  resource_types: ApiResourceType[];
+  nodes: ApiNodeResourceSummary[];
 }
 
 /**

--- a/web/src/adapters/mock/volundr.adapter.test.ts
+++ b/web/src/adapters/mock/volundr.adapter.test.ts
@@ -1381,4 +1381,20 @@ describe('MockVolundrService', () => {
       expect(hasDir).toBe(true);
     });
   });
+
+  describe('getClusterResources', () => {
+    it('returns resource types including cpu, memory, and gpu', async () => {
+      const result = await service.getClusterResources();
+      expect(result.resourceTypes.length).toBeGreaterThanOrEqual(3);
+      const names = result.resourceTypes.map(rt => rt.name);
+      expect(names).toContain('cpu');
+      expect(names).toContain('memory');
+      expect(names).toContain('gpu');
+    });
+
+    it('returns empty nodes array', async () => {
+      const result = await service.getClusterResources();
+      expect(result.nodes).toEqual([]);
+    });
+  });
 });

--- a/web/src/adapters/mock/volundr.adapter.ts
+++ b/web/src/adapters/mock/volundr.adapter.ts
@@ -231,8 +231,20 @@ export class MockVolundrService implements IVolundrService {
     return {
       resourceTypes: [
         { name: 'cpu', resourceKey: 'cpu', displayName: 'CPU', unit: 'cores', category: 'compute' },
-        { name: 'memory', resourceKey: 'memory', displayName: 'Memory', unit: 'bytes', category: 'compute' },
-        { name: 'gpu', resourceKey: 'nvidia.com/gpu', displayName: 'GPU', unit: 'devices', category: 'accelerator' },
+        {
+          name: 'memory',
+          resourceKey: 'memory',
+          displayName: 'Memory',
+          unit: 'bytes',
+          category: 'compute',
+        },
+        {
+          name: 'gpu',
+          resourceKey: 'nvidia.com/gpu',
+          displayName: 'GPU',
+          unit: 'devices',
+          category: 'accelerator',
+        },
       ],
       nodes: [],
     };

--- a/web/src/adapters/mock/volundr.adapter.ts
+++ b/web/src/adapters/mock/volundr.adapter.ts
@@ -227,6 +227,17 @@ export class MockVolundrService implements IVolundrService {
     return { name, keys: Object.keys(data) };
   }
 
+  async getClusterResources(): Promise<import('@/models').ClusterResourceInfo> {
+    return {
+      resourceTypes: [
+        { name: 'cpu', resourceKey: 'cpu', displayName: 'CPU', unit: 'cores', category: 'compute' },
+        { name: 'memory', resourceKey: 'memory', displayName: 'Memory', unit: 'bytes', category: 'compute' },
+        { name: 'gpu', resourceKey: 'nvidia.com/gpu', displayName: 'GPU', unit: 'devices', category: 'accelerator' },
+      ],
+      nodes: [],
+    };
+  }
+
   async startSession(config: {
     name: string;
     source: import('@/models').SessionSource;
@@ -237,6 +248,7 @@ export class MockVolundrService implements IVolundrService {
     terminalRestricted?: boolean;
     credentialNames?: string[];
     integrationIds?: string[];
+    resourceConfig?: Record<string, string | undefined>;
   }): Promise<VolundrSession> {
     const newSession: VolundrSession = {
       id: `forge-${Math.random().toString(36).substring(2, 10)}`,

--- a/web/src/components/LaunchWizard/LaunchWizard.test.tsx
+++ b/web/src/components/LaunchWizard/LaunchWizard.test.tsx
@@ -71,6 +71,7 @@ const mockService = {
   getCredentials: vi.fn().mockResolvedValue([]),
   getIntegrations: vi.fn().mockResolvedValue([]),
   getFeatures: vi.fn().mockResolvedValue({ localMountsEnabled: false }),
+  getClusterResources: vi.fn().mockResolvedValue({ resourceTypes: [], nodes: [] }),
 } as unknown as import('@/ports').IVolundrService;
 
 const defaultProps = {
@@ -225,6 +226,27 @@ describe('LaunchWizard', () => {
           model: 'claude-sonnet',
           source: { type: 'git', repo: 'https://github.com/org/repo.git', branch: 'develop' },
           terminalRestricted: false,
+        })
+      );
+    });
+
+    it('includes resourceConfig when resource fields are set', async () => {
+      render(<LaunchWizard {...defaultProps} />);
+      fireEvent.click(screen.getByText('Standard'));
+      fireEvent.change(screen.getByPlaceholderText('e.g. feature-auth-refactor'), {
+        target: { value: 'test-session' },
+      });
+      // Open advanced config and set CPU
+      fireEvent.click(screen.getByText('Advanced Configuration'));
+      const cpuInput = screen.getByPlaceholderText('e.g. 4');
+      fireEvent.change(cpuInput, { target: { value: '8' } });
+      // Go to step 3 and launch
+      fireEvent.click(screen.getByText('Next'));
+      fireEvent.click(screen.getByText('Launch Session'));
+
+      expect(defaultProps.onLaunch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resourceConfig: expect.objectContaining({ cpu: '8' }),
         })
       );
     });

--- a/web/src/components/LaunchWizard/LaunchWizard.tsx
+++ b/web/src/components/LaunchWizard/LaunchWizard.tsx
@@ -29,6 +29,7 @@ export interface LaunchConfig {
   workspaceId?: string;
   credentialNames?: string[];
   integrationIds?: string[];
+  resourceConfig?: Record<string, string | undefined>;
 }
 
 export type SourceType = 'git' | 'local_mount';
@@ -170,6 +171,11 @@ export function LaunchWizard(props: LaunchWizardProps) {
         ? { type: 'local_mount', paths: state.mountPaths.filter(p => p.host_path && p.mount_path) }
         : { type: 'git', repo: state.repo, branch: state.branch };
 
+    // Build resource config, filtering out empty values
+    const resourceConfig = Object.fromEntries(
+      Object.entries(state.resourceConfig).filter(([, v]) => v !== undefined && v !== '')
+    );
+
     await onLaunch({
       name: state.name.trim(),
       source,
@@ -182,6 +188,7 @@ export function LaunchWizard(props: LaunchWizardProps) {
       workspaceId: state.workspaceId,
       credentialNames: state.selectedCredentials.length ? state.selectedCredentials : undefined,
       integrationIds: state.selectedIntegrations.length ? state.selectedIntegrations : undefined,
+      resourceConfig: Object.keys(resourceConfig).length > 0 ? resourceConfig : undefined,
     });
   }, [state, onLaunch]);
 

--- a/web/src/components/LaunchWizard/steps/ConfigureStep.module.css
+++ b/web/src/components/LaunchWizard/steps/ConfigureStep.module.css
@@ -414,20 +414,80 @@
 /* Resource grid */
 .resourceGrid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: var(--space-3);
+  grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr));
+  gap: var(--space-4);
 }
 
 .resourceField {
   display: flex;
   flex-direction: column;
   gap: var(--space-1);
+  min-width: 0;
 }
 
 .resourceLabel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
   font-size: var(--text-xs);
   color: var(--color-text-muted);
   font-weight: 500;
+}
+
+.resourceUnit {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  font-weight: 400;
+  opacity: 0.6;
+}
+
+.resourceCategory {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.resourceCategoryLabel {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.resourceCategory[data-category='compute'] .resourceCategoryLabel {
+  color: var(--color-accent-cyan);
+}
+
+.resourceCategory[data-category='accelerator'] .resourceCategoryLabel {
+  color: var(--color-accent-purple);
+}
+
+.resourceCapacity {
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-text-muted);
+}
+
+.resourceCapacity[data-category='compute'] {
+  color: var(--color-accent-cyan);
+}
+
+.resourceCapacity[data-category='accelerator'] {
+  color: var(--color-accent-purple);
+}
+
+.resourceError {
+  font-size: var(--text-xs);
+  color: var(--color-accent-red);
+  font-weight: 500;
+}
+
+.formInputError {
+  border-color: var(--color-accent-red);
+}
+
+.formInputError:focus {
+  border-color: var(--color-accent-red);
 }
 
 /* Environment variables */

--- a/web/src/components/LaunchWizard/steps/ConfigureStep.test.tsx
+++ b/web/src/components/LaunchWizard/steps/ConfigureStep.test.tsx
@@ -100,6 +100,7 @@ const mockService = {
   listWorkspaces: vi.fn().mockResolvedValue([]),
   getCredentials: vi.fn().mockResolvedValue([]),
   getIntegrations: vi.fn().mockResolvedValue([]),
+  getClusterResources: vi.fn().mockResolvedValue({ resourceTypes: [], nodes: [] }),
 } as unknown as import('@/ports').IVolundrService;
 
 function renderStep(overrides: Partial<ConfigureStepProps> = {}) {
@@ -1241,6 +1242,57 @@ describe('ConfigureStep', () => {
         screen.getByPlaceholderText('Host path (e.g. /home/user/project)')
       ).toBeInTheDocument();
       expect(screen.getByPlaceholderText('Container path (e.g. /workspace)')).toBeInTheDocument();
+    });
+  });
+
+  describe('GPU type dropdown', () => {
+    it('shows GPU type dropdown when cluster reports accelerator types', async () => {
+      const serviceWithGpu = {
+        ...mockService,
+        getClusterResources: vi.fn().mockResolvedValue({
+          resourceTypes: [
+            { name: 'cpu', resourceKey: 'cpu', displayName: 'CPU', unit: 'cores', category: 'compute' },
+            { name: 'gpu_A100', resourceKey: 'nvidia.com/gpu', displayName: 'NVIDIA A100', unit: 'devices', category: 'accelerator' },
+            { name: 'gpu_H100', resourceKey: 'nvidia.com/gpu', displayName: 'NVIDIA H100', unit: 'devices', category: 'accelerator' },
+          ],
+          nodes: [],
+        }),
+      } as unknown as import('@/ports').IVolundrService;
+
+      renderStep({ service: serviceWithGpu });
+      fireEvent.click(screen.getByText('Advanced Configuration'));
+      const gpuTypeLabel = await screen.findByText('GPU Type');
+      expect(gpuTypeLabel).toBeInTheDocument();
+    });
+
+    it('does not show GPU type dropdown when no accelerator types', () => {
+      renderStep();
+      fireEvent.click(screen.getByText('Advanced Configuration'));
+      expect(screen.queryByText('GPU Type')).not.toBeInTheDocument();
+    });
+
+    it('calls onChange when selecting a GPU type', async () => {
+      const serviceWithGpu = {
+        ...mockService,
+        getClusterResources: vi.fn().mockResolvedValue({
+          resourceTypes: [
+            { name: 'gpu_A100', resourceKey: 'nvidia.com/gpu', displayName: 'NVIDIA A100', unit: 'devices', category: 'accelerator' },
+          ],
+          nodes: [],
+        }),
+      } as unknown as import('@/ports').IVolundrService;
+
+      renderStep({ service: serviceWithGpu });
+      fireEvent.click(screen.getByText('Advanced Configuration'));
+      const gpuTypeLabel = await screen.findByText('GPU Type');
+      const select = gpuTypeLabel.closest('div')?.querySelector('select');
+      expect(select).toBeTruthy();
+      fireEvent.change(select!, { target: { value: 'A100' } });
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resourceConfig: expect.objectContaining({ gpu_type: 'A100' }),
+        })
+      );
     });
   });
 });

--- a/web/src/components/LaunchWizard/steps/ConfigureStep.test.tsx
+++ b/web/src/components/LaunchWizard/steps/ConfigureStep.test.tsx
@@ -1251,9 +1251,27 @@ describe('ConfigureStep', () => {
         ...mockService,
         getClusterResources: vi.fn().mockResolvedValue({
           resourceTypes: [
-            { name: 'cpu', resourceKey: 'cpu', displayName: 'CPU', unit: 'cores', category: 'compute' },
-            { name: 'gpu_A100', resourceKey: 'nvidia.com/gpu', displayName: 'NVIDIA A100', unit: 'devices', category: 'accelerator' },
-            { name: 'gpu_H100', resourceKey: 'nvidia.com/gpu', displayName: 'NVIDIA H100', unit: 'devices', category: 'accelerator' },
+            {
+              name: 'cpu',
+              resourceKey: 'cpu',
+              displayName: 'CPU',
+              unit: 'cores',
+              category: 'compute',
+            },
+            {
+              name: 'gpu_A100',
+              resourceKey: 'nvidia.com/gpu',
+              displayName: 'NVIDIA A100',
+              unit: 'devices',
+              category: 'accelerator',
+            },
+            {
+              name: 'gpu_H100',
+              resourceKey: 'nvidia.com/gpu',
+              displayName: 'NVIDIA H100',
+              unit: 'devices',
+              category: 'accelerator',
+            },
           ],
           nodes: [],
         }),
@@ -1276,7 +1294,13 @@ describe('ConfigureStep', () => {
         ...mockService,
         getClusterResources: vi.fn().mockResolvedValue({
           resourceTypes: [
-            { name: 'gpu_A100', resourceKey: 'nvidia.com/gpu', displayName: 'NVIDIA A100', unit: 'devices', category: 'accelerator' },
+            {
+              name: 'gpu_A100',
+              resourceKey: 'nvidia.com/gpu',
+              displayName: 'NVIDIA A100',
+              unit: 'devices',
+              category: 'accelerator',
+            },
           ],
           nodes: [],
         }),

--- a/web/src/components/LaunchWizard/steps/ConfigureStep.test.tsx
+++ b/web/src/components/LaunchWizard/steps/ConfigureStep.test.tsx
@@ -2,7 +2,13 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { ConfigureStep } from './ConfigureStep';
 import type { ConfigureStepProps } from './ConfigureStep';
-import type { VolundrTemplate, VolundrRepo, VolundrModel, McpServerConfig } from '@/models';
+import type {
+  VolundrTemplate,
+  VolundrRepo,
+  VolundrModel,
+  McpServerConfig,
+  ClusterResourceInfo,
+} from '@/models';
 import type { WizardState } from '../LaunchWizard';
 
 const baseTemplate: VolundrTemplate = {
@@ -427,13 +433,12 @@ describe('ConfigureStep', () => {
   });
 
   describe('resource config', () => {
-    it('renders CPU, Memory, GPU inputs', () => {
+    it('renders CPU and Memory inputs in fallback mode', () => {
       renderStep();
       fireEvent.click(screen.getByText('Advanced Configuration'));
 
       expect(screen.getByPlaceholderText('e.g. 4')).toBeInTheDocument();
       expect(screen.getByPlaceholderText('e.g. 8Gi')).toBeInTheDocument();
-      expect(screen.getByPlaceholderText('e.g. 1')).toBeInTheDocument();
     });
 
     it('calls onChange when setting CPU', () => {
@@ -445,6 +450,139 @@ describe('ConfigureStep', () => {
       });
 
       expect(onChange).toHaveBeenCalledWith({ resourceConfig: { cpu: '2' } });
+    });
+  });
+
+  describe('dynamic resource rendering', () => {
+    const clusterResourceData: ClusterResourceInfo = {
+      resourceTypes: [
+        {
+          name: 'cpu',
+          resourceKey: 'cpu',
+          displayName: 'CPU',
+          unit: 'cores',
+          category: 'compute',
+        },
+        {
+          name: 'memory',
+          resourceKey: 'memory',
+          displayName: 'Memory',
+          unit: 'bytes',
+          category: 'compute',
+        },
+        {
+          name: 'gpu',
+          resourceKey: 'nvidia.com/gpu',
+          displayName: 'GPU',
+          unit: 'devices',
+          category: 'accelerator',
+        },
+      ],
+      nodes: [
+        {
+          name: 'node-1',
+          labels: {},
+          allocatable: { cpu: '8', memory: '16384', 'nvidia.com/gpu': '2' },
+          allocated: {},
+          available: { cpu: '8', memory: '16384', 'nvidia.com/gpu': '2' },
+        },
+        {
+          name: 'node-2',
+          labels: {},
+          allocatable: { cpu: '4', memory: '8192' },
+          allocated: {},
+          available: { cpu: '4', memory: '8192' },
+        },
+      ],
+    };
+
+    it('renders dynamic resource types from cluster data', async () => {
+      const service = {
+        ...mockService,
+        getClusterResources: vi.fn().mockResolvedValue(clusterResourceData),
+      } as unknown as import('@/ports').IVolundrService;
+
+      renderStep({ service });
+      fireEvent.click(screen.getByText('Advanced Configuration'));
+
+      // Wait for cluster resources to load and render
+      expect(await screen.findByText('Compute')).toBeInTheDocument();
+      expect(screen.getByText('Accelerator')).toBeInTheDocument();
+    });
+
+    it('shows capacity text when nodes have data', async () => {
+      const service = {
+        ...mockService,
+        getClusterResources: vi.fn().mockResolvedValue(clusterResourceData),
+      } as unknown as import('@/ports').IVolundrService;
+
+      renderStep({ service });
+      fireEvent.click(screen.getByText('Advanced Configuration'));
+
+      // CPU: 8 + 4 = 12 cores available
+      expect(await screen.findByText('12 cores available')).toBeInTheDocument();
+      // Memory: 16384 + 8192 = 24576 bytes -> formatted as 24.0 KiB
+      expect(screen.getByText(/24\.0 KiB/)).toBeInTheDocument();
+    });
+
+    it('renders fallback static inputs when no cluster data', () => {
+      renderStep();
+      fireEvent.click(screen.getByText('Advanced Configuration'));
+
+      // Static fallback should show CPU and Memory inputs
+      expect(screen.getByPlaceholderText('e.g. 4')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('e.g. 8Gi')).toBeInTheDocument();
+      // Category labels should not appear
+      expect(screen.queryByText('Compute')).not.toBeInTheDocument();
+    });
+
+    it('shows validation error when resource exceeds available capacity', async () => {
+      const service = {
+        ...mockService,
+        getClusterResources: vi.fn().mockResolvedValue(clusterResourceData),
+      } as unknown as import('@/ports').IVolundrService;
+
+      renderStep({
+        service,
+        state: buildState({ resourceConfig: { cpu: '24' } }),
+      });
+      fireEvent.click(screen.getByText('Advanced Configuration'));
+
+      // CPU total is 12 cores, requesting 24 should show error
+      expect(await screen.findByText(/Exceeds available capacity/)).toBeInTheDocument();
+    });
+
+    it('shows format error for invalid K8s quantity', async () => {
+      const service = {
+        ...mockService,
+        getClusterResources: vi.fn().mockResolvedValue(clusterResourceData),
+      } as unknown as import('@/ports').IVolundrService;
+
+      renderStep({
+        service,
+        state: buildState({ resourceConfig: { memory: 'abc' } }),
+      });
+      fireEvent.click(screen.getByText('Advanced Configuration'));
+
+      expect(await screen.findByText(/Invalid format/)).toBeInTheDocument();
+    });
+
+    it('accepts valid K8s quantity notation without error', async () => {
+      const service = {
+        ...mockService,
+        getClusterResources: vi.fn().mockResolvedValue(clusterResourceData),
+      } as unknown as import('@/ports').IVolundrService;
+
+      renderStep({
+        service,
+        state: buildState({ resourceConfig: { cpu: '4' } }),
+      });
+      fireEvent.click(screen.getByText('Advanced Configuration'));
+
+      // Should show capacity, not an error
+      expect(await screen.findByText('12 cores available')).toBeInTheDocument();
+      expect(screen.queryByText(/Exceeds/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Invalid/)).not.toBeInTheDocument();
     });
   });
 
@@ -714,19 +852,6 @@ describe('ConfigureStep', () => {
       });
     });
 
-    it('calls onChange when setting GPU', () => {
-      renderStep();
-      fireEvent.click(screen.getByText('Advanced Configuration'));
-
-      fireEvent.change(screen.getByPlaceholderText('e.g. 1'), {
-        target: { value: '2' },
-      });
-
-      expect(onChange).toHaveBeenCalledWith({
-        resourceConfig: { gpu: '2' },
-      });
-    });
-
     it('sets memory to undefined when cleared', () => {
       renderStep({
         state: buildState({ resourceConfig: { memory: '8Gi' } }),
@@ -739,21 +864,6 @@ describe('ConfigureStep', () => {
 
       expect(onChange).toHaveBeenCalledWith({
         resourceConfig: { memory: undefined },
-      });
-    });
-
-    it('sets gpu to undefined when cleared', () => {
-      renderStep({
-        state: buildState({ resourceConfig: { gpu: '1' } }),
-      });
-      fireEvent.click(screen.getByText('Advanced Configuration'));
-
-      fireEvent.change(screen.getByPlaceholderText('e.g. 1'), {
-        target: { value: '' },
-      });
-
-      expect(onChange).toHaveBeenCalledWith({
-        resourceConfig: { gpu: undefined },
       });
     });
   });

--- a/web/src/components/LaunchWizard/steps/ConfigureStep.test.tsx
+++ b/web/src/components/LaunchWizard/steps/ConfigureStep.test.tsx
@@ -1429,4 +1429,219 @@ describe('ConfigureStep', () => {
       );
     });
   });
+
+  describe('validateResourceInput branches', () => {
+    const clusterResourceData: ClusterResourceInfo = {
+      resourceTypes: [
+        {
+          name: 'cpu',
+          resourceKey: 'cpu',
+          displayName: 'CPU',
+          unit: 'cores',
+          category: 'compute',
+        },
+        {
+          name: 'memory',
+          resourceKey: 'memory',
+          displayName: 'Memory',
+          unit: 'bytes',
+          category: 'compute',
+        },
+        {
+          name: 'gpu',
+          resourceKey: 'nvidia.com/gpu',
+          displayName: 'GPU',
+          unit: 'devices',
+          category: 'accelerator',
+        },
+      ],
+      nodes: [
+        {
+          name: 'node-1',
+          labels: {},
+          allocatable: { cpu: '8', memory: '17179869184', 'nvidia.com/gpu': '2' },
+          allocated: {},
+          available: { cpu: '8', memory: '17179869184', 'nvidia.com/gpu': '2' },
+        },
+      ],
+    };
+
+    it('shows cores format error for invalid CPU value', async () => {
+      const service = {
+        ...mockService,
+        getClusterResources: vi.fn().mockResolvedValue(clusterResourceData),
+      } as unknown as import('@/ports').IVolundrService;
+
+      renderStep({
+        service,
+        state: buildState({ resourceConfig: { cpu: 'xyz' } }),
+      });
+      fireEvent.click(screen.getByText('Advanced Configuration'));
+
+      expect(await screen.findByText('Invalid format. Use e.g. 4, 500m, 1.5')).toBeInTheDocument();
+    });
+
+    it('shows bytes format error for invalid memory value', async () => {
+      const service = {
+        ...mockService,
+        getClusterResources: vi.fn().mockResolvedValue(clusterResourceData),
+      } as unknown as import('@/ports').IVolundrService;
+
+      renderStep({
+        service,
+        state: buildState({ resourceConfig: { memory: 'notbytes' } }),
+      });
+      fireEvent.click(screen.getByText('Advanced Configuration'));
+
+      expect(
+        await screen.findByText('Invalid format. Use e.g. 4Gi, 512Mi, 1Ti')
+      ).toBeInTheDocument();
+    });
+
+    it('shows error when value is zero or negative', async () => {
+      const service = {
+        ...mockService,
+        getClusterResources: vi.fn().mockResolvedValue(clusterResourceData),
+      } as unknown as import('@/ports').IVolundrService;
+
+      renderStep({
+        service,
+        state: buildState({ resourceConfig: { cpu: '0' } }),
+      });
+      fireEvent.click(screen.getByText('Advanced Configuration'));
+
+      expect(await screen.findByText('Must be greater than 0')).toBeInTheDocument();
+    });
+
+    it('shows capacity exceeded with bytes formatting for memory', async () => {
+      const service = {
+        ...mockService,
+        getClusterResources: vi.fn().mockResolvedValue(clusterResourceData),
+      } as unknown as import('@/ports').IVolundrService;
+
+      renderStep({
+        service,
+        state: buildState({ resourceConfig: { memory: '999Ti' } }),
+      });
+      fireEvent.click(screen.getByText('Advanced Configuration'));
+
+      expect(await screen.findByText(/Exceeds available capacity/)).toBeInTheDocument();
+    });
+
+    it('shows capacity exceeded with cores formatting for CPU', async () => {
+      const service = {
+        ...mockService,
+        getClusterResources: vi.fn().mockResolvedValue(clusterResourceData),
+      } as unknown as import('@/ports').IVolundrService;
+
+      renderStep({
+        service,
+        state: buildState({ resourceConfig: { cpu: '100' } }),
+      });
+      fireEvent.click(screen.getByText('Advanced Configuration'));
+
+      expect(await screen.findByText('Exceeds available capacity (8 cores)')).toBeInTheDocument();
+    });
+  });
+
+  describe('hasGpuRequested', () => {
+    it('shows GPU time-slicing toggle when static gpu field is set', async () => {
+      const service = {
+        ...mockService,
+        getClusterResources: vi.fn().mockResolvedValue({
+          resourceTypes: [
+            {
+              name: 'gpu',
+              resourceKey: 'nvidia.com/gpu',
+              displayName: 'GPU',
+              unit: 'devices',
+              category: 'accelerator',
+            },
+          ],
+          nodes: [],
+        }),
+      } as unknown as import('@/ports').IVolundrService;
+
+      renderStep({
+        service,
+        state: buildState({ resourceConfig: { gpu: '1' } }),
+      });
+      fireEvent.click(screen.getByText('Advanced Configuration'));
+
+      expect(await screen.findByText('GPU time-slicing')).toBeInTheDocument();
+    });
+
+    it('shows GPU time-slicing toggle when dynamic accelerator resource is set', async () => {
+      const service = {
+        ...mockService,
+        getClusterResources: vi.fn().mockResolvedValue({
+          resourceTypes: [
+            {
+              name: 'custom_accel',
+              resourceKey: 'custom.io/accel',
+              displayName: 'Custom Accelerator',
+              unit: 'devices',
+              category: 'accelerator',
+            },
+          ],
+          nodes: [
+            {
+              name: 'node-1',
+              labels: {},
+              allocatable: { 'custom.io/accel': '4' },
+              allocated: {},
+              available: { 'custom.io/accel': '4' },
+            },
+          ],
+        }),
+      } as unknown as import('@/ports').IVolundrService;
+
+      renderStep({
+        service,
+        state: buildState({ resourceConfig: { custom_accel: '2' } }),
+      });
+      fireEvent.click(screen.getByText('Advanced Configuration'));
+
+      expect(await screen.findByText('GPU time-slicing')).toBeInTheDocument();
+    });
+
+    it('does not show GPU time-slicing when no GPU resources requested', () => {
+      renderStep({
+        state: buildState({ resourceConfig: {} }),
+      });
+      fireEvent.click(screen.getByText('Advanced Configuration'));
+
+      expect(screen.queryByText('GPU time-slicing')).not.toBeInTheDocument();
+    });
+
+    it('shows time-slicing hint when gpu_timeslice is enabled', async () => {
+      const service = {
+        ...mockService,
+        getClusterResources: vi.fn().mockResolvedValue({
+          resourceTypes: [
+            {
+              name: 'gpu',
+              resourceKey: 'nvidia.com/gpu',
+              displayName: 'GPU',
+              unit: 'devices',
+              category: 'accelerator',
+            },
+          ],
+          nodes: [],
+        }),
+      } as unknown as import('@/ports').IVolundrService;
+
+      renderStep({
+        service,
+        state: buildState({ resourceConfig: { gpu: '1', gpu_timeslice: 'true' } }),
+      });
+      fireEvent.click(screen.getByText('Advanced Configuration'));
+
+      expect(
+        await screen.findByText(
+          'GPU is shared between the AI broker and your workload via NVIDIA time-slicing'
+        )
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/web/src/components/LaunchWizard/steps/ConfigureStep.tsx
+++ b/web/src/components/LaunchWizard/steps/ConfigureStep.tsx
@@ -58,6 +58,109 @@ export interface ConfigureStepProps {
   ) => Promise<VolundrPreset>;
 }
 
+const BYTE_MULTIPLIERS: Record<string, number> = {
+  '': 1,
+  K: 1e3,
+  M: 1e6,
+  G: 1e9,
+  T: 1e12,
+  P: 1e15,
+  E: 1e18,
+  Ki: 1024,
+  Mi: 1024 ** 2,
+  Gi: 1024 ** 3,
+  Ti: 1024 ** 4,
+  Pi: 1024 ** 5,
+  Ei: 1024 ** 6,
+};
+
+/**
+ * Parse a Kubernetes quantity string into a canonical numeric value.
+ * - bytes unit: "8Gi" → bytes, "500Mi" → bytes, "8024304Ki" → bytes
+ * - cores unit: "4" → 4, "500m" → 0.5, "1.5" → 1.5
+ * - other: plain parseFloat
+ * Returns NaN if the string is not a valid quantity.
+ */
+function parseK8sQuantity(raw: string, unit: string): number {
+  const trimmed = raw.trim();
+  if (!trimmed) return NaN;
+
+  if (unit === 'bytes') {
+    const match = trimmed.match(/^(\d+(?:\.\d+)?)\s*([KMGTPE]i?)?$/);
+    if (!match) return NaN;
+    const num = parseFloat(match[1]);
+    const suffix = match[2] ?? '';
+    if (!(suffix in BYTE_MULTIPLIERS)) return NaN;
+    return num * BYTE_MULTIPLIERS[suffix];
+  }
+
+  if (unit === 'cores') {
+    // CPU supports millicores (e.g. "500m" = 0.5 cores) or plain numbers
+    const milliMatch = trimmed.match(/^(\d+)m$/);
+    if (milliMatch) return parseInt(milliMatch[1], 10) / 1000;
+    const num = parseFloat(trimmed);
+    if (isNaN(num) || num < 0) return NaN;
+    return num;
+  }
+
+  // Generic: plain number
+  const num = parseFloat(trimmed);
+  if (isNaN(num) || num < 0) return NaN;
+  return num;
+}
+
+function formatHumanBytes(bytes: number): string {
+  if (bytes >= 1024 ** 5) return `${(bytes / 1024 ** 5).toFixed(1)} PiB`;
+  if (bytes >= 1024 ** 4) return `${(bytes / 1024 ** 4).toFixed(1)} TiB`;
+  if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(1)} GiB`;
+  if (bytes >= 1024 ** 2) return `${(bytes / 1024 ** 2).toFixed(1)} MiB`;
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
+  return `${bytes} B`;
+}
+
+function formatResourceValue(value: number | string, unit: string): string {
+  const raw = String(value);
+  if (unit === 'bytes') {
+    const bytes = parseK8sQuantity(raw, 'bytes');
+    if (isNaN(bytes)) return raw;
+    return formatHumanBytes(bytes);
+  }
+  const num = parseFloat(raw) || 0;
+  if (Number.isInteger(num)) return String(num);
+  return num.toFixed(1);
+}
+
+/**
+ * Validate a resource input value against the available capacity.
+ * Returns an error string or null if valid.
+ */
+function validateResourceInput(
+  inputValue: string,
+  unit: string,
+  totalAvailable: number
+): string | null {
+  if (!inputValue.trim()) return null;
+
+  const parsed = parseK8sQuantity(inputValue, unit);
+  if (isNaN(parsed)) {
+    if (unit === 'bytes') return 'Invalid format. Use e.g. 4Gi, 512Mi, 1Ti';
+    if (unit === 'cores') return 'Invalid format. Use e.g. 4, 500m, 1.5';
+    return 'Invalid number';
+  }
+
+  if (parsed <= 0) return 'Must be greater than 0';
+
+  if (totalAvailable > 0 && parsed > totalAvailable) {
+    const availFormatted =
+      unit === 'bytes'
+        ? formatHumanBytes(totalAvailable)
+        : `${Number.isInteger(totalAvailable) ? totalAvailable : totalAvailable.toFixed(1)} ${unit}`;
+    return `Exceeds available capacity (${availFormatted})`;
+  }
+
+  return null;
+}
+
 const CLI_TOOLS: { value: CliTool; label: string; description: string }[] = [
   { value: 'claude', label: 'Claude Code', description: 'Anthropic Claude CLI agent' },
   { value: 'codex', label: 'Codex', description: 'OpenAI Codex CLI agent' },
@@ -134,6 +237,37 @@ export function ConfigureStep({
         value: rt.name.replace('gpu_', ''),
       }));
   }, [clusterResources]);
+
+  // Aggregate available resources across nodes per resource type
+  const aggregatedResources = useMemo(() => {
+    if (!clusterResources || clusterResources.nodes.length === 0) return [];
+    return clusterResources.resourceTypes
+      .filter(rt => !rt.name.startsWith('gpu_'))
+      .map(rt => {
+        let totalAvailable = 0;
+        for (const node of clusterResources.nodes) {
+          const val = node.available[rt.resourceKey];
+          if (val) {
+            const parsed = parseK8sQuantity(val, rt.unit);
+            if (!isNaN(parsed)) totalAvailable += parsed;
+          }
+        }
+        return { resourceType: rt, totalAvailable };
+      });
+  }, [clusterResources]);
+
+  // Check if user has requested any GPU resources
+  const hasGpuRequested = useMemo(() => {
+    const gpuVal = state.resourceConfig.gpu;
+    if (gpuVal && gpuVal !== '0') return true;
+    // Also check dynamically discovered GPU resource types
+    return aggregatedResources.some(
+      ar =>
+        ar.resourceType.category === 'accelerator' &&
+        state.resourceConfig[ar.resourceType.name] &&
+        state.resourceConfig[ar.resourceType.name] !== '0'
+    );
+  }, [state.resourceConfig, aggregatedResources]);
 
   // Merge availableSecrets and stored credentials into a unified list
   const allCredentials = useMemo(() => {
@@ -1130,80 +1264,170 @@ export function ConfigureStep({
             {/* Resource Config */}
             <div className={styles.formGroup}>
               <label className={styles.formLabel}>Resources</label>
-              <div className={styles.resourceGrid}>
-                <div className={styles.resourceField}>
-                  <label className={styles.resourceLabel}>CPU</label>
-                  <input
-                    className={styles.formInput}
-                    value={state.resourceConfig.cpu ?? ''}
-                    onChange={e =>
-                      onChange({
-                        resourceConfig: {
-                          ...state.resourceConfig,
-                          cpu: e.target.value || undefined,
-                        },
-                      })
-                    }
-                    placeholder="e.g. 4"
-                  />
-                </div>
-                <div className={styles.resourceField}>
-                  <label className={styles.resourceLabel}>Memory</label>
-                  <input
-                    className={styles.formInput}
-                    value={state.resourceConfig.memory ?? ''}
-                    onChange={e =>
-                      onChange({
-                        resourceConfig: {
-                          ...state.resourceConfig,
-                          memory: e.target.value || undefined,
-                        },
-                      })
-                    }
-                    placeholder="e.g. 8Gi"
-                  />
-                </div>
-                <div className={styles.resourceField}>
-                  <label className={styles.resourceLabel}>GPU</label>
-                  <input
-                    className={styles.formInput}
-                    value={state.resourceConfig.gpu ?? ''}
-                    onChange={e =>
-                      onChange({
-                        resourceConfig: {
-                          ...state.resourceConfig,
-                          gpu: e.target.value || undefined,
-                        },
-                      })
-                    }
-                    placeholder="e.g. 1"
-                  />
-                </div>
-                {gpuTypes.length > 0 && (
+              {aggregatedResources.length > 0 ? (
+                <>
+                  {['compute', 'accelerator'].map(category => {
+                    const items = aggregatedResources.filter(
+                      ar => ar.resourceType.category === category
+                    );
+                    if (items.length === 0) return null;
+                    return (
+                      <div
+                        key={category}
+                        className={styles.resourceCategory}
+                        data-category={category}
+                      >
+                        <span className={styles.resourceCategoryLabel}>
+                          {category === 'compute' ? 'Compute' : 'Accelerator'}
+                        </span>
+                        <div className={styles.resourceGrid}>
+                          {items.map(({ resourceType: rt, totalAvailable }) => {
+                            const inputVal = state.resourceConfig[rt.name] ?? '';
+                            const error = validateResourceInput(inputVal, rt.unit, totalAvailable);
+                            const parsed = inputVal ? parseK8sQuantity(inputVal, rt.unit) : NaN;
+                            const showParsed =
+                              !isNaN(parsed) && rt.unit === 'bytes' && inputVal.trim() !== '';
+                            return (
+                              <div key={rt.name} className={styles.resourceField}>
+                                <label className={styles.resourceLabel}>
+                                  {rt.displayName}
+                                  <span className={styles.resourceUnit}>
+                                    {rt.unit === 'bytes'
+                                      ? 'e.g. 4Gi, 512Mi'
+                                      : rt.unit === 'cores'
+                                        ? 'e.g. 4, 500m'
+                                        : rt.unit}
+                                  </span>
+                                </label>
+                                <input
+                                  className={cn(styles.formInput, error && styles.formInputError)}
+                                  value={inputVal}
+                                  onChange={e =>
+                                    onChange({
+                                      resourceConfig: {
+                                        ...state.resourceConfig,
+                                        [rt.name]: e.target.value || undefined,
+                                      },
+                                    })
+                                  }
+                                  placeholder={
+                                    rt.name === 'memory' || rt.unit === 'bytes'
+                                      ? 'e.g. 8Gi'
+                                      : rt.name === 'cpu'
+                                        ? 'e.g. 4'
+                                        : 'e.g. 1'
+                                  }
+                                />
+                                {error ? (
+                                  <span className={styles.resourceError}>{error}</span>
+                                ) : (
+                                  <span
+                                    className={styles.resourceCapacity}
+                                    data-category={category}
+                                  >
+                                    {showParsed && `= ${formatHumanBytes(parsed)} · `}
+                                    {formatResourceValue(totalAvailable, rt.unit)}{' '}
+                                    {rt.unit === 'bytes' ? '' : rt.unit} available
+                                  </span>
+                                )}
+                              </div>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </>
+              ) : (
+                <div className={styles.resourceGrid}>
                   <div className={styles.resourceField}>
-                    <label className={styles.resourceLabel}>GPU Type</label>
-                    <select
-                      className={styles.formSelect}
-                      value={state.resourceConfig.gpu_type ?? ''}
+                    <label className={styles.resourceLabel}>CPU</label>
+                    <input
+                      className={styles.formInput}
+                      value={state.resourceConfig.cpu ?? ''}
                       onChange={e =>
                         onChange({
                           resourceConfig: {
                             ...state.resourceConfig,
-                            gpu_type: e.target.value || undefined,
+                            cpu: e.target.value || undefined,
                           },
                         })
                       }
-                    >
-                      <option value="">Any</option>
-                      {gpuTypes.map(gt => (
-                        <option key={gt.value} value={gt.value}>
-                          {gt.label}
-                        </option>
-                      ))}
-                    </select>
+                      placeholder="e.g. 4"
+                    />
                   </div>
-                )}
-              </div>
+                  <div className={styles.resourceField}>
+                    <label className={styles.resourceLabel}>Memory</label>
+                    <input
+                      className={styles.formInput}
+                      value={state.resourceConfig.memory ?? ''}
+                      onChange={e =>
+                        onChange({
+                          resourceConfig: {
+                            ...state.resourceConfig,
+                            memory: e.target.value || undefined,
+                          },
+                        })
+                      }
+                      placeholder="e.g. 8Gi"
+                    />
+                  </div>
+                </div>
+              )}
+              {gpuTypes.length > 0 && (
+                <div className={styles.resourceField}>
+                  <label className={styles.resourceLabel}>GPU Type</label>
+                  <select
+                    className={styles.formSelect}
+                    value={state.resourceConfig.gpu_type ?? ''}
+                    onChange={e =>
+                      onChange({
+                        resourceConfig: {
+                          ...state.resourceConfig,
+                          gpu_type: e.target.value || undefined,
+                        },
+                      })
+                    }
+                  >
+                    <option value="">Any</option>
+                    {gpuTypes.map(gt => (
+                      <option key={gt.value} value={gt.value}>
+                        {gt.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              )}
+              {hasGpuRequested && (
+                <div className={styles.toggleRow}>
+                  <label className={styles.formLabel}>GPU time-slicing</label>
+                  <button
+                    className={cn(
+                      styles.toggle,
+                      state.resourceConfig.gpu_timeslice === 'true' && styles.toggleActive
+                    )}
+                    onClick={() =>
+                      onChange({
+                        resourceConfig: {
+                          ...state.resourceConfig,
+                          gpu_timeslice:
+                            state.resourceConfig.gpu_timeslice === 'true' ? undefined : 'true',
+                        },
+                      })
+                    }
+                    type="button"
+                    role="switch"
+                    aria-checked={state.resourceConfig.gpu_timeslice === 'true'}
+                  >
+                    <span className={styles.toggleKnob} />
+                  </button>
+                </div>
+              )}
+              {hasGpuRequested && state.resourceConfig.gpu_timeslice === 'true' && (
+                <span className={styles.terminalRestrictedHint}>
+                  GPU is shared between the AI broker and your workload via NVIDIA time-slicing
+                </span>
+              )}
             </div>
 
             {/* Environment Variables */}

--- a/web/src/components/LaunchWizard/steps/ConfigureStep.tsx
+++ b/web/src/components/LaunchWizard/steps/ConfigureStep.tsx
@@ -22,6 +22,7 @@ import {
 } from 'lucide-react';
 import { cn } from '@/utils';
 import { serializePresetYaml, parsePresetYaml } from '@/utils/presetYaml';
+import { parseK8sQuantity, formatHumanBytes, formatResourceValue } from '@/utils/k8sQuantity';
 import type {
   VolundrPreset,
   VolundrRepo,
@@ -56,78 +57,6 @@ export interface ConfigureStepProps {
   onSavePreset: (
     preset: Omit<VolundrPreset, 'id' | 'createdAt' | 'updatedAt'> & { id?: string }
   ) => Promise<VolundrPreset>;
-}
-
-const BYTE_MULTIPLIERS: Record<string, number> = {
-  '': 1,
-  K: 1e3,
-  M: 1e6,
-  G: 1e9,
-  T: 1e12,
-  P: 1e15,
-  E: 1e18,
-  Ki: 1024,
-  Mi: 1024 ** 2,
-  Gi: 1024 ** 3,
-  Ti: 1024 ** 4,
-  Pi: 1024 ** 5,
-  Ei: 1024 ** 6,
-};
-
-/**
- * Parse a Kubernetes quantity string into a canonical numeric value.
- * - bytes unit: "8Gi" → bytes, "500Mi" → bytes, "8024304Ki" → bytes
- * - cores unit: "4" → 4, "500m" → 0.5, "1.5" → 1.5
- * - other: plain parseFloat
- * Returns NaN if the string is not a valid quantity.
- */
-function parseK8sQuantity(raw: string, unit: string): number {
-  const trimmed = raw.trim();
-  if (!trimmed) return NaN;
-
-  if (unit === 'bytes') {
-    const match = trimmed.match(/^(\d+(?:\.\d+)?)\s*([KMGTPE]i?)?$/);
-    if (!match) return NaN;
-    const num = parseFloat(match[1]);
-    const suffix = match[2] ?? '';
-    if (!(suffix in BYTE_MULTIPLIERS)) return NaN;
-    return num * BYTE_MULTIPLIERS[suffix];
-  }
-
-  if (unit === 'cores') {
-    // CPU supports millicores (e.g. "500m" = 0.5 cores) or plain numbers
-    const milliMatch = trimmed.match(/^(\d+)m$/);
-    if (milliMatch) return parseInt(milliMatch[1], 10) / 1000;
-    const num = parseFloat(trimmed);
-    if (isNaN(num) || num < 0) return NaN;
-    return num;
-  }
-
-  // Generic: plain number
-  const num = parseFloat(trimmed);
-  if (isNaN(num) || num < 0) return NaN;
-  return num;
-}
-
-function formatHumanBytes(bytes: number): string {
-  if (bytes >= 1024 ** 5) return `${(bytes / 1024 ** 5).toFixed(1)} PiB`;
-  if (bytes >= 1024 ** 4) return `${(bytes / 1024 ** 4).toFixed(1)} TiB`;
-  if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(1)} GiB`;
-  if (bytes >= 1024 ** 2) return `${(bytes / 1024 ** 2).toFixed(1)} MiB`;
-  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
-  return `${bytes} B`;
-}
-
-function formatResourceValue(value: number | string, unit: string): string {
-  const raw = String(value);
-  if (unit === 'bytes') {
-    const bytes = parseK8sQuantity(raw, 'bytes');
-    if (isNaN(bytes)) return raw;
-    return formatHumanBytes(bytes);
-  }
-  const num = parseFloat(raw) || 0;
-  if (Number.isInteger(num)) return String(num);
-  return num.toFixed(1);
 }
 
 /**

--- a/web/src/components/LaunchWizard/steps/ConfigureStep.tsx
+++ b/web/src/components/LaunchWizard/steps/ConfigureStep.tsx
@@ -35,7 +35,6 @@ import type {
   StoredCredential,
   IntegrationConnection,
   ClusterResourceInfo,
-  ResourceType,
 } from '@/models';
 import type { SourceType } from '../LaunchWizard';
 import type { IVolundrService } from '@/ports';

--- a/web/src/components/LaunchWizard/steps/ConfigureStep.tsx
+++ b/web/src/components/LaunchWizard/steps/ConfigureStep.tsx
@@ -34,6 +34,8 @@ import type {
   VolundrWorkspace,
   StoredCredential,
   IntegrationConnection,
+  ClusterResourceInfo,
+  ResourceType,
 } from '@/models';
 import type { SourceType } from '../LaunchWizard';
 import type { IVolundrService } from '@/ports';
@@ -102,6 +104,7 @@ export function ConfigureStep({
 
   const [credentials, setCredentials] = useState<StoredCredential[]>([]);
   const [integrations, setIntegrations] = useState<IntegrationConnection[]>([]);
+  const [clusterResources, setClusterResources] = useState<ClusterResourceInfo | null>(null);
 
   useEffect(() => {
     service
@@ -116,7 +119,22 @@ export function ConfigureStep({
       .getIntegrations()
       .then(setIntegrations)
       .catch(() => {});
+    service
+      .getClusterResources()
+      .then(setClusterResources)
+      .catch(() => {});
   }, [service]);
+
+  // Derive GPU types from cluster resources for dropdown
+  const gpuTypes = useMemo(() => {
+    if (!clusterResources) return [];
+    return clusterResources.resourceTypes
+      .filter(rt => rt.category === 'accelerator' && rt.name.startsWith('gpu_'))
+      .map(rt => ({
+        label: rt.displayName,
+        value: rt.name.replace('gpu_', ''),
+      }));
+  }, [clusterResources]);
 
   // Merge availableSecrets and stored credentials into a unified list
   const allCredentials = useMemo(() => {
@@ -1162,6 +1180,30 @@ export function ConfigureStep({
                     placeholder="e.g. 1"
                   />
                 </div>
+                {gpuTypes.length > 0 && (
+                  <div className={styles.resourceField}>
+                    <label className={styles.resourceLabel}>GPU Type</label>
+                    <select
+                      className={styles.formSelect}
+                      value={state.resourceConfig.gpu_type ?? ''}
+                      onChange={e =>
+                        onChange({
+                          resourceConfig: {
+                            ...state.resourceConfig,
+                            gpu_type: e.target.value || undefined,
+                          },
+                        })
+                      }
+                    >
+                      <option value="">Any</option>
+                      {gpuTypes.map(gt => (
+                        <option key={gt.value} value={gt.value}>
+                          {gt.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                )}
               </div>
             </div>
 

--- a/web/src/hooks/useVolundr.ts
+++ b/web/src/hooks/useVolundr.ts
@@ -43,6 +43,7 @@ interface UseVolundrResult {
     workspaceId?: string;
     credentialNames?: string[];
     integrationIds?: string[];
+    resourceConfig?: Record<string, string | undefined>;
   }) => Promise<VolundrSession>;
   connectSession: (config: { name: string; hostname: string }) => Promise<VolundrSession>;
   stopSession: (sessionId: string) => Promise<void>;
@@ -219,6 +220,7 @@ export function useVolundr(): UseVolundrResult {
       workspaceId?: string;
       credentialNames?: string[];
       integrationIds?: string[];
+      resourceConfig?: Record<string, string | undefined>;
     }) => {
       return volundrService.startSession(config);
     },

--- a/web/src/models/index.ts
+++ b/web/src/models/index.ts
@@ -57,6 +57,9 @@ export type { MimirStats, MimirConsultation } from './mimir.model';
 
 export type {
   VolundrFeatures,
+  ResourceType,
+  NodeResourceSummary,
+  ClusterResourceInfo,
   ModelTier,
   ModelProvider,
   GitSource,

--- a/web/src/models/volundr.model.ts
+++ b/web/src/models/volundr.model.ts
@@ -4,6 +4,27 @@ export interface VolundrFeatures {
   localMountsEnabled: boolean;
 }
 
+export interface ResourceType {
+  name: string;
+  resourceKey: string;
+  displayName: string;
+  unit: string;
+  category: string;
+}
+
+export interface NodeResourceSummary {
+  name: string;
+  labels: Record<string, string>;
+  allocatable: Record<string, string>;
+  allocated: Record<string, string>;
+  available: Record<string, string>;
+}
+
+export interface ClusterResourceInfo {
+  resourceTypes: ResourceType[];
+  nodes: NodeResourceSummary[];
+}
+
 export type ModelTier = 'frontier' | 'balanced' | 'execution' | 'reasoning';
 export type ModelProvider = 'cloud' | 'local';
 export type SessionOrigin = 'managed' | 'manual';

--- a/web/src/pages/Admin/Admin.tsx
+++ b/web/src/pages/Admin/Admin.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Users, Building2, HardDrive } from 'lucide-react';
+import { Users, Building2, HardDrive, Cpu } from 'lucide-react';
 import type { IVolundrService } from '@/ports';
 import { SectionLayout } from '@/components/SectionLayout';
 import type { SectionDefinition } from '@/components/SectionLayout';
@@ -7,11 +7,13 @@ import { AdminGuard } from '@/components/AdminGuard';
 import { UsersSection } from './sections/UsersSection';
 import { TenantsSection } from './sections/TenantsSection';
 import { StorageSection } from './sections/StorageSection';
+import { ResourcesSection } from './sections/ResourcesSection';
 
 const sections: SectionDefinition[] = [
   { key: 'users', label: 'Users', icon: Users, component: UsersSection },
   { key: 'tenants', label: 'Tenants', icon: Building2, component: TenantsSection },
   { key: 'storage', label: 'Storage', icon: HardDrive, component: StorageSection },
+  { key: 'resources', label: 'Resources', icon: Cpu, component: ResourcesSection },
 ];
 
 interface AdminPageProps {

--- a/web/src/pages/Admin/sections/ResourcesSection.module.css
+++ b/web/src/pages/Admin/sections/ResourcesSection.module.css
@@ -1,0 +1,201 @@
+/* ═══════════════════════════════════════════════════════════════
+   ResourcesSection — Admin cluster resource overview
+   ═══════════════════════════════════════════════════════════════ */
+
+.section {
+  padding: var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+  animation: fadeIn var(--transition-normal);
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+/* ─── Header ─── */
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.headerTitle {
+  font-size: var(--text-lg);
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.refreshButton {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background-color: var(--color-bg-tertiary);
+  color: var(--color-text-secondary);
+  font-size: var(--text-sm);
+  font-family: var(--font-sans);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.refreshButton:hover {
+  background-color: var(--color-bg-elevated);
+  color: var(--color-text-primary);
+}
+
+.refreshIcon {
+  width: 14px;
+  height: 14px;
+}
+
+/* ─── Summary Cards ─── */
+.summaryCards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: var(--space-3);
+}
+
+.summaryCard {
+  padding: var(--space-3);
+  background-color: var(--color-bg-secondary);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-subtle);
+}
+
+.summaryCard[data-category='compute'] {
+  border-left: 3px solid var(--color-accent-cyan);
+}
+
+.summaryCard[data-category='accelerator'] {
+  border-left: 3px solid var(--color-accent-purple);
+}
+
+.summaryLabel {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.summaryValue {
+  font-size: var(--text-xl);
+  font-weight: 700;
+  color: var(--color-text-primary);
+  font-family: var(--font-mono);
+}
+
+.summaryDetail {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  font-family: var(--font-mono);
+  margin-top: var(--space-1);
+}
+
+/* ─── Table ─── */
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.tableHeader {
+  text-align: left;
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.tableRow {
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.tableRow:hover {
+  background-color: var(--color-bg-secondary);
+}
+
+.tableCell {
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+}
+
+.nodeCell {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+}
+
+.resourceCell {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+}
+
+/* ─── Utilization Badge ─── */
+.utilizationBadge {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-full);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  font-family: var(--font-mono);
+}
+
+.utilizationBadge[data-status='healthy'] {
+  background-color: color-mix(in srgb, var(--color-accent-emerald) 20%, transparent);
+  color: var(--color-accent-emerald);
+}
+
+.utilizationBadge[data-status='warning'] {
+  background-color: color-mix(in srgb, var(--color-accent-amber) 20%, transparent);
+  color: var(--color-accent-amber);
+}
+
+.utilizationBadge[data-status='critical'] {
+  background-color: color-mix(in srgb, var(--color-accent-red) 20%, transparent);
+  color: var(--color-accent-red);
+}
+
+/* ─── Empty & Loading States ─── */
+.emptyState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-12) var(--space-4);
+  color: var(--color-text-muted);
+  gap: var(--space-3);
+  border: 1px dashed var(--color-border-subtle);
+  border-radius: var(--radius-lg);
+}
+
+.emptyStateIcon {
+  width: 48px;
+  height: 48px;
+  opacity: 0.3;
+  color: var(--color-text-faint);
+}
+
+.emptyStateText {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+}
+
+.loadingSpinner {
+  display: flex;
+  justify-content: center;
+  padding: var(--space-10);
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+}

--- a/web/src/pages/Admin/sections/ResourcesSection.test.tsx
+++ b/web/src/pages/Admin/sections/ResourcesSection.test.tsx
@@ -183,4 +183,142 @@ describe('ResourcesSection', () => {
     const gpuCard = gpuElements[0].closest('[data-category]');
     expect(gpuCard).toHaveAttribute('data-category', 'accelerator');
   });
+
+  it('handles nodes with unparseable resource values gracefully', async () => {
+    const badResources: ClusterResourceInfo = {
+      resourceTypes: [
+        {
+          name: 'cpu',
+          resourceKey: 'cpu',
+          displayName: 'CPU',
+          unit: 'cores',
+          category: 'compute',
+        },
+      ],
+      nodes: [
+        {
+          name: 'bad-node',
+          labels: {},
+          allocatable: { cpu: 'not-a-number' },
+          allocated: { cpu: 'also-bad' },
+          available: { cpu: 'nope' },
+        },
+      ],
+    };
+
+    service = createMockService(badResources);
+    render(<ResourcesSection service={service} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('bad-node')).toBeInTheDocument();
+    });
+  });
+
+  it('handles nodes with missing resource keys using defaults', async () => {
+    const sparseResources: ClusterResourceInfo = {
+      resourceTypes: [
+        {
+          name: 'cpu',
+          resourceKey: 'cpu',
+          displayName: 'CPU',
+          unit: 'cores',
+          category: 'compute',
+        },
+        {
+          name: 'gpu',
+          resourceKey: 'nvidia.com/gpu',
+          displayName: 'GPU',
+          unit: 'devices',
+          category: 'accelerator',
+        },
+      ],
+      nodes: [
+        {
+          name: 'sparse-node',
+          labels: {},
+          allocatable: { cpu: '8' },
+          allocated: { cpu: '4' },
+          available: { cpu: '4' },
+        },
+      ],
+    };
+
+    service = createMockService(sparseResources);
+    render(<ResourcesSection service={service} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('sparse-node')).toBeInTheDocument();
+    });
+
+    // GPU should show 0/0 with 0% utilization (calculateUtilization with total=0)
+    const zeroBadges = screen.getAllByText('0%');
+    expect(zeroBadges.length).toBeGreaterThan(0);
+  });
+
+  it('renders resources with bytes unit formatted correctly in summary', async () => {
+    const bytesResources: ClusterResourceInfo = {
+      resourceTypes: [
+        {
+          name: 'memory',
+          resourceKey: 'memory',
+          displayName: 'Memory',
+          unit: 'bytes',
+          category: 'compute',
+        },
+      ],
+      nodes: [
+        {
+          name: 'mem-node',
+          labels: {},
+          allocatable: { memory: '8Gi' },
+          allocated: { memory: '4Gi' },
+          available: { memory: '4Gi' },
+        },
+      ],
+    };
+
+    service = createMockService(bytesResources);
+    render(<ResourcesSection service={service} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('mem-node')).toBeInTheDocument();
+    });
+
+    // bytes unit: summary card shows formatted bytes without unit suffix
+    // Available 4Gi = 4.0 GiB
+    expect(screen.getByText('4.0 GiB')).toBeInTheDocument();
+  });
+
+  it('renders 0% utilization when allocatable is zero', async () => {
+    const zeroResources: ClusterResourceInfo = {
+      resourceTypes: [
+        {
+          name: 'gpu',
+          resourceKey: 'nvidia.com/gpu',
+          displayName: 'GPU',
+          unit: 'devices',
+          category: 'accelerator',
+        },
+      ],
+      nodes: [
+        {
+          name: 'no-gpu-node',
+          labels: {},
+          allocatable: { 'nvidia.com/gpu': '0' },
+          allocated: { 'nvidia.com/gpu': '0' },
+          available: { 'nvidia.com/gpu': '0' },
+        },
+      ],
+    };
+
+    service = createMockService(zeroResources);
+    render(<ResourcesSection service={service} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('no-gpu-node')).toBeInTheDocument();
+    });
+
+    // 0/0 = 0% utilization
+    expect(screen.getByText('0%')).toHaveAttribute('data-status', 'healthy');
+  });
 });

--- a/web/src/pages/Admin/sections/ResourcesSection.test.tsx
+++ b/web/src/pages/Admin/sections/ResourcesSection.test.tsx
@@ -1,0 +1,186 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { ResourcesSection } from './ResourcesSection';
+import type { IVolundrService } from '@/ports';
+import type { ClusterResourceInfo } from '@/models';
+
+const mockResources: ClusterResourceInfo = {
+  resourceTypes: [
+    {
+      name: 'cpu',
+      resourceKey: 'cpu',
+      displayName: 'CPU',
+      unit: 'cores',
+      category: 'compute',
+    },
+    {
+      name: 'memory',
+      resourceKey: 'memory',
+      displayName: 'Memory',
+      unit: 'Gi',
+      category: 'compute',
+    },
+    {
+      name: 'gpu',
+      resourceKey: 'nvidia.com/gpu',
+      displayName: 'GPU',
+      unit: 'devices',
+      category: 'accelerator',
+    },
+  ],
+  nodes: [
+    {
+      name: 'node-1',
+      labels: {},
+      allocatable: { cpu: '16', memory: '64', 'nvidia.com/gpu': '2' },
+      allocated: { cpu: '8', memory: '32', 'nvidia.com/gpu': '1' },
+      available: { cpu: '8', memory: '32', 'nvidia.com/gpu': '1' },
+    },
+    {
+      name: 'node-2',
+      labels: {},
+      allocatable: { cpu: '16', memory: '64', 'nvidia.com/gpu': '0' },
+      allocated: { cpu: '14', memory: '60', 'nvidia.com/gpu': '0' },
+      available: { cpu: '2', memory: '4', 'nvidia.com/gpu': '0' },
+    },
+  ],
+};
+
+const emptyResources: ClusterResourceInfo = {
+  resourceTypes: [
+    {
+      name: 'cpu',
+      resourceKey: 'cpu',
+      displayName: 'CPU',
+      unit: 'cores',
+      category: 'compute',
+    },
+  ],
+  nodes: [],
+};
+
+function createMockService(data: ClusterResourceInfo = mockResources): IVolundrService {
+  return {
+    getClusterResources: vi.fn().mockResolvedValue(data),
+  } as unknown as IVolundrService;
+}
+
+describe('ResourcesSection', () => {
+  let service: IVolundrService;
+
+  beforeEach(() => {
+    service = createMockService();
+  });
+
+  it('renders loading state initially', () => {
+    service = {
+      getClusterResources: vi.fn().mockReturnValue(new Promise(() => {})),
+    } as unknown as IVolundrService;
+
+    render(<ResourcesSection service={service} />);
+    expect(screen.getByText('Loading cluster resources...')).toBeInTheDocument();
+  });
+
+  it('renders summary cards for each resource type', async () => {
+    render(<ResourcesSection service={service} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Cluster Resources')).toBeInTheDocument();
+    });
+
+    // Each resource type appears in both summary card and table header
+    expect(screen.getAllByText('CPU')).toHaveLength(2);
+    expect(screen.getAllByText('Memory')).toHaveLength(2);
+    expect(screen.getAllByText('GPU')).toHaveLength(2);
+  });
+
+  it('renders summary card values aggregated across nodes', async () => {
+    render(<ResourcesSection service={service} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Cluster Resources')).toBeInTheDocument();
+    });
+
+    // CPU available: 8 + 2 = 10
+    expect(screen.getByText('10 cores')).toBeInTheDocument();
+    // Memory available: 32 + 4 = 36
+    expect(screen.getByText('36 Gi')).toBeInTheDocument();
+  });
+
+  it('renders node table with correct data', async () => {
+    render(<ResourcesSection service={service} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('node-1')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('node-2')).toBeInTheDocument();
+    // Check table headers
+    expect(screen.getByText('Node')).toBeInTheDocument();
+  });
+
+  it('renders utilization badges with correct status', async () => {
+    render(<ResourcesSection service={service} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('node-1')).toBeInTheDocument();
+    });
+
+    // node-1 CPU: 8/16 = 50% -> healthy
+    const badges = screen.getAllByText('50%');
+    expect(badges[0]).toHaveAttribute('data-status', 'healthy');
+
+    // node-2 CPU: 14/16 = 88% -> warning
+    const warningBadges = screen.getAllByText('88%');
+    expect(warningBadges[0]).toHaveAttribute('data-status', 'warning');
+
+    // node-2 memory: 60/64 = 94% -> critical
+    const criticalBadges = screen.getAllByText('94%');
+    expect(criticalBadges[0]).toHaveAttribute('data-status', 'critical');
+  });
+
+  it('renders empty state when no nodes', async () => {
+    service = createMockService(emptyResources);
+    render(<ResourcesSection service={service} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'No node-level data available. Resource discovery is using a static provider.'
+        )
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('refresh button triggers re-fetch', async () => {
+    render(<ResourcesSection service={service} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Cluster Resources')).toBeInTheDocument();
+    });
+
+    expect(service.getClusterResources).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByText('Refresh'));
+
+    await waitFor(() => {
+      expect(service.getClusterResources).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('applies correct data-category attributes to summary cards', async () => {
+    render(<ResourcesSection service={service} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Cluster Resources')).toBeInTheDocument();
+    });
+
+    const cpuElements = screen.getAllByText('CPU');
+    const cpuCard = cpuElements[0].closest('[data-category]');
+    expect(cpuCard).toHaveAttribute('data-category', 'compute');
+
+    const gpuElements = screen.getAllByText('GPU');
+    const gpuCard = gpuElements[0].closest('[data-category]');
+    expect(gpuCard).toHaveAttribute('data-category', 'accelerator');
+  });
+});

--- a/web/src/pages/Admin/sections/ResourcesSection.tsx
+++ b/web/src/pages/Admin/sections/ResourcesSection.tsx
@@ -5,6 +5,52 @@ import type { IVolundrService } from '@/ports';
 import { cn } from '@/utils/classnames';
 import styles from './ResourcesSection.module.css';
 
+/**
+ * Parse a Kubernetes quantity string (e.g. "8024304Ki", "929001317467", "4Gi")
+ * into a raw byte count. Returns NaN for non-byte values.
+ */
+function parseK8sBytes(raw: string): number {
+  const match = raw.match(/^(\d+(?:\.\d+)?)\s*([KMGTPE]i?)?$/);
+  if (!match) return parseFloat(raw) || 0;
+  const num = parseFloat(match[1]);
+  const suffix = match[2] ?? '';
+  const multipliers: Record<string, number> = {
+    '': 1,
+    K: 1e3,
+    M: 1e6,
+    G: 1e9,
+    T: 1e12,
+    P: 1e15,
+    E: 1e18,
+    Ki: 1024,
+    Mi: 1024 ** 2,
+    Gi: 1024 ** 3,
+    Ti: 1024 ** 4,
+    Pi: 1024 ** 5,
+    Ei: 1024 ** 6,
+  };
+  return num * (multipliers[suffix] ?? 1);
+}
+
+function formatHumanBytes(bytes: number): string {
+  if (bytes >= 1024 ** 5) return `${(bytes / 1024 ** 5).toFixed(1)} PiB`;
+  if (bytes >= 1024 ** 4) return `${(bytes / 1024 ** 4).toFixed(1)} TiB`;
+  if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(1)} GiB`;
+  if (bytes >= 1024 ** 2) return `${(bytes / 1024 ** 2).toFixed(1)} MiB`;
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
+  return `${bytes} B`;
+}
+
+function formatResourceValue(value: number | string, unit: string): string {
+  const raw = String(value);
+  if (unit === 'bytes') {
+    return formatHumanBytes(parseK8sBytes(raw));
+  }
+  const num = parseFloat(raw) || 0;
+  if (Number.isInteger(num)) return String(num);
+  return num.toFixed(1);
+}
+
 function calculateUtilization(allocated: string, allocatable: string): number {
   const alloc = parseFloat(allocated) || 0;
   const total = parseFloat(allocatable) || 0;
@@ -31,6 +77,11 @@ interface AggregatedResource {
   available: number;
 }
 
+function parseNodeValue(raw: string, unit: string): number {
+  if (unit === 'bytes') return parseK8sBytes(raw);
+  return parseFloat(raw) || 0;
+}
+
 function aggregateResources(
   resourceTypes: ResourceType[],
   nodes: NodeResourceSummary[]
@@ -41,9 +92,9 @@ function aggregateResources(
     let available = 0;
 
     for (const node of nodes) {
-      allocatable += parseFloat(node.allocatable[rt.resourceKey] ?? '0') || 0;
-      allocated += parseFloat(node.allocated[rt.resourceKey] ?? '0') || 0;
-      available += parseFloat(node.available[rt.resourceKey] ?? '0') || 0;
+      allocatable += parseNodeValue(node.allocatable[rt.resourceKey] ?? '0', rt.unit);
+      allocated += parseNodeValue(node.allocated[rt.resourceKey] ?? '0', rt.unit);
+      available += parseNodeValue(node.available[rt.resourceKey] ?? '0', rt.unit);
     }
 
     return { resourceType: rt, allocatable, allocated, available };
@@ -104,10 +155,12 @@ export function ResourcesSection({ service }: ResourcesSectionProps) {
           >
             <div className={styles.summaryLabel}>{agg.resourceType.displayName}</div>
             <div className={styles.summaryValue}>
-              {agg.available} {agg.resourceType.unit}
+              {formatResourceValue(agg.available, agg.resourceType.unit)}{' '}
+              {agg.resourceType.unit === 'bytes' ? '' : agg.resourceType.unit}
             </div>
             <div className={styles.summaryDetail}>
-              {agg.allocated} / {agg.allocatable} {agg.resourceType.unit} used
+              {formatResourceValue(agg.allocated, agg.resourceType.unit)} /{' '}
+              {formatResourceValue(agg.allocatable, agg.resourceType.unit)} used
             </div>
           </div>
         ))}
@@ -148,7 +201,8 @@ export function ResourcesSection({ service }: ResourcesSectionProps) {
                         key={rt.resourceKey}
                         className={cn(styles.tableCell, styles.resourceCell)}
                       >
-                        {allocated} / {allocatable}{' '}
+                        {formatResourceValue(allocated, rt.unit)} /{' '}
+                        {formatResourceValue(allocatable, rt.unit)}{' '}
                         <span className={styles.utilizationBadge} data-status={status}>
                           {pct}%
                         </span>

--- a/web/src/pages/Admin/sections/ResourcesSection.tsx
+++ b/web/src/pages/Admin/sections/ResourcesSection.tsx
@@ -3,53 +3,8 @@ import { Cpu, RefreshCw } from 'lucide-react';
 import type { ClusterResourceInfo, ResourceType, NodeResourceSummary } from '@/models';
 import type { IVolundrService } from '@/ports';
 import { cn } from '@/utils/classnames';
+import { parseK8sQuantity, formatResourceValue } from '@/utils/k8sQuantity';
 import styles from './ResourcesSection.module.css';
-
-/**
- * Parse a Kubernetes quantity string (e.g. "8024304Ki", "929001317467", "4Gi")
- * into a raw byte count. Returns NaN for non-byte values.
- */
-function parseK8sBytes(raw: string): number {
-  const match = raw.match(/^(\d+(?:\.\d+)?)\s*([KMGTPE]i?)?$/);
-  if (!match) return parseFloat(raw) || 0;
-  const num = parseFloat(match[1]);
-  const suffix = match[2] ?? '';
-  const multipliers: Record<string, number> = {
-    '': 1,
-    K: 1e3,
-    M: 1e6,
-    G: 1e9,
-    T: 1e12,
-    P: 1e15,
-    E: 1e18,
-    Ki: 1024,
-    Mi: 1024 ** 2,
-    Gi: 1024 ** 3,
-    Ti: 1024 ** 4,
-    Pi: 1024 ** 5,
-    Ei: 1024 ** 6,
-  };
-  return num * (multipliers[suffix] ?? 1);
-}
-
-function formatHumanBytes(bytes: number): string {
-  if (bytes >= 1024 ** 5) return `${(bytes / 1024 ** 5).toFixed(1)} PiB`;
-  if (bytes >= 1024 ** 4) return `${(bytes / 1024 ** 4).toFixed(1)} TiB`;
-  if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(1)} GiB`;
-  if (bytes >= 1024 ** 2) return `${(bytes / 1024 ** 2).toFixed(1)} MiB`;
-  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
-  return `${bytes} B`;
-}
-
-function formatResourceValue(value: number | string, unit: string): string {
-  const raw = String(value);
-  if (unit === 'bytes') {
-    return formatHumanBytes(parseK8sBytes(raw));
-  }
-  const num = parseFloat(raw) || 0;
-  if (Number.isInteger(num)) return String(num);
-  return num.toFixed(1);
-}
 
 function calculateUtilization(allocated: string, allocatable: string): number {
   const alloc = parseFloat(allocated) || 0;
@@ -78,8 +33,8 @@ interface AggregatedResource {
 }
 
 function parseNodeValue(raw: string, unit: string): number {
-  if (unit === 'bytes') return parseK8sBytes(raw);
-  return parseFloat(raw) || 0;
+  const parsed = parseK8sQuantity(raw, unit);
+  return isNaN(parsed) ? 0 : parsed;
 }
 
 function aggregateResources(

--- a/web/src/pages/Admin/sections/ResourcesSection.tsx
+++ b/web/src/pages/Admin/sections/ResourcesSection.tsx
@@ -1,0 +1,166 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { Cpu, RefreshCw } from 'lucide-react';
+import type { ClusterResourceInfo, ResourceType, NodeResourceSummary } from '@/models';
+import type { IVolundrService } from '@/ports';
+import { cn } from '@/utils/classnames';
+import styles from './ResourcesSection.module.css';
+
+function calculateUtilization(allocated: string, allocatable: string): number {
+  const alloc = parseFloat(allocated) || 0;
+  const total = parseFloat(allocatable) || 0;
+  if (total === 0) {
+    return 0;
+  }
+  return Math.round((alloc / total) * 100);
+}
+
+function getUtilizationStatus(pct: number): 'healthy' | 'warning' | 'critical' {
+  if (pct >= 90) {
+    return 'critical';
+  }
+  if (pct >= 70) {
+    return 'warning';
+  }
+  return 'healthy';
+}
+
+interface AggregatedResource {
+  resourceType: ResourceType;
+  allocatable: number;
+  allocated: number;
+  available: number;
+}
+
+function aggregateResources(
+  resourceTypes: ResourceType[],
+  nodes: NodeResourceSummary[]
+): AggregatedResource[] {
+  return resourceTypes.map(rt => {
+    let allocatable = 0;
+    let allocated = 0;
+    let available = 0;
+
+    for (const node of nodes) {
+      allocatable += parseFloat(node.allocatable[rt.resourceKey] ?? '0') || 0;
+      allocated += parseFloat(node.allocated[rt.resourceKey] ?? '0') || 0;
+      available += parseFloat(node.available[rt.resourceKey] ?? '0') || 0;
+    }
+
+    return { resourceType: rt, allocatable, allocated, available };
+  });
+}
+
+interface ResourcesSectionProps {
+  service: IVolundrService;
+}
+
+export function ResourcesSection({ service }: ResourcesSectionProps) {
+  const [resources, setResources] = useState<ClusterResourceInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const loadResources = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await service.getClusterResources();
+      setResources(data);
+    } finally {
+      setLoading(false);
+    }
+  }, [service]);
+
+  useEffect(() => {
+    loadResources();
+  }, [loadResources]);
+
+  const aggregated = useMemo(() => {
+    if (!resources) {
+      return [];
+    }
+    return aggregateResources(resources.resourceTypes, resources.nodes);
+  }, [resources]);
+
+  if (loading) {
+    return <div className={styles.loadingSpinner}>Loading cluster resources...</div>;
+  }
+
+  return (
+    <div className={styles.section}>
+      {/* Header */}
+      <div className={styles.header}>
+        <span className={styles.headerTitle}>Cluster Resources</span>
+        <button type="button" className={styles.refreshButton} onClick={loadResources}>
+          <RefreshCw className={styles.refreshIcon} />
+          Refresh
+        </button>
+      </div>
+
+      {/* Summary cards */}
+      <div className={styles.summaryCards}>
+        {aggregated.map(agg => (
+          <div
+            key={agg.resourceType.resourceKey}
+            className={styles.summaryCard}
+            data-category={agg.resourceType.category}
+          >
+            <div className={styles.summaryLabel}>{agg.resourceType.displayName}</div>
+            <div className={styles.summaryValue}>
+              {agg.available} {agg.resourceType.unit}
+            </div>
+            <div className={styles.summaryDetail}>
+              {agg.allocated} / {agg.allocatable} {agg.resourceType.unit} used
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Node table */}
+      {resources && resources.nodes.length === 0 ? (
+        <div className={styles.emptyState}>
+          <Cpu className={styles.emptyStateIcon} />
+          <span className={styles.emptyStateText}>
+            No node-level data available. Resource discovery is using a static provider.
+          </span>
+        </div>
+      ) : (
+        resources && (
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th className={styles.tableHeader}>Node</th>
+                {resources.resourceTypes.map(rt => (
+                  <th key={rt.resourceKey} className={styles.tableHeader}>
+                    {rt.displayName}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {resources.nodes.map(node => (
+                <tr key={node.name} className={styles.tableRow}>
+                  <td className={cn(styles.tableCell, styles.nodeCell)}>{node.name}</td>
+                  {resources.resourceTypes.map(rt => {
+                    const allocated = node.allocated[rt.resourceKey] ?? '0';
+                    const allocatable = node.allocatable[rt.resourceKey] ?? '0';
+                    const pct = calculateUtilization(allocated, allocatable);
+                    const status = getUtilizationStatus(pct);
+                    return (
+                      <td
+                        key={rt.resourceKey}
+                        className={cn(styles.tableCell, styles.resourceCell)}
+                      >
+                        {allocated} / {allocatable}{' '}
+                        <span className={styles.utilizationBadge} data-status={status}>
+                          {pct}%
+                        </span>
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/Volundr/index.tsx
+++ b/web/src/pages/Volundr/index.tsx
@@ -541,9 +541,11 @@ export function VolundrPage() {
           templateName: config.templateName,
           taskType: config.taskType,
           linearIssue: config.linearIssue,
+          terminalRestricted: config.terminalRestricted,
           workspaceId: config.workspaceId,
           credentialNames: config.credentialNames,
           integrationIds: config.integrationIds,
+          resourceConfig: config.resourceConfig,
         });
         setSelectedSession(session);
         setShowLaunchWizard(false);

--- a/web/src/pages/Volundr/index.tsx
+++ b/web/src/pages/Volundr/index.tsx
@@ -380,6 +380,7 @@ export function VolundrPage() {
     effectiveSelectedSession?.chatEndpoint,
     effectiveSelectedSession?.status,
     effectiveSelectedSession?.source,
+    effectiveSelectedSession?.origin,
     getLogs,
     fetchSessionHostLogs,
   ]);
@@ -418,6 +419,7 @@ export function VolundrPage() {
     effectiveSelectedSession?.status,
     effectiveSelectedSession?.source,
     effectiveSelectedSession?.hostname,
+    effectiveSelectedSession?.origin,
     getCodeServerUrl,
   ]);
 

--- a/web/src/ports/volundr.port.ts
+++ b/web/src/ports/volundr.port.ts
@@ -7,6 +7,7 @@ import type {
   VolundrMessage,
   VolundrLog,
   SessionChronicle,
+  ClusterResourceInfo,
   DiffData,
   DiffBase,
   PullRequest,
@@ -145,6 +146,11 @@ export interface IVolundrService {
   ): Promise<{ name: string; keys: string[] }>;
 
   /**
+   * Get cluster resource types and capacity
+   */
+  getClusterResources(): Promise<ClusterResourceInfo>;
+
+  /**
    * Start a new session
    */
   startSession(config: {
@@ -158,6 +164,7 @@ export interface IVolundrService {
     workspaceId?: string;
     credentialNames?: string[];
     integrationIds?: string[];
+    resourceConfig?: Record<string, string | undefined>;
   }): Promise<VolundrSession>;
 
   /**

--- a/web/src/utils/index.ts
+++ b/web/src/utils/index.ts
@@ -12,3 +12,9 @@ export {
 } from './formatters';
 export { serializePresetYaml, parsePresetYaml } from './presetYaml';
 export type { PresetRuntimeFields } from './presetYaml';
+export {
+  BYTE_MULTIPLIERS,
+  parseK8sQuantity,
+  formatHumanBytes,
+  formatResourceValue,
+} from './k8sQuantity';

--- a/web/src/utils/k8sQuantity.test.ts
+++ b/web/src/utils/k8sQuantity.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseK8sQuantity,
+  formatHumanBytes,
+  formatResourceValue,
+  BYTE_MULTIPLIERS,
+} from './k8sQuantity';
+
+describe('BYTE_MULTIPLIERS', () => {
+  it('contains SI and binary suffixes', () => {
+    expect(BYTE_MULTIPLIERS['K']).toBe(1e3);
+    expect(BYTE_MULTIPLIERS['Ki']).toBe(1024);
+    expect(BYTE_MULTIPLIERS['Gi']).toBe(1024 ** 3);
+    expect(BYTE_MULTIPLIERS['']).toBe(1);
+  });
+});
+
+describe('parseK8sQuantity', () => {
+  describe('bytes unit', () => {
+    it('parses plain bytes', () => {
+      expect(parseK8sQuantity('1024', 'bytes')).toBe(1024);
+    });
+    it('parses Ki suffix', () => {
+      expect(parseK8sQuantity('8Ki', 'bytes')).toBe(8 * 1024);
+    });
+    it('parses Mi suffix', () => {
+      expect(parseK8sQuantity('512Mi', 'bytes')).toBe(512 * 1024 ** 2);
+    });
+    it('parses Gi suffix', () => {
+      expect(parseK8sQuantity('4Gi', 'bytes')).toBe(4 * 1024 ** 3);
+    });
+    it('parses SI suffix G', () => {
+      expect(parseK8sQuantity('2G', 'bytes')).toBe(2e9);
+    });
+    it('returns NaN for invalid byte string', () => {
+      expect(parseK8sQuantity('abc', 'bytes')).toBeNaN();
+    });
+    it('returns NaN for empty string', () => {
+      expect(parseK8sQuantity('', 'bytes')).toBeNaN();
+    });
+    it('returns NaN for unknown suffix', () => {
+      expect(parseK8sQuantity('8Xi', 'bytes')).toBeNaN();
+    });
+    it('handles whitespace', () => {
+      expect(parseK8sQuantity('  4Gi  ', 'bytes')).toBe(4 * 1024 ** 3);
+    });
+    it('parses decimal bytes', () => {
+      expect(parseK8sQuantity('1.5Gi', 'bytes')).toBe(1.5 * 1024 ** 3);
+    });
+  });
+
+  describe('cores unit', () => {
+    it('parses plain number', () => {
+      expect(parseK8sQuantity('4', 'cores')).toBe(4);
+    });
+    it('parses millicores', () => {
+      expect(parseK8sQuantity('500m', 'cores')).toBe(0.5);
+    });
+    it('parses decimal cores', () => {
+      expect(parseK8sQuantity('1.5', 'cores')).toBe(1.5);
+    });
+    it('returns NaN for negative cores', () => {
+      expect(parseK8sQuantity('-1', 'cores')).toBeNaN();
+    });
+    it('returns NaN for non-numeric', () => {
+      expect(parseK8sQuantity('abc', 'cores')).toBeNaN();
+    });
+  });
+
+  describe('generic unit', () => {
+    it('parses plain number', () => {
+      expect(parseK8sQuantity('3', 'count')).toBe(3);
+    });
+    it('returns NaN for negative', () => {
+      expect(parseK8sQuantity('-5', 'count')).toBeNaN();
+    });
+    it('returns NaN for non-numeric', () => {
+      expect(parseK8sQuantity('xyz', 'count')).toBeNaN();
+    });
+  });
+});
+
+describe('formatHumanBytes', () => {
+  it('formats bytes', () => {
+    expect(formatHumanBytes(500)).toBe('500 B');
+  });
+  it('formats KiB', () => {
+    expect(formatHumanBytes(2048)).toBe('2.0 KiB');
+  });
+  it('formats MiB', () => {
+    expect(formatHumanBytes(5 * 1024 ** 2)).toBe('5.0 MiB');
+  });
+  it('formats GiB', () => {
+    expect(formatHumanBytes(1024 ** 3)).toBe('1.0 GiB');
+  });
+  it('formats TiB', () => {
+    expect(formatHumanBytes(2 * 1024 ** 4)).toBe('2.0 TiB');
+  });
+  it('formats PiB', () => {
+    expect(formatHumanBytes(1024 ** 5)).toBe('1.0 PiB');
+  });
+});
+
+describe('formatResourceValue', () => {
+  it('formats bytes unit with K8s quantity', () => {
+    expect(formatResourceValue('4Gi', 'bytes')).toBe('4.0 GiB');
+  });
+  it('returns raw string for invalid bytes', () => {
+    expect(formatResourceValue('invalid', 'bytes')).toBe('invalid');
+  });
+  it('formats integer non-bytes', () => {
+    expect(formatResourceValue(4, 'cores')).toBe('4');
+  });
+  it('formats decimal non-bytes', () => {
+    expect(formatResourceValue(1.5, 'cores')).toBe('1.5');
+  });
+  it('handles string input for non-bytes', () => {
+    expect(formatResourceValue('8', 'cores')).toBe('8');
+  });
+  it('handles zero', () => {
+    expect(formatResourceValue(0, 'cores')).toBe('0');
+  });
+});

--- a/web/src/utils/k8sQuantity.ts
+++ b/web/src/utils/k8sQuantity.ts
@@ -1,0 +1,87 @@
+/**
+ * Kubernetes quantity parsing and formatting utilities.
+ *
+ * Handles SI (K, M, G ...) and binary (Ki, Mi, Gi ...) suffixes as well as
+ * CPU millicore notation (e.g. "500m" = 0.5 cores).
+ */
+
+export const BYTE_MULTIPLIERS: Record<string, number> = {
+  '': 1,
+  K: 1e3,
+  M: 1e6,
+  G: 1e9,
+  T: 1e12,
+  P: 1e15,
+  E: 1e18,
+  Ki: 1024,
+  Mi: 1024 ** 2,
+  Gi: 1024 ** 3,
+  Ti: 1024 ** 4,
+  Pi: 1024 ** 5,
+  Ei: 1024 ** 6,
+};
+
+/**
+ * Parse a Kubernetes quantity string into a canonical numeric value.
+ * - bytes unit: "8Gi" -> bytes, "500Mi" -> bytes, "8024304Ki" -> bytes
+ * - cores unit: "4" -> 4, "500m" -> 0.5, "1.5" -> 1.5
+ * - other: plain parseFloat
+ * Returns NaN if the string is not a valid quantity.
+ */
+export function parseK8sQuantity(raw: string, unit: string): number {
+  const trimmed = raw.trim();
+  if (!trimmed) return NaN;
+
+  if (unit === 'bytes') {
+    const match = trimmed.match(/^(\d+(?:\.\d+)?)\s*([KMGTPE]i?)?$/);
+    if (!match) return NaN;
+    const num = parseFloat(match[1]);
+    const suffix = match[2] ?? '';
+    if (!(suffix in BYTE_MULTIPLIERS)) return NaN;
+    return num * BYTE_MULTIPLIERS[suffix];
+  }
+
+  if (unit === 'cores') {
+    // CPU supports millicores (e.g. "500m" = 0.5 cores) or plain numbers
+    const milliMatch = trimmed.match(/^(\d+)m$/);
+    if (milliMatch) return parseInt(milliMatch[1], 10) / 1000;
+    const num = parseFloat(trimmed);
+    if (isNaN(num) || num < 0) return NaN;
+    return num;
+  }
+
+  // Generic: plain number
+  const num = parseFloat(trimmed);
+  if (isNaN(num) || num < 0) return NaN;
+  return num;
+}
+
+/**
+ * Format a byte count into a human-readable binary-unit string.
+ * @example formatHumanBytes(1073741824) => "1.0 GiB"
+ */
+export function formatHumanBytes(bytes: number): string {
+  if (bytes >= 1024 ** 5) return `${(bytes / 1024 ** 5).toFixed(1)} PiB`;
+  if (bytes >= 1024 ** 4) return `${(bytes / 1024 ** 4).toFixed(1)} TiB`;
+  if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(1)} GiB`;
+  if (bytes >= 1024 ** 2) return `${(bytes / 1024 ** 2).toFixed(1)} MiB`;
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
+  return `${bytes} B`;
+}
+
+/**
+ * Format a resource value for display, handling byte conversion automatically.
+ * For bytes: parses K8s quantity string and formats as human-readable binary units.
+ * For other units: returns the number, with one decimal place if non-integer.
+ */
+export function formatResourceValue(value: number | string, unit: string): string {
+  const raw = String(value);
+  if (unit === 'bytes') {
+    const bytes = parseK8sQuantity(raw, 'bytes');
+    if (isNaN(bytes)) return raw;
+    return formatHumanBytes(bytes);
+  }
+  const num = parseFloat(raw) || 0;
+  if (Number.isInteger(num)) return String(num);
+  return num.toFixed(1);
+}


### PR DESCRIPTION
## Summary

- **Resource management domain**: `ResourceProvider` port with `discover()`, `translate()`, and `validate()` methods, plus `ResourceType`, `ClusterResourceInfo`, `TranslatedResources` domain models
- **Two adapters**: `StaticResourceProvider` (dev/test, hardcoded CPU/Memory/GPU types) and `K8sResourceProvider` (discovers GPU types from node labels, validates against cluster capacity)
- **ResourceContributor**: New pipeline stage that translates user-friendly `{cpu, memory, gpu, gpu_type}` into K8s-native primitives — `nvidia.com/gpu` limits, tolerations, nodeSelector (`nvidia.com/gpu.product`), and `runtimeClassName: nvidia`
- **REST discovery endpoint**: `GET /api/v1/volundr/resources` returns available resource types and node capacity
- **Frontend wiring**: `resourceConfig` flows from ConfigureStep → LaunchWizard → API → session service → contributor pipeline; GPU type dropdown driven by cluster resource discovery
- **Config & DI**: Dynamic adapter pattern for resource provider, Helm chart values/configmap support

## Test plan

- [x] 2499 backend tests pass with 85.13% coverage
- [x] 2237 frontend tests pass with 85.09% branch coverage
- [x] Ruff linting passes with zero errors
- [x] TypeScript compiles cleanly
- [x] Resource translation: `{gpu: "1", gpu_type: "A100"}` → `nvidia.com/gpu: "1"` limits + toleration + nodeSelector + runtimeClassName
- [x] Graceful fallback: StaticResourceProvider returns standard types without cluster access
- [x] Frontend: resource fields render, GPU type dropdown appears when cluster reports accelerator types, `resource_config` included in API payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)