### PR TITLE
fix(cli): prevent global keybindings from capturing text input in TUI

### DIFF
--- a/cli/internal/api/ws.go
+++ b/cli/internal/api/ws.go
@@ -37,10 +37,10 @@ type StreamEvent struct {
 	Delta *StreamDelta `json:"delta,omitempty"`
 
 	// 'result' event
-	Subtype  string  `json:"subtype,omitempty"`
-	CostUSD  float64 `json:"cost_usd,omitempty"`
-	IsError  bool    `json:"is_error,omitempty"`
-	Result   string  `json:"result,omitempty"`
+	Subtype string  `json:"subtype,omitempty"`
+	CostUSD float64 `json:"cost_usd,omitempty"`
+	IsError bool    `json:"is_error,omitempty"`
+	Result  string  `json:"result,omitempty"`
 
 	// 'error' event
 	Error json.RawMessage `json:"error,omitempty"`
@@ -54,10 +54,10 @@ type StreamEvent struct {
 
 // StreamEventMessage holds the message field from an 'assistant' event.
 type StreamEventMessage struct {
-	ID      string                `json:"id,omitempty"`
-	Role    string                `json:"role,omitempty"`
-	Model   string                `json:"model,omitempty"`
-	Content []StreamMessageBlock  `json:"content,omitempty"`
+	ID      string               `json:"id,omitempty"`
+	Role    string               `json:"role,omitempty"`
+	Model   string               `json:"model,omitempty"`
+	Content []StreamMessageBlock `json:"content,omitempty"`
 }
 
 // StreamMessageBlock represents a content block inside a message (text, tool_use, etc.).
@@ -272,7 +272,6 @@ func appendAccessToken(rawURL, token string) string {
 	}
 	return rawURL + sep + "access_token=" + url.QueryEscape(token)
 }
-
 
 // String returns a human-readable representation of the connection state.
 func (s WSState) String() string {

--- a/cli/internal/auth/oidc.go
+++ b/cli/internal/auth/oidc.go
@@ -46,7 +46,7 @@ type DeviceCodeResponse struct {
 type UserinfoResponse struct {
 	Sub               string `json:"sub"`
 	Name              string `json:"name"`
-	PreferredUsername  string `json:"preferred_username"`
+	PreferredUsername string `json:"preferred_username"`
 	Email             string `json:"email"`
 	EmailVerified     bool   `json:"email_verified"`
 }

--- a/cli/internal/cli/context.go
+++ b/cli/internal/cli/context.go
@@ -83,9 +83,9 @@ Example:
 
 // contextListEntry is used for JSON output of context list.
 type contextListEntry struct {
-	Key          string `json:"key"`
-	Name         string `json:"name"`
-	Server       string `json:"server"`
+	Key           string `json:"key"`
+	Name          string `json:"name"`
+	Server        string `json:"server"`
 	Authenticated bool   `json:"authenticated"`
 }
 

--- a/cli/internal/cli/tui.go
+++ b/cli/internal/cli/tui.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -269,20 +270,20 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(cmds...)
 	}
 
-	// When terminal page is active, intercept most keys and forward to PTY.
-	// Esc returns focus to app-level navigation so the user can switch pages.
+	// When terminal page is active, forward almost all keys to PTY.
+	// Only Esc and F11/Ctrl+F fall through to the app layer.
+	// Alt+1-7 navigation is handled by the app layer (always works).
 	if m.app.ActivePage == tuipkg.PageTerminal {
 		if keyMsg, ok := msg.(tea.KeyMsg); ok {
 			key := keyMsg.String()
-			// Let these keys through to the app layer:
 			switch {
-			case key == "f11", key == "ctrl+f",
-				key == "?", key == "esc", key == "[":
+			case key == "f11", key == "ctrl+f", key == "esc":
 				// fall through to app
-			case len(key) == 1 && key >= "1" && key <= "7":
-				// number keys for page navigation
+			case strings.HasPrefix(key, "alt+"):
+				// alt+number navigation — fall through to app
 			default:
-				// Forward everything else (including ctrl+c) to the terminal.
+				// Forward everything else (including ctrl+c, numbers,
+				// q, ?, [, etc.) to the terminal.
 				m.terminal, cmd = m.terminal.Update(msg)
 				if cmd != nil {
 					cmds = append(cmds, cmd)
@@ -292,25 +293,27 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 
-	// When chat input is active, intercept printable keys so they go to the
-	// input field instead of being swallowed by the app (e.g., "?" opening help).
+	// When chat input is active, capture all keys for the input field.
+	// Only Esc, Ctrl+C, F11/Ctrl+F, and Alt+N fall through to the app.
 	if m.app.ActivePage == tuipkg.PageChat && m.chat.InputActive() {
 		if keyMsg, ok := msg.(tea.KeyMsg); ok {
 			key := keyMsg.String()
 			switch {
-			case key == "ctrl+c", key == "esc":
-				// Esc deactivates input, let it through to chat then app.
+			case key == "ctrl+c":
+				// Let through to app (quit).
+			case key == "esc":
+				// Esc deactivates input; send to chat then fall through to app.
 				m.chat, cmd = m.chat.Update(msg)
 				if cmd != nil {
 					cmds = append(cmds, cmd)
 				}
-				// Fall through to app layer too.
 			case key == "f11", key == "ctrl+f":
 				// Let through to app layer (fullscreen toggle).
-			case len(key) == 1 && key >= "1" && key <= "7":
-				// Number keys for page navigation — let through to app layer.
+			case strings.HasPrefix(key, "alt+"):
+				// alt+number navigation — fall through to app
 			default:
-				// Forward directly to chat page (printable keys, enter, backspace, etc.).
+				// Forward directly to chat page (printable keys, enter,
+				// backspace, numbers, q, ?, [, etc.).
 				m.chat, cmd = m.chat.Update(msg)
 				if cmd != nil {
 					cmds = append(cmds, cmd)
@@ -318,6 +321,52 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, tea.Batch(cmds...)
 			}
 		}
+	}
+
+	// When sessions search is active, capture keys for the search field.
+	if m.app.ActivePage == tuipkg.PageSessions && m.sessions.Searching() {
+		if keyMsg, ok := msg.(tea.KeyMsg); ok {
+			key := keyMsg.String()
+			switch {
+			case key == "ctrl+c":
+				// Let through to app (quit).
+			case strings.HasPrefix(key, "alt+"):
+				// alt+number navigation — fall through to app
+			default:
+				// Forward to sessions page (handles esc/enter to exit search).
+				m.sessions, cmd = m.sessions.Update(msg)
+				if cmd != nil {
+					cmds = append(cmds, cmd)
+				}
+				return m, tea.Batch(cmds...)
+			}
+		}
+	}
+
+	// When settings editor is active, capture keys for the edit field.
+	if m.app.ActivePage == tuipkg.PageSettings && m.settings.Editing() {
+		if keyMsg, ok := msg.(tea.KeyMsg); ok {
+			key := keyMsg.String()
+			switch {
+			case key == "ctrl+c":
+				// Let through to app (quit).
+			case strings.HasPrefix(key, "alt+"):
+				// alt+number navigation — fall through to app
+			default:
+				// Forward to settings page (handles esc/enter to exit edit).
+				m.settings, cmd = m.settings.Update(msg)
+				if cmd != nil {
+					cmds = append(cmds, cmd)
+				}
+				return m, tea.Batch(cmds...)
+			}
+		}
+	}
+
+	// Set InputCaptured for KeyMsg so the app layer suppresses global
+	// keybindings (q, ?, [, 1-7) when a text input is active.
+	if _, ok := msg.(tea.KeyMsg); ok {
+		m.app.InputCaptured = m.isInputCaptured()
 	}
 
 	// Update the root app first (handles global keys, window resize)
@@ -408,6 +457,22 @@ func (m tuiModel) handleSessionSelected(msg pages.SessionSelectedMsg) (tea.Model
 	m.sidebar.ActivePage = tuipkg.PageChat
 
 	return m, tea.Batch(cmds...)
+}
+
+// isInputCaptured returns true when the active page has a text input that
+// should suppress global keybindings (q, ?, [, 1-7).
+func (m tuiModel) isInputCaptured() bool {
+	switch m.app.ActivePage {
+	case tuipkg.PageTerminal:
+		return true
+	case tuipkg.PageChat:
+		return m.chat.InputActive()
+	case tuipkg.PageSessions:
+		return m.sessions.Searching()
+	case tuipkg.PageSettings:
+		return m.settings.Editing()
+	}
+	return false
 }
 
 func (m tuiModel) View() tea.View {

--- a/cli/internal/cli/tui.go
+++ b/cli/internal/cli/tui.go
@@ -276,15 +276,18 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// In normal mode: keys fall through to the app layer for navigation.
 	if m.app.ActivePage == tuipkg.PageTerminal {
 		if _, ok := msg.(tea.KeyMsg); ok {
-			// Always send to the terminal page first — it handles mode
+			wasInsert := m.terminal.InsertMode()
+
+			// Send to the terminal page first — it handles mode
 			// switching (ctrl+], i) and PTY forwarding internally.
 			m.terminal, cmd = m.terminal.Update(msg)
 			cmds = appendCmd(cmds, cmd)
 
-			// In insert mode, the terminal consumed the key. Stop here.
-			// In normal mode, also let the key fall through to the app
-			// layer so 1-7, q, ?, [ etc. work as global navigation.
-			if m.terminal.InsertMode() {
+			// If the terminal consumed the key (insert mode, or mode
+			// just changed), stop here. Only let keys fall through to
+			// the app layer when we were already in normal mode and
+			// the mode didn't change (i.e. a navigation key).
+			if m.terminal.InsertMode() || wasInsert != m.terminal.InsertMode() {
 				return m, tea.Batch(cmds...)
 			}
 		}

--- a/cli/internal/cli/tui.go
+++ b/cli/internal/cli/tui.go
@@ -82,13 +82,6 @@ type tuiModel struct {
 
 	// Active session (set when user presses Enter on a session).
 	activeSession *api.Session
-
-	// termEscNavMode is set when the user presses Esc on the terminal page.
-	// The next keypress is treated as a navigation command: if it's 1-7 it
-	// navigates to that page, otherwise it's forwarded to the PTY and the
-	// flag is cleared. This provides a macOS-friendly alternative to alt+N
-	// (since Option+N produces special characters in most Mac terminals).
-	termEscNavMode bool
 }
 
 // newTUIModel creates the fully initialized TUI model.
@@ -277,49 +270,22 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(cmds...)
 	}
 
-	// When terminal page is active, forward almost all keys to PTY.
-	// Esc enters "nav mode" where the next key is treated as a navigation
-	// command (1-7 switches page, q quits, ? help, [ sidebar, i returns
-	// to insert mode). This provides a macOS-friendly alternative to alt+N.
+	// When terminal page is active, route keys based on insert/normal mode.
+	// In insert mode: all keys go to the terminal (PTY) except ctrl+],
+	// ctrl+t/n/p/w/f, f11, and alt+N which the terminal handles internally.
+	// In normal mode: keys fall through to the app layer for navigation.
 	if m.app.ActivePage == tuipkg.PageTerminal {
-		if keyMsg, ok := msg.(tea.KeyMsg); ok {
-			key := keyMsg.String()
+		if _, ok := msg.(tea.KeyMsg); ok {
+			// Always send to the terminal page first — it handles mode
+			// switching (ctrl+], i) and PTY forwarding internally.
+			m.terminal, cmd = m.terminal.Update(msg)
+			cmds = appendCmd(cmds, cmd)
 
-			// In Esc nav mode, handle the follow-up key.
-			if m.termEscNavMode {
-				m.termEscNavMode = false
-				_, isNav := tuipkg.IsNavigationKey(keyMsg)
-				switch {
-				case key == "i":
-					// Return to insert (PTY) mode — consume the key.
-					return m, tea.Batch(cmds...)
-				case isNav:
-					// Fall through to app layer for page navigation.
-				case key == "q", key == "?", key == "[":
-					// Fall through to app layer for global bindings.
-				default:
-					// Not a nav key — forward to PTY.
-					m.terminal, cmd = m.terminal.Update(msg)
-					cmds = appendCmd(cmds, cmd)
-					return m, tea.Batch(cmds...)
-				}
-				// Fall through to app layer for navigation keys.
-			} else {
-				switch {
-				case key == "f11", key == "ctrl+f":
-					// fall through to app
-				case key == "esc":
-					// Enter nav mode instead of forwarding to PTY.
-					m.termEscNavMode = true
-					return m, tea.Batch(cmds...)
-				case strings.HasPrefix(key, "alt+"):
-					// alt+number navigation — fall through to app
-				default:
-					// Forward everything else to the terminal.
-					m.terminal, cmd = m.terminal.Update(msg)
-					cmds = appendCmd(cmds, cmd)
-					return m, tea.Batch(cmds...)
-				}
+			// In insert mode, the terminal consumed the key. Stop here.
+			// In normal mode, also let the key fall through to the app
+			// layer so 1-7, q, ?, [ etc. work as global navigation.
+			if m.terminal.InsertMode() {
+				return m, tea.Batch(cmds...)
 			}
 		}
 	}
@@ -495,7 +461,7 @@ func (m tuiModel) handleSessionSelected(msg pages.SessionSelectedMsg) (tea.Model
 func (m tuiModel) isInputCaptured() bool {
 	switch m.app.ActivePage {
 	case tuipkg.PageTerminal:
-		return !m.termEscNavMode
+		return m.terminal.InsertMode()
 	case tuipkg.PageChat:
 		return m.chat.InputActive()
 	case tuipkg.PageSessions:

--- a/cli/internal/cli/tui.go
+++ b/cli/internal/cli/tui.go
@@ -82,6 +82,13 @@ type tuiModel struct {
 
 	// Active session (set when user presses Enter on a session).
 	activeSession *api.Session
+
+	// termEscNavMode is set when the user presses Esc on the terminal page.
+	// The next keypress is treated as a navigation command: if it's 1-7 it
+	// navigates to that page, otherwise it's forwarded to the PTY and the
+	// flag is cleared. This provides a macOS-friendly alternative to alt+N
+	// (since Option+N produces special characters in most Mac terminals).
+	termEscNavMode bool
 }
 
 // newTUIModel creates the fully initialized TUI model.
@@ -271,24 +278,48 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	// When terminal page is active, forward almost all keys to PTY.
-	// Only Esc and F11/Ctrl+F fall through to the app layer.
-	// Alt+1-7 navigation is handled by the app layer (always works).
+	// Esc enters "nav mode" where the next key is treated as a navigation
+	// command (1-7 switches page, q quits, ? help, [ sidebar, i returns
+	// to insert mode). This provides a macOS-friendly alternative to alt+N.
 	if m.app.ActivePage == tuipkg.PageTerminal {
 		if keyMsg, ok := msg.(tea.KeyMsg); ok {
 			key := keyMsg.String()
-			switch {
-			case key == "f11", key == "ctrl+f", key == "esc":
-				// fall through to app
-			case strings.HasPrefix(key, "alt+"):
-				// alt+number navigation — fall through to app
-			default:
-				// Forward everything else (including ctrl+c, numbers,
-				// q, ?, [, etc.) to the terminal.
-				m.terminal, cmd = m.terminal.Update(msg)
-				if cmd != nil {
-					cmds = append(cmds, cmd)
+
+			// In Esc nav mode, handle the follow-up key.
+			if m.termEscNavMode {
+				m.termEscNavMode = false
+				_, isNav := tuipkg.IsNavigationKey(keyMsg)
+				switch {
+				case key == "i":
+					// Return to insert (PTY) mode — consume the key.
+					return m, tea.Batch(cmds...)
+				case isNav:
+					// Fall through to app layer for page navigation.
+				case key == "q", key == "?", key == "[":
+					// Fall through to app layer for global bindings.
+				default:
+					// Not a nav key — forward to PTY.
+					m.terminal, cmd = m.terminal.Update(msg)
+					cmds = appendCmd(cmds, cmd)
+					return m, tea.Batch(cmds...)
 				}
-				return m, tea.Batch(cmds...)
+				// Fall through to app layer for navigation keys.
+			} else {
+				switch {
+				case key == "f11", key == "ctrl+f":
+					// fall through to app
+				case key == "esc":
+					// Enter nav mode instead of forwarding to PTY.
+					m.termEscNavMode = true
+					return m, tea.Batch(cmds...)
+				case strings.HasPrefix(key, "alt+"):
+					// alt+number navigation — fall through to app
+				default:
+					// Forward everything else to the terminal.
+					m.terminal, cmd = m.terminal.Update(msg)
+					cmds = appendCmd(cmds, cmd)
+					return m, tea.Batch(cmds...)
+				}
 			}
 		}
 	}
@@ -464,7 +495,7 @@ func (m tuiModel) handleSessionSelected(msg pages.SessionSelectedMsg) (tea.Model
 func (m tuiModel) isInputCaptured() bool {
 	switch m.app.ActivePage {
 	case tuipkg.PageTerminal:
-		return true
+		return !m.termEscNavMode
 	case tuipkg.PageChat:
 		return m.chat.InputActive()
 	case tuipkg.PageSessions:
@@ -524,6 +555,14 @@ func (m tuiModel) View() tea.View {
 
 	v.Content = fullView
 	return v
+}
+
+// appendCmd appends a non-nil command to a slice.
+func appendCmd(cmds []tea.Cmd, cmd tea.Cmd) []tea.Cmd {
+	if cmd != nil {
+		return append(cmds, cmd)
+	}
+	return cmds
 }
 
 // debugTUI enables TUI message logging. Set VOLUNDR_TUI_DEBUG=1 to enable.

--- a/cli/internal/runtime/docker.go
+++ b/cli/internal/runtime/docker.go
@@ -74,18 +74,18 @@ type composeData struct {
 
 // dockerAPIConfig represents the Python API config file structure for Docker mode.
 type dockerAPIConfig struct {
-	Database             map[string]interface{}   `yaml:"database"`
-	PodManager           map[string]interface{}   `yaml:"pod_manager"`
-	CredentialStore      map[string]interface{}   `yaml:"credential_store"`
-	Storage              map[string]interface{}   `yaml:"storage"`
-	SecretInjection      map[string]interface{}   `yaml:"secret_injection"`
-	Git                  map[string]interface{}   `yaml:"git,omitempty"`
-	Identity             map[string]interface{}   `yaml:"identity"`
-	Authorization        map[string]interface{}   `yaml:"authorization"`
-	Gateway              map[string]interface{}   `yaml:"gateway"`
-	ResourceProvider     map[string]interface{}   `yaml:"resource_provider,omitempty"`
-	LocalMounts          map[string]interface{}   `yaml:"local_mounts,omitempty"`
-	SessionContributors  []map[string]interface{} `yaml:"session_contributors,omitempty"`
+	Database            map[string]interface{}   `yaml:"database"`
+	PodManager          map[string]interface{}   `yaml:"pod_manager"`
+	CredentialStore     map[string]interface{}   `yaml:"credential_store"`
+	Storage             map[string]interface{}   `yaml:"storage"`
+	SecretInjection     map[string]interface{}   `yaml:"secret_injection"`
+	Git                 map[string]interface{}   `yaml:"git,omitempty"`
+	Identity            map[string]interface{}   `yaml:"identity"`
+	Authorization       map[string]interface{}   `yaml:"authorization"`
+	Gateway             map[string]interface{}   `yaml:"gateway"`
+	ResourceProvider    map[string]interface{}   `yaml:"resource_provider,omitempty"`
+	LocalMounts         map[string]interface{}   `yaml:"local_mounts,omitempty"`
+	SessionContributors []map[string]interface{} `yaml:"session_contributors,omitempty"`
 }
 
 // dockerAPIInternalPort is the host port the API container binds to.
@@ -475,17 +475,17 @@ func (r *DockerRuntime) generateDockerConfig(cfg *config.Config) (string, error)
 		PodManager: map[string]interface{}{
 			"adapter": "volundr.adapters.outbound.docker_pod_manager.DockerPodManager",
 			"kwargs": map[string]interface{}{
-				"network":            dockerImageOrDefault(cfg.Docker.Network, "volundr-net"),
-				"skuld_image":        dockerImageOrDefault(cfg.Docker.SkuldImage, "ghcr.io/niuulabs/skuld:latest"),
-				"code_server_image":  dockerImageOrDefault(cfg.Docker.CodeServerImage, "ghcr.io/niuulabs/code-server:latest"),
-				"ttyd_image":         dockerImageOrDefault(cfg.Docker.TtydImage, "ghcr.io/niuulabs/ttyd:latest"),
-				"compose_dir":        containerStoragePath + "/sessions",
-				"gateway_domain":     "",
-				"db_host":            dbHost,
-				"db_port":            cfg.Database.Port,
-				"db_user":            cfg.Database.User,
-				"db_password":        cfg.Database.Password,
-				"db_name":            cfg.Database.Name,
+				"network":           dockerImageOrDefault(cfg.Docker.Network, "volundr-net"),
+				"skuld_image":       dockerImageOrDefault(cfg.Docker.SkuldImage, "ghcr.io/niuulabs/skuld:latest"),
+				"code_server_image": dockerImageOrDefault(cfg.Docker.CodeServerImage, "ghcr.io/niuulabs/code-server:latest"),
+				"ttyd_image":        dockerImageOrDefault(cfg.Docker.TtydImage, "ghcr.io/niuulabs/ttyd:latest"),
+				"compose_dir":       containerStoragePath + "/sessions",
+				"gateway_domain":    "",
+				"db_host":           dbHost,
+				"db_port":           cfg.Database.Port,
+				"db_user":           cfg.Database.User,
+				"db_password":       cfg.Database.Password,
+				"db_name":           cfg.Database.Name,
 			},
 		},
 		CredentialStore: map[string]interface{}{

--- a/cli/internal/runtime/k3s.go
+++ b/cli/internal/runtime/k3s.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"text/template"
 
-
 	"github.com/niuulabs/volundr/cli/internal/config"
 	"github.com/niuulabs/volundr/cli/internal/postgres"
 	"github.com/niuulabs/volundr/cli/internal/proxy"
@@ -102,18 +101,18 @@ type k3sComposeData struct {
 
 // k3sAPIConfig represents the Python API config file structure for k3s mode.
 type k3sAPIConfig struct {
-	Database             map[string]interface{}   `yaml:"database"`
-	PodManager           map[string]interface{}   `yaml:"pod_manager"`
-	CredentialStore      map[string]interface{}   `yaml:"credential_store"`
-	Storage              map[string]interface{}   `yaml:"storage"`
-	SecretInjection      map[string]interface{}   `yaml:"secret_injection"`
-	Identity             map[string]interface{}   `yaml:"identity"`
-	Authorization        map[string]interface{}   `yaml:"authorization"`
-	Gateway              map[string]interface{}   `yaml:"gateway"`
-	ResourceProvider     map[string]interface{}   `yaml:"resource_provider,omitempty"`
-	Git                  map[string]interface{}   `yaml:"git,omitempty"`
-	LocalMounts          map[string]interface{}   `yaml:"local_mounts,omitempty"`
-	SessionContributors  []map[string]interface{} `yaml:"session_contributors,omitempty"`
+	Database            map[string]interface{}   `yaml:"database"`
+	PodManager          map[string]interface{}   `yaml:"pod_manager"`
+	CredentialStore     map[string]interface{}   `yaml:"credential_store"`
+	Storage             map[string]interface{}   `yaml:"storage"`
+	SecretInjection     map[string]interface{}   `yaml:"secret_injection"`
+	Identity            map[string]interface{}   `yaml:"identity"`
+	Authorization       map[string]interface{}   `yaml:"authorization"`
+	Gateway             map[string]interface{}   `yaml:"gateway"`
+	ResourceProvider    map[string]interface{}   `yaml:"resource_provider,omitempty"`
+	Git                 map[string]interface{}   `yaml:"git,omitempty"`
+	LocalMounts         map[string]interface{}   `yaml:"local_mounts,omitempty"`
+	SessionContributors []map[string]interface{} `yaml:"session_contributors,omitempty"`
 }
 
 // K3sRuntime manages the Volundr stack using k3s/k3d for Kubernetes
@@ -1022,9 +1021,9 @@ func (r *K3sRuntime) generateK3sConfig(cfg *config.Config) (string, error) {
 	// Pass through local_mounts config if enabled.
 	if cfg.LocalMounts.Enabled {
 		apiCfg.LocalMounts = map[string]interface{}{
-			"enabled":          cfg.LocalMounts.Enabled,
-			"allow_root_mount": cfg.LocalMounts.AllowRootMount,
-			"allowed_prefixes": cfg.LocalMounts.AllowedPrefixes,
+			"enabled":           cfg.LocalMounts.Enabled,
+			"allow_root_mount":  cfg.LocalMounts.AllowRootMount,
+			"allowed_prefixes":  cfg.LocalMounts.AllowedPrefixes,
 			"default_read_only": cfg.LocalMounts.DefaultReadOnly,
 		}
 	}

--- a/cli/internal/tui/app.go
+++ b/cli/internal/tui/app.go
@@ -23,6 +23,12 @@ type App struct {
 
 	// Ready signals that we've received the initial window size.
 	Ready bool
+
+	// InputCaptured is set by the tuiModel when a page has an active text
+	// input (chat input, search bar, settings editor, terminal PTY). When
+	// true, global keybindings (q, ?, [, 1-7) are suppressed so keystrokes
+	// reach the input field. Alt+1-7 navigation always works.
+	InputCaptured bool
 }
 
 // NewApp creates a new root TUI application model.
@@ -49,10 +55,33 @@ func (a App) Update(msg tea.Msg) (App, tea.Cmd) {
 		return a, nil
 
 	case tea.KeyMsg:
-		// Global keybindings that work on any page
-		switch msg.String() {
-		case "ctrl+c":
+		// Alt+number navigation always works, even when input is captured.
+		if !a.ShowHelp {
+			if page, ok := IsAltNavigationKey(msg); ok {
+				a.ActivePage = page
+				return a, nil
+			}
+		}
+
+		// ctrl+c always quits.
+		if msg.String() == "ctrl+c" {
 			return a, tea.Quit
+		}
+
+		// Esc always closes help if showing.
+		if msg.String() == "esc" && a.ShowHelp {
+			a.ShowHelp = false
+			return a, nil
+		}
+
+		// When input is captured, suppress all other global keybindings
+		// so keystrokes reach the active text input.
+		if a.InputCaptured {
+			break
+		}
+
+		// Global keybindings (only active when input is NOT captured)
+		switch msg.String() {
 		case "q":
 			if !a.ShowHelp {
 				return a, tea.Quit
@@ -62,17 +91,12 @@ func (a App) Update(msg tea.Msg) (App, tea.Cmd) {
 		case "?":
 			a.ShowHelp = !a.ShowHelp
 			return a, nil
-		case "esc":
-			if a.ShowHelp {
-				a.ShowHelp = false
-				return a, nil
-			}
 		case "[":
 			a.ShowSidebar = !a.ShowSidebar
 			return a, nil
 		}
 
-		// Page navigation shortcuts
+		// Page navigation shortcuts (bare 1-7)
 		if !a.ShowHelp {
 			if page, ok := IsNavigationKey(msg); ok {
 				a.ActivePage = page

--- a/cli/internal/tui/app_test.go
+++ b/cli/internal/tui/app_test.go
@@ -131,6 +131,107 @@ func TestApp_Update_PageNavigation(t *testing.T) {
 	}
 }
 
+func TestApp_Update_InputCaptured_SuppressesQ(t *testing.T) {
+	app := NewApp("")
+	app.Ready = true
+	app.InputCaptured = true
+
+	// 'q' should NOT quit when input is captured.
+	app, cmd := app.Update(tea.KeyPressMsg{Code: 'q'})
+	if cmd != nil {
+		t.Error("expected no quit command when input is captured")
+	}
+	_ = app
+}
+
+func TestApp_Update_InputCaptured_SuppressesHelp(t *testing.T) {
+	app := NewApp("")
+	app.Ready = true
+	app.InputCaptured = true
+
+	// '?' should NOT toggle help when input is captured.
+	app, _ = app.Update(tea.KeyPressMsg{Code: '?'})
+	if app.ShowHelp {
+		t.Error("expected help to stay hidden when input is captured")
+	}
+}
+
+func TestApp_Update_InputCaptured_SuppressesSidebar(t *testing.T) {
+	app := NewApp("")
+	app.Ready = true
+	app.InputCaptured = true
+
+	// '[' should NOT toggle sidebar when input is captured.
+	before := app.ShowSidebar
+	app, _ = app.Update(tea.KeyPressMsg{Code: '['})
+	if app.ShowSidebar != before {
+		t.Error("expected sidebar unchanged when input is captured")
+	}
+}
+
+func TestApp_Update_InputCaptured_SuppressesNavigation(t *testing.T) {
+	app := NewApp("")
+	app.Ready = true
+	app.InputCaptured = true
+	app.ActivePage = PageSessions
+
+	// '3' should NOT navigate when input is captured.
+	app, _ = app.Update(tea.KeyPressMsg{Code: '3'})
+	if app.ActivePage != PageSessions {
+		t.Error("expected page unchanged when input is captured")
+	}
+}
+
+func TestApp_Update_InputCaptured_CtrlCStillQuits(t *testing.T) {
+	app := NewApp("")
+	app.Ready = true
+	app.InputCaptured = true
+
+	// ctrl+c should ALWAYS quit.
+	_, cmd := app.Update(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})
+	if cmd == nil {
+		t.Error("expected quit command for ctrl+c even when input is captured")
+	}
+}
+
+func TestApp_Update_InputCaptured_EscClosesHelp(t *testing.T) {
+	app := NewApp("")
+	app.InputCaptured = true
+	app.ShowHelp = true
+
+	// Esc should ALWAYS close help, even when input is captured.
+	app, _ = app.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if app.ShowHelp {
+		t.Error("expected help closed after Esc, even when input is captured")
+	}
+}
+
+func TestApp_Update_AltNavigation(t *testing.T) {
+	app := NewApp("")
+	app.Ready = true
+	app.InputCaptured = true // should still work
+
+	tests := []struct {
+		key  rune
+		page Page
+	}{
+		{'1', PageSessions},
+		{'2', PageChat},
+		{'3', PageTerminal},
+		{'4', PageDiffs},
+		{'5', PageChronicles},
+		{'6', PageSettings},
+		{'7', PageAdmin},
+	}
+
+	for _, tt := range tests {
+		app, _ = app.Update(tea.KeyPressMsg{Code: tt.key, Mod: tea.ModAlt})
+		if app.ActivePage != tt.page {
+			t.Errorf("alt+%q: expected page %v, got %v", string(tt.key), tt.page, app.ActivePage)
+		}
+	}
+}
+
 func TestApp_View_NotReady(t *testing.T) {
 	app := NewApp("")
 	view := app.View()
@@ -203,6 +304,44 @@ func TestIsNavigationKey_Valid(t *testing.T) {
 		if page != tt.page {
 			t.Errorf("key %q: expected page %v, got %v", string(tt.key), tt.page, page)
 		}
+	}
+}
+
+func TestIsAltNavigationKey_Valid(t *testing.T) {
+	tests := []struct {
+		key  rune
+		page Page
+	}{
+		{'1', PageSessions},
+		{'2', PageChat},
+		{'3', PageTerminal},
+		{'4', PageDiffs},
+		{'5', PageChronicles},
+		{'6', PageSettings},
+		{'7', PageAdmin},
+	}
+
+	for _, tt := range tests {
+		page, ok := IsAltNavigationKey(tea.KeyPressMsg{Code: tt.key, Mod: tea.ModAlt})
+		if !ok {
+			t.Errorf("expected alt+%q to be alt navigation key", string(tt.key))
+		}
+		if page != tt.page {
+			t.Errorf("alt+%q: expected page %v, got %v", string(tt.key), tt.page, page)
+		}
+	}
+}
+
+func TestIsAltNavigationKey_Invalid(t *testing.T) {
+	// Plain number should NOT match alt nav.
+	_, ok := IsAltNavigationKey(tea.KeyPressMsg{Code: '1'})
+	if ok {
+		t.Error("expected plain '1' to not be an alt navigation key")
+	}
+
+	_, ok = IsAltNavigationKey(tea.KeyPressMsg{Code: 'a', Mod: tea.ModAlt})
+	if ok {
+		t.Error("expected alt+a to not be an alt navigation key")
 	}
 }
 

--- a/cli/internal/tui/components/components_test.go
+++ b/cli/internal/tui/components/components_test.go
@@ -3,8 +3,8 @@ package components
 import (
 	"testing"
 
-	tui "github.com/niuulabs/volundr/cli/internal/tui"
 	"github.com/niuulabs/volundr/cli/internal/remote"
+	tui "github.com/niuulabs/volundr/cli/internal/tui"
 )
 
 // --- StatusBadge tests ---

--- a/cli/internal/tui/components/header.go
+++ b/cli/internal/tui/components/header.go
@@ -25,7 +25,7 @@ type Header struct {
 	Width       int
 	Title       string
 	ServerURL   string
-	Connected   bool        // kept for backward compat; use State instead
+	Connected   bool // kept for backward compat; use State instead
 	State       HeaderState
 	PoolSummary string
 }

--- a/cli/internal/tui/components/sidebar.go
+++ b/cli/internal/tui/components/sidebar.go
@@ -36,12 +36,12 @@ func (s Sidebar) View() string {
 		Foreground(theme.AccentAmber).
 		Background(theme.BgTertiary).
 		Bold(true).
-		Width(s.Width - 4).
+		Width(s.Width-4).
 		Padding(0, 1)
 
 	itemStyle := lipgloss.NewStyle().
 		Foreground(theme.TextSecondary).
-		Width(s.Width - 4).
+		Width(s.Width-4).
 		Padding(0, 1)
 
 	dimKeyStyle := lipgloss.NewStyle().
@@ -117,7 +117,7 @@ func (s Sidebar) viewCollapsed() string {
 	items = append(items, lipgloss.NewStyle().
 		Foreground(theme.AccentAmber).
 		Bold(true).
-		Width(collapsedWidth - 2).
+		Width(collapsedWidth-2).
 		Align(lipgloss.Center).
 		Render("⚒"))
 	items = append(items, "")

--- a/cli/internal/tui/keymap.go
+++ b/cli/internal/tui/keymap.go
@@ -8,7 +8,7 @@ import (
 type Page int
 
 const (
-	PageSessions    Page = iota // Sessions list and detail
+	PageSessions   Page = iota // Sessions list and detail
 	PageChat                   // Chat interface
 	PageTerminal               // Remote terminal
 	PageDiffs                  // Git diff viewer
@@ -65,6 +65,29 @@ func IsNavigationKey(msg tea.KeyMsg) (Page, bool) {
 	case "6":
 		return PageSettings, true
 	case "7":
+		return PageAdmin, true
+	}
+	return 0, false
+}
+
+// IsAltNavigationKey checks if a key message is an alt+number page navigation
+// shortcut. These work even when input is captured (e.g. terminal PTY, chat
+// input, search, settings edit).
+func IsAltNavigationKey(msg tea.KeyMsg) (Page, bool) {
+	switch msg.String() {
+	case "alt+1":
+		return PageSessions, true
+	case "alt+2":
+		return PageChat, true
+	case "alt+3":
+		return PageTerminal, true
+	case "alt+4":
+		return PageDiffs, true
+	case "alt+5":
+		return PageChronicles, true
+	case "alt+6":
+		return PageSettings, true
+	case "alt+7":
 		return PageAdmin, true
 	}
 	return 0, false

--- a/cli/internal/tui/pages/admin.go
+++ b/cli/internal/tui/pages/admin.go
@@ -15,7 +15,7 @@ import (
 type AdminTab int
 
 const (
-	AdminUsers    AdminTab = iota
+	AdminUsers AdminTab = iota
 	AdminTenants
 	AdminStats
 )
@@ -210,7 +210,7 @@ func (a AdminPage) renderUsers() string {
 		if i == a.cursor {
 			rows = append(rows, lipgloss.NewStyle().
 				Background(theme.BgTertiary).
-				Width(a.width - 6).
+				Width(a.width-6).
 				Render(row))
 		} else {
 			rows = append(rows, row)
@@ -261,7 +261,7 @@ func (a AdminPage) renderTenants() string {
 		if i == a.cursor {
 			rows = append(rows, lipgloss.NewStyle().
 				Background(theme.BgTertiary).
-				Width(a.width - 6).
+				Width(a.width-6).
 				Render(row))
 		} else {
 			rows = append(rows, row)

--- a/cli/internal/tui/pages/campaigns.go
+++ b/cli/internal/tui/pages/campaigns.go
@@ -149,12 +149,12 @@ func (c CampaignsPage) renderList() string {
 		if i == c.cursor {
 			rows = append(rows, lipgloss.NewStyle().
 				Background(theme.BgTertiary).
-				Width(c.width - 6).
+				Width(c.width-6).
 				Padding(0, 1).
 				Render(entry))
 		} else {
 			rows = append(rows, lipgloss.NewStyle().
-				Width(c.width - 6).
+				Width(c.width-6).
 				Padding(0, 1).
 				Render(entry))
 		}

--- a/cli/internal/tui/pages/chat.go
+++ b/cli/internal/tui/pages/chat.go
@@ -13,7 +13,6 @@ import (
 	"github.com/charmbracelet/glamour/ansi"
 	"github.com/niuulabs/volundr/cli/internal/api"
 	tui "github.com/niuulabs/volundr/cli/internal/tui"
-
 )
 
 // ChatStreamEventMsg carries an incoming stream event from the WS.
@@ -240,8 +239,8 @@ func (c ChatPage) Update(msg tea.Msg) (ChatPage, tea.Cmd) {
 			case "space":
 				c.input += " "
 			default:
-				if len(key) == 1 {
-					c.input += key
+				if text := msg.Key().Text; len(text) > 0 {
+					c.input += text
 				}
 			}
 			break
@@ -249,6 +248,8 @@ func (c ChatPage) Update(msg tea.Msg) (ChatPage, tea.Cmd) {
 
 		// Scroll mode: input is not active.
 		switch key {
+		case "i":
+			c.inputActive = true
 		case "up", "k":
 			c.scrollPos++
 		case "down", "j":
@@ -437,7 +438,7 @@ func (c ChatPage) View() string {
 			messages,
 			"",
 			inputArea,
-			lipgloss.NewStyle().Foreground(theme.TextMuted).Render("  Tab: scroll/input  Enter: send  ↑↓/j/k: scroll  PgUp/PgDn: page  G/g: bottom/top"),
+			lipgloss.NewStyle().Foreground(theme.TextMuted).Render("  i: insert  Esc: normal  Tab: toggle  Enter: send  ↑↓/j/k: scroll  G/g: bottom/top"),
 		))
 }
 
@@ -508,7 +509,7 @@ func (c ChatPage) renderMessages(maxHeight int) string {
 		return lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
 			BorderForeground(theme.BorderSubtle).
-			Width(c.width - 6).
+			Width(c.width-6).
 			Height(maxHeight).
 			Padding(2, 1).
 			Foreground(theme.TextMuted).
@@ -568,7 +569,7 @@ func (c ChatPage) renderMessages(maxHeight int) string {
 	return lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(theme.BorderSubtle).
-		Width(c.width - 6).
+		Width(c.width-6).
 		Height(maxHeight).
 		Padding(0, 1).
 		Render(rendered)
@@ -650,7 +651,7 @@ func (c ChatPage) renderInput() string {
 	return lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(borderColor).
-		Width(c.width - 6).
+		Width(c.width-6).
 		Padding(0, 1).
 		Render(inputContent)
 }
@@ -775,32 +776,32 @@ var chatStyleConfig = ansi.StyleConfig{
 			Margin: uintPtr(2),
 		},
 		Chroma: &ansi.Chroma{
-			Text:    ansi.StylePrimitive{Color: stringPtr("#C4C4C4")},
-			Error:   ansi.StylePrimitive{Color: stringPtr("#C4C4C4")},
-			Comment: ansi.StylePrimitive{Color: stringPtr("#6A6A6A")},
-			CommentPreproc: ansi.StylePrimitive{Color: stringPtr("#D7875F")},
-			Keyword:         ansi.StylePrimitive{Color: stringPtr("#5F87D7")},
-			KeywordReserved: ansi.StylePrimitive{Color: stringPtr("#D75FAF")},
-			KeywordNamespace: ansi.StylePrimitive{Color: stringPtr("#D7875F")},
-			KeywordType:     ansi.StylePrimitive{Color: stringPtr("#5F87AF")},
-			Operator:        ansi.StylePrimitive{Color: stringPtr("#AFAFAF")},
-			Punctuation:     ansi.StylePrimitive{Color: stringPtr("#AFAFAF")},
-			Name:            ansi.StylePrimitive{Color: stringPtr("#C4C4C4")},
-			NameBuiltin:     ansi.StylePrimitive{Color: stringPtr("#D7AF87")},
-			NameTag:         ansi.StylePrimitive{Color: stringPtr("#5F87D7")},
-			NameAttribute:   ansi.StylePrimitive{Color: stringPtr("#87AFD7")},
-			NameClass:       ansi.StylePrimitive{Color: stringPtr("#D7D787"), Bold: boolPtr(true)},
-			NameDecorator:   ansi.StylePrimitive{Color: stringPtr("#D7D787")},
-			NameFunction:    ansi.StylePrimitive{Color: stringPtr("#87D7AF")},
-			LiteralNumber:   ansi.StylePrimitive{Color: stringPtr("#87D7D7")},
-			LiteralString:   ansi.StylePrimitive{Color: stringPtr("#D7AF87")},
+			Text:                ansi.StylePrimitive{Color: stringPtr("#C4C4C4")},
+			Error:               ansi.StylePrimitive{Color: stringPtr("#C4C4C4")},
+			Comment:             ansi.StylePrimitive{Color: stringPtr("#6A6A6A")},
+			CommentPreproc:      ansi.StylePrimitive{Color: stringPtr("#D7875F")},
+			Keyword:             ansi.StylePrimitive{Color: stringPtr("#5F87D7")},
+			KeywordReserved:     ansi.StylePrimitive{Color: stringPtr("#D75FAF")},
+			KeywordNamespace:    ansi.StylePrimitive{Color: stringPtr("#D7875F")},
+			KeywordType:         ansi.StylePrimitive{Color: stringPtr("#5F87AF")},
+			Operator:            ansi.StylePrimitive{Color: stringPtr("#AFAFAF")},
+			Punctuation:         ansi.StylePrimitive{Color: stringPtr("#AFAFAF")},
+			Name:                ansi.StylePrimitive{Color: stringPtr("#C4C4C4")},
+			NameBuiltin:         ansi.StylePrimitive{Color: stringPtr("#D7AF87")},
+			NameTag:             ansi.StylePrimitive{Color: stringPtr("#5F87D7")},
+			NameAttribute:       ansi.StylePrimitive{Color: stringPtr("#87AFD7")},
+			NameClass:           ansi.StylePrimitive{Color: stringPtr("#D7D787"), Bold: boolPtr(true)},
+			NameDecorator:       ansi.StylePrimitive{Color: stringPtr("#D7D787")},
+			NameFunction:        ansi.StylePrimitive{Color: stringPtr("#87D7AF")},
+			LiteralNumber:       ansi.StylePrimitive{Color: stringPtr("#87D7D7")},
+			LiteralString:       ansi.StylePrimitive{Color: stringPtr("#D7AF87")},
 			LiteralStringEscape: ansi.StylePrimitive{Color: stringPtr("#87D7AF")},
-			GenericDeleted:  ansi.StylePrimitive{Color: stringPtr("#D75F5F")},
-			GenericEmph:     ansi.StylePrimitive{Italic: boolPtr(true)},
-			GenericInserted: ansi.StylePrimitive{Color: stringPtr("#87D7AF")},
-			GenericStrong:   ansi.StylePrimitive{Bold: boolPtr(true)},
-			GenericSubheading: ansi.StylePrimitive{Color: stringPtr("#6A6A6A")},
-			Background:      ansi.StylePrimitive{BackgroundColor: stringPtr("#303030")},
+			GenericDeleted:      ansi.StylePrimitive{Color: stringPtr("#D75F5F")},
+			GenericEmph:         ansi.StylePrimitive{Italic: boolPtr(true)},
+			GenericInserted:     ansi.StylePrimitive{Color: stringPtr("#87D7AF")},
+			GenericStrong:       ansi.StylePrimitive{Bold: boolPtr(true)},
+			GenericSubheading:   ansi.StylePrimitive{Color: stringPtr("#6A6A6A")},
+			Background:          ansi.StylePrimitive{BackgroundColor: stringPtr("#303030")},
 		},
 	},
 	Table: ansi.StyleTable{
@@ -813,9 +814,9 @@ var chatStyleConfig = ansi.StyleConfig{
 	},
 }
 
-func boolPtr(b bool) *bool     { return &b }
+func boolPtr(b bool) *bool       { return &b }
 func stringPtr(s string) *string { return &s }
-func uintPtr(u uint) *uint     { return &u }
+func uintPtr(u uint) *uint       { return &u }
 
 // renderMarkdown renders markdown content for terminal display using glamour.
 func renderMarkdown(content string, width int) string {

--- a/cli/internal/tui/pages/diffs.go
+++ b/cli/internal/tui/pages/diffs.go
@@ -318,11 +318,11 @@ func (d DiffsPage) renderFileTree(width, height int) string {
 			items = append(items, lipgloss.NewStyle().
 				Background(theme.BgTertiary).
 				Foreground(theme.AccentAmber).
-				Width(width - 2).
+				Width(width-2).
 				Render(line))
 		} else {
 			items = append(items, lipgloss.NewStyle().
-				Width(width - 2).
+				Width(width-2).
 				Render(line))
 		}
 	}

--- a/cli/internal/tui/pages/pages_test.go
+++ b/cli/internal/tui/pages/pages_test.go
@@ -343,7 +343,7 @@ func TestChatPage_Update_TypeChar(t *testing.T) {
 	page.inputActive = true
 	page.input = ""
 
-	page, _ = page.Update(tea.KeyPressMsg{Code: 'x'})
+	page, _ = page.Update(tea.KeyPressMsg{Code: 'x', Text: "x"})
 	if page.input != "x" {
 		t.Errorf("expected input %q, got %q", "x", page.input)
 	}

--- a/cli/internal/tui/pages/pages_test.go
+++ b/cli/internal/tui/pages/pages_test.go
@@ -96,6 +96,17 @@ func TestSettingsPage_View_AllSections(t *testing.T) {
 	}
 }
 
+func TestSettingsPage_Editing(t *testing.T) {
+	page := NewSettingsPage(nil, nil)
+	if page.Editing() {
+		t.Error("expected not editing initially")
+	}
+	page.editing = true
+	if !page.Editing() {
+		t.Error("expected editing after setting flag")
+	}
+}
+
 func TestMaskToken(t *testing.T) {
 	tests := []struct {
 		token string

--- a/cli/internal/tui/pages/realms.go
+++ b/cli/internal/tui/pages/realms.go
@@ -13,15 +13,15 @@ import (
 
 // Realm represents an infrastructure realm (Kubernetes namespace/cluster).
 type Realm struct {
-	Name      string
-	Status    string
-	Cluster   string
-	Pods      int
-	MaxPods   int
-	CPUUsage  string
-	MemUsage  string
-	GPUs      int
-	Region    string
+	Name     string
+	Status   string
+	Cluster  string
+	Pods     int
+	MaxPods  int
+	CPUUsage string
+	MemUsage string
+	GPUs     int
+	Region   string
 }
 
 // RealmsPage displays an infrastructure grid with health status.
@@ -146,13 +146,13 @@ func (r RealmsPage) renderRealmCard(realm Realm, selected bool) string {
 	if selected {
 		return lipgloss.NewStyle().
 			Background(theme.BgTertiary).
-			Width(r.width - 6).
+			Width(r.width-6).
 			Padding(0, 1).
 			Render(content)
 	}
 
 	return lipgloss.NewStyle().
-		Width(r.width - 6).
+		Width(r.width-6).
 		Padding(0, 1).
 		Render(content)
 }

--- a/cli/internal/tui/pages/sessions.go
+++ b/cli/internal/tui/pages/sessions.go
@@ -247,6 +247,11 @@ func (s SessionsPage) SelectedSession() *tui.ClusterSession {
 	return &sess
 }
 
+// Searching returns whether the search input is active.
+func (s SessionsPage) Searching() bool {
+	return s.searching
+}
+
 // SetSize updates the page dimensions.
 func (s *SessionsPage) SetSize(w, h int) {
 	s.width = w
@@ -430,13 +435,13 @@ func (s SessionsPage) renderSessionCard(sess tui.ClusterSession, selected bool) 
 	if selected {
 		return lipgloss.NewStyle().
 			Background(theme.BgTertiary).
-			Width(s.width - 6).
+			Width(s.width-6).
 			Padding(0, 1).
 			Render(content)
 	}
 
 	return lipgloss.NewStyle().
-		Width(s.width - 6).
+		Width(s.width-6).
 		Padding(0, 1).
 		Render(content)
 }
@@ -577,7 +582,7 @@ func demoSessions() []api.Session {
 			ID: "f6a7b8c9-d0e1-2345-fabc-456789012345", Name: "fix/migration-lock",
 			Model: "claude-sonnet-4", Repo: "niuu/volundr", Branch: "fix/migration",
 			Status: "error", MessageCount: 7, TokensUsed: 23400,
-			Error: "Pod OOMKilled after 4.2GB memory usage",
+			Error:     "Pod OOMKilled after 4.2GB memory usage",
 			CreatedAt: "2026-03-08T13:00:00Z", LastActive: "2026-03-08T13:12:00Z",
 		},
 		{

--- a/cli/internal/tui/pages/sessions.go
+++ b/cli/internal/tui/pages/sessions.go
@@ -156,8 +156,8 @@ func (s SessionsPage) handleSearchInput(msg tea.KeyMsg) (SessionsPage, tea.Cmd) 
 	case "space":
 		s.search += " "
 	default:
-		if len(msg.String()) == 1 {
-			s.search += msg.String()
+		if text := msg.Key().Text; len(text) > 0 {
+			s.search += text
 		}
 	}
 	s.applyFilter()

--- a/cli/internal/tui/pages/sessions_test.go
+++ b/cli/internal/tui/pages/sessions_test.go
@@ -5,8 +5,8 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/niuulabs/volundr/cli/internal/api"
-	tui "github.com/niuulabs/volundr/cli/internal/tui"
 	"github.com/niuulabs/volundr/cli/internal/remote"
+	tui "github.com/niuulabs/volundr/cli/internal/tui"
 )
 
 func TestNewSessionsPage_NilPool(t *testing.T) {
@@ -504,6 +504,17 @@ func TestSessionsPage_Update_ContextCycle(t *testing.T) {
 	page := SessionsPage{filter: "all"}
 	page, _ = page.Update(tea.KeyPressMsg{Code: 'c'})
 	// Should not panic with nil pool
+}
+
+func TestSessionsPage_Searching(t *testing.T) {
+	page := NewSessionsPage(nil)
+	if page.Searching() {
+		t.Error("expected not searching initially")
+	}
+	page.searching = true
+	if !page.Searching() {
+		t.Error("expected searching after setting flag")
+	}
 }
 
 func TestSessionsPage_View_Searching(t *testing.T) {

--- a/cli/internal/tui/pages/sessions_test.go
+++ b/cli/internal/tui/pages/sessions_test.go
@@ -456,10 +456,10 @@ func TestSessionsPage_Update_SearchMode(t *testing.T) {
 	}
 
 	// Type "auth"
-	page, _ = page.Update(tea.KeyPressMsg{Code: 'a'})
-	page, _ = page.Update(tea.KeyPressMsg{Code: 'u'})
-	page, _ = page.Update(tea.KeyPressMsg{Code: 't'})
-	page, _ = page.Update(tea.KeyPressMsg{Code: 'h'})
+	page, _ = page.Update(tea.KeyPressMsg{Code: 'a', Text: "a"})
+	page, _ = page.Update(tea.KeyPressMsg{Code: 'u', Text: "u"})
+	page, _ = page.Update(tea.KeyPressMsg{Code: 't', Text: "t"})
+	page, _ = page.Update(tea.KeyPressMsg{Code: 'h', Text: "h"})
 	if page.search != "auth" {
 		t.Errorf("expected search %q, got %q", "auth", page.search)
 	}

--- a/cli/internal/tui/pages/settings.go
+++ b/cli/internal/tui/pages/settings.go
@@ -186,6 +186,11 @@ func (s SettingsPage) settingsHelp() string {
 	return "  Tab/Shift+Tab: switch section  ↑↓: navigate  Enter: edit  r: refresh"
 }
 
+// Editing returns whether the settings editor is active.
+func (s SettingsPage) Editing() bool {
+	return s.editing
+}
+
 // SetSize updates the page dimensions.
 func (s *SettingsPage) SetSize(w, h int) {
 	s.width = w
@@ -418,7 +423,7 @@ func (s SettingsPage) renderSettingRows(rows []settingRow, theme tui.Theme) stri
 		if i == s.cursor {
 			lines = append(lines, lipgloss.NewStyle().
 				Background(theme.BgTertiary).
-				Width(s.width - 8).
+				Width(s.width-8).
 				Render(line))
 		} else {
 			lines = append(lines, line)

--- a/cli/internal/tui/pages/settings.go
+++ b/cli/internal/tui/pages/settings.go
@@ -162,8 +162,8 @@ func (s *SettingsPage) handleEditInput(msg tea.KeyMsg) {
 	case "space":
 		s.editBuf += " "
 	default:
-		if len(msg.String()) == 1 {
-			s.editBuf += msg.String()
+		if text := msg.Key().Text; len(text) > 0 {
+			s.editBuf += text
 		}
 	}
 }

--- a/cli/internal/tui/pages/terminal.go
+++ b/cli/internal/tui/pages/terminal.go
@@ -52,12 +52,12 @@ type terminalTab struct {
 	label      string
 	terminalID string // server-side tmux session ID (for kill calls)
 	sessionID  string
-	wsURL     string // WebSocket URL for reconnecting on tab switch
-	emulator  *vt.Emulator
-	ws        *api.TerminalWSClient
-	connState string
-	connErr   error
-	mu        sync.Mutex
+	wsURL      string // WebSocket URL for reconnecting on tab switch
+	emulator   *vt.Emulator
+	ws         *api.TerminalWSClient
+	connState  string
+	connErr    error
+	mu         sync.Mutex
 }
 
 // TerminalPage implements a full remote PTY terminal via WebSocket and x/vt.
@@ -674,7 +674,7 @@ func (t TerminalPage) termDimensions() (int, int) {
 		return defaultTermWidth, defaultTermHeight
 	}
 
-	w := t.width - 4 // padding
+	w := t.width - 4  // padding
 	h := t.height - 4 // status line + tab bar + padding
 
 	if t.fullScreen {
@@ -723,7 +723,7 @@ func (t TerminalPage) View() string {
 
 	helpText := lipgloss.NewStyle().
 		Foreground(theme.TextMuted).
-		Render("  ctrl+t: new tab  ctrl+w: close  ctrl+n/p: switch tabs  ctrl+f: fullscreen")
+		Render("  Esc: nav mode (1-7/q/?/[, i: back)  ctrl+t: new  ctrl+w: close  ctrl+n/p: tabs  ctrl+f: fullscreen")
 
 	return lipgloss.NewStyle().
 		Width(t.width).
@@ -831,15 +831,16 @@ func (t TerminalPage) renderTabBar() string {
 	return "  " + strings.Join(tabs, "  │  ")
 }
 
-
 // keyToBytes converts a bubbletea KeyMsg to raw bytes for the PTY.
 func keyToBytes(msg tea.KeyMsg) []byte {
 	// Use Keystroke() for matching — String() may return raw control chars
 	// that don't match our "ctrl+n" style case labels.
 	key := msg.Key().Keystroke()
 
-	// If the key has printable text and no modifier, return it directly.
-	if text := msg.Key().Text; len(text) > 0 && msg.Key().Mod == 0 {
+	// If the key has printable text and no modifier (or only Shift), return it directly.
+	// Shift is included because Kitty keyboard protocol explicitly reports Shift
+	// for uppercase letters, but the text already contains the shifted character.
+	if text := msg.Key().Text; len(text) > 0 && (msg.Key().Mod == 0 || msg.Key().Mod == tea.ModShift) {
 		return []byte(text)
 	}
 

--- a/cli/internal/tui/pages/terminal.go
+++ b/cli/internal/tui/pages/terminal.go
@@ -187,7 +187,8 @@ func (t TerminalPage) handleKey(msg tea.KeyMsg) (TerminalPage, tea.Cmd) {
 
 	// Ctrl+] always toggles between insert and normal mode (like the
 	// classic telnet escape character). Works regardless of current mode.
-	if key == "ctrl+]" {
+	// Match both "ctrl+]" (Kitty protocol) and raw 0x1D (legacy terminals).
+	if key == "ctrl+]" || msg.Key().Code == 0x1D {
 		t.insertMode = !t.insertMode
 		return t, nil
 	}

--- a/cli/internal/tui/pages/terminal.go
+++ b/cli/internal/tui/pages/terminal.go
@@ -76,6 +76,11 @@ type TerminalPage struct {
 	// activeSession is stored so new tabs can be spawned from ctrl+t.
 	activeSession *api.Session
 	activeToken   string
+
+	// insertMode tracks whether keystrokes are forwarded to the PTY (true)
+	// or handled as navigation commands (false). Ctrl+] exits insert mode,
+	// i re-enters it — mirroring the chat page's input/scroll modes.
+	insertMode bool
 }
 
 // defaultTermWidth and defaultTermHeight are initial vt emulator dimensions
@@ -91,13 +96,14 @@ func NewTerminalPage(serverURL string, client *api.Client, pool *tui.ClientPool)
 	connCh := make(chan tea.Msg, 16)
 
 	return TerminalPage{
-		tabs:      nil,
-		activeTab: 0,
-		serverURL: serverURL,
-		client:    client,
-		pool:      pool,
-		outputCh:  outputCh,
-		connCh:    connCh,
+		tabs:       nil,
+		activeTab:  0,
+		serverURL:  serverURL,
+		client:     client,
+		pool:       pool,
+		outputCh:   outputCh,
+		connCh:     connCh,
+		insertMode: true,
 	}
 }
 
@@ -177,26 +183,27 @@ func (t TerminalPage) Update(msg tea.Msg) (TerminalPage, tea.Cmd) {
 
 // handleKey processes keyboard input.
 func (t TerminalPage) handleKey(msg tea.KeyMsg) (TerminalPage, tea.Cmd) {
-	// Use Keystroke() for matching — unlike String(), it always returns the
-	// canonical "ctrl+n" format regardless of whether the terminal sends
-	// the raw control character or enhanced key data.
 	key := msg.Key().Keystroke()
 
-	// Full-screen toggle: F11 or ctrl+f
+	// Ctrl+] always toggles between insert and normal mode (like the
+	// classic telnet escape character). Works regardless of current mode.
+	if key == "ctrl+]" {
+		t.insertMode = !t.insertMode
+		return t, nil
+	}
+
+	// Full-screen toggle: F11 or ctrl+f (works in both modes).
 	if key == "f11" || key == "ctrl+f" {
 		t.fullScreen = !t.fullScreen
 		t.resizeAllEmulators()
 		return t, nil
 	}
 
-	// Tab management: ctrl+t to create new tab
+	// Tab management works in both modes.
 	if key == "ctrl+t" {
 		t.spawnNewTab()
 		return t, nil
 	}
-
-	// Tab switching: ctrl+n for next, ctrl+p for previous.
-	// Reconnects WebSocket since the server only supports one active connection.
 	if key == "ctrl+n" && len(t.tabs) > 1 {
 		t.activeTab = (t.activeTab + 1) % len(t.tabs)
 		t.connectTab(t.activeTab)
@@ -207,14 +214,23 @@ func (t TerminalPage) handleKey(msg tea.KeyMsg) (TerminalPage, tea.Cmd) {
 		t.connectTab(t.activeTab)
 		return t, nil
 	}
-
-	// Close tab: ctrl+w
 	if key == "ctrl+w" && len(t.tabs) > 0 {
 		t.closeTab(t.activeTab)
 		return t, nil
 	}
 
-	// Forward all other keys to the active terminal's WebSocket
+	// --- Normal mode: navigation keys, i to re-enter insert mode ---
+	if !t.insertMode {
+		// i enters insert mode (like vim / chat page).
+		if key == "i" {
+			t.insertMode = true
+		}
+		// All other keys are ignored in normal mode; they fall through
+		// to the app layer in tui.go for page navigation (1-7, q, ?, [).
+		return t, nil
+	}
+
+	// --- Insert mode: forward keys to the active PTY ---
 	if len(t.tabs) == 0 {
 		return t, nil
 	}
@@ -639,6 +655,11 @@ func (t *TerminalPage) Close() {
 	t.tabs = nil
 }
 
+// InsertMode returns whether the terminal is in insert mode (keys go to PTY).
+func (t TerminalPage) InsertMode() bool {
+	return t.insertMode
+}
+
 // SetSize updates the page dimensions and resizes all emulators.
 func (t *TerminalPage) SetSize(w, h int) {
 	t.width = w
@@ -721,9 +742,15 @@ func (t TerminalPage) View() string {
 		Width(termW).
 		Height(termH)
 
-	helpText := lipgloss.NewStyle().
-		Foreground(theme.TextMuted).
-		Render("  Esc: nav mode (1-7/q/?/[, i: back)  ctrl+t: new  ctrl+w: close  ctrl+n/p: tabs  ctrl+f: fullscreen")
+	var helpText string
+	if t.insertMode {
+		modeTag := lipgloss.NewStyle().Foreground(theme.AccentEmerald).Bold(true).Render("INSERT")
+		helpText = fmt.Sprintf("  %s  ctrl+]: normal mode  ctrl+t: new  ctrl+w: close  ctrl+n/p: tabs  ctrl+f: fullscreen", modeTag)
+	} else {
+		modeTag := lipgloss.NewStyle().Foreground(theme.AccentAmber).Bold(true).Render("NORMAL")
+		helpText = fmt.Sprintf("  %s  i: insert  1-7: navigate  q: quit  ?: help  [: sidebar  ctrl+]: insert mode", modeTag)
+	}
+	helpText = lipgloss.NewStyle().Foreground(theme.TextMuted).Render(helpText)
 
 	return lipgloss.NewStyle().
 		Width(t.width).


### PR DESCRIPTION
## Summary

- Adds `InputCaptured` flag to `App` that suppresses global keybindings (`q`, `?`, `[`, `1-7`) when a text input is active (chat, terminal PTY, session search, settings editor)
- Fixes key routing in `tui.go` so numbers 1-7, `q`, `?`, `[`, and capital letters are forwarded to the active input instead of triggering navigation/quit/help/sidebar
- Adds `alt+1` through `alt+7` as alternative page navigation that works in all contexts, including when input is captured

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] New tests for `InputCaptured` suppression (q, ?, [, 1-7 blocked; ctrl+c and esc still work)
- [x] New tests for `IsAltNavigationKey` (alt+1-7 navigates, plain keys and alt+letter don't)
- [x] New tests for `Searching()` and `Editing()` accessor methods
- [ ] Manual: type numbers 1-7 in chat input — should appear in text, not navigate
- [ ] Manual: type `q`, `?`, `[` in chat input — should appear in text
- [ ] Manual: type in terminal PTY — all keys forwarded to shell
- [ ] Manual: search sessions with `/` — all characters work in search field
- [ ] Manual: edit settings — all characters work in edit field
- [ ] Manual: `alt+1`-`alt+7` navigates from any context
- [ ] Manual: `Esc` exits input modes and returns to navigation

Closes [NIU-147](https://linear.app/niuu/issue/NIU-147/tui-keyboard-input-captured-by-global-keybindings-during-text-entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)