### PR TITLE
fix(ci): resolve security findings and add OCI manifest annotations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -391,6 +391,45 @@ jobs:
           docker manifest push "${IMAGE}:${PR_TAG}"
 
   # ---------------------------------------------------------------------------
+  # Security — container vulnerability scanning
+  # ---------------------------------------------------------------------------
+  scan-containers:
+    name: "Scan: ${{ matrix.container }}"
+    needs: [changes, merge-container-manifests]
+    if: needs.changes.outputs.has_containers == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+    strategy:
+      matrix:
+        container: ${{ fromJson(needs.changes.outputs.container-names) }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Scan container with Trivy
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        with:
+          image-ref: ghcr.io/${{ github.repository_owner }}/${{ matrix.container }}:pr-${{ github.event.number }}
+          format: sarif
+          output: trivy-${{ matrix.container }}.sarif
+          severity: CRITICAL,HIGH
+
+      - name: Upload Trivy results
+        uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4
+        if: always() && hashFiles(format('trivy-{0}.sarif', matrix.container)) != ''
+        with:
+          sarif_file: trivy-${{ matrix.container }}.sarif
+          category: trivy-${{ matrix.container }}
+
+  # ---------------------------------------------------------------------------
   # Security (always runs)
   # ---------------------------------------------------------------------------
   dependency-review:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,6 +52,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract image description from Dockerfile
+        id: meta
+        run: |
+          DESC=$(grep 'org.opencontainers.image.description=' \
+            ./containers/${{ matrix.container }}/Dockerfile \
+            | head -1 | sed 's/.*description="\(.*\)"/\1/')
+          echo "description=${DESC}" >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
@@ -61,6 +69,7 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.container }}:${{ needs.version.outputs.version }}-${{ matrix.platform }}
           labels: |
             org.opencontainers.image.title=${{ matrix.container }}
+            org.opencontainers.image.description=${{ steps.meta.outputs.description }}
             org.opencontainers.image.licenses=Apache-2.0
             org.opencontainers.image.vendor=Niuu Labs
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
@@ -76,12 +85,26 @@ jobs:
     needs: [version, build-container-image]
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       packages: write
       id-token: write
     strategy:
       matrix:
         container: [volundr, skuld, skuld-codex, devrunner, volundr-web]
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          sparse-checkout: containers/${{ matrix.container }}/Dockerfile
+          sparse-checkout-cone-mode: false
+
+      - name: Extract image description from Dockerfile
+        id: meta
+        run: |
+          DESC=$(grep 'org.opencontainers.image.description=' \
+            ./containers/${{ matrix.container }}/Dockerfile \
+            | head -1 | sed 's/.*description="\(.*\)"/\1/')
+          echo "description=${DESC}" >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
@@ -97,17 +120,27 @@ jobs:
           IMAGE="${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.container }}"
           VERSION="${{ needs.version.outputs.version }}"
 
+          ANNOTATIONS=(
+            --annotation "index:org.opencontainers.image.title=${{ matrix.container }}"
+            --annotation "index:org.opencontainers.image.description=${{ steps.meta.outputs.description }}"
+            --annotation "index:org.opencontainers.image.licenses=Apache-2.0"
+            --annotation "index:org.opencontainers.image.vendor=Niuu Labs"
+            --annotation "index:org.opencontainers.image.source=https://github.com/${{ github.repository }}"
+            --annotation "index:org.opencontainers.image.documentation=https://github.com/${{ github.repository }}"
+            --annotation "index:org.opencontainers.image.version=${VERSION}"
+          )
+
           # versioned tag
-          docker manifest create "${IMAGE}:${VERSION}" \
+          docker buildx imagetools create "${ANNOTATIONS[@]}" \
+            -t "${IMAGE}:${VERSION}" \
             "${IMAGE}:${VERSION}-amd64" \
             "${IMAGE}:${VERSION}-arm64"
-          docker manifest push "${IMAGE}:${VERSION}"
 
           # latest
-          docker manifest create "${IMAGE}:latest" \
+          docker buildx imagetools create "${ANNOTATIONS[@]}" \
+            -t "${IMAGE}:latest" \
             "${IMAGE}:${VERSION}-amd64" \
             "${IMAGE}:${VERSION}-arm64"
-          docker manifest push "${IMAGE}:latest"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3

--- a/containers/devrunner/Dockerfile
+++ b/containers/devrunner/Dockerfile
@@ -25,11 +25,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install oh-my-zsh system-wide (users get a copy via init-home.sh)
-RUN git clone --depth=1 https://github.com/ohmyzsh/ohmyzsh.git /usr/share/oh-my-zsh
+# Pinned to a specific commit for reproducibility
+RUN git clone https://github.com/ohmyzsh/ohmyzsh.git /usr/share/oh-my-zsh \
+    && cd /usr/share/oh-my-zsh && git checkout 8df5c1b18b1393dc5046c729094f897bd3636a9b \
+    && rm -rf .git
 
-# Install Node.js 24 LTS
-RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
-    && apt-get install -y --no-install-recommends nodejs \
+# Install Node.js 24 LTS (pinned keyring + apt source instead of curl|bash)
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+    | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" \
+    > /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Claude Code CLI globally via npm (same method as skuld pod)

--- a/containers/devrunner/Dockerfile
+++ b/containers/devrunner/Dockerfile
@@ -32,8 +32,8 @@ RUN git clone https://github.com/ohmyzsh/ohmyzsh.git /usr/share/oh-my-zsh \
 
 # Install Node.js 24 LTS (pinned keyring + apt source instead of curl|bash)
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
-    | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" \
+    -o /usr/share/keyrings/nodesource.asc \
+    && echo "deb [signed-by=/usr/share/keyrings/nodesource.asc] https://deb.nodesource.com/node_24.x nodistro main" \
     > /etc/apt/sources.list.d/nodesource.list \
     && apt-get update && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*

--- a/containers/skuld-codex/Dockerfile
+++ b/containers/skuld-codex/Dockerfile
@@ -20,9 +20,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Node.js 24 LTS
-RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
-    && apt-get install -y nodejs \
+# Install Node.js 24 LTS (pinned keyring + apt source instead of curl|bash)
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+    | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" \
+    > /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 # Install OpenAI Codex CLI

--- a/containers/skuld-codex/Dockerfile
+++ b/containers/skuld-codex/Dockerfile
@@ -22,8 +22,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install Node.js 24 LTS (pinned keyring + apt source instead of curl|bash)
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
-    | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" \
+    -o /usr/share/keyrings/nodesource.asc \
+    && echo "deb [signed-by=/usr/share/keyrings/nodesource.asc] https://deb.nodesource.com/node_24.x nodistro main" \
     > /etc/apt/sources.list.d/nodesource.list \
     && apt-get update && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*

--- a/containers/skuld/Dockerfile
+++ b/containers/skuld/Dockerfile
@@ -23,8 +23,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install Node.js 24 LTS (pinned keyring + apt source instead of curl|bash)
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
-    | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" \
+    -o /usr/share/keyrings/nodesource.asc \
+    && echo "deb [signed-by=/usr/share/keyrings/nodesource.asc] https://deb.nodesource.com/node_24.x nodistro main" \
     > /etc/apt/sources.list.d/nodesource.list \
     && apt-get update && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*

--- a/containers/skuld/Dockerfile
+++ b/containers/skuld/Dockerfile
@@ -21,9 +21,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Node.js 24 LTS
-RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
-    && apt-get install -y nodejs \
+# Install Node.js 24 LTS (pinned keyring + apt source instead of curl|bash)
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+    | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" \
+    > /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Claude Code CLI globally via npm

--- a/containers/volundr/Dockerfile
+++ b/containers/volundr/Dockerfile
@@ -21,8 +21,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install Node.js 24 LTS (pinned keyring + apt source instead of curl|bash)
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
-    | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" \
+    -o /usr/share/keyrings/nodesource.asc \
+    && echo "deb [signed-by=/usr/share/keyrings/nodesource.asc] https://deb.nodesource.com/node_24.x nodistro main" \
     > /etc/apt/sources.list.d/nodesource.list \
     && apt-get update && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*

--- a/containers/volundr/Dockerfile
+++ b/containers/volundr/Dockerfile
@@ -19,9 +19,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Node.js 24 LTS
-RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
-    && apt-get install -y nodejs \
+# Install Node.js 24 LTS (pinned keyring + apt source instead of curl|bash)
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+    | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" \
+    > /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Claude Code CLI globally via npm (same method as skuld pod)

--- a/web/src/adapters/mock/volundr.adapter.ts
+++ b/web/src/adapters/mock/volundr.adapter.ts
@@ -201,7 +201,7 @@ export class MockVolundrService implements IVolundrService {
 
     const created: VolundrPreset = {
       ...preset,
-      id: `preset-${Math.random().toString(36).substring(2, 10)}`,
+      id: `preset-${crypto.randomUUID().substring(0, 8)}`,
       createdAt: now,
       updatedAt: now,
     };
@@ -265,7 +265,7 @@ export class MockVolundrService implements IVolundrService {
     resourceConfig?: Record<string, string | undefined>;
   }): Promise<VolundrSession> {
     const newSession: VolundrSession = {
-      id: `forge-${Math.random().toString(36).substring(2, 10)}`,
+      id: `forge-${crypto.randomUUID().substring(0, 8)}`,
       name: config.name,
       source: config.source,
       status: 'starting',
@@ -288,7 +288,7 @@ export class MockVolundrService implements IVolundrService {
 
   async connectSession(config: { name: string; hostname: string }): Promise<VolundrSession> {
     const newSession: VolundrSession = {
-      id: `manual-${Math.random().toString(36).substring(2, 10)}`,
+      id: `manual-${crypto.randomUUID().substring(0, 8)}`,
       name: config.name,
       source: { type: 'git', repo: '', branch: '' },
       status: 'starting',
@@ -611,7 +611,7 @@ export class MockVolundrService implements IVolundrService {
     const session = this.sessions.find(s => s.id === sessionId);
     const sessionRepo = session?.source.type === 'git' ? session.source.repo : '';
     const repo = mockVolundrRepos.find(r => r.url.includes(sessionRepo));
-    const prNumber = Math.floor(Math.random() * 200) + 100;
+    const prNumber = (parseInt(crypto.randomUUID().substring(0, 4), 16) % 200) + 100;
 
     const pr: PullRequest = {
       number: prNumber,
@@ -948,7 +948,7 @@ export class MockVolundrService implements IVolundrService {
     const now = new Date().toISOString();
     const created: IntegrationConnection = {
       ...connection,
-      id: `int-${Math.random().toString(36).substring(2, 8)}`,
+      id: `int-${crypto.randomUUID().substring(0, 6)}`,
       createdAt: now,
       updatedAt: now,
     };


### PR DESCRIPTION
## Summary
- **Dockerfiles**: Replace `curl | bash` NodeSource setup with pinned GPG keyring + apt source in all 4 Dockerfiles, addressing Scorecard `downloadThenRun` findings
- **Mock adapter**: Replace `Math.random()` with `crypto.randomUUID()` to resolve CodeQL insecure randomness finding
- **Devrunner**: Pin oh-my-zsh `git clone` to specific commit SHA for reproducibility
- **Release workflow**: Switch manifest merging from `docker manifest` to `docker buildx imagetools create` with OCI `--annotation` flags so labels (title, description, license, vendor, source) appear on the GitHub Packages UI
- **25 code scanning alerts dismissed** as false positives or won't-fix (path injection already mitigated, test assertions, metadata logging, npm/pip hash pinning impractical)

## Test plan
- [x] All 2286 web tests pass with `crypto.randomUUID()` changes
- [ ] Verify container builds succeed with new NodeSource apt setup
- [ ] Verify OCI annotations appear on GitHub Packages after next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)