### PR TITLE
fix(adapters): prevent bare memory values and NFS git clone failure

### DIFF
--- a/containers/devrunner/configs/init-home.sh
+++ b/containers/devrunner/configs/init-home.sh
@@ -27,10 +27,15 @@ if [ -d /usr/share/oh-my-zsh ] && [ ! -d "$TARGET_DIR/.oh-my-zsh" ]; then
     cp -r /usr/share/oh-my-zsh "$TARGET_DIR/.oh-my-zsh"
 fi
 
-# Install Homebrew into persistent home if not already present
+# Install Homebrew into persistent home if not already present.
+# Clone to /tmp first because git index-pack uses mmap which fails on
+# NFS-backed volumes (Permission denied on tmp_pack files), then move.
 if [ ! -x "$TARGET_DIR/.linuxbrew/bin/brew" ]; then
     echo "Installing Homebrew into $TARGET_DIR/.linuxbrew ..."
-    git clone --depth=1 https://github.com/Homebrew/brew "$TARGET_DIR/.linuxbrew/Homebrew"
+    BREW_TMP="$(mktemp -d)"
+    git clone --depth=1 https://github.com/Homebrew/brew "$BREW_TMP/Homebrew"
     mkdir -p "$TARGET_DIR/.linuxbrew/bin"
+    mv "$BREW_TMP/Homebrew" "$TARGET_DIR/.linuxbrew/Homebrew"
+    rm -rf "$BREW_TMP"
     ln -sf "$TARGET_DIR/.linuxbrew/Homebrew/bin/brew" "$TARGET_DIR/.linuxbrew/bin/brew"
 fi

--- a/src/volundr/adapters/outbound/static_resource_provider.py
+++ b/src/volundr/adapters/outbound/static_resource_provider.py
@@ -105,7 +105,9 @@ def translate_resource_config(resource_config: dict) -> TranslatedResources:
                 )
                 mem_str = f"{mem_str}Gi"
             except (ValueError, TypeError):
-                pass
+                # Non-numeric, non-suffixed value — leave as-is for
+                # downstream validation to reject.
+                logger.warning("Memory value '%s' is not a valid number or K8s quantity", mem_str)
         requests["memory"] = mem_str
         limits["memory"] = mem_str
 
@@ -153,7 +155,8 @@ def validate_resource_config(resource_config: dict) -> list[str]:
                 float(mem_str)
                 # Bare number — warn but don't block (translate auto-appends Gi)
                 errors.append(
-                    f"memory value '{memory}' has no unit suffix — will be interpreted as {memory}Gi"
+                    f"memory value '{memory}' has no unit suffix"
+                    f" — will be interpreted as {memory}Gi"
                     " (use Ki, Mi, Gi, or Ti suffix to be explicit)"
                 )
             except (ValueError, TypeError):

--- a/src/volundr/adapters/outbound/static_resource_provider.py
+++ b/src/volundr/adapters/outbound/static_resource_provider.py
@@ -1,5 +1,7 @@
 """Static resource provider for dev/test environments."""
 
+import logging
+
 from volundr.domain.models import (
     ClusterResourceInfo,
     ResourceCategory,
@@ -7,6 +9,10 @@ from volundr.domain.models import (
     TranslatedResources,
 )
 from volundr.domain.ports import ResourceProvider
+
+logger = logging.getLogger(__name__)
+
+_K8S_MEMORY_SUFFIXES = ("Ki", "Mi", "Gi", "Ti")
 
 # Standard resource types always available (CPU + Memory only;
 # GPU and other resources are discovered dynamically from node data)
@@ -85,11 +91,23 @@ def translate_resource_config(resource_config: dict) -> TranslatedResources:
         requests["cpu"] = str(cpu)
         limits["cpu"] = str(cpu)
 
-    # Memory
+    # Memory — bare numbers are treated as Gi to prevent accidental byte values
     memory = resource_config.get("memory")
     if memory:
-        requests["memory"] = str(memory)
-        limits["memory"] = str(memory)
+        mem_str = str(memory)
+        if mem_str and not any(mem_str.endswith(s) for s in _K8S_MEMORY_SUFFIXES):
+            try:
+                float(mem_str)
+                logger.warning(
+                    "Memory value '%s' has no unit suffix — interpreting as '%sGi'",
+                    mem_str,
+                    mem_str,
+                )
+                mem_str = f"{mem_str}Gi"
+            except (ValueError, TypeError):
+                pass
+        requests["memory"] = mem_str
+        limits["memory"] = mem_str
 
     # GPU
     gpu = resource_config.get("gpu")
@@ -128,10 +146,16 @@ def validate_resource_config(resource_config: dict) -> list[str]:
     memory = resource_config.get("memory")
     if memory is not None:
         mem_str = str(memory)
-        if mem_str and not any(mem_str.endswith(s) for s in ("Ki", "Mi", "Gi", "Ti")):
-            # Allow plain numbers (bytes) or K8s suffixes
+        if not mem_str:
+            errors.append("memory value must not be empty")
+        elif not any(mem_str.endswith(s) for s in _K8S_MEMORY_SUFFIXES):
             try:
                 float(mem_str)
+                # Bare number — warn but don't block (translate auto-appends Gi)
+                errors.append(
+                    f"memory value '{memory}' has no unit suffix — will be interpreted as {memory}Gi"
+                    " (use Ki, Mi, Gi, or Ti suffix to be explicit)"
+                )
             except (ValueError, TypeError):
                 errors.append(f"invalid memory value: {memory} (use Ki, Mi, Gi, or Ti suffix)")
 

--- a/tests/test_adapters/test_resource_provider.py
+++ b/tests/test_adapters/test_resource_provider.py
@@ -60,6 +60,16 @@ class TestTranslateResourceConfig:
         assert result.limits == {"nvidia.com/gpu": "2"}
         assert result.node_selector == {"nvidia.com/gpu.product": "A100"}
 
+    def test_bare_memory_number_gets_gi_suffix(self):
+        result = translate_resource_config({"memory": "4"})
+        assert result.requests == {"memory": "4Gi"}
+        assert result.limits == {"memory": "4Gi"}
+
+    def test_bare_memory_integer_gets_gi_suffix(self):
+        result = translate_resource_config({"memory": 8})
+        assert result.requests == {"memory": "8Gi"}
+        assert result.limits == {"memory": "8Gi"}
+
     def test_full_config(self):
         result = translate_resource_config(
             {
@@ -102,9 +112,16 @@ class TestValidateResourceConfig:
         assert len(errors) == 1
         assert "memory" in errors[0]
 
-    def test_valid_memory_numeric(self):
+    def test_bare_memory_numeric_warns(self):
         errors = validate_resource_config({"memory": "1073741824"})
-        assert errors == []
+        assert len(errors) == 1
+        assert "no unit suffix" in errors[0]
+        assert "1073741824Gi" in errors[0]
+
+    def test_bare_memory_small_number_warns(self):
+        errors = validate_resource_config({"memory": "4"})
+        assert len(errors) == 1
+        assert "no unit suffix" in errors[0]
 
     def test_invalid_gpu(self):
         errors = validate_resource_config({"gpu": "1.5"})

--- a/tests/test_adapters/test_resource_provider.py
+++ b/tests/test_adapters/test_resource_provider.py
@@ -70,6 +70,11 @@ class TestTranslateResourceConfig:
         assert result.requests == {"memory": "8Gi"}
         assert result.limits == {"memory": "8Gi"}
 
+    def test_invalid_memory_string_passed_through(self):
+        result = translate_resource_config({"memory": "lots"})
+        assert result.requests == {"memory": "lots"}
+        assert result.limits == {"memory": "lots"}
+
     def test_full_config(self):
         result = translate_resource_config(
             {
@@ -122,6 +127,11 @@ class TestValidateResourceConfig:
         errors = validate_resource_config({"memory": "4"})
         assert len(errors) == 1
         assert "no unit suffix" in errors[0]
+
+    def test_empty_memory_string_invalid(self):
+        errors = validate_resource_config({"memory": ""})
+        assert len(errors) == 1
+        assert "must not be empty" in errors[0]
 
     def test_invalid_gpu(self):
         errors = validate_resource_config({"gpu": "1.5"})


### PR DESCRIPTION
## Summary
- **Memory resource bug**: Bare numeric memory values (e.g. `memory: 4`) were passed to Kubernetes as-is, interpreted as 4 bytes instead of 4Gi. This caused cgroup configuration failures (`OCI runtime create failed`) preventing skuld and devrunner containers from starting. The translate layer now auto-appends `Gi` to bare numbers with a warning, and validation alerts callers to use explicit suffixes.
- **NFS git clone bug**: Homebrew installation in `init-home.sh` failed on NFS-backed home volumes because git's `index-pack` uses `mmap` which has cache coherence issues on NFS (Longhorn RWX via share manager). Fixed by cloning to local `/tmp` first, then moving to the NFS volume.

## Test plan
- [x] Existing resource provider and validation tests updated and passing (40/40)
- [ ] Deploy a session and verify skuld/devrunner containers start without cgroup errors
- [ ] Verify `init-home.sh` successfully installs Homebrew on NFS-backed home volume
- [ ] Verify bare `memory: 4` in resource config produces a validation warning and translates to `4Gi`

🤖 Generated with [Claude Code](https://claude.com/claude-code)