### PR TITLE
docs: comprehensive documentation overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Self-hosted remote development platform on Kubernetes or Docker. Manages session
 
 ```
 ┌──────────────────┐     ┌────────────────────┐
-│   Hlidskjalf UI  │────▶│   Volundr API      │
+│   Volundr UI     │────▶│   Volundr API      │
 │   (React/Vite)   │     │   (FastAPI)         │
 └──────────────────┘     └────────┬───────────┘
                                   │
@@ -34,7 +34,7 @@ Self-hosted remote development platform on Kubernetes or Docker. Manages session
 
 - **Volundr API** — session CRUD, workspace provisioning, git integration, secret management, tenant hierarchy, event pipeline. FastAPI on asyncpg (raw SQL, no ORM).
 - **Skuld** — WebSocket broker that connects the UI to AI coding agents inside session pods. Supports SDK and subprocess transport modes.
-- **Hlidskjalf** — React web UI for session management, chronicles, diffs, terminal access, and admin. CSS Modules with design tokens.
+- **Web UI** — React web UI for session management, chronicles, diffs, terminal access, and admin. CSS Modules with design tokens.
 
 Each session launches a pod group on Kubernetes. Chat traffic flows directly from the UI through Skuld — Volundr is not in the data path.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@ Völundr is a self-hosted Claude Code session manager. Users create sessions, pi
 │                          VÖLUNDR                                │
 ├─────────────────────────────────────────────────────────────────┤
 │                                                                 │
-│   Hlidskjalf UI ──────► Volundr (API) ───────► Farm (ITaaS)    │
+│   Volundr UI ──────► Volundr (API) ───────► Farm (ITaaS)    │
 │      ✅ DONE                🔨 WIP                ✅ DONE       │
 │                                 │                               │
 │                                 │     Flux/Fleet + Helm         │
@@ -98,7 +98,7 @@ Volundr returns the chat endpoint URL when starting a session. UI connects direc
 
 ---
 
-## Hlidskjalf UI Integration
+## Volundr UI Integration
 
 ### Design Decisions
 
@@ -654,4 +654,4 @@ GET    /health                               - Health check
 
 ---
 
-*Völundr Implementation Roadmap v2.0 — Hlidskjalf UI Integration*
+*Völundr Implementation Roadmap v2.0 — Volundr UI Integration*

--- a/docs/site/architecture/components.md
+++ b/docs/site/architecture/components.md
@@ -2,63 +2,268 @@
 
 ## Volundr API
 
-The main API server. Built with FastAPI, runs as a multi-worker Uvicorn process.
+FastAPI application serving the REST API for session management, chronicles, git workflows, and multi-tenant access control.
 
-**Entry points:**
+### Stack
 
-- `volundr` CLI command (or `python -m volundr.main`)
-- `uvicorn volundr.main:app` for development
+- **Framework:** FastAPI with Uvicorn (4 workers default)
+- **Database:** PostgreSQL via asyncpg (raw SQL, no ORM)
+- **Real-time:** Server-Sent Events (SSE) for live session state and stats updates
+- **Auth:** OIDC JWT validation via pluggable `IdentityPort`, authorization via pluggable `AuthorizationPort`
 
-**Responsibilities:**
+### Port Interfaces
 
-- Session lifecycle (create, start, stop, delete, archive)
-- Workspace provisioning (PVC creation, storage quotas)
-- Git integration (repo validation, branch/PR management)
-- Chronicle management (session history, timelines)
-- Tenant and user management (hierarchy, roles, JIT provisioning)
-- Credential and secret management
-- Event pipeline (ingest, fan-out to sinks)
-- Preset and profile management
-- SSE streaming for real-time updates
-- Issue tracker integration
+The API depends exclusively on abstract port interfaces. Every infrastructure concern is behind an ABC:
 
-## Skuld
+| Port | Purpose |
+|------|---------|
+| `SessionRepository` | Session CRUD (PostgreSQL) |
+| `ChronicleRepository` | Chronicle persistence, reforge chain walking |
+| `TimelineRepository` | Timeline event storage for chronicles |
+| `PodManager` | Start/stop/status of session pods (Farm, Flux, direct K8s, Docker) |
+| `StoragePort` | PVC provisioning -- workspace (per-session) and home (per-user) |
+| `GatewayPort` | Gateway API config for session HTTPRoute creation |
+| `CredentialStorePort` | Pluggable credential storage (Vault, Infisical, memory, file) |
+| `SecretInjectionPort` | CSI driver pod spec additions -- Volundr never sees secret values |
+| `IdentityPort` | JWT validation and JIT user provisioning |
+| `AuthorizationPort` | Action-level authorization decisions (Cerbos, OPA, allow-all) |
+| `GitProvider` | Repository validation, listing, branch discovery per git host |
+| `GitWorkflowProvider` | PR creation/merge, CI status checks |
+| `EventSink` | Event pipeline sink (PostgreSQL always, RabbitMQ and OTel optional) |
+| `EventBroadcaster` | SSE event fan-out to connected browser clients |
+| `ProfileProvider` | Read-only forge profiles from YAML/CRD config |
+| `TemplateProvider` | Read-only workspace templates from YAML/CRD config |
+| `TokenTracker` | Token usage recording per session |
+| `PricingProvider` | Model pricing metadata |
+| `ResourceProvider` | Cluster resource discovery and translation (CPU/GPU/memory) |
+| `IssueTrackerProvider` | External issue tracker integration (Linear, Jira) |
+| `SecretManager` | K8s secret listing and creation |
+| `MCPServerProvider` | Available MCP server configurations |
+| `PresetRepository` | User-created runtime config presets (DB-stored) |
+| `SavedPromptRepository` | Reusable saved prompts |
+| `SessionContributor` | Contributor pipeline -- each wraps a port and produces pod spec additions |
+| `StatsRepository` | Aggregate dashboard statistics |
+| `UserRepository` | User persistence and tenant membership |
+| `TenantRepository` | Tenant hierarchy persistence |
+| `IntegrationRepository` | Integration connection persistence |
+| `ProjectMappingRepository` | Repo-to-tracker-project mappings |
+| `SessionEventRepository` | Read-side query port for persisted session events |
+| `SecretRepository` | Vault/OpenBao credential storage and session secret lifecycle |
 
-WebSocket broker that runs inside each session pod. Connects the web UI to AI coding agents.
+### Domain Services
 
-**Entry point:** `skuld` CLI command (or `python -m volundr.skuld.broker`)
+| Service | Responsibility |
+|---------|---------------|
+| `SessionService` | Session CRUD, start/stop orchestration, contributor pipeline execution, readiness polling, archive/restore |
+| `ChronicleService` | Chronicle CRUD, broker report ingestion, reforge, timeline aggregation |
+| `GitWorkflowService` | PR creation from sessions, merge, CI status, merge confidence calculation |
+| `TenantService` | Tenant hierarchy, default tenant provisioning |
+| `TokenService` | Token usage recording, cost calculation via pricing provider |
+| `StatsService` | Aggregate statistics for the dashboard |
+| `RepoService` | Repository listing across all registered git providers |
+| `CredentialService` | Credential store operations with mount strategy validation |
+| `PresetService` | Preset CRUD with default-flag management |
+| `PromptService` | Saved prompt CRUD and search |
+| `TrackerService` | Issue tracker operations, project mapping management |
+| `EventIngestionService` | Multi-sink event dispatch (fire-and-forget per sink) |
+| `IntegrationRegistry` | Catalog of known integration types and their adapter class paths |
+| `UserIntegrationService` | Per-user ephemeral provider factory (git + issue tracker) |
+| `ForgeProfileService` | Profile listing with active session counts |
+| `WorkspaceTemplateService` | Template listing and lookup |
+| `WorkspaceService` | Workspace PVC listing and management |
 
-**Transport modes:**
+### REST Endpoints
 
-| Mode | Description |
-|------|-------------|
-| `sdk` | Long-lived CLI process connected via `--sdk-url` WebSocket (default) |
-| `subprocess` | Spawns `claude -p` per message, reads stdout (legacy fallback) |
+Routes are organized into separate router modules under `adapters/inbound/`:
 
-**Features:**
+| Module | Prefix | Tags | Key Operations |
+|--------|--------|------|---------------|
+| `rest.py` | `/` | Sessions, Chronicles, Timeline, Models & Stats | Session CRUD, start/stop, chronicle CRUD, reforge, timeline, SSE stream, models, stats |
+| `rest_git.py` | `/git` | Git Workflow | Create PR, merge PR, CI status, list PRs |
+| `rest_profiles.py` | `/profiles`, `/templates` | Profiles, Templates | List/get profiles and workspace templates |
+| `rest_presets.py` | `/presets` | Presets | Preset CRUD, set default |
+| `rest_prompts.py` | `/prompts` | Prompts | Prompt CRUD, search |
+| `rest_tenants.py` | `/tenants`, `/users` | Tenants | Tenant/user CRUD, membership management |
+| `rest_credentials.py` | `/credentials` | Credentials | Credential store/list/delete, mount preview |
+| `rest_secrets.py` | `/mcp-servers`, `/secrets` | MCP Servers, Secrets | MCP server listing, K8s secret management |
+| `rest_events.py` | `/sessions/{id}/events` | Events | Event ingestion, query, token timeline |
+| `rest_integrations.py` | `/integrations` | Integrations | Integration catalog, connection management |
+| `rest_tracker.py` | `/tracker` | Issue Tracker | Issue search, status updates, project mappings |
+| `rest_resources.py` | `/resources` | Resources | Cluster resource discovery |
+| `rest_admin_settings.py` | `/admin/settings` | Admin | Runtime admin settings |
 
-- Multi-channel support (WebSocket, Telegram)
-- In-memory log buffer for pod log retrieval
-- Health and readiness endpoints
-- Service management for sidecar processes
+### Event Pipeline
 
-Skuld has its own configuration (`SkuldSettings`) and is deployed via a separate Helm chart (`charts/skuld/`).
+Session events flow through a multi-sink pipeline:
 
-## Hlidskjalf (Web UI)
+1. Skuld broker (or API routes) emits `SessionEvent` objects.
+2. `EventIngestionService` dispatches to all registered sinks concurrently.
+3. Sink failures are logged but do not block other sinks.
 
-React single-page application built with Vite.
+Sinks:
 
-**Stack:** React, TypeScript, Vite, CSS Modules, design tokens
+- **PostgreSQL** (always enabled) -- buffered writes via `PostgresEventSink`
+- **RabbitMQ** (optional) -- AMQP publish to a configurable exchange
+- **OpenTelemetry** (optional) -- GenAI semantic conventions via OTLP gRPC
 
-**Key pages/components:**
+---
 
-- Session management (list, create, start/stop)
-- Session chat (WebSocket connection to Skuld)
-- Chronicles browser (timeline, diffs, file changes)
-- Terminal access (ttyd integration)
-- Template browser (workspace blueprints)
-- Launch wizard (guided session creation)
-- Admin tools (tenant management, credentials)
-- Integration management (issue tracker setup)
+## Skuld Broker
 
-**Architecture:** follows the same hexagonal pattern — UI has its own `ports/` and `adapters/` directories for API communication, with a store layer for state management.
+WebSocket bridge that sits inside each session pod and connects the browser to the AI agent CLI. One Skuld instance per session.
+
+### Architecture
+
+```
+Browser                    Skuld Broker                AI CLI
+  |                            |                         |
+  |---WebSocket /ws/chat------>|                         |
+  |                            |---SDK WebSocket-------->|
+  |                            |   (or subprocess)       |
+  |<---streaming events--------|<---NDJSON events--------|
+  |                            |                         |
+```
+
+### Transport Modes
+
+Skuld supports multiple CLI backends through the `CLITransport` abstraction:
+
+**SDK WebSocket Transport** (default for Claude Code):
+
+- Skuld spawns the Claude Code CLI with `--sdk-url ws://localhost:{port}/ws/cli/{session_id}`.
+- The CLI connects back to Skuld over a second WebSocket.
+- Messages flow as NDJSON over this persistent connection.
+- Supports session resume, control messages (interrupt, model switch), and tool permission responses.
+- Keep-alive ping every 10 seconds.
+
+**Subprocess Transport** (legacy fallback for Claude Code):
+
+- Spawns `claude -p <message>` per user message.
+- Reads stream-json output from stdout.
+- No persistent connection between messages.
+
+**Codex Subprocess Transport** (OpenAI Codex CLI):
+
+- Spawns `codex --model <model> --full-auto <message>` per message.
+- Normalizes Codex events to the common broker format (tool names mapped, synthetic result events generated).
+- Does not use the SDK WebSocket protocol.
+
+### Session Management
+
+Skuld manages multiple concurrent sessions via `ServiceManager`:
+
+- Each session has its own transport instance, channel registry, and workspace directory.
+- Sessions can be created, stopped, and listed via Skuld's REST API.
+- Session definitions (from Kubernetes CRDs) configure CLI type, model, permissions, and environment.
+
+### Channels
+
+Skuld supports multiple output channels per session:
+
+- **WebSocket channel** -- primary, streams to connected browsers
+- **Telegram channel** -- optional, forwards events to a Telegram bot
+
+### Reporting
+
+On session shutdown, Skuld reports back to the Volundr API:
+
+- Token usage (input/output tokens per model)
+- Chronicle data (summary, key changes, unfinished work)
+- Activity metrics (message count, duration)
+
+This is the only point where Skuld talks to the Volundr API. During active chat, the API is not involved.
+
+---
+
+## Web UI
+
+React single-page application for session management, chat, and administration.
+
+### Stack
+
+- **Framework:** React 18+, TypeScript, Vite
+- **State:** Zustand stores
+- **Styling:** CSS Modules with design tokens (no Tailwind, no inline styles, no CSS-in-JS)
+- **Auth:** OIDC via the configured identity provider
+- **Real-time:** WebSocket for chat, SSE for session state updates
+
+### Architecture
+
+The web UI follows the same hexagonal pattern as the backend:
+
+```
+UI Components
+     |
+     v
+  Zustand Stores (state management)
+     |
+     v
+  Service Ports (abstract interfaces)
+     |
+     v
+  HTTP/WS Adapters (fetch, WebSocket)
+```
+
+Port interfaces define the contract between the UI and the backend. Adapters implement these ports using `fetch` for REST calls and native `WebSocket` for chat. This makes it possible to swap backends or run the UI against mock data for testing.
+
+### Pages
+
+| Page | Function |
+|------|----------|
+| Sessions | List, create, start, stop, archive sessions |
+| Chat | Interactive AI chat within a running session |
+| Terminal | Terminal access to the session pod (ttyd) |
+| Code | VS Code in the browser (code-server) |
+| Diffs | File change viewer for session workspaces |
+| Chronicles | Session history, reforge chains, timeline visualization |
+| Settings | User preferences, credentials, integrations |
+| Admin | Tenant management, user management, system settings |
+
+---
+
+## CLI
+
+Go binary built with Cobra that operates in two modes.
+
+### Local Mode
+
+Runs the entire Volundr stack as a single process for local development:
+
+- Embeds PostgreSQL (or connects to an existing instance)
+- Starts the Volundr API server
+- Runs a reverse proxy that routes traffic to the API and session pods
+- Manages session lifecycle locally
+
+Intended for individual developers who want Volundr without a Kubernetes cluster.
+
+### Remote Mode
+
+Connects to a deployed Volundr instance:
+
+- REST client for session CRUD, chronicles, git workflows
+- WebSocket client for interactive chat and terminal
+- Interactive TUI built with Bubble Tea (7 pages: sessions, chat, logs, chronicles, settings, help, admin)
+- Multi-context support for managing connections to multiple Volundr servers
+
+### Authentication
+
+The CLI supports two OIDC flows:
+
+- **Device flow** -- for headless environments (SSH, containers). User visits a URL and enters a code.
+- **Authorization code flow** -- opens a browser for login, receives the token via localhost callback.
+
+Tokens are cached locally and refreshed automatically.
+
+### Commands
+
+```
+volundr session create    # Create a new session
+volundr session start     # Start a stopped session
+volundr session stop      # Stop a running session
+volundr session list      # List sessions
+volundr chat              # Interactive chat with a session
+volundr chronicle list    # List chronicles
+volundr context           # Manage server contexts
+volundr local start       # Start the local stack
+volundr tui               # Launch the interactive TUI
+```

--- a/docs/site/architecture/hexagonal.md
+++ b/docs/site/architecture/hexagonal.md
@@ -1,120 +1,263 @@
-# Hexagonal Design
+# Hexagonal Architecture
 
-All infrastructure is abstracted behind port interfaces. Business logic (domain services) never imports adapters directly.
+Volundr uses hexagonal architecture (ports and adapters) to keep business logic independent of infrastructure. The domain layer defines abstract interfaces (ports). Infrastructure code implements them (adapters). The composition root wires everything together at startup.
 
-## Directory structure
+## Directory Structure
 
 ```
 src/volundr/
 ├── domain/
-│   ├── models.py          # Domain models (Session, Chronicle, Tenant, etc.)
-│   ├── ports.py           # Port interfaces (abstract base classes)
-│   └── services/          # Business logic
-│       ├── session.py
-│       ├── chronicle.py
-│       ├── git_workflow.py
-│       ├── credential.py
-│       ├── tenant.py
-│       ├── tracker.py
-│       ├── event_ingestion.py
-│       ├── profile.py
-│       ├── template.py
-│       ├── preset.py
-│       ├── prompt.py
-│       └── ...
+│   ├── models.py              # Domain models (Session, Chronicle, User, Tenant, etc.)
+│   ├── ports.py               # All port interfaces (abstract base classes)
+│   └── services/
+│       ├── session.py          # Session lifecycle orchestration
+│       ├── chronicle.py        # Chronicle management, reforge, timeline
+│       ├── git_workflow.py     # PR creation, merge, CI status
+│       ├── tenant.py           # Tenant hierarchy, default tenant
+│       ├── token.py            # Token usage recording and cost
+│       ├── stats.py            # Aggregate dashboard statistics
+│       ├── repo.py             # Repository listing across providers
+│       ├── credential.py       # Credential store operations
+│       ├── preset.py           # User-created runtime config presets
+│       ├── prompt.py           # Saved prompts
+│       ├── tracker.py          # Issue tracker operations
+│       ├── tracker_factory.py  # Per-user issue tracker instantiation
+│       ├── event_ingestion.py  # Multi-sink event dispatch
+│       ├── integration_registry.py  # Integration type catalog
+│       ├── user_integration.py # Per-user provider factory
+│       ├── mcp_injection.py    # MCP server configuration injection
+│       ├── mount_strategies.py # Secret mount type strategies
+│       ├── secret_mount.py     # Secret mount spec resolution
+│       ├── profile.py          # Profile listing with session counts
+│       ├── template.py         # Workspace template operations
+│       └── workspace.py        # Workspace PVC management
 ├── adapters/
-│   ├── inbound/           # REST endpoints (FastAPI routers)
-│   │   ├── rest.py        # Sessions, chronicles, models, stats
-│   │   ├── rest_git.py    # Git workflows
-│   │   ├── rest_profiles.py
-│   │   ├── rest_presets.py
-│   │   ├── rest_prompts.py
-│   │   ├── rest_tenants.py
-│   │   ├── rest_credentials.py
-│   │   ├── rest_secrets.py
-│   │   ├── rest_events.py
-│   │   ├── rest_tracker.py
-│   │   ├── rest_integrations.py
-│   │   └── auth.py        # Auth middleware
-│   └── outbound/          # Infrastructure adapters
-│       ├── postgres*.py   # PostgreSQL repositories
-│       ├── pod_manager.py # Pod orchestration
-│       ├── github.py      # GitHub API
-│       ├── gitlab.py      # GitLab API
-│       ├── identity.py    # OIDC identity
-│       ├── cerbos.py      # Cerbos authorization
-│       ├── linear.py      # Linear issue tracker
-│       ├── jira.py        # Jira issue tracker
-│       └── ...
-├── infrastructure/
-│   └── database.py        # Connection pool management
-├── skuld/                 # WebSocket broker (separate process)
-├── config.py              # Pydantic settings
-└── main.py                # Composition root
+│   ├── inbound/               # REST API routes (FastAPI routers)
+│   │   ├── rest.py            # Sessions, chronicles, timeline, stats, SSE
+│   │   ├── rest_git.py        # Git workflow endpoints
+│   │   ├── rest_profiles.py   # Profiles and templates
+│   │   ├── rest_presets.py    # Presets
+│   │   ├── rest_prompts.py    # Saved prompts
+│   │   ├── rest_tenants.py    # Tenants and users
+│   │   ├── rest_credentials.py # Credential management
+│   │   ├── rest_secrets.py    # MCP servers, K8s secrets
+│   │   ├── rest_events.py     # Event pipeline
+│   │   ├── rest_integrations.py # Integration connections
+│   │   ├── rest_tracker.py    # Issue tracker
+│   │   ├── rest_resources.py  # Cluster resources
+│   │   ├── rest_admin_settings.py # Admin settings
+│   │   └── auth.py            # Auth dependency injection
+│   └── outbound/              # Infrastructure adapters
+│       ├── contributors/      # Session contributor pipeline
+│       │   ├── core.py        # Session identity, ingress, terminal
+│       │   ├── template.py    # Workspace template resolution
+│       │   ├── git.py         # Git clone URL and credentials
+│       │   ├── integrations.py # MCP servers and env from integrations
+│       │   ├── storage.py     # PVC provisioning
+│       │   ├── gateway.py     # Gateway API HTTPRoute config
+│       │   ├── resource.py    # CPU/memory/GPU translation
+│       │   ├── isolation.py   # Namespace, security context
+│       │   ├── secrets.py     # K8s secret env refs
+│       │   └── local_mount.py # Host path mounts (local dev)
+│       ├── postgres.py        # PostgresSessionRepository
+│       ├── postgres_chronicles.py
+│       ├── postgres_timeline.py
+│       ├── postgres_tokens.py
+│       ├── postgres_stats.py
+│       ├── postgres_presets.py
+│       ├── postgres_prompts.py
+│       ├── postgres_tenants.py
+│       ├── postgres_users.py
+│       ├── pg_event_sink.py   # PostgreSQL event sink
+│       ├── rabbitmq_event_sink.py
+│       ├── otel_event_sink.py
+│       ├── broadcaster.py     # In-memory SSE broadcaster
+│       ├── github.py          # GitHub GitProvider + GitWorkflowProvider
+│       ├── gitlab.py          # GitLab GitProvider + GitWorkflowProvider
+│       ├── git_registry.py    # Multi-provider git registry
+│       ├── farm.py            # Farm-based PodManager (Helm tasks)
+│       ├── flux.py            # Flux-based PodManager (HelmRelease)
+│       ├── direct_k8s_pod_manager.py  # Direct K8s PodManager
+│       ├── docker_pod_manager.py      # Docker PodManager (local dev)
+│       ├── k8s_storage.py     # K8s PVC StoragePort
+│       ├── identity.py        # OIDC IdentityPort adapters
+│       ├── authorization.py   # AuthorizationPort (Cerbos, allow-all)
+│       ├── vault_credential_store.py
+│       ├── infisical_credential_store.py
+│       ├── file_credential_store.py
+│       ├── memory_credential_store.py
+│       ├── infisical_secret_injection.py
+│       ├── memory_secret_injection.py
+│       ├── static_resource_provider.py
+│       ├── config_profiles.py  # YAML-driven ProfileProvider
+│       ├── config_templates.py # YAML-driven TemplateProvider
+│       ├── config_mcp_servers.py
+│       ├── pricing.py         # Hardcoded model pricing
+│       ├── memory_secrets.py
+│       ├── memory_secret_repo.py
+│       ├── memory_integrations.py
+│       ├── jira.py            # Jira IssueTrackerProvider
+│       └── linear.py          # Linear IssueTrackerProvider
+├── skuld/                     # Skuld broker (separate FastAPI app)
+│   ├── broker.py              # WebSocket broker, REST endpoints
+│   ├── transport.py           # CLI transport abstractions
+│   ├── channels.py            # Output channel registry
+│   ├── service_manager.py     # Multi-session management
+│   └── config.py              # Skuld-specific settings
+├── config.py                  # Configuration classes (Settings, all sub-configs)
+├── main.py                    # Composition root (wires everything)
+├── utils.py                   # import_class() and shared utilities
+└── infrastructure/
+    └── database.py            # asyncpg pool management, schema creation
 ```
 
-## Layer rules
+## Layer Rules
 
-| Layer | Can import from | Cannot import from |
-|-------|----------------|-------------------|
-| Domain services | `domain.ports`, `domain.models` | `adapters`, `infrastructure` |
-| Adapters | `domain.ports`, `domain.models` | Other adapters |
-| `main.py` | Everything | — |
+Three rules, no exceptions:
 
-## Ports
+1. **Domain imports nothing from adapters.** `domain/models.py`, `domain/ports.py`, and all files under `domain/services/` never import from `adapters/`. The domain layer defines the interfaces; it does not know what implements them.
 
-Ports are abstract base classes in `domain/ports.py`. Each defines the contract that adapters must implement:
+2. **Adapters implement ports and import domain models.** An adapter like `postgres.py` imports `SessionRepository` (the port it implements) and `Session` (the domain model it persists). It never imports from other adapters.
 
-| Port | Purpose |
-|------|---------|
-| `SessionRepository` | Session persistence (CRUD) |
-| `ChronicleRepository` | Chronicle persistence |
-| `TimelineRepository` | Timeline event persistence |
-| `PodManager` | Start/stop session pods |
-| `StatsRepository` | Aggregate statistics |
-| `TokenTracker` | Token usage recording |
-| `PricingProvider` | Model pricing data |
-| `GitProvider` | Git repository operations |
-| `GitWorkflowProvider` | PR/branch/CI operations |
-| `EventBroadcaster` | SSE event publishing |
-| `EventSink` | Event pipeline sinks |
-| `SessionEventRepository` | Event query (read side) |
-| `ProfileProvider` | Config-driven profiles |
-| `TemplateProvider` | Config-driven templates |
-| `PresetRepository` | Preset persistence |
-| `SavedPromptRepository` | Prompt persistence |
-| `MCPServerProvider` | MCP server configs |
-| `SecretManager` | K8s secret management |
-| `IdentityPort` | JWT validation, user provisioning |
-| `AuthorizationPort` | Policy decisions |
-| `CredentialStorePort` | Credential storage |
-| `SecretInjectionPort` | CSI secret mounting |
-| `StoragePort` | PVC management |
-| `GatewayPort` | Gateway API routing |
-| `IssueTrackerProvider` | External issue trackers |
-| `IntegrationRepository` | Integration connections |
-| `TenantRepository` | Tenant hierarchy |
-| `UserRepository` | User persistence |
-| `WorkspaceRepository` | Workspace persistence |
-| `SessionContributor` | Session spec contributors |
+3. **`main.py` is the composition root.** It imports from everywhere -- domain services, ports, and adapters -- and wires them together. This is the only place where concrete adapter classes are referenced by the application startup code.
 
-## Dynamic adapter pattern
+## All Ports
 
-New adapters use dynamic import. Config specifies a fully-qualified class path — remaining keys are passed as kwargs:
+Every port is an abstract base class defined in `domain/ports.py`. Here is the complete list:
+
+| Port | Methods | Purpose |
+|------|---------|---------|
+| `SessionRepository` | create, get, list, update, delete | Session persistence |
+| `ChronicleRepository` | create, get, get_by_session, list, update, delete, get_chain | Chronicle persistence and reforge chain traversal |
+| `TimelineRepository` | add_event, get_events, get_events_by_session, delete_by_chronicle | Timeline event storage |
+| `PodManager` | start, stop, status, wait_for_ready | Session pod lifecycle |
+| `StatsRepository` | get_stats | Aggregate dashboard statistics |
+| `TokenTracker` | record_usage, get_session_usage | Token usage recording |
+| `PricingProvider` | get_price, list_models | Model pricing and metadata |
+| `GitProvider` | provider_type, name, orgs, supports, validate_repo, parse_repo, get_clone_url, list_repos, list_branches | Git repository operations for a single provider endpoint |
+| `GitWorkflowProvider` | create_branch, create_pull_request, get_pull_request, list_pull_requests, merge_pull_request, get_ci_status | PR and CI workflow operations |
+| `EventBroadcaster` | publish, subscribe | SSE event fan-out |
+| `EventSink` | emit, emit_batch, flush, close, sink_name, healthy | Event pipeline sink |
+| `SessionEventRepository` | get_events, get_event_counts, get_token_timeline, delete_by_session | Event query port |
+| `ProfileProvider` | get, list, get_default | Read-only forge profiles |
+| `MutableProfileProvider` | (extends ProfileProvider) create, update, delete | Writable profiles |
+| `TemplateProvider` | get, list | Read-only workspace templates |
+| `SavedPromptRepository` | create, get, list, update, delete, search | Saved prompts |
+| `PresetRepository` | create, get, get_by_name, list, update, delete, clear_default | Runtime presets |
+| `MCPServerProvider` | list, get | MCP server configs |
+| `SecretManager` | list, get, create | K8s secret management |
+| `IssueTrackerProvider` | provider_name, check_connection, search_issues, get_recent_issues, get_issue, update_issue_status | External issue tracker |
+| `IntegrationRepository` | list_connections, get_connection, save_connection, delete_connection | Integration connection storage |
+| `ProjectMappingRepository` | create, list, get_by_repo, delete | Repo-to-tracker project mappings |
+| `TenantRepository` | create, get, get_by_path, list, get_ancestors, update, delete | Tenant hierarchy |
+| `UserRepository` | create, get, get_by_email, list, update, delete, add_membership, get_memberships, get_members, remove_membership | Users and tenant membership |
+| `IdentityPort` | validate_token, get_or_provision_user | JWT validation and JIT provisioning |
+| `AuthorizationPort` | is_allowed, filter_allowed | Action-level authorization |
+| `SecretRepository` | store_credential, get_credential, delete_credential, list_credentials, provision_user, deprovision_user, create_session_secrets, delete_session_secrets | Vault/OpenBao operations |
+| `StoragePort` | provision_user_storage, create_session_workspace, archive_session_workspace, delete_workspace, get_user_storage_usage, deprovision_user_storage, list_workspaces, list_all_workspaces, get_workspace_by_session | PVC lifecycle |
+| `GatewayPort` | get_gateway_config | Gateway API routing config |
+| `CredentialStorePort` | store, get, get_value, delete, list, health_check | Pluggable credential storage |
+| `SecretMountStrategy` | secret_type, default_mount_spec, validate | Per-type secret mount logic |
+| `SecretInjectionPort` | pod_spec_additions, provision_user, deprovision_user | CSI driver pod spec generation |
+| `ResourceProvider` | discover, translate, validate | Cluster resource discovery and translation |
+| `SessionContributor` | name, contribute, cleanup | Contributor pipeline element |
+
+## Dynamic Adapter Loading
+
+Adapters are loaded at runtime from fully-qualified class paths specified in YAML config. This is the `import_class()` mechanism:
+
+```python
+# src/volundr/utils.py
+def import_class(dotted_path: str) -> type:
+    module_path, class_name = dotted_path.rsplit(".", 1)
+    module = importlib.import_module(module_path)
+    return getattr(module, class_name)
+```
+
+Configuration specifies the adapter class and any kwargs:
+
+```yaml
+pod_manager:
+  adapter: "volundr.adapters.outbound.farm.FarmPodManager"
+  kwargs:
+    farm_url: "http://farm.volundr.svc:8080"
+    namespace: "volundr-sessions"
+
+identity:
+  adapter: "volundr.adapters.outbound.identity.OIDCIdentityAdapter"
+  kwargs:
+    issuer_url: "https://keycloak.example.com/realms/volundr"
+    audience: "volundr-api"
+  secret_kwargs_env:
+    client_secret: "OIDC_CLIENT_SECRET"
+```
+
+The composition root (`main.py`) uses this pattern for every infrastructure adapter:
+
+```python
+def _create_pod_manager(settings: Settings) -> PodManager:
+    pm_cfg = settings.pod_manager
+    cls = import_class(pm_cfg.adapter)
+    kwargs = _resolve_secret_kwargs(pm_cfg.kwargs, pm_cfg.secret_kwargs_env)
+    instance = cls(**kwargs)
+    return instance
+```
+
+`secret_kwargs_env` maps kwarg names to environment variable names. This lets sensitive values (API keys, client secrets) come from the environment rather than config files.
+
+### Contributor Wiring
+
+Contributors are slightly different. They receive both config kwargs and injected port instances, because they need to call other ports (storage, git, gateway, etc.):
+
+```python
+def _create_contributors(settings: Settings, **ports: object) -> list[SessionContributor]:
+    contributors = []
+    for cfg in settings.session_contributors:
+        cls = import_class(cfg.adapter)
+        resolved_kwargs = _resolve_secret_kwargs(cfg.kwargs, cfg.secret_kwargs_env)
+        # Merge config kwargs with injected ports
+        kwargs = {**resolved_kwargs, **ports}
+        instance = cls(**kwargs)
+        contributors.append(instance)
+    return contributors
+```
+
+Each contributor constructor accepts the ports it needs by name and ignores the rest via `**_extra`:
+
+```python
+class StorageContributor(SessionContributor):
+    def __init__(
+        self,
+        *,
+        storage: StoragePort,
+        admin_settings: dict,
+        **_extra: object,  # Ignore ports this contributor doesn't need
+    ):
+        self._storage = storage
+        self._admin_settings = admin_settings
+```
+
+This means adding a new contributor is:
+
+1. Write the class, accepting its ports by name.
+2. Add the class path to the `session_contributors` list in YAML config.
+3. If the contributor needs a new port, pass it in `_create_contributors()`.
+
+No match/case chains. No if/else adapter selection. The config declares what to load; `import_class()` loads it.
+
+### Adding a New Adapter
+
+To swap out an infrastructure backend (say, replacing Vault with a new secret store):
+
+1. Write a new class that implements the port (`CredentialStorePort`).
+2. Put it anywhere in the `adapters/outbound/` directory.
+3. Update the YAML config to point to the new class:
 
 ```yaml
 credential_store:
-  adapter: "volundr.adapters.outbound.vault_credential_store.VaultCredentialStore"
+  adapter: "volundr.adapters.outbound.my_new_store.MyNewCredentialStore"
   kwargs:
-    url: "http://vault:8200"
-    auth_method: "kubernetes"
+    endpoint: "https://newsecrets.example.com"
 ```
 
-The composition root (`main.py`) imports the class and instantiates it:
-
-```python
-cls = _import_class(config.adapter)
-instance = cls(**config.kwargs)
-```
-
-Adding a new adapter = write the class + update YAML. No code changes in the container.
+No code changes to `main.py`, no changes to the domain layer, no changes to any other adapter.

--- a/docs/site/architecture/overview.md
+++ b/docs/site/architecture/overview.md
@@ -1,58 +1,171 @@
 # Architecture Overview
 
-Volundr follows hexagonal architecture. Business logic lives in the domain layer and communicates with infrastructure through port interfaces. Adapters implement those interfaces.
+Volundr is a self-hosted remote development platform that provisions ephemeral coding sessions on Kubernetes. Each session runs AI-assisted development tools (Claude Code, Codex) inside isolated pods with their own workspace, terminal, and IDE.
 
-## System architecture
+## System Diagram
 
 ```
-                    ┌──────────────────────┐
-                    │    Hlidskjalf UI     │
-                    │   (React / Vite)     │
-                    └─────────┬────────────┘
-                              │ REST + SSE
-                              ▼
-                    ┌──────────────────────┐
-                    │    Volundr API       │
-                    │    (FastAPI)         │
-                    │                      │
-                    │  Sessions, Profiles, │
-                    │  Chronicles, Git,    │
-                    │  Tenants, Events     │
-                    └──┬─────┬─────┬──────┘
-                       │     │     │
-            ┌──────────┘     │     └──────────┐
-            ▼                ▼                ▼
-     ┌────────────┐  ┌────────────┐   ┌────────────┐
-     │ PostgreSQL │  │ Kubernetes │   │ Git APIs   │
-     │            │  │  (pods)    │   │ (GH/GL)    │
-     └────────────┘  └─────┬──────┘   └────────────┘
-                           │
-              ┌────────────┼────────────┐
-              ▼            ▼            ▼
-        ┌──────────┐ ┌──────────┐ ┌──────────┐
-        │  Skuld   │ │  Code    │ │ Terminal │
-        │ (broker) │ │  Server  │ │  (ttyd)  │
-        └──────────┘ └──────────┘ └──────────┘
-              │
-              │ WebSocket
-              ▼
-        AI Coding Agent
+                         Users
+                    +-----------+
+                    | Web UI    |  React/Vite, OIDC auth
+                    | (browser) |
+                    +-----+-----+
+                          |
+              +-----------+-----------+
+              |                       |
+         REST/SSE                 WebSocket
+         (sessions,               (chat)
+          chronicles,                |
+          git, etc.)                 |
+              |                      |
+    +---------v----------+           |
+    |   Volundr API      |           |
+    |   (FastAPI)        |           |
+    |                    |           |
+    |  +-- Ports ---+    |           |
+    |  | Session    |    |           |
+    |  | Chronicle  |    |           |
+    |  | PodManager |    |           |
+    |  | Storage    |    |           |
+    |  | Gateway    |    |           |
+    |  | Identity   |    |           |
+    |  | AuthZ      |    |           |
+    |  | Git        |    |           |
+    |  | Events     |    |           |
+    |  | Secrets    |    |           |
+    |  | Resources  |    |           |
+    |  +------------+    |           |
+    +---+---+---+---+----+           |
+        |   |   |   |               |
+        |   |   |   +--- Event Pipeline ---> PostgreSQL (always)
+        |   |   |                    |       RabbitMQ  (optional)
+        |   |   |                    |       OTel      (optional)
+        |   |   |                    |
+        |   |   +--- Git APIs -----> GitHub / GitLab
+        |   |                        |
+        |   +--- IDP --------------> Keycloak / Entra ID / Okta
+        |                            |
+        +--- Kubernetes API          |
+             |                       |
+    +--------v-----------------------v--------+
+    |          Session Pod                     |
+    |  +-------------+ +----------+ +-------+ |
+    |  | Skuld broker | | code-    | | ttyd  | |
+    |  | (WebSocket   | | server   | | term  | |
+    |  |  <-> CLI)    | | (VS Code)| |       | |
+    |  +------+-------+ +----------+ +-------+ |
+    |         |                                 |
+    |    Claude Code CLI / Codex CLI            |
+    |         |                                 |
+    |  +------v------+     +-----------+        |
+    |  | Workspace   |     | Home PVC  |        |
+    |  | PVC         |     | (per-user)|        |
+    |  | (per-session)|     +-----------+        |
+    +-----------+-------------------------------+
+                |
+       +--------v--------+
+       | Vault / Infisical|  (CSI secret injection)
+       +------------------+
+
+    +-------------+
+    | CLI (Go)    |  Local mode: embedded stack
+    | local/remote|  Remote mode: REST + WebSocket to API
+    +-------------+
 ```
 
-## Data flow
+### Key data path: Chat bypasses the API
 
-1. User creates a session through the UI or API
-2. Volundr validates the request, provisions a workspace PVC, and calls the pod manager
-3. The pod manager launches a pod group: Skuld broker + Code Server + terminal
-4. All pods share a workspace PVC at the session path
-5. The UI connects to Skuld via WebSocket for chat — Volundr is not in the chat data path
-6. Session events (messages, file changes, git operations) flow through the event pipeline to configured sinks
-7. When the session stops, a chronicle is auto-created with a timeline of events
+Chat messages flow directly from the browser to the Skuld broker inside the session pod via WebSocket. The Volundr API is not in this path. This keeps latency low and avoids the API becoming a bottleneck during interactive coding.
 
-## Key design decisions
+```
+Browser  --WebSocket-->  Skuld broker  --SDK WS-->  Claude Code CLI
+                              |
+                    (reports usage/chronicle
+                     back to API on shutdown)
+```
 
-- **Raw SQL via asyncpg** — no ORM. Queries are explicit and parameterized.
-- **Dynamic adapter loading** — adapters are specified as fully-qualified class paths in YAML config. Adding a new adapter means writing a class and updating config — no code changes in the container.
-- **Ports over mocks** — business logic depends only on abstract port interfaces, making it testable without infrastructure.
-- **CSI-based secrets** — Volundr never sees secret values. It generates pod spec additions that tell the CSI driver what to mount.
-- **Config-driven profiles/templates** — loaded from YAML or CRDs, not stored in the database. Presets (DB-stored) handle user-customizable runtime config.
+## Data Flows
+
+### 1. Session Creation (Contributor Pipeline)
+
+Session creation is a two-phase process: record creation followed by pod provisioning.
+
+1. API receives `POST /sessions` with name, model, source config, optional template/preset.
+2. Template and profile defaults are resolved (if specified).
+3. Repository is validated against the git registry (if git source with validation enabled).
+4. Session record is persisted with status `CREATED`.
+5. `start_session()` transitions to `STARTING` and runs the **contributor pipeline**:
+   - Build a `SessionContext` from the request metadata (principal, template name, credentials, integrations).
+   - Run 10+ contributors sequentially. Each returns a `SessionContribution` (Helm values + pod spec additions).
+   - Deep-merge all contributions into a single `SessionSpec`.
+6. `PodManager.start()` submits the merged spec to the backend (Farm, Flux, or direct K8s).
+7. Session transitions to `PROVISIONING`. A background task polls readiness.
+8. When all containers report ready, session transitions to `RUNNING`.
+
+The contributors, in order:
+
+| # | Contributor | Responsibility |
+|---|-------------|---------------|
+| 1 | Core | Session identity, ingress host, terminal restriction |
+| 2 | Template | Workspace template defaults (repos, setup scripts) |
+| 3 | Git | Clone URL, branch, git credentials |
+| 4 | Integration | MCP servers, env vars from enabled integrations |
+| 5 | Storage | Workspace PVC + home PVC provisioning |
+| 6 | Gateway | Gateway API HTTPRoute config for session routing |
+| 7 | Resource | CPU/memory/GPU requests, node selectors, tolerations |
+| 8 | Isolation | Namespace, security context, network policy |
+| 9 | SecretInjection | CSI driver volumes/mounts for secret injection |
+| 10 | Secrets | K8s secret env refs |
+
+### 2. Chat (WebSocket through Skuld)
+
+1. Browser opens WebSocket to Skuld broker (`wss://<session>.volundr.example.com/ws/chat`).
+2. User message arrives as JSON over WebSocket.
+3. Skuld forwards the message to the CLI transport:
+   - **SDK transport** (Claude Code): sends NDJSON message over a second WebSocket to the CLI process, which connected back via `--sdk-url`.
+   - **Subprocess transport** (legacy): spawns `claude -p <message>` as a subprocess.
+   - **Codex transport**: spawns `codex --full-auto <message>`, normalizes output to the common event format.
+4. CLI streams response events (content deltas, tool use, result) back through the transport.
+5. Skuld forwards events to the browser over the original WebSocket.
+6. On `result` event, Skuld extracts token usage and reports it back to the Volundr API via HTTP.
+
+The API is never in the chat hot path.
+
+### 3. Chronicle Creation
+
+Chronicles capture what happened during a session for continuity across reforges.
+
+1. Session stops (user-initiated or timeout).
+2. Skuld broker sends a final report to the Volundr API: summary, key changes, unfinished work, duration.
+3. Volundr creates (or enriches an existing draft) chronicle with session metadata plus broker data.
+4. Timeline events collected throughout the session lifetime are aggregated into file summaries, commit summaries, and token burn charts.
+5. Chronicle status moves from `DRAFT` to `COMPLETE`.
+
+### 4. Authentication Flow
+
+Volundr is IDP-agnostic. Authentication is delegated to a standard OIDC provider.
+
+1. User authenticates with the IDP (Keycloak, Entra ID, Okta, etc.) via the web UI's OIDC flow or the CLI's device/authorization code flow.
+2. JWT access token is sent with every API request in the `Authorization` header.
+3. The `IdentityPort` adapter validates the JWT (signature, expiry, issuer, audience).
+4. On first login, JIT provisioning creates the user record, home PVC, and secret backend resources.
+5. A `Principal` (user_id, email, tenant_id, roles) is extracted from the validated token.
+6. The `AuthorizationPort` adapter (Cerbos, OPA, or allow-all for dev) checks whether the principal can perform the requested action on the target resource.
+
+In production, Envoy sits in front of session pods and validates JWTs before traffic reaches Skuld.
+
+## Key Design Decisions
+
+**Raw SQL via asyncpg.** No ORM. Queries are parameterized, migrations are idempotent SQL files run by `migrate` (Kubernetes-native). This keeps the data layer explicit and avoids the abstraction overhead of an ORM.
+
+**Dynamic adapter loading.** Infrastructure adapters are specified as fully-qualified Python class paths in YAML config. The composition root (`main.py`) imports each class dynamically and passes remaining config keys as kwargs. Adding a new adapter means writing the class and updating YAML -- zero code changes elsewhere.
+
+**Ports over mocks.** Business logic depends only on abstract port interfaces (ABCs). Tests can use stub implementations without mocking framework magic. The domain layer has zero imports from the adapters package.
+
+**CSI-based secrets.** Volundr never reads or stores secret values. It generates pod spec additions (volumes, mounts, annotations) that tell the CSI driver (Vault Agent, Infisical) how to inject secrets at pod startup. The `SecretInjectionPort` returns `PodSpecAdditions`, not secret data.
+
+**Config-driven profiles/templates vs. user-owned presets.** Profiles and workspace templates are read-only, loaded from YAML config or Kubernetes CRDs -- managed by platform operators. Presets are DB-stored, user-created runtime configurations (model, MCP servers, resources). This separation keeps operator guardrails distinct from user preferences.
+
+**Direct WebSocket for chat.** Chat traffic goes straight from the browser to the Skuld broker inside the session pod. The Volundr API is not in this path. This eliminates a proxy hop, reduces latency, and means the API can restart without interrupting active chat sessions.
+
+**Session contributor pipeline.** Pod spec assembly is decomposed into independent contributors that run sequentially. Each contributor wraps a single port and produces values and pod spec additions. The contributions are deep-merged into a single `SessionSpec`. This makes pod composition extensible without touching the session service.

--- a/docs/site/architecture/session-lifecycle.md
+++ b/docs/site/architecture/session-lifecycle.md
@@ -1,0 +1,266 @@
+# Session Lifecycle
+
+## State Machine
+
+```
+CREATED --> STARTING --> PROVISIONING --> RUNNING --> STOPPING --> STOPPED --> ARCHIVED
+                                            |                       |
+                                          FAILED <------------------+
+                                            |
+                                          ARCHIVED
+
+Restarts:
+  STOPPED --> STARTING    (restart)
+  FAILED  --> STARTING    (restart)
+
+Restore:
+  ARCHIVED --> STOPPED    (restore, then can restart)
+```
+
+### Transition Rules
+
+| From | To | Trigger |
+|------|----|---------|
+| `CREATED` | `STARTING` | `start_session()` |
+| `STOPPED` | `STARTING` | `start_session()` (restart) |
+| `FAILED` | `STARTING` | `start_session()` (restart) |
+| `STARTING` | `PROVISIONING` | Pod manager returns `PodStartResult` |
+| `STARTING` | `FAILED` | Contributor pipeline or pod manager raises |
+| `PROVISIONING` | `RUNNING` | Background readiness poll succeeds |
+| `PROVISIONING` | `FAILED` | Readiness timeout or backend error |
+| `RUNNING` | `STOPPING` | `stop_session()` |
+| `PROVISIONING` | `STOPPING` | `stop_session()` (cancel provisioning) |
+| `STOPPING` | `STOPPED` | Pod manager confirms stop, contributors cleaned up |
+| `STOPPING` | `FAILED` | Pod stop or cleanup raises |
+| `STOPPED` | `ARCHIVED` | `archive_session()` |
+| `FAILED` | `ARCHIVED` | `archive_session()` |
+| `CREATED` | `ARCHIVED` | `archive_session()` |
+| `ARCHIVED` | `STOPPED` | `restore_session()` |
+
+The `can_start()` method gates startability: only `CREATED`, `STOPPED`, and `FAILED` sessions can start. The `can_stop()` method gates stoppability: only `RUNNING` and `PROVISIONING` sessions can stop.
+
+## Creation Flow
+
+1. **API receives `SessionCreate` request.** Required: name. Optional: model, source (git or local_mount), template_name, preset_id.
+
+2. **Resolve template defaults.** If `template_name` is set and a `TemplateProvider` is configured, the template's first repo and model fill in any unset fields. Templates are config-driven (YAML/CRD), not DB-stored.
+
+3. **Validate repository.** If the source is git with a non-empty repo URL, and repo validation is enabled, the git registry finds the matching `GitProvider` and calls `validate_repo()`. Raises `RepoValidationError` if the repo doesn't exist or isn't accessible.
+
+4. **Create session record.** A `Session` object is created with status `CREATED`, a generated UUID, and the resolved source/model. If a `Principal` is present, `owner_id` and `tenant_id` are set from the JWT claims.
+
+5. **Persist and broadcast.** The session is persisted via `SessionRepository.create()`. An SSE event is published to connected clients.
+
+At this point the session exists but has no running infrastructure. The caller (API route) immediately calls `start_session()`.
+
+## Start Flow (Contributor Pipeline)
+
+The start flow is the core orchestration logic. It takes a persisted session and turns it into a running pod group.
+
+### Step 1: State Transition
+
+Session transitions from its current status to `STARTING`. This is persisted and broadcast.
+
+### Step 2: Build SessionContext
+
+A read-only `SessionContext` is assembled from the start request:
+
+```python
+SessionContext(
+    principal=principal,           # Authenticated identity (from JWT)
+    template_name=template_name,   # Optional workspace template
+    profile_name=profile_name,     # Optional forge profile (deprecated)
+    terminal_restricted=...,       # Whether terminal is restricted
+    credential_names=(...),        # Credentials to mount
+    integration_ids=(...),         # Integration connections to enable
+    integration_connections=(...), # Pre-fetched connection objects
+    resource_config={...},         # CPU/memory/GPU config
+)
+```
+
+If no integration IDs are specified, all enabled integrations for the user are auto-included.
+
+### Step 3: Run Contributors
+
+Contributors run sequentially. Each receives the `Session` and `SessionContext` and returns a `SessionContribution`:
+
+```python
+@dataclass(frozen=True)
+class SessionContribution:
+    values: dict[str, Any]          # Helm chart values
+    pod_spec: PodSpecAdditions | None  # Pod spec fragments
+```
+
+The contributor order matters. Later contributors can depend on values set by earlier ones. The configured order:
+
+1. **CoreSessionContributor** -- Session identity (ID, name, model), ingress host, terminal restriction flag. No port dependency.
+
+2. **TemplateContributor** -- Resolves the workspace template. Adds repos, setup scripts, workspace layout, model, system prompt, MCP servers, env vars, and workload config from the template.
+
+3. **GitContributor** -- Resolves the git clone URL using the `GitProvider` registry. Adds authenticated clone URL, branch, and git credentials to the spec.
+
+4. **IntegrationContributor** -- Iterates enabled integration connections. For MCP-type integrations, adds MCP server configs with credential-mapped environment variables. For non-MCP integrations, adds env vars directly.
+
+5. **StorageContributor** -- Provisions the workspace PVC (per-session) and home PVC (per-user) via `StoragePort`. Adds volume and mount specs. Respects admin setting for home directory enablement.
+
+6. **GatewayContributor** -- Fetches gateway config from `GatewayPort`. Adds gateway name, namespace, and JWT/auth config for Skuld's HTTPRoute template.
+
+7. **ResourceContributor** -- Translates user-friendly resource config (e.g., `{"cpu": "4", "memory": "8Gi", "gpu": "1"}`) to K8s-native primitives via `ResourceProvider`. Adds requests, limits, node selectors, tolerations, and runtime class.
+
+8. **IsolationContributor** -- Adds namespace, security context, and network policy for tenant isolation.
+
+9. **SecretInjectionContributor** -- Calls `SecretInjectionPort.pod_spec_additions()` to get CSI driver volumes, mounts, labels, and annotations. Volundr never sees secret values here.
+
+10. **SecretsContributor** -- Adds K8s secret references as environment variables from `env_secret_refs` config.
+
+Additionally, a **LocalMountContributor** is auto-wired for local development scenarios. It adds host path mounts with configurable allowed prefixes and root mount restrictions.
+
+### Step 4: Merge Contributions
+
+All `SessionContribution` objects are deep-merged into a single `SessionSpec`:
+
+- `values` dicts are recursively merged (later values override earlier ones for the same key).
+- `PodSpecAdditions` are concatenated: volumes, volume_mounts, and env are appended; labels and annotations are merged; service_account uses the last non-None value.
+
+### Step 5: Start Pods
+
+`PodManager.start(session, spec)` submits the merged spec to the backend:
+
+- **Farm** -- submits a Helm-based task to the Farm task scheduler
+- **Flux** -- creates a HelmRelease for the Skuld chart
+- **Direct K8s** -- applies pod manifests directly via the Kubernetes API
+- **Docker** -- runs containers via Docker (local development)
+
+Returns a `PodStartResult` with `chat_endpoint`, `code_endpoint`, and `pod_name`.
+
+### Step 6: Transition to PROVISIONING
+
+Session is updated with endpoints, pod name, and status `PROVISIONING`. This is persisted and broadcast.
+
+### Step 7: Background Readiness Poll
+
+An `asyncio.Task` polls for readiness:
+
+1. Initial delay (default 5 seconds, configurable via `provisioning.initial_delay_seconds`).
+2. Calls `PodManager.wait_for_ready(session, timeout)` which blocks until the backend reports ready or the timeout expires (default 300 seconds, configurable via `provisioning.timeout_seconds`).
+3. Re-fetches the session to verify it's still in `PROVISIONING` (could have been stopped/deleted concurrently).
+4. On success: transitions to `RUNNING`.
+5. On timeout or error: transitions to `FAILED` with error detail.
+
+On application restart, `reconcile_provisioning_sessions()` re-launches polling for any sessions stuck in `PROVISIONING`.
+
+## Pod Deployment
+
+A running session pod group contains:
+
+| Container | Image | Purpose |
+|-----------|-------|---------|
+| Skuld broker | `volundr/skuld` | WebSocket bridge between browser and AI CLI |
+| code-server | `linuxserver/code-server` | VS Code in the browser |
+| ttyd terminal | `tsl0922/ttyd` | Web terminal |
+| Envoy sidecar (optional) | `envoyproxy/envoy` | JWT validation for incoming traffic |
+
+All containers share:
+
+- **Workspace PVC** mounted at `/volundr/sessions/<session_id>/workspace` -- per-session, created by `StorageContributor`
+- **Home PVC** mounted at `/volundr/home/<user_id>` -- per-user, persistent across sessions
+
+The Skuld container runs the Claude Code CLI (or Codex CLI) as a child process.
+
+## Stop Flow
+
+1. **Transition to `STOPPING`.** Persisted and broadcast.
+2. **Cancel provisioning task.** If a readiness poll is running, it's cancelled.
+3. **Stop pods.** `PodManager.stop()` tells the backend to tear down the pod group. Logged but non-blocking if the pods are already gone.
+4. **Run contributor cleanup in reverse order.** Each contributor's `cleanup()` method is called. Failures are logged but don't block other contributors. `StorageContributor.cleanup()` archives the workspace PVC (soft delete, PVC is relabeled not destroyed).
+5. **Transition to `STOPPED`.** Endpoints are cleared. Persisted and broadcast.
+6. **Auto-create chronicle** (triggered by Skuld's shutdown report or by the API on session stop).
+
+## Chronicle Creation
+
+Chronicles provide session continuity for reforge workflows.
+
+### From Broker Report
+
+When Skuld shuts down, it sends a POST to the Volundr API with:
+
+```json
+{
+  "session_id": "...",
+  "summary": "Implemented the user authentication flow...",
+  "key_changes": ["Added JWT validation middleware", "Created login page"],
+  "unfinished_work": "Error handling for expired tokens",
+  "duration_seconds": 3600
+}
+```
+
+`ChronicleService.create_or_update_from_broker()` is idempotent:
+
+- If a `DRAFT` chronicle already exists for this session, it's enriched with the broker data.
+- Otherwise, a new chronicle is created from the session's current state (project, repo, branch, model, config snapshot, token usage) and enriched with the broker data.
+
+### Chronicle Data
+
+```python
+Chronicle(
+    session_id=...,
+    project="volundr",          # Derived from repo URL
+    repo="github.com/org/repo",
+    branch="feature/auth",
+    model="claude-sonnet-4-20250514",
+    config_snapshot={...},      # Session config at creation time
+    summary="...",              # From Skuld broker report
+    key_changes=[...],          # From Skuld broker report
+    unfinished_work="...",      # From Skuld broker report
+    token_usage=45000,
+    cost=Decimal("0.45"),
+    duration_seconds=3600,
+    parent_chronicle_id=...,    # Set during reforge
+)
+```
+
+### Timeline
+
+Timeline events are collected throughout the session lifetime and stored via `TimelineRepository`:
+
+- **Session events** -- start, stop
+- **Message events** -- user/assistant messages with token counts
+- **File events** -- created, modified, deleted with insertions/deletions
+- **Git events** -- commits with hashes
+- **Terminal events** -- commands with exit codes
+- **Error events**
+
+The timeline is aggregated into:
+
+- `FileSummary` -- deduplicated file changes (new/modified/deleted, total insertions/deletions)
+- `CommitSummary` -- commit hash, message, wall clock time
+- `token_burn` -- token usage bucketed into 5-minute intervals
+
+## Reforge
+
+Reforge creates a new session from an existing chronicle, preserving the development context chain.
+
+1. Fetch the chronicle by ID.
+2. Extract `config_snapshot` (name, model, repo, branch).
+3. Create a new session with `name = "{original_name} (reforged)"` and the same git source config.
+4. The new session's chronicle will have `parent_chronicle_id` set, linking it to the parent chronicle.
+
+The `get_chain()` method walks `parent_chronicle_id` links to build the full reforge chain from oldest ancestor to current.
+
+## Archive and Restore
+
+**Archive:** Stops the session if running, then sets status to `ARCHIVED` with a timestamp. Archived sessions are excluded from default list queries.
+
+**Restore:** Moves an `ARCHIVED` session back to `STOPPED`. From there it can be restarted normally.
+
+**Bulk archive:** `archive_stopped_sessions()` archives all sessions in `STOPPED` status.
+
+## Delete
+
+Deletion is aggressive but safe:
+
+1. Cancel any active provisioning task.
+2. If running or provisioning, attempt to stop pods. Pod stop failures are logged but don't prevent deletion.
+3. Run contributor cleanup in reverse order.
+4. Delete the session record.
+5. Broadcast deletion event.

--- a/docs/site/configuration/adapters.md
+++ b/docs/site/configuration/adapters.md
@@ -1,0 +1,69 @@
+# Dynamic Adapters
+
+Volundr uses a dynamic adapter pattern for most infrastructure components. Config specifies what class to load and what arguments to pass. No factory functions, no match/case chains.
+
+## How It Works
+
+1. Config specifies a fully-qualified class path in the `adapter` key.
+2. Remaining keys under `kwargs` are passed as `**kwargs` to the constructor.
+3. Some adapters accept injected ports (e.g., StoragePort, CredentialStorePort). These are wired automatically by the application at startup.
+4. Sensitive kwargs can come from Kubernetes Secrets via `secretKwargs` (Helm) or `secret_kwargs_env` (config.yaml).
+
+## Import Mechanism
+
+The container resolves the class at startup:
+
+```python
+module_path, class_name = dotted_path.rsplit(".", 1)
+module = importlib.import_module(module_path)
+cls = getattr(module, class_name)
+instance = cls(**kwargs)
+```
+
+No registration step. If the class exists on the Python path, it works.
+
+## Writing Your Own Adapter
+
+1. Implement the relevant port interface (e.g., `PodManager`, `CredentialStorePort`).
+2. Accept your config as constructor kwargs.
+3. Use `**_extra` to ignore injected kwargs you don't need.
+4. Set the `adapter` key in config to your class path.
+
+```python
+from volundr.ports.credential_store import CredentialStorePort
+
+class MyCredentialStore(CredentialStorePort):
+    def __init__(self, api_url: str, api_key: str, **_extra):
+        self._url = api_url
+        self._key = api_key
+
+    async def get_credential(self, user_id: str, name: str) -> str | None:
+        ...
+```
+
+```yaml
+credentialStore:
+  adapter: "mypackage.creds.MyCredentialStore"
+  kwargs:
+    api_url: "https://secrets.internal"
+  secretKwargs:
+    api_key:
+      secretName: my-creds
+      key: api-key
+```
+
+## All Adapter-Driven Components
+
+| Component | Port | Default Adapter |
+|-----------|------|-----------------|
+| Pod manager | PodManager | FarmPodManager |
+| Identity | IdentityPort | AllowAllIdentityAdapter |
+| Authorization | AuthorizationPort | AllowAllAuthorizationAdapter |
+| Credential store | CredentialStorePort | MemoryCredentialStore |
+| Secret injection | SecretInjectionPort | InMemorySecretInjectionAdapter |
+| Storage | StoragePort | InMemoryStorageAdapter |
+| Gateway | GatewayPort | InMemoryGatewayAdapter |
+| Resource provider | ResourceProvider | StaticResourceProvider |
+| Session contributors | SessionContributor | (10 default contributors) |
+
+Each component page in this section documents the available adapters and their configuration.

--- a/docs/site/configuration/contributors.md
+++ b/docs/site/configuration/contributors.md
@@ -1,0 +1,83 @@
+# Session Contributors
+
+The session contributor pipeline assembles the full pod spec for a session. Contributors run sequentially in config order. Each wraps one or more ports and produces Helm values and/or pod spec additions. Cleanup runs in reverse order on stop/delete.
+
+## Default Pipeline
+
+| # | Contributor | What it does | Key kwargs |
+|---|-------------|-------------|------------|
+| 1 | `CoreSessionContributor` | Session identity, ingress host, terminal flags | `base_domain`, `ingress_enabled` |
+| 2 | `TemplateContributor` | Workspace template, repos, setup scripts, env vars | (uses TemplateProvider, ProfileProvider) |
+| 3 | `GitContributor` | Authenticated git clone URL | (uses GitProviderRegistry) |
+| 4 | `IntegrationContributor` | MCP servers and env vars from integrations | (uses IntegrationRegistry) |
+| 5 | `StorageContributor` | PVC provisioning (workspace + home) | `home_enabled` |
+| 6 | `GatewayContributor` | Gateway API config (HTTPRoute, JWT) | (uses GatewayPort) |
+| 7 | `ResourceContributor` | CPU/memory/GPU translation to K8s primitives | (uses ResourceProvider) |
+| 8 | `IsolationContributor` | Network policies, security context | -- |
+| 9 | `SecretInjectionContributor` | CSI volumes for secret mounting | (uses SecretInjectionPort, CredentialStorePort) |
+| 10 | `SecretsContributor` | Ephemeral session secrets via SecretRepository | (uses SecretRepository) |
+
+## Helm Configuration
+
+```yaml
+sessionContributors:
+  - adapter: "volundr.adapters.outbound.contributors.core.CoreSessionContributor"
+    kwargs:
+      base_domain: "sessions.example.com"
+      ingress_enabled: true
+  - adapter: "volundr.adapters.outbound.contributors.template.TemplateContributor"
+    kwargs: {}
+  - adapter: "volundr.adapters.outbound.contributors.git.GitContributor"
+    kwargs: {}
+  - adapter: "volundr.adapters.outbound.contributors.integration.IntegrationContributor"
+    kwargs: {}
+  - adapter: "volundr.adapters.outbound.contributors.storage.StorageContributor"
+    kwargs:
+      home_enabled: true
+  - adapter: "volundr.adapters.outbound.contributors.gateway.GatewayContributor"
+    kwargs: {}
+  - adapter: "volundr.adapters.outbound.contributors.resource.ResourceContributor"
+    kwargs: {}
+  - adapter: "volundr.adapters.outbound.contributors.isolation.IsolationContributor"
+    kwargs: {}
+  - adapter: "volundr.adapters.outbound.contributors.secret_injection.SecretInjectionContributor"
+    kwargs: {}
+  - adapter: "volundr.adapters.outbound.contributors.secrets.SecretsContributor"
+    kwargs: {}
+```
+
+## How Contributors Work
+
+Each contributor implements two methods:
+
+- `contribute(session, context) -> SessionContribution` — returns Helm values and pod spec additions
+- `cleanup(session, context) -> None` — cleanup on stop/delete (optional)
+
+The SessionContext carries request-level metadata: principal, template name, profile name, credential names, integration IDs, resource config.
+
+All contributions are deep-merged in order. Later contributors can override earlier ones.
+
+## Writing a Custom Contributor
+
+1. Implement the `SessionContributor` ABC.
+2. Define a `name` property.
+3. Implement `contribute()` returning `SessionContribution(values={...})`.
+4. Accept needed ports via constructor kwargs. Use `**_extra` for unused injected kwargs.
+5. Add to `sessionContributors` list in config.
+
+```python
+from volundr.ports.session_contributor import SessionContributor, SessionContribution
+
+class MyContributor(SessionContributor):
+    def __init__(self, my_setting: str = "default", **_extra):
+        self._setting = my_setting
+
+    @property
+    def name(self) -> str:
+        return "my-contributor"
+
+    async def contribute(self, session, context) -> SessionContribution:
+        return SessionContribution(values={
+            "extraEnv": [{"name": "MY_VAR", "value": self._setting}]
+        })
+```

--- a/docs/site/configuration/events.md
+++ b/docs/site/configuration/events.md
@@ -1,0 +1,68 @@
+# Event Pipeline
+
+Session events (messages, file changes, git operations, token usage) flow through the event pipeline to configured sinks. Multiple sinks can run simultaneously.
+
+## Sinks
+
+| Sink | Description | Requires |
+|------|-------------|----------|
+| PostgreSQL | Always active, persists events to DB | Nothing (built-in) |
+| RabbitMQ | Publishes to AMQP exchange | `rabbitmq` extra |
+| OpenTelemetry | Exports to OTLP collector | `otel` extra |
+
+## RabbitMQ
+
+```yaml
+event_pipeline:
+  rabbitmq:
+    enabled: true
+    url: "amqp://guest:guest@rabbitmq:5672/"
+    exchange_name: "volundr.events"
+    exchange_type: "topic"
+```
+
+Install the extra dependency:
+
+```bash
+uv sync --extra rabbitmq
+```
+
+## OpenTelemetry
+
+```yaml
+event_pipeline:
+  otel:
+    enabled: true
+    endpoint: "http://otel-collector:4317"
+    protocol: "grpc"
+    service_name: "volundr"
+    insecure: true
+```
+
+Install the extra dependency:
+
+```bash
+uv sync --extra otel
+```
+
+Follows OTel GenAI semantic conventions (v1.39+).
+
+## SSE Streaming
+
+Real-time session state updates are available via Server-Sent Events:
+
+```
+GET /api/v1/volundr/sessions/stream
+```
+
+These use an in-memory broadcaster. Events are not persisted through this channel.
+
+## Event Health
+
+Check sink status:
+
+```
+GET /api/v1/volundr/events/health
+```
+
+Returns the connection state of each configured sink.

--- a/docs/site/configuration/gateway.md
+++ b/docs/site/configuration/gateway.md
@@ -1,0 +1,57 @@
+# Session Gateway
+
+Controls how session traffic is routed. Two approaches depending on your infrastructure.
+
+## Ingress-per-Session (simpler, default)
+
+Each session gets its own Ingress resource. Session URL: `https://<session-name>.<base_domain>/`
+
+```yaml
+sessionContributors:
+  - adapter: "volundr.adapters.outbound.contributors.core.CoreSessionContributor"
+    kwargs:
+      base_domain: "sessions.example.com"
+      ingress_enabled: true
+```
+
+This works with any ingress controller (nginx, Traefik, etc). No extra infrastructure needed.
+
+## Gateway API (production, centralized)
+
+A shared Gateway with per-session HTTPRoutes and SecurityPolicies. Requires Envoy Gateway controller.
+
+```yaml
+sessionGateway:
+  enabled: true
+  name: "volundr-gateway"
+  gatewayClassName: "eg"
+  hostname: "sessions.example.com"
+  certIssuer: "letsencrypt-prod"
+  httpRedirect: true
+
+gateway:
+  adapter: "volundr.adapters.outbound.k8s_gateway.K8sGatewayAdapter"
+  kwargs:
+    namespace: "volundr-sessions"
+    gateway_name: "volundr-gateway"
+    gateway_namespace: "volundr"
+    gateway_domain: "sessions.example.com"
+    issuer_url: "https://idp.example.com"
+    audience: "volundr"
+```
+
+### Features with Gateway API
+
+- Wildcard TLS via cert-manager
+- JWT validation on session routes via SecurityPolicy
+- Automatic DNS via external-dns
+- HTTP-to-HTTPS redirect
+
+## Port: GatewayPort
+
+| Adapter | Description |
+|---------|-------------|
+| `InMemoryGatewayAdapter` | Development — returns static config |
+| `K8sGatewayAdapter` | Production — manages HTTPRoute and SecurityPolicy resources |
+
+The GatewayContributor (in the session contributor pipeline) calls the GatewayPort to create routing resources when a session starts, and removes them on cleanup.

--- a/docs/site/configuration/git.md
+++ b/docs/site/configuration/git.md
@@ -1,0 +1,73 @@
+# Git Providers
+
+**Port:** GitProvider / GitWorkflowProvider
+
+## Adapters
+
+| Adapter | Description |
+|---------|-------------|
+| `GitHubProvider` | github.com and GitHub Enterprise |
+| `GitLabProvider` | gitlab.com and self-hosted GitLab |
+
+Both adapters support multiple instances. You can connect to several GitHub or GitLab servers simultaneously.
+
+## Configuration (config.yaml)
+
+```yaml
+git:
+  validate_on_create: true
+  github:
+    instances:
+      - name: GitHub
+        base_url: https://api.github.com
+        token: ghp_xxx          # or use token_env
+        token_env: GITHUB_TOKEN # env var name
+        orgs: [my-org]
+      - name: GitHub Enterprise
+        base_url: https://github.company.com/api/v3
+        token: ghp_enterprise
+        orgs: [engineering, platform]
+  gitlab:
+    instances:
+      - name: GitLab.com
+        base_url: https://gitlab.com
+        token: glpat_xxx
+        orgs: [my-group]
+```
+
+## Configuration (Helm)
+
+```yaml
+git:
+  github:
+    enabled: true
+    existingSecret: github-token
+    instances:
+      - name: GitHub Enterprise
+        baseUrl: https://github.company.com/api/v3
+        existingSecret: github-enterprise-secret
+        orgs: [engineering]
+  gitlab:
+    enabled: false
+```
+
+## Token Resolution
+
+Each instance resolves its token in this order:
+
+1. Explicit `token` field on the instance
+2. Environment variable named in `token_env`
+3. Top-level token for that provider
+
+## Workflow Settings
+
+Available in both config.yaml (snake_case) and Helm (camelCase):
+
+| config.yaml | Helm | Description |
+|-------------|------|-------------|
+| `auto_branch` | `autoBranch` | Auto-create branches for sessions |
+| `branch_prefix` | `branchPrefix` | Branch name prefix |
+| `protect_main` | `protectMain` | Prevent direct pushes to main |
+| `default_merge_method` | `defaultMergeMethod` | squash, merge, or rebase |
+| `auto_merge_threshold` | `autoMergeThreshold` | Confidence score for auto-merge |
+| `notify_merge_threshold` | `notifyMergeThreshold` | Confidence score for notify-then-merge |

--- a/docs/site/configuration/identity.md
+++ b/docs/site/configuration/identity.md
@@ -1,0 +1,97 @@
+# Identity & Authorization
+
+Two ports, typically configured together. Identity determines who the user is. Authorization determines what they can do.
+
+## Identity (IdentityPort)
+
+| Adapter | Use case |
+|---------|----------|
+| `AllowAllIdentityAdapter` | Development — no auth, returns a default principal |
+| `EnvoyHeaderIdentityAdapter` | Production — trusts Envoy sidecar headers |
+
+### AllowAll (default)
+
+```yaml
+identity:
+  adapter: "volundr.adapters.outbound.identity.AllowAllIdentityAdapter"
+```
+
+No configuration needed. Every request gets a default principal. Use this for local development only.
+
+### Envoy Headers (production)
+
+```yaml
+identity:
+  adapter: "volundr.adapters.outbound.identity.EnvoyHeaderIdentityAdapter"
+  kwargs:
+    user_id_header: "x-auth-user-id"
+    email_header: "x-auth-email"
+    tenant_header: "x-auth-tenant"
+    roles_header: "x-auth-roles"
+```
+
+Requires the Envoy sidecar enabled in Helm:
+
+```yaml
+envoy:
+  enabled: true
+  jwt:
+    enabled: true
+    issuer: "https://keycloak.example.com/realms/volundr"
+    audiences: [volundr]
+    jwksUri: "https://keycloak.example.com/realms/volundr/protocol/openid-connect/certs"
+```
+
+### JIT Provisioning
+
+On first login, the identity adapter creates the user record, provisions home PVC storage, and assigns tenant membership from IDP claims. This is IDP-agnostic. It works with Keycloak, Entra ID, Okta, or any OIDC provider.
+
+### Role Mapping
+
+Maps IDP claim roles to Volundr roles:
+
+```yaml
+identity:
+  roleMapping:
+    admin: "volundr:admin"
+    developer: "volundr:developer"
+    viewer: "volundr:viewer"
+```
+
+## Authorization (AuthorizationPort)
+
+| Adapter | Description |
+|---------|-------------|
+| `AllowAllAuthorizationAdapter` | Development — permits everything |
+| `SimpleRoleAuthorizationAdapter` | Role-based with ownership checks |
+| `CerbosAuthorizationAdapter` | Full policy engine via Cerbos PDP |
+
+### AllowAll (default)
+
+Every action is permitted. Development only.
+
+### SimpleRole (recommended minimum)
+
+```yaml
+authorization:
+  adapter: "volundr.adapters.outbound.authorization.SimpleRoleAuthorizationAdapter"
+```
+
+Enforces these rules:
+
+- Cross-tenant access is denied.
+- Admins get full access within their tenant.
+- Developers can read/write their own resources.
+- Viewers get read-only access.
+
+### Cerbos (full policy engine)
+
+```yaml
+authorization:
+  adapter: "volundr.adapters.outbound.cerbos.CerbosAuthorizationAdapter"
+  kwargs:
+    url: "http://cerbos:3592"
+    timeout: 5
+```
+
+Delegates all authorization decisions to a Cerbos PDP instance. Use this when you need fine-grained, policy-as-code authorization.

--- a/docs/site/configuration/overview.md
+++ b/docs/site/configuration/overview.md
@@ -1,0 +1,37 @@
+# Configuration Overview
+
+Volundr loads configuration from multiple sources. Higher priority sources override lower ones.
+
+**Priority order (highest to lowest):**
+
+1. **Constructor arguments** — testing only
+2. **Environment variables** — double underscore nesting: `DATABASE__HOST=postgres.local`
+3. **YAML config file** — `./config.yaml` or `/etc/volundr/config.yaml`
+4. **`/run/secrets` files** — Kubernetes secrets mounted as files
+
+## Two Config Contexts
+
+There are two ways to configure Volundr depending on how you run it.
+
+**Config file** (`config.yaml` / `config.yaml.example`) is for running from source or local CLI. Uses snake_case throughout.
+
+**Helm values** (`values.yaml`) is for Kubernetes deployments. The chart generates a ConfigMap mounted at `/etc/volundr/config.yaml`. Uses camelCase.
+
+The naming differs between them. Helm uses camelCase (`podManager`), config.yaml uses snake_case (`pod_manager`). The chart templates handle the translation.
+
+## Dynamic Adapter Pattern
+
+Most infrastructure components are configured by specifying a fully-qualified Python class path and constructor kwargs. You can swap backends without code changes — just update the config.
+
+```yaml
+# Example: switch pod manager from Farm to Flux
+pod_manager:
+  adapter: "volundr.adapters.outbound.flux.FluxPodManager"
+  kwargs:
+    namespace: "default"
+    chart_name: "skuld"
+```
+
+Adding a new adapter = write the class + update config. No code changes in the container.
+
+See [Dynamic Adapters](adapters.md) for full details on how the pattern works.

--- a/docs/site/configuration/secrets.md
+++ b/docs/site/configuration/secrets.md
@@ -1,0 +1,79 @@
+# Secret Management
+
+Two separate systems for different purposes.
+
+## Credential Store (CredentialStorePort)
+
+User-managed secrets like API keys and tokens. Users store and retrieve their own credentials through the Volundr UI or API.
+
+| Adapter | Description |
+|---------|-------------|
+| `MemoryCredentialStore` | Development — in-memory, lost on restart |
+| `VaultCredentialStore` | OpenBao/Vault KV v2 |
+| `InfisicalCredentialStore` | Infisical secret manager |
+
+### Vault
+
+```yaml
+credentialStore:
+  adapter: "volundr.adapters.outbound.vault_credential_store.VaultCredentialStore"
+  kwargs:
+    url: "http://vault:8200"
+    auth_method: "kubernetes"
+    mount_path: "secret"
+```
+
+### Infisical
+
+```yaml
+credentialStore:
+  adapter: "volundr.adapters.outbound.infisical_credential_store.InfisicalCredentialStore"
+  kwargs:
+    site_url: "https://app.infisical.com"
+    client_id: "..."
+    client_secret: "..."
+    project_id: "..."
+```
+
+## Secret Injection (SecretInjectionPort)
+
+Infrastructure secrets mounted into session pods via CSI drivers. Volundr never sees secret values. It generates pod spec additions that tell the CSI driver what to mount. The CSI driver fetches secrets directly from the vault.
+
+| Adapter | Description |
+|---------|-------------|
+| `InMemorySecretInjectionAdapter` | Development — no-op |
+| `InfisicalCSISecretInjectionAdapter` | Infisical Secrets Operator + CSI driver |
+| `OpenBaoCSISecretInjectionAdapter` | OpenBao/Vault CSI driver |
+
+### Infisical CSI
+
+```yaml
+secretInjection:
+  adapter: "volundr.adapters.outbound.infisical_secret_injection.InfisicalCSISecretInjectionAdapter"
+  kwargs:
+    infisical_url: "https://infisical.example.com"
+    client_id: "..."
+    client_secret: "..."
+    namespace: "volundr-sessions"
+```
+
+### OpenBao CSI
+
+```yaml
+secretInjection:
+  adapter: "volundr.adapters.outbound.openbao_secret_injection.OpenBaoCSISecretInjectionAdapter"
+  kwargs:
+    vault_url: "http://openbao:8200"
+    namespace: "volundr-sessions"
+```
+
+## Secret Repository (SecretRepository)
+
+Used internally for OpenBao/Vault operations. Not directly configurable as an adapter — it is wired by the application when Vault-based credential store is active.
+
+Responsibilities:
+
+- Store credentials at vault paths
+- Provision per-user policies and Kubernetes auth roles
+- Create ephemeral session secrets
+- Clean up on user deprovisioning

--- a/docs/site/configuration/storage.md
+++ b/docs/site/configuration/storage.md
@@ -1,0 +1,56 @@
+# Storage
+
+**Port:** StoragePort
+
+| Adapter | Description |
+|---------|-------------|
+| `InMemoryStorageAdapter` | Development — tracks PVC names without creating K8s resources |
+| `K8sStorageAdapter` | Production — creates and manages PVCs via Kubernetes API |
+
+## Two Volume Types
+
+**Session workspace** — Per-session PVC mounted at `/volundr/sessions`. Created when a session starts, archived on stop, deleted on session delete.
+
+**Home volume** — Per-user PVC mounted at `/volundr/home`. Persists across sessions. Stores user config, Claude credentials, shell history.
+
+## Helm Configuration
+
+```yaml
+storage:
+  sessions:
+    enabled: true
+    storageClass: longhorn
+    accessMode: ReadWriteMany
+    size: 1Gi
+    mountPath: /volundr/sessions
+  home:
+    enabled: true
+    storageClass: longhorn
+    accessMode: ReadWriteMany
+    size: 1Gi
+    mountPath: /volundr/home
+```
+
+## K8s Adapter (config.yaml)
+
+```yaml
+storageAdapter:
+  adapter: "volundr.adapters.outbound.k8s_storage_adapter.K8sStorageAdapter"
+  kwargs:
+    namespace: "volundr-sessions"
+    home_storage_class: "longhorn"
+    workspace_storage_class: "longhorn"
+    workspace_size_gb: 2
+```
+
+## Storage Class Requirements
+
+Session PVCs need ReadWriteMany if multiple containers access them simultaneously. Home PVCs need ReadWriteMany for cross-session access.
+
+Compatible storage classes:
+
+- **Longhorn** — recommended for bare-metal and edge
+- **NFS-based provisioners** — works everywhere
+- **Cloud RWX classes** — EFS (AWS), Azure Files, Filestore (GCP)
+
+Single-node clusters can use ReadWriteOnce, but this limits session pods to the node where the PVC is bound.

--- a/docs/site/configuration/trackers.md
+++ b/docs/site/configuration/trackers.md
@@ -1,0 +1,62 @@
+# Issue Trackers
+
+**Port:** IssueTrackerProvider
+
+| Adapter | Description |
+|---------|-------------|
+| `LinearIssueTrackerProvider` | Linear.app integration |
+| `JiraIssueTrackerProvider` | Jira integration |
+
+Issue trackers connect Volundr sessions to project management. Features:
+
+- Search issues by query or project
+- Get recent issues
+- Update issue status
+- Map repos to tracker projects
+
+## Linear
+
+```yaml
+linear:
+  enabled: true
+  api_key: "lin_api_xxx"  # or LINEAR_API_KEY env var
+```
+
+## Jira
+
+Configure via the integration catalog:
+
+```yaml
+integrations:
+  definitions:
+    - slug: jira
+      name: Jira
+      integration_type: issue_tracker
+      adapter: "volundr.adapters.outbound.integrations.jira.JiraAdapter"
+      credential_schema:
+        url:
+          type: string
+          required: true
+        email:
+          type: string
+          required: true
+        api_token:
+          type: string
+          required: true
+```
+
+Users provide their Jira credentials through the Volundr UI. The credentials are stored in the configured credential store.
+
+## Project Mappings
+
+Map git repositories to tracker projects so Volundr knows which project to associate with a session:
+
+```
+POST /api/v1/volundr/tracker/mappings
+{
+  "repo_url": "https://github.com/org/repo",
+  "project_id": "PROJ-123"
+}
+```
+
+Once mapped, sessions created from that repository automatically link to the tracker project. Issue search is scoped to the mapped project by default.

--- a/docs/site/getting-started/first-session.md
+++ b/docs/site/getting-started/first-session.md
@@ -1,0 +1,134 @@
+# First Session
+
+A session is a containerized AI coding environment: an LLM agent, a terminal, a code editor, and your repo -- all wired together. This guide walks through creating one.
+
+---
+
+## Web UI
+
+### 1. Open Volundr
+
+Navigate to your Volundr instance in a browser (default: [http://localhost:8080](http://localhost:8080)).
+
+### 2. Launch a new session
+
+Click **New Session**. The launch wizard opens with two steps.
+
+**Step 1: Template**
+
+Pick a session template or use the default. Templates pre-configure the model, resource limits, and integrations for common workflows.
+
+**Step 2: Configure**
+
+Fill in the details:
+
+| Field | Description |
+|-------|-------------|
+| **Name** | A short name for this session |
+| **Model** | Which AI model to use (e.g. `claude-sonnet-4`) |
+| **Repository URL** | The repo to clone into the workspace |
+| **Branch** | Branch to check out (defaults to the repo's default branch) |
+| **Credentials** | Git credentials for private repos |
+| **Integrations** | Optional tools: Linear, Slack, etc. |
+
+Click **Launch**.
+
+### 3. Watch it start
+
+The session transitions through states:
+
+```
+CREATED -> STARTING -> PROVISIONING -> RUNNING
+```
+
+This takes 10-30 seconds depending on repo size and image pull time.
+
+### 4. Use the session
+
+Once running, the **Chat** tab opens. Type a message to start working with the AI agent.
+
+The session has five tabs:
+
+| Tab | What it does |
+|-----|-------------|
+| **Chat** | Talk to the AI coding agent |
+| **Terminal** | Full shell access to the workspace |
+| **Code** | VS Code editor (Code Server) |
+| **Diffs** | See what the agent changed |
+| **Chronicles** | Session history and summaries |
+
+### 5. Stop the session
+
+When you're done, click **Stop**. A chronicle is automatically created -- a summary of what happened during the session, the changes made, and the conversation history.
+
+---
+
+## CLI
+
+### 1. Set up your context
+
+If you're connecting to a remote Volundr instance, add it as a context:
+
+```bash
+volundr context add local --server http://localhost:8080
+```
+
+Skip this if you ran `volundr init` and `volundr up` locally -- the context is already configured.
+
+### 2. Create a session
+
+```bash
+volundr sessions create \
+  --name my-project \
+  --repo org/repo \
+  --model claude-sonnet-4
+```
+
+This returns a session ID.
+
+### 3. Start the session
+
+```bash
+volundr sessions start <session-id>
+```
+
+### 4. Open the TUI
+
+```bash
+volundr
+```
+
+The terminal UI gives you the same capabilities as the web UI: chat, terminal, diffs, and chronicles. Navigate between views with keyboard shortcuts.
+
+### 5. Stop the session
+
+```bash
+volundr sessions stop <session-id>
+```
+
+A chronicle is created automatically, same as the web UI.
+
+---
+
+## What happens under the hood
+
+When you launch a session, Volundr creates a Kubernetes pod with three main containers:
+
+| Container | Role |
+|-----------|------|
+| **Skuld broker** | Manages the LLM conversation and tool execution |
+| **Code Server** | VS Code in the browser |
+| **Terminal** | Shell access to the workspace |
+
+All three containers share a workspace volume (PVC) where your repo is cloned.
+
+Chat messages go directly from your browser to the Skuld broker inside the pod -- they don't route through the Volundr API server. This keeps latency low and means the API server doesn't need to handle streaming LLM responses.
+
+The Volundr API handles lifecycle operations only: creating, starting, stopping, and deleting sessions.
+
+---
+
+## Next steps
+
+- [Configuration](configuration.md) -- customize models, resource limits, and integrations
+- [Helm Deployment](../deployment/helm.md) -- run Volundr on a real cluster

--- a/docs/site/getting-started/installation.md
+++ b/docs/site/getting-started/installation.md
@@ -1,31 +1,64 @@
 # Installation
 
+Three ways to install Volundr, from simplest to most production-ready.
+
+---
+
 ## Prerequisites
 
-- Python 3.11+ (3.12 recommended)
-- PostgreSQL 12+
-- Node.js 22+ (for the web UI)
-- Kubernetes 1.24+ and Helm 3.8+ (for deployment)
+Not all prerequisites apply to every method. Check the table for your path.
 
-## Backend
+| Prerequisite | CLI Binary | From Source | Kubernetes |
+|-------------|:---:|:---:|:---:|
+| Python 3.11+ (3.12 recommended) | -- | Yes | -- |
+| PostgreSQL 12+ | Bundled (embedded mode) | Yes | Helm chart handles it |
+| Node.js 22+ | -- | Only for web UI dev | -- |
+| Kubernetes 1.24+ | -- | -- | Yes |
+| Helm 3.8+ | -- | -- | Yes |
+| [uv](https://docs.astral.sh/uv/) package manager | -- | Yes | -- |
 
-Volundr uses [uv](https://docs.astral.sh/uv/) for dependency management.
+---
+
+## Method 1: CLI Binary
+
+The fastest path. Download a pre-built binary, answer a few questions, and you're running.
 
 ```bash
-# Clone the repository
+# Download
+curl -fsSL https://get.volundr.dev | sh
+
+# Initialize (interactive wizard)
+volundr init
+
+# Start everything
+volundr up
+```
+
+`volundr init` walks you through runtime selection, API keys, database mode, and GitHub configuration. `volundr up` starts PostgreSQL (if you chose embedded mode), the API server, and a reverse proxy.
+
+Open [http://localhost:8080](http://localhost:8080).
+
+See the [Quick Start](quick-start.md) for a step-by-step walkthrough.
+
+---
+
+## Method 2: From Source
+
+For developers contributing to Volundr.
+
+### Clone and install
+
+```bash
 git clone https://github.com/niuulabs/volundr.git
 cd volundr
 
-# Install core dependencies
+# Install dependencies
 uv sync --dev
-
-# Or install with all optional extras
-uv sync --all-extras --dev
 ```
 
 ### Optional extras
 
-Install only the extras you need:
+Install only what you need:
 
 ```bash
 uv sync --extra rabbitmq   # RabbitMQ event sink (aio-pika)
@@ -34,19 +67,16 @@ uv sync --extra k8s        # Kubernetes client (kubernetes-asyncio)
 uv sync --extra otel       # OpenTelemetry export (traces + metrics)
 ```
 
-## Web UI
+Or install everything:
 
 ```bash
-cd web
-npm install
+uv sync --all-extras --dev
 ```
 
-## Database
-
-Volundr needs a PostgreSQL database. Tables are auto-created on startup for development.
+### Set up the database
 
 ```bash
-# Create the database
+# Local PostgreSQL
 createdb volundr
 
 # Or via Docker
@@ -58,12 +88,75 @@ docker run -d --name volundr-pg \
   postgres:16
 ```
 
-## Configuration
+Tables are auto-created on startup in development mode.
 
-Copy the example config and edit it:
+### Configure and run
 
 ```bash
 cp config.yaml.example config.yaml
+# Edit config.yaml with your settings
+
+uv run volundr
 ```
 
-See [Configuration](configuration.md) for the full reference.
+### Web UI (optional)
+
+```bash
+cd web
+npm install
+npm run dev
+```
+
+---
+
+## Method 3: Kubernetes (Helm)
+
+For production deployments. This is how Volundr is meant to run.
+
+```bash
+helm repo add volundr https://charts.volundr.dev
+helm repo update
+
+helm install volundr volundr/volundr \
+  --namespace volundr --create-namespace \
+  --values your-values.yaml
+```
+
+Minimum `values.yaml`:
+
+```yaml
+anthropic:
+  apiKey: sk-ant-...
+
+github:
+  token: ghp_...
+
+postgresql:
+  auth:
+    password: a-real-password
+```
+
+See the [Helm Deployment Guide](../deployment/helm.md) for the full reference: ingress configuration, resource limits, persistent storage, TLS, and production hardening.
+
+---
+
+## Verifying the installation
+
+Regardless of method, you can verify things are working:
+
+```bash
+# Health check
+curl http://localhost:8080/health
+
+# API version
+curl http://localhost:8080/api/v1/version
+```
+
+---
+
+## Next steps
+
+- [Quick Start](quick-start.md) -- get running in 5 minutes
+- [First Session](first-session.md) -- create your first AI coding session
+- [Configuration](configuration.md) -- full configuration reference
+- [Helm Deployment](../deployment/helm.md) -- production Kubernetes deployment

--- a/docs/site/getting-started/installation.md
+++ b/docs/site/getting-started/installation.md
@@ -24,8 +24,11 @@ Not all prerequisites apply to every method. Check the table for your path.
 The fastest path. Download a pre-built binary, answer a few questions, and you're running.
 
 ```bash
-# Download
-curl -fsSL https://get.volundr.dev | sh
+# Download from GitHub releases
+# https://github.com/niuulabs/volundr/releases
+curl -fsSL https://github.com/niuulabs/volundr/releases/latest/download/volundr-$(uname -s)-$(uname -m) -o volundr
+chmod +x volundr
+sudo mv volundr /usr/local/bin/
 
 # Initialize (interactive wizard)
 volundr init

--- a/docs/site/getting-started/quick-start.md
+++ b/docs/site/getting-started/quick-start.md
@@ -10,9 +10,13 @@ The fastest way to try Volundr. No Kubernetes required.
 
 ### 1. Download the CLI
 
+Grab the latest binary from [GitHub Releases](https://github.com/niuulabs/volundr/releases):
+
 ```bash
 # macOS / Linux
-curl -fsSL https://get.volundr.dev | sh
+curl -fsSL https://github.com/niuulabs/volundr/releases/latest/download/volundr-$(uname -s)-$(uname -m) -o volundr
+chmod +x volundr
+sudo mv volundr /usr/local/bin/
 ```
 
 ### 2. Initialize

--- a/docs/site/getting-started/quick-start.md
+++ b/docs/site/getting-started/quick-start.md
@@ -1,0 +1,96 @@
+# Quick Start
+
+Get Volundr running in under 5 minutes. Pick the path that fits your setup.
+
+---
+
+## Option 1: CLI (Local Mode)
+
+The fastest way to try Volundr. No Kubernetes required.
+
+### 1. Download the CLI
+
+```bash
+# macOS / Linux
+curl -fsSL https://get.volundr.dev | sh
+```
+
+### 2. Initialize
+
+```bash
+volundr init
+```
+
+The wizard asks a few questions:
+
+| Prompt | Options | Notes |
+|--------|---------|-------|
+| Runtime | `local`, `docker`, `k3s` | Start with `local` |
+| Anthropic API key | Your key | Used for AI sessions |
+| Database mode | `embedded`, `external` | `embedded` bundles PostgreSQL |
+| GitHub token | Personal access token | For repo access |
+| GitHub orgs | Comma-separated | Which orgs to surface |
+| GitHub API URL | `https://api.github.com` | Change for GitHub Enterprise |
+
+### 3. Start everything
+
+```bash
+volundr up
+```
+
+This starts PostgreSQL (if embedded), the Python API server, and a reverse proxy. Open [http://localhost:8080](http://localhost:8080) when it's ready.
+
+That's it. Jump to [First Session](first-session.md) to create your first AI coding session.
+
+---
+
+## Option 2: k3d (Local Kubernetes)
+
+For people who want the full Kubernetes experience without a cloud bill.
+
+### 1. Install prerequisites
+
+```bash
+# Install k3d
+curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
+
+# Install Helm
+curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+```
+
+### 2. Create a cluster
+
+```bash
+k3d cluster create volundr \
+  --port "8080:80@loadbalancer" \
+  --port "8443:443@loadbalancer"
+```
+
+### 3. Install Volundr
+
+```bash
+helm repo add volundr https://charts.volundr.dev
+helm repo update
+
+helm install volundr volundr/volundr \
+  --namespace volundr --create-namespace \
+  --set anthropic.apiKey=sk-ant-... \
+  --set github.token=ghp_...
+```
+
+### 4. Wait for pods
+
+```bash
+kubectl -n volundr get pods -w
+```
+
+Once everything shows `Running`, open [http://localhost:8080](http://localhost:8080).
+
+---
+
+## Next steps
+
+- [First Session](first-session.md) -- create and use your first AI coding session
+- [Installation](installation.md) -- full installation details and prerequisites
+- [Configuration](configuration.md) -- all configuration options
+- [Helm Deployment](../deployment/helm.md) -- production Kubernetes deployment

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -86,7 +86,7 @@ Issue trackers (Linear, Jira), MCP servers, SSE streaming, and event pipelines t
 |-----------|------|
 | <span class="component-name">Volundr API</span> | FastAPI/Python backend — session CRUD, workspace provisioning, git integration, secret management, multi-tenant access control |
 | <span class="component-name">Skuld</span> | WebSocket broker — connects the browser UI to AI coding agents running inside session pods |
-| <span class="component-name">Hlidskjalf</span> | React web UI — session management, chronicles, diffs, terminal access, and admin |
+| <span class="component-name">Web UI</span> | React web UI — session management, chronicles, diffs, terminal access, and admin |
 
 ## Tech stack
 
@@ -160,8 +160,9 @@ Each session provides a complete workspace with an integrated terminal and a ful
 
 ## Quick links
 
-- [Installation](getting-started/installation.md) — get up and running
-- [Configuration reference](getting-started/configuration.md) — all YAML options
+- [Quick start](getting-started/quick-start.md) — get running in 5 minutes
+- [Installation guide](installation/overview.md) — deployment options and setup
+- [User guide](user-guide/sessions.md) — sessions, templates, chronicles, CLI
+- [Configuration](configuration/overview.md) — adapters, identity, secrets, storage
 - [API reference](api/openapi.md) — interactive OpenAPI documentation
-- [Helm deployment](deployment/helm.md) — production setup on Kubernetes
 - [Contributing](contributing/development.md) — development workflow

--- a/docs/site/installation/helm-reference.md
+++ b/docs/site/installation/helm-reference.md
@@ -1,0 +1,826 @@
+# Helm Values Reference
+
+Complete reference for the Volundr Helm chart. All values have sensible defaults. Override only what you need.
+
+Install from OCI:
+
+```bash
+helm install volundr oci://ghcr.io/niuulabs/charts/volundr -n volundr -f values.yaml
+```
+
+---
+
+## Image and Replicas
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `replicaCount` | `1` | Number of API replicas (ignored if autoscaling enabled) |
+| `image.registry` | `ghcr.io` | Container registry |
+| `image.repository` | `niuulabs/volundr` | Image repository |
+| `image.tag` | `""` (Chart.appVersion) | Image tag |
+| `image.pullPolicy` | `Always` | Image pull policy |
+| `revisionHistoryLimit` | `10` | Old ReplicaSets to retain |
+
+---
+
+## Service
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `service.type` | `ClusterIP` | Service type |
+| `service.port` | `80` | Service port |
+| `service.targetPort` | `8080` | Container port |
+| `service.clusterIP` | `""` | Cluster IP (ClusterIP type only) |
+| `service.nodePort` | `""` | Node port (NodePort type only) |
+| `service.annotations` | `{}` | Service annotations |
+
+---
+
+## Ingress
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `ingress.enabled` | `false` | Enable ingress |
+| `ingress.className` | `""` | Ingress class (nginx, traefik, haproxy) |
+| `ingress.annotations` | `{}` | Controller-specific annotations |
+| `ingress.hosts` | see below | Host and path rules |
+| `ingress.tls` | `[]` | TLS configuration |
+
+Default host:
+
+```yaml
+hosts:
+  - host: api.example.com
+    paths:
+      - path: /api/v1/volundr
+        pathType: Prefix
+```
+
+Annotation examples by controller:
+
+```yaml
+# NGINX
+nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+
+# Traefik
+traefik.ingress.kubernetes.io/router.middlewares: default-timeout@kubernetescrd
+
+# HAProxy
+haproxy.org/timeout-server: "3600s"
+```
+
+---
+
+## Database
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `database.name` | `volundr` | Database name |
+| `database.minPoolSize` | `5` | Minimum connection pool size |
+| `database.maxPoolSize` | `20` | Maximum connection pool size |
+| `database.existingSecret` | `volundr-db` | Secret with DB credentials |
+| `database.userKey` | `username` | Key in secret for username |
+| `database.passwordKey` | `password` | Key in secret for password |
+| `database.createSecret` | `false` | Create secret (set username/password below) |
+| `database.external.enabled` | `true` | Use external database |
+| `database.external.host` | `postgresql.default.svc.cluster.local` | Database host |
+| `database.external.port` | `5432` | Database port |
+
+---
+
+## Pod Manager
+
+Controls how session pods are deployed. Uses the dynamic adapter pattern.
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `podManager.adapter` | `volundr.adapters.outbound.farm.FarmPodManager` | Fully-qualified class path |
+| `podManager.existingSecret` | `""` | Secret with backend API token |
+| `podManager.tokenKey` | `token` | Key in secret for token |
+| `podManager.kwargs` | see below | Constructor kwargs |
+
+Default kwargs:
+
+```yaml
+kwargs:
+  base_url: "http://farm-tasks.default.svc.cluster.local"
+  timeout: 30
+  task_type: "skuld-claude"
+  user: "volundr"
+  labels:
+    - session
+  base_domain: "skuld.valhalla.asgard.niuu.world"
+  chat_scheme: "wss"
+  code_scheme: "https"
+  chat_path: "/session"
+  code_path: "/"
+```
+
+Flux adapter example:
+
+```yaml
+podManager:
+  adapter: "volundr.adapters.outbound.flux.FluxPodManager"
+  kwargs:
+    namespace: "default"
+    chart_name: "skuld"
+    chart_version: "0.1.0"
+    source_ref_kind: "HelmRepository"
+    source_ref_name: "skuld"
+    timeout: "5m"
+    interval: "5m"
+    base_domain: "skuld.valhalla.asgard.niuu.world"
+    chat_scheme: "wss"
+    code_scheme: "https"
+    chat_path: "/session"
+    code_path: "/"
+```
+
+---
+
+## Provisioning
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `provisioning.timeoutSeconds` | `300.0` | Max wait for infrastructure readiness |
+| `provisioning.initialDelaySeconds` | `5.0` | Delay before starting readiness polls |
+
+---
+
+## Profiles
+
+Profiles define base configurations for sessions. Array of objects.
+
+```yaml
+profiles:
+  - name: standard
+    description: "Standard Claude Code session"
+    workloadType: session
+    sessionDefinition: skuld-claude
+    model: "claude-sonnet-4-20250514"
+    resourceConfig:
+      cpu: "500m"
+      memory: "1Gi"
+    mcpServers: []
+    envVars: {}
+    envSecretRefs: []
+    workloadConfig: {}
+    isDefault: true
+
+  - name: gpu-heavy
+    description: "GPU-accelerated session"
+    workloadType: session
+    sessionDefinition: skuld-claude
+    model: "claude-sonnet-4-20250514"
+    resourceConfig:
+      cpu: "2"
+      memory: "8Gi"
+      gpu: "1"
+    isDefault: false
+```
+
+| Field | Description |
+|-------|-------------|
+| `name` | Unique profile name |
+| `description` | Human-readable description |
+| `workloadType` | Workload type (`session`) |
+| `sessionDefinition` | Which FarmSessionDefinition to use (`skuld-claude`, `skuld-codex`) |
+| `model` | Default AI model |
+| `resourceConfig` | CPU, memory, GPU requests |
+| `mcpServers` | MCP servers to inject |
+| `envVars` | Plain environment variables |
+| `envSecretRefs` | Secret-backed environment variables |
+| `isDefault` | Use as default profile |
+
+---
+
+## Templates
+
+Templates combine a profile with repositories and setup scripts.
+
+```yaml
+templates:
+  - name: default-session
+    description: "Default coding session"
+    profileName: standard
+    repos:
+      - url: "https://github.com/org/repo"
+        branch: main
+    setupScripts:
+      - "pip install -r requirements.txt"
+    workspaceLayout:
+      editor: vscode
+    isDefault: true
+```
+
+| Field | Description |
+|-------|-------------|
+| `name` | Unique template name |
+| `profileName` | Profile to inherit from |
+| `repos` | Repositories to clone (url, branch) |
+| `setupScripts` | Scripts to run after clone |
+| `workspaceLayout` | Editor layout config |
+| `isDefault` | Use as default template |
+
+---
+
+## Git
+
+### Providers
+
+```yaml
+git:
+  validateOnCreate: true
+  github:
+    enabled: true
+    existingSecret: ""
+    tokenKey: token
+    instances: []
+  gitlab:
+    enabled: false
+    existingSecret: ""
+    tokenKey: token
+    instances: []
+```
+
+Add GitHub Enterprise or self-hosted GitLab instances:
+
+```yaml
+github:
+  instances:
+    - name: GitHub Enterprise
+      baseUrl: https://github.company.com/api/v3
+      existingSecret: github-enterprise-secret
+      tokenKey: token
+      orgs:
+        - engineering
+```
+
+### Workflow
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `git.workflow.autoBranch` | `true` | Auto-create branches for sessions |
+| `git.workflow.branchPrefix` | `volundr/session` | Branch name prefix |
+| `git.workflow.protectMain` | `true` | Protect main/master from direct commits |
+| `git.workflow.defaultMergeMethod` | `squash` | Merge method (merge, squash, rebase) |
+| `git.workflow.autoMergeThreshold` | `0.9` | Confidence threshold for auto-merge |
+| `git.workflow.notifyMergeThreshold` | `0.6` | Confidence threshold for notify-then-merge |
+
+---
+
+## Envoy Sidecar
+
+JWT-validating reverse proxy. Extracts claims into trusted headers for the identity adapter.
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `envoy.enabled` | `false` | Enable Envoy sidecar |
+| `envoy.image.repository` | `envoyproxy/envoy` | Envoy image |
+| `envoy.image.tag` | `v1.32-latest` | Envoy version |
+| `envoy.port` | `8443` | Listener port |
+| `envoy.adminPort` | `9901` | Admin port (localhost only) |
+| `envoy.connectTimeout` | `0.25s` | Upstream connect timeout |
+| `envoy.upstreamTimeout` | `60s` | Upstream request timeout |
+
+### JWT Configuration
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `envoy.jwt.enabled` | `false` | Enable JWT filter |
+| `envoy.jwt.issuer` | `""` | JWT issuer URL |
+| `envoy.jwt.audiences` | `[]` | Allowed audiences |
+| `envoy.jwt.jwksUri` | `""` | JWKS endpoint |
+| `envoy.jwt.jwksTimeout` | `5s` | JWKS fetch timeout |
+| `envoy.jwt.jwksCacheDurationSeconds` | `300` | JWKS cache TTL |
+| `envoy.jwt.tenantClaim` | `tenant_id` | Claim for tenant ID |
+| `envoy.jwt.rolesClaim` | `resource_access.volundr.roles` | Claim for roles (dot notation) |
+| `envoy.jwt.keycloakHost` | `""` | IDP upstream host for JWKS |
+| `envoy.jwt.keycloakPort` | `8080` | IDP upstream port |
+| `envoy.jwt.keycloakTls` | `false` | TLS for IDP upstream |
+| `envoy.jwt.bypassPrefixes` | `/api/v1/volundr/auth/config`, `/health` | Paths that skip JWT validation |
+| `envoy.jwt.extraClaimHeaders` | `[]` | Additional claim-to-header mappings |
+
+### Header Names
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `envoy.headerNames.userId` | `x-auth-user-id` | User ID header |
+| `envoy.headerNames.email` | `x-auth-email` | Email header |
+| `envoy.headerNames.tenant` | `x-auth-tenant` | Tenant header |
+| `envoy.headerNames.roles` | `x-auth-roles` | Roles header |
+
+---
+
+## Identity
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `identity.adapter` | `...AllowAllIdentityAdapter` | Identity adapter class |
+| `identity.kwargs` | `{}` | Adapter constructor kwargs |
+| `identity.secretKwargs` | `[]` | Kwargs from K8s secrets |
+| `identity.roleMapping.admin` | `volundr:admin` | IDP role mapping for admin |
+| `identity.roleMapping.developer` | `volundr:developer` | IDP role mapping for developer |
+| `identity.roleMapping.viewer` | `volundr:viewer` | IDP role mapping for viewer |
+
+AllowAll (development):
+
+```yaml
+identity:
+  adapter: "volundr.adapters.outbound.identity.AllowAllIdentityAdapter"
+```
+
+Envoy trusted headers (production):
+
+```yaml
+identity:
+  adapter: "volundr.adapters.outbound.identity.EnvoyHeaderIdentityAdapter"
+  kwargs:
+    user_id_header: "x-auth-user-id"
+    email_header: "x-auth-email"
+    tenant_header: "x-auth-tenant"
+    roles_header: "x-auth-roles"
+```
+
+---
+
+## Authorization
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `authorization.adapter` | `...AllowAllAuthorizationAdapter` | Authorization adapter class |
+| `authorization.kwargs` | `{}` | Adapter constructor kwargs |
+| `authorization.secretKwargs` | `[]` | Kwargs from K8s secrets |
+
+AllowAll (development):
+
+```yaml
+authorization:
+  adapter: "volundr.adapters.outbound.authorization.AllowAllAuthorizationAdapter"
+```
+
+Simple role-based:
+
+```yaml
+authorization:
+  adapter: "volundr.adapters.outbound.authorization.SimpleRoleAuthorizationAdapter"
+```
+
+Cerbos PDP:
+
+```yaml
+authorization:
+  adapter: "volundr.adapters.outbound.cerbos.CerbosAuthorizationAdapter"
+  kwargs:
+    url: "http://cerbos:3592"
+    timeout: 5
+```
+
+---
+
+## Credential Store
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `credentialStore.adapter` | `...MemoryCredentialStore` | Credential store adapter class |
+| `credentialStore.kwargs` | `{}` | Adapter constructor kwargs |
+| `credentialStore.secretKwargs` | `[]` | Kwargs from K8s secrets |
+
+Memory (development):
+
+```yaml
+credentialStore:
+  adapter: "volundr.adapters.outbound.memory_credential_store.MemoryCredentialStore"
+```
+
+Vault / OpenBao:
+
+```yaml
+credentialStore:
+  adapter: "volundr.adapters.outbound.vault_credential_store.VaultCredentialStore"
+  kwargs:
+    url: "http://vault:8200"
+    auth_method: "kubernetes"
+    mount_path: "secret"
+```
+
+Infisical:
+
+```yaml
+credentialStore:
+  adapter: "volundr.adapters.outbound.infisical_credential_store.InfisicalCredentialStore"
+  kwargs:
+    site_url: "https://app.infisical.com"
+    client_id: ""
+    client_secret: ""
+    project_id: ""
+```
+
+---
+
+## Secret Injection
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `secretInjection.adapter` | `...InMemorySecretInjectionAdapter` | Secret injection adapter class |
+| `secretInjection.kwargs` | `{}` | Adapter constructor kwargs |
+| `secretInjection.secretKwargs` | `[]` | Kwargs from K8s secrets |
+
+InMemory (development, no-op):
+
+```yaml
+secretInjection:
+  adapter: "volundr.adapters.outbound.memory_secret_injection.InMemorySecretInjectionAdapter"
+```
+
+Infisical CSI:
+
+```yaml
+secretInjection:
+  adapter: "volundr.adapters.outbound.infisical_secret_injection.InfisicalCSISecretInjectionAdapter"
+  kwargs:
+    infisical_url: "https://infisical.example.com"
+```
+
+---
+
+## Storage
+
+### PVCs
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `storage.sessions.enabled` | `true` | Enable sessions PVC |
+| `storage.sessions.storageClass` | `longhorn` | Storage class |
+| `storage.sessions.accessMode` | `ReadWriteMany` | Access mode (must be RWX) |
+| `storage.sessions.size` | `1Gi` | PVC size |
+| `storage.sessions.mountPath` | `/volundr/sessions` | Mount path |
+| `storage.home.enabled` | `true` | Enable home PVC |
+| `storage.home.storageClass` | `longhorn` | Storage class |
+| `storage.home.accessMode` | `ReadWriteMany` | Access mode (must be RWX) |
+| `storage.home.size` | `1Gi` | PVC size |
+| `storage.home.mountPath` | `/volundr/home` | Mount path |
+
+### Storage Adapter
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `storageAdapter.adapter` | `...InMemoryStorageAdapter` | Storage adapter class |
+| `storageAdapter.kwargs` | `{}` | Adapter constructor kwargs |
+
+Kubernetes PVC adapter:
+
+```yaml
+storageAdapter:
+  adapter: "volundr.adapters.outbound.k8s_storage_adapter.K8sStorageAdapter"
+  kwargs:
+    namespace: "skuld"
+    home_storage_class: "longhorn"
+    workspace_storage_class: "longhorn"
+    workspace_size_gb: 2
+```
+
+---
+
+## Resource Provider
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `resourceProvider.adapter` | `...StaticResourceProvider` | Resource provider adapter class |
+| `resourceProvider.kwargs` | `{}` | Adapter constructor kwargs |
+
+Static (default):
+
+```yaml
+resourceProvider:
+  adapter: "volundr.adapters.outbound.static_resource_provider.StaticResourceProvider"
+```
+
+Kubernetes device-plugin (GPU discovery):
+
+```yaml
+resourceProvider:
+  adapter: "volundr.adapters.outbound.k8s_resource_provider.K8sResourceProvider"
+  kwargs:
+    namespace: "volundr-sessions"
+```
+
+---
+
+## Gateway
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `gateway.adapter` | `...InMemoryGatewayAdapter` | Gateway adapter class |
+| `gateway.kwargs` | `{}` | Adapter constructor kwargs |
+
+Kubernetes Gateway API:
+
+```yaml
+gateway:
+  adapter: "volundr.adapters.outbound.k8s_gateway.K8sGatewayAdapter"
+  kwargs:
+    namespace: "volundr"
+    gateway_name: "volundr-gateway"
+    gateway_namespace: "volundr"
+    gateway_domain: "sessions.valhalla.asgard.niuu.world"
+    issuer_url: "https://idp.example.com"
+    audience: "volundr"
+    jwks_uri: "https://idp.example.com/.well-known/jwks"
+```
+
+### Session Gateway Resource
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `sessionGateway.enabled` | `false` | Enable shared Gateway resource |
+| `sessionGateway.name` | `volundr-gateway` | Gateway resource name |
+| `sessionGateway.gatewayClassName` | `eg` | GatewayClass (Envoy Gateway default) |
+| `sessionGateway.hostname` | `sessions.valhalla.asgard.niuu.world` | HTTPS listener hostname |
+| `sessionGateway.certIssuer` | `letsencrypt-prod` | cert-manager ClusterIssuer |
+| `sessionGateway.tlsSecretName` | `""` | TLS secret name |
+| `sessionGateway.allowedRouteNamespaces` | `All` | Namespace scope for HTTPRoutes |
+| `sessionGateway.httpRedirect` | `true` | HTTP to HTTPS redirect |
+| `sessionGateway.annotations` | `{}` | Extra annotations |
+
+---
+
+## Session Contributors
+
+Pipeline of contributors that assemble session specs before submission. Runs sequentially in config order. Cleanup runs in reverse.
+
+```yaml
+sessionContributors:
+  - adapter: "volundr.adapters.outbound.contributors.core.CoreSessionContributor"
+    kwargs:
+      base_domain: "skuld.valhalla.asgard.niuu.world"
+      ingress_enabled: true
+  - adapter: "volundr.adapters.outbound.contributors.template.TemplateContributor"
+    kwargs: {}
+  - adapter: "volundr.adapters.outbound.contributors.git.GitContributor"
+    kwargs: {}
+  - adapter: "volundr.adapters.outbound.contributors.integrations.IntegrationContributor"
+    kwargs: {}
+  - adapter: "volundr.adapters.outbound.contributors.storage.StorageContributor"
+    kwargs:
+      home_enabled: true
+  - adapter: "volundr.adapters.outbound.contributors.gateway.GatewayContributor"
+    kwargs: {}
+  - adapter: "volundr.adapters.outbound.contributors.resource.ResourceContributor"
+    kwargs: {}
+  - adapter: "volundr.adapters.outbound.contributors.isolation.IsolationContributor"
+    kwargs: {}
+  - adapter: "volundr.adapters.outbound.contributors.secrets.SecretInjectionContributor"
+    kwargs: {}
+  - adapter: "volundr.adapters.outbound.contributors.secrets.SecretsContributor"
+    kwargs: {}
+```
+
+Each entry also supports `secretKwargs` for injecting values from K8s secrets.
+
+---
+
+## Session Definitions
+
+Define session types (FarmSessionDefinition CRs).
+
+### skuld-claude
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `sessionDefinitions.skuldClaude.enabled` | `true` | Enable Claude session definition |
+| `sessionDefinitions.skuldClaude.labels` | `[session]` | Agent routing labels |
+| `sessionDefinitions.skuldClaude.active` | `true` | Whether definition is active |
+| `sessionDefinitions.skuldClaude.helm.chart` | `skuld` | Chart name |
+| `sessionDefinitions.skuldClaude.helm.repo` | `oci://ghcr.io/niuulabs/charts` | Chart repository |
+| `sessionDefinitions.skuldClaude.helm.version` | `0.1.0` | Chart version |
+
+Default session values:
+
+| Key | Default |
+|-----|---------|
+| `defaults.session.model` | `claude-sonnet-4-20250514` |
+| `defaults.broker.cliType` | `claude` |
+| `defaults.broker.transport` | `sdk` |
+| `defaults.broker.skipPermissions` | `true` |
+| `defaults.broker.agentTeams` | `false` |
+| `defaults.image.repository` | `ghcr.io/niuulabs/skuld` |
+| `defaults.image.tag` | `latest` |
+| `defaults.resources.requests.memory` | `256Mi` |
+| `defaults.resources.requests.cpu` | `100m` |
+| `defaults.resources.limits.memory` | `1Gi` |
+| `defaults.resources.limits.cpu` | `500m` |
+| `defaults.codeServer.enabled` | `true` |
+| `defaults.persistence.mountPath` | `/volundr/sessions` |
+| `defaults.homeVolume.enabled` | `true` |
+| `defaults.securityContext.runAsNonRoot` | `true` |
+| `defaults.securityContext.runAsUser` | `1000` |
+
+### skuld-codex
+
+Same structure as skuld-claude with different defaults:
+
+| Key | Default |
+|-----|---------|
+| `sessionDefinitions.skuldCodex.enabled` | `false` |
+| `defaults.session.model` | `o4-mini` |
+| `defaults.broker.cliType` | `codex` |
+| `defaults.broker.transport` | `subprocess` |
+| `defaults.image.repository` | `ghcr.io/niuulabs/skuld-codex` |
+
+---
+
+## Auth Discovery
+
+Public endpoint for CLI auto-configuration.
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `authDiscovery.issuer` | `""` | OIDC issuer URL (falls back to gateway issuer) |
+| `authDiscovery.cliClientId` | `volundr-cli` | OIDC client ID for CLI |
+| `authDiscovery.scopes` | `openid profile email` | OIDC scopes |
+
+---
+
+## Web UI
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `web.enabled` | `false` | Enable web UI |
+| `web.replicaCount` | `1` | Web UI replicas |
+| `web.image.registry` | `ghcr.io` | Web image registry |
+| `web.image.repository` | `niuulabs/volundr-web` | Web image repository |
+| `web.image.tag` | `""` | Web image tag |
+| `web.service.type` | `ClusterIP` | Web service type |
+| `web.service.port` | `80` | Web service port |
+| `web.ingress.enabled` | `false` | Enable web ingress |
+| `web.config.apiBaseUrl` | `""` | API URL (auto-wired if empty) |
+| `web.config.oidc.authority` | `""` | OIDC discovery URL |
+| `web.config.oidc.clientId` | `""` | OIDC client ID |
+| `web.config.oidc.scope` | `openid profile email` | OIDC scopes |
+
+---
+
+## Chronicle
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `chronicle.autoCreateOnStop` | `true` | Auto-create chronicle on session stop |
+| `chronicle.summaryModel` | `claude-haiku-4-5-20251001` | Model for summaries |
+| `chronicle.summaryMaxTokens` | `2000` | Max tokens for summaries |
+| `chronicle.retentionDays` | `0` | Retention period (0 = forever) |
+
+---
+
+## Application Config
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `config.logLevel` | `info` | Log level (debug, info, warning, error) |
+| `config.logFormat` | `json` | Log format (json, text) |
+| `config.host` | `0.0.0.0` | Bind host |
+| `config.workers` | `4` | Uvicorn workers |
+| `config.sessionTimeout` | `3600` | Session timeout in seconds |
+| `config.maxSessionsPerUser` | `5` | Max sessions per user |
+| `config.corsOrigins` | `*` | CORS allowed origins |
+| `config.corsAllowCredentials` | `true` | CORS allow credentials |
+
+---
+
+## Scaling and Availability
+
+### Autoscaling
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `autoscaling.enabled` | `false` | Enable HPA |
+| `autoscaling.minReplicas` | `1` | Minimum replicas |
+| `autoscaling.maxReplicas` | `10` | Maximum replicas |
+| `autoscaling.targetCPUUtilizationPercentage` | `80` | CPU target |
+| `autoscaling.targetMemoryUtilizationPercentage` | `""` | Memory target |
+| `autoscaling.customMetrics` | `[]` | Custom metrics |
+| `autoscaling.behavior` | `{}` | Scaling behavior |
+
+### Pod Disruption Budget
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `podDisruptionBudget.enabled` | `false` | Enable PDB |
+| `podDisruptionBudget.minAvailable` | `1` | Min available pods |
+| `podDisruptionBudget.maxUnavailable` | `""` | Max unavailable pods |
+
+---
+
+## Resources
+
+API backend:
+
+```yaml
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+```
+
+---
+
+## Security
+
+### Pod Security Context
+
+```yaml
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+```
+
+### Container Security Context
+
+```yaml
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
+  capabilities:
+    drop:
+      - ALL
+```
+
+### Network Policy
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `networkPolicy.enabled` | `false` | Enable NetworkPolicy |
+| `networkPolicy.ingressFrom` | `[]` | Ingress selectors |
+| `networkPolicy.databasePodSelector` | `{}` | DB pod selector for egress |
+| `networkPolicy.farmPodSelector` | `{}` | Farm pod selector for egress |
+| `networkPolicy.extraIngress` | `[]` | Extra ingress rules |
+| `networkPolicy.extraEgress` | `[]` | Extra egress rules |
+
+---
+
+## Scheduling
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `nodeSelector` | `{}` | Node selector |
+| `tolerations` | `[]` | Tolerations |
+| `affinity` | `{}` | Affinity rules |
+| `topologySpreadConstraints` | `[]` | Topology spread |
+| `priorityClassName` | `""` | Priority class |
+| `terminationGracePeriodSeconds` | `30` | Graceful shutdown timeout |
+
+---
+
+## Integrations
+
+Define integrations available for users to attach to sessions.
+
+```yaml
+integrations:
+  definitions:
+    - slug: linear
+      name: Linear
+      description: "Linear issue tracker integration"
+      integration_type: issue_tracker
+      adapter: "volundr.adapters.outbound.integrations.linear.LinearAdapter"
+      icon: "linear"
+      credential_schema:
+        api_key:
+          type: string
+          required: true
+          description: "Linear API key"
+      mcp_server:
+        name: linear
+        command: mcp-server-linear
+        args: []
+        env_from_credentials:
+          LINEAR_API_KEY: api_key
+```
+
+---
+
+## Migrations
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `migrations.enabled` | `true` | Run migrations via init container |
+| `migrations.image.repository` | `migrate/migrate` | Migration image |
+| `migrations.image.tag` | `v4.17.0` | Migration version |
+
+---
+
+## Existing Secrets
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `existingSecrets.anthropic` | `volundr-anthropic-api` | Secret with `ANTHROPIC_API_KEY` |

--- a/docs/site/installation/kubernetes.md
+++ b/docs/site/installation/kubernetes.md
@@ -1,0 +1,186 @@
+# Production Kubernetes
+
+For teams running Volundr on an existing Kubernetes cluster.
+
+---
+
+## Cluster Requirements
+
+- Kubernetes 1.24+
+- Ingress controller (nginx, Traefik, HAProxy, or Gateway API)
+- Storage class with ReadWriteMany support (Longhorn, NFS, EFS, etc.)
+- External PostgreSQL 12+ (recommended over in-cluster)
+
+## Optional Cluster Components
+
+- **cert-manager** -- automatic TLS certificate provisioning
+- **Envoy Gateway** -- Gateway API-based routing with JWT validation
+- **Kyverno** -- PVC isolation policies
+- **External DNS** -- automatic DNS record management
+
+---
+
+## Step 1: Namespace and Secrets
+
+```bash
+kubectl create namespace volundr
+
+# Anthropic API key
+kubectl create secret generic volundr-anthropic-api \
+  -n volundr \
+  --from-literal=ANTHROPIC_API_KEY=sk-ant-xxx
+
+# Database credentials
+kubectl create secret generic volundr-db \
+  -n volundr \
+  --from-literal=username=volundr \
+  --from-literal=password=<your-db-password>
+
+# GitHub token (optional)
+kubectl create secret generic github-token \
+  -n volundr \
+  --from-literal=token=ghp_xxx
+```
+
+---
+
+## Step 2: Database
+
+Use an external PostgreSQL instance. Cloud-managed databases (RDS, Cloud SQL, Azure Database) are recommended for production.
+
+```yaml
+# values-production.yaml
+database:
+  external:
+    enabled: true
+    host: postgres.example.com
+    port: 5432
+  existingSecret: volundr-db
+```
+
+---
+
+## Step 3: Identity and Authorization
+
+Configure OIDC via the Envoy sidecar:
+
+```yaml
+envoy:
+  enabled: true
+  jwt:
+    enabled: true
+    issuer: "https://keycloak.example.com/realms/volundr"
+    audiences:
+      - volundr
+    jwksUri: "https://keycloak.example.com/realms/volundr/protocol/openid-connect/certs"
+    keycloakHost: keycloak.default.svc.cluster.local
+    keycloakPort: 8080
+
+identity:
+  adapter: "volundr.adapters.outbound.identity.EnvoyHeaderIdentityAdapter"
+  kwargs:
+    user_id_header: "x-auth-user-id"
+    email_header: "x-auth-email"
+
+authorization:
+  adapter: "volundr.adapters.outbound.authorization.SimpleRoleAuthorizationAdapter"
+```
+
+The Envoy sidecar validates JWTs and extracts claims into trusted headers. The identity adapter reads those headers. No custom auth code needed.
+
+---
+
+## Step 4: Storage
+
+```yaml
+storage:
+  sessions:
+    enabled: true
+    storageClass: longhorn  # or your RWX storage class
+    accessMode: ReadWriteMany
+    size: 10Gi
+  home:
+    enabled: true
+    storageClass: longhorn
+    accessMode: ReadWriteMany
+    size: 5Gi
+```
+
+Sessions and home directories are shared between the API server and session pods. ReadWriteMany is required.
+
+---
+
+## Step 5: Ingress
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+  hosts:
+    - host: volundr.example.com
+      paths:
+        - path: /api/v1/volundr
+          pathType: Prefix
+  tls:
+    - secretName: volundr-tls
+      hosts:
+        - volundr.example.com
+```
+
+Long timeouts are needed for SSE streams and WebSocket connections to session pods.
+
+---
+
+## Step 6: Deploy
+
+```bash
+helm install volundr oci://ghcr.io/niuulabs/charts/volundr \
+  -n volundr --create-namespace \
+  -f values-production.yaml
+```
+
+---
+
+## Step 7: Verify
+
+```bash
+kubectl get pods -n volundr
+kubectl logs -n volundr deployment/volundr
+curl https://volundr.example.com/health
+```
+
+---
+
+## Web UI
+
+Deploy the web frontend alongside the API:
+
+```yaml
+web:
+  enabled: true
+  ingress:
+    enabled: true
+    hosts:
+      - host: volundr.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+  config:
+    oidc:
+      authority: "https://keycloak.example.com/realms/volundr"
+      clientId: "volundr-web"
+```
+
+The web UI and API share the same domain. The API is served at `/api/v1/volundr`, the UI at `/`.
+
+---
+
+## Scaling
+
+- **API** is stateless. Use HPA to scale horizontally.
+- **SSE connections** are per-instance (in-memory broadcaster). Use sticky sessions or a single replica for SSE, or consider external pub/sub for multi-replica SSE.
+- **Skuld brokers** scale with session count (one per session).
+- **Database pool size** should match total connections across all API replicas. Default: `minPoolSize: 5`, `maxPoolSize: 20` per replica.

--- a/docs/site/installation/kubernetes.md
+++ b/docs/site/installation/kubernetes.md
@@ -46,14 +46,45 @@ kubectl create secret generic github-token \
 
 ## Step 2: Database
 
-Use an external PostgreSQL instance. Cloud-managed databases (RDS, Cloud SQL, Azure Database) are recommended for production.
+Use a dedicated PostgreSQL instance. For production, the [CloudNativePG](https://cloudnative-pg.io/) operator (CNCF project) is the recommended way to run PostgreSQL on Kubernetes.
+
+```bash
+# Install CloudNativePG operator
+kubectl apply --server-side -f \
+  https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.25/releases/cnpg-1.25.1.yaml
+```
+
+Create a PostgreSQL cluster:
+
+```yaml
+# postgres-cluster.yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: volundr-pg
+  namespace: volundr
+spec:
+  instances: 2
+  storage:
+    size: 10Gi
+  bootstrap:
+    initdb:
+      database: volundr
+      owner: volundr
+```
+
+```bash
+kubectl apply -f postgres-cluster.yaml
+```
+
+Then point Volundr at it:
 
 ```yaml
 # values-production.yaml
 database:
   external:
     enabled: true
-    host: postgres.example.com
+    host: volundr-pg-rw.volundr.svc.cluster.local
     port: 5432
   existingSecret: volundr-db
 ```

--- a/docs/site/installation/local-k3d.md
+++ b/docs/site/installation/local-k3d.md
@@ -1,0 +1,119 @@
+# Local Development (k3d)
+
+k3d runs a lightweight k3s cluster inside Docker containers. Full Kubernetes, no VM overhead. Good for testing Helm values before deploying to a real cluster.
+
+---
+
+## Prerequisites
+
+```bash
+# Docker
+docker info
+
+# k3d
+k3d version
+# Install: curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
+
+# kubectl
+kubectl version --client
+
+# Helm
+helm version
+```
+
+---
+
+## Create Cluster
+
+```bash
+k3d cluster create volundr \
+  --port "8080:80@loadbalancer" \
+  --port "8443:443@loadbalancer"
+```
+
+This maps port 8080 on your machine to the cluster's ingress controller.
+
+---
+
+## Create Namespace and Secrets
+
+```bash
+kubectl create namespace volundr
+
+# Anthropic API key
+kubectl create secret generic volundr-anthropic-api \
+  -n volundr \
+  --from-literal=ANTHROPIC_API_KEY=sk-ant-xxx
+
+# Database credentials
+kubectl create secret generic volundr-db \
+  -n volundr \
+  --from-literal=username=volundr \
+  --from-literal=password=volundr
+
+# GitHub token (optional)
+kubectl create secret generic github-token \
+  -n volundr \
+  --from-literal=token=ghp_xxx
+```
+
+---
+
+## Deploy PostgreSQL
+
+In-cluster PostgreSQL for development:
+
+```bash
+helm install postgresql oci://registry-1.docker.io/bitnamicharts/postgresql \
+  -n volundr \
+  --set auth.username=volundr \
+  --set auth.password=volundr \
+  --set auth.database=volundr
+```
+
+---
+
+## Deploy Volundr
+
+```bash
+helm install volundr oci://ghcr.io/niuulabs/charts/volundr \
+  -n volundr \
+  --set database.external.host=postgresql.volundr.svc.cluster.local \
+  --set database.existingSecret=volundr-db \
+  --set ingress.enabled=true \
+  --set ingress.hosts[0].host=localhost \
+  --set ingress.hosts[0].paths[0].path=/api/v1/volundr \
+  --set ingress.hosts[0].paths[0].pathType=Prefix
+```
+
+---
+
+## Verify
+
+```bash
+kubectl get pods -n volundr
+curl http://localhost:8080/health
+```
+
+Both the API pod and PostgreSQL pod should be `Running`. The health endpoint returns 200 when the API is ready.
+
+---
+
+## What You Get
+
+Full Kubernetes deployment with sessions, pods, PVCs -- identical to production. The same Helm chart, same container images, same session lifecycle.
+
+## What's Different from Production
+
+- No TLS
+- No OIDC (uses `AllowAllIdentityAdapter`)
+- In-cluster PostgreSQL (not managed/external)
+- No persistent storage class (uses k3d's built-in local-path)
+
+---
+
+## Cleanup
+
+```bash
+k3d cluster delete volundr
+```

--- a/docs/site/installation/overview.md
+++ b/docs/site/installation/overview.md
@@ -1,0 +1,70 @@
+# Installation Overview
+
+Pick the path that matches your goal.
+
+| Goal | Path | Time |
+|------|------|------|
+| Try it out locally | CLI (`volundr init && volundr up`) | 5 min |
+| Local Kubernetes | [k3d cluster + Helm](local-k3d.md) | 15 min |
+| Single-node server (DGX Spark, homelab) | [k3s + Helm](single-node.md) | 20 min |
+| Team / production | [Kubernetes cluster + Helm](kubernetes.md) | 30 min |
+
+All Helm-based paths use the same chart. The difference is cluster setup and values.
+
+---
+
+## Prerequisites by Path
+
+### CLI Local
+
+- `volundr` binary
+- Anthropic API key
+
+### k3d (Local Kubernetes)
+
+- Docker
+- k3d
+- kubectl
+- Helm
+- Anthropic API key
+
+### Single-Node (k3s)
+
+- Linux server (4+ GB RAM recommended)
+- k3s
+- kubectl
+- Helm
+- Anthropic API key
+- PostgreSQL (in-cluster or external)
+
+### Production Kubernetes
+
+- Kubernetes 1.24+ cluster
+- Helm 3.8+
+- Storage class with ReadWriteMany support
+- PostgreSQL 12+ (external recommended)
+- Ingress controller (nginx, Traefik, etc.)
+- Anthropic API key
+- Optional: cert-manager, Gateway API controller, OIDC identity provider
+
+---
+
+## Hardware Requirements
+
+| Component | RAM | CPU |
+|-----------|-----|-----|
+| API server | 256Mi -- 1Gi | 100m -- 1000m |
+| Per session pod (Skuld + code-server + terminal) | 256Mi -- 3Gi | 100m -- 1500m |
+| PostgreSQL | 256Mi+ | 100m+ |
+
+**Storage:** RWX volume for shared sessions. 1Gi minimum recommended. Grows with the number of concurrent sessions and repository sizes.
+
+---
+
+## Next Steps
+
+- [Local Development (k3d)](local-k3d.md) -- full Kubernetes on your laptop
+- [Single-Node Deployment (k3s)](single-node.md) -- DGX Spark, homelab, bare metal
+- [Production Kubernetes](kubernetes.md) -- team clusters with OIDC and TLS
+- [Helm Values Reference](helm-reference.md) -- every configurable value
+- [Production Checklist](production.md) -- go-live readiness

--- a/docs/site/installation/production.md
+++ b/docs/site/installation/production.md
@@ -1,0 +1,64 @@
+# Production Checklist
+
+Use this checklist before going live. Items are grouped by priority.
+
+---
+
+## Required
+
+- [ ] External PostgreSQL provisioned and accessible from the cluster
+- [ ] Database migrations applied (enabled by default via init container)
+- [ ] Database credentials stored in a Kubernetes secret (`volundr-db`)
+- [ ] Anthropic API key stored in a Kubernetes secret (`volundr-anthropic-api`)
+- [ ] Ingress configured with TLS termination
+- [ ] Identity adapter set to `EnvoyHeaderIdentityAdapter` (not `AllowAll`)
+- [ ] Authorization adapter set to `SimpleRoleAuthorizationAdapter` or `CerbosAuthorizationAdapter`
+- [ ] Storage class supports ReadWriteMany for sessions and home PVCs
+
+---
+
+## Security
+
+- [ ] OIDC/OAuth2 configured via Envoy sidecar with JWT validation
+- [ ] Gateway API security policies enforce JWT validation on session routes
+- [ ] Credential store uses Vault or Infisical (not in-memory)
+- [ ] Secret injection uses CSI driver (not in-memory)
+- [ ] Git tokens stored in Kubernetes secrets, referenced by `existingSecret`
+- [ ] Pod security context enforces `runAsNonRoot`, drops all capabilities
+- [ ] Container runs with read-only root filesystem
+- [ ] CORS origins restricted to your domain (not `*`)
+
+---
+
+## Recommended
+
+- [ ] HPA enabled with appropriate min/max replicas
+- [ ] PDB configured to maintain availability during rollouts
+- [ ] NetworkPolicy restricting pod-to-pod traffic
+- [ ] Resource requests and limits set for API and session pods
+- [ ] Kyverno PVC isolation policy applied (prevents cross-session access)
+- [ ] Log format set to `json` for structured logging
+- [ ] Database pool size tuned for replica count (`maxPoolSize * replicaCount <= max_connections`)
+
+---
+
+## Monitoring
+
+Volundr exposes the following endpoints:
+
+| Endpoint | Purpose |
+|----------|---------|
+| `/health` | Liveness and readiness probes |
+| `/api/v1/volundr/sessions/stream` | SSE stream for real-time session state |
+| `/api/v1/volundr/events/health` | Event pipeline and sink status |
+
+OpenTelemetry traces and metrics are available when an OTel collector is configured.
+
+---
+
+## Scaling
+
+- **API** is stateless. Scale horizontally via HPA.
+- **SSE connections** are per-instance (in-memory broadcaster). Use sticky sessions or a single replica for SSE. For multi-replica SSE, add an external pub/sub layer.
+- **Skuld brokers** run one-per-session. They scale with session count.
+- **Database pool size** should account for all replicas: `maxPoolSize * replicaCount` must not exceed PostgreSQL `max_connections`.

--- a/docs/site/installation/single-node.md
+++ b/docs/site/installation/single-node.md
@@ -1,0 +1,168 @@
+# Single-Node Deployment (k3s)
+
+For DGX Spark, homelab servers, or any single Linux machine. k3s is a production-grade Kubernetes distribution that runs as a single binary.
+
+---
+
+## Install k3s
+
+```bash
+curl -sfL https://get.k3s.io | sh -
+# Verify
+sudo kubectl get nodes
+```
+
+k3s bundles Traefik ingress controller and local-path storage provisioner by default.
+
+---
+
+## Set Up Kubeconfig
+
+```bash
+mkdir -p ~/.kube
+sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
+sudo chown $USER:$USER ~/.kube/config
+kubectl get nodes
+```
+
+---
+
+## Create Namespace and Secrets
+
+```bash
+kubectl create namespace volundr
+
+# Anthropic API key
+kubectl create secret generic volundr-anthropic-api \
+  -n volundr \
+  --from-literal=ANTHROPIC_API_KEY=sk-ant-xxx
+
+# Database credentials
+kubectl create secret generic volundr-db \
+  -n volundr \
+  --from-literal=username=volundr \
+  --from-literal=password=volundr
+
+# GitHub token (optional)
+kubectl create secret generic github-token \
+  -n volundr \
+  --from-literal=token=ghp_xxx
+```
+
+---
+
+## Storage
+
+The k3s default `local-path` provisioner works for single-node. For production durability, consider Longhorn:
+
+```bash
+helm install longhorn longhorn/longhorn -n longhorn-system --create-namespace
+```
+
+Then set `storage.sessions.storageClass: longhorn` and `storage.home.storageClass: longhorn` in your values.
+
+---
+
+## Deploy PostgreSQL
+
+In-cluster for simplicity, or use an external instance for durability:
+
+```bash
+helm install postgresql oci://registry-1.docker.io/bitnamicharts/postgresql \
+  -n volundr \
+  --set auth.username=volundr \
+  --set auth.password=volundr \
+  --set auth.database=volundr
+```
+
+---
+
+## Deploy Volundr
+
+```bash
+helm install volundr oci://ghcr.io/niuulabs/charts/volundr \
+  -n volundr --create-namespace \
+  --set database.external.host=postgresql.volundr.svc.cluster.local \
+  --set database.existingSecret=volundr-db \
+  --set ingress.enabled=true \
+  --set ingress.className=traefik \
+  --set ingress.hosts[0].host=volundr.local \
+  --set ingress.hosts[0].paths[0].path=/api/v1/volundr \
+  --set ingress.hosts[0].paths[0].pathType=Prefix \
+  --set storage.sessions.storageClass=local-path \
+  --set storage.home.storageClass=local-path
+```
+
+---
+
+## GPU Passthrough (DGX Spark / NVIDIA)
+
+Install the NVIDIA device plugin:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.14.1/nvidia-device-plugin.yml
+```
+
+Verify the GPU is detected:
+
+```bash
+kubectl get nodes -o jsonpath='{.items[0].status.allocatable}' | jq '.["nvidia.com/gpu"]'
+```
+
+Create a GPU profile in your Helm values:
+
+```yaml
+profiles:
+  - name: gpu-heavy
+    description: "GPU-accelerated session"
+    workloadType: session
+    model: "claude-sonnet-4-20250514"
+    resourceConfig:
+      cpu: "2"
+      memory: "8Gi"
+      gpu: "1"
+    isDefault: false
+```
+
+---
+
+## DNS
+
+Add `volundr.local` to `/etc/hosts` pointing to your server IP:
+
+```
+192.168.1.100  volundr.local
+```
+
+Or use a real domain with DNS pointing to the server.
+
+---
+
+## TLS
+
+For TLS, install cert-manager and add TLS configuration to ingress:
+
+```bash
+helm install cert-manager jetstack/cert-manager \
+  -n cert-manager --create-namespace \
+  --set crds.enabled=true
+```
+
+Then add to your Helm values:
+
+```yaml
+ingress:
+  tls:
+    - secretName: volundr-tls
+      hosts:
+        - volundr.example.com
+```
+
+---
+
+## Verify
+
+```bash
+kubectl get pods -n volundr
+curl http://volundr.local/health
+```

--- a/docs/site/setup/agent-guide.md
+++ b/docs/site/setup/agent-guide.md
@@ -1,0 +1,466 @@
+# AI-Agent Setup Guide
+
+This guide is designed for AI coding agents (Claude Code, OpenClaw, etc.) to follow
+step-by-step when deploying Volundr. Every step includes a command and expected output
+so an agent can verify success before proceeding.
+
+---
+
+## Phase 0: Prerequisites
+
+Verify that each required tool is available before continuing.
+
+| Tool | Check command | Install |
+|------|--------------|---------|
+| kubectl | `kubectl version --client` | See k3s install or cloud provider docs |
+| helm | `helm version` | `curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 \| bash` |
+| k3s (single-node) | `k3s --version` | `curl -sfL https://get.k3s.io \| sh -` |
+| PostgreSQL client | `psql --version` | `apt install postgresql-client` or `brew install postgresql` |
+
+Run each check command. If a tool is missing, use the install command. k3s is only
+required for single-node deployments.
+
+---
+
+## Phase 1: Gather Information
+
+Before starting, the agent should ask the operator these questions:
+
+```
+1. DEPLOYMENT TARGET: Where will Volundr run?
+   - [ ] Single machine (k3s) → Phase 2A
+   - [ ] Existing Kubernetes cluster → Phase 2B
+
+2. DOMAIN: What domain/hostname?
+   Default: volundr.local
+   Used in: ingress.hosts[0].host, sessionContributors[0].kwargs.base_domain
+
+3. DATABASE: PostgreSQL setup?
+   - [ ] Deploy in-cluster (simple, not production-grade)
+   - [ ] External database (provide: host, port, user, password, name)
+
+4. ANTHROPIC API KEY: Required for Claude Code sessions.
+   Value: sk-ant-...
+
+5. GIT PROVIDER: Which providers?
+   - [ ] GitHub (provide: token, orgs)
+   - [ ] GitLab (provide: token, groups)
+   - [ ] Both
+   - [ ] None (skip git integration)
+
+6. STORAGE CLASS: What RWX storage class is available?
+   k3s default: local-path
+   Production: longhorn, nfs, efs, etc.
+
+7. AUTH: Identity provider?
+   - [ ] None (AllowAll for dev/testing)
+   - [ ] OIDC (provide: issuer URL, client ID, JWKS URI)
+
+8. TLS: Need HTTPS?
+   - [ ] No (local/dev)
+   - [ ] Yes (provide: cert-manager issuer or TLS secret name)
+
+9. GPU: GPU workloads needed?
+   - [ ] No
+   - [ ] Yes (provide: GPU type, e.g., nvidia.com/gpu)
+```
+
+Record all answers before continuing. They are used to generate the Helm values file
+in Phase 5.
+
+---
+
+## Phase 2A: Single-Node Setup (k3s)
+
+Use this phase when deploying to a single machine.
+
+### Step 1: Install k3s
+
+```bash
+curl -sfL https://get.k3s.io | sh -
+```
+
+Expected output:
+
+```
+[INFO]  systemd: Starting k3s
+```
+
+### Step 2: Configure kubeconfig
+
+```bash
+mkdir -p ~/.kube
+sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
+sudo chown $(id -u):$(id -g) ~/.kube/config
+```
+
+### Step 3: Verify cluster
+
+```bash
+kubectl get nodes
+```
+
+Expected output:
+
+```
+NAME     STATUS   ROLES                  AGE   VERSION
+<host>   Ready    control-plane,master   <age> v1.x.x+k3s1
+```
+
+Proceed to Phase 3.
+
+---
+
+## Phase 2B: Existing Cluster Setup
+
+Use this phase when deploying to an existing Kubernetes cluster. Skip k3s installation.
+
+### Step 1: Verify cluster access
+
+```bash
+kubectl cluster-info
+```
+
+Expected output:
+
+```
+Kubernetes control plane is running at https://<api-server>
+```
+
+### Step 2: Verify node readiness
+
+```bash
+kubectl get nodes
+```
+
+Expected: all nodes show `STATUS=Ready`.
+
+Proceed to Phase 3.
+
+---
+
+## Phase 3: Create Secrets
+
+### Step 1: Create namespace
+
+```bash
+kubectl create namespace volundr
+```
+
+Expected output:
+
+```
+namespace/volundr created
+```
+
+### Step 2: Create Anthropic API key secret
+
+```bash
+kubectl create secret generic volundr-anthropic-api \
+  -n volundr \
+  --from-literal=ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+```
+
+Expected output:
+
+```
+secret/volundr-anthropic-api created
+```
+
+### Step 3: Create database credentials secret
+
+```bash
+kubectl create secret generic volundr-db \
+  -n volundr \
+  --from-literal=username=volundr \
+  --from-literal=password=${DB_PASSWORD}
+```
+
+Expected output:
+
+```
+secret/volundr-db created
+```
+
+### Step 4: Create Git token secret (if applicable)
+
+For GitHub:
+
+```bash
+kubectl create secret generic github-token \
+  -n volundr \
+  --from-literal=token=${GITHUB_TOKEN}
+```
+
+Expected output:
+
+```
+secret/github-token created
+```
+
+For GitLab:
+
+```bash
+kubectl create secret generic gitlab-token \
+  -n volundr \
+  --from-literal=token=${GITLAB_TOKEN}
+```
+
+Expected output:
+
+```
+secret/gitlab-token created
+```
+
+Skip this step if no Git integration is needed.
+
+---
+
+## Phase 4: Database
+
+### Option A: In-cluster PostgreSQL
+
+```bash
+helm install postgresql oci://registry-1.docker.io/bitnamicharts/postgresql \
+  -n volundr \
+  --set auth.username=volundr \
+  --set auth.password=${DB_PASSWORD} \
+  --set auth.database=volundr
+```
+
+Wait for the pod to become ready (typically 60 seconds):
+
+```bash
+kubectl wait --for=condition=Ready pod/postgresql-0 -n volundr --timeout=120s
+```
+
+Verify:
+
+```bash
+kubectl get pods -n volundr
+```
+
+Expected output:
+
+```
+NAME            READY   STATUS    RESTARTS   AGE
+postgresql-0    1/1     Running   0          <age>
+```
+
+The in-cluster database host is `postgresql.volundr.svc.cluster.local`.
+
+### Option B: External PostgreSQL
+
+Verify connectivity from within the cluster:
+
+```bash
+kubectl run pg-test --rm -it --restart=Never -n volundr \
+  --image=postgres:16 -- \
+  psql "postgresql://volundr:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/volundr" -c "SELECT 1"
+```
+
+Expected: the query returns `1` and the pod terminates.
+
+---
+
+## Phase 5: Deploy Volundr
+
+### Step 1: Generate values file
+
+Create `values-generated.yaml` using the answers gathered in Phase 1. Use the
+template below, replacing `${...}` variables with actual values.
+
+```yaml
+# values-generated.yaml
+database:
+  external:
+    enabled: true
+    host: ${DB_HOST}  # postgresql.volundr.svc.cluster.local for in-cluster
+    port: 5432
+  existingSecret: volundr-db
+
+ingress:
+  enabled: true
+  className: ${INGRESS_CLASS}  # traefik for k3s, nginx for most clusters
+  hosts:
+    - host: ${DOMAIN}
+      paths:
+        - path: /api/v1/volundr
+          pathType: Prefix
+
+storage:
+  sessions:
+    storageClass: ${STORAGE_CLASS}
+  home:
+    storageClass: ${STORAGE_CLASS}
+
+# Git integration (include only the providers that are enabled)
+git:
+  github:
+    enabled: ${GITHUB_ENABLED}      # true or false
+    existingSecret: github-token
+  gitlab:
+    enabled: ${GITLAB_ENABLED}      # true or false
+    existingSecret: gitlab-token
+
+# Identity / Auth
+# Option 1: No auth (dev/testing only)
+identity:
+  adapter: "volundr.adapters.inbound.identity.allow_all.AllowAllIdentityAdapter"
+
+# Option 2: OIDC (production)
+# identity:
+#   adapter: "volundr.adapters.inbound.identity.oidc.OIDCIdentityAdapter"
+#   kwargs:
+#     issuer: "${OIDC_ISSUER}"
+#     client_id: "${OIDC_CLIENT_ID}"
+#     jwks_uri: "${OIDC_JWKS_URI}"
+
+sessionContributors:
+  - adapter: "volundr.adapters.outbound.contributors.core.CoreSessionContributor"
+    kwargs:
+      base_domain: "${DOMAIN}"
+      ingress_enabled: true
+```
+
+### Step 2: Install the Helm chart
+
+```bash
+helm install volundr oci://ghcr.io/niuulabs/charts/volundr \
+  -n volundr \
+  -f values-generated.yaml
+```
+
+### Step 3: Wait for deployment
+
+```bash
+kubectl wait --for=condition=Available deployment/volundr -n volundr --timeout=180s
+```
+
+### Step 4: Verify pods
+
+```bash
+kubectl get pods -n volundr
+```
+
+Expected output:
+
+```
+NAME                       READY   STATUS    RESTARTS   AGE
+postgresql-0               1/1     Running   0          <age>
+volundr-<hash>             1/1     Running   0          <age>
+```
+
+All pods should show `STATUS=Running` and `READY` columns should be complete
+(e.g., `1/1` or `2/2`).
+
+---
+
+## Phase 6: Verification Checklist
+
+Run each check in order. All must pass before the deployment is considered complete.
+
+### 1. All pods running
+
+```bash
+kubectl get pods -n volundr
+```
+
+Expected: all pods show `STATUS=Running`, `READY` is complete.
+
+### 2. API health check
+
+```bash
+curl -s http://${DOMAIN}/health | jq .
+```
+
+Expected output:
+
+```json
+{"status": "healthy"}
+```
+
+### 3. Migrations completed
+
+```bash
+kubectl logs -n volundr deployment/volundr -c migrate
+```
+
+Expected: no errors. Output shows `no change` or lists applied migrations.
+
+### 4. Create a test session
+
+```bash
+curl -s -X POST http://${DOMAIN}/api/v1/volundr/sessions \
+  -H "Content-Type: application/json" \
+  -d '{"name": "test-session", "model": "claude-sonnet-4-20250514"}' | jq .
+```
+
+Expected: JSON response containing a session ID and `"status": "created"`.
+
+### 5. Web UI loads (if enabled)
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" http://${DOMAIN}/
+```
+
+Expected: `200`.
+
+---
+
+## Troubleshooting
+
+### Pod stuck in Pending
+
+```bash
+kubectl describe pod <pod-name> -n volundr
+```
+
+Common causes: storage class does not exist, insufficient CPU/memory resources,
+or node selector/toleration mismatch.
+
+### CrashLoopBackOff
+
+```bash
+kubectl logs <pod-name> -n volundr
+```
+
+Common causes: database connection refused (wrong host or credentials), missing
+secret, or invalid configuration in values file.
+
+### Ingress not working
+
+```bash
+kubectl get ingress -n volundr
+kubectl describe ingress -n volundr
+```
+
+Verify the ingress class name matches the installed ingress controller. For k3s
+the default is `traefik`. Check controller logs:
+
+```bash
+# k3s / traefik
+kubectl logs -n kube-system -l app.kubernetes.io/name=traefik
+
+# nginx ingress
+kubectl logs -n ingress-nginx -l app.kubernetes.io/name=ingress-nginx
+```
+
+### Migration failed
+
+```bash
+kubectl logs <pod-name> -n volundr -c migrate
+```
+
+Common causes: database not reachable at the time the init container ran, or a
+schema conflict from a previous partial migration. Fix the underlying issue and
+delete the pod to let it restart (the migration init container will re-run).
+
+### Secret not found
+
+```bash
+kubectl get secrets -n volundr
+```
+
+Verify all required secrets exist. Re-create any missing secrets using the
+commands from Phase 3.

--- a/docs/site/setup/setup-checklist.yaml
+++ b/docs/site/setup/setup-checklist.yaml
@@ -1,0 +1,157 @@
+volundr_setup:
+  version: "1.0"
+
+  prerequisites:
+    - tool: kubectl
+      check: "kubectl version --client"
+      install_url: "https://kubernetes.io/docs/tasks/tools/"
+    - tool: helm
+      check: "helm version"
+      install: "curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash"
+    - tool: k3s
+      check: "k3s --version"
+      install: "curl -sfL https://get.k3s.io | sh -"
+      required_for: [single-node]
+    - tool: k3d
+      check: "k3d version"
+      install: "curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"
+      required_for: [local-k3d]
+
+  questions:
+    - key: deployment_target
+      question: "Where will Volundr run?"
+      options: [single-node, existing-cluster, local-k3d]
+      required: true
+    - key: domain
+      question: "What domain/hostname for Volundr?"
+      default: "volundr.local"
+      used_in:
+        - "ingress.hosts[0].host"
+        - "sessionContributors[0].kwargs.base_domain"
+    - key: database_mode
+      question: "Deploy PostgreSQL in-cluster or use external?"
+      options: [in-cluster, external]
+      default: "in-cluster"
+    - key: db_host
+      question: "External database hostname?"
+      required_when: "database_mode == external"
+      used_in: ["database.external.host"]
+    - key: db_port
+      question: "Database port?"
+      default: "5432"
+      required_when: "database_mode == external"
+    - key: db_password
+      question: "Database password?"
+      required: true
+      secret: true
+    - key: anthropic_api_key
+      question: "Anthropic API key (sk-ant-...)?"
+      required: true
+      secret: true
+      used_in: ["existingSecrets.anthropic"]
+    - key: github_enabled
+      question: "Enable GitHub integration?"
+      type: boolean
+      default: false
+    - key: github_token
+      question: "GitHub personal access token?"
+      required_when: "github_enabled == true"
+      secret: true
+    - key: github_orgs
+      question: "GitHub organizations to list repos from?"
+      type: list
+      required_when: "github_enabled == true"
+    - key: gitlab_enabled
+      question: "Enable GitLab integration?"
+      type: boolean
+      default: false
+    - key: storage_class
+      question: "Kubernetes storage class (RWX capable)?"
+      default: "local-path"
+      used_in:
+        - "storage.sessions.storageClass"
+        - "storage.home.storageClass"
+    - key: auth_mode
+      question: "Authentication mode?"
+      options: [none, oidc]
+      default: "none"
+    - key: oidc_issuer
+      question: "OIDC issuer URL?"
+      required_when: "auth_mode == oidc"
+      used_in: ["envoy.jwt.issuer"]
+    - key: oidc_client_id
+      question: "OIDC client ID?"
+      required_when: "auth_mode == oidc"
+    - key: tls_enabled
+      question: "Enable TLS?"
+      type: boolean
+      default: false
+    - key: gpu_enabled
+      question: "GPU workloads needed?"
+      type: boolean
+      default: false
+
+  phases:
+    - name: cluster-setup
+      applies_to: [single-node]
+      steps:
+        - command: "curl -sfL https://get.k3s.io | sh -"
+          description: "Install k3s"
+          verify: "kubectl get nodes"
+        - command: "mkdir -p ~/.kube && sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config && sudo chown $(id -u):$(id -g) ~/.kube/config"
+          description: "Configure kubeconfig"
+          verify: "kubectl cluster-info"
+
+    - name: namespace
+      steps:
+        - command: "kubectl create namespace volundr"
+          description: "Create Volundr namespace"
+          verify: "kubectl get namespace volundr"
+
+    - name: secrets
+      steps:
+        - command: "kubectl create secret generic volundr-anthropic-api -n volundr --from-literal=ANTHROPIC_API_KEY=${anthropic_api_key}"
+          description: "Create Anthropic API secret"
+          verify: "kubectl get secret volundr-anthropic-api -n volundr"
+        - command: "kubectl create secret generic volundr-db -n volundr --from-literal=username=volundr --from-literal=password=${db_password}"
+          description: "Create database credentials"
+          verify: "kubectl get secret volundr-db -n volundr"
+        - command: "kubectl create secret generic github-token -n volundr --from-literal=token=${github_token}"
+          description: "Create GitHub token secret"
+          when: "github_enabled == true"
+          verify: "kubectl get secret github-token -n volundr"
+
+    - name: database
+      when: "database_mode == in-cluster"
+      steps:
+        - command: "helm install postgresql oci://registry-1.docker.io/bitnamicharts/postgresql -n volundr --set auth.username=volundr --set auth.password=${db_password} --set auth.database=volundr"
+          description: "Deploy in-cluster PostgreSQL"
+          verify: "kubectl get pods -n volundr -l app.kubernetes.io/name=postgresql"
+          wait_for: "pod/postgresql-0 condition=Ready timeout=120s"
+
+    - name: deploy
+      steps:
+        - description: "Generate values file from answers"
+          template: "values-generated.yaml"
+        - command: "helm install volundr oci://ghcr.io/niuulabs/charts/volundr -n volundr -f values-generated.yaml"
+          description: "Install Volundr Helm chart"
+          verify: "kubectl get pods -n volundr -l app.kubernetes.io/name=volundr"
+          wait_for: "deployment/volundr condition=Available timeout=180s"
+
+    - name: verify
+      steps:
+        - command: "kubectl get pods -n volundr"
+          description: "Check all pods are running"
+          expect: "all pods Running"
+        - command: "curl -sf http://${domain}/health"
+          description: "Health check API endpoint"
+          expect: '{"status":"healthy"}'
+        - command: "kubectl logs -n volundr deployment/volundr -c migrate"
+          description: "Verify database migrations"
+          expect: "no errors"
+        - command: "curl -s -X POST http://${domain}/api/v1/volundr/sessions -H 'Content-Type: application/json' -d '{\"name\": \"test-session\", \"model\": \"claude-sonnet-4-20250514\"}'"
+          description: "Create a test session"
+          expect: "JSON with session ID and status created"
+        - command: "curl -s -o /dev/null -w '%{http_code}' http://${domain}/"
+          description: "Verify web UI loads"
+          expect: "200"

--- a/docs/site/user-guide/chronicles.md
+++ b/docs/site/user-guide/chronicles.md
@@ -1,0 +1,53 @@
+# Chronicles
+
+Chronicles capture the full history of a session. When a session stops, Volundr auto-creates a chronicle with everything that happened.
+
+## What a chronicle contains
+
+**Summary** — An AI-generated description of the session: what was accomplished, what approach was taken.
+
+**Key changes** — A list of the significant modifications made during the session.
+
+**Unfinished work** — Tasks the agent started but did not complete. Useful when reforging a session to continue where it left off.
+
+**Timeline** — Every event that occurred, ordered by time:
+
+- Message exchanges (with token counts)
+- File edits (insertions and deletions per file)
+- Git commits (hash, message, timestamp)
+- Terminal commands (with exit codes)
+- Errors and warnings
+
+**Config snapshot** — The session's configuration at the time: model, repo, branch, resource limits.
+
+**Token usage** — Total tokens consumed during the session.
+
+## Chronicle chains
+
+When you reforge a session (create a new session from a chronicle), the new session's chronicle links back via `parent_chronicle_id`. This creates a traceable chain of work across sessions.
+
+```
+Chronicle A (session 1)
+  └── Chronicle B (session 2, reforged from A)
+       └── Chronicle C (session 3, reforged from B)
+```
+
+Each chronicle in the chain knows its parent. You can walk the chain to see the full history of a long-running task that spanned multiple sessions.
+
+## Browsing chronicles
+
+**Web UI** — Open the Chronicles tab to browse, search, and filter chronicles.
+
+**API** — `GET /api/v1/volundr/chronicles` returns chronicles with filtering support. Filter by project, repo, model, or tags.
+
+**TUI** — The chronicles page shows a timeline view with a token burn graph — a cumulative chart of token usage over the session's lifetime.
+
+## Automatic creation
+
+Chronicles are created automatically when a session stops. You do not need to trigger this manually. The chronicle generation runs as part of the session shutdown process, so there is always a record of what happened.
+
+## Using chronicles for reforging
+
+The main use of chronicles beyond record-keeping is reforging. When you create a new session from a chronicle, the new session starts with the context of the previous one. The agent knows what was done, what is left, and where the code stands.
+
+This makes it practical to break long tasks into multiple sessions without losing context.

--- a/docs/site/user-guide/cli.md
+++ b/docs/site/user-guide/cli.md
@@ -1,0 +1,187 @@
+# CLI Reference
+
+The Volundr CLI operates in two modes: local (run everything on your machine) and remote (connect to a Volundr server). Run it without arguments to launch the interactive TUI.
+
+## Local mode
+
+Run the full Volundr stack locally for development or single-user use.
+
+### `volundr init`
+
+Interactive setup wizard. Walks you through:
+
+- Runtime selection (local, docker, k3s)
+- Anthropic API key
+- Database mode (embedded SQLite or external PostgreSQL)
+- GitHub/GitLab configuration
+
+Creates `~/.volundr/config.yaml` and stores credentials encrypted.
+
+### `volundr up`
+
+Start all services — PostgreSQL (if embedded), API server, and reverse proxy. Blocks until you hit Ctrl+C.
+
+| Flag | Description |
+|------|-------------|
+| `--runtime <runtime>` | Override the configured runtime |
+
+### `volundr down`
+
+Stop all services gracefully.
+
+### `volundr status`
+
+Print a status table showing each service's state:
+
+```
+SERVICE      STATE    PID    PORT   ERROR
+postgresql   running  1234   5432
+api-server   running  1235   8080
+proxy        running  1236   8443
+```
+
+## Remote mode
+
+Connect to a Volundr server running on Kubernetes.
+
+### Authentication
+
+#### `volundr login`
+
+Authenticate via OIDC. Opens your browser for the authorization code flow.
+
+| Flag | Description |
+|------|-------------|
+| `--issuer <url>` | OIDC issuer URL |
+| `--client-id <id>` | OIDC client ID |
+| `--device` | Use device code flow (for headless environments) |
+| `--force` | Force re-authentication even if tokens are valid |
+| `--context <name>` | Login to a specific context |
+
+#### `volundr logout`
+
+Clear stored tokens for the current context.
+
+#### `volundr whoami`
+
+Show current user info: name, email, issuer, and token expiry.
+
+### Sessions
+
+Alias: `volundr s` is shorthand for `volundr sessions`.
+
+#### `volundr sessions list`
+
+List all your sessions.
+
+#### `volundr sessions create`
+
+Create a new session.
+
+| Flag | Description |
+|------|-------------|
+| `-n, --name <name>` | Session name |
+| `-r, --repo <repo>` | Repository URL |
+| `-m, --model <model>` | AI model to use |
+| `-b, --branch <branch>` | Git branch |
+
+#### `volundr sessions start <id>`
+
+Start a stopped session.
+
+#### `volundr sessions stop <id>`
+
+Stop a running session.
+
+#### `volundr sessions delete <id>`
+
+Delete a session permanently.
+
+### Contexts
+
+Contexts let you manage connections to multiple Volundr servers.
+
+#### `volundr context add <key> --server <url>`
+
+Add a server context.
+
+| Flag | Description |
+|------|-------------|
+| `--name <name>` | Display name |
+| `--issuer <url>` | OIDC issuer URL |
+| `--client-id <id>` | OIDC client ID |
+
+#### `volundr context list`
+
+List all configured contexts.
+
+#### `volundr context remove <key>`
+
+Remove a context.
+
+#### `volundr context rename <old> <new>`
+
+Rename a context.
+
+### Config
+
+#### `volundr config get <key>`
+
+Get a config value.
+
+#### `volundr config set <key> <value>`
+
+Set a config value.
+
+### `volundr version`
+
+Print version information.
+
+## Interactive TUI
+
+Run `volundr` with no arguments (or `volundr tui`) to launch the full-screen terminal UI. Navigate between pages with keyboard shortcuts:
+
+| Page | Shortcut | Description |
+|------|----------|-------------|
+| Sessions | Alt+1 | Session list with status filters |
+| Chat | Alt+2 | Conversation with the AI agent |
+| Terminal | Alt+3 | PTY terminal with tmux-style tabs |
+| Diffs | Alt+4 | File changes and unified diffs |
+| Chronicles | Alt+5 | Timeline with token burn graph |
+| Settings | Alt+6 | Connection, credentials, integrations, appearance |
+| Admin | Alt+7 | Users, tenants, stats (admin only) |
+
+## Global flags
+
+These flags work with any command:
+
+| Flag | Description |
+|------|-------------|
+| `--home <path>` | Override config directory |
+| `--server <url>` | Override server URL |
+| `--token <token>` | Use a specific auth token |
+| `--config <path>` | Use a specific config file |
+| `--context <name>` | Use a specific context |
+| `--json` | Output as JSON for scripting |
+
+## Config files
+
+| Mode | Path | Contents |
+|------|------|----------|
+| Local | `~/.volundr/config.yaml` | Runtime settings, database config, API keys |
+| Remote | `~/.config/volundr/config.yaml` | Server contexts, auth tokens |
+
+## Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `VOLUNDR_HOME` | Override the config directory path |
+| `VOLUNDR_TUI_DEBUG=1` | Enable debug logging for the TUI |
+
+## JSON output
+
+All commands support the `--json` flag. Use it for scripting and automation:
+
+```bash
+volundr sessions list --json | jq '.[].name'
+```

--- a/docs/site/user-guide/credentials.md
+++ b/docs/site/user-guide/credentials.md
@@ -1,0 +1,35 @@
+# Credentials & Secrets
+
+Two separate systems. Don't confuse them.
+
+## Credentials
+
+Credentials are API keys, tokens, and SSH keys that **you** manage. You create them, Volundr stores them encrypted in a pluggable credential store (Vault, Infisical, or in-memory for dev).
+
+Credential types:
+
+- **API keys** — for external services (Linear, Jira, etc.)
+- **OAuth tokens** — for source control providers
+- **SSH keys** — for git access over SSH
+
+Each credential has a name, type, and encrypted data.
+
+### Using credentials in a session
+
+1. Go to **Settings > Credentials** in the web UI and store your credential.
+2. When launching a session, select which credentials to inject.
+3. The `SecretInjectionContributor` mounts them into the pod as environment variables or files.
+
+You can also manage credentials via the API or CLI.
+
+## Secrets
+
+Secrets use CSI-based injection for infrastructure-level secrets. Volundr never sees the secret values. It generates pod spec additions that tell the CSI driver (Infisical or OpenBao/Vault) what to mount and where.
+
+### The key difference
+
+**Credentials** — user-managed. You create them, Volundr stores them encrypted, and injects them into pods on your behalf.
+
+**Secrets** — infrastructure-managed. The CSI driver fetches them directly from the vault at pod startup. Volundr only knows the path — it never handles the actual secret value.
+
+Use credentials for things you control (your API keys, your tokens). Use secrets for things your platform team controls (database passwords, TLS certs, shared service accounts).

--- a/docs/site/user-guide/git-workflows.md
+++ b/docs/site/user-guide/git-workflows.md
@@ -1,0 +1,57 @@
+# Git Workflows
+
+Volundr integrates with GitHub and GitLab for branch management and pull requests.
+
+## Branch creation
+
+Sessions auto-create branches by default. Branch naming follows the `volundr/session/<name>` convention. You can disable this or change the prefix in config.
+
+## Pull requests
+
+Create PRs from sessions via the API or the web UI. The PR description is populated from the chronicle — a summary of what happened plus key changes.
+
+## Merge confidence scoring
+
+Volundr calculates a confidence score for each PR based on several factors:
+
+| Factor | Weight |
+|--------|--------|
+| Test results | 30% |
+| Change size | 20% |
+| Change category (safe vs risky) | 15% |
+| Dependency changes | 15% |
+| Coverage delta | 10% |
+| Files changed count | 10% |
+
+What happens next depends on the score:
+
+- **>= 0.9** — Auto-merge. No human needed.
+- **0.6 – 0.9** — Notify reviewers, then merge after approval window.
+- **< 0.6** — Require manual approval before merging.
+
+All thresholds are configurable.
+
+## Configuration
+
+```yaml
+git:
+  workflow:
+    auto_branch: true
+    branch_prefix: "volundr/session"
+    protect_main: true
+    default_merge_method: squash
+    auto_merge_threshold: 0.9
+    notify_merge_threshold: 0.6
+```
+
+Set `auto_branch: false` to skip automatic branch creation. Change `default_merge_method` to `merge` or `rebase` if you prefer those strategies.
+
+## Multiple git instances
+
+You can configure multiple GitHub and GitLab instances side by side. For example: github.com alongside a GitHub Enterprise instance, or gitlab.com alongside a self-hosted GitLab. Each instance gets its own token and org list.
+
+This uses the dynamic adapter pattern — each provider is a separate entry in config with its own credentials and base URL.
+
+## CI status
+
+Volundr monitors CI status on branches and factors it into the merge confidence calculation. If CI is failing, the confidence score drops accordingly.

--- a/docs/site/user-guide/integrations.md
+++ b/docs/site/user-guide/integrations.md
@@ -1,0 +1,57 @@
+# Integrations
+
+Integrations connect external services to Volundr sessions. The operator defines available integrations in config. Users attach them to sessions during launch.
+
+## How it works
+
+1. **Operator** defines integration definitions in Helm values or `config.yaml`.
+2. **Users** store their credentials for each integration (e.g., a Linear API key).
+3. When launching a session, users select which integrations to enable.
+4. The `IntegrationContributor` resolves each integration into:
+    - MCP servers injected into the session pod
+    - Environment variables sourced from credentials
+
+## Built-in integration types
+
+| Type | Examples |
+|------|----------|
+| `source_control` | GitHub, GitLab |
+| `issue_tracker` | Linear, Jira |
+| `mcp_server` | Any MCP-compatible tool |
+
+## Defining an integration
+
+Integration definitions live in config. Here's a complete example:
+
+```yaml
+integrations:
+  definitions:
+    - slug: linear
+      name: Linear
+      description: "Linear issue tracker"
+      integration_type: issue_tracker
+      adapter: "volundr.adapters.outbound.integrations.linear.LinearAdapter"
+      icon: linear
+      credential_schema:
+        api_key:
+          type: string
+          required: true
+          description: "Linear API key"
+      mcp_server:
+        name: linear
+        command: mcp-server-linear
+        args: []
+        env_from_credentials:
+          LINEAR_API_KEY: api_key
+```
+
+When a user selects this integration for a session, Volundr:
+
+1. Fetches the user's stored `api_key` credential.
+2. Starts `mcp-server-linear` in the pod with `LINEAR_API_KEY` set to the credential value.
+
+## Standalone MCP servers
+
+MCP servers can also be configured independently of integrations via the `mcp_servers` config section. These show up in the launch wizard for users to select, but don't require a full integration definition.
+
+Use standalone MCP servers for tools that don't need credentials or have simple setup requirements.

--- a/docs/site/user-guide/presets.md
+++ b/docs/site/user-guide/presets.md
@@ -1,0 +1,61 @@
+# Presets
+
+Presets are user-created, portable runtime configurations stored in the database. They let you save and reuse your preferred session setup without reconfiguring everything each time.
+
+Unlike profiles and templates (which are operator-managed and loaded from YAML config), presets belong to you and live in the database.
+
+## What a preset captures
+
+- Model selection
+- MCP server configuration
+- Resource allocation
+- Environment variables
+- CLI tool type (claude or codex)
+
+```json
+{
+  "name": "my-claude-setup",
+  "cli_tool": "claude",
+  "model": "claude-sonnet-4-20250514",
+  "mcp_servers": [
+    {
+      "name": "linear",
+      "command": "npx",
+      "args": ["-y", "@anthropic-ai/linear-mcp-server"]
+    }
+  ],
+  "env_vars": {
+    "EDITOR": "vim"
+  },
+  "is_default": true
+}
+```
+
+## Creating presets
+
+**API** — `POST /api/v1/volundr/presets` with a JSON body.
+
+**Web UI** — Save your current session configuration as a preset from the session settings panel.
+
+## Using presets
+
+When creating a session, pass `preset_id` to apply a saved configuration.
+
+Preset values merge with template and profile defaults. Where there is a conflict, the preset value takes precedence.
+
+## Default presets
+
+You can mark one preset as default per CLI tool type. When you create a new session without specifying a preset, Volundr uses your default preset for the selected tool type.
+
+Set `is_default: true` on the preset you want as your default. Setting a new default automatically clears the previous one for that tool type.
+
+## Presets vs. profiles and templates
+
+| | Presets | Profiles & Templates |
+|---|---|---|
+| **Owned by** | User | Operator |
+| **Stored in** | Database | YAML config / CRDs |
+| **Editable by users** | Yes | No |
+| **Scope** | Per-user | Platform-wide |
+
+Presets sit on top of the configuration stack. They override values from profiles and templates but do not replace them — unset fields fall through to the underlying profile or template defaults.

--- a/docs/site/user-guide/sessions.md
+++ b/docs/site/user-guide/sessions.md
@@ -1,0 +1,94 @@
+# Sessions
+
+A session is a managed, isolated environment running in a Kubernetes pod (or a Docker container when running locally). Each session contains:
+
+- An AI coding agent (Claude Code or Codex)
+- A code editor (VS Code via code-server)
+- A terminal (ttyd)
+- A shared workspace volume
+
+All containers in a session share the same workspace PVC, so the agent, editor, and terminal all see the same files.
+
+## Session states
+
+Sessions move through a defined lifecycle:
+
+```
+CREATED → STARTING → PROVISIONING → RUNNING → STOPPING → STOPPED → ARCHIVED
+```
+
+A session can also enter `FAILED` from either `PROVISIONING` or `RUNNING`.
+
+| State | Meaning |
+|-------|---------|
+| **CREATED** | Session record exists, nothing deployed yet |
+| **STARTING** | Session start requested, building pod spec |
+| **PROVISIONING** | Pod submitted to Kubernetes, waiting for containers |
+| **RUNNING** | All containers healthy, session is usable |
+| **STOPPING** | Shutdown in progress, pods being terminated |
+| **STOPPED** | Pods removed, chronicle auto-created |
+| **ARCHIVED** | Moved to archive storage, can be restored later |
+| **FAILED** | Something went wrong during provisioning or runtime |
+
+## Creating a session
+
+Two ways to create a session:
+
+**Web UI** — Use the launch wizard. Pick a template or configure manually. Set the session name, model, repository, branch, credentials, and integrations.
+
+**CLI** — Run `volundr sessions create`. Same options available as flags.
+
+You can start from a template (pre-configured blueprint) or set everything yourself: model, resource limits, repos, MCP servers, environment variables.
+
+## What happens during start
+
+When you start a session, this is what runs behind the scenes:
+
+1. The session contributor pipeline kicks in. Ten contributors build the pod spec — each one adds a piece (agent container, editor sidecar, volume mounts, credentials, etc.).
+2. The pod manager deploys the assembled pod to Kubernetes.
+3. Readiness polling begins. Volundr watches for all containers to pass their health checks.
+4. Once everything is healthy, the session status flips to `RUNNING`.
+
+If any container fails to start or crashes during provisioning, the session moves to `FAILED`.
+
+## Working in a session
+
+Once a session is running, you can:
+
+- **Chat with the AI agent** — Give it tasks, ask questions, have it write or refactor code.
+- **Use the terminal** — Run commands, install packages, run tests.
+- **Edit code in VS Code** — Full editor experience via code-server.
+- **Review diffs** — See what the agent changed before committing.
+
+Everything happens in the same workspace. The agent edits files, you see the changes in the editor, and you can run the code in the terminal.
+
+## Stopping a session
+
+Stop a session with `volundr sessions stop <id>` or click Stop in the web UI.
+
+When a session stops:
+
+1. The pod is terminated.
+2. A chronicle is automatically created, capturing the full history of the session.
+3. The session moves to `STOPPED`.
+
+## Archiving
+
+Archiving moves a stopped session to archive storage. This cleans up resources while preserving the session record. Archived sessions can be restored later.
+
+## Reforging
+
+Reforging creates a new session from a chronicle. It picks up where the previous session left off — same repo state, same context.
+
+The new session's chronicle links back to the original via `parent_chronicle_id`, creating a chain. You can trace work across multiple sessions this way.
+
+This is useful when you need to continue a task across sessions, or when a session failed and you want to retry from the last known state.
+
+## Session access
+
+Sessions are scoped by tenant.
+
+- Non-admin users see only their own sessions.
+- Admins see all sessions within their tenant.
+
+There is no cross-tenant session visibility.

--- a/docs/site/user-guide/templates.md
+++ b/docs/site/user-guide/templates.md
@@ -1,0 +1,89 @@
+# Templates & Profiles
+
+Volundr has a layered configuration system for sessions. This page explains the three levels: profiles, templates, and session definitions.
+
+## Profiles
+
+Profiles are resource specification presets. Think of them as "instance types" for sessions.
+
+They are read-only, loaded from YAML config (or Kubernetes CRDs), and managed by the operator — not the user. A profile defines:
+
+- Model
+- CPU and memory limits
+- GPU allocation
+- MCP servers
+- Environment variables
+
+```yaml
+profiles:
+  - name: standard
+    description: "Standard coding session"
+    workload_type: session
+    model: "claude-sonnet-4-20250514"
+    resource_config:
+      cpu: "500m"
+      memory: "1Gi"
+    is_default: true
+```
+
+The `is_default: true` profile is used when no profile or template is specified.
+
+## Templates
+
+Templates are workspace blueprints. They combine resource configuration with repositories and setup scripts.
+
+Like profiles, templates are read-only and operator-managed. Templates are what users see in the launch wizard when creating a session.
+
+```yaml
+templates:
+  - name: python-project
+    description: "Python development workspace"
+    workload_type: session
+    model: "claude-sonnet-4-20250514"
+    resource_config:
+      cpu: "2"
+      memory: "4Gi"
+    repos:
+      - url: "https://github.com/org/repo"
+        branch: main
+    setup_scripts:
+      - "uv sync --dev"
+    is_default: false
+```
+
+A template can do everything a profile can, plus:
+
+- Clone repositories on startup
+- Run setup scripts after clone
+- Pre-configure the workspace for a specific project
+
+## When to use which
+
+**Profiles** — Use when you just need resource allocation presets without any repo or setup configuration. Good for general-purpose sessions where users pick their own repos.
+
+**Templates** — Use when you want full session blueprints. A template gives users a one-click setup for a specific project or workflow, with repos cloned and dependencies installed automatically.
+
+Templates reference profiles internally but can override any value. If a template sets `cpu: "2"` and the underlying profile says `cpu: "500m"`, the template wins.
+
+## Session definitions
+
+Session definitions are Kubernetes CRDs that define pod templates for different agent types (Claude Code, Codex). These sit below profiles and templates in the stack.
+
+Session definitions are infrastructure-level configuration managed via Helm. They specify:
+
+- The Skuld chart version to use
+- Container images for each sidecar
+- Default Helm values
+
+Most users never interact with session definitions directly. They are set up once by the platform operator and rarely change.
+
+## How it all fits together
+
+```
+Session Definition (infrastructure, Helm-managed)
+  └── Profile (resource presets, operator-managed)
+       └── Template (workspace blueprints, operator-managed)
+            └── Preset (user preferences, database-stored)
+```
+
+Each layer can override values from the layer below. The most specific configuration wins.

--- a/docs/site/user-guide/web-ui.md
+++ b/docs/site/user-guide/web-ui.md
@@ -1,0 +1,115 @@
+# Web UI
+
+The Volundr web UI is a React single-page application built with Vite. It covers session management, settings, and admin functions.
+
+## Session management
+
+### Dashboard
+
+The dashboard shows all your sessions with status, model, repo, and tokens used.
+
+<div class="screenshot-full" markdown>
+
+![Dashboard](../images/dashboard.png)
+
+</div>
+
+### Launch wizard
+
+Sessions are created through a two-step wizard:
+
+1. **Pick a template** — browse available workspace templates.
+2. **Configure** — set the session name, model, repo, branch, credentials, integrations, and MCP servers.
+
+<div class="screenshot-gallery" markdown>
+
+<figure markdown>
+![Template selection](../images/launch-wizard.png)
+<figcaption>Step 1 — choose a template</figcaption>
+</figure>
+
+<figure markdown>
+![Session configuration](../images/launch-wizard-config.png)
+<figcaption>Step 2 — configure the session</figcaption>
+</figure>
+
+</div>
+
+### Session workspace
+
+Once a session is running, open it to access the workspace tabs:
+
+- **Chat** — talk to the AI coding agent in real-time via WebSocket.
+- **Terminal** — full shell access powered by ttyd.
+- **Code** — VS Code running in the browser via code-server.
+- **Diffs** — review file changes with an inline diff viewer.
+- **Chronicles** — browse session history and timelines.
+
+<div class="screenshot-gallery" markdown>
+
+<figure markdown>
+![Session workspace](../images/session-workspace.png)
+<figcaption>Session workspace with tabs</figcaption>
+</figure>
+
+<figure markdown>
+![Session diffs](../images/session-diffs.png)
+<figcaption>Diffs — review code changes</figcaption>
+</figure>
+
+</div>
+
+<div class="screenshot-full" markdown>
+
+![Chronicle timeline](../images/chronicle-timeline.png)
+
+</div>
+
+## Settings
+
+<div class="screenshot-full" markdown>
+
+![Credentials management](../images/settings-credentials.png)
+
+</div>
+
+- **Credentials** — manage API keys, OAuth tokens, and SSH keys.
+- **Integrations** — configure connections to external services like Linear and Jira.
+- **Workspaces** — manage PVC storage for persistent session data.
+
+<div class="screenshot-gallery" markdown>
+
+<figure markdown>
+![Workspace storage](../images/settings-workspaces.png)
+<figcaption>Workspace PVC management</figcaption>
+</figure>
+
+<figure markdown>
+![Integrations](../images/settings-integrations.png)
+<figcaption>External service integrations</figcaption>
+</figure>
+
+</div>
+
+## Admin
+
+Admin pages are visible only to users with the admin role.
+
+- **User management** — view and manage users across tenants.
+- **Tenant management** — create and configure tenants.
+
+<div class="screenshot-full" markdown>
+
+![User management](../images/admin-users.png)
+
+</div>
+
+## Authentication
+
+The web UI uses OIDC for authentication. Any compliant identity provider works — Keycloak, Entra ID, Okta, or anything else that speaks OIDC. Auth configuration is set in the Helm values.
+
+<div class="screenshot-full" markdown>
+
+![Login](../images/login.png)
+
+</div>

--- a/docs/site/web-ui/index.md
+++ b/docs/site/web-ui/index.md
@@ -1,4 +1,4 @@
-# Web UI (Hlidskjalf)
+# Web UI
 
 The web UI is a React single-page application built with Vite.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,13 +45,46 @@ extra_css:
 nav:
   - Home: index.md
   - Getting Started:
+      - Quick Start: getting-started/quick-start.md
       - Installation: getting-started/installation.md
+      - Your First Session: getting-started/first-session.md
       - Configuration: getting-started/configuration.md
       - Running: getting-started/running.md
+  - User Guide:
+      - Sessions: user-guide/sessions.md
+      - Templates & Profiles: user-guide/templates.md
+      - Presets: user-guide/presets.md
+      - Chronicles: user-guide/chronicles.md
+      - Git Workflows: user-guide/git-workflows.md
+      - Credentials & Secrets: user-guide/credentials.md
+      - Integrations: user-guide/integrations.md
+      - Web UI: user-guide/web-ui.md
+      - CLI Reference: user-guide/cli.md
+  - Installation Guide:
+      - Overview: installation/overview.md
+      - Local Development (k3d): installation/local-k3d.md
+      - Single-Node (k3s): installation/single-node.md
+      - Production Kubernetes: installation/kubernetes.md
+      - Helm Values Reference: installation/helm-reference.md
+      - Production Checklist: installation/production.md
+  - Configuration:
+      - Overview: configuration/overview.md
+      - Dynamic Adapters: configuration/adapters.md
+      - Git Providers: configuration/git.md
+      - Identity & Auth: configuration/identity.md
+      - Secret Management: configuration/secrets.md
+      - Storage: configuration/storage.md
+      - Event Pipeline: configuration/events.md
+      - Session Contributors: configuration/contributors.md
+      - Session Gateway: configuration/gateway.md
+      - Issue Trackers: configuration/trackers.md
+  - Setup Guide:
+      - AI-Agent Setup: setup/agent-guide.md
   - Architecture:
       - Overview: architecture/overview.md
-      - Hexagonal Design: architecture/hexagonal.md
       - Components: architecture/components.md
+      - Session Lifecycle: architecture/session-lifecycle.md
+      - Hexagonal Design: architecture/hexagonal.md
   - API Reference:
       - OpenAPI Spec: api/openapi.md
       - Sessions: api/sessions.md
@@ -66,21 +99,6 @@ nav:
       - Events: api/events.md
       - Integrations: api/integrations.md
       - Issue Tracker: api/tracker.md
-  - Backends:
-      - Database: backends/database.md
-      - Git Providers: backends/git.md
-      - Secret Management: backends/secrets.md
-      - Credential Stores: backends/credentials.md
-      - Event Sinks: backends/events.md
-      - Storage: backends/storage.md
-      - Authorization: backends/authorization.md
-      - Identity: backends/identity.md
-      - Issue Trackers: backends/trackers.md
-  - Web UI: web-ui/index.md
-  - Deployment:
-      - Helm: deployment/helm.md
-      - Migrations: deployment/migrations.md
-      - Production: deployment/production.md
   - Contributing:
       - Development: contributing/development.md
       - Code Style: contributing/code-style.md


### PR DESCRIPTION
## Summary

- **User Guide** — 9 new pages covering sessions, templates/profiles/presets, chronicles, git workflows, credentials, integrations, web UI, and full CLI reference
- **Installation Guide** — 6 pages with decision tree, local k3d, single-node k3s (DGX Spark + GPU passthrough), production Kubernetes, complete Helm values reference (826 lines), production checklist
- **Configuration** — 10 pages covering dynamic adapters, git providers, identity/auth, secrets, storage, events, all 10 session contributors, gateway, and issue trackers
- **AI-Agent Setup Guide** — phased deployment guide with verification commands + machine-readable `setup-checklist.yaml` (the NIU-139 deliverable)
- **Architecture** — all 4 pages rewritten from codebase analysis: system diagram, components, session lifecycle with state machine, hexagonal design with all 30+ ports
- **Getting Started** — quick start (CLI + k3d), first session walkthrough, rewritten installation page
- **Cleanup** — removed "Hlidskjalf" naming everywhere (web UI is now just "Volundr"), restructured mkdocs.yml nav

39 files changed, 4,794 lines added.

Closes NIU-139

## Test plan

- [ ] Run `mkdocs serve` and verify all pages render without broken links
- [ ] Spot-check code examples against actual `values.yaml` and `config.yaml.example`
- [ ] Verify all referenced screenshot images exist
- [ ] Confirm no remaining "Hlidskjalf" references in docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)