### PR TITLE
feat(cli): init preflight checks, listen host prompt, and container deploy fixes

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -2,34 +2,43 @@ BINARY := volundr
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 LDFLAGS := -ldflags "-s -w -X github.com/niuulabs/volundr/cli/internal/cli.Version=$(VERSION)"
 WEB_DIR := ../web
-EMBED_DEST := internal/web/dist
+MIGRATIONS_DIR := ../migrations
+EMBED_WEB_DEST := internal/web/dist
+EMBED_MIG_DEST := internal/migrations/sql
 DIST_DIR := dist
+BUILD_TAGS := embed_web,embed_migrations
 
-.PHONY: build build-dev build-all web test test-coverage lint clean fmt vet verify
+.PHONY: build build-dev build-all web migrations test test-coverage lint clean fmt vet verify
 
-# build compiles the CLI with the embedded frontend for the current platform.
-build: web
-	go build -tags embed_web $(LDFLAGS) -o bin/$(BINARY) ./cmd/volundr
+# build compiles the CLI with the embedded frontend and migrations for the current platform.
+build: web migrations
+	go build -tags $(BUILD_TAGS) $(LDFLAGS) -o bin/$(BINARY) ./cmd/volundr
 
-# build-dev compiles without the frontend (placeholder page).
+# build-dev compiles without the frontend or embedded migrations (placeholder page, filesystem migrations).
 build-dev:
 	go build $(LDFLAGS) -o bin/$(BINARY) ./cmd/volundr
 
-# build-all cross-compiles for all supported platforms with embedded frontend.
-build-all: web
+# build-all cross-compiles for all supported platforms with embedded frontend and migrations.
+build-all: web migrations
 	@mkdir -p $(DIST_DIR)
-	GOOS=darwin  GOARCH=amd64 go build -tags embed_web $(LDFLAGS) -o $(DIST_DIR)/$(BINARY)-darwin-amd64   ./cmd/volundr
-	GOOS=darwin  GOARCH=arm64 go build -tags embed_web $(LDFLAGS) -o $(DIST_DIR)/$(BINARY)-darwin-arm64   ./cmd/volundr
-	GOOS=linux   GOARCH=amd64 go build -tags embed_web $(LDFLAGS) -o $(DIST_DIR)/$(BINARY)-linux-amd64    ./cmd/volundr
-	GOOS=linux   GOARCH=arm64 go build -tags embed_web $(LDFLAGS) -o $(DIST_DIR)/$(BINARY)-linux-arm64    ./cmd/volundr
+	GOOS=darwin  GOARCH=amd64 go build -tags $(BUILD_TAGS) $(LDFLAGS) -o $(DIST_DIR)/$(BINARY)-darwin-amd64   ./cmd/volundr
+	GOOS=darwin  GOARCH=arm64 go build -tags $(BUILD_TAGS) $(LDFLAGS) -o $(DIST_DIR)/$(BINARY)-darwin-arm64   ./cmd/volundr
+	GOOS=linux   GOARCH=amd64 go build -tags $(BUILD_TAGS) $(LDFLAGS) -o $(DIST_DIR)/$(BINARY)-linux-amd64    ./cmd/volundr
+	GOOS=linux   GOARCH=arm64 go build -tags $(BUILD_TAGS) $(LDFLAGS) -o $(DIST_DIR)/$(BINARY)-linux-arm64    ./cmd/volundr
 	@echo "Built binaries:"
 	@ls -lh $(DIST_DIR)/
 
 # web builds the frontend and copies it into the embed directory.
 web:
 	cd $(WEB_DIR) && npm ci --ignore-scripts && npm run build
-	rm -rf $(EMBED_DEST)
-	cp -r $(WEB_DIR)/dist $(EMBED_DEST)
+	rm -rf $(EMBED_WEB_DEST)
+	cp -r $(WEB_DIR)/dist $(EMBED_WEB_DEST)
+
+# migrations copies SQL migration files into the embed directory.
+migrations:
+	rm -rf $(EMBED_MIG_DEST)
+	mkdir -p $(EMBED_MIG_DEST)
+	cp $(MIGRATIONS_DIR)/*.up.sql $(EMBED_MIG_DEST)/
 
 test:
 	go test ./... -v -count=1
@@ -55,4 +64,4 @@ fmt:
 	gofmt -w .
 
 clean:
-	rm -rf bin/ $(EMBED_DEST) $(DIST_DIR)
+	rm -rf bin/ $(EMBED_WEB_DEST) $(EMBED_MIG_DEST) $(DIST_DIR)

--- a/cli/internal/cli/init.go
+++ b/cli/internal/cli/init.go
@@ -274,7 +274,7 @@ func isEnvVarName(s string) bool {
 
 // checkCommand verifies that a command is available on PATH.
 func checkCommand(name string, args ...string) error {
-	cmd := exec.Command(name, args...)
+	cmd := exec.Command(name, args...) //nolint:gosec // arguments are hardcoded string literals from callers
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	return cmd.Run()
@@ -282,10 +282,10 @@ func checkCommand(name string, args ...string) error {
 
 // installInstructions returns platform-specific install instructions for a tool.
 func installInstructions(tool string) string {
-	os := goruntime.GOOS
+	goos := goruntime.GOOS
 	switch tool {
 	case "kubectl":
-		switch os {
+		switch goos {
 		case "darwin":
 			return "  brew install kubectl\n  or: https://kubernetes.io/docs/tasks/tools/install-kubectl-macos/"
 		case "linux":
@@ -296,7 +296,7 @@ func installInstructions(tool string) string {
 			return "  https://kubernetes.io/docs/tasks/tools/"
 		}
 	case "helm":
-		switch os {
+		switch goos {
 		case "darwin":
 			return "  brew install helm\n  or: https://helm.sh/docs/intro/install/"
 		case "linux":

--- a/cli/internal/cli/init.go
+++ b/cli/internal/cli/init.go
@@ -283,14 +283,18 @@ func checkCommand(name string, args ...string) error {
 
 // installInstructions returns platform-specific install instructions for a tool.
 func installInstructions(tool string) string {
-	goos := goruntime.GOOS
+	return installInstructionsForOS(tool, goruntime.GOOS, goruntime.GOARCH)
+}
+
+// installInstructionsForOS returns install instructions for a tool on the given OS/arch.
+func installInstructionsForOS(tool, goos, goarch string) string {
 	switch tool {
 	case "kubectl":
 		switch goos {
 		case "darwin":
 			return "  brew install kubectl\n  or: https://kubernetes.io/docs/tasks/tools/install-kubectl-macos/"
 		case "linux":
-			return "  curl -LO \"https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/" + goruntime.GOARCH + "/kubectl\"\n" +
+			return "  curl -LO \"https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/" + goarch + "/kubectl\"\n" +
 				"  chmod +x kubectl && sudo mv kubectl /usr/local/bin/\n" +
 				"  or: https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/"
 		default:

--- a/cli/internal/cli/init.go
+++ b/cli/internal/cli/init.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
+	goruntime "runtime"
 	"strings"
 	"unicode"
 
@@ -28,7 +30,7 @@ func init() {
 }
 
 func runInit(_ *cobra.Command, _ []string) error {
-	fmt.Println("Volundr - Self-hosted Claude Code session manager")
+	fmt.Println("Volundr - Self-hosted AI development environment")
 	fmt.Println()
 
 	// Check if already initialized.
@@ -66,6 +68,41 @@ func runInit(_ *cobra.Command, _ []string) error {
 			cfg.Runtime = runtimeStr
 		}
 	}
+
+	// Preflight checks for container runtimes.
+	if cfg.Runtime == "docker" || cfg.Runtime == "k3s" {
+		fmt.Println()
+		fmt.Println("Checking prerequisites...")
+
+		if err := checkCommand("kubectl", "version", "--client"); err != nil {
+			return fmt.Errorf("kubectl is required but not found in PATH.\n\nInstall instructions:\n%s",
+				installInstructions("kubectl"))
+		}
+		fmt.Println("  kubectl  ... ok")
+
+		if err := checkCommand("helm", "version"); err != nil {
+			return fmt.Errorf("helm is required but not found in PATH.\n\nInstall instructions:\n%s",
+				installInstructions("helm"))
+		}
+		fmt.Println("  helm     ... ok")
+		fmt.Println()
+	}
+
+	// Prompt for listen host.
+	fmt.Print("Listen on [localhost/all/IP address] (localhost): ")
+	listenAnswer, _ := reader.ReadString('\n')
+	listenAnswer = strings.TrimSpace(listenAnswer)
+	switch strings.ToLower(listenAnswer) {
+	case "", "localhost":
+		fmt.Println("  Binding to localhost only (127.0.0.1)")
+	case "all", "all interfaces":
+		cfg.Listen.Host = "0.0.0.0"
+		fmt.Println("  Binding to all interfaces (0.0.0.0)")
+	default:
+		cfg.Listen.Host = listenAnswer
+		fmt.Printf("  Binding to %s\n", listenAnswer)
+	}
+	fmt.Println()
 
 	// Prompt for Anthropic API key.
 	fmt.Print("Anthropic API key: ")
@@ -233,6 +270,44 @@ func isEnvVarName(s string) bool {
 		}
 	}
 	return true
+}
+
+// checkCommand verifies that a command is available on PATH.
+func checkCommand(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	return cmd.Run()
+}
+
+// installInstructions returns platform-specific install instructions for a tool.
+func installInstructions(tool string) string {
+	os := goruntime.GOOS
+	switch tool {
+	case "kubectl":
+		switch os {
+		case "darwin":
+			return "  brew install kubectl\n  or: https://kubernetes.io/docs/tasks/tools/install-kubectl-macos/"
+		case "linux":
+			return "  curl -LO \"https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/" + goruntime.GOARCH + "/kubectl\"\n" +
+				"  chmod +x kubectl && sudo mv kubectl /usr/local/bin/\n" +
+				"  or: https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/"
+		default:
+			return "  https://kubernetes.io/docs/tasks/tools/"
+		}
+	case "helm":
+		switch os {
+		case "darwin":
+			return "  brew install helm\n  or: https://helm.sh/docs/intro/install/"
+		case "linux":
+			return "  curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash\n" +
+				"  or: https://helm.sh/docs/intro/install/"
+		default:
+			return "  https://helm.sh/docs/intro/install/"
+		}
+	default:
+		return ""
+	}
 }
 
 // machinePassphrase generates a deterministic passphrase from machine identity.

--- a/cli/internal/cli/init.go
+++ b/cli/internal/cli/init.go
@@ -274,7 +274,8 @@ func isEnvVarName(s string) bool {
 
 // checkCommand verifies that a command is available on PATH.
 func checkCommand(name string, args ...string) error {
-	cmd := exec.Command(name, args...) //nolint:gosec // arguments are hardcoded string literals from callers
+	ctx := context.Background()
+	cmd := exec.CommandContext(ctx, name, args...) //nolint:gosec // arguments are hardcoded string literals from callers
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	return cmd.Run()

--- a/cli/internal/cli/init_full_test.go
+++ b/cli/internal/cli/init_full_test.go
@@ -331,6 +331,61 @@ func TestRunInit_GitHubWithDefaultCloneToken(t *testing.T) {
 	}
 }
 
+func TestRunInit_DockerRuntime_PreflightChecks(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(config.EnvHome, tmpDir)
+
+	// Override PATH to ensure kubectl/helm are not found.
+	t.Setenv("PATH", tmpDir)
+
+	oldFlag := initRuntimeFlag
+	initRuntimeFlag = "docker"
+	defer func() { initRuntimeFlag = oldFlag }()
+
+	// Pipe minimal stdin — preflight should fail before any prompts.
+	oldStdin := os.Stdin
+	r, w, _ := os.Pipe()
+	_, _ = w.WriteString("\n")
+	_ = w.Close()
+	os.Stdin = r
+	defer func() { os.Stdin = oldStdin }()
+
+	err := runInit(nil, nil)
+	if err == nil {
+		t.Fatal("expected preflight check error for missing kubectl")
+	}
+	if !strings.Contains(err.Error(), "kubectl is required") {
+		t.Errorf("expected kubectl error, got: %v", err)
+	}
+}
+
+func TestRunInit_K3sRuntime_PreflightChecks(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(config.EnvHome, tmpDir)
+
+	// Override PATH to ensure kubectl/helm are not found.
+	t.Setenv("PATH", tmpDir)
+
+	oldFlag := initRuntimeFlag
+	initRuntimeFlag = "k3s"
+	defer func() { initRuntimeFlag = oldFlag }()
+
+	oldStdin := os.Stdin
+	r, w, _ := os.Pipe()
+	_, _ = w.WriteString("\n")
+	_ = w.Close()
+	os.Stdin = r
+	defer func() { os.Stdin = oldStdin }()
+
+	err := runInit(nil, nil)
+	if err == nil {
+		t.Fatal("expected preflight check error for missing kubectl")
+	}
+	if !strings.Contains(err.Error(), "kubectl is required") {
+		t.Errorf("expected kubectl error, got: %v", err)
+	}
+}
+
 func TestRunInit_InteractiveRuntime(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv(config.EnvHome, tmpDir)

--- a/cli/internal/cli/init_full_test.go
+++ b/cli/internal/cli/init_full_test.go
@@ -206,6 +206,131 @@ func TestRunInit_WithGitHub_DirectToken(t *testing.T) {
 	}
 }
 
+func TestRunInit_ListenAll(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(config.EnvHome, tmpDir)
+
+	oldFlag := initRuntimeFlag
+	initRuntimeFlag = "local"
+	defer func() { initRuntimeFlag = oldFlag }()
+
+	// Pipe answers: listen=all, API key, db mode, no github.
+	input := strings.Join([]string{
+		"all",          // Listen on all interfaces
+		"test-api-key", // Anthropic API key
+		"",             // Database mode (default embedded)
+		"n",            // Configure GitHub? No
+	}, "\n") + "\n"
+
+	oldStdin := os.Stdin
+	r, w, _ := os.Pipe()
+	_, _ = w.WriteString(input)
+	_ = w.Close()
+	os.Stdin = r
+	defer func() { os.Stdin = oldStdin }()
+
+	err := runInit(nil, nil)
+	if err != nil {
+		t.Logf("runInit error (expected in test env): %v", err)
+	}
+}
+
+func TestRunInit_ListenCustomIP(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(config.EnvHome, tmpDir)
+
+	oldFlag := initRuntimeFlag
+	initRuntimeFlag = "local"
+	defer func() { initRuntimeFlag = oldFlag }()
+
+	// Pipe answers: listen=custom IP, API key, db mode, no github.
+	input := strings.Join([]string{
+		"192.168.1.100", // Custom listen address
+		"test-api-key",  // Anthropic API key
+		"",              // Database mode (default embedded)
+		"n",             // Configure GitHub? No
+	}, "\n") + "\n"
+
+	oldStdin := os.Stdin
+	r, w, _ := os.Pipe()
+	_, _ = w.WriteString(input)
+	_ = w.Close()
+	os.Stdin = r
+	defer func() { os.Stdin = oldStdin }()
+
+	err := runInit(nil, nil)
+	if err != nil {
+		t.Logf("runInit error (expected in test env): %v", err)
+	}
+}
+
+func TestRunInit_ExternalDB_CustomPort(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(config.EnvHome, tmpDir)
+
+	oldFlag := initRuntimeFlag
+	initRuntimeFlag = "local"
+	defer func() { initRuntimeFlag = oldFlag }()
+
+	// Pipe answers: listen, API key, external db with custom port, no github.
+	input := strings.Join([]string{
+		"",             // Listen (default localhost)
+		"test-api-key", // Anthropic API key
+		"external",     // Database mode
+		"localhost",    // DB host
+		"",             // DB port (empty = default 5432)
+		"user",         // DB user
+		"pass",         // DB password
+		"mydb",         // DB name
+		"n",            // Configure GitHub? No
+	}, "\n") + "\n"
+
+	oldStdin := os.Stdin
+	r, w, _ := os.Pipe()
+	_, _ = w.WriteString(input)
+	_ = w.Close()
+	os.Stdin = r
+	defer func() { os.Stdin = oldStdin }()
+
+	err := runInit(nil, nil)
+	if err != nil {
+		t.Logf("runInit error (expected in test env): %v", err)
+	}
+}
+
+func TestRunInit_GitHubWithDefaultCloneToken(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(config.EnvHome, tmpDir)
+
+	oldFlag := initRuntimeFlag
+	initRuntimeFlag = "local"
+	defer func() { initRuntimeFlag = oldFlag }()
+
+	// Pipe answers: listen, API key, db, github with direct token and default clone token.
+	input := strings.Join([]string{
+		"",                   // Listen (default localhost)
+		"test-api-key",       // Anthropic API key
+		"",                   // Database mode (default embedded)
+		"y",                  // Configure GitHub? Yes
+		"ghp_directtoken123", // GitHub token (direct)
+		"org1",               // GitHub orgs
+		"",                   // GitHub API URL (default)
+		"",                   // Session clone token (default: same as above)
+	}, "\n") + "\n"
+
+	oldStdin := os.Stdin
+	r, w, _ := os.Pipe()
+	_, _ = w.WriteString(input)
+	_ = w.Close()
+	os.Stdin = r
+	defer func() { os.Stdin = oldStdin }()
+
+	err := runInit(nil, nil)
+	if err != nil {
+		t.Logf("runInit error (expected in test env): %v", err)
+	}
+}
+
 func TestRunInit_InteractiveRuntime(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv(config.EnvHome, tmpDir)

--- a/cli/internal/cli/init_test.go
+++ b/cli/internal/cli/init_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -31,6 +32,42 @@ func TestIsEnvVarName(t *testing.T) {
 				t.Errorf("isEnvVarName(%q) = %v, want %v", tt.input, got, tt.expected)
 			}
 		})
+	}
+}
+
+func TestCheckCommand(t *testing.T) {
+	// "go" should always be available in test environment.
+	if err := checkCommand("go", "version"); err != nil {
+		t.Errorf("expected 'go version' to succeed: %v", err)
+	}
+
+	// A nonexistent command should fail.
+	if err := checkCommand("volundr-nonexistent-tool-12345"); err == nil {
+		t.Error("expected error for nonexistent command")
+	}
+}
+
+func TestInstallInstructions(t *testing.T) {
+	tests := []struct {
+		tool     string
+		contains string
+	}{
+		{"kubectl", "kubernetes.io"},
+		{"helm", "helm.sh"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.tool, func(t *testing.T) {
+			result := installInstructions(tt.tool)
+			if !strings.Contains(result, tt.contains) {
+				t.Errorf("installInstructions(%q) = %q, expected to contain %q", tt.tool, result, tt.contains)
+			}
+		})
+	}
+
+	// Unknown tool returns empty.
+	if result := installInstructions("unknown"); result != "" {
+		t.Errorf("expected empty for unknown tool, got %q", result)
 	}
 }
 

--- a/cli/internal/cli/init_test.go
+++ b/cli/internal/cli/init_test.go
@@ -47,25 +47,49 @@ func TestCheckCommand(t *testing.T) {
 	}
 }
 
-func TestInstallInstructions(t *testing.T) {
+func TestInstallInstructionsForOS(t *testing.T) {
 	tests := []struct {
+		name     string
 		tool     string
+		goos     string
+		goarch   string
 		contains string
 	}{
-		{"kubectl", "kubernetes.io"},
-		{"helm", "helm.sh"},
+		{"kubectl darwin", "kubectl", "darwin", "arm64", "brew install kubectl"},
+		{"kubectl linux", "kubectl", "linux", "amd64", "kubernetes.io/docs/tasks/tools/install-kubectl-linux"},
+		{"kubectl linux arch", "kubectl", "linux", "arm64", "arm64"},
+		{"kubectl other", "kubectl", "windows", "amd64", "kubernetes.io/docs/tasks/tools/"},
+		{"helm darwin", "helm", "darwin", "arm64", "brew install helm"},
+		{"helm linux", "helm", "linux", "amd64", "get-helm-3"},
+		{"helm other", "helm", "windows", "amd64", "helm.sh/docs/intro/install"},
+		{"unknown tool", "unknown", "linux", "amd64", ""},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.tool, func(t *testing.T) {
-			result := installInstructions(tt.tool)
+		t.Run(tt.name, func(t *testing.T) {
+			result := installInstructionsForOS(tt.tool, tt.goos, tt.goarch)
+			if tt.contains == "" {
+				if result != "" {
+					t.Errorf("expected empty, got %q", result)
+				}
+				return
+			}
 			if !strings.Contains(result, tt.contains) {
-				t.Errorf("installInstructions(%q) = %q, expected to contain %q", tt.tool, result, tt.contains)
+				t.Errorf("installInstructionsForOS(%q, %q, %q) = %q, expected to contain %q",
+					tt.tool, tt.goos, tt.goarch, result, tt.contains)
 			}
 		})
 	}
+}
 
-	// Unknown tool returns empty.
+func TestInstallInstructions(t *testing.T) {
+	// Wrapper should return non-empty for known tools.
+	if result := installInstructions("kubectl"); !strings.Contains(result, "kubernetes.io") {
+		t.Errorf("expected kubernetes.io in result, got %q", result)
+	}
+	if result := installInstructions("helm"); !strings.Contains(result, "helm.sh") {
+		t.Errorf("expected helm.sh in result, got %q", result)
+	}
 	if result := installInstructions("unknown"); result != "" {
 		t.Errorf("expected empty for unknown tool, got %q", result)
 	}

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -170,10 +170,10 @@ func DefaultConfig() (*Config, error) {
 		},
 		Anthropic: AnthropicConfig{},
 		Docker: DockerConfig{
-			APIImage:        "ghcr.io/niuulabs/volundr-api:latest",
+			APIImage:        "ghcr.io/niuulabs/volundr:latest",
 			SkuldImage:      "ghcr.io/niuulabs/skuld:latest",
 			CodeServerImage: "codercom/code-server:latest",
-			TtydImage:       "ghcr.io/niuulabs/ttyd:latest",
+			TtydImage:       "ghcr.io/niuulabs/devrunner:latest",
 			Network:         "volundr-net",
 		},
 		K3s: K3sConfig{

--- a/cli/internal/migrations/embed.go
+++ b/cli/internal/migrations/embed.go
@@ -1,0 +1,19 @@
+//go:build embed_migrations
+
+package migrations
+
+import (
+	"embed"
+	"io/fs"
+)
+
+//go:embed sql/*.up.sql
+var embeddedMigrations embed.FS
+
+func migrationsFS() fs.FS {
+	sub, err := fs.Sub(embeddedMigrations, "sql")
+	if err != nil {
+		panic("embedded migrations directory missing: " + err.Error())
+	}
+	return sub
+}

--- a/cli/internal/migrations/migrations.go
+++ b/cli/internal/migrations/migrations.go
@@ -1,0 +1,15 @@
+// Package migrations provides access to database migration SQL files.
+//
+// Migrations are embedded at build time when using the embed_migrations
+// build tag (included automatically with `make build`). Without the tag,
+// FS() returns nil and the runtime falls back to finding migrations on
+// the filesystem.
+package migrations
+
+import "io/fs"
+
+// FS returns the embedded migrations filesystem, or nil if migrations
+// are not embedded in this build.
+func FS() fs.FS {
+	return migrationsFS()
+}

--- a/cli/internal/migrations/migrations_test.go
+++ b/cli/internal/migrations/migrations_test.go
@@ -1,0 +1,10 @@
+package migrations
+
+import "testing"
+
+func TestFS_WithoutEmbedTag(t *testing.T) {
+	// Without the embed_migrations build tag, FS() returns nil.
+	if got := FS(); got != nil {
+		t.Errorf("FS() = %v, want nil (no embed_migrations tag)", got)
+	}
+}

--- a/cli/internal/migrations/placeholder.go
+++ b/cli/internal/migrations/placeholder.go
@@ -1,0 +1,9 @@
+//go:build !embed_migrations
+
+package migrations
+
+import "io/fs"
+
+func migrationsFS() fs.FS {
+	return nil
+}

--- a/cli/internal/migrations/sql/000001_initial_schema.up.sql
+++ b/cli/internal/migrations/sql/000001_initial_schema.up.sql
@@ -1,0 +1,33 @@
+-- Initial schema for volundr
+
+CREATE TABLE IF NOT EXISTS sessions (
+    id UUID PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    model VARCHAR(100) NOT NULL,
+    repo VARCHAR(500) NOT NULL,
+    branch VARCHAR(255) NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'created',
+    chat_endpoint TEXT,
+    code_endpoint TEXT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    pod_name VARCHAR(255),
+    error TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status);
+CREATE INDEX IF NOT EXISTS idx_sessions_created_at ON sessions(created_at);
+
+CREATE TABLE IF NOT EXISTS token_usage (
+    id UUID PRIMARY KEY,
+    session_id UUID NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    recorded_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    tokens INTEGER NOT NULL,
+    provider VARCHAR(20) NOT NULL,
+    model VARCHAR(100) NOT NULL,
+    cost NUMERIC(10, 6)
+);
+
+CREATE INDEX IF NOT EXISTS idx_token_usage_recorded_at ON token_usage(recorded_at);
+CREATE INDEX IF NOT EXISTS idx_token_usage_session_id ON token_usage(session_id);
+CREATE INDEX IF NOT EXISTS idx_token_usage_provider ON token_usage(provider);

--- a/cli/internal/migrations/sql/000002_add_session_columns.up.sql
+++ b/cli/internal/migrations/sql/000002_add_session_columns.up.sql
@@ -1,0 +1,7 @@
+-- Add last_active, message_count, and tokens_used columns to sessions table
+
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS last_active TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW();
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS message_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS tokens_used INTEGER NOT NULL DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS idx_sessions_last_active ON sessions(last_active);

--- a/cli/internal/migrations/sql/000003_add_repo_branch_columns.up.sql
+++ b/cli/internal/migrations/sql/000003_add_repo_branch_columns.up.sql
@@ -1,0 +1,16 @@
+-- Add all potentially missing columns to sessions table (fixes schema drift)
+-- This migration ensures the sessions table matches the domain model
+
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS repo VARCHAR(500) NOT NULL DEFAULT '';
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS branch VARCHAR(255) NOT NULL DEFAULT 'main';
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS chat_endpoint TEXT;
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS code_endpoint TEXT;
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS last_active TIMESTAMP WITH TIME ZONE DEFAULT NOW();
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS message_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS tokens_used INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS pod_name VARCHAR(255);
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS error TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status);
+CREATE INDEX IF NOT EXISTS idx_sessions_created_at ON sessions(created_at);
+CREATE INDEX IF NOT EXISTS idx_sessions_last_active ON sessions(last_active);

--- a/cli/internal/migrations/sql/000004_fix_schema_drift.up.sql
+++ b/cli/internal/migrations/sql/000004_fix_schema_drift.up.sql
@@ -1,0 +1,13 @@
+-- Fix remaining schema drift - add all missing columns
+
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS chat_endpoint TEXT;
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS code_endpoint TEXT;
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS last_active TIMESTAMP WITH TIME ZONE DEFAULT NOW();
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS message_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS tokens_used INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS pod_name VARCHAR(255);
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS error TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status);
+CREATE INDEX IF NOT EXISTS idx_sessions_created_at ON sessions(created_at);
+CREATE INDEX IF NOT EXISTS idx_sessions_last_active ON sessions(last_active);

--- a/cli/internal/migrations/sql/000005_chronicles.up.sql
+++ b/cli/internal/migrations/sql/000005_chronicles.up.sql
@@ -1,0 +1,29 @@
+-- Add chronicles table for session history and relaunch
+
+CREATE TABLE IF NOT EXISTS chronicles (
+    id UUID PRIMARY KEY,
+    session_id UUID REFERENCES sessions(id) ON DELETE SET NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'draft',
+    project VARCHAR(255) NOT NULL,
+    repo VARCHAR(500) NOT NULL,
+    branch VARCHAR(255) NOT NULL,
+    model VARCHAR(100) NOT NULL,
+    config_snapshot JSONB NOT NULL DEFAULT '{}',
+    summary TEXT,
+    key_changes JSONB NOT NULL DEFAULT '[]',
+    unfinished_work TEXT,
+    token_usage INTEGER NOT NULL DEFAULT 0,
+    cost NUMERIC(10, 6),
+    duration_seconds INTEGER,
+    tags TEXT[] NOT NULL DEFAULT '{}',
+    parent_chronicle_id UUID REFERENCES chronicles(id) ON DELETE SET NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_chronicles_session_id ON chronicles(session_id);
+CREATE INDEX IF NOT EXISTS idx_chronicles_project ON chronicles(project);
+CREATE INDEX IF NOT EXISTS idx_chronicles_repo ON chronicles(repo);
+CREATE INDEX IF NOT EXISTS idx_chronicles_created_at ON chronicles(created_at);
+CREATE INDEX IF NOT EXISTS idx_chronicles_tags ON chronicles USING GIN(tags);
+CREATE INDEX IF NOT EXISTS idx_chronicles_parent_id ON chronicles(parent_chronicle_id);

--- a/cli/internal/migrations/sql/000006_chronicle_events.up.sql
+++ b/cli/internal/migrations/sql/000006_chronicle_events.up.sql
@@ -1,0 +1,21 @@
+-- Add chronicle_events table for session timeline tracking
+
+CREATE TABLE IF NOT EXISTS chronicle_events (
+    id UUID PRIMARY KEY,
+    chronicle_id UUID NOT NULL REFERENCES chronicles(id) ON DELETE CASCADE,
+    session_id UUID NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    t INTEGER NOT NULL,
+    type VARCHAR(20) NOT NULL,
+    label TEXT NOT NULL,
+    tokens INTEGER,
+    action VARCHAR(20),
+    ins INTEGER,
+    del INTEGER,
+    hash VARCHAR(40),
+    exit_code INTEGER,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_chronicle_events_chronicle_id ON chronicle_events(chronicle_id);
+CREATE INDEX IF NOT EXISTS idx_chronicle_events_session_id ON chronicle_events(session_id);
+CREATE INDEX IF NOT EXISTS idx_chronicle_events_t ON chronicle_events(t);

--- a/cli/internal/migrations/sql/000007_session_events.up.sql
+++ b/cli/internal/migrations/sql/000007_session_events.up.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS session_events (
+    id              UUID PRIMARY KEY,
+    session_id      UUID NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    event_type      VARCHAR(30) NOT NULL,
+    timestamp       TIMESTAMP WITH TIME ZONE NOT NULL,
+    data            JSONB NOT NULL DEFAULT '{}',
+    tokens_in       INTEGER,
+    tokens_out      INTEGER,
+    cost            NUMERIC(10, 6),
+    duration_ms     INTEGER,
+    model           VARCHAR(100),
+    sequence        INTEGER NOT NULL,
+    created_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_session_events_session_id
+    ON session_events(session_id);
+CREATE INDEX IF NOT EXISTS idx_session_events_session_type
+    ON session_events(session_id, event_type);
+CREATE INDEX IF NOT EXISTS idx_session_events_session_ts
+    ON session_events(session_id, timestamp);
+CREATE INDEX IF NOT EXISTS idx_session_events_sequence
+    ON session_events(session_id, sequence);

--- a/cli/internal/migrations/sql/000008_saved_prompts.up.sql
+++ b/cli/internal/migrations/sql/000008_saved_prompts.up.sql
@@ -1,0 +1,21 @@
+-- Add saved_prompts table for reusable prompt storage
+
+CREATE TABLE IF NOT EXISTS saved_prompts (
+    id              UUID PRIMARY KEY,
+    name            VARCHAR(255) NOT NULL,
+    content         TEXT NOT NULL,
+    scope           VARCHAR(20) NOT NULL DEFAULT 'global',
+    project_repo    VARCHAR(500),
+    tags            TEXT[] NOT NULL DEFAULT '{}',
+    created_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_saved_prompts_scope
+    ON saved_prompts(scope);
+CREATE INDEX IF NOT EXISTS idx_saved_prompts_project_repo
+    ON saved_prompts(project_repo);
+CREATE INDEX IF NOT EXISTS idx_saved_prompts_tags
+    ON saved_prompts USING GIN(tags);
+CREATE INDEX IF NOT EXISTS idx_saved_prompts_name_content
+    ON saved_prompts USING GIN(to_tsvector('english', name || ' ' || content));

--- a/cli/internal/migrations/sql/000009_session_archive.up.sql
+++ b/cli/internal/migrations/sql/000009_session_archive.up.sql
@@ -1,0 +1,4 @@
+-- Add archived_at column and index for session archiving
+
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS archived_at TIMESTAMP WITH TIME ZONE;
+CREATE INDEX IF NOT EXISTS idx_sessions_archived_at ON sessions(archived_at);

--- a/cli/internal/migrations/sql/000010_project_mappings.up.sql
+++ b/cli/internal/migrations/sql/000010_project_mappings.up.sql
@@ -1,0 +1,16 @@
+-- Add project_mappings table and tracker_issue_id column on sessions
+
+CREATE TABLE IF NOT EXISTS project_mappings (
+    id              UUID PRIMARY KEY,
+    repo_url        VARCHAR(500) NOT NULL,
+    project_id      VARCHAR(255) NOT NULL,
+    project_name    VARCHAR(255) NOT NULL DEFAULT '',
+    created_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_project_mappings_repo_url
+    ON project_mappings(repo_url);
+CREATE INDEX IF NOT EXISTS idx_project_mappings_project_id
+    ON project_mappings(project_id);
+
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS tracker_issue_id VARCHAR(255);

--- a/cli/internal/migrations/sql/000011_volundr_presets.up.sql
+++ b/cli/internal/migrations/sql/000011_volundr_presets.up.sql
@@ -1,0 +1,31 @@
+-- Add volundr_presets table and preset_id on sessions
+
+CREATE TABLE IF NOT EXISTS volundr_presets (
+    id                UUID PRIMARY KEY,
+    name              VARCHAR(255) NOT NULL,
+    description       TEXT NOT NULL DEFAULT '',
+    is_default        BOOLEAN NOT NULL DEFAULT FALSE,
+    cli_tool          VARCHAR(100) NOT NULL DEFAULT '',
+    workload_type     VARCHAR(100) NOT NULL DEFAULT 'session',
+    model             VARCHAR(100),
+    system_prompt     TEXT,
+    resource_config   JSONB NOT NULL DEFAULT '{}',
+    mcp_servers       JSONB NOT NULL DEFAULT '[]',
+    terminal_sidecar  JSONB NOT NULL DEFAULT '{}',
+    skills            JSONB NOT NULL DEFAULT '[]',
+    rules             JSONB NOT NULL DEFAULT '[]',
+    env_vars          JSONB NOT NULL DEFAULT '{}',
+    env_secret_refs   JSONB NOT NULL DEFAULT '[]',
+    workload_config   JSONB NOT NULL DEFAULT '{}',
+    created_at        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_volundr_presets_name
+    ON volundr_presets(name);
+CREATE INDEX IF NOT EXISTS idx_volundr_presets_cli_tool
+    ON volundr_presets(cli_tool);
+CREATE INDEX IF NOT EXISTS idx_volundr_presets_is_default
+    ON volundr_presets(is_default);
+
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS preset_id UUID;

--- a/cli/internal/migrations/sql/000012_tenant_hierarchy.up.sql
+++ b/cli/internal/migrations/sql/000012_tenant_hierarchy.up.sql
@@ -1,0 +1,46 @@
+-- Tenant hierarchy: tenants, users, tenant_memberships
+
+CREATE TABLE IF NOT EXISTS tenants (
+    id              TEXT PRIMARY KEY,
+    path            TEXT NOT NULL UNIQUE,
+    name            TEXT NOT NULL,
+    parent_id       TEXT REFERENCES tenants(id),
+    tier            TEXT NOT NULL DEFAULT 'developer',
+    max_sessions    INT NOT NULL DEFAULT 5,
+    max_storage_gb  INT NOT NULL DEFAULT 50,
+    created_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_tenants_path ON tenants(path);
+CREATE INDEX IF NOT EXISTS idx_tenants_parent_id ON tenants(parent_id);
+
+CREATE TABLE IF NOT EXISTS users (
+    id              TEXT PRIMARY KEY,
+    email           TEXT NOT NULL,
+    display_name    TEXT NOT NULL DEFAULT '',
+    status          TEXT NOT NULL DEFAULT 'active',
+    home_pvc        TEXT,
+    created_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_email ON users(email);
+CREATE INDEX IF NOT EXISTS idx_users_status ON users(status);
+
+CREATE TABLE IF NOT EXISTS tenant_memberships (
+    user_id         TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    tenant_id       TEXT NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    role            TEXT NOT NULL DEFAULT 'volundr:developer',
+    granted_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (user_id, tenant_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tenant_memberships_tenant_id ON tenant_memberships(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_tenant_memberships_user_id ON tenant_memberships(user_id);
+
+-- Add owner_id and tenant_id to sessions for identity-scoped access
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS owner_id TEXT REFERENCES users(id);
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS tenant_id TEXT REFERENCES tenants(id);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_owner_id ON sessions(owner_id);
+CREATE INDEX IF NOT EXISTS idx_sessions_tenant_id ON sessions(tenant_id);

--- a/cli/internal/migrations/sql/000013_credential_metadata.up.sql
+++ b/cli/internal/migrations/sql/000013_credential_metadata.up.sql
@@ -1,0 +1,17 @@
+-- Credential metadata table for the pluggable credential store
+
+CREATE TABLE IF NOT EXISTS credential_metadata (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name VARCHAR(253) NOT NULL,
+    secret_type VARCHAR(50) NOT NULL,
+    keys TEXT[] NOT NULL DEFAULT '{}',
+    metadata JSONB NOT NULL DEFAULT '{}',
+    owner_id VARCHAR(255) NOT NULL,
+    owner_type VARCHAR(50) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(owner_type, owner_id, name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_credential_metadata_owner
+    ON credential_metadata(owner_type, owner_id);

--- a/cli/internal/migrations/sql/000014_integration_connections.up.sql
+++ b/cli/internal/migrations/sql/000014_integration_connections.up.sql
@@ -1,0 +1,16 @@
+-- Integration connections for pluggable issue trackers and other integrations
+
+CREATE TABLE IF NOT EXISTS integration_connections (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id VARCHAR(255) NOT NULL,
+    integration_type VARCHAR(50) NOT NULL,
+    adapter VARCHAR(500) NOT NULL,
+    credential_name VARCHAR(253) NOT NULL,
+    config JSONB NOT NULL DEFAULT '{}',
+    enabled BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_integration_connections_user
+    ON integration_connections(user_id, integration_type);

--- a/cli/internal/migrations/sql/000015_workspaces.up.sql
+++ b/cli/internal/migrations/sql/000015_workspaces.up.sql
@@ -1,0 +1,25 @@
+-- Workspaces table for per-user/per-session storage isolation
+
+CREATE TABLE IF NOT EXISTS workspaces (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    session_id      UUID NOT NULL REFERENCES sessions(id),
+    user_id         TEXT NOT NULL REFERENCES users(id),
+    tenant_id       TEXT NOT NULL REFERENCES tenants(id),
+    pvc_name        TEXT NOT NULL,
+    status          TEXT NOT NULL DEFAULT 'active',
+    size_gb         INT NOT NULL DEFAULT 1,
+    created_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    archived_at     TIMESTAMP WITH TIME ZONE,
+    deleted_at      TIMESTAMP WITH TIME ZONE
+);
+
+CREATE INDEX IF NOT EXISTS idx_workspaces_session_id ON workspaces(session_id);
+CREATE INDEX IF NOT EXISTS idx_workspaces_user_id ON workspaces(user_id);
+CREATE INDEX IF NOT EXISTS idx_workspaces_tenant_id ON workspaces(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_workspaces_status ON workspaces(status);
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS provisioned_at TIMESTAMP WITH TIME ZONE;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS provision_error TEXT;
+
+-- Allow sessions to reference an existing workspace for reuse
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS workspace_id UUID REFERENCES workspaces(id);

--- a/cli/internal/migrations/sql/000016_session_source.up.sql
+++ b/cli/internal/migrations/sql/000016_session_source.up.sql
@@ -1,0 +1,21 @@
+-- Migrate sessions from flat repo/branch columns to source JSONB.
+
+-- Add the new source column
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS source JSONB;
+
+-- Backfill existing rows: convert repo+branch into a GitSource JSON object
+UPDATE sessions
+SET source = jsonb_build_object(
+    'type', 'git',
+    'repo', COALESCE(repo, ''),
+    'branch', COALESCE(branch, 'main')
+)
+WHERE source IS NULL;
+
+-- Set a default for future inserts
+ALTER TABLE sessions ALTER COLUMN source SET DEFAULT '{"type": "git", "repo": "", "branch": "main"}'::jsonb;
+ALTER TABLE sessions ALTER COLUMN source SET NOT NULL;
+
+-- Drop old columns
+ALTER TABLE sessions DROP COLUMN IF EXISTS repo;
+ALTER TABLE sessions DROP COLUMN IF EXISTS branch;

--- a/cli/internal/postgres/embedded.go
+++ b/cli/internal/postgres/embedded.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -50,19 +52,79 @@ func (e *EmbeddedPostgres) Start(_ context.Context) error {
 		return fmt.Errorf("create runtime directory %s: %w", runtimeDir, err)
 	}
 
-	e.pg = embeddedpostgres.NewDatabase(
-		embeddedpostgres.DefaultConfig().
-			Port(uint32(e.config.Database.Port)). //nolint:gosec // port is a valid TCP port number (0-65535)
-			Database(e.config.Database.Name).
-			Username(e.config.Database.User).
-			Password(e.config.Database.Password).
-			DataPath(dataDir).
-			BinariesPath(cachePath).
-			RuntimePath(runtimeDir),
-	)
+	pgConfig := embeddedpostgres.DefaultConfig().
+		Port(uint32(e.config.Database.Port)). //nolint:gosec // port is a valid TCP port number (0-65535)
+		Database(e.config.Database.Name).
+		Username(e.config.Database.User).
+		Password(e.config.Database.Password).
+		DataPath(dataDir).
+		BinariesPath(cachePath).
+		RuntimePath(runtimeDir)
+
+	// When running in Docker or k3s mode, containers reach Postgres via the
+	// Docker bridge IP. Postgres must listen on all interfaces, not just
+	// localhost, and accept connections from Docker networks.
+	if e.config.Runtime == "docker" || e.config.Runtime == "k3s" {
+		pgConfig = pgConfig.StartParameters(map[string]string{
+			"listen_addresses": "*",
+		})
+	}
+
+	e.pg = embeddedpostgres.NewDatabase(pgConfig)
 
 	if err := e.pg.Start(); err != nil {
 		return fmt.Errorf("start embedded postgres: %w", err)
+	}
+
+	// When containers need to connect, allow password auth from Docker
+	// bridge networks (172.16.0.0/12 covers the default 172.17.0.0/16
+	// and k3d networks).
+	if e.config.Runtime == "docker" || e.config.Runtime == "k3s" {
+		if err := e.allowDockerConnections(dataDir); err != nil {
+			return fmt.Errorf("configure pg_hba for docker: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// allowDockerConnections appends a pg_hba.conf rule that permits
+// password-authenticated connections from Docker bridge networks,
+// then signals Postgres to reload its configuration.
+func (e *EmbeddedPostgres) allowDockerConnections(dataDir string) error {
+	hbaPath := filepath.Join(dataDir, "pg_hba.conf")
+	hbaRule := "\n# Allow connections from Docker bridge networks\nhost    all    all    172.16.0.0/12    password\n"
+
+	data, err := os.ReadFile(hbaPath)
+	if err != nil {
+		return fmt.Errorf("read pg_hba.conf: %w", err)
+	}
+
+	// Don't add the rule twice.
+	if strings.Contains(string(data), "172.16.0.0/12") {
+		return nil
+	}
+
+	f, err := os.OpenFile(hbaPath, os.O_APPEND|os.O_WRONLY, 0o600) //nolint:gosec // pg_hba.conf in trusted data directory
+	if err != nil {
+		return fmt.Errorf("open pg_hba.conf: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := f.WriteString(hbaRule); err != nil {
+		return fmt.Errorf("write pg_hba.conf: %w", err)
+	}
+
+	// Reload Postgres config (SIGHUP via pg_ctl).
+	cfgDir, cfgErr := config.ConfigDir()
+	if cfgErr != nil {
+		return fmt.Errorf("get config dir: %w", cfgErr)
+	}
+	pgCtl := filepath.Join(cfgDir, "cache", "pg", "bin", "pg_ctl")
+
+	cmd := exec.Command(pgCtl, "reload", "-D", dataDir) //nolint:gosec // pg_ctl path from trusted cache directory
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("reload postgres config: %w\n%s", err, out)
 	}
 
 	return nil
@@ -93,6 +155,100 @@ func (e *EmbeddedPostgres) RunMigrations(ctx context.Context, migrationsDir stri
 	}()
 
 	return runMigrationsWithDB(ctx, db, migrationsDir)
+}
+
+// RunMigrationsFS applies all pending up migrations from an fs.FS.
+func (e *EmbeddedPostgres) RunMigrationsFS(ctx context.Context, migrationFS fs.FS) (applied int, err error) {
+	dsn := e.config.DSN()
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		return 0, fmt.Errorf("open database: %w", err)
+	}
+	defer func() {
+		if cerr := db.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("close database: %w", cerr)
+		}
+	}()
+
+	return runMigrationsWithFS(ctx, db, migrationFS)
+}
+
+// runMigrationsWithFS applies all pending up migrations from an fs.FS.
+func runMigrationsWithFS(ctx context.Context, db *sql.DB, migrationFS fs.FS) (int, error) {
+	if err := db.PingContext(ctx); err != nil {
+		return 0, fmt.Errorf("ping database: %w", err)
+	}
+
+	_, err := db.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS schema_migrations (
+			version TEXT PRIMARY KEY,
+			applied_at TIMESTAMPTZ DEFAULT NOW()
+		)
+	`)
+	if err != nil {
+		return 0, fmt.Errorf("create schema_migrations table: %w", err)
+	}
+
+	entries, err := fs.ReadDir(migrationFS, ".")
+	if err != nil {
+		return 0, fmt.Errorf("read migrations fs: %w", err)
+	}
+
+	var files []string
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".up.sql") {
+			files = append(files, entry.Name())
+		}
+	}
+	sort.Strings(files)
+
+	applied := 0
+	for _, f := range files {
+		version := extractVersion(f)
+
+		var exists bool
+		err := db.QueryRowContext(ctx,
+			"SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE version = $1)",
+			version,
+		).Scan(&exists)
+		if err != nil {
+			return applied, fmt.Errorf("check migration %s: %w", version, err)
+		}
+		if exists {
+			continue
+		}
+
+		sqlBytes, err := fs.ReadFile(migrationFS, f)
+		if err != nil {
+			return applied, fmt.Errorf("read migration %s: %w", f, err)
+		}
+
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			return applied, fmt.Errorf("begin transaction for %s: %w", f, err)
+		}
+
+		if _, err := tx.ExecContext(ctx, string(sqlBytes)); err != nil {
+			_ = tx.Rollback()
+			return applied, fmt.Errorf("execute migration %s: %w", f, err)
+		}
+
+		if _, err := tx.ExecContext(ctx,
+			"INSERT INTO schema_migrations (version) VALUES ($1)",
+			version,
+		); err != nil {
+			_ = tx.Rollback()
+			return applied, fmt.Errorf("record migration %s: %w", f, err)
+		}
+
+		if err := tx.Commit(); err != nil {
+			return applied, fmt.Errorf("commit migration %s: %w", f, err)
+		}
+
+		applied++
+	}
+
+	return applied, nil
 }
 
 // runMigrationsWithDB applies all pending up migrations using the provided database connection.

--- a/cli/internal/postgres/embedded.go
+++ b/cli/internal/postgres/embedded.go
@@ -32,7 +32,7 @@ func New(cfg *config.Config) *EmbeddedPostgres {
 }
 
 // Start initializes and starts the embedded PostgreSQL instance.
-func (e *EmbeddedPostgres) Start(_ context.Context) error {
+func (e *EmbeddedPostgres) Start(ctx context.Context) error {
 	dataDir := e.config.Database.DataDir
 	if err := os.MkdirAll(dataDir, 0o700); err != nil {
 		return fmt.Errorf("create data directory %s: %w", dataDir, err)
@@ -80,7 +80,7 @@ func (e *EmbeddedPostgres) Start(_ context.Context) error {
 	// bridge networks (172.16.0.0/12 covers the default 172.17.0.0/16
 	// and k3d networks).
 	if e.config.Runtime == "docker" || e.config.Runtime == "k3s" {
-		if err := e.allowDockerConnections(dataDir); err != nil {
+		if err := e.allowDockerConnections(ctx, dataDir); err != nil {
 			return fmt.Errorf("configure pg_hba for docker: %w", err)
 		}
 	}
@@ -91,11 +91,11 @@ func (e *EmbeddedPostgres) Start(_ context.Context) error {
 // allowDockerConnections appends a pg_hba.conf rule that permits
 // password-authenticated connections from Docker bridge networks,
 // then signals Postgres to reload its configuration.
-func (e *EmbeddedPostgres) allowDockerConnections(dataDir string) error {
+func (e *EmbeddedPostgres) allowDockerConnections(ctx context.Context, dataDir string) (err error) {
 	hbaPath := filepath.Join(dataDir, "pg_hba.conf")
 	hbaRule := "\n# Allow connections from Docker bridge networks\nhost    all    all    172.16.0.0/12    password\n"
 
-	data, err := os.ReadFile(hbaPath)
+	data, err := os.ReadFile(hbaPath) //nolint:gosec // pg_hba.conf in trusted data directory
 	if err != nil {
 		return fmt.Errorf("read pg_hba.conf: %w", err)
 	}
@@ -109,7 +109,11 @@ func (e *EmbeddedPostgres) allowDockerConnections(dataDir string) error {
 	if err != nil {
 		return fmt.Errorf("open pg_hba.conf: %w", err)
 	}
-	defer f.Close()
+	defer func() {
+		if cerr := f.Close(); err == nil && cerr != nil {
+			err = fmt.Errorf("close pg_hba.conf: %w", cerr)
+		}
+	}()
 
 	if _, err := f.WriteString(hbaRule); err != nil {
 		return fmt.Errorf("write pg_hba.conf: %w", err)
@@ -122,7 +126,7 @@ func (e *EmbeddedPostgres) allowDockerConnections(dataDir string) error {
 	}
 	pgCtl := filepath.Join(cfgDir, "cache", "pg", "bin", "pg_ctl")
 
-	cmd := exec.Command(pgCtl, "reload", "-D", dataDir) //nolint:gosec // pg_ctl path from trusted cache directory
+	cmd := exec.CommandContext(ctx, pgCtl, "reload", "-D", dataDir) //nolint:gosec // pg_ctl path from trusted cache directory
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("reload postgres config: %w\n%s", err, out)
 	}

--- a/cli/internal/postgres/embedded_test.go
+++ b/cli/internal/postgres/embedded_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
@@ -808,6 +809,468 @@ func TestRunMigrationsWithDB_PartialApplyOnError(t *testing.T) {
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+// RunMigrationsWithFS tests.
+
+func TestRunMigrationsWithFS_PingError(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectPing().WillReturnError(fmt.Errorf("connection refused"))
+
+	applied, err := runMigrationsWithFS(context.Background(), db, os.DirFS(t.TempDir()))
+	if err == nil {
+		t.Fatal("expected ping error")
+	}
+	if applied != 0 {
+		t.Errorf("expected 0 applied, got %d", applied)
+	}
+	if !contains(err.Error(), "ping database") {
+		t.Errorf("expected 'ping database' in error, got %q", err.Error())
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+func TestRunMigrationsWithFS_CreateTableError(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectPing()
+	mock.ExpectExec("CREATE TABLE IF NOT EXISTS schema_migrations").
+		WillReturnError(fmt.Errorf("permission denied"))
+
+	applied, err := runMigrationsWithFS(context.Background(), db, os.DirFS(t.TempDir()))
+	if err == nil {
+		t.Fatal("expected create table error")
+	}
+	if applied != 0 {
+		t.Errorf("expected 0 applied, got %d", applied)
+	}
+	if !contains(err.Error(), "create schema_migrations table") {
+		t.Errorf("expected 'create schema_migrations table' in error, got %q", err.Error())
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+func TestRunMigrationsWithFS_NoMigrations(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectPing()
+	mock.ExpectExec("CREATE TABLE IF NOT EXISTS schema_migrations").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	applied, err := runMigrationsWithFS(context.Background(), db, os.DirFS(t.TempDir()))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if applied != 0 {
+		t.Errorf("expected 0 applied, got %d", applied)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+func TestRunMigrationsWithFS_AppliesNewMigrations(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "000001_init.up.sql"), []byte("CREATE TABLE test (id INT)"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "000002_add_col.up.sql"), []byte("ALTER TABLE test ADD COLUMN name TEXT"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Also add a down migration to verify it's skipped.
+	if err := os.WriteFile(filepath.Join(tmpDir, "000001_init.down.sql"), []byte("DROP TABLE test"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectPing()
+	mock.ExpectExec("CREATE TABLE IF NOT EXISTS schema_migrations").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	// Migration 000001: not yet applied.
+	mock.ExpectQuery("SELECT EXISTS").
+		WithArgs("000001_init").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectBegin()
+	mock.ExpectExec("CREATE TABLE test").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("INSERT INTO schema_migrations").
+		WithArgs("000001_init").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	// Migration 000002: not yet applied.
+	mock.ExpectQuery("SELECT EXISTS").
+		WithArgs("000002_add_col").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectBegin()
+	mock.ExpectExec("ALTER TABLE test ADD COLUMN name TEXT").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("INSERT INTO schema_migrations").
+		WithArgs("000002_add_col").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	applied, err := runMigrationsWithFS(context.Background(), db, os.DirFS(tmpDir))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if applied != 2 {
+		t.Errorf("expected 2 applied, got %d", applied)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+func TestRunMigrationsWithFS_SkipsAlreadyApplied(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "000001_init.up.sql"), []byte("CREATE TABLE test (id INT)"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectPing()
+	mock.ExpectExec("CREATE TABLE IF NOT EXISTS schema_migrations").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery("SELECT EXISTS").
+		WithArgs("000001_init").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+
+	applied, err := runMigrationsWithFS(context.Background(), db, os.DirFS(tmpDir))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if applied != 0 {
+		t.Errorf("expected 0 applied, got %d", applied)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+func TestRunMigrationsWithFS_CheckVersionError(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "000001_init.up.sql"), []byte("CREATE TABLE test (id INT)"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectPing()
+	mock.ExpectExec("CREATE TABLE IF NOT EXISTS schema_migrations").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery("SELECT EXISTS").
+		WithArgs("000001_init").
+		WillReturnError(fmt.Errorf("query failed"))
+
+	applied, err := runMigrationsWithFS(context.Background(), db, os.DirFS(tmpDir))
+	if err == nil {
+		t.Fatal("expected error checking migration version")
+	}
+	if applied != 0 {
+		t.Errorf("expected 0 applied, got %d", applied)
+	}
+	if !contains(err.Error(), "check migration") {
+		t.Errorf("expected 'check migration' in error, got %q", err.Error())
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+func TestRunMigrationsWithFS_BeginTxError(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "000001_init.up.sql"), []byte("CREATE TABLE test (id INT)"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectPing()
+	mock.ExpectExec("CREATE TABLE IF NOT EXISTS schema_migrations").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery("SELECT EXISTS").
+		WithArgs("000001_init").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectBegin().WillReturnError(fmt.Errorf("cannot begin transaction"))
+
+	applied, err := runMigrationsWithFS(context.Background(), db, os.DirFS(tmpDir))
+	if err == nil {
+		t.Fatal("expected begin transaction error")
+	}
+	if applied != 0 {
+		t.Errorf("expected 0 applied, got %d", applied)
+	}
+	if !contains(err.Error(), "begin transaction") {
+		t.Errorf("expected 'begin transaction' in error, got %q", err.Error())
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+func TestRunMigrationsWithFS_ExecMigrationError(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "000001_init.up.sql"), []byte("INVALID SQL"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectPing()
+	mock.ExpectExec("CREATE TABLE IF NOT EXISTS schema_migrations").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery("SELECT EXISTS").
+		WithArgs("000001_init").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectBegin()
+	mock.ExpectExec("INVALID SQL").
+		WillReturnError(fmt.Errorf("syntax error"))
+	mock.ExpectRollback()
+
+	applied, err := runMigrationsWithFS(context.Background(), db, os.DirFS(tmpDir))
+	if err == nil {
+		t.Fatal("expected exec migration error")
+	}
+	if applied != 0 {
+		t.Errorf("expected 0 applied, got %d", applied)
+	}
+	if !contains(err.Error(), "execute migration") {
+		t.Errorf("expected 'execute migration' in error, got %q", err.Error())
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+func TestRunMigrationsWithFS_RecordMigrationError(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "000001_init.up.sql"), []byte("CREATE TABLE test (id INT)"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectPing()
+	mock.ExpectExec("CREATE TABLE IF NOT EXISTS schema_migrations").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery("SELECT EXISTS").
+		WithArgs("000001_init").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectBegin()
+	mock.ExpectExec("CREATE TABLE test").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("INSERT INTO schema_migrations").
+		WithArgs("000001_init").
+		WillReturnError(fmt.Errorf("unique constraint violation"))
+	mock.ExpectRollback()
+
+	applied, err := runMigrationsWithFS(context.Background(), db, os.DirFS(tmpDir))
+	if err == nil {
+		t.Fatal("expected record migration error")
+	}
+	if applied != 0 {
+		t.Errorf("expected 0 applied, got %d", applied)
+	}
+	if !contains(err.Error(), "record migration") {
+		t.Errorf("expected 'record migration' in error, got %q", err.Error())
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+func TestRunMigrationsWithFS_CommitError(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "000001_init.up.sql"), []byte("CREATE TABLE test (id INT)"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectPing()
+	mock.ExpectExec("CREATE TABLE IF NOT EXISTS schema_migrations").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery("SELECT EXISTS").
+		WithArgs("000001_init").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectBegin()
+	mock.ExpectExec("CREATE TABLE test").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("INSERT INTO schema_migrations").
+		WithArgs("000001_init").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit().WillReturnError(fmt.Errorf("commit failed"))
+
+	applied, err := runMigrationsWithFS(context.Background(), db, os.DirFS(tmpDir))
+	if err == nil {
+		t.Fatal("expected commit error")
+	}
+	if applied != 0 {
+		t.Errorf("expected 0 applied, got %d", applied)
+	}
+	if !contains(err.Error(), "commit migration") {
+		t.Errorf("expected 'commit migration' in error, got %q", err.Error())
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %v", err)
+	}
+}
+
+// RunMigrationsFS (public method) tests.
+
+func TestRunMigrationsFS_OpenDatabaseError(t *testing.T) {
+	cfg := &config.Config{
+		Database: config.DatabaseConfig{
+			Mode:     "embedded",
+			Port:     15433,
+			User:     "test",
+			Password: "test",
+			Name:     "testdb",
+		},
+	}
+
+	pg := New(cfg)
+	// RunMigrationsFS will fail at PingContext because no real DB is running.
+	_, err := pg.RunMigrationsFS(context.Background(), os.DirFS(t.TempDir()))
+	if err == nil {
+		t.Fatal("expected error when no database is running")
+	}
+}
+
+// allowDockerConnections tests.
+
+func TestAllowDockerConnections_NoHbaFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("VOLUNDR_HOME", tmpDir)
+
+	cfg := &config.Config{}
+	pg := New(cfg)
+
+	err := pg.allowDockerConnections(context.Background(), tmpDir)
+	if err == nil {
+		t.Fatal("expected error reading pg_hba.conf")
+	}
+	if !contains(err.Error(), "read pg_hba.conf") {
+		t.Errorf("expected 'read pg_hba.conf' in error, got %q", err.Error())
+	}
+}
+
+func TestAllowDockerConnections_AlreadyContainsRule(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("VOLUNDR_HOME", tmpDir)
+
+	// Write pg_hba.conf with the Docker rule already present.
+	hbaPath := filepath.Join(tmpDir, "pg_hba.conf")
+	if err := os.WriteFile(hbaPath, []byte("host all all 172.16.0.0/12 password\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{}
+	pg := New(cfg)
+
+	// Should return nil without error since rule already exists.
+	err := pg.allowDockerConnections(context.Background(), tmpDir)
+	if err != nil {
+		t.Fatalf("expected no error when rule already exists, got: %v", err)
+	}
+}
+
+func TestAllowDockerConnections_AppendsRule(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("VOLUNDR_HOME", tmpDir)
+
+	// Create required directories for pg_ctl path.
+	pgCtlDir := filepath.Join(tmpDir, "cache", "pg", "bin")
+	if err := os.MkdirAll(pgCtlDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write pg_hba.conf without the Docker rule.
+	hbaPath := filepath.Join(tmpDir, "pg_hba.conf")
+	if err := os.WriteFile(hbaPath, []byte("# Default rules\nlocal all all trust\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{}
+	pg := New(cfg)
+
+	// This will fail at the pg_ctl reload step since there's no real pg_ctl,
+	// but the file should have been updated before that point.
+	err := pg.allowDockerConnections(context.Background(), tmpDir)
+
+	// Read the file to verify the rule was appended.
+	data, readErr := os.ReadFile(hbaPath)
+	if readErr != nil {
+		t.Fatalf("read pg_hba.conf: %v", readErr)
+	}
+
+	if !strings.Contains(string(data), "172.16.0.0/12") {
+		t.Error("expected Docker bridge rule to be appended to pg_hba.conf")
+	}
+
+	// We expect an error from pg_ctl reload since there's no real binary.
+	if err == nil {
+		t.Log("allowDockerConnections succeeded unexpectedly (pg_ctl may exist)")
 	}
 }
 

--- a/cli/internal/postgres/embedded_test.go
+++ b/cli/internal/postgres/embedded_test.go
@@ -1197,7 +1197,7 @@ func TestRunMigrationsFS_OpenDatabaseError(t *testing.T) {
 	}
 }
 
-// allowDockerConnections tests.
+// AllowDockerConnections tests.
 
 func TestAllowDockerConnections_NoHbaFile(t *testing.T) {
 	tmpDir := t.TempDir()
@@ -1259,7 +1259,7 @@ func TestAllowDockerConnections_AppendsRule(t *testing.T) {
 	err := pg.allowDockerConnections(context.Background(), tmpDir)
 
 	// Read the file to verify the rule was appended.
-	data, readErr := os.ReadFile(hbaPath)
+	data, readErr := os.ReadFile(hbaPath) //nolint:gosec // test file path from t.TempDir()
 	if readErr != nil {
 		t.Fatalf("read pg_hba.conf: %v", readErr)
 	}

--- a/cli/internal/runtime/docker.go
+++ b/cli/internal/runtime/docker.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	goruntime "runtime"
 	"strings"
 	"text/template"
 
@@ -47,6 +48,12 @@ var composeTemplate = template.Must(template.New("compose").Parse(`services:
       - "{{.ConfigPath}}:/etc/volundr/config.yaml:ro"
       - "{{.StorageDir}}:/volundr-storage"
       - "/var/run/docker.sock:/var/run/docker.sock"
+{{- if .ExtraHosts}}
+    extra_hosts:
+{{- range .ExtraHosts}}
+      - "{{.}}"
+{{- end}}
+{{- end}}
     networks:
       - volundr-net
 
@@ -67,6 +74,7 @@ type composeData struct {
 	AnthropicAPIKey string
 	ConfigPath      string
 	StorageDir      string
+	ExtraHosts      []string
 }
 
 // dockerAPIConfig represents the Python API config file structure for Docker mode.
@@ -114,7 +122,7 @@ func (r *DockerRuntime) Init(ctx context.Context, cfg *config.Config) error {
 	}
 
 	// Ensure required images are available (pull if not present locally).
-	apiImage := dockerImageOrDefault(cfg.Docker.APIImage, "ghcr.io/niuulabs/volundr-api:latest")
+	apiImage := dockerImageOrDefault(cfg.Docker.APIImage, "ghcr.io/niuulabs/volundr:latest")
 	if err := ensureImage(apiImage); err != nil {
 		return err
 	}
@@ -140,17 +148,25 @@ func (r *DockerRuntime) Up(ctx context.Context, cfg *config.Config) error {
 
 		// Run migrations.
 		fmt.Print("  Migrations    ... ")
-		migrationsDir := findMigrationsDir()
-		if migrationsDir != "" {
-			applied, err := r.pg.RunMigrations(ctx, migrationsDir)
-			if err != nil {
-				fmt.Println("failed")
-				return fmt.Errorf("run migrations: %w", err)
-			}
-			fmt.Printf("applied (%d migrations)\n", applied)
-		} else {
-			fmt.Println("skipped (no migrations directory found)")
+		applied, source, err := runMigrationsAuto(ctx, r.pg)
+		if err != nil {
+			fmt.Println("failed")
+			return fmt.Errorf("run migrations: %w", err)
 		}
+		if source != "" {
+			fmt.Printf("applied (%d migrations, source: %s)\n", applied, source)
+		} else {
+			fmt.Println("skipped (no migrations found)")
+		}
+	}
+
+	// Ensure storage directories are accessible by the container user.
+	cfgDirForStorage, err := config.ConfigDir()
+	if err != nil {
+		return fmt.Errorf("get config dir: %w", err)
+	}
+	if err := ensureContainerStorageDirs(cfgDirForStorage); err != nil {
+		return fmt.Errorf("ensure container storage dirs: %w", err)
 	}
 
 	// Create the Docker network if it doesn't exist.
@@ -184,7 +200,7 @@ func (r *DockerRuntime) Up(ctx context.Context, cfg *config.Config) error {
 		return fmt.Errorf("render compose template: %w", err)
 	}
 
-	if err := os.WriteFile(composePath, []byte(composeContent), 0o600); err != nil {
+	if err := os.WriteFile(composePath, []byte(composeContent), 0o644); err != nil { //nolint:gosec // compose file must be readable by container user
 		return fmt.Errorf("write compose file: %w", err)
 	}
 
@@ -435,8 +451,8 @@ func (r *DockerRuntime) buildComposeData(cfg *config.Config) composeData {
 
 	cfgDir, _ := config.ConfigDir()
 
-	return composeData{
-		APIImage:        dockerImageOrDefault(cfg.Docker.APIImage, "ghcr.io/niuulabs/volundr-api:latest"),
+	data := composeData{
+		APIImage:        dockerImageOrDefault(cfg.Docker.APIImage, "ghcr.io/niuulabs/volundr:latest"),
 		APIPort:         dockerAPIInternalPort,
 		DBHost:          dbHost,
 		DBPort:          cfg.Database.Port,
@@ -447,6 +463,14 @@ func (r *DockerRuntime) buildComposeData(cfg *config.Config) composeData {
 		ConfigPath:      filepath.Join(cfgDir, dockerConfigFileName),
 		StorageDir:      cfgDir,
 	}
+
+	// On Linux, host.docker.internal doesn't resolve by default
+	// (Docker Desktop feature only). Add extra_hosts mapping.
+	if goruntime.GOOS == "linux" {
+		data.ExtraHosts = []string{"host.docker.internal:host-gateway"}
+	}
+
+	return data
 }
 
 // generateDockerConfig creates a config.yaml for the Python API in Docker mode.
@@ -476,7 +500,7 @@ func (r *DockerRuntime) generateDockerConfig(cfg *config.Config) (string, error)
 				"network":           dockerImageOrDefault(cfg.Docker.Network, "volundr-net"),
 				"skuld_image":       dockerImageOrDefault(cfg.Docker.SkuldImage, "ghcr.io/niuulabs/skuld:latest"),
 				"code_server_image": dockerImageOrDefault(cfg.Docker.CodeServerImage, "ghcr.io/niuulabs/code-server:latest"),
-				"ttyd_image":        dockerImageOrDefault(cfg.Docker.TtydImage, "ghcr.io/niuulabs/ttyd:latest"),
+				"ttyd_image":        dockerImageOrDefault(cfg.Docker.TtydImage, "ghcr.io/niuulabs/devrunner:latest"),
 				"compose_dir":       containerStoragePath + "/sessions",
 				"gateway_domain":    "",
 				"db_host":           dbHost,
@@ -545,7 +569,7 @@ func (r *DockerRuntime) generateDockerConfig(cfg *config.Config) (string, error)
 	}
 
 	configPath := filepath.Join(cfgDir, dockerConfigFileName)
-	if err := os.WriteFile(configPath, data, 0o600); err != nil {
+	if err := os.WriteFile(configPath, data, 0o644); err != nil { //nolint:gosec // config must be readable by container user
 		return "", fmt.Errorf("write docker config: %w", err)
 	}
 

--- a/cli/internal/runtime/docker_test.go
+++ b/cli/internal/runtime/docker_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestRenderComposeTemplate_WithAnthropicKey(t *testing.T) {
 	data := composeData{ //nolint:gosec // test fixture, not real credentials
-		APIImage:        "ghcr.io/niuulabs/volundr-api:latest",
+		APIImage:        "ghcr.io/niuulabs/volundr:latest",
 		APIPort:         18080,
 		DBHost:          "host.docker.internal",
 		DBPort:          5433,
@@ -35,7 +35,7 @@ func TestRenderComposeTemplate_WithAnthropicKey(t *testing.T) {
 
 	// Verify key parts of the rendered template.
 	checks := []string{
-		`image: ghcr.io/niuulabs/volundr-api:latest`,
+		`image: ghcr.io/niuulabs/volundr:latest`,
 		`"127.0.0.1:18080:8080"`,
 		`DATABASE__HOST: "host.docker.internal"`,
 		`DATABASE__PORT: "5433"`,
@@ -59,7 +59,7 @@ func TestRenderComposeTemplate_WithAnthropicKey(t *testing.T) {
 
 func TestRenderComposeTemplate_WithoutAnthropicKey(t *testing.T) {
 	data := composeData{
-		APIImage:        "ghcr.io/niuulabs/volundr-api:v1.0.0",
+		APIImage:        "ghcr.io/niuulabs/volundr:v1.0.0",
 		APIPort:         18080,
 		DBHost:          "db.example.com",
 		DBPort:          5432,
@@ -80,7 +80,7 @@ func TestRenderComposeTemplate_WithoutAnthropicKey(t *testing.T) {
 		t.Errorf("expected no ANTHROPIC_API_KEY when key is empty, got:\n%s", result)
 	}
 
-	if !strings.Contains(result, "image: ghcr.io/niuulabs/volundr-api:v1.0.0") {
+	if !strings.Contains(result, "image: ghcr.io/niuulabs/volundr:v1.0.0") {
 		t.Errorf("expected custom API image, got:\n%s", result)
 	}
 

--- a/cli/internal/runtime/exec.go
+++ b/cli/internal/runtime/exec.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"bufio"
 	"context"
+	"io/fs"
 	"os"
 	"os/exec"
 
@@ -27,6 +28,7 @@ type postgresProvider interface {
 	Start(ctx context.Context) error
 	Stop() error
 	RunMigrations(ctx context.Context, dir string) (int, error)
+	RunMigrationsFS(ctx context.Context, migrationFS fs.FS) (int, error)
 }
 
 // newPostgres is a hookable function for creating a postgres provider.

--- a/cli/internal/runtime/exec_test.go
+++ b/cli/internal/runtime/exec_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"strings"
@@ -143,6 +144,9 @@ type fakePostgres struct {
 func (f *fakePostgres) Start(_ context.Context) error { return f.startErr }
 func (f *fakePostgres) Stop() error                   { return f.stopErr }
 func (f *fakePostgres) RunMigrations(_ context.Context, _ string) (int, error) {
+	return f.migrationsN, f.migrationsErr
+}
+func (f *fakePostgres) RunMigrationsFS(_ context.Context, _ fs.FS) (int, error) {
 	return f.migrationsN, f.migrationsErr
 }
 

--- a/cli/internal/runtime/k3s.go
+++ b/cli/internal/runtime/k3s.go
@@ -71,6 +71,12 @@ var k3sComposeTemplate = template.Must(template.New("k3s-compose").Parse(`servic
       - "{{.ConfigPath}}:/etc/volundr/config.yaml:ro"
       - "{{.KubeconfigPath}}:/etc/volundr/kubeconfig:ro"
       - "{{.StorageDir}}:/volundr-storage"
+{{- if .ExtraHosts}}
+    extra_hosts:
+{{- range .ExtraHosts}}
+      - "{{.}}"
+{{- end}}
+{{- end}}
     networks:
       - k3d-{{.ClusterName}}
 
@@ -94,6 +100,7 @@ type k3sComposeData struct {
 	KubeconfigPath  string
 	StorageDir      string
 	ClusterName     string
+	ExtraHosts      []string
 }
 
 // k3sAPIConfig represents the Python API config file structure for k3s mode.
@@ -163,6 +170,14 @@ func (r *K3sRuntime) Init(ctx context.Context, cfg *config.Config) error {
 		}
 	}
 
+	// Verify kubectl is available.
+	fmt.Print("  kubectl         ... ")
+	if _, err := execCommandContext(ctx, "kubectl", "version", "--client").CombinedOutput(); err != nil {
+		fmt.Println("not found")
+		return fmt.Errorf("kubectl is required but not installed. Install it from https://kubernetes.io/docs/tasks/tools/")
+	}
+	fmt.Println("ok")
+
 	// Verify helm is available, offer to install if not.
 	fmt.Print("  Helm            ... ")
 	if _, err := execCommandContext(ctx, "helm", "version", "--short").CombinedOutput(); err != nil {
@@ -222,16 +237,15 @@ func (r *K3sRuntime) Up(ctx context.Context, cfg *config.Config) error {
 
 		// Run migrations.
 		fmt.Print("  Migrations    ... ")
-		migrationsDir := findMigrationsDir()
-		if migrationsDir != "" {
-			applied, err := r.pg.RunMigrations(ctx, migrationsDir)
-			if err != nil {
-				fmt.Println("failed")
-				return fmt.Errorf("run migrations: %w", err)
-			}
-			fmt.Printf("applied (%d migrations)\n", applied)
+		applied, source, err := runMigrationsAuto(ctx, r.pg)
+		if err != nil {
+			fmt.Println("failed")
+			return fmt.Errorf("run migrations: %w", err)
+		}
+		if source != "" {
+			fmt.Printf("applied (%d migrations, source: %s)\n", applied, source)
 		} else {
-			fmt.Println("skipped (no migrations directory found)")
+			fmt.Println("skipped (no migrations found)")
 		}
 	}
 
@@ -247,6 +261,15 @@ func (r *K3sRuntime) Up(ctx context.Context, cfg *config.Config) error {
 	namespace := r.namespace(cfg)
 	if err := r.ensureK8sSecrets(cfg, namespace); err != nil {
 		return fmt.Errorf("create k8s secrets: %w", err)
+	}
+
+	// Ensure storage directories are accessible by the container user.
+	cfgDir, err := config.ConfigDir()
+	if err != nil {
+		return fmt.Errorf("get config dir: %w", err)
+	}
+	if err := ensureContainerStorageDirs(cfgDir); err != nil {
+		return fmt.Errorf("ensure container storage dirs: %w", err)
 	}
 
 	// Generate k3s-mode config for the Python API.
@@ -498,6 +521,12 @@ func (r *K3sRuntime) initK3d(ctx context.Context, cfg *config.Config) error {
 
 	if strings.Contains(string(out), k3sClusterName) {
 		fmt.Println("exists")
+		// Cluster exists — still prompt for local mounts config if not
+		// yet configured (the k3d node volumes can't change, but the
+		// config flag is needed for the API to show mount options).
+		if !cfg.LocalMounts.Enabled {
+			r.promptK3dLocalMountPrefixes(cfg)
+		}
 		return nil
 	}
 
@@ -556,7 +585,7 @@ func (r *K3sRuntime) initNativeK3s(cfg *config.Config) error {
 	}
 	kcPath := hostKubeconfigPath()
 	if data, err := os.ReadFile(defaultKC); err == nil { //nolint:gosec // path from known kubeconfig location or KUBECONFIG env
-		if writeErr := os.WriteFile(kcPath, data, 0o600); writeErr != nil { //nolint:gosec // path derived from trusted config directory
+		if writeErr := os.WriteFile(kcPath, data, 0o644); writeErr != nil { //nolint:gosec // kubeconfig must be readable by container user
 			return fmt.Errorf("write kubeconfig: %w", writeErr)
 		}
 	}
@@ -1050,7 +1079,7 @@ func (r *K3sRuntime) generateK3sConfig(cfg *config.Config) (string, error) {
 	}
 
 	configPath := filepath.Join(cfgDir, k3sConfigFileName)
-	if err := os.WriteFile(configPath, data, 0o600); err != nil {
+	if err := os.WriteFile(configPath, data, 0o644); err != nil { //nolint:gosec // config must be readable by container user
 		return "", fmt.Errorf("write k3s config: %w", err)
 	}
 
@@ -1078,7 +1107,7 @@ func (r *K3sRuntime) startAPIContainer(_ context.Context, cfg *config.Config) er
 	}
 
 	data := k3sComposeData{
-		APIImage:        dockerImageOrDefault(cfg.Docker.APIImage, "ghcr.io/niuulabs/volundr-api:latest"),
+		APIImage:        dockerImageOrDefault(cfg.Docker.APIImage, "ghcr.io/niuulabs/volundr:latest"),
 		ContainerName:   k3sContainerName,
 		APIPort:         k3sAPIInternalPort,
 		DBHost:          dbHost,
@@ -1093,13 +1122,19 @@ func (r *K3sRuntime) startAPIContainer(_ context.Context, cfg *config.Config) er
 		ClusterName:     k3sClusterName,
 	}
 
+	// On Linux, host.docker.internal doesn't resolve by default
+	// (Docker Desktop feature only). Add extra_hosts mapping.
+	if runtime.GOOS == "linux" {
+		data.ExtraHosts = []string{"host.docker.internal:host-gateway"}
+	}
+
 	var buf bytes.Buffer
 	if err := k3sComposeTemplate.Execute(&buf, data); err != nil {
 		return fmt.Errorf("render compose template: %w", err)
 	}
 
 	composePath := filepath.Join(cfgDir, k3sComposeFileName)
-	if err := os.WriteFile(composePath, buf.Bytes(), 0o600); err != nil {
+	if err := os.WriteFile(composePath, buf.Bytes(), 0o644); err != nil { //nolint:gosec // compose file must be readable by container user
 		return fmt.Errorf("write compose file: %w", err)
 	}
 
@@ -1129,7 +1164,7 @@ func (r *K3sRuntime) writeHostKubeconfig() error {
 	}
 
 	kcPath := hostKubeconfigPath()
-	if err := os.WriteFile(kcPath, out, 0o600); err != nil {
+	if err := os.WriteFile(kcPath, out, 0o644); err != nil { //nolint:gosec // kubeconfig must be readable by container user
 		return fmt.Errorf("write kubeconfig to %s: %w", kcPath, err)
 	}
 	fmt.Printf("  Kubeconfig     ... %s\n", kcPath)
@@ -1181,7 +1216,7 @@ func (r *K3sRuntime) writeK3dKubeconfig(cfgDir string) (string, error) {
 	}
 
 	kubeconfigPath := filepath.Join(cfgDir, k3sDockerKubeconfigFile)                //nolint:gosec // path derived from trusted config directory
-	if err := os.WriteFile(kubeconfigPath, []byte(kubeconfig), 0o600); err != nil { //nolint:gosec // path derived from trusted config directory
+	if err := os.WriteFile(kubeconfigPath, []byte(kubeconfig), 0o644); err != nil { //nolint:gosec // kubeconfig must be readable by container user
 		return "", fmt.Errorf("write docker kubeconfig: %w", err)
 	}
 

--- a/cli/internal/runtime/k3s_test.go
+++ b/cli/internal/runtime/k3s_test.go
@@ -543,7 +543,7 @@ func TestHostKubeconfigPath(t *testing.T) {
 
 func TestRenderK3sComposeTemplate(t *testing.T) {
 	data := k3sComposeData{
-		APIImage:        "ghcr.io/niuulabs/volundr-api:latest",
+		APIImage:        "ghcr.io/niuulabs/volundr:latest",
 		ContainerName:   "volundr-k3s-api",
 		APIPort:         18080,
 		DBHost:          "host.docker.internal",
@@ -566,7 +566,7 @@ func TestRenderK3sComposeTemplate(t *testing.T) {
 	result := buf.String()
 
 	checks := []string{
-		`image: ghcr.io/niuulabs/volundr-api:latest`,
+		`image: ghcr.io/niuulabs/volundr:latest`,
 		`container_name: volundr-k3s-api`,
 		`"127.0.0.1:18080:8080"`,
 		`DATABASE__HOST: "host.docker.internal"`,
@@ -587,7 +587,7 @@ func TestRenderK3sComposeTemplate(t *testing.T) {
 
 func TestRenderK3sComposeTemplate_WithoutAnthropicKey(t *testing.T) {
 	data := k3sComposeData{
-		APIImage:        "ghcr.io/niuulabs/volundr-api:latest",
+		APIImage:        "ghcr.io/niuulabs/volundr:latest",
 		ContainerName:   "volundr-k3s-api",
 		APIPort:         18080,
 		DBHost:          "host.docker.internal",

--- a/cli/internal/runtime/local.go
+++ b/cli/internal/runtime/local.go
@@ -450,7 +450,7 @@ func findMigrationsDir() string {
 
 // runMigrationsAuto runs migrations using embedded SQL files if available,
 // falling back to the filesystem. Returns (applied, source, error).
-func runMigrationsAuto(ctx context.Context, pg postgresProvider) (int, string, error) {
+func runMigrationsAuto(ctx context.Context, pg postgresProvider) (applied int, source string, err error) {
 	// Try embedded migrations first.
 	if mfs := migrations.FS(); mfs != nil {
 		applied, err := pg.RunMigrationsFS(ctx, mfs)
@@ -462,6 +462,6 @@ func runMigrationsAuto(ctx context.Context, pg postgresProvider) (int, string, e
 	if dir == "" {
 		return 0, "", nil
 	}
-	applied, err := pg.RunMigrations(ctx, dir)
+	applied, err = pg.RunMigrations(ctx, dir)
 	return applied, dir, err
 }

--- a/cli/internal/runtime/local.go
+++ b/cli/internal/runtime/local.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/niuulabs/volundr/cli/internal/config"
+	"github.com/niuulabs/volundr/cli/internal/migrations"
 	"github.com/niuulabs/volundr/cli/internal/proxy"
 )
 
@@ -90,16 +91,15 @@ func (r *LocalRuntime) Up(ctx context.Context, cfg *config.Config) error {
 
 		// Run migrations.
 		fmt.Print("  Migrations    ... ")
-		migrationsDir := findMigrationsDir()
-		if migrationsDir != "" {
-			applied, err := r.pg.RunMigrations(ctx, migrationsDir)
-			if err != nil {
-				fmt.Println("failed")
-				return fmt.Errorf("run migrations: %w", err)
-			}
-			fmt.Printf("applied (%d migrations)\n", applied)
+		applied, source, err := runMigrationsAuto(ctx, r.pg)
+		if err != nil {
+			fmt.Println("failed")
+			return fmt.Errorf("run migrations: %w", err)
+		}
+		if source != "" {
+			fmt.Printf("applied (%d migrations, source: %s)\n", applied, source)
 		} else {
-			fmt.Println("skipped (no migrations directory found)")
+			fmt.Println("skipped (no migrations found)")
 		}
 	}
 
@@ -446,4 +446,22 @@ func findMigrationsDir() string {
 	}
 
 	return ""
+}
+
+// runMigrationsAuto runs migrations using embedded SQL files if available,
+// falling back to the filesystem. Returns (applied, source, error).
+func runMigrationsAuto(ctx context.Context, pg postgresProvider) (int, string, error) {
+	// Try embedded migrations first.
+	if mfs := migrations.FS(); mfs != nil {
+		applied, err := pg.RunMigrationsFS(ctx, mfs)
+		return applied, "embedded", err
+	}
+
+	// Fall back to filesystem.
+	dir := findMigrationsDir()
+	if dir == "" {
+		return 0, "", nil
+	}
+	applied, err := pg.RunMigrations(ctx, dir)
+	return applied, dir, err
 }

--- a/cli/internal/runtime/local_test.go
+++ b/cli/internal/runtime/local_test.go
@@ -1425,7 +1425,7 @@ func TestDownFromPID_SuccessWithRunningProcess(t *testing.T) {
 	}
 
 	// Start a sleep process that we can signal.
-	cmd := exec.Command("sleep", "60")
+	cmd := exec.CommandContext(context.Background(), "sleep", "60") //nolint:gosec // test process
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start sleep process: %v", err)
 	}

--- a/cli/internal/runtime/local_test.go
+++ b/cli/internal/runtime/local_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -1335,6 +1336,132 @@ func TestLocalRuntime_Up_StartAPIFail(t *testing.T) {
 	if !contains(err.Error(), "start API") {
 		t.Errorf("expected 'start API' error, got: %v", err)
 	}
+}
+
+func TestRunMigrationsAuto_FilesystemFallback(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a migrations directory.
+	migDir := filepath.Join(tmpDir, "migrations")
+	if err := os.MkdirAll(migDir, 0o700); err != nil {
+		t.Fatalf("create migrations dir: %v", err)
+	}
+	// Create a migration file so findMigrationsDir finds something.
+	if err := os.WriteFile(filepath.Join(migDir, "000001_init.up.sql"), []byte("-- test"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	fp := &fakePostgres{migrationsN: 1}
+	applied, source, err := runMigrationsAuto(context.Background(), fp)
+	if err != nil {
+		t.Fatalf("runMigrationsAuto: %v", err)
+	}
+	if applied != 1 {
+		t.Errorf("expected 1 applied, got %d", applied)
+	}
+	// source should be an absolute path (not "embedded").
+	if source == "" || source == "embedded" {
+		t.Errorf("expected filesystem path as source, got %q", source)
+	}
+}
+
+func TestRunMigrationsAuto_NoMigrationsFound(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	fp := &fakePostgres{}
+	applied, source, err := runMigrationsAuto(context.Background(), fp)
+	if err != nil {
+		t.Fatalf("runMigrationsAuto: %v", err)
+	}
+	if applied != 0 {
+		t.Errorf("expected 0 applied, got %d", applied)
+	}
+	if source != "" {
+		t.Errorf("expected empty source, got %q", source)
+	}
+}
+
+func TestRunMigrationsAuto_FilesystemError(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a migrations directory.
+	migDir := filepath.Join(tmpDir, "migrations")
+	if err := os.MkdirAll(migDir, 0o700); err != nil {
+		t.Fatalf("create migrations dir: %v", err)
+	}
+
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	fp := &fakePostgres{migrationsErr: fmt.Errorf("migration failed")}
+	_, _, err := runMigrationsAuto(context.Background(), fp)
+	if err == nil {
+		t.Fatal("expected error from migrations")
+	}
+}
+
+func TestDownFromPID_SuccessWithRunningProcess(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	volundrDir := filepath.Join(tmpDir, ".volundr")
+	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
+		t.Fatalf("create config dir: %v", err)
+	}
+
+	// Start a sleep process that we can signal.
+	cmd := exec.Command("sleep", "60")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep process: %v", err)
+	}
+	pid := cmd.Process.Pid
+
+	// Write PID file with the sleep process PID.
+	pidPath := filepath.Join(volundrDir, PIDFile)
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(pid)), 0o600); err != nil {
+		_ = cmd.Process.Kill()
+		t.Fatalf("write PID file: %v", err)
+	}
+
+	// Write state file that should be cleaned up.
+	stateFilePath := filepath.Join(volundrDir, StateFile)
+	if err := os.WriteFile(stateFilePath, []byte("[]"), 0o600); err != nil {
+		_ = cmd.Process.Kill()
+		t.Fatalf("write state file: %v", err)
+	}
+
+	err := DownFromPID()
+	if err != nil {
+		t.Fatalf("DownFromPID: %v", err)
+	}
+
+	// PID file should be cleaned up.
+	if _, err := os.Stat(pidPath); !os.IsNotExist(err) {
+		t.Error("expected PID file to be removed")
+	}
+
+	// State file should be cleaned up.
+	if _, err := os.Stat(stateFilePath); !os.IsNotExist(err) {
+		t.Error("expected state file to be removed")
+	}
+
+	// Clean up: the process was signaled, wait for it.
+	_ = cmd.Wait()
 }
 
 func contains(s, substr string) bool {

--- a/cli/internal/runtime/runtime.go
+++ b/cli/internal/runtime/runtime.go
@@ -4,7 +4,10 @@ package runtime
 
 import (
 	"context"
+	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 
 	"github.com/niuulabs/volundr/cli/internal/config"
 )
@@ -73,6 +76,54 @@ func buildGitConfig(cfg *config.Config) map[string]interface{} {
 	}
 
 	return git
+}
+
+// containerUID and containerGID are the user/group IDs of the volundr
+// user inside the API container image.
+const (
+	containerUID = 1001
+	containerGID = 1001
+)
+
+// ensureContainerStorageDirs creates directories that the API container
+// writes to and chowns them to the container user (UID 1001). The config
+// dir itself needs 0o755 so the container can traverse to its mounted files.
+func ensureContainerStorageDirs(cfgDir string) error {
+	// Config dir must be traversable by the container user.
+	if err := os.Chmod(cfgDir, 0o755); err != nil {
+		return fmt.Errorf("chmod config dir: %w", err)
+	}
+
+	// Directories the container writes to — owned by the container user
+	// with 0o755 so only that user can write. If chown fails (e.g. not
+	// running as root), fall back to 0o777.
+	//
+	// data/ is included because the API creates subdirs like data/home/
+	// at runtime. data/pg/ (Postgres) is host-side and already exists
+	// with 0o700 — chown won't recurse into it.
+	writableDirs := []string{
+		filepath.Join(cfgDir, "data"),
+		filepath.Join(cfgDir, "data", "workspaces"),
+		filepath.Join(cfgDir, "sessions"),
+		filepath.Join(cfgDir, "user-credentials"),
+	}
+	for _, dir := range writableDirs {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("create directory %s: %w", dir, err)
+		}
+		if err := os.Chown(dir, containerUID, containerGID); err != nil {
+			// Not root — can't chown, use world-writable as fallback.
+			if err := os.Chmod(dir, 0o777); err != nil { //nolint:gosec // fallback when chown unavailable
+				return fmt.Errorf("chmod directory %s: %w", dir, err)
+			}
+		} else {
+			if err := os.Chmod(dir, 0o755); err != nil {
+				return fmt.Errorf("chmod directory %s: %w", dir, err)
+			}
+		}
+	}
+
+	return nil
 }
 
 // Runtime manages the Volundr stack lifecycle.

--- a/cli/internal/runtime/runtime.go
+++ b/cli/internal/runtime/runtime.go
@@ -90,7 +90,7 @@ const (
 // dir itself needs 0o755 so the container can traverse to its mounted files.
 func ensureContainerStorageDirs(cfgDir string) error {
 	// Config dir must be traversable by the container user.
-	if err := os.Chmod(cfgDir, 0o755); err != nil {
+	if err := os.Chmod(cfgDir, 0o755); err != nil { //nolint:gosec // container user needs to traverse config dir
 		return fmt.Errorf("chmod config dir: %w", err)
 	}
 
@@ -108,7 +108,7 @@ func ensureContainerStorageDirs(cfgDir string) error {
 		filepath.Join(cfgDir, "user-credentials"),
 	}
 	for _, dir := range writableDirs {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
+		if err := os.MkdirAll(dir, 0o750); err != nil { //nolint:gosec // container user needs access to storage dirs
 			return fmt.Errorf("create directory %s: %w", dir, err)
 		}
 		if err := os.Chown(dir, containerUID, containerGID); err != nil {
@@ -117,7 +117,7 @@ func ensureContainerStorageDirs(cfgDir string) error {
 				return fmt.Errorf("chmod directory %s: %w", dir, err)
 			}
 		} else {
-			if err := os.Chmod(dir, 0o755); err != nil {
+			if err := os.Chmod(dir, 0o750); err != nil { //nolint:gosec // container user needs access to storage dirs
 				return fmt.Errorf("chmod directory %s: %w", dir, err)
 			}
 		}

--- a/cli/internal/runtime/runtime_test.go
+++ b/cli/internal/runtime/runtime_test.go
@@ -1,6 +1,9 @@
 package runtime
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/niuulabs/volundr/cli/internal/config"
@@ -117,6 +120,75 @@ func TestBuildGitConfig_EnabledNoInstances(t *testing.T) {
 
 	if _, ok := ghMap["instances"]; ok {
 		t.Error("expected no instances key when instances is nil")
+	}
+}
+
+func TestEnsureContainerStorageDirs(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	err := ensureContainerStorageDirs(tmpDir)
+	if err != nil {
+		t.Fatalf("ensureContainerStorageDirs: %v", err)
+	}
+
+	// Verify all expected directories were created.
+	expectedDirs := []string{
+		filepath.Join(tmpDir, "data"),
+		filepath.Join(tmpDir, "data", "workspaces"),
+		filepath.Join(tmpDir, "sessions"),
+		filepath.Join(tmpDir, "user-credentials"),
+	}
+
+	for _, dir := range expectedDirs {
+		info, err := os.Stat(dir)
+		if err != nil {
+			t.Errorf("expected directory %s to exist: %v", dir, err)
+			continue
+		}
+		if !info.IsDir() {
+			t.Errorf("expected %s to be a directory", dir)
+		}
+	}
+}
+
+func TestEnsureContainerStorageDirs_ChmodCfgDirError(t *testing.T) {
+	// Use a path that doesn't exist so Chmod fails.
+	err := ensureContainerStorageDirs("/nonexistent/dir/that/does/not/exist")
+	if err == nil {
+		t.Fatal("expected error for non-existent config dir")
+	}
+	if !strings.Contains(err.Error(), "chmod config dir") {
+		t.Errorf("expected 'chmod config dir' in error, got %q", err.Error())
+	}
+}
+
+func TestEnsureContainerStorageDirs_MkdirError(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a file where a directory should be, so MkdirAll fails.
+	dataPath := filepath.Join(tmpDir, "data")
+	if err := os.WriteFile(dataPath, []byte("block"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := ensureContainerStorageDirs(tmpDir)
+	if err == nil {
+		t.Fatal("expected error when directory creation fails")
+	}
+	if !strings.Contains(err.Error(), "create directory") {
+		t.Errorf("expected 'create directory' in error, got %q", err.Error())
+	}
+}
+
+func TestEnsureContainerStorageDirs_Idempotent(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Call twice — should not error on second call.
+	if err := ensureContainerStorageDirs(tmpDir); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if err := ensureContainerStorageDirs(tmpDir); err != nil {
+		t.Fatalf("second call: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `kubectl` and `helm` preflight checks during `volundr init` for docker/k3s runtimes, with platform-specific install instructions if missing
- Add listen host prompt to init wizard — supports `localhost` (default), `all` (0.0.0.0), or a specific IP address
- Fix container networking: `extra_hosts` on Linux, Postgres `listen_addresses` and `pg_hba.conf` for Docker bridge access
- Fix container storage directory permissions (chown to UID 1001 with 0o777 fallback)
- Embed SQL migrations in the binary via `embed_migrations` build tag
- Fix image names (`volundr-api` → `volundr`, `ttyd` → `devrunner`)
- Fix file permissions from 0o600 to 0o644 for container-mounted configs
- Fix k3d init to prompt for local mounts when cluster already exists

## Test plan
- [x] `go vet ./...` passes
- [x] `gofmt` clean
- [x] `go test ./...` passes
- [x] Run `volundr init --runtime k3s` on a machine without kubectl — verify error with install instructions
- [x] Run `volundr init` and select "all" for listen host — verify config has `0.0.0.0`
- [x] Run `volundr init` and type a specific IP — verify config has that IP
- [x] Cross-compile and deploy on DGX Spark (Linux arm64) — verified 4/4 pod containers running

🤖 Generated with [Claude Code](https://claude.com/claude-code)