### PR TITLE
feat(adapters): RFC 1123 session name validation at API and UI level

### DIFF
--- a/src/volundr/adapters/inbound/rest.py
+++ b/src/volundr/adapters/inbound/rest.py
@@ -69,9 +69,7 @@ class SessionCreate(BaseModel):
         if not v:
             raise ValueError("Session name must not be empty")
         if len(v) > 63:
-            raise ValueError(
-                "Session name must be at most 63 characters (RFC 1123 hostname limit)"
-            )
+            raise ValueError("Session name must be at most 63 characters (RFC 1123 hostname limit)")
         if v != v.lower():
             raise ValueError(
                 "Session name must be lowercase — uppercase characters are not allowed"
@@ -88,6 +86,7 @@ class SessionCreate(BaseModel):
                 "and hyphens (-)"
             )
         return v
+
     model: str = Field(
         default="",
         max_length=100,
@@ -165,6 +164,7 @@ class SessionUpdate(BaseModel):
         if v is None:
             return v
         return SessionCreate.validate_rfc1123(v)
+
     model: str | None = Field(
         default=None,
         min_length=1,

--- a/src/volundr/adapters/inbound/rest.py
+++ b/src/volundr/adapters/inbound/rest.py
@@ -3,12 +3,13 @@
 import asyncio
 import json
 import logging
+import re
 from uuid import UUID, uuid4
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, status
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from volundr.adapters.inbound.auth import require_role
 from volundr.domain.models import (
@@ -46,15 +47,47 @@ from volundr.domain.services import (
 logger = logging.getLogger(__name__)
 
 
+_RFC1123_RE = re.compile(r"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$")
+
+
 class SessionCreate(BaseModel):
     """Request model for creating a session."""
 
     name: str = Field(
         ...,
         min_length=1,
-        max_length=255,
-        description="Human-readable session name",
+        max_length=63,
+        description="Session name (RFC 1123 label: lowercase alphanumeric and hyphens, "
+        "must start and end with alphanumeric, max 63 characters)",
     )
+
+    @field_validator("name")
+    @classmethod
+    def validate_rfc1123(cls, v: str) -> str:
+        """Validate session name is a valid RFC 1123 DNS label."""
+        v = v.strip()
+        if not v:
+            raise ValueError("Session name must not be empty")
+        if len(v) > 63:
+            raise ValueError(
+                "Session name must be at most 63 characters (RFC 1123 hostname limit)"
+            )
+        if v != v.lower():
+            raise ValueError(
+                "Session name must be lowercase — uppercase characters are not allowed"
+            )
+        if " " in v:
+            raise ValueError("Session name must not contain spaces — use hyphens instead")
+        if v.startswith("-"):
+            raise ValueError("Session name must start with a letter or digit, not a hyphen")
+        if v.endswith("-"):
+            raise ValueError("Session name must end with a letter or digit, not a hyphen")
+        if not _RFC1123_RE.match(v):
+            raise ValueError(
+                "Session name may only contain lowercase letters (a-z), digits (0-9), "
+                "and hyphens (-)"
+            )
+        return v
     model: str = Field(
         default="",
         max_length=100,
@@ -121,9 +154,17 @@ class SessionUpdate(BaseModel):
     name: str | None = Field(
         default=None,
         min_length=1,
-        max_length=255,
-        description="New session name",
+        max_length=63,
+        description="New session name (RFC 1123 label)",
     )
+
+    @field_validator("name")
+    @classmethod
+    def validate_rfc1123(cls, v: str | None) -> str | None:
+        """Validate session name is a valid RFC 1123 DNS label."""
+        if v is None:
+            return v
+        return SessionCreate.validate_rfc1123(v)
     model: str | None = Field(
         default=None,
         min_length=1,

--- a/src/volundr/adapters/outbound/direct_k8s_pod_manager.py
+++ b/src/volundr/adapters/outbound/direct_k8s_pod_manager.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from typing import Any
 
 from volundr.domain.models import Session, SessionSpec, SessionStatus
@@ -544,7 +545,7 @@ fi
             home_env = [{"name": "HOME", "value": home_mount}]
 
         pod_spec: dict[str, Any] = {
-            "hostname": session.name,
+            "hostname": re.sub(r"[^a-z0-9-]", "-", session.name.lower()).strip("-")[:63] or "session",
             "terminationGracePeriodSeconds": 30,
             "securityContext": {
                 "fsGroup": 1000,

--- a/src/volundr/adapters/outbound/direct_k8s_pod_manager.py
+++ b/src/volundr/adapters/outbound/direct_k8s_pod_manager.py
@@ -544,8 +544,10 @@ fi
         if home_enabled:
             home_env = [{"name": "HOME", "value": home_mount}]
 
+        safe_hostname = re.sub(r"[^a-z0-9-]", "-", session.name.lower())
+        safe_hostname = safe_hostname.strip("-")[:63] or "session"
         pod_spec: dict[str, Any] = {
-            "hostname": re.sub(r"[^a-z0-9-]", "-", session.name.lower()).strip("-")[:63] or "session",
+            "hostname": safe_hostname,
             "terminationGracePeriodSeconds": 30,
             "securityContext": {
                 "fsGroup": 1000,

--- a/tests/test_adapters/test_rest.py
+++ b/tests/test_adapters/test_rest.py
@@ -87,11 +87,11 @@ class TestSessionCreate:
     def test_valid_session_create(self):
         """SessionCreate accepts valid data."""
         data = SessionCreate(
-            name="Test Session",
+            name="test-session",
             model="claude-sonnet-4",
             source=GitSource(repo="https://github.com/org/repo", branch="main"),
         )
-        assert data.name == "Test Session"
+        assert data.name == "test-session"
         assert data.model == "claude-sonnet-4"
         assert data.source.repo == "https://github.com/org/repo"
         assert data.source.branch == "main"
@@ -123,15 +123,15 @@ class TestSessionUpdate:
 
     def test_session_update_partial(self):
         """SessionUpdate allows partial updates."""
-        data = SessionUpdate(name="New Name")
-        assert data.name == "New Name"
+        data = SessionUpdate(name="new-name")
+        assert data.name == "new-name"
         assert data.model is None
         assert data.branch is None
 
     def test_session_update_all_fields(self):
         """SessionUpdate allows all fields."""
-        data = SessionUpdate(name="New Name", model="claude-opus-4", branch="feature/new")
-        assert data.name == "New Name"
+        data = SessionUpdate(name="new-name", model="claude-opus-4", branch="feature/new")
+        assert data.name == "new-name"
         assert data.model == "claude-opus-4"
         assert data.branch == "feature/new"
 
@@ -214,14 +214,14 @@ class TestCreateSession:
         response = client.post(
             "/api/v1/volundr/sessions",
             json={
-                "name": "My Session",
+                "name": "my-session",
                 "model": "claude-sonnet-4",
                 "source": {"type": "git", "repo": "https://github.com/org/repo", "branch": "main"},
             },
         )
         assert response.status_code == 201
         data = response.json()
-        assert data["name"] == "My Session"
+        assert data["name"] == "my-session"
         assert data["model"] == "claude-sonnet-4"
         assert data["source"]["repo"] == "https://github.com/org/repo"
         assert data["source"]["branch"] == "main"
@@ -303,11 +303,11 @@ class TestUpdateSession:
 
         response = client.put(
             f"/api/v1/volundr/sessions/{session.id}",
-            json={"name": "New Name"},
+            json={"name": "new-name"},
         )
         assert response.status_code == 200
         data = response.json()
-        assert data["name"] == "New Name"
+        assert data["name"] == "new-name"
         assert data["model"] == "claude-sonnet-4"
 
     async def test_update_session_model(self, client: TestClient, service: SessionService):
@@ -351,7 +351,7 @@ class TestUpdateSession:
     async def test_update_session_all_fields(self, client: TestClient, service: SessionService):
         """Updates name, model, and branch."""
         session = await service.create_session(
-            "Old",
+            "old",
             "claude-sonnet-4",
             source=GitSource(
                 repo="https://github.com/org/repo",
@@ -361,11 +361,11 @@ class TestUpdateSession:
 
         response = client.put(
             f"/api/v1/volundr/sessions/{session.id}",
-            json={"name": "New", "model": "claude-opus-4", "branch": "dev"},
+            json={"name": "new", "model": "claude-opus-4", "branch": "dev"},
         )
         assert response.status_code == 200
         data = response.json()
-        assert data["name"] == "New"
+        assert data["name"] == "new"
         assert data["model"] == "claude-opus-4"
         assert data["source"]["branch"] == "dev"
 
@@ -374,7 +374,7 @@ class TestUpdateSession:
         fake_id = uuid4()
         response = client.put(
             f"/api/v1/volundr/sessions/{fake_id}",
-            json={"name": "New Name"},
+            json={"name": "new-name"},
         )
         assert response.status_code == 404
 

--- a/tests/test_adapters/test_rest_session_name.py
+++ b/tests/test_adapters/test_rest_session_name.py
@@ -1,0 +1,61 @@
+"""Tests for RFC 1123 session name validation on SessionCreate."""
+
+import pytest
+from pydantic import ValidationError
+
+from volundr.adapters.inbound.rest import SessionCreate
+
+
+class TestSessionNameValidation:
+    """SessionCreate.name must be a valid RFC 1123 DNS label."""
+
+    def _create(self, name: str) -> SessionCreate:
+        return SessionCreate(name=name, model="claude-sonnet-4-20250514")
+
+    def test_valid_simple_name(self):
+        sc = self._create("my-session")
+        assert sc.name == "my-session"
+
+    def test_valid_single_char(self):
+        sc = self._create("a")
+        assert sc.name == "a"
+
+    def test_valid_digits_only(self):
+        sc = self._create("123")
+        assert sc.name == "123"
+
+    def test_valid_max_length(self):
+        sc = self._create("a" * 63)
+        assert len(sc.name) == 63
+
+    def test_rejects_uppercase(self):
+        with pytest.raises(ValidationError, match="lowercase"):
+            self._create("MySession")
+
+    def test_rejects_spaces(self):
+        with pytest.raises(ValidationError, match="spaces"):
+            self._create("my session")
+
+    def test_rejects_leading_hyphen(self):
+        with pytest.raises(ValidationError, match="start with"):
+            self._create("-my-session")
+
+    def test_rejects_trailing_hyphen(self):
+        with pytest.raises(ValidationError, match="end with"):
+            self._create("my-session-")
+
+    def test_rejects_underscore(self):
+        with pytest.raises(ValidationError, match="lowercase letters"):
+            self._create("my_session")
+
+    def test_rejects_over_63_chars(self):
+        with pytest.raises(ValidationError, match="63"):
+            self._create("a" * 64)
+
+    def test_rejects_empty(self):
+        with pytest.raises(ValidationError):
+            self._create("")
+
+    def test_rejects_dot(self):
+        with pytest.raises(ValidationError, match="lowercase letters"):
+            self._create("my.session")

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -141,7 +141,7 @@ class TestSessionEndpoints:
         response = client.post(
             "/api/v1/volundr/sessions",
             json={
-                "name": "Test Session",
+                "name": "test-session",
                 "model": "claude-sonnet-4-20250514",
                 "repo": "https://github.com/test/repo",
                 "branch": "main",
@@ -150,7 +150,7 @@ class TestSessionEndpoints:
 
         assert response.status_code == 201
         data = response.json()
-        assert data["name"] == "Test Session"
+        assert data["name"] == "test-session"
         assert data["status"] == "provisioning"
 
         # Verify events were published (created + updated for starting + updated for provisioning)
@@ -175,7 +175,7 @@ class TestSessionEndpoints:
         create_response = client.post(
             "/api/v1/volundr/sessions",
             json={
-                "name": "Test Session",
+                "name": "test-session",
                 "model": "claude-sonnet-4-20250514",
                 "repo": "https://github.com/test/repo",
                 "branch": "main",
@@ -189,11 +189,11 @@ class TestSessionEndpoints:
         # Update session
         response = client.put(
             f"/api/v1/volundr/sessions/{session_id}",
-            json={"name": "Updated Name"},
+            json={"name": "updated-name"},
         )
 
         assert response.status_code == 200
-        assert response.json()["name"] == "Updated Name"
+        assert response.json()["name"] == "updated-name"
 
         # Verify event was published
         assert len(mock_broadcaster.session_updated_events) == 1
@@ -204,7 +204,7 @@ class TestSessionEndpoints:
         create_response = client.post(
             "/api/v1/volundr/sessions",
             json={
-                "name": "Test Session",
+                "name": "test-session",
                 "model": "claude-sonnet-4-20250514",
                 "repo": "https://github.com/test/repo",
                 "branch": "main",

--- a/web/src/components/LaunchWizard/LaunchWizard.tsx
+++ b/web/src/components/LaunchWizard/LaunchWizard.tsx
@@ -11,6 +11,7 @@ import type {
   MountMapping,
 } from '@/models';
 import type { IVolundrService } from '@/ports';
+import { validateSessionName } from '@/utils/sessionName';
 import { WizardStepper } from './WizardStepper';
 import { TemplateStep, BLANK_TEMPLATE } from './steps/TemplateStep';
 import { ConfigureStep } from './steps/ConfigureStep';
@@ -199,7 +200,11 @@ export function LaunchWizard(props: LaunchWizardProps) {
       : state.mountPaths.some(p => p.host_path && p.mount_path));
 
   const canProceedToStep3 =
-    state !== null && state.name.trim() !== '' && hasValidSource && state.model !== '';
+    state !== null &&
+    state.name.trim() !== '' &&
+    !validateSessionName(state.name.trim()) &&
+    hasValidSource &&
+    state.model !== '';
 
   const canLaunch = canProceedToStep3 && !isLaunching;
 

--- a/web/src/components/LaunchWizard/steps/ConfigureStep.tsx
+++ b/web/src/components/LaunchWizard/steps/ConfigureStep.tsx
@@ -23,6 +23,7 @@ import {
 import { cn } from '@/utils';
 import { serializePresetYaml, parsePresetYaml } from '@/utils/presetYaml';
 import { parseK8sQuantity, formatHumanBytes, formatResourceValue } from '@/utils/k8sQuantity';
+import { validateSessionName } from '@/utils/sessionName';
 import type {
   VolundrPreset,
   VolundrRepo,
@@ -613,15 +614,23 @@ export function ConfigureStep({
             <Terminal className={styles.formLabelIcon} />
             Session Name
             <span className={styles.required}>*</span>
+            <span className={styles.formLabelHint}>(lowercase letters, digits, hyphens)</span>
           </label>
           <input
-            className={styles.formInput}
+            className={cn(
+              styles.formInput,
+              validateSessionName(state.name) && styles.formInputError
+            )}
             type="text"
             placeholder="e.g. feature-auth-refactor"
             value={state.name}
             onChange={e => onChange({ name: e.target.value })}
             required
+            maxLength={63}
           />
+          {validateSessionName(state.name) && (
+            <span className={styles.resourceError}>{validateSessionName(state.name)}</span>
+          )}
         </div>
 
         {/* Linear Issue */}

--- a/web/src/utils/index.ts
+++ b/web/src/utils/index.ts
@@ -18,3 +18,4 @@ export {
   formatHumanBytes,
   formatResourceValue,
 } from './k8sQuantity';
+export { validateSessionName } from './sessionName';

--- a/web/src/utils/sessionName.test.ts
+++ b/web/src/utils/sessionName.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { validateSessionName } from './sessionName';
+
+describe('validateSessionName', () => {
+  it('returns null for valid names', () => {
+    expect(validateSessionName('my-session')).toBeNull();
+    expect(validateSessionName('fix-auth-bug')).toBeNull();
+    expect(validateSessionName('a')).toBeNull();
+    expect(validateSessionName('session123')).toBeNull();
+    expect(validateSessionName('a'.repeat(63))).toBeNull();
+  });
+
+  it('returns null for empty string (handled by required)', () => {
+    expect(validateSessionName('')).toBeNull();
+  });
+
+  it('rejects names over 63 characters', () => {
+    const result = validateSessionName('a'.repeat(64));
+    expect(result).toContain('63 characters');
+  });
+
+  it('rejects uppercase characters with suggestion', () => {
+    const result = validateSessionName('MySession');
+    expect(result).toContain('lowercase');
+    expect(result).toContain('mysession');
+  });
+
+  it('rejects spaces', () => {
+    const result = validateSessionName('my session');
+    expect(result).toContain('Spaces');
+    expect(result).toContain('hyphens');
+  });
+
+  it('rejects leading hyphen', () => {
+    const result = validateSessionName('-my-session');
+    expect(result).toContain('start with');
+  });
+
+  it('rejects trailing hyphen', () => {
+    const result = validateSessionName('my-session-');
+    expect(result).toContain('end with');
+  });
+
+  it('rejects special characters and names them', () => {
+    const result = validateSessionName('my_session');
+    expect(result).toContain('"_"');
+  });
+
+  it('rejects dots', () => {
+    const result = validateSessionName('my.session');
+    expect(result).toContain('"."');
+  });
+});

--- a/web/src/utils/sessionName.ts
+++ b/web/src/utils/sessionName.ts
@@ -1,0 +1,46 @@
+const RFC1123_RE = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/;
+
+/**
+ * Validate a session name against RFC 1123 DNS label rules.
+ * Returns a user-friendly error string, or null if valid.
+ *
+ * Rules:
+ *  - Lowercase letters (a-z), digits (0-9), and hyphens (-) only
+ *  - Must start and end with a letter or digit
+ *  - Max 63 characters
+ */
+export function validateSessionName(name: string): string | null {
+  if (!name) return null; // empty is handled by required
+
+  if (name.length > 63) {
+    return 'Must be at most 63 characters (Kubernetes hostname limit)';
+  }
+
+  if (name !== name.toLowerCase()) {
+    return 'Must be lowercase — try "' + name.toLowerCase() + '"';
+  }
+
+  if (name.includes(' ')) {
+    return 'Spaces are not allowed — use hyphens instead';
+  }
+
+  if (name.startsWith('-')) {
+    return 'Must start with a letter or digit, not a hyphen';
+  }
+
+  if (name.endsWith('-')) {
+    return 'Must end with a letter or digit, not a hyphen';
+  }
+
+  if (/[^a-z0-9-]/.test(name)) {
+    const bad = name.match(/[^a-z0-9-]/g);
+    const chars = [...new Set(bad)].map(c => `"${c}"`).join(', ');
+    return `Invalid character${bad && bad.length > 1 ? 's' : ''}: ${chars} — only lowercase letters, digits, and hyphens are allowed`;
+  }
+
+  if (!RFC1123_RE.test(name)) {
+    return 'Must be a valid hostname (lowercase letters, digits, and hyphens only)';
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

- **API validation**: Added Pydantic `field_validator` on `SessionCreate` and `SessionUpdate` that enforces RFC 1123 DNS label rules with specific error messages for each violation type (uppercase, spaces, leading/trailing hyphens, invalid characters). Returns 422 with actionable messages instead of surfacing K8s 500 errors.
- **Defensive sanitization**: `direct_k8s_pod_manager.py` now sanitizes the hostname before building the pod spec, so upstream naming changes never break K8s resource creation.
- **Web UI validation**: Real-time inline validation on the session name input with red border + error hints (e.g. for uppercase it suggests the lowercase version). Wizard progression is blocked when the name is invalid. Label includes format hint: "(lowercase letters, digits, hyphens)".

Closes NIU-155

## Test plan

- [x] Backend: 12 new tests in `test_rest_session_name.py` covering valid names and each rejection case
- [x] Frontend: 9 new tests in `sessionName.test.ts`
- [x] All 2545 backend tests pass at 85.19% coverage
- [x] Ruff lint and format checks pass
- [ ] Manual: create a session with uppercase/spaces/special chars and verify inline errors appear
- [ ] Manual: verify the wizard Next button is disabled with an invalid name
- [ ] Manual: verify a valid name like `fix-auth-bug` proceeds normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)