### PR TITLE
fix(skuld): process tool_result from user messages in JSONL event mapper

### DIFF
--- a/src/volundr/skuld/event_mapper.py
+++ b/src/volundr/skuld/event_mapper.py
@@ -69,7 +69,7 @@ class EventMapper:
             self._ingest_snapshot(line)
             return []
 
-        if ev_type != "assistant":
+        if ev_type not in ("assistant", "user"):
             return []
 
         msg = line.get("message") or {}
@@ -81,13 +81,18 @@ class EventMapper:
         t = self._elapsed(ts)
 
         # --- tool results (enrich pending events) --------------------------
+        # Tool results arrive as "user" messages in the JSONL format
         result_events = self._try_enrich_results(content, t)
 
-        # --- tool_use blocks -----------------------------------------------
-        tool_events = self._extract_tool_events(content, t)
+        # --- tool_use blocks (only in assistant messages) ------------------
+        tool_events: list[dict] = []
+        if ev_type == "assistant":
+            tool_events = self._extract_tool_events(content, t)
 
-        # --- message-level token usage (on final assistant turn) -----------
-        token_event = self._extract_token_event(msg, t)
+        # --- message-level token usage (only in assistant messages) --------
+        token_event: dict | None = None
+        if ev_type == "assistant":
+            token_event = self._extract_token_event(msg, t)
 
         events: list[dict] = []
         events.extend(result_events)

--- a/tests/test_skuld/test_event_mapper.py
+++ b/tests/test_skuld/test_event_mapper.py
@@ -226,9 +226,28 @@ class TestSkippedEvents:
     def setup_method(self):
         self.mapper = EventMapper()
 
-    def test_user_event_skipped(self):
+    def test_user_text_message_produces_no_events(self):
         events = self.mapper.map_event({"type": "user", "message": {"content": "hi"}})
         assert events == []
+
+    def test_user_with_tool_result_enriches_pending(self):
+        """Tool results arrive as 'user' messages in the JSONL format."""
+        # Buffer a tool_use event
+        tool_line = _assistant_with_tool(
+            "Bash",
+            {"command": "echo hello"},
+            tool_use_id="tool-user-result",
+        )
+        self.mapper.map_event(tool_line)
+        assert "tool-user-result" in self.mapper._pending
+
+        # Result arrives as a 'user' message
+        result_line = _user_with_result("tool-user-result", "hello", is_error=False)
+        assert result_line["type"] == "user"  # Verify the helper uses 'user' type
+        events = self.mapper.map_event(result_line)
+        assert len(events) == 1
+        assert events[0]["type"] == "terminal"
+        assert events[0]["exit"] == 0
 
     def test_progress_event_skipped(self):
         events = self.mapper.map_event({"type": "progress", "data": {"type": "agent_progress"}})
@@ -300,7 +319,7 @@ def _user_with_result(
     is_error: bool = False,
 ) -> dict:
     return {
-        "type": "assistant",
+        "type": "user",
         "timestamp": "2026-03-15T02:42:40.000Z",
         "message": {
             "stop_reason": None,


### PR DESCRIPTION
## Summary

- Fix chronicle watcher only producing `message` events — file, terminal, and git events were missing
- Root cause: tool results in Claude Code's JSONL arrive as `type: "user"` messages, but the mapper only processed `type: "assistant"` events
- Now processes both `"assistant"` (tool_use, tokens) and `"user"` (tool_result enrichment)
- Fixed test helper `_user_with_result` to use `"user"` type matching real JSONL format

## Before/After

**Before:** 102 message events, 0 file/terminal/git (88 pending, never enriched)
**After:** 106 message + 68 terminal + 19 file + 3 git = 196 events

## Test plan

- [x] 2596 tests pass (0 failures)
- [x] Coverage 85.19% (meets 85% threshold)
- [x] Ruff lint clean
- [x] Ruff format clean
- [x] Verified against real JSONL session data — all event types produced correctly

Relates to NIU-156

🤖 Generated with [Claude Code](https://claude.com/claude-code)