### PR TITLE
fix(web): lazy-load EditorPanel to prevent lib build OOM

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -18,14 +18,12 @@
     "directory": "web"
   },
   "type": "module",
-  "main": "dist/volundr-ui.umd.cjs",
   "module": "dist/volundr-ui.es.js",
   "types": "dist/plugin.d.ts",
   "exports": {
     ".": {
       "types": "./dist/plugin.d.ts",
-      "import": "./dist/volundr-ui.es.js",
-      "require": "./dist/volundr-ui.umd.cjs"
+      "import": "./dist/volundr-ui.es.js"
     },
     "./styles": "./dist/volundr-ui.css"
   },

--- a/web/src/pages/Volundr/Volundr.test.tsx
+++ b/web/src/pages/Volundr/Volundr.test.tsx
@@ -72,7 +72,7 @@ vi.mock('@/components/SessionChat', () => ({
   ),
 }));
 
-vi.mock('@/components/EditorPanel', () => ({
+vi.mock('@/components/EditorPanel/EditorPanel', () => ({
   EditorPanel: ({
     hostname,
     sessionId,
@@ -758,7 +758,7 @@ describe('VolundrPage', () => {
 
   // Tests for embedded editor panel (VS Code workbench via REH)
   describe('Editor panel', () => {
-    it('renders EditorPanel when code tab is active and session is running', () => {
+    it('renders EditorPanel when code tab is active and session is running', async () => {
       vi.mocked(useVolundr).mockReturnValue(createMockHookReturn());
 
       render(
@@ -769,7 +769,7 @@ describe('VolundrPage', () => {
 
       fireEvent.click(screen.getByText('Code'));
 
-      const panel = screen.getByTestId('editor-panel');
+      const panel = await screen.findByTestId('editor-panel');
       expect(panel).toBeInTheDocument();
       expect(panel).toHaveAttribute('data-hostname', 'skuld-7f3a2b1c.volundr.local');
       expect(panel).toHaveAttribute('data-session-id', 'forge-7f3a2b1c');
@@ -2024,7 +2024,7 @@ describe('VolundrPage', () => {
 
   // Tests for editor panel states
   describe('Editor panel states', () => {
-    it('renders EditorPanel with session hostname when code tab is active', () => {
+    it('renders EditorPanel with session hostname when code tab is active', async () => {
       vi.mocked(useVolundr).mockReturnValue(createMockHookReturn());
 
       render(
@@ -2035,7 +2035,7 @@ describe('VolundrPage', () => {
 
       fireEvent.click(screen.getByText('Code'));
 
-      const panel = screen.getByTestId('editor-panel');
+      const panel = await screen.findByTestId('editor-panel');
       expect(panel).toHaveAttribute('data-hostname', 'skuld-7f3a2b1c.volundr.local');
     });
 

--- a/web/src/pages/Volundr/VolundrPopout.tsx
+++ b/web/src/pages/Volundr/VolundrPopout.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback, lazy, Suspense } from 'react';
 import { useSearchParams, Link } from 'react-router-dom';
 import {
   Hammer,
@@ -11,18 +11,16 @@ import {
   FolderGit2,
   Globe,
 } from 'lucide-react';
-import {
-  StatusBadge,
-  SessionTerminal,
-  SessionChat,
-  SessionStartingIndicator,
-  EditorPanel,
-} from '@/components';
+import { StatusBadge, SessionTerminal, SessionChat, SessionStartingIndicator } from '@/components';
 import { useVolundr, useBroadcastChannel, useSessionProbe } from '@/hooks';
 import type { VolundrSession } from '@/models';
 import { isSessionBooting } from '@/models';
 import { getSourceLabel, getBranch, isGitSource } from '@/utils/source';
 import styles from './VolundrPopout.module.css';
+
+const EditorPanel = lazy(() =>
+  import('@/components/EditorPanel/EditorPanel').then(m => ({ default: m.EditorPanel }))
+);
 
 type TabType = 'terminal' | 'code' | 'chat';
 
@@ -261,12 +259,14 @@ export function VolundrPopout() {
             </div>
           )
         ) : isSessionReady ? (
-          <EditorPanel
-            hostname={session.hostname ?? null}
-            sessionId={session.id}
-            codeEndpoint={session.codeEndpoint}
-            className={styles.fullPanel}
-          />
+          <Suspense fallback={null}>
+            <EditorPanel
+              hostname={session.hostname ?? null}
+              sessionId={session.id}
+              codeEndpoint={session.codeEndpoint}
+              className={styles.fullPanel}
+            />
+          </Suspense>
         ) : session.status === 'starting' ||
           session.status === 'provisioning' ||
           (isRunning && !connectionVerified) ? (

--- a/web/src/pages/Volundr/index.tsx
+++ b/web/src/pages/Volundr/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef, lazy, Suspense } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   Hammer,
@@ -40,7 +40,6 @@ import {
   SessionChronicles,
   SessionStartingIndicator,
   SessionDiffs,
-  EditorPanel,
   Modal,
   SearchInput,
   StatusBadge,
@@ -58,6 +57,10 @@ import { isSessionBooting, isSessionActive } from '@/models';
 import { formatTokens, cn } from '@/utils';
 import { getRepo, getBranch, getSourceLabel, isGitSource } from '@/utils/source';
 import styles from './VolundrPage.module.css';
+
+const EditorPanel = lazy(() =>
+  import('@/components/EditorPanel/EditorPanel').then(m => ({ default: m.EditorPanel }))
+);
 
 const STATUS_OPTIONS = ['all', 'running', 'stopped', 'error'];
 
@@ -1069,13 +1072,15 @@ export function VolundrPage() {
                 </div>
               ))}
             {isSessionReady && (
-              <EditorPanel
-                hostname={effectiveSelectedSession.hostname ?? null}
-                sessionId={effectiveSelectedSession.id}
-                codeEndpoint={effectiveSelectedSession.codeEndpoint}
-                className={styles.tabPanel}
-                hidden={activeTab !== 'code'}
-              />
+              <Suspense fallback={null}>
+                <EditorPanel
+                  hostname={effectiveSelectedSession.hostname ?? null}
+                  sessionId={effectiveSelectedSession.id}
+                  codeEndpoint={effectiveSelectedSession.codeEndpoint}
+                  className={styles.tabPanel}
+                  hidden={activeTab !== 'code'}
+                />
+              </Suspense>
             )}
 
             {activeTab === 'diffs' && (

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -63,7 +63,6 @@ export default defineConfig(({ mode }) => {
           dts({
             include: ['src/plugin.ts', 'src/**/*.ts', 'src/**/*.tsx'],
             outDir: 'dist',
-            rollupTypes: true,
             tsconfigPath: './tsconfig.app.json',
           }),
         ]
@@ -121,22 +120,13 @@ export default defineConfig(({ mode }) => {
     ? {
         lib: {
           entry: path.resolve(__dirname, 'src/plugin.ts'),
-          name: 'VolundrUI',
-          formats: ['es', 'umd'],
-          fileName: (format) =>
-            format === 'es' ? 'volundr-ui.es.js' : 'volundr-ui.umd.cjs',
+          formats: ['es'],
+          fileName: () => 'volundr-ui.es.js',
         },
         rollupOptions: {
           external: ['react', 'react-dom', 'react-router-dom'],
-          output: {
-            globals: {
-              react: 'React',
-              'react-dom': 'ReactDOM',
-              'react-router-dom': 'ReactRouterDOM',
-            },
-          },
         },
-        sourcemap: true,
+        sourcemap: false,
         outDir: 'dist',
       }
     : {


### PR DESCRIPTION
## Summary
- Lazy-load `EditorPanel` via `React.lazy()` in `VolundrPage` and `VolundrPopout` so the ~82 `@codingame/monaco-vscode-*` packages (~5900 modules) are code-split into a separate chunk
- Drop UMD format from lib build (ES-only), disable sourcemaps, and remove `rollupTypes` to reduce peak memory during `build:lib`
- Remove UMD entry points (`main`, `require`) from `package.json`

## Context
`npm run build:lib` OOMs on `ubuntu-latest` (7 GB) runners because `VolundrPage` and `VolundrPopout` statically import `EditorPanel` → `workbenchInit.ts` → 82 static `@codingame/monaco-vscode-*` imports.

## Test plan
- [ ] `npm run build` completes successfully (app build)
- [ ] `npm run build:lib` completes without OOM locally
- [ ] Verify EditorPanel still loads correctly when switching to the code tab
- [ ] CI publish-web-package job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)