### PR TITLE
feat(ports): save full wizard state in presets

### DIFF
--- a/charts/volundr/templates/migrations-configmap.yaml
+++ b/charts/volundr/templates/migrations-configmap.yaml
@@ -504,4 +504,16 @@ data:
     WHERE source IS NOT NULL AND source->>'type' = 'git';
 
     ALTER TABLE sessions DROP COLUMN IF EXISTS source;
+
+  000017_preset_source_integrations_scripts.up.sql: |
+    -- Add source, integration_ids, and setup_scripts to presets
+    ALTER TABLE volundr_presets ADD COLUMN IF NOT EXISTS source JSONB;
+    ALTER TABLE volundr_presets ADD COLUMN IF NOT EXISTS integration_ids JSONB NOT NULL DEFAULT '[]';
+    ALTER TABLE volundr_presets ADD COLUMN IF NOT EXISTS setup_scripts JSONB NOT NULL DEFAULT '[]';
+
+  000017_preset_source_integrations_scripts.down.sql: |
+    -- Rollback source, integration_ids, and setup_scripts from presets
+    ALTER TABLE volundr_presets DROP COLUMN IF EXISTS setup_scripts;
+    ALTER TABLE volundr_presets DROP COLUMN IF EXISTS integration_ids;
+    ALTER TABLE volundr_presets DROP COLUMN IF EXISTS source;
 {{- end }}

--- a/migrations/000017_preset_source_integrations_scripts.down.sql
+++ b/migrations/000017_preset_source_integrations_scripts.down.sql
@@ -1,0 +1,5 @@
+-- Rollback source, integration_ids, and setup_scripts from presets
+
+ALTER TABLE volundr_presets DROP COLUMN IF EXISTS setup_scripts;
+ALTER TABLE volundr_presets DROP COLUMN IF EXISTS integration_ids;
+ALTER TABLE volundr_presets DROP COLUMN IF EXISTS source;

--- a/migrations/000017_preset_source_integrations_scripts.up.sql
+++ b/migrations/000017_preset_source_integrations_scripts.up.sql
@@ -1,0 +1,5 @@
+-- Add source, integration_ids, and setup_scripts to presets
+
+ALTER TABLE volundr_presets ADD COLUMN IF NOT EXISTS source JSONB;
+ALTER TABLE volundr_presets ADD COLUMN IF NOT EXISTS integration_ids JSONB NOT NULL DEFAULT '[]';
+ALTER TABLE volundr_presets ADD COLUMN IF NOT EXISTS setup_scripts JSONB NOT NULL DEFAULT '[]';

--- a/src/volundr/adapters/inbound/rest_presets.py
+++ b/src/volundr/adapters/inbound/rest_presets.py
@@ -83,6 +83,18 @@ class PresetCreate(BaseModel):
         default_factory=list,
         description="K8s secret names to mount as env vars",
     )
+    source: dict | None = Field(
+        default=None,
+        description="Workspace source (git or local_mount) as JSON",
+    )
+    integration_ids: list[str] = Field(
+        default_factory=list,
+        description="Integration connection IDs to attach",
+    )
+    setup_scripts: list[str] = Field(
+        default_factory=list,
+        description="Shell scripts for workspace setup",
+    )
     workload_config: dict = Field(
         default_factory=dict,
         description="Additional workload-specific configuration",
@@ -165,6 +177,18 @@ class PresetUpdate(BaseModel):
         default=None,
         description="New K8s secret references",
     )
+    source: dict | None = Field(
+        default=None,
+        description="New workspace source",
+    )
+    integration_ids: list[str] | None = Field(
+        default=None,
+        description="New integration connection IDs",
+    )
+    setup_scripts: list[str] | None = Field(
+        default=None,
+        description="New setup scripts",
+    )
     workload_config: dict | None = Field(
         default=None,
         description="New workload config",
@@ -189,6 +213,9 @@ class PresetResponse(BaseModel):
     rules: list[dict] = Field(description="Rule definitions")
     env_vars: dict[str, str] = Field(description="Environment variables")
     env_secret_refs: list[str] = Field(description="K8s secret references")
+    source: dict | None = Field(description="Workspace source configuration")
+    integration_ids: list[str] = Field(description="Integration connection IDs")
+    setup_scripts: list[str] = Field(description="Setup shell scripts")
     workload_config: dict = Field(description="Workload-specific config")
     created_at: str = Field(description="ISO 8601 creation timestamp")
     updated_at: str = Field(description="ISO 8601 last update timestamp")
@@ -212,6 +239,9 @@ class PresetResponse(BaseModel):
             rules=preset.rules,
             env_vars=preset.env_vars,
             env_secret_refs=preset.env_secret_refs,
+            source=preset.source.model_dump() if preset.source else None,
+            integration_ids=preset.integration_ids,
+            setup_scripts=preset.setup_scripts,
             workload_config=preset.workload_config,
             created_at=preset.created_at.isoformat(),
             updated_at=preset.updated_at.isoformat(),
@@ -290,6 +320,9 @@ def create_presets_router(preset_service: PresetService) -> APIRouter:
                 rules=data.rules,
                 env_vars=data.env_vars,
                 env_secret_refs=data.env_secret_refs,
+                source=data.source,
+                integration_ids=data.integration_ids,
+                setup_scripts=data.setup_scripts,
                 workload_config=data.workload_config,
             )
             return PresetResponse.from_preset(preset)

--- a/src/volundr/adapters/outbound/postgres_presets.py
+++ b/src/volundr/adapters/outbound/postgres_presets.py
@@ -25,9 +25,10 @@ class PostgresPresetRepository(PresetRepository):
                 (id, name, description, is_default, cli_tool, workload_type,
                  model, system_prompt, resource_config, mcp_servers,
                  terminal_sidecar, skills, rules, env_vars, env_secret_refs,
+                 source, integration_ids, setup_scripts,
                  workload_config, created_at, updated_at)
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12,
-                    $13, $14, $15, $16, $17, $18)
+                    $13, $14, $15, $16, $17, $18, $19, $20, $21)
             """,
             preset.id,
             preset.name,
@@ -44,6 +45,9 @@ class PostgresPresetRepository(PresetRepository):
             json.dumps(preset.rules),
             json.dumps(preset.env_vars),
             json.dumps(preset.env_secret_refs),
+            json.dumps(preset.source.model_dump()) if preset.source else None,
+            json.dumps(preset.integration_ids),
+            json.dumps(preset.setup_scripts),
             json.dumps(preset.workload_config),
             preset.created_at,
             preset.updated_at,
@@ -105,7 +109,8 @@ class PostgresPresetRepository(PresetRepository):
                 workload_type = $6, model = $7, system_prompt = $8,
                 resource_config = $9, mcp_servers = $10, terminal_sidecar = $11,
                 skills = $12, rules = $13, env_vars = $14, env_secret_refs = $15,
-                workload_config = $16, updated_at = $17
+                source = $16, integration_ids = $17, setup_scripts = $18,
+                workload_config = $19, updated_at = $20
             WHERE id = $1
             """,
             preset.id,
@@ -123,6 +128,9 @@ class PostgresPresetRepository(PresetRepository):
             json.dumps(preset.rules),
             json.dumps(preset.env_vars),
             json.dumps(preset.env_secret_refs),
+            json.dumps(preset.source.model_dump()) if preset.source else None,
+            json.dumps(preset.integration_ids),
+            json.dumps(preset.setup_scripts),
             json.dumps(preset.workload_config),
             preset.updated_at,
         )
@@ -176,6 +184,15 @@ class PostgresPresetRepository(PresetRepository):
             env_secret_refs=json.loads(row["env_secret_refs"])
             if isinstance(row["env_secret_refs"], str)
             else row["env_secret_refs"],
+            source=json.loads(row["source"])
+            if isinstance(row.get("source"), str)
+            else row.get("source"),
+            integration_ids=json.loads(row["integration_ids"])
+            if isinstance(row.get("integration_ids"), str)
+            else (row.get("integration_ids") or []),
+            setup_scripts=json.loads(row["setup_scripts"])
+            if isinstance(row.get("setup_scripts"), str)
+            else (row.get("setup_scripts") or []),
             workload_config=json.loads(row["workload_config"])
             if isinstance(row["workload_config"], str)
             else row["workload_config"],

--- a/src/volundr/domain/models.py
+++ b/src/volundr/domain/models.py
@@ -1220,6 +1220,18 @@ class Preset(BaseModel):
         default_factory=list,
         description="K8s secret names to mount as env vars",
     )
+    source: SessionSource | None = Field(
+        default=None,
+        description="Workspace source configuration (git or local mount)",
+    )
+    integration_ids: list[str] = Field(
+        default_factory=list,
+        description="Integration connection IDs to attach to sessions",
+    )
+    setup_scripts: list[str] = Field(
+        default_factory=list,
+        description="Shell scripts to run during workspace setup",
+    )
     workload_config: dict = Field(
         default_factory=dict,
         description="Additional workload-specific configuration",

--- a/src/volundr/domain/services/preset.py
+++ b/src/volundr/domain/services/preset.py
@@ -42,6 +42,9 @@ class PresetService:
         rules: list[dict] | None = None,
         env_vars: dict[str, str] | None = None,
         env_secret_refs: list[str] | None = None,
+        source: dict | None = None,
+        integration_ids: list[str] | None = None,
+        setup_scripts: list[str] | None = None,
         workload_config: dict | None = None,
     ) -> Preset:
         """Create a new preset."""
@@ -67,6 +70,9 @@ class PresetService:
             rules=rules or [],
             env_vars=env_vars or {},
             env_secret_refs=env_secret_refs or [],
+            source=source,
+            integration_ids=integration_ids or [],
+            setup_scripts=setup_scripts or [],
             workload_config=workload_config or {},
         )
         created = await self._repository.create(preset)

--- a/tests/test_adapters/test_postgres_presets.py
+++ b/tests/test_adapters/test_postgres_presets.py
@@ -28,6 +28,9 @@ def _mock_row(**overrides):
         "rules": json.dumps([]),
         "env_vars": json.dumps({}),
         "env_secret_refs": json.dumps([]),
+        "source": None,
+        "integration_ids": json.dumps([]),
+        "setup_scripts": json.dumps([]),
         "workload_config": json.dumps({}),
         "created_at": datetime.now(UTC),
         "updated_at": datetime.now(UTC),
@@ -35,6 +38,7 @@ def _mock_row(**overrides):
     defaults.update(overrides)
     row = MagicMock()
     row.__getitem__ = lambda self, key: defaults[key]
+    row.get = lambda key, default=None: defaults.get(key, default)
     return row
 
 

--- a/web/src/adapters/api/volundr.adapter.ts
+++ b/web/src/adapters/api/volundr.adapter.ts
@@ -434,6 +434,9 @@ function transformPreset(apiPreset: ApiPresetResponse): VolundrPreset {
     rules: apiPreset.rules ?? [],
     envVars: apiPreset.env_vars ?? {},
     envSecretRefs: apiPreset.env_secret_refs ?? [],
+    source: apiPreset.source ? transformSource(apiPreset.source) : null,
+    integrationIds: apiPreset.integration_ids ?? [],
+    setupScripts: apiPreset.setup_scripts ?? [],
     workloadConfig: apiPreset.workload_config ?? {},
   };
 }
@@ -657,6 +660,17 @@ export class ApiVolundrService implements IVolundrService {
       rules: preset.rules,
       env_vars: preset.envVars,
       env_secret_refs: preset.envSecretRefs,
+      source: preset.source
+        ? preset.source.type === 'git'
+          ? { type: 'git' as const, repo: preset.source.repo, branch: preset.source.branch }
+          : {
+              type: 'local_mount' as const,
+              paths: preset.source.paths,
+              node_selector: preset.source.node_selector,
+            }
+        : null,
+      integration_ids: preset.integrationIds,
+      setup_scripts: preset.setupScripts,
       workload_config: preset.workloadConfig,
     };
 

--- a/web/src/adapters/api/volundr.types.ts
+++ b/web/src/adapters/api/volundr.types.ts
@@ -399,6 +399,9 @@ export interface ApiPresetResponse {
   rules: Array<{ path?: string; inline?: string }>;
   env_vars: Record<string, string>;
   env_secret_refs: string[];
+  source: ApiSessionSource | null;
+  integration_ids: string[];
+  setup_scripts: string[];
   workload_config: Record<string, string | number | boolean | undefined>;
 }
 
@@ -426,6 +429,9 @@ export interface ApiPresetCreate {
   rules: Array<{ path?: string; inline?: string }>;
   env_vars: Record<string, string>;
   env_secret_refs: string[];
+  source: ApiSessionSource | null;
+  integration_ids: string[];
+  setup_scripts: string[];
   workload_config: Record<string, string | number | boolean | undefined>;
 }
 

--- a/web/src/adapters/mock/data/volundr.data.ts
+++ b/web/src/adapters/mock/data/volundr.data.ts
@@ -896,6 +896,9 @@ export const mockVolundrPresets: VolundrPreset[] = [
     rules: [],
     envVars: { WORKSPACE_DIR: '/workspace', LOG_LEVEL: 'info' },
     envSecretRefs: [],
+    source: null,
+    integrationIds: [],
+    setupScripts: [],
     workloadConfig: {},
   },
   {
@@ -916,6 +919,9 @@ export const mockVolundrPresets: VolundrPreset[] = [
     rules: [],
     envVars: {},
     envSecretRefs: ['anthropic-api-key'],
+    source: null,
+    integrationIds: [],
+    setupScripts: [],
     workloadConfig: { maxTurns: 30 },
   },
   {
@@ -939,6 +945,9 @@ export const mockVolundrPresets: VolundrPreset[] = [
     rules: [],
     envVars: {},
     envSecretRefs: ['anthropic-api-key'],
+    source: null,
+    integrationIds: [],
+    setupScripts: [],
     workloadConfig: { maxTurns: 200 },
   },
   {
@@ -959,6 +968,9 @@ export const mockVolundrPresets: VolundrPreset[] = [
     rules: [],
     envVars: {},
     envSecretRefs: [],
+    source: null,
+    integrationIds: [],
+    setupScripts: [],
     workloadConfig: { maxTurns: 50 },
   },
   {
@@ -982,6 +994,9 @@ export const mockVolundrPresets: VolundrPreset[] = [
     rules: [],
     envVars: {},
     envSecretRefs: ['openai-api-key'],
+    source: null,
+    integrationIds: [],
+    setupScripts: [],
     workloadConfig: {},
   },
 ];

--- a/web/src/components/LaunchWizard/steps/ConfigureStep.module.css
+++ b/web/src/components/LaunchWizard/steps/ConfigureStep.module.css
@@ -70,6 +70,40 @@
   font-style: italic;
 }
 
+.presetWarnings {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  background-color: color-mix(in srgb, var(--color-accent-amber) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-accent-amber) 30%, transparent);
+  font-size: var(--text-xs);
+  color: var(--color-accent-amber);
+}
+
+.presetWarningsHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-weight: 500;
+}
+
+.presetWarningsDismiss {
+  background: none;
+  border: none;
+  color: var(--color-accent-amber);
+  cursor: pointer;
+  padding: var(--space-1);
+  line-height: 1;
+}
+
+.presetWarningsList {
+  list-style: disc;
+  padding-left: var(--space-4);
+  margin: 0;
+}
+
 /* Form Section */
 .formSection {
   display: flex;

--- a/web/src/components/LaunchWizard/steps/ConfigureStep.test.tsx
+++ b/web/src/components/LaunchWizard/steps/ConfigureStep.test.tsx
@@ -712,6 +712,109 @@ describe('ConfigureStep', () => {
       );
     });
 
+    it('restores source from preset when repo is available', () => {
+      const presetWithSource = {
+        ...mockPreset,
+        source: {
+          type: 'git' as const,
+          repo: 'https://github.com/org/repo-one.git',
+          branch: 'develop',
+        },
+      };
+      renderStep({ presets: [presetWithSource] });
+
+      const selects = document.querySelectorAll('select');
+      const presetSelect = Array.from(selects).find(s => s.value === '')!;
+      fireEvent.change(presetSelect, { target: { value: 'p1' } });
+
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sourceType: 'git',
+          repo: 'https://github.com/org/repo-one.git',
+          branch: 'develop',
+        })
+      );
+    });
+
+    it('shows warning when preset repo is unavailable', () => {
+      const presetWithMissingRepo = {
+        ...mockPreset,
+        source: {
+          type: 'git' as const,
+          repo: 'https://github.com/org/deleted-repo.git',
+          branch: 'main',
+        },
+      };
+      renderStep({ presets: [presetWithMissingRepo] });
+
+      const selects = document.querySelectorAll('select');
+      const presetSelect = Array.from(selects).find(s => s.value === '')!;
+      fireEvent.change(presetSelect, { target: { value: 'p1' } });
+
+      expect(onChange).toHaveBeenCalledWith(expect.not.objectContaining({ sourceType: 'git' }));
+    });
+
+    it('filters out unavailable credentials from preset', () => {
+      const presetWithMissingCreds = {
+        ...mockPreset,
+        envSecretRefs: ['GITHUB_TOKEN', 'DELETED_SECRET'],
+      };
+      renderStep({
+        presets: [presetWithMissingCreds],
+        availableSecrets: ['GITHUB_TOKEN', 'NPM_TOKEN'],
+      });
+
+      const selects = document.querySelectorAll('select');
+      const presetSelect = Array.from(selects).find(s => s.value === '')!;
+      fireEvent.change(presetSelect, { target: { value: 'p1' } });
+
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          selectedCredentials: ['GITHUB_TOKEN'],
+        })
+      );
+    });
+
+    it('restores local mount source from preset', () => {
+      const presetWithMount = {
+        ...mockPreset,
+        source: {
+          type: 'local_mount' as const,
+          paths: [{ host_path: '/data', mount_path: '/workspace', read_only: true }],
+        },
+      };
+      renderStep({ presets: [presetWithMount] });
+
+      const selects = document.querySelectorAll('select');
+      const presetSelect = Array.from(selects).find(s => s.value === '')!;
+      fireEvent.change(presetSelect, { target: { value: 'p1' } });
+
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sourceType: 'local_mount',
+          mountPaths: [{ host_path: '/data', mount_path: '/workspace', read_only: true }],
+        })
+      );
+    });
+
+    it('restores setup scripts from preset', () => {
+      const presetWithScripts = {
+        ...mockPreset,
+        setupScripts: ['npm install', 'npm run build'],
+      };
+      renderStep({ presets: [presetWithScripts] });
+
+      const selects = document.querySelectorAll('select');
+      const presetSelect = Array.from(selects).find(s => s.value === '')!;
+      fireEvent.change(presetSelect, { target: { value: 'p1' } });
+
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          setupScripts: ['npm install', 'npm run build'],
+        })
+      );
+    });
+
     it('resets to template defaults when "none" is selected', () => {
       renderStep({
         presets: [mockPreset],
@@ -788,6 +891,81 @@ describe('ConfigureStep', () => {
           yamlMode: false,
           model: 'claude-opus',
           systemPrompt: 'Hello',
+        })
+      );
+    });
+
+    it('serializes source to YAML when repo is set', () => {
+      renderStep({
+        state: buildState({
+          sourceType: 'git',
+          repo: 'https://github.com/org/repo-one.git',
+          branch: 'develop',
+        }),
+      });
+      fireEvent.click(screen.getByText('Advanced Configuration'));
+      fireEvent.click(screen.getByText('Edit as YAML'));
+
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          yamlMode: true,
+          yamlContent: expect.stringContaining('source:'),
+        })
+      );
+    });
+
+    it('parses local mount source from YAML back to form mode', () => {
+      const yamlWithMount = [
+        'model: claude-opus',
+        'source:',
+        '  type: local_mount',
+        '  paths:',
+        '    - host_path: /data',
+        '      mount_path: /workspace',
+        '      read_only: true',
+        '',
+      ].join('\n');
+      renderStep({
+        state: buildState({ yamlMode: true, yamlContent: yamlWithMount }),
+      });
+      fireEvent.click(screen.getByText('Advanced Configuration'));
+      fireEvent.click(screen.getByText('Form View'));
+
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          yamlMode: false,
+          sourceType: 'local_mount',
+        })
+      );
+    });
+
+    it('parses source from YAML back to form mode', () => {
+      const yamlWithSource = [
+        'model: claude-opus',
+        'source:',
+        '  type: git',
+        '  repo: https://github.com/org/repo-one.git',
+        '  branch: develop',
+        'integration_ids:',
+        '  - integ-1',
+        'setup_scripts:',
+        '  - npm install',
+        '',
+      ].join('\n');
+      renderStep({
+        state: buildState({ yamlMode: true, yamlContent: yamlWithSource }),
+      });
+      fireEvent.click(screen.getByText('Advanced Configuration'));
+      fireEvent.click(screen.getByText('Form View'));
+
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          yamlMode: false,
+          sourceType: 'git',
+          repo: 'https://github.com/org/repo-one.git',
+          branch: 'develop',
+          selectedIntegrations: ['integ-1'],
+          setupScripts: ['npm install'],
         })
       );
     });
@@ -1089,6 +1267,73 @@ describe('ConfigureStep', () => {
       fireEvent.click(screen.getByText('Save'));
 
       expect(onSavePreset).toHaveBeenCalledWith(expect.objectContaining({ name: 'My Preset' }));
+    });
+
+    it('includes git source in saved preset when repo is set', async () => {
+      const onSavePreset = vi.fn().mockResolvedValue({ id: 'new-p2', name: 'With Repo' });
+      renderStep({
+        onSavePreset,
+        state: buildState({
+          sourceType: 'git',
+          repo: 'https://github.com/org/repo-one.git',
+          branch: 'develop',
+          selectedIntegrations: ['integ-1'],
+          setupScripts: ['npm install'],
+        }),
+      });
+      fireEvent.click(screen.getByText('Save as Preset'));
+      fireEvent.change(screen.getByPlaceholderText('Preset name'), {
+        target: { value: 'With Repo' },
+      });
+      fireEvent.click(screen.getByText('Save'));
+
+      expect(onSavePreset).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: { type: 'git', repo: 'https://github.com/org/repo-one.git', branch: 'develop' },
+          integrationIds: ['integ-1'],
+          setupScripts: ['npm install'],
+        })
+      );
+    });
+
+    it('includes local mount source in saved preset', async () => {
+      const onSavePreset = vi.fn().mockResolvedValue({ id: 'new-p3', name: 'With Mount' });
+      renderStep({
+        onSavePreset,
+        state: buildState({
+          sourceType: 'local_mount',
+          mountPaths: [{ host_path: '/data', mount_path: '/workspace', read_only: true }],
+        }),
+      });
+      fireEvent.click(screen.getByText('Save as Preset'));
+      fireEvent.change(screen.getByPlaceholderText('Preset name'), {
+        target: { value: 'With Mount' },
+      });
+      fireEvent.click(screen.getByText('Save'));
+
+      expect(onSavePreset).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: {
+            type: 'local_mount',
+            paths: [{ host_path: '/data', mount_path: '/workspace', read_only: true }],
+          },
+        })
+      );
+    });
+
+    it('saves null source when no repo is set', async () => {
+      const onSavePreset = vi.fn().mockResolvedValue({ id: 'new-p4', name: 'No Source' });
+      renderStep({
+        onSavePreset,
+        state: buildState({ sourceType: 'git', repo: '', branch: '' }),
+      });
+      fireEvent.click(screen.getByText('Save as Preset'));
+      fireEvent.change(screen.getByPlaceholderText('Preset name'), {
+        target: { value: 'No Source' },
+      });
+      fireEvent.click(screen.getByText('Save'));
+
+      expect(onSavePreset).toHaveBeenCalledWith(expect.objectContaining({ source: null }));
     });
 
     it('hides form when cancel is clicked', () => {

--- a/web/src/components/LaunchWizard/steps/ConfigureStep.test.tsx
+++ b/web/src/components/LaunchWizard/steps/ConfigureStep.test.tsx
@@ -679,6 +679,9 @@ describe('ConfigureStep', () => {
       rules: [],
       envVars: { NODE_ENV: 'test' },
       envSecretRefs: ['GITHUB_TOKEN'],
+      source: null,
+      integrationIds: [],
+      setupScripts: [],
       workloadConfig: {},
     };
 

--- a/web/src/components/LaunchWizard/steps/ConfigureStep.tsx
+++ b/web/src/components/LaunchWizard/steps/ConfigureStep.tsx
@@ -276,18 +276,19 @@ export function ConfigureStep({
 
       // Validate source (repo)
       if (preset.source) {
-        if (preset.source.type === 'git') {
-          const matchedRepo = repos.find(r => r.cloneUrl === preset.source!.repo);
+        const src = preset.source;
+        if (src.type === 'git') {
+          const matchedRepo = repos.find(r => r.cloneUrl === src.repo);
           if (matchedRepo) {
             updates.sourceType = 'git';
-            updates.repo = preset.source.repo;
-            updates.branch = (preset.source as import('@/models').GitSource).branch ?? matchedRepo.defaultBranch;
+            updates.repo = src.repo;
+            updates.branch = src.branch ?? matchedRepo.defaultBranch;
           } else {
-            warnings.push(`Repository "${preset.source.repo}" is no longer available`);
+            warnings.push(`Repository "${src.repo}" is no longer available`);
           }
-        } else if (preset.source.type === 'local_mount') {
+        } else if (src.type === 'local_mount') {
           updates.sourceType = 'local_mount';
-          updates.mountPaths = [...(preset.source as import('@/models').LocalMountSource).paths];
+          updates.mountPaths = [...src.paths];
         }
       }
 
@@ -302,7 +303,9 @@ export function ConfigureStep({
       // Validate integrations
       const enabledIntegrationIds = new Set(integrations.filter(i => i.enabled).map(i => i.id));
       const validIntegrations = preset.integrationIds.filter(id => enabledIntegrationIds.has(id));
-      const missingIntegrations = preset.integrationIds.filter(id => !enabledIntegrationIds.has(id));
+      const missingIntegrations = preset.integrationIds.filter(
+        id => !enabledIntegrationIds.has(id)
+      );
       for (const id of missingIntegrations) {
         const slug = integrations.find(i => i.id === id)?.slug ?? id;
         warnings.push(`Integration "${slug}" is no longer available`);
@@ -321,8 +324,12 @@ export function ConfigureStep({
       const source: import('@/models').SessionSource | null =
         state.sourceType === 'git' && state.repo
           ? { type: 'git', repo: state.repo, branch: state.branch }
-          : state.sourceType === 'local_mount' && state.mountPaths.some(p => p.host_path && p.mount_path)
-            ? { type: 'local_mount', paths: state.mountPaths.filter(p => p.host_path && p.mount_path) }
+          : state.sourceType === 'local_mount' &&
+              state.mountPaths.some(p => p.host_path && p.mount_path)
+            ? {
+                type: 'local_mount',
+                paths: state.mountPaths.filter(p => p.host_path && p.mount_path),
+              }
             : null;
       const yamlContent = serializePresetYaml({
         cliTool: state.template.cliTool,
@@ -572,8 +579,12 @@ export function ConfigureStep({
       const source: import('@/models').SessionSource | null =
         state.sourceType === 'git' && state.repo
           ? { type: 'git', repo: state.repo, branch: state.branch }
-          : state.sourceType === 'local_mount' && state.mountPaths.some(p => p.host_path && p.mount_path)
-            ? { type: 'local_mount', paths: state.mountPaths.filter(p => p.host_path && p.mount_path) }
+          : state.sourceType === 'local_mount' &&
+              state.mountPaths.some(p => p.host_path && p.mount_path)
+            ? {
+                type: 'local_mount',
+                paths: state.mountPaths.filter(p => p.host_path && p.mount_path),
+              }
             : null;
 
       const saved = await onSavePreset({

--- a/web/src/components/LaunchWizard/steps/ConfigureStep.tsx
+++ b/web/src/components/LaunchWizard/steps/ConfigureStep.tsx
@@ -123,6 +123,7 @@ export function ConfigureStep({
   const [showMcpPicker, setShowMcpPicker] = useState(false);
   const [showMcpForm, setShowMcpForm] = useState(false);
   const [yamlError, setYamlError] = useState<string | null>(null);
+  const [presetWarnings, setPresetWarnings] = useState<string[]>([]);
   const [customMcpName, setCustomMcpName] = useState('');
   const [customMcpType, setCustomMcpType] = useState<McpServerType>('stdio');
   const [customMcpCommand, setCustomMcpCommand] = useState('');
@@ -244,13 +245,16 @@ export function ConfigureStep({
     (presetId: string) => {
       if (!presetId) {
         onChange({ preset: null });
+        setPresetWarnings([]);
         return;
       }
       const preset = presets.find(p => p.id === presetId);
       if (!preset) {
         return;
       }
-      onChange({
+
+      const warnings: string[] = [];
+      const updates: Partial<WizardState> = {
         preset,
         model: preset.model ?? '',
         taskType: `skuld-${preset.cliTool}`,
@@ -258,7 +262,7 @@ export function ConfigureStep({
         mcpServers: [...preset.mcpServers],
         resourceConfig: { ...preset.resourceConfig },
         envVars: { ...preset.envVars },
-        selectedCredentials: [...preset.envSecretRefs],
+        setupScripts: [...preset.setupScripts],
         template: {
           ...state.template,
           cliTool: preset.cliTool,
@@ -268,14 +272,58 @@ export function ConfigureStep({
           rules: [...preset.rules],
           workloadConfig: { ...preset.workloadConfig },
         },
-      });
+      };
+
+      // Validate source (repo)
+      if (preset.source) {
+        if (preset.source.type === 'git') {
+          const matchedRepo = repos.find(r => r.cloneUrl === preset.source!.repo);
+          if (matchedRepo) {
+            updates.sourceType = 'git';
+            updates.repo = preset.source.repo;
+            updates.branch = (preset.source as import('@/models').GitSource).branch ?? matchedRepo.defaultBranch;
+          } else {
+            warnings.push(`Repository "${preset.source.repo}" is no longer available`);
+          }
+        } else if (preset.source.type === 'local_mount') {
+          updates.sourceType = 'local_mount';
+          updates.mountPaths = [...(preset.source as import('@/models').LocalMountSource).paths];
+        }
+      }
+
+      // Validate credentials
+      const validCreds = preset.envSecretRefs.filter(s => availableSecrets.includes(s));
+      const missingCreds = preset.envSecretRefs.filter(s => !availableSecrets.includes(s));
+      for (const c of missingCreds) {
+        warnings.push(`Credential "${c}" is no longer available`);
+      }
+      updates.selectedCredentials = validCreds;
+
+      // Validate integrations
+      const enabledIntegrationIds = new Set(integrations.filter(i => i.enabled).map(i => i.id));
+      const validIntegrations = preset.integrationIds.filter(id => enabledIntegrationIds.has(id));
+      const missingIntegrations = preset.integrationIds.filter(id => !enabledIntegrationIds.has(id));
+      for (const id of missingIntegrations) {
+        const slug = integrations.find(i => i.id === id)?.slug ?? id;
+        warnings.push(`Integration "${slug}" is no longer available`);
+      }
+      updates.selectedIntegrations = validIntegrations;
+
+      setPresetWarnings(warnings);
+      onChange(updates);
     },
-    [presets, state.template, onChange]
+    [presets, repos, availableSecrets, integrations, state.template, onChange]
   );
 
   const handleToggleYaml = useCallback(() => {
     if (!state.yamlMode) {
       // Switching to YAML mode: serialize current state
+      const source: import('@/models').SessionSource | null =
+        state.sourceType === 'git' && state.repo
+          ? { type: 'git', repo: state.repo, branch: state.branch }
+          : state.sourceType === 'local_mount' && state.mountPaths.some(p => p.host_path && p.mount_path)
+            ? { type: 'local_mount', paths: state.mountPaths.filter(p => p.host_path && p.mount_path) }
+            : null;
       const yamlContent = serializePresetYaml({
         cliTool: state.template.cliTool,
         workloadType: state.template.workloadType,
@@ -288,6 +336,9 @@ export function ConfigureStep({
         rules: state.template.rules,
         envVars: state.envVars,
         envSecretRefs: state.selectedCredentials,
+        source,
+        integrationIds: state.selectedIntegrations,
+        setupScripts: state.setupScripts,
         workloadConfig: state.template.workloadConfig,
       });
       onChange({ yamlMode: true, yamlContent });
@@ -305,6 +356,18 @@ export function ConfigureStep({
       if (parsed.resourceConfig) updates.resourceConfig = parsed.resourceConfig;
       if (parsed.envVars) updates.envVars = parsed.envVars;
       if (parsed.envSecretRefs) updates.selectedCredentials = parsed.envSecretRefs;
+      if (parsed.source !== undefined) {
+        if (parsed.source && parsed.source.type === 'git') {
+          updates.sourceType = 'git';
+          updates.repo = parsed.source.repo;
+          updates.branch = parsed.source.branch;
+        } else if (parsed.source && parsed.source.type === 'local_mount') {
+          updates.sourceType = 'local_mount';
+          updates.mountPaths = [...parsed.source.paths];
+        }
+      }
+      if (parsed.integrationIds) updates.selectedIntegrations = parsed.integrationIds;
+      if (parsed.setupScripts) updates.setupScripts = parsed.setupScripts;
 
       // Template-nested fields
       const templateUpdates = { ...state.template };
@@ -506,6 +569,13 @@ export function ConfigureStep({
     }
     setIsSavingPreset(true);
     try {
+      const source: import('@/models').SessionSource | null =
+        state.sourceType === 'git' && state.repo
+          ? { type: 'git', repo: state.repo, branch: state.branch }
+          : state.sourceType === 'local_mount' && state.mountPaths.some(p => p.host_path && p.mount_path)
+            ? { type: 'local_mount', paths: state.mountPaths.filter(p => p.host_path && p.mount_path) }
+            : null;
+
       const saved = await onSavePreset({
         name: savePresetName.trim(),
         description: '',
@@ -521,6 +591,9 @@ export function ConfigureStep({
         rules: state.template.rules,
         envVars: state.envVars,
         envSecretRefs: state.selectedCredentials,
+        source,
+        integrationIds: state.selectedIntegrations,
+        setupScripts: state.setupScripts,
         workloadConfig: state.template.workloadConfig,
       });
       onChange({ preset: saved });
@@ -576,6 +649,25 @@ export function ConfigureStep({
           </select>
           {state.preset && (
             <span className={styles.presetDescription}>{state.preset.description}</span>
+          )}
+          {presetWarnings.length > 0 && (
+            <div className={styles.presetWarnings}>
+              <div className={styles.presetWarningsHeader}>
+                <span>Preset loaded with warnings</span>
+                <button
+                  type="button"
+                  className={styles.presetWarningsDismiss}
+                  onClick={() => setPresetWarnings([])}
+                >
+                  <X size={14} />
+                </button>
+              </div>
+              <ul className={styles.presetWarningsList}>
+                {presetWarnings.map((w, i) => (
+                  <li key={i}>{w}</li>
+                ))}
+              </ul>
+            </div>
           )}
         </div>
       )}

--- a/web/src/models/volundr.model.ts
+++ b/web/src/models/volundr.model.ts
@@ -457,6 +457,9 @@ export interface VolundrPreset {
   rules: RuleConfig[];
   envVars: Record<string, string>;
   envSecretRefs: string[];
+  source: SessionSource | null;
+  integrationIds: string[];
+  setupScripts: string[];
   workloadConfig: WorkloadConfig;
 }
 

--- a/web/src/utils/presetYaml.test.ts
+++ b/web/src/utils/presetYaml.test.ts
@@ -20,6 +20,9 @@ const fullFields: PresetRuntimeFields = {
   rules: [{ inline: 'Always use TypeScript.' }],
   envVars: { NODE_ENV: 'development', DEBUG: 'true' },
   envSecretRefs: ['GITHUB_TOKEN', 'LINEAR_API_KEY'],
+  source: { type: 'git', repo: 'github.com/org/repo', branch: 'main' },
+  integrationIds: ['integ-1'],
+  setupScripts: ['npm install'],
   workloadConfig: { timeout: 3600 },
 };
 
@@ -35,6 +38,9 @@ const minimalFields: PresetRuntimeFields = {
   rules: [],
   envVars: {},
   envSecretRefs: [],
+  source: null,
+  integrationIds: [],
+  setupScripts: [],
   workloadConfig: {},
 };
 

--- a/web/src/utils/presetYaml.ts
+++ b/web/src/utils/presetYaml.ts
@@ -7,6 +7,7 @@ import type {
   SkillConfig,
   RuleConfig,
   WorkloadConfig,
+  SessionSource,
 } from '@/models';
 
 /**
@@ -31,6 +32,9 @@ interface PresetYamlDoc {
   rules?: Array<{ path?: string; inline?: string }>;
   env_vars?: Record<string, string>;
   env_secret_refs?: string[];
+  source?: { type: 'git'; repo: string; branch: string } | { type: 'local_mount'; paths: Array<{ host_path: string; mount_path: string; read_only: boolean }> } | null;
+  integration_ids?: string[];
+  setup_scripts?: string[];
   workload_config?: Record<string, string | number | boolean | undefined>;
 }
 
@@ -49,6 +53,9 @@ export interface PresetRuntimeFields {
   rules: RuleConfig[];
   envVars: Record<string, string>;
   envSecretRefs: string[];
+  source: SessionSource | null;
+  integrationIds: string[];
+  setupScripts: string[];
   workloadConfig: WorkloadConfig;
 }
 
@@ -81,6 +88,9 @@ export function serializePresetYaml(fields: PresetRuntimeFields): string {
     rules: fields.rules.length > 0 ? fields.rules : undefined,
     env_vars: Object.keys(fields.envVars).length > 0 ? fields.envVars : undefined,
     env_secret_refs: fields.envSecretRefs.length > 0 ? fields.envSecretRefs : undefined,
+    source: fields.source ?? undefined,
+    integration_ids: fields.integrationIds.length > 0 ? fields.integrationIds : undefined,
+    setup_scripts: fields.setupScripts.length > 0 ? fields.setupScripts : undefined,
     workload_config:
       Object.keys(fields.workloadConfig).length > 0 ? fields.workloadConfig : undefined,
   };
@@ -143,6 +153,15 @@ export function parsePresetYaml(yamlStr: string): Partial<PresetRuntimeFields> {
   }
   if (doc.env_secret_refs) {
     result.envSecretRefs = doc.env_secret_refs;
+  }
+  if (doc.source !== undefined) {
+    result.source = doc.source as SessionSource | null;
+  }
+  if (doc.integration_ids) {
+    result.integrationIds = doc.integration_ids;
+  }
+  if (doc.setup_scripts) {
+    result.setupScripts = doc.setup_scripts;
   }
   if (doc.workload_config) {
     result.workloadConfig = doc.workload_config;

--- a/web/src/utils/presetYaml.ts
+++ b/web/src/utils/presetYaml.ts
@@ -32,7 +32,13 @@ interface PresetYamlDoc {
   rules?: Array<{ path?: string; inline?: string }>;
   env_vars?: Record<string, string>;
   env_secret_refs?: string[];
-  source?: { type: 'git'; repo: string; branch: string } | { type: 'local_mount'; paths: Array<{ host_path: string; mount_path: string; read_only: boolean }> } | null;
+  source?:
+    | { type: 'git'; repo: string; branch: string }
+    | {
+        type: 'local_mount';
+        paths: Array<{ host_path: string; mount_path: string; read_only: boolean }>;
+      }
+    | null;
   integration_ids?: string[];
   setup_scripts?: string[];
   workload_config?: Record<string, string | number | boolean | undefined>;


### PR DESCRIPTION
## Summary
- Expands presets to save the complete wizard state: source (repo+branch or local mounts), integration IDs, and setup scripts
- Adds validation on preset load: unavailable repos, credentials, and integrations are gracefully filtered out with a dismissible amber warning banner
- Adds DB migration (000017) for the three new JSONB columns on `volundr_presets`

## Test plan
- [x] All 2606 backend tests pass
- [x] All 2332 frontend tests pass
- [x] TypeScript compiles clean
- [ ] Verify preset save captures repo, integrations, and setup scripts
- [ ] Verify preset load restores all fields and shows warnings for missing resources
- [ ] Verify YAML mode round-trips the new fields
- [ ] Verify old presets (without new fields) load without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)