### PR TITLE
feat(web): allow editor session switching without page reload

### DIFF
--- a/web/src/components/EditorPanel/EditorPanel.module.css
+++ b/web/src/components/EditorPanel/EditorPanel.module.css
@@ -74,25 +74,6 @@
   opacity: 0.4;
 }
 
-.reloadButton {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-  padding: var(--space-2) var(--space-4);
-  background-color: var(--color-bg-tertiary);
-  color: var(--color-text-primary);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  font-size: var(--text-sm);
-  font-family: var(--font-sans);
-  cursor: pointer;
-  transition: background-color 0.15s ease;
-}
-
-.reloadButton:hover {
-  background-color: var(--color-bg-elevated);
-}
-
 @keyframes pulse {
   0%,
   100% {

--- a/web/src/components/EditorPanel/EditorPanel.test.tsx
+++ b/web/src/components/EditorPanel/EditorPanel.test.tsx
@@ -1,16 +1,22 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { EditorPanel } from './EditorPanel';
-import { resetEditorState } from './editorState';
+import { resetEditorState, markInitialized } from './editorState';
+import { resetSessionRouter, setActiveRoute } from './sessionRouter';
 
-// Mock the workbenchInit module — this is the new initialization module
-import { markInitialized } from './editorState';
-
+// Mock the workbenchInit module
 const mockInitWorkbench = vi.fn().mockImplementation(async (params: { sessionId: string }) => {
-  markInitialized(params.sessionId);
+  markInitialized();
+  setActiveRoute({ sessionId: params.sessionId, hostname: 'test-host' });
 });
+const mockSwitchSession = vi
+  .fn()
+  .mockImplementation(async (sessionId: string, hostname: string) => {
+    setActiveRoute({ sessionId, hostname });
+  });
 vi.mock('./workbenchInit', () => ({
   initWorkbench: (...args: unknown[]) => mockInitWorkbench(...args),
+  switchSession: (...args: unknown[]) => mockSwitchSession(...args),
 }));
 
 // jsdom doesn't support attachShadow natively — stub it
@@ -28,6 +34,7 @@ describe('EditorPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetEditorState();
+    resetSessionRouter();
   });
 
   afterEach(() => {
@@ -79,24 +86,20 @@ describe('EditorPanel', () => {
     expect(screen.getByText('Failed to load workbench')).toBeInTheDocument();
   });
 
-  it('shows session-changed state when sessionId differs from initialized session', async () => {
-    const { unmount } = render(<EditorPanel hostname="pod-1.example.com" sessionId="session-1" />);
+  it('calls switchSession when sessionId changes after initialization', async () => {
+    const { rerender } = render(<EditorPanel hostname="pod-1.example.com" sessionId="session-1" />);
 
     await waitFor(() => {
       expect(mockInitWorkbench).toHaveBeenCalledTimes(1);
     });
 
-    unmount();
-
-    render(<EditorPanel hostname="pod-2.example.com" sessionId="session-2" />);
+    rerender(<EditorPanel hostname="pod-2.example.com" sessionId="session-2" />);
 
     await waitFor(() => {
-      expect(
-        screen.getByText('Session changed — the editor requires a page reload to reconnect.')
-      ).toBeInTheDocument();
+      expect(mockSwitchSession).toHaveBeenCalledTimes(1);
     });
 
-    expect(screen.getByText('Reload page')).toBeInTheDocument();
+    expect(mockSwitchSession).toHaveBeenCalledWith('session-2', 'pod-2.example.com', undefined);
   });
 
   it('does not re-initialize when same session re-renders', async () => {
@@ -108,8 +111,9 @@ describe('EditorPanel', () => {
 
     rerender(<EditorPanel hostname="pod.example.com" sessionId="session-123" />);
 
-    // Should not call initWorkbench again
+    // Should not call initWorkbench or switchSession again
     expect(mockInitWorkbench).toHaveBeenCalledTimes(1);
+    expect(mockSwitchSession).not.toHaveBeenCalled();
   });
 
   it('renders the workbench container div', async () => {
@@ -133,5 +137,23 @@ describe('EditorPanel', () => {
     });
 
     expect(screen.getByText('string error')).toBeInTheDocument();
+  });
+
+  it('shows error when switchSession fails', async () => {
+    const { rerender } = render(<EditorPanel hostname="pod-1.example.com" sessionId="session-1" />);
+
+    await waitFor(() => {
+      expect(mockInitWorkbench).toHaveBeenCalledTimes(1);
+    });
+
+    mockSwitchSession.mockRejectedValueOnce(new Error('Switch failed'));
+
+    rerender(<EditorPanel hostname="pod-2.example.com" sessionId="session-2" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to initialize editor')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Switch failed')).toBeInTheDocument();
   });
 });

--- a/web/src/components/EditorPanel/EditorPanel.tsx
+++ b/web/src/components/EditorPanel/EditorPanel.tsx
@@ -1,8 +1,9 @@
-import { useRef, useEffect, useState, useMemo } from 'react';
-import { Code, RotateCcw } from 'lucide-react';
+import { useRef, useEffect, useState } from 'react';
+import { Code } from 'lucide-react';
 import { cn } from '@/utils';
-import { isInitialized, getInitializedSessionId } from './editorState';
-import { initWorkbench } from './workbenchInit';
+import { isInitialized } from './editorState';
+import { getActiveRoute } from './sessionRouter';
+import { initWorkbench, switchSession } from './workbenchInit';
 import styles from './EditorPanel.module.css';
 
 export interface EditorPanelProps {
@@ -18,7 +19,7 @@ export interface EditorPanelProps {
   hidden?: boolean;
 }
 
-type EditorStatus = 'idle' | 'initializing' | 'connected' | 'error';
+type EditorStatus = 'idle' | 'initializing' | 'connected' | 'switching' | 'error';
 
 /**
  * VS Code workbench panel using @codingame/monaco-vscode-api.
@@ -26,8 +27,9 @@ type EditorStatus = 'idle' | 'initializing' | 'connected' | 'error';
  * Renders the full VS Code workbench inside a div, connected to a
  * VS Code REH server in the session pod.
  *
- * `initialize()` can only be called once per page load (upstream VS Code
- * constraint). If the sessionId changes, the user must reload the page.
+ * The workbench is initialized once on first mount. When the session
+ * changes, the WebSocket routing and workspace folder are dynamically
+ * swapped without requiring a page reload.
  */
 export function EditorPanel({
   hostname,
@@ -40,14 +42,9 @@ export function EditorPanel({
   const [status, setStatus] = useState<EditorStatus>('idle');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  // Derive session-changed state without setState in the effect body.
-  const sessionChanged = useMemo(
-    () => isInitialized() && sessionId != null && getInitializedSessionId() !== sessionId,
-    [sessionId]
-  );
-
+  // First-time initialization effect.
   useEffect(() => {
-    if (!hostname || !sessionId || !containerRef.current || sessionChanged) {
+    if (!hostname || !sessionId || !containerRef.current) {
       return;
     }
 
@@ -76,7 +73,45 @@ export function EditorPanel({
     return () => {
       cancelled = true;
     };
-  }, [hostname, sessionId, codeEndpoint, sessionChanged]);
+  }, [hostname, sessionId, codeEndpoint]);
+
+  // Session switch effect — runs when session changes after initialization.
+  useEffect(() => {
+    if (!hostname || !sessionId) {
+      return;
+    }
+
+    if (!isInitialized()) {
+      return;
+    }
+
+    // Skip if this is already the active session.
+    const currentRoute = getActiveRoute();
+    if (currentRoute?.sessionId === sessionId) {
+      return;
+    }
+
+    let cancelled = false;
+
+    Promise.resolve()
+      .then(() => {
+        if (!cancelled) setStatus('switching');
+        return switchSession(sessionId, hostname, codeEndpoint ?? undefined);
+      })
+      .then(() => {
+        if (!cancelled) setStatus('connected');
+      })
+      .catch(err => {
+        if (!cancelled) {
+          setStatus('error');
+          setErrorMessage(err instanceof Error ? err.message : String(err));
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [hostname, sessionId, codeEndpoint]);
 
   if (!hostname || !sessionId) {
     return (
@@ -84,25 +119,6 @@ export function EditorPanel({
         <div className={styles.emptyState}>
           <Code className={styles.emptyIcon} />
           <p>Start a session to access the editor</p>
-        </div>
-      </div>
-    );
-  }
-
-  if (sessionChanged) {
-    return (
-      <div className={cn(styles.container, className)}>
-        <div className={styles.emptyState}>
-          <RotateCcw className={styles.emptyIcon} />
-          <p>Session changed — the editor requires a page reload to reconnect.</p>
-          <button
-            className={styles.reloadButton}
-            onClick={() => globalThis.location.reload()}
-            type="button"
-          >
-            <RotateCcw size={14} />
-            Reload page
-          </button>
         </div>
       </div>
     );

--- a/web/src/components/EditorPanel/editorState.test.ts
+++ b/web/src/components/EditorPanel/editorState.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import {
-  isInitialized,
-  getInitializedSessionId,
-  markInitialized,
-  resetEditorState,
-} from './editorState';
+import { isInitialized, markInitialized, resetEditorState } from './editorState';
 
 describe('editorState', () => {
   beforeEach(() => {
@@ -13,28 +8,18 @@ describe('editorState', () => {
 
   it('should start as not initialized', () => {
     expect(isInitialized()).toBe(false);
-    expect(getInitializedSessionId()).toBeNull();
   });
 
-  it('should mark as initialized with session ID', () => {
-    markInitialized('session-abc');
+  it('should mark as initialized', () => {
+    markInitialized();
 
     expect(isInitialized()).toBe(true);
-    expect(getInitializedSessionId()).toBe('session-abc');
   });
 
   it('should reset state', () => {
-    markInitialized('session-abc');
+    markInitialized();
     resetEditorState();
 
     expect(isInitialized()).toBe(false);
-    expect(getInitializedSessionId()).toBeNull();
-  });
-
-  it('should overwrite session ID on second markInitialized', () => {
-    markInitialized('session-1');
-    markInitialized('session-2');
-
-    expect(getInitializedSessionId()).toBe('session-2');
   });
 });

--- a/web/src/components/EditorPanel/editorState.ts
+++ b/web/src/components/EditorPanel/editorState.ts
@@ -2,26 +2,22 @@
  * Singleton state tracking for the VS Code workbench initialization.
  *
  * `initialize()` from @codingame/monaco-vscode-api can only be called
- * once per page load. This module tracks whether it has been called
- * and which session it was initialized for.
+ * once per page load. This module tracks whether it has been called.
+ *
+ * Session-specific routing is handled by sessionRouter.ts — the
+ * workbench is initialized once and can serve multiple sessions.
  *
  * @internal — only consumed by EditorPanel and its tests.
  */
 
 let initialized = false;
-let initializedSessionId: string | null = null;
 
 export function isInitialized(): boolean {
   return initialized;
 }
 
-export function getInitializedSessionId(): string | null {
-  return initializedSessionId;
-}
-
-export function markInitialized(sessionId: string): void {
+export function markInitialized(): void {
   initialized = true;
-  initializedSessionId = sessionId;
 }
 
 /**
@@ -30,5 +26,4 @@ export function markInitialized(sessionId: string): void {
  */
 export function resetEditorState(): void {
   initialized = false;
-  initializedSessionId = null;
 }

--- a/web/src/components/EditorPanel/sessionRouter.test.ts
+++ b/web/src/components/EditorPanel/sessionRouter.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  getActiveRoute,
+  setActiveRoute,
+  trackWebSocket,
+  closeAllWebSockets,
+  resetSessionRouter,
+} from './sessionRouter';
+
+function createMockWebSocket(): WebSocket {
+  const listeners: Record<string, Set<EventListener>> = {};
+  return {
+    close: vi.fn(() => {
+      listeners['close']?.forEach(l => l(new Event('close')));
+    }),
+    addEventListener: vi.fn((event: string, listener: EventListener) => {
+      if (!listeners[event]) listeners[event] = new Set();
+      listeners[event].add(listener);
+    }),
+    removeEventListener: vi.fn((event: string, listener: EventListener) => {
+      listeners[event]?.delete(listener);
+    }),
+  } as unknown as WebSocket;
+}
+
+describe('sessionRouter', () => {
+  beforeEach(() => {
+    resetSessionRouter();
+  });
+
+  it('should start with no active route', () => {
+    expect(getActiveRoute()).toBeNull();
+  });
+
+  it('should set and get active route', () => {
+    setActiveRoute({ sessionId: 'abc', hostname: 'pod-1.example.com' });
+
+    expect(getActiveRoute()).toEqual({
+      sessionId: 'abc',
+      hostname: 'pod-1.example.com',
+    });
+  });
+
+  it('should update active route on subsequent calls', () => {
+    setActiveRoute({ sessionId: 'abc', hostname: 'pod-1.example.com' });
+    setActiveRoute({ sessionId: 'def', hostname: 'pod-2.example.com', basePath: '/s/def/' });
+
+    expect(getActiveRoute()).toEqual({
+      sessionId: 'def',
+      hostname: 'pod-2.example.com',
+      basePath: '/s/def/',
+    });
+  });
+
+  it('should track and close WebSocket connections', () => {
+    const ws1 = createMockWebSocket();
+    const ws2 = createMockWebSocket();
+
+    trackWebSocket(ws1);
+    trackWebSocket(ws2);
+
+    closeAllWebSockets();
+
+    expect(ws1.close).toHaveBeenCalledTimes(1);
+    expect(ws2.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('should remove WebSocket from tracking when it closes', () => {
+    const ws = createMockWebSocket();
+    trackWebSocket(ws);
+
+    // Simulate the close event — the close listener registered by trackWebSocket
+    // should remove the ws from the tracked set.
+    ws.close();
+
+    // Calling closeAll again should NOT call close on the already-closed ws.
+    closeAllWebSockets();
+
+    // close() was called once from the explicit call, not again from closeAll.
+    expect(ws.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reset all state', () => {
+    setActiveRoute({ sessionId: 'abc', hostname: 'pod.example.com' });
+    const ws = createMockWebSocket();
+    trackWebSocket(ws);
+
+    resetSessionRouter();
+
+    expect(getActiveRoute()).toBeNull();
+
+    // closeAll after reset should not close the previously tracked ws.
+    closeAllWebSockets();
+    expect(ws.close).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/EditorPanel/sessionRouter.ts
+++ b/web/src/components/EditorPanel/sessionRouter.ts
@@ -1,0 +1,51 @@
+/**
+ * Mutable session routing for the VS Code workbench.
+ *
+ * Because `initialize()` from @codingame/monaco-vscode-api can only be
+ * called once per page load, the WebSocket factory and workspace folder
+ * must be dynamically routable to different session REH servers.
+ *
+ * This module holds the mutable session state and tracks active WebSocket
+ * connections so they can be closed on session switch, forcing VS Code
+ * to reconnect through the factory (which now routes to the new session).
+ */
+
+export interface SessionRoute {
+  sessionId: string;
+  hostname: string;
+  /** Base path for the session (e.g. "/s/{id}/"), used to prefix /reh/. */
+  basePath?: string;
+}
+
+let activeRoute: SessionRoute | null = null;
+const activeWebSockets = new Set<WebSocket>();
+
+/** Get the current session route. */
+export function getActiveRoute(): SessionRoute | null {
+  return activeRoute;
+}
+
+/** Update the active session route. */
+export function setActiveRoute(route: SessionRoute): void {
+  activeRoute = route;
+}
+
+/** Register a WebSocket so it can be closed on session switch. */
+export function trackWebSocket(ws: WebSocket): void {
+  activeWebSockets.add(ws);
+  ws.addEventListener('close', () => activeWebSockets.delete(ws));
+}
+
+/** Close all tracked WebSocket connections to force VS Code to reconnect. */
+export function closeAllWebSockets(): void {
+  for (const ws of activeWebSockets) {
+    ws.close();
+  }
+  activeWebSockets.clear();
+}
+
+/** Reset all state. Exposed for testing only. @internal */
+export function resetSessionRouter(): void {
+  activeRoute = null;
+  activeWebSockets.clear();
+}

--- a/web/src/components/EditorPanel/tabStateManager.test.ts
+++ b/web/src/components/EditorPanel/tabStateManager.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { VsCodeApi } from './tabStateManager';
 import {
   extractRelativePath,
   saveTabState,
@@ -7,44 +8,50 @@ import {
   resetTabStateManager,
 } from './tabStateManager';
 
-// Mock the vscode module
-const mockExecuteCommand = vi.fn();
-const mockShowTextDocument = vi.fn().mockResolvedValue({});
-const mockOpenTextDocument = vi.fn().mockResolvedValue({ uri: {} });
+function createMockApi(): VsCodeApi & {
+  _showTextDocument: ReturnType<typeof vi.fn>;
+  _openTextDocument: ReturnType<typeof vi.fn>;
+  _tabGroups: {
+    all: { tabs: { input: { uri: { path: string; scheme: string } } }[] }[];
+    activeTabGroup: { activeTab: { input: { uri: { path: string } } } | null };
+  };
+} {
+  const showTextDocument = vi.fn().mockResolvedValue({});
+  const openTextDocument = vi.fn().mockResolvedValue({ uri: {} });
+  const tabGroups = {
+    all: [] as { tabs: { input: { uri: { path: string; scheme: string } } }[] }[],
+    activeTabGroup: { activeTab: null as { input: { uri: { path: string } } } | null },
+  };
 
-const mockTabGroups = {
-  all: [] as { tabs: { input: { uri: { path: string; scheme: string } } }[] }[],
-  activeTabGroup: { activeTab: null as { input: { uri: { path: string } } } | null },
-};
-
-vi.mock('vscode', () => ({
-  window: {
-    get tabGroups() {
-      return mockTabGroups;
+  return {
+    Uri: {
+      from: (c: { scheme: string; authority?: string; path?: string }) => ({
+        scheme: c.scheme,
+        authority: c.authority ?? '',
+        path: c.path ?? '',
+      }),
     },
-    showTextDocument: (...args: unknown[]) => mockShowTextDocument(...args),
-  },
-  workspace: {
-    openTextDocument: (...args: unknown[]) => mockOpenTextDocument(...args),
-  },
-  commands: {
-    executeCommand: (...args: unknown[]) => mockExecuteCommand(...args),
-  },
-  Uri: {
-    from: (components: { scheme: string; authority: string; path: string }) => ({
-      scheme: components.scheme,
-      authority: components.authority,
-      path: components.path,
-    }),
-  },
-}));
+    window: {
+      get tabGroups() {
+        return tabGroups;
+      },
+      showTextDocument: showTextDocument,
+    },
+    workspace: {
+      openTextDocument: openTextDocument,
+    },
+    _showTextDocument: showTextDocument,
+    _openTextDocument: openTextDocument,
+    _tabGroups: tabGroups,
+  };
+}
 
 describe('tabStateManager', () => {
+  let api: ReturnType<typeof createMockApi>;
+
   beforeEach(() => {
     resetTabStateManager();
-    vi.clearAllMocks();
-    mockTabGroups.all = [];
-    mockTabGroups.activeTabGroup = { activeTab: null };
+    api = createMockApi();
   });
 
   describe('extractRelativePath', () => {
@@ -70,7 +77,7 @@ describe('tabStateManager', () => {
 
   describe('saveTabState', () => {
     it('should save open tabs for a session', async () => {
-      mockTabGroups.all = [
+      api._tabGroups.all = [
         {
           tabs: [
             {
@@ -86,13 +93,13 @@ describe('tabStateManager', () => {
           ],
         },
       ];
-      mockTabGroups.activeTabGroup = {
+      api._tabGroups.activeTabGroup = {
         activeTab: {
           input: { uri: { path: '/volundr/sessions/s1/workspace/src/b.ts' } },
         },
       };
 
-      await saveTabState('s1');
+      await saveTabState('s1', api);
 
       const saved = getSavedTabState('s1');
       expect(saved).toHaveLength(2);
@@ -101,7 +108,7 @@ describe('tabStateManager', () => {
     });
 
     it('should skip non-vscode-remote tabs', async () => {
-      mockTabGroups.all = [
+      api._tabGroups.all = [
         {
           tabs: [
             {
@@ -113,9 +120,8 @@ describe('tabStateManager', () => {
           ],
         },
       ];
-      mockTabGroups.activeTabGroup = { activeTab: null };
 
-      await saveTabState('s1');
+      await saveTabState('s1', api);
 
       const saved = getSavedTabState('s1');
       expect(saved).toHaveLength(1);
@@ -123,9 +129,7 @@ describe('tabStateManager', () => {
     });
 
     it('should save empty array when no tabs are open', async () => {
-      mockTabGroups.all = [];
-
-      await saveTabState('s1');
+      await saveTabState('s1', api);
 
       const saved = getSavedTabState('s1');
       expect(saved).toEqual([]);
@@ -134,8 +138,7 @@ describe('tabStateManager', () => {
 
   describe('restoreTabState', () => {
     it('should restore previously saved tabs', async () => {
-      // Manually seed saved state by calling save with mock tabs.
-      mockTabGroups.all = [
+      api._tabGroups.all = [
         {
           tabs: [
             {
@@ -151,39 +154,41 @@ describe('tabStateManager', () => {
           ],
         },
       ];
-      mockTabGroups.activeTabGroup = {
+      api._tabGroups.activeTabGroup = {
         activeTab: {
           input: { uri: { path: '/volundr/sessions/s1/workspace/src/b.ts' } },
         },
       };
 
-      await saveTabState('s1');
-      vi.clearAllMocks();
+      await saveTabState('s1', api);
 
-      // Now restore.
-      await restoreTabState('s1', 'gateway.example.com');
+      // Reset mocks for restore phase.
+      api._openTextDocument.mockClear();
+      api._showTextDocument.mockClear();
+
+      await restoreTabState('s1', 'gateway.example.com', api);
 
       // Non-active tab opened first, then active tab last for focus.
-      expect(mockOpenTextDocument).toHaveBeenCalledTimes(2);
-      expect(mockShowTextDocument).toHaveBeenCalledTimes(2);
+      expect(api._openTextDocument).toHaveBeenCalledTimes(2);
+      expect(api._showTextDocument).toHaveBeenCalledTimes(2);
 
       // First call: non-active tab (src/a.ts)
-      const firstUri = mockOpenTextDocument.mock.calls[0][0];
+      const firstUri = api._openTextDocument.mock.calls[0][0];
       expect(firstUri.path).toBe('/volundr/sessions/s1/workspace/src/a.ts');
 
       // Second call: active tab (src/b.ts)
-      const secondUri = mockOpenTextDocument.mock.calls[1][0];
+      const secondUri = api._openTextDocument.mock.calls[1][0];
       expect(secondUri.path).toBe('/volundr/sessions/s1/workspace/src/b.ts');
     });
 
     it('should do nothing when no saved state exists', async () => {
-      await restoreTabState('nonexistent', 'gateway.example.com');
+      await restoreTabState('nonexistent', 'gateway.example.com', api);
 
-      expect(mockOpenTextDocument).not.toHaveBeenCalled();
+      expect(api._openTextDocument).not.toHaveBeenCalled();
     });
 
     it('should skip files that fail to open', async () => {
-      mockTabGroups.all = [
+      api._tabGroups.all = [
         {
           tabs: [
             {
@@ -194,15 +199,12 @@ describe('tabStateManager', () => {
           ],
         },
       ];
-      mockTabGroups.activeTabGroup = { activeTab: null };
 
-      await saveTabState('s1');
-      vi.clearAllMocks();
-
-      mockOpenTextDocument.mockRejectedValueOnce(new Error('File not found'));
+      await saveTabState('s1', api);
+      api._openTextDocument.mockRejectedValueOnce(new Error('File not found'));
 
       // Should not throw.
-      await expect(restoreTabState('s1', 'gateway.example.com')).resolves.toBeUndefined();
+      await expect(restoreTabState('s1', 'gateway.example.com', api)).resolves.toBeUndefined();
     });
   });
 

--- a/web/src/components/EditorPanel/tabStateManager.test.ts
+++ b/web/src/components/EditorPanel/tabStateManager.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  extractRelativePath,
+  saveTabState,
+  getSavedTabState,
+  restoreTabState,
+  resetTabStateManager,
+} from './tabStateManager';
+
+// Mock the vscode module
+const mockExecuteCommand = vi.fn();
+const mockShowTextDocument = vi.fn().mockResolvedValue({});
+const mockOpenTextDocument = vi.fn().mockResolvedValue({ uri: {} });
+
+const mockTabGroups = {
+  all: [] as { tabs: { input: { uri: { path: string; scheme: string } } }[] }[],
+  activeTabGroup: { activeTab: null as { input: { uri: { path: string } } } | null },
+};
+
+vi.mock('vscode', () => ({
+  window: {
+    get tabGroups() {
+      return mockTabGroups;
+    },
+    showTextDocument: (...args: unknown[]) => mockShowTextDocument(...args),
+  },
+  workspace: {
+    openTextDocument: (...args: unknown[]) => mockOpenTextDocument(...args),
+  },
+  commands: {
+    executeCommand: (...args: unknown[]) => mockExecuteCommand(...args),
+  },
+  Uri: {
+    from: (components: { scheme: string; authority: string; path: string }) => ({
+      scheme: components.scheme,
+      authority: components.authority,
+      path: components.path,
+    }),
+  },
+}));
+
+describe('tabStateManager', () => {
+  beforeEach(() => {
+    resetTabStateManager();
+    vi.clearAllMocks();
+    mockTabGroups.all = [];
+    mockTabGroups.activeTabGroup = { activeTab: null };
+  });
+
+  describe('extractRelativePath', () => {
+    it('should extract relative path from workspace URI path', () => {
+      const fullPath = '/volundr/sessions/abc-123/workspace/src/main.ts';
+      expect(extractRelativePath(fullPath)).toBe('src/main.ts');
+    });
+
+    it('should handle nested paths', () => {
+      const fullPath = '/volundr/sessions/abc-123/workspace/src/components/App/App.tsx';
+      expect(extractRelativePath(fullPath)).toBe('src/components/App/App.tsx');
+    });
+
+    it('should return null for non-matching paths', () => {
+      expect(extractRelativePath('/some/other/path/file.ts')).toBeNull();
+    });
+
+    it('should return empty string for workspace root', () => {
+      const fullPath = '/volundr/sessions/abc-123/workspace/';
+      expect(extractRelativePath(fullPath)).toBe('');
+    });
+  });
+
+  describe('saveTabState', () => {
+    it('should save open tabs for a session', async () => {
+      mockTabGroups.all = [
+        {
+          tabs: [
+            {
+              input: {
+                uri: { path: '/volundr/sessions/s1/workspace/src/a.ts', scheme: 'vscode-remote' },
+              },
+            },
+            {
+              input: {
+                uri: { path: '/volundr/sessions/s1/workspace/src/b.ts', scheme: 'vscode-remote' },
+              },
+            },
+          ],
+        },
+      ];
+      mockTabGroups.activeTabGroup = {
+        activeTab: {
+          input: { uri: { path: '/volundr/sessions/s1/workspace/src/b.ts' } },
+        },
+      };
+
+      await saveTabState('s1');
+
+      const saved = getSavedTabState('s1');
+      expect(saved).toHaveLength(2);
+      expect(saved![0]).toEqual({ relativePath: 'src/a.ts', isActive: false });
+      expect(saved![1]).toEqual({ relativePath: 'src/b.ts', isActive: true });
+    });
+
+    it('should skip non-vscode-remote tabs', async () => {
+      mockTabGroups.all = [
+        {
+          tabs: [
+            {
+              input: {
+                uri: { path: '/volundr/sessions/s1/workspace/src/a.ts', scheme: 'vscode-remote' },
+              },
+            },
+            { input: { uri: { path: '/some/local/file.ts', scheme: 'file' } } },
+          ],
+        },
+      ];
+      mockTabGroups.activeTabGroup = { activeTab: null };
+
+      await saveTabState('s1');
+
+      const saved = getSavedTabState('s1');
+      expect(saved).toHaveLength(1);
+      expect(saved![0].relativePath).toBe('src/a.ts');
+    });
+
+    it('should save empty array when no tabs are open', async () => {
+      mockTabGroups.all = [];
+
+      await saveTabState('s1');
+
+      const saved = getSavedTabState('s1');
+      expect(saved).toEqual([]);
+    });
+  });
+
+  describe('restoreTabState', () => {
+    it('should restore previously saved tabs', async () => {
+      // Manually seed saved state by calling save with mock tabs.
+      mockTabGroups.all = [
+        {
+          tabs: [
+            {
+              input: {
+                uri: { path: '/volundr/sessions/s1/workspace/src/a.ts', scheme: 'vscode-remote' },
+              },
+            },
+            {
+              input: {
+                uri: { path: '/volundr/sessions/s1/workspace/src/b.ts', scheme: 'vscode-remote' },
+              },
+            },
+          ],
+        },
+      ];
+      mockTabGroups.activeTabGroup = {
+        activeTab: {
+          input: { uri: { path: '/volundr/sessions/s1/workspace/src/b.ts' } },
+        },
+      };
+
+      await saveTabState('s1');
+      vi.clearAllMocks();
+
+      // Now restore.
+      await restoreTabState('s1', 'gateway.example.com');
+
+      // Non-active tab opened first, then active tab last for focus.
+      expect(mockOpenTextDocument).toHaveBeenCalledTimes(2);
+      expect(mockShowTextDocument).toHaveBeenCalledTimes(2);
+
+      // First call: non-active tab (src/a.ts)
+      const firstUri = mockOpenTextDocument.mock.calls[0][0];
+      expect(firstUri.path).toBe('/volundr/sessions/s1/workspace/src/a.ts');
+
+      // Second call: active tab (src/b.ts)
+      const secondUri = mockOpenTextDocument.mock.calls[1][0];
+      expect(secondUri.path).toBe('/volundr/sessions/s1/workspace/src/b.ts');
+    });
+
+    it('should do nothing when no saved state exists', async () => {
+      await restoreTabState('nonexistent', 'gateway.example.com');
+
+      expect(mockOpenTextDocument).not.toHaveBeenCalled();
+    });
+
+    it('should skip files that fail to open', async () => {
+      mockTabGroups.all = [
+        {
+          tabs: [
+            {
+              input: {
+                uri: { path: '/volundr/sessions/s1/workspace/gone.ts', scheme: 'vscode-remote' },
+              },
+            },
+          ],
+        },
+      ];
+      mockTabGroups.activeTabGroup = { activeTab: null };
+
+      await saveTabState('s1');
+      vi.clearAllMocks();
+
+      mockOpenTextDocument.mockRejectedValueOnce(new Error('File not found'));
+
+      // Should not throw.
+      await expect(restoreTabState('s1', 'gateway.example.com')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('getSavedTabState', () => {
+    it('should return undefined for unknown sessions', () => {
+      expect(getSavedTabState('unknown')).toBeUndefined();
+    });
+  });
+});

--- a/web/src/components/EditorPanel/tabStateManager.ts
+++ b/web/src/components/EditorPanel/tabStateManager.ts
@@ -1,0 +1,134 @@
+/**
+ * Persists open editor tabs per session so they can be restored
+ * when the user switches back to a previously visited session.
+ *
+ * Tab state is stored in-memory (lost on page reload). Each entry
+ * records the file paths relative to the workspace root and which
+ * tab was active, allowing reconstruction of URIs for any session.
+ */
+
+export interface SavedTab {
+  /** Path relative to the workspace root (e.g. "src/main.ts"). */
+  relativePath: string;
+  /** Whether this tab was the active/focused one. */
+  isActive: boolean;
+}
+
+const tabStateBySession = new Map<string, SavedTab[]>();
+
+/** Workspace path prefix: /volundr/sessions/{id}/workspace/ */
+const WORKSPACE_PREFIX_RE = /^\/volundr\/sessions\/[^/]+\/workspace\//;
+
+/**
+ * Extract the relative path from a full vscode-remote URI path.
+ * Returns null if the path doesn't match the expected workspace layout.
+ */
+export function extractRelativePath(fullPath: string): string | null {
+  const match = fullPath.match(WORKSPACE_PREFIX_RE);
+  if (!match) {
+    return null;
+  }
+  return fullPath.slice(match[0].length);
+}
+
+/**
+ * Save the currently open editor tabs for the given session.
+ *
+ * Reads from `vscode.window.tabGroups` to discover all open text
+ * editor tabs and their active state.
+ */
+export async function saveTabState(sessionId: string): Promise<void> {
+  const vscode = await import('vscode');
+
+  const tabs: SavedTab[] = [];
+  const activeTabUri = vscode.window.tabGroups.activeTabGroup?.activeTab?.input;
+
+  for (const group of vscode.window.tabGroups.all) {
+    for (const tab of group.tabs) {
+      const input = tab.input;
+      // TabInputText has a `uri` property — filter to text editor tabs only.
+      if (input && typeof input === 'object' && 'uri' in input) {
+        const uri = (input as { uri: { path: string; scheme: string } }).uri;
+        if (uri.scheme !== 'vscode-remote') {
+          continue;
+        }
+        const relativePath = extractRelativePath(uri.path);
+        if (!relativePath) {
+          continue;
+        }
+        const isActive =
+          activeTabUri != null &&
+          typeof activeTabUri === 'object' &&
+          'uri' in activeTabUri &&
+          (activeTabUri as { uri: { path: string } }).uri.path === uri.path;
+
+        tabs.push({ relativePath, isActive });
+      }
+    }
+  }
+
+  tabStateBySession.set(sessionId, tabs);
+}
+
+/**
+ * Retrieve the saved tab state for a session (if any).
+ */
+export function getSavedTabState(sessionId: string): SavedTab[] | undefined {
+  return tabStateBySession.get(sessionId);
+}
+
+/**
+ * Restore previously saved tabs for a session.
+ *
+ * Opens each saved file and focuses the one that was previously active.
+ * Operates on a best-effort basis — files that no longer exist are skipped.
+ */
+export async function restoreTabState(sessionId: string, authority: string): Promise<void> {
+  const saved = tabStateBySession.get(sessionId);
+  if (!saved || saved.length === 0) {
+    return;
+  }
+
+  const vscode = await import('vscode');
+
+  // Open each saved tab. Save the active one for last so it ends up focused.
+  let activeTab: SavedTab | null = null;
+
+  for (const tab of saved) {
+    if (tab.isActive) {
+      activeTab = tab;
+      continue;
+    }
+    await openTab(vscode, sessionId, authority, tab);
+  }
+
+  // Open the active tab last so it gets focus.
+  if (activeTab) {
+    await openTab(vscode, sessionId, authority, activeTab);
+  }
+}
+
+async function openTab(
+  vscode: typeof import('vscode'),
+  sessionId: string,
+  authority: string,
+  tab: SavedTab
+): Promise<void> {
+  const uri = vscode.Uri.from({
+    scheme: 'vscode-remote',
+    authority,
+    path: `/volundr/sessions/${sessionId}/workspace/${tab.relativePath}`,
+  });
+
+  try {
+    const doc = await vscode.workspace.openTextDocument(uri);
+    await vscode.window.showTextDocument(doc, { preview: false, preserveFocus: !tab.isActive });
+  } catch {
+    // File may no longer exist — skip silently.
+  }
+}
+
+/** Clear all saved state. Exposed for testing only. @internal */
+export function resetTabStateManager(): void {
+  tabStateBySession.clear();
+}

--- a/web/src/components/EditorPanel/tabStateManager.ts
+++ b/web/src/components/EditorPanel/tabStateManager.ts
@@ -5,7 +5,42 @@
  * Tab state is stored in-memory (lost on page reload). Each entry
  * records the file paths relative to the workspace root and which
  * tab was active, allowing reconstruction of URIs for any session.
+ *
+ * The VS Code API is passed in as a parameter (not imported directly)
+ * because the `vscode` module is a virtual module provided at runtime
+ * by @codingame/monaco-vscode-api and cannot be resolved by Vite at
+ * build time.
  */
+
+/** Minimal subset of the VS Code API needed by the tab state manager. */
+export interface VsCodeApi {
+  Uri: {
+    from(components: { scheme: string; authority?: string; path?: string }): {
+      scheme: string;
+      authority: string;
+      path: string;
+    };
+  };
+  window: {
+    tabGroups: {
+      all: readonly {
+        tabs: readonly {
+          input: unknown;
+        }[];
+      }[];
+      activeTabGroup: {
+        activeTab: { input: unknown } | undefined;
+      };
+    };
+    showTextDocument(
+      document: unknown,
+      options?: { preview?: boolean; preserveFocus?: boolean }
+    ): Thenable<unknown>;
+  };
+  workspace: {
+    openTextDocument(uri: unknown): Thenable<unknown>;
+  };
+}
 
 export interface SavedTab {
   /** Path relative to the workspace root (e.g. "src/main.ts"). */
@@ -37,13 +72,11 @@ export function extractRelativePath(fullPath: string): string | null {
  * Reads from `vscode.window.tabGroups` to discover all open text
  * editor tabs and their active state.
  */
-export async function saveTabState(sessionId: string): Promise<void> {
-  const vscode = await import('vscode');
-
+export async function saveTabState(sessionId: string, api: VsCodeApi): Promise<void> {
   const tabs: SavedTab[] = [];
-  const activeTabUri = vscode.window.tabGroups.activeTabGroup?.activeTab?.input;
+  const activeTabUri = api.window.tabGroups.activeTabGroup?.activeTab?.input;
 
-  for (const group of vscode.window.tabGroups.all) {
+  for (const group of api.window.tabGroups.all) {
     for (const tab of group.tabs) {
       const input = tab.input;
       // TabInputText has a `uri` property — filter to text editor tabs only.
@@ -83,13 +116,15 @@ export function getSavedTabState(sessionId: string): SavedTab[] | undefined {
  * Opens each saved file and focuses the one that was previously active.
  * Operates on a best-effort basis — files that no longer exist are skipped.
  */
-export async function restoreTabState(sessionId: string, authority: string): Promise<void> {
+export async function restoreTabState(
+  sessionId: string,
+  authority: string,
+  api: VsCodeApi
+): Promise<void> {
   const saved = tabStateBySession.get(sessionId);
   if (!saved || saved.length === 0) {
     return;
   }
-
-  const vscode = await import('vscode');
 
   // Open each saved tab. Save the active one for last so it ends up focused.
   let activeTab: SavedTab | null = null;
@@ -99,30 +134,30 @@ export async function restoreTabState(sessionId: string, authority: string): Pro
       activeTab = tab;
       continue;
     }
-    await openTab(vscode, sessionId, authority, tab);
+    await openTab(api, sessionId, authority, tab);
   }
 
   // Open the active tab last so it gets focus.
   if (activeTab) {
-    await openTab(vscode, sessionId, authority, activeTab);
+    await openTab(api, sessionId, authority, activeTab);
   }
 }
 
 async function openTab(
-  vscode: typeof import('vscode'),
+  api: VsCodeApi,
   sessionId: string,
   authority: string,
   tab: SavedTab
 ): Promise<void> {
-  const uri = vscode.Uri.from({
+  const uri = api.Uri.from({
     scheme: 'vscode-remote',
     authority,
     path: `/volundr/sessions/${sessionId}/workspace/${tab.relativePath}`,
   });
 
   try {
-    const doc = await vscode.workspace.openTextDocument(uri);
-    await vscode.window.showTextDocument(doc, { preview: false, preserveFocus: !tab.isActive });
+    const doc = await api.workspace.openTextDocument(uri);
+    await api.window.showTextDocument(doc, { preview: false, preserveFocus: !tab.isActive });
   } catch {
     // File may no longer exist — skip silently.
   }

--- a/web/src/components/EditorPanel/workbenchInit.ts
+++ b/web/src/components/EditorPanel/workbenchInit.ts
@@ -182,6 +182,15 @@ export interface InitWorkbenchParams {
 // (mounts → unmounts → remounts in dev, causing two concurrent calls).
 let initPromise: Promise<void> | null = null;
 
+// VS Code extension API reference, populated after initialize + registerExtension.
+// Used by switchSession() and tabStateManager to call workspace/window/commands APIs.
+let vsCodeApi: typeof import('vscode') | null = null;
+
+/** Get the VS Code extension API. Only available after initialization. */
+export function getVsCodeApi(): typeof import('vscode') | null {
+  return vsCodeApi;
+}
+
 export async function initWorkbench(params: InitWorkbenchParams): Promise<void> {
   if (isInitialized()) {
     return;
@@ -387,8 +396,13 @@ async function doInitWorkbench({
     {} // envOptions
   );
 
-  // ── 7. Register default API extension (matching demo) ──
-  registerExtension(
+  // ── 7. Register default API extension and store the API reference ──
+  //
+  // The extension API gives us access to vscode.workspace, vscode.window,
+  // vscode.commands, etc. We store it in a module-level variable so
+  // switchSession() can use it without `import('vscode')` (which Vite
+  // can't resolve at build time since `vscode` is a virtual module).
+  const ext = registerExtension(
     {
       name: 'volundr',
       publisher: 'niuulabs',
@@ -396,7 +410,9 @@ async function doInitWorkbench({
       engines: { vscode: '*' },
     },
     ExtensionHostKind.LocalProcess
-  ).setAsDefaultApi();
+  );
+  ext.setAsDefaultApi();
+  vsCodeApi = await ext.getApi();
 
   markInitialized();
 }
@@ -421,14 +437,17 @@ export async function switchSession(
   const config = editorService.getWorkbenchConfig(sessionId, hostname, codeEndpoint);
   const previousRoute = getActiveRoute();
 
+  if (!vsCodeApi) {
+    throw new Error('Cannot switch session: VS Code API not initialized');
+  }
+
   // 1. Save the current session's open tabs before switching.
   if (previousRoute) {
-    await saveTabState(previousRoute.sessionId);
+    await saveTabState(previousRoute.sessionId, vsCodeApi);
   }
 
   // 2. Close all open editors so stale tabs don't flash errors.
-  const vscode = await import('vscode');
-  await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+  await vsCodeApi.commands.executeCommand('workbench.action.closeAllEditors');
 
   // 3. Update routing so new WebSocket connections go to the new REH server.
   setActiveRoute({
@@ -441,15 +460,15 @@ export async function switchSession(
   closeAllWebSockets();
 
   // 5. Swap the workspace folder.
-  const newFolderUri = vscode.Uri.from({
+  const newFolderUri = vsCodeApi.Uri.from({
     scheme: 'vscode-remote',
     authority: STABLE_AUTHORITY,
     path: `/volundr/sessions/${sessionId}/workspace`,
   });
 
-  const currentFolderCount = vscode.workspace.workspaceFolders?.length ?? 0;
-  vscode.workspace.updateWorkspaceFolders(0, currentFolderCount, { uri: newFolderUri });
+  const currentFolderCount = vsCodeApi.workspace.workspaceFolders?.length ?? 0;
+  vsCodeApi.workspace.updateWorkspaceFolders(0, currentFolderCount, { uri: newFolderUri });
 
   // 6. Restore previously saved tabs for the new session (if any).
-  await restoreTabState(sessionId, STABLE_AUTHORITY);
+  await restoreTabState(sessionId, STABLE_AUTHORITY, vsCodeApi);
 }

--- a/web/src/components/EditorPanel/workbenchInit.ts
+++ b/web/src/components/EditorPanel/workbenchInit.ts
@@ -8,11 +8,22 @@
  * all service override packages. Dynamic imports caused module resolution
  * issues that prevented views from registering.
  *
+ * The workbench is initialized ONCE with a stable remote authority and a
+ * dynamic WebSocket factory. Session switching is handled by updating the
+ * mutable routing state and forcing a reconnection — no page reload needed.
+ *
  * @see https://github.com/CodinGame/monaco-vscode-api/tree/main/demo
  */
 import { getAccessToken } from '@/adapters/api/client';
 import { ApiEditorAdapter } from '@/adapters/api/editor.adapter';
-import { isInitialized, getInitializedSessionId, markInitialized } from './editorState';
+import { isInitialized, markInitialized } from './editorState';
+import {
+  getActiveRoute,
+  setActiveRoute,
+  trackWebSocket,
+  closeAllWebSockets,
+} from './sessionRouter';
+import { saveTabState, restoreTabState } from './tabStateManager';
 
 // ── Static imports (matching demo pattern) ──
 import { initialize } from '@codingame/monaco-vscode-api';
@@ -131,6 +142,16 @@ import searchWorkerUrl from '@codingame/monaco-vscode-search-service-override/wo
 
 const editorService = new ApiEditorAdapter();
 
+/**
+ * Stable remote authority used for ALL sessions.
+ *
+ * By using the gateway host (window.location.host) as the authority,
+ * all session folder URIs share the same authority. This allows the
+ * dynamic WebSocket factory to route connections to different REH
+ * servers without VS Code thinking it's a different remote server.
+ */
+const STABLE_AUTHORITY = globalThis.location?.host ?? 'localhost';
+
 const workerUrls: Record<string, string> = {
   editorWorkerService: editorWorkerUrl,
   extensionHostWorkerMain: extensionHostWorkerUrl,
@@ -162,7 +183,7 @@ export interface InitWorkbenchParams {
 let initPromise: Promise<void> | null = null;
 
 export async function initWorkbench(params: InitWorkbenchParams): Promise<void> {
-  if (isInitialized() && getInitializedSessionId() === params.sessionId) {
+  if (isInitialized()) {
     return;
   }
   if (initPromise) {
@@ -172,6 +193,17 @@ export async function initWorkbench(params: InitWorkbenchParams): Promise<void> 
   return initPromise;
 }
 
+/**
+ * Build a folder URI for a given session.
+ */
+function buildFolderUri(sessionId: string): URI {
+  return URI.from({
+    scheme: 'vscode-remote',
+    authority: STABLE_AUTHORITY,
+    path: `/volundr/sessions/${sessionId}/workspace`,
+  });
+}
+
 async function doInitWorkbench({
   hostname,
   sessionId,
@@ -179,6 +211,13 @@ async function doInitWorkbench({
   container,
 }: InitWorkbenchParams): Promise<void> {
   const config = editorService.getWorkbenchConfig(sessionId, hostname, codeEndpoint);
+
+  // Set the initial session route so the WebSocket factory knows where to connect.
+  setActiveRoute({
+    sessionId,
+    hostname,
+    basePath: config.basePath,
+  });
 
   // ── 1. Create IndexedDB providers (user data persistence) ──
   await createIndexedDBProviders();
@@ -258,16 +297,17 @@ async function doInitWorkbench({
   };
 
   // ── 4. Build workspace provider ──
-  const folderUri = URI.from({
-    scheme: 'vscode-remote',
-    authority: config.remoteAuthority,
-    path: `/volundr/sessions/${sessionId}/workspace`,
-  });
+  const folderUri = buildFolderUri(sessionId);
 
-  // ── 5. Build IWebSocket factory ──
+  // ── 5. Build dynamic IWebSocket factory ──
+  //
+  // The factory reads from the mutable activeRoute on every new connection.
+  // When a session switch closes existing WebSockets, VS Code reconnects
+  // through this factory — which now routes to the new session's REH server.
   const webSocketFactory = {
     create: (url: string) => {
-      const rehPrefix = config.basePath ? `${config.basePath}reh/` : '/reh/';
+      const route = getActiveRoute();
+      const rehPrefix = route?.basePath ? `${route.basePath}reh/` : '/reh/';
       const rewritten = url.replace(/^(wss?:\/\/[^/]+)\//, `$1${rehPrefix}`);
 
       // Append access_token query param for gateway JWT validation,
@@ -279,6 +319,9 @@ async function doInitWorkbench({
 
       const ws = new WebSocket(authedUrl);
       ws.binaryType = 'arraybuffer';
+
+      // Track so we can close on session switch.
+      trackWebSocket(ws);
 
       return {
         onData: (listener: (data: ArrayBuffer) => void) => {
@@ -318,7 +361,7 @@ async function doInitWorkbench({
     services,
     container,
     {
-      remoteAuthority: config.remoteAuthority,
+      remoteAuthority: STABLE_AUTHORITY,
       webSocketFactory,
       workspaceProvider: {
         trusted: true,
@@ -355,5 +398,58 @@ async function doInitWorkbench({
     ExtensionHostKind.LocalProcess
   ).setAsDefaultApi();
 
-  markInitialized(sessionId);
+  markInitialized();
+}
+
+/**
+ * Switch the workbench to a different session without page reload.
+ *
+ * 1. Saves the current session's open editor tabs for later restoration.
+ * 2. Closes all open editors to avoid stale file references.
+ * 3. Updates the mutable routing state so new WebSocket connections
+ *    go to the new session's REH server.
+ * 4. Closes all existing WebSocket connections, forcing VS Code to
+ *    reconnect through the factory (now routing to the new session).
+ * 5. Swaps the workspace folder to the new session's workspace path.
+ * 6. Restores previously saved tabs for the new session (if any).
+ */
+export async function switchSession(
+  sessionId: string,
+  hostname: string,
+  codeEndpoint?: string
+): Promise<void> {
+  const config = editorService.getWorkbenchConfig(sessionId, hostname, codeEndpoint);
+  const previousRoute = getActiveRoute();
+
+  // 1. Save the current session's open tabs before switching.
+  if (previousRoute) {
+    await saveTabState(previousRoute.sessionId);
+  }
+
+  // 2. Close all open editors so stale tabs don't flash errors.
+  const vscode = await import('vscode');
+  await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+
+  // 3. Update routing so new WebSocket connections go to the new REH server.
+  setActiveRoute({
+    sessionId,
+    hostname,
+    basePath: config.basePath,
+  });
+
+  // 4. Close existing WebSocket connections — VS Code will auto-reconnect.
+  closeAllWebSockets();
+
+  // 5. Swap the workspace folder.
+  const newFolderUri = vscode.Uri.from({
+    scheme: 'vscode-remote',
+    authority: STABLE_AUTHORITY,
+    path: `/volundr/sessions/${sessionId}/workspace`,
+  });
+
+  const currentFolderCount = vscode.workspace.workspaceFolders?.length ?? 0;
+  vscode.workspace.updateWorkspaceFolders(0, currentFolderCount, { uri: newFolderUri });
+
+  // 6. Restore previously saved tabs for the new session (if any).
+  await restoreTabState(sessionId, STABLE_AUTHORITY);
 }

--- a/web/src/test/__mocks__/vscode.ts
+++ b/web/src/test/__mocks__/vscode.ts
@@ -1,0 +1,32 @@
+/**
+ * Stub for the `vscode` module used in tests.
+ *
+ * The real `vscode` module is provided by the VS Code extension host at
+ * runtime. This file gives Vite a resolvable path so its import analysis
+ * doesn't fail. The actual mock behaviour is set up in setup.ts via
+ * vi.mock('vscode') — which takes precedence at test time.
+ */
+
+export const Uri = {
+  from: (c: Record<string, string>) => ({
+    scheme: c.scheme,
+    authority: c.authority,
+    path: c.path,
+  }),
+  parse: (v: string) => ({ scheme: '', authority: '', path: v }),
+};
+
+export const workspace = {
+  workspaceFolders: [] as unknown[],
+  updateWorkspaceFolders: () => true,
+  openTextDocument: async () => ({ uri: {} }),
+};
+
+export const window = {
+  tabGroups: { all: [], activeTabGroup: { activeTab: null } },
+  showTextDocument: async () => ({}),
+};
+
+export const commands = {
+  executeCommand: async () => undefined,
+};

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -2,10 +2,35 @@ import '@testing-library/jest-dom/vitest';
 import { cleanup } from '@testing-library/react';
 import { afterEach, vi } from 'vitest';
 
+// Mock the vscode module — it only exists at runtime inside the VS Code
+// extension host, and Vite cannot resolve it during tests.
+vi.mock('vscode', () => ({
+  Uri: {
+    from: (c: Record<string, string>) => ({
+      scheme: c.scheme,
+      authority: c.authority,
+      path: c.path,
+    }),
+  },
+  workspace: {
+    workspaceFolders: [],
+    updateWorkspaceFolders: vi.fn(),
+    openTextDocument: vi.fn().mockResolvedValue({ uri: {} }),
+  },
+  window: {
+    tabGroups: { all: [], activeTabGroup: { activeTab: null } },
+    showTextDocument: vi.fn().mockResolvedValue({}),
+  },
+  commands: {
+    executeCommand: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
 // Mock workbenchInit to prevent @codingame/monaco-vscode-* CSS imports
 // from breaking the test environment (Node.js can't handle .css files).
 vi.mock('@/components/EditorPanel/workbenchInit', () => ({
   initWorkbench: vi.fn().mockResolvedValue(undefined),
+  switchSession: vi.fn().mockResolvedValue(undefined),
 }));
 
 // Polyfill ResizeObserver for assistant-ui components that use it

--- a/web/src/types/monaco-vscode-api.d.ts
+++ b/web/src/types/monaco-vscode-api.d.ts
@@ -338,6 +338,86 @@ declare module '@codingame/monaco-vscode-api/workers/extensionHost.worker' {
   // Extension host worker entry point
 }
 
+declare module 'vscode' {
+  export class Uri {
+    static from(components: {
+      scheme: string;
+      authority?: string;
+      path?: string;
+      query?: string;
+      fragment?: string;
+    }): Uri;
+    static parse(value: string): Uri;
+    readonly scheme: string;
+    readonly authority: string;
+    readonly path: string;
+  }
+
+  export interface WorkspaceFolder {
+    readonly uri: Uri;
+    readonly name: string;
+    readonly index: number;
+  }
+
+  export namespace workspace {
+    export const workspaceFolders: readonly WorkspaceFolder[] | undefined;
+    export function updateWorkspaceFolders(
+      start: number,
+      deleteCount: number | undefined | null,
+      ...workspaceFoldersToAdd: { uri: Uri; name?: string }[]
+    ): boolean;
+    export function openTextDocument(uri: Uri): Thenable<TextDocument>;
+  }
+
+  export namespace commands {
+    export function executeCommand<T>(command: string, ...rest: unknown[]): Thenable<T>;
+  }
+
+  export interface TextDocument {
+    readonly uri: Uri;
+    readonly fileName: string;
+  }
+
+  export interface TextEditor {
+    readonly document: TextDocument;
+  }
+
+  export interface TabInputText {
+    readonly uri: Uri;
+  }
+
+  export interface Tab {
+    readonly label: string;
+    readonly input: TabInputText | unknown;
+    readonly isActive: boolean;
+  }
+
+  export interface TabGroup {
+    readonly isActive: boolean;
+    readonly activeTab: Tab | undefined;
+    readonly tabs: readonly Tab[];
+  }
+
+  export interface TabGroups {
+    readonly all: readonly TabGroup[];
+    readonly activeTabGroup: TabGroup;
+    close(tab: Tab | readonly Tab[]): Thenable<boolean>;
+  }
+
+  export interface ShowTextDocumentOptions {
+    preview?: boolean;
+    preserveFocus?: boolean;
+  }
+
+  export namespace window {
+    export const tabGroups: TabGroups;
+    export function showTextDocument(
+      document: TextDocument,
+      options?: ShowTextDocumentOptions
+    ): Thenable<TextEditor>;
+  }
+}
+
 declare module '@codingame/monaco-vscode-api/vscode/vs/base/common/uri' {
   export class URI {
     static from(components: {

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -34,6 +34,10 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+      // `vscode` is provided at runtime by the VS Code extension host.
+      // In tests it's mocked via vi.mock('vscode') in setup.ts, but Vite's
+      // import analysis still needs a resolvable path.
+      vscode: path.resolve(__dirname, './src/test/__mocks__/vscode.ts'),
     },
   },
 });


### PR DESCRIPTION
## Summary

- Replace the singleton VS Code editor initialization with a dynamic routing approach so switching between Volundr sessions no longer requires a page reload
- The workbench initializes once with a stable remote authority and a mutable WebSocket factory that routes to whichever session's REH server is active
- Open editor tabs are saved per-session and restored when returning to a previously visited session

## Details

**Problem**: `initialize()` from `@codingame/monaco-vscode-api` can only be called once per page load. When switching sessions, the editor was stuck pointing at the old REH server and required a full page reload.

**Solution**: Three new concepts work together:
- **`sessionRouter`** — mutable session routing state + WebSocket connection tracking. The WebSocket factory reads from this on every new connection, and `closeAllWebSockets()` forces VS Code to reconnect after a route change.
- **`tabStateManager`** — saves open editor tabs (relative paths + active state) per session. On switch, tabs are saved, all editors closed, and previously saved tabs for the target session are restored.
- **Stable `remoteAuthority`** — uses `window.location.host` (the gateway) so all sessions share one VS Code remote authority. Session routing happens entirely in the WebSocket factory via the session base path.

## Test plan

- [ ] Verify lint, typecheck, format, and test coverage pass in CI
- [ ] Open session A, open some files in the editor
- [ ] Switch to session B — editor should reconnect without page reload
- [ ] Open different files in session B
- [ ] Switch back to session A — tabs from session A should restore
- [ ] Verify the file explorer shows the correct workspace for each session

🤖 Generated with [Claude Code](https://claude.com/claude-code)