### PR TITLE
ci: add dev branch workflow with prerelease tagging (#68)

### DIFF
--- a/.claude/rules/branching.md
+++ b/.claude/rules/branching.md
@@ -1,0 +1,23 @@
+# Branching & PR Rules
+
+## Default PR Target
+
+- **All PRs target `dev`** unless the user explicitly says to target `main`
+- When pushing branches or creating PRs, always use `dev` as the base branch
+- Only target `main` when the user explicitly requests a production release merge
+
+## Branch Flow
+
+```
+feature-branch ──► dev (integration) ──► main (production releases)
+```
+
+- `dev` is the long-lived integration branch for testing and dev releases
+- `main` is for production releases only
+- Feature branches are created from and merged into `dev`
+
+## Dev Tags
+
+- Pushes to `dev` automatically create `v*-dev.N` prerelease tags
+- These trigger container builds, Helm chart packaging, and CLI builds — but NOT GitHub Releases
+- Dev tags are ignored by the production release pipeline

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 permissions: read-all
 

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -1,0 +1,299 @@
+# Runs on every push to dev:
+# 1. Builds all container images with "dev" + "dev-<sha>" tags
+# 2. Determines next version from conventional commits and creates a v*-dev.N prerelease tag
+# 3. Packages Helm charts with the dev version
+# 4. Builds CLI binaries (uploaded as artifacts, no GitHub Release)
+#
+# The dev prerelease tags (v*-dev.N) are skipped by release.yaml so they
+# never create a production GitHub Release.
+name: Dev
+
+on:
+  push:
+    branches: [dev]
+
+permissions: read-all
+
+env:
+  REGISTRY: ghcr.io
+  CHART_REPO: oci://ghcr.io/${{ github.repository_owner }}/charts
+
+concurrency:
+  group: dev-${{ github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Containers — build per platform natively, then merge manifests
+  # ---------------------------------------------------------------------------
+  build-container-image:
+    name: "Build ${{ matrix.container }} (${{ matrix.platform }})"
+    runs-on: ${{ matrix.platform == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        platform: [amd64, arm64]
+        container: [volundr, skuld, skuld-codex, devrunner, volundr-web, vscode-reh]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        with:
+          context: .
+          file: ./containers/${{ matrix.container }}/Dockerfile
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.container }}:${{ github.sha }}-${{ matrix.platform }}
+          labels: |
+            org.opencontainers.image.title=${{ matrix.container }}
+            org.opencontainers.image.licenses=Apache-2.0
+            org.opencontainers.image.vendor=Niuu Labs
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+          cache-from: type=gha,scope=${{ matrix.container }}-${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.container }}-${{ matrix.platform }}
+          platforms: linux/${{ matrix.platform }}
+          provenance: false
+
+  merge-container-manifests:
+    name: "Manifest ${{ matrix.container }}"
+    needs: build-container-image
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    strategy:
+      matrix:
+        container: [volundr, skuld, skuld-codex, devrunner, volundr-web, vscode-reh]
+    steps:
+      - name: Log in to Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push manifests
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.container }}"
+          SHA="${{ github.sha }}"
+          SHORT_SHA="${SHA:0:7}"
+
+          # dev tag (mutable, always points to latest dev build)
+          docker manifest create "${IMAGE}:dev" \
+            "${IMAGE}:${SHA}-amd64" \
+            "${IMAGE}:${SHA}-arm64"
+          docker manifest push "${IMAGE}:dev"
+
+          # dev + short sha (immutable, for pinning)
+          docker manifest create "${IMAGE}:dev-${SHORT_SHA}" \
+            "${IMAGE}:${SHA}-amd64" \
+            "${IMAGE}:${SHA}-arm64"
+          docker manifest push "${IMAGE}:dev-${SHORT_SHA}"
+
+  # ---------------------------------------------------------------------------
+  # Version tagging — prerelease dev tags
+  # ---------------------------------------------------------------------------
+  tag:
+    name: Determine Version & Tag
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.new_version }}
+      should_release: ${{ steps.version.outputs.should_release }}
+    permissions:
+      contents: write
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Determine version bump
+        id: version
+        run: |
+          # Get the last production (non-prerelease) tag
+          LAST_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname \
+            | grep -v '-' | head -1 || echo "v0.0.0")
+          LAST_VERSION=${LAST_TAG#v}
+
+          # Get all commit messages since last production tag
+          if [ "$LAST_TAG" = "v0.0.0" ]; then
+            COMMIT_MSGS=$(git log --pretty=%B HEAD)
+          else
+            COMMIT_MSGS=$(git log --pretty=%B ${LAST_TAG}..HEAD)
+          fi
+
+          echo "Last production version: $LAST_VERSION"
+
+          # Determine version bump type from conventional commits
+          VERSION_TYPE="none"
+          if echo "$COMMIT_MSGS" | grep -qiE "^feat(\(.+\))?!:|^BREAKING CHANGE:"; then
+            VERSION_TYPE="major"
+          elif echo "$COMMIT_MSGS" | grep -qiE "^(feat|refactor)(\(.+\))?:"; then
+            VERSION_TYPE="minor"
+          elif echo "$COMMIT_MSGS" | grep -qiE "^(fix|style)(\(.+\))?:"; then
+            VERSION_TYPE="patch"
+          fi
+
+          echo "Version bump type: $VERSION_TYPE"
+
+          if [ "$VERSION_TYPE" = "none" ]; then
+            echo "should_release=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Calculate next version
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$LAST_VERSION"
+          case $VERSION_TYPE in
+            major) NEW_BASE="$((MAJOR + 1)).0.0" ;;
+            minor) NEW_BASE="${MAJOR}.$((MINOR + 1)).0" ;;
+            patch) NEW_BASE="${MAJOR}.${MINOR}.$((PATCH + 1))" ;;
+          esac
+
+          # Count existing dev tags for this base version to determine N
+          DEV_COUNT=$(git tag -l "v${NEW_BASE}-dev.*" | wc -l | tr -d ' ')
+          DEV_N=$((DEV_COUNT + 1))
+          NEW_VERSION="${NEW_BASE}-dev.${DEV_N}"
+
+          echo "New dev version: $NEW_VERSION"
+          echo "should_release=true" >> $GITHUB_OUTPUT
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create and push tag
+        if: steps.version.outputs.should_release == 'true'
+        run: |
+          VERSION="${{ steps.version.outputs.new_version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "v${VERSION}" -m "Dev release v${VERSION}"
+          git push origin "v${VERSION}"
+
+  # ---------------------------------------------------------------------------
+  # Helm charts — dev versions
+  # ---------------------------------------------------------------------------
+  build-charts:
+    name: Build Helm Charts
+    needs: [tag]
+    if: needs.tag.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
+        with:
+          version: v3.14.0
+
+      - name: Update chart versions
+        run: |
+          VERSION="${{ needs.tag.outputs.version }}"
+
+          sed -i "s/^version:.*/version: $VERSION/" charts/skuld/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: \"$VERSION\"/" charts/skuld/Chart.yaml
+
+          sed -i "s/^version:.*/version: $VERSION/" charts/volundr/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: \"$VERSION\"/" charts/volundr/Chart.yaml
+
+          cat charts/skuld/Chart.yaml
+          cat charts/volundr/Chart.yaml
+
+      - name: Package Helm charts
+        run: |
+          helm package charts/skuld -d .helm-packages/
+          helm package charts/volundr -d .helm-packages/
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push Helm charts to OCI registry
+        run: |
+          helm push .helm-packages/skuld-*.tgz ${{ env.CHART_REPO }}
+          helm push .helm-packages/volundr-*.tgz ${{ env.CHART_REPO }}
+
+  # ---------------------------------------------------------------------------
+  # CLI binaries — build only, no GitHub Release
+  # ---------------------------------------------------------------------------
+  build-cli:
+    name: Build CLI (${{ matrix.goos }}/${{ matrix.goarch }})
+    needs: [tag]
+    if: needs.tag.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        include:
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
+        with:
+          go-version-file: cli/go.mod
+          cache-dependency-path: cli/go.sum
+
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Build frontend
+        run: |
+          cd web && npm ci --ignore-scripts && npm run build
+          cd ..
+          rm -rf cli/internal/web/dist
+          cp -r web/dist cli/internal/web/dist
+
+      - name: Build CLI
+        working-directory: cli
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: "0"
+        run: |
+          VERSION="${{ needs.tag.outputs.version }}"
+          BINARY="volundr-${{ matrix.goos }}-${{ matrix.goarch }}"
+          go build -tags embed_web \
+            -ldflags "-s -w -X github.com/niuulabs/volundr/cli/internal/cli.Version=${VERSION}" \
+            -o "dist/${BINARY}" ./cmd/volundr
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: volundr-dev-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: cli/dist/volundr-${{ matrix.goos }}-${{ matrix.goarch }}
+          retention-days: 14

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    tags: ["v*"]
+    tags: ["v[0-9]+.[0-9]+.[0-9]+"]  # stable semver only, skip prerelease (v*-dev.*)
 
 permissions: read-all
 


### PR DESCRIPTION
Introduces a long-lived `dev` integration branch strategy:
- New dev.yaml workflow builds containers, Helm charts, and CLI on push to dev
- Auto-creates v*-dev.N prerelease tags from conventional commits
- CI now runs on PRs to both main and dev
- Release workflow filter updated to skip prerelease tags
- Added branching rule so Claude defaults PRs to dev
