### PR TITLE
Release v0.69.0

### DIFF
--- a/.claude/hooks/setup-precommit.sh
+++ b/.claude/hooks/setup-precommit.sh
@@ -1,21 +1,53 @@
 #!/bin/bash
-# Setup pre-commit hooks if not already installed
-# This runs at the start of each Claude session
+# Setup pre-commit hooks and required tooling.
+# This runs at the start of each Claude session.
 
 set -e
 
 cd "$CLAUDE_PROJECT_DIR"
 
-# Check if pre-commit is installed
-if ! command -v pre-commit &> /dev/null; then
+# Use python -m pre_commit to avoid PATH issues with pip-installed binaries
+_pre_commit() {
+    python -m pre_commit "$@"
+}
+
+# ── Tool installation ─────────────────────────────────────────────
+
+# pre-commit framework
+if ! python -c "import pre_commit" &> /dev/null; then
     echo "Installing pre-commit..."
     pip install pre-commit==4.5.1 --quiet
 fi
 
-# Check if hooks are installed in the repo
+# ruff (Python linter + formatter)
+if ! command -v ruff &> /dev/null; then
+    echo "Installing ruff..."
+    pip install ruff --quiet
+fi
+
+# golangci-lint (Go linter)
+if ! command -v golangci-lint &> /dev/null; then
+    echo "Installing golangci-lint..."
+    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+fi
+
+# trufflehog (secret scanner)
+if ! command -v trufflehog &> /dev/null; then
+    echo "Installing trufflehog..."
+    go install github.com/trufflesecurity/trufflehog/v3@latest
+fi
+
+# web dependencies (prettier, eslint)
+if [ -d "web" ] && [ ! -d "web/node_modules" ]; then
+    echo "Installing web dependencies..."
+    (cd web && npm ci --ignore-scripts --quiet)
+fi
+
+# ── Hook installation ─────────────────────────────────────────────
+
 if [ ! -f ".git/hooks/pre-commit" ] || ! grep -q "pre-commit" ".git/hooks/pre-commit" 2>/dev/null; then
     echo "Installing pre-commit hooks..."
-    pre-commit install --install-hooks
+    _pre_commit install --install-hooks
     echo "Pre-commit hooks installed successfully"
 else
     echo "Pre-commit hooks already installed"

--- a/.claude/hooks/setup-precommit.sh
+++ b/.claude/hooks/setup-precommit.sh
@@ -6,6 +6,14 @@ set -e
 
 cd "$CLAUDE_PROJECT_DIR"
 
+# ── PATH setup ───────────────────────────────────────────────────
+# Ensure GOPATH/bin is in PATH so `go install` binaries are found
+# by pre-commit hooks (which run via bash -c with a clean PATH).
+GOBIN="${GOPATH:-$HOME/go}/bin"
+if [[ ":$PATH:" != *":$GOBIN:"* ]]; then
+    export PATH="$GOBIN:$PATH"
+fi
+
 # Use python -m pre_commit to avoid PATH issues with pip-installed binaries
 _pre_commit() {
     python -m pre_commit "$@"
@@ -31,10 +39,12 @@ if ! command -v golangci-lint &> /dev/null; then
     go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 fi
 
-# trufflehog (secret scanner)
+# trufflehog (secret scanner) — installed via release binary because
+# go install fails due to replace directives in trufflehog's go.mod.
 if ! command -v trufflehog &> /dev/null; then
     echo "Installing trufflehog..."
-    go install github.com/trufflesecurity/trufflehog/v3@latest
+    curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh \
+        | sh -s -- -b "$GOBIN"
 fi
 
 # web dependencies (prettier, eslint)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -485,7 +485,7 @@ jobs:
           severity: CRITICAL,HIGH
 
       - name: Upload Trivy results
-        uses: github/codeql-action/upload-sarif@c6f931105cb2c34c8f901cc885ba1e2e259cf745 # v4
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4
         if: always() && hashFiles(format('trivy-{0}.sarif', matrix.container)) != ''
         with:
           sarif_file: trivy-${{ matrix.container }}.sarif

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -288,14 +288,14 @@ jobs:
           CGO_ENABLED: "0"
         run: |
           VERSION="${{ needs.tag.outputs.version }}"
-          BINARY="volundr-${{ matrix.goos }}-${{ matrix.goarch }}"
+          BINARY="niuu-${{ matrix.goos }}-${{ matrix.goarch }}"
           go build -tags embed_web \
             -ldflags "-s -w -X github.com/niuulabs/volundr/cli/internal/cli.Version=${VERSION}" \
-            -o "dist/${BINARY}" ./cmd/volundr
+            -o "dist/${BINARY}" ./cmd/niuu
 
       - name: Upload artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
-          name: volundr-dev-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: cli/dist/volundr-${{ matrix.goos }}-${{ matrix.goarch }}
+          name: niuu-dev-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: cli/dist/niuu-${{ matrix.goos }}-${{ matrix.goarch }}
           retention-days: 14

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -175,7 +175,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate SBOM
-        uses: anchore/sbom-action@57aae528053a48a3f6235f2d9461b05fbcb7366d # v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
           image: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.container }}:${{ needs.version.outputs.version }}
           artifact-name: sbom-${{ matrix.container }}.spdx.json
@@ -190,7 +190,7 @@ jobs:
           severity: CRITICAL,HIGH
 
       - name: Upload Trivy results
-        uses: github/codeql-action/upload-sarif@c6f931105cb2c34c8f901cc885ba1e2e259cf745 # v4
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4
         if: always() && hashFiles(format('trivy-{0}.sarif', matrix.container)) != ''
         with:
           sarif_file: trivy-${{ matrix.container }}.sarif

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -248,16 +248,16 @@ jobs:
           CGO_ENABLED: "0"
         run: |
           VERSION="${{ needs.version.outputs.version }}"
-          BINARY="volundr-${{ matrix.goos }}-${{ matrix.goarch }}"
+          BINARY="niuu-${{ matrix.goos }}-${{ matrix.goarch }}"
           go build -tags embed_web \
             -ldflags "-s -w -X github.com/niuulabs/volundr/cli/internal/cli.Version=${VERSION}" \
-            -o "dist/${BINARY}" ./cmd/volundr
+            -o "dist/${BINARY}" ./cmd/niuu
 
       - name: Upload artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
-          name: volundr-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: cli/dist/volundr-${{ matrix.goos }}-${{ matrix.goarch }}
+          name: niuu-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: cli/dist/niuu-${{ matrix.goos }}-${{ matrix.goarch }}
 
   # ---------------------------------------------------------------------------
   # Helm charts
@@ -370,23 +370,23 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: cli-binaries
-          pattern: volundr-*
+          pattern: niuu-*
 
       - name: Prepare release assets
         run: |
           mkdir -p release-assets
-          for dir in cli-binaries/volundr-*/; do
+          for dir in cli-binaries/niuu-*/; do
             binary=$(basename "$dir")
             cp "${dir}${binary}" "release-assets/${binary}"
             chmod +x "release-assets/${binary}"
           done
-          cd release-assets && sha256sum volundr-* > checksums.txt
+          cd release-assets && sha256sum niuu-* > checksums.txt
           ls -lh
 
       - name: Attest build provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
-          subject-path: release-assets/volundr-*
+          subject-path: release-assets/niuu-*
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
@@ -395,5 +395,5 @@ jobs:
           name: Release v${{ needs.version.outputs.version }}
           generate_release_notes: true
           files: |
-            release-assets/volundr-*
+            release-assets/niuu-*
             release-assets/checksums.txt

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -28,6 +28,6 @@ jobs:
           publish_results: true
 
       - name: Upload Scorecard results
-        uses: github/codeql-action/upload-sarif@c6f931105cb2c34c8f901cc885ba1e2e259cf745 # v4
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4
         with:
           sarif_file: scorecard-results.sarif

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,57 @@ repos:
         language: system
         pass_filenames: false
         stages: [pre-commit]
+
+      # ── Python ──────────────────────────────────────────────
+      - id: ruff-check
+        name: Ruff lint
+        entry: ruff check --fix
+        language: system
+        types: [python]
+        stages: [pre-commit]
+
+      - id: ruff-format
+        name: Ruff format
+        entry: ruff format
+        language: system
+        types: [python]
+        stages: [pre-commit]
+
+      # ── Go ──────────────────────────────────────────────────
+      - id: go-fmt
+        name: Go format
+        entry: gofmt -l -w
+        language: system
+        types: [go]
+        stages: [pre-commit]
+
+      - id: go-vet
+        name: Go vet
+        entry: bash -c 'cd cli && go vet ./...'
+        language: system
+        pass_filenames: false
+        files: ^cli/.*\.go$
+        stages: [pre-commit]
+
+      - id: golangci-lint
+        name: golangci-lint
+        entry: bash -c 'cd cli && golangci-lint run ./...'
+        language: system
+        pass_filenames: false
+        files: ^cli/.*\.go$
+        stages: [pre-commit]
+
+      # ── Web (TypeScript / CSS) ──────────────────────────────
+      - id: prettier
+        name: Prettier format
+        entry: npx prettier --write
+        language: system
+        files: ^web/src/.*\.(ts|tsx|css)$
+        stages: [pre-commit]
+
+      - id: eslint
+        name: ESLint
+        entry: bash -c 'cd web && npx eslint --fix "$@"' --
+        language: system
+        files: ^web/src/.*\.(ts|tsx)$
+        stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     hooks:
       - id: trufflehog
         name: TruffleHog secret scan
-        entry: bash -c 'trufflehog git file://. --since-commit HEAD --only-verified --fail'
+        entry: bash -c 'export PATH="${GOPATH:-$HOME/go}/bin:$PATH"; trufflehog git file://. --since-commit HEAD --only-verified --fail'
         language: system
         pass_filenames: false
         stages: [pre-commit]
@@ -41,7 +41,7 @@ repos:
 
       - id: golangci-lint
         name: golangci-lint
-        entry: bash -c 'cd cli && golangci-lint run ./...'
+        entry: bash -c 'export PATH="${GOPATH:-$HOME/go}/bin:$PATH"; cd cli && golangci-lint run ./...'
         language: system
         pass_filenames: false
         files: ^cli/.*\.go$

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -1,4 +1,4 @@
-BINARY := volundr
+BINARY := niuu
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 LDFLAGS := -ldflags "-s -w -X github.com/niuulabs/volundr/cli/internal/cli.Version=$(VERSION)"
 WEB_DIR := ../web
@@ -12,19 +12,19 @@ BUILD_TAGS := embed_web,embed_migrations
 
 # build compiles the CLI with the embedded frontend and migrations for the current platform.
 build: web migrations
-	go build -tags $(BUILD_TAGS) $(LDFLAGS) -o bin/$(BINARY) ./cmd/volundr
+	go build -tags $(BUILD_TAGS) $(LDFLAGS) -o bin/$(BINARY) ./cmd/niuu
 
 # build-dev compiles without the frontend or embedded migrations (placeholder page, filesystem migrations).
 build-dev:
-	go build $(LDFLAGS) -o bin/$(BINARY) ./cmd/volundr
+	go build $(LDFLAGS) -o bin/$(BINARY) ./cmd/niuu
 
 # build-all cross-compiles for all supported platforms with embedded frontend and migrations.
 build-all: web migrations
 	@mkdir -p $(DIST_DIR)
-	GOOS=darwin  GOARCH=amd64 go build -tags $(BUILD_TAGS) $(LDFLAGS) -o $(DIST_DIR)/$(BINARY)-darwin-amd64   ./cmd/volundr
-	GOOS=darwin  GOARCH=arm64 go build -tags $(BUILD_TAGS) $(LDFLAGS) -o $(DIST_DIR)/$(BINARY)-darwin-arm64   ./cmd/volundr
-	GOOS=linux   GOARCH=amd64 go build -tags $(BUILD_TAGS) $(LDFLAGS) -o $(DIST_DIR)/$(BINARY)-linux-amd64    ./cmd/volundr
-	GOOS=linux   GOARCH=arm64 go build -tags $(BUILD_TAGS) $(LDFLAGS) -o $(DIST_DIR)/$(BINARY)-linux-arm64    ./cmd/volundr
+	GOOS=darwin  GOARCH=amd64 go build -tags $(BUILD_TAGS) $(LDFLAGS) -o $(DIST_DIR)/$(BINARY)-darwin-amd64   ./cmd/niuu
+	GOOS=darwin  GOARCH=arm64 go build -tags $(BUILD_TAGS) $(LDFLAGS) -o $(DIST_DIR)/$(BINARY)-darwin-arm64   ./cmd/niuu
+	GOOS=linux   GOARCH=amd64 go build -tags $(BUILD_TAGS) $(LDFLAGS) -o $(DIST_DIR)/$(BINARY)-linux-amd64    ./cmd/niuu
+	GOOS=linux   GOARCH=arm64 go build -tags $(BUILD_TAGS) $(LDFLAGS) -o $(DIST_DIR)/$(BINARY)-linux-arm64    ./cmd/niuu
 	@echo "Built binaries:"
 	@ls -lh $(DIST_DIR)/
 

--- a/cli/cmd/niuu/main.go
+++ b/cli/cmd/niuu/main.go
@@ -1,4 +1,4 @@
-// Package main is the entry point for the volundr CLI binary.
+// Package main is the entry point for the niuu CLI binary.
 package main
 
 import (

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/charmbracelet/glamour v1.0.0
 	github.com/charmbracelet/x/vt v0.0.0-20260309091332-e8ca31595cc4
-	github.com/fergusstrange/embedded-postgres v1.33.0
+	github.com/fergusstrange/embedded-postgres v1.34.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/lib/pq v1.12.0
 	github.com/spf13/cobra v1.10.2

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/charmbracelet/x/vt v0.0.0-20260309091332-e8ca31595cc4
 	github.com/fergusstrange/embedded-postgres v1.33.0
 	github.com/gorilla/websocket v1.5.3
-	github.com/lib/pq v1.11.2
+	github.com/lib/pq v1.12.0
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/crypto v0.49.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -62,8 +62,8 @@ github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSo
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
-github.com/lib/pq v1.11.2 h1:x6gxUeu39V0BHZiugWe8LXZYZ+Utk7hSJGThs8sdzfs=
-github.com/lib/pq v1.11.2/go.mod h1:/p+8NSbOcwzAEI7wiMXFlgydTwcgTr3OSKMsD2BitpA=
+github.com/lib/pq v1.12.0 h1:mC1zeiNamwKBecjHarAr26c/+d8V5w/u4J0I/yASbJo=
+github.com/lib/pq v1.12.0/go.mod h1:/p+8NSbOcwzAEI7wiMXFlgydTwcgTr3OSKMsD2BitpA=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -51,8 +51,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/fergusstrange/embedded-postgres v1.33.0 h1:ka8vmRpm4IDsES7NPXQ/NThAp1fc/f+crcXYjCW7wK0=
-github.com/fergusstrange/embedded-postgres v1.33.0/go.mod h1:w0YvnCgf19o6tskInrOOACtnqfVlOvluz3hlNLY7tRk=
+github.com/fergusstrange/embedded-postgres v1.34.0 h1:c6RKhPKFsLVU+Tdxsx8q0UxCHsvZZ/iShAnljRBXs6s=
+github.com/fergusstrange/embedded-postgres v1.34.0/go.mod h1:w0YvnCgf19o6tskInrOOACtnqfVlOvluz3hlNLY7tRk=
 github.com/gorilla/css v1.0.1 h1:ntNaBIghp6JmvWnxbZKANoLyuXTPZ4cAMlo6RyhlbO8=
 github.com/gorilla/css v1.0.1/go.mod h1:BvnYkspnSzMmwRK+b8/xgNPLiIuNZr6vbZBTPQ2A3b0=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=

--- a/cli/internal/cli/config_remote.go
+++ b/cli/internal/cli/config_remote.go
@@ -16,7 +16,7 @@ func init() {
 var configCmd = &cobra.Command{
 	Use:   "config",
 	Short: "Manage CLI configuration",
-	Long: `Manage CLI configuration stored in ~/.config/volundr/config.yaml.
+	Long: `Manage CLI configuration stored in ~/.config/niuu/config.yaml.
 
 Global keys: theme
 Context keys (require --context): server, token, issuer, client-id`,

--- a/cli/internal/cli/context.go
+++ b/cli/internal/cli/context.go
@@ -37,7 +37,7 @@ func init() {
 var contextCmd = &cobra.Command{
 	Use:   "context",
 	Short: "Manage cluster contexts",
-	Long:  "Add, list, remove, and rename Volundr cluster contexts.",
+	Long:  "Add, list, remove, and rename cluster contexts.",
 }
 
 var contextAddCmd = &cobra.Command{
@@ -46,8 +46,8 @@ var contextAddCmd = &cobra.Command{
 	Long: `Add a new cluster context with the given key and server URL.
 
 Example:
-  volundr context add prod --server https://volundr.prod.example.com --name "Production"
-  volundr context add local --server http://127.0.0.1:8080`,
+  niuu context add prod --server https://volundr.prod.example.com --name "Production"
+  niuu context add local --server http://127.0.0.1:8080`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(_ *cobra.Command, args []string) error {
 		cfg, err := remote.Load()
@@ -99,7 +99,7 @@ var contextListCmd = &cobra.Command{
 		}
 
 		if len(cfg.Contexts) == 0 {
-			fmt.Println("No contexts configured. Add one with: volundr context add <name> --server <url>")
+			fmt.Println("No contexts configured. Add one with: niuu context add <name> --server <url>")
 			return nil
 		}
 

--- a/cli/internal/cli/context_test.go
+++ b/cli/internal/cli/context_test.go
@@ -18,9 +18,11 @@ func setupTestConfig(t *testing.T, cfg *remote.Config) {
 	t.Helper()
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
+	t.Setenv("NIUU_HOME", "")
+	t.Setenv("VOLUNDR_HOME", "")
 
 	if cfg != nil {
-		configDir := filepath.Join(tmpDir, ".config", "volundr")
+		configDir := filepath.Join(tmpDir, ".config", "niuu")
 		if err := os.MkdirAll(configDir, 0o750); err != nil { //nolint:gosec // test directory
 			t.Fatalf("mkdir: %v", err)
 		}

--- a/cli/internal/cli/init.go
+++ b/cli/internal/cli/init.go
@@ -21,7 +21,7 @@ var initRuntimeFlag string
 var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "First-time setup wizard",
-	Long:  `Runs the interactive setup wizard, creating ~/.volundr/ with config and credentials.`,
+	Long:  `Runs the interactive setup wizard, creating ~/.niuu/ with config and credentials.`,
 	RunE:  runInit,
 }
 
@@ -253,7 +253,7 @@ func runInit(_ *cobra.Command, _ []string) error {
 	}
 
 	fmt.Println()
-	fmt.Println("Run 'volundr up' to start.")
+	fmt.Println("Run 'niuu volundr up' to start.")
 
 	return nil
 }
@@ -318,6 +318,20 @@ func installInstructionsForOS(tool, goos, goarch string) string {
 // machinePassphrase generates a deterministic passphrase from machine identity.
 // In production this would use a more robust machine fingerprint.
 func machinePassphrase() string {
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "niuu-default"
+	}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		homeDir = "/tmp"
+	}
+	return fmt.Sprintf("niuu-%s-%s", hostname, homeDir)
+}
+
+// legacyMachinePassphrase returns the old "volundr-" prefixed passphrase
+// used before the niuu rename. Used as a fallback when loading credentials.
+func legacyMachinePassphrase() string {
 	hostname, err := os.Hostname()
 	if err != nil {
 		hostname = "volundr-default"

--- a/cli/internal/cli/init_test.go
+++ b/cli/internal/cli/init_test.go
@@ -107,8 +107,26 @@ func TestMachinePassphrase(t *testing.T) {
 		t.Errorf("expected deterministic passphrase, got %q and %q", passphrase, passphrase2)
 	}
 
+	// Should start with "niuu-"
+	if len(passphrase) < 5 || passphrase[:5] != "niuu-" {
+		t.Errorf("expected passphrase to start with 'niuu-', got %q", passphrase)
+	}
+}
+
+func TestLegacyMachinePassphrase(t *testing.T) {
+	passphrase := legacyMachinePassphrase()
+	if passphrase == "" {
+		t.Error("expected non-empty passphrase")
+	}
+
 	// Should start with "volundr-"
 	if len(passphrase) < 8 || passphrase[:8] != "volundr-" {
-		t.Errorf("expected passphrase to start with 'volundr-', got %q", passphrase)
+		t.Errorf("expected legacy passphrase to start with 'volundr-', got %q", passphrase)
+	}
+
+	// New and legacy should differ.
+	newPassphrase := machinePassphrase()
+	if passphrase == newPassphrase {
+		t.Error("expected legacy and new passphrases to differ")
 	}
 }

--- a/cli/internal/cli/login.go
+++ b/cli/internal/cli/login.go
@@ -317,9 +317,9 @@ func resolveAuthConfig(rctx *remote.Context) (issuer, clientID string, err error
 	if issuer == "" || clientID == "" {
 		return "", "", fmt.Errorf("could not determine auth configuration\n\n" +
 			"Either configure a server and let it be discovered automatically:\n" +
-			"  volundr context add <name> --server <url>\n\n" +
+			"  niuu context add <name> --server <url>\n\n" +
 			"Or provide flags explicitly:\n" +
-			"  volundr login --issuer <url> --client-id <id>")
+			"  niuu login --issuer <url> --client-id <id>")
 	}
 
 	return issuer, clientID, nil

--- a/cli/internal/cli/root.go
+++ b/cli/internal/cli/root.go
@@ -1,4 +1,4 @@
-// Package cli implements the cobra CLI commands for volundr.
+// Package cli implements the cobra CLI commands for niuu.
 package cli
 
 import (
@@ -20,22 +20,27 @@ var (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "volundr",
-	Short: "Volundr — The Coding Forge",
-	Long: `Volundr is a self-hosted remote development platform.
+	Use:   "niuu",
+	Short: "niuu — The Development Platform",
+	Long: `niuu is the unified CLI for the Niuu development platform.
 
-In local mode it orchestrates the entire Volundr stack (embedded PostgreSQL,
-Python API, reverse proxy) as a single binary.
+It provides access to all platform tools through namespaced subcommands:
 
-In remote mode it provides both a rich terminal UI (TUI) for interactive use
-and direct commands for scripting and automation.
+  niuu volundr ...   Manage the Volundr development stack
+  niuu tyr ...       Tyr saga coordinator (coming soon)
+
+Shared commands (auth, config, context) are top-level:
+
+  niuu login         Authenticate with OIDC
+  niuu context ...   Manage cluster contexts
+  niuu config ...    Manage CLI configuration
 
 Run without arguments to launch the full TUI, or use subcommands
 for specific operations.`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	PersistentPreRun: func(_ *cobra.Command, _ []string) {
-		// --home flag takes precedence over VOLUNDR_HOME env var.
+		// --home flag takes precedence over NIUU_HOME / VOLUNDR_HOME env var.
 		if homeFlag != "" {
 			_ = os.Setenv(config.EnvHome, homeFlag)
 		}
@@ -48,27 +53,24 @@ for specific operations.`,
 
 func init() {
 	// Local runtime flags.
-	rootCmd.PersistentFlags().StringVar(&homeFlag, "home", "", "config directory (default ~/.volundr, env VOLUNDR_HOME)")
+	rootCmd.PersistentFlags().StringVar(&homeFlag, "home", "", "config directory (default ~/.niuu, env NIUU_HOME)")
 
 	// Remote/TUI flags.
-	rootCmd.PersistentFlags().StringVar(&cfgServer, "server", "", "Volundr API server URL (default: from config)")
+	rootCmd.PersistentFlags().StringVar(&cfgServer, "server", "", "API server URL (default: from config)")
 	rootCmd.PersistentFlags().StringVar(&cfgToken, "token", "", "Authentication token (default: from config)")
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "Config file path (default: ~/.config/volundr/config.yaml)")
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "Config file path (default: ~/.config/niuu/config.yaml)")
 	rootCmd.PersistentFlags().StringVar(&cfgContext, "context", "", "Context name to use (default: auto-select if only one exists)")
 
 	// Output flags.
 	rootCmd.PersistentFlags().BoolVar(&jsonOutput, "json", false, "Output results as JSON for piping to jq")
 
-	// Existing local commands.
-	rootCmd.AddCommand(initCmd)
-	rootCmd.AddCommand(upCmd)
-	rootCmd.AddCommand(downCmd)
-	rootCmd.AddCommand(statusCmd)
-	rootCmd.AddCommand(versionCmd)
+	// Tool namespaces.
+	rootCmd.AddCommand(volundrCmd)
+	rootCmd.AddCommand(tyrCmd)
 
-	// Remote/TUI commands.
+	// Shared top-level commands.
+	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(tuiCmd)
-	rootCmd.AddCommand(sessionsCmd)
 	rootCmd.AddCommand(configCmd)
 	rootCmd.AddCommand(loginCmd)
 	rootCmd.AddCommand(logoutCmd)

--- a/cli/internal/cli/root_test.go
+++ b/cli/internal/cli/root_test.go
@@ -10,19 +10,17 @@ func TestRootCmd_HasSubcommands(t *testing.T) {
 		t.Fatal("expected root command to have subcommands")
 	}
 
+	// Top-level commands under niuu.
 	expected := map[string]bool{
-		"init":     false,
-		"up":       false,
-		"down":     false,
-		"status":   false,
-		"version":  false,
-		"tui":      false,
-		"sessions": false,
-		"config":   false,
-		"login":    false,
-		"logout":   false,
-		"whoami":   false,
-		"context":  false,
+		"volundr": false,
+		"tyr":     false,
+		"version": false,
+		"tui":     false,
+		"config":  false,
+		"login":   false,
+		"logout":  false,
+		"whoami":  false,
+		"context": false,
 	}
 
 	for _, cmd := range subcmds {
@@ -34,6 +32,29 @@ func TestRootCmd_HasSubcommands(t *testing.T) {
 	for name, found := range expected {
 		if !found {
 			t.Errorf("expected subcommand %q not found", name)
+		}
+	}
+}
+
+func TestVolundrCmd_HasSubcommands(t *testing.T) {
+	subcmds := volundrCmd.Commands()
+	expected := map[string]bool{
+		"init":     false,
+		"up":       false,
+		"down":     false,
+		"status":   false,
+		"sessions": false,
+	}
+
+	for _, cmd := range subcmds {
+		if _, ok := expected[cmd.Name()]; ok {
+			expected[cmd.Name()] = true
+		}
+	}
+
+	for name, found := range expected {
+		if !found {
+			t.Errorf("expected volundr subcommand %q not found", name)
 		}
 	}
 }
@@ -178,5 +199,20 @@ func TestConfigCmd_HasSubcommands(t *testing.T) {
 		if !found {
 			t.Errorf("expected config subcommand %q not found", name)
 		}
+	}
+}
+
+func TestTyrCmd_Properties(t *testing.T) {
+	if tyrCmd.Use != "tyr" {
+		t.Errorf("expected Use %q, got %q", "tyr", tyrCmd.Use)
+	}
+	if tyrCmd.Short == "" {
+		t.Error("expected non-empty Short description")
+	}
+}
+
+func TestRootCmd_UseName(t *testing.T) {
+	if rootCmd.Use != "niuu" {
+		t.Errorf("expected root command Use %q, got %q", "niuu", rootCmd.Use)
 	}
 }

--- a/cli/internal/cli/tui.go
+++ b/cli/internal/cli/tui.go
@@ -22,7 +22,7 @@ import (
 var tuiCmd = &cobra.Command{
 	Use:   "tui",
 	Short: "Launch the interactive TUI",
-	Long:  "Launch the full-screen terminal user interface for Volundr.",
+	Long:  "Launch the full-screen terminal user interface.",
 	RunE: func(_ *cobra.Command, _ []string) error {
 		return runTUI()
 	},
@@ -670,7 +670,7 @@ func (m tuiModel) View() tea.View { //nolint:gocritic // tea.Model interface req
 		v.Content = lipgloss.NewStyle().
 			Foreground(theme.AccentAmber).
 			Bold(true).
-			Render("\n  Loading Volundr...")
+			Render("\n  Loading niuu...")
 		return v
 	}
 
@@ -733,8 +733,8 @@ func appendCmd(cmds []tea.Cmd, cmd tea.Cmd) []tea.Cmd {
 	return cmds
 }
 
-// debugTUI enables TUI message logging. Set VOLUNDR_TUI_DEBUG=1 to enable.
-var debugTUI = os.Getenv("VOLUNDR_TUI_DEBUG") == "1"
+// debugTUI enables TUI message logging. Set NIUU_TUI_DEBUG=1 to enable.
+var debugTUI = os.Getenv("NIUU_TUI_DEBUG") == "1" || os.Getenv("VOLUNDR_TUI_DEBUG") == "1"
 
 func debugLogMsg(msg tea.Msg) {
 	// Skip high-frequency noise.
@@ -742,7 +742,7 @@ func debugLogMsg(msg tea.Msg) {
 		return
 	}
 
-	f, err := os.OpenFile("/tmp/volundr-tui-debug.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600) //nolint:gosec // debug log in /tmp, not sensitive
+	f, err := os.OpenFile("/tmp/niuu-tui-debug.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600) //nolint:gosec // debug log in /tmp, not sensitive
 	if err != nil {
 		return
 	}

--- a/cli/internal/cli/tyr.go
+++ b/cli/internal/cli/tyr.go
@@ -1,0 +1,21 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var tyrCmd = &cobra.Command{
+	Use:   "tyr",
+	Short: "Tyr saga coordinator (coming soon)",
+	Long: `Tyr is a standalone saga coordinator that autonomously orchestrates
+coding work by decomposing project specs into phases and raids.
+
+This namespace is reserved for future Tyr commands.`,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		fmt.Println("Tyr commands are coming soon.")
+		fmt.Println("See https://github.com/niuulabs/volundr for updates.")
+		return nil
+	},
+}

--- a/cli/internal/cli/up.go
+++ b/cli/internal/cli/up.go
@@ -29,7 +29,7 @@ func init() {
 func runUp(_ *cobra.Command, _ []string) error {
 	cfg, err := config.Load()
 	if err != nil {
-		return fmt.Errorf("load config (run 'volundr init' first): %w", err)
+		return fmt.Errorf("load config (run 'niuu volundr init' first): %w", err)
 	}
 
 	if runtimeFlag != "" {
@@ -41,8 +41,17 @@ func runUp(_ *cobra.Command, _ []string) error {
 	}
 
 	// Load credentials and inject API key into config if available.
+	// Try the current passphrase first, then fall back to the legacy one.
 	machineKey := machinePassphrase()
 	creds, err := config.LoadCredentials(machineKey)
+	if err != nil {
+		legacyKey := legacyMachinePassphrase()
+		creds, err = config.LoadCredentials(legacyKey)
+		if err == nil {
+			fmt.Println("Warning: credentials were encrypted with the legacy passphrase.")
+			fmt.Println("Run 'niuu volundr init' to re-encrypt with the new key.")
+		}
+	}
 	if err == nil && creds.AnthropicAPIKey != "" && cfg.Anthropic.APIKey == "" {
 		cfg.Anthropic.APIKey = creds.AnthropicAPIKey
 	}

--- a/cli/internal/cli/version.go
+++ b/cli/internal/cli/version.go
@@ -49,9 +49,9 @@ var versionCmd = &cobra.Command{
 			Italic(true)
 
 		fmt.Println(hammerStyle.Render(tuipkg.HammerLogo))
-		fmt.Println(titleStyle.Render("  Volundr — The Coding Forge"))
+		fmt.Println(titleStyle.Render("  niuu — The Development Platform"))
 		fmt.Println(versionStyle.Render(fmt.Sprintf("  Version: %s", version)))
-		fmt.Println(taglineStyle.Render("  \"Skilled craftsman of the gods\""))
+		fmt.Println(taglineStyle.Render("  \"Tools of the gods\""))
 		fmt.Println()
 		fmt.Printf("  commit:  %s\n", commit)
 		fmt.Printf("  built:   %s\n", date)

--- a/cli/internal/cli/volundr.go
+++ b/cli/internal/cli/volundr.go
@@ -1,0 +1,22 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var volundrCmd = &cobra.Command{
+	Use:   "volundr",
+	Short: "Manage the Volundr development stack",
+	Long: `Volundr stack lifecycle commands.
+
+Use these subcommands to initialize, start, stop, and manage your
+self-hosted Volundr development environment and coding sessions.`,
+}
+
+func init() {
+	volundrCmd.AddCommand(initCmd)
+	volundrCmd.AddCommand(upCmd)
+	volundrCmd.AddCommand(downCmd)
+	volundrCmd.AddCommand(statusCmd)
+	volundrCmd.AddCommand(sessionsCmd)
+}

--- a/cli/internal/cli/whoami.go
+++ b/cli/internal/cli/whoami.go
@@ -27,11 +27,11 @@ var whoamiCmd = &cobra.Command{
 		}
 
 		if ctx.Token == "" {
-			return fmt.Errorf("not logged in on context %q — run: volundr login --context %s", ctxKey, ctxKey)
+			return fmt.Errorf("not logged in on context %q — run: niuu login --context %s", ctxKey, ctxKey)
 		}
 
 		if ctx.Issuer == "" {
-			return fmt.Errorf("no issuer configured on context %q — run: volundr login --context %s --issuer <url>", ctxKey, ctxKey)
+			return fmt.Errorf("no issuer configured on context %q — run: niuu login --context %s --issuer <url>", ctxKey, ctxKey)
 		}
 
 		client := auth.NewOIDCClient(ctx.Issuer)

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -1,4 +1,4 @@
-// Package config manages the ~/.volundr/config.yaml configuration file.
+// Package config manages the ~/.niuu/config.yaml configuration file.
 package config
 
 import (
@@ -13,9 +13,13 @@ import (
 
 const (
 	// EnvHome is the environment variable that overrides the config directory.
-	EnvHome = "VOLUNDR_HOME"
-	// DefaultConfigDir is the default directory for volundr configuration.
-	DefaultConfigDir = ".volundr"
+	EnvHome = "NIUU_HOME"
+	// LegacyEnvHome is the deprecated environment variable (checked as fallback).
+	LegacyEnvHome = "VOLUNDR_HOME"
+	// DefaultConfigDir is the default directory for niuu configuration.
+	DefaultConfigDir = ".niuu"
+	// LegacyConfigDir is the deprecated directory (checked as fallback).
+	LegacyConfigDir = ".volundr"
 	// DefaultConfigFile is the default config file name.
 	DefaultConfigFile = "config.yaml"
 	// DefaultDBPort is the default port for embedded PostgreSQL.
@@ -117,17 +121,34 @@ type AnthropicConfig struct {
 	APIKey string `yaml:"api_key"`
 }
 
-// ConfigDir returns the path to the volundr config directory.
-// It checks VOLUNDR_HOME first, falling back to ~/.volundr.
+// ConfigDir returns the path to the niuu config directory.
+// It checks NIUU_HOME, then VOLUNDR_HOME (legacy), then ~/.niuu,
+// falling back to ~/.volundr if the new directory doesn't exist yet.
 func ConfigDir() (string, error) { //nolint:revive // used as config.ConfigDir externally
 	if dir := os.Getenv(EnvHome); dir != "" {
+		return dir, nil
+	}
+	if dir := os.Getenv(LegacyEnvHome); dir != "" {
 		return dir, nil
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("get home directory: %w", err)
 	}
-	return filepath.Join(home, DefaultConfigDir), nil
+
+	newDir := filepath.Join(home, DefaultConfigDir)
+	if _, err := os.Stat(newDir); err == nil {
+		return newDir, nil
+	}
+
+	// Fall back to legacy path if it exists.
+	legacyDir := filepath.Join(home, LegacyConfigDir)
+	if _, err := os.Stat(legacyDir); err == nil {
+		return legacyDir, nil
+	}
+
+	// Neither exists — use the new path (will be created on first write).
+	return newDir, nil
 }
 
 // ConfigPath returns the path to the config file.

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -226,9 +226,24 @@ func TestGeneratePassword(t *testing.T) {
 }
 
 func TestConfigDir(t *testing.T) {
-	t.Run("uses VOLUNDR_HOME when set", func(t *testing.T) {
+	t.Run("uses NIUU_HOME when set", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		t.Setenv(EnvHome, tmpDir)
+		t.Setenv(LegacyEnvHome, "")
+
+		dir, err := ConfigDir()
+		if err != nil {
+			t.Fatalf("ConfigDir() error: %v", err)
+		}
+		if dir != tmpDir {
+			t.Errorf("ConfigDir() = %q, want %q", dir, tmpDir)
+		}
+	})
+
+	t.Run("falls back to VOLUNDR_HOME", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv(EnvHome, "")
+		t.Setenv(LegacyEnvHome, tmpDir)
 
 		dir, err := ConfigDir()
 		if err != nil {
@@ -241,6 +256,7 @@ func TestConfigDir(t *testing.T) {
 
 	t.Run("falls back to home directory", func(t *testing.T) {
 		t.Setenv(EnvHome, "")
+		t.Setenv(LegacyEnvHome, "")
 
 		dir, err := ConfigDir()
 		if err != nil {
@@ -376,9 +392,10 @@ func TestValidateDBPortOutOfRange(t *testing.T) {
 	}
 }
 
-func TestDefaultConfigWithVOLUNDR_HOME(t *testing.T) {
+func TestDefaultConfigWithNIUU_HOME(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv(EnvHome, tmpDir)
+	t.Setenv(LegacyEnvHome, "")
 
 	cfg, err := DefaultConfig()
 	if err != nil {
@@ -404,6 +421,7 @@ func TestDefaultConfigWithVOLUNDR_HOME(t *testing.T) {
 
 func TestConfigDirErrorWhenNoHome(t *testing.T) {
 	t.Setenv(EnvHome, "")
+	t.Setenv(LegacyEnvHome, "")
 	t.Setenv("HOME", "")
 
 	_, err := ConfigDir()
@@ -414,6 +432,7 @@ func TestConfigDirErrorWhenNoHome(t *testing.T) {
 
 func TestConfigPathErrorWhenNoHome(t *testing.T) {
 	t.Setenv(EnvHome, "")
+	t.Setenv(LegacyEnvHome, "")
 	t.Setenv("HOME", "")
 
 	_, err := ConfigPath()
@@ -424,6 +443,7 @@ func TestConfigPathErrorWhenNoHome(t *testing.T) {
 
 func TestDefaultConfigErrorWhenNoHome(t *testing.T) {
 	t.Setenv(EnvHome, "")
+	t.Setenv(LegacyEnvHome, "")
 	t.Setenv("HOME", "")
 
 	_, err := DefaultConfig()
@@ -434,6 +454,7 @@ func TestDefaultConfigErrorWhenNoHome(t *testing.T) {
 
 func TestLoadErrorWhenNoHome(t *testing.T) {
 	t.Setenv(EnvHome, "")
+	t.Setenv(LegacyEnvHome, "")
 	t.Setenv("HOME", "")
 
 	_, err := Load()
@@ -444,6 +465,7 @@ func TestLoadErrorWhenNoHome(t *testing.T) {
 
 func TestSaveErrorWhenNoHome(t *testing.T) {
 	t.Setenv(EnvHome, "")
+	t.Setenv(LegacyEnvHome, "")
 	t.Setenv("HOME", "")
 
 	cfg := &Config{Runtime: "local"}
@@ -454,6 +476,7 @@ func TestSaveErrorWhenNoHome(t *testing.T) {
 
 func TestExistsErrorWhenNoHome(t *testing.T) {
 	t.Setenv(EnvHome, "")
+	t.Setenv(LegacyEnvHome, "")
 	t.Setenv("HOME", "")
 
 	_, err := Exists()

--- a/cli/internal/remote/config.go
+++ b/cli/internal/remote/config.go
@@ -1,5 +1,5 @@
-// Package remote manages CLI configuration for the Volundr remote client.
-// Configuration is stored in $VOLUNDR_HOME/remotes.yaml (or ~/.config/volundr/config.yaml as fallback).
+// Package remote manages CLI configuration for the niuu remote client.
+// Configuration is stored in $NIUU_HOME/remotes.yaml (or ~/.config/niuu/config.yaml as fallback).
 package remote
 
 import (
@@ -12,12 +12,16 @@ import (
 
 const (
 	// Environment variable that overrides the config directory.
-	envHome = "VOLUNDR_HOME"
-	// Config file name within VOLUNDR_HOME.
+	envHome = "NIUU_HOME"
+	// Legacy environment variable (checked as fallback).
+	envHomeLegacy = "VOLUNDR_HOME"
+	// Config file name within NIUU_HOME.
 	remotesFile = "remotes.yaml"
-	// Fallback directory when VOLUNDR_HOME is not set.
+	// Default directory when NIUU_HOME is not set.
+	defaultDir = ".config/niuu"
+	// Legacy directory (checked as fallback).
 	legacyDir = ".config/volundr"
-	// Config file name in the legacy directory.
+	// Config file name in the config directory.
 	legacyFile = "config.yaml"
 )
 
@@ -47,30 +51,61 @@ func DefaultConfig() *Config {
 }
 
 // ConfigDir returns the configuration directory path.
-// It checks VOLUNDR_HOME first, falling back to ~/.config/volundr.
+// It checks NIUU_HOME, then VOLUNDR_HOME (legacy), then ~/.config/niuu,
+// falling back to ~/.config/volundr if the new directory doesn't exist yet.
 func ConfigDir() (string, error) {
 	if dir := os.Getenv(envHome); dir != "" {
+		return dir, nil
+	}
+	if dir := os.Getenv(envHomeLegacy); dir != "" {
 		return dir, nil
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("cannot determine home directory: %w", err)
 	}
-	return filepath.Join(home, legacyDir), nil
+
+	newDir := filepath.Join(home, defaultDir)
+	if _, err := os.Stat(newDir); err == nil {
+		return newDir, nil
+	}
+
+	// Fall back to legacy path if it exists.
+	legacy := filepath.Join(home, legacyDir)
+	if _, err := os.Stat(legacy); err == nil {
+		return legacy, nil
+	}
+
+	// Neither exists — use the new path.
+	return newDir, nil
 }
 
 // ConfigPath returns the full path to the config file.
-// When VOLUNDR_HOME is set, uses $VOLUNDR_HOME/remotes.yaml.
-// Otherwise falls back to ~/.config/volundr/config.yaml.
+// When NIUU_HOME is set, uses $NIUU_HOME/remotes.yaml.
+// Otherwise falls back to ~/.config/niuu/config.yaml (or legacy ~/.config/volundr/config.yaml).
 func ConfigPath() (string, error) {
 	if dir := os.Getenv(envHome); dir != "" {
+		return filepath.Join(dir, remotesFile), nil
+	}
+	if dir := os.Getenv(envHomeLegacy); dir != "" {
 		return filepath.Join(dir, remotesFile), nil
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("cannot determine home directory: %w", err)
 	}
-	return filepath.Join(home, legacyDir, legacyFile), nil
+
+	newDir := filepath.Join(home, defaultDir)
+	if _, err := os.Stat(newDir); err == nil {
+		return filepath.Join(newDir, legacyFile), nil
+	}
+
+	legacy := filepath.Join(home, legacyDir)
+	if _, err := os.Stat(legacy); err == nil {
+		return filepath.Join(legacy, legacyFile), nil
+	}
+
+	return filepath.Join(newDir, legacyFile), nil
 }
 
 // legacyConfig represents the old flat config format for migration purposes.
@@ -245,7 +280,7 @@ func (c *Config) ResolveContext(key string) (*Context, string, error) {
 	}
 
 	if len(c.Contexts) == 0 {
-		return nil, "", fmt.Errorf("no contexts configured — run: volundr context add <name> --server <url>")
+		return nil, "", fmt.Errorf("no contexts configured — run: niuu context add <name> --server <url>")
 	}
 
 	if len(c.Contexts) == 1 {

--- a/cli/internal/remote/config_test.go
+++ b/cli/internal/remote/config_test.go
@@ -526,15 +526,38 @@ func TestConfigDir(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 	t.Setenv(envHome, "")
+	t.Setenv(envHomeLegacy, "")
 
 	dir, err := ConfigDir()
 	if err != nil {
 		t.Fatalf("config dir: %v", err)
 	}
 
-	expected := filepath.Join(tmpDir, ".config", "volundr")
+	expected := filepath.Join(tmpDir, ".config", "niuu")
 	if dir != expected {
 		t.Errorf("expected %q, got %q", expected, dir)
+	}
+}
+
+func TestConfigDir_LegacyFallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv(envHome, "")
+	t.Setenv(envHomeLegacy, "")
+
+	// Create the legacy directory so it's picked up as fallback.
+	legacyPath := filepath.Join(tmpDir, ".config", "volundr")
+	if err := os.MkdirAll(legacyPath, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	dir, err := ConfigDir()
+	if err != nil {
+		t.Fatalf("config dir: %v", err)
+	}
+
+	if dir != legacyPath {
+		t.Errorf("expected legacy fallback %q, got %q", legacyPath, dir)
 	}
 }
 
@@ -542,13 +565,14 @@ func TestConfigPath(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 	t.Setenv(envHome, "")
+	t.Setenv(envHomeLegacy, "")
 
 	path, err := ConfigPath()
 	if err != nil {
 		t.Fatalf("config path: %v", err)
 	}
 
-	expected := filepath.Join(tmpDir, ".config", "volundr", "config.yaml")
+	expected := filepath.Join(tmpDir, ".config", "niuu", "config.yaml")
 	if path != expected {
 		t.Errorf("expected %q, got %q", expected, path)
 	}

--- a/cli/internal/runtime/docker_test.go
+++ b/cli/internal/runtime/docker_test.go
@@ -541,7 +541,7 @@ func TestDockerRuntime_Status_NoDocker(t *testing.T) {
 	// Ensure docker command can't be found.
 	t.Setenv("PATH", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -575,7 +575,7 @@ func TestDockerRuntime_Status_WithStateFile(t *testing.T) {
 	t.Setenv("HOME", tmpDir)
 	t.Setenv("PATH", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -626,7 +626,7 @@ func TestDockerRuntime_Down_NoComposeFile(t *testing.T) {
 	t.Setenv("HOME", tmpDir)
 	t.Setenv("PATH", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -648,7 +648,7 @@ func TestDockerRuntime_Down_WithComposeFile(t *testing.T) {
 	t.Setenv("HOME", tmpDir)
 	t.Setenv("PATH", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -732,7 +732,7 @@ func TestDockerRuntime_Status_ContainerRunning(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -770,7 +770,7 @@ func TestDockerRuntime_Status_WithStateFileMerge(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -816,7 +816,7 @@ func TestDockerRuntime_Status_CorruptStateFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -877,7 +877,7 @@ func TestDockerRuntime_Down_SuccessWithMock(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -981,7 +981,7 @@ func TestDockerRuntime_Down_NetworkNotFound(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1001,7 +1001,7 @@ func TestDockerRuntime_Up_ExternalDB(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1060,7 +1060,7 @@ func TestDockerRuntime_Up_AlreadyRunning(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1087,7 +1087,7 @@ func TestDockerRuntime_Up_ComposeUpFail(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1128,7 +1128,7 @@ func TestDockerRuntime_Up_NetworkFail(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1273,7 +1273,7 @@ func TestDockerRuntime_Up_EmbeddedDB(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1329,7 +1329,7 @@ func TestDockerRuntime_Up_EmbeddedDB_StartFail(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1356,7 +1356,7 @@ func TestDockerRuntime_Up_EmbeddedDB_MigrationFail(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1396,7 +1396,7 @@ func TestDockerRuntime_Down_WithPostgres(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1416,7 +1416,7 @@ func TestDockerRuntime_Down_WithPostgresStopFail(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}

--- a/cli/internal/runtime/k3s_test.go
+++ b/cli/internal/runtime/k3s_test.go
@@ -274,7 +274,7 @@ func TestK3sWriteStateFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -329,7 +329,7 @@ func TestK3sRuntime_Status_NoPIDFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -361,7 +361,7 @@ func TestK3sRuntime_Status_PIDFileNoStateFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -394,7 +394,7 @@ func TestK3sRuntime_Status_WithStateFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -441,7 +441,7 @@ func TestK3sRuntime_Status_CorruptStateFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -474,7 +474,7 @@ func TestK3sRuntime_WriteStateFile_ExternalDB(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -529,7 +529,7 @@ func TestHostKubeconfigPath(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -718,7 +718,7 @@ func TestK3sRuntime_Logs_HostService(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	logsDir := filepath.Join(volundrDir, "logs")
 	if err := os.MkdirAll(logsDir, 0o700); err != nil {
 		t.Fatalf("create logs dir: %v", err)
@@ -762,7 +762,7 @@ func TestK3sRuntime_Logs_HostServiceMissing(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -779,7 +779,7 @@ func TestK3sRuntime_Down_Cleanup(t *testing.T) {
 	t.Setenv("HOME", tmpDir)
 	t.Setenv("PATH", tmpDir) // ensure kubectl/docker not found
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -821,7 +821,7 @@ func TestK3sRuntime_WriteK3dKubeconfig(t *testing.T) {
 	t.Setenv("HOME", tmpDir)
 	t.Setenv("PATH", tmpDir) // ensure k3d not found
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -873,7 +873,7 @@ func TestK3sRuntime_WriteK3dKubeconfig_0000(t *testing.T) {
 	t.Setenv("HOME", tmpDir)
 	t.Setenv("PATH", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -912,7 +912,7 @@ func TestK3sRuntime_WriteK3dKubeconfig_Localhost(t *testing.T) {
 	t.Setenv("HOME", tmpDir)
 	t.Setenv("PATH", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -950,7 +950,7 @@ func TestK3sRuntime_WriteK3dKubeconfig_NoHostKC(t *testing.T) {
 	t.Setenv("HOME", tmpDir)
 	t.Setenv("PATH", tmpDir) // no k3d available
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1028,7 +1028,7 @@ func TestK3sRuntime_EnsureNamespace_Exists(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1046,7 +1046,7 @@ func TestK3sRuntime_EnsureClusterRunning_K3d(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1072,7 +1072,7 @@ func TestK3sRuntime_EnsureClusterRunning_Native(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1094,7 +1094,7 @@ func TestK3sRuntime_EnsureClusterRunning_NoProvider(t *testing.T) {
 	t.Setenv("HOME", tmpDir)
 	t.Setenv("PATH", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1115,7 +1115,7 @@ func TestK3sRuntime_Logs_KubeService(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1140,7 +1140,7 @@ func TestK3sRuntime_Logs_KubeServiceFollow(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1159,7 +1159,7 @@ func TestK3sRuntime_Down_WithMock(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1201,7 +1201,7 @@ func TestK3sRuntime_EnsureK8sSecrets_WithTokens(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1229,7 +1229,7 @@ func TestK3sRuntime_EnsureK8sSecrets_FallbackToken(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1258,7 +1258,7 @@ func TestK3sRuntime_EnsureK8sSecrets_NoSecrets(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1278,7 +1278,7 @@ func TestK3sRuntime_WriteHostKubeconfig(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1301,7 +1301,7 @@ func TestK3sRuntime_StartAPIContainer(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1345,7 +1345,7 @@ func TestK3sRuntime_QueryK8sPodStates_Success(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1372,7 +1372,7 @@ func TestK3sRuntime_QueryK8sPodStates_Failure(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1578,7 +1578,7 @@ func TestOfferInstallK3dDarwin_BrewAvailable_UserAccepts(t *testing.T) {
 		t.Fatalf("create config dir: %v", err)
 	}
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1710,7 +1710,7 @@ func TestOfferInstallNativeK3s_AcceptSuccess(t *testing.T) {
 	t.Setenv("HOME", tmpDir)
 	t.Setenv("KUBECONFIG", filepath.Join(tmpDir, "nonexistent"))
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1774,7 +1774,7 @@ func TestEnsureNamespace_NeedCreate(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1794,7 +1794,7 @@ func TestEnsureNamespace_CreateFailAlreadyExists(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1867,7 +1867,7 @@ func TestInitNativeK3s_Success(t *testing.T) {
 	t.Setenv("HOME", tmpDir)
 	t.Setenv("KUBECONFIG", filepath.Join(tmpDir, "nonexistent"))
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1890,7 +1890,7 @@ func TestInitNativeK3s_ClusterNotReachable(t *testing.T) {
 	t.Setenv("HOME", tmpDir)
 	t.Setenv("KUBECONFIG", filepath.Join(tmpDir, "nonexistent"))
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1918,7 +1918,7 @@ func TestK3sRuntime_Init_K3dProvider(t *testing.T) {
 		t.Fatalf("create config dir: %v", err)
 	}
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1951,7 +1951,7 @@ func TestWriteHostKubeconfig_Fail(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1969,7 +1969,7 @@ func TestStartAPIContainer_Fail(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -2000,7 +2000,7 @@ func TestOfferInstallK3dLinux_AcceptSuccess(t *testing.T) {
 		t.Fatalf("create config dir: %v", err)
 	}
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -2055,7 +2055,7 @@ func TestK3sRuntime_Init_NoProvider(t *testing.T) {
 		t.Fatalf("create config dir: %v", err)
 	}
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -2083,7 +2083,7 @@ func TestK3sRuntime_Init_NativeProvider(t *testing.T) {
 		t.Fatalf("create config dir: %v", err)
 	}
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -2112,7 +2112,7 @@ func TestK3sRuntime_Init_HelmNotFound(t *testing.T) {
 		t.Fatalf("create config dir: %v", err)
 	}
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -2148,7 +2148,7 @@ func TestInitK3d_ClusterListFail(t *testing.T) {
 	// Let's use MOCK_COMMANDS for selective responses.
 	withMockExec(t, `MOCK_COMMANDS=k3d version:::1.0.0|||cluster list:::|||cluster create:::ok|||kubeconfig get:::apiVersion: v1`)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -2199,7 +2199,7 @@ func TestEnsureClusterRunning_K3dListFail(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -2223,7 +2223,7 @@ func TestEnsureClusterRunning_NativeFail(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -2247,7 +2247,7 @@ func TestEnsureK8sSecrets_UpsertFail(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -2269,7 +2269,7 @@ func TestK3sRuntime_Up_AlreadyRunning(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -2305,7 +2305,7 @@ func TestK3sRuntime_Up_ExternalDB(t *testing.T) {
 		t.Fatalf("create config dir: %v", err)
 	}
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -2360,7 +2360,7 @@ func TestK3sRuntime_Up_ClusterFail(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -2387,7 +2387,7 @@ func TestEnsureClusterRunning_K3dClusterNotFound(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -2412,7 +2412,7 @@ func TestK3sRuntime_Up_EmbeddedDB(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -2464,7 +2464,7 @@ func TestK3sRuntime_Up_EmbeddedDB_StartFail(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -2491,7 +2491,7 @@ func TestK3sRuntime_Up_EmbeddedDB_MigrationFail(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -2606,7 +2606,7 @@ func TestK3sRuntime_Down_WithPostgres(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -2626,7 +2626,7 @@ func TestK3sRuntime_Down_WithPostgresStopFail(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}

--- a/cli/internal/runtime/local_test.go
+++ b/cli/internal/runtime/local_test.go
@@ -33,7 +33,7 @@ func TestLocalRuntime_Status_NoPIDFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -65,7 +65,7 @@ func TestLocalRuntime_Status_PIDFileNoStateFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -99,7 +99,7 @@ func TestLocalRuntime_Status_WithStateFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -147,7 +147,7 @@ func TestLocalRuntime_Status_CorruptStateFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -183,7 +183,7 @@ func TestLocalRuntime_Logs(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	logsDir := filepath.Join(volundrDir, "logs")
 	if err := os.MkdirAll(logsDir, 0o700); err != nil {
 		t.Fatalf("create logs dir: %v", err)
@@ -213,7 +213,7 @@ func TestLocalRuntime_Logs_MissingFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -229,7 +229,7 @@ func TestLocalRuntime_WriteStateFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -282,7 +282,7 @@ func TestLocalRuntime_WriteStateFile_ExternalDB(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -323,7 +323,7 @@ func TestLocalRuntime_Down_NoProcess(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -406,7 +406,7 @@ func TestStatusFromStateFile_NoPIDFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -433,7 +433,7 @@ func TestStatusFromStateFile_StalePID(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -462,7 +462,7 @@ func TestStatusFromStateFile_RunningWithStateFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -501,7 +501,7 @@ func TestStatusFromStateFile_RunningNoStateFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -535,7 +535,7 @@ func TestStatusFromStateFile_CorruptStateFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -574,7 +574,7 @@ func TestStatusFromStateFile_InvalidPID(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -610,7 +610,7 @@ func TestDownFromPID_NoPIDFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -629,7 +629,7 @@ func TestDownFromPID_InvalidPID(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -653,7 +653,7 @@ func TestDownFromPID_StalePID(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -701,7 +701,7 @@ func TestLocalRuntime_Init_CreatesDirs(t *testing.T) {
 		t.Fatalf("Init: %v", err)
 	}
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	for _, sub := range []string{"data/pg", "logs", "cache"} {
 		dir := filepath.Join(volundrDir, sub)
 		if _, err := os.Stat(dir); err != nil {
@@ -714,7 +714,7 @@ func TestLocalRuntime_Down_NoApiNoPostgres(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -746,7 +746,7 @@ func TestLocalRuntime_StartAPI(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	logsDir := filepath.Join(volundrDir, "logs")
 	if err := os.MkdirAll(logsDir, 0o700); err != nil {
 		t.Fatalf("create logs dir: %v", err)
@@ -784,7 +784,7 @@ func TestLocalRuntime_StartAPI_NoLogsDir(t *testing.T) {
 	t.Setenv("HOME", tmpDir)
 
 	// Create config dir but NOT logs dir.
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -811,7 +811,7 @@ func TestLocalRuntime_WriteStateFile_WithAPICmd(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	logsDir := filepath.Join(volundrDir, "logs")
 	if err := os.MkdirAll(logsDir, 0o700); err != nil {
 		t.Fatalf("create logs dir: %v", err)
@@ -866,7 +866,7 @@ func TestDownFromPID_ReadError(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -896,7 +896,7 @@ func TestLocalRuntime_Down_WithApiCmd(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	logsDir := filepath.Join(volundrDir, "logs")
 	if err := os.MkdirAll(logsDir, 0o700); err != nil {
 		t.Fatalf("create logs dir: %v", err)
@@ -948,7 +948,7 @@ func TestLocalRuntime_Up_AlreadyRunning(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -972,7 +972,7 @@ func TestLocalRuntime_Up_ExternalDB(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	logsDir := filepath.Join(volundrDir, "logs")
 	if err := os.MkdirAll(logsDir, 0o700); err != nil {
 		t.Fatalf("create logs dir: %v", err)
@@ -1035,7 +1035,7 @@ func TestLocalRuntime_Init_ExternalDB(t *testing.T) {
 	}
 
 	// Verify directories were created.
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	for _, sub := range []string{"data/pg", "logs", "cache"} {
 		dir := filepath.Join(volundrDir, sub)
 		if _, err := os.Stat(dir); err != nil {
@@ -1048,7 +1048,7 @@ func TestDownFromPID_SuccessPath(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1143,7 +1143,7 @@ func TestLocalRuntime_Up_EmbeddedDB(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	logsDir := filepath.Join(volundrDir, "logs")
 	if err := os.MkdirAll(logsDir, 0o700); err != nil {
 		t.Fatalf("create logs dir: %v", err)
@@ -1207,7 +1207,7 @@ func TestLocalRuntime_Up_EmbeddedDB_StartFail(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1234,7 +1234,7 @@ func TestLocalRuntime_Up_EmbeddedDB_MigrationFail(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1274,7 +1274,7 @@ func TestLocalRuntime_Down_WithPostgres(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1292,7 +1292,7 @@ func TestLocalRuntime_Down_WithPostgresStopFail(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1314,7 +1314,7 @@ func TestLocalRuntime_Up_StartAPIFail(t *testing.T) {
 	t.Setenv("HOME", tmpDir)
 
 	// Create config dir but NOT logs dir, so startAPI fails.
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -1419,7 +1419,7 @@ func TestDownFromPID_SuccessWithRunningProcess(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}

--- a/cli/internal/runtime/state_test.go
+++ b/cli/internal/runtime/state_test.go
@@ -14,7 +14,7 @@ func TestCheckNotRunning_NoPIDFile(t *testing.T) {
 	t.Setenv("HOME", tmpDir)
 
 	// Ensure the .volundr dir exists but has no PID file.
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -29,7 +29,7 @@ func TestCheckNotRunning_StalePIDFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -55,7 +55,7 @@ func TestCheckNotRunning_InvalidPIDFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestCheckNotRunning_RunningProcess(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -118,7 +118,7 @@ func TestWritePIDFile_RemovePIDFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -159,7 +159,7 @@ func TestWriteStateFile_ReadBack(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -203,7 +203,7 @@ func TestRemoveStateFile_NoFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -219,7 +219,7 @@ func TestRemovePIDFile_NoFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}
@@ -234,7 +234,7 @@ func TestRemoveStateFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	volundrDir := filepath.Join(tmpDir, ".volundr")
+	volundrDir := filepath.Join(tmpDir, ".niuu")
 	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
 		t.Fatalf("create config dir: %v", err)
 	}

--- a/containers/devrunner/Dockerfile
+++ b/containers/devrunner/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14-slim@sha256:35f442c69294267a391b05d9526b6a330986ad9b008152a2e24257a1f98a8dc0
+FROM python:3.14-slim@sha256:fb83750094b46fd6b8adaa80f66e2302ecbe45d513f6cece637a841e1025b4ca
 
 LABEL org.opencontainers.image.title="devrunner"
 LABEL org.opencontainers.image.description="Devrunner — sandboxed development runtime"

--- a/containers/skuld-codex/Dockerfile
+++ b/containers/skuld-codex/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04@sha256:9d6e6f7d762bf55c4a2f17694dc43d3eefae8452ee70e067d5aa4ddd922fc462
+FROM ubuntu:24.04@sha256:186072bba1b2f436cbb91ef2567abca677337cfc786c86e107d25b7072feef0c
 
 LABEL org.opencontainers.image.title="skuld-codex"
 LABEL org.opencontainers.image.description="Skuld Codex — remote AI coding session broker (OpenAI Codex)"

--- a/containers/skuld/Dockerfile
+++ b/containers/skuld/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04@sha256:9d6e6f7d762bf55c4a2f17694dc43d3eefae8452ee70e067d5aa4ddd922fc462
+FROM ubuntu:24.04@sha256:186072bba1b2f436cbb91ef2567abca677337cfc786c86e107d25b7072feef0c
 
 LABEL org.opencontainers.image.title="skuld"
 LABEL org.opencontainers.image.description="Skuld — remote AI coding session broker (Claude Code)"

--- a/containers/volundr/Dockerfile
+++ b/containers/volundr/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04@sha256:9d6e6f7d762bf55c4a2f17694dc43d3eefae8452ee70e067d5aa4ddd922fc462
+FROM ubuntu:24.04@sha256:186072bba1b2f436cbb91ef2567abca677337cfc786c86e107d25b7072feef0c
 
 LABEL org.opencontainers.image.title="volundr"
 LABEL org.opencontainers.image.description="Volundr — self-hosted AI-native development platform"

--- a/src/volundr/adapters/inbound/rest.py
+++ b/src/volundr/adapters/inbound/rest.py
@@ -778,14 +778,16 @@ class WorkspaceResponse(BaseModel):
 
     @classmethod
     def from_workspace(cls, ws, session=None) -> "WorkspaceResponse":
-        source_url = None
-        source_ref = None
-        session_name = None
+        # Prefer workspace-stored metadata; fall back to session lookup.
+        session_name = ws.name
+        source_url = ws.source_url
+        source_ref = ws.source_ref
         if session is not None:
-            session_name = session.name
-            if hasattr(session.source, "repo"):
+            if not session_name:
+                session_name = session.name
+            if not source_url and hasattr(session.source, "repo"):
                 source_url = session.source.repo
-            if hasattr(session.source, "branch"):
+            if not source_ref and hasattr(session.source, "branch"):
                 source_ref = session.source.branch
         return cls(
             id=ws.id,

--- a/src/volundr/adapters/outbound/contributors/storage.py
+++ b/src/volundr/adapters/outbound/contributors/storage.py
@@ -105,10 +105,19 @@ class StorageContributor(SessionContributor):
             return (None, workspace_pvc)
 
         async def _create_workspace() -> str | None:
+            source_url = None
+            source_ref = None
+            if hasattr(session.source, "repo"):
+                source_url = session.source.repo
+            if hasattr(session.source, "branch"):
+                source_ref = session.source.branch
             ws_ref = await self._storage.create_session_workspace(
                 str(session.id),
                 session.owner_id or "",
                 session.tenant_id or "",
+                name=session.name,
+                source_url=source_url,
+                source_ref=source_ref,
             )
             return ws_ref.name if ws_ref else None
 

--- a/src/volundr/adapters/outbound/k8s_storage.py
+++ b/src/volundr/adapters/outbound/k8s_storage.py
@@ -24,6 +24,9 @@ class _WorkspaceEntry:
     status: WorkspaceStatus = WorkspaceStatus.ACTIVE
     uid: UUID = field(default_factory=uuid4)
     created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    name: str | None = None
+    source_url: str | None = None
+    source_ref: str | None = None
 
 
 class InMemoryStorageAdapter(StoragePort):
@@ -76,16 +79,22 @@ class InMemoryStorageAdapter(StoragePort):
         user_id: str = "",
         tenant_id: str = "",
         workspace_gb: int | None = None,
+        name: str | None = None,
+        source_url: str | None = None,
+        source_ref: str | None = None,
     ) -> PVCRef:
         """Create a workspace PVC for a session."""
         size = workspace_gb if workspace_gb is not None else self._workspace_size_gb
-        name = f"volundr-session-{session_id}-workspace"
-        ref = PVCRef(name=name)
+        pvc_name = f"volundr-session-{session_id}-workspace"
+        ref = PVCRef(name=pvc_name)
         self._session_workspaces[session_id] = _WorkspaceEntry(
             pvc_ref=ref,
             user_id=user_id,
             tenant_id=tenant_id,
             size_gb=size,
+            name=name,
+            source_url=source_url,
+            source_ref=source_ref,
         )
         return ref
 
@@ -138,6 +147,9 @@ class InMemoryStorageAdapter(StoragePort):
             status=entry.status,
             size_gb=entry.size_gb,
             created_at=entry.created_at,
+            name=entry.name,
+            source_url=entry.source_url,
+            source_ref=entry.source_ref,
         )
 
     async def list_workspaces(

--- a/src/volundr/adapters/outbound/k8s_storage_adapter.py
+++ b/src/volundr/adapters/outbound/k8s_storage_adapter.py
@@ -13,6 +13,9 @@ from datetime import datetime
 from uuid import UUID
 
 from volundr.domain.models import (
+    ANNOT_WORKSPACE_NAME,
+    ANNOT_WORKSPACE_SOURCE_REF,
+    ANNOT_WORKSPACE_SOURCE_URL,
     LABEL_MANAGED_BY,
     LABEL_OWNER,
     LABEL_PVC_TYPE,
@@ -120,6 +123,7 @@ class K8sStorageAdapter(StoragePort):
     def _pvc_to_workspace(self, pvc) -> Workspace:
         """Convert a K8s PVC object to a Workspace domain model."""
         labels = pvc.metadata.labels or {}
+        annotations = pvc.metadata.annotations or {}
         session_id_str = labels.get(LABEL_SESSION_ID, "")
 
         # Parse storage size from spec
@@ -157,6 +161,9 @@ class K8sStorageAdapter(StoragePort):
             status=status,
             size_gb=size_gb,
             created_at=created_at,
+            name=annotations.get(ANNOT_WORKSPACE_NAME),
+            source_url=annotations.get(ANNOT_WORKSPACE_SOURCE_URL),
+            source_ref=annotations.get(ANNOT_WORKSPACE_SOURCE_REF),
         )
 
     async def _label_workspace(
@@ -228,11 +235,14 @@ class K8sStorageAdapter(StoragePort):
         user_id: str = "",
         tenant_id: str = "",
         workspace_gb: int | None = None,
+        name: str | None = None,
+        source_url: str | None = None,
+        source_ref: str | None = None,
     ) -> PVCRef:
         """Create a workspace PVC for a session."""
         api = await self._get_api()
         size = workspace_gb if workspace_gb is not None else self._workspace_size_gb
-        name = self._workspace_pvc_name(session_id)
+        pvc_name = self._workspace_pvc_name(session_id)
         labels = {
             LABEL_SESSION_ID: session_id,
             LABEL_PVC_TYPE: "workspace",
@@ -245,12 +255,24 @@ class K8sStorageAdapter(StoragePort):
             labels[LABEL_TENANT_ID] = tenant_id
 
         pvc = self._build_pvc_manifest(
-            name=name,
+            name=pvc_name,
             storage_gb=size,
             storage_class=self._workspace_storage_class,
             access_mode=self._workspace_access_mode,
             labels=labels,
         )
+
+        # Store workspace metadata as annotations so it persists
+        # independently of the session record.
+        annotations = {}
+        if name:
+            annotations[ANNOT_WORKSPACE_NAME] = name
+        if source_url:
+            annotations[ANNOT_WORKSPACE_SOURCE_URL] = source_url
+        if source_ref:
+            annotations[ANNOT_WORKSPACE_SOURCE_REF] = source_ref
+        if annotations:
+            pvc.metadata.annotations = annotations
 
         await api.create_namespaced_persistent_volume_claim(
             namespace=self._namespace,
@@ -258,11 +280,11 @@ class K8sStorageAdapter(StoragePort):
         )
         logger.info(
             "Created workspace PVC %s in namespace %s",
-            name,
+            pvc_name,
             self._namespace,
         )
 
-        return PVCRef(name=name, namespace=self._namespace)
+        return PVCRef(name=pvc_name, namespace=self._namespace)
 
     async def archive_session_workspace(
         self,

--- a/src/volundr/adapters/outbound/local_storage_adapter.py
+++ b/src/volundr/adapters/outbound/local_storage_adapter.py
@@ -28,6 +28,9 @@ class _WorkspaceEntry:
     size_gb: int
     status: WorkspaceStatus
     created_at: datetime.datetime
+    name: str | None = None
+    source_url: str | None = None
+    source_ref: str | None = None
 
 
 class LocalStorageAdapter(StoragePort):
@@ -83,6 +86,9 @@ class LocalStorageAdapter(StoragePort):
         user_id: str = "",
         tenant_id: str = "",
         workspace_gb: int = 50,
+        name: str | None = None,
+        source_url: str | None = None,
+        source_ref: str | None = None,
     ) -> PVCRef:
         """Create a workspace directory for a session."""
         ws_path = self._workspaces_dir / session_id
@@ -98,6 +104,9 @@ class LocalStorageAdapter(StoragePort):
             size_gb=workspace_gb,
             status=WorkspaceStatus.ACTIVE,
             created_at=now,
+            name=name,
+            source_url=source_url,
+            source_ref=source_ref,
         )
         self._session_workspaces[session_id] = entry
         self._write_meta(ws_path, entry)
@@ -123,12 +132,16 @@ class LocalStorageAdapter(StoragePort):
         self,
         session_id: str,
     ) -> None:
-        """Permanently delete a session workspace directory."""
-        self._session_workspaces.pop(session_id, None)
-        ws_path = self._workspaces_dir / session_id
-        if ws_path.exists():
-            shutil.rmtree(ws_path)
-        logger.info("Deleted workspace for session %s", session_id)
+        """Refuse to delete local workspace storage.
+
+        Local workspaces are bind-mounted from the user's machine.
+        Deleting them here would destroy data the user manages
+        outside of Volundr.
+        """
+        raise RuntimeError(
+            "Cannot delete a locally mounted workspace. "
+            "Please manage storage on your machine directly."
+        )
 
     async def get_user_storage_usage(
         self,
@@ -158,7 +171,7 @@ class LocalStorageAdapter(StoragePort):
 
     def _write_meta(self, ws_path: Path, entry: _WorkspaceEntry) -> None:
         """Write workspace metadata to a sidecar JSON file."""
-        meta = {
+        meta: dict[str, object] = {
             "session_id": entry.session_id,
             "user_id": entry.user_id,
             "tenant_id": entry.tenant_id,
@@ -166,6 +179,12 @@ class LocalStorageAdapter(StoragePort):
             "size_gb": entry.size_gb,
             "created_at": entry.created_at.isoformat(),
         }
+        if entry.name:
+            meta["name"] = entry.name
+        if entry.source_url:
+            meta["source_url"] = entry.source_url
+        if entry.source_ref:
+            meta["source_ref"] = entry.source_ref
         meta_path = ws_path / _META_FILENAME
         meta_path.write_text(json.dumps(meta, indent=2))
 
@@ -198,6 +217,9 @@ class LocalStorageAdapter(StoragePort):
                 size_gb=meta.get("size_gb", 0),
                 status=WorkspaceStatus(meta.get("status", "active")),
                 created_at=datetime.datetime.fromisoformat(meta["created_at"]),
+                name=meta.get("name"),
+                source_url=meta.get("source_url"),
+                source_ref=meta.get("source_ref"),
             )
 
         # Scan home dirs to reconstruct user PVC refs

--- a/src/volundr/domain/models.py
+++ b/src/volundr/domain/models.py
@@ -1102,6 +1102,9 @@ class Workspace:
     created_at: datetime | None = None
     archived_at: datetime | None = None
     deleted_at: datetime | None = None
+    name: str | None = None
+    source_url: str | None = None
+    source_ref: str | None = None
 
 
 @dataclass(frozen=True)
@@ -1122,6 +1125,11 @@ LABEL_PVC_TYPE = "volundr/pvc-type"
 LABEL_TENANT_ID = "volundr/tenant-id"
 LABEL_MANAGED_BY = "app.kubernetes.io/managed-by"
 LABEL_WORKSPACE_STATUS = "volundr/workspace-status"
+
+# Annotation keys for workspace metadata that may exceed label limits.
+ANNOT_WORKSPACE_NAME = "volundr/workspace-name"
+ANNOT_WORKSPACE_SOURCE_URL = "volundr/workspace-source-url"
+ANNOT_WORKSPACE_SOURCE_REF = "volundr/workspace-source-ref"
 
 
 @dataclass(frozen=True)

--- a/src/volundr/domain/ports.py
+++ b/src/volundr/domain/ports.py
@@ -1061,6 +1061,9 @@ class StoragePort(ABC):
         user_id: str,
         tenant_id: str,
         workspace_gb: int | None = None,
+        name: str | None = None,
+        source_url: str | None = None,
+        source_ref: str | None = None,
     ) -> PVCRef:
         """Create a workspace PVC for a session."""
 

--- a/tests/test_adapters/test_local_storage_adapter.py
+++ b/tests/test_adapters/test_local_storage_adapter.py
@@ -72,6 +72,24 @@ async def test_create_session_workspace_returns_pvcref_with_path(
     assert Path(ref.name).is_absolute()
 
 
+async def test_create_session_workspace_stores_name_and_source(
+    adapter: LocalStorageAdapter, tmp_path: Path
+) -> None:
+    await adapter.create_session_workspace(
+        "sess-3",
+        "user-1",
+        "tenant-1",
+        name="my-project",
+        source_url="github.com/org/repo",
+        source_ref="main",
+    )
+    meta_path = tmp_path / "workspaces" / "sess-3" / ".volundr-meta.json"
+    meta = json.loads(meta_path.read_text())
+    assert meta["name"] == "my-project"
+    assert meta["source_url"] == "github.com/org/repo"
+    assert meta["source_ref"] == "main"
+
+
 # ------------------------------------------------------------------
 # archive_session_workspace
 # ------------------------------------------------------------------
@@ -90,17 +108,16 @@ async def test_archive_session_workspace(adapter: LocalStorageAdapter, tmp_path:
 # ------------------------------------------------------------------
 
 
-async def test_delete_workspace_removes_dir(adapter: LocalStorageAdapter, tmp_path: Path) -> None:
+async def test_delete_workspace_raises_for_local_storage(
+    adapter: LocalStorageAdapter, tmp_path: Path
+) -> None:
     await adapter.create_session_workspace("sess-1", "user-1")
     ws_dir = tmp_path / "workspaces" / "sess-1"
     assert ws_dir.exists()
-    await adapter.delete_workspace("sess-1")
-    assert not ws_dir.exists()
-
-
-async def test_delete_workspace_nonexistent(adapter: LocalStorageAdapter) -> None:
-    # Should not raise
-    await adapter.delete_workspace("no-such-session")
+    with pytest.raises(RuntimeError, match="locally mounted workspace"):
+        await adapter.delete_workspace("sess-1")
+    # Directory must still exist — local storage is never deleted
+    assert ws_dir.exists()
 
 
 # ------------------------------------------------------------------

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -103,7 +103,7 @@
         "@codingame/monaco-vscode-workbench-service-override": "^28.0.1",
         "@codingame/monaco-vscode-working-copy-service-override": "^28.0.1",
         "@codingame/monaco-vscode-workspace-trust-service-override": "^28.0.1",
-        "@codingame/monaco-vscode-xml-default-extension": "^28.0.1",
+        "@codingame/monaco-vscode-xml-default-extension": "^28.3.1",
         "@codingame/monaco-vscode-yaml-default-extension": "^28.0.1",
         "@tailwindcss/postcss": "^4.2.1",
         "@tailwindcss/typography": "^0.5.19",
@@ -1723,12 +1723,104 @@
       }
     },
     "node_modules/@codingame/monaco-vscode-xml-default-extension": {
-      "version": "28.0.1",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-xml-default-extension/-/monaco-vscode-xml-default-extension-28.0.1.tgz",
-      "integrity": "sha512-IOJpNLlQeaeDBXlhOk2NZwqAS1vVR1iNeMYD2aRSlZabJJJppUqcD/ON3BjfW71g7fYTHuJKSn/7ykryNr+7DQ==",
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-xml-default-extension/-/monaco-vscode-xml-default-extension-28.3.1.tgz",
+      "integrity": "sha512-o+hbr+5YOB6UgLMGWt621iejqZYu1zen1hiPrrHP8bZ0efXyuDn3yq4dN9siJUaOg6Ueb5KnQYzqxSVr6maPIw==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "28.0.1"
+        "@codingame/monaco-vscode-api": "28.3.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-xml-default-extension/node_modules/@codingame/monaco-vscode-api": {
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-28.3.1.tgz",
+      "integrity": "sha512-gS4jcU0NAPWHB6EWAVcctgJaqtLbVEHmmb18TEO9qqRuqgzXTNaTQKaXvO4D8IhhcdBlKLb4n/J3dbjOlz4fkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-base-service-override": "28.3.1",
+        "@codingame/monaco-vscode-environment-service-override": "28.3.1",
+        "@codingame/monaco-vscode-extensions-service-override": "28.3.1",
+        "@codingame/monaco-vscode-files-service-override": "28.3.1",
+        "@codingame/monaco-vscode-host-service-override": "28.3.1",
+        "@codingame/monaco-vscode-layout-service-override": "28.3.1",
+        "@codingame/monaco-vscode-quickaccess-service-override": "28.3.1",
+        "@vscode/iconv-lite-umd": "0.7.1",
+        "dompurify": "3.3.3",
+        "jschardet": "3.1.4",
+        "marked": "14.0.0"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-xml-default-extension/node_modules/@codingame/monaco-vscode-base-service-override": {
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-28.3.1.tgz",
+      "integrity": "sha512-m4YvWEasEz832T/Kmw4WwJax9B729juiKjWPG9lGR0q85bp6mh8Gzwm6PIwakXmL5hUiM6SYCWy2erlxk2vpYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "28.3.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-xml-default-extension/node_modules/@codingame/monaco-vscode-environment-service-override": {
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-28.3.1.tgz",
+      "integrity": "sha512-eXWnRLdXAo/vST6f3e2oxK+MOhcAslZSF4kz5ig/jL+Ag0smA/JCS24wq/CmR+zK0HSxkShO3XJ6HMZNio/Vqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "28.3.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-xml-default-extension/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-28.3.1.tgz",
+      "integrity": "sha512-ZWObo5UM5kMQUcEPvxyrwLsU4eqQYLBLp7YLZCABWAjb6k2PDJjw+IvAqRdzlRRnKy95+IK/Uka4VXY0cQSpHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "28.3.1",
+        "@codingame/monaco-vscode-files-service-override": "28.3.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-xml-default-extension/node_modules/@codingame/monaco-vscode-files-service-override": {
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-28.3.1.tgz",
+      "integrity": "sha512-1kOF9KGawmsj0Sn09hW8b+oc+oWBfZLjkGHhqUT2zmcr7E2rBvc8NsmEJlcV/SQhRaWFB9qSmNPbZe9K46vDPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "28.3.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-xml-default-extension/node_modules/@codingame/monaco-vscode-host-service-override": {
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-28.3.1.tgz",
+      "integrity": "sha512-iJ/7alHZoMaj+K55/Osj4l0x3Sdwdrt8NLaygorf4d8UsKXjbVIqu8b3PhqlUNA0KbcH7DVZDmYzuYmp6qL8Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "28.3.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-xml-default-extension/node_modules/@codingame/monaco-vscode-layout-service-override": {
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-28.3.1.tgz",
+      "integrity": "sha512-Y8Dm+snfDw63QIg0pBCXVKBaNm6f8JGSH5Ub13gxK6hfxOBf2aCYEGQXGSRCSR+OQueco2SRZBHNdBPrzt5ZgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "28.3.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-xml-default-extension/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-28.3.1.tgz",
+      "integrity": "sha512-yxgIoQrFp9Modb7cg0iOl5asW8ZcFcQgxtc+8f8E+xyZwEE+AwDv11vQ/ch7Prw0NyQIXjv6wPSgR+HwdnPX9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "28.3.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-xml-default-extension/node_modules/dompurify": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/@codingame/monaco-vscode-xterm-addons-common": {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -82,7 +82,7 @@
         "@codingame/monaco-vscode-sql-default-extension": "^28.0.1",
         "@codingame/monaco-vscode-storage-service-override": "^28.0.1",
         "@codingame/monaco-vscode-survey-service-override": "^28.0.1",
-        "@codingame/monaco-vscode-swift-default-extension": "^28.0.1",
+        "@codingame/monaco-vscode-swift-default-extension": "^28.3.1",
         "@codingame/monaco-vscode-task-service-override": "^28.0.1",
         "@codingame/monaco-vscode-terminal-service-override": "^28.0.1",
         "@codingame/monaco-vscode-testing-service-override": "^28.0.1",
@@ -1322,12 +1322,104 @@
       }
     },
     "node_modules/@codingame/monaco-vscode-swift-default-extension": {
-      "version": "28.0.1",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-swift-default-extension/-/monaco-vscode-swift-default-extension-28.0.1.tgz",
-      "integrity": "sha512-9I5g31swUGsdV0sTLjVpFJKoDuBF1RTfk5tpunv8/QRwyAtHfYx0PKnnLZtCf5UfeTLBUZLnUPz9SG7eR1qylA==",
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-swift-default-extension/-/monaco-vscode-swift-default-extension-28.3.1.tgz",
+      "integrity": "sha512-p0cSf5BC6xszLEJFIsbZFMG1cT+ZLCK/Ri28PH+kDUmKVFt/wlmogjOFWCbq2cicQHco87bn4R5P/wmqMhHT7w==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "28.0.1"
+        "@codingame/monaco-vscode-api": "28.3.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-swift-default-extension/node_modules/@codingame/monaco-vscode-api": {
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-28.3.1.tgz",
+      "integrity": "sha512-gS4jcU0NAPWHB6EWAVcctgJaqtLbVEHmmb18TEO9qqRuqgzXTNaTQKaXvO4D8IhhcdBlKLb4n/J3dbjOlz4fkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-base-service-override": "28.3.1",
+        "@codingame/monaco-vscode-environment-service-override": "28.3.1",
+        "@codingame/monaco-vscode-extensions-service-override": "28.3.1",
+        "@codingame/monaco-vscode-files-service-override": "28.3.1",
+        "@codingame/monaco-vscode-host-service-override": "28.3.1",
+        "@codingame/monaco-vscode-layout-service-override": "28.3.1",
+        "@codingame/monaco-vscode-quickaccess-service-override": "28.3.1",
+        "@vscode/iconv-lite-umd": "0.7.1",
+        "dompurify": "3.3.3",
+        "jschardet": "3.1.4",
+        "marked": "14.0.0"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-swift-default-extension/node_modules/@codingame/monaco-vscode-base-service-override": {
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-28.3.1.tgz",
+      "integrity": "sha512-m4YvWEasEz832T/Kmw4WwJax9B729juiKjWPG9lGR0q85bp6mh8Gzwm6PIwakXmL5hUiM6SYCWy2erlxk2vpYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "28.3.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-swift-default-extension/node_modules/@codingame/monaco-vscode-environment-service-override": {
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-28.3.1.tgz",
+      "integrity": "sha512-eXWnRLdXAo/vST6f3e2oxK+MOhcAslZSF4kz5ig/jL+Ag0smA/JCS24wq/CmR+zK0HSxkShO3XJ6HMZNio/Vqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "28.3.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-swift-default-extension/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-28.3.1.tgz",
+      "integrity": "sha512-ZWObo5UM5kMQUcEPvxyrwLsU4eqQYLBLp7YLZCABWAjb6k2PDJjw+IvAqRdzlRRnKy95+IK/Uka4VXY0cQSpHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "28.3.1",
+        "@codingame/monaco-vscode-files-service-override": "28.3.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-swift-default-extension/node_modules/@codingame/monaco-vscode-files-service-override": {
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-28.3.1.tgz",
+      "integrity": "sha512-1kOF9KGawmsj0Sn09hW8b+oc+oWBfZLjkGHhqUT2zmcr7E2rBvc8NsmEJlcV/SQhRaWFB9qSmNPbZe9K46vDPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "28.3.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-swift-default-extension/node_modules/@codingame/monaco-vscode-host-service-override": {
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-28.3.1.tgz",
+      "integrity": "sha512-iJ/7alHZoMaj+K55/Osj4l0x3Sdwdrt8NLaygorf4d8UsKXjbVIqu8b3PhqlUNA0KbcH7DVZDmYzuYmp6qL8Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "28.3.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-swift-default-extension/node_modules/@codingame/monaco-vscode-layout-service-override": {
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-28.3.1.tgz",
+      "integrity": "sha512-Y8Dm+snfDw63QIg0pBCXVKBaNm6f8JGSH5Ub13gxK6hfxOBf2aCYEGQXGSRCSR+OQueco2SRZBHNdBPrzt5ZgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "28.3.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-swift-default-extension/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-28.3.1.tgz",
+      "integrity": "sha512-yxgIoQrFp9Modb7cg0iOl5asW8ZcFcQgxtc+8f8E+xyZwEE+AwDv11vQ/ch7Prw0NyQIXjv6wPSgR+HwdnPX9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "28.3.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-swift-default-extension/node_modules/dompurify": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/@codingame/monaco-vscode-task-service-override": {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -27,7 +27,7 @@
         "@codingame/monaco-vscode-editor-service-override": "^28.0.1",
         "@codingame/monaco-vscode-emmet-service-override": "^28.0.1",
         "@codingame/monaco-vscode-environment-service-override": "^28.0.1",
-        "@codingame/monaco-vscode-explorer-service-override": "^28.0.1",
+        "@codingame/monaco-vscode-explorer-service-override": "^28.3.1",
         "@codingame/monaco-vscode-extension-api": "^28.0.1",
         "@codingame/monaco-vscode-extension-gallery-service-override": "^28.0.1",
         "@codingame/monaco-vscode-extensions-service-override": "^28.0.1",
@@ -769,12 +769,104 @@
       }
     },
     "node_modules/@codingame/monaco-vscode-explorer-service-override": {
-      "version": "28.0.1",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-explorer-service-override/-/monaco-vscode-explorer-service-override-28.0.1.tgz",
-      "integrity": "sha512-4Y6l/losBUwIxgfoXzlX9Ftc1jENz24343KmOk4XcFGwz0X/3E9CKvPbA9U7DCL5V/CoTftdCfM4RddnNN5QNQ==",
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-explorer-service-override/-/monaco-vscode-explorer-service-override-28.3.1.tgz",
+      "integrity": "sha512-Jx6nc2NlxcqX3uFnh351Q98wGrCLFKE8GpnqBMcE59Oa2C9JMRBz9FFOPpZG5tqzexLO/mUWI1/4sIx1GMZhgg==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "28.0.1"
+        "@codingame/monaco-vscode-api": "28.3.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-explorer-service-override/node_modules/@codingame/monaco-vscode-api": {
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-28.3.1.tgz",
+      "integrity": "sha512-gS4jcU0NAPWHB6EWAVcctgJaqtLbVEHmmb18TEO9qqRuqgzXTNaTQKaXvO4D8IhhcdBlKLb4n/J3dbjOlz4fkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-base-service-override": "28.3.1",
+        "@codingame/monaco-vscode-environment-service-override": "28.3.1",
+        "@codingame/monaco-vscode-extensions-service-override": "28.3.1",
+        "@codingame/monaco-vscode-files-service-override": "28.3.1",
+        "@codingame/monaco-vscode-host-service-override": "28.3.1",
+        "@codingame/monaco-vscode-layout-service-override": "28.3.1",
+        "@codingame/monaco-vscode-quickaccess-service-override": "28.3.1",
+        "@vscode/iconv-lite-umd": "0.7.1",
+        "dompurify": "3.3.3",
+        "jschardet": "3.1.4",
+        "marked": "14.0.0"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-explorer-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-28.3.1.tgz",
+      "integrity": "sha512-m4YvWEasEz832T/Kmw4WwJax9B729juiKjWPG9lGR0q85bp6mh8Gzwm6PIwakXmL5hUiM6SYCWy2erlxk2vpYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "28.3.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-explorer-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-28.3.1.tgz",
+      "integrity": "sha512-eXWnRLdXAo/vST6f3e2oxK+MOhcAslZSF4kz5ig/jL+Ag0smA/JCS24wq/CmR+zK0HSxkShO3XJ6HMZNio/Vqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "28.3.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-explorer-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-28.3.1.tgz",
+      "integrity": "sha512-ZWObo5UM5kMQUcEPvxyrwLsU4eqQYLBLp7YLZCABWAjb6k2PDJjw+IvAqRdzlRRnKy95+IK/Uka4VXY0cQSpHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "28.3.1",
+        "@codingame/monaco-vscode-files-service-override": "28.3.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-explorer-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-28.3.1.tgz",
+      "integrity": "sha512-1kOF9KGawmsj0Sn09hW8b+oc+oWBfZLjkGHhqUT2zmcr7E2rBvc8NsmEJlcV/SQhRaWFB9qSmNPbZe9K46vDPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "28.3.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-explorer-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-28.3.1.tgz",
+      "integrity": "sha512-iJ/7alHZoMaj+K55/Osj4l0x3Sdwdrt8NLaygorf4d8UsKXjbVIqu8b3PhqlUNA0KbcH7DVZDmYzuYmp6qL8Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "28.3.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-explorer-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-28.3.1.tgz",
+      "integrity": "sha512-Y8Dm+snfDw63QIg0pBCXVKBaNm6f8JGSH5Ub13gxK6hfxOBf2aCYEGQXGSRCSR+OQueco2SRZBHNdBPrzt5ZgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "28.3.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-explorer-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-28.3.1.tgz",
+      "integrity": "sha512-yxgIoQrFp9Modb7cg0iOl5asW8ZcFcQgxtc+8f8E+xyZwEE+AwDv11vQ/ch7Prw0NyQIXjv6wPSgR+HwdnPX9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "28.3.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-explorer-service-override/node_modules/dompurify": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/@codingame/monaco-vscode-extension-api": {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@codingame/monaco-vscode-accessibility-service-override": "^28.0.1",
         "@codingame/monaco-vscode-api": "^28.0.1",
-        "@codingame/monaco-vscode-authentication-service-override": "^28.0.1",
+        "@codingame/monaco-vscode-authentication-service-override": "^28.3.1",
         "@codingame/monaco-vscode-comments-service-override": "^28.0.1",
         "@codingame/monaco-vscode-configuration-editing-default-extension": "^28.0.1",
         "@codingame/monaco-vscode-configuration-service-override": "^28.0.1",
@@ -606,12 +606,104 @@
       }
     },
     "node_modules/@codingame/monaco-vscode-authentication-service-override": {
-      "version": "28.0.1",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-authentication-service-override/-/monaco-vscode-authentication-service-override-28.0.1.tgz",
-      "integrity": "sha512-c1n7ujbZLQNLPwZbg71ry7Pq29PNgd29keX+cHuB1lSfPZ7Y5S15WPe3hFLvxZ4oZNIfyPznei6biEo2jwMHkw==",
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-authentication-service-override/-/monaco-vscode-authentication-service-override-28.3.1.tgz",
+      "integrity": "sha512-4qBPjaWhlQDduLsXQWwtcpoCnix4F92f6Q1zjfSx8HEJo1ICCibsY7Us9y5Q2BUxM9Tors0nauoVm+vfGloanQ==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "28.0.1"
+        "@codingame/monaco-vscode-api": "28.3.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-authentication-service-override/node_modules/@codingame/monaco-vscode-api": {
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-28.3.1.tgz",
+      "integrity": "sha512-gS4jcU0NAPWHB6EWAVcctgJaqtLbVEHmmb18TEO9qqRuqgzXTNaTQKaXvO4D8IhhcdBlKLb4n/J3dbjOlz4fkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-base-service-override": "28.3.1",
+        "@codingame/monaco-vscode-environment-service-override": "28.3.1",
+        "@codingame/monaco-vscode-extensions-service-override": "28.3.1",
+        "@codingame/monaco-vscode-files-service-override": "28.3.1",
+        "@codingame/monaco-vscode-host-service-override": "28.3.1",
+        "@codingame/monaco-vscode-layout-service-override": "28.3.1",
+        "@codingame/monaco-vscode-quickaccess-service-override": "28.3.1",
+        "@vscode/iconv-lite-umd": "0.7.1",
+        "dompurify": "3.3.3",
+        "jschardet": "3.1.4",
+        "marked": "14.0.0"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-authentication-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-28.3.1.tgz",
+      "integrity": "sha512-m4YvWEasEz832T/Kmw4WwJax9B729juiKjWPG9lGR0q85bp6mh8Gzwm6PIwakXmL5hUiM6SYCWy2erlxk2vpYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "28.3.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-authentication-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-28.3.1.tgz",
+      "integrity": "sha512-eXWnRLdXAo/vST6f3e2oxK+MOhcAslZSF4kz5ig/jL+Ag0smA/JCS24wq/CmR+zK0HSxkShO3XJ6HMZNio/Vqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "28.3.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-authentication-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-28.3.1.tgz",
+      "integrity": "sha512-ZWObo5UM5kMQUcEPvxyrwLsU4eqQYLBLp7YLZCABWAjb6k2PDJjw+IvAqRdzlRRnKy95+IK/Uka4VXY0cQSpHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "28.3.1",
+        "@codingame/monaco-vscode-files-service-override": "28.3.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-authentication-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-28.3.1.tgz",
+      "integrity": "sha512-1kOF9KGawmsj0Sn09hW8b+oc+oWBfZLjkGHhqUT2zmcr7E2rBvc8NsmEJlcV/SQhRaWFB9qSmNPbZe9K46vDPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "28.3.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-authentication-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-28.3.1.tgz",
+      "integrity": "sha512-iJ/7alHZoMaj+K55/Osj4l0x3Sdwdrt8NLaygorf4d8UsKXjbVIqu8b3PhqlUNA0KbcH7DVZDmYzuYmp6qL8Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "28.3.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-authentication-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-28.3.1.tgz",
+      "integrity": "sha512-Y8Dm+snfDw63QIg0pBCXVKBaNm6f8JGSH5Ub13gxK6hfxOBf2aCYEGQXGSRCSR+OQueco2SRZBHNdBPrzt5ZgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "28.3.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-authentication-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+      "version": "28.3.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-28.3.1.tgz",
+      "integrity": "sha512-yxgIoQrFp9Modb7cg0iOl5asW8ZcFcQgxtc+8f8E+xyZwEE+AwDv11vQ/ch7Prw0NyQIXjv6wPSgR+HwdnPX9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "28.3.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-authentication-service-override/node_modules/dompurify": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/@codingame/monaco-vscode-base-service-override": {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -144,7 +144,7 @@
         "jsdom": "^28.1.0",
         "prettier": "^3.8.1",
         "typescript": "~5.9.3",
-        "typescript-eslint": "^8.57.0",
+        "typescript-eslint": "^8.57.1",
         "vite": "^7.2.4",
         "vite-plugin-dts": "^4.5.0",
         "vitest": "^4.0.18"
@@ -4190,17 +4190,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.0.tgz",
-      "integrity": "sha512-qeu4rTHR3/IaFORbD16gmjq9+rEs9fGKdX0kF6BKSfi+gCuG3RCKLlSBYzn/bGsY9Tj7KE/DAQStbp8AHJGHEQ==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.1.tgz",
+      "integrity": "sha512-Gn3aqnvNl4NGc6x3/Bqk1AOn0thyTU9bqDRhiRnUWezgvr2OnhYCWCgC8zXXRVqBsIL1pSDt7T9nJUe0oM0kDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.57.0",
-        "@typescript-eslint/type-utils": "8.57.0",
-        "@typescript-eslint/utils": "8.57.0",
-        "@typescript-eslint/visitor-keys": "8.57.0",
+        "@typescript-eslint/scope-manager": "8.57.1",
+        "@typescript-eslint/type-utils": "8.57.1",
+        "@typescript-eslint/utils": "8.57.1",
+        "@typescript-eslint/visitor-keys": "8.57.1",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.4.0"
@@ -4213,7 +4213,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.57.0",
+        "@typescript-eslint/parser": "^8.57.1",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
@@ -4229,16 +4229,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.0.tgz",
-      "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.1.tgz",
+      "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.57.0",
-        "@typescript-eslint/types": "8.57.0",
-        "@typescript-eslint/typescript-estree": "8.57.0",
-        "@typescript-eslint/visitor-keys": "8.57.0",
+        "@typescript-eslint/scope-manager": "8.57.1",
+        "@typescript-eslint/types": "8.57.1",
+        "@typescript-eslint/typescript-estree": "8.57.1",
+        "@typescript-eslint/visitor-keys": "8.57.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4254,14 +4254,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.0.tgz",
-      "integrity": "sha512-pR+dK0BlxCLxtWfaKQWtYr7MhKmzqZxuii+ZjuFlZlIGRZm22HnXFqa2eY+90MUz8/i80YJmzFGDUsi8dMOV5w==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.1.tgz",
+      "integrity": "sha512-vx1F37BRO1OftsYlmG9xay1TqnjNVlqALymwWVuYTdo18XuKxtBpCj1QlzNIEHlvlB27osvXFWptYiEWsVdYsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.57.0",
-        "@typescript-eslint/types": "^8.57.0",
+        "@typescript-eslint/tsconfig-utils": "^8.57.1",
+        "@typescript-eslint/types": "^8.57.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4276,14 +4276,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.0.tgz",
-      "integrity": "sha512-nvExQqAHF01lUM66MskSaZulpPL5pgy5hI5RfrxviLgzZVffB5yYzw27uK/ft8QnKXI2X0LBrHJFr1TaZtAibw==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.1.tgz",
+      "integrity": "sha512-hs/QcpCwlwT2L5S+3fT6gp0PabyGk4Q0Rv2doJXA0435/OpnSR3VRgvrp8Xdoc3UAYSg9cyUjTeFXZEPg/3OKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.57.0",
-        "@typescript-eslint/visitor-keys": "8.57.0"
+        "@typescript-eslint/types": "8.57.1",
+        "@typescript-eslint/visitor-keys": "8.57.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4294,9 +4294,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.0.tgz",
-      "integrity": "sha512-LtXRihc5ytjJIQEH+xqjB0+YgsV4/tW35XKX3GTZHpWtcC8SPkT/d4tqdf1cKtesryHm2bgp6l555NYcT2NLvA==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.1.tgz",
+      "integrity": "sha512-0lgOZB8cl19fHO4eI46YUx2EceQqhgkPSuCGLlGi79L2jwYY1cxeYc1Nae8Aw1xjgW3PKVDLlr3YJ6Bxx8HkWg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4311,15 +4311,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.0.tgz",
-      "integrity": "sha512-yjgh7gmDcJ1+TcEg8x3uWQmn8ifvSupnPfjP21twPKrDP/pTHlEQgmKcitzF/rzPSmv7QjJ90vRpN4U+zoUjwQ==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.1.tgz",
+      "integrity": "sha512-+Bwwm0ScukFdyoJsh2u6pp4S9ktegF98pYUU0hkphOOqdMB+1sNQhIz8y5E9+4pOioZijrkfNO/HUJVAFFfPKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.57.0",
-        "@typescript-eslint/typescript-estree": "8.57.0",
-        "@typescript-eslint/utils": "8.57.0",
+        "@typescript-eslint/types": "8.57.1",
+        "@typescript-eslint/typescript-estree": "8.57.1",
+        "@typescript-eslint/utils": "8.57.1",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.4.0"
       },
@@ -4336,9 +4336,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.0.tgz",
-      "integrity": "sha512-dTLI8PEXhjUC7B9Kre+u0XznO696BhXcTlOn0/6kf1fHaQW8+VjJAVHJ3eTI14ZapTxdkOmc80HblPQLaEeJdg==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.1.tgz",
+      "integrity": "sha512-S29BOBPJSFUiblEl6RzPPjJt6w25A6XsBqRVDt53tA/tlL8q7ceQNZHTjPeONt/3S7KRI4quk+yP9jK2WjBiPQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4350,16 +4350,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.0.tgz",
-      "integrity": "sha512-m7faHcyVg0BT3VdYTlX8GdJEM7COexXxS6KqGopxdtkQRvBanK377QDHr4W/vIPAR+ah9+B/RclSW5ldVniO1Q==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.1.tgz",
+      "integrity": "sha512-ybe2hS9G6pXpqGtPli9Gx9quNV0TWLOmh58ADlmZe9DguLq0tiAKVjirSbtM1szG6+QH6rVXyU6GTLQbWnMY+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.57.0",
-        "@typescript-eslint/tsconfig-utils": "8.57.0",
-        "@typescript-eslint/types": "8.57.0",
-        "@typescript-eslint/visitor-keys": "8.57.0",
+        "@typescript-eslint/project-service": "8.57.1",
+        "@typescript-eslint/tsconfig-utils": "8.57.1",
+        "@typescript-eslint/types": "8.57.1",
+        "@typescript-eslint/visitor-keys": "8.57.1",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -4391,16 +4391,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.0.tgz",
-      "integrity": "sha512-5iIHvpD3CZe06riAsbNxxreP+MuYgVUsV0n4bwLH//VJmgtt54sQeY2GszntJ4BjYCpMzrfVh2SBnUQTtys2lQ==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.1.tgz",
+      "integrity": "sha512-XUNSJ/lEVFttPMMoDVA2r2bwrl8/oPx8cURtczkSEswY5T3AeLmCy+EKWQNdL4u0MmAHOjcWrqJp2cdvgjn8dQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.57.0",
-        "@typescript-eslint/types": "8.57.0",
-        "@typescript-eslint/typescript-estree": "8.57.0"
+        "@typescript-eslint/scope-manager": "8.57.1",
+        "@typescript-eslint/types": "8.57.1",
+        "@typescript-eslint/typescript-estree": "8.57.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4415,13 +4415,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.0.tgz",
-      "integrity": "sha512-zm6xx8UT/Xy2oSr2ZXD0pZo7Jx2XsCoID2IUh9YSTFRu7z+WdwYTRk6LhUftm1crwqbuoF6I8zAFeCMw0YjwDg==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.1.tgz",
+      "integrity": "sha512-YWnmJkXbofiz9KbnbbwuA2rpGkFPLbAIetcCNO6mJ8gdhdZ/v7WDXsoGFAJuM6ikUFKTlSQnjWnVO4ux+UzS6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/types": "8.57.1",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -8857,9 +8857,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
-      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8906,16 +8906,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.57.0.tgz",
-      "integrity": "sha512-W8GcigEMEeB07xEZol8oJ26rigm3+bfPHxHvwbYUlu1fUDsGuQ7Hiskx5xGW/xM4USc9Ephe3jtv7ZYPQntHeA==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.57.1.tgz",
+      "integrity": "sha512-fLvZWf+cAGw3tqMCYzGIU6yR8K+Y9NT2z23RwOjlNFF2HwSB3KhdEFI5lSBv8tNmFkkBShSjsCjzx1vahZfISA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.57.0",
-        "@typescript-eslint/parser": "8.57.0",
-        "@typescript-eslint/typescript-estree": "8.57.0",
-        "@typescript-eslint/utils": "8.57.0"
+        "@typescript-eslint/eslint-plugin": "8.57.1",
+        "@typescript-eslint/parser": "8.57.1",
+        "@typescript-eslint/typescript-estree": "8.57.1",
+        "@typescript-eslint/utils": "8.57.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/web/package.json
+++ b/web/package.json
@@ -155,7 +155,7 @@
     "@codingame/monaco-vscode-workbench-service-override": "^28.0.1",
     "@codingame/monaco-vscode-working-copy-service-override": "^28.0.1",
     "@codingame/monaco-vscode-workspace-trust-service-override": "^28.0.1",
-    "@codingame/monaco-vscode-xml-default-extension": "^28.0.1",
+    "@codingame/monaco-vscode-xml-default-extension": "^28.3.1",
     "@codingame/monaco-vscode-yaml-default-extension": "^28.0.1",
     "@tailwindcss/postcss": "^4.2.1",
     "@tailwindcss/typography": "^0.5.19",

--- a/web/package.json
+++ b/web/package.json
@@ -199,7 +199,7 @@
     "jsdom": "^28.1.0",
     "prettier": "^3.8.1",
     "typescript": "~5.9.3",
-    "typescript-eslint": "^8.57.0",
+    "typescript-eslint": "^8.57.1",
     "vite": "^7.2.4",
     "vite-plugin-dts": "^4.5.0",
     "vitest": "^4.0.18"

--- a/web/package.json
+++ b/web/package.json
@@ -79,7 +79,7 @@
     "@codingame/monaco-vscode-editor-service-override": "^28.0.1",
     "@codingame/monaco-vscode-emmet-service-override": "^28.0.1",
     "@codingame/monaco-vscode-environment-service-override": "^28.0.1",
-    "@codingame/monaco-vscode-explorer-service-override": "^28.0.1",
+    "@codingame/monaco-vscode-explorer-service-override": "^28.3.1",
     "@codingame/monaco-vscode-extension-api": "^28.0.1",
     "@codingame/monaco-vscode-extension-gallery-service-override": "^28.0.1",
     "@codingame/monaco-vscode-extensions-service-override": "^28.0.1",

--- a/web/package.json
+++ b/web/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@codingame/monaco-vscode-accessibility-service-override": "^28.0.1",
     "@codingame/monaco-vscode-api": "^28.0.1",
-    "@codingame/monaco-vscode-authentication-service-override": "^28.0.1",
+    "@codingame/monaco-vscode-authentication-service-override": "^28.3.1",
     "@codingame/monaco-vscode-comments-service-override": "^28.0.1",
     "@codingame/monaco-vscode-configuration-editing-default-extension": "^28.0.1",
     "@codingame/monaco-vscode-configuration-service-override": "^28.0.1",

--- a/web/package.json
+++ b/web/package.json
@@ -134,7 +134,7 @@
     "@codingame/monaco-vscode-sql-default-extension": "^28.0.1",
     "@codingame/monaco-vscode-storage-service-override": "^28.0.1",
     "@codingame/monaco-vscode-survey-service-override": "^28.0.1",
-    "@codingame/monaco-vscode-swift-default-extension": "^28.0.1",
+    "@codingame/monaco-vscode-swift-default-extension": "^28.3.1",
     "@codingame/monaco-vscode-task-service-override": "^28.0.1",
     "@codingame/monaco-vscode-terminal-service-override": "^28.0.1",
     "@codingame/monaco-vscode-testing-service-override": "^28.0.1",

--- a/web/src/components/DeleteSessionDialog/DeleteSessionDialog.module.css
+++ b/web/src/components/DeleteSessionDialog/DeleteSessionDialog.module.css
@@ -69,10 +69,19 @@
   cursor: pointer;
 }
 
+.checkboxItem[data-disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .checkbox {
   margin-top: 2px;
   accent-color: var(--color-accent-red);
   cursor: pointer;
+}
+
+.checkbox:disabled {
+  cursor: not-allowed;
 }
 
 .checkboxContent {

--- a/web/src/components/DeleteSessionDialog/DeleteSessionDialog.test.tsx
+++ b/web/src/components/DeleteSessionDialog/DeleteSessionDialog.test.tsx
@@ -153,4 +153,45 @@ describe('DeleteSessionDialog', () => {
 
     expect(onCancel).toHaveBeenCalled();
   });
+
+  it('disables workspace_storage checkbox for local storage sessions', () => {
+    render(
+      <DeleteSessionDialog
+        isOpen={true}
+        sessionName="local-session"
+        isManual={false}
+        isLocalStorage={true}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />
+    );
+
+    const wsCheckbox = screen.getByTestId('cleanup-workspace_storage') as HTMLInputElement;
+    expect(wsCheckbox.disabled).toBe(true);
+
+    const chroniclesCheckbox = screen.getByTestId('cleanup-chronicles') as HTMLInputElement;
+    expect(chroniclesCheckbox.disabled).toBe(false);
+
+    expect(
+      screen.getByText('Local mounted workspace — manage storage on your machine.')
+    ).toBeInTheDocument();
+  });
+
+  it('does not include disabled workspace_storage in cleanup targets', () => {
+    render(
+      <DeleteSessionDialog
+        isOpen={true}
+        sessionName="local-session"
+        isManual={false}
+        isLocalStorage={true}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('cleanup-chronicles'));
+    fireEvent.click(screen.getByTestId('delete-session-confirm'));
+
+    expect(onConfirm).toHaveBeenCalledWith(['chronicles']);
+  });
 });

--- a/web/src/components/DeleteSessionDialog/DeleteSessionDialog.tsx
+++ b/web/src/components/DeleteSessionDialog/DeleteSessionDialog.tsx
@@ -26,6 +26,7 @@ export interface DeleteSessionDialogProps {
   isOpen: boolean;
   sessionName: string;
   isManual: boolean;
+  isLocalStorage?: boolean;
   onConfirm: (cleanup: CleanupTarget[]) => void;
   onCancel: () => void;
 }
@@ -34,6 +35,7 @@ export const DeleteSessionDialog: FC<DeleteSessionDialogProps> = ({
   isOpen,
   sessionName,
   isManual,
+  isLocalStorage = false,
   onConfirm,
   onCancel,
 }) => {
@@ -89,21 +91,38 @@ export const DeleteSessionDialog: FC<DeleteSessionDialogProps> = ({
           <div className={styles.cleanupSection}>
             <p className={styles.cleanupHeading}>Also clean up:</p>
             <div className={styles.checkboxList}>
-              {CLEANUP_OPTIONS.map(option => (
-                <label key={option.target} className={styles.checkboxItem}>
-                  <input
-                    type="checkbox"
-                    className={styles.checkbox}
-                    checked={selected.has(option.target)}
-                    onChange={() => handleToggle(option.target)}
-                    data-testid={`cleanup-${option.target}`}
-                  />
-                  <div className={styles.checkboxContent}>
-                    <span className={styles.checkboxLabel}>{option.label}</span>
-                    <span className={styles.checkboxHint}>{option.hint}</span>
-                  </div>
-                </label>
-              ))}
+              {CLEANUP_OPTIONS.map(option => {
+                const disabled = option.target === 'workspace_storage' && isLocalStorage;
+                return (
+                  <label
+                    key={option.target}
+                    className={styles.checkboxItem}
+                    data-disabled={disabled || undefined}
+                    title={
+                      disabled
+                        ? 'Local mounted workspace — manage storage on your machine'
+                        : undefined
+                    }
+                  >
+                    <input
+                      type="checkbox"
+                      className={styles.checkbox}
+                      checked={selected.has(option.target)}
+                      onChange={() => handleToggle(option.target)}
+                      disabled={disabled}
+                      data-testid={`cleanup-${option.target}`}
+                    />
+                    <div className={styles.checkboxContent}>
+                      <span className={styles.checkboxLabel}>{option.label}</span>
+                      <span className={styles.checkboxHint}>
+                        {disabled
+                          ? 'Local mounted workspace — manage storage on your machine.'
+                          : option.hint}
+                      </span>
+                    </div>
+                  </label>
+                );
+              })}
             </div>
           </div>
         )}

--- a/web/src/pages/Volundr/index.tsx
+++ b/web/src/pages/Volundr/index.tsx
@@ -1396,6 +1396,7 @@ export function VolundrPage() {
         isOpen={showDeleteDialog}
         sessionName={effectiveSelectedSession?.name ?? ''}
         isManual={false}
+        isLocalStorage={effectiveSelectedSession?.source?.type === 'local_mount'}
         onConfirm={handleDeleteConfirm}
         onCancel={handleDeleteCancel}
       />


### PR DESCRIPTION
## Release v0.69.0

**15** commits since v0.68.0 · version bump: **minor**

### Bug Fixes
- **ci**: Fix pre-commit hook PATH and trufflehog installation
- **adapters**: Persist workspace name independently of session

### Refactoring
- **cli**: Rename CLI binary from volundr to niuu as multi-tool umbrella

### CI
true

### Build
- **deps**: Bump the actions group with 2 updates
- **deps-dev**: Bump typescript-eslint from 8.57.0 to 8.57.1 in /web
- **deps**: Bump @codingame/monaco-vscode-authentication-service-override
- **deps**: Bump ubuntu in /containers/skuld-codex
- **deps**: Bump ubuntu in /containers/skuld
- **deps**: Bump @codingame/monaco-vscode-xml-default-extension in /web
- **deps**: Bump python in /containers/devrunner
- **deps**: Bump @codingame/monaco-vscode-explorer-service-override
- **deps**: Bump @codingame/monaco-vscode-swift-default-extension
- **deps**: Bump ubuntu in /containers/volundr
- **deps**: Bump github.com/fergusstrange/embedded-postgres in /cli
- **deps**: Bump github.com/lib/pq from 1.11.2 to 1.12.0 in /cli

---
*Auto-generated by the changelog workflow*