### PR TITLE
feat(tyr): add initial database migrations for saga coordinator

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -118,8 +118,8 @@ jobs:
         run: uv run ruff format --check src/ tests/ || echo "::warning::Formatting issues found - consider running 'ruff format src/ tests/'"
         continue-on-error: true
 
-  python-test:
-    name: "Python: Test"
+  python-test-volundr:
+    name: "Python: Test Volundr"
     needs: changes
     if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
@@ -139,7 +139,7 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          uv run pytest tests/ -v --tb=short \
+          uv run pytest tests/ --ignore=tests/test_tyr -v --tb=short \
             --cov=src/volundr \
             --cov-report=term-missing \
             --cov-report=xml \
@@ -149,7 +149,41 @@ jobs:
         uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5
         with:
           files: coverage.xml
-          flags: backend
+          flags: backend-volundr
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  python-test-tyr:
+    name: "Python: Test Tyr"
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --all-extras --dev
+
+      - name: Run tests with coverage
+        run: |
+          uv run pytest tests/test_tyr -v --tb=short \
+            --cov=src/tyr \
+            --cov-report=term-missing \
+            --cov-report=xml \
+            --cov-fail-under=85
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5
+        with:
+          files: coverage.xml
+          flags: backend-tyr
           token: ${{ secrets.CODECOV_TOKEN }}
 
   # ---------------------------------------------------------------------------

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -174,6 +174,7 @@ jobs:
       - name: Run tests with coverage
         run: |
           uv run pytest tests/test_tyr -v --tb=short \
+            --override-ini="addopts=" \
             --cov=src/tyr \
             --cov-report=term-missing \
             --cov-report=xml \

--- a/charts/tyr/Chart.yaml
+++ b/charts/tyr/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: tyr
+description: "Tyr — saga coordinator for multi-session orchestration"
+type: application
+version: 0.1.0-dev1
+appVersion: "0.1.0"
+keywords:
+  - tyr
+  - saga
+  - coordinator
+  - orchestration
+  - ai
+  - kubernetes
+maintainers:
+  - name: Niuu Labs
+    url: https://github.com/niuulabs
+home: https://github.com/niuulabs/volundr
+sources:
+  - https://github.com/niuulabs/volundr
+dependencies: []

--- a/charts/tyr/templates/_helpers.tpl
+++ b/charts/tyr/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "tyr.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "tyr.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "tyr.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "tyr.labels" -}}
+helm.sh/chart: {{ include "tyr.chart" . }}
+{{ include "tyr.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: saga-coordinator
+app.kubernetes.io/part-of: volundr
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "tyr.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tyr.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/tyr/templates/migrations-configmap.yaml
+++ b/charts/tyr/templates/migrations-configmap.yaml
@@ -1,0 +1,81 @@
+{{- if .Values.migrations.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "tyr.fullname" . }}-migrations
+  labels:
+    {{- include "tyr.labels" . | nindent 4 }}
+data:
+  000001_initial_schema.up.sql: |
+    -- Initial schema for tyr saga coordinator
+
+    CREATE TABLE IF NOT EXISTS sagas (
+        id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        tracker_id    TEXT NOT NULL,
+        tracker_type  TEXT NOT NULL,
+        slug          TEXT NOT NULL UNIQUE,
+        repo          TEXT NOT NULL,
+        feature_branch TEXT NOT NULL,
+        confidence    FLOAT DEFAULT 0,
+        created_at    TIMESTAMPTZ DEFAULT NOW()
+    );
+
+    CREATE TABLE IF NOT EXISTS phases (
+        id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        saga_id       UUID NOT NULL REFERENCES sagas(id),
+        tracker_id    TEXT NOT NULL,
+        number        INT NOT NULL,
+        name          TEXT NOT NULL,
+        status        TEXT NOT NULL DEFAULT 'GATED',
+        confidence    FLOAT DEFAULT 0
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_phases_saga_id ON phases(saga_id);
+
+    CREATE TABLE IF NOT EXISTS raids (
+        id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        phase_id      UUID NOT NULL REFERENCES phases(id),
+        tracker_id    TEXT NOT NULL,
+        name          TEXT NOT NULL,
+        declared_files TEXT[],
+        estimate_hours FLOAT,
+        status        TEXT NOT NULL DEFAULT 'PENDING',
+        confidence    FLOAT DEFAULT 0,
+        session_id    TEXT,
+        branch        TEXT,
+        chronicle_summary TEXT,
+        retry_count   INT DEFAULT 0,
+        created_at    TIMESTAMPTZ DEFAULT NOW(),
+        updated_at    TIMESTAMPTZ DEFAULT NOW()
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_raids_phase_id ON raids(phase_id);
+    CREATE INDEX IF NOT EXISTS idx_raids_status ON raids(status);
+
+    CREATE TABLE IF NOT EXISTS confidence_events (
+        id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        raid_id       UUID NOT NULL REFERENCES raids(id),
+        event_type    TEXT NOT NULL,
+        delta         FLOAT NOT NULL,
+        score_after   FLOAT NOT NULL,
+        created_at    TIMESTAMPTZ DEFAULT NOW()
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_confidence_events_raid_id ON confidence_events(raid_id);
+
+    CREATE TABLE IF NOT EXISTS dispatcher_state (
+        id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        running       BOOL DEFAULT TRUE,
+        threshold     FLOAT DEFAULT 0.75,
+        updated_at    TIMESTAMPTZ DEFAULT NOW()
+    );
+
+  000001_initial_schema.down.sql: |
+    -- Rollback initial schema for tyr saga coordinator
+
+    DROP TABLE IF EXISTS confidence_events;
+    DROP TABLE IF EXISTS dispatcher_state;
+    DROP TABLE IF EXISTS raids;
+    DROP TABLE IF EXISTS phases;
+    DROP TABLE IF EXISTS sagas;
+{{- end }}

--- a/charts/tyr/values.yaml
+++ b/charts/tyr/values.yaml
@@ -1,0 +1,2 @@
+migrations:
+  enabled: true

--- a/migrations/tyr/000001_initial_schema.down.sql
+++ b/migrations/tyr/000001_initial_schema.down.sql
@@ -1,0 +1,7 @@
+-- Rollback initial schema for tyr saga coordinator
+
+DROP TABLE IF EXISTS confidence_events;
+DROP TABLE IF EXISTS dispatcher_state;
+DROP TABLE IF EXISTS raids;
+DROP TABLE IF EXISTS phases;
+DROP TABLE IF EXISTS sagas;

--- a/migrations/tyr/000001_initial_schema.up.sql
+++ b/migrations/tyr/000001_initial_schema.up.sql
@@ -1,0 +1,62 @@
+-- Initial schema for tyr saga coordinator
+
+CREATE TABLE IF NOT EXISTS sagas (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tracker_id    TEXT NOT NULL,
+    tracker_type  TEXT NOT NULL,
+    slug          TEXT NOT NULL UNIQUE,
+    repo          TEXT NOT NULL,
+    feature_branch TEXT NOT NULL,
+    confidence    FLOAT DEFAULT 0,
+    created_at    TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS phases (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    saga_id       UUID NOT NULL REFERENCES sagas(id),
+    tracker_id    TEXT NOT NULL,
+    number        INT NOT NULL,
+    name          TEXT NOT NULL,
+    status        TEXT NOT NULL DEFAULT 'GATED',
+    confidence    FLOAT DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_phases_saga_id ON phases(saga_id);
+
+CREATE TABLE IF NOT EXISTS raids (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    phase_id      UUID NOT NULL REFERENCES phases(id),
+    tracker_id    TEXT NOT NULL,
+    name          TEXT NOT NULL,
+    declared_files TEXT[],
+    estimate_hours FLOAT,
+    status        TEXT NOT NULL DEFAULT 'PENDING',
+    confidence    FLOAT DEFAULT 0,
+    session_id    TEXT,
+    branch        TEXT,
+    chronicle_summary TEXT,
+    retry_count   INT DEFAULT 0,
+    created_at    TIMESTAMPTZ DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_raids_phase_id ON raids(phase_id);
+CREATE INDEX IF NOT EXISTS idx_raids_status ON raids(status);
+
+CREATE TABLE IF NOT EXISTS confidence_events (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    raid_id       UUID NOT NULL REFERENCES raids(id),
+    event_type    TEXT NOT NULL,
+    delta         FLOAT NOT NULL,
+    score_after   FLOAT NOT NULL,
+    created_at    TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_confidence_events_raid_id ON confidence_events(raid_id);
+
+CREATE TABLE IF NOT EXISTS dispatcher_state (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    running       BOOL DEFAULT TRUE,
+    threshold     FLOAT DEFAULT 0.75,
+    updated_at    TIMESTAMPTZ DEFAULT NOW()
+);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
 volundr = "volundr.main:main"
 skuld = "volundr.skuld.broker:main"
 bifrost = "volundr.bifrost.__main__:main"
+tyr = "tyr.main:main"
 
 [project.urls]
 Homepage = "https://github.com/niuulabs/volundr"
@@ -62,7 +63,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/volundr"]
+packages = ["src/volundr", "src/tyr"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/tyr/__init__.py
+++ b/src/tyr/__init__.py
@@ -1,0 +1,3 @@
+"""Tyr — saga coordinator service."""
+
+__version__ = "0.1.0"

--- a/src/tyr/__main__.py
+++ b/src/tyr/__main__.py
@@ -1,0 +1,6 @@
+"""Allow running tyr as ``python -m tyr``."""  # pragma: no cover
+
+from tyr.main import main  # pragma: no cover
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/tyr/config.py
+++ b/src/tyr/config.py
@@ -1,0 +1,95 @@
+"""Configuration settings for Tyr.
+
+Configuration is loaded from YAML, with environment variables overriding.
+
+Config file locations (first found wins):
+- ./tyr.yaml
+- /etc/tyr/config.yaml
+
+Environment variable override format:
+- Use double underscore for nested fields: DATABASE__HOST
+"""
+
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+from pydantic_settings import (
+    BaseSettings,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+    YamlConfigSettingsSource,
+)
+
+CONFIG_PATHS = [
+    Path("./tyr.yaml"),
+    Path("/etc/tyr/config.yaml"),
+]
+
+
+class DatabaseConfig(BaseModel):
+    """PostgreSQL database configuration."""
+
+    host: str = Field(default="localhost")
+    port: int = Field(default=5432)
+    user: str = Field(default="tyr")
+    password: str = Field(default="tyr")
+    name: str = Field(default="tyr")
+
+    @property
+    def dsn(self) -> str:
+        """Return PostgreSQL connection string."""
+        return f"postgresql://{self.user}:{self.password}@{self.host}:{self.port}/{self.name}"
+
+
+class LoggingConfig(BaseModel):
+    """Logging configuration."""
+
+    level: str = Field(default="info")
+    format: str = Field(default="text")
+
+
+class Settings(BaseSettings):
+    """Application settings.
+
+    Loads configuration from YAML file with environment variable overrides.
+
+    YAML file locations (first found wins):
+    - ./tyr.yaml
+    - /etc/tyr/config.yaml
+
+    Environment variable overrides use double underscore for nesting:
+    - DATABASE__HOST=myhost -> settings.database.host
+    """
+
+    model_config = SettingsConfigDict(
+        yaml_file=CONFIG_PATHS,
+        yaml_file_encoding="utf-8",
+        env_nested_delimiter="__",
+    )
+
+    logging: LoggingConfig = Field(default_factory=LoggingConfig)
+    database: DatabaseConfig = Field(default_factory=DatabaseConfig)
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        """Customize settings sources.
+
+        Order (first wins):
+        1. init_settings - explicit constructor arguments
+        2. env_settings - environment variables
+        3. yaml - YAML config file
+        4. file_secret_settings - /run/secrets files
+        """
+        return (
+            init_settings,
+            env_settings,
+            YamlConfigSettingsSource(settings_cls),
+            file_secret_settings,
+        )

--- a/src/tyr/main.py
+++ b/src/tyr/main.py
@@ -1,0 +1,52 @@
+"""Application factory for Tyr saga coordinator."""
+
+import os
+
+from fastapi import FastAPI
+
+from tyr.config import Settings
+
+
+def create_app(settings: Settings | None = None) -> FastAPI:
+    """Create and configure the FastAPI application."""
+    if settings is None:
+        settings = Settings()
+
+    app = FastAPI(
+        title="Tyr",
+        description="Saga coordinator service",
+        version="0.1.0",
+    )
+
+    app.state.settings = settings
+
+    @app.get("/health", tags=["Health"])
+    async def health_check() -> dict[str, str]:
+        """Health check endpoint."""
+        return {"status": "healthy"}
+
+    return app
+
+
+app = create_app()
+
+
+def main() -> None:  # pragma: no cover
+    """Run the Tyr API server."""
+    import uvicorn
+
+    host = os.environ.get("HOST", "0.0.0.0")
+    port = int(os.environ.get("PORT", "8081"))
+    workers = int(os.environ.get("WORKERS", "4"))
+
+    uvicorn.run(
+        "tyr.main:app",
+        host=host,
+        port=port,
+        workers=workers,
+        access_log=False,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_tyr/conftest.py
+++ b/tests/test_tyr/conftest.py
@@ -1,0 +1,18 @@
+"""Shared test fixtures for Tyr tests."""
+
+import pytest
+
+from tyr.config import Settings
+from tyr.main import create_app
+
+
+@pytest.fixture
+def tyr_settings() -> Settings:
+    """Create test settings."""
+    return Settings()
+
+
+@pytest.fixture
+def tyr_app(tyr_settings: Settings):
+    """Create a test FastAPI app."""
+    return create_app(tyr_settings)

--- a/tests/test_tyr/test_config.py
+++ b/tests/test_tyr/test_config.py
@@ -1,0 +1,35 @@
+"""Tests for Tyr configuration."""
+
+from tyr.config import DatabaseConfig, LoggingConfig, Settings
+
+
+def test_default_settings() -> None:
+    """Default settings are created without errors."""
+    settings = Settings()
+
+    assert settings.database.host == "localhost"
+    assert settings.database.port == 5432
+    assert settings.database.name == "tyr"
+    assert settings.logging.level == "info"
+    assert settings.logging.format == "text"
+
+
+def test_database_dsn() -> None:
+    """Database DSN is correctly formatted."""
+    config = DatabaseConfig(
+        host="db.example.com",
+        port=5433,
+        user="myuser",
+        password="mypass",
+        name="mydb",
+    )
+
+    assert config.dsn == "postgresql://myuser:mypass@db.example.com:5433/mydb"
+
+
+def test_logging_config_defaults() -> None:
+    """Logging config has sensible defaults."""
+    config = LoggingConfig()
+
+    assert config.level == "info"
+    assert config.format == "text"

--- a/tests/test_tyr/test_health.py
+++ b/tests/test_tyr/test_health.py
@@ -1,0 +1,53 @@
+"""Tests for Tyr health endpoint."""
+
+import httpx
+import pytest
+
+from tyr.config import Settings
+from tyr.main import create_app
+
+
+@pytest.fixture
+def tyr_app():
+    """Create a test FastAPI app."""
+    return create_app()
+
+
+async def test_health_returns_healthy(tyr_app) -> None:
+    """Health endpoint returns status healthy."""
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=tyr_app),
+        base_url="http://test",
+    ) as client:
+        response = await client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "healthy"}
+
+
+async def test_health_method_not_allowed(tyr_app) -> None:
+    """Health endpoint rejects non-GET methods."""
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=tyr_app),
+        base_url="http://test",
+    ) as client:
+        response = await client.post("/health")
+
+    assert response.status_code == 405
+
+
+async def test_create_app_with_custom_settings() -> None:
+    """App can be created with explicit settings."""
+    settings = Settings()
+    app = create_app(settings)
+
+    assert app.state.settings is settings
+    assert app.title == "Tyr"
+
+
+async def test_create_app_default_settings() -> None:
+    """App created without args uses default settings."""
+    app = create_app()
+
+    assert app.state.settings is not None
+    assert app.version == "0.1.0"


### PR DESCRIPTION
## Summary

- Creates `migrations/tyr/000001_initial_schema.{up,down}.sql` with idempotent DDL for all 5 Tyr tables: `sagas`, `phases`, `raids`, `confidence_events`, `dispatcher_state`
- Adds indexes on foreign keys and status columns
- Embeds the same SQL in `charts/tyr/templates/migrations-configmap.yaml` (dual location requirement)
- Creates minimal `charts/tyr/Chart.yaml` for valid Helm chart

Closes NIU-216. Depends on NIU-210 (#98).

## Test plan

- [ ] `helm lint charts/tyr/` passes
- [ ] SQL is idempotent (can run multiple times without error)
- [ ] Up migration creates all 5 tables with correct columns
- [ ] Down migration drops all tables in correct dependency order
- [ ] ConfigMap SQL matches local migration files exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)