### PR TITLE
feat(tyr): add domain models, port interfaces, and hexagonal FastAPI skeleton

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -118,8 +118,8 @@ jobs:
         run: uv run ruff format --check src/ tests/ || echo "::warning::Formatting issues found - consider running 'ruff format src/ tests/'"
         continue-on-error: true
 
-  python-test:
-    name: "Python: Test"
+  python-test-volundr:
+    name: "Python: Test Volundr"
     needs: changes
     if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
@@ -139,7 +139,7 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          uv run pytest tests/ -v --tb=short \
+          uv run pytest tests/ --ignore=tests/test_tyr -v --tb=short \
             --cov=src/volundr \
             --cov-report=term-missing \
             --cov-report=xml \
@@ -149,7 +149,41 @@ jobs:
         uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5
         with:
           files: coverage.xml
-          flags: backend
+          flags: backend-volundr
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  python-test-tyr:
+    name: "Python: Test Tyr"
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --all-extras --dev
+
+      - name: Run tests with coverage
+        run: |
+          uv run pytest tests/test_tyr -v --tb=short \
+            --cov=src/tyr \
+            --cov-report=term-missing \
+            --cov-report=xml \
+            --cov-fail-under=85
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5
+        with:
+          files: coverage.xml
+          flags: backend-tyr
           token: ${{ secrets.CODECOV_TOKEN }}
 
   # ---------------------------------------------------------------------------

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -174,6 +174,7 @@ jobs:
       - name: Run tests with coverage
         run: |
           uv run pytest tests/test_tyr -v --tb=short \
+            --override-ini="addopts=" \
             --cov=src/tyr \
             --cov-report=term-missing \
             --cov-report=xml \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
 volundr = "volundr.main:main"
 skuld = "volundr.skuld.broker:main"
 bifrost = "volundr.bifrost.__main__:main"
+tyr = "tyr.main:main"
 
 [project.urls]
 Homepage = "https://github.com/niuulabs/volundr"
@@ -62,7 +63,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/volundr"]
+packages = ["src/volundr", "src/tyr"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/tyr/__init__.py
+++ b/src/tyr/__init__.py
@@ -1,0 +1,3 @@
+"""Tyr — saga coordinator service."""
+
+__version__ = "0.1.0"

--- a/src/tyr/__init__.py
+++ b/src/tyr/__init__.py
@@ -1,3 +1,1 @@
-"""Tyr — saga coordinator service."""
-
-__version__ = "0.1.0"
+"""Tyr — saga coordinator for decomposing specs into raids."""

--- a/src/tyr/__main__.py
+++ b/src/tyr/__main__.py
@@ -1,0 +1,6 @@
+"""Allow running tyr as ``python -m tyr``."""  # pragma: no cover
+
+from tyr.main import main  # pragma: no cover
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/tyr/api/__init__.py
+++ b/src/tyr/api/__init__.py
@@ -1,0 +1,1 @@
+"""API layer for the Tyr saga coordinator."""

--- a/src/tyr/config.py
+++ b/src/tyr/config.py
@@ -1,0 +1,95 @@
+"""Configuration settings for Tyr.
+
+Configuration is loaded from YAML, with environment variables overriding.
+
+Config file locations (first found wins):
+- ./tyr.yaml
+- /etc/tyr/config.yaml
+
+Environment variable override format:
+- Use double underscore for nested fields: DATABASE__HOST
+"""
+
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+from pydantic_settings import (
+    BaseSettings,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+    YamlConfigSettingsSource,
+)
+
+CONFIG_PATHS = [
+    Path("./tyr.yaml"),
+    Path("/etc/tyr/config.yaml"),
+]
+
+
+class DatabaseConfig(BaseModel):
+    """PostgreSQL database configuration."""
+
+    host: str = Field(default="localhost")
+    port: int = Field(default=5432)
+    user: str = Field(default="tyr")
+    password: str = Field(default="tyr")
+    name: str = Field(default="tyr")
+
+    @property
+    def dsn(self) -> str:
+        """Return PostgreSQL connection string."""
+        return f"postgresql://{self.user}:{self.password}@{self.host}:{self.port}/{self.name}"
+
+
+class LoggingConfig(BaseModel):
+    """Logging configuration."""
+
+    level: str = Field(default="info")
+    format: str = Field(default="text")
+
+
+class Settings(BaseSettings):
+    """Application settings.
+
+    Loads configuration from YAML file with environment variable overrides.
+
+    YAML file locations (first found wins):
+    - ./tyr.yaml
+    - /etc/tyr/config.yaml
+
+    Environment variable overrides use double underscore for nesting:
+    - DATABASE__HOST=myhost -> settings.database.host
+    """
+
+    model_config = SettingsConfigDict(
+        yaml_file=CONFIG_PATHS,
+        yaml_file_encoding="utf-8",
+        env_nested_delimiter="__",
+    )
+
+    logging: LoggingConfig = Field(default_factory=LoggingConfig)
+    database: DatabaseConfig = Field(default_factory=DatabaseConfig)
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        """Customize settings sources.
+
+        Order (first wins):
+        1. init_settings - explicit constructor arguments
+        2. env_settings - environment variables
+        3. yaml - YAML config file
+        4. file_secret_settings - /run/secrets files
+        """
+        return (
+            init_settings,
+            env_settings,
+            YamlConfigSettingsSource(settings_cls),
+            file_secret_settings,
+        )

--- a/src/tyr/config.py
+++ b/src/tyr/config.py
@@ -1,29 +1,8 @@
-"""Configuration settings for Tyr.
+"""Configuration for the Tyr saga coordinator."""
 
-Configuration is loaded from YAML, with environment variables overriding.
-
-Config file locations (first found wins):
-- ./tyr.yaml
-- /etc/tyr/config.yaml
-
-Environment variable override format:
-- Use double underscore for nested fields: DATABASE__HOST
-"""
-
-from pathlib import Path
+from __future__ import annotations
 
 from pydantic import BaseModel, Field
-from pydantic_settings import (
-    BaseSettings,
-    PydanticBaseSettingsSource,
-    SettingsConfigDict,
-    YamlConfigSettingsSource,
-)
-
-CONFIG_PATHS = [
-    Path("./tyr.yaml"),
-    Path("/etc/tyr/config.yaml"),
-]
 
 
 class DatabaseConfig(BaseModel):
@@ -34,6 +13,8 @@ class DatabaseConfig(BaseModel):
     user: str = Field(default="tyr")
     password: str = Field(default="tyr")
     name: str = Field(default="tyr")
+    min_pool_size: int = Field(default=5)
+    max_pool_size: int = Field(default=20)
 
     @property
     def dsn(self) -> str:
@@ -44,52 +25,12 @@ class DatabaseConfig(BaseModel):
 class LoggingConfig(BaseModel):
     """Logging configuration."""
 
-    level: str = Field(default="info")
-    format: str = Field(default="text")
+    level: str = Field(default="INFO")
+    format: str = Field(default="json")
 
 
-class Settings(BaseSettings):
-    """Application settings.
+class Settings(BaseModel):
+    """Top-level application settings."""
 
-    Loads configuration from YAML file with environment variable overrides.
-
-    YAML file locations (first found wins):
-    - ./tyr.yaml
-    - /etc/tyr/config.yaml
-
-    Environment variable overrides use double underscore for nesting:
-    - DATABASE__HOST=myhost -> settings.database.host
-    """
-
-    model_config = SettingsConfigDict(
-        yaml_file=CONFIG_PATHS,
-        yaml_file_encoding="utf-8",
-        env_nested_delimiter="__",
-    )
-
-    logging: LoggingConfig = Field(default_factory=LoggingConfig)
     database: DatabaseConfig = Field(default_factory=DatabaseConfig)
-
-    @classmethod
-    def settings_customise_sources(
-        cls,
-        settings_cls: type[BaseSettings],
-        init_settings: PydanticBaseSettingsSource,
-        env_settings: PydanticBaseSettingsSource,
-        dotenv_settings: PydanticBaseSettingsSource,
-        file_secret_settings: PydanticBaseSettingsSource,
-    ) -> tuple[PydanticBaseSettingsSource, ...]:
-        """Customize settings sources.
-
-        Order (first wins):
-        1. init_settings - explicit constructor arguments
-        2. env_settings - environment variables
-        3. yaml - YAML config file
-        4. file_secret_settings - /run/secrets files
-        """
-        return (
-            init_settings,
-            env_settings,
-            YamlConfigSettingsSource(settings_cls),
-            file_secret_settings,
-        )
+    logging: LoggingConfig = Field(default_factory=LoggingConfig)

--- a/src/tyr/config.py
+++ b/src/tyr/config.py
@@ -1,8 +1,31 @@
-"""Configuration for the Tyr saga coordinator."""
+"""Configuration settings for Tyr.
+
+Configuration is loaded from YAML, with environment variables overriding.
+
+Config file locations (first found wins):
+- ./tyr.yaml
+- /etc/tyr/config.yaml
+
+Environment variable override format:
+- Use double underscore for nested fields: DATABASE__HOST
+"""
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from pydantic import BaseModel, Field
+from pydantic_settings import (
+    BaseSettings,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+    YamlConfigSettingsSource,
+)
+
+CONFIG_PATHS = [
+    Path("./tyr.yaml"),
+    Path("/etc/tyr/config.yaml"),
+]
 
 
 class DatabaseConfig(BaseModel):
@@ -25,12 +48,52 @@ class DatabaseConfig(BaseModel):
 class LoggingConfig(BaseModel):
     """Logging configuration."""
 
-    level: str = Field(default="INFO")
-    format: str = Field(default="json")
+    level: str = Field(default="info")
+    format: str = Field(default="text")
 
 
-class Settings(BaseModel):
-    """Top-level application settings."""
+class Settings(BaseSettings):
+    """Application settings.
 
-    database: DatabaseConfig = Field(default_factory=DatabaseConfig)
+    Loads configuration from YAML file with environment variable overrides.
+
+    YAML file locations (first found wins):
+    - ./tyr.yaml
+    - /etc/tyr/config.yaml
+
+    Environment variable overrides use double underscore for nesting:
+    - DATABASE__HOST=myhost -> settings.database.host
+    """
+
+    model_config = SettingsConfigDict(
+        yaml_file=CONFIG_PATHS,
+        yaml_file_encoding="utf-8",
+        env_nested_delimiter="__",
+    )
+
     logging: LoggingConfig = Field(default_factory=LoggingConfig)
+    database: DatabaseConfig = Field(default_factory=DatabaseConfig)
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        """Customize settings sources.
+
+        Order (first wins):
+        1. init_settings - explicit constructor arguments
+        2. env_settings - environment variables
+        3. yaml - YAML config file
+        4. file_secret_settings - /run/secrets files
+        """
+        return (
+            init_settings,
+            env_settings,
+            YamlConfigSettingsSource(settings_cls),
+            file_secret_settings,
+        )

--- a/src/tyr/domain/__init__.py
+++ b/src/tyr/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Domain models for the Tyr saga coordinator."""

--- a/src/tyr/domain/exceptions.py
+++ b/src/tyr/domain/exceptions.py
@@ -1,0 +1,10 @@
+"""Domain exceptions for the Tyr saga coordinator."""
+
+
+class InvalidStateTransitionError(Exception):
+    """Raised when an invalid state transition is attempted on a Raid."""
+
+    def __init__(self, current: str, target: str) -> None:
+        self.current = current
+        self.target = target
+        super().__init__(f"Invalid state transition: {current} -> {target}")

--- a/src/tyr/domain/models.py
+++ b/src/tyr/domain/models.py
@@ -1,0 +1,168 @@
+"""Domain models for the Tyr saga coordinator."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+from uuid import UUID
+
+from tyr.domain.exceptions import InvalidStateTransitionError
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class SagaStatus(StrEnum):
+    ACTIVE = "ACTIVE"
+    COMPLETE = "COMPLETE"
+    FAILED = "FAILED"
+
+
+class PhaseStatus(StrEnum):
+    PENDING = "PENDING"
+    ACTIVE = "ACTIVE"
+    GATED = "GATED"
+    COMPLETE = "COMPLETE"
+
+
+class RaidStatus(StrEnum):
+    PENDING = "PENDING"
+    QUEUED = "QUEUED"
+    RUNNING = "RUNNING"
+    REVIEW = "REVIEW"
+    MERGED = "MERGED"
+    FAILED = "FAILED"
+
+
+class ConfidenceEventType(StrEnum):
+    CI_PASS = "ci_pass"
+    CI_FAIL = "ci_fail"
+    SCOPE_BREACH = "scope_breach"
+    RETRY = "retry"
+    HUMAN_REJECT = "human_reject"
+
+
+# ---------------------------------------------------------------------------
+# State machine
+# ---------------------------------------------------------------------------
+
+RAID_TRANSITIONS: dict[RaidStatus, frozenset[RaidStatus]] = {
+    RaidStatus.PENDING: frozenset({RaidStatus.QUEUED}),
+    RaidStatus.QUEUED: frozenset({RaidStatus.RUNNING, RaidStatus.FAILED}),
+    RaidStatus.RUNNING: frozenset({RaidStatus.REVIEW, RaidStatus.MERGED, RaidStatus.FAILED}),
+    RaidStatus.REVIEW: frozenset({RaidStatus.QUEUED, RaidStatus.MERGED, RaidStatus.FAILED}),
+    RaidStatus.MERGED: frozenset(),
+    RaidStatus.FAILED: frozenset({RaidStatus.QUEUED}),
+}
+
+
+def validate_transition(current: RaidStatus, target: RaidStatus) -> None:
+    """Validate a raid state transition, raising on invalid moves."""
+    allowed = RAID_TRANSITIONS.get(current, frozenset())
+    if target not in allowed:
+        raise InvalidStateTransitionError(current, target)
+
+
+# ---------------------------------------------------------------------------
+# Entities
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Saga:
+    id: UUID
+    tracker_id: str
+    tracker_type: str
+    slug: str
+    repo: str
+    feature_branch: str
+    confidence: float
+    created_at: datetime
+
+
+@dataclass(frozen=True)
+class Phase:
+    id: UUID
+    saga_id: UUID
+    tracker_id: str
+    number: int
+    name: str
+    status: PhaseStatus
+    confidence: float
+
+
+@dataclass(frozen=True)
+class Raid:
+    id: UUID
+    phase_id: UUID
+    tracker_id: str
+    name: str
+    declared_files: list[str]
+    estimate_hours: float | None
+    status: RaidStatus
+    confidence: float
+    session_id: str | None
+    branch: str | None
+    chronicle_summary: str | None
+    retry_count: int
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class ConfidenceEvent:
+    id: UUID
+    raid_id: UUID
+    event_type: ConfidenceEventType
+    delta: float
+    score_after: float
+    created_at: datetime
+
+
+@dataclass(frozen=True)
+class DispatcherState:
+    id: UUID
+    running: bool
+    threshold: float
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class SessionInfo:
+    session_id: str
+    status: str
+
+
+@dataclass(frozen=True)
+class PRStatus:
+    pr_id: str
+    state: str
+    mergeable: bool
+    ci_passed: bool | None
+
+
+# ---------------------------------------------------------------------------
+# Spec structures (LLM decomposition output)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RaidSpec:
+    name: str
+    description: str
+    acceptance_criteria: list[str]
+    declared_files: list[str]
+    estimate_hours: float
+
+
+@dataclass(frozen=True)
+class PhaseSpec:
+    name: str
+    raids: list[RaidSpec]
+
+
+@dataclass(frozen=True)
+class SagaStructure:
+    phases: list[PhaseSpec]

--- a/src/tyr/domain/models.py
+++ b/src/tyr/domain/models.py
@@ -76,8 +76,10 @@ class Saga:
     tracker_id: str
     tracker_type: str
     slug: str
+    name: str
     repo: str
     feature_branch: str
+    status: SagaStatus
     confidence: float
     created_at: datetime
 
@@ -99,6 +101,8 @@ class Raid:
     phase_id: UUID
     tracker_id: str
     name: str
+    description: str
+    acceptance_criteria: list[str]
     declared_files: list[str]
     estimate_hours: float | None
     status: RaidStatus

--- a/src/tyr/infrastructure/__init__.py
+++ b/src/tyr/infrastructure/__init__.py
@@ -1,0 +1,1 @@
+"""Infrastructure layer for the Tyr saga coordinator."""

--- a/src/tyr/infrastructure/database.py
+++ b/src/tyr/infrastructure/database.py
@@ -1,0 +1,40 @@
+"""Database infrastructure for PostgreSQL."""
+
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+
+import asyncpg
+
+from tyr.config import DatabaseConfig
+
+
+async def create_pool(config: DatabaseConfig) -> asyncpg.Pool:
+    """Create an asyncpg connection pool."""
+    return await asyncpg.create_pool(
+        host=config.host,
+        port=config.port,
+        user=config.user,
+        password=config.password,
+        database=config.name,
+        min_size=config.min_pool_size,
+        max_size=config.max_pool_size,
+    )
+
+
+async def init_db(pool: asyncpg.Pool) -> None:
+    """Initialize database schema.
+
+    Note: Schema migrations are handled by the migrate init container
+    in Kubernetes. This is a no-op placeholder for development.
+    """
+
+
+@asynccontextmanager
+async def database_pool(config: DatabaseConfig) -> AsyncGenerator[asyncpg.Pool, None]:
+    """Context manager for database pool lifecycle."""
+    pool = await create_pool(config)
+    try:
+        await init_db(pool)
+        yield pool
+    finally:
+        await pool.close()

--- a/src/tyr/main.py
+++ b/src/tyr/main.py
@@ -71,12 +71,24 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 app = create_app()
 
 
-def main() -> None:
+def main() -> None:  # pragma: no cover
     """Run the Tyr API server."""
+    import os
+
     import uvicorn
 
-    uvicorn.run("tyr.main:app", host="0.0.0.0", port=8001, reload=True)  # noqa: S104
+    host = os.environ.get("HOST", "0.0.0.0")
+    port = int(os.environ.get("PORT", "8081"))
+    workers = int(os.environ.get("WORKERS", "4"))
+
+    uvicorn.run(
+        "tyr.main:app",
+        host=host,
+        port=port,
+        workers=workers,
+        access_log=False,
+    )
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/src/tyr/main.py
+++ b/src/tyr/main.py
@@ -1,0 +1,52 @@
+"""Application factory for Tyr saga coordinator."""
+
+import os
+
+from fastapi import FastAPI
+
+from tyr.config import Settings
+
+
+def create_app(settings: Settings | None = None) -> FastAPI:
+    """Create and configure the FastAPI application."""
+    if settings is None:
+        settings = Settings()
+
+    app = FastAPI(
+        title="Tyr",
+        description="Saga coordinator service",
+        version="0.1.0",
+    )
+
+    app.state.settings = settings
+
+    @app.get("/health", tags=["Health"])
+    async def health_check() -> dict[str, str]:
+        """Health check endpoint."""
+        return {"status": "healthy"}
+
+    return app
+
+
+app = create_app()
+
+
+def main() -> None:  # pragma: no cover
+    """Run the Tyr API server."""
+    import uvicorn
+
+    host = os.environ.get("HOST", "0.0.0.0")
+    port = int(os.environ.get("PORT", "8081"))
+    workers = int(os.environ.get("WORKERS", "4"))
+
+    uvicorn.run(
+        "tyr.main:app",
+        host=host,
+        port=port,
+        workers=workers,
+        access_log=False,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/tyr/main.py
+++ b/src/tyr/main.py
@@ -1,10 +1,28 @@
-"""Application factory for Tyr saga coordinator."""
+"""Tyr — saga coordinator FastAPI application."""
 
-import os
+from __future__ import annotations
 
-from fastapi import FastAPI
+import logging
+import uuid
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI, Request, Response
 
 from tyr.config import Settings
+from tyr.infrastructure.database import database_pool
+
+logger = logging.getLogger(__name__)
+
+
+def _configure_logging(settings: Settings) -> None:
+    """Configure structured logging based on settings."""
+    logging.basicConfig(
+        level=getattr(logging, settings.logging.level.upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s [%(correlation_id)s] %(message)s"
+        if settings.logging.format == "text"
+        else "%(message)s",
+    )
 
 
 def create_app(settings: Settings | None = None) -> FastAPI:
@@ -12,18 +30,40 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     if settings is None:
         settings = Settings()
 
+    _configure_logging(settings)
+
     app = FastAPI(
-        title="Tyr",
-        description="Saga coordinator service",
+        title="Tyr — Saga Coordinator",
+        description="Decomposes specs into sagas, phases, and raids.",
         version="0.1.0",
     )
 
     app.state.settings = settings
 
-    @app.get("/health", tags=["Health"])
-    async def health_check() -> dict[str, str]:
-        """Health check endpoint."""
-        return {"status": "healthy"}
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+        """Manage application lifecycle."""
+        settings = app.state.settings
+        async with database_pool(settings.database) as pool:
+            app.state.pool = pool
+            logger.info("Tyr started — database pool ready")
+            yield
+            logger.info("Tyr shutting down")
+
+    app.router.lifespan_context = lifespan
+
+    @app.middleware("http")
+    async def correlation_id_middleware(request: Request, call_next):  # noqa: ANN001
+        """Attach a correlation ID to every request."""
+        correlation_id = request.headers.get("X-Correlation-ID", str(uuid.uuid4()))
+        request.state.correlation_id = correlation_id
+        response: Response = await call_next(request)
+        response.headers["X-Correlation-ID"] = correlation_id
+        return response
+
+    @app.get("/health")
+    async def health() -> dict[str, str]:
+        return {"status": "ok"}
 
     return app
 
@@ -31,22 +71,12 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 app = create_app()
 
 
-def main() -> None:  # pragma: no cover
+def main() -> None:
     """Run the Tyr API server."""
     import uvicorn
 
-    host = os.environ.get("HOST", "0.0.0.0")
-    port = int(os.environ.get("PORT", "8081"))
-    workers = int(os.environ.get("WORKERS", "4"))
-
-    uvicorn.run(
-        "tyr.main:app",
-        host=host,
-        port=port,
-        workers=workers,
-        access_log=False,
-    )
+    uvicorn.run("tyr.main:app", host="0.0.0.0", port=8001, reload=True)  # noqa: S104
 
 
-if __name__ == "__main__":  # pragma: no cover
+if __name__ == "__main__":
     main()

--- a/src/tyr/ports/__init__.py
+++ b/src/tyr/ports/__init__.py
@@ -1,0 +1,1 @@
+"""Port interfaces for the Tyr saga coordinator."""

--- a/src/tyr/ports/confidence.py
+++ b/src/tyr/ports/confidence.py
@@ -1,0 +1,20 @@
+"""Confidence port — interface for raid confidence scoring."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from tyr.domain.models import ConfidenceEvent, Raid
+
+
+class ConfidencePort(ABC):
+    """Abstract interface for confidence score management."""
+
+    @abstractmethod
+    async def score_initial(self, raid: Raid) -> float: ...
+
+    @abstractmethod
+    async def update_score(self, raid_id: str, event: ConfidenceEvent) -> float: ...
+
+    @abstractmethod
+    async def get_score(self, raid_id: str) -> float: ...

--- a/src/tyr/ports/git.py
+++ b/src/tyr/ports/git.py
@@ -1,0 +1,23 @@
+"""Git port — interface for branch and PR operations."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from tyr.domain.models import PRStatus
+
+
+class GitPort(ABC):
+    """Abstract interface for Git/SCM operations."""
+
+    @abstractmethod
+    async def create_branch(self, repo: str, branch: str, base: str) -> None: ...
+
+    @abstractmethod
+    async def merge_branch(self, repo: str, source: str, target: str) -> None: ...
+
+    @abstractmethod
+    async def create_pr(self, repo: str, source: str, target: str, title: str) -> str: ...
+
+    @abstractmethod
+    async def get_pr_status(self, pr_id: str) -> PRStatus: ...

--- a/src/tyr/ports/llm.py
+++ b/src/tyr/ports/llm.py
@@ -1,0 +1,14 @@
+"""LLM port — interface for spec decomposition."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from tyr.domain.models import SagaStructure
+
+
+class LLMPort(ABC):
+    """Abstract interface for LLM-based spec decomposition."""
+
+    @abstractmethod
+    async def decompose_spec(self, spec: str, repo: str) -> SagaStructure: ...

--- a/src/tyr/ports/tracker.py
+++ b/src/tyr/ports/tracker.py
@@ -1,0 +1,32 @@
+"""Tracker port — interface for issue/work-item tracking systems."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from tyr.domain.models import Phase, Raid, RaidStatus, Saga
+
+
+class TrackerPort(ABC):
+    """Abstract interface for tracker integration (Linear, Jira, etc.)."""
+
+    @abstractmethod
+    async def create_saga(self, saga: Saga) -> str: ...
+
+    @abstractmethod
+    async def create_phase(self, phase: Phase) -> str: ...
+
+    @abstractmethod
+    async def create_raid(self, raid: Raid) -> str: ...
+
+    @abstractmethod
+    async def update_raid_state(self, raid_id: str, state: RaidStatus) -> None: ...
+
+    @abstractmethod
+    async def close_raid(self, raid_id: str) -> None: ...
+
+    @abstractmethod
+    async def get_saga(self, saga_id: str) -> Saga: ...
+
+    @abstractmethod
+    async def list_pending_raids(self, phase_id: str) -> list[Raid]: ...

--- a/src/tyr/ports/volundr.py
+++ b/src/tyr/ports/volundr.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
-from tyr.domain.models import Raid, SessionInfo
+from tyr.domain.models import PRStatus, Raid, SessionInfo
 
 
 class VolundrPort(ABC):
@@ -21,3 +21,6 @@ class VolundrPort(ABC):
 
     @abstractmethod
     async def get_chronicle_summary(self, session_id: str) -> str: ...
+
+    @abstractmethod
+    async def get_pr_status(self, session_id: str) -> PRStatus: ...

--- a/src/tyr/ports/volundr.py
+++ b/src/tyr/ports/volundr.py
@@ -1,0 +1,23 @@
+"""Volundr port — interface for session lifecycle management."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from tyr.domain.models import Raid, SessionInfo
+
+
+class VolundrPort(ABC):
+    """Abstract interface for Volundr session management."""
+
+    @abstractmethod
+    async def spawn_session(self, raid: Raid, branch: str) -> str: ...
+
+    @abstractmethod
+    async def get_session(self, session_id: str) -> SessionInfo: ...
+
+    @abstractmethod
+    async def stop_session(self, session_id: str) -> None: ...
+
+    @abstractmethod
+    async def get_chronicle_summary(self, session_id: str) -> str: ...

--- a/tests/test_tyr/conftest.py
+++ b/tests/test_tyr/conftest.py
@@ -1,18 +1,1 @@
-"""Shared test fixtures for Tyr tests."""
-
-import pytest
-
-from tyr.config import Settings
-from tyr.main import create_app
-
-
-@pytest.fixture
-def tyr_settings() -> Settings:
-    """Create test settings."""
-    return Settings()
-
-
-@pytest.fixture
-def tyr_app(tyr_settings: Settings):
-    """Create a test FastAPI app."""
-    return create_app(tyr_settings)
+"""Shared fixtures for Tyr tests."""

--- a/tests/test_tyr/conftest.py
+++ b/tests/test_tyr/conftest.py
@@ -1,0 +1,18 @@
+"""Shared test fixtures for Tyr tests."""
+
+import pytest
+
+from tyr.config import Settings
+from tyr.main import create_app
+
+
+@pytest.fixture
+def tyr_settings() -> Settings:
+    """Create test settings."""
+    return Settings()
+
+
+@pytest.fixture
+def tyr_app(tyr_settings: Settings):
+    """Create a test FastAPI app."""
+    return create_app(tyr_settings)

--- a/tests/test_tyr/test_config.py
+++ b/tests/test_tyr/test_config.py
@@ -1,0 +1,35 @@
+"""Tests for Tyr configuration."""
+
+from tyr.config import DatabaseConfig, LoggingConfig, Settings
+
+
+def test_default_settings() -> None:
+    """Default settings are created without errors."""
+    settings = Settings()
+
+    assert settings.database.host == "localhost"
+    assert settings.database.port == 5432
+    assert settings.database.name == "tyr"
+    assert settings.logging.level == "info"
+    assert settings.logging.format == "text"
+
+
+def test_database_dsn() -> None:
+    """Database DSN is correctly formatted."""
+    config = DatabaseConfig(
+        host="db.example.com",
+        port=5433,
+        user="myuser",
+        password="mypass",
+        name="mydb",
+    )
+
+    assert config.dsn == "postgresql://myuser:mypass@db.example.com:5433/mydb"
+
+
+def test_logging_config_defaults() -> None:
+    """Logging config has sensible defaults."""
+    config = LoggingConfig()
+
+    assert config.level == "info"
+    assert config.format == "text"

--- a/tests/test_tyr/test_config.py
+++ b/tests/test_tyr/test_config.py
@@ -27,8 +27,8 @@ class TestDatabaseConfig:
 class TestLoggingConfig:
     def test_defaults(self) -> None:
         config = LoggingConfig()
-        assert config.level == "INFO"
-        assert config.format == "json"
+        assert config.level == "info"
+        assert config.format == "text"
 
 
 class TestSettings:

--- a/tests/test_tyr/test_config.py
+++ b/tests/test_tyr/test_config.py
@@ -3,33 +3,40 @@
 from tyr.config import DatabaseConfig, LoggingConfig, Settings
 
 
-def test_default_settings() -> None:
-    """Default settings are created without errors."""
-    settings = Settings()
+class TestDatabaseConfig:
+    def test_defaults(self) -> None:
+        config = DatabaseConfig()
+        assert config.host == "localhost"
+        assert config.port == 5432
+        assert config.user == "tyr"
+        assert config.password == "tyr"
+        assert config.name == "tyr"
+        assert config.min_pool_size == 5
+        assert config.max_pool_size == 20
 
-    assert settings.database.host == "localhost"
-    assert settings.database.port == 5432
-    assert settings.database.name == "tyr"
-    assert settings.logging.level == "info"
-    assert settings.logging.format == "text"
+    def test_dsn(self) -> None:
+        config = DatabaseConfig(host="db", port=5433, user="u", password="p", name="mydb")
+        assert config.dsn == "postgresql://u:p@db:5433/mydb"
 
-
-def test_database_dsn() -> None:
-    """Database DSN is correctly formatted."""
-    config = DatabaseConfig(
-        host="db.example.com",
-        port=5433,
-        user="myuser",
-        password="mypass",
-        name="mydb",
-    )
-
-    assert config.dsn == "postgresql://myuser:mypass@db.example.com:5433/mydb"
+    def test_custom_values(self) -> None:
+        config = DatabaseConfig(host="prod-db", min_pool_size=10, max_pool_size=50)
+        assert config.host == "prod-db"
+        assert config.min_pool_size == 10
 
 
-def test_logging_config_defaults() -> None:
-    """Logging config has sensible defaults."""
-    config = LoggingConfig()
+class TestLoggingConfig:
+    def test_defaults(self) -> None:
+        config = LoggingConfig()
+        assert config.level == "INFO"
+        assert config.format == "json"
 
-    assert config.level == "info"
-    assert config.format == "text"
+
+class TestSettings:
+    def test_defaults(self) -> None:
+        settings = Settings()
+        assert isinstance(settings.database, DatabaseConfig)
+        assert isinstance(settings.logging, LoggingConfig)
+
+    def test_nested_override(self) -> None:
+        settings = Settings(database=DatabaseConfig(host="custom-host"))
+        assert settings.database.host == "custom-host"

--- a/tests/test_tyr/test_health.py
+++ b/tests/test_tyr/test_health.py
@@ -1,0 +1,53 @@
+"""Tests for Tyr health endpoint."""
+
+import httpx
+import pytest
+
+from tyr.config import Settings
+from tyr.main import create_app
+
+
+@pytest.fixture
+def tyr_app():
+    """Create a test FastAPI app."""
+    return create_app()
+
+
+async def test_health_returns_healthy(tyr_app) -> None:
+    """Health endpoint returns status healthy."""
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=tyr_app),
+        base_url="http://test",
+    ) as client:
+        response = await client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "healthy"}
+
+
+async def test_health_method_not_allowed(tyr_app) -> None:
+    """Health endpoint rejects non-GET methods."""
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=tyr_app),
+        base_url="http://test",
+    ) as client:
+        response = await client.post("/health")
+
+    assert response.status_code == 405
+
+
+async def test_create_app_with_custom_settings() -> None:
+    """App can be created with explicit settings."""
+    settings = Settings()
+    app = create_app(settings)
+
+    assert app.state.settings is settings
+    assert app.title == "Tyr"
+
+
+async def test_create_app_default_settings() -> None:
+    """App created without args uses default settings."""
+    app = create_app()
+
+    assert app.state.settings is not None
+    assert app.version == "0.1.0"

--- a/tests/test_tyr/test_health.py
+++ b/tests/test_tyr/test_health.py
@@ -1,53 +1,40 @@
 """Tests for Tyr health endpoint."""
 
-import httpx
+from unittest.mock import AsyncMock, patch
+
 import pytest
+from fastapi.testclient import TestClient
 
 from tyr.config import Settings
 from tyr.main import create_app
 
 
 @pytest.fixture
-def tyr_app():
-    """Create a test FastAPI app."""
-    return create_app()
-
-
-async def test_health_returns_healthy(tyr_app) -> None:
-    """Health endpoint returns status healthy."""
-    async with httpx.AsyncClient(
-        transport=httpx.ASGITransport(app=tyr_app),
-        base_url="http://test",
-    ) as client:
-        response = await client.get("/health")
-
-    assert response.status_code == 200
-    assert response.json() == {"status": "healthy"}
-
-
-async def test_health_method_not_allowed(tyr_app) -> None:
-    """Health endpoint rejects non-GET methods."""
-    async with httpx.AsyncClient(
-        transport=httpx.ASGITransport(app=tyr_app),
-        base_url="http://test",
-    ) as client:
-        response = await client.post("/health")
-
-    assert response.status_code == 405
-
-
-async def test_create_app_with_custom_settings() -> None:
-    """App can be created with explicit settings."""
+def client() -> TestClient:
+    """Create a test client with mocked database pool."""
     settings = Settings()
     app = create_app(settings)
 
-    assert app.state.settings is settings
-    assert app.title == "Tyr"
+    mock_pool = AsyncMock()
+    mock_pool.close = AsyncMock()
+
+    with patch("tyr.main.database_pool") as mock_db:
+        mock_db.return_value.__aenter__ = AsyncMock(return_value=mock_pool)
+        mock_db.return_value.__aexit__ = AsyncMock(return_value=False)
+        with TestClient(app) as c:
+            yield c
 
 
-async def test_create_app_default_settings() -> None:
-    """App created without args uses default settings."""
-    app = create_app()
+class TestHealthEndpoint:
+    def test_health_returns_ok(self, client: TestClient) -> None:
+        response = client.get("/health")
+        assert response.status_code == 200
+        assert response.json() == {"status": "ok"}
 
-    assert app.state.settings is not None
-    assert app.version == "0.1.0"
+    def test_health_has_correlation_id(self, client: TestClient) -> None:
+        response = client.get("/health")
+        assert "x-correlation-id" in response.headers
+
+    def test_health_preserves_correlation_id(self, client: TestClient) -> None:
+        response = client.get("/health", headers={"X-Correlation-ID": "test-123"})
+        assert response.headers["x-correlation-id"] == "test-123"

--- a/tests/test_tyr/test_infrastructure.py
+++ b/tests/test_tyr/test_infrastructure.py
@@ -1,0 +1,77 @@
+"""Tests for Tyr infrastructure layer."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tyr.config import DatabaseConfig
+from tyr.infrastructure.database import create_pool, database_pool, init_db
+
+
+class TestCreatePool:
+    @pytest.mark.asyncio
+    async def test_create_pool_calls_asyncpg(self) -> None:
+        config = DatabaseConfig(
+            host="db-host",
+            port=5433,
+            user="tyr_user",
+            password="secret",
+            name="tyr_db",
+            min_pool_size=2,
+            max_pool_size=10,
+        )
+        mock_pool = MagicMock()
+
+        with patch("tyr.infrastructure.database.asyncpg.create_pool", new_callable=AsyncMock) as m:
+            m.return_value = mock_pool
+            result = await create_pool(config)
+
+        assert result is mock_pool
+        m.assert_called_once_with(
+            host="db-host",
+            port=5433,
+            user="tyr_user",
+            password="secret",
+            database="tyr_db",
+            min_size=2,
+            max_size=10,
+        )
+
+
+class TestInitDb:
+    @pytest.mark.asyncio
+    async def test_init_db_is_noop(self) -> None:
+        mock_pool = MagicMock()
+        # Should not raise
+        await init_db(mock_pool)
+
+
+class TestDatabasePool:
+    @pytest.mark.asyncio
+    async def test_lifecycle(self) -> None:
+        config = DatabaseConfig()
+        mock_pool = AsyncMock()
+        mock_pool.close = AsyncMock()
+
+        with patch("tyr.infrastructure.database.create_pool", new_callable=AsyncMock) as m_create:
+            m_create.return_value = mock_pool
+            async with database_pool(config) as pool:
+                assert pool is mock_pool
+
+        mock_pool.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_pool_closes_on_exception(self) -> None:
+        config = DatabaseConfig()
+        mock_pool = AsyncMock()
+        mock_pool.close = AsyncMock()
+
+        with (
+            patch("tyr.infrastructure.database.create_pool", new_callable=AsyncMock) as m_create,
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            m_create.return_value = mock_pool
+            async with database_pool(config):
+                raise RuntimeError("boom")
+
+        mock_pool.close.assert_awaited_once()

--- a/tests/test_tyr/test_models.py
+++ b/tests/test_tyr/test_models.py
@@ -148,12 +148,16 @@ class TestSaga:
             tracker_id="LIN-100",
             tracker_type="linear",
             slug="my-saga",
+            name="My Saga",
             repo="niuulabs/volundr",
             feature_branch="feat/my-saga",
+            status=SagaStatus.ACTIVE,
             confidence=0.9,
             created_at=NOW,
         )
         assert saga.tracker_id == "LIN-100"
+        assert saga.name == "My Saga"
+        assert saga.status == SagaStatus.ACTIVE
         assert saga.confidence == 0.9
 
     def test_frozen(self) -> None:
@@ -162,8 +166,10 @@ class TestSaga:
             tracker_id="LIN-100",
             tracker_type="linear",
             slug="s",
+            name="S",
             repo="r",
             feature_branch="f",
+            status=SagaStatus.ACTIVE,
             confidence=0.5,
             created_at=NOW,
         )
@@ -193,6 +199,8 @@ class TestRaid:
             phase_id=uuid4(),
             tracker_id="LIN-102",
             name="Raid 1",
+            description="Implement the feature",
+            acceptance_criteria=["Tests pass", "Coverage > 85%"],
             declared_files=["src/foo.py"],
             estimate_hours=2.0,
             status=RaidStatus.PENDING,
@@ -204,6 +212,8 @@ class TestRaid:
             created_at=NOW,
             updated_at=NOW,
         )
+        assert raid.description == "Implement the feature"
+        assert len(raid.acceptance_criteria) == 2
         assert raid.declared_files == ["src/foo.py"]
         assert raid.estimate_hours == 2.0
         assert raid.session_id is None

--- a/tests/test_tyr/test_models.py
+++ b/tests/test_tyr/test_models.py
@@ -1,0 +1,275 @@
+"""Tests for Tyr domain models."""
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from tyr.domain.exceptions import InvalidStateTransitionError
+from tyr.domain.models import (
+    RAID_TRANSITIONS,
+    ConfidenceEvent,
+    ConfidenceEventType,
+    DispatcherState,
+    Phase,
+    PhaseSpec,
+    PhaseStatus,
+    PRStatus,
+    Raid,
+    RaidSpec,
+    RaidStatus,
+    Saga,
+    SagaStatus,
+    SagaStructure,
+    SessionInfo,
+    validate_transition,
+)
+
+# ---------------------------------------------------------------------------
+# Enum values
+# ---------------------------------------------------------------------------
+
+
+class TestSagaStatus:
+    def test_values(self) -> None:
+        assert SagaStatus.ACTIVE == "ACTIVE"
+        assert SagaStatus.COMPLETE == "COMPLETE"
+        assert SagaStatus.FAILED == "FAILED"
+
+    def test_member_count(self) -> None:
+        assert len(SagaStatus) == 3
+
+
+class TestPhaseStatus:
+    def test_values(self) -> None:
+        assert PhaseStatus.PENDING == "PENDING"
+        assert PhaseStatus.ACTIVE == "ACTIVE"
+        assert PhaseStatus.GATED == "GATED"
+        assert PhaseStatus.COMPLETE == "COMPLETE"
+
+    def test_member_count(self) -> None:
+        assert len(PhaseStatus) == 4
+
+
+class TestRaidStatus:
+    def test_values(self) -> None:
+        assert RaidStatus.PENDING == "PENDING"
+        assert RaidStatus.QUEUED == "QUEUED"
+        assert RaidStatus.RUNNING == "RUNNING"
+        assert RaidStatus.REVIEW == "REVIEW"
+        assert RaidStatus.MERGED == "MERGED"
+        assert RaidStatus.FAILED == "FAILED"
+
+    def test_member_count(self) -> None:
+        assert len(RaidStatus) == 6
+
+
+class TestConfidenceEventType:
+    def test_values(self) -> None:
+        assert ConfidenceEventType.CI_PASS == "ci_pass"
+        assert ConfidenceEventType.CI_FAIL == "ci_fail"
+        assert ConfidenceEventType.SCOPE_BREACH == "scope_breach"
+        assert ConfidenceEventType.RETRY == "retry"
+        assert ConfidenceEventType.HUMAN_REJECT == "human_reject"
+
+    def test_member_count(self) -> None:
+        assert len(ConfidenceEventType) == 5
+
+
+# ---------------------------------------------------------------------------
+# State machine transitions
+# ---------------------------------------------------------------------------
+
+
+class TestRaidTransitions:
+    def test_pending_to_queued(self) -> None:
+        validate_transition(RaidStatus.PENDING, RaidStatus.QUEUED)
+
+    def test_queued_to_running(self) -> None:
+        validate_transition(RaidStatus.QUEUED, RaidStatus.RUNNING)
+
+    def test_queued_to_failed(self) -> None:
+        validate_transition(RaidStatus.QUEUED, RaidStatus.FAILED)
+
+    def test_running_to_review(self) -> None:
+        validate_transition(RaidStatus.RUNNING, RaidStatus.REVIEW)
+
+    def test_running_to_merged(self) -> None:
+        validate_transition(RaidStatus.RUNNING, RaidStatus.MERGED)
+
+    def test_running_to_failed(self) -> None:
+        validate_transition(RaidStatus.RUNNING, RaidStatus.FAILED)
+
+    def test_review_to_queued(self) -> None:
+        validate_transition(RaidStatus.REVIEW, RaidStatus.QUEUED)
+
+    def test_review_to_merged(self) -> None:
+        validate_transition(RaidStatus.REVIEW, RaidStatus.MERGED)
+
+    def test_review_to_failed(self) -> None:
+        validate_transition(RaidStatus.REVIEW, RaidStatus.FAILED)
+
+    def test_failed_to_queued(self) -> None:
+        validate_transition(RaidStatus.FAILED, RaidStatus.QUEUED)
+
+    def test_merged_is_terminal(self) -> None:
+        for target in RaidStatus:
+            if target == RaidStatus.MERGED:
+                continue
+            with pytest.raises(InvalidStateTransitionError):
+                validate_transition(RaidStatus.MERGED, target)
+
+    def test_invalid_pending_to_running(self) -> None:
+        with pytest.raises(InvalidStateTransitionError) as exc_info:
+            validate_transition(RaidStatus.PENDING, RaidStatus.RUNNING)
+        assert exc_info.value.current == RaidStatus.PENDING
+        assert exc_info.value.target == RaidStatus.RUNNING
+
+    def test_invalid_pending_to_merged(self) -> None:
+        with pytest.raises(InvalidStateTransitionError):
+            validate_transition(RaidStatus.PENDING, RaidStatus.MERGED)
+
+    def test_transition_map_covers_all_statuses(self) -> None:
+        for status in RaidStatus:
+            assert status in RAID_TRANSITIONS
+
+
+# ---------------------------------------------------------------------------
+# Dataclass creation
+# ---------------------------------------------------------------------------
+
+NOW = datetime.now(UTC)
+
+
+class TestSaga:
+    def test_create(self) -> None:
+        saga = Saga(
+            id=uuid4(),
+            tracker_id="LIN-100",
+            tracker_type="linear",
+            slug="my-saga",
+            repo="niuulabs/volundr",
+            feature_branch="feat/my-saga",
+            confidence=0.9,
+            created_at=NOW,
+        )
+        assert saga.tracker_id == "LIN-100"
+        assert saga.confidence == 0.9
+
+    def test_frozen(self) -> None:
+        saga = Saga(
+            id=uuid4(),
+            tracker_id="LIN-100",
+            tracker_type="linear",
+            slug="s",
+            repo="r",
+            feature_branch="f",
+            confidence=0.5,
+            created_at=NOW,
+        )
+        with pytest.raises(AttributeError):
+            saga.slug = "changed"  # type: ignore[misc]
+
+
+class TestPhase:
+    def test_create(self) -> None:
+        phase = Phase(
+            id=uuid4(),
+            saga_id=uuid4(),
+            tracker_id="LIN-101",
+            number=1,
+            name="Phase 1",
+            status=PhaseStatus.PENDING,
+            confidence=0.8,
+        )
+        assert phase.number == 1
+        assert phase.status == PhaseStatus.PENDING
+
+
+class TestRaid:
+    def test_create(self) -> None:
+        raid = Raid(
+            id=uuid4(),
+            phase_id=uuid4(),
+            tracker_id="LIN-102",
+            name="Raid 1",
+            declared_files=["src/foo.py"],
+            estimate_hours=2.0,
+            status=RaidStatus.PENDING,
+            confidence=0.75,
+            session_id=None,
+            branch=None,
+            chronicle_summary=None,
+            retry_count=0,
+            created_at=NOW,
+            updated_at=NOW,
+        )
+        assert raid.declared_files == ["src/foo.py"]
+        assert raid.estimate_hours == 2.0
+        assert raid.session_id is None
+
+
+class TestConfidenceEvent:
+    def test_create(self) -> None:
+        event = ConfidenceEvent(
+            id=uuid4(),
+            raid_id=uuid4(),
+            event_type=ConfidenceEventType.CI_PASS,
+            delta=0.1,
+            score_after=0.85,
+            created_at=NOW,
+        )
+        assert event.event_type == ConfidenceEventType.CI_PASS
+        assert event.delta == 0.1
+
+
+class TestDispatcherState:
+    def test_create(self) -> None:
+        state = DispatcherState(
+            id=uuid4(),
+            running=True,
+            threshold=0.7,
+            updated_at=NOW,
+        )
+        assert state.running is True
+        assert state.threshold == 0.7
+
+
+class TestSessionInfo:
+    def test_create(self) -> None:
+        info = SessionInfo(session_id="sess-1", status="running")
+        assert info.session_id == "sess-1"
+
+
+class TestPRStatus:
+    def test_create(self) -> None:
+        pr = PRStatus(pr_id="PR-1", state="open", mergeable=True, ci_passed=None)
+        assert pr.mergeable is True
+        assert pr.ci_passed is None
+
+
+class TestSpecStructures:
+    def test_raid_spec(self) -> None:
+        spec = RaidSpec(
+            name="Add models",
+            description="Create domain models",
+            acceptance_criteria=["Tests pass"],
+            declared_files=["models.py"],
+            estimate_hours=1.5,
+        )
+        assert spec.estimate_hours == 1.5
+
+    def test_phase_spec(self) -> None:
+        raid = RaidSpec(
+            name="r1",
+            description="d",
+            acceptance_criteria=[],
+            declared_files=[],
+            estimate_hours=1.0,
+        )
+        phase = PhaseSpec(name="Phase 1", raids=[raid])
+        assert len(phase.raids) == 1
+
+    def test_saga_structure(self) -> None:
+        structure = SagaStructure(phases=[])
+        assert structure.phases == []

--- a/tests/test_tyr/test_ports.py
+++ b/tests/test_tyr/test_ports.py
@@ -45,6 +45,7 @@ class TestVolundrPort:
             "get_session",
             "stop_session",
             "get_chronicle_summary",
+            "get_pr_status",
         }
         abstract_methods = {
             name

--- a/tests/test_tyr/test_ports.py
+++ b/tests/test_tyr/test_ports.py
@@ -1,0 +1,99 @@
+"""Tests for Tyr port interfaces."""
+
+import inspect
+
+import pytest
+
+from tyr.ports.confidence import ConfidencePort
+from tyr.ports.git import GitPort
+from tyr.ports.llm import LLMPort
+from tyr.ports.tracker import TrackerPort
+from tyr.ports.volundr import VolundrPort
+
+
+class TestTrackerPort:
+    def test_is_abstract(self) -> None:
+        with pytest.raises(TypeError):
+            TrackerPort()  # type: ignore[abstract]
+
+    def test_methods_exist(self) -> None:
+        methods = {
+            "create_saga",
+            "create_phase",
+            "create_raid",
+            "update_raid_state",
+            "close_raid",
+            "get_saga",
+            "list_pending_raids",
+        }
+        abstract_methods = {
+            name
+            for name, _ in inspect.getmembers(TrackerPort, predicate=inspect.isfunction)
+            if not name.startswith("_")
+        }
+        assert methods == abstract_methods
+
+
+class TestVolundrPort:
+    def test_is_abstract(self) -> None:
+        with pytest.raises(TypeError):
+            VolundrPort()  # type: ignore[abstract]
+
+    def test_methods_exist(self) -> None:
+        methods = {
+            "spawn_session",
+            "get_session",
+            "stop_session",
+            "get_chronicle_summary",
+        }
+        abstract_methods = {
+            name
+            for name, _ in inspect.getmembers(VolundrPort, predicate=inspect.isfunction)
+            if not name.startswith("_")
+        }
+        assert methods == abstract_methods
+
+
+class TestLLMPort:
+    def test_is_abstract(self) -> None:
+        with pytest.raises(TypeError):
+            LLMPort()  # type: ignore[abstract]
+
+    def test_methods_exist(self) -> None:
+        methods = {"decompose_spec"}
+        abstract_methods = {
+            name
+            for name, _ in inspect.getmembers(LLMPort, predicate=inspect.isfunction)
+            if not name.startswith("_")
+        }
+        assert methods == abstract_methods
+
+
+class TestGitPort:
+    def test_is_abstract(self) -> None:
+        with pytest.raises(TypeError):
+            GitPort()  # type: ignore[abstract]
+
+    def test_methods_exist(self) -> None:
+        methods = {"create_branch", "merge_branch", "create_pr", "get_pr_status"}
+        abstract_methods = {
+            name
+            for name, _ in inspect.getmembers(GitPort, predicate=inspect.isfunction)
+            if not name.startswith("_")
+        }
+        assert methods == abstract_methods
+
+
+class TestConfidencePort:
+    def test_is_abstract(self) -> None:
+        with pytest.raises(TypeError):
+            ConfidencePort()  # type: ignore[abstract]
+
+    def test_methods_exist(self) -> None:
+        methods = {"score_initial", "update_score", "get_score"}
+        abstract_methods = {
+            name
+            for name, _ in inspect.getmembers(ConfidencePort, predicate=inspect.isfunction)
+            if not name.startswith("_")
+        }
+        assert methods == abstract_methods


### PR DESCRIPTION
## Summary

Combined implementation of NIU-182, NIU-183, and NIU-184:

- **NIU-182 — Domain models**: Frozen dataclasses for `Saga`, `Phase`, `Raid`, `ConfidenceEvent`, `DispatcherState` with StrEnum status types and explicit raid state machine with transition validation
- **NIU-183 — Port interfaces**: 5 ABC ports (`TrackerPort`, `VolundrPort`, `LLMPort`, `GitPort`, `ConfidencePort`) importing only from domain models
- **NIU-184 — FastAPI skeleton**: asyncpg pool lifecycle via lifespan context manager, correlation ID middleware, hexagonal directory layout (`domain/`, `ports/`, `adapters/`, `api/`, `infrastructure/`)

56 tests, 98.12% coverage.

Depends on NIU-210 (#98).

## Test plan

- [x] `pytest tests/test_tyr/ --cov=src/tyr --cov-fail-under=85` — 56 tests, 98.12% coverage
- [x] `ruff check src/tyr/ tests/test_tyr/` — clean
- [x] No circular imports between tyr modules
- [x] No imports between volundr and tyr
- [x] All ports are abstract (cannot be instantiated)
- [x] Invalid raid state transitions raise `InvalidStateTransitionError`
- [ ] CI passes both volundr and tyr test jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)