### PR TITLE
feat(adapters): wire system prompt and initial prompt through session pipeline

### DIFF
--- a/charts/volundr/values.yaml
+++ b/charts/volundr/values.yaml
@@ -646,6 +646,9 @@ sessionContributors:
   - adapter: "volundr.adapters.outbound.contributors.template.TemplateContributor"
     kwargs: {}
     secretKwargs: []
+  - adapter: "volundr.adapters.outbound.contributors.prompt.PromptContributor"
+    kwargs: {}
+    secretKwargs: []
   - adapter: "volundr.adapters.outbound.contributors.git.GitContributor"
     kwargs: {}
     secretKwargs: []

--- a/src/volundr/adapters/inbound/rest.py
+++ b/src/volundr/adapters/inbound/rest.py
@@ -131,6 +131,16 @@ class SessionCreate(BaseModel):
         default_factory=dict,
         description="Resource allocation overrides (cpu, memory, gpu)",
     )
+    system_prompt: str = Field(
+        default="",
+        max_length=100_000,
+        description="System prompt appended to Claude's default instructions",
+    )
+    initial_prompt: str = Field(
+        default="",
+        max_length=100_000,
+        description="Initial user message sent when the CLI starts",
+    )
     issue_id: str | None = Field(
         default=None,
         max_length=255,
@@ -1044,6 +1054,8 @@ def create_router(
                 credential_names=data.credential_names,
                 integration_ids=data.integration_ids,
                 resource_config=data.resource_config or None,
+                system_prompt=data.system_prompt,
+                initial_prompt=data.initial_prompt,
             )
             return SessionResponse.from_session(started)
         except SessionStateError as e:

--- a/src/volundr/adapters/outbound/contributors/prompt.py
+++ b/src/volundr/adapters/outbound/contributors/prompt.py
@@ -1,0 +1,39 @@
+"""Prompt contributor — injects ad-hoc system and initial prompts into session values."""
+
+from typing import Any
+
+from volundr.domain.models import Session
+from volundr.domain.ports import (
+    SessionContext,
+    SessionContribution,
+    SessionContributor,
+)
+
+
+class PromptContributor(SessionContributor):
+    """Injects system_prompt and initial_prompt from the launch request.
+
+    Runs after TemplateContributor so ad-hoc prompts override template defaults
+    via deep merge (last writer wins for the same key).
+    """
+
+    def __init__(self, **_extra: object) -> None:
+        pass
+
+    @property
+    def name(self) -> str:
+        return "prompt"
+
+    async def contribute(
+        self,
+        session: Session,
+        context: SessionContext,
+    ) -> SessionContribution:
+        values: dict[str, Any] = {}
+
+        if context.system_prompt:
+            values.setdefault("session", {})["systemPrompt"] = context.system_prompt
+        if context.initial_prompt:
+            values.setdefault("session", {})["initialPrompt"] = context.initial_prompt
+
+        return SessionContribution(values=values)

--- a/src/volundr/adapters/outbound/direct_k8s_pod_manager.py
+++ b/src/volundr/adapters/outbound/direct_k8s_pod_manager.py
@@ -316,6 +316,15 @@ class DirectK8sPodManager(PodManager):
             env.append({"name": "SKULD__SESSION__MODEL", "value": session_config["model"]})
             env.append({"name": "MODEL", "value": session_config["model"]})
 
+        if session_config.get("systemPrompt"):
+            env.append(
+                {"name": "SKULD__SESSION__SYSTEM_PROMPT", "value": session_config["systemPrompt"]}
+            )
+        if session_config.get("initialPrompt"):
+            env.append(
+                {"name": "SKULD__SESSION__INITIAL_PROMPT", "value": session_config["initialPrompt"]}
+            )
+
         # Handle extra env passthrough.
         extra_env = spec.values.get("env", {})
         if isinstance(extra_env, dict):

--- a/src/volundr/domain/ports.py
+++ b/src/volundr/domain/ports.py
@@ -1185,6 +1185,8 @@ class SessionContext:
     integration_ids: tuple[str, ...] = ()
     integration_connections: tuple[IntegrationConnection, ...] = ()
     resource_config: dict = field(default_factory=dict)
+    system_prompt: str = ""
+    initial_prompt: str = ""
 
 
 @dataclass(frozen=True)

--- a/src/volundr/domain/services/session.py
+++ b/src/volundr/domain/services/session.py
@@ -490,6 +490,8 @@ class SessionService:
         credential_names: list[str] | None = None,
         integration_ids: list[str] | None = None,
         resource_config: dict | None = None,
+        system_prompt: str = "",
+        initial_prompt: str = "",
     ) -> Session:
         """Start a session's pods via the contributor pipeline."""
         session = await self._repository.get(session_id)
@@ -517,6 +519,8 @@ class SessionService:
                 credential_names=credential_names,
                 integration_ids=integration_ids,
                 resource_config=resource_config,
+                system_prompt=system_prompt,
+                initial_prompt=initial_prompt,
             )
 
             provisioning = (
@@ -554,6 +558,8 @@ class SessionService:
         credential_names: list[str] | None = None,
         integration_ids: list[str] | None = None,
         resource_config: dict | None = None,
+        system_prompt: str = "",
+        initial_prompt: str = "",
     ):
         """Run the contributor pipeline and start pods with merged spec."""
         # Auto-include all enabled integrations when none are specified.
@@ -581,6 +587,8 @@ class SessionService:
             integration_ids=tuple(c.id for c in resolved_connections),
             integration_connections=tuple(resolved_connections),
             resource_config=resource_config or {},
+            system_prompt=system_prompt,
+            initial_prompt=initial_prompt,
         )
 
         contributions: list[SessionContribution] = []

--- a/src/volundr/skuld/broker.py
+++ b/src/volundr/skuld/broker.py
@@ -483,6 +483,8 @@ class Broker:
                             model=self.model,
                             skip_permissions=self._settings.skip_permissions,
                             agent_teams=self._settings.agent_teams,
+                            system_prompt=self._settings.session.system_prompt,
+                            initial_prompt=self._settings.session.initial_prompt,
                         )
 
     async def startup(self) -> None:

--- a/src/volundr/skuld/config.py
+++ b/src/volundr/skuld/config.py
@@ -52,6 +52,8 @@ class SkuldSessionConfig(BaseModel):
     name: str = Field(default="unknown")
     model: str = Field(default="claude-sonnet-4-20250514")
     workspace_dir: str | None = Field(default=None)
+    system_prompt: str = Field(default="")
+    initial_prompt: str = Field(default="")
 
 
 class SkuldSettings(BaseSettings):
@@ -126,6 +128,16 @@ class SkuldSettings(BaseSettings):
             val = os.environ.get("WORKSPACE_DIR")
             if val:
                 self.session.workspace_dir = val
+
+        if not self.session.system_prompt:
+            val = os.environ.get("SESSION_SYSTEM_PROMPT")
+            if val:
+                self.session.system_prompt = val
+
+        if not self.session.initial_prompt:
+            val = os.environ.get("SESSION_INITIAL_PROMPT")
+            if val:
+                self.session.initial_prompt = val
 
         if self.host == "0.0.0.0":
             val = os.environ.get("HOST")

--- a/src/volundr/skuld/transport.py
+++ b/src/volundr/skuld/transport.py
@@ -286,6 +286,8 @@ class SdkWebSocketTransport(CLITransport):
         model: str = "",
         skip_permissions: bool = True,
         agent_teams: bool = False,
+        system_prompt: str = "",
+        initial_prompt: str = "",
     ) -> None:
         super().__init__()
         self.workspace_dir = workspace_dir
@@ -294,6 +296,8 @@ class SdkWebSocketTransport(CLITransport):
         self._model = model
         self._skip_permissions = skip_permissions
         self._agent_teams = agent_teams
+        self._system_prompt = system_prompt
+        self._initial_prompt = initial_prompt
         self._process: asyncio.subprocess.Process | None = None
         self._cli_ws: WebSocket | None = None
         self._cli_connected = asyncio.Event()
@@ -337,7 +341,9 @@ class SdkWebSocketTransport(CLITransport):
             cmd.extend(["--model", self._model])
         if self._skip_permissions:
             cmd.extend(["--permission-mode", "bypassPermissions"])
-        cmd.extend(["-p", "placeholder"])
+        if self._system_prompt:
+            cmd.extend(["--append-system-prompt", self._system_prompt])
+        cmd.extend(["-p", self._initial_prompt or "placeholder"])
         if resume_id:
             cmd.extend(["--resume", resume_id])
 

--- a/tests/test_adapters/test_direct_k8s_pod_manager.py
+++ b/tests/test_adapters/test_direct_k8s_pod_manager.py
@@ -208,6 +208,40 @@ class TestEnvironment:
         assert env_dict["CUSTOM_VAR"] == "custom_value"
         assert env_dict["PORT"] == "3000"
 
+    def test_build_env_with_system_prompt(
+        self,
+        pod_manager: DirectK8sPodManager,
+        sample_session: Session,
+    ) -> None:
+        spec = make_spec(session={"systemPrompt": "You are an agent."})
+        env = pod_manager._build_env(sample_session, spec)
+
+        env_dict = {e["name"]: e["value"] for e in env if "value" in e}
+        assert env_dict["SKULD__SESSION__SYSTEM_PROMPT"] == "You are an agent."
+
+    def test_build_env_with_initial_prompt(
+        self,
+        pod_manager: DirectK8sPodManager,
+        sample_session: Session,
+    ) -> None:
+        spec = make_spec(session={"initialPrompt": "Fix the auth bug."})
+        env = pod_manager._build_env(sample_session, spec)
+
+        env_dict = {e["name"]: e["value"] for e in env if "value" in e}
+        assert env_dict["SKULD__SESSION__INITIAL_PROMPT"] == "Fix the auth bug."
+
+    def test_build_env_without_prompts_omits_vars(
+        self,
+        pod_manager: DirectK8sPodManager,
+        sample_session: Session,
+    ) -> None:
+        spec = make_spec()
+        env = pod_manager._build_env(sample_session, spec)
+
+        env_dict = {e["name"]: e["value"] for e in env if "value" in e}
+        assert "SKULD__SESSION__SYSTEM_PROMPT" not in env_dict
+        assert "SKULD__SESSION__INITIAL_PROMPT" not in env_dict
+
 
 class TestManifests:
     """Test manifest generation."""

--- a/tests/test_adapters/test_prompt_contributor.py
+++ b/tests/test_adapters/test_prompt_contributor.py
@@ -1,0 +1,70 @@
+"""Tests for PromptContributor."""
+
+import pytest
+
+from volundr.adapters.outbound.contributors.prompt import PromptContributor
+from volundr.domain.models import GitSource, Session
+from volundr.domain.ports import SessionContext
+
+
+def _make_session(**overrides) -> Session:
+    defaults = {
+        "name": "test-session",
+        "model": "claude-sonnet",
+        "source": GitSource(repo="github.com/org/repo", branch="main"),
+    }
+    defaults.update(overrides)
+    return Session(**defaults)
+
+
+class TestPromptContributor:
+    """Tests for the prompt contributor."""
+
+    @pytest.mark.asyncio
+    async def test_empty_context_returns_empty(self):
+        contributor = PromptContributor()
+        context = SessionContext()
+        result = await contributor.contribute(_make_session(), context)
+        assert result.values == {}
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_only(self):
+        contributor = PromptContributor()
+        context = SessionContext(system_prompt="You are a code reviewer.")
+        result = await contributor.contribute(_make_session(), context)
+        assert result.values == {"session": {"systemPrompt": "You are a code reviewer."}}
+
+    @pytest.mark.asyncio
+    async def test_initial_prompt_only(self):
+        contributor = PromptContributor()
+        context = SessionContext(initial_prompt="Fix the auth bug in login.py")
+        result = await contributor.contribute(_make_session(), context)
+        assert result.values == {"session": {"initialPrompt": "Fix the auth bug in login.py"}}
+
+    @pytest.mark.asyncio
+    async def test_both_prompts(self):
+        contributor = PromptContributor()
+        context = SessionContext(
+            system_prompt="You are an agent.",
+            initial_prompt="Break down ticket TK-123.",
+        )
+        result = await contributor.contribute(_make_session(), context)
+        assert result.values == {
+            "session": {
+                "systemPrompt": "You are an agent.",
+                "initialPrompt": "Break down ticket TK-123.",
+            }
+        }
+
+    @pytest.mark.asyncio
+    async def test_name_property(self):
+        contributor = PromptContributor()
+        assert contributor.name == "prompt"
+
+    @pytest.mark.asyncio
+    async def test_accepts_extra_kwargs(self):
+        """PromptContributor follows the dynamic adapter pattern and ignores extra kwargs."""
+        contributor = PromptContributor(template_provider=None, some_port=object())
+        context = SessionContext(system_prompt="test")
+        result = await contributor.contribute(_make_session(), context)
+        assert result.values["session"]["systemPrompt"] == "test"

--- a/tests/test_skuld/test_config.py
+++ b/tests/test_skuld/test_config.py
@@ -194,3 +194,37 @@ class TestSkuldSettings:
         monkeypatch.setenv("SKULD__AGENT_TEAMS", "true")
         s = SkuldSettings()
         assert s.agent_teams is True
+
+    def test_session_prompt_defaults_empty(self):
+        config = SkuldSessionConfig()
+        assert config.system_prompt == ""
+        assert config.initial_prompt == ""
+
+    def test_session_prompt_explicit(self):
+        config = SkuldSessionConfig(
+            system_prompt="You are an agent.",
+            initial_prompt="Fix the bug.",
+        )
+        assert config.system_prompt == "You are an agent."
+        assert config.initial_prompt == "Fix the bug."
+
+    def test_legacy_env_system_prompt(self, monkeypatch):
+        monkeypatch.delenv("SKULD__SESSION__SYSTEM_PROMPT", raising=False)
+        monkeypatch.setenv("SESSION_SYSTEM_PROMPT", "legacy system prompt")
+
+        s = SkuldSettings()
+        assert s.session.system_prompt == "legacy system prompt"
+
+    def test_legacy_env_initial_prompt(self, monkeypatch):
+        monkeypatch.delenv("SKULD__SESSION__INITIAL_PROMPT", raising=False)
+        monkeypatch.setenv("SESSION_INITIAL_PROMPT", "legacy initial prompt")
+
+        s = SkuldSettings()
+        assert s.session.initial_prompt == "legacy initial prompt"
+
+    def test_prefixed_env_prompt_takes_precedence(self, monkeypatch):
+        monkeypatch.setenv("SKULD__SESSION__SYSTEM_PROMPT", "prefixed")
+        monkeypatch.setenv("SESSION_SYSTEM_PROMPT", "legacy")
+
+        s = SkuldSettings()
+        assert s.session.system_prompt == "prefixed"

--- a/tests/test_skuld/test_transport.py
+++ b/tests/test_skuld/test_transport.py
@@ -924,6 +924,104 @@ class TestSdkWebSocketTransport:
 
         callback.assert_called_once_with(hook_msg)
 
+    # --- System prompt and initial prompt ---
+
+    def test_init_prompt_defaults_empty(self, transport):
+        assert transport._system_prompt == ""
+        assert transport._initial_prompt == ""
+
+    def test_init_stores_prompts(self, tmp_path):
+        t = SdkWebSocketTransport(
+            workspace_dir=str(tmp_path),
+            sdk_port=8081,
+            session_id="s1",
+            system_prompt="You are an agent.",
+            initial_prompt="Fix the bug.",
+        )
+        assert t._system_prompt == "You are an agent."
+        assert t._initial_prompt == "Fix the bug."
+
+    @pytest.mark.asyncio
+    async def test_spawn_with_system_prompt(self, tmp_path):
+        t = SdkWebSocketTransport(
+            workspace_dir=str(tmp_path),
+            sdk_port=8081,
+            session_id="s1",
+            system_prompt="You are an agent.",
+        )
+        with patch(
+            "volundr.skuld.transport.asyncio.create_subprocess_exec",
+            new_callable=AsyncMock,
+        ) as mock_exec:
+            mock_process = MagicMock()
+            mock_process.stdout = None
+            mock_process.stderr = None
+            mock_exec.return_value = mock_process
+
+            await t.start()
+
+            call_args = mock_exec.call_args[0]
+            assert "--append-system-prompt" in call_args
+            idx = call_args.index("--append-system-prompt")
+            assert call_args[idx + 1] == "You are an agent."
+
+    @pytest.mark.asyncio
+    async def test_spawn_without_system_prompt_omits_flag(self, transport):
+        with patch(
+            "volundr.skuld.transport.asyncio.create_subprocess_exec",
+            new_callable=AsyncMock,
+        ) as mock_exec:
+            mock_process = MagicMock()
+            mock_process.stdout = None
+            mock_process.stderr = None
+            mock_exec.return_value = mock_process
+
+            await transport.start()
+
+            call_args = mock_exec.call_args[0]
+            assert "--append-system-prompt" not in call_args
+
+    @pytest.mark.asyncio
+    async def test_spawn_with_initial_prompt_replaces_placeholder(self, tmp_path):
+        t = SdkWebSocketTransport(
+            workspace_dir=str(tmp_path),
+            sdk_port=8081,
+            session_id="s1",
+            initial_prompt="Break down ticket TK-123.",
+        )
+        with patch(
+            "volundr.skuld.transport.asyncio.create_subprocess_exec",
+            new_callable=AsyncMock,
+        ) as mock_exec:
+            mock_process = MagicMock()
+            mock_process.stdout = None
+            mock_process.stderr = None
+            mock_exec.return_value = mock_process
+
+            await t.start()
+
+            call_args = mock_exec.call_args[0]
+            idx = call_args.index("-p")
+            assert call_args[idx + 1] == "Break down ticket TK-123."
+            assert "placeholder" not in call_args
+
+    @pytest.mark.asyncio
+    async def test_spawn_without_initial_prompt_uses_placeholder(self, transport):
+        with patch(
+            "volundr.skuld.transport.asyncio.create_subprocess_exec",
+            new_callable=AsyncMock,
+        ) as mock_exec:
+            mock_process = MagicMock()
+            mock_process.stdout = None
+            mock_process.stderr = None
+            mock_exec.return_value = mock_process
+
+            await transport.start()
+
+            call_args = mock_exec.call_args[0]
+            idx = call_args.index("-p")
+            assert call_args[idx + 1] == "placeholder"
+
 
 # ---------------------------------------------------------------------------
 # _map_codex_tool

--- a/web/src/modules/volundr/adapters/api/volundr.adapter.ts
+++ b/web/src/modules/volundr/adapters/api/volundr.adapter.ts
@@ -778,6 +778,8 @@ export class ApiVolundrService implements IVolundrService {
     integrationIds?: string[];
     resourceConfig?: Record<string, string | undefined>;
     trackerIssue?: import('@/models').TrackerIssue;
+    systemPrompt?: string;
+    initialPrompt?: string;
   }): Promise<VolundrSession> {
     const createRequest: ApiSessionCreate = {
       name: config.name,
@@ -790,6 +792,8 @@ export class ApiVolundrService implements IVolundrService {
       credential_names: config.credentialNames?.length ? config.credentialNames : undefined,
       integration_ids: config.integrationIds?.length ? config.integrationIds : undefined,
       resource_config: config.resourceConfig,
+      system_prompt: config.systemPrompt,
+      initial_prompt: config.initialPrompt,
       issue_id: config.trackerIssue?.identifier ?? null,
       issue_url: config.trackerIssue?.url ?? null,
     };

--- a/web/src/modules/volundr/adapters/api/volundr.types.ts
+++ b/web/src/modules/volundr/adapters/api/volundr.types.ts
@@ -100,6 +100,8 @@ export interface ApiSessionCreate {
   credential_names?: string[];
   integration_ids?: string[];
   resource_config?: Record<string, string | undefined>;
+  system_prompt?: string;
+  initial_prompt?: string;
   issue_id?: string | null;
   issue_url?: string | null;
 }

--- a/web/src/modules/volundr/adapters/mock/volundr.adapter.ts
+++ b/web/src/modules/volundr/adapters/mock/volundr.adapter.ts
@@ -259,6 +259,8 @@ export class MockVolundrService implements IVolundrService {
     credentialNames?: string[];
     integrationIds?: string[];
     resourceConfig?: Record<string, string | undefined>;
+    systemPrompt?: string;
+    initialPrompt?: string;
   }): Promise<VolundrSession> {
     const newSession: VolundrSession = {
       id: `forge-${crypto.randomUUID().substring(0, 8)}`,

--- a/web/src/modules/volundr/components/LaunchWizard/LaunchWizard.tsx
+++ b/web/src/modules/volundr/components/LaunchWizard/LaunchWizard.tsx
@@ -31,6 +31,8 @@ export interface LaunchConfig {
   credentialNames?: string[];
   integrationIds?: string[];
   resourceConfig?: Record<string, string | undefined>;
+  systemPrompt?: string;
+  initialPrompt?: string;
 }
 
 export type SourceType = 'git' | 'local_mount';
@@ -190,6 +192,7 @@ export function LaunchWizard(props: LaunchWizardProps) {
       credentialNames: state.selectedCredentials.length ? state.selectedCredentials : undefined,
       integrationIds: state.selectedIntegrations.length ? state.selectedIntegrations : undefined,
       resourceConfig: Object.keys(resourceConfig).length > 0 ? resourceConfig : undefined,
+      systemPrompt: state.systemPrompt || undefined,
     });
   }, [state, onLaunch]);
 

--- a/web/src/modules/volundr/hooks/useVolundr.ts
+++ b/web/src/modules/volundr/hooks/useVolundr.ts
@@ -44,6 +44,8 @@ interface UseVolundrResult {
     credentialNames?: string[];
     integrationIds?: string[];
     resourceConfig?: Record<string, string | undefined>;
+    systemPrompt?: string;
+    initialPrompt?: string;
   }) => Promise<VolundrSession>;
   connectSession: (config: { name: string; hostname: string }) => Promise<VolundrSession>;
   updateSession: (sessionId: string, updates: { name?: string }) => Promise<VolundrSession>;
@@ -222,6 +224,8 @@ export function useVolundr(): UseVolundrResult {
       credentialNames?: string[];
       integrationIds?: string[];
       resourceConfig?: Record<string, string | undefined>;
+      systemPrompt?: string;
+      initialPrompt?: string;
     }) => {
       return volundrService.startSession(config);
     },

--- a/web/src/modules/volundr/pages/Volundr/index.tsx
+++ b/web/src/modules/volundr/pages/Volundr/index.tsx
@@ -628,6 +628,8 @@ export function VolundrPage() {
           credentialNames: config.credentialNames,
           integrationIds: config.integrationIds,
           resourceConfig: config.resourceConfig,
+          systemPrompt: config.systemPrompt,
+          initialPrompt: config.initialPrompt,
         });
         setSelectedSession(session);
         setShowLaunchWizard(false);

--- a/web/src/modules/volundr/ports/volundr.port.ts
+++ b/web/src/modules/volundr/ports/volundr.port.ts
@@ -167,6 +167,8 @@ export interface IVolundrService {
     credentialNames?: string[];
     integrationIds?: string[];
     resourceConfig?: Record<string, string | undefined>;
+    systemPrompt?: string;
+    initialPrompt?: string;
   }): Promise<VolundrSession>;
 
   /**


### PR DESCRIPTION
## Summary

- Wire `system_prompt` and `initial_prompt` end-to-end from the session creation API through to the Claude CLI process via `--append-system-prompt` and `-p` flags
- Add new `PromptContributor` that injects ad-hoc prompts into session spec values (runs after TemplateContributor so ad-hoc overrides template defaults)
- Fix the LaunchWizard's `systemPrompt` field which was present in state but dropped when building the `LaunchConfig`

This enables Tyr to programmatically prime Volundr sessions with agent identity, skills, and ticket context when spawning breakdown/analysis sessions.

## Changes

### Backend (Python)
- `SdkWebSocketTransport`: `--append-system-prompt` + real `-p` initial prompt
- `SkuldSessionConfig`: new `system_prompt`/`initial_prompt` fields with env var fallbacks
- `Broker`: thread config fields to transport
- `DirectK8sPodManager`: emit `SKULD__SESSION__SYSTEM_PROMPT`/`INITIAL_PROMPT` env vars
- `SessionContext` + `SessionService`: forward new fields through pipeline
- `SessionCreate` API model: add `system_prompt`/`initial_prompt`
- New `PromptContributor` + Helm values registration

### Frontend (TypeScript)
- `LaunchConfig`, `ApiSessionCreate`, port, hook, adapter, wizard page: wire through

## Test plan

- [x] 12 new tests (6 transport, 6 contributor) — all pass
- [x] Full Python suite: 2851 passed, 86.68% coverage
- [x] Related web tests: 382 passed
- [x] Ruff lint + format clean
- [x] TypeScript compiles cleanly

Closes NIU-217

🤖 Generated with [Claude Code](https://claude.com/claude-code)