### PR TITLE
feat(tyr): SSE event bus and GET /api/v1/tyr/events stream

### DIFF
--- a/src/tyr/api/events.py
+++ b/src/tyr/api/events.py
@@ -1,0 +1,102 @@
+"""SSE event stream for real-time Tyr updates.
+
+GET /api/v1/tyr/events — streams :class:`~tyr.events.TyrEvent` objects as
+standard Server-Sent Events.  On connect, the current state snapshot is pushed
+immediately so the UI can hydrate without a separate REST call.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncGenerator
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.responses import StreamingResponse
+
+from tyr.events import EventBus, TyrEvent
+
+logger = logging.getLogger(__name__)
+
+
+async def resolve_event_bus() -> EventBus:  # pragma: no cover
+    """Dependency stub — always overridden by the app lifespan in main.py."""
+    raise HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail="Event bus not configured",
+    )
+
+
+async def _sse_generator(
+    event_bus: EventBus,
+    q: asyncio.Queue[TyrEvent],
+    keepalive_interval: float,
+) -> AsyncGenerator[str, None]:
+    """Async generator that streams SSE messages.
+
+    Yields the current state snapshot immediately, then relays events from *q*.
+    Sends an SSE comment keepalive after ``keepalive_interval`` idle seconds.
+    Calls ``event_bus.unsubscribe(q)`` in a finally block so the queue is
+    always cleaned up on disconnect or error.
+    """
+    try:
+        for snapshot_event in event_bus.get_snapshot():
+            yield snapshot_event.to_sse()
+
+        while True:
+            try:
+                event: TyrEvent = await asyncio.wait_for(
+                    q.get(), timeout=keepalive_interval
+                )
+                yield event.to_sse()
+            except TimeoutError:
+                yield ": keepalive\n\n"
+    finally:
+        event_bus.unsubscribe(q)
+        logger.debug(
+            "SSE client disconnected; remaining clients: %d",
+            event_bus.client_count,
+        )
+
+
+def create_events_router(keepalive_interval: float = 15.0) -> APIRouter:
+    """Return an APIRouter with the ``GET /api/v1/tyr/events`` SSE endpoint.
+
+    Args:
+        keepalive_interval: Seconds between SSE keepalive comments when no
+            events are queued.  Configurable so tests can use a short value.
+    """
+    router = APIRouter(prefix="/api/v1/tyr", tags=["Events"])
+
+    @router.get("/events", summary="SSE event stream")
+    async def sse_stream(
+        request: Request,  # noqa: ARG001
+        event_bus: EventBus = Depends(resolve_event_bus),
+    ) -> StreamingResponse:
+        """Stream all real-time Tyr state changes as Server-Sent Events.
+
+        The client receives a state snapshot immediately on connect, followed
+        by live events as they are emitted.  The connection is kept alive with
+        SSE comment lines when idle.
+        """
+        if event_bus.at_capacity:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=f"SSE client limit reached ({event_bus.client_count})",
+            )
+
+        # Subscribe *before* creating the response so that events emitted
+        # between "route handler called" and "generator starts" are not lost.
+        q = event_bus.subscribe()
+
+        return StreamingResponse(
+            _sse_generator(event_bus, q, keepalive_interval),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+                "X-Accel-Buffering": "no",
+            },
+        )
+
+    return router

--- a/src/tyr/config.py
+++ b/src/tyr/config.py
@@ -94,6 +94,13 @@ class TrackerConfig(BaseModel):
     rate_limit_max_retries: int = Field(default=3)
 
 
+class EventsConfig(BaseModel):
+    """SSE event stream configuration."""
+
+    max_sse_clients: int = Field(default=10)
+    keepalive_interval: float = Field(default=15.0)
+
+
 class Settings(BaseSettings):
     """Application settings.
 
@@ -124,6 +131,7 @@ class Settings(BaseSettings):
     tracker: TrackerConfig = Field(default_factory=TrackerConfig)
     dispatch: DispatchConfig = Field(default_factory=DispatchConfig)
     credential_store: CredentialStoreConfig = Field(default_factory=CredentialStoreConfig)
+    events: EventsConfig = Field(default_factory=EventsConfig)
 
     @classmethod
     def settings_customise_sources(

--- a/src/tyr/events.py
+++ b/src/tyr/events.py
@@ -1,0 +1,82 @@
+"""Tyr event bus — in-process pub/sub for SSE broadcasting.
+
+Application services call ``event_bus.emit(event)`` to broadcast state changes.
+The SSE handler subscribes a per-client queue and streams events to the browser.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+# Event types that represent current persistent state.
+# These are cached and replayed to new subscribers as an initial snapshot,
+# so the UI doesn't need a separate hydration call.
+_SNAPSHOT_TYPES: frozenset[str] = frozenset({"dispatcher.state"})
+
+
+@dataclass
+class TyrEvent:
+    """A single Tyr SSE event."""
+
+    event: str
+    data: dict[str, Any]
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+
+    def to_sse(self) -> str:
+        """Serialise as SSE wire format (id / event / data / blank line)."""
+        return f"id: {self.id}\nevent: {self.event}\ndata: {json.dumps(self.data)}\n\n"
+
+
+class EventBus:
+    """In-process broadcast bus for Tyr SSE events.
+
+    One queue per connected SSE client.  ``emit`` fans out to all queues.
+    State-type events are cached and replayed to new clients on subscribe.
+    """
+
+    def __init__(self, max_clients: int = 10) -> None:
+        self._max_clients = max_clients
+        self._queues: list[asyncio.Queue[TyrEvent]] = []
+        self._snapshots: dict[str, TyrEvent] = {}
+
+    @property
+    def client_count(self) -> int:
+        """Number of currently connected SSE clients."""
+        return len(self._queues)
+
+    @property
+    def at_capacity(self) -> bool:
+        """True when the maximum number of SSE clients is already connected."""
+        return len(self._queues) >= self._max_clients
+
+    def subscribe(self) -> asyncio.Queue[TyrEvent]:
+        """Register a new SSE client and return its dedicated queue."""
+        q: asyncio.Queue[TyrEvent] = asyncio.Queue()
+        self._queues.append(q)
+        return q
+
+    def unsubscribe(self, q: asyncio.Queue[TyrEvent]) -> None:
+        """Remove a client queue — safe to call even if already removed."""
+        try:
+            self._queues.remove(q)
+        except ValueError:
+            pass
+
+    async def emit(self, event: TyrEvent) -> None:
+        """Broadcast an event to every connected client queue.
+
+        State-type events (``_SNAPSHOT_TYPES``) are also saved so they can be
+        replayed to new subscribers via ``get_snapshot``.
+        """
+        if event.event in _SNAPSHOT_TYPES:
+            self._snapshots[event.event] = event
+        for q in list(self._queues):
+            await q.put(event)
+
+    def get_snapshot(self) -> list[TyrEvent]:
+        """Return the current state snapshot for delivery to a new subscriber."""
+        return list(self._snapshots.values())

--- a/src/tyr/main.py
+++ b/src/tyr/main.py
@@ -18,9 +18,11 @@ from tyr.adapters.postgres_sagas import PostgresSagaRepository
 from tyr.adapters.volundr_http import VolundrHTTPAdapter
 from tyr.api.dispatch import create_dispatch_router, resolve_volundr
 from tyr.api.dispatch import resolve_saga_repo as dispatch_resolve_saga_repo
+from tyr.api.events import create_events_router, resolve_event_bus
 from tyr.api.sagas import create_sagas_router, resolve_saga_repo
 from tyr.api.tracker import create_tracker_router, resolve_trackers
 from tyr.config import Settings
+from tyr.events import EventBus
 from tyr.infrastructure.database import database_pool
 from tyr.ports.saga_repository import SagaRepository
 from tyr.ports.tracker import TrackerPort
@@ -102,6 +104,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(create_tracker_router())
     app.include_router(create_sagas_router())
     app.include_router(create_dispatch_router())
+    app.include_router(create_events_router(settings.events.keepalive_interval))
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
@@ -142,6 +145,15 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 return volundr_adapter
 
             app.dependency_overrides[resolve_volundr] = _resolve_volundr
+
+            # Wire event bus
+            event_bus = EventBus(max_clients=settings.events.max_sse_clients)
+            app.state.event_bus = event_bus
+
+            async def _resolve_event_bus() -> EventBus:
+                return event_bus
+
+            app.dependency_overrides[resolve_event_bus] = _resolve_event_bus
 
             logger.info("Tyr started — database pool ready")
             yield

--- a/tests/test_tyr/test_events.py
+++ b/tests/test_tyr/test_events.py
@@ -1,0 +1,314 @@
+"""Tests for the Tyr EventBus and SSE endpoint."""
+
+from __future__ import annotations
+
+import asyncio
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tyr.api.events import _sse_generator, create_events_router, resolve_event_bus
+from tyr.events import EventBus, TyrEvent
+
+# ---------------------------------------------------------------------------
+# TyrEvent
+# ---------------------------------------------------------------------------
+
+
+class TestTyrEvent:
+    def test_to_sse_format(self):
+        event = TyrEvent(
+            id="fixed-id",
+            event="dispatcher.state",
+            data={"running": True, "threshold": 0.8, "queue_depth": 2},
+        )
+        sse = event.to_sse()
+        assert sse == (
+            "id: fixed-id\nevent: dispatcher.state\n"
+            'data: {"running": true, "threshold": 0.8, "queue_depth": 2}\n\n'
+        )
+
+    def test_id_auto_generated(self):
+        e1 = TyrEvent(event="session.spawned", data={})
+        e2 = TyrEvent(event="session.spawned", data={})
+        assert e1.id
+        assert e1.id != e2.id
+
+    def test_to_sse_ends_with_double_newline(self):
+        event = TyrEvent(
+            id="x",
+            event="phase.unlocked",
+            data={"saga_id": "s1", "phase_id": "p1", "phase_name": "P1"},
+        )
+        assert event.to_sse().endswith("\n\n")
+
+
+# ---------------------------------------------------------------------------
+# EventBus
+# ---------------------------------------------------------------------------
+
+
+class TestEventBus:
+    def test_initial_state(self):
+        bus = EventBus(max_clients=5)
+        assert bus.client_count == 0
+        assert not bus.at_capacity
+        assert bus.get_snapshot() == []
+
+    def test_subscribe_increments_count(self):
+        bus = EventBus(max_clients=5)
+        bus.subscribe()
+        assert bus.client_count == 1
+
+    def test_unsubscribe_decrements_count(self):
+        bus = EventBus(max_clients=5)
+        q = bus.subscribe()
+        bus.unsubscribe(q)
+        assert bus.client_count == 0
+
+    def test_unsubscribe_nonexistent_is_noop(self):
+        bus = EventBus(max_clients=5)
+        orphan: asyncio.Queue = asyncio.Queue()
+        bus.unsubscribe(orphan)  # must not raise
+
+    def test_at_capacity_when_full(self):
+        bus = EventBus(max_clients=2)
+        bus.subscribe()
+        assert not bus.at_capacity
+        bus.subscribe()
+        assert bus.at_capacity
+
+    async def test_emit_puts_event_in_all_queues(self):
+        bus = EventBus(max_clients=5)
+        q1 = bus.subscribe()
+        q2 = bus.subscribe()
+        event = TyrEvent(
+            event="session.spawned",
+            data={"session_id": "s1", "raid_id": "r1", "branch": "feat/x"},
+        )
+        await bus.emit(event)
+        assert q1.qsize() == 1
+        assert q2.qsize() == 1
+        received = await q1.get()
+        assert received is event
+
+    async def test_emit_skips_unsubscribed_queues(self):
+        bus = EventBus(max_clients=5)
+        q = bus.subscribe()
+        bus.unsubscribe(q)
+        event = TyrEvent(event="session.spawned", data={})
+        await bus.emit(event)
+        assert q.qsize() == 0
+
+    async def test_emit_saves_snapshot_for_state_events(self):
+        bus = EventBus(max_clients=5)
+        event = TyrEvent(
+            event="dispatcher.state",
+            data={"running": False, "threshold": 0.8, "queue_depth": 0},
+        )
+        await bus.emit(event)
+        snapshot = bus.get_snapshot()
+        assert len(snapshot) == 1
+        assert snapshot[0] is event
+
+    async def test_emit_does_not_snapshot_transient_events(self):
+        bus = EventBus(max_clients=5)
+        for ev_type in (
+            "session.spawned",
+            "session.stopped",
+            "session.failed",
+            "raid.state_changed",
+            "confidence.updated",
+            "dispatcher.log",
+            "saga.pr_created",
+            "phase.unlocked",
+        ):
+            await bus.emit(TyrEvent(event=ev_type, data={}))
+        assert bus.get_snapshot() == []
+
+    async def test_snapshot_updated_on_repeated_emit(self):
+        bus = EventBus(max_clients=5)
+        e1 = TyrEvent(
+            event="dispatcher.state",
+            data={"running": False, "threshold": 0.8, "queue_depth": 0},
+        )
+        e2 = TyrEvent(
+            event="dispatcher.state",
+            data={"running": True, "threshold": 0.8, "queue_depth": 3},
+        )
+        await bus.emit(e1)
+        await bus.emit(e2)
+        snapshot = bus.get_snapshot()
+        assert len(snapshot) == 1
+        assert snapshot[0].data["running"] is True
+
+    async def test_get_snapshot_returns_copy(self):
+        bus = EventBus(max_clients=5)
+        await bus.emit(
+            TyrEvent(
+                event="dispatcher.state",
+                data={"running": False, "threshold": 0.8, "queue_depth": 0},
+            )
+        )
+        s1 = bus.get_snapshot()
+        s2 = bus.get_snapshot()
+        assert s1 is not s2
+
+
+# ---------------------------------------------------------------------------
+# SSE generator — direct async tests (avoids httpx ASGI transport limitations)
+# ---------------------------------------------------------------------------
+
+
+class TestSseGenerator:
+    """Tests for _sse_generator directly — no HTTP transport required."""
+
+    async def test_yields_snapshot_on_start(self):
+        bus = EventBus(max_clients=5)
+        snap = TyrEvent(
+            id="snap-1",
+            event="dispatcher.state",
+            data={"running": False, "threshold": 0.8, "queue_depth": 0},
+        )
+        await bus.emit(snap)
+
+        q = bus.subscribe()
+        chunks: list[str] = []
+        async for chunk in _sse_generator(bus, q, keepalive_interval=30.0):
+            chunks.append(chunk)
+            break  # Stop after snapshot
+
+        combined = "".join(chunks)
+        assert "event: dispatcher.state" in combined
+        assert "id: snap-1" in combined
+
+    async def test_yields_queued_events(self):
+        bus = EventBus(max_clients=5)
+        q = bus.subscribe()
+        event = TyrEvent(
+            id="live-1",
+            event="raid.state_changed",
+            data={
+                "raid_id": "r1",
+                "saga_id": "s1",
+                "phase_id": "p1",
+                "state": "RUNNING",
+                "confidence": 0.9,
+            },
+        )
+        await bus.emit(event)  # pre-queue before generator starts
+
+        chunks: list[str] = []
+        async for chunk in _sse_generator(bus, q, keepalive_interval=30.0):
+            chunks.append(chunk)
+            if "raid.state_changed" in chunk:
+                break
+
+        combined = "".join(chunks)
+        assert "event: raid.state_changed" in combined
+        assert "id: live-1" in combined
+
+    async def test_yields_keepalive_when_idle(self):
+        bus = EventBus(max_clients=5)
+        q = bus.subscribe()
+
+        chunks: list[str] = []
+        async for chunk in _sse_generator(bus, q, keepalive_interval=0.05):
+            chunks.append(chunk)
+            if ": keepalive" in chunk:
+                break
+
+        assert ": keepalive" in "".join(chunks)
+
+    async def test_unsubscribes_on_close(self):
+        bus = EventBus(max_clients=5)
+        snap = TyrEvent(
+            id="s1",
+            event="dispatcher.state",
+            data={"running": False, "threshold": 0.8, "queue_depth": 0},
+        )
+        await bus.emit(snap)  # Populate snapshot so generator yields immediately
+
+        q = bus.subscribe()
+        assert bus.client_count == 1
+
+        gen = _sse_generator(bus, q, keepalive_interval=30.0)
+        async for _ in gen:
+            break  # Snapshot yields immediately; break schedules aclose()
+        await gen.aclose()  # Explicitly await cleanup to ensure finally runs
+
+        assert bus.client_count == 0
+
+    async def test_multiple_event_types_delivered(self):
+        """All event types flow through the queue correctly."""
+        bus = EventBus(max_clients=5)
+        q = bus.subscribe()
+
+        event_types = [
+            ("session.spawned", {"session_id": "s1", "raid_id": "r1", "branch": "b"}),
+            (
+                "session.stopped",
+                {"session_id": "s1", "raid_id": "r1", "confidence": 0.9, "state": "REVIEW"},
+            ),
+            ("session.failed", {"session_id": "s1", "raid_id": "r1", "retry_count": 1}),
+            ("saga.pr_created", {"saga_id": "sg1", "pr_url": "https://example.com/pr/1"}),
+            ("phase.unlocked", {"saga_id": "sg1", "phase_id": "p1", "phase_name": "Phase 1"}),
+        ]
+
+        for ev_type, data in event_types:
+            await bus.emit(TyrEvent(event=ev_type, data=data))
+
+        received: list[str] = []
+        gen = _sse_generator(bus, q, keepalive_interval=30.0)
+        for _ in range(len(event_types)):
+            chunk = await gen.__anext__()
+            received.append(chunk)
+
+        await gen.aclose()
+
+        combined = "".join(received)
+        for ev_type, _ in event_types:
+            assert ev_type in combined
+
+
+# ---------------------------------------------------------------------------
+# SSE HTTP endpoint — sync tests (no streaming body needed)
+# ---------------------------------------------------------------------------
+
+
+def _make_app(event_bus: EventBus, keepalive_interval: float = 30.0) -> FastAPI:
+    app = FastAPI()
+    app.include_router(create_events_router(keepalive_interval=keepalive_interval))
+    app.dependency_overrides[resolve_event_bus] = lambda: event_bus
+    return app
+
+
+class TestSseEndpointHttp:
+    def test_returns_503_when_at_capacity(self):
+        bus = EventBus(max_clients=1)
+        bus.subscribe()  # fill up
+        client = TestClient(_make_app(bus))
+        resp = client.get("/api/v1/tyr/events")
+        assert resp.status_code == 503
+        assert "limit" in resp.json()["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Config integration
+# ---------------------------------------------------------------------------
+
+
+class TestEventsConfig:
+    def test_default_values(self):
+        from tyr.config import EventsConfig
+
+        cfg = EventsConfig()
+        assert cfg.max_sse_clients == 10
+        assert cfg.keepalive_interval == 15.0
+
+    def test_settings_includes_events(self):
+        from tyr.config import Settings
+
+        s = Settings()
+        assert s.events.max_sse_clients == 10
+        assert s.events.keepalive_interval == 15.0


### PR DESCRIPTION
## Summary

Implements NIU-201 — Tyr's real-time SSE endpoint that the UI connects to for live updates without polling.

### New files

**`src/tyr/events.py`** — Core pub/sub infrastructure
- `TyrEvent` dataclass: auto-UUID `id`, `event` name, `data` dict, `to_sse()` serialiser producing standard SSE format
- `EventBus`: per-client `asyncio.Queue` pub/sub, configurable max clients, snapshot store for stateful events
- Stateful events (`dispatcher.state`) are cached and replayed to new subscribers on connect — no separate hydration call needed
- `unsubscribe()` is a no-op for unknown queues (safe on disconnect race)

**`src/tyr/api/events.py`** — SSE router
- `GET /api/v1/tyr/events` — `StreamingResponse` with `text/event-stream`
- 503 when at capacity: `SSE client limit reached (N)`
- Subscription happens in the route handler *before* returning the response (no event loss between handler call and generator start)
- `_sse_generator` extracted as a module-level async generator (enables direct testing without HTTP transport)
- Yields state snapshot on connect, then live events from queue
- `asyncio.wait_for` with configurable keepalive; sends `: keepalive\n\n` on timeout
- `finally` block guarantees `unsubscribe()` on any disconnect or error

**`src/tyr/config.py`** — `EventsConfig`
- `max_sse_clients: int = 10`
- `keepalive_interval: float = 15.0`

### Modified files

**`src/tyr/main.py`** — Wired in lifespan
- `EventBus(max_clients=settings.events.max_sse_clients)` created on startup, stored in `app.state.event_bus`
- `resolve_event_bus` dependency overridden with real bus

**`tests/test_tyr/test_events.py`** — 22 tests, all passing
- `TestTyrEvent`: SSE format, auto-ID uniqueness, double-newline termination
- `TestEventBus`: subscribe/unsubscribe/capacity/emit/snapshot save+update+copy
- `TestSseGenerator`: snapshot replay on connect, live queued events, keepalive on idle, disconnect cleanup, multi-event-type delivery
- `TestSseEndpointHttp`: 503 at capacity (sync, no streaming)
- `TestEventsConfig`: defaults, `Settings` integration

## Event catalogue

All 9 event types from the spec are supported:

| Event | Snapshot? |
|---|---|
| `raid.state_changed` | no |
| `session.spawned` | no |
| `session.stopped` | no |
| `session.failed` | no |
| `confidence.updated` | no |
| `dispatcher.log` | no |
| `dispatcher.state` | **yes** — replayed on connect |
| `saga.pr_created` | no |
| `phase.unlocked` | no |

## Test plan

- [x] 144 tests passing (22 new)
- [x] 89.47% tyr coverage (threshold: 85%)
- [x] `ruff check` clean
- [x] `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)