### PR TITLE
feat(tyr): add migration 000008 for personal_access_tokens table

### DIFF
--- a/charts/tyr/templates/migrations-configmap.yaml
+++ b/charts/tyr/templates/migrations-configmap.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.migrations.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "tyr.fullname" . }}-migrations
+  labels:
+    {{- include "tyr.labels" . | nindent 4 }}
+data:
+  000008_personal_access_tokens.up.sql: |
+    -- Add personal_access_tokens table for Tyr PAT authentication
+
+    CREATE TABLE IF NOT EXISTS personal_access_tokens (
+        id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+        owner_id     TEXT        NOT NULL,
+        name         TEXT        NOT NULL,
+        token_hash   TEXT        NOT NULL,
+        created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        last_used_at TIMESTAMPTZ
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_pats_owner_id ON personal_access_tokens(owner_id);
+
+  000008_personal_access_tokens.down.sql: |
+    -- Rollback personal_access_tokens table
+
+    DROP TABLE IF EXISTS personal_access_tokens;
+{{- end }}

--- a/migrations/tyr/000008_personal_access_tokens.down.sql
+++ b/migrations/tyr/000008_personal_access_tokens.down.sql
@@ -1,0 +1,3 @@
+-- Rollback personal_access_tokens table
+
+DROP TABLE IF EXISTS personal_access_tokens;

--- a/migrations/tyr/000008_personal_access_tokens.up.sql
+++ b/migrations/tyr/000008_personal_access_tokens.up.sql
@@ -1,0 +1,12 @@
+-- Add personal_access_tokens table for Tyr PAT authentication
+
+CREATE TABLE IF NOT EXISTS personal_access_tokens (
+    id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    owner_id     TEXT        NOT NULL,
+    name         TEXT        NOT NULL,
+    token_hash   TEXT        NOT NULL,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_used_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_pats_owner_id ON personal_access_tokens(owner_id);


### PR DESCRIPTION
## Summary
- Adds `personal_access_tokens` table migration (000008) for Tyr's PostgreSQL schema
- `owner_id` is plain TEXT (IDP sub claim from Envoy headers) — no FK to users table since Tyr has no local users table
- Migration is idempotent (`CREATE TABLE IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`)
- Helm migrations-configmap for `charts/tyr` created with the new migration embedded

## Files Changed
- `migrations/tyr/000008_personal_access_tokens.up.sql` — creates table + index
- `migrations/tyr/000008_personal_access_tokens.down.sql` — drops table
- `charts/tyr/templates/migrations-configmap.yaml` — Helm configmap with embedded migration SQL

## Test plan
- [ ] Verify migration SQL is valid and idempotent (can be run multiple times)
- [ ] Verify down migration cleanly drops the table
- [ ] Verify Helm configmap renders correctly with `helm template`
- [ ] No Python changes — SQL-only migration

Closes NIU-227

🤖 Generated with [Claude Code](https://claude.com/claude-code)