### PR TITLE
feat(niuu): add IntegrationType.CODE_FORGE to shared domain models

### DIFF
--- a/src/volundr/domain/models.py
+++ b/src/volundr/domain/models.py
@@ -137,6 +137,7 @@ class IntegrationType(StrEnum):
     SOURCE_CONTROL = "source_control"
     ISSUE_TRACKER = "issue_tracker"
     MESSAGING = "messaging"
+    CODE_FORGE = "code_forge"
     AI_PROVIDER = "ai_provider"
 
 

--- a/tests/test_domain/test_models.py
+++ b/tests/test_domain/test_models.py
@@ -10,6 +10,7 @@ from pydantic import ValidationError
 from volundr.domain.models import (
     GitProviderType,
     GitSource,
+    IntegrationType,
     Model,
     ModelProvider,
     ModelTier,
@@ -37,6 +38,28 @@ class TestSessionStatus:
         assert SessionStatus.RUNNING.value == "running"
         # Can be compared directly to string
         assert SessionStatus.RUNNING == "running"
+
+
+class TestIntegrationType:
+    """Tests for IntegrationType enum."""
+
+    def test_all_values_exist(self):
+        """Verify all expected integration type values exist."""
+        assert IntegrationType.SOURCE_CONTROL.value == "source_control"
+        assert IntegrationType.ISSUE_TRACKER.value == "issue_tracker"
+        assert IntegrationType.MESSAGING.value == "messaging"
+        assert IntegrationType.CODE_FORGE.value == "code_forge"
+        assert IntegrationType.AI_PROVIDER.value == "ai_provider"
+
+    def test_is_string_enum(self):
+        """IntegrationType values should be usable as strings."""
+        assert IntegrationType.CODE_FORGE == "code_forge"
+        assert IntegrationType.MESSAGING == "messaging"
+
+    def test_round_trip(self):
+        """Values round-trip through StrEnum construction."""
+        for member in IntegrationType:
+            assert IntegrationType(member.value) is member
 
 
 class TestSession:


### PR DESCRIPTION
## Summary

- Added `CODE_FORGE = "code_forge"` to `IntegrationType` StrEnum in `src/volundr/domain/models.py` for Tyr's autonomous credential resolution against Volundr instances (PAT + base URL)
- `MESSAGING` already existed in the enum — no change needed
- Added `TestIntegrationType` test class covering value assertions, string enum behavior, and round-trip construction for all members

## Context

Resolves [NIU-220](https://linear.app/niuu/issue/NIU-220). This is an additive change — no migration required since `IntegrationType` is stored as TEXT.

## Test plan

- [x] `TestIntegrationType::test_all_values_exist` — all 5 enum values present with correct string representations
- [x] `TestIntegrationType::test_is_string_enum` — CODE_FORGE and MESSAGING usable as strings
- [x] `TestIntegrationType::test_round_trip` — all values round-trip through `IntegrationType(value)`
- [x] ruff check + ruff format pass
- [x] Existing SOURCE_CONTROL and ISSUE_TRACKER values unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)