### PR TITLE
feat(adapters): add migration 000021 for personal_access_tokens table

### DIFF
--- a/charts/volundr/templates/migrations-configmap.yaml
+++ b/charts/volundr/templates/migrations-configmap.yaml
@@ -556,4 +556,20 @@ data:
   000020_feature_toggles.down.sql: |
     DROP TABLE IF EXISTS user_feature_preferences;
     DROP TABLE IF EXISTS feature_toggles;
+
+  000021_personal_access_tokens.up.sql: |
+    -- Personal access tokens: stores PAT metadata and bcrypt hash of the raw JWT.
+    CREATE TABLE IF NOT EXISTS personal_access_tokens (
+        id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+        owner_id     TEXT        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        name         TEXT        NOT NULL,
+        token_hash   TEXT        NOT NULL,
+        created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        last_used_at TIMESTAMPTZ
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_pats_owner_id ON personal_access_tokens(owner_id);
+
+  000021_personal_access_tokens.down.sql: |
+    DROP TABLE IF EXISTS personal_access_tokens;
 {{- end }}

--- a/migrations/000021_personal_access_tokens.down.sql
+++ b/migrations/000021_personal_access_tokens.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS personal_access_tokens;

--- a/migrations/000021_personal_access_tokens.up.sql
+++ b/migrations/000021_personal_access_tokens.up.sql
@@ -1,0 +1,11 @@
+-- Personal access tokens: stores PAT metadata and bcrypt hash of the raw JWT.
+CREATE TABLE IF NOT EXISTS personal_access_tokens (
+    id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    owner_id     TEXT        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name         TEXT        NOT NULL,
+    token_hash   TEXT        NOT NULL,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_used_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_pats_owner_id ON personal_access_tokens(owner_id);


### PR DESCRIPTION
## Summary
- Adds `migrations/000021_personal_access_tokens.up.sql` and `.down.sql` with idempotent DDL for the `personal_access_tokens` table
- Table stores PAT metadata (`id`, `owner_id`, `name`, `token_hash`, `created_at`, `last_used_at`) with a foreign key to `users(id)` and CASCADE delete
- Updates `charts/volundr/templates/migrations-configmap.yaml` to include the new migration

## Test plan
- [ ] Verify migration applies cleanly against a fresh database
- [ ] Verify down migration drops the table without errors
- [ ] Confirm Helm configmap renders correctly with `helm template`
- [ ] Validate idempotency by running the up migration twice

Closes NIU-222

🤖 Generated with [Claude Code](https://claude.com/claude-code)