### PR TITLE
feat(tyr): add migration 000008 for personal_access_tokens table

### DIFF
--- a/charts/tyr/templates/migrations-configmap.yaml
+++ b/charts/tyr/templates/migrations-configmap.yaml
@@ -115,4 +115,22 @@ data:
     ALTER TABLE sagas DROP COLUMN IF EXISTS repos;
     ALTER TABLE sagas DROP COLUMN IF EXISTS name;
     ALTER TABLE sagas DROP COLUMN IF EXISTS status;
+
+  000008_personal_access_tokens.up.sql: |
+    -- Personal access tokens for Tyr API callers (e.g. Telegram bot, ODIN/Móði)
+    -- owner_id is the IDP sub claim from Envoy headers, treated as an opaque string
+
+    CREATE TABLE IF NOT EXISTS personal_access_tokens (
+        id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+        owner_id     TEXT        NOT NULL,
+        name         TEXT        NOT NULL,
+        token_hash   TEXT        NOT NULL,
+        created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        last_used_at TIMESTAMPTZ
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_pats_owner_id ON personal_access_tokens(owner_id);
+
+  000008_personal_access_tokens.down.sql: |
+    DROP TABLE IF EXISTS personal_access_tokens;
 {{- end }}

--- a/migrations/tyr/000008_personal_access_tokens.down.sql
+++ b/migrations/tyr/000008_personal_access_tokens.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS personal_access_tokens;

--- a/migrations/tyr/000008_personal_access_tokens.up.sql
+++ b/migrations/tyr/000008_personal_access_tokens.up.sql
@@ -1,0 +1,13 @@
+-- Personal access tokens for Tyr API callers (e.g. Telegram bot, ODIN/Móði)
+-- owner_id is the IDP sub claim from Envoy headers, treated as an opaque string
+
+CREATE TABLE IF NOT EXISTS personal_access_tokens (
+    id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    owner_id     TEXT        NOT NULL,
+    name         TEXT        NOT NULL,
+    token_hash   TEXT        NOT NULL,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_used_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_pats_owner_id ON personal_access_tokens(owner_id);


### PR DESCRIPTION
## Summary

- Add `personal_access_tokens` table migration (000008) for Tyr's PostgreSQL schema
- `owner_id` is a plain TEXT column (IDP sub claim, no FK) since Tyr has no local users table
- Migration is idempotent (`CREATE TABLE IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`)
- Updated both local SQL files and Helm migrations-configmap

## Changes

- `migrations/tyr/000008_personal_access_tokens.up.sql` — creates table + index
- `migrations/tyr/000008_personal_access_tokens.down.sql` — drops table
- `charts/tyr/templates/migrations-configmap.yaml` — embeds migration SQL

## Test plan

- [x] Migration SQL uses idempotent statements
- [x] Down migration correctly drops the table
- [x] Helm configmap matches local SQL files
- [x] No Python changes (SQL-only ticket)

Closes NIU-227

🤖 Generated with [Claude Code](https://claude.com/claude-code)