### PR TITLE
feat(volundr): add PATService — JWT signing, creation and revocation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "httpx>=0.27",
     "fastapi>=0.109",
     "python-multipart>=0.0.9",
+    "PyJWT>=2.8",
     "uvicorn>=0.27",
     "websockets>=12.0",
     "python-on-whales>=0.70",

--- a/src/volundr/adapters/outbound/postgres_pats.py
+++ b/src/volundr/adapters/outbound/postgres_pats.py
@@ -1,0 +1,79 @@
+"""PostgreSQL adapter for personal access token repository."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import asyncpg
+
+from volundr.domain.models import PersonalAccessToken
+from volundr.domain.ports import PATRepository
+
+
+class PostgresPATRepository(PATRepository):
+    """PostgreSQL implementation of PATRepository using raw SQL."""
+
+    def __init__(self, pool: asyncpg.Pool) -> None:
+        self._pool = pool
+
+    async def create(self, owner_id: str, name: str, token_hash: str) -> PersonalAccessToken:
+        """Persist a new PAT record."""
+        row = await self._pool.fetchrow(
+            """
+            INSERT INTO personal_access_tokens (owner_id, name, token_hash)
+            VALUES ($1, $2, $3)
+            RETURNING id, owner_id, name, created_at, last_used_at
+            """,
+            owner_id,
+            name,
+            token_hash,
+        )
+        return self._row_to_pat(row)
+
+    async def list(self, owner_id: str) -> list[PersonalAccessToken]:
+        """List all PATs for an owner."""
+        rows = await self._pool.fetch(
+            """
+            SELECT id, owner_id, name, created_at, last_used_at
+            FROM personal_access_tokens
+            WHERE owner_id = $1
+            ORDER BY created_at DESC
+            """,
+            owner_id,
+        )
+        return [self._row_to_pat(row) for row in rows]
+
+    async def get(self, pat_id: UUID, owner_id: str) -> PersonalAccessToken | None:
+        """Retrieve a PAT by ID scoped to an owner."""
+        row = await self._pool.fetchrow(
+            """
+            SELECT id, owner_id, name, created_at, last_used_at
+            FROM personal_access_tokens
+            WHERE id = $1 AND owner_id = $2
+            """,
+            pat_id,
+            owner_id,
+        )
+        if row is None:
+            return None
+        return self._row_to_pat(row)
+
+    async def delete(self, pat_id: UUID, owner_id: str) -> bool:
+        """Delete a PAT. Returns True if deleted."""
+        result = await self._pool.execute(
+            "DELETE FROM personal_access_tokens WHERE id = $1 AND owner_id = $2",
+            pat_id,
+            owner_id,
+        )
+        return result == "DELETE 1"
+
+    @staticmethod
+    def _row_to_pat(row: asyncpg.Record) -> PersonalAccessToken:
+        """Convert a database row to a PersonalAccessToken domain model."""
+        return PersonalAccessToken(
+            id=row["id"],
+            owner_id=row["owner_id"],
+            name=row["name"],
+            created_at=row["created_at"],
+            last_used_at=row["last_used_at"],
+        )

--- a/src/volundr/config.py
+++ b/src/volundr/config.py
@@ -909,6 +909,19 @@ def _default_feature_modules() -> list[FeatureModuleConfig]:
     ]
 
 
+class PATConfig(BaseModel):
+    """Personal access token configuration."""
+
+    signing_key: str = Field(
+        default="",
+        description="Symmetric signing key for PAT JWTs (same key Envoy uses for validation).",
+    )
+    ttl_days: int = Field(
+        default=365,
+        description="Default PAT lifetime in days.",
+    )
+
+
 class AuthDiscoveryConfig(BaseModel):
     """Public auth discovery configuration for CLI and external clients.
 
@@ -990,6 +1003,7 @@ class Settings(BaseSettings):
     resource_provider: ResourceProviderConfig = Field(default_factory=ResourceProviderConfig)
     storage: StorageConfig = Field(default_factory=StorageConfig)
     linear: LinearConfig = Field(default_factory=LinearConfig)
+    pat: PATConfig = Field(default_factory=PATConfig)
     auth_discovery: AuthDiscoveryConfig = Field(default_factory=AuthDiscoveryConfig)
     integrations: IntegrationsConfig = Field(default_factory=IntegrationsConfig)
     oauth: OAuthConfig = Field(default_factory=OAuthConfig)

--- a/src/volundr/domain/models.py
+++ b/src/volundr/domain/models.py
@@ -1392,6 +1392,17 @@ class SessionSpec:
         return SessionSpec(values=merged_values, pod_spec=merged_pod_spec)
 
 
+@dataclass(frozen=True)
+class PersonalAccessToken:
+    """A personal access token for API authentication."""
+
+    id: UUID
+    owner_id: str
+    name: str
+    created_at: datetime
+    last_used_at: datetime | None = None
+
+
 def _deep_merge(base: dict, override: dict) -> None:
     """Deep-merge override into base in place."""
     for key, value in override.items():

--- a/src/volundr/domain/ports.py
+++ b/src/volundr/domain/ports.py
@@ -26,6 +26,7 @@ from volundr.domain.models import (
     MCPServerConfig,
     Model,
     ModelProvider,
+    PersonalAccessToken,
     PodSpecAdditions,
     Preset,
     Principal,
@@ -1171,6 +1172,26 @@ class ResourceProvider(ABC):
         Returns:
             List of validation error messages (empty = valid).
         """
+
+
+class PATRepository(ABC):
+    """Port for personal access token persistence operations."""
+
+    @abstractmethod
+    async def create(self, owner_id: str, name: str, token_hash: str) -> PersonalAccessToken:
+        """Persist a new PAT record."""
+
+    @abstractmethod
+    async def list(self, owner_id: str) -> list[PersonalAccessToken]:
+        """List all PATs for an owner."""
+
+    @abstractmethod
+    async def get(self, pat_id: UUID, owner_id: str) -> PersonalAccessToken | None:
+        """Retrieve a PAT by ID scoped to an owner."""
+
+    @abstractmethod
+    async def delete(self, pat_id: UUID, owner_id: str) -> bool:
+        """Delete a PAT. Returns True if deleted."""
 
 
 @dataclass(frozen=True)

--- a/src/volundr/domain/services/pat.py
+++ b/src/volundr/domain/services/pat.py
@@ -1,0 +1,63 @@
+"""Domain service for personal access token lifecycle management."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
+
+import jwt
+
+from volundr.domain.models import PersonalAccessToken
+from volundr.domain.ports import PATRepository
+
+logger = logging.getLogger(__name__)
+
+
+class PATService:
+    """Service for creating, listing, and revoking personal access tokens.
+
+    PATs are long-lived JWTs signed with the OIDC signing key so Envoy
+    can validate them with zero infrastructure changes.
+    """
+
+    def __init__(
+        self,
+        repo: PATRepository,
+        signing_key: str,
+        ttl_days: int = 365,
+    ) -> None:
+        self._repo = repo
+        self._signing_key = signing_key
+        self._ttl_days = ttl_days
+
+    async def create(self, owner_id: str, name: str) -> tuple[PersonalAccessToken, str]:
+        """Create a new PAT. Returns (metadata, raw_jwt). raw_jwt shown once only."""
+        now = datetime.now(UTC)
+        jti = str(uuid4())
+        payload = {
+            "sub": owner_id,
+            "type": "pat",
+            "jti": jti,
+            "name": name,
+            "iat": now,
+            "exp": now + timedelta(days=self._ttl_days),
+        }
+        raw_jwt = jwt.encode(payload, self._signing_key, algorithm="HS256")
+        token_hash = hashlib.sha256(raw_jwt.encode()).hexdigest()
+
+        pat = await self._repo.create(owner_id, name, token_hash)
+        logger.info("PAT created: id=%s owner=%s name=%s", pat.id, owner_id, name)
+        return pat, raw_jwt
+
+    async def list(self, owner_id: str) -> list[PersonalAccessToken]:
+        """List all PATs for an owner."""
+        return await self._repo.list(owner_id)
+
+    async def revoke(self, pat_id: UUID, owner_id: str) -> bool:
+        """Revoke (delete) a PAT. Returns True if found and deleted."""
+        deleted = await self._repo.delete(pat_id, owner_id)
+        if deleted:
+            logger.info("PAT revoked: id=%s owner=%s", pat_id, owner_id)
+        return deleted

--- a/src/volundr/main.py
+++ b/src/volundr/main.py
@@ -620,6 +620,18 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             presets_router = create_presets_router(preset_service)
             app.include_router(presets_router)
 
+            # Personal access tokens
+            from volundr.adapters.outbound.postgres_pats import PostgresPATRepository
+            from volundr.domain.services.pat import PATService
+
+            pat_repository = PostgresPATRepository(pool)
+            pat_service = PATService(
+                repo=pat_repository,
+                signing_key=settings.pat.signing_key,
+                ttl_days=settings.pat.ttl_days,
+            )
+            app.state.pat_service = pat_service
+
             git_router = create_git_router(git_workflow_service)
             app.include_router(git_router)
 

--- a/tests/test_adapters/test_postgres_pats.py
+++ b/tests/test_adapters/test_postgres_pats.py
@@ -1,0 +1,162 @@
+"""Tests for PostgreSQL personal access token repository."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+from volundr.adapters.outbound.postgres_pats import PostgresPATRepository
+from volundr.domain.models import PersonalAccessToken
+
+
+def _mock_row(**overrides):
+    defaults = {
+        "id": uuid4(),
+        "owner_id": "user-123",
+        "name": "my-token",
+        "created_at": datetime.now(UTC),
+        "last_used_at": None,
+    }
+    defaults.update(overrides)
+    row = MagicMock()
+    row.__getitem__ = lambda self, key: defaults[key]
+    return row
+
+
+def _make_repo(pool=None):
+    if pool is None:
+        pool = AsyncMock()
+    return PostgresPATRepository(pool), pool
+
+
+class TestCreate:
+    async def test_create_inserts_and_returns_pat(self):
+        repo, pool = _make_repo()
+        pool.fetchrow.return_value = _mock_row()
+
+        result = await repo.create("user-123", "my-token", "hash-abc")
+
+        assert isinstance(result, PersonalAccessToken)
+        assert result.owner_id == "user-123"
+        assert result.name == "my-token"
+        pool.fetchrow.assert_called_once()
+        call_sql = pool.fetchrow.call_args[0][0]
+        assert "INSERT INTO personal_access_tokens" in call_sql
+
+    async def test_create_passes_correct_params(self):
+        repo, pool = _make_repo()
+        pool.fetchrow.return_value = _mock_row()
+
+        await repo.create("owner-1", "token-name", "hash-xyz")
+
+        args = pool.fetchrow.call_args[0]
+        assert args[1] == "owner-1"
+        assert args[2] == "token-name"
+        assert args[3] == "hash-xyz"
+
+
+class TestList:
+    async def test_list_returns_pats(self):
+        repo, pool = _make_repo()
+        pool.fetch.return_value = [_mock_row(), _mock_row(name="second")]
+
+        result = await repo.list("user-123")
+
+        assert len(result) == 2
+        assert all(isinstance(p, PersonalAccessToken) for p in result)
+
+    async def test_list_empty(self):
+        repo, pool = _make_repo()
+        pool.fetch.return_value = []
+
+        result = await repo.list("user-123")
+
+        assert result == []
+
+    async def test_list_filters_by_owner(self):
+        repo, pool = _make_repo()
+        pool.fetch.return_value = []
+
+        await repo.list("owner-abc")
+
+        call_sql = pool.fetch.call_args[0][0]
+        assert "owner_id" in call_sql
+        assert pool.fetch.call_args[0][1] == "owner-abc"
+
+
+class TestGet:
+    async def test_get_existing(self):
+        repo, pool = _make_repo()
+        pat_id = uuid4()
+        pool.fetchrow.return_value = _mock_row(id=pat_id)
+
+        result = await repo.get(pat_id, "user-123")
+
+        assert result is not None
+        assert result.id == pat_id
+
+    async def test_get_missing(self):
+        repo, pool = _make_repo()
+        pool.fetchrow.return_value = None
+
+        result = await repo.get(uuid4(), "user-123")
+
+        assert result is None
+
+    async def test_get_scopes_by_owner(self):
+        repo, pool = _make_repo()
+        pool.fetchrow.return_value = None
+        pat_id = uuid4()
+
+        await repo.get(pat_id, "owner-x")
+
+        call_sql = pool.fetchrow.call_args[0][0]
+        assert "owner_id" in call_sql
+        assert pool.fetchrow.call_args[0][2] == "owner-x"
+
+
+class TestDelete:
+    async def test_delete_success(self):
+        repo, pool = _make_repo()
+        pool.execute.return_value = "DELETE 1"
+
+        result = await repo.delete(uuid4(), "user-123")
+
+        assert result is True
+
+    async def test_delete_not_found(self):
+        repo, pool = _make_repo()
+        pool.execute.return_value = "DELETE 0"
+
+        result = await repo.delete(uuid4(), "user-123")
+
+        assert result is False
+
+    async def test_delete_scopes_by_owner(self):
+        repo, pool = _make_repo()
+        pool.execute.return_value = "DELETE 0"
+        pat_id = uuid4()
+
+        await repo.delete(pat_id, "owner-y")
+
+        call_sql = pool.execute.call_args[0][0]
+        assert "owner_id" in call_sql
+
+
+class TestRowToPat:
+    def test_converts_row(self):
+        row = _mock_row()
+        result = PostgresPATRepository._row_to_pat(row)
+
+        assert isinstance(result, PersonalAccessToken)
+        assert result.owner_id == "user-123"
+        assert result.name == "my-token"
+        assert result.last_used_at is None
+
+    def test_converts_row_with_last_used(self):
+        now = datetime.now(UTC)
+        row = _mock_row(last_used_at=now)
+        result = PostgresPATRepository._row_to_pat(row)
+
+        assert result.last_used_at == now

--- a/tests/test_domain/test_pat_service.py
+++ b/tests/test_domain/test_pat_service.py
@@ -1,0 +1,144 @@
+"""Tests for PATService domain service."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import jwt
+
+from volundr.domain.models import PersonalAccessToken
+from volundr.domain.services.pat import PATService
+
+SIGNING_KEY = "test-secret-key-for-jwt-signing!"
+
+
+def _make_service(repo=None, signing_key=SIGNING_KEY, ttl_days=365):
+    if repo is None:
+        repo = AsyncMock()
+    return PATService(repo=repo, signing_key=signing_key, ttl_days=ttl_days), repo
+
+
+def _make_pat(**overrides):
+    defaults = {
+        "id": uuid4(),
+        "owner_id": "user-123",
+        "name": "my-token",
+        "created_at": datetime.now(UTC),
+        "last_used_at": None,
+    }
+    defaults.update(overrides)
+    return PersonalAccessToken(**defaults)
+
+
+class TestCreate:
+    async def test_create_returns_pat_and_jwt(self):
+        service, repo = _make_service()
+        pat = _make_pat()
+        repo.create.return_value = pat
+
+        result_pat, raw_jwt = await service.create("user-123", "my-token")
+
+        assert result_pat is pat
+        assert isinstance(raw_jwt, str)
+        assert len(raw_jwt) > 0
+
+    async def test_create_jwt_has_correct_payload(self):
+        service, repo = _make_service(ttl_days=30)
+        repo.create.return_value = _make_pat()
+
+        _, raw_jwt = await service.create("user-abc", "deploy-key")
+
+        payload = jwt.decode(raw_jwt, SIGNING_KEY, algorithms=["HS256"])
+        assert payload["sub"] == "user-abc"
+        assert payload["type"] == "pat"
+        assert payload["name"] == "deploy-key"
+        assert "jti" in payload
+        assert "iat" in payload
+        assert "exp" in payload
+
+    async def test_create_stores_sha256_hash(self):
+        service, repo = _make_service()
+        repo.create.return_value = _make_pat()
+
+        _, raw_jwt = await service.create("user-123", "my-token")
+
+        expected_hash = hashlib.sha256(raw_jwt.encode()).hexdigest()
+        call_args = repo.create.call_args[0]
+        assert call_args[0] == "user-123"
+        assert call_args[1] == "my-token"
+        assert call_args[2] == expected_hash
+
+    async def test_create_jwt_respects_ttl_days(self):
+        service, repo = _make_service(ttl_days=7)
+        repo.create.return_value = _make_pat()
+
+        _, raw_jwt = await service.create("user-123", "short-lived")
+
+        payload = jwt.decode(raw_jwt, SIGNING_KEY, algorithms=["HS256"])
+        iat = payload["iat"]
+        exp = payload["exp"]
+        assert exp - iat == 7 * 86400
+
+    async def test_create_jwt_uses_hs256(self):
+        service, repo = _make_service()
+        repo.create.return_value = _make_pat()
+
+        _, raw_jwt = await service.create("user-123", "my-token")
+
+        header = jwt.get_unverified_header(raw_jwt)
+        assert header["alg"] == "HS256"
+
+    async def test_create_unique_jti_per_call(self):
+        service, repo = _make_service()
+        repo.create.return_value = _make_pat()
+
+        _, jwt1 = await service.create("user-123", "token-1")
+        _, jwt2 = await service.create("user-123", "token-2")
+
+        payload1 = jwt.decode(jwt1, SIGNING_KEY, algorithms=["HS256"])
+        payload2 = jwt.decode(jwt2, SIGNING_KEY, algorithms=["HS256"])
+        assert payload1["jti"] != payload2["jti"]
+
+
+class TestList:
+    async def test_list_delegates_to_repo(self):
+        service, repo = _make_service()
+        pats = [_make_pat(), _make_pat(name="second")]
+        repo.list.return_value = pats
+
+        result = await service.list("user-123")
+
+        assert result is pats
+        repo.list.assert_called_once_with("user-123")
+
+    async def test_list_empty(self):
+        service, repo = _make_service()
+        repo.list.return_value = []
+
+        result = await service.list("user-456")
+
+        assert result == []
+
+
+class TestRevoke:
+    async def test_revoke_success(self):
+        service, repo = _make_service()
+        repo.delete.return_value = True
+        pat_id = uuid4()
+
+        result = await service.revoke(pat_id, "user-123")
+
+        assert result is True
+        repo.delete.assert_called_once_with(pat_id, "user-123")
+
+    async def test_revoke_not_found(self):
+        service, repo = _make_service()
+        repo.delete.return_value = False
+        pat_id = uuid4()
+
+        result = await service.revoke(pat_id, "user-123")
+
+        assert result is False


### PR DESCRIPTION
## Summary

- Added `PersonalAccessToken` frozen dataclass to `volundr.domain.models`
- Added `PATRepository` ABC port to `volundr.domain.ports` with create/list/get/delete
- Implemented `PostgresPATRepository` adapter with raw asyncpg queries (owner-scoped)
- Implemented `PATService` domain service: creates HS256-signed JWTs with SHA-256 hash storage, lists tokens, and revokes by delete
- Added `PATConfig` (signing_key, ttl_days) to `volundr.config.Settings`
- Wired `PostgresPATRepository` → `PATService` → `app.state.pat_service` in `main.py`
- Added `PyJWT>=2.8` to project dependencies

## Test plan

- [x] 13 adapter tests (`test_postgres_pats.py`): create, list, get, delete, row conversion
- [x] 10 service tests (`test_pat_service.py`): JWT payload verification, hash storage, TTL, unique JTI, list delegation, revoke
- [x] 100% coverage on new files (`postgres_pats.py`, `pat.py`)
- [x] Overall coverage 86.63% (above 85% threshold)
- [x] `ruff check` and `ruff format` clean
- [x] All 2950 existing tests still pass (4 pre-existing skuld config failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)