### PR TITLE
feat(volundr): POST/GET/DELETE /api/v1/users/tokens endpoints

### DIFF
--- a/charts/volundr/templates/secret.yaml
+++ b/charts/volundr/templates/secret.yaml
@@ -22,3 +22,15 @@ stringData:
   {{- toYaml . | nindent 2 }}
   {{- end }}
 {{- end }}
+---
+{{- if .Values.auth.createSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "volundr.fullname" . }}-auth
+  labels:
+    {{- include "volundr.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  AUTH__PAT_SIGNING_KEY: {{ .Values.auth.patSigningKey | default "" | quote }}
+{{- end }}

--- a/charts/volundr/values.yaml
+++ b/charts/volundr/values.yaml
@@ -728,6 +728,13 @@ authDiscovery:
   # -- OIDC scopes
   scopes: "openid profile email"
 
+# Auth secrets (PAT signing key, etc.)
+auth:
+  # -- Create a K8s Secret for auth-related keys (disable if using an existing secret)
+  createSecret: true
+  # -- Symmetric signing key for PAT JWTs (overridden in production via values/sealed-secrets)
+  patSigningKey: ""
+
 # OAuth integration configuration
 oauth:
   # -- Base URL for OAuth redirect callbacks (e.g. https://volundr.example.com)

--- a/src/volundr/adapters/inbound/rest_pats.py
+++ b/src/volundr/adapters/inbound/rest_pats.py
@@ -1,0 +1,120 @@
+"""FastAPI REST adapter for personal access token management."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel, Field
+
+from volundr.adapters.inbound.auth import extract_principal
+from volundr.domain.models import Principal
+from volundr.domain.services.pat import PATService
+
+logger = logging.getLogger(__name__)
+
+
+class CreatePATRequest(BaseModel):
+    """Request model for creating a personal access token."""
+
+    name: str = Field(
+        min_length=1,
+        max_length=100,
+        description="Human-readable label for the token",
+    )
+
+
+class PATResponse(BaseModel):
+    """Response model for a personal access token (no raw token)."""
+
+    id: str
+    name: str
+    created_at: datetime
+    last_used_at: datetime | None
+
+
+class CreatePATResponse(BaseModel):
+    """Response model returned once on creation (includes raw token)."""
+
+    id: str
+    name: str
+    token: str
+    created_at: datetime
+
+
+def create_pats_router() -> APIRouter:
+    """Create the personal access tokens router."""
+    router = APIRouter(
+        prefix="/api/v1/users/tokens",
+        tags=["Personal Access Tokens"],
+    )
+
+    @router.post(
+        "",
+        response_model=CreatePATResponse,
+        status_code=status.HTTP_201_CREATED,
+    )
+    async def create_token(
+        body: CreatePATRequest,
+        principal: Principal = Depends(extract_principal),
+        request: Request = None,
+    ) -> CreatePATResponse:
+        """Create a new personal access token. The raw token is shown once."""
+        service: PATService = request.app.state.pat_service
+        pat, raw_token = await service.create(principal.user_id, body.name)
+        return CreatePATResponse(
+            id=str(pat.id),
+            name=pat.name,
+            token=raw_token,
+            created_at=pat.created_at,
+        )
+
+    @router.get(
+        "",
+        response_model=list[PATResponse],
+    )
+    async def list_tokens(
+        principal: Principal = Depends(extract_principal),
+        request: Request = None,
+    ) -> list[PATResponse]:
+        """List all personal access tokens for the authenticated user."""
+        service: PATService = request.app.state.pat_service
+        pats = await service.list(principal.user_id)
+        return [
+            PATResponse(
+                id=str(pat.id),
+                name=pat.name,
+                created_at=pat.created_at,
+                last_used_at=pat.last_used_at,
+            )
+            for pat in pats
+        ]
+
+    @router.delete(
+        "/{pat_id}",
+        status_code=status.HTTP_204_NO_CONTENT,
+    )
+    async def revoke_token(
+        pat_id: str,
+        principal: Principal = Depends(extract_principal),
+        request: Request = None,
+    ) -> None:
+        """Revoke a personal access token by ID."""
+        service: PATService = request.app.state.pat_service
+        try:
+            parsed_id = UUID(pat_id)
+        except ValueError:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"PAT not found: {pat_id}",
+            )
+        deleted = await service.revoke(parsed_id, principal.user_id)
+        if not deleted:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"PAT not found: {pat_id}",
+            )
+
+    return router

--- a/src/volundr/main.py
+++ b/src/volundr/main.py
@@ -632,6 +632,11 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             )
             app.state.pat_service = pat_service
 
+            from volundr.adapters.inbound.rest_pats import create_pats_router
+
+            pats_router = create_pats_router()
+            app.include_router(pats_router)
+
             git_router = create_git_router(git_workflow_service)
             app.include_router(git_router)
 

--- a/tests/test_adapters/test_rest_pats.py
+++ b/tests/test_adapters/test_rest_pats.py
@@ -1,0 +1,195 @@
+"""Tests for REST personal access token endpoints."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from volundr.adapters.inbound.rest_pats import create_pats_router
+from volundr.domain.models import PersonalAccessToken, Principal
+
+
+def _mock_identity(principal: Principal | None = None):
+    identity = AsyncMock()
+    if principal is None:
+        principal = Principal(
+            user_id="u1",
+            email="user@test.com",
+            tenant_id="t1",
+            roles=["volundr:developer"],
+        )
+    identity.validate_token.return_value = principal
+    return identity
+
+
+def _make_pat(
+    owner_id: str = "u1",
+    name: str = "my-token",
+    last_used_at: datetime | None = None,
+) -> PersonalAccessToken:
+    return PersonalAccessToken(
+        id=uuid4(),
+        owner_id=owner_id,
+        name=name,
+        created_at=datetime.now(UTC),
+        last_used_at=last_used_at,
+    )
+
+
+def _make_app(
+    identity=None,
+    pat_service: AsyncMock | None = None,
+) -> tuple[FastAPI, AsyncMock]:
+    service = pat_service or AsyncMock()
+    app = FastAPI()
+    app.state.identity = identity or _mock_identity()
+    app.state.pat_service = service
+    router = create_pats_router()
+    app.include_router(router)
+    return app, service
+
+
+AUTH = {"Authorization": "Bearer tok"}
+PREFIX = "/api/v1/users/tokens"
+
+
+class TestCreateToken:
+    """Tests for POST /api/v1/users/tokens."""
+
+    def test_create_returns_201_with_token(self):
+        pat = _make_pat()
+        raw_token = "eyJhbGciOiJIUzI1NiJ9.test.sig"
+        app, service = _make_app()
+        service.create.return_value = (pat, raw_token)
+        client = TestClient(app)
+
+        resp = client.post(PREFIX, json={"name": "my-token"}, headers=AUTH)
+
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["id"] == str(pat.id)
+        assert body["name"] == "my-token"
+        assert body["token"] == raw_token
+        assert "created_at" in body
+        service.create.assert_called_once_with("u1", "my-token")
+
+    def test_create_with_empty_name_returns_422(self):
+        app, _ = _make_app()
+        client = TestClient(app)
+
+        resp = client.post(PREFIX, json={"name": ""}, headers=AUTH)
+
+        assert resp.status_code == 422
+
+    def test_create_with_missing_name_returns_422(self):
+        app, _ = _make_app()
+        client = TestClient(app)
+
+        resp = client.post(PREFIX, json={}, headers=AUTH)
+
+        assert resp.status_code == 422
+
+    def test_create_with_long_name_returns_422(self):
+        app, _ = _make_app()
+        client = TestClient(app)
+
+        resp = client.post(PREFIX, json={"name": "a" * 101}, headers=AUTH)
+
+        assert resp.status_code == 422
+
+    def test_create_without_auth_returns_401(self):
+        app, _ = _make_app()
+        client = TestClient(app)
+
+        resp = client.post(PREFIX, json={"name": "my-token"})
+
+        assert resp.status_code == 401
+
+
+class TestListTokens:
+    """Tests for GET /api/v1/users/tokens."""
+
+    def test_list_empty(self):
+        app, service = _make_app()
+        service.list.return_value = []
+        client = TestClient(app)
+
+        resp = client.get(PREFIX, headers=AUTH)
+
+        assert resp.status_code == 200
+        assert resp.json() == []
+        service.list.assert_called_once_with("u1")
+
+    def test_list_returns_pats(self):
+        pat1 = _make_pat(name="token-a")
+        pat2 = _make_pat(name="token-b", last_used_at=datetime.now(UTC))
+        app, service = _make_app()
+        service.list.return_value = [pat1, pat2]
+        client = TestClient(app)
+
+        resp = client.get(PREFIX, headers=AUTH)
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2
+        assert data[0]["name"] == "token-a"
+        assert data[0]["last_used_at"] is None
+        assert data[1]["name"] == "token-b"
+        assert data[1]["last_used_at"] is not None
+        # Ensure raw token is never in the list response
+        assert "token" not in data[0]
+        assert "token" not in data[1]
+
+    def test_list_without_auth_returns_401(self):
+        app, _ = _make_app()
+        client = TestClient(app)
+
+        resp = client.get(PREFIX)
+
+        assert resp.status_code == 401
+
+
+class TestRevokeToken:
+    """Tests for DELETE /api/v1/users/tokens/{pat_id}."""
+
+    def test_revoke_returns_204(self):
+        pat_id = uuid4()
+        app, service = _make_app()
+        service.revoke.return_value = True
+        client = TestClient(app)
+
+        resp = client.delete(f"{PREFIX}/{pat_id}", headers=AUTH)
+
+        assert resp.status_code == 204
+        assert resp.content == b""
+        service.revoke.assert_called_once_with(pat_id, "u1")
+
+    def test_revoke_nonexistent_returns_404(self):
+        pat_id = uuid4()
+        app, service = _make_app()
+        service.revoke.return_value = False
+        client = TestClient(app)
+
+        resp = client.delete(f"{PREFIX}/{pat_id}", headers=AUTH)
+
+        assert resp.status_code == 404
+
+    def test_revoke_invalid_uuid_returns_404(self):
+        app, _ = _make_app()
+        client = TestClient(app)
+
+        resp = client.delete(f"{PREFIX}/not-a-uuid", headers=AUTH)
+
+        assert resp.status_code == 404
+
+    def test_revoke_without_auth_returns_401(self):
+        app, _ = _make_app()
+        client = TestClient(app)
+
+        resp = client.delete(f"{PREFIX}/{uuid4()}")
+
+        assert resp.status_code == 401


### PR DESCRIPTION
## Summary

- Added `src/volundr/adapters/inbound/rest_pats.py` with `create_pats_router()` exposing three endpoints:
  - **POST** `/api/v1/users/tokens` — create a new PAT (returns 201 with raw JWT shown once)
  - **GET** `/api/v1/users/tokens` — list all PATs for the authenticated user (no raw token)
  - **DELETE** `/api/v1/users/tokens/{pat_id}` — revoke a PAT (204 on success, 404 if not found)
- Registered the router in `main.py` alongside the existing `PATService` wiring
- Added `AUTH__PAT_SIGNING_KEY` to `charts/volundr/templates/secret.yaml` and documented `auth` stanza in `charts/volundr/values.yaml`
- Owner scoping is implicit via `principal.user_id` — no Cerbos call needed

## Test plan

- [x] 12 tests in `tests/test_adapters/test_rest_pats.py` covering:
  - Create returns 201 with token in body
  - Create with empty/missing/too-long name returns 422
  - List returns array (empty and non-empty cases)
  - List response excludes raw token field
  - Delete returns 204
  - Delete non-existent returns 404
  - Delete invalid UUID returns 404
  - All endpoints return 401 without authentication
- [x] `rest_pats.py` at 100% coverage
- [x] `ruff check` and `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)