### PR TITLE
feat(tyr): add api_key constructor param to VolundrHTTPAdapter

### DIFF
--- a/src/tyr/adapters/volundr_http.py
+++ b/src/tyr/adapters/volundr_http.py
@@ -14,20 +14,30 @@ logger = logging.getLogger(__name__)
 class VolundrHTTPAdapter(VolundrPort):
     """Calls Volundr's REST API to manage sessions."""
 
-    def __init__(self, base_url: str, timeout: float = 30.0) -> None:
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str | None = None,
+        timeout: float = 30.0,
+    ) -> None:
         self._base_url = base_url.rstrip("/")
+        self._api_key = api_key
         self._timeout = timeout
-        self._auth_token: str | None = None
+        self._runtime_token: str | None = None
 
     def set_auth_token(self, token: str) -> None:
-        """Set the bearer token for authenticating with Volundr."""
-        self._auth_token = token
+        """Set a per-request token override. Takes precedence over stored api_key."""
+        self._runtime_token = token
+
+    def clear_auth_token(self) -> None:
+        """Clear the per-request override, falling back to stored api_key."""
+        self._runtime_token = None
 
     def _headers(self) -> dict[str, str]:
-        headers: dict[str, str] = {}
-        if self._auth_token:
-            headers["Authorization"] = f"Bearer {self._auth_token}"
-        return headers
+        token = self._runtime_token or self._api_key
+        if token:
+            return {"Authorization": f"Bearer {token}"}
+        return {}
 
     async def spawn_session(self, request: SpawnRequest) -> VolundrSession:
         async with httpx.AsyncClient(timeout=self._timeout) as client:

--- a/tests/test_tyr/test_volundr_http.py
+++ b/tests/test_tyr/test_volundr_http.py
@@ -37,6 +37,30 @@ class TestAuthHeaders:
         adapter.set_auth_token("new")
         assert adapter._headers()["Authorization"] == "Bearer new"
 
+    def test_api_key_provides_header(self):
+        adapter = VolundrHTTPAdapter(base_url=BASE_URL, api_key="pat-abc")
+        assert adapter._headers()["Authorization"] == "Bearer pat-abc"
+
+    def test_runtime_token_overrides_api_key(self):
+        adapter = VolundrHTTPAdapter(base_url=BASE_URL, api_key="pat-abc")
+        adapter.set_auth_token("runtime-tok")
+        assert adapter._headers()["Authorization"] == "Bearer runtime-tok"
+
+    def test_clear_auth_token_restores_api_key(self):
+        adapter = VolundrHTTPAdapter(base_url=BASE_URL, api_key="pat-abc")
+        adapter.set_auth_token("runtime-tok")
+        adapter.clear_auth_token()
+        assert adapter._headers()["Authorization"] == "Bearer pat-abc"
+
+    def test_clear_auth_token_no_api_key(self, adapter: VolundrHTTPAdapter):
+        adapter.set_auth_token("runtime-tok")
+        adapter.clear_auth_token()
+        assert adapter._headers() == {}
+
+    def test_set_auth_token_no_api_key(self, adapter: VolundrHTTPAdapter):
+        adapter.set_auth_token("runtime-tok")
+        assert adapter._headers()["Authorization"] == "Bearer runtime-tok"
+
 
 # -------------------------------------------------------------------
 # spawn_session
@@ -308,3 +332,16 @@ class TestConstructor:
     def test_custom_timeout(self):
         adapter = VolundrHTTPAdapter(base_url="http://example.com", timeout=10.0)
         assert adapter._timeout == 10.0
+
+    def test_default_api_key_is_none(self):
+        adapter = VolundrHTTPAdapter(base_url="http://example.com")
+        assert adapter._api_key is None
+
+    def test_custom_api_key(self):
+        adapter = VolundrHTTPAdapter(base_url="http://example.com", api_key="pat-xyz")
+        assert adapter._api_key == "pat-xyz"
+
+    def test_api_key_with_timeout(self):
+        adapter = VolundrHTTPAdapter(base_url="http://example.com", api_key="pat-xyz", timeout=15.0)
+        assert adapter._api_key == "pat-xyz"
+        assert adapter._timeout == 15.0


### PR DESCRIPTION
## Summary

- Add `api_key: str | None = None` constructor parameter to `VolundrHTTPAdapter` for autonomous dispatcher authentication (PAT-based)
- Rename internal `_auth_token` to `_runtime_token` for clarity — `set_auth_token()` sets the per-request override, `_api_key` is the stored fallback
- Add `clear_auth_token()` method to clear the per-request override and fall back to stored `api_key`
- `_headers()` uses `_runtime_token or _api_key` precedence — existing behaviour unchanged when no `api_key` is provided

## Test plan

- [x] No api_key, no set_auth_token → no Authorization header
- [x] api_key set → Authorization header present
- [x] set_auth_token overrides api_key
- [x] clear_auth_token restores to api_key
- [x] set_auth_token with no api_key → Authorization header with runtime token
- [x] Constructor defaults: api_key=None, timeout=30.0
- [x] All existing `test_dispatch_api.py` tests pass unchanged (55/55 green)

Closes NIU-231

🤖 Generated with [Claude Code](https://claude.com/claude-code)