### PR TITLE
feat(tyr): add VolundrAdapterFactory and TrackerAdapterFactory

### DIFF
--- a/src/tyr/adapters/tracker_factory.py
+++ b/src/tyr/adapters/tracker_factory.py
@@ -1,0 +1,58 @@
+"""Factory for resolving per-owner TrackerPort adapter instances."""
+
+from __future__ import annotations
+
+import logging
+
+from niuu.domain.models import IntegrationType
+from niuu.ports.credentials import CredentialStorePort
+from niuu.ports.integrations import IntegrationRepository
+from niuu.utils import import_class
+from tyr.ports.tracker import TrackerPort
+
+logger = logging.getLogger(__name__)
+
+
+class TrackerAdapterFactory:
+    """Resolves tracker adapters for a specific owner from stored credentials."""
+
+    def __init__(
+        self,
+        integration_repo: IntegrationRepository,
+        credential_store: CredentialStorePort,
+    ) -> None:
+        self._integration_repo = integration_repo
+        self._credential_store = credential_store
+
+    async def for_owner(self, owner_id: str) -> list[TrackerPort]:
+        """Return all enabled TrackerPort adapters for the owner.
+
+        Uses the dynamic adapter pattern: import_class(conn.adapter)(**kwargs).
+        """
+        connections = await self._integration_repo.list_connections(
+            owner_id,
+            integration_type=IntegrationType.ISSUE_TRACKER,
+        )
+        adapters: list[TrackerPort] = []
+        for conn in connections:
+            if not conn.enabled:
+                continue
+            try:
+                cred = await self._credential_store.get_value(
+                    "user",
+                    owner_id,
+                    conn.credential_name,
+                )
+                if cred is None:
+                    continue
+
+                cls = import_class(conn.adapter)
+                kwargs = {**cred, **conn.config}
+                adapters.append(cls(**kwargs))
+            except Exception:
+                logger.warning(
+                    "Failed to create tracker adapter for connection %s",
+                    conn.id,
+                    exc_info=True,
+                )
+        return adapters

--- a/src/tyr/adapters/volundr_factory.py
+++ b/src/tyr/adapters/volundr_factory.py
@@ -1,0 +1,41 @@
+"""Factory for resolving per-owner VolundrHTTPAdapter instances."""
+
+from __future__ import annotations
+
+from niuu.domain.models import IntegrationType
+from niuu.ports.credentials import CredentialStorePort
+from niuu.ports.integrations import IntegrationRepository
+from tyr.adapters.volundr_http import VolundrHTTPAdapter
+
+DEFAULT_VOLUNDR_URL = "http://volundr:8000"
+
+
+class VolundrAdapterFactory:
+    """Resolves a VolundrHTTPAdapter for a specific owner from stored credentials."""
+
+    def __init__(
+        self,
+        integration_repo: IntegrationRepository,
+        credential_store: CredentialStorePort,
+    ) -> None:
+        self._integration_repo = integration_repo
+        self._credential_store = credential_store
+
+    async def for_owner(self, owner_id: str) -> VolundrHTTPAdapter | None:
+        """Return a VolundrHTTPAdapter with stored PAT, or None if not configured."""
+        connections = await self._integration_repo.list_connections(
+            owner_id,
+            integration_type=IntegrationType.CODE_FORGE,
+        )
+        conn = next((c for c in connections if c.enabled), None)
+        if conn is None:
+            return None
+
+        cred = await self._credential_store.get_value("user", owner_id, conn.credential_name)
+        if cred is None:
+            return None
+
+        return VolundrHTTPAdapter(
+            base_url=conn.config.get("url", DEFAULT_VOLUNDR_URL),
+            api_key=cred.get("api_key"),
+        )

--- a/src/tyr/main.py
+++ b/src/tyr/main.py
@@ -10,11 +10,11 @@ from contextlib import asynccontextmanager
 from fastapi import Depends, FastAPI, Request, Response
 
 from niuu.adapters.postgres_integrations import PostgresIntegrationRepository
-from niuu.domain.models import IntegrationType, Principal
-from niuu.ports.credentials import CredentialStorePort
-from niuu.ports.integrations import IntegrationRepository
+from niuu.domain.models import Principal
 from niuu.utils import import_class, resolve_secret_kwargs
 from tyr.adapters.postgres_sagas import PostgresSagaRepository
+from tyr.adapters.tracker_factory import TrackerAdapterFactory
+from tyr.adapters.volundr_factory import VolundrAdapterFactory
 from tyr.adapters.volundr_http import VolundrHTTPAdapter
 from tyr.api.dispatch import create_dispatch_router, resolve_volundr
 from tyr.api.dispatch import resolve_saga_repo as dispatch_resolve_saga_repo
@@ -37,50 +37,6 @@ def _configure_logging(settings: Settings) -> None:
         if settings.logging.format == "text"
         else "%(message)s",
     )
-
-
-async def _resolve_tracker_adapters(
-    principal: Principal,
-    integration_repo: IntegrationRepository,
-    credential_store: CredentialStorePort,
-) -> list[TrackerPort]:
-    """Resolve TrackerPort adapters from the user's integration credentials.
-
-    Uses dynamic adapter pattern: config specifies fully-qualified class path,
-    credentials + config are passed as **kwargs to the constructor.
-    """
-    user_id = principal.user_id
-
-    connections = await integration_repo.list_connections(
-        user_id,
-        integration_type=IntegrationType.ISSUE_TRACKER,
-    )
-
-    adapters: list[TrackerPort] = []
-    for conn in connections:
-        if not conn.enabled:
-            continue
-        try:
-            cred = await credential_store.get_value(
-                "user",
-                conn.user_id,
-                conn.credential_name,
-            )
-            if cred is None:
-                continue
-
-            cls = import_class(conn.adapter)
-            kwargs = {**cred, **conn.config}
-            adapter = cls(**kwargs)
-            adapters.append(adapter)
-        except Exception:
-            logger.warning(
-                "Failed to create tracker adapter for connection %s",
-                conn.id,
-                exc_info=True,
-            )
-
-    return adapters
 
 
 def create_app(settings: Settings | None = None) -> FastAPI:
@@ -119,15 +75,17 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             credential_store = cs_cls(**cs_kwargs)
             logger.info("Credential store: %s", cs_cfg.adapter.rsplit(".", 1)[-1])
 
-            # Override the tracker resolver dependency with real wiring
+            # Wire adapter factories (used by autonomous dispatcher)
+            app.state.volundr_factory = VolundrAdapterFactory(integration_repo, credential_store)
+            app.state.tracker_factory = TrackerAdapterFactory(integration_repo, credential_store)
+
+            # Override the tracker resolver dependency with factory delegation
             from tyr.adapters.inbound.auth import extract_principal
 
             async def _resolve(
                 principal: Principal = Depends(extract_principal),
             ) -> list[TrackerPort]:
-                return await _resolve_tracker_adapters(
-                    principal, integration_repo, credential_store
-                )
+                return await app.state.tracker_factory.for_owner(principal.user_id)
 
             app.dependency_overrides[resolve_trackers] = _resolve
 

--- a/tests/test_tyr/test_tracker_factory.py
+++ b/tests/test_tyr/test_tracker_factory.py
@@ -1,0 +1,230 @@
+"""Tests for TrackerAdapterFactory."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+import pytest
+
+from niuu.domain.models import IntegrationConnection, IntegrationType
+from niuu.ports.credentials import CredentialStorePort
+from niuu.ports.integrations import IntegrationRepository
+from tyr.adapters.tracker_factory import TrackerAdapterFactory
+from tyr.ports.tracker import TrackerPort
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+_NOW = datetime.now(tz=UTC)
+
+
+def _make_connection(
+    *,
+    id: str = "conn-1",
+    enabled: bool = True,
+    credential_name: str = "linear-cred",
+    adapter: str = "tests.test_tyr.test_tracker_factory.FakeTracker",
+    config: dict | None = None,
+) -> IntegrationConnection:
+    return IntegrationConnection(
+        id=id,
+        user_id="owner-1",
+        integration_type=IntegrationType.ISSUE_TRACKER,
+        adapter=adapter,
+        credential_name=credential_name,
+        config=config or {"team_id": "TEAM-1"},
+        enabled=enabled,
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+
+
+class StubIntegrationRepo(IntegrationRepository):
+    """In-memory integration repository for testing."""
+
+    def __init__(self, connections: list[IntegrationConnection] | None = None) -> None:
+        self._connections = connections or []
+
+    async def list_connections(
+        self,
+        user_id: str,
+        integration_type: IntegrationType | None = None,
+    ) -> list[IntegrationConnection]:
+        return [
+            c
+            for c in self._connections
+            if c.user_id == user_id
+            and (integration_type is None or c.integration_type == integration_type)
+        ]
+
+    async def get_connection(self, connection_id: str) -> IntegrationConnection | None:
+        return next((c for c in self._connections if c.id == connection_id), None)
+
+    async def save_connection(self, connection: IntegrationConnection) -> IntegrationConnection:
+        return connection
+
+    async def delete_connection(self, connection_id: str) -> None:
+        pass
+
+
+class StubCredentialStore(CredentialStorePort):
+    """In-memory credential store for testing."""
+
+    def __init__(self, values: dict[str, dict[str, str]] | None = None) -> None:
+        self._values = values or {}
+
+    async def get_value(self, owner_type: str, owner_id: str, name: str) -> dict[str, str] | None:
+        return self._values.get(f"{owner_type}:{owner_id}:{name}")
+
+    async def store(self, *args, **kwargs):  # noqa: ANN002, ANN003
+        raise NotImplementedError
+
+    async def get(self, *args, **kwargs):  # noqa: ANN002, ANN003
+        raise NotImplementedError
+
+    async def delete(self, *args, **kwargs):  # noqa: ANN002, ANN003
+        raise NotImplementedError
+
+    async def list(self, *args, **kwargs):  # noqa: ANN002, ANN003
+        raise NotImplementedError
+
+    async def health_check(self) -> bool:
+        return True
+
+
+class FakeTracker(TrackerPort):
+    """Minimal TrackerPort stub for dynamic import testing."""
+
+    def __init__(self, **kwargs) -> None:  # noqa: ANN003
+        self.kwargs = kwargs
+
+    async def create_saga(self, saga):  # noqa: ANN001
+        return "s-1"
+
+    async def create_phase(self, phase):  # noqa: ANN001
+        return "p-1"
+
+    async def create_raid(self, raid):  # noqa: ANN001
+        return "r-1"
+
+    async def update_raid_state(self, raid_id, state):  # noqa: ANN001
+        pass
+
+    async def close_raid(self, raid_id):  # noqa: ANN001
+        pass
+
+    async def get_saga(self, saga_id):  # noqa: ANN001
+        raise NotImplementedError
+
+    async def get_phase(self, tracker_id):  # noqa: ANN001
+        raise NotImplementedError
+
+    async def get_raid(self, tracker_id):  # noqa: ANN001
+        raise NotImplementedError
+
+    async def list_pending_raids(self, phase_id):  # noqa: ANN001
+        return []
+
+    async def list_projects(self):
+        return []
+
+    async def get_project(self, project_id):  # noqa: ANN001
+        raise NotImplementedError
+
+    async def list_milestones(self, project_id):  # noqa: ANN001
+        return []
+
+    async def list_issues(self, project_id, milestone_id=None):  # noqa: ANN001
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_connections_returns_empty_list() -> None:
+    factory = TrackerAdapterFactory(
+        integration_repo=StubIntegrationRepo(connections=[]),
+        credential_store=StubCredentialStore(),
+    )
+    result = await factory.for_owner("owner-1")
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_one_enabled_one_disabled_returns_only_enabled() -> None:
+    enabled = _make_connection(id="conn-1", enabled=True, credential_name="cred-a")
+    disabled = _make_connection(id="conn-2", enabled=False, credential_name="cred-b")
+    factory = TrackerAdapterFactory(
+        integration_repo=StubIntegrationRepo(connections=[enabled, disabled]),
+        credential_store=StubCredentialStore(
+            values={
+                "user:owner-1:cred-a": {"api_key": "tok-a"},
+                "user:owner-1:cred-b": {"api_key": "tok-b"},
+            }
+        ),
+    )
+    result = await factory.for_owner("owner-1")
+    assert len(result) == 1
+    assert isinstance(result[0], FakeTracker)
+    assert result[0].kwargs["api_key"] == "tok-a"
+    assert result[0].kwargs["team_id"] == "TEAM-1"
+
+
+@pytest.mark.asyncio
+async def test_credential_missing_skips_adapter() -> None:
+    conn = _make_connection(enabled=True)
+    factory = TrackerAdapterFactory(
+        integration_repo=StubIntegrationRepo(connections=[conn]),
+        credential_store=StubCredentialStore(values={}),
+    )
+    result = await factory.for_owner("owner-1")
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_adapter_instantiation_failure_logged_and_skipped(caplog) -> None:  # noqa: ANN001
+    conn = _make_connection(
+        id="conn-bad",
+        enabled=True,
+        adapter="tests.test_tyr.test_tracker_factory.NonExistentClass",
+    )
+    good_conn = _make_connection(id="conn-good", enabled=True, credential_name="cred-good")
+    factory = TrackerAdapterFactory(
+        integration_repo=StubIntegrationRepo(connections=[conn, good_conn]),
+        credential_store=StubCredentialStore(
+            values={
+                "user:owner-1:linear-cred": {"api_key": "tok-bad"},
+                "user:owner-1:cred-good": {"api_key": "tok-good"},
+            }
+        ),
+    )
+    with caplog.at_level(logging.WARNING):
+        result = await factory.for_owner("owner-1")
+
+    assert len(result) == 1
+    assert isinstance(result[0], FakeTracker)
+    assert "Failed to create tracker adapter for connection conn-bad" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_config_merged_with_credentials() -> None:
+    conn = _make_connection(
+        enabled=True,
+        config={"team_id": "TEAM-X", "extra_setting": "val"},
+    )
+    factory = TrackerAdapterFactory(
+        integration_repo=StubIntegrationRepo(connections=[conn]),
+        credential_store=StubCredentialStore(
+            values={"user:owner-1:linear-cred": {"api_key": "tok-merge"}}
+        ),
+    )
+    result = await factory.for_owner("owner-1")
+    assert len(result) == 1
+    assert result[0].kwargs["api_key"] == "tok-merge"
+    assert result[0].kwargs["team_id"] == "TEAM-X"
+    assert result[0].kwargs["extra_setting"] == "val"

--- a/tests/test_tyr/test_volundr_factory.py
+++ b/tests/test_tyr/test_volundr_factory.py
@@ -1,0 +1,175 @@
+"""Tests for VolundrAdapterFactory."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from niuu.domain.models import IntegrationConnection, IntegrationType
+from niuu.ports.credentials import CredentialStorePort
+from niuu.ports.integrations import IntegrationRepository
+from tyr.adapters.volundr_factory import VolundrAdapterFactory
+from tyr.adapters.volundr_http import VolundrHTTPAdapter
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+_NOW = datetime.now(tz=UTC)
+
+
+def _make_connection(
+    *,
+    enabled: bool = True,
+    integration_type: IntegrationType = IntegrationType.CODE_FORGE,
+    credential_name: str = "volundr-pat",
+    config: dict | None = None,
+) -> IntegrationConnection:
+    return IntegrationConnection(
+        id="conn-1",
+        user_id="owner-1",
+        integration_type=integration_type,
+        adapter="tyr.adapters.volundr_http.VolundrHTTPAdapter",
+        credential_name=credential_name,
+        config={"url": "http://volundr-test:8000"} if config is None else config,
+        enabled=enabled,
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+
+
+class StubIntegrationRepo(IntegrationRepository):
+    """In-memory integration repository for testing."""
+
+    def __init__(self, connections: list[IntegrationConnection] | None = None) -> None:
+        self._connections = connections or []
+
+    async def list_connections(
+        self,
+        user_id: str,
+        integration_type: IntegrationType | None = None,
+    ) -> list[IntegrationConnection]:
+        return [
+            c
+            for c in self._connections
+            if c.user_id == user_id
+            and (integration_type is None or c.integration_type == integration_type)
+        ]
+
+    async def get_connection(self, connection_id: str) -> IntegrationConnection | None:
+        return next((c for c in self._connections if c.id == connection_id), None)
+
+    async def save_connection(self, connection: IntegrationConnection) -> IntegrationConnection:
+        return connection
+
+    async def delete_connection(self, connection_id: str) -> None:
+        pass
+
+
+class StubCredentialStore(CredentialStorePort):
+    """In-memory credential store for testing."""
+
+    def __init__(self, values: dict[str, dict[str, str]] | None = None) -> None:
+        self._values = values or {}
+
+    async def get_value(self, owner_type: str, owner_id: str, name: str) -> dict[str, str] | None:
+        return self._values.get(f"{owner_type}:{owner_id}:{name}")
+
+    async def store(self, *args, **kwargs):  # noqa: ANN002, ANN003
+        raise NotImplementedError
+
+    async def get(self, *args, **kwargs):  # noqa: ANN002, ANN003
+        raise NotImplementedError
+
+    async def delete(self, *args, **kwargs):  # noqa: ANN002, ANN003
+        raise NotImplementedError
+
+    async def list(self, *args, **kwargs):  # noqa: ANN002, ANN003
+        raise NotImplementedError
+
+    async def health_check(self) -> bool:
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_code_forge_connection_returns_none() -> None:
+    factory = VolundrAdapterFactory(
+        integration_repo=StubIntegrationRepo(connections=[]),
+        credential_store=StubCredentialStore(),
+    )
+    result = await factory.for_owner("owner-1")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_disabled_connection_returns_none() -> None:
+    conn = _make_connection(enabled=False)
+    factory = VolundrAdapterFactory(
+        integration_repo=StubIntegrationRepo(connections=[conn]),
+        credential_store=StubCredentialStore(
+            values={"user:owner-1:volundr-pat": {"api_key": "tok-123"}}
+        ),
+    )
+    result = await factory.for_owner("owner-1")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_enabled_connection_valid_cred_returns_adapter() -> None:
+    conn = _make_connection(enabled=True)
+    factory = VolundrAdapterFactory(
+        integration_repo=StubIntegrationRepo(connections=[conn]),
+        credential_store=StubCredentialStore(
+            values={"user:owner-1:volundr-pat": {"api_key": "tok-123"}}
+        ),
+    )
+    result = await factory.for_owner("owner-1")
+    assert isinstance(result, VolundrHTTPAdapter)
+    assert result._api_key == "tok-123"
+    assert result._base_url == "http://volundr-test:8000"
+
+
+@pytest.mark.asyncio
+async def test_credential_store_returns_none() -> None:
+    conn = _make_connection(enabled=True)
+    factory = VolundrAdapterFactory(
+        integration_repo=StubIntegrationRepo(connections=[conn]),
+        credential_store=StubCredentialStore(values={}),
+    )
+    result = await factory.for_owner("owner-1")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_uses_default_url_when_not_in_config() -> None:
+    conn = _make_connection(enabled=True, config={})
+    factory = VolundrAdapterFactory(
+        integration_repo=StubIntegrationRepo(connections=[conn]),
+        credential_store=StubCredentialStore(
+            values={"user:owner-1:volundr-pat": {"api_key": "tok-456"}}
+        ),
+    )
+    result = await factory.for_owner("owner-1")
+    assert isinstance(result, VolundrHTTPAdapter)
+    assert result._base_url == "http://volundr:8000"
+
+
+@pytest.mark.asyncio
+async def test_picks_first_enabled_connection() -> None:
+    disabled = _make_connection(enabled=False)
+    enabled = _make_connection(enabled=True, config={"url": "http://second:8000"})
+    factory = VolundrAdapterFactory(
+        integration_repo=StubIntegrationRepo(connections=[disabled, enabled]),
+        credential_store=StubCredentialStore(
+            values={"user:owner-1:volundr-pat": {"api_key": "tok-789"}}
+        ),
+    )
+    result = await factory.for_owner("owner-1")
+    assert isinstance(result, VolundrHTTPAdapter)
+    assert result._base_url == "http://second:8000"


### PR DESCRIPTION
## Summary

- Add `VolundrAdapterFactory` that resolves a per-owner `VolundrHTTPAdapter` from stored integration connections and credentials (`CODE_FORGE` type). Returns `None` when no enabled connection exists.
- Add `TrackerAdapterFactory` that resolves all enabled `TrackerPort` adapters for an owner using the dynamic adapter pattern (`ISSUE_TRACKER` type). Logs and skips failed instantiations gracefully.
- Wire both factories on `app.state` in `main.py` lifespan for use by the autonomous dispatcher.
- Replace the inline `_resolve_tracker_adapters()` function in `main.py` with delegation to `TrackerAdapterFactory.for_owner()`.

## Test plan

- [x] `test_volundr_factory.py`: no connection → None, disabled → None, valid cred → adapter with api_key, missing cred → None, default URL fallback, picks first enabled
- [x] `test_tracker_factory.py`: no connections → empty list, enabled+disabled filtering, missing cred skipped, instantiation failure logged and skipped, config merged with credentials
- [x] 100% coverage on both factory modules
- [x] `ruff check` and `ruff format` clean
- [x] Full test suite passes (2986 passed, 4 pre-existing failures in unrelated skuld config tests)

Closes NIU-232

🤖 Generated with [Claude Code](https://claude.com/claude-code)