### PR TITLE
feat(tyr): add GET/PATCH /api/v1/tyr/dispatcher endpoints

### DIFF
--- a/src/tyr/adapters/postgres_dispatcher.py
+++ b/src/tyr/adapters/postgres_dispatcher.py
@@ -1,0 +1,79 @@
+"""PostgreSQL implementation of DispatcherRepository."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import asyncpg
+
+from tyr.domain.models import DispatcherState
+from tyr.ports.dispatcher_repository import DispatcherRepository
+
+# Defaults used when creating a new dispatcher state row.
+_DEFAULT_RUNNING = True
+_DEFAULT_THRESHOLD = 0.75
+_DEFAULT_MAX_CONCURRENT_RAIDS = 3
+
+
+class PostgresDispatcherRepository(DispatcherRepository):
+    """Dispatcher state persistence backed by asyncpg."""
+
+    def __init__(self, pool: asyncpg.Pool) -> None:
+        self._pool = pool
+
+    async def get_or_create(self, owner_id: str) -> DispatcherState:
+        row = await self._pool.fetchrow(
+            """
+            INSERT INTO dispatcher_state
+                (owner_id, running, threshold, max_concurrent_raids, updated_at)
+            VALUES ($1, $2, $3, $4, NOW())
+            ON CONFLICT (owner_id)
+            DO UPDATE SET owner_id = dispatcher_state.owner_id
+            RETURNING *
+            """,
+            owner_id,
+            _DEFAULT_RUNNING,
+            _DEFAULT_THRESHOLD,
+            _DEFAULT_MAX_CONCURRENT_RAIDS,
+        )
+        return self._row_to_state(row)
+
+    async def update(self, owner_id: str, **fields: object) -> DispatcherState:
+        allowed = {"running", "threshold", "max_concurrent_raids"}
+        to_set = {k: v for k, v in fields.items() if k in allowed and v is not None}
+
+        if not to_set:
+            return await self.get_or_create(owner_id)
+
+        # Build dynamic SET clause
+        set_parts: list[str] = []
+        params: list[object] = []
+        idx = 1
+        for col, val in to_set.items():
+            set_parts.append(f"{col} = ${idx}")
+            params.append(val)
+            idx += 1
+        set_parts.append(f"updated_at = ${idx}")
+        params.append(datetime.now(UTC))
+        idx += 1
+
+        params.append(owner_id)
+        sql = (
+            f"UPDATE dispatcher_state SET {', '.join(set_parts)} "  # noqa: S608
+            f"WHERE owner_id = ${idx} RETURNING *"
+        )
+        row = await self._pool.fetchrow(sql, *params)
+        if row is None:
+            return await self.get_or_create(owner_id)
+        return self._row_to_state(row)
+
+    @staticmethod
+    def _row_to_state(row: asyncpg.Record) -> DispatcherState:
+        return DispatcherState(
+            id=row["id"],
+            owner_id=row["owner_id"],
+            running=row["running"],
+            threshold=row["threshold"],
+            max_concurrent_raids=row["max_concurrent_raids"],
+            updated_at=row["updated_at"] or datetime.now(UTC),
+        )

--- a/src/tyr/api/dispatcher.py
+++ b/src/tyr/api/dispatcher.py
@@ -1,0 +1,85 @@
+"""REST API for dispatcher state — get and update per-user dispatcher config."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from niuu.domain.models import Principal
+from tyr.adapters.inbound.auth import extract_principal
+from tyr.ports.dispatcher_repository import DispatcherRepository
+
+# ---------------------------------------------------------------------------
+# Request / Response models
+# ---------------------------------------------------------------------------
+
+
+class DispatcherStateResponse(BaseModel):
+    id: str
+    running: bool
+    threshold: float
+    max_concurrent_raids: int
+    updated_at: datetime
+
+
+class PatchDispatcherRequest(BaseModel):
+    running: bool | None = None
+    threshold: float | None = Field(None, ge=0.0, le=1.0)
+    max_concurrent_raids: int | None = Field(None, ge=1, le=20)
+
+
+# ---------------------------------------------------------------------------
+# Dependencies
+# ---------------------------------------------------------------------------
+
+
+async def resolve_dispatcher_repo() -> DispatcherRepository:
+    raise HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail="Dispatcher repository not configured",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Router
+# ---------------------------------------------------------------------------
+
+
+def create_dispatcher_router() -> APIRouter:
+    router = APIRouter(prefix="/api/v1/tyr/dispatcher", tags=["Dispatcher"])
+
+    @router.get("", response_model=DispatcherStateResponse)
+    async def get_dispatcher_state(
+        principal: Principal = Depends(extract_principal),
+        repo: DispatcherRepository = Depends(resolve_dispatcher_repo),
+    ) -> DispatcherStateResponse:
+        """Return the dispatcher state for the authenticated user, creating a default if needed."""
+        state = await repo.get_or_create(principal.user_id)
+        return DispatcherStateResponse(
+            id=str(state.id),
+            running=state.running,
+            threshold=state.threshold,
+            max_concurrent_raids=state.max_concurrent_raids,
+            updated_at=state.updated_at,
+        )
+
+    @router.patch("", response_model=DispatcherStateResponse)
+    async def patch_dispatcher_state(
+        body: PatchDispatcherRequest,
+        principal: Principal = Depends(extract_principal),
+        repo: DispatcherRepository = Depends(resolve_dispatcher_repo),
+    ) -> DispatcherStateResponse:
+        """Partially update the dispatcher state for the authenticated user."""
+        updates = body.model_dump(exclude_none=True)
+        state = await repo.update(principal.user_id, **updates)
+        return DispatcherStateResponse(
+            id=str(state.id),
+            running=state.running,
+            threshold=state.threshold,
+            max_concurrent_raids=state.max_concurrent_raids,
+            updated_at=state.updated_at,
+        )
+
+    return router

--- a/src/tyr/domain/models.py
+++ b/src/tyr/domain/models.py
@@ -128,8 +128,10 @@ class ConfidenceEvent:
 @dataclass(frozen=True)
 class DispatcherState:
     id: UUID
+    owner_id: str
     running: bool
     threshold: float
+    max_concurrent_raids: int
     updated_at: datetime
 
 

--- a/src/tyr/main.py
+++ b/src/tyr/main.py
@@ -14,14 +14,17 @@ from niuu.domain.models import IntegrationType, Principal
 from niuu.ports.credentials import CredentialStorePort
 from niuu.ports.integrations import IntegrationRepository
 from niuu.utils import import_class, resolve_secret_kwargs
+from tyr.adapters.postgres_dispatcher import PostgresDispatcherRepository
 from tyr.adapters.postgres_sagas import PostgresSagaRepository
 from tyr.adapters.volundr_http import VolundrHTTPAdapter
 from tyr.api.dispatch import create_dispatch_router, resolve_volundr
 from tyr.api.dispatch import resolve_saga_repo as dispatch_resolve_saga_repo
+from tyr.api.dispatcher import create_dispatcher_router, resolve_dispatcher_repo
 from tyr.api.sagas import create_sagas_router, resolve_saga_repo
 from tyr.api.tracker import create_tracker_router, resolve_trackers
 from tyr.config import Settings
 from tyr.infrastructure.database import database_pool
+from tyr.ports.dispatcher_repository import DispatcherRepository
 from tyr.ports.saga_repository import SagaRepository
 from tyr.ports.tracker import TrackerPort
 from tyr.ports.volundr import VolundrPort
@@ -102,6 +105,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(create_tracker_router())
     app.include_router(create_sagas_router())
     app.include_router(create_dispatch_router())
+    app.include_router(create_dispatcher_router())
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
@@ -140,6 +144,14 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
             app.dependency_overrides[resolve_saga_repo] = _resolve_saga_repo
             app.dependency_overrides[dispatch_resolve_saga_repo] = _resolve_saga_repo
+
+            # Wire dispatcher repository
+            dispatcher_repo = PostgresDispatcherRepository(pool)
+
+            async def _resolve_dispatcher_repo() -> DispatcherRepository:
+                return dispatcher_repo
+
+            app.dependency_overrides[resolve_dispatcher_repo] = _resolve_dispatcher_repo
 
             # Wire Volundr adapter
             volundr_adapter = VolundrHTTPAdapter(settings.volundr.url)

--- a/src/tyr/ports/dispatcher_repository.py
+++ b/src/tyr/ports/dispatcher_repository.py
@@ -1,0 +1,25 @@
+"""Dispatcher repository port — persistence for per-user dispatcher state."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from tyr.domain.models import DispatcherState
+
+
+class DispatcherRepository(ABC):
+    """Abstract persistence for dispatcher state."""
+
+    @abstractmethod
+    async def get_or_create(self, owner_id: str) -> DispatcherState:
+        """Return the dispatcher state for *owner_id*, creating a default row if none exists."""
+        ...
+
+    @abstractmethod
+    async def update(self, owner_id: str, **fields: object) -> DispatcherState:
+        """Partial-update the dispatcher state for *owner_id*.
+
+        Only the keys present in *fields* are written; the rest are untouched.
+        Returns the full state after the update.
+        """
+        ...

--- a/tests/test_tyr/test_dispatcher_api.py
+++ b/tests/test_tyr/test_dispatcher_api.py
@@ -249,30 +249,137 @@ class TestPatchDispatcherState:
 # -------------------------------------------------------------------
 
 
+class _FakeRow(dict):
+    """Dict subclass that mimics asyncpg.Record subscript access."""
+
+    def __getitem__(self, key: str) -> object:
+        return super().__getitem__(key)
+
+
+def _make_row(
+    owner_id: str = "owner-1",
+    running: bool = True,
+    threshold: float = 0.8,
+    max_concurrent_raids: int = 5,
+    updated_at: datetime | None = None,
+) -> _FakeRow:
+    return _FakeRow(
+        id=uuid4(),
+        owner_id=owner_id,
+        running=running,
+        threshold=threshold,
+        max_concurrent_raids=max_concurrent_raids,
+        updated_at=updated_at or datetime.now(UTC),
+    )
+
+
 class TestPostgresDispatcherRepository:
     def test_row_to_state(self):
         from tyr.adapters.postgres_dispatcher import PostgresDispatcherRepository
 
-        now = datetime.now(UTC)
-        uid = uuid4()
-
-        class FakeRow(dict):
-            def __getitem__(self, key):
-                return super().__getitem__(key)
-
-        row = FakeRow(
-            id=uid,
-            owner_id="owner-1",
-            running=True,
-            threshold=0.8,
-            max_concurrent_raids=5,
-            updated_at=now,
-        )
-
+        row = _make_row()
         state = PostgresDispatcherRepository._row_to_state(row)
-        assert state.id == uid
+        assert state.id == row["id"]
         assert state.owner_id == "owner-1"
         assert state.running is True
         assert state.threshold == 0.8
         assert state.max_concurrent_raids == 5
-        assert state.updated_at == now
+
+    def test_row_to_state_null_updated_at(self):
+        from tyr.adapters.postgres_dispatcher import PostgresDispatcherRepository
+
+        row = _make_row(updated_at=None)
+        row["updated_at"] = None
+        state = PostgresDispatcherRepository._row_to_state(row)
+        assert state.updated_at is not None
+
+    @pytest.mark.asyncio
+    async def test_get_or_create(self):
+        from unittest.mock import AsyncMock
+
+        from tyr.adapters.postgres_dispatcher import PostgresDispatcherRepository
+
+        row = _make_row(owner_id="user-x", running=True, threshold=0.75, max_concurrent_raids=3)
+        pool = AsyncMock()
+        pool.fetchrow = AsyncMock(return_value=row)
+
+        repo = PostgresDispatcherRepository(pool)
+        state = await repo.get_or_create("user-x")
+
+        pool.fetchrow.assert_called_once()
+        assert state.owner_id == "user-x"
+        assert state.running is True
+        assert state.threshold == 0.75
+        assert state.max_concurrent_raids == 3
+
+    @pytest.mark.asyncio
+    async def test_update_with_fields(self):
+        from unittest.mock import AsyncMock
+
+        from tyr.adapters.postgres_dispatcher import PostgresDispatcherRepository
+
+        row = _make_row(owner_id="user-x", running=False, threshold=0.9, max_concurrent_raids=5)
+        pool = AsyncMock()
+        pool.fetchrow = AsyncMock(return_value=row)
+
+        repo = PostgresDispatcherRepository(pool)
+        state = await repo.update("user-x", running=False, threshold=0.9)
+
+        pool.fetchrow.assert_called_once()
+        sql_arg = pool.fetchrow.call_args[0][0]
+        assert "UPDATE dispatcher_state SET" in sql_arg
+        assert state.running is False
+        assert state.threshold == 0.9
+
+    @pytest.mark.asyncio
+    async def test_update_empty_fields_delegates_to_get_or_create(self):
+        from unittest.mock import AsyncMock
+
+        from tyr.adapters.postgres_dispatcher import PostgresDispatcherRepository
+
+        row = _make_row(owner_id="user-x")
+        pool = AsyncMock()
+        pool.fetchrow = AsyncMock(return_value=row)
+
+        repo = PostgresDispatcherRepository(pool)
+        state = await repo.update("user-x")
+
+        # Should call get_or_create path (INSERT ... ON CONFLICT)
+        sql_arg = pool.fetchrow.call_args[0][0]
+        assert "INSERT INTO dispatcher_state" in sql_arg
+        assert state.owner_id == "user-x"
+
+    @pytest.mark.asyncio
+    async def test_update_row_none_falls_back_to_get_or_create(self):
+        from unittest.mock import AsyncMock
+
+        from tyr.adapters.postgres_dispatcher import PostgresDispatcherRepository
+
+        row = _make_row(owner_id="user-x")
+        pool = AsyncMock()
+        # First call (UPDATE) returns None, second call (INSERT) returns row
+        pool.fetchrow = AsyncMock(side_effect=[None, row])
+
+        repo = PostgresDispatcherRepository(pool)
+        state = await repo.update("user-x", running=False)
+
+        assert pool.fetchrow.call_count == 2
+        assert state.owner_id == "user-x"
+
+    @pytest.mark.asyncio
+    async def test_update_ignores_disallowed_fields(self):
+        from unittest.mock import AsyncMock
+
+        from tyr.adapters.postgres_dispatcher import PostgresDispatcherRepository
+
+        row = _make_row(owner_id="user-x")
+        pool = AsyncMock()
+        pool.fetchrow = AsyncMock(return_value=row)
+
+        repo = PostgresDispatcherRepository(pool)
+        # Pass only disallowed fields — should delegate to get_or_create
+        state = await repo.update("user-x", bogus_field="nope")
+
+        sql_arg = pool.fetchrow.call_args[0][0]
+        assert "INSERT INTO dispatcher_state" in sql_arg
+        assert state.owner_id == "user-x"

--- a/tests/test_tyr/test_dispatcher_api.py
+++ b/tests/test_tyr/test_dispatcher_api.py
@@ -1,0 +1,278 @@
+"""Tests for the dispatcher state REST API endpoints.
+
+Tests GET /api/v1/tyr/dispatcher and PATCH /api/v1/tyr/dispatcher by
+overriding the DispatcherRepository dependency with an in-memory mock.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tyr.api.dispatcher import (
+    create_dispatcher_router,
+    resolve_dispatcher_repo,
+)
+from tyr.domain.models import DispatcherState
+from tyr.ports.dispatcher_repository import DispatcherRepository
+
+# -------------------------------------------------------------------
+# In-memory mock
+# -------------------------------------------------------------------
+
+_DEFAULT_RUNNING = True
+_DEFAULT_THRESHOLD = 0.75
+_DEFAULT_MAX_CONCURRENT_RAIDS = 3
+
+
+class MockDispatcherRepo(DispatcherRepository):
+    """In-memory dispatcher repository for tests."""
+
+    def __init__(self) -> None:
+        self.states: dict[str, DispatcherState] = {}
+
+    async def get_or_create(self, owner_id: str) -> DispatcherState:
+        if owner_id in self.states:
+            return self.states[owner_id]
+        state = DispatcherState(
+            id=uuid4(),
+            owner_id=owner_id,
+            running=_DEFAULT_RUNNING,
+            threshold=_DEFAULT_THRESHOLD,
+            max_concurrent_raids=_DEFAULT_MAX_CONCURRENT_RAIDS,
+            updated_at=datetime.now(UTC),
+        )
+        self.states[owner_id] = state
+        return state
+
+    async def update(self, owner_id: str, **fields: object) -> DispatcherState:
+        current = await self.get_or_create(owner_id)
+        allowed = {"running", "threshold", "max_concurrent_raids"}
+        updates = {k: v for k, v in fields.items() if k in allowed and v is not None}
+        if not updates:
+            return current
+        new_state = DispatcherState(
+            id=current.id,
+            owner_id=current.owner_id,
+            running=updates.get("running", current.running),
+            threshold=updates.get("threshold", current.threshold),
+            max_concurrent_raids=updates.get("max_concurrent_raids", current.max_concurrent_raids),
+            updated_at=datetime.now(UTC),
+        )
+        self.states[owner_id] = new_state
+        return new_state
+
+
+# -------------------------------------------------------------------
+# Fixtures
+# -------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_repo() -> MockDispatcherRepo:
+    return MockDispatcherRepo()
+
+
+@pytest.fixture
+def client(mock_repo: MockDispatcherRepo) -> TestClient:
+    app = FastAPI()
+    app.include_router(create_dispatcher_router())
+    app.dependency_overrides[resolve_dispatcher_repo] = lambda: mock_repo
+    return TestClient(app)
+
+
+def _auth_headers(user_id: str = "user-1") -> dict[str, str]:
+    return {"x-auth-user-id": user_id}
+
+
+# -------------------------------------------------------------------
+# GET /api/v1/tyr/dispatcher
+# -------------------------------------------------------------------
+
+
+class TestGetDispatcherState:
+    def test_creates_default_when_none_exists(self, client: TestClient):
+        resp = client.get("/api/v1/tyr/dispatcher", headers=_auth_headers())
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["running"] is True
+        assert data["threshold"] == 0.75
+        assert data["max_concurrent_raids"] == 3
+        assert "id" in data
+        assert "updated_at" in data
+
+    def test_returns_existing_state(self, client: TestClient, mock_repo: MockDispatcherRepo):
+        # Pre-populate a state
+        existing = DispatcherState(
+            id=uuid4(),
+            owner_id="user-1",
+            running=False,
+            threshold=0.5,
+            max_concurrent_raids=5,
+            updated_at=datetime.now(UTC),
+        )
+        mock_repo.states["user-1"] = existing
+
+        resp = client.get("/api/v1/tyr/dispatcher", headers=_auth_headers())
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["running"] is False
+        assert data["threshold"] == 0.5
+        assert data["max_concurrent_raids"] == 5
+        assert data["id"] == str(existing.id)
+
+    def test_scoped_to_user(self, client: TestClient, mock_repo: MockDispatcherRepo):
+        # User-1 gets state
+        client.get("/api/v1/tyr/dispatcher", headers=_auth_headers("user-1"))
+        # User-2 gets their own state
+        client.get("/api/v1/tyr/dispatcher", headers=_auth_headers("user-2"))
+        assert len(mock_repo.states) == 2
+        assert "user-1" in mock_repo.states
+        assert "user-2" in mock_repo.states
+
+    def test_default_principal_when_no_auth_headers(self, client: TestClient):
+        resp = client.get("/api/v1/tyr/dispatcher")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["running"] is True
+
+
+# -------------------------------------------------------------------
+# PATCH /api/v1/tyr/dispatcher
+# -------------------------------------------------------------------
+
+
+class TestPatchDispatcherState:
+    def test_updates_running_flag(self, client: TestClient):
+        # First GET to create default
+        client.get("/api/v1/tyr/dispatcher", headers=_auth_headers())
+
+        resp = client.patch(
+            "/api/v1/tyr/dispatcher",
+            json={"running": False},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["running"] is False
+        assert data["threshold"] == 0.75  # unchanged
+
+    def test_updates_threshold(self, client: TestClient):
+        client.get("/api/v1/tyr/dispatcher", headers=_auth_headers())
+
+        resp = client.patch(
+            "/api/v1/tyr/dispatcher",
+            json={"threshold": 0.9},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["threshold"] == 0.9
+        assert data["running"] is True  # unchanged
+
+    def test_updates_max_concurrent_raids(self, client: TestClient):
+        client.get("/api/v1/tyr/dispatcher", headers=_auth_headers())
+
+        resp = client.patch(
+            "/api/v1/tyr/dispatcher",
+            json={"max_concurrent_raids": 10},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["max_concurrent_raids"] == 10
+
+    def test_validates_threshold_range_too_high(self, client: TestClient):
+        resp = client.patch(
+            "/api/v1/tyr/dispatcher",
+            json={"threshold": 1.5},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 422
+
+    def test_validates_threshold_range_too_low(self, client: TestClient):
+        resp = client.patch(
+            "/api/v1/tyr/dispatcher",
+            json={"threshold": -0.1},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 422
+
+    def test_validates_max_concurrent_raids_too_low(self, client: TestClient):
+        resp = client.patch(
+            "/api/v1/tyr/dispatcher",
+            json={"max_concurrent_raids": 0},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 422
+
+    def test_validates_max_concurrent_raids_too_high(self, client: TestClient):
+        resp = client.patch(
+            "/api/v1/tyr/dispatcher",
+            json={"max_concurrent_raids": 21},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 422
+
+    def test_empty_body_returns_current_state(self, client: TestClient):
+        client.get("/api/v1/tyr/dispatcher", headers=_auth_headers())
+
+        resp = client.patch(
+            "/api/v1/tyr/dispatcher",
+            json={},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["running"] is True
+        assert data["threshold"] == 0.75
+        assert data["max_concurrent_raids"] == 3
+
+    def test_multiple_fields_at_once(self, client: TestClient):
+        resp = client.patch(
+            "/api/v1/tyr/dispatcher",
+            json={"running": False, "threshold": 0.6, "max_concurrent_raids": 7},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["running"] is False
+        assert data["threshold"] == 0.6
+        assert data["max_concurrent_raids"] == 7
+
+
+# -------------------------------------------------------------------
+# PostgresDispatcherRepository unit tests
+# -------------------------------------------------------------------
+
+
+class TestPostgresDispatcherRepository:
+    def test_row_to_state(self):
+        from tyr.adapters.postgres_dispatcher import PostgresDispatcherRepository
+
+        now = datetime.now(UTC)
+        uid = uuid4()
+
+        class FakeRow(dict):
+            def __getitem__(self, key):
+                return super().__getitem__(key)
+
+        row = FakeRow(
+            id=uid,
+            owner_id="owner-1",
+            running=True,
+            threshold=0.8,
+            max_concurrent_raids=5,
+            updated_at=now,
+        )
+
+        state = PostgresDispatcherRepository._row_to_state(row)
+        assert state.id == uid
+        assert state.owner_id == "owner-1"
+        assert state.running is True
+        assert state.threshold == 0.8
+        assert state.max_concurrent_raids == 5
+        assert state.updated_at == now

--- a/tests/test_tyr/test_models.py
+++ b/tests/test_tyr/test_models.py
@@ -239,12 +239,16 @@ class TestDispatcherState:
     def test_create(self) -> None:
         state = DispatcherState(
             id=uuid4(),
+            owner_id="user-1",
             running=True,
             threshold=0.7,
+            max_concurrent_raids=3,
             updated_at=NOW,
         )
         assert state.running is True
         assert state.threshold == 0.7
+        assert state.owner_id == "user-1"
+        assert state.max_concurrent_raids == 3
 
 
 class TestSessionInfo:

--- a/web/src/modules/shared/api/client.ts
+++ b/web/src/modules/shared/api/client.ts
@@ -25,6 +25,7 @@ export interface ApiClient {
   get<T>(endpoint: string): Promise<T>;
   post<T>(endpoint: string, body?: unknown): Promise<T>;
   put<T>(endpoint: string, body: unknown): Promise<T>;
+  patch<T>(endpoint: string, body: unknown): Promise<T>;
   delete<T>(endpoint: string, body?: unknown): Promise<T>;
 }
 
@@ -110,6 +111,13 @@ export function createApiClient(basePath: string): ApiClient {
     put<T>(endpoint: string, body: unknown): Promise<T> {
       return request<T>(endpoint, {
         method: 'PUT',
+        body: JSON.stringify(body),
+      });
+    },
+
+    patch<T>(endpoint: string, body: unknown): Promise<T> {
+      return request<T>(endpoint, {
+        method: 'PATCH',
         body: JSON.stringify(body),
       });
     },

--- a/web/src/modules/tyr/adapters/api/dispatcher.ts
+++ b/web/src/modules/tyr/adapters/api/dispatcher.ts
@@ -1,0 +1,23 @@
+import { createApiClient } from '@/modules/shared/api/client';
+import type { IDispatcherService } from '../../ports';
+import type { DispatcherState } from '../../models';
+
+const api = createApiClient('/api/v1/tyr/dispatcher');
+
+export class ApiDispatcherService implements IDispatcherService {
+  async getState(): Promise<DispatcherState | null> {
+    return api.get<DispatcherState>('');
+  }
+
+  async setRunning(running: boolean): Promise<void> {
+    await api.patch('', { running });
+  }
+
+  async setThreshold(threshold: number): Promise<void> {
+    await api.patch('', { threshold });
+  }
+
+  async getLog(): Promise<string[]> {
+    return [];
+  }
+}

--- a/web/src/modules/tyr/adapters/api/index.ts
+++ b/web/src/modules/tyr/adapters/api/index.ts
@@ -1,2 +1,3 @@
 export { ApiTyrService } from './tyr';
+export { ApiDispatcherService } from './dispatcher';
 export { ApiTrackerBrowserService } from './tracker';

--- a/web/src/modules/tyr/adapters/index.ts
+++ b/web/src/modules/tyr/adapters/index.ts
@@ -4,7 +4,7 @@ import {
   MockTyrSessionService,
   MockTrackerBrowserService,
 } from './mock';
-import { ApiTyrService, ApiTrackerBrowserService } from './api';
+import { ApiTyrService, ApiDispatcherService, ApiTrackerBrowserService } from './api';
 import type { ITyrService } from '../ports';
 import type { IDispatcherService } from '../ports';
 import type { ITyrSessionService } from '../ports';
@@ -13,7 +13,9 @@ import type { ITrackerBrowserService } from '../ports';
 const useMocks = import.meta.env.VITE_USE_MOCK_TYR === 'true';
 
 export const tyrService: ITyrService = useMocks ? new MockTyrService() : new ApiTyrService();
-export const dispatcherService: IDispatcherService = new MockDispatcherService();
+export const dispatcherService: IDispatcherService = useMocks
+  ? new MockDispatcherService()
+  : new ApiDispatcherService();
 export const tyrSessionService: ITyrSessionService = new MockTyrSessionService();
 export const trackerService: ITrackerBrowserService = useMocks
   ? new MockTrackerBrowserService()

--- a/web/src/modules/tyr/adapters/mock/data/sagas.data.ts
+++ b/web/src/modules/tyr/adapters/mock/data/sagas.data.ts
@@ -284,6 +284,7 @@ export const mockDispatcherState: DispatcherState = {
   id: 'dispatcher-001',
   running: true,
   threshold: 0.6,
+  max_concurrent_raids: 3,
   updated_at: '2026-03-21T08:00:00Z',
 };
 

--- a/web/src/modules/tyr/hooks/useDispatcher.test.ts
+++ b/web/src/modules/tyr/hooks/useDispatcher.test.ts
@@ -17,6 +17,7 @@ const mockState: DispatcherState = {
   id: 'dispatcher-001',
   running: true,
   threshold: 0.6,
+  max_concurrent_raids: 3,
   updated_at: '2026-03-21T08:00:00Z',
 };
 

--- a/web/src/modules/tyr/models/saga.ts
+++ b/web/src/modules/tyr/models/saga.ts
@@ -60,6 +60,7 @@ export interface DispatcherState {
   id: string;
   running: boolean;
   threshold: number;
+  max_concurrent_raids: number;
   updated_at: string;
 }
 

--- a/web/src/modules/tyr/store/tyr.store.test.ts
+++ b/web/src/modules/tyr/store/tyr.store.test.ts
@@ -19,6 +19,7 @@ const mockDispatcher: DispatcherState = {
   id: 'dispatcher-001',
   running: true,
   threshold: 0.6,
+  max_concurrent_raids: 3,
   updated_at: '2026-03-21T00:00:00Z',
 };
 


### PR DESCRIPTION
## Summary

- Add `GET /api/v1/tyr/dispatcher` and `PATCH /api/v1/tyr/dispatcher` REST endpoints with get-or-create and partial update semantics
- Add `DispatcherRepository` port (`src/tyr/ports/dispatcher_repository.py`) and PostgreSQL adapter (`src/tyr/adapters/postgres_dispatcher.py`) using raw asyncpg
- Add `DispatcherState` domain model fields: `owner_id` and `max_concurrent_raids`
- Wire dispatcher router and repository in `main.py` via dependency overrides
- Add `ApiDispatcherService` frontend adapter wired to real endpoints, with `patch()` method added to shared API client
- Update mock data and all frontend tests to include `max_concurrent_raids`

## Backend

- **Port**: `DispatcherRepository` with `get_or_create(owner_id)` and `update(owner_id, **fields)` 
- **Adapter**: `PostgresDispatcherRepository` — uses `INSERT ... ON CONFLICT` for get-or-create, dynamic SET clause for partial updates
- **Router**: `create_dispatcher_router()` — GET returns/creates state for authenticated user, PATCH validates field ranges (threshold 0.0–1.0, max_concurrent_raids 1–20)
- **Auth**: `owner_id` scoped via `extract_principal` (Envoy-injected headers)

## Frontend

- `ApiDispatcherService` calls real GET/PATCH endpoints
- `createApiClient` gains `patch()` method
- Adapter selection respects `VITE_USE_MOCK_TYR` env var (mock vs real)

## Test plan

- [x] GET creates default state when none exists (running=true, threshold=0.75, max_concurrent_raids=3)
- [x] GET returns existing state
- [x] PATCH updates running flag
- [x] PATCH updates threshold (validates 0.0–1.0 range)
- [x] PATCH validates max_concurrent_raids (1–20 range)
- [x] PATCH with empty body returns current state unchanged
- [x] PATCH with multiple fields at once
- [x] User scoping via owner_id
- [x] Default principal when no auth headers (dev mode)
- [x] PostgresDispatcherRepository._row_to_state unit test
- [x] Frontend useDispatcher hook tests (16 tests)
- [x] Frontend tyr store tests (8 tests)

Closes NIU-230

🤖 Generated with [Claude Code](https://claude.com/claude-code)