### PR TITLE
feat(tyr): add PATService with JWT signing, creation and revocation

### DIFF
--- a/charts/tyr/templates/deployment.yaml
+++ b/charts/tyr/templates/deployment.yaml
@@ -58,6 +58,13 @@ spec:
                   key: {{ .Values.database.passwordKey | default "password" }}
             - name: VOLUNDR_URL
               value: {{ .Values.volundr.url | quote }}
+            {{- if .Values.auth.patSigningKey }}
+            - name: AUTH__PAT_SIGNING_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "tyr.fullname" . }}-auth
+                  key: pat-signing-key
+            {{- end }}
             {{- range .Values.credentialStore.secretKwargs }}
             - name: CREDENTIAL_STORE_SK_{{ .kwarg | upper }}
               valueFrom:

--- a/charts/tyr/templates/secret.yaml
+++ b/charts/tyr/templates/secret.yaml
@@ -14,3 +14,15 @@ data:
   password: {{ .Values.database.password | b64enc | quote }}
   {{- end }}
 {{- end }}
+---
+{{- if .Values.auth.patSigningKey }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "tyr.fullname" . }}-auth
+  labels:
+    {{- include "tyr.labels" . | nindent 4 }}
+type: Opaque
+data:
+  pat-signing-key: {{ .Values.auth.patSigningKey | b64enc | quote }}
+{{- end }}

--- a/charts/tyr/values.yaml
+++ b/charts/tyr/values.yaml
@@ -199,6 +199,12 @@ cerbos:
   # -- Cerbos authorization service URL
   url: "http://localhost:3592"
 
+auth:
+  # -- Symmetric signing key for PAT JWTs (same key Envoy uses for validation)
+  patSigningKey: ""
+  # -- Default PAT lifetime in days
+  patTtlDays: 365
+
 volundr:
   url: "http://volundr:8000"
 

--- a/src/tyr/adapters/postgres_pats.py
+++ b/src/tyr/adapters/postgres_pats.py
@@ -1,0 +1,79 @@
+"""PostgreSQL adapter for personal access token repository."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import asyncpg
+
+from tyr.domain.models import PersonalAccessToken
+from tyr.ports.pat_repository import PATRepository
+
+
+class PostgresPATRepository(PATRepository):
+    """PostgreSQL implementation of PATRepository using raw SQL."""
+
+    def __init__(self, pool: asyncpg.Pool) -> None:
+        self._pool = pool
+
+    async def create(self, owner_id: str, name: str, token_hash: str) -> PersonalAccessToken:
+        """Persist a new PAT record."""
+        row = await self._pool.fetchrow(
+            """
+            INSERT INTO personal_access_tokens (owner_id, name, token_hash)
+            VALUES ($1, $2, $3)
+            RETURNING id, owner_id, name, created_at, last_used_at
+            """,
+            owner_id,
+            name,
+            token_hash,
+        )
+        return self._row_to_pat(row)
+
+    async def list(self, owner_id: str) -> list[PersonalAccessToken]:
+        """List all PATs for an owner."""
+        rows = await self._pool.fetch(
+            """
+            SELECT id, owner_id, name, created_at, last_used_at
+            FROM personal_access_tokens
+            WHERE owner_id = $1
+            ORDER BY created_at DESC
+            """,
+            owner_id,
+        )
+        return [self._row_to_pat(row) for row in rows]
+
+    async def get(self, pat_id: UUID, owner_id: str) -> PersonalAccessToken | None:
+        """Retrieve a PAT by ID scoped to an owner."""
+        row = await self._pool.fetchrow(
+            """
+            SELECT id, owner_id, name, created_at, last_used_at
+            FROM personal_access_tokens
+            WHERE id = $1 AND owner_id = $2
+            """,
+            pat_id,
+            owner_id,
+        )
+        if row is None:
+            return None
+        return self._row_to_pat(row)
+
+    async def delete(self, pat_id: UUID, owner_id: str) -> bool:
+        """Delete a PAT. Returns True if deleted."""
+        result = await self._pool.execute(
+            "DELETE FROM personal_access_tokens WHERE id = $1 AND owner_id = $2",
+            pat_id,
+            owner_id,
+        )
+        return result == "DELETE 1"
+
+    @staticmethod
+    def _row_to_pat(row: asyncpg.Record) -> PersonalAccessToken:
+        """Convert a database row to a PersonalAccessToken domain model."""
+        return PersonalAccessToken(
+            id=row["id"],
+            owner_id=row["owner_id"],
+            name=row["name"],
+            created_at=row["created_at"],
+            last_used_at=row["last_used_at"],
+        )

--- a/src/tyr/config.py
+++ b/src/tyr/config.py
@@ -93,6 +93,19 @@ class CerbosConfig(BaseModel):
     url: str = Field(default="http://localhost:3592")
 
 
+class AuthConfig(BaseModel):
+    """Authentication configuration for PAT signing."""
+
+    pat_signing_key: str = Field(
+        default="",
+        description="Symmetric signing key for PAT JWTs (same key Envoy uses for validation).",
+    )
+    pat_ttl_days: int = Field(
+        default=365,
+        description="Default PAT lifetime in days.",
+    )
+
+
 class TrackerConfig(BaseModel):
     """Tracker adapter configuration."""
 
@@ -132,6 +145,7 @@ class Settings(BaseSettings):
     tracker: TrackerConfig = Field(default_factory=TrackerConfig)
     dispatch: DispatchConfig = Field(default_factory=DispatchConfig)
     credential_store: CredentialStoreConfig = Field(default_factory=CredentialStoreConfig)
+    auth: AuthConfig = Field(default_factory=AuthConfig)
     cerbos: CerbosConfig = Field(default_factory=CerbosConfig)
 
     @classmethod

--- a/src/tyr/domain/models.py
+++ b/src/tyr/domain/models.py
@@ -226,3 +226,19 @@ class PhaseSpec:
 @dataclass(frozen=True)
 class SagaStructure:
     phases: list[PhaseSpec]
+
+
+# ---------------------------------------------------------------------------
+# Personal access tokens
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PersonalAccessToken:
+    """A personal access token for API authentication."""
+
+    id: UUID
+    owner_id: str
+    name: str
+    created_at: datetime
+    last_used_at: datetime | None = None

--- a/src/tyr/domain/services/__init__.py
+++ b/src/tyr/domain/services/__init__.py
@@ -1,0 +1,1 @@
+"""Domain services for the Tyr saga coordinator."""

--- a/src/tyr/domain/services/pat.py
+++ b/src/tyr/domain/services/pat.py
@@ -1,0 +1,63 @@
+"""Domain service for personal access token lifecycle management."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
+
+import jwt
+
+from tyr.domain.models import PersonalAccessToken
+from tyr.ports.pat_repository import PATRepository
+
+logger = logging.getLogger(__name__)
+
+
+class PATService:
+    """Service for creating, listing, and revoking personal access tokens.
+
+    PATs are long-lived JWTs signed with the OIDC signing key so Envoy
+    can validate them with zero infrastructure changes.
+    """
+
+    def __init__(
+        self,
+        repo: PATRepository,
+        signing_key: str,
+        ttl_days: int = 365,
+    ) -> None:
+        self._repo = repo
+        self._signing_key = signing_key
+        self._ttl_days = ttl_days
+
+    async def create(self, owner_id: str, name: str) -> tuple[PersonalAccessToken, str]:
+        """Create a new PAT. Returns (metadata, raw_jwt). raw_jwt shown once only."""
+        now = datetime.now(UTC)
+        jti = str(uuid4())
+        payload = {
+            "sub": owner_id,
+            "type": "pat",
+            "jti": jti,
+            "name": name,
+            "iat": now,
+            "exp": now + timedelta(days=self._ttl_days),
+        }
+        raw_jwt = jwt.encode(payload, self._signing_key, algorithm="HS256")
+        token_hash = hashlib.sha256(raw_jwt.encode()).hexdigest()
+
+        pat = await self._repo.create(owner_id, name, token_hash)
+        logger.info("PAT created: id=%s owner=%s name=%s", pat.id, owner_id, name)
+        return pat, raw_jwt
+
+    async def list(self, owner_id: str) -> list[PersonalAccessToken]:
+        """List all PATs for an owner."""
+        return await self._repo.list(owner_id)
+
+    async def revoke(self, pat_id: UUID, owner_id: str) -> bool:
+        """Revoke (delete) a PAT. Returns True if found and deleted."""
+        deleted = await self._repo.delete(pat_id, owner_id)
+        if deleted:
+            logger.info("PAT revoked: id=%s owner=%s", pat_id, owner_id)
+        return deleted

--- a/src/tyr/main.py
+++ b/src/tyr/main.py
@@ -119,6 +119,18 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
             app.dependency_overrides[resolve_volundr] = _resolve_volundr
 
+            # Wire personal access token service
+            from tyr.adapters.postgres_pats import PostgresPATRepository
+            from tyr.domain.services.pat import PATService
+
+            pat_repo = PostgresPATRepository(pool)
+            pat_service = PATService(
+                repo=pat_repo,
+                signing_key=settings.auth.pat_signing_key,
+                ttl_days=settings.auth.pat_ttl_days,
+            )
+            app.state.pat_service = pat_service
+
             logger.info("Tyr started — database pool ready")
             yield
             logger.info("Tyr shutting down")

--- a/src/tyr/ports/pat_repository.py
+++ b/src/tyr/ports/pat_repository.py
@@ -1,0 +1,28 @@
+"""Port for personal access token persistence operations."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from uuid import UUID
+
+from tyr.domain.models import PersonalAccessToken
+
+
+class PATRepository(ABC):
+    """Port for personal access token persistence operations."""
+
+    @abstractmethod
+    async def create(self, owner_id: str, name: str, token_hash: str) -> PersonalAccessToken:
+        """Persist a new PAT record."""
+
+    @abstractmethod
+    async def list(self, owner_id: str) -> list[PersonalAccessToken]:
+        """List all PATs for an owner."""
+
+    @abstractmethod
+    async def get(self, pat_id: UUID, owner_id: str) -> PersonalAccessToken | None:
+        """Retrieve a PAT by ID scoped to an owner."""
+
+    @abstractmethod
+    async def delete(self, pat_id: UUID, owner_id: str) -> bool:
+        """Delete a PAT. Returns True if deleted."""

--- a/tests/test_tyr/test_pat_service.py
+++ b/tests/test_tyr/test_pat_service.py
@@ -1,0 +1,201 @@
+"""Tests for PATService with mocked repository."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import patch
+from uuid import uuid4
+
+import jwt
+import pytest
+
+from tyr.domain.models import PersonalAccessToken
+from tyr.domain.services.pat import PATService
+from tyr.ports.pat_repository import PATRepository
+
+
+class FakePATRepository(PATRepository):
+    """In-memory fake for testing."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, PersonalAccessToken] = {}
+        self.hashes: dict[str, str] = {}
+
+    async def create(self, owner_id: str, name: str, token_hash: str) -> PersonalAccessToken:
+        pat = PersonalAccessToken(
+            id=uuid4(),
+            owner_id=owner_id,
+            name=name,
+            created_at=datetime.now(UTC),
+        )
+        self.store[str(pat.id)] = pat
+        self.hashes[str(pat.id)] = token_hash
+        return pat
+
+    async def list(self, owner_id: str) -> list[PersonalAccessToken]:
+        return [p for p in self.store.values() if p.owner_id == owner_id]
+
+    async def get(self, pat_id, owner_id: str) -> PersonalAccessToken | None:
+        pat = self.store.get(str(pat_id))
+        if pat and pat.owner_id == owner_id:
+            return pat
+        return None
+
+    async def delete(self, pat_id, owner_id: str) -> bool:
+        key = str(pat_id)
+        pat = self.store.get(key)
+        if pat and pat.owner_id == owner_id:
+            del self.store[key]
+            return True
+        return False
+
+
+SIGNING_KEY = "test-secret-key-for-pats-minimum-32-bytes!"
+
+
+@pytest.fixture
+def fake_repo() -> FakePATRepository:
+    return FakePATRepository()
+
+
+@pytest.fixture
+def service(fake_repo: FakePATRepository) -> PATService:
+    return PATService(repo=fake_repo, signing_key=SIGNING_KEY, ttl_days=30)
+
+
+class TestCreate:
+    @pytest.mark.asyncio
+    async def test_returns_pat_and_raw_jwt(self, service: PATService):
+        pat, raw_jwt = await service.create("user-1", "my-token")
+
+        assert isinstance(pat, PersonalAccessToken)
+        assert pat.owner_id == "user-1"
+        assert pat.name == "my-token"
+        assert isinstance(raw_jwt, str)
+        assert len(raw_jwt) > 0
+
+    @pytest.mark.asyncio
+    async def test_jwt_payload_contains_required_fields(self, service: PATService):
+        pat, raw_jwt = await service.create("user-1", "ci-token")
+
+        payload = jwt.decode(raw_jwt, SIGNING_KEY, algorithms=["HS256"])
+
+        assert payload["sub"] == "user-1"
+        assert payload["type"] == "pat"
+        assert payload["name"] == "ci-token"
+        assert "jti" in payload
+        assert "iat" in payload
+        assert "exp" in payload
+
+    @pytest.mark.asyncio
+    async def test_jwt_expiry_uses_ttl_days(self, service: PATService):
+        _, raw_jwt = await service.create("user-1", "tok")
+
+        payload = jwt.decode(raw_jwt, SIGNING_KEY, algorithms=["HS256"])
+        ttl_seconds = payload["exp"] - payload["iat"]
+
+        assert ttl_seconds == 30 * 86400
+
+    @pytest.mark.asyncio
+    async def test_stores_sha256_hash(self, service: PATService, fake_repo: FakePATRepository):
+        import hashlib
+
+        pat, raw_jwt = await service.create("user-1", "tok")
+        expected_hash = hashlib.sha256(raw_jwt.encode()).hexdigest()
+
+        assert fake_repo.hashes[str(pat.id)] == expected_hash
+
+    @pytest.mark.asyncio
+    async def test_each_token_has_unique_jti(self, service: PATService):
+        _, jwt1 = await service.create("user-1", "tok-1")
+        _, jwt2 = await service.create("user-1", "tok-2")
+
+        payload1 = jwt.decode(jwt1, SIGNING_KEY, algorithms=["HS256"])
+        payload2 = jwt.decode(jwt2, SIGNING_KEY, algorithms=["HS256"])
+
+        assert payload1["jti"] != payload2["jti"]
+
+    @pytest.mark.asyncio
+    async def test_persists_to_repo(self, service: PATService, fake_repo: FakePATRepository):
+        await service.create("user-1", "tok")
+
+        assert len(fake_repo.store) == 1
+
+
+class TestList:
+    @pytest.mark.asyncio
+    async def test_returns_empty_list(self, service: PATService):
+        result = await service.list("user-1")
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_returns_pats_for_owner(self, service: PATService):
+        await service.create("user-1", "tok-a")
+        await service.create("user-1", "tok-b")
+        await service.create("user-2", "tok-c")
+
+        result = await service.list("user-1")
+
+        assert len(result) == 2
+        names = {p.name for p in result}
+        assert names == {"tok-a", "tok-b"}
+
+    @pytest.mark.asyncio
+    async def test_isolates_by_owner(self, service: PATService):
+        await service.create("user-1", "tok")
+
+        result = await service.list("user-2")
+
+        assert result == []
+
+
+class TestRevoke:
+    @pytest.mark.asyncio
+    async def test_returns_true_when_deleted(self, service: PATService):
+        pat, _ = await service.create("user-1", "tok")
+
+        result = await service.revoke(pat.id, "user-1")
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_not_found(self, service: PATService):
+        result = await service.revoke(uuid4(), "user-1")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_removes_from_repo(self, service: PATService, fake_repo: FakePATRepository):
+        pat, _ = await service.create("user-1", "tok")
+        await service.revoke(pat.id, "user-1")
+
+        assert len(fake_repo.store) == 0
+
+    @pytest.mark.asyncio
+    async def test_cannot_revoke_other_owners_token(self, service: PATService):
+        pat, _ = await service.create("user-1", "tok")
+
+        result = await service.revoke(pat.id, "user-2")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_logs_on_successful_revoke(self, service: PATService):
+        pat, _ = await service.create("user-1", "tok")
+
+        with patch("tyr.domain.services.pat.logger") as mock_logger:
+            await service.revoke(pat.id, "user-1")
+            mock_logger.info.assert_called_once()
+            assert "revoked" in mock_logger.info.call_args[0][0].lower()
+
+
+class TestDefaultTtl:
+    @pytest.mark.asyncio
+    async def test_default_ttl_is_365_days(self, fake_repo: FakePATRepository):
+        service = PATService(repo=fake_repo, signing_key=SIGNING_KEY)
+        _, raw_jwt_str = await service.create("user-1", "tok")
+
+        payload = jwt.decode(raw_jwt_str, SIGNING_KEY, algorithms=["HS256"])
+        ttl_seconds = payload["exp"] - payload["iat"]
+
+        assert ttl_seconds == 365 * 86400

--- a/tests/test_tyr/test_postgres_pats.py
+++ b/tests/test_tyr/test_postgres_pats.py
@@ -1,0 +1,173 @@
+"""Tests for PostgresPATRepository with mocked asyncpg pool."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from tyr.adapters.postgres_pats import PostgresPATRepository
+from tyr.domain.models import PersonalAccessToken
+
+
+@pytest.fixture
+def mock_pool() -> MagicMock:
+    pool = MagicMock()
+    pool.execute = AsyncMock()
+    pool.fetch = AsyncMock(return_value=[])
+    pool.fetchrow = AsyncMock(return_value=None)
+    return pool
+
+
+@pytest.fixture
+def repo(mock_pool: MagicMock) -> PostgresPATRepository:
+    return PostgresPATRepository(mock_pool)
+
+
+def _make_row(
+    owner_id: str = "user-1",
+    name: str = "my-token",
+) -> dict:
+    return {
+        "id": uuid4(),
+        "owner_id": owner_id,
+        "name": name,
+        "created_at": datetime.now(UTC),
+        "last_used_at": None,
+    }
+
+
+class TestCreate:
+    @pytest.mark.asyncio
+    async def test_inserts_and_returns_pat(self, repo: PostgresPATRepository, mock_pool: MagicMock):
+        row = _make_row()
+        mock_pool.fetchrow = AsyncMock(return_value=row)
+
+        pat = await repo.create("user-1", "my-token", "hash123")
+
+        mock_pool.fetchrow.assert_called_once()
+        sql = mock_pool.fetchrow.call_args[0][0]
+        assert "INSERT INTO personal_access_tokens" in sql
+        assert mock_pool.fetchrow.call_args[0][1] == "user-1"
+        assert mock_pool.fetchrow.call_args[0][2] == "my-token"
+        assert mock_pool.fetchrow.call_args[0][3] == "hash123"
+        assert isinstance(pat, PersonalAccessToken)
+        assert pat.owner_id == "user-1"
+        assert pat.name == "my-token"
+
+    @pytest.mark.asyncio
+    async def test_returns_correct_id(self, repo: PostgresPATRepository, mock_pool: MagicMock):
+        row = _make_row()
+        mock_pool.fetchrow = AsyncMock(return_value=row)
+
+        pat = await repo.create("user-1", "my-token", "hash123")
+
+        assert pat.id == row["id"]
+
+
+class TestList:
+    @pytest.mark.asyncio
+    async def test_returns_empty_list(self, repo: PostgresPATRepository):
+        result = await repo.list("user-1")
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_returns_pats_for_owner(self, repo: PostgresPATRepository, mock_pool: MagicMock):
+        rows = [_make_row(name="tok-1"), _make_row(name="tok-2")]
+        mock_pool.fetch = AsyncMock(return_value=rows)
+
+        result = await repo.list("user-1")
+
+        assert len(result) == 2
+        assert result[0].name == "tok-1"
+        assert result[1].name == "tok-2"
+
+    @pytest.mark.asyncio
+    async def test_queries_with_owner_id(self, repo: PostgresPATRepository, mock_pool: MagicMock):
+        await repo.list("user-42")
+
+        sql = mock_pool.fetch.call_args[0][0]
+        assert "WHERE owner_id = $1" in sql
+        assert mock_pool.fetch.call_args[0][1] == "user-42"
+
+
+class TestGet:
+    @pytest.mark.asyncio
+    async def test_returns_none_when_not_found(self, repo: PostgresPATRepository):
+        result = await repo.get(uuid4(), "user-1")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_pat_when_found(self, repo: PostgresPATRepository, mock_pool: MagicMock):
+        row = _make_row()
+        pat_id = row["id"]
+        mock_pool.fetchrow = AsyncMock(return_value=row)
+
+        result = await repo.get(pat_id, "user-1")
+
+        assert result is not None
+        assert result.id == pat_id
+
+    @pytest.mark.asyncio
+    async def test_scopes_query_to_owner(self, repo: PostgresPATRepository, mock_pool: MagicMock):
+        pat_id = uuid4()
+        await repo.get(pat_id, "user-1")
+
+        sql = mock_pool.fetchrow.call_args[0][0]
+        assert "WHERE id = $1 AND owner_id = $2" in sql
+        assert mock_pool.fetchrow.call_args[0][1] == pat_id
+        assert mock_pool.fetchrow.call_args[0][2] == "user-1"
+
+
+class TestDelete:
+    @pytest.mark.asyncio
+    async def test_returns_true_when_deleted(
+        self, repo: PostgresPATRepository, mock_pool: MagicMock
+    ):
+        mock_pool.execute = AsyncMock(return_value="DELETE 1")
+
+        result = await repo.delete(uuid4(), "user-1")
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_not_found(
+        self, repo: PostgresPATRepository, mock_pool: MagicMock
+    ):
+        mock_pool.execute = AsyncMock(return_value="DELETE 0")
+
+        result = await repo.delete(uuid4(), "user-1")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_scopes_delete_to_owner(self, repo: PostgresPATRepository, mock_pool: MagicMock):
+        pat_id = uuid4()
+        await repo.delete(pat_id, "user-1")
+
+        sql = mock_pool.execute.call_args[0][0]
+        assert "WHERE id = $1 AND owner_id = $2" in sql
+        assert mock_pool.execute.call_args[0][1] == pat_id
+        assert mock_pool.execute.call_args[0][2] == "user-1"
+
+
+class TestRowToPat:
+    def test_converts_row_to_domain_model(self):
+        row = _make_row()
+        pat = PostgresPATRepository._row_to_pat(row)
+
+        assert isinstance(pat, PersonalAccessToken)
+        assert pat.id == row["id"]
+        assert pat.owner_id == row["owner_id"]
+        assert pat.name == row["name"]
+        assert pat.created_at == row["created_at"]
+        assert pat.last_used_at is None
+
+    def test_converts_row_with_last_used(self):
+        row = _make_row()
+        row["last_used_at"] = datetime.now(UTC)
+        pat = PostgresPATRepository._row_to_pat(row)
+
+        assert pat.last_used_at == row["last_used_at"]


### PR DESCRIPTION
## Summary

- Add `PersonalAccessToken` dataclass to `tyr.domain.models`
- Add `PATRepository` ABC port in `src/tyr/ports/pat_repository.py`
- Add `PostgresPATRepository` adapter with raw asyncpg queries (no FK on `owner_id` — Tyr has no local `users` table)
- Add `PATService` in `src/tyr/domain/services/pat.py` with JWT signing (HS256), SHA-256 token hashing, configurable TTL
- Add `AuthConfig` to `tyr/config.py` with `pat_signing_key` and `pat_ttl_days`
- Wire `PATService` into `app.state.pat_service` in `main.py`
- Add `AUTH__PAT_SIGNING_KEY` to Helm secret template and deployment env injection
- Document `auth.patSigningKey` and `auth.patTtlDays` in `charts/tyr/values.yaml`

## Test plan

- [x] `tests/test_tyr/test_pat_service.py` — mocked repo, covers create (JWT payload + hash), list, revoke, TTL config, logging (15 tests)
- [x] `tests/test_tyr/test_postgres_pats.py` — mocked pool, covers create/list/get/delete, owner scoping, row conversion (13 tests)
- [x] 100% coverage on all PAT files (`pat.py`, `postgres_pats.py`, `pat_repository.py`)
- [x] `ruff check` and `ruff format` clean

Closes NIU-228

🤖 Generated with [Claude Code](https://claude.com/claude-code)