### PR TITLE
feat(tyr): add POST/GET/DELETE /api/v1/users/tokens REST endpoints

### DIFF
--- a/src/tyr/adapters/inbound/rest_pats.py
+++ b/src/tyr/adapters/inbound/rest_pats.py
@@ -1,0 +1,120 @@
+"""FastAPI REST adapter for personal access token management."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel, Field
+
+from niuu.domain.models import Principal
+from tyr.adapters.inbound.auth import extract_principal
+from tyr.domain.services.pat import PATService
+
+logger = logging.getLogger(__name__)
+
+
+class CreatePATRequest(BaseModel):
+    """Request model for creating a personal access token."""
+
+    name: str = Field(
+        min_length=1,
+        max_length=100,
+        description="Human-readable label for the token",
+    )
+
+
+class PATResponse(BaseModel):
+    """Response model for a personal access token (no raw token)."""
+
+    id: str
+    name: str
+    created_at: datetime
+    last_used_at: datetime | None
+
+
+class CreatePATResponse(BaseModel):
+    """Response model returned once on creation (includes raw token)."""
+
+    id: str
+    name: str
+    token: str
+    created_at: datetime
+
+
+def create_pats_router() -> APIRouter:
+    """Create the personal access tokens router."""
+    router = APIRouter(
+        prefix="/api/v1/users/tokens",
+        tags=["Personal Access Tokens"],
+    )
+
+    @router.post(
+        "",
+        response_model=CreatePATResponse,
+        status_code=status.HTTP_201_CREATED,
+    )
+    async def create_token(
+        body: CreatePATRequest,
+        principal: Principal = Depends(extract_principal),
+        request: Request = None,
+    ) -> CreatePATResponse:
+        """Create a new personal access token. The raw token is shown once."""
+        service: PATService = request.app.state.pat_service
+        pat, raw_token = await service.create(principal.user_id, body.name)
+        return CreatePATResponse(
+            id=str(pat.id),
+            name=pat.name,
+            token=raw_token,
+            created_at=pat.created_at,
+        )
+
+    @router.get(
+        "",
+        response_model=list[PATResponse],
+    )
+    async def list_tokens(
+        principal: Principal = Depends(extract_principal),
+        request: Request = None,
+    ) -> list[PATResponse]:
+        """List all personal access tokens for the authenticated user."""
+        service: PATService = request.app.state.pat_service
+        pats = await service.list(principal.user_id)
+        return [
+            PATResponse(
+                id=str(pat.id),
+                name=pat.name,
+                created_at=pat.created_at,
+                last_used_at=pat.last_used_at,
+            )
+            for pat in pats
+        ]
+
+    @router.delete(
+        "/{pat_id}",
+        status_code=status.HTTP_204_NO_CONTENT,
+    )
+    async def revoke_token(
+        pat_id: str,
+        principal: Principal = Depends(extract_principal),
+        request: Request = None,
+    ) -> None:
+        """Revoke a personal access token by ID."""
+        service: PATService = request.app.state.pat_service
+        try:
+            parsed_id = UUID(pat_id)
+        except ValueError:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"PAT not found: {pat_id}",
+            )
+        deleted = await service.revoke(parsed_id, principal.user_id)
+        if not deleted:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"PAT not found: {pat_id}",
+            )
+
+    return router

--- a/src/tyr/main.py
+++ b/src/tyr/main.py
@@ -12,6 +12,7 @@ from fastapi import Depends, FastAPI, Request, Response
 from niuu.adapters.postgres_integrations import PostgresIntegrationRepository
 from niuu.domain.models import Principal
 from niuu.utils import import_class, resolve_secret_kwargs
+from tyr.adapters.inbound.rest_pats import create_pats_router
 from tyr.adapters.postgres_dispatcher import PostgresDispatcherRepository
 from tyr.adapters.postgres_sagas import PostgresSagaRepository
 from tyr.adapters.tracker_factory import TrackerAdapterFactory
@@ -62,6 +63,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(create_sagas_router())
     app.include_router(create_dispatch_router())
     app.include_router(create_dispatcher_router())
+    app.include_router(create_pats_router())
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:

--- a/tests/test_tyr/test_rest_pats.py
+++ b/tests/test_tyr/test_rest_pats.py
@@ -1,0 +1,229 @@
+"""Tests for the PAT REST API endpoints.
+
+Tests POST/GET/DELETE /api/v1/users/tokens by mocking app.state.pat_service.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tyr.adapters.inbound.rest_pats import create_pats_router
+from tyr.domain.models import PersonalAccessToken
+
+# -------------------------------------------------------------------
+# Fixtures
+# -------------------------------------------------------------------
+
+
+def _make_pat(
+    owner_id: str = "user-1",
+    name: str = "my-token",
+) -> PersonalAccessToken:
+    return PersonalAccessToken(
+        id=uuid4(),
+        owner_id=owner_id,
+        name=name,
+        created_at=datetime.now(UTC),
+    )
+
+
+@pytest.fixture
+def mock_service() -> AsyncMock:
+    service = AsyncMock()
+    service.create = AsyncMock()
+    service.list = AsyncMock(return_value=[])
+    service.revoke = AsyncMock(return_value=True)
+    return service
+
+
+@pytest.fixture
+def client(mock_service: AsyncMock) -> TestClient:
+    app = FastAPI()
+    app.state.pat_service = mock_service
+    app.include_router(create_pats_router())
+    return TestClient(app)
+
+
+def _auth_headers(user_id: str = "user-1") -> dict[str, str]:
+    return {"x-auth-user-id": user_id}
+
+
+# -------------------------------------------------------------------
+# POST /api/v1/users/tokens
+# -------------------------------------------------------------------
+
+
+class TestCreateToken:
+    def test_returns_201_with_token(self, client: TestClient, mock_service: AsyncMock):
+        pat = _make_pat()
+        mock_service.create.return_value = (pat, "raw-jwt-token")
+
+        resp = client.post(
+            "/api/v1/users/tokens",
+            json={"name": "ci-token"},
+            headers=_auth_headers(),
+        )
+
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["id"] == str(pat.id)
+        assert data["name"] == pat.name
+        assert data["token"] == "raw-jwt-token"
+        assert "created_at" in data
+
+    def test_calls_service_with_principal_user_id(
+        self, client: TestClient, mock_service: AsyncMock
+    ):
+        pat = _make_pat(owner_id="user-42")
+        mock_service.create.return_value = (pat, "tok")
+
+        client.post(
+            "/api/v1/users/tokens",
+            json={"name": "test"},
+            headers=_auth_headers("user-42"),
+        )
+
+        mock_service.create.assert_called_once_with("user-42", "test")
+
+    def test_rejects_empty_name(self, client: TestClient):
+        resp = client.post(
+            "/api/v1/users/tokens",
+            json={"name": ""},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 422
+
+    def test_rejects_name_too_long(self, client: TestClient):
+        resp = client.post(
+            "/api/v1/users/tokens",
+            json={"name": "x" * 101},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 422
+
+
+# -------------------------------------------------------------------
+# GET /api/v1/users/tokens
+# -------------------------------------------------------------------
+
+
+class TestListTokens:
+    def test_returns_empty_list(self, client: TestClient, mock_service: AsyncMock):
+        mock_service.list.return_value = []
+
+        resp = client.get("/api/v1/users/tokens", headers=_auth_headers())
+
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_returns_pats_without_raw_token(self, client: TestClient, mock_service: AsyncMock):
+        pat1 = _make_pat(name="tok-a")
+        pat2 = _make_pat(name="tok-b")
+        mock_service.list.return_value = [pat1, pat2]
+
+        resp = client.get("/api/v1/users/tokens", headers=_auth_headers())
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2
+        assert data[0]["name"] == "tok-a"
+        assert data[1]["name"] == "tok-b"
+        # No raw token on list responses
+        assert "token" not in data[0]
+        assert "token" not in data[1]
+
+    def test_includes_last_used_at(self, client: TestClient, mock_service: AsyncMock):
+        pat = PersonalAccessToken(
+            id=uuid4(),
+            owner_id="user-1",
+            name="tok",
+            created_at=datetime.now(UTC),
+            last_used_at=datetime.now(UTC),
+        )
+        mock_service.list.return_value = [pat]
+
+        resp = client.get("/api/v1/users/tokens", headers=_auth_headers())
+
+        data = resp.json()
+        assert data[0]["last_used_at"] is not None
+
+    def test_calls_service_with_principal_user_id(
+        self, client: TestClient, mock_service: AsyncMock
+    ):
+        client.get("/api/v1/users/tokens", headers=_auth_headers("user-99"))
+
+        mock_service.list.assert_called_once_with("user-99")
+
+
+# -------------------------------------------------------------------
+# DELETE /api/v1/users/tokens/{pat_id}
+# -------------------------------------------------------------------
+
+
+class TestRevokeToken:
+    def test_returns_204_on_success(self, client: TestClient, mock_service: AsyncMock):
+        pat_id = uuid4()
+        mock_service.revoke.return_value = True
+
+        resp = client.delete(
+            f"/api/v1/users/tokens/{pat_id}",
+            headers=_auth_headers(),
+        )
+
+        assert resp.status_code == 204
+
+    def test_returns_404_when_not_found(self, client: TestClient, mock_service: AsyncMock):
+        mock_service.revoke.return_value = False
+
+        resp = client.delete(
+            f"/api/v1/users/tokens/{uuid4()}",
+            headers=_auth_headers(),
+        )
+
+        assert resp.status_code == 404
+
+    def test_returns_404_for_invalid_uuid(self, client: TestClient):
+        resp = client.delete(
+            "/api/v1/users/tokens/not-a-uuid",
+            headers=_auth_headers(),
+        )
+
+        assert resp.status_code == 404
+
+    def test_calls_service_with_principal_user_id(
+        self, client: TestClient, mock_service: AsyncMock
+    ):
+        pat_id = uuid4()
+        mock_service.revoke.return_value = True
+
+        client.delete(
+            f"/api/v1/users/tokens/{pat_id}",
+            headers=_auth_headers("user-7"),
+        )
+
+        mock_service.revoke.assert_called_once_with(pat_id, "user-7")
+
+
+# -------------------------------------------------------------------
+# Auth / 401 behaviour
+# -------------------------------------------------------------------
+
+
+class TestAuthRequired:
+    def test_no_auth_headers_uses_default_principal(
+        self, client: TestClient, mock_service: AsyncMock
+    ):
+        """Without Envoy headers the fallback principal (user_id='default') is used."""
+        mock_service.list.return_value = []
+
+        resp = client.get("/api/v1/users/tokens")
+
+        # Should succeed with fallback principal
+        assert resp.status_code == 200
+        mock_service.list.assert_called_once_with("default")


### PR DESCRIPTION
## Summary

- Add `src/tyr/adapters/inbound/rest_pats.py` with `create_pats_router()` exposing three endpoints:
  - `POST /api/v1/users/tokens` — create a PAT (201, returns raw token once)
  - `GET /api/v1/users/tokens` — list PATs for authenticated user (no raw token)
  - `DELETE /api/v1/users/tokens/{pat_id}` — revoke a PAT (204, 404 if not found)
- Register the router in `src/tyr/main.py`
- All endpoints use `extract_principal` for owner scoping via `principal.user_id`

## Test plan

- [x] `tests/test_tyr/test_rest_pats.py` — 13 tests covering:
  - Create returns 201 with token field
  - Create calls service with correct principal user_id
  - Validation rejects empty/too-long names (422)
  - List returns empty and non-empty results
  - List responses do not include raw token
  - Delete returns 204 on success
  - Delete returns 404 for non-existent or invalid UUID
  - Fallback principal used when no auth headers
- [x] 100% coverage on `rest_pats.py`
- [x] `ruff check` + `ruff format` clean

Closes NIU-229

🤖 Generated with [Claude Code](https://claude.com/claude-code)