### PR TITLE
feat(tyr): raid review endpoints with approve/reject/retry lifecycle

### DIFF
--- a/charts/tyr/templates/migrations-configmap.yaml
+++ b/charts/tyr/templates/migrations-configmap.yaml
@@ -233,4 +233,11 @@ data:
 
   000010_saga_base_branch.down.sql: |
     ALTER TABLE sagas DROP COLUMN IF EXISTS base_branch;
+
+  000011_raids_reason_column.up.sql: |
+    -- Add reason column to raids for reject context
+    ALTER TABLE raids ADD COLUMN IF NOT EXISTS reason TEXT;
+
+  000011_raids_reason_column.down.sql: |
+    ALTER TABLE raids DROP COLUMN IF EXISTS reason;
 {{- end }}

--- a/migrations/tyr/000010_saga_base_branch.down.sql
+++ b/migrations/tyr/000010_saga_base_branch.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sagas DROP COLUMN IF EXISTS base_branch;

--- a/migrations/tyr/000010_saga_base_branch.up.sql
+++ b/migrations/tyr/000010_saga_base_branch.up.sql
@@ -1,0 +1,2 @@
+-- Add base_branch column to sagas
+ALTER TABLE sagas ADD COLUMN IF NOT EXISTS base_branch TEXT NOT NULL DEFAULT 'main';

--- a/migrations/tyr/000011_raids_reason_column.down.sql
+++ b/migrations/tyr/000011_raids_reason_column.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE raids DROP COLUMN IF EXISTS reason;

--- a/migrations/tyr/000011_raids_reason_column.up.sql
+++ b/migrations/tyr/000011_raids_reason_column.up.sql
@@ -1,0 +1,2 @@
+-- Add reason column to raids for reject context
+ALTER TABLE raids ADD COLUMN IF NOT EXISTS reason TEXT;

--- a/src/tyr/adapters/github_git.py
+++ b/src/tyr/adapters/github_git.py
@@ -1,0 +1,102 @@
+"""GitHub Git adapter — calls the GitHub API for branch and PR operations."""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from tyr.domain.models import PRStatus
+from tyr.ports.git import GitPort
+
+logger = logging.getLogger(__name__)
+
+
+class GitHubGitAdapter(GitPort):
+    """Implements GitPort via the GitHub REST API."""
+
+    def __init__(self, token: str, timeout: float = 30.0) -> None:
+        self._token = token
+        self._timeout = timeout
+        self._client = httpx.AsyncClient(timeout=self._timeout)
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+
+    def _owner_repo(self, repo: str) -> tuple[str, str]:
+        """Split 'owner/repo' into (owner, repo)."""
+        owner, name = repo.split("/", 1)
+        return owner, name
+
+    async def create_branch(self, repo: str, branch: str, base: str) -> None:
+        owner, name = self._owner_repo(repo)
+        # Get base branch SHA
+        resp = await self._client.get(
+            f"https://api.github.com/repos/{owner}/{name}/git/ref/heads/{base}",
+            headers=self._headers(),
+        )
+        resp.raise_for_status()
+        sha = resp.json()["object"]["sha"]
+
+        # Create new branch
+        resp = await self._client.post(
+            f"https://api.github.com/repos/{owner}/{name}/git/refs",
+            headers=self._headers(),
+            json={"ref": f"refs/heads/{branch}", "sha": sha},
+        )
+        resp.raise_for_status()
+
+    async def merge_branch(self, repo: str, source: str, target: str) -> None:
+        owner, name = self._owner_repo(repo)
+        resp = await self._client.post(
+            f"https://api.github.com/repos/{owner}/{name}/merges",
+            headers=self._headers(),
+            json={
+                "base": target,
+                "head": source,
+                "commit_message": f"Merge {source} into {target}",
+            },
+        )
+        resp.raise_for_status()
+
+    async def delete_branch(self, repo: str, branch: str) -> None:
+        owner, name = self._owner_repo(repo)
+        resp = await self._client.delete(
+            f"https://api.github.com/repos/{owner}/{name}/git/refs/heads/{branch}",
+            headers=self._headers(),
+        )
+        if resp.status_code != 404:
+            resp.raise_for_status()
+
+    async def create_pr(self, repo: str, source: str, target: str, title: str) -> str:
+        owner, name = self._owner_repo(repo)
+        resp = await self._client.post(
+            f"https://api.github.com/repos/{owner}/{name}/pulls",
+            headers=self._headers(),
+            json={"title": title, "head": source, "base": target},
+        )
+        resp.raise_for_status()
+        return str(resp.json()["number"])
+
+    async def get_pr_status(self, pr_id: str) -> PRStatus:
+        # pr_id expected as "owner/repo#number" or just a URL
+        resp = await self._client.get(
+            pr_id,
+            headers=self._headers(),
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return PRStatus(
+            pr_id=pr_id,
+            state=data["state"],
+            mergeable=data.get("mergeable", False),
+            ci_passed=None,
+        )
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client."""
+        await self._client.aclose()

--- a/src/tyr/adapters/postgres_raids.py
+++ b/src/tyr/adapters/postgres_raids.py
@@ -1,0 +1,198 @@
+"""PostgreSQL implementation of RaidRepository."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import UUID
+
+import asyncpg
+
+from tyr.domain.models import (
+    ConfidenceEvent,
+    ConfidenceEventType,
+    Phase,
+    PhaseStatus,
+    Raid,
+    RaidStatus,
+    Saga,
+    SagaStatus,
+)
+from tyr.ports.raid_repository import RaidRepository
+
+
+class PostgresRaidRepository(RaidRepository):
+    """Raid persistence backed by asyncpg."""
+
+    def __init__(self, pool: asyncpg.Pool) -> None:
+        self._pool = pool
+
+    async def get_raid(self, raid_id: UUID) -> Raid | None:
+        row = await self._pool.fetchrow("SELECT * FROM raids WHERE id = $1", raid_id)
+        if row is None:
+            return None
+        return self._row_to_raid(row)
+
+    async def update_raid_status(
+        self,
+        raid_id: UUID,
+        status: RaidStatus,
+        *,
+        reason: str | None = None,
+        increment_retry: bool = False,
+    ) -> Raid | None:
+        now = datetime.now(UTC)
+        if increment_retry:
+            row = await self._pool.fetchrow(
+                """
+                UPDATE raids
+                SET status = $2, reason = $3, retry_count = retry_count + 1, updated_at = $4
+                WHERE id = $1
+                RETURNING *
+                """,
+                raid_id,
+                status.value,
+                reason,
+                now,
+            )
+        else:
+            row = await self._pool.fetchrow(
+                """
+                UPDATE raids
+                SET status = $2, reason = $3, updated_at = $4
+                WHERE id = $1
+                RETURNING *
+                """,
+                raid_id,
+                status.value,
+                reason,
+                now,
+            )
+        if row is None:
+            return None
+        return self._row_to_raid(row)
+
+    async def get_confidence_events(self, raid_id: UUID) -> list[ConfidenceEvent]:
+        rows = await self._pool.fetch(
+            "SELECT * FROM confidence_events WHERE raid_id = $1 ORDER BY created_at",
+            raid_id,
+        )
+        return [self._row_to_event(r) for r in rows]
+
+    async def add_confidence_event(self, event: ConfidenceEvent) -> None:
+        await self._pool.execute(
+            """
+            INSERT INTO confidence_events (id, raid_id, event_type, delta, score_after, created_at)
+            VALUES ($1, $2, $3, $4, $5, $6)
+            """,
+            event.id,
+            event.raid_id,
+            event.event_type.value,
+            event.delta,
+            event.score_after,
+            event.created_at,
+        )
+        await self._pool.execute(
+            "UPDATE raids SET confidence = $2, updated_at = $3 WHERE id = $1",
+            event.raid_id,
+            event.score_after,
+            event.created_at,
+        )
+
+    async def get_saga_for_raid(self, raid_id: UUID) -> Saga | None:
+        row = await self._pool.fetchrow(
+            """
+            SELECT s.* FROM sagas s
+            JOIN phases p ON p.saga_id = s.id
+            JOIN raids r ON r.phase_id = p.id
+            WHERE r.id = $1
+            """,
+            raid_id,
+        )
+        if row is None:
+            return None
+        return self._row_to_saga(row)
+
+    async def get_phase_for_raid(self, raid_id: UUID) -> Phase | None:
+        row = await self._pool.fetchrow(
+            """
+            SELECT p.* FROM phases p
+            JOIN raids r ON r.phase_id = p.id
+            WHERE r.id = $1
+            """,
+            raid_id,
+        )
+        if row is None:
+            return None
+        return self._row_to_phase(row)
+
+    async def all_raids_merged(self, phase_id: UUID) -> bool:
+        row = await self._pool.fetchrow(
+            """
+            SELECT count(*) FILTER (WHERE status != 'MERGED') AS remaining
+            FROM raids WHERE phase_id = $1
+            """,
+            phase_id,
+        )
+        return row is not None and row["remaining"] == 0
+
+    # -- Row mappers --
+
+    @staticmethod
+    def _row_to_raid(row: asyncpg.Record) -> Raid:
+        return Raid(
+            id=row["id"],
+            phase_id=row["phase_id"],
+            tracker_id=row["tracker_id"],
+            name=row["name"],
+            description=row.get("description", "") or "",
+            acceptance_criteria=list(row.get("acceptance_criteria") or []),
+            declared_files=list(row.get("declared_files") or []),
+            estimate_hours=row.get("estimate_hours"),
+            status=RaidStatus(row["status"]),
+            confidence=row.get("confidence", 0.0) or 0.0,
+            session_id=row.get("session_id"),
+            branch=row.get("branch"),
+            chronicle_summary=row.get("chronicle_summary"),
+            retry_count=row.get("retry_count", 0) or 0,
+            created_at=row["created_at"] or datetime.now(UTC),
+            updated_at=row["updated_at"] or datetime.now(UTC),
+        )
+
+    @staticmethod
+    def _row_to_event(row: asyncpg.Record) -> ConfidenceEvent:
+        return ConfidenceEvent(
+            id=row["id"],
+            raid_id=row["raid_id"],
+            event_type=ConfidenceEventType(row["event_type"]),
+            delta=row["delta"],
+            score_after=row["score_after"],
+            created_at=row["created_at"],
+        )
+
+    @staticmethod
+    def _row_to_saga(row: asyncpg.Record) -> Saga:
+        return Saga(
+            id=row["id"],
+            tracker_id=row["tracker_id"],
+            tracker_type=row["tracker_type"],
+            slug=row["slug"],
+            name=row["name"],
+            repos=list(row.get("repos") or []),
+            feature_branch=row.get("feature_branch", "") or "",
+            status=SagaStatus(row.get("status", "ACTIVE") or "ACTIVE"),
+            confidence=row.get("confidence", 0.0) or 0.0,
+            created_at=row.get("created_at") or datetime.now(UTC),
+            owner_id=row.get("owner_id", "") or "",
+        )
+
+    @staticmethod
+    def _row_to_phase(row: asyncpg.Record) -> Phase:
+        return Phase(
+            id=row["id"],
+            saga_id=row["saga_id"],
+            tracker_id=row["tracker_id"],
+            number=row["number"],
+            name=row["name"],
+            status=PhaseStatus(row.get("status", "PENDING") or "PENDING"),
+            confidence=row.get("confidence", 0.0) or 0.0,
+        )

--- a/src/tyr/adapters/volundr_http.py
+++ b/src/tyr/adapters/volundr_http.py
@@ -6,6 +6,7 @@ import logging
 
 import httpx
 
+from tyr.domain.models import PRStatus
 from tyr.ports.volundr import SpawnRequest, VolundrPort, VolundrSession
 
 logger = logging.getLogger(__name__)
@@ -106,3 +107,27 @@ class VolundrHTTPAdapter(VolundrPort):
                 )
                 for s in resp.json()
             ]
+
+    async def get_pr_status(self, session_id: str) -> PRStatus:
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            resp = await client.get(
+                f"{self._base_url}/api/v1/volundr/sessions/{session_id}/pr",
+                headers=self._headers(),
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            return PRStatus(
+                pr_id=data["pr_id"],
+                state=data["state"],
+                mergeable=data["mergeable"],
+                ci_passed=data.get("ci_passed"),
+            )
+
+    async def get_chronicle_summary(self, session_id: str) -> str:
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            resp = await client.get(
+                f"{self._base_url}/api/v1/volundr/sessions/{session_id}/chronicle",
+                headers=self._headers(),
+            )
+            resp.raise_for_status()
+            return resp.json().get("summary", "")

--- a/src/tyr/api/events.py
+++ b/src/tyr/api/events.py
@@ -1,0 +1,102 @@
+"""SSE event stream for real-time Tyr updates.
+
+GET /api/v1/tyr/events — streams :class:`~tyr.events.TyrEvent` objects as
+standard Server-Sent Events.  On connect, the current state snapshot is pushed
+immediately so the UI can hydrate without a separate REST call.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncGenerator
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.responses import StreamingResponse
+
+from tyr.events import EventBus, TyrEvent
+
+logger = logging.getLogger(__name__)
+
+
+async def resolve_event_bus() -> EventBus:  # pragma: no cover
+    """Dependency stub — always overridden by the app lifespan in main.py."""
+    raise HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail="Event bus not configured",
+    )
+
+
+async def _sse_generator(
+    event_bus: EventBus,
+    q: asyncio.Queue[TyrEvent],
+    keepalive_interval: float,
+) -> AsyncGenerator[str, None]:
+    """Async generator that streams SSE messages.
+
+    Yields the current state snapshot immediately, then relays events from *q*.
+    Sends an SSE comment keepalive after ``keepalive_interval`` idle seconds.
+    Calls ``event_bus.unsubscribe(q)`` in a finally block so the queue is
+    always cleaned up on disconnect or error.
+    """
+    try:
+        for snapshot_event in event_bus.get_snapshot():
+            yield snapshot_event.to_sse()
+
+        while True:
+            try:
+                event: TyrEvent = await asyncio.wait_for(
+                    q.get(), timeout=keepalive_interval
+                )
+                yield event.to_sse()
+            except TimeoutError:
+                yield ": keepalive\n\n"
+    finally:
+        event_bus.unsubscribe(q)
+        logger.debug(
+            "SSE client disconnected; remaining clients: %d",
+            event_bus.client_count,
+        )
+
+
+def create_events_router(keepalive_interval: float = 15.0) -> APIRouter:
+    """Return an APIRouter with the ``GET /api/v1/tyr/events`` SSE endpoint.
+
+    Args:
+        keepalive_interval: Seconds between SSE keepalive comments when no
+            events are queued.  Configurable so tests can use a short value.
+    """
+    router = APIRouter(prefix="/api/v1/tyr", tags=["Events"])
+
+    @router.get("/events", summary="SSE event stream")
+    async def sse_stream(
+        request: Request,  # noqa: ARG001
+        event_bus: EventBus = Depends(resolve_event_bus),
+    ) -> StreamingResponse:
+        """Stream all real-time Tyr state changes as Server-Sent Events.
+
+        The client receives a state snapshot immediately on connect, followed
+        by live events as they are emitted.  The connection is kept alive with
+        SSE comment lines when idle.
+        """
+        if event_bus.at_capacity:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=f"SSE client limit reached ({event_bus.client_count})",
+            )
+
+        # Subscribe *before* creating the response so that events emitted
+        # between "route handler called" and "generator starts" are not lost.
+        q = event_bus.subscribe()
+
+        return StreamingResponse(
+            _sse_generator(event_bus, q, keepalive_interval),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+                "X-Accel-Buffering": "no",
+            },
+        )
+
+    return router

--- a/src/tyr/api/raids.py
+++ b/src/tyr/api/raids.py
@@ -1,0 +1,414 @@
+"""REST API for raid review actions.
+
+Provides endpoints for reviewing, approving, rejecting, and retrying raids
+that are in the REVIEW state.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel, Field
+
+from tyr.config import ReviewConfig
+from tyr.domain.exceptions import InvalidStateTransitionError
+from tyr.domain.models import (
+    ConfidenceEvent,
+    ConfidenceEventType,
+    RaidStatus,
+    validate_transition,
+)
+from tyr.ports.git import GitPort
+from tyr.ports.raid_repository import RaidRepository
+from tyr.ports.tracker import TrackerPort
+from tyr.ports.volundr import VolundrPort
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Response / request models
+# ---------------------------------------------------------------------------
+
+
+class ConfidenceEventResponse(BaseModel):
+    id: str
+    event_type: str
+    delta: float
+    score_after: float
+    created_at: str
+
+
+class ReviewResponse(BaseModel):
+    raid_id: str
+    name: str
+    status: str
+    chronicle_summary: str | None = None
+    pr_url: str | None = None
+    ci_passed: bool | None = None
+    confidence: float
+    confidence_events: list[ConfidenceEventResponse] = Field(default_factory=list)
+
+
+class RaidResponse(BaseModel):
+    id: str
+    name: str
+    status: str
+    confidence: float
+    retry_count: int
+    branch: str | None = None
+    chronicle_summary: str | None = None
+    reason: str | None = None
+
+
+class RejectRequest(BaseModel):
+    reason: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Dependency stubs -- overridden by main.py lifespan
+# ---------------------------------------------------------------------------
+
+
+async def resolve_raid_repo() -> RaidRepository:
+    raise HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail="Raid repository not configured",
+    )
+
+
+async def resolve_volundr() -> VolundrPort:
+    raise HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail="Volundr port not configured",
+    )
+
+
+async def resolve_git() -> GitPort:
+    raise HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail="Git port not configured",
+    )
+
+
+async def resolve_tracker() -> TrackerPort:
+    raise HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail="Tracker port not configured",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_review_config(request: Request) -> ReviewConfig:
+    """Extract ReviewConfig from app settings, with fallback defaults."""
+    settings = getattr(request.app.state, "settings", None)
+    if settings is None:
+        return ReviewConfig()
+    return settings.review
+
+
+def _raid_response(raid, reason: str | None = None) -> RaidResponse:
+    return RaidResponse(
+        id=str(raid.id),
+        name=raid.name,
+        status=raid.status.value,
+        confidence=raid.confidence,
+        retry_count=raid.retry_count,
+        branch=raid.branch,
+        chronicle_summary=raid.chronicle_summary,
+        reason=reason,
+    )
+
+
+def _make_confidence_event(
+    raid_id: UUID,
+    event_type: ConfidenceEventType,
+    delta: float,
+    current_score: float,
+) -> ConfidenceEvent:
+    new_score = max(0.0, min(1.0, current_score + delta))
+    return ConfidenceEvent(
+        id=uuid4(),
+        raid_id=raid_id,
+        event_type=event_type,
+        delta=delta,
+        score_after=new_score,
+        created_at=datetime.now(UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Router
+# ---------------------------------------------------------------------------
+
+
+def create_raids_router() -> APIRouter:
+    router = APIRouter(prefix="/api/v1/tyr/raids", tags=["Raids"])
+
+    @router.get("/{raid_id}/review", response_model=ReviewResponse)
+    async def get_review(
+        raid_id: UUID,
+        raid_repo: RaidRepository = Depends(resolve_raid_repo),
+        volundr: VolundrPort = Depends(resolve_volundr),
+    ) -> ReviewResponse:
+        """Get review state for a raid: chronicle summary, CI status, confidence."""
+        raid = await raid_repo.get_raid(raid_id)
+        if raid is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Raid not found: {raid_id}",
+            )
+
+        # Fetch PR/CI status from Volundr if a session exists
+        pr_url: str | None = None
+        ci_passed: bool | None = None
+        if raid.session_id:
+            try:
+                pr_status = await volundr.get_pr_status(raid.session_id)
+                pr_url = pr_status.pr_id
+                ci_passed = pr_status.ci_passed
+            except Exception:
+                logger.warning(
+                    "Failed to fetch PR status for session %s",
+                    raid.session_id,
+                    exc_info=True,
+                )
+
+        events = await raid_repo.get_confidence_events(raid_id)
+
+        return ReviewResponse(
+            raid_id=str(raid.id),
+            name=raid.name,
+            status=raid.status.value,
+            chronicle_summary=raid.chronicle_summary,
+            pr_url=pr_url,
+            ci_passed=ci_passed,
+            confidence=raid.confidence,
+            confidence_events=[
+                ConfidenceEventResponse(
+                    id=str(e.id),
+                    event_type=e.event_type.value,
+                    delta=e.delta,
+                    score_after=e.score_after,
+                    created_at=e.created_at.isoformat(),
+                )
+                for e in events
+            ],
+        )
+
+    @router.post("/{raid_id}/approve", response_model=RaidResponse)
+    async def approve_raid(
+        raid_id: UUID,
+        request: Request,
+        raid_repo: RaidRepository = Depends(resolve_raid_repo),
+        volundr: VolundrPort = Depends(resolve_volundr),
+        git: GitPort = Depends(resolve_git),
+        tracker: TrackerPort = Depends(resolve_tracker),
+    ) -> RaidResponse:
+        """Approve a raid: merge branch, update state, check phase gate."""
+        review_cfg = _get_review_config(request)
+
+        raid = await raid_repo.get_raid(raid_id)
+        if raid is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Raid not found: {raid_id}",
+            )
+
+        try:
+            validate_transition(raid.status, RaidStatus.MERGED)
+        except InvalidStateTransitionError:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"Cannot approve raid in {raid.status.value} state",
+            )
+
+        saga = await raid_repo.get_saga_for_raid(raid_id)
+        if saga is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Parent saga not found for raid",
+            )
+
+        # 1. Check CI status (warn but don't block)
+        if raid.session_id:
+            try:
+                pr_status = await volundr.get_pr_status(raid.session_id)
+                if pr_status.ci_passed is False:
+                    logger.warning("Approving raid %s with failing CI", raid_id)
+            except Exception:
+                logger.warning(
+                    "Could not verify CI status for raid %s",
+                    raid_id,
+                    exc_info=True,
+                )
+
+        # 2. Merge raid branch into feature branch
+        if raid.branch and saga.repos:
+            repo = saga.repos[0]
+            try:
+                await git.merge_branch(repo, raid.branch, saga.feature_branch)
+            except Exception as exc:
+                raise HTTPException(
+                    status_code=status.HTTP_502_BAD_GATEWAY,
+                    detail=f"Branch merge failed: {exc}",
+                )
+
+            # 3. Clean up raid branch
+            try:
+                await git.delete_branch(repo, raid.branch)
+            except Exception:
+                logger.warning("Failed to delete branch %s", raid.branch, exc_info=True)
+
+        # 4. Apply HUMAN_APPROVED confidence event
+        event = _make_confidence_event(
+            raid.id,
+            ConfidenceEventType.HUMAN_APPROVED,
+            review_cfg.confidence_delta_approved,
+            raid.confidence,
+        )
+        await raid_repo.add_confidence_event(event)
+
+        # 5. Update raid status to MERGED
+        updated = await raid_repo.update_raid_status(raid_id, RaidStatus.MERGED)
+
+        # 6. Update tracker
+        try:
+            await tracker.update_raid_state(raid.tracker_id, RaidStatus.MERGED)
+            await tracker.close_raid(raid.tracker_id)
+        except Exception:
+            logger.warning("Failed to update tracker for raid %s", raid_id, exc_info=True)
+
+        # 7. Check phase gate
+        phase = await raid_repo.get_phase_for_raid(raid_id)
+        if phase and await raid_repo.all_raids_merged(phase.id):
+            logger.info("Phase gate unlocked -- all raids merged in phase %s", phase.id)
+
+        if updated is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Raid disappeared during approve",
+            )
+
+        return _raid_response(updated)
+
+    @router.post("/{raid_id}/reject", response_model=RaidResponse)
+    async def reject_raid(
+        raid_id: UUID,
+        request: Request,
+        body: RejectRequest | None = None,
+        raid_repo: RaidRepository = Depends(resolve_raid_repo),
+        tracker: TrackerPort = Depends(resolve_tracker),
+    ) -> RaidResponse:
+        """Reject a raid: set FAILED, record reason, apply confidence penalty."""
+        review_cfg = _get_review_config(request)
+
+        raid = await raid_repo.get_raid(raid_id)
+        if raid is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Raid not found: {raid_id}",
+            )
+
+        try:
+            validate_transition(raid.status, RaidStatus.FAILED)
+        except InvalidStateTransitionError:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"Cannot reject raid in {raid.status.value} state",
+            )
+
+        reason = body.reason if body else None
+
+        # Apply HUMAN_REJECT confidence event
+        event = _make_confidence_event(
+            raid.id,
+            ConfidenceEventType.HUMAN_REJECT,
+            review_cfg.confidence_delta_rejected,
+            raid.confidence,
+        )
+        await raid_repo.add_confidence_event(event)
+
+        # Update status
+        updated = await raid_repo.update_raid_status(
+            raid_id,
+            RaidStatus.FAILED,
+            reason=reason,
+        )
+
+        # Update tracker
+        try:
+            await tracker.update_raid_state(raid.tracker_id, RaidStatus.FAILED)
+        except Exception:
+            logger.warning("Failed to update tracker for raid %s", raid_id, exc_info=True)
+
+        if updated is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Raid disappeared during reject",
+            )
+
+        return _raid_response(updated, reason=reason)
+
+    @router.post("/{raid_id}/retry", response_model=RaidResponse)
+    async def retry_raid(
+        raid_id: UUID,
+        request: Request,
+        raid_repo: RaidRepository = Depends(resolve_raid_repo),
+        tracker: TrackerPort = Depends(resolve_tracker),
+    ) -> RaidResponse:
+        """Retry a raid: reset to PENDING, increment retry_count."""
+        review_cfg = _get_review_config(request)
+
+        raid = await raid_repo.get_raid(raid_id)
+        if raid is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Raid not found: {raid_id}",
+            )
+
+        try:
+            validate_transition(raid.status, RaidStatus.PENDING)
+        except InvalidStateTransitionError:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"Cannot retry raid in {raid.status.value} state",
+            )
+
+        # Apply RETRY confidence event
+        event = _make_confidence_event(
+            raid.id,
+            ConfidenceEventType.RETRY,
+            review_cfg.confidence_delta_retry,
+            raid.confidence,
+        )
+        await raid_repo.add_confidence_event(event)
+
+        # Reset to PENDING with incremented retry_count
+        updated = await raid_repo.update_raid_status(
+            raid_id,
+            RaidStatus.PENDING,
+            increment_retry=True,
+        )
+
+        # Update tracker
+        try:
+            await tracker.update_raid_state(raid.tracker_id, RaidStatus.PENDING)
+        except Exception:
+            logger.warning("Failed to update tracker for raid %s", raid_id, exc_info=True)
+
+        if updated is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Raid disappeared during retry",
+            )
+
+        return _raid_response(updated)
+
+    return router

--- a/src/tyr/config.py
+++ b/src/tyr/config.py
@@ -148,6 +148,13 @@ class TrackerConfig(BaseModel):
     rate_limit_max_retries: int = Field(default=3)
 
 
+class EventsConfig(BaseModel):
+    """SSE event stream configuration."""
+
+    max_sse_clients: int = Field(default=10)
+    keepalive_interval: float = Field(default=15.0)
+
+
 class Settings(BaseSettings):
     """Application settings.
 
@@ -183,6 +190,7 @@ class Settings(BaseSettings):
     pat: PATConfig = Field(default_factory=PATConfig)
     auth: AuthConfig = Field(default_factory=AuthConfig)
     cerbos: CerbosConfig = Field(default_factory=CerbosConfig)
+    events: EventsConfig = Field(default_factory=EventsConfig)
     telegram: TelegramConfig = Field(default_factory=TelegramConfig)
 
     @classmethod

--- a/src/tyr/config.py
+++ b/src/tyr/config.py
@@ -80,6 +80,20 @@ class AIModelConfig(BaseModel):
     name: str
 
 
+class ReviewConfig(BaseModel):
+    """Confidence deltas for raid review actions."""
+
+    confidence_delta_approved: float = Field(default=0.15)
+    confidence_delta_rejected: float = Field(default=-0.20)
+    confidence_delta_retry: float = Field(default=-0.05)
+
+
+class GitConfig(BaseModel):
+    """Git provider configuration."""
+
+    token: str = Field(default="")
+
+
 class DispatchConfig(BaseModel):
     """Dispatcher configuration."""
 
@@ -184,6 +198,8 @@ class Settings(BaseSettings):
             AIModelConfig(id="claude-haiku-4-5-20251001", name="Haiku 4.5"),
         ]
     )
+    git: GitConfig = Field(default_factory=GitConfig)
+    review: ReviewConfig = Field(default_factory=ReviewConfig)
     tracker: TrackerConfig = Field(default_factory=TrackerConfig)
     dispatch: DispatchConfig = Field(default_factory=DispatchConfig)
     credential_store: CredentialStoreConfig = Field(default_factory=CredentialStoreConfig)

--- a/src/tyr/domain/models.py
+++ b/src/tyr/domain/models.py
@@ -42,6 +42,7 @@ class ConfidenceEventType(StrEnum):
     SCOPE_BREACH = "scope_breach"
     RETRY = "retry"
     HUMAN_REJECT = "human_reject"
+    HUMAN_APPROVED = "human_approved"
 
 
 # ---------------------------------------------------------------------------
@@ -52,7 +53,14 @@ RAID_TRANSITIONS: dict[RaidStatus, frozenset[RaidStatus]] = {
     RaidStatus.PENDING: frozenset({RaidStatus.QUEUED}),
     RaidStatus.QUEUED: frozenset({RaidStatus.RUNNING, RaidStatus.FAILED}),
     RaidStatus.RUNNING: frozenset({RaidStatus.REVIEW, RaidStatus.MERGED, RaidStatus.FAILED}),
-    RaidStatus.REVIEW: frozenset({RaidStatus.QUEUED, RaidStatus.MERGED, RaidStatus.FAILED}),
+    RaidStatus.REVIEW: frozenset(
+        {
+            RaidStatus.PENDING,
+            RaidStatus.QUEUED,
+            RaidStatus.MERGED,
+            RaidStatus.FAILED,
+        }
+    ),
     RaidStatus.MERGED: frozenset(),
     RaidStatus.FAILED: frozenset({RaidStatus.QUEUED}),
 }

--- a/src/tyr/events.py
+++ b/src/tyr/events.py
@@ -1,0 +1,82 @@
+"""Tyr event bus — in-process pub/sub for SSE broadcasting.
+
+Application services call ``event_bus.emit(event)`` to broadcast state changes.
+The SSE handler subscribes a per-client queue and streams events to the browser.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+# Event types that represent current persistent state.
+# These are cached and replayed to new subscribers as an initial snapshot,
+# so the UI doesn't need a separate hydration call.
+_SNAPSHOT_TYPES: frozenset[str] = frozenset({"dispatcher.state"})
+
+
+@dataclass
+class TyrEvent:
+    """A single Tyr SSE event."""
+
+    event: str
+    data: dict[str, Any]
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+
+    def to_sse(self) -> str:
+        """Serialise as SSE wire format (id / event / data / blank line)."""
+        return f"id: {self.id}\nevent: {self.event}\ndata: {json.dumps(self.data)}\n\n"
+
+
+class EventBus:
+    """In-process broadcast bus for Tyr SSE events.
+
+    One queue per connected SSE client.  ``emit`` fans out to all queues.
+    State-type events are cached and replayed to new clients on subscribe.
+    """
+
+    def __init__(self, max_clients: int = 10) -> None:
+        self._max_clients = max_clients
+        self._queues: list[asyncio.Queue[TyrEvent]] = []
+        self._snapshots: dict[str, TyrEvent] = {}
+
+    @property
+    def client_count(self) -> int:
+        """Number of currently connected SSE clients."""
+        return len(self._queues)
+
+    @property
+    def at_capacity(self) -> bool:
+        """True when the maximum number of SSE clients is already connected."""
+        return len(self._queues) >= self._max_clients
+
+    def subscribe(self) -> asyncio.Queue[TyrEvent]:
+        """Register a new SSE client and return its dedicated queue."""
+        q: asyncio.Queue[TyrEvent] = asyncio.Queue()
+        self._queues.append(q)
+        return q
+
+    def unsubscribe(self, q: asyncio.Queue[TyrEvent]) -> None:
+        """Remove a client queue — safe to call even if already removed."""
+        try:
+            self._queues.remove(q)
+        except ValueError:
+            pass
+
+    async def emit(self, event: TyrEvent) -> None:
+        """Broadcast an event to every connected client queue.
+
+        State-type events (``_SNAPSHOT_TYPES``) are also saved so they can be
+        replayed to new subscribers via ``get_snapshot``.
+        """
+        if event.event in _SNAPSHOT_TYPES:
+            self._snapshots[event.event] = event
+        for q in list(self._queues):
+            await q.put(event)
+
+    def get_snapshot(self) -> list[TyrEvent]:
+        """Return the current state snapshot for delivery to a new subscriber."""
+        return list(self._snapshots.values())

--- a/src/tyr/main.py
+++ b/src/tyr/main.py
@@ -27,9 +27,11 @@ from tyr.adapters.volundr_http import VolundrHTTPAdapter
 from tyr.api.dispatch import create_dispatch_router, resolve_volundr
 from tyr.api.dispatch import resolve_saga_repo as dispatch_resolve_saga_repo
 from tyr.api.dispatcher import create_dispatcher_router, resolve_dispatcher_repo
+from tyr.api.events import create_events_router, resolve_event_bus
 from tyr.api.sagas import create_sagas_router, resolve_saga_repo
 from tyr.api.tracker import create_tracker_router, resolve_trackers
 from tyr.config import Settings
+from tyr.events import EventBus
 from tyr.infrastructure.database import database_pool
 from tyr.ports.dispatcher_repository import DispatcherRepository
 from tyr.ports.saga_repository import SagaRepository
@@ -69,6 +71,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(create_sagas_router())
     app.include_router(create_dispatch_router())
     app.include_router(create_dispatcher_router())
+    app.include_router(create_events_router(settings.events.keepalive_interval))
     from tyr.adapters.inbound.auth import extract_principal as _extract_principal
 
     app.include_router(create_pats_router(_extract_principal))
@@ -166,6 +169,15 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 validator=pat_validator,
             )
             app.state.pat_service = pat_service
+
+            # Wire event bus
+            event_bus = EventBus(max_clients=settings.events.max_sse_clients)
+            app.state.event_bus = event_bus
+
+            async def _resolve_event_bus() -> EventBus:
+                return event_bus
+
+            app.dependency_overrides[resolve_event_bus] = _resolve_event_bus
 
             logger.info("Tyr started — database pool ready")
             yield

--- a/src/tyr/main.py
+++ b/src/tyr/main.py
@@ -14,12 +14,14 @@ from niuu.adapters.postgres_integrations import PostgresIntegrationRepository
 from niuu.domain.models import Principal
 from niuu.domain.services.pat_validator import PATValidator
 from niuu.utils import import_class, resolve_secret_kwargs
+from tyr.adapters.github_git import GitHubGitAdapter
 from tyr.adapters.inbound.rest_integrations import (
     create_integrations_router,
     create_telegram_setup_router,
 )
 from tyr.adapters.inbound.rest_pats import create_pats_router
 from tyr.adapters.postgres_dispatcher import PostgresDispatcherRepository
+from tyr.adapters.postgres_raids import PostgresRaidRepository
 from tyr.adapters.postgres_sagas import PostgresSagaRepository
 from tyr.adapters.tracker_factory import TrackerAdapterFactory
 from tyr.adapters.volundr_factory import VolundrAdapterFactory
@@ -28,12 +30,17 @@ from tyr.api.dispatch import create_dispatch_router, resolve_volundr
 from tyr.api.dispatch import resolve_saga_repo as dispatch_resolve_saga_repo
 from tyr.api.dispatcher import create_dispatcher_router, resolve_dispatcher_repo
 from tyr.api.events import create_events_router, resolve_event_bus
+from tyr.api.raids import create_raids_router, resolve_git, resolve_raid_repo
+from tyr.api.raids import resolve_tracker as resolve_raids_tracker
+from tyr.api.raids import resolve_volundr as resolve_raids_volundr
 from tyr.api.sagas import create_sagas_router, resolve_saga_repo
 from tyr.api.tracker import create_tracker_router, resolve_trackers
 from tyr.config import Settings
 from tyr.events import EventBus
 from tyr.infrastructure.database import database_pool
 from tyr.ports.dispatcher_repository import DispatcherRepository
+from tyr.ports.git import GitPort
+from tyr.ports.raid_repository import RaidRepository
 from tyr.ports.saga_repository import SagaRepository
 from tyr.ports.tracker import TrackerPort
 from tyr.ports.volundr import VolundrPort
@@ -69,6 +76,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     # -- Routers --
     app.include_router(create_tracker_router())
     app.include_router(create_sagas_router())
+    app.include_router(create_raids_router())
     app.include_router(create_dispatch_router())
     app.include_router(create_dispatcher_router())
     app.include_router(create_events_router(settings.events.keepalive_interval))
@@ -143,6 +151,44 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 return volundr_adapter
 
             app.dependency_overrides[resolve_volundr] = _resolve_volundr
+            app.dependency_overrides[resolve_raids_volundr] = _resolve_volundr
+
+            # Wire Git adapter
+            git_adapter = GitHubGitAdapter(settings.git.token)
+
+            async def _resolve_git() -> GitPort:
+                return git_adapter
+
+            app.dependency_overrides[resolve_git] = _resolve_git
+
+            # Wire tracker for raids (uses first available tracker)
+            async def _resolve_raids_tracker_dep(
+                principal: Principal = Depends(extract_principal),
+            ) -> TrackerPort:
+                trackers = await app.state.tracker_factory.for_owner(
+                    principal.user_id
+                )
+                if not trackers:
+                    from fastapi import HTTPException, status
+
+                    raise HTTPException(
+                        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                        detail="No tracker configured",
+                    )
+                return trackers[0]
+
+            app.dependency_overrides[resolve_raids_tracker] = (
+                _resolve_raids_tracker_dep
+            )
+
+            # Wire raid repository
+            raid_repo = PostgresRaidRepository(pool)
+            app.state.raid_repo = raid_repo
+
+            async def _resolve_raid_repo() -> RaidRepository:
+                return raid_repo
+
+            app.dependency_overrides[resolve_raid_repo] = _resolve_raid_repo
 
             # Wire personal access token service
             from tyr.adapters.postgres_pats import PostgresPATRepository

--- a/src/tyr/ports/git.py
+++ b/src/tyr/ports/git.py
@@ -17,6 +17,9 @@ class GitPort(ABC):
     async def merge_branch(self, repo: str, source: str, target: str) -> None: ...
 
     @abstractmethod
+    async def delete_branch(self, repo: str, branch: str) -> None: ...
+
+    @abstractmethod
     async def create_pr(self, repo: str, source: str, target: str, title: str) -> str: ...
 
     @abstractmethod

--- a/src/tyr/ports/raid_repository.py
+++ b/src/tyr/ports/raid_repository.py
@@ -1,0 +1,54 @@
+"""Raid repository port — persistence for raid state in the local DB."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from uuid import UUID
+
+from tyr.domain.models import ConfidenceEvent, Phase, Raid, RaidStatus, Saga
+
+
+class RaidRepository(ABC):
+    """Abstract persistence for raids and their confidence history."""
+
+    @abstractmethod
+    async def get_raid(self, raid_id: UUID) -> Raid | None:
+        """Get a raid by its internal UUID."""
+        ...
+
+    @abstractmethod
+    async def update_raid_status(
+        self,
+        raid_id: UUID,
+        status: RaidStatus,
+        *,
+        reason: str | None = None,
+        increment_retry: bool = False,
+    ) -> Raid | None:
+        """Update raid status (and optionally reason / retry_count). Returns updated raid."""
+        ...
+
+    @abstractmethod
+    async def get_confidence_events(self, raid_id: UUID) -> list[ConfidenceEvent]:
+        """Return all confidence events for a raid, ordered by created_at."""
+        ...
+
+    @abstractmethod
+    async def add_confidence_event(self, event: ConfidenceEvent) -> None:
+        """Persist a new confidence event and update the raid's confidence score."""
+        ...
+
+    @abstractmethod
+    async def get_saga_for_raid(self, raid_id: UUID) -> Saga | None:
+        """Resolve the parent saga for a given raid (raid -> phase -> saga)."""
+        ...
+
+    @abstractmethod
+    async def get_phase_for_raid(self, raid_id: UUID) -> Phase | None:
+        """Resolve the parent phase for a given raid."""
+        ...
+
+    @abstractmethod
+    async def all_raids_merged(self, phase_id: UUID) -> bool:
+        """Check whether every raid in the phase has status MERGED."""
+        ...

--- a/src/tyr/ports/volundr.py
+++ b/src/tyr/ports/volundr.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
+from tyr.domain.models import PRStatus
+
 
 @dataclass(frozen=True)
 class SpawnRequest:
@@ -56,3 +58,9 @@ class VolundrPort(ABC):
         *,
         auth_token: str | None = None,
     ) -> list[VolundrSession]: ...
+
+    @abstractmethod
+    async def get_pr_status(self, session_id: str) -> PRStatus: ...
+
+    @abstractmethod
+    async def get_chronicle_summary(self, session_id: str) -> str: ...

--- a/tests/test_tyr/test_dispatch_api.py
+++ b/tests/test_tyr/test_dispatch_api.py
@@ -87,6 +87,14 @@ class MockVolundr(VolundrPort):
         self.last_auth_token = auth_token
         return list(self.sessions)
 
+    async def get_pr_status(self, session_id: str):  # noqa: ANN201
+        from tyr.domain.models import PRStatus
+
+        return PRStatus(pr_id="pr-1", state="open", mergeable=True, ci_passed=True)
+
+    async def get_chronicle_summary(self, session_id: str) -> str:
+        return "summary"
+
 
 # -------------------------------------------------------------------
 # Fixtures

--- a/tests/test_tyr/test_events.py
+++ b/tests/test_tyr/test_events.py
@@ -1,0 +1,314 @@
+"""Tests for the Tyr EventBus and SSE endpoint."""
+
+from __future__ import annotations
+
+import asyncio
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tyr.api.events import _sse_generator, create_events_router, resolve_event_bus
+from tyr.events import EventBus, TyrEvent
+
+# ---------------------------------------------------------------------------
+# TyrEvent
+# ---------------------------------------------------------------------------
+
+
+class TestTyrEvent:
+    def test_to_sse_format(self):
+        event = TyrEvent(
+            id="fixed-id",
+            event="dispatcher.state",
+            data={"running": True, "threshold": 0.8, "queue_depth": 2},
+        )
+        sse = event.to_sse()
+        assert sse == (
+            "id: fixed-id\nevent: dispatcher.state\n"
+            'data: {"running": true, "threshold": 0.8, "queue_depth": 2}\n\n'
+        )
+
+    def test_id_auto_generated(self):
+        e1 = TyrEvent(event="session.spawned", data={})
+        e2 = TyrEvent(event="session.spawned", data={})
+        assert e1.id
+        assert e1.id != e2.id
+
+    def test_to_sse_ends_with_double_newline(self):
+        event = TyrEvent(
+            id="x",
+            event="phase.unlocked",
+            data={"saga_id": "s1", "phase_id": "p1", "phase_name": "P1"},
+        )
+        assert event.to_sse().endswith("\n\n")
+
+
+# ---------------------------------------------------------------------------
+# EventBus
+# ---------------------------------------------------------------------------
+
+
+class TestEventBus:
+    def test_initial_state(self):
+        bus = EventBus(max_clients=5)
+        assert bus.client_count == 0
+        assert not bus.at_capacity
+        assert bus.get_snapshot() == []
+
+    def test_subscribe_increments_count(self):
+        bus = EventBus(max_clients=5)
+        bus.subscribe()
+        assert bus.client_count == 1
+
+    def test_unsubscribe_decrements_count(self):
+        bus = EventBus(max_clients=5)
+        q = bus.subscribe()
+        bus.unsubscribe(q)
+        assert bus.client_count == 0
+
+    def test_unsubscribe_nonexistent_is_noop(self):
+        bus = EventBus(max_clients=5)
+        orphan: asyncio.Queue = asyncio.Queue()
+        bus.unsubscribe(orphan)  # must not raise
+
+    def test_at_capacity_when_full(self):
+        bus = EventBus(max_clients=2)
+        bus.subscribe()
+        assert not bus.at_capacity
+        bus.subscribe()
+        assert bus.at_capacity
+
+    async def test_emit_puts_event_in_all_queues(self):
+        bus = EventBus(max_clients=5)
+        q1 = bus.subscribe()
+        q2 = bus.subscribe()
+        event = TyrEvent(
+            event="session.spawned",
+            data={"session_id": "s1", "raid_id": "r1", "branch": "feat/x"},
+        )
+        await bus.emit(event)
+        assert q1.qsize() == 1
+        assert q2.qsize() == 1
+        received = await q1.get()
+        assert received is event
+
+    async def test_emit_skips_unsubscribed_queues(self):
+        bus = EventBus(max_clients=5)
+        q = bus.subscribe()
+        bus.unsubscribe(q)
+        event = TyrEvent(event="session.spawned", data={})
+        await bus.emit(event)
+        assert q.qsize() == 0
+
+    async def test_emit_saves_snapshot_for_state_events(self):
+        bus = EventBus(max_clients=5)
+        event = TyrEvent(
+            event="dispatcher.state",
+            data={"running": False, "threshold": 0.8, "queue_depth": 0},
+        )
+        await bus.emit(event)
+        snapshot = bus.get_snapshot()
+        assert len(snapshot) == 1
+        assert snapshot[0] is event
+
+    async def test_emit_does_not_snapshot_transient_events(self):
+        bus = EventBus(max_clients=5)
+        for ev_type in (
+            "session.spawned",
+            "session.stopped",
+            "session.failed",
+            "raid.state_changed",
+            "confidence.updated",
+            "dispatcher.log",
+            "saga.pr_created",
+            "phase.unlocked",
+        ):
+            await bus.emit(TyrEvent(event=ev_type, data={}))
+        assert bus.get_snapshot() == []
+
+    async def test_snapshot_updated_on_repeated_emit(self):
+        bus = EventBus(max_clients=5)
+        e1 = TyrEvent(
+            event="dispatcher.state",
+            data={"running": False, "threshold": 0.8, "queue_depth": 0},
+        )
+        e2 = TyrEvent(
+            event="dispatcher.state",
+            data={"running": True, "threshold": 0.8, "queue_depth": 3},
+        )
+        await bus.emit(e1)
+        await bus.emit(e2)
+        snapshot = bus.get_snapshot()
+        assert len(snapshot) == 1
+        assert snapshot[0].data["running"] is True
+
+    async def test_get_snapshot_returns_copy(self):
+        bus = EventBus(max_clients=5)
+        await bus.emit(
+            TyrEvent(
+                event="dispatcher.state",
+                data={"running": False, "threshold": 0.8, "queue_depth": 0},
+            )
+        )
+        s1 = bus.get_snapshot()
+        s2 = bus.get_snapshot()
+        assert s1 is not s2
+
+
+# ---------------------------------------------------------------------------
+# SSE generator — direct async tests (avoids httpx ASGI transport limitations)
+# ---------------------------------------------------------------------------
+
+
+class TestSseGenerator:
+    """Tests for _sse_generator directly — no HTTP transport required."""
+
+    async def test_yields_snapshot_on_start(self):
+        bus = EventBus(max_clients=5)
+        snap = TyrEvent(
+            id="snap-1",
+            event="dispatcher.state",
+            data={"running": False, "threshold": 0.8, "queue_depth": 0},
+        )
+        await bus.emit(snap)
+
+        q = bus.subscribe()
+        chunks: list[str] = []
+        async for chunk in _sse_generator(bus, q, keepalive_interval=30.0):
+            chunks.append(chunk)
+            break  # Stop after snapshot
+
+        combined = "".join(chunks)
+        assert "event: dispatcher.state" in combined
+        assert "id: snap-1" in combined
+
+    async def test_yields_queued_events(self):
+        bus = EventBus(max_clients=5)
+        q = bus.subscribe()
+        event = TyrEvent(
+            id="live-1",
+            event="raid.state_changed",
+            data={
+                "raid_id": "r1",
+                "saga_id": "s1",
+                "phase_id": "p1",
+                "state": "RUNNING",
+                "confidence": 0.9,
+            },
+        )
+        await bus.emit(event)  # pre-queue before generator starts
+
+        chunks: list[str] = []
+        async for chunk in _sse_generator(bus, q, keepalive_interval=30.0):
+            chunks.append(chunk)
+            if "raid.state_changed" in chunk:
+                break
+
+        combined = "".join(chunks)
+        assert "event: raid.state_changed" in combined
+        assert "id: live-1" in combined
+
+    async def test_yields_keepalive_when_idle(self):
+        bus = EventBus(max_clients=5)
+        q = bus.subscribe()
+
+        chunks: list[str] = []
+        async for chunk in _sse_generator(bus, q, keepalive_interval=0.05):
+            chunks.append(chunk)
+            if ": keepalive" in chunk:
+                break
+
+        assert ": keepalive" in "".join(chunks)
+
+    async def test_unsubscribes_on_close(self):
+        bus = EventBus(max_clients=5)
+        snap = TyrEvent(
+            id="s1",
+            event="dispatcher.state",
+            data={"running": False, "threshold": 0.8, "queue_depth": 0},
+        )
+        await bus.emit(snap)  # Populate snapshot so generator yields immediately
+
+        q = bus.subscribe()
+        assert bus.client_count == 1
+
+        gen = _sse_generator(bus, q, keepalive_interval=30.0)
+        async for _ in gen:
+            break  # Snapshot yields immediately; break schedules aclose()
+        await gen.aclose()  # Explicitly await cleanup to ensure finally runs
+
+        assert bus.client_count == 0
+
+    async def test_multiple_event_types_delivered(self):
+        """All event types flow through the queue correctly."""
+        bus = EventBus(max_clients=5)
+        q = bus.subscribe()
+
+        event_types = [
+            ("session.spawned", {"session_id": "s1", "raid_id": "r1", "branch": "b"}),
+            (
+                "session.stopped",
+                {"session_id": "s1", "raid_id": "r1", "confidence": 0.9, "state": "REVIEW"},
+            ),
+            ("session.failed", {"session_id": "s1", "raid_id": "r1", "retry_count": 1}),
+            ("saga.pr_created", {"saga_id": "sg1", "pr_url": "https://example.com/pr/1"}),
+            ("phase.unlocked", {"saga_id": "sg1", "phase_id": "p1", "phase_name": "Phase 1"}),
+        ]
+
+        for ev_type, data in event_types:
+            await bus.emit(TyrEvent(event=ev_type, data=data))
+
+        received: list[str] = []
+        gen = _sse_generator(bus, q, keepalive_interval=30.0)
+        for _ in range(len(event_types)):
+            chunk = await gen.__anext__()
+            received.append(chunk)
+
+        await gen.aclose()
+
+        combined = "".join(received)
+        for ev_type, _ in event_types:
+            assert ev_type in combined
+
+
+# ---------------------------------------------------------------------------
+# SSE HTTP endpoint — sync tests (no streaming body needed)
+# ---------------------------------------------------------------------------
+
+
+def _make_app(event_bus: EventBus, keepalive_interval: float = 30.0) -> FastAPI:
+    app = FastAPI()
+    app.include_router(create_events_router(keepalive_interval=keepalive_interval))
+    app.dependency_overrides[resolve_event_bus] = lambda: event_bus
+    return app
+
+
+class TestSseEndpointHttp:
+    def test_returns_503_when_at_capacity(self):
+        bus = EventBus(max_clients=1)
+        bus.subscribe()  # fill up
+        client = TestClient(_make_app(bus))
+        resp = client.get("/api/v1/tyr/events")
+        assert resp.status_code == 503
+        assert "limit" in resp.json()["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Config integration
+# ---------------------------------------------------------------------------
+
+
+class TestEventsConfig:
+    def test_default_values(self):
+        from tyr.config import EventsConfig
+
+        cfg = EventsConfig()
+        assert cfg.max_sse_clients == 10
+        assert cfg.keepalive_interval == 15.0
+
+    def test_settings_includes_events(self):
+        from tyr.config import Settings
+
+        s = Settings()
+        assert s.events.max_sse_clients == 10
+        assert s.events.keepalive_interval == 15.0

--- a/tests/test_tyr/test_github_git.py
+++ b/tests/test_tyr/test_github_git.py
@@ -1,0 +1,228 @@
+"""Tests for GitHubGitAdapter with respx-mocked httpx calls."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from tyr.adapters.github_git import GitHubGitAdapter
+
+REPO = "org/repo"
+GH_API = "https://api.github.com"
+
+
+@pytest.fixture
+def adapter() -> GitHubGitAdapter:
+    return GitHubGitAdapter(token="test-token", timeout=5.0)
+
+
+# -------------------------------------------------------------------
+# Constructor
+# -------------------------------------------------------------------
+
+
+class TestConstructor:
+    def test_stores_token(self):
+        adapter = GitHubGitAdapter(token="tok")
+        assert adapter._token == "tok"
+
+    def test_default_timeout(self):
+        adapter = GitHubGitAdapter(token="tok")
+        assert adapter._timeout == 30.0
+
+    def test_custom_timeout(self):
+        adapter = GitHubGitAdapter(token="tok", timeout=10.0)
+        assert adapter._timeout == 10.0
+
+    def test_headers(self):
+        adapter = GitHubGitAdapter(token="tok")
+        headers = adapter._headers()
+        assert headers["Authorization"] == "Bearer tok"
+        assert "application/vnd.github+json" in headers["Accept"]
+
+    def test_owner_repo_split(self):
+        adapter = GitHubGitAdapter(token="tok")
+        owner, name = adapter._owner_repo("myorg/myrepo")
+        assert owner == "myorg"
+        assert name == "myrepo"
+
+    def test_creates_shared_client(self):
+        adapter = GitHubGitAdapter(token="tok")
+        assert adapter._client is not None
+        assert isinstance(adapter._client, httpx.AsyncClient)
+
+
+# -------------------------------------------------------------------
+# create_branch
+# -------------------------------------------------------------------
+
+
+class TestCreateBranch:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_creates_branch(self, adapter: GitHubGitAdapter):
+        respx.get(f"{GH_API}/repos/org/repo/git/ref/heads/main").mock(
+            return_value=httpx.Response(
+                200,
+                json={"object": {"sha": "abc123"}},
+            )
+        )
+        respx.post(f"{GH_API}/repos/org/repo/git/refs").mock(
+            return_value=httpx.Response(201, json={"ref": "refs/heads/new-branch"})
+        )
+
+        await adapter.create_branch(REPO, "new-branch", "main")
+
+        create_call = respx.calls[1]
+        import json
+
+        body = json.loads(create_call.request.content)
+        assert body["ref"] == "refs/heads/new-branch"
+        assert body["sha"] == "abc123"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_raises_on_base_not_found(self, adapter: GitHubGitAdapter):
+        respx.get(f"{GH_API}/repos/org/repo/git/ref/heads/missing").mock(
+            return_value=httpx.Response(404, text="not found")
+        )
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await adapter.create_branch(REPO, "new-branch", "missing")
+
+
+# -------------------------------------------------------------------
+# merge_branch
+# -------------------------------------------------------------------
+
+
+class TestMergeBranch:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_merges_branch(self, adapter: GitHubGitAdapter):
+        route = respx.post(f"{GH_API}/repos/org/repo/merges").mock(
+            return_value=httpx.Response(201, json={"sha": "merged-sha"})
+        )
+
+        await adapter.merge_branch(REPO, "feature", "main")
+
+        import json
+
+        body = json.loads(route.calls[0].request.content)
+        assert body["base"] == "main"
+        assert body["head"] == "feature"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_raises_on_conflict(self, adapter: GitHubGitAdapter):
+        respx.post(f"{GH_API}/repos/org/repo/merges").mock(
+            return_value=httpx.Response(409, text="Merge conflict")
+        )
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await adapter.merge_branch(REPO, "conflicting", "main")
+
+
+# -------------------------------------------------------------------
+# delete_branch
+# -------------------------------------------------------------------
+
+
+class TestDeleteBranch:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_deletes_branch(self, adapter: GitHubGitAdapter):
+        respx.delete(f"{GH_API}/repos/org/repo/git/refs/heads/old-branch").mock(
+            return_value=httpx.Response(204)
+        )
+
+        await adapter.delete_branch(REPO, "old-branch")
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_ignores_already_deleted(self, adapter: GitHubGitAdapter):
+        respx.delete(f"{GH_API}/repos/org/repo/git/refs/heads/gone").mock(
+            return_value=httpx.Response(404)
+        )
+
+        # Should not raise
+        await adapter.delete_branch(REPO, "gone")
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_raises_on_server_error(self, adapter: GitHubGitAdapter):
+        respx.delete(f"{GH_API}/repos/org/repo/git/refs/heads/branch").mock(
+            return_value=httpx.Response(500, text="error")
+        )
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await adapter.delete_branch(REPO, "branch")
+
+
+# -------------------------------------------------------------------
+# create_pr
+# -------------------------------------------------------------------
+
+
+class TestCreatePR:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_creates_pr(self, adapter: GitHubGitAdapter):
+        route = respx.post(f"{GH_API}/repos/org/repo/pulls").mock(
+            return_value=httpx.Response(201, json={"number": 42})
+        )
+
+        pr_id = await adapter.create_pr(REPO, "feature", "main", "My PR")
+
+        assert pr_id == "42"
+        import json
+
+        body = json.loads(route.calls[0].request.content)
+        assert body["title"] == "My PR"
+        assert body["head"] == "feature"
+        assert body["base"] == "main"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_raises_on_error(self, adapter: GitHubGitAdapter):
+        respx.post(f"{GH_API}/repos/org/repo/pulls").mock(
+            return_value=httpx.Response(422, text="validation failed")
+        )
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await adapter.create_pr(REPO, "feature", "main", "Bad PR")
+
+
+# -------------------------------------------------------------------
+# get_pr_status
+# -------------------------------------------------------------------
+
+
+class TestGetPRStatus:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_status(self, adapter: GitHubGitAdapter):
+        pr_url = "https://api.github.com/repos/org/repo/pulls/42"
+        respx.get(pr_url).mock(
+            return_value=httpx.Response(
+                200,
+                json={"state": "open", "mergeable": True},
+            )
+        )
+
+        status = await adapter.get_pr_status(pr_url)
+
+        assert status.pr_id == pr_url
+        assert status.state == "open"
+        assert status.mergeable is True
+        assert status.ci_passed is None
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_raises_on_error(self, adapter: GitHubGitAdapter):
+        pr_url = "https://api.github.com/repos/org/repo/pulls/999"
+        respx.get(pr_url).mock(return_value=httpx.Response(404, text="not found"))
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await adapter.get_pr_status(pr_url)

--- a/tests/test_tyr/test_models.py
+++ b/tests/test_tyr/test_models.py
@@ -71,9 +71,10 @@ class TestConfidenceEventType:
         assert ConfidenceEventType.SCOPE_BREACH == "scope_breach"
         assert ConfidenceEventType.RETRY == "retry"
         assert ConfidenceEventType.HUMAN_REJECT == "human_reject"
+        assert ConfidenceEventType.HUMAN_APPROVED == "human_approved"
 
     def test_member_count(self) -> None:
-        assert len(ConfidenceEventType) == 5
+        assert len(ConfidenceEventType) == 6
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tyr/test_ports.py
+++ b/tests/test_tyr/test_ports.py
@@ -50,6 +50,8 @@ class TestVolundrPort:
             "spawn_session",
             "get_session",
             "list_sessions",
+            "get_pr_status",
+            "get_chronicle_summary",
         }
         abstract_methods = {
             name
@@ -80,7 +82,7 @@ class TestGitPort:
             GitPort()  # type: ignore[abstract]
 
     def test_methods_exist(self) -> None:
-        methods = {"create_branch", "merge_branch", "create_pr", "get_pr_status"}
+        methods = {"create_branch", "merge_branch", "delete_branch", "create_pr", "get_pr_status"}
         abstract_methods = {
             name
             for name, _ in inspect.getmembers(GitPort, predicate=inspect.isfunction)

--- a/tests/test_tyr/test_postgres_raids.py
+++ b/tests/test_tyr/test_postgres_raids.py
@@ -1,0 +1,286 @@
+"""Tests for PostgresRaidRepository with mocked asyncpg."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from tyr.adapters.postgres_raids import PostgresRaidRepository
+from tyr.domain.models import (
+    ConfidenceEvent,
+    ConfidenceEventType,
+    RaidStatus,
+)
+
+
+@pytest.fixture
+def pool() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def repo(pool: MagicMock) -> PostgresRaidRepository:
+    return PostgresRaidRepository(pool)
+
+
+# ---------------------------------------------------------------------------
+# get_raid
+# ---------------------------------------------------------------------------
+
+
+class TestGetRaid:
+    @pytest.mark.asyncio
+    async def test_found(self, repo: PostgresRaidRepository, pool: MagicMock):
+        now = datetime.now(UTC)
+        raid_id = uuid4()
+        pool.fetchrow = AsyncMock(
+            return_value={
+                "id": raid_id,
+                "phase_id": uuid4(),
+                "tracker_id": "TRK-1",
+                "name": "Raid 1",
+                "description": "Do a thing",
+                "acceptance_criteria": ["works"],
+                "declared_files": ["main.py"],
+                "estimate_hours": 2.0,
+                "status": "REVIEW",
+                "confidence": 0.7,
+                "session_id": "ses-1",
+                "branch": "raid/1",
+                "chronicle_summary": "summary",
+                "retry_count": 0,
+                "created_at": now,
+                "updated_at": now,
+            }
+        )
+
+        raid = await repo.get_raid(raid_id)
+        assert raid is not None
+        assert raid.id == raid_id
+        assert raid.name == "Raid 1"
+        assert raid.status == RaidStatus.REVIEW
+
+    @pytest.mark.asyncio
+    async def test_not_found(self, repo: PostgresRaidRepository, pool: MagicMock):
+        pool.fetchrow = AsyncMock(return_value=None)
+
+        raid = await repo.get_raid(uuid4())
+        assert raid is None
+
+
+# ---------------------------------------------------------------------------
+# update_raid_status
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateRaidStatus:
+    @pytest.mark.asyncio
+    async def test_updates_status(self, repo: PostgresRaidRepository, pool: MagicMock):
+        now = datetime.now(UTC)
+        raid_id = uuid4()
+        pool.fetchrow = AsyncMock(
+            return_value={
+                "id": raid_id,
+                "phase_id": uuid4(),
+                "tracker_id": "TRK-1",
+                "name": "Raid 1",
+                "description": "",
+                "acceptance_criteria": [],
+                "declared_files": [],
+                "estimate_hours": None,
+                "status": "MERGED",
+                "confidence": 0.8,
+                "session_id": None,
+                "branch": None,
+                "chronicle_summary": None,
+                "retry_count": 0,
+                "created_at": now,
+                "updated_at": now,
+            }
+        )
+
+        updated = await repo.update_raid_status(raid_id, RaidStatus.MERGED)
+        assert updated is not None
+        assert updated.status == RaidStatus.MERGED
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_missing(
+        self, repo: PostgresRaidRepository, pool: MagicMock
+    ):
+        pool.fetchrow = AsyncMock(return_value=None)
+
+        result = await repo.update_raid_status(uuid4(), RaidStatus.FAILED)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_increment_retry(
+        self, repo: PostgresRaidRepository, pool: MagicMock
+    ):
+        now = datetime.now(UTC)
+        raid_id = uuid4()
+        pool.fetchrow = AsyncMock(
+            return_value={
+                "id": raid_id,
+                "phase_id": uuid4(),
+                "tracker_id": "TRK-1",
+                "name": "Raid 1",
+                "description": "",
+                "acceptance_criteria": [],
+                "declared_files": [],
+                "estimate_hours": None,
+                "status": "PENDING",
+                "confidence": 0.5,
+                "session_id": None,
+                "branch": None,
+                "chronicle_summary": None,
+                "retry_count": 2,
+                "created_at": now,
+                "updated_at": now,
+            }
+        )
+
+        updated = await repo.update_raid_status(
+            raid_id, RaidStatus.PENDING, increment_retry=True
+        )
+        assert updated is not None
+        assert updated.retry_count == 2
+        # Verify SQL uses retry_count + 1
+        call_args = pool.fetchrow.call_args
+        assert "retry_count + 1" in call_args[0][0]
+
+
+# ---------------------------------------------------------------------------
+# add_confidence_event
+# ---------------------------------------------------------------------------
+
+
+class TestAddConfidenceEvent:
+    @pytest.mark.asyncio
+    async def test_inserts_event_and_updates_raid(
+        self, repo: PostgresRaidRepository, pool: MagicMock
+    ):
+        pool.execute = AsyncMock()
+        event = ConfidenceEvent(
+            id=uuid4(),
+            raid_id=uuid4(),
+            event_type=ConfidenceEventType.HUMAN_APPROVED,
+            delta=0.15,
+            score_after=0.65,
+            created_at=datetime.now(UTC),
+        )
+
+        await repo.add_confidence_event(event)
+
+        assert pool.execute.call_count == 2
+        # First call inserts the event
+        first_sql = pool.execute.call_args_list[0][0][0]
+        assert "INSERT INTO confidence_events" in first_sql
+        # Second call updates the raid confidence
+        second_sql = pool.execute.call_args_list[1][0][0]
+        assert "UPDATE raids SET confidence" in second_sql
+
+
+# ---------------------------------------------------------------------------
+# get_confidence_events
+# ---------------------------------------------------------------------------
+
+
+class TestGetConfidenceEvents:
+    @pytest.mark.asyncio
+    async def test_returns_events(
+        self, repo: PostgresRaidRepository, pool: MagicMock
+    ):
+        now = datetime.now(UTC)
+        pool.fetch = AsyncMock(
+            return_value=[
+                {
+                    "id": uuid4(),
+                    "raid_id": uuid4(),
+                    "event_type": "ci_pass",
+                    "delta": 0.1,
+                    "score_after": 0.6,
+                    "created_at": now,
+                }
+            ]
+        )
+
+        events = await repo.get_confidence_events(uuid4())
+        assert len(events) == 1
+        assert events[0].event_type == ConfidenceEventType.CI_PASS
+
+
+# ---------------------------------------------------------------------------
+# get_saga_for_raid / get_phase_for_raid / all_raids_merged
+# ---------------------------------------------------------------------------
+
+
+class TestRelationshipQueries:
+    @pytest.mark.asyncio
+    async def test_get_saga_found(
+        self, repo: PostgresRaidRepository, pool: MagicMock
+    ):
+        now = datetime.now(UTC)
+        pool.fetchrow = AsyncMock(
+            return_value={
+                "id": uuid4(),
+                "tracker_id": "proj-1",
+                "tracker_type": "linear",
+                "slug": "alpha",
+                "name": "Alpha",
+                "repos": ["org/repo"],
+                "feature_branch": "feat/alpha",
+                "status": "ACTIVE",
+                "confidence": 0.5,
+                "created_at": now,
+                "owner_id": "user-1",
+            }
+        )
+
+        saga = await repo.get_saga_for_raid(uuid4())
+        assert saga is not None
+        assert saga.name == "Alpha"
+        assert saga.feature_branch == "feat/alpha"
+
+    @pytest.mark.asyncio
+    async def test_get_saga_not_found(
+        self, repo: PostgresRaidRepository, pool: MagicMock
+    ):
+        pool.fetchrow = AsyncMock(return_value=None)
+        assert await repo.get_saga_for_raid(uuid4()) is None
+
+    @pytest.mark.asyncio
+    async def test_get_phase_found(
+        self, repo: PostgresRaidRepository, pool: MagicMock
+    ):
+        pool.fetchrow = AsyncMock(
+            return_value={
+                "id": uuid4(),
+                "saga_id": uuid4(),
+                "tracker_id": "phase-1",
+                "number": 1,
+                "name": "Phase 1",
+                "status": "ACTIVE",
+                "confidence": 0.5,
+            }
+        )
+
+        phase = await repo.get_phase_for_raid(uuid4())
+        assert phase is not None
+        assert phase.name == "Phase 1"
+
+    @pytest.mark.asyncio
+    async def test_all_raids_merged_true(
+        self, repo: PostgresRaidRepository, pool: MagicMock
+    ):
+        pool.fetchrow = AsyncMock(return_value={"remaining": 0})
+        assert await repo.all_raids_merged(uuid4()) is True
+
+    @pytest.mark.asyncio
+    async def test_all_raids_merged_false(
+        self, repo: PostgresRaidRepository, pool: MagicMock
+    ):
+        pool.fetchrow = AsyncMock(return_value={"remaining": 2})
+        assert await repo.all_raids_merged(uuid4()) is False

--- a/tests/test_tyr/test_raids_api.py
+++ b/tests/test_tyr/test_raids_api.py
@@ -1,0 +1,633 @@
+"""Tests for raid review REST API endpoints."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tyr.api.raids import (
+    create_raids_router,
+    resolve_git,
+    resolve_raid_repo,
+    resolve_tracker,
+    resolve_volundr,
+)
+from tyr.config import ReviewConfig
+from tyr.domain.models import (
+    ConfidenceEvent,
+    ConfidenceEventType,
+    Phase,
+    PhaseStatus,
+    PRStatus,
+    Raid,
+    RaidStatus,
+    Saga,
+    SagaStatus,
+)
+from tyr.ports.git import GitPort
+from tyr.ports.raid_repository import RaidRepository
+from tyr.ports.volundr import SpawnRequest, VolundrPort, VolundrSession
+
+from .test_tracker_api import MockTracker
+
+# ---------------------------------------------------------------------------
+# Default config for tests
+# ---------------------------------------------------------------------------
+
+REVIEW_CFG = ReviewConfig()
+
+# ---------------------------------------------------------------------------
+# Mock implementations
+# ---------------------------------------------------------------------------
+
+PHASE_ID = uuid4()
+SAGA_ID = uuid4()
+
+
+class MockRaidRepository(RaidRepository):
+    """In-memory raid repository for tests."""
+
+    def __init__(self) -> None:
+        self.raids: dict[UUID, Raid] = {}
+        self.events: dict[UUID, list[ConfidenceEvent]] = {}
+        self.saga: Saga | None = None
+        self.phase: Phase | None = None
+        self._all_merged: bool = False
+
+    async def get_raid(self, raid_id: UUID) -> Raid | None:
+        return self.raids.get(raid_id)
+
+    async def update_raid_status(
+        self,
+        raid_id: UUID,
+        status: RaidStatus,
+        *,
+        reason: str | None = None,
+        increment_retry: bool = False,
+    ) -> Raid | None:
+        raid = self.raids.get(raid_id)
+        if raid is None:
+            return None
+        retry_count = raid.retry_count + 1 if increment_retry else raid.retry_count
+        # Get latest confidence from events
+        events = self.events.get(raid_id, [])
+        confidence = events[-1].score_after if events else raid.confidence
+        updated = Raid(
+            id=raid.id,
+            phase_id=raid.phase_id,
+            tracker_id=raid.tracker_id,
+            name=raid.name,
+            description=raid.description,
+            acceptance_criteria=raid.acceptance_criteria,
+            declared_files=raid.declared_files,
+            estimate_hours=raid.estimate_hours,
+            status=status,
+            confidence=confidence,
+            session_id=raid.session_id,
+            branch=raid.branch,
+            chronicle_summary=raid.chronicle_summary,
+            retry_count=retry_count,
+            created_at=raid.created_at,
+            updated_at=datetime.now(UTC),
+        )
+        self.raids[raid_id] = updated
+        return updated
+
+    async def get_confidence_events(self, raid_id: UUID) -> list[ConfidenceEvent]:
+        return self.events.get(raid_id, [])
+
+    async def add_confidence_event(self, event: ConfidenceEvent) -> None:
+        self.events.setdefault(event.raid_id, []).append(event)
+
+    async def get_saga_for_raid(self, raid_id: UUID) -> Saga | None:
+        return self.saga
+
+    async def get_phase_for_raid(self, raid_id: UUID) -> Phase | None:
+        return self.phase
+
+    async def all_raids_merged(self, phase_id: UUID) -> bool:
+        return self._all_merged
+
+
+class MockVolundr(VolundrPort):
+    """In-memory mock for Volundr port."""
+
+    def __init__(self) -> None:
+        self.pr_status = PRStatus(
+            pr_id="https://github.com/org/repo/pull/42",
+            state="open",
+            mergeable=True,
+            ci_passed=True,
+        )
+        self.chronicle = "Everything looks good"
+        self.fail_pr_status = False
+
+    async def spawn_session(
+        self,
+        request: SpawnRequest,
+        *,
+        auth_token: str | None = None,
+    ) -> VolundrSession:
+        return VolundrSession(
+            id="session-1",
+            name=request.name,
+            status="running",
+            tracker_issue_id=request.tracker_issue_id,
+        )
+
+    async def get_session(
+        self,
+        session_id: str,
+        *,
+        auth_token: str | None = None,
+    ) -> VolundrSession | None:
+        return VolundrSession(
+            id=session_id, name="test", status="completed", tracker_issue_id=None
+        )
+
+    async def list_sessions(
+        self,
+        *,
+        auth_token: str | None = None,
+    ) -> list[VolundrSession]:
+        return []
+
+    async def get_chronicle_summary(self, session_id: str) -> str:
+        return self.chronicle
+
+    async def get_pr_status(self, session_id: str) -> PRStatus:
+        if self.fail_pr_status:
+            raise ConnectionError("Volundr unreachable")
+        return self.pr_status
+
+
+class MockGit(GitPort):
+    """In-memory mock for Git port."""
+
+    def __init__(self) -> None:
+        self.merged: list[tuple[str, str, str]] = []
+        self.deleted: list[tuple[str, str]] = []
+        self.fail_merge = False
+
+    async def create_branch(self, repo: str, branch: str, base: str) -> None:
+        pass
+
+    async def merge_branch(self, repo: str, source: str, target: str) -> None:
+        if self.fail_merge:
+            raise RuntimeError("Merge conflict")
+        self.merged.append((repo, source, target))
+
+    async def delete_branch(self, repo: str, branch: str) -> None:
+        self.deleted.append((repo, branch))
+
+    async def create_pr(
+        self, repo: str, source: str, target: str, title: str
+    ) -> str:
+        return "pr-1"
+
+    async def get_pr_status(self, pr_id: str) -> PRStatus:
+        return PRStatus(pr_id=pr_id, state="open", mergeable=True, ci_passed=True)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_raid(
+    raid_id: UUID | None = None,
+    status: RaidStatus = RaidStatus.REVIEW,
+    confidence: float = 0.5,
+    session_id: str | None = "session-1",
+    branch: str | None = "raid/test-branch",
+) -> Raid:
+    now = datetime.now(UTC)
+    return Raid(
+        id=raid_id or uuid4(),
+        phase_id=PHASE_ID,
+        tracker_id="tracker-1",
+        name="Test raid",
+        description="A test raid",
+        acceptance_criteria=["it works"],
+        declared_files=["src/main.py"],
+        estimate_hours=2.0,
+        status=status,
+        confidence=confidence,
+        session_id=session_id,
+        branch=branch,
+        chronicle_summary="All tests pass, code looks clean",
+        retry_count=0,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _make_saga() -> Saga:
+    return Saga(
+        id=SAGA_ID,
+        tracker_id="proj-1",
+        tracker_type="mock",
+        slug="alpha",
+        name="Alpha",
+        repos=["org/repo"],
+        feature_branch="feat/alpha",
+        status=SagaStatus.ACTIVE,
+        confidence=0.0,
+        created_at=datetime.now(UTC),
+    )
+
+
+def _make_phase() -> Phase:
+    return Phase(
+        id=PHASE_ID,
+        saga_id=SAGA_ID,
+        tracker_id="phase-1",
+        number=1,
+        name="Phase 1",
+        status=PhaseStatus.ACTIVE,
+        confidence=0.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def raid_repo() -> MockRaidRepository:
+    repo = MockRaidRepository()
+    repo.saga = _make_saga()
+    repo.phase = _make_phase()
+    return repo
+
+
+@pytest.fixture
+def volundr() -> MockVolundr:
+    return MockVolundr()
+
+
+@pytest.fixture
+def git() -> MockGit:
+    return MockGit()
+
+
+@pytest.fixture
+def tracker() -> MockTracker:
+    return MockTracker()
+
+
+@pytest.fixture
+def client(
+    raid_repo: MockRaidRepository,
+    volundr: MockVolundr,
+    git: MockGit,
+    tracker: MockTracker,
+) -> TestClient:
+    app = FastAPI()
+    app.include_router(create_raids_router())
+    app.dependency_overrides[resolve_raid_repo] = lambda: raid_repo
+    app.dependency_overrides[resolve_volundr] = lambda: volundr
+    app.dependency_overrides[resolve_git] = lambda: git
+    app.dependency_overrides[resolve_tracker] = lambda: tracker
+
+    # Provide settings with ReviewConfig on app.state so _get_review_config works
+    from types import SimpleNamespace
+
+    app.state.settings = SimpleNamespace(review=REVIEW_CFG)
+
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# GET /raids/{id}/review
+# ---------------------------------------------------------------------------
+
+
+class TestGetReview:
+    def test_returns_review_state(
+        self, client: TestClient, raid_repo: MockRaidRepository, volundr: MockVolundr
+    ):
+        raid = _make_raid()
+        raid_repo.raids[raid.id] = raid
+
+        resp = client.get(f"/api/v1/tyr/raids/{raid.id}/review")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["raid_id"] == str(raid.id)
+        assert data["name"] == "Test raid"
+        assert data["status"] == "REVIEW"
+        assert data["chronicle_summary"] == "All tests pass, code looks clean"
+        assert data["pr_url"] == "https://github.com/org/repo/pull/42"
+        assert data["ci_passed"] is True
+        assert data["confidence"] == 0.5
+        assert data["confidence_events"] == []
+
+    def test_includes_confidence_events(
+        self, client: TestClient, raid_repo: MockRaidRepository
+    ):
+        raid = _make_raid()
+        raid_repo.raids[raid.id] = raid
+        event = ConfidenceEvent(
+            id=uuid4(),
+            raid_id=raid.id,
+            event_type=ConfidenceEventType.CI_PASS,
+            delta=0.1,
+            score_after=0.6,
+            created_at=datetime.now(UTC),
+        )
+        raid_repo.events[raid.id] = [event]
+
+        resp = client.get(f"/api/v1/tyr/raids/{raid.id}/review")
+        data = resp.json()
+        assert len(data["confidence_events"]) == 1
+        assert data["confidence_events"][0]["event_type"] == "ci_pass"
+        assert data["confidence_events"][0]["delta"] == 0.1
+
+    def test_not_found(self, client: TestClient):
+        resp = client.get(f"/api/v1/tyr/raids/{uuid4()}/review")
+        assert resp.status_code == 404
+
+    def test_no_session_id(self, client: TestClient, raid_repo: MockRaidRepository):
+        raid = _make_raid(session_id=None)
+        raid_repo.raids[raid.id] = raid
+
+        resp = client.get(f"/api/v1/tyr/raids/{raid.id}/review")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["pr_url"] is None
+        assert data["ci_passed"] is None
+
+    def test_volundr_unreachable(
+        self,
+        client: TestClient,
+        raid_repo: MockRaidRepository,
+        volundr: MockVolundr,
+    ):
+        raid = _make_raid()
+        raid_repo.raids[raid.id] = raid
+        volundr.fail_pr_status = True
+
+        resp = client.get(f"/api/v1/tyr/raids/{raid.id}/review")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["pr_url"] is None
+        assert data["ci_passed"] is None
+
+
+# ---------------------------------------------------------------------------
+# POST /raids/{id}/approve
+# ---------------------------------------------------------------------------
+
+
+class TestApproveRaid:
+    def test_approve_success(
+        self,
+        client: TestClient,
+        raid_repo: MockRaidRepository,
+        git: MockGit,
+    ):
+        raid = _make_raid()
+        raid_repo.raids[raid.id] = raid
+
+        resp = client.post(f"/api/v1/tyr/raids/{raid.id}/approve")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "MERGED"
+        assert data["id"] == str(raid.id)
+
+        # Verify branch was merged and deleted
+        assert len(git.merged) == 1
+        assert git.merged[0] == ("org/repo", "raid/test-branch", "feat/alpha")
+        assert len(git.deleted) == 1
+        assert git.deleted[0] == ("org/repo", "raid/test-branch")
+
+        # Verify confidence event was added
+        events = raid_repo.events[raid.id]
+        assert len(events) == 1
+        assert events[0].event_type == ConfidenceEventType.HUMAN_APPROVED
+        assert events[0].delta == REVIEW_CFG.confidence_delta_approved
+
+    def test_approve_not_found(self, client: TestClient):
+        resp = client.post(f"/api/v1/tyr/raids/{uuid4()}/approve")
+        assert resp.status_code == 404
+
+    def test_approve_wrong_state(
+        self, client: TestClient, raid_repo: MockRaidRepository
+    ):
+        raid = _make_raid(status=RaidStatus.PENDING)
+        raid_repo.raids[raid.id] = raid
+
+        resp = client.post(f"/api/v1/tyr/raids/{raid.id}/approve")
+        assert resp.status_code == 409
+
+    def test_approve_no_saga(
+        self, client: TestClient, raid_repo: MockRaidRepository
+    ):
+        raid = _make_raid()
+        raid_repo.raids[raid.id] = raid
+        raid_repo.saga = None
+
+        resp = client.post(f"/api/v1/tyr/raids/{raid.id}/approve")
+        assert resp.status_code == 404
+        assert "saga" in resp.json()["detail"].lower()
+
+    def test_approve_merge_failure(
+        self, client: TestClient, raid_repo: MockRaidRepository, git: MockGit
+    ):
+        raid = _make_raid()
+        raid_repo.raids[raid.id] = raid
+        git.fail_merge = True
+
+        resp = client.post(f"/api/v1/tyr/raids/{raid.id}/approve")
+        assert resp.status_code == 502
+        assert "merge" in resp.json()["detail"].lower()
+
+    def test_approve_no_branch(
+        self, client: TestClient, raid_repo: MockRaidRepository, git: MockGit
+    ):
+        raid = _make_raid(branch=None)
+        raid_repo.raids[raid.id] = raid
+
+        resp = client.post(f"/api/v1/tyr/raids/{raid.id}/approve")
+        assert resp.status_code == 200
+        # No merge/delete attempted
+        assert len(git.merged) == 0
+        assert len(git.deleted) == 0
+
+    def test_approve_phase_gate_check(
+        self,
+        client: TestClient,
+        raid_repo: MockRaidRepository,
+    ):
+        raid = _make_raid()
+        raid_repo.raids[raid.id] = raid
+        raid_repo._all_merged = True
+
+        resp = client.post(f"/api/v1/tyr/raids/{raid.id}/approve")
+        assert resp.status_code == 200
+
+    def test_approve_ci_failing_still_succeeds(
+        self,
+        client: TestClient,
+        raid_repo: MockRaidRepository,
+        volundr: MockVolundr,
+    ):
+        raid = _make_raid()
+        raid_repo.raids[raid.id] = raid
+        volundr.pr_status = PRStatus(
+            pr_id="pr-1",
+            state="open",
+            mergeable=True,
+            ci_passed=False,
+        )
+
+        resp = client.post(f"/api/v1/tyr/raids/{raid.id}/approve")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "MERGED"
+
+
+# ---------------------------------------------------------------------------
+# POST /raids/{id}/reject
+# ---------------------------------------------------------------------------
+
+
+class TestRejectRaid:
+    def test_reject_success(
+        self, client: TestClient, raid_repo: MockRaidRepository
+    ):
+        raid = _make_raid()
+        raid_repo.raids[raid.id] = raid
+
+        resp = client.post(f"/api/v1/tyr/raids/{raid.id}/reject")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "FAILED"
+        assert data["reason"] is None
+
+        events = raid_repo.events[raid.id]
+        assert len(events) == 1
+        assert events[0].event_type == ConfidenceEventType.HUMAN_REJECT
+        assert events[0].delta == REVIEW_CFG.confidence_delta_rejected
+
+    def test_reject_with_reason(
+        self, client: TestClient, raid_repo: MockRaidRepository
+    ):
+        raid = _make_raid()
+        raid_repo.raids[raid.id] = raid
+
+        resp = client.post(
+            f"/api/v1/tyr/raids/{raid.id}/reject",
+            json={"reason": "Code quality too low"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "FAILED"
+        assert data["reason"] == "Code quality too low"
+
+    def test_reject_not_found(self, client: TestClient):
+        resp = client.post(f"/api/v1/tyr/raids/{uuid4()}/reject")
+        assert resp.status_code == 404
+
+    def test_reject_wrong_state(
+        self, client: TestClient, raid_repo: MockRaidRepository
+    ):
+        raid = _make_raid(status=RaidStatus.MERGED)
+        raid_repo.raids[raid.id] = raid
+
+        resp = client.post(f"/api/v1/tyr/raids/{raid.id}/reject")
+        assert resp.status_code == 409
+
+    def test_reject_confidence_clamped_at_zero(
+        self, client: TestClient, raid_repo: MockRaidRepository
+    ):
+        raid = _make_raid(confidence=0.05)
+        raid_repo.raids[raid.id] = raid
+
+        resp = client.post(f"/api/v1/tyr/raids/{raid.id}/reject")
+        assert resp.status_code == 200
+        events = raid_repo.events[raid.id]
+        assert events[0].score_after == 0.0
+
+
+# ---------------------------------------------------------------------------
+# POST /raids/{id}/retry
+# ---------------------------------------------------------------------------
+
+
+class TestRetryRaid:
+    def test_retry_success(
+        self, client: TestClient, raid_repo: MockRaidRepository
+    ):
+        raid = _make_raid()
+        raid_repo.raids[raid.id] = raid
+
+        resp = client.post(f"/api/v1/tyr/raids/{raid.id}/retry")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "PENDING"
+        assert data["retry_count"] == 1
+
+        events = raid_repo.events[raid.id]
+        assert len(events) == 1
+        assert events[0].event_type == ConfidenceEventType.RETRY
+        assert events[0].delta == REVIEW_CFG.confidence_delta_retry
+
+    def test_retry_not_found(self, client: TestClient):
+        resp = client.post(f"/api/v1/tyr/raids/{uuid4()}/retry")
+        assert resp.status_code == 404
+
+    def test_retry_wrong_state(
+        self, client: TestClient, raid_repo: MockRaidRepository
+    ):
+        raid = _make_raid(status=RaidStatus.MERGED)
+        raid_repo.raids[raid.id] = raid
+
+        resp = client.post(f"/api/v1/tyr/raids/{raid.id}/retry")
+        assert resp.status_code == 409
+
+    def test_retry_from_review_state(
+        self, client: TestClient, raid_repo: MockRaidRepository
+    ):
+        """Retry from REVIEW state resets to PENDING."""
+        raid = _make_raid(status=RaidStatus.REVIEW)
+        raid_repo.raids[raid.id] = raid
+
+        resp = client.post(f"/api/v1/tyr/raids/{raid.id}/retry")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "PENDING"
+
+    def test_retry_increments_count(
+        self, client: TestClient, raid_repo: MockRaidRepository
+    ):
+        raid = _make_raid()
+        raid_repo.raids[raid.id] = raid
+
+        client.post(f"/api/v1/tyr/raids/{raid.id}/retry")
+        # Now the raid is PENDING, set it back to REVIEW to retry again
+        raid_repo.raids[raid.id] = Raid(
+            id=raid.id,
+            phase_id=raid.phase_id,
+            tracker_id=raid.tracker_id,
+            name=raid.name,
+            description=raid.description,
+            acceptance_criteria=raid.acceptance_criteria,
+            declared_files=raid.declared_files,
+            estimate_hours=raid.estimate_hours,
+            status=RaidStatus.REVIEW,
+            confidence=raid.confidence,
+            session_id=raid.session_id,
+            branch=raid.branch,
+            chronicle_summary=raid.chronicle_summary,
+            retry_count=1,
+            created_at=raid.created_at,
+            updated_at=datetime.now(UTC),
+        )
+
+        resp = client.post(f"/api/v1/tyr/raids/{raid.id}/retry")
+        assert resp.status_code == 200
+        assert resp.json()["retry_count"] == 2

--- a/tests/test_tyr/test_volundr_http.py
+++ b/tests/test_tyr/test_volundr_http.py
@@ -299,6 +299,99 @@ class TestListSessions:
 
 
 # -------------------------------------------------------------------
+# get_pr_status
+# -------------------------------------------------------------------
+
+
+class TestGetPRStatus:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_success(self, adapter: VolundrHTTPAdapter):
+        respx.get(f"{SESSIONS_URL}/ses-1/pr").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "pr_id": "https://github.com/org/repo/pull/42",
+                    "state": "open",
+                    "mergeable": True,
+                    "ci_passed": True,
+                },
+            )
+        )
+
+        pr_status = await adapter.get_pr_status("ses-1")
+        assert pr_status.pr_id == "https://github.com/org/repo/pull/42"
+        assert pr_status.state == "open"
+        assert pr_status.mergeable is True
+        assert pr_status.ci_passed is True
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_ci_passed_none(self, adapter: VolundrHTTPAdapter):
+        respx.get(f"{SESSIONS_URL}/ses-1/pr").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "pr_id": "pr-1",
+                    "state": "open",
+                    "mergeable": False,
+                },
+            )
+        )
+
+        pr_status = await adapter.get_pr_status("ses-1")
+        assert pr_status.ci_passed is None
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_raises_on_error(self, adapter: VolundrHTTPAdapter):
+        respx.get(f"{SESSIONS_URL}/ses-1/pr").mock(return_value=httpx.Response(500, text="error"))
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await adapter.get_pr_status("ses-1")
+
+
+# -------------------------------------------------------------------
+# get_chronicle_summary
+# -------------------------------------------------------------------
+
+
+class TestGetChronicleSummary:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_success(self, adapter: VolundrHTTPAdapter):
+        respx.get(f"{SESSIONS_URL}/ses-1/chronicle").mock(
+            return_value=httpx.Response(
+                200,
+                json={"summary": "All tests pass"},
+            )
+        )
+
+        summary = await adapter.get_chronicle_summary("ses-1")
+        assert summary == "All tests pass"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_empty_summary(self, adapter: VolundrHTTPAdapter):
+        respx.get(f"{SESSIONS_URL}/ses-1/chronicle").mock(
+            return_value=httpx.Response(200, json={})
+        )
+
+        summary = await adapter.get_chronicle_summary("ses-1")
+        assert summary == ""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_raises_on_error(self, adapter: VolundrHTTPAdapter):
+        respx.get(f"{SESSIONS_URL}/ses-1/chronicle").mock(
+            return_value=httpx.Response(503, text="unavailable")
+        )
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await adapter.get_chronicle_summary("ses-1")
+
+
+# -------------------------------------------------------------------
 # Constructor
 # -------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Raid review API: `GET /raids/{id}/review`, `POST /raids/{id}/approve|reject|retry`
- `RaidRepository` port and `PostgresRaidRepository` adapter for raid persistence
- `GitHubGitAdapter` implementing `GitPort` with shared httpx client
- Confidence scoring on approve/reject/retry using configurable `ReviewConfig` deltas
- State machine transitions: REVIEW→MERGED (approve), REVIEW→FAILED (reject), REVIEW→PENDING (retry)
- 48 tests across raids API, GitHub git adapter, and PostgreSQL raids repository

Salvaged from closed PR #116, cleaned up and rebased onto feat/tyr.

## Test plan
- [ ] `pytest tests/test_tyr/test_raids_api.py` passes (20 tests)
- [ ] `pytest tests/test_tyr/test_github_git.py` passes (17 tests)
- [ ] `pytest tests/test_tyr/test_postgres_raids.py` passes (11 tests)
- [ ] Approve/reject/retry endpoints update raid status and confidence correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)