### PR TITLE
feat(tyr): session chat interaction — send messages to running sessions

### DIFF
--- a/charts/tyr/templates/migrations-configmap.yaml
+++ b/charts/tyr/templates/migrations-configmap.yaml
@@ -265,4 +265,23 @@ data:
     DROP INDEX IF EXISTS idx_raids_session_id;
     ALTER TABLE raids DROP COLUMN IF EXISTS pr_id;
     ALTER TABLE raids DROP COLUMN IF EXISTS pr_url;
+
+  000015_session_messages.up.sql: |
+    CREATE TABLE IF NOT EXISTS session_messages (
+        id          UUID PRIMARY KEY,
+        raid_id     UUID NOT NULL REFERENCES raids(id),
+        session_id  TEXT NOT NULL,
+        content     TEXT NOT NULL,
+        sender      TEXT NOT NULL DEFAULT 'user',
+        created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_session_messages_raid_id
+        ON session_messages (raid_id);
+
+    CREATE INDEX IF NOT EXISTS idx_session_messages_session_id
+        ON session_messages (session_id);
+
+  000015_session_messages.down.sql: |
+    DROP TABLE IF EXISTS session_messages;
 {{- end }}

--- a/migrations/tyr/000015_session_messages.down.sql
+++ b/migrations/tyr/000015_session_messages.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS session_messages;

--- a/migrations/tyr/000015_session_messages.up.sql
+++ b/migrations/tyr/000015_session_messages.up.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS session_messages (
+    id          UUID PRIMARY KEY,
+    raid_id     UUID NOT NULL REFERENCES raids(id),
+    session_id  TEXT NOT NULL,
+    content     TEXT NOT NULL,
+    sender      TEXT NOT NULL DEFAULT 'user',
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_session_messages_raid_id
+    ON session_messages (raid_id);
+
+CREATE INDEX IF NOT EXISTS idx_session_messages_session_id
+    ON session_messages (session_id);

--- a/src/tyr/adapters/postgres_raids.py
+++ b/src/tyr/adapters/postgres_raids.py
@@ -17,6 +17,7 @@ from tyr.domain.models import (
     RaidStatus,
     Saga,
     SagaStatus,
+    SessionMessage,
 )
 from tyr.ports.raid_repository import RaidRepository
 
@@ -233,6 +234,27 @@ class PostgresRaidRepository(RaidRepository):
         )
         return row is not None and row["remaining"] == 0
 
+    async def save_session_message(self, message: SessionMessage) -> None:
+        await self._pool.execute(
+            """
+            INSERT INTO session_messages (id, raid_id, session_id, content, sender, created_at)
+            VALUES ($1, $2, $3, $4, $5, $6)
+            """,
+            message.id,
+            message.raid_id,
+            message.session_id,
+            message.content,
+            message.sender,
+            message.created_at,
+        )
+
+    async def get_session_messages(self, raid_id: UUID) -> list[SessionMessage]:
+        rows = await self._pool.fetch(
+            "SELECT * FROM session_messages WHERE raid_id = $1 ORDER BY created_at",
+            raid_id,
+        )
+        return [self._row_to_session_message(r) for r in rows]
+
     # -- Row mappers --
 
     @staticmethod
@@ -295,4 +317,15 @@ class PostgresRaidRepository(RaidRepository):
             name=row["name"],
             status=PhaseStatus(row.get("status", "PENDING") or "PENDING"),
             confidence=row.get("confidence", 0.0) or 0.0,
+        )
+
+    @staticmethod
+    def _row_to_session_message(row: asyncpg.Record) -> SessionMessage:
+        return SessionMessage(
+            id=row["id"],
+            raid_id=row["raid_id"],
+            session_id=row["session_id"],
+            content=row["content"],
+            sender=row["sender"],
+            created_at=row["created_at"],
         )

--- a/src/tyr/api/raids.py
+++ b/src/tyr/api/raids.py
@@ -13,19 +13,16 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field
 
 from tyr.config import ReviewConfig
+from tyr.domain.exceptions import RaidNotFoundError
 from tyr.domain.models import RaidStatus
 from tyr.domain.services.raid_review import (
     InvalidRaidStateError,
-    RaidNotFoundError,
     RaidReviewService,
 )
 from tyr.domain.services.session_message import (
     NoActiveSessionError,
     RaidNotRunningError,
     SessionMessageService,
-)
-from tyr.domain.services.session_message import (
-    RaidNotFoundError as MessageRaidNotFoundError,
 )
 from tyr.ports.git import GitPort
 from tyr.ports.raid_repository import RaidRepository
@@ -382,7 +379,7 @@ def create_raids_router() -> APIRouter:
 
         try:
             result = await svc.send_message(raid_id, body.content, sender="user")
-        except MessageRaidNotFoundError:
+        except RaidNotFoundError:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"Raid not found: {raid_id}",

--- a/src/tyr/api/raids.py
+++ b/src/tyr/api/raids.py
@@ -19,6 +19,14 @@ from tyr.domain.services.raid_review import (
     RaidNotFoundError,
     RaidReviewService,
 )
+from tyr.domain.services.session_message import (
+    NoActiveSessionError,
+    RaidNotRunningError,
+    SessionMessageService,
+)
+from tyr.domain.services.session_message import (
+    RaidNotFoundError as MessageRaidNotFoundError,
+)
 from tyr.ports.git import GitPort
 from tyr.ports.raid_repository import RaidRepository
 from tyr.ports.tracker import TrackerPort
@@ -63,6 +71,27 @@ class RaidResponse(BaseModel):
 
 class RejectRequest(BaseModel):
     reason: str | None = None
+
+
+class SendMessageRequest(BaseModel):
+    content: str = Field(..., min_length=1, max_length=32768)
+
+
+class SendMessageResponse(BaseModel):
+    message_id: str
+    raid_id: str
+    session_id: str
+    content: str
+    sender: str
+    created_at: str
+
+
+class SessionMessageResponse(BaseModel):
+    id: str
+    session_id: str
+    content: str
+    sender: str
+    created_at: str
 
 
 # ---------------------------------------------------------------------------
@@ -338,5 +367,69 @@ def create_raids_router() -> APIRouter:
             logger.warning("Failed to update tracker for raid %s", raid_id, exc_info=True)
 
         return _raid_response(result.raid)
+
+    @router.post("/{raid_id}/message", response_model=SendMessageResponse)
+    async def send_message(
+        raid_id: UUID,
+        body: SendMessageRequest,
+        request: Request,
+        raid_repo: RaidRepository = Depends(resolve_raid_repo),
+        volundr: VolundrPort = Depends(resolve_volundr),
+    ) -> SendMessageResponse:
+        """Send a message to the running session for a raid."""
+        event_bus = getattr(request.app.state, "event_bus", None)
+        svc = SessionMessageService(raid_repo, volundr, event_bus=event_bus)
+
+        try:
+            result = await svc.send_message(raid_id, body.content, sender="user")
+        except MessageRaidNotFoundError:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Raid not found: {raid_id}",
+            )
+        except RaidNotRunningError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"Raid is in {exc.status} state, not running",
+            )
+        except NoActiveSessionError:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Raid has no active session",
+            )
+
+        return SendMessageResponse(
+            message_id=str(result.message.id),
+            raid_id=str(result.raid_id),
+            session_id=result.session_id,
+            content=result.message.content,
+            sender=result.message.sender,
+            created_at=result.message.created_at.isoformat(),
+        )
+
+    @router.get("/{raid_id}/messages", response_model=list[SessionMessageResponse])
+    async def list_messages(
+        raid_id: UUID,
+        raid_repo: RaidRepository = Depends(resolve_raid_repo),
+    ) -> list[SessionMessageResponse]:
+        """List all messages sent to a raid's session (audit trail)."""
+        raid = await raid_repo.get_raid(raid_id)
+        if raid is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Raid not found: {raid_id}",
+            )
+
+        messages = await raid_repo.get_session_messages(raid_id)
+        return [
+            SessionMessageResponse(
+                id=str(m.id),
+                session_id=m.session_id,
+                content=m.content,
+                sender=m.sender,
+                created_at=m.created_at.isoformat(),
+            )
+            for m in messages
+        ]
 
     return router

--- a/src/tyr/domain/exceptions.py
+++ b/src/tyr/domain/exceptions.py
@@ -1,5 +1,9 @@
 """Domain exceptions for the Tyr saga coordinator."""
 
+from __future__ import annotations
+
+from uuid import UUID
+
 
 class InvalidStateTransitionError(Exception):
     """Raised when an invalid state transition is attempted on a Raid."""
@@ -8,3 +12,11 @@ class InvalidStateTransitionError(Exception):
         self.current = current
         self.target = target
         super().__init__(f"Invalid state transition: {current} -> {target}")
+
+
+class RaidNotFoundError(Exception):
+    """Raised when a raid cannot be found by ID."""
+
+    def __init__(self, raid_id: UUID | str) -> None:
+        self.raid_id = raid_id
+        super().__init__(f"Raid not found: {raid_id}")

--- a/src/tyr/domain/models.py
+++ b/src/tyr/domain/models.py
@@ -43,6 +43,7 @@ class ConfidenceEventType(StrEnum):
     RETRY = "retry"
     HUMAN_REJECT = "human_reject"
     HUMAN_APPROVED = "human_approved"
+    MESSAGE_SENT = "message_sent"
 
 
 # ---------------------------------------------------------------------------
@@ -134,6 +135,18 @@ class ConfidenceEvent:
     event_type: ConfidenceEventType
     delta: float
     score_after: float
+    created_at: datetime
+
+
+@dataclass(frozen=True)
+class SessionMessage:
+    """A message sent to a running Volundr session (audit record)."""
+
+    id: UUID
+    raid_id: UUID
+    session_id: str
+    content: str
+    sender: str
     created_at: datetime
 
 

--- a/src/tyr/domain/services/raid_review.py
+++ b/src/tyr/domain/services/raid_review.py
@@ -13,7 +13,7 @@ from datetime import UTC, datetime
 from uuid import UUID, uuid4
 
 from tyr.config import ReviewConfig
-from tyr.domain.exceptions import InvalidStateTransitionError
+from tyr.domain.exceptions import InvalidStateTransitionError, RaidNotFoundError
 from tyr.domain.models import (
     ConfidenceEvent,
     ConfidenceEventType,
@@ -39,12 +39,6 @@ class ReviewResult:
     raid: Raid
     reason: str | None = None
     phase_gate_unlocked: bool = False
-
-
-class RaidNotFoundError(Exception):
-    def __init__(self, raid_id: UUID | str) -> None:
-        self.raid_id = raid_id
-        super().__init__(f"Raid not found: {raid_id}")
 
 
 class InvalidRaidStateError(Exception):

--- a/src/tyr/domain/services/session_message.py
+++ b/src/tyr/domain/services/session_message.py
@@ -1,0 +1,149 @@
+"""Service for sending messages to running Volundr sessions.
+
+Handles resolving raid → session, sending via VolundrPort, persisting
+the message for audit, recording a confidence event, and emitting an
+SSE event.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+from tyr.domain.models import (
+    ConfidenceEvent,
+    ConfidenceEventType,
+    RaidStatus,
+    SessionMessage,
+)
+from tyr.events import EventBus, TyrEvent
+from tyr.ports.raid_repository import RaidRepository
+from tyr.ports.volundr import VolundrPort
+
+logger = logging.getLogger(__name__)
+
+RUNNING_STATUSES = frozenset({RaidStatus.RUNNING, RaidStatus.REVIEW})
+
+
+class RaidNotFoundError(Exception):
+    def __init__(self, raid_id: UUID | str) -> None:
+        self.raid_id = raid_id
+        super().__init__(f"Raid not found: {raid_id}")
+
+
+class NoActiveSessionError(Exception):
+    def __init__(self, raid_id: UUID | str) -> None:
+        self.raid_id = raid_id
+        super().__init__(f"Raid {raid_id} has no active session")
+
+
+class RaidNotRunningError(Exception):
+    def __init__(self, raid_id: UUID | str, status: str) -> None:
+        self.raid_id = raid_id
+        self.status = status
+        super().__init__(f"Raid {raid_id} is in {status} state, not running")
+
+
+@dataclass(frozen=True)
+class MessageResult:
+    """Outcome of sending a message to a session."""
+
+    message: SessionMessage
+    raid_id: UUID
+    session_id: str
+
+
+class SessionMessageService:
+    """Sends messages to running sessions and tracks them for audit."""
+
+    def __init__(
+        self,
+        raid_repo: RaidRepository,
+        volundr: VolundrPort,
+        event_bus: EventBus | None = None,
+    ) -> None:
+        self._raid_repo = raid_repo
+        self._volundr = volundr
+        self._event_bus = event_bus
+
+    async def send_message(
+        self,
+        raid_id: UUID,
+        content: str,
+        *,
+        sender: str = "user",
+        auth_token: str | None = None,
+    ) -> MessageResult:
+        """Send a message to the session running a raid.
+
+        1. Resolve raid → session_id
+        2. Send message via VolundrPort
+        3. Persist audit record
+        4. Record confidence event (zero delta)
+        5. Emit SSE event
+        """
+        raid = await self._raid_repo.get_raid(raid_id)
+        if raid is None:
+            raise RaidNotFoundError(raid_id)
+
+        if raid.status not in RUNNING_STATUSES:
+            raise RaidNotRunningError(raid_id, raid.status.value)
+
+        if not raid.session_id:
+            raise NoActiveSessionError(raid_id)
+
+        # Send the message to Volundr
+        await self._volundr.send_message(raid.session_id, content, auth_token=auth_token)
+
+        # Persist audit record
+        now = datetime.now(UTC)
+        msg = SessionMessage(
+            id=uuid4(),
+            raid_id=raid_id,
+            session_id=raid.session_id,
+            content=content,
+            sender=sender,
+            created_at=now,
+        )
+        await self._raid_repo.save_session_message(msg)
+
+        # Record confidence event with zero delta (message doesn't change score)
+        event = ConfidenceEvent(
+            id=uuid4(),
+            raid_id=raid_id,
+            event_type=ConfidenceEventType.MESSAGE_SENT,
+            delta=0.0,
+            score_after=raid.confidence,
+            created_at=now,
+        )
+        await self._raid_repo.add_confidence_event(event)
+
+        # Emit SSE event
+        if self._event_bus:
+            await self._event_bus.emit(
+                TyrEvent(
+                    event="session.message_sent",
+                    data={
+                        "raid_id": str(raid_id),
+                        "session_id": raid.session_id,
+                        "sender": sender,
+                        "content_length": len(content),
+                    },
+                )
+            )
+
+        logger.info(
+            "Message sent to session %s for raid %s (sender=%s, length=%d)",
+            raid.session_id,
+            raid_id,
+            sender,
+            len(content),
+        )
+
+        return MessageResult(
+            message=msg,
+            raid_id=raid_id,
+            session_id=raid.session_id,
+        )

--- a/src/tyr/domain/services/session_message.py
+++ b/src/tyr/domain/services/session_message.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from uuid import UUID, uuid4
 
+from tyr.domain.exceptions import RaidNotFoundError
 from tyr.domain.models import (
     ConfidenceEvent,
     ConfidenceEventType,
@@ -25,12 +26,6 @@ from tyr.ports.volundr import VolundrPort
 logger = logging.getLogger(__name__)
 
 RUNNING_STATUSES = frozenset({RaidStatus.RUNNING, RaidStatus.REVIEW})
-
-
-class RaidNotFoundError(Exception):
-    def __init__(self, raid_id: UUID | str) -> None:
-        self.raid_id = raid_id
-        super().__init__(f"Raid not found: {raid_id}")
 
 
 class NoActiveSessionError(Exception):

--- a/src/tyr/ports/raid_repository.py
+++ b/src/tyr/ports/raid_repository.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from typing import Any
 from uuid import UUID
 
-from tyr.domain.models import ConfidenceEvent, Phase, Raid, RaidStatus, Saga
+from tyr.domain.models import ConfidenceEvent, Phase, Raid, RaidStatus, Saga, SessionMessage
 
 
 class RaidRepository(ABC):
@@ -87,4 +87,14 @@ class RaidRepository(ABC):
     @abstractmethod
     async def all_raids_merged(self, phase_id: UUID) -> bool:
         """Check whether every raid in the phase has status MERGED."""
+        ...
+
+    @abstractmethod
+    async def save_session_message(self, message: SessionMessage) -> None:
+        """Persist a message sent to a running session (audit trail)."""
+        ...
+
+    @abstractmethod
+    async def get_session_messages(self, raid_id: UUID) -> list[SessionMessage]:
+        """Return all messages sent to a raid's session, ordered by created_at."""
         ...

--- a/tests/test_tyr/test_commit_api.py
+++ b/tests/test_tyr/test_commit_api.py
@@ -96,6 +96,12 @@ class MockRaidRepo(RaidRepository):
     async def all_raids_merged(self, phase_id: UUID) -> bool:
         return False
 
+    async def save_session_message(self, message: object) -> None:
+        pass
+
+    async def get_session_messages(self, raid_id: UUID) -> list:
+        return []
+
 
 class MockGit(GitPort):
     """In-memory git adapter for tests."""

--- a/tests/test_tyr/test_models.py
+++ b/tests/test_tyr/test_models.py
@@ -74,7 +74,7 @@ class TestConfidenceEventType:
         assert ConfidenceEventType.HUMAN_APPROVED == "human_approved"
 
     def test_member_count(self) -> None:
-        assert len(ConfidenceEventType) == 6
+        assert len(ConfidenceEventType) == 7
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tyr/test_postgres_raids.py
+++ b/tests/test_tyr/test_postgres_raids.py
@@ -266,3 +266,69 @@ class TestRelationshipQueries:
     async def test_all_raids_merged_false(self, repo: PostgresRaidRepository, pool: MagicMock):
         pool.fetchrow = AsyncMock(return_value={"remaining": 2})
         assert await repo.all_raids_merged(uuid4()) is False
+
+
+# ---------------------------------------------------------------------------
+# save_session_message / get_session_messages
+# ---------------------------------------------------------------------------
+
+
+class TestSessionMessages:
+    @pytest.mark.asyncio
+    async def test_save_session_message(self, repo: PostgresRaidRepository, pool: MagicMock):
+        from datetime import UTC, datetime
+        from uuid import uuid4
+
+        from tyr.domain.models import SessionMessage
+
+        msg = SessionMessage(
+            id=uuid4(),
+            raid_id=uuid4(),
+            session_id="ses-1",
+            content="Fix the tests",
+            sender="user",
+            created_at=datetime.now(UTC),
+        )
+        pool.execute = AsyncMock()
+        await repo.save_session_message(msg)
+
+        pool.execute.assert_called_once()
+        call_args = pool.execute.call_args
+        assert "INSERT INTO session_messages" in call_args[0][0]
+        assert call_args[0][1] == msg.id
+        assert call_args[0][4] == "Fix the tests"
+
+    @pytest.mark.asyncio
+    async def test_get_session_messages(self, repo: PostgresRaidRepository, pool: MagicMock):
+        from datetime import UTC, datetime
+        from uuid import uuid4
+
+        raid_id = uuid4()
+        msg_id = uuid4()
+        now = datetime.now(UTC)
+
+        pool.fetch = AsyncMock(
+            return_value=[
+                {
+                    "id": msg_id,
+                    "raid_id": raid_id,
+                    "session_id": "ses-1",
+                    "content": "hello",
+                    "sender": "user",
+                    "created_at": now,
+                }
+            ]
+        )
+
+        messages = await repo.get_session_messages(raid_id)
+        assert len(messages) == 1
+        assert messages[0].id == msg_id
+        assert messages[0].content == "hello"
+        assert messages[0].sender == "user"
+        assert messages[0].session_id == "ses-1"
+
+    @pytest.mark.asyncio
+    async def test_get_session_messages_empty(self, repo: PostgresRaidRepository, pool: MagicMock):
+        pool.fetch = AsyncMock(return_value=[])
+        messages = await repo.get_session_messages(uuid4())
+        assert messages == []

--- a/tests/test_tyr/test_raids_api.py
+++ b/tests/test_tyr/test_raids_api.py
@@ -27,6 +27,7 @@ from tyr.domain.models import (
     RaidStatus,
     Saga,
     SagaStatus,
+    SessionMessage,
 )
 from tyr.ports.git import GitPort
 from tyr.ports.raid_repository import RaidRepository
@@ -166,6 +167,12 @@ class MockRaidRepository(RaidRepository):
 
     async def all_raids_merged(self, phase_id: UUID) -> bool:
         return self._all_merged
+
+    async def save_session_message(self, message: SessionMessage) -> None:
+        pass
+
+    async def get_session_messages(self, raid_id: UUID) -> list[SessionMessage]:
+        return []
 
 
 class MockVolundr(VolundrPort):

--- a/tests/test_tyr/test_session_message.py
+++ b/tests/test_tyr/test_session_message.py
@@ -17,6 +17,7 @@ from tyr.api.raids import (
     resolve_volundr,
 )
 from tyr.config import ReviewConfig
+from tyr.domain.exceptions import RaidNotFoundError
 from tyr.domain.models import (
     ConfidenceEventType,
     RaidStatus,
@@ -24,7 +25,6 @@ from tyr.domain.models import (
 )
 from tyr.domain.services.session_message import (
     NoActiveSessionError,
-    RaidNotFoundError,
     RaidNotRunningError,
     SessionMessageService,
 )

--- a/tests/test_tyr/test_session_message.py
+++ b/tests/test_tyr/test_session_message.py
@@ -1,0 +1,542 @@
+"""Tests for session message sending — domain service and REST API."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tyr.api.raids import (
+    create_raids_router,
+    resolve_git,
+    resolve_raid_repo,
+    resolve_tracker,
+    resolve_volundr,
+)
+from tyr.config import ReviewConfig
+from tyr.domain.models import (
+    ConfidenceEventType,
+    RaidStatus,
+    SessionMessage,
+)
+from tyr.domain.services.session_message import (
+    NoActiveSessionError,
+    RaidNotFoundError,
+    RaidNotRunningError,
+    SessionMessageService,
+)
+from tyr.events import EventBus
+
+from .test_raids_api import (
+    MockGit,
+    MockRaidRepository,
+    MockVolundr,
+    _make_raid,
+)
+from .test_tracker_api import MockTracker
+
+REVIEW_CFG = ReviewConfig()
+
+
+# ---------------------------------------------------------------------------
+# Extend MockRaidRepository with session message support
+# ---------------------------------------------------------------------------
+
+
+class MessageAwareMockRaidRepo(MockRaidRepository):
+    """MockRaidRepository extended with session message methods."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.messages: dict[UUID, list[SessionMessage]] = {}
+
+    async def save_session_message(self, message: SessionMessage) -> None:
+        self.messages.setdefault(message.raid_id, []).append(message)
+
+    async def get_session_messages(self, raid_id: UUID) -> list[SessionMessage]:
+        return self.messages.get(raid_id, [])
+
+
+# ---------------------------------------------------------------------------
+# Extend MockVolundr to track sent messages
+# ---------------------------------------------------------------------------
+
+
+class MessageTrackingVolundr(MockVolundr):
+    """MockVolundr that tracks messages sent to sessions."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.sent_messages: list[tuple[str, str, str | None]] = []
+        self.fail_send_message = False
+
+    async def send_message(
+        self,
+        session_id: str,
+        message: str,
+        *,
+        auth_token: str | None = None,
+    ) -> None:
+        if self.fail_send_message:
+            raise ConnectionError("Volundr unreachable")
+        self.sent_messages.append((session_id, message, auth_token))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def raid_repo() -> MessageAwareMockRaidRepo:
+    from .test_raids_api import _make_phase, _make_saga
+
+    repo = MessageAwareMockRaidRepo()
+    repo.saga = _make_saga()
+    repo.phase = _make_phase()
+    return repo
+
+
+@pytest.fixture
+def volundr() -> MessageTrackingVolundr:
+    return MessageTrackingVolundr()
+
+
+@pytest.fixture
+def event_bus() -> EventBus:
+    return EventBus()
+
+
+@pytest.fixture
+def service(
+    raid_repo: MessageAwareMockRaidRepo,
+    volundr: MessageTrackingVolundr,
+    event_bus: EventBus,
+) -> SessionMessageService:
+    return SessionMessageService(raid_repo, volundr, event_bus=event_bus)
+
+
+@pytest.fixture
+def client(
+    raid_repo: MessageAwareMockRaidRepo,
+    volundr: MessageTrackingVolundr,
+    event_bus: EventBus,
+) -> TestClient:
+    app = FastAPI()
+    app.include_router(create_raids_router())
+    app.dependency_overrides[resolve_raid_repo] = lambda: raid_repo
+    app.dependency_overrides[resolve_volundr] = lambda: volundr
+    app.dependency_overrides[resolve_git] = lambda: MockGit()
+    app.dependency_overrides[resolve_tracker] = lambda: MockTracker()
+
+    from types import SimpleNamespace
+
+    app.state.settings = SimpleNamespace(review=REVIEW_CFG)
+    app.state.event_bus = event_bus
+
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Domain service tests
+# ---------------------------------------------------------------------------
+
+
+class TestSessionMessageService:
+    @pytest.mark.asyncio
+    async def test_send_message_success(
+        self,
+        service: SessionMessageService,
+        raid_repo: MessageAwareMockRaidRepo,
+        volundr: MessageTrackingVolundr,
+    ):
+        raid = _make_raid(status=RaidStatus.RUNNING)
+        raid_repo.raids[raid.id] = raid
+
+        result = await service.send_message(raid.id, "Fix the failing test")
+
+        assert result.raid_id == raid.id
+        assert result.session_id == "session-1"
+        assert result.message.content == "Fix the failing test"
+        assert result.message.sender == "user"
+
+        # Verify message was sent to Volundr
+        assert len(volundr.sent_messages) == 1
+        assert volundr.sent_messages[0] == ("session-1", "Fix the failing test", None)
+
+        # Verify audit record persisted
+        messages = await raid_repo.get_session_messages(raid.id)
+        assert len(messages) == 1
+        assert messages[0].content == "Fix the failing test"
+
+        # Verify confidence event recorded
+        events = raid_repo.events[raid.id]
+        assert len(events) == 1
+        assert events[0].event_type == ConfidenceEventType.MESSAGE_SENT
+        assert events[0].delta == 0.0
+        assert events[0].score_after == raid.confidence
+
+    @pytest.mark.asyncio
+    async def test_send_message_with_auth_token(
+        self,
+        service: SessionMessageService,
+        raid_repo: MessageAwareMockRaidRepo,
+        volundr: MessageTrackingVolundr,
+    ):
+        raid = _make_raid(status=RaidStatus.RUNNING)
+        raid_repo.raids[raid.id] = raid
+
+        await service.send_message(raid.id, "hello", auth_token="pat-123")
+
+        assert volundr.sent_messages[0][2] == "pat-123"
+
+    @pytest.mark.asyncio
+    async def test_send_message_custom_sender(
+        self,
+        service: SessionMessageService,
+        raid_repo: MessageAwareMockRaidRepo,
+    ):
+        raid = _make_raid(status=RaidStatus.RUNNING)
+        raid_repo.raids[raid.id] = raid
+
+        result = await service.send_message(raid.id, "auto-retry", sender="tyr:watcher")
+
+        assert result.message.sender == "tyr:watcher"
+
+    @pytest.mark.asyncio
+    async def test_send_message_in_review_state(
+        self,
+        service: SessionMessageService,
+        raid_repo: MessageAwareMockRaidRepo,
+    ):
+        raid = _make_raid(status=RaidStatus.REVIEW)
+        raid_repo.raids[raid.id] = raid
+
+        result = await service.send_message(raid.id, "feedback")
+
+        assert result.message.content == "feedback"
+
+    @pytest.mark.asyncio
+    async def test_send_message_raid_not_found(
+        self,
+        service: SessionMessageService,
+    ):
+        with pytest.raises(RaidNotFoundError):
+            await service.send_message(uuid4(), "hello")
+
+    @pytest.mark.asyncio
+    async def test_send_message_raid_not_running(
+        self,
+        service: SessionMessageService,
+        raid_repo: MessageAwareMockRaidRepo,
+    ):
+        raid = _make_raid(status=RaidStatus.PENDING)
+        raid_repo.raids[raid.id] = raid
+
+        with pytest.raises(RaidNotRunningError) as exc_info:
+            await service.send_message(raid.id, "hello")
+        assert exc_info.value.status == "PENDING"
+
+    @pytest.mark.asyncio
+    async def test_send_message_no_active_session(
+        self,
+        service: SessionMessageService,
+        raid_repo: MessageAwareMockRaidRepo,
+    ):
+        raid = _make_raid(status=RaidStatus.RUNNING, session_id=None)
+        raid_repo.raids[raid.id] = raid
+
+        with pytest.raises(NoActiveSessionError):
+            await service.send_message(raid.id, "hello")
+
+    @pytest.mark.asyncio
+    async def test_send_message_merged_state_rejected(
+        self,
+        service: SessionMessageService,
+        raid_repo: MessageAwareMockRaidRepo,
+    ):
+        raid = _make_raid(status=RaidStatus.MERGED)
+        raid_repo.raids[raid.id] = raid
+
+        with pytest.raises(RaidNotRunningError):
+            await service.send_message(raid.id, "hello")
+
+    @pytest.mark.asyncio
+    async def test_send_message_failed_state_rejected(
+        self,
+        service: SessionMessageService,
+        raid_repo: MessageAwareMockRaidRepo,
+    ):
+        raid = _make_raid(status=RaidStatus.FAILED)
+        raid_repo.raids[raid.id] = raid
+
+        with pytest.raises(RaidNotRunningError):
+            await service.send_message(raid.id, "hello")
+
+    @pytest.mark.asyncio
+    async def test_send_message_emits_event(
+        self,
+        service: SessionMessageService,
+        raid_repo: MessageAwareMockRaidRepo,
+        event_bus: EventBus,
+    ):
+        raid = _make_raid(status=RaidStatus.RUNNING)
+        raid_repo.raids[raid.id] = raid
+
+        q = event_bus.subscribe()
+        await service.send_message(raid.id, "CI failed on test_auth.py")
+
+        event = q.get_nowait()
+        assert event.event == "session.message_sent"
+        assert event.data["raid_id"] == str(raid.id)
+        assert event.data["session_id"] == "session-1"
+        assert event.data["sender"] == "user"
+        assert event.data["content_length"] == len("CI failed on test_auth.py")
+
+    @pytest.mark.asyncio
+    async def test_send_message_no_event_bus(
+        self,
+        raid_repo: MessageAwareMockRaidRepo,
+        volundr: MessageTrackingVolundr,
+    ):
+        svc = SessionMessageService(raid_repo, volundr, event_bus=None)
+        raid = _make_raid(status=RaidStatus.RUNNING)
+        raid_repo.raids[raid.id] = raid
+
+        result = await svc.send_message(raid.id, "hello")
+        assert result.message.content == "hello"
+
+    @pytest.mark.asyncio
+    async def test_send_message_volundr_failure_propagates(
+        self,
+        service: SessionMessageService,
+        raid_repo: MessageAwareMockRaidRepo,
+        volundr: MessageTrackingVolundr,
+    ):
+        raid = _make_raid(status=RaidStatus.RUNNING)
+        raid_repo.raids[raid.id] = raid
+        volundr.fail_send_message = True
+
+        with pytest.raises(ConnectionError):
+            await service.send_message(raid.id, "hello")
+
+        # No audit record should be persisted on failure
+        messages = await raid_repo.get_session_messages(raid.id)
+        assert len(messages) == 0
+
+
+# ---------------------------------------------------------------------------
+# REST API tests — POST /raids/{id}/message
+# ---------------------------------------------------------------------------
+
+
+class TestSendMessageEndpoint:
+    def test_send_message_success(
+        self,
+        client: TestClient,
+        raid_repo: MessageAwareMockRaidRepo,
+        volundr: MessageTrackingVolundr,
+    ):
+        raid = _make_raid(status=RaidStatus.RUNNING)
+        raid_repo.raids[raid.id] = raid
+
+        resp = client.post(
+            f"/api/v1/tyr/raids/{raid.id}/message",
+            json={"content": "CI failed: see logs"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["raid_id"] == str(raid.id)
+        assert data["session_id"] == "session-1"
+        assert data["content"] == "CI failed: see logs"
+        assert data["sender"] == "user"
+        assert "message_id" in data
+        assert "created_at" in data
+
+        # Verify Volundr was called
+        assert len(volundr.sent_messages) == 1
+
+    def test_send_message_not_found(self, client: TestClient):
+        resp = client.post(
+            f"/api/v1/tyr/raids/{uuid4()}/message",
+            json={"content": "hello"},
+        )
+        assert resp.status_code == 404
+
+    def test_send_message_not_running(
+        self,
+        client: TestClient,
+        raid_repo: MessageAwareMockRaidRepo,
+    ):
+        raid = _make_raid(status=RaidStatus.PENDING)
+        raid_repo.raids[raid.id] = raid
+
+        resp = client.post(
+            f"/api/v1/tyr/raids/{raid.id}/message",
+            json={"content": "hello"},
+        )
+        assert resp.status_code == 409
+        assert "PENDING" in resp.json()["detail"]
+
+    def test_send_message_no_session(
+        self,
+        client: TestClient,
+        raid_repo: MessageAwareMockRaidRepo,
+    ):
+        raid = _make_raid(status=RaidStatus.RUNNING, session_id=None)
+        raid_repo.raids[raid.id] = raid
+
+        resp = client.post(
+            f"/api/v1/tyr/raids/{raid.id}/message",
+            json={"content": "hello"},
+        )
+        assert resp.status_code == 409
+        assert "no active session" in resp.json()["detail"]
+
+    def test_send_message_empty_content(
+        self,
+        client: TestClient,
+        raid_repo: MessageAwareMockRaidRepo,
+    ):
+        raid = _make_raid(status=RaidStatus.RUNNING)
+        raid_repo.raids[raid.id] = raid
+
+        resp = client.post(
+            f"/api/v1/tyr/raids/{raid.id}/message",
+            json={"content": ""},
+        )
+        assert resp.status_code == 422
+
+    def test_send_message_missing_content(
+        self,
+        client: TestClient,
+        raid_repo: MessageAwareMockRaidRepo,
+    ):
+        raid = _make_raid(status=RaidStatus.RUNNING)
+        raid_repo.raids[raid.id] = raid
+
+        resp = client.post(
+            f"/api/v1/tyr/raids/{raid.id}/message",
+            json={},
+        )
+        assert resp.status_code == 422
+
+    def test_send_message_review_state(
+        self,
+        client: TestClient,
+        raid_repo: MessageAwareMockRaidRepo,
+    ):
+        raid = _make_raid(status=RaidStatus.REVIEW)
+        raid_repo.raids[raid.id] = raid
+
+        resp = client.post(
+            f"/api/v1/tyr/raids/{raid.id}/message",
+            json={"content": "looks good but fix X"},
+        )
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# REST API tests — GET /raids/{id}/messages
+# ---------------------------------------------------------------------------
+
+
+class TestListMessagesEndpoint:
+    def test_list_messages_empty(
+        self,
+        client: TestClient,
+        raid_repo: MessageAwareMockRaidRepo,
+    ):
+        raid = _make_raid(status=RaidStatus.RUNNING)
+        raid_repo.raids[raid.id] = raid
+
+        resp = client.get(f"/api/v1/tyr/raids/{raid.id}/messages")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_list_messages_with_history(
+        self,
+        client: TestClient,
+        raid_repo: MessageAwareMockRaidRepo,
+    ):
+        raid = _make_raid(status=RaidStatus.RUNNING)
+        raid_repo.raids[raid.id] = raid
+
+        now = datetime.now(UTC)
+        msg1 = SessionMessage(
+            id=uuid4(),
+            raid_id=raid.id,
+            session_id="session-1",
+            content="Fix test_auth.py",
+            sender="user",
+            created_at=now,
+        )
+        msg2 = SessionMessage(
+            id=uuid4(),
+            raid_id=raid.id,
+            session_id="session-1",
+            content="Also fix coverage",
+            sender="tyr:watcher",
+            created_at=now,
+        )
+        raid_repo.messages[raid.id] = [msg1, msg2]
+
+        resp = client.get(f"/api/v1/tyr/raids/{raid.id}/messages")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2
+        assert data[0]["content"] == "Fix test_auth.py"
+        assert data[0]["sender"] == "user"
+        assert data[1]["content"] == "Also fix coverage"
+        assert data[1]["sender"] == "tyr:watcher"
+
+    def test_list_messages_not_found(self, client: TestClient):
+        resp = client.get(f"/api/v1/tyr/raids/{uuid4()}/messages")
+        assert resp.status_code == 404
+
+    def test_send_then_list(
+        self,
+        client: TestClient,
+        raid_repo: MessageAwareMockRaidRepo,
+    ):
+        raid = _make_raid(status=RaidStatus.RUNNING)
+        raid_repo.raids[raid.id] = raid
+
+        # Send a message
+        client.post(
+            f"/api/v1/tyr/raids/{raid.id}/message",
+            json={"content": "hello from test"},
+        )
+
+        # List messages
+        resp = client.get(f"/api/v1/tyr/raids/{raid.id}/messages")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["content"] == "hello from test"
+
+
+# ---------------------------------------------------------------------------
+# Model tests
+# ---------------------------------------------------------------------------
+
+
+class TestSessionMessageModel:
+    def test_frozen_dataclass(self):
+        msg = SessionMessage(
+            id=uuid4(),
+            raid_id=uuid4(),
+            session_id="ses-1",
+            content="hello",
+            sender="user",
+            created_at=datetime.now(UTC),
+        )
+        with pytest.raises(AttributeError):
+            msg.content = "changed"  # type: ignore[misc]
+
+    def test_message_sent_event_type(self):
+        assert ConfidenceEventType.MESSAGE_SENT == "message_sent"
+        assert ConfidenceEventType.MESSAGE_SENT.value == "message_sent"

--- a/tests/test_tyr/test_telegram_webhook.py
+++ b/tests/test_tyr/test_telegram_webhook.py
@@ -159,6 +159,12 @@ class StubRaidRepo(RaidRepository):
     async def all_raids_merged(self, phase_id: UUID) -> bool:
         return self._all_merged
 
+    async def save_session_message(self, message: object) -> None:
+        pass
+
+    async def get_session_messages(self, raid_id: UUID) -> list:
+        return []
+
 
 class StubDispatcherRepo(DispatcherRepository):
     def __init__(self, running: bool = True) -> None:

--- a/tests/test_tyr/test_volundr_http.py
+++ b/tests/test_tyr/test_volundr_http.py
@@ -421,3 +421,47 @@ class TestConstructor:
         adapter = VolundrHTTPAdapter(base_url="http://example.com", api_key="pat-xyz", timeout=15.0)
         assert adapter._api_key == "pat-xyz"
         assert adapter._timeout == 15.0
+
+
+# -------------------------------------------------------------------
+# send_message
+# -------------------------------------------------------------------
+
+
+class TestSendMessage:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_success(self, adapter: VolundrHTTPAdapter):
+        route = respx.post(f"{SESSIONS_URL}/ses-1/messages").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+
+        await adapter.send_message("ses-1", "Fix the test")
+
+        sent = route.calls[0].request
+        import json
+
+        body = json.loads(sent.content)
+        assert body["content"] == "Fix the test"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_sends_auth_token(self, adapter: VolundrHTTPAdapter):
+        route = respx.post(f"{SESSIONS_URL}/ses-1/messages").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+
+        await adapter.send_message("ses-1", "hello", auth_token="pat-abc")
+
+        sent = route.calls[0].request
+        assert sent.headers["Authorization"] == "Bearer pat-abc"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_raises_on_error(self, adapter: VolundrHTTPAdapter):
+        respx.post(f"{SESSIONS_URL}/ses-1/messages").mock(
+            return_value=httpx.Response(500, text="error")
+        )
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await adapter.send_message("ses-1", "hello")

--- a/tests/test_tyr/test_watcher.py
+++ b/tests/test_tyr/test_watcher.py
@@ -160,6 +160,12 @@ class StubRaidRepo(RaidRepository):
     async def all_raids_merged(self, phase_id: UUID) -> bool:
         return False
 
+    async def save_session_message(self, message: object) -> None:
+        pass
+
+    async def get_session_messages(self, raid_id: UUID) -> list:
+        return []
+
 
 class StubDispatcherRepo(DispatcherRepository):
     """In-memory dispatcher repo for watcher tests."""


### PR DESCRIPTION
## Summary

- **SessionMessageService** domain service that resolves raid → session_id, sends messages via `VolundrPort.send_message()`, persists audit records, records confidence events, and emits SSE events
- **REST API**: `POST /api/v1/tyr/raids/{raid_id}/message` to send messages, `GET /api/v1/tyr/raids/{raid_id}/messages` to list message history
- **SessionMessage** domain model and `MESSAGE_SENT` confidence event type for audit trail
- **PostgreSQL migration** for `session_messages` table with indexes on raid_id and session_id
- Guards: only RUNNING/REVIEW raids with active sessions can receive messages

## Use Cases

1. **Auto-retry with context**: When CI fails, Tyr sends failure logs to the running session
2. **Scope correction**: Tyr tells the session to revert out-of-scope changes
3. **Human relay**: User types feedback in Tyr UI, forwarded to the session
4. **Phase context**: Tyr briefs sessions about dependencies from prior phases

## Test plan

- [x] Domain service: success, auth token passthrough, custom sender, REVIEW state, not-found, not-running, no-session, merged/failed rejection, event emission, no event bus, Volundr failure propagation
- [x] REST API: send message success, 404, 409 (not running / no session), 422 (empty/missing content), REVIEW state
- [x] REST API: list messages empty, with history, not-found, send-then-list round-trip
- [x] VolundrHTTPAdapter: send_message success, auth token, error handling
- [x] PostgresRaidRepository: save/get session messages
- [x] Model: frozen dataclass, MESSAGE_SENT enum value, updated member count
- [x] All 621 tests passing, new files at 100% coverage

Closes NIU-241

🤖 Generated with [Claude Code](https://claude.com/claude-code)