### PR TITLE
feat(tyr): notification service — Telegram, SSE, and extensible channel dispatch

### DIFF
--- a/src/tyr/adapters/notification_channel_factory.py
+++ b/src/tyr/adapters/notification_channel_factory.py
@@ -1,0 +1,71 @@
+"""Factory for resolving per-owner notification channel instances."""
+
+from __future__ import annotations
+
+import logging
+
+from niuu.domain.models import IntegrationType
+from niuu.ports.credentials import CredentialStorePort
+from niuu.ports.integrations import IntegrationRepository
+from niuu.utils import import_class
+from tyr.ports.notification_channel import NotificationChannel
+
+logger = logging.getLogger(__name__)
+
+
+class NotificationChannelFactory:
+    """Resolves notification channels for a specific owner from stored config.
+
+    Uses the dynamic adapter pattern: each IntegrationConnection with
+    integration_type=MESSAGING becomes a NotificationChannel instance.
+    The ``adapter`` field is a fully-qualified class path, and ``config``
+    provides kwargs (e.g. chat_id, min_urgency).
+    """
+
+    def __init__(
+        self,
+        integration_repo: IntegrationRepository,
+        credential_store: CredentialStorePort,
+    ) -> None:
+        self._integration_repo = integration_repo
+        self._credential_store = credential_store
+
+    async def for_owner(self, owner_id: str) -> list[NotificationChannel]:
+        """Return all enabled NotificationChannel adapters for the owner."""
+        connections = await self._integration_repo.list_connections(
+            owner_id,
+            integration_type=IntegrationType.MESSAGING,
+        )
+        channels: list[NotificationChannel] = []
+        for conn in connections:
+            if not conn.enabled:
+                continue
+            try:
+                cred = await self._credential_store.get_value(
+                    "user",
+                    owner_id,
+                    conn.credential_name,
+                )
+                if cred is None:
+                    logger.debug(
+                        "No credential found for connection %s, skipping",
+                        conn.id,
+                    )
+                    continue
+
+                cls = import_class(conn.adapter)
+                kwargs = {**cred, **conn.config}
+                channels.append(cls(**kwargs))
+            except (ImportError, TypeError, ValueError, AttributeError) as exc:
+                logger.error(
+                    "Failed to create notification channel for connection %s: %s",
+                    conn.id,
+                    exc,
+                )
+            except Exception:
+                logger.error(
+                    "Unexpected error creating notification channel for connection %s",
+                    conn.id,
+                    exc_info=True,
+                )
+        return channels

--- a/src/tyr/adapters/telegram_notification.py
+++ b/src/tyr/adapters/telegram_notification.py
@@ -1,0 +1,101 @@
+"""Telegram notification adapter — sends formatted notifications via Telegram Bot API."""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from tyr.ports.notification_channel import (
+    Notification,
+    NotificationChannel,
+    NotificationUrgency,
+)
+
+logger = logging.getLogger(__name__)
+
+TELEGRAM_API = "https://api.telegram.org"
+
+_URGENCY_EMOJI = {
+    NotificationUrgency.HIGH: "\u26a0\ufe0f",
+    NotificationUrgency.MEDIUM: "\u2139\ufe0f",
+    NotificationUrgency.LOW: "\u2705",
+}
+
+
+class TelegramNotificationAdapter(NotificationChannel):
+    """Sends notifications to a Telegram chat via the Bot API."""
+
+    def __init__(
+        self,
+        bot_token: str,
+        chat_id: str,
+        *,
+        timeout: float = 10.0,
+        min_urgency: str = "low",
+    ) -> None:
+        self._bot_token = bot_token
+        self._chat_id = chat_id
+        self._client = httpx.AsyncClient(timeout=timeout)
+        self._min_urgency = NotificationUrgency(min_urgency)
+        self._urgency_rank = {
+            NotificationUrgency.LOW: 0,
+            NotificationUrgency.MEDIUM: 1,
+            NotificationUrgency.HIGH: 2,
+        }
+
+    def should_notify(self, notification: Notification) -> bool:
+        """Only notify if the urgency meets the minimum threshold."""
+        return (
+            self._urgency_rank.get(notification.urgency, 0) >= self._urgency_rank[self._min_urgency]
+        )
+
+    async def send(self, notification: Notification) -> None:
+        """Send a formatted message to the Telegram chat."""
+        if not self._bot_token:
+            logger.warning("Cannot send notification — bot_token not configured")
+            return
+
+        text = self._format_message(notification)
+        url = f"{TELEGRAM_API}/bot{self._bot_token}/sendMessage"
+        try:
+            resp = await self._client.post(
+                url,
+                json={
+                    "chat_id": self._chat_id,
+                    "text": text,
+                    "parse_mode": "Markdown",
+                },
+            )
+            if resp.status_code != 200:
+                logger.warning(
+                    "Telegram API returned %d for chat %s",
+                    resp.status_code,
+                    self._chat_id,
+                )
+        except Exception:
+            logger.warning(
+                "Failed to send Telegram notification to %s",
+                self._chat_id,
+                exc_info=True,
+            )
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client."""
+        await self._client.aclose()
+
+    @staticmethod
+    def _format_message(notification: Notification) -> str:
+        """Format a notification as a Markdown message."""
+        emoji = _URGENCY_EMOJI.get(notification.urgency, "")
+        parts = [f"{emoji} *{notification.title}*", "", notification.body]
+
+        pr_url = notification.metadata.get("pr_url")
+        if pr_url:
+            parts.append(f"\n[View PR]({pr_url})")
+
+        tracker_id = notification.metadata.get("tracker_id")
+        if tracker_id:
+            parts.append(f"Ticket: {tracker_id}")
+
+        return "\n".join(parts)

--- a/src/tyr/config.py
+++ b/src/tyr/config.py
@@ -207,6 +207,16 @@ class WatcherConfig(BaseModel):
     )
 
 
+class NotificationConfig(BaseModel):
+    """Notification service configuration."""
+
+    enabled: bool = Field(default=True)
+    confidence_threshold: float = Field(
+        default=0.3,
+        description="Notify when raid confidence drops below this value.",
+    )
+
+
 class EventsConfig(BaseModel):
     """SSE event stream configuration."""
 
@@ -255,6 +265,7 @@ class Settings(BaseSettings):
     watcher: WatcherConfig = Field(default_factory=WatcherConfig)
     events: EventsConfig = Field(default_factory=EventsConfig)
     telegram: TelegramConfig = Field(default_factory=TelegramConfig)
+    notification: NotificationConfig = Field(default_factory=NotificationConfig)
 
     @classmethod
     def settings_customise_sources(

--- a/src/tyr/domain/services/notification.py
+++ b/src/tyr/domain/services/notification.py
@@ -196,7 +196,7 @@ class NotificationService:
 
     async def _map_confidence_updated(self, data: dict[str, Any]) -> Notification | None:
         """Map a confidence.updated event when confidence drops below threshold."""
-        confidence = data.get("confidence", 1.0)
+        confidence = data.get("score_after", 1.0)
         if confidence >= self._confidence_threshold:
             return None
 

--- a/src/tyr/domain/services/notification.py
+++ b/src/tyr/domain/services/notification.py
@@ -43,9 +43,6 @@ _STATUS_NOTIFICATION_MAP: dict[str, dict[str, Any]] = {
     },
 }
 
-_CONFIDENCE_THRESHOLD = 0.3
-
-
 # ---------------------------------------------------------------------------
 # Service
 # ---------------------------------------------------------------------------
@@ -65,7 +62,7 @@ class NotificationService:
         channel_factory: NotificationChannelFactory,
         raid_repo: RaidRepository,
         *,
-        confidence_threshold: float = _CONFIDENCE_THRESHOLD,
+        confidence_threshold: float,
     ) -> None:
         self._event_bus = event_bus
         self._channel_factory = channel_factory
@@ -254,6 +251,9 @@ class NotificationService:
         """Map a phase.unlocked event."""
         owner_id = data.get("owner_id", "")
         if not owner_id:
+            logger.warning(
+                "phase.unlocked event missing owner_id, skipping notification"
+            )
             return None
 
         phase_number = data.get("phase_number", "?")

--- a/src/tyr/domain/services/notification.py
+++ b/src/tyr/domain/services/notification.py
@@ -1,0 +1,296 @@
+"""Notification service — subscribes to EventBus and dispatches to channels.
+
+Maps domain events (raid state changes, saga completions, etc.) to
+user-facing notifications and delivers them through configured channels
+(Telegram, Slack, etc.) using the dynamic adapter pattern.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from tyr.adapters.notification_channel_factory import NotificationChannelFactory
+from tyr.events import EventBus, TyrEvent
+from tyr.ports.notification_channel import (
+    Notification,
+    NotificationUrgency,
+)
+from tyr.ports.raid_repository import RaidRepository
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Event → Notification mapping configuration
+# ---------------------------------------------------------------------------
+
+_STATUS_NOTIFICATION_MAP: dict[str, dict[str, Any]] = {
+    "REVIEW": {
+        "title": "Raid ready for review",
+        "body_template": "Raid {tracker_id} is ready for review.",
+        "urgency": NotificationUrgency.HIGH,
+    },
+    "FAILED": {
+        "title": "Raid failed",
+        "body_template": "Raid {tracker_id} failed (retry #{retry_count}).",
+        "urgency": NotificationUrgency.HIGH,
+    },
+    "MERGED": {
+        "title": "Raid merged",
+        "body_template": "Raid {tracker_id} has been merged.",
+        "urgency": NotificationUrgency.LOW,
+    },
+}
+
+_CONFIDENCE_THRESHOLD = 0.3
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+
+class NotificationService:
+    """Subscribes to EventBus events and dispatches notifications to channels.
+
+    Runs as a background task alongside the main application. For each event,
+    it resolves the owning user, builds a Notification, resolves that user's
+    configured channels, and delivers.
+    """
+
+    def __init__(
+        self,
+        event_bus: EventBus,
+        channel_factory: NotificationChannelFactory,
+        raid_repo: RaidRepository,
+        *,
+        confidence_threshold: float = _CONFIDENCE_THRESHOLD,
+    ) -> None:
+        self._event_bus = event_bus
+        self._channel_factory = channel_factory
+        self._raid_repo = raid_repo
+        self._confidence_threshold = confidence_threshold
+        self._running = False
+        self._task: asyncio.Task[None] | None = None
+        self._queue: asyncio.Queue[TyrEvent] | None = None
+
+    @property
+    def running(self) -> bool:
+        return self._running
+
+    async def start(self) -> None:
+        """Start the notification background loop."""
+        self._queue = self._event_bus.subscribe()
+        self._running = True
+        self._task = asyncio.create_task(self._run(), name="notification-service")
+        logger.info("Notification service started")
+
+    async def stop(self) -> None:
+        """Gracefully stop the notification service."""
+        self._running = False
+        if self._queue is not None:
+            self._event_bus.unsubscribe(self._queue)
+            self._queue = None
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        logger.info("Notification service stopped")
+
+    async def _run(self) -> None:
+        """Main loop — consume events and dispatch notifications."""
+        while self._running:
+            try:
+                if self._queue is None:
+                    break
+                event = await asyncio.wait_for(self._queue.get(), timeout=5.0)
+                await self._handle_event(event)
+            except TimeoutError:
+                continue
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("Error processing notification event")
+
+    async def _handle_event(self, event: TyrEvent) -> None:
+        """Map an event to a notification and dispatch it."""
+        notification = await self._map_event(event)
+        if notification is None:
+            return
+
+        channels = await self._channel_factory.for_owner(notification.owner_id)
+        if not channels:
+            return
+
+        for channel in channels:
+            if not channel.should_notify(notification):
+                continue
+            try:
+                await channel.send(notification)
+            except Exception:
+                logger.warning(
+                    "Failed to send notification via %s",
+                    type(channel).__name__,
+                    exc_info=True,
+                )
+
+    async def _map_event(self, event: TyrEvent) -> Notification | None:
+        """Convert a TyrEvent into a Notification, or None if unmapped."""
+        match event.event:
+            case "raid.state_changed":
+                return await self._map_raid_state_changed(event.data)
+            case "confidence.updated":
+                return await self._map_confidence_updated(event.data)
+            case "saga.pr_created":
+                return self._map_saga_pr_created(event.data)
+            case "phase.unlocked":
+                return self._map_phase_unlocked(event.data)
+            case _:
+                return None
+
+    async def _map_raid_state_changed(self, data: dict[str, Any]) -> Notification | None:
+        """Map a raid.state_changed event to a notification."""
+        status = data.get("status", "")
+        mapping = _STATUS_NOTIFICATION_MAP.get(status)
+        if mapping is None:
+            return None
+
+        raid_id = data.get("raid_id", "")
+        tracker_id = data.get("tracker_id", "")
+        pr_url = data.get("pr_url", "")
+
+        # Resolve owner_id from the raid's parent saga
+        owner_id = await self._resolve_owner(raid_id)
+        if not owner_id:
+            return None
+
+        # Resolve tracker_id from raid if not in event data
+        if not tracker_id:
+            tracker_id = await self._resolve_tracker_id(raid_id)
+
+        retry_count = data.get("retry_count", 0)
+
+        body = mapping["body_template"].format(
+            tracker_id=tracker_id or raid_id,
+            retry_count=retry_count,
+        )
+
+        if pr_url:
+            body += f"\nPR: {pr_url}"
+
+        metadata: dict[str, str] = {}
+        if pr_url:
+            metadata["pr_url"] = pr_url
+        if tracker_id:
+            metadata["tracker_id"] = tracker_id
+
+        return Notification(
+            title=mapping["title"],
+            body=body,
+            urgency=mapping["urgency"],
+            owner_id=owner_id,
+            event_type=f"raid.{status.lower()}",
+            metadata=metadata,
+        )
+
+    async def _map_confidence_updated(self, data: dict[str, Any]) -> Notification | None:
+        """Map a confidence.updated event when confidence drops below threshold."""
+        confidence = data.get("confidence", 1.0)
+        if confidence >= self._confidence_threshold:
+            return None
+
+        raid_id = data.get("raid_id", "")
+        tracker_id = data.get("tracker_id", "")
+
+        owner_id = await self._resolve_owner(raid_id)
+        if not owner_id:
+            return None
+
+        if not tracker_id:
+            tracker_id = await self._resolve_tracker_id(raid_id)
+
+        return Notification(
+            title="Confidence dropped",
+            body=f"Raid {tracker_id or raid_id} confidence dropped to {confidence:.0%}.",
+            urgency=NotificationUrgency.MEDIUM,
+            owner_id=owner_id,
+            event_type="confidence.low",
+            metadata={"tracker_id": tracker_id} if tracker_id else {},
+        )
+
+    @staticmethod
+    def _map_saga_pr_created(data: dict[str, Any]) -> Notification | None:
+        """Map a saga.pr_created event."""
+        owner_id = data.get("owner_id", "")
+        if not owner_id:
+            return None
+
+        saga_name = data.get("saga_name", "")
+        pr_url = data.get("pr_url", "")
+
+        body = f'Saga "{saga_name}" complete — final PR ready.'
+        if pr_url:
+            body += f"\nPR: {pr_url}"
+
+        metadata: dict[str, str] = {}
+        if pr_url:
+            metadata["pr_url"] = pr_url
+
+        return Notification(
+            title="Saga complete",
+            body=body,
+            urgency=NotificationUrgency.HIGH,
+            owner_id=owner_id,
+            event_type="saga.complete",
+            metadata=metadata,
+        )
+
+    @staticmethod
+    def _map_phase_unlocked(data: dict[str, Any]) -> Notification | None:
+        """Map a phase.unlocked event."""
+        owner_id = data.get("owner_id", "")
+        if not owner_id:
+            return None
+
+        phase_number = data.get("phase_number", "?")
+        queued_raids = data.get("queued_raids", 0)
+
+        return Notification(
+            title="Phase unlocked",
+            body=f"Phase {phase_number} unlocked, {queued_raids} raids queued.",
+            urgency=NotificationUrgency.MEDIUM,
+            owner_id=owner_id,
+            event_type="phase.unlocked",
+        )
+
+    async def _resolve_owner(self, raid_id: str) -> str:
+        """Resolve the owner_id for a raid via its parent saga."""
+        if not raid_id:
+            return ""
+        try:
+            from uuid import UUID
+
+            saga = await self._raid_repo.get_saga_for_raid(UUID(raid_id))
+            if saga is not None:
+                return saga.owner_id
+        except (ValueError, Exception):
+            logger.debug("Could not resolve owner for raid %s", raid_id)
+        return ""
+
+    async def _resolve_tracker_id(self, raid_id: str) -> str:
+        """Resolve the tracker_id for a raid."""
+        if not raid_id:
+            return ""
+        try:
+            from uuid import UUID
+
+            raid = await self._raid_repo.get_raid(UUID(raid_id))
+            if raid is not None:
+                return raid.tracker_id
+        except (ValueError, Exception):
+            logger.debug("Could not resolve tracker_id for raid %s", raid_id)
+        return ""

--- a/src/tyr/main.py
+++ b/src/tyr/main.py
@@ -21,6 +21,7 @@ from tyr.adapters.inbound.rest_integrations import (
 )
 from tyr.adapters.inbound.rest_pats import create_pats_router
 from tyr.adapters.inbound.rest_telegram_webhook import create_telegram_webhook_router
+from tyr.adapters.notification_channel_factory import NotificationChannelFactory
 from tyr.adapters.postgres_dispatcher import PostgresDispatcherRepository
 from tyr.adapters.postgres_notification_subscriptions import (
     PostgresNotificationSubscriptionRepository,
@@ -42,6 +43,7 @@ from tyr.api.sagas import resolve_git as sagas_resolve_git
 from tyr.api.sagas import resolve_raid_repo as sagas_resolve_raid_repo
 from tyr.api.tracker import create_tracker_router, resolve_trackers
 from tyr.config import Settings
+from tyr.domain.services.notification import NotificationService
 from tyr.domain.services.watcher import RaidWatcher
 from tyr.events import EventBus
 from tyr.infrastructure.database import database_pool
@@ -264,6 +266,20 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
             app.dependency_overrides[resolve_llm] = _resolve_llm
 
+            # Wire notification service
+            channel_factory = NotificationChannelFactory(integration_repo, credential_store)
+            app.state.channel_factory = channel_factory
+
+            notification_service = NotificationService(
+                event_bus=event_bus,
+                channel_factory=channel_factory,
+                raid_repo=raid_repo,
+                confidence_threshold=settings.notification.confidence_threshold,
+            )
+            app.state.notification_service = notification_service
+            if settings.notification.enabled:
+                await notification_service.start()
+
             # Wire raid completion watcher
             watcher = RaidWatcher(
                 volundr=volundr_adapter,
@@ -279,6 +295,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             yield
 
             # Lifecycle cleanup
+            await notification_service.stop()
             await telegram_reply_client.close()
             if hasattr(llm_adapter, "close"):
                 await llm_adapter.close()

--- a/src/tyr/ports/notification_channel.py
+++ b/src/tyr/ports/notification_channel.py
@@ -1,0 +1,39 @@
+"""Notification channel port — interface for outbound notification delivery."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+
+class NotificationUrgency(StrEnum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+@dataclass(frozen=True)
+class Notification:
+    """A notification to be delivered to a user."""
+
+    title: str
+    body: str
+    urgency: NotificationUrgency
+    owner_id: str
+    event_type: str
+    metadata: dict[str, str] = field(default_factory=dict)
+
+
+class NotificationChannel(ABC):
+    """Outbound notification channel (Telegram, Slack, etc.)."""
+
+    @abstractmethod
+    async def send(self, notification: Notification) -> None:
+        """Deliver a notification through this channel."""
+        ...
+
+    @abstractmethod
+    def should_notify(self, notification: Notification) -> bool:
+        """Return True if this channel should handle the given notification."""
+        ...

--- a/tests/test_tyr/test_notification_service.py
+++ b/tests/test_tyr/test_notification_service.py
@@ -850,7 +850,7 @@ class TestNotificationServiceEventMapping:
                 event="confidence.updated",
                 data={
                     "raid_id": str(raid.id),
-                    "confidence": 0.2,
+                    "score_after": 0.2,
                     "tracker_id": "NIU-600",
                 },
             )
@@ -877,7 +877,7 @@ class TestNotificationServiceEventMapping:
         await event_bus.emit(
             TyrEvent(
                 event="confidence.updated",
-                data={"raid_id": str(uuid4()), "confidence": 0.5},
+                data={"raid_id": str(uuid4()), "score_after": 0.5},
             )
         )
 

--- a/tests/test_tyr/test_notification_service.py
+++ b/tests/test_tyr/test_notification_service.py
@@ -465,7 +465,7 @@ class TestNotificationServiceLifecycle:
         event_bus = EventBus()
         factory = StubChannelFactory()
         raid_repo = StubRaidRepo()
-        service = NotificationService(event_bus, factory, raid_repo)
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
 
         assert service.running is False
         await service.start()
@@ -481,7 +481,7 @@ class TestNotificationServiceLifecycle:
         event_bus = EventBus()
         factory = StubChannelFactory()
         raid_repo = StubRaidRepo()
-        service = NotificationService(event_bus, factory, raid_repo)
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
         await service.stop()  # Should not raise
 
 
@@ -498,7 +498,7 @@ class TestNotificationServiceEventMapping:
         raid_repo.raids[raid.id] = raid
         raid_repo.saga = _make_saga(owner_id="user-1")
 
-        service = NotificationService(event_bus, factory, raid_repo)
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
         await service.start()
 
         await event_bus.emit(
@@ -535,7 +535,7 @@ class TestNotificationServiceEventMapping:
         raid_repo.raids[raid.id] = raid
         raid_repo.saga = _make_saga(owner_id="user-1")
 
-        service = NotificationService(event_bus, factory, raid_repo)
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
         await service.start()
 
         await event_bus.emit(
@@ -570,7 +570,7 @@ class TestNotificationServiceEventMapping:
         raid_repo.raids[raid.id] = raid
         raid_repo.saga = _make_saga(owner_id="user-1")
 
-        service = NotificationService(event_bus, factory, raid_repo)
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
         await service.start()
 
         await event_bus.emit(
@@ -599,7 +599,7 @@ class TestNotificationServiceEventMapping:
         raid_repo = StubRaidRepo()
         raid_repo.saga = _make_saga(owner_id="user-1")
 
-        service = NotificationService(event_bus, factory, raid_repo)
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
         await service.start()
 
         await event_bus.emit(
@@ -621,7 +621,7 @@ class TestNotificationServiceEventMapping:
         factory = StubChannelFactory(channels={"user-1": [channel]})
         raid_repo = StubRaidRepo()
 
-        service = NotificationService(event_bus, factory, raid_repo)
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
         await service.start()
 
         await event_bus.emit(TyrEvent(event="some.unknown.event", data={"foo": "bar"}))
@@ -640,7 +640,7 @@ class TestNotificationServiceEventMapping:
         raid_repo = StubRaidRepo()
         # saga is None → owner cannot be resolved
 
-        service = NotificationService(event_bus, factory, raid_repo)
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
         await service.start()
 
         await event_bus.emit(
@@ -666,7 +666,7 @@ class TestNotificationServiceEventMapping:
         raid_repo.raids[raid.id] = raid
         raid_repo.saga = _make_saga(owner_id="user-1")
 
-        service = NotificationService(event_bus, factory, raid_repo)
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
         await service.start()
 
         await event_bus.emit(
@@ -693,7 +693,7 @@ class TestNotificationServiceEventMapping:
         raid_repo.raids[raid.id] = raid
         raid_repo.saga = _make_saga(owner_id="user-1")
 
-        service = NotificationService(event_bus, factory, raid_repo)
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
         await service.start()
 
         await event_bus.emit(
@@ -720,7 +720,7 @@ class TestNotificationServiceEventMapping:
         raid_repo.raids[raid.id] = raid
         raid_repo.saga = _make_saga(owner_id="user-1")
 
-        service = NotificationService(event_bus, factory, raid_repo)
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
         await service.start()
 
         await event_bus.emit(
@@ -742,7 +742,7 @@ class TestNotificationServiceEventMapping:
         factory = StubChannelFactory(channels={"user-1": [channel]})
         raid_repo = StubRaidRepo()
 
-        service = NotificationService(event_bus, factory, raid_repo)
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
         await service.start()
 
         await event_bus.emit(
@@ -772,7 +772,7 @@ class TestNotificationServiceEventMapping:
         factory = StubChannelFactory(channels={"user-1": [channel]})
         raid_repo = StubRaidRepo()
 
-        service = NotificationService(event_bus, factory, raid_repo)
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
         await service.start()
 
         await event_bus.emit(TyrEvent(event="saga.pr_created", data={"saga_name": "X"}))
@@ -789,7 +789,7 @@ class TestNotificationServiceEventMapping:
         factory = StubChannelFactory(channels={"user-1": [channel]})
         raid_repo = StubRaidRepo()
 
-        service = NotificationService(event_bus, factory, raid_repo)
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
         await service.start()
 
         await event_bus.emit(
@@ -819,7 +819,7 @@ class TestNotificationServiceEventMapping:
         factory = StubChannelFactory(channels={"user-1": [channel]})
         raid_repo = StubRaidRepo()
 
-        service = NotificationService(event_bus, factory, raid_repo)
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
         await service.start()
 
         await event_bus.emit(
@@ -898,7 +898,7 @@ class TestNotificationServiceEventMapping:
         raid_repo.raids[raid.id] = raid
         raid_repo.saga = _make_saga(owner_id="user-1")
 
-        service = NotificationService(event_bus, factory, raid_repo)
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
         await service.start()
 
         # Emit without tracker_id in data

--- a/tests/test_tyr/test_notification_service.py
+++ b/tests/test_tyr/test_notification_service.py
@@ -1,0 +1,944 @@
+"""Tests for the notification service, channel factory, and Telegram adapter."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+
+from niuu.domain.models import IntegrationConnection, IntegrationType
+from tyr.adapters.notification_channel_factory import NotificationChannelFactory
+from tyr.adapters.telegram_notification import TelegramNotificationAdapter
+from tyr.domain.models import Phase, Raid, RaidStatus, Saga, SagaStatus
+from tyr.domain.services.notification import NotificationService
+from tyr.events import EventBus, TyrEvent
+from tyr.ports.notification_channel import (
+    Notification,
+    NotificationChannel,
+    NotificationUrgency,
+)
+from tyr.ports.raid_repository import RaidRepository
+
+from .conftest import StubCredentialStore, StubIntegrationRepo
+
+# ---------------------------------------------------------------------------
+# Fixtures / Stubs
+# ---------------------------------------------------------------------------
+
+NOW = datetime.now(UTC)
+
+
+class RecordingChannel(NotificationChannel):
+    """In-memory channel that records sent notifications."""
+
+    def __init__(self, *, min_urgency: NotificationUrgency = NotificationUrgency.LOW) -> None:
+        self.sent: list[Notification] = []
+        self._min_urgency = min_urgency
+        self._urgency_rank = {
+            NotificationUrgency.LOW: 0,
+            NotificationUrgency.MEDIUM: 1,
+            NotificationUrgency.HIGH: 2,
+        }
+
+    def should_notify(self, notification: Notification) -> bool:
+        return (
+            self._urgency_rank.get(notification.urgency, 0) >= self._urgency_rank[self._min_urgency]
+        )
+
+    async def send(self, notification: Notification) -> None:
+        self.sent.append(notification)
+
+
+class FailingChannel(NotificationChannel):
+    """Channel that always raises on send."""
+
+    def should_notify(self, notification: Notification) -> bool:
+        return True
+
+    async def send(self, notification: Notification) -> None:
+        raise RuntimeError("Channel failed")
+
+
+class StubRaidRepo(RaidRepository):
+    """In-memory raid repository for notification tests."""
+
+    def __init__(self) -> None:
+        self.raids: dict[UUID, Raid] = {}
+        self.saga: Saga | None = None
+
+    async def get_raid(self, raid_id: UUID) -> Raid | None:
+        return self.raids.get(raid_id)
+
+    async def update_raid_status(
+        self, raid_id: UUID, status: RaidStatus, **kwargs: object
+    ) -> Raid | None:
+        raise NotImplementedError
+
+    async def list_by_status(self, status: RaidStatus) -> list[Raid]:
+        return [r for r in self.raids.values() if r.status == status]
+
+    async def update_raid_completion(self, raid_id: UUID, **kwargs: object) -> Raid | None:
+        raise NotImplementedError
+
+    async def get_confidence_events(self, raid_id: UUID) -> list:
+        return []
+
+    async def add_confidence_event(self, event: object) -> None:
+        pass
+
+    async def find_raid_by_tracker_id(self, tracker_id: str) -> Raid | None:
+        for raid in self.raids.values():
+            if raid.tracker_id == tracker_id:
+                return raid
+        return None
+
+    async def get_saga_for_raid(self, raid_id: UUID) -> Saga | None:
+        return self.saga
+
+    async def get_phase_for_raid(self, raid_id: UUID) -> Phase | None:
+        return None
+
+    async def save_phase(self, phase: object, *, conn: object = None) -> None:
+        pass
+
+    async def save_raid(self, raid: object, *, conn: object = None) -> None:
+        pass
+
+    async def all_raids_merged(self, phase_id: UUID) -> bool:
+        return False
+
+
+class StubChannelFactory(NotificationChannelFactory):
+    """Factory that returns pre-configured channels."""
+
+    def __init__(self, channels: dict[str, list[NotificationChannel]] | None = None) -> None:
+        self._channels = channels or {}
+
+    async def for_owner(self, owner_id: str) -> list[NotificationChannel]:
+        return self._channels.get(owner_id, [])
+
+
+def _make_raid(
+    raid_id: UUID | None = None,
+    status: RaidStatus = RaidStatus.REVIEW,
+    tracker_id: str = "NIU-100",
+    pr_url: str | None = None,
+) -> Raid:
+    return Raid(
+        id=raid_id or uuid4(),
+        phase_id=uuid4(),
+        tracker_id=tracker_id,
+        name="Test raid",
+        description="Implement feature",
+        acceptance_criteria=["tests pass"],
+        declared_files=["src/main.py"],
+        estimate_hours=2.0,
+        status=status,
+        confidence=0.5,
+        session_id="session-1",
+        branch="raid/test",
+        chronicle_summary=None,
+        pr_url=pr_url,
+        pr_id=None,
+        retry_count=0,
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+
+def _make_saga(owner_id: str = "user-1") -> Saga:
+    return Saga(
+        id=uuid4(),
+        tracker_id="proj-1",
+        tracker_type="mock",
+        slug="alpha",
+        name="Test Saga",
+        repos=["org/repo"],
+        feature_branch="feat/test",
+        status=SagaStatus.ACTIVE,
+        confidence=0.5,
+        created_at=NOW,
+        owner_id=owner_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# NotificationChannel port tests
+# ---------------------------------------------------------------------------
+
+
+class TestNotificationModel:
+    def test_notification_fields(self) -> None:
+        n = Notification(
+            title="Test",
+            body="Body text",
+            urgency=NotificationUrgency.HIGH,
+            owner_id="user-1",
+            event_type="raid.review",
+        )
+        assert n.title == "Test"
+        assert n.urgency == NotificationUrgency.HIGH
+        assert n.metadata == {}
+
+    def test_notification_with_metadata(self) -> None:
+        n = Notification(
+            title="Test",
+            body="Body",
+            urgency=NotificationUrgency.LOW,
+            owner_id="user-1",
+            event_type="raid.merged",
+            metadata={"pr_url": "https://example.com"},
+        )
+        assert n.metadata["pr_url"] == "https://example.com"
+
+
+class TestNotificationUrgency:
+    def test_urgency_values(self) -> None:
+        assert NotificationUrgency.LOW == "low"
+        assert NotificationUrgency.MEDIUM == "medium"
+        assert NotificationUrgency.HIGH == "high"
+
+
+# ---------------------------------------------------------------------------
+# TelegramNotificationAdapter tests
+# ---------------------------------------------------------------------------
+
+
+class TestTelegramNotificationAdapter:
+    def test_should_notify_all_urgencies(self) -> None:
+        adapter = TelegramNotificationAdapter(bot_token="tok", chat_id="123", min_urgency="low")
+        for urgency in NotificationUrgency:
+            n = Notification(title="T", body="B", urgency=urgency, owner_id="u", event_type="e")
+            assert adapter.should_notify(n) is True
+
+    def test_should_notify_medium_filter(self) -> None:
+        adapter = TelegramNotificationAdapter(bot_token="tok", chat_id="123", min_urgency="medium")
+        low = Notification(
+            title="T", body="B", urgency=NotificationUrgency.LOW, owner_id="u", event_type="e"
+        )
+        medium = Notification(
+            title="T", body="B", urgency=NotificationUrgency.MEDIUM, owner_id="u", event_type="e"
+        )
+        high = Notification(
+            title="T", body="B", urgency=NotificationUrgency.HIGH, owner_id="u", event_type="e"
+        )
+        assert adapter.should_notify(low) is False
+        assert adapter.should_notify(medium) is True
+        assert adapter.should_notify(high) is True
+
+    def test_should_notify_high_filter(self) -> None:
+        adapter = TelegramNotificationAdapter(bot_token="tok", chat_id="123", min_urgency="high")
+        low = Notification(
+            title="T", body="B", urgency=NotificationUrgency.LOW, owner_id="u", event_type="e"
+        )
+        high = Notification(
+            title="T", body="B", urgency=NotificationUrgency.HIGH, owner_id="u", event_type="e"
+        )
+        assert adapter.should_notify(low) is False
+        assert adapter.should_notify(high) is True
+
+    def test_format_message_basic(self) -> None:
+        n = Notification(
+            title="Raid ready",
+            body="Raid NIU-100 is ready.",
+            urgency=NotificationUrgency.HIGH,
+            owner_id="u",
+            event_type="raid.review",
+        )
+        msg = TelegramNotificationAdapter._format_message(n)
+        assert "*Raid ready*" in msg
+        assert "Raid NIU-100 is ready." in msg
+
+    def test_format_message_with_pr_url(self) -> None:
+        n = Notification(
+            title="Raid ready",
+            body="Raid NIU-100 is ready.",
+            urgency=NotificationUrgency.HIGH,
+            owner_id="u",
+            event_type="raid.review",
+            metadata={"pr_url": "https://github.com/org/repo/pull/42"},
+        )
+        msg = TelegramNotificationAdapter._format_message(n)
+        assert "[View PR](https://github.com/org/repo/pull/42)" in msg
+
+    def test_format_message_with_tracker_id(self) -> None:
+        n = Notification(
+            title="Raid ready",
+            body="Raid NIU-100 is ready.",
+            urgency=NotificationUrgency.HIGH,
+            owner_id="u",
+            event_type="raid.review",
+            metadata={"tracker_id": "NIU-100"},
+        )
+        msg = TelegramNotificationAdapter._format_message(n)
+        assert "Ticket: NIU-100" in msg
+
+    @pytest.mark.asyncio
+    async def test_send_no_bot_token(self) -> None:
+        """Send with empty bot_token should not raise."""
+        adapter = TelegramNotificationAdapter(bot_token="", chat_id="123")
+        n = Notification(
+            title="T", body="B", urgency=NotificationUrgency.HIGH, owner_id="u", event_type="e"
+        )
+        await adapter.send(n)  # Should not raise
+
+    @pytest.mark.asyncio
+    async def test_send_http_error_does_not_raise(self) -> None:
+        """HTTP errors should be logged, not raised."""
+        import respx
+
+        with respx.mock:
+            respx.post("https://api.telegram.org/bottok/sendMessage").respond(500)
+            adapter = TelegramNotificationAdapter(bot_token="tok", chat_id="123")
+            n = Notification(
+                title="T", body="B", urgency=NotificationUrgency.HIGH, owner_id="u", event_type="e"
+            )
+            await adapter.send(n)  # Should not raise
+            await adapter.close()
+
+    @pytest.mark.asyncio
+    async def test_send_success(self) -> None:
+        """Successful send should call Telegram API."""
+        import respx
+
+        with respx.mock:
+            route = respx.post("https://api.telegram.org/bottok123/sendMessage").respond(
+                200, json={"ok": True}
+            )
+            adapter = TelegramNotificationAdapter(bot_token="tok123", chat_id="456")
+            n = Notification(
+                title="Raid ready",
+                body="Raid NIU-100 is ready.",
+                urgency=NotificationUrgency.HIGH,
+                owner_id="u",
+                event_type="raid.review",
+            )
+            await adapter.send(n)
+
+            assert route.called
+            await adapter.close()
+
+    @pytest.mark.asyncio
+    async def test_send_connection_error_does_not_raise(self) -> None:
+        """Connection errors should be caught, not raised."""
+        import respx
+
+        with respx.mock:
+            respx.post("https://api.telegram.org/bottok/sendMessage").mock(
+                side_effect=httpx.ConnectError("Connection refused")
+            )
+            adapter = TelegramNotificationAdapter(bot_token="tok", chat_id="123")
+            n = Notification(
+                title="T", body="B", urgency=NotificationUrgency.HIGH, owner_id="u", event_type="e"
+            )
+            await adapter.send(n)  # Should not raise
+            await adapter.close()
+
+
+# ---------------------------------------------------------------------------
+# NotificationChannelFactory tests
+# ---------------------------------------------------------------------------
+
+
+class TestNotificationChannelFactory:
+    @pytest.mark.asyncio
+    async def test_no_connections(self) -> None:
+        repo = StubIntegrationRepo()
+        cred_store = StubCredentialStore()
+        factory = NotificationChannelFactory(repo, cred_store)
+        channels = await factory.for_owner("user-1")
+        assert channels == []
+
+    @pytest.mark.asyncio
+    async def test_disabled_connection_skipped(self) -> None:
+        conn = IntegrationConnection(
+            id="conn-1",
+            owner_id="user-1",
+            integration_type=IntegrationType.MESSAGING,
+            adapter="tyr.adapters.telegram_notification.TelegramNotificationAdapter",
+            credential_name="tg-cred",
+            config={"chat_id": "123"},
+            enabled=False,
+            created_at=NOW,
+            updated_at=NOW,
+        )
+        repo = StubIntegrationRepo(connections=[conn])
+        cred_store = StubCredentialStore(values={"user:user-1:tg-cred": {"bot_token": "tok"}})
+        factory = NotificationChannelFactory(repo, cred_store)
+        channels = await factory.for_owner("user-1")
+        assert channels == []
+
+    @pytest.mark.asyncio
+    async def test_missing_credential_skipped(self) -> None:
+        conn = IntegrationConnection(
+            id="conn-1",
+            owner_id="user-1",
+            integration_type=IntegrationType.MESSAGING,
+            adapter="tyr.adapters.telegram_notification.TelegramNotificationAdapter",
+            credential_name="tg-cred",
+            config={"chat_id": "123"},
+            enabled=True,
+            created_at=NOW,
+            updated_at=NOW,
+        )
+        repo = StubIntegrationRepo(connections=[conn])
+        cred_store = StubCredentialStore()  # No credentials
+        factory = NotificationChannelFactory(repo, cred_store)
+        channels = await factory.for_owner("user-1")
+        assert channels == []
+
+    @pytest.mark.asyncio
+    async def test_valid_connection_creates_adapter(self) -> None:
+        conn = IntegrationConnection(
+            id="conn-1",
+            owner_id="user-1",
+            integration_type=IntegrationType.MESSAGING,
+            adapter="tyr.adapters.telegram_notification.TelegramNotificationAdapter",
+            credential_name="tg-cred",
+            config={"chat_id": "123"},
+            enabled=True,
+            created_at=NOW,
+            updated_at=NOW,
+        )
+        repo = StubIntegrationRepo(connections=[conn])
+        cred_store = StubCredentialStore(values={"user:user-1:tg-cred": {"bot_token": "tok"}})
+        factory = NotificationChannelFactory(repo, cred_store)
+        channels = await factory.for_owner("user-1")
+        assert len(channels) == 1
+        assert isinstance(channels[0], TelegramNotificationAdapter)
+
+    @pytest.mark.asyncio
+    async def test_invalid_adapter_path_skipped(self) -> None:
+        conn = IntegrationConnection(
+            id="conn-1",
+            owner_id="user-1",
+            integration_type=IntegrationType.MESSAGING,
+            adapter="nonexistent.module.Adapter",
+            credential_name="cred",
+            config={},
+            enabled=True,
+            created_at=NOW,
+            updated_at=NOW,
+        )
+        repo = StubIntegrationRepo(connections=[conn])
+        cred_store = StubCredentialStore(values={"user:user-1:cred": {"key": "val"}})
+        factory = NotificationChannelFactory(repo, cred_store)
+        channels = await factory.for_owner("user-1")
+        assert channels == []
+
+    @pytest.mark.asyncio
+    async def test_multiple_connections(self) -> None:
+        conns = [
+            IntegrationConnection(
+                id=f"conn-{i}",
+                owner_id="user-1",
+                integration_type=IntegrationType.MESSAGING,
+                adapter="tyr.adapters.telegram_notification.TelegramNotificationAdapter",
+                credential_name=f"tg-cred-{i}",
+                config={"chat_id": f"chat-{i}"},
+                enabled=True,
+                created_at=NOW,
+                updated_at=NOW,
+            )
+            for i in range(3)
+        ]
+        repo = StubIntegrationRepo(connections=conns)
+        cred_store = StubCredentialStore(
+            values={f"user:user-1:tg-cred-{i}": {"bot_token": f"tok-{i}"} for i in range(3)}
+        )
+        factory = NotificationChannelFactory(repo, cred_store)
+        channels = await factory.for_owner("user-1")
+        assert len(channels) == 3
+
+
+# ---------------------------------------------------------------------------
+# NotificationService tests
+# ---------------------------------------------------------------------------
+
+
+class TestNotificationServiceLifecycle:
+    @pytest.mark.asyncio
+    async def test_start_stop(self) -> None:
+        event_bus = EventBus()
+        factory = StubChannelFactory()
+        raid_repo = StubRaidRepo()
+        service = NotificationService(event_bus, factory, raid_repo)
+
+        assert service.running is False
+        await service.start()
+        assert service.running is True
+        assert event_bus.client_count == 1
+
+        await service.stop()
+        assert service.running is False
+        assert event_bus.client_count == 0
+
+    @pytest.mark.asyncio
+    async def test_stop_when_not_started(self) -> None:
+        event_bus = EventBus()
+        factory = StubChannelFactory()
+        raid_repo = StubRaidRepo()
+        service = NotificationService(event_bus, factory, raid_repo)
+        await service.stop()  # Should not raise
+
+
+class TestNotificationServiceEventMapping:
+    @pytest.mark.asyncio
+    async def test_raid_review_notification(self) -> None:
+        """raid.state_changed → REVIEW should produce a HIGH urgency notification."""
+        event_bus = EventBus()
+        channel = RecordingChannel()
+        factory = StubChannelFactory(channels={"user-1": [channel]})
+        raid_repo = StubRaidRepo()
+
+        raid = _make_raid(tracker_id="NIU-200")
+        raid_repo.raids[raid.id] = raid
+        raid_repo.saga = _make_saga(owner_id="user-1")
+
+        service = NotificationService(event_bus, factory, raid_repo)
+        await service.start()
+
+        await event_bus.emit(
+            TyrEvent(
+                event="raid.state_changed",
+                data={
+                    "raid_id": str(raid.id),
+                    "status": "REVIEW",
+                    "tracker_id": "NIU-200",
+                    "pr_url": "https://github.com/org/repo/pull/1",
+                },
+            )
+        )
+
+        # Give the background task time to process
+        await asyncio.sleep(0.1)
+        await service.stop()
+
+        assert len(channel.sent) == 1
+        n = channel.sent[0]
+        assert n.urgency == NotificationUrgency.HIGH
+        assert "NIU-200" in n.body
+        assert n.owner_id == "user-1"
+        assert n.metadata.get("pr_url") == "https://github.com/org/repo/pull/1"
+
+    @pytest.mark.asyncio
+    async def test_raid_failed_notification(self) -> None:
+        event_bus = EventBus()
+        channel = RecordingChannel()
+        factory = StubChannelFactory(channels={"user-1": [channel]})
+        raid_repo = StubRaidRepo()
+
+        raid = _make_raid(tracker_id="NIU-201", status=RaidStatus.FAILED)
+        raid_repo.raids[raid.id] = raid
+        raid_repo.saga = _make_saga(owner_id="user-1")
+
+        service = NotificationService(event_bus, factory, raid_repo)
+        await service.start()
+
+        await event_bus.emit(
+            TyrEvent(
+                event="raid.state_changed",
+                data={
+                    "raid_id": str(raid.id),
+                    "status": "FAILED",
+                    "tracker_id": "NIU-201",
+                    "retry_count": 2,
+                },
+            )
+        )
+
+        await asyncio.sleep(0.1)
+        await service.stop()
+
+        assert len(channel.sent) == 1
+        n = channel.sent[0]
+        assert n.urgency == NotificationUrgency.HIGH
+        assert "failed" in n.title.lower()
+        assert "NIU-201" in n.body
+
+    @pytest.mark.asyncio
+    async def test_raid_merged_notification(self) -> None:
+        event_bus = EventBus()
+        channel = RecordingChannel()
+        factory = StubChannelFactory(channels={"user-1": [channel]})
+        raid_repo = StubRaidRepo()
+
+        raid = _make_raid(tracker_id="NIU-202", status=RaidStatus.MERGED)
+        raid_repo.raids[raid.id] = raid
+        raid_repo.saga = _make_saga(owner_id="user-1")
+
+        service = NotificationService(event_bus, factory, raid_repo)
+        await service.start()
+
+        await event_bus.emit(
+            TyrEvent(
+                event="raid.state_changed",
+                data={
+                    "raid_id": str(raid.id),
+                    "status": "MERGED",
+                    "tracker_id": "NIU-202",
+                },
+            )
+        )
+
+        await asyncio.sleep(0.1)
+        await service.stop()
+
+        assert len(channel.sent) == 1
+        assert channel.sent[0].urgency == NotificationUrgency.LOW
+
+    @pytest.mark.asyncio
+    async def test_unmapped_status_ignored(self) -> None:
+        """Events with statuses not in the mapping should be ignored."""
+        event_bus = EventBus()
+        channel = RecordingChannel()
+        factory = StubChannelFactory(channels={"user-1": [channel]})
+        raid_repo = StubRaidRepo()
+        raid_repo.saga = _make_saga(owner_id="user-1")
+
+        service = NotificationService(event_bus, factory, raid_repo)
+        await service.start()
+
+        await event_bus.emit(
+            TyrEvent(
+                event="raid.state_changed",
+                data={"raid_id": str(uuid4()), "status": "RUNNING"},
+            )
+        )
+
+        await asyncio.sleep(0.1)
+        await service.stop()
+
+        assert len(channel.sent) == 0
+
+    @pytest.mark.asyncio
+    async def test_unknown_event_type_ignored(self) -> None:
+        event_bus = EventBus()
+        channel = RecordingChannel()
+        factory = StubChannelFactory(channels={"user-1": [channel]})
+        raid_repo = StubRaidRepo()
+
+        service = NotificationService(event_bus, factory, raid_repo)
+        await service.start()
+
+        await event_bus.emit(TyrEvent(event="some.unknown.event", data={"foo": "bar"}))
+
+        await asyncio.sleep(0.1)
+        await service.stop()
+
+        assert len(channel.sent) == 0
+
+    @pytest.mark.asyncio
+    async def test_no_owner_found_skips_notification(self) -> None:
+        """Events where owner cannot be resolved should be skipped."""
+        event_bus = EventBus()
+        channel = RecordingChannel()
+        factory = StubChannelFactory(channels={"user-1": [channel]})
+        raid_repo = StubRaidRepo()
+        # saga is None → owner cannot be resolved
+
+        service = NotificationService(event_bus, factory, raid_repo)
+        await service.start()
+
+        await event_bus.emit(
+            TyrEvent(
+                event="raid.state_changed",
+                data={"raid_id": str(uuid4()), "status": "REVIEW"},
+            )
+        )
+
+        await asyncio.sleep(0.1)
+        await service.stop()
+
+        assert len(channel.sent) == 0
+
+    @pytest.mark.asyncio
+    async def test_no_channels_configured(self) -> None:
+        """If owner has no channels, notification is silently dropped."""
+        event_bus = EventBus()
+        factory = StubChannelFactory()  # No channels for anyone
+        raid_repo = StubRaidRepo()
+
+        raid = _make_raid(tracker_id="NIU-300")
+        raid_repo.raids[raid.id] = raid
+        raid_repo.saga = _make_saga(owner_id="user-1")
+
+        service = NotificationService(event_bus, factory, raid_repo)
+        await service.start()
+
+        await event_bus.emit(
+            TyrEvent(
+                event="raid.state_changed",
+                data={"raid_id": str(raid.id), "status": "REVIEW", "tracker_id": "NIU-300"},
+            )
+        )
+
+        await asyncio.sleep(0.1)
+        await service.stop()
+        # No assertion needed — just verifying no crash
+
+    @pytest.mark.asyncio
+    async def test_channel_send_error_does_not_crash(self) -> None:
+        """If a channel fails to send, other channels still get notified."""
+        event_bus = EventBus()
+        failing = FailingChannel()
+        recording = RecordingChannel()
+        factory = StubChannelFactory(channels={"user-1": [failing, recording]})
+        raid_repo = StubRaidRepo()
+
+        raid = _make_raid(tracker_id="NIU-400")
+        raid_repo.raids[raid.id] = raid
+        raid_repo.saga = _make_saga(owner_id="user-1")
+
+        service = NotificationService(event_bus, factory, raid_repo)
+        await service.start()
+
+        await event_bus.emit(
+            TyrEvent(
+                event="raid.state_changed",
+                data={"raid_id": str(raid.id), "status": "REVIEW", "tracker_id": "NIU-400"},
+            )
+        )
+
+        await asyncio.sleep(0.1)
+        await service.stop()
+
+        assert len(recording.sent) == 1
+
+    @pytest.mark.asyncio
+    async def test_urgency_filter_respected(self) -> None:
+        """Channel with high min_urgency should skip low notifications."""
+        event_bus = EventBus()
+        channel = RecordingChannel(min_urgency=NotificationUrgency.HIGH)
+        factory = StubChannelFactory(channels={"user-1": [channel]})
+        raid_repo = StubRaidRepo()
+
+        raid = _make_raid(tracker_id="NIU-500", status=RaidStatus.MERGED)
+        raid_repo.raids[raid.id] = raid
+        raid_repo.saga = _make_saga(owner_id="user-1")
+
+        service = NotificationService(event_bus, factory, raid_repo)
+        await service.start()
+
+        await event_bus.emit(
+            TyrEvent(
+                event="raid.state_changed",
+                data={"raid_id": str(raid.id), "status": "MERGED", "tracker_id": "NIU-500"},
+            )
+        )
+
+        await asyncio.sleep(0.1)
+        await service.stop()
+
+        assert len(channel.sent) == 0
+
+    @pytest.mark.asyncio
+    async def test_saga_pr_created_notification(self) -> None:
+        event_bus = EventBus()
+        channel = RecordingChannel()
+        factory = StubChannelFactory(channels={"user-1": [channel]})
+        raid_repo = StubRaidRepo()
+
+        service = NotificationService(event_bus, factory, raid_repo)
+        await service.start()
+
+        await event_bus.emit(
+            TyrEvent(
+                event="saga.pr_created",
+                data={
+                    "owner_id": "user-1",
+                    "saga_name": "Auth rewrite",
+                    "pr_url": "https://github.com/org/repo/pull/99",
+                },
+            )
+        )
+
+        await asyncio.sleep(0.1)
+        await service.stop()
+
+        assert len(channel.sent) == 1
+        n = channel.sent[0]
+        assert n.urgency == NotificationUrgency.HIGH
+        assert "Auth rewrite" in n.body
+        assert n.metadata.get("pr_url") == "https://github.com/org/repo/pull/99"
+
+    @pytest.mark.asyncio
+    async def test_saga_pr_created_no_owner(self) -> None:
+        event_bus = EventBus()
+        channel = RecordingChannel()
+        factory = StubChannelFactory(channels={"user-1": [channel]})
+        raid_repo = StubRaidRepo()
+
+        service = NotificationService(event_bus, factory, raid_repo)
+        await service.start()
+
+        await event_bus.emit(TyrEvent(event="saga.pr_created", data={"saga_name": "X"}))
+
+        await asyncio.sleep(0.1)
+        await service.stop()
+
+        assert len(channel.sent) == 0
+
+    @pytest.mark.asyncio
+    async def test_phase_unlocked_notification(self) -> None:
+        event_bus = EventBus()
+        channel = RecordingChannel()
+        factory = StubChannelFactory(channels={"user-1": [channel]})
+        raid_repo = StubRaidRepo()
+
+        service = NotificationService(event_bus, factory, raid_repo)
+        await service.start()
+
+        await event_bus.emit(
+            TyrEvent(
+                event="phase.unlocked",
+                data={
+                    "owner_id": "user-1",
+                    "phase_number": 2,
+                    "queued_raids": 5,
+                },
+            )
+        )
+
+        await asyncio.sleep(0.1)
+        await service.stop()
+
+        assert len(channel.sent) == 1
+        n = channel.sent[0]
+        assert n.urgency == NotificationUrgency.MEDIUM
+        assert "Phase 2" in n.body
+        assert "5 raids" in n.body
+
+    @pytest.mark.asyncio
+    async def test_phase_unlocked_no_owner(self) -> None:
+        event_bus = EventBus()
+        channel = RecordingChannel()
+        factory = StubChannelFactory(channels={"user-1": [channel]})
+        raid_repo = StubRaidRepo()
+
+        service = NotificationService(event_bus, factory, raid_repo)
+        await service.start()
+
+        await event_bus.emit(
+            TyrEvent(event="phase.unlocked", data={"phase_number": 1, "queued_raids": 3})
+        )
+
+        await asyncio.sleep(0.1)
+        await service.stop()
+
+        assert len(channel.sent) == 0
+
+    @pytest.mark.asyncio
+    async def test_confidence_below_threshold(self) -> None:
+        event_bus = EventBus()
+        channel = RecordingChannel()
+        factory = StubChannelFactory(channels={"user-1": [channel]})
+        raid_repo = StubRaidRepo()
+
+        raid = _make_raid(tracker_id="NIU-600")
+        raid_repo.raids[raid.id] = raid
+        raid_repo.saga = _make_saga(owner_id="user-1")
+
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
+        await service.start()
+
+        await event_bus.emit(
+            TyrEvent(
+                event="confidence.updated",
+                data={
+                    "raid_id": str(raid.id),
+                    "confidence": 0.2,
+                    "tracker_id": "NIU-600",
+                },
+            )
+        )
+
+        await asyncio.sleep(0.1)
+        await service.stop()
+
+        assert len(channel.sent) == 1
+        n = channel.sent[0]
+        assert n.urgency == NotificationUrgency.MEDIUM
+        assert "20%" in n.body
+
+    @pytest.mark.asyncio
+    async def test_confidence_above_threshold_ignored(self) -> None:
+        event_bus = EventBus()
+        channel = RecordingChannel()
+        factory = StubChannelFactory(channels={"user-1": [channel]})
+        raid_repo = StubRaidRepo()
+
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
+        await service.start()
+
+        await event_bus.emit(
+            TyrEvent(
+                event="confidence.updated",
+                data={"raid_id": str(uuid4()), "confidence": 0.5},
+            )
+        )
+
+        await asyncio.sleep(0.1)
+        await service.stop()
+
+        assert len(channel.sent) == 0
+
+    @pytest.mark.asyncio
+    async def test_tracker_id_resolved_from_raid(self) -> None:
+        """When event data lacks tracker_id, resolve from raid repo."""
+        event_bus = EventBus()
+        channel = RecordingChannel()
+        factory = StubChannelFactory(channels={"user-1": [channel]})
+        raid_repo = StubRaidRepo()
+
+        raid = _make_raid(tracker_id="NIU-700")
+        raid_repo.raids[raid.id] = raid
+        raid_repo.saga = _make_saga(owner_id="user-1")
+
+        service = NotificationService(event_bus, factory, raid_repo)
+        await service.start()
+
+        # Emit without tracker_id in data
+        await event_bus.emit(
+            TyrEvent(
+                event="raid.state_changed",
+                data={"raid_id": str(raid.id), "status": "REVIEW"},
+            )
+        )
+
+        await asyncio.sleep(0.1)
+        await service.stop()
+
+        assert len(channel.sent) == 1
+        assert "NIU-700" in channel.sent[0].body
+
+
+# ---------------------------------------------------------------------------
+# Config tests
+# ---------------------------------------------------------------------------
+
+
+class TestNotificationConfig:
+    def test_defaults(self) -> None:
+        from tyr.config import NotificationConfig
+
+        cfg = NotificationConfig()
+        assert cfg.enabled is True
+        assert cfg.confidence_threshold == 0.3
+
+    def test_custom(self) -> None:
+        from tyr.config import NotificationConfig
+
+        cfg = NotificationConfig(enabled=False, confidence_threshold=0.5)
+        assert cfg.enabled is False
+        assert cfg.confidence_threshold == 0.5
+
+    def test_settings_includes_notification(self) -> None:
+        from tyr.config import Settings
+
+        s = Settings()
+        assert hasattr(s, "notification")
+        assert s.notification.enabled is True


### PR DESCRIPTION
## Summary

- **NotificationChannel port** — abstract interface for outbound notification delivery with `Notification` model and `NotificationUrgency` levels (low/medium/high)
- **TelegramNotificationAdapter** — sends formatted Markdown messages via Telegram Bot API with urgency-based filtering and PR link embedding
- **NotificationChannelFactory** — resolves per-user notification channels from `IntegrationConnection` records using the dynamic adapter pattern (same as tracker/credential adapters)
- **NotificationService** — background task that subscribes to `EventBus` events and dispatches notifications to configured channels:
  - `raid.state_changed` → REVIEW (high), FAILED (high), MERGED (low)
  - `confidence.updated` → alert when confidence drops below configurable threshold (medium)
  - `saga.pr_created` → saga completion with PR link (high)
  - `phase.unlocked` → phase progress notification (medium)
- **NotificationConfig** in `Settings` — `enabled` flag and `confidence_threshold`
- **Wired into `main.py` lifespan** with proper start/stop lifecycle and cleanup

## Test plan

- [x] 40 new tests covering all components (port, adapter, factory, service, config)
- [x] Tyr test suite passes: 630 tests, 92% coverage (threshold: 85%)
- [x] Ruff lint + format clean
- [x] Urgency filtering verified (channels respect min_urgency threshold)
- [x] Error resilience verified (failing channels don't block others, missing owners/channels gracefully skip)
- [x] Per-user channel resolution from IntegrationConnections (dynamic adapter pattern)

Closes NIU-240

🤖 Generated with [Claude Code](https://claude.com/claude-code)