### PR TITLE
feat(tyr): EventBusPort + notification service with hexagonal adapter pattern

### DIFF
--- a/src/tyr/adapters/memory_event_bus.py
+++ b/src/tyr/adapters/memory_event_bus.py
@@ -1,16 +1,15 @@
-"""Tyr event bus — in-process pub/sub for SSE broadcasting.
+"""In-memory event bus adapter — fan-out pub/sub using asyncio queues.
 
-Application services call ``event_bus.emit(event)`` to broadcast state changes.
-The SSE handler subscribes a per-client queue and streams events to the browser.
+This is the default EventBusPort implementation. Each subscriber gets a
+dedicated ``asyncio.Queue``; ``emit`` fans out to all queues.  State-type
+events are cached and replayed to new subscribers as an initial snapshot.
 """
 
 from __future__ import annotations
 
 import asyncio
-import json
-import uuid
-from dataclasses import dataclass, field
-from typing import Any
+
+from tyr.ports.event_bus import EventBusPort, TyrEvent
 
 # Event types that represent current persistent state.
 # These are cached and replayed to new subscribers as an initial snapshot,
@@ -18,20 +17,7 @@ from typing import Any
 _SNAPSHOT_TYPES: frozenset[str] = frozenset({"dispatcher.state"})
 
 
-@dataclass
-class TyrEvent:
-    """A single Tyr SSE event."""
-
-    event: str
-    data: dict[str, Any]
-    id: str = field(default_factory=lambda: str(uuid.uuid4()))
-
-    def to_sse(self) -> str:
-        """Serialise as SSE wire format (id / event / data / blank line)."""
-        return f"id: {self.id}\nevent: {self.event}\ndata: {json.dumps(self.data)}\n\n"
-
-
-class EventBus:
+class InMemoryEventBus(EventBusPort):
     """In-process broadcast bus for Tyr SSE events.
 
     One queue per connected SSE client.  ``emit`` fans out to all queues.

--- a/src/tyr/adapters/notification_channel_factory.py
+++ b/src/tyr/adapters/notification_channel_factory.py
@@ -1,0 +1,64 @@
+"""Notification channel factory — resolves per-user channels from integrations."""
+
+from __future__ import annotations
+
+import logging
+
+from niuu.domain.models import IntegrationType
+from niuu.ports.credentials import CredentialStorePort
+from niuu.ports.integrations import IntegrationRepository
+from niuu.utils import import_class
+from tyr.ports.notification_channel import NotificationChannel
+
+logger = logging.getLogger(__name__)
+
+
+class NotificationChannelFactory:
+    """Resolve notification channels for a user from their integration connections.
+
+    Uses the dynamic adapter pattern: each connection specifies a fully-qualified
+    class path (e.g. ``tyr.adapters.telegram_notification.TelegramNotificationAdapter``)
+    and its config + credentials are merged as kwargs.
+    """
+
+    def __init__(
+        self,
+        integration_repo: IntegrationRepository,
+        credential_store: CredentialStorePort,
+    ) -> None:
+        self._integration_repo = integration_repo
+        self._credential_store = credential_store
+
+    async def for_owner(self, owner_id: str) -> list[NotificationChannel]:
+        """Return all active notification channels for a given owner."""
+        connections = await self._integration_repo.list_connections(
+            owner_id, integration_type=IntegrationType.MESSAGING
+        )
+
+        channels: list[NotificationChannel] = []
+        for conn in connections:
+            if not conn.enabled:
+                continue
+
+            cred = await self._credential_store.get_value("user", owner_id, conn.credential_name)
+            if cred is None:
+                logger.debug(
+                    "Skipping channel %s — credential %s not found",
+                    conn.id,
+                    conn.credential_name,
+                )
+                continue
+
+            try:
+                cls = import_class(conn.adapter)
+                channel = cls(**{**cred, **conn.config})
+                channels.append(channel)
+            except Exception:
+                logger.warning(
+                    "Failed to instantiate channel %s (%s)",
+                    conn.id,
+                    conn.adapter,
+                    exc_info=True,
+                )
+
+        return channels

--- a/src/tyr/adapters/notification_channel_factory.py
+++ b/src/tyr/adapters/notification_channel_factory.py
@@ -8,12 +8,13 @@ from niuu.domain.models import IntegrationType
 from niuu.ports.credentials import CredentialStorePort
 from niuu.ports.integrations import IntegrationRepository
 from niuu.utils import import_class
+from tyr.ports.channel_resolver import ChannelResolverPort
 from tyr.ports.notification_channel import NotificationChannel
 
 logger = logging.getLogger(__name__)
 
 
-class NotificationChannelFactory:
+class NotificationChannelFactory(ChannelResolverPort):
     """Resolve notification channels for a user from their integration connections.
 
     Uses the dynamic adapter pattern: each connection specifies a fully-qualified

--- a/src/tyr/adapters/postgres_raids.py
+++ b/src/tyr/adapters/postgres_raids.py
@@ -223,6 +223,20 @@ class PostgresRaidRepository(RaidRepository):
             return None
         return self._row_to_raid(row)
 
+    async def get_owner_for_raid(self, raid_id: UUID) -> str | None:
+        row = await self._pool.fetchrow(
+            """
+            SELECT s.owner_id FROM sagas s
+            JOIN phases p ON p.saga_id = s.id
+            JOIN raids r ON r.phase_id = p.id
+            WHERE r.id = $1
+            """,
+            raid_id,
+        )
+        if row is None:
+            return None
+        return row["owner_id"]
+
     async def all_raids_merged(self, phase_id: UUID) -> bool:
         row = await self._pool.fetchrow(
             """

--- a/src/tyr/adapters/telegram_notification.py
+++ b/src/tyr/adapters/telegram_notification.py
@@ -1,0 +1,101 @@
+"""Telegram notification adapter — sends formatted notifications via Telegram Bot API."""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from tyr.ports.notification_channel import (
+    Notification,
+    NotificationChannel,
+    NotificationUrgency,
+)
+
+logger = logging.getLogger(__name__)
+
+TELEGRAM_API = "https://api.telegram.org"
+
+_URGENCY_EMOJI = {
+    NotificationUrgency.HIGH: "\u26a0\ufe0f",
+    NotificationUrgency.MEDIUM: "\u2139\ufe0f",
+    NotificationUrgency.LOW: "\u2705",
+}
+
+
+class TelegramNotificationAdapter(NotificationChannel):
+    """Sends notifications to a Telegram chat via the Bot API."""
+
+    def __init__(
+        self,
+        bot_token: str,
+        chat_id: str,
+        *,
+        timeout: float = 10.0,
+        min_urgency: str = "low",
+    ) -> None:
+        self._bot_token = bot_token
+        self._chat_id = chat_id
+        self._client = httpx.AsyncClient(timeout=timeout)
+        self._min_urgency = NotificationUrgency(min_urgency)
+        self._urgency_rank = {
+            NotificationUrgency.LOW: 0,
+            NotificationUrgency.MEDIUM: 1,
+            NotificationUrgency.HIGH: 2,
+        }
+
+    def should_notify(self, notification: Notification) -> bool:
+        """Only notify if the urgency meets the minimum threshold."""
+        return (
+            self._urgency_rank.get(notification.urgency, 0) >= self._urgency_rank[self._min_urgency]
+        )
+
+    async def send(self, notification: Notification) -> None:
+        """Send a formatted message to the Telegram chat."""
+        if not self._bot_token:
+            logger.warning("Cannot send notification — bot_token not configured")
+            return
+
+        text = self._format_message(notification)
+        url = f"{TELEGRAM_API}/bot{self._bot_token}/sendMessage"
+        try:
+            resp = await self._client.post(
+                url,
+                json={
+                    "chat_id": self._chat_id,
+                    "text": text,
+                    "parse_mode": "Markdown",
+                },
+            )
+            if resp.status_code != 200:
+                logger.warning(
+                    "Telegram API returned %d for chat %s",
+                    resp.status_code,
+                    self._chat_id,
+                )
+        except Exception:
+            logger.warning(
+                "Failed to send Telegram notification to %s",
+                self._chat_id,
+                exc_info=True,
+            )
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client."""
+        await self._client.aclose()
+
+    @staticmethod
+    def _format_message(notification: Notification) -> str:
+        """Format a notification as a Markdown message."""
+        emoji = _URGENCY_EMOJI.get(notification.urgency, "")
+        parts = [f"{emoji} *{notification.title}*", "", notification.body]
+
+        pr_url = notification.metadata.get("pr_url")
+        if pr_url:
+            parts.append(f"\n[View PR]({pr_url})")
+
+        tracker_id = notification.metadata.get("tracker_id")
+        if tracker_id:
+            parts.append(f"Ticket: {tracker_id}")
+
+        return "\n".join(parts)

--- a/src/tyr/api/events.py
+++ b/src/tyr/api/events.py
@@ -14,12 +14,12 @@ from collections.abc import AsyncGenerator
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import StreamingResponse
 
-from tyr.events import EventBus, TyrEvent
+from tyr.ports.event_bus import EventBusPort, TyrEvent
 
 logger = logging.getLogger(__name__)
 
 
-async def resolve_event_bus() -> EventBus:  # pragma: no cover
+async def resolve_event_bus() -> EventBusPort:  # pragma: no cover
     """Dependency stub — always overridden by the app lifespan in main.py."""
     raise HTTPException(
         status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -28,7 +28,7 @@ async def resolve_event_bus() -> EventBus:  # pragma: no cover
 
 
 async def _sse_generator(
-    event_bus: EventBus,
+    event_bus: EventBusPort,
     q: asyncio.Queue[TyrEvent],
     keepalive_interval: float,
 ) -> AsyncGenerator[str, None]:
@@ -69,7 +69,7 @@ def create_events_router(keepalive_interval: float = 15.0) -> APIRouter:
     @router.get("/events", summary="SSE event stream")
     async def sse_stream(
         request: Request,  # noqa: ARG001
-        event_bus: EventBus = Depends(resolve_event_bus),
+        event_bus: EventBusPort = Depends(resolve_event_bus),
     ) -> StreamingResponse:
         """Stream all real-time Tyr state changes as Server-Sent Events.
 

--- a/src/tyr/config.py
+++ b/src/tyr/config.py
@@ -207,6 +207,26 @@ class WatcherConfig(BaseModel):
     )
 
 
+class EventBusConfig(BaseModel):
+    """Event bus adapter configuration (dynamic adapter pattern)."""
+
+    adapter: str = Field(
+        default="tyr.adapters.memory_event_bus.InMemoryEventBus",
+        description="Fully-qualified class path for the EventBus adapter.",
+    )
+    kwargs: dict[str, Any] = Field(default_factory=dict)
+
+
+class NotificationConfig(BaseModel):
+    """Notification service configuration."""
+
+    enabled: bool = Field(default=True)
+    confidence_threshold: float = Field(
+        default=0.3,
+        description="Notify when raid confidence drops below this value.",
+    )
+
+
 class EventsConfig(BaseModel):
     """SSE event stream configuration."""
 
@@ -253,8 +273,10 @@ class Settings(BaseSettings):
     cerbos: CerbosConfig = Field(default_factory=CerbosConfig)
     llm: LLMConfig = Field(default_factory=LLMConfig)
     watcher: WatcherConfig = Field(default_factory=WatcherConfig)
+    event_bus: EventBusConfig = Field(default_factory=EventBusConfig)
     events: EventsConfig = Field(default_factory=EventsConfig)
     telegram: TelegramConfig = Field(default_factory=TelegramConfig)
+    notification: NotificationConfig = Field(default_factory=NotificationConfig)
 
     @classmethod
     def settings_customise_sources(

--- a/src/tyr/domain/services/notification.py
+++ b/src/tyr/domain/services/notification.py
@@ -11,7 +11,7 @@ import asyncio
 import logging
 from typing import Any
 
-from tyr.adapters.notification_channel_factory import NotificationChannelFactory
+from tyr.ports.channel_resolver import ChannelResolverPort
 from tyr.ports.event_bus import EventBusPort, TyrEvent
 from tyr.ports.notification_channel import (
     Notification,
@@ -59,7 +59,7 @@ class NotificationService:
     def __init__(
         self,
         event_bus: EventBusPort,
-        channel_factory: NotificationChannelFactory,
+        channel_factory: ChannelResolverPort,
         raid_repo: RaidRepository,
         *,
         confidence_threshold: float,
@@ -266,15 +266,13 @@ class NotificationService:
         )
 
     async def _resolve_owner(self, raid_id: str) -> str:
-        """Resolve the owner_id for a raid via its parent saga."""
+        """Resolve the owner_id for a raid via the repository."""
         if not raid_id:
             return ""
         try:
             from uuid import UUID
 
-            saga = await self._raid_repo.get_saga_for_raid(UUID(raid_id))
-            if saga is not None:
-                return saga.owner_id
+            return await self._raid_repo.get_owner_for_raid(UUID(raid_id)) or ""
         except (ValueError, Exception):
             logger.debug("Could not resolve owner for raid %s", raid_id)
         return ""

--- a/src/tyr/domain/services/notification.py
+++ b/src/tyr/domain/services/notification.py
@@ -1,0 +1,294 @@
+"""Notification service — subscribes to EventBus and dispatches to channels.
+
+Maps domain events (raid state changes, saga completions, etc.) to
+user-facing notifications and delivers them through configured channels
+(Telegram, Slack, etc.) using the dynamic adapter pattern.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from tyr.adapters.notification_channel_factory import NotificationChannelFactory
+from tyr.ports.event_bus import EventBusPort, TyrEvent
+from tyr.ports.notification_channel import (
+    Notification,
+    NotificationUrgency,
+)
+from tyr.ports.raid_repository import RaidRepository
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Event → Notification mapping configuration
+# ---------------------------------------------------------------------------
+
+_STATUS_NOTIFICATION_MAP: dict[str, dict[str, Any]] = {
+    "REVIEW": {
+        "title": "Raid ready for review",
+        "body_template": "Raid {tracker_id} is ready for review.",
+        "urgency": NotificationUrgency.HIGH,
+    },
+    "FAILED": {
+        "title": "Raid failed",
+        "body_template": "Raid {tracker_id} failed (retry #{retry_count}).",
+        "urgency": NotificationUrgency.HIGH,
+    },
+    "MERGED": {
+        "title": "Raid merged",
+        "body_template": "Raid {tracker_id} has been merged.",
+        "urgency": NotificationUrgency.LOW,
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+
+class NotificationService:
+    """Subscribes to EventBus events and dispatches notifications to channels.
+
+    Runs as a background task alongside the main application. For each event,
+    it resolves the owning user, builds a Notification, resolves that user's
+    configured channels, and delivers.
+    """
+
+    def __init__(
+        self,
+        event_bus: EventBusPort,
+        channel_factory: NotificationChannelFactory,
+        raid_repo: RaidRepository,
+        *,
+        confidence_threshold: float,
+    ) -> None:
+        self._event_bus = event_bus
+        self._channel_factory = channel_factory
+        self._raid_repo = raid_repo
+        self._confidence_threshold = confidence_threshold
+        self._running = False
+        self._task: asyncio.Task[None] | None = None
+        self._queue: asyncio.Queue[TyrEvent] | None = None
+
+    @property
+    def running(self) -> bool:
+        return self._running
+
+    async def start(self) -> None:
+        """Start the notification background loop."""
+        self._queue = self._event_bus.subscribe()
+        self._running = True
+        self._task = asyncio.create_task(self._run(), name="notification-service")
+        logger.info("Notification service started")
+
+    async def stop(self) -> None:
+        """Gracefully stop the notification service."""
+        self._running = False
+        if self._queue is not None:
+            self._event_bus.unsubscribe(self._queue)
+            self._queue = None
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        logger.info("Notification service stopped")
+
+    async def _run(self) -> None:
+        """Main loop — consume events and dispatch notifications."""
+        while self._running:
+            try:
+                if self._queue is None:
+                    break
+                event = await asyncio.wait_for(self._queue.get(), timeout=5.0)
+                await self._handle_event(event)
+            except TimeoutError:
+                continue
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("Error processing notification event")
+
+    async def _handle_event(self, event: TyrEvent) -> None:
+        """Map an event to a notification and dispatch it."""
+        notification = await self._map_event(event)
+        if notification is None:
+            return
+
+        channels = await self._channel_factory.for_owner(notification.owner_id)
+        if not channels:
+            return
+
+        for channel in channels:
+            if not channel.should_notify(notification):
+                continue
+            try:
+                await channel.send(notification)
+            except Exception:
+                logger.warning(
+                    "Failed to send notification via %s",
+                    type(channel).__name__,
+                    exc_info=True,
+                )
+
+    async def _map_event(self, event: TyrEvent) -> Notification | None:
+        """Convert a TyrEvent into a Notification, or None if unmapped."""
+        match event.event:
+            case "raid.state_changed":
+                return await self._map_raid_state_changed(event.data)
+            case "confidence.updated":
+                return await self._map_confidence_updated(event.data)
+            case "saga.pr_created":
+                return self._map_saga_pr_created(event.data)
+            case "phase.unlocked":
+                return self._map_phase_unlocked(event.data)
+            case _:
+                return None
+
+    async def _map_raid_state_changed(self, data: dict[str, Any]) -> Notification | None:
+        """Map a raid.state_changed event to a notification."""
+        status = data.get("status", "")
+        mapping = _STATUS_NOTIFICATION_MAP.get(status)
+        if mapping is None:
+            return None
+
+        raid_id = data.get("raid_id", "")
+        tracker_id = data.get("tracker_id", "")
+        pr_url = data.get("pr_url", "")
+
+        # Resolve owner_id from the raid's parent saga
+        owner_id = await self._resolve_owner(raid_id)
+        if not owner_id:
+            return None
+
+        # Resolve tracker_id from raid if not in event data
+        if not tracker_id:
+            tracker_id = await self._resolve_tracker_id(raid_id)
+
+        retry_count = data.get("retry_count", 0)
+
+        body = mapping["body_template"].format(
+            tracker_id=tracker_id or raid_id,
+            retry_count=retry_count,
+        )
+
+        if pr_url:
+            body += f"\nPR: {pr_url}"
+
+        metadata: dict[str, str] = {}
+        if pr_url:
+            metadata["pr_url"] = pr_url
+        if tracker_id:
+            metadata["tracker_id"] = tracker_id
+
+        return Notification(
+            title=mapping["title"],
+            body=body,
+            urgency=mapping["urgency"],
+            owner_id=owner_id,
+            event_type=f"raid.{status.lower()}",
+            metadata=metadata,
+        )
+
+    async def _map_confidence_updated(self, data: dict[str, Any]) -> Notification | None:
+        """Map a confidence.updated event when confidence drops below threshold."""
+        confidence = data.get("score_after", 1.0)
+        if confidence >= self._confidence_threshold:
+            return None
+
+        raid_id = data.get("raid_id", "")
+        tracker_id = data.get("tracker_id", "")
+
+        owner_id = await self._resolve_owner(raid_id)
+        if not owner_id:
+            return None
+
+        if not tracker_id:
+            tracker_id = await self._resolve_tracker_id(raid_id)
+
+        return Notification(
+            title="Confidence dropped",
+            body=f"Raid {tracker_id or raid_id} confidence dropped to {confidence:.0%}.",
+            urgency=NotificationUrgency.MEDIUM,
+            owner_id=owner_id,
+            event_type="confidence.low",
+            metadata={"tracker_id": tracker_id} if tracker_id else {},
+        )
+
+    @staticmethod
+    def _map_saga_pr_created(data: dict[str, Any]) -> Notification | None:
+        """Map a saga.pr_created event."""
+        owner_id = data.get("owner_id", "")
+        if not owner_id:
+            return None
+
+        saga_name = data.get("saga_name", "")
+        pr_url = data.get("pr_url", "")
+
+        body = f'Saga "{saga_name}" complete — final PR ready.'
+        if pr_url:
+            body += f"\nPR: {pr_url}"
+
+        metadata: dict[str, str] = {}
+        if pr_url:
+            metadata["pr_url"] = pr_url
+
+        return Notification(
+            title="Saga complete",
+            body=body,
+            urgency=NotificationUrgency.HIGH,
+            owner_id=owner_id,
+            event_type="saga.complete",
+            metadata=metadata,
+        )
+
+    @staticmethod
+    def _map_phase_unlocked(data: dict[str, Any]) -> Notification | None:
+        """Map a phase.unlocked event."""
+        owner_id = data.get("owner_id", "")
+        if not owner_id:
+            logger.warning("phase.unlocked event missing owner_id, skipping notification")
+            return None
+
+        phase_number = data.get("phase_number", "?")
+        queued_raids = data.get("queued_raids", 0)
+
+        return Notification(
+            title="Phase unlocked",
+            body=f"Phase {phase_number} unlocked, {queued_raids} raids queued.",
+            urgency=NotificationUrgency.MEDIUM,
+            owner_id=owner_id,
+            event_type="phase.unlocked",
+        )
+
+    async def _resolve_owner(self, raid_id: str) -> str:
+        """Resolve the owner_id for a raid via its parent saga."""
+        if not raid_id:
+            return ""
+        try:
+            from uuid import UUID
+
+            saga = await self._raid_repo.get_saga_for_raid(UUID(raid_id))
+            if saga is not None:
+                return saga.owner_id
+        except (ValueError, Exception):
+            logger.debug("Could not resolve owner for raid %s", raid_id)
+        return ""
+
+    async def _resolve_tracker_id(self, raid_id: str) -> str:
+        """Resolve the tracker_id for a raid."""
+        if not raid_id:
+            return ""
+        try:
+            from uuid import UUID
+
+            raid = await self._raid_repo.get_raid(UUID(raid_id))
+            if raid is not None:
+                return raid.tracker_id
+        except (ValueError, Exception):
+            logger.debug("Could not resolve tracker_id for raid %s", raid_id)
+        return ""

--- a/src/tyr/domain/services/raid_review.py
+++ b/src/tyr/domain/services/raid_review.py
@@ -100,21 +100,11 @@ class RaidReviewService:
         self._cfg = review_config
         self._event_bus = event_bus
 
-    async def _resolve_owner(self, raid_id: UUID) -> str:
-        """Resolve the owner_id for a raid via its parent saga."""
-        try:
-            saga = await self._raid_repo.get_saga_for_raid(raid_id)
-            if saga is not None:
-                return saga.owner_id
-        except Exception:
-            logger.debug("Could not resolve owner for raid %s", raid_id)
-        return ""
-
     async def _emit_state_changed(self, raid: Raid, *, action: str) -> None:
         """Emit a raid.state_changed event if an EventBus is wired."""
         if self._event_bus is None:
             return
-        owner_id = await self._resolve_owner(raid.id)
+        owner_id = await self._raid_repo.get_owner_for_raid(raid.id) or ""
         await self._event_bus.emit(
             TyrEvent(
                 event="raid.state_changed",

--- a/src/tyr/domain/services/raid_review.py
+++ b/src/tyr/domain/services/raid_review.py
@@ -21,7 +21,7 @@ from tyr.domain.models import (
     RaidStatus,
     validate_transition,
 )
-from tyr.events import EventBus, TyrEvent
+from tyr.ports.event_bus import EventBusPort, TyrEvent
 from tyr.ports.raid_repository import RaidRepository
 
 logger = logging.getLogger(__name__)
@@ -94,19 +94,31 @@ class RaidReviewService:
         self,
         raid_repo: RaidRepository,
         review_config: ReviewConfig,
-        event_bus: EventBus | None = None,
+        event_bus: EventBusPort | None = None,
     ) -> None:
         self._raid_repo = raid_repo
         self._cfg = review_config
         self._event_bus = event_bus
 
+    async def _resolve_owner(self, raid_id: UUID) -> str:
+        """Resolve the owner_id for a raid via its parent saga."""
+        try:
+            saga = await self._raid_repo.get_saga_for_raid(raid_id)
+            if saga is not None:
+                return saga.owner_id
+        except Exception:
+            logger.debug("Could not resolve owner for raid %s", raid_id)
+        return ""
+
     async def _emit_state_changed(self, raid: Raid, *, action: str) -> None:
         """Emit a raid.state_changed event if an EventBus is wired."""
         if self._event_bus is None:
             return
+        owner_id = await self._resolve_owner(raid.id)
         await self._event_bus.emit(
             TyrEvent(
                 event="raid.state_changed",
+                owner_id=owner_id,
                 data={
                     "raid_id": str(raid.id),
                     "status": raid.status.value,

--- a/src/tyr/domain/services/session_message.py
+++ b/src/tyr/domain/services/session_message.py
@@ -19,7 +19,7 @@ from tyr.domain.models import (
     RaidStatus,
     SessionMessage,
 )
-from tyr.events import EventBus, TyrEvent
+from tyr.ports.event_bus import EventBusPort, TyrEvent
 from tyr.ports.raid_repository import RaidRepository
 from tyr.ports.volundr import VolundrPort
 
@@ -57,7 +57,7 @@ class SessionMessageService:
         self,
         raid_repo: RaidRepository,
         volundr: VolundrPort,
-        event_bus: EventBus | None = None,
+        event_bus: EventBusPort | None = None,
     ) -> None:
         self._raid_repo = raid_repo
         self._volundr = volundr

--- a/src/tyr/domain/services/watcher.py
+++ b/src/tyr/domain/services/watcher.py
@@ -244,19 +244,9 @@ class RaidWatcher:
                 raid.session_id,
             )
 
-    async def _resolve_owner(self, raid_id: object) -> str:
-        """Resolve the owner_id for a raid via its parent saga."""
-        try:
-            saga = await self._raid_repo.get_saga_for_raid(raid_id)
-            if saga is not None:
-                return saga.owner_id
-        except Exception:
-            logger.debug("Could not resolve owner for raid %s", raid_id)
-        return ""
-
     async def _emit_state_changed(self, raid: Raid) -> None:
         """Emit a raid.state_changed event via the event bus."""
-        owner_id = await self._resolve_owner(raid.id)
+        owner_id = await self._raid_repo.get_owner_for_raid(raid.id) or ""
         await self._event_bus.emit(
             TyrEvent(
                 event="raid.state_changed",

--- a/src/tyr/domain/services/watcher.py
+++ b/src/tyr/domain/services/watcher.py
@@ -12,8 +12,8 @@ from dataclasses import dataclass
 
 from tyr.config import WatcherConfig
 from tyr.domain.models import Raid, RaidStatus
-from tyr.events import EventBus, TyrEvent
 from tyr.ports.dispatcher_repository import DispatcherRepository
+from tyr.ports.event_bus import EventBusPort, TyrEvent
 from tyr.ports.raid_repository import RaidRepository
 from tyr.ports.volundr import VolundrPort, VolundrSession
 
@@ -40,7 +40,7 @@ class RaidWatcher:
         volundr: VolundrPort,
         raid_repo: RaidRepository,
         dispatcher_repo: DispatcherRepository,
-        event_bus: EventBus,
+        event_bus: EventBusPort,
         config: WatcherConfig,
     ) -> None:
         self._volundr = volundr
@@ -244,11 +244,23 @@ class RaidWatcher:
                 raid.session_id,
             )
 
+    async def _resolve_owner(self, raid_id: object) -> str:
+        """Resolve the owner_id for a raid via its parent saga."""
+        try:
+            saga = await self._raid_repo.get_saga_for_raid(raid_id)
+            if saga is not None:
+                return saga.owner_id
+        except Exception:
+            logger.debug("Could not resolve owner for raid %s", raid_id)
+        return ""
+
     async def _emit_state_changed(self, raid: Raid) -> None:
         """Emit a raid.state_changed event via the event bus."""
+        owner_id = await self._resolve_owner(raid.id)
         await self._event_bus.emit(
             TyrEvent(
                 event="raid.state_changed",
+                owner_id=owner_id,
                 data={
                     "raid_id": str(raid.id),
                     "status": raid.status.value,

--- a/src/tyr/main.py
+++ b/src/tyr/main.py
@@ -21,6 +21,7 @@ from tyr.adapters.inbound.rest_integrations import (
 )
 from tyr.adapters.inbound.rest_pats import create_pats_router
 from tyr.adapters.inbound.rest_telegram_webhook import create_telegram_webhook_router
+from tyr.adapters.notification_channel_factory import NotificationChannelFactory
 from tyr.adapters.postgres_dispatcher import PostgresDispatcherRepository
 from tyr.adapters.postgres_notification_subscriptions import (
     PostgresNotificationSubscriptionRepository,
@@ -42,10 +43,11 @@ from tyr.api.sagas import resolve_git as sagas_resolve_git
 from tyr.api.sagas import resolve_raid_repo as sagas_resolve_raid_repo
 from tyr.api.tracker import create_tracker_router, resolve_trackers
 from tyr.config import Settings
+from tyr.domain.services.notification import NotificationService
 from tyr.domain.services.watcher import RaidWatcher
-from tyr.events import EventBus
 from tyr.infrastructure.database import database_pool
 from tyr.ports.dispatcher_repository import DispatcherRepository
+from tyr.ports.event_bus import EventBusPort
 from tyr.ports.git import GitPort
 from tyr.ports.raid_repository import RaidRepository
 from tyr.ports.saga_repository import SagaRepository
@@ -228,11 +230,15 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             )
             app.state.pat_service = pat_service
 
-            # Wire event bus
-            event_bus = EventBus(max_clients=settings.events.max_sse_clients)
+            # Wire event bus (dynamic adapter pattern)
+            eb_cfg = settings.event_bus
+            eb_cls = import_class(eb_cfg.adapter)
+            eb_kwargs = {"max_clients": settings.events.max_sse_clients, **eb_cfg.kwargs}
+            event_bus: EventBusPort = eb_cls(**eb_kwargs)
             app.state.event_bus = event_bus
+            logger.info("Event bus: %s", eb_cfg.adapter.rsplit(".", 1)[-1])
 
-            async def _resolve_event_bus() -> EventBus:
+            async def _resolve_event_bus() -> EventBusPort:
                 return event_bus
 
             app.dependency_overrides[resolve_event_bus] = _resolve_event_bus
@@ -264,6 +270,20 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
             app.dependency_overrides[resolve_llm] = _resolve_llm
 
+            # Wire notification service
+            channel_factory = NotificationChannelFactory(integration_repo, credential_store)
+            app.state.channel_factory = channel_factory
+
+            notification_service = NotificationService(
+                event_bus=event_bus,
+                channel_factory=channel_factory,
+                raid_repo=raid_repo,
+                confidence_threshold=settings.notification.confidence_threshold,
+            )
+            app.state.notification_service = notification_service
+            if settings.notification.enabled:
+                await notification_service.start()
+
             # Wire raid completion watcher
             watcher = RaidWatcher(
                 volundr=volundr_adapter,
@@ -279,6 +299,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             yield
 
             # Lifecycle cleanup
+            await notification_service.stop()
             await telegram_reply_client.close()
             if hasattr(llm_adapter, "close"):
                 await llm_adapter.close()

--- a/src/tyr/ports/channel_resolver.py
+++ b/src/tyr/ports/channel_resolver.py
@@ -1,0 +1,15 @@
+"""Channel resolver port — resolves notification channels for a user."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from tyr.ports.notification_channel import NotificationChannel
+
+
+class ChannelResolverPort(ABC):
+    """Abstract resolver for per-user notification channels."""
+
+    @abstractmethod
+    async def for_owner(self, owner_id: str) -> list[NotificationChannel]:
+        """Return all active notification channels for the given owner."""

--- a/src/tyr/ports/event_bus.py
+++ b/src/tyr/ports/event_bus.py
@@ -1,0 +1,71 @@
+"""EventBus port — abstract interface for Tyr's event pub/sub system.
+
+Consumers subscribe to receive TyrEvent objects; producers emit events.
+The port is infrastructure-agnostic — the in-memory implementation lives
+in ``tyr.adapters.memory_event_bus``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class TyrEvent:
+    """A single Tyr SSE event.
+
+    Attributes:
+        event: Dot-separated event type (e.g. ``raid.state_changed``).
+        data: Arbitrary event payload.
+        owner_id: Tenant/user who owns the resource that triggered this event.
+            Empty string when the owner is unknown or the event is global.
+        id: Unique event identifier (auto-generated UUID by default).
+    """
+
+    event: str
+    data: dict[str, Any]
+    owner_id: str = ""
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+
+    def to_sse(self) -> str:
+        """Serialise as SSE wire format (id / event / data / blank line)."""
+        return f"id: {self.id}\nevent: {self.event}\ndata: {json.dumps(self.data)}\n\n"
+
+
+class EventBusPort(ABC):
+    """Abstract event bus for Tyr domain events.
+
+    Implementations must support fan-out to multiple subscribers,
+    snapshot caching for state-type events, and capacity management.
+    """
+
+    @abstractmethod
+    def subscribe(self) -> asyncio.Queue[TyrEvent]:
+        """Register a new subscriber and return its dedicated queue."""
+
+    @abstractmethod
+    def unsubscribe(self, q: asyncio.Queue[TyrEvent]) -> None:
+        """Remove a subscriber queue — safe to call even if already removed."""
+
+    @abstractmethod
+    async def emit(self, event: TyrEvent) -> None:
+        """Broadcast an event to every connected subscriber."""
+
+    @abstractmethod
+    def get_snapshot(self) -> list[TyrEvent]:
+        """Return the current state snapshot for delivery to a new subscriber."""
+
+    @property
+    @abstractmethod
+    def client_count(self) -> int:
+        """Number of currently connected subscribers."""
+
+    @property
+    @abstractmethod
+    def at_capacity(self) -> bool:
+        """True when the maximum number of subscribers is already connected."""

--- a/src/tyr/ports/notification_channel.py
+++ b/src/tyr/ports/notification_channel.py
@@ -1,0 +1,39 @@
+"""Notification channel port — abstract interface for delivering notifications."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+
+class NotificationUrgency(StrEnum):
+    """Urgency level for a notification."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+@dataclass(frozen=True)
+class Notification:
+    """A user-facing notification built from a domain event."""
+
+    title: str
+    body: str
+    urgency: NotificationUrgency
+    owner_id: str
+    event_type: str
+    metadata: dict[str, str] = field(default_factory=dict)
+
+
+class NotificationChannel(ABC):
+    """Abstract notification delivery channel (Telegram, Slack, etc.)."""
+
+    @abstractmethod
+    async def send(self, notification: Notification) -> None:
+        """Deliver a notification through this channel."""
+
+    @abstractmethod
+    def should_notify(self, notification: Notification) -> bool:
+        """Return True if this channel should deliver the given notification."""

--- a/src/tyr/ports/raid_repository.py
+++ b/src/tyr/ports/raid_repository.py
@@ -85,6 +85,14 @@ class RaidRepository(ABC):
         ...
 
     @abstractmethod
+    async def get_owner_for_raid(self, raid_id: UUID) -> str | None:
+        """Resolve the owner_id for a raid via its parent saga.
+
+        Returns the owner_id string, or None if the raid or saga is not found.
+        """
+        ...
+
+    @abstractmethod
     async def all_raids_merged(self, phase_id: UUID) -> bool:
         """Check whether every raid in the phase has status MERGED."""
         ...

--- a/tests/test_tyr/test_commit_api.py
+++ b/tests/test_tyr/test_commit_api.py
@@ -93,6 +93,9 @@ class MockRaidRepo(RaidRepository):
     ) -> Raid | None:
         return None
 
+    async def get_owner_for_raid(self, raid_id: UUID) -> str | None:
+        return None
+
     async def all_raids_merged(self, phase_id: UUID) -> bool:
         return False
 

--- a/tests/test_tyr/test_events.py
+++ b/tests/test_tyr/test_events.py
@@ -9,7 +9,7 @@ from fastapi.testclient import TestClient
 
 from tyr.adapters.memory_event_bus import InMemoryEventBus
 from tyr.api.events import _sse_generator, create_events_router, resolve_event_bus
-from tyr.ports.event_bus import TyrEvent
+from tyr.ports.event_bus import EventBusPort, TyrEvent
 
 # ---------------------------------------------------------------------------
 # TyrEvent
@@ -277,7 +277,7 @@ class TestSseGenerator:
 # ---------------------------------------------------------------------------
 
 
-def _make_app(event_bus: InMemoryEventBus, keepalive_interval: float = 30.0) -> FastAPI:
+def _make_app(event_bus: EventBusPort, keepalive_interval: float = 30.0) -> FastAPI:
     app = FastAPI()
     app.include_router(create_events_router(keepalive_interval=keepalive_interval))
     app.dependency_overrides[resolve_event_bus] = lambda: event_bus

--- a/tests/test_tyr/test_events.py
+++ b/tests/test_tyr/test_events.py
@@ -7,8 +7,9 @@ import asyncio
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from tyr.adapters.memory_event_bus import InMemoryEventBus
 from tyr.api.events import _sse_generator, create_events_router, resolve_event_bus
-from tyr.events import EventBus, TyrEvent
+from tyr.ports.event_bus import TyrEvent
 
 # ---------------------------------------------------------------------------
 # TyrEvent
@@ -50,36 +51,36 @@ class TestTyrEvent:
 
 class TestEventBus:
     def test_initial_state(self):
-        bus = EventBus(max_clients=5)
+        bus = InMemoryEventBus(max_clients=5)
         assert bus.client_count == 0
         assert not bus.at_capacity
         assert bus.get_snapshot() == []
 
     def test_subscribe_increments_count(self):
-        bus = EventBus(max_clients=5)
+        bus = InMemoryEventBus(max_clients=5)
         bus.subscribe()
         assert bus.client_count == 1
 
     def test_unsubscribe_decrements_count(self):
-        bus = EventBus(max_clients=5)
+        bus = InMemoryEventBus(max_clients=5)
         q = bus.subscribe()
         bus.unsubscribe(q)
         assert bus.client_count == 0
 
     def test_unsubscribe_nonexistent_is_noop(self):
-        bus = EventBus(max_clients=5)
+        bus = InMemoryEventBus(max_clients=5)
         orphan: asyncio.Queue = asyncio.Queue()
         bus.unsubscribe(orphan)  # must not raise
 
     def test_at_capacity_when_full(self):
-        bus = EventBus(max_clients=2)
+        bus = InMemoryEventBus(max_clients=2)
         bus.subscribe()
         assert not bus.at_capacity
         bus.subscribe()
         assert bus.at_capacity
 
     async def test_emit_puts_event_in_all_queues(self):
-        bus = EventBus(max_clients=5)
+        bus = InMemoryEventBus(max_clients=5)
         q1 = bus.subscribe()
         q2 = bus.subscribe()
         event = TyrEvent(
@@ -93,7 +94,7 @@ class TestEventBus:
         assert received is event
 
     async def test_emit_skips_unsubscribed_queues(self):
-        bus = EventBus(max_clients=5)
+        bus = InMemoryEventBus(max_clients=5)
         q = bus.subscribe()
         bus.unsubscribe(q)
         event = TyrEvent(event="session.spawned", data={})
@@ -101,7 +102,7 @@ class TestEventBus:
         assert q.qsize() == 0
 
     async def test_emit_saves_snapshot_for_state_events(self):
-        bus = EventBus(max_clients=5)
+        bus = InMemoryEventBus(max_clients=5)
         event = TyrEvent(
             event="dispatcher.state",
             data={"running": False, "threshold": 0.8, "queue_depth": 0},
@@ -112,7 +113,7 @@ class TestEventBus:
         assert snapshot[0] is event
 
     async def test_emit_does_not_snapshot_transient_events(self):
-        bus = EventBus(max_clients=5)
+        bus = InMemoryEventBus(max_clients=5)
         for ev_type in (
             "session.spawned",
             "session.stopped",
@@ -127,7 +128,7 @@ class TestEventBus:
         assert bus.get_snapshot() == []
 
     async def test_snapshot_updated_on_repeated_emit(self):
-        bus = EventBus(max_clients=5)
+        bus = InMemoryEventBus(max_clients=5)
         e1 = TyrEvent(
             event="dispatcher.state",
             data={"running": False, "threshold": 0.8, "queue_depth": 0},
@@ -143,7 +144,7 @@ class TestEventBus:
         assert snapshot[0].data["running"] is True
 
     async def test_get_snapshot_returns_copy(self):
-        bus = EventBus(max_clients=5)
+        bus = InMemoryEventBus(max_clients=5)
         await bus.emit(
             TyrEvent(
                 event="dispatcher.state",
@@ -164,7 +165,7 @@ class TestSseGenerator:
     """Tests for _sse_generator directly — no HTTP transport required."""
 
     async def test_yields_snapshot_on_start(self):
-        bus = EventBus(max_clients=5)
+        bus = InMemoryEventBus(max_clients=5)
         snap = TyrEvent(
             id="snap-1",
             event="dispatcher.state",
@@ -183,7 +184,7 @@ class TestSseGenerator:
         assert "id: snap-1" in combined
 
     async def test_yields_queued_events(self):
-        bus = EventBus(max_clients=5)
+        bus = InMemoryEventBus(max_clients=5)
         q = bus.subscribe()
         event = TyrEvent(
             id="live-1",
@@ -209,7 +210,7 @@ class TestSseGenerator:
         assert "id: live-1" in combined
 
     async def test_yields_keepalive_when_idle(self):
-        bus = EventBus(max_clients=5)
+        bus = InMemoryEventBus(max_clients=5)
         q = bus.subscribe()
 
         chunks: list[str] = []
@@ -221,7 +222,7 @@ class TestSseGenerator:
         assert ": keepalive" in "".join(chunks)
 
     async def test_unsubscribes_on_close(self):
-        bus = EventBus(max_clients=5)
+        bus = InMemoryEventBus(max_clients=5)
         snap = TyrEvent(
             id="s1",
             event="dispatcher.state",
@@ -241,7 +242,7 @@ class TestSseGenerator:
 
     async def test_multiple_event_types_delivered(self):
         """All event types flow through the queue correctly."""
-        bus = EventBus(max_clients=5)
+        bus = InMemoryEventBus(max_clients=5)
         q = bus.subscribe()
 
         event_types = [
@@ -276,7 +277,7 @@ class TestSseGenerator:
 # ---------------------------------------------------------------------------
 
 
-def _make_app(event_bus: EventBus, keepalive_interval: float = 30.0) -> FastAPI:
+def _make_app(event_bus: InMemoryEventBus, keepalive_interval: float = 30.0) -> FastAPI:
     app = FastAPI()
     app.include_router(create_events_router(keepalive_interval=keepalive_interval))
     app.dependency_overrides[resolve_event_bus] = lambda: event_bus
@@ -285,7 +286,7 @@ def _make_app(event_bus: EventBus, keepalive_interval: float = 30.0) -> FastAPI:
 
 class TestSseEndpointHttp:
     def test_returns_503_when_at_capacity(self):
-        bus = EventBus(max_clients=1)
+        bus = InMemoryEventBus(max_clients=1)
         bus.subscribe()  # fill up
         client = TestClient(_make_app(bus))
         resp = client.get("/api/v1/tyr/events")
@@ -296,6 +297,38 @@ class TestSseEndpointHttp:
 # ---------------------------------------------------------------------------
 # Config integration
 # ---------------------------------------------------------------------------
+
+
+class TestTyrEventOwnerID:
+    def test_owner_id_default_empty(self):
+        event = TyrEvent(event="test.event", data={})
+        assert event.owner_id == ""
+
+    def test_owner_id_set(self):
+        event = TyrEvent(event="test.event", data={}, owner_id="user-1")
+        assert event.owner_id == "user-1"
+
+    def test_owner_id_not_in_sse(self):
+        """owner_id is metadata for routing, not included in SSE wire format."""
+        event = TyrEvent(id="x", event="test.event", data={}, owner_id="user-1")
+        sse = event.to_sse()
+        assert "owner_id" not in sse
+
+
+class TestEventBusPortIsABC:
+    def test_cannot_instantiate_port(self):
+        import pytest
+
+        from tyr.ports.event_bus import EventBusPort
+
+        with pytest.raises(TypeError):
+            EventBusPort()  # type: ignore[abstract]
+
+    def test_in_memory_implements_port(self):
+        from tyr.ports.event_bus import EventBusPort
+
+        bus = InMemoryEventBus()
+        assert isinstance(bus, EventBusPort)
 
 
 class TestEventsConfig:
@@ -312,3 +345,18 @@ class TestEventsConfig:
         s = Settings()
         assert s.events.max_sse_clients == 10
         assert s.events.keepalive_interval == 15.0
+
+
+class TestEventBusConfig:
+    def test_default_values(self):
+        from tyr.config import EventBusConfig
+
+        cfg = EventBusConfig()
+        assert cfg.adapter == "tyr.adapters.memory_event_bus.InMemoryEventBus"
+        assert cfg.kwargs == {}
+
+    def test_settings_includes_event_bus(self):
+        from tyr.config import Settings
+
+        s = Settings()
+        assert s.event_bus.adapter == "tyr.adapters.memory_event_bus.InMemoryEventBus"

--- a/tests/test_tyr/test_notification_service.py
+++ b/tests/test_tyr/test_notification_service.py
@@ -1,0 +1,945 @@
+"""Tests for the notification service, channel factory, and Telegram adapter."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+
+from niuu.domain.models import IntegrationConnection, IntegrationType
+from tyr.adapters.memory_event_bus import InMemoryEventBus
+from tyr.adapters.notification_channel_factory import NotificationChannelFactory
+from tyr.adapters.telegram_notification import TelegramNotificationAdapter
+from tyr.domain.models import Phase, Raid, RaidStatus, Saga, SagaStatus
+from tyr.domain.services.notification import NotificationService
+from tyr.ports.event_bus import TyrEvent
+from tyr.ports.notification_channel import (
+    Notification,
+    NotificationChannel,
+    NotificationUrgency,
+)
+from tyr.ports.raid_repository import RaidRepository
+
+from .conftest import StubCredentialStore, StubIntegrationRepo
+
+# ---------------------------------------------------------------------------
+# Fixtures / Stubs
+# ---------------------------------------------------------------------------
+
+NOW = datetime.now(UTC)
+
+
+class RecordingChannel(NotificationChannel):
+    """In-memory channel that records sent notifications."""
+
+    def __init__(self, *, min_urgency: NotificationUrgency = NotificationUrgency.LOW) -> None:
+        self.sent: list[Notification] = []
+        self._min_urgency = min_urgency
+        self._urgency_rank = {
+            NotificationUrgency.LOW: 0,
+            NotificationUrgency.MEDIUM: 1,
+            NotificationUrgency.HIGH: 2,
+        }
+
+    def should_notify(self, notification: Notification) -> bool:
+        return (
+            self._urgency_rank.get(notification.urgency, 0) >= self._urgency_rank[self._min_urgency]
+        )
+
+    async def send(self, notification: Notification) -> None:
+        self.sent.append(notification)
+
+
+class FailingChannel(NotificationChannel):
+    """Channel that always raises on send."""
+
+    def should_notify(self, notification: Notification) -> bool:
+        return True
+
+    async def send(self, notification: Notification) -> None:
+        raise RuntimeError("Channel failed")
+
+
+class StubRaidRepo(RaidRepository):
+    """In-memory raid repository for notification tests."""
+
+    def __init__(self) -> None:
+        self.raids: dict[UUID, Raid] = {}
+        self.saga: Saga | None = None
+
+    async def get_raid(self, raid_id: UUID) -> Raid | None:
+        return self.raids.get(raid_id)
+
+    async def update_raid_status(
+        self, raid_id: UUID, status: RaidStatus, **kwargs: object
+    ) -> Raid | None:
+        raise NotImplementedError
+
+    async def list_by_status(self, status: RaidStatus) -> list[Raid]:
+        return [r for r in self.raids.values() if r.status == status]
+
+    async def update_raid_completion(self, raid_id: UUID, **kwargs: object) -> Raid | None:
+        raise NotImplementedError
+
+    async def get_confidence_events(self, raid_id: UUID) -> list:
+        return []
+
+    async def add_confidence_event(self, event: object) -> None:
+        pass
+
+    async def find_raid_by_tracker_id(self, tracker_id: str) -> Raid | None:
+        for raid in self.raids.values():
+            if raid.tracker_id == tracker_id:
+                return raid
+        return None
+
+    async def get_saga_for_raid(self, raid_id: UUID) -> Saga | None:
+        return self.saga
+
+    async def get_phase_for_raid(self, raid_id: UUID) -> Phase | None:
+        return None
+
+    async def save_phase(self, phase: object, *, conn: object = None) -> None:
+        pass
+
+    async def save_raid(self, raid: object, *, conn: object = None) -> None:
+        pass
+
+    async def all_raids_merged(self, phase_id: UUID) -> bool:
+        return False
+
+
+class StubChannelFactory(NotificationChannelFactory):
+    """Factory that returns pre-configured channels."""
+
+    def __init__(self, channels: dict[str, list[NotificationChannel]] | None = None) -> None:
+        self._channels = channels or {}
+
+    async def for_owner(self, owner_id: str) -> list[NotificationChannel]:
+        return self._channels.get(owner_id, [])
+
+
+def _make_raid(
+    raid_id: UUID | None = None,
+    status: RaidStatus = RaidStatus.REVIEW,
+    tracker_id: str = "NIU-100",
+    pr_url: str | None = None,
+) -> Raid:
+    return Raid(
+        id=raid_id or uuid4(),
+        phase_id=uuid4(),
+        tracker_id=tracker_id,
+        name="Test raid",
+        description="Implement feature",
+        acceptance_criteria=["tests pass"],
+        declared_files=["src/main.py"],
+        estimate_hours=2.0,
+        status=status,
+        confidence=0.5,
+        session_id="session-1",
+        branch="raid/test",
+        chronicle_summary=None,
+        pr_url=pr_url,
+        pr_id=None,
+        retry_count=0,
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+
+def _make_saga(owner_id: str = "user-1") -> Saga:
+    return Saga(
+        id=uuid4(),
+        tracker_id="proj-1",
+        tracker_type="mock",
+        slug="alpha",
+        name="Test Saga",
+        repos=["org/repo"],
+        feature_branch="feat/test",
+        status=SagaStatus.ACTIVE,
+        confidence=0.5,
+        created_at=NOW,
+        owner_id=owner_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# NotificationChannel port tests
+# ---------------------------------------------------------------------------
+
+
+class TestNotificationModel:
+    def test_notification_fields(self) -> None:
+        n = Notification(
+            title="Test",
+            body="Body text",
+            urgency=NotificationUrgency.HIGH,
+            owner_id="user-1",
+            event_type="raid.review",
+        )
+        assert n.title == "Test"
+        assert n.urgency == NotificationUrgency.HIGH
+        assert n.metadata == {}
+
+    def test_notification_with_metadata(self) -> None:
+        n = Notification(
+            title="Test",
+            body="Body",
+            urgency=NotificationUrgency.LOW,
+            owner_id="user-1",
+            event_type="raid.merged",
+            metadata={"pr_url": "https://example.com"},
+        )
+        assert n.metadata["pr_url"] == "https://example.com"
+
+
+class TestNotificationUrgency:
+    def test_urgency_values(self) -> None:
+        assert NotificationUrgency.LOW == "low"
+        assert NotificationUrgency.MEDIUM == "medium"
+        assert NotificationUrgency.HIGH == "high"
+
+
+# ---------------------------------------------------------------------------
+# TelegramNotificationAdapter tests
+# ---------------------------------------------------------------------------
+
+
+class TestTelegramNotificationAdapter:
+    def test_should_notify_all_urgencies(self) -> None:
+        adapter = TelegramNotificationAdapter(bot_token="tok", chat_id="123", min_urgency="low")
+        for urgency in NotificationUrgency:
+            n = Notification(title="T", body="B", urgency=urgency, owner_id="u", event_type="e")
+            assert adapter.should_notify(n) is True
+
+    def test_should_notify_medium_filter(self) -> None:
+        adapter = TelegramNotificationAdapter(bot_token="tok", chat_id="123", min_urgency="medium")
+        low = Notification(
+            title="T", body="B", urgency=NotificationUrgency.LOW, owner_id="u", event_type="e"
+        )
+        medium = Notification(
+            title="T", body="B", urgency=NotificationUrgency.MEDIUM, owner_id="u", event_type="e"
+        )
+        high = Notification(
+            title="T", body="B", urgency=NotificationUrgency.HIGH, owner_id="u", event_type="e"
+        )
+        assert adapter.should_notify(low) is False
+        assert adapter.should_notify(medium) is True
+        assert adapter.should_notify(high) is True
+
+    def test_should_notify_high_filter(self) -> None:
+        adapter = TelegramNotificationAdapter(bot_token="tok", chat_id="123", min_urgency="high")
+        low = Notification(
+            title="T", body="B", urgency=NotificationUrgency.LOW, owner_id="u", event_type="e"
+        )
+        high = Notification(
+            title="T", body="B", urgency=NotificationUrgency.HIGH, owner_id="u", event_type="e"
+        )
+        assert adapter.should_notify(low) is False
+        assert adapter.should_notify(high) is True
+
+    def test_format_message_basic(self) -> None:
+        n = Notification(
+            title="Raid ready",
+            body="Raid NIU-100 is ready.",
+            urgency=NotificationUrgency.HIGH,
+            owner_id="u",
+            event_type="raid.review",
+        )
+        msg = TelegramNotificationAdapter._format_message(n)
+        assert "*Raid ready*" in msg
+        assert "Raid NIU-100 is ready." in msg
+
+    def test_format_message_with_pr_url(self) -> None:
+        n = Notification(
+            title="Raid ready",
+            body="Raid NIU-100 is ready.",
+            urgency=NotificationUrgency.HIGH,
+            owner_id="u",
+            event_type="raid.review",
+            metadata={"pr_url": "https://github.com/org/repo/pull/42"},
+        )
+        msg = TelegramNotificationAdapter._format_message(n)
+        assert "[View PR](https://github.com/org/repo/pull/42)" in msg
+
+    def test_format_message_with_tracker_id(self) -> None:
+        n = Notification(
+            title="Raid ready",
+            body="Raid NIU-100 is ready.",
+            urgency=NotificationUrgency.HIGH,
+            owner_id="u",
+            event_type="raid.review",
+            metadata={"tracker_id": "NIU-100"},
+        )
+        msg = TelegramNotificationAdapter._format_message(n)
+        assert "Ticket: NIU-100" in msg
+
+    @pytest.mark.asyncio
+    async def test_send_no_bot_token(self) -> None:
+        """Send with empty bot_token should not raise."""
+        adapter = TelegramNotificationAdapter(bot_token="", chat_id="123")
+        n = Notification(
+            title="T", body="B", urgency=NotificationUrgency.HIGH, owner_id="u", event_type="e"
+        )
+        await adapter.send(n)  # Should not raise
+
+    @pytest.mark.asyncio
+    async def test_send_http_error_does_not_raise(self) -> None:
+        """HTTP errors should be logged, not raised."""
+        import respx
+
+        with respx.mock:
+            respx.post("https://api.telegram.org/bottok/sendMessage").respond(500)
+            adapter = TelegramNotificationAdapter(bot_token="tok", chat_id="123")
+            n = Notification(
+                title="T", body="B", urgency=NotificationUrgency.HIGH, owner_id="u", event_type="e"
+            )
+            await adapter.send(n)  # Should not raise
+            await adapter.close()
+
+    @pytest.mark.asyncio
+    async def test_send_success(self) -> None:
+        """Successful send should call Telegram API."""
+        import respx
+
+        with respx.mock:
+            route = respx.post("https://api.telegram.org/bottok123/sendMessage").respond(
+                200, json={"ok": True}
+            )
+            adapter = TelegramNotificationAdapter(bot_token="tok123", chat_id="456")
+            n = Notification(
+                title="Raid ready",
+                body="Raid NIU-100 is ready.",
+                urgency=NotificationUrgency.HIGH,
+                owner_id="u",
+                event_type="raid.review",
+            )
+            await adapter.send(n)
+
+            assert route.called
+            await adapter.close()
+
+    @pytest.mark.asyncio
+    async def test_send_connection_error_does_not_raise(self) -> None:
+        """Connection errors should be caught, not raised."""
+        import respx
+
+        with respx.mock:
+            respx.post("https://api.telegram.org/bottok/sendMessage").mock(
+                side_effect=httpx.ConnectError("Connection refused")
+            )
+            adapter = TelegramNotificationAdapter(bot_token="tok", chat_id="123")
+            n = Notification(
+                title="T", body="B", urgency=NotificationUrgency.HIGH, owner_id="u", event_type="e"
+            )
+            await adapter.send(n)  # Should not raise
+            await adapter.close()
+
+
+# ---------------------------------------------------------------------------
+# NotificationChannelFactory tests
+# ---------------------------------------------------------------------------
+
+
+class TestNotificationChannelFactory:
+    @pytest.mark.asyncio
+    async def test_no_connections(self) -> None:
+        repo = StubIntegrationRepo()
+        cred_store = StubCredentialStore()
+        factory = NotificationChannelFactory(repo, cred_store)
+        channels = await factory.for_owner("user-1")
+        assert channels == []
+
+    @pytest.mark.asyncio
+    async def test_disabled_connection_skipped(self) -> None:
+        conn = IntegrationConnection(
+            id="conn-1",
+            owner_id="user-1",
+            integration_type=IntegrationType.MESSAGING,
+            adapter="tyr.adapters.telegram_notification.TelegramNotificationAdapter",
+            credential_name="tg-cred",
+            config={"chat_id": "123"},
+            enabled=False,
+            created_at=NOW,
+            updated_at=NOW,
+        )
+        repo = StubIntegrationRepo(connections=[conn])
+        cred_store = StubCredentialStore(values={"user:user-1:tg-cred": {"bot_token": "tok"}})
+        factory = NotificationChannelFactory(repo, cred_store)
+        channels = await factory.for_owner("user-1")
+        assert channels == []
+
+    @pytest.mark.asyncio
+    async def test_missing_credential_skipped(self) -> None:
+        conn = IntegrationConnection(
+            id="conn-1",
+            owner_id="user-1",
+            integration_type=IntegrationType.MESSAGING,
+            adapter="tyr.adapters.telegram_notification.TelegramNotificationAdapter",
+            credential_name="tg-cred",
+            config={"chat_id": "123"},
+            enabled=True,
+            created_at=NOW,
+            updated_at=NOW,
+        )
+        repo = StubIntegrationRepo(connections=[conn])
+        cred_store = StubCredentialStore()  # No credentials
+        factory = NotificationChannelFactory(repo, cred_store)
+        channels = await factory.for_owner("user-1")
+        assert channels == []
+
+    @pytest.mark.asyncio
+    async def test_valid_connection_creates_adapter(self) -> None:
+        conn = IntegrationConnection(
+            id="conn-1",
+            owner_id="user-1",
+            integration_type=IntegrationType.MESSAGING,
+            adapter="tyr.adapters.telegram_notification.TelegramNotificationAdapter",
+            credential_name="tg-cred",
+            config={"chat_id": "123"},
+            enabled=True,
+            created_at=NOW,
+            updated_at=NOW,
+        )
+        repo = StubIntegrationRepo(connections=[conn])
+        cred_store = StubCredentialStore(values={"user:user-1:tg-cred": {"bot_token": "tok"}})
+        factory = NotificationChannelFactory(repo, cred_store)
+        channels = await factory.for_owner("user-1")
+        assert len(channels) == 1
+        assert isinstance(channels[0], TelegramNotificationAdapter)
+
+    @pytest.mark.asyncio
+    async def test_invalid_adapter_path_skipped(self) -> None:
+        conn = IntegrationConnection(
+            id="conn-1",
+            owner_id="user-1",
+            integration_type=IntegrationType.MESSAGING,
+            adapter="nonexistent.module.Adapter",
+            credential_name="cred",
+            config={},
+            enabled=True,
+            created_at=NOW,
+            updated_at=NOW,
+        )
+        repo = StubIntegrationRepo(connections=[conn])
+        cred_store = StubCredentialStore(values={"user:user-1:cred": {"key": "val"}})
+        factory = NotificationChannelFactory(repo, cred_store)
+        channels = await factory.for_owner("user-1")
+        assert channels == []
+
+    @pytest.mark.asyncio
+    async def test_multiple_connections(self) -> None:
+        conns = [
+            IntegrationConnection(
+                id=f"conn-{i}",
+                owner_id="user-1",
+                integration_type=IntegrationType.MESSAGING,
+                adapter="tyr.adapters.telegram_notification.TelegramNotificationAdapter",
+                credential_name=f"tg-cred-{i}",
+                config={"chat_id": f"chat-{i}"},
+                enabled=True,
+                created_at=NOW,
+                updated_at=NOW,
+            )
+            for i in range(3)
+        ]
+        repo = StubIntegrationRepo(connections=conns)
+        cred_store = StubCredentialStore(
+            values={f"user:user-1:tg-cred-{i}": {"bot_token": f"tok-{i}"} for i in range(3)}
+        )
+        factory = NotificationChannelFactory(repo, cred_store)
+        channels = await factory.for_owner("user-1")
+        assert len(channels) == 3
+
+
+# ---------------------------------------------------------------------------
+# NotificationService tests
+# ---------------------------------------------------------------------------
+
+
+class TestNotificationServiceLifecycle:
+    @pytest.mark.asyncio
+    async def test_start_stop(self) -> None:
+        event_bus = InMemoryEventBus()
+        factory = StubChannelFactory()
+        raid_repo = StubRaidRepo()
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
+
+        assert service.running is False
+        await service.start()
+        assert service.running is True
+        assert event_bus.client_count == 1
+
+        await service.stop()
+        assert service.running is False
+        assert event_bus.client_count == 0
+
+    @pytest.mark.asyncio
+    async def test_stop_when_not_started(self) -> None:
+        event_bus = InMemoryEventBus()
+        factory = StubChannelFactory()
+        raid_repo = StubRaidRepo()
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
+        await service.stop()  # Should not raise
+
+
+class TestNotificationServiceEventMapping:
+    @pytest.mark.asyncio
+    async def test_raid_review_notification(self) -> None:
+        """raid.state_changed → REVIEW should produce a HIGH urgency notification."""
+        event_bus = InMemoryEventBus()
+        channel = RecordingChannel()
+        factory = StubChannelFactory(channels={"user-1": [channel]})
+        raid_repo = StubRaidRepo()
+
+        raid = _make_raid(tracker_id="NIU-200")
+        raid_repo.raids[raid.id] = raid
+        raid_repo.saga = _make_saga(owner_id="user-1")
+
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
+        await service.start()
+
+        await event_bus.emit(
+            TyrEvent(
+                event="raid.state_changed",
+                data={
+                    "raid_id": str(raid.id),
+                    "status": "REVIEW",
+                    "tracker_id": "NIU-200",
+                    "pr_url": "https://github.com/org/repo/pull/1",
+                },
+            )
+        )
+
+        # Give the background task time to process
+        await asyncio.sleep(0.1)
+        await service.stop()
+
+        assert len(channel.sent) == 1
+        n = channel.sent[0]
+        assert n.urgency == NotificationUrgency.HIGH
+        assert "NIU-200" in n.body
+        assert n.owner_id == "user-1"
+        assert n.metadata.get("pr_url") == "https://github.com/org/repo/pull/1"
+
+    @pytest.mark.asyncio
+    async def test_raid_failed_notification(self) -> None:
+        event_bus = InMemoryEventBus()
+        channel = RecordingChannel()
+        factory = StubChannelFactory(channels={"user-1": [channel]})
+        raid_repo = StubRaidRepo()
+
+        raid = _make_raid(tracker_id="NIU-201", status=RaidStatus.FAILED)
+        raid_repo.raids[raid.id] = raid
+        raid_repo.saga = _make_saga(owner_id="user-1")
+
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
+        await service.start()
+
+        await event_bus.emit(
+            TyrEvent(
+                event="raid.state_changed",
+                data={
+                    "raid_id": str(raid.id),
+                    "status": "FAILED",
+                    "tracker_id": "NIU-201",
+                    "retry_count": 2,
+                },
+            )
+        )
+
+        await asyncio.sleep(0.1)
+        await service.stop()
+
+        assert len(channel.sent) == 1
+        n = channel.sent[0]
+        assert n.urgency == NotificationUrgency.HIGH
+        assert "failed" in n.title.lower()
+        assert "NIU-201" in n.body
+
+    @pytest.mark.asyncio
+    async def test_raid_merged_notification(self) -> None:
+        event_bus = InMemoryEventBus()
+        channel = RecordingChannel()
+        factory = StubChannelFactory(channels={"user-1": [channel]})
+        raid_repo = StubRaidRepo()
+
+        raid = _make_raid(tracker_id="NIU-202", status=RaidStatus.MERGED)
+        raid_repo.raids[raid.id] = raid
+        raid_repo.saga = _make_saga(owner_id="user-1")
+
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
+        await service.start()
+
+        await event_bus.emit(
+            TyrEvent(
+                event="raid.state_changed",
+                data={
+                    "raid_id": str(raid.id),
+                    "status": "MERGED",
+                    "tracker_id": "NIU-202",
+                },
+            )
+        )
+
+        await asyncio.sleep(0.1)
+        await service.stop()
+
+        assert len(channel.sent) == 1
+        assert channel.sent[0].urgency == NotificationUrgency.LOW
+
+    @pytest.mark.asyncio
+    async def test_unmapped_status_ignored(self) -> None:
+        """Events with statuses not in the mapping should be ignored."""
+        event_bus = InMemoryEventBus()
+        channel = RecordingChannel()
+        factory = StubChannelFactory(channels={"user-1": [channel]})
+        raid_repo = StubRaidRepo()
+        raid_repo.saga = _make_saga(owner_id="user-1")
+
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
+        await service.start()
+
+        await event_bus.emit(
+            TyrEvent(
+                event="raid.state_changed",
+                data={"raid_id": str(uuid4()), "status": "RUNNING"},
+            )
+        )
+
+        await asyncio.sleep(0.1)
+        await service.stop()
+
+        assert len(channel.sent) == 0
+
+    @pytest.mark.asyncio
+    async def test_unknown_event_type_ignored(self) -> None:
+        event_bus = InMemoryEventBus()
+        channel = RecordingChannel()
+        factory = StubChannelFactory(channels={"user-1": [channel]})
+        raid_repo = StubRaidRepo()
+
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
+        await service.start()
+
+        await event_bus.emit(TyrEvent(event="some.unknown.event", data={"foo": "bar"}))
+
+        await asyncio.sleep(0.1)
+        await service.stop()
+
+        assert len(channel.sent) == 0
+
+    @pytest.mark.asyncio
+    async def test_no_owner_found_skips_notification(self) -> None:
+        """Events where owner cannot be resolved should be skipped."""
+        event_bus = InMemoryEventBus()
+        channel = RecordingChannel()
+        factory = StubChannelFactory(channels={"user-1": [channel]})
+        raid_repo = StubRaidRepo()
+        # saga is None → owner cannot be resolved
+
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
+        await service.start()
+
+        await event_bus.emit(
+            TyrEvent(
+                event="raid.state_changed",
+                data={"raid_id": str(uuid4()), "status": "REVIEW"},
+            )
+        )
+
+        await asyncio.sleep(0.1)
+        await service.stop()
+
+        assert len(channel.sent) == 0
+
+    @pytest.mark.asyncio
+    async def test_no_channels_configured(self) -> None:
+        """If owner has no channels, notification is silently dropped."""
+        event_bus = InMemoryEventBus()
+        factory = StubChannelFactory()  # No channels for anyone
+        raid_repo = StubRaidRepo()
+
+        raid = _make_raid(tracker_id="NIU-300")
+        raid_repo.raids[raid.id] = raid
+        raid_repo.saga = _make_saga(owner_id="user-1")
+
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
+        await service.start()
+
+        await event_bus.emit(
+            TyrEvent(
+                event="raid.state_changed",
+                data={"raid_id": str(raid.id), "status": "REVIEW", "tracker_id": "NIU-300"},
+            )
+        )
+
+        await asyncio.sleep(0.1)
+        await service.stop()
+        # No assertion needed — just verifying no crash
+
+    @pytest.mark.asyncio
+    async def test_channel_send_error_does_not_crash(self) -> None:
+        """If a channel fails to send, other channels still get notified."""
+        event_bus = InMemoryEventBus()
+        failing = FailingChannel()
+        recording = RecordingChannel()
+        factory = StubChannelFactory(channels={"user-1": [failing, recording]})
+        raid_repo = StubRaidRepo()
+
+        raid = _make_raid(tracker_id="NIU-400")
+        raid_repo.raids[raid.id] = raid
+        raid_repo.saga = _make_saga(owner_id="user-1")
+
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
+        await service.start()
+
+        await event_bus.emit(
+            TyrEvent(
+                event="raid.state_changed",
+                data={"raid_id": str(raid.id), "status": "REVIEW", "tracker_id": "NIU-400"},
+            )
+        )
+
+        await asyncio.sleep(0.1)
+        await service.stop()
+
+        assert len(recording.sent) == 1
+
+    @pytest.mark.asyncio
+    async def test_urgency_filter_respected(self) -> None:
+        """Channel with high min_urgency should skip low notifications."""
+        event_bus = InMemoryEventBus()
+        channel = RecordingChannel(min_urgency=NotificationUrgency.HIGH)
+        factory = StubChannelFactory(channels={"user-1": [channel]})
+        raid_repo = StubRaidRepo()
+
+        raid = _make_raid(tracker_id="NIU-500", status=RaidStatus.MERGED)
+        raid_repo.raids[raid.id] = raid
+        raid_repo.saga = _make_saga(owner_id="user-1")
+
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
+        await service.start()
+
+        await event_bus.emit(
+            TyrEvent(
+                event="raid.state_changed",
+                data={"raid_id": str(raid.id), "status": "MERGED", "tracker_id": "NIU-500"},
+            )
+        )
+
+        await asyncio.sleep(0.1)
+        await service.stop()
+
+        assert len(channel.sent) == 0
+
+    @pytest.mark.asyncio
+    async def test_saga_pr_created_notification(self) -> None:
+        event_bus = InMemoryEventBus()
+        channel = RecordingChannel()
+        factory = StubChannelFactory(channels={"user-1": [channel]})
+        raid_repo = StubRaidRepo()
+
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
+        await service.start()
+
+        await event_bus.emit(
+            TyrEvent(
+                event="saga.pr_created",
+                data={
+                    "owner_id": "user-1",
+                    "saga_name": "Auth rewrite",
+                    "pr_url": "https://github.com/org/repo/pull/99",
+                },
+            )
+        )
+
+        await asyncio.sleep(0.1)
+        await service.stop()
+
+        assert len(channel.sent) == 1
+        n = channel.sent[0]
+        assert n.urgency == NotificationUrgency.HIGH
+        assert "Auth rewrite" in n.body
+        assert n.metadata.get("pr_url") == "https://github.com/org/repo/pull/99"
+
+    @pytest.mark.asyncio
+    async def test_saga_pr_created_no_owner(self) -> None:
+        event_bus = InMemoryEventBus()
+        channel = RecordingChannel()
+        factory = StubChannelFactory(channels={"user-1": [channel]})
+        raid_repo = StubRaidRepo()
+
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
+        await service.start()
+
+        await event_bus.emit(TyrEvent(event="saga.pr_created", data={"saga_name": "X"}))
+
+        await asyncio.sleep(0.1)
+        await service.stop()
+
+        assert len(channel.sent) == 0
+
+    @pytest.mark.asyncio
+    async def test_phase_unlocked_notification(self) -> None:
+        event_bus = InMemoryEventBus()
+        channel = RecordingChannel()
+        factory = StubChannelFactory(channels={"user-1": [channel]})
+        raid_repo = StubRaidRepo()
+
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
+        await service.start()
+
+        await event_bus.emit(
+            TyrEvent(
+                event="phase.unlocked",
+                data={
+                    "owner_id": "user-1",
+                    "phase_number": 2,
+                    "queued_raids": 5,
+                },
+            )
+        )
+
+        await asyncio.sleep(0.1)
+        await service.stop()
+
+        assert len(channel.sent) == 1
+        n = channel.sent[0]
+        assert n.urgency == NotificationUrgency.MEDIUM
+        assert "Phase 2" in n.body
+        assert "5 raids" in n.body
+
+    @pytest.mark.asyncio
+    async def test_phase_unlocked_no_owner(self) -> None:
+        event_bus = InMemoryEventBus()
+        channel = RecordingChannel()
+        factory = StubChannelFactory(channels={"user-1": [channel]})
+        raid_repo = StubRaidRepo()
+
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
+        await service.start()
+
+        await event_bus.emit(
+            TyrEvent(event="phase.unlocked", data={"phase_number": 1, "queued_raids": 3})
+        )
+
+        await asyncio.sleep(0.1)
+        await service.stop()
+
+        assert len(channel.sent) == 0
+
+    @pytest.mark.asyncio
+    async def test_confidence_below_threshold(self) -> None:
+        event_bus = InMemoryEventBus()
+        channel = RecordingChannel()
+        factory = StubChannelFactory(channels={"user-1": [channel]})
+        raid_repo = StubRaidRepo()
+
+        raid = _make_raid(tracker_id="NIU-600")
+        raid_repo.raids[raid.id] = raid
+        raid_repo.saga = _make_saga(owner_id="user-1")
+
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
+        await service.start()
+
+        await event_bus.emit(
+            TyrEvent(
+                event="confidence.updated",
+                data={
+                    "raid_id": str(raid.id),
+                    "score_after": 0.2,
+                    "tracker_id": "NIU-600",
+                },
+            )
+        )
+
+        await asyncio.sleep(0.1)
+        await service.stop()
+
+        assert len(channel.sent) == 1
+        n = channel.sent[0]
+        assert n.urgency == NotificationUrgency.MEDIUM
+        assert "20%" in n.body
+
+    @pytest.mark.asyncio
+    async def test_confidence_above_threshold_ignored(self) -> None:
+        event_bus = InMemoryEventBus()
+        channel = RecordingChannel()
+        factory = StubChannelFactory(channels={"user-1": [channel]})
+        raid_repo = StubRaidRepo()
+
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
+        await service.start()
+
+        await event_bus.emit(
+            TyrEvent(
+                event="confidence.updated",
+                data={"raid_id": str(uuid4()), "score_after": 0.5},
+            )
+        )
+
+        await asyncio.sleep(0.1)
+        await service.stop()
+
+        assert len(channel.sent) == 0
+
+    @pytest.mark.asyncio
+    async def test_tracker_id_resolved_from_raid(self) -> None:
+        """When event data lacks tracker_id, resolve from raid repo."""
+        event_bus = InMemoryEventBus()
+        channel = RecordingChannel()
+        factory = StubChannelFactory(channels={"user-1": [channel]})
+        raid_repo = StubRaidRepo()
+
+        raid = _make_raid(tracker_id="NIU-700")
+        raid_repo.raids[raid.id] = raid
+        raid_repo.saga = _make_saga(owner_id="user-1")
+
+        service = NotificationService(event_bus, factory, raid_repo, confidence_threshold=0.3)
+        await service.start()
+
+        # Emit without tracker_id in data
+        await event_bus.emit(
+            TyrEvent(
+                event="raid.state_changed",
+                data={"raid_id": str(raid.id), "status": "REVIEW"},
+            )
+        )
+
+        await asyncio.sleep(0.1)
+        await service.stop()
+
+        assert len(channel.sent) == 1
+        assert "NIU-700" in channel.sent[0].body
+
+
+# ---------------------------------------------------------------------------
+# Config tests
+# ---------------------------------------------------------------------------
+
+
+class TestNotificationConfig:
+    def test_defaults(self) -> None:
+        from tyr.config import NotificationConfig
+
+        cfg = NotificationConfig()
+        assert cfg.enabled is True
+        assert cfg.confidence_threshold == 0.3
+
+    def test_custom(self) -> None:
+        from tyr.config import NotificationConfig
+
+        cfg = NotificationConfig(enabled=False, confidence_threshold=0.5)
+        assert cfg.enabled is False
+        assert cfg.confidence_threshold == 0.5
+
+    def test_settings_includes_notification(self) -> None:
+        from tyr.config import Settings
+
+        s = Settings()
+        assert hasattr(s, "notification")
+        assert s.notification.enabled is True

--- a/tests/test_tyr/test_notification_service.py
+++ b/tests/test_tyr/test_notification_service.py
@@ -116,6 +116,12 @@ class StubRaidRepo(RaidRepository):
     async def all_raids_merged(self, phase_id: UUID) -> bool:
         return False
 
+    async def save_session_message(self, message: object) -> None:
+        pass
+
+    async def get_session_messages(self, raid_id: UUID) -> list:
+        return []
+
 
 class StubChannelFactory(ChannelResolverPort):
     """Factory that returns pre-configured channels."""

--- a/tests/test_tyr/test_notification_service.py
+++ b/tests/test_tyr/test_notification_service.py
@@ -15,6 +15,7 @@ from tyr.adapters.notification_channel_factory import NotificationChannelFactory
 from tyr.adapters.telegram_notification import TelegramNotificationAdapter
 from tyr.domain.models import Phase, Raid, RaidStatus, Saga, SagaStatus
 from tyr.domain.services.notification import NotificationService
+from tyr.ports.channel_resolver import ChannelResolverPort
 from tyr.ports.event_bus import TyrEvent
 from tyr.ports.notification_channel import (
     Notification,
@@ -108,11 +109,15 @@ class StubRaidRepo(RaidRepository):
     async def save_raid(self, raid: object, *, conn: object = None) -> None:
         pass
 
+    async def get_owner_for_raid(self, raid_id: UUID) -> str | None:
+        saga = await self.get_saga_for_raid(raid_id)
+        return saga.owner_id if saga else None
+
     async def all_raids_merged(self, phase_id: UUID) -> bool:
         return False
 
 
-class StubChannelFactory(NotificationChannelFactory):
+class StubChannelFactory(ChannelResolverPort):
     """Factory that returns pre-configured channels."""
 
     def __init__(self, channels: dict[str, list[NotificationChannel]] | None = None) -> None:

--- a/tests/test_tyr/test_raids_api.py
+++ b/tests/test_tyr/test_raids_api.py
@@ -164,6 +164,10 @@ class MockRaidRepository(RaidRepository):
         self.raids[raid_id] = updated
         return updated
 
+    async def get_owner_for_raid(self, raid_id: UUID) -> str | None:
+        saga = await self.get_saga_for_raid(raid_id)
+        return saga.owner_id if saga else None
+
     async def all_raids_merged(self, phase_id: UUID) -> bool:
         return self._all_merged
 

--- a/tests/test_tyr/test_session_message.py
+++ b/tests/test_tyr/test_session_message.py
@@ -9,6 +9,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from tyr.adapters.memory_event_bus import InMemoryEventBus
 from tyr.api.raids import (
     create_raids_router,
     resolve_git,
@@ -28,7 +29,6 @@ from tyr.domain.services.session_message import (
     RaidNotRunningError,
     SessionMessageService,
 )
-from tyr.events import EventBus
 
 from .test_raids_api import (
     MockGit,
@@ -106,15 +106,15 @@ def volundr() -> MessageTrackingVolundr:
 
 
 @pytest.fixture
-def event_bus() -> EventBus:
-    return EventBus()
+def event_bus() -> InMemoryEventBus:
+    return InMemoryEventBus()
 
 
 @pytest.fixture
 def service(
     raid_repo: MessageAwareMockRaidRepo,
     volundr: MessageTrackingVolundr,
-    event_bus: EventBus,
+    event_bus: InMemoryEventBus,
 ) -> SessionMessageService:
     return SessionMessageService(raid_repo, volundr, event_bus=event_bus)
 
@@ -123,7 +123,7 @@ def service(
 def client(
     raid_repo: MessageAwareMockRaidRepo,
     volundr: MessageTrackingVolundr,
-    event_bus: EventBus,
+    event_bus: InMemoryEventBus,
 ) -> TestClient:
     app = FastAPI()
     app.include_router(create_raids_router())
@@ -281,7 +281,7 @@ class TestSessionMessageService:
         self,
         service: SessionMessageService,
         raid_repo: MessageAwareMockRaidRepo,
-        event_bus: EventBus,
+        event_bus: InMemoryEventBus,
     ):
         raid = _make_raid(status=RaidStatus.RUNNING)
         raid_repo.raids[raid.id] = raid

--- a/tests/test_tyr/test_telegram_webhook.py
+++ b/tests/test_tyr/test_telegram_webhook.py
@@ -156,6 +156,10 @@ class StubRaidRepo(RaidRepository):
     async def update_raid_completion(self, raid_id, **kwargs) -> Raid | None:  # noqa: ANN001
         return await self.update_raid_status(raid_id, kwargs.get("status", RaidStatus.MERGED))
 
+    async def get_owner_for_raid(self, raid_id: UUID) -> str | None:
+        saga = await self.get_saga_for_raid(raid_id)
+        return saga.owner_id if saga else None
+
     async def all_raids_merged(self, phase_id: UUID) -> bool:
         return self._all_merged
 

--- a/tests/test_tyr/test_watcher.py
+++ b/tests/test_tyr/test_watcher.py
@@ -8,6 +8,7 @@ from uuid import UUID, uuid4
 
 import pytest
 
+from tyr.adapters.memory_event_bus import InMemoryEventBus
 from tyr.config import WatcherConfig
 from tyr.domain.models import (
     DispatcherState,
@@ -18,7 +19,6 @@ from tyr.domain.models import (
     SagaStatus,
 )
 from tyr.domain.services.watcher import RaidWatcher, WatcherStats
-from tyr.events import EventBus
 from tyr.ports.dispatcher_repository import DispatcherRepository
 from tyr.ports.raid_repository import RaidRepository
 from tyr.ports.volundr import SpawnRequest, VolundrPort, VolundrSession
@@ -244,13 +244,13 @@ def _make_watcher(
     volundr: StubVolundr | None = None,
     raid_repo: StubRaidRepo | None = None,
     dispatcher_repo: StubDispatcherRepo | None = None,
-    event_bus: EventBus | None = None,
+    event_bus: InMemoryEventBus | None = None,
     config: WatcherConfig | None = None,
-) -> tuple[RaidWatcher, StubVolundr, StubRaidRepo, EventBus]:
+) -> tuple[RaidWatcher, StubVolundr, StubRaidRepo, InMemoryEventBus]:
     v = volundr or StubVolundr()
     r = raid_repo or StubRaidRepo()
     d = dispatcher_repo or StubDispatcherRepo()
-    e = event_bus or EventBus()
+    e = event_bus or InMemoryEventBus()
     c = config or _default_config()
     watcher = RaidWatcher(volundr=v, raid_repo=r, dispatcher_repo=d, event_bus=e, config=c)
     return watcher, v, r, e

--- a/tests/test_tyr/test_watcher.py
+++ b/tests/test_tyr/test_watcher.py
@@ -157,6 +157,10 @@ class StubRaidRepo(RaidRepository):
     async def save_raid(self, raid: object, *, conn: object = None) -> None:
         pass
 
+    async def get_owner_for_raid(self, raid_id: UUID) -> str | None:
+        saga = await self.get_saga_for_raid(raid_id)
+        return saga.owner_id if saga else None
+
     async def all_raids_merged(self, phase_id: UUID) -> bool:
         return False
 


### PR DESCRIPTION
## Summary
- Extract EventBus into hexagonal architecture: `EventBusPort` ABC in `tyr/ports/event_bus.py`, `InMemoryEventBus` adapter in `tyr/adapters/memory_event_bus.py`, wired via dynamic adapter pattern with `EventBusConfig`
- Add `owner_id: str` field to `TyrEvent` for tenant-scoped event filtering; all `emit()` calls updated to resolve and include owner
- Implement notification service (NIU-240): `NotificationChannel` port, `TelegramNotificationAdapter`, `NotificationChannelFactory` for per-user channel resolution, `NotificationService` background task mapping domain events to notifications
- Delete `src/tyr/events.py` — all imports updated to canonical port/adapter locations (no backwards-compat shim)

## Test plan
- [x] 637 tests pass, 91.80% coverage (above 85% minimum)
- [x] ruff check + format clean
- [x] New tests for: EventBusPort ABC enforcement, TyrEvent owner_id, InMemoryEventBus, EventBusConfig, NotificationChannel port, TelegramNotificationAdapter, NotificationChannelFactory, NotificationService lifecycle + all event mappings
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)