### PR TITLE
feat(tyr): interactive planning sessions with LLM-driven saga decomposition (NIU-244)

### DIFF
--- a/charts/tyr/templates/configmap.yaml
+++ b/charts/tyr/templates/configmap.yaml
@@ -51,6 +51,10 @@ data:
     auth:
       pat_ttl_days: {{ .Values.auth.patTtlDays | default 365 }}
 
+    planner:
+      adapter: {{ .Values.planner.adapter | quote }}
+      kwargs: {{ .Values.planner.kwargs | toJson }}
+
     credential_store:
       adapter: {{ .Values.credentialStore.adapter | quote }}
       kwargs: {{ .Values.credentialStore.kwargs | toJson }}

--- a/charts/tyr/values.yaml
+++ b/charts/tyr/values.yaml
@@ -216,6 +216,12 @@ auth:
   # -- Default PAT lifetime in days
   patTtlDays: 365
 
+planner:
+  # -- Fully-qualified class path for the PlanningSessionRepository adapter
+  adapter: "tyr.adapters.memory_planning_repo.InMemoryPlanningSessionRepository"
+  # -- Extra kwargs forwarded to the adapter constructor
+  kwargs: {}
+
 volundr:
   url: "http://volundr:8000"
 

--- a/src/tyr/adapters/memory_planning_repo.py
+++ b/src/tyr/adapters/memory_planning_repo.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from tyr.domain.models import PlanningMessage, PlanningSession
+from tyr.domain.models import PlanningMessage, PlanningSession, PlanningSessionStatus
 from tyr.ports.planning_repository import PlanningSessionRepository
 
 
@@ -29,6 +29,13 @@ class InMemoryPlanningSessionRepository(PlanningSessionRepository):
 
     async def list_by_owner(self, owner_id: str) -> list[PlanningSession]:
         return [s for s in self._sessions.values() if s.owner_id == owner_id]
+
+    async def list_active(self) -> list[PlanningSession]:
+        return [
+            s
+            for s in self._sessions.values()
+            if s.status in (PlanningSessionStatus.ACTIVE, PlanningSessionStatus.STRUCTURE_PROPOSED)
+        ]
 
     async def delete(self, session_id: UUID) -> bool:
         if session_id in self._sessions:

--- a/src/tyr/adapters/memory_planning_repo.py
+++ b/src/tyr/adapters/memory_planning_repo.py
@@ -1,0 +1,44 @@
+"""In-memory planning session repository — suitable for dev and tests."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from tyr.domain.models import PlanningMessage, PlanningSession
+from tyr.ports.planning_repository import PlanningSessionRepository
+
+
+class InMemoryPlanningSessionRepository(PlanningSessionRepository):
+    """Stores planning sessions in memory (no persistence across restarts)."""
+
+    def __init__(self) -> None:
+        self._sessions: dict[UUID, PlanningSession] = {}
+        self._messages: dict[UUID, list[PlanningMessage]] = {}
+
+    async def save(self, session: PlanningSession) -> None:
+        self._sessions[session.id] = session
+
+    async def get(self, session_id: UUID) -> PlanningSession | None:
+        return self._sessions.get(session_id)
+
+    async def get_by_volundr_id(self, volundr_session_id: str) -> PlanningSession | None:
+        for s in self._sessions.values():
+            if s.session_id == volundr_session_id:
+                return s
+        return None
+
+    async def list_by_owner(self, owner_id: str) -> list[PlanningSession]:
+        return [s for s in self._sessions.values() if s.owner_id == owner_id]
+
+    async def delete(self, session_id: UUID) -> bool:
+        if session_id in self._sessions:
+            del self._sessions[session_id]
+            self._messages.pop(session_id, None)
+            return True
+        return False
+
+    async def save_message(self, message: PlanningMessage) -> None:
+        self._messages.setdefault(message.planning_session_id, []).append(message)
+
+    async def get_messages(self, session_id: UUID) -> list[PlanningMessage]:
+        return list(self._messages.get(session_id, []))

--- a/src/tyr/adapters/volundr_http.py
+++ b/src/tyr/adapters/volundr_http.py
@@ -65,6 +65,7 @@ class VolundrHTTPAdapter(VolundrPort):
                 name=data["name"],
                 status=data["status"],
                 tracker_issue_id=data.get("tracker_issue_id"),
+                chat_endpoint=data.get("chat_endpoint"),
             )
 
     async def get_session(
@@ -87,6 +88,7 @@ class VolundrHTTPAdapter(VolundrPort):
                 name=data["name"],
                 status=data["status"],
                 tracker_issue_id=data.get("tracker_issue_id"),
+                chat_endpoint=data.get("chat_endpoint"),
             )
 
     async def list_sessions(
@@ -148,6 +150,21 @@ class VolundrHTTPAdapter(VolundrPort):
                 headers=self._headers(auth_token),
                 json={"content": message},
             )
+            resp.raise_for_status()
+
+    async def stop_session(
+        self,
+        session_id: str,
+        *,
+        auth_token: str | None = None,
+    ) -> None:
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            resp = await client.delete(
+                f"{self._base_url}/api/v1/volundr/sessions/{session_id}",
+                headers=self._headers(auth_token),
+            )
+            if resp.status_code == 404:
+                return
             resp.raise_for_status()
 
     async def subscribe_activity(self) -> AsyncGenerator[ActivityEvent, None]:

--- a/src/tyr/api/planning.py
+++ b/src/tyr/api/planning.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel, Field
 
 from niuu.domain.models import Principal
 from tyr.adapters.inbound.auth import extract_principal
+from tyr.api.sagas import PhaseSpecResponse, RaidSpecResponse, SagaStructureResponse
 from tyr.domain.services.planning_session import (
     InvalidPlanningStateError,
     PlanningSessionNotFoundError,
@@ -43,32 +44,14 @@ class ProposeStructureRequest(BaseModel):
     raw_json: str = Field(min_length=1)
 
 
-class RaidSpecResponse(BaseModel):
-    name: str
-    description: str
-    acceptance_criteria: list[str]
-    declared_files: list[str]
-    estimate_hours: float
-    confidence: float
-
-
-class PhaseSpecResponse(BaseModel):
-    name: str
-    raids: list[RaidSpecResponse]
-
-
-class StructureResponse(BaseModel):
-    name: str
-    phases: list[PhaseSpecResponse]
-
-
 class PlanningSessionResponse(BaseModel):
     id: str
     owner_id: str
     session_id: str
     repo: str
     status: str
-    structure: StructureResponse | None = None
+    structure: SagaStructureResponse | None = None
+    chat_endpoint: str | None = None
     created_at: str
     updated_at: str
 
@@ -100,7 +83,7 @@ async def resolve_planning_service() -> PlanningSessionService:
 def _session_response(session) -> PlanningSessionResponse:  # noqa: ANN001
     structure = None
     if session.structure is not None:
-        structure = StructureResponse(
+        structure = SagaStructureResponse(
             name=session.structure.name,
             phases=[
                 PhaseSpecResponse(
@@ -127,6 +110,7 @@ def _session_response(session) -> PlanningSessionResponse:  # noqa: ANN001
         repo=session.repo,
         status=session.status.value,
         structure=structure,
+        chat_endpoint=session.chat_endpoint,
         created_at=session.created_at.isoformat(),
         updated_at=session.updated_at.isoformat(),
     )

--- a/src/tyr/api/planning.py
+++ b/src/tyr/api/planning.py
@@ -1,0 +1,317 @@
+"""REST API for interactive planning sessions.
+
+Provides endpoints for spawning, messaging, and capturing saga structures
+from conversational decomposition sessions.
+"""
+
+from __future__ import annotations
+
+import logging
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel, Field
+
+from niuu.domain.models import Principal
+from tyr.adapters.inbound.auth import extract_principal
+from tyr.domain.services.planning_session import (
+    InvalidPlanningStateError,
+    PlanningSessionNotFoundError,
+    PlanningSessionService,
+    SessionLimitReachedError,
+)
+from tyr.domain.validation import ValidationError
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Request / response models
+# ---------------------------------------------------------------------------
+
+
+class SpawnPlanningRequest(BaseModel):
+    spec: str = Field(min_length=1)
+    repo: str = Field(min_length=1)
+
+
+class SendPlanningMessageRequest(BaseModel):
+    content: str = Field(min_length=1, max_length=32768)
+
+
+class ProposeStructureRequest(BaseModel):
+    raw_json: str = Field(min_length=1)
+
+
+class RaidSpecResponse(BaseModel):
+    name: str
+    description: str
+    acceptance_criteria: list[str]
+    declared_files: list[str]
+    estimate_hours: float
+    confidence: float
+
+
+class PhaseSpecResponse(BaseModel):
+    name: str
+    raids: list[RaidSpecResponse]
+
+
+class StructureResponse(BaseModel):
+    name: str
+    phases: list[PhaseSpecResponse]
+
+
+class PlanningSessionResponse(BaseModel):
+    id: str
+    owner_id: str
+    session_id: str
+    repo: str
+    status: str
+    structure: StructureResponse | None = None
+    created_at: str
+    updated_at: str
+
+
+class PlanningMessageResponse(BaseModel):
+    id: str
+    content: str
+    sender: str
+    created_at: str
+
+
+# ---------------------------------------------------------------------------
+# Dependency stubs — overridden by main.py lifespan
+# ---------------------------------------------------------------------------
+
+
+async def resolve_planning_service() -> PlanningSessionService:
+    raise HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail="Planning service not configured",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _session_response(session) -> PlanningSessionResponse:  # noqa: ANN001
+    structure = None
+    if session.structure is not None:
+        structure = StructureResponse(
+            name=session.structure.name,
+            phases=[
+                PhaseSpecResponse(
+                    name=p.name,
+                    raids=[
+                        RaidSpecResponse(
+                            name=r.name,
+                            description=r.description,
+                            acceptance_criteria=r.acceptance_criteria,
+                            declared_files=r.declared_files,
+                            estimate_hours=r.estimate_hours,
+                            confidence=r.confidence,
+                        )
+                        for r in p.raids
+                    ],
+                )
+                for p in session.structure.phases
+            ],
+        )
+    return PlanningSessionResponse(
+        id=str(session.id),
+        owner_id=session.owner_id,
+        session_id=session.session_id,
+        repo=session.repo,
+        status=session.status.value,
+        structure=structure,
+        created_at=session.created_at.isoformat(),
+        updated_at=session.updated_at.isoformat(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Router
+# ---------------------------------------------------------------------------
+
+
+def create_planning_router() -> APIRouter:
+    router = APIRouter(prefix="/api/v1/tyr/planning", tags=["Planning"])
+
+    @router.post("/sessions", response_model=PlanningSessionResponse, status_code=201)
+    async def spawn_planning_session(
+        body: SpawnPlanningRequest,
+        request: Request,
+        principal: Principal = Depends(extract_principal),
+        svc: PlanningSessionService = Depends(resolve_planning_service),
+    ) -> PlanningSessionResponse:
+        """Spawn an interactive planning session."""
+        raw_header = request.headers.get("Authorization", "")
+        auth_token = raw_header.removeprefix("Bearer ").strip() or None
+        try:
+            session = await svc.spawn(
+                owner_id=principal.user_id,
+                spec=body.spec,
+                repo=body.repo,
+                auth_token=auth_token,
+            )
+        except SessionLimitReachedError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail=str(exc),
+            )
+        return _session_response(session)
+
+    @router.get("/sessions", response_model=list[PlanningSessionResponse])
+    async def list_planning_sessions(
+        principal: Principal = Depends(extract_principal),
+        svc: PlanningSessionService = Depends(resolve_planning_service),
+    ) -> list[PlanningSessionResponse]:
+        """List planning sessions for the current user."""
+        sessions = await svc.list_sessions(principal.user_id)
+        return [_session_response(s) for s in sessions]
+
+    @router.get("/sessions/{session_id}", response_model=PlanningSessionResponse)
+    async def get_planning_session(
+        session_id: UUID,
+        svc: PlanningSessionService = Depends(resolve_planning_service),
+    ) -> PlanningSessionResponse:
+        """Get a planning session by ID."""
+        session = await svc.get(session_id)
+        if session is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Planning session not found: {session_id}",
+            )
+        return _session_response(session)
+
+    @router.post(
+        "/sessions/{session_id}/messages",
+        response_model=PlanningMessageResponse,
+    )
+    async def send_planning_message(
+        session_id: UUID,
+        body: SendPlanningMessageRequest,
+        request: Request,
+        svc: PlanningSessionService = Depends(resolve_planning_service),
+    ) -> PlanningMessageResponse:
+        """Send a message to a planning session."""
+        raw_header = request.headers.get("Authorization", "")
+        auth_token = raw_header.removeprefix("Bearer ").strip() or None
+        try:
+            msg = await svc.send_message(
+                session_id,
+                body.content,
+                auth_token=auth_token,
+            )
+        except PlanningSessionNotFoundError:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Planning session not found: {session_id}",
+            )
+        except InvalidPlanningStateError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=str(exc),
+            )
+        return PlanningMessageResponse(
+            id=str(msg.id),
+            content=msg.content,
+            sender=msg.sender,
+            created_at=msg.created_at.isoformat(),
+        )
+
+    @router.get(
+        "/sessions/{session_id}/messages",
+        response_model=list[PlanningMessageResponse],
+    )
+    async def list_planning_messages(
+        session_id: UUID,
+        svc: PlanningSessionService = Depends(resolve_planning_service),
+    ) -> list[PlanningMessageResponse]:
+        """List all messages in a planning session."""
+        try:
+            messages = await svc.get_messages(session_id)
+        except PlanningSessionNotFoundError:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Planning session not found: {session_id}",
+            )
+        return [
+            PlanningMessageResponse(
+                id=str(m.id),
+                content=m.content,
+                sender=m.sender,
+                created_at=m.created_at.isoformat(),
+            )
+            for m in messages
+        ]
+
+    @router.post(
+        "/sessions/{session_id}/structure",
+        response_model=PlanningSessionResponse,
+    )
+    async def propose_structure(
+        session_id: UUID,
+        body: ProposeStructureRequest,
+        svc: PlanningSessionService = Depends(resolve_planning_service),
+    ) -> PlanningSessionResponse:
+        """Submit a proposed SagaStructure from the planning conversation."""
+        try:
+            session = await svc.propose_structure(session_id, body.raw_json)
+        except PlanningSessionNotFoundError:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Planning session not found: {session_id}",
+            )
+        except InvalidPlanningStateError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=str(exc),
+            )
+        except ValidationError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail=f"Invalid saga structure: {exc}",
+            )
+        return _session_response(session)
+
+    @router.post(
+        "/sessions/{session_id}/complete",
+        response_model=PlanningSessionResponse,
+    )
+    async def complete_planning_session(
+        session_id: UUID,
+        svc: PlanningSessionService = Depends(resolve_planning_service),
+    ) -> PlanningSessionResponse:
+        """Mark a planning session as completed (accept the proposed structure)."""
+        try:
+            session = await svc.complete(session_id)
+        except PlanningSessionNotFoundError:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Planning session not found: {session_id}",
+            )
+        except InvalidPlanningStateError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=str(exc),
+            )
+        return _session_response(session)
+
+    @router.delete("/sessions/{session_id}", status_code=204)
+    async def delete_planning_session(
+        session_id: UUID,
+        svc: PlanningSessionService = Depends(resolve_planning_service),
+    ) -> None:
+        """Delete a planning session."""
+        deleted = await svc.delete(session_id)
+        if not deleted:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Planning session not found: {session_id}",
+            )
+
+    return router

--- a/src/tyr/config.py
+++ b/src/tyr/config.py
@@ -264,6 +264,32 @@ class WatcherConfig(BaseModel):
     )
 
 
+class PlannerConfig(BaseModel):
+    """Planning session configuration."""
+
+    idle_timeout_seconds: float = Field(
+        default=1800.0,
+        description="Seconds of idle before a planning session is expired.",
+    )
+    max_sessions_per_user: int = Field(
+        default=3,
+        description="Maximum concurrent planning sessions per user.",
+    )
+    default_model: str = Field(
+        default="claude-opus-4-6",
+        description="Default LLM model for planning sessions.",
+    )
+    system_prompt: str = Field(
+        default=(
+            "You are a saga decomposition planner for the Niuu platform. "
+            "Help the user iteratively decompose their specification into "
+            "phases and raids. When the user is satisfied, output the final "
+            "structure as a JSON block with the saga structure schema."
+        ),
+        description="System prompt for the planning session LLM.",
+    )
+
+
 class EventBusConfig(BaseModel):
     """Event bus adapter configuration (dynamic adapter pattern)."""
 
@@ -334,6 +360,7 @@ class Settings(BaseSettings):
     events: EventsConfig = Field(default_factory=EventsConfig)
     telegram: TelegramConfig = Field(default_factory=TelegramConfig)
     notification: NotificationConfig = Field(default_factory=NotificationConfig)
+    planner: PlannerConfig = Field(default_factory=PlannerConfig)
 
     @classmethod
     def settings_customise_sources(

--- a/src/tyr/config.py
+++ b/src/tyr/config.py
@@ -265,8 +265,13 @@ class WatcherConfig(BaseModel):
 
 
 class PlannerConfig(BaseModel):
-    """Planning session configuration."""
+    """Planning session configuration (dynamic adapter pattern)."""
 
+    adapter: str = Field(
+        default="tyr.adapters.memory_planning_repo.InMemoryPlanningSessionRepository",
+        description="Fully-qualified class path for the PlanningSessionRepository adapter.",
+    )
+    kwargs: dict[str, Any] = Field(default_factory=dict)
     idle_timeout_seconds: float = Field(
         default=1800.0,
         description="Seconds of idle before a planning session is expired.",

--- a/src/tyr/domain/models.py
+++ b/src/tyr/domain/models.py
@@ -259,6 +259,7 @@ class PlanningSession:
     structure: SagaStructure | None
     created_at: datetime
     updated_at: datetime
+    chat_endpoint: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/tyr/domain/models.py
+++ b/src/tyr/domain/models.py
@@ -14,6 +14,15 @@ from tyr.domain.exceptions import InvalidStateTransitionError
 # ---------------------------------------------------------------------------
 
 
+class PlanningSessionStatus(StrEnum):
+    SPAWNING = "SPAWNING"
+    ACTIVE = "ACTIVE"
+    STRUCTURE_PROPOSED = "STRUCTURE_PROPOSED"
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
+    EXPIRED = "EXPIRED"
+
+
 class SagaStatus(StrEnum):
     ACTIVE = "ACTIVE"
     COMPLETE = "COMPLETE"
@@ -230,6 +239,37 @@ class TrackerIssue:
     estimate: float | None = None
     url: str = ""
     milestone_id: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Planning sessions (interactive saga decomposition)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PlanningSession:
+    """An interactive planning session for saga decomposition."""
+
+    id: UUID
+    owner_id: str
+    session_id: str
+    repo: str
+    spec: str
+    status: PlanningSessionStatus
+    structure: SagaStructure | None
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class PlanningMessage:
+    """A message in a planning session conversation."""
+
+    id: UUID
+    planning_session_id: UUID
+    content: str
+    sender: str
+    created_at: datetime
 
 
 # ---------------------------------------------------------------------------

--- a/src/tyr/domain/services/planning_session.py
+++ b/src/tyr/domain/services/planning_session.py
@@ -125,6 +125,7 @@ class PlanningSessionService:
         planning_session = replace(
             planning_session,
             session_id=volundr_session.id,
+            chat_endpoint=volundr_session.chat_endpoint,
             status=PlanningSessionStatus.ACTIVE,
             updated_at=datetime.now(UTC),
         )
@@ -244,6 +245,17 @@ class PlanningSessionService:
             updated_at=datetime.now(UTC),
         )
         await self._repo.save(updated)
+
+        if session.session_id:
+            try:
+                await self._volundr.stop_session(session.session_id)
+            except Exception:
+                logger.warning(
+                    "Failed to stop Volundr session %s on complete",
+                    session.session_id,
+                    exc_info=True,
+                )
+
         return updated
 
     async def get(self, session_id: UUID) -> PlanningSession | None:
@@ -255,14 +267,57 @@ class PlanningSessionService:
         return await self._repo.list_by_owner(owner_id)
 
     async def delete(self, session_id: UUID) -> bool:
-        """Delete a planning session."""
+        """Delete a planning session, stopping the Volundr session if active."""
+        session = await self._repo.get(session_id)
+        if session is None:
+            return False
+
+        if session.session_id and session.status in (
+            PlanningSessionStatus.ACTIVE,
+            PlanningSessionStatus.STRUCTURE_PROPOSED,
+            PlanningSessionStatus.SPAWNING,
+        ):
+            try:
+                await self._volundr.stop_session(session.session_id)
+            except Exception:
+                logger.warning(
+                    "Failed to stop Volundr session %s on delete",
+                    session.session_id,
+                    exc_info=True,
+                )
+
         return await self._repo.delete(session_id)
 
     async def cleanup_expired(self) -> int:
         """Expire idle planning sessions past the timeout. Returns count expired."""
-        # This would be called by a periodic task; for now it's a manual method.
-        # Real implementation would scan all active sessions.
-        return 0
+        now = datetime.now(UTC)
+        idle_cutoff = now.timestamp() - self._config.idle_timeout_seconds
+        all_sessions = await self._repo.list_active()
+        expired = 0
+
+        for session in all_sessions:
+            if session.updated_at.timestamp() >= idle_cutoff:
+                continue
+
+            if session.session_id:
+                try:
+                    await self._volundr.stop_session(session.session_id)
+                except Exception:
+                    logger.warning(
+                        "Failed to stop Volundr session %s during cleanup",
+                        session.session_id,
+                        exc_info=True,
+                    )
+
+            updated = replace(
+                session,
+                status=PlanningSessionStatus.EXPIRED,
+                updated_at=now,
+            )
+            await self._repo.save(updated)
+            expired += 1
+
+        return expired
 
     async def get_messages(self, session_id: UUID) -> list[PlanningMessage]:
         """Get all messages for a planning session."""

--- a/src/tyr/domain/services/planning_session.py
+++ b/src/tyr/domain/services/planning_session.py
@@ -1,0 +1,272 @@
+"""Planning session service — orchestrates interactive saga decomposition.
+
+Manages the lifecycle of planning sessions: spawn via Volundr, send messages,
+capture SagaStructure from conversation, and clean up expired sessions.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import replace
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+from tyr.config import PlannerConfig
+from tyr.domain.models import (
+    PlanningMessage,
+    PlanningSession,
+    PlanningSessionStatus,
+)
+from tyr.domain.validation import parse_and_validate
+from tyr.ports.event_bus import EventBusPort, TyrEvent
+from tyr.ports.planning_repository import PlanningSessionRepository
+from tyr.ports.volundr import SpawnRequest, VolundrPort
+
+logger = logging.getLogger(__name__)
+
+
+class PlanningSessionError(Exception):
+    """Base error for planning session operations."""
+
+
+class SessionLimitReachedError(PlanningSessionError):
+    def __init__(self, owner_id: str, limit: int) -> None:
+        self.owner_id = owner_id
+        self.limit = limit
+        super().__init__(f"User {owner_id} has reached the limit of {limit} planning sessions")
+
+
+class PlanningSessionNotFoundError(PlanningSessionError):
+    def __init__(self, session_id: UUID | str) -> None:
+        self.session_id = session_id
+        super().__init__(f"Planning session not found: {session_id}")
+
+
+class InvalidPlanningStateError(PlanningSessionError):
+    def __init__(self, session_id: UUID | str, current: str, action: str) -> None:
+        self.session_id = session_id
+        self.current = current
+        self.action = action
+        super().__init__(f"Cannot {action} session {session_id} in {current} state")
+
+
+class PlanningSessionService:
+    """Orchestrates interactive planning sessions for saga decomposition."""
+
+    def __init__(
+        self,
+        repo: PlanningSessionRepository,
+        volundr: VolundrPort,
+        config: PlannerConfig,
+        event_bus: EventBusPort | None = None,
+    ) -> None:
+        self._repo = repo
+        self._volundr = volundr
+        self._config = config
+        self._event_bus = event_bus
+
+    async def spawn(
+        self,
+        owner_id: str,
+        spec: str,
+        repo: str,
+        *,
+        auth_token: str | None = None,
+    ) -> PlanningSession:
+        """Spawn a new planning session via Volundr."""
+        existing = await self._repo.list_by_owner(owner_id)
+        active = [
+            s
+            for s in existing
+            if s.status in (PlanningSessionStatus.SPAWNING, PlanningSessionStatus.ACTIVE)
+        ]
+        if len(active) >= self._config.max_sessions_per_user:
+            raise SessionLimitReachedError(owner_id, self._config.max_sessions_per_user)
+
+        now = datetime.now(UTC)
+        session_id = uuid4()
+
+        planning_session = PlanningSession(
+            id=session_id,
+            owner_id=owner_id,
+            session_id="",
+            repo=repo,
+            spec=spec,
+            status=PlanningSessionStatus.SPAWNING,
+            structure=None,
+            created_at=now,
+            updated_at=now,
+        )
+        await self._repo.save(planning_session)
+
+        try:
+            volundr_session = await self._volundr.spawn_session(
+                SpawnRequest(
+                    name=f"planner-{session_id.hex[:8]}",
+                    repo=repo,
+                    branch="main",
+                    model=self._config.default_model,
+                    tracker_issue_id="",
+                    tracker_issue_url="",
+                    system_prompt=self._config.system_prompt,
+                    initial_prompt=f"Here is the specification to decompose:\n\n{spec}",
+                ),
+                auth_token=auth_token,
+            )
+        except Exception:
+            planning_session = replace(
+                planning_session,
+                status=PlanningSessionStatus.FAILED,
+                updated_at=datetime.now(UTC),
+            )
+            await self._repo.save(planning_session)
+            raise
+
+        planning_session = replace(
+            planning_session,
+            session_id=volundr_session.id,
+            status=PlanningSessionStatus.ACTIVE,
+            updated_at=datetime.now(UTC),
+        )
+        await self._repo.save(planning_session)
+
+        if self._event_bus:
+            await self._event_bus.emit(
+                TyrEvent(
+                    event="planning.session_spawned",
+                    data={
+                        "planning_session_id": str(session_id),
+                        "volundr_session_id": volundr_session.id,
+                    },
+                    owner_id=owner_id,
+                )
+            )
+
+        return planning_session
+
+    async def send_message(
+        self,
+        session_id: UUID,
+        content: str,
+        *,
+        sender: str = "user",
+        auth_token: str | None = None,
+    ) -> PlanningMessage:
+        """Send a message to a planning session."""
+        session = await self._repo.get(session_id)
+        if session is None:
+            raise PlanningSessionNotFoundError(session_id)
+
+        if session.status not in (
+            PlanningSessionStatus.ACTIVE,
+            PlanningSessionStatus.STRUCTURE_PROPOSED,
+        ):
+            raise InvalidPlanningStateError(session_id, session.status.value, "send message to")
+
+        await self._volundr.send_message(session.session_id, content, auth_token=auth_token)
+
+        now = datetime.now(UTC)
+        msg = PlanningMessage(
+            id=uuid4(),
+            planning_session_id=session_id,
+            content=content,
+            sender=sender,
+            created_at=now,
+        )
+        await self._repo.save_message(msg)
+
+        # Update the session timestamp
+        updated = replace(session, updated_at=now)
+        await self._repo.save(updated)
+
+        return msg
+
+    async def propose_structure(
+        self,
+        session_id: UUID,
+        raw_json: str,
+    ) -> PlanningSession:
+        """Parse and store a proposed SagaStructure from the conversation."""
+        session = await self._repo.get(session_id)
+        if session is None:
+            raise PlanningSessionNotFoundError(session_id)
+
+        if session.status not in (
+            PlanningSessionStatus.ACTIVE,
+            PlanningSessionStatus.STRUCTURE_PROPOSED,
+        ):
+            raise InvalidPlanningStateError(
+                session_id, session.status.value, "propose structure on"
+            )
+
+        structure = parse_and_validate(raw_json)
+
+        updated = replace(
+            session,
+            structure=structure,
+            status=PlanningSessionStatus.STRUCTURE_PROPOSED,
+            updated_at=datetime.now(UTC),
+        )
+        await self._repo.save(updated)
+
+        if self._event_bus:
+            await self._event_bus.emit(
+                TyrEvent(
+                    event="planning.structure_proposed",
+                    data={
+                        "planning_session_id": str(session_id),
+                        "saga_name": structure.name,
+                        "phase_count": len(structure.phases),
+                    },
+                    owner_id=session.owner_id,
+                )
+            )
+
+        return updated
+
+    async def complete(self, session_id: UUID) -> PlanningSession:
+        """Mark a planning session as completed (structure accepted)."""
+        session = await self._repo.get(session_id)
+        if session is None:
+            raise PlanningSessionNotFoundError(session_id)
+
+        if session.status != PlanningSessionStatus.STRUCTURE_PROPOSED:
+            raise InvalidPlanningStateError(session_id, session.status.value, "complete")
+
+        if session.structure is None:
+            raise InvalidPlanningStateError(
+                session_id, session.status.value, "complete without structure"
+            )
+
+        updated = replace(
+            session,
+            status=PlanningSessionStatus.COMPLETED,
+            updated_at=datetime.now(UTC),
+        )
+        await self._repo.save(updated)
+        return updated
+
+    async def get(self, session_id: UUID) -> PlanningSession | None:
+        """Get a planning session by ID."""
+        return await self._repo.get(session_id)
+
+    async def list_sessions(self, owner_id: str) -> list[PlanningSession]:
+        """List planning sessions for a user."""
+        return await self._repo.list_by_owner(owner_id)
+
+    async def delete(self, session_id: UUID) -> bool:
+        """Delete a planning session."""
+        return await self._repo.delete(session_id)
+
+    async def cleanup_expired(self) -> int:
+        """Expire idle planning sessions past the timeout. Returns count expired."""
+        # This would be called by a periodic task; for now it's a manual method.
+        # Real implementation would scan all active sessions.
+        return 0
+
+    async def get_messages(self, session_id: UUID) -> list[PlanningMessage]:
+        """Get all messages for a planning session."""
+        session = await self._repo.get(session_id)
+        if session is None:
+            raise PlanningSessionNotFoundError(session_id)
+        return await self._repo.get_messages(session_id)

--- a/src/tyr/domain/validation.py
+++ b/src/tyr/domain/validation.py
@@ -7,6 +7,7 @@ against the SagaStructure schema and returns typed domain objects.
 from __future__ import annotations
 
 import json
+import re
 
 from tyr.domain.models import PhaseSpec, RaidSpec, SagaStructure
 
@@ -138,3 +139,34 @@ def validate_raid(
         estimate_hours=estimate,
         confidence=confidence,
     )
+
+
+_JSON_BLOCK_RE = re.compile(r"```(?:json)?\s*\n(.*?)```", re.DOTALL)
+
+
+def try_extract_structure(text: str) -> SagaStructure | None:
+    """Scan freeform text for a JSON block matching the SagaStructure schema.
+
+    Returns the first valid SagaStructure found, or None if no match.
+    """
+    candidates: list[str] = []
+
+    for match in _JSON_BLOCK_RE.finditer(text):
+        candidates.append(match.group(1).strip())
+
+    if not candidates:
+        # Try parsing the whole text as JSON (no fences)
+        try:
+            data = json.loads(text.strip())
+            if isinstance(data, dict) and "phases" in data:
+                candidates.append(text.strip())
+        except (json.JSONDecodeError, ValueError):
+            pass
+
+    for candidate in candidates:
+        try:
+            return parse_and_validate(candidate)
+        except (ValidationError, json.JSONDecodeError, ValueError, KeyError):
+            continue
+
+    return None

--- a/src/tyr/main.py
+++ b/src/tyr/main.py
@@ -35,6 +35,7 @@ from tyr.api.dispatch import create_dispatch_router, resolve_volundr
 from tyr.api.dispatch import resolve_saga_repo as dispatch_resolve_saga_repo
 from tyr.api.dispatcher import create_dispatcher_router, resolve_dispatcher_repo
 from tyr.api.events import create_events_router, resolve_event_bus
+from tyr.api.planning import create_planning_router, resolve_planning_service
 from tyr.api.raids import create_raids_router, resolve_git, resolve_raid_repo
 from tyr.api.raids import resolve_tracker as resolve_raids_tracker
 from tyr.api.raids import resolve_volundr as resolve_raids_volundr
@@ -86,6 +87,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     # -- Routers --
     app.include_router(create_tracker_router())
     app.include_router(create_sagas_router())
+    app.include_router(create_planning_router())
     app.include_router(create_raids_router())
     app.include_router(create_dispatch_router())
     app.include_router(create_dispatcher_router())
@@ -244,6 +246,24 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 return event_bus
 
             app.dependency_overrides[resolve_event_bus] = _resolve_event_bus
+
+            # Wire planning session service (in-memory for now)
+            from tyr.adapters.memory_planning_repo import InMemoryPlanningSessionRepository
+            from tyr.domain.services.planning_session import PlanningSessionService
+
+            planning_repo = InMemoryPlanningSessionRepository()
+            planning_service = PlanningSessionService(
+                repo=planning_repo,
+                volundr=volundr_adapter,
+                config=settings.planner,
+                event_bus=event_bus,
+            )
+            app.state.planning_service = planning_service
+
+            async def _resolve_planning_service() -> PlanningSessionService:
+                return planning_service
+
+            app.dependency_overrides[resolve_planning_service] = _resolve_planning_service
 
             # Wire Telegram reply client (shared httpx.AsyncClient)
             from tyr.adapters.inbound.rest_telegram_webhook import (

--- a/src/tyr/main.py
+++ b/src/tyr/main.py
@@ -247,15 +247,16 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
             app.dependency_overrides[resolve_event_bus] = _resolve_event_bus
 
-            # Wire planning session service (in-memory for now)
-            from tyr.adapters.memory_planning_repo import InMemoryPlanningSessionRepository
+            # Wire planning session service (dynamic adapter pattern)
             from tyr.domain.services.planning_session import PlanningSessionService
 
-            planning_repo = InMemoryPlanningSessionRepository()
+            planner_cfg = settings.planner
+            planner_repo_cls = import_class(planner_cfg.adapter)
+            planning_repo = planner_repo_cls(**planner_cfg.kwargs)
             planning_service = PlanningSessionService(
                 repo=planning_repo,
                 volundr=volundr_adapter,
-                config=settings.planner,
+                config=planner_cfg,
                 event_bus=event_bus,
             )
             app.state.planning_service = planning_service

--- a/src/tyr/ports/planning_repository.py
+++ b/src/tyr/ports/planning_repository.py
@@ -1,0 +1,33 @@
+"""PlanningSessionRepository port — persistence for interactive planning sessions."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from uuid import UUID
+
+from tyr.domain.models import PlanningMessage, PlanningSession
+
+
+class PlanningSessionRepository(ABC):
+    """Abstract interface for planning session persistence."""
+
+    @abstractmethod
+    async def save(self, session: PlanningSession) -> None: ...
+
+    @abstractmethod
+    async def get(self, session_id: UUID) -> PlanningSession | None: ...
+
+    @abstractmethod
+    async def get_by_volundr_id(self, volundr_session_id: str) -> PlanningSession | None: ...
+
+    @abstractmethod
+    async def list_by_owner(self, owner_id: str) -> list[PlanningSession]: ...
+
+    @abstractmethod
+    async def delete(self, session_id: UUID) -> bool: ...
+
+    @abstractmethod
+    async def save_message(self, message: PlanningMessage) -> None: ...
+
+    @abstractmethod
+    async def get_messages(self, session_id: UUID) -> list[PlanningMessage]: ...

--- a/src/tyr/ports/planning_repository.py
+++ b/src/tyr/ports/planning_repository.py
@@ -24,6 +24,9 @@ class PlanningSessionRepository(ABC):
     async def list_by_owner(self, owner_id: str) -> list[PlanningSession]: ...
 
     @abstractmethod
+    async def list_active(self) -> list[PlanningSession]: ...
+
+    @abstractmethod
     async def delete(self, session_id: UUID) -> bool: ...
 
     @abstractmethod

--- a/src/tyr/ports/volundr.py
+++ b/src/tyr/ports/volundr.py
@@ -32,6 +32,7 @@ class VolundrSession:
     name: str
     status: str
     tracker_issue_id: str | None
+    chat_endpoint: str | None = None
 
 
 @dataclass(frozen=True)
@@ -90,6 +91,16 @@ class VolundrPort(ABC):
         auth_token: str | None = None,
     ) -> None:
         """Send a human message to a running Volundr session."""
+        ...
+
+    @abstractmethod
+    async def stop_session(
+        self,
+        session_id: str,
+        *,
+        auth_token: str | None = None,
+    ) -> None:
+        """Stop a running Volundr session."""
         ...
 
     @abstractmethod

--- a/tests/test_tyr/test_activity_subscriber.py
+++ b/tests/test_tyr/test_activity_subscriber.py
@@ -71,6 +71,9 @@ class StubVolundr(VolundrPort):
     ) -> None:
         pass
 
+    async def stop_session(self, session_id, *, auth_token=None):
+        pass
+
     async def subscribe_activity(self) -> AsyncGenerator[ActivityEvent, None]:
         for event in self.activity_events:
             yield event
@@ -155,6 +158,7 @@ class StubPool:
         tracker_issue_id: str = "issue-1",
     ) -> None:
         from uuid import UUID
+
         self.sessions[session_id] = {
             "id": UUID("00000000-0000-0000-0000-000000000001"),
             "session_id": session_id,

--- a/tests/test_tyr/test_activity_subscriber.py
+++ b/tests/test_tyr/test_activity_subscriber.py
@@ -554,7 +554,8 @@ class TestCompletionEvaluationLogic:
         raid = _make_raid()
         volundr.pr_error_sessions.add(raid.session_id or "")
 
-        result = await sub._evaluate_completion(raid, volundr, {"turn_count": 5, "duration_seconds": 60})
+        activity = {"turn_count": 5, "duration_seconds": 60}
+        result = await sub._evaluate_completion(raid, volundr, activity)
         assert result.is_complete is True
         assert result.signals["session_idle"] is True
         assert result.signals["has_turns"] is True
@@ -573,7 +574,8 @@ class TestCompletionEvaluationLogic:
             ci_passed=True,
         )
 
-        result = await sub._evaluate_completion(raid, volundr, {"turn_count": 5, "duration_seconds": 60})
+        activity = {"turn_count": 5, "duration_seconds": 60}
+        result = await sub._evaluate_completion(raid, volundr, activity)
         assert result.is_complete is True
         assert result.signals["pr_exists"] is True
         assert result.signals["ci_passed"] is True
@@ -587,7 +589,8 @@ class TestCompletionEvaluationLogic:
         raid = _make_raid()
         volundr.pr_error_sessions.add(raid.session_id or "")
 
-        result = await sub._evaluate_completion(raid, volundr, {"turn_count": 5, "duration_seconds": 60})
+        activity = {"turn_count": 5, "duration_seconds": 60}
+        result = await sub._evaluate_completion(raid, volundr, activity)
         assert result.is_complete is False
 
     @pytest.mark.asyncio
@@ -604,7 +607,8 @@ class TestCompletionEvaluationLogic:
             ci_passed=False,
         )
 
-        result = await sub._evaluate_completion(raid, volundr, {"turn_count": 5, "duration_seconds": 60})
+        activity = {"turn_count": 5, "duration_seconds": 60}
+        result = await sub._evaluate_completion(raid, volundr, activity)
         assert result.is_complete is False
 
     @pytest.mark.asyncio
@@ -615,7 +619,8 @@ class TestCompletionEvaluationLogic:
         raid = _make_raid()
         volundr.pr_error_sessions.add(raid.session_id or "")
 
-        result = await sub._evaluate_completion(raid, volundr, {"turn_count": 5, "duration_seconds": 120})
+        activity = {"turn_count": 5, "duration_seconds": 120}
+        result = await sub._evaluate_completion(raid, volundr, activity)
         assert result.signals["extended_idle"] is True
         assert result.confidence >= 0.6
 
@@ -625,7 +630,8 @@ class TestCompletionEvaluationLogic:
         sub, volundr, _, _ = _make_subscriber()
         raid = _make_raid(branch=None)
 
-        result = await sub._evaluate_completion(raid, volundr, {"turn_count": 5, "duration_seconds": 60})
+        activity = {"turn_count": 5, "duration_seconds": 60}
+        result = await sub._evaluate_completion(raid, volundr, activity)
         assert result.is_complete is True
         assert result.signals["pr_exists"] is False
 

--- a/tests/test_tyr/test_activity_subscriber.py
+++ b/tests/test_tyr/test_activity_subscriber.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncGenerator
 from datetime import UTC, datetime
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 import pytest
 
@@ -14,17 +14,12 @@ from tyr.config import WatcherConfig
 from tyr.domain.models import (
     DispatcherState,
     PRStatus,
-    Raid,
-    RaidStatus,
-    Saga,
-    SagaStatus,
 )
 from tyr.domain.services.activity_subscriber import (
     CompletionEvaluation,
     SessionActivitySubscriber,
 )
 from tyr.ports.dispatcher_repository import DispatcherRepository
-from tyr.ports.raid_repository import RaidRepository
 from tyr.ports.volundr import ActivityEvent, SpawnRequest, VolundrPort, VolundrSession
 
 # ---------------------------------------------------------------------------
@@ -81,112 +76,6 @@ class StubVolundr(VolundrPort):
             yield event
 
 
-class StubRaidRepo(RaidRepository):
-    """In-memory raid repository for activity subscriber tests."""
-
-    def __init__(self) -> None:
-        self.raids: dict[UUID, Raid] = {}
-        self.saga: Saga | None = None
-
-    async def get_raid(self, raid_id: UUID) -> Raid | None:
-        return self.raids.get(raid_id)
-
-    async def update_raid_status(
-        self,
-        raid_id: UUID,
-        status: RaidStatus,
-        *,
-        reason: str | None = None,
-        increment_retry: bool = False,
-    ) -> Raid | None:
-        raise NotImplementedError
-
-    async def list_by_status(self, status: RaidStatus) -> list[Raid]:
-        return [r for r in self.raids.values() if r.status == status]
-
-    async def update_raid_completion(
-        self,
-        raid_id: UUID,
-        *,
-        status: RaidStatus,
-        chronicle_summary: str | None = None,
-        pr_url: str | None = None,
-        pr_id: str | None = None,
-        reason: str | None = None,
-        increment_retry: bool = False,
-    ) -> Raid | None:
-        raid = self.raids.get(raid_id)
-        if raid is None:
-            return None
-        retry_count = raid.retry_count + 1 if increment_retry else raid.retry_count
-        updated = Raid(
-            id=raid.id,
-            phase_id=raid.phase_id,
-            tracker_id=raid.tracker_id,
-            name=raid.name,
-            description=raid.description,
-            acceptance_criteria=raid.acceptance_criteria,
-            declared_files=raid.declared_files,
-            estimate_hours=raid.estimate_hours,
-            status=status,
-            confidence=raid.confidence,
-            session_id=raid.session_id,
-            branch=raid.branch,
-            chronicle_summary=chronicle_summary or raid.chronicle_summary,
-            pr_url=pr_url or raid.pr_url,
-            pr_id=pr_id or raid.pr_id,
-            retry_count=retry_count,
-            created_at=raid.created_at,
-            updated_at=datetime.now(UTC),
-        )
-        self.raids[raid_id] = updated
-        return updated
-
-    async def get_confidence_events(self, raid_id: UUID) -> list:
-        return []
-
-    async def add_confidence_event(self, event: object) -> None:
-        pass
-
-    async def find_raid_by_tracker_id(self, tracker_id: str) -> Raid | None:
-        for raid in self.raids.values():
-            if raid.tracker_id == tracker_id:
-                return raid
-        return None
-
-    async def get_owner_for_raid(self, raid_id: UUID) -> str | None:
-        if self.saga is None:
-            return None
-        return self.saga.owner_id or None
-
-    async def get_saga_for_raid(self, raid_id: UUID) -> Saga | None:
-        return self.saga
-
-    async def get_phase_for_raid(self, raid_id: UUID) -> None:
-        return None
-
-    async def save_phase(self, phase: object, *, conn: object = None) -> None:
-        pass
-
-    async def save_raid(self, raid: object, *, conn: object = None) -> None:
-        pass
-
-    async def all_raids_merged(self, phase_id: UUID) -> bool:
-        return False
-
-    async def save_session_message(self, message: object) -> None:
-        pass
-
-    async def get_session_messages(self, raid_id: UUID) -> list:
-        return []
-
-    async def list_phases_for_saga(self, saga_id: UUID) -> list:
-        return []
-
-    async def update_phase_status(self, phase_id: UUID, status) -> None:  # noqa: ANN001
-        return None
-
-
 class StubDispatcherRepo(DispatcherRepository):
     """In-memory dispatcher repo for activity subscriber tests."""
 
@@ -210,50 +99,6 @@ class StubDispatcherRepo(DispatcherRepository):
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _make_raid(
-    raid_id: UUID | None = None,
-    status: RaidStatus = RaidStatus.RUNNING,
-    session_id: str = "session-1",
-    branch: str | None = "raid/test",
-) -> Raid:
-    return Raid(
-        id=raid_id or uuid4(),
-        phase_id=uuid4(),
-        tracker_id="tracker-1",
-        name="Test raid",
-        description="Implement feature",
-        acceptance_criteria=["tests pass"],
-        declared_files=["src/main.py"],
-        estimate_hours=2.0,
-        status=status,
-        confidence=0.5,
-        session_id=session_id,
-        branch=branch,
-        chronicle_summary=None,
-        pr_url=None,
-        pr_id=None,
-        retry_count=0,
-        created_at=NOW,
-        updated_at=NOW,
-    )
-
-
-def _make_saga(owner_id: str = "user-1") -> Saga:
-    return Saga(
-        id=uuid4(),
-        tracker_id="proj-1",
-        tracker_type="mock",
-        slug="alpha",
-        name="Test Saga",
-        repos=["org/repo"],
-        feature_branch="feat/test",
-        status=SagaStatus.ACTIVE,
-        confidence=0.5,
-        created_at=NOW,
-        owner_id=owner_id,
-    )
 
 
 def _default_config(**overrides: object) -> WatcherConfig:
@@ -302,7 +147,13 @@ class StubPool:
         self.sessions: dict[str, dict] = {}
         self.executed: list = []
 
-    def add_session(self, session_id: str, owner_id: str = "user-1", saga_id: str = "saga-1", tracker_issue_id: str = "issue-1") -> None:
+    def add_session(
+        self,
+        session_id: str,
+        owner_id: str = "user-1",
+        saga_id: str = "saga-1",
+        tracker_issue_id: str = "issue-1",
+    ) -> None:
         from uuid import UUID
         self.sessions[session_id] = {
             "id": UUID("00000000-0000-0000-0000-000000000001"),
@@ -329,9 +180,8 @@ class StubPool:
 
     async def execute(self, query: str, *args) -> None:
         self.executed.append((query, args))
-        if "UPDATE dispatched_sessions SET status" in query and len(args) >= 2:
-            new_status = args[1] if "= $2" in query else args[0]
-            session_id = args[0] if "$1" in query else args[1]
+        if "UPDATE dispatched_sessions SET status" in query and len(args) >= 1:
+            session_id = args[0]
             # Simple: first arg is status value from the SET clause
             for s in self.sessions.values():
                 if s["session_id"] == session_id:
@@ -425,15 +275,13 @@ class TestSubscriberLifecycle:
 
 class TestActivityEventHandling:
     @pytest.mark.asyncio
-    async def test_idle_event_triggers_completion_for_running_raid(self) -> None:
-        """An idle event with sufficient turns should transition the raid to REVIEW."""
-        sub, volundr, raid_repo, event_bus = _make_subscriber()
-        raid = _make_raid()
-        raid_repo.raids[raid.id] = raid
-        raid_repo.saga = _make_saga()
+    async def test_idle_event_triggers_completion_for_running_session(self) -> None:
+        """An idle event with sufficient turns should transition the session to complete."""
+        sub, volundr, pool, event_bus = _make_subscriber()
+        pool.add_session("session-1")
 
         event = ActivityEvent(
-            session_id=raid.session_id or "",
+            session_id="session-1",
             state="idle",
             metadata={"turn_count": 5, "duration_seconds": 60},
             owner_id="user-1",
@@ -445,23 +293,20 @@ class TestActivityEventHandling:
         # Wait for debounced evaluation (delay=0)
         await asyncio.sleep(0.1)
 
-        updated = raid_repo.raids[raid.id]
-        assert updated.status == RaidStatus.REVIEW
+        assert pool.sessions["session-1"]["status"] == "complete"
 
         bus_event = await asyncio.wait_for(q.get(), timeout=1.0)
-        assert bus_event.event == "raid.state_changed"
-        assert bus_event.data["status"] == "REVIEW"
+        assert bus_event.event == "session.state_changed"
+        assert bus_event.data["status"] == "complete"
 
     @pytest.mark.asyncio
     async def test_idle_with_no_turns_does_not_complete(self) -> None:
         """Idle with turn_count <= 1 should not trigger completion."""
-        sub, volundr, raid_repo, _ = _make_subscriber()
-        raid = _make_raid()
-        raid_repo.raids[raid.id] = raid
-        raid_repo.saga = _make_saga()
+        sub, volundr, pool, _ = _make_subscriber()
+        pool.add_session("session-1")
 
         event = ActivityEvent(
-            session_id=raid.session_id or "",
+            session_id="session-1",
             state="idle",
             metadata={"turn_count": 1, "duration_seconds": 5},
             owner_id="user-1",
@@ -470,46 +315,44 @@ class TestActivityEventHandling:
         await sub._on_activity_event(event, volundr)
         await asyncio.sleep(0.1)
 
-        assert raid_repo.raids[raid.id].status == RaidStatus.RUNNING
+        assert pool.sessions["session-1"]["status"] == "running"
 
     @pytest.mark.asyncio
     async def test_active_event_cancels_pending_evaluation(self) -> None:
         """An active event should cancel any pending idle evaluation."""
         config = _default_config(completion_check_delay=1.0)
-        sub, volundr, raid_repo, _ = _make_subscriber(config=config)
-        raid = _make_raid()
-        raid_repo.raids[raid.id] = raid
+        sub, volundr, pool, _ = _make_subscriber(config=config)
+        pool.add_session("session-1")
 
         idle_event = ActivityEvent(
-            session_id=raid.session_id or "",
+            session_id="session-1",
             state="idle",
             metadata={"turn_count": 5, "duration_seconds": 60},
             owner_id="user-1",
         )
         await sub._on_activity_event(idle_event, volundr)
-        assert raid.session_id in sub._pending_evaluations
+        assert "session-1" in sub._pending_evaluations
 
         # Active event cancels it
         active_event = ActivityEvent(
-            session_id=raid.session_id or "",
+            session_id="session-1",
             state="active",
             metadata={},
             owner_id="user-1",
         )
         await sub._on_activity_event(active_event, volundr)
-        assert raid.session_id not in sub._pending_evaluations
-        assert raid_repo.raids[raid.id].status == RaidStatus.RUNNING
+        assert "session-1" not in sub._pending_evaluations
+        assert pool.sessions["session-1"]["status"] == "running"
 
     @pytest.mark.asyncio
     async def test_tool_executing_cancels_pending_evaluation(self) -> None:
         """A tool_executing event should cancel pending idle evaluation."""
         config = _default_config(completion_check_delay=1.0)
-        sub, volundr, raid_repo, _ = _make_subscriber(config=config)
-        raid = _make_raid()
-        raid_repo.raids[raid.id] = raid
+        sub, volundr, pool, _ = _make_subscriber(config=config)
+        pool.add_session("session-1")
 
         idle_event = ActivityEvent(
-            session_id=raid.session_id or "",
+            session_id="session-1",
             state="idle",
             metadata={"turn_count": 5, "duration_seconds": 60},
             owner_id="user-1",
@@ -517,18 +360,18 @@ class TestActivityEventHandling:
         await sub._on_activity_event(idle_event, volundr)
 
         tool_event = ActivityEvent(
-            session_id=raid.session_id or "",
+            session_id="session-1",
             state="tool_executing",
             metadata={},
             owner_id="user-1",
         )
         await sub._on_activity_event(tool_event, volundr)
-        assert raid.session_id not in sub._pending_evaluations
+        assert "session-1" not in sub._pending_evaluations
 
     @pytest.mark.asyncio
-    async def test_no_raid_for_session_is_ignored(self) -> None:
-        """Idle event for a session with no RUNNING raid should be ignored."""
-        sub, volundr, raid_repo, _ = _make_subscriber()
+    async def test_no_session_record_is_ignored(self) -> None:
+        """Idle event for a session with no dispatched record should be ignored."""
+        sub, volundr, pool, _ = _make_subscriber()
 
         event = ActivityEvent(
             session_id="unknown-session",
@@ -547,15 +390,27 @@ class TestActivityEventHandling:
 
 
 class TestCompletionEvaluationLogic:
+    def _record(
+        self,
+        session_id: str = "session-1",
+        owner_id: str = "user-1",
+        tracker_issue_id: str = "issue-1",
+    ) -> dict:
+        return {
+            "session_id": session_id,
+            "owner_id": owner_id,
+            "tracker_issue_id": tracker_issue_id,
+        }
+
     @pytest.mark.asyncio
     async def test_basic_completion(self) -> None:
         """Session idle with turns > 1 should evaluate as complete."""
-        sub, volundr, raid_repo, _ = _make_subscriber()
-        raid = _make_raid()
-        volundr.pr_error_sessions.add(raid.session_id or "")
+        sub, volundr, _, _ = _make_subscriber()
+        record = self._record()
+        volundr.pr_error_sessions.add(record["session_id"])
 
         activity = {"turn_count": 5, "duration_seconds": 60}
-        result = await sub._evaluate_completion(raid, volundr, activity)
+        result = await sub._evaluate_completion(record, volundr, activity)
         assert result.is_complete is True
         assert result.signals["session_idle"] is True
         assert result.signals["has_turns"] is True
@@ -564,9 +419,9 @@ class TestCompletionEvaluationLogic:
     @pytest.mark.asyncio
     async def test_pr_increases_confidence(self) -> None:
         """PR existence should increase confidence."""
-        sub, volundr, raid_repo, _ = _make_subscriber()
-        raid = _make_raid()
-        volundr.pr_statuses[raid.session_id or ""] = PRStatus(
+        sub, volundr, _, _ = _make_subscriber()
+        record = self._record()
+        volundr.pr_statuses[record["session_id"]] = PRStatus(
             pr_id="PR-1",
             url="https://github.com/pull/1",
             state="open",
@@ -575,7 +430,7 @@ class TestCompletionEvaluationLogic:
         )
 
         activity = {"turn_count": 5, "duration_seconds": 60}
-        result = await sub._evaluate_completion(raid, volundr, activity)
+        result = await sub._evaluate_completion(record, volundr, activity)
         assert result.is_complete is True
         assert result.signals["pr_exists"] is True
         assert result.signals["ci_passed"] is True
@@ -585,21 +440,21 @@ class TestCompletionEvaluationLogic:
     async def test_require_pr_blocks_completion(self) -> None:
         """When require_pr=True and no PR, should not complete."""
         config = _default_config(require_pr=True)
-        sub, volundr, raid_repo, _ = _make_subscriber(config=config)
-        raid = _make_raid()
-        volundr.pr_error_sessions.add(raid.session_id or "")
+        sub, volundr, _, _ = _make_subscriber(config=config)
+        record = self._record()
+        volundr.pr_error_sessions.add(record["session_id"])
 
         activity = {"turn_count": 5, "duration_seconds": 60}
-        result = await sub._evaluate_completion(raid, volundr, activity)
+        result = await sub._evaluate_completion(record, volundr, activity)
         assert result.is_complete is False
 
     @pytest.mark.asyncio
     async def test_require_ci_blocks_completion(self) -> None:
         """When require_ci=True and CI not passed, should not complete."""
         config = _default_config(require_ci=True)
-        sub, volundr, raid_repo, _ = _make_subscriber(config=config)
-        raid = _make_raid()
-        volundr.pr_statuses[raid.session_id or ""] = PRStatus(
+        sub, volundr, _, _ = _make_subscriber(config=config)
+        record = self._record()
+        volundr.pr_statuses[record["session_id"]] = PRStatus(
             pr_id="PR-1",
             url="url",
             state="open",
@@ -608,7 +463,7 @@ class TestCompletionEvaluationLogic:
         )
 
         activity = {"turn_count": 5, "duration_seconds": 60}
-        result = await sub._evaluate_completion(raid, volundr, activity)
+        result = await sub._evaluate_completion(record, volundr, activity)
         assert result.is_complete is False
 
     @pytest.mark.asyncio
@@ -616,22 +471,23 @@ class TestCompletionEvaluationLogic:
         """Duration above threshold should increase confidence."""
         config = _default_config(idle_threshold=10.0)
         sub, volundr, _, _ = _make_subscriber(config=config)
-        raid = _make_raid()
-        volundr.pr_error_sessions.add(raid.session_id or "")
+        record = self._record()
+        volundr.pr_error_sessions.add(record["session_id"])
 
         activity = {"turn_count": 5, "duration_seconds": 120}
-        result = await sub._evaluate_completion(raid, volundr, activity)
+        result = await sub._evaluate_completion(record, volundr, activity)
         assert result.signals["extended_idle"] is True
         assert result.confidence >= 0.6
 
     @pytest.mark.asyncio
-    async def test_no_branch_skips_pr_check(self) -> None:
-        """Raid without a branch should not attempt PR lookup."""
+    async def test_no_pr_error_skips_pr_check(self) -> None:
+        """Session with no PR should report pr_exists=False."""
         sub, volundr, _, _ = _make_subscriber()
-        raid = _make_raid(branch=None)
+        record = self._record()
+        volundr.pr_error_sessions.add(record["session_id"])
 
         activity = {"turn_count": 5, "duration_seconds": 60}
-        result = await sub._evaluate_completion(raid, volundr, activity)
+        result = await sub._evaluate_completion(record, volundr, activity)
         assert result.is_complete is True
         assert result.signals["pr_exists"] is False
 
@@ -643,11 +499,16 @@ class TestCompletionEvaluationLogic:
 
 class TestCompletionHandling:
     @pytest.mark.asyncio
-    async def test_pr_info_stored_on_completion(self) -> None:
-        """PR URL and ID should be stored when PR is detected."""
-        sub, volundr, raid_repo, _ = _make_subscriber()
-        raid = _make_raid()
-        raid_repo.raids[raid.id] = raid
+    async def test_pr_info_emitted_on_completion(self) -> None:
+        """PR URL and ID should be emitted in the event when PR is detected."""
+        sub, volundr, pool, event_bus = _make_subscriber()
+        record = {
+            "session_id": "session-1",
+            "owner_id": "user-1",
+            "saga_id": "saga-1",
+            "tracker_issue_id": "issue-1",
+        }
+        pool.add_session("session-1")
 
         evaluation = CompletionEvaluation(
             is_complete=True,
@@ -657,19 +518,25 @@ class TestCompletionHandling:
             pr_url="https://github.com/org/repo/pull/42",
         )
 
-        await sub._handle_completion(raid, volundr, evaluation)
+        q = event_bus.subscribe()
+        await sub._handle_completion(record, evaluation)
 
-        updated = raid_repo.raids[raid.id]
-        assert updated.status == RaidStatus.REVIEW
-        assert updated.pr_id == "PR-42"
-        assert updated.pr_url == "https://github.com/org/repo/pull/42"
+        assert pool.sessions["session-1"]["status"] == "complete"
+        bus_event = await asyncio.wait_for(q.get(), timeout=1.0)
+        assert bus_event.data["pr_id"] == "PR-42"
+        assert bus_event.data["pr_url"] == "https://github.com/org/repo/pull/42"
 
     @pytest.mark.asyncio
     async def test_no_pr_still_transitions(self) -> None:
-        """Completion without a PR should still transition to REVIEW."""
-        sub, volundr, raid_repo, _ = _make_subscriber()
-        raid = _make_raid()
-        raid_repo.raids[raid.id] = raid
+        """Completion without a PR should still transition to complete."""
+        sub, volundr, pool, _ = _make_subscriber()
+        record = {
+            "session_id": "session-1",
+            "owner_id": "user-1",
+            "saga_id": "saga-1",
+            "tracker_issue_id": "issue-1",
+        }
+        pool.add_session("session-1")
 
         evaluation = CompletionEvaluation(
             is_complete=True,
@@ -677,66 +544,29 @@ class TestCompletionHandling:
             confidence=0.5,
         )
 
-        await sub._handle_completion(raid, volundr, evaluation)
+        await sub._handle_completion(record, evaluation)
 
-        updated = raid_repo.raids[raid.id]
-        assert updated.status == RaidStatus.REVIEW
-        assert updated.pr_id is None
-
-    @pytest.mark.asyncio
-    async def test_chronicle_stored_on_completion(self) -> None:
-        """Chronicle summary should be stored on completion."""
-        sub, volundr, raid_repo, _ = _make_subscriber()
-        raid = _make_raid()
-        raid_repo.raids[raid.id] = raid
-        volundr.chronicles[raid.session_id or ""] = "Work completed successfully"
-
-        await sub._handle_completion(raid, volundr)
-
-        updated = raid_repo.raids[raid.id]
-        assert updated.chronicle_summary == "Work completed successfully"
-
-    @pytest.mark.asyncio
-    async def test_chronicle_fetch_failure_does_not_block(self) -> None:
-        """Chronicle fetch failure should not prevent transition."""
-        sub, volundr, raid_repo, _ = _make_subscriber()
-        raid = _make_raid()
-        raid_repo.raids[raid.id] = raid
-        volundr.chronicle_error_sessions.add(raid.session_id or "")
-
-        await sub._handle_completion(raid, volundr)
-
-        updated = raid_repo.raids[raid.id]
-        assert updated.status == RaidStatus.REVIEW
-
-    @pytest.mark.asyncio
-    async def test_chronicle_disabled(self) -> None:
-        """When chronicle_on_complete is False, no chronicle fetch occurs."""
-        config = _default_config(chronicle_on_complete=False)
-        sub, volundr, raid_repo, _ = _make_subscriber(config=config)
-        raid = _make_raid()
-        raid_repo.raids[raid.id] = raid
-        volundr.chronicles[raid.session_id or ""] = "Should not be fetched"
-
-        await sub._handle_completion(raid, volundr)
-
-        updated = raid_repo.raids[raid.id]
-        assert updated.chronicle_summary is None
+        assert pool.sessions["session-1"]["status"] == "complete"
 
     @pytest.mark.asyncio
     async def test_event_emitted_on_completion(self) -> None:
-        """Event bus should receive raid.state_changed on completion."""
-        sub, volundr, raid_repo, event_bus = _make_subscriber()
-        raid = _make_raid()
-        raid_repo.raids[raid.id] = raid
+        """Event bus should receive session.state_changed on completion."""
+        sub, volundr, pool, event_bus = _make_subscriber()
+        record = {
+            "session_id": "session-1",
+            "owner_id": "user-1",
+            "saga_id": "saga-1",
+            "tracker_issue_id": "issue-1",
+        }
+        pool.add_session("session-1")
 
         q = event_bus.subscribe()
-        await sub._handle_completion(raid, volundr)
+        await sub._handle_completion(record)
 
         event = await asyncio.wait_for(q.get(), timeout=1.0)
-        assert event.event == "raid.state_changed"
-        assert event.data["raid_id"] == str(raid.id)
-        assert event.data["status"] == "REVIEW"
+        assert event.event == "session.state_changed"
+        assert event.data["session_id"] == "session-1"
+        assert event.data["status"] == "complete"
 
 
 # ---------------------------------------------------------------------------
@@ -747,17 +577,15 @@ class TestCompletionHandling:
 class TestDispatcherPauseFiltering:
     @pytest.mark.asyncio
     async def test_paused_dispatcher_skips_completion(self) -> None:
-        """Raids belonging to paused owners should not complete."""
+        """Sessions belonging to paused owners should not complete."""
         dispatcher_repo = StubDispatcherRepo(running=False)
-        raid_repo = StubRaidRepo()
-        raid_repo.saga = _make_saga(owner_id="user-paused")
+        pool = StubPool()
+        pool.add_session("session-1", owner_id="user-paused")
 
-        sub, volundr, _, _ = _make_subscriber(raid_repo=raid_repo, dispatcher_repo=dispatcher_repo)
-        raid = _make_raid()
-        raid_repo.raids[raid.id] = raid
+        sub, volundr, _, _ = _make_subscriber(pool=pool, dispatcher_repo=dispatcher_repo)
 
         event = ActivityEvent(
-            session_id=raid.session_id or "",
+            session_id="session-1",
             state="idle",
             metadata={"turn_count": 5, "duration_seconds": 60},
             owner_id="user-paused",
@@ -765,21 +593,19 @@ class TestDispatcherPauseFiltering:
         await sub._on_activity_event(event, volundr)
         await asyncio.sleep(0.1)
 
-        assert raid_repo.raids[raid.id].status == RaidStatus.RUNNING
+        assert pool.sessions["session-1"]["status"] == "running"
 
     @pytest.mark.asyncio
     async def test_running_dispatcher_allows_completion(self) -> None:
-        """Raids belonging to running owners should complete normally."""
+        """Sessions belonging to running owners should complete normally."""
         dispatcher_repo = StubDispatcherRepo(running=True)
-        raid_repo = StubRaidRepo()
-        raid_repo.saga = _make_saga(owner_id="user-active")
+        pool = StubPool()
+        pool.add_session("session-1", owner_id="user-active")
 
-        sub, volundr, _, _ = _make_subscriber(raid_repo=raid_repo, dispatcher_repo=dispatcher_repo)
-        raid = _make_raid()
-        raid_repo.raids[raid.id] = raid
+        sub, volundr, _, _ = _make_subscriber(pool=pool, dispatcher_repo=dispatcher_repo)
 
         event = ActivityEvent(
-            session_id=raid.session_id or "",
+            session_id="session-1",
             state="idle",
             metadata={"turn_count": 5, "duration_seconds": 60},
             owner_id="user-active",
@@ -787,29 +613,27 @@ class TestDispatcherPauseFiltering:
         await sub._on_activity_event(event, volundr)
         await asyncio.sleep(0.1)
 
-        assert raid_repo.raids[raid.id].status == RaidStatus.REVIEW
+        assert pool.sessions["session-1"]["status"] == "complete"
 
     @pytest.mark.asyncio
-    async def test_no_saga_allows_completion(self) -> None:
-        """Raids with no parent saga should still complete (graceful fallback)."""
+    async def test_paused_owner_still_allows_failure(self) -> None:
+        """Even with a paused dispatcher, failure events should still be processed."""
         dispatcher_repo = StubDispatcherRepo(running=False)
-        raid_repo = StubRaidRepo()
-        # saga is None by default
+        pool = StubPool()
+        pool.add_session("session-1", owner_id="user-paused")
 
-        sub, volundr, _, _ = _make_subscriber(raid_repo=raid_repo, dispatcher_repo=dispatcher_repo)
-        raid = _make_raid()
-        raid_repo.raids[raid.id] = raid
+        sub, volundr, _, _ = _make_subscriber(pool=pool, dispatcher_repo=dispatcher_repo)
 
         event = ActivityEvent(
-            session_id=raid.session_id or "",
-            state="idle",
-            metadata={"turn_count": 5, "duration_seconds": 60},
-            owner_id="user-1",
+            session_id="session-1",
+            state="",
+            metadata={},
+            owner_id="user-paused",
+            session_status="stopped",
         )
         await sub._on_activity_event(event, volundr)
-        await asyncio.sleep(0.1)
 
-        assert raid_repo.raids[raid.id].status == RaidStatus.REVIEW
+        assert pool.sessions["session-1"]["status"] == "failed"
 
 
 # ---------------------------------------------------------------------------
@@ -819,14 +643,13 @@ class TestDispatcherPauseFiltering:
 
 class TestFailureDetection:
     @pytest.mark.asyncio
-    async def test_session_stopped_transitions_raid_to_failed(self) -> None:
-        """A session_updated event with status=stopped should transition raid to FAILED."""
-        sub, volundr, raid_repo, event_bus = _make_subscriber()
-        raid = _make_raid()
-        raid_repo.raids[raid.id] = raid
+    async def test_session_stopped_transitions_to_failed(self) -> None:
+        """A session_updated event with status=stopped should transition session to failed."""
+        sub, volundr, pool, event_bus = _make_subscriber()
+        pool.add_session("session-1")
 
         event = ActivityEvent(
-            session_id=raid.session_id or "",
+            session_id="session-1",
             state="",
             metadata={},
             owner_id="user-1",
@@ -836,23 +659,20 @@ class TestFailureDetection:
         q = event_bus.subscribe()
         await sub._on_activity_event(event, volundr)
 
-        updated = raid_repo.raids[raid.id]
-        assert updated.status == RaidStatus.FAILED
-        assert updated.retry_count == 1
+        assert pool.sessions["session-1"]["status"] == "failed"
 
         bus_event = await asyncio.wait_for(q.get(), timeout=1.0)
-        assert bus_event.event == "raid.state_changed"
-        assert bus_event.data["status"] == "FAILED"
+        assert bus_event.event == "session.state_changed"
+        assert bus_event.data["status"] == "failed"
 
     @pytest.mark.asyncio
-    async def test_session_failed_transitions_raid_to_failed(self) -> None:
-        """A session_updated event with status=failed should transition raid to FAILED."""
-        sub, volundr, raid_repo, _ = _make_subscriber()
-        raid = _make_raid()
-        raid_repo.raids[raid.id] = raid
+    async def test_session_failed_transitions_to_failed(self) -> None:
+        """A session_updated event with status=failed should transition session to failed."""
+        sub, volundr, pool, _ = _make_subscriber()
+        pool.add_session("session-1")
 
         event = ActivityEvent(
-            session_id=raid.session_id or "",
+            session_id="session-1",
             state="",
             metadata={},
             owner_id="user-1",
@@ -861,31 +681,28 @@ class TestFailureDetection:
 
         await sub._on_activity_event(event, volundr)
 
-        updated = raid_repo.raids[raid.id]
-        assert updated.status == RaidStatus.FAILED
+        assert pool.sessions["session-1"]["status"] == "failed"
 
     @pytest.mark.asyncio
     async def test_session_failed_cancels_pending_evaluation(self) -> None:
         """A failure event should cancel any pending idle evaluation."""
         config = _default_config(completion_check_delay=1.0)
-        sub, volundr, raid_repo, _ = _make_subscriber(config=config)
-        raid = _make_raid()
-        raid_repo.raids[raid.id] = raid
-        raid_repo.saga = _make_saga()
+        sub, volundr, pool, _ = _make_subscriber(config=config)
+        pool.add_session("session-1")
 
         # Schedule an idle evaluation
         idle_event = ActivityEvent(
-            session_id=raid.session_id or "",
+            session_id="session-1",
             state="idle",
             metadata={"turn_count": 5, "duration_seconds": 60},
             owner_id="user-1",
         )
         await sub._on_activity_event(idle_event, volundr)
-        assert raid.session_id in sub._pending_evaluations
+        assert "session-1" in sub._pending_evaluations
 
         # Session crashes
         fail_event = ActivityEvent(
-            session_id=raid.session_id or "",
+            session_id="session-1",
             state="",
             metadata={},
             owner_id="user-1",
@@ -893,22 +710,20 @@ class TestFailureDetection:
         )
         await sub._on_activity_event(fail_event, volundr)
 
-        assert raid.session_id not in sub._pending_evaluations
-        assert raid_repo.raids[raid.id].status == RaidStatus.FAILED
+        assert "session-1" not in sub._pending_evaluations
+        assert pool.sessions["session-1"]["status"] == "failed"
 
     @pytest.mark.asyncio
     async def test_session_not_found_during_evaluation_transitions_to_failed(self) -> None:
-        """If get_session returns None during debounced evaluation, raid should fail."""
-        sub, volundr, raid_repo, _ = _make_subscriber()
-        raid = _make_raid()
-        raid_repo.raids[raid.id] = raid
-        raid_repo.saga = _make_saga()
+        """If get_session returns None during debounced evaluation, session should fail."""
+        sub, volundr, pool, _ = _make_subscriber()
+        pool.add_session("session-1")
 
-        # Remove the session so get_session returns None
-        volundr.sessions.pop(raid.session_id or "", None)
+        # Remove the session from volundr so get_session returns None
+        volundr.sessions.pop("session-1", None)
 
         event = ActivityEvent(
-            session_id=raid.session_id or "",
+            session_id="session-1",
             state="idle",
             metadata={"turn_count": 5, "duration_seconds": 60},
             owner_id="user-1",
@@ -916,24 +731,21 @@ class TestFailureDetection:
         await sub._on_activity_event(event, volundr)
         await asyncio.sleep(0.1)
 
-        assert raid_repo.raids[raid.id].status == RaidStatus.FAILED
-        assert raid_repo.raids[raid.id].retry_count == 1
+        assert pool.sessions["session-1"]["status"] == "failed"
 
     @pytest.mark.asyncio
     async def test_session_stopped_during_evaluation_transitions_to_failed(self) -> None:
-        """If get_session returns a stopped session during evaluation, raid should fail."""
-        sub, volundr, raid_repo, _ = _make_subscriber()
-        raid = _make_raid()
-        raid_repo.raids[raid.id] = raid
-        raid_repo.saga = _make_saga()
+        """If get_session returns a stopped session during evaluation, session should fail."""
+        sub, volundr, pool, _ = _make_subscriber()
+        pool.add_session("session-1")
 
-        # Session is stopped
-        volundr.sessions[raid.session_id or ""] = _make_volundr_session(
-            session_id=raid.session_id or "", status="stopped"
+        # Session is stopped in volundr
+        volundr.sessions["session-1"] = _make_volundr_session(
+            session_id="session-1", status="stopped"
         )
 
         event = ActivityEvent(
-            session_id=raid.session_id or "",
+            session_id="session-1",
             state="idle",
             metadata={"turn_count": 5, "duration_seconds": 60},
             owner_id="user-1",
@@ -941,12 +753,12 @@ class TestFailureDetection:
         await sub._on_activity_event(event, volundr)
         await asyncio.sleep(0.1)
 
-        assert raid_repo.raids[raid.id].status == RaidStatus.FAILED
+        assert pool.sessions["session-1"]["status"] == "failed"
 
     @pytest.mark.asyncio
-    async def test_failure_no_raid_is_ignored(self) -> None:
-        """A failure event for a session with no RUNNING raid should be ignored."""
-        sub, volundr, raid_repo, _ = _make_subscriber()
+    async def test_failure_no_session_record_is_ignored(self) -> None:
+        """A failure event for a session with no dispatched record should be ignored."""
+        sub, volundr, pool, _ = _make_subscriber()
 
         event = ActivityEvent(
             session_id="unknown-session",
@@ -957,27 +769,6 @@ class TestFailureDetection:
         )
         await sub._on_activity_event(event, volundr)
         # No crash, no transitions
-
-    @pytest.mark.asyncio
-    async def test_chronicle_fetched_on_failure(self) -> None:
-        """Chronicle summary should be fetched when a raid fails."""
-        sub, volundr, raid_repo, _ = _make_subscriber()
-        raid = _make_raid()
-        raid_repo.raids[raid.id] = raid
-        volundr.chronicles[raid.session_id or ""] = "Session crashed"
-
-        event = ActivityEvent(
-            session_id=raid.session_id or "",
-            state="",
-            metadata={},
-            owner_id="user-1",
-            session_status="failed",
-        )
-        await sub._on_activity_event(event, volundr)
-
-        updated = raid_repo.raids[raid.id]
-        assert updated.status == RaidStatus.FAILED
-        assert updated.chronicle_summary == "Session crashed"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tyr/test_dispatch_api.py
+++ b/tests/test_tyr/test_dispatch_api.py
@@ -131,6 +131,9 @@ class MockVolundr(VolundrPort):
     ) -> None:
         pass
 
+    async def stop_session(self, session_id, *, auth_token=None):
+        pass
+
     async def subscribe_activity(self):
         return
         yield  # type: ignore[misc]  # pragma: no cover

--- a/tests/test_tyr/test_planning_session.py
+++ b/tests/test_tyr/test_planning_session.py
@@ -25,7 +25,7 @@ from tyr.domain.services.planning_session import (
     PlanningSessionService,
     SessionLimitReachedError,
 )
-from tyr.domain.validation import ValidationError
+from tyr.domain.validation import ValidationError, try_extract_structure
 from tyr.ports.volundr import SpawnRequest, VolundrPort, VolundrSession
 
 # ---------------------------------------------------------------------------
@@ -39,7 +39,9 @@ class MockVolundr(VolundrPort):
     def __init__(self) -> None:
         self.spawn_calls: list[SpawnRequest] = []
         self.sent_messages: list[tuple[str, str]] = []
+        self.stopped_sessions: list[str] = []
         self.fail_spawn = False
+        self.fail_stop = False
 
     async def spawn_session(self, request, *, auth_token=None):
         self.spawn_calls.append(request)
@@ -50,6 +52,7 @@ class MockVolundr(VolundrPort):
             name=request.name,
             status="RUNNING",
             tracker_issue_id=None,
+            chat_endpoint="wss://sessions.test/s/volundr-sess-001/session",
         )
 
     async def get_session(self, session_id, *, auth_token=None):
@@ -66,6 +69,11 @@ class MockVolundr(VolundrPort):
 
     async def send_message(self, session_id, message, *, auth_token=None):
         self.sent_messages.append((session_id, message))
+
+    async def stop_session(self, session_id, *, auth_token=None):
+        if self.fail_stop:
+            raise ConnectionError("Volundr unreachable")
+        self.stopped_sessions.append(session_id)
 
     async def subscribe_activity(self):
         return
@@ -342,14 +350,36 @@ class TestPlanningSessionService:
         assert updated.status == PlanningSessionStatus.STRUCTURE_PROPOSED
 
     @pytest.mark.asyncio
+    async def test_spawn_stores_chat_endpoint(
+        self,
+        service: PlanningSessionService,
+    ):
+        session = await service.spawn("user-1", "Spec", "repo")
+        assert session.chat_endpoint == "wss://sessions.test/s/volundr-sess-001/session"
+
+    @pytest.mark.asyncio
     async def test_complete_success(
         self,
         service: PlanningSessionService,
+        volundr: MockVolundr,
     ):
         session = await service.spawn("user-1", "Spec", "repo")
         await service.propose_structure(session.id, VALID_STRUCTURE_JSON)
         completed = await service.complete(session.id)
 
+        assert completed.status == PlanningSessionStatus.COMPLETED
+        assert "volundr-sess-001" in volundr.stopped_sessions
+
+    @pytest.mark.asyncio
+    async def test_complete_stop_failure_does_not_block(
+        self,
+        service: PlanningSessionService,
+        volundr: MockVolundr,
+    ):
+        session = await service.spawn("user-1", "Spec", "repo")
+        await service.propose_structure(session.id, VALID_STRUCTURE_JSON)
+        volundr.fail_stop = True
+        completed = await service.complete(session.id)
         assert completed.status == PlanningSessionStatus.COMPLETED
 
     @pytest.mark.asyncio
@@ -407,6 +437,7 @@ class TestPlanningSessionService:
     async def test_delete_session(
         self,
         service: PlanningSessionService,
+        volundr: MockVolundr,
     ):
         session = await service.spawn("user-1", "Spec", "repo")
         deleted = await service.delete(session.id)
@@ -414,6 +445,23 @@ class TestPlanningSessionService:
 
         found = await service.get(session.id)
         assert found is None
+        assert "volundr-sess-001" in volundr.stopped_sessions
+
+    @pytest.mark.asyncio
+    async def test_delete_completed_session_does_not_stop(
+        self,
+        service: PlanningSessionService,
+        volundr: MockVolundr,
+    ):
+        session = await service.spawn("user-1", "Spec", "repo")
+        await service.propose_structure(session.id, VALID_STRUCTURE_JSON)
+        await service.complete(session.id)
+        volundr.stopped_sessions.clear()
+
+        deleted = await service.delete(session.id)
+        assert deleted is True
+        # Session was already completed; stop_session should NOT be called again
+        assert len(volundr.stopped_sessions) == 0
 
     @pytest.mark.asyncio
     async def test_delete_session_not_found(
@@ -446,12 +494,39 @@ class TestPlanningSessionService:
             await service.get_messages(uuid4())
 
     @pytest.mark.asyncio
-    async def test_cleanup_expired(
+    async def test_cleanup_expired_no_sessions(
         self,
         service: PlanningSessionService,
     ):
         count = await service.cleanup_expired()
         assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_cleanup_expired_expires_idle_sessions(
+        self,
+        service: PlanningSessionService,
+        planning_repo: InMemoryPlanningSessionRepository,
+        volundr: MockVolundr,
+    ):
+        session = await service.spawn("user-1", "Spec", "repo")
+
+        # Force updated_at to 2 hours ago (well past 1800s idle timeout)
+        from dataclasses import replace
+        from datetime import timedelta
+
+        stale = replace(
+            session,
+            updated_at=datetime.now(UTC) - timedelta(hours=2),
+        )
+        await planning_repo.save(stale)
+
+        count = await service.cleanup_expired()
+        assert count == 1
+        assert "volundr-sess-001" in volundr.stopped_sessions
+
+        updated = await service.get(session.id)
+        assert updated is not None
+        assert updated.status == PlanningSessionStatus.EXPIRED
 
     @pytest.mark.asyncio
     async def test_send_message_in_structure_proposed_state(
@@ -796,3 +871,41 @@ class TestPlanningModels:
         assert config.max_sessions_per_user == 3
         assert config.default_model == "claude-opus-4-6"
         assert len(config.system_prompt) > 0
+
+
+# ---------------------------------------------------------------------------
+# try_extract_structure tests
+# ---------------------------------------------------------------------------
+
+
+class TestTryExtractStructure:
+    def test_extracts_from_fenced_json(self):
+        text = "Here is the structure:\n```json\n" + VALID_STRUCTURE_JSON + "\n```\nDone."
+        result = try_extract_structure(text)
+        assert result is not None
+        assert result.name == "Auth Refactor"
+
+    def test_extracts_from_fenced_no_lang(self):
+        text = "```\n" + VALID_STRUCTURE_JSON + "\n```"
+        result = try_extract_structure(text)
+        assert result is not None
+        assert result.name == "Auth Refactor"
+
+    def test_returns_none_for_plain_text(self):
+        result = try_extract_structure("Just some discussion about the saga")
+        assert result is None
+
+    def test_returns_none_for_invalid_structure(self):
+        text = '```json\n{"name": "Bad"}\n```'
+        result = try_extract_structure(text)
+        assert result is None
+
+    def test_returns_none_for_non_json_fence(self):
+        text = "```python\nprint('hello')\n```"
+        result = try_extract_structure(text)
+        assert result is None
+
+    def test_extracts_from_bare_json(self):
+        result = try_extract_structure(VALID_STRUCTURE_JSON)
+        assert result is not None
+        assert result.name == "Auth Refactor"

--- a/tests/test_tyr/test_planning_session.py
+++ b/tests/test_tyr/test_planning_session.py
@@ -2,16 +2,15 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from datetime import UTC, datetime
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from tyr.adapters.memory_event_bus import InMemoryEventBus
-from tyr.adapters.memory_planning_repo import InMemoryPlanningSessionRepository
 from tyr.api.planning import create_planning_router, resolve_planning_service
 from tyr.config import PlannerConfig
 from tyr.domain.models import (
@@ -26,6 +25,8 @@ from tyr.domain.services.planning_session import (
     SessionLimitReachedError,
 )
 from tyr.domain.validation import ValidationError, try_extract_structure
+from tyr.ports.event_bus import EventBusPort, TyrEvent
+from tyr.ports.planning_repository import PlanningSessionRepository
 from tyr.ports.volundr import SpawnRequest, VolundrPort, VolundrSession
 
 # ---------------------------------------------------------------------------
@@ -81,6 +82,91 @@ class MockVolundr(VolundrPort):
 
 
 # ---------------------------------------------------------------------------
+# Stub PlanningSessionRepository (implements the port, no adapter import)
+# ---------------------------------------------------------------------------
+
+
+class StubPlanningSessionRepository(PlanningSessionRepository):
+    """In-memory stub implementing PlanningSessionRepository port for tests."""
+
+    def __init__(self) -> None:
+        self._sessions: dict[UUID, PlanningSession] = {}
+        self._messages: dict[UUID, list[PlanningMessage]] = {}
+
+    async def save(self, session: PlanningSession) -> None:
+        self._sessions[session.id] = session
+
+    async def get(self, session_id: UUID) -> PlanningSession | None:
+        return self._sessions.get(session_id)
+
+    async def get_by_volundr_id(self, volundr_session_id: str) -> PlanningSession | None:
+        for s in self._sessions.values():
+            if s.session_id == volundr_session_id:
+                return s
+        return None
+
+    async def list_by_owner(self, owner_id: str) -> list[PlanningSession]:
+        return [s for s in self._sessions.values() if s.owner_id == owner_id]
+
+    async def list_active(self) -> list[PlanningSession]:
+        active = {PlanningSessionStatus.ACTIVE, PlanningSessionStatus.STRUCTURE_PROPOSED}
+        return [s for s in self._sessions.values() if s.status in active]
+
+    async def delete(self, session_id: UUID) -> bool:
+        if session_id not in self._sessions:
+            return False
+        del self._sessions[session_id]
+        self._messages.pop(session_id, None)
+        return True
+
+    async def save_message(self, message: PlanningMessage) -> None:
+        self._messages.setdefault(message.planning_session_id, []).append(message)
+
+    async def get_messages(self, session_id: UUID) -> list[PlanningMessage]:
+        return list(self._messages.get(session_id, []))
+
+
+# ---------------------------------------------------------------------------
+# Stub EventBus (implements the port, no adapter import)
+# ---------------------------------------------------------------------------
+
+
+class StubEventBus(EventBusPort):
+    """In-memory stub implementing EventBusPort for tests."""
+
+    def __init__(self, max_clients: int = 100) -> None:
+        self._subscribers: list[asyncio.Queue[TyrEvent]] = []
+        self._snapshot: list[TyrEvent] = []
+        self._max_clients = max_clients
+
+    def subscribe(self) -> asyncio.Queue[TyrEvent]:
+        q: asyncio.Queue[TyrEvent] = asyncio.Queue()
+        self._subscribers.append(q)
+        return q
+
+    def unsubscribe(self, q: asyncio.Queue[TyrEvent]) -> None:
+        try:
+            self._subscribers.remove(q)
+        except ValueError:
+            pass
+
+    async def emit(self, event: TyrEvent) -> None:
+        for q in self._subscribers:
+            q.put_nowait(event)
+
+    def get_snapshot(self) -> list[TyrEvent]:
+        return list(self._snapshot)
+
+    @property
+    def client_count(self) -> int:
+        return len(self._subscribers)
+
+    @property
+    def at_capacity(self) -> bool:
+        return len(self._subscribers) >= self._max_clients
+
+
+# ---------------------------------------------------------------------------
 # Valid saga structure JSON for testing
 # ---------------------------------------------------------------------------
 
@@ -114,8 +200,8 @@ INVALID_STRUCTURE_JSON = json.dumps({"name": "Bad"})
 
 
 @pytest.fixture
-def planning_repo() -> InMemoryPlanningSessionRepository:
-    return InMemoryPlanningSessionRepository()
+def planning_repo() -> StubPlanningSessionRepository:
+    return StubPlanningSessionRepository()
 
 
 @pytest.fixture
@@ -124,8 +210,8 @@ def volundr() -> MockVolundr:
 
 
 @pytest.fixture
-def event_bus() -> InMemoryEventBus:
-    return InMemoryEventBus()
+def event_bus() -> StubEventBus:
+    return StubEventBus()
 
 
 @pytest.fixture
@@ -135,10 +221,10 @@ def config() -> PlannerConfig:
 
 @pytest.fixture
 def service(
-    planning_repo: InMemoryPlanningSessionRepository,
+    planning_repo: StubPlanningSessionRepository,
     volundr: MockVolundr,
     config: PlannerConfig,
-    event_bus: InMemoryEventBus,
+    event_bus: StubEventBus,
 ) -> PlanningSessionService:
     return PlanningSessionService(planning_repo, volundr, config, event_bus=event_bus)
 
@@ -183,7 +269,7 @@ class TestPlanningSessionService:
     async def test_spawn_emits_event(
         self,
         service: PlanningSessionService,
-        event_bus: InMemoryEventBus,
+        event_bus: StubEventBus,
     ):
         q = event_bus.subscribe()
         await service.spawn("user-1", "Build auth", "niuu/volundr")
@@ -220,7 +306,7 @@ class TestPlanningSessionService:
         self,
         service: PlanningSessionService,
         volundr: MockVolundr,
-        planning_repo: InMemoryPlanningSessionRepository,
+        planning_repo: StubPlanningSessionRepository,
     ):
         volundr.fail_spawn = True
 
@@ -258,7 +344,7 @@ class TestPlanningSessionService:
     async def test_send_message_invalid_state(
         self,
         service: PlanningSessionService,
-        planning_repo: InMemoryPlanningSessionRepository,
+        planning_repo: StubPlanningSessionRepository,
     ):
         session = await service.spawn("user-1", "Spec", "repo")
 
@@ -289,7 +375,7 @@ class TestPlanningSessionService:
     async def test_propose_structure_emits_event(
         self,
         service: PlanningSessionService,
-        event_bus: InMemoryEventBus,
+        event_bus: StubEventBus,
     ):
         q = event_bus.subscribe()
         session = await service.spawn("user-1", "Spec", "repo")
@@ -326,7 +412,7 @@ class TestPlanningSessionService:
     async def test_propose_structure_invalid_state(
         self,
         service: PlanningSessionService,
-        planning_repo: InMemoryPlanningSessionRepository,
+        planning_repo: StubPlanningSessionRepository,
     ):
         session = await service.spawn("user-1", "Spec", "repo")
         from dataclasses import replace
@@ -505,7 +591,7 @@ class TestPlanningSessionService:
     async def test_cleanup_expired_expires_idle_sessions(
         self,
         service: PlanningSessionService,
-        planning_repo: InMemoryPlanningSessionRepository,
+        planning_repo: StubPlanningSessionRepository,
         volundr: MockVolundr,
     ):
         session = await service.spawn("user-1", "Spec", "repo")
@@ -548,7 +634,7 @@ class TestPlanningSessionService:
 
 class TestInMemoryPlanningRepo:
     @pytest.mark.asyncio
-    async def test_save_and_get(self, planning_repo: InMemoryPlanningSessionRepository):
+    async def test_save_and_get(self, planning_repo: StubPlanningSessionRepository):
         session = PlanningSession(
             id=uuid4(),
             owner_id="user-1",
@@ -566,7 +652,7 @@ class TestInMemoryPlanningRepo:
         assert found.id == session.id
 
     @pytest.mark.asyncio
-    async def test_get_by_volundr_id(self, planning_repo: InMemoryPlanningSessionRepository):
+    async def test_get_by_volundr_id(self, planning_repo: StubPlanningSessionRepository):
         session = PlanningSession(
             id=uuid4(),
             owner_id="user-1",
@@ -587,7 +673,7 @@ class TestInMemoryPlanningRepo:
         assert not_found is None
 
     @pytest.mark.asyncio
-    async def test_delete_removes_messages(self, planning_repo: InMemoryPlanningSessionRepository):
+    async def test_delete_removes_messages(self, planning_repo: StubPlanningSessionRepository):
         session_id = uuid4()
         session = PlanningSession(
             id=session_id,
@@ -867,6 +953,9 @@ class TestPlanningModels:
 
     def test_planner_config_defaults(self):
         config = PlannerConfig()
+        expected_adapter = "tyr.adapters.memory_planning_repo.InMemoryPlanningSessionRepository"
+        assert config.adapter == expected_adapter
+        assert config.kwargs == {}
         assert config.idle_timeout_seconds == 1800.0
         assert config.max_sessions_per_user == 3
         assert config.default_model == "claude-opus-4-6"

--- a/tests/test_tyr/test_planning_session.py
+++ b/tests/test_tyr/test_planning_session.py
@@ -1,0 +1,798 @@
+"""Tests for interactive planning sessions — domain service and REST API."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tyr.adapters.memory_event_bus import InMemoryEventBus
+from tyr.adapters.memory_planning_repo import InMemoryPlanningSessionRepository
+from tyr.api.planning import create_planning_router, resolve_planning_service
+from tyr.config import PlannerConfig
+from tyr.domain.models import (
+    PlanningMessage,
+    PlanningSession,
+    PlanningSessionStatus,
+)
+from tyr.domain.services.planning_session import (
+    InvalidPlanningStateError,
+    PlanningSessionNotFoundError,
+    PlanningSessionService,
+    SessionLimitReachedError,
+)
+from tyr.domain.validation import ValidationError
+from tyr.ports.volundr import SpawnRequest, VolundrPort, VolundrSession
+
+# ---------------------------------------------------------------------------
+# Mock Volundr
+# ---------------------------------------------------------------------------
+
+
+class MockVolundr(VolundrPort):
+    """Mock Volundr adapter for tests."""
+
+    def __init__(self) -> None:
+        self.spawn_calls: list[SpawnRequest] = []
+        self.sent_messages: list[tuple[str, str]] = []
+        self.fail_spawn = False
+
+    async def spawn_session(self, request, *, auth_token=None):
+        self.spawn_calls.append(request)
+        if self.fail_spawn:
+            raise ConnectionError("Volundr unreachable")
+        return VolundrSession(
+            id="volundr-sess-001",
+            name=request.name,
+            status="RUNNING",
+            tracker_issue_id=None,
+        )
+
+    async def get_session(self, session_id, *, auth_token=None):
+        return None
+
+    async def list_sessions(self, *, auth_token=None):
+        return []
+
+    async def get_pr_status(self, session_id):
+        raise NotImplementedError
+
+    async def get_chronicle_summary(self, session_id):
+        return ""
+
+    async def send_message(self, session_id, message, *, auth_token=None):
+        self.sent_messages.append((session_id, message))
+
+    async def subscribe_activity(self):
+        return
+        yield  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Valid saga structure JSON for testing
+# ---------------------------------------------------------------------------
+
+VALID_STRUCTURE_JSON = json.dumps(
+    {
+        "name": "Auth Refactor",
+        "phases": [
+            {
+                "name": "Phase 1: Foundation",
+                "raids": [
+                    {
+                        "name": "Setup auth middleware",
+                        "description": "Implement OAuth2 middleware for API routes",
+                        "acceptance_criteria": ["All routes protected", "Token validation works"],
+                        "declared_files": ["src/middleware/auth.py", "src/config.py"],
+                        "estimate_hours": 4.0,
+                        "confidence": 0.8,
+                    }
+                ],
+            }
+        ],
+    }
+)
+
+INVALID_STRUCTURE_JSON = json.dumps({"name": "Bad"})
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def planning_repo() -> InMemoryPlanningSessionRepository:
+    return InMemoryPlanningSessionRepository()
+
+
+@pytest.fixture
+def volundr() -> MockVolundr:
+    return MockVolundr()
+
+
+@pytest.fixture
+def event_bus() -> InMemoryEventBus:
+    return InMemoryEventBus()
+
+
+@pytest.fixture
+def config() -> PlannerConfig:
+    return PlannerConfig(max_sessions_per_user=2)
+
+
+@pytest.fixture
+def service(
+    planning_repo: InMemoryPlanningSessionRepository,
+    volundr: MockVolundr,
+    config: PlannerConfig,
+    event_bus: InMemoryEventBus,
+) -> PlanningSessionService:
+    return PlanningSessionService(planning_repo, volundr, config, event_bus=event_bus)
+
+
+@pytest.fixture
+def client(service: PlanningSessionService) -> TestClient:
+    from types import SimpleNamespace
+
+    from tyr.config import AuthConfig
+
+    app = FastAPI()
+    app.include_router(create_planning_router())
+    app.dependency_overrides[resolve_planning_service] = lambda: service
+    app.state.settings = SimpleNamespace(auth=AuthConfig(allow_anonymous_dev=True))
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Domain service tests
+# ---------------------------------------------------------------------------
+
+
+class TestPlanningSessionService:
+    @pytest.mark.asyncio
+    async def test_spawn_success(
+        self,
+        service: PlanningSessionService,
+        volundr: MockVolundr,
+    ):
+        session = await service.spawn("user-1", "Build auth", "niuu/volundr")
+
+        assert session.owner_id == "user-1"
+        assert session.repo == "niuu/volundr"
+        assert session.spec == "Build auth"
+        assert session.status == PlanningSessionStatus.ACTIVE
+        assert session.session_id == "volundr-sess-001"
+
+        assert len(volundr.spawn_calls) == 1
+        assert volundr.spawn_calls[0].model == "claude-opus-4-6"
+
+    @pytest.mark.asyncio
+    async def test_spawn_emits_event(
+        self,
+        service: PlanningSessionService,
+        event_bus: InMemoryEventBus,
+    ):
+        q = event_bus.subscribe()
+        await service.spawn("user-1", "Build auth", "niuu/volundr")
+
+        event = q.get_nowait()
+        assert event.event == "planning.session_spawned"
+        assert event.owner_id == "user-1"
+
+    @pytest.mark.asyncio
+    async def test_spawn_limit_reached(
+        self,
+        service: PlanningSessionService,
+    ):
+        await service.spawn("user-1", "Spec 1", "repo1")
+        await service.spawn("user-1", "Spec 2", "repo2")
+
+        with pytest.raises(SessionLimitReachedError):
+            await service.spawn("user-1", "Spec 3", "repo3")
+
+    @pytest.mark.asyncio
+    async def test_spawn_different_owners_no_limit(
+        self,
+        service: PlanningSessionService,
+    ):
+        await service.spawn("user-1", "Spec 1", "repo1")
+        await service.spawn("user-1", "Spec 2", "repo2")
+
+        # Different user should not be limited
+        session = await service.spawn("user-2", "Spec 3", "repo3")
+        assert session.owner_id == "user-2"
+
+    @pytest.mark.asyncio
+    async def test_spawn_volundr_failure(
+        self,
+        service: PlanningSessionService,
+        volundr: MockVolundr,
+        planning_repo: InMemoryPlanningSessionRepository,
+    ):
+        volundr.fail_spawn = True
+
+        with pytest.raises(ConnectionError):
+            await service.spawn("user-1", "Spec", "repo")
+
+        # Session should be marked as FAILED
+        sessions = await planning_repo.list_by_owner("user-1")
+        assert len(sessions) == 1
+        assert sessions[0].status == PlanningSessionStatus.FAILED
+
+    @pytest.mark.asyncio
+    async def test_send_message_success(
+        self,
+        service: PlanningSessionService,
+        volundr: MockVolundr,
+    ):
+        session = await service.spawn("user-1", "Spec", "repo")
+        msg = await service.send_message(session.id, "How about splitting phase 1?")
+
+        assert msg.content == "How about splitting phase 1?"
+        assert msg.sender == "user"
+        assert len(volundr.sent_messages) == 1
+        assert volundr.sent_messages[0] == ("volundr-sess-001", "How about splitting phase 1?")
+
+    @pytest.mark.asyncio
+    async def test_send_message_not_found(
+        self,
+        service: PlanningSessionService,
+    ):
+        with pytest.raises(PlanningSessionNotFoundError):
+            await service.send_message(uuid4(), "hello")
+
+    @pytest.mark.asyncio
+    async def test_send_message_invalid_state(
+        self,
+        service: PlanningSessionService,
+        planning_repo: InMemoryPlanningSessionRepository,
+    ):
+        session = await service.spawn("user-1", "Spec", "repo")
+
+        # Force to COMPLETED state
+        from dataclasses import replace
+
+        completed = replace(session, status=PlanningSessionStatus.COMPLETED)
+        await planning_repo.save(completed)
+
+        with pytest.raises(InvalidPlanningStateError):
+            await service.send_message(session.id, "hello")
+
+    @pytest.mark.asyncio
+    async def test_propose_structure_success(
+        self,
+        service: PlanningSessionService,
+    ):
+        session = await service.spawn("user-1", "Spec", "repo")
+        updated = await service.propose_structure(session.id, VALID_STRUCTURE_JSON)
+
+        assert updated.status == PlanningSessionStatus.STRUCTURE_PROPOSED
+        assert updated.structure is not None
+        assert updated.structure.name == "Auth Refactor"
+        assert len(updated.structure.phases) == 1
+        assert len(updated.structure.phases[0].raids) == 1
+
+    @pytest.mark.asyncio
+    async def test_propose_structure_emits_event(
+        self,
+        service: PlanningSessionService,
+        event_bus: InMemoryEventBus,
+    ):
+        q = event_bus.subscribe()
+        session = await service.spawn("user-1", "Spec", "repo")
+
+        # Drain the spawn event
+        spawn_event = q.get_nowait()
+        assert spawn_event.event == "planning.session_spawned"
+
+        await service.propose_structure(session.id, VALID_STRUCTURE_JSON)
+
+        event = q.get_nowait()
+        assert event.event == "planning.structure_proposed"
+        assert event.data["saga_name"] == "Auth Refactor"
+
+    @pytest.mark.asyncio
+    async def test_propose_structure_invalid_json(
+        self,
+        service: PlanningSessionService,
+    ):
+        session = await service.spawn("user-1", "Spec", "repo")
+
+        with pytest.raises(ValidationError):
+            await service.propose_structure(session.id, INVALID_STRUCTURE_JSON)
+
+    @pytest.mark.asyncio
+    async def test_propose_structure_not_found(
+        self,
+        service: PlanningSessionService,
+    ):
+        with pytest.raises(PlanningSessionNotFoundError):
+            await service.propose_structure(uuid4(), VALID_STRUCTURE_JSON)
+
+    @pytest.mark.asyncio
+    async def test_propose_structure_invalid_state(
+        self,
+        service: PlanningSessionService,
+        planning_repo: InMemoryPlanningSessionRepository,
+    ):
+        session = await service.spawn("user-1", "Spec", "repo")
+        from dataclasses import replace
+
+        completed = replace(session, status=PlanningSessionStatus.COMPLETED)
+        await planning_repo.save(completed)
+
+        with pytest.raises(InvalidPlanningStateError):
+            await service.propose_structure(session.id, VALID_STRUCTURE_JSON)
+
+    @pytest.mark.asyncio
+    async def test_re_propose_structure(
+        self,
+        service: PlanningSessionService,
+    ):
+        session = await service.spawn("user-1", "Spec", "repo")
+        await service.propose_structure(session.id, VALID_STRUCTURE_JSON)
+
+        # Re-proposing in STRUCTURE_PROPOSED state should work
+        updated = await service.propose_structure(session.id, VALID_STRUCTURE_JSON)
+        assert updated.status == PlanningSessionStatus.STRUCTURE_PROPOSED
+
+    @pytest.mark.asyncio
+    async def test_complete_success(
+        self,
+        service: PlanningSessionService,
+    ):
+        session = await service.spawn("user-1", "Spec", "repo")
+        await service.propose_structure(session.id, VALID_STRUCTURE_JSON)
+        completed = await service.complete(session.id)
+
+        assert completed.status == PlanningSessionStatus.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_complete_not_found(
+        self,
+        service: PlanningSessionService,
+    ):
+        with pytest.raises(PlanningSessionNotFoundError):
+            await service.complete(uuid4())
+
+    @pytest.mark.asyncio
+    async def test_complete_without_structure(
+        self,
+        service: PlanningSessionService,
+    ):
+        session = await service.spawn("user-1", "Spec", "repo")
+
+        with pytest.raises(InvalidPlanningStateError):
+            await service.complete(session.id)
+
+    @pytest.mark.asyncio
+    async def test_list_sessions(
+        self,
+        service: PlanningSessionService,
+    ):
+        await service.spawn("user-1", "Spec 1", "repo1")
+        await service.spawn("user-1", "Spec 2", "repo2")
+        await service.spawn("user-2", "Spec 3", "repo3")
+
+        sessions = await service.list_sessions("user-1")
+        assert len(sessions) == 2
+
+        sessions = await service.list_sessions("user-2")
+        assert len(sessions) == 1
+
+    @pytest.mark.asyncio
+    async def test_get_session(
+        self,
+        service: PlanningSessionService,
+    ):
+        session = await service.spawn("user-1", "Spec", "repo")
+        found = await service.get(session.id)
+        assert found is not None
+        assert found.id == session.id
+
+    @pytest.mark.asyncio
+    async def test_get_session_not_found(
+        self,
+        service: PlanningSessionService,
+    ):
+        found = await service.get(uuid4())
+        assert found is None
+
+    @pytest.mark.asyncio
+    async def test_delete_session(
+        self,
+        service: PlanningSessionService,
+    ):
+        session = await service.spawn("user-1", "Spec", "repo")
+        deleted = await service.delete(session.id)
+        assert deleted is True
+
+        found = await service.get(session.id)
+        assert found is None
+
+    @pytest.mark.asyncio
+    async def test_delete_session_not_found(
+        self,
+        service: PlanningSessionService,
+    ):
+        deleted = await service.delete(uuid4())
+        assert deleted is False
+
+    @pytest.mark.asyncio
+    async def test_get_messages(
+        self,
+        service: PlanningSessionService,
+    ):
+        session = await service.spawn("user-1", "Spec", "repo")
+        await service.send_message(session.id, "msg 1")
+        await service.send_message(session.id, "msg 2")
+
+        messages = await service.get_messages(session.id)
+        assert len(messages) == 2
+        assert messages[0].content == "msg 1"
+        assert messages[1].content == "msg 2"
+
+    @pytest.mark.asyncio
+    async def test_get_messages_not_found(
+        self,
+        service: PlanningSessionService,
+    ):
+        with pytest.raises(PlanningSessionNotFoundError):
+            await service.get_messages(uuid4())
+
+    @pytest.mark.asyncio
+    async def test_cleanup_expired(
+        self,
+        service: PlanningSessionService,
+    ):
+        count = await service.cleanup_expired()
+        assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_send_message_in_structure_proposed_state(
+        self,
+        service: PlanningSessionService,
+    ):
+        session = await service.spawn("user-1", "Spec", "repo")
+        await service.propose_structure(session.id, VALID_STRUCTURE_JSON)
+
+        # Should still be able to send messages in STRUCTURE_PROPOSED state
+        msg = await service.send_message(session.id, "Actually, change phase 1")
+        assert msg.content == "Actually, change phase 1"
+
+
+# ---------------------------------------------------------------------------
+# In-memory repository tests
+# ---------------------------------------------------------------------------
+
+
+class TestInMemoryPlanningRepo:
+    @pytest.mark.asyncio
+    async def test_save_and_get(self, planning_repo: InMemoryPlanningSessionRepository):
+        session = PlanningSession(
+            id=uuid4(),
+            owner_id="user-1",
+            session_id="vs-001",
+            repo="repo",
+            spec="spec",
+            status=PlanningSessionStatus.ACTIVE,
+            structure=None,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        await planning_repo.save(session)
+        found = await planning_repo.get(session.id)
+        assert found is not None
+        assert found.id == session.id
+
+    @pytest.mark.asyncio
+    async def test_get_by_volundr_id(self, planning_repo: InMemoryPlanningSessionRepository):
+        session = PlanningSession(
+            id=uuid4(),
+            owner_id="user-1",
+            session_id="vs-001",
+            repo="repo",
+            spec="spec",
+            status=PlanningSessionStatus.ACTIVE,
+            structure=None,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        await planning_repo.save(session)
+        found = await planning_repo.get_by_volundr_id("vs-001")
+        assert found is not None
+        assert found.id == session.id
+
+        not_found = await planning_repo.get_by_volundr_id("non-existent")
+        assert not_found is None
+
+    @pytest.mark.asyncio
+    async def test_delete_removes_messages(self, planning_repo: InMemoryPlanningSessionRepository):
+        session_id = uuid4()
+        session = PlanningSession(
+            id=session_id,
+            owner_id="user-1",
+            session_id="vs-001",
+            repo="repo",
+            spec="spec",
+            status=PlanningSessionStatus.ACTIVE,
+            structure=None,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        await planning_repo.save(session)
+        msg = PlanningMessage(
+            id=uuid4(),
+            planning_session_id=session_id,
+            content="test",
+            sender="user",
+            created_at=datetime.now(UTC),
+        )
+        await planning_repo.save_message(msg)
+
+        await planning_repo.delete(session_id)
+        assert await planning_repo.get(session_id) is None
+        assert await planning_repo.get_messages(session_id) == []
+
+
+# ---------------------------------------------------------------------------
+# REST API tests
+# ---------------------------------------------------------------------------
+
+
+class TestPlanningAPI:
+    def test_spawn_session(self, client: TestClient):
+        resp = client.post(
+            "/api/v1/tyr/planning/sessions",
+            json={"spec": "Build auth system", "repo": "niuu/volundr"},
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["status"] == "ACTIVE"
+        assert data["session_id"] == "volundr-sess-001"
+        assert data["repo"] == "niuu/volundr"
+
+    def test_spawn_session_empty_spec(self, client: TestClient):
+        resp = client.post(
+            "/api/v1/tyr/planning/sessions",
+            json={"spec": "", "repo": "niuu/volundr"},
+        )
+        assert resp.status_code == 422
+
+    def test_spawn_session_limit_reached(self, client: TestClient):
+        client.post(
+            "/api/v1/tyr/planning/sessions",
+            json={"spec": "Spec 1", "repo": "repo1"},
+        )
+        client.post(
+            "/api/v1/tyr/planning/sessions",
+            json={"spec": "Spec 2", "repo": "repo2"},
+        )
+        resp = client.post(
+            "/api/v1/tyr/planning/sessions",
+            json={"spec": "Spec 3", "repo": "repo3"},
+        )
+        assert resp.status_code == 429
+
+    def test_list_sessions(self, client: TestClient):
+        client.post(
+            "/api/v1/tyr/planning/sessions",
+            json={"spec": "Spec 1", "repo": "repo1"},
+        )
+        resp = client.get("/api/v1/tyr/planning/sessions")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+
+    def test_get_session(self, client: TestClient):
+        spawn_resp = client.post(
+            "/api/v1/tyr/planning/sessions",
+            json={"spec": "Spec", "repo": "repo"},
+        )
+        session_id = spawn_resp.json()["id"]
+
+        resp = client.get(f"/api/v1/tyr/planning/sessions/{session_id}")
+        assert resp.status_code == 200
+        assert resp.json()["id"] == session_id
+
+    def test_get_session_not_found(self, client: TestClient):
+        resp = client.get(f"/api/v1/tyr/planning/sessions/{uuid4()}")
+        assert resp.status_code == 404
+
+    def test_send_message(self, client: TestClient):
+        spawn_resp = client.post(
+            "/api/v1/tyr/planning/sessions",
+            json={"spec": "Spec", "repo": "repo"},
+        )
+        session_id = spawn_resp.json()["id"]
+
+        resp = client.post(
+            f"/api/v1/tyr/planning/sessions/{session_id}/messages",
+            json={"content": "Split the auth phase"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["content"] == "Split the auth phase"
+        assert data["sender"] == "user"
+
+    def test_send_message_not_found(self, client: TestClient):
+        resp = client.post(
+            f"/api/v1/tyr/planning/sessions/{uuid4()}/messages",
+            json={"content": "hello"},
+        )
+        assert resp.status_code == 404
+
+    def test_send_message_empty_content(self, client: TestClient):
+        spawn_resp = client.post(
+            "/api/v1/tyr/planning/sessions",
+            json={"spec": "Spec", "repo": "repo"},
+        )
+        session_id = spawn_resp.json()["id"]
+
+        resp = client.post(
+            f"/api/v1/tyr/planning/sessions/{session_id}/messages",
+            json={"content": ""},
+        )
+        assert resp.status_code == 422
+
+    def test_list_messages(self, client: TestClient):
+        spawn_resp = client.post(
+            "/api/v1/tyr/planning/sessions",
+            json={"spec": "Spec", "repo": "repo"},
+        )
+        session_id = spawn_resp.json()["id"]
+
+        client.post(
+            f"/api/v1/tyr/planning/sessions/{session_id}/messages",
+            json={"content": "msg 1"},
+        )
+        client.post(
+            f"/api/v1/tyr/planning/sessions/{session_id}/messages",
+            json={"content": "msg 2"},
+        )
+
+        resp = client.get(f"/api/v1/tyr/planning/sessions/{session_id}/messages")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2
+
+    def test_list_messages_not_found(self, client: TestClient):
+        resp = client.get(f"/api/v1/tyr/planning/sessions/{uuid4()}/messages")
+        assert resp.status_code == 404
+
+    def test_propose_structure(self, client: TestClient):
+        spawn_resp = client.post(
+            "/api/v1/tyr/planning/sessions",
+            json={"spec": "Spec", "repo": "repo"},
+        )
+        session_id = spawn_resp.json()["id"]
+
+        resp = client.post(
+            f"/api/v1/tyr/planning/sessions/{session_id}/structure",
+            json={"raw_json": VALID_STRUCTURE_JSON},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "STRUCTURE_PROPOSED"
+        assert data["structure"] is not None
+        assert data["structure"]["name"] == "Auth Refactor"
+
+    def test_propose_structure_invalid(self, client: TestClient):
+        spawn_resp = client.post(
+            "/api/v1/tyr/planning/sessions",
+            json={"spec": "Spec", "repo": "repo"},
+        )
+        session_id = spawn_resp.json()["id"]
+
+        resp = client.post(
+            f"/api/v1/tyr/planning/sessions/{session_id}/structure",
+            json={"raw_json": INVALID_STRUCTURE_JSON},
+        )
+        assert resp.status_code == 422
+
+    def test_propose_structure_not_found(self, client: TestClient):
+        resp = client.post(
+            f"/api/v1/tyr/planning/sessions/{uuid4()}/structure",
+            json={"raw_json": VALID_STRUCTURE_JSON},
+        )
+        assert resp.status_code == 404
+
+    def test_complete_session(self, client: TestClient):
+        spawn_resp = client.post(
+            "/api/v1/tyr/planning/sessions",
+            json={"spec": "Spec", "repo": "repo"},
+        )
+        session_id = spawn_resp.json()["id"]
+
+        client.post(
+            f"/api/v1/tyr/planning/sessions/{session_id}/structure",
+            json={"raw_json": VALID_STRUCTURE_JSON},
+        )
+
+        resp = client.post(f"/api/v1/tyr/planning/sessions/{session_id}/complete")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "COMPLETED"
+
+    def test_complete_without_structure(self, client: TestClient):
+        spawn_resp = client.post(
+            "/api/v1/tyr/planning/sessions",
+            json={"spec": "Spec", "repo": "repo"},
+        )
+        session_id = spawn_resp.json()["id"]
+
+        resp = client.post(f"/api/v1/tyr/planning/sessions/{session_id}/complete")
+        assert resp.status_code == 409
+
+    def test_complete_not_found(self, client: TestClient):
+        resp = client.post(f"/api/v1/tyr/planning/sessions/{uuid4()}/complete")
+        assert resp.status_code == 404
+
+    def test_delete_session(self, client: TestClient):
+        spawn_resp = client.post(
+            "/api/v1/tyr/planning/sessions",
+            json={"spec": "Spec", "repo": "repo"},
+        )
+        session_id = spawn_resp.json()["id"]
+
+        resp = client.delete(f"/api/v1/tyr/planning/sessions/{session_id}")
+        assert resp.status_code == 204
+
+        resp = client.get(f"/api/v1/tyr/planning/sessions/{session_id}")
+        assert resp.status_code == 404
+
+    def test_delete_session_not_found(self, client: TestClient):
+        resp = client.delete(f"/api/v1/tyr/planning/sessions/{uuid4()}")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Model tests
+# ---------------------------------------------------------------------------
+
+
+class TestPlanningModels:
+    def test_planning_session_status_values(self):
+        assert PlanningSessionStatus.SPAWNING == "SPAWNING"
+        assert PlanningSessionStatus.ACTIVE == "ACTIVE"
+        assert PlanningSessionStatus.STRUCTURE_PROPOSED == "STRUCTURE_PROPOSED"
+        assert PlanningSessionStatus.COMPLETED == "COMPLETED"
+        assert PlanningSessionStatus.FAILED == "FAILED"
+        assert PlanningSessionStatus.EXPIRED == "EXPIRED"
+
+    def test_planning_session_frozen(self):
+        session = PlanningSession(
+            id=uuid4(),
+            owner_id="user-1",
+            session_id="vs-001",
+            repo="repo",
+            spec="spec",
+            status=PlanningSessionStatus.ACTIVE,
+            structure=None,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        with pytest.raises(AttributeError):
+            session.status = PlanningSessionStatus.COMPLETED  # type: ignore[misc]
+
+    def test_planning_message_frozen(self):
+        msg = PlanningMessage(
+            id=uuid4(),
+            planning_session_id=uuid4(),
+            content="hello",
+            sender="user",
+            created_at=datetime.now(UTC),
+        )
+        with pytest.raises(AttributeError):
+            msg.content = "changed"  # type: ignore[misc]
+
+    def test_planner_config_defaults(self):
+        config = PlannerConfig()
+        assert config.idle_timeout_seconds == 1800.0
+        assert config.max_sessions_per_user == 3
+        assert config.default_model == "claude-opus-4-6"
+        assert len(config.system_prompt) > 0

--- a/tests/test_tyr/test_ports.py
+++ b/tests/test_tyr/test_ports.py
@@ -53,6 +53,7 @@ class TestVolundrPort:
             "get_pr_status",
             "get_chronicle_summary",
             "send_message",
+            "stop_session",
             "subscribe_activity",
         }
         abstract_methods = {

--- a/tests/test_tyr/test_raids_api.py
+++ b/tests/test_tyr/test_raids_api.py
@@ -245,6 +245,9 @@ class MockVolundr(VolundrPort):
     ) -> None:
         pass
 
+    async def stop_session(self, session_id, *, auth_token=None):
+        pass
+
     async def subscribe_activity(self):
         return
         yield  # type: ignore[misc]  # pragma: no cover

--- a/tests/test_tyr/test_review_engine.py
+++ b/tests/test_tyr/test_review_engine.py
@@ -235,6 +235,9 @@ class StubVolundr(VolundrPort):
             raise RuntimeError("Send failed")
         self.messages.append((session_id, message))
 
+    async def stop_session(self, session_id, *, auth_token=None):
+        pass
+
     async def subscribe_activity(self) -> AsyncGenerator[ActivityEvent, None]:
         return
         yield  # type: ignore[misc]  # pragma: no cover

--- a/tests/test_tyr/test_telegram_webhook.py
+++ b/tests/test_tyr/test_telegram_webhook.py
@@ -225,6 +225,9 @@ class StubVolundr(VolundrPort):
     async def send_message(self, session_id, message, *, auth_token=None):
         self.sent_messages.append((session_id, message))
 
+    async def stop_session(self, session_id, *, auth_token=None):
+        pass
+
     async def subscribe_activity(self):
         return
         yield  # type: ignore[misc]  # pragma: no cover

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -42,6 +42,9 @@ const TyrSessionsView = lazy(() =>
 const ImportView = lazy(() =>
   import('@/modules/tyr/pages/ImportView').then(m => ({ default: m.ImportView }))
 );
+const PlanSagaView = lazy(() =>
+  import('@/modules/tyr/pages/PlanSagaView').then(m => ({ default: m.PlanSagaView }))
+);
 
 function PageLoader() {
   return (
@@ -67,6 +70,7 @@ function AppContent() {
             <Route path="sagas/:id" element={<SagaDetailView />} />
             <Route path="new" element={<NewSagaView />} />
             <Route path="import" element={<ImportView />} />
+            <Route path="plan" element={<PlanSagaView />} />
             <Route path="dispatcher" element={<DispatcherView />} />
             <Route path="sessions" element={<TyrSessionsView />} />
             <Route path="settings" element={<Navigate to="/settings" replace />} />

--- a/web/src/modules/tyr/adapters/api/index.ts
+++ b/web/src/modules/tyr/adapters/api/index.ts
@@ -2,3 +2,4 @@ export { ApiTyrService } from './tyr';
 export { ApiDispatcherService } from './dispatcher';
 export { ApiTrackerBrowserService } from './tracker';
 export { ApiTyrIntegrationService } from './integrations';
+export { ApiPlanningService } from './planning';

--- a/web/src/modules/tyr/adapters/api/planning.ts
+++ b/web/src/modules/tyr/adapters/api/planning.ts
@@ -1,0 +1,45 @@
+import { createApiClient } from '@/modules/shared/api/client';
+import type { IPlanningService } from '../../ports/planning.port';
+import type { PlanningSession, PlanningMessage } from '../../models/planning';
+
+const api = createApiClient('/api/v1/tyr/planning');
+
+export class ApiPlanningService implements IPlanningService {
+  async spawnSession(spec: string, repo: string): Promise<PlanningSession> {
+    return api.post<PlanningSession>('/sessions', { spec, repo });
+  }
+
+  async listSessions(): Promise<PlanningSession[]> {
+    return api.get<PlanningSession[]>('/sessions');
+  }
+
+  async getSession(id: string): Promise<PlanningSession | null> {
+    try {
+      return await api.get<PlanningSession>(`/sessions/${id}`);
+    } catch {
+      return null;
+    }
+  }
+
+  async sendMessage(sessionId: string, content: string): Promise<PlanningMessage> {
+    return api.post<PlanningMessage>(`/sessions/${sessionId}/messages`, { content });
+  }
+
+  async getMessages(sessionId: string): Promise<PlanningMessage[]> {
+    return api.get<PlanningMessage[]>(`/sessions/${sessionId}/messages`);
+  }
+
+  async proposeStructure(sessionId: string, rawJson: string): Promise<PlanningSession> {
+    return api.post<PlanningSession>(`/sessions/${sessionId}/structure`, {
+      raw_json: rawJson,
+    });
+  }
+
+  async completeSession(sessionId: string): Promise<PlanningSession> {
+    return api.post<PlanningSession>(`/sessions/${sessionId}/complete`);
+  }
+
+  async deleteSession(sessionId: string): Promise<void> {
+    await api.delete(`/sessions/${sessionId}`);
+  }
+}

--- a/web/src/modules/tyr/adapters/api/tyr.ts
+++ b/web/src/modules/tyr/adapters/api/tyr.ts
@@ -1,5 +1,5 @@
 import { createApiClient } from '@/modules/shared/api/client';
-import type { ITyrService } from '../../ports';
+import type { ITyrService, CommitSagaRequest } from '../../ports';
 import type { Saga, Phase } from '../../models';
 
 const api = createApiClient('/api/v1/tyr/sagas');
@@ -130,6 +130,33 @@ export class ApiTyrService implements ITyrService {
 
   async createSaga(_spec: string, _repo: string): Promise<Saga> {
     throw new Error('Use the import flow instead');
+  }
+
+  async commitSaga(request: CommitSagaRequest): Promise<Saga> {
+    const data = await api.post<{
+      id: string;
+      tracker_id: string;
+      tracker_type: string;
+      slug: string;
+      name: string;
+      repos: string[];
+      feature_branch: string;
+      base_branch: string;
+      status: string;
+    }>('/commit', request);
+    return {
+      id: data.id,
+      tracker_id: data.tracker_id,
+      tracker_type: data.tracker_type,
+      slug: data.slug,
+      name: data.name,
+      repos: data.repos,
+      feature_branch: data.feature_branch,
+      status: data.status.toLowerCase() as Saga['status'],
+      confidence: 0,
+      created_at: '',
+      phase_summary: { total: request.phases.length, completed: 0 },
+    };
   }
 
   async decompose(_spec: string, _repo: string): Promise<Phase[]> {

--- a/web/src/modules/tyr/adapters/index.ts
+++ b/web/src/modules/tyr/adapters/index.ts
@@ -4,18 +4,21 @@ import {
   MockTyrSessionService,
   MockTrackerBrowserService,
   MockTyrIntegrationService,
+  MockPlanningService,
 } from './mock';
 import {
   ApiTyrService,
   ApiDispatcherService,
   ApiTrackerBrowserService,
   ApiTyrIntegrationService,
+  ApiPlanningService,
 } from './api';
 import type { ITyrService } from '../ports';
 import type { IDispatcherService } from '../ports';
 import type { ITyrSessionService } from '../ports';
 import type { ITrackerBrowserService } from '../ports';
 import type { ITyrIntegrationService } from '../ports';
+import type { IPlanningService } from '../ports';
 
 const useMocks = import.meta.env.VITE_USE_MOCK_TYR === 'true';
 
@@ -30,3 +33,6 @@ export const trackerService: ITrackerBrowserService = useMocks
 export const tyrIntegrationService: ITyrIntegrationService = useMocks
   ? new MockTyrIntegrationService()
   : new ApiTyrIntegrationService();
+export const planningService: IPlanningService = useMocks
+  ? new MockPlanningService()
+  : new ApiPlanningService();

--- a/web/src/modules/tyr/adapters/mock/index.ts
+++ b/web/src/modules/tyr/adapters/mock/index.ts
@@ -3,3 +3,4 @@ export { MockDispatcherService } from './dispatcher.adapter';
 export { MockTyrSessionService } from './session.adapter';
 export { MockTrackerBrowserService } from './tracker.adapter';
 export { MockTyrIntegrationService } from './integrations.adapter';
+export { MockPlanningService } from './planning.adapter';

--- a/web/src/modules/tyr/adapters/mock/planning.adapter.ts
+++ b/web/src/modules/tyr/adapters/mock/planning.adapter.ts
@@ -8,6 +8,7 @@ const mockSession: PlanningSession = {
   repo: 'niuulabs/volundr',
   status: 'ACTIVE',
   structure: null,
+  chat_endpoint: null,
   created_at: new Date().toISOString(),
   updated_at: new Date().toISOString(),
 };

--- a/web/src/modules/tyr/adapters/mock/planning.adapter.ts
+++ b/web/src/modules/tyr/adapters/mock/planning.adapter.ts
@@ -1,0 +1,52 @@
+import type { IPlanningService } from '../../ports/planning.port';
+import type { PlanningSession, PlanningMessage } from '../../models/planning';
+
+const mockSession: PlanningSession = {
+  id: 'plan-001',
+  owner_id: 'user-1',
+  session_id: 'volundr-sess-001',
+  repo: 'niuulabs/volundr',
+  status: 'ACTIVE',
+  structure: null,
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+};
+
+export class MockPlanningService implements IPlanningService {
+  async spawnSession(_spec: string, _repo: string): Promise<PlanningSession> {
+    return { ...mockSession };
+  }
+
+  async listSessions(): Promise<PlanningSession[]> {
+    return [{ ...mockSession }];
+  }
+
+  async getSession(_id: string): Promise<PlanningSession | null> {
+    return { ...mockSession };
+  }
+
+  async sendMessage(_sessionId: string, content: string): Promise<PlanningMessage> {
+    return {
+      id: 'msg-001',
+      content,
+      sender: 'user',
+      created_at: new Date().toISOString(),
+    };
+  }
+
+  async getMessages(_sessionId: string): Promise<PlanningMessage[]> {
+    return [];
+  }
+
+  async proposeStructure(_sessionId: string, _rawJson: string): Promise<PlanningSession> {
+    return { ...mockSession, status: 'STRUCTURE_PROPOSED' };
+  }
+
+  async completeSession(_sessionId: string): Promise<PlanningSession> {
+    return { ...mockSession, status: 'COMPLETED' };
+  }
+
+  async deleteSession(_sessionId: string): Promise<void> {
+    return;
+  }
+}

--- a/web/src/modules/tyr/adapters/mock/tyr.adapter.ts
+++ b/web/src/modules/tyr/adapters/mock/tyr.adapter.ts
@@ -2,6 +2,8 @@ import type { ITyrService, CommitSagaRequest } from '../../ports';
 import type { Saga, Phase } from '../../models';
 import { mockSagas, mockPhases } from './data';
 
+let mockTrackerSeq = 100;
+
 export class MockTyrService implements ITyrService {
   async getSagas(): Promise<Saga[]> {
     return [...mockSagas];
@@ -22,7 +24,7 @@ export class MockTyrService implements ITyrService {
   async createSaga(spec: string, repo: string): Promise<Saga> {
     const saga: Saga = {
       id: crypto.randomUUID(),
-      tracker_id: `NIU-${Math.floor(Math.random() * 900) + 100}`,
+      tracker_id: `NIU-${++mockTrackerSeq}`,
       tracker_type: 'linear',
       slug: spec.toLowerCase().replace(/\s+/g, '-').slice(0, 40),
       name: spec,
@@ -39,7 +41,7 @@ export class MockTyrService implements ITyrService {
   async commitSaga(request: CommitSagaRequest): Promise<Saga> {
     return {
       id: crypto.randomUUID(),
-      tracker_id: `NIU-${Math.floor(Math.random() * 900) + 100}`,
+      tracker_id: `NIU-${++mockTrackerSeq}`,
       tracker_type: 'linear',
       slug: request.slug,
       name: request.name,
@@ -61,7 +63,7 @@ export class MockTyrService implements ITyrService {
       {
         id: crypto.randomUUID(),
         saga_id: sagaId,
-        tracker_id: `NIU-${Math.floor(Math.random() * 900) + 100}`,
+        tracker_id: `NIU-${++mockTrackerSeq}`,
         number: 1,
         name: `Phase 1: Setup for ${spec}`,
         status: 'pending',
@@ -70,7 +72,7 @@ export class MockTyrService implements ITyrService {
           {
             id: crypto.randomUUID(),
             phase_id: '',
-            tracker_id: `NIU-${Math.floor(Math.random() * 900) + 100}`,
+            tracker_id: `NIU-${++mockTrackerSeq}`,
             name: `Scaffold ${spec} infrastructure`,
             description: `Set up the foundational infrastructure for ${spec} in ${repo}.`,
             acceptance_criteria: [

--- a/web/src/modules/tyr/adapters/mock/tyr.adapter.ts
+++ b/web/src/modules/tyr/adapters/mock/tyr.adapter.ts
@@ -1,4 +1,4 @@
-import type { ITyrService } from '../../ports';
+import type { ITyrService, CommitSagaRequest } from '../../ports';
 import type { Saga, Phase } from '../../models';
 import { mockSagas, mockPhases } from './data';
 
@@ -34,6 +34,22 @@ export class MockTyrService implements ITyrService {
       phase_summary: { total: 0, completed: 0 },
     };
     return saga;
+  }
+
+  async commitSaga(request: CommitSagaRequest): Promise<Saga> {
+    return {
+      id: crypto.randomUUID(),
+      tracker_id: `NIU-${Math.floor(Math.random() * 900) + 100}`,
+      tracker_type: 'linear',
+      slug: request.slug,
+      name: request.name,
+      repos: request.repos,
+      feature_branch: `feat/${request.slug}`,
+      status: 'active',
+      confidence: 0.5,
+      created_at: new Date().toISOString(),
+      phase_summary: { total: request.phases.length, completed: 0 },
+    };
   }
 
   async decompose(spec: string, repo: string): Promise<Phase[]> {

--- a/web/src/modules/tyr/components/ChatPanel/ChatPanel.module.css
+++ b/web/src/modules/tyr/components/ChatPanel/ChatPanel.module.css
@@ -30,12 +30,12 @@
   background-color: var(--color-bg-tertiary);
 }
 
-.message[data-sender="user"] {
+.message[data-sender='user'] {
   background-color: color-mix(in srgb, var(--color-accent-cyan) 10%, transparent);
   border: 1px solid color-mix(in srgb, var(--color-accent-cyan) 20%, transparent);
 }
 
-.message[data-sender="system"] {
+.message[data-sender='system'] {
   background-color: color-mix(in srgb, var(--color-accent-purple) 10%, transparent);
   border: 1px solid color-mix(in srgb, var(--color-accent-purple) 20%, transparent);
 }

--- a/web/src/modules/tyr/components/ChatPanel/ChatPanel.module.css
+++ b/web/src/modules/tyr/components/ChatPanel/ChatPanel.module.css
@@ -1,0 +1,106 @@
+.panel {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background-color: var(--color-bg-secondary);
+  overflow: hidden;
+  height: 400px;
+}
+
+.messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.empty {
+  text-align: center;
+  padding: var(--space-6);
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+}
+
+.message {
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  background-color: var(--color-bg-tertiary);
+}
+
+.message[data-sender="user"] {
+  background-color: color-mix(in srgb, var(--color-accent-cyan) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-accent-cyan) 20%, transparent);
+}
+
+.message[data-sender="system"] {
+  background-color: color-mix(in srgb, var(--color-accent-purple) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-accent-purple) 20%, transparent);
+}
+
+.sender {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-secondary);
+}
+
+.content {
+  margin: var(--space-1) 0 0;
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+  white-space: pre-wrap;
+}
+
+.inputArea {
+  display: flex;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-top: 1px solid var(--color-border);
+  background-color: var(--color-bg-primary);
+}
+
+.input {
+  flex: 1;
+  padding: var(--space-2) var(--space-3);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  transition: border-color var(--transition-fast);
+}
+
+.input:focus {
+  outline: none;
+  border-color: var(--color-accent-cyan);
+}
+
+.input::placeholder {
+  color: var(--color-text-faint);
+}
+
+.sendButton {
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--color-accent-cyan);
+  background-color: color-mix(in srgb, var(--color-accent-cyan) 15%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-accent-cyan) 30%, transparent);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
+}
+
+.sendButton:hover:not(:disabled) {
+  background-color: color-mix(in srgb, var(--color-accent-cyan) 25%, transparent);
+}
+
+.sendButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/web/src/modules/tyr/components/ChatPanel/ChatPanel.test.tsx
+++ b/web/src/modules/tyr/components/ChatPanel/ChatPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ChatPanel } from './ChatPanel';
 import type { PlanningMessage } from '../../models/planning';

--- a/web/src/modules/tyr/components/ChatPanel/ChatPanel.test.tsx
+++ b/web/src/modules/tyr/components/ChatPanel/ChatPanel.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ChatPanel } from './ChatPanel';
+import type { PlanningMessage } from '../../models/planning';
+
+const mockMessages: PlanningMessage[] = [
+  {
+    id: 'msg-1',
+    content: 'Should we split the auth phase?',
+    sender: 'user',
+    created_at: '2026-03-25T10:00:00Z',
+  },
+  {
+    id: 'msg-2',
+    content: 'Yes, splitting into middleware and token validation would be cleaner.',
+    sender: 'system',
+    created_at: '2026-03-25T10:01:00Z',
+  },
+];
+
+describe('ChatPanel', () => {
+  it('renders empty state when no messages', () => {
+    const onSend = vi.fn();
+    render(<ChatPanel messages={[]} onSend={onSend} />);
+
+    expect(screen.getByText(/start the conversation/i)).toBeInTheDocument();
+  });
+
+  it('renders messages with correct sender attribution', () => {
+    const onSend = vi.fn();
+    render(<ChatPanel messages={mockMessages} onSend={onSend} />);
+
+    expect(screen.getByText('Should we split the auth phase?')).toBeInTheDocument();
+    expect(
+      screen.getByText(/splitting into middleware/),
+    ).toBeInTheDocument();
+  });
+
+  it('renders sender labels', () => {
+    const onSend = vi.fn();
+    render(<ChatPanel messages={mockMessages} onSend={onSend} />);
+
+    const senders = screen.getAllByText(/user|system/);
+    expect(senders.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('calls onSend when form is submitted with content', async () => {
+    const onSend = vi.fn();
+    const user = userEvent.setup();
+    render(<ChatPanel messages={[]} onSend={onSend} />);
+
+    const input = screen.getByPlaceholderText(/discuss/i);
+    await user.type(input, 'What about adding a caching layer?');
+    await user.click(screen.getByRole('button', { name: /send/i }));
+
+    expect(onSend).toHaveBeenCalledWith('What about adding a caching layer?');
+  });
+
+  it('clears input after sending', async () => {
+    const onSend = vi.fn();
+    const user = userEvent.setup();
+    render(<ChatPanel messages={[]} onSend={onSend} />);
+
+    const input = screen.getByPlaceholderText(/discuss/i) as HTMLInputElement;
+    await user.type(input, 'Test message');
+    await user.click(screen.getByRole('button', { name: /send/i }));
+
+    expect(input.value).toBe('');
+  });
+
+  it('does not send empty messages', async () => {
+    const onSend = vi.fn();
+    const user = userEvent.setup();
+    render(<ChatPanel messages={[]} onSend={onSend} />);
+
+    await user.click(screen.getByRole('button', { name: /send/i }));
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('disables input and button when disabled prop is true', () => {
+    const onSend = vi.fn();
+    render(<ChatPanel messages={[]} onSend={onSend} disabled />);
+
+    const input = screen.getByPlaceholderText(/discuss/i) as HTMLInputElement;
+    const button = screen.getByRole('button', { name: /send/i });
+
+    expect(input.disabled).toBe(true);
+    expect(button).toBeDisabled();
+  });
+
+  it('renders message data-sender attributes', () => {
+    const onSend = vi.fn();
+    const { container } = render(
+      <ChatPanel messages={mockMessages} onSend={onSend} />,
+    );
+
+    const userMsg = container.querySelector('[data-sender="user"]');
+    const systemMsg = container.querySelector('[data-sender="system"]');
+
+    expect(userMsg).toBeInTheDocument();
+    expect(systemMsg).toBeInTheDocument();
+  });
+});

--- a/web/src/modules/tyr/components/ChatPanel/ChatPanel.test.tsx
+++ b/web/src/modules/tyr/components/ChatPanel/ChatPanel.test.tsx
@@ -32,9 +32,7 @@ describe('ChatPanel', () => {
     render(<ChatPanel messages={mockMessages} onSend={onSend} />);
 
     expect(screen.getByText('Should we split the auth phase?')).toBeInTheDocument();
-    expect(
-      screen.getByText(/splitting into middleware/),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/splitting into middleware/)).toBeInTheDocument();
   });
 
   it('renders sender labels', () => {
@@ -91,9 +89,7 @@ describe('ChatPanel', () => {
 
   it('renders message data-sender attributes', () => {
     const onSend = vi.fn();
-    const { container } = render(
-      <ChatPanel messages={mockMessages} onSend={onSend} />,
-    );
+    const { container } = render(<ChatPanel messages={mockMessages} onSend={onSend} />);
 
     const userMsg = container.querySelector('[data-sender="user"]');
     const systemMsg = container.querySelector('[data-sender="system"]');

--- a/web/src/modules/tyr/components/ChatPanel/ChatPanel.tsx
+++ b/web/src/modules/tyr/components/ChatPanel/ChatPanel.tsx
@@ -1,0 +1,68 @@
+import { useState, useRef, useEffect } from 'react';
+import type { PlanningMessage } from '../../models/planning';
+import styles from './ChatPanel.module.css';
+
+interface ChatPanelProps {
+  messages: PlanningMessage[];
+  onSend: (content: string) => void;
+  disabled?: boolean;
+}
+
+export function ChatPanel({ messages, onSend, disabled = false }: ChatPanelProps) {
+  const [input, setInput] = useState('');
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (typeof messagesEndRef.current?.scrollIntoView === 'function') {
+      messagesEndRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [messages]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = input.trim();
+    if (!trimmed || disabled) return;
+    onSend(trimmed);
+    setInput('');
+  };
+
+  return (
+    <div className={styles.panel}>
+      <div className={styles.messages}>
+        {messages.length === 0 && (
+          <div className={styles.empty}>
+            Start the conversation to refine your saga decomposition.
+          </div>
+        )}
+        {messages.map(msg => (
+          <div
+            key={msg.id}
+            className={styles.message}
+            data-sender={msg.sender}
+          >
+            <span className={styles.sender}>{msg.sender}</span>
+            <p className={styles.content}>{msg.content}</p>
+          </div>
+        ))}
+        <div ref={messagesEndRef} />
+      </div>
+      <form className={styles.inputArea} onSubmit={handleSubmit}>
+        <input
+          type="text"
+          className={styles.input}
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          placeholder="Discuss the decomposition..."
+          disabled={disabled}
+        />
+        <button
+          type="submit"
+          className={styles.sendButton}
+          disabled={disabled || !input.trim()}
+        >
+          Send
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/web/src/modules/tyr/components/ChatPanel/ChatPanel.tsx
+++ b/web/src/modules/tyr/components/ChatPanel/ChatPanel.tsx
@@ -35,11 +35,7 @@ export function ChatPanel({ messages, onSend, disabled = false }: ChatPanelProps
           </div>
         )}
         {messages.map(msg => (
-          <div
-            key={msg.id}
-            className={styles.message}
-            data-sender={msg.sender}
-          >
+          <div key={msg.id} className={styles.message} data-sender={msg.sender}>
             <span className={styles.sender}>{msg.sender}</span>
             <p className={styles.content}>{msg.content}</p>
           </div>
@@ -55,11 +51,7 @@ export function ChatPanel({ messages, onSend, disabled = false }: ChatPanelProps
           placeholder="Discuss the decomposition..."
           disabled={disabled}
         />
-        <button
-          type="submit"
-          className={styles.sendButton}
-          disabled={disabled || !input.trim()}
-        >
+        <button type="submit" className={styles.sendButton} disabled={disabled || !input.trim()}>
           Send
         </button>
       </form>

--- a/web/src/modules/tyr/components/ChatPanel/index.ts
+++ b/web/src/modules/tyr/components/ChatPanel/index.ts
@@ -1,0 +1,1 @@
+export { ChatPanel } from './ChatPanel';

--- a/web/src/modules/tyr/models/planning.ts
+++ b/web/src/modules/tyr/models/planning.ts
@@ -1,0 +1,44 @@
+export type PlanningSessionStatus =
+  | 'SPAWNING'
+  | 'ACTIVE'
+  | 'STRUCTURE_PROPOSED'
+  | 'COMPLETED'
+  | 'FAILED'
+  | 'EXPIRED';
+
+export interface PlanningRaidSpec {
+  name: string;
+  description: string;
+  acceptance_criteria: string[];
+  declared_files: string[];
+  estimate_hours: number;
+  confidence: number;
+}
+
+export interface PlanningPhaseSpec {
+  name: string;
+  raids: PlanningRaidSpec[];
+}
+
+export interface PlanningStructure {
+  name: string;
+  phases: PlanningPhaseSpec[];
+}
+
+export interface PlanningSession {
+  id: string;
+  owner_id: string;
+  session_id: string;
+  repo: string;
+  status: PlanningSessionStatus;
+  structure: PlanningStructure | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PlanningMessage {
+  id: string;
+  content: string;
+  sender: string;
+  created_at: string;
+}

--- a/web/src/modules/tyr/models/planning.ts
+++ b/web/src/modules/tyr/models/planning.ts
@@ -32,6 +32,7 @@ export interface PlanningSession {
   repo: string;
   status: PlanningSessionStatus;
   structure: PlanningStructure | null;
+  chat_endpoint: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/web/src/modules/tyr/pages/NewSagaView/NewSagaView.test.tsx
+++ b/web/src/modules/tyr/pages/NewSagaView/NewSagaView.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { NewSagaView } from './NewSagaView';
 
 vi.mock('../../adapters', () => ({
@@ -15,6 +15,17 @@ function renderView() {
   return render(
     <MemoryRouter>
       <NewSagaView />
+    </MemoryRouter>
+  );
+}
+
+function renderViewWithState(state: Record<string, unknown>) {
+  return render(
+    <MemoryRouter initialEntries={[{ pathname: '/tyr/new', state }]}>
+      <Routes>
+        <Route path="/tyr/new" element={<NewSagaView />} />
+        <Route path="/tyr/sagas/:id" element={<div>Saga Detail</div>} />
+      </Routes>
     </MemoryRouter>
   );
 }
@@ -130,5 +141,24 @@ describe('NewSagaView', () => {
     const input = screen.getByLabelText('Repository') as HTMLInputElement;
     await userEvent.type(input, 'niuulabs/app');
     expect(input.value).toBe('niuulabs/app');
+  });
+
+  it('initializes spec and repo from navigation state', () => {
+    renderViewWithState({ spec: 'Auth refactor', repo: 'niuu/volundr' });
+
+    const textarea = screen.getByLabelText('Specification') as HTMLTextAreaElement;
+    const input = screen.getByLabelText('Repository') as HTMLInputElement;
+    expect(textarea.value).toBe('Auth refactor');
+    expect(input.value).toBe('niuu/volundr');
+  });
+
+  it('initializes with preview from navigation state phases', () => {
+    renderViewWithState({
+      spec: 'Auth',
+      repo: 'niuu/volundr',
+      phases: [{ id: 'p1', name: 'Phase 1', raids: [] }],
+    });
+
+    expect(screen.getByText('Phase Preview')).toBeInTheDocument();
   });
 });

--- a/web/src/modules/tyr/pages/NewSagaView/NewSagaView.tsx
+++ b/web/src/modules/tyr/pages/NewSagaView/NewSagaView.tsx
@@ -1,14 +1,22 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import type { Phase } from '../../models';
 import { tyrService } from '../../adapters';
 import { PhaseBlock } from '../../components/PhaseBlock';
 import styles from './NewSagaView.module.css';
 
+interface LocationState {
+  phases?: Phase[];
+  spec?: string;
+  repo?: string;
+}
+
 export function NewSagaView() {
-  const [spec, setSpec] = useState('');
-  const [repo, setRepo] = useState('');
-  const [preview, setPreview] = useState<Phase[] | null>(null);
+  const location = useLocation();
+  const navState = (location.state ?? {}) as LocationState;
+  const [spec, setSpec] = useState(navState.spec ?? '');
+  const [repo, setRepo] = useState(navState.repo ?? '');
+  const [preview, setPreview] = useState<Phase[] | null>(navState.phases ?? null);
   const [decomposing, setDecomposing] = useState(false);
   const [committing, setCommitting] = useState(false);
   const navigate = useNavigate();

--- a/web/src/modules/tyr/pages/PlanSagaView/PlanSagaView.module.css
+++ b/web/src/modules/tyr/pages/PlanSagaView/PlanSagaView.module.css
@@ -250,3 +250,40 @@
   opacity: 0.5;
   cursor: not-allowed;
 }
+
+.detectedStructure {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  background-color: color-mix(in srgb, var(--color-accent-amber) 8%, var(--color-bg-secondary));
+  border: 1px solid color-mix(in srgb, var(--color-accent-amber) 30%, transparent);
+  border-radius: var(--radius-md);
+}
+
+.detectedLabel {
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--color-accent-amber);
+}
+
+.useStructureButton {
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--color-accent-amber);
+  background-color: color-mix(in srgb, var(--color-accent-amber) 15%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-accent-amber) 30%, transparent);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
+}
+
+.useStructureButton:hover:not(:disabled) {
+  background-color: color-mix(in srgb, var(--color-accent-amber) 25%, transparent);
+}
+
+.useStructureButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/web/src/modules/tyr/pages/PlanSagaView/PlanSagaView.module.css
+++ b/web/src/modules/tyr/pages/PlanSagaView/PlanSagaView.module.css
@@ -1,0 +1,252 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+  max-width: 800px;
+}
+
+.heading {
+  font-size: var(--text-lg);
+  font-weight: 600;
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+.error {
+  padding: var(--space-3);
+  font-size: var(--text-sm);
+  color: var(--color-accent-red);
+  background-color: color-mix(in srgb, var(--color-accent-red) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-accent-red) 30%, transparent);
+  border-radius: var(--radius-sm);
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.label {
+  font-size: var(--text-xs);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-secondary);
+}
+
+.textarea {
+  width: 100%;
+  padding: var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  resize: vertical;
+  transition: border-color var(--transition-fast);
+}
+
+.textarea:focus {
+  outline: none;
+  border-color: var(--color-accent-cyan);
+}
+
+.textarea::placeholder {
+  color: var(--color-text-faint);
+}
+
+.input {
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  transition: border-color var(--transition-fast);
+}
+
+.input:focus {
+  outline: none;
+  border-color: var(--color-accent-cyan);
+}
+
+.input::placeholder {
+  color: var(--color-text-faint);
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-3);
+  padding-top: var(--space-2);
+}
+
+.primaryButton {
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--color-accent-cyan);
+  background-color: color-mix(in srgb, var(--color-accent-cyan) 15%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-accent-cyan) 30%, transparent);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
+}
+
+.primaryButton:hover:not(:disabled) {
+  background-color: color-mix(in srgb, var(--color-accent-cyan) 25%, transparent);
+}
+
+.primaryButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.secondaryButton {
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  background-color: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
+}
+
+.secondaryButton:hover:not(:disabled) {
+  background-color: var(--color-bg-elevated);
+}
+
+.secondaryButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.sessionArea {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.sessionHeader {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.sessionStatus {
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  border-radius: var(--radius-full);
+  color: var(--color-text-secondary);
+  background-color: var(--color-bg-tertiary);
+}
+
+.sessionStatus[data-status="ACTIVE"] {
+  color: var(--color-accent-emerald);
+  background-color: color-mix(in srgb, var(--color-accent-emerald) 15%, transparent);
+}
+
+.sessionStatus[data-status="STRUCTURE_PROPOSED"] {
+  color: var(--color-accent-amber);
+  background-color: color-mix(in srgb, var(--color-accent-amber) 15%, transparent);
+}
+
+.sessionStatus[data-status="COMPLETED"] {
+  color: var(--color-accent-cyan);
+  background-color: color-mix(in srgb, var(--color-accent-cyan) 15%, transparent);
+}
+
+.sessionRepo {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+.structureArea {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.structurePreview {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  background-color: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.previewHeading {
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
+.structureName {
+  font-size: var(--text-base);
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.phase {
+  padding: var(--space-2) var(--space-3);
+  background-color: var(--color-bg-tertiary);
+  border-radius: var(--radius-sm);
+}
+
+.phaseName {
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--color-accent-purple);
+  margin-bottom: var(--space-1);
+}
+
+.raid {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--text-sm);
+}
+
+.raidName {
+  color: var(--color-text-primary);
+}
+
+.raidEstimate {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+.commitButton {
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--color-accent-emerald);
+  background-color: color-mix(in srgb, var(--color-accent-emerald) 15%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-accent-emerald) 30%, transparent);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
+}
+
+.commitButton:hover:not(:disabled) {
+  background-color: color-mix(in srgb, var(--color-accent-emerald) 25%, transparent);
+}
+
+.commitButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/web/src/modules/tyr/pages/PlanSagaView/PlanSagaView.module.css
+++ b/web/src/modules/tyr/pages/PlanSagaView/PlanSagaView.module.css
@@ -149,17 +149,17 @@
   background-color: var(--color-bg-tertiary);
 }
 
-.sessionStatus[data-status="ACTIVE"] {
+.sessionStatus[data-status='ACTIVE'] {
   color: var(--color-accent-emerald);
   background-color: color-mix(in srgb, var(--color-accent-emerald) 15%, transparent);
 }
 
-.sessionStatus[data-status="STRUCTURE_PROPOSED"] {
+.sessionStatus[data-status='STRUCTURE_PROPOSED'] {
   color: var(--color-accent-amber);
   background-color: color-mix(in srgb, var(--color-accent-amber) 15%, transparent);
 }
 
-.sessionStatus[data-status="COMPLETED"] {
+.sessionStatus[data-status='COMPLETED'] {
   color: var(--color-accent-cyan);
   background-color: color-mix(in srgb, var(--color-accent-cyan) 15%, transparent);
 }

--- a/web/src/modules/tyr/pages/PlanSagaView/PlanSagaView.test.tsx
+++ b/web/src/modules/tyr/pages/PlanSagaView/PlanSagaView.test.tsx
@@ -52,7 +52,7 @@ vi.mock('../../adapters', () => ({
     sendMessage: vi.fn(() => Promise.resolve({ ...mockMessage })),
     proposeStructure: vi.fn(() => Promise.resolve({ ...mockSessionWithStructure })),
     completeSession: vi.fn(() =>
-      Promise.resolve({ ...mockSessionWithStructure, status: 'COMPLETED' }),
+      Promise.resolve({ ...mockSessionWithStructure, status: 'COMPLETED' })
     ),
     deleteSession: vi.fn(() => Promise.resolve()),
   },
@@ -70,7 +70,7 @@ function renderView() {
         <Route path="/tyr/sagas/:id" element={<div>Saga Detail</div>} />
         <Route path="/tyr/new" element={<div>New Saga</div>} />
       </Routes>
-    </MemoryRouter>,
+    </MemoryRouter>
   );
 }
 
@@ -132,9 +132,7 @@ describe('PlanSagaView', () => {
   it('shows error on spawn failure', async () => {
     const user = userEvent.setup();
     const { planningService } = await import('../../adapters');
-    vi.mocked(planningService.spawnSession).mockRejectedValueOnce(
-      new Error('Volundr unreachable'),
-    );
+    vi.mocked(planningService.spawnSession).mockRejectedValueOnce(new Error('Volundr unreachable'));
     renderView();
 
     await user.type(screen.getByLabelText(/specification/i), 'Build auth');

--- a/web/src/modules/tyr/pages/PlanSagaView/PlanSagaView.test.tsx
+++ b/web/src/modules/tyr/pages/PlanSagaView/PlanSagaView.test.tsx
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { PlanSagaView } from './PlanSagaView';
+import type { PlanningSession, PlanningMessage } from '../../models/planning';
+
+const mockSession: PlanningSession = {
+  id: 'plan-001',
+  owner_id: 'user-1',
+  session_id: 'volundr-sess-001',
+  repo: 'niuu/volundr',
+  status: 'ACTIVE',
+  structure: null,
+  created_at: '2026-03-25T10:00:00Z',
+  updated_at: '2026-03-25T10:00:00Z',
+};
+
+const mockMessage: PlanningMessage = {
+  id: 'msg-001',
+  content: 'Split the auth phase',
+  sender: 'user',
+  created_at: '2026-03-25T10:00:00Z',
+};
+
+const mockSessionWithStructure: PlanningSession = {
+  ...mockSession,
+  status: 'STRUCTURE_PROPOSED',
+  structure: {
+    name: 'Auth Refactor',
+    phases: [
+      {
+        name: 'Phase 1',
+        raids: [
+          {
+            name: 'Setup middleware',
+            description: 'Implement auth middleware',
+            acceptance_criteria: ['Routes protected'],
+            declared_files: ['src/auth.py'],
+            estimate_hours: 4,
+            confidence: 0.8,
+          },
+        ],
+      },
+    ],
+  },
+};
+
+vi.mock('../../adapters', () => ({
+  planningService: {
+    spawnSession: vi.fn(() => Promise.resolve({ ...mockSession })),
+    sendMessage: vi.fn(() => Promise.resolve({ ...mockMessage })),
+    proposeStructure: vi.fn(() => Promise.resolve({ ...mockSessionWithStructure })),
+    completeSession: vi.fn(() =>
+      Promise.resolve({ ...mockSessionWithStructure, status: 'COMPLETED' }),
+    ),
+    deleteSession: vi.fn(() => Promise.resolve()),
+  },
+  tyrService: {
+    decompose: vi.fn(() => Promise.resolve([])),
+    createSaga: vi.fn(() => Promise.resolve({ id: 'saga-001' })),
+  },
+}));
+
+function renderView() {
+  return render(
+    <MemoryRouter initialEntries={['/tyr/plan']}>
+      <Routes>
+        <Route path="/tyr/plan" element={<PlanSagaView />} />
+        <Route path="/tyr/sagas/:id" element={<div>Saga Detail</div>} />
+        <Route path="/tyr/new" element={<div>New Saga</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('PlanSagaView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the initial form', () => {
+    renderView();
+
+    expect(screen.getByText('Plan Saga')).toBeInTheDocument();
+    expect(screen.getByLabelText(/specification/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/repository/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /start planning session/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /one-shot decompose/i })).toBeInTheDocument();
+  });
+
+  it('disables buttons when spec or repo is empty', () => {
+    renderView();
+
+    const spawnBtn = screen.getByRole('button', { name: /start planning session/i });
+    const decomposeBtn = screen.getByRole('button', { name: /one-shot decompose/i });
+
+    expect(spawnBtn).toBeDisabled();
+    expect(decomposeBtn).toBeDisabled();
+  });
+
+  it('enables buttons when spec and repo are filled', async () => {
+    const user = userEvent.setup();
+    renderView();
+
+    await user.type(screen.getByLabelText(/specification/i), 'Build auth');
+    await user.type(screen.getByLabelText(/repository/i), 'niuu/volundr');
+
+    const spawnBtn = screen.getByRole('button', { name: /start planning session/i });
+    expect(spawnBtn).not.toBeDisabled();
+  });
+
+  it('spawns a planning session on button click', async () => {
+    const user = userEvent.setup();
+    const { planningService } = await import('../../adapters');
+    renderView();
+
+    await user.type(screen.getByLabelText(/specification/i), 'Build auth');
+    await user.type(screen.getByLabelText(/repository/i), 'niuu/volundr');
+    await user.click(screen.getByRole('button', { name: /start planning session/i }));
+
+    await waitFor(() => {
+      expect(planningService.spawnSession).toHaveBeenCalledWith('Build auth', 'niuu/volundr');
+    });
+
+    // After spawning, should show the session area
+    await waitFor(() => {
+      expect(screen.getByText('ACTIVE')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error on spawn failure', async () => {
+    const user = userEvent.setup();
+    const { planningService } = await import('../../adapters');
+    vi.mocked(planningService.spawnSession).mockRejectedValueOnce(
+      new Error('Volundr unreachable'),
+    );
+    renderView();
+
+    await user.type(screen.getByLabelText(/specification/i), 'Build auth');
+    await user.type(screen.getByLabelText(/repository/i), 'niuu/volundr');
+    await user.click(screen.getByRole('button', { name: /start planning session/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/volundr unreachable/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows structure preview after proposing', async () => {
+    const user = userEvent.setup();
+    renderView();
+
+    // Spawn session
+    await user.type(screen.getByLabelText(/specification/i), 'Build auth');
+    await user.type(screen.getByLabelText(/repository/i), 'niuu/volundr');
+    await user.click(screen.getByRole('button', { name: /start planning session/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('ACTIVE')).toBeInTheDocument();
+    });
+
+    // Propose structure — use fireEvent to avoid userEvent parsing curly braces
+    const jsonInput = screen.getByPlaceholderText(/name.*phases/i);
+    fireEvent.change(jsonInput, { target: { value: '{"name":"test"}' } });
+    await user.click(screen.getByRole('button', { name: /propose structure/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Auth Refactor')).toBeInTheDocument();
+      expect(screen.getByText('Phase 1')).toBeInTheDocument();
+      expect(screen.getByText('Setup middleware')).toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/modules/tyr/pages/PlanSagaView/PlanSagaView.test.tsx
+++ b/web/src/modules/tyr/pages/PlanSagaView/PlanSagaView.test.tsx
@@ -74,6 +74,15 @@ function renderView() {
   );
 }
 
+async function spawnSession(user: ReturnType<typeof userEvent.setup>) {
+  await user.type(screen.getByLabelText(/specification/i), 'Build auth');
+  await user.type(screen.getByLabelText(/repository/i), 'niuu/volundr');
+  await user.click(screen.getByRole('button', { name: /start planning session/i }));
+  await waitFor(() => {
+    expect(screen.getByText('ACTIVE')).toBeInTheDocument();
+  });
+}
+
 describe('PlanSagaView', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -115,18 +124,9 @@ describe('PlanSagaView', () => {
     const { planningService } = await import('../../adapters');
     renderView();
 
-    await user.type(screen.getByLabelText(/specification/i), 'Build auth');
-    await user.type(screen.getByLabelText(/repository/i), 'niuu/volundr');
-    await user.click(screen.getByRole('button', { name: /start planning session/i }));
+    await spawnSession(user);
 
-    await waitFor(() => {
-      expect(planningService.spawnSession).toHaveBeenCalledWith('Build auth', 'niuu/volundr');
-    });
-
-    // After spawning, should show the session area
-    await waitFor(() => {
-      expect(screen.getByText('ACTIVE')).toBeInTheDocument();
-    });
+    expect(planningService.spawnSession).toHaveBeenCalledWith('Build auth', 'niuu/volundr');
   });
 
   it('shows error on spawn failure', async () => {
@@ -144,20 +144,80 @@ describe('PlanSagaView', () => {
     });
   });
 
-  it('shows structure preview after proposing', async () => {
+  it('shows fallback error message on spawn non-Error throw', async () => {
     const user = userEvent.setup();
+    const { planningService } = await import('../../adapters');
+    vi.mocked(planningService.spawnSession).mockRejectedValueOnce('string error');
     renderView();
 
-    // Spawn session
     await user.type(screen.getByLabelText(/specification/i), 'Build auth');
     await user.type(screen.getByLabelText(/repository/i), 'niuu/volundr');
     await user.click(screen.getByRole('button', { name: /start planning session/i }));
 
     await waitFor(() => {
-      expect(screen.getByText('ACTIVE')).toBeInTheDocument();
+      expect(screen.getByText(/failed to spawn planning session/i)).toBeInTheDocument();
     });
+  });
 
-    // Propose structure — use fireEvent to avoid userEvent parsing curly braces
+  it('sends a message in the chat panel', async () => {
+    const user = userEvent.setup();
+    const { planningService } = await import('../../adapters');
+    renderView();
+
+    await spawnSession(user);
+
+    const chatInput = screen.getByPlaceholderText(/discuss/i);
+    await user.type(chatInput, 'Should we add caching?');
+    await user.click(screen.getByRole('button', { name: /send/i }));
+
+    await waitFor(() => {
+      expect(planningService.sendMessage).toHaveBeenCalledWith(
+        'plan-001',
+        'Should we add caching?'
+      );
+    });
+  });
+
+  it('shows error on send message failure', async () => {
+    const user = userEvent.setup();
+    const { planningService } = await import('../../adapters');
+    vi.mocked(planningService.sendMessage).mockRejectedValueOnce(new Error('Send failed'));
+    renderView();
+
+    await spawnSession(user);
+
+    const chatInput = screen.getByPlaceholderText(/discuss/i);
+    await user.type(chatInput, 'Test msg');
+    await user.click(screen.getByRole('button', { name: /send/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/send failed/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows fallback error on send message non-Error throw', async () => {
+    const user = userEvent.setup();
+    const { planningService } = await import('../../adapters');
+    vi.mocked(planningService.sendMessage).mockRejectedValueOnce(42);
+    renderView();
+
+    await spawnSession(user);
+
+    const chatInput = screen.getByPlaceholderText(/discuss/i);
+    await user.type(chatInput, 'Test msg');
+    await user.click(screen.getByRole('button', { name: /send/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/failed to send message/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows structure preview after proposing', async () => {
+    const user = userEvent.setup();
+    renderView();
+
+    await spawnSession(user);
+
     const jsonInput = screen.getByPlaceholderText(/name.*phases/i);
     fireEvent.change(jsonInput, { target: { value: '{"name":"test"}' } });
     await user.click(screen.getByRole('button', { name: /propose structure/i }));
@@ -167,5 +227,179 @@ describe('PlanSagaView', () => {
       expect(screen.getByText('Phase 1')).toBeInTheDocument();
       expect(screen.getByText('Setup middleware')).toBeInTheDocument();
     });
+  });
+
+  it('shows error on propose structure failure', async () => {
+    const user = userEvent.setup();
+    const { planningService } = await import('../../adapters');
+    vi.mocked(planningService.proposeStructure).mockRejectedValueOnce(
+      new Error('Invalid JSON schema')
+    );
+    renderView();
+
+    await spawnSession(user);
+
+    const jsonInput = screen.getByPlaceholderText(/name.*phases/i);
+    fireEvent.change(jsonInput, { target: { value: '{"bad": true}' } });
+    await user.click(screen.getByRole('button', { name: /propose structure/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/invalid json schema/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows fallback error on propose structure non-Error throw', async () => {
+    const user = userEvent.setup();
+    const { planningService } = await import('../../adapters');
+    vi.mocked(planningService.proposeStructure).mockRejectedValueOnce(null);
+    renderView();
+
+    await spawnSession(user);
+
+    const jsonInput = screen.getByPlaceholderText(/name.*phases/i);
+    fireEvent.change(jsonInput, { target: { value: '{"x":1}' } });
+    await user.click(screen.getByRole('button', { name: /propose structure/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/invalid saga structure/i)).toBeInTheDocument();
+    });
+  });
+
+  it('commits saga and navigates on success', async () => {
+    const user = userEvent.setup();
+    const { planningService } = await import('../../adapters');
+    vi.mocked(planningService.spawnSession).mockResolvedValueOnce({
+      ...mockSessionWithStructure,
+    });
+    renderView();
+
+    await user.type(screen.getByLabelText(/specification/i), 'Build auth');
+    await user.type(screen.getByLabelText(/repository/i), 'niuu/volundr');
+    await user.click(screen.getByRole('button', { name: /start planning session/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('STRUCTURE_PROPOSED')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /commit saga/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Saga Detail')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error on commit failure', async () => {
+    const user = userEvent.setup();
+    const { planningService } = await import('../../adapters');
+    vi.mocked(planningService.spawnSession).mockResolvedValueOnce({
+      ...mockSessionWithStructure,
+    });
+    vi.mocked(planningService.completeSession).mockRejectedValueOnce(new Error('Commit failed'));
+    renderView();
+
+    await user.type(screen.getByLabelText(/specification/i), 'Build auth');
+    await user.type(screen.getByLabelText(/repository/i), 'niuu/volundr');
+    await user.click(screen.getByRole('button', { name: /start planning session/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('STRUCTURE_PROPOSED')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /commit saga/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/commit failed/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows fallback error on commit non-Error throw', async () => {
+    const user = userEvent.setup();
+    const { planningService } = await import('../../adapters');
+    vi.mocked(planningService.spawnSession).mockResolvedValueOnce({
+      ...mockSessionWithStructure,
+    });
+    vi.mocked(planningService.completeSession).mockRejectedValueOnce(undefined);
+    renderView();
+
+    await user.type(screen.getByLabelText(/specification/i), 'Build auth');
+    await user.type(screen.getByLabelText(/repository/i), 'niuu/volundr');
+    await user.click(screen.getByRole('button', { name: /start planning session/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('STRUCTURE_PROPOSED')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /commit saga/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/failed to commit saga/i)).toBeInTheDocument();
+    });
+  });
+
+  it('runs fallback decompose and navigates on success', async () => {
+    const user = userEvent.setup();
+    const { tyrService } = await import('../../adapters');
+    vi.mocked(tyrService.decompose).mockResolvedValueOnce([{ name: 'Phase 1', raids: [] }]);
+    renderView();
+
+    await user.type(screen.getByLabelText(/specification/i), 'Build auth');
+    await user.type(screen.getByLabelText(/repository/i), 'niuu/volundr');
+    await user.click(screen.getByRole('button', { name: /one-shot decompose/i }));
+
+    await waitFor(() => {
+      expect(tyrService.decompose).toHaveBeenCalledWith('Build auth', 'niuu/volundr');
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('New Saga')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error on fallback decompose failure', async () => {
+    const user = userEvent.setup();
+    const { tyrService } = await import('../../adapters');
+    vi.mocked(tyrService.decompose).mockRejectedValueOnce(new Error('LLM unavailable'));
+    renderView();
+
+    await user.type(screen.getByLabelText(/specification/i), 'Build auth');
+    await user.type(screen.getByLabelText(/repository/i), 'niuu/volundr');
+    await user.click(screen.getByRole('button', { name: /one-shot decompose/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/llm unavailable/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows fallback error on decompose non-Error throw', async () => {
+    const user = userEvent.setup();
+    const { tyrService } = await import('../../adapters');
+    vi.mocked(tyrService.decompose).mockRejectedValueOnce('oops');
+    renderView();
+
+    await user.type(screen.getByLabelText(/specification/i), 'Build auth');
+    await user.type(screen.getByLabelText(/repository/i), 'niuu/volundr');
+    await user.click(screen.getByRole('button', { name: /one-shot decompose/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/fallback decomposition failed/i)).toBeInTheDocument();
+    });
+  });
+
+  it('does not navigate when decompose returns empty phases', async () => {
+    const user = userEvent.setup();
+    const { tyrService } = await import('../../adapters');
+    vi.mocked(tyrService.decompose).mockResolvedValueOnce([]);
+    renderView();
+
+    await user.type(screen.getByLabelText(/specification/i), 'Build auth');
+    await user.type(screen.getByLabelText(/repository/i), 'niuu/volundr');
+    await user.click(screen.getByRole('button', { name: /one-shot decompose/i }));
+
+    await waitFor(() => {
+      expect(tyrService.decompose).toHaveBeenCalled();
+    });
+
+    // Should still be on the plan page
+    expect(screen.getByText('Plan Saga')).toBeInTheDocument();
   });
 });

--- a/web/src/modules/tyr/pages/PlanSagaView/PlanSagaView.test.tsx
+++ b/web/src/modules/tyr/pages/PlanSagaView/PlanSagaView.test.tsx
@@ -376,4 +376,216 @@ describe('PlanSagaView', () => {
       expect(screen.getByText('4h')).toBeInTheDocument();
     });
   });
+
+  it('auto-detects structure from assistant messages and shows use-structure banner', async () => {
+    const user = userEvent.setup();
+    const structureObj = {
+      name: 'Detected Plan',
+      phases: [
+        {
+          name: 'P1',
+          raids: [
+            {
+              name: 'R1',
+              description: 'd',
+              acceptance_criteria: [],
+              declared_files: [],
+              estimate_hours: 2,
+            },
+          ],
+        },
+      ],
+    };
+    const structureJson = JSON.stringify(structureObj);
+    // Push an assistant message with JSON before render so useEffect fires on mount
+    mockSkuldMessages.push({
+      id: 'msg-1',
+      role: 'assistant',
+      content: `Here is the plan:\n\`\`\`json\n${structureJson}\n\`\`\``,
+      createdAt: new Date(),
+      status: 'complete',
+    });
+
+    const { planningService } = await import('../../adapters');
+    // Spawn session immediately so the detected structure banner shows (session must be ACTIVE)
+    vi.mocked(planningService.spawnSession).mockResolvedValueOnce({ ...mockSession });
+    renderView();
+
+    await user.type(screen.getByLabelText(/specification/i), 'Build auth');
+    await user.type(screen.getByLabelText(/repository/i), 'niuu/volundr');
+    await user.click(screen.getByRole('button', { name: /start planning session/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('ACTIVE')).toBeInTheDocument();
+    });
+
+    // The structure detection effect should have fired — wait for banner
+    await waitFor(() => {
+      expect(screen.getByText(/structure detected/i)).toBeInTheDocument();
+    });
+
+    // Click "Use this structure?" to propose it
+    await user.click(screen.getByRole('button', { name: /use this structure/i }));
+
+    await waitFor(() => {
+      expect(planningService.proposeStructure).toHaveBeenCalledWith(
+        'plan-001',
+        JSON.stringify(structureObj)
+      );
+    });
+  });
+
+  it('does not auto-detect structure from incomplete assistant messages', async () => {
+    const user = userEvent.setup();
+    mockSkuldMessages.push({
+      id: 'msg-2',
+      role: 'assistant',
+      content: 'Still thinking...',
+      createdAt: new Date(),
+      status: 'streaming',
+    });
+    renderView();
+    await spawnSession(user);
+
+    expect(screen.queryByText(/structure detected/i)).not.toBeInTheDocument();
+  });
+
+  it('does not auto-detect structure from user messages', async () => {
+    const user = userEvent.setup();
+    const structureJson = JSON.stringify({ name: 'Plan', phases: [{ name: 'P1', raids: [] }] });
+    mockSkuldMessages.push({
+      id: 'msg-3',
+      role: 'user',
+      content: `\`\`\`json\n${structureJson}\n\`\`\``,
+      createdAt: new Date(),
+      status: 'complete',
+    });
+    renderView();
+    await spawnSession(user);
+
+    expect(screen.queryByText(/structure detected/i)).not.toBeInTheDocument();
+  });
+
+  it('shows error on propose structure failure', async () => {
+    const user = userEvent.setup();
+    const structureJson = JSON.stringify({
+      name: 'Detected Plan',
+      phases: [{ name: 'P1', raids: [] }],
+    });
+    mockSkuldMessages.push({
+      id: 'msg-4',
+      role: 'assistant',
+      content: `\`\`\`json\n${structureJson}\n\`\`\``,
+      createdAt: new Date(),
+      status: 'complete',
+    });
+
+    const { planningService } = await import('../../adapters');
+    vi.mocked(planningService.proposeStructure).mockRejectedValueOnce(new Error('Bad structure'));
+    renderView();
+    await spawnSession(user);
+
+    await waitFor(() => {
+      expect(screen.getByText(/use this structure/i)).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /use this structure/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/bad structure/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows fallback error on propose structure non-Error throw', async () => {
+    const user = userEvent.setup();
+    const structureJson = JSON.stringify({
+      name: 'Detected Plan',
+      phases: [{ name: 'P1', raids: [] }],
+    });
+    mockSkuldMessages.push({
+      id: 'msg-5',
+      role: 'assistant',
+      content: `\`\`\`json\n${structureJson}\n\`\`\``,
+      createdAt: new Date(),
+      status: 'complete',
+    });
+
+    const { planningService } = await import('../../adapters');
+    vi.mocked(planningService.proposeStructure).mockRejectedValueOnce(42);
+    renderView();
+    await spawnSession(user);
+
+    await waitFor(() => {
+      expect(screen.getByText(/use this structure/i)).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /use this structure/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/invalid saga structure/i)).toBeInTheDocument();
+    });
+  });
+
+  it('spawns session without chat_endpoint gracefully', async () => {
+    const user = userEvent.setup();
+    const { planningService } = await import('../../adapters');
+    vi.mocked(planningService.spawnSession).mockResolvedValueOnce({
+      ...mockSession,
+      chat_endpoint: null,
+    });
+    renderView();
+
+    await user.type(screen.getByLabelText(/specification/i), 'Build auth');
+    await user.type(screen.getByLabelText(/repository/i), 'niuu/volundr');
+    await user.click(screen.getByRole('button', { name: /start planning session/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('ACTIVE')).toBeInTheDocument();
+    });
+  });
+
+  it('does not detect structure from non-JSON assistant messages', async () => {
+    const user = userEvent.setup();
+    mockSkuldMessages.push({
+      id: 'msg-6',
+      role: 'assistant',
+      content: 'Here is some plain text with no JSON blocks.',
+      createdAt: new Date(),
+      status: 'complete',
+    });
+    renderView();
+    await spawnSession(user);
+
+    expect(screen.queryByText(/structure detected/i)).not.toBeInTheDocument();
+  });
+
+  it('does not detect structure from invalid JSON in code blocks', async () => {
+    const user = userEvent.setup();
+    mockSkuldMessages.push({
+      id: 'msg-7',
+      role: 'assistant',
+      content: '```json\n{not valid json}\n```',
+      createdAt: new Date(),
+      status: 'complete',
+    });
+    renderView();
+    await spawnSession(user);
+
+    expect(screen.queryByText(/structure detected/i)).not.toBeInTheDocument();
+  });
+
+  it('does not detect structure from JSON missing name or phases', async () => {
+    const user = userEvent.setup();
+    mockSkuldMessages.push({
+      id: 'msg-8',
+      role: 'assistant',
+      content: '```json\n{"key": "value"}\n```',
+      createdAt: new Date(),
+      status: 'complete',
+    });
+    renderView();
+    await spawnSession(user);
+
+    expect(screen.queryByText(/structure detected/i)).not.toBeInTheDocument();
+  });
 });

--- a/web/src/modules/tyr/pages/PlanSagaView/PlanSagaView.test.tsx
+++ b/web/src/modules/tyr/pages/PlanSagaView/PlanSagaView.test.tsx
@@ -1,9 +1,36 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { PlanSagaView } from './PlanSagaView';
-import type { PlanningSession, PlanningMessage } from '../../models/planning';
+import type { PlanningSession } from '../../models/planning';
+
+const mockSendMessage = vi.fn();
+const mockSkuldMessages: Array<{
+  id: string;
+  role: string;
+  content: string;
+  createdAt: Date;
+  status: string;
+}> = [];
+
+vi.mock('@/modules/volundr/hooks/useSkuldChat', () => ({
+  useSkuldChat: () => ({
+    messages: mockSkuldMessages,
+    connected: true,
+    isRunning: false,
+    historyLoaded: true,
+    pendingPermissions: [],
+    availableCommands: [],
+    sendMessage: mockSendMessage,
+    respondToPermission: vi.fn(),
+    sendInterrupt: vi.fn(),
+    sendSetModel: vi.fn(),
+    sendSetMaxThinkingTokens: vi.fn(),
+    sendRewindFiles: vi.fn(),
+    clearMessages: vi.fn(),
+  }),
+}));
 
 const mockSession: PlanningSession = {
   id: 'plan-001',
@@ -12,15 +39,9 @@ const mockSession: PlanningSession = {
   repo: 'niuu/volundr',
   status: 'ACTIVE',
   structure: null,
+  chat_endpoint: 'wss://sessions.test/s/volundr-sess-001/session',
   created_at: '2026-03-25T10:00:00Z',
   updated_at: '2026-03-25T10:00:00Z',
-};
-
-const mockMessage: PlanningMessage = {
-  id: 'msg-001',
-  content: 'Split the auth phase',
-  sender: 'user',
-  created_at: '2026-03-25T10:00:00Z',
 };
 
 const mockSessionWithStructure: PlanningSession = {
@@ -49,7 +70,7 @@ const mockSessionWithStructure: PlanningSession = {
 vi.mock('../../adapters', () => ({
   planningService: {
     spawnSession: vi.fn(() => Promise.resolve({ ...mockSession })),
-    sendMessage: vi.fn(() => Promise.resolve({ ...mockMessage })),
+    sendMessage: vi.fn(),
     proposeStructure: vi.fn(() => Promise.resolve({ ...mockSessionWithStructure })),
     completeSession: vi.fn(() =>
       Promise.resolve({ ...mockSessionWithStructure, status: 'COMPLETED' })
@@ -59,6 +80,7 @@ vi.mock('../../adapters', () => ({
   tyrService: {
     decompose: vi.fn(() => Promise.resolve([])),
     createSaga: vi.fn(() => Promise.resolve({ id: 'saga-001' })),
+    commitSaga: vi.fn(() => Promise.resolve({ id: 'saga-001' })),
   },
 }));
 
@@ -86,6 +108,7 @@ async function spawnSession(user: ReturnType<typeof userEvent.setup>) {
 describe('PlanSagaView', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSkuldMessages.length = 0;
   });
 
   it('renders the initial form', () => {
@@ -159,9 +182,8 @@ describe('PlanSagaView', () => {
     });
   });
 
-  it('sends a message in the chat panel', async () => {
+  it('sends a message via skuld WebSocket', async () => {
     const user = userEvent.setup();
-    const { planningService } = await import('../../adapters');
     renderView();
 
     await spawnSession(user);
@@ -170,104 +192,12 @@ describe('PlanSagaView', () => {
     await user.type(chatInput, 'Should we add caching?');
     await user.click(screen.getByRole('button', { name: /send/i }));
 
-    await waitFor(() => {
-      expect(planningService.sendMessage).toHaveBeenCalledWith(
-        'plan-001',
-        'Should we add caching?'
-      );
-    });
+    expect(mockSendMessage).toHaveBeenCalledWith('Should we add caching?');
   });
 
-  it('shows error on send message failure', async () => {
+  it('commits saga with structure and navigates', async () => {
     const user = userEvent.setup();
-    const { planningService } = await import('../../adapters');
-    vi.mocked(planningService.sendMessage).mockRejectedValueOnce(new Error('Send failed'));
-    renderView();
-
-    await spawnSession(user);
-
-    const chatInput = screen.getByPlaceholderText(/discuss/i);
-    await user.type(chatInput, 'Test msg');
-    await user.click(screen.getByRole('button', { name: /send/i }));
-
-    await waitFor(() => {
-      expect(screen.getByText(/send failed/i)).toBeInTheDocument();
-    });
-  });
-
-  it('shows fallback error on send message non-Error throw', async () => {
-    const user = userEvent.setup();
-    const { planningService } = await import('../../adapters');
-    vi.mocked(planningService.sendMessage).mockRejectedValueOnce(42);
-    renderView();
-
-    await spawnSession(user);
-
-    const chatInput = screen.getByPlaceholderText(/discuss/i);
-    await user.type(chatInput, 'Test msg');
-    await user.click(screen.getByRole('button', { name: /send/i }));
-
-    await waitFor(() => {
-      expect(screen.getByText(/failed to send message/i)).toBeInTheDocument();
-    });
-  });
-
-  it('shows structure preview after proposing', async () => {
-    const user = userEvent.setup();
-    renderView();
-
-    await spawnSession(user);
-
-    const jsonInput = screen.getByPlaceholderText(/name.*phases/i);
-    fireEvent.change(jsonInput, { target: { value: '{"name":"test"}' } });
-    await user.click(screen.getByRole('button', { name: /propose structure/i }));
-
-    await waitFor(() => {
-      expect(screen.getByText('Auth Refactor')).toBeInTheDocument();
-      expect(screen.getByText('Phase 1')).toBeInTheDocument();
-      expect(screen.getByText('Setup middleware')).toBeInTheDocument();
-    });
-  });
-
-  it('shows error on propose structure failure', async () => {
-    const user = userEvent.setup();
-    const { planningService } = await import('../../adapters');
-    vi.mocked(planningService.proposeStructure).mockRejectedValueOnce(
-      new Error('Invalid JSON schema')
-    );
-    renderView();
-
-    await spawnSession(user);
-
-    const jsonInput = screen.getByPlaceholderText(/name.*phases/i);
-    fireEvent.change(jsonInput, { target: { value: '{"bad": true}' } });
-    await user.click(screen.getByRole('button', { name: /propose structure/i }));
-
-    await waitFor(() => {
-      expect(screen.getByText(/invalid json schema/i)).toBeInTheDocument();
-    });
-  });
-
-  it('shows fallback error on propose structure non-Error throw', async () => {
-    const user = userEvent.setup();
-    const { planningService } = await import('../../adapters');
-    vi.mocked(planningService.proposeStructure).mockRejectedValueOnce(null);
-    renderView();
-
-    await spawnSession(user);
-
-    const jsonInput = screen.getByPlaceholderText(/name.*phases/i);
-    fireEvent.change(jsonInput, { target: { value: '{"x":1}' } });
-    await user.click(screen.getByRole('button', { name: /propose structure/i }));
-
-    await waitFor(() => {
-      expect(screen.getByText(/invalid saga structure/i)).toBeInTheDocument();
-    });
-  });
-
-  it('commits saga and navigates on success', async () => {
-    const user = userEvent.setup();
-    const { planningService } = await import('../../adapters');
+    const { planningService, tyrService } = await import('../../adapters');
     vi.mocked(planningService.spawnSession).mockResolvedValueOnce({
       ...mockSessionWithStructure,
     });
@@ -282,6 +212,21 @@ describe('PlanSagaView', () => {
     });
 
     await user.click(screen.getByRole('button', { name: /commit saga/i }));
+
+    await waitFor(() => {
+      expect(planningService.completeSession).toHaveBeenCalledWith('plan-001');
+      expect(tyrService.commitSaga).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Auth Refactor',
+          repos: ['niuu/volundr'],
+          phases: expect.arrayContaining([
+            expect.objectContaining({
+              name: 'Phase 1',
+            }),
+          ]),
+        })
+      );
+    });
 
     await waitFor(() => {
       expect(screen.getByText('Saga Detail')).toBeInTheDocument();
@@ -401,5 +346,34 @@ describe('PlanSagaView', () => {
 
     // Should still be on the plan page
     expect(screen.getByText('Plan Saga')).toBeInTheDocument();
+  });
+
+  it('shows session status and repo after spawn', async () => {
+    const user = userEvent.setup();
+    renderView();
+
+    await spawnSession(user);
+
+    expect(screen.getByText('niuu/volundr')).toBeInTheDocument();
+  });
+
+  it('shows structure preview with phase and raid details', async () => {
+    const user = userEvent.setup();
+    const { planningService } = await import('../../adapters');
+    vi.mocked(planningService.spawnSession).mockResolvedValueOnce({
+      ...mockSessionWithStructure,
+    });
+    renderView();
+
+    await user.type(screen.getByLabelText(/specification/i), 'Build auth');
+    await user.type(screen.getByLabelText(/repository/i), 'niuu/volundr');
+    await user.click(screen.getByRole('button', { name: /start planning session/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Auth Refactor')).toBeInTheDocument();
+      expect(screen.getByText('Phase 1')).toBeInTheDocument();
+      expect(screen.getByText('Setup middleware')).toBeInTheDocument();
+      expect(screen.getByText('4h')).toBeInTheDocument();
+    });
   });
 });

--- a/web/src/modules/tyr/pages/PlanSagaView/PlanSagaView.tsx
+++ b/web/src/modules/tyr/pages/PlanSagaView/PlanSagaView.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { planningService, tyrService } from '../../adapters';
 import { ChatPanel } from '../../components/ChatPanel';
-import type { PlanningSession, PlanningMessage, PlanningStructure } from '../../models/planning';
+import type { PlanningSession, PlanningMessage } from '../../models/planning';
 import styles from './PlanSagaView.module.css';
 
 export function PlanSagaView() {

--- a/web/src/modules/tyr/pages/PlanSagaView/PlanSagaView.tsx
+++ b/web/src/modules/tyr/pages/PlanSagaView/PlanSagaView.tsx
@@ -1,0 +1,219 @@
+import { useState, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { planningService, tyrService } from '../../adapters';
+import { ChatPanel } from '../../components/ChatPanel';
+import type { PlanningSession, PlanningMessage, PlanningStructure } from '../../models/planning';
+import styles from './PlanSagaView.module.css';
+
+export function PlanSagaView() {
+  const [spec, setSpec] = useState('');
+  const [repo, setRepo] = useState('');
+  const [session, setSession] = useState<PlanningSession | null>(null);
+  const [messages, setMessages] = useState<PlanningMessage[]>([]);
+  const [spawning, setSpawning] = useState(false);
+  const [structureJson, setStructureJson] = useState('');
+  const [proposing, setProposing] = useState(false);
+  const [committing, setCommitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
+
+  const handleSpawn = async () => {
+    setSpawning(true);
+    setError(null);
+    try {
+      const s = await planningService.spawnSession(spec, repo);
+      setSession(s);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to spawn planning session');
+    } finally {
+      setSpawning(false);
+    }
+  };
+
+  const handleSendMessage = useCallback(
+    async (content: string) => {
+      if (!session) return;
+      try {
+        const msg = await planningService.sendMessage(session.id, content);
+        setMessages(prev => [...prev, msg]);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to send message');
+      }
+    },
+    [session],
+  );
+
+  const handleProposeStructure = async () => {
+    if (!session) return;
+    setProposing(true);
+    setError(null);
+    try {
+      const updated = await planningService.proposeStructure(session.id, structureJson);
+      setSession(updated);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Invalid saga structure');
+    } finally {
+      setProposing(false);
+    }
+  };
+
+  const handleCommit = async () => {
+    if (!session?.structure) return;
+    setCommitting(true);
+    setError(null);
+    try {
+      await planningService.completeSession(session.id);
+      const saga = await tyrService.createSaga(spec, repo);
+      navigate(`/tyr/sagas/${saga.id}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to commit saga');
+    } finally {
+      setCommitting(false);
+    }
+  };
+
+  const handleFallbackDecompose = async () => {
+    setSpawning(true);
+    setError(null);
+    try {
+      const phases = await tyrService.decompose(spec, repo);
+      if (phases.length > 0) {
+        navigate('/tyr/new');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Fallback decomposition failed');
+    } finally {
+      setSpawning(false);
+    }
+  };
+
+  const isActive = session?.status === 'ACTIVE' || session?.status === 'STRUCTURE_PROPOSED';
+
+  return (
+    <div className={styles.container}>
+      <h2 className={styles.heading}>Plan Saga</h2>
+
+      {error && <div className={styles.error}>{error}</div>}
+
+      {!session && (
+        <div className={styles.form}>
+          <label className={styles.label} htmlFor="plan-spec">
+            Specification
+          </label>
+          <textarea
+            id="plan-spec"
+            className={styles.textarea}
+            value={spec}
+            onChange={e => setSpec(e.target.value)}
+            placeholder="Describe the feature to decompose..."
+            rows={8}
+          />
+
+          <label className={styles.label} htmlFor="plan-repo">
+            Repository
+          </label>
+          <input
+            id="plan-repo"
+            type="text"
+            className={styles.input}
+            value={repo}
+            onChange={e => setRepo(e.target.value)}
+            placeholder="org/repo"
+          />
+
+          <div className={styles.actions}>
+            <button
+              type="button"
+              className={styles.secondaryButton}
+              onClick={handleFallbackDecompose}
+              disabled={!spec.trim() || !repo.trim() || spawning}
+            >
+              One-shot Decompose
+            </button>
+            <button
+              type="button"
+              className={styles.primaryButton}
+              onClick={handleSpawn}
+              disabled={!spec.trim() || !repo.trim() || spawning}
+            >
+              {spawning ? 'Starting...' : 'Start Planning Session'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {session && (
+        <div className={styles.sessionArea}>
+          <div className={styles.sessionHeader}>
+            <span className={styles.sessionStatus} data-status={session.status}>
+              {session.status}
+            </span>
+            <span className={styles.sessionRepo}>{session.repo}</span>
+          </div>
+
+          <ChatPanel
+            messages={messages}
+            onSend={handleSendMessage}
+            disabled={!isActive}
+          />
+
+          {isActive && (
+            <div className={styles.structureArea}>
+              <label className={styles.label} htmlFor="structure-json">
+                Paste saga structure JSON
+              </label>
+              <textarea
+                id="structure-json"
+                className={styles.textarea}
+                value={structureJson}
+                onChange={e => setStructureJson(e.target.value)}
+                placeholder='{"name": "...", "phases": [...]}'
+                rows={6}
+              />
+              <div className={styles.actions}>
+                <button
+                  type="button"
+                  className={styles.primaryButton}
+                  onClick={handleProposeStructure}
+                  disabled={!structureJson.trim() || proposing}
+                >
+                  {proposing ? 'Validating...' : 'Propose Structure'}
+                </button>
+              </div>
+            </div>
+          )}
+
+          {session.structure && (
+            <div className={styles.structurePreview}>
+              <h3 className={styles.previewHeading}>Proposed Structure</h3>
+              <div className={styles.structureName}>{session.structure.name}</div>
+              {session.structure.phases.map((phase, pi) => (
+                <div key={pi} className={styles.phase}>
+                  <div className={styles.phaseName}>{phase.name}</div>
+                  {phase.raids.map((raid, ri) => (
+                    <div key={ri} className={styles.raid}>
+                      <span className={styles.raidName}>{raid.name}</span>
+                      <span className={styles.raidEstimate}>
+                        {raid.estimate_hours}h
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              ))}
+              <div className={styles.actions}>
+                <button
+                  type="button"
+                  className={styles.commitButton}
+                  onClick={handleCommit}
+                  disabled={committing}
+                >
+                  {committing ? 'Committing...' : 'Commit Saga'}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/modules/tyr/pages/PlanSagaView/PlanSagaView.tsx
+++ b/web/src/modules/tyr/pages/PlanSagaView/PlanSagaView.tsx
@@ -40,7 +40,7 @@ export function PlanSagaView() {
         setError(err instanceof Error ? err.message : 'Failed to send message');
       }
     },
-    [session],
+    [session]
   );
 
   const handleProposeStructure = async () => {
@@ -151,11 +151,7 @@ export function PlanSagaView() {
             <span className={styles.sessionRepo}>{session.repo}</span>
           </div>
 
-          <ChatPanel
-            messages={messages}
-            onSend={handleSendMessage}
-            disabled={!isActive}
-          />
+          <ChatPanel messages={messages} onSend={handleSendMessage} disabled={!isActive} />
 
           {isActive && (
             <div className={styles.structureArea}>
@@ -193,9 +189,7 @@ export function PlanSagaView() {
                   {phase.raids.map((raid, ri) => (
                     <div key={ri} className={styles.raid}>
                       <span className={styles.raidName}>{raid.name}</span>
-                      <span className={styles.raidEstimate}>
-                        {raid.estimate_hours}h
-                      </span>
+                      <span className={styles.raidEstimate}>{raid.estimate_hours}h</span>
                     </div>
                   ))}
                 </div>

--- a/web/src/modules/tyr/pages/PlanSagaView/PlanSagaView.tsx
+++ b/web/src/modules/tyr/pages/PlanSagaView/PlanSagaView.tsx
@@ -1,21 +1,80 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { planningService, tyrService } from '../../adapters';
 import { ChatPanel } from '../../components/ChatPanel';
-import type { PlanningSession, PlanningMessage } from '../../models/planning';
+import { useSkuldChat } from '@/modules/volundr/hooks/useSkuldChat';
+import type { PlanningSession, PlanningStructure } from '../../models/planning';
+import type { CommitSagaRequest } from '../../ports/tyr.port';
 import styles from './PlanSagaView.module.css';
+
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 40);
+}
+
+/** Try to extract a SagaStructure JSON from assistant message text. */
+function tryDetectStructure(text: string): PlanningStructure | null {
+  const fenceRe = /```(?:json)?\s*\n([\s\S]*?)```/g;
+  let match: RegExpExecArray | null;
+  while ((match = fenceRe.exec(text)) !== null) {
+    try {
+      const data = JSON.parse(match[1].trim());
+      if (data && typeof data === 'object' && Array.isArray(data.phases) && data.name) {
+        return data as PlanningStructure;
+      }
+    } catch {
+      // not valid JSON
+    }
+  }
+  return null;
+}
 
 export function PlanSagaView() {
   const [spec, setSpec] = useState('');
   const [repo, setRepo] = useState('');
   const [session, setSession] = useState<PlanningSession | null>(null);
-  const [messages, setMessages] = useState<PlanningMessage[]>([]);
   const [spawning, setSpawning] = useState(false);
-  const [structureJson, setStructureJson] = useState('');
   const [proposing, setProposing] = useState(false);
   const [committing, setCommitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [detectedStructure, setDetectedStructure] = useState<PlanningStructure | null>(null);
   const navigate = useNavigate();
+
+  // Derive the skuld WebSocket URL from the planning session's chat_endpoint
+  const chatWsUrl = useMemo(() => {
+    if (!session?.chat_endpoint) return null;
+    if (session.status !== 'ACTIVE' && session.status !== 'STRUCTURE_PROPOSED') return null;
+    return session.chat_endpoint;
+  }, [session?.chat_endpoint, session?.status]);
+
+  const skuld = useSkuldChat(chatWsUrl);
+
+  // Convert skuld messages into PlanningMessage format for display
+  const displayMessages = useMemo(
+    () =>
+      skuld.messages.map(m => ({
+        id: m.id,
+        content: m.content,
+        sender: m.role === 'user' ? 'user' : 'assistant',
+        created_at: m.createdAt.toISOString(),
+      })),
+    [skuld.messages]
+  );
+
+  // Auto-detect structure in new assistant messages
+  useEffect(() => {
+    if (skuld.messages.length === 0) return;
+    const lastMsg = skuld.messages[skuld.messages.length - 1];
+    if (lastMsg.role !== 'assistant' || lastMsg.status !== 'complete') return;
+
+    const found = tryDetectStructure(lastMsg.content);
+    if (found) {
+      setDetectedStructure(found);
+    }
+  }, [skuld.messages]);
 
   const handleSpawn = async () => {
     setSpawning(true);
@@ -31,25 +90,24 @@ export function PlanSagaView() {
   };
 
   const handleSendMessage = useCallback(
-    async (content: string) => {
-      if (!session) return;
-      try {
-        const msg = await planningService.sendMessage(session.id, content);
-        setMessages(prev => [...prev, msg]);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to send message');
-      }
+    (content: string) => {
+      if (!session || !skuld.connected) return;
+      skuld.sendMessage(content);
     },
-    [session]
+    [session, skuld]
   );
 
-  const handleProposeStructure = async () => {
-    if (!session) return;
+  const handleUseDetectedStructure = async () => {
+    if (!session || !detectedStructure) return;
     setProposing(true);
     setError(null);
     try {
-      const updated = await planningService.proposeStructure(session.id, structureJson);
+      const updated = await planningService.proposeStructure(
+        session.id,
+        JSON.stringify(detectedStructure)
+      );
       setSession(updated);
+      setDetectedStructure(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Invalid saga structure');
     } finally {
@@ -63,7 +121,23 @@ export function PlanSagaView() {
     setError(null);
     try {
       await planningService.completeSession(session.id);
-      const saga = await tyrService.createSaga(spec, repo);
+      const commitRequest: CommitSagaRequest = {
+        name: session.structure.name,
+        slug: slugify(session.structure.name),
+        repos: [session.repo],
+        base_branch: 'main',
+        phases: session.structure.phases.map(phase => ({
+          name: phase.name,
+          raids: phase.raids.map(raid => ({
+            name: raid.name,
+            description: raid.description,
+            acceptance_criteria: raid.acceptance_criteria,
+            declared_files: raid.declared_files,
+            estimate_hours: raid.estimate_hours,
+          })),
+        })),
+      };
+      const saga = await tyrService.commitSaga(commitRequest);
       navigate(`/tyr/sagas/${saga.id}`);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to commit saga');
@@ -78,7 +152,7 @@ export function PlanSagaView() {
     try {
       const phases = await tyrService.decompose(spec, repo);
       if (phases.length > 0) {
-        navigate('/tyr/new');
+        navigate('/tyr/new', { state: { phases, spec, repo } });
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Fallback decomposition failed');
@@ -151,29 +225,22 @@ export function PlanSagaView() {
             <span className={styles.sessionRepo}>{session.repo}</span>
           </div>
 
-          <ChatPanel messages={messages} onSend={handleSendMessage} disabled={!isActive} />
+          <ChatPanel messages={displayMessages} onSend={handleSendMessage} disabled={!isActive} />
 
-          {isActive && (
-            <div className={styles.structureArea}>
-              <label className={styles.label} htmlFor="structure-json">
-                Paste saga structure JSON
-              </label>
-              <textarea
-                id="structure-json"
-                className={styles.textarea}
-                value={structureJson}
-                onChange={e => setStructureJson(e.target.value)}
-                placeholder='{"name": "...", "phases": [...]}'
-                rows={6}
-              />
+          {detectedStructure && isActive && (
+            <div className={styles.detectedStructure}>
+              <span className={styles.detectedLabel}>
+                Structure detected: {detectedStructure.name} ({detectedStructure.phases.length}{' '}
+                phases)
+              </span>
               <div className={styles.actions}>
                 <button
                   type="button"
-                  className={styles.primaryButton}
-                  onClick={handleProposeStructure}
-                  disabled={!structureJson.trim() || proposing}
+                  className={styles.useStructureButton}
+                  onClick={handleUseDetectedStructure}
+                  disabled={proposing}
                 >
-                  {proposing ? 'Validating...' : 'Propose Structure'}
+                  {proposing ? 'Validating...' : 'Use this structure?'}
                 </button>
               </div>
             </div>

--- a/web/src/modules/tyr/pages/PlanSagaView/index.ts
+++ b/web/src/modules/tyr/pages/PlanSagaView/index.ts
@@ -1,0 +1,1 @@
+export { PlanSagaView } from './PlanSagaView';

--- a/web/src/modules/tyr/ports/index.ts
+++ b/web/src/modules/tyr/ports/index.ts
@@ -1,4 +1,4 @@
-export type { ITyrService } from './tyr.port';
+export type { ITyrService, CommitSagaRequest } from './tyr.port';
 export type { IDispatcherService } from './dispatcher.port';
 export type { ITyrSessionService } from './session.port';
 export type { ITrackerBrowserService } from './tracker.port';

--- a/web/src/modules/tyr/ports/index.ts
+++ b/web/src/modules/tyr/ports/index.ts
@@ -8,3 +8,4 @@ export type {
   TelegramSetupResult,
   CreateIntegrationParams,
 } from './integrations.port';
+export type { IPlanningService } from './planning.port';

--- a/web/src/modules/tyr/ports/planning.port.ts
+++ b/web/src/modules/tyr/ports/planning.port.ts
@@ -1,4 +1,4 @@
-import type { PlanningSession, PlanningMessage, PlanningStructure } from '../models/planning';
+import type { PlanningSession, PlanningMessage } from '../models/planning';
 
 export interface IPlanningService {
   spawnSession(spec: string, repo: string): Promise<PlanningSession>;

--- a/web/src/modules/tyr/ports/planning.port.ts
+++ b/web/src/modules/tyr/ports/planning.port.ts
@@ -1,0 +1,12 @@
+import type { PlanningSession, PlanningMessage, PlanningStructure } from '../models/planning';
+
+export interface IPlanningService {
+  spawnSession(spec: string, repo: string): Promise<PlanningSession>;
+  listSessions(): Promise<PlanningSession[]>;
+  getSession(id: string): Promise<PlanningSession | null>;
+  sendMessage(sessionId: string, content: string): Promise<PlanningMessage>;
+  getMessages(sessionId: string): Promise<PlanningMessage[]>;
+  proposeStructure(sessionId: string, rawJson: string): Promise<PlanningSession>;
+  completeSession(sessionId: string): Promise<PlanningSession>;
+  deleteSession(sessionId: string): Promise<void>;
+}

--- a/web/src/modules/tyr/ports/tyr.port.ts
+++ b/web/src/modules/tyr/ports/tyr.port.ts
@@ -1,9 +1,27 @@
 import type { Saga, Phase } from '../models';
 
+export interface CommitSagaRequest {
+  name: string;
+  slug: string;
+  repos: string[];
+  base_branch: string;
+  phases: {
+    name: string;
+    raids: {
+      name: string;
+      description: string;
+      acceptance_criteria: string[];
+      declared_files: string[];
+      estimate_hours: number;
+    }[];
+  }[];
+}
+
 export interface ITyrService {
   getSagas(): Promise<Saga[]>;
   getSaga(id: string): Promise<Saga | null>;
   getPhases(sagaId: string): Promise<Phase[]>;
   createSaga(spec: string, repo: string): Promise<Saga>;
+  commitSaga(request: CommitSagaRequest): Promise<Saga>;
   decompose(spec: string, repo: string): Promise<Phase[]>;
 }


### PR DESCRIPTION
## Summary

- Add full-stack interactive planning sessions enabling users to collaboratively decompose specs into saga structures via conversational LLM interaction with human-in-the-loop refinement
- Backend: PlanningSessionRepository port, InMemoryPlanningSessionRepository adapter, PlanningSessionService (spawn/message/propose/complete lifecycle), REST API at `/api/v1/tyr/planning`, PlannerConfig, domain models
- Frontend: ChatPanel component, PlanSagaView page with session management, planning service port + API/mock adapters, route at `/tyr/plan`
- Falls back to one-shot `/decompose` when planning session is unavailable

## Test plan

- [x] 52 backend tests: service lifecycle, repository CRUD, all REST endpoints, domain models
- [x] 14 frontend tests: ChatPanel rendering/interaction, PlanSagaView form/spawn/structure
- [x] All 776 existing backend tests pass — zero regressions
- [x] Ruff check + format clean
- [ ] CI pipeline passes (tests, lint, coverage ≥ 85%)

Closes NIU-244

🤖 Generated with [Claude Code](https://claude.com/claude-code)