### PR TITLE
feat(web): SessionChat UI polish (NIU-256)

### DIFF
--- a/web/src/modules/shared/components/SessionChat/ChatInput.module.css
+++ b/web/src/modules/shared/components/SessionChat/ChatInput.module.css
@@ -24,6 +24,12 @@
   border-color: var(--color-bg-elevated);
 }
 
+.wrapper[data-drag-over='true'] {
+  border-style: dashed;
+  border-color: var(--color-brand);
+  background-color: color-mix(in srgb, var(--color-brand) 5%, var(--color-bg-secondary) 80%);
+}
+
 /* ── Attachments ─────────────────────────────────────────── */
 
 .attachments {
@@ -78,6 +84,14 @@
 .attachmentRemoveIcon {
   width: 12px;
   height: 12px;
+}
+
+.attachmentThumbnail {
+  width: 24px;
+  height: 24px;
+  object-fit: cover;
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
 }
 
 /* ── Input Area ──────────────────────────────────────────── */

--- a/web/src/modules/shared/components/SessionChat/ChatInput.test.tsx
+++ b/web/src/modules/shared/components/SessionChat/ChatInput.test.tsx
@@ -203,7 +203,7 @@ describe('ChatInput', () => {
       fireEvent.keyDown(textarea, { key: 'Enter' });
 
       expect(onSend).toHaveBeenCalledTimes(1);
-      expect(onSend).toHaveBeenCalledWith('hello world');
+      expect(onSend).toHaveBeenCalledWith('hello world', []);
     });
 
     it('does not send on Shift+Enter (allows newline)', () => {
@@ -234,7 +234,7 @@ describe('ChatInput', () => {
       fireEvent.click(screen.getByLabelText('Send message'));
 
       expect(onSend).toHaveBeenCalledTimes(1);
-      expect(onSend).toHaveBeenCalledWith('click send test');
+      expect(onSend).toHaveBeenCalledWith('click send test', []);
     });
 
     it('clears input after sending', () => {
@@ -551,11 +551,11 @@ describe('ChatInput', () => {
       const textarea = screen.getByPlaceholderText('Message...');
       fireEvent.change(textarea, { target: { value: 'first' } });
       fireEvent.keyDown(textarea, { key: 'Enter' });
-      expect(onSend).toHaveBeenCalledWith('first');
+      expect(onSend).toHaveBeenCalledWith('first', []);
 
       fireEvent.change(textarea, { target: { value: 'second' } });
       fireEvent.keyDown(textarea, { key: 'Enter' });
-      expect(onSend).toHaveBeenCalledWith('second');
+      expect(onSend).toHaveBeenCalledWith('second', []);
 
       expect(onSend).toHaveBeenCalledTimes(2);
     });
@@ -946,7 +946,7 @@ describe('ChatInput', () => {
       fireEvent.keyDown(textarea, { key: 'Enter' });
 
       // Falls through to normal Enter handling
-      expect(onSend).toHaveBeenCalledWith('hello');
+      expect(onSend).toHaveBeenCalledWith('hello', []);
     });
   });
 
@@ -1109,7 +1109,7 @@ describe('ChatInput', () => {
       fireEvent.change(textarea, { target: { value: 'hello' } });
       fireEvent.keyDown(textarea, { key: 'Enter' });
 
-      expect(onSend).toHaveBeenCalledWith('hello');
+      expect(onSend).toHaveBeenCalledWith('hello', []);
     });
   });
 
@@ -1147,7 +1147,7 @@ describe('ChatInput', () => {
       fireEvent.change(textarea, { target: { value: 'fix this' } });
       fireEvent.keyDown(textarea, { key: 'Enter' });
 
-      expect(onSend).toHaveBeenCalledWith('@src/utils.ts @src/index.ts fix this');
+      expect(onSend).toHaveBeenCalledWith('@src/utils.ts @src/index.ts fix this', []);
     });
 
     it('removes mentions after sending', () => {

--- a/web/src/modules/shared/components/SessionChat/ChatInput.tsx
+++ b/web/src/modules/shared/components/SessionChat/ChatInput.tsx
@@ -94,9 +94,19 @@ export function ChatInput({
 
   const slashMenu = useSlashMenu(availableCommands as SlashCommand[] | undefined);
   const mentionMenu = useMentionMenu(sessionId, sessionHost, chatEndpoint);
-  const fileAttachments = useFileAttachments();
+  const {
+    attachments: fileAttachmentsList,
+    isDragging,
+    addFiles,
+    removeAttachment,
+    clearAttachments: clearFileAttachments,
+    handleDragOver,
+    handleDragLeave,
+    handleDrop,
+    handlePaste,
+  } = useFileAttachments();
 
-  const hasContent = input.trim().length > 0 || fileAttachments.attachments.length > 0;
+  const hasContent = input.trim().length > 0 || fileAttachmentsList.length > 0;
 
   const resetTextareaHeight = useCallback(() => {
     const textarea = textareaRef.current;
@@ -126,14 +136,14 @@ export function ChatInput({
     // Prepend mention paths to the message so the backend knows which files are referenced
     const mentionPaths = mentionMenu.mentions.map(m => `@${m.path}`);
     const fullMessage = mentionPaths.length > 0 ? `${mentionPaths.join(' ')} ${trimmed}` : trimmed;
-    onSend(fullMessage, fileAttachments.attachments);
+    onSend(fullMessage, fileAttachmentsList);
     setInput('');
-    fileAttachments.clearAttachments();
+    clearFileAttachments();
     // Clear mentions after send
     for (const m of mentionMenu.mentions) {
       mentionMenu.removeMention(m.path);
     }
-  }, [input, disabled, onSend, mentionMenu, fileAttachments]);
+  }, [input, disabled, onSend, mentionMenu, fileAttachmentsList, clearFileAttachments]);
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -213,11 +223,11 @@ export function ChatInput({
       if (!files) {
         return;
       }
-      fileAttachments.addFiles(files);
+      addFiles(files);
       // Reset the input so the same file can be re-attached
       e.target.value = '';
     },
-    [fileAttachments]
+    [addFiles]
   );
 
   const handleMicToggle = useCallback(() => {
@@ -235,18 +245,18 @@ export function ChatInput({
     <div
       className={cn(styles.wrapper, className)}
       data-disabled={disabled}
-      data-drag-over={fileAttachments.isDragging}
-      onDragOver={fileAttachments.handleDragOver}
-      onDragLeave={fileAttachments.handleDragLeave}
-      onDrop={fileAttachments.handleDrop}
-      onPaste={fileAttachments.handlePaste}
+      data-drag-over={isDragging}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+      onPaste={handlePaste}
     >
-      {(fileAttachments.attachments.length > 0 || mentionMenu.mentions.length > 0) && (
+      {(fileAttachmentsList.length > 0 || mentionMenu.mentions.length > 0) && (
         <div className={styles.attachments}>
           {mentionMenu.mentions.map(entry => (
             <MentionPill key={entry.path} entry={entry} onRemove={mentionMenu.removeMention} />
           ))}
-          {fileAttachments.attachments.map(attachment => (
+          {fileAttachmentsList.map(attachment => (
             <span key={attachment.id} className={styles.attachmentChip}>
               {attachment.previewUrl && (
                 <img
@@ -259,7 +269,7 @@ export function ChatInput({
               <button
                 type="button"
                 className={styles.attachmentRemove}
-                onClick={() => fileAttachments.removeAttachment(attachment.id)}
+                onClick={() => removeAttachment(attachment.id)}
                 aria-label={`Remove ${attachment.name}`}
               >
                 <X className={styles.attachmentRemoveIcon} />

--- a/web/src/modules/shared/components/SessionChat/ChatInput.tsx
+++ b/web/src/modules/shared/components/SessionChat/ChatInput.tsx
@@ -215,22 +215,25 @@ export function ChatInput({
     fileInputRef.current?.click();
   }, [disabled]);
 
-  const handleFileChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
-    const files = e.target.files;
-    if (!files) {
-      return;
-    }
-    const newAttachments: Attachment[] = Array.from(files).map(file => ({
-      file,
-      name: file.name,
-      id: `${file.name}-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
-    }));
-    setAttachments(prev => [...prev, ...newAttachments]);
-    // Also process through fileAttachments hook for image compression/previews
-    fileAttachments.addFiles(files);
-    // Reset the input so the same file can be re-attached
-    e.target.value = '';
-  }, [fileAttachments]);
+  const handleFileChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const files = e.target.files;
+      if (!files) {
+        return;
+      }
+      const newAttachments: Attachment[] = Array.from(files).map(file => ({
+        file,
+        name: file.name,
+        id: `${file.name}-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+      }));
+      setAttachments(prev => [...prev, ...newAttachments]);
+      // Also process through fileAttachments hook for image compression/previews
+      fileAttachments.addFiles(files);
+      // Reset the input so the same file can be re-attached
+      e.target.value = '';
+    },
+    [fileAttachments]
+  );
 
   const handleRemoveAttachment = useCallback((id: string) => {
     setAttachments(prev => prev.filter(a => a.id !== id));
@@ -257,14 +260,16 @@ export function ChatInput({
       onDrop={fileAttachments.handleDrop}
       onPaste={fileAttachments.handlePaste}
     >
-      {(attachments.length > 0 || mentionMenu.mentions.length > 0 || fileAttachments.attachments.length > 0) && (
+      {(attachments.length > 0 ||
+        mentionMenu.mentions.length > 0 ||
+        fileAttachments.attachments.length > 0) && (
         <div className={styles.attachments}>
           {mentionMenu.mentions.map(entry => (
             <MentionPill key={entry.path} entry={entry} onRemove={mentionMenu.removeMention} />
           ))}
           {attachments.map(attachment => {
             const imagePreview = fileAttachments.attachments.find(
-              fa => fa.name === attachment.name && fa.previewUrl,
+              fa => fa.name === attachment.name && fa.previewUrl
             );
             return (
               <span key={attachment.id} className={styles.attachmentChip}>

--- a/web/src/modules/shared/components/SessionChat/ChatInput.tsx
+++ b/web/src/modules/shared/components/SessionChat/ChatInput.tsx
@@ -15,17 +15,11 @@ import { useSlashMenu } from './useSlashMenu';
 import { MentionMenu } from './MentionMenu';
 import { MentionPill } from './MentionPill';
 import { useMentionMenu } from './useMentionMenu';
-import { useFileAttachments } from './useFileAttachments';
+import { useFileAttachments, type FileAttachment } from './useFileAttachments';
 import styles from './ChatInput.module.css';
 
-interface Attachment {
-  file: File;
-  name: string;
-  id: string;
-}
-
 interface ChatInputProps {
-  onSend: (text: string) => void;
+  onSend: (text: string, attachments: FileAttachment[]) => void;
   isLoading: boolean;
   onStop: () => void;
   disabled?: boolean;
@@ -76,7 +70,6 @@ export function ChatInput({
   availableCommands,
 }: ChatInputProps) {
   const [input, setInput] = useState('');
-  const [attachments, setAttachments] = useState<Attachment[]>([]);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const inputSnapshotRef = useRef('');
@@ -103,7 +96,7 @@ export function ChatInput({
   const mentionMenu = useMentionMenu(sessionId, sessionHost, chatEndpoint);
   const fileAttachments = useFileAttachments();
 
-  const hasContent = input.trim().length > 0;
+  const hasContent = input.trim().length > 0 || fileAttachments.attachments.length > 0;
 
   const resetTextareaHeight = useCallback(() => {
     const textarea = textareaRef.current;
@@ -133,9 +126,8 @@ export function ChatInput({
     // Prepend mention paths to the message so the backend knows which files are referenced
     const mentionPaths = mentionMenu.mentions.map(m => `@${m.path}`);
     const fullMessage = mentionPaths.length > 0 ? `${mentionPaths.join(' ')} ${trimmed}` : trimmed;
-    onSend(fullMessage);
+    onSend(fullMessage, fileAttachments.attachments);
     setInput('');
-    setAttachments([]);
     fileAttachments.clearAttachments();
     // Clear mentions after send
     for (const m of mentionMenu.mentions) {
@@ -221,23 +213,12 @@ export function ChatInput({
       if (!files) {
         return;
       }
-      const newAttachments: Attachment[] = Array.from(files).map(file => ({
-        file,
-        name: file.name,
-        id: `${file.name}-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
-      }));
-      setAttachments(prev => [...prev, ...newAttachments]);
-      // Also process through fileAttachments hook for image compression/previews
       fileAttachments.addFiles(files);
       // Reset the input so the same file can be re-attached
       e.target.value = '';
     },
     [fileAttachments]
   );
-
-  const handleRemoveAttachment = useCallback((id: string) => {
-    setAttachments(prev => prev.filter(a => a.id !== id));
-  }, []);
 
   const handleMicToggle = useCallback(() => {
     if (disabled) {
@@ -260,43 +241,31 @@ export function ChatInput({
       onDrop={fileAttachments.handleDrop}
       onPaste={fileAttachments.handlePaste}
     >
-      {(attachments.length > 0 ||
-        mentionMenu.mentions.length > 0 ||
-        fileAttachments.attachments.length > 0) && (
+      {(fileAttachments.attachments.length > 0 || mentionMenu.mentions.length > 0) && (
         <div className={styles.attachments}>
           {mentionMenu.mentions.map(entry => (
             <MentionPill key={entry.path} entry={entry} onRemove={mentionMenu.removeMention} />
           ))}
-          {attachments.map(attachment => {
-            const imagePreview = fileAttachments.attachments.find(
-              fa => fa.name === attachment.name && fa.previewUrl
-            );
-            return (
-              <span key={attachment.id} className={styles.attachmentChip}>
-                {imagePreview?.previewUrl && (
-                  <img
-                    src={imagePreview.previewUrl}
-                    alt={attachment.name}
-                    className={styles.attachmentThumbnail}
-                  />
-                )}
-                <span className={styles.attachmentName}>{attachment.name}</span>
-                <button
-                  type="button"
-                  className={styles.attachmentRemove}
-                  onClick={() => {
-                    handleRemoveAttachment(attachment.id);
-                    if (imagePreview) {
-                      fileAttachments.removeAttachment(imagePreview.id);
-                    }
-                  }}
-                  aria-label={`Remove ${attachment.name}`}
-                >
-                  <X className={styles.attachmentRemoveIcon} />
-                </button>
-              </span>
-            );
-          })}
+          {fileAttachments.attachments.map(attachment => (
+            <span key={attachment.id} className={styles.attachmentChip}>
+              {attachment.previewUrl && (
+                <img
+                  src={attachment.previewUrl}
+                  alt={attachment.name}
+                  className={styles.attachmentThumbnail}
+                />
+              )}
+              <span className={styles.attachmentName}>{attachment.name}</span>
+              <button
+                type="button"
+                className={styles.attachmentRemove}
+                onClick={() => fileAttachments.removeAttachment(attachment.id)}
+                aria-label={`Remove ${attachment.name}`}
+              >
+                <X className={styles.attachmentRemoveIcon} />
+              </button>
+            </span>
+          ))}
         </div>
       )}
 

--- a/web/src/modules/shared/components/SessionChat/ChatInput.tsx
+++ b/web/src/modules/shared/components/SessionChat/ChatInput.tsx
@@ -15,6 +15,7 @@ import { useSlashMenu } from './useSlashMenu';
 import { MentionMenu } from './MentionMenu';
 import { MentionPill } from './MentionPill';
 import { useMentionMenu } from './useMentionMenu';
+import { useFileAttachments } from './useFileAttachments';
 import styles from './ChatInput.module.css';
 
 interface Attachment {
@@ -100,6 +101,7 @@ export function ChatInput({
 
   const slashMenu = useSlashMenu(availableCommands as SlashCommand[] | undefined);
   const mentionMenu = useMentionMenu(sessionId, sessionHost, chatEndpoint);
+  const fileAttachments = useFileAttachments();
 
   const hasContent = input.trim().length > 0;
 
@@ -134,11 +136,12 @@ export function ChatInput({
     onSend(fullMessage);
     setInput('');
     setAttachments([]);
+    fileAttachments.clearAttachments();
     // Clear mentions after send
     for (const m of mentionMenu.mentions) {
       mentionMenu.removeMention(m.path);
     }
-  }, [input, disabled, onSend, mentionMenu]);
+  }, [input, disabled, onSend, mentionMenu, fileAttachments]);
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -223,9 +226,11 @@ export function ChatInput({
       id: `${file.name}-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
     }));
     setAttachments(prev => [...prev, ...newAttachments]);
+    // Also process through fileAttachments hook for image compression/previews
+    fileAttachments.addFiles(files);
     // Reset the input so the same file can be re-attached
     e.target.value = '';
-  }, []);
+  }, [fileAttachments]);
 
   const handleRemoveAttachment = useCallback((id: string) => {
     setAttachments(prev => prev.filter(a => a.id !== id));
@@ -243,25 +248,50 @@ export function ChatInput({
   }, [disabled, isListening, startListening, stopListening]);
 
   return (
-    <div className={cn(styles.wrapper, className)} data-disabled={disabled}>
-      {(attachments.length > 0 || mentionMenu.mentions.length > 0) && (
+    <div
+      className={cn(styles.wrapper, className)}
+      data-disabled={disabled}
+      data-drag-over={fileAttachments.isDragging}
+      onDragOver={fileAttachments.handleDragOver}
+      onDragLeave={fileAttachments.handleDragLeave}
+      onDrop={fileAttachments.handleDrop}
+      onPaste={fileAttachments.handlePaste}
+    >
+      {(attachments.length > 0 || mentionMenu.mentions.length > 0 || fileAttachments.attachments.length > 0) && (
         <div className={styles.attachments}>
           {mentionMenu.mentions.map(entry => (
             <MentionPill key={entry.path} entry={entry} onRemove={mentionMenu.removeMention} />
           ))}
-          {attachments.map(attachment => (
-            <span key={attachment.id} className={styles.attachmentChip}>
-              <span className={styles.attachmentName}>{attachment.name}</span>
-              <button
-                type="button"
-                className={styles.attachmentRemove}
-                onClick={() => handleRemoveAttachment(attachment.id)}
-                aria-label={`Remove ${attachment.name}`}
-              >
-                <X className={styles.attachmentRemoveIcon} />
-              </button>
-            </span>
-          ))}
+          {attachments.map(attachment => {
+            const imagePreview = fileAttachments.attachments.find(
+              fa => fa.name === attachment.name && fa.previewUrl,
+            );
+            return (
+              <span key={attachment.id} className={styles.attachmentChip}>
+                {imagePreview?.previewUrl && (
+                  <img
+                    src={imagePreview.previewUrl}
+                    alt={attachment.name}
+                    className={styles.attachmentThumbnail}
+                  />
+                )}
+                <span className={styles.attachmentName}>{attachment.name}</span>
+                <button
+                  type="button"
+                  className={styles.attachmentRemove}
+                  onClick={() => {
+                    handleRemoveAttachment(attachment.id);
+                    if (imagePreview) {
+                      fileAttachments.removeAttachment(imagePreview.id);
+                    }
+                  }}
+                  aria-label={`Remove ${attachment.name}`}
+                >
+                  <X className={styles.attachmentRemoveIcon} />
+                </button>
+              </span>
+            );
+          })}
         </div>
       )}
 

--- a/web/src/modules/shared/components/SessionChat/ChatMessages.module.css
+++ b/web/src/modules/shared/components/SessionChat/ChatMessages.module.css
@@ -197,45 +197,42 @@
 /* ── Reasoning / Thinking ─────────────────────────────────────────── */
 
 .reasoningSection {
-  margin-top: var(--space-3);
+  margin-top: var(--space-2);
   margin-bottom: var(--space-3);
-  border-radius: var(--radius-lg);
-  border: 1px solid color-mix(in srgb, var(--color-border-subtle) 20%, transparent);
-  background-color: color-mix(in srgb, var(--color-bg-secondary) 20%, transparent);
-  overflow: hidden;
 }
 
 .reasoningTrigger {
-  display: flex;
-  width: 100%;
+  display: inline-flex;
   cursor: pointer;
   align-items: center;
   gap: var(--space-2);
-  padding: var(--space-2) 14px;
-  color: var(--color-text-muted);
-  font-size: var(--text-sm);
+  padding: var(--space-1) var(--space-3);
+  color: color-mix(in srgb, var(--color-accent-purple) 80%, var(--color-text-muted));
+  font-size: var(--text-xs);
   font-family: var(--font-sans);
-  background: none;
-  border: none;
-  transition: color var(--transition-fast);
+  background: color-mix(in srgb, var(--color-accent-purple) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-accent-purple) 20%, transparent);
+  border-radius: var(--radius-full);
+  transition: all var(--transition-fast);
 }
 
 .reasoningTrigger:hover {
-  color: var(--color-text-secondary);
+  background: color-mix(in srgb, var(--color-accent-purple) 18%, transparent);
+  border-color: color-mix(in srgb, var(--color-accent-purple) 35%, transparent);
+  color: var(--color-accent-purple);
 }
 
 .reasoningChevron {
-  width: 14px;
-  height: 14px;
+  width: 12px;
+  height: 12px;
   flex-shrink: 0;
-  color: var(--color-text-muted);
 }
 
 .reasoningIcon {
-  width: 14px;
-  height: 14px;
+  width: 12px;
+  height: 12px;
   flex-shrink: 0;
-  color: color-mix(in srgb, var(--color-accent-purple) 60%, transparent);
+  color: var(--color-accent-purple);
 }
 
 .reasoningLabel {
@@ -245,8 +242,15 @@
 }
 
 .reasoningContent {
-  border-top: 1px solid color-mix(in srgb, var(--color-border-subtle) 20%, transparent);
+  margin-top: var(--space-2);
   padding: 10px 14px;
+  border-radius: var(--radius-lg);
+  border: 1px solid color-mix(in srgb, var(--color-accent-purple) 15%, transparent);
+  background-color: color-mix(in srgb, var(--color-accent-purple) 5%, transparent);
+  max-height: 300px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--color-accent-purple) 20%, transparent) transparent;
 }
 
 .reasoningText {
@@ -266,6 +270,12 @@
   gap: var(--space-1);
   margin-top: 10px;
   margin-left: -4px;
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+}
+
+.assistantWrapper:hover .actionBar {
+  opacity: 1;
 }
 
 .actionBtn {
@@ -416,5 +426,9 @@
   .actionBtn {
     width: 44px;
     height: 44px;
+  }
+
+  .actionBar {
+    opacity: 1;
   }
 }

--- a/web/src/modules/shared/components/SessionChat/ChatMessages.test.tsx
+++ b/web/src/modules/shared/components/SessionChat/ChatMessages.test.tsx
@@ -388,6 +388,20 @@ describe('AssistantMessage', () => {
     expect(thumbDown).toHaveAttribute('data-active', 'false');
   });
 
+  it('bookmark toggle: click once = active, click again = inactive', () => {
+    const msg = createMessage();
+    render(<AssistantMessage message={msg} />);
+
+    const bookmarkBtn = screen.getByTitle('Bookmark');
+    expect(bookmarkBtn).toHaveAttribute('data-active', 'false');
+
+    fireEvent.click(bookmarkBtn);
+    expect(screen.getByTitle('Remove bookmark')).toHaveAttribute('data-active', 'true');
+
+    fireEvent.click(screen.getByTitle('Remove bookmark'));
+    expect(screen.getByTitle('Bookmark')).toHaveAttribute('data-active', 'false');
+  });
+
   it('reasoning section: hidden when no reasoning parts', () => {
     const msg = createMessage({ parts: [{ type: 'text', text: 'Just text' }] });
     render(<AssistantMessage message={msg} />);

--- a/web/src/modules/shared/components/SessionChat/ChatMessages.test.tsx
+++ b/web/src/modules/shared/components/SessionChat/ChatMessages.test.tsx
@@ -402,6 +402,18 @@ describe('AssistantMessage', () => {
     expect(screen.getByTitle('Bookmark')).toHaveAttribute('data-active', 'false');
   });
 
+  it('bookmark toggle calls onBookmark callback with messageId and state', () => {
+    const msg = createMessage();
+    const onBookmark = vi.fn();
+    render(<AssistantMessage message={msg} onBookmark={onBookmark} />);
+
+    fireEvent.click(screen.getByTitle('Bookmark'));
+    expect(onBookmark).toHaveBeenCalledWith(msg.id, true);
+
+    fireEvent.click(screen.getByTitle('Remove bookmark'));
+    expect(onBookmark).toHaveBeenCalledWith(msg.id, false);
+  });
+
   it('reasoning section: hidden when no reasoning parts', () => {
     const msg = createMessage({ parts: [{ type: 'text', text: 'Just text' }] });
     render(<AssistantMessage message={msg} />);

--- a/web/src/modules/shared/components/SessionChat/ChatMessages.tsx
+++ b/web/src/modules/shared/components/SessionChat/ChatMessages.tsx
@@ -118,13 +118,21 @@ interface AssistantMessageProps {
   message: SkuldChatMessage;
   onCopy?: (text: string) => void;
   onRegenerate?: (messageId: string) => void;
+  onBookmark?: (messageId: string, bookmarked: boolean) => void;
+  bookmarked?: boolean;
 }
 
-export function AssistantMessage({ message, onCopy, onRegenerate }: AssistantMessageProps) {
+export function AssistantMessage({
+  message,
+  onCopy,
+  onRegenerate,
+  onBookmark,
+  bookmarked: bookmarkedProp = false,
+}: AssistantMessageProps) {
   const [copied, setCopied] = useState(false);
   const [thumbState, setThumbState] = useState<'up' | 'down' | null>(null);
   const [reasoningOpen, setReasoningOpen] = useState(false);
-  const [bookmarked, setBookmarked] = useState(false);
+  const [bookmarked, setBookmarked] = useState(bookmarkedProp);
 
   const reasoningParts = (message.parts?.filter(p => p.type === 'reasoning') ?? []) as Array<{
     readonly type: 'reasoning';
@@ -160,8 +168,10 @@ export function AssistantMessage({ message, onCopy, onRegenerate }: AssistantMes
   }, []);
 
   const handleBookmark = useCallback(() => {
-    setBookmarked(prev => !prev);
-  }, []);
+    const next = !bookmarked;
+    setBookmarked(next);
+    onBookmark?.(message.id, next);
+  }, [bookmarked, message.id, onBookmark]);
 
   return (
     <div className={styles.assistantWrapper}>

--- a/web/src/modules/shared/components/SessionChat/ChatMessages.tsx
+++ b/web/src/modules/shared/components/SessionChat/ChatMessages.tsx
@@ -11,6 +11,7 @@ import {
   Loader2,
   Terminal,
   Paperclip,
+  Bookmark,
 } from 'lucide-react';
 import { cn } from '@/utils';
 import { MarkdownContent } from './MarkdownContent';
@@ -123,6 +124,7 @@ export function AssistantMessage({ message, onCopy, onRegenerate }: AssistantMes
   const [copied, setCopied] = useState(false);
   const [thumbState, setThumbState] = useState<'up' | 'down' | null>(null);
   const [reasoningOpen, setReasoningOpen] = useState(false);
+  const [bookmarked, setBookmarked] = useState(false);
 
   const reasoningParts = (message.parts?.filter(p => p.type === 'reasoning') ?? []) as Array<{
     readonly type: 'reasoning';
@@ -155,6 +157,10 @@ export function AssistantMessage({ message, onCopy, onRegenerate }: AssistantMes
 
   const handleThumbDown = useCallback(() => {
     setThumbState(prev => (prev === 'down' ? null : 'down'));
+  }, []);
+
+  const handleBookmark = useCallback(() => {
+    setBookmarked(prev => !prev);
   }, []);
 
   return (
@@ -257,6 +263,18 @@ export function AssistantMessage({ message, onCopy, onRegenerate }: AssistantMes
             title="Not helpful"
           >
             <ThumbsDown className={styles.actionIcon} />
+          </button>
+
+          <div className={styles.actionDivider} />
+
+          <button
+            type="button"
+            className={styles.actionBtn}
+            data-active={bookmarked}
+            onClick={handleBookmark}
+            title={bookmarked ? 'Remove bookmark' : 'Bookmark'}
+          >
+            <Bookmark className={styles.actionIcon} />
           </button>
         </div>
       </div>

--- a/web/src/modules/shared/components/SessionChat/MarkdownContent.module.css
+++ b/web/src/modules/shared/components/SessionChat/MarkdownContent.module.css
@@ -89,7 +89,7 @@
 }
 
 .codeLang {
-  font-size: 10px;
+  font-size: var(--text-xs);
   font-family: var(--font-mono);
   color: var(--color-text-faint);
   text-transform: uppercase;
@@ -123,7 +123,7 @@
 }
 
 .codeHeaderBtnLabel {
-  font-size: 10px;
+  font-size: var(--text-xs);
   font-family: var(--font-mono);
   font-weight: 600;
   line-height: 1;
@@ -133,7 +133,7 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: 10px;
+  font-size: var(--text-xs);
   color: var(--color-text-faint);
   background: none;
   border: none;
@@ -160,7 +160,7 @@
 
 .codeContent[data-wrap='true'] pre {
   white-space: pre-wrap;
-  word-break: break-all;
+  overflow-wrap: break-word;
 }
 
 .codeContent pre {

--- a/web/src/modules/shared/components/SessionChat/MarkdownContent.module.css
+++ b/web/src/modules/shared/components/SessionChat/MarkdownContent.module.css
@@ -96,6 +96,39 @@
   letter-spacing: 0.05em;
 }
 
+.codeHeaderActions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.codeHeaderBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 2px;
+  color: var(--color-text-faint);
+  transition: color var(--transition-fast);
+}
+
+.codeHeaderBtn:hover {
+  color: var(--color-text-muted);
+}
+
+.codeHeaderBtn[data-active='true'] {
+  color: var(--color-brand);
+}
+
+.codeHeaderBtnLabel {
+  font-size: 10px;
+  font-family: var(--font-mono);
+  font-weight: 600;
+  line-height: 1;
+}
+
 .copyBtn {
   display: flex;
   align-items: center;
@@ -120,8 +153,14 @@
 }
 
 .codeContent {
+  position: relative;
   padding: var(--space-4);
   overflow-x: auto;
+}
+
+.codeContent[data-wrap='true'] pre {
+  white-space: pre-wrap;
+  word-break: break-all;
 }
 
 .codeContent pre {
@@ -130,12 +169,73 @@
   font-family: var(--font-mono);
   color: var(--color-text-secondary);
   line-height: 1.625;
-  white-space: pre-wrap;
+  white-space: pre;
 }
 
 .codeContent code {
   font-family: inherit;
   font-size: inherit;
+}
+
+/* ── Line numbers grid ──────────────────────────────────── */
+
+.codeContentGrid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0 var(--space-4);
+}
+
+.lineNumbers {
+  display: flex;
+  flex-direction: column;
+  text-align: right;
+  user-select: none;
+  color: var(--color-text-faint);
+  font-size: var(--text-xs);
+  line-height: 1.625;
+  border-right: 1px solid var(--color-border-subtle);
+  padding-right: var(--space-3);
+}
+
+/* ── Collapsed code block ───────────────────────────────── */
+
+.codeCollapsed {
+  max-height: 420px;
+  overflow: hidden;
+}
+
+.codeFade {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 80px;
+  background: linear-gradient(
+    to bottom,
+    transparent,
+    color-mix(in srgb, var(--color-bg-primary) 50%, var(--color-bg-secondary) 50%)
+  );
+  pointer-events: none;
+}
+
+.showAllBtn {
+  display: block;
+  width: 100%;
+  padding: var(--space-2);
+  background-color: color-mix(in srgb, var(--color-bg-secondary) 80%, transparent);
+  border: none;
+  border-top: 1px solid var(--color-border-subtle);
+  color: var(--color-accent-cyan);
+  font-size: var(--text-xs);
+  font-family: var(--font-sans);
+  cursor: pointer;
+  text-align: center;
+  transition: all var(--transition-fast);
+}
+
+.showAllBtn:hover {
+  background-color: color-mix(in srgb, var(--color-accent-cyan) 8%, transparent);
+  color: var(--color-accent-cyan);
 }
 
 /* ── Lists ───────────────────────────────────────────────── */

--- a/web/src/modules/shared/components/SessionChat/MarkdownContent.test.tsx
+++ b/web/src/modules/shared/components/SessionChat/MarkdownContent.test.tsx
@@ -149,15 +149,16 @@ describe('MarkdownContent', () => {
 
   it('toggle line numbers button hides line numbers', () => {
     const md = '```js\nconst x = 1;\nconst y = 2;\n```';
-    render(<MarkdownContent content={md} />);
+    const { container } = render(<MarkdownContent content={md} />);
+
+    // Line numbers column should exist before toggle
+    expect(container.querySelector('[class*="lineNumbers"]')).toBeInTheDocument();
 
     const toggleBtn = screen.getByTestId('toggle-line-numbers');
     fireEvent.click(toggleBtn);
 
     // After toggling, line numbers column should be removed
-    // The "1" text from line numbers should not be in a line-number element
-    // (it may still exist as code content, so we check the toggle worked)
-    expect(toggleBtn).toBeInTheDocument();
+    expect(container.querySelector('[class*="lineNumbers"]')).not.toBeInTheDocument();
   });
 
   it('toggle word wrap button activates wrap', () => {
@@ -194,9 +195,23 @@ describe('MarkdownContent', () => {
     const showAllBtn = screen.getByText('Show all 30 lines');
     fireEvent.click(showAllBtn);
 
-    // After expanding, line30 should be visible (in the code text) and button should be gone
+    // After expanding, line30 should be visible and "Collapse" button should appear
     expect(screen.getByText(/line30/)).toBeInTheDocument();
     expect(screen.queryByText('Show all 30 lines')).not.toBeInTheDocument();
+    expect(screen.getByText('Collapse')).toBeInTheDocument();
+  });
+
+  it('re-collapses expanded code block when "Collapse" is clicked', () => {
+    const lines = Array.from({ length: 30 }, (_, i) => `line${i + 1}`).join('\n');
+    const md = '```\n' + lines + '\n```';
+    render(<MarkdownContent content={md} />);
+
+    fireEvent.click(screen.getByText('Show all 30 lines'));
+    expect(screen.getByText(/line30/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Collapse'));
+    expect(screen.queryByText('line30')).not.toBeInTheDocument();
+    expect(screen.getByText('Show all 30 lines')).toBeInTheDocument();
   });
 
   it('does not collapse short code blocks (<= 25 lines)', () => {

--- a/web/src/modules/shared/components/SessionChat/MarkdownContent.test.tsx
+++ b/web/src/modules/shared/components/SessionChat/MarkdownContent.test.tsx
@@ -138,4 +138,74 @@ describe('MarkdownContent', () => {
     const { container } = render(<MarkdownContent content="text" className="custom" />);
     expect(container.firstChild).toHaveClass('custom');
   });
+
+  it('shows line numbers by default in code blocks', () => {
+    const md = '```js\nconst x = 1;\nconst y = 2;\n```';
+    render(<MarkdownContent content={md} />);
+    // Line numbers should render "1" and "2"
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('toggle line numbers button hides line numbers', () => {
+    const md = '```js\nconst x = 1;\nconst y = 2;\n```';
+    render(<MarkdownContent content={md} />);
+
+    const toggleBtn = screen.getByTestId('toggle-line-numbers');
+    fireEvent.click(toggleBtn);
+
+    // After toggling, line numbers column should be removed
+    // The "1" text from line numbers should not be in a line-number element
+    // (it may still exist as code content, so we check the toggle worked)
+    expect(toggleBtn).toBeInTheDocument();
+  });
+
+  it('toggle word wrap button activates wrap', () => {
+    const md = '```js\nconst x = 1;\n```';
+    render(<MarkdownContent content={md} />);
+
+    const wrapBtn = screen.getByTestId('toggle-word-wrap');
+    expect(wrapBtn).toHaveAttribute('data-active', 'false');
+
+    fireEvent.click(wrapBtn);
+    expect(wrapBtn).toHaveAttribute('data-active', 'true');
+
+    fireEvent.click(wrapBtn);
+    expect(wrapBtn).toHaveAttribute('data-active', 'false');
+  });
+
+  it('collapses long code blocks (>25 lines) and shows "Show all" button', () => {
+    const lines = Array.from({ length: 30 }, (_, i) => `line${i + 1}`).join('\n');
+    const md = '```\n' + lines + '\n```';
+    render(<MarkdownContent content={md} />);
+
+    // Should show "Show all 30 lines" button
+    expect(screen.getByText('Show all 30 lines')).toBeInTheDocument();
+
+    // line30 should NOT be visible (collapsed)
+    expect(screen.queryByText('line30')).not.toBeInTheDocument();
+  });
+
+  it('expands collapsed code block when "Show all" is clicked', () => {
+    const lines = Array.from({ length: 30 }, (_, i) => `line${i + 1}`).join('\n');
+    const md = '```\n' + lines + '\n```';
+    render(<MarkdownContent content={md} />);
+
+    const showAllBtn = screen.getByText('Show all 30 lines');
+    fireEvent.click(showAllBtn);
+
+    // After expanding, line30 should be visible (in the code text) and button should be gone
+    expect(screen.getByText(/line30/)).toBeInTheDocument();
+    expect(screen.queryByText('Show all 30 lines')).not.toBeInTheDocument();
+  });
+
+  it('does not collapse short code blocks (<= 25 lines)', () => {
+    const lines = Array.from({ length: 10 }, (_, i) => `line${i + 1}`).join('\n');
+    const md = '```\n' + lines + '\n```';
+    render(<MarkdownContent content={md} />);
+
+    expect(screen.queryByText(/Show all/)).not.toBeInTheDocument();
+    // Code content should include line10
+    expect(screen.getByText(/line10/)).toBeInTheDocument();
+  });
 });

--- a/web/src/modules/shared/components/SessionChat/MarkdownContent.tsx
+++ b/web/src/modules/shared/components/SessionChat/MarkdownContent.tsx
@@ -89,6 +89,11 @@ function CodeBlockRenderer({ language, code }: CodeBlockRendererProps) {
           Show all {lineCount} lines
         </button>
       )}
+      {isLong && !collapsed && (
+        <button type="button" className={styles.showAllBtn} onClick={() => setCollapsed(true)}>
+          Collapse
+        </button>
+      )}
     </div>
   );
 }

--- a/web/src/modules/shared/components/SessionChat/MarkdownContent.tsx
+++ b/web/src/modules/shared/components/SessionChat/MarkdownContent.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useState, type ComponentPropsWithoutRef } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { Copy, Check } from 'lucide-react';
+import { Copy, Check, WrapText } from 'lucide-react';
 import { cn } from '@/utils';
 import styles from './MarkdownContent.module.css';
+
+const COLLAPSE_LINE_THRESHOLD = 25;
 
 /* ------------------------------------------------------------------ */
 /*  Code block with copy button                                        */
@@ -16,6 +18,14 @@ interface CodeBlockRendererProps {
 
 function CodeBlockRenderer({ language, code }: CodeBlockRendererProps) {
   const [copied, setCopied] = useState(false);
+  const [collapsed, setCollapsed] = useState(true);
+  const [wordWrap, setWordWrap] = useState(false);
+  const [showLineNumbers, setShowLineNumbers] = useState(true);
+
+  const lines = code.split('\n');
+  const lineCount = lines.length;
+  const isLong = lineCount > COLLAPSE_LINE_THRESHOLD;
+  const shouldCollapse = isLong && collapsed;
 
   const handleCopy = useCallback(() => {
     navigator.clipboard.writeText(code).then(() => {
@@ -24,20 +34,64 @@ function CodeBlockRenderer({ language, code }: CodeBlockRendererProps) {
     });
   }, [code]);
 
+  const displayCode = shouldCollapse
+    ? lines.slice(0, COLLAPSE_LINE_THRESHOLD).join('\n')
+    : code;
+
   return (
     <div className={styles.codeBlock}>
       <div className={styles.codeHeader}>
         <span className={styles.codeLang}>{language || 'text'}</span>
-        <button type="button" className={styles.copyBtn} onClick={handleCopy}>
-          {copied ? <Check className={styles.copyIcon} /> : <Copy className={styles.copyIcon} />}
-          {copied ? 'Copied!' : 'Copy'}
-        </button>
+        <div className={styles.codeHeaderActions}>
+          <button
+            type="button"
+            className={styles.codeHeaderBtn}
+            onClick={() => setShowLineNumbers(prev => !prev)}
+            title={showLineNumbers ? 'Hide line numbers' : 'Show line numbers'}
+            data-testid="toggle-line-numbers"
+          >
+            <span className={styles.codeHeaderBtnLabel}>{showLineNumbers ? '#' : '¶'}</span>
+          </button>
+          <button
+            type="button"
+            className={styles.codeHeaderBtn}
+            onClick={() => setWordWrap(prev => !prev)}
+            title={wordWrap ? 'Disable word wrap' : 'Enable word wrap'}
+            data-active={wordWrap}
+            data-testid="toggle-word-wrap"
+          >
+            <WrapText className={styles.copyIcon} />
+          </button>
+          <button type="button" className={styles.copyBtn} onClick={handleCopy}>
+            {copied ? <Check className={styles.copyIcon} /> : <Copy className={styles.copyIcon} />}
+            {copied ? 'Copied!' : 'Copy'}
+          </button>
+        </div>
       </div>
-      <div className={styles.codeContent}>
+      <div className={cn(styles.codeContent, shouldCollapse && styles.codeCollapsed)} data-wrap={wordWrap}>
         <pre>
-          <code>{code}</code>
+          <code className={showLineNumbers ? styles.codeContentGrid : undefined}>
+            {showLineNumbers && (
+              <span className={styles.lineNumbers} aria-hidden="true">
+                {(shouldCollapse ? lines.slice(0, COLLAPSE_LINE_THRESHOLD) : lines).map((_, i) => (
+                  <span key={i}>{i + 1}</span>
+                ))}
+              </span>
+            )}
+            <span>{displayCode}</span>
+          </code>
         </pre>
+        {shouldCollapse && <div className={styles.codeFade} />}
       </div>
+      {shouldCollapse && (
+        <button
+          type="button"
+          className={styles.showAllBtn}
+          onClick={() => setCollapsed(false)}
+        >
+          Show all {lineCount} lines
+        </button>
+      )}
     </div>
   );
 }

--- a/web/src/modules/shared/components/SessionChat/MarkdownContent.tsx
+++ b/web/src/modules/shared/components/SessionChat/MarkdownContent.tsx
@@ -34,9 +34,7 @@ function CodeBlockRenderer({ language, code }: CodeBlockRendererProps) {
     });
   }, [code]);
 
-  const displayCode = shouldCollapse
-    ? lines.slice(0, COLLAPSE_LINE_THRESHOLD).join('\n')
-    : code;
+  const displayCode = shouldCollapse ? lines.slice(0, COLLAPSE_LINE_THRESHOLD).join('\n') : code;
 
   return (
     <div className={styles.codeBlock}>
@@ -68,7 +66,10 @@ function CodeBlockRenderer({ language, code }: CodeBlockRendererProps) {
           </button>
         </div>
       </div>
-      <div className={cn(styles.codeContent, shouldCollapse && styles.codeCollapsed)} data-wrap={wordWrap}>
+      <div
+        className={cn(styles.codeContent, shouldCollapse && styles.codeCollapsed)}
+        data-wrap={wordWrap}
+      >
         <pre>
           <code className={showLineNumbers ? styles.codeContentGrid : undefined}>
             {showLineNumbers && (
@@ -84,11 +85,7 @@ function CodeBlockRenderer({ language, code }: CodeBlockRendererProps) {
         {shouldCollapse && <div className={styles.codeFade} />}
       </div>
       {shouldCollapse && (
-        <button
-          type="button"
-          className={styles.showAllBtn}
-          onClick={() => setCollapsed(false)}
-        >
+        <button type="button" className={styles.showAllBtn} onClick={() => setCollapsed(false)}>
           Show all {lineCount} lines
         </button>
       )}

--- a/web/src/modules/shared/components/SessionChat/SessionChat.module.css
+++ b/web/src/modules/shared/components/SessionChat/SessionChat.module.css
@@ -247,7 +247,7 @@
 .scrollToBottom:hover {
   background-color: var(--color-bg-tertiary);
   color: var(--color-text-primary);
-  border-color: color-mix(in srgb, var(--color-accent-purple) 50%, transparent);
+  border-color: color-mix(in srgb, var(--color-brand) 50%, transparent);
 }
 
 .scrollToBottomIcon {
@@ -263,7 +263,7 @@
   height: 1.25rem;
   padding: 0 var(--space-1);
   border-radius: var(--radius-full);
-  background-color: var(--color-accent-purple);
+  background-color: var(--color-brand);
   color: white;
   font-size: 10px;
   font-weight: 700;

--- a/web/src/modules/shared/components/SessionChat/SessionChat.tsx
+++ b/web/src/modules/shared/components/SessionChat/SessionChat.tsx
@@ -2,11 +2,16 @@ import { useCallback, useMemo, useState, useRef, useEffect } from 'react';
 import { Wifi, WifiOff, BrainCircuitIcon, RotateCcwIcon, ArrowDownIcon } from 'lucide-react';
 import { PermissionStack } from '@/modules/shared/components/PermissionDialog';
 import { useSkuldChat } from '@/modules/shared/hooks/useSkuldChat';
-import type { PermissionBehavior } from '@/modules/shared/hooks/useSkuldChat';
+import type {
+  PermissionBehavior,
+  ContentBlock,
+  AttachmentMeta,
+} from '@/modules/shared/hooks/useSkuldChat';
 import { cn } from '@/utils';
 import { UserMessage, AssistantMessage, StreamingMessage, SystemMessage } from './ChatMessages';
 import { ChatInput } from './ChatInput';
 import { SessionEmptyChat } from './ChatEmptyStates';
+import type { FileAttachment } from './useFileAttachments';
 import styles from './SessionChat.module.css';
 
 const SCROLL_THRESHOLD = 150;
@@ -150,9 +155,53 @@ export function SessionChat({
   );
 
   const handleSend = useCallback(
-    (text: string) => {
+    (text: string, fileAttachments: FileAttachment[]) => {
       userSentRef.current = true;
-      sendMessage(text);
+
+      if (fileAttachments.length === 0) {
+        sendMessage(text);
+        return;
+      }
+
+      const contentBlocks: ContentBlock[] = [];
+      const attachmentMeta: AttachmentMeta[] = [];
+
+      for (const fa of fileAttachments) {
+        const isImage = fa.file.type.startsWith('image/');
+        attachmentMeta.push({
+          name: fa.name,
+          type: isImage ? 'image' : fa.file.type === 'application/pdf' ? 'document' : 'text',
+          size: fa.compressed?.size ?? fa.file.size,
+          contentType: fa.compressed ? 'image/jpeg' : fa.file.type,
+        });
+
+        // Image content blocks are sent as base64 — read the blob
+        if (isImage && fa.compressed) {
+          const reader = new FileReader();
+          reader.onload = () => {
+            const base64 = (reader.result as string).split(',')[1];
+            contentBlocks.push({
+              type: 'image',
+              source: {
+                type: 'base64',
+                media_type: 'image/jpeg',
+                data: base64,
+              },
+            });
+            // Send once all images are processed
+            if (contentBlocks.length === fileAttachments.filter(f => f.compressed).length) {
+              sendMessage(text, contentBlocks, attachmentMeta);
+            }
+          };
+          reader.readAsDataURL(fa.compressed);
+        }
+      }
+
+      // If no images need base64 encoding, send immediately with just metadata
+      const hasImages = fileAttachments.some(f => f.compressed);
+      if (!hasImages) {
+        sendMessage(text, contentBlocks, attachmentMeta);
+      }
     },
     [sendMessage]
   );
@@ -343,7 +392,7 @@ export function SessionChat({
           )}
         </div>
       ) : (
-        <SessionEmptyChat sessionName="Volundr" onSuggestionClick={handleSend} />
+        <SessionEmptyChat sessionName="Volundr" onSuggestionClick={text => handleSend(text, [])} />
       )}
 
       <div className={styles.inputArea}>

--- a/web/src/modules/shared/components/SessionChat/SessionChat.tsx
+++ b/web/src/modules/shared/components/SessionChat/SessionChat.tsx
@@ -158,49 +158,46 @@ export function SessionChat({
     (text: string, fileAttachments: FileAttachment[]) => {
       userSentRef.current = true;
 
-      if (fileAttachments.length === 0) {
+      // Only image files with compressed blobs can be transmitted as content blocks.
+      // Non-image files are filtered out so metadata stays consistent with actual
+      // content blocks sent over the wire.
+      const imageAttachments = fileAttachments.filter(
+        (fa): fa is FileAttachment & { compressed: Blob } =>
+          fa.file.type.startsWith('image/') && fa.compressed !== null
+      );
+
+      if (imageAttachments.length === 0) {
         sendMessage(text);
         return;
       }
 
       const contentBlocks: ContentBlock[] = [];
-      const attachmentMeta: AttachmentMeta[] = [];
+      const attachmentMeta: AttachmentMeta[] = imageAttachments.map(fa => ({
+        name: fa.name,
+        type: 'image' as const,
+        size: fa.compressed.size,
+        contentType: 'image/jpeg',
+      }));
 
-      for (const fa of fileAttachments) {
-        const isImage = fa.file.type.startsWith('image/');
-        attachmentMeta.push({
-          name: fa.name,
-          type: isImage ? 'image' : fa.file.type === 'application/pdf' ? 'document' : 'text',
-          size: fa.compressed?.size ?? fa.file.size,
-          contentType: fa.compressed ? 'image/jpeg' : fa.file.type,
-        });
-
-        // Image content blocks are sent as base64 — read the blob
-        if (isImage && fa.compressed) {
-          const reader = new FileReader();
-          reader.onload = () => {
-            const base64 = (reader.result as string).split(',')[1];
-            contentBlocks.push({
-              type: 'image',
-              source: {
-                type: 'base64',
-                media_type: 'image/jpeg',
-                data: base64,
-              },
-            });
-            // Send once all images are processed
-            if (contentBlocks.length === fileAttachments.filter(f => f.compressed).length) {
-              sendMessage(text, contentBlocks, attachmentMeta);
-            }
-          };
-          reader.readAsDataURL(fa.compressed);
-        }
-      }
-
-      // If no images need base64 encoding, send immediately with just metadata
-      const hasImages = fileAttachments.some(f => f.compressed);
-      if (!hasImages) {
-        sendMessage(text, contentBlocks, attachmentMeta);
+      let processedCount = 0;
+      for (const fa of imageAttachments) {
+        const reader = new FileReader();
+        reader.onload = () => {
+          const base64 = (reader.result as string).split(',')[1];
+          contentBlocks.push({
+            type: 'image',
+            source: {
+              type: 'base64',
+              media_type: 'image/jpeg',
+              data: base64,
+            },
+          });
+          processedCount += 1;
+          if (processedCount === imageAttachments.length) {
+            sendMessage(text, contentBlocks, attachmentMeta);
+          }
+        };
+        reader.readAsDataURL(fa.compressed);
       }
     },
     [sendMessage]
@@ -212,6 +209,15 @@ export function SessionChat({
 
   const handleCopy = useCallback((text: string) => {
     navigator.clipboard?.writeText(text);
+  }, []);
+
+  const handleBookmark = useCallback((id: string, bookmarked: boolean) => {
+    const key = `bookmark:${id}`;
+    if (bookmarked) {
+      localStorage.setItem(key, '1');
+    } else {
+      localStorage.removeItem(key);
+    }
   }, []);
 
   const handleRegenerate = useCallback(
@@ -370,6 +376,8 @@ export function SessionChat({
                   message={msg}
                   onCopy={handleCopy}
                   onRegenerate={handleRegenerate}
+                  onBookmark={handleBookmark}
+                  bookmarked={localStorage.getItem(`bookmark:${msg.id}`) === '1'}
                 />
               );
             })}

--- a/web/src/modules/shared/components/SessionChat/SessionChat.tsx
+++ b/web/src/modules/shared/components/SessionChat/SessionChat.tsx
@@ -171,7 +171,6 @@ export function SessionChat({
         return;
       }
 
-      const contentBlocks: ContentBlock[] = [];
       const attachmentMeta: AttachmentMeta[] = imageAttachments.map(fa => ({
         name: fa.name,
         type: 'image' as const,
@@ -179,26 +178,46 @@ export function SessionChat({
         contentType: 'image/jpeg',
       }));
 
+      // Pre-allocate to preserve ordering: contentBlocks[i] matches attachmentMeta[i]
+      const contentBlocks: (ContentBlock | null)[] = new Array(imageAttachments.length).fill(null);
       let processedCount = 0;
-      for (const fa of imageAttachments) {
+
+      const checkComplete = () => {
+        processedCount += 1;
+        if (processedCount < imageAttachments.length) return;
+        // Filter out failed reads, keep meta in sync
+        const finalBlocks: ContentBlock[] = [];
+        const finalMeta: AttachmentMeta[] = [];
+        for (let i = 0; i < contentBlocks.length; i++) {
+          const block = contentBlocks[i];
+          if (block) {
+            finalBlocks.push(block);
+            finalMeta.push(attachmentMeta[i]);
+          }
+        }
+        sendMessage(text, finalBlocks, finalMeta);
+      };
+
+      imageAttachments.forEach((fa, index) => {
         const reader = new FileReader();
         reader.onload = () => {
           const base64 = (reader.result as string).split(',')[1];
-          contentBlocks.push({
+          contentBlocks[index] = {
             type: 'image',
             source: {
               type: 'base64',
               media_type: 'image/jpeg',
               data: base64,
             },
-          });
-          processedCount += 1;
-          if (processedCount === imageAttachments.length) {
-            sendMessage(text, contentBlocks, attachmentMeta);
-          }
+          };
+          checkComplete();
+        };
+        reader.onerror = () => {
+          // Skip failed image but still send the message
+          checkComplete();
         };
         reader.readAsDataURL(fa.compressed);
-      }
+      });
     },
     [sendMessage]
   );

--- a/web/src/modules/shared/components/SessionChat/ToolBlock/ToolBlock.module.css
+++ b/web/src/modules/shared/components/SessionChat/ToolBlock/ToolBlock.module.css
@@ -238,3 +238,110 @@
 .groupItem:last-child {
   border-bottom: none;
 }
+
+/* ── Tool category color-coding ─────────────────────────── */
+
+.toolBlock[data-tool-category='terminal'] .toolIcon,
+.groupBlock[data-tool-category='terminal'] .toolIcon {
+  color: var(--color-tool-terminal);
+}
+
+.toolBlock[data-tool-category='terminal'],
+.groupBlock[data-tool-category='terminal'] {
+  border-color: color-mix(in srgb, var(--color-tool-terminal) 20%, var(--color-border-subtle));
+}
+
+.toolBlock[data-tool-category='terminal'] .toolHeader:hover,
+.groupBlock[data-tool-category='terminal'] .groupHeader:hover {
+  background-color: color-mix(in srgb, var(--color-tool-terminal) 8%, transparent);
+}
+
+.toolBlock[data-tool-category='file'] .toolIcon,
+.groupBlock[data-tool-category='file'] .toolIcon {
+  color: var(--color-tool-file);
+}
+
+.toolBlock[data-tool-category='file'],
+.groupBlock[data-tool-category='file'] {
+  border-color: color-mix(in srgb, var(--color-tool-file) 20%, var(--color-border-subtle));
+}
+
+.toolBlock[data-tool-category='file'] .toolHeader:hover,
+.groupBlock[data-tool-category='file'] .groupHeader:hover {
+  background-color: color-mix(in srgb, var(--color-tool-file) 8%, transparent);
+}
+
+.toolBlock[data-tool-category='search'] .toolIcon,
+.groupBlock[data-tool-category='search'] .toolIcon {
+  color: var(--color-tool-search);
+}
+
+.toolBlock[data-tool-category='search'],
+.groupBlock[data-tool-category='search'] {
+  border-color: color-mix(in srgb, var(--color-tool-search) 20%, var(--color-border-subtle));
+}
+
+.toolBlock[data-tool-category='search'] .toolHeader:hover,
+.groupBlock[data-tool-category='search'] .groupHeader:hover {
+  background-color: color-mix(in srgb, var(--color-tool-search) 8%, transparent);
+}
+
+.toolBlock[data-tool-category='web'] .toolIcon,
+.groupBlock[data-tool-category='web'] .toolIcon {
+  color: var(--color-tool-web);
+}
+
+.toolBlock[data-tool-category='web'],
+.groupBlock[data-tool-category='web'] {
+  border-color: color-mix(in srgb, var(--color-tool-web) 20%, var(--color-border-subtle));
+}
+
+.toolBlock[data-tool-category='web'] .toolHeader:hover,
+.groupBlock[data-tool-category='web'] .groupHeader:hover {
+  background-color: color-mix(in srgb, var(--color-tool-web) 8%, transparent);
+}
+
+.toolBlock[data-tool-category='agent'] .toolIcon,
+.groupBlock[data-tool-category='agent'] .toolIcon {
+  color: var(--color-tool-agent);
+}
+
+.toolBlock[data-tool-category='agent'],
+.groupBlock[data-tool-category='agent'] {
+  border-color: color-mix(in srgb, var(--color-tool-agent) 20%, var(--color-border-subtle));
+}
+
+.toolBlock[data-tool-category='agent'] .toolHeader:hover,
+.groupBlock[data-tool-category='agent'] .groupHeader:hover {
+  background-color: color-mix(in srgb, var(--color-tool-agent) 8%, transparent);
+}
+
+.toolBlock[data-tool-category='task'] .toolIcon,
+.groupBlock[data-tool-category='task'] .toolIcon {
+  color: var(--color-tool-task);
+}
+
+.toolBlock[data-tool-category='task'],
+.groupBlock[data-tool-category='task'] {
+  border-color: color-mix(in srgb, var(--color-tool-task) 20%, var(--color-border-subtle));
+}
+
+.toolBlock[data-tool-category='task'] .toolHeader:hover,
+.groupBlock[data-tool-category='task'] .groupHeader:hover {
+  background-color: color-mix(in srgb, var(--color-tool-task) 8%, transparent);
+}
+
+.toolBlock[data-tool-category='mcp'] .toolIcon,
+.groupBlock[data-tool-category='mcp'] .toolIcon {
+  color: var(--color-tool-mcp);
+}
+
+.toolBlock[data-tool-category='mcp'],
+.groupBlock[data-tool-category='mcp'] {
+  border-color: color-mix(in srgb, var(--color-tool-mcp) 20%, var(--color-border-subtle));
+}
+
+.toolBlock[data-tool-category='mcp'] .toolHeader:hover,
+.groupBlock[data-tool-category='mcp'] .groupHeader:hover {
+  background-color: color-mix(in srgb, var(--color-tool-mcp) 8%, transparent);
+}

--- a/web/src/modules/shared/components/SessionChat/ToolBlock/ToolBlock.module.css
+++ b/web/src/modules/shared/components/SessionChat/ToolBlock/ToolBlock.module.css
@@ -80,7 +80,7 @@
   color: var(--color-text-secondary);
   line-height: 1.625;
   white-space: pre-wrap;
-  word-break: break-all;
+  overflow-wrap: break-word;
 }
 
 .commandPrefix {
@@ -146,7 +146,7 @@
 .paramValue {
   color: var(--color-text-secondary);
   font-family: var(--font-mono);
-  word-break: break-all;
+  overflow-wrap: break-word;
 }
 
 /* ── Diff view (Edit/Write) ──────────────────────────────── */

--- a/web/src/modules/shared/components/SessionChat/ToolBlock/ToolBlock.module.css
+++ b/web/src/modules/shared/components/SessionChat/ToolBlock/ToolBlock.module.css
@@ -345,3 +345,16 @@
 .groupBlock[data-tool-category='mcp'] .groupHeader:hover {
   background-color: color-mix(in srgb, var(--color-tool-mcp) 8%, transparent);
 }
+
+.toolBlock[data-tool-category='default'] .toolIcon,
+.groupBlock[data-tool-category='default'] .toolIcon {
+  color: var(--color-tool-default);
+}
+.toolBlock[data-tool-category='default'],
+.groupBlock[data-tool-category='default'] {
+  border-color: color-mix(in srgb, var(--color-tool-default) 20%, var(--color-border-subtle) 80%);
+}
+.toolBlock[data-tool-category='default'] .toolHeader:hover,
+.groupBlock[data-tool-category='default'] .groupHeader:hover {
+  background-color: color-mix(in srgb, var(--color-tool-default) 8%, transparent);
+}

--- a/web/src/modules/shared/components/SessionChat/ToolBlock/ToolBlock.test.tsx
+++ b/web/src/modules/shared/components/SessionChat/ToolBlock/ToolBlock.test.tsx
@@ -246,6 +246,42 @@ describe('ToolBlock', () => {
     expect(screen.getByRole('button')).toBeInTheDocument();
   });
 
+  it('sets data-tool-category attribute based on tool name', () => {
+    const { container } = render(<ToolBlock block={bashBlock} />);
+    const root = container.firstChild as HTMLElement;
+    expect(root).toHaveAttribute('data-tool-category', 'terminal');
+  });
+
+  it('sets file category for Edit tool', () => {
+    const { container } = render(<ToolBlock block={editBlock} />);
+    const root = container.firstChild as HTMLElement;
+    expect(root).toHaveAttribute('data-tool-category', 'file');
+  });
+
+  it('sets mcp category for mcp prefixed tools', () => {
+    const mcpBlock: ToolUseBlock = {
+      type: 'tool_use',
+      id: 't-mcp',
+      name: 'mcp__linear-server__get_issue',
+      input: { id: 'LIN-123' },
+    };
+    const { container } = render(<ToolBlock block={mcpBlock} />);
+    const root = container.firstChild as HTMLElement;
+    expect(root).toHaveAttribute('data-tool-category', 'mcp');
+  });
+
+  it('sets default category for unknown tools', () => {
+    const unknownBlock: ToolUseBlock = {
+      type: 'tool_use',
+      id: 't-unknown',
+      name: 'MyCustomTool',
+      input: {},
+    };
+    const { container } = render(<ToolBlock block={unknownBlock} />);
+    const root = container.firstChild as HTMLElement;
+    expect(root).toHaveAttribute('data-tool-category', 'default');
+  });
+
   it('shows "Show full output" button for long Bash output and expands on click', () => {
     const longOutput = Array.from({ length: 30 }, (_, i) => `line ${i + 1}`).join('\n');
     const result: ToolResultBlock = {

--- a/web/src/modules/shared/components/SessionChat/ToolBlock/ToolBlock.tsx
+++ b/web/src/modules/shared/components/SessionChat/ToolBlock/ToolBlock.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback } from 'react';
 import { ChevronRight } from 'lucide-react';
 import { cn } from '@/utils';
 import { ToolIcon } from './ToolIcon';
-import { getToolLabel } from './toolLabels';
+import { getToolLabel, getToolCategory } from './toolLabels';
 import type { ToolUseBlock, ToolResultBlock } from './groupContentBlocks';
 import styles from './ToolBlock.module.css';
 
@@ -188,7 +188,7 @@ export function ToolBlock({ block, result }: ToolBlockProps) {
   const toggle = useCallback(() => setExpanded(prev => !prev), []);
 
   return (
-    <div className={styles.toolBlock}>
+    <div className={styles.toolBlock} data-tool-category={getToolCategory(block.name)}>
       <button type="button" className={styles.toolHeader} onClick={toggle}>
         <ToolIcon toolName={block.name} className={styles.toolIcon} />
         <span className={styles.toolLabel}>{getToolLabel(block.name)}</span>

--- a/web/src/modules/shared/components/SessionChat/ToolBlock/ToolGroupBlock.test.tsx
+++ b/web/src/modules/shared/components/SessionChat/ToolBlock/ToolGroupBlock.test.tsx
@@ -55,6 +55,22 @@ describe('ToolGroupBlock', () => {
     expect(container.querySelector('svg')).toBeTruthy();
   });
 
+  it('sets data-tool-category attribute based on tool name', () => {
+    const { container } = render(<ToolGroupBlock toolName="Read" blocks={blocks} />);
+    const root = container.firstChild as HTMLElement;
+    expect(root).toHaveAttribute('data-tool-category', 'file');
+  });
+
+  it('sets terminal category for Bash group', () => {
+    const bashBlocks = [
+      { block: { type: 'tool_use' as const, id: 't1', name: 'Bash', input: { command: 'ls' } } },
+      { block: { type: 'tool_use' as const, id: 't2', name: 'Bash', input: { command: 'pwd' } } },
+    ];
+    const { container } = render(<ToolGroupBlock toolName="Bash" blocks={bashBlocks} />);
+    const root = container.firstChild as HTMLElement;
+    expect(root).toHaveAttribute('data-tool-category', 'terminal');
+  });
+
   it('handles blocks with results', () => {
     const blocksWithResults: { block: ToolUseBlock; result?: ToolResultBlock }[] = [
       {

--- a/web/src/modules/shared/components/SessionChat/ToolBlock/ToolGroupBlock.tsx
+++ b/web/src/modules/shared/components/SessionChat/ToolBlock/ToolGroupBlock.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback } from 'react';
 import { ChevronRight } from 'lucide-react';
 import { cn } from '@/utils';
 import { ToolIcon } from './ToolIcon';
-import { getToolLabel } from './toolLabels';
+import { getToolLabel, getToolCategory } from './toolLabels';
 import { ToolBlock } from './ToolBlock';
 import type { ToolUseBlock, ToolResultBlock } from './groupContentBlocks';
 import styles from './ToolBlock.module.css';
@@ -18,7 +18,7 @@ export function ToolGroupBlock({ toolName, blocks }: ToolGroupBlockProps) {
   const toggle = useCallback(() => setExpanded(prev => !prev), []);
 
   return (
-    <div className={styles.groupBlock}>
+    <div className={styles.groupBlock} data-tool-category={getToolCategory(toolName)}>
       <button type="button" className={styles.groupHeader} onClick={toggle}>
         <ToolIcon toolName={toolName} className={styles.toolIcon} />
         <span className={styles.toolLabel}>{getToolLabel(toolName)}</span>

--- a/web/src/modules/shared/components/SessionChat/ToolBlock/toolLabels.test.ts
+++ b/web/src/modules/shared/components/SessionChat/ToolBlock/toolLabels.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getToolLabel } from './toolLabels';
+import { getToolLabel, getToolCategory } from './toolLabels';
 
 describe('getToolLabel', () => {
   it('returns "Terminal" for Bash', () => {
@@ -56,5 +56,63 @@ describe('getToolLabel', () => {
 
   it('returns tool name as-is for unknown non-mcp tools', () => {
     expect(getToolLabel('CustomTool')).toBe('CustomTool');
+  });
+});
+
+describe('getToolCategory', () => {
+  it('returns "terminal" for Bash', () => {
+    expect(getToolCategory('Bash')).toBe('terminal');
+  });
+
+  it('returns "file" for Read', () => {
+    expect(getToolCategory('Read')).toBe('file');
+  });
+
+  it('returns "file" for Write', () => {
+    expect(getToolCategory('Write')).toBe('file');
+  });
+
+  it('returns "file" for Edit', () => {
+    expect(getToolCategory('Edit')).toBe('file');
+  });
+
+  it('returns "search" for Glob', () => {
+    expect(getToolCategory('Glob')).toBe('search');
+  });
+
+  it('returns "search" for Grep', () => {
+    expect(getToolCategory('Grep')).toBe('search');
+  });
+
+  it('returns "web" for WebSearch', () => {
+    expect(getToolCategory('WebSearch')).toBe('web');
+  });
+
+  it('returns "web" for WebFetch', () => {
+    expect(getToolCategory('WebFetch')).toBe('web');
+  });
+
+  it('returns "agent" for Agent', () => {
+    expect(getToolCategory('Agent')).toBe('agent');
+  });
+
+  it('returns "task" for TaskCreate', () => {
+    expect(getToolCategory('TaskCreate')).toBe('task');
+  });
+
+  it('returns "task" for TaskUpdate', () => {
+    expect(getToolCategory('TaskUpdate')).toBe('task');
+  });
+
+  it('returns "task" for TodoWrite', () => {
+    expect(getToolCategory('TodoWrite')).toBe('task');
+  });
+
+  it('returns "mcp" for mcp__ prefixed tools', () => {
+    expect(getToolCategory('mcp__linear-server__get_issue')).toBe('mcp');
+  });
+
+  it('returns "default" for unknown tools', () => {
+    expect(getToolCategory('CustomTool')).toBe('default');
   });
 });

--- a/web/src/modules/shared/components/SessionChat/ToolBlock/toolLabels.ts
+++ b/web/src/modules/shared/components/SessionChat/ToolBlock/toolLabels.ts
@@ -20,3 +20,34 @@ export function getToolLabel(toolName: string): string {
   }
   return toolName;
 }
+
+export type ToolCategory =
+  | 'terminal'
+  | 'file'
+  | 'search'
+  | 'web'
+  | 'agent'
+  | 'task'
+  | 'mcp'
+  | 'default';
+
+const TOOL_CATEGORY_MAP: Record<string, ToolCategory> = {
+  Bash: 'terminal',
+  Read: 'file',
+  Write: 'file',
+  Edit: 'file',
+  Glob: 'search',
+  Grep: 'search',
+  WebSearch: 'web',
+  WebFetch: 'web',
+  Agent: 'agent',
+  TaskCreate: 'task',
+  TaskUpdate: 'task',
+  TodoWrite: 'task',
+};
+
+export function getToolCategory(toolName: string): ToolCategory {
+  if (TOOL_CATEGORY_MAP[toolName]) return TOOL_CATEGORY_MAP[toolName];
+  if (toolName.startsWith('mcp__')) return 'mcp';
+  return 'default';
+}

--- a/web/src/modules/shared/components/SessionChat/compressImage.test.ts
+++ b/web/src/modules/shared/components/SessionChat/compressImage.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { compressImage } from './compressImage';
+
+describe('compressImage', () => {
+  const mockClose = vi.fn();
+  const mockConvertToBlob = vi.fn();
+  const mockDrawImage = vi.fn();
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    // Mock createImageBitmap
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn().mockResolvedValue({
+        width: 800,
+        height: 600,
+        close: mockClose,
+      }),
+    );
+
+    // Mock OffscreenCanvas as a class
+    class MockOffscreenCanvas {
+      width: number;
+      height: number;
+      constructor(w: number, h: number) {
+        this.width = w;
+        this.height = h;
+      }
+      getContext() {
+        return { drawImage: mockDrawImage };
+      }
+      convertToBlob(...args: unknown[]) {
+        return mockConvertToBlob(...args);
+      }
+    }
+    vi.stubGlobal('OffscreenCanvas', MockOffscreenCanvas);
+  });
+
+  it('compresses an image and returns blob + previewUrl', async () => {
+    const smallBlob = new Blob(['x'], { type: 'image/jpeg' });
+    mockConvertToBlob.mockResolvedValue(smallBlob);
+    vi.stubGlobal('URL', {
+      createObjectURL: vi.fn().mockReturnValue('blob:preview-123'),
+      revokeObjectURL: vi.fn(),
+    });
+
+    const file = new File(['data'], 'photo.jpg', { type: 'image/jpeg' });
+    const result = await compressImage(file);
+
+    expect(result.blob).toBe(smallBlob);
+    expect(result.previewUrl).toBe('blob:preview-123');
+    expect(mockClose).toHaveBeenCalled();
+  });
+
+  it('downscales images larger than 1280px', async () => {
+    vi.stubGlobal(
+      'createImageBitmap',
+      vi.fn().mockResolvedValue({
+        width: 2560,
+        height: 1920,
+        close: mockClose,
+      }),
+    );
+
+    const smallBlob = new Blob(['x'], { type: 'image/jpeg' });
+    mockConvertToBlob.mockResolvedValue(smallBlob);
+    vi.stubGlobal('URL', {
+      createObjectURL: vi.fn().mockReturnValue('blob:url'),
+      revokeObjectURL: vi.fn(),
+    });
+
+    const file = new File(['data'], 'large.jpg', { type: 'image/jpeg' });
+    await compressImage(file);
+
+    // Canvas should have drawn the image (confirming it got created)
+    expect(mockDrawImage).toHaveBeenCalled();
+    expect(mockConvertToBlob).toHaveBeenCalled();
+  });
+
+  it('retries with lower quality if blob exceeds 300KB', async () => {
+    const largeBlobData = new Uint8Array(400 * 1024);
+    const largeBlob = new Blob([largeBlobData], { type: 'image/jpeg' });
+    const smallBlob = new Blob(['small'], { type: 'image/jpeg' });
+
+    mockConvertToBlob
+      .mockResolvedValueOnce(largeBlob)
+      .mockResolvedValueOnce(smallBlob);
+
+    vi.stubGlobal('URL', {
+      createObjectURL: vi.fn().mockReturnValue('blob:url'),
+      revokeObjectURL: vi.fn(),
+    });
+
+    const file = new File(['data'], 'big.jpg', { type: 'image/jpeg' });
+    const result = await compressImage(file);
+
+    expect(mockConvertToBlob).toHaveBeenCalledTimes(2);
+    expect(result.blob).toBe(smallBlob);
+  });
+
+  it('throws when canvas context is null', async () => {
+    class NullCtxCanvas {
+      width: number;
+      height: number;
+      constructor(w: number, h: number) {
+        this.width = w;
+        this.height = h;
+      }
+      getContext() {
+        return null;
+      }
+      convertToBlob() {
+        return Promise.resolve(new Blob());
+      }
+    }
+    vi.stubGlobal('OffscreenCanvas', NullCtxCanvas);
+
+    const file = new File(['data'], 'test.jpg', { type: 'image/jpeg' });
+    await expect(compressImage(file)).rejects.toThrow('Failed to get canvas context');
+  });
+});

--- a/web/src/modules/shared/components/SessionChat/compressImage.test.ts
+++ b/web/src/modules/shared/components/SessionChat/compressImage.test.ts
@@ -16,7 +16,7 @@ describe('compressImage', () => {
         width: 800,
         height: 600,
         close: mockClose,
-      }),
+      })
     );
 
     // Mock OffscreenCanvas as a class
@@ -60,7 +60,7 @@ describe('compressImage', () => {
         width: 2560,
         height: 1920,
         close: mockClose,
-      }),
+      })
     );
 
     const smallBlob = new Blob(['x'], { type: 'image/jpeg' });
@@ -83,9 +83,7 @@ describe('compressImage', () => {
     const largeBlob = new Blob([largeBlobData], { type: 'image/jpeg' });
     const smallBlob = new Blob(['small'], { type: 'image/jpeg' });
 
-    mockConvertToBlob
-      .mockResolvedValueOnce(largeBlob)
-      .mockResolvedValueOnce(smallBlob);
+    mockConvertToBlob.mockResolvedValueOnce(largeBlob).mockResolvedValueOnce(smallBlob);
 
     vi.stubGlobal('URL', {
       createObjectURL: vi.fn().mockReturnValue('blob:url'),

--- a/web/src/modules/shared/components/SessionChat/compressImage.ts
+++ b/web/src/modules/shared/components/SessionChat/compressImage.ts
@@ -1,0 +1,45 @@
+const MAX_DIMENSION = 1280;
+const INITIAL_QUALITY = 0.85;
+const FALLBACK_QUALITY = 0.5;
+const TARGET_SIZE_BYTES = 300 * 1024; // 300KB
+
+/**
+ * Compress an image File using canvas-based JPEG compression.
+ * Resizes to fit within MAX_DIMENSION, then tries INITIAL_QUALITY.
+ * If still above TARGET_SIZE_BYTES, falls back to FALLBACK_QUALITY.
+ *
+ * Returns the compressed blob and a preview data-URL.
+ */
+export async function compressImage(
+  file: File,
+): Promise<{ blob: Blob; previewUrl: string }> {
+  const bitmap = await createImageBitmap(file);
+  const { width, height } = bitmap;
+
+  let targetWidth = width;
+  let targetHeight = height;
+
+  if (width > MAX_DIMENSION || height > MAX_DIMENSION) {
+    const scale = MAX_DIMENSION / Math.max(width, height);
+    targetWidth = Math.round(width * scale);
+    targetHeight = Math.round(height * scale);
+  }
+
+  const canvas = new OffscreenCanvas(targetWidth, targetHeight);
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    throw new Error('Failed to get canvas context');
+  }
+  ctx.drawImage(bitmap, 0, 0, targetWidth, targetHeight);
+  bitmap.close();
+
+  let blob = await canvas.convertToBlob({ type: 'image/jpeg', quality: INITIAL_QUALITY });
+
+  if (blob.size > TARGET_SIZE_BYTES) {
+    blob = await canvas.convertToBlob({ type: 'image/jpeg', quality: FALLBACK_QUALITY });
+  }
+
+  const previewUrl = URL.createObjectURL(blob);
+
+  return { blob, previewUrl };
+}

--- a/web/src/modules/shared/components/SessionChat/compressImage.ts
+++ b/web/src/modules/shared/components/SessionChat/compressImage.ts
@@ -10,9 +10,7 @@ const TARGET_SIZE_BYTES = 300 * 1024; // 300KB
  *
  * Returns the compressed blob and a preview data-URL.
  */
-export async function compressImage(
-  file: File,
-): Promise<{ blob: Blob; previewUrl: string }> {
+export async function compressImage(file: File): Promise<{ blob: Blob; previewUrl: string }> {
   const bitmap = await createImageBitmap(file);
   const { width, height } = bitmap;
 

--- a/web/src/modules/shared/components/SessionChat/useFileAttachments.test.ts
+++ b/web/src/modules/shared/components/SessionChat/useFileAttachments.test.ts
@@ -166,9 +166,7 @@ describe('useFileAttachments', () => {
     await act(async () => {
       await result.current.handlePaste({
         clipboardData: {
-          items: [
-            { kind: 'string', getAsFile: () => null },
-          ],
+          items: [{ kind: 'string', getAsFile: () => null }],
         },
       } as unknown as React.ClipboardEvent);
     });

--- a/web/src/modules/shared/components/SessionChat/useFileAttachments.test.ts
+++ b/web/src/modules/shared/components/SessionChat/useFileAttachments.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useFileAttachments } from './useFileAttachments';
+
+vi.mock('./compressImage', () => ({
+  compressImage: vi.fn().mockResolvedValue({
+    blob: new Blob(['compressed'], { type: 'image/jpeg' }),
+    previewUrl: 'blob:preview-mock',
+  }),
+}));
+
+beforeEach(() => {
+  vi.stubGlobal('URL', {
+    createObjectURL: vi.fn().mockReturnValue('blob:url'),
+    revokeObjectURL: vi.fn(),
+  });
+});
+
+describe('useFileAttachments', () => {
+  it('starts with empty attachments and not dragging', () => {
+    const { result } = renderHook(() => useFileAttachments());
+    expect(result.current.attachments).toEqual([]);
+    expect(result.current.isDragging).toBe(false);
+  });
+
+  it('addFiles adds non-image files without preview', async () => {
+    const { result } = renderHook(() => useFileAttachments());
+    const file = new File(['content'], 'readme.md', { type: 'text/markdown' });
+
+    await act(async () => {
+      await result.current.addFiles([file]);
+    });
+
+    expect(result.current.attachments).toHaveLength(1);
+    expect(result.current.attachments[0].name).toBe('readme.md');
+    expect(result.current.attachments[0].previewUrl).toBeNull();
+    expect(result.current.attachments[0].compressed).toBeNull();
+  });
+
+  it('addFiles processes image files with compression', async () => {
+    const { result } = renderHook(() => useFileAttachments());
+    const file = new File(['img'], 'photo.jpg', { type: 'image/jpeg' });
+
+    await act(async () => {
+      await result.current.addFiles([file]);
+    });
+
+    expect(result.current.attachments).toHaveLength(1);
+    expect(result.current.attachments[0].name).toBe('photo.jpg');
+    expect(result.current.attachments[0].previewUrl).toBe('blob:preview-mock');
+    expect(result.current.attachments[0].compressed).toBeTruthy();
+  });
+
+  it('removeAttachment removes by id and revokes preview URL', async () => {
+    const { result } = renderHook(() => useFileAttachments());
+    const file = new File(['img'], 'photo.jpg', { type: 'image/jpeg' });
+
+    await act(async () => {
+      await result.current.addFiles([file]);
+    });
+
+    const id = result.current.attachments[0].id;
+
+    act(() => {
+      result.current.removeAttachment(id);
+    });
+
+    expect(result.current.attachments).toHaveLength(0);
+    expect(URL.revokeObjectURL).toHaveBeenCalled();
+  });
+
+  it('clearAttachments removes all and revokes URLs', async () => {
+    const { result } = renderHook(() => useFileAttachments());
+    const file1 = new File(['img1'], 'a.jpg', { type: 'image/jpeg' });
+    const file2 = new File(['txt'], 'b.txt', { type: 'text/plain' });
+
+    await act(async () => {
+      await result.current.addFiles([file1, file2]);
+    });
+
+    expect(result.current.attachments).toHaveLength(2);
+
+    act(() => {
+      result.current.clearAttachments();
+    });
+
+    expect(result.current.attachments).toHaveLength(0);
+  });
+
+  it('handleDragOver sets isDragging to true', () => {
+    const { result } = renderHook(() => useFileAttachments());
+
+    act(() => {
+      result.current.handleDragOver({
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+      } as unknown as React.DragEvent);
+    });
+
+    expect(result.current.isDragging).toBe(true);
+  });
+
+  it('handleDragLeave sets isDragging to false', () => {
+    const { result } = renderHook(() => useFileAttachments());
+
+    act(() => {
+      result.current.handleDragOver({
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+      } as unknown as React.DragEvent);
+    });
+
+    expect(result.current.isDragging).toBe(true);
+
+    act(() => {
+      result.current.handleDragLeave({
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+      } as unknown as React.DragEvent);
+    });
+
+    expect(result.current.isDragging).toBe(false);
+  });
+
+  it('handleDrop processes dropped files', async () => {
+    const { result } = renderHook(() => useFileAttachments());
+    const file = new File(['data'], 'dropped.txt', { type: 'text/plain' });
+
+    await act(async () => {
+      await result.current.handleDrop({
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        dataTransfer: { files: [file] as unknown as FileList },
+      } as unknown as React.DragEvent);
+    });
+
+    expect(result.current.attachments).toHaveLength(1);
+    expect(result.current.attachments[0].name).toBe('dropped.txt');
+    expect(result.current.isDragging).toBe(false);
+  });
+
+  it('handlePaste processes pasted files', async () => {
+    const { result } = renderHook(() => useFileAttachments());
+    const file = new File(['data'], 'pasted.png', { type: 'image/png' });
+
+    await act(async () => {
+      await result.current.handlePaste({
+        clipboardData: {
+          items: [
+            {
+              kind: 'file',
+              getAsFile: () => file,
+            },
+          ],
+        },
+      } as unknown as React.ClipboardEvent);
+    });
+
+    expect(result.current.attachments).toHaveLength(1);
+    expect(result.current.attachments[0].name).toBe('pasted.png');
+  });
+
+  it('handlePaste ignores non-file items', async () => {
+    const { result } = renderHook(() => useFileAttachments());
+
+    await act(async () => {
+      await result.current.handlePaste({
+        clipboardData: {
+          items: [
+            { kind: 'string', getAsFile: () => null },
+          ],
+        },
+      } as unknown as React.ClipboardEvent);
+    });
+
+    expect(result.current.attachments).toHaveLength(0);
+  });
+
+  it('handles missing clipboardData gracefully', async () => {
+    const { result } = renderHook(() => useFileAttachments());
+
+    await act(async () => {
+      await result.current.handlePaste({
+        clipboardData: null,
+      } as unknown as React.ClipboardEvent);
+    });
+
+    expect(result.current.attachments).toHaveLength(0);
+  });
+});

--- a/web/src/modules/shared/components/SessionChat/useFileAttachments.test.ts
+++ b/web/src/modules/shared/components/SessionChat/useFileAttachments.test.ts
@@ -139,12 +139,14 @@ describe('useFileAttachments', () => {
     expect(result.current.isDragging).toBe(false);
   });
 
-  it('handlePaste processes pasted files', async () => {
+  it('handlePaste processes pasted files and calls preventDefault', async () => {
     const { result } = renderHook(() => useFileAttachments());
     const file = new File(['data'], 'pasted.png', { type: 'image/png' });
+    const preventDefault = vi.fn();
 
     await act(async () => {
       await result.current.handlePaste({
+        preventDefault,
         clipboardData: {
           items: [
             {
@@ -158,6 +160,7 @@ describe('useFileAttachments', () => {
 
     expect(result.current.attachments).toHaveLength(1);
     expect(result.current.attachments[0].name).toBe('pasted.png');
+    expect(preventDefault).toHaveBeenCalled();
   });
 
   it('handlePaste ignores non-file items', async () => {

--- a/web/src/modules/shared/components/SessionChat/useFileAttachments.ts
+++ b/web/src/modules/shared/components/SessionChat/useFileAttachments.ts
@@ -1,4 +1,11 @@
-import { useState, useCallback, useEffect, useRef, type DragEvent, type ClipboardEvent } from 'react';
+import {
+  useState,
+  useCallback,
+  useEffect,
+  useRef,
+  type DragEvent,
+  type ClipboardEvent,
+} from 'react';
 import { compressImage } from './compressImage';
 
 export interface FileAttachment {
@@ -113,7 +120,7 @@ export function useFileAttachments(): UseFileAttachmentsReturn {
         await addFiles(files);
       }
     },
-    [addFiles],
+    [addFiles]
   );
 
   const handlePaste = useCallback(
@@ -135,7 +142,7 @@ export function useFileAttachments(): UseFileAttachmentsReturn {
         await addFiles(imageFiles);
       }
     },
-    [addFiles],
+    [addFiles]
   );
 
   return {

--- a/web/src/modules/shared/components/SessionChat/useFileAttachments.ts
+++ b/web/src/modules/shared/components/SessionChat/useFileAttachments.ts
@@ -139,6 +139,7 @@ export function useFileAttachments(): UseFileAttachmentsReturn {
       }
 
       if (imageFiles.length > 0) {
+        e.preventDefault();
         await addFiles(imageFiles);
       }
     },

--- a/web/src/modules/shared/components/SessionChat/useFileAttachments.ts
+++ b/web/src/modules/shared/components/SessionChat/useFileAttachments.ts
@@ -1,0 +1,152 @@
+import { useState, useCallback, useEffect, useRef, type DragEvent, type ClipboardEvent } from 'react';
+import { compressImage } from './compressImage';
+
+export interface FileAttachment {
+  id: string;
+  file: File;
+  name: string;
+  previewUrl: string | null;
+  compressed: Blob | null;
+}
+
+interface UseFileAttachmentsReturn {
+  attachments: FileAttachment[];
+  isDragging: boolean;
+  addFiles: (files: FileList | File[]) => Promise<void>;
+  removeAttachment: (id: string) => void;
+  clearAttachments: () => void;
+  handleDragOver: (e: DragEvent) => void;
+  handleDragLeave: (e: DragEvent) => void;
+  handleDrop: (e: DragEvent) => Promise<void>;
+  handlePaste: (e: ClipboardEvent) => Promise<void>;
+}
+
+function isImageFile(file: File): boolean {
+  return file.type.startsWith('image/');
+}
+
+function generateId(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+export function useFileAttachments(): UseFileAttachmentsReturn {
+  const [attachments, setAttachments] = useState<FileAttachment[]>([]);
+  const [isDragging, setIsDragging] = useState(false);
+  const previewUrlsRef = useRef<string[]>([]);
+
+  // Clean up preview URLs on unmount
+  useEffect(() => {
+    return () => {
+      for (const url of previewUrlsRef.current) {
+        URL.revokeObjectURL(url);
+      }
+    };
+  }, []);
+
+  const addFiles = useCallback(async (files: FileList | File[]) => {
+    const fileArray = Array.from(files);
+    const newAttachments: FileAttachment[] = [];
+
+    for (const file of fileArray) {
+      const id = generateId();
+
+      if (isImageFile(file)) {
+        try {
+          const { blob, previewUrl } = await compressImage(file);
+          previewUrlsRef.current.push(previewUrl);
+          newAttachments.push({ id, file, name: file.name, previewUrl, compressed: blob });
+        } catch {
+          // Compression failed — attach original without preview
+          newAttachments.push({ id, file, name: file.name, previewUrl: null, compressed: null });
+        }
+      } else {
+        newAttachments.push({ id, file, name: file.name, previewUrl: null, compressed: null });
+      }
+    }
+
+    setAttachments(prev => [...prev, ...newAttachments]);
+  }, []);
+
+  const removeAttachment = useCallback((id: string) => {
+    setAttachments(prev => {
+      const removed = prev.find(a => a.id === id);
+      if (removed?.previewUrl) {
+        URL.revokeObjectURL(removed.previewUrl);
+        previewUrlsRef.current = previewUrlsRef.current.filter(u => u !== removed.previewUrl);
+      }
+      return prev.filter(a => a.id !== id);
+    });
+  }, []);
+
+  const clearAttachments = useCallback(() => {
+    setAttachments(prev => {
+      for (const a of prev) {
+        if (a.previewUrl) {
+          URL.revokeObjectURL(a.previewUrl);
+        }
+      }
+      previewUrlsRef.current = [];
+      return [];
+    });
+  }, []);
+
+  const handleDragOver = useCallback((e: DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragging(false);
+  }, []);
+
+  const handleDrop = useCallback(
+    async (e: DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setIsDragging(false);
+
+      const files = e.dataTransfer?.files;
+      if (files && files.length > 0) {
+        await addFiles(files);
+      }
+    },
+    [addFiles],
+  );
+
+  const handlePaste = useCallback(
+    async (e: ClipboardEvent) => {
+      const items = e.clipboardData?.items;
+      if (!items) return;
+
+      const imageFiles: File[] = [];
+      for (const item of Array.from(items)) {
+        if (item.kind === 'file') {
+          const file = item.getAsFile();
+          if (file) {
+            imageFiles.push(file);
+          }
+        }
+      }
+
+      if (imageFiles.length > 0) {
+        await addFiles(imageFiles);
+      }
+    },
+    [addFiles],
+  );
+
+  return {
+    attachments,
+    isDragging,
+    addFiles,
+    removeAttachment,
+    clearAttachments,
+    handleDragOver,
+    handleDragLeave,
+    handleDrop,
+    handlePaste,
+  };
+}

--- a/web/src/modules/shared/styles/tokens.css
+++ b/web/src/modules/shared/styles/tokens.css
@@ -29,6 +29,16 @@
   --color-accent-yellow: #eab308;
   --color-accent-blue: #3b82f6;
 
+  /* Tool category colors — overridable per-theme */
+  --color-tool-terminal: var(--color-accent-amber);
+  --color-tool-file: var(--color-accent-indigo);
+  --color-tool-search: var(--color-accent-emerald);
+  --color-tool-web: var(--color-accent-cyan);
+  --color-tool-agent: var(--color-accent-purple);
+  --color-tool-task: var(--color-accent-orange);
+  --color-tool-mcp: var(--color-accent-blue);
+  --color-tool-default: var(--color-brand);
+
   /* Typography */
   --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
   --font-mono: 'JetBrains Mono', 'Fira Code', monospace;


### PR DESCRIPTION
## Summary

- **Tool call color-coding**: Added `--color-tool-*` CSS custom properties in `tokens.css` with category-based color coding (terminal=amber, file=indigo, search=emerald, web=cyan, agent=purple, task=orange, mcp=blue). Tools display `data-tool-category` attributes with matching border tints, icon colors, and hover backgrounds.
- **Hover-reveal message actions**: Action bar hidden by default, revealed on hover. Added bookmark toggle button. Mobile keeps actions always visible.
- **Better thinking blocks**: Compact pill trigger with purple accent tint and `border-radius: full`. Expanded content scrollable with `max-height: 300px`.
- **Enhanced code blocks**: Toggleable line numbers (CSS grid), word-wrap toggle, auto-collapse for >25 lines with gradient fade and "Show all N lines" button.
- **Scroll-to-bottom button**: Updated from `--color-accent-purple` to `--color-brand`.
- **File attachments on input**: `compressImage.ts` (canvas JPEG compression, max 1280px), `useFileAttachments.ts` hook (drag/paste/preview/cleanup), thumbnail previews in attachment chips.

## Test plan

- [x] `npx tsc --noEmit` — type-check passes
- [x] `npx eslint .` — zero warnings
- [x] `npx vitest run` — 2916 tests pass (42 new tests added, 401 SessionChat tests total)
- [ ] Manual: hover over assistant message to reveal action bar
- [ ] Manual: click bookmark toggle on/off
- [ ] Manual: paste code block >25 lines, verify collapse + "Show all" button
- [ ] Manual: verify tool call badges show category colors
- [ ] Manual: drag-drop an image file onto chat input
- [ ] Manual: scroll-to-bottom button uses brand color

🤖 Generated with [Claude Code](https://claude.com/claude-code)