### PR TITLE
docs: fix local dev onboarding documentation

### DIFF
--- a/docs/site/getting-started/configuration.md
+++ b/docs/site/getting-started/configuration.md
@@ -2,14 +2,38 @@
 
 Volundr loads configuration from YAML with environment variable overrides.
 
-## Config file locations
+## Local mode (CLI)
+
+If you used `volundr init`, your config lives at `~/.volundr/config.yaml`. The wizard sets up everything you need. You can edit it directly or use:
+
+```bash
+volundr config get database.host
+volundr config set database.host localhost
+```
+
+The most common settings to change for local development:
+
+| Setting | Where | What it does |
+|---------|-------|-------------|
+| Anthropic API key | `volundr init` wizard | Powers the AI agent |
+| GitHub token | `volundr init` wizard | Repo access |
+| Database mode | `volundr init` wizard | `embedded` (default) bundles PostgreSQL |
+| Runtime | `volundr init` wizard | `local`, `docker`, or `k3s` |
+
+For most local users, the defaults from `volundr init` are sufficient. The full reference below is primarily for server deployments and advanced configuration.
+
+---
+
+## Server / advanced configuration
+
+### Config file locations
 
 Files are checked in order — first found wins:
 
 1. `./config.yaml`
 2. `/etc/volundr/config.yaml`
 
-## Environment variable overrides
+### Environment variable overrides
 
 Use double underscores for nesting. Environment variables take precedence over YAML.
 
@@ -20,7 +44,7 @@ GIT__GITHUB__TOKEN=ghp_xxxx
 EVENT_PIPELINE__RABBITMQ__ENABLED=true
 ```
 
-## Priority order
+### Priority order
 
 1. Constructor arguments (for testing)
 2. Environment variables

--- a/docs/site/getting-started/first-session.md
+++ b/docs/site/getting-started/first-session.md
@@ -112,19 +112,22 @@ A chronicle is created automatically, same as the web UI.
 
 ## What happens under the hood
 
-When you launch a session, Volundr creates a Kubernetes pod with three main containers:
+When you launch a session, Volundr provisions an isolated workspace with three core components:
 
-| Container | Role |
+| Component | Role |
 |-----------|------|
 | **Skuld broker** | Manages the LLM conversation and tool execution |
 | **Code Server** | VS Code in the browser |
 | **Terminal** | Shell access to the workspace |
 
-All three containers share a workspace volume (PVC) where your repo is cloned.
+All three components share a workspace directory where your repo is cloned.
 
-Chat messages go directly from your browser to the Skuld broker inside the pod -- they don't route through the Volundr API server. This keeps latency low and means the API server doesn't need to handle streaming LLM responses.
+Chat messages go directly from your browser to the Skuld broker — they don't route through the Volundr API server. This keeps latency low and means the API server doesn't need to handle streaming LLM responses.
 
 The Volundr API handles lifecycle operations only: creating, starting, stopping, and deleting sessions.
+
+??? note "If using K8s mode (k3s or production)"
+    In Kubernetes modes, each session runs as a pod with the three components above as separate containers. They share a persistent volume claim (PVC) for the workspace. The pod is scheduled by Kubernetes and managed by the Volundr pod manager adapter.
 
 ---
 

--- a/docs/site/getting-started/installation.md
+++ b/docs/site/getting-started/installation.md
@@ -26,7 +26,9 @@ The fastest path. Download a pre-built binary, answer a few questions, and you'r
 ```bash
 # Download from GitHub releases
 # https://github.com/niuulabs/volundr/releases
-curl -fsSL https://github.com/niuulabs/volundr/releases/latest/download/volundr-$(uname -s)-$(uname -m) -o volundr
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m); [ "$ARCH" = "x86_64" ] && ARCH="amd64"; [ "$ARCH" = "aarch64" ] && ARCH="arm64"
+curl -fsSL "https://github.com/niuulabs/volundr/releases/latest/download/volundr-${OS}-${ARCH}" -o volundr
 chmod +x volundr
 sudo mv volundr /usr/local/bin/
 

--- a/docs/site/getting-started/local-quickstart.md
+++ b/docs/site/getting-started/local-quickstart.md
@@ -1,0 +1,191 @@
+# Local Quickstart
+
+Go from zero to a working AI coding session on your machine. No Kubernetes required.
+
+---
+
+## Prerequisites
+
+| Requirement | Why |
+|------------|-----|
+| macOS or Linux | The CLI runs on both platforms (Intel and ARM) |
+| An Anthropic API key | Powers the AI coding agent ([get one here](https://console.anthropic.com/)) |
+| A GitHub personal access token | For cloning private repos ([create one here](https://github.com/settings/tokens)) |
+| `claude` CLI (optional) | Required if you want Claude Code as your session agent |
+
+---
+
+## Step 1: Download the CLI
+
+```bash
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m); [ "$ARCH" = "x86_64" ] && ARCH="amd64"; [ "$ARCH" = "aarch64" ] && ARCH="arm64"
+curl -fsSL "https://github.com/niuulabs/volundr/releases/latest/download/volundr-${OS}-${ARCH}" -o volundr
+chmod +x volundr
+sudo mv volundr /usr/local/bin/
+```
+
+Verify it works:
+
+```bash
+volundr version
+```
+
+Expected output:
+
+```
+volundr version 0.x.x (commit abc1234)
+```
+
+---
+
+## Step 2: Initialize
+
+```bash
+volundr init
+```
+
+The interactive wizard walks you through setup. Here are the prompts and recommended answers for local development:
+
+```
+? Select runtime: local
+? Anthropic API key: sk-ant-xxxxxxxxxxxx
+? Database mode: embedded
+? GitHub personal access token: ghp_xxxxxxxxxxxx
+? GitHub organizations (comma-separated): your-org
+? GitHub API URL: https://api.github.com
+```
+
+| Prompt | What to enter |
+|--------|---------------|
+| **Runtime** | `local` — runs everything as local processes, no containers needed |
+| **Anthropic API key** | Your `sk-ant-...` key from the Anthropic console |
+| **Database mode** | `embedded` — bundles PostgreSQL so you don't need to install it |
+| **GitHub token** | A personal access token with `repo` scope |
+| **GitHub orgs** | Comma-separated list of orgs whose repos you want to access |
+| **GitHub API URL** | `https://api.github.com` (change only for GitHub Enterprise) |
+
+This creates `~/.volundr/config.yaml` and stores your credentials encrypted.
+
+---
+
+## Step 3: Start Volundr
+
+```bash
+volundr up
+```
+
+Volundr starts three services:
+
+```
+SERVICE      STATE    PID    PORT
+postgresql   running  1234   5432
+api-server   running  1235   8080
+proxy        running  1236   8443
+```
+
+Wait until all services show `running`. The web UI is available at [http://localhost:8080](http://localhost:8080).
+
+!!! note
+    The web UI is embedded in the proxy server. If port 8080 is already in use, see [Troubleshooting](troubleshooting.md#port-already-in-use).
+
+---
+
+## Step 4: Create your first session
+
+### Option A: Web UI
+
+1. Open [http://localhost:8080](http://localhost:8080) in your browser.
+2. Click **New Session**.
+3. Pick a template or use the default.
+4. Fill in:
+    - **Name**: `my-first-session`
+    - **Repository URL**: `your-org/your-repo`
+    - **Branch**: `main` (or any branch)
+5. Click **Launch**.
+
+### Option B: CLI
+
+```bash
+volundr sessions create \
+  --name my-first-session \
+  --repo your-org/your-repo \
+  --model claude-sonnet-4
+```
+
+Then start it:
+
+```bash
+volundr sessions start <session-id>
+```
+
+---
+
+## Step 5: Watch it start
+
+The session transitions through these states:
+
+```
+CREATED → STARTING → PROVISIONING → RUNNING
+```
+
+This takes 10–30 seconds depending on repo size.
+
+---
+
+## Step 6: Start coding
+
+Once the session is `RUNNING`:
+
+- **Web UI**: The **Chat** tab opens. Type a message to start working with the AI agent.
+- **CLI TUI**: Run `volundr` (no arguments) to launch the terminal UI. Use `Alt+2` for the chat view.
+
+The session gives you:
+
+| Feature | Description |
+|---------|-------------|
+| **Chat** | Conversation with the AI coding agent |
+| **Terminal** | Full shell access to the workspace |
+| **Code** | VS Code editor (Code Server) |
+| **Diffs** | See what the agent changed |
+| **Chronicles** | Session history and summaries |
+
+---
+
+## Step 7: Stop the session
+
+When you're done:
+
+- **Web UI**: Click **Stop**.
+- **CLI**: `volundr sessions stop <session-id>`
+
+A chronicle is automatically created — a summary of what happened, the changes made, and the conversation history.
+
+To shut down all Volundr services:
+
+```bash
+volundr down
+```
+
+---
+
+## Local mode vs K8s modes
+
+| Feature | Local (`local`) | Docker (`docker`) | K3s (`k3s`) | Production K8s |
+|---------|:-:|:-:|:-:|:-:|
+| No dependencies needed | Yes | Docker required | k3s required | Full cluster |
+| Embedded PostgreSQL | Yes | Yes | Helm chart | External |
+| Multiple concurrent sessions | Limited | Yes | Yes | Yes |
+| Resource isolation | No | Container-level | Pod-level | Pod-level |
+| Persistent volumes | Local filesystem | Docker volumes | PVCs | PVCs |
+| Gateway/routing | Reverse proxy | Reverse proxy | Ingress | Ingress + Gateway API |
+| Auth (OIDC) | Disabled (AllowAll) | Disabled | Optional | Required |
+| Best for | Trying it out, solo dev | Local dev with isolation | Full-stack local testing | Teams, production |
+
+---
+
+## Next steps
+
+- [Troubleshooting](troubleshooting.md) — common errors and how to fix them
+- [Configuration](configuration.md) — customize models, integrations, and adapters
+- [CLI Reference](../user-guide/cli.md) — full command reference

--- a/docs/site/getting-started/quick-start.md
+++ b/docs/site/getting-started/quick-start.md
@@ -14,7 +14,9 @@ Grab the latest binary from [GitHub Releases](https://github.com/niuulabs/volund
 
 ```bash
 # macOS / Linux
-curl -fsSL https://github.com/niuulabs/volundr/releases/latest/download/volundr-$(uname -s)-$(uname -m) -o volundr
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m); [ "$ARCH" = "x86_64" ] && ARCH="amd64"; [ "$ARCH" = "aarch64" ] && ARCH="arm64"
+curl -fsSL "https://github.com/niuulabs/volundr/releases/latest/download/volundr-${OS}-${ARCH}" -o volundr
 chmod +x volundr
 sudo mv volundr /usr/local/bin/
 ```

--- a/docs/site/getting-started/troubleshooting.md
+++ b/docs/site/getting-started/troubleshooting.md
@@ -1,0 +1,233 @@
+# Troubleshooting
+
+Common issues when running Volundr locally and how to fix them.
+
+---
+
+## `claude` binary not found
+
+**Symptom**: Session starts but the AI agent fails to respond, or logs show `claude: command not found`.
+
+**Cause**: The `claude` CLI is not installed or not on your `PATH`.
+
+**Fix**:
+
+```bash
+# Check if claude is installed
+which claude
+
+# If not found, install it (see https://docs.anthropic.com/en/docs/claude-code)
+npm install -g @anthropic-ai/claude-code
+
+# Verify
+claude --version
+```
+
+If `claude` is installed but in a non-standard location, make sure it's on your `PATH`:
+
+```bash
+export PATH="$PATH:/path/to/claude/directory"
+```
+
+---
+
+## API key invalid or missing
+
+**Symptom**: Sessions fail to start, logs show authentication errors or `401 Unauthorized` from the Anthropic API.
+
+**Cause**: The Anthropic API key is missing, expired, or incorrect.
+
+**Fix**:
+
+```bash
+# Re-run init to update the key
+volundr init
+
+# Or edit the config directly
+volundr config set anthropic.api_key sk-ant-your-new-key
+```
+
+Verify your key works:
+
+```bash
+curl -s https://api.anthropic.com/v1/messages \
+  -H "x-api-key: sk-ant-your-key" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "content-type: application/json" \
+  -d '{"model":"claude-haiku-4-5-20251001","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}'
+```
+
+---
+
+## Port already in use
+
+**Symptom**: `volundr up` fails with `address already in use` or `EADDRINUSE` on port 8080 or 5432.
+
+**Cause**: Another process is using the port Volundr needs.
+
+**Fix**:
+
+```bash
+# Find what's using port 8080
+lsof -i :8080
+
+# Or on Linux
+ss -tlnp | grep 8080
+```
+
+Then either stop the conflicting process or configure Volundr to use a different port. If port 5432 is in use, you likely have another PostgreSQL instance running:
+
+```bash
+# Check for existing PostgreSQL
+lsof -i :5432
+
+# Stop a Homebrew PostgreSQL (macOS)
+brew services stop postgresql
+
+# Stop a system PostgreSQL (Linux)
+sudo systemctl stop postgresql
+```
+
+---
+
+## Session stuck in PROVISIONING
+
+**Symptom**: A session stays in `PROVISIONING` state and never transitions to `RUNNING`.
+
+**Cause**: The workspace setup is taking too long or failed silently. Common reasons:
+
+- Git clone is slow or failing (see below)
+- Setup scripts in the template are failing
+- Insufficient disk space
+
+**Fix**:
+
+```bash
+# Check session status for error details
+volundr sessions list --json | jq '.[] | select(.state == "PROVISIONING")'
+
+# Check the Volundr API server logs (visible in the terminal where you ran `volundr up`)
+```
+
+If the session is permanently stuck, delete it and create a new one:
+
+```bash
+volundr sessions delete <session-id>
+```
+
+If this happens repeatedly, check disk space:
+
+```bash
+df -h
+```
+
+---
+
+## Git clone fails
+
+**Symptom**: Session creation fails with git-related errors.
+
+### Authentication errors
+
+**Cause**: GitHub token is missing, expired, or lacks the `repo` scope.
+
+**Fix**:
+
+```bash
+# Test your token
+curl -s -H "Authorization: token ghp_your-token" https://api.github.com/user | jq .login
+
+# If it fails, create a new token at https://github.com/settings/tokens
+# Ensure it has the `repo` scope
+
+# Update the token
+volundr init
+```
+
+### Network errors
+
+**Cause**: DNS resolution failure, proxy issues, or firewall blocking GitHub.
+
+**Fix**:
+
+```bash
+# Test connectivity to GitHub
+curl -s https://api.github.com/zen
+
+# If behind a corporate proxy, set the proxy environment variables
+export HTTP_PROXY=http://proxy:8080
+export HTTPS_PROXY=http://proxy:8080
+```
+
+### Repository not found
+
+**Cause**: The repo URL is wrong, or your token doesn't have access to the org.
+
+**Fix**:
+
+- Double-check the repository URL (use `org/repo` format, not the full HTTPS URL)
+- Verify your token has access: `curl -s -H "Authorization: token ghp_..." https://api.github.com/repos/org/repo | jq .full_name`
+- Make sure the org is listed in your Volundr config (`volundr init` asks for orgs)
+
+---
+
+## `volundr up` fails immediately
+
+**Symptom**: `volundr up` exits right after starting.
+
+**Cause**: Usually a configuration issue.
+
+**Fix**:
+
+1. Check that `volundr init` was run first:
+    ```bash
+    ls ~/.volundr/config.yaml
+    ```
+
+2. Try running with debug logging:
+    ```bash
+    VOLUNDR_TUI_DEBUG=1 volundr up
+    ```
+
+3. Check if the embedded PostgreSQL data directory is corrupted:
+    ```bash
+    # Remove the embedded database and reinitialize
+    rm -rf ~/.volundr/data/pg
+    volundr init
+    ```
+
+---
+
+## Web UI not loading
+
+**Symptom**: `volundr up` succeeds but `http://localhost:8080` shows a blank page or connection refused.
+
+**Fix**:
+
+1. Verify services are running:
+    ```bash
+    volundr status
+    ```
+
+2. Check that the proxy service is running and bound to port 8080.
+
+3. Try accessing the API directly:
+    ```bash
+    curl http://localhost:8080/health
+    ```
+    Expected: `{"status": "healthy"}`
+
+4. If the health check works but the page is blank, try a hard refresh (`Ctrl+Shift+R`) or clear your browser cache.
+
+---
+
+## Getting help
+
+If none of these solutions work:
+
+1. Check the [GitHub Issues](https://github.com/niuulabs/volundr/issues) for similar problems.
+2. Open a new issue with:
+    - Your OS and architecture (`uname -a`)
+    - Volundr version (`volundr version`)
+    - The full error output
+    - Your runtime mode (`local`, `docker`, or `k3s`)

--- a/docs/site/user-guide/cli.md
+++ b/docs/site/user-guide/cli.md
@@ -24,6 +24,7 @@ Start all services — PostgreSQL (if embedded), API server, and reverse proxy. 
 | Flag | Description |
 |------|-------------|
 | `--runtime <runtime>` | Override the configured runtime |
+| `--no-web` | Disable the embedded web UI |
 
 ### `volundr down`
 

--- a/docs/site/user-guide/cli.md
+++ b/docs/site/user-guide/cli.md
@@ -12,7 +12,7 @@ Interactive setup wizard. Walks you through:
 
 - Runtime selection (local, docker, k3s)
 - Anthropic API key
-- Database mode (embedded SQLite or external PostgreSQL)
+- Database mode (embedded PostgreSQL or external PostgreSQL)
 - GitHub/GitLab configuration
 
 Creates `~/.volundr/config.yaml` and stores credentials encrypted.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,11 +45,13 @@ extra_css:
 nav:
   - Home: index.md
   - Getting Started:
+      - Local Quickstart: getting-started/local-quickstart.md
       - Quick Start: getting-started/quick-start.md
       - Installation: getting-started/installation.md
       - Your First Session: getting-started/first-session.md
       - Configuration: getting-started/configuration.md
       - Running: getting-started/running.md
+      - Troubleshooting: getting-started/troubleshooting.md
   - User Guide:
       - Sessions: user-guide/sessions.md
       - Templates & Profiles: user-guide/templates.md


### PR DESCRIPTION
## Summary

- **Fixed binary download URLs** in `quick-start.md` and `installation.md` — the `curl` commands now correctly map `uname -s` (e.g. `Darwin` → `darwin`) and `uname -m` (e.g. `x86_64` → `amd64`) to match actual release artifact names (`volundr-darwin-amd64`, etc.)
- **Fixed "embedded SQLite" → "embedded PostgreSQL"** in `user-guide/cli.md`
- **Created `local-quickstart.md`** — a single end-to-end walkthrough from zero to working session, with exact copy-pasteable commands and expected output
- **Created `troubleshooting.md`** — covers top common errors: `claude` binary not found, API key invalid/missing, port already in use, session stuck in PROVISIONING, git clone fails (auth, network, repo not found)
- **Cleaned up K8s references** in `first-session.md` — replaced "Kubernetes pod with 3 containers" with runtime-agnostic language, gated K8s details behind a collapsible admonition
- **Restructured `configuration.md`** — added a local-mode quick reference section at the top, moved heavy adapter/reference content under a "Server / advanced" heading
- **Added local mode vs K8s comparison table** in the local quickstart
- **Updated `mkdocs.yml` navigation** with new pages

## Test plan

- [ ] Verify download URLs work for all 4 platform/arch combinations
- [ ] Follow the local quickstart end-to-end on a clean machine
- [ ] Confirm all internal doc links resolve correctly
- [ ] Check mkdocs builds without errors (`mkdocs build`)

Closes NIU-325

🤖 Generated with [Claude Code](https://claude.com/claude-code)