### PR TITLE
feat(cli): add prerequisite validation to init and up

### DIFF
--- a/cli/internal/cli/init.go
+++ b/cli/internal/cli/init.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/niuulabs/volundr/cli/internal/config"
+	"github.com/niuulabs/volundr/cli/internal/preflight"
 	"github.com/niuulabs/volundr/cli/internal/runtime"
 )
 
@@ -245,6 +246,11 @@ func runInit(_ *cobra.Command, _ []string) error {
 		fmt.Println("  credentials.enc    ... done")
 	}
 
+	// Run preflight checks (warnings only, do not block).
+	if cfg.Runtime == "local" {
+		runInitPreflight(cfg, apiKey)
+	}
+
 	// Run runtime-specific init.
 	rt := runtime.NewRuntime(cfg.Runtime)
 	ctx := context.Background()
@@ -312,6 +318,32 @@ func installInstructionsForOS(tool, goos, goarch string) string {
 		}
 	default:
 		return ""
+	}
+}
+
+// runInitPreflight runs preflight checks after the init wizard and prints warnings.
+// These are advisory only — they never block init from completing.
+func runInitPreflight(cfg *config.Config, apiKey string) {
+	fmt.Println("\nPreflight checks:")
+
+	// Check claude binary.
+	claudeResult := preflight.CheckBinary("claude", "--version")
+	fmt.Println(preflight.FormatResult(claudeResult))
+
+	// Check API key.
+	credsPath, _ := config.CredentialsPath()
+	apiKeyResult := preflight.CheckAPIKey(apiKey, credsPath)
+	fmt.Println(preflight.FormatResult(apiKeyResult))
+
+	// Check git binary.
+	gitResult := preflight.CheckBinary("git", "--version")
+	fmt.Println(preflight.FormatResult(gitResult))
+
+	// Check workspace directory writable.
+	cfgDir, err := config.ConfigDir()
+	if err == nil {
+		dirResult := preflight.CheckDirWritable(cfgDir)
+		fmt.Println(preflight.FormatResult(dirResult))
 	}
 }
 

--- a/cli/internal/cli/preflight_test.go
+++ b/cli/internal/cli/preflight_test.go
@@ -1,0 +1,187 @@
+package cli
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/niuulabs/volundr/cli/internal/config"
+)
+
+func TestRunInitPreflight(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(config.EnvHome, tmpDir)
+
+	cfg := &config.Config{
+		Runtime: "local",
+		Listen:  config.ListenConfig{Host: "127.0.0.1", Port: 8080},
+	}
+
+	// runInitPreflight only prints warnings, never returns errors.
+	// We just verify it doesn't panic.
+	runInitPreflight(cfg, "test-api-key")
+}
+
+func TestRunInitPreflight_NoAPIKey(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(config.EnvHome, tmpDir)
+
+	cfg := &config.Config{
+		Runtime: "local",
+		Listen:  config.ListenConfig{Host: "127.0.0.1", Port: 8080},
+	}
+
+	// Should still succeed (warnings only).
+	runInitPreflight(cfg, "")
+}
+
+func TestRunUpPreflight_PortInUse(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(config.EnvHome, tmpDir)
+
+	// Bind a port so it's in use.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("bind port: %v", err)
+	}
+	defer ln.Close()
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	cfg := &config.Config{
+		Runtime:   "local",
+		Listen:    config.ListenConfig{Host: "127.0.0.1", Port: port},
+		Anthropic: config.AnthropicConfig{APIKey: "test-key"},
+	}
+
+	err = runUpPreflight(cfg)
+	if err == nil {
+		t.Fatal("expected error for port in use")
+	}
+	if !strings.Contains(err.Error(), "already in use") {
+		t.Errorf("expected 'already in use' error, got: %v", err)
+	}
+}
+
+func TestRunUpPreflight_ClaudeMissing(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(config.EnvHome, tmpDir)
+
+	// Override PATH so claude is not found.
+	t.Setenv("PATH", tmpDir)
+
+	cfg := &config.Config{
+		Runtime:   "local",
+		Listen:    config.ListenConfig{Host: "127.0.0.1", Port: 18999},
+		Anthropic: config.AnthropicConfig{APIKey: "test-key"},
+	}
+
+	err := runUpPreflight(cfg)
+	if err == nil {
+		t.Fatal("expected error for missing claude binary")
+	}
+	if !strings.Contains(err.Error(), "claude") {
+		t.Errorf("expected claude error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "npm install") {
+		t.Errorf("expected remediation hint, got: %v", err)
+	}
+}
+
+func TestRunUpPreflight_APIKeyWarning(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(config.EnvHome, tmpDir)
+
+	// Create a fake claude binary in PATH.
+	fakeBin := filepath.Join(tmpDir, "bin")
+	if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	claudePath := filepath.Join(fakeBin, "claude")
+	if err := os.WriteFile(claudePath, []byte("#!/bin/sh\necho claude 1.0"), 0o755); err != nil {
+		t.Fatalf("write claude: %v", err)
+	}
+	t.Setenv("PATH", fakeBin)
+
+	cfg := &config.Config{
+		Runtime:   "local",
+		Listen:    config.ListenConfig{Host: "127.0.0.1", Port: 18998},
+		Anthropic: config.AnthropicConfig{APIKey: ""},
+	}
+
+	// Should succeed (API key is a soft warning, not a hard failure).
+	err := runUpPreflight(cfg)
+	if err != nil {
+		t.Errorf("expected no error for missing API key (soft warning), got: %v", err)
+	}
+}
+
+func TestRunUpPreflight_AllPass(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(config.EnvHome, tmpDir)
+
+	// Create a fake claude binary.
+	fakeBin := filepath.Join(tmpDir, "bin")
+	if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	claudePath := filepath.Join(fakeBin, "claude")
+	if err := os.WriteFile(claudePath, []byte("#!/bin/sh\necho claude 1.0"), 0o755); err != nil {
+		t.Fatalf("write claude: %v", err)
+	}
+	t.Setenv("PATH", fakeBin)
+
+	// Create credentials.enc so API key check passes.
+	credsPath := filepath.Join(tmpDir, "credentials.enc")
+	if err := os.WriteFile(credsPath, []byte("encrypted"), 0o600); err != nil {
+		t.Fatalf("write creds: %v", err)
+	}
+
+	cfg := &config.Config{
+		Runtime:   "local",
+		Listen:    config.ListenConfig{Host: "127.0.0.1", Port: 18997},
+		Anthropic: config.AnthropicConfig{APIKey: "sk-ant-test"},
+	}
+
+	err := runUpPreflight(cfg)
+	if err != nil {
+		t.Errorf("expected all checks to pass, got: %v", err)
+	}
+}
+
+func TestRunUp_PreflightBlocksPortInUse(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(config.EnvHome, tmpDir)
+
+	// Bind a port.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("bind port: %v", err)
+	}
+	defer ln.Close()
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	// Write config with the occupied port.
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
+	cfgContent := "runtime: local\nlisten:\n  host: 127.0.0.1\n  port: " +
+		strings.TrimSpace(strings.Replace(net.JoinHostPort("", fmt.Sprint(port)), ":", "", 1)) +
+		"\ntls:\n  mode: \"off\"\ndatabase:\n  mode: embedded\n  port: 15432\n  user: volundr\n  password: test\n  name: volundr\n"
+	if err := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	oldRuntimeFlag := runtimeFlag
+	runtimeFlag = ""
+	defer func() { runtimeFlag = oldRuntimeFlag }()
+
+	err = runUp(nil, nil)
+	if err == nil {
+		t.Fatal("expected error for port in use")
+	}
+	// Either port in use or claude missing — both are preflight errors.
+	if !strings.Contains(err.Error(), "already in use") && !strings.Contains(err.Error(), "claude") {
+		t.Errorf("expected preflight error, got: %v", err)
+	}
+}

--- a/cli/internal/cli/up.go
+++ b/cli/internal/cli/up.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/niuulabs/volundr/cli/internal/config"
+	"github.com/niuulabs/volundr/cli/internal/preflight"
 	"github.com/niuulabs/volundr/cli/internal/runtime"
 )
 
@@ -56,6 +57,13 @@ func runUp(_ *cobra.Command, _ []string) error {
 		cfg.Anthropic.APIKey = creds.AnthropicAPIKey
 	}
 
+	// Run preflight validation for local runtime.
+	if cfg.Runtime == "local" {
+		if err := runUpPreflight(cfg); err != nil {
+			return err
+		}
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -89,5 +97,40 @@ func runUp(_ *cobra.Command, _ []string) error {
 	}
 
 	fmt.Println("Stopped.")
+	return nil
+}
+
+// runUpPreflight validates prerequisites before starting the server.
+// Hard failures (port, claude binary) return errors; soft issues (API key) print warnings.
+func runUpPreflight(cfg *config.Config) error {
+	// Hard failure: claude binary must be available.
+	claudeResult := preflight.CheckBinary("claude")
+	if !claudeResult.OK {
+		return fmt.Errorf("%s\n\n%s", claudeResult.Message, preflight.BinaryRemediation("claude"))
+	}
+
+	// Hard failure: configured port must be available.
+	portResult := preflight.CheckPortAvailable(cfg.Listen.Host, cfg.Listen.Port)
+	if !portResult.OK {
+		return fmt.Errorf("%s\n\n%s", portResult.Message, preflight.PortRemediation(cfg.Listen.Host, cfg.Listen.Port))
+	}
+
+	// Hard failure: workspace directory must be writable.
+	cfgDir, err := config.ConfigDir()
+	if err != nil {
+		return fmt.Errorf("get config dir: %w", err)
+	}
+	dirResult := preflight.CheckDirWritable(cfgDir)
+	if !dirResult.OK {
+		return fmt.Errorf("%s", dirResult.Message)
+	}
+
+	// Soft warning: API key.
+	credsPath, _ := config.CredentialsPath()
+	apiKeyResult := preflight.CheckAPIKey(cfg.Anthropic.APIKey, credsPath)
+	if !apiKeyResult.OK {
+		fmt.Printf("\n%s\n", preflight.APIKeyRemediation())
+	}
+
 	return nil
 }

--- a/cli/internal/preflight/checks.go
+++ b/cli/internal/preflight/checks.go
@@ -146,12 +146,7 @@ func BinaryRemediation(name string) string {
 		return `Error: claude binary not found in PATH
 
 The Claude Code CLI is required to run coding sessions.
-Install it with: npm install -g @anthropic-ai/claude-code
-
-Or specify a custom path in ~/.volundr/config.yaml:
-  volundr:
-    forge:
-      claude_binary: /path/to/claude`
+Install it with: npm install -g @anthropic-ai/claude-code`
 	case "git":
 		return `Error: git binary not found in PATH
 
@@ -185,6 +180,5 @@ Another process is using this port. Either:
   1. Stop the process using port %d
   2. Change the port in ~/.volundr/config.yaml:
        listen:
-         port: <new-port>
-  3. Use a different port: volundr up --port <new-port>`, port, host, port)
+         port: <new-port>`, port, host, port)
 }

--- a/cli/internal/preflight/checks.go
+++ b/cli/internal/preflight/checks.go
@@ -1,0 +1,190 @@
+// Package preflight provides reusable prerequisite validation checks
+// for the Volundr CLI init and up commands.
+package preflight
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Result represents the outcome of a single preflight check.
+type Result struct {
+	Name    string // human-readable check name
+	OK      bool
+	Message string // success or failure detail
+}
+
+// CheckBinary verifies that a binary exists on PATH and optionally retrieves its version.
+// versionArgs are passed to the binary to get a version string (e.g. "--version").
+// Returns a Result with the binary path and version if found.
+func CheckBinary(name string, versionArgs ...string) Result {
+	path, err := exec.LookPath(name)
+	if err != nil {
+		return Result{
+			Name:    name + " binary",
+			OK:      false,
+			Message: fmt.Sprintf("%s not found in PATH", name),
+		}
+	}
+
+	version := ""
+	if len(versionArgs) > 0 {
+		cmd := exec.Command(path, versionArgs...) //nolint:gosec // args are caller-provided version flags
+		out, err := cmd.Output()
+		if err == nil {
+			version = strings.TrimSpace(string(out))
+			// Take only the first line if multi-line.
+			if idx := strings.IndexByte(version, '\n'); idx >= 0 {
+				version = version[:idx]
+			}
+		}
+	}
+
+	msg := fmt.Sprintf("found at %s", path)
+	if version != "" {
+		msg = fmt.Sprintf("found at %s (%s)", path, version)
+	}
+
+	return Result{
+		Name:    name + " binary",
+		OK:      true,
+		Message: msg,
+	}
+}
+
+// CheckAPIKey verifies that an Anthropic API key is configured.
+// It checks the provided config value and whether credentials.enc exists.
+func CheckAPIKey(configKey string, credentialsPath string) Result {
+	name := "Anthropic API key"
+
+	if configKey != "" {
+		return Result{Name: name, OK: true, Message: "set in config"}
+	}
+
+	if credentialsPath != "" {
+		if _, err := os.Stat(credentialsPath); err == nil {
+			return Result{Name: name, OK: true, Message: "found in credentials.enc"}
+		}
+	}
+
+	return Result{
+		Name:    name,
+		OK:      false,
+		Message: "not set — sessions will fail without it",
+	}
+}
+
+// CheckPortAvailable verifies that a TCP port is available for binding.
+func CheckPortAvailable(host string, port int) Result {
+	name := fmt.Sprintf("port %d", port)
+	addr := net.JoinHostPort(host, fmt.Sprintf("%d", port))
+
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return Result{
+			Name:    name,
+			OK:      false,
+			Message: fmt.Sprintf("port %d on %s is already in use", port, host),
+		}
+	}
+	_ = ln.Close()
+
+	return Result{
+		Name:    name,
+		OK:      true,
+		Message: fmt.Sprintf("port %d is available", port),
+	}
+}
+
+// CheckDirWritable verifies that a directory is writable by creating a temporary file.
+// If the directory does not exist, it attempts to create it.
+func CheckDirWritable(dir string) Result {
+	name := "workspace directory"
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return Result{
+			Name:    name,
+			OK:      false,
+			Message: fmt.Sprintf("cannot create directory %s: %v", dir, err),
+		}
+	}
+
+	tmpFile := filepath.Join(dir, ".volundr-preflight-check")
+	if err := os.WriteFile(tmpFile, []byte("ok"), 0o600); err != nil {
+		return Result{
+			Name:    name,
+			OK:      false,
+			Message: fmt.Sprintf("directory %s is not writable: %v", dir, err),
+		}
+	}
+	_ = os.Remove(tmpFile)
+
+	return Result{
+		Name:    name,
+		OK:      true,
+		Message: "writable",
+	}
+}
+
+// FormatResult formats a Result as a human-readable line with a check/cross mark.
+func FormatResult(r Result) string {
+	mark := "✓"
+	if !r.OK {
+		mark = "✗"
+	}
+	return fmt.Sprintf("  %s %s — %s", mark, r.Name, r.Message)
+}
+
+// BinaryRemediation returns an actionable error message for a missing binary.
+func BinaryRemediation(name string) string {
+	switch name {
+	case "claude":
+		return `Error: claude binary not found in PATH
+
+The Claude Code CLI is required to run coding sessions.
+Install it with: npm install -g @anthropic-ai/claude-code
+
+Or specify a custom path in ~/.volundr/config.yaml:
+  volundr:
+    forge:
+      claude_binary: /path/to/claude`
+	case "git":
+		return `Error: git binary not found in PATH
+
+Git is required for repository-based sessions.
+Install it with your system package manager:
+  macOS:  brew install git
+  Ubuntu: sudo apt install git
+  Fedora: sudo dnf install git`
+	default:
+		return fmt.Sprintf("Error: %s not found in PATH", name)
+	}
+}
+
+// APIKeyRemediation returns an actionable error message for a missing API key.
+func APIKeyRemediation() string {
+	return `Warning: Anthropic API key not configured
+
+Sessions will fail without an API key.
+Set it by running 'volundr init' or adding to ~/.volundr/config.yaml:
+  anthropic:
+    api_key: sk-ant-...
+
+Or set the ANTHROPIC_API_KEY environment variable.`
+}
+
+// PortRemediation returns an actionable error message for an unavailable port.
+func PortRemediation(host string, port int) string {
+	return fmt.Sprintf(`Error: port %d on %s is already in use
+
+Another process is using this port. Either:
+  1. Stop the process using port %d
+  2. Change the port in ~/.volundr/config.yaml:
+       listen:
+         port: <new-port>
+  3. Use a different port: volundr up --port <new-port>`, port, host, port)
+}

--- a/cli/internal/preflight/checks_test.go
+++ b/cli/internal/preflight/checks_test.go
@@ -1,0 +1,274 @@
+package preflight
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCheckBinary_Found(t *testing.T) {
+	// "go" should always be available in the test environment.
+	result := CheckBinary("go", "version")
+	if !result.OK {
+		t.Errorf("expected go binary to be found, got: %s", result.Message)
+	}
+	if !strings.Contains(result.Message, "found at") {
+		t.Errorf("expected message to contain 'found at', got: %s", result.Message)
+	}
+	if result.Name != "go binary" {
+		t.Errorf("expected name 'go binary', got: %s", result.Name)
+	}
+}
+
+func TestCheckBinary_FoundNoVersion(t *testing.T) {
+	// Check a binary without requesting version.
+	result := CheckBinary("go")
+	if !result.OK {
+		t.Errorf("expected go binary to be found, got: %s", result.Message)
+	}
+	if !strings.Contains(result.Message, "found at") {
+		t.Errorf("expected 'found at' in message, got: %s", result.Message)
+	}
+	// Without version args, message should not contain parentheses with version.
+	if strings.Contains(result.Message, "(go version") {
+		t.Errorf("unexpected version in message without version args: %s", result.Message)
+	}
+}
+
+func TestCheckBinary_NotFound(t *testing.T) {
+	result := CheckBinary("volundr-nonexistent-binary-12345")
+	if result.OK {
+		t.Error("expected binary not found")
+	}
+	if !strings.Contains(result.Message, "not found in PATH") {
+		t.Errorf("expected 'not found in PATH' in message, got: %s", result.Message)
+	}
+}
+
+func TestCheckBinary_FoundVersionFails(t *testing.T) {
+	// "go" with an invalid version flag — binary exists but version extraction fails gracefully.
+	result := CheckBinary("go", "--nonexistent-flag-xyz")
+	if !result.OK {
+		t.Errorf("expected binary to be found even if version fails, got: %s", result.Message)
+	}
+	// Should still report found, just without version.
+	if !strings.Contains(result.Message, "found at") {
+		t.Errorf("expected 'found at' in message, got: %s", result.Message)
+	}
+}
+
+func TestCheckAPIKey_InConfig(t *testing.T) {
+	result := CheckAPIKey("sk-ant-test-key", "")
+	if !result.OK {
+		t.Errorf("expected API key check to pass with config key, got: %s", result.Message)
+	}
+	if !strings.Contains(result.Message, "set in config") {
+		t.Errorf("expected 'set in config' in message, got: %s", result.Message)
+	}
+}
+
+func TestCheckAPIKey_InCredentials(t *testing.T) {
+	tmpDir := t.TempDir()
+	credsPath := filepath.Join(tmpDir, "credentials.enc")
+	if err := os.WriteFile(credsPath, []byte("encrypted"), 0o600); err != nil {
+		t.Fatalf("write creds: %v", err)
+	}
+
+	result := CheckAPIKey("", credsPath)
+	if !result.OK {
+		t.Errorf("expected API key check to pass with credentials file, got: %s", result.Message)
+	}
+	if !strings.Contains(result.Message, "credentials.enc") {
+		t.Errorf("expected 'credentials.enc' in message, got: %s", result.Message)
+	}
+}
+
+func TestCheckAPIKey_Missing(t *testing.T) {
+	result := CheckAPIKey("", "/nonexistent/path/credentials.enc")
+	if result.OK {
+		t.Error("expected API key check to fail when no key is configured")
+	}
+	if !strings.Contains(result.Message, "not set") {
+		t.Errorf("expected 'not set' in message, got: %s", result.Message)
+	}
+}
+
+func TestCheckAPIKey_EmptyCredentialsPath(t *testing.T) {
+	result := CheckAPIKey("", "")
+	if result.OK {
+		t.Error("expected API key check to fail with empty paths")
+	}
+}
+
+func TestCheckPortAvailable_Free(t *testing.T) {
+	// Use port 0 to let the OS assign a free port, then check that port.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("get free port: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+
+	result := CheckPortAvailable("127.0.0.1", port)
+	if !result.OK {
+		t.Errorf("expected port %d to be available, got: %s", port, result.Message)
+	}
+}
+
+func TestCheckPortAvailable_InUse(t *testing.T) {
+	// Bind a port, then check it.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("bind port: %v", err)
+	}
+	defer ln.Close()
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	result := CheckPortAvailable("127.0.0.1", port)
+	if result.OK {
+		t.Errorf("expected port %d to be in use", port)
+	}
+	if !strings.Contains(result.Message, "already in use") {
+		t.Errorf("expected 'already in use' in message, got: %s", result.Message)
+	}
+}
+
+func TestCheckDirWritable_Writable(t *testing.T) {
+	tmpDir := t.TempDir()
+	result := CheckDirWritable(tmpDir)
+	if !result.OK {
+		t.Errorf("expected dir to be writable, got: %s", result.Message)
+	}
+	if result.Message != "writable" {
+		t.Errorf("expected 'writable', got: %s", result.Message)
+	}
+}
+
+func TestCheckDirWritable_CreatesDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	newDir := filepath.Join(tmpDir, "subdir", "nested")
+	result := CheckDirWritable(newDir)
+	if !result.OK {
+		t.Errorf("expected new dir to be created and writable, got: %s", result.Message)
+	}
+	if _, err := os.Stat(newDir); os.IsNotExist(err) {
+		t.Error("expected directory to be created")
+	}
+}
+
+func TestCheckDirWritable_NotWritable(t *testing.T) {
+	tmpDir := t.TempDir()
+	readOnlyDir := filepath.Join(tmpDir, "readonly")
+	if err := os.Mkdir(readOnlyDir, 0o555); err != nil {
+		t.Fatalf("create dir: %v", err)
+	}
+
+	// Try to write inside the read-only dir (should fail on most systems).
+	result := CheckDirWritable(filepath.Join(readOnlyDir, "subdir"))
+	// On some CI systems running as root, this may succeed. Accept either outcome.
+	if result.OK {
+		t.Log("write succeeded (likely running as root), skipping failure assertion")
+		return
+	}
+	if result.Name != "workspace directory" {
+		t.Errorf("expected name 'workspace directory', got: %s", result.Name)
+	}
+}
+
+func TestFormatResult_OK(t *testing.T) {
+	r := Result{Name: "test check", OK: true, Message: "all good"}
+	formatted := FormatResult(r)
+	if !strings.Contains(formatted, "✓") {
+		t.Errorf("expected check mark in output, got: %s", formatted)
+	}
+	if !strings.Contains(formatted, "test check") {
+		t.Errorf("expected check name in output, got: %s", formatted)
+	}
+	if !strings.Contains(formatted, "all good") {
+		t.Errorf("expected message in output, got: %s", formatted)
+	}
+}
+
+func TestFormatResult_Fail(t *testing.T) {
+	r := Result{Name: "test check", OK: false, Message: "not found"}
+	formatted := FormatResult(r)
+	if !strings.Contains(formatted, "✗") {
+		t.Errorf("expected cross mark in output, got: %s", formatted)
+	}
+}
+
+func TestBinaryRemediation_Claude(t *testing.T) {
+	msg := BinaryRemediation("claude")
+	if !strings.Contains(msg, "npm install -g @anthropic-ai/claude-code") {
+		t.Errorf("expected npm install instruction, got: %s", msg)
+	}
+	if !strings.Contains(msg, "claude_binary") {
+		t.Errorf("expected config path hint, got: %s", msg)
+	}
+}
+
+func TestBinaryRemediation_Git(t *testing.T) {
+	msg := BinaryRemediation("git")
+	if !strings.Contains(msg, "brew install git") {
+		t.Errorf("expected brew install instruction, got: %s", msg)
+	}
+	if !strings.Contains(msg, "apt install git") {
+		t.Errorf("expected apt install instruction, got: %s", msg)
+	}
+}
+
+func TestBinaryRemediation_Unknown(t *testing.T) {
+	msg := BinaryRemediation("unknown-tool")
+	if !strings.Contains(msg, "unknown-tool") {
+		t.Errorf("expected tool name in message, got: %s", msg)
+	}
+}
+
+func TestAPIKeyRemediation(t *testing.T) {
+	msg := APIKeyRemediation()
+	if !strings.Contains(msg, "ANTHROPIC_API_KEY") {
+		t.Errorf("expected env var hint, got: %s", msg)
+	}
+	if !strings.Contains(msg, "volundr init") {
+		t.Errorf("expected init hint, got: %s", msg)
+	}
+}
+
+func TestPortRemediation(t *testing.T) {
+	msg := PortRemediation("127.0.0.1", 8080)
+	if !strings.Contains(msg, "8080") {
+		t.Errorf("expected port in message, got: %s", msg)
+	}
+	if !strings.Contains(msg, "127.0.0.1") {
+		t.Errorf("expected host in message, got: %s", msg)
+	}
+	if !strings.Contains(msg, "listen:") {
+		t.Errorf("expected config hint, got: %s", msg)
+	}
+}
+
+func TestCheckPortAvailable_ResultName(t *testing.T) {
+	result := CheckPortAvailable("127.0.0.1", 0)
+	expected := fmt.Sprintf("port %d", 0)
+	if result.Name != expected {
+		t.Errorf("expected name %q, got %q", expected, result.Name)
+	}
+}
+
+func TestCheckAPIKey_Name(t *testing.T) {
+	result := CheckAPIKey("key", "")
+	if result.Name != "Anthropic API key" {
+		t.Errorf("expected name 'Anthropic API key', got %q", result.Name)
+	}
+}
+
+func TestCheckDirWritable_Name(t *testing.T) {
+	tmpDir := t.TempDir()
+	result := CheckDirWritable(tmpDir)
+	if result.Name != "workspace directory" {
+		t.Errorf("expected name 'workspace directory', got %q", result.Name)
+	}
+}

--- a/cli/internal/preflight/checks_test.go
+++ b/cli/internal/preflight/checks_test.go
@@ -205,8 +205,8 @@ func TestBinaryRemediation_Claude(t *testing.T) {
 	if !strings.Contains(msg, "npm install -g @anthropic-ai/claude-code") {
 		t.Errorf("expected npm install instruction, got: %s", msg)
 	}
-	if !strings.Contains(msg, "claude_binary") {
-		t.Errorf("expected config path hint, got: %s", msg)
+	if !strings.Contains(msg, "Claude Code CLI is required") {
+		t.Errorf("expected description of requirement, got: %s", msg)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **New `preflight` package** (`cli/internal/preflight/`) with reusable check functions for binary lookup, API key validation, port availability, and directory writability
- **`init` command** now runs advisory preflight checks after the wizard completes (local runtime only), printing clear ✓/✗ status for claude binary, API key, git binary, and workspace directory
- **`up` command** now validates prerequisites before starting the server:
  - **Hard failure**: claude binary missing → actionable error with install instructions
  - **Hard failure**: configured port already in use → actionable error with remediation steps
  - **Hard failure**: workspace directory not writable
  - **Soft warning**: API key not configured → warning with setup instructions
- K3s/docker mode preflight checks continue to work unchanged

## Test plan

- [x] Preflight package tests: 23 tests, 95.7% coverage
- [x] CLI integration tests: `runInitPreflight`, `runUpPreflight` with port-in-use, missing claude, API key warning, all-pass scenarios
- [x] Full test suite passes across all packages (15 packages, 0 failures)
- [x] `go vet` clean

Closes NIU-328

🤖 Generated with [Claude Code](https://claude.com/claude-code)