### PR TITLE
feat(cli): enhance volundr status with session details

### DIFF
--- a/cli/internal/cli/down_test.go
+++ b/cli/internal/cli/down_test.go
@@ -76,10 +76,11 @@ docker:
 	// since docker isn't available, but that's expected — the error is collected).
 	// This tests that config is loaded and the docker runtime is dispatched.
 	err := runDown(nil, nil)
-	// Docker compose errors are expected in test env without docker.
-	// The function may or may not error depending on whether docker CLI exists.
-	// We just verify it doesn't panic and goes through the config-based path.
-	_ = err
+	// Docker compose may or may not error depending on whether docker CLI exists.
+	// We verify it doesn't panic and goes through the config-based path.
+	if err != nil {
+		t.Logf("expected error in test env (no docker): %v", err)
+	}
 }
 
 func TestRunDown_WithConfig_K3sRuntime(t *testing.T) {
@@ -108,7 +109,10 @@ k3s:
 
 	// K3s runtime Down() calls kubectl/docker (will fail in test env).
 	err := runDown(nil, nil)
-	_ = err
+	// We verify it doesn't panic and goes through the config-based path.
+	if err != nil {
+		t.Logf("expected error in test env (no k3s): %v", err)
+	}
 }
 
 func TestRunDown_NoConfig_FallbackToDownFromPID(t *testing.T) {

--- a/cli/internal/cli/status.go
+++ b/cli/internal/cli/status.go
@@ -1,22 +1,48 @@
 package cli
 
 import (
+	"context"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
+	"github.com/niuulabs/volundr/cli/internal/config"
 	"github.com/niuulabs/volundr/cli/internal/runtime"
 )
 
 var statusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Show status of Volundr services",
-	Long:  `Displays the current state of all Volundr services.`,
+	Long:  `Displays the current state of all Volundr services including sessions.`,
 	RunE:  runStatus,
 }
 
 func runStatus(_ *cobra.Command, _ []string) error {
-	// TODO: load config and use runtime.NewRuntime(cfg.Runtime).Status() for runtime-specific status
+	cfg, err := config.Load()
+	if err != nil {
+		// Config not available — fall back to state file for basic info.
+		return runStatusFallback()
+	}
+
+	ctx := context.Background()
+	rt := runtime.NewRuntime(cfg.Runtime)
+	rs, err := rt.RichStatus(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("get status: %w", err)
+	}
+
+	if jsonOutput {
+		return printJSON(rs)
+	}
+
+	printRichStatus(rs)
+	return nil
+}
+
+// runStatusFallback handles the case where config is not available.
+func runStatusFallback() error {
 	status, err := runtime.StatusFromStateFile()
 	if err != nil {
 		return fmt.Errorf("get status: %w", err)
@@ -42,6 +68,118 @@ func runStatus(_ *cobra.Command, _ []string) error {
 		fmt.Printf("%-15s %-10s %-8s %-6s %s\n",
 			svc.Name, svc.State, pid, port, svc.Error)
 	}
-
 	return nil
+}
+
+// printRichStatus formats and prints the rich status to stdout.
+func printRichStatus(rs *runtime.RichStatus) {
+	fmt.Printf("Volundr (%s mode)\n", rs.Mode)
+
+	// Server.
+	if rs.Server.PID > 0 {
+		fmt.Printf("  Server:     %s on %s (PID %d)\n", rs.Server.Status, rs.Server.Address, rs.Server.PID)
+	} else if rs.Server.Detail != "" {
+		fmt.Printf("  Server:     %s (%s)\n", rs.Server.Status, rs.Server.Detail)
+	} else if rs.Server.Address != "" {
+		fmt.Printf("  Server:     %s on %s\n", rs.Server.Status, rs.Server.Address)
+	} else {
+		fmt.Printf("  Server:     %s\n", rs.Server.Status)
+	}
+
+	// Web UI.
+	if rs.WebUI != "" {
+		fmt.Printf("  Web UI:     %s\n", rs.WebUI)
+	}
+
+	// Cluster (k3s only).
+	if rs.Cluster != nil {
+		fmt.Printf("  Cluster:    %s (%s)\n", rs.Cluster.Name, rs.Cluster.Status)
+	}
+
+	// Tyr (when available).
+	if rs.Tyr != nil {
+		if rs.Tyr.Address != "" {
+			fmt.Printf("  Tyr:        %s on %s (PID %d)\n", rs.Tyr.Status, rs.Tyr.Address, rs.Tyr.PID)
+		} else {
+			fmt.Printf("  Tyr:        %s\n", rs.Tyr.Status)
+		}
+	}
+
+	// Database.
+	if rs.Database.Detail != "" {
+		fmt.Printf("  Database:   %s\n", rs.Database.Detail)
+	} else {
+		fmt.Printf("  Database:   %s\n", rs.Database.Status)
+	}
+
+	// Proxy (k3s).
+	if rs.Proxy != "" {
+		fmt.Printf("  Proxy:      %s\n", rs.Proxy)
+	}
+
+	// Sessions summary.
+	fmt.Printf("  Sessions:   %d/%d active\n", rs.Sessions.Active, rs.Sessions.Max)
+
+	// Session list.
+	if len(rs.Sessions.List) > 0 {
+		fmt.Println()
+		fmt.Printf("  %-10s  %-15s  %-10s  %-18s  %-28s  %s\n",
+			"ID", "NAME", "STATUS", "MODEL", "REPO", "AGE")
+		for _, s := range rs.Sessions.List {
+			age := formatAge(s.CreatedAt)
+			fmt.Printf("  %-10s  %-15s  %-10s  %-18s  %-28s  %s\n",
+				s.ID, truncateName(s.Name), s.Status, s.Model, s.Repo, age)
+		}
+	}
+
+	// Pod list (k3s mode).
+	if len(rs.Pods) > 0 {
+		fmt.Println()
+		fmt.Printf("  PODS (kubectl get pods -n volundr):\n")
+		fmt.Printf("  %-30s  %-8s  %-10s  %s\n", "NAME", "READY", "STATUS", "AGE")
+		for _, p := range rs.Pods {
+			age := formatAge(p.Age)
+			fmt.Printf("  %-30s  %-8s  %-10s  %s\n", p.Name, p.Ready, p.Status, age)
+		}
+	}
+}
+
+// truncateName truncates a session name to 15 characters.
+func truncateName(name string) string {
+	if len(name) > 15 {
+		return name[:12] + "..."
+	}
+	return name
+}
+
+// formatAge converts an ISO 8601 timestamp to a human-readable age string.
+func formatAge(timestamp string) string {
+	if timestamp == "" {
+		return ""
+	}
+
+	// Try common ISO 8601 formats.
+	for _, layout := range []string{
+		time.RFC3339,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05",
+		"2006-01-02T15:04:05Z",
+	} {
+		t, err := time.Parse(layout, strings.TrimSpace(timestamp))
+		if err != nil {
+			continue
+		}
+		d := time.Since(t)
+		switch {
+		case d < time.Minute:
+			return fmt.Sprintf("%ds", int(d.Seconds()))
+		case d < time.Hour:
+			return fmt.Sprintf("%dm", int(d.Minutes()))
+		case d < 24*time.Hour:
+			return fmt.Sprintf("%dh", int(d.Hours()))
+		default:
+			return fmt.Sprintf("%dd", int(d.Hours()/24))
+		}
+	}
+	return timestamp
 }

--- a/cli/internal/cli/status_test.go
+++ b/cli/internal/cli/status_test.go
@@ -1,10 +1,15 @@
 package cli
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/niuulabs/volundr/cli/internal/config"
+	"github.com/niuulabs/volundr/cli/internal/runtime"
 )
 
 func TestRunStatus_NoPIDFile(t *testing.T) {
@@ -60,4 +65,363 @@ func TestRunStatus_WithPIDFile_DeadProcess(t *testing.T) {
 	if err := runStatus(nil, nil); err != nil {
 		t.Fatalf("runStatus: %v", err)
 	}
+}
+
+func TestRunStatus_WithConfig_NoPID(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(config.EnvHome, tmpDir)
+
+	// Write a valid config file.
+	cfg := &config.Config{
+		Runtime: "local",
+		Listen: config.ListenConfig{
+			Host: "127.0.0.1",
+			Port: 8080,
+		},
+		Database: config.DatabaseConfig{
+			Mode: "embedded",
+			Port: 5433,
+			User: "volundr",
+			Name: "volundr",
+		},
+	}
+	if err := cfg.SaveTo(filepath.Join(tmpDir, "config.yaml")); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	oldJSON := jsonOutput
+	jsonOutput = false
+	defer func() { jsonOutput = oldJSON }()
+
+	// Should succeed showing stopped status.
+	if err := runStatus(nil, nil); err != nil {
+		t.Fatalf("runStatus: %v", err)
+	}
+}
+
+func TestRunStatus_WithConfig_JSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(config.EnvHome, tmpDir)
+
+	// Write a valid config file.
+	cfg := &config.Config{
+		Runtime: "local",
+		Listen: config.ListenConfig{
+			Host: "127.0.0.1",
+			Port: 8080,
+		},
+		Database: config.DatabaseConfig{
+			Mode: "embedded",
+			Port: 5433,
+			User: "volundr",
+			Name: "volundr",
+		},
+	}
+	if err := cfg.SaveTo(filepath.Join(tmpDir, "config.yaml")); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	oldJSON := jsonOutput
+	jsonOutput = true
+	defer func() { jsonOutput = oldJSON }()
+
+	r, w, _ := os.Pipe()
+	old := os.Stdout
+	os.Stdout = w
+
+	err := runStatus(nil, nil)
+
+	_ = w.Close()
+	os.Stdout = old
+
+	if err != nil {
+		t.Fatalf("runStatus JSON: %v", err)
+	}
+
+	// Verify it's valid JSON.
+	var rs runtime.RichStatus
+	if err := json.NewDecoder(r).Decode(&rs); err != nil {
+		t.Fatalf("decode JSON: %v", err)
+	}
+
+	if rs.Mode != "local" {
+		t.Errorf("expected mode 'local', got %q", rs.Mode)
+	}
+
+	if rs.Server.Status != "stopped" {
+		t.Errorf("expected server status 'stopped', got %q", rs.Server.Status)
+	}
+}
+
+func TestRunStatusFallback_NoPIDFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(config.EnvHome, tmpDir)
+
+	oldJSON := jsonOutput
+	jsonOutput = false
+	defer func() { jsonOutput = oldJSON }()
+
+	if err := runStatusFallback(); err != nil {
+		t.Fatalf("runStatusFallback: %v", err)
+	}
+}
+
+func TestRunStatusFallback_WithStateFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(config.EnvHome, tmpDir)
+
+	// Write a PID file with our own PID.
+	pidFile := tmpDir + "/volundr.pid"
+	if err := os.WriteFile(pidFile, []byte(fmt.Sprintf("%d", os.Getpid())), 0o600); err != nil {
+		t.Fatalf("write pid file: %v", err)
+	}
+
+	// Write a state file with services.
+	stateFile := tmpDir + "/state.json"
+	stateData := `[{"name":"api","state":"running","port":8081},{"name":"postgres","state":"running","port":5433}]`
+	if err := os.WriteFile(stateFile, []byte(stateData), 0o600); err != nil {
+		t.Fatalf("write state file: %v", err)
+	}
+
+	oldJSON := jsonOutput
+	jsonOutput = false
+	defer func() { jsonOutput = oldJSON }()
+
+	if err := runStatusFallback(); err != nil {
+		t.Fatalf("runStatusFallback: %v", err)
+	}
+}
+
+func TestRunStatusFallback_JSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(config.EnvHome, tmpDir)
+
+	oldJSON := jsonOutput
+	jsonOutput = true
+	defer func() { jsonOutput = oldJSON }()
+
+	old := os.Stdout
+	_, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := runStatusFallback()
+
+	_ = w.Close()
+	os.Stdout = old
+
+	if err != nil {
+		t.Fatalf("runStatusFallback JSON: %v", err)
+	}
+}
+
+func TestFormatAge(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"empty string", "", ""},
+		{"invalid timestamp", "not-a-date", "not-a-date"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatAge(tt.input)
+			if result != tt.expected {
+				t.Errorf("formatAge(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFormatAge_Recent(t *testing.T) {
+	// Use a recent RFC3339 timestamp.
+	result := formatAge("2020-01-01T00:00:00Z")
+	// Should be something like "NNd" (many days ago).
+	if result == "" || result == "2020-01-01T00:00:00Z" {
+		t.Errorf("expected formatted age, got %q", result)
+	}
+}
+
+func TestFormatAge_RFC3339Nano(t *testing.T) {
+	result := formatAge("2020-01-01T00:00:00.000000000Z")
+	if result == "" || result == "2020-01-01T00:00:00.000000000Z" {
+		t.Errorf("expected formatted age, got %q", result)
+	}
+}
+
+func TestFormatAge_NoTimezone(t *testing.T) {
+	result := formatAge("2020-01-01T00:00:00")
+	if result == "" || result == "2020-01-01T00:00:00" {
+		t.Errorf("expected formatted age, got %q", result)
+	}
+}
+
+func TestFormatAge_Minutes(t *testing.T) {
+	// 5 minutes ago.
+	ts := time.Now().Add(-5 * time.Minute).UTC().Format(time.RFC3339)
+	result := formatAge(ts)
+	if result != "5m" {
+		t.Errorf("expected '5m', got %q", result)
+	}
+}
+
+func TestFormatAge_Hours(t *testing.T) {
+	// 3 hours ago.
+	ts := time.Now().Add(-3 * time.Hour).UTC().Format(time.RFC3339)
+	result := formatAge(ts)
+	if result != "3h" {
+		t.Errorf("expected '3h', got %q", result)
+	}
+}
+
+func TestFormatAge_Seconds(t *testing.T) {
+	// 30 seconds ago.
+	ts := time.Now().Add(-30 * time.Second).UTC().Format(time.RFC3339)
+	result := formatAge(ts)
+	if result != "30s" {
+		t.Errorf("expected '30s', got %q", result)
+	}
+}
+
+func TestFormatAge_WithZSuffix(t *testing.T) {
+	result := formatAge("2020-01-01T00:00:00Z")
+	if result == "" || result == "2020-01-01T00:00:00Z" {
+		t.Errorf("expected formatted age, got %q", result)
+	}
+	// Very old, should be days.
+	if len(result) < 2 || result[len(result)-1] != 'd' {
+		t.Errorf("expected days format, got %q", result)
+	}
+}
+
+func TestTruncateName(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"short", "short"},
+		{"exactly15chars!", "exactly15chars!"},
+		{"this-is-a-very-long-session-name", "this-is-a-ve..."},
+	}
+
+	for _, tt := range tests {
+		result := truncateName(tt.input)
+		if result != tt.expected {
+			t.Errorf("truncateName(%q) = %q, want %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func TestPrintRichStatus_Stopped(t *testing.T) {
+	rs := &runtime.RichStatus{
+		Mode:     "local",
+		Server:   runtime.ComponentStatus{Status: "stopped"},
+		Database: runtime.ComponentStatus{Status: "stopped"},
+		Sessions: runtime.SessionSummary{Max: 4},
+	}
+
+	// Should not panic.
+	old := os.Stdout
+	_, w, _ := os.Pipe()
+	os.Stdout = w
+
+	printRichStatus(rs)
+
+	_ = w.Close()
+	os.Stdout = old
+}
+
+func TestPrintRichStatus_Running(t *testing.T) {
+	rs := &runtime.RichStatus{
+		Mode: "local",
+		Server: runtime.ComponentStatus{
+			Status:  "running",
+			Address: "127.0.0.1:8080",
+			PID:     12345,
+		},
+		WebUI: "http://127.0.0.1:8080",
+		Database: runtime.ComponentStatus{
+			Status: "running",
+			Detail: "embedded PostgreSQL on port 5433",
+			Port:   5433,
+		},
+		Sessions: runtime.SessionSummary{
+			Active: 2,
+			Max:    4,
+			List: []runtime.SessionInfo{
+				{ID: "a1b2c3d4", Name: "fix-auth-bug", Status: "running", Model: "claude-sonnet-4", Repo: "github.com/org/api"},
+				{ID: "e5f6g7h8", Name: "add-tests", Status: "stopped", Model: "claude-sonnet-4", Repo: "github.com/org/web"},
+			},
+		},
+	}
+
+	old := os.Stdout
+	_, w, _ := os.Pipe()
+	os.Stdout = w
+
+	printRichStatus(rs)
+
+	_ = w.Close()
+	os.Stdout = old
+}
+
+func TestPrintRichStatus_K3sWithPods(t *testing.T) {
+	rs := &runtime.RichStatus{
+		Mode: "k3s",
+		Server: runtime.ComponentStatus{
+			Status: "running",
+			Detail: "Docker container volundr-k3s-api",
+		},
+		Cluster: &runtime.ClusterStatus{Name: "k3d-volundr", Status: "running"},
+		Database: runtime.ComponentStatus{
+			Status: "running",
+			Detail: "embedded PostgreSQL on port 5433",
+		},
+		Proxy: "http://127.0.0.1:8080",
+		Sessions: runtime.SessionSummary{
+			Active: 1,
+			Max:    4,
+		},
+		Pods: []runtime.PodStatus{
+			{Name: "session-a1b2c3-skuld", Ready: "3/3", Status: "Running"},
+			{Name: "tyr-7f8d9e-abc", Ready: "1/1", Status: "Running"},
+		},
+	}
+
+	old := os.Stdout
+	_, w, _ := os.Pipe()
+	os.Stdout = w
+
+	printRichStatus(rs)
+
+	_ = w.Close()
+	os.Stdout = old
+}
+
+func TestPrintRichStatus_WithTyr(t *testing.T) {
+	rs := &runtime.RichStatus{
+		Mode: "local",
+		Server: runtime.ComponentStatus{
+			Status:  "running",
+			Address: "127.0.0.1:8080",
+			PID:     12345,
+		},
+		Tyr: &runtime.ComponentStatus{
+			Status:  "running",
+			Address: "127.0.0.1:8081",
+			PID:     12346,
+		},
+		Database: runtime.ComponentStatus{Status: "stopped"},
+		Sessions: runtime.SessionSummary{Max: 4},
+	}
+
+	old := os.Stdout
+	_, w, _ := os.Pipe()
+	os.Stdout = w
+
+	printRichStatus(rs)
+
+	_ = w.Close()
+	os.Stdout = old
 }

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -75,6 +75,14 @@ type LocalMountsConfig struct {
 	DefaultReadOnly bool     `yaml:"default_read_only"`
 }
 
+// DefaultMaxSessions is the default maximum number of concurrent sessions.
+const DefaultMaxSessions = 4
+
+// SessionsConfig holds session-related settings.
+type SessionsConfig struct {
+	MaxSessions int `yaml:"max_sessions"`
+}
+
 // Config represents the full volundr configuration.
 type Config struct {
 	Runtime     string            `yaml:"runtime"`
@@ -82,6 +90,7 @@ type Config struct {
 	TLS         TLSConfig         `yaml:"tls"`
 	Database    DatabaseConfig    `yaml:"database"`
 	Anthropic   AnthropicConfig   `yaml:"anthropic"`
+	Sessions    SessionsConfig    `yaml:"sessions,omitempty"`
 	Git         GitConfig         `yaml:"git,omitempty"`
 	Docker      DockerConfig      `yaml:"docker,omitempty"`
 	K3s         K3sConfig         `yaml:"k3s,omitempty"`
@@ -169,6 +178,9 @@ func DefaultConfig() (*Config, error) {
 			Name:     DefaultDBName,
 		},
 		Anthropic: AnthropicConfig{},
+		Sessions: SessionsConfig{
+			MaxSessions: DefaultMaxSessions,
+		},
 		Docker: DockerConfig{
 			APIImage:   "ghcr.io/niuulabs/volundr:latest",
 			SkuldImage: "ghcr.io/niuulabs/skuld:latest",

--- a/cli/internal/runtime/docker.go
+++ b/cli/internal/runtime/docker.go
@@ -385,7 +385,7 @@ func (r *DockerRuntime) RichStatus(ctx context.Context, cfg *config.Config) (*Ri
 			Detail: fmt.Sprintf("Docker container %s-api-1", dockerProject),
 		}
 		rs.Database = ComponentStatus{Status: "stopped"}
-		rs.Sessions = SessionSummary{Max: defaultMaxSessions}
+		rs.Sessions = SessionSummary{Max: effectiveMaxSessions(cfg.Sessions.MaxSessions)}
 		return rs, nil
 	}
 
@@ -403,7 +403,7 @@ func (r *DockerRuntime) RichStatus(ctx context.Context, cfg *config.Config) (*Ri
 	rs.Database = databaseStatus(cfg)
 
 	// Fetch sessions from the API.
-	rs.Sessions = buildSessionSummary(ctx, listenAddr)
+	rs.Sessions = buildSessionSummary(ctx, listenAddr, cfg.Sessions.MaxSessions)
 
 	return rs, nil
 }

--- a/cli/internal/runtime/docker.go
+++ b/cli/internal/runtime/docker.go
@@ -366,6 +366,48 @@ func (r *DockerRuntime) Status(ctx context.Context) (*StackStatus, error) {
 	return status, nil
 }
 
+// RichStatus returns detailed status including session info for docker runtime.
+func (r *DockerRuntime) RichStatus(ctx context.Context, cfg *config.Config) (*RichStatus, error) {
+	rs := &RichStatus{
+		Mode: "docker",
+	}
+
+	// Inspect the API container.
+	out, err := execCommandContext(ctx,
+		"docker", "inspect",
+		"--format", "{{.State.Status}}",
+		dockerProject+"-api-1",
+	).CombinedOutput()
+
+	if err != nil {
+		rs.Server = ComponentStatus{
+			Status: "stopped",
+			Detail: fmt.Sprintf("Docker container %s-api-1", dockerProject),
+		}
+		rs.Database = ComponentStatus{Status: "stopped"}
+		rs.Sessions = SessionSummary{Max: defaultMaxSessions}
+		return rs, nil
+	}
+
+	containerState := strings.TrimSpace(string(out))
+	listenAddr := fmt.Sprintf("%s:%d", cfg.Listen.Host, cfg.Listen.Port)
+
+	rs.Server = ComponentStatus{
+		Status:  string(mapContainerState(containerState)),
+		Address: listenAddr,
+		Detail:  fmt.Sprintf("Docker container %s-api-1", dockerProject),
+	}
+	rs.WebUI = fmt.Sprintf("http://%s", listenAddr)
+
+	// Database status.
+	rs.Database = databaseStatus(cfg)
+
+	// Fetch sessions from the API.
+	rs.Sessions = buildSessionSummary(ctx, listenAddr)
+
+	return rs, nil
+}
+
 // Logs streams logs for a Docker service.
 func (r *DockerRuntime) Logs(ctx context.Context, service string, follow bool) (io.ReadCloser, error) {
 	args := []string{"logs"}

--- a/cli/internal/runtime/k3s.go
+++ b/cli/internal/runtime/k3s.go
@@ -434,6 +434,131 @@ func (r *K3sRuntime) Status(_ context.Context) (*StackStatus, error) {
 	return status, nil
 }
 
+// RichStatus returns detailed status including pod info for k3s runtime.
+func (r *K3sRuntime) RichStatus(ctx context.Context, cfg *config.Config) (*RichStatus, error) {
+	rs := &RichStatus{
+		Mode: "k3s",
+	}
+
+	// Check API container status.
+	out, err := execCommandContext(ctx,
+		"docker", "inspect",
+		"--format", "{{.State.Status}}",
+		k3sContainerName,
+	).CombinedOutput()
+
+	if err != nil {
+		rs.Server = ComponentStatus{
+			Status: "stopped",
+			Detail: fmt.Sprintf("Docker container %s", k3sContainerName),
+		}
+		rs.Database = ComponentStatus{Status: "stopped"}
+		rs.Sessions = SessionSummary{Max: defaultMaxSessions}
+		return rs, nil
+	}
+
+	containerState := strings.TrimSpace(string(out))
+	listenAddr := fmt.Sprintf("%s:%d", cfg.Listen.Host, cfg.Listen.Port)
+
+	rs.Server = ComponentStatus{
+		Status:  string(mapContainerState(containerState)),
+		Address: listenAddr,
+		Detail:  fmt.Sprintf("Docker container %s", k3sContainerName),
+	}
+	rs.Proxy = fmt.Sprintf("http://%s", listenAddr)
+
+	// Cluster status.
+	clusterStatus := "stopped"
+	clusterOut, clusterErr := execCommandContext(ctx,
+		"k3d", "cluster", "list", "-o", "json",
+	).CombinedOutput()
+	if clusterErr == nil {
+		var clusters []struct {
+			Name           string `json:"name"`
+			ServersRunning int    `json:"serversRunning"`
+		}
+		if json.Unmarshal(clusterOut, &clusters) == nil {
+			for _, c := range clusters {
+				if c.Name == k3sClusterName {
+					if c.ServersRunning > 0 {
+						clusterStatus = "running"
+					}
+					break
+				}
+			}
+		}
+	}
+	rs.Cluster = &ClusterStatus{
+		Name:   "k3d-" + k3sClusterName,
+		Status: clusterStatus,
+	}
+
+	// Database status.
+	rs.Database = databaseStatus(cfg)
+
+	// Fetch pod details.
+	rs.Pods = r.queryPodDetails(cfg)
+
+	// Fetch sessions from the API.
+	rs.Sessions = buildSessionSummary(ctx, listenAddr)
+
+	return rs, nil
+}
+
+// queryPodDetails queries Kubernetes for pod details including readiness.
+func (r *K3sRuntime) queryPodDetails(cfg *config.Config) []PodStatus {
+	namespace := resolveNamespace(cfg)
+
+	out, err := execCommandContext(context.Background(), //nolint:gosec // arguments from trusted internal config
+		"kubectl", "get", "pods",
+		"--namespace", namespace,
+		"--kubeconfig", hostKubeconfigPath(),
+		"-o", "json",
+	).CombinedOutput()
+	if err != nil {
+		return nil
+	}
+
+	var podList struct {
+		Items []struct {
+			Metadata struct {
+				Name              string `json:"name"`
+				CreationTimestamp string `json:"creationTimestamp"`
+			} `json:"metadata"`
+			Status struct {
+				Phase             string `json:"phase"`
+				ContainerStatuses []struct {
+					Ready bool `json:"ready"`
+				} `json:"containerStatuses"`
+			} `json:"status"`
+		} `json:"items"`
+	}
+
+	if err := json.Unmarshal(out, &podList); err != nil {
+		return nil
+	}
+
+	pods := make([]PodStatus, 0, len(podList.Items))
+	for _, pod := range podList.Items {
+		ready := 0
+		total := len(pod.Status.ContainerStatuses)
+		for _, cs := range pod.Status.ContainerStatuses {
+			if cs.Ready {
+				ready++
+			}
+		}
+
+		pods = append(pods, PodStatus{
+			Name:   pod.Metadata.Name,
+			Ready:  fmt.Sprintf("%d/%d", ready, total),
+			Status: pod.Status.Phase,
+			Age:    pod.Metadata.CreationTimestamp,
+		})
+	}
+
+	return pods
+}
+
 // Logs streams logs for a service.
 func (r *K3sRuntime) Logs(_ context.Context, service string, follow bool) (io.ReadCloser, error) {
 	// For host services (api, postgres), use log files.

--- a/cli/internal/runtime/k3s.go
+++ b/cli/internal/runtime/k3s.go
@@ -453,7 +453,7 @@ func (r *K3sRuntime) RichStatus(ctx context.Context, cfg *config.Config) (*RichS
 			Detail: fmt.Sprintf("Docker container %s", k3sContainerName),
 		}
 		rs.Database = ComponentStatus{Status: "stopped"}
-		rs.Sessions = SessionSummary{Max: defaultMaxSessions}
+		rs.Sessions = SessionSummary{Max: effectiveMaxSessions(cfg.Sessions.MaxSessions)}
 		return rs, nil
 	}
 
@@ -497,19 +497,19 @@ func (r *K3sRuntime) RichStatus(ctx context.Context, cfg *config.Config) (*RichS
 	rs.Database = databaseStatus(cfg)
 
 	// Fetch pod details.
-	rs.Pods = r.queryPodDetails(cfg)
+	rs.Pods = r.queryPodDetails(ctx, cfg)
 
 	// Fetch sessions from the API.
-	rs.Sessions = buildSessionSummary(ctx, listenAddr)
+	rs.Sessions = buildSessionSummary(ctx, listenAddr, cfg.Sessions.MaxSessions)
 
 	return rs, nil
 }
 
 // queryPodDetails queries Kubernetes for pod details including readiness.
-func (r *K3sRuntime) queryPodDetails(cfg *config.Config) []PodStatus {
+func (r *K3sRuntime) queryPodDetails(ctx context.Context, cfg *config.Config) []PodStatus {
 	namespace := resolveNamespace(cfg)
 
-	out, err := execCommandContext(context.Background(), //nolint:gosec // arguments from trusted internal config
+	out, err := execCommandContext(ctx, //nolint:gosec // arguments from trusted internal config
 		"kubectl", "get", "pods",
 		"--namespace", namespace,
 		"--kubeconfig", hostKubeconfigPath(),

--- a/cli/internal/runtime/local.go
+++ b/cli/internal/runtime/local.go
@@ -353,6 +353,46 @@ func StatusFromStateFile() (*StackStatus, error) {
 	return status, nil
 }
 
+// defaultMaxSessions is the default max concurrent sessions for local mode.
+const defaultMaxSessions = 4
+
+// RichStatus returns detailed status including session info for local runtime.
+func (r *LocalRuntime) RichStatus(ctx context.Context, cfg *config.Config) (*RichStatus, error) {
+	cfgDir, err := config.ConfigDir()
+	if err != nil {
+		return nil, fmt.Errorf("get config dir: %w", err)
+	}
+
+	rs := &RichStatus{
+		Mode: "local",
+	}
+
+	// Check if server is running via PID file.
+	pid, running := checkPIDFile(cfgDir)
+	if !running {
+		rs.Server = ComponentStatus{Status: "stopped"}
+		rs.Database = ComponentStatus{Status: "stopped"}
+		rs.Sessions = SessionSummary{Max: defaultMaxSessions}
+		return rs, nil
+	}
+
+	listenAddr := fmt.Sprintf("%s:%d", cfg.Listen.Host, cfg.Listen.Port)
+	rs.Server = ComponentStatus{
+		Status:  "running",
+		Address: listenAddr,
+		PID:     pid,
+	}
+	rs.WebUI = fmt.Sprintf("http://%s", listenAddr)
+
+	// Database status.
+	rs.Database = databaseStatus(cfg)
+
+	// Fetch sessions from the API.
+	rs.Sessions = buildSessionSummary(ctx, listenAddr)
+
+	return rs, nil
+}
+
 func (r *LocalRuntime) startAPI(ctx context.Context, cfg *config.Config, port int) error {
 	cfgDir, err := config.ConfigDir()
 	if err != nil {

--- a/cli/internal/runtime/local.go
+++ b/cli/internal/runtime/local.go
@@ -353,9 +353,6 @@ func StatusFromStateFile() (*StackStatus, error) {
 	return status, nil
 }
 
-// defaultMaxSessions is the default max concurrent sessions for local mode.
-const defaultMaxSessions = 4
-
 // RichStatus returns detailed status including session info for local runtime.
 func (r *LocalRuntime) RichStatus(ctx context.Context, cfg *config.Config) (*RichStatus, error) {
 	cfgDir, err := config.ConfigDir()
@@ -372,7 +369,7 @@ func (r *LocalRuntime) RichStatus(ctx context.Context, cfg *config.Config) (*Ric
 	if !running {
 		rs.Server = ComponentStatus{Status: "stopped"}
 		rs.Database = ComponentStatus{Status: "stopped"}
-		rs.Sessions = SessionSummary{Max: defaultMaxSessions}
+		rs.Sessions = SessionSummary{Max: effectiveMaxSessions(cfg.Sessions.MaxSessions)}
 		return rs, nil
 	}
 
@@ -388,7 +385,7 @@ func (r *LocalRuntime) RichStatus(ctx context.Context, cfg *config.Config) (*Ric
 	rs.Database = databaseStatus(cfg)
 
 	// Fetch sessions from the API.
-	rs.Sessions = buildSessionSummary(ctx, listenAddr)
+	rs.Sessions = buildSessionSummary(ctx, listenAddr, cfg.Sessions.MaxSessions)
 
 	return rs, nil
 }

--- a/cli/internal/runtime/runtime.go
+++ b/cli/internal/runtime/runtime.go
@@ -140,6 +140,9 @@ type Runtime interface {
 	// Status returns the state of each service.
 	Status(ctx context.Context) (*StackStatus, error)
 
+	// RichStatus returns detailed status including session info.
+	RichStatus(ctx context.Context, cfg *config.Config) (*RichStatus, error)
+
 	// Logs streams logs for a service.
 	Logs(ctx context.Context, service string, follow bool) (io.ReadCloser, error)
 }

--- a/cli/internal/runtime/sessions.go
+++ b/cli/internal/runtime/sessions.go
@@ -27,7 +27,6 @@ type apiSessionSource struct {
 	Repo string `json:"repo,omitempty"`
 }
 
-
 // fetchSessions queries the Volundr API for the current session list.
 // Returns nil (not an error) if the API is unreachable — the caller
 // should display "unavailable" rather than failing.

--- a/cli/internal/runtime/sessions.go
+++ b/cli/internal/runtime/sessions.go
@@ -1,0 +1,92 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// sessionAPITimeout is the timeout for API requests when fetching session info.
+const sessionAPITimeout = 5 * time.Second
+
+// apiSessionResponse mirrors the Python API's SessionResponse fields we need.
+type apiSessionResponse struct {
+	ID        string           `json:"id"`
+	Name      string           `json:"name"`
+	Model     string           `json:"model"`
+	Status    string           `json:"status"`
+	CreatedAt string           `json:"created_at"`
+	Source    apiSessionSource `json:"source"`
+}
+
+// apiSessionSource represents the workspace source (git or local_mount).
+type apiSessionSource struct {
+	Type string `json:"type"`
+	Repo string `json:"repo,omitempty"`
+}
+
+
+// fetchSessions queries the Volundr API for the current session list.
+// Returns nil (not an error) if the API is unreachable — the caller
+// should display "unavailable" rather than failing.
+func fetchSessions(ctx context.Context, baseURL string) ([]SessionInfo, error) {
+	ctx, cancel := context.WithTimeout(ctx, sessionAPITimeout)
+	defer cancel()
+
+	url := baseURL + "/api/v1/volundr/sessions"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		// API not reachable — not an error for status display.
+		return nil, nil //nolint:nilerr // unreachable API is expected when server is stopped
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, nil
+	}
+
+	var sessions []apiSessionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&sessions); err != nil {
+		return nil, nil //nolint:nilerr // malformed response treated as unavailable
+	}
+
+	result := make([]SessionInfo, 0, len(sessions))
+	for _, s := range sessions {
+		result = append(result, SessionInfo{
+			ID:        truncateID(s.ID),
+			Name:      s.Name,
+			Status:    s.Status,
+			Model:     s.Model,
+			Repo:      s.Source.Repo,
+			CreatedAt: s.CreatedAt,
+		})
+	}
+	return result, nil
+}
+
+// truncateID returns the first 8 characters of a UUID string.
+func truncateID(id string) string {
+	if len(id) > 8 {
+		return id[:8]
+	}
+	return id
+}
+
+// countActiveSessions counts sessions in active states (running, starting, provisioning, created).
+func countActiveSessions(sessions []SessionInfo) int {
+	count := 0
+	for _, s := range sessions {
+		switch s.Status {
+		case "running", "starting", "provisioning", "created":
+			count++
+		}
+	}
+	return count
+}

--- a/cli/internal/runtime/sessions_test.go
+++ b/cli/internal/runtime/sessions_test.go
@@ -1,0 +1,166 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestFetchSessions_Success(t *testing.T) {
+	sessions := []apiSessionResponse{
+		{
+			ID:        "a1b2c3d4-e5f6-g7h8-i9j0-k1l2m3n4o5p6",
+			Name:      "fix-auth-bug",
+			Model:     "claude-sonnet-4",
+			Status:    "running",
+			CreatedAt: "2026-03-29T10:00:00Z",
+			Source:    apiSessionSource{Type: "git", Repo: "github.com/org/api"},
+		},
+		{
+			ID:        "b2c3d4e5-f6g7-h8i9-j0k1-l2m3n4o5p6q7",
+			Name:      "add-tests",
+			Model:     "claude-sonnet-4",
+			Status:    "stopped",
+			CreatedAt: "2026-03-29T11:00:00Z",
+			Source:    apiSessionSource{Type: "git", Repo: "github.com/org/web"},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/volundr/sessions" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(sessions)
+	}))
+	defer server.Close()
+
+	result, err := fetchSessions(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("fetchSessions: %v", err)
+	}
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 sessions, got %d", len(result))
+	}
+
+	if result[0].ID != "a1b2c3d4" {
+		t.Errorf("expected truncated ID 'a1b2c3d4', got %q", result[0].ID)
+	}
+	if result[0].Name != "fix-auth-bug" {
+		t.Errorf("expected name 'fix-auth-bug', got %q", result[0].Name)
+	}
+	if result[0].Status != "running" {
+		t.Errorf("expected status 'running', got %q", result[0].Status)
+	}
+	if result[0].Repo != "github.com/org/api" {
+		t.Errorf("expected repo 'github.com/org/api', got %q", result[0].Repo)
+	}
+}
+
+func TestFetchSessions_Unreachable(t *testing.T) {
+	// Use a URL that won't connect.
+	result, err := fetchSessions(context.Background(), "http://127.0.0.1:1")
+	if err != nil {
+		t.Fatalf("expected nil error for unreachable server, got: %v", err)
+	}
+	if result != nil {
+		t.Errorf("expected nil sessions for unreachable server, got %d", len(result))
+	}
+}
+
+func TestFetchSessions_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	result, err := fetchSessions(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("expected nil error for server error, got: %v", err)
+	}
+	if result != nil {
+		t.Errorf("expected nil sessions for server error, got %d", len(result))
+	}
+}
+
+func TestFetchSessions_InvalidJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer server.Close()
+
+	result, err := fetchSessions(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("expected nil error for invalid JSON, got: %v", err)
+	}
+	if result != nil {
+		t.Errorf("expected nil sessions for invalid JSON, got %d", len(result))
+	}
+}
+
+func TestFetchSessions_EmptyList(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer server.Close()
+
+	result, err := fetchSessions(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("fetchSessions: %v", err)
+	}
+
+	if len(result) != 0 {
+		t.Errorf("expected 0 sessions, got %d", len(result))
+	}
+}
+
+func TestTruncateID(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"a1b2c3d4-e5f6-g7h8", "a1b2c3d4"},
+		{"short", "short"},
+		{"12345678", "12345678"},
+		{"123456789", "12345678"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		result := truncateID(tt.input)
+		if result != tt.expected {
+			t.Errorf("truncateID(%q) = %q, want %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func TestCountActiveSessions(t *testing.T) {
+	sessions := []SessionInfo{
+		{Status: "running"},
+		{Status: "starting"},
+		{Status: "provisioning"},
+		{Status: "created"},
+		{Status: "stopped"},
+		{Status: "failed"},
+		{Status: "archived"},
+	}
+
+	count := countActiveSessions(sessions)
+	if count != 4 {
+		t.Errorf("expected 4 active sessions, got %d", count)
+	}
+}
+
+func TestCountActiveSessions_Empty(t *testing.T) {
+	count := countActiveSessions(nil)
+	if count != 0 {
+		t.Errorf("expected 0 for nil sessions, got %d", count)
+	}
+}

--- a/cli/internal/runtime/state.go
+++ b/cli/internal/runtime/state.go
@@ -94,6 +94,36 @@ func WriteStateFile(services []ServiceStatus) error {
 	return os.WriteFile(stateFilePath, data, 0o600)
 }
 
+// checkPIDFile reads the PID file from the given config directory and
+// verifies the process is alive. Returns (pid, true) if running, (0, false)
+// if stopped or the PID file is missing/stale.
+func checkPIDFile(cfgDir string) (int, bool) {
+	pidPath := filepath.Join(cfgDir, PIDFile)
+	data, err := os.ReadFile(pidPath) //nolint:gosec // path derived from trusted config directory
+	if err != nil {
+		return 0, false
+	}
+
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		_ = os.Remove(pidPath)
+		return 0, false
+	}
+
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		_ = os.Remove(pidPath)
+		return 0, false
+	}
+
+	if err := proc.Signal(syscall.Signal(0)); err != nil {
+		_ = os.Remove(pidPath)
+		return 0, false
+	}
+
+	return pid, true
+}
+
 // RemoveStateFile removes the state file.
 func RemoveStateFile() error {
 	cfgDir, err := config.ConfigDir()

--- a/cli/internal/runtime/status.go
+++ b/cli/internal/runtime/status.go
@@ -7,6 +7,14 @@ import (
 	"github.com/niuulabs/volundr/cli/internal/config"
 )
 
+// effectiveMaxSessions returns the configured max or the default when unset.
+func effectiveMaxSessions(max int) int {
+	if max > 0 {
+		return max
+	}
+	return config.DefaultMaxSessions
+}
+
 // RichStatus holds the full status of the Volundr stack, including
 // server info, session details, and component status.
 type RichStatus struct {
@@ -49,7 +57,7 @@ func databaseStatus(cfg *config.Config) ComponentStatus {
 }
 
 // buildSessionSummary fetches sessions from the API and returns a summary.
-func buildSessionSummary(ctx context.Context, listenAddr string) SessionSummary {
+func buildSessionSummary(ctx context.Context, listenAddr string, maxSessions int) SessionSummary {
 	baseURL := fmt.Sprintf("http://%s", listenAddr)
 	sessions, _ := fetchSessions(ctx, baseURL)
 	if sessions == nil {
@@ -57,7 +65,7 @@ func buildSessionSummary(ctx context.Context, listenAddr string) SessionSummary 
 	}
 	return SessionSummary{
 		Active: countActiveSessions(sessions),
-		Max:    defaultMaxSessions,
+		Max:    effectiveMaxSessions(maxSessions),
 		List:   sessions,
 	}
 }

--- a/cli/internal/runtime/status.go
+++ b/cli/internal/runtime/status.go
@@ -1,0 +1,94 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/niuulabs/volundr/cli/internal/config"
+)
+
+// RichStatus holds the full status of the Volundr stack, including
+// server info, session details, and component status.
+type RichStatus struct {
+	Mode     string          `json:"mode"`
+	Server   ComponentStatus `json:"server"`
+	WebUI    string          `json:"web_ui,omitempty"`
+	Tyr      *ComponentStatus `json:"tyr,omitempty"`
+	Database ComponentStatus `json:"database"`
+	Sessions SessionSummary  `json:"sessions"`
+
+	// K3s-specific fields.
+	Cluster *ClusterStatus `json:"cluster,omitempty"`
+	Proxy   string         `json:"proxy,omitempty"`
+	Pods    []PodStatus    `json:"pods,omitempty"`
+}
+
+// ComponentStatus describes the status of a single component (server, db, tyr).
+type ComponentStatus struct {
+	Status  string `json:"status"`
+	Address string `json:"address,omitempty"`
+	PID     int    `json:"pid,omitempty"`
+	Port    int    `json:"port,omitempty"`
+	Detail  string `json:"detail,omitempty"`
+}
+
+// databaseStatus returns a ComponentStatus for the database from config.
+func databaseStatus(cfg *config.Config) ComponentStatus {
+	if cfg.Database.Mode == "embedded" {
+		return ComponentStatus{
+			Status: "running",
+			Detail: fmt.Sprintf("embedded PostgreSQL on port %d", cfg.Database.Port),
+			Port:   cfg.Database.Port,
+		}
+	}
+	return ComponentStatus{
+		Status: "running",
+		Detail: fmt.Sprintf("external PostgreSQL at %s:%d", cfg.Database.Host, cfg.Database.Port),
+		Port:   cfg.Database.Port,
+	}
+}
+
+// buildSessionSummary fetches sessions from the API and returns a summary.
+func buildSessionSummary(ctx context.Context, listenAddr string) SessionSummary {
+	baseURL := fmt.Sprintf("http://%s", listenAddr)
+	sessions, _ := fetchSessions(ctx, baseURL)
+	if sessions == nil {
+		sessions = []SessionInfo{}
+	}
+	return SessionSummary{
+		Active: countActiveSessions(sessions),
+		Max:    defaultMaxSessions,
+		List:   sessions,
+	}
+}
+
+// SessionSummary holds aggregate session counts and the list of sessions.
+type SessionSummary struct {
+	Active int             `json:"active"`
+	Max    int             `json:"max"`
+	List   []SessionInfo   `json:"list"`
+}
+
+// SessionInfo holds details about a single session.
+type SessionInfo struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	Model     string `json:"model"`
+	Repo      string `json:"repo,omitempty"`
+	CreatedAt string `json:"created_at,omitempty"`
+}
+
+// ClusterStatus holds k3s/k3d cluster information.
+type ClusterStatus struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+}
+
+// PodStatus holds status for a Kubernetes pod.
+type PodStatus struct {
+	Name   string `json:"name"`
+	Ready  string `json:"ready"`
+	Status string `json:"status"`
+	Age    string `json:"age,omitempty"`
+}

--- a/cli/internal/runtime/status_test.go
+++ b/cli/internal/runtime/status_test.go
@@ -115,8 +115,8 @@ func TestLocalRuntime_RichStatus_NoPIDFile(t *testing.T) {
 		t.Errorf("expected database status 'stopped', got %q", rs.Database.Status)
 	}
 
-	if rs.Sessions.Max != defaultMaxSessions {
-		t.Errorf("expected max sessions %d, got %d", defaultMaxSessions, rs.Sessions.Max)
+	if rs.Sessions.Max != config.DefaultMaxSessions {
+		t.Errorf("expected max sessions %d, got %d", config.DefaultMaxSessions, rs.Sessions.Max)
 	}
 
 	if rs.Sessions.Active != 0 {
@@ -323,8 +323,8 @@ func TestDockerRuntime_RichStatus_Stopped(t *testing.T) {
 		t.Errorf("expected server status 'stopped', got %q", rs.Server.Status)
 	}
 
-	if rs.Sessions.Max != defaultMaxSessions {
-		t.Errorf("expected max sessions %d, got %d", defaultMaxSessions, rs.Sessions.Max)
+	if rs.Sessions.Max != config.DefaultMaxSessions {
+		t.Errorf("expected max sessions %d, got %d", config.DefaultMaxSessions, rs.Sessions.Max)
 	}
 }
 
@@ -366,8 +366,8 @@ func TestK3sRuntime_RichStatus_Stopped(t *testing.T) {
 		t.Errorf("expected server status 'stopped', got %q", rs.Server.Status)
 	}
 
-	if rs.Sessions.Max != defaultMaxSessions {
-		t.Errorf("expected max sessions %d, got %d", defaultMaxSessions, rs.Sessions.Max)
+	if rs.Sessions.Max != config.DefaultMaxSessions {
+		t.Errorf("expected max sessions %d, got %d", config.DefaultMaxSessions, rs.Sessions.Max)
 	}
 }
 
@@ -490,12 +490,12 @@ func TestDatabaseStatus_External(t *testing.T) {
 }
 
 func TestBuildSessionSummary_Unreachable(t *testing.T) {
-	summary := buildSessionSummary(context.Background(), "127.0.0.1:1")
+	summary := buildSessionSummary(context.Background(), "127.0.0.1:1", config.DefaultMaxSessions)
 	if summary.Active != 0 {
 		t.Errorf("expected 0 active, got %d", summary.Active)
 	}
-	if summary.Max != defaultMaxSessions {
-		t.Errorf("expected max %d, got %d", defaultMaxSessions, summary.Max)
+	if summary.Max != config.DefaultMaxSessions {
+		t.Errorf("expected max %d, got %d", config.DefaultMaxSessions, summary.Max)
 	}
 	if len(summary.List) != 0 {
 		t.Errorf("expected empty list, got %d", len(summary.List))
@@ -513,7 +513,7 @@ func TestBuildSessionSummary_WithServer(t *testing.T) {
 	defer server.Close()
 
 	addr := server.Listener.Addr().String()
-	summary := buildSessionSummary(context.Background(), addr)
+	summary := buildSessionSummary(context.Background(), addr, config.DefaultMaxSessions)
 	if summary.Active != 1 {
 		t.Errorf("expected 1 active, got %d", summary.Active)
 	}

--- a/cli/internal/runtime/status_test.go
+++ b/cli/internal/runtime/status_test.go
@@ -1,0 +1,678 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/niuulabs/volundr/cli/internal/config"
+)
+
+func TestCheckPIDFile_NoPIDFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	pid, running := checkPIDFile(tmpDir)
+	if running {
+		t.Error("expected not running when no PID file")
+	}
+	if pid != 0 {
+		t.Errorf("expected pid 0, got %d", pid)
+	}
+}
+
+func TestCheckPIDFile_InvalidPID(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	pidPath := filepath.Join(tmpDir, PIDFile)
+	if err := os.WriteFile(pidPath, []byte("not-a-number"), 0o600); err != nil {
+		t.Fatalf("write PID file: %v", err)
+	}
+
+	pid, running := checkPIDFile(tmpDir)
+	if running {
+		t.Error("expected not running for invalid PID")
+	}
+	if pid != 0 {
+		t.Errorf("expected pid 0, got %d", pid)
+	}
+}
+
+func TestCheckPIDFile_StalePID(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	pidPath := filepath.Join(tmpDir, PIDFile)
+	if err := os.WriteFile(pidPath, []byte("999999999"), 0o600); err != nil {
+		t.Fatalf("write PID file: %v", err)
+	}
+
+	pid, running := checkPIDFile(tmpDir)
+	if running {
+		t.Error("expected not running for stale PID")
+	}
+	if pid != 0 {
+		t.Errorf("expected pid 0, got %d", pid)
+	}
+}
+
+func TestCheckPIDFile_RunningProcess(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	pidPath := filepath.Join(tmpDir, PIDFile)
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+		t.Fatalf("write PID file: %v", err)
+	}
+
+	pid, running := checkPIDFile(tmpDir)
+	if !running {
+		t.Error("expected running for own PID")
+	}
+	if pid != os.Getpid() {
+		t.Errorf("expected pid %d, got %d", os.Getpid(), pid)
+	}
+}
+
+func TestLocalRuntime_RichStatus_NoPIDFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	volundrDir := filepath.Join(tmpDir, ".volundr")
+	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
+		t.Fatalf("create config dir: %v", err)
+	}
+
+	cfg := &config.Config{
+		Runtime: "local",
+		Listen: config.ListenConfig{
+			Host: "127.0.0.1",
+			Port: 8080,
+		},
+		Database: config.DatabaseConfig{
+			Mode: "embedded",
+			Port: 5433,
+		},
+	}
+
+	r := NewLocalRuntime()
+	rs, err := r.RichStatus(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("RichStatus: %v", err)
+	}
+
+	if rs.Mode != "local" {
+		t.Errorf("expected mode 'local', got %q", rs.Mode)
+	}
+
+	if rs.Server.Status != "stopped" {
+		t.Errorf("expected server status 'stopped', got %q", rs.Server.Status)
+	}
+
+	if rs.Database.Status != "stopped" {
+		t.Errorf("expected database status 'stopped', got %q", rs.Database.Status)
+	}
+
+	if rs.Sessions.Max != defaultMaxSessions {
+		t.Errorf("expected max sessions %d, got %d", defaultMaxSessions, rs.Sessions.Max)
+	}
+
+	if rs.Sessions.Active != 0 {
+		t.Errorf("expected 0 active sessions, got %d", rs.Sessions.Active)
+	}
+}
+
+func TestLocalRuntime_RichStatus_Running(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	volundrDir := filepath.Join(tmpDir, ".volundr")
+	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
+		t.Fatalf("create config dir: %v", err)
+	}
+
+	// Write a PID file with our own PID.
+	pidPath := filepath.Join(volundrDir, PIDFile)
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+		t.Fatalf("write PID file: %v", err)
+	}
+
+	cfg := &config.Config{
+		Runtime: "local",
+		Listen: config.ListenConfig{
+			Host: "127.0.0.1",
+			Port: 8080,
+		},
+		Database: config.DatabaseConfig{
+			Mode: "embedded",
+			Port: 5433,
+		},
+	}
+
+	r := NewLocalRuntime()
+	rs, err := r.RichStatus(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("RichStatus: %v", err)
+	}
+
+	if rs.Mode != "local" {
+		t.Errorf("expected mode 'local', got %q", rs.Mode)
+	}
+
+	if rs.Server.Status != "running" {
+		t.Errorf("expected server status 'running', got %q", rs.Server.Status)
+	}
+
+	if rs.Server.Address != "127.0.0.1:8080" {
+		t.Errorf("expected address '127.0.0.1:8080', got %q", rs.Server.Address)
+	}
+
+	if rs.Server.PID != os.Getpid() {
+		t.Errorf("expected PID %d, got %d", os.Getpid(), rs.Server.PID)
+	}
+
+	if rs.WebUI != "http://127.0.0.1:8080" {
+		t.Errorf("expected web UI 'http://127.0.0.1:8080', got %q", rs.WebUI)
+	}
+
+	if rs.Database.Status != "running" {
+		t.Errorf("expected database status 'running', got %q", rs.Database.Status)
+	}
+
+	if rs.Database.Port != 5433 {
+		t.Errorf("expected database port 5433, got %d", rs.Database.Port)
+	}
+}
+
+func TestLocalRuntime_RichStatus_ExternalDB(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	volundrDir := filepath.Join(tmpDir, ".volundr")
+	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
+		t.Fatalf("create config dir: %v", err)
+	}
+
+	// Write a PID file with our own PID.
+	pidPath := filepath.Join(volundrDir, PIDFile)
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+		t.Fatalf("write PID file: %v", err)
+	}
+
+	cfg := &config.Config{
+		Runtime: "local",
+		Listen: config.ListenConfig{
+			Host: "127.0.0.1",
+			Port: 8080,
+		},
+		Database: config.DatabaseConfig{
+			Mode: "external",
+			Host: "db.example.com",
+			Port: 5432,
+		},
+	}
+
+	r := NewLocalRuntime()
+	rs, err := r.RichStatus(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("RichStatus: %v", err)
+	}
+
+	if rs.Database.Detail != "external PostgreSQL at db.example.com:5432" {
+		t.Errorf("unexpected database detail: %q", rs.Database.Detail)
+	}
+}
+
+func TestRichStatus_JSONSerialization(t *testing.T) {
+	rs := &RichStatus{
+		Mode: "local",
+		Server: ComponentStatus{
+			Status:  "running",
+			Address: "127.0.0.1:8080",
+			PID:     12345,
+		},
+		WebUI: "http://127.0.0.1:8080",
+		Database: ComponentStatus{
+			Status: "running",
+			Detail: "embedded PostgreSQL on port 5433",
+			Port:   5433,
+		},
+		Sessions: SessionSummary{
+			Active: 2,
+			Max:    4,
+			List: []SessionInfo{
+				{
+					ID:     "a1b2c3d4",
+					Name:   "fix-auth-bug",
+					Status: "running",
+					Model:  "claude-sonnet-4",
+					Repo:   "github.com/org/api",
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(rs)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded RichStatus
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if decoded.Mode != "local" {
+		t.Errorf("expected mode 'local', got %q", decoded.Mode)
+	}
+	if decoded.Server.PID != 12345 {
+		t.Errorf("expected PID 12345, got %d", decoded.Server.PID)
+	}
+	if decoded.Sessions.Active != 2 {
+		t.Errorf("expected 2 active, got %d", decoded.Sessions.Active)
+	}
+	if len(decoded.Sessions.List) != 1 {
+		t.Fatalf("expected 1 session in list, got %d", len(decoded.Sessions.List))
+	}
+	if decoded.Sessions.List[0].ID != "a1b2c3d4" {
+		t.Errorf("expected session ID 'a1b2c3d4', got %q", decoded.Sessions.List[0].ID)
+	}
+	// Tyr and Cluster should be nil.
+	if decoded.Tyr != nil {
+		t.Error("expected nil Tyr")
+	}
+	if decoded.Cluster != nil {
+		t.Error("expected nil Cluster")
+	}
+}
+
+func TestDockerRuntime_RichStatus_Stopped(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	volundrDir := filepath.Join(tmpDir, ".volundr")
+	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
+		t.Fatalf("create config dir: %v", err)
+	}
+
+	cfg := &config.Config{
+		Runtime: "docker",
+		Listen: config.ListenConfig{
+			Host: "127.0.0.1",
+			Port: 8080,
+		},
+		Database: config.DatabaseConfig{
+			Mode: "embedded",
+			Port: 5433,
+		},
+	}
+
+	r := NewDockerRuntime()
+	rs, err := r.RichStatus(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("RichStatus: %v", err)
+	}
+
+	if rs.Mode != "docker" {
+		t.Errorf("expected mode 'docker', got %q", rs.Mode)
+	}
+
+	if rs.Server.Status != "stopped" {
+		t.Errorf("expected server status 'stopped', got %q", rs.Server.Status)
+	}
+
+	if rs.Sessions.Max != defaultMaxSessions {
+		t.Errorf("expected max sessions %d, got %d", defaultMaxSessions, rs.Sessions.Max)
+	}
+}
+
+func TestK3sRuntime_RichStatus_Stopped(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	volundrDir := filepath.Join(tmpDir, ".volundr")
+	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
+		t.Fatalf("create config dir: %v", err)
+	}
+
+	cfg := &config.Config{
+		Runtime: "k3s",
+		Listen: config.ListenConfig{
+			Host: "127.0.0.1",
+			Port: 8080,
+		},
+		Database: config.DatabaseConfig{
+			Mode: "embedded",
+			Port: 5433,
+		},
+		K3s: config.K3sConfig{
+			Namespace: "volundr",
+		},
+	}
+
+	r := NewK3sRuntime()
+	rs, err := r.RichStatus(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("RichStatus: %v", err)
+	}
+
+	if rs.Mode != "k3s" {
+		t.Errorf("expected mode 'k3s', got %q", rs.Mode)
+	}
+
+	if rs.Server.Status != "stopped" {
+		t.Errorf("expected server status 'stopped', got %q", rs.Server.Status)
+	}
+
+	if rs.Sessions.Max != defaultMaxSessions {
+		t.Errorf("expected max sessions %d, got %d", defaultMaxSessions, rs.Sessions.Max)
+	}
+}
+
+func TestLocalRuntime_RichStatus_WithSessions(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	volundrDir := filepath.Join(tmpDir, ".volundr")
+	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
+		t.Fatalf("create config dir: %v", err)
+	}
+
+	// Write a PID file with our own PID.
+	pidPath := filepath.Join(volundrDir, PIDFile)
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+		t.Fatalf("write PID file: %v", err)
+	}
+
+	// Start a fake API server that returns sessions.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/volundr/sessions" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{"id": "aaaa-bbbb-cccc-dddd", "name": "test-session", "model": "claude-sonnet-4", "status": "running", "created_at": "2026-03-29T10:00:00Z", "source": {"type": "git", "repo": "github.com/org/repo"}},
+			{"id": "eeee-ffff-0000-1111", "name": "stopped-session", "model": "claude-sonnet-4", "status": "stopped", "created_at": "2026-03-29T09:00:00Z", "source": {"type": "git", "repo": "github.com/org/other"}}
+		]`))
+	}))
+	defer server.Close()
+
+	// Parse the server address to use as listen config.
+	// server.URL is like "http://127.0.0.1:PORT"
+	addr := server.Listener.Addr().String()
+	host, portStr, _ := splitHostPort(addr)
+	port, _ := strconv.Atoi(portStr)
+
+	cfg := &config.Config{
+		Runtime: "local",
+		Listen: config.ListenConfig{
+			Host: host,
+			Port: port,
+		},
+		Database: config.DatabaseConfig{
+			Mode: "embedded",
+			Port: 5433,
+		},
+	}
+
+	r := NewLocalRuntime()
+	rs, err := r.RichStatus(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("RichStatus: %v", err)
+	}
+
+	if rs.Sessions.Active != 1 {
+		t.Errorf("expected 1 active session, got %d", rs.Sessions.Active)
+	}
+
+	if len(rs.Sessions.List) != 2 {
+		t.Fatalf("expected 2 sessions, got %d", len(rs.Sessions.List))
+	}
+
+	if rs.Sessions.List[0].Name != "test-session" {
+		t.Errorf("expected name 'test-session', got %q", rs.Sessions.List[0].Name)
+	}
+
+	if rs.Sessions.List[0].Repo != "github.com/org/repo" {
+		t.Errorf("expected repo 'github.com/org/repo', got %q", rs.Sessions.List[0].Repo)
+	}
+}
+
+// splitHostPort splits a host:port string. Simple version for tests.
+func splitHostPort(hostport string) (string, string, error) {
+	colon := len(hostport) - 1
+	for colon >= 0 && hostport[colon] != ':' {
+		colon--
+	}
+	if colon < 0 {
+		return hostport, "", nil
+	}
+	return hostport[:colon], hostport[colon+1:], nil
+}
+
+func TestDatabaseStatus_Embedded(t *testing.T) {
+	cfg := &config.Config{
+		Database: config.DatabaseConfig{
+			Mode: "embedded",
+			Port: 5433,
+		},
+	}
+	cs := databaseStatus(cfg)
+	if cs.Status != "running" {
+		t.Errorf("expected 'running', got %q", cs.Status)
+	}
+	if cs.Port != 5433 {
+		t.Errorf("expected port 5433, got %d", cs.Port)
+	}
+	if cs.Detail != "embedded PostgreSQL on port 5433" {
+		t.Errorf("unexpected detail: %q", cs.Detail)
+	}
+}
+
+func TestDatabaseStatus_External(t *testing.T) {
+	cfg := &config.Config{
+		Database: config.DatabaseConfig{
+			Mode: "external",
+			Host: "db.example.com",
+			Port: 5432,
+		},
+	}
+	cs := databaseStatus(cfg)
+	if cs.Status != "running" {
+		t.Errorf("expected 'running', got %q", cs.Status)
+	}
+	if cs.Detail != "external PostgreSQL at db.example.com:5432" {
+		t.Errorf("unexpected detail: %q", cs.Detail)
+	}
+}
+
+func TestBuildSessionSummary_Unreachable(t *testing.T) {
+	summary := buildSessionSummary(context.Background(), "127.0.0.1:1")
+	if summary.Active != 0 {
+		t.Errorf("expected 0 active, got %d", summary.Active)
+	}
+	if summary.Max != defaultMaxSessions {
+		t.Errorf("expected max %d, got %d", defaultMaxSessions, summary.Max)
+	}
+	if len(summary.List) != 0 {
+		t.Errorf("expected empty list, got %d", len(summary.List))
+	}
+}
+
+func TestBuildSessionSummary_WithServer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{"id": "aaaa-bbbb", "name": "s1", "model": "m1", "status": "running", "created_at": "", "source": {"type": "git", "repo": "r1"}},
+			{"id": "cccc-dddd", "name": "s2", "model": "m2", "status": "stopped", "created_at": "", "source": {"type": "git", "repo": "r2"}}
+		]`))
+	}))
+	defer server.Close()
+
+	addr := server.Listener.Addr().String()
+	summary := buildSessionSummary(context.Background(), addr)
+	if summary.Active != 1 {
+		t.Errorf("expected 1 active, got %d", summary.Active)
+	}
+	if len(summary.List) != 2 {
+		t.Errorf("expected 2 sessions, got %d", len(summary.List))
+	}
+}
+
+func TestDockerRuntime_RichStatus_Running(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	volundrDir := filepath.Join(tmpDir, ".volundr")
+	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
+		t.Fatalf("create config dir: %v", err)
+	}
+
+	// Mock docker inspect to return "running".
+	withMockExec(t, "MOCK_RESPONSE=running")
+
+	cfg := &config.Config{
+		Runtime: "docker",
+		Listen: config.ListenConfig{
+			Host: "127.0.0.1",
+			Port: 8080,
+		},
+		Database: config.DatabaseConfig{
+			Mode: "embedded",
+			Port: 5433,
+		},
+	}
+
+	r := NewDockerRuntime()
+	rs, err := r.RichStatus(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("RichStatus: %v", err)
+	}
+
+	if rs.Mode != "docker" {
+		t.Errorf("expected mode 'docker', got %q", rs.Mode)
+	}
+
+	if rs.Server.Status != "running" {
+		t.Errorf("expected server status 'running', got %q", rs.Server.Status)
+	}
+
+	if rs.WebUI != "http://127.0.0.1:8080" {
+		t.Errorf("expected web UI, got %q", rs.WebUI)
+	}
+
+	if rs.Database.Status != "running" {
+		t.Errorf("expected database running, got %q", rs.Database.Status)
+	}
+}
+
+func TestK3sRuntime_RichStatus_Running(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	volundrDir := filepath.Join(tmpDir, ".volundr")
+	if err := os.MkdirAll(volundrDir, 0o700); err != nil {
+		t.Fatalf("create config dir: %v", err)
+	}
+
+	// Mock commands: docker inspect returns "running", k3d cluster list returns cluster info,
+	// kubectl returns pod list.
+	mockCmds := `docker:::running|||k3d:::[{"name":"volundr","serversRunning":1}]|||kubectl:::{"items":[]}`
+	withMockExec(t, "MOCK_COMMANDS="+mockCmds)
+
+	cfg := &config.Config{
+		Runtime: "k3s",
+		Listen: config.ListenConfig{
+			Host: "127.0.0.1",
+			Port: 8080,
+		},
+		Database: config.DatabaseConfig{
+			Mode: "embedded",
+			Port: 5433,
+		},
+		K3s: config.K3sConfig{
+			Namespace: "volundr",
+		},
+	}
+
+	r := NewK3sRuntime()
+	rs, err := r.RichStatus(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("RichStatus: %v", err)
+	}
+
+	if rs.Mode != "k3s" {
+		t.Errorf("expected mode 'k3s', got %q", rs.Mode)
+	}
+
+	if rs.Server.Status != "running" {
+		t.Errorf("expected server status 'running', got %q", rs.Server.Status)
+	}
+
+	if rs.Cluster == nil {
+		t.Fatal("expected non-nil Cluster")
+	}
+
+	if rs.Cluster.Status != "running" {
+		t.Errorf("expected cluster status 'running', got %q", rs.Cluster.Status)
+	}
+
+	if rs.Database.Status != "running" {
+		t.Errorf("expected database running, got %q", rs.Database.Status)
+	}
+}
+
+func TestRichStatus_K3s_JSONSerialization(t *testing.T) {
+	rs := &RichStatus{
+		Mode: "k3s",
+		Server: ComponentStatus{
+			Status: "running",
+			Detail: "Docker container volundr-k3s-api",
+		},
+		Cluster: &ClusterStatus{
+			Name:   "k3d-volundr",
+			Status: "running",
+		},
+		Database: ComponentStatus{
+			Status: "running",
+			Port:   5433,
+		},
+		Proxy: "http://127.0.0.1:8080",
+		Sessions: SessionSummary{
+			Active: 1,
+			Max:    4,
+		},
+		Pods: []PodStatus{
+			{Name: "session-abc-skuld", Ready: "3/3", Status: "Running", Age: "12m"},
+		},
+	}
+
+	data, err := json.Marshal(rs)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded RichStatus
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if decoded.Mode != "k3s" {
+		t.Errorf("expected mode 'k3s', got %q", decoded.Mode)
+	}
+	if decoded.Cluster == nil {
+		t.Fatal("expected non-nil Cluster")
+	}
+	if decoded.Cluster.Name != "k3d-volundr" {
+		t.Errorf("expected cluster name 'k3d-volundr', got %q", decoded.Cluster.Name)
+	}
+	if len(decoded.Pods) != 1 {
+		t.Fatalf("expected 1 pod, got %d", len(decoded.Pods))
+	}
+	if decoded.Pods[0].Name != "session-abc-skuld" {
+		t.Errorf("expected pod name 'session-abc-skuld', got %q", decoded.Pods[0].Name)
+	}
+}


### PR DESCRIPTION
## Summary
- **Config-based runtime dispatch**: `status` now loads config and dispatches to the correct runtime's `RichStatus()` method instead of reading a static state file
- **Rich output for all modes**: Local, Docker, and K3s modes show server status, database info, web UI URL, and a session table with ID, name, status, model, repo, and age
- **JSON output**: `--json` flag produces structured JSON for scripting/AI consumption
- **Graceful degradation**: Falls back to state-file output when config is unavailable; shows "stopped" cleanly when server is not running

### Local mode output
```
Volundr (local mode)
  Server:     running on 127.0.0.1:8080 (PID 12345)
  Web UI:     http://127.0.0.1:8080
  Database:   embedded PostgreSQL on port 5433
  Sessions:   2/4 active

  ID          NAME             STATUS      MODEL               REPO                          AGE
  a1b2c3d4    fix-auth-bug     running     claude-sonnet-4     github.com/org/api            12m
```

### K3s mode output
```
Volundr (k3s mode)
  Server:     running (Docker container volundr-k3s-api)
  Cluster:    k3d-volundr (running)
  Database:   embedded PostgreSQL on port 5433
  Sessions:   1/4 active

  PODS (kubectl get pods -n volundr):
  NAME                            READY     STATUS      AGE
  session-a1b2c3-skuld            3/3       Running     12m
```

### Files changed
- `cli/internal/cli/status.go` — config-based dispatch, rich text + JSON formatting
- `cli/internal/runtime/runtime.go` — added `RichStatus()` to `Runtime` interface
- `cli/internal/runtime/status.go` — new rich status types and shared helpers
- `cli/internal/runtime/sessions.go` — API session fetching logic
- `cli/internal/runtime/local.go` — `LocalRuntime.RichStatus()`
- `cli/internal/runtime/docker.go` — `DockerRuntime.RichStatus()`
- `cli/internal/runtime/k3s.go` — `K3sRuntime.RichStatus()` with pod details
- `cli/internal/runtime/state.go` — `checkPIDFile` helper

## Test plan
- [x] All existing tests pass
- [x] New tests for `RichStatus()` on all three runtimes (stopped + running paths)
- [x] Session fetching tested with httptest mock server
- [x] JSON serialization round-trip tests
- [x] Format helpers (age, truncation) tested
- [x] Coverage at 85.3% (above 85% threshold)
- [x] `go vet ./...` clean

Closes NIU-329

🤖 Generated with [Claude Code](https://claude.com/claude-code)