### PR TITLE
feat(tyr): implement tyr-mini in Go for mini mode

### DIFF
--- a/charts/volundr/templates/migrations-configmap.yaml
+++ b/charts/volundr/templates/migrations-configmap.yaml
@@ -556,4 +556,103 @@ data:
   000020_feature_toggles.down.sql: |
     DROP TABLE IF EXISTS user_feature_preferences;
     DROP TABLE IF EXISTS feature_toggles;
+
+  tyr_000001_initial_schema.up.sql: |
+    -- Initial schema for tyr saga coordinator
+
+    CREATE TABLE IF NOT EXISTS sagas (
+        id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        tracker_id    TEXT NOT NULL,
+        tracker_type  TEXT NOT NULL,
+        slug          TEXT NOT NULL UNIQUE,
+        name          TEXT NOT NULL DEFAULT '',
+        repos         TEXT[] NOT NULL DEFAULT '{}',
+        status        TEXT NOT NULL DEFAULT 'ACTIVE',
+        confidence    FLOAT DEFAULT 0,
+        owner_id      TEXT NOT NULL DEFAULT 'default',
+        base_branch   TEXT NOT NULL DEFAULT 'main',
+        created_at    TIMESTAMPTZ DEFAULT NOW()
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_sagas_owner_id ON sagas(owner_id);
+
+    CREATE TABLE IF NOT EXISTS phases (
+        id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        saga_id       UUID NOT NULL REFERENCES sagas(id),
+        tracker_id    TEXT NOT NULL,
+        number        INT NOT NULL,
+        name          TEXT NOT NULL,
+        status        TEXT NOT NULL DEFAULT 'GATED',
+        confidence    FLOAT DEFAULT 0
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_phases_saga_id ON phases(saga_id);
+
+    CREATE TABLE IF NOT EXISTS raids (
+        id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        phase_id            UUID NOT NULL REFERENCES phases(id),
+        tracker_id          TEXT NOT NULL,
+        name                TEXT NOT NULL,
+        description         TEXT NOT NULL DEFAULT '',
+        acceptance_criteria TEXT[] NOT NULL DEFAULT '{}',
+        declared_files      TEXT[],
+        estimate_hours      FLOAT,
+        status              TEXT NOT NULL DEFAULT 'PENDING',
+        confidence          FLOAT DEFAULT 0,
+        session_id          TEXT,
+        branch              TEXT,
+        chronicle_summary   TEXT,
+        pr_url              TEXT,
+        pr_id               TEXT,
+        reason              TEXT,
+        retry_count         INT DEFAULT 0,
+        created_at          TIMESTAMPTZ DEFAULT NOW(),
+        updated_at          TIMESTAMPTZ DEFAULT NOW()
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_raids_phase_id ON raids(phase_id);
+    CREATE INDEX IF NOT EXISTS idx_raids_status ON raids(status);
+    CREATE INDEX IF NOT EXISTS idx_raids_session_id ON raids(session_id) WHERE session_id IS NOT NULL;
+
+    CREATE TABLE IF NOT EXISTS confidence_events (
+        id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        raid_id       UUID NOT NULL REFERENCES raids(id),
+        event_type    TEXT NOT NULL,
+        delta         FLOAT NOT NULL,
+        score_after   FLOAT NOT NULL,
+        created_at    TIMESTAMPTZ DEFAULT NOW()
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_confidence_events_raid_id ON confidence_events(raid_id);
+
+    CREATE TABLE IF NOT EXISTS dispatcher_state (
+        id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        owner_id             TEXT NOT NULL DEFAULT 'default',
+        running              BOOL DEFAULT TRUE,
+        threshold            FLOAT DEFAULT 0.75,
+        max_concurrent_raids INT NOT NULL DEFAULT 3,
+        updated_at           TIMESTAMPTZ DEFAULT NOW()
+    );
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_dispatcher_state_owner ON dispatcher_state(owner_id);
+
+  tyr_000001_initial_schema.down.sql: |
+    -- Rollback initial tyr schema
+
+    DROP INDEX IF EXISTS idx_dispatcher_state_owner;
+    DROP TABLE IF EXISTS dispatcher_state;
+
+    DROP INDEX IF EXISTS idx_confidence_events_raid_id;
+    DROP TABLE IF EXISTS confidence_events;
+
+    DROP INDEX IF EXISTS idx_raids_session_id;
+    DROP INDEX IF EXISTS idx_raids_status;
+    DROP INDEX IF EXISTS idx_raids_phase_id;
+    DROP TABLE IF EXISTS raids;
+
+    DROP INDEX IF EXISTS idx_phases_saga_id;
+    DROP TABLE IF EXISTS phases;
+
+    DROP INDEX IF EXISTS idx_sagas_owner_id;
+    DROP TABLE IF EXISTS sagas;
 {{- end }}

--- a/cli/internal/cli/init.go
+++ b/cli/internal/cli/init.go
@@ -216,6 +216,16 @@ func runInit(_ *cobra.Command, _ []string) error {
 		}
 	}
 
+	// Prompt for tyr-mini.
+	fmt.Println()
+	fmt.Print("Enable Tyr (saga/raid coordinator)? [Y/n]: ")
+	tyrAnswer, _ := reader.ReadString('\n')
+	tyrAnswer = strings.TrimSpace(strings.ToLower(tyrAnswer))
+	cfg.Tyr.Enabled = tyrAnswer != "n" && tyrAnswer != "no"
+	if cfg.Tyr.Enabled {
+		fmt.Println("  Tyr (mini) will start with 'volundr up'")
+	}
+
 	// Validate.
 	if err := cfg.Validate(); err != nil {
 		return fmt.Errorf("invalid configuration: %w", err)

--- a/cli/internal/cli/tyr.go
+++ b/cli/internal/cli/tyr.go
@@ -1,0 +1,174 @@
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	_ "github.com/lib/pq" // PostgreSQL driver
+
+	"github.com/spf13/cobra"
+
+	"github.com/niuulabs/volundr/cli/internal/config"
+	"github.com/niuulabs/volundr/cli/internal/tyr"
+)
+
+var tyrCmd = &cobra.Command{
+	Use:   "tyr",
+	Short: "Manage sagas, phases, and raids (tyr-mini)",
+	Long:  `Interact with tyr-mini — the lightweight saga coordinator for mini mode.`,
+}
+
+var tyrSagasCmd = &cobra.Command{
+	Use:   "sagas",
+	Short: "Manage sagas",
+}
+
+var tyrSagasListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all sagas",
+	RunE:  runTyrSagasList,
+}
+
+var tyrRaidsCmd = &cobra.Command{
+	Use:   "raids",
+	Short: "Manage raids",
+}
+
+var tyrRaidsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List raids for a phase",
+	RunE:  runTyrRaidsList,
+}
+
+var tyrStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show tyr-mini health status",
+	RunE:  runTyrStatus,
+}
+
+var tyrPhaseIDFlag string
+
+func init() {
+	tyrRaidsListCmd.Flags().StringVar(&tyrPhaseIDFlag, "phase", "", "Phase ID to list raids for")
+
+	tyrSagasCmd.AddCommand(tyrSagasListCmd)
+	tyrRaidsCmd.AddCommand(tyrRaidsListCmd)
+	tyrCmd.AddCommand(tyrSagasCmd)
+	tyrCmd.AddCommand(tyrRaidsCmd)
+	tyrCmd.AddCommand(tyrStatusCmd)
+
+	rootCmd.AddCommand(tyrCmd)
+}
+
+func openTyrStore() (*tyr.Store, func(), error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, nil, fmt.Errorf("load config: %w", err)
+	}
+
+	if !cfg.TyrEnabled() {
+		return nil, nil, fmt.Errorf("tyr is not enabled — run 'volundr init' and enable tyr, or set tyr.enabled: true in config")
+	}
+
+	db, err := sql.Open("postgres", cfg.DSN())
+	if err != nil {
+		return nil, nil, fmt.Errorf("open database: %w", err)
+	}
+
+	cleanup := func() { _ = db.Close() }
+
+	if err := db.PingContext(context.Background()); err != nil {
+		cleanup()
+		return nil, nil, fmt.Errorf("ping database (is volundr running?): %w", err)
+	}
+
+	return tyr.NewStore(db), cleanup, nil
+}
+
+func runTyrSagasList(_ *cobra.Command, _ []string) error {
+	store, cleanup, err := openTyrStore()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	sagas, err := store.ListSagas(context.Background())
+	if err != nil {
+		return fmt.Errorf("list sagas: %w", err)
+	}
+
+	if jsonOutput {
+		return json.NewEncoder(os.Stdout).Encode(sagas)
+	}
+
+	if len(sagas) == 0 {
+		fmt.Println("No sagas found.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tNAME\tSTATUS\tCONFIDENCE\tBRANCH")
+	for _, s := range sagas {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%.0f%%\t%s\n",
+			s.ID, s.Name, s.Status, s.Confidence*100, s.FeatureBranch())
+	}
+	return w.Flush()
+}
+
+func runTyrRaidsList(_ *cobra.Command, _ []string) error {
+	if tyrPhaseIDFlag == "" {
+		return fmt.Errorf("--phase flag is required")
+	}
+
+	store, cleanup, err := openTyrStore()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	raids, err := store.ListRaids(context.Background(), tyrPhaseIDFlag)
+	if err != nil {
+		return fmt.Errorf("list raids: %w", err)
+	}
+
+	if jsonOutput {
+		return json.NewEncoder(os.Stdout).Encode(raids)
+	}
+
+	if len(raids) == 0 {
+		fmt.Println("No raids found.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tNAME\tSTATUS\tCONFIDENCE\tSESSION")
+	for _, r := range raids {
+		sessionID := "-"
+		if r.SessionID != nil {
+			sessionID = *r.SessionID
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%.0f%%\t%s\n",
+			r.ID, r.Name, r.Status, r.Confidence*100, sessionID)
+	}
+	return w.Flush()
+}
+
+func runTyrStatus(_ *cobra.Command, _ []string) error {
+	store, cleanup, err := openTyrStore()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	if err := store.Ping(context.Background()); err != nil {
+		fmt.Println("tyr-mini: degraded (database unreachable)")
+		return nil
+	}
+
+	fmt.Println("tyr-mini: ok")
+	return nil
+}

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -83,6 +83,11 @@ type SessionsConfig struct {
 	MaxSessions int `yaml:"max_sessions"`
 }
 
+// TyrConfig holds tyr-mini settings.
+type TyrConfig struct {
+	Enabled bool `yaml:"enabled"`
+}
+
 // Config represents the full volundr configuration.
 type Config struct {
 	Runtime     string            `yaml:"runtime"`
@@ -92,6 +97,7 @@ type Config struct {
 	Database    DatabaseConfig    `yaml:"database"`
 	Anthropic   AnthropicConfig   `yaml:"anthropic"`
 	Sessions    SessionsConfig    `yaml:"sessions,omitempty"`
+	Tyr         TyrConfig         `yaml:"tyr,omitempty"`
 	Git         GitConfig         `yaml:"git,omitempty"`
 	Docker      DockerConfig      `yaml:"docker,omitempty"`
 	K3s         K3sConfig         `yaml:"k3s,omitempty"`
@@ -314,6 +320,11 @@ func (c *Config) WebEnabled() bool {
 		return true
 	}
 	return *c.Web
+}
+
+// TyrEnabled returns true if tyr-mini should be started.
+func (c *Config) TyrEnabled() bool {
+	return c.Tyr.Enabled
 }
 
 func boolPtr(v bool) *bool { return &v }

--- a/cli/internal/proxy/proxy.go
+++ b/cli/internal/proxy/proxy.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/niuulabs/volundr/cli/internal/tyr"
 	"github.com/niuulabs/volundr/cli/internal/web"
 )
 
@@ -36,6 +37,8 @@ type Router struct {
 	// rewriteHosts lists Docker-internal hostnames that should be replaced
 	// with the browser-facing host (derived from the request's Host header).
 	rewriteHosts []string
+	// tyrServer holds the tyr-mini server for route registration.
+	tyrServer *tyr.Server
 }
 
 // NewRouter creates a new Router with the given API backend URL.
@@ -91,6 +94,11 @@ func (r *Router) SetSessionBackend(backendURL string) error {
 	}
 	r.sessionBackend = u
 	return nil
+}
+
+// RegisterTyrRoutes stores the tyr-mini server for route mounting.
+func (r *Router) RegisterTyrRoutes(srv *tyr.Server) {
+	r.tyrServer = srv
 }
 
 // AddRewriteHost registers a Docker-internal hostname that should be
@@ -152,6 +160,11 @@ func (r *Router) Handler() http.Handler {
 	if r.sessionBackend != nil {
 		sessionProxy := httputil.NewSingleHostReverseProxy(r.sessionBackend)
 		mux.Handle("/s/", sessionProxy)
+	}
+
+	// Tyr-mini routes (served directly, not proxied).
+	if r.tyrServer != nil {
+		r.tyrServer.RegisterRoutes(mux)
 	}
 
 	// API routes -> Python API.

--- a/cli/internal/runtime/local.go
+++ b/cli/internal/runtime/local.go
@@ -16,6 +16,7 @@ import (
 	"github.com/niuulabs/volundr/cli/internal/config"
 	"github.com/niuulabs/volundr/cli/internal/migrations"
 	"github.com/niuulabs/volundr/cli/internal/proxy"
+	"github.com/niuulabs/volundr/cli/internal/tyr"
 )
 
 const (
@@ -30,6 +31,7 @@ type LocalRuntime struct {
 	pg       postgresProvider
 	apiCmd   *exec.Cmd
 	proxyRtr *proxy.Router
+	tyrSrv   *tyr.Server
 }
 
 // NewLocalRuntime creates a new LocalRuntime.
@@ -103,6 +105,18 @@ func (r *LocalRuntime) Up(ctx context.Context, cfg *config.Config) error {
 		}
 	}
 
+	// Start tyr-mini if enabled.
+	if cfg.TyrEnabled() {
+		fmt.Print("  Tyr (mini)    ... ")
+		tyrSrv, tyrErr := startTyrMini(ctx, cfg)
+		if tyrErr != nil {
+			fmt.Println("failed")
+			return fmt.Errorf("start tyr-mini: %w", tyrErr)
+		}
+		r.tyrSrv = tyrSrv
+		fmt.Println("started")
+	}
+
 	// Start the Python API.
 	fmt.Print("  Volundr API   ... ")
 	apiPort := cfg.Listen.Port + 1 // API on internal port, proxy on listen port
@@ -120,6 +134,12 @@ func (r *LocalRuntime) Up(ctx context.Context, cfg *config.Config) error {
 		fmt.Println("failed")
 		return fmt.Errorf("create proxy: %w", err)
 	}
+
+	// Mount tyr-mini routes on the proxy mux if enabled.
+	if r.tyrSrv != nil {
+		rtr.RegisterTyrRoutes(r.tyrSrv)
+	}
+
 	configureWeb(rtr, cfg)
 	r.proxyRtr = rtr
 
@@ -160,6 +180,13 @@ func (r *LocalRuntime) Down(_ context.Context) error {
 		case <-done:
 		case <-time.After(5 * time.Second):
 			_ = r.apiCmd.Process.Kill()
+		}
+	}
+
+	// Stop tyr-mini.
+	if r.tyrSrv != nil {
+		if err := r.tyrSrv.Close(); err != nil {
+			errs = append(errs, fmt.Sprintf("stop tyr-mini: %v", err))
 		}
 	}
 
@@ -461,6 +488,13 @@ func (r *LocalRuntime) writeStateFile(cfg *config.Config) error {
 		})
 	}
 
+	if r.tyrSrv != nil {
+		services = append(services, ServiceStatus{
+			Name:  "tyr-mini",
+			State: StateRunning,
+		})
+	}
+
 	return WriteStateFile(services)
 }
 
@@ -484,6 +518,16 @@ func findMigrationsDir() string {
 	}
 
 	return ""
+}
+
+// startTyrMini creates and initialises the tyr-mini server.
+func startTyrMini(ctx context.Context, cfg *config.Config) (*tyr.Server, error) {
+	apiPort := cfg.Listen.Port + 1
+	tyrCfg := tyr.ServerConfig{
+		ForgeBaseURL: fmt.Sprintf("http://127.0.0.1:%d", apiPort),
+		DSN:          cfg.DSN(),
+	}
+	return tyr.NewServer(ctx, tyrCfg, tyr.MigrationsFS())
 }
 
 // runMigrationsAuto runs migrations using embedded SQL files if available,

--- a/cli/internal/tyr/dispatcher.go
+++ b/cli/internal/tyr/dispatcher.go
@@ -1,0 +1,138 @@
+package tyr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// DispatcherConfig holds settings for the raid dispatcher.
+type DispatcherConfig struct {
+	// ForgeBaseURL is the base URL for the Forge API (e.g., "http://127.0.0.1:8081").
+	ForgeBaseURL string
+	// HTTPTimeout is the timeout for HTTP requests to Forge.
+	HTTPTimeout time.Duration
+}
+
+// DefaultDispatcherTimeout is the default HTTP timeout for dispatch requests.
+const DefaultDispatcherTimeout = 30 * time.Second
+
+// Dispatcher calls Forge to create coding sessions for raids.
+type Dispatcher struct {
+	cfg    DispatcherConfig
+	client *http.Client
+	store  *Store
+}
+
+// NewDispatcher creates a dispatcher with the given config and store.
+func NewDispatcher(cfg DispatcherConfig, store *Store) *Dispatcher {
+	timeout := cfg.HTTPTimeout
+	if timeout == 0 {
+		timeout = DefaultDispatcherTimeout
+	}
+	return &Dispatcher{
+		cfg:    cfg,
+		client: &http.Client{Timeout: timeout},
+		store:  store,
+	}
+}
+
+// sessionCreateRequest matches the Forge API session creation payload.
+type sessionCreateRequest struct {
+	Name   string `json:"name"`
+	Repo   string `json:"repo,omitempty"`
+	Branch string `json:"branch,omitempty"`
+}
+
+// sessionCreateResponse captures the relevant fields from Forge's response.
+type sessionCreateResponse struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Status string `json:"status"`
+}
+
+// DispatchRaid creates a Forge session for the given raid and updates its state.
+func (d *Dispatcher) DispatchRaid(ctx context.Context, raidID string) (*Raid, error) {
+	raid, err := d.store.GetRaid(ctx, raidID)
+	if err != nil {
+		return nil, err
+	}
+	if raid == nil {
+		return nil, fmt.Errorf("raid %s not found", raidID)
+	}
+
+	if !ValidTransition(raid.Status, RaidStatusDispatched) {
+		return nil, fmt.Errorf("cannot dispatch raid in status %s", raid.Status)
+	}
+
+	// Look up the saga to determine the repo.
+	phase, err := d.store.GetPhase(ctx, raid.PhaseID)
+	if err != nil {
+		return nil, fmt.Errorf("get phase for raid: %w", err)
+	}
+	if phase == nil {
+		return nil, fmt.Errorf("phase %s not found", raid.PhaseID)
+	}
+
+	saga, err := d.store.GetSaga(ctx, phase.SagaID)
+	if err != nil {
+		return nil, fmt.Errorf("get saga for phase: %w", err)
+	}
+	if saga == nil {
+		return nil, fmt.Errorf("saga %s not found", phase.SagaID)
+	}
+
+	repo := ""
+	if len(saga.Repos) > 0 {
+		repo = saga.Repos[0]
+	}
+
+	reqBody := sessionCreateRequest{
+		Name:   fmt.Sprintf("raid-%s", raid.ID),
+		Repo:   repo,
+		Branch: saga.FeatureBranch(),
+	}
+
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal session request: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/api/v1/volundr/sessions", d.cfg.ForgeBaseURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("create dispatch request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("dispatch to forge: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("forge returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var sessionResp sessionCreateResponse
+	if err := json.NewDecoder(resp.Body).Decode(&sessionResp); err != nil {
+		return nil, fmt.Errorf("decode forge response: %w", err)
+	}
+
+	// Update raid to dispatched state.
+	raid.Status = RaidStatusDispatched
+	raid.SessionID = &sessionResp.ID
+	branch := saga.FeatureBranch()
+	raid.Branch = &branch
+	if err := d.store.UpdateRaid(ctx, raid); err != nil {
+		return nil, fmt.Errorf("update raid after dispatch: %w", err)
+	}
+
+	return raid, nil
+}

--- a/cli/internal/tyr/dispatcher_test.go
+++ b/cli/internal/tyr/dispatcher_test.go
@@ -1,0 +1,221 @@
+package tyr
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/lib/pq"
+)
+
+func TestNewDispatcher(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	store := NewStore(db)
+	cfg := DispatcherConfig{ForgeBaseURL: "http://localhost:8081"}
+	d := NewDispatcher(cfg, store)
+
+	if d == nil {
+		t.Fatal("expected non-nil dispatcher")
+	}
+	if d.client.Timeout != DefaultDispatcherTimeout {
+		t.Errorf("expected default timeout, got %v", d.client.Timeout)
+	}
+}
+
+func TestNewDispatcher_CustomTimeout(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	store := NewStore(db)
+	cfg := DispatcherConfig{ForgeBaseURL: "http://localhost:8081", HTTPTimeout: 5 * time.Second}
+	d := NewDispatcher(cfg, store)
+
+	if d.client.Timeout != 5*time.Second {
+		t.Errorf("expected 5s timeout, got %v", d.client.Timeout)
+	}
+}
+
+func TestDispatcher_DispatchRaid(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	store := NewStore(db)
+
+	// Mock Forge server
+	forgeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/volundr/sessions" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+
+		var req sessionCreateRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(sessionCreateResponse{
+			ID:     "session-123",
+			Name:   req.Name,
+			Status: "pending",
+		})
+	}))
+	defer forgeServer.Close()
+
+	cfg := DispatcherConfig{ForgeBaseURL: forgeServer.URL}
+	d := NewDispatcher(cfg, store)
+
+	now := time.Now()
+	ctx := context.Background()
+
+	// GetRaid
+	raidRows := sqlmock.NewRows([]string{
+		"id", "phase_id", "tracker_id", "name", "description", "acceptance_criteria",
+		"declared_files", "estimate_hours", "status", "confidence", "session_id", "branch",
+		"chronicle_summary", "pr_url", "pr_id", "reason", "retry_count", "created_at", "updated_at",
+	}).AddRow("r1", "p1", "t1", "Raid 1", "", pq.Array([]string{}),
+		pq.Array([]string{}), nil, "PENDING", 0.0, nil, nil,
+		nil, nil, nil, nil, 0, now, now)
+	mock.ExpectQuery("SELECT .* FROM raids WHERE id").WithArgs("r1").WillReturnRows(raidRows)
+
+	// GetPhase
+	phaseRows := sqlmock.NewRows([]string{
+		"id", "saga_id", "tracker_id", "number", "name", "status", "confidence",
+	}).AddRow("p1", "saga-1", "t1", 1, "Phase 1", "ACTIVE", 0.0)
+	mock.ExpectQuery("SELECT .* FROM phases WHERE id").WithArgs("p1").WillReturnRows(phaseRows)
+
+	// GetSaga
+	sagaRows := sqlmock.NewRows([]string{
+		"id", "tracker_id", "tracker_type", "slug", "name", "repos",
+		"status", "confidence", "owner_id", "base_branch", "created_at",
+	}).AddRow("saga-1", "proj-1", "native", "my-saga", "My Saga", pq.Array([]string{"niuulabs/volundr"}),
+		"ACTIVE", 0.0, "default", "main", now)
+	mock.ExpectQuery("SELECT .* FROM sagas WHERE id").WithArgs("saga-1").WillReturnRows(sagaRows)
+
+	// UpdateRaid
+	mock.ExpectExec("UPDATE raids SET").WillReturnResult(sqlmock.NewResult(0, 1))
+
+	raid, err := d.DispatchRaid(ctx, "r1")
+	if err != nil {
+		t.Fatalf("DispatchRaid: %v", err)
+	}
+	if raid.Status != RaidStatusDispatched {
+		t.Errorf("expected DISPATCHED, got %s", raid.Status)
+	}
+	if raid.SessionID == nil || *raid.SessionID != "session-123" {
+		t.Errorf("expected session ID session-123, got %v", raid.SessionID)
+	}
+}
+
+func TestDispatcher_DispatchRaid_NotFound(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	store := NewStore(db)
+	d := NewDispatcher(DispatcherConfig{ForgeBaseURL: "http://localhost:8081"}, store)
+
+	mock.ExpectQuery("SELECT .* FROM raids WHERE id").
+		WithArgs("nonexistent").WillReturnError(sql.ErrNoRows)
+
+	_, err = d.DispatchRaid(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestDispatcher_DispatchRaid_InvalidStatus(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	store := NewStore(db)
+	d := NewDispatcher(DispatcherConfig{ForgeBaseURL: "http://localhost:8081"}, store)
+
+	now := time.Now()
+	// Raid in RUNNING state — cannot dispatch.
+	raidRows := sqlmock.NewRows([]string{
+		"id", "phase_id", "tracker_id", "name", "description", "acceptance_criteria",
+		"declared_files", "estimate_hours", "status", "confidence", "session_id", "branch",
+		"chronicle_summary", "pr_url", "pr_id", "reason", "retry_count", "created_at", "updated_at",
+	}).AddRow("r1", "p1", "t1", "Raid 1", "", pq.Array([]string{}),
+		pq.Array([]string{}), nil, "RUNNING", 0.0, nil, nil,
+		nil, nil, nil, nil, 0, now, now)
+	mock.ExpectQuery("SELECT .* FROM raids WHERE id").WithArgs("r1").WillReturnRows(raidRows)
+
+	_, err = d.DispatchRaid(context.Background(), "r1")
+	if err == nil {
+		t.Fatal("expected error for invalid status")
+	}
+}
+
+func TestDispatcher_DispatchRaid_ForgeError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	store := NewStore(db)
+
+	// Forge returns 500
+	forgeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("internal error"))
+	}))
+	defer forgeServer.Close()
+
+	d := NewDispatcher(DispatcherConfig{ForgeBaseURL: forgeServer.URL}, store)
+
+	now := time.Now()
+	ctx := context.Background()
+
+	raidRows := sqlmock.NewRows([]string{
+		"id", "phase_id", "tracker_id", "name", "description", "acceptance_criteria",
+		"declared_files", "estimate_hours", "status", "confidence", "session_id", "branch",
+		"chronicle_summary", "pr_url", "pr_id", "reason", "retry_count", "created_at", "updated_at",
+	}).AddRow("r1", "p1", "t1", "Raid 1", "", pq.Array([]string{}),
+		pq.Array([]string{}), nil, "PENDING", 0.0, nil, nil,
+		nil, nil, nil, nil, 0, now, now)
+	mock.ExpectQuery("SELECT .* FROM raids WHERE id").WithArgs("r1").WillReturnRows(raidRows)
+
+	phaseRows := sqlmock.NewRows([]string{
+		"id", "saga_id", "tracker_id", "number", "name", "status", "confidence",
+	}).AddRow("p1", "saga-1", "t1", 1, "Phase 1", "ACTIVE", 0.0)
+	mock.ExpectQuery("SELECT .* FROM phases WHERE id").WithArgs("p1").WillReturnRows(phaseRows)
+
+	sagaRows := sqlmock.NewRows([]string{
+		"id", "tracker_id", "tracker_type", "slug", "name", "repos",
+		"status", "confidence", "owner_id", "base_branch", "created_at",
+	}).AddRow("saga-1", "proj-1", "native", "my-saga", "My Saga", pq.Array([]string{"repo1"}),
+		"ACTIVE", 0.0, "default", "main", now)
+	mock.ExpectQuery("SELECT .* FROM sagas WHERE id").WithArgs("saga-1").WillReturnRows(sagaRows)
+
+	_, err = d.DispatchRaid(ctx, "r1")
+	if err == nil {
+		t.Fatal("expected error from forge")
+	}
+}

--- a/cli/internal/tyr/handler.go
+++ b/cli/internal/tyr/handler.go
@@ -200,7 +200,13 @@ func (h *Handler) updateSaga(w http.ResponseWriter, r *http.Request, id string) 
 		return
 	}
 
-	var update Saga
+	var update struct {
+		Name       string     `json:"name"`
+		Status     SagaStatus `json:"status"`
+		Repos      []string   `json:"repos"`
+		BaseBranch string     `json:"base_branch"`
+		Confidence *float64   `json:"confidence"`
+	}
 	if err := json.NewDecoder(r.Body).Decode(&update); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
 		return
@@ -218,8 +224,8 @@ func (h *Handler) updateSaga(w http.ResponseWriter, r *http.Request, id string) 
 	if update.BaseBranch != "" {
 		existing.BaseBranch = update.BaseBranch
 	}
-	if update.Confidence != 0 {
-		existing.Confidence = update.Confidence
+	if update.Confidence != nil {
+		existing.Confidence = *update.Confidence
 	}
 
 	if err := h.store.UpdateSaga(r.Context(), existing); err != nil {
@@ -378,7 +384,11 @@ func (h *Handler) updatePhaseHandler(w http.ResponseWriter, r *http.Request, id 
 		return
 	}
 
-	var update Phase
+	var update struct {
+		Name       string      `json:"name"`
+		Status     PhaseStatus `json:"status"`
+		Confidence *float64    `json:"confidence"`
+	}
 	if err := json.NewDecoder(r.Body).Decode(&update); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
 		return
@@ -390,8 +400,8 @@ func (h *Handler) updatePhaseHandler(w http.ResponseWriter, r *http.Request, id 
 	if update.Status != "" {
 		existing.Status = update.Status
 	}
-	if update.Confidence != 0 {
-		existing.Confidence = update.Confidence
+	if update.Confidence != nil {
+		existing.Confidence = *update.Confidence
 	}
 
 	if err := h.store.UpdatePhase(r.Context(), existing); err != nil {

--- a/cli/internal/tyr/handler.go
+++ b/cli/internal/tyr/handler.go
@@ -1,0 +1,717 @@
+package tyr
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// Handler provides HTTP handlers for the tyr-mini REST API.
+type Handler struct {
+	store      *Store
+	dispatcher *Dispatcher
+}
+
+// NewHandler creates a handler with the given store and dispatcher.
+func NewHandler(store *Store, dispatcher *Dispatcher) *Handler {
+	return &Handler{store: store, dispatcher: dispatcher}
+}
+
+// RegisterRoutes mounts all tyr-mini API routes onto the given mux.
+// All routes are prefixed with /api/v1/tyr/.
+func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/api/v1/tyr/sagas", h.handleSagas)
+	mux.HandleFunc("/api/v1/tyr/sagas/", h.handleSagaByID)
+	mux.HandleFunc("/api/v1/tyr/phases", h.handlePhases)
+	mux.HandleFunc("/api/v1/tyr/phases/", h.handlePhaseByID)
+	mux.HandleFunc("/api/v1/tyr/raids", h.handleRaids)
+	mux.HandleFunc("/api/v1/tyr/raids/", h.handleRaidByID)
+	mux.HandleFunc("/api/v1/tyr/health", h.handleHealth)
+}
+
+// --- Sagas ---
+
+func (h *Handler) handleSagas(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		h.listSagas(w, r)
+	case http.MethodPost:
+		h.createSaga(w, r)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
+func (h *Handler) handleSagaByID(w http.ResponseWriter, r *http.Request) {
+	id := extractID(r.URL.Path, "/api/v1/tyr/sagas/")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "missing saga id")
+		return
+	}
+
+	// Check for sub-resource paths.
+	parts := strings.SplitN(id, "/", 2)
+	sagaID := parts[0]
+
+	if len(parts) == 2 {
+		subPath := parts[1]
+		switch {
+		case subPath == "phases":
+			h.handleSagaPhases(w, r, sagaID)
+		case strings.HasPrefix(subPath, "phases/"):
+			// Redirect to phase-specific handler.
+			h.handleSagaSubPhase(w, r, sagaID, strings.TrimPrefix(subPath, "phases/"))
+		default:
+			writeError(w, http.StatusNotFound, "not found")
+		}
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getSaga(w, r, sagaID)
+	case http.MethodPut:
+		h.updateSaga(w, r, sagaID)
+	case http.MethodDelete:
+		h.deleteSaga(w, r, sagaID)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
+func (h *Handler) listSagas(w http.ResponseWriter, r *http.Request) {
+	sagas, err := h.store.ListSagas(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if sagas == nil {
+		sagas = []*Saga{}
+	}
+
+	type sagaListItem struct {
+		*Saga
+		FeatureBranch string `json:"feature_branch"`
+	}
+
+	items := make([]sagaListItem, len(sagas))
+	for i, s := range sagas {
+		items[i] = sagaListItem{Saga: s, FeatureBranch: s.FeatureBranch()}
+	}
+	writeJSON(w, http.StatusOK, items)
+}
+
+func (h *Handler) createSaga(w http.ResponseWriter, r *http.Request) {
+	var saga Saga
+	if err := json.NewDecoder(r.Body).Decode(&saga); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		return
+	}
+
+	if saga.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	if saga.Slug == "" {
+		writeError(w, http.StatusBadRequest, "slug is required")
+		return
+	}
+	if saga.Status == "" {
+		saga.Status = SagaStatusActive
+	}
+	if saga.OwnerID == "" {
+		saga.OwnerID = "default"
+	}
+	if saga.BaseBranch == "" {
+		saga.BaseBranch = "main"
+	}
+	if saga.TrackerType == "" {
+		saga.TrackerType = "native"
+	}
+	if saga.TrackerID == "" {
+		saga.TrackerID = saga.Slug
+	}
+
+	created, err := h.store.CreateSaga(r.Context(), &saga)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, created)
+}
+
+func (h *Handler) getSaga(w http.ResponseWriter, r *http.Request, id string) {
+	saga, err := h.store.GetSaga(r.Context(), id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if saga == nil {
+		writeError(w, http.StatusNotFound, "saga not found")
+		return
+	}
+
+	// Build detail response with phases and raids.
+	phases, err := h.store.ListPhases(r.Context(), id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	type phaseDetail struct {
+		*Phase
+		Raids []*Raid `json:"raids"`
+	}
+
+	phaseDetails := make([]phaseDetail, 0, len(phases))
+	for _, p := range phases {
+		raids, raidErr := h.store.ListRaids(r.Context(), p.ID)
+		if raidErr != nil {
+			writeError(w, http.StatusInternalServerError, raidErr.Error())
+			return
+		}
+		if raids == nil {
+			raids = []*Raid{}
+		}
+		phaseDetails = append(phaseDetails, phaseDetail{Phase: p, Raids: raids})
+	}
+
+	resp := struct {
+		*Saga
+		FeatureBranch string        `json:"feature_branch"`
+		Phases        []phaseDetail `json:"phases"`
+	}{
+		Saga:          saga,
+		FeatureBranch: saga.FeatureBranch(),
+		Phases:        phaseDetails,
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (h *Handler) updateSaga(w http.ResponseWriter, r *http.Request, id string) {
+	existing, err := h.store.GetSaga(r.Context(), id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if existing == nil {
+		writeError(w, http.StatusNotFound, "saga not found")
+		return
+	}
+
+	var update Saga
+	if err := json.NewDecoder(r.Body).Decode(&update); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		return
+	}
+
+	if update.Name != "" {
+		existing.Name = update.Name
+	}
+	if update.Status != "" {
+		existing.Status = update.Status
+	}
+	if len(update.Repos) > 0 {
+		existing.Repos = update.Repos
+	}
+	if update.BaseBranch != "" {
+		existing.BaseBranch = update.BaseBranch
+	}
+	if update.Confidence != 0 {
+		existing.Confidence = update.Confidence
+	}
+
+	if err := h.store.UpdateSaga(r.Context(), existing); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, existing)
+}
+
+func (h *Handler) deleteSaga(w http.ResponseWriter, r *http.Request, id string) {
+	if err := h.store.DeleteSaga(r.Context(), id); err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// --- Phases ---
+
+func (h *Handler) handleSagaPhases(w http.ResponseWriter, r *http.Request, sagaID string) {
+	switch r.Method {
+	case http.MethodGet:
+		h.listPhasesBySaga(w, r, sagaID)
+	case http.MethodPost:
+		h.createPhaseForSaga(w, r, sagaID)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
+func (h *Handler) handleSagaSubPhase(w http.ResponseWriter, r *http.Request, _ string, phaseIDAndSub string) {
+	parts := strings.SplitN(phaseIDAndSub, "/", 2)
+	phaseID := parts[0]
+
+	if len(parts) == 2 && parts[1] == "raids" {
+		h.handlePhaseRaids(w, r, phaseID)
+		return
+	}
+
+	// Single phase operations under saga.
+	switch r.Method {
+	case http.MethodGet:
+		h.getPhase(w, r, phaseID)
+	case http.MethodPut:
+		h.updatePhaseHandler(w, r, phaseID)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
+func (h *Handler) handlePhases(w http.ResponseWriter, r *http.Request) {
+	sagaID := r.URL.Query().Get("saga_id")
+	if sagaID == "" {
+		writeError(w, http.StatusBadRequest, "saga_id query parameter is required")
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		h.listPhasesBySaga(w, r, sagaID)
+	case http.MethodPost:
+		h.createPhaseForSaga(w, r, sagaID)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
+func (h *Handler) handlePhaseByID(w http.ResponseWriter, r *http.Request) {
+	id := extractID(r.URL.Path, "/api/v1/tyr/phases/")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "missing phase id")
+		return
+	}
+
+	parts := strings.SplitN(id, "/", 2)
+	phaseID := parts[0]
+
+	if len(parts) == 2 && parts[1] == "raids" {
+		h.handlePhaseRaids(w, r, phaseID)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getPhase(w, r, phaseID)
+	case http.MethodPut:
+		h.updatePhaseHandler(w, r, phaseID)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
+func (h *Handler) listPhasesBySaga(w http.ResponseWriter, r *http.Request, sagaID string) {
+	phases, err := h.store.ListPhases(r.Context(), sagaID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if phases == nil {
+		phases = []*Phase{}
+	}
+	writeJSON(w, http.StatusOK, phases)
+}
+
+func (h *Handler) createPhaseForSaga(w http.ResponseWriter, r *http.Request, sagaID string) {
+	var phase Phase
+	if err := json.NewDecoder(r.Body).Decode(&phase); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		return
+	}
+
+	phase.SagaID = sagaID
+	if phase.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	if phase.Status == "" {
+		phase.Status = PhaseStatusGated
+	}
+	if phase.TrackerID == "" {
+		phase.TrackerID = fmt.Sprintf("phase-%d", phase.Number)
+	}
+
+	created, err := h.store.CreatePhase(r.Context(), &phase)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, created)
+}
+
+func (h *Handler) getPhase(w http.ResponseWriter, r *http.Request, id string) {
+	phase, err := h.store.GetPhase(r.Context(), id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if phase == nil {
+		writeError(w, http.StatusNotFound, "phase not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, phase)
+}
+
+func (h *Handler) updatePhaseHandler(w http.ResponseWriter, r *http.Request, id string) {
+	existing, err := h.store.GetPhase(r.Context(), id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if existing == nil {
+		writeError(w, http.StatusNotFound, "phase not found")
+		return
+	}
+
+	var update Phase
+	if err := json.NewDecoder(r.Body).Decode(&update); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		return
+	}
+
+	if update.Name != "" {
+		existing.Name = update.Name
+	}
+	if update.Status != "" {
+		existing.Status = update.Status
+	}
+	if update.Confidence != 0 {
+		existing.Confidence = update.Confidence
+	}
+
+	if err := h.store.UpdatePhase(r.Context(), existing); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, existing)
+}
+
+// --- Raids ---
+
+func (h *Handler) handlePhaseRaids(w http.ResponseWriter, r *http.Request, phaseID string) {
+	switch r.Method {
+	case http.MethodGet:
+		h.listRaidsByPhase(w, r, phaseID)
+	case http.MethodPost:
+		h.createRaidForPhase(w, r, phaseID)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
+func (h *Handler) handleRaids(w http.ResponseWriter, r *http.Request) {
+	phaseID := r.URL.Query().Get("phase_id")
+	if phaseID == "" {
+		writeError(w, http.StatusBadRequest, "phase_id query parameter is required")
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		h.listRaidsByPhase(w, r, phaseID)
+	case http.MethodPost:
+		h.createRaidForPhase(w, r, phaseID)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
+func (h *Handler) handleRaidByID(w http.ResponseWriter, r *http.Request) {
+	id := extractID(r.URL.Path, "/api/v1/tyr/raids/")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "missing raid id")
+		return
+	}
+
+	parts := strings.SplitN(id, "/", 2)
+	raidID := parts[0]
+
+	if len(parts) == 2 {
+		switch parts[1] {
+		case "dispatch":
+			h.dispatchRaid(w, r, raidID)
+		case "status":
+			h.updateRaidStatusHandler(w, r, raidID)
+		case "confidence":
+			h.handleConfidence(w, r, raidID)
+		default:
+			writeError(w, http.StatusNotFound, "not found")
+		}
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getRaid(w, r, raidID)
+	case http.MethodPut:
+		h.updateRaidHandler(w, r, raidID)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
+func (h *Handler) listRaidsByPhase(w http.ResponseWriter, r *http.Request, phaseID string) {
+	raids, err := h.store.ListRaids(r.Context(), phaseID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if raids == nil {
+		raids = []*Raid{}
+	}
+	writeJSON(w, http.StatusOK, raids)
+}
+
+func (h *Handler) createRaidForPhase(w http.ResponseWriter, r *http.Request, phaseID string) {
+	var raid Raid
+	if err := json.NewDecoder(r.Body).Decode(&raid); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		return
+	}
+
+	raid.PhaseID = phaseID
+	if raid.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	if raid.Status == "" {
+		raid.Status = RaidStatusPending
+	}
+	if raid.TrackerID == "" {
+		raid.TrackerID = raid.Name
+	}
+
+	created, err := h.store.CreateRaid(r.Context(), &raid)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, created)
+}
+
+func (h *Handler) getRaid(w http.ResponseWriter, r *http.Request, id string) {
+	raid, err := h.store.GetRaid(r.Context(), id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if raid == nil {
+		writeError(w, http.StatusNotFound, "raid not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, raid)
+}
+
+func (h *Handler) updateRaidHandler(w http.ResponseWriter, r *http.Request, id string) {
+	existing, err := h.store.GetRaid(r.Context(), id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if existing == nil {
+		writeError(w, http.StatusNotFound, "raid not found")
+		return
+	}
+
+	var update Raid
+	if err := json.NewDecoder(r.Body).Decode(&update); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		return
+	}
+
+	if update.Name != "" {
+		existing.Name = update.Name
+	}
+	if update.Description != "" {
+		existing.Description = update.Description
+	}
+	if len(update.AcceptanceCriteria) > 0 {
+		existing.AcceptanceCriteria = update.AcceptanceCriteria
+	}
+	if len(update.DeclaredFiles) > 0 {
+		existing.DeclaredFiles = update.DeclaredFiles
+	}
+	if update.EstimateHours != nil {
+		existing.EstimateHours = update.EstimateHours
+	}
+
+	if err := h.store.UpdateRaid(r.Context(), existing); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, existing)
+}
+
+func (h *Handler) dispatchRaid(w http.ResponseWriter, r *http.Request, id string) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	if h.dispatcher == nil {
+		writeError(w, http.StatusServiceUnavailable, "dispatcher not configured")
+		return
+	}
+
+	raid, err := h.dispatcher.DispatchRaid(r.Context(), id)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		if strings.Contains(err.Error(), "cannot dispatch") {
+			writeError(w, http.StatusConflict, err.Error())
+			return
+		}
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, raid)
+}
+
+func (h *Handler) updateRaidStatusHandler(w http.ResponseWriter, r *http.Request, id string) {
+	if r.Method != http.MethodPut && r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	var body struct {
+		Status RaidStatus `json:"status"`
+		Reason *string    `json:"reason,omitempty"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		return
+	}
+
+	if body.Status == "" {
+		writeError(w, http.StatusBadRequest, "status is required")
+		return
+	}
+
+	if err := h.store.UpdateRaidStatus(r.Context(), id, body.Status, body.Reason); err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		if strings.Contains(err.Error(), "invalid transition") {
+			writeError(w, http.StatusConflict, err.Error())
+			return
+		}
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	raid, err := h.store.GetRaid(r.Context(), id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, raid)
+}
+
+// --- Confidence ---
+
+func (h *Handler) handleConfidence(w http.ResponseWriter, r *http.Request, raidID string) {
+	switch r.Method {
+	case http.MethodGet:
+		h.listConfidenceEvents(w, r, raidID)
+	case http.MethodPost:
+		h.createConfidenceEvent(w, r, raidID)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
+func (h *Handler) listConfidenceEvents(w http.ResponseWriter, r *http.Request, raidID string) {
+	events, err := h.store.ListConfidenceEvents(r.Context(), raidID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if events == nil {
+		events = []*ConfidenceEvent{}
+	}
+	writeJSON(w, http.StatusOK, events)
+}
+
+func (h *Handler) createConfidenceEvent(w http.ResponseWriter, r *http.Request, raidID string) {
+	var body struct {
+		EventType ConfidenceEventType `json:"event_type"`
+		Delta     float64             `json:"delta"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		return
+	}
+	if body.EventType == "" {
+		writeError(w, http.StatusBadRequest, "event_type is required")
+		return
+	}
+
+	event, err := h.store.CreateConfidenceEvent(r.Context(), raidID, body.EventType, body.Delta)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			writeError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, event)
+}
+
+// --- Health ---
+
+func (h *Handler) handleHealth(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	status := "ok"
+	if err := h.store.Ping(r.Context()); err != nil {
+		status = "degraded"
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{
+		"service": "tyr-mini",
+		"status":  status,
+	})
+}
+
+// --- Helpers ---
+
+func extractID(path, prefix string) string {
+	return strings.TrimPrefix(path, prefix)
+}
+
+type errorResponse struct {
+	Error string `json:"error"`
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(errorResponse{Error: msg})
+}
+
+func writeJSON(w http.ResponseWriter, status int, data any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(data)
+}

--- a/cli/internal/tyr/handler_error_test.go
+++ b/cli/internal/tyr/handler_error_test.go
@@ -1,0 +1,455 @@
+package tyr
+
+import (
+	"bytes"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/lib/pq"
+)
+
+// Tests for error paths in handlers that hit SQL errors (db.QueryContext returns error).
+
+func TestHandler_ListSagas_DBError(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+	mock.ExpectQuery("SELECT .* FROM sagas ORDER BY").WillReturnError(sql.ErrConnDone)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/sagas", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestHandler_CreateSaga_DBError(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+	mock.ExpectQuery("INSERT INTO sagas").WillReturnError(sql.ErrConnDone)
+
+	body := `{"name":"Test","slug":"test"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tyr/sagas", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestHandler_GetSaga_DBError(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+	mock.ExpectQuery("SELECT .* FROM sagas WHERE id").WillReturnError(sql.ErrConnDone)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/sagas/uuid-1", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestHandler_GetSaga_PhaseListError(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	now := time.Now()
+	sagaRows := sqlmock.NewRows([]string{
+		"id", "tracker_id", "tracker_type", "slug", "name", "repos",
+		"status", "confidence", "owner_id", "base_branch", "created_at",
+	}).AddRow("uuid-1", "p1", "native", "test", "Test", pq.Array([]string{}),
+		"ACTIVE", 0.0, "default", "main", now)
+	mock.ExpectQuery("SELECT .* FROM sagas WHERE id").WillReturnRows(sagaRows)
+	mock.ExpectQuery("SELECT .* FROM phases WHERE saga_id").WillReturnError(sql.ErrConnDone)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/sagas/uuid-1", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestHandler_GetSaga_RaidListError(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	now := time.Now()
+	sagaRows := sqlmock.NewRows([]string{
+		"id", "tracker_id", "tracker_type", "slug", "name", "repos",
+		"status", "confidence", "owner_id", "base_branch", "created_at",
+	}).AddRow("uuid-1", "p1", "native", "test", "Test", pq.Array([]string{}),
+		"ACTIVE", 0.0, "default", "main", now)
+	mock.ExpectQuery("SELECT .* FROM sagas WHERE id").WillReturnRows(sagaRows)
+
+	phaseRows := sqlmock.NewRows([]string{
+		"id", "saga_id", "tracker_id", "number", "name", "status", "confidence",
+	}).AddRow("p1", "uuid-1", "t1", 1, "Phase 1", "ACTIVE", 0.5)
+	mock.ExpectQuery("SELECT .* FROM phases WHERE saga_id").WillReturnRows(phaseRows)
+	mock.ExpectQuery("SELECT .* FROM raids WHERE phase_id").WillReturnError(sql.ErrConnDone)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/sagas/uuid-1", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestHandler_UpdateSaga_DBError(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	mock.ExpectQuery("SELECT .* FROM sagas WHERE id").WillReturnError(sql.ErrConnDone)
+
+	body := `{"name":"Updated"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/tyr/sagas/uuid-1", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestHandler_UpdateSaga_UpdateError(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	now := time.Now()
+	sagaRows := sqlmock.NewRows([]string{
+		"id", "tracker_id", "tracker_type", "slug", "name", "repos",
+		"status", "confidence", "owner_id", "base_branch", "created_at",
+	}).AddRow("uuid-1", "p1", "native", "test", "Test", pq.Array([]string{}),
+		"ACTIVE", 0.0, "default", "main", now)
+	mock.ExpectQuery("SELECT .* FROM sagas WHERE id").WillReturnRows(sagaRows)
+	mock.ExpectExec("UPDATE sagas SET").WillReturnError(sql.ErrConnDone)
+
+	body := `{"name":"Updated"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/tyr/sagas/uuid-1", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestHandler_DeleteSaga_DBError(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	mock.ExpectBegin()
+	mock.ExpectExec("DELETE FROM confidence_events").WillReturnError(sql.ErrConnDone)
+	mock.ExpectRollback()
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/tyr/sagas/uuid-1", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestHandler_ListPhases_DBError(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+	mock.ExpectQuery("SELECT .* FROM phases WHERE saga_id").WillReturnError(sql.ErrConnDone)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/sagas/saga-1/phases", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestHandler_CreatePhase_DBError(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+	mock.ExpectQuery("INSERT INTO phases").WillReturnError(sql.ErrConnDone)
+
+	body := `{"name":"Phase 1","number":1}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tyr/sagas/saga-1/phases", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestHandler_GetPhase_DBError(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+	mock.ExpectQuery("SELECT .* FROM phases WHERE id").WillReturnError(sql.ErrConnDone)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/phases/p1", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestHandler_UpdatePhase_DBError(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+	mock.ExpectQuery("SELECT .* FROM phases WHERE id").WillReturnError(sql.ErrConnDone)
+
+	body := `{"name":"Updated"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/tyr/phases/p1", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestHandler_UpdatePhase_UpdateError(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	rows := sqlmock.NewRows([]string{
+		"id", "saga_id", "tracker_id", "number", "name", "status", "confidence",
+	}).AddRow("p1", "saga-1", "t1", 1, "Phase 1", "GATED", 0.0)
+	mock.ExpectQuery("SELECT .* FROM phases WHERE id").WillReturnRows(rows)
+	mock.ExpectExec("UPDATE phases SET").WillReturnError(sql.ErrConnDone)
+
+	body := `{"name":"Updated"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/tyr/phases/p1", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestHandler_ListRaids_DBError(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+	mock.ExpectQuery("SELECT .* FROM raids WHERE phase_id").WillReturnError(sql.ErrConnDone)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/phases/p1/raids", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestHandler_CreateRaid_DBError(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+	mock.ExpectQuery("INSERT INTO raids").WillReturnError(sql.ErrConnDone)
+
+	body := `{"name":"Raid 1"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tyr/phases/p1/raids", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestHandler_GetRaid_DBError(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+	mock.ExpectQuery("SELECT .* FROM raids WHERE id").WillReturnError(sql.ErrConnDone)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/raids/r1", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestHandler_UpdateRaid_DBError(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+	mock.ExpectQuery("SELECT .* FROM raids WHERE id").WillReturnError(sql.ErrConnDone)
+
+	body := `{"name":"Updated"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/tyr/raids/r1", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestHandler_UpdateRaid_UpdateError(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	now := time.Now()
+	raidRows := sqlmock.NewRows([]string{
+		"id", "phase_id", "tracker_id", "name", "description", "acceptance_criteria",
+		"declared_files", "estimate_hours", "status", "confidence", "session_id", "branch",
+		"chronicle_summary", "pr_url", "pr_id", "reason", "retry_count", "created_at", "updated_at",
+	}).AddRow("r1", "p1", "t1", "Raid 1", "", pq.Array([]string{}),
+		pq.Array([]string{}), nil, "PENDING", 0.0, nil, nil,
+		nil, nil, nil, nil, 0, now, now)
+	mock.ExpectQuery("SELECT .* FROM raids WHERE id").WillReturnRows(raidRows)
+	mock.ExpectExec("UPDATE raids SET").WillReturnError(sql.ErrConnDone)
+
+	body := `{"name":"Updated"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/tyr/raids/r1", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestHandler_DispatchRaid_NotFound(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	store := NewStore(db)
+	dispatcher := NewDispatcher(DispatcherConfig{ForgeBaseURL: "http://localhost:8081"}, store)
+	handler := NewHandler(store, dispatcher)
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux)
+
+	mock.ExpectQuery("SELECT .* FROM raids WHERE id").WillReturnError(sql.ErrNoRows)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tyr/raids/nonexistent/dispatch", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_ListConfidenceEvents_DBError(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+	mock.ExpectQuery("SELECT .* FROM confidence_events").WillReturnError(sql.ErrConnDone)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/raids/r1/confidence", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestHandler_UpdateRaidStatus_DBError(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+	mock.ExpectQuery("SELECT .* FROM raids WHERE id").WillReturnError(sql.ErrConnDone)
+
+	body := `{"status":"QUEUED"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/tyr/raids/r1/status", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestHandler_SagaPhases_MethodNotAllowed(t *testing.T) {
+	_, _, mux := setupTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/tyr/sagas/saga-1/phases", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestHandler_PhaseRaids_MethodNotAllowed(t *testing.T) {
+	_, _, mux := setupTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/tyr/phases/p1/raids", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestHandler_Health_Degraded(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	store := NewStore(db)
+	handler := NewHandler(store, nil)
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux)
+
+	mock.ExpectPing().WillReturnError(sql.ErrConnDone)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/health", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestHandler_DispatchRaid_ForgeServerError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	store := NewStore(db)
+
+	forgeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("server error"))
+	}))
+	defer forgeServer.Close()
+
+	dispatcher := NewDispatcher(DispatcherConfig{ForgeBaseURL: forgeServer.URL}, store)
+	handler := NewHandler(store, dispatcher)
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux)
+
+	now := time.Now()
+	raidRows := sqlmock.NewRows([]string{
+		"id", "phase_id", "tracker_id", "name", "description", "acceptance_criteria",
+		"declared_files", "estimate_hours", "status", "confidence", "session_id", "branch",
+		"chronicle_summary", "pr_url", "pr_id", "reason", "retry_count", "created_at", "updated_at",
+	}).AddRow("r1", "p1", "t1", "Raid 1", "", pq.Array([]string{}),
+		pq.Array([]string{}), nil, "PENDING", 0.0, nil, nil,
+		nil, nil, nil, nil, 0, now, now)
+	mock.ExpectQuery("SELECT .* FROM raids WHERE id").WillReturnRows(raidRows)
+
+	phaseRows := sqlmock.NewRows([]string{
+		"id", "saga_id", "tracker_id", "number", "name", "status", "confidence",
+	}).AddRow("p1", "saga-1", "t1", 1, "Phase 1", "ACTIVE", 0.0)
+	mock.ExpectQuery("SELECT .* FROM phases WHERE id").WillReturnRows(phaseRows)
+
+	sagaRows := sqlmock.NewRows([]string{
+		"id", "tracker_id", "tracker_type", "slug", "name", "repos",
+		"status", "confidence", "owner_id", "base_branch", "created_at",
+	}).AddRow("saga-1", "proj-1", "native", "my-saga", "My Saga", pq.Array([]string{"repo1"}),
+		"ACTIVE", 0.0, "default", "main", now)
+	mock.ExpectQuery("SELECT .* FROM sagas WHERE id").WillReturnRows(sagaRows)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tyr/raids/r1/dispatch", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/cli/internal/tyr/handler_extra_test.go
+++ b/cli/internal/tyr/handler_extra_test.go
@@ -1,0 +1,554 @@
+package tyr
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/lib/pq"
+)
+
+func TestHandler_GetPhase_Direct(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	rows := sqlmock.NewRows([]string{
+		"id", "saga_id", "tracker_id", "number", "name", "status", "confidence",
+	}).AddRow("p1", "saga-1", "t1", 1, "Phase 1", "GATED", 0.0)
+	mock.ExpectQuery("SELECT .* FROM phases WHERE id").WithArgs("p1").WillReturnRows(rows)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/phases/p1", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_GetPhase_NotFound(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	mock.ExpectQuery("SELECT .* FROM phases WHERE id").
+		WithArgs("nonexistent").WillReturnError(sql.ErrNoRows)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/phases/nonexistent", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestHandler_UpdatePhase_Direct(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	rows := sqlmock.NewRows([]string{
+		"id", "saga_id", "tracker_id", "number", "name", "status", "confidence",
+	}).AddRow("p1", "saga-1", "t1", 1, "Old Name", "GATED", 0.0)
+	mock.ExpectQuery("SELECT .* FROM phases WHERE id").WithArgs("p1").WillReturnRows(rows)
+	mock.ExpectExec("UPDATE phases SET").WillReturnResult(sqlmock.NewResult(0, 1))
+
+	body := `{"name":"New Phase","status":"ACTIVE"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/tyr/phases/p1", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_UpdatePhase_NotFound(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	mock.ExpectQuery("SELECT .* FROM phases WHERE id").
+		WithArgs("nonexistent").WillReturnError(sql.ErrNoRows)
+
+	body := `{"name":"Updated"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/tyr/phases/nonexistent", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestHandler_UpdatePhase_InvalidJSON(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	rows := sqlmock.NewRows([]string{
+		"id", "saga_id", "tracker_id", "number", "name", "status", "confidence",
+	}).AddRow("p1", "saga-1", "t1", 1, "Phase 1", "GATED", 0.0)
+	mock.ExpectQuery("SELECT .* FROM phases WHERE id").WithArgs("p1").WillReturnRows(rows)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/tyr/phases/p1", bytes.NewBufferString("{invalid"))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandler_PhaseByID_MethodNotAllowed(t *testing.T) {
+	_, _, mux := setupTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/tyr/phases/p1", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestHandler_GetRaid_NotFound(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	mock.ExpectQuery("SELECT .* FROM raids WHERE id").
+		WithArgs("nonexistent").WillReturnError(sql.ErrNoRows)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/raids/nonexistent", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestHandler_UpdateRaid_NotFound(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	mock.ExpectQuery("SELECT .* FROM raids WHERE id").
+		WithArgs("nonexistent").WillReturnError(sql.ErrNoRows)
+
+	body := `{"name":"Updated"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/tyr/raids/nonexistent", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestHandler_UpdateRaid_InvalidJSON(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	now := time.Now()
+	raidRows := sqlmock.NewRows([]string{
+		"id", "phase_id", "tracker_id", "name", "description", "acceptance_criteria",
+		"declared_files", "estimate_hours", "status", "confidence", "session_id", "branch",
+		"chronicle_summary", "pr_url", "pr_id", "reason", "retry_count", "created_at", "updated_at",
+	}).AddRow("r1", "p1", "t1", "Raid 1", "", pq.Array([]string{}),
+		pq.Array([]string{}), nil, "PENDING", 0.0, nil, nil,
+		nil, nil, nil, nil, 0, now, now)
+	mock.ExpectQuery("SELECT .* FROM raids WHERE id").WithArgs("r1").WillReturnRows(raidRows)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/tyr/raids/r1", bytes.NewBufferString("{invalid"))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandler_UpdateSaga_NotFound(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	mock.ExpectQuery("SELECT .* FROM sagas WHERE id").
+		WithArgs("nonexistent").WillReturnError(sql.ErrNoRows)
+
+	body := `{"name":"Updated"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/tyr/sagas/nonexistent", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestHandler_UpdateSaga_InvalidJSON(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	now := time.Now()
+	sagaRows := sqlmock.NewRows([]string{
+		"id", "tracker_id", "tracker_type", "slug", "name", "repos",
+		"status", "confidence", "owner_id", "base_branch", "created_at",
+	}).AddRow("uuid-1", "p1", "native", "test", "Test", pq.Array([]string{}),
+		"ACTIVE", 0.0, "default", "main", now)
+	mock.ExpectQuery("SELECT .* FROM sagas WHERE id").WithArgs("uuid-1").WillReturnRows(sagaRows)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/tyr/sagas/uuid-1", bytes.NewBufferString("{invalid"))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandler_DeleteSaga_NotFound(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	mock.ExpectBegin()
+	mock.ExpectExec("DELETE FROM confidence_events").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DELETE FROM raids").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DELETE FROM phases").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DELETE FROM sagas").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectRollback()
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/tyr/sagas/nonexistent", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestHandler_UpdateRaidStatus_NotFound(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	mock.ExpectQuery("SELECT .* FROM raids WHERE id").
+		WithArgs("nonexistent").WillReturnError(sql.ErrNoRows)
+
+	body := `{"status":"QUEUED"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/tyr/raids/nonexistent/status", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestHandler_UpdateRaidStatus_InvalidJSON(t *testing.T) {
+	_, _, mux := setupTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/tyr/raids/r1/status", bytes.NewBufferString("{invalid"))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandler_UpdateRaidStatus_MethodNotAllowed(t *testing.T) {
+	_, _, mux := setupTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/raids/r1/status", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	// Should match handleRaidByID, then match subpath "status", then check method.
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestHandler_CreateConfidenceEvent_InvalidJSON(t *testing.T) {
+	_, _, mux := setupTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tyr/raids/r1/confidence", bytes.NewBufferString("{invalid"))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandler_CreateConfidenceEvent_RaidNotFound(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	mock.ExpectQuery("SELECT .* FROM raids WHERE id").
+		WithArgs("nonexistent").WillReturnError(sql.ErrNoRows)
+
+	body := `{"event_type":"ci_pass","delta":0.1}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tyr/raids/nonexistent/confidence", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestHandler_Confidence_MethodNotAllowed(t *testing.T) {
+	_, _, mux := setupTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/tyr/raids/r1/confidence", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestHandler_DispatchRaid_WithDispatcher(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	store := NewStore(db)
+
+	forgeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(sessionCreateResponse{ID: "s-1", Name: "test", Status: "pending"})
+	}))
+	defer forgeServer.Close()
+
+	dispatcher := NewDispatcher(DispatcherConfig{ForgeBaseURL: forgeServer.URL}, store)
+	handler := NewHandler(store, dispatcher)
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux)
+
+	now := time.Now()
+	raidRows := sqlmock.NewRows([]string{
+		"id", "phase_id", "tracker_id", "name", "description", "acceptance_criteria",
+		"declared_files", "estimate_hours", "status", "confidence", "session_id", "branch",
+		"chronicle_summary", "pr_url", "pr_id", "reason", "retry_count", "created_at", "updated_at",
+	}).AddRow("r1", "p1", "t1", "Raid 1", "", pq.Array([]string{}),
+		pq.Array([]string{}), nil, "PENDING", 0.0, nil, nil,
+		nil, nil, nil, nil, 0, now, now)
+	mock.ExpectQuery("SELECT .* FROM raids WHERE id").WithArgs("r1").WillReturnRows(raidRows)
+
+	phaseRows := sqlmock.NewRows([]string{
+		"id", "saga_id", "tracker_id", "number", "name", "status", "confidence",
+	}).AddRow("p1", "saga-1", "t1", 1, "Phase 1", "ACTIVE", 0.0)
+	mock.ExpectQuery("SELECT .* FROM phases WHERE id").WithArgs("p1").WillReturnRows(phaseRows)
+
+	sagaRows := sqlmock.NewRows([]string{
+		"id", "tracker_id", "tracker_type", "slug", "name", "repos",
+		"status", "confidence", "owner_id", "base_branch", "created_at",
+	}).AddRow("saga-1", "proj-1", "native", "my-saga", "My Saga", pq.Array([]string{"repo1"}),
+		"ACTIVE", 0.0, "default", "main", now)
+	mock.ExpectQuery("SELECT .* FROM sagas WHERE id").WithArgs("saga-1").WillReturnRows(sagaRows)
+
+	mock.ExpectExec("UPDATE raids SET").WillReturnResult(sqlmock.NewResult(0, 1))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tyr/raids/r1/dispatch", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_DispatchRaid_Conflict(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	store := NewStore(db)
+	dispatcher := NewDispatcher(DispatcherConfig{ForgeBaseURL: "http://localhost:8081"}, store)
+	handler := NewHandler(store, dispatcher)
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux)
+
+	now := time.Now()
+	// Raid in RUNNING state — cannot dispatch
+	raidRows := sqlmock.NewRows([]string{
+		"id", "phase_id", "tracker_id", "name", "description", "acceptance_criteria",
+		"declared_files", "estimate_hours", "status", "confidence", "session_id", "branch",
+		"chronicle_summary", "pr_url", "pr_id", "reason", "retry_count", "created_at", "updated_at",
+	}).AddRow("r1", "p1", "t1", "Raid 1", "", pq.Array([]string{}),
+		pq.Array([]string{}), nil, "RUNNING", 0.0, nil, nil,
+		nil, nil, nil, nil, 0, now, now)
+	mock.ExpectQuery("SELECT .* FROM raids WHERE id").WithArgs("r1").WillReturnRows(raidRows)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tyr/raids/r1/dispatch", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_SagaSubPhase_Get(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	rows := sqlmock.NewRows([]string{
+		"id", "saga_id", "tracker_id", "number", "name", "status", "confidence",
+	}).AddRow("p1", "saga-1", "t1", 1, "Phase 1", "GATED", 0.0)
+	mock.ExpectQuery("SELECT .* FROM phases WHERE id").WithArgs("p1").WillReturnRows(rows)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/sagas/saga-1/phases/p1", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_SagaSubPhase_Raids(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	now := time.Now()
+	raidRows := sqlmock.NewRows([]string{
+		"id", "phase_id", "tracker_id", "name", "description", "acceptance_criteria",
+		"declared_files", "estimate_hours", "status", "confidence", "session_id", "branch",
+		"chronicle_summary", "pr_url", "pr_id", "reason", "retry_count", "created_at", "updated_at",
+	}).AddRow("r1", "p1", "t1", "Raid 1", "", pq.Array([]string{}),
+		pq.Array([]string{}), nil, "PENDING", 0.0, nil, nil,
+		nil, nil, nil, nil, 0, now, now)
+	mock.ExpectQuery("SELECT .* FROM raids WHERE phase_id").WithArgs("p1").WillReturnRows(raidRows)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/sagas/saga-1/phases/p1/raids", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_GetSaga_WithPhaseAndRaids(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	now := time.Now()
+	sagaRows := sqlmock.NewRows([]string{
+		"id", "tracker_id", "tracker_type", "slug", "name", "repos",
+		"status", "confidence", "owner_id", "base_branch", "created_at",
+	}).AddRow("uuid-1", "p1", "native", "test", "Test", pq.Array([]string{}),
+		"ACTIVE", 0.0, "default", "main", now)
+	mock.ExpectQuery("SELECT .* FROM sagas WHERE id").WithArgs("uuid-1").WillReturnRows(sagaRows)
+
+	phaseRows := sqlmock.NewRows([]string{
+		"id", "saga_id", "tracker_id", "number", "name", "status", "confidence",
+	}).AddRow("p1", "uuid-1", "t1", 1, "Phase 1", "ACTIVE", 0.5)
+	mock.ExpectQuery("SELECT .* FROM phases WHERE saga_id").WithArgs("uuid-1").WillReturnRows(phaseRows)
+
+	raidRows := sqlmock.NewRows([]string{
+		"id", "phase_id", "tracker_id", "name", "description", "acceptance_criteria",
+		"declared_files", "estimate_hours", "status", "confidence", "session_id", "branch",
+		"chronicle_summary", "pr_url", "pr_id", "reason", "retry_count", "created_at", "updated_at",
+	}).AddRow("r1", "p1", "t1", "Raid 1", "", pq.Array([]string{}),
+		pq.Array([]string{}), nil, "PENDING", 0.0, nil, nil,
+		nil, nil, nil, nil, 0, now, now)
+	mock.ExpectQuery("SELECT .* FROM raids WHERE phase_id").WithArgs("p1").WillReturnRows(raidRows)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/sagas/uuid-1", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	phases, ok := resp["phases"].([]any)
+	if !ok || len(phases) != 1 {
+		t.Fatalf("expected 1 phase in response")
+	}
+}
+
+func TestHandler_PhaseByID_Raids(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	raidRows := sqlmock.NewRows([]string{
+		"id", "phase_id", "tracker_id", "name", "description", "acceptance_criteria",
+		"declared_files", "estimate_hours", "status", "confidence", "session_id", "branch",
+		"chronicle_summary", "pr_url", "pr_id", "reason", "retry_count", "created_at", "updated_at",
+	})
+	mock.ExpectQuery("SELECT .* FROM raids WHERE phase_id").WithArgs("p1").WillReturnRows(raidRows)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/phases/p1/raids", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestHandler_RaidByID_MissingID(t *testing.T) {
+	_, _, mux := setupTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/raids/", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandler_PhaseByID_MissingID(t *testing.T) {
+	_, _, mux := setupTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/phases/", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandler_CreatePhase_InvalidJSON(t *testing.T) {
+	_, _, mux := setupTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tyr/sagas/saga-1/phases", bytes.NewBufferString("{invalid"))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandler_CreateRaid_InvalidJSON(t *testing.T) {
+	_, _, mux := setupTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tyr/phases/p1/raids", bytes.NewBufferString("{invalid"))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandler_SagaSubPhase_Update(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	rows := sqlmock.NewRows([]string{
+		"id", "saga_id", "tracker_id", "number", "name", "status", "confidence",
+	}).AddRow("p1", "saga-1", "t1", 1, "Phase 1", "GATED", 0.0)
+	mock.ExpectQuery("SELECT .* FROM phases WHERE id").WithArgs("p1").WillReturnRows(rows)
+	mock.ExpectExec("UPDATE phases SET").WillReturnResult(sqlmock.NewResult(0, 1))
+
+	body := `{"name":"Updated Phase"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/tyr/sagas/saga-1/phases/p1", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/cli/internal/tyr/handler_test.go
+++ b/cli/internal/tyr/handler_test.go
@@ -1,0 +1,678 @@
+package tyr
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/lib/pq"
+)
+
+func setupTestHandler(t *testing.T) (*Handler, sqlmock.Sqlmock, *http.ServeMux) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	store := NewStore(db)
+	handler := NewHandler(store, nil)
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux)
+	return handler, mock, mux
+}
+
+func TestHandler_Health(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	mock.ExpectPing()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/health", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["service"] != "tyr-mini" {
+		t.Errorf("expected service tyr-mini, got %q", body["service"])
+	}
+	if body["status"] != "ok" {
+		t.Errorf("expected status ok, got %q", body["status"])
+	}
+}
+
+func TestHandler_Health_MethodNotAllowed(t *testing.T) {
+	_, _, mux := setupTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tyr/health", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestHandler_ListSagas(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	now := time.Now()
+	rows := sqlmock.NewRows([]string{
+		"id", "tracker_id", "tracker_type", "slug", "name", "repos",
+		"status", "confidence", "owner_id", "base_branch", "created_at",
+	}).AddRow("uuid-1", "p1", "native", "test", "Test Saga", pq.Array([]string{}),
+		"ACTIVE", 0.5, "default", "main", now)
+
+	mock.ExpectQuery("SELECT .* FROM sagas ORDER BY").WillReturnRows(rows)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/sagas", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+
+	var sagas []map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &sagas); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(sagas) != 1 {
+		t.Fatalf("expected 1 saga, got %d", len(sagas))
+	}
+	if sagas[0]["feature_branch"] != "feat/test" {
+		t.Errorf("expected feature_branch feat/test, got %v", sagas[0]["feature_branch"])
+	}
+}
+
+func TestHandler_ListSagas_Empty(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	rows := sqlmock.NewRows([]string{
+		"id", "tracker_id", "tracker_type", "slug", "name", "repos",
+		"status", "confidence", "owner_id", "base_branch", "created_at",
+	})
+	mock.ExpectQuery("SELECT .* FROM sagas ORDER BY").WillReturnRows(rows)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/sagas", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+
+	var sagas []map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &sagas)
+	if len(sagas) != 0 {
+		t.Errorf("expected empty array, got %d items", len(sagas))
+	}
+}
+
+func TestHandler_CreateSaga(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	rows := sqlmock.NewRows([]string{"id", "created_at"}).AddRow("uuid-1", time.Now())
+	mock.ExpectQuery("INSERT INTO sagas").WillReturnRows(rows)
+
+	body := `{"name":"Test","slug":"test","repos":["repo1"]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tyr/sagas", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_CreateSaga_MissingName(t *testing.T) {
+	_, _, mux := setupTestHandler(t)
+
+	body := `{"slug":"test"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tyr/sagas", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandler_CreateSaga_MissingSlug(t *testing.T) {
+	_, _, mux := setupTestHandler(t)
+
+	body := `{"name":"Test"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tyr/sagas", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandler_CreateSaga_InvalidJSON(t *testing.T) {
+	_, _, mux := setupTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tyr/sagas", bytes.NewBufferString("{invalid"))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandler_GetSaga(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	now := time.Now()
+	sagaRows := sqlmock.NewRows([]string{
+		"id", "tracker_id", "tracker_type", "slug", "name", "repos",
+		"status", "confidence", "owner_id", "base_branch", "created_at",
+	}).AddRow("uuid-1", "p1", "native", "test", "Test", pq.Array([]string{}),
+		"ACTIVE", 0.0, "default", "main", now)
+	mock.ExpectQuery("SELECT .* FROM sagas WHERE id").WithArgs("uuid-1").WillReturnRows(sagaRows)
+
+	// ListPhases returns empty
+	phaseRows := sqlmock.NewRows([]string{
+		"id", "saga_id", "tracker_id", "number", "name", "status", "confidence",
+	})
+	mock.ExpectQuery("SELECT .* FROM phases WHERE saga_id").WithArgs("uuid-1").WillReturnRows(phaseRows)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/sagas/uuid-1", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_GetSaga_NotFound(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	mock.ExpectQuery("SELECT .* FROM sagas WHERE id").WillReturnRows(
+		sqlmock.NewRows([]string{
+			"id", "tracker_id", "tracker_type", "slug", "name", "repos",
+			"status", "confidence", "owner_id", "base_branch", "created_at",
+		}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/sagas/nonexistent", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestHandler_DeleteSaga(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	mock.ExpectBegin()
+	mock.ExpectExec("DELETE FROM confidence_events").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DELETE FROM raids").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DELETE FROM phases").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DELETE FROM sagas").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/tyr/sagas/uuid-1", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_UpdateSaga(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	now := time.Now()
+	sagaRows := sqlmock.NewRows([]string{
+		"id", "tracker_id", "tracker_type", "slug", "name", "repos",
+		"status", "confidence", "owner_id", "base_branch", "created_at",
+	}).AddRow("uuid-1", "p1", "native", "test", "Old Name", pq.Array([]string{}),
+		"ACTIVE", 0.0, "default", "main", now)
+	mock.ExpectQuery("SELECT .* FROM sagas WHERE id").WithArgs("uuid-1").WillReturnRows(sagaRows)
+	mock.ExpectExec("UPDATE sagas SET").WillReturnResult(sqlmock.NewResult(0, 1))
+
+	body := `{"name":"New Name"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/tyr/sagas/uuid-1", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_SagasMethodNotAllowed(t *testing.T) {
+	_, _, mux := setupTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/tyr/sagas", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestHandler_SagaByID_MethodNotAllowed(t *testing.T) {
+	_, _, mux := setupTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tyr/sagas/uuid-1", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestHandler_CreatePhaseForSaga(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	rows := sqlmock.NewRows([]string{"id"}).AddRow("phase-uuid-1")
+	mock.ExpectQuery("INSERT INTO phases").WillReturnRows(rows)
+
+	body := `{"name":"Phase 1","number":1}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tyr/sagas/saga-1/phases", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_ListPhasesBySaga(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	phaseRows := sqlmock.NewRows([]string{
+		"id", "saga_id", "tracker_id", "number", "name", "status", "confidence",
+	}).AddRow("p1", "saga-1", "t1", 1, "Phase 1", "GATED", 0.0)
+	mock.ExpectQuery("SELECT .* FROM phases WHERE saga_id").WithArgs("saga-1").WillReturnRows(phaseRows)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/sagas/saga-1/phases", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestHandler_CreateRaidForPhase(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	rows := sqlmock.NewRows([]string{"id"}).AddRow("raid-uuid-1")
+	mock.ExpectQuery("INSERT INTO raids").WillReturnRows(rows)
+
+	body := `{"name":"Implement feature"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tyr/phases/phase-1/raids", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_ListRaidsByPhase(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	now := time.Now()
+	raidRows := sqlmock.NewRows([]string{
+		"id", "phase_id", "tracker_id", "name", "description", "acceptance_criteria",
+		"declared_files", "estimate_hours", "status", "confidence", "session_id", "branch",
+		"chronicle_summary", "pr_url", "pr_id", "reason", "retry_count", "created_at", "updated_at",
+	}).AddRow("r1", "p1", "t1", "Raid 1", "", pq.Array([]string{}),
+		pq.Array([]string{}), nil, "PENDING", 0.0, nil, nil,
+		nil, nil, nil, nil, 0, now, now)
+	mock.ExpectQuery("SELECT .* FROM raids WHERE phase_id").WithArgs("phase-1").WillReturnRows(raidRows)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/phases/phase-1/raids", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestHandler_GetRaid(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	now := time.Now()
+	raidRows := sqlmock.NewRows([]string{
+		"id", "phase_id", "tracker_id", "name", "description", "acceptance_criteria",
+		"declared_files", "estimate_hours", "status", "confidence", "session_id", "branch",
+		"chronicle_summary", "pr_url", "pr_id", "reason", "retry_count", "created_at", "updated_at",
+	}).AddRow("r1", "p1", "t1", "Raid 1", "", pq.Array([]string{}),
+		pq.Array([]string{}), nil, "PENDING", 0.0, nil, nil,
+		nil, nil, nil, nil, 0, now, now)
+	mock.ExpectQuery("SELECT .* FROM raids WHERE id").WithArgs("r1").WillReturnRows(raidRows)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/raids/r1", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestHandler_UpdateRaidStatus(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	now := time.Now()
+	// GetRaid for UpdateRaidStatus
+	raidRows := sqlmock.NewRows([]string{
+		"id", "phase_id", "tracker_id", "name", "description", "acceptance_criteria",
+		"declared_files", "estimate_hours", "status", "confidence", "session_id", "branch",
+		"chronicle_summary", "pr_url", "pr_id", "reason", "retry_count", "created_at", "updated_at",
+	}).AddRow("r1", "p1", "t1", "Raid 1", "", pq.Array([]string{}),
+		pq.Array([]string{}), nil, "PENDING", 0.0, nil, nil,
+		nil, nil, nil, nil, 0, now, now)
+	mock.ExpectQuery("SELECT .* FROM raids WHERE id").WithArgs("r1").WillReturnRows(raidRows)
+
+	// UpdateRaid
+	mock.ExpectExec("UPDATE raids SET").WillReturnResult(sqlmock.NewResult(0, 1))
+
+	// GetRaid for response
+	raidRows2 := sqlmock.NewRows([]string{
+		"id", "phase_id", "tracker_id", "name", "description", "acceptance_criteria",
+		"declared_files", "estimate_hours", "status", "confidence", "session_id", "branch",
+		"chronicle_summary", "pr_url", "pr_id", "reason", "retry_count", "created_at", "updated_at",
+	}).AddRow("r1", "p1", "t1", "Raid 1", "", pq.Array([]string{}),
+		pq.Array([]string{}), nil, "QUEUED", 0.0, nil, nil,
+		nil, nil, nil, nil, 0, now, now)
+	mock.ExpectQuery("SELECT .* FROM raids WHERE id").WithArgs("r1").WillReturnRows(raidRows2)
+
+	body := `{"status":"QUEUED"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/tyr/raids/r1/status", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_UpdateRaidStatus_InvalidTransition(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	now := time.Now()
+	raidRows := sqlmock.NewRows([]string{
+		"id", "phase_id", "tracker_id", "name", "description", "acceptance_criteria",
+		"declared_files", "estimate_hours", "status", "confidence", "session_id", "branch",
+		"chronicle_summary", "pr_url", "pr_id", "reason", "retry_count", "created_at", "updated_at",
+	}).AddRow("r1", "p1", "t1", "Raid 1", "", pq.Array([]string{}),
+		pq.Array([]string{}), nil, "PENDING", 0.0, nil, nil,
+		nil, nil, nil, nil, 0, now, now)
+	mock.ExpectQuery("SELECT .* FROM raids WHERE id").WithArgs("r1").WillReturnRows(raidRows)
+
+	body := `{"status":"MERGED"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/tyr/raids/r1/status", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %d", w.Code)
+	}
+}
+
+func TestHandler_UpdateRaidStatus_MissingStatus(t *testing.T) {
+	_, _, mux := setupTestHandler(t)
+
+	body := `{}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/tyr/raids/r1/status", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandler_DispatchRaid_NoDispatcher(t *testing.T) {
+	_, _, mux := setupTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tyr/raids/r1/dispatch", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestHandler_DispatchRaid_MethodNotAllowed(t *testing.T) {
+	_, _, mux := setupTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/raids/r1/dispatch", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestHandler_CreateConfidenceEvent(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	now := time.Now()
+	raidRows := sqlmock.NewRows([]string{
+		"id", "phase_id", "tracker_id", "name", "description", "acceptance_criteria",
+		"declared_files", "estimate_hours", "status", "confidence", "session_id", "branch",
+		"chronicle_summary", "pr_url", "pr_id", "reason", "retry_count", "created_at", "updated_at",
+	}).AddRow("r1", "p1", "t1", "Raid", "", pq.Array([]string{}),
+		pq.Array([]string{}), nil, "RUNNING", 0.5, nil, nil,
+		nil, nil, nil, nil, 0, now, now)
+	mock.ExpectQuery("SELECT .* FROM raids WHERE id").WithArgs("r1").WillReturnRows(raidRows)
+
+	evRows := sqlmock.NewRows([]string{"id", "created_at"}).AddRow("ev-1", now)
+	mock.ExpectQuery("INSERT INTO confidence_events").WillReturnRows(evRows)
+	mock.ExpectExec("UPDATE raids SET confidence").WillReturnResult(sqlmock.NewResult(0, 1))
+
+	body := `{"event_type":"ci_pass","delta":0.1}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tyr/raids/r1/confidence", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_ListConfidenceEvents(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	rows := sqlmock.NewRows([]string{
+		"id", "raid_id", "event_type", "delta", "score_after", "created_at",
+	})
+	mock.ExpectQuery("SELECT .* FROM confidence_events WHERE raid_id").
+		WithArgs("r1").WillReturnRows(rows)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/raids/r1/confidence", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestHandler_CreateConfidenceEvent_MissingEventType(t *testing.T) {
+	_, _, mux := setupTestHandler(t)
+
+	body := `{"delta":0.1}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tyr/raids/r1/confidence", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandler_Phases_MissingSagaID(t *testing.T) {
+	_, _, mux := setupTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/phases", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandler_Raids_MissingPhaseID(t *testing.T) {
+	_, _, mux := setupTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/raids", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandler_UpdateRaid(t *testing.T) {
+	_, mock, mux := setupTestHandler(t)
+
+	now := time.Now()
+	raidRows := sqlmock.NewRows([]string{
+		"id", "phase_id", "tracker_id", "name", "description", "acceptance_criteria",
+		"declared_files", "estimate_hours", "status", "confidence", "session_id", "branch",
+		"chronicle_summary", "pr_url", "pr_id", "reason", "retry_count", "created_at", "updated_at",
+	}).AddRow("r1", "p1", "t1", "Old Name", "", pq.Array([]string{}),
+		pq.Array([]string{}), nil, "PENDING", 0.0, nil, nil,
+		nil, nil, nil, nil, 0, now, now)
+	mock.ExpectQuery("SELECT .* FROM raids WHERE id").WithArgs("r1").WillReturnRows(raidRows)
+	mock.ExpectExec("UPDATE raids SET").WillReturnResult(sqlmock.NewResult(0, 1))
+
+	body := `{"name":"New Name"}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/tyr/raids/r1", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_SagaByID_MissingID(t *testing.T) {
+	_, _, mux := setupTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/sagas/", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandler_RaidByID_UnknownSubpath(t *testing.T) {
+	_, _, mux := setupTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/raids/r1/unknown", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestHandler_SagaByID_UnknownSubpath(t *testing.T) {
+	_, _, mux := setupTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/sagas/uuid-1/unknown", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestHandler_Phases_MethodNotAllowed(t *testing.T) {
+	_, _, mux := setupTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/tyr/phases?saga_id=s1", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestHandler_Raids_MethodNotAllowed(t *testing.T) {
+	_, _, mux := setupTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/tyr/raids?phase_id=p1", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestHandler_RaidsByID_MethodNotAllowed(t *testing.T) {
+	_, _, mux := setupTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/tyr/raids/r1", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestHandler_CreatePhase_MissingName(t *testing.T) {
+	_, _, mux := setupTestHandler(t)
+
+	body := `{"number":1}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tyr/sagas/saga-1/phases", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandler_CreateRaid_MissingName(t *testing.T) {
+	_, _, mux := setupTestHandler(t)
+
+	body := `{}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tyr/phases/phase-1/raids", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}

--- a/cli/internal/tyr/handler_test.go
+++ b/cli/internal/tyr/handler_test.go
@@ -486,9 +486,11 @@ func TestHandler_CreateConfidenceEvent(t *testing.T) {
 		nil, nil, nil, nil, 0, now, now)
 	mock.ExpectQuery("SELECT .* FROM raids WHERE id").WithArgs("r1").WillReturnRows(raidRows)
 
+	mock.ExpectBegin()
 	evRows := sqlmock.NewRows([]string{"id", "created_at"}).AddRow("ev-1", now)
 	mock.ExpectQuery("INSERT INTO confidence_events").WillReturnRows(evRows)
 	mock.ExpectExec("UPDATE raids SET confidence").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
 
 	body := `{"event_type":"ci_pass","delta":0.1}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/tyr/raids/r1/confidence", bytes.NewBufferString(body))

--- a/cli/internal/tyr/migrations/000001_initial_schema.down.sql
+++ b/cli/internal/tyr/migrations/000001_initial_schema.down.sql
@@ -1,0 +1,18 @@
+-- Rollback initial tyr schema
+
+DROP INDEX IF EXISTS idx_dispatcher_state_owner;
+DROP TABLE IF EXISTS dispatcher_state;
+
+DROP INDEX IF EXISTS idx_confidence_events_raid_id;
+DROP TABLE IF EXISTS confidence_events;
+
+DROP INDEX IF EXISTS idx_raids_session_id;
+DROP INDEX IF EXISTS idx_raids_status;
+DROP INDEX IF EXISTS idx_raids_phase_id;
+DROP TABLE IF EXISTS raids;
+
+DROP INDEX IF EXISTS idx_phases_saga_id;
+DROP TABLE IF EXISTS phases;
+
+DROP INDEX IF EXISTS idx_sagas_owner_id;
+DROP TABLE IF EXISTS sagas;

--- a/cli/internal/tyr/migrations/000001_initial_schema.up.sql
+++ b/cli/internal/tyr/migrations/000001_initial_schema.up.sql
@@ -1,0 +1,77 @@
+-- Initial schema for tyr saga coordinator
+
+CREATE TABLE IF NOT EXISTS sagas (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tracker_id    TEXT NOT NULL,
+    tracker_type  TEXT NOT NULL,
+    slug          TEXT NOT NULL UNIQUE,
+    name          TEXT NOT NULL DEFAULT '',
+    repos         TEXT[] NOT NULL DEFAULT '{}',
+    status        TEXT NOT NULL DEFAULT 'ACTIVE',
+    confidence    FLOAT DEFAULT 0,
+    owner_id      TEXT NOT NULL DEFAULT 'default',
+    base_branch   TEXT NOT NULL DEFAULT 'main',
+    created_at    TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_sagas_owner_id ON sagas(owner_id);
+
+CREATE TABLE IF NOT EXISTS phases (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    saga_id       UUID NOT NULL REFERENCES sagas(id),
+    tracker_id    TEXT NOT NULL,
+    number        INT NOT NULL,
+    name          TEXT NOT NULL,
+    status        TEXT NOT NULL DEFAULT 'GATED',
+    confidence    FLOAT DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_phases_saga_id ON phases(saga_id);
+
+CREATE TABLE IF NOT EXISTS raids (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    phase_id            UUID NOT NULL REFERENCES phases(id),
+    tracker_id          TEXT NOT NULL,
+    name                TEXT NOT NULL,
+    description         TEXT NOT NULL DEFAULT '',
+    acceptance_criteria TEXT[] NOT NULL DEFAULT '{}',
+    declared_files      TEXT[],
+    estimate_hours      FLOAT,
+    status              TEXT NOT NULL DEFAULT 'PENDING',
+    confidence          FLOAT DEFAULT 0,
+    session_id          TEXT,
+    branch              TEXT,
+    chronicle_summary   TEXT,
+    pr_url              TEXT,
+    pr_id               TEXT,
+    reason              TEXT,
+    retry_count         INT DEFAULT 0,
+    created_at          TIMESTAMPTZ DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_raids_phase_id ON raids(phase_id);
+CREATE INDEX IF NOT EXISTS idx_raids_status ON raids(status);
+CREATE INDEX IF NOT EXISTS idx_raids_session_id ON raids(session_id) WHERE session_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS confidence_events (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    raid_id       UUID NOT NULL REFERENCES raids(id),
+    event_type    TEXT NOT NULL,
+    delta         FLOAT NOT NULL,
+    score_after   FLOAT NOT NULL,
+    created_at    TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_confidence_events_raid_id ON confidence_events(raid_id);
+
+CREATE TABLE IF NOT EXISTS dispatcher_state (
+    id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    owner_id             TEXT NOT NULL DEFAULT 'default',
+    running              BOOL DEFAULT TRUE,
+    threshold            FLOAT DEFAULT 0.75,
+    max_concurrent_raids INT NOT NULL DEFAULT 3,
+    updated_at           TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_dispatcher_state_owner ON dispatcher_state(owner_id);

--- a/cli/internal/tyr/migrations_embed.go
+++ b/cli/internal/tyr/migrations_embed.go
@@ -5,7 +5,7 @@ import (
 	"io/fs"
 )
 
-//go:embed migrations/*.up.sql
+//go:embed migrations/*.sql
 var embeddedTyrMigrations embed.FS
 
 // MigrationsFS returns the embedded tyr migration files.

--- a/cli/internal/tyr/migrations_embed.go
+++ b/cli/internal/tyr/migrations_embed.go
@@ -1,0 +1,18 @@
+package tyr
+
+import (
+	"embed"
+	"io/fs"
+)
+
+//go:embed migrations/*.up.sql
+var embeddedTyrMigrations embed.FS
+
+// MigrationsFS returns the embedded tyr migration files.
+func MigrationsFS() fs.FS {
+	sub, err := fs.Sub(embeddedTyrMigrations, "migrations")
+	if err != nil {
+		panic("embedded tyr migrations directory missing: " + err.Error())
+	}
+	return sub
+}

--- a/cli/internal/tyr/migrations_test.go
+++ b/cli/internal/tyr/migrations_test.go
@@ -1,0 +1,258 @@
+package tyr
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestRunTyrMigrations_NoFiles(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec("CREATE TABLE IF NOT EXISTS tyr_schema_migrations").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	emptyFS := fstest.MapFS{}
+	applied, err := runTyrMigrations(context.Background(), db, emptyFS)
+	if err != nil {
+		t.Fatalf("runTyrMigrations: %v", err)
+	}
+	if applied != 0 {
+		t.Errorf("expected 0 applied, got %d", applied)
+	}
+}
+
+func TestRunTyrMigrations_WithFiles(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec("CREATE TABLE IF NOT EXISTS tyr_schema_migrations").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	mock.ExpectQuery("SELECT EXISTS").
+		WithArgs("000001_test").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+
+	mock.ExpectBegin()
+	mock.ExpectExec("CREATE TABLE IF NOT EXISTS test_table").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("INSERT INTO tyr_schema_migrations").
+		WithArgs("000001_test").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	testFS := fstest.MapFS{
+		"000001_test.up.sql": &fstest.MapFile{
+			Data: []byte("CREATE TABLE IF NOT EXISTS test_table (id INT);"),
+		},
+	}
+
+	applied, err := runTyrMigrations(context.Background(), db, testFS)
+	if err != nil {
+		t.Fatalf("runTyrMigrations: %v", err)
+	}
+	if applied != 1 {
+		t.Errorf("expected 1 applied, got %d", applied)
+	}
+}
+
+func TestRunTyrMigrations_AlreadyApplied(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec("CREATE TABLE IF NOT EXISTS tyr_schema_migrations").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	mock.ExpectQuery("SELECT EXISTS").
+		WithArgs("000001_test").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+
+	testFS := fstest.MapFS{
+		"000001_test.up.sql": &fstest.MapFile{
+			Data: []byte("CREATE TABLE IF NOT EXISTS test_table (id INT);"),
+		},
+	}
+
+	applied, err := runTyrMigrations(context.Background(), db, testFS)
+	if err != nil {
+		t.Fatalf("runTyrMigrations: %v", err)
+	}
+	if applied != 0 {
+		t.Errorf("expected 0 applied, got %d", applied)
+	}
+}
+
+func TestRunTyrMigrations_CreateTableError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec("CREATE TABLE IF NOT EXISTS tyr_schema_migrations").
+		WillReturnError(fmt.Errorf("permission denied"))
+
+	testFS := fstest.MapFS{}
+	_, err = runTyrMigrations(context.Background(), db, testFS)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestRunTyrMigrations_MigrationExecError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec("CREATE TABLE IF NOT EXISTS tyr_schema_migrations").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	mock.ExpectQuery("SELECT EXISTS").
+		WithArgs("000001_bad").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+
+	mock.ExpectBegin()
+	mock.ExpectExec("INVALID SQL").
+		WillReturnError(fmt.Errorf("syntax error"))
+	mock.ExpectRollback()
+
+	testFS := fstest.MapFS{
+		"000001_bad.up.sql": &fstest.MapFile{
+			Data: []byte("INVALID SQL"),
+		},
+	}
+
+	_, err = runTyrMigrations(context.Background(), db, testFS)
+	if err == nil {
+		t.Fatal("expected error for bad SQL")
+	}
+}
+
+func TestServerRegisterRoutes(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	store := NewStore(db)
+	handler := NewHandler(store, nil)
+	srv := &Server{handler: handler, store: store, db: db}
+
+	mux := http.NewServeMux()
+	srv.RegisterRoutes(mux)
+
+	// Verify health endpoint is registered.
+	mock.ExpectPing()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/tyr/health", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 from health after RegisterRoutes, got %d", w.Code)
+	}
+}
+
+func TestRunTyrMigrations_CheckError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec("CREATE TABLE IF NOT EXISTS tyr_schema_migrations").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	mock.ExpectQuery("SELECT EXISTS").
+		WithArgs("000001_test").
+		WillReturnError(fmt.Errorf("check error"))
+
+	testFS := fstest.MapFS{
+		"000001_test.up.sql": &fstest.MapFile{
+			Data: []byte("SELECT 1;"),
+		},
+	}
+
+	_, err = runTyrMigrations(context.Background(), db, testFS)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestRunTyrMigrations_BeginTxError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec("CREATE TABLE IF NOT EXISTS tyr_schema_migrations").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	mock.ExpectQuery("SELECT EXISTS").
+		WithArgs("000001_test").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+
+	mock.ExpectBegin().WillReturnError(fmt.Errorf("begin error"))
+
+	testFS := fstest.MapFS{
+		"000001_test.up.sql": &fstest.MapFile{
+			Data: []byte("SELECT 1;"),
+		},
+	}
+
+	_, err = runTyrMigrations(context.Background(), db, testFS)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestRunTyrMigrations_RecordError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec("CREATE TABLE IF NOT EXISTS tyr_schema_migrations").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	mock.ExpectQuery("SELECT EXISTS").
+		WithArgs("000001_test").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+
+	mock.ExpectBegin()
+	mock.ExpectExec("SELECT 1").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("INSERT INTO tyr_schema_migrations").
+		WithArgs("000001_test").
+		WillReturnError(fmt.Errorf("insert error"))
+	mock.ExpectRollback()
+
+	testFS := fstest.MapFS{
+		"000001_test.up.sql": &fstest.MapFile{
+			Data: []byte("SELECT 1;"),
+		},
+	}
+
+	_, err = runTyrMigrations(context.Background(), db, testFS)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/cli/internal/tyr/models.go
+++ b/cli/internal/tyr/models.go
@@ -1,0 +1,141 @@
+// Package tyr implements a lightweight Go-native subset of Tyr for mini mode.
+// It provides saga/phase/raid CRUD, session dispatch, and a REST API that
+// mirrors the full Tyr API shape so the web UI works without changes.
+package tyr
+
+import (
+	"fmt"
+	"time"
+)
+
+// SagaStatus represents the lifecycle state of a saga.
+type SagaStatus string
+
+const (
+	SagaStatusActive   SagaStatus = "ACTIVE"
+	SagaStatusComplete SagaStatus = "COMPLETE"
+	SagaStatusFailed   SagaStatus = "FAILED"
+)
+
+// PhaseStatus represents the lifecycle state of a phase.
+type PhaseStatus string
+
+const (
+	PhaseStatusPending  PhaseStatus = "PENDING"
+	PhaseStatusActive   PhaseStatus = "ACTIVE"
+	PhaseStatusGated    PhaseStatus = "GATED"
+	PhaseStatusComplete PhaseStatus = "COMPLETE"
+)
+
+// RaidStatus represents the lifecycle state of a raid.
+type RaidStatus string
+
+const (
+	RaidStatusPending    RaidStatus = "PENDING"
+	RaidStatusQueued     RaidStatus = "QUEUED"
+	RaidStatusRunning    RaidStatus = "RUNNING"
+	RaidStatusReview     RaidStatus = "REVIEW"
+	RaidStatusMerged     RaidStatus = "MERGED"
+	RaidStatusFailed     RaidStatus = "FAILED"
+	RaidStatusDispatched RaidStatus = "DISPATCHED"
+)
+
+// raidTransitions defines valid status transitions for raids.
+var raidTransitions = map[RaidStatus][]RaidStatus{
+	RaidStatusPending:    {RaidStatusQueued, RaidStatusDispatched},
+	RaidStatusQueued:     {RaidStatusDispatched, RaidStatusRunning},
+	RaidStatusDispatched: {RaidStatusRunning, RaidStatusFailed},
+	RaidStatusRunning:    {RaidStatusReview, RaidStatusFailed},
+	RaidStatusReview:     {RaidStatusMerged, RaidStatusFailed, RaidStatusRunning},
+	RaidStatusFailed:     {RaidStatusQueued, RaidStatusPending},
+}
+
+// ValidTransition checks whether a raid status transition is allowed.
+func ValidTransition(from, to RaidStatus) bool {
+	targets, ok := raidTransitions[from]
+	if !ok {
+		return false
+	}
+	for _, t := range targets {
+		if t == to {
+			return true
+		}
+	}
+	return false
+}
+
+// ConfidenceEventType categorises confidence score changes.
+type ConfidenceEventType string
+
+const (
+	ConfidenceEventCIPass      ConfidenceEventType = "ci_pass"
+	ConfidenceEventCIFail      ConfidenceEventType = "ci_fail"
+	ConfidenceEventScopeBreach ConfidenceEventType = "scope_breach"
+	ConfidenceEventRetry       ConfidenceEventType = "retry"
+	ConfidenceEventHumanReject ConfidenceEventType = "human_reject"
+	ConfidenceEventManual      ConfidenceEventType = "manual"
+)
+
+// Saga represents a top-level work unit (maps to a tracker project/epic).
+type Saga struct {
+	ID          string     `json:"id"`
+	TrackerID   string     `json:"tracker_id"`
+	TrackerType string     `json:"tracker_type"`
+	Slug        string     `json:"slug"`
+	Name        string     `json:"name"`
+	Repos       []string   `json:"repos"`
+	Status      SagaStatus `json:"status"`
+	Confidence  float64    `json:"confidence"`
+	OwnerID     string     `json:"owner_id"`
+	BaseBranch  string     `json:"base_branch"`
+	CreatedAt   time.Time  `json:"created_at"`
+}
+
+// FeatureBranch returns the auto-generated feature branch name.
+func (s *Saga) FeatureBranch() string {
+	return fmt.Sprintf("feat/%s", s.Slug)
+}
+
+// Phase represents a milestone within a saga.
+type Phase struct {
+	ID         string      `json:"id"`
+	SagaID     string      `json:"saga_id"`
+	TrackerID  string      `json:"tracker_id"`
+	Number     int         `json:"number"`
+	Name       string      `json:"name"`
+	Status     PhaseStatus `json:"status"`
+	Confidence float64     `json:"confidence"`
+}
+
+// Raid represents a single coding task within a phase.
+type Raid struct {
+	ID                 string     `json:"id"`
+	PhaseID            string     `json:"phase_id"`
+	TrackerID          string     `json:"tracker_id"`
+	Name               string     `json:"name"`
+	Description        string     `json:"description"`
+	AcceptanceCriteria []string   `json:"acceptance_criteria"`
+	DeclaredFiles      []string   `json:"declared_files"`
+	EstimateHours      *float64   `json:"estimate_hours,omitempty"`
+	Status             RaidStatus `json:"status"`
+	Confidence         float64    `json:"confidence"`
+	SessionID          *string    `json:"session_id,omitempty"`
+	Branch             *string    `json:"branch,omitempty"`
+	ChronicleSummary   *string    `json:"chronicle_summary,omitempty"`
+	PRUrl              *string    `json:"pr_url,omitempty"`
+	PRID               *string    `json:"pr_id,omitempty"`
+	Reason             *string    `json:"reason,omitempty"`
+	RetryCount         int        `json:"retry_count"`
+	CreatedAt          time.Time  `json:"created_at"`
+	UpdatedAt          time.Time  `json:"updated_at"`
+}
+
+// ConfidenceEvent records a change in raid confidence.
+type ConfidenceEvent struct {
+	ID         string              `json:"id"`
+	RaidID     string              `json:"raid_id"`
+	EventType  ConfidenceEventType `json:"event_type"`
+	Delta      float64             `json:"delta"`
+	ScoreAfter float64             `json:"score_after"`
+	CreatedAt  time.Time           `json:"created_at"`
+}

--- a/cli/internal/tyr/models_test.go
+++ b/cli/internal/tyr/models_test.go
@@ -1,0 +1,98 @@
+package tyr
+
+import (
+	"testing"
+)
+
+func TestValidTransition(t *testing.T) {
+	tests := []struct {
+		name string
+		from RaidStatus
+		to   RaidStatus
+		want bool
+	}{
+		{"pending to queued", RaidStatusPending, RaidStatusQueued, true},
+		{"pending to dispatched", RaidStatusPending, RaidStatusDispatched, true},
+		{"pending to running", RaidStatusPending, RaidStatusRunning, false},
+		{"queued to dispatched", RaidStatusQueued, RaidStatusDispatched, true},
+		{"queued to running", RaidStatusQueued, RaidStatusRunning, true},
+		{"dispatched to running", RaidStatusDispatched, RaidStatusRunning, true},
+		{"dispatched to failed", RaidStatusDispatched, RaidStatusFailed, true},
+		{"dispatched to review", RaidStatusDispatched, RaidStatusReview, false},
+		{"running to review", RaidStatusRunning, RaidStatusReview, true},
+		{"running to failed", RaidStatusRunning, RaidStatusFailed, true},
+		{"running to merged", RaidStatusRunning, RaidStatusMerged, false},
+		{"review to merged", RaidStatusReview, RaidStatusMerged, true},
+		{"review to failed", RaidStatusReview, RaidStatusFailed, true},
+		{"review to running", RaidStatusReview, RaidStatusRunning, true},
+		{"failed to queued", RaidStatusFailed, RaidStatusQueued, true},
+		{"failed to pending", RaidStatusFailed, RaidStatusPending, true},
+		{"failed to running", RaidStatusFailed, RaidStatusRunning, false},
+		{"merged to anything", RaidStatusMerged, RaidStatusPending, false},
+		{"unknown from status", RaidStatus("UNKNOWN"), RaidStatusPending, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ValidTransition(tt.from, tt.to)
+			if got != tt.want {
+				t.Errorf("ValidTransition(%s, %s) = %v, want %v", tt.from, tt.to, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSagaFeatureBranch(t *testing.T) {
+	saga := &Saga{Slug: "my-project"}
+	if got := saga.FeatureBranch(); got != "feat/my-project" {
+		t.Errorf("FeatureBranch() = %q, want %q", got, "feat/my-project")
+	}
+}
+
+func TestSagaStatusConstants(t *testing.T) {
+	if SagaStatusActive != "ACTIVE" {
+		t.Errorf("unexpected SagaStatusActive: %s", SagaStatusActive)
+	}
+	if SagaStatusComplete != "COMPLETE" {
+		t.Errorf("unexpected SagaStatusComplete: %s", SagaStatusComplete)
+	}
+	if SagaStatusFailed != "FAILED" {
+		t.Errorf("unexpected SagaStatusFailed: %s", SagaStatusFailed)
+	}
+}
+
+func TestPhaseStatusConstants(t *testing.T) {
+	statuses := []PhaseStatus{PhaseStatusPending, PhaseStatusActive, PhaseStatusGated, PhaseStatusComplete}
+	expected := []string{"PENDING", "ACTIVE", "GATED", "COMPLETE"}
+	for i, s := range statuses {
+		if string(s) != expected[i] {
+			t.Errorf("PhaseStatus[%d] = %q, want %q", i, s, expected[i])
+		}
+	}
+}
+
+func TestRaidStatusConstants(t *testing.T) {
+	statuses := []RaidStatus{
+		RaidStatusPending, RaidStatusQueued, RaidStatusRunning,
+		RaidStatusReview, RaidStatusMerged, RaidStatusFailed, RaidStatusDispatched,
+	}
+	expected := []string{"PENDING", "QUEUED", "RUNNING", "REVIEW", "MERGED", "FAILED", "DISPATCHED"}
+	for i, s := range statuses {
+		if string(s) != expected[i] {
+			t.Errorf("RaidStatus[%d] = %q, want %q", i, s, expected[i])
+		}
+	}
+}
+
+func TestConfidenceEventTypeConstants(t *testing.T) {
+	types := []ConfidenceEventType{
+		ConfidenceEventCIPass, ConfidenceEventCIFail, ConfidenceEventScopeBreach,
+		ConfidenceEventRetry, ConfidenceEventHumanReject, ConfidenceEventManual,
+	}
+	expected := []string{"ci_pass", "ci_fail", "scope_breach", "retry", "human_reject", "manual"}
+	for i, s := range types {
+		if string(s) != expected[i] {
+			t.Errorf("ConfidenceEventType[%d] = %q, want %q", i, s, expected[i])
+		}
+	}
+}

--- a/cli/internal/tyr/server.go
+++ b/cli/internal/tyr/server.go
@@ -1,0 +1,150 @@
+package tyr
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"sort"
+	"strings"
+)
+
+// ServerConfig holds settings for the tyr-mini server.
+type ServerConfig struct {
+	// ForgeBaseURL is the Forge API URL for dispatching raids.
+	ForgeBaseURL string
+	// DSN is the PostgreSQL connection string.
+	DSN string
+}
+
+// Server is the tyr-mini server that can be embedded into Forge's mux.
+type Server struct {
+	handler *Handler
+	store   *Store
+	db      *sql.DB
+}
+
+// NewServer creates a tyr-mini server, runs migrations, and initialises the store.
+func NewServer(ctx context.Context, cfg ServerConfig, migrationFS fs.FS) (*Server, error) {
+	db, err := sql.Open("postgres", cfg.DSN)
+	if err != nil {
+		return nil, fmt.Errorf("open tyr database: %w", err)
+	}
+
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("ping tyr database: %w", err)
+	}
+
+	// Run tyr migrations.
+	if migrationFS != nil {
+		if _, err := runTyrMigrations(ctx, db, migrationFS); err != nil {
+			_ = db.Close()
+			return nil, fmt.Errorf("run tyr migrations: %w", err)
+		}
+	}
+
+	store := NewStore(db)
+	dispatcher := NewDispatcher(DispatcherConfig{ForgeBaseURL: cfg.ForgeBaseURL}, store)
+	handler := NewHandler(store, dispatcher)
+
+	return &Server{
+		handler: handler,
+		store:   store,
+		db:      db,
+	}, nil
+}
+
+// RegisterRoutes mounts tyr-mini routes onto an existing HTTP mux.
+func (s *Server) RegisterRoutes(mux *http.ServeMux) {
+	s.handler.RegisterRoutes(mux)
+}
+
+// Close releases database resources.
+func (s *Server) Close() error {
+	if s.db != nil {
+		return s.db.Close()
+	}
+	return nil
+}
+
+// Store returns the underlying store for direct access (e.g., CLI commands).
+func (s *Server) Store() *Store {
+	return s.store
+}
+
+// runTyrMigrations applies tyr-specific migrations using the same pattern as
+// the main embedded postgres migration runner.
+func runTyrMigrations(ctx context.Context, db *sql.DB, migrationFS fs.FS) (int, error) {
+	_, err := db.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS tyr_schema_migrations (
+			version TEXT PRIMARY KEY,
+			applied_at TIMESTAMPTZ DEFAULT NOW()
+		)
+	`)
+	if err != nil {
+		return 0, fmt.Errorf("create tyr_schema_migrations table: %w", err)
+	}
+
+	entries, err := fs.ReadDir(migrationFS, ".")
+	if err != nil {
+		return 0, fmt.Errorf("read tyr migrations fs: %w", err)
+	}
+
+	var files []string
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".up.sql") {
+			files = append(files, entry.Name())
+		}
+	}
+	sort.Strings(files)
+
+	applied := 0
+	for _, f := range files {
+		version := strings.TrimSuffix(f, ".up.sql")
+
+		var exists bool
+		err := db.QueryRowContext(ctx,
+			"SELECT EXISTS(SELECT 1 FROM tyr_schema_migrations WHERE version = $1)",
+			version,
+		).Scan(&exists)
+		if err != nil {
+			return applied, fmt.Errorf("check tyr migration %s: %w", version, err)
+		}
+		if exists {
+			continue
+		}
+
+		sqlBytes, err := fs.ReadFile(migrationFS, f)
+		if err != nil {
+			return applied, fmt.Errorf("read tyr migration %s: %w", f, err)
+		}
+
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			return applied, fmt.Errorf("begin tx for %s: %w", f, err)
+		}
+
+		if _, err := tx.ExecContext(ctx, string(sqlBytes)); err != nil {
+			_ = tx.Rollback()
+			return applied, fmt.Errorf("execute tyr migration %s: %w", f, err)
+		}
+
+		if _, err := tx.ExecContext(ctx,
+			"INSERT INTO tyr_schema_migrations (version) VALUES ($1)",
+			version,
+		); err != nil {
+			_ = tx.Rollback()
+			return applied, fmt.Errorf("record tyr migration %s: %w", f, err)
+		}
+
+		if err := tx.Commit(); err != nil {
+			return applied, fmt.Errorf("commit tyr migration %s: %w", f, err)
+		}
+
+		applied++
+	}
+
+	return applied, nil
+}

--- a/cli/internal/tyr/server_test.go
+++ b/cli/internal/tyr/server_test.go
@@ -1,0 +1,76 @@
+package tyr
+
+import (
+	"context"
+	"io/fs"
+	"testing"
+	"testing/fstest"
+)
+
+func TestMigrationsFS(t *testing.T) {
+	mfs := MigrationsFS()
+	if mfs == nil {
+		t.Fatal("expected non-nil migrations FS")
+	}
+
+	entries, err := fs.ReadDir(mfs, ".")
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected at least one migration file")
+	}
+
+	found := false
+	for _, e := range entries {
+		if e.Name() == "000001_initial_schema.up.sql" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected to find 000001_initial_schema.up.sql")
+	}
+}
+
+func TestRunTyrMigrations_EmptyFS(t *testing.T) {
+	// Use an empty FS — should apply 0 migrations.
+	emptyFS := fstest.MapFS{}
+
+	// We can't test with a real DB here, but we can test the "no files" path
+	// by verifying the function doesn't panic with nil db.
+	// This is a basic smoke test — full integration tested via server_test.
+	_ = emptyFS
+
+	// Test that MigrationsFS returns a valid FS.
+	mfs := MigrationsFS()
+	if mfs == nil {
+		t.Fatal("MigrationsFS returned nil")
+	}
+}
+
+func TestNewServer_InvalidDSN(t *testing.T) {
+	ctx := context.Background()
+	cfg := ServerConfig{
+		ForgeBaseURL: "http://localhost:8081",
+		DSN:          "postgres://invalid:invalid@localhost:99999/nonexistent?sslmode=disable",
+	}
+
+	_, err := NewServer(ctx, cfg, nil)
+	if err == nil {
+		t.Fatal("expected error for invalid DSN")
+	}
+}
+
+func TestServerClose_Nil(t *testing.T) {
+	s := &Server{}
+	if err := s.Close(); err != nil {
+		t.Errorf("Close on nil db should not error: %v", err)
+	}
+}
+
+func TestServerStore(t *testing.T) {
+	s := &Server{store: &Store{}}
+	if s.Store() == nil {
+		t.Error("expected non-nil store")
+	}
+}

--- a/cli/internal/tyr/store.go
+++ b/cli/internal/tyr/store.go
@@ -1,0 +1,419 @@
+package tyr
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/lib/pq"
+)
+
+// Store provides CRUD operations for sagas, phases, and raids against PostgreSQL.
+type Store struct {
+	db *sql.DB
+}
+
+// NewStore creates a store backed by the given database connection.
+func NewStore(db *sql.DB) *Store {
+	return &Store{db: db}
+}
+
+// --- Sagas ---
+
+// CreateSaga inserts a new saga and returns the created record.
+func (s *Store) CreateSaga(ctx context.Context, saga *Saga) (*Saga, error) {
+	row := s.db.QueryRowContext(ctx, `
+		INSERT INTO sagas (tracker_id, tracker_type, slug, name, repos, status, confidence, owner_id, base_branch)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		RETURNING id, created_at
+	`,
+		saga.TrackerID, saga.TrackerType, saga.Slug, saga.Name,
+		pq.Array(saga.Repos), saga.Status, saga.Confidence,
+		saga.OwnerID, saga.BaseBranch,
+	)
+
+	if err := row.Scan(&saga.ID, &saga.CreatedAt); err != nil {
+		return nil, fmt.Errorf("insert saga: %w", err)
+	}
+	return saga, nil
+}
+
+// GetSaga retrieves a saga by ID.
+func (s *Store) GetSaga(ctx context.Context, id string) (*Saga, error) {
+	saga := &Saga{}
+	err := s.db.QueryRowContext(ctx, `
+		SELECT id, tracker_id, tracker_type, slug, name, repos, status, confidence, owner_id, base_branch, created_at
+		FROM sagas WHERE id = $1
+	`, id).Scan(
+		&saga.ID, &saga.TrackerID, &saga.TrackerType, &saga.Slug, &saga.Name,
+		pq.Array(&saga.Repos), &saga.Status, &saga.Confidence,
+		&saga.OwnerID, &saga.BaseBranch, &saga.CreatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get saga %s: %w", id, err)
+	}
+	return saga, nil
+}
+
+// ListSagas returns all sagas, ordered by creation time descending.
+func (s *Store) ListSagas(ctx context.Context) ([]*Saga, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, tracker_id, tracker_type, slug, name, repos, status, confidence, owner_id, base_branch, created_at
+		FROM sagas ORDER BY created_at DESC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list sagas: %w", err)
+	}
+	defer rows.Close()
+
+	var sagas []*Saga
+	for rows.Next() {
+		saga := &Saga{}
+		if err := rows.Scan(
+			&saga.ID, &saga.TrackerID, &saga.TrackerType, &saga.Slug, &saga.Name,
+			pq.Array(&saga.Repos), &saga.Status, &saga.Confidence,
+			&saga.OwnerID, &saga.BaseBranch, &saga.CreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan saga: %w", err)
+		}
+		sagas = append(sagas, saga)
+	}
+	return sagas, rows.Err()
+}
+
+// UpdateSaga updates mutable fields on a saga.
+func (s *Store) UpdateSaga(ctx context.Context, saga *Saga) error {
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE sagas SET name = $1, status = $2, confidence = $3, repos = $4, base_branch = $5
+		WHERE id = $6
+	`, saga.Name, saga.Status, saga.Confidence, pq.Array(saga.Repos), saga.BaseBranch, saga.ID)
+	if err != nil {
+		return fmt.Errorf("update saga %s: %w", saga.ID, err)
+	}
+	n, _ := result.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("saga %s not found", saga.ID)
+	}
+	return nil
+}
+
+// DeleteSaga removes a saga and cascading phases/raids.
+func (s *Store) DeleteSaga(ctx context.Context, id string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+
+	// Delete confidence events for raids in this saga.
+	_, err = tx.ExecContext(ctx, `
+		DELETE FROM confidence_events WHERE raid_id IN (
+			SELECT r.id FROM raids r
+			JOIN phases p ON r.phase_id = p.id
+			WHERE p.saga_id = $1
+		)
+	`, id)
+	if err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("delete confidence events: %w", err)
+	}
+
+	// Delete raids for phases in this saga.
+	_, err = tx.ExecContext(ctx, `
+		DELETE FROM raids WHERE phase_id IN (
+			SELECT id FROM phases WHERE saga_id = $1
+		)
+	`, id)
+	if err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("delete raids: %w", err)
+	}
+
+	// Delete phases.
+	if _, err = tx.ExecContext(ctx, `DELETE FROM phases WHERE saga_id = $1`, id); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("delete phases: %w", err)
+	}
+
+	// Delete saga.
+	result, err := tx.ExecContext(ctx, `DELETE FROM sagas WHERE id = $1`, id)
+	if err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("delete saga: %w", err)
+	}
+	n, _ := result.RowsAffected()
+	if n == 0 {
+		_ = tx.Rollback()
+		return fmt.Errorf("saga %s not found", id)
+	}
+	return tx.Commit()
+}
+
+// --- Phases ---
+
+// CreatePhase inserts a new phase.
+func (s *Store) CreatePhase(ctx context.Context, phase *Phase) (*Phase, error) {
+	err := s.db.QueryRowContext(ctx, `
+		INSERT INTO phases (saga_id, tracker_id, number, name, status, confidence)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		RETURNING id
+	`,
+		phase.SagaID, phase.TrackerID, phase.Number, phase.Name,
+		phase.Status, phase.Confidence,
+	).Scan(&phase.ID)
+	if err != nil {
+		return nil, fmt.Errorf("insert phase: %w", err)
+	}
+	return phase, nil
+}
+
+// ListPhases returns phases for a saga, ordered by number.
+func (s *Store) ListPhases(ctx context.Context, sagaID string) ([]*Phase, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, saga_id, tracker_id, number, name, status, confidence
+		FROM phases WHERE saga_id = $1 ORDER BY number
+	`, sagaID)
+	if err != nil {
+		return nil, fmt.Errorf("list phases: %w", err)
+	}
+	defer rows.Close()
+
+	var phases []*Phase
+	for rows.Next() {
+		p := &Phase{}
+		if err := rows.Scan(&p.ID, &p.SagaID, &p.TrackerID, &p.Number, &p.Name, &p.Status, &p.Confidence); err != nil {
+			return nil, fmt.Errorf("scan phase: %w", err)
+		}
+		phases = append(phases, p)
+	}
+	return phases, rows.Err()
+}
+
+// GetPhase retrieves a single phase by ID.
+func (s *Store) GetPhase(ctx context.Context, id string) (*Phase, error) {
+	p := &Phase{}
+	err := s.db.QueryRowContext(ctx, `
+		SELECT id, saga_id, tracker_id, number, name, status, confidence
+		FROM phases WHERE id = $1
+	`, id).Scan(&p.ID, &p.SagaID, &p.TrackerID, &p.Number, &p.Name, &p.Status, &p.Confidence)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get phase %s: %w", id, err)
+	}
+	return p, nil
+}
+
+// UpdatePhase updates mutable fields on a phase.
+func (s *Store) UpdatePhase(ctx context.Context, phase *Phase) error {
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE phases SET name = $1, status = $2, confidence = $3 WHERE id = $4
+	`, phase.Name, phase.Status, phase.Confidence, phase.ID)
+	if err != nil {
+		return fmt.Errorf("update phase %s: %w", phase.ID, err)
+	}
+	n, _ := result.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("phase %s not found", phase.ID)
+	}
+	return nil
+}
+
+// --- Raids ---
+
+// CreateRaid inserts a new raid.
+func (s *Store) CreateRaid(ctx context.Context, raid *Raid) (*Raid, error) {
+	now := time.Now().UTC()
+	err := s.db.QueryRowContext(ctx, `
+		INSERT INTO raids (phase_id, tracker_id, name, description, acceptance_criteria,
+			declared_files, estimate_hours, status, confidence, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+		RETURNING id
+	`,
+		raid.PhaseID, raid.TrackerID, raid.Name, raid.Description,
+		pq.Array(raid.AcceptanceCriteria), pq.Array(raid.DeclaredFiles),
+		raid.EstimateHours, raid.Status, raid.Confidence, now, now,
+	).Scan(&raid.ID)
+	if err != nil {
+		return nil, fmt.Errorf("insert raid: %w", err)
+	}
+	raid.CreatedAt = now
+	raid.UpdatedAt = now
+	return raid, nil
+}
+
+// GetRaid retrieves a single raid by ID.
+func (s *Store) GetRaid(ctx context.Context, id string) (*Raid, error) {
+	r := &Raid{}
+	err := s.db.QueryRowContext(ctx, `
+		SELECT id, phase_id, tracker_id, name, description, acceptance_criteria,
+			declared_files, estimate_hours, status, confidence, session_id, branch,
+			chronicle_summary, pr_url, pr_id, reason, retry_count, created_at, updated_at
+		FROM raids WHERE id = $1
+	`, id).Scan(
+		&r.ID, &r.PhaseID, &r.TrackerID, &r.Name, &r.Description,
+		pq.Array(&r.AcceptanceCriteria), pq.Array(&r.DeclaredFiles),
+		&r.EstimateHours, &r.Status, &r.Confidence, &r.SessionID, &r.Branch,
+		&r.ChronicleSummary, &r.PRUrl, &r.PRID, &r.Reason,
+		&r.RetryCount, &r.CreatedAt, &r.UpdatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get raid %s: %w", id, err)
+	}
+	return r, nil
+}
+
+// ListRaids returns raids for a phase, ordered by creation time.
+func (s *Store) ListRaids(ctx context.Context, phaseID string) ([]*Raid, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, phase_id, tracker_id, name, description, acceptance_criteria,
+			declared_files, estimate_hours, status, confidence, session_id, branch,
+			chronicle_summary, pr_url, pr_id, reason, retry_count, created_at, updated_at
+		FROM raids WHERE phase_id = $1 ORDER BY created_at
+	`, phaseID)
+	if err != nil {
+		return nil, fmt.Errorf("list raids: %w", err)
+	}
+	defer rows.Close()
+
+	var raids []*Raid
+	for rows.Next() {
+		r := &Raid{}
+		if err := rows.Scan(
+			&r.ID, &r.PhaseID, &r.TrackerID, &r.Name, &r.Description,
+			pq.Array(&r.AcceptanceCriteria), pq.Array(&r.DeclaredFiles),
+			&r.EstimateHours, &r.Status, &r.Confidence, &r.SessionID, &r.Branch,
+			&r.ChronicleSummary, &r.PRUrl, &r.PRID, &r.Reason,
+			&r.RetryCount, &r.CreatedAt, &r.UpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan raid: %w", err)
+		}
+		raids = append(raids, r)
+	}
+	return raids, rows.Err()
+}
+
+// UpdateRaid updates mutable fields on a raid.
+func (s *Store) UpdateRaid(ctx context.Context, raid *Raid) error {
+	raid.UpdatedAt = time.Now().UTC()
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE raids SET name = $1, status = $2, confidence = $3, session_id = $4,
+			branch = $5, chronicle_summary = $6, pr_url = $7, pr_id = $8,
+			reason = $9, retry_count = $10, description = $11, acceptance_criteria = $12,
+			updated_at = $13
+		WHERE id = $14
+	`,
+		raid.Name, raid.Status, raid.Confidence, raid.SessionID,
+		raid.Branch, raid.ChronicleSummary, raid.PRUrl, raid.PRID,
+		raid.Reason, raid.RetryCount, raid.Description, pq.Array(raid.AcceptanceCriteria),
+		raid.UpdatedAt, raid.ID,
+	)
+	if err != nil {
+		return fmt.Errorf("update raid %s: %w", raid.ID, err)
+	}
+	n, _ := result.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("raid %s not found", raid.ID)
+	}
+	return nil
+}
+
+// UpdateRaidStatus transitions a raid to a new status, enforcing the state machine.
+func (s *Store) UpdateRaidStatus(ctx context.Context, id string, newStatus RaidStatus, reason *string) error {
+	raid, err := s.GetRaid(ctx, id)
+	if err != nil {
+		return err
+	}
+	if raid == nil {
+		return fmt.Errorf("raid %s not found", id)
+	}
+
+	if !ValidTransition(raid.Status, newStatus) {
+		return fmt.Errorf("invalid transition from %s to %s", raid.Status, newStatus)
+	}
+
+	raid.Status = newStatus
+	raid.Reason = reason
+	if newStatus == RaidStatusFailed {
+		raid.RetryCount++
+	}
+	return s.UpdateRaid(ctx, raid)
+}
+
+// --- Confidence Events ---
+
+// CreateConfidenceEvent records a confidence change and updates the raid score.
+func (s *Store) CreateConfidenceEvent(ctx context.Context, raidID string, eventType ConfidenceEventType, delta float64) (*ConfidenceEvent, error) {
+	raid, err := s.GetRaid(ctx, raidID)
+	if err != nil {
+		return nil, err
+	}
+	if raid == nil {
+		return nil, fmt.Errorf("raid %s not found", raidID)
+	}
+
+	scoreAfter := raid.Confidence + delta
+	if scoreAfter < 0 {
+		scoreAfter = 0
+	}
+	if scoreAfter > 1 {
+		scoreAfter = 1
+	}
+
+	ev := &ConfidenceEvent{}
+	err = s.db.QueryRowContext(ctx, `
+		INSERT INTO confidence_events (raid_id, event_type, delta, score_after)
+		VALUES ($1, $2, $3, $4)
+		RETURNING id, created_at
+	`, raidID, eventType, delta, scoreAfter).Scan(&ev.ID, &ev.CreatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("insert confidence event: %w", err)
+	}
+
+	// Update raid confidence.
+	_, err = s.db.ExecContext(ctx, `UPDATE raids SET confidence = $1, updated_at = NOW() WHERE id = $2`, scoreAfter, raidID)
+	if err != nil {
+		return nil, fmt.Errorf("update raid confidence: %w", err)
+	}
+
+	ev.RaidID = raidID
+	ev.EventType = eventType
+	ev.Delta = delta
+	ev.ScoreAfter = scoreAfter
+	return ev, nil
+}
+
+// ListConfidenceEvents returns events for a raid, ordered by creation time.
+func (s *Store) ListConfidenceEvents(ctx context.Context, raidID string) ([]*ConfidenceEvent, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, raid_id, event_type, delta, score_after, created_at
+		FROM confidence_events WHERE raid_id = $1 ORDER BY created_at
+	`, raidID)
+	if err != nil {
+		return nil, fmt.Errorf("list confidence events: %w", err)
+	}
+	defer rows.Close()
+
+	var events []*ConfidenceEvent
+	for rows.Next() {
+		ev := &ConfidenceEvent{}
+		if err := rows.Scan(&ev.ID, &ev.RaidID, &ev.EventType, &ev.Delta, &ev.ScoreAfter, &ev.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan confidence event: %w", err)
+		}
+		events = append(events, ev)
+	}
+	return events, rows.Err()
+}
+
+// Ping verifies the database connection is alive.
+func (s *Store) Ping(ctx context.Context) error {
+	return s.db.PingContext(ctx)
+}
+

--- a/cli/internal/tyr/store.go
+++ b/cli/internal/tyr/store.go
@@ -307,13 +307,13 @@ func (s *Store) UpdateRaid(ctx context.Context, raid *Raid) error {
 		UPDATE raids SET name = $1, status = $2, confidence = $3, session_id = $4,
 			branch = $5, chronicle_summary = $6, pr_url = $7, pr_id = $8,
 			reason = $9, retry_count = $10, description = $11, acceptance_criteria = $12,
-			updated_at = $13
-		WHERE id = $14
+			declared_files = $13, estimate_hours = $14, updated_at = $15
+		WHERE id = $16
 	`,
 		raid.Name, raid.Status, raid.Confidence, raid.SessionID,
 		raid.Branch, raid.ChronicleSummary, raid.PRUrl, raid.PRID,
 		raid.Reason, raid.RetryCount, raid.Description, pq.Array(raid.AcceptanceCriteria),
-		raid.UpdatedAt, raid.ID,
+		pq.Array(raid.DeclaredFiles), raid.EstimateHours, raid.UpdatedAt, raid.ID,
 	)
 	if err != nil {
 		return fmt.Errorf("update raid %s: %w", raid.ID, err)
@@ -350,6 +350,7 @@ func (s *Store) UpdateRaidStatus(ctx context.Context, id string, newStatus RaidS
 // --- Confidence Events ---
 
 // CreateConfidenceEvent records a confidence change and updates the raid score.
+// Both the event insert and raid confidence update are wrapped in a transaction.
 func (s *Store) CreateConfidenceEvent(ctx context.Context, raidID string, eventType ConfidenceEventType, delta float64) (*ConfidenceEvent, error) {
 	raid, err := s.GetRaid(ctx, raidID)
 	if err != nil {
@@ -367,20 +368,31 @@ func (s *Store) CreateConfidenceEvent(ctx context.Context, raidID string, eventT
 		scoreAfter = 1
 	}
 
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+
 	ev := &ConfidenceEvent{}
-	err = s.db.QueryRowContext(ctx, `
+	err = tx.QueryRowContext(ctx, `
 		INSERT INTO confidence_events (raid_id, event_type, delta, score_after)
 		VALUES ($1, $2, $3, $4)
 		RETURNING id, created_at
 	`, raidID, eventType, delta, scoreAfter).Scan(&ev.ID, &ev.CreatedAt)
 	if err != nil {
+		_ = tx.Rollback()
 		return nil, fmt.Errorf("insert confidence event: %w", err)
 	}
 
 	// Update raid confidence.
-	_, err = s.db.ExecContext(ctx, `UPDATE raids SET confidence = $1, updated_at = NOW() WHERE id = $2`, scoreAfter, raidID)
+	_, err = tx.ExecContext(ctx, `UPDATE raids SET confidence = $1, updated_at = NOW() WHERE id = $2`, scoreAfter, raidID)
 	if err != nil {
+		_ = tx.Rollback()
 		return nil, fmt.Errorf("update raid confidence: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit confidence event: %w", err)
 	}
 
 	ev.RaidID = raidID

--- a/cli/internal/tyr/store_test.go
+++ b/cli/internal/tyr/store_test.go
@@ -575,12 +575,12 @@ func TestStore_CreateConfidenceEvent(t *testing.T) {
 		nil, nil, nil, nil, 0, now, now)
 	mock.ExpectQuery("SELECT .* FROM raids WHERE id").WithArgs("r1").WillReturnRows(raidRows)
 
-	// Insert confidence event
+	// Transaction for confidence event
+	mock.ExpectBegin()
 	evRows := sqlmock.NewRows([]string{"id", "created_at"}).AddRow("ev-1", now)
 	mock.ExpectQuery("INSERT INTO confidence_events").WillReturnRows(evRows)
-
-	// Update raid confidence
 	mock.ExpectExec("UPDATE raids SET confidence").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
 
 	event, err := store.CreateConfidenceEvent(ctx, "r1", ConfidenceEventCIPass, 0.1)
 	if err != nil {
@@ -606,9 +606,11 @@ func TestStore_CreateConfidenceEvent_Clamped(t *testing.T) {
 		nil, nil, nil, nil, 0, now, now)
 	mock.ExpectQuery("SELECT .* FROM raids WHERE id").WithArgs("r1").WillReturnRows(raidRows)
 
+	mock.ExpectBegin()
 	evRows := sqlmock.NewRows([]string{"id", "created_at"}).AddRow("ev-1", now)
 	mock.ExpectQuery("INSERT INTO confidence_events").WillReturnRows(evRows)
 	mock.ExpectExec("UPDATE raids SET confidence").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
 
 	event, err := store.CreateConfidenceEvent(ctx, "r1", ConfidenceEventCIPass, 0.2)
 	if err != nil {
@@ -633,9 +635,11 @@ func TestStore_CreateConfidenceEvent_ClampedToZero(t *testing.T) {
 		nil, nil, nil, nil, 0, now, now)
 	mock.ExpectQuery("SELECT .* FROM raids WHERE id").WithArgs("r1").WillReturnRows(raidRows)
 
+	mock.ExpectBegin()
 	evRows := sqlmock.NewRows([]string{"id", "created_at"}).AddRow("ev-1", now)
 	mock.ExpectQuery("INSERT INTO confidence_events").WillReturnRows(evRows)
 	mock.ExpectExec("UPDATE raids SET confidence").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
 
 	event, err := store.CreateConfidenceEvent(ctx, "r1", ConfidenceEventCIFail, -0.5)
 	if err != nil {

--- a/cli/internal/tyr/store_test.go
+++ b/cli/internal/tyr/store_test.go
@@ -1,0 +1,694 @@
+package tyr
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/lib/pq"
+)
+
+func newMockStore(t *testing.T) (*Store, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("create sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return NewStore(db), mock
+}
+
+func TestNewStore(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	store := NewStore(db)
+	if store == nil {
+		t.Fatal("expected non-nil store")
+	}
+	if store.db != db {
+		t.Error("store.db should be the passed db")
+	}
+}
+
+func TestStore_CreateSaga(t *testing.T) {
+	store, mock := newMockStore(t)
+	ctx := context.Background()
+
+	saga := &Saga{
+		TrackerID:   "proj-1",
+		TrackerType: "native",
+		Slug:        "test-saga",
+		Name:        "Test Saga",
+		Repos:       []string{"repo1"},
+		Status:      SagaStatusActive,
+		Confidence:  0,
+		OwnerID:     "default",
+		BaseBranch:  "main",
+	}
+
+	rows := sqlmock.NewRows([]string{"id", "created_at"}).
+		AddRow("uuid-1", time.Now())
+	mock.ExpectQuery("INSERT INTO sagas").
+		WithArgs(saga.TrackerID, saga.TrackerType, saga.Slug, saga.Name,
+			pq.Array(saga.Repos), saga.Status, saga.Confidence,
+			saga.OwnerID, saga.BaseBranch).
+		WillReturnRows(rows)
+
+	result, err := store.CreateSaga(ctx, saga)
+	if err != nil {
+		t.Fatalf("CreateSaga: %v", err)
+	}
+	if result.ID != "uuid-1" {
+		t.Errorf("expected ID uuid-1, got %s", result.ID)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestStore_CreateSaga_Error(t *testing.T) {
+	store, mock := newMockStore(t)
+	ctx := context.Background()
+
+	mock.ExpectQuery("INSERT INTO sagas").WillReturnError(sql.ErrConnDone)
+
+	_, err := store.CreateSaga(ctx, &Saga{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestStore_GetSaga(t *testing.T) {
+	store, mock := newMockStore(t)
+	ctx := context.Background()
+
+	now := time.Now()
+	rows := sqlmock.NewRows([]string{
+		"id", "tracker_id", "tracker_type", "slug", "name", "repos",
+		"status", "confidence", "owner_id", "base_branch", "created_at",
+	}).AddRow("uuid-1", "proj-1", "native", "test", "Test", pq.Array([]string{"repo1"}),
+		"ACTIVE", 0.5, "default", "main", now)
+
+	mock.ExpectQuery("SELECT .* FROM sagas WHERE id").
+		WithArgs("uuid-1").
+		WillReturnRows(rows)
+
+	saga, err := store.GetSaga(ctx, "uuid-1")
+	if err != nil {
+		t.Fatalf("GetSaga: %v", err)
+	}
+	if saga == nil {
+		t.Fatal("expected non-nil saga")
+	}
+	if saga.Name != "Test" {
+		t.Errorf("expected name 'Test', got %q", saga.Name)
+	}
+}
+
+func TestStore_GetSaga_NotFound(t *testing.T) {
+	store, mock := newMockStore(t)
+	ctx := context.Background()
+
+	mock.ExpectQuery("SELECT .* FROM sagas WHERE id").
+		WithArgs("nonexistent").
+		WillReturnError(sql.ErrNoRows)
+
+	saga, err := store.GetSaga(ctx, "nonexistent")
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if saga != nil {
+		t.Error("expected nil saga for not found")
+	}
+}
+
+func TestStore_ListSagas(t *testing.T) {
+	store, mock := newMockStore(t)
+	ctx := context.Background()
+
+	now := time.Now()
+	rows := sqlmock.NewRows([]string{
+		"id", "tracker_id", "tracker_type", "slug", "name", "repos",
+		"status", "confidence", "owner_id", "base_branch", "created_at",
+	}).AddRow("uuid-1", "p1", "native", "s1", "Saga 1", pq.Array([]string{}),
+		"ACTIVE", 0.0, "default", "main", now).
+		AddRow("uuid-2", "p2", "native", "s2", "Saga 2", pq.Array([]string{"r1"}),
+			"COMPLETE", 1.0, "default", "main", now)
+
+	mock.ExpectQuery("SELECT .* FROM sagas ORDER BY").WillReturnRows(rows)
+
+	sagas, err := store.ListSagas(ctx)
+	if err != nil {
+		t.Fatalf("ListSagas: %v", err)
+	}
+	if len(sagas) != 2 {
+		t.Fatalf("expected 2 sagas, got %d", len(sagas))
+	}
+	if sagas[0].Name != "Saga 1" {
+		t.Errorf("expected 'Saga 1', got %q", sagas[0].Name)
+	}
+}
+
+func TestStore_ListSagas_Error(t *testing.T) {
+	store, mock := newMockStore(t)
+	ctx := context.Background()
+
+	mock.ExpectQuery("SELECT .* FROM sagas ORDER BY").WillReturnError(sql.ErrConnDone)
+
+	_, err := store.ListSagas(ctx)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestStore_UpdateSaga(t *testing.T) {
+	store, mock := newMockStore(t)
+	ctx := context.Background()
+
+	saga := &Saga{ID: "uuid-1", Name: "Updated", Status: SagaStatusComplete,
+		Confidence: 0.9, Repos: []string{"r1"}, BaseBranch: "dev"}
+
+	mock.ExpectExec("UPDATE sagas SET").
+		WithArgs(saga.Name, saga.Status, saga.Confidence, pq.Array(saga.Repos), saga.BaseBranch, saga.ID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := store.UpdateSaga(ctx, saga); err != nil {
+		t.Fatalf("UpdateSaga: %v", err)
+	}
+}
+
+func TestStore_UpdateSaga_NotFound(t *testing.T) {
+	store, mock := newMockStore(t)
+	ctx := context.Background()
+
+	mock.ExpectExec("UPDATE sagas SET").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	err := store.UpdateSaga(ctx, &Saga{ID: "nonexistent"})
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+}
+
+func TestStore_DeleteSaga(t *testing.T) {
+	store, mock := newMockStore(t)
+	ctx := context.Background()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("DELETE FROM confidence_events").WithArgs("uuid-1").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DELETE FROM raids").WithArgs("uuid-1").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DELETE FROM phases").WithArgs("uuid-1").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DELETE FROM sagas").WithArgs("uuid-1").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	if err := store.DeleteSaga(ctx, "uuid-1"); err != nil {
+		t.Fatalf("DeleteSaga: %v", err)
+	}
+}
+
+func TestStore_DeleteSaga_NotFound(t *testing.T) {
+	store, mock := newMockStore(t)
+	ctx := context.Background()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("DELETE FROM confidence_events").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DELETE FROM raids").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DELETE FROM phases").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DELETE FROM sagas").WithArgs("nonexistent").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectRollback()
+
+	err := store.DeleteSaga(ctx, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestStore_CreatePhase(t *testing.T) {
+	store, mock := newMockStore(t)
+	ctx := context.Background()
+
+	phase := &Phase{
+		SagaID:    "saga-1",
+		TrackerID: "phase-1",
+		Number:    1,
+		Name:      "Phase 1",
+		Status:    PhaseStatusGated,
+	}
+
+	rows := sqlmock.NewRows([]string{"id"}).AddRow("phase-uuid-1")
+	mock.ExpectQuery("INSERT INTO phases").
+		WithArgs(phase.SagaID, phase.TrackerID, phase.Number, phase.Name, phase.Status, phase.Confidence).
+		WillReturnRows(rows)
+
+	result, err := store.CreatePhase(ctx, phase)
+	if err != nil {
+		t.Fatalf("CreatePhase: %v", err)
+	}
+	if result.ID != "phase-uuid-1" {
+		t.Errorf("expected ID phase-uuid-1, got %s", result.ID)
+	}
+}
+
+func TestStore_ListPhases(t *testing.T) {
+	store, mock := newMockStore(t)
+	ctx := context.Background()
+
+	rows := sqlmock.NewRows([]string{
+		"id", "saga_id", "tracker_id", "number", "name", "status", "confidence",
+	}).AddRow("p1", "saga-1", "t1", 1, "Phase 1", "GATED", 0.0).
+		AddRow("p2", "saga-1", "t2", 2, "Phase 2", "ACTIVE", 0.5)
+
+	mock.ExpectQuery("SELECT .* FROM phases WHERE saga_id").
+		WithArgs("saga-1").
+		WillReturnRows(rows)
+
+	phases, err := store.ListPhases(ctx, "saga-1")
+	if err != nil {
+		t.Fatalf("ListPhases: %v", err)
+	}
+	if len(phases) != 2 {
+		t.Fatalf("expected 2 phases, got %d", len(phases))
+	}
+}
+
+func TestStore_GetPhase(t *testing.T) {
+	store, mock := newMockStore(t)
+	ctx := context.Background()
+
+	rows := sqlmock.NewRows([]string{
+		"id", "saga_id", "tracker_id", "number", "name", "status", "confidence",
+	}).AddRow("p1", "saga-1", "t1", 1, "Phase 1", "GATED", 0.0)
+
+	mock.ExpectQuery("SELECT .* FROM phases WHERE id").
+		WithArgs("p1").
+		WillReturnRows(rows)
+
+	phase, err := store.GetPhase(ctx, "p1")
+	if err != nil {
+		t.Fatalf("GetPhase: %v", err)
+	}
+	if phase == nil {
+		t.Fatal("expected non-nil phase")
+	}
+	if phase.Name != "Phase 1" {
+		t.Errorf("expected 'Phase 1', got %q", phase.Name)
+	}
+}
+
+func TestStore_GetPhase_NotFound(t *testing.T) {
+	store, mock := newMockStore(t)
+	ctx := context.Background()
+
+	mock.ExpectQuery("SELECT .* FROM phases WHERE id").
+		WithArgs("nonexistent").
+		WillReturnError(sql.ErrNoRows)
+
+	phase, err := store.GetPhase(ctx, "nonexistent")
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if phase != nil {
+		t.Error("expected nil phase")
+	}
+}
+
+func TestStore_UpdatePhase(t *testing.T) {
+	store, mock := newMockStore(t)
+	ctx := context.Background()
+
+	phase := &Phase{ID: "p1", Name: "Updated", Status: PhaseStatusActive, Confidence: 0.7}
+
+	mock.ExpectExec("UPDATE phases SET").
+		WithArgs(phase.Name, phase.Status, phase.Confidence, phase.ID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := store.UpdatePhase(ctx, phase); err != nil {
+		t.Fatalf("UpdatePhase: %v", err)
+	}
+}
+
+func TestStore_UpdatePhase_NotFound(t *testing.T) {
+	store, mock := newMockStore(t)
+	ctx := context.Background()
+
+	mock.ExpectExec("UPDATE phases SET").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	err := store.UpdatePhase(ctx, &Phase{ID: "nonexistent"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestStore_CreateRaid(t *testing.T) {
+	store, mock := newMockStore(t)
+	ctx := context.Background()
+
+	raid := &Raid{
+		PhaseID:            "phase-1",
+		TrackerID:          "raid-1",
+		Name:               "Implement feature",
+		Description:        "Do the thing",
+		AcceptanceCriteria: []string{"test passes"},
+		DeclaredFiles:      []string{"file.go"},
+		Status:             RaidStatusPending,
+	}
+
+	rows := sqlmock.NewRows([]string{"id"}).AddRow("raid-uuid-1")
+	mock.ExpectQuery("INSERT INTO raids").WillReturnRows(rows)
+
+	result, err := store.CreateRaid(ctx, raid)
+	if err != nil {
+		t.Fatalf("CreateRaid: %v", err)
+	}
+	if result.ID != "raid-uuid-1" {
+		t.Errorf("expected ID raid-uuid-1, got %s", result.ID)
+	}
+	if result.CreatedAt.IsZero() {
+		t.Error("expected non-zero CreatedAt")
+	}
+}
+
+func TestStore_GetRaid(t *testing.T) {
+	store, mock := newMockStore(t)
+	ctx := context.Background()
+
+	now := time.Now()
+	rows := sqlmock.NewRows([]string{
+		"id", "phase_id", "tracker_id", "name", "description", "acceptance_criteria",
+		"declared_files", "estimate_hours", "status", "confidence", "session_id", "branch",
+		"chronicle_summary", "pr_url", "pr_id", "reason", "retry_count", "created_at", "updated_at",
+	}).AddRow("r1", "p1", "t1", "Raid 1", "desc", pq.Array([]string{}),
+		pq.Array([]string{}), nil, "PENDING", 0.0, nil, nil,
+		nil, nil, nil, nil, 0, now, now)
+
+	mock.ExpectQuery("SELECT .* FROM raids WHERE id").
+		WithArgs("r1").
+		WillReturnRows(rows)
+
+	raid, err := store.GetRaid(ctx, "r1")
+	if err != nil {
+		t.Fatalf("GetRaid: %v", err)
+	}
+	if raid == nil {
+		t.Fatal("expected non-nil raid")
+	}
+	if raid.Name != "Raid 1" {
+		t.Errorf("expected 'Raid 1', got %q", raid.Name)
+	}
+}
+
+func TestStore_GetRaid_NotFound(t *testing.T) {
+	store, mock := newMockStore(t)
+	ctx := context.Background()
+
+	mock.ExpectQuery("SELECT .* FROM raids WHERE id").
+		WithArgs("nonexistent").
+		WillReturnError(sql.ErrNoRows)
+
+	raid, err := store.GetRaid(ctx, "nonexistent")
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if raid != nil {
+		t.Error("expected nil raid")
+	}
+}
+
+func TestStore_ListRaids(t *testing.T) {
+	store, mock := newMockStore(t)
+	ctx := context.Background()
+
+	now := time.Now()
+	rows := sqlmock.NewRows([]string{
+		"id", "phase_id", "tracker_id", "name", "description", "acceptance_criteria",
+		"declared_files", "estimate_hours", "status", "confidence", "session_id", "branch",
+		"chronicle_summary", "pr_url", "pr_id", "reason", "retry_count", "created_at", "updated_at",
+	}).AddRow("r1", "p1", "t1", "Raid 1", "", pq.Array([]string{}),
+		pq.Array([]string{}), nil, "PENDING", 0.0, nil, nil,
+		nil, nil, nil, nil, 0, now, now)
+
+	mock.ExpectQuery("SELECT .* FROM raids WHERE phase_id").
+		WithArgs("p1").
+		WillReturnRows(rows)
+
+	raids, err := store.ListRaids(ctx, "p1")
+	if err != nil {
+		t.Fatalf("ListRaids: %v", err)
+	}
+	if len(raids) != 1 {
+		t.Fatalf("expected 1 raid, got %d", len(raids))
+	}
+}
+
+func TestStore_UpdateRaid(t *testing.T) {
+	store, mock := newMockStore(t)
+	ctx := context.Background()
+
+	raid := &Raid{
+		ID: "r1", Name: "Updated", Status: RaidStatusRunning,
+		Description: "new desc", AcceptanceCriteria: []string{},
+	}
+
+	mock.ExpectExec("UPDATE raids SET").WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := store.UpdateRaid(ctx, raid); err != nil {
+		t.Fatalf("UpdateRaid: %v", err)
+	}
+	if raid.UpdatedAt.IsZero() {
+		t.Error("expected non-zero UpdatedAt")
+	}
+}
+
+func TestStore_UpdateRaid_NotFound(t *testing.T) {
+	store, mock := newMockStore(t)
+	ctx := context.Background()
+
+	mock.ExpectExec("UPDATE raids SET").WillReturnResult(sqlmock.NewResult(0, 0))
+
+	err := store.UpdateRaid(ctx, &Raid{ID: "nonexistent"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestStore_UpdateRaidStatus(t *testing.T) {
+	store, mock := newMockStore(t)
+	ctx := context.Background()
+
+	now := time.Now()
+	// GetRaid
+	rows := sqlmock.NewRows([]string{
+		"id", "phase_id", "tracker_id", "name", "description", "acceptance_criteria",
+		"declared_files", "estimate_hours", "status", "confidence", "session_id", "branch",
+		"chronicle_summary", "pr_url", "pr_id", "reason", "retry_count", "created_at", "updated_at",
+	}).AddRow("r1", "p1", "t1", "Raid 1", "", pq.Array([]string{}),
+		pq.Array([]string{}), nil, "PENDING", 0.0, nil, nil,
+		nil, nil, nil, nil, 0, now, now)
+	mock.ExpectQuery("SELECT .* FROM raids WHERE id").WithArgs("r1").WillReturnRows(rows)
+
+	// UpdateRaid
+	mock.ExpectExec("UPDATE raids SET").WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := store.UpdateRaidStatus(ctx, "r1", RaidStatusQueued, nil); err != nil {
+		t.Fatalf("UpdateRaidStatus: %v", err)
+	}
+}
+
+func TestStore_UpdateRaidStatus_InvalidTransition(t *testing.T) {
+	store, mock := newMockStore(t)
+	ctx := context.Background()
+
+	now := time.Now()
+	rows := sqlmock.NewRows([]string{
+		"id", "phase_id", "tracker_id", "name", "description", "acceptance_criteria",
+		"declared_files", "estimate_hours", "status", "confidence", "session_id", "branch",
+		"chronicle_summary", "pr_url", "pr_id", "reason", "retry_count", "created_at", "updated_at",
+	}).AddRow("r1", "p1", "t1", "Raid 1", "", pq.Array([]string{}),
+		pq.Array([]string{}), nil, "PENDING", 0.0, nil, nil,
+		nil, nil, nil, nil, 0, now, now)
+	mock.ExpectQuery("SELECT .* FROM raids WHERE id").WithArgs("r1").WillReturnRows(rows)
+
+	err := store.UpdateRaidStatus(ctx, "r1", RaidStatusMerged, nil)
+	if err == nil {
+		t.Fatal("expected error for invalid transition")
+	}
+}
+
+func TestStore_UpdateRaidStatus_NotFound(t *testing.T) {
+	store, mock := newMockStore(t)
+	ctx := context.Background()
+
+	mock.ExpectQuery("SELECT .* FROM raids WHERE id").
+		WithArgs("nonexistent").
+		WillReturnError(sql.ErrNoRows)
+
+	err := store.UpdateRaidStatus(ctx, "nonexistent", RaidStatusQueued, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestStore_UpdateRaidStatus_Failed_IncrementsRetry(t *testing.T) {
+	store, mock := newMockStore(t)
+	ctx := context.Background()
+
+	now := time.Now()
+	rows := sqlmock.NewRows([]string{
+		"id", "phase_id", "tracker_id", "name", "description", "acceptance_criteria",
+		"declared_files", "estimate_hours", "status", "confidence", "session_id", "branch",
+		"chronicle_summary", "pr_url", "pr_id", "reason", "retry_count", "created_at", "updated_at",
+	}).AddRow("r1", "p1", "t1", "Raid 1", "", pq.Array([]string{}),
+		pq.Array([]string{}), nil, "RUNNING", 0.0, nil, nil,
+		nil, nil, nil, nil, 0, now, now)
+	mock.ExpectQuery("SELECT .* FROM raids WHERE id").WithArgs("r1").WillReturnRows(rows)
+
+	mock.ExpectExec("UPDATE raids SET").WillReturnResult(sqlmock.NewResult(0, 1))
+
+	reason := "tests failed"
+	if err := store.UpdateRaidStatus(ctx, "r1", RaidStatusFailed, &reason); err != nil {
+		t.Fatalf("UpdateRaidStatus: %v", err)
+	}
+}
+
+func TestStore_CreateConfidenceEvent(t *testing.T) {
+	store, mock := newMockStore(t)
+	ctx := context.Background()
+
+	now := time.Now()
+	// GetRaid
+	raidRows := sqlmock.NewRows([]string{
+		"id", "phase_id", "tracker_id", "name", "description", "acceptance_criteria",
+		"declared_files", "estimate_hours", "status", "confidence", "session_id", "branch",
+		"chronicle_summary", "pr_url", "pr_id", "reason", "retry_count", "created_at", "updated_at",
+	}).AddRow("r1", "p1", "t1", "Raid 1", "", pq.Array([]string{}),
+		pq.Array([]string{}), nil, "RUNNING", 0.5, nil, nil,
+		nil, nil, nil, nil, 0, now, now)
+	mock.ExpectQuery("SELECT .* FROM raids WHERE id").WithArgs("r1").WillReturnRows(raidRows)
+
+	// Insert confidence event
+	evRows := sqlmock.NewRows([]string{"id", "created_at"}).AddRow("ev-1", now)
+	mock.ExpectQuery("INSERT INTO confidence_events").WillReturnRows(evRows)
+
+	// Update raid confidence
+	mock.ExpectExec("UPDATE raids SET confidence").WillReturnResult(sqlmock.NewResult(0, 1))
+
+	event, err := store.CreateConfidenceEvent(ctx, "r1", ConfidenceEventCIPass, 0.1)
+	if err != nil {
+		t.Fatalf("CreateConfidenceEvent: %v", err)
+	}
+	if event.ScoreAfter != 0.6 {
+		t.Errorf("expected score 0.6, got %f", event.ScoreAfter)
+	}
+}
+
+func TestStore_CreateConfidenceEvent_Clamped(t *testing.T) {
+	store, mock := newMockStore(t)
+	ctx := context.Background()
+
+	now := time.Now()
+	// Raid with confidence 0.9 — adding 0.2 should clamp to 1.0
+	raidRows := sqlmock.NewRows([]string{
+		"id", "phase_id", "tracker_id", "name", "description", "acceptance_criteria",
+		"declared_files", "estimate_hours", "status", "confidence", "session_id", "branch",
+		"chronicle_summary", "pr_url", "pr_id", "reason", "retry_count", "created_at", "updated_at",
+	}).AddRow("r1", "p1", "t1", "Raid", "", pq.Array([]string{}),
+		pq.Array([]string{}), nil, "RUNNING", 0.9, nil, nil,
+		nil, nil, nil, nil, 0, now, now)
+	mock.ExpectQuery("SELECT .* FROM raids WHERE id").WithArgs("r1").WillReturnRows(raidRows)
+
+	evRows := sqlmock.NewRows([]string{"id", "created_at"}).AddRow("ev-1", now)
+	mock.ExpectQuery("INSERT INTO confidence_events").WillReturnRows(evRows)
+	mock.ExpectExec("UPDATE raids SET confidence").WillReturnResult(sqlmock.NewResult(0, 1))
+
+	event, err := store.CreateConfidenceEvent(ctx, "r1", ConfidenceEventCIPass, 0.2)
+	if err != nil {
+		t.Fatalf("CreateConfidenceEvent: %v", err)
+	}
+	if event.ScoreAfter != 1.0 {
+		t.Errorf("expected clamped score 1.0, got %f", event.ScoreAfter)
+	}
+}
+
+func TestStore_CreateConfidenceEvent_ClampedToZero(t *testing.T) {
+	store, mock := newMockStore(t)
+	ctx := context.Background()
+
+	now := time.Now()
+	raidRows := sqlmock.NewRows([]string{
+		"id", "phase_id", "tracker_id", "name", "description", "acceptance_criteria",
+		"declared_files", "estimate_hours", "status", "confidence", "session_id", "branch",
+		"chronicle_summary", "pr_url", "pr_id", "reason", "retry_count", "created_at", "updated_at",
+	}).AddRow("r1", "p1", "t1", "Raid", "", pq.Array([]string{}),
+		pq.Array([]string{}), nil, "RUNNING", 0.1, nil, nil,
+		nil, nil, nil, nil, 0, now, now)
+	mock.ExpectQuery("SELECT .* FROM raids WHERE id").WithArgs("r1").WillReturnRows(raidRows)
+
+	evRows := sqlmock.NewRows([]string{"id", "created_at"}).AddRow("ev-1", now)
+	mock.ExpectQuery("INSERT INTO confidence_events").WillReturnRows(evRows)
+	mock.ExpectExec("UPDATE raids SET confidence").WillReturnResult(sqlmock.NewResult(0, 1))
+
+	event, err := store.CreateConfidenceEvent(ctx, "r1", ConfidenceEventCIFail, -0.5)
+	if err != nil {
+		t.Fatalf("CreateConfidenceEvent: %v", err)
+	}
+	if event.ScoreAfter != 0 {
+		t.Errorf("expected clamped score 0, got %f", event.ScoreAfter)
+	}
+}
+
+func TestStore_CreateConfidenceEvent_RaidNotFound(t *testing.T) {
+	store, mock := newMockStore(t)
+	ctx := context.Background()
+
+	mock.ExpectQuery("SELECT .* FROM raids WHERE id").
+		WithArgs("nonexistent").
+		WillReturnError(sql.ErrNoRows)
+
+	_, err := store.CreateConfidenceEvent(ctx, "nonexistent", ConfidenceEventCIPass, 0.1)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestStore_ListConfidenceEvents(t *testing.T) {
+	store, mock := newMockStore(t)
+	ctx := context.Background()
+
+	now := time.Now()
+	rows := sqlmock.NewRows([]string{
+		"id", "raid_id", "event_type", "delta", "score_after", "created_at",
+	}).AddRow("ev-1", "r1", "ci_pass", 0.1, 0.6, now)
+
+	mock.ExpectQuery("SELECT .* FROM confidence_events WHERE raid_id").
+		WithArgs("r1").
+		WillReturnRows(rows)
+
+	events, err := store.ListConfidenceEvents(ctx, "r1")
+	if err != nil {
+		t.Fatalf("ListConfidenceEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+}
+
+func TestStore_Ping(t *testing.T) {
+	store, mock := newMockStore(t)
+	ctx := context.Background()
+
+	mock.ExpectPing()
+
+	if err := store.Ping(ctx); err != nil {
+		t.Fatalf("Ping: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- **tyr-mini package** (`cli/internal/tyr/`): Go-native saga coordinator with saga/phase/raid CRUD, raid dispatch to Forge, state machine, and confidence tracking
- **REST API** (`/api/v1/tyr/*`): Same API shape as full Tyr so web UI works without changes
- **Embedded migrations**: Tyr schema tables embedded via `go:embed`, compatible with full Tyr for migration path to k3s/production
- **Proxy integration**: tyr-mini routes mounted on Forge's HTTP mux (Option A) — single process, single port
- **CLI commands**: `volundr tyr sagas list`, `volundr tyr raids list --phase <id>`, `volundr tyr status`
- **Config**: Added `tyr.enabled` to config, init wizard prompt
- **Runtime integration**: `volundr up` starts tyr-mini alongside Forge when enabled
- **91% test coverage** on tyr package

## Test plan

- [x] All 120+ tyr tests pass with 91% coverage
- [x] Full CLI test suite passes (all existing tests unaffected)
- [x] `go vet ./...` clean
- [x] `go build ./...` succeeds
- [ ] CI pipeline passes (tests, lint, coverage)

Resolves NIU-326

🤖 Generated with [Claude Code](https://claude.com/claude-code)