### PR TITLE
feat(forge): wire embedded web UI into Forge server

### DIFF
--- a/cli/internal/cli/up.go
+++ b/cli/internal/cli/up.go
@@ -174,6 +174,8 @@ func buildForgeConfig(cfg *config.Config) (*forge.Config, error) {
 		forgeCfg.Forge.Xcode.DefaultVersion = fs.Xcode.DefaultVersion
 	}
 
+	forgeCfg.Web = cfg.Volundr.Web
+
 	forgeCfg.Auth.Mode = fs.Auth.Mode
 	forgeCfg.Auth.Tokens = make([]forge.PATEntry, len(fs.Auth.Tokens))
 	for i, t := range fs.Auth.Tokens {

--- a/cli/internal/forge/config.go
+++ b/cli/internal/forge/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	Auth      AuthConfig      `yaml:"auth"`
 	Git       GitConfig       `yaml:"git"`
 	Anthropic AnthropicConfig `yaml:"anthropic"`
+	Web       bool            `yaml:"web"`
 }
 
 // ListenConfig holds the listener settings.
@@ -81,6 +82,7 @@ func DefaultForgeConfig() *Config {
 	volundrDir := filepath.Join(home, ".niuu")
 
 	cfg := &Config{
+		Web: true,
 		Listen: ListenConfig{
 			Host:              "127.0.0.1",
 			Port:              8080,

--- a/cli/internal/forge/server.go
+++ b/cli/internal/forge/server.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+
+	"github.com/niuulabs/volundr/cli/internal/web"
 )
 
 // Server is the main forge server that ties together the store, runner,
@@ -55,6 +57,11 @@ func (s *Server) Run(ctx context.Context) error {
 
 	addr := fmt.Sprintf("%s:%d", s.cfg.Listen.Host, s.cfg.Listen.Port)
 
+	if s.cfg.Web {
+		webCfg := &web.RuntimeConfig{APIBaseURL: fmt.Sprintf("http://%s", addr)}
+		mux.Handle("/", web.Handler(webCfg))
+	}
+
 	s.srv = &http.Server{
 		Addr:              addr,
 		Handler:           s.auth.Wrap(mux),
@@ -79,6 +86,7 @@ func (s *Server) Run(ctx context.Context) error {
 	log.Printf("  workspaces: %s", s.cfg.Forge.WorkspacesDir)
 	log.Printf("  max concurrent sessions: %d", s.cfg.Forge.MaxConcurrent)
 	log.Printf("  auth mode: %s", s.cfg.Auth.Mode)
+	log.Printf("  web ui: %v", s.cfg.Web)
 
 	if s.cfg.Listen.Host == "0.0.0.0" && s.cfg.Auth.Mode == "none" {
 		log.Println("WARNING: listening on all interfaces with auth=none — any network client can create sessions")

--- a/cli/internal/forge/server_test.go
+++ b/cli/internal/forge/server_test.go
@@ -2,9 +2,15 @@ package forge
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
 	"net"
+	"net/http"
 	"testing"
 	"time"
+
+	"github.com/niuulabs/volundr/cli/internal/web"
 )
 
 func TestNewServer_ValidConfig(t *testing.T) {
@@ -120,5 +126,168 @@ func TestServer_ConfigTimeoutDefaults(t *testing.T) {
 	}
 	if cfg.Forge.StopTimeout != 10*time.Second {
 		t.Errorf("expected StopTimeout 10s, got %v", cfg.Forge.StopTimeout)
+	}
+}
+
+func TestDefaultForgeConfig_WebEnabledByDefault(t *testing.T) {
+	cfg := DefaultForgeConfig()
+	if !cfg.Web {
+		t.Error("expected Web to be true by default")
+	}
+}
+
+// startTestServer creates and starts a forge server on a random port,
+// returning the base URL and a cancel function.
+func startTestServer(t *testing.T, cfg *Config) (string, context.CancelFunc) {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("find free port: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+
+	cfg.Listen.Host = "127.0.0.1"
+	cfg.Listen.Port = port
+
+	srv, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		_ = srv.Run(ctx)
+	}()
+
+	// Wait for server to be ready.
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(baseURL + "/health")
+		if err == nil {
+			_ = resp.Body.Close()
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	return baseURL, cancel
+}
+
+func TestServer_WebEnabled_ServesConfigJSON(t *testing.T) {
+	cfg := DefaultForgeConfig()
+	cfg.Forge.WorkspacesDir = t.TempDir()
+	cfg.Web = true
+
+	baseURL, cancel := startTestServer(t, cfg)
+	defer cancel()
+
+	resp, err := http.Get(baseURL + "/config.json")
+	if err != nil {
+		t.Fatalf("GET /config.json: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", ct)
+	}
+
+	var rtCfg web.RuntimeConfig
+	body, _ := io.ReadAll(resp.Body)
+	if err := json.Unmarshal(body, &rtCfg); err != nil {
+		t.Fatalf("decode config.json: %v", err)
+	}
+
+	expectedURL := fmt.Sprintf("http://%s:%d", cfg.Listen.Host, cfg.Listen.Port)
+	if rtCfg.APIBaseURL != expectedURL {
+		t.Errorf("expected apiBaseUrl %q, got %q", expectedURL, rtCfg.APIBaseURL)
+	}
+}
+
+func TestServer_WebEnabled_SPAFallback(t *testing.T) {
+	cfg := DefaultForgeConfig()
+	cfg.Forge.WorkspacesDir = t.TempDir()
+	cfg.Web = true
+
+	baseURL, cancel := startTestServer(t, cfg)
+	defer cancel()
+
+	// SPA fallback: unknown path should return 200 (index.html), not 404.
+	resp, err := http.Get(baseURL + "/sessions/some-id")
+	if err != nil {
+		t.Fatalf("GET /sessions/some-id: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected SPA fallback 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestServer_WebEnabled_APIRoutesPrecedence(t *testing.T) {
+	cfg := DefaultForgeConfig()
+	cfg.Forge.WorkspacesDir = t.TempDir()
+	cfg.Web = true
+
+	baseURL, cancel := startTestServer(t, cfg)
+	defer cancel()
+
+	// API routes must still work when web is enabled.
+	resp, err := http.Get(baseURL + "/health")
+	if err != nil {
+		t.Fatalf("GET /health: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200 for /health, got %d", resp.StatusCode)
+	}
+
+	resp2, err := http.Get(baseURL + "/api/v1/volundr/sessions")
+	if err != nil {
+		t.Fatalf("GET /api/v1/volundr/sessions: %v", err)
+	}
+	defer resp2.Body.Close()
+
+	if resp2.StatusCode != http.StatusOK {
+		t.Errorf("expected 200 for /api/v1/volundr/sessions, got %d", resp2.StatusCode)
+	}
+}
+
+func TestServer_WebDisabled_NoSPA(t *testing.T) {
+	cfg := DefaultForgeConfig()
+	cfg.Forge.WorkspacesDir = t.TempDir()
+	cfg.Web = false
+
+	baseURL, cancel := startTestServer(t, cfg)
+	defer cancel()
+
+	// With web disabled, root path should return 404.
+	resp, err := http.Get(baseURL + "/config.json")
+	if err != nil {
+		t.Fatalf("GET /config.json: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 for /config.json when web disabled, got %d", resp.StatusCode)
+	}
+
+	// API routes must still work.
+	resp2, err := http.Get(baseURL + "/health")
+	if err != nil {
+		t.Fatalf("GET /health: %v", err)
+	}
+	defer resp2.Body.Close()
+
+	if resp2.StatusCode != http.StatusOK {
+		t.Errorf("expected 200 for /health when web disabled, got %d", resp2.StatusCode)
 	}
 }

--- a/cli/internal/forge/server_test.go
+++ b/cli/internal/forge/server_test.go
@@ -189,7 +189,7 @@ func TestServer_WebEnabled_ServesConfigJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET /config.json: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
@@ -224,7 +224,7 @@ func TestServer_WebEnabled_SPAFallback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET /sessions/some-id: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("expected SPA fallback 200, got %d", resp.StatusCode)
@@ -244,7 +244,7 @@ func TestServer_WebEnabled_APIRoutesPrecedence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET /health: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("expected 200 for /health, got %d", resp.StatusCode)
@@ -254,7 +254,7 @@ func TestServer_WebEnabled_APIRoutesPrecedence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET /api/v1/volundr/sessions: %v", err)
 	}
-	defer resp2.Body.Close()
+	defer func() { _ = resp2.Body.Close() }()
 
 	if resp2.StatusCode != http.StatusOK {
 		t.Errorf("expected 200 for /api/v1/volundr/sessions, got %d", resp2.StatusCode)
@@ -274,7 +274,7 @@ func TestServer_WebDisabled_NoSPA(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET /config.json: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusNotFound {
 		t.Errorf("expected 404 for /config.json when web disabled, got %d", resp.StatusCode)
@@ -285,7 +285,7 @@ func TestServer_WebDisabled_NoSPA(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET /health: %v", err)
 	}
-	defer resp2.Body.Close()
+	defer func() { _ = resp2.Body.Close() }()
 
 	if resp2.StatusCode != http.StatusOK {
 		t.Errorf("expected 200 for /health when web disabled, got %d", resp2.StatusCode)


### PR DESCRIPTION
## Summary

- Mount `web.Handler()` on the Forge HTTP mux when `cfg.Web == true` (default), serving the embedded SPA alongside API routes
- Add `Web bool` field to `forge.Config` with default `true`; pass `cfg.Volundr.Web` through `buildForgeConfig()` in `up.go`
- API routes (`/api/v1/*`, `/health`) take precedence over the SPA catch-all; `--no-web` skips mounting entirely

## Test plan

- [x] `TestServer_WebEnabled_ServesConfigJSON` — `/config.json` returns correct `apiBaseUrl`
- [x] `TestServer_WebEnabled_SPAFallback` — unknown paths serve index.html (200, not 404)
- [x] `TestServer_WebEnabled_APIRoutesPrecedence` — `/health` and `/api/v1/volundr/sessions` still work
- [x] `TestServer_WebDisabled_NoSPA` — `/config.json` returns 404 when web disabled; API routes still work
- [x] `TestDefaultForgeConfig_WebEnabledByDefault` — `Web` defaults to `true`
- [x] All existing tests pass, coverage 87.8%

Closes NIU-323

🤖 Generated with [Claude Code](https://claude.com/claude-code)