### PR TITLE
feat(tyr): add planner_session_id to raids and raid_progress

### DIFF
--- a/charts/tyr/templates/migrations-configmap.yaml
+++ b/charts/tyr/templates/migrations-configmap.yaml
@@ -381,4 +381,15 @@ data:
     ALTER TABLE raids DROP COLUMN IF EXISTS reviewer_session_id;
     ALTER TABLE raid_progress DROP COLUMN IF EXISTS review_round;
     ALTER TABLE raid_progress DROP COLUMN IF EXISTS reviewer_session_id;
+
+  000019_raid_planner_session.up.sql: |
+    ALTER TABLE raids ADD COLUMN IF NOT EXISTS planner_session_id TEXT;
+    CREATE INDEX IF NOT EXISTS idx_raids_planner_session
+        ON raids (planner_session_id) WHERE planner_session_id IS NOT NULL;
+    ALTER TABLE raid_progress ADD COLUMN IF NOT EXISTS planner_session_id TEXT;
+
+  000019_raid_planner_session.down.sql: |
+    DROP INDEX IF EXISTS idx_raids_planner_session;
+    ALTER TABLE raids DROP COLUMN IF EXISTS planner_session_id;
+    ALTER TABLE raid_progress DROP COLUMN IF EXISTS planner_session_id;
 {{- end }}

--- a/migrations/tyr/000019_raid_planner_session.down.sql
+++ b/migrations/tyr/000019_raid_planner_session.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_raids_planner_session;
+ALTER TABLE raids DROP COLUMN IF EXISTS planner_session_id;
+ALTER TABLE raid_progress DROP COLUMN IF EXISTS planner_session_id;

--- a/migrations/tyr/000019_raid_planner_session.up.sql
+++ b/migrations/tyr/000019_raid_planner_session.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE raids ADD COLUMN IF NOT EXISTS planner_session_id TEXT;
+CREATE INDEX IF NOT EXISTS idx_raids_planner_session
+    ON raids (planner_session_id) WHERE planner_session_id IS NOT NULL;
+
+ALTER TABLE raid_progress ADD COLUMN IF NOT EXISTS planner_session_id TEXT;

--- a/src/tyr/adapters/linear.py
+++ b/src/tyr/adapters/linear.py
@@ -398,9 +398,7 @@ class LinearTrackerAdapter(TrackerPort):
     async def create_saga(self, saga: Saga, *, description: str = "") -> str:
         team_id = await self._get_team_id()
         project_desc = description or (
-            f"Saga: {saga.slug}\n"
-            f"Repos: {', '.join(saga.repos)}\n"
-            f"Branch: {saga.feature_branch}"
+            f"Saga: {saga.slug}\nRepos: {', '.join(saga.repos)}\nBranch: {saga.feature_branch}"
         )
         data = await self._gql.query(
             _CREATE_PROJECT_QUERY,
@@ -432,9 +430,7 @@ class LinearTrackerAdapter(TrackerPort):
             {"issueId": issue_id, "body": body},
         )
 
-    async def attach_issue_document(
-        self, issue_id: str, title: str, content: str
-    ) -> str:
+    async def attach_issue_document(self, issue_id: str, title: str, content: str) -> str:
         """Attach a document to an issue (shows as a resource)."""
         data = await self._gql.query(
             _CREATE_ISSUE_DOCUMENT_QUERY,
@@ -461,9 +457,7 @@ class LinearTrackerAdapter(TrackerPort):
         self._gql.invalidate_cache("milestones")
         return milestone["id"]
 
-    async def create_raid(
-        self, raid: Raid, *, project_id: str = "", milestone_id: str = ""
-    ) -> str:
+    async def create_raid(self, raid: Raid, *, project_id: str = "", milestone_id: str = "") -> str:
         description = raid.description
         if raid.acceptance_criteria:
             criteria = "\n".join(f"- [ ] {c}" for c in raid.acceptance_criteria)
@@ -676,6 +670,7 @@ class LinearTrackerAdapter(TrackerPort):
         chronicle_summary: str | None = None,
         reviewer_session_id: str | None = None,
         review_round: int | None = None,
+        planner_session_id: str | None = None,
     ) -> Raid:
         if self._pool is None:
             raise RuntimeError("pool is required for update_raid_progress")
@@ -684,10 +679,11 @@ class LinearTrackerAdapter(TrackerPort):
             INSERT INTO raid_progress
                 (tracker_id, status, session_id, confidence, pr_url, pr_id,
                  retry_count, reason, owner_id, phase_tracker_id, saga_tracker_id,
-                 chronicle_summary, reviewer_session_id, review_round)
+                 chronicle_summary, reviewer_session_id, review_round,
+                 planner_session_id)
             VALUES ($1, COALESCE($2, 'PENDING'), $3, $4, $5, $6,
                     COALESCE($7, 0), $8, $9, $10, $11, $12, $13,
-                    COALESCE($14, 0))
+                    COALESCE($14, 0), $15)
             ON CONFLICT (tracker_id) DO UPDATE SET
                 status              = COALESCE($2, raid_progress.status),
                 session_id          = COALESCE($3, raid_progress.session_id),
@@ -702,6 +698,7 @@ class LinearTrackerAdapter(TrackerPort):
                 chronicle_summary   = COALESCE($12, raid_progress.chronicle_summary),
                 reviewer_session_id = COALESCE($13, raid_progress.reviewer_session_id),
                 review_round        = COALESCE($14, raid_progress.review_round),
+                planner_session_id  = COALESCE($15, raid_progress.planner_session_id),
                 updated_at          = NOW()
             """,
             tracker_id,
@@ -718,6 +715,7 @@ class LinearTrackerAdapter(TrackerPort):
             chronicle_summary,
             reviewer_session_id,
             review_round,
+            planner_session_id,
         )
         if status is not None:
             try:
@@ -1110,6 +1108,7 @@ class LinearTrackerAdapter(TrackerPort):
             review_round=int(progress["review_round"])
             if progress and progress.get("review_round")
             else 0,
+            planner_session_id=progress.get("planner_session_id") if progress else None,
         )
 
 

--- a/src/tyr/adapters/native.py
+++ b/src/tyr/adapters/native.py
@@ -98,9 +98,7 @@ class NativeTrackerAdapter(TrackerPort):
         )
         return tracker_id
 
-    async def create_raid(
-        self, raid: Raid, *, project_id: str = "", milestone_id: str = ""
-    ) -> str:
+    async def create_raid(self, raid: Raid, *, project_id: str = "", milestone_id: str = "") -> str:
         tracker_id = str(raid.id)
         await self._pool.execute(
             """
@@ -253,6 +251,7 @@ class NativeTrackerAdapter(TrackerPort):
         chronicle_summary: str | None = None,
         reviewer_session_id: str | None = None,
         review_round: int | None = None,
+        planner_session_id: str | None = None,
     ) -> Raid:
         row = await self._pool.fetchrow(
             """
@@ -267,6 +266,7 @@ class NativeTrackerAdapter(TrackerPort):
                 chronicle_summary   = COALESCE($9, chronicle_summary),
                 reviewer_session_id = COALESCE($10, reviewer_session_id),
                 review_round        = COALESCE($11, review_round),
+                planner_session_id  = COALESCE($12, planner_session_id),
                 updated_at          = NOW()
             WHERE tracker_id = $1
             RETURNING *
@@ -282,6 +282,7 @@ class NativeTrackerAdapter(TrackerPort):
             chronicle_summary,
             reviewer_session_id,
             review_round,
+            planner_session_id,
         )
         if row is None:
             raise LookupError(f"Raid not found: {tracker_id}")
@@ -543,6 +544,7 @@ class NativeTrackerAdapter(TrackerPort):
             updated_at=row["updated_at"] or datetime.now(UTC),
             reviewer_session_id=row.get("reviewer_session_id"),
             review_round=row.get("review_round", 0) or 0,
+            planner_session_id=row.get("planner_session_id"),
         )
 
     async def _saga_row_to_project(self, row: asyncpg.Record) -> TrackerProject:

--- a/src/tyr/domain/models.py
+++ b/src/tyr/domain/models.py
@@ -143,6 +143,7 @@ class Raid:
     url: str = ""
     reviewer_session_id: str | None = None
     review_round: int = 0
+    planner_session_id: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/tyr/ports/tracker.py
+++ b/src/tyr/ports/tracker.py
@@ -42,18 +42,14 @@ class TrackerPort(ABC):
         self, raid: Raid, *, project_id: str = "", milestone_id: str = ""
     ) -> str: ...
 
-    async def attach_document(
-        self, project_id: str, title: str, content: str
-    ) -> str:
+    async def attach_document(self, project_id: str, title: str, content: str) -> str:
         """Attach a document to a project. Returns document ID. Optional — noop by default."""
         return ""
 
     async def add_comment(self, issue_id: str, body: str) -> None:
         """Add a comment to an issue. Optional — noop by default."""
 
-    async def attach_issue_document(
-        self, issue_id: str, title: str, content: str
-    ) -> str:
+    async def attach_issue_document(self, issue_id: str, title: str, content: str) -> str:
         """Attach a document to an issue. Returns document ID. Optional — noop by default."""
         return ""
 
@@ -117,6 +113,7 @@ class TrackerPort(ABC):
         chronicle_summary: str | None = None,
         reviewer_session_id: str | None = None,
         review_round: int | None = None,
+        planner_session_id: str | None = None,
     ) -> Raid: ...
 
     @abstractmethod


### PR DESCRIPTION
## Summary

- Adds `planner_session_id TEXT` column to `raids` and `raid_progress` tables via migration 000019, mirroring the `reviewer_session_id` pattern from migration 000018
- Extends `Raid` dataclass, `TrackerPort.update_raid_progress()`, and both native/linear adapters with the new optional field
- Updates Helm chart migrations configmap to include the new migration

## Changes

| File | Change |
|------|--------|
| `migrations/tyr/000019_raid_planner_session.{up,down}.sql` | New migration adding `planner_session_id` column + partial index |
| `src/tyr/domain/models.py` | `planner_session_id: str \| None = None` on `Raid` dataclass |
| `src/tyr/ports/tracker.py` | New kwarg on `update_raid_progress()` |
| `src/tyr/adapters/native.py` | COALESCE update + `_row_to_raid()` conversion |
| `src/tyr/adapters/linear.py` | INSERT ON CONFLICT + `_build_raid_from_node()` conversion |
| `charts/tyr/templates/migrations-configmap.yaml` | Migration 000019 added |

## Test plan

- [x] All 934 existing tests pass unchanged (new field is optional with default `None`)
- [x] Ruff lint + format clean
- [ ] CI pipeline green

> **Note:** Linear MCP tools were unavailable — ticket NIU-331 status update pending manual action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)