### PR TITLE
feat(cli): enhance volundr status with session details

### DIFF
--- a/cli/internal/cli/status.go
+++ b/cli/internal/cli/status.go
@@ -121,7 +121,7 @@ func runStatus(_ *cobra.Command, _ []string) error {
 		return printJSON(detailed)
 	}
 
-	printDetailedStatus(detailed)
+	printDetailedStatus(&detailed)
 	return nil
 }
 
@@ -143,7 +143,7 @@ func runStatusFallback() error {
 		return printJSON(detailed)
 	}
 
-	printDetailedStatus(detailed)
+	printDetailedStatus(&detailed)
 	return nil
 }
 
@@ -272,17 +272,19 @@ func fetchMiniSessions(ds *DetailedStatus, cfg *config.Config) {
 		return
 	}
 
-	var sessions []struct {
-		ID        string `json:"id"`
-		Name      string `json:"name"`
-		Status    string `json:"status"`
-		Model     string `json:"model"`
-		Source    *struct {
+	type sessionEntry struct {
+		ID     string `json:"id"`
+		Name   string `json:"name"`
+		Status string `json:"status"`
+		Model  string `json:"model"`
+		Source *struct {
 			Repo string `json:"repo"`
 		} `json:"source"`
 		Repo      string `json:"repo"`
 		CreatedAt string `json:"created_at"`
 	}
+
+	var sessions []sessionEntry
 	if json.NewDecoder(sessResp.Body).Decode(&sessions) != nil {
 		return
 	}
@@ -314,7 +316,7 @@ func fetchMiniSessions(ds *DetailedStatus, cfg *config.Config) {
 }
 
 // printDetailedStatus renders the rich status to stdout.
-func printDetailedStatus(ds DetailedStatus) {
+func printDetailedStatus(ds *DetailedStatus) {
 	modeName := ds.Mode
 	if modeName == "" {
 		modeName = "local"
@@ -469,4 +471,3 @@ func formatAge(d time.Duration) string {
 	}
 	return strconv.Itoa(int(d.Hours()/24)) + "d"
 }
-

--- a/cli/internal/cli/status.go
+++ b/cli/internal/cli/status.go
@@ -17,6 +17,11 @@ import (
 	"github.com/niuulabs/volundr/cli/internal/runtime"
 )
 
+// statusHTTPTimeout is the timeout for HTTP requests to the local Forge API
+// during status checks. Kept short so the CLI feels responsive when the
+// server is unreachable.
+const statusHTTPTimeout = 2 * time.Second
+
 var statusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Show status of Volundr services",
@@ -213,12 +218,15 @@ func buildDetailedStatus(mode string, cfg *config.Config, stack *runtime.StackSt
 			}
 		}
 
-		// Collect pod entries (anything that's not a host service).
-		hostServices := map[string]bool{
+		// Collect pod entries (anything that's not a host service or already shown as Tyr).
+		excludeServices := map[string]bool{
 			"proxy": true, "api": true, "postgres": true, "k3s-cluster": true,
 		}
+		if tyrSvc != nil {
+			excludeServices[tyrSvc.Name] = true
+		}
 		for _, svc := range stack.Services {
-			if hostServices[svc.Name] {
+			if excludeServices[svc.Name] {
 				continue
 			}
 			ds.Pods = append(ds.Pods, PodInfo{
@@ -241,7 +249,7 @@ func buildDetailedStatus(mode string, cfg *config.Config, stack *runtime.StackSt
 // fetchMiniSessions queries the running forge server for session data.
 func fetchMiniSessions(ds *DetailedStatus, cfg *config.Config) {
 	addr := fmt.Sprintf("http://%s:%d", cfg.Listen.Host, cfg.Listen.Port)
-	client := &http.Client{Timeout: 2 * time.Second}
+	client := &http.Client{Timeout: statusHTTPTimeout}
 
 	// Fetch stats.
 	statsResp, err := client.Get(addr + "/api/v1/volundr/stats") //nolint:noctx // short-lived status check
@@ -415,15 +423,7 @@ func inferServerState(services []runtime.ServiceStatus) string {
 			return string(svc.State)
 		}
 		if svc.Name == "proxy" || svc.Name == "api" {
-			if svc.State == runtime.StateRunning {
-				return "running"
-			}
-		}
-	}
-	// If we have services but none matched specifically, check if any are running.
-	for _, svc := range services {
-		if svc.State == runtime.StateRunning {
-			return "running"
+			return string(svc.State)
 		}
 	}
 	return "stopped"

--- a/cli/internal/cli/status.go
+++ b/cli/internal/cli/status.go
@@ -1,47 +1,472 @@
 package cli
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
 
 	"github.com/spf13/cobra"
 
+	"github.com/niuulabs/volundr/cli/internal/config"
 	"github.com/niuulabs/volundr/cli/internal/runtime"
 )
 
 var statusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Show status of Volundr services",
-	Long:  `Displays the current state of all Volundr services.`,
+	Long:  `Displays the current state of all Volundr services including session details.`,
 	RunE:  runStatus,
 }
 
+// DetailedStatus holds the rich status output for both modes.
+type DetailedStatus struct {
+	Mode     string          `json:"mode"`
+	Server   ServerInfo      `json:"server"`
+	WebUI    string          `json:"web_ui,omitempty"`
+	Tyr      *ServiceInfo    `json:"tyr,omitempty"`
+	Database *DatabaseInfo   `json:"database,omitempty"`
+	Cluster  *ClusterInfo    `json:"cluster,omitempty"`
+	Sessions *SessionSummary `json:"sessions,omitempty"`
+	Pods     []PodInfo       `json:"pods,omitempty"`
+}
+
+// ServerInfo holds server/API process information.
+type ServerInfo struct {
+	Status  string `json:"status"`
+	Address string `json:"address,omitempty"`
+	PID     int    `json:"pid,omitempty"`
+}
+
+// ServiceInfo holds information about an auxiliary service.
+type ServiceInfo struct {
+	Status  string `json:"status"`
+	Address string `json:"address,omitempty"`
+	PID     int    `json:"pid,omitempty"`
+	Detail  string `json:"detail,omitempty"`
+}
+
+// DatabaseInfo holds database status.
+type DatabaseInfo struct {
+	Status string `json:"status"`
+	Mode   string `json:"mode"`
+	Port   int    `json:"port,omitempty"`
+}
+
+// ClusterInfo holds k3s cluster details.
+type ClusterInfo struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+}
+
+// SessionSummary holds aggregate session information.
+type SessionSummary struct {
+	Active int           `json:"active"`
+	Max    int           `json:"max"`
+	Total  int           `json:"total"`
+	List   []SessionInfo `json:"list,omitempty"`
+}
+
+// SessionInfo holds individual session details for display.
+type SessionInfo struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	Model     string `json:"model"`
+	Repo      string `json:"repo"`
+	CreatedAt string `json:"created_at"`
+	Age       string `json:"age,omitempty"`
+}
+
+// PodInfo holds k3s pod details for display.
+type PodInfo struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+}
+
 func runStatus(_ *cobra.Command, _ []string) error {
-	// TODO: load config and use runtime.NewRuntime(cfg.Runtime).Status() for runtime-specific status
+	cfg, cfgErr := config.Load()
+
+	// If config cannot be loaded, fall back to basic state file status.
+	if cfgErr != nil {
+		return runStatusFallback()
+	}
+
+	mode := cfg.Volundr.Mode
+	if mode == "" {
+		mode = "mini"
+	}
+
+	rt := runtime.NewRuntime(mode)
+	ctx := context.Background()
+
+	stackStatus, err := rt.Status(ctx)
+	if err != nil {
+		return fmt.Errorf("get status: %w", err)
+	}
+
+	detailed := buildDetailedStatus(mode, cfg, stackStatus)
+
+	// For mini mode with a running server, fetch session data.
+	if mode == "mini" && detailed.Server.Status == "running" {
+		fetchMiniSessions(&detailed, cfg)
+	}
+
+	if jsonOutput {
+		return printJSON(detailed)
+	}
+
+	printDetailedStatus(detailed)
+	return nil
+}
+
+// runStatusFallback handles the case where no config file exists.
+func runStatusFallback() error {
 	status, err := runtime.StatusFromStateFile()
 	if err != nil {
 		return fmt.Errorf("get status: %w", err)
 	}
 
+	detailed := DetailedStatus{
+		Mode: status.Runtime,
+		Server: ServerInfo{
+			Status: inferServerState(status.Services),
+		},
+	}
+
 	if jsonOutput {
-		return printJSON(status)
+		return printJSON(detailed)
 	}
 
-	fmt.Printf("Runtime: %s\n\n", status.Runtime)
-	fmt.Printf("%-15s %-10s %-8s %-6s %s\n", "SERVICE", "STATE", "PID", "PORT", "ERROR")
-	fmt.Printf("%-15s %-10s %-8s %-6s %s\n", "-------", "-----", "---", "----", "-----")
-
-	for _, svc := range status.Services {
-		pid := ""
-		if svc.PID > 0 {
-			pid = fmt.Sprintf("%d", svc.PID)
-		}
-		port := ""
-		if svc.Port > 0 {
-			port = fmt.Sprintf("%d", svc.Port)
-		}
-		fmt.Printf("%-15s %-10s %-8s %-6s %s\n",
-			svc.Name, svc.State, pid, port, svc.Error)
-	}
-
+	printDetailedStatus(detailed)
 	return nil
 }
+
+// buildDetailedStatus constructs the rich status from stack status and config.
+func buildDetailedStatus(mode string, cfg *config.Config, stack *runtime.StackStatus) DetailedStatus {
+	ds := DetailedStatus{
+		Mode: mode,
+	}
+
+	serverState := inferServerState(stack.Services)
+	ds.Server = ServerInfo{
+		Status: serverState,
+	}
+
+	if serverState == "running" {
+		ds.Server.Address = fmt.Sprintf("%s:%d", cfg.Listen.Host, cfg.Listen.Port)
+		ds.Server.PID = findServicePID("proxy", stack.Services)
+		if ds.Server.PID == 0 {
+			ds.Server.PID = findServicePID("api", stack.Services)
+		}
+
+		if mode == "mini" {
+			ds.WebUI = fmt.Sprintf("http://%s:%d", cfg.Listen.Host, cfg.Listen.Port)
+		}
+	}
+
+	// Database info.
+	dbSvc := findService("postgres", stack.Services)
+	if dbSvc != nil {
+		ds.Database = &DatabaseInfo{
+			Status: string(dbSvc.State),
+			Mode:   cfg.Database.Mode,
+			Port:   dbSvc.Port,
+		}
+	} else if cfg.Database.Mode == "embedded" {
+		ds.Database = &DatabaseInfo{
+			Status: serverState,
+			Mode:   cfg.Database.Mode,
+			Port:   cfg.Database.Port,
+		}
+	}
+
+	// Tyr status - check for tyr-related services/pods.
+	tyrSvc := findServicePrefix("tyr", stack.Services)
+	if tyrSvc != nil {
+		ds.Tyr = &ServiceInfo{
+			Status: string(tyrSvc.State),
+		}
+		if tyrSvc.Port > 0 {
+			ds.Tyr.Address = fmt.Sprintf("%s:%d", cfg.Listen.Host, tyrSvc.Port)
+		}
+		if tyrSvc.PID > 0 {
+			ds.Tyr.PID = tyrSvc.PID
+		}
+		if tyrSvc.Name != "tyr" {
+			ds.Tyr.Detail = tyrSvc.Name
+		}
+	}
+
+	// K3s-specific: cluster info and pods.
+	if mode == "k3s" {
+		clusterSvc := findService("k3s-cluster", stack.Services)
+		if clusterSvc != nil {
+			ds.Cluster = &ClusterInfo{
+				Name:   "k3d-volundr",
+				Status: string(clusterSvc.State),
+			}
+		}
+
+		// Collect pod entries (anything that's not a host service).
+		hostServices := map[string]bool{
+			"proxy": true, "api": true, "postgres": true, "k3s-cluster": true,
+		}
+		for _, svc := range stack.Services {
+			if hostServices[svc.Name] {
+				continue
+			}
+			ds.Pods = append(ds.Pods, PodInfo{
+				Name:   svc.Name,
+				Status: string(svc.State),
+			})
+		}
+	}
+
+	// Session capacity for mini mode.
+	if mode == "mini" && cfg.Volundr.Forge.MaxConcurrent > 0 {
+		ds.Sessions = &SessionSummary{
+			Max: cfg.Volundr.Forge.MaxConcurrent,
+		}
+	}
+
+	return ds
+}
+
+// fetchMiniSessions queries the running forge server for session data.
+func fetchMiniSessions(ds *DetailedStatus, cfg *config.Config) {
+	addr := fmt.Sprintf("http://%s:%d", cfg.Listen.Host, cfg.Listen.Port)
+	client := &http.Client{Timeout: 2 * time.Second}
+
+	// Fetch stats.
+	statsResp, err := client.Get(addr + "/api/v1/volundr/stats") //nolint:noctx // short-lived status check
+	if err == nil {
+		defer statsResp.Body.Close() //nolint:errcheck // best-effort status
+		if statsResp.StatusCode == http.StatusOK {
+			var stats struct {
+				ActiveSessions int `json:"active_sessions"`
+				TotalSessions  int `json:"total_sessions"`
+			}
+			if json.NewDecoder(statsResp.Body).Decode(&stats) == nil {
+				if ds.Sessions == nil {
+					ds.Sessions = &SessionSummary{Max: cfg.Volundr.Forge.MaxConcurrent}
+				}
+				ds.Sessions.Active = stats.ActiveSessions
+				ds.Sessions.Total = stats.TotalSessions
+			}
+		}
+	}
+
+	// Fetch session list.
+	sessResp, err := client.Get(addr + "/api/v1/volundr/sessions") //nolint:noctx // short-lived status check
+	if err != nil {
+		return
+	}
+	defer sessResp.Body.Close() //nolint:errcheck // best-effort status
+	if sessResp.StatusCode != http.StatusOK {
+		return
+	}
+
+	var sessions []struct {
+		ID        string `json:"id"`
+		Name      string `json:"name"`
+		Status    string `json:"status"`
+		Model     string `json:"model"`
+		Source    *struct {
+			Repo string `json:"repo"`
+		} `json:"source"`
+		Repo      string `json:"repo"`
+		CreatedAt string `json:"created_at"`
+	}
+	if json.NewDecoder(sessResp.Body).Decode(&sessions) != nil {
+		return
+	}
+
+	if ds.Sessions == nil {
+		ds.Sessions = &SessionSummary{Max: cfg.Volundr.Forge.MaxConcurrent}
+	}
+
+	now := time.Now()
+	for _, s := range sessions {
+		repo := s.Repo
+		if repo == "" && s.Source != nil {
+			repo = s.Source.Repo
+		}
+		age := ""
+		if t, err := time.Parse(time.RFC3339, s.CreatedAt); err == nil {
+			age = formatAge(now.Sub(t))
+		}
+		ds.Sessions.List = append(ds.Sessions.List, SessionInfo{
+			ID:        s.ID,
+			Name:      s.Name,
+			Status:    s.Status,
+			Model:     s.Model,
+			Repo:      repo,
+			CreatedAt: s.CreatedAt,
+			Age:       age,
+		})
+	}
+}
+
+// printDetailedStatus renders the rich status to stdout.
+func printDetailedStatus(ds DetailedStatus) {
+	modeName := ds.Mode
+	if modeName == "" {
+		modeName = "local"
+	}
+	fmt.Printf("Volundr (%s mode)\n", modeName)
+
+	// Server line.
+	if ds.Server.Status == "running" {
+		pidStr := ""
+		if ds.Server.PID > 0 {
+			pidStr = fmt.Sprintf(" (PID %d)", ds.Server.PID)
+		}
+		fmt.Printf("  Server:     running on %s%s\n", ds.Server.Address, pidStr)
+	} else {
+		fmt.Printf("  Server:     %s\n", ds.Server.Status)
+	}
+
+	// Web UI.
+	if ds.WebUI != "" {
+		fmt.Printf("  Web UI:     %s\n", ds.WebUI)
+	}
+
+	// Tyr.
+	if ds.Tyr != nil {
+		if ds.Tyr.Status == "running" {
+			detail := ""
+			if ds.Tyr.Address != "" {
+				detail = fmt.Sprintf(" on %s", ds.Tyr.Address)
+			}
+			if ds.Tyr.PID > 0 {
+				detail += fmt.Sprintf(" (PID %d)", ds.Tyr.PID)
+			}
+			if ds.Tyr.Detail != "" {
+				detail += fmt.Sprintf(" (%s)", ds.Tyr.Detail)
+			}
+			fmt.Printf("  Tyr:        running%s\n", detail)
+		} else {
+			fmt.Printf("  Tyr:        %s\n", ds.Tyr.Status)
+		}
+	}
+
+	// Database.
+	if ds.Database != nil {
+		if ds.Database.Status == "running" {
+			fmt.Printf("  Database:   %s PostgreSQL on port %d\n", ds.Database.Mode, ds.Database.Port)
+		} else {
+			fmt.Printf("  Database:   %s (%s)\n", ds.Database.Mode, ds.Database.Status)
+		}
+	}
+
+	// Cluster (k3s).
+	if ds.Cluster != nil {
+		fmt.Printf("  Cluster:    %s (%s)\n", ds.Cluster.Name, ds.Cluster.Status)
+	}
+
+	// Sessions.
+	if ds.Sessions != nil {
+		fmt.Printf("  Sessions:   %d/%d active\n", ds.Sessions.Active, ds.Sessions.Max)
+
+		if len(ds.Sessions.List) > 0 {
+			fmt.Println()
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			_, _ = fmt.Fprintln(w, "  ID\tNAME\tSTATUS\tMODEL\tREPO\tAGE")
+			for _, s := range ds.Sessions.List {
+				id := s.ID
+				if len(id) > 8 {
+					id = id[:8]
+				}
+				_, _ = fmt.Fprintf(w, "  %s\t%s\t%s\t%s\t%s\t%s\n",
+					id, s.Name, s.Status, s.Model, s.Repo, s.Age)
+			}
+			_ = w.Flush()
+		}
+	}
+
+	// Pods (k3s).
+	if len(ds.Pods) > 0 {
+		fmt.Println()
+		fmt.Println("  PODS:")
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		_, _ = fmt.Fprintln(w, "  NAME\tSTATUS")
+		for _, p := range ds.Pods {
+			_, _ = fmt.Fprintf(w, "  %s\t%s\n", p.Name, p.Status)
+		}
+		_ = w.Flush()
+	}
+}
+
+// inferServerState determines overall server state from service list.
+func inferServerState(services []runtime.ServiceStatus) string {
+	if len(services) == 0 {
+		return "stopped"
+	}
+	for _, svc := range services {
+		if svc.Name == "volundr" {
+			return string(svc.State)
+		}
+		if svc.Name == "proxy" || svc.Name == "api" {
+			if svc.State == runtime.StateRunning {
+				return "running"
+			}
+		}
+	}
+	// If we have services but none matched specifically, check if any are running.
+	for _, svc := range services {
+		if svc.State == runtime.StateRunning {
+			return "running"
+		}
+	}
+	return "stopped"
+}
+
+// findService returns the first service with the exact name.
+func findService(name string, services []runtime.ServiceStatus) *runtime.ServiceStatus {
+	for i := range services {
+		if services[i].Name == name {
+			return &services[i]
+		}
+	}
+	return nil
+}
+
+// findServicePrefix returns the first service whose name starts with prefix.
+func findServicePrefix(prefix string, services []runtime.ServiceStatus) *runtime.ServiceStatus {
+	for i := range services {
+		if strings.HasPrefix(services[i].Name, prefix) {
+			return &services[i]
+		}
+	}
+	return nil
+}
+
+// findServicePID returns the PID of the named service, or 0.
+func findServicePID(name string, services []runtime.ServiceStatus) int {
+	svc := findService(name, services)
+	if svc == nil {
+		return 0
+	}
+	return svc.PID
+}
+
+// formatAge formats a duration as a human-readable age string.
+func formatAge(d time.Duration) string {
+	if d < time.Minute {
+		return strconv.Itoa(int(d.Seconds())) + "s"
+	}
+	if d < time.Hour {
+		return strconv.Itoa(int(d.Minutes())) + "m"
+	}
+	if d < 24*time.Hour {
+		return strconv.Itoa(int(d.Hours())) + "h"
+	}
+	return strconv.Itoa(int(d.Hours()/24)) + "d"
+}
+

--- a/cli/internal/cli/status_test.go
+++ b/cli/internal/cli/status_test.go
@@ -2,10 +2,12 @@ package cli
 
 import (
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -210,7 +212,7 @@ func TestRunStatus_WithStateFile_Running(t *testing.T) {
 
 	// Write PID file with our own PID (guaranteed to be alive).
 	pidFile := filepath.Join(tmpDir, "volundr.pid")
-	if err := os.WriteFile(pidFile, []byte(itoa(os.Getpid())), 0o600); err != nil {
+	if err := os.WriteFile(pidFile, []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
 		t.Fatalf("write pid file: %v", err)
 	}
 
@@ -267,7 +269,7 @@ func TestRunStatus_WithStateFile_TextOutput(t *testing.T) {
 	writeTestConfigSimple(t, tmpDir, "mini")
 
 	pidFile := filepath.Join(tmpDir, "volundr.pid")
-	if err := os.WriteFile(pidFile, []byte(itoa(os.Getpid())), 0o600); err != nil {
+	if err := os.WriteFile(pidFile, []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
 		t.Fatalf("write pid file: %v", err)
 	}
 
@@ -313,18 +315,18 @@ func TestRunStatus_MiniWithSessions(t *testing.T) {
 	defer srv.Close()
 
 	// Parse the server address to get host and port for config.
-	srvAddr := srv.Listener.Addr().String()
+	host, portStr, _ := net.SplitHostPort(srv.Listener.Addr().String())
 
 	// Write config pointing to our mock server.
 	cfgData := `volundr:
   mode: mini
   web: true
   forge:
-    listen: "` + srvAddr + `"
+    listen: "` + host + `:` + portStr + `"
     max_concurrent: 4
 listen:
-  host: "` + srvAddr[:len(srvAddr)-findPortOffset(srvAddr)] + `"
-  port: ` + srvAddr[len(srvAddr)-findPortOffset(srvAddr)+1:] + `
+  host: "` + host + `"
+  port: ` + portStr + `
 database:
   mode: embedded
   port: 5433
@@ -337,7 +339,7 @@ database:
 	}
 
 	// Write PID + state to indicate running.
-	if err := os.WriteFile(filepath.Join(tmpDir, "volundr.pid"), []byte(itoa(os.Getpid())), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, "volundr.pid"), []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
 		t.Fatalf("write pid: %v", err)
 	}
 	stateData := `[{"name": "proxy", "state": "running", "port": 8080}]`
@@ -502,13 +504,15 @@ func TestBuildDetailedStatus_K3sWithPods(t *testing.T) {
 	if ds.Cluster.Status != "running" {
 		t.Errorf("expected cluster running, got %s", ds.Cluster.Status)
 	}
-	if len(ds.Pods) != 2 {
-		t.Errorf("expected 2 pods, got %d", len(ds.Pods))
-	}
-
-	// Tyr should be detected from tyr-prefixed pod.
+	// Tyr should be detected from tyr-prefixed pod and excluded from pods list.
 	if ds.Tyr == nil {
 		t.Fatal("expected tyr info from tyr-prefixed pod")
+	}
+	if len(ds.Pods) != 1 {
+		t.Errorf("expected 1 pod (tyr excluded), got %d", len(ds.Pods))
+	}
+	if len(ds.Pods) > 0 && ds.Pods[0].Name != "session-a1b2c3-skuld" {
+		t.Errorf("expected session pod, got %s", ds.Pods[0].Name)
 	}
 }
 
@@ -576,11 +580,27 @@ func TestInferServerState(t *testing.T) {
 			expected: "running",
 		},
 		{
+			name: "proxy stopped but postgres running",
+			services: []runtime.ServiceStatus{
+				{Name: "proxy", State: runtime.StateStopped, Port: 8080},
+				{Name: "postgres", State: runtime.StateRunning, Port: 5433},
+			},
+			expected: "stopped",
+		},
+		{
+			name: "proxy in error state",
+			services: []runtime.ServiceStatus{
+				{Name: "proxy", State: runtime.StateError, Port: 8080},
+				{Name: "postgres", State: runtime.StateRunning, Port: 5433},
+			},
+			expected: "error",
+		},
+		{
 			name: "only postgres running",
 			services: []runtime.ServiceStatus{
 				{Name: "postgres", State: runtime.StateRunning, Port: 5433},
 			},
-			expected: "running",
+			expected: "stopped",
 		},
 	}
 
@@ -793,11 +813,11 @@ func TestFetchMiniSessions_WithMockServer(t *testing.T) {
 	defer srv.Close()
 
 	// Parse host/port from server.
-	addr := srv.Listener.Addr().String()
-	parts := splitHostPort(addr)
+	host, portStr, _ := net.SplitHostPort(srv.Listener.Addr().String())
+	port, _ := strconv.Atoi(portStr)
 
 	cfg := &config.Config{
-		Listen: config.ListenConfig{Host: parts[0], Port: mustAtoi(parts[1])},
+		Listen: config.ListenConfig{Host: host, Port: port},
 		Volundr: config.VolundrConfig{
 			Forge: config.ForgeSettings{MaxConcurrent: 4},
 		},
@@ -845,11 +865,11 @@ func TestFetchMiniSessions_StatsError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	addr := srv.Listener.Addr().String()
-	parts := splitHostPort(addr)
+	host, portStr, _ := net.SplitHostPort(srv.Listener.Addr().String())
+	port, _ := strconv.Atoi(portStr)
 
 	cfg := &config.Config{
-		Listen: config.ListenConfig{Host: parts[0], Port: mustAtoi(parts[1])},
+		Listen: config.ListenConfig{Host: host, Port: port},
 		Volundr: config.VolundrConfig{
 			Forge: config.ForgeSettings{MaxConcurrent: 4},
 		},
@@ -881,11 +901,11 @@ func TestFetchMiniSessions_SessionsError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	addr := srv.Listener.Addr().String()
-	parts := splitHostPort(addr)
+	host, portStr, _ := net.SplitHostPort(srv.Listener.Addr().String())
+	port, _ := strconv.Atoi(portStr)
 
 	cfg := &config.Config{
-		Listen: config.ListenConfig{Host: parts[0], Port: mustAtoi(parts[1])},
+		Listen: config.ListenConfig{Host: host, Port: port},
 		Volundr: config.VolundrConfig{
 			Forge: config.ForgeSettings{MaxConcurrent: 4},
 		},
@@ -904,37 +924,4 @@ func TestFetchMiniSessions_SessionsError(t *testing.T) {
 	if len(ds.Sessions.List) != 0 {
 		t.Errorf("expected 0 sessions in list, got %d", len(ds.Sessions.List))
 	}
-}
-
-// Helper functions for tests.
-
-func itoa(n int) string {
-	return json.Number(json.Number(func() string {
-		b, _ := json.Marshal(n)
-		return string(b)
-	}()).String()).String()
-}
-
-func splitHostPort(addr string) []string {
-	// Simple split for test addresses like "127.0.0.1:12345".
-	idx := len(addr) - 1
-	for idx >= 0 && addr[idx] != ':' {
-		idx--
-	}
-	return []string{addr[:idx], addr[idx+1:]}
-}
-
-func mustAtoi(s string) int {
-	n, _ := json.Number(s).Int64()
-	return int(n)
-}
-
-// findPortOffset returns the number of characters from the end to the colon.
-func findPortOffset(addr string) int {
-	for i := len(addr) - 1; i >= 0; i-- {
-		if addr[i] == ':' {
-			return len(addr) - i
-		}
-	}
-	return 0
 }

--- a/cli/internal/cli/status_test.go
+++ b/cli/internal/cli/status_test.go
@@ -1,21 +1,86 @@
 package cli
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/niuulabs/volundr/cli/internal/config"
+	"github.com/niuulabs/volundr/cli/internal/runtime"
 )
+
+// writeTestConfig writes a minimal config file to the given directory.
+func writeTestConfig(t *testing.T, dir, mode string, maxConcurrent int) {
+	t.Helper()
+	cfg := `volundr:
+  mode: ` + mode + `
+  web: true
+  forge:
+    listen: "127.0.0.1:8080"
+    max_concurrent: ` + json.Number(json.Number(
+		func() string {
+			if maxConcurrent == 0 {
+				return "4"
+			}
+			b, _ := json.Marshal(maxConcurrent)
+			return string(b)
+		}(),
+	)).String() + `
+listen:
+  host: "127.0.0.1"
+  port: 8080
+database:
+  mode: embedded
+  port: 5433
+  user: volundr
+  password: testpass
+  name: volundr
+`
+	err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(cfg), 0o600)
+	if err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+// writeTestConfigSimple writes a simple config yaml to the dir.
+func writeTestConfigSimple(t *testing.T, dir, mode string) {
+	t.Helper()
+	cfg := `volundr:
+  mode: ` + mode + `
+  web: true
+  forge:
+    listen: "127.0.0.1:8080"
+    max_concurrent: 4
+listen:
+  host: "127.0.0.1"
+  port: 8080
+database:
+  mode: embedded
+  port: 5433
+  user: volundr
+  password: testpass
+  name: volundr
+`
+	err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(cfg), 0o600)
+	if err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
 
 func TestRunStatus_NoPIDFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv(config.EnvHome, tmpDir)
 
+	writeTestConfigSimple(t, tmpDir, "mini")
+
 	oldJSON := jsonOutput
 	jsonOutput = false
 	defer func() { jsonOutput = oldJSON }()
 
-	// No PID file exists, so status should show "stopped".
 	if err := runStatus(nil, nil); err != nil {
 		t.Fatalf("runStatus: %v", err)
 	}
@@ -25,12 +90,14 @@ func TestRunStatus_JSON_NoPIDFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv(config.EnvHome, tmpDir)
 
+	writeTestConfigSimple(t, tmpDir, "mini")
+
 	oldJSON := jsonOutput
 	jsonOutput = true
 	defer func() { jsonOutput = oldJSON }()
 
 	old := os.Stdout
-	_, w, _ := os.Pipe()
+	r, w, _ := os.Pipe()
 	os.Stdout = w
 
 	err := runStatus(nil, nil)
@@ -41,14 +108,29 @@ func TestRunStatus_JSON_NoPIDFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runStatus JSON: %v", err)
 	}
+
+	// Read and validate JSON output.
+	var result DetailedStatus
+	if decErr := json.NewDecoder(r).Decode(&result); decErr != nil {
+		t.Fatalf("decode JSON: %v", decErr)
+	}
+
+	if result.Mode != "mini" {
+		t.Errorf("expected mode mini, got %s", result.Mode)
+	}
+	if result.Server.Status != "stopped" {
+		t.Errorf("expected server stopped, got %s", result.Server.Status)
+	}
 }
 
 func TestRunStatus_WithPIDFile_DeadProcess(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv(config.EnvHome, tmpDir)
 
+	writeTestConfigSimple(t, tmpDir, "mini")
+
 	// Write a PID file with a PID that doesn't exist (99999999).
-	pidFile := tmpDir + "/volundr.pid"
+	pidFile := filepath.Join(tmpDir, "volundr.pid")
 	if err := os.WriteFile(pidFile, []byte("99999999"), 0o600); err != nil {
 		t.Fatalf("write pid file: %v", err)
 	}
@@ -60,4 +142,832 @@ func TestRunStatus_WithPIDFile_DeadProcess(t *testing.T) {
 	if err := runStatus(nil, nil); err != nil {
 		t.Fatalf("runStatus: %v", err)
 	}
+}
+
+func TestRunStatus_NoConfig_Fallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(config.EnvHome, tmpDir)
+
+	// No config file — should fall back to StatusFromStateFile.
+	oldJSON := jsonOutput
+	jsonOutput = false
+	defer func() { jsonOutput = oldJSON }()
+
+	if err := runStatus(nil, nil); err != nil {
+		t.Fatalf("runStatus: %v", err)
+	}
+}
+
+func TestRunStatus_NoConfig_JSON_Fallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(config.EnvHome, tmpDir)
+
+	oldJSON := jsonOutput
+	jsonOutput = true
+	defer func() { jsonOutput = oldJSON }()
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := runStatus(nil, nil)
+
+	_ = w.Close()
+	os.Stdout = old
+
+	if err != nil {
+		t.Fatalf("runStatus: %v", err)
+	}
+
+	var result DetailedStatus
+	if decErr := json.NewDecoder(r).Decode(&result); decErr != nil {
+		t.Fatalf("decode JSON: %v", decErr)
+	}
+	if result.Server.Status != "stopped" {
+		t.Errorf("expected server stopped, got %s", result.Server.Status)
+	}
+}
+
+func TestRunStatus_K3sMode_NoPIDFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(config.EnvHome, tmpDir)
+
+	writeTestConfigSimple(t, tmpDir, "k3s")
+
+	oldJSON := jsonOutput
+	jsonOutput = false
+	defer func() { jsonOutput = oldJSON }()
+
+	if err := runStatus(nil, nil); err != nil {
+		t.Fatalf("runStatus: %v", err)
+	}
+}
+
+func TestRunStatus_K3sMode_JSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(config.EnvHome, tmpDir)
+
+	writeTestConfigSimple(t, tmpDir, "k3s")
+
+	oldJSON := jsonOutput
+	jsonOutput = true
+	defer func() { jsonOutput = oldJSON }()
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := runStatus(nil, nil)
+
+	_ = w.Close()
+	os.Stdout = old
+
+	if err != nil {
+		t.Fatalf("runStatus: %v", err)
+	}
+
+	var result DetailedStatus
+	if decErr := json.NewDecoder(r).Decode(&result); decErr != nil {
+		t.Fatalf("decode JSON: %v", decErr)
+	}
+	if result.Mode != "k3s" {
+		t.Errorf("expected mode k3s, got %s", result.Mode)
+	}
+}
+
+func TestRunStatus_WithStateFile_Running(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(config.EnvHome, tmpDir)
+
+	writeTestConfigSimple(t, tmpDir, "mini")
+
+	// Write PID file with our own PID (guaranteed to be alive).
+	pidFile := filepath.Join(tmpDir, "volundr.pid")
+	if err := os.WriteFile(pidFile, []byte(itoa(os.Getpid())), 0o600); err != nil {
+		t.Fatalf("write pid file: %v", err)
+	}
+
+	// Write state file.
+	stateData := `[
+		{"name": "proxy", "state": "running", "port": 8080},
+		{"name": "api", "state": "running", "pid": 12345, "port": 8081},
+		{"name": "postgres", "state": "running", "port": 5433}
+	]`
+	if err := os.WriteFile(filepath.Join(tmpDir, "state.json"), []byte(stateData), 0o600); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+
+	oldJSON := jsonOutput
+	jsonOutput = true
+	defer func() { jsonOutput = oldJSON }()
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := runStatus(nil, nil)
+
+	_ = w.Close()
+	os.Stdout = old
+
+	if err != nil {
+		t.Fatalf("runStatus: %v", err)
+	}
+
+	var result DetailedStatus
+	if decErr := json.NewDecoder(r).Decode(&result); decErr != nil {
+		t.Fatalf("decode JSON: %v", decErr)
+	}
+
+	if result.Server.Status != "running" {
+		t.Errorf("expected server running, got %s", result.Server.Status)
+	}
+	if result.Server.Address != "127.0.0.1:8080" {
+		t.Errorf("expected address 127.0.0.1:8080, got %s", result.Server.Address)
+	}
+	if result.Database == nil {
+		t.Fatal("expected database info")
+	}
+	if result.Database.Port != 5433 {
+		t.Errorf("expected db port 5433, got %d", result.Database.Port)
+	}
+}
+
+func TestRunStatus_WithStateFile_TextOutput(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(config.EnvHome, tmpDir)
+
+	writeTestConfigSimple(t, tmpDir, "mini")
+
+	pidFile := filepath.Join(tmpDir, "volundr.pid")
+	if err := os.WriteFile(pidFile, []byte(itoa(os.Getpid())), 0o600); err != nil {
+		t.Fatalf("write pid file: %v", err)
+	}
+
+	stateData := `[
+		{"name": "proxy", "state": "running", "port": 8080},
+		{"name": "api", "state": "running", "pid": 12345, "port": 8081},
+		{"name": "postgres", "state": "running", "port": 5433}
+	]`
+	if err := os.WriteFile(filepath.Join(tmpDir, "state.json"), []byte(stateData), 0o600); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+
+	oldJSON := jsonOutput
+	jsonOutput = false
+	defer func() { jsonOutput = oldJSON }()
+
+	// Should not error — just prints.
+	if err := runStatus(nil, nil); err != nil {
+		t.Fatalf("runStatus: %v", err)
+	}
+}
+
+func TestRunStatus_MiniWithSessions(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(config.EnvHome, tmpDir)
+
+	// Create a mock server that serves sessions and stats.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/volundr/stats":
+			_, _ = w.Write([]byte(`{"active_sessions": 2, "total_sessions": 3}`))
+		case "/api/v1/volundr/sessions":
+			_, _ = w.Write([]byte(`[
+				{"id": "a1b2c3d4e5f6", "name": "fix-auth", "status": "running", "model": "claude-sonnet-4", "repo": "github.com/org/api", "created_at": "` + time.Now().Add(-12*time.Minute).Format(time.RFC3339) + `"},
+				{"id": "g7h8i9j0k1l2", "name": "add-tests", "status": "running", "model": "claude-sonnet-4", "repo": "github.com/org/web", "created_at": "` + time.Now().Add(-3*time.Minute).Format(time.RFC3339) + `"},
+				{"id": "m3n4o5p6q7r8", "name": "refactor-db", "status": "stopped", "model": "claude-sonnet-4", "repo": "github.com/org/core", "created_at": "` + time.Now().Add(-1*time.Hour).Format(time.RFC3339) + `"}
+			]`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	// Parse the server address to get host and port for config.
+	srvAddr := srv.Listener.Addr().String()
+
+	// Write config pointing to our mock server.
+	cfgData := `volundr:
+  mode: mini
+  web: true
+  forge:
+    listen: "` + srvAddr + `"
+    max_concurrent: 4
+listen:
+  host: "` + srvAddr[:len(srvAddr)-findPortOffset(srvAddr)] + `"
+  port: ` + srvAddr[len(srvAddr)-findPortOffset(srvAddr)+1:] + `
+database:
+  mode: embedded
+  port: 5433
+  user: volundr
+  password: testpass
+  name: volundr
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.yaml"), []byte(cfgData), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	// Write PID + state to indicate running.
+	if err := os.WriteFile(filepath.Join(tmpDir, "volundr.pid"), []byte(itoa(os.Getpid())), 0o600); err != nil {
+		t.Fatalf("write pid: %v", err)
+	}
+	stateData := `[{"name": "proxy", "state": "running", "port": 8080}]`
+	if err := os.WriteFile(filepath.Join(tmpDir, "state.json"), []byte(stateData), 0o600); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+
+	oldJSON := jsonOutput
+	jsonOutput = true
+	defer func() { jsonOutput = oldJSON }()
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := runStatus(nil, nil)
+
+	_ = w.Close()
+	os.Stdout = old
+
+	if err != nil {
+		t.Fatalf("runStatus: %v", err)
+	}
+
+	var result DetailedStatus
+	if decErr := json.NewDecoder(r).Decode(&result); decErr != nil {
+		t.Fatalf("decode JSON: %v", decErr)
+	}
+
+	if result.Sessions == nil {
+		t.Fatal("expected sessions info")
+	}
+	if result.Sessions.Active != 2 {
+		t.Errorf("expected 2 active sessions, got %d", result.Sessions.Active)
+	}
+	if result.Sessions.Total != 3 {
+		t.Errorf("expected 3 total sessions, got %d", result.Sessions.Total)
+	}
+	if len(result.Sessions.List) != 3 {
+		t.Errorf("expected 3 sessions in list, got %d", len(result.Sessions.List))
+	}
+}
+
+func TestBuildDetailedStatus_MiniRunning(t *testing.T) {
+	cfg := &config.Config{
+		Volundr: config.VolundrConfig{
+			Mode: "mini",
+			Web:  true,
+			Forge: config.ForgeSettings{
+				MaxConcurrent: 4,
+			},
+		},
+		Listen: config.ListenConfig{
+			Host: "127.0.0.1",
+			Port: 8080,
+		},
+		Database: config.DatabaseConfig{
+			Mode: "embedded",
+			Port: 5433,
+		},
+	}
+
+	stack := &runtime.StackStatus{
+		Runtime: "local",
+		Services: []runtime.ServiceStatus{
+			{Name: "proxy", State: runtime.StateRunning, Port: 8080},
+			{Name: "api", State: runtime.StateRunning, PID: 12345, Port: 8081},
+			{Name: "postgres", State: runtime.StateRunning, Port: 5433},
+		},
+	}
+
+	ds := buildDetailedStatus("mini", cfg, stack)
+
+	if ds.Mode != "mini" {
+		t.Errorf("expected mode mini, got %s", ds.Mode)
+	}
+	if ds.Server.Status != "running" {
+		t.Errorf("expected server running, got %s", ds.Server.Status)
+	}
+	if ds.Server.Address != "127.0.0.1:8080" {
+		t.Errorf("expected address 127.0.0.1:8080, got %s", ds.Server.Address)
+	}
+	if ds.WebUI != "http://127.0.0.1:8080" {
+		t.Errorf("expected web UI url, got %s", ds.WebUI)
+	}
+	if ds.Database == nil || ds.Database.Port != 5433 {
+		t.Errorf("expected database on port 5433")
+	}
+	if ds.Sessions == nil || ds.Sessions.Max != 4 {
+		t.Errorf("expected sessions max 4")
+	}
+}
+
+func TestBuildDetailedStatus_MiniStopped(t *testing.T) {
+	cfg := &config.Config{
+		Volundr: config.VolundrConfig{
+			Mode: "mini",
+			Forge: config.ForgeSettings{
+				MaxConcurrent: 4,
+			},
+		},
+		Listen: config.ListenConfig{
+			Host: "127.0.0.1",
+			Port: 8080,
+		},
+		Database: config.DatabaseConfig{
+			Mode: "embedded",
+			Port: 5433,
+		},
+	}
+
+	stack := &runtime.StackStatus{
+		Runtime: "local",
+		Services: []runtime.ServiceStatus{
+			{Name: "volundr", State: runtime.StateStopped},
+		},
+	}
+
+	ds := buildDetailedStatus("mini", cfg, stack)
+
+	if ds.Server.Status != "stopped" {
+		t.Errorf("expected server stopped, got %s", ds.Server.Status)
+	}
+	if ds.WebUI != "" {
+		t.Errorf("expected no web UI when stopped, got %s", ds.WebUI)
+	}
+	if ds.Server.Address != "" {
+		t.Errorf("expected no address when stopped, got %s", ds.Server.Address)
+	}
+}
+
+func TestBuildDetailedStatus_K3sWithPods(t *testing.T) {
+	cfg := &config.Config{
+		Volundr: config.VolundrConfig{Mode: "k3s"},
+		Listen:  config.ListenConfig{Host: "127.0.0.1", Port: 8080},
+		Database: config.DatabaseConfig{
+			Mode: "embedded",
+			Port: 5433,
+		},
+	}
+
+	stack := &runtime.StackStatus{
+		Runtime: "k3s",
+		Services: []runtime.ServiceStatus{
+			{Name: "proxy", State: runtime.StateRunning, Port: 8080},
+			{Name: "api", State: runtime.StateRunning, Port: 18080},
+			{Name: "postgres", State: runtime.StateRunning, Port: 5433},
+			{Name: "k3s-cluster", State: runtime.StateRunning},
+			{Name: "session-a1b2c3-skuld", State: runtime.StateRunning},
+			{Name: "tyr-7f8d9e-abc", State: runtime.StateRunning},
+		},
+	}
+
+	ds := buildDetailedStatus("k3s", cfg, stack)
+
+	if ds.Mode != "k3s" {
+		t.Errorf("expected mode k3s, got %s", ds.Mode)
+	}
+	if ds.Cluster == nil {
+		t.Fatal("expected cluster info")
+	}
+	if ds.Cluster.Status != "running" {
+		t.Errorf("expected cluster running, got %s", ds.Cluster.Status)
+	}
+	if len(ds.Pods) != 2 {
+		t.Errorf("expected 2 pods, got %d", len(ds.Pods))
+	}
+
+	// Tyr should be detected from tyr-prefixed pod.
+	if ds.Tyr == nil {
+		t.Fatal("expected tyr info from tyr-prefixed pod")
+	}
+}
+
+func TestBuildDetailedStatus_WithTyrService(t *testing.T) {
+	cfg := &config.Config{
+		Volundr: config.VolundrConfig{Mode: "mini"},
+		Listen:  config.ListenConfig{Host: "127.0.0.1", Port: 8080},
+	}
+
+	stack := &runtime.StackStatus{
+		Runtime: "local",
+		Services: []runtime.ServiceStatus{
+			{Name: "proxy", State: runtime.StateRunning, Port: 8080},
+			{Name: "tyr", State: runtime.StateRunning, Port: 8081, PID: 99999},
+		},
+	}
+
+	ds := buildDetailedStatus("mini", cfg, stack)
+
+	if ds.Tyr == nil {
+		t.Fatal("expected tyr info")
+	}
+	if ds.Tyr.Status != "running" {
+		t.Errorf("expected tyr running, got %s", ds.Tyr.Status)
+	}
+	if ds.Tyr.PID != 99999 {
+		t.Errorf("expected tyr PID 99999, got %d", ds.Tyr.PID)
+	}
+	if ds.Tyr.Address != "127.0.0.1:8081" {
+		t.Errorf("expected tyr address 127.0.0.1:8081, got %s", ds.Tyr.Address)
+	}
+}
+
+func TestInferServerState(t *testing.T) {
+	tests := []struct {
+		name     string
+		services []runtime.ServiceStatus
+		expected string
+	}{
+		{
+			name:     "empty services",
+			services: nil,
+			expected: "stopped",
+		},
+		{
+			name: "volundr stopped",
+			services: []runtime.ServiceStatus{
+				{Name: "volundr", State: runtime.StateStopped},
+			},
+			expected: "stopped",
+		},
+		{
+			name: "volundr running",
+			services: []runtime.ServiceStatus{
+				{Name: "volundr", State: runtime.StateRunning},
+			},
+			expected: "running",
+		},
+		{
+			name: "proxy running",
+			services: []runtime.ServiceStatus{
+				{Name: "proxy", State: runtime.StateRunning, Port: 8080},
+				{Name: "api", State: runtime.StateRunning, Port: 8081},
+			},
+			expected: "running",
+		},
+		{
+			name: "only postgres running",
+			services: []runtime.ServiceStatus{
+				{Name: "postgres", State: runtime.StateRunning, Port: 5433},
+			},
+			expected: "running",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := inferServerState(tt.services)
+			if result != tt.expected {
+				t.Errorf("expected %s, got %s", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestFindService(t *testing.T) {
+	services := []runtime.ServiceStatus{
+		{Name: "proxy", State: runtime.StateRunning, Port: 8080},
+		{Name: "api", State: runtime.StateRunning, PID: 123, Port: 8081},
+		{Name: "postgres", State: runtime.StateRunning, Port: 5433},
+	}
+
+	svc := findService("api", services)
+	if svc == nil {
+		t.Fatal("expected to find api service")
+	}
+	if svc.PID != 123 {
+		t.Errorf("expected PID 123, got %d", svc.PID)
+	}
+
+	svc = findService("nonexistent", services)
+	if svc != nil {
+		t.Error("expected nil for nonexistent service")
+	}
+}
+
+func TestFindServicePrefix(t *testing.T) {
+	services := []runtime.ServiceStatus{
+		{Name: "proxy", State: runtime.StateRunning},
+		{Name: "tyr-abc-123", State: runtime.StateRunning, Port: 8081},
+	}
+
+	svc := findServicePrefix("tyr", services)
+	if svc == nil {
+		t.Fatal("expected to find tyr-prefixed service")
+	}
+	if svc.Name != "tyr-abc-123" {
+		t.Errorf("expected tyr-abc-123, got %s", svc.Name)
+	}
+
+	svc = findServicePrefix("missing", services)
+	if svc != nil {
+		t.Error("expected nil for missing prefix")
+	}
+}
+
+func TestFindServicePID(t *testing.T) {
+	services := []runtime.ServiceStatus{
+		{Name: "api", State: runtime.StateRunning, PID: 456},
+	}
+
+	pid := findServicePID("api", services)
+	if pid != 456 {
+		t.Errorf("expected PID 456, got %d", pid)
+	}
+
+	pid = findServicePID("missing", services)
+	if pid != 0 {
+		t.Errorf("expected PID 0, got %d", pid)
+	}
+}
+
+func TestFormatAge(t *testing.T) {
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{30 * time.Second, "30s"},
+		{5 * time.Minute, "5m"},
+		{90 * time.Minute, "1h"},
+		{3 * time.Hour, "3h"},
+		{36 * time.Hour, "1d"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := formatAge(tt.d)
+			if got != tt.want {
+				t.Errorf("formatAge(%v) = %s, want %s", tt.d, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrintDetailedStatus_Stopped(t *testing.T) {
+	ds := DetailedStatus{
+		Mode: "mini",
+		Server: ServerInfo{
+			Status: "stopped",
+		},
+	}
+
+	// Should not panic.
+	printDetailedStatus(ds)
+}
+
+func TestPrintDetailedStatus_Running(t *testing.T) {
+	ds := DetailedStatus{
+		Mode: "mini",
+		Server: ServerInfo{
+			Status:  "running",
+			Address: "127.0.0.1:8080",
+			PID:     12345,
+		},
+		WebUI: "http://127.0.0.1:8080",
+		Tyr: &ServiceInfo{
+			Status:  "running",
+			Address: "127.0.0.1:8081",
+			PID:     12346,
+		},
+		Database: &DatabaseInfo{
+			Status: "running",
+			Mode:   "embedded",
+			Port:   5433,
+		},
+		Sessions: &SessionSummary{
+			Active: 2,
+			Max:    4,
+			Total:  3,
+			List: []SessionInfo{
+				{ID: "a1b2c3d4e5f6", Name: "fix-auth", Status: "running", Model: "claude-sonnet-4", Repo: "github.com/org/api", Age: "12m"},
+				{ID: "g7h8i9j0k1l2", Name: "add-tests", Status: "running", Model: "claude-sonnet-4", Repo: "github.com/org/web", Age: "3m"},
+			},
+		},
+	}
+
+	// Should not panic.
+	printDetailedStatus(ds)
+}
+
+func TestPrintDetailedStatus_K3sWithPods(t *testing.T) {
+	ds := DetailedStatus{
+		Mode: "k3s",
+		Server: ServerInfo{
+			Status:  "running",
+			Address: "127.0.0.1:8080",
+		},
+		Cluster: &ClusterInfo{
+			Name:   "k3d-volundr",
+			Status: "running",
+		},
+		Database: &DatabaseInfo{
+			Status: "running",
+			Mode:   "embedded",
+			Port:   5433,
+		},
+		Pods: []PodInfo{
+			{Name: "session-a1b2c3-skuld", Status: "running"},
+			{Name: "tyr-7f8d9e-abc", Status: "running"},
+		},
+	}
+
+	// Should not panic.
+	printDetailedStatus(ds)
+}
+
+func TestPrintDetailedStatus_EmptyMode(t *testing.T) {
+	ds := DetailedStatus{
+		Mode:   "",
+		Server: ServerInfo{Status: "stopped"},
+	}
+
+	// Should default to "local" in display.
+	printDetailedStatus(ds)
+}
+
+func TestFetchMiniSessions_ServerDown(t *testing.T) {
+	cfg := &config.Config{
+		Listen: config.ListenConfig{Host: "127.0.0.1", Port: 19999},
+		Volundr: config.VolundrConfig{
+			Forge: config.ForgeSettings{MaxConcurrent: 4},
+		},
+	}
+
+	ds := DetailedStatus{
+		Sessions: &SessionSummary{Max: 4},
+	}
+
+	// Should not panic when server is unreachable.
+	fetchMiniSessions(&ds, cfg)
+
+	// Sessions should remain at defaults since server is down.
+	if ds.Sessions.Active != 0 {
+		t.Errorf("expected 0 active sessions, got %d", ds.Sessions.Active)
+	}
+}
+
+func TestFetchMiniSessions_WithMockServer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/volundr/stats":
+			_, _ = w.Write([]byte(`{"active_sessions": 1, "total_sessions": 2}`))
+		case "/api/v1/volundr/sessions":
+			_, _ = w.Write([]byte(`[
+				{"id": "abc123def456", "name": "test-session", "status": "running", "model": "claude-sonnet-4", "source": {"repo": "github.com/test/repo"}, "created_at": "` + time.Now().Add(-5*time.Minute).Format(time.RFC3339) + `"}
+			]`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	// Parse host/port from server.
+	addr := srv.Listener.Addr().String()
+	parts := splitHostPort(addr)
+
+	cfg := &config.Config{
+		Listen: config.ListenConfig{Host: parts[0], Port: mustAtoi(parts[1])},
+		Volundr: config.VolundrConfig{
+			Forge: config.ForgeSettings{MaxConcurrent: 4},
+		},
+	}
+
+	ds := DetailedStatus{}
+	fetchMiniSessions(&ds, cfg)
+
+	if ds.Sessions == nil {
+		t.Fatal("expected sessions to be populated")
+	}
+	if ds.Sessions.Active != 1 {
+		t.Errorf("expected 1 active, got %d", ds.Sessions.Active)
+	}
+	if ds.Sessions.Total != 2 {
+		t.Errorf("expected 2 total, got %d", ds.Sessions.Total)
+	}
+	if len(ds.Sessions.List) != 1 {
+		t.Fatalf("expected 1 session in list, got %d", len(ds.Sessions.List))
+	}
+
+	sess := ds.Sessions.List[0]
+	if sess.Name != "test-session" {
+		t.Errorf("expected name test-session, got %s", sess.Name)
+	}
+	if sess.Repo != "github.com/test/repo" {
+		t.Errorf("expected repo github.com/test/repo, got %s", sess.Repo)
+	}
+	if sess.Age == "" {
+		t.Error("expected age to be set")
+	}
+}
+
+func TestFetchMiniSessions_StatsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/volundr/stats":
+			w.WriteHeader(http.StatusInternalServerError)
+		case "/api/v1/volundr/sessions":
+			_, _ = w.Write([]byte(`[{"id": "abc123", "name": "s1", "status": "running", "model": "m", "created_at": "` + time.Now().Format(time.RFC3339) + `"}]`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	addr := srv.Listener.Addr().String()
+	parts := splitHostPort(addr)
+
+	cfg := &config.Config{
+		Listen: config.ListenConfig{Host: parts[0], Port: mustAtoi(parts[1])},
+		Volundr: config.VolundrConfig{
+			Forge: config.ForgeSettings{MaxConcurrent: 4},
+		},
+	}
+
+	ds := DetailedStatus{}
+	fetchMiniSessions(&ds, cfg)
+
+	// Stats failed but sessions should still be fetched.
+	if ds.Sessions == nil {
+		t.Fatal("expected sessions to be populated")
+	}
+	if len(ds.Sessions.List) != 1 {
+		t.Errorf("expected 1 session, got %d", len(ds.Sessions.List))
+	}
+}
+
+func TestFetchMiniSessions_SessionsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/volundr/stats":
+			_, _ = w.Write([]byte(`{"active_sessions": 1, "total_sessions": 1}`))
+		case "/api/v1/volundr/sessions":
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	addr := srv.Listener.Addr().String()
+	parts := splitHostPort(addr)
+
+	cfg := &config.Config{
+		Listen: config.ListenConfig{Host: parts[0], Port: mustAtoi(parts[1])},
+		Volundr: config.VolundrConfig{
+			Forge: config.ForgeSettings{MaxConcurrent: 4},
+		},
+	}
+
+	ds := DetailedStatus{}
+	fetchMiniSessions(&ds, cfg)
+
+	// Stats should succeed even if sessions fail.
+	if ds.Sessions == nil {
+		t.Fatal("expected sessions from stats")
+	}
+	if ds.Sessions.Active != 1 {
+		t.Errorf("expected 1 active, got %d", ds.Sessions.Active)
+	}
+	if len(ds.Sessions.List) != 0 {
+		t.Errorf("expected 0 sessions in list, got %d", len(ds.Sessions.List))
+	}
+}
+
+// Helper functions for tests.
+
+func itoa(n int) string {
+	return json.Number(json.Number(func() string {
+		b, _ := json.Marshal(n)
+		return string(b)
+	}()).String()).String()
+}
+
+func splitHostPort(addr string) []string {
+	// Simple split for test addresses like "127.0.0.1:12345".
+	idx := len(addr) - 1
+	for idx >= 0 && addr[idx] != ':' {
+		idx--
+	}
+	return []string{addr[:idx], addr[idx+1:]}
+}
+
+func mustAtoi(s string) int {
+	n, _ := json.Number(s).Int64()
+	return int(n)
+}
+
+// findPortOffset returns the number of characters from the end to the colon.
+func findPortOffset(addr string) int {
+	for i := len(addr) - 1; i >= 0; i-- {
+		if addr[i] == ':' {
+			return len(addr) - i
+		}
+	}
+	return 0
 }

--- a/cli/internal/cli/status_test.go
+++ b/cli/internal/cli/status_test.go
@@ -13,39 +13,6 @@ import (
 	"github.com/niuulabs/volundr/cli/internal/runtime"
 )
 
-// writeTestConfig writes a minimal config file to the given directory.
-func writeTestConfig(t *testing.T, dir, mode string, maxConcurrent int) {
-	t.Helper()
-	cfg := `volundr:
-  mode: ` + mode + `
-  web: true
-  forge:
-    listen: "127.0.0.1:8080"
-    max_concurrent: ` + json.Number(json.Number(
-		func() string {
-			if maxConcurrent == 0 {
-				return "4"
-			}
-			b, _ := json.Marshal(maxConcurrent)
-			return string(b)
-		}(),
-	)).String() + `
-listen:
-  host: "127.0.0.1"
-  port: 8080
-database:
-  mode: embedded
-  port: 5433
-  user: volundr
-  password: testpass
-  name: volundr
-`
-	err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(cfg), 0o600)
-	if err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-}
-
 // writeTestConfigSimple writes a simple config yaml to the dir.
 func writeTestConfigSimple(t *testing.T, dir, mode string) {
 	t.Helper()
@@ -715,7 +682,7 @@ func TestPrintDetailedStatus_Stopped(t *testing.T) {
 	}
 
 	// Should not panic.
-	printDetailedStatus(ds)
+	printDetailedStatus(&ds)
 }
 
 func TestPrintDetailedStatus_Running(t *testing.T) {
@@ -749,7 +716,7 @@ func TestPrintDetailedStatus_Running(t *testing.T) {
 	}
 
 	// Should not panic.
-	printDetailedStatus(ds)
+	printDetailedStatus(&ds)
 }
 
 func TestPrintDetailedStatus_K3sWithPods(t *testing.T) {
@@ -775,7 +742,7 @@ func TestPrintDetailedStatus_K3sWithPods(t *testing.T) {
 	}
 
 	// Should not panic.
-	printDetailedStatus(ds)
+	printDetailedStatus(&ds)
 }
 
 func TestPrintDetailedStatus_EmptyMode(t *testing.T) {
@@ -785,7 +752,7 @@ func TestPrintDetailedStatus_EmptyMode(t *testing.T) {
 	}
 
 	// Should default to "local" in display.
-	printDetailedStatus(ds)
+	printDetailedStatus(&ds)
 }
 
 func TestFetchMiniSessions_ServerDown(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Config-based dispatch**: Replace the `StatusFromStateFile()` TODO with `config.Load()` + `runtime.NewRuntime(mode).Status()`, dispatching to the correct runtime (mini/k3s) based on config
- **Rich mini mode output**: Show server address/PID, web UI URL, database status, Tyr status, session count vs max capacity, and a detailed session table fetched from the Forge API (`/api/v1/volundr/sessions` + `/api/v1/volundr/stats`)
- **Enhanced k3s mode output**: Show cluster info, pod listing with status, and Tyr pod detection
- **JSON output**: `--json` flag produces structured `DetailedStatus` JSON for scripting/AI consumption
- **Graceful fallback**: When config file is missing (e.g. first run before `niuu volundr init`), falls back to basic state file reading without error

## Test plan

- [x] All existing status tests updated and passing
- [x] New tests for `buildDetailedStatus`, `fetchMiniSessions`, `inferServerState`, `findService*`, `formatAge`, `printDetailedStatus` (all variants)
- [x] Mock HTTP server tests for session/stats fetching (including error cases)
- [x] Coverage on status.go: 88-100% per function (patch coverage well above 80%)
- [x] Full test suite passes (`go test ./...`)
- [x] `go vet` clean

Closes NIU-329

🤖 Generated with [Claude Code](https://claude.com/claude-code)