### PR TITLE
feat(tyr): implement ContractEngine for planner-driven sprint contracts

### DIFF
--- a/charts/tyr/templates/migrations-configmap.yaml
+++ b/charts/tyr/templates/migrations-configmap.yaml
@@ -392,4 +392,12 @@ data:
     DROP INDEX IF EXISTS idx_raids_planner_session;
     ALTER TABLE raids DROP COLUMN IF EXISTS planner_session_id;
     ALTER TABLE raid_progress DROP COLUMN IF EXISTS planner_session_id;
+
+  000020_raid_contract_fields.up.sql: |
+    ALTER TABLE raid_progress ADD COLUMN IF NOT EXISTS acceptance_criteria TEXT[] NOT NULL DEFAULT '{}';
+    ALTER TABLE raid_progress ADD COLUMN IF NOT EXISTS declared_files TEXT[] NOT NULL DEFAULT '{}';
+
+  000020_raid_contract_fields.down.sql: |
+    ALTER TABLE raid_progress DROP COLUMN IF EXISTS declared_files;
+    ALTER TABLE raid_progress DROP COLUMN IF EXISTS acceptance_criteria;
 {{- end }}

--- a/migrations/tyr/000020_raid_contract_fields.down.sql
+++ b/migrations/tyr/000020_raid_contract_fields.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE raid_progress DROP COLUMN IF EXISTS declared_files;
+ALTER TABLE raid_progress DROP COLUMN IF EXISTS acceptance_criteria;

--- a/migrations/tyr/000020_raid_contract_fields.up.sql
+++ b/migrations/tyr/000020_raid_contract_fields.up.sql
@@ -1,0 +1,4 @@
+-- Add acceptance_criteria and declared_files to raid_progress for contract engine.
+-- The raids table (NativeAdapter) already has these columns.
+ALTER TABLE raid_progress ADD COLUMN IF NOT EXISTS acceptance_criteria TEXT[] NOT NULL DEFAULT '{}';
+ALTER TABLE raid_progress ADD COLUMN IF NOT EXISTS declared_files TEXT[] NOT NULL DEFAULT '{}';

--- a/src/tyr/adapters/linear.py
+++ b/src/tyr/adapters/linear.py
@@ -671,6 +671,8 @@ class LinearTrackerAdapter(TrackerPort):
         reviewer_session_id: str | None = None,
         review_round: int | None = None,
         planner_session_id: str | None = None,
+        acceptance_criteria: list[str] | None = None,
+        declared_files: list[str] | None = None,
     ) -> Raid:
         if self._pool is None:
             raise RuntimeError("pool is required for update_raid_progress")
@@ -680,10 +682,10 @@ class LinearTrackerAdapter(TrackerPort):
                 (tracker_id, status, session_id, confidence, pr_url, pr_id,
                  retry_count, reason, owner_id, phase_tracker_id, saga_tracker_id,
                  chronicle_summary, reviewer_session_id, review_round,
-                 planner_session_id)
+                 planner_session_id, acceptance_criteria, declared_files)
             VALUES ($1, COALESCE($2, 'PENDING'), $3, $4, $5, $6,
                     COALESCE($7, 0), $8, $9, $10, $11, $12, $13,
-                    COALESCE($14, 0), $15)
+                    COALESCE($14, 0), $15, COALESCE($16, '{}'), COALESCE($17, '{}'))
             ON CONFLICT (tracker_id) DO UPDATE SET
                 status              = COALESCE($2, raid_progress.status),
                 session_id          = COALESCE($3, raid_progress.session_id),
@@ -699,6 +701,8 @@ class LinearTrackerAdapter(TrackerPort):
                 reviewer_session_id = COALESCE($13, raid_progress.reviewer_session_id),
                 review_round        = COALESCE($14, raid_progress.review_round),
                 planner_session_id  = COALESCE($15, raid_progress.planner_session_id),
+                acceptance_criteria = COALESCE($16, raid_progress.acceptance_criteria),
+                declared_files      = COALESCE($17, raid_progress.declared_files),
                 updated_at          = NOW()
             """,
             tracker_id,
@@ -716,6 +720,8 @@ class LinearTrackerAdapter(TrackerPort):
             reviewer_session_id,
             review_round,
             planner_session_id,
+            acceptance_criteria,
+            declared_files,
         )
         if status is not None:
             try:
@@ -1087,8 +1093,12 @@ class LinearTrackerAdapter(TrackerPort):
             url=node.get("url", ""),
             name=node.get("title", ""),
             description=node.get("description") or "",
-            acceptance_criteria=[],
-            declared_files=[],
+            acceptance_criteria=list(progress.get("acceptance_criteria") or [])
+            if progress
+            else [],
+            declared_files=list(progress.get("declared_files") or [])
+            if progress
+            else [],
             estimate_hours=None,
             status=raid_status,
             confidence=float(progress["confidence"])

--- a/src/tyr/adapters/native.py
+++ b/src/tyr/adapters/native.py
@@ -252,6 +252,8 @@ class NativeTrackerAdapter(TrackerPort):
         reviewer_session_id: str | None = None,
         review_round: int | None = None,
         planner_session_id: str | None = None,
+        acceptance_criteria: list[str] | None = None,
+        declared_files: list[str] | None = None,
     ) -> Raid:
         row = await self._pool.fetchrow(
             """
@@ -267,6 +269,8 @@ class NativeTrackerAdapter(TrackerPort):
                 reviewer_session_id = COALESCE($10, reviewer_session_id),
                 review_round        = COALESCE($11, review_round),
                 planner_session_id  = COALESCE($12, planner_session_id),
+                acceptance_criteria = COALESCE($13, acceptance_criteria),
+                declared_files      = COALESCE($14, declared_files),
                 updated_at          = NOW()
             WHERE tracker_id = $1
             RETURNING *
@@ -283,6 +287,8 @@ class NativeTrackerAdapter(TrackerPort):
             reviewer_session_id,
             review_round,
             planner_session_id,
+            acceptance_criteria,
+            declared_files,
         )
         if row is None:
             raise LookupError(f"Raid not found: {tracker_id}")

--- a/src/tyr/config.py
+++ b/src/tyr/config.py
@@ -277,6 +277,112 @@ class ReviewConfig(BaseModel):
     )
 
 
+class ContractConfig(BaseModel):
+    """Contract engine configuration for planner-driven sprint contracts."""
+
+    contract_enabled: bool = Field(
+        default=True,
+        description="Enable planner-driven sprint contract negotiation before coding begins.",
+    )
+    contract_model: str = Field(
+        default="claude-sonnet-4-6",
+        description="AI model for contract planner sessions.",
+    )
+    contract_max_rounds: int = Field(
+        default=3,
+        description="Maximum negotiation rounds before escalating.",
+    )
+    contract_profile: str = Field(
+        default="planner",
+        description="Volundr profile for contract planner sessions (reuses skuld-planner).",
+    )
+    working_session_wait_prompt: str = Field(
+        default=(
+            "Your sprint contract is being prepared. Stand by — you will receive "
+            "a CONTRACT_AGREED message with your acceptance criteria and declared "
+            "files before you begin coding. Do not start any implementation yet."
+        ),
+        description="Message sent to the working session while the contract is being negotiated.",
+    )
+    contract_system_prompt: str = Field(
+        default=(
+            "You are a sprint contract negotiator for the Niuu platform.\n"
+            "\n"
+            "Your job is to review the raid specification and negotiate a clear,\n"
+            "testable contract with the working session before coding begins.\n"
+            "\n"
+            "## Process\n"
+            "\n"
+            "1. Read the raid description and any existing acceptance criteria.\n"
+            "2. Propose a contract: a list of testable acceptance criteria and\n"
+            "   the set of files the raid is expected to touch.\n"
+            "3. If the specification is ambiguous, ask clarifying questions.\n"
+            "4. Once agreed, output the final contract.\n"
+            "\n"
+            "## Output Format\n"
+            "\n"
+            "When the contract is agreed, output exactly:\n"
+            "\n"
+            "CONTRACT_AGREED\n"
+            "```json\n"
+            "{\n"
+            '  "acceptance_criteria": ["testable imperative criterion", ...],\n'
+            '  "declared_files": ["relative/path/to/file.py", ...]\n'
+            "}\n"
+            "```\n"
+            "\n"
+            "If the contract cannot be agreed after the maximum rounds,\n"
+            "output exactly:\n"
+            "\n"
+            "CONTRACT_FAILED\n"
+            "```json\n"
+            '{"reason": "explanation of why agreement could not be reached"}\n'
+            "```"
+        ),
+        description="System prompt for contract planner sessions.",
+    )
+    contract_initial_prompt_template: str = Field(
+        default=(
+            "## Sprint Contract Negotiation\n"
+            "\n"
+            "**Ticket**: {tracker_id}\n"
+            "**Raid**: {raid_name}\n"
+            "**Description**: {raid_description}\n"
+            "\n"
+            "{acceptance_criteria_section}"
+            "{declared_files_section}"
+            "## Instructions\n"
+            "\n"
+            "1. Read the raid specification above.\n"
+            "2. Propose a contract with testable acceptance criteria and declared files.\n"
+            "3. The working session (ID: `{working_session_id}`) is waiting.\n"
+            "4. You have {max_rounds} rounds to reach agreement.\n"
+            "5. When agreed, send the contract to the working session:\n"
+            "   `curl -s -X POST http://localhost:8081/api/message "
+            '-H "Content-Type: application/json" '
+            '-d \'{{"session_id": "{working_session_id}", '
+            '"content": "CONTRACT_AGREED\\n```json\\n<contract>\\n```"}}\'`\n'
+            "6. Then output your CONTRACT_AGREED block.\n"
+            "\n"
+            "## Output\n"
+            "\n"
+            "CONTRACT_AGREED\n"
+            "```json\n"
+            "{{\n"
+            '  "acceptance_criteria": ["criterion 1", ...],\n'
+            '  "declared_files": ["path/to/file.py", ...]\n'
+            "}}\n"
+            "```"
+        ),
+        description=(
+            "Template for the contract planner's initial prompt. "
+            "Placeholders: {tracker_id}, {raid_name}, {raid_description}, "
+            "{acceptance_criteria_section}, {declared_files_section}, "
+            "{working_session_id}, {max_rounds}."
+        ),
+    )
+
+
 class GitConfig(BaseModel):
     """Git provider configuration."""
 
@@ -620,6 +726,7 @@ class Settings(BaseSettings):
     )
     git: GitConfig = Field(default_factory=GitConfig)
     review: ReviewConfig = Field(default_factory=ReviewConfig)
+    contract: ContractConfig = Field(default_factory=ContractConfig)
     tracker: TrackerConfig = Field(default_factory=TrackerConfig)
     dispatch: DispatchConfig = Field(default_factory=DispatchConfig)
     planner: PlannerConfig = Field(default_factory=PlannerConfig)

--- a/src/tyr/domain/services/contract_engine.py
+++ b/src/tyr/domain/services/contract_engine.py
@@ -1,0 +1,605 @@
+"""Contract engine — planner-driven sprint contract negotiation for raids.
+
+Mirrors the ReviewEngine pattern exactly: listens on the event bus for a status
+change (CONTRACTING), tracks an in-memory session→raid mapping (rebuilt from DB
+on startup), and receives completion callbacks from ActivitySubscriber.
+
+When a raid enters CONTRACTING, the engine spawns a planner session that
+negotiates acceptance criteria and declared files with the working session.
+On agreement the contract is persisted to the raid and posted as a Linear
+comment for audit trail. On failure the raid is escalated.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+
+from tyr.config import ContractConfig
+from tyr.domain.models import (
+    RaidStatus,
+    validate_transition,
+)
+from tyr.ports.dispatcher_repository import DispatcherRepository
+from tyr.ports.event_bus import EventBusPort, TyrEvent
+from tyr.ports.tracker import TrackerFactory, TrackerPort
+from tyr.ports.volundr import SpawnRequest, VolundrFactory, VolundrSession
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Prompt helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_acceptance_criteria_section(criteria: list[str]) -> str:
+    if not criteria:
+        return ""
+    lines = ["**Existing Acceptance Criteria**:"]
+    for criterion in criteria:
+        lines.append(f"- {criterion}")
+    return "\n".join(lines) + "\n\n"
+
+
+def _build_declared_files_section(files: list[str]) -> str:
+    if not files:
+        return ""
+    lines = [f"**Declared Files** ({len(files)}):"]
+    for f in files:
+        lines.append(f"- `{f}`")
+    return "\n".join(lines) + "\n\n"
+
+
+def build_contract_initial_prompt(
+    raid_tracker_id: str,
+    raid_name: str,
+    raid_description: str,
+    acceptance_criteria: list[str],
+    declared_files: list[str],
+    working_session_id: str,
+    max_rounds: int,
+    template: str = "",
+) -> str:
+    """Build the initial prompt sent to the contract planner session."""
+    sections = {
+        "tracker_id": raid_tracker_id,
+        "raid_name": raid_name,
+        "raid_description": raid_description,
+        "acceptance_criteria_section": _build_acceptance_criteria_section(acceptance_criteria),
+        "declared_files_section": _build_declared_files_section(declared_files),
+        "working_session_id": working_session_id,
+        "max_rounds": str(max_rounds),
+    }
+
+    if template:
+        return template.format(**sections)
+
+    return (
+        f"## Sprint Contract Negotiation\n\n"
+        f"**Ticket**: {raid_tracker_id}\n"
+        f"**Raid**: {raid_name}\n"
+        f"**Description**: {raid_description}\n\n"
+        f"{sections['acceptance_criteria_section']}"
+        f"{sections['declared_files_section']}"
+        f"Working session: `{working_session_id}`\n"
+        f"Max rounds: {max_rounds}\n\n"
+        "Negotiate and output CONTRACT_AGREED with acceptance criteria and declared files as JSON."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Contract response parser
+# ---------------------------------------------------------------------------
+
+
+def parse_contract_response(text: str) -> dict | None:
+    """Parse the contract planner's output.
+
+    Looks for CONTRACT_AGREED or CONTRACT_FAILED markers followed by a JSON block.
+    Returns the parsed dict with a ``status`` key ("agreed" or "failed"),
+    or None if the output cannot be parsed (intermediate idle).
+    """
+    if "CONTRACT_AGREED" not in text and "CONTRACT_FAILED" not in text:
+        return None
+
+    # Extract JSON from markdown code fences
+    cleaned = text.strip()
+    json_str = ""
+    for prefix in ("```json", "```"):
+        if prefix in cleaned:
+            start = cleaned.index(prefix) + len(prefix)
+            end = cleaned.index("```", start) if "```" in cleaned[start:] else len(cleaned)
+            json_str = cleaned[start:end].strip()
+            break
+
+    if not json_str:
+        # Try parsing whatever comes after the marker
+        for marker in ("CONTRACT_AGREED", "CONTRACT_FAILED"):
+            if marker in cleaned:
+                after = cleaned.split(marker, 1)[1].strip()
+                json_str = after
+                break
+
+    try:
+        data = json.loads(json_str)
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+    if not isinstance(data, dict):
+        return None
+
+    if "CONTRACT_FAILED" in text:
+        return {"status": "failed", "reason": data.get("reason", "Unknown failure")}
+
+    criteria = data.get("acceptance_criteria", [])
+    files = data.get("declared_files", [])
+
+    if not isinstance(criteria, list) or not isinstance(files, list):
+        return None
+
+    return {
+        "status": "agreed",
+        "acceptance_criteria": [str(c) for c in criteria],
+        "declared_files": [str(f) for f in files],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Engine
+# ---------------------------------------------------------------------------
+
+
+class ContractEngine:
+    """Planner-driven sprint contract negotiation engine.
+
+    Mirrors ReviewEngine: listens for raids entering CONTRACTING, spawns a
+    planner session, and handles completion via ActivitySubscriber callbacks.
+    """
+
+    def __init__(
+        self,
+        tracker_factory: TrackerFactory,
+        volundr_factory: VolundrFactory,
+        contract_config: ContractConfig,
+        event_bus: EventBusPort | None = None,
+        dispatcher_repo: DispatcherRepository | None = None,
+    ) -> None:
+        self._tracker_factory = tracker_factory
+        self._volundr_factory = volundr_factory
+        self._cfg = contract_config
+        self._event_bus = event_bus
+        self._dispatcher_repo = dispatcher_repo
+        self._task: asyncio.Task[None] | None = None
+        # Maps planner_session_id → (raid_tracker_id, owner_id)
+        self._contract_sessions: dict[str, tuple[str, str]] = {}
+        # Maps planner_session_id → current round number
+        self._contract_rounds: dict[str, int] = {}
+
+    @property
+    def running(self) -> bool:
+        return self._task is not None
+
+    def get_contract_raid(self, session_id: str) -> tuple[str, str] | None:
+        """Look up the raid tracker_id and owner_id for a contract planner session.
+
+        Returns (tracker_id, owner_id) if the session is a tracked contract planner,
+        None otherwise.
+        """
+        return self._contract_sessions.get(session_id)
+
+    async def handle_contract_completion(self, session_id: str, planner_output: str) -> None:
+        """Handle a contract planner session idle event (called by ActivitySubscriber).
+
+        The planner may go idle multiple times during negotiation. Only act
+        when the output contains CONTRACT_AGREED or CONTRACT_FAILED — otherwise
+        it's an intermediate idle and we increment the round counter.
+        """
+        mapping = self._contract_sessions.get(session_id)
+        if mapping is None:
+            logger.warning("Contract session %s not tracked — ignoring completion", session_id)
+            return
+
+        tracker_id, owner_id = mapping
+
+        result = parse_contract_response(planner_output)
+
+        # Intermediate idle — no CONTRACT_AGREED/FAILED marker
+        if result is None:
+            current_round = self._contract_rounds.get(session_id, 0) + 1
+            self._contract_rounds[session_id] = current_round
+
+            if current_round >= self._cfg.contract_max_rounds:
+                logger.info(
+                    "Contract session %s reached max rounds (%d) — escalating",
+                    session_id,
+                    self._cfg.contract_max_rounds,
+                )
+                await self._handle_contract_failed(
+                    tracker_id,
+                    owner_id,
+                    session_id,
+                    reason=f"Max negotiation rounds ({self._cfg.contract_max_rounds}) exceeded",
+                )
+                return
+
+            logger.info(
+                "Contract session %s idle without agreement — round %d/%d, skipping",
+                session_id,
+                current_round,
+                self._cfg.contract_max_rounds,
+            )
+            return
+
+        trackers = await self._tracker_factory.for_owner(owner_id)
+        if not trackers:
+            raise RuntimeError(f"No tracker for owner {owner_id[:8]}")
+        tracker = trackers[0]
+
+        raid = await tracker.get_raid(tracker_id)
+        if raid.status != RaidStatus.CONTRACTING:
+            logger.info(
+                "Raid %s no longer in CONTRACTING (status=%s) — skipping contract result",
+                tracker_id,
+                raid.status,
+            )
+            self._cleanup_session(session_id)
+            return
+
+        if result["status"] == "failed":
+            await self._handle_contract_failed(
+                tracker_id,
+                owner_id,
+                session_id,
+                reason=result.get("reason", "Contract negotiation failed"),
+            )
+            return
+
+        # Contract agreed
+        await self._handle_contract_agreed(
+            tracker,
+            tracker_id,
+            owner_id,
+            session_id,
+            acceptance_criteria=result["acceptance_criteria"],
+            declared_files=result["declared_files"],
+        )
+
+    async def _handle_contract_agreed(
+        self,
+        tracker: TrackerPort,
+        tracker_id: str,
+        owner_id: str,
+        session_id: str,
+        *,
+        acceptance_criteria: list[str],
+        declared_files: list[str],
+    ) -> None:
+        """Handle a successful contract agreement."""
+        # Persist contract to the raid
+        await tracker.update_raid_progress(
+            tracker_id,
+            acceptance_criteria=acceptance_criteria,
+            declared_files=declared_files,
+        )
+
+        # Post agreed contract as a Linear comment for audit trail
+        contract_json = json.dumps(
+            {
+                "acceptance_criteria": acceptance_criteria,
+                "declared_files": declared_files,
+            },
+            indent=2,
+        )
+        try:
+            await tracker.add_comment(
+                tracker_id,
+                f"## Sprint Contract Agreed\n\n```json\n{contract_json}\n```",
+            )
+        except Exception:
+            logger.warning("Failed to post contract comment on %s", tracker_id, exc_info=True)
+
+        # Transition CONTRACTING → RUNNING
+        validate_transition(RaidStatus.CONTRACTING, RaidStatus.RUNNING)
+        updated = await tracker.update_raid_progress(tracker_id, status=RaidStatus.RUNNING)
+
+        await self._emit_event(
+            "contract.agreed",
+            owner_id,
+            {
+                "tracker_id": tracker_id,
+                "criteria_count": len(acceptance_criteria),
+                "files_count": len(declared_files),
+            },
+        )
+
+        # Also emit raid.state_changed so downstream listeners react
+        await self._emit_event(
+            "raid.state_changed",
+            owner_id,
+            {
+                "raid_id": str(updated.id),
+                "status": updated.status.value,
+                "tracker_id": tracker_id,
+                "action": "contract_agreed",
+            },
+        )
+
+        self._cleanup_session(session_id)
+        logger.info(
+            "Contract agreed for raid %s: %d criteria, %d files",
+            tracker_id,
+            len(acceptance_criteria),
+            len(declared_files),
+        )
+
+    async def _handle_contract_failed(
+        self,
+        tracker_id: str,
+        owner_id: str,
+        session_id: str,
+        *,
+        reason: str,
+    ) -> None:
+        """Handle a failed contract negotiation — escalate the raid."""
+        trackers = await self._tracker_factory.for_owner(owner_id)
+        if not trackers:
+            logger.error("No tracker for owner %s during contract failure", owner_id[:8])
+            self._cleanup_session(session_id)
+            return
+        tracker = trackers[0]
+
+        validate_transition(RaidStatus.CONTRACTING, RaidStatus.ESCALATED)
+        await tracker.update_raid_progress(tracker_id, status=RaidStatus.ESCALATED, reason=reason)
+
+        await self._emit_event(
+            "contract.failed",
+            owner_id,
+            {"tracker_id": tracker_id, "reason": reason},
+        )
+
+        await self._emit_event(
+            "raid.state_changed",
+            owner_id,
+            {
+                "tracker_id": tracker_id,
+                "status": RaidStatus.ESCALATED.value,
+                "action": "contract_failed",
+            },
+        )
+
+        self._cleanup_session(session_id)
+        logger.info("Contract failed for raid %s: %s", tracker_id, reason)
+
+    async def evaluate(self, tracker_id: str, owner_id: str) -> None:
+        """Spawn a contract planner session for a raid entering CONTRACTING.
+
+        Called by the dispatcher (NIU-334) or by the event listener.
+        """
+        if not self._cfg.contract_enabled:
+            logger.info("Contract engine disabled — skipping %s", tracker_id)
+            return
+
+        trackers = await self._tracker_factory.for_owner(owner_id)
+        if not trackers:
+            raise ValueError(f"No tracker adapter found for owner {owner_id}")
+        tracker = trackers[0]
+
+        raid = await tracker.get_raid(tracker_id)
+        if raid.status != RaidStatus.CONTRACTING:
+            raise ValueError(f"Raid {tracker_id} not in CONTRACTING state: {raid.status}")
+
+        # Resolve the working session
+        working_session: VolundrSession | None = None
+        if raid.session_id:
+            adapters = await self._volundr_factory.for_owner(owner_id)
+            for adapter in adapters:
+                try:
+                    working_session = await adapter.get_session(raid.session_id)
+                    if working_session is not None:
+                        break
+                except Exception:
+                    continue
+
+        # Send wait prompt to working session
+        if working_session is not None:
+            try:
+                volundr_adapters = await self._volundr_factory.for_owner(owner_id)
+                if volundr_adapters:
+                    await volundr_adapters[0].send_message(
+                        raid.session_id, self._cfg.working_session_wait_prompt
+                    )
+            except Exception:
+                logger.warning(
+                    "Failed to send wait prompt to session %s",
+                    raid.session_id,
+                    exc_info=True,
+                )
+
+        # Spawn the planner session
+        session = await self._spawn_planner_session(raid, owner_id, working_session)
+        if session is None:
+            logger.warning(
+                "Contract planner session not spawned for raid %s — escalating",
+                tracker_id,
+            )
+            await self._handle_contract_failed(
+                tracker_id,
+                owner_id,
+                "",
+                reason="Failed to spawn contract planner session",
+            )
+            return
+
+        # Persist planner session mapping
+        await tracker.update_raid_progress(tracker_id, planner_session_id=session.id)
+        self._contract_sessions[session.id] = (tracker_id, owner_id)
+        self._contract_rounds[session.id] = 0
+
+        logger.info(
+            "Contract planner session %s spawned for raid %s",
+            session.id,
+            tracker_id,
+        )
+
+    async def _spawn_planner_session(
+        self,
+        raid,
+        owner_id: str,
+        working_session: VolundrSession | None,
+    ) -> VolundrSession | None:
+        """Spawn a contract planner session via Volundr."""
+        adapters = await self._volundr_factory.for_owner(owner_id)
+        if not adapters:
+            logger.error(
+                "No authenticated Volundr adapter for owner %s",
+                owner_id[:8],
+            )
+            return None
+
+        volundr = adapters[0]
+
+        initial_prompt = build_contract_initial_prompt(
+            raid_tracker_id=raid.tracker_id,
+            raid_name=raid.name,
+            raid_description=raid.description,
+            acceptance_criteria=raid.acceptance_criteria,
+            declared_files=raid.declared_files,
+            working_session_id=working_session.id if working_session else "",
+            max_rounds=self._cfg.contract_max_rounds,
+            template=self._cfg.contract_initial_prompt_template,
+        )
+
+        request = SpawnRequest(
+            name=f"contract-{(raid.identifier or raid.tracker_id[:8]).lower()}",
+            repo=working_session.repo if working_session else "",
+            branch=working_session.branch if working_session else "",
+            base_branch=working_session.base_branch if working_session else "",
+            model=self._cfg.contract_model,
+            tracker_issue_id=raid.identifier or raid.tracker_id,
+            tracker_issue_url=raid.url or "",
+            system_prompt=self._cfg.contract_system_prompt,
+            initial_prompt=initial_prompt,
+            workload_type="planner",
+            profile=self._cfg.contract_profile,
+        )
+
+        try:
+            return await volundr.spawn_session(request)
+        except Exception:
+            logger.warning(
+                "Failed to spawn contract planner for raid %s",
+                raid.tracker_id,
+                exc_info=True,
+            )
+            return None
+
+    # -- Lifecycle --
+
+    async def start(self) -> None:
+        """Subscribe to the event bus and react to raids entering CONTRACTING.
+
+        Rebuilds the in-memory contract session mapping from the database
+        so that contract completions are handled after a restart.
+        """
+        await self._rebuild_contract_sessions()
+        if self._event_bus is None:
+            return
+        self._task = asyncio.create_task(self._listen())
+
+    async def _rebuild_contract_sessions(self) -> None:
+        """Rebuild _contract_sessions from DB.
+
+        Queries all active dispatchers and their trackers to find raids
+        in CONTRACTING state with a planner_session_id.
+        """
+        if self._dispatcher_repo is None:
+            return
+
+        try:
+            owner_ids = await self._dispatcher_repo.list_active_owner_ids()
+        except Exception:
+            logger.warning("Could not list active owners for contract rebuild", exc_info=True)
+            return
+
+        for owner_id in owner_ids:
+            trackers = await self._tracker_factory.for_owner(owner_id)
+            for tracker in trackers:
+                raids = await tracker.list_raids_by_status(RaidStatus.CONTRACTING)
+                for raid in raids:
+                    if raid.planner_session_id:
+                        self._contract_sessions[raid.planner_session_id] = (
+                            raid.tracker_id,
+                            owner_id,
+                        )
+        if self._contract_sessions:
+            logger.info(
+                "Rebuilt %d contract session mapping(s) from database",
+                len(self._contract_sessions),
+            )
+
+    async def stop(self) -> None:
+        """Cancel the event listener task."""
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+
+    async def _listen(self) -> None:
+        """Listen for raid.state_changed events where status == CONTRACTING."""
+        if self._event_bus is None:
+            logger.warning("Contract engine has no event bus — cannot listen")
+            return
+        q = self._event_bus.subscribe()
+        logger.info("Contract engine listening for raid.state_changed events")
+        try:
+            while True:
+                event = await q.get()
+                if event.event != "raid.state_changed":
+                    continue
+                if event.data.get("status") != RaidStatus.CONTRACTING.value:
+                    continue
+                tracker_id = event.data.get("tracker_id")
+                owner_id = event.owner_id
+                if not tracker_id or not owner_id:
+                    logger.warning(
+                        "Skipping — missing tracker_id=%s or owner_id=%s",
+                        tracker_id,
+                        owner_id,
+                    )
+                    continue
+                logger.info(
+                    "Contract engine evaluating raid %s for owner %s",
+                    tracker_id,
+                    owner_id[:8],
+                )
+                try:
+                    await self.evaluate(tracker_id, owner_id)
+                except Exception:
+                    logger.warning(
+                        "Contract engine failed for raid %s",
+                        tracker_id,
+                        exc_info=True,
+                    )
+        except asyncio.CancelledError:
+            return
+        finally:
+            if self._event_bus is not None:
+                self._event_bus.unsubscribe(q)
+
+    # -- Helpers --
+
+    def _cleanup_session(self, session_id: str) -> None:
+        """Remove a session from tracking maps."""
+        self._contract_sessions.pop(session_id, None)
+        self._contract_rounds.pop(session_id, None)
+
+    async def _emit_event(self, event_name: str, owner_id: str, data: dict) -> None:
+        """Emit an event via the event bus."""
+        if self._event_bus is None:
+            return
+        await self._event_bus.emit(TyrEvent(event=event_name, owner_id=owner_id, data=data))

--- a/src/tyr/ports/tracker.py
+++ b/src/tyr/ports/tracker.py
@@ -114,6 +114,8 @@ class TrackerPort(ABC):
         reviewer_session_id: str | None = None,
         review_round: int | None = None,
         planner_session_id: str | None = None,
+        acceptance_criteria: list[str] | None = None,
+        declared_files: list[str] | None = None,
     ) -> Raid: ...
 
     @abstractmethod

--- a/tests/test_tyr/test_activity_subscriber.py
+++ b/tests/test_tyr/test_activity_subscriber.py
@@ -183,6 +183,11 @@ class StubTracker(TrackerPort):
         phase_tracker_id: str | None = None,
         saga_tracker_id: str | None = None,
         chronicle_summary: str | None = None,
+        reviewer_session_id: str | None = None,
+        review_round: int | None = None,
+        planner_session_id: str | None = None,
+        acceptance_criteria: list[str] | None = None,
+        declared_files: list[str] | None = None,
     ) -> Raid:
         entry = self.progress.setdefault(tracker_id, {})
         if status is not None:

--- a/tests/test_tyr/test_contract_engine.py
+++ b/tests/test_tyr/test_contract_engine.py
@@ -1,0 +1,923 @@
+"""Tests for the contract engine (NIU-332)."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+import pytest
+
+from tyr.adapters.memory_event_bus import InMemoryEventBus
+from tyr.config import ContractConfig
+from tyr.domain.models import (
+    ConfidenceEvent,
+    Phase,
+    PhaseStatus,
+    Raid,
+    RaidStatus,
+    Saga,
+    SessionMessage,
+    TrackerIssue,
+    TrackerMilestone,
+    TrackerProject,
+)
+from tyr.domain.services.contract_engine import (
+    ContractEngine,
+    build_contract_initial_prompt,
+    parse_contract_response,
+)
+from tyr.ports.tracker import TrackerPort
+from tyr.ports.volundr import ActivityEvent, SpawnRequest, VolundrPort, VolundrSession
+
+NOW = datetime.now(UTC)
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+PHASE_ID = uuid4()
+SAGA_ID = uuid4()
+OWNER_ID = "user-1"
+TRACKER_ID = "NIU-100"
+
+
+class StubTracker(TrackerPort):
+    """In-memory tracker stub for contract engine tests."""
+
+    def __init__(self) -> None:
+        self.raids: dict[str, Raid] = {}
+        self.events: dict[str, list[ConfidenceEvent]] = {}
+        self.comments: list[tuple[str, str]] = []
+
+    # -- CRUD --
+
+    async def create_saga(self, saga: Saga, *, description: str = "") -> str:
+        return saga.tracker_id
+
+    async def create_phase(self, phase: Phase, *, project_id: str = "") -> str:
+        return phase.tracker_id
+
+    async def create_raid(self, raid: Raid, *, project_id: str = "", milestone_id: str = "") -> str:
+        self.raids[raid.tracker_id] = raid
+        return raid.tracker_id
+
+    async def update_raid_state(self, raid_id: str, state: RaidStatus) -> None:
+        pass
+
+    async def close_raid(self, raid_id: str) -> None:
+        pass
+
+    async def get_saga(self, saga_id: str) -> Saga:
+        raise NotImplementedError
+
+    async def get_phase(self, tracker_id: str) -> Phase:
+        raise NotImplementedError
+
+    async def get_raid(self, tracker_id: str) -> Raid:
+        raid = self.raids.get(tracker_id)
+        if raid is None:
+            raise ValueError(f"Raid not found: {tracker_id}")
+        return raid
+
+    async def list_pending_raids(self, phase_id: str) -> list[Raid]:
+        return []
+
+    async def list_projects(self) -> list[TrackerProject]:
+        return []
+
+    async def get_project(self, project_id: str) -> TrackerProject:
+        raise NotImplementedError
+
+    async def list_milestones(self, project_id: str) -> list[TrackerMilestone]:
+        return []
+
+    async def list_issues(
+        self, project_id: str, milestone_id: str | None = None
+    ) -> list[TrackerIssue]:
+        return []
+
+    async def update_raid_progress(
+        self,
+        tracker_id: str,
+        *,
+        status: RaidStatus | None = None,
+        session_id: str | None = None,
+        confidence: float | None = None,
+        pr_url: str | None = None,
+        pr_id: str | None = None,
+        retry_count: int | None = None,
+        reason: str | None = None,
+        owner_id: str | None = None,
+        phase_tracker_id: str | None = None,
+        saga_tracker_id: str | None = None,
+        chronicle_summary: str | None = None,
+        reviewer_session_id: str | None = None,
+        review_round: int | None = None,
+        planner_session_id: str | None = None,
+        acceptance_criteria: list[str] | None = None,
+        declared_files: list[str] | None = None,
+    ) -> Raid:
+        raid = self.raids.get(tracker_id)
+        if raid is None:
+            raise ValueError(f"Raid not found: {tracker_id}")
+        updated = Raid(
+            id=raid.id,
+            phase_id=raid.phase_id,
+            tracker_id=raid.tracker_id,
+            name=raid.name,
+            description=raid.description,
+            acceptance_criteria=acceptance_criteria
+            if acceptance_criteria is not None
+            else raid.acceptance_criteria,
+            declared_files=declared_files if declared_files is not None else raid.declared_files,
+            estimate_hours=raid.estimate_hours,
+            status=status if status is not None else raid.status,
+            confidence=confidence if confidence is not None else raid.confidence,
+            session_id=session_id if session_id is not None else raid.session_id,
+            branch=raid.branch,
+            chronicle_summary=raid.chronicle_summary,
+            pr_url=pr_url if pr_url is not None else raid.pr_url,
+            pr_id=pr_id if pr_id is not None else raid.pr_id,
+            retry_count=retry_count if retry_count is not None else raid.retry_count,
+            created_at=raid.created_at,
+            updated_at=datetime.now(UTC),
+            identifier=raid.identifier,
+            url=raid.url,
+            reviewer_session_id=reviewer_session_id
+            if reviewer_session_id is not None
+            else raid.reviewer_session_id,
+            review_round=review_round if review_round is not None else raid.review_round,
+            planner_session_id=planner_session_id
+            if planner_session_id is not None
+            else raid.planner_session_id,
+        )
+        self.raids[tracker_id] = updated
+        return updated
+
+    async def get_raid_progress_for_saga(self, saga_tracker_id: str) -> list[Raid]:
+        return list(self.raids.values())
+
+    async def get_raid_by_session(self, session_id: str) -> Raid | None:
+        return next((r for r in self.raids.values() if r.session_id == session_id), None)
+
+    async def list_raids_by_status(self, status: RaidStatus) -> list[Raid]:
+        return [r for r in self.raids.values() if r.status == status]
+
+    async def get_raid_by_id(self, raid_id: UUID) -> Raid | None:
+        return next((r for r in self.raids.values() if r.id == raid_id), None)
+
+    async def add_confidence_event(self, tracker_id: str, event: ConfidenceEvent) -> None:
+        self.events.setdefault(tracker_id, []).append(event)
+
+    async def get_confidence_events(self, tracker_id: str) -> list[ConfidenceEvent]:
+        return self.events.get(tracker_id, [])
+
+    async def all_raids_merged(self, phase_tracker_id: str) -> bool:
+        return False
+
+    async def list_phases_for_saga(self, saga_tracker_id: str) -> list[Phase]:
+        return []
+
+    async def update_phase_status(self, phase_tracker_id: str, status: PhaseStatus) -> Phase | None:
+        return None
+
+    async def get_saga_for_raid(self, tracker_id: str) -> Saga | None:
+        return None
+
+    async def get_phase_for_raid(self, tracker_id: str) -> Phase | None:
+        return None
+
+    async def get_owner_for_raid(self, tracker_id: str) -> str | None:
+        return None
+
+    async def save_session_message(self, message: SessionMessage) -> None:
+        pass
+
+    async def get_session_messages(self, tracker_id: str) -> list[SessionMessage]:
+        return []
+
+    async def add_comment(self, issue_id: str, body: str) -> None:
+        self.comments.append((issue_id, body))
+
+    async def attach_issue_document(self, issue_id: str, title: str, content: str) -> str:
+        return ""
+
+
+class StubTrackerFactory:
+    def __init__(self, tracker: StubTracker) -> None:
+        self._tracker = tracker
+
+    async def for_owner(self, owner_id: str) -> list[StubTracker]:
+        return [self._tracker]
+
+
+class StubVolundr(VolundrPort):
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, str]] = []
+        self.spawned: list[SpawnRequest] = []
+        self.fail_spawn: bool = False
+
+    async def spawn_session(
+        self, request: SpawnRequest, *, auth_token: str | None = None
+    ) -> VolundrSession:
+        if self.fail_spawn:
+            raise RuntimeError("Spawn failed")
+        self.spawned.append(request)
+        return VolundrSession(
+            id="planner-session-1",
+            name=request.name,
+            status="running",
+            tracker_issue_id=request.tracker_issue_id,
+        )
+
+    async def get_session(
+        self, session_id: str, *, auth_token: str | None = None
+    ) -> VolundrSession | None:
+        return VolundrSession(
+            id=session_id,
+            name="s",
+            status="running",
+            tracker_issue_id=None,
+            repo="org/repo",
+            branch="raid/test",
+            base_branch="feat/test",
+        )
+
+    async def list_sessions(self, *, auth_token: str | None = None) -> list[VolundrSession]:
+        return []
+
+    async def get_pr_status(self, session_id: str):
+        raise NotImplementedError
+
+    async def get_chronicle_summary(self, session_id: str) -> str:
+        return ""
+
+    async def send_message(
+        self, session_id: str, message: str, *, auth_token: str | None = None
+    ) -> None:
+        self.messages.append((session_id, message))
+
+    async def stop_session(self, session_id, *, auth_token=None):
+        pass
+
+    async def list_integration_ids(self, *, auth_token=None) -> list[str]:
+        return []
+
+    async def list_repos(self, *, auth_token: str | None = None) -> list[dict]:
+        return []
+
+    async def get_conversation(self, session_id: str) -> dict:
+        return {"turns": []}
+
+    async def get_last_assistant_message(self, session_id: str) -> str:
+        return ""
+
+    async def subscribe_activity(self) -> AsyncGenerator[ActivityEvent, None]:
+        return
+        yield  # type: ignore[misc]  # pragma: no cover
+
+
+class StubVolundrFactory:
+    def __init__(self, volundr: StubVolundr) -> None:
+        self._volundr = volundr
+
+    async def for_owner(self, owner_id: str) -> list[StubVolundr]:
+        return [self._volundr]
+
+
+class StubDispatcherRepo:
+    def __init__(self, owner_ids: list[str] | None = None) -> None:
+        self._owner_ids = owner_ids or []
+
+    async def get_or_create(self, owner_id: str):
+        raise NotImplementedError
+
+    async def update(self, owner_id: str, **fields):
+        raise NotImplementedError
+
+    async def list_active_owner_ids(self) -> list[str]:
+        return self._owner_ids
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_raid(
+    raid_id: UUID | None = None,
+    tracker_id: str = TRACKER_ID,
+    status: RaidStatus = RaidStatus.CONTRACTING,
+    confidence: float = 0.5,
+    session_id: str | None = "session-1",
+    planner_session_id: str | None = None,
+    acceptance_criteria: list[str] | None = None,
+    declared_files: list[str] | None = None,
+) -> Raid:
+    return Raid(
+        id=raid_id or uuid4(),
+        phase_id=PHASE_ID,
+        tracker_id=tracker_id,
+        name="Test raid",
+        description="A test raid for contract negotiation",
+        acceptance_criteria=acceptance_criteria or [],
+        declared_files=declared_files or [],
+        estimate_hours=2.0,
+        status=status,
+        confidence=confidence,
+        session_id=session_id,
+        branch="raid/test-branch",
+        chronicle_summary=None,
+        pr_url=None,
+        pr_id=None,
+        retry_count=0,
+        created_at=NOW,
+        updated_at=NOW,
+        identifier="NIU-100",
+        url="https://linear.app/niuu/issue/NIU-100",
+        planner_session_id=planner_session_id,
+    )
+
+
+def _make_engine(
+    tracker: StubTracker | None = None,
+    volundr: StubVolundr | None = None,
+    config: ContractConfig | None = None,
+    event_bus: InMemoryEventBus | None = None,
+    dispatcher_repo: StubDispatcherRepo | None = None,
+) -> tuple[ContractEngine, StubTracker, StubVolundr]:
+    tracker = tracker or StubTracker()
+    volundr = volundr or StubVolundr()
+    cfg = config or ContractConfig()
+    return (
+        ContractEngine(
+            tracker_factory=StubTrackerFactory(tracker),
+            volundr_factory=StubVolundrFactory(volundr),
+            contract_config=cfg,
+            event_bus=event_bus,
+            dispatcher_repo=dispatcher_repo,
+        ),
+        tracker,
+        volundr,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: parse_contract_response
+# ---------------------------------------------------------------------------
+
+
+class TestParseContractResponse:
+    def test_agreed_with_json_block(self) -> None:
+        text = (
+            "CONTRACT_AGREED\n```json\n"
+            '{"acceptance_criteria": ["test passes"], "declared_files": ["src/main.py"]}\n'
+            "```"
+        )
+        result = parse_contract_response(text)
+        assert result is not None
+        assert result["status"] == "agreed"
+        assert result["acceptance_criteria"] == ["test passes"]
+        assert result["declared_files"] == ["src/main.py"]
+
+    def test_failed_with_json_block(self) -> None:
+        text = 'CONTRACT_FAILED\n```json\n{"reason": "Could not agree on scope"}\n```'
+        result = parse_contract_response(text)
+        assert result is not None
+        assert result["status"] == "failed"
+        assert result["reason"] == "Could not agree on scope"
+
+    def test_returns_none_for_intermediate_idle(self) -> None:
+        text = "I'm still negotiating with the working session..."
+        result = parse_contract_response(text)
+        assert result is None
+
+    def test_returns_none_for_invalid_json(self) -> None:
+        text = "CONTRACT_AGREED\n```json\nnot-valid-json\n```"
+        result = parse_contract_response(text)
+        assert result is None
+
+    def test_returns_none_when_no_marker(self) -> None:
+        text = '```json\n{"acceptance_criteria": ["x"]}\n```'
+        result = parse_contract_response(text)
+        assert result is None
+
+    def test_agreed_with_multiple_criteria(self) -> None:
+        text = (
+            "CONTRACT_AGREED\n```json\n"
+            '{"acceptance_criteria": ["crit1", "crit2", "crit3"], '
+            '"declared_files": ["a.py", "b.py"]}\n'
+            "```"
+        )
+        result = parse_contract_response(text)
+        assert result is not None
+        assert len(result["acceptance_criteria"]) == 3
+        assert len(result["declared_files"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests: build_contract_initial_prompt
+# ---------------------------------------------------------------------------
+
+
+class TestBuildContractInitialPrompt:
+    def test_fallback_prompt(self) -> None:
+        prompt = build_contract_initial_prompt(
+            raid_tracker_id="NIU-100",
+            raid_name="Test raid",
+            raid_description="A test raid",
+            acceptance_criteria=["tests pass"],
+            declared_files=["src/main.py"],
+            working_session_id="ws-1",
+            max_rounds=3,
+        )
+        assert "NIU-100" in prompt
+        assert "Test raid" in prompt
+        assert "tests pass" in prompt
+        assert "src/main.py" in prompt
+        assert "ws-1" in prompt
+
+    def test_with_template(self) -> None:
+        template = "Ticket: {tracker_id}, Raid: {raid_name}, Rounds: {max_rounds}"
+        prompt = build_contract_initial_prompt(
+            raid_tracker_id="NIU-200",
+            raid_name="Another raid",
+            raid_description="desc",
+            acceptance_criteria=[],
+            declared_files=[],
+            working_session_id="ws-2",
+            max_rounds=5,
+            template=template,
+        )
+        assert prompt == "Ticket: NIU-200, Raid: Another raid, Rounds: 5"
+
+    def test_empty_criteria_and_files(self) -> None:
+        prompt = build_contract_initial_prompt(
+            raid_tracker_id="NIU-300",
+            raid_name="Bare raid",
+            raid_description="No criteria",
+            acceptance_criteria=[],
+            declared_files=[],
+            working_session_id="ws-3",
+            max_rounds=3,
+        )
+        assert "Existing Acceptance Criteria" not in prompt
+        assert "Declared Files" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# Tests: ContractEngine — agreed path
+# ---------------------------------------------------------------------------
+
+
+class TestContractAgreed:
+    @pytest.mark.asyncio
+    async def test_handle_agreed_updates_raid(self) -> None:
+        engine, tracker, volundr = _make_engine()
+        raid = _make_raid(planner_session_id="planner-1")
+        tracker.raids[TRACKER_ID] = raid
+        engine._contract_sessions["planner-1"] = (TRACKER_ID, OWNER_ID)
+
+        output = (
+            "CONTRACT_AGREED\n```json\n"
+            '{"acceptance_criteria": ["crit1", "crit2"], "declared_files": ["a.py"]}\n'
+            "```"
+        )
+        await engine.handle_contract_completion("planner-1", output)
+
+        updated = tracker.raids[TRACKER_ID]
+        assert updated.status == RaidStatus.RUNNING
+        assert updated.acceptance_criteria == ["crit1", "crit2"]
+        assert updated.declared_files == ["a.py"]
+
+    @pytest.mark.asyncio
+    async def test_handle_agreed_posts_comment(self) -> None:
+        engine, tracker, volundr = _make_engine()
+        raid = _make_raid(planner_session_id="planner-1")
+        tracker.raids[TRACKER_ID] = raid
+        engine._contract_sessions["planner-1"] = (TRACKER_ID, OWNER_ID)
+
+        output = (
+            "CONTRACT_AGREED\n```json\n"
+            '{"acceptance_criteria": ["crit1"], "declared_files": ["b.py"]}\n'
+            "```"
+        )
+        await engine.handle_contract_completion("planner-1", output)
+
+        assert len(tracker.comments) == 1
+        issue_id, body = tracker.comments[0]
+        assert issue_id == TRACKER_ID
+        assert "Sprint Contract Agreed" in body
+        assert "crit1" in body
+
+    @pytest.mark.asyncio
+    async def test_handle_agreed_cleans_up_session(self) -> None:
+        engine, tracker, volundr = _make_engine()
+        raid = _make_raid(planner_session_id="planner-1")
+        tracker.raids[TRACKER_ID] = raid
+        engine._contract_sessions["planner-1"] = (TRACKER_ID, OWNER_ID)
+        engine._contract_rounds["planner-1"] = 1
+
+        output = (
+            "CONTRACT_AGREED\n```json\n"
+            '{"acceptance_criteria": ["x"], "declared_files": ["y.py"]}\n'
+            "```"
+        )
+        await engine.handle_contract_completion("planner-1", output)
+
+        assert "planner-1" not in engine._contract_sessions
+        assert "planner-1" not in engine._contract_rounds
+
+    @pytest.mark.asyncio
+    async def test_handle_agreed_emits_events(self) -> None:
+        bus = InMemoryEventBus()
+        engine, tracker, volundr = _make_engine(event_bus=bus)
+        raid = _make_raid(planner_session_id="planner-1")
+        tracker.raids[TRACKER_ID] = raid
+        engine._contract_sessions["planner-1"] = (TRACKER_ID, OWNER_ID)
+
+        output = (
+            "CONTRACT_AGREED\n```json\n"
+            '{"acceptance_criteria": ["x"], "declared_files": ["y.py"]}\n'
+            "```"
+        )
+        await engine.handle_contract_completion("planner-1", output)
+
+        event_names = [e.event for e in bus.get_log(10)]
+        assert "contract.agreed" in event_names
+        assert "raid.state_changed" in event_names
+
+
+# ---------------------------------------------------------------------------
+# Tests: ContractEngine — failed path
+# ---------------------------------------------------------------------------
+
+
+class TestContractFailed:
+    @pytest.mark.asyncio
+    async def test_handle_failed_escalates_raid(self) -> None:
+        engine, tracker, volundr = _make_engine()
+        raid = _make_raid(planner_session_id="planner-1")
+        tracker.raids[TRACKER_ID] = raid
+        engine._contract_sessions["planner-1"] = (TRACKER_ID, OWNER_ID)
+
+        output = 'CONTRACT_FAILED\n```json\n{"reason": "Scope too ambiguous"}\n```'
+        await engine.handle_contract_completion("planner-1", output)
+
+        updated = tracker.raids[TRACKER_ID]
+        assert updated.status == RaidStatus.ESCALATED
+        assert "planner-1" not in engine._contract_sessions
+
+    @pytest.mark.asyncio
+    async def test_handle_failed_emits_events(self) -> None:
+        bus = InMemoryEventBus()
+        engine, tracker, volundr = _make_engine(event_bus=bus)
+        raid = _make_raid(planner_session_id="planner-1")
+        tracker.raids[TRACKER_ID] = raid
+        engine._contract_sessions["planner-1"] = (TRACKER_ID, OWNER_ID)
+
+        output = 'CONTRACT_FAILED\n```json\n{"reason": "Failed"}\n```'
+        await engine.handle_contract_completion("planner-1", output)
+
+        event_names = [e.event for e in bus.get_log(10)]
+        assert "contract.failed" in event_names
+        assert "raid.state_changed" in event_names
+
+
+# ---------------------------------------------------------------------------
+# Tests: ContractEngine — intermediate idle and max rounds
+# ---------------------------------------------------------------------------
+
+
+class TestIntermediateIdle:
+    @pytest.mark.asyncio
+    async def test_intermediate_idle_skipped(self) -> None:
+        engine, tracker, volundr = _make_engine()
+        raid = _make_raid(planner_session_id="planner-1")
+        tracker.raids[TRACKER_ID] = raid
+        engine._contract_sessions["planner-1"] = (TRACKER_ID, OWNER_ID)
+
+        await engine.handle_contract_completion(
+            "planner-1", "Still negotiating with the working session..."
+        )
+
+        # Raid should remain in CONTRACTING
+        assert tracker.raids[TRACKER_ID].status == RaidStatus.CONTRACTING
+        assert engine._contract_rounds["planner-1"] == 1
+        assert "planner-1" in engine._contract_sessions
+
+    @pytest.mark.asyncio
+    async def test_max_rounds_escalates(self) -> None:
+        cfg = ContractConfig(contract_max_rounds=2)
+        engine, tracker, volundr = _make_engine(config=cfg)
+        raid = _make_raid(planner_session_id="planner-1")
+        tracker.raids[TRACKER_ID] = raid
+        engine._contract_sessions["planner-1"] = (TRACKER_ID, OWNER_ID)
+
+        # Round 1 — just increments
+        await engine.handle_contract_completion("planner-1", "Still thinking...")
+        assert tracker.raids[TRACKER_ID].status == RaidStatus.CONTRACTING
+        assert engine._contract_rounds["planner-1"] == 1
+
+        # Round 2 — reaches max, escalates
+        await engine.handle_contract_completion("planner-1", "Still working on it...")
+        assert tracker.raids[TRACKER_ID].status == RaidStatus.ESCALATED
+        assert "planner-1" not in engine._contract_sessions
+
+
+# ---------------------------------------------------------------------------
+# Tests: ContractEngine — evaluate (spawn planner)
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluate:
+    @pytest.mark.asyncio
+    async def test_evaluate_spawns_planner(self) -> None:
+        engine, tracker, volundr = _make_engine()
+        raid = _make_raid()
+        tracker.raids[TRACKER_ID] = raid
+
+        await engine.evaluate(TRACKER_ID, OWNER_ID)
+
+        assert len(volundr.spawned) == 1
+        assert volundr.spawned[0].workload_type == "planner"
+        assert "planner-session-1" in engine._contract_sessions
+
+    @pytest.mark.asyncio
+    async def test_evaluate_sends_wait_prompt(self) -> None:
+        engine, tracker, volundr = _make_engine()
+        raid = _make_raid()
+        tracker.raids[TRACKER_ID] = raid
+
+        await engine.evaluate(TRACKER_ID, OWNER_ID)
+
+        # Wait prompt sent to the working session
+        wait_messages = [(sid, msg) for sid, msg in volundr.messages if "Stand by" in msg]
+        assert len(wait_messages) == 1
+
+    @pytest.mark.asyncio
+    async def test_evaluate_persists_planner_session_id(self) -> None:
+        engine, tracker, volundr = _make_engine()
+        raid = _make_raid()
+        tracker.raids[TRACKER_ID] = raid
+
+        await engine.evaluate(TRACKER_ID, OWNER_ID)
+
+        updated = tracker.raids[TRACKER_ID]
+        assert updated.planner_session_id == "planner-session-1"
+
+    @pytest.mark.asyncio
+    async def test_evaluate_disabled_skips(self) -> None:
+        cfg = ContractConfig(contract_enabled=False)
+        engine, tracker, volundr = _make_engine(config=cfg)
+        raid = _make_raid()
+        tracker.raids[TRACKER_ID] = raid
+
+        await engine.evaluate(TRACKER_ID, OWNER_ID)
+
+        assert len(volundr.spawned) == 0
+        assert len(engine._contract_sessions) == 0
+
+    @pytest.mark.asyncio
+    async def test_evaluate_spawn_failure_escalates(self) -> None:
+        engine, tracker, volundr = _make_engine()
+        volundr.fail_spawn = True
+        raid = _make_raid()
+        tracker.raids[TRACKER_ID] = raid
+
+        await engine.evaluate(TRACKER_ID, OWNER_ID)
+
+        assert tracker.raids[TRACKER_ID].status == RaidStatus.ESCALATED
+
+    @pytest.mark.asyncio
+    async def test_evaluate_wrong_status_raises(self) -> None:
+        engine, tracker, volundr = _make_engine()
+        raid = _make_raid(status=RaidStatus.RUNNING)
+        tracker.raids[TRACKER_ID] = raid
+
+        with pytest.raises(ValueError, match="not in CONTRACTING"):
+            await engine.evaluate(TRACKER_ID, OWNER_ID)
+
+
+# ---------------------------------------------------------------------------
+# Tests: ContractEngine — lifecycle (start/stop/rebuild)
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycle:
+    @pytest.mark.asyncio
+    async def test_start_stop(self) -> None:
+        bus = InMemoryEventBus()
+        engine, _, _ = _make_engine(event_bus=bus)
+
+        await engine.start()
+        assert engine.running
+
+        await engine.stop()
+        assert not engine.running
+
+    @pytest.mark.asyncio
+    async def test_rebuild_contract_sessions(self) -> None:
+        tracker = StubTracker()
+        raid = _make_raid(planner_session_id="planner-rebuild-1")
+        tracker.raids[TRACKER_ID] = raid
+
+        dispatcher_repo = StubDispatcherRepo(owner_ids=[OWNER_ID])
+        engine, _, _ = _make_engine(
+            tracker=tracker,
+            dispatcher_repo=dispatcher_repo,
+        )
+
+        await engine._rebuild_contract_sessions()
+
+        assert "planner-rebuild-1" in engine._contract_sessions
+        tid, oid = engine._contract_sessions["planner-rebuild-1"]
+        assert tid == TRACKER_ID
+        assert oid == OWNER_ID
+
+    @pytest.mark.asyncio
+    async def test_rebuild_ignores_raids_without_planner_session(self) -> None:
+        tracker = StubTracker()
+        raid = _make_raid(planner_session_id=None)
+        tracker.raids[TRACKER_ID] = raid
+
+        dispatcher_repo = StubDispatcherRepo(owner_ids=[OWNER_ID])
+        engine, _, _ = _make_engine(
+            tracker=tracker,
+            dispatcher_repo=dispatcher_repo,
+        )
+
+        await engine._rebuild_contract_sessions()
+
+        assert len(engine._contract_sessions) == 0
+
+    @pytest.mark.asyncio
+    async def test_get_contract_raid_returns_none_for_unknown(self) -> None:
+        engine, _, _ = _make_engine()
+        assert engine.get_contract_raid("unknown-session") is None
+
+    @pytest.mark.asyncio
+    async def test_get_contract_raid_returns_mapping(self) -> None:
+        engine, _, _ = _make_engine()
+        engine._contract_sessions["planner-1"] = (TRACKER_ID, OWNER_ID)
+        result = engine.get_contract_raid("planner-1")
+        assert result == (TRACKER_ID, OWNER_ID)
+
+
+# ---------------------------------------------------------------------------
+# Tests: ContractEngine — event-driven
+# ---------------------------------------------------------------------------
+
+
+class TestEventDriven:
+    @pytest.mark.asyncio
+    async def test_listen_reacts_to_contracting_event(self) -> None:
+        bus = InMemoryEventBus()
+        engine, tracker, volundr = _make_engine(event_bus=bus)
+        raid = _make_raid()
+        tracker.raids[TRACKER_ID] = raid
+
+        await engine.start()
+        await asyncio.sleep(0)  # yield so listener task subscribes
+
+        # Emit a CONTRACTING event
+        from tyr.ports.event_bus import TyrEvent
+
+        await bus.emit(
+            TyrEvent(
+                event="raid.state_changed",
+                owner_id=OWNER_ID,
+                data={"tracker_id": TRACKER_ID, "status": "CONTRACTING"},
+            )
+        )
+
+        # Give the listener task time to process
+        await asyncio.sleep(0.1)
+        await engine.stop()
+
+        # Engine should have spawned a planner session
+        assert len(volundr.spawned) == 1
+
+    @pytest.mark.asyncio
+    async def test_listen_ignores_non_contracting_events(self) -> None:
+        bus = InMemoryEventBus()
+        engine, tracker, volundr = _make_engine(event_bus=bus)
+        raid = _make_raid(status=RaidStatus.REVIEW)
+        tracker.raids[TRACKER_ID] = raid
+
+        await engine.start()
+        await asyncio.sleep(0)  # yield so listener task subscribes
+
+        from tyr.ports.event_bus import TyrEvent
+
+        await bus.emit(
+            TyrEvent(
+                event="raid.state_changed",
+                owner_id=OWNER_ID,
+                data={"tracker_id": TRACKER_ID, "status": "REVIEW"},
+            )
+        )
+
+        await asyncio.sleep(0.1)
+        await engine.stop()
+
+        assert len(volundr.spawned) == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: ContractConfig
+# ---------------------------------------------------------------------------
+
+
+class TestContractConfig:
+    def test_defaults(self) -> None:
+        cfg = ContractConfig()
+        assert cfg.contract_enabled is True
+        assert cfg.contract_model == "claude-sonnet-4-6"
+        assert cfg.contract_max_rounds == 3
+        assert cfg.contract_profile == "planner"
+        assert "Stand by" in cfg.working_session_wait_prompt
+
+    def test_override(self) -> None:
+        cfg = ContractConfig(contract_max_rounds=5, contract_enabled=False)
+        assert cfg.contract_max_rounds == 5
+        assert cfg.contract_enabled is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    @pytest.mark.asyncio
+    async def test_unknown_session_ignored(self) -> None:
+        engine, tracker, volundr = _make_engine()
+        # Should not raise
+        await engine.handle_contract_completion("unknown-session", "some output")
+
+    @pytest.mark.asyncio
+    async def test_raid_no_longer_contracting_skipped(self) -> None:
+        engine, tracker, volundr = _make_engine()
+        raid = _make_raid(status=RaidStatus.RUNNING, planner_session_id="planner-1")
+        tracker.raids[TRACKER_ID] = raid
+        engine._contract_sessions["planner-1"] = (TRACKER_ID, OWNER_ID)
+
+        output = (
+            "CONTRACT_AGREED\n```json\n"
+            '{"acceptance_criteria": ["x"], "declared_files": ["y.py"]}\n'
+            "```"
+        )
+        await engine.handle_contract_completion("planner-1", output)
+
+        # Session should be cleaned up but status unchanged
+        assert tracker.raids[TRACKER_ID].status == RaidStatus.RUNNING
+        assert "planner-1" not in engine._contract_sessions
+
+    @pytest.mark.asyncio
+    async def test_evaluate_no_working_session(self) -> None:
+        """Evaluate succeeds even when the raid has no session_id."""
+        engine, tracker, volundr = _make_engine()
+        raid = _make_raid(session_id=None)
+        tracker.raids[TRACKER_ID] = raid
+
+        await engine.evaluate(TRACKER_ID, OWNER_ID)
+
+        assert len(volundr.spawned) == 1
+        # No wait prompt sent since no working session
+        assert len(volundr.messages) == 0
+
+
+class TestParseContractResponseAdditional:
+    """Additional parser tests for coverage of edge-case branches."""
+
+    def test_agreed_without_code_fence(self) -> None:
+        """CONTRACT_AGREED with raw JSON (no code fence) — fallback parsing."""
+        text = 'CONTRACT_AGREED\n{"acceptance_criteria": ["a"], "declared_files": ["b.py"]}'
+        result = parse_contract_response(text)
+        assert result is not None
+        assert result["status"] == "agreed"
+        assert result["acceptance_criteria"] == ["a"]
+
+    def test_non_dict_json_returns_none(self) -> None:
+        text = "CONTRACT_AGREED\n```json\n[1, 2, 3]\n```"
+        result = parse_contract_response(text)
+        assert result is None
+
+    def test_non_list_criteria_returns_none(self) -> None:
+        text = (
+            "CONTRACT_AGREED\n```json\n"
+            '{"acceptance_criteria": "not a list", "declared_files": []}\n'
+            "```"
+        )
+        result = parse_contract_response(text)
+        assert result is None
+
+    def test_failed_without_code_fence(self) -> None:
+        text = 'CONTRACT_FAILED\n{"reason": "too vague"}'
+        result = parse_contract_response(text)
+        assert result is not None
+        assert result["status"] == "failed"
+        assert result["reason"] == "too vague"

--- a/tests/test_tyr/test_review_engine.py
+++ b/tests/test_tyr/test_review_engine.py
@@ -170,6 +170,11 @@ class StubTracker(TrackerPort):
         phase_tracker_id: str | None = None,
         saga_tracker_id: str | None = None,
         chronicle_summary: str | None = None,
+        reviewer_session_id: str | None = None,
+        review_round: int | None = None,
+        planner_session_id: str | None = None,
+        acceptance_criteria: list[str] | None = None,
+        declared_files: list[str] | None = None,
     ) -> Raid:
         raid = self.raids.get(tracker_id)
         if raid is None:

--- a/tests/test_tyr/test_telegram_webhook.py
+++ b/tests/test_tyr/test_telegram_webhook.py
@@ -180,6 +180,11 @@ class StubTracker(TrackerPort):
         phase_tracker_id: str | None = None,
         saga_tracker_id: str | None = None,
         chronicle_summary: str | None = None,
+        reviewer_session_id: str | None = None,
+        review_round: int | None = None,
+        planner_session_id: str | None = None,
+        acceptance_criteria: list[str] | None = None,
+        declared_files: list[str] | None = None,
     ) -> Raid:
         raid = self._tracker_id_map.get(tracker_id)
         if raid is None:


### PR DESCRIPTION
## Summary

- **ContractEngine** (`tyr/domain/services/contract_engine.py`) — mirrors `ReviewEngine` structure with `start/stop/_listen/_rebuild` lifecycle, spawns planner sessions for raids entering `CONTRACTING`, handles `CONTRACT_AGREED`/`CONTRACT_FAILED` completion callbacks
- **ContractConfig** added to `tyr/config.py` with `contract_enabled`, `contract_model`, `contract_max_rounds`, `contract_profile`, `working_session_wait_prompt`, and prompt templates
- **TrackerPort.update_raid_progress()** extended with `acceptance_criteria` and `declared_files` kwargs (native + linear adapters updated, migration 000020)
- **39 unit tests** covering agreed path, failed path, intermediate idle, max rounds escalation, evaluate/spawn, lifecycle rebuild, event-driven listener, and edge cases (89% coverage on contract_engine)

## Test plan

- [x] `parse_contract_response` handles `CONTRACT_AGREED`, `CONTRACT_FAILED`, intermediate idle, invalid JSON, no-marker, raw JSON fallback
- [x] `handle_contract_completion` agreed path: updates raid criteria/files, transitions to RUNNING, posts Linear comment, emits events
- [x] `handle_contract_completion` failed path: escalates to ESCALATED, emits events
- [x] Intermediate idle increments round counter; max rounds triggers escalation
- [x] `evaluate` spawns planner session, sends wait prompt, persists planner_session_id
- [x] `evaluate` with disabled config skips; spawn failure escalates; wrong status raises
- [x] Lifecycle: start/stop, rebuild from DB, get_contract_raid lookups
- [x] Event-driven: listener reacts to CONTRACTING events, ignores others
- [x] All 973 existing tests pass (no regressions)

Closes NIU-332

🤖 Generated with [Claude Code](https://claude.com/claude-code)