### PR TITLE
feat(tyr): route planner idle events to ContractEngine

### DIFF
--- a/src/tyr/domain/services/activity_subscriber.py
+++ b/src/tyr/domain/services/activity_subscriber.py
@@ -28,6 +28,7 @@ from tyr.ports.tracker import TrackerFactory, TrackerPort  # noqa: F401 — re-e
 from tyr.ports.volundr import ActivityEvent, VolundrFactory, VolundrPort
 
 if TYPE_CHECKING:
+    from tyr.domain.services.contract_engine import ContractEngine
     from tyr.domain.services.review_engine import ReviewEngine
 
 logger = logging.getLogger(__name__)
@@ -60,6 +61,7 @@ class SessionActivitySubscriber:
         event_bus: EventBusPort,
         config: WatcherConfig,
         review_engine: ReviewEngine | None = None,
+        contract_engine: ContractEngine | None = None,
     ) -> None:
         self._factory = volundr_factory
         self._tracker_factory = tracker_factory
@@ -67,6 +69,7 @@ class SessionActivitySubscriber:
         self._event_bus = event_bus
         self._config = config
         self._review_engine = review_engine
+        self._contract_engine = contract_engine
         self._running = False
         self._task: asyncio.Task[None] | None = None
         self._owner_tasks: dict[str, list[asyncio.Task[None]]] = {}
@@ -270,8 +273,9 @@ class SessionActivitySubscriber:
 
         raid, tracker = await self._find_raid_for_session(event.session_id, owner_id)
         if raid is None or tracker is None:
-            # Check if this is a reviewer session completing
+            # Check if this is a reviewer or contract planner session completing
             await self._try_handle_reviewer_completion(event.session_id, volundr)
+            await self._try_handle_contract_completion(event.session_id, volundr)
             return
 
         # Working session idle during an active review loop (round >= 1) —
@@ -283,6 +287,13 @@ class SessionActivitySubscriber:
                 "Working session %s idle during review loop (round %d) — reviewer drives",
                 event.session_id[:8],
                 raid.review_round,
+            )
+            return
+
+        if raid.status == RaidStatus.CONTRACTING:
+            logger.info(
+                "Working session %s idle during CONTRACTING — waiting for contract",
+                event.session_id[:8],
             )
             return
 
@@ -500,6 +511,33 @@ class SessionActivitySubscriber:
         except Exception:
             logger.warning(
                 "Failed to handle reviewer completion for session %s",
+                session_id,
+                exc_info=True,
+            )
+
+    async def _try_handle_contract_completion(self, session_id: str, volundr: VolundrPort) -> None:
+        """If the session is a tracked contract planner, fetch its output and delegate."""
+        if self._contract_engine is None:
+            return
+
+        if self._contract_engine.get_contract_raid(session_id) is None:
+            return
+
+        try:
+            output = await volundr.get_last_assistant_message(session_id)
+        except Exception:
+            logger.error(
+                "Failed to fetch contract output for session %s",
+                session_id,
+                exc_info=True,
+            )
+            raise
+
+        try:
+            await self._contract_engine.handle_contract_completion(session_id, output)
+        except Exception:
+            logger.warning(
+                "Failed to handle contract completion for session %s",
                 session_id,
                 exc_info=True,
             )

--- a/src/tyr/main.py
+++ b/src/tyr/main.py
@@ -329,6 +329,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 dispatcher_repo=dispatcher_repo,
             )
             app.state.contract_engine = contract_engine
+            await contract_engine.start()
 
             # Wire event-driven session completion subscriber
             # Uses VolundrAdapterFactory for per-owner authenticated SSE subscriptions
@@ -348,6 +349,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             yield
 
             # Lifecycle cleanup
+            await contract_engine.stop()
             await review_engine.stop()
             await notification_service.stop()
             await telegram_reply_client.close()

--- a/src/tyr/main.py
+++ b/src/tyr/main.py
@@ -45,6 +45,7 @@ from tyr.api.sagas import resolve_volundr as sagas_resolve_volundr
 from tyr.api.tracker import create_tracker_router, resolve_trackers
 from tyr.config import Settings
 from tyr.domain.services.activity_subscriber import SessionActivitySubscriber
+from tyr.domain.services.contract_engine import ContractEngine
 from tyr.domain.services.notification import NotificationService
 from tyr.domain.services.review_engine import ReviewEngine
 from tyr.domain.services.reviewer_session import ReviewerSessionService
@@ -130,9 +131,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             app.state.credential_store = credential_store
 
             # Wire adapter factories (used by autonomous dispatcher)
-            app.state.volundr_factory = VolundrAdapterFactory(
-                integration_repo, credential_store
-            )
+            app.state.volundr_factory = VolundrAdapterFactory(integration_repo, credential_store)
             app.state.tracker_factory = TrackerAdapterFactory(
                 integration_repo, credential_store, pool=pool
             )
@@ -321,6 +320,16 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             app.state.review_engine = review_engine
             await review_engine.start()
 
+            # Wire contract engine (planner-driven sprint contracts)
+            contract_engine = ContractEngine(
+                tracker_factory=app.state.tracker_factory,
+                volundr_factory=app.state.volundr_factory,
+                contract_config=settings.contract,
+                event_bus=event_bus,
+                dispatcher_repo=dispatcher_repo,
+            )
+            app.state.contract_engine = contract_engine
+
             # Wire event-driven session completion subscriber
             # Uses VolundrAdapterFactory for per-owner authenticated SSE subscriptions
             subscriber = SessionActivitySubscriber(
@@ -330,6 +339,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 event_bus=event_bus,
                 config=settings.watcher,
                 review_engine=review_engine,
+                contract_engine=contract_engine,
             )
             app.state.subscriber = subscriber
             await subscriber.start()

--- a/tests/test_tyr/test_activity_subscriber.py
+++ b/tests/test_tyr/test_activity_subscriber.py
@@ -1445,3 +1445,133 @@ class TestResolveOwnerAdapters:
         # Second call returns cached
         cached = await sub._resolve_owner_adapters("owner-1")
         assert cached is result
+
+
+# ---------------------------------------------------------------------------
+# Tests — Contract completion routing
+# ---------------------------------------------------------------------------
+
+
+class StubContractEngine:
+    """Minimal stub mirroring ContractEngine for subscriber tests."""
+
+    def __init__(self) -> None:
+        self._sessions: dict[str, tuple[str, str]] = {}
+        self.completions: list[tuple[str, str]] = []
+
+    def register(self, session_id: str, tracker_id: str, owner_id: str) -> None:
+        self._sessions[session_id] = (tracker_id, owner_id)
+
+    def get_contract_raid(self, session_id: str) -> tuple[str, str] | None:
+        return self._sessions.get(session_id)
+
+    async def handle_contract_completion(self, session_id: str, planner_output: str) -> None:
+        self.completions.append((session_id, planner_output))
+
+
+class TestContractCompletionRouting:
+    @pytest.mark.asyncio
+    async def test_planner_idle_triggers_contract_completion(self) -> None:
+        """Idle event for a tracked contract planner session calls handle_contract_completion."""
+        contract_engine = StubContractEngine()
+        planner_session = "planner-session-1"
+        contract_engine.register(planner_session, "tracker-1", "user-1")
+
+        sub, volundr, tracker, _ = _make_subscriber()
+        sub._contract_engine = contract_engine
+
+        volundr.sessions[planner_session] = _make_volundr_session(
+            session_id=planner_session,
+        )
+
+        event = ActivityEvent(
+            session_id=planner_session,
+            state="idle",
+            metadata={"turn_count": 3, "duration_seconds": 10},
+            owner_id="user-1",
+        )
+        await sub._on_activity_event(event, volundr, owner_id="user-1")
+        await asyncio.sleep(0.1)
+
+        assert len(contract_engine.completions) == 1
+        assert contract_engine.completions[0][0] == planner_session
+
+    @pytest.mark.asyncio
+    async def test_untracked_session_does_not_trigger_contract_completion(self) -> None:
+        """Idle event for a session not tracked by contract engine is ignored."""
+        contract_engine = StubContractEngine()
+
+        sub, volundr, tracker, _ = _make_subscriber()
+        sub._contract_engine = contract_engine
+
+        event = ActivityEvent(
+            session_id="unknown-session",
+            state="idle",
+            metadata={"turn_count": 3, "duration_seconds": 10},
+            owner_id="user-1",
+        )
+        await sub._on_activity_event(event, volundr, owner_id="user-1")
+        await asyncio.sleep(0.1)
+
+        assert len(contract_engine.completions) == 0
+
+    @pytest.mark.asyncio
+    async def test_no_contract_engine_does_not_crash(self) -> None:
+        """When contract_engine is None, idle events for unknown sessions do not crash."""
+        sub, volundr, tracker, _ = _make_subscriber()
+        assert sub._contract_engine is None
+
+        event = ActivityEvent(
+            session_id="orphan-session",
+            state="idle",
+            metadata={"turn_count": 3, "duration_seconds": 10},
+            owner_id="user-1",
+        )
+        await sub._on_activity_event(event, volundr, owner_id="user-1")
+        await asyncio.sleep(0.1)
+        # No crash
+
+
+# ---------------------------------------------------------------------------
+# Tests — CONTRACTING guard
+# ---------------------------------------------------------------------------
+
+
+class TestContractingGuard:
+    @pytest.mark.asyncio
+    async def test_working_session_idle_during_contracting_not_evaluated(self) -> None:
+        """Working session idle in CONTRACTING state should return early — no completion."""
+        sub, volundr, tracker, _ = _make_subscriber()
+        raid = _make_raid(status=RaidStatus.CONTRACTING)
+        tracker.add_raid(raid)
+
+        event = ActivityEvent(
+            session_id=raid.session_id or "",
+            state="idle",
+            metadata={"turn_count": 5, "duration_seconds": 60},
+            owner_id="user-1",
+        )
+        await sub._on_activity_event(event, volundr, owner_id="user-1")
+        await asyncio.sleep(0.1)
+
+        # Status should remain CONTRACTING — no transition to REVIEW
+        assert tracker.progress[raid.tracker_id]["status"] == RaidStatus.CONTRACTING
+
+    @pytest.mark.asyncio
+    async def test_running_session_still_evaluates_normally(self) -> None:
+        """Working session idle in RUNNING state should still evaluate for completion."""
+        sub, volundr, tracker, _ = _make_subscriber()
+        raid = _make_raid(status=RaidStatus.RUNNING)
+        tracker.add_raid(raid)
+
+        event = ActivityEvent(
+            session_id=raid.session_id or "",
+            state="idle",
+            metadata={"turn_count": 5, "duration_seconds": 60},
+            owner_id="user-1",
+        )
+        await sub._on_activity_event(event, volundr, owner_id="user-1")
+        await asyncio.sleep(0.1)
+
+        # Should transition to REVIEW as normal
+        assert tracker.progress[raid.tracker_id]["status"] == RaidStatus.REVIEW

--- a/tests/test_tyr/test_activity_subscriber.py
+++ b/tests/test_tyr/test_activity_subscriber.py
@@ -1516,6 +1516,44 @@ class TestContractCompletionRouting:
         assert len(contract_engine.completions) == 0
 
     @pytest.mark.asyncio
+    async def test_contract_fetch_error_raises(self) -> None:
+        """Error fetching contract output should propagate (re-raised)."""
+        contract_engine = StubContractEngine()
+        planner_session = "planner-err-1"
+        contract_engine.register(planner_session, "tracker-1", "user-1")
+
+        class FailingVolundr(StubVolundr):
+            async def get_last_assistant_message(self, session_id: str) -> str:
+                raise RuntimeError("fetch failed")
+
+        failing_volundr = FailingVolundr()
+        sub, _, tracker, _ = _make_subscriber()
+        sub._contract_engine = contract_engine
+
+        with pytest.raises(RuntimeError, match="fetch failed"):
+            await sub._try_handle_contract_completion(planner_session, failing_volundr)
+
+        assert len(contract_engine.completions) == 0
+
+    @pytest.mark.asyncio
+    async def test_contract_handle_error_is_swallowed(self) -> None:
+        """Error in handle_contract_completion should be logged, not raised."""
+
+        class FailingContractEngine(StubContractEngine):
+            async def handle_contract_completion(self, session_id: str, output: str) -> None:
+                raise RuntimeError("handle failed")
+
+        contract_engine = FailingContractEngine()
+        planner_session = "planner-err-2"
+        contract_engine.register(planner_session, "tracker-1", "user-1")
+
+        sub, volundr, tracker, _ = _make_subscriber()
+        sub._contract_engine = contract_engine
+
+        # Should not raise
+        await sub._try_handle_contract_completion(planner_session, volundr)
+
+    @pytest.mark.asyncio
     async def test_no_contract_engine_does_not_crash(self) -> None:
         """When contract_engine is None, idle events for unknown sessions do not crash."""
         sub, volundr, tracker, _ = _make_subscriber()


### PR DESCRIPTION
## Summary
- Inject `ContractEngine` into `SessionActivitySubscriber` alongside existing `ReviewEngine`
- Add `_try_handle_contract_completion` method (mirrors `_try_handle_reviewer_completion`) to route planner session idle events to `ContractEngine.handle_contract_completion`
- Extend `_debounced_evaluation` to call both reviewer and contract try-handlers when no raid is found for an idle session
- Guard working sessions in `CONTRACTING` state from completion evaluation (they're waiting for the planner)
- Wire `ContractEngine` instantiation in `main.py`, passing it to the subscriber

## Test plan
- [x] Planner idle → `handle_contract_completion` called
- [x] Untracked session → contract completion not triggered
- [x] No contract engine (None) → no crash on idle events
- [x] Working session idle during CONTRACTING → no evaluation (status stays CONTRACTING)
- [x] RUNNING sessions still evaluate normally
- [x] All 54 existing + new tests pass
- [x] Ruff lint and format clean

Closes NIU-333

🤖 Generated with [Claude Code](https://claude.com/claude-code)