### PR TITLE
feat(tyr): wire CONTRACTING status into dispatch with dual-spawn

### DIFF
--- a/src/tyr/api/dispatch.py
+++ b/src/tyr/api/dispatch.py
@@ -17,6 +17,7 @@ from niuu.domain.models import IntegrationType, Principal
 from tyr.adapters.inbound.auth import extract_bearer_token, extract_principal
 from tyr.api.tracker import resolve_trackers
 from tyr.domain.models import RaidStatus, TrackerIssue
+from tyr.domain.services.contract_engine import build_contract_initial_prompt
 from tyr.ports.saga_repository import SagaRepository
 from tyr.ports.tracker import TrackerPort
 from tyr.ports.volundr import SpawnRequest, VolundrFactory, VolundrPort
@@ -165,16 +166,21 @@ def _build_prompt(
     repo: str,
     feature_branch: str,
     template: str = "",
+    *,
+    wait_for_contract: bool = False,
+    wait_prompt: str = "",
 ) -> str:
     """Build the initial prompt for a session from a tracker issue.
 
     Uses the configurable template if provided, otherwise falls back to
-    a minimal default.
+    a minimal default.  When *wait_for_contract* is True the
+    *wait_prompt* is prepended so the working session pauses until the
+    contract planner delivers a CONTRACT_AGREED message.
     """
     raid_branch = issue.identifier.lower()
 
     if template:
-        return template.format(
+        body = template.format(
             identifier=issue.identifier,
             title=issue.title,
             description=issue.description or "",
@@ -182,21 +188,26 @@ def _build_prompt(
             feature_branch=feature_branch,
             raid_branch=raid_branch,
         )
+    else:
+        # Minimal fallback when no template is configured.
+        parts = [
+            f"# Task: {issue.identifier} — {issue.title}",
+            "",
+            issue.description or "",
+            "",
+            f"Repository: {repo}",
+            f"Feature branch: {feature_branch}",
+            f"Create a working branch: `{raid_branch}`",
+            "",
+            "Implement the task, write tests, create a PR against"
+            f" `{feature_branch}`, and ensure CI passes.",
+        ]
+        body = "\n".join(parts)
 
-    # Minimal fallback when no template is configured.
-    parts = [
-        f"# Task: {issue.identifier} — {issue.title}",
-        "",
-        issue.description or "",
-        "",
-        f"Repository: {repo}",
-        f"Feature branch: {feature_branch}",
-        f"Create a working branch: `{raid_branch}`",
-        "",
-        "Implement the task, write tests, create a PR against"
-        f" `{feature_branch}`, and ensure CI passes.",
-    ]
-    return "\n".join(parts)
+    if wait_for_contract and wait_prompt:
+        return wait_prompt + "\n\n---\n\n" + body
+
+    return body
 
 
 # ---------------------------------------------------------------------------
@@ -388,8 +399,10 @@ def create_dispatch_router() -> APIRouter:
             target_volundr = _resolve_target_adapter(target_connection, adapter_by_name, volundr)
 
             session_name = issue.identifier.lower()
+            contract_enabled = settings.contract.contract_enabled
 
             try:
+                # Spawn the working session — with wait prompt when contracting
                 session = await target_volundr.spawn_session(
                     request=SpawnRequest(
                         name=session_name,
@@ -401,33 +414,74 @@ def create_dispatch_router() -> APIRouter:
                         tracker_issue_url=issue.url,
                         system_prompt=effective_prompt,
                         initial_prompt=_build_prompt(
-                            issue, item.repo, saga.feature_branch,
+                            issue,
+                            item.repo,
+                            saga.feature_branch,
                             template=settings.dispatch.dispatch_prompt_template,
+                            wait_for_contract=contract_enabled,
+                            wait_prompt=settings.contract.working_session_wait_prompt,
                         ),
                         integration_ids=integration_ids,
                     ),
                     auth_token=auth_token,
                 )
-                # Record raid progress and set tracker issue to In Progress
+
+                if contract_enabled:
+                    # Dual-spawn: transition QUEUED → CONTRACTING and spawn planner
+                    target_status = RaidStatus.CONTRACTING
+
+                    # Spawn planner session
+                    planner_session = await target_volundr.spawn_session(
+                        request=SpawnRequest(
+                            name=f"contract-{session_name}",
+                            repo=item.repo,
+                            branch=saga.feature_branch,
+                            base_branch=saga.base_branch,
+                            model=settings.contract.contract_model,
+                            tracker_issue_id=issue.identifier,
+                            tracker_issue_url=issue.url,
+                            system_prompt=settings.contract.contract_system_prompt,
+                            initial_prompt=build_contract_initial_prompt(
+                                raid_tracker_id=issue.identifier,
+                                raid_name=issue.title,
+                                raid_description=issue.description or "",
+                                acceptance_criteria=[],
+                                declared_files=[],
+                                working_session_id=session.id,
+                                max_rounds=settings.contract.contract_max_rounds,
+                                template=settings.contract.contract_initial_prompt_template,
+                            ),
+                            workload_type="contract",
+                            profile=settings.contract.contract_profile,
+                            integration_ids=integration_ids,
+                        ),
+                        auth_token=auth_token,
+                    )
+                else:
+                    target_status = RaidStatus.RUNNING
+                    planner_session = None
+
+                # Record raid progress and set tracker issue status
                 for adapter in adapters:
                     try:
                         await adapter.update_raid_progress(
                             issue.id,
-                            status=RaidStatus.RUNNING,
+                            status=target_status,
                             session_id=session.id,
                             owner_id=principal.user_id,
                             phase_tracker_id=issue.milestone_id,
                             saga_tracker_id=saga.tracker_id,
+                            planner_session_id=(planner_session.id if planner_session else None),
                         )
                     except Exception:
                         logger.warning(
                             "Failed to update raid progress for %s", issue.id, exc_info=True
                         )
                     try:
-                        await adapter.update_raid_state(issue.id, RaidStatus.RUNNING)
+                        await adapter.update_raid_state(issue.id, target_status)
                     except Exception:
                         logger.warning(
-                            "Failed to set tracker issue %s to In Progress", issue.id, exc_info=True
+                            "Failed to set tracker issue %s status", issue.id, exc_info=True
                         )
 
                 results.append(
@@ -439,7 +493,12 @@ def create_dispatch_router() -> APIRouter:
                         cluster_name=session.cluster_name,
                     )
                 )
-                logger.info("Dispatched %s → session %s", issue.identifier, session.id)
+                logger.info(
+                    "Dispatched %s → session %s%s",
+                    issue.identifier,
+                    session.id,
+                    f" (contract planner: {planner_session.id})" if planner_session else "",
+                )
             except Exception:
                 logger.error("Failed to spawn session for %s", issue.identifier, exc_info=True)
                 results.append(

--- a/tests/test_tyr/test_dispatch_api.py
+++ b/tests/test_tyr/test_dispatch_api.py
@@ -25,7 +25,7 @@ from tyr.api.dispatch import (
     resolve_volundr_factory,
 )
 from tyr.api.tracker import resolve_trackers
-from tyr.config import AIModelConfig, AuthConfig, Settings
+from tyr.config import AIModelConfig, AuthConfig, ContractConfig, Settings
 from tyr.config import DispatchConfig as DispatchCfg
 from tyr.domain.models import (
     Saga,
@@ -162,6 +162,7 @@ class MockVolundrFactory:
 def _make_settings(**overrides) -> Settings:
     """Build a Settings with dispatch defaults and anonymous dev enabled."""
     overrides.setdefault("auth", AuthConfig(allow_anonymous_dev=True))
+    overrides.setdefault("contract", ContractConfig(contract_enabled=False))
     return Settings(
         dispatch=DispatchCfg(
             default_system_prompt="Be helpful.",
@@ -262,7 +263,7 @@ def saga_repo() -> MockSagaRepo:
             status=SagaStatus.ACTIVE,
             confidence=0.0,
             created_at=datetime.now(UTC),
-        base_branch="dev",
+            base_branch="dev",
         )
     )
     return repo
@@ -432,6 +433,67 @@ class TestBuildPrompt:
         assert "Implement OAuth" in prompt
         assert "niu-42" in prompt  # raid_branch is lowercased identifier
         assert "feat/saga" in prompt
+
+    def test_wait_for_contract_prepends_wait_prompt(self):
+        issue = TrackerIssue(
+            id="1",
+            identifier="X-1",
+            title="Task",
+            description="Do stuff",
+            status="Todo",
+        )
+        wait = "Stand by for contract."
+        prompt = _build_prompt(
+            issue,
+            "org/repo",
+            "feat/alpha",
+            wait_for_contract=True,
+            wait_prompt=wait,
+        )
+        assert prompt.startswith(wait)
+        assert "\n\n---\n\n" in prompt
+        # Original content still present after the separator
+        assert "X-1" in prompt
+        assert "Task" in prompt
+
+    def test_wait_for_contract_false_no_prepend(self):
+        issue = TrackerIssue(
+            id="1",
+            identifier="X-1",
+            title="Task",
+            description="Do stuff",
+            status="Todo",
+        )
+        prompt = _build_prompt(
+            issue,
+            "org/repo",
+            "feat/alpha",
+            wait_for_contract=False,
+            wait_prompt="should not appear",
+        )
+        assert "should not appear" not in prompt
+
+    def test_wait_for_contract_with_template(self):
+        issue = TrackerIssue(
+            id="1",
+            identifier="NIU-10",
+            title="Auth",
+            description="OAuth flow",
+            status="Todo",
+        )
+        template = "Task: {identifier}\n{description}"
+        wait = "Contract pending."
+        prompt = _build_prompt(
+            issue,
+            "org/repo",
+            "feat/saga",
+            template=template,
+            wait_for_contract=True,
+            wait_prompt=wait,
+        )
+        assert prompt.startswith("Contract pending.\n\n---\n\n")
+        assert "NIU-10" in prompt
+        assert "OAuth flow" in prompt
 
 
 # -------------------------------------------------------------------
@@ -843,6 +905,223 @@ class TestApproveDispatch:
         data = resp.json()
         assert len(data) == 1
         assert data[0]["status"] == "spawned"
+
+
+# -------------------------------------------------------------------
+# Contract dispatch tests
+# -------------------------------------------------------------------
+
+
+class TestContractDispatch:
+    """Tests for dual-spawn contract negotiation at dispatch time."""
+
+    def _make_contract_client(
+        self,
+        mock_tracker: MockTracker,
+        mock_volundr: MockVolundr,
+        saga_repo: MockSagaRepo,
+        *,
+        contract_enabled: bool = True,
+    ) -> TestClient:
+        app = FastAPI()
+        app.include_router(create_dispatch_router())
+        app.state.settings = _make_settings(
+            contract=ContractConfig(contract_enabled=contract_enabled),
+        )
+        app.dependency_overrides[resolve_trackers] = lambda: [mock_tracker]
+        app.dependency_overrides[resolve_saga_repo] = lambda: saga_repo
+        app.dependency_overrides[resolve_volundr] = lambda: mock_volundr
+        app.dependency_overrides[resolve_volundr_factory] = lambda: MockVolundrFactory()
+        return app, TestClient(app)
+
+    def test_contract_enabled_spawns_two_sessions(
+        self,
+        mock_tracker: MockTracker,
+        mock_volundr: MockVolundr,
+        saga_repo: MockSagaRepo,
+    ):
+        """contract_enabled=True spawns working + planner sessions."""
+        _, client = self._make_contract_client(
+            mock_tracker,
+            mock_volundr,
+            saga_repo,
+            contract_enabled=True,
+        )
+        saga_id = str(saga_repo.sagas[0].id)
+        resp = client.post(
+            "/api/v1/tyr/dispatch/approve",
+            json={
+                "items": [
+                    {"saga_id": saga_id, "issue_id": "i-1", "repo": "org/repo-a"},
+                ],
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["status"] == "spawned"
+
+        # Two sessions: working + planner
+        assert len(mock_volundr.spawned) == 2
+
+        working_req = mock_volundr.spawned[0]
+        planner_req = mock_volundr.spawned[1]
+
+        # Working session has wait prompt prepended
+        assert "Stand by" in working_req.initial_prompt
+        assert "---" in working_req.initial_prompt
+        assert working_req.workload_type == "default"
+
+        # Planner session uses contract config
+        assert planner_req.workload_type == "contract"
+        assert planner_req.profile == "planner"
+        assert planner_req.name == "contract-alpha-1"
+        assert "Sprint Contract" in planner_req.initial_prompt
+
+    def test_contract_disabled_spawns_one_session(
+        self,
+        mock_tracker: MockTracker,
+        mock_volundr: MockVolundr,
+        saga_repo: MockSagaRepo,
+    ):
+        """contract_enabled=False uses existing QUEUED→RUNNING path."""
+        _, client = self._make_contract_client(
+            mock_tracker,
+            mock_volundr,
+            saga_repo,
+            contract_enabled=False,
+        )
+        saga_id = str(saga_repo.sagas[0].id)
+        resp = client.post(
+            "/api/v1/tyr/dispatch/approve",
+            json={
+                "items": [
+                    {"saga_id": saga_id, "issue_id": "i-1", "repo": "org/repo-a"},
+                ],
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["status"] == "spawned"
+
+        # Only one session (working), no planner
+        assert len(mock_volundr.spawned) == 1
+        req = mock_volundr.spawned[0]
+        assert "Stand by" not in req.initial_prompt
+        assert req.workload_type == "default"
+
+    def test_contract_enabled_working_session_id_in_planner_prompt(
+        self,
+        mock_tracker: MockTracker,
+        mock_volundr: MockVolundr,
+        saga_repo: MockSagaRepo,
+    ):
+        """Planner initial prompt contains the working session ID."""
+        _, client = self._make_contract_client(
+            mock_tracker,
+            mock_volundr,
+            saga_repo,
+            contract_enabled=True,
+        )
+        saga_id = str(saga_repo.sagas[0].id)
+        client.post(
+            "/api/v1/tyr/dispatch/approve",
+            json={
+                "items": [
+                    {"saga_id": saga_id, "issue_id": "i-1", "repo": "org/repo-a"},
+                ],
+            },
+        )
+        planner_req = mock_volundr.spawned[1]
+        # The working session id is "ses-1" (first spawn)
+        assert "ses-1" in planner_req.initial_prompt
+
+    def test_contract_enabled_planner_uses_contract_model(
+        self,
+        mock_tracker: MockTracker,
+        mock_volundr: MockVolundr,
+        saga_repo: MockSagaRepo,
+    ):
+        """Planner session uses the contract model, not the dispatch model."""
+        _, client = self._make_contract_client(
+            mock_tracker,
+            mock_volundr,
+            saga_repo,
+            contract_enabled=True,
+        )
+        saga_id = str(saga_repo.sagas[0].id)
+        client.post(
+            "/api/v1/tyr/dispatch/approve",
+            json={
+                "items": [
+                    {"saga_id": saga_id, "issue_id": "i-1", "repo": "org/repo-a"},
+                ],
+                "model": "claude-opus-4-6",
+            },
+        )
+        working_req = mock_volundr.spawned[0]
+        planner_req = mock_volundr.spawned[1]
+
+        # Working session uses the request model
+        assert working_req.model == "claude-opus-4-6"
+        # Planner uses contract config model (default: claude-sonnet-4-6)
+        assert planner_req.model == "claude-sonnet-4-6"
+
+    def test_contract_enabled_result_returns_working_session_id(
+        self,
+        mock_tracker: MockTracker,
+        mock_volundr: MockVolundr,
+        saga_repo: MockSagaRepo,
+    ):
+        """DispatchResult returns the working session, not the planner."""
+        _, client = self._make_contract_client(
+            mock_tracker,
+            mock_volundr,
+            saga_repo,
+            contract_enabled=True,
+        )
+        saga_id = str(saga_repo.sagas[0].id)
+        resp = client.post(
+            "/api/v1/tyr/dispatch/approve",
+            json={
+                "items": [
+                    {"saga_id": saga_id, "issue_id": "i-1", "repo": "org/repo-a"},
+                ],
+            },
+        )
+        data = resp.json()
+        # The result should have the working session id (ses-1), not planner (ses-2)
+        assert data[0]["session_id"] == "ses-1"
+
+    def test_contract_enabled_multiple_items(
+        self,
+        mock_tracker: MockTracker,
+        mock_volundr: MockVolundr,
+        saga_repo: MockSagaRepo,
+    ):
+        """Multiple items with contract_enabled spawns two sessions per item."""
+        _, client = self._make_contract_client(
+            mock_tracker,
+            mock_volundr,
+            saga_repo,
+            contract_enabled=True,
+        )
+        saga_id = str(saga_repo.sagas[0].id)
+        resp = client.post(
+            "/api/v1/tyr/dispatch/approve",
+            json={
+                "items": [
+                    {"saga_id": saga_id, "issue_id": "i-1", "repo": "org/repo-a"},
+                    {"saga_id": saga_id, "issue_id": "i-3", "repo": "org/repo-b"},
+                ],
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2
+        # 4 total: 2 working + 2 planner
+        assert len(mock_volundr.spawned) == 4
 
 
 # -------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Modified `_build_prompt()` to accept `wait_for_contract` and `wait_prompt` kwargs — when enabled, the wait prompt is prepended with a `---` separator so the working session pauses until CONTRACT_AGREED arrives.
- When `contract_enabled=True`, the dispatch loop now spawns **two** sessions per item: the working session (with wait prompt) and a planner session (`workload_type="contract"`, `profile="planner"`). The raid transitions `QUEUED→CONTRACTING` with `planner_session_id` stored.
- When `contract_enabled=False`, the existing `QUEUED→RUNNING` path is completely unchanged.
- Added 9 new tests covering both contract-enabled and contract-disabled paths, plus `_build_prompt` wait-for-contract behaviour.

## Test plan

- [x] `_build_prompt()` with `wait_for_contract=True` prepends wait prompt
- [x] `_build_prompt()` with `wait_for_contract=False` has no wait prompt
- [x] `_build_prompt()` with template + `wait_for_contract=True` works correctly
- [x] `contract_enabled=True` → 2 sessions spawned per item (working + planner)
- [x] `contract_enabled=False` → 1 session per item (existing behaviour)
- [x] Planner prompt contains the working session ID
- [x] Planner uses contract model, not dispatch model
- [x] DispatchResult returns working session ID, not planner
- [x] Multiple items with contract enabled spawn correct number of sessions
- [x] All 48 tests pass, dispatch.py coverage 90%

Closes NIU-334

🤖 Generated with [Claude Code](https://claude.com/claude-code)