### PR TITLE
feat(tyr): add Raid.launch_command — parse from Linear, propagate to reviewer

### DIFF
--- a/charts/tyr/templates/migrations-configmap.yaml
+++ b/charts/tyr/templates/migrations-configmap.yaml
@@ -400,4 +400,12 @@ data:
   000020_raid_contract_fields.down.sql: |
     ALTER TABLE raid_progress DROP COLUMN IF EXISTS declared_files;
     ALTER TABLE raid_progress DROP COLUMN IF EXISTS acceptance_criteria;
+
+  000021_raid_launch_command.up.sql: |
+    ALTER TABLE raids ADD COLUMN IF NOT EXISTS launch_command TEXT;
+    ALTER TABLE raid_progress ADD COLUMN IF NOT EXISTS launch_command TEXT;
+
+  000021_raid_launch_command.down.sql: |
+    ALTER TABLE raids DROP COLUMN IF EXISTS launch_command;
+    ALTER TABLE raid_progress DROP COLUMN IF EXISTS launch_command;
 {{- end }}

--- a/migrations/tyr/000021_raid_launch_command.down.sql
+++ b/migrations/tyr/000021_raid_launch_command.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE raids DROP COLUMN IF EXISTS launch_command;
+ALTER TABLE raid_progress DROP COLUMN IF EXISTS launch_command;

--- a/migrations/tyr/000021_raid_launch_command.up.sql
+++ b/migrations/tyr/000021_raid_launch_command.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE raids ADD COLUMN IF NOT EXISTS launch_command TEXT;
+ALTER TABLE raid_progress ADD COLUMN IF NOT EXISTS launch_command TEXT;

--- a/src/tyr/adapters/linear.py
+++ b/src/tyr/adapters/linear.py
@@ -7,6 +7,7 @@ Maps: Project=Saga, Milestone=Phase, Issue=Raid.
 from __future__ import annotations
 
 import logging
+import re
 from datetime import UTC, datetime
 from uuid import UUID, uuid4, uuid5
 
@@ -673,6 +674,7 @@ class LinearTrackerAdapter(TrackerPort):
         planner_session_id: str | None = None,
         acceptance_criteria: list[str] | None = None,
         declared_files: list[str] | None = None,
+        launch_command: str | None = None,
     ) -> Raid:
         if self._pool is None:
             raise RuntimeError("pool is required for update_raid_progress")
@@ -682,10 +684,12 @@ class LinearTrackerAdapter(TrackerPort):
                 (tracker_id, status, session_id, confidence, pr_url, pr_id,
                  retry_count, reason, owner_id, phase_tracker_id, saga_tracker_id,
                  chronicle_summary, reviewer_session_id, review_round,
-                 planner_session_id, acceptance_criteria, declared_files)
+                 planner_session_id, acceptance_criteria, declared_files,
+                 launch_command)
             VALUES ($1, COALESCE($2, 'PENDING'), $3, $4, $5, $6,
                     COALESCE($7, 0), $8, $9, $10, $11, $12, $13,
-                    COALESCE($14, 0), $15, COALESCE($16, '{}'), COALESCE($17, '{}'))
+                    COALESCE($14, 0), $15, COALESCE($16, '{}'), COALESCE($17, '{}'),
+                    $18)
             ON CONFLICT (tracker_id) DO UPDATE SET
                 status              = COALESCE($2, raid_progress.status),
                 session_id          = COALESCE($3, raid_progress.session_id),
@@ -703,6 +707,7 @@ class LinearTrackerAdapter(TrackerPort):
                 planner_session_id  = COALESCE($15, raid_progress.planner_session_id),
                 acceptance_criteria = COALESCE($16, raid_progress.acceptance_criteria),
                 declared_files      = COALESCE($17, raid_progress.declared_files),
+                launch_command      = COALESCE($18, raid_progress.launch_command),
                 updated_at          = NOW()
             """,
             tracker_id,
@@ -722,6 +727,7 @@ class LinearTrackerAdapter(TrackerPort):
             planner_session_id,
             acceptance_criteria,
             declared_files,
+            launch_command,
         )
         if status is not None:
             try:
@@ -1032,11 +1038,12 @@ class LinearTrackerAdapter(TrackerPort):
     @staticmethod
     def _node_to_tracker_issue(node: dict) -> TrackerIssue:
         state = node.get("state") or {}
+        description = node.get("description") or ""
         return TrackerIssue(
             id=node["id"],
             identifier=node.get("identifier", ""),
             title=node.get("title", ""),
-            description=node.get("description") or "",
+            description=description,
             status=state.get("name", "Unknown"),
             status_type=state.get("type", ""),
             assignee=(node.get("assignee") or {}).get("name"),
@@ -1046,6 +1053,7 @@ class LinearTrackerAdapter(TrackerPort):
             estimate=node.get("estimate"),
             url=node.get("url", ""),
             milestone_id=(node.get("projectMilestone") or {}).get("id"),
+            launch_command=_parse_launch_command(description),
         )
 
     @staticmethod
@@ -1093,12 +1101,8 @@ class LinearTrackerAdapter(TrackerPort):
             url=node.get("url", ""),
             name=node.get("title", ""),
             description=node.get("description") or "",
-            acceptance_criteria=list(progress.get("acceptance_criteria") or [])
-            if progress
-            else [],
-            declared_files=list(progress.get("declared_files") or [])
-            if progress
-            else [],
+            acceptance_criteria=list(progress.get("acceptance_criteria") or []) if progress else [],
+            declared_files=list(progress.get("declared_files") or []) if progress else [],
             estimate_hours=None,
             status=raid_status,
             confidence=float(progress["confidence"])
@@ -1119,7 +1123,20 @@ class LinearTrackerAdapter(TrackerPort):
             if progress and progress.get("review_round")
             else 0,
             planner_session_id=progress.get("planner_session_id") if progress else None,
+            launch_command=progress.get("launch_command") if progress else None,
         )
+
+
+_LAUNCH_BLOCK_RE = re.compile(r"```launch\s*\n(.*?)```", re.DOTALL)
+
+
+def _parse_launch_command(description: str) -> str | None:
+    """Extract the launch command from a ```launch fenced block in the description."""
+    match = _LAUNCH_BLOCK_RE.search(description)
+    if not match:
+        return None
+    command = match.group(1).strip()
+    return command or None
 
 
 def _parse_progress(value: object) -> float:

--- a/src/tyr/adapters/native.py
+++ b/src/tyr/adapters/native.py
@@ -254,6 +254,7 @@ class NativeTrackerAdapter(TrackerPort):
         planner_session_id: str | None = None,
         acceptance_criteria: list[str] | None = None,
         declared_files: list[str] | None = None,
+        launch_command: str | None = None,
     ) -> Raid:
         row = await self._pool.fetchrow(
             """
@@ -271,6 +272,7 @@ class NativeTrackerAdapter(TrackerPort):
                 planner_session_id  = COALESCE($12, planner_session_id),
                 acceptance_criteria = COALESCE($13, acceptance_criteria),
                 declared_files      = COALESCE($14, declared_files),
+                launch_command      = COALESCE($15, launch_command),
                 updated_at          = NOW()
             WHERE tracker_id = $1
             RETURNING *
@@ -289,6 +291,7 @@ class NativeTrackerAdapter(TrackerPort):
             planner_session_id,
             acceptance_criteria,
             declared_files,
+            launch_command,
         )
         if row is None:
             raise LookupError(f"Raid not found: {tracker_id}")
@@ -551,6 +554,7 @@ class NativeTrackerAdapter(TrackerPort):
             reviewer_session_id=row.get("reviewer_session_id"),
             review_round=row.get("review_round", 0) or 0,
             planner_session_id=row.get("planner_session_id"),
+            launch_command=row.get("launch_command"),
         )
 
     async def _saga_row_to_project(self, row: asyncpg.Record) -> TrackerProject:

--- a/src/tyr/api/dispatch.py
+++ b/src/tyr/api/dispatch.py
@@ -472,6 +472,7 @@ def create_dispatch_router() -> APIRouter:
                             phase_tracker_id=issue.milestone_id,
                             saga_tracker_id=saga.tracker_id,
                             planner_session_id=(planner_session.id if planner_session else None),
+                            launch_command=issue.launch_command,
                         )
                     except Exception:
                         logger.warning(

--- a/src/tyr/domain/models.py
+++ b/src/tyr/domain/models.py
@@ -144,6 +144,7 @@ class Raid:
     reviewer_session_id: str | None = None
     review_round: int = 0
     planner_session_id: str | None = None
+    launch_command: str | None = None
 
 
 @dataclass(frozen=True)
@@ -245,6 +246,7 @@ class TrackerIssue:
     estimate: float | None = None
     url: str = ""
     milestone_id: str | None = None
+    launch_command: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/src/tyr/domain/services/reviewer_session.py
+++ b/src/tyr/domain/services/reviewer_session.py
@@ -87,16 +87,16 @@ def _build_review_loop_section(
         "2. Send detailed feedback to the working session:\n"
         f"   `curl -s -X POST http://localhost:8081/api/message "
         f'-H "Content-Type: application/json" '
-        f"-d '{{\"session_id\": \"{working_session_id}\", \"content\": \"<FEEDBACK>\"}}'`\n"
+        f'-d \'{{"session_id": "{working_session_id}", "content": "<FEEDBACK>"}}\'`\n'
         "3. In your feedback, tell the working session to:\n"
         "   a. Fix the issues\n"
         "   b. `git add` and `git commit` the fixes\n"
         "   c. `git push` to update the PR\n"
         "   d. Notify you when done by running:\n"
         "      `curl -s -X POST http://localhost:8081/api/message "
-        "-H \"Content-Type: application/json\" "
-        "-d '{\"session_id\": \"<YOUR_SESSION_ID>\", "
-        "\"content\": \"Fixed. Please pull and re-review.\"}'`\n"
+        '-H "Content-Type: application/json" '
+        '-d \'{"session_id": "<YOUR_SESSION_ID>", '
+        '"content": "Fixed. Please pull and re-review."}\'`\n'
         "      where <YOUR_SESSION_ID> is `$MY_ID`\n"
         "4. When the working session responds, run `git pull` to get the latest changes\n"
         "5. Re-read the diff and re-review\n"
@@ -114,6 +114,7 @@ def build_reviewer_initial_prompt(
     working_session_id: str = "",
     max_review_rounds: int = 6,
     template: str = "",
+    launch_command: str | None = None,
 ) -> str:
     """Build the initial prompt sent to the reviewer session.
 
@@ -124,13 +125,12 @@ def build_reviewer_initial_prompt(
         "tracker_id": raid.tracker_id,
         "raid_name": raid.name,
         "raid_description": raid.description,
+        "launch_command": launch_command or "",
         "acceptance_criteria_section": _build_acceptance_criteria_section(raid),
         "pr_section": _build_pr_section(pr_status),
         "changed_files_section": _build_changed_files_section(changed_files),
         "diff_summary_section": _build_diff_summary_section(diff_summary),
-        "review_loop_section": _build_review_loop_section(
-            working_session_id, max_review_rounds
-        ),
+        "review_loop_section": _build_review_loop_section(working_session_id, max_review_rounds),
     }
 
     if template:
@@ -322,6 +322,7 @@ class ReviewerSessionService:
             working_session_id=working_session.id if working_session else "",
             max_review_rounds=self._cfg.max_review_rounds,
             template=self._cfg.reviewer_initial_prompt_template,
+            launch_command=raid.launch_command,
         )
 
         request = SpawnRequest(
@@ -395,11 +396,13 @@ class ReviewerSessionService:
         ]
         for finding in result.findings:
             feedback_lines.append(f"- {finding}")
-        feedback_lines.extend([
-            "",
-            "After fixing, `git add`, `git commit`, and `git push` your changes,",
-            "then notify the reviewer that the fixes are ready for re-review.",
-        ])
+        feedback_lines.extend(
+            [
+                "",
+                "After fixing, `git add`, `git commit`, and `git push` your changes,",
+                "then notify the reviewer that the fixes are ready for re-review.",
+            ]
+        )
 
         try:
             await volundr.send_message(raid.session_id, "\n".join(feedback_lines))

--- a/src/tyr/ports/tracker.py
+++ b/src/tyr/ports/tracker.py
@@ -116,6 +116,7 @@ class TrackerPort(ABC):
         planner_session_id: str | None = None,
         acceptance_criteria: list[str] | None = None,
         declared_files: list[str] | None = None,
+        launch_command: str | None = None,
     ) -> Raid: ...
 
     @abstractmethod

--- a/tests/test_tyr/test_activity_subscriber.py
+++ b/tests/test_tyr/test_activity_subscriber.py
@@ -188,6 +188,7 @@ class StubTracker(TrackerPort):
         planner_session_id: str | None = None,
         acceptance_criteria: list[str] | None = None,
         declared_files: list[str] | None = None,
+        launch_command: str | None = None,
     ) -> Raid:
         entry = self.progress.setdefault(tracker_id, {})
         if status is not None:
@@ -223,6 +224,9 @@ class StubTracker(TrackerPort):
                     retry_count=raid.retry_count,
                     created_at=raid.created_at,
                     updated_at=datetime.now(UTC),
+                    launch_command=launch_command
+                    if launch_command is not None
+                    else raid.launch_command,
                 )
                 if raid.session_id:
                     self.raids_by_session[raid.session_id] = updated

--- a/tests/test_tyr/test_contract_engine.py
+++ b/tests/test_tyr/test_contract_engine.py
@@ -118,6 +118,7 @@ class StubTracker(TrackerPort):
         planner_session_id: str | None = None,
         acceptance_criteria: list[str] | None = None,
         declared_files: list[str] | None = None,
+        launch_command: str | None = None,
     ) -> Raid:
         raid = self.raids.get(tracker_id)
         if raid is None:
@@ -152,6 +153,7 @@ class StubTracker(TrackerPort):
             planner_session_id=planner_session_id
             if planner_session_id is not None
             else raid.planner_session_id,
+            launch_command=launch_command if launch_command is not None else raid.launch_command,
         )
         self.raids[tracker_id] = updated
         return updated

--- a/tests/test_tyr/test_linear_adapter.py
+++ b/tests/test_tyr/test_linear_adapter.py
@@ -14,6 +14,7 @@ from tyr.adapters.linear import (
     _LINEAR_TO_RAID,
     _RAID_TO_LINEAR,
     LinearTrackerAdapter,
+    _parse_launch_command,
     _parse_progress,
 )
 from tyr.domain.models import (
@@ -290,7 +291,7 @@ class TestCreateSaga:
             status=SagaStatus.ACTIVE,
             confidence=0.0,
             created_at=now,
-        base_branch="dev",
+            base_branch="dev",
         )
 
         result = await adapter.create_saga(saga)
@@ -315,7 +316,7 @@ class TestCreateSaga:
             status=SagaStatus.ACTIVE,
             confidence=0.0,
             created_at=now,
-        base_branch="dev",
+            base_branch="dev",
         )
 
         with pytest.raises(GraphQLError, match="Failed to create Linear project"):
@@ -1685,3 +1686,111 @@ class TestIssueToRaid:
         }
         raid = LinearTrackerAdapter._issue_to_raid(node, progress=progress)
         assert raid.status == RaidStatus.RUNNING
+
+
+# ---------------------------------------------------------------------------
+# _parse_launch_command
+# ---------------------------------------------------------------------------
+
+
+class TestParseLaunchCommand:
+    def test_with_launch_block(self):
+        description = (
+            "Some description\n\n"
+            "```launch\n"
+            "uvicorn src.myapp.main:app --port 8000\n"
+            "```\n\n"
+            "More text."
+        )
+        assert _parse_launch_command(description) == "uvicorn src.myapp.main:app --port 8000"
+
+    def test_without_launch_block(self):
+        description = "Just a normal description with no launch block."
+        assert _parse_launch_command(description) is None
+
+    def test_empty_description(self):
+        assert _parse_launch_command("") is None
+
+    def test_empty_launch_block(self):
+        description = "```launch\n\n```"
+        assert _parse_launch_command(description) is None
+
+    def test_multiline_launch_command(self):
+        description = "```launch\ncd /app && \\\nuvicorn main:app --port 8000\n```"
+        result = _parse_launch_command(description)
+        assert result == "cd /app && \\\nuvicorn main:app --port 8000"
+
+    def test_launch_block_with_surrounding_content(self):
+        description = (
+            "# Issue Title\n\n"
+            "Description here.\n\n"
+            "```launch\n"
+            "npm run dev\n"
+            "```\n\n"
+            "```python\n"
+            "print('not this')\n"
+            "```"
+        )
+        assert _parse_launch_command(description) == "npm run dev"
+
+
+# ---------------------------------------------------------------------------
+# _node_to_tracker_issue: launch_command parsing
+# ---------------------------------------------------------------------------
+
+
+class TestNodeToTrackerIssueLaunchCommand:
+    def test_issue_with_launch_block(self):
+        node = _issue_node(description="Desc\n\n```launch\nuvicorn app:main --port 8000\n```")
+        issue = LinearTrackerAdapter._node_to_tracker_issue(node)
+        assert issue.launch_command == "uvicorn app:main --port 8000"
+
+    def test_issue_without_launch_block(self):
+        node = _issue_node(description="A plain description")
+        issue = LinearTrackerAdapter._node_to_tracker_issue(node)
+        assert issue.launch_command is None
+
+    def test_issue_with_no_description(self):
+        node = _issue_node(description=None)
+        issue = LinearTrackerAdapter._node_to_tracker_issue(node)
+        assert issue.launch_command is None
+
+
+# ---------------------------------------------------------------------------
+# _issue_to_raid: launch_command from progress
+# ---------------------------------------------------------------------------
+
+
+class TestIssueToRaidLaunchCommand:
+    def test_launch_command_from_progress(self):
+        node = _issue_node()
+        progress = {
+            "status": "RUNNING",
+            "launch_command": "make serve",
+            "confidence": None,
+            "session_id": None,
+            "pr_url": None,
+            "pr_id": None,
+            "retry_count": None,
+        }
+        raid = LinearTrackerAdapter._issue_to_raid(node, progress=progress)
+        assert raid.launch_command == "make serve"
+
+    def test_launch_command_null_in_progress(self):
+        node = _issue_node()
+        progress = {
+            "status": "RUNNING",
+            "launch_command": None,
+            "confidence": None,
+            "session_id": None,
+            "pr_url": None,
+            "pr_id": None,
+            "retry_count": None,
+        }
+        raid = LinearTrackerAdapter._issue_to_raid(node, progress=progress)
+        assert raid.launch_command is None
+
+    def test_launch_command_no_progress(self):
+        node = _issue_node()
+        raid = LinearTrackerAdapter._issue_to_raid(node, progress=None)
+        assert raid.launch_command is None

--- a/tests/test_tyr/test_review_engine.py
+++ b/tests/test_tyr/test_review_engine.py
@@ -175,6 +175,7 @@ class StubTracker(TrackerPort):
         planner_session_id: str | None = None,
         acceptance_criteria: list[str] | None = None,
         declared_files: list[str] | None = None,
+        launch_command: str | None = None,
     ) -> Raid:
         raid = self.raids.get(tracker_id)
         if raid is None:
@@ -200,6 +201,7 @@ class StubTracker(TrackerPort):
             retry_count=retry_count if retry_count is not None else raid.retry_count,
             created_at=raid.created_at,
             updated_at=datetime.now(UTC),
+            launch_command=launch_command if launch_command is not None else raid.launch_command,
         )
         self.raids[tracker_id] = updated
         return updated

--- a/tests/test_tyr/test_reviewer_session.py
+++ b/tests/test_tyr/test_reviewer_session.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncGenerator
+from dataclasses import replace
 from datetime import UTC, datetime
 from uuid import uuid4
 
@@ -406,6 +407,29 @@ class TestBuildReviewerInitialPrompt:
         )
         assert "Refactored auth module" in prompt
 
+    def test_launch_command_in_template_sections(self) -> None:
+        raid = _make_raid()
+        prompt = build_reviewer_initial_prompt(
+            raid=raid,
+            pr_status=None,
+            changed_files=[],
+            diff_summary="",
+            template="{launch_command}",
+            launch_command="uvicorn app:main --port 8000",
+        )
+        assert prompt == "uvicorn app:main --port 8000"
+
+    def test_launch_command_defaults_to_empty(self) -> None:
+        raid = _make_raid()
+        prompt = build_reviewer_initial_prompt(
+            raid=raid,
+            pr_status=None,
+            changed_files=[],
+            diff_summary="",
+            template="{launch_command}",
+        )
+        assert prompt == ""
+
 
 # ---------------------------------------------------------------------------
 # Tests: reviewer_system_prompt config field
@@ -509,6 +533,22 @@ class TestSpawnReviewer:
 
         assert len(volundr.spawn_calls) == 1
         assert "Implemented auth flow" in volundr.spawn_calls[0].initial_prompt
+
+    @pytest.mark.asyncio
+    async def test_spawn_passes_launch_command(self) -> None:
+        service, volundr = _make_service(
+            config=_default_config(reviewer_initial_prompt_template="cmd:{launch_command}"),
+        )
+        raid = replace(_make_raid(), launch_command="make serve")
+
+        session = await service.spawn_reviewer(
+            raid=raid,
+            owner_id=OWNER_ID,
+            pr_status=None,
+            changed_files=[],
+        )
+        assert session is not None
+        assert "make serve" in volundr.spawn_calls[0].initial_prompt
 
     @pytest.mark.asyncio
     async def test_spawn_with_no_chronicle(self) -> None:

--- a/tests/test_tyr/test_telegram_webhook.py
+++ b/tests/test_tyr/test_telegram_webhook.py
@@ -185,6 +185,7 @@ class StubTracker(TrackerPort):
         planner_session_id: str | None = None,
         acceptance_criteria: list[str] | None = None,
         declared_files: list[str] | None = None,
+        launch_command: str | None = None,
     ) -> Raid:
         raid = self._tracker_id_map.get(tracker_id)
         if raid is None:
@@ -212,6 +213,7 @@ class StubTracker(TrackerPort):
             retry_count=retry_count if retry_count is not None else raid.retry_count,
             created_at=raid.created_at,
             updated_at=datetime.now(UTC),
+            launch_command=launch_command if launch_command is not None else raid.launch_command,
         )
         self.raids[raid.id] = updated
         self._tracker_id_map[tracker_id] = updated


### PR DESCRIPTION
## Summary
- Adds `launch_command: str | None` to `Raid` and `TrackerIssue` domain models
- Parses ````launch` fenced blocks from Linear issue descriptions to populate the field
- Propagates `launch_command` through `update_raid_progress` (port + both adapters) and `dispatch.approve_dispatch`
- Passes `launch_command` to `build_reviewer_initial_prompt` for reviewer sessions to boot and exercise the app during QA
- Migration 000021 adds nullable `launch_command` column to `raids` and `raid_progress` tables
- Helm chart migrations-configmap updated

## Changes
| File | Change |
|------|--------|
| `src/tyr/domain/models.py` | Add `launch_command` to `Raid` and `TrackerIssue` |
| `src/tyr/ports/tracker.py` | Add `launch_command` kwarg to `update_raid_progress` |
| `src/tyr/adapters/native.py` | COALESCE update + `_row_to_raid` mapping |
| `src/tyr/adapters/linear.py` | COALESCE update + `_issue_to_raid` + `_parse_launch_command` + `_node_to_tracker_issue` |
| `src/tyr/api/dispatch.py` | Pass `launch_command` from tracker issue to `update_raid_progress` |
| `src/tyr/domain/services/reviewer_session.py` | Accept and forward `launch_command` in prompt builder + spawn |
| `migrations/tyr/000021_*` | Up/down migration for both tables |
| `charts/tyr/templates/migrations-configmap.yaml` | Embed migration SQL |
| `tests/test_tyr/test_linear_adapter.py` | Tests for `_parse_launch_command`, `_node_to_tracker_issue`, `_issue_to_raid` |
| `tests/test_tyr/test_reviewer_session.py` | Tests for `launch_command` in prompt builder and `spawn_reviewer` |

## Test plan
- [x] `_parse_launch_command` with/without launch block, empty, multiline
- [x] `_node_to_tracker_issue` populates `launch_command` from description
- [x] `_issue_to_raid` reads `launch_command` from progress dict
- [x] `build_reviewer_initial_prompt` includes `launch_command` in template sections
- [x] `spawn_reviewer` passes `launch_command` through to prompt
- [x] All 1004 tyr tests pass, 90% coverage (above 85% threshold)

Closes NIU-335

🤖 Generated with [Claude Code](https://claude.com/claude-code)