### PR TITLE
feat(tyr): add runtime QA section to reviewer prompt

### DIFF
--- a/src/tyr/domain/services/reviewer_session.py
+++ b/src/tyr/domain/services/reviewer_session.py
@@ -106,6 +106,43 @@ def _build_review_loop_section(
     )
 
 
+def _build_runtime_qa_section(launch_command: str | None) -> str:
+    if not launch_command:
+        return ""
+    return (
+        "## Runtime QA\n"
+        "\n"
+        "Start the application before reviewing code:\n"
+        "\n"
+        "```bash\n"
+        f"{launch_command} &\n"
+        "APP_PID=$!\n"
+        "until curl -sf http://localhost:8000/health 2>/dev/null; do sleep 1; done\n"
+        'echo "App ready"\n'
+        "```\n"
+        "\n"
+        "For **each acceptance criterion**, make at least one verifiable assertion:\n"
+        "\n"
+        "* `curl -sf http://localhost:8000/...` for API endpoints\n"
+        "* `pytest -x -q` if a test suite exists\n"
+        "* Check database state where relevant\n"
+        "\n"
+        "Score **deductions** (mandatory — do not skip):\n"
+        "\n"
+        "* App won't start → confidence −0.4, approved=false\n"
+        "* Test suite red (any failure) → confidence −0.3, approved=false\n"
+        "* Criterion not exercised → confidence −0.1 per criterion\n"
+        "* HTTP 4xx/5xx on criterion exercise → confidence −0.2 per criterion\n"
+        "\n"
+        "Kill the app before finishing:\n"
+        "\n"
+        "```bash\n"
+        "kill $APP_PID 2>/dev/null || true\n"
+        "```\n"
+        "\n"
+    )
+
+
 def build_reviewer_initial_prompt(
     raid: Raid,
     pr_status: PRStatus | None,
@@ -131,6 +168,7 @@ def build_reviewer_initial_prompt(
         "changed_files_section": _build_changed_files_section(changed_files),
         "diff_summary_section": _build_diff_summary_section(diff_summary),
         "review_loop_section": _build_review_loop_section(working_session_id, max_review_rounds),
+        "runtime_qa_section": _build_runtime_qa_section(launch_command),
     }
 
     if template:
@@ -147,6 +185,7 @@ def build_reviewer_initial_prompt(
         f"{sections['changed_files_section']}"
         f"{sections['diff_summary_section']}"
         f"{sections['review_loop_section']}"
+        f"{sections['runtime_qa_section']}"
         "Review the PR and output your assessment as JSON."
     )
 

--- a/tests/test_tyr/test_reviewer_session.py
+++ b/tests/test_tyr/test_reviewer_session.py
@@ -430,6 +430,80 @@ class TestBuildReviewerInitialPrompt:
         )
         assert prompt == ""
 
+    def test_runtime_qa_section_present_when_launch_command_set(self) -> None:
+        raid = _make_raid()
+        prompt = build_reviewer_initial_prompt(
+            raid=raid,
+            pr_status=None,
+            changed_files=[],
+            diff_summary="",
+            launch_command="uvicorn app:main --port 8000",
+        )
+        assert "## Runtime QA" in prompt
+        assert "uvicorn app:main --port 8000" in prompt
+        assert "APP_PID=$!" in prompt
+        assert "confidence −0.4" in prompt
+        assert "kill $APP_PID" in prompt
+
+    def test_runtime_qa_section_absent_when_launch_command_none(self) -> None:
+        raid = _make_raid()
+        prompt = build_reviewer_initial_prompt(
+            raid=raid,
+            pr_status=None,
+            changed_files=[],
+            diff_summary="",
+            launch_command=None,
+        )
+        assert "## Runtime QA" not in prompt
+
+    def test_runtime_qa_section_absent_when_launch_command_omitted(self) -> None:
+        raid = _make_raid()
+        prompt = build_reviewer_initial_prompt(
+            raid=raid,
+            pr_status=None,
+            changed_files=[],
+            diff_summary="",
+        )
+        assert "## Runtime QA" not in prompt
+
+    def test_runtime_qa_section_includes_deduction_table(self) -> None:
+        raid = _make_raid()
+        prompt = build_reviewer_initial_prompt(
+            raid=raid,
+            pr_status=None,
+            changed_files=[],
+            diff_summary="",
+            launch_command="make serve",
+        )
+        assert "App won't start" in prompt
+        assert "Test suite red" in prompt
+        assert "Criterion not exercised" in prompt
+        assert "HTTP 4xx/5xx" in prompt
+
+    def test_runtime_qa_available_in_template(self) -> None:
+        raid = _make_raid()
+        prompt = build_reviewer_initial_prompt(
+            raid=raid,
+            pr_status=None,
+            changed_files=[],
+            diff_summary="",
+            template="QA:{runtime_qa_section}",
+            launch_command="npm start",
+        )
+        assert "## Runtime QA" in prompt
+        assert "npm start" in prompt
+
+    def test_runtime_qa_template_empty_when_no_launch_command(self) -> None:
+        raid = _make_raid()
+        prompt = build_reviewer_initial_prompt(
+            raid=raid,
+            pr_status=None,
+            changed_files=[],
+            diff_summary="",
+            template="QA:{runtime_qa_section}",
+        )
+        assert prompt == "QA:"
+
 
 # ---------------------------------------------------------------------------
 # Tests: reviewer_system_prompt config field


### PR DESCRIPTION
## Summary

- Add `_build_runtime_qa_section()` to `reviewer_session.py` that generates a Runtime QA markdown block when `launch_command` is set
- The section includes app startup snippet, per-criterion verification guidance, and mandatory score deduction table
- Available as `{runtime_qa_section}` template placeholder; appended to fallback prompt automatically
- When `launch_command` is `None`, the prompt is unchanged (no regression)
- `spawn_reviewer` already passes `raid.launch_command` through (from NIU-335)

## Test plan

- [x] `test_runtime_qa_section_present_when_launch_command_set` — verifies section content when launch_command is provided
- [x] `test_runtime_qa_section_absent_when_launch_command_none` — no section when explicitly None
- [x] `test_runtime_qa_section_absent_when_launch_command_omitted` — no section when parameter omitted
- [x] `test_runtime_qa_section_includes_deduction_table` — all four deduction rules present
- [x] `test_runtime_qa_available_in_template` — works via `{runtime_qa_section}` placeholder
- [x] `test_runtime_qa_template_empty_when_no_launch_command` — empty when no command
- [x] All 59 existing tests pass unchanged

Closes NIU-336

🤖 Generated with [Claude Code](https://claude.com/claude-code)