### PR TITLE
feat(tyr): add ReviewerOutcome log table and wire into ReviewEngine

### DIFF
--- a/charts/tyr/templates/migrations-configmap.yaml
+++ b/charts/tyr/templates/migrations-configmap.yaml
@@ -408,4 +408,25 @@ data:
   000021_raid_launch_command.down.sql: |
     ALTER TABLE raids DROP COLUMN IF EXISTS launch_command;
     ALTER TABLE raid_progress DROP COLUMN IF EXISTS launch_command;
+
+  000022_reviewer_outcomes.up.sql: |
+    CREATE TABLE IF NOT EXISTS tyr_reviewer_outcomes (
+        id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        raid_id               UUID NOT NULL,
+        owner_id              TEXT NOT NULL,
+        reviewer_decision     TEXT NOT NULL,
+        reviewer_confidence   FLOAT NOT NULL,
+        reviewer_issues_count INT NOT NULL DEFAULT 0,
+        actual_outcome        TEXT,
+        decision_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+        resolved_at           TIMESTAMPTZ,
+        notes                 TEXT
+    );
+    CREATE INDEX IF NOT EXISTS idx_reviewer_outcomes_owner ON tyr_reviewer_outcomes (owner_id, decision_at);
+    CREATE INDEX IF NOT EXISTS idx_reviewer_outcomes_raid ON tyr_reviewer_outcomes (raid_id);
+
+  000022_reviewer_outcomes.down.sql: |
+    DROP INDEX IF EXISTS idx_reviewer_outcomes_raid;
+    DROP INDEX IF EXISTS idx_reviewer_outcomes_owner;
+    DROP TABLE IF EXISTS tyr_reviewer_outcomes;
 {{- end }}

--- a/migrations/tyr/000022_reviewer_outcomes.down.sql
+++ b/migrations/tyr/000022_reviewer_outcomes.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_reviewer_outcomes_raid;
+DROP INDEX IF EXISTS idx_reviewer_outcomes_owner;
+DROP TABLE IF EXISTS tyr_reviewer_outcomes;

--- a/migrations/tyr/000022_reviewer_outcomes.up.sql
+++ b/migrations/tyr/000022_reviewer_outcomes.up.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS tyr_reviewer_outcomes (
+    id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    raid_id               UUID NOT NULL,
+    owner_id              TEXT NOT NULL,
+    reviewer_decision     TEXT NOT NULL,
+    reviewer_confidence   FLOAT NOT NULL,
+    reviewer_issues_count INT NOT NULL DEFAULT 0,
+    actual_outcome        TEXT,
+    decision_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+    resolved_at           TIMESTAMPTZ,
+    notes                 TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_reviewer_outcomes_owner ON tyr_reviewer_outcomes (owner_id, decision_at);
+CREATE INDEX IF NOT EXISTS idx_reviewer_outcomes_raid ON tyr_reviewer_outcomes (raid_id);

--- a/src/tyr/adapters/postgres_reviewer_outcomes.py
+++ b/src/tyr/adapters/postgres_reviewer_outcomes.py
@@ -1,0 +1,101 @@
+"""PostgreSQL implementation of ReviewerOutcomeRepository."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import UUID
+
+import asyncpg
+
+from tyr.domain.models import ReviewerOutcome
+from tyr.ports.reviewer_outcome_repository import ReviewerOutcomeRepository
+
+
+class PostgresReviewerOutcomeRepository(ReviewerOutcomeRepository):
+    """Reviewer outcome persistence backed by asyncpg."""
+
+    def __init__(self, pool: asyncpg.Pool) -> None:
+        self._pool = pool
+
+    async def record(self, outcome: ReviewerOutcome) -> None:
+        await self._pool.execute(
+            """
+            INSERT INTO tyr_reviewer_outcomes
+                (id, raid_id, owner_id, reviewer_decision, reviewer_confidence,
+                 reviewer_issues_count, actual_outcome, decision_at, resolved_at, notes)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+            """,
+            outcome.id,
+            outcome.raid_id,
+            outcome.owner_id,
+            outcome.reviewer_decision,
+            outcome.reviewer_confidence,
+            outcome.reviewer_issues_count,
+            outcome.actual_outcome,
+            outcome.decision_at or datetime.now(UTC),
+            outcome.resolved_at,
+            outcome.notes,
+        )
+
+    async def resolve(self, raid_id: UUID, actual_outcome: str, notes: str | None = None) -> None:
+        await self._pool.execute(
+            """
+            UPDATE tyr_reviewer_outcomes
+            SET actual_outcome = $2, resolved_at = $3, notes = COALESCE($4, notes)
+            WHERE raid_id = $1 AND resolved_at IS NULL
+            """,
+            raid_id,
+            actual_outcome,
+            datetime.now(UTC),
+            notes,
+        )
+
+    async def list_recent(self, owner_id: str, limit: int = 100) -> list[ReviewerOutcome]:
+        rows = await self._pool.fetch(
+            """
+            SELECT * FROM tyr_reviewer_outcomes
+            WHERE owner_id = $1
+            ORDER BY decision_at DESC
+            LIMIT $2
+            """,
+            owner_id,
+            limit,
+        )
+        return [self._row_to_outcome(row) for row in rows]
+
+    async def divergence_rate(self, owner_id: str, window_days: int = 30) -> float:
+        row = await self._pool.fetchrow(
+            """
+            SELECT
+                COUNT(*) FILTER (
+                    WHERE actual_outcome IN ('reverted', 'abandoned')
+                ) AS diverged,
+                COUNT(*) AS total
+            FROM tyr_reviewer_outcomes
+            WHERE owner_id = $1
+              AND reviewer_decision = 'auto_approved'
+              AND actual_outcome IS NOT NULL
+              AND decision_at >= now() - make_interval(days => $2)
+            """,
+            owner_id,
+            window_days,
+        )
+        total = row["total"]
+        if total == 0:
+            return 0.0
+        return row["diverged"] / total
+
+    @staticmethod
+    def _row_to_outcome(row: asyncpg.Record) -> ReviewerOutcome:
+        return ReviewerOutcome(
+            id=row["id"],
+            raid_id=row["raid_id"],
+            owner_id=row["owner_id"],
+            reviewer_decision=row["reviewer_decision"],
+            reviewer_confidence=row["reviewer_confidence"],
+            reviewer_issues_count=row["reviewer_issues_count"],
+            actual_outcome=row["actual_outcome"],
+            decision_at=row["decision_at"],
+            resolved_at=row["resolved_at"],
+            notes=row["notes"],
+        )

--- a/src/tyr/domain/models.py
+++ b/src/tyr/domain/models.py
@@ -277,6 +277,27 @@ class SagaStructure:
 
 
 # ---------------------------------------------------------------------------
+# Reviewer outcome log (append-only audit)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ReviewerOutcome:
+    """A single reviewer decision record for calibration analytics."""
+
+    id: UUID
+    raid_id: UUID
+    owner_id: str
+    reviewer_decision: str  # auto_approved | retried | escalated
+    reviewer_confidence: float
+    reviewer_issues_count: int = 0
+    actual_outcome: str | None = None  # merged | reverted | abandoned | None = pending
+    decision_at: datetime | None = None
+    resolved_at: datetime | None = None
+    notes: str | None = None
+
+
+# ---------------------------------------------------------------------------
 # Personal access tokens — re-exported from shared niuu module
 # ---------------------------------------------------------------------------
 

--- a/src/tyr/domain/services/review_engine.py
+++ b/src/tyr/domain/services/review_engine.py
@@ -35,6 +35,7 @@ from tyr.domain.models import (
     PRStatus,
     Raid,
     RaidStatus,
+    ReviewerOutcome,
     validate_transition,
 )
 from tyr.domain.services.reviewer_session import (
@@ -44,6 +45,7 @@ from tyr.domain.services.reviewer_session import (
 from tyr.ports.dispatcher_repository import DispatcherRepository
 from tyr.ports.event_bus import EventBusPort, TyrEvent
 from tyr.ports.git import GitPort
+from tyr.ports.reviewer_outcome_repository import ReviewerOutcomeRepository
 from tyr.ports.tracker import TrackerFactory, TrackerPort
 from tyr.ports.volundr import VolundrFactory
 
@@ -130,6 +132,7 @@ class ReviewEngine:
         reviewer_service: ReviewerSessionService | None = None,
         integration_repo: IntegrationRepository | None = None,
         dispatcher_repo: DispatcherRepository | None = None,
+        outcome_repo: ReviewerOutcomeRepository | None = None,
     ) -> None:
         self._tracker_factory = tracker_factory
         self._volundr_factory = volundr_factory
@@ -139,6 +142,7 @@ class ReviewEngine:
         self._reviewer = reviewer_service
         self._integration_repo = integration_repo
         self._dispatcher_repo = dispatcher_repo
+        self._outcome_repo = outcome_repo
         self._task: asyncio.Task[None] | None = None
         self._processed: set[str] = set()
         # Maps reviewer_session_id → (raid_tracker_id, owner_id)
@@ -220,9 +224,7 @@ class ReviewEngine:
                     tracker, tracker_id, owner_id, raid, score
                 )
             elif raid.review_round >= self._cfg.max_review_rounds:
-                decision = await self._handle_escalation(
-                    tracker, tracker_id, owner_id, raid, score
-                )
+                decision = await self._handle_escalation(tracker, tracker_id, owner_id, raid, score)
             else:
                 # Low confidence but approved — let the loop continue
                 new_round = raid.review_round + 1
@@ -230,13 +232,17 @@ class ReviewEngine:
                 self._reviewer_sessions[session_id] = (tracker_id, owner_id)
                 logger.info(
                     "Reviewer approved but low confidence (%.2f < %.2f) — round %d/%d, continuing",
-                    result.confidence, self._cfg.auto_approve_threshold,
-                    new_round, self._cfg.max_review_rounds,
+                    result.confidence,
+                    self._cfg.auto_approve_threshold,
+                    new_round,
+                    self._cfg.max_review_rounds,
                 )
                 return
             logger.info(
                 "Post-reviewer decision for %s: %s (reason=%s)",
-                tracker_id, decision.action, decision.reason,
+                tracker_id,
+                decision.action,
+                decision.reason,
             )
             return
 
@@ -249,18 +255,22 @@ class ReviewEngine:
         if new_round >= self._cfg.max_review_rounds:
             # Max rounds exhausted — escalate
             self._reviewer_sessions.pop(session_id, None)
-            decision = await self._handle_escalation(
-                tracker, tracker_id, owner_id, raid, score
-            )
+            decision = await self._handle_escalation(tracker, tracker_id, owner_id, raid, score)
             logger.info(
                 "Max review rounds (%d) reached for %s — %s (reason=%s)",
-                self._cfg.max_review_rounds, tracker_id, decision.action, decision.reason,
+                self._cfg.max_review_rounds,
+                tracker_id,
+                decision.action,
+                decision.reason,
             )
             return
 
         logger.info(
             "Review round %d/%d for %s: %d issues, reviewer driving loop",
-            new_round, self._cfg.max_review_rounds, tracker_id, len(result.findings),
+            new_round,
+            self._cfg.max_review_rounds,
+            tracker_id,
+            len(result.findings),
         )
 
     async def start(self) -> None:
@@ -691,6 +701,7 @@ class ReviewEngine:
         phase_gate_unlocked = await self._check_phase_gate(tracker, tracker_id, owner_id)
 
         await self._emit_state_changed(updated, owner_id=owner_id, action="auto_approved")
+        await self._record_outcome(raid, owner_id, "auto_approved", score)
 
         return ReviewDecision(
             raid=updated,
@@ -727,12 +738,11 @@ class ReviewEngine:
                 lines.append("---")
                 lines.append("")
             title = f"Review Transcript — {raid.name}"
-            await tracker.attach_issue_document(
-                tracker_id, title, "\n".join(lines)
-            )
+            await tracker.attach_issue_document(tracker_id, title, "\n".join(lines))
             logger.info(
                 "Attached review transcript (%d turns) to %s",
-                len(turns), tracker_id,
+                len(turns),
+                tracker_id,
             )
         except Exception:
             logger.warning(
@@ -748,9 +758,7 @@ class ReviewEngine:
             await adapters[0].stop_session(reviewer_session_id)
             logger.info("Stopped reviewer session %s", reviewer_session_id)
         except Exception:
-            logger.warning(
-                "Failed to stop reviewer session %s", reviewer_session_id, exc_info=True
-            )
+            logger.warning("Failed to stop reviewer session %s", reviewer_session_id, exc_info=True)
 
     async def _handle_ci_failure(
         self,
@@ -826,6 +834,7 @@ class ReviewEngine:
         validate_transition(raid.status, RaidStatus.ESCALATED)
         updated = await tracker.update_raid_progress(tracker_id, status=RaidStatus.ESCALATED)
         await self._emit_state_changed(updated, owner_id=owner_id, action="escalated")
+        await self._record_outcome(raid, owner_id, "escalated", score)
         return ReviewDecision(
             raid=updated,
             action="escalated",
@@ -862,6 +871,7 @@ class ReviewEngine:
         )
 
         await self._emit_state_changed(updated, owner_id=owner_id, action="retried")
+        await self._record_outcome(raid, owner_id, "retried", raid.confidence)
         return ReviewDecision(raid=updated, action="retried", reason=reason)
 
     # -- Session feedback --
@@ -970,3 +980,28 @@ class ReviewEngine:
                 },
             )
         )
+
+    async def _record_outcome(
+        self,
+        raid: Raid,
+        owner_id: str,
+        decision: str,
+        confidence: float,
+        issues_count: int = 0,
+    ) -> None:
+        """Fire-and-log: persist a reviewer outcome record if the repo is wired."""
+        if self._outcome_repo is None:
+            return
+        try:
+            outcome = ReviewerOutcome(
+                id=uuid4(),
+                raid_id=raid.id,
+                owner_id=owner_id,
+                reviewer_decision=decision,
+                reviewer_confidence=confidence,
+                reviewer_issues_count=issues_count,
+                decision_at=datetime.now(UTC),
+            )
+            await self._outcome_repo.record(outcome)
+        except Exception:
+            logger.warning("Failed to record reviewer outcome for raid %s", raid.id, exc_info=True)

--- a/src/tyr/main.py
+++ b/src/tyr/main.py
@@ -26,6 +26,7 @@ from tyr.adapters.postgres_dispatcher import PostgresDispatcherRepository
 from tyr.adapters.postgres_notification_subscriptions import (
     PostgresNotificationSubscriptionRepository,
 )
+from tyr.adapters.postgres_reviewer_outcomes import PostgresReviewerOutcomeRepository
 from tyr.adapters.postgres_sagas import PostgresSagaRepository
 from tyr.adapters.tracker_factory import TrackerAdapterFactory
 from tyr.adapters.volundr_factory import VolundrAdapterFactory
@@ -308,6 +309,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 volundr_factory=app.state.volundr_factory,
                 review_config=settings.review,
             )
+            outcome_repo = PostgresReviewerOutcomeRepository(pool)
             review_engine = ReviewEngine(
                 tracker_factory=app.state.tracker_factory,
                 volundr_factory=app.state.volundr_factory,
@@ -316,6 +318,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 event_bus=event_bus,
                 reviewer_service=reviewer_service,
                 dispatcher_repo=dispatcher_repo,
+                outcome_repo=outcome_repo,
             )
             app.state.review_engine = review_engine
             await review_engine.start()

--- a/src/tyr/ports/reviewer_outcome_repository.py
+++ b/src/tyr/ports/reviewer_outcome_repository.py
@@ -1,0 +1,36 @@
+"""Reviewer outcome repository port — persistence for reviewer decision audit log."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from uuid import UUID
+
+from tyr.domain.models import ReviewerOutcome
+
+
+class ReviewerOutcomeRepository(ABC):
+    """Abstract persistence for reviewer outcome records."""
+
+    @abstractmethod
+    async def record(self, outcome: ReviewerOutcome) -> None:
+        """Append a reviewer decision to the audit log."""
+        ...
+
+    @abstractmethod
+    async def resolve(self, raid_id: UUID, actual_outcome: str, notes: str | None = None) -> None:
+        """Mark all unresolved outcomes for a raid with the actual outcome."""
+        ...
+
+    @abstractmethod
+    async def list_recent(self, owner_id: str, limit: int = 100) -> list[ReviewerOutcome]:
+        """Return the most recent outcomes for an owner, newest first."""
+        ...
+
+    @abstractmethod
+    async def divergence_rate(self, owner_id: str, window_days: int = 30) -> float:
+        """Fraction of auto_approved decisions where actual_outcome is reverted or abandoned.
+
+        Denominator = auto_approved with non-null actual_outcome only.
+        Returns 0.0 when denominator is zero.
+        """
+        ...

--- a/tests/test_tyr/test_postgres_reviewer_outcomes.py
+++ b/tests/test_tyr/test_postgres_reviewer_outcomes.py
@@ -1,0 +1,180 @@
+"""Tests for PostgresReviewerOutcomeRepository with mocked asyncpg pool."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from tyr.adapters.postgres_reviewer_outcomes import PostgresReviewerOutcomeRepository
+from tyr.domain.models import ReviewerOutcome
+
+NOW = datetime.now(UTC)
+
+
+@pytest.fixture
+def mock_pool() -> MagicMock:
+    pool = MagicMock()
+    pool.execute = AsyncMock()
+    pool.fetch = AsyncMock(return_value=[])
+    pool.fetchrow = AsyncMock(return_value=None)
+    return pool
+
+
+@pytest.fixture
+def repo(mock_pool: MagicMock) -> PostgresReviewerOutcomeRepository:
+    return PostgresReviewerOutcomeRepository(mock_pool)
+
+
+class TestRecord:
+    @pytest.mark.asyncio
+    async def test_inserts_outcome(
+        self, repo: PostgresReviewerOutcomeRepository, mock_pool: MagicMock
+    ) -> None:
+        outcome = ReviewerOutcome(
+            id=uuid4(),
+            raid_id=uuid4(),
+            owner_id="user-1",
+            reviewer_decision="auto_approved",
+            reviewer_confidence=0.92,
+            reviewer_issues_count=0,
+            decision_at=NOW,
+        )
+        await repo.record(outcome)
+        mock_pool.execute.assert_called_once()
+        sql = mock_pool.execute.call_args[0][0]
+        assert "INSERT INTO tyr_reviewer_outcomes" in sql
+        assert mock_pool.execute.call_args[0][1] == outcome.id
+
+    @pytest.mark.asyncio
+    async def test_inserts_with_none_decision_at(
+        self, repo: PostgresReviewerOutcomeRepository, mock_pool: MagicMock
+    ) -> None:
+        outcome = ReviewerOutcome(
+            id=uuid4(),
+            raid_id=uuid4(),
+            owner_id="user-1",
+            reviewer_decision="retried",
+            reviewer_confidence=0.5,
+        )
+        await repo.record(outcome)
+        mock_pool.execute.assert_called_once()
+        # decision_at=None should be replaced with now()
+        args = mock_pool.execute.call_args[0]
+        # arg at index 8 is decision_at
+        assert args[8] is not None  # filled in by adapter
+
+
+class TestResolve:
+    @pytest.mark.asyncio
+    async def test_updates_unresolved(
+        self, repo: PostgresReviewerOutcomeRepository, mock_pool: MagicMock
+    ) -> None:
+        raid_id = uuid4()
+        await repo.resolve(raid_id, "merged")
+        mock_pool.execute.assert_called_once()
+        sql = mock_pool.execute.call_args[0][0]
+        assert "UPDATE tyr_reviewer_outcomes" in sql
+        assert "actual_outcome" in sql
+        assert mock_pool.execute.call_args[0][1] == raid_id
+        assert mock_pool.execute.call_args[0][2] == "merged"
+
+    @pytest.mark.asyncio
+    async def test_resolve_with_notes(
+        self, repo: PostgresReviewerOutcomeRepository, mock_pool: MagicMock
+    ) -> None:
+        raid_id = uuid4()
+        await repo.resolve(raid_id, "reverted", notes="Broke staging")
+        args = mock_pool.execute.call_args[0]
+        assert args[4] == "Broke staging"
+
+
+class TestListRecent:
+    @pytest.mark.asyncio
+    async def test_queries_by_owner(
+        self, repo: PostgresReviewerOutcomeRepository, mock_pool: MagicMock
+    ) -> None:
+        mock_pool.fetch.return_value = []
+        result = await repo.list_recent("user-1", limit=50)
+        assert result == []
+        sql = mock_pool.fetch.call_args[0][0]
+        assert "owner_id" in sql
+        assert "ORDER BY decision_at DESC" in sql
+        assert mock_pool.fetch.call_args[0][1] == "user-1"
+        assert mock_pool.fetch.call_args[0][2] == 50
+
+    @pytest.mark.asyncio
+    async def test_maps_rows_to_outcomes(
+        self, repo: PostgresReviewerOutcomeRepository, mock_pool: MagicMock
+    ) -> None:
+        outcome_id = uuid4()
+        raid_id = uuid4()
+        mock_pool.fetch.return_value = [
+            {
+                "id": outcome_id,
+                "raid_id": raid_id,
+                "owner_id": "user-1",
+                "reviewer_decision": "auto_approved",
+                "reviewer_confidence": 0.92,
+                "reviewer_issues_count": 0,
+                "actual_outcome": "merged",
+                "decision_at": NOW,
+                "resolved_at": NOW,
+                "notes": None,
+            }
+        ]
+        result = await repo.list_recent("user-1")
+        assert len(result) == 1
+        assert result[0].id == outcome_id
+        assert result[0].reviewer_decision == "auto_approved"
+        assert result[0].actual_outcome == "merged"
+
+
+class TestDivergenceRate:
+    @pytest.mark.asyncio
+    async def test_zero_total_returns_zero(
+        self, repo: PostgresReviewerOutcomeRepository, mock_pool: MagicMock
+    ) -> None:
+        mock_pool.fetchrow.return_value = {"diverged": 0, "total": 0}
+        rate = await repo.divergence_rate("user-1")
+        assert rate == 0.0
+
+    @pytest.mark.asyncio
+    async def test_computes_fraction(
+        self, repo: PostgresReviewerOutcomeRepository, mock_pool: MagicMock
+    ) -> None:
+        mock_pool.fetchrow.return_value = {"diverged": 2, "total": 5}
+        rate = await repo.divergence_rate("user-1")
+        assert rate == pytest.approx(0.4)
+
+    @pytest.mark.asyncio
+    async def test_all_diverged(
+        self, repo: PostgresReviewerOutcomeRepository, mock_pool: MagicMock
+    ) -> None:
+        mock_pool.fetchrow.return_value = {"diverged": 3, "total": 3}
+        rate = await repo.divergence_rate("user-1")
+        assert rate == 1.0
+
+    @pytest.mark.asyncio
+    async def test_passes_window_days(
+        self, repo: PostgresReviewerOutcomeRepository, mock_pool: MagicMock
+    ) -> None:
+        mock_pool.fetchrow.return_value = {"diverged": 0, "total": 0}
+        await repo.divergence_rate("user-1", window_days=7)
+        args = mock_pool.fetchrow.call_args[0]
+        assert args[1] == "user-1"
+        assert args[2] == 7
+
+    @pytest.mark.asyncio
+    async def test_sql_filters_auto_approved(
+        self, repo: PostgresReviewerOutcomeRepository, mock_pool: MagicMock
+    ) -> None:
+        mock_pool.fetchrow.return_value = {"diverged": 0, "total": 0}
+        await repo.divergence_rate("user-1")
+        sql = mock_pool.fetchrow.call_args[0][0]
+        assert "auto_approved" in sql
+        assert "actual_outcome IS NOT NULL" in sql
+        assert "reverted" in sql
+        assert "abandoned" in sql

--- a/tests/test_tyr/test_reviewer_outcomes.py
+++ b/tests/test_tyr/test_reviewer_outcomes.py
@@ -1,0 +1,788 @@
+"""Tests for ReviewerOutcome recording and divergence_rate (NIU-337)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+import pytest
+
+from tyr.adapters.memory_event_bus import InMemoryEventBus
+from tyr.config import ReviewConfig
+from tyr.domain.models import (
+    ConfidenceEvent,
+    Phase,
+    PRStatus,
+    Raid,
+    RaidStatus,
+    ReviewerOutcome,
+    Saga,
+)
+from tyr.domain.services.review_engine import ReviewEngine
+from tyr.ports.git import GitPort
+from tyr.ports.reviewer_outcome_repository import ReviewerOutcomeRepository
+from tyr.ports.tracker import TrackerPort
+from tyr.ports.volundr import VolundrPort, VolundrSession
+
+NOW = datetime.now(UTC)
+
+# ---------------------------------------------------------------------------
+# In-memory ReviewerOutcomeRepository for testing
+# ---------------------------------------------------------------------------
+
+
+class InMemoryOutcomeRepo(ReviewerOutcomeRepository):
+    """In-memory implementation for unit tests."""
+
+    def __init__(self) -> None:
+        self.outcomes: list[ReviewerOutcome] = []
+
+    async def record(self, outcome: ReviewerOutcome) -> None:
+        self.outcomes.append(outcome)
+
+    async def resolve(self, raid_id: UUID, actual_outcome: str, notes: str | None = None) -> None:
+        updated = []
+        for o in self.outcomes:
+            if o.raid_id == raid_id and o.resolved_at is None:
+                o = ReviewerOutcome(
+                    id=o.id,
+                    raid_id=o.raid_id,
+                    owner_id=o.owner_id,
+                    reviewer_decision=o.reviewer_decision,
+                    reviewer_confidence=o.reviewer_confidence,
+                    reviewer_issues_count=o.reviewer_issues_count,
+                    actual_outcome=actual_outcome,
+                    decision_at=o.decision_at,
+                    resolved_at=datetime.now(UTC),
+                    notes=notes or o.notes,
+                )
+            updated.append(o)
+        self.outcomes = updated
+
+    async def list_recent(self, owner_id: str, limit: int = 100) -> list[ReviewerOutcome]:
+        filtered = [o for o in self.outcomes if o.owner_id == owner_id]
+        filtered.sort(key=lambda o: o.decision_at or NOW, reverse=True)
+        return filtered[:limit]
+
+    async def divergence_rate(self, owner_id: str, window_days: int = 30) -> float:
+        auto_approved = [
+            o
+            for o in self.outcomes
+            if o.owner_id == owner_id
+            and o.reviewer_decision == "auto_approved"
+            and o.actual_outcome is not None
+        ]
+        if not auto_approved:
+            return 0.0
+        diverged = [o for o in auto_approved if o.actual_outcome in ("reverted", "abandoned")]
+        return len(diverged) / len(auto_approved)
+
+
+# ---------------------------------------------------------------------------
+# Stubs (minimal, reused from test_review_engine pattern)
+# ---------------------------------------------------------------------------
+
+PHASE_ID = uuid4()
+SAGA_ID = uuid4()
+OWNER_ID = "user-1"
+TRACKER_ID = "NIU-100"
+
+
+class StubGit(GitPort):
+    def __init__(self) -> None:
+        self.pr_statuses: dict[str, PRStatus] = {}
+        self.changed_files: dict[str, list[str]] = {}
+
+    async def create_branch(self, repo, branch, base):
+        pass
+
+    async def merge_branch(self, repo, source, target):
+        pass
+
+    async def delete_branch(self, repo, branch):
+        pass
+
+    async def create_pr(self, repo, source, target, title):
+        return "pr-1"
+
+    async def get_pr_status(self, pr_id):
+        pr = self.pr_statuses.get(pr_id)
+        if pr is None:
+            raise RuntimeError(f"No PR: {pr_id}")
+        return pr
+
+    async def get_pr_changed_files(self, pr_id):
+        return self.changed_files.get(pr_id, [])
+
+
+class StubTracker(TrackerPort):
+    def __init__(self) -> None:
+        self.raids: dict[str, Raid] = {}
+        self.events: dict[str, list[ConfidenceEvent]] = {}
+        self.saga: Saga | None = None
+        self.phase: Phase | None = None
+        self.phases: list[Phase] = []
+        self._all_merged: bool = False
+
+    async def create_saga(self, saga, *, description=""):
+        return saga.tracker_id
+
+    async def create_phase(self, phase, *, project_id=""):
+        return phase.tracker_id
+
+    async def create_raid(self, raid, *, project_id="", milestone_id=""):
+        self.raids[raid.tracker_id] = raid
+        return raid.tracker_id
+
+    async def update_raid_state(self, raid_id, state):
+        pass
+
+    async def close_raid(self, raid_id):
+        pass
+
+    async def get_saga(self, saga_id):
+        return self.saga
+
+    async def get_phase(self, tracker_id):
+        return self.phase
+
+    async def get_raid(self, tracker_id):
+        raid = self.raids.get(tracker_id)
+        if raid is None:
+            raise ValueError(f"Raid not found: {tracker_id}")
+        return raid
+
+    async def list_pending_raids(self, phase_id):
+        return []
+
+    async def list_projects(self):
+        return []
+
+    async def get_project(self, project_id):
+        raise NotImplementedError
+
+    async def list_milestones(self, project_id):
+        return []
+
+    async def list_issues(self, project_id, milestone_id=None):
+        return []
+
+    async def update_raid_progress(
+        self,
+        tracker_id,
+        *,
+        status=None,
+        session_id=None,
+        confidence=None,
+        pr_url=None,
+        pr_id=None,
+        retry_count=None,
+        reason=None,
+        owner_id=None,
+        phase_tracker_id=None,
+        saga_tracker_id=None,
+        chronicle_summary=None,
+        reviewer_session_id=None,
+        review_round=None,
+        planner_session_id=None,
+        acceptance_criteria=None,
+        declared_files=None,
+        launch_command=None,
+    ):
+        raid = self.raids[tracker_id]
+        events = self.events.get(tracker_id, [])
+        new_confidence = events[-1].score_after if events else raid.confidence
+        updated = Raid(
+            id=raid.id,
+            phase_id=raid.phase_id,
+            tracker_id=raid.tracker_id,
+            name=raid.name,
+            description=raid.description,
+            acceptance_criteria=raid.acceptance_criteria,
+            declared_files=raid.declared_files,
+            estimate_hours=raid.estimate_hours,
+            status=status if status is not None else raid.status,
+            confidence=confidence if confidence is not None else new_confidence,
+            session_id=session_id if session_id is not None else raid.session_id,
+            branch=raid.branch,
+            chronicle_summary=raid.chronicle_summary,
+            pr_url=pr_url if pr_url is not None else raid.pr_url,
+            pr_id=pr_id if pr_id is not None else raid.pr_id,
+            retry_count=retry_count if retry_count is not None else raid.retry_count,
+            created_at=raid.created_at,
+            updated_at=datetime.now(UTC),
+        )
+        self.raids[tracker_id] = updated
+        return updated
+
+    async def get_raid_progress_for_saga(self, saga_tracker_id):
+        return list(self.raids.values())
+
+    async def get_raid_by_session(self, session_id):
+        return next((r for r in self.raids.values() if r.session_id == session_id), None)
+
+    async def list_raids_by_status(self, status):
+        return [r for r in self.raids.values() if r.status == status]
+
+    async def get_raid_by_id(self, raid_id):
+        return next((r for r in self.raids.values() if r.id == raid_id), None)
+
+    async def add_confidence_event(self, tracker_id, event):
+        self.events.setdefault(tracker_id, []).append(event)
+
+    async def get_confidence_events(self, tracker_id):
+        return self.events.get(tracker_id, [])
+
+    async def all_raids_merged(self, phase_tracker_id):
+        return self._all_merged
+
+    async def list_phases_for_saga(self, saga_tracker_id):
+        return self.phases
+
+    async def update_phase_status(self, phase_tracker_id, status):
+        return None
+
+    async def get_saga_for_raid(self, tracker_id):
+        return self.saga
+
+    async def get_phase_for_raid(self, tracker_id):
+        return self.phase
+
+    async def get_owner_for_raid(self, tracker_id):
+        return self.saga.owner_id if self.saga else None
+
+    async def save_session_message(self, message):
+        pass
+
+    async def get_session_messages(self, tracker_id):
+        return []
+
+    async def attach_issue_document(self, issue_id, title, content):
+        return ""
+
+
+class StubVolundr(VolundrPort):
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, str]] = []
+
+    async def spawn_session(self, request, *, auth_token=None):
+        raise NotImplementedError
+
+    async def get_session(self, session_id, *, auth_token=None):
+        return VolundrSession(id=session_id, name="s", status="running", tracker_issue_id=None)
+
+    async def list_sessions(self, *, auth_token=None):
+        return []
+
+    async def get_pr_status(self, session_id):
+        raise NotImplementedError
+
+    async def get_chronicle_summary(self, session_id):
+        return ""
+
+    async def send_message(self, session_id, message, *, auth_token=None):
+        self.messages.append((session_id, message))
+
+    async def stop_session(self, session_id, *, auth_token=None):
+        pass
+
+    async def list_integration_ids(self, *, auth_token=None):
+        return []
+
+    async def list_repos(self, *, auth_token=None):
+        return []
+
+    async def get_conversation(self, session_id):
+        return {"turns": []}
+
+    async def get_last_assistant_message(self, session_id):
+        return ""
+
+    async def subscribe_activity(self):
+        return
+        yield  # type: ignore[misc]  # pragma: no cover
+
+
+class StubTrackerFactory:
+    def __init__(self, tracker: StubTracker) -> None:
+        self._tracker = tracker
+
+    async def for_owner(self, owner_id: str) -> list[StubTracker]:
+        return [self._tracker]
+
+
+class _StubVolundrFactory:
+    def __init__(self, volundr: StubVolundr) -> None:
+        self._v = volundr
+
+    async def for_owner(self, owner_id):
+        return [self._v]
+
+    async def primary_for_owner(self, owner_id):
+        return self._v
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_raid(
+    raid_id: UUID | None = None,
+    tracker_id: str = TRACKER_ID,
+    status: RaidStatus = RaidStatus.REVIEW,
+    confidence: float = 0.5,
+    pr_id: str | None = "https://api.github.com/repos/org/repo/pulls/42",
+    declared_files: list[str] | None = None,
+    retry_count: int = 0,
+) -> Raid:
+    return Raid(
+        id=raid_id or uuid4(),
+        phase_id=PHASE_ID,
+        tracker_id=tracker_id,
+        name="Test raid",
+        description="A test raid",
+        acceptance_criteria=["tests pass"],
+        declared_files=declared_files or ["src/main.py", "tests/test_main.py"],
+        estimate_hours=2.0,
+        status=status,
+        confidence=confidence,
+        session_id="session-1",
+        branch="raid/test-branch",
+        chronicle_summary="All tests pass",
+        pr_url="https://github.com/org/repo/pull/42",
+        pr_id=pr_id,
+        retry_count=retry_count,
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+
+def _default_config(**overrides: object) -> ReviewConfig:
+    defaults: dict = {
+        "auto_approve_threshold": 0.80,
+        "max_retries": 3,
+        "scope_breach_threshold": 0.30,
+    }
+    defaults.update(overrides)
+    return ReviewConfig(**defaults)
+
+
+def _make_engine(
+    tracker: StubTracker | None = None,
+    git: StubGit | None = None,
+    config: ReviewConfig | None = None,
+    outcome_repo: InMemoryOutcomeRepo | None = None,
+) -> tuple[ReviewEngine, StubTracker, StubGit, InMemoryOutcomeRepo]:
+    t = tracker or StubTracker()
+    g = git or StubGit()
+    c = config or _default_config()
+    o = outcome_repo or InMemoryOutcomeRepo()
+    v = StubVolundr()
+    e = InMemoryEventBus()
+
+    engine = ReviewEngine(
+        tracker_factory=StubTrackerFactory(t),
+        volundr_factory=_StubVolundrFactory(v),
+        git=g,
+        review_config=c,
+        event_bus=e,
+        outcome_repo=o,
+    )
+    return engine, t, g, o
+
+
+def _setup_passing_pr(git: StubGit, pr_id: str) -> None:
+    git.pr_statuses[pr_id] = PRStatus(
+        pr_id=pr_id,
+        url="https://github.com/org/repo/pull/42",
+        state="open",
+        mergeable=True,
+        ci_passed=True,
+    )
+
+
+def _setup_failing_pr(git: StubGit, pr_id: str) -> None:
+    git.pr_statuses[pr_id] = PRStatus(
+        pr_id=pr_id,
+        url="https://github.com/org/repo/pull/42",
+        state="open",
+        mergeable=True,
+        ci_passed=False,
+    )
+
+
+def _setup_conflicted_pr(git: StubGit, pr_id: str) -> None:
+    git.pr_statuses[pr_id] = PRStatus(
+        pr_id=pr_id,
+        url="https://github.com/org/repo/pull/42",
+        state="open",
+        mergeable=False,
+        ci_passed=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: ReviewerOutcome model
+# ---------------------------------------------------------------------------
+
+
+class TestReviewerOutcomeModel:
+    def test_create_outcome(self) -> None:
+        outcome = ReviewerOutcome(
+            id=uuid4(),
+            raid_id=uuid4(),
+            owner_id="user-1",
+            reviewer_decision="auto_approved",
+            reviewer_confidence=0.92,
+            reviewer_issues_count=0,
+        )
+        assert outcome.reviewer_decision == "auto_approved"
+        assert outcome.actual_outcome is None
+        assert outcome.resolved_at is None
+
+    def test_create_outcome_with_all_fields(self) -> None:
+        outcome = ReviewerOutcome(
+            id=uuid4(),
+            raid_id=uuid4(),
+            owner_id="user-1",
+            reviewer_decision="escalated",
+            reviewer_confidence=0.3,
+            reviewer_issues_count=5,
+            actual_outcome="abandoned",
+            decision_at=NOW,
+            resolved_at=NOW,
+            notes="Too many issues",
+        )
+        assert outcome.actual_outcome == "abandoned"
+        assert outcome.notes == "Too many issues"
+
+
+# ---------------------------------------------------------------------------
+# Tests: InMemoryOutcomeRepo (divergence_rate logic)
+# ---------------------------------------------------------------------------
+
+
+class TestDivergenceRate:
+    @pytest.mark.asyncio
+    async def test_empty_returns_zero(self) -> None:
+        repo = InMemoryOutcomeRepo()
+        rate = await repo.divergence_rate("user-1")
+        assert rate == 0.0
+
+    @pytest.mark.asyncio
+    async def test_all_merged_returns_zero(self) -> None:
+        repo = InMemoryOutcomeRepo()
+        for _ in range(5):
+            await repo.record(
+                ReviewerOutcome(
+                    id=uuid4(),
+                    raid_id=uuid4(),
+                    owner_id="user-1",
+                    reviewer_decision="auto_approved",
+                    reviewer_confidence=0.9,
+                    actual_outcome="merged",
+                    decision_at=NOW,
+                )
+            )
+        rate = await repo.divergence_rate("user-1")
+        assert rate == 0.0
+
+    @pytest.mark.asyncio
+    async def test_some_reverted(self) -> None:
+        repo = InMemoryOutcomeRepo()
+        # 3 merged, 2 reverted = 2/5 = 0.4
+        for _ in range(3):
+            await repo.record(
+                ReviewerOutcome(
+                    id=uuid4(),
+                    raid_id=uuid4(),
+                    owner_id="user-1",
+                    reviewer_decision="auto_approved",
+                    reviewer_confidence=0.9,
+                    actual_outcome="merged",
+                    decision_at=NOW,
+                )
+            )
+        for _ in range(2):
+            await repo.record(
+                ReviewerOutcome(
+                    id=uuid4(),
+                    raid_id=uuid4(),
+                    owner_id="user-1",
+                    reviewer_decision="auto_approved",
+                    reviewer_confidence=0.85,
+                    actual_outcome="reverted",
+                    decision_at=NOW,
+                )
+            )
+        rate = await repo.divergence_rate("user-1")
+        assert rate == pytest.approx(0.4)
+
+    @pytest.mark.asyncio
+    async def test_abandoned_counts_as_diverged(self) -> None:
+        repo = InMemoryOutcomeRepo()
+        await repo.record(
+            ReviewerOutcome(
+                id=uuid4(),
+                raid_id=uuid4(),
+                owner_id="user-1",
+                reviewer_decision="auto_approved",
+                reviewer_confidence=0.9,
+                actual_outcome="abandoned",
+                decision_at=NOW,
+            )
+        )
+        rate = await repo.divergence_rate("user-1")
+        assert rate == 1.0
+
+    @pytest.mark.asyncio
+    async def test_pending_excluded_from_denominator(self) -> None:
+        repo = InMemoryOutcomeRepo()
+        # 1 merged, 1 pending (null outcome) — only 1 in denominator
+        await repo.record(
+            ReviewerOutcome(
+                id=uuid4(),
+                raid_id=uuid4(),
+                owner_id="user-1",
+                reviewer_decision="auto_approved",
+                reviewer_confidence=0.9,
+                actual_outcome="merged",
+                decision_at=NOW,
+            )
+        )
+        await repo.record(
+            ReviewerOutcome(
+                id=uuid4(),
+                raid_id=uuid4(),
+                owner_id="user-1",
+                reviewer_decision="auto_approved",
+                reviewer_confidence=0.85,
+                actual_outcome=None,
+                decision_at=NOW,
+            )
+        )
+        rate = await repo.divergence_rate("user-1")
+        assert rate == 0.0
+
+    @pytest.mark.asyncio
+    async def test_non_auto_approved_excluded(self) -> None:
+        repo = InMemoryOutcomeRepo()
+        # escalated decisions with reverted outcome should not count
+        await repo.record(
+            ReviewerOutcome(
+                id=uuid4(),
+                raid_id=uuid4(),
+                owner_id="user-1",
+                reviewer_decision="escalated",
+                reviewer_confidence=0.3,
+                actual_outcome="reverted",
+                decision_at=NOW,
+            )
+        )
+        rate = await repo.divergence_rate("user-1")
+        assert rate == 0.0
+
+    @pytest.mark.asyncio
+    async def test_other_owner_excluded(self) -> None:
+        repo = InMemoryOutcomeRepo()
+        await repo.record(
+            ReviewerOutcome(
+                id=uuid4(),
+                raid_id=uuid4(),
+                owner_id="user-2",
+                reviewer_decision="auto_approved",
+                reviewer_confidence=0.9,
+                actual_outcome="reverted",
+                decision_at=NOW,
+            )
+        )
+        rate = await repo.divergence_rate("user-1")
+        assert rate == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Tests: InMemoryOutcomeRepo.resolve
+# ---------------------------------------------------------------------------
+
+
+class TestResolve:
+    @pytest.mark.asyncio
+    async def test_resolve_sets_actual_outcome(self) -> None:
+        repo = InMemoryOutcomeRepo()
+        raid_id = uuid4()
+        await repo.record(
+            ReviewerOutcome(
+                id=uuid4(),
+                raid_id=raid_id,
+                owner_id="user-1",
+                reviewer_decision="auto_approved",
+                reviewer_confidence=0.9,
+                decision_at=NOW,
+            )
+        )
+        await repo.resolve(raid_id, "merged")
+        assert repo.outcomes[0].actual_outcome == "merged"
+        assert repo.outcomes[0].resolved_at is not None
+
+    @pytest.mark.asyncio
+    async def test_resolve_with_notes(self) -> None:
+        repo = InMemoryOutcomeRepo()
+        raid_id = uuid4()
+        await repo.record(
+            ReviewerOutcome(
+                id=uuid4(),
+                raid_id=raid_id,
+                owner_id="user-1",
+                reviewer_decision="auto_approved",
+                reviewer_confidence=0.9,
+                decision_at=NOW,
+            )
+        )
+        await repo.resolve(raid_id, "reverted", notes="Broke staging")
+        assert repo.outcomes[0].notes == "Broke staging"
+
+
+# ---------------------------------------------------------------------------
+# Tests: InMemoryOutcomeRepo.list_recent
+# ---------------------------------------------------------------------------
+
+
+class TestListRecent:
+    @pytest.mark.asyncio
+    async def test_returns_newest_first(self) -> None:
+        repo = InMemoryOutcomeRepo()
+        t1 = datetime(2026, 1, 1, tzinfo=UTC)
+        t2 = datetime(2026, 1, 2, tzinfo=UTC)
+        await repo.record(
+            ReviewerOutcome(
+                id=uuid4(),
+                raid_id=uuid4(),
+                owner_id="user-1",
+                reviewer_decision="auto_approved",
+                reviewer_confidence=0.9,
+                decision_at=t1,
+            )
+        )
+        await repo.record(
+            ReviewerOutcome(
+                id=uuid4(),
+                raid_id=uuid4(),
+                owner_id="user-1",
+                reviewer_decision="escalated",
+                reviewer_confidence=0.3,
+                decision_at=t2,
+            )
+        )
+        results = await repo.list_recent("user-1")
+        assert len(results) == 2
+        assert results[0].decision_at == t2
+
+    @pytest.mark.asyncio
+    async def test_respects_limit(self) -> None:
+        repo = InMemoryOutcomeRepo()
+        for i in range(5):
+            await repo.record(
+                ReviewerOutcome(
+                    id=uuid4(),
+                    raid_id=uuid4(),
+                    owner_id="user-1",
+                    reviewer_decision="auto_approved",
+                    reviewer_confidence=0.9,
+                    decision_at=datetime(2026, 1, i + 1, tzinfo=UTC),
+                )
+            )
+        results = await repo.list_recent("user-1", limit=2)
+        assert len(results) == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests: ReviewEngine records outcomes
+# ---------------------------------------------------------------------------
+
+
+class TestEngineRecordsOutcomes:
+    @pytest.mark.asyncio
+    async def test_auto_approve_records_outcome(self) -> None:
+        engine, tracker, git, outcome_repo = _make_engine()
+        raid = _make_raid(confidence=0.5)
+        tracker.raids[TRACKER_ID] = raid
+        _setup_passing_pr(git, raid.pr_id)
+        git.changed_files[raid.pr_id] = ["src/main.py"]
+
+        decision = await engine.evaluate(TRACKER_ID, OWNER_ID)
+        assert decision.action == "auto_approved"
+        assert len(outcome_repo.outcomes) == 1
+        assert outcome_repo.outcomes[0].reviewer_decision == "auto_approved"
+        assert outcome_repo.outcomes[0].owner_id == OWNER_ID
+        assert outcome_repo.outcomes[0].raid_id == raid.id
+
+    @pytest.mark.asyncio
+    async def test_escalation_records_outcome(self) -> None:
+        engine, tracker, git, outcome_repo = _make_engine()
+        raid = _make_raid(confidence=0.1)
+        tracker.raids[TRACKER_ID] = raid
+        # PR passes CI + mergeable, but low confidence → escalate
+        _setup_passing_pr(git, raid.pr_id)
+        git.changed_files[raid.pr_id] = ["src/main.py"]
+
+        decision = await engine.evaluate(TRACKER_ID, OWNER_ID)
+        assert decision.action == "escalated"
+        assert len(outcome_repo.outcomes) == 1
+        assert outcome_repo.outcomes[0].reviewer_decision == "escalated"
+
+    @pytest.mark.asyncio
+    async def test_retry_records_outcome(self) -> None:
+        engine, tracker, git, outcome_repo = _make_engine()
+        raid = _make_raid(confidence=0.5, retry_count=0)
+        tracker.raids[TRACKER_ID] = raid
+        _setup_failing_pr(git, raid.pr_id)
+        git.changed_files[raid.pr_id] = ["src/main.py"]
+
+        decision = await engine.evaluate(TRACKER_ID, OWNER_ID)
+        assert decision.action == "retried"
+        assert len(outcome_repo.outcomes) == 1
+        assert outcome_repo.outcomes[0].reviewer_decision == "retried"
+
+    @pytest.mark.asyncio
+    async def test_no_outcome_repo_is_noop(self) -> None:
+        """When outcome_repo is None, engine works without recording."""
+        t = StubTracker()
+        g = StubGit()
+        v = StubVolundr()
+        engine = ReviewEngine(
+            tracker_factory=StubTrackerFactory(t),
+            volundr_factory=_StubVolundrFactory(v),
+            git=g,
+            review_config=_default_config(),
+            event_bus=InMemoryEventBus(),
+            outcome_repo=None,
+        )
+        raid = _make_raid(confidence=0.5)
+        t.raids[TRACKER_ID] = raid
+        _setup_passing_pr(g, raid.pr_id)
+        g.changed_files[raid.pr_id] = ["src/main.py"]
+
+        decision = await engine.evaluate(TRACKER_ID, OWNER_ID)
+        assert decision.action == "auto_approved"
+
+    @pytest.mark.asyncio
+    async def test_outcome_repo_failure_does_not_break_engine(self) -> None:
+        """If outcome recording fails, the engine continues normally."""
+
+        class FailingOutcomeRepo(InMemoryOutcomeRepo):
+            async def record(self, outcome: ReviewerOutcome) -> None:
+                raise RuntimeError("DB down")
+
+        engine, tracker, git, _ = _make_engine()
+        failing_repo = FailingOutcomeRepo()
+        engine._outcome_repo = failing_repo
+
+        raid = _make_raid(confidence=0.5)
+        tracker.raids[TRACKER_ID] = raid
+        _setup_passing_pr(git, raid.pr_id)
+        git.changed_files[raid.pr_id] = ["src/main.py"]
+
+        # Should not raise
+        decision = await engine.evaluate(TRACKER_ID, OWNER_ID)
+        assert decision.action == "auto_approved"


### PR DESCRIPTION
## Summary
- **Migration 000022**: Creates `tyr_reviewer_outcomes` append-only audit table with indexes on `(owner_id, decision_at)` and `(raid_id)`
- **Domain model + port**: `ReviewerOutcome` dataclass + `ReviewerOutcomeRepository` ABC with `record`, `resolve`, `list_recent`, and `divergence_rate` methods
- **Postgres adapter**: `PostgresReviewerOutcomeRepository` with raw SQL via asyncpg
- **ReviewEngine wiring**: Injects `outcome_repo` (default `None` for backwards compatibility), records at all 3 decision sites (`_handle_auto_approve`, `_auto_retry`, `_handle_escalation`) using fire-and-log pattern
- **main.py**: Creates and injects `PostgresReviewerOutcomeRepository`
- **Helm**: Migration embedded in tyr migrations configmap

## Test plan
- [x] 18 unit tests covering all acceptance criteria
- [x] `divergence_rate`: empty → 0.0, all merged → 0.0, some reverted → correct fraction, pending excluded from denominator
- [x] Engine records outcomes at auto_approve, retry, and escalation paths
- [x] `outcome_repo=None` → no-ops (existing tests unaffected)
- [x] Outcome repo failure does not break engine (fire-and-log)
- [x] All 122 review-related tests pass
- [x] ruff check + ruff format clean

Closes NIU-337

🤖 Generated with [Claude Code](https://claude.com/claude-code)