### PR TITLE
feat(cli): implement API client, OIDC auth, and WebSocket broker (NIU-408)

### DIFF
--- a/src/cli/api/__init__.py
+++ b/src/cli/api/__init__.py
@@ -1,1 +1,17 @@
-"""Base async httpx client with token refresh (stubs)."""
+"""Async API client for Volundr and Tyr services."""
+
+from cli.api.client import APIClient
+from cli.api.tyr import DispatchResult, RaidInfo, SagaInfo, TyrAPI
+from cli.api.volundr import ActivityEvent, SessionInfo, TimelineEntry, VolundrAPI
+
+__all__ = [
+    "APIClient",
+    "ActivityEvent",
+    "DispatchResult",
+    "RaidInfo",
+    "SagaInfo",
+    "SessionInfo",
+    "TimelineEntry",
+    "TyrAPI",
+    "VolundrAPI",
+]

--- a/src/cli/api/client.py
+++ b/src/cli/api/client.py
@@ -1,0 +1,132 @@
+"""Base async HTTP client with Bearer token auth and automatic 401 retry."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+REQUEST_TIMEOUT_SECONDS = 30.0
+SSE_KEEPALIVE_COMMENT = ": keepalive"
+
+
+class APIClient:
+    """Async httpx wrapper with Bearer auth and transparent token refresh.
+
+    On a 401 response the client calls ``refresh_token_fn`` (if provided),
+    replaces the cached access token and retries the request **once**.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        access_token: str | None = None,
+        timeout: float = REQUEST_TIMEOUT_SECONDS,
+        refresh_token_fn: Any | None = None,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._access_token = access_token
+        self._timeout = timeout
+        self._refresh_token_fn = refresh_token_fn
+
+    @property
+    def base_url(self) -> str:
+        return self._base_url
+
+    def set_token(self, token: str) -> None:
+        self._access_token = token
+
+    def _headers(self) -> dict[str, str]:
+        if self._access_token:
+            return {"Authorization": f"Bearer {self._access_token}"}
+        return {}
+
+    async def _maybe_refresh(self) -> bool:
+        """Attempt to refresh the access token. Returns True on success."""
+        if self._refresh_token_fn is None:
+            return False
+        try:
+            new_token = await self._refresh_token_fn()
+            if new_token:
+                self._access_token = new_token
+                return True
+        except Exception:
+            logger.debug("token refresh failed", exc_info=True)
+        return False
+
+    async def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: Any | None = None,
+        params: dict[str, str] | None = None,
+        timeout: float | None = None,
+    ) -> httpx.Response:
+        """Send an HTTP request, retrying once on 401 after token refresh."""
+        url = f"{self._base_url}{path}"
+        effective_timeout = timeout or self._timeout
+        async with httpx.AsyncClient(timeout=effective_timeout) as client:
+            resp = await client.request(
+                method,
+                url,
+                headers=self._headers(),
+                json=json,
+                params=params,
+            )
+            if resp.status_code == 401 and await self._maybe_refresh():
+                resp = await client.request(
+                    method,
+                    url,
+                    headers=self._headers(),
+                    json=json,
+                    params=params,
+                )
+            return resp
+
+    async def get(
+        self,
+        path: str,
+        *,
+        params: dict[str, str] | None = None,
+        timeout: float | None = None,
+    ) -> httpx.Response:
+        return await self.request("GET", path, params=params, timeout=timeout)
+
+    async def post(
+        self,
+        path: str,
+        *,
+        json: Any | None = None,
+        timeout: float | None = None,
+    ) -> httpx.Response:
+        return await self.request("POST", path, json=json, timeout=timeout)
+
+    async def delete(
+        self,
+        path: str,
+        *,
+        timeout: float | None = None,
+    ) -> httpx.Response:
+        return await self.request("DELETE", path, timeout=timeout)
+
+    async def stream_sse(self, path: str) -> AsyncGenerator[tuple[str, str], None]:
+        """Yield ``(event_type, data)`` tuples from an SSE endpoint."""
+        url = f"{self._base_url}{path}"
+        async with httpx.AsyncClient(timeout=None) as client:
+            async with client.stream("GET", url, headers=self._headers()) as resp:
+                resp.raise_for_status()
+                event_type = ""
+                async for line in resp.aiter_lines():
+                    if line.startswith("event:"):
+                        event_type = line[len("event:") :].strip()
+                    elif line.startswith("data:"):
+                        data = line[len("data:") :].strip()
+                        yield event_type, data
+                        event_type = ""
+                    elif line == "":
+                        event_type = ""

--- a/src/cli/api/client.py
+++ b/src/cli/api/client.py
@@ -11,7 +11,6 @@ import httpx
 logger = logging.getLogger(__name__)
 
 REQUEST_TIMEOUT_SECONDS = 30.0
-SSE_KEEPALIVE_COMMENT = ": keepalive"
 
 
 class APIClient:
@@ -115,13 +114,29 @@ class APIClient:
         return await self.request("DELETE", path, timeout=timeout)
 
     async def stream_sse(self, path: str) -> AsyncGenerator[tuple[str, str], None]:
-        """Yield ``(event_type, data)`` tuples from an SSE endpoint."""
+        """Yield ``(event_type, data)`` tuples from an SSE endpoint.
+
+        On a 401 the client attempts a single token refresh and reconnects.
+        SSE keepalive comments (lines starting with ``:``) are silently dropped.
+        """
         url = f"{self._base_url}{path}"
         async with httpx.AsyncClient(timeout=None) as client:
-            async with client.stream("GET", url, headers=self._headers()) as resp:
-                resp.raise_for_status()
+            resp = await client.send(
+                client.build_request("GET", url, headers=self._headers()),
+                stream=True,
+            )
+            if resp.status_code == 401 and await self._maybe_refresh():
+                await resp.aclose()
+                resp = await client.send(
+                    client.build_request("GET", url, headers=self._headers()),
+                    stream=True,
+                )
+            resp.raise_for_status()
+            try:
                 event_type = ""
                 async for line in resp.aiter_lines():
+                    if line.startswith(":"):
+                        continue
                     if line.startswith("event:"):
                         event_type = line[len("event:") :].strip()
                     elif line.startswith("data:"):
@@ -130,3 +145,5 @@ class APIClient:
                         event_type = ""
                     elif line == "":
                         event_type = ""
+            finally:
+                await resp.aclose()

--- a/src/cli/api/tyr.py
+++ b/src/cli/api/tyr.py
@@ -1,0 +1,118 @@
+"""Tyr REST API methods for the CLI client."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from cli.api.client import APIClient
+
+logger = logging.getLogger(__name__)
+
+V1 = "/api/v1/tyr"
+
+
+@dataclass(frozen=True)
+class SagaInfo:
+    """Lightweight saga representation for the CLI."""
+
+    id: str
+    name: str
+    status: str
+    description: str = ""
+
+
+@dataclass(frozen=True)
+class RaidInfo:
+    """Lightweight raid representation for the CLI."""
+
+    id: str
+    saga_id: str
+    status: str
+    session_ids: list[str]
+
+
+@dataclass(frozen=True)
+class DispatchResult:
+    """Result of dispatching a saga."""
+
+    raid_id: str
+    session_ids: list[str]
+
+
+class TyrAPI:
+    """Tyr orchestration endpoint methods."""
+
+    def __init__(self, client: APIClient) -> None:
+        self._client = client
+
+    async def list_sagas(self) -> list[SagaInfo]:
+        resp = await self._client.get(f"{V1}/sagas")
+        resp.raise_for_status()
+        return [
+            SagaInfo(
+                id=s["id"],
+                name=s["name"],
+                status=s["status"],
+                description=s.get("description", ""),
+            )
+            for s in resp.json()
+        ]
+
+    async def get_saga(self, saga_id: str) -> SagaInfo | None:
+        resp = await self._client.get(f"{V1}/sagas/{saga_id}")
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        data = resp.json()
+        return SagaInfo(
+            id=data["id"],
+            name=data["name"],
+            status=data["status"],
+            description=data.get("description", ""),
+        )
+
+    async def create_saga(self, name: str, description: str = "") -> SagaInfo:
+        resp = await self._client.post(
+            f"{V1}/sagas",
+            json={"name": name, "description": description},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return SagaInfo(
+            id=data["id"],
+            name=data["name"],
+            status=data["status"],
+            description=data.get("description", ""),
+        )
+
+    async def list_raids(self, saga_id: str) -> list[RaidInfo]:
+        resp = await self._client.get(f"{V1}/sagas/{saga_id}/raids")
+        resp.raise_for_status()
+        return [
+            RaidInfo(
+                id=r["id"],
+                saga_id=r.get("saga_id", saga_id),
+                status=r["status"],
+                session_ids=r.get("session_ids", []),
+            )
+            for r in resp.json()
+        ]
+
+    async def dispatch(
+        self,
+        saga_id: str,
+        *,
+        params: dict[str, Any] | None = None,
+    ) -> DispatchResult:
+        resp = await self._client.post(
+            f"{V1}/sagas/{saga_id}/dispatch",
+            json=params or {},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return DispatchResult(
+            raid_id=data["raid_id"],
+            session_ids=data.get("session_ids", []),
+        )

--- a/src/cli/api/volundr.py
+++ b/src/cli/api/volundr.py
@@ -1,0 +1,197 @@
+"""Volundr REST API methods for the CLI client."""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
+from typing import Any
+
+from cli.api.client import APIClient
+
+logger = logging.getLogger(__name__)
+
+V1 = "/api/v1/volundr"
+
+
+@dataclass(frozen=True)
+class SessionInfo:
+    """Lightweight session representation for the CLI."""
+
+    id: str
+    name: str
+    status: str
+    tracker_issue_id: str | None = None
+    chat_endpoint: str | None = None
+    repo: str = ""
+    branch: str = ""
+    base_branch: str = ""
+
+
+@dataclass(frozen=True)
+class ActivityEvent:
+    """Activity event from the SSE stream."""
+
+    session_id: str
+    state: str
+    metadata: dict[str, Any]
+    owner_id: str = ""
+    session_status: str | None = None
+
+
+@dataclass(frozen=True)
+class TimelineEntry:
+    """Single entry in a session timeline."""
+
+    timestamp: str
+    event: str
+    details: dict[str, Any]
+
+
+class VolundrAPI:
+    """Volundr session endpoint methods."""
+
+    def __init__(self, client: APIClient) -> None:
+        self._client = client
+
+    async def list_sessions(self) -> list[SessionInfo]:
+        resp = await self._client.get(f"{V1}/sessions")
+        resp.raise_for_status()
+        return [
+            SessionInfo(
+                id=s["id"],
+                name=s["name"],
+                status=s["status"],
+                tracker_issue_id=s.get("tracker_issue_id"),
+            )
+            for s in resp.json()
+        ]
+
+    async def create_session(
+        self,
+        name: str,
+        *,
+        model: str = "",
+        repo: str = "",
+        branch: str = "",
+        base_branch: str = "",
+        system_prompt: str = "",
+        initial_prompt: str = "",
+        issue_id: str = "",
+        issue_url: str = "",
+        workload_type: str = "",
+        profile_name: str = "",
+        integration_ids: list[str] | None = None,
+    ) -> SessionInfo:
+        payload: dict[str, Any] = {
+            "name": name,
+            "model": model,
+            "source": {"type": "git", "repo": repo, "branch": branch, "base_branch": base_branch},
+            "system_prompt": system_prompt,
+            "initial_prompt": initial_prompt,
+            "issue_id": issue_id,
+            "issue_url": issue_url,
+            "workload_type": workload_type,
+            "profile_name": profile_name,
+            "integration_ids": integration_ids or [],
+        }
+        resp = await self._client.post(f"{V1}/sessions", json=payload)
+        resp.raise_for_status()
+        data = resp.json()
+        source = data.get("source") or {}
+        return SessionInfo(
+            id=data["id"],
+            name=data["name"],
+            status=data["status"],
+            tracker_issue_id=data.get("tracker_issue_id"),
+            chat_endpoint=data.get("chat_endpoint"),
+            repo=source.get("repo", ""),
+            branch=source.get("branch", ""),
+            base_branch=source.get("base_branch", ""),
+        )
+
+    async def get_session(self, session_id: str) -> SessionInfo | None:
+        resp = await self._client.get(f"{V1}/sessions/{session_id}")
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        data = resp.json()
+        source = data.get("source") or {}
+        return SessionInfo(
+            id=data["id"],
+            name=data["name"],
+            status=data["status"],
+            tracker_issue_id=data.get("tracker_issue_id"),
+            chat_endpoint=data.get("chat_endpoint"),
+            repo=source.get("repo", ""),
+            branch=source.get("branch", ""),
+            base_branch=source.get("base_branch", ""),
+        )
+
+    async def start_session(self, session_id: str) -> None:
+        resp = await self._client.post(f"{V1}/sessions/{session_id}/start")
+        resp.raise_for_status()
+
+    async def stop_session(self, session_id: str) -> None:
+        resp = await self._client.delete(f"{V1}/sessions/{session_id}")
+        if resp.status_code == 404:
+            return
+        resp.raise_for_status()
+
+    async def delete_session(self, session_id: str) -> None:
+        resp = await self._client.delete(f"{V1}/sessions/{session_id}/delete")
+        if resp.status_code == 404:
+            return
+        resp.raise_for_status()
+
+    async def get_chronicle(self, session_id: str) -> str:
+        resp = await self._client.get(f"{V1}/sessions/{session_id}/chronicle")
+        resp.raise_for_status()
+        return resp.json().get("summary", "")
+
+    async def get_timeline(self, session_id: str) -> list[TimelineEntry]:
+        resp = await self._client.get(f"{V1}/sessions/{session_id}/timeline")
+        resp.raise_for_status()
+        return [
+            TimelineEntry(
+                timestamp=e["timestamp"],
+                event=e["event"],
+                details=e.get("details", {}),
+            )
+            for e in resp.json()
+        ]
+
+    async def get_stats(self, session_id: str) -> dict[str, Any]:
+        resp = await self._client.get(f"{V1}/sessions/{session_id}/stats")
+        resp.raise_for_status()
+        return resp.json()
+
+    async def subscribe_activity(self) -> AsyncGenerator[ActivityEvent, None]:
+        """Subscribe to the Volundr SSE stream and yield activity events."""
+        async for event_type, raw in self._client.stream_sse(f"{V1}/sessions/stream"):
+            if event_type == "session_activity":
+                try:
+                    data = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                yield ActivityEvent(
+                    session_id=data.get("session_id", ""),
+                    state=data.get("state", ""),
+                    metadata=data.get("metadata", {}),
+                    owner_id=data.get("owner_id", ""),
+                )
+            elif event_type == "session_updated":
+                try:
+                    data = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                status = data.get("status", "")
+                if status in ("stopped", "failed"):
+                    yield ActivityEvent(
+                        session_id=data.get("id", ""),
+                        state="",
+                        metadata={},
+                        owner_id=data.get("owner_id", ""),
+                        session_status=status,
+                    )

--- a/src/cli/app.py
+++ b/src/cli/app.py
@@ -40,6 +40,7 @@ class _SortedGroup(typer.core.TyperGroup):
     def list_commands(self, ctx: click.Context) -> list[str]:
         return sorted(super().list_commands(ctx))
 
+
 logger = logging.getLogger(__name__)
 
 
@@ -111,13 +112,44 @@ def build_app(
     app.add_typer(create_context_commands(settings), name="context")
 
     @app.command()
-    def login() -> None:
+    def login(
+        issuer: str = typer.Option(
+            "",
+            "--issuer",
+            "-i",
+            help="OIDC issuer URL.",
+            envvar="NIUU_OIDC_ISSUER",
+        ),
+        client_id: str = typer.Option(
+            "niuu-cli",
+            "--client-id",
+            help="OIDC client ID.",
+            envvar="NIUU_OIDC_CLIENT_ID",
+        ),
+    ) -> None:
         """Authenticate with the Niuu platform."""
+        if not issuer:
+            typer.echo("Error: --issuer is required (or set NIUU_OIDC_ISSUER).")
+            raise typer.Exit(1)
+        import asyncio
+
+        from cli.auth.oidc import OIDCClient
+
+        oidc = OIDCClient(issuer=issuer, client_id=client_id)
         typer.echo("Opening browser for authentication...")
+        try:
+            tokens = asyncio.get_event_loop().run_until_complete(oidc.login())
+            typer.echo(f"Authenticated successfully (token type: {tokens.token_type}).")
+        except Exception as exc:
+            typer.echo(f"Authentication failed: {exc}")
+            raise typer.Exit(1) from None
 
     @app.command()
     def logout() -> None:
         """Clear stored credentials."""
+        from cli.auth.credentials import CredentialStore
+
+        CredentialStore().clear()
         typer.echo("Logged out.")
 
     app.add_typer(create_platform_commands(registry, settings, manager), name="platform")
@@ -145,6 +177,19 @@ def build_app(
     @app.command()
     def whoami() -> None:
         """Show the currently authenticated user."""
-        typer.echo("Not authenticated. Run 'niuu login' first.")
+        from cli.auth.oidc import OIDCClient
+
+        oidc = OIDCClient(issuer="", client_id="")
+        claims = oidc.whoami()
+        if not claims:
+            typer.echo("Not authenticated. Run 'niuu login' first.")
+            raise typer.Exit(1)
+        name = claims.get("name", claims.get("preferred_username", "unknown"))
+        email = claims.get("email", "")
+        sub = claims.get("sub", "")
+        typer.echo(f"User:  {name}")
+        if email:
+            typer.echo(f"Email: {email}")
+        typer.echo(f"Sub:   {sub}")
 
     return app

--- a/src/cli/auth/__init__.py
+++ b/src/cli/auth/__init__.py
@@ -1,1 +1,12 @@
-"""OIDC/PKCE client + encrypted secrets (stubs)."""
+"""OIDC/PKCE authentication and encrypted credential storage."""
+
+from cli.auth.credentials import CredentialStore, StoredTokens
+from cli.auth.oidc import OIDCClient, decode_id_token, generate_pkce_pair
+
+__all__ = [
+    "CredentialStore",
+    "OIDCClient",
+    "StoredTokens",
+    "decode_id_token",
+    "generate_pkce_pair",
+]

--- a/src/cli/auth/credentials.py
+++ b/src/cli/auth/credentials.py
@@ -1,0 +1,101 @@
+"""Encrypted credential storage in ~/.niuu/credentials."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CREDENTIALS_PATH = Path.home() / ".niuu" / "credentials"
+MACHINE_KEY_ENV = "NIUU_CREDENTIAL_KEY"
+
+
+@dataclass
+class StoredTokens:
+    """Token set persisted to disk."""
+
+    access_token: str
+    refresh_token: str = ""
+    id_token: str = ""
+    token_type: str = "Bearer"
+    expires_at: float = 0.0
+    issuer: str = ""
+
+
+def _derive_key() -> bytes:
+    """Derive a Fernet key from a stable machine-specific secret.
+
+    Priority:
+    1. ``NIUU_CREDENTIAL_KEY`` env-var (explicit override, CI-friendly).
+    2. Fallback: SHA-256 of hostname + uid, base64-encoded to 32 bytes.
+    """
+    explicit = os.environ.get(MACHINE_KEY_ENV)
+    if explicit:
+        raw = hashlib.sha256(explicit.encode()).digest()
+        return base64.urlsafe_b64encode(raw)
+
+    seed = f"{os.uname().nodename}-{os.getuid()}".encode()
+    raw = hashlib.sha256(seed).digest()
+    return base64.urlsafe_b64encode(raw)
+
+
+class CredentialStore:
+    """Read/write encrypted tokens to disk using Fernet symmetric encryption."""
+
+    def __init__(self, path: Path | None = None) -> None:
+        self._path = path or DEFAULT_CREDENTIALS_PATH
+
+    def _fernet(self):  # noqa: ANN202
+        from cryptography.fernet import Fernet
+
+        return Fernet(_derive_key())
+
+    def store(self, tokens: StoredTokens) -> None:
+        """Encrypt and persist tokens."""
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps(
+            {
+                "access_token": tokens.access_token,
+                "refresh_token": tokens.refresh_token,
+                "id_token": tokens.id_token,
+                "token_type": tokens.token_type,
+                "expires_at": tokens.expires_at,
+                "issuer": tokens.issuer,
+            }
+        ).encode()
+        encrypted = self._fernet().encrypt(payload)
+        self._path.write_bytes(encrypted)
+        self._path.chmod(0o600)
+        logger.debug("credentials stored at %s", self._path)
+
+    def load(self) -> StoredTokens | None:
+        """Load and decrypt stored tokens, or None if absent/corrupt."""
+        if not self._path.exists():
+            return None
+        try:
+            encrypted = self._path.read_bytes()
+            payload = self._fernet().decrypt(encrypted)
+            data = json.loads(payload)
+            return StoredTokens(
+                access_token=data["access_token"],
+                refresh_token=data.get("refresh_token", ""),
+                id_token=data.get("id_token", ""),
+                token_type=data.get("token_type", "Bearer"),
+                expires_at=data.get("expires_at", 0.0),
+                issuer=data.get("issuer", ""),
+            )
+        except Exception:
+            logger.debug("failed to load credentials", exc_info=True)
+            return None
+
+    def clear(self) -> None:
+        """Remove stored credentials."""
+        if self._path.exists():
+            self._path.unlink()
+            logger.debug("credentials cleared at %s", self._path)

--- a/src/cli/auth/oidc.py
+++ b/src/cli/auth/oidc.py
@@ -1,0 +1,269 @@
+"""OIDC/PKCE authentication client for CLI login flow."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import logging
+import secrets
+import time
+import webbrowser
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from threading import Event, Thread
+from typing import Any
+from urllib.parse import parse_qs, urlencode, urlparse
+
+import httpx
+import jwt
+
+from cli.auth.credentials import CredentialStore, StoredTokens
+
+logger = logging.getLogger(__name__)
+
+PKCE_VERIFIER_LENGTH = 64
+CALLBACK_TIMEOUT_SECONDS = 120
+LOCAL_CALLBACK_HOST = "127.0.0.1"
+
+
+def generate_pkce_pair() -> tuple[str, str]:
+    """Generate a PKCE code_verifier and code_challenge (S256).
+
+    Returns (verifier, challenge).
+    """
+    verifier = secrets.token_urlsafe(PKCE_VERIFIER_LENGTH)
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return verifier, challenge
+
+
+def decode_id_token(token: str) -> dict[str, Any]:
+    """Decode a JWT id_token without verification (for display only)."""
+    return jwt.decode(token, options={"verify_signature": False})
+
+
+class OIDCClient:
+    """OIDC Authorization Code + PKCE flow for CLI login.
+
+    Discovers endpoints from the issuer's well-known configuration,
+    opens a browser for authentication, and exchanges the code for tokens.
+    """
+
+    def __init__(
+        self,
+        issuer: str,
+        client_id: str,
+        scopes: str = "openid profile email",
+        credential_store: CredentialStore | None = None,
+    ) -> None:
+        self._issuer = issuer.rstrip("/")
+        self._client_id = client_id
+        self._scopes = scopes
+        self._credential_store = credential_store or CredentialStore()
+        self._discovery: dict[str, Any] = {}
+
+    async def discover(self) -> dict[str, Any]:
+        """Fetch OIDC discovery document."""
+        if self._discovery:
+            return self._discovery
+        url = f"{self._issuer}/.well-known/openid-configuration"
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.get(url)
+            resp.raise_for_status()
+            self._discovery = resp.json()
+        return self._discovery
+
+    async def login(self) -> StoredTokens:
+        """Run the full OIDC/PKCE login flow.
+
+        1. Discover endpoints.
+        2. Generate PKCE verifier/challenge.
+        3. Start local callback server.
+        4. Open browser to authorization URL.
+        5. Wait for callback with auth code.
+        6. Exchange code for tokens.
+        7. Persist tokens.
+        """
+        discovery = await self.discover()
+        authorization_endpoint = discovery["authorization_endpoint"]
+        token_endpoint = discovery["token_endpoint"]
+
+        verifier, challenge = generate_pkce_pair()
+
+        callback_received = Event()
+        result: dict[str, str] = {}
+
+        handler_factory = _make_callback_handler(callback_received, result)
+        server = HTTPServer((LOCAL_CALLBACK_HOST, 0), handler_factory)
+        port = server.server_address[1]
+        redirect_uri = f"http://{LOCAL_CALLBACK_HOST}:{port}/callback"
+
+        server_thread = Thread(target=server.serve_forever, daemon=True)
+        server_thread.start()
+
+        try:
+            auth_params = urlencode(
+                {
+                    "response_type": "code",
+                    "client_id": self._client_id,
+                    "redirect_uri": redirect_uri,
+                    "scope": self._scopes,
+                    "code_challenge": challenge,
+                    "code_challenge_method": "S256",
+                    "state": secrets.token_urlsafe(32),
+                }
+            )
+            auth_url = f"{authorization_endpoint}?{auth_params}"
+            webbrowser.open(auth_url)
+
+            if not callback_received.wait(timeout=CALLBACK_TIMEOUT_SECONDS):
+                raise TimeoutError("Authentication callback not received in time")
+
+            if "error" in result:
+                raise RuntimeError(
+                    f"OIDC error: {result['error']} — {result.get('error_description', '')}"
+                )
+
+            code = result["code"]
+            tokens = await self._exchange_code(
+                token_endpoint,
+                code,
+                redirect_uri,
+                verifier,
+            )
+            self._credential_store.store(tokens)
+            return tokens
+        finally:
+            server.shutdown()
+
+    async def _exchange_code(
+        self,
+        token_endpoint: str,
+        code: str,
+        redirect_uri: str,
+        verifier: str,
+    ) -> StoredTokens:
+        """Exchange authorization code for tokens."""
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.post(
+                token_endpoint,
+                data={
+                    "grant_type": "authorization_code",
+                    "client_id": self._client_id,
+                    "code": code,
+                    "redirect_uri": redirect_uri,
+                    "code_verifier": verifier,
+                },
+            )
+            resp.raise_for_status()
+            data = resp.json()
+
+        expires_at = 0.0
+        if "expires_in" in data:
+            expires_at = time.time() + data["expires_in"]
+
+        return StoredTokens(
+            access_token=data["access_token"],
+            refresh_token=data.get("refresh_token", ""),
+            id_token=data.get("id_token", ""),
+            token_type=data.get("token_type", "Bearer"),
+            expires_at=expires_at,
+            issuer=self._issuer,
+        )
+
+    async def refresh(self) -> str | None:
+        """Refresh the access token using stored refresh_token.
+
+        Returns the new access token, or None if refresh fails.
+        """
+        tokens = self._credential_store.load()
+        if not tokens or not tokens.refresh_token:
+            return None
+
+        discovery = await self.discover()
+        token_endpoint = discovery["token_endpoint"]
+
+        try:
+            async with httpx.AsyncClient(timeout=15.0) as client:
+                resp = await client.post(
+                    token_endpoint,
+                    data={
+                        "grant_type": "refresh_token",
+                        "client_id": self._client_id,
+                        "refresh_token": tokens.refresh_token,
+                    },
+                )
+                resp.raise_for_status()
+                data = resp.json()
+        except Exception:
+            logger.debug("token refresh failed", exc_info=True)
+            return None
+
+        expires_at = 0.0
+        if "expires_in" in data:
+            expires_at = time.time() + data["expires_in"]
+
+        new_tokens = StoredTokens(
+            access_token=data["access_token"],
+            refresh_token=data.get("refresh_token", tokens.refresh_token),
+            id_token=data.get("id_token", tokens.id_token),
+            token_type=data.get("token_type", "Bearer"),
+            expires_at=expires_at,
+            issuer=tokens.issuer,
+        )
+        self._credential_store.store(new_tokens)
+        return new_tokens.access_token
+
+    def logout(self) -> None:
+        """Clear all stored credentials."""
+        self._credential_store.clear()
+
+    def whoami(self) -> dict[str, Any] | None:
+        """Decode the stored id_token and return user claims, or None."""
+        tokens = self._credential_store.load()
+        if not tokens or not tokens.id_token:
+            return None
+        try:
+            return decode_id_token(tokens.id_token)
+        except Exception:
+            logger.debug("failed to decode id_token", exc_info=True)
+            return None
+
+    def load_access_token(self) -> str | None:
+        """Load the stored access token if present."""
+        tokens = self._credential_store.load()
+        if not tokens:
+            return None
+        return tokens.access_token
+
+
+def _make_callback_handler(
+    callback_received: Event,
+    result: dict[str, str],
+) -> type[BaseHTTPRequestHandler]:
+    """Create an HTTP request handler that captures the OIDC callback."""
+
+    class CallbackHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802
+            parsed = urlparse(self.path)
+            params = parse_qs(parsed.query)
+
+            if "code" in params:
+                result["code"] = params["code"][0]
+            if "error" in params:
+                result["error"] = params["error"][0]
+                result["error_description"] = params.get("error_description", [""])[0]
+
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.end_headers()
+            body = (
+                "<html><body><h1>Authentication complete</h1>"
+                "<p>You can close this window.</p></body></html>"
+            )
+            self.wfile.write(body.encode())
+            callback_received.set()
+
+        def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+            logger.debug(format, *args)
+
+    return CallbackHandler

--- a/src/cli/auth/oidc.py
+++ b/src/cli/auth/oidc.py
@@ -92,7 +92,8 @@ class OIDCClient:
         callback_received = Event()
         result: dict[str, str] = {}
 
-        handler_factory = _make_callback_handler(callback_received, result)
+        expected_state = secrets.token_urlsafe(32)
+        handler_factory = _make_callback_handler(callback_received, result, expected_state)
         server = HTTPServer((LOCAL_CALLBACK_HOST, 0), handler_factory)
         port = server.server_address[1]
         redirect_uri = f"http://{LOCAL_CALLBACK_HOST}:{port}/callback"
@@ -109,7 +110,7 @@ class OIDCClient:
                     "scope": self._scopes,
                     "code_challenge": challenge,
                     "code_challenge_method": "S256",
-                    "state": secrets.token_urlsafe(32),
+                    "state": expected_state,
                 }
             )
             auth_url = f"{authorization_endpoint}?{auth_params}"
@@ -239,6 +240,7 @@ class OIDCClient:
 def _make_callback_handler(
     callback_received: Event,
     result: dict[str, str],
+    expected_state: str,
 ) -> type[BaseHTTPRequestHandler]:
     """Create an HTTP request handler that captures the OIDC callback."""
 
@@ -246,6 +248,22 @@ def _make_callback_handler(
         def do_GET(self) -> None:  # noqa: N802
             parsed = urlparse(self.path)
             params = parse_qs(parsed.query)
+
+            # Validate state to prevent CSRF.
+            returned_state = params.get("state", [""])[0]
+            if returned_state != expected_state:
+                result["error"] = "state_mismatch"
+                result["error_description"] = "OIDC state parameter does not match"
+                self.send_response(400)
+                self.send_header("Content-Type", "text/html")
+                self.end_headers()
+                body = (
+                    "<html><body><h1>Authentication failed</h1>"
+                    "<p>State mismatch — possible CSRF attack.</p></body></html>"
+                )
+                self.wfile.write(body.encode())
+                callback_received.set()
+                return
 
             if "code" in params:
                 result["code"] = params["code"][0]

--- a/src/cli/broker/__init__.py
+++ b/src/cli/broker/__init__.py
@@ -1,1 +1,15 @@
-"""WebSocket bridge — broker, translate (stubs)."""
+"""WebSocket broker — bridges browser clients to Claude Code SDK."""
+
+from cli.broker.broker import BrowserConnection, ConversationTurn, SessionBroker
+from cli.broker.translate import filter_cli_event, skuld_to_sdk_control, skuld_to_sdk_permission
+from cli.broker.transport import Transport
+
+__all__ = [
+    "BrowserConnection",
+    "ConversationTurn",
+    "SessionBroker",
+    "Transport",
+    "filter_cli_event",
+    "skuld_to_sdk_control",
+    "skuld_to_sdk_permission",
+]

--- a/src/cli/broker/broker.py
+++ b/src/cli/broker/broker.py
@@ -20,6 +20,7 @@ from cli.broker.transport import Transport
 logger = logging.getLogger(__name__)
 
 BROWSER_SEND_BUFFER = 256
+MAX_HISTORY_TURNS = 500
 
 CONTROL_MSG_TYPES = frozenset(
     {
@@ -62,7 +63,7 @@ class BrowserConnection:
                 data = await self.queue.get()
                 await self.ws.send_text(data.decode())
         except Exception:
-            pass
+            logger.debug("write loop ended", exc_info=True)
 
     async def send(self, payload: bytes) -> None:
         try:
@@ -337,3 +338,5 @@ class SessionBroker:
             metadata=metadata or {},
         )
         self._history.append(turn)
+        if len(self._history) > MAX_HISTORY_TURNS:
+            self._history = self._history[-MAX_HISTORY_TURNS:]

--- a/src/cli/broker/broker.py
+++ b/src/cli/broker/broker.py
@@ -1,0 +1,339 @@
+"""Session broker — bridges N browser WebSocket clients to 1 SDK connection."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from cli.broker.translate import (
+    filter_cli_event,
+    skuld_to_sdk_control,
+    skuld_to_sdk_permission,
+)
+from cli.broker.transport import Transport
+
+logger = logging.getLogger(__name__)
+
+BROWSER_SEND_BUFFER = 256
+
+CONTROL_MSG_TYPES = frozenset(
+    {
+        "interrupt",
+        "set_model",
+        "set_max_thinking_tokens",
+        "set_permission_mode",
+        "rewind_files",
+        "mcp_set_servers",
+    }
+)
+
+
+@dataclass(frozen=True)
+class ConversationTurn:
+    """A single user or assistant turn in the conversation."""
+
+    id: str
+    role: str
+    content: str
+    parts: list[Any]
+    created_at: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class BrowserConnection:
+    """Wraps an asyncio WebSocket with a bounded send queue."""
+
+    def __init__(self, ws: Any) -> None:
+        self.ws = ws
+        self.queue: asyncio.Queue[bytes] = asyncio.Queue(maxsize=BROWSER_SEND_BUFFER)
+        self._write_task: asyncio.Task[None] | None = None
+
+    def start(self) -> None:
+        self._write_task = asyncio.create_task(self._write_loop())
+
+    async def _write_loop(self) -> None:
+        try:
+            while True:
+                data = await self.queue.get()
+                await self.ws.send_text(data.decode())
+        except Exception:
+            pass
+
+    async def send(self, payload: bytes) -> None:
+        try:
+            self.queue.put_nowait(payload)
+        except asyncio.QueueFull:
+            logger.debug("dropping message for slow browser client")
+
+    async def close(self) -> None:
+        if self._write_task:
+            self._write_task.cancel()
+            try:
+                await self._write_task
+            except asyncio.CancelledError:
+                pass
+        try:
+            await self.ws.close()
+        except Exception:
+            pass
+
+
+class SessionBroker:
+    """Per-session broker: N browser clients to 1 SDK connection.
+
+    Mirrors the Go ``Broker`` struct. Handles:
+    - Browser WebSocket connections (fan-out broadcasts, fan-in forwards)
+    - Conversation history for late joiners
+    - CLI event tracking and state management
+    """
+
+    def __init__(self, session_id: str, transport: Transport) -> None:
+        self._session_id = session_id
+        self._transport = transport
+        self._browsers: list[BrowserConnection] = []
+        self._history: list[ConversationTurn] = []
+        self._active = False
+        self._lock = asyncio.Lock()
+
+        # Streaming accumulator for building assistant turns.
+        self._pending_text: list[str] = []
+        self._pending_parts: list[Any] = []
+        self._pending_model = ""
+
+    @property
+    def session_id(self) -> str:
+        return self._session_id
+
+    def conversation_history(self) -> dict[str, Any]:
+        """Return the history payload for the HTTP endpoint."""
+        turns = [
+            {
+                "id": t.id,
+                "role": t.role,
+                "content": t.content,
+                "parts": t.parts,
+                "created_at": t.created_at,
+                "metadata": t.metadata,
+            }
+            for t in self._history
+        ]
+        last_activity = "Assistant is responding..." if self._active else ""
+        return {
+            "turns": turns,
+            "is_active": self._active,
+            "last_activity": last_activity,
+        }
+
+    async def add_browser(self, ws: Any) -> BrowserConnection:
+        """Register a new browser WebSocket connection."""
+        bc = BrowserConnection(ws)
+        bc.start()
+        async with self._lock:
+            self._browsers.append(bc)
+        logger.info(
+            "browser connected (session %s, %d clients)",
+            self._session_id,
+            len(self._browsers),
+        )
+        await self._send_to(
+            bc,
+            {
+                "type": "system",
+                "content": f"Connected to session {self._session_id}",
+            },
+        )
+        return bc
+
+    async def remove_browser(self, bc: BrowserConnection) -> None:
+        """Unregister and close a browser connection."""
+        async with self._lock:
+            self._browsers = [b for b in self._browsers if b is not bc]
+        await bc.close()
+        logger.info(
+            "browser disconnected (session %s, %d clients)",
+            self._session_id,
+            len(self._browsers),
+        )
+
+    async def handle_browser_message(self, msg: dict[str, Any]) -> None:
+        """Route a message received from a browser client."""
+        msg_type = msg.get("type", "")
+
+        # Legacy format: {content: "text"} without type field.
+        if not msg_type and "content" in msg:
+            msg_type = "user"
+
+        if msg_type in ("user", "message"):
+            content = msg.get("content")
+            if content is None:
+                return
+
+            content_str = content if isinstance(content, str) else json.dumps(content)
+            self._append_turn("user", content_str, None, None)
+
+            await self._broadcast(
+                {
+                    "type": "user_confirmed",
+                    "id": str(uuid.uuid4()),
+                    "content": content_str,
+                }
+            )
+
+            cli_session_id = self._transport.cli_session_id()
+            try:
+                self._transport.send_user_message(content, cli_session_id)
+            except Exception as exc:
+                logger.error("send user message: %s", exc)
+                await self._broadcast(
+                    {
+                        "type": "error",
+                        "error": f"Failed to send message: {exc}",
+                    }
+                )
+
+        elif msg_type == "permission_response":
+            resp = skuld_to_sdk_permission(msg)
+            try:
+                self._transport.send_control_response(resp)
+            except Exception as exc:
+                logger.error("send permission response: %s", exc)
+
+        elif msg_type in CONTROL_MSG_TYPES:
+            resp = skuld_to_sdk_control(msg_type, msg)
+            try:
+                self._transport.send_control_response(resp)
+            except Exception as exc:
+                logger.error("send control %s: %s", msg_type, exc)
+
+    def on_cli_event(self, data: dict[str, Any]) -> asyncio.Task[None] | None:
+        """Handle a CLI event — track state and broadcast to browsers.
+
+        Returns the broadcast task so callers can optionally await it.
+        """
+        if not filter_cli_event(data):
+            return None
+
+        msg_type = data.get("type", "")
+
+        match msg_type:
+            case "user":
+                message = data.get("message")
+                if isinstance(message, dict):
+                    content = message.get("content")
+                    if isinstance(content, str) and content:
+                        self._append_turn("user", content, None, None)
+
+            case "system":
+                subtype = data.get("subtype", "")
+                if subtype == "init":
+                    cmds: dict[str, Any] = {"type": "available_commands"}
+                    if "slash_commands" in data:
+                        cmds["slash_commands"] = data["slash_commands"]
+                    if "skills" in data:
+                        cmds["skills"] = data["skills"]
+                    return asyncio.ensure_future(self._broadcast(cmds))
+
+            case "assistant":
+                self._active = True
+                self._pending_text.clear()
+                self._pending_parts.clear()
+                self._pending_model = ""
+                message = data.get("message")
+                if isinstance(message, dict):
+                    model = message.get("model")
+                    if isinstance(model, str):
+                        self._pending_model = model
+
+            case "content_block_delta":
+                delta = data.get("delta")
+                if isinstance(delta, dict):
+                    text = delta.get("text", "")
+                    if text:
+                        self._pending_text.append(text)
+                    thinking = delta.get("thinking", "")
+                    if thinking:
+                        self._pending_parts.append({"type": "reasoning", "text": thinking})
+
+            case "result":
+                self._active = False
+                content = "".join(self._pending_text)
+                parts = list(self._pending_parts)
+
+                if not content:
+                    result_val = data.get("result")
+                    if isinstance(result_val, str):
+                        content = result_val
+
+                if content:
+                    parts.append({"type": "text", "text": content})
+
+                metadata: dict[str, Any] = {}
+                if self._pending_model:
+                    metadata["model"] = self._pending_model
+                if "modelUsage" in data:
+                    metadata["usage"] = data["modelUsage"]
+
+                self._pending_text.clear()
+                self._pending_parts.clear()
+
+                if content or parts:
+                    self._append_turn("assistant", content, parts, metadata)
+
+        return asyncio.ensure_future(self._broadcast(data))
+
+    async def stop(self) -> None:
+        """Close all browser connections."""
+        async with self._lock:
+            browsers = list(self._browsers)
+            self._browsers.clear()
+        for bc in browsers:
+            await bc.close()
+
+    async def inject_message(self, content: str) -> None:
+        """Send a message to the CLI from an external source."""
+        cli_session_id = self._transport.cli_session_id()
+        self._transport.send_user_message(content, cli_session_id)
+        self._append_turn("user", content, None, None)
+
+    async def _broadcast(self, data: dict[str, Any]) -> None:
+        """Send a JSON payload to all connected browsers."""
+        try:
+            payload = json.dumps(data).encode()
+        except (TypeError, ValueError):
+            return
+
+        async with self._lock:
+            browsers = list(self._browsers)
+
+        for bc in browsers:
+            await bc.send(payload)
+
+    async def _send_to(self, bc: BrowserConnection, data: dict[str, Any]) -> None:
+        """Send a JSON payload to a single browser."""
+        try:
+            payload = json.dumps(data).encode()
+        except (TypeError, ValueError):
+            return
+        await bc.send(payload)
+
+    def _append_turn(
+        self,
+        role: str,
+        content: str,
+        parts: list[Any] | None,
+        metadata: dict[str, Any] | None,
+    ) -> None:
+        turn = ConversationTurn(
+            id=str(uuid.uuid4()),
+            role=role,
+            content=content,
+            parts=parts or [],
+            created_at=datetime.now(UTC).isoformat(),
+            metadata=metadata or {},
+        )
+        self._history.append(turn)

--- a/src/cli/broker/translate.py
+++ b/src/cli/broker/translate.py
@@ -1,0 +1,80 @@
+"""Pure message-translation functions between Skuld (browser) and SDK (CLI) protocols."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+
+def skuld_to_sdk_permission(msg: dict[str, Any]) -> dict[str, Any]:
+    """Translate a browser ``permission_response`` into an SDK control response.
+
+    Browser format::
+
+        {type: "permission_response", request_id, behavior, updated_input, updated_permissions}
+
+    SDK format::
+
+        {subtype: "success", request_id, response: {behavior, updatedInput, updatedPermissions}}
+    """
+    request_id = msg.get("request_id", "")
+    behavior = msg.get("behavior", "")
+    updated_input = msg.get("updated_input") or {}
+    updated_permissions = msg.get("updated_permissions") or []
+
+    return {
+        "subtype": "success",
+        "request_id": request_id,
+        "response": {
+            "behavior": behavior,
+            "updatedInput": updated_input,
+            "updatedPermissions": updated_permissions,
+        },
+    }
+
+
+def skuld_to_sdk_control(msg_type: str, msg: dict[str, Any]) -> dict[str, Any]:
+    """Translate a browser control message into an SDK control response.
+
+    Handles: interrupt, set_model, set_max_thinking_tokens,
+    set_permission_mode, rewind_files, mcp_set_servers.
+    """
+    resp: dict[str, Any] = {
+        "subtype": msg_type,
+        "request_id": str(uuid.uuid4()),
+    }
+
+    match msg_type:
+        case "set_model":
+            resp["model"] = msg.get("model", "")
+        case "set_max_thinking_tokens":
+            resp["max_thinking_tokens"] = msg.get("max_thinking_tokens")
+        case "set_permission_mode":
+            resp["mode"] = msg.get("mode", "")
+        case "mcp_set_servers":
+            resp["servers"] = msg.get("servers")
+
+    return resp
+
+
+def filter_cli_event(data: dict[str, Any]) -> bool:
+    """Return True if the event should be forwarded to browsers.
+
+    Drops ``keep_alive`` and ``content_block_delta`` with empty content.
+    """
+    msg_type = data.get("type", "")
+
+    if msg_type == "keep_alive":
+        return False
+
+    if msg_type == "content_block_delta":
+        delta = data.get("delta")
+        if not isinstance(delta, dict):
+            return False
+        text = delta.get("text", "")
+        thinking = delta.get("thinking", "")
+        partial_json = delta.get("partial_json", "")
+        if not text and not thinking and not partial_json:
+            return False
+
+    return True

--- a/src/cli/broker/transport.py
+++ b/src/cli/broker/transport.py
@@ -1,0 +1,29 @@
+"""Transport protocol — abstraction for CLI communication."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class Transport(Protocol):
+    """Abstraction for sending messages to the Claude Code CLI process.
+
+    In embedded mode, Volundr's SDK transport implements this.
+    In standalone mode, a transport that spawns and manages the CLI
+    process directly would implement this.
+    """
+
+    def send_user_message(self, content: Any, cli_session_id: str) -> None:
+        """Send a user message to the CLI process.
+
+        ``content`` can be a string or an array of content blocks.
+        """
+        ...
+
+    def send_control_response(self, response: dict[str, Any]) -> None:
+        """Send a control_response envelope to the CLI."""
+        ...
+
+    def cli_session_id(self) -> str:
+        """Return the session ID reported by the CLI on init."""
+        ...

--- a/tests/test_cli/test_api_client.py
+++ b/tests/test_cli/test_api_client.py
@@ -1,0 +1,131 @@
+"""Tests for cli.api.client — base HTTP client with auth and retry."""
+
+from __future__ import annotations
+
+import httpx
+import respx
+
+from cli.api.client import APIClient
+
+BASE = "http://volundr.test"
+
+
+class TestAPIClientBasicRequests:
+    async def test_get_sends_bearer_token(self) -> None:
+        client = APIClient(base_url=BASE, access_token="tok123")
+        with respx.mock:
+            route = respx.get(f"{BASE}/api/v1/health").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+            resp = await client.get("/api/v1/health")
+        assert resp.status_code == 200
+        assert route.called
+        assert route.calls[0].request.headers["authorization"] == "Bearer tok123"
+
+    async def test_get_without_token(self) -> None:
+        client = APIClient(base_url=BASE)
+        with respx.mock:
+            route = respx.get(f"{BASE}/test").mock(return_value=httpx.Response(200, json={}))
+            resp = await client.get("/test")
+        assert resp.status_code == 200
+        assert "authorization" not in route.calls[0].request.headers
+
+    async def test_post_sends_json(self) -> None:
+        client = APIClient(base_url=BASE, access_token="t")
+        with respx.mock:
+            route = respx.post(f"{BASE}/create").mock(
+                return_value=httpx.Response(201, json={"id": "1"})
+            )
+            resp = await client.post("/create", json={"name": "test"})
+        assert resp.status_code == 201
+        import json
+
+        assert json.loads(route.calls[0].request.content) == {"name": "test"}
+
+    async def test_delete_request(self) -> None:
+        client = APIClient(base_url=BASE, access_token="t")
+        with respx.mock:
+            respx.delete(f"{BASE}/item/1").mock(return_value=httpx.Response(204))
+            resp = await client.delete("/item/1")
+        assert resp.status_code == 204
+
+    async def test_trailing_slash_stripped_from_base_url(self) -> None:
+        client = APIClient(base_url="http://host:8080/")
+        assert client.base_url == "http://host:8080"
+
+
+class TestAPIClientTokenRefresh:
+    async def test_401_triggers_refresh_and_retry(self) -> None:
+        refreshed = False
+
+        async def refresh_fn() -> str:
+            nonlocal refreshed
+            refreshed = True
+            return "new-token"
+
+        client = APIClient(base_url=BASE, access_token="old", refresh_token_fn=refresh_fn)
+
+        with respx.mock:
+            route = respx.get(f"{BASE}/data")
+            route.side_effect = [
+                httpx.Response(401),
+                httpx.Response(200, json={"v": 1}),
+            ]
+            resp = await client.get("/data")
+
+        assert resp.status_code == 200
+        assert refreshed
+        # Second request should use new token.
+        assert route.calls[1].request.headers["authorization"] == "Bearer new-token"
+
+    async def test_401_no_refresh_fn_returns_401(self) -> None:
+        client = APIClient(base_url=BASE, access_token="old")
+        with respx.mock:
+            respx.get(f"{BASE}/data").mock(return_value=httpx.Response(401))
+            resp = await client.get("/data")
+        assert resp.status_code == 401
+
+    async def test_401_refresh_fails_returns_401(self) -> None:
+        async def bad_refresh() -> str | None:
+            return None
+
+        client = APIClient(base_url=BASE, access_token="old", refresh_token_fn=bad_refresh)
+        with respx.mock:
+            respx.get(f"{BASE}/data").mock(return_value=httpx.Response(401))
+            resp = await client.get("/data")
+        assert resp.status_code == 401
+
+    async def test_401_refresh_raises_returns_401(self) -> None:
+        async def raise_refresh() -> str:
+            raise RuntimeError("network error")
+
+        client = APIClient(base_url=BASE, access_token="old", refresh_token_fn=raise_refresh)
+        with respx.mock:
+            respx.get(f"{BASE}/data").mock(return_value=httpx.Response(401))
+            resp = await client.get("/data")
+        assert resp.status_code == 401
+
+    async def test_set_token(self) -> None:
+        client = APIClient(base_url=BASE, access_token="old")
+        client.set_token("brand-new")
+        with respx.mock:
+            route = respx.get(f"{BASE}/x").mock(return_value=httpx.Response(200))
+            await client.get("/x")
+        assert route.calls[0].request.headers["authorization"] == "Bearer brand-new"
+
+
+class TestAPIClientSSE:
+    async def test_stream_sse_yields_events(self) -> None:
+        sse_body = (
+            'event: session_activity\ndata: {"session_id": "s1"}\n\nevent: keepalive\ndata: {}\n\n'
+        )
+        client = APIClient(base_url=BASE, access_token="t")
+        with respx.mock:
+            respx.get(f"{BASE}/stream").mock(return_value=httpx.Response(200, text=sse_body))
+            events = []
+            async for event_type, data in client.stream_sse("/stream"):
+                events.append((event_type, data))
+
+        assert len(events) == 2
+        assert events[0] == ("session_activity", '{"session_id": "s1"}')
+        assert events[1] == ("keepalive", "{}")

--- a/tests/test_cli/test_api_client.py
+++ b/tests/test_cli/test_api_client.py
@@ -129,3 +129,45 @@ class TestAPIClientSSE:
         assert len(events) == 2
         assert events[0] == ("session_activity", '{"session_id": "s1"}')
         assert events[1] == ("keepalive", "{}")
+
+    async def test_stream_sse_filters_keepalive_comments(self) -> None:
+        sse_body = ": keepalive\nevent: update\ndata: ok\n\n: another comment\n"
+        client = APIClient(base_url=BASE, access_token="t")
+        with respx.mock:
+            respx.get(f"{BASE}/stream").mock(return_value=httpx.Response(200, text=sse_body))
+            events = []
+            async for event_type, data in client.stream_sse("/stream"):
+                events.append((event_type, data))
+
+        assert len(events) == 1
+        assert events[0] == ("update", "ok")
+
+    async def test_stream_sse_retries_on_401(self) -> None:
+        sse_body = "event: ping\ndata: pong\n\n"
+
+        async def refresh_fn() -> str:
+            return "refreshed-token"
+
+        client = APIClient(base_url=BASE, access_token="old", refresh_token_fn=refresh_fn)
+        with respx.mock:
+            route = respx.get(f"{BASE}/sse")
+            route.side_effect = [
+                httpx.Response(401),
+                httpx.Response(200, text=sse_body),
+            ]
+            events = []
+            async for event_type, data in client.stream_sse("/sse"):
+                events.append((event_type, data))
+
+        assert len(events) == 1
+        assert events[0] == ("ping", "pong")
+
+    async def test_stream_sse_no_refresh_raises_on_401(self) -> None:
+        import pytest
+
+        client = APIClient(base_url=BASE, access_token="old")
+        with respx.mock:
+            respx.get(f"{BASE}/sse").mock(return_value=httpx.Response(401))
+            with pytest.raises(httpx.HTTPStatusError):
+                async for _ in client.stream_sse("/sse"):
+                    pass

--- a/tests/test_cli/test_api_tyr.py
+++ b/tests/test_cli/test_api_tyr.py
@@ -1,0 +1,115 @@
+"""Tests for cli.api.tyr — Tyr REST API methods."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from cli.api.client import APIClient
+from cli.api.tyr import TyrAPI
+
+BASE = "http://tyr.test"
+V1 = "/api/v1/tyr"
+
+
+@pytest.fixture
+def api() -> TyrAPI:
+    return TyrAPI(APIClient(base_url=BASE, access_token="t"))
+
+
+class TestListSagas:
+    async def test_returns_sagas(self, api: TyrAPI) -> None:
+        with respx.mock:
+            respx.get(f"{BASE}{V1}/sagas").mock(
+                return_value=httpx.Response(
+                    200,
+                    json=[
+                        {"id": "sg1", "name": "deploy", "status": "active"},
+                    ],
+                )
+            )
+            sagas = await api.list_sagas()
+        assert len(sagas) == 1
+        assert sagas[0].name == "deploy"
+
+    async def test_empty_list(self, api: TyrAPI) -> None:
+        with respx.mock:
+            respx.get(f"{BASE}{V1}/sagas").mock(return_value=httpx.Response(200, json=[]))
+            sagas = await api.list_sagas()
+        assert sagas == []
+
+
+class TestGetSaga:
+    async def test_returns_saga(self, api: TyrAPI) -> None:
+        with respx.mock:
+            respx.get(f"{BASE}{V1}/sagas/sg1").mock(
+                return_value=httpx.Response(
+                    200,
+                    json={
+                        "id": "sg1",
+                        "name": "deploy",
+                        "status": "active",
+                        "description": "deployment saga",
+                    },
+                )
+            )
+            saga = await api.get_saga("sg1")
+        assert saga is not None
+        assert saga.description == "deployment saga"
+
+    async def test_returns_none_for_404(self, api: TyrAPI) -> None:
+        with respx.mock:
+            respx.get(f"{BASE}{V1}/sagas/missing").mock(return_value=httpx.Response(404))
+            saga = await api.get_saga("missing")
+        assert saga is None
+
+
+class TestCreateSaga:
+    async def test_creates_saga(self, api: TyrAPI) -> None:
+        with respx.mock:
+            respx.post(f"{BASE}{V1}/sagas").mock(
+                return_value=httpx.Response(
+                    201,
+                    json={
+                        "id": "sg2",
+                        "name": "new-saga",
+                        "status": "pending",
+                    },
+                )
+            )
+            saga = await api.create_saga("new-saga", description="test")
+        assert saga.id == "sg2"
+
+
+class TestListRaids:
+    async def test_returns_raids(self, api: TyrAPI) -> None:
+        with respx.mock:
+            respx.get(f"{BASE}{V1}/sagas/sg1/raids").mock(
+                return_value=httpx.Response(
+                    200,
+                    json=[
+                        {"id": "r1", "saga_id": "sg1", "status": "running", "session_ids": ["s1"]},
+                    ],
+                )
+            )
+            raids = await api.list_raids("sg1")
+        assert len(raids) == 1
+        assert raids[0].session_ids == ["s1"]
+
+
+class TestDispatch:
+    async def test_dispatches_saga(self, api: TyrAPI) -> None:
+        with respx.mock:
+            respx.post(f"{BASE}{V1}/sagas/sg1/dispatch").mock(
+                return_value=httpx.Response(
+                    200,
+                    json={
+                        "raid_id": "r2",
+                        "session_ids": ["s1", "s2"],
+                    },
+                )
+            )
+            result = await api.dispatch("sg1", params={"target": "prod"})
+        assert result.raid_id == "r2"
+        assert len(result.session_ids) == 2

--- a/tests/test_cli/test_api_volundr.py
+++ b/tests/test_cli/test_api_volundr.py
@@ -1,0 +1,163 @@
+"""Tests for cli.api.volundr — Volundr REST API methods."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from cli.api.client import APIClient
+from cli.api.volundr import VolundrAPI
+
+BASE = "http://volundr.test"
+V1 = "/api/v1/volundr"
+
+
+@pytest.fixture
+def api() -> VolundrAPI:
+    return VolundrAPI(APIClient(base_url=BASE, access_token="t"))
+
+
+class TestListSessions:
+    async def test_returns_sessions(self, api: VolundrAPI) -> None:
+        with respx.mock:
+            respx.get(f"{BASE}{V1}/sessions").mock(
+                return_value=httpx.Response(
+                    200,
+                    json=[
+                        {"id": "s1", "name": "alpha", "status": "running"},
+                        {"id": "s2", "name": "beta", "status": "stopped"},
+                    ],
+                )
+            )
+            sessions = await api.list_sessions()
+        assert len(sessions) == 2
+        assert sessions[0].id == "s1"
+        assert sessions[1].status == "stopped"
+
+    async def test_empty_list(self, api: VolundrAPI) -> None:
+        with respx.mock:
+            respx.get(f"{BASE}{V1}/sessions").mock(return_value=httpx.Response(200, json=[]))
+            sessions = await api.list_sessions()
+        assert sessions == []
+
+
+class TestCreateSession:
+    async def test_creates_session(self, api: VolundrAPI) -> None:
+        with respx.mock:
+            respx.post(f"{BASE}{V1}/sessions").mock(
+                return_value=httpx.Response(
+                    201,
+                    json={
+                        "id": "new-id",
+                        "name": "test",
+                        "status": "pending",
+                        "source": {"repo": "org/repo", "branch": "main", "base_branch": "main"},
+                    },
+                )
+            )
+            session = await api.create_session("test", repo="org/repo", branch="main")
+        assert session.id == "new-id"
+        assert session.repo == "org/repo"
+
+    async def test_create_sends_payload(self, api: VolundrAPI) -> None:
+        with respx.mock:
+            route = respx.post(f"{BASE}{V1}/sessions").mock(
+                return_value=httpx.Response(
+                    201,
+                    json={
+                        "id": "x",
+                        "name": "n",
+                        "status": "pending",
+                    },
+                )
+            )
+            await api.create_session("n", model="opus", initial_prompt="go")
+            body = json.loads(route.calls[0].request.content)
+        assert body["name"] == "n"
+        assert body["model"] == "opus"
+        assert body["initial_prompt"] == "go"
+
+
+class TestGetSession:
+    async def test_returns_session(self, api: VolundrAPI) -> None:
+        with respx.mock:
+            respx.get(f"{BASE}{V1}/sessions/s1").mock(
+                return_value=httpx.Response(
+                    200,
+                    json={
+                        "id": "s1",
+                        "name": "a",
+                        "status": "running",
+                        "source": {"repo": "r", "branch": "b", "base_branch": "m"},
+                    },
+                )
+            )
+            session = await api.get_session("s1")
+        assert session is not None
+        assert session.branch == "b"
+
+    async def test_returns_none_for_404(self, api: VolundrAPI) -> None:
+        with respx.mock:
+            respx.get(f"{BASE}{V1}/sessions/missing").mock(return_value=httpx.Response(404))
+            session = await api.get_session("missing")
+        assert session is None
+
+
+class TestStartStopDelete:
+    async def test_start_session(self, api: VolundrAPI) -> None:
+        with respx.mock:
+            route = respx.post(f"{BASE}{V1}/sessions/s1/start").mock(
+                return_value=httpx.Response(200)
+            )
+            await api.start_session("s1")
+        assert route.called
+
+    async def test_stop_session(self, api: VolundrAPI) -> None:
+        with respx.mock:
+            respx.delete(f"{BASE}{V1}/sessions/s1").mock(return_value=httpx.Response(204))
+            await api.stop_session("s1")
+
+    async def test_stop_session_404_is_ok(self, api: VolundrAPI) -> None:
+        with respx.mock:
+            respx.delete(f"{BASE}{V1}/sessions/gone").mock(return_value=httpx.Response(404))
+            await api.stop_session("gone")
+
+    async def test_delete_session(self, api: VolundrAPI) -> None:
+        with respx.mock:
+            respx.delete(f"{BASE}{V1}/sessions/s1/delete").mock(return_value=httpx.Response(204))
+            await api.delete_session("s1")
+
+
+class TestChronicleTimelineStats:
+    async def test_get_chronicle(self, api: VolundrAPI) -> None:
+        with respx.mock:
+            respx.get(f"{BASE}{V1}/sessions/s1/chronicle").mock(
+                return_value=httpx.Response(200, json={"summary": "Did things."})
+            )
+            summary = await api.get_chronicle("s1")
+        assert summary == "Did things."
+
+    async def test_get_timeline(self, api: VolundrAPI) -> None:
+        with respx.mock:
+            respx.get(f"{BASE}{V1}/sessions/s1/timeline").mock(
+                return_value=httpx.Response(
+                    200,
+                    json=[
+                        {"timestamp": "2026-01-01T00:00:00Z", "event": "started", "details": {}},
+                    ],
+                )
+            )
+            timeline = await api.get_timeline("s1")
+        assert len(timeline) == 1
+        assert timeline[0].event == "started"
+
+    async def test_get_stats(self, api: VolundrAPI) -> None:
+        with respx.mock:
+            respx.get(f"{BASE}{V1}/sessions/s1/stats").mock(
+                return_value=httpx.Response(200, json={"tokens_in": 100, "tokens_out": 200})
+            )
+            stats = await api.get_stats("s1")
+        assert stats["tokens_in"] == 100

--- a/tests/test_cli/test_app.py
+++ b/tests/test_cli/test_app.py
@@ -115,10 +115,11 @@ class TestContextCommand:
 
 
 class TestIdentityCommands:
-    def test_login(self) -> None:
+    def test_login_requires_issuer(self) -> None:
         app, _, _ = _build_test_app()
         result = runner.invoke(app, ["login"])
-        assert result.exit_code == 0
+        assert result.exit_code == 1
+        assert "issuer" in result.output.lower()
 
     def test_logout(self) -> None:
         app, _, _ = _build_test_app()
@@ -126,10 +127,11 @@ class TestIdentityCommands:
         assert result.exit_code == 0
         assert "logged out" in result.output.lower()
 
-    def test_whoami(self) -> None:
+    def test_whoami_not_authenticated(self) -> None:
         app, _, _ = _build_test_app()
         result = runner.invoke(app, ["whoami"])
-        assert result.exit_code == 0
+        assert result.exit_code == 1
+        assert "not authenticated" in result.output.lower()
 
 
 class TestPluginWorkflowCommands:

--- a/tests/test_cli/test_auth_credentials.py
+++ b/tests/test_cli/test_auth_credentials.py
@@ -1,0 +1,92 @@
+"""Tests for cli.auth.credentials — encrypted credential storage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from cli.auth.credentials import CredentialStore, StoredTokens, _derive_key
+
+
+@pytest.fixture
+def cred_path(tmp_path: Path) -> Path:
+    return tmp_path / "credentials"
+
+
+@pytest.fixture
+def store(cred_path: Path) -> CredentialStore:
+    return CredentialStore(path=cred_path)
+
+
+@pytest.fixture(autouse=True)
+def _set_credential_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NIUU_CREDENTIAL_KEY", "test-secret-key-for-ci")
+
+
+class TestDeriveKey:
+    def test_key_is_32_bytes_urlsafe_base64(self) -> None:
+        key = _derive_key()
+        assert len(key) == 44  # 32 bytes base64-encoded
+
+    def test_explicit_env_var_used(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NIUU_CREDENTIAL_KEY", "my-key")
+        key1 = _derive_key()
+        monkeypatch.setenv("NIUU_CREDENTIAL_KEY", "other-key")
+        key2 = _derive_key()
+        assert key1 != key2
+
+
+class TestCredentialStoreRoundTrip:
+    def test_store_and_load(self, store: CredentialStore, cred_path: Path) -> None:
+        tokens = StoredTokens(
+            access_token="access123",
+            refresh_token="refresh456",
+            id_token="id789",
+            token_type="Bearer",
+            expires_at=1700000000.0,
+            issuer="https://idp.example.com",
+        )
+        store.store(tokens)
+        assert cred_path.exists()
+
+        loaded = store.load()
+        assert loaded is not None
+        assert loaded.access_token == "access123"
+        assert loaded.refresh_token == "refresh456"
+        assert loaded.id_token == "id789"
+        assert loaded.expires_at == 1700000000.0
+        assert loaded.issuer == "https://idp.example.com"
+
+    def test_file_permissions(self, store: CredentialStore, cred_path: Path) -> None:
+        store.store(StoredTokens(access_token="x"))
+        mode = oct(cred_path.stat().st_mode & 0o777)
+        assert mode == "0o600"
+
+    def test_load_returns_none_when_missing(self, store: CredentialStore) -> None:
+        assert store.load() is None
+
+    def test_load_returns_none_on_corrupt_data(
+        self,
+        store: CredentialStore,
+        cred_path: Path,
+    ) -> None:
+        cred_path.parent.mkdir(parents=True, exist_ok=True)
+        cred_path.write_bytes(b"garbage")
+        assert store.load() is None
+
+    def test_clear_removes_file(self, store: CredentialStore, cred_path: Path) -> None:
+        store.store(StoredTokens(access_token="x"))
+        assert cred_path.exists()
+        store.clear()
+        assert not cred_path.exists()
+
+    def test_clear_when_no_file(self, store: CredentialStore) -> None:
+        store.clear()  # should not raise
+
+    def test_overwrite_existing(self, store: CredentialStore) -> None:
+        store.store(StoredTokens(access_token="first"))
+        store.store(StoredTokens(access_token="second"))
+        loaded = store.load()
+        assert loaded is not None
+        assert loaded.access_token == "second"

--- a/tests/test_cli/test_auth_oidc.py
+++ b/tests/test_cli/test_auth_oidc.py
@@ -1,0 +1,200 @@
+"""Tests for cli.auth.oidc — OIDC/PKCE authentication client."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from pathlib import Path
+
+import httpx
+import pytest
+import respx
+
+from cli.auth.credentials import CredentialStore, StoredTokens
+from cli.auth.oidc import (
+    OIDCClient,
+    decode_id_token,
+    generate_pkce_pair,
+)
+
+
+@pytest.fixture(autouse=True)
+def _set_credential_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NIUU_CREDENTIAL_KEY", "test-secret-key-for-ci")
+
+
+class TestPKCE:
+    def test_verifier_length(self) -> None:
+        verifier, _ = generate_pkce_pair()
+        assert len(verifier) > 40
+
+    def test_challenge_is_s256(self) -> None:
+        verifier, challenge = generate_pkce_pair()
+        expected_digest = hashlib.sha256(verifier.encode("ascii")).digest()
+        expected = base64.urlsafe_b64encode(expected_digest).rstrip(b"=").decode("ascii")
+        assert challenge == expected
+
+    def test_unique_pairs(self) -> None:
+        pair1 = generate_pkce_pair()
+        pair2 = generate_pkce_pair()
+        assert pair1[0] != pair2[0]
+
+
+class TestDecodeIdToken:
+    def test_decodes_jwt_without_verification(self) -> None:
+        import jwt as pyjwt
+
+        payload = {"sub": "user-1", "name": "Test User", "email": "test@example.com"}
+        token = pyjwt.encode(payload, "a-test-secret-long-enough-for-hs256", algorithm="HS256")
+        claims = decode_id_token(token)
+        assert claims["sub"] == "user-1"
+        assert claims["name"] == "Test User"
+
+
+class TestOIDCClientDiscover:
+    async def test_fetches_discovery_document(self) -> None:
+        issuer = "https://idp.example.com"
+        discovery = {
+            "authorization_endpoint": f"{issuer}/authorize",
+            "token_endpoint": f"{issuer}/token",
+            "issuer": issuer,
+        }
+        with respx.mock:
+            respx.get(f"{issuer}/.well-known/openid-configuration").mock(
+                return_value=httpx.Response(200, json=discovery)
+            )
+            client = OIDCClient(issuer=issuer, client_id="test")
+            result = await client.discover()
+        assert result["authorization_endpoint"] == f"{issuer}/authorize"
+
+    async def test_caches_discovery(self) -> None:
+        issuer = "https://idp.example.com"
+        discovery = {"authorization_endpoint": "x", "token_endpoint": "y"}
+        with respx.mock:
+            route = respx.get(f"{issuer}/.well-known/openid-configuration").mock(
+                return_value=httpx.Response(200, json=discovery)
+            )
+            client = OIDCClient(issuer=issuer, client_id="test")
+            await client.discover()
+            await client.discover()
+        assert route.call_count == 1
+
+
+class TestOIDCClientRefresh:
+    async def test_refresh_exchanges_token(self, tmp_path: Path) -> None:
+        issuer = "https://idp.example.com"
+        store = CredentialStore(path=tmp_path / "creds")
+        store.store(
+            StoredTokens(
+                access_token="old-access",
+                refresh_token="refresh-tok",
+                issuer=issuer,
+            )
+        )
+
+        client = OIDCClient(
+            issuer=issuer,
+            client_id="cli",
+            credential_store=store,
+        )
+        client._discovery = {
+            "authorization_endpoint": f"{issuer}/authorize",
+            "token_endpoint": f"{issuer}/token",
+        }
+
+        with respx.mock:
+            respx.post(f"{issuer}/token").mock(
+                return_value=httpx.Response(
+                    200,
+                    json={
+                        "access_token": "new-access",
+                        "refresh_token": "new-refresh",
+                        "token_type": "Bearer",
+                        "expires_in": 3600,
+                    },
+                )
+            )
+            new_token = await client.refresh()
+
+        assert new_token == "new-access"
+        loaded = store.load()
+        assert loaded is not None
+        assert loaded.access_token == "new-access"
+        assert loaded.refresh_token == "new-refresh"
+
+    async def test_refresh_returns_none_without_tokens(self, tmp_path: Path) -> None:
+        store = CredentialStore(path=tmp_path / "creds")
+        client = OIDCClient(
+            issuer="https://idp.example.com",
+            client_id="cli",
+            credential_store=store,
+        )
+        result = await client.refresh()
+        assert result is None
+
+    async def test_refresh_returns_none_on_error(self, tmp_path: Path) -> None:
+        issuer = "https://idp.example.com"
+        store = CredentialStore(path=tmp_path / "creds")
+        store.store(
+            StoredTokens(
+                access_token="old",
+                refresh_token="ref",
+                issuer=issuer,
+            )
+        )
+        client = OIDCClient(issuer=issuer, client_id="cli", credential_store=store)
+        client._discovery = {
+            "authorization_endpoint": f"{issuer}/authorize",
+            "token_endpoint": f"{issuer}/token",
+        }
+        with respx.mock:
+            respx.post(f"{issuer}/token").mock(
+                return_value=httpx.Response(400, json={"error": "invalid_grant"})
+            )
+            result = await client.refresh()
+        assert result is None
+
+
+class TestOIDCClientWhoami:
+    def test_whoami_returns_claims(self, tmp_path: Path) -> None:
+        import jwt as pyjwt
+
+        id_token = pyjwt.encode(
+            {"sub": "u1", "name": "Alice", "email": "alice@example.com"},
+            "a-test-secret-long-enough-for-hs256",
+            algorithm="HS256",
+        )
+        store = CredentialStore(path=tmp_path / "creds")
+        store.store(StoredTokens(access_token="x", id_token=id_token))
+
+        client = OIDCClient(issuer="", client_id="", credential_store=store)
+        claims = client.whoami()
+        assert claims is not None
+        assert claims["name"] == "Alice"
+
+    def test_whoami_returns_none_when_not_logged_in(self, tmp_path: Path) -> None:
+        store = CredentialStore(path=tmp_path / "creds")
+        client = OIDCClient(issuer="", client_id="", credential_store=store)
+        assert client.whoami() is None
+
+
+class TestOIDCClientLogout:
+    def test_logout_clears_store(self, tmp_path: Path) -> None:
+        store = CredentialStore(path=tmp_path / "creds")
+        store.store(StoredTokens(access_token="x"))
+        client = OIDCClient(issuer="", client_id="", credential_store=store)
+        client.logout()
+        assert store.load() is None
+
+
+class TestOIDCClientLoadAccessToken:
+    def test_load_access_token(self, tmp_path: Path) -> None:
+        store = CredentialStore(path=tmp_path / "creds")
+        store.store(StoredTokens(access_token="my-token"))
+        client = OIDCClient(issuer="", client_id="", credential_store=store)
+        assert client.load_access_token() == "my-token"
+
+    def test_load_access_token_none(self, tmp_path: Path) -> None:
+        store = CredentialStore(path=tmp_path / "creds")
+        client = OIDCClient(issuer="", client_id="", credential_store=store)
+        assert client.load_access_token() is None

--- a/tests/test_cli/test_broker.py
+++ b/tests/test_cli/test_broker.py
@@ -1,0 +1,305 @@
+"""Tests for cli.broker.broker — SessionBroker multi-client broadcast and history."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+
+from cli.broker.broker import SessionBroker
+
+
+class FakeWebSocket:
+    """Minimal fake WebSocket for testing."""
+
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+        self.closed = False
+
+    async def send_text(self, data: str) -> None:
+        self.sent.append(data)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class FakeTransport:
+    """Fake Transport implementation for testing."""
+
+    def __init__(self, session_id: str = "test-session") -> None:
+        self._session_id = session_id
+        self.user_messages: list[tuple[Any, str]] = []
+        self.control_responses: list[dict[str, Any]] = []
+
+    def send_user_message(self, content: Any, cli_session_id: str) -> None:
+        self.user_messages.append((content, cli_session_id))
+
+    def send_control_response(self, response: dict[str, Any]) -> None:
+        self.control_responses.append(response)
+
+    def cli_session_id(self) -> str:
+        return self._session_id
+
+
+@pytest.fixture
+def transport() -> FakeTransport:
+    return FakeTransport()
+
+
+@pytest.fixture
+def broker(transport: FakeTransport) -> SessionBroker:
+    return SessionBroker(session_id="sess-1", transport=transport)
+
+
+class TestSessionBrokerAddRemove:
+    async def test_add_browser_sends_welcome(self, broker: SessionBroker) -> None:
+        ws = FakeWebSocket()
+        bc = await broker.add_browser(ws)
+        await asyncio.sleep(0.05)
+        assert len(ws.sent) >= 1
+        welcome = json.loads(ws.sent[0])
+        assert welcome["type"] == "system"
+        assert "sess-1" in welcome["content"]
+        await broker.remove_browser(bc)
+
+    async def test_remove_browser(self, broker: SessionBroker) -> None:
+        ws = FakeWebSocket()
+        bc = await broker.add_browser(ws)
+        await broker.remove_browser(bc)
+        assert ws.closed
+
+
+class TestSessionBrokerBroadcast:
+    async def test_broadcast_to_multiple_clients(self, broker: SessionBroker) -> None:
+        ws1 = FakeWebSocket()
+        ws2 = FakeWebSocket()
+        await broker.add_browser(ws1)
+        await broker.add_browser(ws2)
+        await asyncio.sleep(0.05)
+
+        # Clear welcome messages.
+        ws1.sent.clear()
+        ws2.sent.clear()
+
+        await broker._broadcast({"type": "test", "data": "hello"})
+        await asyncio.sleep(0.05)
+
+        assert len(ws1.sent) == 1
+        assert len(ws2.sent) == 1
+        assert json.loads(ws1.sent[0])["data"] == "hello"
+
+        await broker.stop()
+
+
+class TestSessionBrokerHandleBrowserMessage:
+    async def test_user_message_forwarded_to_transport(
+        self,
+        broker: SessionBroker,
+        transport: FakeTransport,
+    ) -> None:
+        ws = FakeWebSocket()
+        await broker.add_browser(ws)
+
+        await broker.handle_browser_message({"type": "user", "content": "hello"})
+
+        assert len(transport.user_messages) == 1
+        assert transport.user_messages[0][0] == "hello"
+        await broker.stop()
+
+    async def test_user_message_recorded_in_history(self, broker: SessionBroker) -> None:
+        ws = FakeWebSocket()
+        await broker.add_browser(ws)
+
+        await broker.handle_browser_message({"type": "user", "content": "test"})
+
+        history = broker.conversation_history()
+        assert len(history["turns"]) == 1
+        assert history["turns"][0]["role"] == "user"
+        assert history["turns"][0]["content"] == "test"
+        await broker.stop()
+
+    async def test_legacy_format_handled(
+        self,
+        broker: SessionBroker,
+        transport: FakeTransport,
+    ) -> None:
+        ws = FakeWebSocket()
+        await broker.add_browser(ws)
+
+        await broker.handle_browser_message({"content": "legacy msg"})
+
+        assert len(transport.user_messages) == 1
+        await broker.stop()
+
+    async def test_permission_response_forwarded(
+        self,
+        broker: SessionBroker,
+        transport: FakeTransport,
+    ) -> None:
+        ws = FakeWebSocket()
+        await broker.add_browser(ws)
+
+        await broker.handle_browser_message(
+            {
+                "type": "permission_response",
+                "request_id": "r1",
+                "behavior": "allow",
+            }
+        )
+
+        assert len(transport.control_responses) == 1
+        assert transport.control_responses[0]["subtype"] == "success"
+        await broker.stop()
+
+    async def test_interrupt_forwarded(
+        self,
+        broker: SessionBroker,
+        transport: FakeTransport,
+    ) -> None:
+        ws = FakeWebSocket()
+        await broker.add_browser(ws)
+
+        await broker.handle_browser_message({"type": "interrupt"})
+
+        assert len(transport.control_responses) == 1
+        assert transport.control_responses[0]["subtype"] == "interrupt"
+        await broker.stop()
+
+    async def test_empty_content_ignored(
+        self,
+        broker: SessionBroker,
+        transport: FakeTransport,
+    ) -> None:
+        ws = FakeWebSocket()
+        await broker.add_browser(ws)
+
+        await broker.handle_browser_message({"type": "user", "content": None})
+
+        assert len(transport.user_messages) == 0
+        await broker.stop()
+
+
+class TestSessionBrokerOnCliEvent:
+    async def test_assistant_result_flow(self, broker: SessionBroker) -> None:
+        ws = FakeWebSocket()
+        await broker.add_browser(ws)
+        await asyncio.sleep(0.05)
+        ws.sent.clear()
+
+        # Simulate assistant turn.
+        broker.on_cli_event({"type": "assistant", "message": {"model": "opus"}})
+        broker.on_cli_event(
+            {
+                "type": "content_block_delta",
+                "delta": {"text": "Hello "},
+            }
+        )
+        broker.on_cli_event(
+            {
+                "type": "content_block_delta",
+                "delta": {"text": "world"},
+            }
+        )
+        broker.on_cli_event({"type": "result", "result": ""})
+        await asyncio.sleep(0.1)
+
+        history = broker.conversation_history()
+        assert len(history["turns"]) == 1
+        assert history["turns"][0]["content"] == "Hello world"
+        assert history["turns"][0]["metadata"]["model"] == "opus"
+        await broker.stop()
+
+    async def test_result_fallback_text(self, broker: SessionBroker) -> None:
+        ws = FakeWebSocket()
+        await broker.add_browser(ws)
+        await asyncio.sleep(0.05)
+
+        broker.on_cli_event({"type": "assistant", "message": {}})
+        broker.on_cli_event({"type": "result", "result": "fallback text"})
+        await asyncio.sleep(0.05)
+
+        history = broker.conversation_history()
+        assert len(history["turns"]) == 1
+        assert history["turns"][0]["content"] == "fallback text"
+        await broker.stop()
+
+    async def test_keep_alive_filtered(self, broker: SessionBroker) -> None:
+        ws = FakeWebSocket()
+        await broker.add_browser(ws)
+        await asyncio.sleep(0.05)
+        ws.sent.clear()
+
+        result = broker.on_cli_event({"type": "keep_alive"})
+        assert result is None
+        await asyncio.sleep(0.05)
+        assert len(ws.sent) == 0
+        await broker.stop()
+
+    async def test_system_init_broadcasts_commands(self, broker: SessionBroker) -> None:
+        ws = FakeWebSocket()
+        await broker.add_browser(ws)
+        await asyncio.sleep(0.05)
+        ws.sent.clear()
+
+        broker.on_cli_event(
+            {
+                "type": "system",
+                "subtype": "init",
+                "slash_commands": ["/help"],
+            }
+        )
+        await asyncio.sleep(0.05)
+
+        # Should have both the system event broadcast and the available_commands broadcast
+        messages = [json.loads(m) for m in ws.sent]
+        cmd_msgs = [m for m in messages if m.get("type") == "available_commands"]
+        assert len(cmd_msgs) >= 1
+        assert cmd_msgs[0]["slash_commands"] == ["/help"]
+        await broker.stop()
+
+
+class TestSessionBrokerConversationHistory:
+    async def test_empty_history(self, broker: SessionBroker) -> None:
+        history = broker.conversation_history()
+        assert history["turns"] == []
+        assert history["is_active"] is False
+        assert history["last_activity"] == ""
+
+    async def test_history_replayed_for_late_joiner(self, broker: SessionBroker) -> None:
+        ws1 = FakeWebSocket()
+        await broker.add_browser(ws1)
+        await broker.handle_browser_message({"type": "user", "content": "first message"})
+
+        # Late joiner.
+        history = broker.conversation_history()
+        assert len(history["turns"]) == 1
+        assert history["turns"][0]["content"] == "first message"
+        await broker.stop()
+
+
+class TestSessionBrokerInjectMessage:
+    async def test_inject_message(
+        self,
+        broker: SessionBroker,
+        transport: FakeTransport,
+    ) -> None:
+        await broker.inject_message("injected content")
+        assert len(transport.user_messages) == 1
+        assert transport.user_messages[0][0] == "injected content"
+        history = broker.conversation_history()
+        assert len(history["turns"]) == 1
+
+
+class TestSessionBrokerStop:
+    async def test_stop_closes_all_browsers(self, broker: SessionBroker) -> None:
+        ws1 = FakeWebSocket()
+        ws2 = FakeWebSocket()
+        await broker.add_browser(ws1)
+        await broker.add_browser(ws2)
+
+        await broker.stop()
+
+        assert ws1.closed
+        assert ws2.closed

--- a/tests/test_cli/test_broker.py
+++ b/tests/test_cli/test_broker.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import pytest
 
-from cli.broker.broker import SessionBroker
+from cli.broker.broker import MAX_HISTORY_TURNS, SessionBroker
 
 
 class FakeWebSocket:
@@ -276,6 +276,17 @@ class TestSessionBrokerConversationHistory:
         history = broker.conversation_history()
         assert len(history["turns"]) == 1
         assert history["turns"][0]["content"] == "first message"
+        await broker.stop()
+
+    async def test_history_capped_at_max(self, broker: SessionBroker) -> None:
+        ws = FakeWebSocket()
+        await broker.add_browser(ws)
+        for i in range(MAX_HISTORY_TURNS + 50):
+            await broker.handle_browser_message({"type": "user", "content": f"msg-{i}"})
+        history = broker.conversation_history()
+        assert len(history["turns"]) == MAX_HISTORY_TURNS
+        # Oldest messages should have been trimmed — the last message should be the newest.
+        assert history["turns"][-1]["content"] == f"msg-{MAX_HISTORY_TURNS + 49}"
         await broker.stop()
 
 

--- a/tests/test_cli/test_broker_translate.py
+++ b/tests/test_cli/test_broker_translate.py
@@ -1,0 +1,131 @@
+"""Tests for cli.broker.translate — message translation functions."""
+
+from __future__ import annotations
+
+from cli.broker.translate import (
+    filter_cli_event,
+    skuld_to_sdk_control,
+    skuld_to_sdk_permission,
+)
+
+
+class TestSkuldToSdkPermission:
+    def test_translates_permission_response(self) -> None:
+        msg = {
+            "type": "permission_response",
+            "request_id": "req-1",
+            "behavior": "allow",
+            "updated_input": {"path": "/tmp"},
+            "updated_permissions": ["read"],
+        }
+        result = skuld_to_sdk_permission(msg)
+        assert result["subtype"] == "success"
+        assert result["request_id"] == "req-1"
+        assert result["response"]["behavior"] == "allow"
+        assert result["response"]["updatedInput"] == {"path": "/tmp"}
+        assert result["response"]["updatedPermissions"] == ["read"]
+
+    def test_defaults_for_missing_fields(self) -> None:
+        msg = {"type": "permission_response"}
+        result = skuld_to_sdk_permission(msg)
+        assert result["request_id"] == ""
+        assert result["response"]["behavior"] == ""
+        assert result["response"]["updatedInput"] == {}
+        assert result["response"]["updatedPermissions"] == []
+
+
+class TestSkuldToSdkControl:
+    def test_interrupt(self) -> None:
+        result = skuld_to_sdk_control("interrupt", {})
+        assert result["subtype"] == "interrupt"
+        assert "request_id" in result
+
+    def test_set_model(self) -> None:
+        result = skuld_to_sdk_control("set_model", {"model": "opus"})
+        assert result["subtype"] == "set_model"
+        assert result["model"] == "opus"
+
+    def test_set_max_thinking_tokens(self) -> None:
+        result = skuld_to_sdk_control("set_max_thinking_tokens", {"max_thinking_tokens": 1024})
+        assert result["max_thinking_tokens"] == 1024
+
+    def test_set_permission_mode(self) -> None:
+        result = skuld_to_sdk_control("set_permission_mode", {"mode": "auto"})
+        assert result["mode"] == "auto"
+
+    def test_mcp_set_servers(self) -> None:
+        servers = [{"name": "s1"}]
+        result = skuld_to_sdk_control("mcp_set_servers", {"servers": servers})
+        assert result["servers"] == servers
+
+    def test_rewind_files(self) -> None:
+        result = skuld_to_sdk_control("rewind_files", {})
+        assert result["subtype"] == "rewind_files"
+
+    def test_unknown_type_returns_basic_response(self) -> None:
+        result = skuld_to_sdk_control("unknown_type", {"foo": "bar"})
+        assert result["subtype"] == "unknown_type"
+
+
+class TestFilterCliEvent:
+    def test_drops_keep_alive(self) -> None:
+        assert filter_cli_event({"type": "keep_alive"}) is False
+
+    def test_drops_empty_content_block_delta(self) -> None:
+        assert (
+            filter_cli_event(
+                {
+                    "type": "content_block_delta",
+                    "delta": {"text": "", "thinking": "", "partial_json": ""},
+                }
+            )
+            is False
+        )
+
+    def test_drops_delta_without_dict(self) -> None:
+        assert filter_cli_event({"type": "content_block_delta", "delta": "bad"}) is False
+
+    def test_keeps_delta_with_text(self) -> None:
+        assert (
+            filter_cli_event(
+                {
+                    "type": "content_block_delta",
+                    "delta": {"text": "hello"},
+                }
+            )
+            is True
+        )
+
+    def test_keeps_delta_with_thinking(self) -> None:
+        assert (
+            filter_cli_event(
+                {
+                    "type": "content_block_delta",
+                    "delta": {"thinking": "hmm"},
+                }
+            )
+            is True
+        )
+
+    def test_keeps_delta_with_partial_json(self) -> None:
+        assert (
+            filter_cli_event(
+                {
+                    "type": "content_block_delta",
+                    "delta": {"partial_json": "{"},
+                }
+            )
+            is True
+        )
+
+    def test_keeps_user_event(self) -> None:
+        assert filter_cli_event({"type": "user"}) is True
+
+    def test_keeps_result_event(self) -> None:
+        assert filter_cli_event({"type": "result"}) is True
+
+    def test_keeps_assistant_event(self) -> None:
+        assert filter_cli_event({"type": "assistant"}) is True
+
+    def test_keeps_system_event(self) -> None:
+        assert filter_cli_event({"type": "system", "subtype": "init"}) is True

--- a/tests/test_cli/test_main.py
+++ b/tests/test_cli/test_main.py
@@ -61,9 +61,10 @@ class TestCLIEntryPoint:
         result = runner.invoke(_app(), ["config", "show"])
         assert result.exit_code == 0
 
-    def test_login_command(self) -> None:
+    def test_login_command_requires_issuer(self) -> None:
         result = runner.invoke(_app(), ["login"])
-        assert result.exit_code == 0
+        assert result.exit_code == 1
+        assert "issuer" in result.output.lower()
 
     def test_unknown_command_fails(self) -> None:
         result = runner.invoke(_app(), ["nonexistent"])

--- a/tests/test_cli/test_platform_commands.py
+++ b/tests/test_cli/test_platform_commands.py
@@ -242,12 +242,16 @@ class TestCreatePlatformCommands:
         assert "volundr" in result.output
 
     def test_platform_up_all_flag_in_help(self) -> None:
+        import re
+
         platform, *_ = self._make_platform()
         result = runner.invoke(platform, ["up", "--help"])
         assert result.exit_code == 0
+        # Strip ANSI escape codes before checking flag names.
+        plain = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
         # Must be --all, not --start-all
-        assert "--all" in result.output
-        assert "--start-all" not in result.output
+        assert "--all" in plain
+        assert "--start-all" not in plain
 
 
 class TestDependencyResolutionViaEnabledServices:


### PR DESCRIPTION
## Summary

- **API client** (`src/cli/api/`): Async httpx client with Bearer token auth and automatic 401 refresh. Full Volundr session endpoints (list, create, start, stop, delete, chronicle, timeline, stats, SSE activity stream) and Tyr endpoints (sagas, raids, dispatch).
- **OIDC auth** (`src/cli/auth/`): PKCE authorization code flow with local callback server, OIDC discovery, token exchange, Fernet-encrypted credential storage (`~/.niuu/credentials`), and refresh flow. Wired into `niuu login`, `niuu logout`, and `niuu whoami` commands.
- **WebSocket broker** (`src/cli/broker/`): Ported from Go broker. `SessionBroker` bridges N browser WebSocket clients to 1 SDK connection with fan-out broadcast, fan-in forwarding, 256-msg async queues per client, conversation history for late joiners, and Skuld-to-SDK protocol translation.

## Test plan

- [x] 90 new tests across all three modules (326 total CLI tests pass)
- [x] API client: respx mocks for all Volundr and Tyr endpoints, 401 refresh/retry
- [x] Auth: PKCE generation, token parsing, credential store round-trip, mock OIDC discovery/refresh
- [x] Broker: multi-client broadcast, history replay, disconnect handling, protocol translation
- [x] Ruff lint + format clean
- [x] Existing CLI tests updated for new login/whoami behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)