### PR TITLE
feat(cli): TUI component library, zinc theme, and keybinding/mode system (NIU-406)

### DIFF
--- a/src/cli/app.py
+++ b/src/cli/app.py
@@ -40,6 +40,7 @@ class _SortedGroup(typer.core.TyperGroup):
     def list_commands(self, ctx: click.Context) -> list[str]:
         return sorted(super().list_commands(ctx))
 
+
 logger = logging.getLogger(__name__)
 
 

--- a/src/cli/tui/__init__.py
+++ b/src/cli/tui/__init__.py
@@ -1,1 +1,6 @@
 """Textual TUI — dynamic pages from plugin registry."""
+
+from cli.tui.app import NiuuTUI, build_tui
+from cli.tui.mode import InputMode
+
+__all__ = ["InputMode", "NiuuTUI", "build_tui"]

--- a/src/cli/tui/app.py
+++ b/src/cli/tui/app.py
@@ -33,12 +33,9 @@ class NiuuTUI(App[str]):
 
     TITLE = "Niuu"
     SUB_TITLE = "Platform Control"
+    CSS_PATH = "theme.tcss"
 
     CSS = """
-    Screen {
-        background: #09090b;
-        color: #fafafa;
-    }
     #content {
         width: 1fr;
         height: 1fr;
@@ -133,7 +130,7 @@ class NiuuTUI(App[str]):
 
         # SEARCH/COMMAND: allow escape-like actions.
         if self.mode in (InputMode.SEARCH, InputMode.COMMAND):
-            search_allowed = {"enter_search", "open_palette", "toggle_help"}
+            search_allowed = {"enter_search", "toggle_help"}
             return action in search_allowed or None
 
         return True

--- a/src/cli/tui/app.py
+++ b/src/cli/tui/app.py
@@ -1,4 +1,7 @@
-"""Textual TUI app — queries plugin registry for pages dynamically."""
+"""Textual TUI app — queries plugin registry for pages dynamically.
+
+Uses the zinc theme, 4-mode keybinding system, and widget library.
+"""
 
 from __future__ import annotations
 
@@ -6,30 +9,26 @@ from typing import TYPE_CHECKING
 
 from textual.app import App, ComposeResult
 from textual.binding import Binding
-from textual.containers import Horizontal, Vertical
-from textual.widgets import Footer, Header, Static
+from textual.containers import Vertical
+from textual.reactive import reactive
+from textual.widgets import Static
+
+from cli.tui.mode import InputMode
+from cli.tui.widgets.command_palette import CommandPalette, PaletteItem, PaletteItemType
+from cli.tui.widgets.footer import NiuuFooter
+from cli.tui.widgets.header import NiuuHeader
+from cli.tui.widgets.help_overlay import HelpOverlay
+from cli.tui.widgets.sidebar import NiuuSidebar, SidebarPage
 
 if TYPE_CHECKING:
     from cli.registry import PluginRegistry, TUIPageSpec
-
-
-class PluginPageList(Static):
-    """Sidebar listing available plugin pages."""
-
-    def __init__(self, pages: list[TUIPageSpec], **kwargs: object) -> None:
-        self._pages = pages
-        lines = ["Available Pages:", ""]
-        for page in pages:
-            lines.append(f"  {page.icon} {page.name}")
-        if not pages:
-            lines.append("  (no plugins loaded)")
-        super().__init__("\n".join(lines), **kwargs)
 
 
 class NiuuTUI(App[str]):
     """Main niuu TUI application.
 
     Dynamically shows pages registered by plugins via the PluginRegistry.
+    Four input modes control keybinding routing.
     """
 
     TITLE = "Niuu"
@@ -37,63 +36,213 @@ class NiuuTUI(App[str]):
 
     CSS = """
     Screen {
-        layout: vertical;
+        background: #09090b;
+        color: #fafafa;
     }
-
-    #main-container {
-        height: 1fr;
-    }
-
-    #sidebar {
-        width: 30;
-        border: solid $accent;
-        padding: 1;
-    }
-
     #content {
         width: 1fr;
+        height: 1fr;
         padding: 1;
     }
-
     #welcome {
         margin: 1;
     }
     """
 
     BINDINGS = [
-        Binding("q", "quit", "Quit"),
+        Binding("q", "quit_app", "Quit", priority=True),
+        Binding("question_mark", "toggle_help", "Help", priority=True),
+        Binding("left_square_bracket", "toggle_sidebar", "Sidebar", priority=True),
+        Binding("slash", "enter_search", "Search", priority=True),
+        Binding("ctrl+k", "open_palette", "Palette", priority=True),
+        Binding("1", "go_page('0')", "Page 1", show=False, priority=True),
+        Binding("2", "go_page('1')", "Page 2", show=False, priority=True),
+        Binding("3", "go_page('2')", "Page 3", show=False, priority=True),
+        Binding("4", "go_page('3')", "Page 4", show=False, priority=True),
+        Binding("5", "go_page('4')", "Page 5", show=False, priority=True),
+        Binding("6", "go_page('5')", "Page 6", show=False, priority=True),
+        Binding("7", "go_page('6')", "Page 7", show=False, priority=True),
     ]
+
+    mode: reactive[InputMode] = reactive(InputMode.NORMAL)
 
     def __init__(
         self,
         pages: list[TUIPageSpec] | None = None,
         theme_name: str = "textual-dark",
+        server_url: str = "",
         **kwargs: object,
     ) -> None:
         super().__init__(**kwargs)
         self._pages: list[TUIPageSpec] = pages or []
         self._theme_name = theme_name
+        self._server_url = server_url
+
+    # ── Compose ──────────────────────────────────────────────
 
     def compose(self) -> ComposeResult:
-        yield Header()
-        with Horizontal(id="main-container"):
-            with Vertical(id="sidebar"):
-                yield PluginPageList(self._pages, id="page-list")
-            with Vertical(id="content"):
-                yield Static("Welcome to Niuu", id="welcome")
-        yield Footer()
+        sidebar_pages = [
+            SidebarPage(name=p.name, icon=p.icon, key=str(i + 1)) for i, p in enumerate(self._pages)
+        ]
+        yield NiuuHeader(
+            server_url=self._server_url,
+            id="niuu-header",
+        )
+        yield NiuuSidebar(sidebar_pages, id="niuu-sidebar")
+        with Vertical(id="content"):
+            yield Static("Welcome to Niuu", id="welcome")
+        yield NiuuFooter(id="niuu-footer")
 
     def on_mount(self) -> None:
         self.theme = self._theme_name
+
+    # ── Mode management ──────────────────────────────────────
+
+    def watch_mode(self, new_mode: InputMode) -> None:
+        try:
+            self.query_one("#niuu-header", NiuuHeader).mode = new_mode
+        except Exception:
+            pass
+        try:
+            self.query_one("#niuu-footer", NiuuFooter).mode = new_mode
+        except Exception:
+            pass
+
+    def set_mode(self, new_mode: InputMode) -> None:
+        self.mode = new_mode
+
+    # ── Key routing (mode-aware) ─────────────────────────────
+
+    def check_action(self, action: str, _parameters: tuple[object, ...]) -> bool | None:
+        """Block normal-mode keys when in INSERT/SEARCH/COMMAND mode."""
+        if self.mode == InputMode.NORMAL:
+            return True
+
+        # Always allow these regardless of mode.
+        always_allowed = {
+            "open_palette",
+            "quit_app",
+        }
+        if action in always_allowed:
+            return True
+
+        # In INSERT mode, suppress most global keys.
+        if self.mode == InputMode.INSERT:
+            insert_allowed = {"go_page", "toggle_help"}
+            return action in insert_allowed or None
+
+        # SEARCH/COMMAND: allow escape-like actions.
+        if self.mode in (InputMode.SEARCH, InputMode.COMMAND):
+            search_allowed = {"enter_search", "open_palette", "toggle_help"}
+            return action in search_allowed or None
+
+        return True
+
+    # ── Actions ──────────────────────────────────────────────
+
+    def action_quit_app(self) -> None:
+        self.exit()
+
+    def action_toggle_help(self) -> None:
+        self.push_screen(HelpOverlay())
+        self.set_mode(InputMode.NORMAL)
+
+    def action_toggle_sidebar(self) -> None:
+        try:
+            self.query_one("#niuu-sidebar", NiuuSidebar).toggle()
+        except Exception:
+            pass
+
+    def action_enter_search(self) -> None:
+        if self.mode == InputMode.SEARCH:
+            self.set_mode(InputMode.NORMAL)
+            return
+        self.set_mode(InputMode.SEARCH)
+
+    def action_open_palette(self) -> None:
+        items = self._build_palette_items()
+        self.set_mode(InputMode.COMMAND)
+        self.push_screen(
+            CommandPalette(items),
+            callback=self._on_palette_dismissed,
+        )
+
+    def _on_palette_dismissed(self, result: PaletteItem | None) -> None:
+        self.set_mode(InputMode.NORMAL)
+        if result is None:
+            return
+        if result.item_type == PaletteItemType.PAGE:
+            try:
+                idx = int(result.action_id)
+                self._navigate_to_page(idx)
+            except (ValueError, IndexError):
+                pass
+
+    def action_go_page(self, index_str: str) -> None:
+        try:
+            idx = int(index_str)
+        except ValueError:
+            return
+        self._navigate_to_page(idx)
+
+    def _navigate_to_page(self, index: int) -> None:
+        try:
+            sidebar = self.query_one("#niuu-sidebar", NiuuSidebar)
+        except Exception:
+            return
+        sidebar.select_page(index)
+
+    def _build_palette_items(self) -> list[PaletteItem]:
+        items: list[PaletteItem] = []
+        for i, page in enumerate(self._pages):
+            items.append(
+                PaletteItem(
+                    label=page.name,
+                    description=f"Go to {page.name}",
+                    item_type=PaletteItemType.PAGE,
+                    icon=page.icon,
+                    action_id=str(i),
+                )
+            )
+        items.append(
+            PaletteItem(
+                label="Toggle sidebar",
+                description="Show/hide sidebar",
+                item_type=PaletteItemType.ACTION,
+                icon="[",
+                action_id="toggle_sidebar",
+            )
+        )
+        items.append(
+            PaletteItem(
+                label="Help",
+                description="Show keybinding help",
+                item_type=PaletteItemType.ACTION,
+                icon="?",
+                action_id="toggle_help",
+            )
+        )
+        return items
+
+    # ── Sidebar message handling ─────────────────────────────
+
+    def on_niuu_sidebar_page_selected(self, message: NiuuSidebar.PageSelected) -> None:
+        # Future: switch content area to the selected page's widget.
+        try:
+            welcome = self.query_one("#welcome", Static)
+            welcome.update(f"[bold]{message.page.icon} {message.page.name}[/]")
+        except Exception:
+            pass
 
 
 def build_tui(
     registry: PluginRegistry | None = None,
     theme: str = "textual-dark",
+    server_url: str = "",
 ) -> NiuuTUI:
     """Build the TUI app from a plugin registry."""
     pages: list[TUIPageSpec] = []
     if registry:
         for plugin in registry.plugins.values():
             pages.extend(plugin.tui_pages())
-    return NiuuTUI(pages=pages, theme_name=theme)
+    return NiuuTUI(pages=pages, theme_name=theme, server_url=server_url)

--- a/src/cli/tui/mode.py
+++ b/src/cli/tui/mode.py
@@ -1,0 +1,42 @@
+"""Input-mode system for the Niuu TUI.
+
+Four modes control which keybindings are active:
+
+* NORMAL  — navigation (1-7, ?, q, [, etc.)
+* INSERT  — text input captured; most global keys suppressed
+* SEARCH  — filter/search active; / toggles, Esc exits
+* COMMAND — command palette open; Ctrl+K activates
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class InputMode(StrEnum):
+    """TUI input mode."""
+
+    NORMAL = "NORMAL"
+    INSERT = "INSERT"
+    SEARCH = "SEARCH"
+    COMMAND = "COMMAND"
+
+    def __str__(self) -> str:  # noqa: D105
+        return self.value
+
+
+# Mode → accent color (Textual CSS variable name).
+MODE_COLORS: dict[InputMode, str] = {
+    InputMode.NORMAL: "$accent-cyan",
+    InputMode.INSERT: "$accent-emerald",
+    InputMode.SEARCH: "$accent-amber",
+    InputMode.COMMAND: "$accent-purple",
+}
+
+# Raw hex fallback used in Rich markup inside widgets.
+MODE_COLORS_HEX: dict[InputMode, str] = {
+    InputMode.NORMAL: "#06b6d4",
+    InputMode.INSERT: "#10b981",
+    InputMode.SEARCH: "#f59e0b",
+    InputMode.COMMAND: "#a855f7",
+}

--- a/src/cli/tui/theme.py
+++ b/src/cli/tui/theme.py
@@ -1,0 +1,29 @@
+"""Zinc theme constants for the Niuu TUI.
+
+Exact color parity with the Go Bubble Tea TUI and the web UI (tokens.css).
+All widgets import from here — never hardcode colors.
+"""
+
+# ── Backgrounds ─────────────────────────────────────────────
+BG_PRIMARY = "#09090b"
+BG_SECONDARY = "#18181b"
+BG_TERTIARY = "#27272a"
+BG_ELEVATED = "#3f3f46"
+
+# ── Text ────────────────────────────────────────────────────
+TEXT_PRIMARY = "#fafafa"
+TEXT_SECONDARY = "#a1a1aa"
+TEXT_MUTED = "#71717a"
+
+# ── Borders ─────────────────────────────────────────────────
+BORDER = "#3f3f46"
+BORDER_SUBTLE = "#27272a"
+
+# ── Accents ─────────────────────────────────────────────────
+ACCENT_AMBER = "#f59e0b"
+ACCENT_CYAN = "#06b6d4"
+ACCENT_EMERALD = "#10b981"
+ACCENT_PURPLE = "#a855f7"
+ACCENT_RED = "#ef4444"
+ACCENT_INDIGO = "#6366f1"
+ACCENT_ORANGE = "#f97316"

--- a/src/cli/tui/theme.tcss
+++ b/src/cli/tui/theme.tcss
@@ -1,0 +1,35 @@
+/* Niuu TUI — Zinc dark theme.
+ *
+ * Exact color parity with the Go Bubble Tea TUI and the web UI.
+ * All widgets reference these variables — never hardcode colors.
+ */
+
+/* ── Backgrounds ─────────────────────────────────────────────── */
+$bg-primary: #09090b;
+$bg-secondary: #18181b;
+$bg-tertiary: #27272a;
+$bg-elevated: #3f3f46;
+
+/* ── Text ────────────────────────────────────────────────────── */
+$text-primary: #fafafa;
+$text-secondary: #a1a1aa;
+$text-muted: #71717a;
+
+/* ── Borders ─────────────────────────────────────────────────── */
+$border: #3f3f46;
+$border-subtle: #27272a;
+
+/* ── Accents ─────────────────────────────────────────────────── */
+$accent-amber: #f59e0b;
+$accent-cyan: #06b6d4;
+$accent-emerald: #10b981;
+$accent-purple: #a855f7;
+$accent-red: #ef4444;
+$accent-indigo: #6366f1;
+$accent-orange: #f97316;
+
+/* ── Global Screen ───────────────────────────────────────────── */
+Screen {
+    background: $bg-primary;
+    color: $text-primary;
+}

--- a/src/cli/tui/widgets/__init__.py
+++ b/src/cli/tui/widgets/__init__.py
@@ -7,7 +7,7 @@ from cli.tui.widgets.help_overlay import HelpOverlay, KeyBinding
 from cli.tui.widgets.mention_menu import MentionItem, MentionMenu
 from cli.tui.widgets.metric_card import MetricCard, MetricRow
 from cli.tui.widgets.modal import NiuuModal
-from cli.tui.widgets.sidebar import NiuuSidebar
+from cli.tui.widgets.sidebar import NiuuSidebar, SidebarPage
 from cli.tui.widgets.status_badge import StatusBadge
 from cli.tui.widgets.tabs import NiuuTabs
 
@@ -24,6 +24,7 @@ __all__ = [
     "NiuuModal",
     "NiuuSidebar",
     "NiuuTabs",
+    "SidebarPage",
     "HelpOverlay",
     "PaletteItem",
     "PaletteItemType",

--- a/src/cli/tui/widgets/__init__.py
+++ b/src/cli/tui/widgets/__init__.py
@@ -1,0 +1,31 @@
+"""Reusable Textual widgets for the Niuu TUI."""
+
+from cli.tui.widgets.command_palette import CommandPalette, PaletteItem, PaletteItemType
+from cli.tui.widgets.footer import NiuuFooter
+from cli.tui.widgets.header import ConnectionState, NiuuHeader
+from cli.tui.widgets.help_overlay import HelpOverlay, KeyBinding
+from cli.tui.widgets.mention_menu import MentionItem, MentionMenu
+from cli.tui.widgets.metric_card import MetricCard, MetricRow
+from cli.tui.widgets.modal import NiuuModal
+from cli.tui.widgets.sidebar import NiuuSidebar
+from cli.tui.widgets.status_badge import StatusBadge
+from cli.tui.widgets.tabs import NiuuTabs
+
+__all__ = [
+    "CommandPalette",
+    "ConnectionState",
+    "KeyBinding",
+    "MentionItem",
+    "MentionMenu",
+    "MetricCard",
+    "MetricRow",
+    "NiuuFooter",
+    "NiuuHeader",
+    "NiuuModal",
+    "NiuuSidebar",
+    "NiuuTabs",
+    "HelpOverlay",
+    "PaletteItem",
+    "PaletteItemType",
+    "StatusBadge",
+]

--- a/src/cli/tui/widgets/command_palette.py
+++ b/src/cli/tui/widgets/command_palette.py
@@ -11,6 +11,16 @@ from textual.message import Message
 from textual.screen import ModalScreen
 from textual.widgets import Input, Static
 
+from cli.tui.theme import (
+    ACCENT_AMBER,
+    ACCENT_CYAN,
+    ACCENT_EMERALD,
+    ACCENT_PURPLE,
+    BG_SECONDARY,
+    BG_TERTIARY,
+    TEXT_MUTED,
+)
+
 MAX_VISIBLE_RESULTS = 10
 
 
@@ -23,9 +33,9 @@ class PaletteItemType(StrEnum):
 
 
 _TYPE_COLORS: dict[PaletteItemType, str] = {
-    PaletteItemType.SESSION: "#10b981",
-    PaletteItemType.PAGE: "#06b6d4",
-    PaletteItemType.ACTION: "#f59e0b",
+    PaletteItemType.SESSION: ACCENT_EMERALD,
+    PaletteItemType.PAGE: ACCENT_CYAN,
+    PaletteItemType.ACTION: ACCENT_AMBER,
 }
 
 
@@ -54,38 +64,38 @@ def _fuzzy_match(query: str, text: str) -> bool:
 class CommandPalette(ModalScreen[PaletteItem | None]):
     """Ctrl+K command palette with fuzzy search."""
 
-    DEFAULT_CSS = """
-    CommandPalette {
+    DEFAULT_CSS = f"""
+    CommandPalette {{
         align: center top;
         padding-top: 3;
-    }
-    CommandPalette #palette-container {
+    }}
+    CommandPalette #palette-container {{
         width: 60;
         max-height: 70%;
-        background: #18181b;
-        border: round #a855f7;
+        background: {BG_SECONDARY};
+        border: round {ACCENT_PURPLE};
         padding: 1 2;
-    }
-    CommandPalette #palette-input {
+    }}
+    CommandPalette #palette-input {{
         margin-bottom: 1;
-    }
-    CommandPalette .palette-section-header {
-        color: #71717a;
+    }}
+    CommandPalette .palette-section-header {{
+        color: {TEXT_MUTED};
         text-style: bold;
         height: 1;
         margin-top: 1;
-    }
-    CommandPalette .palette-item {
+    }}
+    CommandPalette .palette-item {{
         height: 1;
         padding: 0 1;
-    }
-    CommandPalette .palette-item.selected {
-        background: #27272a;
-    }
-    CommandPalette #palette-more {
-        color: #71717a;
+    }}
+    CommandPalette .palette-item.selected {{
+        background: {BG_TERTIARY};
+    }}
+    CommandPalette #palette-more {{
+        color: {TEXT_MUTED};
         height: 1;
-    }
+    }}
     """
 
     BINDINGS = [
@@ -163,7 +173,7 @@ class CommandPalette(ModalScreen[PaletteItem | None]):
                 )
             icon = f"{item.icon} " if item.icon else ""
             color = _TYPE_COLORS[item.item_type]
-            desc = f" [#71717a]{item.description}[/]" if item.description else ""
+            desc = f" [{TEXT_MUTED}]{item.description}[/]" if item.description else ""
             classes = "palette-item selected" if i == self._cursor else "palette-item"
             container.mount(Static(f"[{color}]{icon}{item.label}[/]{desc}", classes=classes))
 

--- a/src/cli/tui/widgets/command_palette.py
+++ b/src/cli/tui/widgets/command_palette.py
@@ -1,0 +1,203 @@
+"""CommandPalette — modal screen with Ctrl+K fuzzy-search command launcher."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from textual.app import ComposeResult
+from textual.containers import Center, Vertical
+from textual.message import Message
+from textual.screen import ModalScreen
+from textual.widgets import Input, Static
+
+MAX_VISIBLE_RESULTS = 10
+
+
+class PaletteItemType(StrEnum):
+    """Category of a command palette item."""
+
+    SESSION = "session"
+    PAGE = "page"
+    ACTION = "action"
+
+
+_TYPE_COLORS: dict[PaletteItemType, str] = {
+    PaletteItemType.SESSION: "#10b981",
+    PaletteItemType.PAGE: "#06b6d4",
+    PaletteItemType.ACTION: "#f59e0b",
+}
+
+
+@dataclass(frozen=True)
+class PaletteItem:
+    """A single entry in the command palette."""
+
+    label: str
+    description: str = ""
+    item_type: PaletteItemType = PaletteItemType.ACTION
+    icon: str = ""
+    action_id: str = ""
+
+
+def _fuzzy_match(query: str, text: str) -> bool:
+    """Case-insensitive subsequence match."""
+    query = query.lower()
+    text = text.lower()
+    qi = 0
+    for char in text:
+        if qi < len(query) and char == query[qi]:
+            qi += 1
+    return qi == len(query)
+
+
+class CommandPalette(ModalScreen[PaletteItem | None]):
+    """Ctrl+K command palette with fuzzy search."""
+
+    DEFAULT_CSS = """
+    CommandPalette {
+        align: center top;
+        padding-top: 3;
+    }
+    CommandPalette #palette-container {
+        width: 60;
+        max-height: 70%;
+        background: #18181b;
+        border: round #a855f7;
+        padding: 1 2;
+    }
+    CommandPalette #palette-input {
+        margin-bottom: 1;
+    }
+    CommandPalette .palette-section-header {
+        color: #71717a;
+        text-style: bold;
+        height: 1;
+        margin-top: 1;
+    }
+    CommandPalette .palette-item {
+        height: 1;
+        padding: 0 1;
+    }
+    CommandPalette .palette-item.selected {
+        background: #27272a;
+    }
+    CommandPalette #palette-more {
+        color: #71717a;
+        height: 1;
+    }
+    """
+
+    BINDINGS = [
+        ("escape", "dismiss_palette", "Close"),
+    ]
+
+    class ItemSelected(Message):
+        """Fired when a palette item is selected."""
+
+        def __init__(self, item: PaletteItem) -> None:
+            super().__init__()
+            self.item = item
+
+    def __init__(
+        self,
+        items: list[PaletteItem] | None = None,
+        *,
+        name: str | None = None,
+        id: str | None = None,
+        classes: str | None = None,
+    ) -> None:
+        super().__init__(name=name, id=id, classes=classes)
+        self._all_items: list[PaletteItem] = items or []
+        self._matched: list[PaletteItem] = list(self._all_items)
+        self._cursor: int = 0
+
+    @property
+    def matched(self) -> list[PaletteItem]:
+        return list(self._matched)
+
+    @property
+    def cursor(self) -> int:
+        return self._cursor
+
+    def compose(self) -> ComposeResult:
+        with Center():
+            with Vertical(id="palette-container"):
+                yield Input(placeholder="Type to search…", id="palette-input")
+                yield Vertical(id="palette-results")
+
+    def on_mount(self) -> None:
+        self._filter("")
+        self.query_one("#palette-input", Input).focus()
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        self._filter(event.value)
+
+    def _filter(self, query: str) -> None:
+        if not query:
+            self._matched = list(self._all_items)
+        else:
+            self._matched = [item for item in self._all_items if _fuzzy_match(query, item.label)]
+        self._cursor = 0
+        self._rebuild_results()
+
+    def _rebuild_results(self) -> None:
+        try:
+            container = self.query_one("#palette-results", Vertical)
+        except Exception:
+            return
+        container.query("Static").remove()
+
+        visible = self._matched[:MAX_VISIBLE_RESULTS]
+        current_type: PaletteItemType | None = None
+
+        for i, item in enumerate(visible):
+            if item.item_type != current_type:
+                current_type = item.item_type
+                color = _TYPE_COLORS[item.item_type]
+                container.mount(
+                    Static(
+                        f"[{color}]{item.item_type.value.title()}s[/]",
+                        classes="palette-section-header",
+                    )
+                )
+            icon = f"{item.icon} " if item.icon else ""
+            color = _TYPE_COLORS[item.item_type]
+            desc = f" [#71717a]{item.description}[/]" if item.description else ""
+            classes = "palette-item selected" if i == self._cursor else "palette-item"
+            container.mount(Static(f"[{color}]{icon}{item.label}[/]{desc}", classes=classes))
+
+        remaining = len(self._matched) - MAX_VISIBLE_RESULTS
+        if remaining > 0:
+            container.mount(Static(f"  …{remaining} more", id="palette-more"))
+
+    def on_key(self, event: object) -> None:
+        from textual.events import Key
+
+        if not isinstance(event, Key):
+            return
+        if event.key in ("down", "j"):
+            self._move_cursor(1)
+            event.prevent_default()
+        elif event.key in ("up", "k"):
+            self._move_cursor(-1)
+            event.prevent_default()
+        elif event.key == "enter":
+            self._select_current()
+            event.prevent_default()
+
+    def _move_cursor(self, delta: int) -> None:
+        if not self._matched:
+            return
+        self._cursor = (self._cursor + delta) % len(self._matched)
+        self._rebuild_results()
+
+    def _select_current(self) -> None:
+        if not self._matched:
+            return
+        item = self._matched[self._cursor]
+        self.post_message(self.ItemSelected(item))
+        self.dismiss(item)
+
+    def action_dismiss_palette(self) -> None:
+        self.dismiss(None)

--- a/src/cli/tui/widgets/footer.py
+++ b/src/cli/tui/widgets/footer.py
@@ -1,0 +1,115 @@
+"""Footer widget — context-sensitive key hints per page and mode."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from textual.app import ComposeResult
+from textual.reactive import reactive
+from textual.widget import Widget
+from textual.widgets import Static
+
+from cli.tui.mode import InputMode
+
+
+@dataclass(frozen=True)
+class KeyHint:
+    """A single key hint shown in the footer."""
+
+    key: str
+    description: str
+
+
+# Default hints for NORMAL mode when no page overrides.
+DEFAULT_HINTS: list[KeyHint] = [
+    KeyHint("1-7", "pages"),
+    KeyHint("?", "help"),
+    KeyHint("[", "sidebar"),
+    KeyHint("/", "search"),
+    KeyHint("Ctrl+K", "command"),
+    KeyHint("q", "quit"),
+]
+
+INSERT_HINTS: list[KeyHint] = [
+    KeyHint("Esc", "normal mode"),
+    KeyHint("Alt+1-7", "pages"),
+]
+
+SEARCH_HINTS: list[KeyHint] = [
+    KeyHint("Esc", "cancel"),
+    KeyHint("Enter", "confirm"),
+    KeyHint("Tab", "next filter"),
+]
+
+COMMAND_HINTS: list[KeyHint] = [
+    KeyHint("Esc", "close"),
+    KeyHint("j/k", "navigate"),
+    KeyHint("Enter", "select"),
+]
+
+_MODE_HINTS: dict[InputMode, list[KeyHint]] = {
+    InputMode.NORMAL: DEFAULT_HINTS,
+    InputMode.INSERT: INSERT_HINTS,
+    InputMode.SEARCH: SEARCH_HINTS,
+    InputMode.COMMAND: COMMAND_HINTS,
+}
+
+
+class NiuuFooter(Widget):
+    """Bottom bar showing context-sensitive keybinding hints."""
+
+    DEFAULT_CSS = """
+    NiuuFooter {
+        dock: bottom;
+        height: 1;
+        background: #18181b;
+        color: #71717a;
+    }
+    NiuuFooter #footer-hints {
+        width: 1fr;
+        height: 1;
+    }
+    """
+
+    mode: reactive[InputMode] = reactive(InputMode.NORMAL)
+
+    def __init__(
+        self,
+        hints: list[KeyHint] | None = None,
+        *,
+        name: str | None = None,
+        id: str | None = None,
+        classes: str | None = None,
+    ) -> None:
+        super().__init__(name=name, id=id, classes=classes)
+        self._page_hints: list[KeyHint] | None = hints
+
+    def compose(self) -> ComposeResult:
+        yield Static(self._render_hints(), id="footer-hints")
+
+    def set_hints(self, hints: list[KeyHint]) -> None:
+        self._page_hints = hints
+        self._refresh()
+
+    def watch_mode(self) -> None:
+        self._refresh()
+
+    def _active_hints(self) -> list[KeyHint]:
+        if self.mode != InputMode.NORMAL:
+            return _MODE_HINTS[self.mode]
+        if self._page_hints is not None:
+            return self._page_hints
+        return DEFAULT_HINTS
+
+    def _render_hints(self) -> str:
+        parts: list[str] = []
+        for hint in self._active_hints():
+            parts.append(f" [bold #f59e0b]{hint.key}[/] {hint.description} ")
+        return "[#71717a]│[/]".join(parts)
+
+    def _refresh(self) -> None:
+        try:
+            bar = self.query_one("#footer-hints", Static)
+        except Exception:
+            return
+        bar.update(self._render_hints())

--- a/src/cli/tui/widgets/footer.py
+++ b/src/cli/tui/widgets/footer.py
@@ -10,6 +10,7 @@ from textual.widget import Widget
 from textual.widgets import Static
 
 from cli.tui.mode import InputMode
+from cli.tui.theme import ACCENT_AMBER, BG_SECONDARY, TEXT_MUTED
 
 
 @dataclass(frozen=True)
@@ -58,17 +59,17 @@ _MODE_HINTS: dict[InputMode, list[KeyHint]] = {
 class NiuuFooter(Widget):
     """Bottom bar showing context-sensitive keybinding hints."""
 
-    DEFAULT_CSS = """
-    NiuuFooter {
+    DEFAULT_CSS = f"""
+    NiuuFooter {{
         dock: bottom;
         height: 1;
-        background: #18181b;
-        color: #71717a;
-    }
-    NiuuFooter #footer-hints {
+        background: {BG_SECONDARY};
+        color: {TEXT_MUTED};
+    }}
+    NiuuFooter #footer-hints {{
         width: 1fr;
         height: 1;
-    }
+    }}
     """
 
     mode: reactive[InputMode] = reactive(InputMode.NORMAL)
@@ -104,8 +105,8 @@ class NiuuFooter(Widget):
     def _render_hints(self) -> str:
         parts: list[str] = []
         for hint in self._active_hints():
-            parts.append(f" [bold #f59e0b]{hint.key}[/] {hint.description} ")
-        return "[#71717a]│[/]".join(parts)
+            parts.append(f" [bold {ACCENT_AMBER}]{hint.key}[/] {hint.description} ")
+        return f"[{TEXT_MUTED}]│[/]".join(parts)
 
     def _refresh(self) -> None:
         try:

--- a/src/cli/tui/widgets/header.py
+++ b/src/cli/tui/widgets/header.py
@@ -1,0 +1,94 @@
+"""Header widget — top bar with hammer icon, title, mode badge, and connection status."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from textual.app import ComposeResult
+from textual.reactive import reactive
+from textual.widget import Widget
+from textual.widgets import Static
+
+from cli.tui.mode import MODE_COLORS_HEX, InputMode
+
+
+class ConnectionState(StrEnum):
+    """Server connection state shown in the header."""
+
+    CONNECTING = "connecting"
+    CONNECTED = "connected"
+    DISCONNECTED = "disconnected"
+
+
+_CONNECTION_INDICATORS: dict[ConnectionState, tuple[str, str]] = {
+    ConnectionState.CONNECTING: ("◌", "#f59e0b"),
+    ConnectionState.CONNECTED: ("●", "#10b981"),
+    ConnectionState.DISCONNECTED: ("●", "#ef4444"),
+}
+
+
+class NiuuHeader(Widget):
+    """Top bar: hammer icon + 'Niuu' + mode badge + connection dot + server URL."""
+
+    DEFAULT_CSS = """
+    NiuuHeader {
+        dock: top;
+        height: 1;
+        background: #18181b;
+        color: #fafafa;
+    }
+    NiuuHeader .header-content {
+        width: 1fr;
+        height: 1;
+    }
+    """
+
+    mode: reactive[InputMode] = reactive(InputMode.NORMAL)
+    connection: reactive[ConnectionState] = reactive(ConnectionState.CONNECTING)
+    server_url: reactive[str] = reactive("")
+
+    def __init__(
+        self,
+        server_url: str = "",
+        *,
+        mode: InputMode = InputMode.NORMAL,
+        connection: ConnectionState = ConnectionState.CONNECTING,
+        name: str | None = None,
+        id: str | None = None,
+        classes: str | None = None,
+    ) -> None:
+        super().__init__(name=name, id=id, classes=classes)
+        self.mode = mode
+        self.connection = connection
+        self.server_url = server_url
+
+    def compose(self) -> ComposeResult:
+        yield Static(self._render_bar(), id="header-bar", classes="header-content")
+
+    def _render_bar(self) -> str:
+        mode_color = MODE_COLORS_HEX[self.mode]
+        mode_label = f"[bold {mode_color}] {self.mode} [/]"
+
+        dot_char, dot_color = _CONNECTION_INDICATORS[self.connection]
+        status = f"[{dot_color}]{dot_char}[/]"
+
+        url_display = self.server_url.removeprefix("https://").removeprefix("http://")
+        url_part = f" [{dot_color}]{url_display}[/]" if url_display else ""
+
+        return f"[bold #f59e0b]⚒[/] [bold]Niuu[/] {mode_label}  {status}{url_part}"
+
+    def watch_mode(self) -> None:
+        self._refresh_bar()
+
+    def watch_connection(self) -> None:
+        self._refresh_bar()
+
+    def watch_server_url(self) -> None:
+        self._refresh_bar()
+
+    def _refresh_bar(self) -> None:
+        try:
+            bar = self.query_one("#header-bar", Static)
+        except Exception:
+            return
+        bar.update(self._render_bar())

--- a/src/cli/tui/widgets/header.py
+++ b/src/cli/tui/widgets/header.py
@@ -10,6 +10,13 @@ from textual.widget import Widget
 from textual.widgets import Static
 
 from cli.tui.mode import MODE_COLORS_HEX, InputMode
+from cli.tui.theme import (
+    ACCENT_AMBER,
+    ACCENT_EMERALD,
+    ACCENT_RED,
+    BG_SECONDARY,
+    TEXT_PRIMARY,
+)
 
 
 class ConnectionState(StrEnum):
@@ -21,26 +28,26 @@ class ConnectionState(StrEnum):
 
 
 _CONNECTION_INDICATORS: dict[ConnectionState, tuple[str, str]] = {
-    ConnectionState.CONNECTING: ("◌", "#f59e0b"),
-    ConnectionState.CONNECTED: ("●", "#10b981"),
-    ConnectionState.DISCONNECTED: ("●", "#ef4444"),
+    ConnectionState.CONNECTING: ("◌", ACCENT_AMBER),
+    ConnectionState.CONNECTED: ("●", ACCENT_EMERALD),
+    ConnectionState.DISCONNECTED: ("●", ACCENT_RED),
 }
 
 
 class NiuuHeader(Widget):
     """Top bar: hammer icon + 'Niuu' + mode badge + connection dot + server URL."""
 
-    DEFAULT_CSS = """
-    NiuuHeader {
+    DEFAULT_CSS = f"""
+    NiuuHeader {{
         dock: top;
         height: 1;
-        background: #18181b;
-        color: #fafafa;
-    }
-    NiuuHeader .header-content {
+        background: {BG_SECONDARY};
+        color: {TEXT_PRIMARY};
+    }}
+    NiuuHeader .header-content {{
         width: 1fr;
         height: 1;
-    }
+    }}
     """
 
     mode: reactive[InputMode] = reactive(InputMode.NORMAL)
@@ -75,7 +82,7 @@ class NiuuHeader(Widget):
         url_display = self.server_url.removeprefix("https://").removeprefix("http://")
         url_part = f" [{dot_color}]{url_display}[/]" if url_display else ""
 
-        return f"[bold #f59e0b]⚒[/] [bold]Niuu[/] {mode_label}  {status}{url_part}"
+        return f"[bold {ACCENT_AMBER}]⚒[/] [bold]Niuu[/] {mode_label}  {status}{url_part}"
 
     def watch_mode(self) -> None:
         self._refresh_bar()

--- a/src/cli/tui/widgets/help_overlay.py
+++ b/src/cli/tui/widgets/help_overlay.py
@@ -9,6 +9,14 @@ from textual.containers import Center, Vertical
 from textual.screen import ModalScreen
 from textual.widgets import Static
 
+from cli.tui.theme import (
+    ACCENT_AMBER,
+    ACCENT_PURPLE,
+    BG_SECONDARY,
+    TEXT_MUTED,
+    TEXT_SECONDARY,
+)
+
 
 @dataclass(frozen=True)
 class KeyBinding:
@@ -47,39 +55,39 @@ DEFAULT_BINDINGS: list[KeyBinding] = [
 class HelpOverlay(ModalScreen[None]):
     """Full-screen modal showing keybinding reference."""
 
-    DEFAULT_CSS = """
-    HelpOverlay {
+    DEFAULT_CSS = f"""
+    HelpOverlay {{
         align: center middle;
-    }
-    HelpOverlay #help-container {
+    }}
+    HelpOverlay #help-container {{
         width: 54;
         max-height: 80%;
-        background: #18181b;
-        border: round #f59e0b;
+        background: {BG_SECONDARY};
+        border: round {ACCENT_AMBER};
         padding: 1 2;
-    }
-    HelpOverlay #help-title {
+    }}
+    HelpOverlay #help-title {{
         text-align: center;
         text-style: bold;
-        color: #f59e0b;
+        color: {ACCENT_AMBER};
         height: 1;
         margin-bottom: 1;
-    }
-    HelpOverlay .help-section {
-        color: #a855f7;
+    }}
+    HelpOverlay .help-section {{
+        color: {ACCENT_PURPLE};
         text-style: bold;
         height: 1;
         margin-top: 1;
-    }
-    HelpOverlay .help-row {
+    }}
+    HelpOverlay .help-row {{
         height: 1;
-    }
-    HelpOverlay .help-close-hint {
+    }}
+    HelpOverlay .help-close-hint {{
         text-align: center;
-        color: #71717a;
+        color: {TEXT_MUTED};
         height: 1;
         margin-top: 1;
-    }
+    }}
     """
 
     BINDINGS = [
@@ -115,8 +123,9 @@ class HelpOverlay(ModalScreen[None]):
             if binding.section:
                 rows.append(Static(f"── {binding.section} ──", classes="help-section"))
                 continue
-            key_col = f"[bold #f59e0b]{binding.key:>14}[/]"
-            rows.append(Static(f"{key_col}  [#a1a1aa]{binding.description}[/]", classes="help-row"))
+            key_col = f"[bold {ACCENT_AMBER}]{binding.key:>14}[/]"
+            desc = f"[{TEXT_SECONDARY}]{binding.description}[/]"
+            rows.append(Static(f"{key_col}  {desc}", classes="help-row"))
         return rows
 
     def action_dismiss(self) -> None:

--- a/src/cli/tui/widgets/help_overlay.py
+++ b/src/cli/tui/widgets/help_overlay.py
@@ -1,0 +1,123 @@
+"""HelpOverlay — modal screen showing keybinding table grouped by section."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from textual.app import ComposeResult
+from textual.containers import Center, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Static
+
+
+@dataclass(frozen=True)
+class KeyBinding:
+    """A single keybinding entry.
+
+    Use key="" and description="" for a section header.
+    """
+
+    key: str
+    description: str
+    section: str = ""
+
+
+# Default keybindings shown in the help overlay.
+DEFAULT_BINDINGS: list[KeyBinding] = [
+    KeyBinding("", "", section="Navigation"),
+    KeyBinding("1-7", "Switch page"),
+    KeyBinding("Alt+1-7", "Switch page (insert mode)"),
+    KeyBinding("j / ↓", "Move down"),
+    KeyBinding("k / ↑", "Move up"),
+    KeyBinding("g", "Go to top"),
+    KeyBinding("G", "Go to bottom"),
+    KeyBinding("Enter", "Select"),
+    KeyBinding("", "", section="Modes"),
+    KeyBinding("/", "Enter search mode"),
+    KeyBinding("Ctrl+K", "Open command palette"),
+    KeyBinding("Esc", "Exit mode / close overlay"),
+    KeyBinding("", "", section="App"),
+    KeyBinding("[", "Toggle sidebar"),
+    KeyBinding("?", "Toggle help"),
+    KeyBinding("r", "Refresh"),
+    KeyBinding("q", "Quit"),
+]
+
+
+class HelpOverlay(ModalScreen[None]):
+    """Full-screen modal showing keybinding reference."""
+
+    DEFAULT_CSS = """
+    HelpOverlay {
+        align: center middle;
+    }
+    HelpOverlay #help-container {
+        width: 54;
+        max-height: 80%;
+        background: #18181b;
+        border: round #f59e0b;
+        padding: 1 2;
+    }
+    HelpOverlay #help-title {
+        text-align: center;
+        text-style: bold;
+        color: #f59e0b;
+        height: 1;
+        margin-bottom: 1;
+    }
+    HelpOverlay .help-section {
+        color: #a855f7;
+        text-style: bold;
+        height: 1;
+        margin-top: 1;
+    }
+    HelpOverlay .help-row {
+        height: 1;
+    }
+    HelpOverlay .help-close-hint {
+        text-align: center;
+        color: #71717a;
+        height: 1;
+        margin-top: 1;
+    }
+    """
+
+    BINDINGS = [
+        ("question_mark", "dismiss", "Close"),
+        ("escape", "dismiss", "Close"),
+    ]
+
+    def __init__(
+        self,
+        bindings: list[KeyBinding] | None = None,
+        *,
+        name: str | None = None,
+        id: str | None = None,
+        classes: str | None = None,
+    ) -> None:
+        super().__init__(name=name, id=id, classes=classes)
+        self._bindings_list = bindings or DEFAULT_BINDINGS
+
+    @property
+    def bindings_list(self) -> list[KeyBinding]:
+        return list(self._bindings_list)
+
+    def compose(self) -> ComposeResult:
+        with Center():
+            with Vertical(id="help-container"):
+                yield Static("⚒ Niuu — Keybindings", id="help-title")
+                yield from self._build_rows()
+                yield Static("Press ? or Esc to close", classes="help-close-hint")
+
+    def _build_rows(self) -> list[Static]:
+        rows: list[Static] = []
+        for binding in self._bindings_list:
+            if binding.section:
+                rows.append(Static(f"── {binding.section} ──", classes="help-section"))
+                continue
+            key_col = f"[bold #f59e0b]{binding.key:>14}[/]"
+            rows.append(Static(f"{key_col}  [#a1a1aa]{binding.description}[/]", classes="help-row"))
+        return rows
+
+    def action_dismiss(self) -> None:
+        self.dismiss(None)

--- a/src/cli/tui/widgets/mention_menu.py
+++ b/src/cli/tui/widgets/mention_menu.py
@@ -11,6 +11,8 @@ from textual.reactive import reactive
 from textual.widget import Widget
 from textual.widgets import Static
 
+from cli.tui.theme import ACCENT_AMBER, BG_SECONDARY, BG_TERTIARY, BORDER, TEXT_MUTED
+
 MAX_VISIBLE_ITEMS = 10
 
 
@@ -33,31 +35,31 @@ def _fuzzy_contains(query: str, text: str) -> bool:
 class MentionMenu(Widget):
     """Autocomplete dropdown showing up to 10 items with wrap-around selection."""
 
-    DEFAULT_CSS = """
-    MentionMenu {
+    DEFAULT_CSS = f"""
+    MentionMenu {{
         display: none;
         width: 50;
         max-height: 14;
-        background: #18181b;
-        border: round #3f3f46;
+        background: {BG_SECONDARY};
+        border: round {BORDER};
         padding: 0 1;
         layer: autocomplete;
-    }
-    MentionMenu.active {
+    }}
+    MentionMenu.active {{
         display: block;
-    }
-    MentionMenu .mention-item {
+    }}
+    MentionMenu .mention-item {{
         height: 1;
         padding: 0 1;
-    }
-    MentionMenu .mention-item.selected {
-        background: #27272a;
-        color: #f59e0b;
-    }
-    MentionMenu .mention-more {
-        color: #71717a;
+    }}
+    MentionMenu .mention-item.selected {{
+        background: {BG_TERTIARY};
+        color: {ACCENT_AMBER};
+    }}
+    MentionMenu .mention-more {{
+        color: {TEXT_MUTED};
         height: 1;
-    }
+    }}
     """
 
     active: reactive[bool] = reactive(False)
@@ -155,7 +157,7 @@ class MentionMenu(Widget):
 
         items = self.filtered
         if not items:
-            container.mount(Static("[#71717a]No matches[/]", classes="mention-more"))
+            container.mount(Static(f"[{TEXT_MUTED}]No matches[/]", classes="mention-more"))
             return
 
         # Window around selected item.
@@ -171,7 +173,7 @@ class MentionMenu(Widget):
         for i in range(start, end):
             item = items[i]
             icon = f"{item.icon} " if item.icon else ""
-            detail = f" [#71717a]{item.detail}[/]" if item.detail else ""
+            detail = f" [{TEXT_MUTED}]{item.detail}[/]" if item.detail else ""
             classes = "mention-item selected" if i == self.selected else "mention-item"
             container.mount(Static(f"{icon}{item.label}{detail}", classes=classes))
 

--- a/src/cli/tui/widgets/mention_menu.py
+++ b/src/cli/tui/widgets/mention_menu.py
@@ -1,0 +1,180 @@
+"""MentionMenu widget — autocomplete dropdown for @files, /commands, !issues."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.message import Message
+from textual.reactive import reactive
+from textual.widget import Widget
+from textual.widgets import Static
+
+MAX_VISIBLE_ITEMS = 10
+
+
+@dataclass(frozen=True)
+class MentionItem:
+    """A single autocomplete suggestion."""
+
+    label: str
+    value: str
+    detail: str = ""
+    icon: str = ""
+    category: str = ""
+
+
+def _fuzzy_contains(query: str, text: str) -> bool:
+    """Case-insensitive substring match."""
+    return query.lower() in text.lower()
+
+
+class MentionMenu(Widget):
+    """Autocomplete dropdown showing up to 10 items with wrap-around selection."""
+
+    DEFAULT_CSS = """
+    MentionMenu {
+        display: none;
+        width: 50;
+        max-height: 14;
+        background: #18181b;
+        border: round #3f3f46;
+        padding: 0 1;
+        layer: autocomplete;
+    }
+    MentionMenu.active {
+        display: block;
+    }
+    MentionMenu .mention-item {
+        height: 1;
+        padding: 0 1;
+    }
+    MentionMenu .mention-item.selected {
+        background: #27272a;
+        color: #f59e0b;
+    }
+    MentionMenu .mention-more {
+        color: #71717a;
+        height: 1;
+    }
+    """
+
+    active: reactive[bool] = reactive(False)
+    selected: reactive[int] = reactive(0)
+
+    class ItemChosen(Message):
+        """Fired when a mention item is selected."""
+
+        def __init__(self, item: MentionItem) -> None:
+            super().__init__()
+            self.item = item
+
+    def __init__(
+        self,
+        *,
+        trigger: str = "@",
+        name: str | None = None,
+        id: str | None = None,
+        classes: str | None = None,
+    ) -> None:
+        super().__init__(name=name, id=id, classes=classes)
+        self._trigger = trigger
+        self._items: list[MentionItem] = []
+        self._query = ""
+
+    @property
+    def trigger(self) -> str:
+        return self._trigger
+
+    @property
+    def items(self) -> list[MentionItem]:
+        return list(self._items)
+
+    @property
+    def filtered(self) -> list[MentionItem]:
+        if not self._query:
+            return list(self._items)
+        return [i for i in self._items if _fuzzy_contains(self._query, i.label)]
+
+    def compose(self) -> ComposeResult:
+        yield Vertical(id="mention-list")
+
+    def open(self, items: list[MentionItem] | None = None, query: str = "") -> None:
+        if items is not None:
+            self._items = list(items)
+        self._query = query
+        self.selected = 0
+        self.active = True
+        self._rebuild()
+
+    def close(self) -> None:
+        self.active = False
+        self._query = ""
+
+    def set_query(self, query: str) -> None:
+        self._query = query
+        self.selected = 0
+        self._rebuild()
+
+    def watch_active(self, value: bool) -> None:
+        if value:
+            self.add_class("active")
+        else:
+            self.remove_class("active")
+
+    def move_up(self) -> None:
+        items = self.filtered
+        if not items:
+            return
+        self.selected = (self.selected - 1) % len(items)
+        self._rebuild()
+
+    def move_down(self) -> None:
+        items = self.filtered
+        if not items:
+            return
+        self.selected = (self.selected + 1) % len(items)
+        self._rebuild()
+
+    def select_current(self) -> MentionItem | None:
+        items = self.filtered
+        if not items:
+            return None
+        item = items[self.selected]
+        self.post_message(self.ItemChosen(item))
+        self.close()
+        return item
+
+    def _rebuild(self) -> None:
+        try:
+            container = self.query_one("#mention-list", Vertical)
+        except Exception:
+            return
+        container.query("Static").remove()
+
+        items = self.filtered
+        if not items:
+            container.mount(Static("[#71717a]No matches[/]", classes="mention-more"))
+            return
+
+        # Window around selected item.
+        total = len(items)
+        start = max(0, self.selected - MAX_VISIBLE_ITEMS // 2)
+        end = min(total, start + MAX_VISIBLE_ITEMS)
+        if end - start < MAX_VISIBLE_ITEMS:
+            start = max(0, end - MAX_VISIBLE_ITEMS)
+
+        if start > 0:
+            container.mount(Static(f"  …{start} more above", classes="mention-more"))
+
+        for i in range(start, end):
+            item = items[i]
+            icon = f"{item.icon} " if item.icon else ""
+            detail = f" [#71717a]{item.detail}[/]" if item.detail else ""
+            classes = "mention-item selected" if i == self.selected else "mention-item"
+            container.mount(Static(f"{icon}{item.label}{detail}", classes=classes))
+
+        remaining = total - end
+        if remaining > 0:
+            container.mount(Static(f"  …{remaining} more below", classes="mention-more"))

--- a/src/cli/tui/widgets/metric_card.py
+++ b/src/cli/tui/widgets/metric_card.py
@@ -7,27 +7,29 @@ from textual.containers import Horizontal
 from textual.widget import Widget
 from textual.widgets import Static
 
-DEFAULT_METRIC_COLOR = "#06b6d4"
+from cli.tui.theme import ACCENT_CYAN, BG_SECONDARY, BORDER_SUBTLE, TEXT_MUTED
+
+DEFAULT_METRIC_COLOR = ACCENT_CYAN
 
 
 class MetricCard(Widget):
     """Bordered card displaying icon + value (bold, colored) + label (muted)."""
 
-    DEFAULT_CSS = """
-    MetricCard {
+    DEFAULT_CSS = f"""
+    MetricCard {{
         width: 22;
         height: 5;
-        border: round #27272a;
+        border: round {BORDER_SUBTLE};
         padding: 1 2;
-        background: #18181b;
-    }
-    MetricCard #metric-icon-value {
+        background: {BG_SECONDARY};
+    }}
+    MetricCard #metric-icon-value {{
         height: 1;
-    }
-    MetricCard #metric-label {
+    }}
+    MetricCard #metric-label {{
         height: 1;
-        color: #71717a;
-    }
+        color: {TEXT_MUTED};
+    }}
     """
 
     def __init__(
@@ -61,7 +63,7 @@ class MetricCard(Widget):
             f"[bold {self._color}]{icon_part}{self._value}[/]",
             id="metric-icon-value",
         )
-        yield Static(f"[#71717a]{self._label}[/]", id="metric-label")
+        yield Static(f"[{TEXT_MUTED}]{self._label}[/]", id="metric-label")
 
     def set_value(self, value: str) -> None:
         self._value = value

--- a/src/cli/tui/widgets/metric_card.py
+++ b/src/cli/tui/widgets/metric_card.py
@@ -1,0 +1,85 @@
+"""MetricCard widget — bordered box with icon, value, and label."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.containers import Horizontal
+from textual.widget import Widget
+from textual.widgets import Static
+
+DEFAULT_METRIC_COLOR = "#06b6d4"
+
+
+class MetricCard(Widget):
+    """Bordered card displaying icon + value (bold, colored) + label (muted)."""
+
+    DEFAULT_CSS = """
+    MetricCard {
+        width: 22;
+        height: 5;
+        border: round #27272a;
+        padding: 1 2;
+        background: #18181b;
+    }
+    MetricCard #metric-icon-value {
+        height: 1;
+    }
+    MetricCard #metric-label {
+        height: 1;
+        color: #71717a;
+    }
+    """
+
+    def __init__(
+        self,
+        label: str,
+        value: str,
+        icon: str = "",
+        color: str = DEFAULT_METRIC_COLOR,
+        *,
+        name: str | None = None,
+        id: str | None = None,
+        classes: str | None = None,
+    ) -> None:
+        super().__init__(name=name, id=id, classes=classes)
+        self._label = label
+        self._value = value
+        self._icon = icon
+        self._color = color
+
+    @property
+    def label(self) -> str:
+        return self._label
+
+    @property
+    def value(self) -> str:
+        return self._value
+
+    def compose(self) -> ComposeResult:
+        icon_part = f"{self._icon} " if self._icon else ""
+        yield Static(
+            f"[bold {self._color}]{icon_part}{self._value}[/]",
+            id="metric-icon-value",
+        )
+        yield Static(f"[#71717a]{self._label}[/]", id="metric-label")
+
+    def set_value(self, value: str) -> None:
+        self._value = value
+        try:
+            icon_part = f"{self._icon} " if self._icon else ""
+            self.query_one("#metric-icon-value", Static).update(
+                f"[bold {self._color}]{icon_part}{value}[/]"
+            )
+        except Exception:
+            pass
+
+
+class MetricRow(Horizontal):
+    """Horizontal layout container for MetricCard widgets."""
+
+    DEFAULT_CSS = """
+    MetricRow {
+        height: auto;
+        width: 1fr;
+    }
+    """

--- a/src/cli/tui/widgets/modal.py
+++ b/src/cli/tui/widgets/modal.py
@@ -8,6 +8,8 @@ from textual.reactive import reactive
 from textual.widget import Widget
 from textual.widgets import Static
 
+from cli.tui.theme import ACCENT_AMBER, BG_SECONDARY, TEXT_PRIMARY
+
 
 class NiuuModal(Widget):
     """Generic centered modal dialog.
@@ -15,33 +17,33 @@ class NiuuModal(Widget):
     Set ``visible`` reactive to show/hide.
     """
 
-    DEFAULT_CSS = """
-    NiuuModal {
+    DEFAULT_CSS = f"""
+    NiuuModal {{
         align: center middle;
         display: none;
-    }
-    NiuuModal.visible {
+    }}
+    NiuuModal.visible {{
         display: block;
         layer: modal;
-    }
-    NiuuModal #modal-container {
+    }}
+    NiuuModal #modal-container {{
         width: 60;
         max-height: 20;
-        background: #18181b;
-        border: round #f59e0b;
+        background: {BG_SECONDARY};
+        border: round {ACCENT_AMBER};
         padding: 1 2;
-    }
-    NiuuModal #modal-title {
+    }}
+    NiuuModal #modal-title {{
         text-align: center;
         text-style: bold;
-        color: #f59e0b;
+        color: {ACCENT_AMBER};
         height: 1;
         margin-bottom: 1;
-    }
-    NiuuModal #modal-body {
+    }}
+    NiuuModal #modal-body {{
         height: auto;
-        color: #fafafa;
-    }
+        color: {TEXT_PRIMARY};
+    }}
     """
 
     is_visible: reactive[bool] = reactive(False)

--- a/src/cli/tui/widgets/modal.py
+++ b/src/cli/tui/widgets/modal.py
@@ -1,0 +1,98 @@
+"""Modal widget — generic centered dialog with title and content."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.containers import Center, Vertical
+from textual.reactive import reactive
+from textual.widget import Widget
+from textual.widgets import Static
+
+
+class NiuuModal(Widget):
+    """Generic centered modal dialog.
+
+    Set ``visible`` reactive to show/hide.
+    """
+
+    DEFAULT_CSS = """
+    NiuuModal {
+        align: center middle;
+        display: none;
+    }
+    NiuuModal.visible {
+        display: block;
+        layer: modal;
+    }
+    NiuuModal #modal-container {
+        width: 60;
+        max-height: 20;
+        background: #18181b;
+        border: round #f59e0b;
+        padding: 1 2;
+    }
+    NiuuModal #modal-title {
+        text-align: center;
+        text-style: bold;
+        color: #f59e0b;
+        height: 1;
+        margin-bottom: 1;
+    }
+    NiuuModal #modal-body {
+        height: auto;
+        color: #fafafa;
+    }
+    """
+
+    is_visible: reactive[bool] = reactive(False)
+
+    def __init__(
+        self,
+        title: str = "",
+        content: str = "",
+        *,
+        name: str | None = None,
+        id: str | None = None,
+        classes: str | None = None,
+    ) -> None:
+        super().__init__(name=name, id=id, classes=classes)
+        self._title = title
+        self._content = content
+
+    @property
+    def title(self) -> str:
+        return self._title
+
+    @property
+    def content(self) -> str:
+        return self._content
+
+    def compose(self) -> ComposeResult:
+        with Center():
+            with Vertical(id="modal-container"):
+                yield Static(self._title, id="modal-title")
+                yield Static(self._content, id="modal-body")
+
+    def watch_is_visible(self, value: bool) -> None:
+        if value:
+            self.add_class("visible")
+        else:
+            self.remove_class("visible")
+
+    def show(self, title: str | None = None, content: str | None = None) -> None:
+        if title is not None:
+            self._title = title
+            try:
+                self.query_one("#modal-title", Static).update(title)
+            except Exception:
+                pass
+        if content is not None:
+            self._content = content
+            try:
+                self.query_one("#modal-body", Static).update(content)
+            except Exception:
+                pass
+        self.is_visible = True
+
+    def hide(self) -> None:
+        self.is_visible = False

--- a/src/cli/tui/widgets/sidebar.py
+++ b/src/cli/tui/widgets/sidebar.py
@@ -11,6 +11,15 @@ from textual.reactive import reactive
 from textual.widget import Widget
 from textual.widgets import Static
 
+from cli.tui.theme import (
+    ACCENT_AMBER,
+    BG_SECONDARY,
+    BG_TERTIARY,
+    BORDER_SUBTLE,
+    TEXT_MUTED,
+    TEXT_SECONDARY,
+)
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
@@ -31,32 +40,32 @@ class SidebarPage:
 class NiuuSidebar(Widget):
     """Navigation sidebar: 24ch expanded, 5ch collapsed."""
 
-    DEFAULT_CSS = """
-    NiuuSidebar {
+    DEFAULT_CSS = f"""
+    NiuuSidebar {{
         dock: left;
         width: 24;
-        background: #18181b;
-        border-right: solid #27272a;
+        background: {BG_SECONDARY};
+        border-right: solid {BORDER_SUBTLE};
         padding: 1 0;
-    }
-    NiuuSidebar.collapsed {
+    }}
+    NiuuSidebar.collapsed {{
         width: 5;
-    }
-    NiuuSidebar .sidebar-item {
+    }}
+    NiuuSidebar .sidebar-item {{
         padding: 0 1;
-        color: #a1a1aa;
+        color: {TEXT_SECONDARY};
         height: 1;
-    }
-    NiuuSidebar .sidebar-item.active {
-        color: #f59e0b;
-        background: #27272a;
+    }}
+    NiuuSidebar .sidebar-item.active {{
+        color: {ACCENT_AMBER};
+        background: {BG_TERTIARY};
         text-style: bold;
-    }
-    NiuuSidebar .sidebar-hint {
-        color: #71717a;
+    }}
+    NiuuSidebar .sidebar-hint {{
+        color: {TEXT_MUTED};
         padding: 0 1;
         height: 1;
-    }
+    }}
     """
 
     collapsed: reactive[bool] = reactive(False)

--- a/src/cli/tui/widgets/sidebar.py
+++ b/src/cli/tui/widgets/sidebar.py
@@ -1,0 +1,139 @@
+"""Sidebar widget — page navigation with icons, names, and number-key hints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from textual.app import ComposeResult
+from textual.message import Message
+from textual.reactive import reactive
+from textual.widget import Widget
+from textual.widgets import Static
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+SIDEBAR_EXPANDED_WIDTH = 24
+SIDEBAR_COLLAPSED_WIDTH = 5
+
+
+@dataclass(frozen=True)
+class SidebarPage:
+    """A page entry rendered in the sidebar."""
+
+    name: str
+    icon: str
+    key: str  # e.g. "1", "2"
+
+
+class NiuuSidebar(Widget):
+    """Navigation sidebar: 24ch expanded, 5ch collapsed."""
+
+    DEFAULT_CSS = """
+    NiuuSidebar {
+        dock: left;
+        width: 24;
+        background: #18181b;
+        border-right: solid #27272a;
+        padding: 1 0;
+    }
+    NiuuSidebar.collapsed {
+        width: 5;
+    }
+    NiuuSidebar .sidebar-item {
+        padding: 0 1;
+        color: #a1a1aa;
+        height: 1;
+    }
+    NiuuSidebar .sidebar-item.active {
+        color: #f59e0b;
+        background: #27272a;
+        text-style: bold;
+    }
+    NiuuSidebar .sidebar-hint {
+        color: #71717a;
+        padding: 0 1;
+        height: 1;
+    }
+    """
+
+    collapsed: reactive[bool] = reactive(False)
+    active_index: reactive[int] = reactive(0)
+
+    class PageSelected(Message):
+        """Fired when a sidebar page is clicked or navigated to."""
+
+        def __init__(self, index: int, page: SidebarPage) -> None:
+            super().__init__()
+            self.index = index
+            self.page = page
+
+    def __init__(
+        self,
+        pages: Sequence[SidebarPage] = (),
+        *,
+        name: str | None = None,
+        id: str | None = None,
+        classes: str | None = None,
+    ) -> None:
+        super().__init__(name=name, id=id, classes=classes)
+        self._pages: list[SidebarPage] = list(pages)
+        self._mounted = False
+
+    @property
+    def pages(self) -> list[SidebarPage]:
+        return list(self._pages)
+
+    def set_pages(self, pages: Sequence[SidebarPage]) -> None:
+        self._pages = list(pages)
+        if self._mounted:
+            self._rebuild()
+
+    def compose(self) -> ComposeResult:
+        yield from self._build_items()
+
+    def on_mount(self) -> None:
+        self._mounted = True
+
+    def _build_items(self) -> list[Static]:
+        items: list[Static] = []
+        for i, page in enumerate(self._pages):
+            if self.collapsed:
+                label = page.icon
+            else:
+                label = f"{page.icon} {page.name:<14}{page.key}"
+            classes = "sidebar-item active" if i == self.active_index else "sidebar-item"
+            items.append(Static(label, classes=classes))
+
+        if not self.collapsed:
+            items.append(Static("? help  q quit", classes="sidebar-hint"))
+        return items
+
+    def watch_collapsed(self) -> None:
+        if self.collapsed:
+            self.add_class("collapsed")
+        else:
+            self.remove_class("collapsed")
+        if self._mounted:
+            self._rebuild()
+
+    def watch_active_index(self) -> None:
+        if self._mounted:
+            self._rebuild()
+
+    def _rebuild(self) -> None:
+        existing = self.query("Static")
+        if existing:
+            existing.remove()
+        for widget in self._build_items():
+            self.mount(widget)
+
+    def toggle(self) -> None:
+        self.collapsed = not self.collapsed
+
+    def select_page(self, index: int) -> None:
+        if 0 <= index < len(self._pages):
+            self.active_index = index
+            self.post_message(self.PageSelected(index, self._pages[index]))

--- a/src/cli/tui/widgets/status_badge.py
+++ b/src/cli/tui/widgets/status_badge.py
@@ -1,0 +1,67 @@
+"""StatusBadge widget — colored dot + label for status indicators."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.widget import Widget
+from textual.widgets import Static
+
+# Status → (dot character, color hex).
+_STATUS_MAP: dict[str, tuple[str, str]] = {
+    "running": ("●", "#10b981"),
+    "connected": ("●", "#10b981"),
+    "starting": ("◐", "#f59e0b"),
+    "provisioning": ("◐", "#f59e0b"),
+    "stopped": ("○", "#71717a"),
+    "disconnected": ("○", "#71717a"),
+    "error": ("●", "#ef4444"),
+    "failed": ("●", "#ef4444"),
+    "completed": ("●", "#06b6d4"),
+    "pending": ("◌", "#a855f7"),
+}
+
+_DEFAULT_INDICATOR: tuple[str, str] = ("○", "#71717a")
+
+
+class StatusBadge(Widget):
+    """Colored dot + label showing a status value."""
+
+    DEFAULT_CSS = """
+    StatusBadge {
+        height: 1;
+        width: auto;
+    }
+    """
+
+    def __init__(
+        self,
+        status: str = "stopped",
+        *,
+        name: str | None = None,
+        id: str | None = None,
+        classes: str | None = None,
+    ) -> None:
+        super().__init__(name=name, id=id, classes=classes)
+        self._status = status
+
+    @property
+    def status(self) -> str:
+        return self._status
+
+    def set_status(self, status: str) -> None:
+        self._status = status
+        self._refresh()
+
+    def compose(self) -> ComposeResult:
+        yield Static(self._render(), id="badge-label")
+
+    def _render(self) -> str:
+        dot, color = _STATUS_MAP.get(self._status, _DEFAULT_INDICATOR)
+        return f"[{color}]{dot}[/] [{color}]{self._status}[/]"
+
+    def _refresh(self) -> None:
+        try:
+            label = self.query_one("#badge-label", Static)
+        except Exception:
+            return
+        label.update(self._render())

--- a/src/cli/tui/widgets/status_badge.py
+++ b/src/cli/tui/widgets/status_badge.py
@@ -6,21 +6,30 @@ from textual.app import ComposeResult
 from textual.widget import Widget
 from textual.widgets import Static
 
+from cli.tui.theme import (
+    ACCENT_AMBER,
+    ACCENT_CYAN,
+    ACCENT_EMERALD,
+    ACCENT_PURPLE,
+    ACCENT_RED,
+    TEXT_MUTED,
+)
+
 # Status → (dot character, color hex).
 _STATUS_MAP: dict[str, tuple[str, str]] = {
-    "running": ("●", "#10b981"),
-    "connected": ("●", "#10b981"),
-    "starting": ("◐", "#f59e0b"),
-    "provisioning": ("◐", "#f59e0b"),
-    "stopped": ("○", "#71717a"),
-    "disconnected": ("○", "#71717a"),
-    "error": ("●", "#ef4444"),
-    "failed": ("●", "#ef4444"),
-    "completed": ("●", "#06b6d4"),
-    "pending": ("◌", "#a855f7"),
+    "running": ("●", ACCENT_EMERALD),
+    "connected": ("●", ACCENT_EMERALD),
+    "starting": ("◐", ACCENT_AMBER),
+    "provisioning": ("◐", ACCENT_AMBER),
+    "stopped": ("○", TEXT_MUTED),
+    "disconnected": ("○", TEXT_MUTED),
+    "error": ("●", ACCENT_RED),
+    "failed": ("●", ACCENT_RED),
+    "completed": ("●", ACCENT_CYAN),
+    "pending": ("◌", ACCENT_PURPLE),
 }
 
-_DEFAULT_INDICATOR: tuple[str, str] = ("○", "#71717a")
+_DEFAULT_INDICATOR: tuple[str, str] = ("○", TEXT_MUTED)
 
 
 class StatusBadge(Widget):

--- a/src/cli/tui/widgets/tabs.py
+++ b/src/cli/tui/widgets/tabs.py
@@ -8,20 +8,22 @@ from textual.reactive import reactive
 from textual.widget import Widget
 from textual.widgets import Static
 
+from cli.tui.theme import ACCENT_AMBER, BG_ELEVATED, BG_SECONDARY, BORDER_SUBTLE, TEXT_MUTED
+
 
 class NiuuTabs(Widget):
     """Horizontal tab bar. Active tab = amber + bold + underline."""
 
-    DEFAULT_CSS = """
-    NiuuTabs {
+    DEFAULT_CSS = f"""
+    NiuuTabs {{
         height: 1;
-        background: #18181b;
-        border-bottom: solid #27272a;
-    }
-    NiuuTabs #tabs-bar {
+        background: {BG_SECONDARY};
+        border-bottom: solid {BORDER_SUBTLE};
+    }}
+    NiuuTabs #tabs-bar {{
         width: 1fr;
         height: 1;
-    }
+    }}
     """
 
     active_tab: reactive[int] = reactive(0)
@@ -68,10 +70,10 @@ class NiuuTabs(Widget):
         parts: list[str] = []
         for i, label in enumerate(self._items):
             if i == self.active_tab:
-                parts.append(f"[bold underline #f59e0b] {label} [/]")
+                parts.append(f"[bold underline {ACCENT_AMBER}] {label} [/]")
             else:
-                parts.append(f"[#71717a] {label} [/]")
-        return " [#3f3f46]│[/] ".join(parts)
+                parts.append(f"[{TEXT_MUTED}] {label} [/]")
+        return f" [{BG_ELEVATED}]│[/] ".join(parts)
 
     def _refresh(self) -> None:
         try:

--- a/src/cli/tui/widgets/tabs.py
+++ b/src/cli/tui/widgets/tabs.py
@@ -1,0 +1,81 @@
+"""Tabs widget — horizontal tab bar with separators."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.message import Message
+from textual.reactive import reactive
+from textual.widget import Widget
+from textual.widgets import Static
+
+
+class NiuuTabs(Widget):
+    """Horizontal tab bar. Active tab = amber + bold + underline."""
+
+    DEFAULT_CSS = """
+    NiuuTabs {
+        height: 1;
+        background: #18181b;
+        border-bottom: solid #27272a;
+    }
+    NiuuTabs #tabs-bar {
+        width: 1fr;
+        height: 1;
+    }
+    """
+
+    active_tab: reactive[int] = reactive(0)
+
+    class TabSelected(Message):
+        """Fired when a tab is selected."""
+
+        def __init__(self, index: int, label: str) -> None:
+            super().__init__()
+            self.index = index
+            self.label = label
+
+    def __init__(
+        self,
+        items: list[str] | None = None,
+        *,
+        name: str | None = None,
+        id: str | None = None,
+        classes: str | None = None,
+    ) -> None:
+        super().__init__(name=name, id=id, classes=classes)
+        self._items: list[str] = items or []
+
+    @property
+    def items(self) -> list[str]:
+        return list(self._items)
+
+    def compose(self) -> ComposeResult:
+        yield Static(self._render(), id="tabs-bar")
+
+    def set_items(self, items: list[str]) -> None:
+        self._items = list(items)
+        self._refresh()
+
+    def select(self, index: int) -> None:
+        if 0 <= index < len(self._items):
+            self.active_tab = index
+            self.post_message(self.TabSelected(index, self._items[index]))
+
+    def watch_active_tab(self) -> None:
+        self._refresh()
+
+    def _render(self) -> str:
+        parts: list[str] = []
+        for i, label in enumerate(self._items):
+            if i == self.active_tab:
+                parts.append(f"[bold underline #f59e0b] {label} [/]")
+            else:
+                parts.append(f"[#71717a] {label} [/]")
+        return " [#3f3f46]│[/] ".join(parts)
+
+    def _refresh(self) -> None:
+        try:
+            bar = self.query_one("#tabs-bar", Static)
+        except Exception:
+            return
+        bar.update(self._render())

--- a/tests/test_cli/test_platform_commands.py
+++ b/tests/test_cli/test_platform_commands.py
@@ -242,12 +242,16 @@ class TestCreatePlatformCommands:
         assert "volundr" in result.output
 
     def test_platform_up_all_flag_in_help(self) -> None:
+        import re
+
         platform, *_ = self._make_platform()
         result = runner.invoke(platform, ["up", "--help"])
         assert result.exit_code == 0
+        # Strip ANSI escape codes before checking flag names.
+        clean = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
         # Must be --all, not --start-all
-        assert "--all" in result.output
-        assert "--start-all" not in result.output
+        assert "--all" in clean
+        assert "--start-all" not in clean
 
 
 class TestDependencyResolutionViaEnabledServices:

--- a/tests/test_cli/test_tui.py
+++ b/tests/test_cli/test_tui.py
@@ -1,4 +1,4 @@
-"""Tests for cli.tui.app — Textual TUI app."""
+"""Tests for cli.tui.app — Textual TUI app with mode system and widgets."""
 
 from __future__ import annotations
 
@@ -6,94 +6,941 @@ import pytest
 from textual.widgets import Static
 
 from cli.registry import PluginRegistry, TUIPageSpec
-from cli.tui.app import NiuuTUI, PluginPageList, build_tui
+from cli.tui.app import NiuuTUI, build_tui
+from cli.tui.mode import MODE_COLORS, MODE_COLORS_HEX, InputMode
+from cli.tui.widgets.command_palette import (
+    CommandPalette,
+    PaletteItem,
+    PaletteItemType,
+    _fuzzy_match,
+)
+from cli.tui.widgets.footer import (
+    DEFAULT_HINTS,
+    INSERT_HINTS,
+    KeyHint,
+    NiuuFooter,
+)
+from cli.tui.widgets.header import ConnectionState, NiuuHeader
+from cli.tui.widgets.help_overlay import DEFAULT_BINDINGS, HelpOverlay, KeyBinding
+from cli.tui.widgets.mention_menu import MentionItem, MentionMenu, _fuzzy_contains
+from cli.tui.widgets.metric_card import DEFAULT_METRIC_COLOR, MetricCard, MetricRow
+from cli.tui.widgets.modal import NiuuModal
+from cli.tui.widgets.sidebar import (
+    SIDEBAR_COLLAPSED_WIDTH,
+    SIDEBAR_EXPANDED_WIDTH,
+    NiuuSidebar,
+    SidebarPage,
+)
+from cli.tui.widgets.status_badge import _STATUS_MAP, StatusBadge
+from cli.tui.widgets.tabs import NiuuTabs
 from tests.test_cli.conftest import FakePlugin
+
+# ── Fixtures ─────────────────────────────────────────────────
+
+
+SAMPLE_PAGES = [
+    TUIPageSpec(name="Sessions", icon="S", widget_class=Static),
+    TUIPageSpec(name="Sagas", icon="T", widget_class=Static),
+]
 
 
 @pytest.fixture
 def tui_app() -> NiuuTUI:
+    return NiuuTUI(pages=SAMPLE_PAGES)
+
+
+@pytest.fixture
+def empty_app() -> NiuuTUI:
     return NiuuTUI()
 
 
-async def test_app_starts(tui_app: NiuuTUI) -> None:
-    """App mounts successfully."""
-    async with tui_app.run_test() as pilot:
-        assert tui_app.title == "Niuu"
-        assert tui_app.sub_title == "Platform Control"
-        await pilot.pause()
+# ── InputMode tests ──────────────────────────────────────────
 
 
-async def test_sidebar_present(tui_app: NiuuTUI) -> None:
-    """Sidebar with page list is rendered."""
-    async with tui_app.run_test() as pilot:
-        await pilot.pause()
-        sidebar = tui_app.query_one("#sidebar")
-        assert sidebar is not None
+class TestInputMode:
+    def test_mode_values(self) -> None:
+        assert InputMode.NORMAL.value == "NORMAL"
+        assert InputMode.INSERT.value == "INSERT"
+        assert InputMode.SEARCH.value == "SEARCH"
+        assert InputMode.COMMAND.value == "COMMAND"
+
+    def test_mode_str(self) -> None:
+        assert str(InputMode.NORMAL) == "NORMAL"
+        assert str(InputMode.INSERT) == "INSERT"
+
+    def test_mode_colors_mapping(self) -> None:
+        for mode in InputMode:
+            assert mode in MODE_COLORS
+            assert mode in MODE_COLORS_HEX
+
+    def test_mode_colors_hex_format(self) -> None:
+        for color in MODE_COLORS_HEX.values():
+            assert color.startswith("#")
+            assert len(color) == 7
+
+    def test_mode_is_enum(self) -> None:
+        assert len(InputMode) == 4
+
+    def test_mode_comparison(self) -> None:
+        assert InputMode.NORMAL == "NORMAL"
+        assert InputMode.INSERT != InputMode.NORMAL
 
 
-async def test_welcome_message(tui_app: NiuuTUI) -> None:
-    """Content area shows welcome message."""
-    async with tui_app.run_test() as pilot:
-        await pilot.pause()
-        welcome = tui_app.query_one("#welcome", Static)
-        assert welcome is not None
+# ── NiuuTUI app tests ───────────────────────────────────────
 
 
-async def test_quit_binding(tui_app: NiuuTUI) -> None:
-    """Pressing q exits the app."""
-    async with tui_app.run_test() as pilot:
-        await pilot.pause()
-        await pilot.press("q")
-        assert True
+class TestNiuuTUI:
+    async def test_app_starts(self, tui_app: NiuuTUI) -> None:
+        async with tui_app.run_test() as pilot:
+            assert tui_app.title == "Niuu"
+            assert tui_app.sub_title == "Platform Control"
+            await pilot.pause()
+
+    async def test_initial_mode_is_normal(self, tui_app: NiuuTUI) -> None:
+        async with tui_app.run_test() as pilot:
+            await pilot.pause()
+            assert tui_app.mode == InputMode.NORMAL
+
+    async def test_header_present(self, tui_app: NiuuTUI) -> None:
+        async with tui_app.run_test() as pilot:
+            await pilot.pause()
+            header = tui_app.query_one("#niuu-header", NiuuHeader)
+            assert header is not None
+
+    async def test_sidebar_present(self, tui_app: NiuuTUI) -> None:
+        async with tui_app.run_test() as pilot:
+            await pilot.pause()
+            sidebar = tui_app.query_one("#niuu-sidebar", NiuuSidebar)
+            assert sidebar is not None
+
+    async def test_footer_present(self, tui_app: NiuuTUI) -> None:
+        async with tui_app.run_test() as pilot:
+            await pilot.pause()
+            footer = tui_app.query_one("#niuu-footer", NiuuFooter)
+            assert footer is not None
+
+    async def test_welcome_message(self, tui_app: NiuuTUI) -> None:
+        async with tui_app.run_test() as pilot:
+            await pilot.pause()
+            welcome = tui_app.query_one("#welcome", Static)
+            assert welcome is not None
+
+    async def test_quit_binding(self, tui_app: NiuuTUI) -> None:
+        async with tui_app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("q")
+
+    async def test_theme_applied(self) -> None:
+        app = NiuuTUI(theme_name="textual-light")
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app.theme == "textual-light"
+
+    async def test_toggle_sidebar(self, tui_app: NiuuTUI) -> None:
+        async with tui_app.run_test() as pilot:
+            await pilot.pause()
+            sidebar = tui_app.query_one("#niuu-sidebar", NiuuSidebar)
+            assert not sidebar.collapsed
+            await pilot.press("left_square_bracket")
+            await pilot.pause()
+            assert sidebar.collapsed
+
+    async def test_set_mode(self, tui_app: NiuuTUI) -> None:
+        async with tui_app.run_test() as pilot:
+            await pilot.pause()
+            tui_app.set_mode(InputMode.INSERT)
+            assert tui_app.mode == InputMode.INSERT
+
+    async def test_enter_search_mode(self, tui_app: NiuuTUI) -> None:
+        async with tui_app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("slash")
+            await pilot.pause()
+            assert tui_app.mode == InputMode.SEARCH
+
+    async def test_exit_search_mode(self, tui_app: NiuuTUI) -> None:
+        async with tui_app.run_test() as pilot:
+            await pilot.pause()
+            tui_app.set_mode(InputMode.SEARCH)
+            await pilot.press("slash")
+            await pilot.pause()
+            assert tui_app.mode == InputMode.NORMAL
+
+    async def test_page_navigation(self, tui_app: NiuuTUI) -> None:
+        async with tui_app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("1")
+            await pilot.pause()
+            sidebar = tui_app.query_one("#niuu-sidebar", NiuuSidebar)
+            assert sidebar.active_index == 0
+
+    async def test_page_navigation_key_2(self, tui_app: NiuuTUI) -> None:
+        async with tui_app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("2")
+            await pilot.pause()
+            sidebar = tui_app.query_one("#niuu-sidebar", NiuuSidebar)
+            assert sidebar.active_index == 1
+
+    async def test_mode_propagates_to_header(self, tui_app: NiuuTUI) -> None:
+        async with tui_app.run_test() as pilot:
+            await pilot.pause()
+            tui_app.set_mode(InputMode.INSERT)
+            await pilot.pause()
+            header = tui_app.query_one("#niuu-header", NiuuHeader)
+            assert header.mode == InputMode.INSERT
+
+    async def test_mode_propagates_to_footer(self, tui_app: NiuuTUI) -> None:
+        async with tui_app.run_test() as pilot:
+            await pilot.pause()
+            tui_app.set_mode(InputMode.INSERT)
+            await pilot.pause()
+            footer = tui_app.query_one("#niuu-footer", NiuuFooter)
+            assert footer.mode == InputMode.INSERT
+
+    async def test_insert_mode_blocks_normal_keys(self, tui_app: NiuuTUI) -> None:
+        async with tui_app.run_test() as pilot:
+            await pilot.pause()
+            tui_app.set_mode(InputMode.INSERT)
+            result = tui_app.check_action("toggle_sidebar", ())
+            assert result is None
+
+    async def test_insert_mode_allows_go_page(self, tui_app: NiuuTUI) -> None:
+        async with tui_app.run_test() as pilot:
+            await pilot.pause()
+            tui_app.set_mode(InputMode.INSERT)
+            result = tui_app.check_action("go_page", ("0",))
+            assert result is True
+
+    async def test_normal_mode_allows_all(self, tui_app: NiuuTUI) -> None:
+        async with tui_app.run_test() as pilot:
+            await pilot.pause()
+            result = tui_app.check_action("toggle_sidebar", ())
+            assert result is True
+
+    async def test_command_mode_blocks_sidebar(self, tui_app: NiuuTUI) -> None:
+        async with tui_app.run_test() as pilot:
+            await pilot.pause()
+            tui_app.set_mode(InputMode.COMMAND)
+            result = tui_app.check_action("toggle_sidebar", ())
+            assert result is None
+
+    async def test_search_mode_allows_enter_search(self, tui_app: NiuuTUI) -> None:
+        async with tui_app.run_test() as pilot:
+            await pilot.pause()
+            tui_app.set_mode(InputMode.SEARCH)
+            result = tui_app.check_action("enter_search", ())
+            assert result is True
 
 
-async def test_theme_applied() -> None:
-    """Custom theme is applied on mount."""
-    app = NiuuTUI(theme_name="textual-light")
-    async with app.run_test() as pilot:
-        await pilot.pause()
-        assert app.theme == "textual-light"
+# ── build_tui tests ──────────────────────────────────────────
 
 
-async def test_pages_shown_in_sidebar() -> None:
-    """Plugin pages are listed in the sidebar."""
-    pages = [
-        TUIPageSpec(name="Sessions", icon="S", widget_class=Static),
-        TUIPageSpec(name="Sagas", icon="T", widget_class=Static),
-    ]
-    app = NiuuTUI(pages=pages)
-    async with app.run_test() as pilot:
-        await pilot.pause()
-        page_list = app.query_one("#page-list", PluginPageList)
-        assert page_list._pages == pages
-        assert len(page_list._pages) == 2
+class TestBuildTUI:
+    def test_without_registry(self) -> None:
+        app = build_tui()
+        assert isinstance(app, NiuuTUI)
+
+    def test_with_registry(self) -> None:
+        registry = PluginRegistry()
+        registry.register(FakePlugin(name="test"))
+        app = build_tui(registry=registry)
+        assert isinstance(app, NiuuTUI)
+
+    def test_with_server_url(self) -> None:
+        app = build_tui(server_url="https://niuu.dev")
+        assert app._server_url == "https://niuu.dev"
+
+    def test_with_theme(self) -> None:
+        app = build_tui(theme="textual-light")
+        assert app._theme_name == "textual-light"
 
 
-async def test_no_pages_message() -> None:
-    """Empty pages list shows 'no plugins loaded' message."""
-    app = NiuuTUI(pages=[])
-    async with app.run_test() as pilot:
-        await pilot.pause()
-        page_list = app.query_one("#page-list", PluginPageList)
-        assert page_list._pages == []
+# ── Header tests ─────────────────────────────────────────────
 
 
-def test_build_tui_without_registry() -> None:
-    """build_tui works with no registry."""
-    app = build_tui()
-    assert isinstance(app, NiuuTUI)
+class TestNiuuHeader:
+    async def test_header_renders(self) -> None:
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            header = app.query_one("#niuu-header", NiuuHeader)
+            assert header.mode == InputMode.NORMAL
+            assert header.connection == ConnectionState.CONNECTING
+
+    async def test_header_server_url(self) -> None:
+        app = NiuuTUI(server_url="https://niuu.dev")
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            header = app.query_one("#niuu-header", NiuuHeader)
+            assert header.server_url == "https://niuu.dev"
+
+    async def test_header_mode_change(self) -> None:
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            header = app.query_one("#niuu-header", NiuuHeader)
+            header.mode = InputMode.SEARCH
+            await pilot.pause()
+            assert header.mode == InputMode.SEARCH
+
+    async def test_header_connection_states(self) -> None:
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            header = app.query_one("#niuu-header", NiuuHeader)
+            for state in ConnectionState:
+                header.connection = state
+                await pilot.pause()
+                assert header.connection == state
+
+    def test_connection_state_values(self) -> None:
+        assert ConnectionState.CONNECTING == "connecting"
+        assert ConnectionState.CONNECTED == "connected"
+        assert ConnectionState.DISCONNECTED == "disconnected"
+
+    def test_render_bar_content(self) -> None:
+        header = NiuuHeader(server_url="https://niuu.dev")
+        bar = header._render_bar()
+        assert "Niuu" in bar
+        assert "niuu.dev" in bar
+        assert "NORMAL" in bar
 
 
-def test_build_tui_with_registry() -> None:
-    """build_tui collects pages from plugins."""
-    registry = PluginRegistry()
-    registry.register(FakePlugin(name="test"))
-    app = build_tui(registry=registry)
-    assert isinstance(app, NiuuTUI)
+# ── Sidebar tests ────────────────────────────────────────────
 
 
-def test_plugin_page_list_widget() -> None:
-    """PluginPageList renders page names."""
-    pages = [TUIPageSpec(name="Test", icon="🧪", widget_class=Static)]
-    widget = PluginPageList(pages)
-    assert widget._pages == pages
+class TestNiuuSidebar:
+    async def test_sidebar_renders_pages(self) -> None:
+        app = NiuuTUI(pages=SAMPLE_PAGES)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            sidebar = app.query_one("#niuu-sidebar", NiuuSidebar)
+            assert len(sidebar.pages) == 2
+
+    async def test_sidebar_toggle(self) -> None:
+        app = NiuuTUI(pages=SAMPLE_PAGES)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            sidebar = app.query_one("#niuu-sidebar", NiuuSidebar)
+            assert not sidebar.collapsed
+            sidebar.toggle()
+            await pilot.pause()
+            assert sidebar.collapsed
+            sidebar.toggle()
+            await pilot.pause()
+            assert not sidebar.collapsed
+
+    async def test_sidebar_select_page(self) -> None:
+        app = NiuuTUI(pages=SAMPLE_PAGES)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            sidebar = app.query_one("#niuu-sidebar", NiuuSidebar)
+            sidebar.select_page(1)
+            await pilot.pause()
+            assert sidebar.active_index == 1
+
+    async def test_sidebar_select_invalid_page(self) -> None:
+        app = NiuuTUI(pages=SAMPLE_PAGES)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            sidebar = app.query_one("#niuu-sidebar", NiuuSidebar)
+            sidebar.select_page(99)
+            await pilot.pause()
+            assert sidebar.active_index == 0
+
+    async def test_sidebar_set_pages(self) -> None:
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            sidebar = app.query_one("#niuu-sidebar", NiuuSidebar)
+            new_pages = [SidebarPage(name="New", icon="N", key="1")]
+            sidebar.set_pages(new_pages)
+            await pilot.pause()
+            assert len(sidebar.pages) == 1
+
+    def test_sidebar_constants(self) -> None:
+        assert SIDEBAR_EXPANDED_WIDTH == 24
+        assert SIDEBAR_COLLAPSED_WIDTH == 5
+
+    def test_sidebar_page_dataclass(self) -> None:
+        page = SidebarPage(name="Test", icon="T", key="1")
+        assert page.name == "Test"
+        assert page.icon == "T"
+        assert page.key == "1"
+
+    def test_sidebar_page_frozen(self) -> None:
+        page = SidebarPage(name="Test", icon="T", key="1")
+        with pytest.raises(AttributeError):
+            page.name = "Other"  # type: ignore[misc]
+
+
+# ── Footer tests ─────────────────────────────────────────────
+
+
+class TestNiuuFooter:
+    async def test_footer_renders(self) -> None:
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            footer = app.query_one("#niuu-footer", NiuuFooter)
+            assert footer.mode == InputMode.NORMAL
+
+    async def test_footer_mode_changes_hints(self) -> None:
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            footer = app.query_one("#niuu-footer", NiuuFooter)
+            footer.mode = InputMode.INSERT
+            await pilot.pause()
+            assert footer._active_hints() == INSERT_HINTS
+
+    async def test_footer_custom_hints(self) -> None:
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            footer = app.query_one("#niuu-footer", NiuuFooter)
+            custom = [KeyHint("x", "custom")]
+            footer.set_hints(custom)
+            await pilot.pause()
+            assert footer._active_hints() == custom
+
+    async def test_footer_insert_mode_overrides_page_hints(self) -> None:
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            footer = app.query_one("#niuu-footer", NiuuFooter)
+            footer.set_hints([KeyHint("x", "custom")])
+            footer.mode = InputMode.INSERT
+            assert footer._active_hints() == INSERT_HINTS
+
+    def test_default_hints(self) -> None:
+        assert len(DEFAULT_HINTS) > 0
+        assert any(h.key == "q" for h in DEFAULT_HINTS)
+
+    def test_key_hint_dataclass(self) -> None:
+        hint = KeyHint("Ctrl+K", "command")
+        assert hint.key == "Ctrl+K"
+        assert hint.description == "command"
+
+    def test_render_hints_format(self) -> None:
+        footer = NiuuFooter()
+        rendered = footer._render_hints()
+        assert "help" in rendered
+        assert "quit" in rendered
+
+
+# ── Tabs tests ───────────────────────────────────────────────
+
+
+class TestNiuuTabs:
+    async def test_tabs_render(self) -> None:
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            tabs = NiuuTabs(items=["All", "Active", "Completed"])
+            app.mount(tabs)
+            await pilot.pause()
+            assert tabs.active_tab == 0
+            assert tabs.items == ["All", "Active", "Completed"]
+
+    async def test_tabs_select(self) -> None:
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            tabs = NiuuTabs(items=["A", "B", "C"])
+            app.mount(tabs)
+            await pilot.pause()
+            tabs.select(2)
+            await pilot.pause()
+            assert tabs.active_tab == 2
+
+    async def test_tabs_select_invalid(self) -> None:
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            tabs = NiuuTabs(items=["A", "B"])
+            app.mount(tabs)
+            await pilot.pause()
+            tabs.select(99)
+            await pilot.pause()
+            assert tabs.active_tab == 0
+
+    async def test_tabs_set_items(self) -> None:
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            tabs = NiuuTabs(items=["A"])
+            app.mount(tabs)
+            await pilot.pause()
+            tabs.set_items(["X", "Y", "Z"])
+            await pilot.pause()
+            assert tabs.items == ["X", "Y", "Z"]
+
+    def test_tabs_render_content(self) -> None:
+        tabs = NiuuTabs(items=["A", "B"])
+        rendered = tabs._render()
+        assert "A" in rendered
+        assert "B" in rendered
+
+
+# ── StatusBadge tests ────────────────────────────────────────
+
+
+class TestStatusBadge:
+    def test_badge_properties(self) -> None:
+        badge = StatusBadge("running")
+        assert badge.status == "running"
+
+    def test_badge_set_status(self) -> None:
+        badge = StatusBadge("stopped")
+        badge.set_status("error")
+        assert badge.status == "error"
+
+    def test_badge_unknown_status(self) -> None:
+        badge = StatusBadge("unknown_state")
+        assert badge.status == "unknown_state"
+
+    def test_all_known_statuses(self) -> None:
+        for status in [
+            "running",
+            "connected",
+            "starting",
+            "provisioning",
+            "stopped",
+            "disconnected",
+            "error",
+            "failed",
+            "completed",
+            "pending",
+        ]:
+            assert status in _STATUS_MAP
+
+    def test_render_running(self) -> None:
+        badge = StatusBadge("running")
+        rendered = badge._render()
+        assert "●" in rendered
+        assert "running" in rendered
+        assert "#10b981" in rendered
+
+    def test_render_error(self) -> None:
+        badge = StatusBadge("error")
+        rendered = badge._render()
+        assert "#ef4444" in rendered
+
+    def test_render_default(self) -> None:
+        badge = StatusBadge("unknown")
+        rendered = badge._render()
+        assert "○" in rendered
+
+
+# ── MetricCard tests ─────────────────────────────────────────
+
+
+class TestMetricCard:
+    def test_card_properties(self) -> None:
+        card = MetricCard(label="Sessions", value="42", icon="📊")
+        assert card.label == "Sessions"
+        assert card.value == "42"
+
+    def test_card_set_value(self) -> None:
+        card = MetricCard(label="Count", value="0")
+        card.set_value("99")
+        assert card.value == "99"
+
+    def test_card_default_color(self) -> None:
+        assert DEFAULT_METRIC_COLOR == "#06b6d4"
+
+    def test_card_custom_color(self) -> None:
+        card = MetricCard(label="X", value="1", color="#ff0000")
+        assert card._color == "#ff0000"
+
+    async def test_metric_row_renders(self) -> None:
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            row = MetricRow()
+            app.mount(row)
+            await pilot.pause()
+            assert row is not None
+
+
+# ── Modal tests ──────────────────────────────────────────────
+
+
+class TestNiuuModal:
+    def test_modal_properties(self) -> None:
+        modal = NiuuModal(title="T", content="C")
+        assert modal.title == "T"
+        assert modal.content == "C"
+
+    def test_modal_default_hidden(self) -> None:
+        modal = NiuuModal()
+        assert not modal.is_visible
+
+    def test_modal_show_sets_visible(self) -> None:
+        modal = NiuuModal()
+        modal.show(title="New")
+        assert modal.is_visible
+        assert modal.title == "New"
+
+    def test_modal_hide(self) -> None:
+        modal = NiuuModal()
+        modal.show()
+        modal.hide()
+        assert not modal.is_visible
+
+    def test_modal_update_content(self) -> None:
+        modal = NiuuModal(title="Old", content="Old body")
+        modal.show(title="New", content="New body")
+        assert modal.title == "New"
+        assert modal.content == "New body"
+
+    async def test_modal_visibility_class(self) -> None:
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            modal = NiuuModal(title="Test")
+            app.mount(modal)
+            await pilot.pause()
+            assert not modal.has_class("visible")
+            modal.is_visible = True
+            await pilot.pause()
+            assert modal.has_class("visible")
+
+
+# ── HelpOverlay tests ───────────────────────────────────────
+
+
+class TestHelpOverlay:
+    async def test_help_mounts(self) -> None:
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("question_mark")
+            await pilot.pause()
+            assert app.screen.__class__.__name__ == "HelpOverlay"
+
+    async def test_help_dismiss_escape(self) -> None:
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("question_mark")
+            await pilot.pause()
+            await pilot.press("escape")
+            await pilot.pause()
+            assert app.screen.__class__.__name__ != "HelpOverlay"
+
+    def test_help_custom_bindings(self) -> None:
+        custom = [KeyBinding("x", "do thing")]
+        overlay = HelpOverlay(bindings=custom)
+        assert overlay.bindings_list == custom
+
+    def test_default_bindings_exist(self) -> None:
+        assert len(DEFAULT_BINDINGS) > 0
+        sections = [b for b in DEFAULT_BINDINGS if b.section]
+        assert len(sections) >= 3
+
+    def test_key_binding_dataclass(self) -> None:
+        kb = KeyBinding("Ctrl+K", "palette", section="Modes")
+        assert kb.key == "Ctrl+K"
+        assert kb.description == "palette"
+        assert kb.section == "Modes"
+
+    def test_key_binding_default_section(self) -> None:
+        kb = KeyBinding("q", "quit")
+        assert kb.section == ""
+
+    def test_build_rows(self) -> None:
+        overlay = HelpOverlay()
+        rows = overlay._build_rows()
+        assert len(rows) > 0
+
+
+# ── CommandPalette tests ─────────────────────────────────────
+
+
+class TestCommandPalette:
+    def test_fuzzy_match_basic(self) -> None:
+        assert _fuzzy_match("ses", "Sessions")
+        assert _fuzzy_match("SES", "Sessions")
+        assert not _fuzzy_match("xyz", "Sessions")
+
+    def test_fuzzy_match_subsequence(self) -> None:
+        assert _fuzzy_match("sn", "Sessions")
+        assert _fuzzy_match("ss", "Sessions")
+
+    def test_fuzzy_match_empty(self) -> None:
+        assert _fuzzy_match("", "anything")
+
+    def test_fuzzy_match_no_match(self) -> None:
+        assert not _fuzzy_match("zzz", "abc")
+
+    async def test_palette_opens(self) -> None:
+        app = NiuuTUI(pages=SAMPLE_PAGES)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("ctrl+k")
+            await pilot.pause()
+            assert app.mode == InputMode.COMMAND
+            assert app.screen.__class__.__name__ == "CommandPalette"
+
+    async def test_palette_dismiss(self) -> None:
+        app = NiuuTUI(pages=SAMPLE_PAGES)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("ctrl+k")
+            await pilot.pause()
+            await pilot.press("escape")
+            await pilot.pause()
+            assert app.mode == InputMode.NORMAL
+
+    def test_palette_item_dataclass(self) -> None:
+        item = PaletteItem(
+            label="Test",
+            description="A test",
+            item_type=PaletteItemType.ACTION,
+            icon="!",
+            action_id="test",
+        )
+        assert item.label == "Test"
+        assert item.item_type == PaletteItemType.ACTION
+
+    def test_palette_item_types(self) -> None:
+        assert PaletteItemType.SESSION == "session"
+        assert PaletteItemType.PAGE == "page"
+        assert PaletteItemType.ACTION == "action"
+
+    def test_palette_item_defaults(self) -> None:
+        item = PaletteItem(label="X")
+        assert item.description == ""
+        assert item.item_type == PaletteItemType.ACTION
+        assert item.icon == ""
+        assert item.action_id == ""
+
+    async def test_palette_filtering(self) -> None:
+        items = [
+            PaletteItem(label="Sessions", item_type=PaletteItemType.PAGE),
+            PaletteItem(label="Settings", item_type=PaletteItemType.PAGE),
+            PaletteItem(label="Help", item_type=PaletteItemType.ACTION),
+        ]
+        palette = CommandPalette(items)
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            app.push_screen(palette)
+            await pilot.pause()
+            assert len(palette.matched) == 3
+            palette._filter("ses")
+            assert len(palette.matched) == 2  # Sessions + Settings (s-e-s subsequence)
+            palette._filter("help")
+            assert len(palette.matched) == 1
+
+    async def test_palette_cursor_movement(self) -> None:
+        items = [
+            PaletteItem(label="A"),
+            PaletteItem(label="B"),
+            PaletteItem(label="C"),
+        ]
+        palette = CommandPalette(items)
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            app.push_screen(palette)
+            await pilot.pause()
+            assert palette.cursor == 0
+            palette._move_cursor(1)
+            assert palette.cursor == 1
+            palette._move_cursor(-1)
+            assert palette.cursor == 0
+
+    async def test_palette_cursor_wraps(self) -> None:
+        items = [PaletteItem(label="A"), PaletteItem(label="B")]
+        palette = CommandPalette(items)
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            app.push_screen(palette)
+            await pilot.pause()
+            palette._move_cursor(-1)
+            assert palette.cursor == 1
+
+    async def test_palette_filter_empty(self) -> None:
+        items = [PaletteItem(label="A")]
+        palette = CommandPalette(items)
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            app.push_screen(palette)
+            await pilot.pause()
+            palette._filter("zzz")
+            assert len(palette.matched) == 0
+
+
+# ── MentionMenu tests ───────────────────────────────────────
+
+
+class TestMentionMenu:
+    def test_fuzzy_contains(self) -> None:
+        assert _fuzzy_contains("test", "Testing")
+        assert _fuzzy_contains("TEST", "testing")
+        assert not _fuzzy_contains("xyz", "testing")
+
+    def test_fuzzy_contains_empty(self) -> None:
+        assert _fuzzy_contains("", "anything")
+
+    async def test_menu_hidden_by_default(self) -> None:
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            menu = MentionMenu(trigger="@")
+            app.mount(menu)
+            await pilot.pause()
+            assert not menu.active
+
+    async def test_menu_open_close(self) -> None:
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            menu = MentionMenu(trigger="@")
+            app.mount(menu)
+            await pilot.pause()
+            items = [MentionItem(label="file.py", value="file.py")]
+            menu.open(items)
+            await pilot.pause()
+            assert menu.active
+            assert len(menu.items) == 1
+            menu.close()
+            await pilot.pause()
+            assert not menu.active
+
+    async def test_menu_navigation(self) -> None:
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            menu = MentionMenu()
+            app.mount(menu)
+            await pilot.pause()
+            items = [
+                MentionItem(label="a", value="a"),
+                MentionItem(label="b", value="b"),
+                MentionItem(label="c", value="c"),
+            ]
+            menu.open(items)
+            await pilot.pause()
+            assert menu.selected == 0
+            menu.move_down()
+            assert menu.selected == 1
+            menu.move_up()
+            assert menu.selected == 0
+
+    async def test_menu_wrap_around(self) -> None:
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            menu = MentionMenu()
+            app.mount(menu)
+            await pilot.pause()
+            items = [
+                MentionItem(label="a", value="a"),
+                MentionItem(label="b", value="b"),
+            ]
+            menu.open(items)
+            await pilot.pause()
+            menu.move_up()
+            assert menu.selected == 1
+
+    async def test_menu_select_current(self) -> None:
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            menu = MentionMenu()
+            app.mount(menu)
+            await pilot.pause()
+            items = [MentionItem(label="file.py", value="file.py")]
+            menu.open(items)
+            await pilot.pause()
+            result = menu.select_current()
+            assert result is not None
+            assert result.label == "file.py"
+            assert not menu.active
+
+    async def test_menu_select_empty(self) -> None:
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            menu = MentionMenu()
+            app.mount(menu)
+            await pilot.pause()
+            menu.open([])
+            result = menu.select_current()
+            assert result is None
+
+    async def test_menu_set_query(self) -> None:
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            menu = MentionMenu()
+            app.mount(menu)
+            await pilot.pause()
+            items = [
+                MentionItem(label="alpha", value="a"),
+                MentionItem(label="beta", value="b"),
+            ]
+            menu.open(items)
+            menu.set_query("alp")
+            assert len(menu.filtered) == 1
+
+    def test_mention_item_dataclass(self) -> None:
+        item = MentionItem(
+            label="test.py",
+            value="test.py",
+            detail="src/",
+            icon="📄",
+            category="files",
+        )
+        assert item.label == "test.py"
+        assert item.category == "files"
+
+    def test_trigger_property(self) -> None:
+        menu = MentionMenu(trigger="/")
+        assert menu.trigger == "/"
+
+    def test_filtered_empty_query(self) -> None:
+        menu = MentionMenu()
+        menu._items = [MentionItem(label="a", value="a")]
+        assert len(menu.filtered) == 1
+
+    def test_filtered_with_query(self) -> None:
+        menu = MentionMenu()
+        menu._items = [
+            MentionItem(label="alpha", value="a"),
+            MentionItem(label="beta", value="b"),
+        ]
+        menu._query = "alp"
+        assert len(menu.filtered) == 1
+
+
+# ── Theme constants tests ────────────────────────────────────
+
+
+class TestThemeConstants:
+    def test_theme_module_imports(self) -> None:
+        from cli.tui.theme import (
+            ACCENT_AMBER,
+            ACCENT_CYAN,
+            ACCENT_EMERALD,
+            ACCENT_INDIGO,
+            ACCENT_ORANGE,
+            ACCENT_PURPLE,
+            ACCENT_RED,
+            BG_ELEVATED,
+            BG_PRIMARY,
+            BG_SECONDARY,
+            BG_TERTIARY,
+            BORDER,
+            BORDER_SUBTLE,
+            TEXT_MUTED,
+            TEXT_PRIMARY,
+            TEXT_SECONDARY,
+        )
+
+        assert BG_PRIMARY == "#09090b"
+        assert BG_SECONDARY == "#18181b"
+        assert BG_TERTIARY == "#27272a"
+        assert BG_ELEVATED == "#3f3f46"
+        assert TEXT_PRIMARY == "#fafafa"
+        assert TEXT_SECONDARY == "#a1a1aa"
+        assert TEXT_MUTED == "#71717a"
+        assert BORDER == "#3f3f46"
+        assert BORDER_SUBTLE == "#27272a"
+        assert ACCENT_AMBER == "#f59e0b"
+        assert ACCENT_CYAN == "#06b6d4"
+        assert ACCENT_EMERALD == "#10b981"
+        assert ACCENT_PURPLE == "#a855f7"
+        assert ACCENT_RED == "#ef4444"
+        assert ACCENT_INDIGO == "#6366f1"
+        assert ACCENT_ORANGE == "#f97316"


### PR DESCRIPTION
## Summary
- Port all 10 Go Bubble Tea TUI components to Python Textual widgets (Header, Sidebar, Footer, Tabs, StatusBadge, MetricCard, HelpOverlay, CommandPalette, Modal, MentionMenu)
- Zinc dark theme with exact color parity to Go TUI and web UI tokens.css
- 4-mode input system (NORMAL/INSERT/SEARCH/COMMAND) with mode-aware key routing

## Test plan
- [x] 109 new TUI widget tests + 236 existing CLI tests = 345 total, all passing
- [x] 91.11% CLI coverage (threshold: 85%)
- [x] Ruff lint and format clean
- [x] All widgets render correctly with Textual Pilot framework

Closes NIU-406

🤖 Generated with [Claude Code](https://claude.com/claude-code)