### PR TITLE
feat(tyr): add TUI pages for sagas, raids, dispatch, and review (NIU-411)

### DIFF
--- a/src/tyr/plugin.py
+++ b/src/tyr/plugin.py
@@ -6,13 +6,16 @@ coordinator service, and TUI pages for saga management.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import typer
 
 from niuu.cli_api_client import CLIAPIClient
 from niuu.cli_output import print_json, print_success, print_table
-from niuu.ports.plugin import Service, ServiceDefinition, ServicePlugin
+from niuu.ports.plugin import Service, ServiceDefinition, ServicePlugin, TUIPageSpec
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class _TyrService(Service):
@@ -218,3 +221,17 @@ class TyrPlugin(ServicePlugin):
 
         app.add_typer(sagas, name="sagas")
         app.add_typer(raids, name="raids")
+
+    def tui_pages(self) -> Sequence[TUIPageSpec]:
+        """Return TUI page specs for the Textual app."""
+        from tyr.tui.pages.dispatch import DispatchPage
+        from tyr.tui.pages.raids import RaidsPage
+        from tyr.tui.pages.review import ReviewPage
+        from tyr.tui.pages.sagas import SagasPage
+
+        return [
+            TUIPageSpec(name="Sagas", icon="⚡", widget_class=SagasPage),
+            TUIPageSpec(name="Raids", icon="⚔", widget_class=RaidsPage),
+            TUIPageSpec(name="Dispatch", icon="🚀", widget_class=DispatchPage),
+            TUIPageSpec(name="Review", icon="👁", widget_class=ReviewPage),
+        ]

--- a/src/tyr/tui/__init__.py
+++ b/src/tyr/tui/__init__.py
@@ -1,0 +1,1 @@
+"""Tyr TUI pages — registered via TyrPlugin.tui_pages()."""

--- a/src/tyr/tui/_helpers.py
+++ b/src/tyr/tui/_helpers.py
@@ -1,0 +1,23 @@
+"""Shared formatting helpers for Tyr TUI pages."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def format_confidence(value: float | Any) -> str:
+    """Format a confidence value as a percentage string."""
+    if isinstance(value, float):
+        return f"{value * 100:.0f}%"
+    return str(value)
+
+
+def format_confidence_history(
+    history: list[dict[str, Any]],
+    muted_color: str,
+) -> str:
+    """Format the last 5 confidence history deltas as a Rich markup string."""
+    if not history:
+        return ""
+    deltas = [f"{e.get('delta', 0):+.0%}" for e in history[-5:]]
+    return f"  [{muted_color}]delta {' '.join(deltas)}[/]"

--- a/src/tyr/tui/pages/__init__.py
+++ b/src/tyr/tui/pages/__init__.py
@@ -1,0 +1,13 @@
+"""Tyr TUI page widgets."""
+
+from tyr.tui.pages.dispatch import DispatchPage
+from tyr.tui.pages.raids import RaidsPage
+from tyr.tui.pages.review import ReviewPage
+from tyr.tui.pages.sagas import SagasPage
+
+__all__ = [
+    "DispatchPage",
+    "RaidsPage",
+    "ReviewPage",
+    "SagasPage",
+]

--- a/src/tyr/tui/pages/dispatch.py
+++ b/src/tyr/tui/pages/dispatch.py
@@ -1,0 +1,367 @@
+"""Dispatch TUI page — queue view with bulk dispatch and activity log."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from textual.app import ComposeResult
+from textual.containers import VerticalScroll
+from textual.message import Message
+from textual.widget import Widget
+from textual.widgets import Static
+
+from cli.tui.theme import (
+    ACCENT_AMBER,
+    ACCENT_CYAN,
+    ACCENT_EMERALD,
+    ACCENT_PURPLE,
+    ACCENT_RED,
+    BG_SECONDARY,
+    TEXT_MUTED,
+    TEXT_PRIMARY,
+    TEXT_SECONDARY,
+)
+from cli.tui.widgets.metric_card import MetricCard, MetricRow
+from cli.tui.widgets.tabs import NiuuTabs
+
+if TYPE_CHECKING:
+    from niuu.cli_api_client import CLIAPIClient
+
+_DISPATCH_TABS = ["Queue", "Activity"]
+
+
+class QueueItem(Widget):
+    """A pending raid ready for dispatch."""
+
+    DEFAULT_CSS = """
+    QueueItem {
+        height: auto;
+        padding: 1 2;
+        border-bottom: solid #27272a;
+        background: #18181b;
+    }
+    """
+
+    def __init__(self, raid: dict[str, Any], selected: bool = False, **kwargs: object) -> None:
+        super().__init__(**kwargs)
+        self._raid = raid
+        self._selected = selected
+
+    @property
+    def raid(self) -> dict[str, Any]:
+        return self._raid
+
+    @property
+    def selected(self) -> bool:
+        return self._selected
+
+    def set_selected(self, selected: bool) -> None:
+        self._selected = selected
+        self._refresh_display()
+
+    def compose(self) -> ComposeResult:
+        yield Static(self._render_content(), id="queue-item-content")
+
+    def _render_content(self) -> str:
+        raid = self._raid
+        name = raid.get("name", "Unknown")
+        raid_id = str(raid.get("id", ""))[:8]
+        confidence = raid.get("confidence", 0.0)
+        conf_pct = f"{confidence * 100:.0f}%" if isinstance(confidence, float) else str(confidence)
+
+        check = "☑" if self._selected else "☐"
+        check_color = ACCENT_EMERALD if self._selected else TEXT_MUTED
+
+        return (
+            f"[{check_color}]{check}[/]  "
+            f"[bold {TEXT_PRIMARY}]{name}[/]  "
+            f"[{TEXT_MUTED}]{raid_id}[/]  "
+            f"[{ACCENT_AMBER}]{conf_pct}[/]"
+        )
+
+    def _refresh_display(self) -> None:
+        try:
+            label = self.query_one("#queue-item-content", Static)
+        except Exception:
+            return
+        label.update(self._render_content())
+
+    def _on_click(self) -> None:
+        self._selected = not self._selected
+        self._refresh_display()
+
+
+class ActivityEntry(Widget):
+    """A single entry in the dispatch activity log."""
+
+    DEFAULT_CSS = """
+    ActivityEntry {
+        height: 1;
+        padding: 0 2;
+    }
+    """
+
+    def __init__(self, entry: dict[str, Any], **kwargs: object) -> None:
+        super().__init__(**kwargs)
+        self._entry = entry
+
+    def compose(self) -> ComposeResult:
+        entry = self._entry
+        action = entry.get("action", "dispatch")
+        name = entry.get("name", "")
+        timestamp = entry.get("timestamp", "")
+        status = entry.get("status", "")
+
+        if status == "success":
+            color = ACCENT_EMERALD
+        elif status == "failed":
+            color = ACCENT_RED
+        else:
+            color = TEXT_MUTED
+
+        yield Static(
+            f"[{TEXT_MUTED}]{timestamp}[/]  [{color}]{action}[/]  [{TEXT_PRIMARY}]{name}[/]"
+        )
+
+
+class DispatchPage(Widget):
+    """TUI page for dispatch queue and activity log."""
+
+    DEFAULT_CSS = f"""
+    DispatchPage {{
+        width: 1fr;
+        height: 1fr;
+        background: {BG_SECONDARY};
+    }}
+    DispatchPage #dispatch-content {{
+        height: 1fr;
+    }}
+    DispatchPage #dispatch-config {{
+        height: auto;
+        padding: 1 2;
+    }}
+    """
+
+    class BulkDispatchRequested(Message):
+        """Fired when bulk dispatch is requested."""
+
+        def __init__(self, raid_ids: list[str]) -> None:
+            super().__init__()
+            self.raid_ids = raid_ids
+
+    def __init__(
+        self,
+        client: CLIAPIClient | None = None,
+        **kwargs: object,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._client = client
+        self._pending_raids: list[dict[str, Any]] = []
+        self._activity_log: list[dict[str, Any]] = []
+        self._selected_ids: set[str] = set()
+        self._active_tab: str = "Queue"
+        self._dispatch_config: dict[str, Any] = {
+            "max_concurrent": 3,
+            "threshold": 0.7,
+        }
+
+    @property
+    def pending_raids(self) -> list[dict[str, Any]]:
+        return list(self._pending_raids)
+
+    @property
+    def activity_log(self) -> list[dict[str, Any]]:
+        return list(self._activity_log)
+
+    @property
+    def selected_ids(self) -> set[str]:
+        return set(self._selected_ids)
+
+    @property
+    def dispatch_config(self) -> dict[str, Any]:
+        return dict(self._dispatch_config)
+
+    def compose(self) -> ComposeResult:
+        yield NiuuTabs(items=_DISPATCH_TABS, id="dispatch-tabs")
+        yield MetricRow(id="dispatch-metrics")
+        yield Static(self._render_config(), id="dispatch-config")
+        yield VerticalScroll(id="dispatch-content")
+
+    def on_mount(self) -> None:
+        self._load_data()
+
+    def load_data(
+        self,
+        pending: list[dict[str, Any]] | None = None,
+        activity: list[dict[str, Any]] | None = None,
+        config: dict[str, Any] | None = None,
+    ) -> None:
+        """Load data directly (for testing or programmatic use)."""
+        if pending is not None:
+            self._pending_raids = pending
+        if activity is not None:
+            self._activity_log = activity
+        if config is not None:
+            self._dispatch_config.update(config)
+        self._update_metrics()
+        self._render_content()
+        self._update_config_display()
+
+    def _load_data(self) -> None:
+        if not self._client:
+            return
+        try:
+            resp = self._client.get("/api/v1/tyr/raids/active")
+            resp.raise_for_status()
+            all_raids = resp.json()
+            self._pending_raids = [r for r in all_raids if r.get("status") == "PENDING"]
+        except Exception:
+            self._pending_raids = []
+        self._update_metrics()
+        self._render_content()
+
+    def _update_metrics(self) -> None:
+        try:
+            row = self.query_one("#dispatch-metrics", MetricRow)
+        except Exception:
+            return
+        row.remove_children()
+
+        queued = len(self._pending_raids)
+        selected = len(self._selected_ids)
+        dispatched = len(self._activity_log)
+        max_conc = self._dispatch_config.get("max_concurrent", 3)
+
+        row.mount(
+            MetricCard(
+                label="Queued",
+                value=str(queued),
+                icon="📋",
+                id="metric-queued",
+            )
+        )
+        row.mount(
+            MetricCard(
+                label="Selected",
+                value=str(selected),
+                icon="☑",
+                color=ACCENT_EMERALD,
+                id="metric-selected",
+            )
+        )
+        row.mount(
+            MetricCard(
+                label="Dispatched",
+                value=str(dispatched),
+                icon="🚀",
+                color=ACCENT_CYAN,
+                id="metric-dispatched",
+            )
+        )
+        row.mount(
+            MetricCard(
+                label="Max Concurrent",
+                value=str(max_conc),
+                icon="⚙",
+                color=ACCENT_PURPLE,
+                id="metric-max-concurrent",
+            )
+        )
+
+    def _render_config(self) -> str:
+        max_conc = self._dispatch_config.get("max_concurrent", 3)
+        threshold = self._dispatch_config.get("threshold", 0.7)
+        return (
+            f"[{TEXT_MUTED}]Config:[/]  "
+            f"[{TEXT_SECONDARY}]max concurrent: [{ACCENT_CYAN}]{max_conc}[/][/]  "
+            f"[{TEXT_SECONDARY}]threshold: [{ACCENT_AMBER}]{threshold:.0%}[/][/]"
+        )
+
+    def _update_config_display(self) -> None:
+        try:
+            config = self.query_one("#dispatch-config", Static)
+        except Exception:
+            return
+        config.update(self._render_config())
+
+    def _render_content(self) -> None:
+        try:
+            container = self.query_one("#dispatch-content", VerticalScroll)
+        except Exception:
+            return
+        container.remove_children()
+
+        if self._active_tab == "Queue":
+            self._render_queue(container)
+        else:
+            self._render_activity(container)
+
+    def _render_queue(self, container: VerticalScroll) -> None:
+        if not self._pending_raids:
+            container.mount(
+                Static(
+                    f"[{TEXT_MUTED}]No pending raids in queue.[/]",
+                )
+            )
+            return
+
+        for raid in self._pending_raids:
+            raid_id = str(raid.get("id", ""))
+            selected = raid_id in self._selected_ids
+            container.mount(QueueItem(raid, selected=selected))
+
+    def _render_activity(self, container: VerticalScroll) -> None:
+        if not self._activity_log:
+            container.mount(
+                Static(
+                    f"[{TEXT_MUTED}]No recent activity.[/]",
+                )
+            )
+            return
+
+        for entry in self._activity_log:
+            container.mount(ActivityEntry(entry))
+
+    def on_niuu_tabs_tab_selected(self, message: NiuuTabs.TabSelected) -> None:
+        self._active_tab = message.label
+        self._render_content()
+
+    def toggle_selection(self, raid_id: str) -> None:
+        """Toggle selection of a raid for bulk dispatch."""
+        if raid_id in self._selected_ids:
+            self._selected_ids.discard(raid_id)
+        else:
+            self._selected_ids.add(raid_id)
+        self._update_metrics()
+
+    def select_all(self) -> None:
+        """Select all pending raids."""
+        self._selected_ids = {str(r.get("id", "")) for r in self._pending_raids}
+        self._update_metrics()
+        self._render_content()
+
+    def clear_selection(self) -> None:
+        """Clear all selections."""
+        self._selected_ids.clear()
+        self._update_metrics()
+        self._render_content()
+
+    def dispatch_selected(self) -> list[str]:
+        """Dispatch all selected raids. Returns list of successfully dispatched IDs."""
+        if not self._client:
+            return []
+
+        dispatched: list[str] = []
+        for raid_id in list(self._selected_ids):
+            try:
+                resp = self._client.post(
+                    "/api/v1/tyr/dispatch/approve",
+                    json_body={"saga_id": raid_id},
+                )
+                resp.raise_for_status()
+                dispatched.append(raid_id)
+            except Exception:
+                pass
+
+        self._selected_ids -= set(dispatched)
+        return dispatched

--- a/src/tyr/tui/pages/dispatch.py
+++ b/src/tyr/tui/pages/dispatch.py
@@ -8,7 +8,7 @@ from textual.app import ComposeResult
 from textual.containers import VerticalScroll
 from textual.message import Message
 from textual.widget import Widget
-from textual.widgets import Static
+from textual.widgets import Input, Static
 
 from cli.tui.theme import (
     ACCENT_AMBER,
@@ -23,6 +23,7 @@ from cli.tui.theme import (
 )
 from cli.tui.widgets.metric_card import MetricCard, MetricRow
 from cli.tui.widgets.tabs import NiuuTabs
+from tyr.tui._helpers import format_confidence
 
 if TYPE_CHECKING:
     from niuu.cli_api_client import CLIAPIClient
@@ -67,7 +68,7 @@ class QueueItem(Widget):
         name = raid.get("name", "Unknown")
         raid_id = str(raid.get("id", ""))[:8]
         confidence = raid.get("confidence", 0.0)
-        conf_pct = f"{confidence * 100:.0f}%" if isinstance(confidence, float) else str(confidence)
+        conf_pct = format_confidence(confidence)
 
         check = "☑" if self._selected else "☐"
         check_color = ACCENT_EMERALD if self._selected else TEXT_MUTED
@@ -160,6 +161,7 @@ class DispatchPage(Widget):
         self._activity_log: list[dict[str, Any]] = []
         self._selected_ids: set[str] = set()
         self._active_tab: str = "Queue"
+        self._search_query: str = ""
         self._dispatch_config: dict[str, Any] = {
             "max_concurrent": 3,
             "threshold": 0.7,
@@ -181,9 +183,18 @@ class DispatchPage(Widget):
     def dispatch_config(self) -> dict[str, Any]:
         return dict(self._dispatch_config)
 
+    @property
+    def filtered_pending_raids(self) -> list[dict[str, Any]]:
+        """Return pending raids filtered by search query."""
+        if not self._search_query:
+            return self._pending_raids
+        q = self._search_query.lower()
+        return [r for r in self._pending_raids if q in r.get("name", "").lower()]
+
     def compose(self) -> ComposeResult:
         yield NiuuTabs(items=_DISPATCH_TABS, id="dispatch-tabs")
         yield MetricRow(id="dispatch-metrics")
+        yield Input(placeholder="Search queue...", id="dispatch-search")
         yield Static(self._render_config(), id="dispatch-config")
         yield VerticalScroll(id="dispatch-content")
 
@@ -296,8 +307,14 @@ class DispatchPage(Widget):
         else:
             self._render_activity(container)
 
+    def on_input_changed(self, message: Input.Changed) -> None:
+        if message.input.id == "dispatch-search":
+            self._search_query = message.value
+            self._render_content()
+
     def _render_queue(self, container: VerticalScroll) -> None:
-        if not self._pending_raids:
+        filtered = self.filtered_pending_raids
+        if not filtered:
             container.mount(
                 Static(
                     f"[{TEXT_MUTED}]No pending raids in queue.[/]",
@@ -305,7 +322,7 @@ class DispatchPage(Widget):
             )
             return
 
-        for raid in self._pending_raids:
+        for raid in filtered:
             raid_id = str(raid.get("id", ""))
             selected = raid_id in self._selected_ids
             container.mount(QueueItem(raid, selected=selected))
@@ -355,8 +372,7 @@ class DispatchPage(Widget):
         for raid_id in list(self._selected_ids):
             try:
                 resp = self._client.post(
-                    "/api/v1/tyr/dispatch/approve",
-                    json_body={"saga_id": raid_id},
+                    f"/api/v1/tyr/raids/{raid_id}/dispatch",
                 )
                 resp.raise_for_status()
                 dispatched.append(raid_id)

--- a/src/tyr/tui/pages/raids.py
+++ b/src/tyr/tui/pages/raids.py
@@ -25,6 +25,7 @@ from cli.tui.theme import (
 )
 from cli.tui.widgets.metric_card import MetricCard, MetricRow
 from cli.tui.widgets.tabs import NiuuTabs
+from tyr.tui._helpers import format_confidence, format_confidence_history
 
 if TYPE_CHECKING:
     from niuu.cli_api_client import CLIAPIClient
@@ -74,14 +75,11 @@ class RaidRow(Widget):
         retry_count = raid.get("retry_count", 0)
 
         color = _RAID_STATUS_COLORS.get(status, TEXT_MUTED)
-        conf_pct = f"{confidence * 100:.0f}%" if isinstance(confidence, float) else str(confidence)
-
-        # Confidence history summary.
-        history = raid.get("confidence_history", [])
-        history_str = ""
-        if history:
-            deltas = [f"{e.get('delta', 0):+.0%}" for e in history[-5:]]
-            history_str = f"  [{TEXT_MUTED}]Δ {' '.join(deltas)}[/]"
+        conf_pct = format_confidence(confidence)
+        history_str = format_confidence_history(
+            raid.get("confidence_history", []),
+            TEXT_MUTED,
+        )
 
         retry_str = f"  [{TEXT_MUTED}]retries: {retry_count}[/]" if retry_count else ""
 

--- a/src/tyr/tui/pages/raids.py
+++ b/src/tyr/tui/pages/raids.py
@@ -1,0 +1,292 @@
+"""Raids TUI page — list raids with status, confidence, and actions."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from textual.app import ComposeResult
+from textual.containers import VerticalScroll
+from textual.message import Message
+from textual.widget import Widget
+from textual.widgets import Input, Static
+
+from cli.tui.theme import (
+    ACCENT_AMBER,
+    ACCENT_CYAN,
+    ACCENT_EMERALD,
+    ACCENT_INDIGO,
+    ACCENT_ORANGE,
+    ACCENT_PURPLE,
+    ACCENT_RED,
+    BG_SECONDARY,
+    TEXT_MUTED,
+    TEXT_PRIMARY,
+    TEXT_SECONDARY,
+)
+from cli.tui.widgets.metric_card import MetricCard, MetricRow
+from cli.tui.widgets.tabs import NiuuTabs
+
+if TYPE_CHECKING:
+    from niuu.cli_api_client import CLIAPIClient
+
+# Filter tabs matching RaidStatus values.
+_RAID_TABS = ["All", "Pending", "Queued", "Running", "Review", "Escalated"]
+
+# RaidStatus → display color.
+_RAID_STATUS_COLORS: dict[str, str] = {
+    "PENDING": ACCENT_PURPLE,
+    "QUEUED": ACCENT_AMBER,
+    "RUNNING": ACCENT_EMERALD,
+    "REVIEW": ACCENT_CYAN,
+    "ESCALATED": ACCENT_ORANGE,
+    "MERGED": ACCENT_INDIGO,
+    "FAILED": ACCENT_RED,
+}
+
+
+class RaidRow(Widget):
+    """A single raid entry in the list."""
+
+    DEFAULT_CSS = """
+    RaidRow {
+        height: auto;
+        padding: 1 2;
+        border-bottom: solid #27272a;
+        background: #18181b;
+    }
+    """
+
+    def __init__(self, raid: dict[str, Any], **kwargs: object) -> None:
+        super().__init__(**kwargs)
+        self._raid = raid
+
+    @property
+    def raid(self) -> dict[str, Any]:
+        return self._raid
+
+    def compose(self) -> ComposeResult:
+        raid = self._raid
+        name = raid.get("name", "Unknown")
+        status = raid.get("status", "PENDING")
+        confidence = raid.get("confidence", 0.0)
+        session_id = raid.get("session_id") or "—"
+        raid_id = str(raid.get("id", ""))[:8]
+        retry_count = raid.get("retry_count", 0)
+
+        color = _RAID_STATUS_COLORS.get(status, TEXT_MUTED)
+        conf_pct = f"{confidence * 100:.0f}%" if isinstance(confidence, float) else str(confidence)
+
+        # Confidence history summary.
+        history = raid.get("confidence_history", [])
+        history_str = ""
+        if history:
+            deltas = [f"{e.get('delta', 0):+.0%}" for e in history[-5:]]
+            history_str = f"  [{TEXT_MUTED}]Δ {' '.join(deltas)}[/]"
+
+        retry_str = f"  [{TEXT_MUTED}]retries: {retry_count}[/]" if retry_count else ""
+
+        yield Static(
+            f"[bold {TEXT_PRIMARY}]{name}[/]  "
+            f"[{TEXT_MUTED}]{raid_id}[/]  "
+            f"[{color}]{status}[/]  "
+            f"[{ACCENT_AMBER}]{conf_pct}[/]  "
+            f"[{TEXT_SECONDARY}]session: {session_id}[/]"
+            f"{retry_str}{history_str}",
+            id="raid-row-content",
+        )
+
+
+class RaidsPage(Widget):
+    """TUI page for viewing and managing raids."""
+
+    DEFAULT_CSS = f"""
+    RaidsPage {{
+        width: 1fr;
+        height: 1fr;
+        background: {BG_SECONDARY};
+    }}
+    RaidsPage #raids-search {{
+        margin: 0 2;
+        height: 3;
+    }}
+    RaidsPage #raids-list {{
+        height: 1fr;
+    }}
+    """
+
+    class ApproveRequested(Message):
+        def __init__(self, raid_id: str) -> None:
+            super().__init__()
+            self.raid_id = raid_id
+
+    class RejectRequested(Message):
+        def __init__(self, raid_id: str) -> None:
+            super().__init__()
+            self.raid_id = raid_id
+
+    class RetryRequested(Message):
+        def __init__(self, raid_id: str) -> None:
+            super().__init__()
+            self.raid_id = raid_id
+
+    def __init__(
+        self,
+        client: CLIAPIClient | None = None,
+        **kwargs: object,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._client = client
+        self._raids: list[dict[str, Any]] = []
+        self._filter_status: str = "All"
+        self._search_query: str = ""
+
+    @property
+    def raids(self) -> list[dict[str, Any]]:
+        return list(self._raids)
+
+    @property
+    def filtered_raids(self) -> list[dict[str, Any]]:
+        result = self._raids
+        if self._filter_status != "All":
+            target = self._filter_status.upper()
+            result = [r for r in result if r.get("status", "").upper() == target]
+        if self._search_query:
+            q = self._search_query.lower()
+            result = [r for r in result if q in r.get("name", "").lower()]
+        return result
+
+    def compose(self) -> ComposeResult:
+        yield NiuuTabs(items=_RAID_TABS, id="raids-tabs")
+        yield MetricRow(id="raids-metrics")
+        yield Input(placeholder="Search raids...", id="raids-search")
+        yield VerticalScroll(id="raids-list")
+
+    def on_mount(self) -> None:
+        self._load_raids()
+
+    def load_data(self, raids: list[dict[str, Any]]) -> None:
+        """Load raid data directly (for testing or programmatic use)."""
+        self._raids = raids
+        self._update_metrics()
+        self._render_list()
+
+    def _load_raids(self) -> None:
+        if not self._client:
+            return
+        try:
+            resp = self._client.get("/api/v1/tyr/raids/active")
+            resp.raise_for_status()
+            self._raids = resp.json()
+        except Exception:
+            self._raids = []
+        self._update_metrics()
+        self._render_list()
+
+    def _update_metrics(self) -> None:
+        try:
+            row = self.query_one("#raids-metrics", MetricRow)
+        except Exception:
+            return
+        row.remove_children()
+
+        total = len(self._raids)
+        running = sum(1 for r in self._raids if r.get("status") == "RUNNING")
+        review = sum(1 for r in self._raids if r.get("status") == "REVIEW")
+        failed = sum(1 for r in self._raids if r.get("status") == "FAILED")
+
+        row.mount(
+            MetricCard(
+                label="Total",
+                value=str(total),
+                icon="⚔",
+                id="metric-total",
+            )
+        )
+        row.mount(
+            MetricCard(
+                label="Running",
+                value=str(running),
+                icon="▶",
+                color=ACCENT_EMERALD,
+                id="metric-running",
+            )
+        )
+        row.mount(
+            MetricCard(
+                label="Review",
+                value=str(review),
+                icon="👁",
+                color=ACCENT_CYAN,
+                id="metric-review",
+            )
+        )
+        row.mount(
+            MetricCard(
+                label="Failed",
+                value=str(failed),
+                icon="✗",
+                color=ACCENT_RED,
+                id="metric-failed",
+            )
+        )
+
+    def _render_list(self) -> None:
+        try:
+            container = self.query_one("#raids-list", VerticalScroll)
+        except Exception:
+            return
+        container.remove_children()
+
+        filtered = self.filtered_raids
+        if not filtered:
+            container.mount(
+                Static(
+                    f"[{TEXT_MUTED}]No raids found.[/]",
+                )
+            )
+            return
+
+        for raid in filtered:
+            container.mount(RaidRow(raid))
+
+    def on_niuu_tabs_tab_selected(self, message: NiuuTabs.TabSelected) -> None:
+        self._filter_status = message.label
+        self._render_list()
+
+    def on_input_changed(self, message: Input.Changed) -> None:
+        if message.input.id == "raids-search":
+            self._search_query = message.value
+            self._render_list()
+
+    def approve_raid(self, raid_id: str) -> bool:
+        """Approve a raid via API. Returns True on success."""
+        if not self._client:
+            return False
+        try:
+            resp = self._client.post(f"/api/v1/tyr/raids/{raid_id}/approve")
+            resp.raise_for_status()
+            return True
+        except Exception:
+            return False
+
+    def reject_raid(self, raid_id: str) -> bool:
+        """Reject a raid via API. Returns True on success."""
+        if not self._client:
+            return False
+        try:
+            resp = self._client.post(f"/api/v1/tyr/raids/{raid_id}/reject")
+            resp.raise_for_status()
+            return True
+        except Exception:
+            return False
+
+    def retry_raid(self, raid_id: str) -> bool:
+        """Retry a raid via API. Returns True on success."""
+        if not self._client:
+            return False
+        try:
+            resp = self._client.post(f"/api/v1/tyr/raids/{raid_id}/retry")
+            resp.raise_for_status()
+            return True
+        except Exception:
+            return False

--- a/src/tyr/tui/pages/review.py
+++ b/src/tyr/tui/pages/review.py
@@ -1,0 +1,257 @@
+"""Review TUI page — live review dashboard for raids in REVIEW state."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from textual.app import ComposeResult
+from textual.containers import VerticalScroll
+from textual.message import Message
+from textual.widget import Widget
+from textual.widgets import Static
+
+from cli.tui.theme import (
+    ACCENT_AMBER,
+    ACCENT_CYAN,
+    ACCENT_EMERALD,
+    ACCENT_PURPLE,
+    ACCENT_RED,
+    BG_SECONDARY,
+    TEXT_MUTED,
+    TEXT_PRIMARY,
+    TEXT_SECONDARY,
+)
+from cli.tui.widgets.metric_card import MetricCard, MetricRow
+from cli.tui.widgets.tabs import NiuuTabs
+
+if TYPE_CHECKING:
+    from niuu.cli_api_client import CLIAPIClient
+
+_REVIEW_TABS = ["All", "In Review", "Auto-approved", "Escalated"]
+
+
+class ReviewRow(Widget):
+    """A single raid in review state."""
+
+    DEFAULT_CSS = """
+    ReviewRow {
+        height: auto;
+        padding: 1 2;
+        border-bottom: solid #27272a;
+        background: #18181b;
+    }
+    """
+
+    def __init__(self, raid: dict[str, Any], **kwargs: object) -> None:
+        super().__init__(**kwargs)
+        self._raid = raid
+
+    @property
+    def raid(self) -> dict[str, Any]:
+        return self._raid
+
+    def compose(self) -> ComposeResult:
+        raid = self._raid
+        name = raid.get("name", "Unknown")
+        raid_id = str(raid.get("id", ""))[:8]
+        confidence = raid.get("confidence", 0.0)
+        reviewer_session = raid.get("reviewer_session_id") or "—"
+        review_round = raid.get("review_round", 0)
+        status = raid.get("status", "REVIEW")
+        auto_approved = raid.get("auto_approved", False)
+
+        conf_pct = f"{confidence * 100:.0f}%" if isinstance(confidence, float) else str(confidence)
+
+        # Confidence color based on threshold.
+        if confidence >= 0.8:
+            conf_color = ACCENT_EMERALD
+        elif confidence >= 0.5:
+            conf_color = ACCENT_AMBER
+        else:
+            conf_color = ACCENT_RED
+
+        status_label = "auto-approved" if auto_approved else status.lower()
+        if auto_approved:
+            status_color = ACCENT_EMERALD
+        elif status == "REVIEW":
+            status_color = ACCENT_CYAN
+        else:
+            status_color = ACCENT_PURPLE
+
+        # Confidence history.
+        history = raid.get("confidence_history", [])
+        history_str = ""
+        if history:
+            deltas = [f"{e.get('delta', 0):+.0%}" for e in history[-5:]]
+            history_str = f"  [{TEXT_MUTED}]Δ {' '.join(deltas)}[/]"
+
+        yield Static(
+            f"[bold {TEXT_PRIMARY}]{name}[/]  "
+            f"[{TEXT_MUTED}]{raid_id}[/]  "
+            f"[{status_color}]{status_label}[/]  "
+            f"[{conf_color}]{conf_pct}[/]  "
+            f"[{TEXT_SECONDARY}]reviewer: {reviewer_session}[/]  "
+            f"[{TEXT_MUTED}]round: {review_round}[/]"
+            f"{history_str}",
+            id="review-row-content",
+        )
+
+
+class ReviewPage(Widget):
+    """TUI page for live review dashboard."""
+
+    DEFAULT_CSS = f"""
+    ReviewPage {{
+        width: 1fr;
+        height: 1fr;
+        background: {BG_SECONDARY};
+    }}
+    ReviewPage #review-list {{
+        height: 1fr;
+    }}
+    """
+
+    class OpenReviewerSession(Message):
+        """Fired when user wants to open a reviewer session in Chat."""
+
+        def __init__(self, session_id: str) -> None:
+            super().__init__()
+            self.session_id = session_id
+
+    def __init__(
+        self,
+        client: CLIAPIClient | None = None,
+        **kwargs: object,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._client = client
+        self._raids: list[dict[str, Any]] = []
+        self._filter_tab: str = "All"
+
+    @property
+    def raids(self) -> list[dict[str, Any]]:
+        return list(self._raids)
+
+    @property
+    def filtered_raids(self) -> list[dict[str, Any]]:
+        result = self._raids
+        match self._filter_tab:
+            case "In Review":
+                result = [
+                    r
+                    for r in result
+                    if r.get("status") == "REVIEW" and not r.get("auto_approved", False)
+                ]
+            case "Auto-approved":
+                result = [r for r in result if r.get("auto_approved", False)]
+            case "Escalated":
+                result = [r for r in result if r.get("status") == "ESCALATED"]
+            case _:
+                pass
+        return result
+
+    def compose(self) -> ComposeResult:
+        yield NiuuTabs(items=_REVIEW_TABS, id="review-tabs")
+        yield MetricRow(id="review-metrics")
+        yield VerticalScroll(id="review-list")
+
+    def on_mount(self) -> None:
+        self._load_data()
+
+    def load_data(self, raids: list[dict[str, Any]]) -> None:
+        """Load raid data directly (for testing or programmatic use)."""
+        self._raids = raids
+        self._update_metrics()
+        self._render_list()
+
+    def _load_data(self) -> None:
+        if not self._client:
+            return
+        try:
+            resp = self._client.get("/api/v1/tyr/raids/active")
+            resp.raise_for_status()
+            all_raids = resp.json()
+            self._raids = [
+                r
+                for r in all_raids
+                if r.get("status") in ("REVIEW", "ESCALATED") or r.get("auto_approved", False)
+            ]
+        except Exception:
+            self._raids = []
+        self._update_metrics()
+        self._render_list()
+
+    def _update_metrics(self) -> None:
+        try:
+            row = self.query_one("#review-metrics", MetricRow)
+        except Exception:
+            return
+        row.remove_children()
+
+        total = len(self._raids)
+        in_review = sum(
+            1
+            for r in self._raids
+            if r.get("status") == "REVIEW" and not r.get("auto_approved", False)
+        )
+        auto_approved = sum(1 for r in self._raids if r.get("auto_approved", False))
+        escalated = sum(1 for r in self._raids if r.get("status") == "ESCALATED")
+
+        row.mount(
+            MetricCard(
+                label="Total",
+                value=str(total),
+                icon="👁",
+                id="metric-total",
+            )
+        )
+        row.mount(
+            MetricCard(
+                label="In Review",
+                value=str(in_review),
+                icon="🔍",
+                color=ACCENT_CYAN,
+                id="metric-in-review",
+            )
+        )
+        row.mount(
+            MetricCard(
+                label="Auto-approved",
+                value=str(auto_approved),
+                icon="✓",
+                color=ACCENT_EMERALD,
+                id="metric-auto-approved",
+            )
+        )
+        row.mount(
+            MetricCard(
+                label="Escalated",
+                value=str(escalated),
+                icon="⚠",
+                color=ACCENT_AMBER,
+                id="metric-escalated",
+            )
+        )
+
+    def _render_list(self) -> None:
+        try:
+            container = self.query_one("#review-list", VerticalScroll)
+        except Exception:
+            return
+        container.remove_children()
+
+        filtered = self.filtered_raids
+        if not filtered:
+            container.mount(
+                Static(
+                    f"[{TEXT_MUTED}]No raids in review.[/]",
+                )
+            )
+            return
+
+        for raid in filtered:
+            container.mount(ReviewRow(raid))
+
+    def on_niuu_tabs_tab_selected(self, message: NiuuTabs.TabSelected) -> None:
+        self._filter_tab = message.label
+        self._render_list()

--- a/src/tyr/tui/pages/review.py
+++ b/src/tyr/tui/pages/review.py
@@ -8,7 +8,7 @@ from textual.app import ComposeResult
 from textual.containers import VerticalScroll
 from textual.message import Message
 from textual.widget import Widget
-from textual.widgets import Static
+from textual.widgets import Input, Static
 
 from cli.tui.theme import (
     ACCENT_AMBER,
@@ -23,11 +23,16 @@ from cli.tui.theme import (
 )
 from cli.tui.widgets.metric_card import MetricCard, MetricRow
 from cli.tui.widgets.tabs import NiuuTabs
+from tyr.tui._helpers import format_confidence, format_confidence_history
 
 if TYPE_CHECKING:
     from niuu.cli_api_client import CLIAPIClient
 
 _REVIEW_TABS = ["All", "In Review", "Auto-approved", "Escalated"]
+
+# Confidence color thresholds.
+_CONFIDENCE_HIGH = 0.8
+_CONFIDENCE_MED = 0.5
 
 
 class ReviewRow(Widget):
@@ -60,12 +65,12 @@ class ReviewRow(Widget):
         status = raid.get("status", "REVIEW")
         auto_approved = raid.get("auto_approved", False)
 
-        conf_pct = f"{confidence * 100:.0f}%" if isinstance(confidence, float) else str(confidence)
+        conf_pct = format_confidence(confidence)
 
         # Confidence color based on threshold.
-        if confidence >= 0.8:
+        if confidence >= _CONFIDENCE_HIGH:
             conf_color = ACCENT_EMERALD
-        elif confidence >= 0.5:
+        elif confidence >= _CONFIDENCE_MED:
             conf_color = ACCENT_AMBER
         else:
             conf_color = ACCENT_RED
@@ -78,12 +83,10 @@ class ReviewRow(Widget):
         else:
             status_color = ACCENT_PURPLE
 
-        # Confidence history.
-        history = raid.get("confidence_history", [])
-        history_str = ""
-        if history:
-            deltas = [f"{e.get('delta', 0):+.0%}" for e in history[-5:]]
-            history_str = f"  [{TEXT_MUTED}]Δ {' '.join(deltas)}[/]"
+        history_str = format_confidence_history(
+            raid.get("confidence_history", []),
+            TEXT_MUTED,
+        )
 
         yield Static(
             f"[bold {TEXT_PRIMARY}]{name}[/]  "
@@ -127,6 +130,7 @@ class ReviewPage(Widget):
         self._client = client
         self._raids: list[dict[str, Any]] = []
         self._filter_tab: str = "All"
+        self._search_query: str = ""
 
     @property
     def raids(self) -> list[dict[str, Any]]:
@@ -148,11 +152,15 @@ class ReviewPage(Widget):
                 result = [r for r in result if r.get("status") == "ESCALATED"]
             case _:
                 pass
+        if self._search_query:
+            q = self._search_query.lower()
+            result = [r for r in result if q in r.get("name", "").lower()]
         return result
 
     def compose(self) -> ComposeResult:
         yield NiuuTabs(items=_REVIEW_TABS, id="review-tabs")
         yield MetricRow(id="review-metrics")
+        yield Input(placeholder="Search reviews...", id="review-search")
         yield VerticalScroll(id="review-list")
 
     def on_mount(self) -> None:
@@ -255,3 +263,8 @@ class ReviewPage(Widget):
     def on_niuu_tabs_tab_selected(self, message: NiuuTabs.TabSelected) -> None:
         self._filter_tab = message.label
         self._render_list()
+
+    def on_input_changed(self, message: Input.Changed) -> None:
+        if message.input.id == "review-search":
+            self._search_query = message.value
+            self._render_list()

--- a/src/tyr/tui/pages/sagas.py
+++ b/src/tyr/tui/pages/sagas.py
@@ -1,0 +1,285 @@
+"""Sagas TUI page — list sagas with status, phases, and raid counts."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from textual.app import ComposeResult
+from textual.containers import VerticalScroll
+from textual.message import Message
+from textual.widget import Widget
+from textual.widgets import Input, Static
+
+from cli.tui.theme import (
+    ACCENT_AMBER,
+    ACCENT_CYAN,
+    ACCENT_EMERALD,
+    ACCENT_RED,
+    BG_SECONDARY,
+    TEXT_MUTED,
+    TEXT_PRIMARY,
+    TEXT_SECONDARY,
+)
+from cli.tui.widgets.metric_card import MetricCard, MetricRow
+from cli.tui.widgets.tabs import NiuuTabs
+
+if TYPE_CHECKING:
+    from niuu.cli_api_client import CLIAPIClient
+
+# Status filter tabs.
+_SAGA_TABS = ["All", "Active", "Complete", "Failed"]
+
+# Status → color for progress bars.
+_STATUS_COLORS: dict[str, str] = {
+    "ACTIVE": ACCENT_EMERALD,
+    "COMPLETE": ACCENT_CYAN,
+    "FAILED": ACCENT_RED,
+}
+
+
+class SagaRow(Widget):
+    """A single saga entry in the list."""
+
+    DEFAULT_CSS = """
+    SagaRow {
+        height: auto;
+        padding: 1 2;
+        border-bottom: solid #27272a;
+        background: #18181b;
+    }
+    SagaRow:hover {
+        background: #27272a;
+    }
+    """
+
+    class Selected(Message):
+        """Fired when a saga row is clicked."""
+
+        def __init__(self, saga_id: str) -> None:
+            super().__init__()
+            self.saga_id = saga_id
+
+    def __init__(self, saga: dict[str, Any], **kwargs: object) -> None:
+        super().__init__(**kwargs)
+        self._saga = saga
+
+    @property
+    def saga(self) -> dict[str, Any]:
+        return self._saga
+
+    def compose(self) -> ComposeResult:
+        saga = self._saga
+        name = saga.get("name", "Unknown")
+        status = saga.get("status", "ACTIVE")
+        raid_count = saga.get("raid_count", 0)
+        progress = saga.get("progress", "0/0")
+        confidence = saga.get("confidence", 0.0)
+        saga_id = str(saga.get("id", ""))[:8]
+
+        color = _STATUS_COLORS.get(status, TEXT_MUTED)
+        conf_pct = f"{confidence * 100:.0f}%" if isinstance(confidence, float) else str(confidence)
+
+        yield Static(
+            f"[bold {TEXT_PRIMARY}]{name}[/]  "
+            f"[{TEXT_MUTED}]{saga_id}[/]  "
+            f"[{color}]{status}[/]  "
+            f"[{TEXT_SECONDARY}]Raids: {raid_count}[/]  "
+            f"[{TEXT_SECONDARY}]Progress: {progress}[/]  "
+            f"[{ACCENT_AMBER}]{conf_pct}[/]",
+            id="saga-row-content",
+        )
+
+    def _on_click(self) -> None:
+        self.post_message(self.Selected(str(self._saga.get("id", ""))))
+
+
+class SagasPage(Widget):
+    """TUI page for viewing and managing sagas."""
+
+    DEFAULT_CSS = f"""
+    SagasPage {{
+        width: 1fr;
+        height: 1fr;
+        background: {BG_SECONDARY};
+    }}
+    SagasPage #sagas-search {{
+        margin: 0 2;
+        height: 3;
+    }}
+    SagasPage #sagas-list {{
+        height: 1fr;
+    }}
+    SagasPage #sagas-empty {{
+        margin: 2 2;
+        color: {TEXT_MUTED};
+    }}
+    """
+
+    class DispatchRequested(Message):
+        """Fired when user requests dispatch on a saga."""
+
+        def __init__(self, saga_id: str) -> None:
+            super().__init__()
+            self.saga_id = saga_id
+
+    class DeleteRequested(Message):
+        """Fired when user requests saga deletion."""
+
+        def __init__(self, saga_id: str) -> None:
+            super().__init__()
+            self.saga_id = saga_id
+
+    def __init__(
+        self,
+        client: CLIAPIClient | None = None,
+        **kwargs: object,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._client = client
+        self._sagas: list[dict[str, Any]] = []
+        self._filter_status: str = "All"
+        self._search_query: str = ""
+
+    @property
+    def sagas(self) -> list[dict[str, Any]]:
+        return list(self._sagas)
+
+    @property
+    def filtered_sagas(self) -> list[dict[str, Any]]:
+        """Return sagas filtered by status tab and search query."""
+        result = self._sagas
+        if self._filter_status != "All":
+            target = self._filter_status.upper()
+            result = [s for s in result if s.get("status", "").upper() == target]
+        if self._search_query:
+            q = self._search_query.lower()
+            result = [s for s in result if q in s.get("name", "").lower()]
+        return result
+
+    def compose(self) -> ComposeResult:
+        yield NiuuTabs(items=_SAGA_TABS, id="sagas-tabs")
+        yield MetricRow(id="sagas-metrics")
+        yield Input(placeholder="Search sagas...", id="sagas-search")
+        yield VerticalScroll(id="sagas-list")
+
+    def on_mount(self) -> None:
+        self._load_sagas()
+
+    def load_data(self, sagas: list[dict[str, Any]]) -> None:
+        """Load saga data directly (for testing or programmatic use)."""
+        self._sagas = sagas
+        self._update_metrics()
+        self._render_list()
+
+    def _load_sagas(self) -> None:
+        if not self._client:
+            return
+        try:
+            resp = self._client.get("/api/v1/tyr/sagas")
+            resp.raise_for_status()
+            self._sagas = resp.json()
+        except Exception:
+            self._sagas = []
+        self._update_metrics()
+        self._render_list()
+
+    def _update_metrics(self) -> None:
+        try:
+            row = self.query_one("#sagas-metrics", MetricRow)
+        except Exception:
+            return
+        row.remove_children()
+
+        total = len(self._sagas)
+        active = sum(1 for s in self._sagas if s.get("status") == "ACTIVE")
+        complete = sum(1 for s in self._sagas if s.get("status") == "COMPLETE")
+        failed = sum(1 for s in self._sagas if s.get("status") == "FAILED")
+
+        row.mount(
+            MetricCard(
+                label="Total",
+                value=str(total),
+                icon="⚡",
+                id="metric-total",
+            )
+        )
+        row.mount(
+            MetricCard(
+                label="Active",
+                value=str(active),
+                icon="▶",
+                color=ACCENT_EMERALD,
+                id="metric-active",
+            )
+        )
+        row.mount(
+            MetricCard(
+                label="Complete",
+                value=str(complete),
+                icon="✓",
+                color=ACCENT_CYAN,
+                id="metric-complete",
+            )
+        )
+        row.mount(
+            MetricCard(
+                label="Failed",
+                value=str(failed),
+                icon="✗",
+                color=ACCENT_RED,
+                id="metric-failed",
+            )
+        )
+
+    def _render_list(self) -> None:
+        try:
+            container = self.query_one("#sagas-list", VerticalScroll)
+        except Exception:
+            return
+        container.remove_children()
+
+        filtered = self.filtered_sagas
+        if not filtered:
+            container.mount(
+                Static(
+                    f"[{TEXT_MUTED}]No sagas found.[/]",
+                )
+            )
+            return
+
+        for saga in filtered:
+            container.mount(SagaRow(saga))
+
+    def on_niuu_tabs_tab_selected(self, message: NiuuTabs.TabSelected) -> None:
+        self._filter_status = message.label
+        self._render_list()
+
+    def on_input_changed(self, message: Input.Changed) -> None:
+        if message.input.id == "sagas-search":
+            self._search_query = message.value
+            self._render_list()
+
+    def dispatch_saga(self, saga_id: str) -> bool:
+        """Dispatch a saga via the API. Returns True on success."""
+        if not self._client:
+            return False
+        try:
+            resp = self._client.post(
+                "/api/v1/tyr/dispatch/approve",
+                json_body={"saga_id": saga_id},
+            )
+            resp.raise_for_status()
+            return True
+        except Exception:
+            return False
+
+    def delete_saga(self, saga_id: str) -> bool:
+        """Delete a saga via the API. Returns True on success."""
+        if not self._client:
+            return False
+        try:
+            resp = self._client.delete(f"/api/v1/tyr/sagas/{saga_id}")
+            resp.raise_for_status()
+            return True
+        except Exception:
+            return False

--- a/src/tyr/tui/pages/sagas.py
+++ b/src/tyr/tui/pages/sagas.py
@@ -22,6 +22,7 @@ from cli.tui.theme import (
 )
 from cli.tui.widgets.metric_card import MetricCard, MetricRow
 from cli.tui.widgets.tabs import NiuuTabs
+from tyr.tui._helpers import format_confidence
 
 if TYPE_CHECKING:
     from niuu.cli_api_client import CLIAPIClient
@@ -77,7 +78,7 @@ class SagaRow(Widget):
         saga_id = str(saga.get("id", ""))[:8]
 
         color = _STATUS_COLORS.get(status, TEXT_MUTED)
-        conf_pct = f"{confidence * 100:.0f}%" if isinstance(confidence, float) else str(confidence)
+        conf_pct = format_confidence(confidence)
 
         yield Static(
             f"[bold {TEXT_PRIMARY}]{name}[/]  "

--- a/tests/test_tyr/test_tui_pages.py
+++ b/tests/test_tyr/test_tui_pages.py
@@ -1,0 +1,811 @@
+"""Tests for Tyr TUI pages — sagas, raids, dispatch, review."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import httpx
+
+from cli.tui.app import NiuuTUI
+from cli.tui.widgets.metric_card import MetricCard
+from cli.tui.widgets.tabs import NiuuTabs
+from niuu.ports.plugin import TUIPageSpec
+from tyr.tui.pages.dispatch import ActivityEntry, DispatchPage, QueueItem
+from tyr.tui.pages.raids import RaidRow, RaidsPage
+from tyr.tui.pages.review import ReviewPage, ReviewRow
+from tyr.tui.pages.sagas import SagaRow, SagasPage
+
+# ── Fixtures ─────────────────────────────────────────────────
+
+
+def _saga(name: str = "test-saga", status: str = "ACTIVE", **kwargs: object) -> dict:
+    return {
+        "id": str(uuid4()),
+        "name": name,
+        "status": status,
+        "raid_count": kwargs.get("raid_count", 3),
+        "progress": kwargs.get("progress", "2/3"),
+        "confidence": kwargs.get("confidence", 0.85),
+    }
+
+
+def _raid(name: str = "test-raid", status: str = "RUNNING", **kwargs: object) -> dict:
+    return {
+        "id": str(uuid4()),
+        "name": name,
+        "status": status,
+        "confidence": kwargs.get("confidence", 0.75),
+        "session_id": kwargs.get("session_id", "sess-001"),
+        "retry_count": kwargs.get("retry_count", 0),
+        "reviewer_session_id": kwargs.get("reviewer_session_id"),
+        "review_round": kwargs.get("review_round", 0),
+        "auto_approved": kwargs.get("auto_approved", False),
+        "confidence_history": kwargs.get("confidence_history", []),
+    }
+
+
+SAMPLE_SAGAS = [
+    _saga("auth-refactor", "ACTIVE"),
+    _saga("db-migration", "COMPLETE"),
+    _saga("ci-fix", "FAILED"),
+]
+
+SAMPLE_RAIDS = [
+    _raid("implement-login", "RUNNING", confidence=0.9),
+    _raid("add-tests", "REVIEW", confidence=0.7),
+    _raid("fix-ci", "PENDING", confidence=0.5),
+    _raid("update-docs", "FAILED", confidence=0.3),
+    _raid("refactor-api", "ESCALATED", confidence=0.4),
+]
+
+
+def _mock_client(
+    response_data: list | dict | None = None,
+    status_code: int = 200,
+) -> MagicMock:
+    client = MagicMock()
+    resp = MagicMock(spec=httpx.Response)
+    resp.json.return_value = response_data or []
+    resp.status_code = status_code
+    resp.raise_for_status = MagicMock()
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "error", request=MagicMock(), response=resp
+        )
+    client.get.return_value = resp
+    client.post.return_value = resp
+    client.delete.return_value = resp
+    return client
+
+
+# ── SagaRow tests ─────────────────────────────────────────────
+
+
+class TestSagaRow:
+    def test_saga_property(self) -> None:
+        saga = _saga("test")
+        row = SagaRow(saga)
+        assert row.saga["name"] == "test"
+
+    def test_saga_row_defaults(self) -> None:
+        row = SagaRow({"name": "x", "status": "ACTIVE"})
+        assert row.saga["name"] == "x"
+
+    def test_click_posts_message(self) -> None:
+        saga = _saga("click-test")
+        row = SagaRow(saga)
+        row.post_message = MagicMock()
+        row._on_click()
+        row.post_message.assert_called_once()
+
+
+# ── SagasPage unit tests ─────────────────────────────────────
+
+
+class TestSagasPage:
+    def test_filter_by_status_active(self) -> None:
+        page = SagasPage()
+        page._sagas = SAMPLE_SAGAS
+        page._filter_status = "Active"
+        assert len(page.filtered_sagas) == 1
+        assert page.filtered_sagas[0]["name"] == "auth-refactor"
+
+    def test_filter_by_status_failed(self) -> None:
+        page = SagasPage()
+        page._sagas = SAMPLE_SAGAS
+        page._filter_status = "Failed"
+        assert len(page.filtered_sagas) == 1
+        assert page.filtered_sagas[0]["name"] == "ci-fix"
+
+    def test_filter_all(self) -> None:
+        page = SagasPage()
+        page._sagas = SAMPLE_SAGAS
+        page._filter_status = "All"
+        assert len(page.filtered_sagas) == 3
+
+    def test_search_by_name(self) -> None:
+        page = SagasPage()
+        page._sagas = SAMPLE_SAGAS
+        page._search_query = "auth"
+        assert len(page.filtered_sagas) == 1
+
+    def test_search_empty_result(self) -> None:
+        page = SagasPage()
+        page._sagas = SAMPLE_SAGAS
+        page._search_query = "nonexistent"
+        assert len(page.filtered_sagas) == 0
+
+    def test_combined_filter_and_search(self) -> None:
+        page = SagasPage()
+        page._sagas = SAMPLE_SAGAS
+        page._filter_status = "Active"
+        page._search_query = "auth"
+        assert len(page.filtered_sagas) == 1
+
+    def test_combined_filter_and_search_no_match(self) -> None:
+        page = SagasPage()
+        page._sagas = SAMPLE_SAGAS
+        page._filter_status = "Failed"
+        page._search_query = "auth"
+        assert len(page.filtered_sagas) == 0
+
+    def test_sagas_property(self) -> None:
+        page = SagasPage()
+        page._sagas = SAMPLE_SAGAS
+        assert len(page.sagas) == 3
+
+    def test_dispatch_action_with_client(self) -> None:
+        client = _mock_client({"status": "dispatched"})
+        page = SagasPage(client=client)
+        assert page.dispatch_saga("saga-123") is True
+        client.post.assert_called_once()
+
+    def test_dispatch_action_without_client(self) -> None:
+        page = SagasPage()
+        assert page.dispatch_saga("saga-123") is False
+
+    def test_delete_action_with_client(self) -> None:
+        client = _mock_client()
+        page = SagasPage(client=client)
+        assert page.delete_saga("saga-123") is True
+        client.delete.assert_called_once()
+
+    def test_delete_action_without_client(self) -> None:
+        page = SagasPage()
+        assert page.delete_saga("saga-123") is False
+
+    def test_dispatch_action_failure(self) -> None:
+        client = _mock_client(status_code=500)
+        page = SagasPage(client=client)
+        assert page.dispatch_saga("saga-123") is False
+
+    def test_delete_action_failure(self) -> None:
+        client = _mock_client(status_code=500)
+        page = SagasPage(client=client)
+        assert page.delete_saga("saga-123") is False
+
+    def test_tab_selection_updates_filter(self) -> None:
+        page = SagasPage()
+        page._sagas = SAMPLE_SAGAS
+        page.on_niuu_tabs_tab_selected(NiuuTabs.TabSelected(1, "Active"))
+        assert page._filter_status == "Active"
+
+    def test_page_as_tui_spec(self) -> None:
+        spec = TUIPageSpec(name="Sagas", icon="⚡", widget_class=SagasPage)
+        assert spec.name == "Sagas"
+        assert spec.widget_class is SagasPage
+
+    def test_empty_data(self) -> None:
+        page = SagasPage()
+        page._sagas = []
+        assert len(page.filtered_sagas) == 0
+
+    def test_load_data_stores(self) -> None:
+        """load_data stores sagas without needing a mounted widget."""
+        page = SagasPage()
+        page.load_data(SAMPLE_SAGAS)
+        assert len(page.sagas) == 3
+
+
+# ── RaidRow tests ─────────────────────────────────────────────
+
+
+class TestRaidRow:
+    def test_raid_property(self) -> None:
+        raid = _raid("test")
+        row = RaidRow(raid)
+        assert row.raid["name"] == "test"
+
+    def test_raid_defaults(self) -> None:
+        row = RaidRow({"name": "x", "status": "PENDING"})
+        assert row.raid["status"] == "PENDING"
+
+
+# ── RaidsPage unit tests ─────────────────────────────────────
+
+
+class TestRaidsPage:
+    def test_filter_by_status_running(self) -> None:
+        page = RaidsPage()
+        page._raids = SAMPLE_RAIDS
+        page._filter_status = "Running"
+        assert len(page.filtered_raids) == 1
+
+    def test_filter_by_status_review(self) -> None:
+        page = RaidsPage()
+        page._raids = SAMPLE_RAIDS
+        page._filter_status = "Review"
+        assert len(page.filtered_raids) == 1
+
+    def test_filter_all(self) -> None:
+        page = RaidsPage()
+        page._raids = SAMPLE_RAIDS
+        page._filter_status = "All"
+        assert len(page.filtered_raids) == 5
+
+    def test_search_raids(self) -> None:
+        page = RaidsPage()
+        page._raids = SAMPLE_RAIDS
+        page._search_query = "login"
+        assert len(page.filtered_raids) == 1
+
+    def test_search_empty(self) -> None:
+        page = RaidsPage()
+        page._raids = SAMPLE_RAIDS
+        page._search_query = "nonexistent"
+        assert len(page.filtered_raids) == 0
+
+    def test_combined_filter_search(self) -> None:
+        page = RaidsPage()
+        page._raids = SAMPLE_RAIDS
+        page._filter_status = "Running"
+        page._search_query = "login"
+        assert len(page.filtered_raids) == 1
+
+    def test_raids_property(self) -> None:
+        page = RaidsPage()
+        page._raids = SAMPLE_RAIDS
+        assert len(page.raids) == 5
+
+    def test_approve_with_client(self) -> None:
+        client = _mock_client({"status": "approved"})
+        page = RaidsPage(client=client)
+        assert page.approve_raid("r-1") is True
+        client.post.assert_called_once_with("/api/v1/tyr/raids/r-1/approve")
+
+    def test_reject_with_client(self) -> None:
+        client = _mock_client({"status": "rejected"})
+        page = RaidsPage(client=client)
+        assert page.reject_raid("r-1") is True
+        client.post.assert_called_once_with("/api/v1/tyr/raids/r-1/reject")
+
+    def test_retry_with_client(self) -> None:
+        client = _mock_client({"status": "retrying"})
+        page = RaidsPage(client=client)
+        assert page.retry_raid("r-1") is True
+        client.post.assert_called_once_with("/api/v1/tyr/raids/r-1/retry")
+
+    def test_approve_without_client(self) -> None:
+        page = RaidsPage()
+        assert page.approve_raid("r-1") is False
+
+    def test_reject_without_client(self) -> None:
+        page = RaidsPage()
+        assert page.reject_raid("r-1") is False
+
+    def test_retry_without_client(self) -> None:
+        page = RaidsPage()
+        assert page.retry_raid("r-1") is False
+
+    def test_approve_failure(self) -> None:
+        client = _mock_client(status_code=500)
+        page = RaidsPage(client=client)
+        assert page.approve_raid("r-1") is False
+
+    def test_reject_failure(self) -> None:
+        client = _mock_client(status_code=500)
+        page = RaidsPage(client=client)
+        assert page.reject_raid("r-1") is False
+
+    def test_retry_failure(self) -> None:
+        client = _mock_client(status_code=500)
+        page = RaidsPage(client=client)
+        assert page.retry_raid("r-1") is False
+
+    def test_tab_selection(self) -> None:
+        page = RaidsPage()
+        page.on_niuu_tabs_tab_selected(NiuuTabs.TabSelected(2, "Queued"))
+        assert page._filter_status == "Queued"
+
+    def test_load_data_stores(self) -> None:
+        page = RaidsPage()
+        page.load_data(SAMPLE_RAIDS)
+        assert len(page.raids) == 5
+
+    def test_empty_data(self) -> None:
+        page = RaidsPage()
+        page._raids = []
+        assert len(page.filtered_raids) == 0
+
+
+# ── QueueItem tests ───────────────────────────────────────────
+
+
+class TestQueueItem:
+    def test_properties(self) -> None:
+        raid = _raid("queue-item")
+        item = QueueItem(raid)
+        assert item.raid["name"] == "queue-item"
+        assert item.selected is False
+
+    def test_set_selected(self) -> None:
+        item = QueueItem(_raid("x"))
+        item.set_selected(True)
+        assert item.selected is True
+
+    def test_click_toggles(self) -> None:
+        item = QueueItem(_raid("toggle-raid"))
+        assert not item.selected
+        item._on_click()
+        assert item.selected
+        item._on_click()
+        assert not item.selected
+
+    def test_render_content_selected(self) -> None:
+        item = QueueItem(_raid("sel-raid"), selected=True)
+        content = item._render_content()
+        assert "☑" in content
+
+    def test_render_content_unselected(self) -> None:
+        item = QueueItem(_raid("unsel-raid"), selected=False)
+        content = item._render_content()
+        assert "☐" in content
+
+
+# ── ActivityEntry tests ───────────────────────────────────────
+
+
+class TestActivityEntry:
+    def test_init(self) -> None:
+        entry = ActivityEntry(
+            {
+                "action": "dispatch",
+                "name": "test-saga",
+                "timestamp": "12:00",
+                "status": "success",
+            }
+        )
+        assert entry._entry["action"] == "dispatch"
+
+
+# ── DispatchPage unit tests ───────────────────────────────────
+
+
+class TestDispatchPage:
+    def test_pending_raids_property(self) -> None:
+        page = DispatchPage()
+        pending = [_raid("p1", "PENDING"), _raid("p2", "PENDING")]
+        page._pending_raids = pending
+        assert len(page.pending_raids) == 2
+
+    def test_activity_log_property(self) -> None:
+        page = DispatchPage()
+        activity = [{"action": "dispatch", "name": "s1"}]
+        page._activity_log = activity
+        assert len(page.activity_log) == 1
+
+    def test_default_config(self) -> None:
+        page = DispatchPage()
+        assert page.dispatch_config["max_concurrent"] == 3
+        assert page.dispatch_config["threshold"] == 0.7
+
+    def test_toggle_selection(self) -> None:
+        page = DispatchPage()
+        page.toggle_selection("raid-1")
+        assert "raid-1" in page.selected_ids
+        page.toggle_selection("raid-1")
+        assert "raid-1" not in page.selected_ids
+
+    def test_toggle_selection_multiple(self) -> None:
+        page = DispatchPage()
+        page.toggle_selection("r1")
+        page.toggle_selection("r2")
+        assert len(page.selected_ids) == 2
+
+    def test_select_all(self) -> None:
+        pending = [_raid("p1", "PENDING"), _raid("p2", "PENDING")]
+        page = DispatchPage()
+        page._pending_raids = pending
+        page.select_all()
+        assert len(page.selected_ids) == 2
+
+    def test_clear_selection(self) -> None:
+        page = DispatchPage()
+        page._selected_ids = {"r1", "r2"}
+        page.clear_selection()
+        assert len(page.selected_ids) == 0
+
+    def test_dispatch_selected_with_client(self) -> None:
+        client = _mock_client({"status": "dispatched"})
+        page = DispatchPage(client=client)
+        page._selected_ids = {"raid-1", "raid-2"}
+        result = page.dispatch_selected()
+        assert len(result) == 2
+        assert client.post.call_count == 2
+
+    def test_dispatch_selected_without_client(self) -> None:
+        page = DispatchPage()
+        page._selected_ids = {"raid-1"}
+        result = page.dispatch_selected()
+        assert result == []
+
+    def test_dispatch_selected_clears_successes(self) -> None:
+        client = _mock_client({"status": "dispatched"})
+        page = DispatchPage(client=client)
+        page._selected_ids = {"r1", "r2"}
+        page.dispatch_selected()
+        assert len(page._selected_ids) == 0
+
+    def test_tab_selection(self) -> None:
+        page = DispatchPage()
+        page.on_niuu_tabs_tab_selected(NiuuTabs.TabSelected(1, "Activity"))
+        assert page._active_tab == "Activity"
+
+    def test_load_data_pending(self) -> None:
+        page = DispatchPage()
+        pending = [_raid("p1", "PENDING")]
+        page.load_data(pending=pending)
+        assert len(page.pending_raids) == 1
+
+    def test_load_data_activity(self) -> None:
+        page = DispatchPage()
+        activity = [{"action": "dispatch", "name": "s1"}]
+        page.load_data(activity=activity)
+        assert len(page.activity_log) == 1
+
+    def test_load_data_config(self) -> None:
+        page = DispatchPage()
+        page.load_data(config={"max_concurrent": 5, "threshold": 0.8})
+        assert page.dispatch_config["max_concurrent"] == 5
+        assert page.dispatch_config["threshold"] == 0.8
+
+    def test_empty_queue(self) -> None:
+        page = DispatchPage()
+        page._pending_raids = []
+        assert len(page.pending_raids) == 0
+
+    def test_render_config(self) -> None:
+        page = DispatchPage()
+        rendered = page._render_config()
+        assert "max concurrent" in rendered
+        assert "threshold" in rendered
+
+
+# ── ReviewRow tests ───────────────────────────────────────────
+
+
+class TestReviewRow:
+    def test_raid_property(self) -> None:
+        raid = _raid("review-raid", "REVIEW")
+        row = ReviewRow(raid)
+        assert row.raid["name"] == "review-raid"
+
+    def test_high_confidence(self) -> None:
+        raid = _raid("hi", "REVIEW", confidence=0.9)
+        row = ReviewRow(raid)
+        assert row.raid["confidence"] == 0.9
+
+    def test_low_confidence(self) -> None:
+        raid = _raid("lo", "REVIEW", confidence=0.3)
+        row = ReviewRow(raid)
+        assert row.raid["confidence"] == 0.3
+
+
+# ── ReviewPage unit tests ─────────────────────────────────────
+
+
+class TestReviewPage:
+    def test_filter_in_review(self) -> None:
+        raids = [
+            _raid("r1", "REVIEW"),
+            _raid("r2", "ESCALATED"),
+            _raid("r3", "REVIEW", auto_approved=True),
+        ]
+        page = ReviewPage()
+        page._raids = raids
+        page._filter_tab = "In Review"
+        assert len(page.filtered_raids) == 1
+        assert page.filtered_raids[0]["name"] == "r1"
+
+    def test_filter_auto_approved(self) -> None:
+        raids = [
+            _raid("r1", "REVIEW"),
+            _raid("r2", "REVIEW", auto_approved=True),
+        ]
+        page = ReviewPage()
+        page._raids = raids
+        page._filter_tab = "Auto-approved"
+        assert len(page.filtered_raids) == 1
+        assert page.filtered_raids[0]["name"] == "r2"
+
+    def test_filter_escalated(self) -> None:
+        raids = [
+            _raid("r1", "REVIEW"),
+            _raid("r2", "ESCALATED"),
+        ]
+        page = ReviewPage()
+        page._raids = raids
+        page._filter_tab = "Escalated"
+        assert len(page.filtered_raids) == 1
+        assert page.filtered_raids[0]["name"] == "r2"
+
+    def test_filter_all(self) -> None:
+        raids = [_raid("r1", "REVIEW"), _raid("r2", "ESCALATED")]
+        page = ReviewPage()
+        page._raids = raids
+        page._filter_tab = "All"
+        assert len(page.filtered_raids) == 2
+
+    def test_raids_property(self) -> None:
+        page = ReviewPage()
+        raids = [_raid("r1", "REVIEW")]
+        page._raids = raids
+        assert len(page.raids) == 1
+
+    def test_tab_selection(self) -> None:
+        page = ReviewPage()
+        page.on_niuu_tabs_tab_selected(NiuuTabs.TabSelected(1, "In Review"))
+        assert page._filter_tab == "In Review"
+
+    def test_load_data_stores(self) -> None:
+        page = ReviewPage()
+        raids = [_raid("r1", "REVIEW"), _raid("r2", "ESCALATED")]
+        page.load_data(raids)
+        assert len(page.raids) == 2
+
+    def test_empty_data(self) -> None:
+        page = ReviewPage()
+        page._raids = []
+        assert len(page.filtered_raids) == 0
+
+    def test_confidence_history(self) -> None:
+        raids = [
+            _raid(
+                "hist-raid",
+                "REVIEW",
+                confidence_history=[
+                    {"delta": 0.1, "score_after": 0.8},
+                    {"delta": -0.05, "score_after": 0.75},
+                ],
+            ),
+        ]
+        page = ReviewPage()
+        page._raids = raids
+        assert len(page.filtered_raids) == 1
+
+
+# ── TyrPlugin.tui_pages() tests ──────────────────────────────
+
+
+class TestTyrPluginTUIPages:
+    def test_tui_pages_returns_specs(self) -> None:
+        from tyr.plugin import TyrPlugin
+
+        plugin = TyrPlugin()
+        pages = plugin.tui_pages()
+        assert len(pages) == 4
+        names = [p.name for p in pages]
+        assert "Sagas" in names
+        assert "Raids" in names
+        assert "Dispatch" in names
+        assert "Review" in names
+
+    def test_tui_pages_have_icons(self) -> None:
+        from tyr.plugin import TyrPlugin
+
+        plugin = TyrPlugin()
+        pages = plugin.tui_pages()
+        for page in pages:
+            assert page.icon
+
+    def test_tui_pages_widget_classes(self) -> None:
+        from tyr.plugin import TyrPlugin
+
+        plugin = TyrPlugin()
+        pages = plugin.tui_pages()
+        widget_classes = {p.widget_class for p in pages}
+        assert SagasPage in widget_classes
+        assert RaidsPage in widget_classes
+        assert DispatchPage in widget_classes
+        assert ReviewPage in widget_classes
+
+    def test_tui_pages_are_tuipagespecs(self) -> None:
+        from tyr.plugin import TyrPlugin
+
+        plugin = TyrPlugin()
+        pages = plugin.tui_pages()
+        for page in pages:
+            assert isinstance(page, TUIPageSpec)
+
+
+# ── Textual integration tests (minimal) ──────────────────────
+
+
+class TestTUIIntegration:
+    """Minimal Textual app tests — one per page to verify mounting."""
+
+    async def test_sagas_page_mounts(self) -> None:
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            page = SagasPage()
+            app.mount(page)
+            await pilot.pause()
+            assert page.query_one("#sagas-tabs", NiuuTabs) is not None
+
+    async def test_raids_page_mounts(self) -> None:
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            page = RaidsPage()
+            app.mount(page)
+            await pilot.pause()
+            assert page.query_one("#raids-tabs", NiuuTabs) is not None
+
+    async def test_dispatch_page_mounts(self) -> None:
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            page = DispatchPage()
+            app.mount(page)
+            await pilot.pause()
+            assert page.query_one("#dispatch-tabs", NiuuTabs) is not None
+
+    async def test_review_page_mounts(self) -> None:
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            page = ReviewPage()
+            app.mount(page)
+            await pilot.pause()
+            assert page.query_one("#review-tabs", NiuuTabs) is not None
+
+    async def test_sagas_load_data_renders(self) -> None:
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            page = SagasPage()
+            app.mount(page)
+            await pilot.pause()
+            page.load_data(SAMPLE_SAGAS)
+            await pilot.pause()
+            total = page.query_one("#metric-total", MetricCard)
+            assert total.value == "3"
+
+    async def test_raids_load_data_renders(self) -> None:
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            page = RaidsPage()
+            app.mount(page)
+            await pilot.pause()
+            page.load_data(SAMPLE_RAIDS)
+            await pilot.pause()
+            total = page.query_one("#metric-total", MetricCard)
+            assert total.value == "5"
+
+    async def test_sagas_from_api(self) -> None:
+        client = _mock_client(SAMPLE_SAGAS)
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            page = SagasPage(client=client)
+            app.mount(page)
+            await pilot.pause()
+            assert len(page.sagas) == 3
+
+    async def test_raids_from_api(self) -> None:
+        client = _mock_client(SAMPLE_RAIDS)
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            page = RaidsPage(client=client)
+            app.mount(page)
+            await pilot.pause()
+            assert len(page.raids) == 5
+
+    async def test_dispatch_load_data_renders(self) -> None:
+        pending = [_raid("p1", "PENDING"), _raid("p2", "PENDING")]
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            page = DispatchPage()
+            app.mount(page)
+            await pilot.pause()
+            page.load_data(pending=pending)
+            await pilot.pause()
+            queued = page.query_one("#metric-queued", MetricCard)
+            assert queued.value == "2"
+
+    async def test_dispatch_from_api(self) -> None:
+        raids = [_raid("p1", "PENDING"), _raid("r1", "RUNNING")]
+        client = _mock_client(raids)
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            page = DispatchPage(client=client)
+            app.mount(page)
+            await pilot.pause()
+            assert len(page.pending_raids) == 1
+
+    async def test_review_load_data_renders(self) -> None:
+        raids = [
+            _raid("r1", "REVIEW"),
+            _raid("r2", "ESCALATED"),
+            _raid("r3", "REVIEW", auto_approved=True),
+        ]
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            page = ReviewPage()
+            app.mount(page)
+            await pilot.pause()
+            page.load_data(raids)
+            await pilot.pause()
+            total = page.query_one("#metric-total", MetricCard)
+            assert total.value == "3"
+
+    async def test_review_from_api(self) -> None:
+        all_raids = [
+            _raid("r1", "REVIEW"),
+            _raid("r2", "RUNNING"),
+            _raid("r3", "ESCALATED"),
+        ]
+        client = _mock_client(all_raids)
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            page = ReviewPage(client=client)
+            app.mount(page)
+            await pilot.pause()
+            assert len(page.raids) == 2
+
+    async def test_saga_row_renders_in_app(self) -> None:
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            row = SagaRow(_saga("my-saga", "ACTIVE", confidence=0.9))
+            app.mount(row)
+            await pilot.pause()
+            content = row.query_one("#saga-row-content")
+            assert content is not None
+
+    async def test_raid_row_renders_in_app(self) -> None:
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            row = RaidRow(_raid("my-raid", "RUNNING"))
+            app.mount(row)
+            await pilot.pause()
+            content = row.query_one("#raid-row-content")
+            assert content is not None
+
+    async def test_review_row_renders_in_app(self) -> None:
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            row = ReviewRow(_raid("rv-raid", "REVIEW", confidence=0.85, auto_approved=True))
+            app.mount(row)
+            await pilot.pause()
+            content = row.query_one("#review-row-content")
+            assert content is not None
+
+    async def test_queue_item_renders_in_app(self) -> None:
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            item = QueueItem(_raid("q-raid", "PENDING"), selected=True)
+            app.mount(item)
+            await pilot.pause()
+            content = item.query_one("#queue-item-content")
+            assert content is not None
+
+    async def test_activity_entry_renders_in_app(self) -> None:
+        app = NiuuTUI()
+        async with app.run_test() as pilot:
+            entry = ActivityEntry(
+                {
+                    "action": "dispatch",
+                    "name": "test",
+                    "timestamp": "12:00",
+                    "status": "success",
+                }
+            )
+            app.mount(entry)
+            await pilot.pause()
+            assert entry is not None

--- a/tests/test_tyr/test_tui_pages.py
+++ b/tests/test_tyr/test_tui_pages.py
@@ -11,9 +11,10 @@ from cli.tui.app import NiuuTUI
 from cli.tui.widgets.metric_card import MetricCard
 from cli.tui.widgets.tabs import NiuuTabs
 from niuu.ports.plugin import TUIPageSpec
+from tyr.tui._helpers import format_confidence, format_confidence_history
 from tyr.tui.pages.dispatch import ActivityEntry, DispatchPage, QueueItem
 from tyr.tui.pages.raids import RaidRow, RaidsPage
-from tyr.tui.pages.review import ReviewPage, ReviewRow
+from tyr.tui.pages.review import _CONFIDENCE_HIGH, _CONFIDENCE_MED, ReviewPage, ReviewRow
 from tyr.tui.pages.sagas import SagaRow, SagasPage
 
 # ── Fixtures ─────────────────────────────────────────────────
@@ -77,6 +78,49 @@ def _mock_client(
     client.post.return_value = resp
     client.delete.return_value = resp
     return client
+
+
+# ── Helpers tests ─────────────────────────────────────────────
+
+
+class TestHelpers:
+    def test_format_confidence_float(self) -> None:
+        assert format_confidence(0.85) == "85%"
+
+    def test_format_confidence_zero(self) -> None:
+        assert format_confidence(0.0) == "0%"
+
+    def test_format_confidence_one(self) -> None:
+        assert format_confidence(1.0) == "100%"
+
+    def test_format_confidence_non_float(self) -> None:
+        assert format_confidence("N/A") == "N/A"
+
+    def test_format_confidence_int(self) -> None:
+        assert format_confidence(85) == "85"
+
+    def test_format_confidence_history_empty(self) -> None:
+        assert format_confidence_history([], "#71717a") == ""
+
+    def test_format_confidence_history_single(self) -> None:
+        result = format_confidence_history([{"delta": 0.1}], "#71717a")
+        assert "delta" in result
+        assert "+10%" in result
+
+    def test_format_confidence_history_negative(self) -> None:
+        result = format_confidence_history([{"delta": -0.05}], "#71717a")
+        assert "-5%" in result
+
+    def test_format_confidence_history_limits_to_5(self) -> None:
+        history = [{"delta": 0.01 * i} for i in range(10)]
+        result = format_confidence_history(history, "#71717a")
+        # Should only include last 5
+        assert "+5%" in result
+        assert "+9%" in result
+
+    def test_confidence_thresholds_are_sensible(self) -> None:
+        assert _CONFIDENCE_HIGH > _CONFIDENCE_MED
+        assert _CONFIDENCE_MED > 0
 
 
 # ── SagaRow tests ─────────────────────────────────────────────
@@ -426,6 +470,28 @@ class TestDispatchPage:
         page.clear_selection()
         assert len(page.selected_ids) == 0
 
+    def test_search_queue(self) -> None:
+        pending = [_raid("alpha-raid", "PENDING"), _raid("beta-raid", "PENDING")]
+        page = DispatchPage()
+        page._pending_raids = pending
+        page._search_query = "alpha"
+        assert len(page.filtered_pending_raids) == 1
+        assert page.filtered_pending_raids[0]["name"] == "alpha-raid"
+
+    def test_search_queue_no_match(self) -> None:
+        pending = [_raid("alpha-raid", "PENDING")]
+        page = DispatchPage()
+        page._pending_raids = pending
+        page._search_query = "nonexistent"
+        assert len(page.filtered_pending_raids) == 0
+
+    def test_search_queue_empty_query(self) -> None:
+        pending = [_raid("alpha-raid", "PENDING"), _raid("beta-raid", "PENDING")]
+        page = DispatchPage()
+        page._pending_raids = pending
+        page._search_query = ""
+        assert len(page.filtered_pending_raids) == 2
+
     def test_dispatch_selected_with_client(self) -> None:
         client = _mock_client({"status": "dispatched"})
         page = DispatchPage(client=client)
@@ -446,6 +512,15 @@ class TestDispatchPage:
         page._selected_ids = {"r1", "r2"}
         page.dispatch_selected()
         assert len(page._selected_ids) == 0
+
+    def test_dispatch_selected_uses_raid_endpoint(self) -> None:
+        client = _mock_client({"status": "dispatched"})
+        page = DispatchPage(client=client)
+        page._selected_ids = {"raid-42"}
+        page.dispatch_selected()
+        client.post.assert_called_once_with(
+            "/api/v1/tyr/raids/raid-42/dispatch",
+        )
 
     def test_tab_selection(self) -> None:
         page = DispatchPage()
@@ -563,6 +638,33 @@ class TestReviewPage:
         raids = [_raid("r1", "REVIEW"), _raid("r2", "ESCALATED")]
         page.load_data(raids)
         assert len(page.raids) == 2
+
+    def test_search_reviews(self) -> None:
+        raids = [_raid("auth-review", "REVIEW"), _raid("db-review", "REVIEW")]
+        page = ReviewPage()
+        page._raids = raids
+        page._search_query = "auth"
+        assert len(page.filtered_raids) == 1
+        assert page.filtered_raids[0]["name"] == "auth-review"
+
+    def test_search_reviews_no_match(self) -> None:
+        raids = [_raid("auth-review", "REVIEW")]
+        page = ReviewPage()
+        page._raids = raids
+        page._search_query = "nonexistent"
+        assert len(page.filtered_raids) == 0
+
+    def test_search_combined_with_tab(self) -> None:
+        raids = [
+            _raid("auth-review", "REVIEW"),
+            _raid("auth-escalated", "ESCALATED"),
+        ]
+        page = ReviewPage()
+        page._raids = raids
+        page._filter_tab = "In Review"
+        page._search_query = "auth"
+        assert len(page.filtered_raids) == 1
+        assert page.filtered_raids[0]["name"] == "auth-review"
 
     def test_empty_data(self) -> None:
         page = ReviewPage()


### PR DESCRIPTION
## Summary

- **Sagas page**: List sagas with status (active/complete/failed), phase progress, raid counts, search, and filter. Actions: dispatch, delete via Tyr API.
- **Raids page**: Active raids with confidence scores, status badges, session links. Actions: approve, reject, retry. Filter by status (pending/queued/running/review/escalated).
- **Dispatch page**: Queue view of pending raids with bulk select and dispatch. Shows dispatch config (max concurrent, threshold) and activity log.
- **Review page**: Live dashboard for raids in REVIEW state, reviewer session info, confidence scoring with history deltas, auto-approval status.
- **Plugin registration**: All 4 pages registered via `TyrPlugin.tui_pages()` using `TUIPageSpec`.
- **97 tests**: Unit tests for filtering, search, API actions + Textual integration tests for page mounting and data rendering.

## Architecture

Pages live in `src/tyr/tui/pages/` (inside the tyr package). They use shared widgets from `cli/tui/widgets/` (MetricCard, NiuuTabs) and the zinc theme constants. Data is fetched via `CLIAPIClient`.

## Test plan

- [x] All pages render correctly in Textual pilot tests
- [x] Filter by status tab works on all pages
- [x] Search by name works on sagas and raids pages
- [x] API actions (dispatch, approve, reject, retry, delete) call correct endpoints
- [x] API failures handled gracefully (return False)
- [x] Bulk dispatch selection/deselection works
- [x] Review page filters: In Review, Auto-approved, Escalated
- [x] Confidence history displayed per raid
- [x] 97 tests passing locally

Closes NIU-411

🤖 Generated with [Claude Code](https://claude.com/claude-code)