### PR TITLE
feat(cli): add TransportCapabilities dataclass to CLITransport

### DIFF
--- a/src/skuld/broker.py
+++ b/src/skuld/broker.py
@@ -1486,7 +1486,7 @@ class Broker:
             type(self._transport).__name__ if self._transport else None,
         )
 
-        if not self._transport or not self._transport.supports_cli_websocket:
+        if not self._transport or not self._transport.capabilities.cli_websocket:
             logger.warning(
                 "CLI WebSocket received but transport %s does not support SDK WebSocket protocol",
                 type(self._transport).__name__ if self._transport else "None",

--- a/src/skuld/transports/__init__.py
+++ b/src/skuld/transports/__init__.py
@@ -11,10 +11,31 @@ import asyncio
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 
 logger = logging.getLogger("skuld.transport")
 
 EventCallback = Callable[[dict], Awaitable[None]]
+
+
+@dataclass(frozen=True)
+class TransportCapabilities:
+    """Declares what a transport supports.
+
+    All fields default to False so new transports are safe-by-default.
+    """
+
+    cli_websocket: bool = False
+    session_resume: bool = False
+    interrupt: bool = False
+    set_model: bool = False
+    set_thinking_tokens: bool = False
+    set_permission_mode: bool = False
+    rewind_files: bool = False
+    mcp_set_servers: bool = False
+    permission_requests: bool = False
+    slash_commands: bool = False
+    skills: bool = False
 
 
 class CLITransport(ABC):
@@ -77,13 +98,13 @@ class CLITransport(ABC):
         """Whether the transport is connected and operational."""
 
     @property
-    def supports_cli_websocket(self) -> bool:
-        """Whether this transport uses the Claude SDK WebSocket protocol.
+    def capabilities(self) -> TransportCapabilities:
+        """Declare what this transport supports.
 
-        Only SdkWebSocketTransport returns True. All other transports
-        communicate via subprocess stdio and return False.
+        Returns all-False defaults — safe for new transports.
+        Subclasses override to advertise their capabilities.
         """
-        return False
+        return TransportCapabilities()
 
 
 # ---------------------------------------------------------------------------
@@ -165,6 +186,7 @@ __all__ = [
     "EventCallback",
     "SdkWebSocketTransport",
     "SubprocessTransport",
+    "TransportCapabilities",
     "_CODEX_TOOL_MAP",
     "_drain_stream",
     "_filter_event",

--- a/src/skuld/transports/codex.py
+++ b/src/skuld/transports/codex.py
@@ -38,7 +38,7 @@ class CodexSubprocessTransport(CLITransport):
     Authentication: set OPENAI_API_KEY in the environment.
 
     Codex does not implement the Claude SDK WebSocket protocol, so
-    supports_cli_websocket returns False and the /ws/cli endpoint is not used.
+    capabilities.cli_websocket is False and the /ws/cli endpoint is not used.
 
     Events emitted by Codex are normalized to the same format the broker
     expects so the rest of the pipeline (browser rendering, artifact tracking,

--- a/src/skuld/transports/sdk_websocket.py
+++ b/src/skuld/transports/sdk_websocket.py
@@ -8,7 +8,13 @@ import uuid
 
 from fastapi import WebSocket
 
-from skuld.transports import CLITransport, _drain_stream, _filter_event, _stop_process
+from skuld.transports import (
+    CLITransport,
+    TransportCapabilities,
+    _drain_stream,
+    _filter_event,
+    _stop_process,
+)
 
 logger = logging.getLogger("skuld.transport")
 
@@ -421,5 +427,17 @@ class SdkWebSocketTransport(CLITransport):
         return self._skills
 
     @property
-    def supports_cli_websocket(self) -> bool:
-        return True
+    def capabilities(self) -> TransportCapabilities:
+        return TransportCapabilities(
+            cli_websocket=True,
+            session_resume=True,
+            interrupt=True,
+            set_model=True,
+            set_thinking_tokens=True,
+            set_permission_mode=True,
+            rewind_files=True,
+            mcp_set_servers=True,
+            permission_requests=True,
+            slash_commands=True,
+            skills=True,
+        )

--- a/src/skuld/transports/subprocess.py
+++ b/src/skuld/transports/subprocess.py
@@ -4,7 +4,13 @@ import asyncio
 import json
 import logging
 
-from skuld.transports import CLITransport, _drain_stream, _filter_event, _stop_process
+from skuld.transports import (
+    CLITransport,
+    TransportCapabilities,
+    _drain_stream,
+    _filter_event,
+    _stop_process,
+)
 
 logger = logging.getLogger("skuld.transport")
 
@@ -102,6 +108,10 @@ class SubprocessTransport(CLITransport):
             if not stderr_task.done():
                 stderr_task.cancel()
             self._process = None
+
+    @property
+    def capabilities(self) -> TransportCapabilities:
+        return TransportCapabilities(session_resume=True)
 
     @property
     def session_id(self) -> str | None:

--- a/tests/test_skuld/test_broker.py
+++ b/tests/test_skuld/test_broker.py
@@ -20,6 +20,7 @@ from skuld.transport import (
     CodexSubprocessTransport,
     SdkWebSocketTransport,
     SubprocessTransport,
+    TransportCapabilities,
 )
 
 
@@ -1055,7 +1056,7 @@ class TestHandleWebSocket:
     async def test_handle_cli_websocket_wrong_transport(self, test_broker):
         """Rejects CLI WS when transport does not support SDK WebSocket."""
         mock_transport = AsyncMock(spec=SubprocessTransport)
-        mock_transport.supports_cli_websocket = False
+        mock_transport.capabilities = TransportCapabilities(session_resume=True)
         test_broker._transport = mock_transport
         mock_ws = AsyncMock()
 
@@ -1068,7 +1069,7 @@ class TestHandleWebSocket:
     async def test_handle_cli_websocket_codex_rejected(self, test_broker):
         """Rejects CLI WS for Codex transport (subprocess only)."""
         mock_transport = AsyncMock(spec=CodexSubprocessTransport)
-        mock_transport.supports_cli_websocket = False
+        mock_transport.capabilities = TransportCapabilities()
         test_broker._transport = mock_transport
         mock_ws = AsyncMock()
 
@@ -1081,7 +1082,7 @@ class TestHandleWebSocket:
     async def test_handle_cli_websocket_session_mismatch(self, test_broker):
         """Rejects CLI WS when session ID doesn't match."""
         mock_transport = AsyncMock(spec=SdkWebSocketTransport)
-        mock_transport.supports_cli_websocket = True
+        mock_transport.capabilities = TransportCapabilities(cli_websocket=True)
         test_broker._transport = mock_transport
         mock_ws = AsyncMock()
 
@@ -1094,7 +1095,7 @@ class TestHandleWebSocket:
     async def test_handle_cli_websocket_success(self, test_broker):
         """CLI WS attaches to transport and waits for disconnect."""
         mock_transport = AsyncMock(spec=SdkWebSocketTransport)
-        mock_transport.supports_cli_websocket = True
+        mock_transport.capabilities = TransportCapabilities(cli_websocket=True)
         test_broker._transport = mock_transport
         mock_ws = AsyncMock()
 

--- a/tests/test_skuld/test_conversation_history.py
+++ b/tests/test_skuld/test_conversation_history.py
@@ -15,6 +15,7 @@ from skuld.broker import (
     broker,
 )
 from skuld.config import SkuldSettings
+from skuld.transport import TransportCapabilities
 
 
 class TestConversationTurn:
@@ -121,7 +122,7 @@ class TestConversationTurnCapture:
         b = Broker(settings=settings)
         b._transport = MagicMock()
         b._transport.is_alive = True
-        b._transport.supports_cli_websocket = False
+        b._transport.capabilities = TransportCapabilities()
         return b
 
     @pytest.mark.asyncio

--- a/tests/test_skuld/test_transport.py
+++ b/tests/test_skuld/test_transport.py
@@ -1075,8 +1075,10 @@ class TestCodexSubprocessTransport:
         assert transport.last_result is None
         assert transport.is_alive is False
 
-    def test_supports_cli_websocket_is_false(self, transport):
-        assert transport.supports_cli_websocket is False
+    def test_capabilities_all_false(self, transport):
+        caps = transport.capabilities
+        assert caps.cli_websocket is False
+        assert caps.session_resume is False
 
     @pytest.mark.asyncio
     async def test_start_is_noop(self, transport):


### PR DESCRIPTION
## Summary

- Added a frozen `TransportCapabilities` dataclass to `src/skuld/transports/__init__.py` that each transport declares to expose its capabilities (cli_websocket, session_resume, interrupt, set_model, etc.)
- Added concrete `capabilities` property to `CLITransport` base class returning all-False defaults (safe for new transports)
- Overrode in each transport: `SubprocessTransport` (session_resume=True), `SdkWebSocketTransport` (all True), `CodexSubprocessTransport` (all False)
- Removed deprecated `supports_cli_websocket` property — zero references remain in src/ and tests/
- Updated broker.py and all test files to use `capabilities.cli_websocket`

## Test plan

- [x] `pytest tests/test_skuld/ -v` — 533 tests pass
- [x] `grep -r "supports_cli_websocket" src/ tests/` — zero matches
- [x] `ruff check` and `ruff format --check` pass

Closes NIU-414

🤖 Generated with [Claude Code](https://claude.com/claude-code)