### PR TITLE
feat(cli): add transport_adapter to Skuld Helm chart config

### DIFF
--- a/charts/skuld/README.md
+++ b/charts/skuld/README.md
@@ -241,8 +241,9 @@ Core Skuld broker configuration controlling which AI CLI backend to use and how 
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `broker.cliType` | string | `"claude"` | AI CLI backend: `"claude"` (Claude Code) or `"codex"` (OpenAI Codex) |
-| `broker.transport` | string | `"sdk"` | CLI transport mode: `"sdk"` (WebSocket, default) or `"subprocess"` (legacy). Ignored when cliType is `"codex"` (always uses subprocess) |
+| `broker.transportAdapter` | string | `"skuld.transports.sdk_websocket.SdkWebSocketTransport"` | Fully-qualified class path of the transport adapter. Replaces `broker.cliType` + `broker.transport` with a single, extensible field |
+| `broker.cliType` | string | `"claude"` | **(DEPRECATED)** AI CLI backend: `"claude"` (Claude Code) or `"codex"` (OpenAI Codex). Use `broker.transportAdapter` instead |
+| `broker.transport` | string | `"sdk"` | **(DEPRECATED)** CLI transport mode: `"sdk"` (WebSocket, default) or `"subprocess"` (legacy). Use `broker.transportAdapter` instead |
 | `broker.skipPermissions` | bool | `true` | Skip tool permission prompts (`--dangerously-skip-permissions` for Claude, `--full-auto` for Codex) |
 | `broker.agentTeams` | bool | `false` | Enable Claude Code experimental Agent Teams (Claude only) |
 
@@ -421,8 +422,7 @@ session:
   model: "claude-sonnet-4-20250514"
 
 broker:
-  cliType: claude
-  transport: sdk
+  transportAdapter: "skuld.transports.sdk_websocket.SdkWebSocketTransport"
   skipPermissions: true
 
 ingress:
@@ -444,8 +444,7 @@ session:
   model: "o4-mini"
 
 broker:
-  cliType: codex
-  transport: subprocess
+  transportAdapter: "skuld.transports.codex_subprocess.CodexSubprocessTransport"
   skipPermissions: true
 
 image:

--- a/charts/skuld/templates/deployment.yaml
+++ b/charts/skuld/templates/deployment.yaml
@@ -246,13 +246,10 @@ spec:
             {{- if .Values.homeVolume.enabled }}
             - name: HOME
               value: {{ .Values.homeVolume.mountPath | quote }}
-            {{- if eq (toString .Values.broker.cliType) "codex" }}
-            - name: CODEX_HOME
-              value: "{{ .Values.homeVolume.mountPath }}/{{ .Values.homeVolume.credentialFiles.destDir }}"
-            {{- else }}
             - name: CLAUDE_CONFIG_DIR
               value: "{{ .Values.homeVolume.mountPath }}/{{ .Values.homeVolume.credentialFiles.destDir }}"
-            {{- end }}
+            - name: CODEX_HOME
+              value: "{{ .Values.homeVolume.mountPath }}/{{ .Values.homeVolume.credentialFiles.destDir }}"
             {{- end }}
             {{- range .Values.envSecrets }}
             - name: {{ .envVar }}

--- a/charts/skuld/templates/skuld-configmap.yaml
+++ b/charts/skuld/templates/skuld-configmap.yaml
@@ -20,6 +20,7 @@ data:
       {{- end }}
 
     transport: {{ .Values.broker.transport | default "sdk" | quote }}
+    transport_adapter: {{ .Values.broker.transportAdapter | default "skuld.transports.sdk_websocket.SdkWebSocketTransport" | quote }}
     skip_permissions: {{ .Values.broker.skipPermissions | default true }}
     agent_teams: {{ .Values.broker.agentTeams | default false }}
     cli_type: {{ .Values.broker.cliType | default "claude" | quote }}

--- a/charts/skuld/values.yaml
+++ b/charts/skuld/values.yaml
@@ -237,11 +237,15 @@ git:
 
 # Broker configuration (Skuld application settings)
 broker:
-  # -- AI CLI backend: "claude" (Claude Code, default) or "codex" (OpenAI Codex)
+  # -- (DEPRECATED) AI CLI backend: "claude" (Claude Code, default) or "codex" (OpenAI Codex).
+  # Use broker.transportAdapter instead. Kept for backward compatibility during rollout.
   cliType: claude
-  # -- CLI transport mode for Claude: "sdk" (WebSocket, default) or "subprocess" (legacy)
-  # Ignored when cliType is "codex" (always uses subprocess)
+  # -- (DEPRECATED) CLI transport mode for Claude: "sdk" (WebSocket, default) or "subprocess" (legacy).
+  # Use broker.transportAdapter instead. Kept for backward compatibility during rollout.
   transport: sdk
+  # -- Fully-qualified class path of the transport adapter to use.
+  # Replaces broker.cliType + broker.transport with a single, extensible field.
+  transportAdapter: "skuld.transports.sdk_websocket.SdkWebSocketTransport"
   # -- Skip tool permission prompts (true = --dangerously-skip-permissions for Claude,
   # --full-auto for Codex)
   skipPermissions: true


### PR DESCRIPTION
## Summary

- **configmap**: Emit `transport_adapter` field with the fully-qualified transport adapter class path (default: `skuld.transports.sdk_websocket.SdkWebSocketTransport`)
- **values.yaml**: Add `broker.transportAdapter`, mark `broker.cliType` and `broker.transport` as deprecated
- **deployment.yaml**: Always set both `CLAUDE_CONFIG_DIR` and `CODEX_HOME` env vars when `homeVolume.enabled` (each CLI reads only its own, harmless overlap)
- **README.md**: Document new `broker.transportAdapter` field, mark deprecated fields

Closes NIU-419

## Verification

- `helm template skuld charts/skuld/` renders valid YAML with `transport_adapter` in configmap
- Legacy values (`broker.cliType: codex`) still produce correct configmap via migration
- Both `CLAUDE_CONFIG_DIR` and `CODEX_HOME` env vars present in deployment spec when homeVolume enabled

## Test plan

- [ ] `helm template` renders `transport_adapter` in configmap output
- [ ] Legacy `broker.cliType` / `broker.transport` values still rendered for backward compat
- [ ] Both `CLAUDE_CONFIG_DIR` and `CODEX_HOME` present when `homeVolume.enabled=true`
- [ ] Full template renders valid YAML without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)