### PR TITLE
refactor(cli): replace match/case transport factory with dynamic import

### DIFF
--- a/src/skuld/broker.py
+++ b/src/skuld/broker.py
@@ -8,6 +8,8 @@ Supports two transport modes (selected via config):
 import asyncio
 import base64
 import collections
+import importlib
+import inspect
 import json
 import logging
 import os
@@ -39,12 +41,7 @@ from skuld.service_manager import (
     ServiceManager,
     ServiceStatus,
 )
-from skuld.transport import (
-    CLITransport,
-    CodexSubprocessTransport,
-    SdkWebSocketTransport,
-    SubprocessTransport,
-)
+from skuld.transport import CLITransport
 
 # ---------------------------------------------------------------------------
 # In-memory log buffer (Part 2: Pod Log Retrieval)
@@ -484,43 +481,54 @@ class Broker:
         self._pending_assistant_parts = []
         self._pending_reasoning_text = ""
 
-    def _create_transport(self) -> CLITransport:
-        """Create the configured CLI transport.
+    def _build_transport_kwargs(self) -> dict:
+        """Return superset of kwargs that any transport constructor might need."""
+        return {
+            "workspace_dir": self.workspace_dir,
+            "model": self.model,
+            "sdk_port": self._settings.port,
+            "session_id": self.session_id,
+            "skip_permissions": self._settings.skip_permissions,
+            "agent_teams": self._settings.agent_teams,
+            "system_prompt": self._settings.session.system_prompt,
+            "initial_prompt": self._settings.session.initial_prompt,
+        }
 
-        Dispatch order:
-        1. cli_type selects the CLI backend ("claude" or "codex")
-        2. For Claude, transport selects the protocol ("sdk" or "subprocess")
+    def _create_transport(self) -> CLITransport:
+        """Create the configured CLI transport via dynamic import.
+
+        Uses ``transport_adapter`` from settings (a fully-qualified class path).
+        Legacy ``cli_type`` / ``transport`` fields are resolved to the correct
+        adapter path by the config validator before this method is called.
         """
-        match self._settings.cli_type:
-            case "codex":
-                logger.info("Using CodexSubprocessTransport (model: %s)", self.model)
-                return CodexSubprocessTransport(
-                    workspace_dir=self.workspace_dir,
-                    model=self.model,
-                )
-            case _:
-                # Default: Claude Code
-                match self._settings.transport:
-                    case "subprocess":
-                        logger.info("Using SubprocessTransport (Claude legacy)")
-                        return SubprocessTransport(self.workspace_dir)
-                    case _:
-                        logger.info("Using SdkWebSocketTransport (Claude SDK)")
-                        return SdkWebSocketTransport(
-                            workspace_dir=self.workspace_dir,
-                            sdk_port=self._settings.port,
-                            session_id=self.session_id,
-                            model=self.model,
-                            skip_permissions=self._settings.skip_permissions,
-                            agent_teams=self._settings.agent_teams,
-                            system_prompt=self._settings.session.system_prompt,
-                            initial_prompt=self._settings.session.initial_prompt,
-                        )
+        adapter_path = self._settings.transport_adapter
+        module_path, _, class_name = adapter_path.rpartition(".")
+        if not module_path:
+            raise ValueError(
+                f"Invalid transport_adapter '{adapter_path}': "
+                "must be a fully-qualified class path "
+                "(e.g. 'skuld.transports.sdk_websocket.SdkWebSocketTransport')"
+            )
+
+        try:
+            module = importlib.import_module(module_path)
+        except ModuleNotFoundError as exc:
+            raise ValueError(f"Cannot import transport module '{module_path}': {exc}") from exc
+
+        cls = getattr(module, class_name, None)
+        if cls is None:
+            raise ValueError(f"Transport class '{class_name}' not found in module '{module_path}'")
+
+        kwargs = self._build_transport_kwargs()
+        sig = inspect.signature(cls)
+        filtered = {k: v for k, v in kwargs.items() if k in sig.parameters}
+        logger.info("Using %s (adapter: %s)", class_name, adapter_path)
+        return cls(**filtered)
 
     async def startup(self) -> None:
         """Initialize the broker on startup."""
         logger.info("Broker starting for session %s", self.session_id)
-        logger.info("Transport: %s", self._settings.transport)
+        logger.info("Transport adapter: %s", self._settings.transport_adapter)
 
         if self.volundr_api_url:
             logger.info("Token usage reporting enabled: %s", self.volundr_api_url)

--- a/src/skuld/broker.py
+++ b/src/skuld/broker.py
@@ -8,7 +8,6 @@ Supports two transport modes (selected via config):
 import asyncio
 import base64
 import collections
-import importlib
 import inspect
 import json
 import logging
@@ -29,6 +28,7 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
 from niuu.domain.logging import LoggingConfig
+from niuu.utils import import_class
 from skuld.channels import (
     ChannelRegistry,
     TelegramChannel,
@@ -502,8 +502,7 @@ class Broker:
         adapter path by the config validator before this method is called.
         """
         adapter_path = self._settings.transport_adapter
-        module_path, _, class_name = adapter_path.rpartition(".")
-        if not module_path:
+        if "." not in adapter_path:
             raise ValueError(
                 f"Invalid transport_adapter '{adapter_path}': "
                 "must be a fully-qualified class path "
@@ -511,18 +510,14 @@ class Broker:
             )
 
         try:
-            module = importlib.import_module(module_path)
-        except ModuleNotFoundError as exc:
-            raise ValueError(f"Cannot import transport module '{module_path}': {exc}") from exc
-
-        cls = getattr(module, class_name, None)
-        if cls is None:
-            raise ValueError(f"Transport class '{class_name}' not found in module '{module_path}'")
+            cls = import_class(adapter_path)
+        except (ImportError, AttributeError) as exc:
+            raise ValueError(f"Cannot load transport adapter '{adapter_path}': {exc}") from exc
 
         kwargs = self._build_transport_kwargs()
         sig = inspect.signature(cls)
         filtered = {k: v for k, v in kwargs.items() if k in sig.parameters}
-        logger.info("Using %s (adapter: %s)", class_name, adapter_path)
+        logger.info("Using %s (adapter: %s)", cls.__name__, adapter_path)
         return cls(**filtered)
 
     async def startup(self) -> None:

--- a/tests/test_skuld/test_broker.py
+++ b/tests/test_skuld/test_broker.py
@@ -267,23 +267,23 @@ class TestBroker:
         assert isinstance(transport, CodexSubprocessTransport)
 
     def test_create_transport_invalid_module(self, tmp_path):
-        """Non-existent module raises ValueError."""
+        """Non-existent module raises ValueError via ImportError."""
         settings = SkuldSettings(
             session={"id": "s1", "workspace_dir": str(tmp_path)},
         )
         settings.transport_adapter = "skuld.transports.nonexistent.FakeTransport"
         b = Broker(settings=settings)
-        with pytest.raises(ValueError, match="Cannot import transport module"):
+        with pytest.raises(ValueError, match="Cannot load transport adapter"):
             b._create_transport()
 
     def test_create_transport_invalid_class(self, tmp_path):
-        """Valid module but missing class raises ValueError."""
+        """Valid module but missing class raises ValueError via AttributeError."""
         settings = SkuldSettings(
             session={"id": "s1", "workspace_dir": str(tmp_path)},
         )
         settings.transport_adapter = "skuld.transports.codex.NonexistentTransport"
         b = Broker(settings=settings)
-        with pytest.raises(ValueError, match="not found in module"):
+        with pytest.raises(ValueError, match="Cannot load transport adapter"):
             b._create_transport()
 
     def test_create_transport_invalid_path_no_dot(self, tmp_path):

--- a/tests/test_skuld/test_broker.py
+++ b/tests/test_skuld/test_broker.py
@@ -254,6 +254,85 @@ class TestBroker:
         assert isinstance(transport, SdkWebSocketTransport)
         assert transport._agent_teams is True
 
+    # --- Dynamic transport adapter tests ---
+
+    def test_create_transport_explicit_adapter(self, tmp_path):
+        """Direct transport_adapter bypasses legacy field resolution."""
+        settings = SkuldSettings(
+            transport_adapter="skuld.transports.codex.CodexSubprocessTransport",
+            session={"id": "s1", "workspace_dir": str(tmp_path), "model": "o4-mini"},
+        )
+        b = Broker(settings=settings)
+        transport = b._create_transport()
+        assert isinstance(transport, CodexSubprocessTransport)
+
+    def test_create_transport_invalid_module(self, tmp_path):
+        """Non-existent module raises ValueError."""
+        settings = SkuldSettings(
+            session={"id": "s1", "workspace_dir": str(tmp_path)},
+        )
+        settings.transport_adapter = "skuld.transports.nonexistent.FakeTransport"
+        b = Broker(settings=settings)
+        with pytest.raises(ValueError, match="Cannot import transport module"):
+            b._create_transport()
+
+    def test_create_transport_invalid_class(self, tmp_path):
+        """Valid module but missing class raises ValueError."""
+        settings = SkuldSettings(
+            session={"id": "s1", "workspace_dir": str(tmp_path)},
+        )
+        settings.transport_adapter = "skuld.transports.codex.NonexistentTransport"
+        b = Broker(settings=settings)
+        with pytest.raises(ValueError, match="not found in module"):
+            b._create_transport()
+
+    def test_create_transport_invalid_path_no_dot(self, tmp_path):
+        """Adapter path without a dot raises ValueError."""
+        settings = SkuldSettings(
+            session={"id": "s1", "workspace_dir": str(tmp_path)},
+        )
+        settings.transport_adapter = "NotAFullyQualifiedPath"
+        b = Broker(settings=settings)
+        with pytest.raises(ValueError, match="must be a fully-qualified class path"):
+            b._create_transport()
+
+    def test_build_transport_kwargs(self, tmp_path):
+        """_build_transport_kwargs returns expected superset of settings."""
+        settings = SkuldSettings(
+            session={
+                "id": "s1",
+                "workspace_dir": str(tmp_path),
+                "model": "opus",
+                "system_prompt": "be helpful",
+                "initial_prompt": "hello",
+            },
+            port=9999,
+            skip_permissions=False,
+            agent_teams=True,
+        )
+        b = Broker(settings=settings)
+        kwargs = b._build_transport_kwargs()
+        assert kwargs["workspace_dir"] == str(tmp_path)
+        assert kwargs["model"] == "opus"
+        assert kwargs["sdk_port"] == 9999
+        assert kwargs["session_id"] == "s1"
+        assert kwargs["skip_permissions"] is False
+        assert kwargs["agent_teams"] is True
+        assert kwargs["system_prompt"] == "be helpful"
+        assert kwargs["initial_prompt"] == "hello"
+
+    def test_create_transport_filters_kwargs(self, tmp_path):
+        """Only kwargs matching the constructor signature are passed."""
+        settings = SkuldSettings(
+            transport="subprocess",
+            session={"id": "s1", "workspace_dir": str(tmp_path)},
+        )
+        b = Broker(settings=settings)
+        transport = b._create_transport()
+        # SubprocessTransport only accepts workspace_dir
+        assert isinstance(transport, SubprocessTransport)
+        assert transport.workspace_dir == str(tmp_path)
+
 
 class TestDispatchBrowserMessage:
     """Tests for Broker._dispatch_browser_message (Phase 2/3/4)."""


### PR DESCRIPTION
## Summary
- Replaced hardcoded `match/case` dispatch in `broker._create_transport()` with dynamic import via `importlib` + `inspect.signature` filtering
- Added `_build_transport_kwargs()` that returns a superset dict of all settings any transport might need
- Constructor kwargs are filtered by `inspect.signature` so each transport only receives parameters it accepts
- Removed direct imports of concrete transport classes from `broker.py` (only `CLITransport` is imported for type checking)
- Legacy `cli_type`/`transport` config fields still work via the existing `_resolve_transport_adapter` validator

## Test plan
- [x] Existing transport creation tests pass (subprocess, sdk, codex, model/skip_permissions/agent_teams pass-through)
- [x] New test: explicit `transport_adapter` config creates correct transport
- [x] New test: invalid module path raises `ValueError`
- [x] New test: valid module but missing class raises `ValueError`
- [x] New test: non-qualified path (no dot) raises `ValueError`
- [x] New test: `_build_transport_kwargs` returns expected superset
- [x] New test: kwargs filtering only passes constructor-accepted params
- [x] All 138 broker tests pass
- [x] ruff check + format clean

Closes NIU-416

🤖 Generated with [Claude Code](https://claude.com/claude-code)