### PR TITLE
fix(ci): align release-tag container matrix with other workflows

### DIFF
--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         platform: [amd64, arm64]
-        container: [volundr, skuld, devrunner, volundr-web]
+        container: [volundr, skuld, devrunner, volundr-web, vscode-reh, tyr, niuu]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -73,7 +73,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        container: [volundr, skuld, devrunner, volundr-web]
+        container: [volundr, skuld, devrunner, volundr-web, vscode-reh, tyr, niuu]
     steps:
       - name: Log in to Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4


### PR DESCRIPTION
## Summary

- Aligns `release-tag.yaml` container build and manifest matrices with all other CI workflows by adding `vscode-reh`, `tyr`, and `niuu` containers that were missing
- Confirms zero `skuld-codex` references remain in `.github/workflows/` after the container merge in #247

### Context

PR #247 (NIU-417) merged `skuld-codex` into the unified `skuld` image and removed `skuld-codex` from all CI matrices. However, `release-tag.yaml` was left with a stale 4-container matrix `[volundr, skuld, devrunner, volundr-web]` while all other workflows use the full 7-container list. This PR aligns it.

### Verification

```
$ grep -r "skuld-codex" .github/
# (zero matches)

$ grep -n 'container:.*\[' .github/workflows/*.yaml | grep -v '#'
# All matrices now use: [volundr, skuld, devrunner, volundr-web, vscode-reh, tyr, niuu]
```

## Test plan

- [x] `grep -r "skuld-codex" .github/` returns zero matches
- [x] YAML validates successfully
- [x] All 145 chart tests pass
- [ ] CI checks pass on this PR

Closes NIU-418

🤖 Generated with [Claude Code](https://claude.com/claude-code)