### PR TITLE
test(infra): add migration runner helper for integration tests

### DIFF
--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,0 +1,5 @@
+"""Reusable test helpers for integration and unit tests."""
+
+from tests.helpers.migrations import apply_migrations
+
+__all__ = ["apply_migrations"]

--- a/tests/helpers/migrations.py
+++ b/tests/helpers/migrations.py
@@ -1,0 +1,82 @@
+"""Migration runner helper for integration tests.
+
+Discovers and applies `*.up.sql` migration files against a real PostgreSQL
+database, sorted by their 6-digit numeric prefix.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import asyncpg
+
+_PREFIX_RE = re.compile(r"^(\d{6})_.*\.up\.sql$")
+
+
+class MigrationError(Exception):
+    """Raised when a migration file fails to apply."""
+
+    def __init__(self, file: Path, cause: Exception) -> None:
+        self.file = file
+        self.cause = cause
+        super().__init__(f"Migration failed: {file.name} — {cause}")
+
+
+def discover_migrations(migrations_dir: Path) -> list[Path]:
+    """Return `*.up.sql` files sorted by their 6-digit numeric prefix.
+
+    Raises ``FileNotFoundError`` if *migrations_dir* does not exist.
+    """
+    if not migrations_dir.is_dir():
+        raise FileNotFoundError(f"Migrations directory not found: {migrations_dir}")
+
+    files: list[tuple[str, Path]] = []
+    for path in migrations_dir.iterdir():
+        m = _PREFIX_RE.match(path.name)
+        if m:
+            files.append((m.group(1), path))
+
+    files.sort(key=lambda t: t[0])
+    return [path for _, path in files]
+
+
+async def apply_migrations(
+    pool: asyncpg.Pool,
+    migrations_dir: Path,
+) -> list[Path]:
+    """Apply all ``*.up.sql`` migrations in *migrations_dir* sequentially.
+
+    Parameters
+    ----------
+    pool:
+        An ``asyncpg`` connection pool.
+    migrations_dir:
+        Directory containing ``NNNNNN_*.up.sql`` migration files.
+
+    Returns
+    -------
+    list[Path]
+        The ordered list of migration files that were applied.
+
+    Raises
+    ------
+    MigrationError
+        If any migration file fails to execute, wrapping the original
+        exception and identifying the failing file.
+    FileNotFoundError
+        If *migrations_dir* does not exist.
+    """
+    migration_files = discover_migrations(migrations_dir)
+
+    async with pool.acquire() as conn:
+        for file in migration_files:
+            sql = file.read_text(encoding="utf-8")
+            try:
+                await conn.execute(sql)
+            except Exception as exc:
+                raise MigrationError(file, exc) from exc
+
+    return migration_files

--- a/tests/helpers/test_migrations.py
+++ b/tests/helpers/test_migrations.py
@@ -1,0 +1,139 @@
+"""Unit tests for the migration runner helper.
+
+These tests verify file discovery and ordering using a temporary directory
+of mock `.sql` files — no database connection required.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tests.helpers.migrations import (
+    MigrationError,
+    apply_migrations,
+    discover_migrations,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def migrations_dir(tmp_path: Path) -> Path:
+    """Create a temp directory with mock migration files."""
+    files = [
+        "000001_initial_schema.up.sql",
+        "000002_add_columns.up.sql",
+        "000003_add_indexes.up.sql",
+        "000001_initial_schema.down.sql",  # should be ignored
+        "README.md",  # should be ignored
+    ]
+    for name in files:
+        (tmp_path / name).write_text(f"-- {name}", encoding="utf-8")
+    return tmp_path
+
+
+@pytest.fixture()
+def unordered_dir(tmp_path: Path) -> Path:
+    """Migrations written in non-alphabetical filesystem order."""
+    files = [
+        "000010_late.up.sql",
+        "000003_middle.up.sql",
+        "000001_first.up.sql",
+    ]
+    for name in files:
+        (tmp_path / name).write_text(f"-- {name}", encoding="utf-8")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# discover_migrations
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverMigrations:
+    def test_discovers_only_up_sql_files(self, migrations_dir: Path) -> None:
+        result = discover_migrations(migrations_dir)
+        names = [p.name for p in result]
+        assert names == [
+            "000001_initial_schema.up.sql",
+            "000002_add_columns.up.sql",
+            "000003_add_indexes.up.sql",
+        ]
+
+    def test_ignores_down_and_non_sql(self, migrations_dir: Path) -> None:
+        result = discover_migrations(migrations_dir)
+        names = {p.name for p in result}
+        assert "000001_initial_schema.down.sql" not in names
+        assert "README.md" not in names
+
+    def test_sorts_by_numeric_prefix(self, unordered_dir: Path) -> None:
+        result = discover_migrations(unordered_dir)
+        prefixes = [p.name[:6] for p in result]
+        assert prefixes == ["000001", "000003", "000010"]
+
+    def test_empty_directory(self, tmp_path: Path) -> None:
+        result = discover_migrations(tmp_path)
+        assert result == []
+
+    def test_missing_directory_raises(self, tmp_path: Path) -> None:
+        missing = tmp_path / "nonexistent"
+        with pytest.raises(FileNotFoundError, match="nonexistent"):
+            discover_migrations(missing)
+
+
+# ---------------------------------------------------------------------------
+# apply_migrations
+# ---------------------------------------------------------------------------
+
+
+class TestApplyMigrations:
+    async def test_applies_all_in_order(self, migrations_dir: Path) -> None:
+        conn = AsyncMock()
+        pool = MagicMock()
+        pool.acquire.return_value.__aenter__ = AsyncMock(return_value=conn)
+        pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        applied = await apply_migrations(pool, migrations_dir)
+
+        assert len(applied) == 3
+        assert applied[0].name == "000001_initial_schema.up.sql"
+        assert applied[2].name == "000003_add_indexes.up.sql"
+
+        # Verify execute was called three times with the file contents
+        assert conn.execute.call_count == 3
+        first_sql = conn.execute.call_args_list[0].args[0]
+        assert "000001_initial_schema.up.sql" in first_sql
+
+    async def test_raises_migration_error_on_failure(self, migrations_dir: Path) -> None:
+        conn = AsyncMock()
+        conn.execute.side_effect = [None, RuntimeError("syntax error")]
+        pool = MagicMock()
+        pool.acquire.return_value.__aenter__ = AsyncMock(return_value=conn)
+        pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with pytest.raises(MigrationError, match="000002_add_columns.up.sql") as exc:
+            await apply_migrations(pool, migrations_dir)
+
+        assert exc.value.file.name == "000002_add_columns.up.sql"
+        assert isinstance(exc.value.cause, RuntimeError)
+
+    async def test_missing_dir_raises(self, tmp_path: Path) -> None:
+        pool = MagicMock()
+        with pytest.raises(FileNotFoundError):
+            await apply_migrations(pool, tmp_path / "nope")
+
+    async def test_empty_dir_returns_empty(self, tmp_path: Path) -> None:
+        conn = AsyncMock()
+        pool = MagicMock()
+        pool.acquire.return_value.__aenter__ = AsyncMock(return_value=conn)
+        pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await apply_migrations(pool, tmp_path)
+
+        assert result == []
+        conn.execute.assert_not_called()


### PR DESCRIPTION
## Summary

- Add `tests/helpers/migrations.py` with `apply_migrations(pool, migrations_dir)` — discovers `*.up.sql` files, sorts by 6-digit prefix, executes sequentially via asyncpg
- Add `MigrationError` exception that clearly identifies the failing migration file
- Add `discover_migrations()` for file discovery/ordering (also usable standalone)
- Add comprehensive unit tests (9 tests) covering discovery, ordering, error handling — no DB required

Works for both `migrations/` (Volundr) and `migrations/tyr/` (Tyr).

Closes NIU-441

## Test plan

- [x] All 9 unit tests pass (`pytest tests/helpers/test_migrations.py`)
- [x] Ruff lint and format clean
- [x] No external dependencies beyond asyncpg

🤖 Generated with [Claude Code](https://claude.com/claude-code)