### PR TITLE
test(e2e): install Playwright and configure auth-bypassed E2E testing

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -5,3 +5,8 @@ dist-ssr
 .DS_Store
 /coverage
 *.log
+
+# Playwright
+test-results/
+playwright-report/
+blob-report/

--- a/web/e2e/fixtures.ts
+++ b/web/e2e/fixtures.ts
@@ -1,0 +1,27 @@
+import { test as base, type Page } from '@playwright/test';
+
+/**
+ * Wait for the app to finish auth initialisation.
+ *
+ * Without OIDC env vars the AuthProvider immediately sets
+ * `authenticated: true`, but the React tree still needs a tick to render.
+ * This helper navigates to the root and waits for the redirect to /volundr
+ * (which proves the auth gate passed and the router is active).
+ */
+async function waitForAuth(page: Page, baseURL: string) {
+  await page.goto(baseURL);
+  await page.waitForURL('**/volundr', { timeout: 15_000 });
+}
+
+type Fixtures = {
+  authenticatedPage: Page;
+};
+
+export const test = base.extend<Fixtures>({
+  authenticatedPage: async ({ page, baseURL }, use) => {
+    await waitForAuth(page, baseURL ?? 'http://localhost:5174');
+    await use(page);
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/web/e2e/smoke.spec.ts
+++ b/web/e2e/smoke.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from './fixtures';
+
+test.describe('smoke', () => {
+  test('loads the app and redirects to /volundr', async ({ authenticatedPage }) => {
+    await expect(authenticatedPage).toHaveURL(/\/volundr/);
+    await expect(authenticatedPage.locator('body')).toBeVisible();
+  });
+});

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist', 'coverage']),
+  globalIgnores(['dist', 'coverage', 'e2e']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -129,6 +129,7 @@
       "devDependencies": {
         "@codingame/esbuild-import-meta-url-plugin": "^1.0.3",
         "@eslint/js": "^9.39.1",
+        "@playwright/test": "^1.59.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -2659,6 +2660,22 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
@@ -7671,6 +7688,53 @@
         "confbox": "^0.2.2",
         "exsolve": "^1.0.7",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/web/package.json
+++ b/web/package.json
@@ -42,7 +42,9 @@
     "preview": "vite preview",
     "test": "vitest",
     "test:run": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",
@@ -184,6 +186,7 @@
   "devDependencies": {
     "@codingame/esbuild-import-meta-url-plugin": "^1.0.3",
     "@eslint/js": "^9.39.1",
+    "@playwright/test": "^1.59.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const CI = !!process.env.CI;
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: CI,
+  retries: CI ? 1 : 0,
+  workers: CI ? 1 : undefined,
+  reporter: [['html'], ...(CI ? [['github'] as const] : [])],
+  use: {
+    baseURL: 'http://localhost:5174',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:5174',
+    reuseExistingServer: !CI,
+  },
+});

--- a/web/src/utils/formatters.test.ts
+++ b/web/src/utils/formatters.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
+  formatBytes,
   formatNumber,
   formatTokens,
   formatPercent,
@@ -11,6 +12,36 @@ import {
 } from './formatters';
 
 describe('formatters', () => {
+  describe('formatBytes', () => {
+    it('returns "0 B" for zero bytes', () => {
+      expect(formatBytes(0)).toBe('0 B');
+    });
+
+    it('formats bytes', () => {
+      expect(formatBytes(500)).toBe('500 B');
+    });
+
+    it('formats kilobytes', () => {
+      expect(formatBytes(1024)).toBe('1.0 KB');
+    });
+
+    it('formats megabytes', () => {
+      expect(formatBytes(1_048_576)).toBe('1.0 MB');
+    });
+
+    it('formats gigabytes', () => {
+      expect(formatBytes(1_073_741_824)).toBe('1.0 GB');
+    });
+
+    it('formats terabytes', () => {
+      expect(formatBytes(2_000_000_000_000)).toBe('1.8 TB');
+    });
+
+    it('uses 0 decimal places for values >= 10', () => {
+      expect(formatBytes(12_000_000)).toBe('11 MB');
+    });
+  });
+
   describe('formatNumber', () => {
     it('formats millions with M suffix', () => {
       expect(formatNumber(1_000_000)).toBe('1.0M');

--- a/web/src/utils/source.test.ts
+++ b/web/src/utils/source.test.ts
@@ -95,6 +95,15 @@ describe('getSourceLabel', () => {
     expect(getSourceLabel(localPath)).toBe('my-app');
   });
 
+  it('returns full local_path when path is root "/"', () => {
+    const localPath: LocalMountSource = {
+      type: 'local_mount',
+      local_path: '/',
+      paths: [],
+    };
+    expect(getSourceLabel(localPath)).toBe('/');
+  });
+
   it('returns "0 local mounts" for empty paths without local_path', () => {
     const emptyMount: LocalMountSource = {
       type: 'local_mount',


### PR DESCRIPTION
## Summary

- Adds `@playwright/test` to devDependencies with `test:e2e` and `test:e2e:ui` npm scripts
- Creates `playwright.config.ts` targeting Chromium with `webServer` auto-start of Vite dev server, trace on first retry, and CI-aware retries + GitHub reporter
- Adds `e2e/fixtures.ts` with `authenticatedPage` fixture leveraging the existing auth bypass (no OIDC config → `authenticated: true`)
- Adds `e2e/smoke.spec.ts` verifying the app loads and redirects from `/` to `/volundr`
- Updates `.gitignore` for Playwright artifacts (`test-results/`, `playwright-report/`, `blob-report/`)
- Excludes `e2e/` from ESLint to avoid React hooks rule conflict with Playwright's `use()` callback

## Test plan

- [ ] `npx playwright install chromium` installs browser successfully
- [ ] `npm run test:e2e` runs the smoke test (with backend running)
- [ ] Smoke test passes with Vite proxying to a running Volundr backend
- [ ] No OIDC configuration needed — auth bypass works out of the box
- [ ] Playwright config uses `webServer` to auto-start Vite

Closes NIU-446

🤖 Generated with [Claude Code](https://claude.com/claude-code)