### PR TITLE
test(cli): update backend tests for transport capabilities refactor

### DIFF
--- a/tests/test_skuld/test_broker.py
+++ b/tests/test_skuld/test_broker.py
@@ -16,7 +16,7 @@ from skuld.broker import (
     broker,
 )
 from skuld.config import SkuldSettings
-from skuld.transport import (
+from skuld.transports import (
     CodexSubprocessTransport,
     SdkWebSocketTransport,
     SubprocessTransport,
@@ -105,6 +105,44 @@ class TestBroker:
         transport = b._create_transport()
         assert isinstance(transport, SdkWebSocketTransport)
         assert transport._model == "claude-opus-4-20250514"
+
+    def test_create_transport_dynamic_import(self, tmp_path):
+        """Dynamic transport factory uses importlib to load the configured adapter."""
+        settings = SkuldSettings(
+            transport_adapter="skuld.transports.subprocess.SubprocessTransport",
+            session={"id": "s1", "workspace_dir": str(tmp_path)},
+        )
+        b = Broker(settings=settings)
+
+        with patch("skuld.broker.import_class") as mock_import:
+            mock_import.return_value = SubprocessTransport
+            transport = b._create_transport()
+
+        mock_import.assert_called_once_with("skuld.transports.subprocess.SubprocessTransport")
+        assert isinstance(transport, SubprocessTransport)
+
+    def test_create_transport_invalid_adapter_path(self, tmp_path):
+        """Invalid adapter path (no dot) raises ValueError."""
+        settings = SkuldSettings(
+            transport_adapter="BadPath",
+            session={"id": "s1", "workspace_dir": str(tmp_path)},
+        )
+        b = Broker(settings=settings)
+
+        with pytest.raises(ValueError, match="must be a fully-qualified"):
+            b._create_transport()
+
+    def test_create_transport_import_error(self, tmp_path):
+        """ImportError from dynamic import is wrapped in ValueError."""
+        settings = SkuldSettings(
+            transport_adapter="nonexistent.module.Transport",
+            session={"id": "s1", "workspace_dir": str(tmp_path)},
+        )
+        b = Broker(settings=settings)
+
+        with patch("skuld.broker.import_class", side_effect=ImportError("no module")):
+            with pytest.raises(ValueError, match="Cannot load transport adapter"):
+                b._create_transport()
 
     @pytest.mark.asyncio
     async def test_startup_creates_workspace(self, test_broker, tmp_path):

--- a/tests/test_skuld/test_conversation_history.py
+++ b/tests/test_skuld/test_conversation_history.py
@@ -15,7 +15,7 @@ from skuld.broker import (
     broker,
 )
 from skuld.config import SkuldSettings
-from skuld.transport import TransportCapabilities
+from skuld.transports import TransportCapabilities
 
 
 class TestConversationTurn:

--- a/tests/test_skuld/test_transport.py
+++ b/tests/test_skuld/test_transport.py
@@ -6,15 +6,106 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from skuld.transport import (
+from skuld.transports import (
     CodexSubprocessTransport,
     SdkWebSocketTransport,
     SubprocessTransport,
+    TransportCapabilities,
     _drain_stream,
     _filter_event,
     _map_codex_tool,
     _stop_process,
 )
+
+# ---------------------------------------------------------------------------
+# TransportCapabilities
+# ---------------------------------------------------------------------------
+
+
+class TestTransportCapabilities:
+    """Tests for TransportCapabilities dataclass and per-transport values."""
+
+    def test_default_capabilities_all_false(self):
+        """Default TransportCapabilities() has all fields False."""
+        caps = TransportCapabilities()
+        assert caps.cli_websocket is False
+        assert caps.session_resume is False
+        assert caps.interrupt is False
+        assert caps.set_model is False
+        assert caps.set_thinking_tokens is False
+        assert caps.set_permission_mode is False
+        assert caps.rewind_files is False
+        assert caps.mcp_set_servers is False
+        assert caps.permission_requests is False
+        assert caps.slash_commands is False
+        assert caps.skills is False
+
+    def test_subprocess_transport_capabilities(self, tmp_path):
+        """SubprocessTransport has session_resume=True, rest False."""
+        transport = SubprocessTransport(str(tmp_path))
+        caps = transport.capabilities
+        assert caps.session_resume is True
+        assert caps.cli_websocket is False
+        assert caps.interrupt is False
+        assert caps.set_model is False
+        assert caps.set_thinking_tokens is False
+        assert caps.set_permission_mode is False
+        assert caps.rewind_files is False
+        assert caps.mcp_set_servers is False
+        assert caps.permission_requests is False
+        assert caps.slash_commands is False
+        assert caps.skills is False
+
+    def test_sdk_websocket_transport_capabilities(self, tmp_path):
+        """SdkWebSocketTransport has all capabilities True."""
+        transport = SdkWebSocketTransport(
+            workspace_dir=str(tmp_path),
+            sdk_port=8081,
+            session_id="test",
+        )
+        caps = transport.capabilities
+        assert caps.cli_websocket is True
+        assert caps.session_resume is True
+        assert caps.interrupt is True
+        assert caps.set_model is True
+        assert caps.set_thinking_tokens is True
+        assert caps.set_permission_mode is True
+        assert caps.rewind_files is True
+        assert caps.mcp_set_servers is True
+        assert caps.permission_requests is True
+        assert caps.slash_commands is True
+        assert caps.skills is True
+
+    def test_codex_subprocess_transport_capabilities(self, tmp_path):
+        """CodexSubprocessTransport has all capabilities False."""
+        transport = CodexSubprocessTransport(str(tmp_path))
+        caps = transport.capabilities
+        assert caps.cli_websocket is False
+        assert caps.session_resume is False
+        assert caps.interrupt is False
+        assert caps.set_model is False
+        assert caps.set_thinking_tokens is False
+        assert caps.set_permission_mode is False
+        assert caps.rewind_files is False
+        assert caps.mcp_set_servers is False
+        assert caps.permission_requests is False
+        assert caps.slash_commands is False
+        assert caps.skills is False
+
+    def test_capabilities_is_frozen(self):
+        """TransportCapabilities is immutable (frozen dataclass)."""
+        caps = TransportCapabilities()
+        with pytest.raises(AttributeError):
+            caps.cli_websocket = True  # type: ignore[misc]
+
+    def test_capabilities_partial_override(self):
+        """Individual fields can be set at construction time."""
+        caps = TransportCapabilities(interrupt=True, set_model=True)
+        assert caps.interrupt is True
+        assert caps.set_model is True
+        assert caps.cli_websocket is False
+        assert caps.session_resume is False
+
 
 # ---------------------------------------------------------------------------
 # _filter_event
@@ -741,7 +832,7 @@ class TestSdkWebSocketTransport:
     @pytest.mark.asyncio
     async def test_send_control_response_noop_on_base_class(self):
         """Base CLITransport.send_control_response is a no-op."""
-        from skuld.transport import SubprocessTransport
+        from skuld.transports import SubprocessTransport
 
         t = SubprocessTransport("/tmp")
         # Should not raise
@@ -814,7 +905,7 @@ class TestSdkWebSocketTransport:
     @pytest.mark.asyncio
     async def test_send_control_noop_on_base_class(self):
         """Base CLITransport.send_control is a no-op."""
-        from skuld.transport import SubprocessTransport
+        from skuld.transports import SubprocessTransport
 
         t = SubprocessTransport("/tmp")
         # Should not raise
@@ -1079,6 +1170,15 @@ class TestCodexSubprocessTransport:
         caps = transport.capabilities
         assert caps.cli_websocket is False
         assert caps.session_resume is False
+        assert caps.interrupt is False
+        assert caps.set_model is False
+        assert caps.set_thinking_tokens is False
+        assert caps.set_permission_mode is False
+        assert caps.rewind_files is False
+        assert caps.mcp_set_servers is False
+        assert caps.permission_requests is False
+        assert caps.slash_commands is False
+        assert caps.skills is False
 
     @pytest.mark.asyncio
     async def test_start_is_noop(self, transport):


### PR DESCRIPTION
## Summary

- Updated all skuld test imports from `skuld.transport` to `skuld.transports` (the canonical package path)
- Added `TestTransportCapabilities` class to `test_transport.py` verifying:
  - Default `TransportCapabilities()` has all 11 fields False
  - `SubprocessTransport.capabilities` has `session_resume=True`, rest False
  - `SdkWebSocketTransport.capabilities` has all True
  - `CodexSubprocessTransport.capabilities` has all False
  - Frozen dataclass immutability
  - Partial field override at construction
- Expanded existing `test_capabilities_all_false` to assert all 11 capability fields
- Added dynamic transport factory tests to `test_broker.py`:
  - `test_create_transport_dynamic_import` — verifies `import_class` is called with configured adapter path
  - `test_create_transport_invalid_adapter_path` — invalid path (no dot) raises `ValueError`
  - `test_create_transport_import_error` — `ImportError` wrapped as `ValueError`

## Test plan

- [x] `pytest tests/test_skuld/ -v` — 564 tests pass, zero failures
- [x] `pytest tests/test_skuld/ --cov=skuld --cov-fail-under=85` — 86.19% coverage
- [x] `ruff check` + `ruff format` — clean

Resolves NIU-423

🤖 Generated with [Claude Code](https://claude.com/claude-code)