### PR TITLE
feat(cli): consume transport capabilities and gate UI controls

### DIFF
--- a/web/src/modules/shared/components/SessionChat/ChatInput.module.css
+++ b/web/src/modules/shared/components/SessionChat/ChatInput.module.css
@@ -214,8 +214,13 @@
   transition: all var(--transition-fast);
 }
 
-.stopBtn:hover {
+.stopBtn:hover:not(:disabled) {
   background-color: var(--color-bg-elevated);
+}
+
+.stopBtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 .stopIcon {

--- a/web/src/modules/shared/components/SessionChat/ChatInput.tsx
+++ b/web/src/modules/shared/components/SessionChat/ChatInput.tsx
@@ -23,6 +23,7 @@ interface ChatInputProps {
   isLoading: boolean;
   onStop: () => void;
   disabled?: boolean;
+  stopDisabled?: boolean;
   className?: string;
   sessionId?: string | null;
   sessionHost?: string | null;
@@ -63,6 +64,7 @@ export function ChatInput({
   isLoading,
   onStop,
   disabled = false,
+  stopDisabled = false,
   className,
   sessionId = null,
   sessionHost = null,
@@ -367,7 +369,14 @@ export function ChatInput({
 
         <div className={styles.rightActions}>
           {isLoading && (
-            <button type="button" className={styles.stopBtn} onClick={onStop}>
+            <button
+              type="button"
+              className={styles.stopBtn}
+              onClick={onStop}
+              disabled={stopDisabled}
+              title={stopDisabled ? 'Interrupt not supported by this transport' : 'Stop generation'}
+              data-testid="stop-btn"
+            >
               <Square className={styles.stopIcon} />
               <span>Stop</span>
             </button>

--- a/web/src/modules/shared/components/SessionChat/SessionChat.test.tsx
+++ b/web/src/modules/shared/components/SessionChat/SessionChat.test.tsx
@@ -7,15 +7,50 @@ vi.mock('@/modules/shared/hooks/useSkuldChat', () => ({
 }));
 
 import { useSkuldChat } from '@/modules/shared/hooks/useSkuldChat';
-import type { SkuldChatMessage, PermissionRequest } from '@/modules/shared/hooks/useSkuldChat';
+import type {
+  SkuldChatMessage,
+  PermissionRequest,
+  TransportCapabilities,
+} from '@/modules/shared/hooks/useSkuldChat';
 import { SessionChat } from './SessionChat';
+
+const NO_CAPABILITIES: TransportCapabilities = {
+  cli_websocket: false,
+  session_resume: false,
+  interrupt: false,
+  set_model: false,
+  set_thinking_tokens: false,
+  set_permission_mode: false,
+  rewind_files: false,
+  mcp_set_servers: false,
+  permission_requests: false,
+  slash_commands: false,
+  skills: false,
+};
+
+const ALL_CAPABILITIES: TransportCapabilities = {
+  cli_websocket: true,
+  session_resume: true,
+  interrupt: true,
+  set_model: true,
+  set_thinking_tokens: true,
+  set_permission_mode: true,
+  rewind_files: true,
+  mcp_set_servers: true,
+  permission_requests: true,
+  slash_commands: true,
+  skills: true,
+};
 
 function mockSkuldChat(overrides: Partial<ReturnType<typeof useSkuldChat>> = {}) {
   const defaults: ReturnType<typeof useSkuldChat> = {
     messages: [],
     connected: false,
     isRunning: false,
+    historyLoaded: true,
     pendingPermissions: [],
+    availableCommands: [],
+    capabilities: ALL_CAPABILITIES,
     sendMessage: vi.fn(),
     respondToPermission: vi.fn(),
     sendInterrupt: vi.fn(),
@@ -495,5 +530,85 @@ describe('SessionChat', () => {
     render(<SessionChat url="wss://test/session" onMessageCountChange={onMessageCountChange} />);
 
     expect(onMessageCountChange).toHaveBeenCalled();
+  });
+
+  // ── Capability gating ───────────────────────────────────────
+
+  it('hides model switch when capabilities.set_model is false', () => {
+    mockSkuldChat({
+      connected: true,
+      capabilities: { ...ALL_CAPABILITIES, set_model: false },
+    });
+    render(<SessionChat url="wss://test/session" />);
+
+    expect(screen.queryByTestId('model-switch-toggle')).not.toBeInTheDocument();
+  });
+
+  it('shows model switch when capabilities.set_model is true', () => {
+    mockSkuldChat({
+      connected: true,
+      capabilities: { ...ALL_CAPABILITIES, set_model: true },
+    });
+    render(<SessionChat url="wss://test/session" />);
+
+    expect(screen.getByTestId('model-switch-toggle')).toBeInTheDocument();
+  });
+
+  it('hides thinking budget when capabilities.set_thinking_tokens is false', () => {
+    mockSkuldChat({
+      connected: true,
+      capabilities: { ...ALL_CAPABILITIES, set_thinking_tokens: false },
+    });
+    render(<SessionChat url="wss://test/session" />);
+
+    expect(screen.queryByTestId('thinking-budget-toggle')).not.toBeInTheDocument();
+  });
+
+  it('hides rewind button when capabilities.rewind_files is false', () => {
+    mockSkuldChat({
+      connected: true,
+      capabilities: { ...ALL_CAPABILITIES, rewind_files: false },
+    });
+    render(<SessionChat url="wss://test/session" />);
+
+    expect(screen.queryByTestId('rewind-files')).not.toBeInTheDocument();
+  });
+
+  it('disables stop button when capabilities.interrupt is false', () => {
+    mockSkuldChat({
+      connected: true,
+      isRunning: true,
+      capabilities: { ...ALL_CAPABILITIES, interrupt: false },
+    });
+    render(<SessionChat url="wss://test/session" />);
+
+    const stopBtn = screen.getByTestId('stop-btn');
+    expect(stopBtn).toBeDisabled();
+    expect(stopBtn).toHaveAttribute('title', 'Interrupt not supported by this transport');
+  });
+
+  it('enables stop button when capabilities.interrupt is true', () => {
+    mockSkuldChat({
+      connected: true,
+      isRunning: true,
+      capabilities: { ...ALL_CAPABILITIES, interrupt: true },
+    });
+    render(<SessionChat url="wss://test/session" />);
+
+    const stopBtn = screen.getByTestId('stop-btn');
+    expect(stopBtn).not.toBeDisabled();
+    expect(stopBtn).toHaveAttribute('title', 'Stop generation');
+  });
+
+  it('hides all controls with no capabilities (all false)', () => {
+    mockSkuldChat({
+      connected: true,
+      capabilities: NO_CAPABILITIES,
+    });
+    render(<SessionChat url="wss://test/session" />);
+
+    expect(screen.queryByTestId('model-switch-toggle')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('thinking-budget-toggle')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('rewind-files')).not.toBeInTheDocument();
   });
 });

--- a/web/src/modules/shared/components/SessionChat/SessionChat.tsx
+++ b/web/src/modules/shared/components/SessionChat/SessionChat.tsx
@@ -6,6 +6,7 @@ import type {
   PermissionBehavior,
   ContentBlock,
   AttachmentMeta,
+  TransportCapabilities,
 } from '@/modules/shared/hooks/useSkuldChat';
 import { cn } from '@/utils';
 import { UserMessage, AssistantMessage, StreamingMessage, SystemMessage } from './ChatMessages';
@@ -57,6 +58,7 @@ export function SessionChat({
     sendSetMaxThinkingTokens,
     sendRewindFiles,
     availableCommands,
+    capabilities,
   } = useSkuldChat(url);
 
   const [modelInput, setModelInput] = useState('');
@@ -309,52 +311,58 @@ export function SessionChat({
         {connected && (
           <div className={styles.toolbarRight}>
             <div className={styles.controlGroup}>
-              <button
-                type="button"
-                className={styles.controlBtn}
-                onClick={() => setShowModelInput(prev => !prev)}
-                title="Switch model"
-                data-testid="model-switch-toggle"
-              >
-                <BrainCircuitIcon className={styles.controlIcon} />
-              </button>
-
-              <div className={styles.thinkingWrapper}>
+              {capabilities.set_model && (
                 <button
                   type="button"
                   className={styles.controlBtn}
-                  onClick={() => setShowThinkingMenu(prev => !prev)}
-                  title="Set thinking budget"
-                  data-testid="thinking-budget-toggle"
+                  onClick={() => setShowModelInput(prev => !prev)}
+                  title="Switch model"
+                  data-testid="model-switch-toggle"
                 >
-                  <span className={styles.controlLabel}>Thinking</span>
+                  <BrainCircuitIcon className={styles.controlIcon} />
                 </button>
-                {showThinkingMenu && (
-                  <div className={styles.thinkingMenu} data-testid="thinking-menu">
-                    {THINKING_PRESETS.map(preset => (
-                      <button
-                        key={preset.value}
-                        type="button"
-                        className={styles.thinkingOption}
-                        onClick={() => handleThinkingSelect(preset.value)}
-                        data-testid={`thinking-${preset.label}`}
-                      >
-                        {preset.label}
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </div>
+              )}
 
-              <button
-                type="button"
-                className={styles.controlBtn}
-                onClick={sendRewindFiles}
-                title="Rewind files"
-                data-testid="rewind-files"
-              >
-                <RotateCcwIcon className={styles.controlIcon} />
-              </button>
+              {capabilities.set_thinking_tokens && (
+                <div className={styles.thinkingWrapper}>
+                  <button
+                    type="button"
+                    className={styles.controlBtn}
+                    onClick={() => setShowThinkingMenu(prev => !prev)}
+                    title="Set thinking budget"
+                    data-testid="thinking-budget-toggle"
+                  >
+                    <span className={styles.controlLabel}>Thinking</span>
+                  </button>
+                  {showThinkingMenu && (
+                    <div className={styles.thinkingMenu} data-testid="thinking-menu">
+                      {THINKING_PRESETS.map(preset => (
+                        <button
+                          key={preset.value}
+                          type="button"
+                          className={styles.thinkingOption}
+                          onClick={() => handleThinkingSelect(preset.value)}
+                          data-testid={`thinking-${preset.label}`}
+                        >
+                          {preset.label}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {capabilities.rewind_files && (
+                <button
+                  type="button"
+                  className={styles.controlBtn}
+                  onClick={sendRewindFiles}
+                  title="Rewind files"
+                  data-testid="rewind-files"
+                >
+                  <RotateCcwIcon className={styles.controlIcon} />
+                </button>
+              )}
             </div>
           </div>
         )}
@@ -467,6 +475,7 @@ export function SessionChat({
             isLoading={isRunning}
             onStop={handleStop}
             disabled={!connected}
+            stopDisabled={!capabilities.interrupt}
             sessionHost={sessionHost}
             chatEndpoint={chatEndpoint}
             availableCommands={availableCommands}

--- a/web/src/modules/shared/components/SessionChat/SessionChat.tsx
+++ b/web/src/modules/shared/components/SessionChat/SessionChat.tsx
@@ -367,7 +367,7 @@ export function SessionChat({
         )}
       </div>
 
-      {showModelInput && connected && (
+      {showModelInput && connected && capabilities.set_model && (
         <div className={styles.modelInputBar} data-testid="model-input-bar">
           <input
             type="text"

--- a/web/src/modules/shared/components/SessionChat/SessionChat.tsx
+++ b/web/src/modules/shared/components/SessionChat/SessionChat.tsx
@@ -6,7 +6,6 @@ import type {
   PermissionBehavior,
   ContentBlock,
   AttachmentMeta,
-  TransportCapabilities,
 } from '@/modules/shared/hooks/useSkuldChat';
 import { cn } from '@/utils';
 import { UserMessage, AssistantMessage, StreamingMessage, SystemMessage } from './ChatMessages';

--- a/web/src/modules/shared/hooks/useSkuldChat.test.ts
+++ b/web/src/modules/shared/hooks/useSkuldChat.test.ts
@@ -1968,11 +1968,7 @@ describe('useSkuldChat', () => {
     const { result } = renderHook(() => useSkuldChat('wss://test/session'));
 
     act(() => handlers.onOpen?.());
-    act(() =>
-      handlers.onMessage?.(
-        JSON.stringify({ type: 'user_confirmed' })
-      )
-    );
+    act(() => handlers.onMessage?.(JSON.stringify({ type: 'user_confirmed' })));
 
     expect(result.current.messages).toEqual([]);
   });

--- a/web/src/modules/shared/hooks/useSkuldChat.test.ts
+++ b/web/src/modules/shared/hooks/useSkuldChat.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { useSkuldChat } from './useSkuldChat';
+import { useSkuldChat, DEFAULT_CAPABILITIES } from './useSkuldChat';
 
 // Mock the useWebSocket hook
 vi.mock('@/hooks/useWebSocket', () => ({
@@ -1939,5 +1939,102 @@ describe('useSkuldChat', () => {
 
     expect(result.current.messages).toHaveLength(1);
     expect(result.current.messages[0].content).toBe('Hook TestHook: ');
+  });
+
+  // ── Available Commands ───────────────────────────────────────
+
+  it('updates availableCommands when available_commands event is received', () => {
+    const { handlers } = setupMock();
+    const { result } = renderHook(() => useSkuldChat('wss://test/session'));
+
+    act(() => handlers.onOpen?.());
+    act(() =>
+      handlers.onMessage?.(
+        JSON.stringify({
+          type: 'available_commands',
+          slash_commands: ['/help', '/clear'],
+          skills: ['commit'],
+        })
+      )
+    );
+
+    expect(result.current.availableCommands).toHaveLength(3);
+  });
+
+  // ── User Confirmed ─────────────────────────────────────────
+
+  it('silently consumes user_confirmed event without changing messages', () => {
+    const { handlers } = setupMock();
+    const { result } = renderHook(() => useSkuldChat('wss://test/session'));
+
+    act(() => handlers.onOpen?.());
+    act(() =>
+      handlers.onMessage?.(
+        JSON.stringify({ type: 'user_confirmed' })
+      )
+    );
+
+    expect(result.current.messages).toEqual([]);
+  });
+
+  // ── Capabilities ────────────────────────────────────────────
+
+  it('starts with DEFAULT_CAPABILITIES (all false)', () => {
+    setupMock();
+    const { result } = renderHook(() => useSkuldChat('wss://test/session'));
+
+    expect(result.current.capabilities).toEqual(DEFAULT_CAPABILITIES);
+    expect(result.current.capabilities.interrupt).toBe(false);
+    expect(result.current.capabilities.set_model).toBe(false);
+  });
+
+  it('updates capabilities when capabilities event is received', () => {
+    const { handlers } = setupMock();
+    const { result } = renderHook(() => useSkuldChat('wss://test/session'));
+
+    act(() => handlers.onOpen?.());
+    act(() =>
+      handlers.onMessage?.(
+        JSON.stringify({
+          type: 'capabilities',
+          cli_websocket: true,
+          interrupt: true,
+          set_model: true,
+          set_thinking_tokens: true,
+          rewind_files: true,
+          permission_requests: true,
+          slash_commands: true,
+          skills: true,
+        })
+      )
+    );
+
+    expect(result.current.capabilities.cli_websocket).toBe(true);
+    expect(result.current.capabilities.interrupt).toBe(true);
+    expect(result.current.capabilities.set_model).toBe(true);
+    expect(result.current.capabilities.set_thinking_tokens).toBe(true);
+    expect(result.current.capabilities.rewind_files).toBe(true);
+    expect(result.current.capabilities.session_resume).toBe(false);
+    expect(result.current.capabilities.set_permission_mode).toBe(false);
+    expect(result.current.capabilities.mcp_set_servers).toBe(false);
+  });
+
+  it('treats missing capabilities fields as false', () => {
+    const { handlers } = setupMock();
+    const { result } = renderHook(() => useSkuldChat('wss://test/session'));
+
+    act(() => handlers.onOpen?.());
+    act(() =>
+      handlers.onMessage?.(
+        JSON.stringify({
+          type: 'capabilities',
+          interrupt: true,
+        })
+      )
+    );
+
+    expect(result.current.capabilities.interrupt).toBe(true);
+    expect(result.current.capabilities.set_model).toBe(false);
+    expect(result.current.capabilities.cli_websocket).toBe(false);
   });
 });

--- a/web/src/modules/shared/hooks/useSkuldChat.ts
+++ b/web/src/modules/shared/hooks/useSkuldChat.ts
@@ -68,6 +68,34 @@ interface CliStreamEvent {
   input?: Record<string, unknown>;
 }
 
+export interface TransportCapabilities {
+  readonly cli_websocket: boolean;
+  readonly session_resume: boolean;
+  readonly interrupt: boolean;
+  readonly set_model: boolean;
+  readonly set_thinking_tokens: boolean;
+  readonly set_permission_mode: boolean;
+  readonly rewind_files: boolean;
+  readonly mcp_set_servers: boolean;
+  readonly permission_requests: boolean;
+  readonly slash_commands: boolean;
+  readonly skills: boolean;
+}
+
+export const DEFAULT_CAPABILITIES: TransportCapabilities = {
+  cli_websocket: false,
+  session_resume: false,
+  interrupt: false,
+  set_model: false,
+  set_thinking_tokens: false,
+  set_permission_mode: false,
+  rewind_files: false,
+  mcp_set_servers: false,
+  permission_requests: false,
+  slash_commands: false,
+  skills: false,
+};
+
 export type ChatMessageRole = 'user' | 'assistant' | 'system';
 
 export type SkuldChatMessagePart =
@@ -209,6 +237,7 @@ interface UseSkuldChatReturn {
   historyLoaded: boolean;
   pendingPermissions: readonly PermissionRequest[];
   availableCommands: readonly SlashCommand[];
+  capabilities: TransportCapabilities;
   sendMessage: (
     text: string,
     attachments?: ContentBlock[],
@@ -257,6 +286,7 @@ export function useSkuldChat(
   const [isRunning, setIsRunning] = useState(false);
   const [pendingPermissions, setPendingPermissions] = useState<PermissionRequest[]>([]);
   const [availableCommands, setAvailableCommands] = useState<SlashCommand[]>([]);
+  const [capabilities, setCapabilities] = useState<TransportCapabilities>(DEFAULT_CAPABILITIES);
   // Track which URL we've loaded history for. When the URL changes,
   // historyLoadedForUrl will no longer match, triggering a re-fetch.
   const [historyLoadedForUrl, setHistoryLoadedForUrl] = useState<string | null>(null);
@@ -718,6 +748,25 @@ export function useSkuldChat(
           continue;
         }
 
+        // ── capabilities: update transport capabilities ──
+        if (eventType === 'capabilities') {
+          const caps = event as unknown as Record<string, unknown>;
+          setCapabilities({
+            cli_websocket: caps.cli_websocket === true,
+            session_resume: caps.session_resume === true,
+            interrupt: caps.interrupt === true,
+            set_model: caps.set_model === true,
+            set_thinking_tokens: caps.set_thinking_tokens === true,
+            set_permission_mode: caps.set_permission_mode === true,
+            rewind_files: caps.rewind_files === true,
+            mcp_set_servers: caps.mcp_set_servers === true,
+            permission_requests: caps.permission_requests === true,
+            slash_commands: caps.slash_commands === true,
+            skills: caps.skills === true,
+          });
+          continue;
+        }
+
         // ── user_confirmed: broker echo confirming message reached session ──
         if (eventType === 'user_confirmed') {
           // The broker confirmed the message was sent to the CLI.
@@ -954,6 +1003,7 @@ export function useSkuldChat(
   const stableMessages = useMemo(() => messages, [messages]);
   const stablePermissions = useMemo(() => pendingPermissions, [pendingPermissions]);
   const stableCommands = useMemo(() => availableCommands, [availableCommands]);
+  const stableCapabilities = useMemo(() => capabilities, [capabilities]);
 
   return {
     messages: stableMessages,
@@ -962,6 +1012,7 @@ export function useSkuldChat(
     historyLoaded,
     pendingPermissions: stablePermissions,
     availableCommands: stableCommands,
+    capabilities: stableCapabilities,
     sendMessage,
     respondToPermission,
     sendInterrupt,

--- a/web/src/modules/volundr/components/LaunchWizard/steps/ConfigureStep.tsx
+++ b/web/src/modules/volundr/components/LaunchWizard/steps/ConfigureStep.tsx
@@ -37,6 +37,7 @@ import type {
   IntegrationConnection,
   ClusterResourceInfo,
 } from '@/modules/volundr/models';
+import { CLI_TOOL_LABELS } from '@/modules/volundr/models';
 import type { SourceType } from '../LaunchWizard';
 import type { IVolundrService } from '@/modules/volundr/ports';
 import { TrackerIssueSearch } from '@/modules/volundr/components/molecules/TrackerIssueSearch';
@@ -102,8 +103,8 @@ function workspaceLabel(ws: VolundrWorkspace): string {
 }
 
 const CLI_TOOLS: { value: CliTool; label: string; description: string }[] = [
-  { value: 'claude', label: 'Claude Code', description: 'Anthropic Claude CLI agent' },
-  { value: 'codex', label: 'Codex', description: 'OpenAI Codex CLI agent' },
+  { value: 'claude', label: CLI_TOOL_LABELS['claude'] ?? 'claude', description: 'Anthropic Claude CLI agent' },
+  { value: 'codex', label: CLI_TOOL_LABELS['codex'] ?? 'codex', description: 'OpenAI Codex CLI agent' },
 ];
 
 const PROVIDER_LABELS: Record<RepoProvider, string> = {

--- a/web/src/modules/volundr/components/LaunchWizard/steps/ConfigureStep.tsx
+++ b/web/src/modules/volundr/components/LaunchWizard/steps/ConfigureStep.tsx
@@ -103,8 +103,16 @@ function workspaceLabel(ws: VolundrWorkspace): string {
 }
 
 const CLI_TOOLS: { value: CliTool; label: string; description: string }[] = [
-  { value: 'claude', label: CLI_TOOL_LABELS['claude'] ?? 'claude', description: 'Anthropic Claude CLI agent' },
-  { value: 'codex', label: CLI_TOOL_LABELS['codex'] ?? 'codex', description: 'OpenAI Codex CLI agent' },
+  {
+    value: 'claude',
+    label: CLI_TOOL_LABELS['claude'] ?? 'claude',
+    description: 'Anthropic Claude CLI agent',
+  },
+  {
+    value: 'codex',
+    label: CLI_TOOL_LABELS['codex'] ?? 'codex',
+    description: 'OpenAI Codex CLI agent',
+  },
 ];
 
 const PROVIDER_LABELS: Record<RepoProvider, string> = {

--- a/web/src/modules/volundr/components/LaunchWizard/steps/ReviewStep.tsx
+++ b/web/src/modules/volundr/components/LaunchWizard/steps/ReviewStep.tsx
@@ -15,6 +15,7 @@ import {
   HardDrive,
 } from 'lucide-react';
 import type { VolundrModel, VolundrRepo } from '@/modules/volundr/models';
+import { CLI_TOOL_LABELS } from '@/modules/volundr/models';
 import { TrackerIssueBadge } from '@/modules/volundr/components/molecules/TrackerIssueBadge';
 import type { WizardState } from '../LaunchWizard';
 import styles from './ReviewStep.module.css';
@@ -85,7 +86,7 @@ export function ReviewStep({ state, repos, models }: ReviewStepProps) {
           <div className={styles.summaryRow}>
             <span className={styles.summaryLabel}>CLI Tool</span>
             <span className={styles.summaryValue}>
-              {state.template.cliTool === 'claude' ? 'Claude Code' : 'Codex'}
+              {CLI_TOOL_LABELS[state.template.cliTool] ?? state.template.cliTool}
             </span>
           </div>
           {state.trackerIssue && (

--- a/web/src/modules/volundr/models/index.ts
+++ b/web/src/modules/volundr/models/index.ts
@@ -133,7 +133,7 @@ export type {
   CreatePATResult,
 } from './volundr.model';
 
-export { TASK_TYPES } from './volundr.model';
+export { TASK_TYPES, CLI_TOOL_LABELS } from './volundr.model';
 
 export type {
   IntegrationType,

--- a/web/src/modules/volundr/models/volundr.model.ts
+++ b/web/src/modules/volundr/models/volundr.model.ts
@@ -425,7 +425,12 @@ export interface WorkloadConfig {
   [key: string]: string | number | boolean | undefined;
 }
 
-export type CliTool = 'claude' | 'codex';
+export type CliTool = string;
+
+export const CLI_TOOL_LABELS: Record<string, string> = {
+  claude: 'Claude Code',
+  codex: 'Codex',
+};
 
 export interface TerminalSidecarConfig {
   enabled: boolean;


### PR DESCRIPTION
## Summary

- Add `TransportCapabilities` TypeScript interface and `DEFAULT_CAPABILITIES` constant to `useSkuldChat` hook, matching the backend `TransportCapabilities` dataclass
- Handle `capabilities` WebSocket event to update capability state when the transport reports its feature support
- Gate SessionChat toolbar controls on reported capabilities:
  - **Model selector**: hidden when `set_model` is `false`
  - **Thinking budget menu**: hidden when `set_thinking_tokens` is `false`
  - **Rewind button**: hidden when `rewind_files` is `false`
  - **Stop button**: visible but disabled (with tooltip) when `interrupt` is `false`
- Make `CliTool` type extensible (`string` instead of `'claude' | 'codex'` union) and add `CLI_TOOL_LABELS` lookup map
- Update `ReviewStep` and `ConfigureStep` to use the shared labels map instead of hardcoded ternary

## Test plan

- [x] 3038 vitest tests pass (added 7 new tests covering capabilities, available_commands, user_confirmed)
- [x] Coverage thresholds met (branches >= 85%)
- [x] Codex session scenario: stop button visible but disabled, model/thinking/rewind controls hidden
- [x] Claude SDK session scenario: all controls active when capabilities report true
- [x] No inline styles or Tailwind — CSS Modules only per project rules
- [x] Disabled stop button styled via `:disabled` pseudo-class in CSS Module

Closes NIU-422

🤖 Generated with [Claude Code](https://claude.com/claude-code)