### PR TITLE
test(infra): add integration test conftest with real DB and transaction rollback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,10 @@ packages = ["src/cli", "src/niuu", "src/volundr", "src/tyr", "src/skuld"]
 testpaths = ["tests"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
-addopts = "-v --tb=short"
+addopts = "-v --tb=short -m 'not integration'"
+markers = [
+    "integration: tests that require a real PostgreSQL database",
+]
 
 [tool.ruff]
 target-version = "py311"

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Integration test infrastructure — real DB pool, transaction rollback, auth helpers."""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -49,7 +49,7 @@ _MIGRATIONS_DIR = Path(__file__).resolve().parent.parent.parent / "migrations"
 # ---------------------------------------------------------------------------
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest_asyncio.fixture(scope="session", loop_scope="session")
 async def db_pool() -> asyncpg.Pool:
     """Create a real asyncpg pool and apply migrations once per session."""
     pool = await asyncpg.create_pool(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,184 @@
+"""Shared fixtures for integration tests that hit a real PostgreSQL database.
+
+Fixtures
+--------
+db_pool       (session) — real asyncpg pool; migrations applied once.
+txn_pool      (function) — per-test transactional wrapper; rolled back after each test.
+volundr_settings (function) — ``volundr.config.Settings`` pointing at the test DB.
+tyr_settings     (function) — ``tyr.config.Settings`` pointing at the test DB.
+auth_headers     (function) — factory that returns Envoy-style header dicts.
+
+Environment variables
+---------------------
+TEST_DATABASE_HOST      (default: localhost)
+TEST_DATABASE_PORT      (default: 5432)
+TEST_DATABASE_USER      (default: volundr_test)
+TEST_DATABASE_PASSWORD  (default: volundr_test)
+TEST_DATABASE_NAME      (default: volundr_test)
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from tests.helpers.migrations import apply_migrations
+from tests.integration.pool_wrapper import TransactionalPool
+
+# ---------------------------------------------------------------------------
+# Environment helpers
+# ---------------------------------------------------------------------------
+
+_DB_HOST = os.environ.get("TEST_DATABASE_HOST", "localhost")
+_DB_PORT = int(os.environ.get("TEST_DATABASE_PORT", "5432"))
+_DB_USER = os.environ.get("TEST_DATABASE_USER", "volundr_test")
+_DB_PASSWORD = os.environ.get("TEST_DATABASE_PASSWORD", "volundr_test")
+_DB_NAME = os.environ.get("TEST_DATABASE_NAME", "volundr_test")
+
+_MIGRATIONS_DIR = Path(__file__).resolve().parent.parent.parent / "migrations"
+
+# ---------------------------------------------------------------------------
+# Session-scoped real pool (migrations applied once)
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture(scope="session")
+async def db_pool() -> asyncpg.Pool:
+    """Create a real asyncpg pool and apply migrations once per session."""
+    pool = await asyncpg.create_pool(
+        host=_DB_HOST,
+        port=_DB_PORT,
+        user=_DB_USER,
+        password=_DB_PASSWORD,
+        database=_DB_NAME,
+        min_size=1,
+        max_size=5,
+    )
+    assert pool is not None
+
+    await apply_migrations(pool, _MIGRATIONS_DIR)
+
+    yield pool
+
+    await pool.close()
+
+
+# ---------------------------------------------------------------------------
+# Per-test transactional wrapper (rollback after each test)
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def txn_pool(db_pool: asyncpg.Pool) -> TransactionalPool:
+    """Acquire a connection, start a transaction, and wrap it.
+
+    After the test, ROLLBACK ensures zero data leakage between tests.
+    """
+    conn = await db_pool.acquire()
+    txn = conn.transaction()
+    await txn.start()
+
+    wrapper = TransactionalPool(conn)
+
+    yield wrapper
+
+    await txn.rollback()
+    await db_pool.release(conn)
+
+
+# ---------------------------------------------------------------------------
+# Settings fixtures (skip YAML file loading)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def volundr_settings() -> Any:
+    """Return ``volundr.config.Settings`` pointing at the test database.
+
+    Uses AllowAllIdentity and the default (in-memory) PodManager so no
+    external services are required.
+    """
+    from volundr.config import DatabaseConfig, IdentityConfig, PodManagerConfig, Settings
+
+    return Settings(
+        database=DatabaseConfig(
+            host=_DB_HOST,
+            port=_DB_PORT,
+            user=_DB_USER,
+            password=_DB_PASSWORD,
+            name=_DB_NAME,
+        ),
+        identity=IdentityConfig(
+            adapter="volundr.adapters.outbound.identity.AllowAllIdentityAdapter",
+        ),
+        pod_manager=PodManagerConfig(
+            adapter="volundr.adapters.outbound.local_process.LocalProcessManager",
+        ),
+    )
+
+
+@pytest.fixture
+def tyr_settings() -> Any:
+    """Return ``tyr.config.Settings`` pointing at the test database.
+
+    Enables anonymous dev mode so no real IDP is needed.
+    """
+    from tyr.config import AuthConfig, DatabaseConfig, Settings
+
+    return Settings(
+        database=DatabaseConfig(
+            host=_DB_HOST,
+            port=_DB_PORT,
+            user=_DB_USER,
+            password=_DB_PASSWORD,
+            name=_DB_NAME,
+        ),
+        auth=AuthConfig(allow_anonymous_dev=True),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Auth header factory
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def auth_headers() -> _AuthHeaderFactory:
+    """Factory fixture that produces Envoy-style header dicts.
+
+    Usage::
+
+        headers = auth_headers("user-1", "u@example.com", "tenant-a", ["admin"])
+    """
+    return _AuthHeaderFactory()
+
+
+class _AuthHeaderFactory:
+    """Callable that builds Envoy-style authentication header dicts."""
+
+    def __call__(
+        self,
+        user_id: str = "test-user",
+        email: str = "test@example.com",
+        tenant: str = "default",
+        roles: list[str] | None = None,
+    ) -> dict[str, str]:
+        if roles is None:
+            roles = ["volundr:developer"]
+
+        # Envoy base64-encodes array claims (e.g. roles)
+        roles_b64 = base64.b64encode(json.dumps(roles).encode()).decode()
+
+        return {
+            "x-auth-user-id": user_id,
+            "x-auth-email": email,
+            "x-auth-tenant": tenant,
+            "x-auth-roles": roles_b64,
+        }

--- a/tests/integration/pool_wrapper.py
+++ b/tests/integration/pool_wrapper.py
@@ -1,0 +1,54 @@
+"""TransactionalPool — wraps a single asyncpg connection with an open transaction.
+
+Repository adapters use ``pool.acquire()`` internally.  This wrapper makes
+``acquire()`` return the *same* connection (inside a BEGIN), so every
+operation in a test shares one transaction that is rolled back afterward.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    import asyncpg
+
+
+class TransactionalPool:
+    """Drop-in replacement for ``asyncpg.Pool`` scoped to a single transaction.
+
+    * ``acquire()`` yields the wrapped connection (no real pool checkout).
+    * ``execute / fetch / fetchrow / fetchval`` delegate directly.
+    * ``close()`` is a no-op — the real pool is managed by the session fixture.
+    """
+
+    def __init__(self, conn: asyncpg.Connection) -> None:
+        self._conn = conn
+
+    # -- pool.acquire() compat ------------------------------------------------
+
+    @asynccontextmanager
+    async def acquire(self) -> AsyncIterator[asyncpg.Connection]:
+        """Yield the underlying connection without actually checking one out."""
+        yield self._conn
+
+    # -- direct query delegation -----------------------------------------------
+
+    async def execute(self, query: str, *args: Any, timeout: float | None = None) -> str:
+        return await self._conn.execute(query, *args, timeout=timeout)
+
+    async def fetch(self, query: str, *args: Any, timeout: float | None = None) -> list[Any]:
+        return await self._conn.fetch(query, *args, timeout=timeout)
+
+    async def fetchrow(self, query: str, *args: Any, timeout: float | None = None) -> Any:
+        return await self._conn.fetchrow(query, *args, timeout=timeout)
+
+    async def fetchval(self, query: str, *args: Any, timeout: float | None = None) -> Any:
+        return await self._conn.fetchval(query, *args, timeout=timeout)
+
+    # -- lifecycle no-ops ------------------------------------------------------
+
+    async def close(self) -> None:
+        """No-op — the session-scoped pool manages its own lifecycle."""

--- a/tests/test_integration_harness/test_conftest_fixtures.py
+++ b/tests/test_integration_harness/test_conftest_fixtures.py
@@ -1,0 +1,171 @@
+"""Unit tests for integration conftest fixtures and auth_headers factory.
+
+These tests verify the fixture helpers *without* requiring a real database.
+They import the classes/functions directly and test them in isolation.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tests.integration.conftest import _AuthHeaderFactory
+from tests.integration.pool_wrapper import TransactionalPool
+
+
+class TestAuthHeaderFactory:
+    """Verify auth_headers produces correct Envoy-style header dicts."""
+
+    @pytest.fixture
+    def factory(self) -> _AuthHeaderFactory:
+        return _AuthHeaderFactory()
+
+    def test_default_headers(self, factory: _AuthHeaderFactory) -> None:
+        headers = factory()
+        assert headers["x-auth-user-id"] == "test-user"
+        assert headers["x-auth-email"] == "test@example.com"
+        assert headers["x-auth-tenant"] == "default"
+
+        # Roles should be base64-encoded JSON array
+        decoded = json.loads(base64.b64decode(headers["x-auth-roles"]))
+        assert decoded == ["volundr:developer"]
+
+    def test_custom_values(self, factory: _AuthHeaderFactory) -> None:
+        headers = factory(
+            user_id="u-123",
+            email="alice@corp.com",
+            tenant="acme",
+            roles=["volundr:admin", "volundr:developer"],
+        )
+        assert headers["x-auth-user-id"] == "u-123"
+        assert headers["x-auth-email"] == "alice@corp.com"
+        assert headers["x-auth-tenant"] == "acme"
+
+        decoded = json.loads(base64.b64decode(headers["x-auth-roles"]))
+        assert decoded == ["volundr:admin", "volundr:developer"]
+
+    def test_empty_roles_produces_empty_array(self, factory: _AuthHeaderFactory) -> None:
+        headers = factory(roles=[])
+        decoded = json.loads(base64.b64decode(headers["x-auth-roles"]))
+        assert decoded == []
+
+    def test_header_keys_match_envoy_defaults(self, factory: _AuthHeaderFactory) -> None:
+        headers = factory()
+        expected_keys = {"x-auth-user-id", "x-auth-email", "x-auth-tenant", "x-auth-roles"}
+        assert set(headers.keys()) == expected_keys
+
+    def test_roles_are_base64_decodable(self, factory: _AuthHeaderFactory) -> None:
+        headers = factory(roles=["role-a", "role-b", "role-c"])
+        raw = headers["x-auth-roles"]
+        decoded_bytes = base64.b64decode(raw)
+        parsed = json.loads(decoded_bytes)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 3
+
+
+class TestVolundrSettings:
+    """Verify volundr_settings fixture creates valid Settings."""
+
+    def test_settings_use_test_database(self) -> None:
+        from volundr.config import DatabaseConfig, IdentityConfig, PodManagerConfig, Settings
+
+        settings = Settings(
+            database=DatabaseConfig(
+                host="testhost",
+                port=15432,
+                user="testuser",
+                password="testpass",
+                name="testdb",
+            ),
+            identity=IdentityConfig(
+                adapter="volundr.adapters.outbound.identity.AllowAllIdentityAdapter",
+            ),
+            pod_manager=PodManagerConfig(
+                adapter="volundr.adapters.outbound.local_process.LocalProcessManager",
+            ),
+        )
+        assert settings.database.host == "testhost"
+        assert settings.database.port == 15432
+        assert settings.database.name == "testdb"
+        assert "AllowAll" in settings.identity.adapter
+        assert "LocalProcess" in settings.pod_manager.adapter
+
+    def test_settings_skip_yaml_loading(self) -> None:
+        """Constructor args take precedence over YAML — no file needed."""
+        from volundr.config import DatabaseConfig, Settings
+
+        settings = Settings(
+            database=DatabaseConfig(host="explicit-host"),
+        )
+        assert settings.database.host == "explicit-host"
+
+
+class TestTyrSettings:
+    """Verify tyr_settings fixture creates valid Settings."""
+
+    def test_settings_use_test_database(self) -> None:
+        from tyr.config import AuthConfig, DatabaseConfig, Settings
+
+        settings = Settings(
+            database=DatabaseConfig(
+                host="testhost",
+                port=15432,
+                user="testuser",
+                password="testpass",
+                name="testdb",
+            ),
+            auth=AuthConfig(allow_anonymous_dev=True),
+        )
+        assert settings.database.host == "testhost"
+        assert settings.database.port == 15432
+        assert settings.auth.allow_anonymous_dev is True
+
+    def test_anonymous_dev_enabled(self) -> None:
+        from tyr.config import AuthConfig, Settings
+
+        settings = Settings(auth=AuthConfig(allow_anonymous_dev=True))
+        assert settings.auth.allow_anonymous_dev is True
+
+
+class TestTransactionalPoolIsolation:
+    """Verify the rollback pattern works (mocked)."""
+
+    async def test_rollback_discards_writes(self) -> None:
+        """Simulate the txn_pool pattern: BEGIN → write → ROLLBACK → invisible."""
+        conn = AsyncMock()
+        txn = AsyncMock()
+        conn.transaction.return_value = txn
+
+        # Simulate: start txn, wrap, write, rollback
+        await txn.start()
+        pool = TransactionalPool(conn)
+        await pool.execute("INSERT INTO t (id) VALUES ($1)", 1)
+        await txn.rollback()
+
+        # Verify the sequence
+        txn.start.assert_awaited_once()
+        conn.execute.assert_awaited_once_with("INSERT INTO t (id) VALUES ($1)", 1, timeout=None)
+        txn.rollback.assert_awaited_once()
+
+
+class TestEnvironmentDefaults:
+    """Verify env-var defaults used in conftest."""
+
+    def test_defaults_when_no_env_vars(self) -> None:
+        """Import-time defaults should be localhost:5432/volundr_test."""
+        # Re-import to pick up the module-level values
+        from tests.integration import conftest
+
+        assert conftest._DB_HOST == os.environ.get("TEST_DATABASE_HOST", "localhost")
+        assert conftest._DB_PORT == int(os.environ.get("TEST_DATABASE_PORT", "5432"))
+        assert conftest._DB_USER == os.environ.get("TEST_DATABASE_USER", "volundr_test")
+        assert conftest._DB_NAME == os.environ.get("TEST_DATABASE_NAME", "volundr_test")
+
+    def test_migrations_dir_exists(self) -> None:
+        from tests.integration import conftest
+
+        assert conftest._MIGRATIONS_DIR.is_dir()

--- a/tests/test_integration_harness/test_pool_wrapper.py
+++ b/tests/test_integration_harness/test_pool_wrapper.py
@@ -1,0 +1,79 @@
+"""Unit tests for TransactionalPool wrapper."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tests.integration.pool_wrapper import TransactionalPool
+
+
+@pytest.fixture
+def mock_conn() -> AsyncMock:
+    """Return a mock asyncpg connection."""
+    conn = AsyncMock()
+    conn.execute = AsyncMock(return_value="INSERT 0 1")
+    conn.fetch = AsyncMock(return_value=[{"id": 1}])
+    conn.fetchrow = AsyncMock(return_value={"id": 1, "name": "test"})
+    conn.fetchval = AsyncMock(return_value=42)
+    return conn
+
+
+@pytest.fixture
+def pool(mock_conn: AsyncMock) -> TransactionalPool:
+    return TransactionalPool(mock_conn)
+
+
+class TestAcquire:
+    async def test_acquire_yields_underlying_connection(
+        self, pool: TransactionalPool, mock_conn: AsyncMock
+    ) -> None:
+        async with pool.acquire() as conn:
+            assert conn is mock_conn
+
+    async def test_acquire_returns_same_connection_every_time(
+        self, pool: TransactionalPool, mock_conn: AsyncMock
+    ) -> None:
+        async with pool.acquire() as conn1:
+            pass
+        async with pool.acquire() as conn2:
+            pass
+        assert conn1 is conn2 is mock_conn
+
+
+class TestDirectDelegation:
+    async def test_execute_delegates(self, pool: TransactionalPool, mock_conn: AsyncMock) -> None:
+        result = await pool.execute("INSERT INTO t VALUES ($1)", 1)
+        assert result == "INSERT 0 1"
+        mock_conn.execute.assert_awaited_once_with("INSERT INTO t VALUES ($1)", 1, timeout=None)
+
+    async def test_fetch_delegates(self, pool: TransactionalPool, mock_conn: AsyncMock) -> None:
+        result = await pool.fetch("SELECT * FROM t")
+        assert result == [{"id": 1}]
+        mock_conn.fetch.assert_awaited_once_with("SELECT * FROM t", timeout=None)
+
+    async def test_fetchrow_delegates(self, pool: TransactionalPool, mock_conn: AsyncMock) -> None:
+        result = await pool.fetchrow("SELECT * FROM t WHERE id = $1", 1)
+        assert result == {"id": 1, "name": "test"}
+        mock_conn.fetchrow.assert_awaited_once_with(
+            "SELECT * FROM t WHERE id = $1", 1, timeout=None
+        )
+
+    async def test_fetchval_delegates(self, pool: TransactionalPool, mock_conn: AsyncMock) -> None:
+        result = await pool.fetchval("SELECT count(*) FROM t")
+        assert result == 42
+        mock_conn.fetchval.assert_awaited_once_with("SELECT count(*) FROM t", timeout=None)
+
+    async def test_execute_with_timeout(
+        self, pool: TransactionalPool, mock_conn: AsyncMock
+    ) -> None:
+        await pool.execute("SELECT 1", timeout=5.0)
+        mock_conn.execute.assert_awaited_once_with("SELECT 1", timeout=5.0)
+
+
+class TestLifecycle:
+    async def test_close_is_noop(self, pool: TransactionalPool, mock_conn: AsyncMock) -> None:
+        await pool.close()
+        # Should not call anything on the connection
+        mock_conn.close.assert_not_awaited()


### PR DESCRIPTION
## Summary

- Add `TransactionalPool` wrapper (`tests/integration/pool_wrapper.py`) that wraps a single asyncpg connection with an open transaction, making `acquire()` return the same connection so repository adapters work unchanged
- Add shared integration test fixtures (`tests/integration/conftest.py`): `db_pool` (session-scoped, migrations applied once), `txn_pool` (function-scoped, rolled back after each test), `volundr_settings`, `tyr_settings`, and `auth_headers` factory
- Add `integration` pytest marker and exclude from default test runs via `-m 'not integration'` in `addopts`

## Test plan

- [x] `TransactionalPool.acquire()` yields underlying connection
- [x] Direct delegation methods (`execute`, `fetch`, `fetchrow`, `fetchval`) forward correctly
- [x] `close()` is a no-op
- [x] `auth_headers` factory produces correct Envoy-style headers with base64-encoded roles
- [x] Settings fixtures create valid objects with test DB config
- [x] Existing unit tests unaffected by marker exclusion
- [x] 20 unit tests covering the harness pass locally

Closes NIU-442

🤖 Generated with [Claude Code](https://claude.com/claude-code)