### PR TITLE
test(cli): update frontend tests for capabilities and extensible CliTool

### DIFF
--- a/src/skuld/transports/__init__.py
+++ b/src/skuld/transports/__init__.py
@@ -23,8 +23,11 @@ class TransportCapabilities:
     """Declares what a transport supports.
 
     All fields default to False so new transports are safe-by-default.
+    ``send_message`` defaults to True because every transport can receive
+    user messages.
     """
 
+    send_message: bool = True
     cli_websocket: bool = False
     session_resume: bool = False
     interrupt: bool = False

--- a/web/src/modules/shared/components/SessionChat/SessionChat.test.tsx
+++ b/web/src/modules/shared/components/SessionChat/SessionChat.test.tsx
@@ -15,6 +15,7 @@ import type {
 import { SessionChat } from './SessionChat';
 
 const NO_CAPABILITIES: TransportCapabilities = {
+  send_message: true,
   cli_websocket: false,
   session_resume: false,
   interrupt: false,
@@ -29,6 +30,7 @@ const NO_CAPABILITIES: TransportCapabilities = {
 };
 
 const ALL_CAPABILITIES: TransportCapabilities = {
+  send_message: true,
   cli_websocket: true,
   session_resume: true,
   interrupt: true,
@@ -610,5 +612,20 @@ describe('SessionChat', () => {
     expect(screen.queryByTestId('model-switch-toggle')).not.toBeInTheDocument();
     expect(screen.queryByTestId('thinking-budget-toggle')).not.toBeInTheDocument();
     expect(screen.queryByTestId('rewind-files')).not.toBeInTheDocument();
+  });
+
+  it('shows all controls when full capabilities reported', () => {
+    mockSkuldChat({
+      connected: true,
+      isRunning: true,
+      capabilities: ALL_CAPABILITIES,
+    });
+    render(<SessionChat url="wss://test/session" />);
+
+    expect(screen.getByTestId('model-switch-toggle')).toBeInTheDocument();
+    expect(screen.getByTestId('thinking-budget-toggle')).toBeInTheDocument();
+    expect(screen.getByTestId('rewind-files')).toBeInTheDocument();
+    const stopBtn = screen.getByTestId('stop-btn');
+    expect(stopBtn).not.toBeDisabled();
   });
 });

--- a/web/src/modules/shared/hooks/useSkuldChat.test.ts
+++ b/web/src/modules/shared/hooks/useSkuldChat.test.ts
@@ -1975,13 +1975,24 @@ describe('useSkuldChat', () => {
 
   // ── Capabilities ────────────────────────────────────────────
 
-  it('starts with DEFAULT_CAPABILITIES (all false)', () => {
+  it('starts with DEFAULT_CAPABILITIES (all false except send_message)', () => {
     setupMock();
     const { result } = renderHook(() => useSkuldChat('wss://test/session'));
 
     expect(result.current.capabilities).toEqual(DEFAULT_CAPABILITIES);
+    expect(result.current.capabilities.send_message).toBe(true);
     expect(result.current.capabilities.interrupt).toBe(false);
     expect(result.current.capabilities.set_model).toBe(false);
+  });
+
+  it('includes capabilities in hook return value', () => {
+    setupMock();
+    const { result } = renderHook(() => useSkuldChat('wss://test/session'));
+
+    expect(result.current).toHaveProperty('capabilities');
+    expect(result.current.capabilities).toBeDefined();
+    expect(typeof result.current.capabilities.send_message).toBe('boolean');
+    expect(typeof result.current.capabilities.interrupt).toBe('boolean');
   });
 
   it('updates capabilities when capabilities event is received', () => {

--- a/web/src/modules/shared/hooks/useSkuldChat.ts
+++ b/web/src/modules/shared/hooks/useSkuldChat.ts
@@ -69,6 +69,7 @@ interface CliStreamEvent {
 }
 
 export interface TransportCapabilities {
+  readonly send_message: boolean;
   readonly cli_websocket: boolean;
   readonly session_resume: boolean;
   readonly interrupt: boolean;
@@ -83,6 +84,7 @@ export interface TransportCapabilities {
 }
 
 export const DEFAULT_CAPABILITIES: TransportCapabilities = {
+  send_message: true,
   cli_websocket: false,
   session_resume: false,
   interrupt: false,
@@ -752,6 +754,7 @@ export function useSkuldChat(
         if (eventType === 'capabilities') {
           const caps = event as unknown as Record<string, unknown>;
           setCapabilities({
+            send_message: caps.send_message !== false,
             cli_websocket: caps.cli_websocket === true,
             session_resume: caps.session_resume === true,
             interrupt: caps.interrupt === true,

--- a/web/src/modules/volundr/components/LaunchWizard/steps/ConfigureStep.test.tsx
+++ b/web/src/modules/volundr/components/LaunchWizard/steps/ConfigureStep.test.tsx
@@ -698,7 +698,7 @@ describe('ConfigureStep', () => {
       isDefault: false,
       createdAt: '2026-01-01T00:00:00Z',
       updatedAt: '2026-01-01T00:00:00Z',
-      cliTool: 'claude' as const,
+      cliTool: 'claude',
       workloadType: 'coding',
       model: 'claude-opus',
       systemPrompt: 'Be concise.',

--- a/web/src/modules/volundr/components/LaunchWizard/steps/ReviewStep.test.tsx
+++ b/web/src/modules/volundr/components/LaunchWizard/steps/ReviewStep.test.tsx
@@ -129,6 +129,17 @@ describe('ReviewStep', () => {
       expect(screen.getByText('Codex')).toBeInTheDocument();
     });
 
+    it('falls back to raw cliTool string for unknown tool', () => {
+      renderStep({
+        state: buildState({
+          template: { ...baseTemplate, cliTool: 'custom-agent' },
+        }),
+      });
+
+      expect(screen.getByText('CLI Tool')).toBeInTheDocument();
+      expect(screen.getByText('custom-agent')).toBeInTheDocument();
+    });
+
     it('shows tracker issue badge when set', () => {
       renderStep({
         state: buildState({


### PR DESCRIPTION
## Summary
- Add `send_message` capability (default `true`) to `TransportCapabilities` in both backend dataclass and frontend TypeScript interface
- Update `useSkuldChat.test.ts` with tests for `DEFAULT_CAPABILITIES` initialization (all false except `send_message`) and capabilities in hook return value
- Update `SessionChat.test.tsx` with `send_message` in capability fixtures and a test for all controls active with full capabilities
- Update `ReviewStep.test.tsx` with a test for unknown `cliTool` string fallback via map-based `CLI_TOOL_LABELS` lookup
- Update `ConfigureStep.test.tsx` to remove unnecessary `as const` on string-typed `cliTool`

## Test plan
- [x] `useSkuldChat.test.ts`: hook initializes with `DEFAULT_CAPABILITIES` (all false except `send_message`)
- [x] `useSkuldChat.test.ts`: hook updates capabilities state when `capabilities` event arrives
- [x] `useSkuldChat.test.ts`: capabilities are included in return value
- [x] `SessionChat.test.tsx`: stop button disabled when `capabilities.interrupt === false`
- [x] `SessionChat.test.tsx`: model selector hidden when `capabilities.set_model === false`
- [x] `SessionChat.test.tsx`: all controls active when full capabilities reported
- [x] `ReviewStep.test.tsx`: map-based label lookup with fallback for unknown tool
- [x] `ConfigureStep.test.tsx`: string-based `cliTool` fixture (no `as const`)
- [x] All 344 frontend tests pass
- [x] All 564 skuld backend tests pass

Closes NIU-425

🤖 Generated with [Claude Code](https://claude.com/claude-code)