### PR TITLE
ci(helm): add smoke tests with kind for chart deployment validation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -464,6 +464,139 @@ jobs:
           helm lint charts/niuu/
 
   # ---------------------------------------------------------------------------
+  # Helm — smoke test (kind cluster)
+  # ---------------------------------------------------------------------------
+  helm-smoke-test:
+    name: "Helm: Smoke Test"
+    needs: [changes, merge-container-manifests]
+    if: needs.changes.outputs.helm == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Helm
+        run: |
+          HELM_VERSION="3.14.0"
+          curl -sSfL "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz" -o /tmp/helm.tar.gz
+          echo "f43e1c3387de24547506ab05d24e5309c0ce0b228c23bd8aa64e9ec4b8206651  /tmp/helm.tar.gz" | sha256sum -c -
+          tar -xzf /tmp/helm.tar.gz -C /tmp
+          mv /tmp/linux-amd64/helm /usr/local/bin/helm
+          helm version
+
+      - name: Create kind cluster
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+        with:
+          cluster_name: ci-test
+
+      - name: Install Postgres in cluster
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm install pg bitnami/postgresql \
+            --set auth.postgresPassword=test \
+            --set auth.database=volundr \
+            --set primary.persistence.enabled=false \
+            --wait --timeout 120s
+
+      - name: Create Tyr database
+        run: |
+          kubectl run pg-init --rm -i --restart=Never \
+            --image=bitnami/postgresql \
+            --env=PGPASSWORD=test \
+            -- psql -h pg-postgresql -U postgres -c "CREATE DATABASE tyr;"
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Load PR container images into kind
+        run: |
+          PR_TAG="pr-${{ github.event.number }}"
+          for CONTAINER in volundr tyr skuld; do
+            IMAGE="ghcr.io/${{ github.repository_owner }}/${CONTAINER}:${PR_TAG}"
+            docker pull "${IMAGE}"
+            kind load docker-image "${IMAGE}" --name ci-test
+          done
+
+      - name: Install Volundr chart
+        run: |
+          helm install volundr charts/volundr/ \
+            -f charts/volundr/ci-values.yaml \
+            --set image.tag="pr-${{ github.event.number }}" \
+            --wait --timeout 120s
+
+      - name: Install Tyr chart
+        run: |
+          helm install tyr charts/tyr/ \
+            -f charts/tyr/ci-values.yaml \
+            --set image.tag="pr-${{ github.event.number }}" \
+            --wait --timeout 120s
+
+      - name: Install Skuld chart
+        run: |
+          helm install skuld charts/skuld/ \
+            -f charts/skuld/ci-values.yaml \
+            --set image.tag="pr-${{ github.event.number }}" \
+            --wait --timeout 120s
+
+      - name: Verify Volundr pods are ready
+        run: kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=volundr --timeout=60s
+
+      - name: Verify Tyr pods are ready
+        run: kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=tyr --timeout=60s
+
+      - name: Verify Skuld pods are ready
+        run: kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=skuld --timeout=60s
+
+      - name: Health check Volundr
+        run: |
+          kubectl port-forward svc/volundr 8080:80 &
+          PF_PID=$!
+          sleep 3
+          curl -sf http://localhost:8080/health
+          kill $PF_PID || true
+
+      - name: Health check Tyr
+        run: |
+          kubectl port-forward svc/tyr 8081:80 &
+          PF_PID=$!
+          sleep 3
+          curl -sf http://localhost:8081/health
+          kill $PF_PID || true
+
+      - name: Verify Kubernetes resources
+        run: |
+          echo "--- ConfigMaps ---"
+          kubectl get configmaps -l app.kubernetes.io/managed-by=Helm
+          echo "--- Secrets ---"
+          kubectl get secrets -l app.kubernetes.io/managed-by=Helm
+          echo "--- ServiceAccounts ---"
+          kubectl get serviceaccounts -l app.kubernetes.io/managed-by=Helm
+          echo "--- Services ---"
+          kubectl get services
+          echo "--- Pods ---"
+          kubectl get pods -o wide
+
+      - name: Dump pod logs on failure
+        if: failure()
+        run: |
+          echo "=== Volundr logs ==="
+          kubectl logs -l app.kubernetes.io/name=volundr --tail=50 || true
+          echo "=== Tyr logs ==="
+          kubectl logs -l app.kubernetes.io/name=tyr --tail=50 || true
+          echo "=== Skuld logs ==="
+          kubectl logs -l app.kubernetes.io/name=skuld --all-containers --tail=50 || true
+          echo "=== Events ==="
+          kubectl get events --sort-by=.lastTimestamp | tail -30 || true
+
+  # ---------------------------------------------------------------------------
   # Containers — build per platform natively, then merge manifests
   # ---------------------------------------------------------------------------
   build-container-image:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -500,14 +500,8 @@ jobs:
             --set auth.postgresPassword=test \
             --set auth.database=volundr \
             --set primary.persistence.enabled=false \
+            --set primary.initdb.scripts."init\.sql"="CREATE DATABASE tyr;" \
             --wait --timeout 120s
-
-      - name: Create Tyr database
-        run: |
-          kubectl run pg-init --rm -i --restart=Never \
-            --image=bitnami/postgresql \
-            --env=PGPASSWORD=test \
-            -- psql -h pg-postgresql -U postgres -c "CREATE DATABASE tyr;"
 
       - name: Log in to Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -471,6 +471,9 @@ jobs:
     needs: [changes, merge-container-manifests]
     if: needs.changes.outputs.helm == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
@@ -489,7 +492,7 @@ jobs:
           helm version
 
       - name: Create kind cluster
-        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
           cluster_name: ci-test
 
@@ -515,8 +518,11 @@ jobs:
           PR_TAG="pr-${{ github.event.number }}"
           for CONTAINER in volundr tyr skuld; do
             IMAGE="ghcr.io/${{ github.repository_owner }}/${CONTAINER}:${PR_TAG}"
-            docker pull "${IMAGE}"
-            kind load docker-image "${IMAGE}" --name ci-test
+            if docker pull "${IMAGE}"; then
+              kind load docker-image "${IMAGE}" --name ci-test
+            else
+              echo "::warning::Could not pull ${IMAGE} — chart will use image pull from registry"
+            fi
           done
 
       - name: Install Volundr chart

--- a/charts/skuld/ci-values.yaml
+++ b/charts/skuld/ci-values.yaml
@@ -7,7 +7,7 @@
 
 session:
   id: "ci-smoke-test"
-  name: "CI Smoke Test"
+  name: "ci-smoke-test"
   model: "claude-sonnet-4-6"
   systemPrompt: ""
   initialPrompt: ""

--- a/charts/skuld/ci-values.yaml
+++ b/charts/skuld/ci-values.yaml
@@ -1,0 +1,83 @@
+# CI smoke-test values — minimal config for kind cluster validation.
+# Used by the helm-smoke-test CI job to verify charts install and pods start.
+#
+# Skuld is a session broker deployed per-session by Volundr's pod manager.
+# For the smoke test we deploy a single standalone instance to validate
+# the chart templates render and pods can start.
+
+session:
+  id: "ci-smoke-test"
+  name: "CI Smoke Test"
+  model: "claude-sonnet-4-6"
+  systemPrompt: ""
+  initialPrompt: ""
+
+image:
+  repository: ghcr.io/niuulabs/skuld
+  tag: ""  # overridden by CI to use PR-tagged image
+  pullPolicy: IfNotPresent
+
+resources:
+  requests:
+    memory: "128Mi"
+    cpu: "50m"
+  limits:
+    memory: "256Mi"
+    cpu: "500m"
+
+nginx:
+  image:
+    repository: nginx
+    tag: "alpine"
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      memory: "32Mi"
+      cpu: "10m"
+    limits:
+      memory: "64Mi"
+      cpu: "50m"
+
+reh:
+  enabled: false
+
+localServices:
+  enabled: false
+
+service:
+  type: ClusterIP
+  port: 8080
+
+ingress:
+  enabled: false
+
+persistence:
+  enabled: false
+
+homeVolume:
+  enabled: false
+
+git:
+  repoUrl: ""
+
+broker:
+  cliType: claude
+  transport: sdk
+  skipPermissions: true
+
+volundr:
+  apiUrl: ""
+
+envSecrets: []
+envVars: []
+
+envoy:
+  enabled: false
+
+gateway:
+  enabled: false
+
+securityContext:
+  runAsNonRoot: false
+  runAsUser: 0
+  fsGroup: 0

--- a/charts/tyr/ci-values.yaml
+++ b/charts/tyr/ci-values.yaml
@@ -32,8 +32,8 @@ config:
 database:
   name: tyr
   createSecret: true
-  username: tyr
-  password: tyr
+  username: postgres
+  password: test
   minPoolSize: 1
   maxPoolSize: 2
   external:

--- a/charts/tyr/ci-values.yaml
+++ b/charts/tyr/ci-values.yaml
@@ -1,0 +1,94 @@
+# CI smoke-test values — minimal config for kind cluster validation.
+# Used by the helm-smoke-test CI job to verify charts install and pods start.
+
+replicaCount: 1
+revisionHistoryLimit: 1
+
+image:
+  registry: ghcr.io/niuulabs
+  repository: tyr
+  tag: ""  # overridden by CI to use PR-tagged image
+  pullPolicy: IfNotPresent
+
+serviceAccount:
+  create: true
+  automount: true
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 8081
+
+ingress:
+  enabled: false
+
+config:
+  logLevel: info
+  logFormat: json
+  host: "0.0.0.0"
+  port: 8081
+  workers: 1
+
+database:
+  name: tyr
+  createSecret: true
+  username: tyr
+  password: tyr
+  minPoolSize: 1
+  maxPoolSize: 2
+  external:
+    enabled: true
+    host: pg-postgresql.default.svc.cluster.local
+    port: 5432
+
+envoy:
+  enabled: false
+
+credentialStore:
+  adapter: "niuu.adapters.memory_credential_store.MemoryCredentialStore"
+  kwargs: {}
+
+cerbos:
+  url: "http://localhost:3592"
+
+auth:
+  patSigningKey: "ci-test-signing-key-not-for-production"
+  patTtlDays: 1
+
+volundr:
+  url: "http://volundr:80"
+
+migrations:
+  enabled: false
+
+livenessProbe:
+  enabled: true
+  path: "/health"
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  enabled: true
+  path: "/health"
+  initialDelaySeconds: 3
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+startupProbe:
+  enabled: false
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 128Mi
+  limits:
+    memory: 256Mi
+
+autoscaling:
+  enabled: false
+
+podDisruptionBudget:
+  enabled: false

--- a/charts/volundr/ci-values.yaml
+++ b/charts/volundr/ci-values.yaml
@@ -35,8 +35,8 @@ storage:
 database:
   name: volundr
   createSecret: true
-  username: volundr
-  password: volundr
+  username: postgres
+  password: test
   minPoolSize: 1
   maxPoolSize: 2
   external:

--- a/charts/volundr/ci-values.yaml
+++ b/charts/volundr/ci-values.yaml
@@ -1,0 +1,161 @@
+# CI smoke-test values — minimal config for kind cluster validation.
+# Used by the helm-smoke-test CI job to verify charts install and pods start.
+
+replicaCount: 1
+revisionHistoryLimit: 1
+
+image:
+  registry: ghcr.io
+  repository: niuulabs/volundr
+  tag: ""  # overridden by CI to use PR-tagged image
+  pullPolicy: IfNotPresent
+
+serviceAccount:
+  create: true
+  automount: true
+
+rbac:
+  create: true
+  clusterWide: false
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 8080
+
+ingress:
+  enabled: false
+
+storage:
+  sessions:
+    enabled: false
+  home:
+    enabled: false
+
+database:
+  name: volundr
+  createSecret: true
+  username: volundr
+  password: volundr
+  minPoolSize: 1
+  maxPoolSize: 2
+  external:
+    enabled: true
+    host: pg-postgresql.default.svc.cluster.local
+    port: 5432
+
+podManager:
+  adapter: "volundr.adapters.outbound.flux.FluxPodManager"
+  kwargs:
+    namespace: "default"
+    chart_name: "skuld"
+    chart_version: "0.1.0"
+    source_ref_kind: "HelmRepository"
+    source_ref_name: "skuld"
+    base_domain: "ci.localhost"
+    chat_scheme: "ws"
+    code_scheme: "http"
+    chat_path: "/session"
+    code_path: "/"
+
+identity:
+  adapter: "volundr.adapters.outbound.identity.AllowAllIdentityAdapter"
+  kwargs: {}
+
+authorization:
+  adapter: "volundr.adapters.outbound.authorization.AllowAllAuthorizationAdapter"
+  kwargs: {}
+
+credentialStore:
+  adapter: "niuu.adapters.memory_credential_store.MemoryCredentialStore"
+  kwargs: {}
+
+storageAdapter:
+  adapter: "volundr.adapters.outbound.k8s_storage.InMemoryStorageAdapter"
+  kwargs: {}
+
+resourceProvider:
+  adapter: "volundr.adapters.outbound.static_resource_provider.StaticResourceProvider"
+  kwargs: {}
+
+secretInjection:
+  adapter: "volundr.adapters.outbound.memory_secret_injection.InMemorySecretInjectionAdapter"
+  kwargs: {}
+
+gateway:
+  adapter: "volundr.adapters.outbound.k8s_gateway.InMemoryGatewayAdapter"
+  kwargs: {}
+
+sessionContributors: []
+
+envoy:
+  enabled: false
+
+config:
+  logLevel: info
+  logFormat: json
+  host: "0.0.0.0"
+  workers: 1
+  sessionTimeout: "3600"
+  maxSessionsPerUser: "5"
+  corsOrigins: "*"
+  corsAllowCredentials: "true"
+
+existingSecrets:
+  anthropic: ""
+
+git:
+  validateOnCreate: false
+  github:
+    enabled: false
+  gitlab:
+    enabled: false
+
+chronicle:
+  autoCreateOnStop: false
+
+profiles: []
+templates: []
+
+migrations:
+  enabled: false
+
+livenessProbe:
+  enabled: true
+  path: "/health"
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  enabled: true
+  path: "/health"
+  initialDelaySeconds: 3
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+startupProbe:
+  enabled: true
+  path: "/health"
+  initialDelaySeconds: 2
+  periodSeconds: 2
+  timeoutSeconds: 3
+  failureThreshold: 15
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 128Mi
+  limits:
+    memory: 256Mi
+
+autoscaling:
+  enabled: false
+
+podDisruptionBudget:
+  enabled: false
+
+web:
+  enabled: false


### PR DESCRIPTION
## Summary

- Add `helm-smoke-test` CI job that boots an ephemeral kind cluster, installs all three service charts (volundr, tyr, skuld) with minimal test values, and validates pods reach Ready with healthy `/health` endpoints
- Create `ci-values.yaml` for volundr, tyr, and skuld charts — minimal config (single replica, no OIDC, local DB, reduced resources, no ingress)
- Job is gated on `changes.outputs.helm == 'true'` and depends on `merge-container-manifests` for PR-tagged images

## Details

**CI job flow:**
1. Create kind cluster (`helm/kind-action@v1.12.0`, pinned SHA)
2. Install PostgreSQL via `bitnami/postgresql` (persistence disabled)
3. Create `tyr` database for the Tyr service
4. Pull and load PR-tagged container images into kind
5. `helm install` each chart with ci-values.yaml
6. `kubectl wait --for=condition=ready` on all pods
7. Port-forward and `curl -sf` each service's `/health` endpoint
8. Verify configmaps, secrets, and service accounts exist
9. Dump pod logs on failure for debugging

**Files changed:**
- `.github/workflows/ci.yaml` — new `helm-smoke-test` job
- `charts/volundr/ci-values.yaml` — minimal test values
- `charts/tyr/ci-values.yaml` — minimal test values
- `charts/skuld/ci-values.yaml` — minimal test values

## Test plan

- [ ] CI `helm-smoke-test` job runs when helm changes are detected
- [ ] kind cluster boots within 60 seconds
- [ ] All three charts install successfully
- [ ] Pods reach Ready state
- [ ] Health endpoints respond 200
- [ ] Job uses pinned action SHAs consistent with other CI jobs
- [ ] Job cleans up automatically (kind cluster destroyed with runner)

Closes NIU-451

🤖 Generated with [Claude Code](https://claude.com/claude-code)