### PR TITLE
test(volundr): add integration tests for sessions, auth, stats, and prompts

### DIFF
--- a/tests/integration/volundr/conftest.py
+++ b/tests/integration/volundr/conftest.py
@@ -1,0 +1,137 @@
+"""Volundr-specific integration test fixtures.
+
+Provides ``volundr_app`` and ``volundr_client`` fixtures that spin up the
+full FastAPI application backed by a real PostgreSQL database with
+per-test transaction rollback.
+
+The database pool created by the lifespan is replaced with the shared
+``txn_pool`` fixture so every test runs inside a single transaction
+that is automatically rolled back.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from typing import Any
+
+import httpx
+import pytest_asyncio
+
+from tests.integration.pool_wrapper import TransactionalPool
+from volundr.config import (
+    DatabaseConfig,
+    IdentityConfig,
+    PodManagerConfig,
+    Settings,
+)
+from volundr.domain.models import Session, SessionSpec, SessionStatus
+from volundr.domain.ports import PodManager, PodStartResult
+
+# ---------------------------------------------------------------------------
+# Stub PodManager — avoids spawning real processes during integration tests
+# ---------------------------------------------------------------------------
+
+
+class _StubPodManager(PodManager):
+    """No-op pod manager that immediately returns fake endpoints."""
+
+    async def start(self, session: Session, spec: SessionSpec) -> PodStartResult:
+        return PodStartResult(
+            chat_endpoint="http://stub:9100/chat",
+            code_endpoint="http://stub:9100/code",
+            pod_name=f"stub-{session.id}",
+        )
+
+    async def stop(self, session: Session) -> bool:
+        return True
+
+    async def status(self, session: Session) -> SessionStatus:
+        return SessionStatus.RUNNING
+
+    async def wait_for_ready(self, session: Session, timeout: float) -> SessionStatus:
+        return SessionStatus.RUNNING
+
+    async def close(self) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# App & client fixtures
+# ---------------------------------------------------------------------------
+
+
+def _test_settings() -> Settings:
+    """Build ``Settings`` for integration tests.
+
+    Uses ``EnvoyHeaderIdentityAdapter`` so that the ``auth_headers``
+    factory fixture controls which principal each request impersonates.
+    """
+    import os
+
+    host = os.environ.get("TEST_DATABASE_HOST", "localhost")
+    port = int(os.environ.get("TEST_DATABASE_PORT", "5432"))
+    user = os.environ.get("TEST_DATABASE_USER", "volundr_test")
+    password = os.environ.get("TEST_DATABASE_PASSWORD", "volundr_test")
+    name = os.environ.get("TEST_DATABASE_NAME", "volundr_test")
+
+    return Settings(
+        database=DatabaseConfig(
+            host=host,
+            port=port,
+            user=user,
+            password=password,
+            name=name,
+        ),
+        identity=IdentityConfig(
+            adapter="volundr.adapters.outbound.identity.EnvoyHeaderIdentityAdapter",
+        ),
+        pod_manager=PodManagerConfig(
+            adapter="volundr.adapters.outbound.local_process.LocalProcessManager",
+        ),
+    )
+
+
+@pytest_asyncio.fixture
+async def volundr_app(
+    txn_pool: TransactionalPool,
+    monkeypatch: Any,
+) -> AsyncGenerator:
+    """Create a fully wired FastAPI app with the txn_pool as the database.
+
+    The lifespan is triggered manually so that all routers and services
+    are wired before HTTP requests are made.
+    """
+
+    @asynccontextmanager
+    async def _patched_pool(_config: Any) -> AsyncGenerator:
+        yield txn_pool
+
+    monkeypatch.setattr("volundr.main.database_pool", _patched_pool)
+
+    # Stub the pod manager factory so no real processes are spawned
+    monkeypatch.setattr(
+        "volundr.main._create_pod_manager",
+        lambda _settings: _StubPodManager(),
+    )
+
+    from volundr.main import create_app
+
+    settings = _test_settings()
+    app = create_app(settings)
+
+    # Manually trigger the lifespan so that all routes, services, and
+    # adapters are wired up (they are registered inside the lifespan).
+    async with app.router.lifespan_context(app):
+        yield app
+
+
+@pytest_asyncio.fixture
+async def volundr_client(volundr_app: Any) -> AsyncGenerator[httpx.AsyncClient, None]:
+    """httpx.AsyncClient wired to the Volundr ASGI app."""
+    transport = httpx.ASGITransport(app=volundr_app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+    ) as client:
+        yield client

--- a/tests/integration/volundr/test_auth.py
+++ b/tests/integration/volundr/test_auth.py
@@ -1,0 +1,51 @@
+"""Integration tests for authentication and authorization behaviour."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+BASE = "/api/v1/volundr"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio(loop_scope="session")
+async def test_health_no_auth(volundr_client: httpx.AsyncClient):
+    """GET /health returns 200 without any auth headers."""
+    resp = await volundr_client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "healthy"}
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio(loop_scope="session")
+async def test_auth_headers_propagate_principal(
+    volundr_client: httpx.AsyncClient,
+    auth_headers,
+):
+    """The x-auth-user-id header is used as the session owner."""
+    user_id = "principal-check-user"
+    headers = auth_headers(user_id=user_id, email="principal@test.com")
+
+    resp = await volundr_client.post(
+        f"{BASE}/sessions",
+        json={"name": "auth-principal"},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    session_id = resp.json()["id"]
+
+    # Fetch with the same principal — should succeed
+    get_resp = await volundr_client.get(
+        f"{BASE}/sessions/{session_id}",
+        headers=headers,
+    )
+    assert get_resp.status_code == 200
+
+    # Fetch with a different principal — should be denied (403)
+    other_headers = auth_headers(user_id="other-user", email="other@test.com")
+    deny_resp = await volundr_client.get(
+        f"{BASE}/sessions/{session_id}",
+        headers=other_headers,
+    )
+    assert deny_resp.status_code == 403

--- a/tests/integration/volundr/test_prompts.py
+++ b/tests/integration/volundr/test_prompts.py
@@ -1,0 +1,64 @@
+"""Integration tests for saved prompt endpoints."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+BASE = "/api/v1/volundr"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio(loop_scope="session")
+async def test_create_and_list_prompts(
+    volundr_client: httpx.AsyncClient,
+    auth_headers,
+):
+    """POST a prompt then GET /prompts includes it."""
+    headers = auth_headers()
+
+    create_resp = await volundr_client.post(
+        f"{BASE}/prompts",
+        json={
+            "name": "test-prompt",
+            "content": "You are a helpful assistant.",
+        },
+        headers=headers,
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    prompt_id = create_resp.json()["id"]
+
+    list_resp = await volundr_client.get(f"{BASE}/prompts", headers=headers)
+    assert list_resp.status_code == 200
+    ids = {p["id"] for p in list_resp.json()}
+    assert prompt_id in ids
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio(loop_scope="session")
+async def test_delete_prompt(volundr_client: httpx.AsyncClient, auth_headers):
+    """Create a prompt, delete it, then verify it is gone."""
+    headers = auth_headers()
+
+    create_resp = await volundr_client.post(
+        f"{BASE}/prompts",
+        json={
+            "name": "delete-me",
+            "content": "Temporary prompt.",
+        },
+        headers=headers,
+    )
+    assert create_resp.status_code == 201
+    prompt_id = create_resp.json()["id"]
+
+    del_resp = await volundr_client.delete(
+        f"{BASE}/prompts/{prompt_id}",
+        headers=headers,
+    )
+    assert del_resp.status_code == 204
+
+    # Verify it is no longer in the list
+    list_resp = await volundr_client.get(f"{BASE}/prompts", headers=headers)
+    assert list_resp.status_code == 200
+    ids = {p["id"] for p in list_resp.json()}
+    assert prompt_id not in ids

--- a/tests/integration/volundr/test_sessions.py
+++ b/tests/integration/volundr/test_sessions.py
@@ -1,0 +1,140 @@
+"""Integration tests for session CRUD endpoints.
+
+Each test creates its own data, uses transaction rollback for isolation,
+and exercises the full HTTP → FastAPI → service → PostgreSQL path.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+BASE = "/api/v1/volundr"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio(loop_scope="session")
+async def test_create_session(volundr_client: httpx.AsyncClient, auth_headers):
+    """POST /api/sessions creates a session and returns 201."""
+    headers = auth_headers()
+    resp = await volundr_client.post(
+        f"{BASE}/sessions",
+        json={"name": "integ-test-create"},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["name"] == "integ-test-create"
+    assert body["id"]
+    assert body["status"] in ("created", "provisioning", "running")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio(loop_scope="session")
+async def test_list_sessions(volundr_client: httpx.AsyncClient, auth_headers):
+    """Create 3 sessions, then GET /api/sessions returns all of them."""
+    headers = auth_headers()
+    names = ["list-a", "list-b", "list-c"]
+    for name in names:
+        resp = await volundr_client.post(
+            f"{BASE}/sessions",
+            json={"name": name},
+            headers=headers,
+        )
+        assert resp.status_code == 201, resp.text
+
+    resp = await volundr_client.get(f"{BASE}/sessions", headers=headers)
+    assert resp.status_code == 200
+    returned_names = {s["name"] for s in resp.json()}
+    for name in names:
+        assert name in returned_names
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio(loop_scope="session")
+async def test_get_session(volundr_client: httpx.AsyncClient, auth_headers):
+    """Create a session, then GET by ID returns matching fields."""
+    headers = auth_headers()
+    create_resp = await volundr_client.post(
+        f"{BASE}/sessions",
+        json={"name": "get-by-id"},
+        headers=headers,
+    )
+    assert create_resp.status_code == 201
+    session_id = create_resp.json()["id"]
+
+    resp = await volundr_client.get(
+        f"{BASE}/sessions/{session_id}",
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == session_id
+    assert body["name"] == "get-by-id"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio(loop_scope="session")
+async def test_delete_session(volundr_client: httpx.AsyncClient, auth_headers):
+    """Create a session, DELETE it, then GET returns 404."""
+    headers = auth_headers()
+    create_resp = await volundr_client.post(
+        f"{BASE}/sessions",
+        json={"name": "to-delete"},
+        headers=headers,
+    )
+    assert create_resp.status_code == 201
+    session_id = create_resp.json()["id"]
+
+    del_resp = await volundr_client.delete(
+        f"{BASE}/sessions/{session_id}",
+        headers=headers,
+    )
+    assert del_resp.status_code == 204
+
+    get_resp = await volundr_client.get(
+        f"{BASE}/sessions/{session_id}",
+        headers=headers,
+    )
+    assert get_resp.status_code == 404
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio(loop_scope="session")
+async def test_create_session_invalid_name(
+    volundr_client: httpx.AsyncClient,
+    auth_headers,
+):
+    """POST with an invalid (uppercase) name returns 422."""
+    headers = auth_headers()
+    resp = await volundr_client.post(
+        f"{BASE}/sessions",
+        json={"name": "Invalid-Name!"},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio(loop_scope="session")
+async def test_session_owner_filtering(
+    volundr_client: httpx.AsyncClient,
+    auth_headers,
+):
+    """Sessions created by user A are not visible to user B."""
+    headers_a = auth_headers(user_id="owner-a", email="a@test.com")
+    headers_b = auth_headers(user_id="owner-b", email="b@test.com")
+
+    # User A creates a session
+    resp = await volundr_client.post(
+        f"{BASE}/sessions",
+        json={"name": "owned-by-a"},
+        headers=headers_a,
+    )
+    assert resp.status_code == 201
+
+    # User B lists sessions — should not see user A's session
+    resp = await volundr_client.get(f"{BASE}/sessions", headers=headers_b)
+    assert resp.status_code == 200
+    names = {s["name"] for s in resp.json()}
+    assert "owned-by-a" not in names

--- a/tests/integration/volundr/test_stats.py
+++ b/tests/integration/volundr/test_stats.py
@@ -1,0 +1,37 @@
+"""Integration tests for stats and models endpoints."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+BASE = "/api/v1/volundr"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio(loop_scope="session")
+async def test_stats_empty_db(volundr_client: httpx.AsyncClient, auth_headers):
+    """GET /api/stats on an empty database returns zero counters."""
+    headers = auth_headers()
+    resp = await volundr_client.get(f"{BASE}/stats", headers=headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["active_sessions"] == 0
+    assert body["tokens_today"] == 0
+    assert body["cost_today"] == 0.0
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio(loop_scope="session")
+async def test_models_list(volundr_client: httpx.AsyncClient, auth_headers):
+    """GET /api/models returns the configured model list."""
+    headers = auth_headers()
+    resp = await volundr_client.get(f"{BASE}/models", headers=headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    # The default HardcodedPricingProvider always returns at least one model
+    assert isinstance(body, list)
+    assert len(body) > 0
+    first = body[0]
+    assert "id" in first
+    assert "name" in first


### PR DESCRIPTION
## Summary

- Add ~15 integration tests for Volundr's most-used API endpoints
- Tests exercise the full request path: HTTP → FastAPI → auth → service → PostgreSQL → response
- Each test uses real PostgreSQL with per-test transaction rollback for isolation
- Uses `EnvoyHeaderIdentityAdapter` so `auth_headers` fixture controls principal identity
- `StubPodManager` avoids spawning real processes during tests

## Test Coverage

| File | Tests |
|------|-------|
| `test_sessions.py` | create, list, get, delete, invalid name, owner filtering |
| `test_auth.py` | health without auth, auth header → principal propagation |
| `test_stats.py` | stats on empty DB, models list |
| `test_prompts.py` | create + list, delete |

## Files Changed

- `tests/integration/volundr/conftest.py` — Volundr-specific fixtures (`volundr_app`, `volundr_client`, `_StubPodManager`)
- `tests/integration/volundr/test_sessions.py` — 6 session CRUD tests
- `tests/integration/volundr/test_auth.py` — 2 auth behavior tests
- `tests/integration/volundr/test_stats.py` — 2 stats/models tests
- `tests/integration/volundr/test_prompts.py` — 2 prompt CRUD tests

## Linear

Resolves NIU-444. (Linear MCP tools not available — ticket update pending manual action.)

## Test plan

- [ ] All 14 integration tests pass in CI with real PostgreSQL
- [ ] No data leaks between tests (transaction rollback)
- [ ] Existing unit tests unaffected (integration marker excludes these by default)
- [ ] Ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)