### PR TITLE
feat(ports): promote get_blocked_identifiers to TrackerPort

### DIFF
--- a/src/tyr/api/dispatch.py
+++ b/src/tyr/api/dispatch.py
@@ -192,9 +192,7 @@ def _build_prompt(
             "raid_branch": raid_branch,
         }
         used_fields = {
-            fname
-            for _, fname, _, _ in string.Formatter().parse(template)
-            if fname is not None
+            fname for _, fname, _, _ in string.Formatter().parse(template) if fname is not None
         }
         return template.format(**{k: v for k, v in available.items() if k in used_fields})
 
@@ -273,19 +271,16 @@ def create_dispatch_router() -> APIRouter:
 
                     # Build milestone lookup and dependency filter
                     milestone_names = {m.id: m.name for m in milestones}
-                    if hasattr(adapter, "get_blocked_identifiers"):
-                        try:
-                            blocked_identifiers = await adapter.get_blocked_identifiers(
-                                saga.tracker_id,
-                            )
-                        except Exception:
-                            logger.warning(
-                                "Failed to fetch blocked identifiers for saga %s,"
-                                " skipping dependency filter",
-                                saga.id,
-                            )
-                            blocked_identifiers = set()
-                    else:
+                    try:
+                        blocked_identifiers = await adapter.get_blocked_identifiers(
+                            saga.tracker_id,
+                        )
+                    except Exception:
+                        logger.warning(
+                            "Failed to fetch blocked identifiers for saga %s,"
+                            " skipping dependency filter",
+                            saga.id,
+                        )
                         blocked_identifiers = set()
 
                     for issue in issues:
@@ -420,7 +415,9 @@ def create_dispatch_router() -> APIRouter:
                         tracker_issue_url=issue.url,
                         system_prompt=effective_prompt,
                         initial_prompt=_build_prompt(
-                            issue, item.repo, saga.feature_branch,
+                            issue,
+                            item.repo,
+                            saga.feature_branch,
                             template=settings.dispatch.dispatch_prompt_template,
                         ),
                         integration_ids=integration_ids,
@@ -430,7 +427,8 @@ def create_dispatch_router() -> APIRouter:
                 # Record raid progress and set tracker issue to In Progress
                 logger.info(
                     "Dispatch: updating %d tracker adapters for issue %s",
-                    len(adapters), issue.id,
+                    len(adapters),
+                    issue.id,
                 )
                 for adapter in adapters:
                     adapter_name = type(adapter).__name__
@@ -444,18 +442,22 @@ def create_dispatch_router() -> APIRouter:
                     )
                     logger.info(
                         "Dispatch: %s.update_raid_progress OK for %s",
-                        adapter_name, issue.id,
+                        adapter_name,
+                        issue.id,
                     )
                     try:
                         await adapter.update_raid_state(issue.id, RaidStatus.RUNNING)
                         logger.info(
                             "Dispatch: %s.update_raid_state OK for %s → In Progress",
-                            adapter_name, issue.id,
+                            adapter_name,
+                            issue.id,
                         )
                     except Exception:
                         logger.error(
                             "FAILED: %s.update_raid_state for %s",
-                            adapter_name, issue.id, exc_info=True,
+                            adapter_name,
+                            issue.id,
+                            exc_info=True,
                         )
 
                 results.append(

--- a/src/tyr/ports/tracker.py
+++ b/src/tyr/ports/tracker.py
@@ -42,18 +42,14 @@ class TrackerPort(ABC):
         self, raid: Raid, *, project_id: str = "", milestone_id: str = ""
     ) -> str: ...
 
-    async def attach_document(
-        self, project_id: str, title: str, content: str
-    ) -> str:
+    async def attach_document(self, project_id: str, title: str, content: str) -> str:
         """Attach a document to a project. Returns document ID. Optional — noop by default."""
         return ""
 
     async def add_comment(self, issue_id: str, body: str) -> None:
         """Add a comment to an issue. Optional — noop by default."""
 
-    async def attach_issue_document(
-        self, issue_id: str, title: str, content: str
-    ) -> str:
+    async def attach_issue_document(self, issue_id: str, title: str, content: str) -> str:
         """Attach a document to an issue. Returns document ID. Optional — noop by default."""
         return ""
 
@@ -78,6 +74,15 @@ class TrackerPort(ABC):
 
     @abstractmethod
     async def list_pending_raids(self, phase_id: str) -> list[Raid]: ...
+
+    # -- Dependency tracking --
+
+    async def get_blocked_identifiers(self, project_id: str) -> set[str]:
+        """Return identifiers of issues blocked by incomplete dependencies.
+
+        Default returns empty set (no dependency tracking).
+        """
+        return set()
 
     # -- Browsing: read-only access to external tracker hierarchy --
 

--- a/tests/test_tyr/test_ports.py
+++ b/tests/test_tyr/test_ports.py
@@ -49,6 +49,7 @@ class TestTrackerPort:
             "attach_document",
             "add_comment",
             "attach_issue_document",
+            "get_blocked_identifiers",
         }
         abstract_methods = {
             name

--- a/tests/test_tyr/test_tracker_port.py
+++ b/tests/test_tyr/test_tracker_port.py
@@ -93,7 +93,7 @@ class ConcreteTracker(TrackerPort):
             status=SagaStatus.ACTIVE,
             confidence=0.0,
             created_at=now,
-        base_branch="dev",
+            base_branch="dev",
         )
 
     async def get_phase(self, tracker_id: str) -> Phase:
@@ -222,7 +222,7 @@ class TestConcreteTracker:
             status=SagaStatus.ACTIVE,
             confidence=0.0,
             created_at=now,
-        base_branch="dev",
+            base_branch="dev",
         )
         result = await tracker.create_saga(saga)
         assert result == "saga-1"
@@ -241,3 +241,10 @@ class TestConcreteTracker:
         tracker = ConcreteTracker()
         issues = await tracker.list_issues("p-1", milestone_id="m-1")
         assert issues == []
+
+    async def test_get_blocked_identifiers_default(self):
+        """Default implementation returns empty set (no dependency tracking)."""
+        tracker = ConcreteTracker()
+        result = await tracker.get_blocked_identifiers("p-1")
+        assert result == set()
+        assert isinstance(result, set)


### PR DESCRIPTION
## Summary

- Added `get_blocked_identifiers` as a default method on `TrackerPort` that returns an empty set (no dependency tracking by default)
- Removed `hasattr` guard in `dispatch.py` queue endpoint — now calls the method directly on the port interface
- Added test verifying the default implementation returns an empty set

Resolves NIU-468

> **Note**: Linear MCP tools were not available in this session. Ticket status updates (In Progress → In Review) should be applied manually.

## Test plan

- [x] `test_get_blocked_identifiers_default` — verifies default returns empty set
- [x] `test_queue_excludes_blocked` — verifies dispatch queue still filters blocked issues
- [x] All 93 existing tyr tests pass with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)