### PR TITLE
feat(tyr): enrich raid.state_changed events with saga context

### DIFF
--- a/src/tyr/domain/services/review_engine.py
+++ b/src/tyr/domain/services/review_engine.py
@@ -220,9 +220,7 @@ class ReviewEngine:
                     tracker, tracker_id, owner_id, raid, score
                 )
             elif raid.review_round >= self._cfg.max_review_rounds:
-                decision = await self._handle_escalation(
-                    tracker, tracker_id, owner_id, raid, score
-                )
+                decision = await self._handle_escalation(tracker, tracker_id, owner_id, raid, score)
             else:
                 # Low confidence but approved — let the loop continue
                 new_round = raid.review_round + 1
@@ -230,13 +228,17 @@ class ReviewEngine:
                 self._reviewer_sessions[session_id] = (tracker_id, owner_id)
                 logger.info(
                     "Reviewer approved but low confidence (%.2f < %.2f) — round %d/%d, continuing",
-                    result.confidence, self._cfg.auto_approve_threshold,
-                    new_round, self._cfg.max_review_rounds,
+                    result.confidence,
+                    self._cfg.auto_approve_threshold,
+                    new_round,
+                    self._cfg.max_review_rounds,
                 )
                 return
             logger.info(
                 "Post-reviewer decision for %s: %s (reason=%s)",
-                tracker_id, decision.action, decision.reason,
+                tracker_id,
+                decision.action,
+                decision.reason,
             )
             return
 
@@ -249,18 +251,22 @@ class ReviewEngine:
         if new_round >= self._cfg.max_review_rounds:
             # Max rounds exhausted — escalate
             self._reviewer_sessions.pop(session_id, None)
-            decision = await self._handle_escalation(
-                tracker, tracker_id, owner_id, raid, score
-            )
+            decision = await self._handle_escalation(tracker, tracker_id, owner_id, raid, score)
             logger.info(
                 "Max review rounds (%d) reached for %s — %s (reason=%s)",
-                self._cfg.max_review_rounds, tracker_id, decision.action, decision.reason,
+                self._cfg.max_review_rounds,
+                tracker_id,
+                decision.action,
+                decision.reason,
             )
             return
 
         logger.info(
             "Review round %d/%d for %s: %d issues, reviewer driving loop",
-            new_round, self._cfg.max_review_rounds, tracker_id, len(result.findings),
+            new_round,
+            self._cfg.max_review_rounds,
+            tracker_id,
+            len(result.findings),
         )
 
     async def start(self) -> None:
@@ -679,9 +685,7 @@ class ReviewEngine:
             await tracker.close_raid(tracker_id)
             logger.info("Closed tracker issue %s (Done)", tracker_id)
         except Exception:
-            logger.error(
-                "FAILED to close tracker issue %s after merge", tracker_id, exc_info=True
-            )
+            logger.error("FAILED to close tracker issue %s after merge", tracker_id, exc_info=True)
 
         # Attach review transcript as a comment on the Linear issue
         if raid.reviewer_session_id:
@@ -691,7 +695,13 @@ class ReviewEngine:
         # Phase gate check
         phase_gate_unlocked = await self._check_phase_gate(tracker, tracker_id, owner_id)
 
-        await self._emit_state_changed(updated, owner_id=owner_id, action="auto_approved")
+        # Look up saga context for the event payload
+        saga = await tracker.get_saga_for_raid(tracker_id)
+        saga_tid = saga.tracker_id if saga else None
+
+        await self._emit_state_changed(
+            updated, owner_id=owner_id, action="auto_approved", saga_tracker_id=saga_tid
+        )
 
         return ReviewDecision(
             raid=updated,
@@ -728,12 +738,11 @@ class ReviewEngine:
                 lines.append("---")
                 lines.append("")
             title = f"Review Transcript — {raid.name}"
-            await tracker.attach_issue_document(
-                tracker_id, title, "\n".join(lines)
-            )
+            await tracker.attach_issue_document(tracker_id, title, "\n".join(lines))
             logger.info(
                 "Attached review transcript (%d turns) to %s",
-                len(turns), tracker_id,
+                len(turns),
+                tracker_id,
             )
         except Exception:
             logger.warning(
@@ -749,9 +758,7 @@ class ReviewEngine:
             await adapters[0].stop_session(reviewer_session_id)
             logger.info("Stopped reviewer session %s", reviewer_session_id)
         except Exception:
-            logger.warning(
-                "Failed to stop reviewer session %s", reviewer_session_id, exc_info=True
-            )
+            logger.warning("Failed to stop reviewer session %s", reviewer_session_id, exc_info=True)
 
     async def _handle_ci_failure(
         self,
@@ -940,20 +947,30 @@ class ReviewEngine:
 
     # -- Event emission --
 
-    async def _emit_state_changed(self, raid: Raid, *, owner_id: str, action: str) -> None:
+    async def _emit_state_changed(
+        self,
+        raid: Raid,
+        *,
+        owner_id: str,
+        action: str,
+        saga_tracker_id: str | None = None,
+    ) -> None:
         if self._event_bus is None:
             return
+        data: dict[str, object] = {
+            "raid_id": str(raid.id),
+            "status": raid.status.value,
+            "confidence": raid.confidence,
+            "action": action,
+            "tracker_id": raid.tracker_id,
+        }
+        if saga_tracker_id is not None:
+            data["saga_tracker_id"] = saga_tracker_id
         await self._event_bus.emit(
             TyrEvent(
                 event="raid.state_changed",
                 owner_id=owner_id,
-                data={
-                    "raid_id": str(raid.id),
-                    "status": raid.status.value,
-                    "confidence": raid.confidence,
-                    "action": action,
-                    "tracker_id": raid.tracker_id,
-                },
+                data=data,
             )
         )
 

--- a/tests/test_tyr/test_review_engine.py
+++ b/tests/test_tyr/test_review_engine.py
@@ -583,6 +583,52 @@ class TestAutoApprove:
 
         state_event = next(e for e in events if e.event == "raid.state_changed")
         assert state_event.data["action"] == "auto_approved"
+        assert state_event.data["saga_tracker_id"] == "proj-1"
+
+    @pytest.mark.asyncio
+    async def test_auto_approve_event_includes_saga_tracker_id(self) -> None:
+        """raid.state_changed from auto-approve must include saga_tracker_id."""
+        engine, repo, git, bus = _make_engine()
+        raid = _make_raid(confidence=0.5)
+        repo.raids[raid.tracker_id] = raid
+        repo.saga = _make_saga()
+        repo.phase = _make_phase()
+
+        _setup_passing_pr(git, raid.pr_id)
+        git.changed_files[raid.pr_id] = ["src/main.py"]
+
+        q = bus.subscribe()
+        await engine.evaluate(raid.tracker_id, OWNER_ID)
+
+        events = []
+        while not q.empty():
+            events.append(await q.get())
+
+        state_event = next(e for e in events if e.event == "raid.state_changed")
+        assert state_event.data["saga_tracker_id"] == repo.saga.tracker_id
+
+    @pytest.mark.asyncio
+    async def test_auto_approve_event_no_saga(self) -> None:
+        """raid.state_changed omits saga_tracker_id when saga is not found."""
+        engine, repo, git, bus = _make_engine()
+        raid = _make_raid(confidence=0.5)
+        repo.raids[raid.tracker_id] = raid
+        repo.saga = None
+        repo.phase = _make_phase()
+        repo._all_merged = False
+
+        _setup_passing_pr(git, raid.pr_id)
+        git.changed_files[raid.pr_id] = ["src/main.py"]
+
+        q = bus.subscribe()
+        await engine.evaluate(raid.tracker_id, OWNER_ID)
+
+        events = []
+        while not q.empty():
+            events.append(await q.get())
+
+        state_event = next(e for e in events if e.event == "raid.state_changed")
+        assert "saga_tracker_id" not in state_event.data
 
     @pytest.mark.asyncio
     async def test_auto_approve_records_confidence_events(self) -> None:
@@ -912,6 +958,12 @@ class TestPhaseGate:
         assert len(phase_events) == 1
         assert phase_events[0].data["phase_id"] == phase2.tracker_id
         assert phase_events[0].data["owner_id"] == OWNER_ID
+        assert phase_events[0].data["saga_id"] == repo.saga.tracker_id
+
+        # Also verify raid.state_changed includes saga_tracker_id
+        state_events = [e for e in events if e.event == "raid.state_changed"]
+        assert len(state_events) == 1
+        assert state_events[0].data["saga_tracker_id"] == repo.saga.tracker_id
 
     @pytest.mark.asyncio
     async def test_no_phase_gate_when_raids_remain(self) -> None:

--- a/web/src/modules/shared/components/CollapsibleSection/CollapsibleSection.test.tsx
+++ b/web/src/modules/shared/components/CollapsibleSection/CollapsibleSection.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Settings } from 'lucide-react';
+import { CollapsibleSection } from './CollapsibleSection';
+
+const defaultProps = {
+  storageKey: 'test-section',
+  title: 'Test Section',
+  description: 'A test description',
+  icon: Settings,
+  accentColor: 'amber' as const,
+};
+
+describe('CollapsibleSection', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('renders expanded by default with description visible', () => {
+    render(<CollapsibleSection {...defaultProps} />);
+
+    expect(screen.getByText('Test Section')).toBeInTheDocument();
+    expect(screen.getByText('A test description')).toBeInTheDocument();
+  });
+
+  it('renders collapsed when defaultCollapsed is true', () => {
+    render(<CollapsibleSection {...defaultProps} defaultCollapsed />);
+
+    expect(screen.getByText('Test Section')).toBeInTheDocument();
+    expect(screen.queryByText('A test description')).not.toBeInTheDocument();
+  });
+
+  it('toggles collapsed state on header click', () => {
+    render(<CollapsibleSection {...defaultProps} />);
+
+    expect(screen.getByText('A test description')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.queryByText('A test description')).not.toBeInTheDocument();
+  });
+
+  it('renders footer items when provided', () => {
+    render(<CollapsibleSection {...defaultProps} footerItems={['Item A', 'Item B']} />);
+
+    expect(screen.getByText('Item A')).toBeInTheDocument();
+    expect(screen.getByText('Item B')).toBeInTheDocument();
+  });
+
+  it('renders children when expanded', () => {
+    render(
+      <CollapsibleSection {...defaultProps}>
+        <span>Child content</span>
+      </CollapsibleSection>,
+    );
+
+    expect(screen.getByText('Child content')).toBeInTheDocument();
+  });
+
+  it('does not render footer when footerItems is empty', () => {
+    render(<CollapsibleSection {...defaultProps} footerItems={[]} />);
+
+    expect(screen.getByText('A test description')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Look up saga via `tracker.get_saga_for_raid()` in `_handle_auto_approve` and include `saga_tracker_id` in the `raid.state_changed` event payload
- Update `_emit_state_changed` to accept optional `saga_tracker_id` — only included when present (other actions like fail/escalate/retry are unaffected)
- Verify `phase.unlocked` events already include `saga_id` as the tracker ID (confirmed, no changes needed)

## Test plan

- [x] `test_auto_approve_event_includes_saga_tracker_id` — verifies `saga_tracker_id` is present in `raid.state_changed` after auto-approve
- [x] `test_auto_approve_event_no_saga` — verifies `saga_tracker_id` is omitted when no saga found
- [x] `test_auto_approve_emits_events` — updated to assert `saga_tracker_id` in existing event test
- [x] `test_phase_gate_unlocked` — updated to assert `saga_id` in `phase.unlocked` and `saga_tracker_id` in `raid.state_changed`

Closes NIU-470

🤖 Generated with [Claude Code](https://claude.com/claude-code)