### PR TITLE
feat(tyr): clean up working session on terminal raid states

### DIFF
--- a/src/tyr/domain/services/review_engine.py
+++ b/src/tyr/domain/services/review_engine.py
@@ -691,10 +691,10 @@ class ReviewEngine:
         # Attach transcripts and stop sessions
         if raid.session_id:
             await self._attach_working_transcript(tracker, tracker_id, owner_id, raid)
-            await self._stop_working_session(owner_id, raid.session_id)
+            await self._stop_session(owner_id, raid.session_id, "working session")
         if raid.reviewer_session_id:
             await self._attach_review_transcript(tracker, tracker_id, owner_id, raid)
-            await self._stop_reviewer_session(owner_id, raid.reviewer_session_id)
+            await self._stop_session(owner_id, raid.reviewer_session_id, "reviewer session")
 
         # Phase gate check
         phase_gate_unlocked = await self._check_phase_gate(tracker, tracker_id, owner_id)
@@ -726,16 +726,16 @@ class ReviewEngine:
             raid_name=raid.name,
         )
 
-    async def _stop_reviewer_session(self, owner_id: str, reviewer_session_id: str) -> None:
-        """Stop the reviewer session after review is complete."""
+    async def _stop_session(self, owner_id: str, session_id: str, label: str = "session") -> None:
+        """Stop a Volundr session after terminal state."""
         try:
             adapters = await self._volundr_factory.for_owner(owner_id)
             if not adapters:
                 return
-            await adapters[0].stop_session(reviewer_session_id)
-            logger.info("Stopped reviewer session %s", reviewer_session_id)
+            await adapters[0].stop_session(session_id)
+            logger.info("Stopped %s %s", label, session_id)
         except Exception:
-            logger.warning("Failed to stop reviewer session %s", reviewer_session_id, exc_info=True)
+            logger.warning("Failed to stop %s %s", label, session_id, exc_info=True)
 
     async def _attach_working_transcript(
         self,
@@ -754,17 +754,6 @@ class ReviewEngine:
             title_prefix="Working Session Transcript",
             raid_name=raid.name,
         )
-
-    async def _stop_working_session(self, owner_id: str, session_id: str) -> None:
-        """Stop the working session after terminal state is reached."""
-        try:
-            adapters = await self._volundr_factory.for_owner(owner_id)
-            if not adapters:
-                return
-            await adapters[0].stop_session(session_id)
-            logger.info("Stopped working session %s", session_id)
-        except Exception:
-            logger.warning("Failed to stop working session %s", session_id, exc_info=True)
 
     async def _handle_ci_failure(
         self,
@@ -793,7 +782,7 @@ class ReviewEngine:
 
         if raid.session_id:
             await self._attach_working_transcript(tracker, tracker_id, owner_id, raid)
-            await self._stop_working_session(owner_id, raid.session_id)
+            await self._stop_session(owner_id, raid.session_id, "working session")
 
         await self._emit_state_changed(updated, owner_id=owner_id, action="failed")
         return ReviewDecision(
@@ -827,7 +816,7 @@ class ReviewEngine:
 
         if raid.session_id:
             await self._attach_working_transcript(tracker, tracker_id, owner_id, raid)
-            await self._stop_working_session(owner_id, raid.session_id)
+            await self._stop_session(owner_id, raid.session_id, "working session")
 
         await self._emit_state_changed(updated, owner_id=owner_id, action="failed")
         return ReviewDecision(

--- a/src/tyr/domain/services/review_engine.py
+++ b/src/tyr/domain/services/review_engine.py
@@ -688,7 +688,10 @@ class ReviewEngine:
         except Exception:
             logger.error("FAILED to close tracker issue %s after merge", tracker_id, exc_info=True)
 
-        # Attach review transcript as a comment on the Linear issue
+        # Attach transcripts and stop sessions
+        if raid.session_id:
+            await self._attach_working_transcript(tracker, tracker_id, owner_id, raid)
+            await self._stop_working_session(owner_id, raid.session_id)
         if raid.reviewer_session_id:
             await self._attach_review_transcript(tracker, tracker_id, owner_id, raid)
             await self._stop_reviewer_session(owner_id, raid.reviewer_session_id)
@@ -734,6 +737,35 @@ class ReviewEngine:
         except Exception:
             logger.warning("Failed to stop reviewer session %s", reviewer_session_id, exc_info=True)
 
+    async def _attach_working_transcript(
+        self,
+        tracker: TrackerPort,
+        tracker_id: str,
+        owner_id: str,
+        raid: Raid,
+    ) -> None:
+        """Fetch the working session conversation and attach as a document."""
+        await attach_session_transcript(
+            volundr_factory=self._volundr_factory,
+            tracker=tracker,
+            tracker_id=tracker_id,
+            owner_id=owner_id,
+            session_id=raid.session_id,
+            title_prefix="Working Session Transcript",
+            raid_name=raid.name,
+        )
+
+    async def _stop_working_session(self, owner_id: str, session_id: str) -> None:
+        """Stop the working session after terminal state is reached."""
+        try:
+            adapters = await self._volundr_factory.for_owner(owner_id)
+            if not adapters:
+                return
+            await adapters[0].stop_session(session_id)
+            logger.info("Stopped working session %s", session_id)
+        except Exception:
+            logger.warning("Failed to stop working session %s", session_id, exc_info=True)
+
     async def _handle_ci_failure(
         self,
         tracker: TrackerPort,
@@ -758,6 +790,10 @@ class ReviewEngine:
         updated = await tracker.update_raid_progress(
             tracker_id, status=RaidStatus.FAILED, reason="CI failed, retries exhausted"
         )
+
+        if raid.session_id:
+            await self._attach_working_transcript(tracker, tracker_id, owner_id, raid)
+            await self._stop_working_session(owner_id, raid.session_id)
 
         await self._emit_state_changed(updated, owner_id=owner_id, action="failed")
         return ReviewDecision(
@@ -789,6 +825,10 @@ class ReviewEngine:
             tracker_id, status=RaidStatus.FAILED, reason="PR conflicts, retries exhausted"
         )
 
+        if raid.session_id:
+            await self._attach_working_transcript(tracker, tracker_id, owner_id, raid)
+            await self._stop_working_session(owner_id, raid.session_id)
+
         await self._emit_state_changed(updated, owner_id=owner_id, action="failed")
         return ReviewDecision(
             raid=updated,
@@ -807,6 +847,11 @@ class ReviewEngine:
         """Confidence too low or conditions not met — escalate to human review."""
         validate_transition(raid.status, RaidStatus.ESCALATED)
         updated = await tracker.update_raid_progress(tracker_id, status=RaidStatus.ESCALATED)
+
+        # Snapshot the working transcript but keep the session alive for human review
+        if raid.session_id:
+            await self._attach_working_transcript(tracker, tracker_id, owner_id, raid)
+
         await self._emit_state_changed(updated, owner_id=owner_id, action="escalated")
         return ReviewDecision(
             raid=updated,

--- a/tests/test_tyr/test_review_engine.py
+++ b/tests/test_tyr/test_review_engine.py
@@ -93,6 +93,7 @@ class StubTracker(TrackerPort):
         self.phases: list[Phase] = []
         self._all_merged: bool = False
         self.phase_status_updates: list[tuple[str, PhaseStatus]] = []
+        self.attached_documents: list[tuple[str, str, str]] = []
 
     # -- CRUD: create entities --
 
@@ -113,6 +114,10 @@ class StubTracker(TrackerPort):
 
     async def close_raid(self, raid_id: str) -> None:
         pass
+
+    async def attach_issue_document(self, issue_id: str, title: str, content: str) -> str:
+        self.attached_documents.append((issue_id, title, content))
+        return "doc-stub"
 
     # -- Read: fetch domain entities by tracker ID --
 
@@ -1358,7 +1363,7 @@ class TestWorkingSessionCleanup:
 
     @pytest.mark.asyncio
     async def test_merged_attaches_working_transcript(self) -> None:
-        """MERGED should attach the working session transcript."""
+        """MERGED should attach the working session transcript to the tracker."""
         volundr = StubVolundr()
         engine, repo, git, _, _ = _make_engine(volundr=volundr)
         raid = _make_raid(confidence=0.5)
@@ -1371,12 +1376,11 @@ class TestWorkingSessionCleanup:
 
         await engine.evaluate(raid.tracker_id, OWNER_ID)
 
-        # get_conversation is called for the working session transcript
-        assert raid.session_id in volundr.stopped_sessions
+        assert any("Working Session Transcript" in title for _, title, _ in repo.attached_documents)
 
     @pytest.mark.asyncio
     async def test_failed_attaches_working_transcript(self) -> None:
-        """FAILED should attach the working session transcript."""
+        """FAILED should attach the working session transcript to the tracker."""
         volundr = StubVolundr()
         config = _default_config(max_retries=3)
         engine, repo, git, _, _ = _make_engine(config=config, volundr=volundr)
@@ -1387,7 +1391,7 @@ class TestWorkingSessionCleanup:
 
         await engine.evaluate(raid.tracker_id, OWNER_ID)
 
-        assert raid.session_id in volundr.stopped_sessions
+        assert any("Working Session Transcript" in title for _, title, _ in repo.attached_documents)
 
     @pytest.mark.asyncio
     async def test_escalated_attaches_working_transcript(self) -> None:
@@ -1404,5 +1408,6 @@ class TestWorkingSessionCleanup:
         result = await engine.evaluate(raid.tracker_id, OWNER_ID)
 
         assert result.action == "escalated"
+        assert any("Working Session Transcript" in title for _, title, _ in repo.attached_documents)
         # Session should NOT be stopped for escalation
         assert raid.session_id not in volundr.stopped_sessions

--- a/tests/test_tyr/test_review_engine.py
+++ b/tests/test_tyr/test_review_engine.py
@@ -281,6 +281,7 @@ class StubVolundr(VolundrPort):
 
     def __init__(self) -> None:
         self.messages: list[tuple[str, str]] = []
+        self.stopped_sessions: list[str] = []
         self.fail_send: bool = False
 
     async def spawn_session(
@@ -310,7 +311,7 @@ class StubVolundr(VolundrPort):
         self.messages.append((session_id, message))
 
     async def stop_session(self, session_id, *, auth_token=None):
-        pass
+        self.stopped_sessions.append(session_id)
 
     async def list_integration_ids(self, *, auth_token=None) -> list[str]:
         return []
@@ -422,7 +423,7 @@ def _make_engine(
     config: ReviewConfig | None = None,
     event_bus: InMemoryEventBus | None = None,
     volundr: StubVolundr | None = None,
-) -> tuple[ReviewEngine, StubTracker, StubGit, InMemoryEventBus]:
+) -> tuple[ReviewEngine, StubTracker, StubGit, InMemoryEventBus, StubVolundr]:
     r = tracker or StubTracker()
     g = git or StubGit()
     e = event_bus or InMemoryEventBus()
@@ -443,7 +444,7 @@ def _make_engine(
         review_config=c,
         event_bus=e,
     )
-    return engine, r, g, e
+    return engine, r, g, e, v
 
 
 def _setup_passing_pr(git: StubGit, pr_id: str) -> None:
@@ -526,7 +527,7 @@ class TestAutoApprove:
     @pytest.mark.asyncio
     async def test_auto_approve_high_confidence(self) -> None:
         """Raid with high confidence, passing CI, and mergeable PR is auto-approved."""
-        engine, repo, git, bus = _make_engine()
+        engine, repo, git, bus, _ = _make_engine()
         raid = _make_raid(confidence=0.5)
         repo.raids[raid.tracker_id] = raid
         repo.saga = _make_saga()
@@ -544,7 +545,7 @@ class TestAutoApprove:
     @pytest.mark.asyncio
     async def test_auto_approve_does_not_merge_branch(self) -> None:
         """Auto-approve should NOT merge the branch — the reviewer session does it."""
-        engine, repo, git, _ = _make_engine()
+        engine, repo, git, _, _ = _make_engine()
         raid = _make_raid(confidence=0.5)
         repo.raids[raid.tracker_id] = raid
         repo.saga = _make_saga()
@@ -561,7 +562,7 @@ class TestAutoApprove:
     @pytest.mark.asyncio
     async def test_auto_approve_emits_events(self) -> None:
         """Auto-approve should emit raid.state_changed and confidence.updated events."""
-        engine, repo, git, bus = _make_engine()
+        engine, repo, git, bus, _ = _make_engine()
         raid = _make_raid(confidence=0.5)
         repo.raids[raid.tracker_id] = raid
         repo.saga = _make_saga()
@@ -587,7 +588,7 @@ class TestAutoApprove:
     @pytest.mark.asyncio
     async def test_auto_approve_records_confidence_events(self) -> None:
         """Auto-approve should record CI_PASS and AUTO_APPROVED confidence events."""
-        engine, repo, git, _ = _make_engine()
+        engine, repo, git, _, _ = _make_engine()
         raid = _make_raid(confidence=0.5)
         repo.raids[raid.tracker_id] = raid
         repo.saga = _make_saga()
@@ -606,7 +607,7 @@ class TestAutoApprove:
     @pytest.mark.asyncio
     async def test_merge_failure_does_not_block_approval(self) -> None:
         """If branch merge fails, the raid should still transition to MERGED."""
-        engine, repo, git, _ = _make_engine()
+        engine, repo, git, _, _ = _make_engine()
         raid = _make_raid(confidence=0.5)
         repo.raids[raid.tracker_id] = raid
         repo.saga = _make_saga()
@@ -631,7 +632,7 @@ class TestCIFailure:
     @pytest.mark.asyncio
     async def test_ci_failure_auto_retry(self) -> None:
         """CI failure with retries remaining should auto-retry (REVIEW → PENDING)."""
-        engine, repo, git, _ = _make_engine()
+        engine, repo, git, _, _ = _make_engine()
         raid = _make_raid(retry_count=0)
         repo.raids[raid.tracker_id] = raid
 
@@ -647,7 +648,7 @@ class TestCIFailure:
     async def test_ci_failure_retries_exhausted(self) -> None:
         """CI failure with no retries left should transition to FAILED."""
         config = _default_config(max_retries=3)
-        engine, repo, git, _ = _make_engine(config=config)
+        engine, repo, git, _, _ = _make_engine(config=config)
         raid = _make_raid(retry_count=3)
         repo.raids[raid.tracker_id] = raid
 
@@ -661,7 +662,7 @@ class TestCIFailure:
     @pytest.mark.asyncio
     async def test_ci_failure_emits_ci_fail_event(self) -> None:
         """CI failure should record a CI_FAIL confidence event."""
-        engine, repo, git, _ = _make_engine()
+        engine, repo, git, _, _ = _make_engine()
         raid = _make_raid()
         repo.raids[raid.tracker_id] = raid
 
@@ -683,7 +684,7 @@ class TestPRConflicts:
     @pytest.mark.asyncio
     async def test_conflict_auto_retry(self) -> None:
         """PR with conflicts and retries remaining should auto-retry."""
-        engine, repo, git, _ = _make_engine()
+        engine, repo, git, _, _ = _make_engine()
         raid = _make_raid(retry_count=0)
         repo.raids[raid.tracker_id] = raid
 
@@ -698,7 +699,7 @@ class TestPRConflicts:
     async def test_conflict_retries_exhausted(self) -> None:
         """PR with conflicts and no retries left should fail."""
         config = _default_config(max_retries=2)
-        engine, repo, git, _ = _make_engine(config=config)
+        engine, repo, git, _, _ = _make_engine(config=config)
         raid = _make_raid(retry_count=2)
         repo.raids[raid.tracker_id] = raid
 
@@ -712,7 +713,7 @@ class TestPRConflicts:
     @pytest.mark.asyncio
     async def test_conflict_records_pr_conflict_event(self) -> None:
         """PR conflict should record a PR_CONFLICT confidence event."""
-        engine, repo, git, _ = _make_engine()
+        engine, repo, git, _, _ = _make_engine()
         raid = _make_raid()
         repo.raids[raid.tracker_id] = raid
 
@@ -734,7 +735,7 @@ class TestScopeBreach:
     @pytest.mark.asyncio
     async def test_scope_breach_lowers_confidence(self) -> None:
         """Scope breach should apply a negative confidence delta."""
-        engine, repo, git, _ = _make_engine()
+        engine, repo, git, _, _ = _make_engine()
         raid = _make_raid(
             declared_files=["src/main.py"],
         )
@@ -760,7 +761,7 @@ class TestScopeBreach:
     @pytest.mark.asyncio
     async def test_no_scope_breach_within_threshold(self) -> None:
         """No scope breach when undeclared files are within threshold."""
-        engine, repo, git, _ = _make_engine()
+        engine, repo, git, _, _ = _make_engine()
         raid = _make_raid(
             declared_files=["src/main.py", "src/b.py", "src/c.py"],
         )
@@ -789,7 +790,7 @@ class TestEscalation:
     async def test_low_confidence_escalates(self) -> None:
         """Confidence below threshold should escalate to human review."""
         config = _default_config(auto_approve_threshold=0.95)
-        engine, repo, git, _ = _make_engine(config=config)
+        engine, repo, git, _, _ = _make_engine(config=config)
         raid = _make_raid(confidence=0.5)
         repo.raids[raid.tracker_id] = raid
 
@@ -805,7 +806,7 @@ class TestEscalation:
     @pytest.mark.asyncio
     async def test_no_pr_escalates(self) -> None:
         """Raid without a PR ID should escalate to human review."""
-        engine, repo, git, _ = _make_engine()
+        engine, repo, git, _, _ = _make_engine()
         raid = _make_raid(pr_id=None, confidence=0.9)
         repo.raids[raid.tracker_id] = raid
 
@@ -816,7 +817,7 @@ class TestEscalation:
     @pytest.mark.asyncio
     async def test_pr_status_fetch_failure_escalates(self) -> None:
         """If PR status cannot be fetched, escalate to human review."""
-        engine, repo, git, _ = _make_engine()
+        engine, repo, git, _, _ = _make_engine()
         raid = _make_raid(confidence=0.9)
         repo.raids[raid.tracker_id] = raid
         git.fail_pr_status = True
@@ -835,7 +836,7 @@ class TestRetryPenalty:
     @pytest.mark.asyncio
     async def test_retry_count_applies_penalty(self) -> None:
         """Previous retries should apply a cumulative confidence penalty."""
-        engine, repo, git, _ = _make_engine()
+        engine, repo, git, _, _ = _make_engine()
         raid = _make_raid(confidence=0.5, retry_count=2)
         repo.raids[raid.tracker_id] = raid
         repo.saga = _make_saga()
@@ -855,7 +856,7 @@ class TestRetryPenalty:
     @pytest.mark.asyncio
     async def test_zero_retries_no_penalty(self) -> None:
         """First attempt should not apply a retry penalty."""
-        engine, repo, git, _ = _make_engine()
+        engine, repo, git, _, _ = _make_engine()
         raid = _make_raid(confidence=0.5, retry_count=0)
         repo.raids[raid.tracker_id] = raid
         repo.saga = _make_saga()
@@ -880,7 +881,7 @@ class TestPhaseGate:
     @pytest.mark.asyncio
     async def test_phase_gate_unlocked(self) -> None:
         """When all raids in a phase are merged, the next phase is unlocked."""
-        engine, repo, git, bus = _make_engine()
+        engine, repo, git, bus, _ = _make_engine()
         raid = _make_raid(confidence=0.5)
         repo.raids[raid.tracker_id] = raid
         repo.saga = _make_saga()
@@ -916,7 +917,7 @@ class TestPhaseGate:
     @pytest.mark.asyncio
     async def test_no_phase_gate_when_raids_remain(self) -> None:
         """Phase gate should not unlock when not all raids are merged."""
-        engine, repo, git, _ = _make_engine()
+        engine, repo, git, _, _ = _make_engine()
         raid = _make_raid(confidence=0.5)
         repo.raids[raid.tracker_id] = raid
         repo.saga = _make_saga()
@@ -934,7 +935,7 @@ class TestPhaseGate:
     @pytest.mark.asyncio
     async def test_no_next_phase(self) -> None:
         """Phase gate unlocked but no next phase — should return True without error."""
-        engine, repo, git, _ = _make_engine()
+        engine, repo, git, _, _ = _make_engine()
         raid = _make_raid(confidence=0.5)
         repo.raids[raid.tracker_id] = raid
         repo.saga = _make_saga()
@@ -960,14 +961,14 @@ class TestErrorHandling:
     @pytest.mark.asyncio
     async def test_raid_not_found(self) -> None:
         """Evaluating a non-existent raid should raise ValueError."""
-        engine, _, _, _ = _make_engine()
+        engine, _, _, _, _ = _make_engine()
         with pytest.raises(ValueError, match="Raid not found"):
             await engine.evaluate("NIU-NONEXISTENT", OWNER_ID)
 
     @pytest.mark.asyncio
     async def test_wrong_state(self) -> None:
         """Evaluating a raid not in REVIEW should raise ValueError."""
-        engine, repo, _, _ = _make_engine()
+        engine, repo, _, _, _ = _make_engine()
         raid = _make_raid(status=RaidStatus.RUNNING)
         repo.raids[raid.tracker_id] = raid
 
@@ -977,7 +978,7 @@ class TestErrorHandling:
     @pytest.mark.asyncio
     async def test_changed_files_failure_does_not_block(self) -> None:
         """If fetching changed files fails, review should still proceed."""
-        engine, repo, git, _ = _make_engine()
+        engine, repo, git, _, _ = _make_engine()
         raid = _make_raid(confidence=0.5)
         repo.raids[raid.tracker_id] = raid
         repo.saga = _make_saga()
@@ -1029,7 +1030,7 @@ class TestEventDrivenReview:
 
         from tyr.ports.event_bus import TyrEvent
 
-        engine, repo, git, bus = _make_engine()
+        engine, repo, git, bus, _ = _make_engine()
         raid = _make_raid(confidence=0.5)
         repo.raids[raid.tracker_id] = raid
         repo.saga = _make_saga()
@@ -1070,7 +1071,7 @@ class TestEventDrivenReview:
 
         from tyr.ports.event_bus import TyrEvent
 
-        engine, repo, git, bus = _make_engine()
+        engine, repo, git, bus, _ = _make_engine()
         raid = _make_raid(confidence=0.5, status=RaidStatus.RUNNING)
         repo.raids[raid.tracker_id] = raid
 
@@ -1104,7 +1105,7 @@ class TestEventDrivenReview:
 
         from tyr.ports.event_bus import TyrEvent
 
-        engine, repo, git, bus = _make_engine()
+        engine, repo, git, bus, _ = _make_engine()
         # No raid in repo — will cause ValueError("Raid not found")
 
         await engine.start()
@@ -1159,7 +1160,7 @@ class TestMergeableSignal:
     @pytest.mark.asyncio
     async def test_mergeable_records_pr_mergeable_event(self) -> None:
         """Mergeable PR should record PR_MERGEABLE, not CI_PASS."""
-        engine, repo, git, _ = _make_engine()
+        engine, repo, git, _, _ = _make_engine()
         raid = _make_raid(confidence=0.5)
         repo.raids[raid.tracker_id] = raid
         repo.saga = _make_saga()
@@ -1188,7 +1189,7 @@ class TestSessionFeedback:
     async def test_retry_sends_message_to_session(self) -> None:
         """Auto-retry should send failure context to the session."""
         volundr = StubVolundr()
-        engine, repo, git, _ = _make_engine(volundr=volundr)
+        engine, repo, git, _, _ = _make_engine(volundr=volundr)
         raid = _make_raid(retry_count=0)
         repo.raids[raid.tracker_id] = raid
 
@@ -1206,7 +1207,7 @@ class TestSessionFeedback:
     async def test_retry_sends_conflict_message(self) -> None:
         """Auto-retry for PR conflicts should send conflict context."""
         volundr = StubVolundr()
-        engine, repo, git, _ = _make_engine(volundr=volundr)
+        engine, repo, git, _, _ = _make_engine(volundr=volundr)
         raid = _make_raid(retry_count=0)
         repo.raids[raid.tracker_id] = raid
 
@@ -1221,7 +1222,7 @@ class TestSessionFeedback:
     @pytest.mark.asyncio
     async def test_retry_without_volundr_does_not_fail(self) -> None:
         """Auto-retry without VolundrPort should still work."""
-        engine, repo, git, _ = _make_engine()  # no volundr
+        engine, repo, git, _, _ = _make_engine()  # no volundr
         raid = _make_raid(retry_count=0)
         repo.raids[raid.tracker_id] = raid
 
@@ -1236,7 +1237,7 @@ class TestSessionFeedback:
         """If sending the message fails, retry should still proceed."""
         volundr = StubVolundr()
         volundr.fail_send = True
-        engine, repo, git, _ = _make_engine(volundr=volundr)
+        engine, repo, git, _, _ = _make_engine(volundr=volundr)
         raid = _make_raid(retry_count=0)
         repo.raids[raid.tracker_id] = raid
 
@@ -1251,7 +1252,7 @@ class TestSessionFeedback:
     async def test_retry_no_session_id_skips_message(self) -> None:
         """If the raid has no session_id, skip sending the message."""
         volundr = StubVolundr()
-        engine, repo, git, _ = _make_engine(volundr=volundr)
+        engine, repo, git, _, _ = _make_engine(volundr=volundr)
         raid = _make_raid(retry_count=0)
         # Clear session_id
         raid = Raid(
@@ -1282,3 +1283,126 @@ class TestSessionFeedback:
 
         assert result.action == "retried"
         assert len(volundr.messages) == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: Working session cleanup on terminal states (NIU-471)
+# ---------------------------------------------------------------------------
+
+
+class TestWorkingSessionCleanup:
+    """Verify working session transcript attachment and stop on terminal states."""
+
+    @pytest.mark.asyncio
+    async def test_merged_stops_working_session(self) -> None:
+        """MERGED should stop the working session."""
+        volundr = StubVolundr()
+        engine, repo, git, _, _ = _make_engine(volundr=volundr)
+        raid = _make_raid(confidence=0.5)
+        repo.raids[raid.tracker_id] = raid
+        repo.saga = _make_saga()
+        repo.phase = _make_phase()
+
+        _setup_passing_pr(git, raid.pr_id)
+        git.changed_files[raid.pr_id] = ["src/main.py", "tests/test_main.py"]
+
+        await engine.evaluate(raid.tracker_id, OWNER_ID)
+
+        assert raid.session_id in volundr.stopped_sessions
+
+    @pytest.mark.asyncio
+    async def test_ci_failure_exhausted_stops_working_session(self) -> None:
+        """FAILED (CI retries exhausted) should stop the working session."""
+        volundr = StubVolundr()
+        config = _default_config(max_retries=3)
+        engine, repo, git, _, _ = _make_engine(config=config, volundr=volundr)
+        raid = _make_raid(retry_count=3)
+        repo.raids[raid.tracker_id] = raid
+
+        _setup_failing_pr(git, raid.pr_id)
+
+        await engine.evaluate(raid.tracker_id, OWNER_ID)
+
+        assert raid.session_id in volundr.stopped_sessions
+
+    @pytest.mark.asyncio
+    async def test_conflict_exhausted_stops_working_session(self) -> None:
+        """FAILED (conflict retries exhausted) should stop the working session."""
+        volundr = StubVolundr()
+        config = _default_config(max_retries=2)
+        engine, repo, git, _, _ = _make_engine(config=config, volundr=volundr)
+        raid = _make_raid(retry_count=2)
+        repo.raids[raid.tracker_id] = raid
+
+        _setup_conflicted_pr(git, raid.pr_id)
+
+        await engine.evaluate(raid.tracker_id, OWNER_ID)
+
+        assert raid.session_id in volundr.stopped_sessions
+
+    @pytest.mark.asyncio
+    async def test_escalated_does_not_stop_working_session(self) -> None:
+        """ESCALATED should NOT stop the working session."""
+        volundr = StubVolundr()
+        config = _default_config(auto_approve_threshold=0.95)
+        engine, repo, git, _, _ = _make_engine(config=config, volundr=volundr)
+        raid = _make_raid(confidence=0.5)
+        repo.raids[raid.tracker_id] = raid
+
+        _setup_passing_pr(git, raid.pr_id)
+        git.changed_files[raid.pr_id] = ["src/main.py"]
+
+        await engine.evaluate(raid.tracker_id, OWNER_ID)
+
+        assert raid.session_id not in volundr.stopped_sessions
+
+    @pytest.mark.asyncio
+    async def test_merged_attaches_working_transcript(self) -> None:
+        """MERGED should attach the working session transcript."""
+        volundr = StubVolundr()
+        engine, repo, git, _, _ = _make_engine(volundr=volundr)
+        raid = _make_raid(confidence=0.5)
+        repo.raids[raid.tracker_id] = raid
+        repo.saga = _make_saga()
+        repo.phase = _make_phase()
+
+        _setup_passing_pr(git, raid.pr_id)
+        git.changed_files[raid.pr_id] = ["src/main.py", "tests/test_main.py"]
+
+        await engine.evaluate(raid.tracker_id, OWNER_ID)
+
+        # get_conversation is called for the working session transcript
+        assert raid.session_id in volundr.stopped_sessions
+
+    @pytest.mark.asyncio
+    async def test_failed_attaches_working_transcript(self) -> None:
+        """FAILED should attach the working session transcript."""
+        volundr = StubVolundr()
+        config = _default_config(max_retries=3)
+        engine, repo, git, _, _ = _make_engine(config=config, volundr=volundr)
+        raid = _make_raid(retry_count=3)
+        repo.raids[raid.tracker_id] = raid
+
+        _setup_failing_pr(git, raid.pr_id)
+
+        await engine.evaluate(raid.tracker_id, OWNER_ID)
+
+        assert raid.session_id in volundr.stopped_sessions
+
+    @pytest.mark.asyncio
+    async def test_escalated_attaches_working_transcript(self) -> None:
+        """ESCALATED should attach the working session transcript as a snapshot."""
+        volundr = StubVolundr()
+        config = _default_config(auto_approve_threshold=0.95)
+        engine, repo, git, _, _ = _make_engine(config=config, volundr=volundr)
+        raid = _make_raid(confidence=0.5)
+        repo.raids[raid.tracker_id] = raid
+
+        _setup_passing_pr(git, raid.pr_id)
+        git.changed_files[raid.pr_id] = ["src/main.py"]
+
+        result = await engine.evaluate(raid.tracker_id, OWNER_ID)
+
+        assert result.action == "escalated"
+        # Session should NOT be stopped for escalation
+        assert raid.session_id not in volundr.stopped_sessions


### PR DESCRIPTION
## Summary

- Attach working session transcript and stop the session when a raid reaches **MERGED** or **FAILED** (retries exhausted)
- On **ESCALATED**, attach the transcript as a snapshot but keep the session alive for human review
- Added `_attach_working_transcript` and `_stop_working_session` helper methods to `ReviewEngine`

## Changes

### `_handle_auto_approve` (MERGED)
- Attach working session transcript via `attach_session_transcript()` with title prefix "Working Session Transcript"
- Stop working session via `stop_session(raid.session_id)`
- Existing reviewer session cleanup unchanged

### `_handle_ci_failure` / `_handle_conflict` (FAILED, retries exhausted)
- Same pattern: attach transcript, then stop working session

### `_handle_escalation` (ESCALATED)
- Attach transcript as a snapshot but do NOT stop the session

### Tests (7 new)
- Working session is stopped on MERGED
- Working session is stopped on FAILED (CI retries exhausted)
- Working session is stopped on FAILED (conflict retries exhausted)
- Working session is NOT stopped on ESCALATED
- Transcript is attached on MERGED, FAILED, and ESCALATED

Closes NIU-471

## Test plan

- [x] All 52 review engine tests pass
- [x] Full test suite passes (4574 passed, 4 pre-existing failures unrelated to this PR)
- [x] Ruff lint and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)