### PR TITLE
fix(tyr): correct _make_engine unpacking in no-saga test

### DIFF
--- a/tests/test_tyr/test_review_engine.py
+++ b/tests/test_tyr/test_review_engine.py
@@ -594,7 +594,7 @@ class TestAutoApprove:
     @pytest.mark.asyncio
     async def test_auto_approve_event_no_saga(self) -> None:
         """raid.state_changed omits saga_tracker_id when saga is not found."""
-        engine, repo, git, bus = _make_engine()
+        engine, repo, git, bus, _ = _make_engine()
         raid = _make_raid(confidence=0.5)
         repo.raids[raid.tracker_id] = raid
         repo.saga = None


### PR DESCRIPTION
## Summary

- Fix `ValueError: too many values to unpack` in `test_auto_approve_event_no_saga` introduced by NIU-470
- `_make_engine()` returns 5 values but the test only unpacked 4

One-line fix: `engine, repo, git, bus = _make_engine()` → `engine, repo, git, bus, _ = _make_engine()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)