### PR TITLE
feat(tyr): auto-continue logic in DispatchService

### DIFF
--- a/src/tyr/domain/services/dispatch_service.py
+++ b/src/tyr/domain/services/dispatch_service.py
@@ -6,8 +6,10 @@ auto-continue and future consumers without an HTTP request context.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import string
+from collections import defaultdict
 from dataclasses import dataclass
 
 from tyr.domain.models import RaidStatus, Saga, TrackerIssue
@@ -181,6 +183,7 @@ class DispatchService:
         self._saga_repo = saga_repo
         self._dispatcher_repo = dispatcher_repo
         self._config = config
+        self._locks: defaultdict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
 
     async def find_ready_issues(
         self,
@@ -324,6 +327,52 @@ class DispatchService:
             results.append(result)
 
         return results
+
+    async def try_auto_continue(
+        self,
+        owner_id: str,
+        saga_tracker_id: str,
+    ) -> list[DispatchResult]:
+        """Dispatch newly unblocked issues if auto_continue is enabled.
+
+        Called after a raid merges or a phase gate is unlocked. Uses a
+        per-owner lock to prevent double-dispatch from concurrent merge
+        events.
+        """
+        async with self._locks[owner_id]:
+            state = await self._dispatcher_repo.get_or_create(owner_id)
+            if not state.running or not state.auto_continue:
+                return []
+
+            adapters = await self._tracker_factory.for_owner(owner_id)
+            if not adapters:
+                return []
+
+            running_raids = await adapters[0].list_raids_by_status(RaidStatus.RUNNING)
+            available_slots = state.max_concurrent_raids - len(running_raids)
+            if available_slots <= 0:
+                return []
+
+            ready = await self.find_ready_issues(owner_id, saga_tracker_id=saga_tracker_id)
+            if not ready:
+                return []
+
+            items = [
+                DispatchItem(
+                    saga_id=q.saga_id,
+                    issue_id=q.issue_id,
+                    repo=q.repos[0] if q.repos else "",
+                )
+                for q in ready[:available_slots]
+            ]
+            results = await self.dispatch_issues(owner_id, items)
+            logger.info(
+                "Auto-continue dispatched %d issue(s) for owner %s (saga=%s)",
+                len(results),
+                owner_id[:8],
+                saga_tracker_id,
+            )
+            return results
 
     # -------------------------------------------------------------------
     # Private helpers

--- a/src/tyr/domain/services/review_engine.py
+++ b/src/tyr/domain/services/review_engine.py
@@ -38,6 +38,7 @@ from tyr.domain.models import (
     Saga,
     validate_transition,
 )
+from tyr.domain.services.dispatch_service import DispatchService
 from tyr.domain.services.reviewer_session import (
     ReviewerSessionService,
     parse_reviewer_response,
@@ -132,6 +133,7 @@ class ReviewEngine:
         reviewer_service: ReviewerSessionService | None = None,
         integration_repo: IntegrationRepository | None = None,
         dispatcher_repo: DispatcherRepository | None = None,
+        dispatch_service: DispatchService | None = None,
     ) -> None:
         self._tracker_factory = tracker_factory
         self._volundr_factory = volundr_factory
@@ -141,6 +143,7 @@ class ReviewEngine:
         self._reviewer = reviewer_service
         self._integration_repo = integration_repo
         self._dispatcher_repo = dispatcher_repo
+        self._dispatch_service = dispatch_service
         self._task: asyncio.Task[None] | None = None
         self._processed: set[str] = set()
         # Maps reviewer_session_id → (raid_tracker_id, owner_id)
@@ -708,6 +711,10 @@ class ReviewEngine:
             updated, owner_id=owner_id, action="auto_approved", saga_tracker_id=saga_tid
         )
 
+        # Trigger auto-continue after merge (and after phase unlock)
+        if saga_tid:
+            await self._try_auto_continue(owner_id, saga_tid)
+
         return ReviewDecision(
             raid=updated,
             action="auto_approved",
@@ -966,7 +973,26 @@ class ReviewEngine:
                     )
                 )
 
+            # Phase unlock may unblock new issues — trigger auto-continue
+            await self._try_auto_continue(owner_id, saga.tracker_id)
+
         return True
+
+    # -- Auto-continue --
+
+    async def _try_auto_continue(self, owner_id: str, saga_tracker_id: str) -> None:
+        """Delegate auto-continue to DispatchService if available."""
+        if self._dispatch_service is None:
+            return
+        try:
+            await self._dispatch_service.try_auto_continue(owner_id, saga_tracker_id)
+        except Exception:
+            logger.warning(
+                "Auto-continue failed for owner %s (saga=%s)",
+                owner_id[:8],
+                saga_tracker_id,
+                exc_info=True,
+            )
 
     # -- Event emission --
 

--- a/src/tyr/main.py
+++ b/src/tyr/main.py
@@ -437,6 +437,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 event_bus=event_bus,
                 reviewer_service=reviewer_service,
                 dispatcher_repo=dispatcher_repo,
+                dispatch_service=dispatch_svc,
             )
             app.state.review_engine = review_engine
             await review_engine.start()

--- a/tests/test_tyr/test_services/test_auto_continue.py
+++ b/tests/test_tyr/test_services/test_auto_continue.py
@@ -1,0 +1,568 @@
+"""Tests for auto-continue logic in DispatchService and ReviewEngine.
+
+Verifies that newly unblocked issues are dispatched after a raid merges
+or a phase gate is unlocked, respecting the auto_continue toggle and
+max_concurrent_raids limit.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from tyr.domain.models import (
+    DispatcherState,
+    PhaseStatus,
+    PRStatus,
+    Raid,
+    RaidStatus,
+    Saga,
+    SagaStatus,
+    TrackerIssue,
+    TrackerMilestone,
+    TrackerProject,
+)
+from tyr.domain.services.dispatch_service import (
+    DispatchConfig,
+    DispatchService,
+)
+
+from ..test_dispatch_api import (
+    MockDispatcherRepo,
+    MockTrackerFactory,
+    MockVolundr,
+    MockVolundrFactory,
+)
+from ..test_tracker_api import MockSagaRepo, MockTracker
+
+NOW = datetime.now(UTC)
+OWNER = "owner-1"
+SAGA_TRACKER_ID = "proj-1"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class ConfigurableDispatcherRepo(MockDispatcherRepo):
+    """DispatcherRepo whose get_or_create returns configurable state."""
+
+    def __init__(
+        self,
+        *,
+        running: bool = True,
+        auto_continue: bool = True,
+        max_concurrent_raids: int = 3,
+    ) -> None:
+        self._running = running
+        self._auto_continue = auto_continue
+        self._max_concurrent = max_concurrent_raids
+
+    async def get_or_create(self, owner_id: str) -> DispatcherState:
+        return DispatcherState(
+            id=uuid4(),
+            owner_id=owner_id,
+            running=self._running,
+            threshold=0.5,
+            max_concurrent_raids=self._max_concurrent,
+            auto_continue=self._auto_continue,
+            updated_at=NOW,
+        )
+
+
+class RaidAwareTracker(MockTracker):
+    """MockTracker that supports list_raids_by_status with configurable raids."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._raids: list[Raid] = []
+
+    async def list_raids_by_status(self, status: RaidStatus) -> list[Raid]:
+        return [r for r in self._raids if r.status == status]
+
+
+def _make_saga() -> Saga:
+    return Saga(
+        id=uuid4(),
+        tracker_id=SAGA_TRACKER_ID,
+        tracker_type="linear",
+        slug="alpha",
+        name="Alpha",
+        repos=["org/repo-a"],
+        feature_branch="feat/alpha",
+        status=SagaStatus.ACTIVE,
+        confidence=0.0,
+        created_at=NOW,
+        base_branch="dev",
+    )
+
+
+def _make_raid(status: RaidStatus = RaidStatus.RUNNING) -> Raid:
+    return Raid(
+        id=uuid4(),
+        phase_id=uuid4(),
+        tracker_id=f"raid-{uuid4().hex[:6]}",
+        name="Test Raid",
+        description="",
+        acceptance_criteria=[],
+        declared_files=[],
+        estimate_hours=1.0,
+        status=status,
+        confidence=0.5,
+        session_id="ses-1",
+        branch="raid/test",
+        chronicle_summary=None,
+        pr_url=None,
+        pr_id=None,
+        retry_count=0,
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+
+def _make_tracker_with_issues() -> RaidAwareTracker:
+    tracker = RaidAwareTracker()
+    tracker.projects = [
+        TrackerProject(
+            id="proj-1",
+            name="Alpha",
+            description="",
+            status="started",
+            url="",
+            milestone_count=1,
+            issue_count=2,
+        ),
+    ]
+    tracker.milestones = {
+        "proj-1": [
+            TrackerMilestone(
+                id="ms-1",
+                project_id="proj-1",
+                name="Phase 1",
+                description="",
+                sort_order=1,
+                progress=0.0,
+            ),
+        ],
+    }
+    tracker.issues = {
+        "proj-1": [
+            TrackerIssue(
+                id="i-1",
+                identifier="ALPHA-1",
+                title="Task A",
+                description="Do A",
+                status="Todo",
+                priority=1,
+                priority_label="Urgent",
+                url="",
+                milestone_id="ms-1",
+            ),
+            TrackerIssue(
+                id="i-2",
+                identifier="ALPHA-2",
+                title="Task B",
+                description="Do B",
+                status="Todo",
+                priority=2,
+                priority_label="High",
+                url="",
+                milestone_id="ms-1",
+            ),
+        ],
+    }
+    return tracker
+
+
+def _build_service(
+    tracker: MockTracker | None = None,
+    volundr: MockVolundr | None = None,
+    dispatcher_repo: MockDispatcherRepo | None = None,
+    saga_repo: MockSagaRepo | None = None,
+) -> tuple[DispatchService, MockVolundr, RaidAwareTracker]:
+    t = tracker or _make_tracker_with_issues()
+    v = volundr or MockVolundr()
+    repo = saga_repo or MockSagaRepo()
+    if not repo.sagas:
+        repo.sagas.append(_make_saga())
+    d_repo = dispatcher_repo or ConfigurableDispatcherRepo()
+
+    svc = DispatchService(
+        tracker_factory=MockTrackerFactory([t]),
+        volundr_factory=MockVolundrFactory(adapters=[v]),
+        saga_repo=repo,
+        dispatcher_repo=d_repo,
+        config=DispatchConfig(default_system_prompt="Be helpful."),
+    )
+    return svc, v, t
+
+
+# ---------------------------------------------------------------------------
+# Tests: try_auto_continue on DispatchService
+# ---------------------------------------------------------------------------
+
+
+class TestTryAutoContinue:
+    @pytest.mark.asyncio
+    async def test_dispatches_when_enabled(self):
+        """auto_continue=True and running=True should dispatch ready issues."""
+        svc, volundr, _ = _build_service()
+        results = await svc.try_auto_continue(OWNER, SAGA_TRACKER_ID)
+        assert len(results) > 0
+        assert all(r.status == "spawned" for r in results)
+        assert len(volundr.spawned) > 0
+
+    @pytest.mark.asyncio
+    async def test_noop_when_auto_continue_disabled(self):
+        """auto_continue=False should return empty list without dispatching."""
+        repo = ConfigurableDispatcherRepo(auto_continue=False)
+        svc, volundr, _ = _build_service(dispatcher_repo=repo)
+        results = await svc.try_auto_continue(OWNER, SAGA_TRACKER_ID)
+        assert results == []
+        assert len(volundr.spawned) == 0
+
+    @pytest.mark.asyncio
+    async def test_noop_when_not_running(self):
+        """running=False should return empty list."""
+        repo = ConfigurableDispatcherRepo(running=False)
+        svc, volundr, _ = _build_service(dispatcher_repo=repo)
+        results = await svc.try_auto_continue(OWNER, SAGA_TRACKER_ID)
+        assert results == []
+        assert len(volundr.spawned) == 0
+
+    @pytest.mark.asyncio
+    async def test_respects_max_concurrent_raids(self):
+        """Should not dispatch more issues than available slots."""
+        tracker = _make_tracker_with_issues()
+        # 2 already running, max=3 → only 1 slot available
+        tracker._raids = [_make_raid(RaidStatus.RUNNING), _make_raid(RaidStatus.RUNNING)]
+        repo = ConfigurableDispatcherRepo(max_concurrent_raids=3)
+
+        svc, volundr, _ = _build_service(tracker=tracker, dispatcher_repo=repo)
+        results = await svc.try_auto_continue(OWNER, SAGA_TRACKER_ID)
+        assert len(results) == 1
+        assert len(volundr.spawned) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_slots_returns_empty(self):
+        """When max_concurrent_raids already reached, return empty."""
+        tracker = _make_tracker_with_issues()
+        tracker._raids = [
+            _make_raid(RaidStatus.RUNNING),
+            _make_raid(RaidStatus.RUNNING),
+            _make_raid(RaidStatus.RUNNING),
+        ]
+        repo = ConfigurableDispatcherRepo(max_concurrent_raids=3)
+
+        svc, volundr, _ = _build_service(tracker=tracker, dispatcher_repo=repo)
+        results = await svc.try_auto_continue(OWNER, SAGA_TRACKER_ID)
+        assert results == []
+        assert len(volundr.spawned) == 0
+
+    @pytest.mark.asyncio
+    async def test_no_ready_issues_returns_empty(self):
+        """When no issues are ready, return empty."""
+        tracker = RaidAwareTracker()
+        tracker.projects = [
+            TrackerProject(
+                id="proj-1",
+                name="Alpha",
+                description="",
+                status="started",
+                url="",
+                milestone_count=0,
+                issue_count=0,
+            ),
+        ]
+        tracker.milestones = {"proj-1": []}
+        tracker.issues = {"proj-1": []}
+
+        svc, volundr, _ = _build_service(tracker=tracker)
+        results = await svc.try_auto_continue(OWNER, SAGA_TRACKER_ID)
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_per_owner_lock_prevents_concurrent_dispatch(self):
+        """Concurrent calls for the same owner should serialize via lock."""
+        svc, volundr, _ = _build_service()
+
+        call_count = 0
+        original_find = svc.find_ready_issues
+
+        async def counting_find(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            # Small delay to increase overlap window
+            await asyncio.sleep(0.01)
+            return await original_find(*args, **kwargs)
+
+        svc.find_ready_issues = counting_find  # type: ignore[assignment]
+
+        # Launch two concurrent auto-continue calls
+        await asyncio.gather(
+            svc.try_auto_continue(OWNER, SAGA_TRACKER_ID),
+            svc.try_auto_continue(OWNER, SAGA_TRACKER_ID),
+        )
+        # Both calls should complete (serialized), not crash
+        assert call_count == 2
+        # The lock key should exist for the owner
+        assert OWNER in svc._locks
+
+
+# ---------------------------------------------------------------------------
+# Tests: ReviewEngine integration with auto-continue
+# ---------------------------------------------------------------------------
+
+
+class TestReviewEngineAutoContinue:
+    """Verify ReviewEngine calls try_auto_continue after merge and phase unlock."""
+
+    @pytest.mark.asyncio
+    async def test_auto_approve_triggers_auto_continue(self):
+        """After _handle_auto_approve, try_auto_continue should be called."""
+        from tyr.adapters.memory_event_bus import InMemoryEventBus
+        from tyr.config import ReviewConfig
+        from tyr.domain.services.review_engine import ReviewEngine
+
+        from ..test_review_engine import (
+            StubGit,
+            StubTracker,
+            StubTrackerFactory,
+            StubVolundr,
+            _make_raid,
+            _make_saga,
+        )
+
+        tracker = StubTracker()
+        git = StubGit()
+        bus = InMemoryEventBus()
+        volundr = StubVolundr()
+        saga = _make_saga()
+
+        raid = _make_raid(confidence=0.9)
+        tracker.raids[raid.tracker_id] = raid
+        tracker.saga = saga
+
+        pr_id = raid.pr_id
+        git.pr_statuses[pr_id] = PRStatus(
+            pr_id=pr_id,
+            url="https://github.com/org/repo/pull/42",
+            state="open",
+            mergeable=True,
+            ci_passed=True,
+        )
+
+        # Track auto-continue calls
+        auto_continue_calls: list[tuple[str, str]] = []
+
+        class TrackingDispatchService:
+            async def try_auto_continue(self, owner_id: str, saga_tracker_id: str):
+                auto_continue_calls.append((owner_id, saga_tracker_id))
+                return []
+
+        class _StubVolundrFactory:
+            async def for_owner(self, owner_id):
+                return [volundr]
+
+            async def primary_for_owner(self, owner_id):
+                return volundr
+
+        engine = ReviewEngine(
+            tracker_factory=StubTrackerFactory(tracker),
+            volundr_factory=_StubVolundrFactory(),
+            git=git,
+            review_config=ReviewConfig(auto_approve_threshold=0.80),
+            event_bus=bus,
+            dispatch_service=TrackingDispatchService(),
+        )
+
+        decision = await engine.evaluate(raid.tracker_id, "user-1")
+        assert decision.action == "auto_approved"
+        assert len(auto_continue_calls) == 1
+        assert auto_continue_calls[0] == ("user-1", saga.tracker_id)
+
+    @pytest.mark.asyncio
+    async def test_phase_unlock_triggers_auto_continue(self):
+        """When a phase gate is unlocked, try_auto_continue should be called."""
+        from tyr.adapters.memory_event_bus import InMemoryEventBus
+        from tyr.config import ReviewConfig
+        from tyr.domain.services.review_engine import ReviewEngine
+
+        from ..test_review_engine import (
+            PHASE_ID,
+            StubGit,
+            StubTracker,
+            StubTrackerFactory,
+            StubVolundr,
+            _make_phase,
+            _make_raid,
+            _make_saga,
+        )
+
+        tracker = StubTracker()
+        git = StubGit()
+        bus = InMemoryEventBus()
+        volundr = StubVolundr()
+        saga = _make_saga()
+
+        # Setup phase gate: phase 1 is current, phase 2 is gated
+        phase1 = _make_phase(phase_id=PHASE_ID, number=1, status=PhaseStatus.ACTIVE)
+        phase2 = _make_phase(phase_id=uuid4(), number=2, status=PhaseStatus.GATED)
+        tracker.saga = saga
+        tracker.phase = phase1
+        tracker.phases = [phase1, phase2]
+        tracker._all_merged = True  # All raids in phase merged
+
+        raid = _make_raid(confidence=0.9)
+        tracker.raids[raid.tracker_id] = raid
+
+        pr_id = raid.pr_id
+        git.pr_statuses[pr_id] = PRStatus(
+            pr_id=pr_id,
+            url="https://github.com/org/repo/pull/42",
+            state="open",
+            mergeable=True,
+            ci_passed=True,
+        )
+
+        auto_continue_calls: list[tuple[str, str]] = []
+
+        class TrackingDispatchService:
+            async def try_auto_continue(self, owner_id: str, saga_tracker_id: str):
+                auto_continue_calls.append((owner_id, saga_tracker_id))
+                return []
+
+        class _StubVolundrFactory:
+            async def for_owner(self, owner_id):
+                return [volundr]
+
+            async def primary_for_owner(self, owner_id):
+                return volundr
+
+        engine = ReviewEngine(
+            tracker_factory=StubTrackerFactory(tracker),
+            volundr_factory=_StubVolundrFactory(),
+            git=git,
+            review_config=ReviewConfig(auto_approve_threshold=0.80),
+            event_bus=bus,
+            dispatch_service=TrackingDispatchService(),
+        )
+
+        decision = await engine.evaluate(raid.tracker_id, "user-1")
+        assert decision.action == "auto_approved"
+        assert decision.phase_gate_unlocked is True
+        # Called twice: once from phase unlock, once from merge in _handle_auto_approve
+        assert len(auto_continue_calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_no_dispatch_service_is_safe(self):
+        """ReviewEngine without dispatch_service should work fine (no-op)."""
+        from tyr.config import ReviewConfig
+        from tyr.domain.services.review_engine import ReviewEngine
+
+        from ..test_review_engine import (
+            StubGit,
+            StubTracker,
+            StubTrackerFactory,
+            StubVolundr,
+            _make_raid,
+            _make_saga,
+        )
+
+        tracker = StubTracker()
+        git = StubGit()
+        volundr = StubVolundr()
+        saga = _make_saga()
+
+        raid = _make_raid(confidence=0.9)
+        tracker.raids[raid.tracker_id] = raid
+        tracker.saga = saga
+
+        pr_id = raid.pr_id
+        git.pr_statuses[pr_id] = PRStatus(
+            pr_id=pr_id,
+            url="https://github.com/org/repo/pull/42",
+            state="open",
+            mergeable=True,
+            ci_passed=True,
+        )
+
+        class _StubVolundrFactory:
+            async def for_owner(self, owner_id):
+                return [volundr]
+
+            async def primary_for_owner(self, owner_id):
+                return volundr
+
+        engine = ReviewEngine(
+            tracker_factory=StubTrackerFactory(tracker),
+            volundr_factory=_StubVolundrFactory(),
+            git=git,
+            review_config=ReviewConfig(auto_approve_threshold=0.80),
+            # No dispatch_service passed
+        )
+
+        decision = await engine.evaluate(raid.tracker_id, "user-1")
+        assert decision.action == "auto_approved"
+
+    @pytest.mark.asyncio
+    async def test_dispatch_service_error_does_not_break_merge(self):
+        """If try_auto_continue raises, the merge should still succeed."""
+        from tyr.adapters.memory_event_bus import InMemoryEventBus
+        from tyr.config import ReviewConfig
+        from tyr.domain.services.review_engine import ReviewEngine
+
+        from ..test_review_engine import (
+            StubGit,
+            StubTracker,
+            StubTrackerFactory,
+            StubVolundr,
+            _make_raid,
+            _make_saga,
+        )
+
+        tracker = StubTracker()
+        git = StubGit()
+        volundr = StubVolundr()
+        saga = _make_saga()
+
+        raid = _make_raid(confidence=0.9)
+        tracker.raids[raid.tracker_id] = raid
+        tracker.saga = saga
+
+        pr_id = raid.pr_id
+        git.pr_statuses[pr_id] = PRStatus(
+            pr_id=pr_id,
+            url="https://github.com/org/repo/pull/42",
+            state="open",
+            mergeable=True,
+            ci_passed=True,
+        )
+
+        class FailingDispatchService:
+            async def try_auto_continue(self, owner_id: str, saga_tracker_id: str):
+                raise RuntimeError("dispatch blew up")
+
+        class _StubVolundrFactory:
+            async def for_owner(self, owner_id):
+                return [volundr]
+
+            async def primary_for_owner(self, owner_id):
+                return volundr
+
+        engine = ReviewEngine(
+            tracker_factory=StubTrackerFactory(tracker),
+            volundr_factory=_StubVolundrFactory(),
+            git=git,
+            review_config=ReviewConfig(auto_approve_threshold=0.80),
+            event_bus=InMemoryEventBus(),
+            dispatch_service=FailingDispatchService(),
+        )
+
+        # Should not raise
+        decision = await engine.evaluate(raid.tracker_id, "user-1")
+        assert decision.action == "auto_approved"


### PR DESCRIPTION
## Summary

- Add `try_auto_continue()` method to `DispatchService` that dispatches newly unblocked issues after a raid merges or a phase gate is unlocked, when `auto_continue` is enabled
- Per-owner `asyncio.Lock` prevents double-dispatch from concurrent merge events
- Wire auto-continue into `ReviewEngine._handle_auto_approve` (post-merge) and `_check_phase_gate` (post-phase-unlock)
- Dispatch errors are caught and logged — they never break the merge flow

## Test plan

- [x] Verify dispatch called when `auto_continue=True` and `running=True`
- [x] Verify no-op when `auto_continue=False`
- [x] Verify no-op when `running=False`
- [x] Verify respects `max_concurrent_raids` (no over-dispatch)
- [x] Verify no-op when max slots already taken
- [x] Verify no-op when no ready issues exist
- [x] Verify per-owner locking prevents race conditions
- [x] Verify merge triggers auto-continue via ReviewEngine
- [x] Verify phase unlock triggers auto-continue via ReviewEngine
- [x] Verify ReviewEngine works without dispatch_service (graceful no-op)
- [x] Verify dispatch_service errors don't break merge flow

Closes NIU-473

🤖 Generated with [Claude Code](https://claude.com/claude-code)