### PR TITLE
feat(ravn): bootstrap core agent loop with domain models, ports, and adapters (NIU-426)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ volundr = "volundr.main:main"
 skuld = "skuld.broker:main"
 bifrost = "volundr.bifrost.__main__:main"
 tyr = "tyr.main:main"
+ravn = "ravn.cli.commands:app"
 
 [project.entry-points."niuu.plugins"]
 niuu = "niuu.plugin:NiuuPlugin"
@@ -77,7 +78,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/cli", "src/niuu", "src/volundr", "src/tyr", "src/skuld"]
+packages = ["src/cli", "src/niuu", "src/volundr", "src/tyr", "src/skuld", "src/ravn"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -96,7 +97,7 @@ line-length = 100
 select = ["E", "F", "I", "N", "W", "UP"]
 
 [tool.coverage.run]
-source = ["src/volundr", "src/cli", "src/tyr", "src/niuu", "src/skuld"]
+source = ["src/volundr", "src/cli", "src/tyr", "src/niuu", "src/skuld", "src/ravn"]
 branch = true
 
 [tool.coverage.report]

--- a/src/ravn/__init__.py
+++ b/src/ravn/__init__.py
@@ -1,0 +1,1 @@
+"""Ravn — conversational AI agent with tool calling."""

--- a/src/ravn/__main__.py
+++ b/src/ravn/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point for `python -m ravn`."""
+
+from ravn.cli.commands import app
+
+if __name__ == "__main__":
+    app()

--- a/src/ravn/adapters/__init__.py
+++ b/src/ravn/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Ravn adapter implementations."""

--- a/src/ravn/adapters/anthropic_adapter.py
+++ b/src/ravn/adapters/anthropic_adapter.py
@@ -1,0 +1,320 @@
+"""AnthropicAdapter — LLMPort implementation using the Anthropic Messages API.
+
+Uses httpx for HTTP, following the project pattern established in
+tyr/adapters/bifrost.py.  Implements streaming (SSE), tool calling,
+prompt caching (cache_control: ephemeral on system prompt), and
+transient-error retries.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections.abc import AsyncIterator
+
+import httpx
+
+from ravn.domain.exceptions import LLMError
+from ravn.domain.models import (
+    LLMResponse,
+    StopReason,
+    StreamEvent,
+    StreamEventType,
+    TokenUsage,
+    ToolCall,
+)
+from ravn.ports.llm import LLMPort
+
+logger = logging.getLogger(__name__)
+
+ANTHROPIC_API_VERSION = "2023-06-01"
+ANTHROPIC_BETA_HEADER = "prompt-caching-2024-07-31"
+
+_RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503})
+_DEFAULT_BASE_URL = "https://api.anthropic.com"
+
+
+class AnthropicAdapter(LLMPort):
+    """Calls the Anthropic Messages API with streaming and tool support.
+
+    Constructor kwargs are forwarded from config via the dynamic adapter pattern.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str = "",
+        base_url: str = _DEFAULT_BASE_URL,
+        model: str = "claude-sonnet-4-6",
+        max_tokens: int = 8192,
+        max_retries: int = 3,
+        retry_base_delay: float = 1.0,
+        timeout: float = 120.0,
+    ) -> None:
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+        self._default_model = model
+        self._default_max_tokens = max_tokens
+        self._max_retries = max_retries
+        self._retry_base_delay = retry_base_delay
+        self._timeout = timeout
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "x-api-key": self._api_key,
+            "anthropic-version": ANTHROPIC_API_VERSION,
+            "anthropic-beta": ANTHROPIC_BETA_HEADER,
+            "content-type": "application/json",
+        }
+
+    def _build_system(self, system: str) -> list[dict]:
+        """Wrap the system prompt with ephemeral cache control."""
+        if not system:
+            return []
+        return [
+            {
+                "type": "text",
+                "text": system,
+                "cache_control": {"type": "ephemeral"},
+            }
+        ]
+
+    def _build_request(
+        self,
+        messages: list[dict],
+        *,
+        tools: list[dict],
+        system: str,
+        model: str,
+        max_tokens: int,
+        stream: bool,
+    ) -> dict:
+        body: dict = {
+            "model": model or self._default_model,
+            "max_tokens": max_tokens or self._default_max_tokens,
+            "messages": messages,
+            "stream": stream,
+        }
+        system_blocks = self._build_system(system)
+        if system_blocks:
+            body["system"] = system_blocks
+        if tools:
+            body["tools"] = tools
+        return body
+
+    async def _post_with_retry(
+        self,
+        client: httpx.AsyncClient,
+        payload: dict,
+        *,
+        stream: bool,
+    ) -> httpx.Response:
+        url = f"{self._base_url}/v1/messages"
+        last_exc: Exception | None = None
+
+        for attempt in range(self._max_retries + 1):
+            try:
+                if stream:
+                    response = await client.send(
+                        client.build_request("POST", url, json=payload),
+                        stream=True,
+                    )
+                else:
+                    response = await client.post(url, json=payload)
+
+                if response.status_code not in _RETRYABLE_STATUS_CODES:
+                    return response
+
+                if attempt < self._max_retries:
+                    delay = self._retry_base_delay * (2**attempt)
+                    logger.warning(
+                        "Anthropic API returned %s, retrying in %.1fs (attempt %d/%d)",
+                        response.status_code,
+                        delay,
+                        attempt + 1,
+                        self._max_retries,
+                    )
+                    if stream:
+                        await response.aclose()
+                    await asyncio.sleep(delay)
+                    last_exc = LLMError(
+                        f"Anthropic API error {response.status_code}",
+                        status_code=response.status_code,
+                    )
+
+            except httpx.TransportError as exc:
+                last_exc = exc
+                if attempt < self._max_retries:
+                    delay = self._retry_base_delay * (2**attempt)
+                    await asyncio.sleep(delay)
+
+        raise LLMError(f"Anthropic API failed after {self._max_retries} retries") from last_exc
+
+    async def stream(
+        self,
+        messages: list[dict],
+        *,
+        tools: list[dict],
+        system: str,
+        model: str,
+        max_tokens: int,
+    ) -> AsyncIterator[StreamEvent]:
+        payload = self._build_request(
+            messages,
+            tools=tools,
+            system=system,
+            model=model,
+            max_tokens=max_tokens,
+            stream=True,
+        )
+
+        async with httpx.AsyncClient(headers=self._headers(), timeout=self._timeout) as client:
+            response = await self._post_with_retry(client, payload, stream=True)
+
+            if response.status_code != 200:
+                body = await response.aread()
+                raise LLMError(
+                    f"Anthropic API error {response.status_code}: {body.decode()}",
+                    status_code=response.status_code,
+                )
+
+            # Accumulate partial tool inputs keyed by tool_use block index.
+            partial_inputs: dict[int, dict] = {}
+            tool_ids: dict[int, str] = {}
+            tool_names: dict[int, str] = {}
+            current_block_index = -1
+
+            async for line in response.aiter_lines():
+                if not line.startswith("data: "):
+                    continue
+                raw = line[len("data: ") :]
+                if raw == "[DONE]":
+                    break
+
+                try:
+                    event_data = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+
+                event_type = event_data.get("type", "")
+
+                match event_type:
+                    case "content_block_start":
+                        block = event_data.get("content_block", {})
+                        current_block_index = event_data.get("index", current_block_index)
+                        if block.get("type") == "tool_use":
+                            tool_ids[current_block_index] = block.get("id", "")
+                            tool_names[current_block_index] = block.get("name", "")
+                            partial_inputs[current_block_index] = {}
+
+                    case "content_block_delta":
+                        delta = event_data.get("delta", {})
+                        idx = event_data.get("index", current_block_index)
+                        match delta.get("type"):
+                            case "text_delta":
+                                yield StreamEvent(
+                                    type=StreamEventType.TEXT_DELTA,
+                                    text=delta.get("text", ""),
+                                )
+                            case "input_json_delta":
+                                # Accumulate partial JSON — emit when block stops.
+                                if idx not in partial_inputs:
+                                    partial_inputs[idx] = {}
+                                chunk = delta.get("partial_json", "")
+                                partial_inputs[idx]["_raw"] = (
+                                    partial_inputs[idx].get("_raw", "") + chunk
+                                )
+
+                    case "content_block_stop":
+                        idx = event_data.get("index", current_block_index)
+                        if idx in partial_inputs:
+                            raw_json = partial_inputs[idx].get("_raw", "")
+                            try:
+                                parsed_input = json.loads(raw_json) if raw_json else {}
+                            except json.JSONDecodeError:
+                                parsed_input = {}
+                            yield StreamEvent(
+                                type=StreamEventType.TOOL_CALL,
+                                tool_call=ToolCall(
+                                    id=tool_ids.get(idx, ""),
+                                    name=tool_names.get(idx, ""),
+                                    input=parsed_input,
+                                ),
+                            )
+                            del partial_inputs[idx]
+
+                    case "message_delta":
+                        usage_data = event_data.get("usage", {})
+                        yield StreamEvent(
+                            type=StreamEventType.MESSAGE_DONE,
+                            usage=TokenUsage(
+                                input_tokens=usage_data.get("input_tokens", 0),
+                                output_tokens=usage_data.get("output_tokens", 0),
+                                cache_read_tokens=usage_data.get("cache_read_input_tokens", 0),
+                                cache_write_tokens=usage_data.get("cache_creation_input_tokens", 0),
+                            ),
+                        )
+
+    async def generate(
+        self,
+        messages: list[dict],
+        *,
+        tools: list[dict],
+        system: str,
+        model: str,
+        max_tokens: int,
+    ) -> LLMResponse:
+        payload = self._build_request(
+            messages,
+            tools=tools,
+            system=system,
+            model=model,
+            max_tokens=max_tokens,
+            stream=False,
+        )
+
+        async with httpx.AsyncClient(headers=self._headers(), timeout=self._timeout) as client:
+            response = await self._post_with_retry(client, payload, stream=False)
+
+        if response.status_code != 200:
+            raise LLMError(
+                f"Anthropic API error {response.status_code}: {response.text}",
+                status_code=response.status_code,
+            )
+
+        data = response.json()
+        content_text = ""
+        tool_calls: list[ToolCall] = []
+
+        for block in data.get("content", []):
+            match block.get("type"):
+                case "text":
+                    content_text += block.get("text", "")
+                case "tool_use":
+                    tool_calls.append(
+                        ToolCall(
+                            id=block.get("id", ""),
+                            name=block.get("name", ""),
+                            input=block.get("input", {}),
+                        )
+                    )
+
+        usage_data = data.get("usage", {})
+        stop_reason_raw = data.get("stop_reason", "end_turn")
+        try:
+            stop_reason = StopReason(stop_reason_raw)
+        except ValueError:
+            stop_reason = StopReason.END_TURN
+
+        return LLMResponse(
+            content=content_text,
+            tool_calls=tool_calls,
+            stop_reason=stop_reason,
+            usage=TokenUsage(
+                input_tokens=usage_data.get("input_tokens", 0),
+                output_tokens=usage_data.get("output_tokens", 0),
+                cache_read_tokens=usage_data.get("cache_read_input_tokens", 0),
+                cache_write_tokens=usage_data.get("cache_creation_input_tokens", 0),
+            ),
+        )

--- a/src/ravn/adapters/anthropic_adapter.py
+++ b/src/ravn/adapters/anthropic_adapter.py
@@ -126,6 +126,9 @@ class AnthropicAdapter(LLMPort):
                 if response.status_code not in _RETRYABLE_STATUS_CODES:
                     return response
 
+                if stream:
+                    await response.aclose()
+
                 if attempt < self._max_retries:
                     delay = self._retry_base_delay * (2**attempt)
                     logger.warning(
@@ -135,8 +138,6 @@ class AnthropicAdapter(LLMPort):
                         attempt + 1,
                         self._max_retries,
                     )
-                    if stream:
-                        await response.aclose()
                     await asyncio.sleep(delay)
                     last_exc = LLMError(
                         f"Anthropic API error {response.status_code}",

--- a/src/ravn/adapters/cli_channel.py
+++ b/src/ravn/adapters/cli_channel.py
@@ -1,0 +1,74 @@
+"""CliChannel — renders Ravn events to the terminal."""
+
+from __future__ import annotations
+
+import sys
+
+from ravn.domain.events import RavnEvent, RavnEventType
+from ravn.ports.channel import ChannelPort
+
+
+class CliChannel(ChannelPort):
+    """Renders streaming text and tool use/results to stdout.
+
+    Output is written synchronously to avoid interleaving with other async I/O.
+    Each event type has a distinct visual treatment so the user can follow
+    what the agent is doing in real time.
+    """
+
+    def __init__(self, *, file=None) -> None:
+        self._file = file or sys.stdout
+        self._in_response = False
+
+    async def emit(self, event: RavnEvent) -> None:
+        match event.type:
+            case RavnEventType.THOUGHT:
+                # Stream text deltas inline without a newline.
+                print(event.data, end="", flush=True, file=self._file)
+                self._in_response = True
+
+            case RavnEventType.RESPONSE:
+                # Final complete response — just print a newline to end the stream.
+                if self._in_response:
+                    print(file=self._file)
+                    self._in_response = False
+
+            case RavnEventType.TOOL_START:
+                tool_name = event.data
+                tool_input = event.metadata.get("input", {})
+                if self._in_response:
+                    print(file=self._file)
+                    self._in_response = False
+                print(f"\n⚙ {tool_name}({_format_input(tool_input)})", file=self._file)
+
+            case RavnEventType.TOOL_RESULT:
+                tool_name = event.metadata.get("tool_name", "")
+                is_error = event.metadata.get("is_error", False)
+                prefix = "✗" if is_error else "✓"
+                content = event.data
+                # Truncate very long results for readability.
+                if len(content) > 500:
+                    content = content[:500] + "…"
+                print(f"{prefix} {tool_name}: {content}", file=self._file)
+
+            case RavnEventType.ERROR:
+                print(f"\n[error] {event.data}", file=self._file)
+
+    def finish(self) -> None:
+        """Ensure the terminal is in a clean state after output."""
+        if self._in_response:
+            print(file=self._file)
+            self._in_response = False
+
+
+def _format_input(tool_input: dict) -> str:
+    """Format tool input for compact display."""
+    if not tool_input:
+        return ""
+    parts = []
+    for key, value in tool_input.items():
+        value_str = str(value)
+        if len(value_str) > 60:
+            value_str = value_str[:60] + "…"
+        parts.append(f"{key}={value_str!r}")
+    return ", ".join(parts)

--- a/src/ravn/adapters/cli_channel.py
+++ b/src/ravn/adapters/cli_channel.py
@@ -16,9 +16,17 @@ class CliChannel(ChannelPort):
     what the agent is doing in real time.
     """
 
-    def __init__(self, *, file=None) -> None:
+    def __init__(
+        self,
+        *,
+        file=None,
+        result_truncation_limit: int = 500,
+        input_value_limit: int = 60,
+    ) -> None:
         self._file = file or sys.stdout
         self._in_response = False
+        self._result_truncation_limit = result_truncation_limit
+        self._input_value_limit = input_value_limit
 
     async def emit(self, event: RavnEvent) -> None:
         match event.type:
@@ -39,7 +47,10 @@ class CliChannel(ChannelPort):
                 if self._in_response:
                     print(file=self._file)
                     self._in_response = False
-                print(f"\n⚙ {tool_name}({_format_input(tool_input)})", file=self._file)
+                print(
+                    f"\n⚙ {tool_name}({_format_input(tool_input, self._input_value_limit)})",
+                    file=self._file,
+                )
 
             case RavnEventType.TOOL_RESULT:
                 tool_name = event.metadata.get("tool_name", "")
@@ -47,8 +58,8 @@ class CliChannel(ChannelPort):
                 prefix = "✗" if is_error else "✓"
                 content = event.data
                 # Truncate very long results for readability.
-                if len(content) > 500:
-                    content = content[:500] + "…"
+                if len(content) > self._result_truncation_limit:
+                    content = content[: self._result_truncation_limit] + "…"
                 print(f"{prefix} {tool_name}: {content}", file=self._file)
 
             case RavnEventType.ERROR:
@@ -61,14 +72,14 @@ class CliChannel(ChannelPort):
             self._in_response = False
 
 
-def _format_input(tool_input: dict) -> str:
+def _format_input(tool_input: dict, value_limit: int = 60) -> str:
     """Format tool input for compact display."""
     if not tool_input:
         return ""
     parts = []
     for key, value in tool_input.items():
         value_str = str(value)
-        if len(value_str) > 60:
-            value_str = value_str[:60] + "…"
+        if len(value_str) > value_limit:
+            value_str = value_str[:value_limit] + "…"
         parts.append(f"{key}={value_str!r}")
     return ", ".join(parts)

--- a/src/ravn/adapters/permission_adapter.py
+++ b/src/ravn/adapters/permission_adapter.py
@@ -1,0 +1,29 @@
+"""Built-in permission adapter implementations."""
+
+from __future__ import annotations
+
+from ravn.ports.permission import PermissionPort
+
+
+class AllowAllPermission(PermissionPort):
+    """Grants every permission — suitable for trusted/local contexts."""
+
+    async def check(self, permission: str) -> bool:
+        return True
+
+
+class DenyAllPermission(PermissionPort):
+    """Denies every permission — used to block all tool execution."""
+
+    async def check(self, permission: str) -> bool:
+        return False
+
+
+class AllowListPermission(PermissionPort):
+    """Grants only the permissions in a fixed allow-list."""
+
+    def __init__(self, allowed: set[str]) -> None:
+        self._allowed = allowed
+
+    async def check(self, permission: str) -> bool:
+        return permission in self._allowed

--- a/src/ravn/agent.py
+++ b/src/ravn/agent.py
@@ -13,6 +13,7 @@ from ravn.domain.models import (
     Message,
     Session,
     StopReason,
+    StreamEventType,
     TokenUsage,
     ToolCall,
     ToolResult,
@@ -106,7 +107,7 @@ class RavnAgent:
 
             # Append the assistant message (with tool calls) to history.
             assistant_content = _build_assistant_content(llm_response)
-            self._session.messages.append(Message(role="assistant", content=assistant_content))  # type: ignore[arg-type]
+            self._session.messages.append(Message(role="assistant", content=assistant_content))
 
             # Execute all tool calls sequentially.
             tool_results_content = []
@@ -124,9 +125,7 @@ class RavnAgent:
                 )
 
             # Append tool results as a user message.
-            self._session.messages.append(  # type: ignore[arg-type]
-                Message(role="user", content=tool_results_content)  # type: ignore[arg-type]
-            )
+            self._session.messages.append(Message(role="user", content=tool_results_content))
         else:
             raise MaxIterationsError(self._max_iterations)
 
@@ -141,8 +140,6 @@ class RavnAgent:
 
     async def _call_llm_streaming(self) -> LLMResponse:
         """Call the LLM with streaming and accumulate into an LLMResponse."""
-        from ravn.domain.models import StopReason, StreamEventType
-
         accumulated_text = ""
         tool_calls: list[ToolCall] = []
         final_usage = TokenUsage(input_tokens=0, output_tokens=0)

--- a/src/ravn/agent.py
+++ b/src/ravn/agent.py
@@ -1,0 +1,253 @@
+"""Core Ravn agent loop."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Coroutine
+from typing import Any
+
+from ravn.domain.events import RavnEvent, RavnEventType
+from ravn.domain.exceptions import MaxIterationsError, PermissionDeniedError
+from ravn.domain.models import (
+    LLMResponse,
+    Message,
+    Session,
+    StopReason,
+    TokenUsage,
+    ToolCall,
+    ToolResult,
+    TurnResult,
+)
+from ravn.ports.channel import ChannelPort
+from ravn.ports.llm import LLMPort
+from ravn.ports.permission import PermissionPort
+from ravn.ports.tool import ToolPort
+
+logger = logging.getLogger(__name__)
+
+# Hook type: async callable receiving the tool call and (for post) the result.
+PreToolHook = Callable[[ToolCall], Coroutine[Any, Any, None]]
+PostToolHook = Callable[[ToolCall, ToolResult], Coroutine[Any, Any, None]]
+
+
+class RavnAgent:
+    """Turn-based agent that converses with an LLM and executes tools.
+
+    The agent maintains a session (conversation history) and runs a loop
+    for each user turn:
+    1. Append the user message to history.
+    2. Call the LLM (streaming).
+    3. If the LLM requests tool calls, execute them (with permission check and hooks).
+    4. Feed tool results back to the LLM and repeat from step 2.
+    5. When the LLM returns a final response (stop_reason != tool_use), return.
+    """
+
+    def __init__(
+        self,
+        llm: LLMPort,
+        tools: list[ToolPort],
+        channel: ChannelPort,
+        permission: PermissionPort,
+        *,
+        system_prompt: str,
+        model: str,
+        max_tokens: int,
+        max_iterations: int,
+        pre_tool_hooks: list[PreToolHook] | None = None,
+        post_tool_hooks: list[PostToolHook] | None = None,
+    ) -> None:
+        self._llm = llm
+        self._tools = {t.name: t for t in tools}
+        self._channel = channel
+        self._permission = permission
+        self._system_prompt = system_prompt
+        self._model = model
+        self._max_tokens = max_tokens
+        self._max_iterations = max_iterations
+        self._pre_tool_hooks: list[PreToolHook] = pre_tool_hooks or []
+        self._post_tool_hooks: list[PostToolHook] = post_tool_hooks or []
+        self._session = Session()
+
+    @property
+    def session(self) -> Session:
+        return self._session
+
+    def _tool_defs(self) -> list[dict]:
+        return [t.to_api_dict() for t in self._tools.values()]
+
+    def _build_api_messages(self) -> list[dict]:
+        """Convert session messages to the API format."""
+        return [{"role": m.role, "content": m.content} for m in self._session.messages]
+
+    async def run_turn(self, user_input: str) -> TurnResult:
+        """Process one user turn and return the result.
+
+        Runs the full tool-call loop until the LLM produces a final response
+        or the maximum number of iterations is reached.
+        """
+        self._session.add_message(Message(role="user", content=user_input))
+
+        turn_tool_calls: list[ToolCall] = []
+        turn_tool_results: list[ToolResult] = []
+        cumulative_usage = TokenUsage(input_tokens=0, output_tokens=0)
+        final_response = ""
+
+        for iteration in range(self._max_iterations):
+            llm_response = await self._call_llm_streaming()
+            cumulative_usage = cumulative_usage + llm_response.usage
+
+            if llm_response.content:
+                await self._channel.emit(RavnEvent.response(llm_response.content))
+
+            if llm_response.stop_reason != StopReason.TOOL_USE:
+                final_response = llm_response.content
+                self._session.add_message(Message(role="assistant", content=llm_response.content))
+                break
+
+            # Append the assistant message (with tool calls) to history.
+            assistant_content = _build_assistant_content(llm_response)
+            self._session.messages.append(Message(role="assistant", content=assistant_content))  # type: ignore[arg-type]
+
+            # Execute all tool calls sequentially.
+            tool_results_content = []
+            for tool_call in llm_response.tool_calls:
+                turn_tool_calls.append(tool_call)
+                result = await self._execute_tool(tool_call)
+                turn_tool_results.append(result)
+                tool_results_content.append(
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": tool_call.id,
+                        "content": result.content,
+                        "is_error": result.is_error,
+                    }
+                )
+
+            # Append tool results as a user message.
+            self._session.messages.append(  # type: ignore[arg-type]
+                Message(role="user", content=tool_results_content)  # type: ignore[arg-type]
+            )
+        else:
+            raise MaxIterationsError(self._max_iterations)
+
+        self._session.record_turn(cumulative_usage)
+
+        return TurnResult(
+            response=final_response,
+            tool_calls=turn_tool_calls,
+            tool_results=turn_tool_results,
+            usage=cumulative_usage,
+        )
+
+    async def _call_llm_streaming(self) -> LLMResponse:
+        """Call the LLM with streaming and accumulate into an LLMResponse."""
+        from ravn.domain.models import StopReason, StreamEventType
+
+        accumulated_text = ""
+        tool_calls: list[ToolCall] = []
+        final_usage = TokenUsage(input_tokens=0, output_tokens=0)
+        stop_reason = StopReason.END_TURN
+
+        async for event in self._llm.stream(
+            self._build_api_messages(),
+            tools=self._tool_defs(),
+            system=self._system_prompt,
+            model=self._model,
+            max_tokens=self._max_tokens,
+        ):
+            match event.type:
+                case StreamEventType.TEXT_DELTA:
+                    if event.text:
+                        accumulated_text += event.text
+                        await self._channel.emit(RavnEvent.thought(event.text))
+                case StreamEventType.TOOL_CALL:
+                    if event.tool_call:
+                        tool_calls.append(event.tool_call)
+                case StreamEventType.MESSAGE_DONE:
+                    if event.usage:
+                        final_usage = event.usage
+                    if tool_calls:
+                        stop_reason = StopReason.TOOL_USE
+
+        return LLMResponse(
+            content=accumulated_text,
+            tool_calls=tool_calls,
+            stop_reason=stop_reason,
+            usage=final_usage,
+        )
+
+    async def _execute_tool(self, tool_call: ToolCall) -> ToolResult:
+        """Execute a single tool call, enforcing permissions and running hooks."""
+        tool = self._tools.get(tool_call.name)
+
+        if tool is None:
+            result = ToolResult(
+                tool_call_id=tool_call.id,
+                content=f"Unknown tool: {tool_call.name}",
+                is_error=True,
+            )
+            await self._channel.emit(
+                RavnEvent.tool_result(tool_call.name, result.content, is_error=True)
+            )
+            return result
+
+        await self._channel.emit(RavnEvent.tool_start(tool_call.name, tool_call.input))
+
+        granted = await self._permission.check(tool.required_permission)
+        if not granted:
+            error = PermissionDeniedError(tool_call.name, tool.required_permission)
+            result = ToolResult(
+                tool_call_id=tool_call.id,
+                content=str(error),
+                is_error=True,
+            )
+            await self._channel.emit(
+                RavnEvent.tool_result(tool_call.name, result.content, is_error=True)
+            )
+            return result
+
+        for hook in self._pre_tool_hooks:
+            await hook(tool_call)
+
+        try:
+            result = await tool.execute(tool_call.input)
+        except Exception as exc:
+            logger.warning("Tool '%s' raised: %s", tool_call.name, exc)
+            result = ToolResult(
+                tool_call_id=tool_call.id,
+                content=f"Tool error: {exc}",
+                is_error=True,
+            )
+
+        for hook in self._post_tool_hooks:
+            await hook(tool_call, result)
+
+        event_type = RavnEventType.TOOL_RESULT
+        await self._channel.emit(
+            RavnEvent(
+                type=event_type,
+                data=result.content,
+                metadata={"tool_name": tool_call.name, "is_error": result.is_error},
+            )
+        )
+        return result
+
+
+def _build_assistant_content(response: LLMResponse) -> list[dict]:
+    """Build the Anthropic-format assistant content list from an LLMResponse."""
+    content: list[dict] = []
+
+    if response.content:
+        content.append({"type": "text", "text": response.content})
+
+    for tc in response.tool_calls:
+        content.append(
+            {
+                "type": "tool_use",
+                "id": tc.id,
+                "name": tc.name,
+                "input": tc.input,
+            }
+        )
+
+    return content

--- a/src/ravn/cli/__init__.py
+++ b/src/ravn/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Ravn CLI commands."""

--- a/src/ravn/cli/commands.py
+++ b/src/ravn/cli/commands.py
@@ -86,7 +86,7 @@ async def _chat(
 ) -> None:
     """Run a single-turn or multi-turn conversation."""
     if prompt:
-        await _run_turn(agent, channel, prompt, show_usage=show_usage)
+        await _run_turn(agent, channel, prompt, show_usage=show_usage, single_turn=True)
         return
 
     # REPL mode.
@@ -109,6 +109,7 @@ async def _run_turn(
     user_input: str,
     *,
     show_usage: bool,
+    single_turn: bool = False,
 ) -> None:
     try:
         result = await agent.run_turn(user_input)
@@ -118,7 +119,8 @@ async def _run_turn(
     except Exception as exc:
         channel.finish()
         typer.echo(f"\n[error] {exc}", err=True)
-        sys.exit(1)
+        if single_turn:
+            sys.exit(1)
 
 
 def _print_usage(usage: TokenUsage) -> None:

--- a/src/ravn/cli/commands.py
+++ b/src/ravn/cli/commands.py
@@ -1,0 +1,134 @@
+"""Ravn CLI entry point."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+import typer
+
+from ravn.adapters.anthropic_adapter import AnthropicAdapter
+from ravn.adapters.cli_channel import CliChannel
+from ravn.adapters.permission_adapter import AllowAllPermission, DenyAllPermission
+from ravn.agent import RavnAgent
+from ravn.config import Settings
+from ravn.domain.models import TokenUsage
+
+app = typer.Typer(
+    name="ravn",
+    help="Ravn — conversational AI agent with tool calling.",
+    add_completion=False,
+)
+
+
+def _build_agent(settings: Settings, *, no_tools: bool = False) -> tuple[RavnAgent, CliChannel]:
+    api_key = settings.effective_api_key()
+    if not api_key:
+        typer.echo(
+            "Error: No API key found. Set ANTHROPIC_API_KEY or configure ravn.yaml.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    llm = AnthropicAdapter(
+        api_key=api_key,
+        base_url=settings.anthropic.base_url,
+        model=settings.agent.model,
+        max_tokens=settings.agent.max_tokens,
+        max_retries=settings.llm_adapter.max_retries,
+        retry_base_delay=settings.llm_adapter.retry_base_delay,
+        timeout=settings.llm_adapter.timeout,
+    )
+
+    channel = CliChannel()
+
+    permission = DenyAllPermission() if no_tools else AllowAllPermission()
+
+    agent = RavnAgent(
+        llm=llm,
+        tools=[],
+        channel=channel,
+        permission=permission,
+        system_prompt=settings.agent.system_prompt,
+        model=settings.agent.model,
+        max_tokens=settings.agent.max_tokens,
+        max_iterations=settings.agent.max_iterations,
+    )
+
+    return agent, channel
+
+
+@app.command()
+def run(
+    prompt: str = typer.Argument(default="", help="Initial prompt. If empty, starts REPL."),
+    no_tools: bool = typer.Option(False, "--no-tools", help="Disable all tool execution."),
+    show_usage: bool = typer.Option(False, "--show-usage", help="Print token usage after turn."),
+    config: str = typer.Option("", "--config", "-c", help="Path to ravn config YAML."),
+) -> None:
+    """Start a Ravn conversation. Pass a prompt for single-turn, or omit for REPL."""
+    import os
+
+    if config:
+        os.environ["RAVN_CONFIG"] = config
+
+    settings = Settings()
+    agent, channel = _build_agent(settings, no_tools=no_tools)
+
+    asyncio.run(_chat(agent, channel, prompt=prompt, show_usage=show_usage))
+
+
+async def _chat(
+    agent: RavnAgent,
+    channel: CliChannel,
+    *,
+    prompt: str,
+    show_usage: bool,
+) -> None:
+    """Run a single-turn or multi-turn conversation."""
+    if prompt:
+        await _run_turn(agent, channel, prompt, show_usage=show_usage)
+        return
+
+    # REPL mode.
+    typer.echo("Ravn — type your message, Ctrl+D to exit.\n")
+    while True:
+        try:
+            user_input = input("You: ").strip()
+        except EOFError:
+            break
+
+        if not user_input:
+            continue
+
+        await _run_turn(agent, channel, user_input, show_usage=show_usage)
+
+
+async def _run_turn(
+    agent: RavnAgent,
+    channel: CliChannel,
+    user_input: str,
+    *,
+    show_usage: bool,
+) -> None:
+    try:
+        result = await agent.run_turn(user_input)
+        channel.finish()
+        if show_usage:
+            _print_usage(result.usage)
+    except Exception as exc:
+        channel.finish()
+        typer.echo(f"\n[error] {exc}", err=True)
+        sys.exit(1)
+
+
+def _print_usage(usage: TokenUsage) -> None:
+    parts = [f"in={usage.input_tokens}", f"out={usage.output_tokens}"]
+    if usage.cache_read_tokens:
+        parts.append(f"cache_read={usage.cache_read_tokens}")
+    if usage.cache_write_tokens:
+        parts.append(f"cache_write={usage.cache_write_tokens}")
+    typer.echo(f"[tokens] {', '.join(parts)}")
+
+
+def main() -> None:
+    app()

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -1,0 +1,132 @@
+"""Configuration settings for Ravn.
+
+Config file locations (first found wins):
+- ~/.ravn/config.yaml
+- ./ravn.yaml
+- /etc/ravn/config.yaml
+
+Environment variable override format (RAVN_ prefix, double underscore for nesting):
+- RAVN_ANTHROPIC__API_KEY
+- RAVN_AGENT__MODEL
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+from pydantic_settings import (
+    BaseSettings,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+    YamlConfigSettingsSource,
+)
+
+
+def _config_paths() -> list[Path]:
+    env = os.environ.get("RAVN_CONFIG")
+    if env:
+        return [Path(env)]
+    return [
+        Path.home() / ".ravn" / "config.yaml",
+        Path("./ravn.yaml"),
+        Path("/etc/ravn/config.yaml"),
+    ]
+
+
+CONFIG_PATHS = _config_paths()
+
+
+class AnthropicConfig(BaseModel):
+    """Anthropic API configuration."""
+
+    api_key: str = Field(default="", description="Anthropic API key (or set ANTHROPIC_API_KEY).")
+    base_url: str = Field(default="https://api.anthropic.com")
+
+
+class AgentConfig(BaseModel):
+    """Core agent behaviour configuration."""
+
+    model: str = Field(default="claude-sonnet-4-6")
+    max_tokens: int = Field(default=8192)
+    max_iterations: int = Field(default=20, description="Max tool-call iterations per turn.")
+    system_prompt: str = Field(
+        default=(
+            "You are Ravn, a helpful AI assistant. "
+            "Be concise, accurate, and use tools when they help."
+        )
+    )
+
+
+class LLMAdapterConfig(BaseModel):
+    """Dynamic LLM adapter configuration."""
+
+    adapter: str = Field(
+        default="ravn.adapters.anthropic_adapter.AnthropicAdapter",
+        description="Fully-qualified class path for the LLM adapter.",
+    )
+    kwargs: dict[str, Any] = Field(default_factory=dict)
+    max_retries: int = Field(default=3)
+    retry_base_delay: float = Field(default=1.0)
+    timeout: float = Field(default=120.0)
+
+
+class PermissionConfig(BaseModel):
+    """Permission enforcement configuration."""
+
+    mode: str = Field(
+        default="allow_all",
+        description="Permission mode: allow_all, deny_all, or prompt.",
+    )
+
+
+class LoggingConfig(BaseModel):
+    """Logging configuration."""
+
+    level: str = Field(default="warning")
+    format: str = Field(default="text")
+
+
+class Settings(BaseSettings):
+    """Ravn application settings.
+
+    Loaded from YAML with RAVN_ environment variable overrides.
+    """
+
+    model_config = SettingsConfigDict(
+        yaml_file=CONFIG_PATHS,
+        yaml_file_encoding="utf-8",
+        env_prefix="RAVN_",
+        env_nested_delimiter="__",
+        extra="ignore",
+    )
+
+    anthropic: AnthropicConfig = Field(default_factory=AnthropicConfig)
+    agent: AgentConfig = Field(default_factory=AgentConfig)
+    llm_adapter: LLMAdapterConfig = Field(default_factory=LLMAdapterConfig)
+    permission: PermissionConfig = Field(default_factory=PermissionConfig)
+    logging: LoggingConfig = Field(default_factory=LoggingConfig)
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        return (
+            init_settings,
+            env_settings,
+            YamlConfigSettingsSource(settings_cls),
+            file_secret_settings,
+        )
+
+    def effective_api_key(self) -> str:
+        """Return the API key, preferring ANTHROPIC_API_KEY env var."""
+        import os
+
+        return os.environ.get("ANTHROPIC_API_KEY", "") or self.anthropic.api_key

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -36,9 +36,6 @@ def _config_paths() -> list[Path]:
     ]
 
 
-CONFIG_PATHS = _config_paths()
-
-
 class AnthropicConfig(BaseModel):
     """Anthropic API configuration."""
 
@@ -96,7 +93,6 @@ class Settings(BaseSettings):
     """
 
     model_config = SettingsConfigDict(
-        yaml_file=CONFIG_PATHS,
         yaml_file_encoding="utf-8",
         env_prefix="RAVN_",
         env_nested_delimiter="__",
@@ -121,7 +117,7 @@ class Settings(BaseSettings):
         return (
             init_settings,
             env_settings,
-            YamlConfigSettingsSource(settings_cls),
+            YamlConfigSettingsSource(settings_cls, yaml_file=_config_paths()),
             file_secret_settings,
         )
 

--- a/src/ravn/domain/__init__.py
+++ b/src/ravn/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Ravn domain layer — models, events, and exceptions."""

--- a/src/ravn/domain/events.py
+++ b/src/ravn/domain/events.py
@@ -1,0 +1,51 @@
+"""Domain events for Ravn — emitted to output channels."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+
+class RavnEventType(StrEnum):
+    THOUGHT = "thought"
+    TOOL_START = "tool_start"
+    TOOL_RESULT = "tool_result"
+    RESPONSE = "response"
+    ERROR = "error"
+
+
+@dataclass(frozen=True)
+class RavnEvent:
+    """An event emitted by the Ravn agent to its output channel."""
+
+    type: RavnEventType
+    data: str
+    metadata: dict = field(default_factory=dict)
+
+    @classmethod
+    def thought(cls, text: str) -> RavnEvent:
+        return cls(type=RavnEventType.THOUGHT, data=text)
+
+    @classmethod
+    def tool_start(cls, tool_name: str, tool_input: dict) -> RavnEvent:
+        return cls(
+            type=RavnEventType.TOOL_START,
+            data=tool_name,
+            metadata={"input": tool_input},
+        )
+
+    @classmethod
+    def tool_result(cls, tool_name: str, result: str, *, is_error: bool = False) -> RavnEvent:
+        return cls(
+            type=RavnEventType.TOOL_RESULT,
+            data=result,
+            metadata={"tool_name": tool_name, "is_error": is_error},
+        )
+
+    @classmethod
+    def response(cls, text: str) -> RavnEvent:
+        return cls(type=RavnEventType.RESPONSE, data=text)
+
+    @classmethod
+    def error(cls, message: str) -> RavnEvent:
+        return cls(type=RavnEventType.ERROR, data=message)

--- a/src/ravn/domain/exceptions.py
+++ b/src/ravn/domain/exceptions.py
@@ -1,0 +1,45 @@
+"""Domain exceptions for Ravn."""
+
+from __future__ import annotations
+
+
+class RavnError(Exception):
+    """Base exception for all Ravn errors."""
+
+
+class PermissionDeniedError(RavnError):
+    """Raised when a tool call is denied by the permission enforcer."""
+
+    def __init__(self, tool_name: str, permission: str) -> None:
+        self.tool_name = tool_name
+        self.permission = permission
+        super().__init__(f"Permission '{permission}' denied for tool '{tool_name}'")
+
+
+class ToolExecutionError(RavnError):
+    """Raised when a tool fails to execute."""
+
+    def __init__(self, tool_name: str, cause: Exception) -> None:
+        self.tool_name = tool_name
+        self.cause = cause
+        super().__init__(f"Tool '{tool_name}' failed: {cause}")
+
+
+class LLMError(RavnError):
+    """Raised when the LLM call fails after all retries."""
+
+    def __init__(self, message: str, status_code: int | None = None) -> None:
+        self.status_code = status_code
+        super().__init__(message)
+
+
+class MaxIterationsError(RavnError):
+    """Raised when the agent loop exceeds the maximum allowed iterations."""
+
+    def __init__(self, max_iterations: int) -> None:
+        self.max_iterations = max_iterations
+        super().__init__(f"Agent loop exceeded {max_iterations} iterations")
+
+
+class ConfigurationError(RavnError):
+    """Raised when Ravn is misconfigured."""

--- a/src/ravn/domain/models.py
+++ b/src/ravn/domain/models.py
@@ -1,0 +1,133 @@
+"""Domain models for Ravn."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from uuid import UUID, uuid4
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class StopReason(StrEnum):
+    END_TURN = "end_turn"
+    TOOL_USE = "tool_use"
+    MAX_TOKENS = "max_tokens"
+    STOP_SEQUENCE = "stop_sequence"
+
+
+class StreamEventType(StrEnum):
+    TEXT_DELTA = "text_delta"
+    TOOL_CALL = "tool_call"
+    MESSAGE_DONE = "message_done"
+
+
+# ---------------------------------------------------------------------------
+# Value objects
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TokenUsage:
+    """Token usage for a single LLM call or cumulative across a session."""
+
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+
+    @property
+    def total_tokens(self) -> int:
+        return self.input_tokens + self.output_tokens
+
+    def __add__(self, other: TokenUsage) -> TokenUsage:
+        return TokenUsage(
+            input_tokens=self.input_tokens + other.input_tokens,
+            output_tokens=self.output_tokens + other.output_tokens,
+            cache_read_tokens=self.cache_read_tokens + other.cache_read_tokens,
+            cache_write_tokens=self.cache_write_tokens + other.cache_write_tokens,
+        )
+
+
+@dataclass(frozen=True)
+class ToolCall:
+    """A tool invocation requested by the LLM."""
+
+    id: str
+    name: str
+    input: dict
+
+
+@dataclass(frozen=True)
+class ToolResult:
+    """The result of executing a tool."""
+
+    tool_call_id: str
+    content: str
+    is_error: bool = False
+
+
+@dataclass(frozen=True)
+class Message:
+    """A single message in a conversation."""
+
+    role: str  # "user" or "assistant"
+    content: str
+
+
+@dataclass(frozen=True)
+class LLMResponse:
+    """A complete (non-streaming) response from the LLM."""
+
+    content: str
+    tool_calls: list[ToolCall]
+    stop_reason: StopReason
+    usage: TokenUsage
+
+
+@dataclass(frozen=True)
+class StreamEvent:
+    """A single event from the LLM streaming API."""
+
+    type: StreamEventType
+    text: str | None = None
+    tool_call: ToolCall | None = None
+    usage: TokenUsage | None = None
+
+
+@dataclass(frozen=True)
+class TurnResult:
+    """The result of a single agent turn."""
+
+    response: str
+    tool_calls: list[ToolCall]
+    tool_results: list[ToolResult]
+    usage: TokenUsage
+
+
+# ---------------------------------------------------------------------------
+# Session
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Session:
+    """A Ravn conversation session."""
+
+    id: UUID = field(default_factory=uuid4)
+    messages: list[Message] = field(default_factory=list)
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    turn_count: int = 0
+    total_usage: TokenUsage = field(
+        default_factory=lambda: TokenUsage(input_tokens=0, output_tokens=0)
+    )
+
+    def add_message(self, message: Message) -> None:
+        self.messages.append(message)
+
+    def record_turn(self, usage: TokenUsage) -> None:
+        self.turn_count += 1
+        self.total_usage = self.total_usage + usage

--- a/src/ravn/domain/models.py
+++ b/src/ravn/domain/models.py
@@ -75,7 +75,7 @@ class Message:
     """A single message in a conversation."""
 
     role: str  # "user" or "assistant"
-    content: str
+    content: str | list[dict]
 
 
 @dataclass(frozen=True)

--- a/src/ravn/ports/__init__.py
+++ b/src/ravn/ports/__init__.py
@@ -1,0 +1,1 @@
+"""Ravn port interfaces."""

--- a/src/ravn/ports/channel.py
+++ b/src/ravn/ports/channel.py
@@ -1,0 +1,16 @@
+"""Channel port — interface for emitting agent events to an output surface."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from ravn.domain.events import RavnEvent
+
+
+class ChannelPort(ABC):
+    """Abstract interface for an output channel (CLI, web socket, etc.)."""
+
+    @abstractmethod
+    async def emit(self, event: RavnEvent) -> None:
+        """Emit a Ravn event to the output surface."""
+        ...

--- a/src/ravn/ports/llm.py
+++ b/src/ravn/ports/llm.py
@@ -1,0 +1,41 @@
+"""LLM port — interface for language model calls."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator
+
+from ravn.domain.models import LLMResponse, StreamEvent
+
+
+class LLMPort(ABC):
+    """Abstract interface for LLM streaming and generation with tool support."""
+
+    @abstractmethod
+    def stream(
+        self,
+        messages: list[dict],
+        *,
+        tools: list[dict],
+        system: str,
+        model: str,
+        max_tokens: int,
+    ) -> AsyncIterator[StreamEvent]:
+        """Stream a response from the LLM, yielding events as they arrive.
+
+        Yields StreamEvent objects with TEXT_DELTA, TOOL_CALL, and MESSAGE_DONE types.
+        """
+        ...
+
+    @abstractmethod
+    async def generate(
+        self,
+        messages: list[dict],
+        *,
+        tools: list[dict],
+        system: str,
+        model: str,
+        max_tokens: int,
+    ) -> LLMResponse:
+        """Generate a complete (non-streaming) response from the LLM."""
+        ...

--- a/src/ravn/ports/permission.py
+++ b/src/ravn/ports/permission.py
@@ -1,0 +1,23 @@
+"""Permission port — interface for tool execution authorization."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from enum import StrEnum
+
+
+class PermissionMode(StrEnum):
+    """Built-in permission modes."""
+
+    ALLOW_ALL = "allow_all"
+    DENY_ALL = "deny_all"
+    PROMPT = "prompt"
+
+
+class PermissionPort(ABC):
+    """Abstract interface for checking tool execution permissions."""
+
+    @abstractmethod
+    async def check(self, permission: str) -> bool:
+        """Return True if the given permission is granted, False to deny."""
+        ...

--- a/src/ravn/ports/tool.py
+++ b/src/ravn/ports/tool.py
@@ -1,0 +1,48 @@
+"""Tool port — interface for agent tools."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from ravn.domain.models import ToolResult
+
+
+class ToolPort(ABC):
+    """Abstract interface for a tool the agent can call."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Unique tool name used by the LLM."""
+        ...
+
+    @property
+    @abstractmethod
+    def description(self) -> str:
+        """Human-readable description of what the tool does."""
+        ...
+
+    @property
+    @abstractmethod
+    def input_schema(self) -> dict:
+        """JSON Schema for the tool's input parameters."""
+        ...
+
+    @property
+    @abstractmethod
+    def required_permission(self) -> str:
+        """Permission string that must be granted before this tool executes."""
+        ...
+
+    @abstractmethod
+    async def execute(self, input: dict) -> ToolResult:
+        """Execute the tool with the given input and return a result."""
+        ...
+
+    def to_api_dict(self) -> dict:
+        """Serialize to the Anthropic tool definition format."""
+        return {
+            "name": self.name,
+            "description": self.description,
+            "input_schema": self.input_schema,
+        }

--- a/tests/test_ravn/conftest.py
+++ b/tests/test_ravn/conftest.py
@@ -1,0 +1,135 @@
+"""Shared fixtures for Ravn tests."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ravn.domain.events import RavnEvent
+from ravn.domain.models import (
+    LLMResponse,
+    StopReason,
+    StreamEvent,
+    StreamEventType,
+    TokenUsage,
+    ToolResult,
+)
+from ravn.ports.channel import ChannelPort
+from ravn.ports.llm import LLMPort
+from ravn.ports.permission import PermissionPort
+from ravn.ports.tool import ToolPort
+
+
+class InMemoryChannel(ChannelPort):
+    """Records all emitted events for assertion in tests."""
+
+    def __init__(self) -> None:
+        self.events: list[RavnEvent] = []
+
+    async def emit(self, event: RavnEvent) -> None:
+        self.events.append(event)
+
+
+class AllowAllPermission(PermissionPort):
+    async def check(self, permission: str) -> bool:
+        return True
+
+
+class DenyAllPermission(PermissionPort):
+    async def check(self, permission: str) -> bool:
+        return False
+
+
+class EchoTool(ToolPort):
+    """A test tool that echoes its input back."""
+
+    @property
+    def name(self) -> str:
+        return "echo"
+
+    @property
+    def description(self) -> str:
+        return "Echoes the message back."
+
+    @property
+    def input_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {"message": {"type": "string"}},
+            "required": ["message"],
+        }
+
+    @property
+    def required_permission(self) -> str:
+        return "tool:echo"
+
+    async def execute(self, input: dict) -> ToolResult:
+        return ToolResult(tool_call_id="", content=input.get("message", ""))
+
+
+class FailingTool(ToolPort):
+    """A test tool that always raises an exception."""
+
+    @property
+    def name(self) -> str:
+        return "fail"
+
+    @property
+    def description(self) -> str:
+        return "Always fails."
+
+    @property
+    def input_schema(self) -> dict:
+        return {"type": "object", "properties": {}}
+
+    @property
+    def required_permission(self) -> str:
+        return "tool:fail"
+
+    async def execute(self, input: dict) -> ToolResult:
+        raise RuntimeError("intentional failure")
+
+
+def make_simple_llm(response_text: str = "Hello!") -> LLMPort:
+    """Build a mock LLM that returns a simple text response."""
+
+    async def _stream(*args, **kwargs) -> AsyncIterator[StreamEvent]:
+        yield StreamEvent(type=StreamEventType.TEXT_DELTA, text=response_text)
+        yield StreamEvent(
+            type=StreamEventType.MESSAGE_DONE,
+            usage=TokenUsage(input_tokens=10, output_tokens=5),
+        )
+
+    llm = AsyncMock(spec=LLMPort)
+    llm.stream = _stream
+    llm.generate = AsyncMock(
+        return_value=LLMResponse(
+            content=response_text,
+            tool_calls=[],
+            stop_reason=StopReason.END_TURN,
+            usage=TokenUsage(input_tokens=10, output_tokens=5),
+        )
+    )
+    return llm
+
+
+@pytest.fixture
+def channel() -> InMemoryChannel:
+    return InMemoryChannel()
+
+
+@pytest.fixture
+def allow_permission() -> AllowAllPermission:
+    return AllowAllPermission()
+
+
+@pytest.fixture
+def deny_permission() -> DenyAllPermission:
+    return DenyAllPermission()
+
+
+@pytest.fixture
+def echo_tool() -> EchoTool:
+    return EchoTool()

--- a/tests/test_ravn/test_agent.py
+++ b/tests/test_ravn/test_agent.py
@@ -1,0 +1,382 @@
+"""Tests for the Ravn agent loop."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ravn.agent import RavnAgent, _build_assistant_content
+from ravn.domain.events import RavnEventType
+from ravn.domain.exceptions import MaxIterationsError
+from ravn.domain.models import (
+    LLMResponse,
+    StopReason,
+    StreamEvent,
+    StreamEventType,
+    TokenUsage,
+    ToolCall,
+    ToolResult,
+)
+from ravn.ports.llm import LLMPort
+from tests.test_ravn.conftest import (
+    AllowAllPermission,
+    DenyAllPermission,
+    EchoTool,
+    FailingTool,
+    InMemoryChannel,
+    make_simple_llm,
+)
+
+
+def make_agent(
+    llm: LLMPort,
+    tools=None,
+    *,
+    channel: InMemoryChannel | None = None,
+    permission=None,
+    max_iterations: int = 10,
+) -> tuple[RavnAgent, InMemoryChannel]:
+    ch = channel or InMemoryChannel()
+    perm = permission or AllowAllPermission()
+    agent = RavnAgent(
+        llm=llm,
+        tools=tools or [],
+        channel=ch,
+        permission=perm,
+        system_prompt="You are a test assistant.",
+        model="claude-sonnet-4-6",
+        max_tokens=1024,
+        max_iterations=max_iterations,
+    )
+    return agent, ch
+
+
+class TestRavnAgentSimpleTurn:
+    async def test_simple_response(self) -> None:
+        llm = make_simple_llm("Hello, world!")
+        agent, channel = make_agent(llm)
+
+        result = await agent.run_turn("Hi")
+
+        assert result.response == "Hello, world!"
+        assert result.tool_calls == []
+        assert result.tool_results == []
+        assert result.usage.input_tokens == 10
+        assert result.usage.output_tokens == 5
+
+    async def test_session_updated(self) -> None:
+        llm = make_simple_llm("response")
+        agent, _ = make_agent(llm)
+
+        await agent.run_turn("Hello")
+
+        assert agent.session.turn_count == 1
+        assert len(agent.session.messages) == 2
+        assert agent.session.messages[0].role == "user"
+        assert agent.session.messages[1].role == "assistant"
+
+    async def test_channel_receives_thought_and_response(self) -> None:
+        llm = make_simple_llm("Hi!")
+        agent, channel = make_agent(llm)
+
+        await agent.run_turn("Hey")
+
+        event_types = [e.type for e in channel.events]
+        assert RavnEventType.THOUGHT in event_types
+        assert RavnEventType.RESPONSE in event_types
+
+    async def test_cumulative_usage_tracked(self) -> None:
+        llm = make_simple_llm("ok")
+        agent, _ = make_agent(llm)
+
+        await agent.run_turn("turn 1")
+        await agent.run_turn("turn 2")
+
+        assert agent.session.turn_count == 2
+        assert agent.session.total_usage.input_tokens == 20
+
+
+class TestRavnAgentToolUse:
+    async def test_tool_executed_and_result_fed_back(self) -> None:
+        """LLM requests tool_use → tool runs → second call returns final text."""
+        tool = EchoTool()
+        tool_call = ToolCall(id="tc1", name="echo", input={"message": "ping"})
+
+        call_count = 0
+
+        async def _stream(*args, **kwargs) -> AsyncIterator[StreamEvent]:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # First call: return tool_use
+                yield StreamEvent(type=StreamEventType.TOOL_CALL, tool_call=tool_call)
+                yield StreamEvent(
+                    type=StreamEventType.MESSAGE_DONE,
+                    usage=TokenUsage(input_tokens=5, output_tokens=2),
+                )
+            else:
+                # Second call: return final answer
+                yield StreamEvent(type=StreamEventType.TEXT_DELTA, text="pong received")
+                yield StreamEvent(
+                    type=StreamEventType.MESSAGE_DONE,
+                    usage=TokenUsage(input_tokens=8, output_tokens=3),
+                )
+
+        llm = AsyncMock(spec=LLMPort)
+        llm.stream = _stream
+
+        agent, channel = make_agent(llm, tools=[tool])
+        result = await agent.run_turn("echo ping")
+
+        assert result.response == "pong received"
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].name == "echo"
+        assert len(result.tool_results) == 1
+        assert result.tool_results[0].content == "ping"
+
+    async def test_tool_start_event_emitted(self) -> None:
+        tool = EchoTool()
+        tool_call = ToolCall(id="tc1", name="echo", input={"message": "hi"})
+
+        call_count = 0
+
+        async def _stream(*args, **kwargs) -> AsyncIterator[StreamEvent]:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                yield StreamEvent(type=StreamEventType.TOOL_CALL, tool_call=tool_call)
+                yield StreamEvent(
+                    type=StreamEventType.MESSAGE_DONE,
+                    usage=TokenUsage(input_tokens=5, output_tokens=2),
+                )
+            else:
+                yield StreamEvent(type=StreamEventType.TEXT_DELTA, text="done")
+                yield StreamEvent(
+                    type=StreamEventType.MESSAGE_DONE,
+                    usage=TokenUsage(input_tokens=5, output_tokens=2),
+                )
+
+        llm = AsyncMock(spec=LLMPort)
+        llm.stream = _stream
+        agent, channel = make_agent(llm, tools=[tool])
+        await agent.run_turn("go")
+
+        event_types = [e.type for e in channel.events]
+        assert RavnEventType.TOOL_START in event_types
+        assert RavnEventType.TOOL_RESULT in event_types
+
+    async def test_unknown_tool_returns_error(self) -> None:
+        tool_call = ToolCall(id="tc1", name="nonexistent", input={})
+
+        async def _stream(*args, **kwargs) -> AsyncIterator[StreamEvent]:
+            yield StreamEvent(type=StreamEventType.TOOL_CALL, tool_call=tool_call)
+            yield StreamEvent(
+                type=StreamEventType.MESSAGE_DONE,
+                usage=TokenUsage(input_tokens=5, output_tokens=2),
+            )
+            # Need a second pass to end:
+
+        call_count = 0
+
+        async def _stream2(*args, **kwargs) -> AsyncIterator[StreamEvent]:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                yield StreamEvent(type=StreamEventType.TOOL_CALL, tool_call=tool_call)
+                yield StreamEvent(
+                    type=StreamEventType.MESSAGE_DONE,
+                    usage=TokenUsage(input_tokens=5, output_tokens=2),
+                )
+            else:
+                yield StreamEvent(type=StreamEventType.TEXT_DELTA, text="ok")
+                yield StreamEvent(
+                    type=StreamEventType.MESSAGE_DONE,
+                    usage=TokenUsage(input_tokens=5, output_tokens=2),
+                )
+
+        llm = AsyncMock(spec=LLMPort)
+        llm.stream = _stream2
+        agent, channel = make_agent(llm, tools=[])
+        await agent.run_turn("go")
+
+        error_events = [e for e in channel.events if e.type == RavnEventType.TOOL_RESULT]
+        assert any(e.metadata.get("is_error") for e in error_events)
+
+    async def test_permission_denied_returns_error(self) -> None:
+        tool = EchoTool()
+        tool_call = ToolCall(id="tc1", name="echo", input={"message": "hi"})
+
+        call_count = 0
+
+        async def _stream(*args, **kwargs) -> AsyncIterator[StreamEvent]:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                yield StreamEvent(type=StreamEventType.TOOL_CALL, tool_call=tool_call)
+                yield StreamEvent(
+                    type=StreamEventType.MESSAGE_DONE,
+                    usage=TokenUsage(input_tokens=5, output_tokens=2),
+                )
+            else:
+                yield StreamEvent(type=StreamEventType.TEXT_DELTA, text="denied handled")
+                yield StreamEvent(
+                    type=StreamEventType.MESSAGE_DONE,
+                    usage=TokenUsage(input_tokens=5, output_tokens=2),
+                )
+
+        llm = AsyncMock(spec=LLMPort)
+        llm.stream = _stream
+        agent, channel = make_agent(llm, tools=[tool], permission=DenyAllPermission())
+        await agent.run_turn("go")
+
+        tool_result_events = [e for e in channel.events if e.type == RavnEventType.TOOL_RESULT]
+        assert any(e.metadata.get("is_error") for e in tool_result_events)
+
+    async def test_tool_exception_returns_error_result(self) -> None:
+        tool = FailingTool()
+        tool_call = ToolCall(id="tc1", name="fail", input={})
+
+        call_count = 0
+
+        async def _stream(*args, **kwargs) -> AsyncIterator[StreamEvent]:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                yield StreamEvent(type=StreamEventType.TOOL_CALL, tool_call=tool_call)
+                yield StreamEvent(
+                    type=StreamEventType.MESSAGE_DONE,
+                    usage=TokenUsage(input_tokens=5, output_tokens=2),
+                )
+            else:
+                yield StreamEvent(type=StreamEventType.TEXT_DELTA, text="handled error")
+                yield StreamEvent(
+                    type=StreamEventType.MESSAGE_DONE,
+                    usage=TokenUsage(input_tokens=5, output_tokens=2),
+                )
+
+        llm = AsyncMock(spec=LLMPort)
+        llm.stream = _stream
+        agent, channel = make_agent(llm, tools=[tool])
+        result = await agent.run_turn("go")
+
+        assert len(result.tool_results) == 1
+        assert result.tool_results[0].is_error is True
+        assert "intentional failure" in result.tool_results[0].content
+
+    async def test_max_iterations_raises(self) -> None:
+        """Agent that always returns tool_use should hit the iteration limit."""
+        tool = EchoTool()
+        tool_call = ToolCall(id="tc1", name="echo", input={"message": "loop"})
+
+        async def _stream(*args, **kwargs) -> AsyncIterator[StreamEvent]:
+            yield StreamEvent(type=StreamEventType.TOOL_CALL, tool_call=tool_call)
+            yield StreamEvent(
+                type=StreamEventType.MESSAGE_DONE,
+                usage=TokenUsage(input_tokens=1, output_tokens=1),
+            )
+
+        llm = AsyncMock(spec=LLMPort)
+        llm.stream = _stream
+
+        agent, _ = make_agent(llm, tools=[tool], max_iterations=3)
+
+        with pytest.raises(MaxIterationsError) as exc_info:
+            await agent.run_turn("go")
+
+        assert exc_info.value.max_iterations == 3
+
+
+class TestRavnAgentHooks:
+    async def test_pre_and_post_hooks_called(self) -> None:
+        tool = EchoTool()
+        tool_call = ToolCall(id="tc1", name="echo", input={"message": "test"})
+        pre_calls: list[ToolCall] = []
+        post_calls: list[tuple[ToolCall, ToolResult]] = []
+
+        async def pre_hook(tc: ToolCall) -> None:
+            pre_calls.append(tc)
+
+        async def post_hook(tc: ToolCall, tr: ToolResult) -> None:
+            post_calls.append((tc, tr))
+
+        call_count = 0
+
+        async def _stream(*args, **kwargs) -> AsyncIterator[StreamEvent]:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                yield StreamEvent(type=StreamEventType.TOOL_CALL, tool_call=tool_call)
+                yield StreamEvent(
+                    type=StreamEventType.MESSAGE_DONE,
+                    usage=TokenUsage(input_tokens=5, output_tokens=2),
+                )
+            else:
+                yield StreamEvent(type=StreamEventType.TEXT_DELTA, text="done")
+                yield StreamEvent(
+                    type=StreamEventType.MESSAGE_DONE,
+                    usage=TokenUsage(input_tokens=5, output_tokens=2),
+                )
+
+        llm = AsyncMock(spec=LLMPort)
+        llm.stream = _stream
+        ch = InMemoryChannel()
+        agent = RavnAgent(
+            llm=llm,
+            tools=[tool],
+            channel=ch,
+            permission=AllowAllPermission(),
+            system_prompt="",
+            model="claude-sonnet-4-6",
+            max_tokens=1024,
+            max_iterations=10,
+            pre_tool_hooks=[pre_hook],
+            post_tool_hooks=[post_hook],
+        )
+        await agent.run_turn("go")
+
+        assert len(pre_calls) == 1
+        assert len(post_calls) == 1
+        assert pre_calls[0].name == "echo"
+        assert post_calls[0][1].content == "test"
+
+
+class TestBuildAssistantContent:
+    def test_text_only(self) -> None:
+        resp = LLMResponse(
+            content="hello",
+            tool_calls=[],
+            stop_reason=StopReason.END_TURN,
+            usage=TokenUsage(input_tokens=1, output_tokens=1),
+        )
+        blocks = _build_assistant_content(resp)
+        assert len(blocks) == 1
+        assert blocks[0] == {"type": "text", "text": "hello"}
+
+    def test_tool_calls_only(self) -> None:
+        tc = ToolCall(id="x", name="echo", input={"msg": "hi"})
+        resp = LLMResponse(
+            content="",
+            tool_calls=[tc],
+            stop_reason=StopReason.TOOL_USE,
+            usage=TokenUsage(input_tokens=1, output_tokens=1),
+        )
+        blocks = _build_assistant_content(resp)
+        assert len(blocks) == 1
+        assert blocks[0]["type"] == "tool_use"
+        assert blocks[0]["id"] == "x"
+        assert blocks[0]["name"] == "echo"
+
+    def test_text_and_tool_calls(self) -> None:
+        tc = ToolCall(id="y", name="run", input={})
+        resp = LLMResponse(
+            content="thinking...",
+            tool_calls=[tc],
+            stop_reason=StopReason.TOOL_USE,
+            usage=TokenUsage(input_tokens=1, output_tokens=1),
+        )
+        blocks = _build_assistant_content(resp)
+        assert len(blocks) == 2
+        assert blocks[0]["type"] == "text"
+        assert blocks[1]["type"] == "tool_use"

--- a/tests/test_ravn/test_anthropic_adapter.py
+++ b/tests/test_ravn/test_anthropic_adapter.py
@@ -1,0 +1,352 @@
+"""Tests for the AnthropicAdapter."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from ravn.adapters.anthropic_adapter import AnthropicAdapter
+from ravn.domain.exceptions import LLMError
+from ravn.domain.models import StopReason, StreamEventType
+
+
+class TestAnthropicAdapterInit:
+    def test_defaults(self) -> None:
+        adapter = AnthropicAdapter(api_key="test")
+        assert adapter._api_key == "test"
+        assert "api.anthropic.com" in adapter._base_url
+        assert adapter._default_max_tokens > 0
+        assert adapter._max_retries >= 0
+
+    def test_custom_base_url_trailing_slash_stripped(self) -> None:
+        adapter = AnthropicAdapter(api_key="k", base_url="http://proxy/")
+        assert not adapter._base_url.endswith("/")
+
+
+class TestAnthropicAdapterHeaders:
+    def test_headers_include_api_key(self) -> None:
+        adapter = AnthropicAdapter(api_key="my-key")
+        headers = adapter._headers()
+        assert headers["x-api-key"] == "my-key"
+        assert "anthropic-version" in headers
+
+    def test_headers_include_beta_for_caching(self) -> None:
+        adapter = AnthropicAdapter(api_key="k")
+        headers = adapter._headers()
+        assert "anthropic-beta" in headers
+
+
+class TestAnthropicAdapterBuildSystem:
+    def test_empty_system(self) -> None:
+        adapter = AnthropicAdapter(api_key="k")
+        assert adapter._build_system("") == []
+
+    def test_system_with_cache_control(self) -> None:
+        adapter = AnthropicAdapter(api_key="k")
+        blocks = adapter._build_system("You are helpful.")
+        assert len(blocks) == 1
+        assert blocks[0]["type"] == "text"
+        assert blocks[0]["text"] == "You are helpful."
+        assert blocks[0]["cache_control"] == {"type": "ephemeral"}
+
+
+class TestAnthropicAdapterBuildRequest:
+    def test_includes_tools_when_provided(self) -> None:
+        adapter = AnthropicAdapter(api_key="k")
+        tools = [{"name": "echo", "description": "...", "input_schema": {}}]
+        body = adapter._build_request(
+            [{"role": "user", "content": "hi"}],
+            tools=tools,
+            system="sys",
+            model="claude-sonnet-4-6",
+            max_tokens=1024,
+            stream=False,
+        )
+        assert "tools" in body
+        assert body["tools"] == tools
+
+    def test_omits_tools_when_empty(self) -> None:
+        adapter = AnthropicAdapter(api_key="k")
+        body = adapter._build_request(
+            [], tools=[], system="", model="claude-sonnet-4-6", max_tokens=1024, stream=False
+        )
+        assert "tools" not in body
+
+    def test_stream_flag(self) -> None:
+        adapter = AnthropicAdapter(api_key="k")
+        body = adapter._build_request(
+            [], tools=[], system="", model="m", max_tokens=100, stream=True
+        )
+        assert body["stream"] is True
+
+
+@respx.mock
+async def test_generate_success() -> None:
+    adapter = AnthropicAdapter(api_key="test-key", base_url="https://api.anthropic.com")
+
+    response_body = {
+        "id": "msg_123",
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "text", "text": "Hello!"}],
+        "model": "claude-sonnet-4-6",
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 10, "output_tokens": 5},
+    }
+
+    respx.post("https://api.anthropic.com/v1/messages").mock(
+        return_value=httpx.Response(200, json=response_body)
+    )
+
+    result = await adapter.generate(
+        [{"role": "user", "content": "Hi"}],
+        tools=[],
+        system="",
+        model="claude-sonnet-4-6",
+        max_tokens=1024,
+    )
+
+    assert result.content == "Hello!"
+    assert result.stop_reason == StopReason.END_TURN
+    assert result.usage.input_tokens == 10
+    assert result.usage.output_tokens == 5
+    assert result.tool_calls == []
+
+
+@respx.mock
+async def test_generate_with_tool_use() -> None:
+    adapter = AnthropicAdapter(api_key="test-key", base_url="https://api.anthropic.com")
+
+    response_body = {
+        "id": "msg_456",
+        "type": "message",
+        "role": "assistant",
+        "content": [
+            {"type": "tool_use", "id": "tu1", "name": "echo", "input": {"message": "hi"}},
+        ],
+        "model": "claude-sonnet-4-6",
+        "stop_reason": "tool_use",
+        "usage": {"input_tokens": 15, "output_tokens": 8},
+    }
+
+    respx.post("https://api.anthropic.com/v1/messages").mock(
+        return_value=httpx.Response(200, json=response_body)
+    )
+
+    result = await adapter.generate(
+        [{"role": "user", "content": "echo hi"}],
+        tools=[],
+        system="",
+        model="claude-sonnet-4-6",
+        max_tokens=1024,
+    )
+
+    assert result.stop_reason == StopReason.TOOL_USE
+    assert len(result.tool_calls) == 1
+    assert result.tool_calls[0].name == "echo"
+    assert result.tool_calls[0].input == {"message": "hi"}
+
+
+@respx.mock
+async def test_generate_error_response() -> None:
+    adapter = AnthropicAdapter(
+        api_key="test-key", base_url="https://api.anthropic.com", max_retries=0
+    )
+
+    respx.post("https://api.anthropic.com/v1/messages").mock(
+        return_value=httpx.Response(400, text="Bad request")
+    )
+
+    with pytest.raises(LLMError) as exc_info:
+        await adapter.generate(
+            [{"role": "user", "content": "hi"}],
+            tools=[],
+            system="",
+            model="claude-sonnet-4-6",
+            max_tokens=1024,
+        )
+
+    assert exc_info.value.status_code == 400
+
+
+@respx.mock
+async def test_generate_unknown_stop_reason() -> None:
+    adapter = AnthropicAdapter(api_key="test-key", base_url="https://api.anthropic.com")
+
+    response_body = {
+        "content": [{"type": "text", "text": "ok"}],
+        "stop_reason": "future_unknown_reason",
+        "usage": {"input_tokens": 1, "output_tokens": 1},
+    }
+
+    respx.post("https://api.anthropic.com/v1/messages").mock(
+        return_value=httpx.Response(200, json=response_body)
+    )
+
+    result = await adapter.generate([], tools=[], system="", model="m", max_tokens=100)
+    assert result.stop_reason == StopReason.END_TURN
+
+
+def _sse(event: dict) -> str:
+    return "data: " + json.dumps(event)
+
+
+def _text_block_sse(text: str, usage: dict | None = None) -> list[str]:
+    lines = [
+        _sse(
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "text", "text": ""},
+            }
+        ),
+        _sse(
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": text},
+            }
+        ),
+        _sse({"type": "content_block_stop", "index": 0}),
+        _sse(
+            {
+                "type": "message_delta",
+                "delta": {},
+                "usage": usage or {"output_tokens": 5, "input_tokens": 3},
+            }
+        ),
+    ]
+    return lines
+
+
+def _tool_block_sse(
+    tool_id: str, name: str, chunks: list[str], usage: dict | None = None
+) -> list[str]:
+    lines = [
+        _sse(
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "tool_use", "id": tool_id, "name": name},
+            }
+        ),
+    ]
+    for chunk in chunks:
+        lines.append(
+            _sse(
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "input_json_delta", "partial_json": chunk},
+                }
+            )
+        )
+    lines.append(_sse({"type": "content_block_stop", "index": 0}))
+    lines.append(
+        _sse(
+            {
+                "type": "message_delta",
+                "delta": {},
+                "usage": usage or {"output_tokens": 10, "input_tokens": 5},
+            }
+        )
+    )
+    return lines
+
+
+class TestStreamParsing:
+    """Tests for SSE stream parsing logic."""
+
+    @respx.mock
+    async def test_stream_text_delta(self) -> None:
+        adapter = AnthropicAdapter(api_key="k", base_url="https://api.anthropic.com")
+
+        lines = _text_block_sse("Hello", {"output_tokens": 5, "input_tokens": 3})
+        lines.append("data: [DONE]")
+        sse_body = "\n".join(lines) + "\n"
+
+        respx.post("https://api.anthropic.com/v1/messages").mock(
+            return_value=httpx.Response(
+                200, text=sse_body, headers={"content-type": "text/event-stream"}
+            )
+        )
+
+        events = []
+        async for event in adapter.stream(
+            [{"role": "user", "content": "hi"}],
+            tools=[],
+            system="",
+            model="claude-sonnet-4-6",
+            max_tokens=1024,
+        ):
+            events.append(event)
+
+        text_events = [e for e in events if e.type == StreamEventType.TEXT_DELTA]
+        assert len(text_events) >= 1
+        assert text_events[0].text == "Hello"
+
+        done_events = [e for e in events if e.type == StreamEventType.MESSAGE_DONE]
+        assert len(done_events) == 1
+        assert done_events[0].usage is not None
+
+    @respx.mock
+    async def test_stream_tool_call(self) -> None:
+        adapter = AnthropicAdapter(api_key="k", base_url="https://api.anthropic.com")
+
+        lines = _tool_block_sse("tu1", "echo", ['{"message":', '"hi"}'])
+        lines.append("data: [DONE]")
+        sse_body = "\n".join(lines) + "\n"
+
+        respx.post("https://api.anthropic.com/v1/messages").mock(
+            return_value=httpx.Response(
+                200, text=sse_body, headers={"content-type": "text/event-stream"}
+            )
+        )
+
+        events = []
+        async for event in adapter.stream(
+            [{"role": "user", "content": "echo hi"}],
+            tools=[],
+            system="",
+            model="claude-sonnet-4-6",
+            max_tokens=1024,
+        ):
+            events.append(event)
+
+        tool_events = [e for e in events if e.type == StreamEventType.TOOL_CALL]
+        assert len(tool_events) == 1
+        assert tool_events[0].tool_call is not None
+        assert tool_events[0].tool_call.name == "echo"
+        assert tool_events[0].tool_call.input == {"message": "hi"}
+
+    @respx.mock
+    async def test_stream_error_response(self) -> None:
+        adapter = AnthropicAdapter(api_key="k", base_url="https://api.anthropic.com", max_retries=0)
+
+        respx.post("https://api.anthropic.com/v1/messages").mock(
+            return_value=httpx.Response(500, text="server error")
+        )
+
+        with pytest.raises(LLMError):
+            async for _ in adapter.stream([], tools=[], system="", model="m", max_tokens=100):
+                pass
+
+    @respx.mock
+    async def test_stream_skips_non_data_lines(self) -> None:
+        adapter = AnthropicAdapter(api_key="k", base_url="https://api.anthropic.com")
+
+        lines = ["event: message_start", ""] + _text_block_sse("Hi")
+        sse_body = "\n".join(lines) + "\n"
+
+        respx.post("https://api.anthropic.com/v1/messages").mock(
+            return_value=httpx.Response(200, text=sse_body)
+        )
+
+        events = []
+        async for ev in adapter.stream([], tools=[], system="", model="m", max_tokens=100):
+            events.append(ev)
+
+        assert len(events) > 0

--- a/tests/test_ravn/test_anthropic_adapter_retry.py
+++ b/tests/test_ravn/test_anthropic_adapter_retry.py
@@ -1,0 +1,266 @@
+"""Tests for AnthropicAdapter retry logic and edge cases."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from ravn.adapters.anthropic_adapter import AnthropicAdapter
+from ravn.domain.exceptions import LLMError
+from ravn.domain.models import StreamEventType
+
+
+def _sse(event: dict) -> str:
+    return "data: " + json.dumps(event)
+
+
+def _text_block_sse(text: str) -> list[str]:
+    usage = {"output_tokens": 1, "input_tokens": 1}
+    return [
+        _sse(
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "text", "text": ""},
+            }
+        ),
+        _sse(
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": text},
+            }
+        ),
+        _sse({"type": "content_block_stop", "index": 0}),
+        _sse({"type": "message_delta", "delta": {}, "usage": usage}),
+    ]
+
+
+def _tool_block_sse(tool_id: str, name: str, chunk: str) -> list[str]:
+    usage = {"output_tokens": 1, "input_tokens": 1}
+    return [
+        _sse(
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "tool_use", "id": tool_id, "name": name},
+            }
+        ),
+        _sse(
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "input_json_delta", "partial_json": chunk},
+            }
+        ),
+        _sse({"type": "content_block_stop", "index": 0}),
+        _sse({"type": "message_delta", "delta": {}, "usage": usage}),
+    ]
+
+
+@respx.mock
+async def test_retry_on_429_then_success() -> None:
+    """Adapter retries on 429, succeeds on second attempt."""
+    adapter = AnthropicAdapter(
+        api_key="k",
+        base_url="https://api.anthropic.com",
+        max_retries=2,
+        retry_base_delay=0.0,
+    )
+
+    response_body = {
+        "content": [{"type": "text", "text": "ok"}],
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 5, "output_tokens": 3},
+    }
+
+    call_count = 0
+
+    def side_effect(request):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return httpx.Response(429, text="rate limited")
+        return httpx.Response(200, json=response_body)
+
+    respx.post("https://api.anthropic.com/v1/messages").mock(side_effect=side_effect)
+
+    result = await adapter.generate(
+        [{"role": "user", "content": "hi"}],
+        tools=[],
+        system="",
+        model="m",
+        max_tokens=100,
+    )
+
+    assert result.content == "ok"
+    assert call_count == 2
+
+
+@respx.mock
+async def test_retry_exhausted_raises_llm_error() -> None:
+    """Adapter raises LLMError when all retries are exhausted."""
+    adapter = AnthropicAdapter(
+        api_key="k",
+        base_url="https://api.anthropic.com",
+        max_retries=2,
+        retry_base_delay=0.0,
+    )
+
+    respx.post("https://api.anthropic.com/v1/messages").mock(
+        return_value=httpx.Response(500, text="server error")
+    )
+
+    with pytest.raises(LLMError):
+        await adapter.generate([], tools=[], system="", model="m", max_tokens=100)
+
+
+@respx.mock
+async def test_transport_error_retried() -> None:
+    """Adapter retries on transport errors."""
+    adapter = AnthropicAdapter(
+        api_key="k",
+        base_url="https://api.anthropic.com",
+        max_retries=1,
+        retry_base_delay=0.0,
+    )
+
+    response_body = {
+        "content": [{"type": "text", "text": "recovered"}],
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 1, "output_tokens": 1},
+    }
+
+    call_count = 0
+
+    def side_effect(request):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise httpx.ConnectError("connection refused")
+        return httpx.Response(200, json=response_body)
+
+    respx.post("https://api.anthropic.com/v1/messages").mock(side_effect=side_effect)
+
+    result = await adapter.generate([], tools=[], system="", model="m", max_tokens=100)
+    assert result.content == "recovered"
+
+
+@respx.mock
+async def test_transport_error_exhausted_raises() -> None:
+    """Adapter raises LLMError when transport errors exhaust all retries."""
+    adapter = AnthropicAdapter(
+        api_key="k",
+        base_url="https://api.anthropic.com",
+        max_retries=1,
+        retry_base_delay=0.0,
+    )
+
+    def side_effect(request):
+        raise httpx.ConnectError("connection refused")
+
+    respx.post("https://api.anthropic.com/v1/messages").mock(side_effect=side_effect)
+
+    with pytest.raises(LLMError):
+        await adapter.generate([], tools=[], system="", model="m", max_tokens=100)
+
+
+@respx.mock
+async def test_stream_invalid_json_skipped() -> None:
+    """Invalid JSON lines in SSE stream are skipped without crashing."""
+    adapter = AnthropicAdapter(api_key="k", base_url="https://api.anthropic.com")
+
+    lines = ["data: {invalid json}"] + _text_block_sse("ok")
+    sse_body = "\n".join(lines) + "\n"
+
+    respx.post("https://api.anthropic.com/v1/messages").mock(
+        return_value=httpx.Response(200, text=sse_body)
+    )
+
+    events = []
+    async for ev in adapter.stream([], tools=[], system="", model="m", max_tokens=100):
+        events.append(ev)
+
+    text_events = [e for e in events if e.type == StreamEventType.TEXT_DELTA]
+    assert len(text_events) >= 1
+
+
+@respx.mock
+async def test_stream_invalid_tool_json_handled() -> None:
+    """Invalid JSON in tool input is handled gracefully (empty dict)."""
+    adapter = AnthropicAdapter(api_key="k", base_url="https://api.anthropic.com")
+
+    lines = _tool_block_sse("x", "tool", "{invalid")
+    sse_body = "\n".join(lines) + "\n"
+
+    respx.post("https://api.anthropic.com/v1/messages").mock(
+        return_value=httpx.Response(200, text=sse_body)
+    )
+
+    events = []
+    async for ev in adapter.stream([], tools=[], system="", model="m", max_tokens=100):
+        events.append(ev)
+
+    tool_events = [e for e in events if e.type == StreamEventType.TOOL_CALL]
+    assert len(tool_events) == 1
+    assert tool_events[0].tool_call.input == {}
+
+
+@respx.mock
+async def test_stream_input_json_delta_without_prior_block_start() -> None:
+    """input_json_delta for unknown index is handled gracefully."""
+    adapter = AnthropicAdapter(api_key="k", base_url="https://api.anthropic.com")
+
+    # Send input_json_delta for index 99 without a prior content_block_start.
+    delta = {"type": "input_json_delta", "partial_json": '{"k":"v"}'}
+    usage = {"output_tokens": 1, "input_tokens": 1}
+    lines = [
+        _sse({"type": "content_block_delta", "index": 99, "delta": delta}),
+        _sse({"type": "message_delta", "delta": {}, "usage": usage}),
+    ]
+    sse_body = "\n".join(lines) + "\n"
+
+    respx.post("https://api.anthropic.com/v1/messages").mock(
+        return_value=httpx.Response(200, text=sse_body)
+    )
+
+    events = []
+    async for ev in adapter.stream([], tools=[], system="", model="m", max_tokens=100):
+        events.append(ev)
+
+    # Should complete without crashing — just emits MESSAGE_DONE.
+    done = [e for e in events if e.type == StreamEventType.MESSAGE_DONE]
+    assert len(done) == 1
+
+
+@respx.mock
+async def test_stream_retry_on_server_error() -> None:
+    """Stream retries on 500 errors."""
+    adapter = AnthropicAdapter(
+        api_key="k",
+        base_url="https://api.anthropic.com",
+        max_retries=2,
+        retry_base_delay=0.0,
+    )
+
+    sse_body = "\n".join(_text_block_sse("ok")) + "\n"
+
+    call_count = 0
+
+    def side_effect(request):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return httpx.Response(503, text="unavailable")
+        return httpx.Response(200, text=sse_body, headers={"content-type": "text/event-stream"})
+
+    respx.post("https://api.anthropic.com/v1/messages").mock(side_effect=side_effect)
+
+    events = []
+    async for ev in adapter.stream([], tools=[], system="", model="m", max_tokens=100):
+        events.append(ev)
+
+    assert call_count == 2

--- a/tests/test_ravn/test_anthropic_adapter_retry.py
+++ b/tests/test_ravn/test_anthropic_adapter_retry.py
@@ -237,6 +237,25 @@ async def test_stream_input_json_delta_without_prior_block_start() -> None:
 
 
 @respx.mock
+async def test_stream_retry_exhausted_raises_llm_error() -> None:
+    """Stream raises LLMError when all retries are exhausted (covers last-attempt close)."""
+    adapter = AnthropicAdapter(
+        api_key="k",
+        base_url="https://api.anthropic.com",
+        max_retries=1,
+        retry_base_delay=0.0,
+    )
+
+    respx.post("https://api.anthropic.com/v1/messages").mock(
+        return_value=httpx.Response(503, text="unavailable")
+    )
+
+    with pytest.raises(LLMError):
+        async for _ in adapter.stream([], tools=[], system="", model="m", max_tokens=100):
+            pass
+
+
+@respx.mock
 async def test_stream_retry_on_server_error() -> None:
     """Stream retries on 500 errors."""
     adapter = AnthropicAdapter(

--- a/tests/test_ravn/test_cli_channel.py
+++ b/tests/test_ravn/test_cli_channel.py
@@ -82,6 +82,21 @@ class TestCliChannel:
         assert "thinking" in output
         assert "echo" in output
 
+    async def test_custom_result_truncation_limit(self) -> None:
+        buf = io.StringIO()
+        ch = CliChannel(file=buf, result_truncation_limit=10)
+        await ch.emit(RavnEvent.tool_result("tool", "x" * 20))
+        output = buf.getvalue()
+        assert "…" in output
+        assert len(output) < 30
+
+    async def test_custom_input_value_limit(self) -> None:
+        buf = io.StringIO()
+        ch = CliChannel(file=buf, input_value_limit=5)
+        await ch.emit(RavnEvent.tool_start("t", {"k": "v" * 10}))
+        output = buf.getvalue()
+        assert "…" in output
+
 
 class TestFormatInput:
     def test_empty(self) -> None:
@@ -94,6 +109,10 @@ class TestFormatInput:
 
     def test_long_value_truncated(self) -> None:
         result = _format_input({"k": "v" * 100})
+        assert "…" in result
+
+    def test_custom_limit(self) -> None:
+        result = _format_input({"k": "v" * 10}, value_limit=5)
         assert "…" in result
 
     def test_multiple_keys(self) -> None:

--- a/tests/test_ravn/test_cli_channel.py
+++ b/tests/test_ravn/test_cli_channel.py
@@ -1,0 +1,103 @@
+"""Tests for the CliChannel adapter."""
+
+from __future__ import annotations
+
+import io
+
+from ravn.adapters.cli_channel import CliChannel, _format_input
+from ravn.domain.events import RavnEvent
+
+
+def make_channel() -> tuple[CliChannel, io.StringIO]:
+    buf = io.StringIO()
+    return CliChannel(file=buf), buf
+
+
+class TestCliChannel:
+    async def test_thought_emitted_inline(self) -> None:
+        ch, buf = make_channel()
+        await ch.emit(RavnEvent.thought("hello "))
+        await ch.emit(RavnEvent.thought("world"))
+        output = buf.getvalue()
+        assert "hello world" in output
+
+    async def test_response_adds_newline(self) -> None:
+        ch, buf = make_channel()
+        await ch.emit(RavnEvent.thought("text"))
+        await ch.emit(RavnEvent.response("text"))
+        output = buf.getvalue()
+        assert output.endswith("\n")
+
+    async def test_tool_start_printed(self) -> None:
+        ch, buf = make_channel()
+        await ch.emit(RavnEvent.tool_start("echo", {"message": "hi"}))
+        output = buf.getvalue()
+        assert "echo" in output
+
+    async def test_tool_result_success(self) -> None:
+        ch, buf = make_channel()
+        await ch.emit(RavnEvent.tool_result("echo", "pong"))
+        output = buf.getvalue()
+        assert "✓" in output
+        assert "pong" in output
+
+    async def test_tool_result_error(self) -> None:
+        ch, buf = make_channel()
+        await ch.emit(RavnEvent.tool_result("fail", "boom", is_error=True))
+        output = buf.getvalue()
+        assert "✗" in output
+
+    async def test_error_event(self) -> None:
+        ch, buf = make_channel()
+        await ch.emit(RavnEvent.error("bad thing"))
+        output = buf.getvalue()
+        assert "bad thing" in output
+        assert "error" in output
+
+    async def test_long_tool_result_truncated(self) -> None:
+        ch, buf = make_channel()
+        long_content = "x" * 600
+        await ch.emit(RavnEvent.tool_result("tool", long_content))
+        output = buf.getvalue()
+        assert "…" in output
+        assert len(output) < 600
+
+    def test_finish_adds_newline_if_in_response(self) -> None:
+        ch, buf = make_channel()
+        # Simulate a streaming response that hasn't ended yet.
+        ch._in_response = True
+        ch.finish()
+        assert buf.getvalue() == "\n"
+
+    def test_finish_noop_if_not_in_response(self) -> None:
+        ch, buf = make_channel()
+        ch.finish()
+        assert buf.getvalue() == ""
+
+    async def test_tool_start_after_thought_adds_newline(self) -> None:
+        ch, buf = make_channel()
+        await ch.emit(RavnEvent.thought("thinking"))
+        await ch.emit(RavnEvent.tool_start("echo", {}))
+        output = buf.getvalue()
+        assert "thinking" in output
+        assert "echo" in output
+
+
+class TestFormatInput:
+    def test_empty(self) -> None:
+        assert _format_input({}) == ""
+
+    def test_simple(self) -> None:
+        result = _format_input({"key": "value"})
+        assert "key=" in result
+        assert "value" in result
+
+    def test_long_value_truncated(self) -> None:
+        result = _format_input({"k": "v" * 100})
+        assert "…" in result
+
+    def test_multiple_keys(self) -> None:
+        result = _format_input({"a": "1", "b": "2"})
+        assert "a=" in result
+        assert "b=" in result
+        assert ", " in result

--- a/tests/test_ravn/test_cli_commands.py
+++ b/tests/test_ravn/test_cli_commands.py
@@ -1,0 +1,128 @@
+"""Tests for Ravn CLI commands."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from ravn.cli.commands import _print_usage, app
+from ravn.domain.models import (
+    StreamEvent,
+    StreamEventType,
+    TokenUsage,
+)
+
+runner = CliRunner()
+
+
+class TestPrintUsage:
+    def test_basic(self, capsys) -> None:
+        _print_usage(TokenUsage(input_tokens=10, output_tokens=5))
+        # Just verify it doesn't crash — the output goes through typer.echo.
+
+    def test_with_cache_tokens(self) -> None:
+        # Just verify no exception.
+        _print_usage(
+            TokenUsage(
+                input_tokens=10,
+                output_tokens=5,
+                cache_read_tokens=100,
+                cache_write_tokens=200,
+            )
+        )
+
+
+class TestRunCommand:
+    def test_no_api_key_exits(self) -> None:
+        with patch.dict("os.environ", {}, clear=False):
+            import os
+
+            env_without_key = {k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"}
+            with patch.dict("os.environ", env_without_key, clear=True):
+                result = runner.invoke(app, ["hi"])
+                assert result.exit_code != 0
+
+    def test_single_turn_with_mocked_agent(self) -> None:
+        """Test that run_turn is called with the given prompt."""
+
+        async def _stream(*args, **kwargs) -> AsyncIterator[StreamEvent]:
+            yield StreamEvent(type=StreamEventType.TEXT_DELTA, text="Hello!")
+            yield StreamEvent(
+                type=StreamEventType.MESSAGE_DONE,
+                usage=TokenUsage(input_tokens=10, output_tokens=5),
+            )
+
+        with (
+            patch("ravn.cli.commands.AnthropicAdapter") as mock_adapter_cls,
+            patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}),
+        ):
+            mock_adapter = MagicMock()
+            mock_adapter.stream = _stream
+            mock_adapter_cls.return_value = mock_adapter
+
+            result = runner.invoke(app, ["Hello, Ravn!"])
+            assert result.exit_code == 0
+
+    def test_single_turn_with_show_usage(self) -> None:
+        async def _stream(*args, **kwargs) -> AsyncIterator[StreamEvent]:
+            yield StreamEvent(type=StreamEventType.TEXT_DELTA, text="ok")
+            yield StreamEvent(
+                type=StreamEventType.MESSAGE_DONE,
+                usage=TokenUsage(input_tokens=5, output_tokens=3),
+            )
+
+        with (
+            patch("ravn.cli.commands.AnthropicAdapter") as mock_adapter_cls,
+            patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}),
+        ):
+            mock_adapter = MagicMock()
+            mock_adapter.stream = _stream
+            mock_adapter_cls.return_value = mock_adapter
+
+            result = runner.invoke(app, ["Hello!", "--show-usage"])
+            assert result.exit_code == 0
+            assert "tokens" in result.output
+
+    def test_help(self) -> None:
+        result = runner.invoke(app, ["--help"])
+        assert result.exit_code == 0
+        assert "ravn" in result.output.lower()
+
+    def test_no_tools_flag(self) -> None:
+        async def _stream(*args, **kwargs) -> AsyncIterator[StreamEvent]:
+            yield StreamEvent(type=StreamEventType.TEXT_DELTA, text="ok")
+            yield StreamEvent(
+                type=StreamEventType.MESSAGE_DONE,
+                usage=TokenUsage(input_tokens=5, output_tokens=3),
+            )
+
+        with (
+            patch("ravn.cli.commands.AnthropicAdapter") as mock_adapter_cls,
+            patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}),
+        ):
+            mock_adapter = MagicMock()
+            mock_adapter.stream = _stream
+            mock_adapter_cls.return_value = mock_adapter
+
+            result = runner.invoke(app, ["Hello!", "--no-tools"])
+            assert result.exit_code == 0
+
+
+class TestRunTurnErrorHandling:
+    def test_exception_exits_nonzero(self) -> None:
+        async def _stream(*args, **kwargs) -> AsyncIterator[StreamEvent]:
+            raise RuntimeError("boom")
+            yield  # make it a generator
+
+        with (
+            patch("ravn.cli.commands.AnthropicAdapter") as mock_adapter_cls,
+            patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}),
+        ):
+            mock_adapter = MagicMock()
+            mock_adapter.stream = _stream
+            mock_adapter_cls.return_value = mock_adapter
+
+            result = runner.invoke(app, ["Hello!"])
+            assert result.exit_code != 0 or "error" in result.output.lower()

--- a/tests/test_ravn/test_cli_commands.py
+++ b/tests/test_ravn/test_cli_commands.py
@@ -126,3 +126,20 @@ class TestRunTurnErrorHandling:
 
             result = runner.invoke(app, ["Hello!"])
             assert result.exit_code != 0 or "error" in result.output.lower()
+
+    async def test_repl_continues_after_error(self) -> None:
+        """In REPL mode (single_turn=False), an error prints but does not exit."""
+        from unittest.mock import AsyncMock
+
+        from ravn.adapters.cli_channel import CliChannel
+        from ravn.cli.commands import _run_turn
+
+        agent = MagicMock()
+        agent.run_turn = AsyncMock(side_effect=RuntimeError("boom"))
+
+        import io
+
+        channel = CliChannel(file=io.StringIO())
+
+        # Must not raise SystemExit
+        await _run_turn(agent, channel, "hi", show_usage=False, single_turn=False)

--- a/tests/test_ravn/test_config.py
+++ b/tests/test_ravn/test_config.py
@@ -82,3 +82,11 @@ class TestSettings:
         with patch.dict(os.environ, {"RAVN_AGENT__MODEL": "claude-haiku-4-5-20251001"}):
             s = Settings()
             assert s.agent.model == "claude-haiku-4-5-20251001"
+
+    def test_config_path_resolved_at_instantiation(self, tmp_path) -> None:
+        """RAVN_CONFIG set before Settings() is constructed is picked up."""
+        cfg = tmp_path / "custom.yaml"
+        cfg.write_text("agent:\n  model: claude-custom\n")
+        with patch.dict(os.environ, {"RAVN_CONFIG": str(cfg)}):
+            s = Settings()
+            assert s.agent.model == "claude-custom"

--- a/tests/test_ravn/test_config.py
+++ b/tests/test_ravn/test_config.py
@@ -1,0 +1,84 @@
+"""Tests for Ravn configuration."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+from ravn.config import (
+    AgentConfig,
+    AnthropicConfig,
+    LLMAdapterConfig,
+    LoggingConfig,
+    PermissionConfig,
+    Settings,
+)
+
+
+class TestAnthropicConfig:
+    def test_defaults(self) -> None:
+        c = AnthropicConfig()
+        assert c.api_key == ""
+        assert "api.anthropic.com" in c.base_url
+
+
+class TestAgentConfig:
+    def test_defaults(self) -> None:
+        c = AgentConfig()
+        assert "claude" in c.model
+        assert c.max_tokens > 0
+        assert c.max_iterations > 0
+        assert c.system_prompt != ""
+
+
+class TestLLMAdapterConfig:
+    def test_defaults(self) -> None:
+        c = LLMAdapterConfig()
+        assert "AnthropicAdapter" in c.adapter
+        assert c.max_retries >= 0
+        assert c.timeout > 0
+
+
+class TestPermissionConfig:
+    def test_defaults(self) -> None:
+        c = PermissionConfig()
+        assert c.mode == "allow_all"
+
+
+class TestLoggingConfig:
+    def test_defaults(self) -> None:
+        c = LoggingConfig()
+        assert c.level in ("debug", "info", "warning", "error", "critical", "warning")
+
+
+class TestSettings:
+    def test_defaults(self) -> None:
+        s = Settings()
+        assert isinstance(s.anthropic, AnthropicConfig)
+        assert isinstance(s.agent, AgentConfig)
+        assert isinstance(s.llm_adapter, LLMAdapterConfig)
+        assert isinstance(s.permission, PermissionConfig)
+        assert isinstance(s.logging, LoggingConfig)
+
+    def test_effective_api_key_from_env(self) -> None:
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "env-key"}):
+            s = Settings()
+            assert s.effective_api_key() == "env-key"
+
+    def test_effective_api_key_from_config(self) -> None:
+        with patch.dict(os.environ, {}, clear=False):
+            # Remove env var if set.
+            env_without_key = {k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"}
+            with patch.dict(os.environ, env_without_key, clear=True):
+                s = Settings(anthropic=AnthropicConfig(api_key="config-key"))
+                assert s.effective_api_key() == "config-key"
+
+    def test_effective_api_key_env_takes_precedence(self) -> None:
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "env-key"}):
+            s = Settings(anthropic=AnthropicConfig(api_key="config-key"))
+            assert s.effective_api_key() == "env-key"
+
+    def test_env_override(self) -> None:
+        with patch.dict(os.environ, {"RAVN_AGENT__MODEL": "claude-haiku-4-5-20251001"}):
+            s = Settings()
+            assert s.agent.model == "claude-haiku-4-5-20251001"

--- a/tests/test_ravn/test_events.py
+++ b/tests/test_ravn/test_events.py
@@ -1,0 +1,63 @@
+"""Tests for Ravn domain events."""
+
+from __future__ import annotations
+
+import pytest
+
+from ravn.domain.events import RavnEvent, RavnEventType
+
+
+class TestRavnEventType:
+    def test_values(self) -> None:
+        assert RavnEventType.THOUGHT == "thought"
+        assert RavnEventType.TOOL_START == "tool_start"
+        assert RavnEventType.TOOL_RESULT == "tool_result"
+        assert RavnEventType.RESPONSE == "response"
+        assert RavnEventType.ERROR == "error"
+
+    def test_member_count(self) -> None:
+        assert len(RavnEventType) == 5
+
+
+class TestRavnEvent:
+    def test_thought_factory(self) -> None:
+        ev = RavnEvent.thought("thinking...")
+        assert ev.type == RavnEventType.THOUGHT
+        assert ev.data == "thinking..."
+        assert ev.metadata == {}
+
+    def test_tool_start_factory(self) -> None:
+        ev = RavnEvent.tool_start("echo", {"message": "hi"})
+        assert ev.type == RavnEventType.TOOL_START
+        assert ev.data == "echo"
+        assert ev.metadata == {"input": {"message": "hi"}}
+
+    def test_tool_result_factory(self) -> None:
+        ev = RavnEvent.tool_result("echo", "pong")
+        assert ev.type == RavnEventType.TOOL_RESULT
+        assert ev.data == "pong"
+        assert ev.metadata["is_error"] is False
+        assert ev.metadata["tool_name"] == "echo"
+
+    def test_tool_result_error(self) -> None:
+        ev = RavnEvent.tool_result("fail", "boom", is_error=True)
+        assert ev.metadata["is_error"] is True
+
+    def test_response_factory(self) -> None:
+        ev = RavnEvent.response("Hello there!")
+        assert ev.type == RavnEventType.RESPONSE
+        assert ev.data == "Hello there!"
+
+    def test_error_factory(self) -> None:
+        ev = RavnEvent.error("something went wrong")
+        assert ev.type == RavnEventType.ERROR
+        assert ev.data == "something went wrong"
+
+    def test_frozen(self) -> None:
+        ev = RavnEvent.thought("test")
+        with pytest.raises(Exception):
+            ev.data = "other"  # type: ignore[misc]
+
+    def test_default_metadata(self) -> None:
+        ev = RavnEvent(type=RavnEventType.RESPONSE, data="hi")
+        assert ev.metadata == {}

--- a/tests/test_ravn/test_exceptions.py
+++ b/tests/test_ravn/test_exceptions.py
@@ -1,0 +1,77 @@
+"""Tests for Ravn domain exceptions."""
+
+from __future__ import annotations
+
+from ravn.domain.exceptions import (
+    ConfigurationError,
+    LLMError,
+    MaxIterationsError,
+    PermissionDeniedError,
+    RavnError,
+    ToolExecutionError,
+)
+
+
+class TestRavnError:
+    def test_is_exception(self) -> None:
+        e = RavnError("base error")
+        assert isinstance(e, Exception)
+        assert str(e) == "base error"
+
+
+class TestPermissionDeniedError:
+    def test_fields(self) -> None:
+        e = PermissionDeniedError("echo", "tool:echo")
+        assert e.tool_name == "echo"
+        assert e.permission == "tool:echo"
+        assert "echo" in str(e)
+        assert "tool:echo" in str(e)
+
+    def test_is_ravn_error(self) -> None:
+        e = PermissionDeniedError("x", "y")
+        assert isinstance(e, RavnError)
+
+
+class TestToolExecutionError:
+    def test_fields(self) -> None:
+        cause = ValueError("bad input")
+        e = ToolExecutionError("my_tool", cause)
+        assert e.tool_name == "my_tool"
+        assert e.cause is cause
+        assert "my_tool" in str(e)
+
+    def test_is_ravn_error(self) -> None:
+        e = ToolExecutionError("t", Exception())
+        assert isinstance(e, RavnError)
+
+
+class TestLLMError:
+    def test_without_status_code(self) -> None:
+        e = LLMError("connection failed")
+        assert e.status_code is None
+        assert str(e) == "connection failed"
+
+    def test_with_status_code(self) -> None:
+        e = LLMError("rate limited", status_code=429)
+        assert e.status_code == 429
+
+    def test_is_ravn_error(self) -> None:
+        e = LLMError("x")
+        assert isinstance(e, RavnError)
+
+
+class TestMaxIterationsError:
+    def test_fields(self) -> None:
+        e = MaxIterationsError(20)
+        assert e.max_iterations == 20
+        assert "20" in str(e)
+
+    def test_is_ravn_error(self) -> None:
+        e = MaxIterationsError(5)
+        assert isinstance(e, RavnError)
+
+
+class TestConfigurationError:
+    def test_is_ravn_error(self) -> None:
+        e = ConfigurationError("bad config")
+        assert isinstance(e, RavnError)

--- a/tests/test_ravn/test_models.py
+++ b/tests/test_ravn/test_models.py
@@ -1,0 +1,159 @@
+"""Tests for Ravn domain models."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+import pytest
+
+from ravn.domain.models import (
+    LLMResponse,
+    Message,
+    Session,
+    StopReason,
+    StreamEvent,
+    StreamEventType,
+    TokenUsage,
+    ToolCall,
+    ToolResult,
+    TurnResult,
+)
+
+
+class TestTokenUsage:
+    def test_total_tokens(self) -> None:
+        u = TokenUsage(input_tokens=10, output_tokens=5)
+        assert u.total_tokens == 15
+
+    def test_add(self) -> None:
+        a = TokenUsage(input_tokens=10, output_tokens=5, cache_read_tokens=2)
+        b = TokenUsage(input_tokens=20, output_tokens=10, cache_write_tokens=3)
+        result = a + b
+        assert result.input_tokens == 30
+        assert result.output_tokens == 15
+        assert result.cache_read_tokens == 2
+        assert result.cache_write_tokens == 3
+
+    def test_defaults(self) -> None:
+        u = TokenUsage(input_tokens=1, output_tokens=1)
+        assert u.cache_read_tokens == 0
+        assert u.cache_write_tokens == 0
+
+    def test_frozen(self) -> None:
+        u = TokenUsage(input_tokens=1, output_tokens=1)
+        with pytest.raises(Exception):
+            u.input_tokens = 99  # type: ignore[misc]
+
+
+class TestToolCall:
+    def test_fields(self) -> None:
+        tc = ToolCall(id="id1", name="echo", input={"message": "hi"})
+        assert tc.id == "id1"
+        assert tc.name == "echo"
+        assert tc.input == {"message": "hi"}
+
+    def test_frozen(self) -> None:
+        tc = ToolCall(id="id1", name="echo", input={})
+        with pytest.raises(Exception):
+            tc.name = "other"  # type: ignore[misc]
+
+
+class TestToolResult:
+    def test_defaults(self) -> None:
+        r = ToolResult(tool_call_id="x", content="ok")
+        assert r.is_error is False
+
+    def test_error(self) -> None:
+        r = ToolResult(tool_call_id="x", content="boom", is_error=True)
+        assert r.is_error is True
+
+
+class TestMessage:
+    def test_user_message(self) -> None:
+        m = Message(role="user", content="Hello")
+        assert m.role == "user"
+        assert m.content == "Hello"
+
+    def test_frozen(self) -> None:
+        m = Message(role="user", content="Hello")
+        with pytest.raises(Exception):
+            m.content = "other"  # type: ignore[misc]
+
+
+class TestStopReason:
+    def test_values(self) -> None:
+        assert StopReason.END_TURN == "end_turn"
+        assert StopReason.TOOL_USE == "tool_use"
+        assert StopReason.MAX_TOKENS == "max_tokens"
+        assert StopReason.STOP_SEQUENCE == "stop_sequence"
+
+
+class TestStreamEvent:
+    def test_text_delta(self) -> None:
+        ev = StreamEvent(type=StreamEventType.TEXT_DELTA, text="hello")
+        assert ev.type == StreamEventType.TEXT_DELTA
+        assert ev.text == "hello"
+        assert ev.tool_call is None
+        assert ev.usage is None
+
+    def test_tool_call_event(self) -> None:
+        tc = ToolCall(id="1", name="echo", input={})
+        ev = StreamEvent(type=StreamEventType.TOOL_CALL, tool_call=tc)
+        assert ev.tool_call is tc
+
+    def test_message_done(self) -> None:
+        u = TokenUsage(input_tokens=5, output_tokens=3)
+        ev = StreamEvent(type=StreamEventType.MESSAGE_DONE, usage=u)
+        assert ev.usage is u
+
+
+class TestLLMResponse:
+    def test_fields(self) -> None:
+        r = LLMResponse(
+            content="Hello",
+            tool_calls=[],
+            stop_reason=StopReason.END_TURN,
+            usage=TokenUsage(input_tokens=5, output_tokens=3),
+        )
+        assert r.content == "Hello"
+        assert r.tool_calls == []
+        assert r.stop_reason == StopReason.END_TURN
+
+
+class TestTurnResult:
+    def test_fields(self) -> None:
+        tr = TurnResult(
+            response="OK",
+            tool_calls=[],
+            tool_results=[],
+            usage=TokenUsage(input_tokens=1, output_tokens=1),
+        )
+        assert tr.response == "OK"
+
+
+class TestSession:
+    def test_defaults(self) -> None:
+        s = Session()
+        assert isinstance(s.id, UUID)
+        assert s.messages == []
+        assert s.turn_count == 0
+        assert s.total_usage.total_tokens == 0
+        assert isinstance(s.created_at, datetime)
+        assert s.created_at.tzinfo is not None
+
+    def test_add_message(self) -> None:
+        s = Session()
+        m = Message(role="user", content="hi")
+        s.add_message(m)
+        assert len(s.messages) == 1
+        assert s.messages[0] is m
+
+    def test_record_turn(self) -> None:
+        s = Session()
+        s.record_turn(TokenUsage(input_tokens=10, output_tokens=5))
+        assert s.turn_count == 1
+        assert s.total_usage.input_tokens == 10
+        s.record_turn(TokenUsage(input_tokens=20, output_tokens=8))
+        assert s.turn_count == 2
+        assert s.total_usage.input_tokens == 30

--- a/tests/test_ravn/test_models.py
+++ b/tests/test_ravn/test_models.py
@@ -75,6 +75,11 @@ class TestMessage:
         assert m.role == "user"
         assert m.content == "Hello"
 
+    def test_content_as_list(self) -> None:
+        blocks = [{"type": "text", "text": "hi"}, {"type": "tool_use", "id": "x"}]
+        m = Message(role="assistant", content=blocks)
+        assert m.content == blocks
+
     def test_frozen(self) -> None:
         m = Message(role="user", content="Hello")
         with pytest.raises(Exception):

--- a/tests/test_ravn/test_permission_adapter.py
+++ b/tests/test_ravn/test_permission_adapter.py
@@ -1,0 +1,39 @@
+"""Tests for built-in permission adapters."""
+
+from __future__ import annotations
+
+from ravn.adapters.permission_adapter import (
+    AllowAllPermission,
+    AllowListPermission,
+    DenyAllPermission,
+)
+
+
+class TestAllowAllPermission:
+    async def test_allows_any(self) -> None:
+        p = AllowAllPermission()
+        assert await p.check("tool:anything") is True
+        assert await p.check("some:random:permission") is True
+        assert await p.check("") is True
+
+
+class TestDenyAllPermission:
+    async def test_denies_any(self) -> None:
+        p = DenyAllPermission()
+        assert await p.check("tool:anything") is False
+        assert await p.check("") is False
+
+
+class TestAllowListPermission:
+    async def test_allows_listed(self) -> None:
+        p = AllowListPermission({"tool:echo", "tool:read"})
+        assert await p.check("tool:echo") is True
+        assert await p.check("tool:read") is True
+
+    async def test_denies_unlisted(self) -> None:
+        p = AllowListPermission({"tool:echo"})
+        assert await p.check("tool:write") is False
+
+    async def test_empty_list(self) -> None:
+        p = AllowListPermission(set())
+        assert await p.check("tool:anything") is False

--- a/tests/test_ravn/test_ports.py
+++ b/tests/test_ravn/test_ports.py
@@ -1,0 +1,28 @@
+"""Tests for port interfaces and ToolPort.to_api_dict()."""
+
+from __future__ import annotations
+
+from ravn.domain.models import ToolResult
+from tests.test_ravn.conftest import EchoTool
+
+
+class TestToolPort:
+    def test_to_api_dict(self) -> None:
+        tool = EchoTool()
+        d = tool.to_api_dict()
+        assert d["name"] == "echo"
+        assert d["description"] == "Echoes the message back."
+        assert "properties" in d["input_schema"]
+
+    def test_all_required_properties(self) -> None:
+        tool = EchoTool()
+        assert tool.name == "echo"
+        assert tool.description
+        assert tool.input_schema
+        assert tool.required_permission == "tool:echo"
+
+    async def test_execute(self) -> None:
+        tool = EchoTool()
+        result = await tool.execute({"message": "hello"})
+        assert isinstance(result, ToolResult)
+        assert result.content == "hello"


### PR DESCRIPTION
## Summary
Reopened from #289 — the original was accidentally merged into main via #290 (now reverted).

- Bootstraps `src/ravn/` package with hexagonal architecture
- Domain models, port interfaces, RavnAgent core loop
- AnthropicAdapter with streaming + retry
- CliChannel, permission adapters, config with YAML + env vars
- 119 tests, 95% coverage

## Test plan
- [ ] `pytest tests/test_ravn` — all passing
- [ ] `ruff check` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)