### PR TITLE
feat(adapters): tool registry + file tools (NIU-428)

### DIFF
--- a/src/ravn/adapters/file_security.py
+++ b/src/ravn/adapters/file_security.py
@@ -1,0 +1,77 @@
+"""File security utilities shared across all file tools."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Default limits (read from config at tool construction; these are fallbacks)
+# ---------------------------------------------------------------------------
+
+DEFAULT_MAX_READ_BYTES: int = 1 * 1024 * 1024  # 1 MB
+DEFAULT_MAX_WRITE_BYTES: int = 5 * 1024 * 1024  # 5 MB
+DEFAULT_BINARY_CHECK_BYTES: int = 8 * 1024  # 8 KB
+
+# ---------------------------------------------------------------------------
+# System path prefixes that are always rejected
+# ---------------------------------------------------------------------------
+
+_SYSTEM_PREFIXES: tuple[str, ...] = (
+    "/etc",
+    "/usr",
+    "/var",
+    "/boot",
+    "/sys",
+    "/proc",
+)
+
+
+class PathSecurityError(Exception):
+    """Raised when a path violates workspace or system-path constraints."""
+
+
+def resolve_safe(path: str | Path, workspace: Path) -> Path:
+    """Resolve *path* to an absolute path that lies within *workspace*.
+
+    Steps
+    -----
+    1. Resolve the path via ``Path.resolve()``, which normalises ``../``
+       components and follows any existing symlinks.
+    2. Verify the resolved path is inside *workspace*.
+    3. Verify the resolved path is not a system path (/etc, /usr, …).
+
+    The path need not exist (useful for write targets).
+
+    Raises
+    ------
+    PathSecurityError
+        If the path escapes the workspace or matches a system prefix.
+    """
+    workspace = workspace.resolve()
+    resolved = Path(path).resolve()
+
+    _assert_within(resolved, workspace)
+    _assert_not_system(resolved)
+
+    return resolved
+
+
+def _assert_within(path: Path, workspace: Path) -> None:
+    """Raise PathSecurityError if *path* is not a sub-path of *workspace*."""
+    try:
+        path.relative_to(workspace)
+    except ValueError:
+        raise PathSecurityError(f"Path '{path}' is outside the workspace '{workspace}'")
+
+
+def _assert_not_system(path: Path) -> None:
+    """Raise PathSecurityError if *path* starts with a system prefix."""
+    path_str = str(path)
+    for prefix in _SYSTEM_PREFIXES:
+        if path_str == prefix or path_str.startswith(prefix + "/"):
+            raise PathSecurityError(f"Access to system path '{path}' is not allowed")
+
+
+def is_binary(data: bytes, check_bytes: int = DEFAULT_BINARY_CHECK_BYTES) -> bool:
+    """Return True if *data* looks like binary content (contains NUL bytes)."""
+    return b"\x00" in data[:check_bytes]

--- a/src/ravn/adapters/file_tools.py
+++ b/src/ravn/adapters/file_tools.py
@@ -1,0 +1,480 @@
+"""File operation tools for Ravn agents."""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+
+from ravn.adapters.file_security import (
+    DEFAULT_BINARY_CHECK_BYTES,
+    DEFAULT_MAX_READ_BYTES,
+    DEFAULT_MAX_WRITE_BYTES,
+    PathSecurityError,
+    is_binary,
+    resolve_safe,
+)
+from ravn.domain.models import ToolResult
+from ravn.ports.tool import ToolPort
+
+logger = logging.getLogger(__name__)
+
+_PERMISSION_READ = "file:read"
+_PERMISSION_WRITE = "file:write"
+
+
+class ReadFileTool(ToolPort):
+    """Read a file's contents with 1-based line numbers."""
+
+    def __init__(
+        self,
+        workspace: Path,
+        max_bytes: int = DEFAULT_MAX_READ_BYTES,
+    ) -> None:
+        self._workspace = workspace
+        self._max_bytes = max_bytes
+
+    @property
+    def name(self) -> str:
+        return "read_file"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Read the contents of a file. "
+            "Returns lines prefixed with their 1-based line number. "
+            "Use offset and limit to page through large files."
+        )
+
+    @property
+    def input_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string", "description": "Path to the file to read."},
+                "offset": {
+                    "type": "integer",
+                    "description": "1-based line number to start reading from (default: 1).",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of lines to return.",
+                },
+            },
+            "required": ["path"],
+        }
+
+    @property
+    def required_permission(self) -> str:
+        return _PERMISSION_READ
+
+    async def execute(self, input: dict) -> ToolResult:
+        path_str = input.get("path", "")
+        offset = input.get("offset", 1)
+        limit = input.get("limit")
+
+        try:
+            safe_path = resolve_safe(path_str, self._workspace)
+        except PathSecurityError as exc:
+            return ToolResult(tool_call_id="", content=str(exc), is_error=True)
+
+        if not safe_path.exists():
+            return ToolResult(
+                tool_call_id="",
+                content=f"File not found: '{path_str}'",
+                is_error=True,
+            )
+
+        if not safe_path.is_file():
+            return ToolResult(
+                tool_call_id="",
+                content=f"Not a file: '{path_str}'",
+                is_error=True,
+            )
+
+        size = safe_path.stat().st_size
+        if size > self._max_bytes:
+            return ToolResult(
+                tool_call_id="",
+                content=f"File too large: {size} bytes (limit {self._max_bytes})",
+                is_error=True,
+            )
+
+        try:
+            text = safe_path.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            return ToolResult(tool_call_id="", content=f"Read error: {exc}", is_error=True)
+
+        lines = text.splitlines(keepends=True)
+        start = max(0, (offset or 1) - 1)
+        slice_ = lines[start:] if limit is None else lines[start : start + limit]
+
+        numbered = "".join(f"{start + idx + 1}\t{line}" for idx, line in enumerate(slice_))
+        return ToolResult(tool_call_id="", content=numbered)
+
+
+class WriteFileTool(ToolPort):
+    """Create or overwrite a file within the workspace."""
+
+    def __init__(
+        self,
+        workspace: Path,
+        max_bytes: int = DEFAULT_MAX_WRITE_BYTES,
+        binary_check_bytes: int = DEFAULT_BINARY_CHECK_BYTES,
+    ) -> None:
+        self._workspace = workspace
+        self._max_bytes = max_bytes
+        self._binary_check_bytes = binary_check_bytes
+
+    @property
+    def name(self) -> str:
+        return "write_file"
+
+    @property
+    def description(self) -> str:
+        return "Create or overwrite a file with the given text content."
+
+    @property
+    def input_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string", "description": "Path to write."},
+                "content": {"type": "string", "description": "Text content to write."},
+            },
+            "required": ["path", "content"],
+        }
+
+    @property
+    def required_permission(self) -> str:
+        return _PERMISSION_WRITE
+
+    async def execute(self, input: dict) -> ToolResult:
+        path_str = input.get("path", "")
+        content = input.get("content", "")
+
+        try:
+            safe_path = resolve_safe(path_str, self._workspace)
+        except PathSecurityError as exc:
+            return ToolResult(tool_call_id="", content=str(exc), is_error=True)
+
+        encoded = content.encode("utf-8")
+
+        if len(encoded) > self._max_bytes:
+            return ToolResult(
+                tool_call_id="",
+                content=f"Content too large: {len(encoded)} bytes (limit {self._max_bytes})",
+                is_error=True,
+            )
+
+        if is_binary(encoded, self._binary_check_bytes):
+            return ToolResult(
+                tool_call_id="",
+                content="Binary content detected; refusing to write",
+                is_error=True,
+            )
+
+        try:
+            safe_path.parent.mkdir(parents=True, exist_ok=True)
+            safe_path.write_text(content, encoding="utf-8")
+        except OSError as exc:
+            return ToolResult(tool_call_id="", content=f"Write error: {exc}", is_error=True)
+
+        return ToolResult(tool_call_id="", content=f"Written: '{safe_path}'")
+
+
+class EditFileTool(ToolPort):
+    """Exact string replacement in a file."""
+
+    def __init__(
+        self,
+        workspace: Path,
+        max_bytes: int = DEFAULT_MAX_WRITE_BYTES,
+        binary_check_bytes: int = DEFAULT_BINARY_CHECK_BYTES,
+    ) -> None:
+        self._workspace = workspace
+        self._max_bytes = max_bytes
+        self._binary_check_bytes = binary_check_bytes
+
+    @property
+    def name(self) -> str:
+        return "edit_file"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Replace an exact string in a file. "
+            "Fails if old_string is not found or appears more than once "
+            "(unless replace_all is set)."
+        )
+
+    @property
+    def input_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string", "description": "Path to the file to edit."},
+                "old_string": {
+                    "type": "string",
+                    "description": "Exact text to find and replace.",
+                },
+                "new_string": {
+                    "type": "string",
+                    "description": "Replacement text.",
+                },
+                "replace_all": {
+                    "type": "boolean",
+                    "description": (
+                        "Replace all occurrences instead of requiring uniqueness (default: false)."
+                    ),
+                },
+            },
+            "required": ["path", "old_string", "new_string"],
+        }
+
+    @property
+    def required_permission(self) -> str:
+        return _PERMISSION_WRITE
+
+    async def execute(self, input: dict) -> ToolResult:
+        path_str = input.get("path", "")
+        old_string = input.get("old_string", "")
+        new_string = input.get("new_string", "")
+        replace_all = input.get("replace_all", False)
+
+        try:
+            safe_path = resolve_safe(path_str, self._workspace)
+        except PathSecurityError as exc:
+            return ToolResult(tool_call_id="", content=str(exc), is_error=True)
+
+        if not safe_path.exists():
+            return ToolResult(
+                tool_call_id="",
+                content=f"File not found: '{path_str}'",
+                is_error=True,
+            )
+
+        if not safe_path.is_file():
+            return ToolResult(
+                tool_call_id="",
+                content=f"Not a file: '{path_str}'",
+                is_error=True,
+            )
+
+        try:
+            original = safe_path.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            return ToolResult(tool_call_id="", content=f"Read error: {exc}", is_error=True)
+
+        count = original.count(old_string)
+
+        if count == 0:
+            return ToolResult(
+                tool_call_id="",
+                content=f"old_string not found in '{path_str}'",
+                is_error=True,
+            )
+
+        if not replace_all and count > 1:
+            return ToolResult(
+                tool_call_id="",
+                content=(
+                    f"old_string found {count} times in '{path_str}'; "
+                    "use replace_all=true to replace all occurrences"
+                ),
+                is_error=True,
+            )
+
+        updated = original.replace(old_string, new_string)
+        encoded = updated.encode("utf-8")
+
+        if len(encoded) > self._max_bytes:
+            return ToolResult(
+                tool_call_id="",
+                content=f"Result too large: {len(encoded)} bytes (limit {self._max_bytes})",
+                is_error=True,
+            )
+
+        if is_binary(encoded, self._binary_check_bytes):
+            return ToolResult(
+                tool_call_id="",
+                content="Binary content detected after replacement; refusing to write",
+                is_error=True,
+            )
+
+        try:
+            safe_path.write_text(updated, encoding="utf-8")
+        except OSError as exc:
+            return ToolResult(tool_call_id="", content=f"Write error: {exc}", is_error=True)
+
+        replacements = count if replace_all else 1
+        return ToolResult(
+            tool_call_id="",
+            content=f"Replaced {replacements} occurrence(s) in '{safe_path}'",
+        )
+
+
+class GlobSearchTool(ToolPort):
+    """Find files by glob pattern within the workspace."""
+
+    def __init__(self, workspace: Path) -> None:
+        self._workspace = workspace
+
+    @property
+    def name(self) -> str:
+        return "glob_search"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Find files by glob pattern. "
+            "Returns paths relative to the workspace root, one per line."
+        )
+
+    @property
+    def input_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "pattern": {
+                    "type": "string",
+                    "description": "Glob pattern (e.g. '**/*.py', 'src/**/*.ts').",
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Base directory for the search (default: workspace root).",
+                },
+            },
+            "required": ["pattern"],
+        }
+
+    @property
+    def required_permission(self) -> str:
+        return _PERMISSION_READ
+
+    async def execute(self, input: dict) -> ToolResult:
+        pattern = input.get("pattern", "")
+        base_str = input.get("path")
+
+        base = self._workspace
+        if base_str:
+            try:
+                base = resolve_safe(base_str, self._workspace)
+            except PathSecurityError as exc:
+                return ToolResult(tool_call_id="", content=str(exc), is_error=True)
+
+            if not base.is_dir():
+                return ToolResult(
+                    tool_call_id="",
+                    content=f"Not a directory: '{base_str}'",
+                    is_error=True,
+                )
+
+        matches = sorted(
+            str(p.relative_to(self._workspace)) for p in base.glob(pattern) if p.is_file()
+        )
+        return ToolResult(tool_call_id="", content="\n".join(matches) if matches else "")
+
+
+class GrepSearchTool(ToolPort):
+    """Search file contents by regular expression."""
+
+    def __init__(self, workspace: Path) -> None:
+        self._workspace = workspace
+
+    @property
+    def name(self) -> str:
+        return "grep_search"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Search file contents by regular expression. "
+            "Returns matching lines formatted as path:line_number:line_content."
+        )
+
+    @property
+    def input_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "pattern": {
+                    "type": "string",
+                    "description": "Regular expression pattern.",
+                },
+                "path": {
+                    "type": "string",
+                    "description": "File or directory to search (default: workspace root).",
+                },
+                "glob": {
+                    "type": "string",
+                    "description": (
+                        "Glob pattern to filter files when searching a directory (default: **/*)."
+                    ),
+                },
+            },
+            "required": ["pattern"],
+        }
+
+    @property
+    def required_permission(self) -> str:
+        return _PERMISSION_READ
+
+    async def execute(self, input: dict) -> ToolResult:
+        pattern = input.get("pattern", "")
+        path_str = input.get("path")
+        glob_pattern = input.get("glob", "**/*")
+
+        try:
+            regex = re.compile(pattern)
+        except re.error as exc:
+            return ToolResult(
+                tool_call_id="",
+                content=f"Invalid regex pattern: {exc}",
+                is_error=True,
+            )
+
+        if path_str:
+            try:
+                candidate = resolve_safe(path_str, self._workspace)
+            except PathSecurityError as exc:
+                return ToolResult(tool_call_id="", content=str(exc), is_error=True)
+
+            if candidate.is_file():
+                return self._grep_file(candidate, regex)
+
+            if not candidate.is_dir():
+                return ToolResult(
+                    tool_call_id="",
+                    content=f"Path not found: '{path_str}'",
+                    is_error=True,
+                )
+
+            base = candidate
+        else:
+            base = self._workspace
+
+        results: list[str] = []
+        for filepath in sorted(base.glob(glob_pattern)):
+            if not filepath.is_file():
+                continue
+            results.extend(self._grep_file_lines(filepath, regex))
+
+        return ToolResult(tool_call_id="", content="\n".join(results) if results else "")
+
+    def _grep_file(self, filepath: Path, regex: re.Pattern) -> ToolResult:  # type: ignore[type-arg]
+        lines = self._grep_file_lines(filepath, regex)
+        return ToolResult(tool_call_id="", content="\n".join(lines) if lines else "")
+
+    def _grep_file_lines(self, filepath: Path, regex: re.Pattern) -> list[str]:  # type: ignore[type-arg]
+        try:
+            text = filepath.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return []
+
+        rel = filepath.relative_to(self._workspace)
+        return [
+            f"{rel}:{lineno}:{line}"
+            for lineno, line in enumerate(text.splitlines(), start=1)
+            if regex.search(line)
+        ]

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -104,6 +104,23 @@ class ToolAdapterConfig(BaseModel):
     secret_kwargs_env: dict[str, str] = Field(default_factory=dict)
 
 
+class FileToolsConfig(BaseModel):
+    """File operation tool limits and thresholds."""
+
+    max_read_bytes: int = Field(
+        default=1 * 1024 * 1024,
+        description="Maximum file size allowed for read_file (bytes).",
+    )
+    max_write_bytes: int = Field(
+        default=5 * 1024 * 1024,
+        description="Maximum content size allowed for write_file / edit_file (bytes).",
+    )
+    binary_check_bytes: int = Field(
+        default=8 * 1024,
+        description="Number of bytes inspected for binary (NUL-byte) detection.",
+    )
+
+
 class ToolsConfig(BaseModel):
     """Tool availability and custom adapter configuration."""
 
@@ -121,6 +138,10 @@ class ToolsConfig(BaseModel):
     custom: list[ToolAdapterConfig] = Field(
         default_factory=list,
         description="Custom tool adapters to register alongside built-ins.",
+    )
+    file: FileToolsConfig = Field(
+        default_factory=FileToolsConfig,
+        description="Limits and thresholds for the built-in file tools.",
     )
 
 

--- a/src/ravn/registry.py
+++ b/src/ravn/registry.py
@@ -1,0 +1,98 @@
+"""Tool registry — register, validate, and dispatch tools."""
+
+from __future__ import annotations
+
+import logging
+
+from ravn.domain.models import ToolResult
+from ravn.ports.tool import ToolPort
+
+logger = logging.getLogger(__name__)
+
+_VALID_SCHEMA_TYPES = frozenset(
+    {"object", "array", "string", "integer", "number", "boolean", "null"}
+)
+
+
+class ToolRegistrationError(Exception):
+    """Raised when a tool cannot be registered."""
+
+
+class ToolRegistry:
+    """Registry of agent tools.
+
+    Handles registration (with collision detection and schema validation),
+    dispatching (with exception capture), and listing.
+    """
+
+    def __init__(self) -> None:
+        self._tools: dict[str, ToolPort] = {}
+
+    def register(self, tool: ToolPort) -> None:
+        """Register *tool*.
+
+        Raises:
+            ToolRegistrationError: on name collision or invalid JSON Schema.
+        """
+        name = tool.name
+        if name in self._tools:
+            raise ToolRegistrationError(f"Tool '{name}' is already registered")
+
+        _validate_schema(name, tool.input_schema)
+        self._tools[name] = tool
+
+    async def dispatch(self, name: str, input: dict, call_id: str) -> ToolResult:
+        """Execute tool *name* with *input*, returning a ToolResult.
+
+        Unknown tools and execution errors are returned as error results —
+        exceptions are never propagated to the caller.
+        """
+        tool = self._tools.get(name)
+        if tool is None:
+            return ToolResult(
+                tool_call_id=call_id,
+                content=f"Unknown tool: {name!r}",
+                is_error=True,
+            )
+
+        try:
+            result = await tool.execute(input)
+            return ToolResult(
+                tool_call_id=call_id,
+                content=result.content,
+                is_error=result.is_error,
+            )
+        except Exception as exc:
+            logger.warning("Tool %r raised: %s", name, exc)
+            return ToolResult(
+                tool_call_id=call_id,
+                content=f"Tool error: {exc}",
+                is_error=True,
+            )
+
+    def list(self) -> list[ToolPort]:
+        """Return all registered tools in registration order."""
+        return list(self._tools.values())
+
+    def get(self, name: str) -> ToolPort | None:
+        """Return a tool by name, or None if not registered."""
+        return self._tools.get(name)
+
+    def __len__(self) -> int:
+        return len(self._tools)
+
+
+def _validate_schema(name: str, schema: dict) -> None:
+    """Validate that *schema* is a structurally plausible JSON Schema."""
+    if not isinstance(schema, dict):
+        raise ToolRegistrationError(
+            f"Tool '{name}' input_schema must be a dict, got {type(schema).__name__}"
+        )
+
+    schema_type = schema.get("type")
+    if schema_type is not None and schema_type not in _VALID_SCHEMA_TYPES:
+        raise ToolRegistrationError(f"Tool '{name}' input_schema has invalid type: {schema_type!r}")
+
+    properties = schema.get("properties")
+    if properties is not None and not isinstance(properties, dict):
+        raise ToolRegistrationError(f"Tool '{name}' input_schema 'properties' must be a dict")

--- a/tests/test_ravn/test_file_security.py
+++ b/tests/test_ravn/test_file_security.py
@@ -1,0 +1,173 @@
+"""Unit tests for file security utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ravn.adapters.file_security import (
+    DEFAULT_BINARY_CHECK_BYTES,
+    PathSecurityError,
+    is_binary,
+    resolve_safe,
+)
+
+# ---------------------------------------------------------------------------
+# resolve_safe — workspace boundary
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_path_inside_workspace(tmp_path: Path):
+    target = tmp_path / "subdir" / "file.txt"
+    result = resolve_safe(target, tmp_path)
+    assert result == target.resolve()
+
+
+def test_resolve_workspace_root_itself(tmp_path: Path):
+    result = resolve_safe(tmp_path, tmp_path)
+    assert result == tmp_path.resolve()
+
+
+def test_resolve_rejects_dotdot_traversal(tmp_path: Path):
+    with pytest.raises(PathSecurityError, match="outside the workspace"):
+        resolve_safe(tmp_path / ".." / "sibling.txt", tmp_path)
+
+
+def test_resolve_rejects_absolute_path_outside(tmp_path: Path):
+    with pytest.raises(PathSecurityError, match="outside the workspace"):
+        resolve_safe("/tmp/attacker.txt", tmp_path)
+
+
+def test_resolve_string_path(tmp_path: Path):
+    target = str(tmp_path / "file.txt")
+    result = resolve_safe(target, tmp_path)
+    assert result == Path(target).resolve()
+
+
+def test_resolve_nonexistent_target_is_ok(tmp_path: Path):
+    """Write targets do not need to exist."""
+    result = resolve_safe(tmp_path / "new_file.txt", tmp_path)
+    assert result == (tmp_path / "new_file.txt").resolve()
+
+
+# ---------------------------------------------------------------------------
+# resolve_safe — symlink validation
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_rejects_symlink_pointing_outside(tmp_path: Path):
+    """A symlink inside the workspace that points outside must be rejected."""
+    link = tmp_path / "evil_link"
+    # Point to parent directory (outside workspace)
+    link.symlink_to(tmp_path.parent)
+    with pytest.raises(PathSecurityError):
+        resolve_safe(link / "some_file.txt", tmp_path)
+
+
+def test_resolve_rejects_symlink_to_etc(tmp_path: Path):
+    link = tmp_path / "etc_link"
+    link.symlink_to("/etc")
+    with pytest.raises(PathSecurityError):
+        resolve_safe(link, tmp_path)
+
+
+def test_resolve_allows_internal_symlink(tmp_path: Path):
+    """Symlink within the workspace should be allowed."""
+    real_file = tmp_path / "real.txt"
+    real_file.write_text("hello")
+    link = tmp_path / "link.txt"
+    link.symlink_to(real_file)
+    result = resolve_safe(link, tmp_path)
+    assert result == real_file.resolve()
+
+
+# ---------------------------------------------------------------------------
+# resolve_safe — system path rejection
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_rejects_etc(tmp_path: Path):
+    # Use root as workspace to bypass workspace boundary check
+    root = Path("/")
+    with pytest.raises(PathSecurityError, match="system path"):
+        resolve_safe("/etc/passwd", root)
+
+
+def test_resolve_rejects_usr(tmp_path: Path):
+    root = Path("/")
+    with pytest.raises(PathSecurityError, match="system path"):
+        resolve_safe("/usr/bin/env", root)
+
+
+def test_resolve_rejects_var(tmp_path: Path):
+    root = Path("/")
+    with pytest.raises(PathSecurityError, match="system path"):
+        resolve_safe("/var/log/syslog", root)
+
+
+def test_resolve_rejects_boot(tmp_path: Path):
+    root = Path("/")
+    with pytest.raises(PathSecurityError, match="system path"):
+        resolve_safe("/boot/grub/grub.cfg", root)
+
+
+def test_resolve_rejects_sys(tmp_path: Path):
+    root = Path("/")
+    with pytest.raises(PathSecurityError, match="system path"):
+        resolve_safe("/sys/fs/cgroup", root)
+
+
+def test_resolve_rejects_proc(tmp_path: Path):
+    root = Path("/")
+    with pytest.raises(PathSecurityError, match="system path"):
+        resolve_safe("/proc/1/mem", root)
+
+
+def test_resolve_rejects_exact_system_prefix(tmp_path: Path):
+    root = Path("/")
+    with pytest.raises(PathSecurityError, match="system path"):
+        resolve_safe("/etc", root)
+
+
+# ---------------------------------------------------------------------------
+# is_binary
+# ---------------------------------------------------------------------------
+
+
+def test_is_binary_detects_nul_byte():
+    assert is_binary(b"hello\x00world")
+
+
+def test_is_binary_returns_false_for_text():
+    assert not is_binary(b"hello world\n")
+
+
+def test_is_binary_empty_data():
+    assert not is_binary(b"")
+
+
+def test_is_binary_nul_within_check_window():
+    data = b"a" * 100 + b"\x00" + b"a" * 1000
+    assert is_binary(data)
+
+
+def test_is_binary_nul_beyond_check_limit():
+    """NUL bytes beyond the check window should not trigger detection."""
+    data = b"a" * DEFAULT_BINARY_CHECK_BYTES + b"\x00"
+    assert not is_binary(data)
+
+
+def test_is_binary_custom_check_bytes():
+    data = b"a" * 5 + b"\x00" + b"a" * 100
+    assert is_binary(data, check_bytes=10)
+    assert not is_binary(data, check_bytes=3)
+
+
+def test_is_binary_all_nul():
+    assert is_binary(b"\x00" * 100)
+
+
+def test_is_binary_utf8_text():
+    text = "héllo wörld\n".encode()
+    assert not is_binary(text)

--- a/tests/test_ravn/test_file_tools.py
+++ b/tests/test_ravn/test_file_tools.py
@@ -1,0 +1,420 @@
+"""Integration tests for file tools against a real tmpdir filesystem."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ravn.adapters.file_tools import (
+    EditFileTool,
+    GlobSearchTool,
+    GrepSearchTool,
+    ReadFileTool,
+    WriteFileTool,
+)
+
+# ---------------------------------------------------------------------------
+# ReadFileTool
+# ---------------------------------------------------------------------------
+
+
+class TestReadFileTool:
+    def _tool(self, workspace: Path) -> ReadFileTool:
+        return ReadFileTool(workspace=workspace)
+
+    @pytest.mark.asyncio
+    async def test_reads_file_with_line_numbers(self, tmp_path: Path):
+        f = tmp_path / "hello.txt"
+        f.write_text("line one\nline two\n")
+        result = await self._tool(tmp_path).execute({"path": str(f)})
+        assert not result.is_error
+        assert "1\tline one" in result.content
+        assert "2\tline two" in result.content
+
+    @pytest.mark.asyncio
+    async def test_offset_skips_leading_lines(self, tmp_path: Path):
+        f = tmp_path / "multi.txt"
+        f.write_text("a\nb\nc\nd\ne\n")
+        result = await self._tool(tmp_path).execute({"path": str(f), "offset": 3})
+        assert not result.is_error
+        assert "3\tc" in result.content
+        assert "a" not in result.content
+        assert "b" not in result.content
+
+    @pytest.mark.asyncio
+    async def test_limit_caps_lines_returned(self, tmp_path: Path):
+        f = tmp_path / "multi.txt"
+        f.write_text("a\nb\nc\nd\ne\n")
+        result = await self._tool(tmp_path).execute({"path": str(f), "offset": 2, "limit": 2})
+        assert not result.is_error
+        assert "2\tb" in result.content
+        assert "3\tc" in result.content
+        assert "d" not in result.content
+        assert "e" not in result.content
+
+    @pytest.mark.asyncio
+    async def test_missing_file_returns_error(self, tmp_path: Path):
+        result = await self._tool(tmp_path).execute({"path": str(tmp_path / "missing.txt")})
+        assert result.is_error
+        assert "not found" in result.content.lower()
+
+    @pytest.mark.asyncio
+    async def test_directory_returns_error(self, tmp_path: Path):
+        d = tmp_path / "subdir"
+        d.mkdir()
+        result = await self._tool(tmp_path).execute({"path": str(d)})
+        assert result.is_error
+        assert "not a file" in result.content.lower()
+
+    @pytest.mark.asyncio
+    async def test_size_limit_returns_error(self, tmp_path: Path):
+        f = tmp_path / "big.bin"
+        f.write_bytes(b"x" * (1024 * 1024 + 1))
+        tool = ReadFileTool(workspace=tmp_path, max_bytes=1024 * 1024)
+        result = await tool.execute({"path": str(f)})
+        assert result.is_error
+        assert "too large" in result.content.lower()
+
+    @pytest.mark.asyncio
+    async def test_path_traversal_returns_error(self, tmp_path: Path):
+        result = await self._tool(tmp_path).execute({"path": str(tmp_path / ".." / "outside.txt")})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_reads_empty_file(self, tmp_path: Path):
+        f = tmp_path / "empty.txt"
+        f.write_text("")
+        result = await self._tool(tmp_path).execute({"path": str(f)})
+        assert not result.is_error
+        assert result.content == ""
+
+    @pytest.mark.asyncio
+    async def test_reads_single_line_no_newline(self, tmp_path: Path):
+        f = tmp_path / "oneliner.txt"
+        f.write_text("no newline")
+        result = await self._tool(tmp_path).execute({"path": str(f)})
+        assert not result.is_error
+        assert "1\tno newline" in result.content
+
+
+# ---------------------------------------------------------------------------
+# WriteFileTool
+# ---------------------------------------------------------------------------
+
+
+class TestWriteFileTool:
+    def _tool(self, workspace: Path) -> WriteFileTool:
+        return WriteFileTool(workspace=workspace)
+
+    @pytest.mark.asyncio
+    async def test_creates_new_file(self, tmp_path: Path):
+        path = tmp_path / "new.txt"
+        result = await self._tool(tmp_path).execute({"path": str(path), "content": "hello"})
+        assert not result.is_error
+        assert path.read_text() == "hello"
+
+    @pytest.mark.asyncio
+    async def test_overwrites_existing_file(self, tmp_path: Path):
+        f = tmp_path / "existing.txt"
+        f.write_text("old content")
+        result = await self._tool(tmp_path).execute({"path": str(f), "content": "new content"})
+        assert not result.is_error
+        assert f.read_text() == "new content"
+
+    @pytest.mark.asyncio
+    async def test_creates_parent_directories(self, tmp_path: Path):
+        path = tmp_path / "a" / "b" / "c.txt"
+        result = await self._tool(tmp_path).execute({"path": str(path), "content": "deep"})
+        assert not result.is_error
+        assert path.read_text() == "deep"
+
+    @pytest.mark.asyncio
+    async def test_path_traversal_returns_error(self, tmp_path: Path):
+        result = await self._tool(tmp_path).execute(
+            {"path": str(tmp_path / ".." / "evil.txt"), "content": "bad"}
+        )
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_binary_content_rejected(self, tmp_path: Path):
+        result = await self._tool(tmp_path).execute(
+            {"path": str(tmp_path / "bin.txt"), "content": "hello\x00world"}
+        )
+        assert result.is_error
+        assert "binary" in result.content.lower()
+
+    @pytest.mark.asyncio
+    async def test_size_limit_returns_error(self, tmp_path: Path):
+        tool = WriteFileTool(workspace=tmp_path, max_bytes=10)
+        result = await tool.execute({"path": str(tmp_path / "f.txt"), "content": "x" * 11})
+        assert result.is_error
+        assert "too large" in result.content.lower()
+
+    @pytest.mark.asyncio
+    async def test_result_mentions_written_path(self, tmp_path: Path):
+        path = tmp_path / "out.txt"
+        result = await self._tool(tmp_path).execute({"path": str(path), "content": "data"})
+        assert not result.is_error
+        assert "Written" in result.content
+
+
+# ---------------------------------------------------------------------------
+# EditFileTool
+# ---------------------------------------------------------------------------
+
+
+class TestEditFileTool:
+    def _tool(self, workspace: Path) -> EditFileTool:
+        return EditFileTool(workspace=workspace)
+
+    @pytest.mark.asyncio
+    async def test_replaces_unique_string(self, tmp_path: Path):
+        f = tmp_path / "edit.txt"
+        f.write_text("hello world")
+        result = await self._tool(tmp_path).execute(
+            {"path": str(f), "old_string": "world", "new_string": "earth"}
+        )
+        assert not result.is_error
+        assert f.read_text() == "hello earth"
+
+    @pytest.mark.asyncio
+    async def test_missing_old_string_returns_error(self, tmp_path: Path):
+        f = tmp_path / "edit.txt"
+        f.write_text("hello")
+        result = await self._tool(tmp_path).execute(
+            {"path": str(f), "old_string": "xyz", "new_string": "abc"}
+        )
+        assert result.is_error
+        assert "not found" in result.content.lower()
+
+    @pytest.mark.asyncio
+    async def test_duplicate_string_without_replace_all_returns_error(self, tmp_path: Path):
+        f = tmp_path / "dup.txt"
+        f.write_text("aa bb aa cc aa")
+        result = await self._tool(tmp_path).execute(
+            {"path": str(f), "old_string": "aa", "new_string": "zz"}
+        )
+        assert result.is_error
+        assert "3" in result.content  # found 3 times
+
+    @pytest.mark.asyncio
+    async def test_replace_all_replaces_every_occurrence(self, tmp_path: Path):
+        f = tmp_path / "multi.txt"
+        f.write_text("aa bb aa")
+        result = await self._tool(tmp_path).execute(
+            {"path": str(f), "old_string": "aa", "new_string": "cc", "replace_all": True}
+        )
+        assert not result.is_error
+        assert f.read_text() == "cc bb cc"
+
+    @pytest.mark.asyncio
+    async def test_file_not_found_returns_error(self, tmp_path: Path):
+        result = await self._tool(tmp_path).execute(
+            {"path": str(tmp_path / "missing.txt"), "old_string": "x", "new_string": "y"}
+        )
+        assert result.is_error
+        assert "not found" in result.content.lower()
+
+    @pytest.mark.asyncio
+    async def test_directory_returns_error(self, tmp_path: Path):
+        d = tmp_path / "subdir"
+        d.mkdir()
+        result = await self._tool(tmp_path).execute(
+            {"path": str(d), "old_string": "x", "new_string": "y"}
+        )
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_path_traversal_returns_error(self, tmp_path: Path):
+        result = await self._tool(tmp_path).execute(
+            {
+                "path": str(tmp_path / ".." / "outside.txt"),
+                "old_string": "x",
+                "new_string": "y",
+            }
+        )
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_result_reports_replacement_count(self, tmp_path: Path):
+        f = tmp_path / "rep.txt"
+        f.write_text("x y x")
+        result = await self._tool(tmp_path).execute(
+            {"path": str(f), "old_string": "x", "new_string": "z", "replace_all": True}
+        )
+        assert not result.is_error
+        assert "2" in result.content
+
+    @pytest.mark.asyncio
+    async def test_size_limit_after_replacement(self, tmp_path: Path):
+        f = tmp_path / "expand.txt"
+        f.write_text("a")
+        tool = EditFileTool(workspace=tmp_path, max_bytes=5)
+        result = await tool.execute({"path": str(f), "old_string": "a", "new_string": "x" * 10})
+        assert result.is_error
+        assert "too large" in result.content.lower()
+
+
+# ---------------------------------------------------------------------------
+# GlobSearchTool
+# ---------------------------------------------------------------------------
+
+
+class TestGlobSearchTool:
+    @pytest.mark.asyncio
+    async def test_matches_simple_pattern(self, tmp_path: Path):
+        (tmp_path / "a.py").write_text("# a")
+        (tmp_path / "b.py").write_text("# b")
+        (tmp_path / "c.txt").write_text("# c")
+        result = await GlobSearchTool(tmp_path).execute({"pattern": "*.py"})
+        assert not result.is_error
+        assert "a.py" in result.content
+        assert "b.py" in result.content
+        assert "c.txt" not in result.content
+
+    @pytest.mark.asyncio
+    async def test_recursive_pattern(self, tmp_path: Path):
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "x.py").write_text("x")
+        result = await GlobSearchTool(tmp_path).execute({"pattern": "**/*.py"})
+        assert not result.is_error
+        # Path separator may vary — just check the filename is present
+        assert "x.py" in result.content
+
+    @pytest.mark.asyncio
+    async def test_empty_result(self, tmp_path: Path):
+        result = await GlobSearchTool(tmp_path).execute({"pattern": "*.nonexistent"})
+        assert not result.is_error
+        assert result.content == ""
+
+    @pytest.mark.asyncio
+    async def test_scoped_to_subdirectory(self, tmp_path: Path):
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "x.py").write_text("x")
+        (tmp_path / "y.py").write_text("y")
+        result = await GlobSearchTool(tmp_path).execute({"pattern": "*.py", "path": str(sub)})
+        assert not result.is_error
+        assert "x.py" in result.content
+        # y.py is outside the sub-directory scope
+        assert "y.py" not in result.content
+
+    @pytest.mark.asyncio
+    async def test_path_traversal_returns_error(self, tmp_path: Path):
+        result = await GlobSearchTool(tmp_path).execute(
+            {"pattern": "*", "path": str(tmp_path / ".." / "etc")}
+        )
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_non_directory_path_returns_error(self, tmp_path: Path):
+        f = tmp_path / "file.txt"
+        f.write_text("x")
+        result = await GlobSearchTool(tmp_path).execute({"pattern": "*", "path": str(f)})
+        assert result.is_error
+        assert "not a directory" in result.content.lower()
+
+    @pytest.mark.asyncio
+    async def test_results_are_sorted(self, tmp_path: Path):
+        for name in ["z.txt", "a.txt", "m.txt"]:
+            (tmp_path / name).write_text("x")
+        result = await GlobSearchTool(tmp_path).execute({"pattern": "*.txt"})
+        assert not result.is_error
+        lines = result.content.splitlines()
+        assert lines == sorted(lines)
+
+    @pytest.mark.asyncio
+    async def test_excludes_directories_from_results(self, tmp_path: Path):
+        (tmp_path / "dir").mkdir()
+        (tmp_path / "file.txt").write_text("x")
+        result = await GlobSearchTool(tmp_path).execute({"pattern": "*"})
+        assert not result.is_error
+        assert "file.txt" in result.content
+        assert "dir" not in result.content
+
+
+# ---------------------------------------------------------------------------
+# GrepSearchTool
+# ---------------------------------------------------------------------------
+
+
+class TestGrepSearchTool:
+    @pytest.mark.asyncio
+    async def test_finds_matching_lines(self, tmp_path: Path):
+        (tmp_path / "a.txt").write_text("hello world\nfoo bar\n")
+        result = await GrepSearchTool(tmp_path).execute({"pattern": "hello", "glob": "*.txt"})
+        assert not result.is_error
+        assert "hello world" in result.content
+
+    @pytest.mark.asyncio
+    async def test_no_match_returns_empty(self, tmp_path: Path):
+        (tmp_path / "a.txt").write_text("foo bar\n")
+        result = await GrepSearchTool(tmp_path).execute({"pattern": "xyz", "glob": "*.txt"})
+        assert not result.is_error
+        assert result.content == ""
+
+    @pytest.mark.asyncio
+    async def test_invalid_regex_returns_error(self, tmp_path: Path):
+        result = await GrepSearchTool(tmp_path).execute({"pattern": "[invalid"})
+        assert result.is_error
+        assert "Invalid regex" in result.content
+
+    @pytest.mark.asyncio
+    async def test_grep_single_file(self, tmp_path: Path):
+        f = tmp_path / "search.txt"
+        f.write_text("alpha\nbeta\ngamma\n")
+        result = await GrepSearchTool(tmp_path).execute({"pattern": "beta", "path": str(f)})
+        assert not result.is_error
+        assert "beta" in result.content
+
+    @pytest.mark.asyncio
+    async def test_result_includes_line_numbers(self, tmp_path: Path):
+        f = tmp_path / "nums.txt"
+        f.write_text("alpha\nbeta\ngamma\n")
+        result = await GrepSearchTool(tmp_path).execute({"pattern": "beta", "path": str(f)})
+        assert not result.is_error
+        assert ":2:" in result.content
+
+    @pytest.mark.asyncio
+    async def test_result_includes_relative_path(self, tmp_path: Path):
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "file.txt").write_text("found here\n")
+        result = await GrepSearchTool(tmp_path).execute({"pattern": "found"})
+        assert not result.is_error
+        assert "sub" in result.content and "file.txt" in result.content
+
+    @pytest.mark.asyncio
+    async def test_path_traversal_returns_error(self, tmp_path: Path):
+        result = await GrepSearchTool(tmp_path).execute(
+            {"pattern": "x", "path": str(tmp_path / ".." / "evil")}
+        )
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_path_not_found_returns_error(self, tmp_path: Path):
+        result = await GrepSearchTool(tmp_path).execute(
+            {"pattern": "x", "path": str(tmp_path / "nonexistent_dir")}
+        )
+        assert result.is_error
+        assert "not found" in result.content.lower()
+
+    @pytest.mark.asyncio
+    async def test_regex_pattern_works(self, tmp_path: Path):
+        f = tmp_path / "code.py"
+        f.write_text("def foo():\n    pass\ndef bar():\n    pass\n")
+        result = await GrepSearchTool(tmp_path).execute({"pattern": r"def \w+\(\)", "path": str(f)})
+        assert not result.is_error
+        assert "def foo()" in result.content
+        assert "def bar()" in result.content
+
+    @pytest.mark.asyncio
+    async def test_grep_with_glob_filter(self, tmp_path: Path):
+        (tmp_path / "a.py").write_text("target\n")
+        (tmp_path / "b.txt").write_text("target\n")
+        result = await GrepSearchTool(tmp_path).execute({"pattern": "target", "glob": "*.py"})
+        assert not result.is_error
+        assert "a.py" in result.content
+        assert "b.txt" not in result.content

--- a/tests/test_ravn/test_registry.py
+++ b/tests/test_ravn/test_registry.py
@@ -1,0 +1,233 @@
+"""Unit tests for ToolRegistry."""
+
+from __future__ import annotations
+
+import pytest
+
+from ravn.domain.models import ToolResult
+from ravn.ports.tool import ToolPort
+from ravn.registry import ToolRegistrationError, ToolRegistry
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+class SimpleTool(ToolPort):
+    """A minimal tool that echoes back a value."""
+
+    def __init__(self, tool_name: str = "simple") -> None:
+        self._tool_name = tool_name
+
+    @property
+    def name(self) -> str:
+        return self._tool_name
+
+    @property
+    def description(self) -> str:
+        return "A simple tool."
+
+    @property
+    def input_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {"x": {"type": "string"}},
+        }
+
+    @property
+    def required_permission(self) -> str:
+        return "tool:simple"
+
+    async def execute(self, input: dict) -> ToolResult:
+        return ToolResult(tool_call_id="", content=f"ok:{input.get('x', '')}")
+
+
+class ErrorTool(ToolPort):
+    """A tool that always raises an exception."""
+
+    @property
+    def name(self) -> str:
+        return "error_tool"
+
+    @property
+    def description(self) -> str:
+        return "Always raises."
+
+    @property
+    def input_schema(self) -> dict:
+        return {"type": "object", "properties": {}}
+
+    @property
+    def required_permission(self) -> str:
+        return "tool:error"
+
+    async def execute(self, input: dict) -> ToolResult:
+        raise RuntimeError("boom")
+
+
+# ---------------------------------------------------------------------------
+# Registration tests
+# ---------------------------------------------------------------------------
+
+
+def test_register_single_tool():
+    reg = ToolRegistry()
+    reg.register(SimpleTool())
+    assert len(reg) == 1
+
+
+def test_register_multiple_tools_increments_count():
+    reg = ToolRegistry()
+    reg.register(SimpleTool("a"))
+    reg.register(SimpleTool("b"))
+    assert len(reg) == 2
+
+
+def test_list_returns_tools_in_order():
+    reg = ToolRegistry()
+    t1 = SimpleTool("first")
+    t2 = SimpleTool("second")
+    reg.register(t1)
+    reg.register(t2)
+    assert reg.list() == [t1, t2]
+
+
+def test_list_returns_copy():
+    reg = ToolRegistry()
+    reg.register(SimpleTool())
+    lst = reg.list()
+    lst.clear()
+    assert len(reg) == 1
+
+
+def test_get_returns_registered_tool():
+    reg = ToolRegistry()
+    t = SimpleTool()
+    reg.register(t)
+    assert reg.get("simple") is t
+
+
+def test_get_returns_none_for_unknown():
+    reg = ToolRegistry()
+    assert reg.get("nonexistent") is None
+
+
+def test_collision_raises_registration_error():
+    reg = ToolRegistry()
+    reg.register(SimpleTool())
+    with pytest.raises(ToolRegistrationError, match="already registered"):
+        reg.register(SimpleTool())
+
+
+# ---------------------------------------------------------------------------
+# Schema validation tests
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_schema_type_raises():
+    class BadTypeTool(SimpleTool):
+        @property
+        def input_schema(self) -> dict:
+            return {"type": "notavalidtype"}
+
+    with pytest.raises(ToolRegistrationError, match="invalid type"):
+        ToolRegistry().register(BadTypeTool())
+
+
+def test_schema_not_dict_raises():
+    class NotDictTool(SimpleTool):
+        @property
+        def input_schema(self) -> dict:
+            return "not a dict"  # type: ignore[return-value]
+
+    with pytest.raises(ToolRegistrationError, match="must be a dict"):
+        ToolRegistry().register(NotDictTool())
+
+
+def test_properties_not_dict_raises():
+    class BadPropertiesTool(SimpleTool):
+        @property
+        def input_schema(self) -> dict:
+            return {"type": "object", "properties": "wrong"}
+
+    with pytest.raises(ToolRegistrationError, match="'properties' must be a dict"):
+        ToolRegistry().register(BadPropertiesTool())
+
+
+def test_schema_without_type_is_valid():
+    class NoTypeTool(SimpleTool):
+        @property
+        def input_schema(self) -> dict:
+            return {"properties": {"x": {"type": "string"}}}
+
+    reg = ToolRegistry()
+    reg.register(NoTypeTool())
+    assert len(reg) == 1
+
+
+def test_all_valid_schema_types_accepted():
+    valid_types = ["object", "array", "string", "integer", "number", "boolean", "null"]
+    for schema_type in valid_types:
+
+        class TypedTool(SimpleTool):
+            _t = schema_type
+
+            @property
+            def name(self) -> str:
+                return f"tool_{self._t}"
+
+            @property
+            def input_schema(self) -> dict:
+                return {"type": self._t}
+
+        reg = ToolRegistry()
+        reg.register(TypedTool())  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Dispatch tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dispatch_success_returns_result():
+    reg = ToolRegistry()
+    reg.register(SimpleTool())
+    result = await reg.dispatch("simple", {"x": "hello"}, call_id="abc")
+    assert not result.is_error
+    assert result.content == "ok:hello"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_sets_call_id():
+    reg = ToolRegistry()
+    reg.register(SimpleTool())
+    result = await reg.dispatch("simple", {}, call_id="my-call-id")
+    assert result.tool_call_id == "my-call-id"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_unknown_tool_returns_error():
+    reg = ToolRegistry()
+    result = await reg.dispatch("missing", {}, call_id="x")
+    assert result.is_error
+    assert "Unknown tool" in result.content
+    assert result.tool_call_id == "x"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_exception_returns_error_not_raises():
+    reg = ToolRegistry()
+    reg.register(ErrorTool())
+    result = await reg.dispatch("error_tool", {}, call_id="y")
+    assert result.is_error
+    assert "boom" in result.content
+    assert result.tool_call_id == "y"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_error_preserves_call_id():
+    reg = ToolRegistry()
+    reg.register(ErrorTool())
+    result = await reg.dispatch("error_tool", {}, call_id="err-id-42")
+    assert result.tool_call_id == "err-id-42"


### PR DESCRIPTION
## Summary

- **ToolRegistry** (`src/ravn/registry.py`): registers tools, validates JSON Schema, dispatches calls, catches exceptions as error results. Name collision detection raises `ToolRegistrationError`.
- **File security** (`src/ravn/adapters/file_security.py`): shared `resolve_safe()` enforces workspace boundary (handles `../` and symlinks via `Path.resolve()`), rejects system paths (`/etc`, `/usr`, `/var`, `/boot`, `/sys`, `/proc`), and `is_binary()` detects NUL bytes in the first 8 KB.
- **Five file tools** (`src/ravn/adapters/file_tools.py`):
  - `read_file` (ReadOnly) — line-numbered output, 1 MB limit, `offset`/`limit` paging
  - `write_file` (WorkspaceWrite) — create/overwrite, 5 MB limit, binary rejection
  - `edit_file` (WorkspaceWrite) — exact string replacement, uniqueness enforcement, `replace_all` mode
  - `glob_search` (ReadOnly) — workspace-relative results, optional base-dir scoping
  - `grep_search` (ReadOnly) — `path:line:content` output, `glob` filter for directories
- **`FileToolsConfig`** added to `ToolsConfig` in `config.py` — configurable `max_read_bytes`, `max_write_bytes`, `binary_check_bytes` with sensible defaults.

## Test plan

- [x] 84 new tests across `test_registry.py`, `test_file_security.py`, `test_file_tools.py`
- [x] All 288 ravn tests pass
- [x] Coverage: 94% overall, 100% on registry/security, 86% on file_tools (above 85% gate)
- [x] `ruff check` + `ruff format` clean

## Ticket

Closes NIU-428

🤖 Generated with [Claude Code](https://claude.com/claude-code)