### PR TITLE
feat(bifrost): NIU-474 architecture audit — tests, coverage, and gap report

### DIFF
--- a/docs/bifrost-audit.md
+++ b/docs/bifrost-audit.md
@@ -1,0 +1,112 @@
+# Bifröst Architecture Audit — NIU-474
+
+**Date:** 2026-04-05
+**Branch audited:** `feat/bifrost` (commits `29cbc00` – `050447f`)
+**Auditor:** Claude Code
+
+---
+
+## Summary
+
+The Bifröst implementation is in excellent shape. 128 tests pass, coverage is 93%, lint is clean. The core proxy functionality (Anthropic-compatible inbound API, multi-provider routing, translation layer, streaming SSE passthrough, model failover) fully matches the architecture vision.
+
+Four gaps were found and filed as child issues of this ticket (all blocked-by NIU-474):
+
+| Issue | Gap | Priority |
+|-------|-----|----------|
+| NIU-511 | Missing routing strategies: `cost_optimised`, `round_robin`, `latency_optimised` | High |
+| NIU-512 | `cache_control` field not handled in translation layer | Medium |
+| NIU-514 | No Pi-mode config example (local-only, no auth) | Medium |
+| NIU-513 | `inbound/` package layer missing — routes live in root `app.py` | Low |
+
+---
+
+## Checklist Results
+
+### Inbound layer
+
+| Item | Status | Location |
+|------|--------|----------|
+| `POST /v1/messages` — Anthropic-compatible endpoint | ✅ | `app.py:137` |
+| `GET /v1/models` — model listing | ✅ | `app.py:126` |
+| Streaming SSE passthrough (non-buffering) | ✅ | `app.py:154-163` — `cache-control: no-cache`, `x-accel-buffering: no` |
+
+### Provider adapters
+
+| Item | Status | Location |
+|------|--------|----------|
+| `AnthropicAdapter` — passthrough, headers, streaming | ✅ | `adapters/anthropic.py` — sends `x-api-key` + `anthropic-version: 2023-06-01` |
+| `OpenAIAdapter` — full translation (roles, system, tool_use, streaming) | ✅ | `adapters/openai_compat.py` + `translation/` |
+| `OllamaAdapter` — local endpoint, OpenAI-compat quirks | ✅ | `adapters/ollama.py` — strips `top_p`, 300s timeout, defaults to `localhost:11434` |
+| `GenericOpenAIAdapter` — any OpenAI-compatible endpoint | ✅ | `OpenAICompatAdapter` with configurable `base_url` |
+
+### Domain
+
+| Item | Status | Notes |
+|------|--------|-------|
+| Model alias resolution | ✅ | `config.resolve_alias()` → `router._resolve()` |
+| Routing strategies: `direct`, `failover` | ✅ | Implemented in `router.py` |
+| Routing strategies: `cost_optimised`, `round_robin`, `latency_optimised` | ❌ | Filed as NIU-511 |
+| Translation: role names | ✅ | `user`/`assistant` passthrough; `tool` role created for `ToolResultBlock` |
+| Translation: system prompt | ✅ | Anthropic top-level `system` → OpenAI `{"role":"system"}` message |
+| Translation: tool calling (request + response) | ✅ | Full `tool_use`/`tool_result` ↔ `tool_calls`/`tool` round-trip |
+| Translation: streaming events | ✅ | `openai_stream_to_anthropic()` — complete state machine in `streaming.py` |
+| Translation: `cache_control` | ❌ | Field not in models; silently dropped. Filed as NIU-512 |
+| Translation: thinking blocks | ✅ (partial) | `<thinking>` tag extraction for OpenAI; native Anthropic passthrough |
+
+### Config
+
+| Item | Status | Notes |
+|------|--------|-------|
+| `api_key_env`, `models`, `base_url` load correctly | ✅ | `ProviderConfig` with env-var indirection |
+| Pi mode (local-only, no auth) boots cleanly | ❌ | No example config. Filed as NIU-514 |
+| Ravn `BifrostAdapter` one-line switchover | ✅ | `src/tyr/adapters/bifrost.py` — configure `base_url` to point at Bifröst |
+
+### Package structure
+
+| Item | Status | Notes |
+|------|--------|-------|
+| `domain/` — models only, no infra imports | ✅ | `domain/models.py` — pure dataclasses |
+| `ports/` — abstract interfaces | ✅ | `ports/provider.py` — `ProviderPort` ABC |
+| `adapters/` — implementations only | ✅ | No business logic; delegate to translation layer |
+| `inbound/` — HTTP layer | ❌ | Routes live in root `app.py`; no `inbound/` subdirectory. Filed as NIU-513 |
+| No business logic in adapters | ✅ | Adapters only call HTTP and delegate to `translation/` |
+| No port imports in domain | ✅ | `domain/models.py` has zero imports from `ports/` or `adapters/` |
+
+---
+
+## Test coverage
+
+```
+TOTAL   691 stmts   33 miss   180 branches   17 partial   93% coverage
+```
+
+All 128 tests pass. Coverage is above the 85% threshold. Lint (`ruff check` + `ruff format`) is clean.
+
+---
+
+## Detailed gap notes
+
+### NIU-511 — Missing routing strategies
+
+`ModelRouter` implements a single combined strategy: try primary provider, then on 429/5xx optionally try alternatives (failover). The config has `failover_enabled: bool` but no `routing_strategy` field. The three missing strategies require:
+
+- **`cost_optimised`**: Needs a cost-per-token table in config; select cheapest provider for the model on each request.
+- **`round_robin`**: Needs a per-model counter (thread/async-safe) that advances on each request.
+- **`latency_optimised`**: Needs a sliding window P99 tracker updated after each request.
+
+These are non-trivial additions and belong in a dedicated Phase 3 milestone.
+
+### NIU-512 — `cache_control` not forwarded
+
+Anthropic's prompt-caching feature works by adding `{"cache_control": {"type": "ephemeral"}}` to content blocks. This field is absent from all Pydantic models in `translation/models.py`. Pydantic silently drops unknown fields on parse, so clients that rely on prompt caching via Bifröst will lose cache hits without any error signal.
+
+Fix is mechanical: add `cache_control: dict | None = None` to `TextBlock`, `ToolResultBlock`, and the system-block type; the `AnthropicAdapter` already uses `model_dump(exclude_none=True)` so it will forward it automatically once the field exists.
+
+### NIU-514 — No Pi-mode config
+
+The architecture vision mentions running Bifröst on resource-constrained hardware with only Ollama. The `BifrostConfig` already supports this (providers dict can contain only `ollama`), but there is no example YAML demonstrating the setup, making discoverability poor.
+
+### NIU-513 — `inbound/` layer not a package
+
+Routes, middleware, and SSE tracking helpers are all in `app.py` (~188 lines). This is acceptable for the current scope but deviates from the vision's `inbound/` layer. Low priority until the inbound surface grows.

--- a/src/bifrost/app.py
+++ b/src/bifrost/app.py
@@ -131,10 +131,7 @@ def create_app(config: BifrostConfig) -> FastAPI:
             for model_id in provider_cfg.models:
                 models.append(ModelInfo(id=model_id, display_name=model_id))
         return {
-            "data": [
-                {"id": m.id, "type": "model", "display_name": m.display_name}
-                for m in models
-            ]
+            "data": [{"id": m.id, "type": "model", "display_name": m.display_name} for m in models]
         }
 
     @app.post("/v1/messages", response_model=None)
@@ -175,9 +172,7 @@ def create_app(config: BifrostConfig) -> FastAPI:
                     usage=TokenUsage(
                         input_tokens=raw_usage.get("input_tokens", 0),
                         output_tokens=raw_usage.get("output_tokens", 0),
-                        cache_creation_input_tokens=raw_usage.get(
-                            "cache_creation_input_tokens", 0
-                        ),
+                        cache_creation_input_tokens=raw_usage.get("cache_creation_input_tokens", 0),
                         cache_read_input_tokens=raw_usage.get("cache_read_input_tokens", 0),
                     ),
                     latency_ms=latency_ms,

--- a/tests/test_bifrost/conftest.py
+++ b/tests/test_bifrost/conftest.py
@@ -16,9 +16,7 @@ def make_config(models: list[str] | None = None) -> BifrostConfig:
     """Return a minimal BifrostConfig suitable for unit tests."""
     return BifrostConfig(
         providers={
-            "anthropic": ProviderConfig(
-                models=models or ["claude-sonnet-4-6", "claude-opus-4-6"]
-            )
+            "anthropic": ProviderConfig(models=models or ["claude-sonnet-4-6", "claude-opus-4-6"])
         }
     )
 

--- a/tests/test_bifrost/test_audit.py
+++ b/tests/test_bifrost/test_audit.py
@@ -1,0 +1,397 @@
+"""NIU-474 — Bifröst architecture audit verification tests.
+
+Exercises the specific items from the audit checklist and fills the remaining
+coverage gaps identified during the audit.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from bifrost.app import _extract_usage_from_sse_line, create_app
+from bifrost.config import BifrostConfig, ProviderConfig
+from bifrost.domain.models import TokenUsage
+from bifrost.ports.provider import ProviderError, ProviderPort
+from bifrost.router import ModelRouter, RouterError, _load_adapter
+from bifrost.translation.models import (
+    AnthropicRequest,
+    AnthropicResponse,
+    Message,
+    TextBlock,
+    ToolChoiceAny,
+    ToolChoiceTool,
+    ToolDefinition,
+    ToolResultBlock,
+    ToolUseBlock,
+    UsageInfo,
+)
+from bifrost.translation.to_openai import (
+    _content_to_openai_text,
+    _message_to_openai,
+    anthropic_to_openai,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_request(model: str = "gpt-4o") -> AnthropicRequest:
+    return AnthropicRequest(
+        model=model,
+        max_tokens=100,
+        messages=[Message(role="user", content="Hello")],
+    )
+
+
+def _make_response(text: str = "OK") -> AnthropicResponse:
+    return AnthropicResponse(
+        id="msg_test",
+        content=[TextBlock(text=text)],
+        model="gpt-4o",
+        stop_reason="end_turn",
+        usage=UsageInfo(input_tokens=5, output_tokens=3),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Inbound layer — POST /v1/messages, GET /v1/models, streaming headers
+# ---------------------------------------------------------------------------
+
+
+class TestInboundLayer:
+    """Audit: inbound HTTP layer is functional."""
+
+    def _client(self) -> TestClient:
+        config = BifrostConfig(
+            providers={"openai": ProviderConfig(models=["gpt-4o"])},
+        )
+        return TestClient(create_app(config))
+
+    def test_messages_endpoint_exists(self):
+        """POST /v1/messages returns 200 for a valid request."""
+        with patch("bifrost.router.ModelRouter.complete", new_callable=AsyncMock) as m:
+            m.return_value = _make_response()
+            with self._client() as client:
+                resp = client.post(
+                    "/v1/messages",
+                    json={
+                        "model": "gpt-4o",
+                        "max_tokens": 100,
+                        "messages": [{"role": "user", "content": "Hi"}],
+                    },
+                )
+        assert resp.status_code == 200
+
+    def test_models_endpoint_lists_all_models(self):
+        """GET /v1/models returns all configured models."""
+        config = BifrostConfig(
+            providers={
+                "anthropic": ProviderConfig(models=["claude-sonnet-4-6"]),
+                "openai": ProviderConfig(models=["gpt-4o", "gpt-4o-mini"]),
+            }
+        )
+        with TestClient(create_app(config)) as client:
+            resp = client.get("/v1/models")
+        assert resp.status_code == 200
+        ids = {m["id"] for m in resp.json()["data"]}
+        assert ids == {"claude-sonnet-4-6", "gpt-4o", "gpt-4o-mini"}
+
+    def test_streaming_response_has_non_buffering_headers(self):
+        """Streaming response carries cache-control and x-accel-buffering headers."""
+
+        async def _fake_stream(request):
+            yield "data: [DONE]\n\n"
+
+        with patch("bifrost.router.ModelRouter.stream", return_value=_fake_stream(None)):
+            with self._client() as client:
+                resp = client.post(
+                    "/v1/messages",
+                    json={
+                        "model": "gpt-4o",
+                        "max_tokens": 100,
+                        "messages": [{"role": "user", "content": "Hi"}],
+                        "stream": True,
+                    },
+                )
+        assert resp.headers.get("cache-control") == "no-cache"
+        assert resp.headers.get("x-accel-buffering") == "no"
+
+    def test_correlation_id_echoed_in_response(self):
+        """X-Correlation-ID sent by the client is echoed back."""
+        with patch("bifrost.router.ModelRouter.complete", new_callable=AsyncMock) as m:
+            m.return_value = _make_response()
+            with self._client() as client:
+                resp = client.post(
+                    "/v1/messages",
+                    json={
+                        "model": "gpt-4o",
+                        "max_tokens": 100,
+                        "messages": [{"role": "user", "content": "Hi"}],
+                    },
+                    headers={"X-Correlation-ID": "test-correlation-id"},
+                )
+        assert resp.headers.get("x-correlation-id") == "test-correlation-id"
+
+
+# ---------------------------------------------------------------------------
+# SSE token tracking — _extract_usage_from_sse_line (app.py:40-49)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractUsageFromSseLine:
+    """Audit: token usage is extracted correctly from SSE events."""
+
+    def test_message_start_populates_input_tokens(self):
+        usage = TokenUsage()
+        line = 'data: {"type":"message_start","message":{"usage":{"input_tokens":42}}}'
+        _extract_usage_from_sse_line(line, usage)
+        assert usage.input_tokens == 42
+
+    def test_message_start_populates_cache_tokens(self):
+        usage = TokenUsage()
+        line = (
+            'data: {"type":"message_start","message":{"usage":{'
+            '"input_tokens":10,"cache_creation_input_tokens":5,'
+            '"cache_read_input_tokens":3}}}'
+        )
+        _extract_usage_from_sse_line(line, usage)
+        assert usage.input_tokens == 10
+        assert usage.cache_creation_input_tokens == 5
+        assert usage.cache_read_input_tokens == 3
+
+    def test_message_delta_populates_output_tokens(self):
+        usage = TokenUsage()
+        line = 'data: {"type":"message_delta","usage":{"output_tokens":17}}'
+        _extract_usage_from_sse_line(line, usage)
+        assert usage.output_tokens == 17
+
+    def test_unknown_event_type_is_a_no_op(self):
+        usage = TokenUsage()
+        _extract_usage_from_sse_line('data: {"type":"content_block_start"}', usage)
+        assert usage.input_tokens == 0
+        assert usage.output_tokens == 0
+
+    def test_non_data_line_is_a_no_op(self):
+        usage = TokenUsage()
+        _extract_usage_from_sse_line("event: message_start", usage)
+        assert usage.input_tokens == 0
+
+    def test_invalid_json_is_ignored(self):
+        usage = TokenUsage()
+        _extract_usage_from_sse_line("data: not-valid-json", usage)
+        assert usage.input_tokens == 0
+
+
+# ---------------------------------------------------------------------------
+# _load_adapter — api_key and custom timeout paths (router.py:46,48)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadAdapter:
+    """Audit: adapter instantiation passes api_key and custom timeout."""
+
+    def test_api_key_forwarded_to_adapter(self, monkeypatch):
+        monkeypatch.setenv("TEST_KEY_ENV", "sk-test-123")
+        cfg = ProviderConfig(api_key_env="TEST_KEY_ENV", models=["gpt-4o"])
+        adapter = _load_adapter("openai", cfg, "https://api.openai.com")
+        assert adapter._api_key == "sk-test-123"  # type: ignore[attr-defined]
+
+    def test_custom_timeout_forwarded_to_adapter(self):
+        cfg = ProviderConfig(models=["gpt-4o"], timeout=60.0)
+        adapter = _load_adapter("openai", cfg, "https://api.openai.com")
+        # Timeout is stored in the underlying httpx client.
+        client_timeout = adapter._client.timeout  # type: ignore[attr-defined]
+        assert client_timeout.read == 60.0
+
+    def test_unknown_provider_falls_back_to_openai_compat(self):
+        from bifrost.adapters.openai_compat import OpenAICompatAdapter
+
+        cfg = ProviderConfig(models=["my-model"], base_url="https://custom.llm/")
+        adapter = _load_adapter("custom-provider", cfg, "https://custom.llm/")
+        assert isinstance(adapter, OpenAICompatAdapter)
+
+
+# ---------------------------------------------------------------------------
+# Streaming failover on HTTP errors (router.py:145-168)
+# ---------------------------------------------------------------------------
+
+
+class FakeProvider(ProviderPort):
+    def __init__(self, raises: Exception | None = None):
+        self._raises = raises
+
+    async def complete(self, request: AnthropicRequest, model: str) -> AnthropicResponse:
+        if self._raises:
+            raise self._raises
+        return _make_response()
+
+    async def stream(self, request: AnthropicRequest, model: str) -> AsyncIterator[str]:
+        if self._raises:
+            raise self._raises
+        yield "data: ok\n\n"
+
+
+class TestStreamingFailover:
+    """Audit: stream() failover mirrors complete() failover behaviour."""
+
+    @pytest.mark.asyncio
+    async def test_stream_failover_on_http_503(self):
+        cfg = BifrostConfig(
+            providers={
+                "openai": ProviderConfig(models=["gpt-4o"]),
+                "backup": ProviderConfig(models=["gpt-4o"]),
+            },
+            failover_enabled=True,
+        )
+        router = ModelRouter(cfg)
+        mock_resp = MagicMock()
+        mock_resp.status_code = 503
+        router._adapters["openai"] = FakeProvider(
+            raises=httpx.HTTPStatusError("fail", request=MagicMock(), response=mock_resp)
+        )
+        router._adapters["backup"] = FakeProvider()
+
+        chunks = []
+        async for chunk in router.stream(_make_request()):
+            chunks.append(chunk)
+        assert chunks == ["data: ok\n\n"]
+
+    @pytest.mark.asyncio
+    async def test_stream_non_retryable_http_error_is_raised(self):
+        cfg = BifrostConfig(
+            providers={
+                "openai": ProviderConfig(models=["gpt-4o"]),
+                "backup": ProviderConfig(models=["gpt-4o"]),
+            },
+            failover_enabled=True,
+        )
+        router = ModelRouter(cfg)
+        mock_resp = MagicMock()
+        mock_resp.status_code = 400
+        router._adapters["openai"] = FakeProvider(
+            raises=httpx.HTTPStatusError("bad req", request=MagicMock(), response=mock_resp)
+        )
+        router._adapters["backup"] = FakeProvider()
+
+        with pytest.raises(httpx.HTTPStatusError):
+            async for _ in router.stream(_make_request()):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_stream_all_providers_fail_raises_router_error(self):
+        cfg = BifrostConfig(
+            providers={
+                "openai": ProviderConfig(models=["gpt-4o"]),
+                "backup": ProviderConfig(models=["gpt-4o"]),
+            },
+            failover_enabled=True,
+        )
+        router = ModelRouter(cfg)
+        router._adapters["openai"] = FakeProvider(raises=ProviderError("down"))
+        router._adapters["backup"] = FakeProvider(raises=ProviderError("also down"))
+
+        with pytest.raises(RouterError, match="All providers failed"):
+            async for _ in router.stream(_make_request()):
+                pass
+
+
+# ---------------------------------------------------------------------------
+# to_openai.py coverage gaps — _content_to_openai_text, _message_to_openai
+# ---------------------------------------------------------------------------
+
+
+class TestContentToOpenaiText:
+    """Audit: content flattening handles all block types."""
+
+    def test_string_passthrough(self):
+        assert _content_to_openai_text("hello") == "hello"
+
+    def test_list_of_text_blocks(self):
+        blocks = [TextBlock(text="foo"), TextBlock(text="bar")]
+        assert _content_to_openai_text(blocks) == "foobar"
+
+    def test_non_text_blocks_skipped(self):
+        blocks = [
+            TextBlock(text="before"),
+            ToolUseBlock(id="t1", name="my_tool", input={}),
+            TextBlock(text="after"),
+        ]
+        assert _content_to_openai_text(blocks) == "beforeafter"
+
+
+class TestMessageToOpenai:
+    """Audit: message translation handles all edge cases."""
+
+    def test_empty_content_block_list_produces_empty_content(self):
+        """Message with no text and no tool use → empty content string."""
+        msg = Message(role="user", content=[])
+        result = _message_to_openai(msg)
+        assert result == [{"role": "user", "content": ""}]
+
+    def test_tool_result_with_list_content(self):
+        """ToolResultBlock with list[TextBlock] content is flattened."""
+        msg = Message(
+            role="user",
+            content=[
+                ToolResultBlock(
+                    tool_use_id="t1",
+                    content=[TextBlock(text="result text")],
+                )
+            ],
+        )
+        result = _message_to_openai(msg)
+        assert result[0]["role"] == "tool"
+        assert result[0]["content"] == "result text"
+
+
+class TestAnthropicToOpenaiEdgeCases:
+    """Audit: anthropic_to_openai covers all optional field paths."""
+
+    def test_tool_choice_any_maps_to_required(self):
+        req = AnthropicRequest(
+            model="gpt-4o",
+            max_tokens=100,
+            messages=[Message(role="user", content="hi")],
+            tools=[ToolDefinition(name="my_tool", input_schema={})],
+            tool_choice=ToolChoiceAny(),
+        )
+        payload = anthropic_to_openai(req, "gpt-4o")
+        assert payload["tool_choice"] == "required"
+
+    def test_tool_choice_specific_tool(self):
+        req = AnthropicRequest(
+            model="gpt-4o",
+            max_tokens=100,
+            messages=[Message(role="user", content="hi")],
+            tools=[ToolDefinition(name="my_tool", input_schema={})],
+            tool_choice=ToolChoiceTool(name="my_tool"),
+        )
+        payload = anthropic_to_openai(req, "gpt-4o")
+        assert payload["tool_choice"] == {"type": "function", "function": {"name": "my_tool"}}
+
+    def test_no_tool_choice_when_no_tools(self):
+        req = AnthropicRequest(
+            model="gpt-4o",
+            max_tokens=100,
+            messages=[Message(role="user", content="hi")],
+        )
+        payload = anthropic_to_openai(req, "gpt-4o")
+        assert "tool_choice" not in payload
+        assert "tools" not in payload
+
+    def test_system_blocks_concatenated(self):
+        req = AnthropicRequest(
+            model="gpt-4o",
+            max_tokens=100,
+            messages=[Message(role="user", content="hi")],
+            system=[TextBlock(text="You are"), TextBlock(text=" helpful.")],
+        )
+        payload = anthropic_to_openai(req, "gpt-4o")
+        assert payload["messages"][0]["role"] == "system"
+        assert payload["messages"][0]["content"] == "You are helpful."


### PR DESCRIPTION
## Summary

Audit of the existing Bifröst implementation against the architecture vision (NIU-474).

- **13 checklist items pass** — core functionality is solid
- **4 gaps identified** and filed as child issues (all blocked-by NIU-474)
- Coverage improved from **93% to 97%** on the bifrost package
- All 153 tests pass, lint clean

## Changes

### docs/bifrost-audit.md
Full audit report with checklist table, gap details, and coverage summary.

### tests/test_bifrost/test_audit.py (25 new tests)
Targeted tests that verify the audit checklist items and fill coverage gaps:

| Class | What it covers |
|-------|---------------|
| TestInboundLayer | POST /v1/messages, GET /v1/models, streaming headers, correlation ID |
| TestExtractUsageFromSseLine | message_start token extraction, message_delta output tokens, edge cases |
| TestLoadAdapter | api_key env-var forwarding, custom timeout, unknown provider fallback |
| TestStreamingFailover | HTTP 503 stream failover, non-retryable 400 raises, all-fail RouterError |
| TestContentToOpenaiText | string passthrough, block list, non-text block skipping |
| TestMessageToOpenai | empty content list, tool_result with list[TextBlock] content |
| TestAnthropicToOpenaiEdgeCases | tool_choice=any/tool, no tools, system blocks concatenation |

### Format fixes
src/bifrost/app.py and tests/test_bifrost/conftest.py reformatted by ruff.

## Gaps filed as child issues

| Issue | Title | Priority |
|-------|-------|----------|
| NIU-511 | Add missing routing strategies (cost_optimised, round_robin, latency_optimised) | High |
| NIU-512 | Handle cache_control field in translation layer | Medium |
| NIU-514 | Add Pi-mode config example (local-only, no auth) | Medium |
| NIU-513 | Extract inbound/ package layer from app.py | Low |

## Test plan

- [x] uv run pytest tests/test_bifrost/ — 153 passed
- [x] uv run ruff check src/bifrost/ tests/test_bifrost/ — no issues
- [x] uv run ruff format --check src/bifrost/ tests/test_bifrost/ — all formatted
- [x] Coverage: 97% (well above 85% minimum)

Generated with Claude Code