### PR TITLE
feat(bifrost): NIU-476 unified model listing endpoint (GET /v1/models)

### DIFF
--- a/src/bifrost/app.py
+++ b/src/bifrost/app.py
@@ -125,13 +125,39 @@ def create_app(config: BifrostConfig) -> FastAPI:
 
     @app.get("/v1/models")
     async def list_models() -> dict:
-        """List models available across all configured providers."""
+        """List models available across all configured providers.
+
+        Returns an OpenAI-compatible list response including both canonical
+        model IDs and any configured aliases.
+        """
         models: list[ModelInfo] = []
-        for provider_cfg in config.providers.values():
+        seen: set[str] = set()
+
+        for provider_name, provider_cfg in config.providers.items():
             for model_id in provider_cfg.models:
-                models.append(ModelInfo(id=model_id, display_name=model_id))
+                if model_id in seen:
+                    continue
+                seen.add(model_id)
+                models.append(ModelInfo(id=model_id, display_name=model_id, owned_by=provider_name))
+
+        for alias, canonical in config.aliases.items():
+            if alias in seen:
+                continue
+            seen.add(alias)
+            provider_name = config.provider_for_model(canonical) or "unknown"
+            models.append(ModelInfo(id=alias, display_name=canonical, owned_by=provider_name))
+
         return {
-            "data": [{"id": m.id, "type": "model", "display_name": m.display_name} for m in models]
+            "object": "list",
+            "data": [
+                {
+                    "id": m.id,
+                    "object": "model",
+                    "owned_by": m.owned_by,
+                    "display_name": m.display_name,
+                }
+                for m in models
+            ],
         }
 
     @app.post("/v1/messages", response_model=None)

--- a/src/bifrost/domain/models.py
+++ b/src/bifrost/domain/models.py
@@ -22,6 +22,7 @@ class ModelInfo:
 
     id: str
     display_name: str
+    owned_by: str = ""
 
 
 @dataclass

--- a/tests/test_bifrost/test_models_endpoint.py
+++ b/tests/test_bifrost/test_models_endpoint.py
@@ -4,31 +4,161 @@ from __future__ import annotations
 
 from fastapi.testclient import TestClient
 
+from bifrost.app import create_app
+from bifrost.config import BifrostConfig, ProviderConfig
+
 
 class TestModelsEndpoint:
     def test_list_models_returns_200(self, client: TestClient) -> None:
         response = client.get("/v1/models")
         assert response.status_code == 200
 
+    def test_list_models_top_level_object_field(self, client: TestClient) -> None:
+        body = client.get("/v1/models").json()
+        assert body.get("object") == "list"
+
     def test_list_models_returns_data_list(self, client: TestClient) -> None:
-        response = client.get("/v1/models")
-        body = response.json()
+        body = client.get("/v1/models").json()
         assert "data" in body
         assert isinstance(body["data"], list)
 
     def test_list_models_contains_expected_models(self, client: TestClient) -> None:
-        response = client.get("/v1/models")
-        data = response.json()["data"]
+        data = client.get("/v1/models").json()["data"]
         ids = {m["id"] for m in data}
         assert "claude-sonnet-4-6" in ids
         assert "claude-opus-4-6" in ids
 
-    def test_list_models_has_type_field(self, client: TestClient) -> None:
-        response = client.get("/v1/models")
-        data = response.json()["data"]
-        assert all(m.get("type") == "model" for m in data)
+    def test_list_models_has_object_field(self, client: TestClient) -> None:
+        data = client.get("/v1/models").json()["data"]
+        assert all(m.get("object") == "model" for m in data)
 
     def test_list_models_has_display_name(self, client: TestClient) -> None:
-        response = client.get("/v1/models")
-        data = response.json()["data"]
+        data = client.get("/v1/models").json()["data"]
         assert all("display_name" in m for m in data)
+
+    def test_list_models_has_owned_by(self, client: TestClient) -> None:
+        data = client.get("/v1/models").json()["data"]
+        assert all("owned_by" in m for m in data)
+
+    def test_list_models_owned_by_is_provider_name(self, client: TestClient) -> None:
+        data = client.get("/v1/models").json()["data"]
+        assert all(m["owned_by"] == "anthropic" for m in data)
+
+
+class TestModelsEndpointAliases:
+    def test_aliases_included_in_model_list(self) -> None:
+        config = BifrostConfig(
+            providers={"anthropic": ProviderConfig(models=["claude-sonnet-4-6"])},
+            aliases={"smart": "claude-sonnet-4-6"},
+        )
+        app = create_app(config)
+        with TestClient(app) as client:
+            data = client.get("/v1/models").json()["data"]
+        ids = {m["id"] for m in data}
+        assert "smart" in ids
+
+    def test_alias_display_name_is_canonical_model(self) -> None:
+        config = BifrostConfig(
+            providers={"anthropic": ProviderConfig(models=["claude-sonnet-4-6"])},
+            aliases={"smart": "claude-sonnet-4-6"},
+        )
+        app = create_app(config)
+        with TestClient(app) as client:
+            data = client.get("/v1/models").json()["data"]
+        alias_entry = next(m for m in data if m["id"] == "smart")
+        assert alias_entry["display_name"] == "claude-sonnet-4-6"
+
+    def test_alias_owned_by_resolves_to_provider(self) -> None:
+        config = BifrostConfig(
+            providers={"anthropic": ProviderConfig(models=["claude-sonnet-4-6"])},
+            aliases={"smart": "claude-sonnet-4-6"},
+        )
+        app = create_app(config)
+        with TestClient(app) as client:
+            data = client.get("/v1/models").json()["data"]
+        alias_entry = next(m for m in data if m["id"] == "smart")
+        assert alias_entry["owned_by"] == "anthropic"
+
+    def test_no_duplicate_entries_when_alias_matches_canonical(self) -> None:
+        config = BifrostConfig(
+            providers={"anthropic": ProviderConfig(models=["claude-sonnet-4-6"])},
+            aliases={"claude-sonnet-4-6": "claude-sonnet-4-6"},
+        )
+        app = create_app(config)
+        with TestClient(app) as client:
+            data = client.get("/v1/models").json()["data"]
+        ids = [m["id"] for m in data]
+        assert ids.count("claude-sonnet-4-6") == 1
+
+    def test_alias_with_unknown_canonical_owned_by_unknown(self) -> None:
+        config = BifrostConfig(
+            providers={"anthropic": ProviderConfig(models=["claude-sonnet-4-6"])},
+            aliases={"mystery": "some-unknown-model"},
+        )
+        app = create_app(config)
+        with TestClient(app) as client:
+            data = client.get("/v1/models").json()["data"]
+        alias_entry = next(m for m in data if m["id"] == "mystery")
+        assert alias_entry["owned_by"] == "unknown"
+
+    def test_no_aliases_config_returns_only_provider_models(self) -> None:
+        config = BifrostConfig(
+            providers={
+                "anthropic": ProviderConfig(models=["claude-sonnet-4-6", "claude-opus-4-6"])
+            },
+        )
+        app = create_app(config)
+        with TestClient(app) as client:
+            data = client.get("/v1/models").json()["data"]
+        assert len(data) == 2
+
+
+class TestModelsEndpointMultiProvider:
+    def test_models_from_all_providers_included(self) -> None:
+        config = BifrostConfig(
+            providers={
+                "anthropic": ProviderConfig(models=["claude-sonnet-4-6"]),
+                "openai": ProviderConfig(models=["gpt-4o"]),
+            }
+        )
+        app = create_app(config)
+        with TestClient(app) as client:
+            data = client.get("/v1/models").json()["data"]
+        ids = {m["id"] for m in data}
+        assert "claude-sonnet-4-6" in ids
+        assert "gpt-4o" in ids
+
+    def test_owned_by_reflects_correct_provider(self) -> None:
+        config = BifrostConfig(
+            providers={
+                "anthropic": ProviderConfig(models=["claude-sonnet-4-6"]),
+                "openai": ProviderConfig(models=["gpt-4o"]),
+            }
+        )
+        app = create_app(config)
+        with TestClient(app) as client:
+            data = client.get("/v1/models").json()["data"]
+        by_id = {m["id"]: m for m in data}
+        assert by_id["claude-sonnet-4-6"]["owned_by"] == "anthropic"
+        assert by_id["gpt-4o"]["owned_by"] == "openai"
+
+    def test_deduplicates_model_listed_in_multiple_providers(self) -> None:
+        config = BifrostConfig(
+            providers={
+                "anthropic": ProviderConfig(models=["claude-sonnet-4-6"]),
+                "mirror": ProviderConfig(models=["claude-sonnet-4-6"]),
+            }
+        )
+        app = create_app(config)
+        with TestClient(app) as client:
+            data = client.get("/v1/models").json()["data"]
+        ids = [m["id"] for m in data]
+        assert ids.count("claude-sonnet-4-6") == 1
+
+    def test_empty_providers_returns_empty_data(self) -> None:
+        config = BifrostConfig(providers={})
+        app = create_app(config)
+        with TestClient(app) as client:
+            body = client.get("/v1/models").json()
+        assert body["object"] == "list"
+        assert body["data"] == []


### PR DESCRIPTION
## Summary

- **OpenAI-compatible response shape**: `GET /v1/models` now returns `{object: 'list', data: [{id, object: 'model', owned_by, display_name}]}` matching the OpenAI Models API format
- **Multi-provider aggregation**: models from all configured providers are collected and attributed with the correct `owned_by` provider name
- **Alias discovery**: configured aliases are included as additional entries; `display_name` shows the canonical model the alias resolves to, `owned_by` reflects the underlying provider
- **Deduplication**: models listed in multiple providers appear only once (first provider wins)
- **`ModelInfo` domain model**: extended with `owned_by` field

## Changes

| File | Change |
|---|---|
| `src/bifrost/app.py` | Rewrote `list_models()` — OpenAI shape, aliases, deduplication |
| `src/bifrost/domain/models.py` | Added `owned_by: str` to `ModelInfo` |
| `tests/test_bifrost/test_models_endpoint.py` | Expanded from 5 → 18 tests; covers multi-provider, aliases, deduplication, empty config |

## Test plan

- [x] All 166 bifrost tests pass
- [x] 98% coverage on `src/bifrost/`
- [x] `ruff check` and `ruff format --check` clean
- [x] `object: "list"` at top level
- [x] `object: "model"` on each item
- [x] Aliases included with resolved `owned_by`
- [x] Deduplication when model in multiple providers
- [x] Empty provider config returns `{object: 'list', data: []}`

Closes NIU-476

🤖 Generated with [Claude Code](https://claude.com/claude-code)