### PR TITLE
feat(bifrost): NIU-475 OpenAI-compatible inbound endpoint (POST /v1/chat/completions)

### DIFF
--- a/src/bifrost/app.py
+++ b/src/bifrost/app.py
@@ -27,6 +27,13 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from bifrost.auth import AgentIdentity, extract_identity
 from bifrost.config import AgentPermissions, BifrostConfig
 from bifrost.domain.models import ModelInfo, RequestLog, TokenUsage
+from bifrost.inbound.chat_completions import (
+    OpenAIChatRequest,
+    anthropic_response_to_openai,
+    anthropic_stream_to_openai,
+    openai_error_response,
+    openai_request_to_anthropic,
+)
 from bifrost.ports.usage_store import UsageRecord, UsageStore
 from bifrost.pricing import ModelPricing, calculate_cost
 from bifrost.router import ModelRouter, RouterError
@@ -537,5 +544,112 @@ def create_app(config: BifrostConfig) -> FastAPI:
                 for r in records
             ],
         }
+
+    @app.post("/v1/chat/completions", response_model=None)
+    async def chat_completions(raw_request: Request) -> JSONResponse | StreamingResponse:
+        """OpenAI Chat Completions-compatible endpoint.
+
+        Accepts an OpenAI Chat Completions request, translates it to the
+        internal Anthropic canonical format, routes via the shared ModelRouter,
+        then translates the response back to OpenAI format.  The full streaming
+        path is supported; token usage is extracted and logged on each request.
+        """
+        # --- Authentication ---
+        identity = extract_identity(raw_request, auth_mode, pat_secret)
+
+        try:
+            body = await raw_request.json()
+            oai_request = OpenAIChatRequest.model_validate(body)
+        except Exception as exc:
+            return openai_error_response(422, str(exc), "invalid_request_error")
+
+        request = openai_request_to_anthropic(oai_request)
+
+        # --- Model access control ---
+        agent_perms = config.permissions_for_agent(identity.agent_id)
+        try:
+            _check_model_access(identity, request.model, agent_perms)
+        except HTTPException as exc:
+            return openai_error_response(exc.status_code, exc.detail, "invalid_request_error")
+
+        # --- Quota check (before routing) ---
+        try:
+            warnings = await _check_quotas(identity, config, store, agent_perms)
+        except HTTPException as exc:
+            return openai_error_response(exc.status_code, exc.detail, "rate_limit_error")
+
+        request_id = str(raw_request.state.correlation_id)
+        start = time.monotonic()
+
+        try:
+            if request.stream:
+                message_id = f"chatcmpl-{uuid.uuid4().hex[:24]}"
+                stream_resp = StreamingResponse(
+                    anthropic_stream_to_openai(
+                        _stream_with_tracking(
+                            router.stream(request),
+                            request.model,
+                            start,
+                            identity,
+                            store,
+                            pricing_overrides,
+                            request_id,
+                        ),
+                        message_id=message_id,
+                        model=request.model,
+                    ),
+                    media_type="text/event-stream",
+                    headers={
+                        "cache-control": "no-cache",
+                        "x-accel-buffering": "no",
+                        "connection": "keep-alive",
+                    },
+                )
+                if warnings:
+                    stream_resp.headers[_HEADER_QUOTA_WARNING] = "; ".join(warnings)
+                return stream_resp
+
+            response = await router.complete(request)
+            latency_ms = (time.monotonic() - start) * 1000
+            usage = TokenUsage(
+                input_tokens=response.usage.input_tokens,
+                output_tokens=response.usage.output_tokens,
+                cache_creation_input_tokens=0,
+                cache_read_input_tokens=0,
+            )
+            _log_request(
+                RequestLog(
+                    timestamp=datetime.now(UTC),
+                    model=request.model,
+                    usage=usage,
+                    latency_ms=latency_ms,
+                    stream=False,
+                )
+            )
+
+            cost = calculate_cost(request.model, usage, pricing_overrides)
+            await store.record(
+                UsageRecord(
+                    request_id=request_id,
+                    agent_id=identity.agent_id,
+                    tenant_id=identity.tenant_id,
+                    session_id=identity.session_id,
+                    saga_id=identity.saga_id,
+                    model=request.model,
+                    input_tokens=usage.input_tokens,
+                    output_tokens=usage.output_tokens,
+                    cost_usd=cost,
+                    timestamp=datetime.now(UTC),
+                )
+            )
+
+            json_resp = JSONResponse(content=anthropic_response_to_openai(response))
+            if warnings:
+                json_resp.headers[_HEADER_QUOTA_WARNING] = "; ".join(warnings)
+            return json_resp
+
+        except RouterError as exc:
+            logger.error("Routing failed: %s", exc)
+            return openai_error_response(502, str(exc), "server_error")
 
     return app

--- a/src/bifrost/inbound/__init__.py
+++ b/src/bifrost/inbound/__init__.py
@@ -1,0 +1,1 @@
+"""Bifröst inbound interface modules."""

--- a/src/bifrost/inbound/chat_completions.py
+++ b/src/bifrost/inbound/chat_completions.py
@@ -1,0 +1,511 @@
+"""OpenAI Chat Completions inbound interface for Bifröst.
+
+Accepts POST /v1/chat/completions in OpenAI format, normalises the request
+to the internal Anthropic canonical form, routes via the shared ModelRouter,
+then translates the response (and SSE stream) back to OpenAI format.
+
+This enables any OpenAI-SDK-based tool (Continue, Cursor, openai-python,
+etc.) to point at Bifröst without code changes.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import AsyncIterator
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from bifrost.translation.models import (
+    AnthropicRequest,
+    AnthropicResponse,
+    ContentBlock,
+    Message,
+    TextBlock,
+    ThinkingBlock,
+    ToolChoiceAny,
+    ToolChoiceAuto,
+    ToolChoiceTool,
+    ToolDefinition,
+    ToolResultBlock,
+    ToolUseBlock,
+)
+
+# ---------------------------------------------------------------------------
+# Stop-reason mapping (Anthropic → OpenAI)
+# ---------------------------------------------------------------------------
+
+STOP_REASON_TO_OPENAI: dict[str, str] = {
+    "end_turn": "stop",
+    "tool_use": "tool_calls",
+    "max_tokens": "length",
+    "stop_sequence": "stop",
+}
+
+# ---------------------------------------------------------------------------
+# OpenAI request Pydantic models
+# ---------------------------------------------------------------------------
+
+
+class _OpenAIFunction(BaseModel):
+    name: str
+    description: str = ""
+    parameters: dict[str, Any] = Field(default_factory=dict)
+
+
+class _OpenAITool(BaseModel):
+    type: Literal["function"] = "function"
+    function: _OpenAIFunction
+
+
+class _OpenAIToolCall(BaseModel):
+    id: str = ""
+    type: str = "function"
+    function: dict[str, Any] = Field(default_factory=dict)
+
+
+class _OpenAIMessage(BaseModel):
+    role: str
+    content: str | list[dict[str, Any]] | None = None
+    tool_calls: list[_OpenAIToolCall] | None = None
+    tool_call_id: str | None = None
+
+
+class OpenAIChatRequest(BaseModel):
+    """Pydantic model for an OpenAI Chat Completions request."""
+
+    model: str
+    messages: list[_OpenAIMessage]
+    max_tokens: int | None = None
+    temperature: float | None = None
+    top_p: float | None = None
+    stop: str | list[str] | None = None
+    stream: bool = False
+    tools: list[_OpenAITool] | None = None
+    tool_choice: str | dict[str, Any] | None = None
+    metadata: dict[str, Any] | None = None
+
+
+# ---------------------------------------------------------------------------
+# Request translation: OpenAI → Anthropic canonical
+# ---------------------------------------------------------------------------
+
+
+def _extract_text_content(content: str | list[dict[str, Any]] | None) -> str:
+    """Flatten an OpenAI message content value to a plain string."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    parts: list[str] = []
+    for part in content:
+        if part.get("type") == "text":
+            parts.append(part.get("text", ""))
+    return "".join(parts)
+
+
+def _build_user_content(msg: _OpenAIMessage) -> str | list[ContentBlock]:
+    """Build Anthropic content for a user-role message."""
+    text = _extract_text_content(msg.content)
+    if not text:
+        return ""
+    return text
+
+
+def _build_assistant_content(msg: _OpenAIMessage) -> str | list[ContentBlock]:
+    """Build Anthropic content for an assistant-role message."""
+    text = _extract_text_content(msg.content)
+    tool_calls = msg.tool_calls or []
+
+    if not text and not tool_calls:
+        return ""
+
+    if not tool_calls:
+        return text
+
+    blocks: list[ContentBlock] = []
+    if text:
+        blocks.append(TextBlock(text=text))
+
+    for tc in tool_calls:
+        fn = tc.function
+        arguments_raw = fn.get("arguments", "{}")
+        try:
+            tool_input = json.loads(arguments_raw)
+        except json.JSONDecodeError:
+            tool_input = {"raw": arguments_raw}
+        blocks.append(
+            ToolUseBlock(
+                id=tc.id,
+                name=fn.get("name", ""),
+                input=tool_input,
+            )
+        )
+
+    return blocks
+
+
+def _openai_tool_choice_to_anthropic(
+    tool_choice: str | dict[str, Any] | None,
+) -> ToolChoiceAuto | ToolChoiceAny | ToolChoiceTool | None:
+    """Translate an OpenAI tool_choice value to the Anthropic equivalent."""
+    if tool_choice is None or tool_choice == "none":
+        return None
+    if tool_choice == "auto":
+        return ToolChoiceAuto()
+    if tool_choice == "required":
+        return ToolChoiceAny()
+    if isinstance(tool_choice, dict) and tool_choice.get("type") == "function":
+        name = tool_choice.get("function", {}).get("name", "")
+        return ToolChoiceTool(name=name)
+    return ToolChoiceAuto()
+
+
+def openai_request_to_anthropic(req: OpenAIChatRequest) -> AnthropicRequest:
+    """Convert an OpenAI Chat Completions request to Anthropic canonical format.
+
+    Args:
+        req: Parsed OpenAI Chat Completions request.
+
+    Returns:
+        An ``AnthropicRequest`` ready for the routing layer.
+    """
+    system_parts: list[str] = []
+    anthropic_messages: list[Message] = []
+    pending_tool_results: list[ToolResultBlock] = []
+
+    for msg in req.messages:
+        if msg.role == "system":
+            text = _extract_text_content(msg.content)
+            if text:
+                system_parts.append(text)
+            continue
+
+        # Flush accumulated tool results when a non-tool message appears.
+        if pending_tool_results and msg.role != "tool":
+            anthropic_messages.append(Message(role="user", content=list(pending_tool_results)))
+            pending_tool_results = []
+
+        if msg.role == "tool":
+            content_text = _extract_text_content(msg.content)
+            pending_tool_results.append(
+                ToolResultBlock(
+                    tool_use_id=msg.tool_call_id or "",
+                    content=content_text,
+                )
+            )
+            continue
+
+        if msg.role == "user":
+            content = _build_user_content(msg)
+            anthropic_messages.append(Message(role="user", content=content))
+            continue
+
+        if msg.role == "assistant":
+            content = _build_assistant_content(msg)
+            anthropic_messages.append(Message(role="assistant", content=content))
+
+    # Flush any remaining tool results at end of message list.
+    if pending_tool_results:
+        anthropic_messages.append(Message(role="user", content=list(pending_tool_results)))
+
+    system: str | None = "\n\n".join(system_parts) if system_parts else None
+
+    # Tool definitions.
+    tools: list[ToolDefinition] | None = None
+    if req.tools and req.tool_choice != "none":
+        tools = [
+            ToolDefinition(
+                name=t.function.name,
+                description=t.function.description,
+                input_schema=t.function.parameters,
+            )
+            for t in req.tools
+        ]
+
+    # Tool choice — only meaningful when tools are present.
+    tool_choice = _openai_tool_choice_to_anthropic(req.tool_choice) if tools else None
+
+    # Stop sequences.
+    stop_sequences: list[str] | None = None
+    if req.stop:
+        stop_sequences = [req.stop] if isinstance(req.stop, str) else list(req.stop)
+
+    return AnthropicRequest(
+        model=req.model,
+        max_tokens=req.max_tokens or 1024,
+        messages=anthropic_messages,
+        system=system,
+        tools=tools,
+        tool_choice=tool_choice,
+        temperature=req.temperature,
+        top_p=req.top_p,
+        stop_sequences=stop_sequences,
+        stream=req.stream,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Response translation: Anthropic canonical → OpenAI
+# ---------------------------------------------------------------------------
+
+
+def anthropic_response_to_openai(response: AnthropicResponse) -> dict[str, Any]:
+    """Convert an Anthropic Messages API response to OpenAI Chat Completions format.
+
+    Args:
+        response: The Anthropic canonical response from the routing layer.
+
+    Returns:
+        A dict ready to be JSON-serialised and returned to the caller.
+    """
+    text_parts: list[str] = []
+    tool_calls: list[dict[str, Any]] = []
+
+    for block in response.content:
+        if isinstance(block, TextBlock):
+            text_parts.append(block.text)
+        elif isinstance(block, ThinkingBlock):
+            text_parts.append(f"<thinking>{block.thinking}</thinking>")
+        elif isinstance(block, ToolUseBlock):
+            tool_calls.append(
+                {
+                    "id": block.id,
+                    "type": "function",
+                    "function": {
+                        "name": block.name,
+                        "arguments": json.dumps(block.input),
+                    },
+                }
+            )
+
+    text = "".join(text_parts)
+    finish_reason = STOP_REASON_TO_OPENAI.get(response.stop_reason or "end_turn", "stop")
+
+    message: dict[str, Any] = {"role": "assistant", "content": text or None}
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+
+    return {
+        "id": response.id,
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": response.model,
+        "choices": [
+            {
+                "index": 0,
+                "message": message,
+                "finish_reason": finish_reason,
+                "logprobs": None,
+            }
+        ],
+        "usage": {
+            "prompt_tokens": response.usage.input_tokens,
+            "completion_tokens": response.usage.output_tokens,
+            "total_tokens": response.usage.input_tokens + response.usage.output_tokens,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Streaming translation: Anthropic SSE → OpenAI delta SSE
+# ---------------------------------------------------------------------------
+
+
+def _openai_chunk(
+    message_id: str,
+    model: str,
+    created: int,
+    delta: dict[str, Any],
+    finish_reason: str | None = None,
+    usage: dict[str, Any] | None = None,
+) -> str:
+    """Format a single OpenAI SSE chunk."""
+    payload: dict[str, Any] = {
+        "id": message_id,
+        "object": "chat.completion.chunk",
+        "created": created,
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "delta": delta,
+                "finish_reason": finish_reason,
+                "logprobs": None,
+            }
+        ],
+    }
+    if usage is not None:
+        payload["usage"] = usage
+    return f"data: {json.dumps(payload)}\n\n"
+
+
+async def anthropic_stream_to_openai(
+    source: AsyncIterator[str],
+    *,
+    message_id: str,
+    model: str,
+) -> AsyncIterator[str]:
+    """Translate a Bifröst Anthropic SSE stream to OpenAI delta SSE format.
+
+    The source is the output of ``router.stream()``, which may produce either
+    individual SSE field lines (AnthropicAdapter) or complete multi-line SSE
+    event strings (OpenAICompatAdapter via ``openai_stream_to_anthropic``).
+    Both formats are handled by splitting on newlines and buffering the current
+    event type.
+
+    Args:
+        source: Async iterator of raw SSE strings from the routing layer.
+        message_id: ID to embed in every chunk (taken from the ``message_start``
+            event if available, otherwise the caller-supplied fallback).
+        model: Model name to embed in every chunk.
+
+    Yields:
+        OpenAI-formatted SSE strings (``data: {...}\\n\\n`` and ``data: [DONE]\\n\\n``).
+    """
+    created = int(time.time())
+    current_event_type = ""
+    input_tokens = 0
+    output_tokens = 0
+    emitted_role = False
+
+    # Anthropic block-index → OpenAI tool_call index mapping.
+    tool_block_index_map: dict[int, int] = {}
+    tool_call_counter = 0
+
+    async for raw in source:
+        for raw_line in raw.split("\n"):
+            line = raw_line.strip()
+
+            if not line:
+                current_event_type = ""
+                continue
+
+            if line.startswith("event: "):
+                current_event_type = line[7:]
+                continue
+
+            if not line.startswith("data: "):
+                continue
+
+            payload_str = line[6:]
+
+            if payload_str == "[DONE]":
+                yield "data: [DONE]\n\n"
+                return
+
+            try:
+                payload = json.loads(payload_str)
+            except json.JSONDecodeError:
+                continue
+
+            event_type = current_event_type or payload.get("type", "")
+
+            if event_type in ("ping",):
+                continue
+
+            if event_type == "message_start":
+                msg = payload.get("message", {})
+                # Use the actual message ID from the upstream event when available.
+                upstream_id = msg.get("id")
+                if upstream_id:
+                    message_id = upstream_id
+                usage = msg.get("usage", {})
+                input_tokens = usage.get("input_tokens", 0)
+
+                if not emitted_role:
+                    emitted_role = True
+                    yield _openai_chunk(
+                        message_id,
+                        model,
+                        created,
+                        {"role": "assistant", "content": ""},
+                    )
+
+            elif event_type == "content_block_start":
+                index = payload.get("index", 0)
+                cb = payload.get("content_block", {})
+                cb_type = cb.get("type", "text")
+
+                if cb_type == "tool_use":
+                    tc_index = tool_call_counter
+                    tool_block_index_map[index] = tc_index
+                    tool_call_counter += 1
+
+                    yield _openai_chunk(
+                        message_id,
+                        model,
+                        created,
+                        {
+                            "tool_calls": [
+                                {
+                                    "index": tc_index,
+                                    "id": cb.get("id", ""),
+                                    "type": "function",
+                                    "function": {
+                                        "name": cb.get("name", ""),
+                                        "arguments": "",
+                                    },
+                                }
+                            ]
+                        },
+                    )
+
+            elif event_type == "content_block_delta":
+                index = payload.get("index", 0)
+                delta = payload.get("delta", {})
+                delta_type = delta.get("type", "")
+
+                if delta_type == "text_delta":
+                    text = delta.get("text", "")
+                    yield _openai_chunk(
+                        message_id,
+                        model,
+                        created,
+                        {"content": text},
+                    )
+
+                elif delta_type == "input_json_delta":
+                    partial_json = delta.get("partial_json", "")
+                    tc_index = tool_block_index_map.get(index, 0)
+                    yield _openai_chunk(
+                        message_id,
+                        model,
+                        created,
+                        {
+                            "tool_calls": [
+                                {
+                                    "index": tc_index,
+                                    "function": {"arguments": partial_json},
+                                }
+                            ]
+                        },
+                    )
+
+            elif event_type == "message_delta":
+                delta = payload.get("delta", {})
+                stop_reason = delta.get("stop_reason", "end_turn")
+                usage = payload.get("usage", {})
+                output_tokens = usage.get("output_tokens", output_tokens)
+                finish_reason = STOP_REASON_TO_OPENAI.get(stop_reason, "stop")
+
+                yield _openai_chunk(
+                    message_id,
+                    model,
+                    created,
+                    {},
+                    finish_reason=finish_reason,
+                    usage={
+                        "prompt_tokens": input_tokens,
+                        "completion_tokens": output_tokens,
+                        "total_tokens": input_tokens + output_tokens,
+                    },
+                )
+
+            elif event_type == "message_stop":
+                yield "data: [DONE]\n\n"
+                return
+
+    # Fallback: if stream ended without message_stop, emit [DONE].
+    yield "data: [DONE]\n\n"

--- a/src/bifrost/inbound/chat_completions.py
+++ b/src/bifrost/inbound/chat_completions.py
@@ -15,9 +15,11 @@ import time
 from collections.abc import AsyncIterator
 from typing import Any, Literal
 
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
 from bifrost.translation.models import (
+    STOP_REASON_TO_OPENAI,
     AnthropicRequest,
     AnthropicResponse,
     ContentBlock,
@@ -29,19 +31,9 @@ from bifrost.translation.models import (
     ToolChoiceTool,
     ToolDefinition,
     ToolResultBlock,
-    ToolUseBlock,
 )
-
-# ---------------------------------------------------------------------------
-# Stop-reason mapping (Anthropic → OpenAI)
-# ---------------------------------------------------------------------------
-
-STOP_REASON_TO_OPENAI: dict[str, str] = {
-    "end_turn": "stop",
-    "tool_use": "tool_calls",
-    "max_tokens": "length",
-    "stop_sequence": "stop",
-}
+from bifrost.translation.to_anthropic import _openai_tool_calls_to_blocks
+from bifrost.translation.to_openai import _extract_tool_calls
 
 # ---------------------------------------------------------------------------
 # OpenAI request Pydantic models
@@ -88,6 +80,22 @@ class OpenAIChatRequest(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Error helper: produce OpenAI-shaped error responses
+# ---------------------------------------------------------------------------
+
+
+def openai_error_response(status: int, message: str, error_type: str) -> JSONResponse:
+    """Return a JSONResponse whose body matches the OpenAI error schema.
+
+    OpenAI SDK clients expect ``{"error": {"message": ..., "type": ..., ...}}``.
+    """
+    return JSONResponse(
+        status_code=status,
+        content={"error": {"message": message, "type": error_type, "param": None, "code": None}},
+    )
+
+
+# ---------------------------------------------------------------------------
 # Request translation: OpenAI → Anthropic canonical
 # ---------------------------------------------------------------------------
 
@@ -105,14 +113,6 @@ def _extract_text_content(content: str | list[dict[str, Any]] | None) -> str:
     return "".join(parts)
 
 
-def _build_user_content(msg: _OpenAIMessage) -> str | list[ContentBlock]:
-    """Build Anthropic content for a user-role message."""
-    text = _extract_text_content(msg.content)
-    if not text:
-        return ""
-    return text
-
-
 def _build_assistant_content(msg: _OpenAIMessage) -> str | list[ContentBlock]:
     """Build Anthropic content for an assistant-role message."""
     text = _extract_text_content(msg.content)
@@ -128,20 +128,8 @@ def _build_assistant_content(msg: _OpenAIMessage) -> str | list[ContentBlock]:
     if text:
         blocks.append(TextBlock(text=text))
 
-    for tc in tool_calls:
-        fn = tc.function
-        arguments_raw = fn.get("arguments", "{}")
-        try:
-            tool_input = json.loads(arguments_raw)
-        except json.JSONDecodeError:
-            tool_input = {"raw": arguments_raw}
-        blocks.append(
-            ToolUseBlock(
-                id=tc.id,
-                name=fn.get("name", ""),
-                input=tool_input,
-            )
-        )
+    tool_call_dicts = [{"id": tc.id, "function": tc.function} for tc in tool_calls]
+    blocks.extend(_openai_tool_calls_to_blocks(tool_call_dicts))
 
     return blocks
 
@@ -198,8 +186,9 @@ def openai_request_to_anthropic(req: OpenAIChatRequest) -> AnthropicRequest:
             continue
 
         if msg.role == "user":
-            content = _build_user_content(msg)
-            anthropic_messages.append(Message(role="user", content=content))
+            anthropic_messages.append(
+                Message(role="user", content=_extract_text_content(msg.content))
+            )
             continue
 
         if msg.role == "assistant":
@@ -261,26 +250,14 @@ def anthropic_response_to_openai(response: AnthropicResponse) -> dict[str, Any]:
         A dict ready to be JSON-serialised and returned to the caller.
     """
     text_parts: list[str] = []
-    tool_calls: list[dict[str, Any]] = []
-
     for block in response.content:
         if isinstance(block, TextBlock):
             text_parts.append(block.text)
         elif isinstance(block, ThinkingBlock):
             text_parts.append(f"<thinking>{block.thinking}</thinking>")
-        elif isinstance(block, ToolUseBlock):
-            tool_calls.append(
-                {
-                    "id": block.id,
-                    "type": "function",
-                    "function": {
-                        "name": block.name,
-                        "arguments": json.dumps(block.input),
-                    },
-                }
-            )
 
     text = "".join(text_parts)
+    tool_calls = _extract_tool_calls(response.content)
     finish_reason = STOP_REASON_TO_OPENAI.get(response.stop_reason or "end_turn", "stop")
 
     message: dict[str, Any] = {"role": "assistant", "content": text or None}

--- a/src/bifrost/translation/models.py
+++ b/src/bifrost/translation/models.py
@@ -177,3 +177,11 @@ FINISH_REASON_MAP: dict[str, str] = {
     "content_filter": "end_turn",
     "function_call": "tool_use",
 }
+
+# Mapping from Anthropic stop_reason → OpenAI finish_reason (inverse of FINISH_REASON_MAP).
+STOP_REASON_TO_OPENAI: dict[str, str] = {
+    "end_turn": "stop",
+    "tool_use": "tool_calls",
+    "max_tokens": "length",
+    "stop_sequence": "stop",
+}

--- a/tests/test_bifrost/test_chat_completions.py
+++ b/tests/test_bifrost/test_chat_completions.py
@@ -14,6 +14,7 @@ from bifrost.inbound.chat_completions import (
     OpenAIChatRequest,
     anthropic_response_to_openai,
     anthropic_stream_to_openai,
+    openai_error_response,
     openai_request_to_anthropic,
 )
 from bifrost.translation.models import (
@@ -1057,3 +1058,70 @@ class TestChatCompletionsEndpoint:
         call_args = mock_complete.call_args
         anthropic_req = call_args[0][0]
         assert anthropic_req.temperature == 0.5
+
+    def test_invalid_body_has_openai_error_shape(self):
+        with self._client() as client:
+            resp = client.post(
+                "/v1/chat/completions",
+                json={"not_a_valid_field": True},
+            )
+        body = resp.json()
+        assert "error" in body
+        assert "message" in body["error"]
+        assert body["error"]["type"] == "invalid_request_error"
+        assert body["error"]["param"] is None
+        assert body["error"]["code"] is None
+
+    @patch("bifrost.router.ModelRouter.complete", new_callable=AsyncMock)
+    def test_router_error_has_openai_error_shape(self, mock_complete):
+        from bifrost.router import RouterError
+
+        mock_complete.side_effect = RouterError("all providers failed")
+        with self._client() as client:
+            resp = client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "gpt-4o",
+                    "messages": [{"role": "user", "content": "Hi"}],
+                },
+            )
+        assert resp.status_code == 502
+        body = resp.json()
+        assert "error" in body
+        assert "all providers failed" in body["error"]["message"]
+        assert body["error"]["type"] == "server_error"
+
+    def test_unknown_model_error_has_openai_shape(self):
+        with self._client() as client:
+            resp = client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "no-such-model-xyz",
+                    "messages": [{"role": "user", "content": "Hi"}],
+                },
+            )
+        assert resp.status_code == 502
+        body = resp.json()
+        assert "error" in body
+        assert body["error"]["type"] == "server_error"
+
+
+# ---------------------------------------------------------------------------
+# openai_error_response helper
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIErrorResponse:
+    def test_status_code(self):
+        resp = openai_error_response(422, "bad input", "invalid_request_error")
+        assert resp.status_code == 422
+
+    def test_body_shape(self):
+        import json as _json
+
+        resp = openai_error_response(502, "upstream failed", "server_error")
+        body = _json.loads(resp.body)
+        assert body["error"]["message"] == "upstream failed"
+        assert body["error"]["type"] == "server_error"
+        assert body["error"]["param"] is None
+        assert body["error"]["code"] is None

--- a/tests/test_bifrost/test_chat_completions.py
+++ b/tests/test_bifrost/test_chat_completions.py
@@ -1,0 +1,1059 @@
+"""Tests for the OpenAI Chat Completions inbound interface."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from bifrost.app import create_app
+from bifrost.config import BifrostConfig, ProviderConfig
+from bifrost.inbound.chat_completions import (
+    OpenAIChatRequest,
+    anthropic_response_to_openai,
+    anthropic_stream_to_openai,
+    openai_request_to_anthropic,
+)
+from bifrost.translation.models import (
+    AnthropicResponse,
+    TextBlock,
+    ThinkingBlock,
+    ToolUseBlock,
+    UsageInfo,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config() -> BifrostConfig:
+    return BifrostConfig(
+        providers={"openai": ProviderConfig(models=["gpt-4o"])},
+    )
+
+
+def _make_anthropic_response(
+    text: str = "Hello!",
+    stop_reason: str = "end_turn",
+    input_tokens: int = 10,
+    output_tokens: int = 5,
+) -> AnthropicResponse:
+    return AnthropicResponse(
+        id="msg_test123",
+        content=[TextBlock(text=text)],
+        model="gpt-4o",
+        stop_reason=stop_reason,
+        usage=UsageInfo(input_tokens=input_tokens, output_tokens=output_tokens),
+    )
+
+
+def _parse_sse_chunks(body: str) -> list[dict]:
+    """Parse an SSE response body into a list of JSON payloads."""
+    chunks = []
+    for line in body.splitlines():
+        if line.startswith("data: ") and line[6:] != "[DONE]":
+            chunks.append(json.loads(line[6:]))
+    return chunks
+
+
+async def _async_iter(items: list[str]):
+    for item in items:
+        yield item
+
+
+# ---------------------------------------------------------------------------
+# Request translation: OpenAI → Anthropic
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIRequestToAnthropic:
+    def _req(self, **kwargs) -> OpenAIChatRequest:
+        defaults = {
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+        defaults.update(kwargs)
+        return OpenAIChatRequest.model_validate(defaults)
+
+    def test_simple_user_message(self):
+        req = self._req()
+        result = openai_request_to_anthropic(req)
+        assert result.model == "gpt-4o"
+        assert len(result.messages) == 1
+        assert result.messages[0].role == "user"
+        assert result.messages[0].content == "Hello"
+
+    def test_system_message_extracted(self):
+        req = self._req(
+            messages=[
+                {"role": "system", "content": "You are helpful."},
+                {"role": "user", "content": "Hello"},
+            ]
+        )
+        result = openai_request_to_anthropic(req)
+        assert result.system == "You are helpful."
+        assert len(result.messages) == 1
+        assert result.messages[0].role == "user"
+
+    def test_multiple_system_messages_joined(self):
+        req = self._req(
+            messages=[
+                {"role": "system", "content": "Part 1."},
+                {"role": "system", "content": "Part 2."},
+                {"role": "user", "content": "Hi"},
+            ]
+        )
+        result = openai_request_to_anthropic(req)
+        assert result.system == "Part 1.\n\nPart 2."
+
+    def test_no_system_message(self):
+        req = self._req()
+        result = openai_request_to_anthropic(req)
+        assert result.system is None
+
+    def test_assistant_text_message(self):
+        req = self._req(
+            messages=[
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi there!"},
+            ]
+        )
+        result = openai_request_to_anthropic(req)
+        assert result.messages[1].role == "assistant"
+        assert result.messages[1].content == "Hi there!"
+
+    def test_assistant_tool_calls_become_tool_use_blocks(self):
+        req = self._req(
+            messages=[
+                {"role": "user", "content": "What's the weather?"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_abc",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": '{"city": "Oslo"}',
+                            },
+                        }
+                    ],
+                },
+            ]
+        )
+        result = openai_request_to_anthropic(req)
+        asst_msg = result.messages[1]
+        assert asst_msg.role == "assistant"
+        content = asst_msg.content
+        assert isinstance(content, list)
+        assert isinstance(content[0], ToolUseBlock)
+        assert content[0].id == "call_abc"
+        assert content[0].name == "get_weather"
+        assert content[0].input == {"city": "Oslo"}
+
+    def test_tool_role_becomes_tool_result_block(self):
+        req = self._req(
+            messages=[
+                {"role": "user", "content": "Hello"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "lookup", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call_1", "content": "Result text"},
+            ]
+        )
+        result = openai_request_to_anthropic(req)
+        # Tool results become a user message
+        tool_msg = result.messages[2]
+        assert tool_msg.role == "user"
+        content = tool_msg.content
+        assert isinstance(content, list)
+        from bifrost.translation.models import ToolResultBlock
+
+        assert isinstance(content[0], ToolResultBlock)
+        assert content[0].tool_use_id == "call_1"
+        assert content[0].content == "Result text"
+
+    def test_multiple_tool_results_merged_into_one_user_message(self):
+        req = self._req(
+            messages=[
+                {"role": "user", "content": "Lookup two things"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "fn1", "arguments": "{}"},
+                        },
+                        {
+                            "id": "call_2",
+                            "type": "function",
+                            "function": {"name": "fn2", "arguments": "{}"},
+                        },
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call_1", "content": "Result 1"},
+                {"role": "tool", "tool_call_id": "call_2", "content": "Result 2"},
+            ]
+        )
+        result = openai_request_to_anthropic(req)
+        # Multiple tool results should collapse into one user message
+        assert len(result.messages) == 3
+        tool_msg = result.messages[2]
+        assert tool_msg.role == "user"
+        content = tool_msg.content
+        assert isinstance(content, list)
+        assert len(content) == 2
+
+    def test_tool_definitions_translated(self):
+        req = self._req(
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "Get weather",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"city": {"type": "string"}},
+                        },
+                    },
+                }
+            ]
+        )
+        result = openai_request_to_anthropic(req)
+        assert result.tools is not None
+        assert len(result.tools) == 1
+        assert result.tools[0].name == "get_weather"
+        assert result.tools[0].description == "Get weather"
+
+    def test_tool_choice_auto(self):
+        req = self._req(
+            tools=[
+                {
+                    "type": "function",
+                    "function": {"name": "fn", "description": "", "parameters": {}},
+                }
+            ],
+            tool_choice="auto",
+        )
+        result = openai_request_to_anthropic(req)
+        from bifrost.translation.models import ToolChoiceAuto
+
+        assert isinstance(result.tool_choice, ToolChoiceAuto)
+
+    def test_tool_choice_required_maps_to_any(self):
+        req = self._req(
+            tools=[
+                {
+                    "type": "function",
+                    "function": {"name": "fn", "description": "", "parameters": {}},
+                }
+            ],
+            tool_choice="required",
+        )
+        result = openai_request_to_anthropic(req)
+        from bifrost.translation.models import ToolChoiceAny
+
+        assert isinstance(result.tool_choice, ToolChoiceAny)
+
+    def test_tool_choice_specific_function(self):
+        req = self._req(
+            tools=[
+                {
+                    "type": "function",
+                    "function": {"name": "my_fn", "description": "", "parameters": {}},
+                }
+            ],
+            tool_choice={"type": "function", "function": {"name": "my_fn"}},
+        )
+        result = openai_request_to_anthropic(req)
+        from bifrost.translation.models import ToolChoiceTool
+
+        assert isinstance(result.tool_choice, ToolChoiceTool)
+        assert result.tool_choice.name == "my_fn"
+
+    def test_tool_choice_none_strips_tools(self):
+        req = self._req(
+            tools=[
+                {
+                    "type": "function",
+                    "function": {"name": "fn", "description": "", "parameters": {}},
+                }
+            ],
+            tool_choice="none",
+        )
+        result = openai_request_to_anthropic(req)
+        assert result.tools is None
+        assert result.tool_choice is None
+
+    def test_stop_string_converted_to_list(self):
+        req = self._req(stop="END")
+        result = openai_request_to_anthropic(req)
+        assert result.stop_sequences == ["END"]
+
+    def test_stop_list_forwarded(self):
+        req = self._req(stop=["END", "STOP"])
+        result = openai_request_to_anthropic(req)
+        assert result.stop_sequences == ["END", "STOP"]
+
+    def test_temperature_forwarded(self):
+        req = self._req(temperature=0.7)
+        result = openai_request_to_anthropic(req)
+        assert result.temperature == 0.7
+
+    def test_top_p_forwarded(self):
+        req = self._req(top_p=0.95)
+        result = openai_request_to_anthropic(req)
+        assert result.top_p == 0.95
+
+    def test_max_tokens_forwarded(self):
+        req = self._req(max_tokens=512)
+        result = openai_request_to_anthropic(req)
+        assert result.max_tokens == 512
+
+    def test_max_tokens_defaults_to_1024(self):
+        req = self._req()
+        result = openai_request_to_anthropic(req)
+        assert result.max_tokens == 1024
+
+    def test_stream_flag_forwarded(self):
+        req = self._req(stream=True)
+        result = openai_request_to_anthropic(req)
+        assert result.stream is True
+
+    def test_assistant_text_and_tool_calls(self):
+        req = self._req(
+            messages=[
+                {"role": "user", "content": "Go"},
+                {
+                    "role": "assistant",
+                    "content": "Calling tool...",
+                    "tool_calls": [
+                        {
+                            "id": "call_x",
+                            "type": "function",
+                            "function": {"name": "do_it", "arguments": "{}"},
+                        }
+                    ],
+                },
+            ]
+        )
+        result = openai_request_to_anthropic(req)
+        content = result.messages[1].content
+        assert isinstance(content, list)
+        assert isinstance(content[0], TextBlock)
+        assert isinstance(content[1], ToolUseBlock)
+
+    def test_invalid_tool_call_json_handled(self):
+        req = self._req(
+            messages=[
+                {"role": "user", "content": "Go"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_bad",
+                            "type": "function",
+                            "function": {"name": "bad_fn", "arguments": "not-json"},
+                        }
+                    ],
+                },
+            ]
+        )
+        result = openai_request_to_anthropic(req)
+        content = result.messages[1].content
+        assert isinstance(content, list)
+        block = content[0]
+        assert isinstance(block, ToolUseBlock)
+        assert block.input == {"raw": "not-json"}
+
+    def test_list_content_parts_extracted(self):
+        req = self._req(
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Hello "},
+                        {"type": "text", "text": "world"},
+                    ],
+                }
+            ]
+        )
+        result = openai_request_to_anthropic(req)
+        assert result.messages[0].content == "Hello world"
+
+
+# ---------------------------------------------------------------------------
+# Response translation: Anthropic → OpenAI
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicResponseToOpenAI:
+    def test_basic_text_response(self):
+        resp = _make_anthropic_response("Hello!")
+        result = anthropic_response_to_openai(resp)
+        assert result["object"] == "chat.completion"
+        assert result["id"] == "msg_test123"
+        assert result["model"] == "gpt-4o"
+        assert result["choices"][0]["message"]["role"] == "assistant"
+        assert result["choices"][0]["message"]["content"] == "Hello!"
+        assert result["choices"][0]["finish_reason"] == "stop"
+
+    def test_usage_fields_translated(self):
+        resp = _make_anthropic_response(input_tokens=20, output_tokens=10)
+        result = anthropic_response_to_openai(resp)
+        assert result["usage"]["prompt_tokens"] == 20
+        assert result["usage"]["completion_tokens"] == 10
+        assert result["usage"]["total_tokens"] == 30
+
+    def test_stop_reason_end_turn_maps_to_stop(self):
+        resp = _make_anthropic_response(stop_reason="end_turn")
+        result = anthropic_response_to_openai(resp)
+        assert result["choices"][0]["finish_reason"] == "stop"
+
+    def test_stop_reason_tool_use_maps_to_tool_calls(self):
+        resp = AnthropicResponse(
+            id="msg_t",
+            content=[ToolUseBlock(id="t1", name="fn", input={})],
+            model="gpt-4o",
+            stop_reason="tool_use",
+            usage=UsageInfo(),
+        )
+        result = anthropic_response_to_openai(resp)
+        assert result["choices"][0]["finish_reason"] == "tool_calls"
+
+    def test_stop_reason_max_tokens_maps_to_length(self):
+        resp = _make_anthropic_response(stop_reason="max_tokens")
+        result = anthropic_response_to_openai(resp)
+        assert result["choices"][0]["finish_reason"] == "length"
+
+    def test_tool_use_blocks_become_tool_calls(self):
+        resp = AnthropicResponse(
+            id="msg_t",
+            content=[ToolUseBlock(id="call_1", name="get_weather", input={"city": "Oslo"})],
+            model="gpt-4o",
+            stop_reason="tool_use",
+            usage=UsageInfo(),
+        )
+        result = anthropic_response_to_openai(resp)
+        msg = result["choices"][0]["message"]
+        assert "tool_calls" in msg
+        tc = msg["tool_calls"][0]
+        assert tc["id"] == "call_1"
+        assert tc["type"] == "function"
+        assert tc["function"]["name"] == "get_weather"
+        assert json.loads(tc["function"]["arguments"]) == {"city": "Oslo"}
+
+    def test_thinking_block_wrapped_in_tags(self):
+        resp = AnthropicResponse(
+            id="msg_t",
+            content=[ThinkingBlock(thinking="Let me think."), TextBlock(text="Answer.")],
+            model="gpt-4o",
+            stop_reason="end_turn",
+            usage=UsageInfo(),
+        )
+        result = anthropic_response_to_openai(resp)
+        content = result["choices"][0]["message"]["content"]
+        assert "<thinking>Let me think.</thinking>" in content
+        assert "Answer." in content
+
+    def test_empty_text_gives_null_content(self):
+        resp = AnthropicResponse(
+            id="msg_t",
+            content=[ToolUseBlock(id="t1", name="fn", input={})],
+            model="gpt-4o",
+            stop_reason="tool_use",
+            usage=UsageInfo(),
+        )
+        result = anthropic_response_to_openai(resp)
+        assert result["choices"][0]["message"]["content"] is None
+
+    def test_created_is_integer(self):
+        resp = _make_anthropic_response()
+        result = anthropic_response_to_openai(resp)
+        assert isinstance(result["created"], int)
+
+    def test_logprobs_null(self):
+        resp = _make_anthropic_response()
+        result = anthropic_response_to_openai(resp)
+        assert result["choices"][0]["logprobs"] is None
+
+
+# ---------------------------------------------------------------------------
+# Streaming translation: Anthropic SSE → OpenAI delta SSE
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicStreamToOpenAI:
+    @pytest.mark.asyncio
+    async def test_basic_text_stream(self):
+        events = [
+            "event: message_start\ndata: "
+            + json.dumps(
+                {
+                    "type": "message_start",
+                    "message": {
+                        "id": "msg_123",
+                        "model": "gpt-4o",
+                        "usage": {"input_tokens": 5, "output_tokens": 0},
+                    },
+                }
+            )
+            + "\n\n",
+            "event: content_block_start\ndata: "
+            + json.dumps(
+                {
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": {"type": "text", "text": ""},
+                }
+            )
+            + "\n\n",
+            "event: content_block_delta\ndata: "
+            + json.dumps(
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": "Hello"},
+                }
+            )
+            + "\n\n",
+            "event: content_block_delta\ndata: "
+            + json.dumps(
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": " world"},
+                }
+            )
+            + "\n\n",
+            "event: content_block_stop\ndata: "
+            + json.dumps({"type": "content_block_stop", "index": 0})
+            + "\n\n",
+            "event: message_delta\ndata: "
+            + json.dumps(
+                {
+                    "type": "message_delta",
+                    "delta": {"stop_reason": "end_turn"},
+                    "usage": {"output_tokens": 10},
+                }
+            )
+            + "\n\n",
+            "event: message_stop\ndata: " + json.dumps({"type": "message_stop"}) + "\n\n",
+        ]
+
+        chunks = []
+        async for line in anthropic_stream_to_openai(
+            _async_iter(events), message_id="chatcmpl-test", model="gpt-4o"
+        ):
+            chunks.append(line)
+
+        # Verify [DONE] is last
+        assert chunks[-1] == "data: [DONE]\n\n"
+
+        # Parse non-DONE chunks
+        parsed = [json.loads(c[6:]) for c in chunks if c != "data: [DONE]\n\n"]
+
+        # First chunk should have role
+        assert parsed[0]["choices"][0]["delta"] == {"role": "assistant", "content": ""}
+
+        # Text delta chunks (exclude role chunk with content="")
+        text_chunks = [p for p in parsed if p["choices"][0]["delta"].get("content")]
+        assert len(text_chunks) == 2
+        assert text_chunks[0]["choices"][0]["delta"]["content"] == "Hello"
+        assert text_chunks[1]["choices"][0]["delta"]["content"] == " world"
+
+        # Finish chunk
+        finish_chunk = [p for p in parsed if p["choices"][0].get("finish_reason") is not None]
+        assert len(finish_chunk) == 1
+        assert finish_chunk[0]["choices"][0]["finish_reason"] == "stop"
+
+    @pytest.mark.asyncio
+    async def test_tool_use_stream(self):
+        events = [
+            "event: message_start\ndata: "
+            + json.dumps(
+                {
+                    "type": "message_start",
+                    "message": {
+                        "id": "msg_tool",
+                        "usage": {"input_tokens": 10},
+                    },
+                }
+            )
+            + "\n\n",
+            "event: content_block_start\ndata: "
+            + json.dumps(
+                {
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": {
+                        "type": "tool_use",
+                        "id": "call_abc",
+                        "name": "get_weather",
+                    },
+                }
+            )
+            + "\n\n",
+            "event: content_block_delta\ndata: "
+            + json.dumps(
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "input_json_delta", "partial_json": '{"city":'},
+                }
+            )
+            + "\n\n",
+            "event: content_block_delta\ndata: "
+            + json.dumps(
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {
+                        "type": "input_json_delta",
+                        "partial_json": '"Oslo"}',
+                    },
+                }
+            )
+            + "\n\n",
+            "event: content_block_stop\ndata: "
+            + json.dumps({"type": "content_block_stop", "index": 0})
+            + "\n\n",
+            "event: message_delta\ndata: "
+            + json.dumps(
+                {
+                    "type": "message_delta",
+                    "delta": {"stop_reason": "tool_use"},
+                    "usage": {"output_tokens": 8},
+                }
+            )
+            + "\n\n",
+            "event: message_stop\ndata: " + json.dumps({"type": "message_stop"}) + "\n\n",
+        ]
+
+        chunks = []
+        async for line in anthropic_stream_to_openai(
+            _async_iter(events), message_id="chatcmpl-tool", model="gpt-4o"
+        ):
+            chunks.append(line)
+
+        parsed = [json.loads(c[6:]) for c in chunks if c != "data: [DONE]\n\n"]
+
+        # Tool call start chunk
+        tool_start = [
+            p
+            for p in parsed
+            if "tool_calls" in p["choices"][0]["delta"]
+            and p["choices"][0]["delta"]["tool_calls"][0].get("id")
+        ]
+        assert len(tool_start) == 1
+        tc = tool_start[0]["choices"][0]["delta"]["tool_calls"][0]
+        assert tc["id"] == "call_abc"
+        assert tc["function"]["name"] == "get_weather"
+        assert tc["index"] == 0
+
+        # Argument delta chunks
+        arg_chunks = [
+            p
+            for p in parsed
+            if "tool_calls" in p["choices"][0]["delta"]
+            and "arguments" in p["choices"][0]["delta"]["tool_calls"][0].get("function", {})
+            and not p["choices"][0]["delta"]["tool_calls"][0].get("id")
+        ]
+        assert len(arg_chunks) == 2
+
+        # Finish reason = tool_calls
+        finish = [p for p in parsed if p["choices"][0].get("finish_reason")]
+        assert finish[-1]["choices"][0]["finish_reason"] == "tool_calls"
+
+    @pytest.mark.asyncio
+    async def test_usage_in_finish_chunk(self):
+        events = [
+            "event: message_start\ndata: "
+            + json.dumps(
+                {
+                    "type": "message_start",
+                    "message": {"id": "m", "usage": {"input_tokens": 7}},
+                }
+            )
+            + "\n\n",
+            "event: message_delta\ndata: "
+            + json.dumps(
+                {
+                    "type": "message_delta",
+                    "delta": {"stop_reason": "end_turn"},
+                    "usage": {"output_tokens": 3},
+                }
+            )
+            + "\n\n",
+            "event: message_stop\ndata: " + json.dumps({"type": "message_stop"}) + "\n\n",
+        ]
+
+        chunks = []
+        async for line in anthropic_stream_to_openai(
+            _async_iter(events), message_id="cid", model="gpt-4o"
+        ):
+            chunks.append(line)
+
+        parsed = [json.loads(c[6:]) for c in chunks if c != "data: [DONE]\n\n"]
+        finish = [p for p in parsed if "usage" in p]
+        assert len(finish) == 1
+        assert finish[0]["usage"]["prompt_tokens"] == 7
+        assert finish[0]["usage"]["completion_tokens"] == 3
+        assert finish[0]["usage"]["total_tokens"] == 10
+
+    @pytest.mark.asyncio
+    async def test_done_sentinel_terminates_stream(self):
+        events = [
+            "data: [DONE]\n\n",
+            "data: " + json.dumps({"type": "message_start"}) + "\n\n",
+        ]
+        chunks = []
+        async for line in anthropic_stream_to_openai(
+            _async_iter(events), message_id="cid", model="gpt-4o"
+        ):
+            chunks.append(line)
+        assert chunks == ["data: [DONE]\n\n"]
+
+    @pytest.mark.asyncio
+    async def test_ping_events_ignored(self):
+        events = [
+            "event: ping\ndata: " + json.dumps({"type": "ping"}) + "\n\n",
+            "event: message_start\ndata: "
+            + json.dumps(
+                {
+                    "type": "message_start",
+                    "message": {"id": "m", "usage": {"input_tokens": 1}},
+                }
+            )
+            + "\n\n",
+            "event: message_stop\ndata: " + json.dumps({"type": "message_stop"}) + "\n\n",
+        ]
+        chunks = []
+        async for line in anthropic_stream_to_openai(
+            _async_iter(events), message_id="cid", model="gpt-4o"
+        ):
+            chunks.append(line)
+        # No chunk from ping
+        parsed = [json.loads(c[6:]) for c in chunks if c != "data: [DONE]\n\n"]
+        assert all("ping" not in str(p) for p in parsed)
+
+    @pytest.mark.asyncio
+    async def test_individual_lines_format(self):
+        """AnthropicAdapter yields individual lines rather than full events."""
+        lines = [
+            "event: message_start\n",
+            "data: "
+            + json.dumps(
+                {
+                    "type": "message_start",
+                    "message": {"id": "msg_x", "usage": {"input_tokens": 2}},
+                }
+            )
+            + "\n",
+            "\n",
+            "event: message_delta\n",
+            "data: "
+            + json.dumps(
+                {
+                    "type": "message_delta",
+                    "delta": {"stop_reason": "end_turn"},
+                    "usage": {"output_tokens": 1},
+                }
+            )
+            + "\n",
+            "\n",
+            "event: message_stop\n",
+            "data: " + json.dumps({"type": "message_stop"}) + "\n",
+        ]
+
+        chunks = []
+        async for line in anthropic_stream_to_openai(
+            _async_iter(lines), message_id="cid", model="gpt-4o"
+        ):
+            chunks.append(line)
+
+        assert "data: [DONE]\n\n" in chunks
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_skipped(self):
+        events = [
+            "data: not-json\n\n",
+            "event: message_stop\ndata: " + json.dumps({"type": "message_stop"}) + "\n\n",
+        ]
+        chunks = []
+        async for line in anthropic_stream_to_openai(
+            _async_iter(events), message_id="cid", model="gpt-4o"
+        ):
+            chunks.append(line)
+        assert "data: [DONE]\n\n" in chunks
+
+    @pytest.mark.asyncio
+    async def test_empty_stream_emits_done(self):
+        chunks = []
+        async for line in anthropic_stream_to_openai(
+            _async_iter([]), message_id="cid", model="gpt-4o"
+        ):
+            chunks.append(line)
+        assert chunks == ["data: [DONE]\n\n"]
+
+    @pytest.mark.asyncio
+    async def test_message_id_from_upstream_event(self):
+        events = [
+            "event: message_start\ndata: "
+            + json.dumps(
+                {
+                    "type": "message_start",
+                    "message": {
+                        "id": "upstream_id_xyz",
+                        "usage": {"input_tokens": 1},
+                    },
+                }
+            )
+            + "\n\n",
+            "event: message_stop\ndata: " + json.dumps({"type": "message_stop"}) + "\n\n",
+        ]
+        chunks = []
+        async for line in anthropic_stream_to_openai(
+            _async_iter(events), message_id="fallback_id", model="gpt-4o"
+        ):
+            chunks.append(line)
+
+        parsed = [json.loads(c[6:]) for c in chunks if c != "data: [DONE]\n\n"]
+        assert all(p["id"] == "upstream_id_xyz" for p in parsed)
+
+
+# ---------------------------------------------------------------------------
+# /v1/chat/completions endpoint integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestChatCompletionsEndpoint:
+    def _client(self) -> TestClient:
+        return TestClient(create_app(_make_config()))
+
+    @patch("bifrost.router.ModelRouter.complete", new_callable=AsyncMock)
+    def test_basic_request_returns_openai_format(self, mock_complete):
+        mock_complete.return_value = _make_anthropic_response("World!")
+        with self._client() as client:
+            resp = client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "gpt-4o",
+                    "messages": [{"role": "user", "content": "Hello"}],
+                },
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["object"] == "chat.completion"
+        assert body["choices"][0]["message"]["content"] == "World!"
+        assert body["choices"][0]["finish_reason"] == "stop"
+        assert "usage" in body
+        assert body["usage"]["prompt_tokens"] == 10
+        assert body["usage"]["completion_tokens"] == 5
+
+    @patch("bifrost.router.ModelRouter.complete", new_callable=AsyncMock)
+    def test_system_message_translated(self, mock_complete):
+        mock_complete.return_value = _make_anthropic_response()
+        with self._client() as client:
+            resp = client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "gpt-4o",
+                    "messages": [
+                        {"role": "system", "content": "Be helpful."},
+                        {"role": "user", "content": "Hi"},
+                    ],
+                },
+            )
+        assert resp.status_code == 200
+        # The system message should have been extracted and the AnthropicRequest
+        # should have a system field — verified by checking the call args.
+        call_args = mock_complete.call_args
+        anthropic_req = call_args[0][0]
+        assert anthropic_req.system == "Be helpful."
+
+    def test_invalid_body_returns_422(self):
+        with self._client() as client:
+            resp = client.post(
+                "/v1/chat/completions",
+                json={"not_a_valid_field": True},
+            )
+        assert resp.status_code == 422
+
+    def test_malformed_json_returns_422(self):
+        with self._client() as client:
+            resp = client.post(
+                "/v1/chat/completions",
+                content=b"not json",
+                headers={"content-type": "application/json"},
+            )
+        assert resp.status_code == 422
+
+    @patch("bifrost.router.ModelRouter.complete", new_callable=AsyncMock)
+    def test_router_error_returns_502(self, mock_complete):
+        from bifrost.router import RouterError
+
+        mock_complete.side_effect = RouterError("no provider")
+        with self._client() as client:
+            resp = client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "gpt-4o",
+                    "messages": [{"role": "user", "content": "Hi"}],
+                },
+            )
+        assert resp.status_code == 502
+
+    def test_unknown_model_returns_502(self):
+        with self._client() as client:
+            resp = client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "no-such-model-xyz",
+                    "messages": [{"role": "user", "content": "Hi"}],
+                },
+            )
+        assert resp.status_code == 502
+
+    @patch("bifrost.router.ModelRouter.stream")
+    def test_streaming_returns_event_stream(self, mock_stream):
+        async def _fake_stream(request):
+            yield (
+                "event: message_start\ndata: "
+                + json.dumps(
+                    {
+                        "type": "message_start",
+                        "message": {"id": "m", "usage": {"input_tokens": 1}},
+                    }
+                )
+                + "\n\n"
+            )
+            yield ("event: message_stop\ndata: " + json.dumps({"type": "message_stop"}) + "\n\n")
+
+        mock_stream.return_value = _fake_stream(None)
+
+        with self._client() as client:
+            resp = client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "gpt-4o",
+                    "messages": [{"role": "user", "content": "Hi"}],
+                    "stream": True,
+                },
+            )
+        assert resp.status_code == 200
+        assert "text/event-stream" in resp.headers["content-type"]
+        assert "data: [DONE]" in resp.text
+
+    @patch("bifrost.router.ModelRouter.stream")
+    def test_streaming_chunks_have_openai_format(self, mock_stream):
+        async def _fake_stream(request):
+            yield (
+                "event: message_start\ndata: "
+                + json.dumps(
+                    {
+                        "type": "message_start",
+                        "message": {"id": "msg_s", "usage": {"input_tokens": 2}},
+                    }
+                )
+                + "\n\n"
+            )
+            yield (
+                "event: content_block_delta\ndata: "
+                + json.dumps(
+                    {
+                        "type": "content_block_delta",
+                        "index": 0,
+                        "delta": {"type": "text_delta", "text": "Hi!"},
+                    }
+                )
+                + "\n\n"
+            )
+            yield (
+                "event: message_delta\ndata: "
+                + json.dumps(
+                    {
+                        "type": "message_delta",
+                        "delta": {"stop_reason": "end_turn"},
+                        "usage": {"output_tokens": 1},
+                    }
+                )
+                + "\n\n"
+            )
+            yield ("event: message_stop\ndata: " + json.dumps({"type": "message_stop"}) + "\n\n")
+
+        mock_stream.return_value = _fake_stream(None)
+
+        with self._client() as client:
+            resp = client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "gpt-4o",
+                    "messages": [{"role": "user", "content": "Hi"}],
+                    "stream": True,
+                },
+            )
+
+        chunks = _parse_sse_chunks(resp.text)
+        assert all(c["object"] == "chat.completion.chunk" for c in chunks)
+        text_chunks = [c for c in chunks if c["choices"][0]["delta"].get("content")]
+        assert any(c["choices"][0]["delta"]["content"] == "Hi!" for c in text_chunks)
+
+    @patch("bifrost.router.ModelRouter.complete", new_callable=AsyncMock)
+    def test_correlation_id_echoed(self, mock_complete):
+        mock_complete.return_value = _make_anthropic_response()
+        with self._client() as client:
+            resp = client.post(
+                "/v1/chat/completions",
+                json={"model": "gpt-4o", "messages": [{"role": "user", "content": "Hi"}]},
+                headers={"X-Correlation-ID": "test-cid-123"},
+            )
+        assert resp.headers.get("X-Correlation-ID") == "test-cid-123"
+
+    @patch("bifrost.router.ModelRouter.complete", new_callable=AsyncMock)
+    def test_max_tokens_forwarded(self, mock_complete):
+        mock_complete.return_value = _make_anthropic_response()
+        with self._client() as client:
+            client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "gpt-4o",
+                    "messages": [{"role": "user", "content": "Hi"}],
+                    "max_tokens": 256,
+                },
+            )
+        call_args = mock_complete.call_args
+        anthropic_req = call_args[0][0]
+        assert anthropic_req.max_tokens == 256
+
+    @patch("bifrost.router.ModelRouter.complete", new_callable=AsyncMock)
+    def test_temperature_forwarded(self, mock_complete):
+        mock_complete.return_value = _make_anthropic_response()
+        with self._client() as client:
+            client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "gpt-4o",
+                    "messages": [{"role": "user", "content": "Hi"}],
+                    "temperature": 0.5,
+                },
+            )
+        call_args = mock_complete.call_args
+        anthropic_req = call_args[0][0]
+        assert anthropic_req.temperature == 0.5


### PR DESCRIPTION
## Summary

- Adds `POST /v1/chat/completions` that accepts OpenAI Chat Completions format and routes through the same `ModelRouter` as `/v1/messages`
- New `src/bifrost/inbound/chat_completions.py` handles the full translation layer (request in, response out, SSE streaming)
- Shares correlation ID middleware, token tracking/logging, auth, and failover with the existing endpoint — only translation differs

## Changes

### `src/bifrost/inbound/chat_completions.py` (new)

**Request translation (`openai_request_to_anthropic`):**
- `system` role messages → `AnthropicRequest.system` field
- `user`/`assistant` messages → `messages[]` with content blocks
- `assistant.tool_calls[]` → `ToolUseBlock` content blocks
- `tool` role messages → `ToolResultBlock` in a `user` message; consecutive tool results are merged into one message
- OpenAI tools/tool_choice → `ToolDefinition` / `ToolChoiceAuto|Any|Tool`; `"none"` strips tools entirely
- `stop` string or list → `stop_sequences`

**Response translation (`anthropic_response_to_openai`):**
- `TextBlock` / `ThinkingBlock` → `choices[0].message.content`
- `ToolUseBlock` → `choices[0].message.tool_calls[]`
- `stop_reason` → `finish_reason` (`end_turn→stop`, `tool_use→tool_calls`, `max_tokens→length`)
- `usage.input_tokens` → `usage.prompt_tokens`, `output_tokens` → `completion_tokens`

**Streaming translation (`anthropic_stream_to_openai`):**
- Handles both AnthropicAdapter (per-line SSE) and OpenAICompatAdapter (per-event SSE) formats
- `message_start` → role chunk
- `content_block_delta[text_delta]` → `delta.content` chunks
- `content_block_start[tool_use]` + `content_block_delta[input_json_delta]` → `delta.tool_calls[]` chunks
- `message_delta` → finish chunk with usage fields
- `message_stop` / `[DONE]` → `data: [DONE]`

### `src/bifrost/app.py`

Adds `POST /v1/chat/completions` endpoint using the above translation functions.

### `tests/test_bifrost/test_chat_completions.py` (new)

53 tests covering all translation paths including edge cases (invalid JSON, multiple tool results, list content parts, empty streams, per-line vs per-event SSE formats).

## Test plan

- [x] All 206 bifrost tests pass (`pytest tests/test_bifrost/`)
- [x] Coverage: `bifrost/inbound/chat_completions.py` 94%, overall bifrost 97%
- [x] `ruff check` + `ruff format` clean
- [ ] CI green

Closes NIU-475

🤖 Generated with [Claude Code](https://claude.com/claude-code)