### PR TITLE
feat(bifrost): NIU-461 key management, agent auth, cost tracking + quotas

### DIFF
--- a/bifrost.yaml.example
+++ b/bifrost.yaml.example
@@ -79,6 +79,72 @@ bifrost:
   #
   # latency_ewma_alpha: 0.2
 
+  # ── Authentication ───────────────────────────────────────────────────────────
+  #
+  # Controls how Bifröst verifies caller identity.
+  #
+  # Modes:
+  #   open  — No auth. Headers (x-agent-id, x-tenant-id) are trusted verbatim.
+  #            Suitable for local/Pi mode or behind a fully-trusted proxy. DEFAULT.
+  #   pat   — Bearer JWT (HS256) issued by Bifröst. Supply the signing secret via
+  #            pat_secret (or the PAT_SECRET environment variable).
+  #   mesh  — Service-mesh mode. Envoy / mTLS has already verified the caller;
+  #            Bifröst reads Envoy-injected headers (x-agent-id, x-tenant-id).
+  #
+  auth_mode: open
+
+  # pat_secret: ""   # Required when auth_mode = pat (or set PAT_SECRET env var)
+
+  # ── Pricing overrides ────────────────────────────────────────────────────────
+  #
+  # Override or extend the built-in pricing snapshot (USD per million tokens).
+  # Omitted models fall back to the built-in table; unknown models cost $0.
+  #
+  # pricing:
+  #   claude-sonnet-4-6:
+  #     input_per_million: 3.00
+  #     output_per_million: 15.00
+  #     cache_creation_per_million: 3.75
+  #     cache_read_per_million: 0.30
+
+  # ── Quota enforcement ─────────────────────────────────────────────────────────
+  #
+  # Limits are evaluated before each request.
+  # Soft limit (default: 90% of any hard limit) → X-Quota-Warning response header.
+  # Hard limit → HTTP 429 with a descriptive reason.
+  # Zero (0 / 0.0) means unlimited for that dimension.
+  #
+  # default_quota:                   # applied to every tenant unless overridden
+  #   max_tokens_per_day: 0          # 0 = unlimited
+  #   max_cost_per_day: 0.0
+  #   max_requests_per_hour: 0
+  #   soft_limit_fraction: 0.9       # warn at 90% of the hard limit
+
+  # tenant_quotas:                   # per-tenant overrides
+  #   my-tenant:
+  #     max_tokens_per_day: 1000000
+  #     max_cost_per_day: 10.0
+  #     max_requests_per_hour: 1000
+
+  # agent_permissions:               # per-agent model access + optional budget
+  #   my-agent-id:
+  #     allowed_models:              # empty list = all models allowed
+  #       - claude-sonnet-4-6
+  #     quota:
+  #       max_cost_per_day: 2.50
+
+  # ── Usage storage ─────────────────────────────────────────────────────────────
+  #
+  # Where per-request usage records are persisted.
+  #
+  #   memory  — In-process only. Lost on restart. Good for testing. DEFAULT.
+  #   sqlite  — Persistent single-file database. Good for standalone / Pi mode.
+  #   postgres — (coming) PostgreSQL backend for multi-node deployments.
+  #
+  # usage_store:
+  #   adapter: memory
+  #   path: ./bifrost_usage.db      # for sqlite adapter
+
   # ── Server ──────────────────────────────────────────────────────────────────
   host: 0.0.0.0
   port: 8088

--- a/src/bifrost/adapters/memory_store.py
+++ b/src/bifrost/adapters/memory_store.py
@@ -1,0 +1,108 @@
+"""In-memory UsageStore adapter.
+
+Suitable for testing and standalone single-process deployments where
+persistence across restarts is not required.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from bifrost.ports.usage_store import UsageRecord, UsageStore, UsageSummary
+
+
+def _today_start() -> datetime:
+    now = datetime.now(UTC)
+    return now.replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+def _hour_start() -> datetime:
+    now = datetime.now(UTC)
+    return now.replace(minute=0, second=0, microsecond=0)
+
+
+class MemoryUsageStore(UsageStore):
+    """Thread-safe (GIL) in-memory implementation of ``UsageStore``."""
+
+    def __init__(self) -> None:
+        self._records: list[UsageRecord] = []
+
+    async def record(self, usage: UsageRecord) -> None:
+        self._records.append(usage)
+
+    async def query(
+        self,
+        *,
+        agent_id: str | None = None,
+        tenant_id: str | None = None,
+        model: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        limit: int = 1000,
+    ) -> list[UsageRecord]:
+        results = self._records
+        if agent_id is not None:
+            results = [r for r in results if r.agent_id == agent_id]
+        if tenant_id is not None:
+            results = [r for r in results if r.tenant_id == tenant_id]
+        if model is not None:
+            results = [r for r in results if r.model == model]
+        if since is not None:
+            results = [r for r in results if r.timestamp >= since]
+        if until is not None:
+            results = [r for r in results if r.timestamp <= until]
+        return results[-limit:]
+
+    async def summarise(
+        self,
+        *,
+        agent_id: str | None = None,
+        tenant_id: str | None = None,
+        model: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+    ) -> UsageSummary:
+        records = await self.query(
+            agent_id=agent_id,
+            tenant_id=tenant_id,
+            model=model,
+            since=since,
+            until=until,
+            limit=1_000_000,
+        )
+        summary = UsageSummary()
+        summary.total_requests = len(records)
+        for r in records:
+            summary.total_input_tokens += r.input_tokens
+            summary.total_output_tokens += r.output_tokens
+            summary.total_cost_usd += r.cost_usd
+            entry = summary.by_model.setdefault(
+                r.model,
+                {"requests": 0, "input_tokens": 0, "output_tokens": 0, "cost_usd": 0.0},
+            )
+            entry["requests"] += 1
+            entry["input_tokens"] += r.input_tokens
+            entry["output_tokens"] += r.output_tokens
+            entry["cost_usd"] += r.cost_usd
+        return summary
+
+    async def tokens_today(self, tenant_id: str) -> int:
+        since = _today_start()
+        records = [r for r in self._records if r.tenant_id == tenant_id and r.timestamp >= since]
+        return sum(r.input_tokens + r.output_tokens for r in records)
+
+    async def cost_today(self, tenant_id: str) -> float:
+        since = _today_start()
+        return sum(
+            r.cost_usd for r in self._records if r.tenant_id == tenant_id and r.timestamp >= since
+        )
+
+    async def requests_this_hour(self, tenant_id: str) -> int:
+        since = _hour_start()
+        return sum(1 for r in self._records if r.tenant_id == tenant_id and r.timestamp >= since)
+
+    async def agent_cost_today(self, agent_id: str) -> float:
+        since = _today_start()
+        return sum(
+            r.cost_usd for r in self._records if r.agent_id == agent_id and r.timestamp >= since
+        )

--- a/src/bifrost/adapters/sqlite_store.py
+++ b/src/bifrost/adapters/sqlite_store.py
@@ -1,0 +1,255 @@
+"""SQLite-backed UsageStore adapter.
+
+Uses the standard-library ``sqlite3`` module via ``asyncio``
+``run_in_executor`` so no extra dependencies are required.
+
+The schema is created automatically on first use (``CREATE TABLE IF NOT EXISTS``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from collections.abc import Callable
+from datetime import UTC, datetime
+from functools import partial
+from typing import Any
+
+from bifrost.ports.usage_store import UsageRecord, UsageStore, UsageSummary
+
+_CREATE_TABLE = """
+CREATE TABLE IF NOT EXISTS usage_records (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    request_id    TEXT    NOT NULL DEFAULT '',
+    agent_id      TEXT    NOT NULL,
+    tenant_id     TEXT    NOT NULL,
+    session_id    TEXT    NOT NULL DEFAULT '',
+    saga_id       TEXT    NOT NULL DEFAULT '',
+    model         TEXT    NOT NULL,
+    input_tokens  INTEGER NOT NULL DEFAULT 0,
+    output_tokens INTEGER NOT NULL DEFAULT 0,
+    cost_usd      REAL    NOT NULL DEFAULT 0.0,
+    timestamp     TEXT    NOT NULL
+);
+"""
+
+_CREATE_INDEXES = """
+CREATE INDEX IF NOT EXISTS idx_usage_tenant_ts  ON usage_records(tenant_id, timestamp);
+CREATE INDEX IF NOT EXISTS idx_usage_agent_ts   ON usage_records(agent_id,  timestamp);
+CREATE INDEX IF NOT EXISTS idx_usage_model      ON usage_records(model);
+"""
+
+_INSERT = """
+INSERT INTO usage_records
+    (request_id, agent_id, tenant_id, session_id, saga_id,
+     model, input_tokens, output_tokens, cost_usd, timestamp)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+"""
+
+
+def _ts(dt: datetime) -> str:
+    return dt.astimezone(UTC).isoformat()
+
+
+def _parse_ts(s: str) -> datetime:
+    return datetime.fromisoformat(s).replace(tzinfo=UTC)
+
+
+def _row_to_record(row: tuple) -> UsageRecord:
+    (
+        _id,
+        request_id,
+        agent_id,
+        tenant_id,
+        session_id,
+        saga_id,
+        model,
+        input_tokens,
+        output_tokens,
+        cost_usd,
+        timestamp,
+    ) = row
+    return UsageRecord(
+        request_id=request_id,
+        agent_id=agent_id,
+        tenant_id=tenant_id,
+        session_id=session_id,
+        saga_id=saga_id,
+        model=model,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cost_usd=cost_usd,
+        timestamp=_parse_ts(timestamp),
+    )
+
+
+class SQLiteUsageStore(UsageStore):
+    """Persistent SQLite implementation of ``UsageStore``."""
+
+    def __init__(self, path: str = ":memory:") -> None:
+        self._path = path
+        self._conn: sqlite3.Connection | None = None
+        self._lock = asyncio.Lock()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def _open(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self._path, check_same_thread=False)
+        conn.execute("PRAGMA journal_mode=WAL;")
+        conn.executescript(_CREATE_TABLE + _CREATE_INDEXES)
+        conn.commit()
+        return conn
+
+    async def _get_conn(self) -> sqlite3.Connection:
+        async with self._lock:
+            if self._conn is None:
+                loop = asyncio.get_event_loop()
+                self._conn = await loop.run_in_executor(None, self._open)
+        return self._conn
+
+    async def close(self) -> None:
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    async def _run(self, fn: Callable[..., Any], *args: Any) -> Any:
+        conn = await self._get_conn()
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(None, partial(fn, conn, *args))
+
+    @staticmethod
+    def _do_insert(conn: sqlite3.Connection, record: UsageRecord) -> None:
+        conn.execute(
+            _INSERT,
+            (
+                record.request_id,
+                record.agent_id,
+                record.tenant_id,
+                record.session_id,
+                record.saga_id,
+                record.model,
+                record.input_tokens,
+                record.output_tokens,
+                record.cost_usd,
+                _ts(record.timestamp),
+            ),
+        )
+        conn.commit()
+
+    @staticmethod
+    def _do_query(
+        conn: sqlite3.Connection,
+        agent_id: str | None,
+        tenant_id: str | None,
+        model: str | None,
+        since: datetime | None,
+        until: datetime | None,
+        limit: int,
+    ) -> list[tuple]:
+        clauses = []
+        params: list[Any] = []
+        if agent_id is not None:
+            clauses.append("agent_id = ?")
+            params.append(agent_id)
+        if tenant_id is not None:
+            clauses.append("tenant_id = ?")
+            params.append(tenant_id)
+        if model is not None:
+            clauses.append("model = ?")
+            params.append(model)
+        if since is not None:
+            clauses.append("timestamp >= ?")
+            params.append(_ts(since))
+        if until is not None:
+            clauses.append("timestamp <= ?")
+            params.append(_ts(until))
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+        sql = f"""
+            SELECT id, request_id, agent_id, tenant_id, session_id, saga_id,
+                   model, input_tokens, output_tokens, cost_usd, timestamp
+            FROM usage_records {where}
+            ORDER BY timestamp DESC
+            LIMIT ?
+        """
+        params.append(limit)
+        cur = conn.execute(sql, params)
+        return cur.fetchall()
+
+    # ------------------------------------------------------------------
+    # Port implementation
+    # ------------------------------------------------------------------
+
+    async def record(self, usage: UsageRecord) -> None:
+        await self._run(self._do_insert, usage)
+
+    async def query(
+        self,
+        *,
+        agent_id: str | None = None,
+        tenant_id: str | None = None,
+        model: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        limit: int = 1000,
+    ) -> list[UsageRecord]:
+        rows = await self._run(self._do_query, agent_id, tenant_id, model, since, until, limit)
+        return [_row_to_record(r) for r in rows]
+
+    async def summarise(
+        self,
+        *,
+        agent_id: str | None = None,
+        tenant_id: str | None = None,
+        model: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+    ) -> UsageSummary:
+        records = await self.query(
+            agent_id=agent_id,
+            tenant_id=tenant_id,
+            model=model,
+            since=since,
+            until=until,
+            limit=1_000_000,
+        )
+        summary = UsageSummary()
+        summary.total_requests = len(records)
+        for r in records:
+            summary.total_input_tokens += r.input_tokens
+            summary.total_output_tokens += r.output_tokens
+            summary.total_cost_usd += r.cost_usd
+            entry = summary.by_model.setdefault(
+                r.model,
+                {"requests": 0, "input_tokens": 0, "output_tokens": 0, "cost_usd": 0.0},
+            )
+            entry["requests"] += 1
+            entry["input_tokens"] += r.input_tokens
+            entry["output_tokens"] += r.output_tokens
+            entry["cost_usd"] += r.cost_usd
+        return summary
+
+    async def tokens_today(self, tenant_id: str) -> int:
+        since = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+        records = await self.query(tenant_id=tenant_id, since=since, limit=1_000_000)
+        return sum(r.input_tokens + r.output_tokens for r in records)
+
+    async def cost_today(self, tenant_id: str) -> float:
+        since = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+        records = await self.query(tenant_id=tenant_id, since=since, limit=1_000_000)
+        return sum(r.cost_usd for r in records)
+
+    async def requests_this_hour(self, tenant_id: str) -> int:
+        since = datetime.now(UTC).replace(minute=0, second=0, microsecond=0)
+        records = await self.query(tenant_id=tenant_id, since=since, limit=1_000_000)
+        return len(records)
+
+    async def agent_cost_today(self, agent_id: str) -> float:
+        since = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+        records = await self.query(agent_id=agent_id, since=since, limit=1_000_000)
+        return sum(r.cost_usd for r in records)

--- a/src/bifrost/adapters/sqlite_store.py
+++ b/src/bifrost/adapters/sqlite_store.py
@@ -52,7 +52,10 @@ def _ts(dt: datetime) -> str:
 
 
 def _parse_ts(s: str) -> datetime:
-    return datetime.fromisoformat(s).replace(tzinfo=UTC)
+    dt = datetime.fromisoformat(s)
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
 
 
 def _row_to_record(row: tuple) -> UsageRecord:
@@ -105,7 +108,7 @@ class SQLiteUsageStore(UsageStore):
     async def _get_conn(self) -> sqlite3.Connection:
         async with self._lock:
             if self._conn is None:
-                loop = asyncio.get_event_loop()
+                loop = asyncio.get_running_loop()
                 self._conn = await loop.run_in_executor(None, self._open)
         return self._conn
 
@@ -120,7 +123,7 @@ class SQLiteUsageStore(UsageStore):
 
     async def _run(self, fn: Callable[..., Any], *args: Any) -> Any:
         conn = await self._get_conn()
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, partial(fn, conn, *args))
 
     @staticmethod
@@ -181,6 +184,88 @@ class SQLiteUsageStore(UsageStore):
         cur = conn.execute(sql, params)
         return cur.fetchall()
 
+    @staticmethod
+    def _do_summarise(
+        conn: sqlite3.Connection,
+        agent_id: str | None,
+        tenant_id: str | None,
+        model: str | None,
+        since: datetime | None,
+        until: datetime | None,
+    ) -> tuple[int, int, int, float, list[tuple]]:
+        """Run SQL aggregation for summarise() — no Python-level looping."""
+        clauses = []
+        params: list[Any] = []
+        if agent_id is not None:
+            clauses.append("agent_id = ?")
+            params.append(agent_id)
+        if tenant_id is not None:
+            clauses.append("tenant_id = ?")
+            params.append(tenant_id)
+        if model is not None:
+            clauses.append("model = ?")
+            params.append(model)
+        if since is not None:
+            clauses.append("timestamp >= ?")
+            params.append(_ts(since))
+        if until is not None:
+            clauses.append("timestamp <= ?")
+            params.append(_ts(until))
+        where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+
+        totals_row = conn.execute(
+            f"SELECT COUNT(*), SUM(input_tokens), SUM(output_tokens), SUM(cost_usd) "
+            f"FROM usage_records {where}",
+            params,
+        ).fetchone()
+
+        model_rows = conn.execute(
+            f"SELECT model, COUNT(*), SUM(input_tokens), SUM(output_tokens), SUM(cost_usd) "
+            f"FROM usage_records {where} GROUP BY model",
+            params,
+        ).fetchall()
+
+        return (
+            totals_row[0] or 0,
+            totals_row[1] or 0,
+            totals_row[2] or 0,
+            totals_row[3] or 0.0,
+            model_rows,
+        )
+
+    @staticmethod
+    def _do_tokens_today(conn: sqlite3.Connection, tenant_id: str, since: str) -> int:
+        row = conn.execute(
+            "SELECT SUM(input_tokens + output_tokens) FROM usage_records "
+            "WHERE tenant_id = ? AND timestamp >= ?",
+            (tenant_id, since),
+        ).fetchone()
+        return row[0] or 0
+
+    @staticmethod
+    def _do_cost_today(conn: sqlite3.Connection, tenant_id: str, since: str) -> float:
+        row = conn.execute(
+            "SELECT SUM(cost_usd) FROM usage_records WHERE tenant_id = ? AND timestamp >= ?",
+            (tenant_id, since),
+        ).fetchone()
+        return row[0] or 0.0
+
+    @staticmethod
+    def _do_requests_this_hour(conn: sqlite3.Connection, tenant_id: str, since: str) -> int:
+        row = conn.execute(
+            "SELECT COUNT(*) FROM usage_records WHERE tenant_id = ? AND timestamp >= ?",
+            (tenant_id, since),
+        ).fetchone()
+        return row[0] or 0
+
+    @staticmethod
+    def _do_agent_cost_today(conn: sqlite3.Connection, agent_id: str, since: str) -> float:
+        row = conn.execute(
+            "SELECT SUM(cost_usd) FROM usage_records WHERE agent_id = ? AND timestamp >= ?",
+            (agent_id, since),
+        ).fetchone()
+        return row[0] or 0.0
+
     # ------------------------------------------------------------------
     # Port implementation
     # ------------------------------------------------------------------
@@ -210,46 +295,36 @@ class SQLiteUsageStore(UsageStore):
         since: datetime | None = None,
         until: datetime | None = None,
     ) -> UsageSummary:
-        records = await self.query(
-            agent_id=agent_id,
-            tenant_id=tenant_id,
-            model=model,
-            since=since,
-            until=until,
-            limit=1_000_000,
+        total_requests, total_input, total_output, total_cost, model_rows = await self._run(
+            self._do_summarise, agent_id, tenant_id, model, since, until
         )
-        summary = UsageSummary()
-        summary.total_requests = len(records)
-        for r in records:
-            summary.total_input_tokens += r.input_tokens
-            summary.total_output_tokens += r.output_tokens
-            summary.total_cost_usd += r.cost_usd
-            entry = summary.by_model.setdefault(
-                r.model,
-                {"requests": 0, "input_tokens": 0, "output_tokens": 0, "cost_usd": 0.0},
-            )
-            entry["requests"] += 1
-            entry["input_tokens"] += r.input_tokens
-            entry["output_tokens"] += r.output_tokens
-            entry["cost_usd"] += r.cost_usd
+        summary = UsageSummary(
+            total_requests=total_requests,
+            total_input_tokens=total_input,
+            total_output_tokens=total_output,
+            total_cost_usd=total_cost,
+        )
+        for m, req_count, in_tok, out_tok, cost in model_rows:
+            summary.by_model[m] = {
+                "requests": req_count,
+                "input_tokens": in_tok or 0,
+                "output_tokens": out_tok or 0,
+                "cost_usd": cost or 0.0,
+            }
         return summary
 
     async def tokens_today(self, tenant_id: str) -> int:
-        since = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
-        records = await self.query(tenant_id=tenant_id, since=since, limit=1_000_000)
-        return sum(r.input_tokens + r.output_tokens for r in records)
+        since = _ts(datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0))
+        return await self._run(self._do_tokens_today, tenant_id, since)
 
     async def cost_today(self, tenant_id: str) -> float:
-        since = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
-        records = await self.query(tenant_id=tenant_id, since=since, limit=1_000_000)
-        return sum(r.cost_usd for r in records)
+        since = _ts(datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0))
+        return await self._run(self._do_cost_today, tenant_id, since)
 
     async def requests_this_hour(self, tenant_id: str) -> int:
-        since = datetime.now(UTC).replace(minute=0, second=0, microsecond=0)
-        records = await self.query(tenant_id=tenant_id, since=since, limit=1_000_000)
-        return len(records)
+        since = _ts(datetime.now(UTC).replace(minute=0, second=0, microsecond=0))
+        return await self._run(self._do_requests_this_hour, tenant_id, since)
 
     async def agent_cost_today(self, agent_id: str) -> float:
-        since = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
-        records = await self.query(agent_id=agent_id, since=since, limit=1_000_000)
-        return sum(r.cost_usd for r in records)
+        since = _ts(datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0))
+        return await self._run(self._do_agent_cost_today, agent_id, since)

--- a/src/bifrost/app.py
+++ b/src/bifrost/app.py
@@ -25,7 +25,7 @@ from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.responses import JSONResponse, StreamingResponse
 
 from bifrost.auth import AgentIdentity, extract_identity
-from bifrost.config import BifrostConfig
+from bifrost.config import AgentPermissions, BifrostConfig
 from bifrost.domain.models import ModelInfo, RequestLog, TokenUsage
 from bifrost.ports.usage_store import UsageRecord, UsageStore
 from bifrost.pricing import ModelPricing, calculate_cost
@@ -125,8 +125,13 @@ async def _check_quotas(
     identity: AgentIdentity,
     config: BifrostConfig,
     store: UsageStore,
+    agent_perms: AgentPermissions,
 ) -> list[str]:
     """Check quota limits and return a list of warning strings (empty = OK).
+
+    Args:
+        agent_perms: Pre-resolved permissions for the caller (avoids a second
+                     ``config.permissions_for_agent()`` lookup per request).
 
     Raises:
         HTTPException(429): If any hard limit is exceeded.
@@ -134,7 +139,6 @@ async def _check_quotas(
     warnings: list[str] = []
 
     tenant_quota = config.quota_for_tenant(identity.tenant_id)
-    agent_perms = config.permissions_for_agent(identity.agent_id)
     agent_quota = agent_perms.quota
 
     # Tenant: tokens per day
@@ -199,21 +203,23 @@ async def _check_quotas(
 def _check_model_access(
     identity: AgentIdentity,
     model: str,
-    config: BifrostConfig,
+    agent_perms: AgentPermissions,
 ) -> None:
     """Raise 403 if the agent does not have permission to use *model*.
 
     An empty ``allowed_models`` list means all models are permitted.
+
+    Args:
+        agent_perms: Pre-resolved permissions for the caller.
     """
-    perms = config.permissions_for_agent(identity.agent_id)
-    if not perms.allowed_models:
+    if not agent_perms.allowed_models:
         return
-    if model not in perms.allowed_models:
+    if model not in agent_perms.allowed_models:
         raise HTTPException(
             status_code=403,
             detail=(
                 f"Agent '{identity.agent_id}' is not permitted to use model '{model}'. "
-                f"Allowed: {perms.allowed_models}"
+                f"Allowed: {agent_perms.allowed_models}"
             ),
         )
 
@@ -291,6 +297,8 @@ def create_app(config: BifrostConfig) -> FastAPI:
     async def lifespan(app: FastAPI):
         yield
         await router.close()
+        if hasattr(store, "close"):
+            await store.close()
 
     app = FastAPI(
         title="Bifröst LLM Gateway",
@@ -365,11 +373,14 @@ def create_app(config: BifrostConfig) -> FastAPI:
         except Exception as exc:
             raise HTTPException(status_code=422, detail=str(exc)) from exc
 
+        # Resolve permissions once — used by both access control and quota checks.
+        agent_perms = config.permissions_for_agent(identity.agent_id)
+
         # --- Model access control ---
-        _check_model_access(identity, request.model, config)
+        _check_model_access(identity, request.model, agent_perms)
 
         # --- Quota check (before routing) ---
-        warnings = await _check_quotas(identity, config, store)
+        warnings = await _check_quotas(identity, config, store, agent_perms)
 
         request_id = str(raw_request.state.correlation_id)
         start = time.monotonic()
@@ -468,7 +479,8 @@ def create_app(config: BifrostConfig) -> FastAPI:
 
         if since is not None:
             try:
-                since_dt = datetime.fromisoformat(since).replace(tzinfo=UTC)
+                _dt = datetime.fromisoformat(since)
+                since_dt = _dt.replace(tzinfo=UTC) if _dt.tzinfo is None else _dt.astimezone(UTC)
             except ValueError as exc:
                 raise HTTPException(
                     status_code=422,
@@ -477,7 +489,8 @@ def create_app(config: BifrostConfig) -> FastAPI:
 
         if until is not None:
             try:
-                until_dt = datetime.fromisoformat(until).replace(tzinfo=UTC)
+                _dt = datetime.fromisoformat(until)
+                until_dt = _dt.replace(tzinfo=UTC) if _dt.tzinfo is None else _dt.astimezone(UTC)
             except ValueError as exc:
                 raise HTTPException(
                     status_code=422,

--- a/src/bifrost/app.py
+++ b/src/bifrost/app.py
@@ -3,8 +3,12 @@
 Exposes an Anthropic-compatible HTTP API that routes requests to the
 configured providers (Anthropic, OpenAI, Ollama, generic).
 
-Phase 1 additions integrated here: correlation-ID middleware, token
-tracking with request logging, and the GET /v1/models endpoint.
+Phase 3 additions:
+- Agent authentication (open / PAT / mesh)
+- Per-agent model access control
+- Per-request cost tracking with attribution
+- Quota enforcement (soft warn + hard 429 reject)
+- Usage query endpoint (GET /v1/usage)
 """
 
 from __future__ import annotations
@@ -20,12 +24,60 @@ from datetime import UTC, datetime
 from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.responses import JSONResponse, StreamingResponse
 
+from bifrost.auth import AgentIdentity, extract_identity
 from bifrost.config import BifrostConfig
 from bifrost.domain.models import ModelInfo, RequestLog, TokenUsage
+from bifrost.ports.usage_store import UsageRecord, UsageStore
+from bifrost.pricing import ModelPricing, calculate_cost
 from bifrost.router import ModelRouter, RouterError
 from bifrost.translation.models import AnthropicRequest
 
 logger = logging.getLogger(__name__)
+
+# Header names for quota warnings.
+_HEADER_QUOTA_WARNING = "X-Quota-Warning"
+_HEADER_QUOTA_REMAINING = "X-Quota-Remaining"
+
+
+# ---------------------------------------------------------------------------
+# Usage store factory
+# ---------------------------------------------------------------------------
+
+
+def _build_usage_store(config: BifrostConfig) -> UsageStore:
+    """Instantiate the configured usage store adapter."""
+    match config.usage_store.adapter:
+        case "sqlite":
+            from bifrost.adapters.sqlite_store import SQLiteUsageStore
+
+            return SQLiteUsageStore(path=config.usage_store.path)
+        case _:
+            from bifrost.adapters.memory_store import MemoryUsageStore
+
+            return MemoryUsageStore()
+
+
+# ---------------------------------------------------------------------------
+# Pricing helpers
+# ---------------------------------------------------------------------------
+
+
+def _pricing_overrides(config: BifrostConfig) -> dict[str, ModelPricing]:
+    """Convert PricingOverride config objects to ModelPricing instances."""
+    result: dict[str, ModelPricing] = {}
+    for model, override in config.pricing.items():
+        result[model] = ModelPricing(
+            input_per_million=override.input_per_million,
+            output_per_million=override.output_per_million,
+            cache_creation_per_million=override.cache_creation_per_million,
+            cache_read_per_million=override.cache_read_per_million,
+        )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# SSE / streaming helpers
+# ---------------------------------------------------------------------------
 
 
 def _extract_usage_from_sse_line(line: str, usage: TokenUsage) -> None:
@@ -64,12 +116,123 @@ def _log_request(log: RequestLog) -> None:
     )
 
 
+# ---------------------------------------------------------------------------
+# Quota enforcement
+# ---------------------------------------------------------------------------
+
+
+async def _check_quotas(
+    identity: AgentIdentity,
+    config: BifrostConfig,
+    store: UsageStore,
+) -> list[str]:
+    """Check quota limits and return a list of warning strings (empty = OK).
+
+    Raises:
+        HTTPException(429): If any hard limit is exceeded.
+    """
+    warnings: list[str] = []
+
+    tenant_quota = config.quota_for_tenant(identity.tenant_id)
+    agent_perms = config.permissions_for_agent(identity.agent_id)
+    agent_quota = agent_perms.quota
+
+    # Tenant: tokens per day
+    if tenant_quota.max_tokens_per_day > 0:
+        used = await store.tokens_today(identity.tenant_id)
+        limit = tenant_quota.max_tokens_per_day
+        fraction = used / limit
+        if fraction >= 1.0:
+            raise HTTPException(
+                status_code=429,
+                detail=f"Tenant daily token quota exceeded ({used}/{limit}).",
+            )
+        if fraction >= tenant_quota.soft_limit_fraction:
+            warnings.append(f"tenant_tokens_per_day={used}/{limit} ({fraction:.0%})")
+
+    # Tenant: cost per day
+    if tenant_quota.max_cost_per_day > 0.0:
+        used_cost = await store.cost_today(identity.tenant_id)
+        limit_cost = tenant_quota.max_cost_per_day
+        fraction = used_cost / limit_cost
+        if fraction >= 1.0:
+            raise HTTPException(
+                status_code=429,
+                detail=f"Tenant daily cost quota exceeded (${used_cost:.4f}/${limit_cost:.4f}).",
+            )
+        if fraction >= tenant_quota.soft_limit_fraction:
+            warnings.append(
+                f"tenant_cost_per_day=${used_cost:.4f}/${limit_cost:.4f} ({fraction:.0%})"
+            )
+
+    # Tenant: requests per hour
+    if tenant_quota.max_requests_per_hour > 0:
+        used_req = await store.requests_this_hour(identity.tenant_id)
+        limit_req = tenant_quota.max_requests_per_hour
+        fraction = used_req / limit_req
+        if fraction >= 1.0:
+            raise HTTPException(
+                status_code=429,
+                detail=f"Tenant hourly request quota exceeded ({used_req}/{limit_req}).",
+            )
+        if fraction >= tenant_quota.soft_limit_fraction:
+            warnings.append(f"tenant_requests_per_hour={used_req}/{limit_req} ({fraction:.0%})")
+
+    # Agent: cost per day (only when a per-agent budget is configured)
+    if agent_quota.max_cost_per_day > 0.0:
+        agent_cost = await store.agent_cost_today(identity.agent_id)
+        limit_cost = agent_quota.max_cost_per_day
+        fraction = agent_cost / limit_cost
+        if fraction >= 1.0:
+            raise HTTPException(
+                status_code=429,
+                detail=(f"Agent daily cost quota exceeded (${agent_cost:.4f}/${limit_cost:.4f})."),
+            )
+        if fraction >= agent_quota.soft_limit_fraction:
+            warnings.append(
+                f"agent_cost_per_day=${agent_cost:.4f}/${limit_cost:.4f} ({fraction:.0%})"
+            )
+
+    return warnings
+
+
+def _check_model_access(
+    identity: AgentIdentity,
+    model: str,
+    config: BifrostConfig,
+) -> None:
+    """Raise 403 if the agent does not have permission to use *model*.
+
+    An empty ``allowed_models`` list means all models are permitted.
+    """
+    perms = config.permissions_for_agent(identity.agent_id)
+    if not perms.allowed_models:
+        return
+    if model not in perms.allowed_models:
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                f"Agent '{identity.agent_id}' is not permitted to use model '{model}'. "
+                f"Allowed: {perms.allowed_models}"
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Streaming wrapper with tracking
+# ---------------------------------------------------------------------------
+
+
 async def _stream_with_tracking(
     source: AsyncIterator[str],
     model: str,
     start: float,
+    identity: AgentIdentity,
+    store: UsageStore,
+    pricing_overrides: dict[str, ModelPricing],
+    request_id: str,
 ) -> AsyncIterator[str]:
-    """Yield SSE lines from *source* while tracking token usage for logging."""
+    """Yield SSE lines from *source* while tracking token usage."""
     usage = TokenUsage()
 
     async for line in source:
@@ -87,17 +250,42 @@ async def _stream_with_tracking(
         )
     )
 
+    cost = calculate_cost(model, usage, pricing_overrides)
+    await store.record(
+        UsageRecord(
+            request_id=request_id,
+            agent_id=identity.agent_id,
+            tenant_id=identity.tenant_id,
+            session_id=identity.session_id,
+            saga_id=identity.saga_id,
+            model=model,
+            input_tokens=usage.input_tokens,
+            output_tokens=usage.output_tokens,
+            cost_usd=cost,
+            timestamp=datetime.now(UTC),
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Application factory
+# ---------------------------------------------------------------------------
+
 
 def create_app(config: BifrostConfig) -> FastAPI:
     """Create and return the Bifröst FastAPI application.
 
     Args:
-        config: Gateway configuration (providers, aliases, etc.).
+        config: Gateway configuration (providers, aliases, auth, quotas, etc.).
 
     Returns:
         A configured ``FastAPI`` instance.
     """
     router = ModelRouter(config)
+    store = _build_usage_store(config)
+    pricing_overrides = _pricing_overrides(config)
+    auth_mode = config.auth_mode
+    pat_secret = config.effective_pat_secret()
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
@@ -166,20 +354,38 @@ def create_app(config: BifrostConfig) -> FastAPI:
 
         Accepts an Anthropic Messages API request body, routes it to the
         configured provider, and returns the response in Anthropic format.
-        Token usage is extracted and logged on each request.
+        Token usage is tracked per-request and attributed to the caller.
         """
+        # --- Authentication ---
+        identity = extract_identity(raw_request, auth_mode, pat_secret)
+
         try:
             body = await raw_request.json()
             request = AnthropicRequest.model_validate(body)
         except Exception as exc:
             raise HTTPException(status_code=422, detail=str(exc)) from exc
 
+        # --- Model access control ---
+        _check_model_access(identity, request.model, config)
+
+        # --- Quota check (before routing) ---
+        warnings = await _check_quotas(identity, config, store)
+
+        request_id = str(raw_request.state.correlation_id)
         start = time.monotonic()
 
         try:
             if request.stream:
-                return StreamingResponse(
-                    _stream_with_tracking(router.stream(request), request.model, start),
+                stream_resp = StreamingResponse(
+                    _stream_with_tracking(
+                        router.stream(request),
+                        request.model,
+                        start,
+                        identity,
+                        store,
+                        pricing_overrides,
+                        request_id,
+                    ),
                     media_type="text/event-stream",
                     headers={
                         "cache-control": "no-cache",
@@ -187,27 +393,136 @@ def create_app(config: BifrostConfig) -> FastAPI:
                         "connection": "keep-alive",
                     },
                 )
+                if warnings:
+                    stream_resp.headers[_HEADER_QUOTA_WARNING] = "; ".join(warnings)
+                return stream_resp
+
             response = await router.complete(request)
             latency_ms = (time.monotonic() - start) * 1000
             data = response.model_dump()
             raw_usage = data.get("usage", {})
+            usage = TokenUsage(
+                input_tokens=raw_usage.get("input_tokens", 0),
+                output_tokens=raw_usage.get("output_tokens", 0),
+                cache_creation_input_tokens=raw_usage.get("cache_creation_input_tokens", 0),
+                cache_read_input_tokens=raw_usage.get("cache_read_input_tokens", 0),
+            )
             _log_request(
                 RequestLog(
                     timestamp=datetime.now(UTC),
                     model=request.model,
-                    usage=TokenUsage(
-                        input_tokens=raw_usage.get("input_tokens", 0),
-                        output_tokens=raw_usage.get("output_tokens", 0),
-                        cache_creation_input_tokens=raw_usage.get("cache_creation_input_tokens", 0),
-                        cache_read_input_tokens=raw_usage.get("cache_read_input_tokens", 0),
-                    ),
+                    usage=usage,
                     latency_ms=latency_ms,
                     stream=False,
                 )
             )
-            return JSONResponse(content=data)
+
+            cost = calculate_cost(request.model, usage, pricing_overrides)
+            await store.record(
+                UsageRecord(
+                    request_id=request_id,
+                    agent_id=identity.agent_id,
+                    tenant_id=identity.tenant_id,
+                    session_id=identity.session_id,
+                    saga_id=identity.saga_id,
+                    model=request.model,
+                    input_tokens=usage.input_tokens,
+                    output_tokens=usage.output_tokens,
+                    cost_usd=cost,
+                    timestamp=datetime.now(UTC),
+                )
+            )
+
+            json_resp = JSONResponse(content=data)
+            if warnings:
+                json_resp.headers[_HEADER_QUOTA_WARNING] = "; ".join(warnings)
+            return json_resp
+
         except RouterError as exc:
             logger.error("Routing failed: %s", exc)
             raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    @app.get("/v1/usage")
+    async def usage_endpoint(
+        agent_id: str | None = None,
+        tenant_id: str | None = None,
+        model: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        limit: int = 1000,
+    ) -> dict:
+        """Return aggregated usage statistics with optional filters.
+
+        Query parameters:
+            agent_id:  Filter by agent identifier.
+            tenant_id: Filter by tenant identifier.
+            model:     Filter by model name.
+            since:     ISO-8601 datetime (inclusive lower bound).
+            until:     ISO-8601 datetime (inclusive upper bound).
+            limit:     Maximum number of raw records returned (default 1000).
+
+        Returns a summary (totals + per-model breakdown) and the raw record list.
+        """
+        since_dt: datetime | None = None
+        until_dt: datetime | None = None
+
+        if since is not None:
+            try:
+                since_dt = datetime.fromisoformat(since).replace(tzinfo=UTC)
+            except ValueError as exc:
+                raise HTTPException(
+                    status_code=422,
+                    detail=f"Invalid 'since' datetime: {exc}",
+                ) from exc
+
+        if until is not None:
+            try:
+                until_dt = datetime.fromisoformat(until).replace(tzinfo=UTC)
+            except ValueError as exc:
+                raise HTTPException(
+                    status_code=422,
+                    detail=f"Invalid 'until' datetime: {exc}",
+                ) from exc
+
+        summary = await store.summarise(
+            agent_id=agent_id,
+            tenant_id=tenant_id,
+            model=model,
+            since=since_dt,
+            until=until_dt,
+        )
+        records = await store.query(
+            agent_id=agent_id,
+            tenant_id=tenant_id,
+            model=model,
+            since=since_dt,
+            until=until_dt,
+            limit=limit,
+        )
+
+        return {
+            "summary": {
+                "total_requests": summary.total_requests,
+                "total_input_tokens": summary.total_input_tokens,
+                "total_output_tokens": summary.total_output_tokens,
+                "total_cost_usd": round(summary.total_cost_usd, 6),
+                "by_model": summary.by_model,
+            },
+            "records": [
+                {
+                    "request_id": r.request_id,
+                    "agent_id": r.agent_id,
+                    "tenant_id": r.tenant_id,
+                    "session_id": r.session_id,
+                    "saga_id": r.saga_id,
+                    "model": r.model,
+                    "input_tokens": r.input_tokens,
+                    "output_tokens": r.output_tokens,
+                    "cost_usd": round(r.cost_usd, 6),
+                    "timestamp": r.timestamp.isoformat(),
+                }
+                for r in records
+            ],
+        }
 
     return app

--- a/src/bifrost/auth.py
+++ b/src/bifrost/auth.py
@@ -16,7 +16,7 @@ In all modes the standard attribution headers (``X-Session-Id``,
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import StrEnum
 
 import jwt
@@ -44,11 +44,6 @@ class AgentIdentity:
     tenant_id: str = "default"
     session_id: str = ""
     saga_id: str = ""
-    allowed_models: list[str] = field(default_factory=list)
-    """Models this agent is permitted to use (empty = all models allowed)."""
-
-
-_ANON = AgentIdentity()
 
 
 def _read_attribution_headers(request: Request) -> tuple[str, str]:

--- a/src/bifrost/auth.py
+++ b/src/bifrost/auth.py
@@ -1,0 +1,131 @@
+"""Agent authentication for Bifröst.
+
+Supports three modes:
+
+- ``open``  — No authentication required. Headers are trusted as-is
+              (suitable for local/Pi mode or behind a trusted proxy).
+- ``pat``   — Bearer token must be a valid Bifröst Personal Access Token
+              (HS256 JWT signed with ``pat_secret``).
+- ``mesh``  — Trust Envoy / service-mesh injected headers
+              (``X-Agent-Id``, ``X-Tenant-Id``, etc.).  Envoy has already
+              verified the caller's identity; no further validation needed.
+
+In all modes the standard attribution headers (``X-Session-Id``,
+``X-Saga-Id``) are extracted from the request and forwarded to tracking.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+import jwt
+from fastapi import HTTPException, Request
+
+
+class AuthMode(StrEnum):
+    """Authentication mode for the Bifröst gateway."""
+
+    OPEN = "open"
+    """No authentication — headers are trusted verbatim."""
+
+    PAT = "pat"
+    """Bearer-token Personal Access Token (HS256 JWT)."""
+
+    MESH = "mesh"
+    """Service-mesh / Envoy injected identity headers."""
+
+
+@dataclass
+class AgentIdentity:
+    """Caller identity attached to every tracked request."""
+
+    agent_id: str = "anonymous"
+    tenant_id: str = "default"
+    session_id: str = ""
+    saga_id: str = ""
+    allowed_models: list[str] = field(default_factory=list)
+    """Models this agent is permitted to use (empty = all models allowed)."""
+
+
+_ANON = AgentIdentity()
+
+
+def _read_attribution_headers(request: Request) -> tuple[str, str]:
+    """Return (session_id, saga_id) from standard attribution headers."""
+    return (
+        request.headers.get("x-session-id", ""),
+        request.headers.get("x-saga-id", ""),
+    )
+
+
+def _extract_open(request: Request) -> AgentIdentity:
+    """Open mode: trust any headers the caller provides."""
+    session_id, saga_id = _read_attribution_headers(request)
+    return AgentIdentity(
+        agent_id=request.headers.get("x-agent-id", "anonymous"),
+        tenant_id=request.headers.get("x-tenant-id", "default"),
+        session_id=session_id,
+        saga_id=saga_id,
+    )
+
+
+def _extract_mesh(request: Request) -> AgentIdentity:
+    """Mesh mode: read Envoy-injected identity headers."""
+    session_id, saga_id = _read_attribution_headers(request)
+    return AgentIdentity(
+        agent_id=request.headers.get("x-agent-id", "anonymous"),
+        tenant_id=request.headers.get("x-tenant-id", "default"),
+        session_id=session_id,
+        saga_id=saga_id,
+    )
+
+
+def _extract_pat(request: Request, secret: str) -> AgentIdentity:
+    """PAT mode: validate Bearer JWT and extract claims."""
+    auth_header = request.headers.get("authorization", "")
+    if not auth_header.lower().startswith("bearer "):
+        raise HTTPException(status_code=401, detail="Missing Bearer token")
+
+    token = auth_header[7:]
+    try:
+        payload = jwt.decode(token, secret, algorithms=["HS256"])
+    except jwt.ExpiredSignatureError as exc:
+        raise HTTPException(status_code=401, detail="Token has expired") from exc
+    except jwt.InvalidTokenError as exc:
+        raise HTTPException(status_code=401, detail=f"Invalid token: {exc}") from exc
+
+    session_id, saga_id = _read_attribution_headers(request)
+    return AgentIdentity(
+        agent_id=payload.get("sub", "anonymous"),
+        tenant_id=payload.get("tenant_id", "default"),
+        session_id=session_id,
+        saga_id=saga_id,
+    )
+
+
+def extract_identity(
+    request: Request,
+    mode: AuthMode,
+    secret: str = "",
+) -> AgentIdentity:
+    """Extract caller identity from *request* according to *mode*.
+
+    Args:
+        request: The incoming FastAPI request.
+        mode:    Authentication mode (open / pat / mesh).
+        secret:  HS256 signing secret used in ``pat`` mode.
+
+    Returns:
+        ``AgentIdentity`` populated from request headers / JWT claims.
+
+    Raises:
+        HTTPException(401): In ``pat`` mode when the token is absent or invalid.
+    """
+    match mode:
+        case AuthMode.PAT:
+            return _extract_pat(request, secret)
+        case AuthMode.MESH:
+            return _extract_mesh(request)
+        case _:
+            return _extract_open(request)

--- a/src/bifrost/config.py
+++ b/src/bifrost/config.py
@@ -1,4 +1,4 @@
-"""Bifröst configuration: providers, aliases, and routing settings."""
+"""Bifröst configuration: providers, aliases, routing settings, auth, and quotas."""
 
 from __future__ import annotations
 
@@ -6,6 +6,8 @@ import os
 from enum import StrEnum
 
 from pydantic import BaseModel, Field
+
+from bifrost.auth import AuthMode
 
 
 class RoutingStrategy(StrEnum):
@@ -51,6 +53,71 @@ class ProviderConfig(BaseModel):
         return os.environ.get(self.api_key_env, "")
 
 
+class PricingOverride(BaseModel):
+    """USD per million tokens for a single model (overrides built-in snapshot)."""
+
+    input_per_million: float = 0.0
+    output_per_million: float = 0.0
+    cache_creation_per_million: float = 0.0
+    cache_read_per_million: float = 0.0
+
+
+class QuotaConfig(BaseModel):
+    """Quota limits for a tenant or agent."""
+
+    max_tokens_per_day: int = Field(
+        default=0,
+        description="Maximum total tokens (input + output) per day. 0 = unlimited.",
+    )
+    max_cost_per_day: float = Field(
+        default=0.0,
+        description="Maximum USD cost per day. 0.0 = unlimited.",
+    )
+    max_requests_per_hour: int = Field(
+        default=0,
+        description="Maximum requests per calendar hour. 0 = unlimited.",
+    )
+    soft_limit_fraction: float = Field(
+        default=0.9,
+        description=(
+            "Fraction of any hard limit at which a warning header is injected "
+            "(0 < fraction < 1). Default: 0.9 (warn at 90% of the limit)."
+        ),
+    )
+
+
+class AgentPermissions(BaseModel):
+    """Per-agent access control and optional budget."""
+
+    allowed_models: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Models this agent is permitted to use. Empty list means all models are allowed."
+        ),
+    )
+    quota: QuotaConfig = Field(
+        default_factory=QuotaConfig,
+        description="Optional per-agent quota (zero values mean no limit).",
+    )
+
+
+class UsageStoreConfig(BaseModel):
+    """Configuration for the usage persistence backend."""
+
+    adapter: str = Field(
+        default="memory",
+        description=("Storage backend. Accepted values: 'memory' (default), 'sqlite', 'postgres'."),
+    )
+    path: str = Field(
+        default="./bifrost_usage.db",
+        description="File path for the SQLite backend (ignored for other adapters).",
+    )
+    dsn: str = Field(
+        default="",
+        description="PostgreSQL DSN for the postgres backend (ignored for other adapters).",
+    )
+
+
 # Default base URLs per provider type.
 _DEFAULT_BASE_URLS: dict[str, str] = {
     "anthropic": "https://api.anthropic.com",
@@ -88,6 +155,54 @@ class BifrostConfig(BaseModel):
     host: str = Field(default="0.0.0.0", description="Host to bind the gateway server.")
     port: int = Field(default=8088, description="Port to bind the gateway server.")
 
+    # ── Authentication ───────────────────────────────────────────────────────
+    auth_mode: AuthMode = Field(
+        default=AuthMode.OPEN,
+        description=(
+            "Authentication mode: 'open' (trust headers), "
+            "'pat' (Bearer JWT), or 'mesh' (Envoy injected headers)."
+        ),
+    )
+    pat_secret: str = Field(
+        default="",
+        description=(
+            "HS256 signing secret for PAT verification. "
+            "Required when auth_mode = 'pat'. "
+            "Read from the PAT_SECRET environment variable if blank."
+        ),
+    )
+
+    # ── Pricing overrides ───────────────────────────────────────────────────
+    pricing: dict[str, PricingOverride] = Field(
+        default_factory=dict,
+        description=(
+            "Per-model pricing overrides (USD / million tokens). "
+            "Unspecified models fall back to the built-in snapshot."
+        ),
+    )
+
+    # ── Quota enforcement ────────────────────────────────────────────────────
+    default_quota: QuotaConfig = Field(
+        default_factory=QuotaConfig,
+        description="Default quota applied to all tenants (zero values = unlimited).",
+    )
+    tenant_quotas: dict[str, QuotaConfig] = Field(
+        default_factory=dict,
+        description="Per-tenant quota overrides (keyed by tenant_id).",
+    )
+    agent_permissions: dict[str, AgentPermissions] = Field(
+        default_factory=dict,
+        description="Per-agent model access control and optional budget.",
+    )
+
+    # ── Usage storage ────────────────────────────────────────────────────────
+    usage_store: UsageStoreConfig = Field(
+        default_factory=UsageStoreConfig,
+        description="Configuration for the usage persistence backend.",
+    )
+
+    # ── Helpers ──────────────────────────────────────────────────────────────
+
     def resolve_alias(self, model: str) -> str:
         """Expand a model alias to its canonical name."""
         return self.aliases.get(model, model)
@@ -109,3 +224,15 @@ class BifrostConfig(BaseModel):
         if cfg and cfg.base_url:
             return cfg.base_url
         return _DEFAULT_BASE_URLS.get(provider_name, "")
+
+    def effective_pat_secret(self) -> str:
+        """Return the PAT signing secret, falling back to the PAT_SECRET env var."""
+        return self.pat_secret or os.environ.get("PAT_SECRET", "")
+
+    def quota_for_tenant(self, tenant_id: str) -> QuotaConfig:
+        """Return the quota config for *tenant_id*, falling back to the default."""
+        return self.tenant_quotas.get(tenant_id, self.default_quota)
+
+    def permissions_for_agent(self, agent_id: str) -> AgentPermissions:
+        """Return the permissions for *agent_id* (empty = unrestricted)."""
+        return self.agent_permissions.get(agent_id, AgentPermissions())

--- a/src/bifrost/ports/usage_store.py
+++ b/src/bifrost/ports/usage_store.py
@@ -1,0 +1,89 @@
+"""Port (abstract interface) for usage record persistence and quota queries.
+
+All concrete storage adapters — in-memory, SQLite, PostgreSQL — must implement
+``UsageStore``.  Business logic in ``app.py`` depends on this port only; it
+never imports an adapter directly.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime
+
+
+@dataclass
+class UsageRecord:
+    """A single tracked LLM request with attribution and cost."""
+
+    agent_id: str
+    tenant_id: str
+    model: str
+    input_tokens: int
+    output_tokens: int
+    cost_usd: float
+    timestamp: datetime
+    request_id: str = ""
+    session_id: str = ""
+    saga_id: str = ""
+
+
+@dataclass
+class UsageSummary:
+    """Aggregated usage statistics for a set of records."""
+
+    total_requests: int = 0
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    total_cost_usd: float = 0.0
+    by_model: dict[str, dict] = field(default_factory=dict)
+    """Per-model breakdown: model → {requests, input_tokens, output_tokens, cost_usd}."""
+
+
+class UsageStore(ABC):
+    """Port for persisting and querying per-request usage records."""
+
+    @abstractmethod
+    async def record(self, usage: UsageRecord) -> None:
+        """Persist *usage* immediately."""
+
+    @abstractmethod
+    async def query(
+        self,
+        *,
+        agent_id: str | None = None,
+        tenant_id: str | None = None,
+        model: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        limit: int = 1000,
+    ) -> list[UsageRecord]:
+        """Return records matching all supplied filters (AND logic)."""
+
+    @abstractmethod
+    async def summarise(
+        self,
+        *,
+        agent_id: str | None = None,
+        tenant_id: str | None = None,
+        model: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+    ) -> UsageSummary:
+        """Return aggregated totals for the given filter set."""
+
+    @abstractmethod
+    async def tokens_today(self, tenant_id: str) -> int:
+        """Total tokens (input + output) consumed today by *tenant_id*."""
+
+    @abstractmethod
+    async def cost_today(self, tenant_id: str) -> float:
+        """Total USD cost today for *tenant_id*."""
+
+    @abstractmethod
+    async def requests_this_hour(self, tenant_id: str) -> int:
+        """Number of requests made this calendar hour by *tenant_id*."""
+
+    @abstractmethod
+    async def agent_cost_today(self, agent_id: str) -> float:
+        """Total USD cost today attributed to *agent_id*."""

--- a/src/bifrost/pricing.py
+++ b/src/bifrost/pricing.py
@@ -1,0 +1,83 @@
+"""Per-model pricing table and cost calculation.
+
+Prices are USD per million tokens (input / output / cache variants).
+The built-in snapshot can be extended or overridden via ``BifrostConfig``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from bifrost.domain.models import TokenUsage
+
+
+@dataclass(frozen=True)
+class ModelPricing:
+    """USD cost per one million tokens for a single model."""
+
+    input_per_million: float = 0.0
+    output_per_million: float = 0.0
+    cache_creation_per_million: float = 0.0
+    cache_read_per_million: float = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Built-in pricing snapshot — USD/million tokens as of 2026-04.
+# These can be overridden or extended through BifrostConfig.pricing.
+# ---------------------------------------------------------------------------
+BUILTIN_PRICING: dict[str, ModelPricing] = {
+    # Anthropic ──────────────────────────────────────────────────────────────
+    "claude-opus-4-6": ModelPricing(
+        input_per_million=15.00,
+        output_per_million=75.00,
+        cache_creation_per_million=18.75,
+        cache_read_per_million=1.50,
+    ),
+    "claude-sonnet-4-6": ModelPricing(
+        input_per_million=3.00,
+        output_per_million=15.00,
+        cache_creation_per_million=3.75,
+        cache_read_per_million=0.30,
+    ),
+    "claude-haiku-4-5-20251001": ModelPricing(
+        input_per_million=0.80,
+        output_per_million=4.00,
+        cache_creation_per_million=1.00,
+        cache_read_per_million=0.08,
+    ),
+    # OpenAI ─────────────────────────────────────────────────────────────────
+    "gpt-4o": ModelPricing(input_per_million=2.50, output_per_million=10.00),
+    "gpt-4o-mini": ModelPricing(input_per_million=0.15, output_per_million=0.60),
+    # Local / free (Ollama) ──────────────────────────────────────────────────
+    "llama3.1:8b": ModelPricing(),
+}
+
+
+def calculate_cost(
+    model: str,
+    usage: TokenUsage,
+    overrides: dict[str, ModelPricing] | None = None,
+) -> float:
+    """Return the USD cost for *usage* on *model*.
+
+    Pricing is looked up in *overrides* first, then ``BUILTIN_PRICING``.
+    Returns ``0.0`` when the model has no pricing entry.
+
+    Args:
+        model:     Canonical model identifier.
+        usage:     Token counts from the completed request.
+        overrides: Optional per-model overrides from config.
+
+    Returns:
+        Cost in USD (may be 0.0 for unknown / free models).
+    """
+    pricing = (overrides or {}).get(model) or BUILTIN_PRICING.get(model)
+    if pricing is None:
+        return 0.0
+
+    return (
+        usage.input_tokens * pricing.input_per_million / 1_000_000
+        + usage.output_tokens * pricing.output_per_million / 1_000_000
+        + usage.cache_creation_input_tokens * pricing.cache_creation_per_million / 1_000_000
+        + usage.cache_read_input_tokens * pricing.cache_read_per_million / 1_000_000
+    )

--- a/tests/test_bifrost/test_auth.py
+++ b/tests/test_bifrost/test_auth.py
@@ -1,0 +1,222 @@
+"""Tests for bifrost.auth — agent identity extraction."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+
+from bifrost.app import create_app
+from bifrost.auth import AgentIdentity, AuthMode, extract_identity
+from bifrost.config import BifrostConfig, ProviderConfig
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SECRET = "test-secret-key-that-is-at-least-32-bytes-long!"
+
+
+def _make_token(payload: dict) -> str:
+    return jwt.encode(payload, _SECRET, algorithm="HS256")
+
+
+def _make_request(headers: dict | None = None):
+    """Create a minimal mock Request-like object."""
+    from unittest.mock import MagicMock
+
+    req = MagicMock()
+    req.headers = headers or {}
+    return req
+
+
+def _make_config(auth_mode: AuthMode = AuthMode.OPEN, secret: str = "") -> BifrostConfig:
+    return BifrostConfig(
+        providers={"anthropic": ProviderConfig(models=["claude-sonnet-4-6"])},
+        auth_mode=auth_mode,
+        pat_secret=secret,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Open mode
+# ---------------------------------------------------------------------------
+
+
+class TestOpenMode:
+    def test_anonymous_when_no_headers(self):
+        req = _make_request()
+        identity = extract_identity(req, AuthMode.OPEN)
+        assert identity.agent_id == "anonymous"
+        assert identity.tenant_id == "default"
+
+    def test_reads_agent_and_tenant_headers(self):
+        req = _make_request(
+            {
+                "x-agent-id": "agent-xyz",
+                "x-tenant-id": "tenant-abc",
+                "x-session-id": "sess-1",
+                "x-saga-id": "saga-2",
+            }
+        )
+        identity = extract_identity(req, AuthMode.OPEN)
+        assert identity.agent_id == "agent-xyz"
+        assert identity.tenant_id == "tenant-abc"
+        assert identity.session_id == "sess-1"
+        assert identity.saga_id == "saga-2"
+
+    def test_returns_agent_identity_type(self):
+        req = _make_request()
+        identity = extract_identity(req, AuthMode.OPEN)
+        assert isinstance(identity, AgentIdentity)
+
+
+# ---------------------------------------------------------------------------
+# Mesh mode
+# ---------------------------------------------------------------------------
+
+
+class TestMeshMode:
+    def test_reads_envoy_injected_headers(self):
+        req = _make_request(
+            {
+                "x-agent-id": "mesh-agent",
+                "x-tenant-id": "mesh-tenant",
+                "x-session-id": "s",
+                "x-saga-id": "sg",
+            }
+        )
+        identity = extract_identity(req, AuthMode.MESH)
+        assert identity.agent_id == "mesh-agent"
+        assert identity.tenant_id == "mesh-tenant"
+        assert identity.session_id == "s"
+        assert identity.saga_id == "sg"
+
+    def test_defaults_when_headers_absent(self):
+        req = _make_request()
+        identity = extract_identity(req, AuthMode.MESH)
+        assert identity.agent_id == "anonymous"
+        assert identity.tenant_id == "default"
+
+
+# ---------------------------------------------------------------------------
+# PAT mode
+# ---------------------------------------------------------------------------
+
+
+class TestPATMode:
+    def test_valid_token_extracts_claims(self):
+        token = _make_token({"sub": "agent-1", "tenant_id": "tenant-1"})
+        req = _make_request({"authorization": f"Bearer {token}"})
+        identity = extract_identity(req, AuthMode.PAT, _SECRET)
+        assert identity.agent_id == "agent-1"
+        assert identity.tenant_id == "tenant-1"
+
+    def test_missing_bearer_raises_401(self):
+        from fastapi import HTTPException
+
+        req = _make_request({})
+        with pytest.raises(HTTPException) as exc_info:
+            extract_identity(req, AuthMode.PAT, _SECRET)
+        assert exc_info.value.status_code == 401
+
+    def test_invalid_token_raises_401(self):
+        from fastapi import HTTPException
+
+        req = _make_request({"authorization": "Bearer not-a-jwt"})
+        with pytest.raises(HTTPException) as exc_info:
+            extract_identity(req, AuthMode.PAT, _SECRET)
+        assert exc_info.value.status_code == 401
+
+    def test_wrong_secret_raises_401(self):
+        from fastapi import HTTPException
+
+        token = _make_token({"sub": "agent-1"})
+        req = _make_request({"authorization": f"Bearer {token}"})
+        with pytest.raises(HTTPException) as exc_info:
+            extract_identity(req, AuthMode.PAT, "wrong-secret-that-is-at-least-32-bytes-long!")
+        assert exc_info.value.status_code == 401
+
+    def test_expired_token_raises_401(self):
+        import time
+
+        from fastapi import HTTPException
+
+        token = _make_token({"sub": "agent-1", "exp": int(time.time()) - 10})
+        req = _make_request({"authorization": f"Bearer {token}"})
+        with pytest.raises(HTTPException) as exc_info:
+            extract_identity(req, AuthMode.PAT, _SECRET)
+        assert exc_info.value.status_code == 401
+
+    def test_defaults_when_claims_absent(self):
+        token = _make_token({})
+        req = _make_request({"authorization": f"Bearer {token}"})
+        identity = extract_identity(req, AuthMode.PAT, _SECRET)
+        assert identity.agent_id == "anonymous"
+        assert identity.tenant_id == "default"
+
+    def test_reads_attribution_headers_alongside_jwt(self):
+        token = _make_token({"sub": "ag"})
+        req = _make_request(
+            {
+                "authorization": f"Bearer {token}",
+                "x-session-id": "sess",
+                "x-saga-id": "saga",
+            }
+        )
+        identity = extract_identity(req, AuthMode.PAT, _SECRET)
+        assert identity.session_id == "sess"
+        assert identity.saga_id == "saga"
+
+
+# ---------------------------------------------------------------------------
+# Integration: auth mode wired into the app via TestClient
+# ---------------------------------------------------------------------------
+
+
+class TestAuthIntegration:
+    """Verify the FastAPI app enforces the configured auth mode end-to-end."""
+
+    def _client_with_pat(self) -> TestClient:
+        cfg = _make_config(AuthMode.PAT, _SECRET)
+        app = create_app(cfg)
+        with patch("bifrost.router.ModelRouter.complete", new_callable=AsyncMock) as m:
+            from bifrost.translation.models import AnthropicResponse, TextBlock, UsageInfo
+
+            m.return_value = AnthropicResponse(
+                id="msg",
+                content=[TextBlock(text="hi")],
+                model="claude-sonnet-4-6",
+                stop_reason="end_turn",
+                usage=UsageInfo(input_tokens=5, output_tokens=2),
+            )
+            with TestClient(app, raise_server_exceptions=False) as c:
+                yield c
+
+    def test_pat_mode_rejects_missing_token(self):
+        for client in self._client_with_pat():
+            resp = client.post(
+                "/v1/messages",
+                json={
+                    "model": "claude-sonnet-4-6",
+                    "max_tokens": 10,
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+            )
+            assert resp.status_code == 401
+
+    def test_pat_mode_accepts_valid_token(self):
+        token = _make_token({"sub": "agent-test"})
+        for client in self._client_with_pat():
+            resp = client.post(
+                "/v1/messages",
+                headers={"Authorization": f"Bearer {token}"},
+                json={
+                    "model": "claude-sonnet-4-6",
+                    "max_tokens": 10,
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+            )
+            assert resp.status_code == 200

--- a/tests/test_bifrost/test_pricing.py
+++ b/tests/test_bifrost/test_pricing.py
@@ -1,0 +1,115 @@
+"""Tests for bifrost.pricing — cost calculation."""
+
+from __future__ import annotations
+
+import pytest
+
+from bifrost.domain.models import TokenUsage
+from bifrost.pricing import BUILTIN_PRICING, ModelPricing, calculate_cost
+
+
+class TestBuiltinPricing:
+    def test_anthropic_models_present(self):
+        assert "claude-opus-4-6" in BUILTIN_PRICING
+        assert "claude-sonnet-4-6" in BUILTIN_PRICING
+        assert "claude-haiku-4-5-20251001" in BUILTIN_PRICING
+
+    def test_openai_models_present(self):
+        assert "gpt-4o" in BUILTIN_PRICING
+        assert "gpt-4o-mini" in BUILTIN_PRICING
+
+    def test_ollama_free(self):
+        pricing = BUILTIN_PRICING["llama3.1:8b"]
+        assert pricing.input_per_million == 0.0
+        assert pricing.output_per_million == 0.0
+
+    def test_opus_more_expensive_than_sonnet(self):
+        opus = BUILTIN_PRICING["claude-opus-4-6"]
+        sonnet = BUILTIN_PRICING["claude-sonnet-4-6"]
+        assert opus.output_per_million > sonnet.output_per_million
+
+
+class TestCalculateCost:
+    def test_zero_usage_returns_zero(self):
+        usage = TokenUsage()
+        cost = calculate_cost("claude-sonnet-4-6", usage)
+        assert cost == 0.0
+
+    def test_input_tokens_only(self):
+        usage = TokenUsage(input_tokens=1_000_000)
+        cost = calculate_cost("claude-sonnet-4-6", usage)
+        expected = BUILTIN_PRICING["claude-sonnet-4-6"].input_per_million
+        assert abs(cost - expected) < 1e-9
+
+    def test_output_tokens_only(self):
+        usage = TokenUsage(output_tokens=1_000_000)
+        cost = calculate_cost("claude-opus-4-6", usage)
+        expected = BUILTIN_PRICING["claude-opus-4-6"].output_per_million
+        assert abs(cost - expected) < 1e-9
+
+    def test_combined_tokens(self):
+        usage = TokenUsage(input_tokens=100_000, output_tokens=50_000)
+        pricing = BUILTIN_PRICING["claude-sonnet-4-6"]
+        expected = (
+            100_000 * pricing.input_per_million / 1_000_000
+            + 50_000 * pricing.output_per_million / 1_000_000
+        )
+        cost = calculate_cost("claude-sonnet-4-6", usage)
+        assert abs(cost - expected) < 1e-9
+
+    def test_cache_tokens_included(self):
+        usage = TokenUsage(
+            input_tokens=0,
+            output_tokens=0,
+            cache_creation_input_tokens=1_000_000,
+            cache_read_input_tokens=1_000_000,
+        )
+        pricing = BUILTIN_PRICING["claude-sonnet-4-6"]
+        expected = pricing.cache_creation_per_million + pricing.cache_read_per_million
+        cost = calculate_cost("claude-sonnet-4-6", usage)
+        assert abs(cost - expected) < 1e-9
+
+    def test_unknown_model_returns_zero(self):
+        usage = TokenUsage(input_tokens=1000, output_tokens=500)
+        assert calculate_cost("totally-unknown-model", usage) == 0.0
+
+    def test_free_model_returns_zero(self):
+        usage = TokenUsage(input_tokens=500_000, output_tokens=200_000)
+        assert calculate_cost("llama3.1:8b", usage) == 0.0
+
+    def test_overrides_take_precedence(self):
+        usage = TokenUsage(input_tokens=1_000_000)
+        override = {"claude-sonnet-4-6": ModelPricing(input_per_million=99.0)}
+        cost = calculate_cost("claude-sonnet-4-6", usage, overrides=override)
+        assert abs(cost - 99.0) < 1e-9
+
+    def test_overrides_can_add_new_model(self):
+        usage = TokenUsage(output_tokens=1_000_000)
+        override = {"custom-model": ModelPricing(output_per_million=7.5)}
+        cost = calculate_cost("custom-model", usage, overrides=override)
+        assert abs(cost - 7.5) < 1e-9
+
+    def test_override_does_not_affect_other_models(self):
+        usage = TokenUsage(input_tokens=1_000_000)
+        override = {"claude-opus-4-6": ModelPricing(input_per_million=999.0)}
+        cost = calculate_cost("claude-sonnet-4-6", usage, overrides=override)
+        expected = BUILTIN_PRICING["claude-sonnet-4-6"].input_per_million
+        assert abs(cost - expected) < 1e-9
+
+    @pytest.mark.parametrize(
+        "model,input_tok,output_tok",
+        [
+            ("claude-haiku-4-5-20251001", 10_000, 5_000),
+            ("gpt-4o-mini", 20_000, 10_000),
+            ("gpt-4o", 500, 200),
+        ],
+    )
+    def test_parametrised_models(self, model: str, input_tok: int, output_tok: int):
+        usage = TokenUsage(input_tokens=input_tok, output_tokens=output_tok)
+        pricing = BUILTIN_PRICING[model]
+        expected = (
+            input_tok * pricing.input_per_million / 1_000_000
+            + output_tok * pricing.output_per_million / 1_000_000
+        )
+        cost = calculate_cost(model, usage)
+        assert abs(cost - expected) < 1e-9

--- a/tests/test_bifrost/test_quotas.py
+++ b/tests/test_bifrost/test_quotas.py
@@ -1,0 +1,320 @@
+"""Tests for quota enforcement in the Bifröst gateway."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from bifrost.adapters.memory_store import MemoryUsageStore
+from bifrost.app import _check_quotas, create_app
+from bifrost.auth import AgentIdentity
+from bifrost.config import AgentPermissions, BifrostConfig, ProviderConfig, QuotaConfig
+from bifrost.ports.usage_store import UsageRecord
+from bifrost.translation.models import AnthropicResponse, TextBlock, UsageInfo
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_response() -> AnthropicResponse:
+    return AnthropicResponse(
+        id="msg",
+        content=[TextBlock(text="ok")],
+        model="claude-sonnet-4-6",
+        stop_reason="end_turn",
+        usage=UsageInfo(input_tokens=10, output_tokens=5),
+    )
+
+
+def _base_config(**kwargs) -> BifrostConfig:
+    return BifrostConfig(
+        providers={"anthropic": ProviderConfig(models=["claude-sonnet-4-6"])},
+        **kwargs,
+    )
+
+
+def _seeded_store(*records: UsageRecord) -> MemoryUsageStore:
+    store = MemoryUsageStore()
+    # Seed synchronously via the internal list.
+    store._records.extend(records)
+    return store
+
+
+def _now_record(
+    tenant_id: str = "t",
+    agent_id: str = "a",
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cost_usd: float = 0.0,
+) -> UsageRecord:
+    return UsageRecord(
+        request_id="",
+        agent_id=agent_id,
+        tenant_id=tenant_id,
+        session_id="",
+        saga_id="",
+        model="claude-sonnet-4-6",
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cost_usd=cost_usd,
+        timestamp=datetime.now(UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _check_quotas
+# ---------------------------------------------------------------------------
+
+
+class TestCheckQuotas:
+    @pytest.fixture
+    def identity(self) -> AgentIdentity:
+        return AgentIdentity(agent_id="agent-1", tenant_id="tenant-1")
+
+    async def test_no_limits_no_warnings(self, identity):
+        config = _base_config()
+        store = MemoryUsageStore()
+        warnings = await _check_quotas(identity, config, store)
+        assert warnings == []
+
+    # ── Token quota ──────────────────────────────────────────────────────────
+
+    async def test_hard_token_limit_raises_429(self, identity):
+        from fastapi import HTTPException
+
+        config = _base_config(
+            default_quota=QuotaConfig(max_tokens_per_day=100),
+        )
+        store = _seeded_store(_now_record(tenant_id="tenant-1", input_tokens=80, output_tokens=30))
+        with pytest.raises(HTTPException) as exc_info:
+            await _check_quotas(identity, config, store)
+        assert exc_info.value.status_code == 429
+
+    async def test_soft_token_limit_returns_warning(self, identity):
+        config = _base_config(
+            default_quota=QuotaConfig(max_tokens_per_day=100, soft_limit_fraction=0.8),
+        )
+        store = _seeded_store(_now_record(tenant_id="tenant-1", input_tokens=85, output_tokens=0))
+        warnings = await _check_quotas(identity, config, store)
+        assert any("token" in w for w in warnings)
+
+    async def test_under_soft_token_limit_no_warning(self, identity):
+        config = _base_config(
+            default_quota=QuotaConfig(max_tokens_per_day=1000, soft_limit_fraction=0.9),
+        )
+        store = _seeded_store(_now_record(tenant_id="tenant-1", input_tokens=100, output_tokens=0))
+        warnings = await _check_quotas(identity, config, store)
+        assert not any("token" in w for w in warnings)
+
+    # ── Cost quota ───────────────────────────────────────────────────────────
+
+    async def test_hard_cost_limit_raises_429(self, identity):
+        from fastapi import HTTPException
+
+        config = _base_config(
+            default_quota=QuotaConfig(max_cost_per_day=1.0),
+        )
+        store = _seeded_store(_now_record(tenant_id="tenant-1", cost_usd=1.50))
+        with pytest.raises(HTTPException) as exc_info:
+            await _check_quotas(identity, config, store)
+        assert exc_info.value.status_code == 429
+
+    async def test_soft_cost_limit_returns_warning(self, identity):
+        config = _base_config(
+            default_quota=QuotaConfig(max_cost_per_day=1.0, soft_limit_fraction=0.9),
+        )
+        store = _seeded_store(_now_record(tenant_id="tenant-1", cost_usd=0.95))
+        warnings = await _check_quotas(identity, config, store)
+        assert any("cost" in w for w in warnings)
+
+    # ── Request-rate quota ───────────────────────────────────────────────────
+
+    async def test_hard_request_limit_raises_429(self, identity):
+        from fastapi import HTTPException
+
+        config = _base_config(
+            default_quota=QuotaConfig(max_requests_per_hour=2),
+        )
+        store = _seeded_store(
+            _now_record(tenant_id="tenant-1"),
+            _now_record(tenant_id="tenant-1"),
+            _now_record(tenant_id="tenant-1"),
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await _check_quotas(identity, config, store)
+        assert exc_info.value.status_code == 429
+
+    async def test_soft_request_limit_returns_warning(self, identity):
+        config = _base_config(
+            default_quota=QuotaConfig(max_requests_per_hour=10, soft_limit_fraction=0.8),
+        )
+        store = _seeded_store(*[_now_record(tenant_id="tenant-1") for _ in range(9)])
+        warnings = await _check_quotas(identity, config, store)
+        assert any("request" in w for w in warnings)
+
+    # ── Agent-level cost quota ───────────────────────────────────────────────
+
+    async def test_agent_cost_hard_limit(self, identity):
+        from fastapi import HTTPException
+
+        config = _base_config(
+            agent_permissions={
+                "agent-1": AgentPermissions(quota=QuotaConfig(max_cost_per_day=0.50))
+            }
+        )
+        store = _seeded_store(_now_record(agent_id="agent-1", cost_usd=0.60))
+        with pytest.raises(HTTPException) as exc_info:
+            await _check_quotas(identity, config, store)
+        assert exc_info.value.status_code == 429
+
+    async def test_agent_cost_soft_limit(self, identity):
+        config = _base_config(
+            agent_permissions={
+                "agent-1": AgentPermissions(
+                    quota=QuotaConfig(max_cost_per_day=1.0, soft_limit_fraction=0.8)
+                )
+            }
+        )
+        store = _seeded_store(_now_record(agent_id="agent-1", cost_usd=0.85))
+        warnings = await _check_quotas(identity, config, store)
+        assert any("agent" in w for w in warnings)
+
+    # ── Per-tenant override ──────────────────────────────────────────────────
+
+    async def test_tenant_specific_quota_used(self, identity):
+        from fastapi import HTTPException
+
+        config = _base_config(
+            default_quota=QuotaConfig(max_tokens_per_day=10_000),
+            tenant_quotas={"tenant-1": QuotaConfig(max_tokens_per_day=100)},
+        )
+        store = _seeded_store(_now_record(tenant_id="tenant-1", input_tokens=80, output_tokens=30))
+        with pytest.raises(HTTPException) as exc_info:
+            await _check_quotas(identity, config, store)
+        assert exc_info.value.status_code == 429
+
+
+# ---------------------------------------------------------------------------
+# Model access control — via HTTP endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestModelAccessControl:
+    def _build_client(self, allowed_models: list[str]) -> TestClient:
+        config = _base_config(
+            agent_permissions={"agent-restricted": AgentPermissions(allowed_models=allowed_models)}
+        )
+        app = create_app(config)
+        return TestClient(app, raise_server_exceptions=False)
+
+    def test_unrestricted_agent_can_use_any_model(self):
+        config = _base_config()
+        app = create_app(config)
+        with patch("bifrost.router.ModelRouter.complete", new_callable=AsyncMock) as m:
+            m.return_value = _make_response()
+            with TestClient(app) as client:
+                resp = client.post(
+                    "/v1/messages",
+                    json={
+                        "model": "claude-sonnet-4-6",
+                        "max_tokens": 10,
+                        "messages": [{"role": "user", "content": "hi"}],
+                    },
+                )
+        assert resp.status_code == 200
+
+    def test_restricted_agent_blocked_from_disallowed_model(self):
+        client = self._build_client(["claude-haiku-4-5-20251001"])
+        with patch("bifrost.router.ModelRouter.complete", new_callable=AsyncMock):
+            resp = client.post(
+                "/v1/messages",
+                headers={"x-agent-id": "agent-restricted"},
+                json={
+                    "model": "claude-sonnet-4-6",
+                    "max_tokens": 10,
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+            )
+        assert resp.status_code == 403
+
+    def test_restricted_agent_allowed_for_permitted_model(self):
+        client = self._build_client(["claude-sonnet-4-6"])
+        with patch("bifrost.router.ModelRouter.complete", new_callable=AsyncMock) as m:
+            m.return_value = _make_response()
+            resp = client.post(
+                "/v1/messages",
+                headers={"x-agent-id": "agent-restricted"},
+                json={
+                    "model": "claude-sonnet-4-6",
+                    "max_tokens": 10,
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+            )
+        assert resp.status_code == 200
+
+    def test_quota_warning_header_on_soft_limit(self):
+        config = _base_config(
+            default_quota=QuotaConfig(
+                max_requests_per_hour=10,
+                soft_limit_fraction=0.5,
+            )
+        )
+        app = create_app(config)
+        # Pre-seed 6 requests so we're above the 50% soft limit (6/10).
+        # Access the store through the app's internal store.
+
+        # Create a store and patch it into the app via create_app internals.
+        # Simpler: just make many requests in the test.
+        with patch("bifrost.router.ModelRouter.complete", new_callable=AsyncMock) as m:
+            m.return_value = _make_response()
+            with TestClient(app) as client:
+                # Make 6 requests to exceed the soft limit.
+                for _ in range(6):
+                    client.post(
+                        "/v1/messages",
+                        json={
+                            "model": "claude-sonnet-4-6",
+                            "max_tokens": 10,
+                            "messages": [{"role": "user", "content": "hi"}],
+                        },
+                    )
+                # 7th request should have the warning header.
+                resp = client.post(
+                    "/v1/messages",
+                    json={
+                        "model": "claude-sonnet-4-6",
+                        "max_tokens": 10,
+                        "messages": [{"role": "user", "content": "hi"}],
+                    },
+                )
+        assert resp.status_code == 200
+        assert "X-Quota-Warning" in resp.headers
+
+    def test_hard_limit_returns_429_via_http(self):
+        config = _base_config(default_quota=QuotaConfig(max_requests_per_hour=2))
+        app = create_app(config)
+        with patch("bifrost.router.ModelRouter.complete", new_callable=AsyncMock) as m:
+            m.return_value = _make_response()
+            with TestClient(app, raise_server_exceptions=False) as client:
+                for _ in range(2):
+                    client.post(
+                        "/v1/messages",
+                        json={
+                            "model": "claude-sonnet-4-6",
+                            "max_tokens": 10,
+                            "messages": [{"role": "user", "content": "hi"}],
+                        },
+                    )
+                resp = client.post(
+                    "/v1/messages",
+                    json={
+                        "model": "claude-sonnet-4-6",
+                        "max_tokens": 10,
+                        "messages": [{"role": "user", "content": "hi"}],
+                    },
+                )
+        assert resp.status_code == 429

--- a/tests/test_bifrost/test_quotas.py
+++ b/tests/test_bifrost/test_quotas.py
@@ -70,6 +70,13 @@ def _now_record(
 # ---------------------------------------------------------------------------
 
 
+async def _check(identity: AgentIdentity, config: BifrostConfig, store) -> list[str]:
+    """Convenience wrapper that resolves agent_perms before calling _check_quotas."""
+    return await _check_quotas(
+        identity, config, store, config.permissions_for_agent(identity.agent_id)
+    )
+
+
 class TestCheckQuotas:
     @pytest.fixture
     def identity(self) -> AgentIdentity:
@@ -78,7 +85,7 @@ class TestCheckQuotas:
     async def test_no_limits_no_warnings(self, identity):
         config = _base_config()
         store = MemoryUsageStore()
-        warnings = await _check_quotas(identity, config, store)
+        warnings = await _check(identity, config, store)
         assert warnings == []
 
     # ── Token quota ──────────────────────────────────────────────────────────
@@ -91,7 +98,7 @@ class TestCheckQuotas:
         )
         store = _seeded_store(_now_record(tenant_id="tenant-1", input_tokens=80, output_tokens=30))
         with pytest.raises(HTTPException) as exc_info:
-            await _check_quotas(identity, config, store)
+            await _check(identity, config, store)
         assert exc_info.value.status_code == 429
 
     async def test_soft_token_limit_returns_warning(self, identity):
@@ -99,7 +106,7 @@ class TestCheckQuotas:
             default_quota=QuotaConfig(max_tokens_per_day=100, soft_limit_fraction=0.8),
         )
         store = _seeded_store(_now_record(tenant_id="tenant-1", input_tokens=85, output_tokens=0))
-        warnings = await _check_quotas(identity, config, store)
+        warnings = await _check(identity, config, store)
         assert any("token" in w for w in warnings)
 
     async def test_under_soft_token_limit_no_warning(self, identity):
@@ -107,7 +114,7 @@ class TestCheckQuotas:
             default_quota=QuotaConfig(max_tokens_per_day=1000, soft_limit_fraction=0.9),
         )
         store = _seeded_store(_now_record(tenant_id="tenant-1", input_tokens=100, output_tokens=0))
-        warnings = await _check_quotas(identity, config, store)
+        warnings = await _check(identity, config, store)
         assert not any("token" in w for w in warnings)
 
     # ── Cost quota ───────────────────────────────────────────────────────────
@@ -120,7 +127,7 @@ class TestCheckQuotas:
         )
         store = _seeded_store(_now_record(tenant_id="tenant-1", cost_usd=1.50))
         with pytest.raises(HTTPException) as exc_info:
-            await _check_quotas(identity, config, store)
+            await _check(identity, config, store)
         assert exc_info.value.status_code == 429
 
     async def test_soft_cost_limit_returns_warning(self, identity):
@@ -128,7 +135,7 @@ class TestCheckQuotas:
             default_quota=QuotaConfig(max_cost_per_day=1.0, soft_limit_fraction=0.9),
         )
         store = _seeded_store(_now_record(tenant_id="tenant-1", cost_usd=0.95))
-        warnings = await _check_quotas(identity, config, store)
+        warnings = await _check(identity, config, store)
         assert any("cost" in w for w in warnings)
 
     # ── Request-rate quota ───────────────────────────────────────────────────
@@ -145,7 +152,7 @@ class TestCheckQuotas:
             _now_record(tenant_id="tenant-1"),
         )
         with pytest.raises(HTTPException) as exc_info:
-            await _check_quotas(identity, config, store)
+            await _check(identity, config, store)
         assert exc_info.value.status_code == 429
 
     async def test_soft_request_limit_returns_warning(self, identity):
@@ -153,7 +160,7 @@ class TestCheckQuotas:
             default_quota=QuotaConfig(max_requests_per_hour=10, soft_limit_fraction=0.8),
         )
         store = _seeded_store(*[_now_record(tenant_id="tenant-1") for _ in range(9)])
-        warnings = await _check_quotas(identity, config, store)
+        warnings = await _check(identity, config, store)
         assert any("request" in w for w in warnings)
 
     # ── Agent-level cost quota ───────────────────────────────────────────────
@@ -168,7 +175,7 @@ class TestCheckQuotas:
         )
         store = _seeded_store(_now_record(agent_id="agent-1", cost_usd=0.60))
         with pytest.raises(HTTPException) as exc_info:
-            await _check_quotas(identity, config, store)
+            await _check(identity, config, store)
         assert exc_info.value.status_code == 429
 
     async def test_agent_cost_soft_limit(self, identity):
@@ -180,7 +187,7 @@ class TestCheckQuotas:
             }
         )
         store = _seeded_store(_now_record(agent_id="agent-1", cost_usd=0.85))
-        warnings = await _check_quotas(identity, config, store)
+        warnings = await _check(identity, config, store)
         assert any("agent" in w for w in warnings)
 
     # ── Per-tenant override ──────────────────────────────────────────────────
@@ -194,7 +201,7 @@ class TestCheckQuotas:
         )
         store = _seeded_store(_now_record(tenant_id="tenant-1", input_tokens=80, output_tokens=30))
         with pytest.raises(HTTPException) as exc_info:
-            await _check_quotas(identity, config, store)
+            await _check(identity, config, store)
         assert exc_info.value.status_code == 429
 
 

--- a/tests/test_bifrost/test_usage_endpoint.py
+++ b/tests/test_bifrost/test_usage_endpoint.py
@@ -1,0 +1,208 @@
+"""Tests for the GET /v1/usage endpoint."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from bifrost.app import create_app
+from bifrost.config import BifrostConfig, ProviderConfig
+from bifrost.ports.usage_store import UsageRecord
+
+
+def _make_config() -> BifrostConfig:
+    return BifrostConfig(providers={"anthropic": ProviderConfig(models=["claude-sonnet-4-6"])})
+
+
+def _make_record(
+    agent_id: str = "agent-1",
+    tenant_id: str = "tenant-1",
+    model: str = "claude-sonnet-4-6",
+    input_tokens: int = 100,
+    output_tokens: int = 50,
+    cost_usd: float = 0.001,
+    timestamp: datetime | None = None,
+) -> UsageRecord:
+    return UsageRecord(
+        request_id="req-1",
+        agent_id=agent_id,
+        tenant_id=tenant_id,
+        session_id="sess",
+        saga_id="saga",
+        model=model,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cost_usd=cost_usd,
+        timestamp=timestamp or datetime.now(UTC),
+    )
+
+
+@pytest.fixture
+def app_with_data():
+    """App with pre-seeded usage records."""
+    config = _make_config()
+    app = create_app(config)
+    # Access the store directly through the usage endpoint's closure.
+    # We'll seed via HTTP calls followed by assertions, or reach into the module.
+    # Simplest: return the app and a helper to seed the store.
+    return app
+
+
+class TestUsageEndpoint:
+    @pytest.fixture
+    def client(self) -> TestClient:
+        config = _make_config()
+        app = create_app(config)
+        with TestClient(app) as c:
+            yield c
+
+    def _seed(self, client: TestClient, n: int = 3) -> None:
+        """Make *n* completion requests to populate the usage store."""
+        from bifrost.translation.models import AnthropicResponse, TextBlock, UsageInfo
+
+        response = AnthropicResponse(
+            id="msg",
+            content=[TextBlock(text="hi")],
+            model="claude-sonnet-4-6",
+            stop_reason="end_turn",
+            usage=UsageInfo(input_tokens=100, output_tokens=50),
+        )
+        with patch("bifrost.router.ModelRouter.complete", new_callable=AsyncMock) as m:
+            m.return_value = response
+            for _ in range(n):
+                client.post(
+                    "/v1/messages",
+                    json={
+                        "model": "claude-sonnet-4-6",
+                        "max_tokens": 10,
+                        "messages": [{"role": "user", "content": "hi"}],
+                    },
+                )
+
+    def test_empty_usage_returns_zero_summary(self, client):
+        resp = client.get("/v1/usage")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["summary"]["total_requests"] == 0
+        assert data["summary"]["total_cost_usd"] == 0.0
+        assert data["records"] == []
+
+    def test_usage_counts_after_requests(self, client):
+        self._seed(client, 3)
+        resp = client.get("/v1/usage")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["summary"]["total_requests"] == 3
+        assert data["summary"]["total_input_tokens"] == 300
+        assert data["summary"]["total_output_tokens"] == 150
+        assert len(data["records"]) == 3
+
+    def test_filter_by_agent_id(self, client):
+        # Two agents make requests.
+        from bifrost.translation.models import AnthropicResponse, TextBlock, UsageInfo
+
+        response = AnthropicResponse(
+            id="msg",
+            content=[TextBlock(text="hi")],
+            model="claude-sonnet-4-6",
+            stop_reason="end_turn",
+            usage=UsageInfo(input_tokens=100, output_tokens=50),
+        )
+        with patch("bifrost.router.ModelRouter.complete", new_callable=AsyncMock) as m:
+            m.return_value = response
+            client.post(
+                "/v1/messages",
+                headers={"x-agent-id": "agent-A"},
+                json={
+                    "model": "claude-sonnet-4-6",
+                    "max_tokens": 10,
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+            )
+            client.post(
+                "/v1/messages",
+                headers={"x-agent-id": "agent-B"},
+                json={
+                    "model": "claude-sonnet-4-6",
+                    "max_tokens": 10,
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+            )
+
+        resp = client.get("/v1/usage", params={"agent_id": "agent-A"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["summary"]["total_requests"] == 1
+        assert all(r["agent_id"] == "agent-A" for r in data["records"])
+
+    def test_filter_by_model(self, client):
+        self._seed(client, 2)
+        resp = client.get("/v1/usage", params={"model": "claude-sonnet-4-6"})
+        data = resp.json()
+        assert data["summary"]["total_requests"] == 2
+
+        resp2 = client.get("/v1/usage", params={"model": "gpt-4o"})
+        data2 = resp2.json()
+        assert data2["summary"]["total_requests"] == 0
+
+    def test_filter_by_time_range(self, client):
+        self._seed(client, 2)
+        far_future = (datetime.now(UTC) + timedelta(days=10)).isoformat()
+        resp = client.get("/v1/usage", params={"since": far_future})
+        data = resp.json()
+        assert data["summary"]["total_requests"] == 0
+
+    def test_invalid_since_returns_422(self, client):
+        resp = client.get("/v1/usage", params={"since": "not-a-date"})
+        assert resp.status_code == 422
+
+    def test_invalid_until_returns_422(self, client):
+        resp = client.get("/v1/usage", params={"until": "bad-date"})
+        assert resp.status_code == 422
+
+    def test_response_includes_per_model_breakdown(self, client):
+        self._seed(client, 2)
+        resp = client.get("/v1/usage")
+        data = resp.json()
+        by_model = data["summary"]["by_model"]
+        assert "claude-sonnet-4-6" in by_model
+        assert by_model["claude-sonnet-4-6"]["requests"] == 2
+
+    def test_cost_is_tracked_and_returned(self, client):
+        self._seed(client, 1)
+        resp = client.get("/v1/usage")
+        data = resp.json()
+        # claude-sonnet-4-6: 100 input + 50 output tokens
+        # 100 * 3.0/1M + 50 * 15.0/1M = 0.0003 + 0.00075 = 0.00105
+        assert data["summary"]["total_cost_usd"] > 0.0
+
+    def test_records_have_required_fields(self, client):
+        self._seed(client, 1)
+        resp = client.get("/v1/usage")
+        data = resp.json()
+        record = data["records"][0]
+        required_fields = [
+            "request_id",
+            "agent_id",
+            "tenant_id",
+            "session_id",
+            "saga_id",
+            "model",
+            "input_tokens",
+            "output_tokens",
+            "cost_usd",
+            "timestamp",
+        ]
+        for field in required_fields:
+            assert field in record, f"Missing field: {field}"
+
+    def test_limit_parameter_respected(self, client):
+        self._seed(client, 5)
+        resp = client.get("/v1/usage", params={"limit": 2})
+        data = resp.json()
+        assert len(data["records"]) <= 2
+        # Summary still reflects all records (no limit on summary).
+        assert data["summary"]["total_requests"] == 5

--- a/tests/test_bifrost/test_usage_store.py
+++ b/tests/test_bifrost/test_usage_store.py
@@ -1,0 +1,233 @@
+"""Tests for UsageStore port implementations (memory and SQLite)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from bifrost.adapters.memory_store import MemoryUsageStore
+from bifrost.adapters.sqlite_store import SQLiteUsageStore
+from bifrost.ports.usage_store import UsageRecord
+
+
+def _record(
+    agent_id: str = "agent-1",
+    tenant_id: str = "tenant-1",
+    model: str = "claude-sonnet-4-6",
+    input_tokens: int = 100,
+    output_tokens: int = 50,
+    cost_usd: float = 0.001,
+    timestamp: datetime | None = None,
+    session_id: str = "",
+    saga_id: str = "",
+    request_id: str = "",
+) -> UsageRecord:
+    return UsageRecord(
+        request_id=request_id,
+        agent_id=agent_id,
+        tenant_id=tenant_id,
+        session_id=session_id,
+        saga_id=saga_id,
+        model=model,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cost_usd=cost_usd,
+        timestamp=timestamp or datetime.now(UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Parametrise tests over both implementations
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(params=["memory", "sqlite"])
+async def store(request):
+    if request.param == "memory":
+        yield MemoryUsageStore()
+    else:
+        s = SQLiteUsageStore(":memory:")
+        yield s
+        await s.close()
+
+
+# ---------------------------------------------------------------------------
+# Basic record / query
+# ---------------------------------------------------------------------------
+
+
+class TestRecordAndQuery:
+    async def test_empty_store_returns_nothing(self, store):
+        records = await store.query()
+        assert records == []
+
+    async def test_record_is_retrievable(self, store):
+        r = _record()
+        await store.record(r)
+        records = await store.query()
+        assert len(records) == 1
+        assert records[0].agent_id == "agent-1"
+        assert records[0].model == "claude-sonnet-4-6"
+
+    async def test_filter_by_agent(self, store):
+        await store.record(_record(agent_id="a1"))
+        await store.record(_record(agent_id="a2"))
+        results = await store.query(agent_id="a1")
+        assert len(results) == 1
+        assert results[0].agent_id == "a1"
+
+    async def test_filter_by_tenant(self, store):
+        await store.record(_record(tenant_id="t1"))
+        await store.record(_record(tenant_id="t2"))
+        results = await store.query(tenant_id="t2")
+        assert len(results) == 1
+        assert results[0].tenant_id == "t2"
+
+    async def test_filter_by_model(self, store):
+        await store.record(_record(model="claude-sonnet-4-6"))
+        await store.record(_record(model="gpt-4o"))
+        results = await store.query(model="gpt-4o")
+        assert len(results) == 1
+        assert results[0].model == "gpt-4o"
+
+    async def test_filter_by_time_range(self, store):
+        now = datetime.now(UTC)
+        yesterday = now - timedelta(days=1)
+        tomorrow = now + timedelta(days=1)
+
+        await store.record(_record(timestamp=yesterday))
+        await store.record(_record(timestamp=now))
+        await store.record(_record(timestamp=tomorrow))
+
+        results = await store.query(since=now - timedelta(hours=1), until=now + timedelta(hours=1))
+        assert len(results) == 1
+
+    async def test_limit_is_respected(self, store):
+        for _ in range(10):
+            await store.record(_record())
+        results = await store.query(limit=3)
+        assert len(results) == 3
+
+    async def test_combined_filters(self, store):
+        now = datetime.now(UTC)
+        await store.record(_record(agent_id="a", tenant_id="t", model="m1", timestamp=now))
+        await store.record(_record(agent_id="a", tenant_id="t", model="m2", timestamp=now))
+        await store.record(_record(agent_id="b", tenant_id="t", model="m1", timestamp=now))
+
+        results = await store.query(agent_id="a", model="m1")
+        assert len(results) == 1
+
+    async def test_session_and_saga_roundtrip(self, store):
+        r = _record(session_id="sess-x", saga_id="saga-y")
+        await store.record(r)
+        results = await store.query()
+        assert results[0].session_id == "sess-x"
+        assert results[0].saga_id == "saga-y"
+
+
+# ---------------------------------------------------------------------------
+# Summarise
+# ---------------------------------------------------------------------------
+
+
+class TestSummarise:
+    async def test_empty_summary(self, store):
+        summary = await store.summarise()
+        assert summary.total_requests == 0
+        assert summary.total_cost_usd == 0.0
+
+    async def test_totals_are_correct(self, store):
+        await store.record(_record(input_tokens=100, output_tokens=50, cost_usd=0.01))
+        await store.record(_record(input_tokens=200, output_tokens=100, cost_usd=0.02))
+
+        summary = await store.summarise()
+        assert summary.total_requests == 2
+        assert summary.total_input_tokens == 300
+        assert summary.total_output_tokens == 150
+        assert abs(summary.total_cost_usd - 0.03) < 1e-9
+
+    async def test_per_model_breakdown(self, store):
+        await store.record(_record(model="m1", cost_usd=0.01))
+        await store.record(_record(model="m1", cost_usd=0.01))
+        await store.record(_record(model="m2", cost_usd=0.05))
+
+        summary = await store.summarise()
+        assert "m1" in summary.by_model
+        assert "m2" in summary.by_model
+        assert summary.by_model["m1"]["requests"] == 2
+        assert abs(summary.by_model["m2"]["cost_usd"] - 0.05) < 1e-9
+
+    async def test_filter_is_applied_to_summary(self, store):
+        await store.record(_record(tenant_id="t1", cost_usd=0.01))
+        await store.record(_record(tenant_id="t2", cost_usd=0.50))
+
+        summary = await store.summarise(tenant_id="t1")
+        assert summary.total_requests == 1
+        assert abs(summary.total_cost_usd - 0.01) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Quota helper methods
+# ---------------------------------------------------------------------------
+
+
+class TestQuotaHelpers:
+    async def test_tokens_today_counts_only_today(self, store):
+        now = datetime.now(UTC)
+        yesterday = now - timedelta(days=1)
+
+        await store.record(
+            _record(tenant_id="t", input_tokens=100, output_tokens=50, timestamp=now)
+        )
+        await store.record(
+            _record(tenant_id="t", input_tokens=999, output_tokens=999, timestamp=yesterday)
+        )
+
+        total = await store.tokens_today("t")
+        assert total == 150
+
+    async def test_tokens_today_is_per_tenant(self, store):
+        now = datetime.now(UTC)
+        await store.record(
+            _record(tenant_id="t1", input_tokens=100, output_tokens=0, timestamp=now)
+        )
+        await store.record(
+            _record(tenant_id="t2", input_tokens=999, output_tokens=0, timestamp=now)
+        )
+        assert await store.tokens_today("t1") == 100
+
+    async def test_cost_today(self, store):
+        now = datetime.now(UTC)
+        yesterday = now - timedelta(days=1)
+        await store.record(_record(tenant_id="t", cost_usd=0.50, timestamp=now))
+        await store.record(_record(tenant_id="t", cost_usd=9.99, timestamp=yesterday))
+
+        cost = await store.cost_today("t")
+        assert abs(cost - 0.50) < 1e-9
+
+    async def test_requests_this_hour(self, store):
+        now = datetime.now(UTC)
+        two_hours_ago = now - timedelta(hours=2)
+
+        await store.record(_record(tenant_id="t", timestamp=now))
+        await store.record(_record(tenant_id="t", timestamp=now))
+        await store.record(_record(tenant_id="t", timestamp=two_hours_ago))
+
+        count = await store.requests_this_hour("t")
+        assert count == 2
+
+    async def test_agent_cost_today(self, store):
+        now = datetime.now(UTC)
+        yesterday = now - timedelta(days=1)
+        await store.record(_record(agent_id="a", cost_usd=1.23, timestamp=now))
+        await store.record(_record(agent_id="a", cost_usd=9.99, timestamp=yesterday))
+        await store.record(_record(agent_id="b", cost_usd=5.00, timestamp=now))
+
+        cost = await store.agent_cost_today("a")
+        assert abs(cost - 1.23) < 1e-9
+
+    async def test_zero_for_unknown_tenant(self, store):
+        assert await store.tokens_today("no-such-tenant") == 0
+        assert await store.cost_today("no-such-tenant") == 0.0
+        assert await store.requests_this_hour("no-such-tenant") == 0


### PR DESCRIPTION
## Summary

Phase 3 of the Bifröst gateway: security and economics layer.

- **Agent authentication** (`bifrost.auth`) — three modes selectable via config:
  - `open` (default): trust caller headers, no verification (local/Pi mode)
  - `pat`: HS256 Bearer JWT; secret configured via `pat_secret` / `PAT_SECRET` env
  - `mesh`: trust Envoy-injected `x-agent-id` / `x-tenant-id` headers after mTLS

- **Per-agent model access control** — `agent_permissions[id].allowed_models` list enforced before routing; returns HTTP 403 when the calling agent is not permitted to use the requested model

- **Pricing table** (`bifrost.pricing`) — built-in USD/million-token snapshot for Claude (Opus 4.6, Sonnet 4.6, Haiku 4.5), GPT-4o/mini, and Ollama; fully overridable via `BifrostConfig.pricing`

- **Per-request cost tracking** — cost calculated after every completion and streaming request, attributed with `agent_id`, `tenant_id`, `session_id`, `saga_id`

- **Usage store port + adapters**:
  - `UsageStore` abstract port (`ports/usage_store.py`)
  - `MemoryUsageStore` — in-process (default; reset on restart)
  - `SQLiteUsageStore` — persistent single-file (standalone / Pi mode)

- **Quota enforcement** — evaluated before each request:
  - Soft limit (configurable fraction, default 90%) → `X-Quota-Warning` header
  - Hard limit → HTTP 429 with descriptive reason
  - Per-tenant: `max_tokens_per_day`, `max_cost_per_day`, `max_requests_per_hour`
  - Per-agent: `max_cost_per_day`
  - Per-tenant overrides via `tenant_quotas`; falls back to `default_quota`

- **`GET /v1/usage`** — aggregated usage dashboard:
  - Filters: `agent_id`, `tenant_id`, `model`, `since`, `until`, `limit`
  - Returns summary (totals + per-model breakdown) and raw record list

- **Config** (`bifrost.yaml.example`) updated with all new sections documented

## Test plan

- [x] `tests/test_bifrost/test_auth.py` — open / mesh / PAT modes, expired tokens, wrong secret, missing bearer, integration via HTTP
- [x] `tests/test_bifrost/test_pricing.py` — built-in table, overrides, cache tokens, parametrised models
- [x] `tests/test_bifrost/test_usage_store.py` — memory + SQLite adapters (parametrised), query filters, quota helpers
- [x] `tests/test_bifrost/test_quotas.py` — soft/hard token/cost/request limits, agent budget, tenant-specific quotas, model access control, warning header
- [x] `tests/test_bifrost/test_usage_endpoint.py` — empty store, seeded data, agent filter, model filter, time filter, field completeness, cost tracking, limit param

**281 tests, 97.78% coverage, zero warnings**

## Linear

Ticket: NIU-461 — please set to "In Review" (Linear MCP unavailable in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)