### PR TITLE
feat(ravn): persistent todo/task tracker tools (NIU-491)

### DIFF
--- a/src/ravn/adapters/tools/__init__.py
+++ b/src/ravn/adapters/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Tool adapters for Ravn agents."""

--- a/src/ravn/adapters/tools/todo.py
+++ b/src/ravn/adapters/tools/todo.py
@@ -1,0 +1,280 @@
+"""Todo list tools for Ravn agents.
+
+Provides two tools that share session-scoped todo state:
+
+* ``todo_write`` — create, update, or delete todo items.
+* ``todo_read``  — read the current todo list.
+
+Todo state lives in ``Session.todos`` so it persists across turns within a
+task and is automatically discarded when the session ends.
+"""
+
+from __future__ import annotations
+
+import logging
+from uuid import uuid4
+
+from ravn.domain.models import Session, TodoItem, TodoStatus, ToolResult
+from ravn.ports.tool import ToolPort
+
+logger = logging.getLogger(__name__)
+
+_PERMISSION = "todo:write"
+_PERMISSION_READ = "todo:read"
+
+_VALID_STATUSES = {s.value for s in TodoStatus}
+
+_STATUS_SYMBOLS = {
+    TodoStatus.PENDING: "○",
+    TodoStatus.IN_PROGRESS: "◉",
+    TodoStatus.DONE: "✓",
+    TodoStatus.CANCELLED: "✗",
+}
+
+
+def _format_todos(todos: list[TodoItem]) -> str:
+    if not todos:
+        return "(no todos)"
+    lines: list[str] = []
+    for item in sorted(todos, key=lambda t: (-t.priority, t.id)):
+        symbol = _STATUS_SYMBOLS.get(item.status, "?")
+        lines.append(f"[{symbol}] {item.id}: {item.content}  ({item.status})")
+    return "\n".join(lines)
+
+
+class TodoWriteTool(ToolPort):
+    """Create, update, or delete items in the session todo list.
+
+    Operations
+    ----------
+    * ``create`` — add a new item (``content`` required; ``id`` auto-generated
+      unless provided; ``priority`` defaults to 0).
+    * ``update`` — change ``content``, ``status``, and/or ``priority`` of an
+      existing item (``id`` required).
+    * ``delete`` — remove an item by ``id``.
+    """
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    @property
+    def name(self) -> str:
+        return "todo_write"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Manage the in-session todo list. "
+            "Use operation='create' to add items, 'update' to change status/content/priority, "
+            "and 'delete' to remove an item by id. "
+            "Statuses: pending | in_progress | done | cancelled."
+        )
+
+    @property
+    def input_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "operation": {
+                    "type": "string",
+                    "enum": ["create", "update", "delete"],
+                    "description": "The operation to perform.",
+                },
+                "id": {
+                    "type": "string",
+                    "description": (
+                        "Item id. Required for 'update' and 'delete'. "
+                        "Optional for 'create' (auto-generated if omitted)."
+                    ),
+                },
+                "content": {
+                    "type": "string",
+                    "description": "Text description of the todo item.",
+                },
+                "status": {
+                    "type": "string",
+                    "enum": ["pending", "in_progress", "done", "cancelled"],
+                    "description": "Item status (default: pending for create).",
+                },
+                "priority": {
+                    "type": "integer",
+                    "description": "Higher numbers = higher priority (default: 0).",
+                },
+            },
+            "required": ["operation"],
+        }
+
+    @property
+    def required_permission(self) -> str:
+        return _PERMISSION
+
+    async def execute(self, input: dict) -> ToolResult:
+        operation = input.get("operation", "")
+
+        match operation:
+            case "create":
+                return self._create(input)
+            case "update":
+                return self._update(input)
+            case "delete":
+                return self._delete(input)
+            case _:
+                return ToolResult(
+                    tool_call_id="",
+                    content=f"Unknown operation: '{operation}'. Use create, update, or delete.",
+                    is_error=True,
+                )
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _create(self, input: dict) -> ToolResult:
+        content = input.get("content", "").strip()
+        if not content:
+            return ToolResult(
+                tool_call_id="",
+                content="'content' is required for create.",
+                is_error=True,
+            )
+
+        status_str = input.get("status", TodoStatus.PENDING.value)
+        if status_str not in _VALID_STATUSES:
+            return ToolResult(
+                tool_call_id="",
+                content=f"Invalid status '{status_str}'. Valid: {sorted(_VALID_STATUSES)}",
+                is_error=True,
+            )
+
+        item_id = input.get("id") or uuid4().hex[:8]
+        priority = int(input.get("priority", 0))
+
+        item = TodoItem(
+            id=item_id,
+            content=content,
+            status=TodoStatus(status_str),
+            priority=priority,
+        )
+        self._session.upsert_todo(item)
+        logger.debug("todo_write: created %s", item_id)
+
+        return ToolResult(
+            tool_call_id="",
+            content=f"Created todo {item_id}.\n\n{_format_todos(self._session.todos)}",
+        )
+
+    def _update(self, input: dict) -> ToolResult:
+        item_id = input.get("id", "").strip()
+        if not item_id:
+            return ToolResult(
+                tool_call_id="",
+                content="'id' is required for update.",
+                is_error=True,
+            )
+
+        existing = next((t for t in self._session.todos if t.id == item_id), None)
+        if existing is None:
+            return ToolResult(
+                tool_call_id="",
+                content=f"Todo '{item_id}' not found.",
+                is_error=True,
+            )
+
+        content = input.get("content", existing.content).strip() or existing.content
+        status_str = input.get("status", existing.status.value)
+        if status_str not in _VALID_STATUSES:
+            return ToolResult(
+                tool_call_id="",
+                content=f"Invalid status '{status_str}'. Valid: {sorted(_VALID_STATUSES)}",
+                is_error=True,
+            )
+
+        priority = int(input.get("priority", existing.priority))
+
+        updated = TodoItem(
+            id=item_id,
+            content=content,
+            status=TodoStatus(status_str),
+            priority=priority,
+        )
+        self._session.upsert_todo(updated)
+        logger.debug("todo_write: updated %s -> %s", item_id, status_str)
+
+        return ToolResult(
+            tool_call_id="",
+            content=f"Updated todo {item_id}.\n\n{_format_todos(self._session.todos)}",
+        )
+
+    def _delete(self, input: dict) -> ToolResult:
+        item_id = input.get("id", "").strip()
+        if not item_id:
+            return ToolResult(
+                tool_call_id="",
+                content="'id' is required for delete.",
+                is_error=True,
+            )
+
+        removed = self._session.remove_todo(item_id)
+        if not removed:
+            return ToolResult(
+                tool_call_id="",
+                content=f"Todo '{item_id}' not found.",
+                is_error=True,
+            )
+
+        logger.debug("todo_write: deleted %s", item_id)
+        return ToolResult(
+            tool_call_id="",
+            content=f"Deleted todo {item_id}.\n\n{_format_todos(self._session.todos)}",
+        )
+
+
+class TodoReadTool(ToolPort):
+    """Read the current todo list from the session."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    @property
+    def name(self) -> str:
+        return "todo_read"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Read the current todo list. "
+            "Returns all items with their id, content, status, and priority."
+        )
+
+    @property
+    def input_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "enum": ["pending", "in_progress", "done", "cancelled"],
+                    "description": "Filter by status (omit to return all items).",
+                },
+            },
+        }
+
+    @property
+    def required_permission(self) -> str:
+        return _PERMISSION_READ
+
+    async def execute(self, input: dict) -> ToolResult:
+        status_filter = input.get("status")
+
+        if status_filter is not None and status_filter not in _VALID_STATUSES:
+            return ToolResult(
+                tool_call_id="",
+                content=f"Invalid status '{status_filter}'. Valid: {sorted(_VALID_STATUSES)}",
+                is_error=True,
+            )
+
+        todos = self._session.todos
+        if status_filter:
+            todos = [t for t in todos if t.status.value == status_filter]
+
+        return ToolResult(tool_call_id="", content=_format_todos(todos))

--- a/src/ravn/domain/models.py
+++ b/src/ravn/domain/models.py
@@ -12,6 +12,13 @@ from uuid import UUID, uuid4
 # ---------------------------------------------------------------------------
 
 
+class TodoStatus(StrEnum):
+    PENDING = "pending"
+    IN_PROGRESS = "in_progress"
+    DONE = "done"
+    CANCELLED = "cancelled"
+
+
 class StopReason(StrEnum):
     END_TURN = "end_turn"
     TOOL_USE = "tool_use"
@@ -23,6 +30,21 @@ class StreamEventType(StrEnum):
     TEXT_DELTA = "text_delta"
     TOOL_CALL = "tool_call"
     MESSAGE_DONE = "message_done"
+
+
+# ---------------------------------------------------------------------------
+# Todo domain models
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TodoItem:
+    """A single todo item in the agent's task list."""
+
+    id: str
+    content: str
+    status: TodoStatus = TodoStatus.PENDING
+    priority: int = 0
 
 
 # ---------------------------------------------------------------------------
@@ -124,6 +146,7 @@ class Session:
     total_usage: TokenUsage = field(
         default_factory=lambda: TokenUsage(input_tokens=0, output_tokens=0)
     )
+    todos: list[TodoItem] = field(default_factory=list)
 
     def add_message(self, message: Message) -> None:
         self.messages.append(message)
@@ -131,3 +154,21 @@ class Session:
     def record_turn(self, usage: TokenUsage) -> None:
         self.turn_count += 1
         self.total_usage = self.total_usage + usage
+
+    def upsert_todo(self, item: TodoItem) -> None:
+        """Insert or replace a todo item by id."""
+        for idx, existing in enumerate(self.todos):
+            if existing.id == item.id:
+                self.todos[idx] = item
+                return
+        self.todos.append(item)
+
+    def remove_todo(self, todo_id: str) -> bool:
+        """Remove a todo item by id. Returns True if found and removed."""
+        before = len(self.todos)
+        self.todos = [t for t in self.todos if t.id != todo_id]
+        return len(self.todos) < before
+
+    def clear_todos(self) -> None:
+        """Remove all todo items (call at task start)."""
+        self.todos.clear()

--- a/tests/ravn/unit/test_todo_tools.py
+++ b/tests/ravn/unit/test_todo_tools.py
@@ -1,0 +1,368 @@
+"""Unit tests for the todo_write and todo_read tools."""
+
+from __future__ import annotations
+
+from ravn.adapters.tools.todo import TodoReadTool, TodoWriteTool
+from ravn.domain.models import Session, TodoItem, TodoStatus
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_session(*items: TodoItem) -> Session:
+    s = Session()
+    for item in items:
+        s.upsert_todo(item)
+    return s
+
+
+def todo(
+    id: str,
+    content: str,
+    status: TodoStatus = TodoStatus.PENDING,
+    priority: int = 0,
+) -> TodoItem:
+    return TodoItem(id=id, content=content, status=status, priority=priority)
+
+
+# ---------------------------------------------------------------------------
+# Session model tests
+# ---------------------------------------------------------------------------
+
+
+class TestSessionTodoMethods:
+    def test_upsert_new_item(self) -> None:
+        s = Session()
+        item = todo("a", "do something")
+        s.upsert_todo(item)
+        assert len(s.todos) == 1
+        assert s.todos[0].id == "a"
+
+    def test_upsert_replaces_existing(self) -> None:
+        s = make_session(todo("a", "old content"))
+        updated = todo("a", "new content", TodoStatus.DONE)
+        s.upsert_todo(updated)
+        assert len(s.todos) == 1
+        assert s.todos[0].content == "new content"
+        assert s.todos[0].status == TodoStatus.DONE
+
+    def test_remove_existing_returns_true(self) -> None:
+        s = make_session(todo("a", "item"))
+        result = s.remove_todo("a")
+        assert result is True
+        assert s.todos == []
+
+    def test_remove_missing_returns_false(self) -> None:
+        s = Session()
+        result = s.remove_todo("nonexistent")
+        assert result is False
+
+    def test_clear_todos(self) -> None:
+        s = make_session(todo("a", "x"), todo("b", "y"))
+        s.clear_todos()
+        assert s.todos == []
+
+    def test_upsert_multiple_items(self) -> None:
+        s = Session()
+        s.upsert_todo(todo("a", "first"))
+        s.upsert_todo(todo("b", "second"))
+        assert len(s.todos) == 2
+
+
+# ---------------------------------------------------------------------------
+# TodoWriteTool — create
+# ---------------------------------------------------------------------------
+
+
+class TestTodoWriteCreate:
+    async def test_create_basic(self) -> None:
+        s = Session()
+        tool = TodoWriteTool(s)
+        result = await tool.execute({"operation": "create", "content": "buy milk"})
+        assert not result.is_error
+        assert len(s.todos) == 1
+        assert s.todos[0].content == "buy milk"
+        assert s.todos[0].status == TodoStatus.PENDING
+
+    async def test_create_with_explicit_id(self) -> None:
+        s = Session()
+        tool = TodoWriteTool(s)
+        result = await tool.execute(
+            {"operation": "create", "id": "task-1", "content": "write tests"}
+        )
+        assert not result.is_error
+        assert s.todos[0].id == "task-1"
+
+    async def test_create_with_status(self) -> None:
+        s = Session()
+        tool = TodoWriteTool(s)
+        await tool.execute({"operation": "create", "content": "already done", "status": "done"})
+        assert s.todos[0].status == TodoStatus.DONE
+
+    async def test_create_with_priority(self) -> None:
+        s = Session()
+        tool = TodoWriteTool(s)
+        await tool.execute({"operation": "create", "content": "urgent", "priority": 5})
+        assert s.todos[0].priority == 5
+
+    async def test_create_autogenerates_id(self) -> None:
+        s = Session()
+        tool = TodoWriteTool(s)
+        await tool.execute({"operation": "create", "content": "item one"})
+        await tool.execute({"operation": "create", "content": "item two"})
+        assert len(s.todos) == 2
+        assert s.todos[0].id != s.todos[1].id
+
+    async def test_create_missing_content_returns_error(self) -> None:
+        s = Session()
+        tool = TodoWriteTool(s)
+        result = await tool.execute({"operation": "create"})
+        assert result.is_error
+        assert "content" in result.content
+
+    async def test_create_empty_content_returns_error(self) -> None:
+        s = Session()
+        tool = TodoWriteTool(s)
+        result = await tool.execute({"operation": "create", "content": "   "})
+        assert result.is_error
+
+    async def test_create_invalid_status_returns_error(self) -> None:
+        s = Session()
+        tool = TodoWriteTool(s)
+        result = await tool.execute({"operation": "create", "content": "x", "status": "flying"})
+        assert result.is_error
+        assert "flying" in result.content
+
+    async def test_create_result_includes_todo_list(self) -> None:
+        s = Session()
+        tool = TodoWriteTool(s)
+        result = await tool.execute({"operation": "create", "content": "do work"})
+        assert "do work" in result.content
+
+
+# ---------------------------------------------------------------------------
+# TodoWriteTool — update
+# ---------------------------------------------------------------------------
+
+
+class TestTodoWriteUpdate:
+    async def test_update_status(self) -> None:
+        s = make_session(todo("t1", "some task"))
+        tool = TodoWriteTool(s)
+        result = await tool.execute({"operation": "update", "id": "t1", "status": "in_progress"})
+        assert not result.is_error
+        assert s.todos[0].status == TodoStatus.IN_PROGRESS
+
+    async def test_update_content(self) -> None:
+        s = make_session(todo("t1", "old"))
+        tool = TodoWriteTool(s)
+        await tool.execute({"operation": "update", "id": "t1", "content": "new content"})
+        assert s.todos[0].content == "new content"
+
+    async def test_update_priority(self) -> None:
+        s = make_session(todo("t1", "task", priority=0))
+        tool = TodoWriteTool(s)
+        await tool.execute({"operation": "update", "id": "t1", "priority": 10})
+        assert s.todos[0].priority == 10
+
+    async def test_update_preserves_unchanged_fields(self) -> None:
+        s = make_session(todo("t1", "original", TodoStatus.IN_PROGRESS, priority=3))
+        tool = TodoWriteTool(s)
+        await tool.execute({"operation": "update", "id": "t1", "status": "done"})
+        updated = s.todos[0]
+        assert updated.content == "original"
+        assert updated.priority == 3
+        assert updated.status == TodoStatus.DONE
+
+    async def test_update_missing_id_returns_error(self) -> None:
+        s = Session()
+        tool = TodoWriteTool(s)
+        result = await tool.execute({"operation": "update", "status": "done"})
+        assert result.is_error
+        assert "'id' is required" in result.content
+
+    async def test_update_unknown_id_returns_error(self) -> None:
+        s = Session()
+        tool = TodoWriteTool(s)
+        result = await tool.execute({"operation": "update", "id": "ghost"})
+        assert result.is_error
+        assert "not found" in result.content
+
+    async def test_update_invalid_status_returns_error(self) -> None:
+        s = make_session(todo("t1", "task"))
+        tool = TodoWriteTool(s)
+        result = await tool.execute({"operation": "update", "id": "t1", "status": "bad"})
+        assert result.is_error
+
+    async def test_update_result_includes_todo_list(self) -> None:
+        s = make_session(todo("t1", "my task"))
+        tool = TodoWriteTool(s)
+        result = await tool.execute({"operation": "update", "id": "t1", "status": "done"})
+        assert "my task" in result.content
+
+
+# ---------------------------------------------------------------------------
+# TodoWriteTool — delete
+# ---------------------------------------------------------------------------
+
+
+class TestTodoWriteDelete:
+    async def test_delete_existing(self) -> None:
+        s = make_session(todo("t1", "to remove"))
+        tool = TodoWriteTool(s)
+        result = await tool.execute({"operation": "delete", "id": "t1"})
+        assert not result.is_error
+        assert s.todos == []
+
+    async def test_delete_missing_id_returns_error(self) -> None:
+        s = Session()
+        tool = TodoWriteTool(s)
+        result = await tool.execute({"operation": "delete"})
+        assert result.is_error
+        assert "'id' is required" in result.content
+
+    async def test_delete_unknown_id_returns_error(self) -> None:
+        s = Session()
+        tool = TodoWriteTool(s)
+        result = await tool.execute({"operation": "delete", "id": "ghost"})
+        assert result.is_error
+        assert "not found" in result.content
+
+    async def test_delete_result_shows_remaining_todos(self) -> None:
+        s = make_session(todo("t1", "first"), todo("t2", "second"))
+        tool = TodoWriteTool(s)
+        result = await tool.execute({"operation": "delete", "id": "t1"})
+        assert not result.is_error
+        assert "second" in result.content
+        assert "first" not in result.content
+
+    async def test_delete_last_item_shows_empty(self) -> None:
+        s = make_session(todo("t1", "only item"))
+        tool = TodoWriteTool(s)
+        result = await tool.execute({"operation": "delete", "id": "t1"})
+        assert "(no todos)" in result.content
+
+
+# ---------------------------------------------------------------------------
+# TodoWriteTool — unknown operation
+# ---------------------------------------------------------------------------
+
+
+class TestTodoWriteUnknownOperation:
+    async def test_unknown_operation_returns_error(self) -> None:
+        s = Session()
+        tool = TodoWriteTool(s)
+        result = await tool.execute({"operation": "explode"})
+        assert result.is_error
+        assert "explode" in result.content
+
+
+# ---------------------------------------------------------------------------
+# TodoReadTool
+# ---------------------------------------------------------------------------
+
+
+class TestTodoReadTool:
+    async def test_read_empty_session(self) -> None:
+        s = Session()
+        tool = TodoReadTool(s)
+        result = await tool.execute({})
+        assert not result.is_error
+        assert "(no todos)" in result.content
+
+    async def test_read_shows_all_items(self) -> None:
+        s = make_session(
+            todo("t1", "first task"),
+            todo("t2", "second task", TodoStatus.DONE),
+        )
+        tool = TodoReadTool(s)
+        result = await tool.execute({})
+        assert "first task" in result.content
+        assert "second task" in result.content
+
+    async def test_read_filter_by_status(self) -> None:
+        s = make_session(
+            todo("t1", "pending item"),
+            todo("t2", "done item", TodoStatus.DONE),
+        )
+        tool = TodoReadTool(s)
+        result = await tool.execute({"status": "pending"})
+        assert "pending item" in result.content
+        assert "done item" not in result.content
+
+    async def test_read_filter_no_matches(self) -> None:
+        s = make_session(todo("t1", "pending item"))
+        tool = TodoReadTool(s)
+        result = await tool.execute({"status": "done"})
+        assert "(no todos)" in result.content
+
+    async def test_read_invalid_status_filter_returns_error(self) -> None:
+        s = Session()
+        tool = TodoReadTool(s)
+        result = await tool.execute({"status": "invalid"})
+        assert result.is_error
+        assert "invalid" in result.content
+
+    async def test_read_items_sorted_by_priority(self) -> None:
+        s = make_session(
+            todo("t1", "low priority", priority=1),
+            todo("t2", "high priority", priority=10),
+        )
+        tool = TodoReadTool(s)
+        result = await tool.execute({})
+        high_pos = result.content.index("high priority")
+        low_pos = result.content.index("low priority")
+        assert high_pos < low_pos
+
+    async def test_read_shows_status_symbols(self) -> None:
+        s = make_session(todo("t1", "task", TodoStatus.DONE))
+        tool = TodoReadTool(s)
+        result = await tool.execute({})
+        assert "✓" in result.content
+
+    async def test_read_all_statuses_filter(self) -> None:
+        for status in TodoStatus:
+            s = make_session(todo("t1", "item", status))
+            tool = TodoReadTool(s)
+            result = await tool.execute({"status": status.value})
+            assert not result.is_error
+            assert "item" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Tool metadata
+# ---------------------------------------------------------------------------
+
+
+class TestToolMetadata:
+    def test_write_tool_name(self) -> None:
+        assert TodoWriteTool(Session()).name == "todo_write"
+
+    def test_read_tool_name(self) -> None:
+        assert TodoReadTool(Session()).name == "todo_read"
+
+    def test_write_tool_permission(self) -> None:
+        assert TodoWriteTool(Session()).required_permission == "todo:write"
+
+    def test_read_tool_permission(self) -> None:
+        assert TodoReadTool(Session()).required_permission == "todo:read"
+
+    def test_write_tool_has_input_schema(self) -> None:
+        schema = TodoWriteTool(Session()).input_schema
+        assert schema["type"] == "object"
+        assert "operation" in schema["properties"]
+
+    def test_read_tool_has_input_schema(self) -> None:
+        schema = TodoReadTool(Session()).input_schema
+        assert schema["type"] == "object"
+
+    def test_write_tool_to_api_dict(self) -> None:
+        d = TodoWriteTool(Session()).to_api_dict()
+        assert d["name"] == "todo_write"
+        assert "description" in d
+        assert "input_schema" in d
+
+    def test_read_tool_to_api_dict(self) -> None:
+        d = TodoReadTool(Session()).to_api_dict()
+        assert d["name"] == "todo_read"


### PR DESCRIPTION
## Summary

- **`TodoStatus` enum** (`pending` | `in_progress` | `done` | `cancelled`) and **`TodoItem`** dataclass added to `src/ravn/domain/models.py`
- **`Session.todos`** field added; `upsert_todo`, `remove_todo`, `clear_todos` methods handle CRUD without mutation surprises
- **`src/ravn/adapters/tools/todo.py`** — two new `ToolPort` implementations:
  - `TodoWriteTool` (`todo_write`) — create / update / delete items; each result echoes the full formatted list for visibility
  - `TodoReadTool` (`todo_read`) — read all items or filter by status; items sorted by priority descending
- Both tools wire into the existing tool-list mechanism — no agent changes required
- Permission strings: `todo:write` / `todo:read`

## Test plan

- [x] 45 unit tests in `tests/ravn/unit/test_todo_tools.py` covering all operations, all error paths, filter logic, sorting, and metadata
- [x] `todo.py` at **100% branch coverage**
- [x] All 55 ravn tests pass (10 pre-existing + 45 new)
- [x] `ruff check` clean on all changed files

## Notes

- Linear MCP tools were not available in this environment; NIU-491 could not be updated programmatically. Please update the ticket manually to **In Review** and link this PR.

Closes NIU-491

🤖 Generated with [Claude Code](https://claude.com/claude-code)