### PR TITLE
feat(bifrost): NIU-514 add Pi-mode config example (local-only, no auth)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,46 @@ uv sync --extra k8s        # Kubernetes client
 uv sync --extra otel       # OpenTelemetry export
 ```
 
+## Bifröst Gateway
+
+Bifröst is a lightweight multi-provider LLM gateway bundled with this repo. It
+presents an OpenAI-compatible API (`POST /v1/chat/completions`, `GET /v1/models`)
+and can route requests across Anthropic, OpenAI, and Ollama backends with
+failover, cost optimisation, round-robin, and latency-optimised strategies.
+
+### Pi mode (local-only, no auth)
+
+Run Bifröst entirely offline on a Raspberry Pi or any low-power device using
+[Ollama](https://ollama.com) as the sole provider — no cloud API keys, no
+authentication proxy.
+
+```bash
+# 1. Install Ollama and pull models
+curl -fsSL https://ollama.com/install.sh | sh
+ollama pull llama3.2:1b      # fast   — 1.3 GB
+ollama pull llama3.2:3b      # balanced — 2.0 GB
+ollama pull llama3.1:8b      # best   — 4.7 GB (Pi 5 + 8 GB RAM recommended)
+
+# 2. Start the gateway with the Pi-mode example config
+bifrost --config bifrost.pi.example.yaml
+```
+
+The gateway starts at `http://localhost:8088`. Standard aliases resolve
+automatically:
+
+| Alias      | Model        | Notes                       |
+|------------|--------------|-----------------------------|
+| `fast`     | llama3.2:1b  | ~30 tok/s on Pi 5           |
+| `balanced` | llama3.2:3b  | ~15 tok/s on Pi 5           |
+| `best`     | llama3.1:8b  | ~6 tok/s on Pi 5, 8 GB RAM  |
+
+Usage logs are persisted to `./bifrost_usage.db` (SQLite). Auth is `open` —
+headers are trusted verbatim. If you expose the gateway beyond localhost,
+switch to `auth_mode: pat` and issue tokens for each client.
+
+See `bifrost.pi.example.yaml` for the full annotated configuration and
+`bifrost.yaml.example` for the complete multi-provider reference config.
+
 ## Documentation
 
 Full documentation at [niuulabs.github.io/volundr](https://niuulabs.github.io/volundr/).

--- a/bifrost.pi.example.yaml
+++ b/bifrost.pi.example.yaml
@@ -1,0 +1,79 @@
+# Bifröst Gateway — Pi Mode Configuration
+# =========================================
+#
+# Lightweight deployment for Raspberry Pi and other low-power hardware.
+# Runs entirely offline with Ollama as the only provider — no cloud API
+# keys required, no authentication proxy.
+#
+# Prerequisites:
+#   1. Install Ollama: https://ollama.com/download/linux
+#   2. Pull the models you want to use:
+#        ollama pull llama3.2:1b      # fast  — 1.3 GB, ~30 tok/s on Pi 5
+#        ollama pull llama3.2:3b      # balanced — 2.0 GB, ~15 tok/s on Pi 5
+#        ollama pull llama3.1:8b      # best  — 4.7 GB, ~6 tok/s on Pi 5
+#
+# Start the gateway:
+#   bifrost --config bifrost.pi.example.yaml
+#
+# The server will be available at http://localhost:8088
+
+bifrost:
+
+  # ── Routing Strategy ──────────────────────────────────────────────────────
+  #
+  # direct: always use the first (and only) configured provider with no
+  # failover. Correct for Pi mode where there is a single local endpoint.
+  #
+  routing_strategy: direct
+
+  # ── Providers ─────────────────────────────────────────────────────────────
+  #
+  # Only Ollama is configured. No API key is needed — Ollama accepts
+  # unauthenticated requests on localhost by default.
+  #
+  providers:
+    ollama:
+      base_url: http://localhost:11434
+      models:
+        - llama3.2:1b      # 1.3 GB  — fastest, good for simple tasks
+        - llama3.2:3b      # 2.0 GB  — balanced quality/speed
+        - llama3.1:8b      # 4.7 GB  — best quality, requires Pi 5 + 8 GB RAM
+      cost_per_token: 0.0  # free — runs locally
+
+  # ── Model Aliases ──────────────────────────────────────────────────────────
+  #
+  # Clients that use the standard alias names (fast / balanced / best) will
+  # be routed to the appropriate local model automatically.
+  #
+  aliases:
+    fast: llama3.2:1b
+    balanced: llama3.2:3b
+    best: llama3.1:8b
+    local: llama3.2:3b     # generic "local" alias, same as balanced
+
+  # ── Authentication ────────────────────────────────────────────────────────
+  #
+  # open: no authentication. Headers (x-agent-id, x-tenant-id) are trusted
+  # verbatim. Suitable for a single-user or trusted-LAN deployment.
+  #
+  # If you expose Bifröst beyond localhost, consider switching to pat mode
+  # and issuing personal access tokens for each client.
+  #
+  auth_mode: open
+
+  # ── Usage Storage ─────────────────────────────────────────────────────────
+  #
+  # sqlite: persists request logs to a single file that survives restarts.
+  # Sensible default for Pi — no external database required.
+  #
+  usage_store:
+    adapter: sqlite
+    path: ./bifrost_usage.db
+
+  # ── Server ────────────────────────────────────────────────────────────────
+  #
+  # Bind to localhost only. Change to 0.0.0.0 if you want other devices on
+  # your local network to reach the gateway.
+  #
+  host: 127.0.0.1
+  port: 8088

--- a/tests/test_bifrost/test_config.py
+++ b/tests/test_bifrost/test_config.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
+from bifrost.__main__ import _load_config
+from bifrost.auth import AuthMode
 from bifrost.config import BifrostConfig, ProviderConfig, RoutingStrategy
 
 
@@ -142,3 +146,77 @@ class TestBifrostConfig:
         assert len(cfg.aliases) == 3
         assert cfg.provider_for_model("gpt-4o") == "openai"
         assert cfg.resolve_alias("local") == "llama3.1:8b"
+
+
+# ---------------------------------------------------------------------------
+# Pi-mode config
+# ---------------------------------------------------------------------------
+
+#: Absolute path to the Pi-mode example config shipped in the repo root.
+_PI_CONFIG = Path(__file__).parents[2] / "bifrost.pi.example.yaml"
+
+
+class TestPiModeConfig:
+    """Verify that BifrostConfig boots cleanly with only Ollama configured."""
+
+    def test_pi_example_file_exists(self):
+        assert _PI_CONFIG.exists(), "bifrost.pi.example.yaml must exist in repo root"
+
+    def test_pi_config_loads_without_error(self):
+        cfg = _load_config(str(_PI_CONFIG))
+        assert isinstance(cfg, BifrostConfig)
+
+    def test_pi_config_single_ollama_provider(self):
+        cfg = _load_config(str(_PI_CONFIG))
+        assert list(cfg.providers.keys()) == ["ollama"]
+
+    def test_pi_config_no_cloud_api_keys(self):
+        cfg = _load_config(str(_PI_CONFIG))
+        for provider in cfg.providers.values():
+            assert provider.api_key_env == "", (
+                "Pi-mode config must not reference any cloud API key env vars"
+            )
+
+    def test_pi_config_ollama_default_base_url(self):
+        cfg = _load_config(str(_PI_CONFIG))
+        assert cfg.effective_base_url("ollama") == "http://localhost:11434"
+
+    def test_pi_config_open_auth(self):
+        cfg = _load_config(str(_PI_CONFIG))
+        assert cfg.auth_mode == AuthMode.OPEN
+
+    def test_pi_config_direct_routing(self):
+        cfg = _load_config(str(_PI_CONFIG))
+        assert cfg.routing_strategy == RoutingStrategy.DIRECT
+
+    def test_pi_config_aliases_point_to_local_models(self):
+        cfg = _load_config(str(_PI_CONFIG))
+        fast = cfg.resolve_alias("fast")
+        balanced = cfg.resolve_alias("balanced")
+        best = cfg.resolve_alias("best")
+        ollama_models = cfg.providers["ollama"].models
+        assert fast in ollama_models, f"fast alias '{fast}' not in ollama models"
+        assert balanced in ollama_models, f"balanced alias '{balanced}' not in ollama models"
+        assert best in ollama_models, f"best alias '{best}' not in ollama models"
+
+    def test_pi_config_provider_for_alias_resolves_to_ollama(self):
+        cfg = _load_config(str(_PI_CONFIG))
+        for alias in ("fast", "balanced", "best", "local"):
+            canonical = cfg.resolve_alias(alias)
+            provider = cfg.provider_for_model(canonical)
+            assert provider == "ollama", (
+                f"alias '{alias}' → '{canonical}' should route to ollama, got {provider!r}"
+            )
+
+    def test_pi_config_sqlite_usage_store(self):
+        cfg = _load_config(str(_PI_CONFIG))
+        assert cfg.usage_store.adapter == "sqlite"
+
+    def test_pi_config_localhost_binding(self):
+        cfg = _load_config(str(_PI_CONFIG))
+        assert cfg.host == "127.0.0.1"
+        assert cfg.port == 8088
+
+    def test_pi_config_ollama_free_cost(self):
+        cfg = _load_config(str(_PI_CONFIG))
+        assert cfg.providers["ollama"].cost_per_token == 0.0


### PR DESCRIPTION
## Summary

- **`bifrost.pi.example.yaml`** — new example config for running Bifröst on Raspberry Pi / low-power hardware with only Ollama, no cloud API keys, no auth proxy. Covers: single Ollama provider, `direct` routing strategy, `open` auth mode, SQLite usage store, localhost binding, three local models (`llama3.2:1b`, `llama3.2:3b`, `llama3.1:8b`) with `fast`/`balanced`/`best`/`local` aliases.
- **`README.md`** — new *Bifröst Gateway* section with Pi-mode quick-start (Ollama install, model pull, one-line start), alias table with throughput notes, and links to both example configs.
- **`tests/test_bifrost/test_config.py`** — `TestPiModeConfig` class (12 tests) verifying the Pi config loads cleanly: single Ollama provider, no cloud API key env vars, open auth, direct routing, aliases all resolve to Ollama models, SQLite store, localhost binding, zero cost.

Closes NIU-514.

## Test plan

- [x] `TestPiModeConfig` — 12 new tests, all green
- [x] Full bifrost suite: 351 tests, 0 failures
- [x] `ruff check` + `ruff format --check` — clean

## Notes

Linear MCP tools were not available in this session. Please set NIU-514 to **In Review** manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)