### PR TITLE
feat(adapters): tool execution hook pipeline (NIU-493)

### DIFF
--- a/src/ravn/adapters/tools/hooks.py
+++ b/src/ravn/adapters/tools/hooks.py
@@ -1,0 +1,290 @@
+"""Built-in hook implementations for the Ravn tool execution pipeline.
+
+Configuration example (ravn.yaml):
+
+    tools:
+      hooks:
+        pre:
+          - adapter: ravn.adapters.tools.hooks.PermissionHook
+          - adapter: ravn.adapters.tools.hooks.BudgetHook
+            kwargs:
+              max_calls: 50
+        post:
+          - adapter: ravn.adapters.tools.hooks.AuditHook
+          - adapter: ravn.adapters.tools.hooks.SanitisationHook
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+from dataclasses import dataclass, field
+
+from ravn.domain.exceptions import PermissionDeniedError
+from ravn.domain.models import ToolResult
+from ravn.ports.hooks import PostToolHookPort, PreToolHookPort
+from ravn.ports.permission import PermissionPort
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Secret patterns used by SanitisationHook
+# ---------------------------------------------------------------------------
+
+_SECRET_PATTERNS: list[re.Pattern[str]] = [
+    # Generic API key / token assignments  (key = value)
+    re.compile(
+        r"(?i)(api[_-]?key|apikey|api[_-]?token|auth[_-]?token|access[_-]?token)\s*[=:]\s*\S+"
+    ),
+    # Bearer tokens in Authorization headers
+    re.compile(r"(?i)bearer\s+[A-Za-z0-9\-._~+/]+=*"),
+    # AWS access key IDs
+    re.compile(r"AKIA[0-9A-Z]{16}"),
+    # AWS secret / access key assignments
+    re.compile(r"(?i)aws[_-]?(secret|access)[_-]?key\s*[=:]\s*\S+"),
+    # PEM private key headers
+    re.compile(r"-----BEGIN [A-Z ]+PRIVATE KEY-----"),
+    # Password assignments
+    re.compile(r"(?i)(password|passwd|pwd)\s*[=:]\s*\S+"),
+    # Generic secret / token assignments (≥8 chars value)
+    re.compile(r"(?i)(secret|token)\s*[=:]\s*[A-Za-z0-9\-._~+/]{8,}"),
+]
+
+_REDACTED = "[REDACTED]"
+
+
+# ---------------------------------------------------------------------------
+# PermissionHook
+# ---------------------------------------------------------------------------
+
+
+class PermissionHook(PreToolHookPort):
+    """Pre-hook that validates tool permission via a PermissionPort.
+
+    Reads ``required_permission`` from ``agent_state`` and delegates to the
+    configured ``PermissionPort``.  Raises ``PermissionDeniedError`` when the
+    permission is not granted, which the registry converts to an error result.
+
+    This replaces the inline permission check that would otherwise live
+    directly inside the dispatch path.
+    """
+
+    def __init__(self, permission: PermissionPort) -> None:
+        self._permission = permission
+
+    async def pre_execute(
+        self,
+        tool_name: str,
+        args: dict,
+        agent_state: dict,
+    ) -> dict:
+        required = agent_state.get("required_permission", "")
+        granted = await self._permission.check(required)
+        if not granted:
+            raise PermissionDeniedError(tool_name, required)
+        return args
+
+
+# ---------------------------------------------------------------------------
+# BudgetHook
+# ---------------------------------------------------------------------------
+
+
+class BudgetHook(PreToolHookPort):
+    """Pre-hook that enforces a maximum tool-call budget per hook instance.
+
+    Each call to ``pre_execute`` increments an internal counter.  Once the
+    counter exceeds ``max_calls``, further calls raise ``PermissionDeniedError``
+    so the registry returns an error result rather than executing the tool.
+
+    The counter is instance-scoped; create one ``BudgetHook`` per session to
+    track per-session budgets, or share one across sessions for a global cap.
+    """
+
+    def __init__(self, max_calls: int) -> None:
+        self._max_calls = max_calls
+        self._call_count = 0
+
+    @property
+    def call_count(self) -> int:
+        """Number of tool calls seen so far."""
+        return self._call_count
+
+    @property
+    def max_calls(self) -> int:
+        """Configured maximum calls."""
+        return self._max_calls
+
+    async def pre_execute(
+        self,
+        tool_name: str,
+        args: dict,
+        agent_state: dict,
+    ) -> dict:
+        self._call_count += 1
+        if self._call_count > self._max_calls:
+            raise PermissionDeniedError(tool_name, f"budget:{self._max_calls}")
+        return args
+
+
+# ---------------------------------------------------------------------------
+# AuditHook
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AuditEntry:
+    """One structured audit record for a completed tool call."""
+
+    tool_name: str
+    args: dict
+    result_content: str
+    is_error: bool
+    elapsed_ms: float
+    timestamp: float = field(default_factory=time.time)
+
+
+class AuditHook(PostToolHookPort):
+    """Post-hook that records a structured audit entry for every tool call.
+
+    Entries are accumulated in ``self.entries`` and also emitted at DEBUG
+    level so they appear in structured logs when the log level is set low
+    enough.
+
+    The hook reads ``_started_at`` from ``agent_state`` (a ``time.monotonic``
+    stamp set by the registry before dispatch) to compute elapsed time.
+    """
+
+    def __init__(self) -> None:
+        self.entries: list[AuditEntry] = []
+
+    async def post_execute(
+        self,
+        tool_name: str,
+        args: dict,
+        result: ToolResult,
+        agent_state: dict,
+    ) -> ToolResult:
+        started_at: float = agent_state.get("_started_at", time.monotonic())
+        elapsed_ms = (time.monotonic() - started_at) * 1000.0
+
+        entry = AuditEntry(
+            tool_name=tool_name,
+            args=args,
+            result_content=result.content,
+            is_error=result.is_error,
+            elapsed_ms=elapsed_ms,
+        )
+        self.entries.append(entry)
+
+        logger.debug(
+            "audit tool=%r is_error=%s elapsed_ms=%.1f",
+            tool_name,
+            result.is_error,
+            elapsed_ms,
+        )
+        return result
+
+
+# ---------------------------------------------------------------------------
+# SanitisationHook
+# ---------------------------------------------------------------------------
+
+
+class SanitisationHook(PostToolHookPort):
+    """Post-hook that strips secrets and sensitive tokens from tool results.
+
+    Scans the result content string against a configurable set of regex
+    patterns and replaces any match with ``[REDACTED]``.  This prevents
+    accidentally captured secrets (API keys, passwords, bearer tokens, etc.)
+    from being injected into the LLM context.
+
+    A fresh ``ToolResult`` is returned only when content actually changed,
+    so the hook is a no-op for clean output.
+    """
+
+    def __init__(
+        self,
+        patterns: list[re.Pattern[str]] | None = None,
+        redacted: str = _REDACTED,
+    ) -> None:
+        self._patterns = patterns if patterns is not None else _SECRET_PATTERNS
+        self._redacted = redacted
+
+    async def post_execute(
+        self,
+        tool_name: str,
+        args: dict,
+        result: ToolResult,
+        agent_state: dict,
+    ) -> ToolResult:
+        sanitised = result.content
+        for pattern in self._patterns:
+            sanitised = pattern.sub(self._redacted, sanitised)
+
+        if sanitised == result.content:
+            return result
+
+        return ToolResult(
+            tool_call_id=result.tool_call_id,
+            content=sanitised,
+            is_error=result.is_error,
+        )
+
+
+# ---------------------------------------------------------------------------
+# HookPipeline
+# ---------------------------------------------------------------------------
+
+
+class HookPipeline:
+    """Orchestrates pre and post hooks around a tool dispatch.
+
+    Pre-hooks run in registration order before the tool executes; any hook
+    may raise ``PermissionDeniedError`` to abort the call.  Post-hooks run in
+    registration order after execution and may transform the result.
+
+    The pipeline is transparent to individual tool implementations — they
+    receive (possibly modified) args and their results may be modified before
+    being returned to the caller.
+    """
+
+    def __init__(
+        self,
+        pre_hooks: list[PreToolHookPort] | None = None,
+        post_hooks: list[PostToolHookPort] | None = None,
+    ) -> None:
+        self._pre_hooks: list[PreToolHookPort] = pre_hooks or []
+        self._post_hooks: list[PostToolHookPort] = post_hooks or []
+
+    @property
+    def pre_hooks(self) -> list[PreToolHookPort]:
+        return list(self._pre_hooks)
+
+    @property
+    def post_hooks(self) -> list[PostToolHookPort]:
+        return list(self._post_hooks)
+
+    async def run_pre(
+        self,
+        tool_name: str,
+        args: dict,
+        agent_state: dict,
+    ) -> dict:
+        """Run all pre-hooks in order and return the (possibly modified) args."""
+        for hook in self._pre_hooks:
+            args = await hook.pre_execute(tool_name, args, agent_state)
+        return args
+
+    async def run_post(
+        self,
+        tool_name: str,
+        args: dict,
+        result: ToolResult,
+        agent_state: dict,
+    ) -> ToolResult:
+        """Run all post-hooks in order and return the (possibly modified) result."""
+        for hook in self._post_hooks:
+            result = await hook.post_execute(tool_name, args, result, agent_state)
+        return result

--- a/src/ravn/adapters/tools/hooks.py
+++ b/src/ravn/adapters/tools/hooks.py
@@ -19,11 +19,12 @@ from __future__ import annotations
 import logging
 import re
 import time
+from collections import deque
 from dataclasses import dataclass, field
 
 from ravn.domain.exceptions import PermissionDeniedError
 from ravn.domain.models import ToolResult
-from ravn.ports.hooks import PostToolHookPort, PreToolHookPort
+from ravn.ports.hooks import HookPipelinePort, PostToolHookPort, PreToolHookPort
 from ravn.ports.permission import PermissionPort
 
 logger = logging.getLogger(__name__)
@@ -145,19 +146,24 @@ class AuditEntry:
     timestamp: float = field(default_factory=time.time)
 
 
+_DEFAULT_MAX_AUDIT_ENTRIES = 1000
+
+
 class AuditHook(PostToolHookPort):
     """Post-hook that records a structured audit entry for every tool call.
 
-    Entries are accumulated in ``self.entries`` and also emitted at DEBUG
-    level so they appear in structured logs when the log level is set low
-    enough.
+    Entries are accumulated in ``self.entries`` (a bounded deque) and also
+    emitted at DEBUG level so they appear in structured logs when the log
+    level is set low enough.  Once ``max_entries`` is reached the oldest
+    entry is evicted automatically, bounding memory use in long-running
+    sessions.
 
     The hook reads ``_started_at`` from ``agent_state`` (a ``time.monotonic``
     stamp set by the registry before dispatch) to compute elapsed time.
     """
 
-    def __init__(self) -> None:
-        self.entries: list[AuditEntry] = []
+    def __init__(self, max_entries: int = _DEFAULT_MAX_AUDIT_ENTRIES) -> None:
+        self.entries: deque[AuditEntry] = deque(maxlen=max_entries)
 
     async def post_execute(
         self,
@@ -238,7 +244,7 @@ class SanitisationHook(PostToolHookPort):
 # ---------------------------------------------------------------------------
 
 
-class HookPipeline:
+class HookPipeline(HookPipelinePort):
     """Orchestrates pre and post hooks around a tool dispatch.
 
     Pre-hooks run in registration order before the tool executes; any hook

--- a/src/ravn/ports/hooks.py
+++ b/src/ravn/ports/hooks.py
@@ -63,3 +63,36 @@ class PostToolHookPort(ABC):
             Possibly modified ToolResult.
         """
         ...
+
+
+class HookPipelinePort(ABC):
+    """Abstract interface for the hook pipeline that wraps tool dispatch.
+
+    The registry depends on this port — concrete implementations live in
+    ``ravn.adapters.tools.hooks``.
+    """
+
+    @abstractmethod
+    async def run_pre(
+        self,
+        tool_name: str,
+        args: dict,
+        agent_state: dict,
+    ) -> dict:
+        """Run all pre-hooks in order and return the (possibly modified) args.
+
+        Raises:
+            PermissionDeniedError: If any pre-hook blocks execution.
+        """
+        ...
+
+    @abstractmethod
+    async def run_post(
+        self,
+        tool_name: str,
+        args: dict,
+        result: ToolResult,
+        agent_state: dict,
+    ) -> ToolResult:
+        """Run all post-hooks in order and return the (possibly modified) result."""
+        ...

--- a/src/ravn/ports/hooks.py
+++ b/src/ravn/ports/hooks.py
@@ -1,0 +1,65 @@
+"""Hook ports — interfaces for pre/post tool execution hooks."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from ravn.domain.models import ToolResult
+
+
+class PreToolHookPort(ABC):
+    """Abstract interface for a pre-execution tool hook.
+
+    Called before a tool executes. May return modified args or raise
+    ``PermissionDeniedError`` to block execution entirely.
+    """
+
+    @abstractmethod
+    async def pre_execute(
+        self,
+        tool_name: str,
+        args: dict,
+        agent_state: dict,
+    ) -> dict:
+        """Called before tool execution.
+
+        Args:
+            tool_name: Name of the tool being invoked.
+            args: Input arguments to be passed to the tool.
+            agent_state: Ambient state (e.g. required_permission, session_id).
+
+        Returns:
+            Possibly modified args dict passed to the next hook or the tool.
+
+        Raises:
+            PermissionDeniedError: If the tool should be blocked.
+        """
+        ...
+
+
+class PostToolHookPort(ABC):
+    """Abstract interface for a post-execution tool hook.
+
+    Called after a tool executes. May return a modified result.
+    """
+
+    @abstractmethod
+    async def post_execute(
+        self,
+        tool_name: str,
+        args: dict,
+        result: ToolResult,
+        agent_state: dict,
+    ) -> ToolResult:
+        """Called after tool execution.
+
+        Args:
+            tool_name: Name of the tool that was invoked.
+            args: Input arguments that were passed to the tool.
+            result: The tool's execution result.
+            agent_state: Ambient state at the time of the call.
+
+        Returns:
+            Possibly modified ToolResult.
+        """
+        ...

--- a/src/ravn/registry.py
+++ b/src/ravn/registry.py
@@ -7,6 +7,7 @@ import time
 
 from ravn.domain.exceptions import PermissionDeniedError
 from ravn.domain.models import ToolResult
+from ravn.ports.hooks import HookPipelinePort
 from ravn.ports.tool import ToolPort
 
 logger = logging.getLogger(__name__)
@@ -30,7 +31,7 @@ class ToolRegistry:
     every dispatch call — transparent to individual tool implementations.
     """
 
-    def __init__(self, hook_pipeline: object | None = None) -> None:
+    def __init__(self, hook_pipeline: HookPipelinePort | None = None) -> None:
         self._tools: dict[str, ToolPort] = {}
         self._pipeline = hook_pipeline
 

--- a/src/ravn/registry.py
+++ b/src/ravn/registry.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import logging
+import time
 
+from ravn.domain.exceptions import PermissionDeniedError
 from ravn.domain.models import ToolResult
 from ravn.ports.tool import ToolPort
 
@@ -23,10 +25,14 @@ class ToolRegistry:
 
     Handles registration (with collision detection and schema validation),
     dispatching (with exception capture), and listing.
+
+    An optional ``HookPipeline`` can be supplied to run pre/post hooks around
+    every dispatch call — transparent to individual tool implementations.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, hook_pipeline: object | None = None) -> None:
         self._tools: dict[str, ToolPort] = {}
+        self._pipeline = hook_pipeline
 
     def register(self, tool: ToolPort) -> None:
         """Register *tool*.
@@ -41,11 +47,30 @@ class ToolRegistry:
         _validate_schema(name, tool.input_schema)
         self._tools[name] = tool
 
-    async def dispatch(self, name: str, input: dict, call_id: str) -> ToolResult:
+    async def dispatch(
+        self,
+        name: str,
+        input: dict,
+        call_id: str,
+        agent_state: dict | None = None,
+    ) -> ToolResult:
         """Execute tool *name* with *input*, returning a ToolResult.
+
+        The hook pipeline (if configured) runs pre-hooks before the tool
+        and post-hooks after.  Pre-hooks may modify args or raise
+        ``PermissionDeniedError`` to block execution.  Post-hooks may modify
+        the result before it is returned.
 
         Unknown tools and execution errors are returned as error results —
         exceptions are never propagated to the caller.
+
+        Args:
+            name: Registered tool name.
+            input: Tool input arguments.
+            call_id: Correlation ID for the ToolResult.
+            agent_state: Optional ambient state forwarded to hooks.  The
+                registry injects ``required_permission`` and ``_started_at``
+                automatically when they are absent.
         """
         tool = self._tools.get(name)
         if tool is None:
@@ -55,12 +80,32 @@ class ToolRegistry:
                 is_error=True,
             )
 
+        state: dict = dict(agent_state) if agent_state else {}
+        state.setdefault("required_permission", tool.required_permission)
+        state.setdefault("_started_at", time.monotonic())
+
         try:
-            result = await tool.execute(input)
+            args = input
+            if self._pipeline is not None:
+                args = await self._pipeline.run_pre(name, args, state)
+
+            raw = await tool.execute(args)
+            result = ToolResult(
+                tool_call_id=call_id,
+                content=raw.content,
+                is_error=raw.is_error,
+            )
+
+            if self._pipeline is not None:
+                result = await self._pipeline.run_post(name, args, result, state)
+
+            return result
+
+        except PermissionDeniedError as exc:
             return ToolResult(
                 tool_call_id=call_id,
-                content=result.content,
-                is_error=result.is_error,
+                content=str(exc),
+                is_error=True,
             )
         except Exception as exc:
             logger.warning("Tool %r raised: %s", name, exc)

--- a/tests/ravn/unit/test_hooks.py
+++ b/tests/ravn/unit/test_hooks.py
@@ -19,7 +19,7 @@ from ravn.adapters.tools.hooks import (
 )
 from ravn.domain.exceptions import PermissionDeniedError
 from ravn.domain.models import ToolResult
-from ravn.ports.hooks import PostToolHookPort, PreToolHookPort
+from ravn.ports.hooks import HookPipelinePort, PostToolHookPort, PreToolHookPort
 from ravn.registry import ToolRegistry
 from tests.ravn.fixtures.fakes import EchoTool, FailingTool
 
@@ -75,6 +75,47 @@ class TestPostToolHookPort:
         r = _result("hello")
         out = await hook.post_execute("echo", {}, r, {})
         assert out is r
+
+
+# ---------------------------------------------------------------------------
+# HookPipelinePort
+# ---------------------------------------------------------------------------
+
+
+class TestHookPipelinePort:
+    def test_is_abstract(self) -> None:
+        with pytest.raises(TypeError):
+            HookPipelinePort()  # type: ignore[abstract]
+
+    def test_concrete_must_implement_run_pre_and_run_post(self) -> None:
+        class Incomplete(HookPipelinePort):
+            async def run_pre(self, tool_name: str, args: dict, state: dict) -> dict:
+                return args
+
+        with pytest.raises(TypeError):
+            Incomplete()  # type: ignore[abstract]
+
+    async def test_hook_pipeline_implements_port(self) -> None:
+        pipeline = HookPipeline()
+        assert isinstance(pipeline, HookPipelinePort)
+
+    async def test_concrete_subclass_works(self) -> None:
+        class NoopPipeline(HookPipelinePort):
+            async def run_pre(self, tool_name: str, args: dict, state: dict) -> dict:
+                return args
+
+            async def run_post(
+                self, tool_name: str, args: dict, result: ToolResult, state: dict
+            ) -> ToolResult:
+                return result
+
+        pipeline = NoopPipeline()
+        args = {"x": 1}
+        out = await pipeline.run_pre("t", args, {})
+        assert out == args
+        r = _result("ok")
+        out2 = await pipeline.run_post("t", {}, r, {})
+        assert out2 is r
 
 
 # ---------------------------------------------------------------------------
@@ -227,6 +268,30 @@ class TestAuditHook:
         )
         assert entry.tool_name == "t"
         assert entry.elapsed_ms == 1.5
+
+    async def test_entries_is_bounded_deque(self) -> None:
+        from collections import deque
+
+        hook = AuditHook(max_entries=3)
+        assert isinstance(hook.entries, deque)
+        assert hook.entries.maxlen == 3
+
+    async def test_entries_evicts_oldest_when_full(self) -> None:
+        hook = AuditHook(max_entries=3)
+        for i in range(5):
+            await hook.post_execute("t", {}, _result(f"r{i}"), {})
+        # deque kept only the last 3
+        assert len(hook.entries) == 3
+        contents = [e.result_content for e in hook.entries]
+        assert contents == ["r2", "r3", "r4"]
+
+    async def test_default_max_entries_is_1000(self) -> None:
+        hook = AuditHook()
+        assert hook.entries.maxlen == 1000
+
+    async def test_custom_max_entries(self) -> None:
+        hook = AuditHook(max_entries=50)
+        assert hook.entries.maxlen == 50
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ravn/unit/test_hooks.py
+++ b/tests/ravn/unit/test_hooks.py
@@ -1,0 +1,586 @@
+"""Unit tests for the hook pipeline — ports, built-in hooks, and registry integration."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from ravn.adapters.permission_adapter import AllowAllPermission, DenyAllPermission
+from ravn.adapters.tools.hooks import (
+    _REDACTED,
+    _SECRET_PATTERNS,
+    AuditEntry,
+    AuditHook,
+    BudgetHook,
+    HookPipeline,
+    PermissionHook,
+    SanitisationHook,
+)
+from ravn.domain.exceptions import PermissionDeniedError
+from ravn.domain.models import ToolResult
+from ravn.ports.hooks import PostToolHookPort, PreToolHookPort
+from ravn.registry import ToolRegistry
+from tests.ravn.fixtures.fakes import EchoTool, FailingTool
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _result(content: str = "ok", *, is_error: bool = False) -> ToolResult:
+    return ToolResult(tool_call_id="cid", content=content, is_error=is_error)
+
+
+# ---------------------------------------------------------------------------
+# Port ABC contracts
+# ---------------------------------------------------------------------------
+
+
+class TestPreToolHookPort:
+    def test_is_abstract(self) -> None:
+        with pytest.raises(TypeError):
+            PreToolHookPort()  # type: ignore[abstract]
+
+    def test_concrete_subclass_must_implement_pre_execute(self) -> None:
+        class Incomplete(PreToolHookPort):
+            pass
+
+        with pytest.raises(TypeError):
+            Incomplete()  # type: ignore[abstract]
+
+    async def test_concrete_subclass_works(self) -> None:
+        class Identity(PreToolHookPort):
+            async def pre_execute(self, tool_name: str, args: dict, agent_state: dict) -> dict:
+                return args
+
+        hook = Identity()
+        result = await hook.pre_execute("echo", {"msg": "hi"}, {})
+        assert result == {"msg": "hi"}
+
+
+class TestPostToolHookPort:
+    def test_is_abstract(self) -> None:
+        with pytest.raises(TypeError):
+            PostToolHookPort()  # type: ignore[abstract]
+
+    async def test_concrete_subclass_works(self) -> None:
+        class Identity(PostToolHookPort):
+            async def post_execute(
+                self, tool_name: str, args: dict, result: ToolResult, agent_state: dict
+            ) -> ToolResult:
+                return result
+
+        hook = Identity()
+        r = _result("hello")
+        out = await hook.post_execute("echo", {}, r, {})
+        assert out is r
+
+
+# ---------------------------------------------------------------------------
+# PermissionHook
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionHook:
+    async def test_allows_when_permission_granted(self) -> None:
+        hook = PermissionHook(AllowAllPermission())
+        args = {"message": "hello"}
+        result = await hook.pre_execute("echo", args, {"required_permission": "tool:echo"})
+        assert result == args
+
+    async def test_raises_when_permission_denied(self) -> None:
+        hook = PermissionHook(DenyAllPermission())
+        with pytest.raises(PermissionDeniedError) as exc_info:
+            await hook.pre_execute("echo", {}, {"required_permission": "tool:echo"})
+        assert exc_info.value.tool_name == "echo"
+        assert exc_info.value.permission == "tool:echo"
+
+    async def test_uses_empty_permission_when_not_in_state(self) -> None:
+        """Missing required_permission key defaults to empty string — still allowed."""
+        hook = PermissionHook(AllowAllPermission())
+        args = {"x": 1}
+        out = await hook.pre_execute("any_tool", args, {})
+        assert out == args
+
+    async def test_passes_args_through_unmodified(self) -> None:
+        hook = PermissionHook(AllowAllPermission())
+        args = {"a": 1, "b": [1, 2, 3]}
+        out = await hook.pre_execute("tool", args, {"required_permission": "x"})
+        assert out == args
+
+    async def test_raises_permission_denied_error_not_builtin(self) -> None:
+        hook = PermissionHook(DenyAllPermission())
+        with pytest.raises(PermissionDeniedError):
+            await hook.pre_execute("t", {}, {"required_permission": "p"})
+
+
+# ---------------------------------------------------------------------------
+# BudgetHook
+# ---------------------------------------------------------------------------
+
+
+class TestBudgetHook:
+    async def test_allows_within_budget(self) -> None:
+        hook = BudgetHook(max_calls=3)
+        for _ in range(3):
+            result = await hook.pre_execute("echo", {"msg": "hi"}, {})
+            assert result == {"msg": "hi"}
+
+    async def test_rejects_when_budget_exhausted(self) -> None:
+        hook = BudgetHook(max_calls=2)
+        await hook.pre_execute("echo", {}, {})
+        await hook.pre_execute("echo", {}, {})
+        with pytest.raises(PermissionDeniedError) as exc_info:
+            await hook.pre_execute("echo", {}, {})
+        assert "budget:2" in exc_info.value.permission
+
+    async def test_call_count_increments(self) -> None:
+        hook = BudgetHook(max_calls=10)
+        assert hook.call_count == 0
+        await hook.pre_execute("t", {}, {})
+        assert hook.call_count == 1
+        await hook.pre_execute("t", {}, {})
+        assert hook.call_count == 2
+
+    async def test_max_calls_property(self) -> None:
+        hook = BudgetHook(max_calls=5)
+        assert hook.max_calls == 5
+
+    async def test_first_over_budget_call_raises(self) -> None:
+        hook = BudgetHook(max_calls=0)
+        with pytest.raises(PermissionDeniedError):
+            await hook.pre_execute("t", {}, {})
+
+    async def test_passes_args_through_unmodified(self) -> None:
+        hook = BudgetHook(max_calls=5)
+        args = {"key": "value"}
+        out = await hook.pre_execute("t", args, {})
+        assert out == args
+
+    async def test_includes_tool_name_in_error(self) -> None:
+        hook = BudgetHook(max_calls=0)
+        with pytest.raises(PermissionDeniedError) as exc_info:
+            await hook.pre_execute("my_tool", {}, {})
+        assert exc_info.value.tool_name == "my_tool"
+
+
+# ---------------------------------------------------------------------------
+# AuditHook
+# ---------------------------------------------------------------------------
+
+
+class TestAuditHook:
+    async def test_returns_result_unchanged(self) -> None:
+        hook = AuditHook()
+        r = _result("output")
+        out = await hook.post_execute("echo", {}, r, {})
+        assert out is r
+
+    async def test_records_audit_entry(self) -> None:
+        hook = AuditHook()
+        r = _result("output")
+        await hook.post_execute("echo", {"msg": "hi"}, r, {})
+        assert len(hook.entries) == 1
+        entry = hook.entries[0]
+        assert entry.tool_name == "echo"
+        assert entry.args == {"msg": "hi"}
+        assert entry.result_content == "output"
+        assert entry.is_error is False
+
+    async def test_records_error_result(self) -> None:
+        hook = AuditHook()
+        r = _result("boom", is_error=True)
+        await hook.post_execute("fail", {}, r, {})
+        assert hook.entries[0].is_error is True
+
+    async def test_accumulates_multiple_entries(self) -> None:
+        hook = AuditHook()
+        for i in range(5):
+            await hook.post_execute("tool", {}, _result(f"result_{i}"), {})
+        assert len(hook.entries) == 5
+
+    async def test_elapsed_ms_is_non_negative(self) -> None:
+        import time
+
+        hook = AuditHook()
+        state = {"_started_at": time.monotonic()}
+        await hook.post_execute("t", {}, _result("x"), state)
+        assert hook.entries[0].elapsed_ms >= 0.0
+
+    async def test_timestamp_is_set(self) -> None:
+        import time
+
+        hook = AuditHook()
+        before = time.time()
+        await hook.post_execute("t", {}, _result("x"), {})
+        after = time.time()
+        assert before <= hook.entries[0].timestamp <= after
+
+    async def test_audit_entry_dataclass_fields(self) -> None:
+        entry = AuditEntry(
+            tool_name="t",
+            args={},
+            result_content="r",
+            is_error=False,
+            elapsed_ms=1.5,
+        )
+        assert entry.tool_name == "t"
+        assert entry.elapsed_ms == 1.5
+
+
+# ---------------------------------------------------------------------------
+# SanitisationHook
+# ---------------------------------------------------------------------------
+
+
+class TestSanitisationHook:
+    async def test_clean_content_returned_as_is(self) -> None:
+        hook = SanitisationHook()
+        r = _result("The weather is nice today.")
+        out = await hook.post_execute("t", {}, r, {})
+        assert out is r
+
+    async def test_redacts_api_key_assignment(self) -> None:
+        hook = SanitisationHook()
+        r = _result("api_key=sk-abc123XYZ890")
+        out = await hook.post_execute("t", {}, r, {})
+        assert _REDACTED in out.content
+        assert "sk-abc123XYZ890" not in out.content
+
+    async def test_redacts_bearer_token(self) -> None:
+        hook = SanitisationHook()
+        r = _result("Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig")
+        out = await hook.post_execute("t", {}, r, {})
+        assert _REDACTED in out.content
+
+    async def test_redacts_aws_access_key_id(self) -> None:
+        hook = SanitisationHook()
+        r = _result("AKIAIOSFODNN7EXAMPLE")
+        out = await hook.post_execute("t", {}, r, {})
+        assert _REDACTED in out.content
+
+    async def test_redacts_password_assignment(self) -> None:
+        hook = SanitisationHook()
+        r = _result("password=supersecret123")
+        out = await hook.post_execute("t", {}, r, {})
+        assert _REDACTED in out.content
+
+    async def test_redacts_private_key_header(self) -> None:
+        hook = SanitisationHook()
+        r = _result("-----BEGIN RSA PRIVATE KEY-----\nMIIE...\n-----END RSA PRIVATE KEY-----")
+        out = await hook.post_execute("t", {}, r, {})
+        assert _REDACTED in out.content
+
+    async def test_preserves_is_error_flag(self) -> None:
+        hook = SanitisationHook()
+        r = _result("api_key=secret", is_error=True)
+        out = await hook.post_execute("t", {}, r, {})
+        assert out.is_error is True
+
+    async def test_preserves_tool_call_id(self) -> None:
+        hook = SanitisationHook()
+        r = ToolResult(tool_call_id="xyz", content="api_key=secret", is_error=False)
+        out = await hook.post_execute("t", {}, r, {})
+        assert out.tool_call_id == "xyz"
+
+    async def test_custom_patterns(self) -> None:
+        pattern = re.compile(r"\bCUSTOM_SECRET\b")
+        hook = SanitisationHook(patterns=[pattern])
+        r = _result("value is CUSTOM_SECRET here")
+        out = await hook.post_execute("t", {}, r, {})
+        assert "CUSTOM_SECRET" not in out.content
+        assert _REDACTED in out.content
+
+    async def test_custom_redacted_string(self) -> None:
+        pattern = re.compile(r"api_key=\S+")
+        hook = SanitisationHook(patterns=[pattern], redacted="***")
+        r = _result("api_key=abc123")
+        out = await hook.post_execute("t", {}, r, {})
+        assert "***" in out.content
+
+    async def test_multiple_secrets_in_same_content(self) -> None:
+        hook = SanitisationHook()
+        r = _result("api_key=abc123 and password=secret99")
+        out = await hook.post_execute("t", {}, r, {})
+        assert "abc123" not in out.content
+        assert "secret99" not in out.content
+
+    async def test_default_patterns_list(self) -> None:
+        hook = SanitisationHook()
+        assert hook._patterns is _SECRET_PATTERNS
+
+
+# ---------------------------------------------------------------------------
+# HookPipeline
+# ---------------------------------------------------------------------------
+
+
+class TestHookPipeline:
+    async def test_empty_pipeline_returns_args_unchanged(self) -> None:
+        pipeline = HookPipeline()
+        args = {"x": 1}
+        out = await pipeline.run_pre("t", args, {})
+        assert out == args
+
+    async def test_empty_pipeline_returns_result_unchanged(self) -> None:
+        pipeline = HookPipeline()
+        r = _result("hello")
+        out = await pipeline.run_post("t", {}, r, {})
+        assert out is r
+
+    async def test_pre_hooks_run_in_order(self) -> None:
+        order: list[str] = []
+
+        class TagHook(PreToolHookPort):
+            def __init__(self, tag: str) -> None:
+                self._tag = tag
+
+            async def pre_execute(self, tool_name: str, args: dict, state: dict) -> dict:
+                order.append(self._tag)
+                return args
+
+        pipeline = HookPipeline(pre_hooks=[TagHook("first"), TagHook("second")])
+        await pipeline.run_pre("t", {}, {})
+        assert order == ["first", "second"]
+
+    async def test_post_hooks_run_in_order(self) -> None:
+        order: list[str] = []
+
+        class TagHook(PostToolHookPort):
+            def __init__(self, tag: str) -> None:
+                self._tag = tag
+
+            async def post_execute(
+                self, tool_name: str, args: dict, result: ToolResult, state: dict
+            ) -> ToolResult:
+                order.append(self._tag)
+                return result
+
+        pipeline = HookPipeline(post_hooks=[TagHook("first"), TagHook("second")])
+        await pipeline.run_post("t", {}, _result(), {})
+        assert order == ["first", "second"]
+
+    async def test_pre_hook_can_modify_args(self) -> None:
+        class AddKeyHook(PreToolHookPort):
+            async def pre_execute(self, tool_name: str, args: dict, state: dict) -> dict:
+                return {**args, "injected": True}
+
+        pipeline = HookPipeline(pre_hooks=[AddKeyHook()])
+        out = await pipeline.run_pre("t", {"original": 1}, {})
+        assert out == {"original": 1, "injected": True}
+
+    async def test_post_hook_can_modify_result(self) -> None:
+        class UpperHook(PostToolHookPort):
+            async def post_execute(
+                self, tool_name: str, args: dict, result: ToolResult, state: dict
+            ) -> ToolResult:
+                return ToolResult(
+                    tool_call_id=result.tool_call_id,
+                    content=result.content.upper(),
+                    is_error=result.is_error,
+                )
+
+        pipeline = HookPipeline(post_hooks=[UpperHook()])
+        r = _result("hello world")
+        out = await pipeline.run_post("t", {}, r, {})
+        assert out.content == "HELLO WORLD"
+
+    async def test_pre_hook_exception_propagates(self) -> None:
+        pipeline = HookPipeline(pre_hooks=[PermissionHook(DenyAllPermission())])
+        with pytest.raises(PermissionDeniedError):
+            await pipeline.run_pre("t", {}, {"required_permission": "x"})
+
+    async def test_pre_hooks_chain_modified_args(self) -> None:
+        class AppendHook(PreToolHookPort):
+            def __init__(self, char: str) -> None:
+                self._char = char
+
+            async def pre_execute(self, tool_name: str, args: dict, state: dict) -> dict:
+                return {**args, "chars": args.get("chars", "") + self._char}
+
+        pipeline = HookPipeline(pre_hooks=[AppendHook("a"), AppendHook("b"), AppendHook("c")])
+        out = await pipeline.run_pre("t", {}, {})
+        assert out == {"chars": "abc"}
+
+    async def test_properties_return_copies(self) -> None:
+        pre = PermissionHook(AllowAllPermission())
+        post = AuditHook()
+        pipeline = HookPipeline(pre_hooks=[pre], post_hooks=[post])
+        pre_list = pipeline.pre_hooks
+        post_list = pipeline.post_hooks
+        pre_list.append(pre)
+        post_list.append(post)
+        assert len(pipeline.pre_hooks) == 1
+        assert len(pipeline.post_hooks) == 1
+
+
+# ---------------------------------------------------------------------------
+# Registry + HookPipeline integration
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryWithHookPipeline:
+    async def test_dispatch_without_pipeline_works(self) -> None:
+        registry = ToolRegistry()
+        registry.register(EchoTool())
+        result = await registry.dispatch("echo", {"message": "hello"}, "cid1")
+        assert result.content == "hello"
+        assert not result.is_error
+
+    async def test_dispatch_with_empty_pipeline(self) -> None:
+        registry = ToolRegistry(hook_pipeline=HookPipeline())
+        registry.register(EchoTool())
+        result = await registry.dispatch("echo", {"message": "hi"}, "cid1")
+        assert result.content == "hi"
+
+    async def test_dispatch_pre_hook_can_modify_args(self) -> None:
+        class OverrideHook(PreToolHookPort):
+            async def pre_execute(self, tool_name: str, args: dict, state: dict) -> dict:
+                return {"message": "intercepted"}
+
+        pipeline = HookPipeline(pre_hooks=[OverrideHook()])
+        registry = ToolRegistry(hook_pipeline=pipeline)
+        registry.register(EchoTool())
+        result = await registry.dispatch("echo", {"message": "original"}, "cid")
+        assert result.content == "intercepted"
+
+    async def test_dispatch_post_hook_can_modify_result(self) -> None:
+        class PrefixHook(PostToolHookPort):
+            async def post_execute(
+                self, tool_name: str, args: dict, result: ToolResult, state: dict
+            ) -> ToolResult:
+                return ToolResult(
+                    tool_call_id=result.tool_call_id,
+                    content="PREFIX:" + result.content,
+                    is_error=result.is_error,
+                )
+
+        pipeline = HookPipeline(post_hooks=[PrefixHook()])
+        registry = ToolRegistry(hook_pipeline=pipeline)
+        registry.register(EchoTool())
+        result = await registry.dispatch("echo", {"message": "hello"}, "cid")
+        assert result.content == "PREFIX:hello"
+
+    async def test_dispatch_permission_hook_blocks_tool(self) -> None:
+        pipeline = HookPipeline(pre_hooks=[PermissionHook(DenyAllPermission())])
+        registry = ToolRegistry(hook_pipeline=pipeline)
+        registry.register(EchoTool())
+        result = await registry.dispatch(
+            "echo",
+            {"message": "hi"},
+            "cid",
+            agent_state={"required_permission": "tool:echo"},
+        )
+        assert result.is_error
+        assert "denied" in result.content.lower()
+
+    async def test_dispatch_sets_required_permission_in_state(self) -> None:
+        observed: list[str] = []
+
+        class ObserveHook(PreToolHookPort):
+            async def pre_execute(self, tool_name: str, args: dict, state: dict) -> dict:
+                observed.append(state.get("required_permission", ""))
+                return args
+
+        pipeline = HookPipeline(pre_hooks=[ObserveHook()])
+        registry = ToolRegistry(hook_pipeline=pipeline)
+        registry.register(EchoTool())
+        await registry.dispatch("echo", {"message": "x"}, "cid")
+        assert observed == ["tool:echo"]
+
+    async def test_dispatch_sets_started_at_in_state(self) -> None:
+        observed: list[float] = []
+
+        class ObserveHook(PreToolHookPort):
+            async def pre_execute(self, tool_name: str, args: dict, state: dict) -> dict:
+                observed.append(state.get("_started_at", -1.0))
+                return args
+
+        pipeline = HookPipeline(pre_hooks=[ObserveHook()])
+        registry = ToolRegistry(hook_pipeline=pipeline)
+        registry.register(EchoTool())
+        await registry.dispatch("echo", {"message": "x"}, "cid")
+        assert observed[0] > 0
+
+    async def test_dispatch_unknown_tool_returns_error(self) -> None:
+        registry = ToolRegistry(hook_pipeline=HookPipeline())
+        result = await registry.dispatch("unknown", {}, "cid")
+        assert result.is_error
+        assert "Unknown tool" in result.content
+
+    async def test_dispatch_failing_tool_returns_error(self) -> None:
+        registry = ToolRegistry(hook_pipeline=HookPipeline())
+        registry.register(FailingTool())
+        result = await registry.dispatch("fail", {}, "cid")
+        assert result.is_error
+
+    async def test_dispatch_audit_hook_records_entry(self) -> None:
+        audit = AuditHook()
+        pipeline = HookPipeline(post_hooks=[audit])
+        registry = ToolRegistry(hook_pipeline=pipeline)
+        registry.register(EchoTool())
+        await registry.dispatch("echo", {"message": "hello"}, "cid")
+        assert len(audit.entries) == 1
+        assert audit.entries[0].tool_name == "echo"
+
+    async def test_dispatch_sanitisation_hook_redacts_output(self) -> None:
+        class SecretTool(EchoTool):
+            async def execute(self, input: dict) -> ToolResult:
+                return ToolResult(
+                    tool_call_id="",
+                    content="api_key=sk-abc123secretXYZ",
+                )
+
+        pipeline = HookPipeline(post_hooks=[SanitisationHook()])
+        registry = ToolRegistry(hook_pipeline=pipeline)
+        registry.register(SecretTool())
+        result = await registry.dispatch("echo", {}, "cid")
+        assert "sk-abc123secretXYZ" not in result.content
+        assert _REDACTED in result.content
+
+    async def test_dispatch_budget_hook_blocks_after_limit(self) -> None:
+        budget = BudgetHook(max_calls=2)
+        pipeline = HookPipeline(pre_hooks=[budget])
+        registry = ToolRegistry(hook_pipeline=pipeline)
+        registry.register(EchoTool())
+
+        r1 = await registry.dispatch("echo", {"message": "a"}, "c1")
+        r2 = await registry.dispatch("echo", {"message": "b"}, "c2")
+        r3 = await registry.dispatch("echo", {"message": "c"}, "c3")
+
+        assert not r1.is_error
+        assert not r2.is_error
+        assert r3.is_error
+
+    async def test_dispatch_call_id_preserved_in_result(self) -> None:
+        registry = ToolRegistry()
+        registry.register(EchoTool())
+        result = await registry.dispatch("echo", {"message": "x"}, "my-call-id")
+        assert result.tool_call_id == "my-call-id"
+
+    async def test_dispatch_agent_state_not_mutated(self) -> None:
+        registry = ToolRegistry(hook_pipeline=HookPipeline())
+        registry.register(EchoTool())
+        state = {"custom": "value"}
+        await registry.dispatch("echo", {"message": "x"}, "cid", agent_state=state)
+        assert state == {"custom": "value"}
+
+    async def test_dispatch_none_agent_state_works(self) -> None:
+        registry = ToolRegistry(hook_pipeline=HookPipeline())
+        registry.register(EchoTool())
+        result = await registry.dispatch("echo", {"message": "hi"}, "cid", agent_state=None)
+        assert not result.is_error
+
+    async def test_full_pipeline_pre_and_post(self) -> None:
+        audit = AuditHook()
+        sanitise = SanitisationHook()
+        pipeline = HookPipeline(
+            pre_hooks=[PermissionHook(AllowAllPermission()), BudgetHook(max_calls=10)],
+            post_hooks=[audit, sanitise],
+        )
+        registry = ToolRegistry(hook_pipeline=pipeline)
+        registry.register(EchoTool())
+        result = await registry.dispatch("echo", {"message": "clean output"}, "cid")
+        assert result.content == "clean output"
+        assert len(audit.entries) == 1


### PR DESCRIPTION
## Summary

Implements a pre/post hook pipeline for the tool registry dispatch path, transparent to individual tool implementations.

- **`src/ravn/ports/hooks.py`** — `PreToolHookPort` and `PostToolHookPort` abstract base classes defining the hook interface (`pre_execute → modified args | PermissionDeniedError`, `post_execute → modified result`)
- **`src/ravn/adapters/tools/hooks.py`** — Four built-in hooks plus `HookPipeline` orchestrator:
  - `PermissionHook` (pre) — delegates to `PermissionPort`, raises `PermissionDeniedError` when a tool's required permission is not granted; replaces inline checks
  - `BudgetHook` (pre) — per-instance call counter that rejects once `max_calls` is exceeded
  - `AuditHook` (post) — records a structured `AuditEntry` with elapsed timing per call, emits a DEBUG log line
  - `SanitisationHook` (post) — strips API keys, bearer tokens, passwords, AWS credentials, and PEM headers from tool output via configurable regex patterns before results enter LLM context
- **`src/ravn/registry.py`** — `ToolRegistry` accepts an optional `HookPipeline`; `dispatch()` runs the pre-pipeline (can modify args), executes the tool, then runs the post-pipeline (can modify result); `PermissionDeniedError` from pre-hooks becomes an error `ToolResult`; the registry automatically injects `required_permission` and `_started_at` into `agent_state` for hooks

## Configuration

```yaml
tools:
  hooks:
    pre:
      - adapter: ravn.adapters.tools.hooks.PermissionHook
      - adapter: ravn.adapters.tools.hooks.BudgetHook
        kwargs:
          max_calls: 50
    post:
      - adapter: ravn.adapters.tools.hooks.AuditHook
      - adapter: ravn.adapters.tools.hooks.SanitisationHook
```

## Test plan

- [x] 61 new unit tests in `tests/ravn/unit/test_hooks.py` covering all hook classes, `HookPipeline` ordering/chaining, arg/result mutation, port ABC contracts, and registry integration
- [x] 100% branch coverage on `src/ravn/adapters/tools/hooks.py`
- [x] All 71 ravn tests pass (including existing e2e conversation tests — backward compatible)
- [x] `ruff check` clean, `ruff format` applied

Closes NIU-493

🤖 Generated with [Claude Code](https://claude.com/claude-code)