### PR TITLE
feat(bifrost): NIU-481 Ollama inbound passthrough (/api/generate, /api/chat, /api/tags)

### DIFF
--- a/src/bifrost/inbound/chat_completions.py
+++ b/src/bifrost/inbound/chat_completions.py
@@ -25,12 +25,12 @@ from bifrost.translation.models import (
     ContentBlock,
     Message,
     TextBlock,
-    ThinkingBlock,
     ToolChoiceAny,
     ToolChoiceAuto,
     ToolChoiceTool,
     ToolDefinition,
     ToolResultBlock,
+    extract_text_from_response,
 )
 from bifrost.translation.to_anthropic import _openai_tool_calls_to_blocks
 from bifrost.translation.to_openai import _extract_tool_calls
@@ -249,14 +249,7 @@ def anthropic_response_to_openai(response: AnthropicResponse) -> dict[str, Any]:
     Returns:
         A dict ready to be JSON-serialised and returned to the caller.
     """
-    text_parts: list[str] = []
-    for block in response.content:
-        if isinstance(block, TextBlock):
-            text_parts.append(block.text)
-        elif isinstance(block, ThinkingBlock):
-            text_parts.append(f"<thinking>{block.thinking}</thinking>")
-
-    text = "".join(text_parts)
+    text = extract_text_from_response(response)
     tool_calls = _extract_tool_calls(response.content)
     finish_reason = STOP_REASON_TO_OPENAI.get(response.stop_reason or "end_turn", "stop")
 

--- a/src/bifrost/inbound/ollama.py
+++ b/src/bifrost/inbound/ollama.py
@@ -1,0 +1,429 @@
+"""Ollama inbound interface for Bifröst.
+
+Accepts POST /api/generate and POST /api/chat in native Ollama format,
+normalises the request to the internal Anthropic canonical form, routes via
+the shared ModelRouter, then translates the response back to Ollama format.
+
+Ollama streaming uses newline-delimited JSON (NDJSON), not SSE.  Each line
+is a complete JSON object.  Intermediate chunks have ``"done": false``; the
+final chunk has ``"done": true`` and carries timing / token metadata.
+
+This enables tools that speak native Ollama (Open WebUI, etc.) to point at
+Bifröst without any configuration changes.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from typing import Any
+
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+from bifrost.translation.models import (
+    AnthropicRequest,
+    AnthropicResponse,
+    Message,
+    TextBlock,
+    ThinkingBlock,
+)
+
+# ---------------------------------------------------------------------------
+# Ollama request Pydantic models
+# ---------------------------------------------------------------------------
+
+
+class _OllamaOptions(BaseModel):
+    """Subset of Ollama /api/generate and /api/chat options we translate."""
+
+    temperature: float | None = None
+    top_p: float | None = None
+    top_k: int | None = None
+    num_predict: int | None = None
+    stop: list[str] | None = None
+
+
+class OllamaGenerateRequest(BaseModel):
+    """Pydantic model for a POST /api/generate request."""
+
+    model: str
+    prompt: str = ""
+    system: str | None = None
+    stream: bool = True
+    options: _OllamaOptions = Field(default_factory=_OllamaOptions)
+    context: list[int] | None = None
+    raw: bool = False
+
+
+class _OllamaChatMessage(BaseModel):
+    role: str
+    content: str = ""
+
+
+class OllamaChatRequest(BaseModel):
+    """Pydantic model for a POST /api/chat request."""
+
+    model: str
+    messages: list[_OllamaChatMessage] = Field(default_factory=list)
+    stream: bool = True
+    options: _OllamaOptions = Field(default_factory=_OllamaOptions)
+
+
+# ---------------------------------------------------------------------------
+# Error helper
+# ---------------------------------------------------------------------------
+
+
+def ollama_error_response(status: int, message: str) -> JSONResponse:
+    """Return a JSONResponse in the Ollama error shape."""
+    return JSONResponse(status_code=status, content={"error": message})
+
+
+# ---------------------------------------------------------------------------
+# Request translation: Ollama → Anthropic canonical
+# ---------------------------------------------------------------------------
+
+
+def ollama_generate_to_anthropic(req: OllamaGenerateRequest) -> AnthropicRequest:
+    """Convert an Ollama /api/generate request to Anthropic canonical format.
+
+    The prompt becomes a single ``user`` message.  The optional ``system``
+    field maps directly to the Anthropic ``system`` parameter.
+
+    Args:
+        req: Parsed Ollama generate request.
+
+    Returns:
+        An ``AnthropicRequest`` ready for the routing layer.
+    """
+    messages = [Message(role="user", content=req.prompt)] if req.prompt else []
+
+    return AnthropicRequest(
+        model=req.model,
+        max_tokens=req.options.num_predict or 1024,
+        messages=messages,
+        system=req.system,
+        temperature=req.options.temperature,
+        top_p=req.options.top_p,
+        top_k=req.options.top_k,
+        stop_sequences=req.options.stop or None,
+        stream=req.stream,
+    )
+
+
+def ollama_chat_to_anthropic(req: OllamaChatRequest) -> AnthropicRequest:
+    """Convert an Ollama /api/chat request to Anthropic canonical format.
+
+    System messages are extracted and concatenated; remaining messages become
+    alternating user/assistant turns.
+
+    Args:
+        req: Parsed Ollama chat request.
+
+    Returns:
+        An ``AnthropicRequest`` ready for the routing layer.
+    """
+    system_parts: list[str] = []
+    anthropic_messages: list[Message] = []
+
+    for msg in req.messages:
+        if msg.role == "system":
+            if msg.content:
+                system_parts.append(msg.content)
+            continue
+        if msg.role in ("user", "assistant"):
+            anthropic_messages.append(Message(role=msg.role, content=msg.content))
+
+    system: str | None = "\n\n".join(system_parts) if system_parts else None
+
+    return AnthropicRequest(
+        model=req.model,
+        max_tokens=req.options.num_predict or 1024,
+        messages=anthropic_messages,
+        system=system,
+        temperature=req.options.temperature,
+        top_p=req.options.top_p,
+        top_k=req.options.top_k,
+        stop_sequences=req.options.stop or None,
+        stream=req.stream,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Response translation: Anthropic canonical → Ollama
+# ---------------------------------------------------------------------------
+
+
+def _extract_response_text(response: AnthropicResponse) -> str:
+    """Flatten Anthropic content blocks to a plain string for Ollama."""
+    parts: list[str] = []
+    for block in response.content:
+        if isinstance(block, TextBlock):
+            parts.append(block.text)
+        elif isinstance(block, ThinkingBlock):
+            parts.append(f"<thinking>{block.thinking}</thinking>")
+    return "".join(parts)
+
+
+def _done_reason(stop_reason: str | None) -> str:
+    """Map Anthropic stop_reason to an Ollama done_reason string."""
+    mapping = {
+        "end_turn": "stop",
+        "max_tokens": "length",
+        "tool_use": "stop",
+        "stop_sequence": "stop",
+    }
+    return mapping.get(stop_reason or "end_turn", "stop")
+
+
+def anthropic_response_to_ollama_generate(
+    response: AnthropicResponse,
+    *,
+    created_at: str,
+    total_duration_ns: int,
+) -> dict[str, Any]:
+    """Convert an Anthropic response to Ollama /api/generate non-streaming format."""
+    text = _extract_response_text(response)
+    return {
+        "model": response.model,
+        "created_at": created_at,
+        "response": text,
+        "done": True,
+        "done_reason": _done_reason(response.stop_reason),
+        "total_duration": total_duration_ns,
+        "load_duration": 0,
+        "prompt_eval_count": response.usage.input_tokens,
+        "prompt_eval_duration": 0,
+        "eval_count": response.usage.output_tokens,
+        "eval_duration": total_duration_ns,
+    }
+
+
+def anthropic_response_to_ollama_chat(
+    response: AnthropicResponse,
+    *,
+    created_at: str,
+    total_duration_ns: int,
+) -> dict[str, Any]:
+    """Convert an Anthropic response to Ollama /api/chat non-streaming format."""
+    text = _extract_response_text(response)
+    return {
+        "model": response.model,
+        "created_at": created_at,
+        "message": {"role": "assistant", "content": text},
+        "done": True,
+        "done_reason": _done_reason(response.stop_reason),
+        "total_duration": total_duration_ns,
+        "load_duration": 0,
+        "prompt_eval_count": response.usage.input_tokens,
+        "prompt_eval_duration": 0,
+        "eval_count": response.usage.output_tokens,
+        "eval_duration": total_duration_ns,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Streaming translation: Anthropic SSE → Ollama NDJSON
+# ---------------------------------------------------------------------------
+
+
+def _ndjson(obj: dict[str, Any]) -> str:
+    """Serialise *obj* as a single newline-terminated JSON line."""
+    return json.dumps(obj) + "\n"
+
+
+async def anthropic_stream_to_ollama_generate(
+    source: AsyncIterator[str],
+    *,
+    model: str,
+    start: float,
+) -> AsyncIterator[str]:
+    """Translate Anthropic SSE stream to Ollama /api/generate NDJSON.
+
+    Each text delta is emitted as an intermediate chunk (``"done": false``).
+    On stream completion a final chunk with ``"done": true`` and token counts
+    is emitted.
+
+    Args:
+        source: Async iterator of raw Anthropic SSE strings from the router.
+        model: Model name to embed in every chunk.
+        start: ``time.monotonic()`` value recorded before the request was sent.
+
+    Yields:
+        NDJSON lines compatible with the Ollama /api/generate streaming format.
+    """
+    current_event_type = ""
+    input_tokens = 0
+    output_tokens = 0
+    done_reason = "stop"
+
+    async for raw in source:
+        for raw_line in raw.split("\n"):
+            line = raw_line.strip()
+
+            if not line:
+                current_event_type = ""
+                continue
+
+            if line.startswith("event: "):
+                current_event_type = line[7:]
+                continue
+
+            if not line.startswith("data: "):
+                continue
+
+            payload_str = line[6:]
+            if payload_str == "[DONE]":
+                break
+
+            try:
+                payload = json.loads(payload_str)
+            except json.JSONDecodeError:
+                continue
+
+            event_type = current_event_type or payload.get("type", "")
+
+            if event_type == "message_start":
+                usage = payload.get("message", {}).get("usage", {})
+                input_tokens = usage.get("input_tokens", 0)
+
+            elif event_type == "content_block_delta":
+                delta = payload.get("delta", {})
+                if delta.get("type") == "text_delta":
+                    text = delta.get("text", "")
+                    created_at = datetime.now(UTC).isoformat()
+                    yield _ndjson(
+                        {
+                            "model": model,
+                            "created_at": created_at,
+                            "response": text,
+                            "done": False,
+                        }
+                    )
+
+            elif event_type == "message_delta":
+                delta = payload.get("delta", {})
+                done_reason = _done_reason(delta.get("stop_reason"))
+                usage = payload.get("usage", {})
+                output_tokens = usage.get("output_tokens", output_tokens)
+
+            elif event_type == "message_stop":
+                break
+
+    total_ns = int((time.monotonic() - start) * 1e9)
+    created_at = datetime.now(UTC).isoformat()
+    yield _ndjson(
+        {
+            "model": model,
+            "created_at": created_at,
+            "response": "",
+            "done": True,
+            "done_reason": done_reason,
+            "total_duration": total_ns,
+            "load_duration": 0,
+            "prompt_eval_count": input_tokens,
+            "prompt_eval_duration": 0,
+            "eval_count": output_tokens,
+            "eval_duration": total_ns,
+        }
+    )
+
+
+async def anthropic_stream_to_ollama_chat(
+    source: AsyncIterator[str],
+    *,
+    model: str,
+    start: float,
+) -> AsyncIterator[str]:
+    """Translate Anthropic SSE stream to Ollama /api/chat NDJSON.
+
+    Identical to ``anthropic_stream_to_ollama_generate`` except each
+    intermediate chunk wraps the text in a ``message`` object to match the
+    /api/chat streaming shape.
+
+    Args:
+        source: Async iterator of raw Anthropic SSE strings from the router.
+        model: Model name to embed in every chunk.
+        start: ``time.monotonic()`` value recorded before the request was sent.
+
+    Yields:
+        NDJSON lines compatible with the Ollama /api/chat streaming format.
+    """
+    current_event_type = ""
+    input_tokens = 0
+    output_tokens = 0
+    done_reason = "stop"
+
+    async for raw in source:
+        for raw_line in raw.split("\n"):
+            line = raw_line.strip()
+
+            if not line:
+                current_event_type = ""
+                continue
+
+            if line.startswith("event: "):
+                current_event_type = line[7:]
+                continue
+
+            if not line.startswith("data: "):
+                continue
+
+            payload_str = line[6:]
+            if payload_str == "[DONE]":
+                break
+
+            try:
+                payload = json.loads(payload_str)
+            except json.JSONDecodeError:
+                continue
+
+            event_type = current_event_type or payload.get("type", "")
+
+            if event_type == "message_start":
+                usage = payload.get("message", {}).get("usage", {})
+                input_tokens = usage.get("input_tokens", 0)
+
+            elif event_type == "content_block_delta":
+                delta = payload.get("delta", {})
+                if delta.get("type") == "text_delta":
+                    text = delta.get("text", "")
+                    created_at = datetime.now(UTC).isoformat()
+                    yield _ndjson(
+                        {
+                            "model": model,
+                            "created_at": created_at,
+                            "message": {"role": "assistant", "content": text},
+                            "done": False,
+                        }
+                    )
+
+            elif event_type == "message_delta":
+                delta = payload.get("delta", {})
+                done_reason = _done_reason(delta.get("stop_reason"))
+                usage = payload.get("usage", {})
+                output_tokens = usage.get("output_tokens", output_tokens)
+
+            elif event_type == "message_stop":
+                break
+
+    total_ns = int((time.monotonic() - start) * 1e9)
+    created_at = datetime.now(UTC).isoformat()
+    yield _ndjson(
+        {
+            "model": model,
+            "created_at": created_at,
+            "message": {"role": "assistant", "content": ""},
+            "done": True,
+            "done_reason": done_reason,
+            "total_duration": total_ns,
+            "load_duration": 0,
+            "prompt_eval_count": input_tokens,
+            "prompt_eval_duration": 0,
+            "eval_count": output_tokens,
+            "eval_duration": total_ns,
+        }
+    )

--- a/src/bifrost/inbound/ollama.py
+++ b/src/bifrost/inbound/ollama.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import json
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from datetime import UTC, datetime
 from typing import Any
 
@@ -27,8 +27,7 @@ from bifrost.translation.models import (
     AnthropicRequest,
     AnthropicResponse,
     Message,
-    TextBlock,
-    ThinkingBlock,
+    extract_text_from_response,
 )
 
 # ---------------------------------------------------------------------------
@@ -157,17 +156,6 @@ def ollama_chat_to_anthropic(req: OllamaChatRequest) -> AnthropicRequest:
 # ---------------------------------------------------------------------------
 
 
-def _extract_response_text(response: AnthropicResponse) -> str:
-    """Flatten Anthropic content blocks to a plain string for Ollama."""
-    parts: list[str] = []
-    for block in response.content:
-        if isinstance(block, TextBlock):
-            parts.append(block.text)
-        elif isinstance(block, ThinkingBlock):
-            parts.append(f"<thinking>{block.thinking}</thinking>")
-    return "".join(parts)
-
-
 def _done_reason(stop_reason: str | None) -> str:
     """Map Anthropic stop_reason to an Ollama done_reason string."""
     mapping = {
@@ -186,7 +174,7 @@ def anthropic_response_to_ollama_generate(
     total_duration_ns: int,
 ) -> dict[str, Any]:
     """Convert an Anthropic response to Ollama /api/generate non-streaming format."""
-    text = _extract_response_text(response)
+    text = extract_text_from_response(response)
     return {
         "model": response.model,
         "created_at": created_at,
@@ -209,7 +197,7 @@ def anthropic_response_to_ollama_chat(
     total_duration_ns: int,
 ) -> dict[str, Any]:
     """Convert an Anthropic response to Ollama /api/chat non-streaming format."""
-    text = _extract_response_text(response)
+    text = extract_text_from_response(response)
     return {
         "model": response.model,
         "created_at": created_at,
@@ -235,6 +223,93 @@ def _ndjson(obj: dict[str, Any]) -> str:
     return json.dumps(obj) + "\n"
 
 
+async def _parse_anthropic_sse_to_ollama(
+    source: AsyncIterator[str],
+    *,
+    model: str,
+    start: float,
+    intermediate_chunk: Callable[[str, str, str], dict[str, Any]],
+    final_chunk: Callable[[str, str, str, int, int, int], dict[str, Any]],
+) -> AsyncIterator[str]:
+    """Parse Anthropic SSE events and yield Ollama NDJSON lines.
+
+    This is the shared core for both /api/generate and /api/chat streaming.
+    The two callables control the chunk shape for each endpoint:
+
+    - ``intermediate_chunk(model, created_at, text)`` — called for each text
+      delta; should return a dict with ``"done": false``.
+    - ``final_chunk(model, created_at, done_reason, total_ns, input_tokens,
+      output_tokens)`` — called once after the stream ends; should return a
+      dict with ``"done": true`` and timing / token metadata.
+
+    Args:
+        source: Async iterator of raw Anthropic SSE strings from the router.
+        model: Model name passed through to each chunk builder.
+        start: ``time.monotonic()`` value recorded before the request was sent.
+        intermediate_chunk: Callable that builds intermediate NDJSON payloads.
+        final_chunk: Callable that builds the terminal NDJSON payload.
+
+    Yields:
+        Newline-terminated JSON strings (NDJSON).
+    """
+    current_event_type = ""
+    input_tokens = 0
+    output_tokens = 0
+    done_reason = "stop"
+
+    async for raw in source:
+        for raw_line in raw.split("\n"):
+            line = raw_line.strip()
+
+            if not line:
+                current_event_type = ""
+                continue
+
+            if line.startswith("event: "):
+                current_event_type = line[7:]
+                continue
+
+            if not line.startswith("data: "):
+                continue
+
+            payload_str = line[6:]
+            if payload_str == "[DONE]":
+                break
+
+            try:
+                payload = json.loads(payload_str)
+            except json.JSONDecodeError:
+                continue
+
+            event_type = current_event_type or payload.get("type", "")
+
+            if event_type == "message_start":
+                usage = payload.get("message", {}).get("usage", {})
+                input_tokens = usage.get("input_tokens", 0)
+
+            elif event_type == "content_block_delta":
+                delta = payload.get("delta", {})
+                if delta.get("type") == "text_delta":
+                    text = delta.get("text", "")
+                    created_at = datetime.now(UTC).isoformat()
+                    yield _ndjson(intermediate_chunk(model, created_at, text))
+
+            elif event_type == "message_delta":
+                delta = payload.get("delta", {})
+                done_reason = _done_reason(delta.get("stop_reason"))
+                usage = payload.get("usage", {})
+                output_tokens = usage.get("output_tokens", output_tokens)
+
+            elif event_type == "message_stop":
+                break
+
+    total_ns = int((time.monotonic() - start) * 1e9)
+    created_at = datetime.now(UTC).isoformat()
+    yield _ndjson(
+        final_chunk(model, created_at, done_reason, total_ns, input_tokens, output_tokens)
+    )
+
+
 async def anthropic_stream_to_ollama_generate(
     source: AsyncIterator[str],
     *,
@@ -255,81 +330,29 @@ async def anthropic_stream_to_ollama_generate(
     Yields:
         NDJSON lines compatible with the Ollama /api/generate streaming format.
     """
-    current_event_type = ""
-    input_tokens = 0
-    output_tokens = 0
-    done_reason = "stop"
 
-    async for raw in source:
-        for raw_line in raw.split("\n"):
-            line = raw_line.strip()
+    def _intermediate(m: str, ts: str, text: str) -> dict[str, Any]:
+        return {"model": m, "created_at": ts, "response": text, "done": False}
 
-            if not line:
-                current_event_type = ""
-                continue
-
-            if line.startswith("event: "):
-                current_event_type = line[7:]
-                continue
-
-            if not line.startswith("data: "):
-                continue
-
-            payload_str = line[6:]
-            if payload_str == "[DONE]":
-                break
-
-            try:
-                payload = json.loads(payload_str)
-            except json.JSONDecodeError:
-                continue
-
-            event_type = current_event_type or payload.get("type", "")
-
-            if event_type == "message_start":
-                usage = payload.get("message", {}).get("usage", {})
-                input_tokens = usage.get("input_tokens", 0)
-
-            elif event_type == "content_block_delta":
-                delta = payload.get("delta", {})
-                if delta.get("type") == "text_delta":
-                    text = delta.get("text", "")
-                    created_at = datetime.now(UTC).isoformat()
-                    yield _ndjson(
-                        {
-                            "model": model,
-                            "created_at": created_at,
-                            "response": text,
-                            "done": False,
-                        }
-                    )
-
-            elif event_type == "message_delta":
-                delta = payload.get("delta", {})
-                done_reason = _done_reason(delta.get("stop_reason"))
-                usage = payload.get("usage", {})
-                output_tokens = usage.get("output_tokens", output_tokens)
-
-            elif event_type == "message_stop":
-                break
-
-    total_ns = int((time.monotonic() - start) * 1e9)
-    created_at = datetime.now(UTC).isoformat()
-    yield _ndjson(
-        {
-            "model": model,
-            "created_at": created_at,
+    def _final(m: str, ts: str, dr: str, ns: int, inp: int, out: int) -> dict[str, Any]:
+        return {
+            "model": m,
+            "created_at": ts,
             "response": "",
             "done": True,
-            "done_reason": done_reason,
-            "total_duration": total_ns,
+            "done_reason": dr,
+            "total_duration": ns,
             "load_duration": 0,
-            "prompt_eval_count": input_tokens,
+            "prompt_eval_count": inp,
             "prompt_eval_duration": 0,
-            "eval_count": output_tokens,
-            "eval_duration": total_ns,
+            "eval_count": out,
+            "eval_duration": ns,
         }
-    )
+
+    async for chunk in _parse_anthropic_sse_to_ollama(
+        source, model=model, start=start, intermediate_chunk=_intermediate, final_chunk=_final
+    ):
+        yield chunk
 
 
 async def anthropic_stream_to_ollama_chat(
@@ -340,9 +363,9 @@ async def anthropic_stream_to_ollama_chat(
 ) -> AsyncIterator[str]:
     """Translate Anthropic SSE stream to Ollama /api/chat NDJSON.
 
-    Identical to ``anthropic_stream_to_ollama_generate`` except each
-    intermediate chunk wraps the text in a ``message`` object to match the
-    /api/chat streaming shape.
+    Each text delta is emitted as an intermediate chunk (``"done": false``)
+    wrapping the text in a ``message`` object.  On stream completion a final
+    chunk with ``"done": true`` and token counts is emitted.
 
     Args:
         source: Async iterator of raw Anthropic SSE strings from the router.
@@ -352,78 +375,31 @@ async def anthropic_stream_to_ollama_chat(
     Yields:
         NDJSON lines compatible with the Ollama /api/chat streaming format.
     """
-    current_event_type = ""
-    input_tokens = 0
-    output_tokens = 0
-    done_reason = "stop"
 
-    async for raw in source:
-        for raw_line in raw.split("\n"):
-            line = raw_line.strip()
+    def _intermediate(m: str, ts: str, text: str) -> dict[str, Any]:
+        return {
+            "model": m,
+            "created_at": ts,
+            "message": {"role": "assistant", "content": text},
+            "done": False,
+        }
 
-            if not line:
-                current_event_type = ""
-                continue
-
-            if line.startswith("event: "):
-                current_event_type = line[7:]
-                continue
-
-            if not line.startswith("data: "):
-                continue
-
-            payload_str = line[6:]
-            if payload_str == "[DONE]":
-                break
-
-            try:
-                payload = json.loads(payload_str)
-            except json.JSONDecodeError:
-                continue
-
-            event_type = current_event_type or payload.get("type", "")
-
-            if event_type == "message_start":
-                usage = payload.get("message", {}).get("usage", {})
-                input_tokens = usage.get("input_tokens", 0)
-
-            elif event_type == "content_block_delta":
-                delta = payload.get("delta", {})
-                if delta.get("type") == "text_delta":
-                    text = delta.get("text", "")
-                    created_at = datetime.now(UTC).isoformat()
-                    yield _ndjson(
-                        {
-                            "model": model,
-                            "created_at": created_at,
-                            "message": {"role": "assistant", "content": text},
-                            "done": False,
-                        }
-                    )
-
-            elif event_type == "message_delta":
-                delta = payload.get("delta", {})
-                done_reason = _done_reason(delta.get("stop_reason"))
-                usage = payload.get("usage", {})
-                output_tokens = usage.get("output_tokens", output_tokens)
-
-            elif event_type == "message_stop":
-                break
-
-    total_ns = int((time.monotonic() - start) * 1e9)
-    created_at = datetime.now(UTC).isoformat()
-    yield _ndjson(
-        {
-            "model": model,
-            "created_at": created_at,
+    def _final(m: str, ts: str, dr: str, ns: int, inp: int, out: int) -> dict[str, Any]:
+        return {
+            "model": m,
+            "created_at": ts,
             "message": {"role": "assistant", "content": ""},
             "done": True,
-            "done_reason": done_reason,
-            "total_duration": total_ns,
+            "done_reason": dr,
+            "total_duration": ns,
             "load_duration": 0,
-            "prompt_eval_count": input_tokens,
+            "prompt_eval_count": inp,
             "prompt_eval_duration": 0,
-            "eval_count": output_tokens,
-            "eval_duration": total_ns,
+            "eval_count": out,
+            "eval_duration": ns,
         }
-    )
+
+    async for chunk in _parse_anthropic_sse_to_ollama(
+        source, model=model, start=start, intermediate_chunk=_intermediate, final_chunk=_final
+    ):
+        yield chunk

--- a/src/bifrost/inbound/routes.py
+++ b/src/bifrost/inbound/routes.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 import time
 import uuid
+from collections.abc import Callable
 from datetime import UTC, datetime
 
 from fastapi import APIRouter, HTTPException, Request
@@ -17,7 +18,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from bifrost.auth import AgentIdentity, extract_identity
 from bifrost.config import AgentPermissions, BifrostConfig
-from bifrost.domain.models import ModelInfo, RequestLog, TokenUsage
+from bifrost.domain.models import RequestLog, TokenUsage
 from bifrost.domain.routing import RuleRejectError
 from bifrost.inbound.chat_completions import (
     OpenAIChatRequest,
@@ -158,6 +159,43 @@ def _check_model_access(
 
 
 # ---------------------------------------------------------------------------
+# Model enumeration helper (shared between /v1/models and /api/tags)
+# ---------------------------------------------------------------------------
+
+
+def _enumerate_models(config: BifrostConfig) -> list[tuple[str, str]]:
+    """Return ``(model_id, provider_name)`` pairs for all models and aliases.
+
+    Iterates configured providers first, then aliases, using a seen-set to
+    deduplicate entries that appear under multiple names.
+
+    Args:
+        config: The gateway configuration.
+
+    Returns:
+        An ordered list of ``(model_id, provider_name)`` 2-tuples.
+    """
+    result: list[tuple[str, str]] = []
+    seen: set[str] = set()
+
+    for provider_name, provider_cfg in config.providers.items():
+        for model_id in provider_cfg.models:
+            if model_id in seen:
+                continue
+            seen.add(model_id)
+            result.append((model_id, provider_name))
+
+    for alias, canonical in config.aliases.items():
+        if alias in seen:
+            continue
+        seen.add(alias)
+        provider_name = config.provider_for_model(canonical) or "unknown"
+        result.append((alias, provider_name))
+
+    return result
+
+
+# ---------------------------------------------------------------------------
 # Router factory
 # ---------------------------------------------------------------------------
 
@@ -196,33 +234,16 @@ def create_router(
         Returns an OpenAI-compatible list response including both canonical
         model IDs and any configured aliases.
         """
-        models: list[ModelInfo] = []
-        seen: set[str] = set()
-
-        for provider_name, provider_cfg in config.providers.items():
-            for model_id in provider_cfg.models:
-                if model_id in seen:
-                    continue
-                seen.add(model_id)
-                models.append(ModelInfo(id=model_id, display_name=model_id, owned_by=provider_name))
-
-        for alias, canonical in config.aliases.items():
-            if alias in seen:
-                continue
-            seen.add(alias)
-            provider_name = config.provider_for_model(canonical) or "unknown"
-            models.append(ModelInfo(id=alias, display_name=canonical, owned_by=provider_name))
-
         return {
             "object": "list",
             "data": [
                 {
-                    "id": m.id,
+                    "id": model_id,
                     "object": "model",
-                    "owned_by": m.owned_by,
-                    "display_name": m.display_name,
+                    "owned_by": provider_name,
+                    "display_name": config.aliases.get(model_id, model_id),
                 }
-                for m in models
+                for model_id, provider_name in _enumerate_models(config)
             ],
         }
 
@@ -523,6 +544,126 @@ def create_router(
     # Ollama-compatible endpoints
     # -----------------------------------------------------------------------
 
+    async def _handle_ollama_request(
+        raw_request: Request,
+        parse_fn: Callable,
+        translate_fn: Callable,
+        stream_translate_fn: Callable,
+        response_translate_fn: Callable,
+    ) -> JSONResponse | StreamingResponse:
+        """Shared handler for Ollama /api/generate and /api/chat.
+
+        Handles auth, request parsing + translation, quota enforcement,
+        routing, usage tracking, and response translation.  The four
+        callables let callers plug in endpoint-specific logic without
+        duplicating the common plumbing.
+
+        Args:
+            raw_request: The incoming FastAPI request.
+            parse_fn: ``body_dict → OllamaXxxRequest`` — validates the raw body.
+            translate_fn: ``OllamaXxxRequest → AnthropicRequest`` — converts to
+                the internal canonical format.
+            stream_translate_fn: ``(source, *, model, start) → AsyncIterator[str]``
+                — translates Anthropic SSE to Ollama NDJSON for streaming responses.
+            response_translate_fn: ``(response, *, created_at, total_duration_ns)
+                → dict`` — translates a non-streaming Anthropic response to Ollama
+                format.
+        """
+        identity = extract_identity(raw_request, auth_mode, pat_secret)
+
+        try:
+            body = await raw_request.json()
+            ollama_req = parse_fn(body)
+        except Exception as exc:
+            return ollama_error_response(422, str(exc))
+
+        request = translate_fn(ollama_req)
+
+        agent_perms = config.permissions_for_agent(identity.agent_id)
+        try:
+            _check_model_access(identity, request.model, agent_perms)
+        except HTTPException as exc:
+            return ollama_error_response(exc.status_code, exc.detail)
+
+        try:
+            warnings = await _check_quotas(identity, config, store, agent_perms)
+        except HTTPException as exc:
+            return ollama_error_response(exc.status_code, exc.detail)
+
+        request_id = str(raw_request.state.correlation_id)
+        start = time.monotonic()
+
+        try:
+            if request.stream:
+                stream_resp = StreamingResponse(
+                    stream_translate_fn(
+                        _stream_with_tracking(
+                            router.stream(request),
+                            request.model,
+                            start,
+                            identity,
+                            store,
+                            pricing_overrides,
+                            request_id,
+                        ),
+                        model=request.model,
+                        start=start,
+                    ),
+                    media_type="application/x-ndjson",
+                )
+                if warnings:
+                    stream_resp.headers[_HEADER_QUOTA_WARNING] = "; ".join(warnings)
+                return stream_resp
+
+            response = await router.complete(request)
+            latency_ms = (time.monotonic() - start) * 1000
+            usage = TokenUsage(
+                input_tokens=response.usage.input_tokens,
+                output_tokens=response.usage.output_tokens,
+                cache_creation_input_tokens=0,
+                cache_read_input_tokens=0,
+            )
+            _log_request(
+                RequestLog(
+                    timestamp=datetime.now(UTC),
+                    model=request.model,
+                    usage=usage,
+                    latency_ms=latency_ms,
+                    stream=False,
+                )
+            )
+
+            cost = calculate_cost(request.model, usage, pricing_overrides)
+            await store.record(
+                UsageRecord(
+                    request_id=request_id,
+                    agent_id=identity.agent_id,
+                    tenant_id=identity.tenant_id,
+                    session_id=identity.session_id,
+                    saga_id=identity.saga_id,
+                    model=request.model,
+                    input_tokens=usage.input_tokens,
+                    output_tokens=usage.output_tokens,
+                    cost_usd=cost,
+                    timestamp=datetime.now(UTC),
+                )
+            )
+
+            created_at = datetime.now(UTC).isoformat()
+            total_ns = int(latency_ms * 1e6)
+            json_resp = JSONResponse(
+                content=response_translate_fn(
+                    response, created_at=created_at, total_duration_ns=total_ns
+                )
+            )
+            if warnings:
+                json_resp.headers[_HEADER_QUOTA_WARNING] = "; ".join(warnings)
+            return json_resp
+
+        except RouterError as exc:
+            logger.error("Routing failed: %s", exc)
+            return ollama_error_response(502, str(exc))
+
     @api_router.get("/api/tags")
     async def ollama_tags() -> dict:
         """List available models in Ollama /api/tags format.
@@ -530,41 +671,11 @@ def create_router(
         Maps the internal model registry to the Ollama model list shape so
         that tools like Open WebUI can discover available models automatically.
         """
-        models: list[dict] = []
-        seen: set[str] = set()
-
-        for provider_name, provider_cfg in config.providers.items():
-            for model_id in provider_cfg.models:
-                if model_id in seen:
-                    continue
-                seen.add(model_id)
-                models.append(
-                    {
-                        "name": model_id,
-                        "model": model_id,
-                        "modified_at": "2024-01-01T00:00:00Z",
-                        "size": 0,
-                        "digest": "",
-                        "details": {
-                            "format": "unknown",
-                            "family": provider_name,
-                            "families": None,
-                            "parameter_size": "unknown",
-                            "quantization_level": "unknown",
-                        },
-                    }
-                )
-
-        for alias in config.aliases:
-            if alias in seen:
-                continue
-            seen.add(alias)
-            canonical = config.aliases[alias]
-            provider_name = config.provider_for_model(canonical) or "unknown"
-            models.append(
+        return {
+            "models": [
                 {
-                    "name": alias,
-                    "model": alias,
+                    "name": model_id,
+                    "model": model_id,
                     "modified_at": "2024-01-01T00:00:00Z",
                     "size": 0,
                     "digest": "",
@@ -576,216 +687,42 @@ def create_router(
                         "quantization_level": "unknown",
                     },
                 }
-            )
-
-        return {"models": models}
+                for model_id, provider_name in _enumerate_models(config)
+            ]
+        }
 
     @api_router.post("/api/generate", response_model=None)
     async def ollama_generate(raw_request: Request) -> JSONResponse | StreamingResponse:
-        """Ollama /api/generate endpoint.
+        """Ollama /api/generate endpoint (prompt-based completion).
 
-        Accepts a native Ollama generate request (prompt-based completion),
-        translates it to the internal Anthropic canonical format, routes via
-        the shared ModelRouter, and returns the response in Ollama format.
-        Streaming uses newline-delimited JSON (NDJSON), not SSE.
-        """
-        identity = extract_identity(raw_request, auth_mode, pat_secret)
-
-        try:
-            body = await raw_request.json()
-            ollama_req = OllamaGenerateRequest.model_validate(body)
-        except Exception as exc:
-            return ollama_error_response(422, str(exc))
-
-        request = ollama_generate_to_anthropic(ollama_req)
-
-        agent_perms = config.permissions_for_agent(identity.agent_id)
-        try:
-            _check_model_access(identity, request.model, agent_perms)
-        except HTTPException as exc:
-            return ollama_error_response(exc.status_code, exc.detail)
-
-        try:
-            warnings = await _check_quotas(identity, config, store, agent_perms)
-        except HTTPException as exc:
-            return ollama_error_response(exc.status_code, exc.detail)
-
-        request_id = str(raw_request.state.correlation_id)
-        start = time.monotonic()
-
-        try:
-            if request.stream:
-                stream_resp = StreamingResponse(
-                    anthropic_stream_to_ollama_generate(
-                        _stream_with_tracking(
-                            router.stream(request),
-                            request.model,
-                            start,
-                            identity,
-                            store,
-                            pricing_overrides,
-                            request_id,
-                        ),
-                        model=request.model,
-                        start=start,
-                    ),
-                    media_type="application/x-ndjson",
-                )
-                if warnings:
-                    stream_resp.headers[_HEADER_QUOTA_WARNING] = "; ".join(warnings)
-                return stream_resp
-
-            response = await router.complete(request)
-            latency_ms = (time.monotonic() - start) * 1000
-            usage = TokenUsage(
-                input_tokens=response.usage.input_tokens,
-                output_tokens=response.usage.output_tokens,
-                cache_creation_input_tokens=0,
-                cache_read_input_tokens=0,
-            )
-            _log_request(
-                RequestLog(
-                    timestamp=datetime.now(UTC),
-                    model=request.model,
-                    usage=usage,
-                    latency_ms=latency_ms,
-                    stream=False,
-                )
-            )
-
-            cost = calculate_cost(request.model, usage, pricing_overrides)
-            await store.record(
-                UsageRecord(
-                    request_id=request_id,
-                    agent_id=identity.agent_id,
-                    tenant_id=identity.tenant_id,
-                    session_id=identity.session_id,
-                    saga_id=identity.saga_id,
-                    model=request.model,
-                    input_tokens=usage.input_tokens,
-                    output_tokens=usage.output_tokens,
-                    cost_usd=cost,
-                    timestamp=datetime.now(UTC),
-                )
-            )
-
-            created_at = datetime.now(UTC).isoformat()
-            total_ns = int(latency_ms * 1e6)
-            json_resp = JSONResponse(
-                content=anthropic_response_to_ollama_generate(
-                    response, created_at=created_at, total_duration_ns=total_ns
-                )
-            )
-            if warnings:
-                json_resp.headers[_HEADER_QUOTA_WARNING] = "; ".join(warnings)
-            return json_resp
-
-        except RouterError as exc:
-            logger.error("Routing failed: %s", exc)
-            return ollama_error_response(502, str(exc))
-
-    @api_router.post("/api/chat", response_model=None)
-    async def ollama_chat(raw_request: Request) -> JSONResponse | StreamingResponse:
-        """Ollama /api/chat endpoint.
-
-        Accepts a native Ollama chat request (messages-based), translates it
-        to the internal Anthropic canonical format, routes via the shared
+        Accepts a native Ollama generate request, translates it to the
+        internal Anthropic canonical format, routes via the shared
         ModelRouter, and returns the response in Ollama format.
         Streaming uses newline-delimited JSON (NDJSON), not SSE.
         """
-        identity = extract_identity(raw_request, auth_mode, pat_secret)
+        return await _handle_ollama_request(
+            raw_request,
+            OllamaGenerateRequest.model_validate,
+            ollama_generate_to_anthropic,
+            anthropic_stream_to_ollama_generate,
+            anthropic_response_to_ollama_generate,
+        )
 
-        try:
-            body = await raw_request.json()
-            ollama_req = OllamaChatRequest.model_validate(body)
-        except Exception as exc:
-            return ollama_error_response(422, str(exc))
+    @api_router.post("/api/chat", response_model=None)
+    async def ollama_chat(raw_request: Request) -> JSONResponse | StreamingResponse:
+        """Ollama /api/chat endpoint (messages-based chat).
 
-        request = ollama_chat_to_anthropic(ollama_req)
-
-        agent_perms = config.permissions_for_agent(identity.agent_id)
-        try:
-            _check_model_access(identity, request.model, agent_perms)
-        except HTTPException as exc:
-            return ollama_error_response(exc.status_code, exc.detail)
-
-        try:
-            warnings = await _check_quotas(identity, config, store, agent_perms)
-        except HTTPException as exc:
-            return ollama_error_response(exc.status_code, exc.detail)
-
-        request_id = str(raw_request.state.correlation_id)
-        start = time.monotonic()
-
-        try:
-            if request.stream:
-                stream_resp = StreamingResponse(
-                    anthropic_stream_to_ollama_chat(
-                        _stream_with_tracking(
-                            router.stream(request),
-                            request.model,
-                            start,
-                            identity,
-                            store,
-                            pricing_overrides,
-                            request_id,
-                        ),
-                        model=request.model,
-                        start=start,
-                    ),
-                    media_type="application/x-ndjson",
-                )
-                if warnings:
-                    stream_resp.headers[_HEADER_QUOTA_WARNING] = "; ".join(warnings)
-                return stream_resp
-
-            response = await router.complete(request)
-            latency_ms = (time.monotonic() - start) * 1000
-            usage = TokenUsage(
-                input_tokens=response.usage.input_tokens,
-                output_tokens=response.usage.output_tokens,
-                cache_creation_input_tokens=0,
-                cache_read_input_tokens=0,
-            )
-            _log_request(
-                RequestLog(
-                    timestamp=datetime.now(UTC),
-                    model=request.model,
-                    usage=usage,
-                    latency_ms=latency_ms,
-                    stream=False,
-                )
-            )
-
-            cost = calculate_cost(request.model, usage, pricing_overrides)
-            await store.record(
-                UsageRecord(
-                    request_id=request_id,
-                    agent_id=identity.agent_id,
-                    tenant_id=identity.tenant_id,
-                    session_id=identity.session_id,
-                    saga_id=identity.saga_id,
-                    model=request.model,
-                    input_tokens=usage.input_tokens,
-                    output_tokens=usage.output_tokens,
-                    cost_usd=cost,
-                    timestamp=datetime.now(UTC),
-                )
-            )
-
-            created_at = datetime.now(UTC).isoformat()
-            total_ns = int(latency_ms * 1e6)
-            json_resp = JSONResponse(
-                content=anthropic_response_to_ollama_chat(
-                    response, created_at=created_at, total_duration_ns=total_ns
-                )
-            )
-            if warnings:
-                json_resp.headers[_HEADER_QUOTA_WARNING] = "; ".join(warnings)
-            return json_resp
-
-        except RouterError as exc:
-            logger.error("Routing failed: %s", exc)
-            return ollama_error_response(502, str(exc))
+        Accepts a native Ollama chat request, translates it to the internal
+        Anthropic canonical format, routes via the shared ModelRouter, and
+        returns the response in Ollama format.
+        Streaming uses newline-delimited JSON (NDJSON), not SSE.
+        """
+        return await _handle_ollama_request(
+            raw_request,
+            OllamaChatRequest.model_validate,
+            ollama_chat_to_anthropic,
+            anthropic_stream_to_ollama_chat,
+            anthropic_response_to_ollama_chat,
+        )
 
     return api_router

--- a/src/bifrost/inbound/routes.py
+++ b/src/bifrost/inbound/routes.py
@@ -26,6 +26,17 @@ from bifrost.inbound.chat_completions import (
     openai_error_response,
     openai_request_to_anthropic,
 )
+from bifrost.inbound.ollama import (
+    OllamaChatRequest,
+    OllamaGenerateRequest,
+    anthropic_response_to_ollama_chat,
+    anthropic_response_to_ollama_generate,
+    anthropic_stream_to_ollama_chat,
+    anthropic_stream_to_ollama_generate,
+    ollama_chat_to_anthropic,
+    ollama_error_response,
+    ollama_generate_to_anthropic,
+)
 from bifrost.inbound.tracking import (
     _HEADER_QUOTA_WARNING,
     _log_request,
@@ -507,5 +518,274 @@ def create_router(
         except RouterError as exc:
             logger.error("Routing failed: %s", exc)
             return openai_error_response(502, str(exc), "server_error")
+
+    # -----------------------------------------------------------------------
+    # Ollama-compatible endpoints
+    # -----------------------------------------------------------------------
+
+    @api_router.get("/api/tags")
+    async def ollama_tags() -> dict:
+        """List available models in Ollama /api/tags format.
+
+        Maps the internal model registry to the Ollama model list shape so
+        that tools like Open WebUI can discover available models automatically.
+        """
+        models: list[dict] = []
+        seen: set[str] = set()
+
+        for provider_name, provider_cfg in config.providers.items():
+            for model_id in provider_cfg.models:
+                if model_id in seen:
+                    continue
+                seen.add(model_id)
+                models.append(
+                    {
+                        "name": model_id,
+                        "model": model_id,
+                        "modified_at": "2024-01-01T00:00:00Z",
+                        "size": 0,
+                        "digest": "",
+                        "details": {
+                            "format": "unknown",
+                            "family": provider_name,
+                            "families": None,
+                            "parameter_size": "unknown",
+                            "quantization_level": "unknown",
+                        },
+                    }
+                )
+
+        for alias in config.aliases:
+            if alias in seen:
+                continue
+            seen.add(alias)
+            canonical = config.aliases[alias]
+            provider_name = config.provider_for_model(canonical) or "unknown"
+            models.append(
+                {
+                    "name": alias,
+                    "model": alias,
+                    "modified_at": "2024-01-01T00:00:00Z",
+                    "size": 0,
+                    "digest": "",
+                    "details": {
+                        "format": "unknown",
+                        "family": provider_name,
+                        "families": None,
+                        "parameter_size": "unknown",
+                        "quantization_level": "unknown",
+                    },
+                }
+            )
+
+        return {"models": models}
+
+    @api_router.post("/api/generate", response_model=None)
+    async def ollama_generate(raw_request: Request) -> JSONResponse | StreamingResponse:
+        """Ollama /api/generate endpoint.
+
+        Accepts a native Ollama generate request (prompt-based completion),
+        translates it to the internal Anthropic canonical format, routes via
+        the shared ModelRouter, and returns the response in Ollama format.
+        Streaming uses newline-delimited JSON (NDJSON), not SSE.
+        """
+        identity = extract_identity(raw_request, auth_mode, pat_secret)
+
+        try:
+            body = await raw_request.json()
+            ollama_req = OllamaGenerateRequest.model_validate(body)
+        except Exception as exc:
+            return ollama_error_response(422, str(exc))
+
+        request = ollama_generate_to_anthropic(ollama_req)
+
+        agent_perms = config.permissions_for_agent(identity.agent_id)
+        try:
+            _check_model_access(identity, request.model, agent_perms)
+        except HTTPException as exc:
+            return ollama_error_response(exc.status_code, exc.detail)
+
+        try:
+            warnings = await _check_quotas(identity, config, store, agent_perms)
+        except HTTPException as exc:
+            return ollama_error_response(exc.status_code, exc.detail)
+
+        request_id = str(raw_request.state.correlation_id)
+        start = time.monotonic()
+
+        try:
+            if request.stream:
+                stream_resp = StreamingResponse(
+                    anthropic_stream_to_ollama_generate(
+                        _stream_with_tracking(
+                            router.stream(request),
+                            request.model,
+                            start,
+                            identity,
+                            store,
+                            pricing_overrides,
+                            request_id,
+                        ),
+                        model=request.model,
+                        start=start,
+                    ),
+                    media_type="application/x-ndjson",
+                )
+                if warnings:
+                    stream_resp.headers[_HEADER_QUOTA_WARNING] = "; ".join(warnings)
+                return stream_resp
+
+            response = await router.complete(request)
+            latency_ms = (time.monotonic() - start) * 1000
+            usage = TokenUsage(
+                input_tokens=response.usage.input_tokens,
+                output_tokens=response.usage.output_tokens,
+                cache_creation_input_tokens=0,
+                cache_read_input_tokens=0,
+            )
+            _log_request(
+                RequestLog(
+                    timestamp=datetime.now(UTC),
+                    model=request.model,
+                    usage=usage,
+                    latency_ms=latency_ms,
+                    stream=False,
+                )
+            )
+
+            cost = calculate_cost(request.model, usage, pricing_overrides)
+            await store.record(
+                UsageRecord(
+                    request_id=request_id,
+                    agent_id=identity.agent_id,
+                    tenant_id=identity.tenant_id,
+                    session_id=identity.session_id,
+                    saga_id=identity.saga_id,
+                    model=request.model,
+                    input_tokens=usage.input_tokens,
+                    output_tokens=usage.output_tokens,
+                    cost_usd=cost,
+                    timestamp=datetime.now(UTC),
+                )
+            )
+
+            created_at = datetime.now(UTC).isoformat()
+            total_ns = int(latency_ms * 1e6)
+            json_resp = JSONResponse(
+                content=anthropic_response_to_ollama_generate(
+                    response, created_at=created_at, total_duration_ns=total_ns
+                )
+            )
+            if warnings:
+                json_resp.headers[_HEADER_QUOTA_WARNING] = "; ".join(warnings)
+            return json_resp
+
+        except RouterError as exc:
+            logger.error("Routing failed: %s", exc)
+            return ollama_error_response(502, str(exc))
+
+    @api_router.post("/api/chat", response_model=None)
+    async def ollama_chat(raw_request: Request) -> JSONResponse | StreamingResponse:
+        """Ollama /api/chat endpoint.
+
+        Accepts a native Ollama chat request (messages-based), translates it
+        to the internal Anthropic canonical format, routes via the shared
+        ModelRouter, and returns the response in Ollama format.
+        Streaming uses newline-delimited JSON (NDJSON), not SSE.
+        """
+        identity = extract_identity(raw_request, auth_mode, pat_secret)
+
+        try:
+            body = await raw_request.json()
+            ollama_req = OllamaChatRequest.model_validate(body)
+        except Exception as exc:
+            return ollama_error_response(422, str(exc))
+
+        request = ollama_chat_to_anthropic(ollama_req)
+
+        agent_perms = config.permissions_for_agent(identity.agent_id)
+        try:
+            _check_model_access(identity, request.model, agent_perms)
+        except HTTPException as exc:
+            return ollama_error_response(exc.status_code, exc.detail)
+
+        try:
+            warnings = await _check_quotas(identity, config, store, agent_perms)
+        except HTTPException as exc:
+            return ollama_error_response(exc.status_code, exc.detail)
+
+        request_id = str(raw_request.state.correlation_id)
+        start = time.monotonic()
+
+        try:
+            if request.stream:
+                stream_resp = StreamingResponse(
+                    anthropic_stream_to_ollama_chat(
+                        _stream_with_tracking(
+                            router.stream(request),
+                            request.model,
+                            start,
+                            identity,
+                            store,
+                            pricing_overrides,
+                            request_id,
+                        ),
+                        model=request.model,
+                        start=start,
+                    ),
+                    media_type="application/x-ndjson",
+                )
+                if warnings:
+                    stream_resp.headers[_HEADER_QUOTA_WARNING] = "; ".join(warnings)
+                return stream_resp
+
+            response = await router.complete(request)
+            latency_ms = (time.monotonic() - start) * 1000
+            usage = TokenUsage(
+                input_tokens=response.usage.input_tokens,
+                output_tokens=response.usage.output_tokens,
+                cache_creation_input_tokens=0,
+                cache_read_input_tokens=0,
+            )
+            _log_request(
+                RequestLog(
+                    timestamp=datetime.now(UTC),
+                    model=request.model,
+                    usage=usage,
+                    latency_ms=latency_ms,
+                    stream=False,
+                )
+            )
+
+            cost = calculate_cost(request.model, usage, pricing_overrides)
+            await store.record(
+                UsageRecord(
+                    request_id=request_id,
+                    agent_id=identity.agent_id,
+                    tenant_id=identity.tenant_id,
+                    session_id=identity.session_id,
+                    saga_id=identity.saga_id,
+                    model=request.model,
+                    input_tokens=usage.input_tokens,
+                    output_tokens=usage.output_tokens,
+                    cost_usd=cost,
+                    timestamp=datetime.now(UTC),
+                )
+            )
+
+            created_at = datetime.now(UTC).isoformat()
+            total_ns = int(latency_ms * 1e6)
+            json_resp = JSONResponse(
+                content=anthropic_response_to_ollama_chat(
+                    response, created_at=created_at, total_duration_ns=total_ns
+                )
+            )
+            if warnings:
+                json_resp.headers[_HEADER_QUOTA_WARNING] = "; ".join(warnings)
+            return json_resp
+
+        except RouterError as exc:
+            logger.error("Routing failed: %s", exc)
+            return ollama_error_response(502, str(exc))
 
     return api_router

--- a/src/bifrost/translation/models.py
+++ b/src/bifrost/translation/models.py
@@ -192,3 +192,24 @@ STOP_REASON_TO_OPENAI: dict[str, str] = {
     "max_tokens": "length",
     "stop_sequence": "stop",
 }
+
+
+def extract_text_from_response(response: AnthropicResponse) -> str:
+    """Flatten Anthropic content blocks to a plain text string.
+
+    ``TextBlock`` content is concatenated directly; ``ThinkingBlock`` content
+    is wrapped in ``<thinking>`` tags.  All other block types are ignored.
+
+    Args:
+        response: An ``AnthropicResponse`` from the routing layer.
+
+    Returns:
+        A single string suitable for embedding in any text-based response format.
+    """
+    parts: list[str] = []
+    for block in response.content:
+        if isinstance(block, TextBlock):
+            parts.append(block.text)
+        elif isinstance(block, ThinkingBlock):
+            parts.append(f"<thinking>{block.thinking}</thinking>")
+    return "".join(parts)

--- a/tests/test_bifrost/test_ollama.py
+++ b/tests/test_bifrost/test_ollama.py
@@ -1,0 +1,714 @@
+"""Tests for the Ollama inbound interface (inbound/ollama.py and routes)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from bifrost.app import create_app
+from bifrost.config import BifrostConfig, ProviderConfig
+from bifrost.inbound.ollama import (
+    OllamaChatRequest,
+    OllamaGenerateRequest,
+    _done_reason,
+    _ndjson,
+    anthropic_response_to_ollama_chat,
+    anthropic_response_to_ollama_generate,
+    anthropic_stream_to_ollama_chat,
+    anthropic_stream_to_ollama_generate,
+    ollama_chat_to_anthropic,
+    ollama_error_response,
+    ollama_generate_to_anthropic,
+)
+from bifrost.translation.models import (
+    AnthropicResponse,
+    TextBlock,
+    ThinkingBlock,
+    UsageInfo,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(models: list[str] | None = None) -> BifrostConfig:
+    return BifrostConfig(
+        providers={"anthropic": ProviderConfig(models=models or ["claude-sonnet-4-6"])},
+    )
+
+
+def _make_response(
+    text: str = "Hello!",
+    stop_reason: str = "end_turn",
+    input_tokens: int = 10,
+    output_tokens: int = 5,
+    model: str = "claude-sonnet-4-6",
+) -> AnthropicResponse:
+    return AnthropicResponse(
+        id="msg_test",
+        content=[TextBlock(text=text)],
+        model=model,
+        stop_reason=stop_reason,
+        usage=UsageInfo(input_tokens=input_tokens, output_tokens=output_tokens),
+    )
+
+
+async def _async_iter(items: list[str]):
+    for item in items:
+        yield item
+
+
+def _parse_ndjson_lines(body: str) -> list[dict]:
+    """Parse an NDJSON response body into a list of dicts."""
+    lines = []
+    for line in body.splitlines():
+        line = line.strip()
+        if line:
+            lines.append(json.loads(line))
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# Unit: _done_reason
+# ---------------------------------------------------------------------------
+
+
+class TestDoneReason:
+    def test_end_turn_maps_to_stop(self):
+        assert _done_reason("end_turn") == "stop"
+
+    def test_max_tokens_maps_to_length(self):
+        assert _done_reason("max_tokens") == "length"
+
+    def test_tool_use_maps_to_stop(self):
+        assert _done_reason("tool_use") == "stop"
+
+    def test_stop_sequence_maps_to_stop(self):
+        assert _done_reason("stop_sequence") == "stop"
+
+    def test_none_defaults_to_stop(self):
+        assert _done_reason(None) == "stop"
+
+    def test_unknown_value_defaults_to_stop(self):
+        assert _done_reason("unknown_reason") == "stop"
+
+
+# ---------------------------------------------------------------------------
+# Unit: _ndjson
+# ---------------------------------------------------------------------------
+
+
+class TestNdjson:
+    def test_produces_newline_terminated_json(self):
+        result = _ndjson({"model": "llama3", "done": False})
+        assert result.endswith("\n")
+        parsed = json.loads(result.strip())
+        assert parsed == {"model": "llama3", "done": False}
+
+
+# ---------------------------------------------------------------------------
+# Unit: ollama_generate_to_anthropic
+# ---------------------------------------------------------------------------
+
+
+class TestOllamaGenerateToAnthropic:
+    def _req(self, **kwargs) -> OllamaGenerateRequest:
+        defaults = {"model": "claude-sonnet-4-6", "prompt": "Why is the sky blue?"}
+        defaults.update(kwargs)
+        return OllamaGenerateRequest.model_validate(defaults)
+
+    def test_basic_prompt(self):
+        result = ollama_generate_to_anthropic(self._req())
+        assert result.model == "claude-sonnet-4-6"
+        assert len(result.messages) == 1
+        assert result.messages[0].role == "user"
+        assert result.messages[0].content == "Why is the sky blue?"
+
+    def test_default_max_tokens(self):
+        result = ollama_generate_to_anthropic(self._req())
+        assert result.max_tokens == 1024
+
+    def test_num_predict_sets_max_tokens(self):
+        result = ollama_generate_to_anthropic(self._req(options={"num_predict": 512}))
+        assert result.max_tokens == 512
+
+    def test_system_forwarded(self):
+        result = ollama_generate_to_anthropic(self._req(system="You are a helpful assistant."))
+        assert result.system == "You are a helpful assistant."
+
+    def test_temperature_forwarded(self):
+        result = ollama_generate_to_anthropic(self._req(options={"temperature": 0.7}))
+        assert result.temperature == 0.7
+
+    def test_top_p_forwarded(self):
+        result = ollama_generate_to_anthropic(self._req(options={"top_p": 0.9}))
+        assert result.top_p == 0.9
+
+    def test_top_k_forwarded(self):
+        result = ollama_generate_to_anthropic(self._req(options={"top_k": 40}))
+        assert result.top_k == 40
+
+    def test_stop_forwarded(self):
+        result = ollama_generate_to_anthropic(self._req(options={"stop": ["END", "STOP"]}))
+        assert result.stop_sequences == ["END", "STOP"]
+
+    def test_stream_forwarded(self):
+        result = ollama_generate_to_anthropic(self._req(stream=False))
+        assert result.stream is False
+
+    def test_empty_prompt_gives_empty_messages(self):
+        result = ollama_generate_to_anthropic(self._req(prompt=""))
+        assert result.messages == []
+
+
+# ---------------------------------------------------------------------------
+# Unit: ollama_chat_to_anthropic
+# ---------------------------------------------------------------------------
+
+
+class TestOllamaChatToAnthropic:
+    def _req(self, **kwargs) -> OllamaChatRequest:
+        defaults = {
+            "model": "claude-sonnet-4-6",
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+        defaults.update(kwargs)
+        return OllamaChatRequest.model_validate(defaults)
+
+    def test_basic_user_message(self):
+        result = ollama_chat_to_anthropic(self._req())
+        assert len(result.messages) == 1
+        assert result.messages[0].role == "user"
+        assert result.messages[0].content == "Hello"
+
+    def test_system_message_extracted(self):
+        result = ollama_chat_to_anthropic(
+            self._req(
+                messages=[
+                    {"role": "system", "content": "Be concise."},
+                    {"role": "user", "content": "Hi"},
+                ]
+            )
+        )
+        assert result.system == "Be concise."
+        assert len(result.messages) == 1
+        assert result.messages[0].role == "user"
+
+    def test_multiple_system_messages_joined(self):
+        result = ollama_chat_to_anthropic(
+            self._req(
+                messages=[
+                    {"role": "system", "content": "Rule one."},
+                    {"role": "system", "content": "Rule two."},
+                    {"role": "user", "content": "Hi"},
+                ]
+            )
+        )
+        assert result.system == "Rule one.\n\nRule two."
+
+    def test_assistant_message_preserved(self):
+        result = ollama_chat_to_anthropic(
+            self._req(
+                messages=[
+                    {"role": "user", "content": "Hello"},
+                    {"role": "assistant", "content": "Hi there!"},
+                ]
+            )
+        )
+        assert len(result.messages) == 2
+        assert result.messages[1].role == "assistant"
+        assert result.messages[1].content == "Hi there!"
+
+    def test_no_system_when_absent(self):
+        result = ollama_chat_to_anthropic(self._req())
+        assert result.system is None
+
+    def test_options_forwarded(self):
+        result = ollama_chat_to_anthropic(
+            self._req(options={"temperature": 0.5, "num_predict": 256})
+        )
+        assert result.temperature == 0.5
+        assert result.max_tokens == 256
+
+    def test_stream_forwarded(self):
+        result = ollama_chat_to_anthropic(self._req(stream=False))
+        assert result.stream is False
+
+
+# ---------------------------------------------------------------------------
+# Unit: anthropic_response_to_ollama_generate
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicResponseToOllamaGenerate:
+    def test_basic_response(self):
+        resp = _make_response(text="42")
+        result = anthropic_response_to_ollama_generate(
+            resp, created_at="2024-01-01T00:00:00Z", total_duration_ns=1_000_000
+        )
+        assert result["response"] == "42"
+        assert result["done"] is True
+        assert result["model"] == "claude-sonnet-4-6"
+        assert result["done_reason"] == "stop"
+        assert result["prompt_eval_count"] == 10
+        assert result["eval_count"] == 5
+        assert result["total_duration"] == 1_000_000
+
+    def test_thinking_block_wrapped(self):
+        resp = AnthropicResponse(
+            id="msg_1",
+            content=[ThinkingBlock(thinking="Let me think...")],
+            model="claude-sonnet-4-6",
+            stop_reason="end_turn",
+            usage=UsageInfo(input_tokens=5, output_tokens=3),
+        )
+        result = anthropic_response_to_ollama_generate(
+            resp, created_at="2024-01-01T00:00:00Z", total_duration_ns=0
+        )
+        assert "<thinking>Let me think...</thinking>" in result["response"]
+
+    def test_max_tokens_reason(self):
+        resp = _make_response(stop_reason="max_tokens")
+        result = anthropic_response_to_ollama_generate(
+            resp, created_at="2024-01-01T00:00:00Z", total_duration_ns=0
+        )
+        assert result["done_reason"] == "length"
+
+
+# ---------------------------------------------------------------------------
+# Unit: anthropic_response_to_ollama_chat
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicResponseToOllamaChat:
+    def test_basic_response(self):
+        resp = _make_response(text="Hello!")
+        result = anthropic_response_to_ollama_chat(
+            resp, created_at="2024-01-01T00:00:00Z", total_duration_ns=0
+        )
+        assert result["message"] == {"role": "assistant", "content": "Hello!"}
+        assert result["done"] is True
+        assert result["done_reason"] == "stop"
+
+    def test_model_preserved(self):
+        resp = _make_response(model="claude-opus-4-6")
+        result = anthropic_response_to_ollama_chat(
+            resp, created_at="2024-01-01T00:00:00Z", total_duration_ns=0
+        )
+        assert result["model"] == "claude-opus-4-6"
+
+
+# ---------------------------------------------------------------------------
+# Unit: ollama_error_response
+# ---------------------------------------------------------------------------
+
+
+class TestOllamaErrorResponse:
+    def test_error_shape(self):
+        resp = ollama_error_response(422, "bad input")
+        assert resp.status_code == 422
+        body = json.loads(resp.body)
+        assert body == {"error": "bad input"}
+
+
+# ---------------------------------------------------------------------------
+# Unit: streaming translators
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicStreamToOllamaGenerate:
+    @pytest.mark.asyncio
+    async def test_yields_text_chunks_and_final_done(self):
+        sse_lines = [
+            "event: message_start\ndata: "
+            + json.dumps(
+                {
+                    "type": "message_start",
+                    "message": {"id": "m1", "usage": {"input_tokens": 8}},
+                }
+            )
+            + "\n",
+            "event: content_block_delta\ndata: "
+            + json.dumps(
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": "Hello"},
+                }
+            )
+            + "\n",
+            "event: content_block_delta\ndata: "
+            + json.dumps(
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": " world"},
+                }
+            )
+            + "\n",
+            "event: message_delta\ndata: "
+            + json.dumps(
+                {
+                    "type": "message_delta",
+                    "delta": {"stop_reason": "end_turn"},
+                    "usage": {"output_tokens": 3},
+                }
+            )
+            + "\n",
+            "event: message_stop\ndata: " + json.dumps({"type": "message_stop"}) + "\n",
+        ]
+
+        chunks = []
+        async for chunk in anthropic_stream_to_ollama_generate(
+            _async_iter(sse_lines), model="claude-sonnet-4-6", start=0.0
+        ):
+            chunks.append(json.loads(chunk.strip()))
+
+        # Intermediate text chunks (not done)
+        text_chunks = [c for c in chunks if not c["done"]]
+        assert len(text_chunks) == 2
+        assert text_chunks[0]["response"] == "Hello"
+        assert text_chunks[1]["response"] == " world"
+
+        # Final done chunk
+        done_chunks = [c for c in chunks if c["done"]]
+        assert len(done_chunks) == 1
+        assert done_chunks[0]["done_reason"] == "stop"
+        assert done_chunks[0]["prompt_eval_count"] == 8
+        assert done_chunks[0]["eval_count"] == 3
+        assert done_chunks[0]["response"] == ""
+
+    @pytest.mark.asyncio
+    async def test_empty_stream_emits_done(self):
+        chunks = []
+        async for chunk in anthropic_stream_to_ollama_generate(
+            _async_iter([]), model="claude-sonnet-4-6", start=0.0
+        ):
+            chunks.append(json.loads(chunk.strip()))
+        assert len(chunks) == 1
+        assert chunks[0]["done"] is True
+
+    @pytest.mark.asyncio
+    async def test_non_text_deltas_ignored(self):
+        sse_lines = [
+            "event: content_block_delta\ndata: "
+            + json.dumps(
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "input_json_delta", "partial_json": '{"k":'},
+                }
+            )
+            + "\n",
+        ]
+        chunks = []
+        async for chunk in anthropic_stream_to_ollama_generate(
+            _async_iter(sse_lines), model="claude-sonnet-4-6", start=0.0
+        ):
+            chunks.append(json.loads(chunk.strip()))
+        # Only the final done chunk, no intermediate chunks for non-text deltas
+        assert all(c["done"] for c in chunks)
+
+
+class TestAnthropicStreamToOllamaChat:
+    @pytest.mark.asyncio
+    async def test_yields_message_chunks_and_final_done(self):
+        sse_lines = [
+            "event: message_start\ndata: "
+            + json.dumps(
+                {
+                    "type": "message_start",
+                    "message": {"id": "m1", "usage": {"input_tokens": 5}},
+                }
+            )
+            + "\n",
+            "event: content_block_delta\ndata: "
+            + json.dumps(
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": "Hi"},
+                }
+            )
+            + "\n",
+            "event: message_delta\ndata: "
+            + json.dumps(
+                {
+                    "type": "message_delta",
+                    "delta": {"stop_reason": "end_turn"},
+                    "usage": {"output_tokens": 2},
+                }
+            )
+            + "\n",
+            "event: message_stop\ndata: " + json.dumps({"type": "message_stop"}) + "\n",
+        ]
+
+        chunks = []
+        async for chunk in anthropic_stream_to_ollama_chat(
+            _async_iter(sse_lines), model="claude-sonnet-4-6", start=0.0
+        ):
+            chunks.append(json.loads(chunk.strip()))
+
+        text_chunks = [c for c in chunks if not c["done"]]
+        assert len(text_chunks) == 1
+        assert text_chunks[0]["message"] == {"role": "assistant", "content": "Hi"}
+
+        done_chunks = [c for c in chunks if c["done"]]
+        assert len(done_chunks) == 1
+        assert done_chunks[0]["message"] == {"role": "assistant", "content": ""}
+        assert done_chunks[0]["prompt_eval_count"] == 5
+        assert done_chunks[0]["eval_count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_max_tokens_stop_reason(self):
+        sse_lines = [
+            "event: message_delta\ndata: "
+            + json.dumps(
+                {
+                    "type": "message_delta",
+                    "delta": {"stop_reason": "max_tokens"},
+                    "usage": {"output_tokens": 100},
+                }
+            )
+            + "\n",
+        ]
+        chunks = []
+        async for chunk in anthropic_stream_to_ollama_chat(
+            _async_iter(sse_lines), model="claude-sonnet-4-6", start=0.0
+        ):
+            chunks.append(json.loads(chunk.strip()))
+        done = [c for c in chunks if c["done"]]
+        assert done[0]["done_reason"] == "length"
+
+
+# ---------------------------------------------------------------------------
+# Integration: HTTP endpoints via TestClient
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client() -> TestClient:
+    config = _make_config()
+    app = create_app(config)
+    with patch("bifrost.router.ModelRouter.complete", new_callable=AsyncMock) as mock:
+        mock.return_value = _make_response()
+        with TestClient(app) as c:
+            yield c
+
+
+class TestOllamaTagsEndpoint:
+    def test_returns_models_list(self, client: TestClient):
+        resp = client.get("/api/tags")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "models" in body
+        names = [m["name"] for m in body["models"]]
+        assert "claude-sonnet-4-6" in names
+
+    def test_model_shape(self, client: TestClient):
+        resp = client.get("/api/tags")
+        model = resp.json()["models"][0]
+        assert "name" in model
+        assert "model" in model
+        assert "details" in model
+        assert "family" in model["details"]
+
+    def test_aliases_included(self):
+        config = BifrostConfig(
+            providers={"anthropic": ProviderConfig(models=["claude-sonnet-4-6"])},
+            aliases={"sonnet": "claude-sonnet-4-6"},
+        )
+        app = create_app(config)
+        with patch("bifrost.router.ModelRouter.complete", new_callable=AsyncMock) as m:
+            m.return_value = _make_response()
+            with TestClient(app) as c:
+                resp = c.get("/api/tags")
+        names = [m["name"] for m in resp.json()["models"]]
+        assert "sonnet" in names
+
+
+class TestOllamaGenerateEndpoint:
+    def test_non_streaming_response(self, client: TestClient):
+        resp = client.post(
+            "/api/generate",
+            json={"model": "claude-sonnet-4-6", "prompt": "Hello", "stream": False},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["done"] is True
+        assert "response" in body
+        assert body["model"] == "claude-sonnet-4-6"
+
+    def test_non_streaming_response_shape(self, client: TestClient):
+        resp = client.post(
+            "/api/generate",
+            json={"model": "claude-sonnet-4-6", "prompt": "Hi", "stream": False},
+        )
+        body = resp.json()
+        assert "created_at" in body
+        assert "total_duration" in body
+        assert "prompt_eval_count" in body
+        assert "eval_count" in body
+
+    def test_invalid_body_returns_422(self, client: TestClient):
+        resp = client.post("/api/generate", json={"bad": "body"})
+        assert resp.status_code == 422
+        assert "error" in resp.json()
+
+    def test_streaming_response(self):
+        config = _make_config()
+        app = create_app(config)
+
+        async def _fake_stream(_request):
+            sse = [
+                "event: message_start\ndata: "
+                + json.dumps(
+                    {
+                        "type": "message_start",
+                        "message": {"id": "m1", "usage": {"input_tokens": 3}},
+                    }
+                )
+                + "\n",
+                "event: content_block_delta\ndata: "
+                + json.dumps(
+                    {
+                        "type": "content_block_delta",
+                        "index": 0,
+                        "delta": {"type": "text_delta", "text": "Hi"},
+                    }
+                )
+                + "\n",
+                "event: message_delta\ndata: "
+                + json.dumps(
+                    {
+                        "type": "message_delta",
+                        "delta": {"stop_reason": "end_turn"},
+                        "usage": {"output_tokens": 1},
+                    }
+                )
+                + "\n",
+                "event: message_stop\ndata: " + json.dumps({"type": "message_stop"}) + "\n",
+            ]
+            for s in sse:
+                yield s
+
+        with patch("bifrost.router.ModelRouter.stream", return_value=_fake_stream(None)):
+            with TestClient(app) as c:
+                resp = c.post(
+                    "/api/generate",
+                    json={"model": "claude-sonnet-4-6", "prompt": "Hi", "stream": True},
+                )
+        assert resp.status_code == 200
+        lines = _parse_ndjson_lines(resp.text)
+        assert len(lines) >= 2
+        assert any(ln["done"] for ln in lines)
+        assert any(not ln["done"] and ln["response"] == "Hi" for ln in lines)
+
+
+class TestOllamaChatEndpoint:
+    def test_non_streaming_response(self, client: TestClient):
+        resp = client.post(
+            "/api/chat",
+            json={
+                "model": "claude-sonnet-4-6",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": False,
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["done"] is True
+        assert "message" in body
+        assert body["message"]["role"] == "assistant"
+
+    def test_non_streaming_response_shape(self, client: TestClient):
+        resp = client.post(
+            "/api/chat",
+            json={
+                "model": "claude-sonnet-4-6",
+                "messages": [{"role": "user", "content": "Hi"}],
+                "stream": False,
+            },
+        )
+        body = resp.json()
+        assert "created_at" in body
+        assert "total_duration" in body
+        assert "prompt_eval_count" in body
+        assert "eval_count" in body
+
+    def test_invalid_body_returns_422(self, client: TestClient):
+        resp = client.post("/api/chat", json={"bad": "input"})
+        assert resp.status_code == 422
+        assert "error" in resp.json()
+
+    def test_streaming_response(self):
+        config = _make_config()
+        app = create_app(config)
+
+        async def _fake_stream(_request):
+            sse = [
+                "event: message_start\ndata: "
+                + json.dumps(
+                    {
+                        "type": "message_start",
+                        "message": {"id": "m1", "usage": {"input_tokens": 4}},
+                    }
+                )
+                + "\n",
+                "event: content_block_delta\ndata: "
+                + json.dumps(
+                    {
+                        "type": "content_block_delta",
+                        "index": 0,
+                        "delta": {"type": "text_delta", "text": "Sure"},
+                    }
+                )
+                + "\n",
+                "event: message_delta\ndata: "
+                + json.dumps(
+                    {
+                        "type": "message_delta",
+                        "delta": {"stop_reason": "end_turn"},
+                        "usage": {"output_tokens": 1},
+                    }
+                )
+                + "\n",
+                "event: message_stop\ndata: " + json.dumps({"type": "message_stop"}) + "\n",
+            ]
+            for s in sse:
+                yield s
+
+        with patch("bifrost.router.ModelRouter.stream", return_value=_fake_stream(None)):
+            with TestClient(app) as c:
+                resp = c.post(
+                    "/api/chat",
+                    json={
+                        "model": "claude-sonnet-4-6",
+                        "messages": [{"role": "user", "content": "Hi"}],
+                        "stream": True,
+                    },
+                )
+        assert resp.status_code == 200
+        lines = _parse_ndjson_lines(resp.text)
+        assert any(ln["done"] for ln in lines)
+        text_chunks = [ln for ln in lines if not ln["done"]]
+        assert any(ln["message"]["content"] == "Sure" for ln in text_chunks)
+
+    def test_system_message_in_chat(self, client: TestClient):
+        """System messages in chat requests should be accepted without error."""
+        resp = client.post(
+            "/api/chat",
+            json={
+                "model": "claude-sonnet-4-6",
+                "messages": [
+                    {"role": "system", "content": "You are helpful."},
+                    {"role": "user", "content": "Hi"},
+                ],
+                "stream": False,
+            },
+        )
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary

Adds native Ollama API support to Bifröst so tools that speak Ollama natively (Open WebUI, etc.) can point at Bifröst and have their requests routed through the full rule engine and accounting layer.

- **`POST /api/generate`** — Ollama completion format; `prompt` + optional `system` → Anthropic canonical → response back as Ollama generate shape
- **`POST /api/chat`** — Ollama chat format; `messages` array with system extraction → Anthropic canonical → response back as Ollama chat shape
- **`GET /api/tags`** — Lists available models (maps internal model registry to Ollama model list shape)

### Architecture

New `src/bifrost/inbound/ollama.py` translation module (mirrors `chat_completions.py`):

| Function | Purpose |
|---|---|
| `ollama_generate_to_anthropic` | Translate `/api/generate` → `AnthropicRequest` |
| `ollama_chat_to_anthropic` | Translate `/api/chat` → `AnthropicRequest` |
| `anthropic_response_to_ollama_generate` | Non-streaming response → Ollama generate shape |
| `anthropic_response_to_ollama_chat` | Non-streaming response → Ollama chat shape |
| `anthropic_stream_to_ollama_generate` | Anthropic SSE → Ollama NDJSON (generate) |
| `anthropic_stream_to_ollama_chat` | Anthropic SSE → Ollama NDJSON (chat) |

Ollama streaming uses newline-delimited JSON (NDJSON), not SSE — intermediate chunks have `"done": false`, the final chunk has `"done": true` with token counts and timing metadata.

All three new endpoints go through the existing auth, quota, access-control, usage-tracking, and routing layers unchanged.

### Linear

**NIU-481** — set to In Progress at start; Linear MCP was unavailable so status update is noted here. Ticket should be moved to **In Review**.

## Test plan

- [x] 47 new unit + integration tests in `tests/test_bifrost/test_ollama.py`
- [x] All 423 bifrost tests pass
- [x] `inbound/ollama.py` coverage: **91%**
- [x] `inbound/routes.py` coverage: **89%**
- [x] Overall bifrost coverage: **91%** (above 85% threshold)
- [x] `ruff check` + `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)