### PR TITLE
feat(bifrost): NIU-478 declarative routing rule engine

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -172,7 +172,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: always() && hashFiles('coverage.xml') != ''
-        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67af1b5c037d887 # v5
+        uses: codecov/codecov-action@4650159d642e33fdc30954ca22638caf0df6cac8 # v5.4.3
         with:
           files: coverage.xml
           flags: backend-volundr
@@ -213,7 +213,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: always() && hashFiles('coverage.xml') != ''
-        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67af1b5c037d887 # v5
+        uses: codecov/codecov-action@4650159d642e33fdc30954ca22638caf0df6cac8 # v5.4.3
         with:
           files: coverage.xml
           flags: backend-tyr
@@ -517,7 +517,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: always() && hashFiles('web/coverage/lcov.info') != ''
-        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67af1b5c037d887 # v5
+        uses: codecov/codecov-action@4650159d642e33fdc30954ca22638caf0df6cac8 # v5.4.3
         with:
           files: web/coverage/lcov.info
           flags: web

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -172,7 +172,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: always() && hashFiles('coverage.xml') != ''
-        uses: codecov/codecov-action@4650159d642e33fdc30954ca22638caf0df6cac8 # v5.4.3
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67af1b5c037d887 # v5
         with:
           files: coverage.xml
           flags: backend-volundr
@@ -213,7 +213,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: always() && hashFiles('coverage.xml') != ''
-        uses: codecov/codecov-action@4650159d642e33fdc30954ca22638caf0df6cac8 # v5.4.3
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67af1b5c037d887 # v5
         with:
           files: coverage.xml
           flags: backend-tyr
@@ -517,7 +517,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: always() && hashFiles('web/coverage/lcov.info') != ''
-        uses: codecov/codecov-action@4650159d642e33fdc30954ca22638caf0df6cac8 # v5.4.3
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67af1b5c037d887 # v5
         with:
           files: web/coverage/lcov.info
           flags: web

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: always() && hashFiles('coverage.xml') != ''
-        uses: codecov/codecov-action@4650159d642e33fdc30954ca22638caf0df6cac8 # v5.4.3
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67af1b5c037d887 # v5
         with:
           files: coverage.xml
           flags: backend-volundr
@@ -128,7 +128,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: always() && hashFiles('coverage.xml') != ''
-        uses: codecov/codecov-action@4650159d642e33fdc30954ca22638caf0df6cac8 # v5.4.3
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67af1b5c037d887 # v5
         with:
           files: coverage.xml
           flags: backend-tyr
@@ -389,7 +389,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: always() && hashFiles('web/coverage/lcov.info') != ''
-        uses: codecov/codecov-action@4650159d642e33fdc30954ca22638caf0df6cac8 # v5.4.3
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67af1b5c037d887 # v5
         with:
           files: web/coverage/lcov.info
           flags: web

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: always() && hashFiles('coverage.xml') != ''
-        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67af1b5c037d887 # v5
+        uses: codecov/codecov-action@4650159d642e33fdc30954ca22638caf0df6cac8 # v5.4.3
         with:
           files: coverage.xml
           flags: backend-volundr
@@ -128,7 +128,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: always() && hashFiles('coverage.xml') != ''
-        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67af1b5c037d887 # v5
+        uses: codecov/codecov-action@4650159d642e33fdc30954ca22638caf0df6cac8 # v5.4.3
         with:
           files: coverage.xml
           flags: backend-tyr
@@ -389,7 +389,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: always() && hashFiles('web/coverage/lcov.info') != ''
-        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67af1b5c037d887 # v5
+        uses: codecov/codecov-action@4650159d642e33fdc30954ca22638caf0df6cac8 # v5.4.3
         with:
           files: web/coverage/lcov.info
           flags: web

--- a/.github/workflows/feature.yaml
+++ b/.github/workflows/feature.yaml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: always() && hashFiles('coverage.xml') != ''
-        uses: codecov/codecov-action@4650159d642e33fdc30954ca22638caf0df6cac8 # v5.4.3
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67af1b5c037d887 # v5
         with:
           files: coverage.xml
           flags: backend-volundr
@@ -142,7 +142,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: always() && hashFiles('coverage.xml') != ''
-        uses: codecov/codecov-action@4650159d642e33fdc30954ca22638caf0df6cac8 # v5.4.3
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67af1b5c037d887 # v5
         with:
           files: coverage.xml
           flags: backend-tyr
@@ -203,7 +203,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: always() && hashFiles('web/coverage/lcov.info') != ''
-        uses: codecov/codecov-action@4650159d642e33fdc30954ca22638caf0df6cac8 # v5.4.3
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67af1b5c037d887 # v5
         with:
           files: web/coverage/lcov.info
           flags: web

--- a/.github/workflows/feature.yaml
+++ b/.github/workflows/feature.yaml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: always() && hashFiles('coverage.xml') != ''
-        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67af1b5c037d887 # v5
+        uses: codecov/codecov-action@4650159d642e33fdc30954ca22638caf0df6cac8 # v5.4.3
         with:
           files: coverage.xml
           flags: backend-volundr
@@ -142,7 +142,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: always() && hashFiles('coverage.xml') != ''
-        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67af1b5c037d887 # v5
+        uses: codecov/codecov-action@4650159d642e33fdc30954ca22638caf0df6cac8 # v5.4.3
         with:
           files: coverage.xml
           flags: backend-tyr
@@ -203,7 +203,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: always() && hashFiles('web/coverage/lcov.info') != ''
-        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67af1b5c037d887 # v5
+        uses: codecov/codecov-action@4650159d642e33fdc30954ca22638caf0df6cac8 # v5.4.3
         with:
           files: web/coverage/lcov.info
           flags: web

--- a/src/bifrost/adapters/rules/yaml_engine.py
+++ b/src/bifrost/adapters/rules/yaml_engine.py
@@ -1,0 +1,171 @@
+"""YamlRuleEngine — rule engine backed by YAML-configurable rule definitions.
+
+Rules are stored as ``RuleConfig`` objects (loaded from YAML via Pydantic).
+Each rule has a ``when`` block with zero or more conditions; all conditions
+must match for the rule to fire (AND semantics).  Rules are evaluated in the
+order they appear in the config; first match wins.
+
+Supported conditions
+--------------------
+* ``model``          — request model equals this alias or model ID.
+* ``max_tokens``     — numeric comparison expression (e.g. ``'<= 512'``).
+* ``thinking``       — thinking enabled / disabled (bool).
+* ``agent_budget_pct`` — numeric comparison on remaining budget % (e.g. ``'>= 80'``).
+* ``provider``       — resolved primary provider name equals this value.
+* ``has_tools``      — request includes tool definitions (bool).
+
+Numeric comparison expressions
+-------------------------------
+Supported operators: ``<=``, ``>=``, ``<``, ``>``, ``==``, ``!=``.
+A plain number is treated as an equality check (``== N``).
+"""
+
+from __future__ import annotations
+
+import re
+
+from bifrost.config import BifrostConfig, RuleCondition, RuleConfig
+from bifrost.ports.rules import RoutingContext, RuleAction, RuleEnginePort, RuleMatch
+from bifrost.translation.models import AnthropicRequest
+
+# Pre-compiled pattern for numeric comparison expressions like '<= 512' or '>= 80'.
+_CMP_RE = re.compile(r"^\s*(<=|>=|<|>|==|!=)\s*([0-9]+(?:\.[0-9]*)?)\s*$")
+
+
+def _parse_numeric_expr(expr: str) -> tuple[str, float]:
+    """Parse a comparison expression and return ``(operator, rhs)``.
+
+    Args:
+        expr: Expression string such as ``'<= 512'`` or ``'80'``.
+
+    Returns:
+        A ``(op, rhs)`` tuple where *op* is one of
+        ``<=``, ``>=``, ``<``, ``>``, ``==``, ``!=``.
+
+    Raises:
+        ValueError: If the expression cannot be parsed.
+    """
+    m = _CMP_RE.match(expr)
+    if m:
+        return m.group(1), float(m.group(2))
+
+    # Plain number → equality
+    stripped = expr.strip()
+    try:
+        return "==", float(stripped)
+    except ValueError:
+        raise ValueError(f"Cannot parse numeric comparison expression: {expr!r}") from None
+
+
+def _compare_numeric(value: float, expr: str) -> bool:
+    """Return ``True`` if *value* satisfies the comparison *expr*.
+
+    Args:
+        value: Left-hand side of the comparison.
+        expr:  Expression string (e.g. ``'<= 512'``).
+    """
+    op, rhs = _parse_numeric_expr(expr)
+    match op:
+        case "<=":
+            return value <= rhs
+        case ">=":
+            return value >= rhs
+        case "<":
+            return value < rhs
+        case ">":
+            return value > rhs
+        case "==":
+            return value == rhs
+        case "!=":
+            return value != rhs
+        case _:
+            return False
+
+
+def _thinking_enabled(request: AnthropicRequest) -> bool:
+    """Return ``True`` if the request has extended thinking enabled."""
+    if request.thinking is None:
+        return False
+    return request.thinking.get("type") == "enabled"
+
+
+class YamlRuleEngine(RuleEnginePort):
+    """Rule engine driven by a list of ``RuleConfig`` objects.
+
+    Typically constructed by the application factory from ``BifrostConfig.rules``.
+
+    Args:
+        rules:  Ordered list of rule definitions to evaluate.
+        config: Gateway config used to resolve model aliases and providers.
+    """
+
+    def __init__(self, rules: list[RuleConfig], config: BifrostConfig) -> None:
+        self._rules = rules
+        self._config = config
+
+    def evaluate(
+        self,
+        request: AnthropicRequest,
+        context: RoutingContext,
+    ) -> RuleMatch | None:
+        """Evaluate each rule in order and return the first match.
+
+        Args:
+            request: Inbound Anthropic-format request.
+            context: Per-request routing context.
+
+        Returns:
+            The first matching ``RuleMatch``, or ``None`` if no rule fires.
+        """
+        for rule in self._rules:
+            if self._matches(rule.when, request, context):
+                return RuleMatch(
+                    rule_name=rule.name,
+                    action=RuleAction(rule.action),
+                    target=rule.target,
+                    message=rule.message,
+                )
+        return None
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _matches(
+        self,
+        condition: RuleCondition,
+        request: AnthropicRequest,
+        context: RoutingContext,
+    ) -> bool:
+        """Return ``True`` only when ALL non-None conditions in *condition* match."""
+        if condition.model is not None:
+            if request.model != condition.model:
+                return False
+
+        if condition.thinking is not None:
+            if _thinking_enabled(request) != condition.thinking:
+                return False
+
+        if condition.max_tokens is not None:
+            if not _compare_numeric(request.max_tokens, condition.max_tokens):
+                return False
+
+        if condition.has_tools is not None:
+            req_has_tools = bool(request.tools)
+            if req_has_tools != condition.has_tools:
+                return False
+
+        if condition.agent_budget_pct is not None:
+            if context.agent_budget_pct is None:
+                # Budget not available in this context — skip condition.
+                return False
+            if not _compare_numeric(context.agent_budget_pct, condition.agent_budget_pct):
+                return False
+
+        if condition.provider is not None:
+            resolved = self._config.resolve_alias(request.model)
+            providers = self._config.providers_for_model(resolved)
+            if condition.provider not in providers:
+                return False
+
+        return True

--- a/src/bifrost/app.py
+++ b/src/bifrost/app.py
@@ -19,9 +19,24 @@ from fastapi import FastAPI, Request, Response
 
 from bifrost.config import BifrostConfig
 from bifrost.inbound.routes import create_router
+from bifrost.ports.rules import RuleEnginePort
 from bifrost.ports.usage_store import UsageStore
 from bifrost.pricing import ModelPricing
 from bifrost.router import ModelRouter
+
+# ---------------------------------------------------------------------------
+# Rule engine factory
+# ---------------------------------------------------------------------------
+
+
+def _build_rule_engine(config: BifrostConfig) -> RuleEnginePort | None:
+    """Instantiate a ``YamlRuleEngine`` when rules are configured, else return ``None``."""
+    if not config.rules:
+        return None
+    from bifrost.adapters.rules.yaml_engine import YamlRuleEngine
+
+    return YamlRuleEngine(rules=config.rules, config=config)
+
 
 # ---------------------------------------------------------------------------
 # Usage store factory
@@ -73,7 +88,8 @@ def create_app(config: BifrostConfig) -> FastAPI:
     Returns:
         A configured ``FastAPI`` instance.
     """
-    router = ModelRouter(config)
+    rule_engine = _build_rule_engine(config)
+    router = ModelRouter(config, rule_engine=rule_engine)
     store = _build_usage_store(config)
     pricing_overrides = _pricing_overrides(config)
     auth_mode = config.auth_mode

--- a/src/bifrost/config.py
+++ b/src/bifrost/config.py
@@ -6,7 +6,7 @@ import os
 from enum import StrEnum
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from bifrost.auth import AuthMode
 
@@ -151,6 +151,12 @@ class RuleConfig(BaseModel):
         default=None,
         description="Rejection message returned to the caller (for action='reject').",
     )
+
+    @model_validator(mode="after")
+    def _validate_action_fields(self) -> RuleConfig:
+        if self.action == "route_to" and not self.target:
+            raise ValueError("target is required when action is 'route_to'")
+        return self
 
 
 class UsageStoreConfig(BaseModel):

--- a/src/bifrost/config.py
+++ b/src/bifrost/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from enum import StrEnum
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -101,6 +102,57 @@ class AgentPermissions(BaseModel):
     )
 
 
+class RuleCondition(BaseModel):
+    """Conditions that must all match for a rule to fire (AND semantics).
+
+    Numeric fields accept comparison expressions like ``'<= 512'`` or ``'>= 80'``.
+    Plain numbers are treated as equality checks.
+    """
+
+    model: str | None = Field(
+        default=None,
+        description="Match when the request model equals this alias or model ID.",
+    )
+    max_tokens: str | None = Field(
+        default=None,
+        description="Numeric comparison expression for max_tokens (e.g. '<= 512').",
+    )
+    thinking: bool | None = Field(
+        default=None,
+        description="Match when thinking is enabled (true) or disabled (false).",
+    )
+    agent_budget_pct: str | None = Field(
+        default=None,
+        description="Numeric comparison expression for remaining agent budget % (e.g. '>= 80').",
+    )
+    provider: str | None = Field(
+        default=None,
+        description="Match when the resolved primary provider name equals this value.",
+    )
+    has_tools: bool | None = Field(
+        default=None,
+        description="Match when the request includes tool definitions (true) or not (false).",
+    )
+
+
+class RuleConfig(BaseModel):
+    """A single declarative routing rule."""
+
+    name: str = Field(description="Human-readable rule identifier (used in logs).")
+    when: RuleCondition = Field(description="Conditions that must all match for the rule to fire.")
+    action: Literal["route_to", "reject", "log"] = Field(
+        description="Action to take when the rule matches.",
+    )
+    target: str | None = Field(
+        default=None,
+        description="Model or alias to route to (required for action='route_to').",
+    )
+    message: str | None = Field(
+        default=None,
+        description="Rejection message returned to the caller (for action='reject').",
+    )
+
+
 class UsageStoreConfig(BaseModel):
     """Configuration for the usage persistence backend."""
 
@@ -193,6 +245,15 @@ class BifrostConfig(BaseModel):
     agent_permissions: dict[str, AgentPermissions] = Field(
         default_factory=dict,
         description="Per-agent model access control and optional budget.",
+    )
+
+    # ── Routing rules ────────────────────────────────────────────────────────
+    rules: list[RuleConfig] = Field(
+        default_factory=list,
+        description=(
+            "Declarative routing rules evaluated in order before the routing strategy runs. "
+            "First match wins."
+        ),
     )
 
     # ── Usage storage ────────────────────────────────────────────────────────

--- a/src/bifrost/domain/routing.py
+++ b/src/bifrost/domain/routing.py
@@ -1,0 +1,92 @@
+"""Routing domain logic: rule evaluation before strategy selection.
+
+``apply_rules`` is the single entry-point called by the ``ModelRouter`` before
+it builds provider candidates.  It delegates to whichever ``RuleEnginePort``
+implementation is configured, and handles the three possible outcomes:
+
+* ``route_to``  — returns a copy of the request with the model overridden.
+* ``reject``    — raises ``RuleRejectError`` (callers map this to HTTP 400).
+* ``log``       — emits a full-level audit log entry, returns the request unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from bifrost.ports.rules import RoutingContext, RuleAction, RuleEnginePort
+from bifrost.translation.models import AnthropicRequest
+
+logger = logging.getLogger(__name__)
+
+
+class RuleRejectError(Exception):
+    """Raised when a routing rule rejects the request."""
+
+    def __init__(self, rule_name: str, message: str) -> None:
+        super().__init__(message)
+        self.rule_name = rule_name
+        self.message = message
+
+
+def apply_rules(
+    request: AnthropicRequest,
+    context: RoutingContext,
+    engine: RuleEnginePort | None,
+) -> AnthropicRequest:
+    """Evaluate *engine*'s rules against *request* and act on the first match.
+
+    If *engine* is ``None`` (no rules configured), the request is returned
+    unchanged.
+
+    Args:
+        request: Inbound Anthropic-format request.
+        context: Per-request routing context (agent budget, etc.).
+        engine:  Rule engine to evaluate, or ``None`` to skip.
+
+    Returns:
+        The original request, or a copy with an overridden model when a
+        ``route_to`` rule fires.
+
+    Raises:
+        RuleRejectError: When a ``reject`` rule fires.
+    """
+    if engine is None:
+        return request
+
+    match_result = engine.evaluate(request, context)
+    if match_result is None:
+        return request
+
+    match match_result.action:
+        case RuleAction.ROUTE_TO:
+            logger.debug(
+                "Rule '%s' rerouting model '%s' → '%s'",
+                match_result.rule_name,
+                request.model,
+                match_result.target,
+            )
+            return request.model_copy(update={"model": match_result.target})
+
+        case RuleAction.REJECT:
+            reject_msg = match_result.message or (
+                f"Request rejected by rule '{match_result.rule_name}'"
+            )
+            logger.info(
+                "Rule '%s' rejected request for model '%s': %s",
+                match_result.rule_name,
+                request.model,
+                reject_msg,
+            )
+            raise RuleRejectError(match_result.rule_name, reject_msg)
+
+        case RuleAction.LOG:
+            logger.info(
+                "AUDIT rule='%s' model='%s' action=log",
+                match_result.rule_name,
+                request.model,
+            )
+            return request
+
+        case _:
+            logger.warning("Unknown rule action '%s'; ignoring", match_result.action)
+            return request

--- a/src/bifrost/inbound/routes.py
+++ b/src/bifrost/inbound/routes.py
@@ -18,6 +18,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from bifrost.auth import AgentIdentity, extract_identity
 from bifrost.config import AgentPermissions, BifrostConfig
 from bifrost.domain.models import ModelInfo, RequestLog, TokenUsage
+from bifrost.domain.routing import RuleRejectError
 from bifrost.inbound.chat_completions import (
     OpenAIChatRequest,
     anthropic_response_to_openai,
@@ -307,6 +308,8 @@ def create_router(
                 json_resp.headers[_HEADER_QUOTA_WARNING] = "; ".join(warnings)
             return json_resp
 
+        except RuleRejectError as exc:
+            raise HTTPException(status_code=400, detail=exc.message) from exc
         except RouterError as exc:
             logger.error("Routing failed: %s", exc)
             raise HTTPException(status_code=502, detail=str(exc)) from exc
@@ -499,6 +502,8 @@ def create_router(
                 json_resp.headers[_HEADER_QUOTA_WARNING] = "; ".join(warnings)
             return json_resp
 
+        except RuleRejectError as exc:
+            return openai_error_response(400, exc.message, "invalid_request_error")
         except RouterError as exc:
             logger.error("Routing failed: %s", exc)
             return openai_error_response(502, str(exc), "server_error")

--- a/src/bifrost/ports/rules.py
+++ b/src/bifrost/ports/rules.py
@@ -1,0 +1,84 @@
+"""RuleEnginePort — abstract interface for declarative routing rule engines."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+from bifrost.translation.models import AnthropicRequest
+
+
+class RuleAction(StrEnum):
+    """Actions a matched rule can take."""
+
+    ROUTE_TO = "route_to"
+    """Override the model/alias used for routing."""
+
+    REJECT = "reject"
+    """Reject the request with HTTP 400."""
+
+    LOG = "log"
+    """Emit a full-level audit log entry; request continues unchanged."""
+
+
+@dataclass
+class RuleMatch:
+    """The result of a successful rule evaluation."""
+
+    rule_name: str
+    """Name of the matched rule."""
+
+    action: RuleAction
+    """Action to take."""
+
+    target: str | None = None
+    """Model or alias to route to (only for ROUTE_TO)."""
+
+    message: str | None = None
+    """Rejection message shown to the caller (only for REJECT)."""
+
+
+@dataclass
+class RoutingContext:
+    """Per-request context passed alongside the request during rule evaluation.
+
+    Carries computed values that are not present in the raw request body, such
+    as the remaining agent budget percentage.
+    """
+
+    agent_budget_pct: float | None = field(
+        default=None,
+        metadata={"description": "Fraction (0–100) of the agent's daily budget already consumed."},
+    )
+    """Remaining agent budget as a percentage (0–100).
+
+    ``None`` when the usage store has not been queried or when there is no
+    per-agent budget configured (M4 feature).
+    """
+
+
+class RuleEnginePort(ABC):
+    """Abstract interface for rule engines that evaluate routing rules.
+
+    Implementations receive the inbound request and a routing context and
+    return the first matching ``RuleMatch``, or ``None`` if no rule fires.
+    """
+
+    @abstractmethod
+    def evaluate(
+        self,
+        request: AnthropicRequest,
+        context: RoutingContext,
+    ) -> RuleMatch | None:
+        """Evaluate rules against *request* and *context*.
+
+        Rules are evaluated in order; the first match wins.
+
+        Args:
+            request: The inbound Anthropic-format request.
+            context: Extra per-request routing context.
+
+        Returns:
+            The first matching ``RuleMatch``, or ``None`` if no rule fires.
+        """

--- a/src/bifrost/router.py
+++ b/src/bifrost/router.py
@@ -14,7 +14,9 @@ from collections.abc import AsyncIterator
 import httpx
 
 from bifrost.config import BifrostConfig, ProviderConfig, RoutingStrategy
+from bifrost.domain.routing import RoutingContext, apply_rules
 from bifrost.ports.provider import ProviderError, ProviderPort
+from bifrost.ports.rules import RuleEnginePort
 from bifrost.translation.models import AnthropicRequest, AnthropicResponse
 
 logger = logging.getLogger(__name__)
@@ -61,8 +63,13 @@ class ModelRouter:
     opened until an actual request arrives.
     """
 
-    def __init__(self, config: BifrostConfig) -> None:
+    def __init__(
+        self,
+        config: BifrostConfig,
+        rule_engine: RuleEnginePort | None = None,
+    ) -> None:
         self._config = config
+        self._rule_engine = rule_engine
         self._adapters: dict[str, ProviderPort] = {}
         # Per-model request counter used by the round_robin strategy.
         self._round_robin_counters: dict[str, int] = {}
@@ -161,6 +168,7 @@ class ModelRouter:
 
         Tries candidates in order; moves to the next on retryable errors.
         """
+        request = apply_rules(request, RoutingContext(), self._rule_engine)
         candidates = self._build_candidates(request.model)
         last_exc: Exception | None = None
 
@@ -195,6 +203,7 @@ class ModelRouter:
         Failover is attempted on connection or HTTP errors before the first
         byte is yielded.
         """
+        request = apply_rules(request, RoutingContext(), self._rule_engine)
         candidates = self._build_candidates(request.model)
         last_exc: Exception | None = None
 

--- a/src/bifrost/translation/models.py
+++ b/src/bifrost/translation/models.py
@@ -111,6 +111,7 @@ class AnthropicRequest(BaseModel):
     stop_sequences: list[str] | None = None
     stream: bool = False
     metadata: dict[str, Any] | None = None
+    thinking: dict[str, Any] | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bifrost/test_rules.py
+++ b/tests/test_bifrost/test_rules.py
@@ -1,0 +1,826 @@
+"""Tests for the declarative routing rule engine (NIU-478).
+
+Covers:
+ - ports/rules.py          — RuleEnginePort, RuleMatch, RoutingContext, RuleAction
+ - adapters/rules/yaml_engine.py — YamlRuleEngine (all conditions + actions)
+ - domain/routing.py        — apply_rules(), RuleRejectError
+ - config.py                — RuleConfig, RuleCondition validation
+ - app.py                   — _build_rule_engine factory
+ - router.py                — rule evaluation wired into complete() and stream()
+ - inbound/routes.py        — RuleRejectError → HTTP 400 mapping
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from bifrost.adapters.rules.yaml_engine import YamlRuleEngine, _compare_numeric, _parse_numeric_expr
+from bifrost.app import _build_rule_engine, create_app
+from bifrost.config import BifrostConfig, ProviderConfig, RuleCondition, RuleConfig
+from bifrost.domain.routing import RuleRejectError, apply_rules
+from bifrost.ports.rules import RoutingContext, RuleAction, RuleEnginePort, RuleMatch
+from bifrost.router import ModelRouter
+from bifrost.translation.models import (
+    AnthropicRequest,
+    AnthropicResponse,
+    Message,
+    TextBlock,
+    ToolDefinition,
+    UsageInfo,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _req(
+    model: str = "gpt-4o",
+    max_tokens: int = 1024,
+    thinking: dict | None = None,
+    tools: list[ToolDefinition] | None = None,
+) -> AnthropicRequest:
+    return AnthropicRequest(
+        model=model,
+        max_tokens=max_tokens,
+        messages=[Message(role="user", content="hi")],
+        thinking=thinking,
+        tools=tools,
+    )
+
+
+def _cfg_with_rules(rules: list[RuleConfig]) -> BifrostConfig:
+    return BifrostConfig(
+        providers={"anthropic": ProviderConfig(models=["claude-sonnet-4-6"])},
+        aliases={"fast": "claude-haiku", "balanced": "claude-sonnet-4-6"},
+        rules=rules,
+    )
+
+
+def _make_response() -> AnthropicResponse:
+    return AnthropicResponse(
+        id="msg_test",
+        content=[TextBlock(text="ok")],
+        model="claude-sonnet-4-6",
+        stop_reason="end_turn",
+        usage=UsageInfo(input_tokens=5, output_tokens=3),
+    )
+
+
+# ---------------------------------------------------------------------------
+# _parse_numeric_expr
+# ---------------------------------------------------------------------------
+
+
+class TestParseNumericExpr:
+    def test_less_than_or_equal(self):
+        assert _parse_numeric_expr("<= 512") == ("<=", 512.0)
+
+    def test_greater_than_or_equal(self):
+        assert _parse_numeric_expr(">= 80") == (">=", 80.0)
+
+    def test_less_than(self):
+        assert _parse_numeric_expr("< 100") == ("<", 100.0)
+
+    def test_greater_than(self):
+        assert _parse_numeric_expr("> 0") == (">", 0.0)
+
+    def test_equal(self):
+        assert _parse_numeric_expr("== 42") == ("==", 42.0)
+
+    def test_not_equal(self):
+        assert _parse_numeric_expr("!= 0") == ("!=", 0.0)
+
+    def test_plain_number_becomes_equality(self):
+        assert _parse_numeric_expr("512") == ("==", 512.0)
+
+    def test_decimal_rhs(self):
+        assert _parse_numeric_expr(">= 0.5") == (">=", 0.5)
+
+    def test_invalid_raises_value_error(self):
+        with pytest.raises(ValueError, match="Cannot parse"):
+            _parse_numeric_expr("not-a-number")
+
+
+# ---------------------------------------------------------------------------
+# _compare_numeric
+# ---------------------------------------------------------------------------
+
+
+class TestCompareNumeric:
+    def test_lte_true(self):
+        assert _compare_numeric(512, "<= 512") is True
+
+    def test_lte_false(self):
+        assert _compare_numeric(513, "<= 512") is False
+
+    def test_gte_true(self):
+        assert _compare_numeric(80, ">= 80") is True
+
+    def test_gte_false(self):
+        assert _compare_numeric(79, ">= 80") is False
+
+    def test_lt_true(self):
+        assert _compare_numeric(99, "< 100") is True
+
+    def test_lt_false(self):
+        assert _compare_numeric(100, "< 100") is False
+
+    def test_gt_true(self):
+        assert _compare_numeric(1, "> 0") is True
+
+    def test_eq_true(self):
+        assert _compare_numeric(42, "== 42") is True
+
+    def test_ne_true(self):
+        assert _compare_numeric(1, "!= 0") is True
+
+    def test_ne_false(self):
+        assert _compare_numeric(0, "!= 0") is False
+
+    def test_plain_number_equality(self):
+        assert _compare_numeric(256, "256") is True
+
+
+# ---------------------------------------------------------------------------
+# RoutingContext
+# ---------------------------------------------------------------------------
+
+
+class TestRoutingContext:
+    def test_default_agent_budget_pct_is_none(self):
+        ctx = RoutingContext()
+        assert ctx.agent_budget_pct is None
+
+    def test_can_set_budget_pct(self):
+        ctx = RoutingContext(agent_budget_pct=85.0)
+        assert ctx.agent_budget_pct == 85.0
+
+
+# ---------------------------------------------------------------------------
+# RuleCondition and RuleConfig
+# ---------------------------------------------------------------------------
+
+
+class TestRuleCondition:
+    def test_all_fields_default_to_none(self):
+        cond = RuleCondition()
+        assert cond.model is None
+        assert cond.max_tokens is None
+        assert cond.thinking is None
+        assert cond.agent_budget_pct is None
+        assert cond.provider is None
+        assert cond.has_tools is None
+
+    def test_explicit_values(self):
+        cond = RuleCondition(model="gpt-4o", thinking=True, max_tokens="<= 512")
+        assert cond.model == "gpt-4o"
+        assert cond.thinking is True
+        assert cond.max_tokens == "<= 512"
+
+
+class TestRuleConfig:
+    def test_route_to_rule(self):
+        rule = RuleConfig(
+            name="test-rule",
+            when=RuleCondition(thinking=True),
+            action="route_to",
+            target="anthropic",
+        )
+        assert rule.name == "test-rule"
+        assert rule.action == "route_to"
+        assert rule.target == "anthropic"
+
+    def test_reject_rule(self):
+        rule = RuleConfig(
+            name="reject-rule",
+            when=RuleCondition(model="bad-model"),
+            action="reject",
+            message="Not allowed",
+        )
+        assert rule.message == "Not allowed"
+
+    def test_log_rule(self):
+        rule = RuleConfig(name="log-rule", when=RuleCondition(), action="log")
+        assert rule.action == "log"
+
+
+# ---------------------------------------------------------------------------
+# YamlRuleEngine — condition matching
+# ---------------------------------------------------------------------------
+
+
+class TestYamlRuleEngineModelCondition:
+    def test_matches_exact_model(self):
+        cfg = _cfg_with_rules([])
+        engine = YamlRuleEngine(
+            rules=[RuleConfig(name="r", when=RuleCondition(model="gpt-4o"), action="log")],
+            config=cfg,
+        )
+        assert engine.evaluate(_req(model="gpt-4o"), RoutingContext()) is not None
+
+    def test_does_not_match_different_model(self):
+        cfg = _cfg_with_rules([])
+        engine = YamlRuleEngine(
+            rules=[RuleConfig(name="r", when=RuleCondition(model="gpt-4o"), action="log")],
+            config=cfg,
+        )
+        assert engine.evaluate(_req(model="claude-sonnet-4-6"), RoutingContext()) is None
+
+
+class TestYamlRuleEngineMaxTokensCondition:
+    def test_matches_lte_512_at_boundary(self):
+        cfg = _cfg_with_rules([])
+        engine = YamlRuleEngine(
+            rules=[RuleConfig(name="r", when=RuleCondition(max_tokens="<= 512"), action="log")],
+            config=cfg,
+        )
+        assert engine.evaluate(_req(max_tokens=512), RoutingContext()) is not None
+
+    def test_does_not_match_lte_512_above(self):
+        cfg = _cfg_with_rules([])
+        engine = YamlRuleEngine(
+            rules=[RuleConfig(name="r", when=RuleCondition(max_tokens="<= 512"), action="log")],
+            config=cfg,
+        )
+        assert engine.evaluate(_req(max_tokens=513), RoutingContext()) is None
+
+    def test_matches_gte_80(self):
+        cfg = _cfg_with_rules([])
+        engine = YamlRuleEngine(
+            rules=[RuleConfig(name="r", when=RuleCondition(max_tokens=">= 1000"), action="log")],
+            config=cfg,
+        )
+        assert engine.evaluate(_req(max_tokens=1024), RoutingContext()) is not None
+
+
+class TestYamlRuleEngineThinkingCondition:
+    def test_matches_thinking_enabled(self):
+        cfg = _cfg_with_rules([])
+        engine = YamlRuleEngine(
+            rules=[RuleConfig(name="r", when=RuleCondition(thinking=True), action="log")],
+            config=cfg,
+        )
+        req = _req(thinking={"type": "enabled", "budget_tokens": 5000})
+        assert engine.evaluate(req, RoutingContext()) is not None
+
+    def test_does_not_match_thinking_disabled(self):
+        cfg = _cfg_with_rules([])
+        engine = YamlRuleEngine(
+            rules=[RuleConfig(name="r", when=RuleCondition(thinking=True), action="log")],
+            config=cfg,
+        )
+        assert engine.evaluate(_req(thinking=None), RoutingContext()) is None
+
+    def test_thinking_false_matches_when_no_thinking(self):
+        cfg = _cfg_with_rules([])
+        engine = YamlRuleEngine(
+            rules=[RuleConfig(name="r", when=RuleCondition(thinking=False), action="log")],
+            config=cfg,
+        )
+        assert engine.evaluate(_req(thinking=None), RoutingContext()) is not None
+
+    def test_thinking_disabled_type_not_enabled(self):
+        cfg = _cfg_with_rules([])
+        engine = YamlRuleEngine(
+            rules=[RuleConfig(name="r", when=RuleCondition(thinking=True), action="log")],
+            config=cfg,
+        )
+        # type != "enabled" → not considered thinking
+        req = _req(thinking={"type": "disabled"})
+        assert engine.evaluate(req, RoutingContext()) is None
+
+
+class TestYamlRuleEngineHasToolsCondition:
+    def test_matches_has_tools_true(self):
+        cfg = _cfg_with_rules([])
+        engine = YamlRuleEngine(
+            rules=[RuleConfig(name="r", when=RuleCondition(has_tools=True), action="log")],
+            config=cfg,
+        )
+        tools = [ToolDefinition(name="search", input_schema={})]
+        assert engine.evaluate(_req(tools=tools), RoutingContext()) is not None
+
+    def test_does_not_match_has_tools_true_when_no_tools(self):
+        cfg = _cfg_with_rules([])
+        engine = YamlRuleEngine(
+            rules=[RuleConfig(name="r", when=RuleCondition(has_tools=True), action="log")],
+            config=cfg,
+        )
+        assert engine.evaluate(_req(tools=None), RoutingContext()) is None
+
+    def test_matches_has_tools_false_when_no_tools(self):
+        cfg = _cfg_with_rules([])
+        engine = YamlRuleEngine(
+            rules=[RuleConfig(name="r", when=RuleCondition(has_tools=False), action="log")],
+            config=cfg,
+        )
+        assert engine.evaluate(_req(tools=None), RoutingContext()) is not None
+
+
+class TestYamlRuleEngineAgentBudgetPctCondition:
+    def test_matches_gte_80_with_context(self):
+        cfg = _cfg_with_rules([])
+        engine = YamlRuleEngine(
+            rules=[
+                RuleConfig(name="r", when=RuleCondition(agent_budget_pct=">= 80"), action="log")
+            ],
+            config=cfg,
+        )
+        ctx = RoutingContext(agent_budget_pct=85.0)
+        assert engine.evaluate(_req(), ctx) is not None
+
+    def test_does_not_match_below_threshold(self):
+        cfg = _cfg_with_rules([])
+        engine = YamlRuleEngine(
+            rules=[
+                RuleConfig(name="r", when=RuleCondition(agent_budget_pct=">= 80"), action="log")
+            ],
+            config=cfg,
+        )
+        ctx = RoutingContext(agent_budget_pct=70.0)
+        assert engine.evaluate(_req(), ctx) is None
+
+    def test_skips_when_context_budget_is_none(self):
+        cfg = _cfg_with_rules([])
+        engine = YamlRuleEngine(
+            rules=[
+                RuleConfig(name="r", when=RuleCondition(agent_budget_pct=">= 80"), action="log")
+            ],
+            config=cfg,
+        )
+        assert engine.evaluate(_req(), RoutingContext()) is None
+
+
+class TestYamlRuleEngineProviderCondition:
+    def test_matches_correct_provider(self):
+        cfg = BifrostConfig(
+            providers={"anthropic": ProviderConfig(models=["claude-sonnet-4-6"])},
+            rules=[],
+        )
+        engine = YamlRuleEngine(
+            rules=[RuleConfig(name="r", when=RuleCondition(provider="anthropic"), action="log")],
+            config=cfg,
+        )
+        assert engine.evaluate(_req(model="claude-sonnet-4-6"), RoutingContext()) is not None
+
+    def test_does_not_match_wrong_provider(self):
+        cfg = BifrostConfig(
+            providers={"anthropic": ProviderConfig(models=["claude-sonnet-4-6"])},
+            rules=[],
+        )
+        engine = YamlRuleEngine(
+            rules=[RuleConfig(name="r", when=RuleCondition(provider="openai"), action="log")],
+            config=cfg,
+        )
+        assert engine.evaluate(_req(model="claude-sonnet-4-6"), RoutingContext()) is None
+
+    def test_provider_via_alias(self):
+        cfg = BifrostConfig(
+            providers={"anthropic": ProviderConfig(models=["claude-sonnet-4-6"])},
+            aliases={"sonnet": "claude-sonnet-4-6"},
+            rules=[],
+        )
+        engine = YamlRuleEngine(
+            rules=[RuleConfig(name="r", when=RuleCondition(provider="anthropic"), action="log")],
+            config=cfg,
+        )
+        assert engine.evaluate(_req(model="sonnet"), RoutingContext()) is not None
+
+
+class TestYamlRuleEngineMultipleConditions:
+    def test_all_conditions_must_match(self):
+        cfg = _cfg_with_rules([])
+        engine = YamlRuleEngine(
+            rules=[
+                RuleConfig(
+                    name="r",
+                    when=RuleCondition(max_tokens="<= 512", thinking=False),
+                    action="log",
+                )
+            ],
+            config=cfg,
+        )
+        # Both conditions match
+        assert engine.evaluate(_req(max_tokens=256), RoutingContext()) is not None
+        # Only max_tokens matches, thinking doesn't
+        assert (
+            engine.evaluate(_req(max_tokens=256, thinking={"type": "enabled"}), RoutingContext())
+            is None
+        )
+        # Only thinking matches, max_tokens doesn't
+        assert engine.evaluate(_req(max_tokens=1024), RoutingContext()) is None
+
+    def test_empty_when_matches_all_requests(self):
+        cfg = _cfg_with_rules([])
+        engine = YamlRuleEngine(
+            rules=[RuleConfig(name="catch-all", when=RuleCondition(), action="log")],
+            config=cfg,
+        )
+        assert engine.evaluate(_req(), RoutingContext()) is not None
+
+
+class TestYamlRuleEngineFirstMatchWins:
+    def test_first_matching_rule_fires(self):
+        cfg = _cfg_with_rules([])
+        engine = YamlRuleEngine(
+            rules=[
+                RuleConfig(name="first", when=RuleCondition(model="gpt-4o"), action="log"),
+                RuleConfig(
+                    name="second",
+                    when=RuleCondition(model="gpt-4o"),
+                    action="reject",
+                    message="nope",
+                ),
+            ],
+            config=cfg,
+        )
+        result = engine.evaluate(_req(model="gpt-4o"), RoutingContext())
+        assert result is not None
+        assert result.rule_name == "first"
+        assert result.action == RuleAction.LOG
+
+    def test_no_rules_returns_none(self):
+        cfg = _cfg_with_rules([])
+        engine = YamlRuleEngine(rules=[], config=cfg)
+        assert engine.evaluate(_req(), RoutingContext()) is None
+
+    def test_no_matching_rule_returns_none(self):
+        cfg = _cfg_with_rules([])
+        engine = YamlRuleEngine(
+            rules=[RuleConfig(name="r", when=RuleCondition(model="other"), action="log")],
+            config=cfg,
+        )
+        assert engine.evaluate(_req(model="gpt-4o"), RoutingContext()) is None
+
+
+class TestYamlRuleEngineActions:
+    def test_route_to_returns_correct_match(self):
+        cfg = _cfg_with_rules([])
+        engine = YamlRuleEngine(
+            rules=[
+                RuleConfig(
+                    name="r",
+                    when=RuleCondition(thinking=True),
+                    action="route_to",
+                    target="anthropic",
+                )
+            ],
+            config=cfg,
+        )
+        req = _req(thinking={"type": "enabled", "budget_tokens": 5000})
+        result = engine.evaluate(req, RoutingContext())
+        assert result is not None
+        assert result.action == RuleAction.ROUTE_TO
+        assert result.target == "anthropic"
+
+    def test_reject_returns_correct_match(self):
+        cfg = _cfg_with_rules([])
+        engine = YamlRuleEngine(
+            rules=[
+                RuleConfig(
+                    name="r",
+                    when=RuleCondition(model="forbidden"),
+                    action="reject",
+                    message="Model is not allowed",
+                )
+            ],
+            config=cfg,
+        )
+        result = engine.evaluate(_req(model="forbidden"), RoutingContext())
+        assert result is not None
+        assert result.action == RuleAction.REJECT
+        assert result.message == "Model is not allowed"
+
+    def test_log_returns_correct_match(self):
+        cfg = _cfg_with_rules([])
+        engine = YamlRuleEngine(
+            rules=[RuleConfig(name="audit", when=RuleCondition(), action="log")],
+            config=cfg,
+        )
+        result = engine.evaluate(_req(), RoutingContext())
+        assert result is not None
+        assert result.action == RuleAction.LOG
+        assert result.rule_name == "audit"
+
+
+# ---------------------------------------------------------------------------
+# apply_rules()
+# ---------------------------------------------------------------------------
+
+
+class FakeRuleEngine(RuleEnginePort):
+    """Test double that returns a fixed match (or None)."""
+
+    def __init__(self, match: RuleMatch | None = None) -> None:
+        self._match = match
+
+    def evaluate(self, request: AnthropicRequest, context: RoutingContext) -> RuleMatch | None:
+        return self._match
+
+
+class TestApplyRules:
+    def test_no_engine_returns_request_unchanged(self):
+        req = _req(model="gpt-4o")
+        result = apply_rules(req, RoutingContext(), engine=None)
+        assert result is req
+
+    def test_no_match_returns_request_unchanged(self):
+        req = _req(model="gpt-4o")
+        result = apply_rules(req, RoutingContext(), engine=FakeRuleEngine(match=None))
+        assert result is req
+
+    def test_route_to_overrides_model(self):
+        req = _req(model="gpt-4o")
+        match = RuleMatch(rule_name="r", action=RuleAction.ROUTE_TO, target="claude-sonnet-4-6")
+        result = apply_rules(req, RoutingContext(), engine=FakeRuleEngine(match=match))
+        assert result.model == "claude-sonnet-4-6"
+        # Original request is not mutated
+        assert req.model == "gpt-4o"
+
+    def test_reject_raises_rule_reject_error(self):
+        req = _req(model="bad")
+        match = RuleMatch(rule_name="r", action=RuleAction.REJECT, message="Not allowed")
+        with pytest.raises(RuleRejectError) as exc_info:
+            apply_rules(req, RoutingContext(), engine=FakeRuleEngine(match=match))
+        assert exc_info.value.message == "Not allowed"
+        assert exc_info.value.rule_name == "r"
+
+    def test_reject_uses_default_message_when_none(self):
+        req = _req(model="bad")
+        match = RuleMatch(rule_name="my-rule", action=RuleAction.REJECT, message=None)
+        with pytest.raises(RuleRejectError) as exc_info:
+            apply_rules(req, RoutingContext(), engine=FakeRuleEngine(match=match))
+        assert "my-rule" in exc_info.value.message
+
+    def test_log_returns_request_unchanged(self):
+        req = _req(model="gpt-4o")
+        match = RuleMatch(rule_name="audit", action=RuleAction.LOG)
+        result = apply_rules(req, RoutingContext(), engine=FakeRuleEngine(match=match))
+        assert result is req
+
+
+# ---------------------------------------------------------------------------
+# ModelRouter integration
+# ---------------------------------------------------------------------------
+
+
+class FakeProvider:
+    def __init__(self, response=None, raises=None):
+        self._response = response or _make_response()
+        self._raises = raises
+        self.complete_calls: list = []
+        self.stream_calls: list = []
+
+    async def complete(self, request, model):
+        self.complete_calls.append((request, model))
+        if self._raises:
+            raise self._raises
+        return self._response
+
+    async def stream(self, request, model) -> AsyncIterator[str]:
+        self.stream_calls.append((request, model))
+        if self._raises:
+            raise self._raises
+        yield "data: test\n\n"
+
+    async def close(self):
+        pass
+
+
+class TestModelRouterRuleIntegrationTracked:
+    @pytest.mark.asyncio
+    async def test_complete_respects_route_to_rule(self):
+        cfg = BifrostConfig(
+            providers={
+                "anthropic": ProviderConfig(models=["claude-sonnet-4-6"]),
+                "openai": ProviderConfig(models=["gpt-4o"]),
+            },
+        )
+        match = RuleMatch(rule_name="r", action=RuleAction.ROUTE_TO, target="claude-sonnet-4-6")
+        router = ModelRouter(cfg, rule_engine=FakeRuleEngine(match=match))
+
+        anthropic_fake = FakeProvider()
+        openai_fake = FakeProvider()
+        router._adapters["anthropic"] = anthropic_fake
+        router._adapters["openai"] = openai_fake
+
+        await router.complete(_req(model="gpt-4o"))
+        assert len(anthropic_fake.complete_calls) == 1
+        assert len(openai_fake.complete_calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_complete_propagates_reject_error(self):
+        cfg = BifrostConfig(
+            providers={"anthropic": ProviderConfig(models=["claude-sonnet-4-6"])},
+        )
+        match = RuleMatch(rule_name="r", action=RuleAction.REJECT, message="Rejected")
+        router = ModelRouter(cfg, rule_engine=FakeRuleEngine(match=match))
+        with pytest.raises(RuleRejectError, match="Rejected"):
+            await router.complete(_req(model="claude-sonnet-4-6"))
+
+    @pytest.mark.asyncio
+    async def test_stream_respects_route_to_rule(self):
+        cfg = BifrostConfig(
+            providers={
+                "anthropic": ProviderConfig(models=["claude-sonnet-4-6"]),
+                "openai": ProviderConfig(models=["gpt-4o"]),
+            },
+        )
+        match = RuleMatch(rule_name="r", action=RuleAction.ROUTE_TO, target="claude-sonnet-4-6")
+        router = ModelRouter(cfg, rule_engine=FakeRuleEngine(match=match))
+        fake = FakeProvider()
+        router._adapters["anthropic"] = fake
+
+        chunks = []
+        async for chunk in router.stream(_req(model="gpt-4o")):
+            chunks.append(chunk)
+        assert chunks == ["data: test\n\n"]
+        assert len(fake.stream_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_stream_propagates_reject_error(self):
+        cfg = BifrostConfig(
+            providers={"anthropic": ProviderConfig(models=["claude-sonnet-4-6"])},
+        )
+        match = RuleMatch(rule_name="r", action=RuleAction.REJECT, message="No streaming")
+        router = ModelRouter(cfg, rule_engine=FakeRuleEngine(match=match))
+        with pytest.raises(RuleRejectError):
+            async for _ in router.stream(_req(model="claude-sonnet-4-6")):
+                pass
+
+
+# ---------------------------------------------------------------------------
+# _build_rule_engine (app factory)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildRuleEngine:
+    def test_returns_none_when_no_rules(self):
+        cfg = BifrostConfig(providers={"a": ProviderConfig(models=["m"])}, rules=[])
+        assert _build_rule_engine(cfg) is None
+
+    def test_returns_yaml_engine_when_rules_configured(self):
+        from bifrost.adapters.rules.yaml_engine import YamlRuleEngine
+
+        cfg = BifrostConfig(
+            providers={"anthropic": ProviderConfig(models=["claude-sonnet-4-6"])},
+            rules=[RuleConfig(name="r", when=RuleCondition(), action="log")],
+        )
+        engine = _build_rule_engine(cfg)
+        assert engine is not None
+        assert isinstance(engine, YamlRuleEngine)
+
+
+# ---------------------------------------------------------------------------
+# HTTP layer: RuleRejectError → 400
+# ---------------------------------------------------------------------------
+
+
+def _make_test_client_with_rules(rules: list[RuleConfig]) -> TestClient:
+    cfg = BifrostConfig(
+        providers={"anthropic": ProviderConfig(models=["claude-sonnet-4-6"])},
+        rules=rules,
+    )
+    app = create_app(cfg)
+    with patch("bifrost.router.ModelRouter.complete", new_callable=AsyncMock) as mock_complete:
+        mock_complete.side_effect = RuleRejectError("r", "Request rejected by rule 'r'")
+        client = TestClient(app, raise_server_exceptions=False)
+        return client
+
+
+class TestHttpRuleReject:
+    def test_messages_endpoint_returns_400_on_rule_reject(self):
+        cfg = BifrostConfig(
+            providers={"anthropic": ProviderConfig(models=["claude-sonnet-4-6"])},
+        )
+        app = create_app(cfg)
+
+        with patch(
+            "bifrost.router.ModelRouter.complete",
+            new_callable=AsyncMock,
+            side_effect=RuleRejectError("r", "Blocked by rule"),
+        ):
+            client = TestClient(app, raise_server_exceptions=False)
+            resp = client.post(
+                "/v1/messages",
+                json={
+                    "model": "claude-sonnet-4-6",
+                    "max_tokens": 100,
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+            )
+        assert resp.status_code == 400
+        assert "Blocked by rule" in resp.json()["detail"]
+
+    def test_chat_completions_endpoint_returns_400_on_rule_reject(self):
+        cfg = BifrostConfig(
+            providers={"anthropic": ProviderConfig(models=["claude-sonnet-4-6"])},
+        )
+        app = create_app(cfg)
+
+        with patch(
+            "bifrost.router.ModelRouter.complete",
+            new_callable=AsyncMock,
+            side_effect=RuleRejectError("r", "Blocked by rule"),
+        ):
+            client = TestClient(app, raise_server_exceptions=False)
+            resp = client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "claude-sonnet-4-6",
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+            )
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# BifrostConfig with rules field
+# ---------------------------------------------------------------------------
+
+
+class TestBifrostConfigWithRules:
+    def test_default_rules_is_empty(self):
+        cfg = BifrostConfig()
+        assert cfg.rules == []
+
+    def test_rules_deserialized_from_dict(self):
+        cfg = BifrostConfig.model_validate(
+            {
+                "providers": {},
+                "rules": [
+                    {
+                        "name": "thinking-requires-anthropic",
+                        "when": {"thinking": True},
+                        "action": "route_to",
+                        "target": "anthropic",
+                    }
+                ],
+            }
+        )
+        assert len(cfg.rules) == 1
+        assert cfg.rules[0].name == "thinking-requires-anthropic"
+        assert cfg.rules[0].when.thinking is True
+        assert cfg.rules[0].action == "route_to"
+        assert cfg.rules[0].target == "anthropic"
+
+    def test_full_example_from_spec(self):
+        """Validate the exact YAML structure from the NIU-478 task description."""
+        cfg = BifrostConfig.model_validate(
+            {
+                "providers": {},
+                "rules": [
+                    {
+                        "name": "thinking-requires-anthropic",
+                        "when": {"thinking": True},
+                        "action": "route_to",
+                        "target": "anthropic",
+                    },
+                    {
+                        "name": "small-tasks-stay-local",
+                        "when": {"max_tokens": "<= 512", "model": "fast"},
+                        "action": "route_to",
+                        "target": "local",
+                    },
+                    {
+                        "name": "force-balanced-on-budget",
+                        "when": {"agent_budget_pct": ">= 80"},
+                        "action": "route_to",
+                        "target": "balanced",
+                    },
+                ],
+            }
+        )
+        assert len(cfg.rules) == 3
+        assert cfg.rules[1].when.max_tokens == "<= 512"
+        assert cfg.rules[1].when.model == "fast"
+        assert cfg.rules[2].when.agent_budget_pct == ">= 80"
+
+
+# ---------------------------------------------------------------------------
+# AnthropicRequest thinking field
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicRequestThinking:
+    def test_thinking_defaults_to_none(self):
+        req = AnthropicRequest(
+            model="m",
+            max_tokens=10,
+            messages=[Message(role="user", content="hi")],
+        )
+        assert req.thinking is None
+
+    def test_thinking_can_be_set(self):
+        req = AnthropicRequest(
+            model="m",
+            max_tokens=10,
+            messages=[Message(role="user", content="hi")],
+            thinking={"type": "enabled", "budget_tokens": 5000},
+        )
+        assert req.thinking == {"type": "enabled", "budget_tokens": 5000}

--- a/tests/test_bifrost/test_rules.py
+++ b/tests/test_bifrost/test_rules.py
@@ -208,6 +208,28 @@ class TestRuleConfig:
         rule = RuleConfig(name="log-rule", when=RuleCondition(), action="log")
         assert rule.action == "log"
 
+    def test_route_to_without_target_raises_validation_error(self):
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="target is required"):
+            RuleConfig(name="bad", when=RuleCondition(), action="route_to", target=None)
+
+    def test_route_to_with_empty_target_raises_validation_error(self):
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="target is required"):
+            RuleConfig(name="bad", when=RuleCondition(), action="route_to", target="")
+
+    def test_reject_without_target_is_valid(self):
+        # target is not required for reject
+        rule = RuleConfig(name="r", when=RuleCondition(), action="reject")
+        assert rule.target is None
+
+    def test_log_without_target_is_valid(self):
+        # target is not required for log
+        rule = RuleConfig(name="r", when=RuleCondition(), action="log")
+        assert rule.target is None
+
 
 # ---------------------------------------------------------------------------
 # YamlRuleEngine — condition matching


### PR DESCRIPTION
## Summary

- **New port** `src/bifrost/ports/rules.py` — `RuleEnginePort` ABC with `RuleMatch`, `RoutingContext`, and `RuleAction` (route_to / reject / log)
- **New adapter** `src/bifrost/adapters/rules/yaml_engine.py` — `YamlRuleEngine` driven by `BifrostConfig.rules` YAML list
- **New domain module** `src/bifrost/domain/routing.py` — `apply_rules()` called in `ModelRouter.complete()` and `stream()` before strategy execution; `RuleRejectError` for reject actions
- **Config additions** — `RuleCondition` and `RuleConfig` Pydantic models; `BifrostConfig.rules: list[RuleConfig]` field
- **`AnthropicRequest.thinking`** — added standard Anthropic API field used by the `thinking` condition
- **HTTP wiring** — `RuleRejectError` mapped to HTTP 400 in both `/v1/messages` and `/v1/chat/completions` endpoints
- **App factory** — `_build_rule_engine()` creates `YamlRuleEngine` when rules are configured; passed to `ModelRouter`

### Supported conditions
`model`, `max_tokens` (numeric expressions e.g. `<= 512`), `thinking` (bool), `agent_budget_pct` (numeric, M4), `provider`, `has_tools` (bool)

### Supported actions
`route_to` (override model/alias), `reject` (HTTP 400 + message), `log` (audit entry, request unchanged)

### Example config
```yaml
rules:
  - name: thinking-requires-anthropic
    when:
      thinking: true
    action: route_to
    target: anthropic

  - name: small-tasks-stay-local
    when:
      max_tokens: '<= 512'
      model: fast
    action: route_to
    target: local

  - name: force-balanced-on-budget
    when:
      agent_budget_pct: '>= 80'
    action: route_to
    target: balanced
```

## Test plan

- [x] 72 new tests in `tests/test_bifrost/test_rules.py` covering all conditions, actions, edge cases, and HTTP layer
- [x] Full bifrost test suite: 468 tests, 96% coverage (threshold: 85%)
- [x] `ruff check` clean, `ruff format` applied
- [x] All conditions tested with true/false/boundary cases
- [x] Router integration tested for `complete()` and `stream()` with rule engine wired in
- [x] HTTP 400 mapping verified for both `/v1/messages` and `/v1/chat/completions`

Closes NIU-478

🤖 Generated with [Claude Code](https://claude.com/claude-code)