### PR TITLE
feat(adapters): nng PUB/SUB transport adapter — multi-process, single-node (NIU-464)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+nng = [
+    "pynng>=0.9.0",
+]
 rabbitmq = [
     "aio-pika>=9.0",
 ]

--- a/src/sleipnir/adapters/_subscriber_support.py
+++ b/src/sleipnir/adapters/_subscriber_support.py
@@ -1,0 +1,110 @@
+"""Shared helpers for Sleipnir subscriber adapters.
+
+Extracted so that both :mod:`sleipnir.adapters.in_process` and
+:mod:`sleipnir.adapters.nng_transport` can reuse the consumer loop,
+base subscription class, and ring-buffer overflow helper without
+duplicating code.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+
+from sleipnir.domain.events import SleipnirEvent
+from sleipnir.ports.events import EventHandler, Subscription
+
+
+async def consume_queue(
+    queue: asyncio.Queue[SleipnirEvent],
+    handler: EventHandler,
+) -> None:
+    """Consumer loop: read events from *queue* and invoke *handler*."""
+    while True:
+        event = await queue.get()
+        try:
+            await handler(event)
+        except Exception:
+            logging.getLogger(__name__).exception(
+                "Handler raised an exception for event %s (%s)",
+                event.event_id,
+                event.event_type,
+            )
+        finally:
+            queue.task_done()
+
+
+async def enqueue_with_overflow(
+    queue: asyncio.Queue[SleipnirEvent],
+    event: SleipnirEvent,
+    ring_buffer_depth: int,
+    log: logging.Logger,
+) -> None:
+    """Put *event* on *queue*, dropping the oldest entry on overflow.
+
+    When the queue is full the oldest event is dequeued and discarded so that
+    the producer is never blocked.  A ``WARNING`` is logged with the dropped
+    event's id and type.
+    """
+    if queue.full():
+        try:
+            dropped = queue.get_nowait()
+            queue.task_done()
+            log.warning(
+                "Ring buffer overflow (depth=%d): dropped event %s (%s)",
+                ring_buffer_depth,
+                dropped.event_id,
+                dropped.event_type,
+            )
+        except asyncio.QueueEmpty:
+            pass
+    await queue.put(event)
+
+
+class _BaseSubscription(Subscription):
+    """Subscription backed by an asyncio.Queue and a consumer task.
+
+    *remove_fn* is invoked once during :meth:`unsubscribe` to deregister this
+    subscription from its owning bus or subscriber.  It receives no arguments
+    and should remove *self* from the parent's subscription list.
+    """
+
+    def __init__(
+        self,
+        patterns: list[str],
+        queue: asyncio.Queue[SleipnirEvent],
+        task: asyncio.Task[None],
+        remove_fn: Callable[[], None],
+    ) -> None:
+        self._patterns = patterns
+        self._queue = queue
+        self._task = task
+        self._remove_fn = remove_fn
+        self._active = True
+
+    @property
+    def patterns(self) -> list[str]:
+        return self._patterns
+
+    @property
+    def active(self) -> bool:
+        return self._active
+
+    async def unsubscribe(self) -> None:
+        if not self._active:
+            return
+        self._active = False
+        self._remove_fn()
+        self._task.cancel()
+        try:
+            await self._task
+        except asyncio.CancelledError:
+            pass
+        # Drain remaining items so join() is never blocked.
+        while not self._queue.empty():
+            try:
+                self._queue.get_nowait()
+                self._queue.task_done()
+            except asyncio.QueueEmpty:
+                break

--- a/src/sleipnir/adapters/in_process.py
+++ b/src/sleipnir/adapters/in_process.py
@@ -12,74 +12,17 @@ from __future__ import annotations
 import asyncio
 import logging
 
+from sleipnir.adapters._subscriber_support import (
+    _BaseSubscription,
+    consume_queue,
+    enqueue_with_overflow,
+)
 from sleipnir.domain.events import SleipnirEvent, match_event_type
 from sleipnir.ports.events import EventHandler, SleipnirPublisher, SleipnirSubscriber, Subscription
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_RING_BUFFER_DEPTH = 1000
-
-
-async def _consume(
-    queue: asyncio.Queue[SleipnirEvent],
-    handler: EventHandler,
-) -> None:
-    """Consumer loop: read events from *queue* and invoke *handler*."""
-    while True:
-        event = await queue.get()
-        try:
-            await handler(event)
-        except Exception:
-            logger.exception(
-                "Handler raised an exception for event %s (%s)",
-                event.event_id,
-                event.event_type,
-            )
-        finally:
-            queue.task_done()
-
-
-class _InProcessSubscription(Subscription):
-    """A subscription backed by an asyncio.Queue and a consumer task."""
-
-    def __init__(
-        self,
-        patterns: list[str],
-        queue: asyncio.Queue[SleipnirEvent],
-        task: asyncio.Task[None],
-        bus: InProcessBus,
-    ) -> None:
-        self._patterns = patterns
-        self._queue = queue
-        self._task = task
-        self._bus = bus
-        self._active = True
-
-    @property
-    def patterns(self) -> list[str]:
-        return self._patterns
-
-    @property
-    def active(self) -> bool:
-        return self._active
-
-    async def unsubscribe(self) -> None:
-        if not self._active:
-            return
-        self._active = False
-        self._bus._remove_subscription(self)
-        self._task.cancel()
-        try:
-            await self._task
-        except asyncio.CancelledError:
-            pass
-        # Drain remaining items so join() is never blocked.
-        while not self._queue.empty():
-            try:
-                self._queue.get_nowait()
-                self._queue.task_done()
-            except asyncio.QueueEmpty:
-                break
 
 
 class InProcessBus(SleipnirPublisher, SleipnirSubscriber):
@@ -94,9 +37,9 @@ class InProcessBus(SleipnirPublisher, SleipnirSubscriber):
         if ring_buffer_depth < 1:
             raise ValueError(f"ring_buffer_depth must be >= 1, got {ring_buffer_depth}")
         self._ring_buffer_depth = ring_buffer_depth
-        self._subscriptions: list[_InProcessSubscription] = []
+        self._subscriptions: list[_BaseSubscription] = []
 
-    def _remove_subscription(self, sub: _InProcessSubscription) -> None:
+    def _remove_subscription(self, sub: _BaseSubscription) -> None:
         try:
             self._subscriptions.remove(sub)
         except ValueError:
@@ -120,20 +63,7 @@ class InProcessBus(SleipnirPublisher, SleipnirSubscriber):
                 continue
             if not any(match_event_type(p, event.event_type) for p in sub.patterns):
                 continue
-            queue = sub._queue
-            if queue.full():
-                try:
-                    dropped = queue.get_nowait()
-                    queue.task_done()
-                    logger.warning(
-                        "Ring buffer overflow (depth=%d): dropped event %s (%s)",
-                        self._ring_buffer_depth,
-                        dropped.event_id,
-                        dropped.event_type,
-                    )
-                except asyncio.QueueEmpty:
-                    pass
-            await queue.put(event)
+            await enqueue_with_overflow(sub._queue, event, self._ring_buffer_depth, logger)
 
     async def publish_batch(self, events: list[SleipnirEvent]) -> None:
         """Publish all *events* in iteration order."""
@@ -147,8 +77,10 @@ class InProcessBus(SleipnirPublisher, SleipnirSubscriber):
     ) -> Subscription:
         """Register *handler* for events matching any pattern in *event_types*."""
         queue: asyncio.Queue[SleipnirEvent] = asyncio.Queue(maxsize=self._ring_buffer_depth)
-        task = asyncio.create_task(_consume(queue, handler))
-        sub = _InProcessSubscription(list(event_types), queue, task, self)
+        task = asyncio.create_task(consume_queue(queue, handler))
+        sub = _BaseSubscription(
+            list(event_types), queue, task, lambda: self._remove_subscription(sub)
+        )
         self._subscriptions.append(sub)
         return sub
 

--- a/src/sleipnir/adapters/nng_transport.py
+++ b/src/sleipnir/adapters/nng_transport.py
@@ -48,6 +48,11 @@ try:
 except ImportError:
     _PYNNG_AVAILABLE = False
 
+from sleipnir.adapters._subscriber_support import (
+    _BaseSubscription,
+    consume_queue,
+    enqueue_with_overflow,
+)
 from sleipnir.adapters.serialization import deserialize, serialize
 from sleipnir.domain.events import SleipnirEvent, match_event_type
 from sleipnir.ports.events import EventHandler, SleipnirPublisher, SleipnirSubscriber, Subscription
@@ -106,6 +111,8 @@ def _nng_topics_for_patterns(patterns: list[str]) -> list[bytes]:
     - ``"ravn.*"`` → ``b"ravn."`` (namespace prefix)
     - ``"ravn.tool.*"`` → ``b"ravn.tool."`` (sub-namespace prefix)
     - ``"ravn.tool.complete"`` → ``b"ravn.tool.complete\\x00"`` (exact match)
+    - Any other pattern with wildcard characters (``*``, ``?``, ``[``) →
+      ``b""`` (receive all; application-level fnmatch filtering handles it)
     """
     topics: list[bytes] = []
     for pattern in patterns:
@@ -115,74 +122,16 @@ def _nng_topics_for_patterns(patterns: list[str]) -> list[bytes]:
             # "ravn.*" → "ravn."  (trim the star, keep the dot)
             prefix = pattern[:-1]
             topics.append(prefix.encode())
+        elif any(c in pattern for c in ("*", "?", "[")):
+            # Pattern contains wildcard characters not handled by prefix rules
+            # (e.g. "ravn.tool.?").  Subscribe to all messages and rely on
+            # application-level fnmatch filtering for correctness.
+            return [b""]
         else:
             # Exact event type: include the null separator so no other type
             # with the same prefix can slip through.
             topics.append(pattern.encode() + b"\x00")
     return topics or [b""]
-
-
-async def _consume_queue(
-    queue: asyncio.Queue[SleipnirEvent],
-    handler: EventHandler,
-) -> None:
-    """Drain *queue* and invoke *handler* for each event."""
-    while True:
-        event = await queue.get()
-        try:
-            await handler(event)
-        except Exception:
-            logger.exception(
-                "Handler raised an exception for event %s (%s)",
-                event.event_id,
-                event.event_type,
-            )
-        finally:
-            queue.task_done()
-
-
-# ---------------------------------------------------------------------------
-# Subscription handle
-# ---------------------------------------------------------------------------
-
-
-class _NngSubscription(Subscription):
-    """Active subscription backed by an asyncio.Queue and a consumer task."""
-
-    def __init__(
-        self,
-        patterns: list[str],
-        queue: asyncio.Queue[SleipnirEvent],
-        task: asyncio.Task[None],
-        owner: NngSubscriber | NngTransport,
-    ) -> None:
-        self._patterns = patterns
-        self._queue = queue
-        self._task = task
-        self._owner = owner
-        self._active = True
-
-    @property
-    def patterns(self) -> list[str]:
-        return self._patterns
-
-    @property
-    def active(self) -> bool:
-        return self._active
-
-    async def unsubscribe(self) -> None:
-        if not self._active:
-            return
-        self._active = False
-        self._owner._remove_subscription(self)
-        self._task.cancel()
-        with suppress(asyncio.CancelledError):
-            await self._task
-        # Drain the queue so join() never blocks.
-        while not self._queue.empty():
-            with suppress(asyncio.QueueEmpty):
-                self._queue.get_nowait()
-                self._queue.task_done()
 
 
 # ---------------------------------------------------------------------------
@@ -311,7 +260,7 @@ class NngSubscriber(SleipnirSubscriber):
 
         self._socket: pynng.Sub0 | None = None  # type: ignore[name-defined]
         self._recv_task: asyncio.Task[None] | None = None
-        self._subscriptions: list[_NngSubscription] = []
+        self._subscriptions: list[_BaseSubscription] = []
         self._nng_subscribed_topics: set[bytes] = set()
         self._running = False
 
@@ -361,8 +310,10 @@ class NngSubscriber(SleipnirSubscriber):
                 self._socket.subscribe(topic)
                 self._nng_subscribed_topics.add(topic)
         queue: asyncio.Queue[SleipnirEvent] = asyncio.Queue(maxsize=self._ring_buffer_depth)
-        task = asyncio.create_task(_consume_queue(queue, handler))
-        sub = _NngSubscription(list(event_types), queue, task, self)
+        task = asyncio.create_task(consume_queue(queue, handler))
+        sub = _BaseSubscription(
+            list(event_types), queue, task, lambda: self._remove_subscription(sub)
+        )
         self._subscriptions.append(sub)
         return sub
 
@@ -371,7 +322,7 @@ class NngSubscriber(SleipnirSubscriber):
         for sub in list(self._subscriptions):
             await sub._queue.join()
 
-    def _remove_subscription(self, sub: _NngSubscription) -> None:
+    def _remove_subscription(self, sub: _BaseSubscription) -> None:
         with suppress(ValueError):
             self._subscriptions.remove(sub)
 
@@ -404,18 +355,7 @@ class NngSubscriber(SleipnirSubscriber):
                 continue
             if not any(match_event_type(p, event.event_type) for p in sub.patterns):
                 continue
-            queue = sub._queue
-            if queue.full():
-                with suppress(asyncio.QueueEmpty):
-                    dropped = queue.get_nowait()
-                    queue.task_done()
-                    logger.warning(
-                        "Ring buffer overflow (depth=%d): dropped event %s (%s)",
-                        self._ring_buffer_depth,
-                        dropped.event_id,
-                        dropped.event_type,
-                    )
-            await queue.put(event)
+            await enqueue_with_overflow(sub._queue, event, self._ring_buffer_depth, logger)
 
 
 # ---------------------------------------------------------------------------
@@ -509,7 +449,7 @@ class NngTransport(SleipnirPublisher, SleipnirSubscriber):
         """Wait until every queued (already-received) event has been processed."""
         await self._subscriber.flush()
 
-    def _remove_subscription(self, sub: _NngSubscription) -> None:
+    def _remove_subscription(self, sub: _BaseSubscription) -> None:
         self._subscriber._remove_subscription(sub)
 
 

--- a/src/sleipnir/adapters/nng_transport.py
+++ b/src/sleipnir/adapters/nng_transport.py
@@ -1,0 +1,553 @@
+"""nng PUB/SUB transport adapter for Sleipnir.
+
+Multi-process, single-node event transport using pynng (nng Python bindings).
+
+Architecture
+------------
+- :class:`NngPublisher` — binds a Pub0 socket; call :meth:`~NngPublisher.start`
+  before publishing.
+- :class:`NngSubscriber` — dials a Sub0 socket; call :meth:`~NngSubscriber.start`
+  before subscribing.
+- :class:`NngTransport` — combined publisher + subscriber backed by both sockets,
+  suitable for single-process use where the same service publishes and subscribes.
+
+Wire format
+-----------
+Every nng message is::
+
+    <event_type_bytes> \\x00 <msgpack_payload>
+
+The event type prefix enables nng's native prefix-based topic filtering so that
+subscribers only receive messages matching their subscription patterns.
+
+Configuration example
+---------------------
+::
+
+    sleipnir:
+      transport: "nng"
+      address: "ipc:///tmp/sleipnir.sock"
+
+Transports
+----------
+- **IPC** (``ipc:///tmp/sleipnir.sock``) — Unix-domain socket, ~10-50 µs latency.
+- **TCP** (``tcp://localhost:9500``) — for multi-machine or container deployments.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from contextlib import suppress
+
+try:
+    import pynng
+    import pynng.exceptions
+
+    _PYNNG_AVAILABLE = True
+except ImportError:
+    _PYNNG_AVAILABLE = False
+
+from sleipnir.adapters.serialization import deserialize, serialize
+from sleipnir.domain.events import SleipnirEvent, match_event_type
+from sleipnir.ports.events import EventHandler, SleipnirPublisher, SleipnirSubscriber, Subscription
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Defaults (avoids magic numbers in business logic; values can be overridden
+# via constructor kwargs or config).
+# ---------------------------------------------------------------------------
+
+DEFAULT_IPC_ADDRESS = "ipc:///tmp/sleipnir.sock"
+DEFAULT_TCP_ADDRESS = "tcp://localhost:9500"
+
+#: How long to wait for an incoming message before looping (milliseconds).
+#: Controls shutdown responsiveness — smaller = faster stop, more CPU.
+DEFAULT_RECV_TIMEOUT_MS = 100
+
+#: Seconds to wait between bind retries when address is already in use.
+DEFAULT_BIND_RETRY_DELAY_S = 0.1
+
+#: Maximum number of bind attempts before raising.
+DEFAULT_BIND_MAX_RETRIES = 50
+
+#: Depth of each subscriber's ring buffer (events).
+DEFAULT_RING_BUFFER_DEPTH = 1000
+
+#: Milliseconds to sleep after opening sockets to let nng establish the
+#: underlying IPC/TCP connection before the first publish.
+DEFAULT_CONNECT_SETTLE_MS = 20
+
+#: Minimum reconnect interval in milliseconds.  nng's default is 1000ms which
+#: is too slow for tests and fast-restart scenarios.  50ms gives sub-second
+#: reconnection without hammering the OS.
+DEFAULT_RECONNECT_MIN_MS = 50
+
+#: Maximum reconnect interval (0 = same as min, i.e. fixed interval).
+DEFAULT_RECONNECT_MAX_MS = 0
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _nng_topics_for_patterns(patterns: list[str]) -> list[bytes]:
+    """Translate fnmatch patterns to nng topic-prefix byte strings.
+
+    nng delivers a message to a SUB socket if the message *starts with* the
+    subscribed topic bytes.  An empty-bytes subscription ``b""`` matches all
+    messages.
+
+    Rules
+    -----
+    - ``"*"`` → ``b""`` (subscribe to everything)
+    - ``"ravn.*"`` → ``b"ravn."`` (namespace prefix)
+    - ``"ravn.tool.*"`` → ``b"ravn.tool."`` (sub-namespace prefix)
+    - ``"ravn.tool.complete"`` → ``b"ravn.tool.complete\\x00"`` (exact match)
+    """
+    topics: list[bytes] = []
+    for pattern in patterns:
+        if pattern == "*":
+            return [b""]  # wildcard: receive all; short-circuit
+        if pattern.endswith(".*"):
+            # "ravn.*" → "ravn."  (trim the star, keep the dot)
+            prefix = pattern[:-1]
+            topics.append(prefix.encode())
+        else:
+            # Exact event type: include the null separator so no other type
+            # with the same prefix can slip through.
+            topics.append(pattern.encode() + b"\x00")
+    return topics or [b""]
+
+
+async def _consume_queue(
+    queue: asyncio.Queue[SleipnirEvent],
+    handler: EventHandler,
+) -> None:
+    """Drain *queue* and invoke *handler* for each event."""
+    while True:
+        event = await queue.get()
+        try:
+            await handler(event)
+        except Exception:
+            logger.exception(
+                "Handler raised an exception for event %s (%s)",
+                event.event_id,
+                event.event_type,
+            )
+        finally:
+            queue.task_done()
+
+
+# ---------------------------------------------------------------------------
+# Subscription handle
+# ---------------------------------------------------------------------------
+
+
+class _NngSubscription(Subscription):
+    """Active subscription backed by an asyncio.Queue and a consumer task."""
+
+    def __init__(
+        self,
+        patterns: list[str],
+        queue: asyncio.Queue[SleipnirEvent],
+        task: asyncio.Task[None],
+        owner: NngSubscriber | NngTransport,
+    ) -> None:
+        self._patterns = patterns
+        self._queue = queue
+        self._task = task
+        self._owner = owner
+        self._active = True
+
+    @property
+    def patterns(self) -> list[str]:
+        return self._patterns
+
+    @property
+    def active(self) -> bool:
+        return self._active
+
+    async def unsubscribe(self) -> None:
+        if not self._active:
+            return
+        self._active = False
+        self._owner._remove_subscription(self)
+        self._task.cancel()
+        with suppress(asyncio.CancelledError):
+            await self._task
+        # Drain the queue so join() never blocks.
+        while not self._queue.empty():
+            with suppress(asyncio.QueueEmpty):
+                self._queue.get_nowait()
+                self._queue.task_done()
+
+
+# ---------------------------------------------------------------------------
+# NngPublisher
+# ---------------------------------------------------------------------------
+
+
+class NngPublisher(SleipnirPublisher):
+    """nng Pub0 publisher.
+
+    Binds a PUB socket at *address* and serialises :class:`SleipnirEvent`
+    objects with msgpack before sending.
+
+    Usage::
+
+        pub = NngPublisher("ipc:///tmp/sleipnir.sock")
+        async with pub:
+            await pub.publish(event)
+    """
+
+    def __init__(
+        self,
+        address: str = DEFAULT_IPC_ADDRESS,
+        bind_retry_delay_s: float = DEFAULT_BIND_RETRY_DELAY_S,
+        bind_max_retries: int = DEFAULT_BIND_MAX_RETRIES,
+    ) -> None:
+        _require_pynng()
+        self._address = address
+        self._bind_retry_delay_s = bind_retry_delay_s
+        self._bind_max_retries = bind_max_retries
+        self._socket: pynng.Pub0 | None = None  # type: ignore[name-defined]
+
+    async def start(self) -> None:
+        """Bind the PUB socket, retrying on transient address-in-use errors."""
+        self._socket = pynng.Pub0()
+        for attempt in range(self._bind_max_retries):
+            try:
+                self._socket.listen(self._address)
+                logger.debug("NngPublisher: bound to %s", self._address)
+                return
+            except pynng.AddressInUse:
+                if attempt == self._bind_max_retries - 1:
+                    self._socket.close()
+                    self._socket = None
+                    raise
+                logger.warning(
+                    "NngPublisher: %s in use, retry %d/%d",
+                    self._address,
+                    attempt + 1,
+                    self._bind_max_retries,
+                )
+                await asyncio.sleep(self._bind_retry_delay_s)
+
+    async def stop(self) -> None:
+        """Close the PUB socket."""
+        if self._socket is not None:
+            with suppress(Exception):
+                self._socket.close()
+            self._socket = None
+            logger.debug("NngPublisher: closed")
+
+    async def __aenter__(self) -> NngPublisher:
+        await self.start()
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        await self.stop()
+
+    async def publish(self, event: SleipnirEvent) -> None:
+        if event.ttl is not None and event.ttl <= 0:
+            logger.debug(
+                "Dropping expired event %s (%s): ttl=%d",
+                event.event_id,
+                event.event_type,
+                event.ttl,
+            )
+            return
+        if self._socket is None:
+            raise RuntimeError("NngPublisher is not started. Call start() first.")
+        msg = _encode_message(event)
+        await self._socket.asend(msg)
+
+    async def publish_batch(self, events: list[SleipnirEvent]) -> None:
+        for event in events:
+            await self.publish(event)
+
+
+# ---------------------------------------------------------------------------
+# NngSubscriber
+# ---------------------------------------------------------------------------
+
+
+class NngSubscriber(SleipnirSubscriber):
+    """nng Sub0 subscriber.
+
+    Dials a SUB socket to *address* and dispatches received events to
+    registered handlers via per-subscription asyncio queues.
+
+    Usage::
+
+        sub = NngSubscriber("ipc:///tmp/sleipnir.sock")
+        async with sub:
+            handle = await sub.subscribe(["ravn.*"], my_handler)
+            ...
+            await handle.unsubscribe()
+    """
+
+    def __init__(
+        self,
+        address: str = DEFAULT_IPC_ADDRESS,
+        recv_timeout_ms: int = DEFAULT_RECV_TIMEOUT_MS,
+        ring_buffer_depth: int = DEFAULT_RING_BUFFER_DEPTH,
+        connect_settle_ms: int = DEFAULT_CONNECT_SETTLE_MS,
+        reconnect_min_ms: int = DEFAULT_RECONNECT_MIN_MS,
+        reconnect_max_ms: int = DEFAULT_RECONNECT_MAX_MS,
+    ) -> None:
+        _require_pynng()
+        if ring_buffer_depth < 1:
+            raise ValueError(f"ring_buffer_depth must be >= 1, got {ring_buffer_depth}")
+        self._address = address
+        self._recv_timeout_ms = recv_timeout_ms
+        self._ring_buffer_depth = ring_buffer_depth
+        self._connect_settle_ms = connect_settle_ms
+        self._reconnect_min_ms = reconnect_min_ms
+        self._reconnect_max_ms = reconnect_max_ms
+
+        self._socket: pynng.Sub0 | None = None  # type: ignore[name-defined]
+        self._recv_task: asyncio.Task[None] | None = None
+        self._subscriptions: list[_NngSubscription] = []
+        self._nng_subscribed_topics: set[bytes] = set()
+        self._running = False
+
+    async def start(self) -> None:
+        """Dial the SUB socket and start the receive loop."""
+        self._socket = pynng.Sub0()
+        self._socket.recv_timeout = self._recv_timeout_ms
+        self._socket.reconnect_time_min = self._reconnect_min_ms
+        self._socket.reconnect_time_max = self._reconnect_max_ms
+        self._socket.dial(self._address, block=False)
+        logger.debug("NngSubscriber: dialing %s", self._address)
+        if self._connect_settle_ms > 0:
+            await asyncio.sleep(self._connect_settle_ms / 1000.0)
+        self._running = True
+        self._recv_task = asyncio.create_task(self._recv_loop(), name="sleipnir-nng-sub-recv")
+
+    async def stop(self) -> None:
+        """Cancel the receive loop and close the SUB socket."""
+        self._running = False
+        if self._recv_task and not self._recv_task.done():
+            self._recv_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._recv_task
+        if self._socket is not None:
+            with suppress(Exception):
+                self._socket.close()
+            self._socket = None
+        logger.debug("NngSubscriber: closed")
+
+    async def __aenter__(self) -> NngSubscriber:
+        await self.start()
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        await self.stop()
+
+    async def subscribe(
+        self,
+        event_types: list[str],
+        handler: EventHandler,
+    ) -> Subscription:
+        if self._socket is None:
+            raise RuntimeError("NngSubscriber is not started. Call start() first.")
+        # Register nng-level topic subscriptions for efficient pre-filtering.
+        for topic in _nng_topics_for_patterns(event_types):
+            if topic not in self._nng_subscribed_topics:
+                self._socket.subscribe(topic)
+                self._nng_subscribed_topics.add(topic)
+        queue: asyncio.Queue[SleipnirEvent] = asyncio.Queue(maxsize=self._ring_buffer_depth)
+        task = asyncio.create_task(_consume_queue(queue, handler))
+        sub = _NngSubscription(list(event_types), queue, task, self)
+        self._subscriptions.append(sub)
+        return sub
+
+    async def flush(self) -> None:
+        """Wait until every queued (already-received) event has been processed."""
+        for sub in list(self._subscriptions):
+            await sub._queue.join()
+
+    def _remove_subscription(self, sub: _NngSubscription) -> None:
+        with suppress(ValueError):
+            self._subscriptions.remove(sub)
+
+    async def _recv_loop(self) -> None:
+        """Read messages from the SUB socket and dispatch to handlers."""
+        while self._running:
+            try:
+                data = await self._socket.arecv()
+            except pynng.Timeout:
+                continue
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                if not self._running:
+                    return
+                logger.exception("NngSubscriber: receive error; will retry")
+                await asyncio.sleep(self._recv_timeout_ms / 1000.0)
+                continue
+            await self._dispatch(data)
+
+    async def _dispatch(self, data: bytes) -> None:
+        """Decode *data* and deliver to all matching subscriptions."""
+        event = _decode_message(data)
+        if event is None:
+            return
+        if event.ttl is not None and event.ttl <= 0:
+            return
+        for sub in list(self._subscriptions):
+            if not sub.active:
+                continue
+            if not any(match_event_type(p, event.event_type) for p in sub.patterns):
+                continue
+            queue = sub._queue
+            if queue.full():
+                with suppress(asyncio.QueueEmpty):
+                    dropped = queue.get_nowait()
+                    queue.task_done()
+                    logger.warning(
+                        "Ring buffer overflow (depth=%d): dropped event %s (%s)",
+                        self._ring_buffer_depth,
+                        dropped.event_id,
+                        dropped.event_type,
+                    )
+            await queue.put(event)
+
+
+# ---------------------------------------------------------------------------
+# NngTransport — combined publisher + subscriber
+# ---------------------------------------------------------------------------
+
+
+class NngTransport(SleipnirPublisher, SleipnirSubscriber):
+    """Combined nng PUB/SUB transport for single-process use.
+
+    Opens both a :class:`NngPublisher` (which binds) and a
+    :class:`NngSubscriber` (which dials) at *address*.  Events published
+    by this process loop back through nng and are delivered to local
+    subscribers as well as remote ones.
+
+    Usage::
+
+        bus = NngTransport("ipc:///tmp/sleipnir.sock")
+        async with bus:
+            handle = await bus.subscribe(["ravn.*"], my_handler)
+            await bus.publish(event)
+            await bus.flush()
+            await handle.unsubscribe()
+    """
+
+    def __init__(
+        self,
+        address: str = DEFAULT_IPC_ADDRESS,
+        recv_timeout_ms: int = DEFAULT_RECV_TIMEOUT_MS,
+        bind_retry_delay_s: float = DEFAULT_BIND_RETRY_DELAY_S,
+        bind_max_retries: int = DEFAULT_BIND_MAX_RETRIES,
+        ring_buffer_depth: int = DEFAULT_RING_BUFFER_DEPTH,
+        connect_settle_ms: int = DEFAULT_CONNECT_SETTLE_MS,
+        reconnect_min_ms: int = DEFAULT_RECONNECT_MIN_MS,
+        reconnect_max_ms: int = DEFAULT_RECONNECT_MAX_MS,
+    ) -> None:
+        _require_pynng()
+        self._publisher = NngPublisher(
+            address=address,
+            bind_retry_delay_s=bind_retry_delay_s,
+            bind_max_retries=bind_max_retries,
+        )
+        self._subscriber = NngSubscriber(
+            address=address,
+            recv_timeout_ms=recv_timeout_ms,
+            ring_buffer_depth=ring_buffer_depth,
+            connect_settle_ms=connect_settle_ms,
+            reconnect_min_ms=reconnect_min_ms,
+            reconnect_max_ms=reconnect_max_ms,
+        )
+
+    async def start(self) -> None:
+        """Bind the PUB socket, then dial the SUB socket."""
+        await self._publisher.start()
+        await self._subscriber.start()
+
+    async def stop(self) -> None:
+        """Graceful shutdown: stop subscriber first, then publisher."""
+        await self._subscriber.stop()
+        await self._publisher.stop()
+
+    async def __aenter__(self) -> NngTransport:
+        await self.start()
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        await self.stop()
+
+    # ------------------------------------------------------------------
+    # SleipnirPublisher
+    # ------------------------------------------------------------------
+
+    async def publish(self, event: SleipnirEvent) -> None:
+        await self._publisher.publish(event)
+
+    async def publish_batch(self, events: list[SleipnirEvent]) -> None:
+        await self._publisher.publish_batch(events)
+
+    # ------------------------------------------------------------------
+    # SleipnirSubscriber
+    # ------------------------------------------------------------------
+
+    async def subscribe(
+        self,
+        event_types: list[str],
+        handler: EventHandler,
+    ) -> Subscription:
+        return await self._subscriber.subscribe(event_types, handler)
+
+    async def flush(self) -> None:
+        """Wait until every queued (already-received) event has been processed."""
+        await self._subscriber.flush()
+
+    def _remove_subscription(self, sub: _NngSubscription) -> None:
+        self._subscriber._remove_subscription(sub)
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _require_pynng() -> None:
+    if not _PYNNG_AVAILABLE:
+        raise ImportError(
+            "pynng is required for the nng transport adapter. Install it with: pip install pynng"
+        )
+
+
+def _encode_message(event: SleipnirEvent) -> bytes:
+    """Encode *event* as ``<event_type>\\x00<msgpack_payload>``."""
+    return event.event_type.encode() + b"\x00" + serialize(event)
+
+
+def _decode_message(data: bytes) -> SleipnirEvent | None:
+    """Decode a message produced by :func:`_encode_message`.
+
+    Returns ``None`` and logs a warning on malformed input.
+    """
+    try:
+        sep_idx = data.index(b"\x00")
+    except ValueError:
+        logger.warning("NngTransport: malformed message (no \\x00 separator), dropped")
+        return None
+    body = data[sep_idx + 1 :]
+    try:
+        return deserialize(body)
+    except Exception:
+        logger.exception("NngTransport: deserialization failed, dropped")
+        return None
+
+
+def nng_available() -> bool:
+    """Return ``True`` if pynng is installed and the nng transport can be used."""
+    return _PYNNG_AVAILABLE

--- a/tests/test_sleipnir/test_nng_transport.py
+++ b/tests/test_sleipnir/test_nng_transport.py
@@ -105,6 +105,26 @@ def test_nng_topics_empty_list():
     assert _nng_topics_for_patterns([]) == [b""]
 
 
+def test_nng_topics_question_mark_wildcard_falls_back_to_all():
+    """Pattern with '?' wildcard (e.g. 'ravn.tool.?') → b'' fallback.
+
+    nng prefix matching cannot express single-character wildcards; the adapter
+    must subscribe to all messages and rely on application-level fnmatch
+    filtering for the final match decision.
+    """
+    assert _nng_topics_for_patterns(["ravn.tool.?"]) == [b""]
+
+
+def test_nng_topics_bracket_wildcard_falls_back_to_all():
+    """Pattern with '[' wildcard (e.g. 'ravn.[abc]*') → b'' fallback."""
+    assert _nng_topics_for_patterns(["ravn.[abc]*"]) == [b""]
+
+
+def test_nng_topics_mid_star_wildcard_falls_back_to_all():
+    """Pattern with '*' not at the end (e.g. 'ravn.*.complete') → b'' fallback."""
+    assert _nng_topics_for_patterns(["ravn.*.complete"]) == [b""]
+
+
 def test_encode_message_format():
     """Encoded message starts with event_type, then null byte, then payload."""
     event = make_event(event_type="ravn.tool.complete")

--- a/tests/test_sleipnir/test_nng_transport.py
+++ b/tests/test_sleipnir/test_nng_transport.py
@@ -1,0 +1,724 @@
+"""Tests for the nng PUB/SUB transport adapter (NIU-464).
+
+Test strategy
+-------------
+Unit tests mock pynng sockets to keep them fast and hermetic.
+Functional tests use real pynng IPC sockets (no external services needed).
+Multi-process delivery is tested via asyncio.create_subprocess_exec.
+
+All functional tests use a per-test unique IPC socket path (via tmp_path)
+to ensure isolation even when tests run in parallel.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import textwrap
+import time
+from contextlib import suppress
+from unittest.mock import patch
+
+import pytest
+
+from sleipnir.adapters.nng_transport import (
+    DEFAULT_IPC_ADDRESS,
+    DEFAULT_TCP_ADDRESS,
+    NngPublisher,
+    NngSubscriber,
+    NngTransport,
+    _decode_message,
+    _encode_message,
+    _nng_topics_for_patterns,
+    nng_available,
+)
+from sleipnir.domain.events import SleipnirEvent
+from tests.test_sleipnir.conftest import make_event
+
+# ---------------------------------------------------------------------------
+# Skip all tests if pynng is not installed.
+# ---------------------------------------------------------------------------
+
+pynng = pytest.importorskip("pynng", reason="pynng not installed; skipping nng tests")
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def ipc_address(tmp_path):
+    """Unique IPC address per test — avoids cross-test socket leaks."""
+    return f"ipc://{tmp_path}/sleipnir_test.sock"
+
+
+@pytest.fixture
+def tcp_address():
+    """A local TCP address for testing TCP transport."""
+    return DEFAULT_TCP_ADDRESS
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def test_nng_available_returns_true():
+    assert nng_available() is True
+
+
+def test_nng_topics_wildcard_star():
+    """'*' should produce b'' (subscribe to everything)."""
+    assert _nng_topics_for_patterns(["*"]) == [b""]
+
+
+def test_nng_topics_namespace_wildcard():
+    """'ravn.*' should produce b'ravn.' prefix."""
+    assert _nng_topics_for_patterns(["ravn.*"]) == [b"ravn."]
+
+
+def test_nng_topics_sub_namespace_wildcard():
+    """'ravn.tool.*' should produce b'ravn.tool.' prefix."""
+    assert _nng_topics_for_patterns(["ravn.tool.*"]) == [b"ravn.tool."]
+
+
+def test_nng_topics_exact_match():
+    """Exact event type should produce bytes + null separator."""
+    assert _nng_topics_for_patterns(["ravn.tool.complete"]) == [b"ravn.tool.complete\x00"]
+
+
+def test_nng_topics_multiple_patterns():
+    """Multiple patterns produce one nng topic each."""
+    result = _nng_topics_for_patterns(["ravn.*", "tyr.*"])
+    assert b"ravn." in result
+    assert b"tyr." in result
+
+
+def test_nng_topics_star_short_circuits():
+    """'*' anywhere in patterns returns [b''] immediately."""
+    result = _nng_topics_for_patterns(["ravn.*", "*", "tyr.*"])
+    assert result == [b""]
+
+
+def test_nng_topics_empty_list():
+    """Empty pattern list falls back to b'' (subscribe to all)."""
+    assert _nng_topics_for_patterns([]) == [b""]
+
+
+def test_encode_message_format():
+    """Encoded message starts with event_type, then null byte, then payload."""
+    event = make_event(event_type="ravn.tool.complete")
+    data = _encode_message(event)
+    sep = data.index(b"\x00")
+    assert data[:sep] == b"ravn.tool.complete"
+    assert len(data[sep + 1 :]) > 0  # msgpack payload is non-empty
+
+
+def test_decode_message_round_trip():
+    """decode(encode(event)) == event."""
+    event = make_event(event_id="rt-001", event_type="ravn.tool.complete")
+    data = _encode_message(event)
+    decoded = _decode_message(data)
+    assert decoded is not None
+    assert decoded.event_id == "rt-001"
+    assert decoded.event_type == "ravn.tool.complete"
+
+
+def test_decode_message_malformed_returns_none(caplog):
+    """Malformed message (no null separator) returns None and logs warning."""
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="sleipnir.adapters.nng_transport"):
+        result = _decode_message(b"no-null-separator-here")
+    assert result is None
+    assert any("malformed" in r.message for r in caplog.records)
+
+
+def test_decode_message_bad_payload_returns_none(caplog):
+    """A null byte followed by garbage returns None and logs exception."""
+    import logging
+
+    bad = b"ravn.tool.complete\x00\xff\xfe\xfd"
+    with caplog.at_level(logging.ERROR, logger="sleipnir.adapters.nng_transport"):
+        result = _decode_message(bad)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — constructor validation
+# ---------------------------------------------------------------------------
+
+
+def test_nng_subscriber_rejects_zero_ring_buffer_depth():
+    with pytest.raises(ValueError, match="ring_buffer_depth"):
+        NngSubscriber(ring_buffer_depth=0)
+
+
+async def test_nng_publisher_raises_without_start():
+    """publish() before start() raises RuntimeError."""
+    pub = NngPublisher(address=DEFAULT_IPC_ADDRESS)
+    with pytest.raises(RuntimeError, match="not started"):
+        await pub.publish(make_event())
+
+
+async def test_nng_subscriber_raises_without_start():
+    """subscribe() before start() raises RuntimeError."""
+    sub = NngSubscriber(address=DEFAULT_IPC_ADDRESS)
+
+    async def handler(_: SleipnirEvent) -> None:
+        pass
+
+    with pytest.raises(RuntimeError, match="not started"):
+        await sub.subscribe(["*"], handler)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — ImportError guard
+# ---------------------------------------------------------------------------
+
+
+def test_import_error_when_pynng_not_available():
+    """NngPublisher/Subscriber raise ImportError if pynng is absent."""
+    with patch("sleipnir.adapters.nng_transport._PYNNG_AVAILABLE", False):
+        with pytest.raises(ImportError, match="pynng"):
+            NngPublisher()
+        with pytest.raises(ImportError, match="pynng"):
+            NngSubscriber()
+        with pytest.raises(ImportError, match="pynng"):
+            NngTransport()
+
+
+def test_nng_available_false_when_not_installed():
+    with patch("sleipnir.adapters.nng_transport._PYNNG_AVAILABLE", False):
+        assert nng_available() is False
+
+
+# ---------------------------------------------------------------------------
+# Functional tests — real pynng IPC sockets (no external services)
+# ---------------------------------------------------------------------------
+
+
+async def test_functional_single_event_delivery(ipc_address):
+    """Publish one event; subscriber receives it."""
+    received: list[SleipnirEvent] = []
+    ready = asyncio.Event()
+
+    async def handler(evt: SleipnirEvent) -> None:
+        received.append(evt)
+        ready.set()
+
+    async with NngPublisher(ipc_address) as pub:
+        async with NngSubscriber(ipc_address) as sub:
+            await sub.subscribe(["ravn.*"], handler)
+            event = make_event(event_id="nng-single")
+            await pub.publish(event)
+            await asyncio.wait_for(ready.wait(), timeout=3.0)
+
+    assert len(received) == 1
+    assert received[0].event_id == "nng-single"
+
+
+async def test_functional_multiple_subscribers(ipc_address):
+    """All subscribers independently receive the same event."""
+    bucket_a: list[str] = []
+    bucket_b: list[str] = []
+    done_a = asyncio.Event()
+    done_b = asyncio.Event()
+
+    async def handler_a(evt: SleipnirEvent) -> None:
+        bucket_a.append(evt.event_id)
+        done_a.set()
+
+    async def handler_b(evt: SleipnirEvent) -> None:
+        bucket_b.append(evt.event_id)
+        done_b.set()
+
+    async with NngPublisher(ipc_address) as pub:
+        async with NngSubscriber(ipc_address) as sub:
+            await sub.subscribe(["*"], handler_a)
+            await sub.subscribe(["*"], handler_b)
+            await pub.publish(make_event(event_id="nng-multi"))
+            await asyncio.wait_for(asyncio.gather(done_a.wait(), done_b.wait()), timeout=3.0)
+
+    assert bucket_a == ["nng-multi"]
+    assert bucket_b == ["nng-multi"]
+
+
+async def test_functional_topic_filtering_ravn_star(ipc_address):
+    """'ravn.*' subscriber receives ravn events but not tyr events."""
+    received_types: list[str] = []
+    ravn_event_received = asyncio.Event()
+
+    async def handler(evt: SleipnirEvent) -> None:
+        received_types.append(evt.event_type)
+        if evt.event_type.startswith("ravn."):
+            ravn_event_received.set()
+
+    async with NngPublisher(ipc_address) as pub:
+        async with NngSubscriber(ipc_address) as sub:
+            await sub.subscribe(["ravn.*"], handler)
+
+            await pub.publish(make_event(event_type="ravn.tool.complete", event_id="e1"))
+            await asyncio.wait_for(ravn_event_received.wait(), timeout=3.0)
+
+            # Publish a tyr event — should NOT arrive since subscriber only
+            # set nng topic to "ravn." which won't match "tyr.*" messages.
+            await pub.publish(make_event(event_type="tyr.task.started", event_id="e2"))
+            # Give nng a moment to deliver if it were going to.
+            await asyncio.sleep(0.1)
+
+    assert "ravn.tool.complete" in received_types
+    assert "tyr.task.started" not in received_types
+
+
+async def test_functional_topic_filtering_star_wildcard(ipc_address):
+    """'*' subscriber receives events from all namespaces."""
+    received_types: list[str] = []
+    all_received = asyncio.Event()
+
+    target_types = [
+        "ravn.tool.complete",
+        "tyr.task.started",
+        "volundr.pr.opened",
+    ]
+
+    async def handler(evt: SleipnirEvent) -> None:
+        received_types.append(evt.event_type)
+        if all(t in received_types for t in target_types):
+            all_received.set()
+
+    async with NngPublisher(ipc_address) as pub:
+        async with NngSubscriber(ipc_address) as sub:
+            await sub.subscribe(["*"], handler)
+            for i, et in enumerate(target_types):
+                await pub.publish(make_event(event_type=et, event_id=str(i)))
+            await asyncio.wait_for(all_received.wait(), timeout=3.0)
+
+    assert sorted(received_types) == sorted(target_types)
+
+
+async def test_functional_unsubscribe_stops_delivery(ipc_address):
+    """Events published after unsubscribe() are never delivered."""
+    received: list[str] = []
+    first_received = asyncio.Event()
+
+    async def handler(evt: SleipnirEvent) -> None:
+        received.append(evt.event_id)
+        first_received.set()
+
+    async with NngPublisher(ipc_address) as pub:
+        async with NngSubscriber(ipc_address) as sub:
+            handle = await sub.subscribe(["ravn.*"], handler)
+
+            await pub.publish(make_event(event_id="before"))
+            await asyncio.wait_for(first_received.wait(), timeout=3.0)
+
+            await handle.unsubscribe()
+
+            await pub.publish(make_event(event_id="after"))
+            await asyncio.sleep(0.15)  # allow delivery if it were going to happen
+            await sub.flush()
+
+    assert received == ["before"]
+
+
+async def test_functional_ttl_zero_not_delivered(ipc_address):
+    """Events with ttl=0 are dropped by the publisher and never sent."""
+    received: list[str] = []
+    live_received = asyncio.Event()
+
+    async def handler(evt: SleipnirEvent) -> None:
+        received.append(evt.event_id)
+        live_received.set()
+
+    async with NngPublisher(ipc_address) as pub:
+        async with NngSubscriber(ipc_address) as sub:
+            await sub.subscribe(["*"], handler)
+
+            await pub.publish(make_event(event_id="expired", ttl=0))
+            await pub.publish(make_event(event_id="live", ttl=None))
+            await asyncio.wait_for(live_received.wait(), timeout=3.0)
+
+    assert received == ["live"]
+    assert "expired" not in received
+
+
+async def test_functional_correlation_id_preserved(ipc_address):
+    """correlation_id reaches the subscriber unchanged."""
+    received: list[SleipnirEvent] = []
+    done = asyncio.Event()
+
+    async def handler(evt: SleipnirEvent) -> None:
+        received.append(evt)
+        done.set()
+
+    async with NngPublisher(ipc_address) as pub:
+        async with NngSubscriber(ipc_address) as sub:
+            await sub.subscribe(["*"], handler)
+            await pub.publish(make_event(event_id="corr-test", correlation_id="corr-xyz"))
+            await asyncio.wait_for(done.wait(), timeout=3.0)
+
+    assert received[0].correlation_id == "corr-xyz"
+
+
+async def test_functional_urgency_preserved(ipc_address):
+    """urgency reaches the subscriber unchanged."""
+    received: list[SleipnirEvent] = []
+    done = asyncio.Event()
+
+    async def handler(evt: SleipnirEvent) -> None:
+        received.append(evt)
+        done.set()
+
+    async with NngPublisher(ipc_address) as pub:
+        async with NngSubscriber(ipc_address) as sub:
+            await sub.subscribe(["*"], handler)
+            await pub.publish(make_event(event_id="urgency-test", urgency=0.95))
+            await asyncio.wait_for(done.wait(), timeout=3.0)
+
+    assert received[0].urgency == pytest.approx(0.95)
+
+
+async def test_functional_publish_batch(ipc_address):
+    """publish_batch delivers all events in order."""
+    received: list[str] = []
+    batch_size = 20
+    all_done = asyncio.Event()
+
+    async def handler(evt: SleipnirEvent) -> None:
+        received.append(evt.event_id)
+        if len(received) >= batch_size:
+            all_done.set()
+
+    async with NngPublisher(ipc_address) as pub:
+        async with NngSubscriber(ipc_address) as sub:
+            await sub.subscribe(["*"], handler)
+            batch = [make_event(event_id=f"batch-{i}") for i in range(batch_size)]
+            await pub.publish_batch(batch)
+            await asyncio.wait_for(all_done.wait(), timeout=5.0)
+
+    assert received == [f"batch-{i}" for i in range(batch_size)]
+
+
+async def test_functional_nng_transport_combined(ipc_address):
+    """NngTransport (combined pub+sub) loops events back to local subscriber."""
+    received: list[SleipnirEvent] = []
+    done = asyncio.Event()
+
+    async def handler(evt: SleipnirEvent) -> None:
+        received.append(evt)
+        done.set()
+
+    async with NngTransport(ipc_address) as bus:
+        await bus.subscribe(["ravn.*"], handler)
+        await bus.publish(make_event(event_id="combined-test"))
+        await asyncio.wait_for(done.wait(), timeout=3.0)
+
+    assert len(received) == 1
+    assert received[0].event_id == "combined-test"
+
+
+async def test_functional_nng_transport_flush(ipc_address):
+    """flush() waits for already-received events to be processed."""
+    processed: list[str] = []
+
+    async def slow_handler(evt: SleipnirEvent) -> None:
+        await asyncio.sleep(0.01)
+        processed.append(evt.event_id)
+
+    async with NngTransport(ipc_address) as bus:
+        await bus.subscribe(["*"], slow_handler)
+        await bus.publish(make_event(event_id="flush-test"))
+        await asyncio.sleep(0.1)  # allow nng delivery
+        await bus.flush()
+
+    assert "flush-test" in processed
+
+
+async def test_functional_graceful_shutdown_no_leak(ipc_address):
+    """stop() completes cleanly even with active subscriptions."""
+    received: list[str] = []
+
+    async def handler(evt: SleipnirEvent) -> None:
+        received.append(evt.event_id)
+
+    pub = NngPublisher(ipc_address)
+    sub = NngSubscriber(ipc_address)
+    await pub.start()
+    await sub.start()
+    await sub.subscribe(["*"], handler)
+
+    await pub.publish(make_event(event_id="before-stop"))
+    await asyncio.sleep(0.1)
+
+    # Stop both — should not raise.
+    await sub.stop()
+    await pub.stop()
+    # Verify sockets are closed.
+    assert sub._socket is None
+    assert pub._socket is None
+
+
+async def test_functional_stop_idempotent(ipc_address):
+    """Calling stop() multiple times does not raise."""
+    pub = NngPublisher(ipc_address)
+    await pub.start()
+    await pub.stop()
+    await pub.stop()  # second call should be a no-op
+
+
+async def test_functional_unsubscribe_idempotent(ipc_address):
+    """Calling unsubscribe() multiple times does not raise."""
+    received: list[SleipnirEvent] = []
+
+    async def handler(evt: SleipnirEvent) -> None:
+        received.append(evt)
+
+    async with NngPublisher(ipc_address):
+        async with NngSubscriber(ipc_address) as sub:
+            handle = await sub.subscribe(["*"], handler)
+            await handle.unsubscribe()
+            await handle.unsubscribe()  # second call should be a no-op
+
+
+# ---------------------------------------------------------------------------
+# Functional tests — TCP transport
+# ---------------------------------------------------------------------------
+
+
+async def test_functional_tcp_transport(tcp_address):
+    """Basic publish/subscribe works over TCP."""
+    received: list[SleipnirEvent] = []
+    done = asyncio.Event()
+
+    async def handler(evt: SleipnirEvent) -> None:
+        received.append(evt)
+        done.set()
+
+    async with NngPublisher(tcp_address) as pub:
+        async with NngSubscriber(tcp_address) as sub:
+            await sub.subscribe(["ravn.*"], handler)
+            await pub.publish(make_event(event_id="tcp-test"))
+            await asyncio.wait_for(done.wait(), timeout=3.0)
+
+    assert received[0].event_id == "tcp-test"
+
+
+# ---------------------------------------------------------------------------
+# Functional tests — multi-process delivery
+# ---------------------------------------------------------------------------
+
+
+async def test_multiprocess_publisher_to_subscriber(ipc_address, tmp_path):
+    """Events published in a subprocess are received in the main process."""
+    received: list[SleipnirEvent] = []
+    done = asyncio.Event()
+
+    async def handler(evt: SleipnirEvent) -> None:
+        received.append(evt)
+        done.set()
+
+    import os
+    from pathlib import Path
+
+    # Locate the workspace src directory so the subprocess can import sleipnir.
+    workspace_src = str(Path(__file__).parent.parent.parent / "src")
+
+    # Propagate PYTHONPATH so pynng and sleipnir are importable in the child.
+    env = os.environ.copy()
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = f"{workspace_src}:{existing}" if existing else workspace_src
+
+    # Publisher code that runs in the subprocess.
+    publisher_code = textwrap.dedent(
+        f"""
+        import asyncio
+        from sleipnir.adapters.nng_transport import NngPublisher
+        from sleipnir.domain.events import SleipnirEvent
+        from datetime import datetime, UTC
+
+        async def main():
+            pub = NngPublisher({ipc_address!r})
+            await pub.start()
+            await asyncio.sleep(0.4)  # wait for subscriber to connect
+            event = SleipnirEvent(
+                event_id="cross-proc",
+                event_type="ravn.tool.complete",
+                source="ravn:subprocess",
+                payload={{}},
+                summary="cross-process test event",
+                urgency=0.5,
+                domain="code",
+                timestamp=datetime.now(UTC),
+            )
+            await pub.publish(event)
+            await asyncio.sleep(0.2)  # allow delivery
+            await pub.stop()
+
+        asyncio.run(main())
+        """
+    )
+
+    # Start subscriber first so it is ready when the publisher sends.
+    async with NngSubscriber(ipc_address, connect_settle_ms=50) as sub:
+        await sub.subscribe(["ravn.*"], handler)
+
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-c",
+            publisher_code,
+            env=env,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            await asyncio.wait_for(done.wait(), timeout=15.0)
+        finally:
+            with suppress(Exception):
+                proc.kill()
+            await proc.wait()
+
+    assert len(received) >= 1
+    assert any(e.event_id == "cross-proc" for e in received)
+
+
+# ---------------------------------------------------------------------------
+# Functional tests — reconnection
+# ---------------------------------------------------------------------------
+
+
+async def test_reconnection_subscriber_survives_publisher_restart(ipc_address):
+    """Subscriber continues to receive after publisher is restarted.
+
+    Sequence:
+    1. Publisher binds first so subscriber can connect immediately.
+    2. Verify first event is received.
+    3. Restart the publisher (stop, then start a new one at the same address).
+    4. Retry publishing until the subscriber reconnects — nng PUB/SUB drops
+       messages sent while no subscriber pipe is connected.
+    5. Verify second event is received.
+    """
+    received: list[str] = []
+    first_received = asyncio.Event()
+    second_received = asyncio.Event()
+
+    async def handler(evt: SleipnirEvent) -> None:
+        received.append(evt.event_id)
+        if evt.event_id == "before-restart":
+            first_received.set()
+        if evt.event_id == "after-restart":
+            second_received.set()
+
+    # Bind publisher FIRST so the subscriber connects on its first dial attempt.
+    pub1 = NngPublisher(ipc_address)
+    await pub1.start()
+
+    async with NngSubscriber(ipc_address) as sub:
+        await sub.subscribe(["ravn.*"], handler)
+
+        # Publish and confirm delivery before stopping pub1.
+        deadline = asyncio.get_running_loop().time() + 5.0
+        while not first_received.is_set():
+            await pub1.publish(make_event(event_id="before-restart"))
+            try:
+                await asyncio.wait_for(first_received.wait(), timeout=0.3)
+            except TimeoutError:
+                if asyncio.get_running_loop().time() > deadline:
+                    raise
+
+        await pub1.stop()
+
+        # Brief gap to let nng detect the broken connection.
+        await asyncio.sleep(0.15)
+
+        # Start a second publisher at the same address.
+        async with NngPublisher(ipc_address, bind_retry_delay_s=0.05) as pub2:
+            deadline = asyncio.get_running_loop().time() + 8.0
+            while not second_received.is_set():
+                await pub2.publish(make_event(event_id="after-restart"))
+                try:
+                    await asyncio.wait_for(second_received.wait(), timeout=0.3)
+                except TimeoutError:
+                    if asyncio.get_running_loop().time() > deadline:
+                        raise
+
+    assert "before-restart" in received
+    assert "after-restart" in received
+
+
+# ---------------------------------------------------------------------------
+# Functional tests — latency (IPC)
+# ---------------------------------------------------------------------------
+
+
+async def test_ipc_latency_under_threshold(ipc_address):
+    """Median IPC round-trip should be well under 10 ms (not µs since we're in
+    a containerised CI environment, but still fast enough to be useful)."""
+    latencies: list[float] = []
+    n = 50
+    events_received = asyncio.Event()
+
+    timestamps: dict[str, float] = {}
+
+    async def handler(evt: SleipnirEvent) -> None:
+        latencies.append(time.monotonic() - timestamps[evt.event_id])
+        if len(latencies) >= n:
+            events_received.set()
+
+    async with NngPublisher(ipc_address) as pub:
+        async with NngSubscriber(ipc_address) as sub:
+            await sub.subscribe(["ravn.*"], handler)
+
+            for i in range(n):
+                eid = f"lat-{i}"
+                timestamps[eid] = time.monotonic()
+                await pub.publish(make_event(event_id=eid))
+
+            await asyncio.wait_for(events_received.wait(), timeout=10.0)
+
+    median_ms = sorted(latencies)[n // 2] * 1000
+    # Allow up to 50 ms median on CI (IPC is typically <1 ms on metal).
+    assert median_ms < 50.0, f"Median IPC latency too high: {median_ms:.2f} ms"
+
+
+# ---------------------------------------------------------------------------
+# Functional tests — ring buffer overflow
+# ---------------------------------------------------------------------------
+
+
+async def test_ring_buffer_overflow_drops_oldest_and_warns(ipc_address, caplog):
+    """When the ring buffer overflows, the oldest event is dropped with a warning.
+
+    Strategy: publish many more events than the ring buffer can hold while the
+    consumer is blocked on a Semaphore.  Once at least one overflow warning is
+    logged we unblock the consumer and verify no assert is raised.
+    """
+    import logging
+
+    received_ids: list[str] = []
+    # Semaphore starts at 0 — the consumer blocks until we release it.
+    release = asyncio.Semaphore(0)
+
+    async def blocking_handler(evt: SleipnirEvent) -> None:
+        await release.acquire()
+        received_ids.append(evt.event_id)
+
+    n_events = 20  # far more than ring_buffer_depth=2
+
+    async with NngPublisher(ipc_address) as pub:
+        async with NngSubscriber(ipc_address, ring_buffer_depth=2) as sub:
+            await sub.subscribe(["*"], blocking_handler)
+
+            with caplog.at_level(logging.WARNING, logger="sleipnir.adapters.nng_transport"):
+                for i in range(n_events):
+                    await pub.publish(make_event(event_id=f"e{i}"))
+                # Give nng time to deliver all messages to the recv_loop.
+                await asyncio.sleep(0.4)
+
+            warning_records = [r for r in caplog.records if "Ring buffer overflow" in r.message]
+            assert len(warning_records) >= 1
+
+            # Release the consumer for all queued items so flush() can complete.
+            for _ in range(sub._subscriptions[0]._queue.qsize() + 1):
+                release.release()
+            await sub.flush()


### PR DESCRIPTION
## Summary

- Adds `NngPublisher`, `NngSubscriber`, and `NngTransport` classes backed by **pynng** (nng Python bindings) for cross-process event delivery over IPC and TCP.
- Wire format: `<event_type>\x00<msgpack_payload>` — compatible with the Buri serialization format.
- Implements `SleipnirPublisher` and `SleipnirSubscriber` ports with the same ring-buffer semantics as `InProcessBus`.
- Adds `pynng>=0.9.0` as the optional `nng` extra in `pyproject.toml`.

### Key design decisions

| Concern | Decision |
|---|---|
| Wire format | `event_type` null-separated prefix + msgpack body; enables nng topic prefix filtering |
| nng topic filtering | `_nng_topics_for_patterns()` maps fnmatch patterns to nng byte-string prefixes; fnmatch applied again after deserialization for correctness |
| Reconnection | `reconnect_time_min=50ms` (overrides nng's 1000ms default) for fast sub-second reconnection |
| Graceful shutdown | `stop()` cancels recv loop task, suppresses `CancelledError`, closes both sockets |
| TTL expiry | Checked on publish (events with `ttl≤0` never sent); also checked on dispatch |
| Combined transport | `NngTransport` wraps both publisher (bind) and subscriber (dial) for single-process use |

### Architecture

```
src/sleipnir/adapters/
├── nng_transport.py   ← NEW
├── in_process.py
└── serialization.py
```

## Test plan

- [x] 36 new tests covering unit, functional (IPC + TCP), multi-process, reconnection, latency, and ring buffer overflow
- [x] All 144 tests in `tests/test_sleipnir/` pass
- [x] Coverage: **91.93%** on `src/sleipnir/` (requirement: 85%)
- [x] `ruff check` and `ruff format --check` pass clean
- [x] Multi-process test: subprocess publisher → main-process subscriber via IPC
- [x] Reconnection test: publisher stops → restarts at same address → subscriber reconnects
- [x] Latency test: median IPC latency < 50ms

## Linear

NIU-464 — Phase 2: nng transport adapter — multi-process, single-node

🤖 Generated with [Claude Code](https://claude.com/claude-code)