### PR TITLE
feat(adapters): Docker sandboxed terminal backend (NIU-515)

### DIFF
--- a/src/ravn/adapters/bash_validator.py
+++ b/src/ravn/adapters/bash_validator.py
@@ -541,18 +541,14 @@ class BashValidationPipeline:
         if cmd == "git":
             subcmd = tokens[1] if len(tokens) > 1 else ""
             if subcmd not in _GIT_READ_SUBCOMMANDS:
-                return StageDeny(
-                    f"git subcommand {subcmd!r} is not allowed in read_only mode"
-                )
+                return StageDeny(f"git subcommand {subcmd!r} is not allowed in read_only mode")
 
         return StageAllow()
 
     def _check_workspace_write(self, command: str) -> StageResult:
         """Warn if command references known system paths."""
         for prefix in _SYSTEM_PATH_WARN_PREFIXES:
-            if re.search(
-                rf"(?:^|\s|['\"]){re.escape(prefix)}(?:/|\s|['\"]|$)", command
-            ):
+            if re.search(rf"(?:^|\s|['\"]){re.escape(prefix)}(?:/|\s|['\"]|$)", command):
                 return StageWarn(
                     f"command references system path {prefix!r} — "
                     "proceed with caution in workspace_write mode"
@@ -661,7 +657,9 @@ class BashValidationPipeline:
         if cmd in _READ_ONLY_WHITELIST:
             return CommandIntent.READ_ONLY
 
-        return CommandIntent.UNKNOWN
+        # Unknown commands are treated as WRITE-level for safety: they may
+        # mutate state even though we cannot determine the exact intent.
+        return CommandIntent.WRITE
 
     @staticmethod
     def _highest_intent(intents: list[CommandIntent]) -> CommandIntent:

--- a/src/ravn/adapters/bash_validator.py
+++ b/src/ravn/adapters/bash_validator.py
@@ -657,9 +657,7 @@ class BashValidationPipeline:
         if cmd in _READ_ONLY_WHITELIST:
             return CommandIntent.READ_ONLY
 
-        # Unknown commands are treated as WRITE-level for safety: they may
-        # mutate state even though we cannot determine the exact intent.
-        return CommandIntent.WRITE
+        return CommandIntent.UNKNOWN
 
     @staticmethod
     def _highest_intent(intents: list[CommandIntent]) -> CommandIntent:

--- a/src/ravn/adapters/permission_enforcer.py
+++ b/src/ravn/adapters/permission_enforcer.py
@@ -245,7 +245,9 @@ class BashValidator:
         if cmd in _READ_ONLY_WHITELIST:
             return CommandIntent.READ_ONLY
 
-        return CommandIntent.UNKNOWN
+        # Unknown commands are treated as WRITE-level for safety: they may
+        # mutate state even though we cannot determine the exact intent.
+        return CommandIntent.WRITE
 
     def _highest_intent(self, intents: list[CommandIntent]) -> CommandIntent:
         """Return the highest-risk intent from a list."""

--- a/src/ravn/adapters/tools/terminal.py
+++ b/src/ravn/adapters/tools/terminal.py
@@ -17,6 +17,7 @@ import asyncio
 import logging
 import shlex
 import uuid
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 
 from ravn.domain.models import ToolResult
@@ -28,6 +29,7 @@ _PERMISSION_SHELL = "shell:execute"
 _SENTINEL_PREFIX = "RAVN_DONE"
 _DEFAULT_SHELL = "/bin/bash"
 _DEFAULT_TIMEOUT_SECONDS = 30.0
+_EOF_WAIT_TIMEOUT_SECONDS = 5.0
 
 
 # ---------------------------------------------------------------------------
@@ -46,6 +48,116 @@ class ShellState:
 
     cwd: str = ""
     env_exports: str = field(default="", repr=False)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers — sentinel protocol, state capture, result building
+# ---------------------------------------------------------------------------
+
+
+async def run_sentinel_command(
+    process: asyncio.subprocess.Process,
+    command: str,
+    timeout: float,
+    label: str = "shell",
+    eof_wait_timeout: float = _EOF_WAIT_TIMEOUT_SECONDS,
+) -> tuple[str, int, bool]:
+    """Execute *command* via *process* stdin using the sentinel demarcation protocol.
+
+    Writes the command followed by ``echo SENTINEL:$?`` to stdin, then
+    reads stdout line-by-line until the sentinel is found.
+
+    Returns ``(output, exit_code, process_exited)`` where *process_exited*
+    is ``True`` when the process closed stdout (EOF) or was killed on timeout.
+    The caller must clear its process reference when *process_exited* is True.
+
+    Args:
+        process:          A running asyncio subprocess with open stdin/stdout.
+        command:          Shell command to execute (cd/export effects persist).
+        timeout:          Seconds before the command is killed (exit code 124).
+        label:            Descriptive label used in timeout warning log messages.
+        eof_wait_timeout: Seconds to wait for process exit after EOF is detected.
+    """
+    assert process.stdin is not None  # noqa: S101 — narrowing
+    assert process.stdout is not None  # noqa: S101 — narrowing
+
+    sentinel = f"{_SENTINEL_PREFIX}_{uuid.uuid4().hex}"
+    # Do NOT wrap in a subshell — we want cd/export to persist.
+    wrapped = f"{command}\necho {sentinel}:$?\n"
+
+    process.stdin.write(wrapped.encode())
+    await process.stdin.drain()
+
+    output_lines: list[str] = []
+    exit_code = 1
+    try:
+        async with asyncio.timeout(timeout):
+            while True:
+                line_bytes = await process.stdout.readline()
+                if not line_bytes:
+                    # EOF — process exited (e.g. the command was "exit N").
+                    try:
+                        await asyncio.wait_for(process.wait(), timeout=eof_wait_timeout)
+                    except TimeoutError:
+                        pass
+                    actual_rc = process.returncode if process.returncode is not None else 1
+                    return "\n".join(output_lines), actual_rc, True
+                line_str = line_bytes.decode(errors="replace").rstrip("\n")
+                if line_str.startswith(f"{sentinel}:"):
+                    exit_code_str = line_str[len(sentinel) + 1 :]
+                    exit_code = int(exit_code_str) if exit_code_str.isdigit() else 1
+                    break
+                output_lines.append(line_str)
+    except TimeoutError:
+        logger.warning("%s timed out — killing to avoid output pollution", label)
+        process.kill()
+        await process.wait()
+        return "\n".join(output_lines) + "\n[timed out]", 124, True
+
+    return "\n".join(output_lines), exit_code, False
+
+
+async def get_shell_state(
+    run_fn: Callable[[str], Awaitable[tuple[str, int]]],
+) -> ShellState:
+    """Capture the current shell state (cwd + exported env vars).
+
+    Args:
+        run_fn: Bound ``run`` method of a shell (``PersistentShell.run`` or
+                ``DockerPersistentShell.run``).
+    """
+    cwd, _ = await run_fn("pwd")
+    env, _ = await run_fn("export -p")
+    return ShellState(cwd=cwd.strip(), env_exports=env)
+
+
+async def restore_shell_state(
+    run_fn: Callable[[str], Awaitable[tuple[str, int]]],
+    state: ShellState,
+) -> None:
+    """Restore a shell to a previously captured state.
+
+    Re-sources environment exports and changes to the saved working directory.
+    Errors (e.g. directory no longer exists) are silently ignored so the shell
+    remains usable.
+
+    Args:
+        run_fn: Bound ``run`` method of a shell.
+        state:  Previously captured :class:`ShellState`.
+    """
+    if state.env_exports:
+        await run_fn(state.env_exports)
+    if state.cwd:
+        await run_fn(f"cd {shlex.quote(state.cwd)} 2>/dev/null || true")
+
+
+def _build_result(output: str, exit_code: int) -> ToolResult:
+    """Build a :class:`~ravn.domain.models.ToolResult` from shell output."""
+    content = output.rstrip("\n")
+    if exit_code != 0:
+        suffix = f"\n[exit {exit_code}]"
+        content = (content + suffix).strip()
+    return ToolResult(tool_call_id="", content=content, is_error=exit_code != 0)
 
 
 # ---------------------------------------------------------------------------
@@ -151,47 +263,12 @@ class PersistentShell:
 
     async def _run_locked(self, command: str) -> tuple[str, int]:
         assert self._process is not None  # noqa: S101 — narrowing
-        assert self._process.stdin is not None  # noqa: S101 — narrowing
-        assert self._process.stdout is not None  # noqa: S101 — narrowing
-
-        sentinel = f"{_SENTINEL_PREFIX}_{uuid.uuid4().hex}"
-        # Do NOT wrap in a subshell — we want cd/export to persist.
-        wrapped = f"{command}\necho {sentinel}:$?\n"
-
-        self._process.stdin.write(wrapped.encode())
-        await self._process.stdin.drain()
-
-        output_lines: list[str] = []
-        try:
-            async with asyncio.timeout(self._timeout):
-                while True:
-                    line_bytes = await self._process.stdout.readline()
-                    if not line_bytes:
-                        # EOF — process exited (e.g. the command was "exit N").
-                        try:
-                            await asyncio.wait_for(self._process.wait(), timeout=5.0)
-                        except TimeoutError:
-                            pass
-                        actual_rc = (
-                            self._process.returncode if self._process.returncode is not None else 1
-                        )
-                        self._process = None
-                        return "\n".join(output_lines), actual_rc
-                    line_str = line_bytes.decode(errors="replace").rstrip("\n")
-                    if line_str.startswith(f"{sentinel}:"):
-                        exit_code_str = line_str[len(sentinel) + 1 :]
-                        exit_code = int(exit_code_str) if exit_code_str.isdigit() else 1
-                        break
-                    output_lines.append(line_str)
-        except TimeoutError:
-            if self._process is not None:
-                logger.warning("PersistentShell timed out — killing to avoid output pollution")
-                self._process.kill()
-                await self._process.wait()
-                self._process = None
-            return "\n".join(output_lines) + "\n[timed out]", 124
-
-        return "\n".join(output_lines), exit_code
+        output, exit_code, process_exited = await run_sentinel_command(
+            self._process, command, self._timeout, label="PersistentShell"
+        )
+        if process_exited:
+            self._process = None
+        return output, exit_code
 
     # ------------------------------------------------------------------
     # State capture / restore
@@ -199,9 +276,7 @@ class PersistentShell:
 
     async def get_state(self) -> ShellState:
         """Capture the current shell state (cwd + exported env vars)."""
-        cwd, _ = await self.run("pwd")
-        env, _ = await self.run("export -p")
-        return ShellState(cwd=cwd.strip(), env_exports=env)
+        return await get_shell_state(self.run)
 
     async def restore_state(self, state: ShellState) -> None:
         """Restore shell to a previously captured state.
@@ -210,10 +285,7 @@ class PersistentShell:
         directory.  Errors (e.g. directory no longer exists) are
         silently ignored so the shell remains usable.
         """
-        if state.env_exports:
-            await self.run(state.env_exports)
-        if state.cwd:
-            await self.run(f"cd {shlex.quote(state.cwd)} 2>/dev/null || true")
+        await restore_shell_state(self.run, state)
 
 
 # ---------------------------------------------------------------------------
@@ -310,7 +382,7 @@ class TerminalTool(ToolPort):
                 await self._shell.restore_state(self._initial_state)
 
         output, exit_code = await self._shell.run(command)
-        return self._build_result(output, exit_code)
+        return _build_result(output, exit_code)
 
     async def _run_ephemeral(self, command: str) -> ToolResult:
         """Spawn a fresh subprocess per call (non-persistent fallback)."""
@@ -327,17 +399,9 @@ class TerminalTool(ToolPort):
                 await proc.communicate()
                 return ToolResult(tool_call_id="", content="[timed out]", is_error=True)
             output = stdout.decode(errors="replace").rstrip("\n") if stdout else ""
-            return self._build_result(output, proc.returncode or 0)
+            return _build_result(output, proc.returncode or 0)
         except OSError as exc:
             return ToolResult(tool_call_id="", content=f"Execution error: {exc}", is_error=True)
-
-    @staticmethod
-    def _build_result(output: str, exit_code: int) -> ToolResult:
-        content = output.rstrip("\n")
-        if exit_code != 0:
-            suffix = f"\n[exit {exit_code}]"
-            content = (content + suffix).strip()
-        return ToolResult(tool_call_id="", content=content, is_error=exit_code != 0)
 
     # ------------------------------------------------------------------
     # State / cleanup

--- a/src/ravn/adapters/tools/terminal_docker.py
+++ b/src/ravn/adapters/tools/terminal_docker.py
@@ -30,41 +30,39 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import shlex
 import uuid
-from dataclasses import dataclass, field
 from pathlib import Path
 
+from ravn.adapters.tools.terminal import (
+    _DEFAULT_SHELL,
+    _DEFAULT_TIMEOUT_SECONDS,
+    _PERMISSION_SHELL,
+    _SENTINEL_PREFIX,
+    ShellState,
+    _build_result,
+    get_shell_state,
+    restore_shell_state,
+    run_sentinel_command,
+)
 from ravn.config import DockerTerminalConfig
 from ravn.domain.models import ToolResult
 from ravn.ports.tool import ToolPort
 
 logger = logging.getLogger(__name__)
 
-_PERMISSION_SHELL = "shell:execute"
-_SENTINEL_PREFIX = "RAVN_DONE"
-_DEFAULT_SHELL = "/bin/bash"
-_DEFAULT_TIMEOUT_SECONDS = 30.0
 _CONTAINER_STOP_TIMEOUT_SECONDS = 5.0
 _CONTAINER_REMOVE_TIMEOUT_SECONDS = 10.0
 
-
-# ---------------------------------------------------------------------------
-# Shell state (checkpoint / resume)
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class ShellState:
-    """Snapshot of a Docker shell's state for checkpoint/resume.
-
-    ``cwd`` is the current working directory; ``env_exports`` is the
-    output of ``export -p`` — the full set of exported variables in
-    POSIX-portable syntax, suitable for re-sourcing into a fresh shell.
-    """
-
-    cwd: str = ""
-    env_exports: str = field(default="", repr=False)
+# Re-export shared symbols so existing imports from this module keep working.
+__all__ = [
+    "DockerPersistentShell",
+    "DockerTerminalTool",
+    "ShellState",
+    "_DEFAULT_SHELL",
+    "_DEFAULT_TIMEOUT_SECONDS",
+    "_PERMISSION_SHELL",
+    "_SENTINEL_PREFIX",
+]
 
 
 # ---------------------------------------------------------------------------
@@ -221,52 +219,13 @@ class DockerPersistentShell:
 
     async def _run_locked(self, command: str) -> tuple[str, int]:
         assert self._process is not None  # noqa: S101 — narrowing
-        assert self._process.stdin is not None  # noqa: S101 — narrowing
-        assert self._process.stdout is not None  # noqa: S101 — narrowing
-
-        sentinel = f"{_SENTINEL_PREFIX}_{uuid.uuid4().hex}"
-        # Do NOT wrap in a subshell — we want cd/export to persist.
-        wrapped = f"{command}\necho {sentinel}:$?\n"
-
-        self._process.stdin.write(wrapped.encode())
-        await self._process.stdin.drain()
-
-        output_lines: list[str] = []
-        try:
-            async with asyncio.timeout(self._timeout):
-                while True:
-                    line_bytes = await self._process.stdout.readline()
-                    if not line_bytes:
-                        # EOF — container exited (e.g. command was "exit N").
-                        try:
-                            await asyncio.wait_for(
-                                self._process.wait(), timeout=_CONTAINER_STOP_TIMEOUT_SECONDS
-                            )
-                        except TimeoutError:
-                            pass
-                        actual_rc = (
-                            self._process.returncode if self._process.returncode is not None else 1
-                        )
-                        self._process = None
-                        return "\n".join(output_lines), actual_rc
-                    line_str = line_bytes.decode(errors="replace").rstrip("\n")
-                    if line_str.startswith(f"{sentinel}:"):
-                        exit_code_str = line_str[len(sentinel) + 1 :]
-                        exit_code = int(exit_code_str) if exit_code_str.isdigit() else 1
-                        break
-                    output_lines.append(line_str)
-        except TimeoutError:
-            if self._process is not None:
-                logger.warning(
-                    "DockerPersistentShell timed out — killing container=%s",
-                    self._container_name,
-                )
-                self._process.kill()
-                await self._process.wait()
-                self._process = None
-            return "\n".join(output_lines) + "\n[timed out]", 124
-
-        return "\n".join(output_lines), exit_code
+        label = f"DockerPersistentShell container={self._container_name}"
+        output, exit_code, process_exited = await run_sentinel_command(
+            self._process, command, self._timeout, label=label
+        )
+        if process_exited:
+            self._process = None
+        return output, exit_code
 
     # ------------------------------------------------------------------
     # State capture / restore
@@ -274,9 +233,7 @@ class DockerPersistentShell:
 
     async def get_state(self) -> ShellState:
         """Capture the current shell state (cwd + exported env vars)."""
-        cwd, _ = await self.run("pwd")
-        env, _ = await self.run("export -p")
-        return ShellState(cwd=cwd.strip(), env_exports=env)
+        return await get_shell_state(self.run)
 
     async def restore_state(self, state: ShellState) -> None:
         """Restore shell to a previously captured state.
@@ -284,10 +241,7 @@ class DockerPersistentShell:
         Re-sources environment exports and changes to the saved working
         directory.  Errors are silently ignored so the shell remains usable.
         """
-        if state.env_exports:
-            await self.run(state.env_exports)
-        if state.cwd:
-            await self.run(f"cd {shlex.quote(state.cwd)} 2>/dev/null || true")
+        await restore_shell_state(self.run, state)
 
 
 # ---------------------------------------------------------------------------
@@ -384,7 +338,7 @@ class DockerTerminalTool(ToolPort):
                 await self._shell.restore_state(self._initial_state)
 
         output, exit_code = await self._shell.run(command)
-        return self._build_result(output, exit_code)
+        return _build_result(output, exit_code)
 
     # ------------------------------------------------------------------
     # State / cleanup
@@ -404,15 +358,3 @@ class DockerTerminalTool(ToolPort):
         if self._shell is not None:
             await self._shell.close()
             self._shell = None
-
-    # ------------------------------------------------------------------
-    # Internal helpers
-    # ------------------------------------------------------------------
-
-    @staticmethod
-    def _build_result(output: str, exit_code: int) -> ToolResult:
-        content = output.rstrip("\n")
-        if exit_code != 0:
-            suffix = f"\n[exit {exit_code}]"
-            content = (content + suffix).strip()
-        return ToolResult(tool_call_id="", content=content, is_error=exit_code != 0)

--- a/src/ravn/adapters/tools/terminal_docker.py
+++ b/src/ravn/adapters/tools/terminal_docker.py
@@ -1,0 +1,418 @@
+"""Docker-sandboxed terminal backend.
+
+Runs commands inside an ephemeral Docker container rather than the host
+shell.  A single container is started per task; shell state (cwd,
+environment variables) persists across calls within that container.
+The container is destroyed cleanly when :meth:`DockerTerminalTool.close`
+is called or on interruption.
+
+Sandboxing properties
+---------------------
+* **Network isolation** — the container's network is ``none`` by default
+  (no outbound or inbound traffic).  Set ``network`` to ``"bridge"`` or
+  ``"host"`` in :class:`~ravn.config.DockerTerminalConfig` to relax this.
+* **Filesystem isolation** — only the workspace directory is mounted
+  read-write.  The host filesystem outside the workspace is not visible
+  unless ``extra_mounts`` are configured.
+* **Ephemeral** — the container is started with ``--rm`` so it is removed
+  automatically if the process exits unexpectedly.
+
+Usage::
+
+    tool = DockerTerminalTool(config=DockerTerminalConfig(), workspace_root=Path("."))
+    result = await tool.execute({"command": "echo hello"})
+    await tool.close()
+
+Or wire via :class:`~ravn.config.TerminalToolConfig` with ``backend="docker"``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import shlex
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from ravn.config import DockerTerminalConfig
+from ravn.domain.models import ToolResult
+from ravn.ports.tool import ToolPort
+
+logger = logging.getLogger(__name__)
+
+_PERMISSION_SHELL = "shell:execute"
+_SENTINEL_PREFIX = "RAVN_DONE"
+_DEFAULT_SHELL = "/bin/bash"
+_DEFAULT_TIMEOUT_SECONDS = 30.0
+_CONTAINER_STOP_TIMEOUT_SECONDS = 5.0
+_CONTAINER_REMOVE_TIMEOUT_SECONDS = 10.0
+
+
+# ---------------------------------------------------------------------------
+# Shell state (checkpoint / resume)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ShellState:
+    """Snapshot of a Docker shell's state for checkpoint/resume.
+
+    ``cwd`` is the current working directory; ``env_exports`` is the
+    output of ``export -p`` — the full set of exported variables in
+    POSIX-portable syntax, suitable for re-sourcing into a fresh shell.
+    """
+
+    cwd: str = ""
+    env_exports: str = field(default="", repr=False)
+
+
+# ---------------------------------------------------------------------------
+# DockerPersistentShell
+# ---------------------------------------------------------------------------
+
+
+class DockerPersistentShell:
+    """Manages a long-lived bash session inside an ephemeral Docker container.
+
+    A single container is started on the first :meth:`run` call.  Commands
+    are written to the container's stdin pipe; a UUID sentinel echoed after
+    each command marks the end of output.  This preserves ``cd``, ``export``,
+    and venv activations across calls — identical semantics to
+    :class:`~ravn.adapters.tools.terminal.PersistentShell`.
+
+    The container is destroyed when :meth:`close` is called (or on timeout).
+
+    Args:
+        config:           Docker configuration (image, network, mounts).
+        workspace_root:   Host path mounted read-write at the same path
+                          inside the container when ``mount_workspace=True``.
+        timeout_seconds:  Per-command timeout.
+    """
+
+    def __init__(
+        self,
+        config: DockerTerminalConfig,
+        workspace_root: Path,
+        timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        self._config = config
+        self._workspace_root = workspace_root.resolve()
+        self._timeout = timeout_seconds
+        self._container_name: str | None = None
+        self._process: asyncio.subprocess.Process | None = None
+        self._lock = asyncio.Lock()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    @property
+    def is_running(self) -> bool:
+        """True if the container process is alive."""
+        return self._process is not None and self._process.returncode is None
+
+    async def start(self) -> None:
+        """Start the Docker container (no-op if already running)."""
+        if self.is_running:
+            return
+
+        self._container_name = f"ravn-sandbox-{uuid.uuid4().hex[:12]}"
+        cmd = self._build_docker_cmd()
+
+        self._process = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        logger.debug(
+            "DockerPersistentShell started container=%s image=%s pid=%s",
+            self._container_name,
+            self._config.image,
+            self._process.pid,
+        )
+
+    def _build_docker_cmd(self) -> list[str]:
+        """Build the ``docker run`` command list."""
+        cmd = [
+            "docker",
+            "run",
+            "--rm",
+            "--interactive",
+            "--name",
+            self._container_name,  # type: ignore[list-item]
+            f"--network={self._config.network}",
+        ]
+
+        if self._config.mount_workspace:
+            ws = str(self._workspace_root)
+            cmd.extend(["-v", f"{ws}:{ws}", "-w", ws])
+
+        for mount in self._config.extra_mounts:
+            cmd.extend(["-v", mount])
+
+        cmd.extend([self._config.image, _DEFAULT_SHELL, "--norc", "--noprofile"])
+        return cmd
+
+    async def close(self) -> None:
+        """Cleanly terminate the container and shell process."""
+        if not self.is_running:
+            await self._force_remove_container()
+            return
+
+        assert self._process is not None  # noqa: S101 — narrowing
+        assert self._process.stdin is not None  # noqa: S101 — narrowing
+
+        try:
+            self._process.stdin.write(b"exit 0\n")
+            await self._process.stdin.drain()
+            await asyncio.wait_for(self._process.wait(), timeout=_CONTAINER_STOP_TIMEOUT_SECONDS)
+        except Exception:
+            self._process.kill()
+            await self._process.wait()
+        finally:
+            self._process = None
+            await self._force_remove_container()
+            logger.debug("DockerPersistentShell closed container=%s", self._container_name)
+
+    async def _force_remove_container(self) -> None:
+        """Remove the container by name, ignoring errors (already gone is fine)."""
+        if not self._container_name:
+            return
+        name = self._container_name
+        self._container_name = None
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "docker",
+                "rm",
+                "-f",
+                name,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            await asyncio.wait_for(proc.wait(), timeout=_CONTAINER_REMOVE_TIMEOUT_SECONDS)
+        except Exception:
+            logger.debug("docker rm -f %s failed (container may already be gone)", name)
+
+    async def __aenter__(self) -> DockerPersistentShell:
+        await self.start()
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        await self.close()
+
+    # ------------------------------------------------------------------
+    # Command execution
+    # ------------------------------------------------------------------
+
+    async def run(self, command: str) -> tuple[str, int]:
+        """Run *command* inside the Docker container.
+
+        Returns ``(output, exit_code)``.  On timeout, output is truncated
+        and exit code 124 is returned (matching ``timeout(1)`` convention).
+        The container is killed on timeout to avoid output pollution.
+        """
+        if not self.is_running:
+            await self.start()
+
+        async with self._lock:
+            return await self._run_locked(command)
+
+    async def _run_locked(self, command: str) -> tuple[str, int]:
+        assert self._process is not None  # noqa: S101 — narrowing
+        assert self._process.stdin is not None  # noqa: S101 — narrowing
+        assert self._process.stdout is not None  # noqa: S101 — narrowing
+
+        sentinel = f"{_SENTINEL_PREFIX}_{uuid.uuid4().hex}"
+        # Do NOT wrap in a subshell — we want cd/export to persist.
+        wrapped = f"{command}\necho {sentinel}:$?\n"
+
+        self._process.stdin.write(wrapped.encode())
+        await self._process.stdin.drain()
+
+        output_lines: list[str] = []
+        try:
+            async with asyncio.timeout(self._timeout):
+                while True:
+                    line_bytes = await self._process.stdout.readline()
+                    if not line_bytes:
+                        # EOF — container exited (e.g. command was "exit N").
+                        try:
+                            await asyncio.wait_for(
+                                self._process.wait(), timeout=_CONTAINER_STOP_TIMEOUT_SECONDS
+                            )
+                        except TimeoutError:
+                            pass
+                        actual_rc = (
+                            self._process.returncode if self._process.returncode is not None else 1
+                        )
+                        self._process = None
+                        return "\n".join(output_lines), actual_rc
+                    line_str = line_bytes.decode(errors="replace").rstrip("\n")
+                    if line_str.startswith(f"{sentinel}:"):
+                        exit_code_str = line_str[len(sentinel) + 1 :]
+                        exit_code = int(exit_code_str) if exit_code_str.isdigit() else 1
+                        break
+                    output_lines.append(line_str)
+        except TimeoutError:
+            if self._process is not None:
+                logger.warning(
+                    "DockerPersistentShell timed out — killing container=%s",
+                    self._container_name,
+                )
+                self._process.kill()
+                await self._process.wait()
+                self._process = None
+            return "\n".join(output_lines) + "\n[timed out]", 124
+
+        return "\n".join(output_lines), exit_code
+
+    # ------------------------------------------------------------------
+    # State capture / restore
+    # ------------------------------------------------------------------
+
+    async def get_state(self) -> ShellState:
+        """Capture the current shell state (cwd + exported env vars)."""
+        cwd, _ = await self.run("pwd")
+        env, _ = await self.run("export -p")
+        return ShellState(cwd=cwd.strip(), env_exports=env)
+
+    async def restore_state(self, state: ShellState) -> None:
+        """Restore shell to a previously captured state.
+
+        Re-sources environment exports and changes to the saved working
+        directory.  Errors are silently ignored so the shell remains usable.
+        """
+        if state.env_exports:
+            await self.run(state.env_exports)
+        if state.cwd:
+            await self.run(f"cd {shlex.quote(state.cwd)} 2>/dev/null || true")
+
+
+# ---------------------------------------------------------------------------
+# DockerTerminalTool
+# ---------------------------------------------------------------------------
+
+
+class DockerTerminalTool(ToolPort):
+    """Execute shell commands inside an ephemeral Docker container.
+
+    Implements the same :class:`~ravn.ports.tool.ToolPort` interface as
+    :class:`~ravn.adapters.tools.terminal.TerminalTool` — the tool registry
+    treats them identically; backend selection is done by configuration.
+
+    One container is started per task (on first ``execute`` call).  Shell
+    state — working directory, environment variables, activated venvs —
+    persists across calls within the container.
+
+    Pass ``initial_state`` to resume from a previously checkpointed
+    :class:`ShellState` (e.g. for task restart after interruption).
+
+    Args:
+        config:         :class:`~ravn.config.DockerTerminalConfig` instance.
+        workspace_root: Host path to mount read-write inside the container.
+        timeout_seconds: Per-command execution timeout.
+        initial_state:  Optional shell state to restore on first call.
+    """
+
+    def __init__(
+        self,
+        config: DockerTerminalConfig | None = None,
+        workspace_root: Path | None = None,
+        timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+        initial_state: ShellState | None = None,
+    ) -> None:
+        self._config = config or DockerTerminalConfig()
+        self._workspace_root = (workspace_root or Path.cwd()).resolve()
+        self._timeout = timeout_seconds
+        self._initial_state = initial_state
+        self._shell: DockerPersistentShell | None = None
+
+    # ------------------------------------------------------------------
+    # ToolPort interface
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return "terminal"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Run a shell command inside an isolated Docker container and return its "
+            "combined stdout/stderr output. "
+            "Working directory, environment variables, and activated virtual "
+            "environments persist across calls within the same task. "
+            "The container is destroyed cleanly when the task ends."
+        )
+
+    @property
+    def input_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string",
+                    "description": "Shell command to execute inside the Docker sandbox.",
+                },
+            },
+            "required": ["command"],
+        }
+
+    @property
+    def required_permission(self) -> str:
+        return _PERMISSION_SHELL
+
+    @property
+    def parallelisable(self) -> bool:
+        return False
+
+    async def execute(self, input: dict) -> ToolResult:
+        command = input.get("command", "").strip()
+        if not command:
+            return ToolResult(tool_call_id="", content="No command provided.", is_error=True)
+
+        if self._shell is None:
+            self._shell = DockerPersistentShell(
+                config=self._config,
+                workspace_root=self._workspace_root,
+                timeout_seconds=self._timeout,
+            )
+            await self._shell.start()
+            if self._initial_state is not None:
+                await self._shell.restore_state(self._initial_state)
+
+        output, exit_code = await self._shell.run(command)
+        return self._build_result(output, exit_code)
+
+    # ------------------------------------------------------------------
+    # State / cleanup
+    # ------------------------------------------------------------------
+
+    async def get_state(self) -> ShellState | None:
+        """Return the current shell state for checkpointing.
+
+        Returns ``None`` if the container has not been started yet.
+        """
+        if self._shell is None or not self._shell.is_running:
+            return None
+        return await self._shell.get_state()
+
+    async def close(self) -> None:
+        """Destroy the Docker container and clean up resources."""
+        if self._shell is not None:
+            await self._shell.close()
+            self._shell = None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _build_result(output: str, exit_code: int) -> ToolResult:
+        content = output.rstrip("\n")
+        if exit_code != 0:
+            suffix = f"\n[exit {exit_code}]"
+            content = (content + suffix).strip()
+        return ToolResult(tool_call_id="", content=content, is_error=exit_code != 0)

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -126,9 +126,34 @@ class FileToolsConfig(BaseModel):
     )
 
 
+class DockerTerminalConfig(BaseModel):
+    """Docker-specific settings for the docker terminal backend."""
+
+    image: str = Field(
+        default="python:3.11-slim",
+        description="Docker image used for the sandboxed container.",
+    )
+    network: str = Field(
+        default="none",
+        description="Docker network mode: 'none' (isolated), 'bridge', or 'host'.",
+    )
+    mount_workspace: bool = Field(
+        default=True,
+        description="Mount the workspace directory read-write inside the container.",
+    )
+    extra_mounts: list[str] = Field(
+        default_factory=list,
+        description="Additional volume mounts in 'host:container' format.",
+    )
+
+
 class TerminalToolConfig(BaseModel):
     """Terminal tool configuration."""
 
+    backend: str = Field(
+        default="local",
+        description="Terminal backend: 'local' (host shell) or 'docker' (sandboxed container).",
+    )
     persistent_shell: bool = Field(
         default=True,
         description="Keep a single shell process alive across tool calls.",
@@ -140,6 +165,10 @@ class TerminalToolConfig(BaseModel):
     timeout_seconds: float = Field(
         default=30.0,
         description="Seconds to wait for a command to complete before timing out.",
+    )
+    docker: DockerTerminalConfig = Field(
+        default_factory=DockerTerminalConfig,
+        description="Docker backend configuration (used when backend='docker').",
     )
 
 
@@ -210,7 +239,6 @@ class BashToolConfig(BaseModel):
             "and for path boundary checks. Defaults to CWD when empty."
         ),
     )
-
 
 
 class ToolsConfig(BaseModel):
@@ -554,7 +582,7 @@ class ProjectConfig:
         for line in text.splitlines():
             if not past_header:
                 if line.startswith("# RAVN Project:"):
-                    project_name = line[len("# RAVN Project:"):].strip()
+                    project_name = line[len("# RAVN Project:") :].strip()
                     past_header = True
                 continue
             yaml_lines.append(line)

--- a/tests/ravn/unit/test_permission_enforcer.py
+++ b/tests/ravn/unit/test_permission_enforcer.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from ravn.adapters.bash_validator import unwrap_sudo
 from ravn.adapters.permission_enforcer import (
     BashValidator,
     PermissionEnforcer,
@@ -156,7 +157,7 @@ class TestBashValidatorSudoUnwrap:
         assert intent in (CommandIntent.DESTRUCTIVE, CommandIntent.SYSTEM_ADMIN)
 
     def test_nested_sudo_unwrapped(self, v: BashValidator) -> None:
-        inner = v._unwrap_sudo("sudo sudo ls")
+        inner = unwrap_sudo("sudo sudo ls")
         assert "sudo" not in inner.split()[0] if inner else True
 
 

--- a/tests/ravn/unit/test_terminal_docker.py
+++ b/tests/ravn/unit/test_terminal_docker.py
@@ -1,0 +1,865 @@
+"""Unit tests for the Docker-sandboxed terminal backend.
+
+All tests mock ``asyncio.create_subprocess_exec`` so Docker is not required.
+The fake process is a simple in-memory pipe that simulates a bash process
+responding to commands with a sentinel line.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ravn.adapters.tools.terminal_docker import (
+    _PERMISSION_SHELL,
+    _SENTINEL_PREFIX,
+    DockerPersistentShell,
+    DockerTerminalTool,
+    ShellState,
+)
+from ravn.config import DockerTerminalConfig
+
+# ---------------------------------------------------------------------------
+# Helpers — fake asyncio subprocess
+# ---------------------------------------------------------------------------
+
+WORKSPACE = Path("/workspace")
+
+
+def _make_config(**kwargs) -> DockerTerminalConfig:
+    return DockerTerminalConfig(**kwargs)
+
+
+class FakeStdin:
+    """Fake stdin that records writes."""
+
+    def __init__(self) -> None:
+        self._buf = bytearray()
+
+    def write(self, data: bytes) -> None:
+        self._buf.extend(data)
+
+    async def drain(self) -> None:
+        pass
+
+    @property
+    def written(self) -> str:
+        return self._buf.decode()
+
+
+class FakeStdout:
+    """Fake stdout that returns pre-configured lines."""
+
+    def __init__(self, lines: list[bytes]) -> None:
+        self._lines = iter(lines)
+
+    async def readline(self) -> bytes:
+        try:
+            return next(self._lines)
+        except StopIteration:
+            return b""
+
+
+def _make_fake_process(
+    lines: list[bytes],
+    returncode: int = 0,
+    pid: int = 12345,
+) -> MagicMock:
+    """Build a fake asyncio.subprocess.Process with configurable stdout lines."""
+    proc = MagicMock()
+    proc.pid = pid
+    proc.returncode = None  # still running
+    proc.stdin = FakeStdin()
+    proc.stdout = FakeStdout(lines)
+
+    async def _wait():
+        proc.returncode = returncode
+
+    proc.wait = _wait
+    proc.kill = MagicMock()
+    return proc
+
+
+def _sentinel_line(sentinel: str, exit_code: int = 0) -> bytes:
+    return f"{sentinel}:{exit_code}\n".encode()
+
+
+# ---------------------------------------------------------------------------
+# ShellState
+# ---------------------------------------------------------------------------
+
+
+class TestShellState:
+    def test_defaults(self):
+        state = ShellState()
+        assert state.cwd == ""
+        assert state.env_exports == ""
+
+    def test_custom_values(self):
+        state = ShellState(cwd="/tmp", env_exports="export FOO=bar")
+        assert state.cwd == "/tmp"
+        assert state.env_exports == "export FOO=bar"
+
+
+# ---------------------------------------------------------------------------
+# DockerPersistentShell — lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestDockerPersistentShellLifecycle:
+    @pytest.mark.asyncio
+    async def test_start_launches_docker_run(self):
+        config = _make_config()
+        shell = DockerPersistentShell(config=config, workspace_root=WORKSPACE)
+        assert not shell.is_running
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            mock_exec.return_value = _make_fake_process([])
+            await shell.start()
+            assert shell.is_running
+            call_args = mock_exec.call_args[0]
+            assert call_args[0] == "docker"
+            assert call_args[1] == "run"
+
+        await shell.close()
+
+    @pytest.mark.asyncio
+    async def test_start_is_idempotent(self):
+        config = _make_config()
+        shell = DockerPersistentShell(config=config, workspace_root=WORKSPACE)
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            mock_exec.return_value = _make_fake_process([])
+            await shell.start()
+            await shell.start()
+            # create_subprocess_exec called only once
+            assert mock_exec.call_count == 1
+
+        await shell.close()
+
+    @pytest.mark.asyncio
+    async def test_close_kills_process_and_removes_container(self):
+        config = _make_config()
+        shell = DockerPersistentShell(config=config, workspace_root=WORKSPACE)
+
+        proc = _make_fake_process([])
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            mock_exec.side_effect = [
+                proc,  # docker run
+                _make_fake_process([]),  # docker rm -f
+            ]
+            await shell.start()
+            assert shell.is_running
+            await shell.close()
+
+        assert not shell.is_running
+
+    @pytest.mark.asyncio
+    async def test_close_before_start_is_safe(self):
+        config = _make_config()
+        shell = DockerPersistentShell(config=config, workspace_root=WORKSPACE)
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            mock_exec.return_value = _make_fake_process([])
+            await shell.close()  # never started — should not raise
+
+    @pytest.mark.asyncio
+    async def test_context_manager(self):
+        config = _make_config()
+
+        proc = _make_fake_process([])
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            mock_exec.side_effect = [
+                proc,  # docker run
+                _make_fake_process([]),  # docker rm -f
+            ]
+            async with DockerPersistentShell(config=config, workspace_root=WORKSPACE) as shell:
+                assert shell.is_running
+            assert not shell.is_running
+
+
+# ---------------------------------------------------------------------------
+# DockerPersistentShell — docker command construction
+# ---------------------------------------------------------------------------
+
+
+class TestDockerCmdConstruction:
+    @pytest.mark.asyncio
+    async def test_network_flag_included(self):
+        config = _make_config(network="bridge")
+        shell = DockerPersistentShell(config=config, workspace_root=WORKSPACE)
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            mock_exec.return_value = _make_fake_process([])
+            await shell.start()
+            args = mock_exec.call_args[0]
+            assert "--network=bridge" in args
+
+        await shell.close()
+
+    @pytest.mark.asyncio
+    async def test_workspace_mount_included_when_enabled(self):
+        config = _make_config(mount_workspace=True)
+        shell = DockerPersistentShell(config=config, workspace_root=WORKSPACE)
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            mock_exec.return_value = _make_fake_process([])
+            await shell.start()
+            args = mock_exec.call_args[0]
+            assert "-v" in args
+            # workspace path appears as both source and target
+            ws = str(WORKSPACE)
+            assert any(f"{ws}:{ws}" == arg for arg in args)
+
+        await shell.close()
+
+    @pytest.mark.asyncio
+    async def test_workspace_mount_omitted_when_disabled(self):
+        config = _make_config(mount_workspace=False)
+        shell = DockerPersistentShell(config=config, workspace_root=WORKSPACE)
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            mock_exec.return_value = _make_fake_process([])
+            await shell.start()
+            args = mock_exec.call_args[0]
+            ws = str(WORKSPACE)
+            assert not any(f"{ws}:{ws}" == arg for arg in args)
+
+        await shell.close()
+
+    @pytest.mark.asyncio
+    async def test_extra_mounts_included(self):
+        config = _make_config(extra_mounts=["/data:/data:ro"])
+        shell = DockerPersistentShell(config=config, workspace_root=WORKSPACE)
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            mock_exec.return_value = _make_fake_process([])
+            await shell.start()
+            args = mock_exec.call_args[0]
+            assert "/data:/data:ro" in args
+
+        await shell.close()
+
+    @pytest.mark.asyncio
+    async def test_image_used(self):
+        config = _make_config(image="ubuntu:22.04")
+        shell = DockerPersistentShell(config=config, workspace_root=WORKSPACE)
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            mock_exec.return_value = _make_fake_process([])
+            await shell.start()
+            args = mock_exec.call_args[0]
+            assert "ubuntu:22.04" in args
+
+        await shell.close()
+
+    @pytest.mark.asyncio
+    async def test_rm_and_interactive_flags_present(self):
+        config = _make_config()
+        shell = DockerPersistentShell(config=config, workspace_root=WORKSPACE)
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            mock_exec.return_value = _make_fake_process([])
+            await shell.start()
+            args = mock_exec.call_args[0]
+            assert "--rm" in args
+            assert "--interactive" in args
+
+        await shell.close()
+
+    @pytest.mark.asyncio
+    async def test_shell_flags_present(self):
+        config = _make_config()
+        shell = DockerPersistentShell(config=config, workspace_root=WORKSPACE)
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            mock_exec.return_value = _make_fake_process([])
+            await shell.start()
+            args = mock_exec.call_args[0]
+            assert "--norc" in args
+            assert "--noprofile" in args
+
+        await shell.close()
+
+
+# ---------------------------------------------------------------------------
+# DockerPersistentShell — command execution
+# ---------------------------------------------------------------------------
+
+
+class TestDockerPersistentShellRun:
+    """Tests for run() using a fake process with sentinel-terminated output."""
+
+    async def _run_with_output(
+        self,
+        command: str,
+        output_lines: list[str],
+        exit_code: int = 0,
+        config: DockerTerminalConfig | None = None,
+    ) -> tuple[str, int]:
+        """Helper: start a shell, inject output_lines + sentinel, run command."""
+        cfg = config or _make_config()
+        shell = DockerPersistentShell(config=cfg, workspace_root=WORKSPACE)
+
+        # We need to intercept the sentinel written by run() itself.
+        # Strategy: patch create_subprocess_exec, capture the stdin writes,
+        # and serve back lines dynamically.
+
+        written_chunks: list[bytes] = []
+
+        class DynamicStdin:
+            def write(self, data: bytes) -> None:
+                written_chunks.append(data)
+
+            async def drain(self) -> None:
+                pass
+
+        # Build response lines: user-defined output + sentinel line.
+        # The sentinel is written as part of the wrapped command;
+        # we extract it by inspecting what was written to stdin.
+        response_queue: asyncio.Queue[bytes] = asyncio.Queue()
+
+        class DynamicStdout:
+            async def readline(self) -> bytes:
+                return await response_queue.get()
+
+        async def populate_responses():
+            # Wait until stdin has the sentinel written into it
+            await asyncio.sleep(0.01)
+            # Extract sentinel from the last write
+            combined = b"".join(written_chunks).decode()
+            sentinel = ""
+            for line in combined.splitlines():
+                if line.startswith(f"echo {_SENTINEL_PREFIX}_"):
+                    sentinel = line.split()[1].split(":")[0]
+                    break
+
+            for line in output_lines:
+                await response_queue.put(line.encode() + b"\n")
+            await response_queue.put(f"{sentinel}:{exit_code}\n".encode())
+
+        proc = MagicMock()
+        proc.pid = 42
+        proc.returncode = None
+        proc.stdin = DynamicStdin()
+        proc.stdout = DynamicStdout()
+
+        async def _wait():
+            proc.returncode = 0
+
+        proc.wait = _wait
+        proc.kill = MagicMock()
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            rm_proc = _make_fake_process([])
+            mock_exec.side_effect = [proc, rm_proc]
+
+            await shell.start()
+            asyncio.create_task(populate_responses())
+            result = await shell.run(command)
+            await shell.close()
+
+        return result
+
+    @pytest.mark.asyncio
+    async def test_run_returns_output_and_zero_exit(self):
+        output, rc = await self._run_with_output("echo hello", ["hello"], exit_code=0)
+        assert "hello" in output
+        assert rc == 0
+
+    @pytest.mark.asyncio
+    async def test_run_returns_nonzero_exit(self):
+        _, rc = await self._run_with_output("false", [], exit_code=1)
+        assert rc == 1
+
+    @pytest.mark.asyncio
+    async def test_run_captures_multiple_output_lines(self):
+        output, rc = await self._run_with_output("printf 'a\\nb\\nc'", ["a", "b", "c"], exit_code=0)
+        assert "a" in output
+        assert "b" in output
+        assert "c" in output
+        assert rc == 0
+
+    @pytest.mark.asyncio
+    async def test_run_auto_starts_shell(self):
+        """run() must start the shell automatically if not yet started."""
+        cfg = _make_config()
+        shell = DockerPersistentShell(config=cfg, workspace_root=WORKSPACE)
+        assert not shell.is_running
+
+        written_chunks: list[bytes] = []
+
+        class DynamicStdin:
+            def write(self, data: bytes) -> None:
+                written_chunks.append(data)
+
+            async def drain(self) -> None:
+                pass
+
+        response_queue: asyncio.Queue[bytes] = asyncio.Queue()
+
+        class DynamicStdout:
+            async def readline(self) -> bytes:
+                return await response_queue.get()
+
+        proc = MagicMock()
+        proc.pid = 99
+        proc.returncode = None
+        proc.stdin = DynamicStdin()
+        proc.stdout = DynamicStdout()
+
+        async def _wait():
+            proc.returncode = 0
+
+        proc.wait = _wait
+        proc.kill = MagicMock()
+
+        async def populate():
+            await asyncio.sleep(0.01)
+            combined = b"".join(written_chunks).decode()
+            sentinel = ""
+            for line in combined.splitlines():
+                if line.startswith(f"echo {_SENTINEL_PREFIX}_"):
+                    sentinel = line.split()[1].split(":")[0]
+                    break
+            await response_queue.put(b"auto-started\n")
+            await response_queue.put(f"{sentinel}:0\n".encode())
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            rm_proc = _make_fake_process([])
+            mock_exec.side_effect = [proc, rm_proc]
+            asyncio.create_task(populate())
+            output, rc = await shell.run("echo auto-started")
+            await shell.close()
+
+        assert "auto-started" in output
+        assert rc == 0
+
+    @pytest.mark.asyncio
+    async def test_run_eof_returns_process_exit_code(self):
+        """When stdout returns EOF, run() returns the process returncode."""
+        cfg = _make_config()
+        shell = DockerPersistentShell(config=cfg, workspace_root=WORKSPACE)
+
+        proc = MagicMock()
+        proc.pid = 1
+        proc.returncode = None
+        proc.stdin = FakeStdin()
+        # stdout immediately returns EOF
+        proc.stdout = FakeStdout([])  # empty — immediately returns b""
+
+        async def _wait():
+            proc.returncode = 42
+
+        proc.wait = _wait
+        proc.kill = MagicMock()
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            rm_proc = _make_fake_process([])
+            mock_exec.side_effect = [proc, rm_proc]
+            await shell.start()
+            output, rc = await shell.run("exit 42")
+            await shell.close()
+
+        assert rc == 42
+
+
+# ---------------------------------------------------------------------------
+# DockerPersistentShell — timeout
+# ---------------------------------------------------------------------------
+
+
+class TestDockerPersistentShellTimeout:
+    @pytest.mark.asyncio
+    async def test_timeout_returns_124(self):
+        cfg = _make_config()
+        shell = DockerPersistentShell(config=cfg, workspace_root=WORKSPACE, timeout_seconds=0.05)
+
+        proc = MagicMock()
+        proc.pid = 5
+        proc.returncode = None
+        proc.stdin = FakeStdin()
+
+        class HangingStdout:
+            async def readline(self) -> bytes:
+                await asyncio.sleep(60)  # never returns within timeout
+                return b""
+
+        proc.stdout = HangingStdout()
+
+        async def _wait():
+            proc.returncode = 0
+
+        proc.wait = _wait
+        proc.kill = MagicMock()
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            rm_proc = _make_fake_process([])
+            mock_exec.side_effect = [proc, rm_proc]
+            await shell.start()
+            output, rc = await shell.run("sleep 60")
+
+        assert rc == 124
+        assert "timed out" in output
+        assert not shell.is_running
+
+
+# ---------------------------------------------------------------------------
+# DockerPersistentShell — state capture / restore
+# ---------------------------------------------------------------------------
+
+
+class TestDockerShellState:
+    @pytest.mark.asyncio
+    async def test_get_state_calls_pwd_and_export(self):
+        """get_state() must run both pwd and export -p."""
+        cfg = _make_config()
+        shell = DockerPersistentShell(config=cfg, workspace_root=WORKSPACE)
+
+        written: list[str] = []
+        response_queue: asyncio.Queue[bytes] = asyncio.Queue()
+        written_bytes: list[bytes] = []
+
+        class CapturingStdin:
+            def write(self, data: bytes) -> None:
+                written_bytes.append(data)
+
+            async def drain(self) -> None:
+                pass
+
+        class DynamicStdout:
+            async def readline(self) -> bytes:
+                return await response_queue.get()
+
+        proc = MagicMock()
+        proc.pid = 77
+        proc.returncode = None
+        proc.stdin = CapturingStdin()
+        proc.stdout = DynamicStdout()
+
+        async def _wait():
+            proc.returncode = 0
+
+        proc.wait = _wait
+        proc.kill = MagicMock()
+
+        sentinel_count = 0
+
+        async def populate():
+            nonlocal sentinel_count
+            # get_state sends two commands: pwd and export -p
+            # We respond with sentinel for each
+            for _ in range(2):
+                await asyncio.sleep(0.02)
+                combined = b"".join(written_bytes).decode()
+                # Find the latest unseen sentinel
+                lines = combined.splitlines()
+                last_sentinel = ""
+                for line in reversed(lines):
+                    if line.startswith(f"echo {_SENTINEL_PREFIX}_"):
+                        candidate = line.split()[1].split(":")[0]
+                        if candidate not in written:
+                            last_sentinel = candidate
+                            written.append(candidate)
+                            break
+                if sentinel_count == 0:
+                    await response_queue.put(b"/tmp\n")
+                else:
+                    await response_queue.put(b"export FOO=bar\n")
+                await response_queue.put(f"{last_sentinel}:0\n".encode())
+                sentinel_count += 1
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            rm_proc = _make_fake_process([])
+            mock_exec.side_effect = [proc, rm_proc]
+            await shell.start()
+            asyncio.create_task(populate())
+            await asyncio.sleep(0.01)
+            state = await shell.get_state()
+            await shell.close()
+
+        assert "/tmp" in state.cwd
+        assert "FOO" in state.env_exports
+
+    @pytest.mark.asyncio
+    async def test_restore_state_empty_is_noop(self):
+        """restore_state with empty ShellState should not raise or send commands."""
+        cfg = _make_config()
+        shell = DockerPersistentShell(config=cfg, workspace_root=WORKSPACE)
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            rm_proc = _make_fake_process([])
+            mock_exec.side_effect = [rm_proc]
+            await shell.restore_state(ShellState())  # no-op, shell not started
+
+
+# ---------------------------------------------------------------------------
+# DockerTerminalTool — interface
+# ---------------------------------------------------------------------------
+
+
+class TestDockerTerminalToolInterface:
+    def test_name(self):
+        assert DockerTerminalTool().name == "terminal"
+
+    def test_description_mentions_docker(self):
+        desc = DockerTerminalTool().description
+        assert "docker" in desc.lower() or "container" in desc.lower()
+
+    def test_required_permission(self):
+        assert DockerTerminalTool().required_permission == _PERMISSION_SHELL
+
+    def test_input_schema_requires_command(self):
+        schema = DockerTerminalTool().input_schema
+        assert schema["type"] == "object"
+        assert "command" in schema["properties"]
+        assert "command" in schema["required"]
+
+    def test_to_api_dict_shape(self):
+        api = DockerTerminalTool().to_api_dict()
+        assert api["name"] == "terminal"
+        assert "description" in api
+        assert "input_schema" in api
+
+    def test_not_parallelisable(self):
+        assert DockerTerminalTool().parallelisable is False
+
+    def test_default_config_applied(self):
+        tool = DockerTerminalTool()
+        assert isinstance(tool._config, DockerTerminalConfig)
+
+    def test_custom_config_applied(self):
+        cfg = DockerTerminalConfig(image="node:20-slim", network="bridge")
+        tool = DockerTerminalTool(config=cfg)
+        assert tool._config.image == "node:20-slim"
+        assert tool._config.network == "bridge"
+
+    def test_timeout_propagated(self):
+        tool = DockerTerminalTool(timeout_seconds=99.0)
+        assert tool._timeout == 99.0
+
+    def test_initial_state_stored(self):
+        state = ShellState(cwd="/app", env_exports="export X=1")
+        tool = DockerTerminalTool(initial_state=state)
+        assert tool._initial_state is state
+
+
+# ---------------------------------------------------------------------------
+# DockerTerminalTool — execute
+# ---------------------------------------------------------------------------
+
+
+class TestDockerTerminalToolExecute:
+    @pytest.mark.asyncio
+    async def test_empty_command_returns_error(self):
+        tool = DockerTerminalTool()
+        result = await tool.execute({"command": ""})
+        assert result.is_error
+        assert "No command" in result.content
+
+    @pytest.mark.asyncio
+    async def test_whitespace_command_returns_error(self):
+        tool = DockerTerminalTool()
+        result = await tool.execute({"command": "   "})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_execute_calls_shell_run(self):
+        tool = DockerTerminalTool()
+        mock_shell = AsyncMock()
+        mock_shell.is_running = True
+        mock_shell.run = AsyncMock(return_value=("hello", 0))
+        mock_shell.restore_state = AsyncMock()
+        tool._shell = mock_shell
+
+        result = await tool.execute({"command": "echo hello"})
+        assert not result.is_error
+        assert "hello" in result.content
+        mock_shell.run.assert_called_once_with("echo hello")
+
+    @pytest.mark.asyncio
+    async def test_execute_nonzero_exit_is_error(self):
+        tool = DockerTerminalTool()
+        mock_shell = AsyncMock()
+        mock_shell.is_running = True
+        mock_shell.run = AsyncMock(return_value=("", 1))
+        tool._shell = mock_shell
+
+        result = await tool.execute({"command": "false"})
+        assert result.is_error
+        assert "exit 1" in result.content
+
+    @pytest.mark.asyncio
+    async def test_execute_creates_shell_on_first_call(self):
+        tool = DockerTerminalTool()
+        assert tool._shell is None
+
+        with patch("ravn.adapters.tools.terminal_docker.DockerPersistentShell") as mock_shell_cls:
+            instance = AsyncMock()
+            instance.is_running = True
+            instance.run = AsyncMock(return_value=("ok", 0))
+            instance.start = AsyncMock()
+            instance.restore_state = AsyncMock()
+            mock_shell_cls.return_value = instance
+
+            result = await tool.execute({"command": "echo ok"})
+            instance.start.assert_called_once()
+            assert result.content == "ok"
+
+    @pytest.mark.asyncio
+    async def test_execute_restores_initial_state_on_first_call(self):
+        initial = ShellState(cwd="/app", env_exports="export X=1")
+        tool = DockerTerminalTool(initial_state=initial)
+
+        with patch("ravn.adapters.tools.terminal_docker.DockerPersistentShell") as mock_shell_cls:
+            instance = AsyncMock()
+            instance.is_running = True
+            instance.run = AsyncMock(return_value=("ok", 0))
+            instance.start = AsyncMock()
+            instance.restore_state = AsyncMock()
+            mock_shell_cls.return_value = instance
+
+            await tool.execute({"command": "echo ok"})
+            instance.restore_state.assert_called_once_with(initial)
+
+    @pytest.mark.asyncio
+    async def test_execute_does_not_restore_state_without_initial_state(self):
+        tool = DockerTerminalTool()
+
+        with patch("ravn.adapters.tools.terminal_docker.DockerPersistentShell") as mock_shell_cls:
+            instance = AsyncMock()
+            instance.is_running = True
+            instance.run = AsyncMock(return_value=("ok", 0))
+            instance.start = AsyncMock()
+            instance.restore_state = AsyncMock()
+            mock_shell_cls.return_value = instance
+
+            await tool.execute({"command": "echo ok"})
+            instance.restore_state.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# DockerTerminalTool — get_state and close
+# ---------------------------------------------------------------------------
+
+
+class TestDockerTerminalToolStateAndClose:
+    @pytest.mark.asyncio
+    async def test_get_state_none_before_first_call(self):
+        tool = DockerTerminalTool()
+        state = await tool.get_state()
+        assert state is None
+
+    @pytest.mark.asyncio
+    async def test_get_state_none_when_shell_not_running(self):
+        tool = DockerTerminalTool()
+        mock_shell = AsyncMock()
+        mock_shell.is_running = False
+        tool._shell = mock_shell
+
+        state = await tool.get_state()
+        assert state is None
+
+    @pytest.mark.asyncio
+    async def test_get_state_delegates_to_shell(self):
+        tool = DockerTerminalTool()
+        expected_state = ShellState(cwd="/tmp", env_exports="")
+        mock_shell = AsyncMock()
+        mock_shell.is_running = True
+        mock_shell.get_state = AsyncMock(return_value=expected_state)
+        tool._shell = mock_shell
+
+        state = await tool.get_state()
+        assert state is expected_state
+
+    @pytest.mark.asyncio
+    async def test_close_destroys_shell(self):
+        tool = DockerTerminalTool()
+        mock_shell = AsyncMock()
+        mock_shell.close = AsyncMock()
+        tool._shell = mock_shell
+
+        await tool.close()
+        mock_shell.close.assert_called_once()
+        assert tool._shell is None
+
+    @pytest.mark.asyncio
+    async def test_close_is_idempotent(self):
+        tool = DockerTerminalTool()
+        await tool.close()  # no shell — should not raise
+        await tool.close()  # still no shell — should not raise
+
+    @pytest.mark.asyncio
+    async def test_close_sets_shell_to_none(self):
+        tool = DockerTerminalTool()
+        mock_shell = AsyncMock()
+        mock_shell.close = AsyncMock()
+        tool._shell = mock_shell
+
+        await tool.close()
+        assert tool._shell is None
+
+
+# ---------------------------------------------------------------------------
+# DockerTerminalConfig defaults
+# ---------------------------------------------------------------------------
+
+
+class TestDockerTerminalConfig:
+    def test_default_image(self):
+        cfg = DockerTerminalConfig()
+        assert cfg.image == "python:3.11-slim"
+
+    def test_default_network_is_none(self):
+        cfg = DockerTerminalConfig()
+        assert cfg.network == "none"
+
+    def test_default_mount_workspace_true(self):
+        cfg = DockerTerminalConfig()
+        assert cfg.mount_workspace is True
+
+    def test_default_extra_mounts_empty(self):
+        cfg = DockerTerminalConfig()
+        assert cfg.extra_mounts == []
+
+    def test_custom_values(self):
+        cfg = DockerTerminalConfig(
+            image="node:20",
+            network="bridge",
+            mount_workspace=False,
+            extra_mounts=["/data:/data"],
+        )
+        assert cfg.image == "node:20"
+        assert cfg.network == "bridge"
+        assert cfg.mount_workspace is False
+        assert cfg.extra_mounts == ["/data:/data"]
+
+
+# ---------------------------------------------------------------------------
+# TerminalToolConfig integration
+# ---------------------------------------------------------------------------
+
+
+class TestTerminalToolConfigIntegration:
+    def test_terminal_config_has_backend_field(self):
+        from ravn.config import TerminalToolConfig
+
+        cfg = TerminalToolConfig()
+        assert cfg.backend == "local"
+
+    def test_terminal_config_backend_docker(self):
+        from ravn.config import TerminalToolConfig
+
+        cfg = TerminalToolConfig(backend="docker")
+        assert cfg.backend == "docker"
+
+    def test_terminal_config_has_docker_sub_config(self):
+        from ravn.config import TerminalToolConfig
+
+        cfg = TerminalToolConfig()
+        assert isinstance(cfg.docker, DockerTerminalConfig)


### PR DESCRIPTION
## Summary

- **New file** `src/ravn/adapters/tools/terminal_docker.py`: implements `DockerTerminalTool` and `DockerPersistentShell` — an ephemeral-container terminal backend that satisfies the same `ToolPort` interface as the existing local backend
- **Config** (`src/ravn/config.py`): adds `DockerTerminalConfig` model and extends `TerminalToolConfig` with `backend` (local | docker) and `docker` sub-config fields
- **Tests** (`tests/ravn/unit/test_terminal_docker.py`): 53 unit tests covering lifecycle, Docker command construction, command execution, timeout, state capture/restore, ToolPort interface, and config integration — all mocked so Docker is not required in CI
- **Pre-existing bug fixes** (`bash_validator.py`, `permission_enforcer.py`, `test_permission_enforcer.py`): two failing tests on `feat/ravn` fixed — `_unwrap_sudo` renamed to module-level `unwrap_sudo`, unknown commands classified as `WRITE` (safer default)

### Docker backend behaviour

| Property | Value |
|---|---|
| Container lifetime | One per task (not per command) — shell state persists across calls |
| Network | `none` (isolated) by default; configurable to `bridge` or `host` |
| Workspace mount | Read-write bind mount at the same path inside the container |
| Extra mounts | Opt-in via `tools.terminal.docker.extra_mounts` |
| Cleanup | Container destroyed on `close()` or timeout kill |

### Config example (ravn.yaml / RAVN.md)

```yaml
tools:
  terminal:
    backend: docker
    docker:
      image: python:3.11-slim
      network: none
      mount_workspace: true
      extra_mounts: []
```

## Test plan

- [x] `pytest tests/ravn/unit/test_terminal_docker.py` — 53/53 passed
- [x] `pytest tests/ravn/` — 577/577 passed (0 failures, pre-existing failures fixed)
- [x] `ruff check` — clean
- [x] `ruff format` — no changes needed
- [x] Coverage for `terminal_docker.py` — 95%

🤖 Generated with [Claude Code](https://claude.com/claude-code)