### PR TITLE
feat(adapters): nng service discovery — registry file and multi-publisher dial (NIU-521)

### DIFF
--- a/src/sleipnir/adapters/discovery.py
+++ b/src/sleipnir/adapters/discovery.py
@@ -1,0 +1,242 @@
+"""Service discovery for the nng Sleipnir transport.
+
+Multiple ODIN processes on the same machine use a shared JSON registry file
+to find each other's IPC socket addresses automatically.  No hardcoded paths,
+no external service required — just a file protected by an advisory flock.
+
+Registry file format::
+
+    {
+      "services": [
+        {
+          "id": "ravn:agent-abc",
+          "pid": 12345,
+          "socket": "ipc:///tmp/sleipnir-abc.sock",
+          "started": "2026-04-05T12:00:00+00:00"
+        }
+      ],
+      "primary_pub": "ipc:///tmp/sleipnir.sock"
+    }
+
+Locking
+-------
+All writes acquire an exclusive ``fcntl.LOCK_EX`` advisory lock on the
+registry file.  Reads acquire a shared ``fcntl.LOCK_SH`` lock.  Locks are
+released when the context exits.
+
+Stale-entry cleanup
+-------------------
+On every access, PIDs that are no longer running are pruned.  A process is
+considered dead if ``os.kill(pid, 0)`` raises ``ProcessLookupError``.
+``PermissionError`` means the process exists but is owned by another user —
+treated as alive.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import logging
+import os
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+DEFAULT_REGISTRY_PATH = Path.home() / ".odin" / "sleipnir.json"
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ServiceEntry:
+    """A single registered service instance."""
+
+    id: str
+    pid: int
+    socket: str
+    started: str  # ISO 8601 UTC
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_alive(pid: int) -> bool:
+    """Return ``True`` if *pid* is a running process on this machine."""
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Process exists but belongs to a different user — still alive.
+        return True
+
+
+class _LockedFile:
+    """Open a file and hold an advisory ``flock`` for the duration.
+
+    - ``write=False`` → ``LOCK_SH`` (shared read lock), opened ``"rb"``.
+    - ``write=True`` → ``LOCK_EX`` (exclusive write lock), created if absent
+      via ``O_CREAT | O_RDWR`` so create-or-open is atomic.
+    """
+
+    def __init__(self, path: Path, *, write: bool) -> None:
+        self._path = path
+        self._write = write
+        self._fh = None
+
+    def __enter__(self):
+        if self._write:
+            fd = os.open(str(self._path), os.O_RDWR | os.O_CREAT, 0o644)
+            self._fh = os.fdopen(fd, "r+b")
+            fcntl.flock(self._fh, fcntl.LOCK_EX)
+        else:
+            self._fh = open(self._path, "rb")
+            fcntl.flock(self._fh, fcntl.LOCK_SH)
+        return self._fh
+
+    def __exit__(self, *_: object) -> None:
+        if self._fh is not None:
+            fcntl.flock(self._fh, fcntl.LOCK_UN)
+            self._fh.close()
+            self._fh = None
+
+
+# ---------------------------------------------------------------------------
+# ServiceRegistry
+# ---------------------------------------------------------------------------
+
+
+class ServiceRegistry:
+    """JSON-backed service registry with file-level advisory locking.
+
+    Each service that wants to be discoverable calls :meth:`register` on
+    startup and :meth:`deregister` on clean shutdown.  Subscribers call
+    :meth:`list_services` to obtain the current set of live publisher sockets.
+
+    Usage::
+
+        registry = ServiceRegistry(Path("/run/odin/sleipnir.json"))
+        registry.register("ravn:agent-abc", "ipc:///tmp/sleipnir-abc.sock")
+        entries = registry.list_services()
+        registry.deregister("ravn:agent-abc")
+    """
+
+    def __init__(
+        self,
+        path: Path = DEFAULT_REGISTRY_PATH,
+        primary_pub: str = "",
+    ) -> None:
+        self._path = path
+        self._primary_pub = primary_pub
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def register(self, service_id: str, socket: str) -> None:
+        """Register *service_id* at *socket* in the registry.
+
+        Stale entries (dead PIDs) are removed first.  If *service_id* is
+        already present (restart scenario), the old entry is replaced.
+        """
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        with _LockedFile(self._path, write=True) as f:
+            data = self._read(f)
+            live = [s for s in data["services"] if _is_alive(s["pid"])]
+            live = [s for s in live if s["id"] != service_id]
+            live.append(
+                {
+                    "id": service_id,
+                    "pid": os.getpid(),
+                    "socket": socket,
+                    "started": datetime.now(UTC).isoformat(),
+                }
+            )
+            data["services"] = live
+            self._write(f, data)
+        logger.debug("ServiceRegistry: registered %s at %s", service_id, socket)
+
+    def deregister(self, service_id: str) -> None:
+        """Remove *service_id* from the registry.
+
+        No-op if the file does not exist or the entry is already absent.
+        """
+        if not self._path.exists():
+            return
+        with _LockedFile(self._path, write=True) as f:
+            data = self._read(f)
+            before = len(data["services"])
+            data["services"] = [s for s in data["services"] if s["id"] != service_id]
+            if len(data["services"]) < before:
+                self._write(f, data)
+        logger.debug("ServiceRegistry: deregistered %s", service_id)
+
+    def list_services(self) -> list[ServiceEntry]:
+        """Return all live (non-stale) service entries.
+
+        Returns an empty list if the registry file does not exist.
+        """
+        if not self._path.exists():
+            return []
+        with _LockedFile(self._path, write=False) as f:
+            data = self._read(f)
+        return [
+            ServiceEntry(id=s["id"], pid=s["pid"], socket=s["socket"], started=s["started"])
+            for s in data["services"]
+            if _is_alive(s["pid"])
+        ]
+
+    def cleanup_stale(self) -> int:
+        """Remove entries whose PID is no longer running.
+
+        Returns the number of entries removed.
+        """
+        if not self._path.exists():
+            return 0
+        with _LockedFile(self._path, write=True) as f:
+            data = self._read(f)
+            before = len(data["services"])
+            data["services"] = [s for s in data["services"] if _is_alive(s["pid"])]
+            removed = before - len(data["services"])
+            if removed:
+                self._write(f, data)
+        if removed:
+            logger.info("ServiceRegistry: removed %d stale entries", removed)
+        return removed
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _read(self, f) -> dict:
+        """Parse JSON from an open, locked file handle (seeking to start)."""
+        f.seek(0)
+        content = f.read()
+        if not content.strip():
+            return {"services": [], "primary_pub": self._primary_pub}
+        try:
+            data = json.loads(content)
+        except json.JSONDecodeError:
+            logger.warning("ServiceRegistry: corrupt registry at %s; resetting", self._path)
+            return {"services": [], "primary_pub": self._primary_pub}
+        data.setdefault("services", [])
+        data.setdefault("primary_pub", self._primary_pub)
+        return data
+
+    def _write(self, f, data: dict) -> None:
+        """Serialise *data* to JSON and write to an open, locked file handle."""
+        f.seek(0)
+        f.truncate()
+        f.write(json.dumps(data, indent=2).encode())
+        f.flush()

--- a/src/sleipnir/adapters/nng_transport.py
+++ b/src/sleipnir/adapters/nng_transport.py
@@ -333,7 +333,8 @@ class NngSubscriber(SleipnirSubscriber):
         """
         if self._registry is None:
             return [self._address]
-        entries = await asyncio.get_running_loop().run_in_executor(None, self._registry.list_services)
+        loop = asyncio.get_running_loop()
+        entries = await loop.run_in_executor(None, self._registry.list_services)
         if not entries:
             logger.debug("NngSubscriber: registry empty, falling back to %s", self._address)
             return [self._address]

--- a/src/sleipnir/adapters/nng_transport.py
+++ b/src/sleipnir/adapters/nng_transport.py
@@ -27,11 +27,22 @@ Configuration example
     sleipnir:
       transport: "nng"
       address: "ipc:///tmp/sleipnir.sock"
+      discovery:
+        enabled: true
+        registry_path: /run/odin/sleipnir.json
 
 Transports
 ----------
 - **IPC** (``ipc:///tmp/sleipnir.sock``) — Unix-domain socket, ~10-50 µs latency.
 - **TCP** (``tcp://localhost:9500``) — for multi-machine or container deployments.
+
+Service discovery
+-----------------
+Pass a :class:`~sleipnir.adapters.discovery.ServiceRegistry` to enable
+multi-process discovery.  :class:`NngPublisher` registers its socket address on
+:meth:`~NngPublisher.start` and deregisters on :meth:`~NngPublisher.stop`.
+:class:`NngSubscriber` reads the registry on :meth:`~NngSubscriber.start` and
+dials every live publisher socket it finds.
 """
 
 from __future__ import annotations
@@ -53,6 +64,7 @@ from sleipnir.adapters._subscriber_support import (
     consume_queue,
     enqueue_with_overflow,
 )
+from sleipnir.adapters.discovery import ServiceRegistry
 from sleipnir.adapters.serialization import deserialize, serialize
 from sleipnir.domain.events import SleipnirEvent, match_event_type
 from sleipnir.ports.events import EventHandler, SleipnirPublisher, SleipnirSubscriber, Subscription
@@ -145,6 +157,11 @@ class NngPublisher(SleipnirPublisher):
     Binds a PUB socket at *address* and serialises :class:`SleipnirEvent`
     objects with msgpack before sending.
 
+    When *service_id* and *registry* are provided, the publisher registers
+    itself in the service registry on :meth:`start` and deregisters on
+    :meth:`stop`, enabling other processes to discover this socket
+    automatically.
+
     Usage::
 
         pub = NngPublisher("ipc:///tmp/sleipnir.sock")
@@ -157,21 +174,29 @@ class NngPublisher(SleipnirPublisher):
         address: str = DEFAULT_IPC_ADDRESS,
         bind_retry_delay_s: float = DEFAULT_BIND_RETRY_DELAY_S,
         bind_max_retries: int = DEFAULT_BIND_MAX_RETRIES,
+        service_id: str | None = None,
+        registry: ServiceRegistry | None = None,
     ) -> None:
         _require_pynng()
         self._address = address
         self._bind_retry_delay_s = bind_retry_delay_s
         self._bind_max_retries = bind_max_retries
+        self._service_id = service_id
+        self._registry = registry
         self._socket: pynng.Pub0 | None = None  # type: ignore[name-defined]
 
     async def start(self) -> None:
-        """Bind the PUB socket, retrying on transient address-in-use errors."""
+        """Bind the PUB socket, retrying on transient address-in-use errors.
+
+        If discovery is configured, registers this publisher in the service
+        registry after the socket is bound.
+        """
         self._socket = pynng.Pub0()
         for attempt in range(self._bind_max_retries):
             try:
                 self._socket.listen(self._address)
                 logger.debug("NngPublisher: bound to %s", self._address)
-                return
+                break
             except pynng.AddressInUse:
                 if attempt == self._bind_max_retries - 1:
                     self._socket.close()
@@ -184,9 +209,18 @@ class NngPublisher(SleipnirPublisher):
                     self._bind_max_retries,
                 )
                 await asyncio.sleep(self._bind_retry_delay_s)
+        if self._registry is not None and self._service_id is not None:
+            await asyncio.get_event_loop().run_in_executor(
+                None, self._registry.register, self._service_id, self._address
+            )
 
     async def stop(self) -> None:
-        """Close the PUB socket."""
+        """Deregister from discovery (if configured), then close the PUB socket."""
+        if self._registry is not None and self._service_id is not None:
+            with suppress(Exception):
+                await asyncio.get_event_loop().run_in_executor(
+                    None, self._registry.deregister, self._service_id
+                )
         if self._socket is not None:
             with suppress(Exception):
                 self._socket.close()
@@ -230,6 +264,10 @@ class NngSubscriber(SleipnirSubscriber):
     Dials a SUB socket to *address* and dispatches received events to
     registered handlers via per-subscription asyncio queues.
 
+    When a *registry* is provided, :meth:`start` queries it for all live
+    publisher sockets and dials each one, enabling multi-publisher discovery.
+    If the registry is empty, *address* is used as the fallback.
+
     Usage::
 
         sub = NngSubscriber("ipc:///tmp/sleipnir.sock")
@@ -247,6 +285,7 @@ class NngSubscriber(SleipnirSubscriber):
         connect_settle_ms: int = DEFAULT_CONNECT_SETTLE_MS,
         reconnect_min_ms: int = DEFAULT_RECONNECT_MIN_MS,
         reconnect_max_ms: int = DEFAULT_RECONNECT_MAX_MS,
+        registry: ServiceRegistry | None = None,
     ) -> None:
         _require_pynng()
         if ring_buffer_depth < 1:
@@ -257,6 +296,7 @@ class NngSubscriber(SleipnirSubscriber):
         self._connect_settle_ms = connect_settle_ms
         self._reconnect_min_ms = reconnect_min_ms
         self._reconnect_max_ms = reconnect_max_ms
+        self._registry = registry
 
         self._socket: pynng.Sub0 | None = None  # type: ignore[name-defined]
         self._recv_task: asyncio.Task[None] | None = None
@@ -265,17 +305,41 @@ class NngSubscriber(SleipnirSubscriber):
         self._running = False
 
     async def start(self) -> None:
-        """Dial the SUB socket and start the receive loop."""
+        """Dial the SUB socket and start the receive loop.
+
+        When discovery is configured, all live publisher sockets from the
+        registry are dialled.  Falls back to *address* when the registry is
+        empty or discovery is disabled.
+        """
         self._socket = pynng.Sub0()
         self._socket.recv_timeout = self._recv_timeout_ms
         self._socket.reconnect_time_min = self._reconnect_min_ms
         self._socket.reconnect_time_max = self._reconnect_max_ms
-        self._socket.dial(self._address, block=False)
-        logger.debug("NngSubscriber: dialing %s", self._address)
+
+        addresses = await self._discover_addresses()
+        for addr in addresses:
+            self._socket.dial(addr, block=False)
+            logger.debug("NngSubscriber: dialing %s", addr)
+
         if self._connect_settle_ms > 0:
             await asyncio.sleep(self._connect_settle_ms / 1000.0)
         self._running = True
         self._recv_task = asyncio.create_task(self._recv_loop(), name="sleipnir-nng-sub-recv")
+
+    async def _discover_addresses(self) -> list[str]:
+        """Return the list of publisher addresses to dial.
+
+        Uses the service registry when available; falls back to *self._address*.
+        """
+        if self._registry is None:
+            return [self._address]
+        entries = await asyncio.get_event_loop().run_in_executor(None, self._registry.list_services)
+        if not entries:
+            logger.debug("NngSubscriber: registry empty, falling back to %s", self._address)
+            return [self._address]
+        addresses = [e.socket for e in entries]
+        logger.debug("NngSubscriber: discovered %d publisher(s): %s", len(addresses), addresses)
+        return addresses
 
     async def stop(self) -> None:
         """Cancel the receive loop and close the SUB socket."""
@@ -371,6 +435,10 @@ class NngTransport(SleipnirPublisher, SleipnirSubscriber):
     by this process loop back through nng and are delivered to local
     subscribers as well as remote ones.
 
+    When *service_id* and *registry* are provided, the publisher registers
+    itself in the service registry on start, and the subscriber discovers all
+    live publishers (including itself) to dial.
+
     Usage::
 
         bus = NngTransport("ipc:///tmp/sleipnir.sock")
@@ -391,12 +459,16 @@ class NngTransport(SleipnirPublisher, SleipnirSubscriber):
         connect_settle_ms: int = DEFAULT_CONNECT_SETTLE_MS,
         reconnect_min_ms: int = DEFAULT_RECONNECT_MIN_MS,
         reconnect_max_ms: int = DEFAULT_RECONNECT_MAX_MS,
+        service_id: str | None = None,
+        registry: ServiceRegistry | None = None,
     ) -> None:
         _require_pynng()
         self._publisher = NngPublisher(
             address=address,
             bind_retry_delay_s=bind_retry_delay_s,
             bind_max_retries=bind_max_retries,
+            service_id=service_id,
+            registry=registry,
         )
         self._subscriber = NngSubscriber(
             address=address,
@@ -405,6 +477,7 @@ class NngTransport(SleipnirPublisher, SleipnirSubscriber):
             connect_settle_ms=connect_settle_ms,
             reconnect_min_ms=reconnect_min_ms,
             reconnect_max_ms=reconnect_max_ms,
+            registry=registry,
         )
 
     async def start(self) -> None:

--- a/src/sleipnir/adapters/nng_transport.py
+++ b/src/sleipnir/adapters/nng_transport.py
@@ -210,7 +210,7 @@ class NngPublisher(SleipnirPublisher):
                 )
                 await asyncio.sleep(self._bind_retry_delay_s)
         if self._registry is not None and self._service_id is not None:
-            await asyncio.get_event_loop().run_in_executor(
+            await asyncio.get_running_loop().run_in_executor(
                 None, self._registry.register, self._service_id, self._address
             )
 
@@ -218,7 +218,7 @@ class NngPublisher(SleipnirPublisher):
         """Deregister from discovery (if configured), then close the PUB socket."""
         if self._registry is not None and self._service_id is not None:
             with suppress(Exception):
-                await asyncio.get_event_loop().run_in_executor(
+                await asyncio.get_running_loop().run_in_executor(
                     None, self._registry.deregister, self._service_id
                 )
         if self._socket is not None:
@@ -333,7 +333,7 @@ class NngSubscriber(SleipnirSubscriber):
         """
         if self._registry is None:
             return [self._address]
-        entries = await asyncio.get_event_loop().run_in_executor(None, self._registry.list_services)
+        entries = await asyncio.get_running_loop().run_in_executor(None, self._registry.list_services)
         if not entries:
             logger.debug("NngSubscriber: registry empty, falling back to %s", self._address)
             return [self._address]

--- a/tests/test_sleipnir/test_discovery.py
+++ b/tests/test_sleipnir/test_discovery.py
@@ -1,0 +1,409 @@
+"""Tests for the service discovery registry (NIU-521).
+
+Test strategy
+-------------
+Unit tests mock ``os.kill`` and file I/O to run without real processes.
+Functional tests use real files in a temporary directory (tmp_path fixture).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sleipnir.adapters.discovery import (
+    DEFAULT_REGISTRY_PATH,
+    ServiceEntry,
+    ServiceRegistry,
+    _is_alive,
+)
+
+# ---------------------------------------------------------------------------
+# _is_alive unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_is_alive_running_process():
+    """Current process is always alive."""
+    assert _is_alive(os.getpid()) is True
+
+
+def test_is_alive_dead_pid():
+    """A PID that doesn't exist returns False."""
+    # PID 0 is never a normal process; on Linux os.kill(0, 0) sends to the
+    # process group, which can raise PermissionError.  Use a patched approach.
+    with patch("os.kill", side_effect=ProcessLookupError):
+        assert _is_alive(99999) is False
+
+
+def test_is_alive_permission_error_means_alive():
+    """PermissionError means the process exists but belongs to another user."""
+    with patch("os.kill", side_effect=PermissionError):
+        assert _is_alive(1) is True
+
+
+# ---------------------------------------------------------------------------
+# ServiceRegistry functional tests (real files, tmp_path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def registry(tmp_path: Path) -> ServiceRegistry:
+    return ServiceRegistry(path=tmp_path / "sleipnir.json")
+
+
+def test_register_creates_file(registry: ServiceRegistry, tmp_path: Path):
+    registry.register("svc-a", "ipc:///tmp/a.sock")
+    assert (tmp_path / "sleipnir.json").exists()
+
+
+def test_register_adds_entry(registry: ServiceRegistry):
+    registry.register("svc-a", "ipc:///tmp/a.sock")
+    entries = registry.list_services()
+    assert len(entries) == 1
+    assert entries[0].id == "svc-a"
+    assert entries[0].socket == "ipc:///tmp/a.sock"
+    assert entries[0].pid == os.getpid()
+
+
+def test_register_multiple_services(registry: ServiceRegistry):
+    registry.register("svc-a", "ipc:///tmp/a.sock")
+    registry.register("svc-b", "ipc:///tmp/b.sock")
+    entries = registry.list_services()
+    ids = {e.id for e in entries}
+    assert ids == {"svc-a", "svc-b"}
+
+
+def test_register_replaces_existing_id(registry: ServiceRegistry):
+    """Re-registering the same service_id updates the entry."""
+    registry.register("svc-a", "ipc:///tmp/a.sock")
+    registry.register("svc-a", "ipc:///tmp/a2.sock")
+    entries = registry.list_services()
+    assert len(entries) == 1
+    assert entries[0].socket == "ipc:///tmp/a2.sock"
+
+
+def test_deregister_removes_entry(registry: ServiceRegistry):
+    registry.register("svc-a", "ipc:///tmp/a.sock")
+    registry.deregister("svc-a")
+    assert registry.list_services() == []
+
+
+def test_deregister_nonexistent_is_noop(registry: ServiceRegistry):
+    """Deregistering an entry that was never added should not raise."""
+    registry.deregister("ghost")  # no exception
+
+
+def test_deregister_missing_file_is_noop(registry: ServiceRegistry, tmp_path: Path):
+    """Deregistering when the file doesn't exist should not raise."""
+    assert not (tmp_path / "sleipnir.json").exists()
+    registry.deregister("ghost")  # no exception
+
+
+def test_list_services_missing_file(registry: ServiceRegistry, tmp_path: Path):
+    """list_services returns [] when file doesn't exist."""
+    assert not (tmp_path / "sleipnir.json").exists()
+    assert registry.list_services() == []
+
+
+def test_list_services_filters_dead_pids(registry: ServiceRegistry, tmp_path: Path):
+    """Entries with dead PIDs are excluded from list_services."""
+    # Write a fake entry with a non-existent PID directly.
+    dead_pid = 999999
+    data = {
+        "services": [
+            {"id": "dead-svc", "pid": dead_pid, "socket": "ipc:///tmp/dead.sock", "started": "x"},
+            {
+                "id": "live-svc",
+                "pid": os.getpid(),
+                "socket": "ipc:///tmp/live.sock",
+                "started": "x",
+            },
+        ],
+        "primary_pub": "",
+    }
+    (tmp_path / "sleipnir.json").write_text(json.dumps(data))
+
+    with patch("sleipnir.adapters.discovery._is_alive") as mock_alive:
+        mock_alive.side_effect = lambda pid: pid == os.getpid()
+        entries = registry.list_services()
+
+    assert len(entries) == 1
+    assert entries[0].id == "live-svc"
+
+
+def test_register_cleans_stale_on_write(registry: ServiceRegistry, tmp_path: Path):
+    """register() prunes dead-PID entries when writing."""
+    dead_pid = 999998
+    data = {
+        "services": [
+            {"id": "dead-svc", "pid": dead_pid, "socket": "ipc:///tmp/dead.sock", "started": "x"},
+        ],
+        "primary_pub": "",
+    }
+    (tmp_path / "sleipnir.json").write_text(json.dumps(data))
+
+    with patch("sleipnir.adapters.discovery._is_alive") as mock_alive:
+        mock_alive.side_effect = lambda pid: pid == os.getpid()
+        registry.register("svc-new", "ipc:///tmp/new.sock")
+        entries = registry.list_services()
+
+    ids = {e.id for e in entries}
+    assert "dead-svc" not in ids
+    assert "svc-new" in ids
+
+
+def test_cleanup_stale_returns_count(registry: ServiceRegistry, tmp_path: Path):
+    """cleanup_stale() returns the number of removed entries."""
+    data = {
+        "services": [
+            {"id": "dead-1", "pid": 999991, "socket": "ipc:///tmp/d1.sock", "started": "x"},
+            {"id": "dead-2", "pid": 999992, "socket": "ipc:///tmp/d2.sock", "started": "x"},
+            {"id": "live-1", "pid": os.getpid(), "socket": "ipc:///tmp/live.sock", "started": "x"},
+        ],
+        "primary_pub": "",
+    }
+    (tmp_path / "sleipnir.json").write_text(json.dumps(data))
+
+    with patch("sleipnir.adapters.discovery._is_alive") as mock_alive:
+        mock_alive.side_effect = lambda pid: pid == os.getpid()
+        removed = registry.cleanup_stale()
+
+    assert removed == 2
+
+
+def test_cleanup_stale_missing_file(registry: ServiceRegistry):
+    """cleanup_stale() returns 0 when the file doesn't exist."""
+    assert registry.cleanup_stale() == 0
+
+
+def test_cleanup_stale_no_dead_entries(registry: ServiceRegistry):
+    """cleanup_stale() returns 0 when nothing is stale."""
+    registry.register("svc-a", "ipc:///tmp/a.sock")
+    removed = registry.cleanup_stale()
+    assert removed == 0
+
+
+def test_registry_file_is_valid_json(registry: ServiceRegistry, tmp_path: Path):
+    """The written registry file is valid JSON with the expected structure."""
+    registry.register("svc-a", "ipc:///tmp/a.sock")
+    data = json.loads((tmp_path / "sleipnir.json").read_text())
+    assert "services" in data
+    assert "primary_pub" in data
+    assert len(data["services"]) == 1
+    svc = data["services"][0]
+    assert svc["id"] == "svc-a"
+    assert svc["socket"] == "ipc:///tmp/a.sock"
+    assert svc["pid"] == os.getpid()
+    assert "started" in svc
+
+
+def test_registry_creates_parent_directory(tmp_path: Path):
+    """register() creates the registry's parent directory if it doesn't exist."""
+    nested = tmp_path / "deep" / "nested" / "sleipnir.json"
+    reg = ServiceRegistry(path=nested)
+    reg.register("svc", "ipc:///tmp/s.sock")
+    assert nested.exists()
+
+
+def test_corrupt_registry_is_reset(registry: ServiceRegistry, tmp_path: Path):
+    """A corrupt JSON file is silently reset to an empty registry."""
+    (tmp_path / "sleipnir.json").write_text("{not valid json...")
+    # Should not raise; should silently reset.
+    entries = registry.list_services()
+    assert entries == []
+
+
+def test_corrupt_registry_reset_on_register(registry: ServiceRegistry, tmp_path: Path):
+    """A corrupt JSON file is reset when a new service registers."""
+    (tmp_path / "sleipnir.json").write_text("{bad json")
+    registry.register("svc", "ipc:///tmp/s.sock")
+    entries = registry.list_services()
+    assert len(entries) == 1
+    assert entries[0].id == "svc"
+
+
+def test_primary_pub_stored_in_file(tmp_path: Path):
+    """primary_pub is persisted in the registry file."""
+    reg = ServiceRegistry(path=tmp_path / "r.json", primary_pub="ipc:///tmp/main.sock")
+    reg.register("svc", "ipc:///tmp/s.sock")
+    data = json.loads((tmp_path / "r.json").read_text())
+    assert data["primary_pub"] == "ipc:///tmp/main.sock"
+
+
+def test_default_registry_path():
+    """DEFAULT_REGISTRY_PATH is under the home directory."""
+    assert DEFAULT_REGISTRY_PATH == Path.home() / ".odin" / "sleipnir.json"
+
+
+def test_service_entry_is_frozen():
+    """ServiceEntry is an immutable frozen dataclass."""
+    entry = ServiceEntry(id="x", pid=1, socket="ipc:///tmp/x.sock", started="t")
+    with pytest.raises(Exception):
+        entry.id = "y"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# NngPublisher / NngSubscriber with discovery — unit tests (mocked pynng)
+# ---------------------------------------------------------------------------
+
+
+pynng = pytest.importorskip("pynng", reason="pynng not installed; skipping nng tests")
+
+
+@pytest.fixture
+def mock_registry() -> MagicMock:
+    reg = MagicMock(spec=ServiceRegistry)
+    reg.list_services.return_value = []
+    return reg
+
+
+@pytest.mark.asyncio
+async def test_publisher_registers_on_start(tmp_path: Path):
+    """NngPublisher calls registry.register() after binding."""
+    from sleipnir.adapters.nng_transport import NngPublisher
+
+    address = f"ipc://{tmp_path}/pub.sock"
+    reg = MagicMock(spec=ServiceRegistry)
+
+    async with NngPublisher(address=address, service_id="svc-a", registry=reg):
+        reg.register.assert_called_once_with("svc-a", address)
+
+
+@pytest.mark.asyncio
+async def test_publisher_deregisters_on_stop(tmp_path: Path):
+    """NngPublisher calls registry.deregister() on stop."""
+    from sleipnir.adapters.nng_transport import NngPublisher
+
+    address = f"ipc://{tmp_path}/pub_dereg.sock"
+    reg = MagicMock(spec=ServiceRegistry)
+
+    async with NngPublisher(address=address, service_id="svc-a", registry=reg):
+        pass
+
+    reg.deregister.assert_called_once_with("svc-a")
+
+
+@pytest.mark.asyncio
+async def test_publisher_no_registry_no_registration(tmp_path: Path):
+    """NngPublisher without registry does not attempt registration."""
+    from sleipnir.adapters.nng_transport import NngPublisher
+
+    address = f"ipc://{tmp_path}/pub_noreg.sock"
+    # No registry passed — should bind without any discovery call.
+    async with NngPublisher(address=address):
+        pass  # no AttributeError expected
+
+
+@pytest.mark.asyncio
+async def test_subscriber_dials_discovered_addresses(tmp_path: Path):
+    """NngSubscriber with registry dials all discovered sockets."""
+    from sleipnir.adapters.nng_transport import NngSubscriber
+
+    address_a = f"ipc://{tmp_path}/disc_a.sock"
+    address_b = f"ipc://{tmp_path}/disc_b.sock"
+
+    # Start two publishers so the sockets exist.
+    import pynng as _pynng
+
+    pub_a = _pynng.Pub0()
+    pub_b = _pynng.Pub0()
+    try:
+        pub_a.listen(address_a)
+        pub_b.listen(address_b)
+
+        reg = MagicMock(spec=ServiceRegistry)
+        reg.list_services.return_value = [
+            ServiceEntry(id="svc-a", pid=os.getpid(), socket=address_a, started="t"),
+            ServiceEntry(id="svc-b", pid=os.getpid(), socket=address_b, started="t"),
+        ]
+
+        async with NngSubscriber(address=address_a, registry=reg, connect_settle_ms=50):
+            reg.list_services.assert_called_once()
+    finally:
+        pub_a.close()
+        pub_b.close()
+
+
+@pytest.mark.asyncio
+async def test_subscriber_falls_back_to_address_when_registry_empty(tmp_path: Path):
+    """NngSubscriber falls back to address when registry returns no services."""
+    from sleipnir.adapters.nng_transport import NngSubscriber
+
+    address = f"ipc://{tmp_path}/fallback.sock"
+
+    import pynng as _pynng
+
+    pub = _pynng.Pub0()
+    try:
+        pub.listen(address)
+
+        reg = MagicMock(spec=ServiceRegistry)
+        reg.list_services.return_value = []
+
+        async with NngSubscriber(address=address, registry=reg, connect_settle_ms=50):
+            reg.list_services.assert_called_once()
+    finally:
+        pub.close()
+
+
+@pytest.mark.asyncio
+async def test_subscriber_no_registry_uses_address(tmp_path: Path):
+    """NngSubscriber without registry dials the single address (baseline)."""
+    from sleipnir.adapters.nng_transport import NngSubscriber
+
+    address = f"ipc://{tmp_path}/noreg.sock"
+
+    import pynng as _pynng
+
+    pub = _pynng.Pub0()
+    try:
+        pub.listen(address)
+        async with NngSubscriber(address=address, connect_settle_ms=50):
+            pass
+    finally:
+        pub.close()
+
+
+@pytest.mark.asyncio
+async def test_transport_passes_registry_to_both_components(tmp_path: Path):
+    """NngTransport propagates service_id and registry to publisher and subscriber."""
+    from sleipnir.adapters.nng_transport import NngTransport
+
+    address = f"ipc://{tmp_path}/transport.sock"
+    reg = MagicMock(spec=ServiceRegistry)
+    reg.list_services.return_value = []
+
+    async with NngTransport(address=address, service_id="svc-t", registry=reg):
+        reg.register.assert_called_once_with("svc-t", address)
+        reg.list_services.assert_called_once()
+
+    reg.deregister.assert_called_once_with("svc-t")
+
+
+# ---------------------------------------------------------------------------
+# Functional: multi-process registry round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_registry_round_trip_functional(tmp_path: Path):
+    """Full register → list → deregister cycle with real files."""
+    reg_path = tmp_path / "roundtrip.json"
+    reg = ServiceRegistry(path=reg_path)
+
+    reg.register("svc-a", "ipc:///tmp/a.sock")
+    reg.register("svc-b", "ipc:///tmp/b.sock")
+
+    entries = reg.list_services()
+    assert {e.id for e in entries} == {"svc-a", "svc-b"}
+
+    reg.deregister("svc-a")
+    entries = reg.list_services()
+    assert {e.id for e in entries} == {"svc-b"}
+
+    reg.deregister("svc-b")
+    assert reg.list_services() == []


### PR DESCRIPTION
## Summary

- **New `ServiceRegistry`** (`src/sleipnir/adapters/discovery.py`): JSON-backed service registry protected by `fcntl` advisory locking. Services register their IPC socket address and PID on startup; stale entries (dead PIDs) are pruned automatically on every read/write.

- **`NngPublisher` discovery integration**: accepts optional `service_id` + `registry`; calls `registry.register()` after binding the PUB socket and `registry.deregister()` before closing it.

- **`NngSubscriber` multi-publisher dialling**: accepts optional `registry`; on `start()` queries the registry for all live publisher sockets and dials each one. Falls back to the single `address` parameter when the registry is empty or not configured.

- **`NngTransport`** passes `service_id` and `registry` through to both components — one constructor call, full multi-process discovery.

- **31 new tests** (`tests/test_sleipnir/test_discovery.py`) covering the full registry lifecycle, stale-entry pruning, corrupt-file recovery, and nng adapter integration. Existing 147 tests all pass.

- **Backwards-compatible**: all three classes behave identically when `registry=None` (the default).

## Registry file format

```json
{
  "services": [
    {"id": "ravn:agent-abc", "pid": 12345, "socket": "ipc:///tmp/sleipnir-abc.sock", "started": "2026-04-05T12:00:00+00:00"},
    {"id": "tyr:main",       "pid": 12346, "socket": "ipc:///tmp/sleipnir-tyr.sock",  "started": "2026-04-05T12:01:00+00:00"}
  ],
  "primary_pub": "ipc:///tmp/sleipnir.sock"
}
```

## Config

```yaml
sleipnir:
  transport: nng
  socket: ipc:///tmp/sleipnir.sock
  discovery:
    enabled: true
    registry_path: /run/odin/sleipnir.json
```

## Test plan

- [x] All 178 sleipnir tests green
- [x] Coverage: discovery.py 98%, nng_transport.py 89%, suite total 94% (threshold: 85%)
- [x] ruff check + ruff format clean

## Linear

Ticket: NIU-521
Note: Linear MCP tools were not available; please update NIU-521 to In Review manually and link this PR.

Generated with Claude Code