### PR TITLE
feat(adapters): RabbitMQ transport adapter — primary durable broker (NIU-523)

### DIFF
--- a/src/sleipnir/adapters/_subscriber_support.py
+++ b/src/sleipnir/adapters/_subscriber_support.py
@@ -1,9 +1,8 @@
 """Shared helpers for Sleipnir subscriber adapters.
 
-Extracted so that both :mod:`sleipnir.adapters.in_process` and
-:mod:`sleipnir.adapters.nng_transport` can reuse the consumer loop,
-base subscription class, and ring-buffer overflow helper without
-duplicating code.
+Extracted so that all transport adapters (in-process, nng, RabbitMQ, …) can
+reuse the consumer loop, base subscription class, ring-buffer overflow helper,
+and event dispatch logic without duplicating code.
 """
 
 from __future__ import annotations
@@ -12,8 +11,12 @@ import asyncio
 import logging
 from collections.abc import Callable
 
-from sleipnir.domain.events import SleipnirEvent
+from sleipnir.domain.events import SleipnirEvent, match_event_type
 from sleipnir.ports.events import EventHandler, Subscription
+
+#: Default depth of each subscriber's ring buffer (events).
+#: All adapters use this value so the behaviour is consistent across transports.
+DEFAULT_RING_BUFFER_DEPTH = 1000
 
 
 async def consume_queue(
@@ -108,3 +111,39 @@ class _BaseSubscription(Subscription):
                 self._queue.task_done()
             except asyncio.QueueEmpty:
                 break
+
+
+async def dispatch_to_subscriptions(
+    event: SleipnirEvent,
+    subscriptions: list[_BaseSubscription],
+    ring_buffer_depth: int,
+    log: logging.Logger,
+) -> None:
+    """Dispatch *event* to all active subscriptions whose patterns match.
+
+    Events with ``ttl`` that is not ``None`` and ``<= 0`` are considered
+    expired on arrival and silently dropped (logged at DEBUG level).
+
+    This is the canonical dispatch loop shared by all transport adapters so
+    that TTL handling, pattern matching, and ring-buffer overflow semantics
+    are consistent everywhere.
+
+    :param event: The event to dispatch.
+    :param subscriptions: The list of active subscriptions to consider.
+    :param ring_buffer_depth: Ring buffer depth used for overflow warnings.
+    :param log: Logger to use for debug/warning messages.
+    """
+    if event.ttl is not None and event.ttl <= 0:
+        log.debug(
+            "Dropping expired event %s (%s): ttl=%d",
+            event.event_id,
+            event.event_type,
+            event.ttl,
+        )
+        return
+    for sub in list(subscriptions):
+        if not sub.active:
+            continue
+        if not any(match_event_type(p, event.event_type) for p in sub.patterns):
+            continue
+        await enqueue_with_overflow(sub._queue, event, ring_buffer_depth, log)

--- a/src/sleipnir/adapters/in_process.py
+++ b/src/sleipnir/adapters/in_process.py
@@ -13,16 +13,15 @@ import asyncio
 import logging
 
 from sleipnir.adapters._subscriber_support import (
+    DEFAULT_RING_BUFFER_DEPTH,
     _BaseSubscription,
     consume_queue,
-    enqueue_with_overflow,
+    dispatch_to_subscriptions,
 )
-from sleipnir.domain.events import SleipnirEvent, match_event_type
+from sleipnir.domain.events import SleipnirEvent
 from sleipnir.ports.events import EventHandler, SleipnirPublisher, SleipnirSubscriber, Subscription
 
 logger = logging.getLogger(__name__)
-
-DEFAULT_RING_BUFFER_DEPTH = 1000
 
 
 class InProcessBus(SleipnirPublisher, SleipnirSubscriber):
@@ -50,20 +49,7 @@ class InProcessBus(SleipnirPublisher, SleipnirSubscriber):
 
         Events with ``ttl=0`` are expired on arrival and never delivered.
         """
-        if event.ttl is not None and event.ttl <= 0:
-            logger.debug(
-                "Dropping expired event %s (%s): ttl=%d",
-                event.event_id,
-                event.event_type,
-                event.ttl,
-            )
-            return
-        for sub in list(self._subscriptions):
-            if not sub.active:
-                continue
-            if not any(match_event_type(p, event.event_type) for p in sub.patterns):
-                continue
-            await enqueue_with_overflow(sub._queue, event, self._ring_buffer_depth, logger)
+        await dispatch_to_subscriptions(event, self._subscriptions, self._ring_buffer_depth, logger)
 
     async def publish_batch(self, events: list[SleipnirEvent]) -> None:
         """Publish all *events* in iteration order."""

--- a/src/sleipnir/adapters/nng_transport.py
+++ b/src/sleipnir/adapters/nng_transport.py
@@ -60,13 +60,14 @@ except ImportError:
     _PYNNG_AVAILABLE = False
 
 from sleipnir.adapters._subscriber_support import (
+    DEFAULT_RING_BUFFER_DEPTH,
     _BaseSubscription,
     consume_queue,
-    enqueue_with_overflow,
+    dispatch_to_subscriptions,
 )
 from sleipnir.adapters.discovery import ServiceRegistry
 from sleipnir.adapters.serialization import deserialize, serialize
-from sleipnir.domain.events import SleipnirEvent, match_event_type
+from sleipnir.domain.events import SleipnirEvent
 from sleipnir.ports.events import EventHandler, SleipnirPublisher, SleipnirSubscriber, Subscription
 
 logger = logging.getLogger(__name__)
@@ -88,9 +89,6 @@ DEFAULT_BIND_RETRY_DELAY_S = 0.1
 
 #: Maximum number of bind attempts before raising.
 DEFAULT_BIND_MAX_RETRIES = 50
-
-#: Depth of each subscriber's ring buffer (events).
-DEFAULT_RING_BUFFER_DEPTH = 1000
 
 #: Milliseconds to sleep after opening sockets to let nng establish the
 #: underlying IPC/TCP connection before the first publish.
@@ -416,14 +414,7 @@ class NngSubscriber(SleipnirSubscriber):
         event = _decode_message(data)
         if event is None:
             return
-        if event.ttl is not None and event.ttl <= 0:
-            return
-        for sub in list(self._subscriptions):
-            if not sub.active:
-                continue
-            if not any(match_event_type(p, event.event_type) for p in sub.patterns):
-                continue
-            await enqueue_with_overflow(sub._queue, event, self._ring_buffer_depth, logger)
+        await dispatch_to_subscriptions(event, self._subscriptions, self._ring_buffer_depth, logger)
 
 
 # ---------------------------------------------------------------------------

--- a/src/sleipnir/adapters/rabbitmq.py
+++ b/src/sleipnir/adapters/rabbitmq.py
@@ -1,0 +1,520 @@
+"""RabbitMQ transport adapter for Sleipnir.
+
+Primary durable broker for production deployments.  Already present in the
+ODIN infrastructure stack as Yggdrasil's backbone, so teams already running
+ODIN need zero additional broker infrastructure.
+
+Architecture
+------------
+- :class:`RabbitMQPublisher` — connects via AMQP, declares the topic exchange,
+  publishes events with routing key = event_type.  Persistent delivery mode for
+  urgency > threshold (default 0.4).
+- :class:`RabbitMQSubscriber` — connects via AMQP, declares a per-subscriber
+  queue, binds it to the topic exchange for each subscription pattern, and
+  dispatches incoming messages to application-level handlers.
+- :class:`RabbitMQTransport` — combined publisher + subscriber for single-process
+  use.
+
+Topology
+--------
+- Exchange: ``sleipnir.events`` (topic, durable)
+- Routing key: event_type (e.g. ``ravn.tool.complete``)
+- Dead-letter exchange: ``sleipnir.dead_letter`` (fanout, durable)
+- Consumer queues: durable for named services, auto-delete for ephemeral
+
+Routing key translation
+-----------------------
+fnmatch patterns are translated to AMQP topic routing keys:
+
+- ``"*"``               → ``"#"``           (all events)
+- ``"ravn.*"``          → ``"ravn.#"``      (all ravn events; fnmatch * spans dots)
+- ``"ravn.tool.*"``     → ``"ravn.tool.#"`` (all ravn tool events)
+- ``"ravn.tool.complete"`` → ``"ravn.tool.complete"`` (exact match)
+- Any other wildcard pattern → ``"#"`` (receive all; app-level fnmatch filters)
+
+Serialisation
+-------------
+JSON is used for all messages (not msgpack) to enable human-readable
+inspection via the RabbitMQ management UI.
+
+Configuration example
+---------------------
+::
+
+    sleipnir:
+      transport: rabbitmq
+      url: amqp://guest:guest@rabbitmq:5672/
+      exchange: sleipnir.events
+      prefetch: 1
+      durable_threshold_urgency: 0.4
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from contextlib import suppress
+
+try:
+    import aio_pika
+    import aio_pika.abc
+
+    _AIO_PIKA_AVAILABLE = True
+except ImportError:
+    _AIO_PIKA_AVAILABLE = False
+
+from sleipnir.adapters._subscriber_support import (
+    _BaseSubscription,
+    consume_queue,
+    enqueue_with_overflow,
+)
+from sleipnir.adapters.serialization import deserialize, serialize
+from sleipnir.domain.events import SleipnirEvent, match_event_type
+from sleipnir.ports.events import EventHandler, SleipnirPublisher, SleipnirSubscriber, Subscription
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Defaults (all overridable via constructor kwargs or config)
+# ---------------------------------------------------------------------------
+
+DEFAULT_AMQP_URL = "amqp://guest:guest@localhost:5672/"
+DEFAULT_EXCHANGE_NAME = "sleipnir.events"
+DEFAULT_DEAD_LETTER_EXCHANGE = "sleipnir.dead_letter"
+
+#: Prefetch count for fair dispatch — one outstanding message per consumer.
+DEFAULT_PREFETCH_COUNT = 1
+
+#: Events with urgency above this threshold are published as persistent
+#: (delivery_mode=2); events at or below are transient (delivery_mode=1).
+DEFAULT_DURABLE_THRESHOLD_URGENCY = 0.4
+
+#: Depth of each application-level subscriber ring buffer (events).
+DEFAULT_RING_BUFFER_DEPTH = 1000
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _fnmatch_to_amqp(pattern: str) -> str:
+    """Translate an fnmatch pattern to an AMQP topic routing key.
+
+    In AMQP topic exchanges:
+    - ``*`` matches exactly one dot-delimited word
+    - ``#`` matches zero or more dot-delimited words
+
+    In fnmatch:
+    - ``*`` matches any sequence of characters, including dots
+
+    Therefore ``ravn.*`` in fnmatch means "anything under ravn", which maps to
+    ``ravn.#`` in AMQP (not ``ravn.*``, which would only match a single word).
+
+    Rules
+    -----
+    - ``"*"``   → ``"#"``              (subscribe to all)
+    - ``"a.*"`` → ``"a.#"``            (trailing ``.*`` → ``.#``)
+    - Exact     → unchanged             (no wildcard chars)
+    - Other     → ``"#"``              (complex pattern; app-level filtering)
+    """
+    if pattern == "*":
+        return "#"
+    if pattern.endswith(".*"):
+        # "ravn.*" → "ravn.#"  (strip the star, keep the dot, append hash)
+        return pattern[:-1] + "#"
+    if any(c in pattern for c in ("*", "?", "[")):
+        # Non-trivial wildcard — subscribe to all, rely on fnmatch at app level
+        return "#"
+    return pattern
+
+
+def _require_aio_pika() -> None:
+    if not _AIO_PIKA_AVAILABLE:
+        raise ImportError(
+            "aio-pika is required for the RabbitMQ transport adapter. "
+            "Install it with: pip install aio-pika"
+        )
+
+
+def _encode_event(event: SleipnirEvent) -> bytes:
+    """Serialise *event* to JSON bytes."""
+    return serialize(event, fmt="json")
+
+
+def _decode_event(data: bytes) -> SleipnirEvent | None:
+    """Deserialise *data* from JSON bytes.  Returns ``None`` on failure."""
+    try:
+        return deserialize(data, fmt="json")
+    except Exception:
+        logger.exception("RabbitMQ: deserialization failed, message dropped")
+        return None
+
+
+# ---------------------------------------------------------------------------
+# RabbitMQPublisher
+# ---------------------------------------------------------------------------
+
+
+class RabbitMQPublisher(SleipnirPublisher):
+    """AMQP publisher for Sleipnir events.
+
+    Connects to RabbitMQ with a robust (auto-reconnecting) connection, declares
+    the topic exchange, and publishes :class:`SleipnirEvent` objects as JSON
+    messages.
+
+    Delivery mode per event:
+    - ``urgency > durable_threshold_urgency`` → :attr:`~aio_pika.DeliveryMode.PERSISTENT`
+    - ``urgency ≤ durable_threshold_urgency`` → :attr:`~aio_pika.DeliveryMode.NOT_PERSISTENT`
+
+    Usage::
+
+        pub = RabbitMQPublisher("amqp://guest:guest@rabbitmq:5672/")
+        async with pub:
+            await pub.publish(event)
+    """
+
+    def __init__(
+        self,
+        url: str = DEFAULT_AMQP_URL,
+        exchange_name: str = DEFAULT_EXCHANGE_NAME,
+        durable_threshold_urgency: float = DEFAULT_DURABLE_THRESHOLD_URGENCY,
+    ) -> None:
+        _require_aio_pika()
+        self._url = url
+        self._exchange_name = exchange_name
+        self._durable_threshold_urgency = durable_threshold_urgency
+        self._connection: aio_pika.abc.AbstractRobustConnection | None = None  # type: ignore[name-defined]
+        self._channel: aio_pika.abc.AbstractChannel | None = None  # type: ignore[name-defined]
+        self._exchange: aio_pika.abc.AbstractExchange | None = None  # type: ignore[name-defined]
+
+    async def start(self) -> None:
+        """Connect to RabbitMQ and declare the topic exchange."""
+        self._connection = await aio_pika.connect_robust(self._url)
+        self._channel = await self._connection.channel()
+        self._exchange = await self._channel.declare_exchange(
+            self._exchange_name,
+            aio_pika.ExchangeType.TOPIC,
+            durable=True,
+        )
+        logger.debug("RabbitMQPublisher: connected, exchange=%s", self._exchange_name)
+
+    async def stop(self) -> None:
+        """Close the AMQP channel and connection."""
+        if self._channel is not None:
+            with suppress(Exception):
+                await self._channel.close()
+            self._channel = None
+        if self._connection is not None:
+            with suppress(Exception):
+                await self._connection.close()
+            self._connection = None
+        self._exchange = None
+        logger.debug("RabbitMQPublisher: closed")
+
+    async def __aenter__(self) -> RabbitMQPublisher:
+        await self.start()
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        await self.stop()
+
+    async def publish(self, event: SleipnirEvent) -> None:
+        if event.ttl is not None and event.ttl <= 0:
+            logger.debug(
+                "Dropping expired event %s (%s): ttl=%d",
+                event.event_id,
+                event.event_type,
+                event.ttl,
+            )
+            return
+        if self._exchange is None:
+            raise RuntimeError("RabbitMQPublisher is not started. Call start() first.")
+        delivery_mode = (
+            aio_pika.DeliveryMode.PERSISTENT
+            if event.urgency > self._durable_threshold_urgency
+            else aio_pika.DeliveryMode.NOT_PERSISTENT
+        )
+        message = aio_pika.Message(
+            body=_encode_event(event),
+            delivery_mode=delivery_mode,
+            content_type="application/json",
+        )
+        await self._exchange.publish(message, routing_key=event.event_type)
+
+    async def publish_batch(self, events: list[SleipnirEvent]) -> None:
+        for event in events:
+            await self.publish(event)
+
+
+# ---------------------------------------------------------------------------
+# RabbitMQSubscriber
+# ---------------------------------------------------------------------------
+
+
+class RabbitMQSubscriber(SleipnirSubscriber):
+    """AMQP subscriber for Sleipnir events.
+
+    Connects to RabbitMQ, declares a single queue for this subscriber, and
+    binds it to the topic exchange for each subscription pattern.  Incoming
+    messages are dispatched to application-level handlers via per-subscription
+    asyncio queues (ring-buffer semantics on overflow).
+
+    Queue durability:
+    - When *service_id* is provided → durable, named queue (survives broker restart)
+    - When *service_id* is ``None`` → auto-delete, anonymous queue (ephemeral)
+
+    Dead-letter exchange:
+    The subscriber queue is declared with ``x-dead-letter-exchange`` pointing to
+    ``sleipnir.dead_letter``.  Nacked messages (e.g. on deserialization failure)
+    are routed there for inspection by Sköll.
+
+    Usage::
+
+        sub = RabbitMQSubscriber(service_id="ravn:agent-abc")
+        async with sub:
+            handle = await sub.subscribe(["ravn.*"], my_handler)
+            ...
+            await handle.unsubscribe()
+    """
+
+    def __init__(
+        self,
+        url: str = DEFAULT_AMQP_URL,
+        exchange_name: str = DEFAULT_EXCHANGE_NAME,
+        dead_letter_exchange: str = DEFAULT_DEAD_LETTER_EXCHANGE,
+        service_id: str | None = None,
+        prefetch_count: int = DEFAULT_PREFETCH_COUNT,
+        ring_buffer_depth: int = DEFAULT_RING_BUFFER_DEPTH,
+    ) -> None:
+        _require_aio_pika()
+        if ring_buffer_depth < 1:
+            raise ValueError(f"ring_buffer_depth must be >= 1, got {ring_buffer_depth}")
+        self._url = url
+        self._exchange_name = exchange_name
+        self._dead_letter_exchange = dead_letter_exchange
+        self._service_id = service_id
+        self._prefetch_count = prefetch_count
+        self._ring_buffer_depth = ring_buffer_depth
+
+        self._connection: aio_pika.abc.AbstractRobustConnection | None = None  # type: ignore[name-defined]
+        self._channel: aio_pika.abc.AbstractChannel | None = None  # type: ignore[name-defined]
+        self._exchange: aio_pika.abc.AbstractExchange | None = None  # type: ignore[name-defined]
+        self._queue: aio_pika.abc.AbstractQueue | None = None  # type: ignore[name-defined]
+        self._consumer_tag: str | None = None
+
+        self._subscriptions: list[_BaseSubscription] = []
+        self._bound_amqp_keys: set[str] = set()
+        self._running = False
+
+    async def start(self) -> None:
+        """Connect to RabbitMQ and begin consuming from the subscriber queue."""
+        self._connection = await aio_pika.connect_robust(self._url)
+        self._channel = await self._connection.channel()
+        await self._channel.set_qos(prefetch_count=self._prefetch_count)
+
+        # Declare dead-letter exchange first so queue arguments are valid.
+        await self._channel.declare_exchange(
+            self._dead_letter_exchange,
+            aio_pika.ExchangeType.FANOUT,
+            durable=True,
+        )
+
+        # Declare the main topic exchange.
+        self._exchange = await self._channel.declare_exchange(
+            self._exchange_name,
+            aio_pika.ExchangeType.TOPIC,
+            durable=True,
+        )
+
+        is_named = self._service_id is not None
+        self._queue = await self._channel.declare_queue(
+            self._service_id or "",
+            durable=is_named,
+            auto_delete=not is_named,
+            arguments={"x-dead-letter-exchange": self._dead_letter_exchange},
+        )
+
+        self._running = True
+        self._consumer_tag = await self._queue.consume(self._on_message)
+        logger.debug("RabbitMQSubscriber: consuming from queue=%s", self._queue.name)
+
+    async def stop(self) -> None:
+        """Cancel AMQP consumption and close the connection."""
+        self._running = False
+        if self._queue is not None and self._consumer_tag is not None:
+            with suppress(Exception):
+                await self._queue.cancel(self._consumer_tag)
+            self._consumer_tag = None
+        if self._channel is not None:
+            with suppress(Exception):
+                await self._channel.close()
+            self._channel = None
+        if self._connection is not None:
+            with suppress(Exception):
+                await self._connection.close()
+            self._connection = None
+        self._queue = None
+        self._exchange = None
+        logger.debug("RabbitMQSubscriber: closed")
+
+    async def __aenter__(self) -> RabbitMQSubscriber:
+        await self.start()
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        await self.stop()
+
+    async def subscribe(
+        self,
+        event_types: list[str],
+        handler: EventHandler,
+    ) -> Subscription:
+        if self._queue is None:
+            raise RuntimeError("RabbitMQSubscriber is not started. Call start() first.")
+        # Bind the AMQP queue to the exchange for each new routing key.
+        for pattern in event_types:
+            amqp_key = _fnmatch_to_amqp(pattern)
+            if amqp_key not in self._bound_amqp_keys:
+                await self._queue.bind(self._exchange, routing_key=amqp_key)
+                self._bound_amqp_keys.add(amqp_key)
+                logger.debug(
+                    "RabbitMQSubscriber: bound queue=%s key=%s",
+                    self._queue.name,
+                    amqp_key,
+                )
+        queue: asyncio.Queue[SleipnirEvent] = asyncio.Queue(maxsize=self._ring_buffer_depth)
+        task = asyncio.create_task(consume_queue(queue, handler))
+        sub = _BaseSubscription(
+            list(event_types), queue, task, lambda: self._remove_subscription(sub)
+        )
+        self._subscriptions.append(sub)
+        return sub
+
+    async def flush(self) -> None:
+        """Wait until every queued (already-received) event has been processed."""
+        for sub in list(self._subscriptions):
+            await sub._queue.join()
+
+    def _remove_subscription(self, sub: _BaseSubscription) -> None:
+        with suppress(ValueError):
+            self._subscriptions.remove(sub)
+
+    async def _on_message(
+        self,
+        message: aio_pika.abc.AbstractIncomingMessage,  # type: ignore[name-defined]
+    ) -> None:
+        """Receive an AMQP message, deserialise it, and dispatch to handlers."""
+        async with message.process():
+            event = _decode_event(message.body)
+            if event is None:
+                return
+            if event.ttl is not None and event.ttl <= 0:
+                logger.debug(
+                    "Dropping expired event %s (%s): ttl=%d",
+                    event.event_id,
+                    event.event_type,
+                    event.ttl,
+                )
+                return
+            for sub in list(self._subscriptions):
+                if not sub.active:
+                    continue
+                if not any(match_event_type(p, event.event_type) for p in sub.patterns):
+                    continue
+                await enqueue_with_overflow(sub._queue, event, self._ring_buffer_depth, logger)
+
+
+# ---------------------------------------------------------------------------
+# RabbitMQTransport — combined publisher + subscriber
+# ---------------------------------------------------------------------------
+
+
+class RabbitMQTransport(SleipnirPublisher, SleipnirSubscriber):
+    """Combined RabbitMQ publisher + subscriber for single-process use.
+
+    Opens both a :class:`RabbitMQPublisher` and a :class:`RabbitMQSubscriber`.
+    Unlike nng (where events loop back via the socket), published events are
+    received by the subscriber only if the subscriber's queue is bound to a
+    routing key that matches the published event_type.
+
+    Usage::
+
+        bus = RabbitMQTransport(
+            url="amqp://guest:guest@rabbitmq:5672/",
+            service_id="ravn:agent-abc",
+        )
+        async with bus:
+            handle = await bus.subscribe(["ravn.*"], my_handler)
+            await bus.publish(event)
+            await bus.flush()
+            await handle.unsubscribe()
+    """
+
+    def __init__(
+        self,
+        url: str = DEFAULT_AMQP_URL,
+        exchange_name: str = DEFAULT_EXCHANGE_NAME,
+        dead_letter_exchange: str = DEFAULT_DEAD_LETTER_EXCHANGE,
+        service_id: str | None = None,
+        prefetch_count: int = DEFAULT_PREFETCH_COUNT,
+        ring_buffer_depth: int = DEFAULT_RING_BUFFER_DEPTH,
+        durable_threshold_urgency: float = DEFAULT_DURABLE_THRESHOLD_URGENCY,
+    ) -> None:
+        _require_aio_pika()
+        self._publisher = RabbitMQPublisher(
+            url=url,
+            exchange_name=exchange_name,
+            durable_threshold_urgency=durable_threshold_urgency,
+        )
+        self._subscriber = RabbitMQSubscriber(
+            url=url,
+            exchange_name=exchange_name,
+            dead_letter_exchange=dead_letter_exchange,
+            service_id=service_id,
+            prefetch_count=prefetch_count,
+            ring_buffer_depth=ring_buffer_depth,
+        )
+
+    async def start(self) -> None:
+        """Start the publisher then the subscriber."""
+        await self._publisher.start()
+        await self._subscriber.start()
+
+    async def stop(self) -> None:
+        """Graceful shutdown: stop subscriber first, then publisher."""
+        await self._subscriber.stop()
+        await self._publisher.stop()
+
+    async def __aenter__(self) -> RabbitMQTransport:
+        await self.start()
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        await self.stop()
+
+    async def publish(self, event: SleipnirEvent) -> None:
+        await self._publisher.publish(event)
+
+    async def publish_batch(self, events: list[SleipnirEvent]) -> None:
+        await self._publisher.publish_batch(events)
+
+    async def subscribe(
+        self,
+        event_types: list[str],
+        handler: EventHandler,
+    ) -> Subscription:
+        return await self._subscriber.subscribe(event_types, handler)
+
+    async def flush(self) -> None:
+        await self._subscriber.flush()
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def rabbitmq_available() -> bool:
+    """Return ``True`` if aio-pika is installed and the RabbitMQ adapter can be used."""
+    return _AIO_PIKA_AVAILABLE

--- a/src/sleipnir/adapters/rabbitmq.py
+++ b/src/sleipnir/adapters/rabbitmq.py
@@ -64,12 +64,13 @@ except ImportError:
     _AIO_PIKA_AVAILABLE = False
 
 from sleipnir.adapters._subscriber_support import (
+    DEFAULT_RING_BUFFER_DEPTH,
     _BaseSubscription,
     consume_queue,
-    enqueue_with_overflow,
+    dispatch_to_subscriptions,
 )
 from sleipnir.adapters.serialization import deserialize, serialize
-from sleipnir.domain.events import SleipnirEvent, match_event_type
+from sleipnir.domain.events import SleipnirEvent
 from sleipnir.ports.events import EventHandler, SleipnirPublisher, SleipnirSubscriber, Subscription
 
 logger = logging.getLogger(__name__)
@@ -88,10 +89,6 @@ DEFAULT_PREFETCH_COUNT = 1
 #: Events with urgency above this threshold are published as persistent
 #: (delivery_mode=2); events at or below are transient (delivery_mode=1).
 DEFAULT_DURABLE_THRESHOLD_URGENCY = 0.4
-
-#: Depth of each application-level subscriber ring buffer (events).
-DEFAULT_RING_BUFFER_DEPTH = 1000
-
 
 # ---------------------------------------------------------------------------
 # Internal helpers
@@ -404,25 +401,20 @@ class RabbitMQSubscriber(SleipnirSubscriber):
         self,
         message: aio_pika.abc.AbstractIncomingMessage,  # type: ignore[name-defined]
     ) -> None:
-        """Receive an AMQP message, deserialise it, and dispatch to handlers."""
-        async with message.process():
-            event = _decode_event(message.body)
-            if event is None:
-                return
-            if event.ttl is not None and event.ttl <= 0:
-                logger.debug(
-                    "Dropping expired event %s (%s): ttl=%d",
-                    event.event_id,
-                    event.event_type,
-                    event.ttl,
-                )
-                return
-            for sub in list(self._subscriptions):
-                if not sub.active:
-                    continue
-                if not any(match_event_type(p, event.event_type) for p in sub.patterns):
-                    continue
-                await enqueue_with_overflow(sub._queue, event, self._ring_buffer_depth, logger)
+        """Receive an AMQP message, deserialise it, and dispatch to handlers.
+
+        Acknowledgement policy:
+        - Deserialization failure → ``nack(requeue=False)`` so the message is
+          routed to ``sleipnir.dead_letter`` for Sköll inspection.
+        - TTL-expired event → ``ack()``; the message is valid but stale.
+        - Successful dispatch → ``ack()``.
+        """
+        event = _decode_event(message.body)
+        if event is None:
+            await message.nack(requeue=False)
+            return
+        await message.ack()
+        await dispatch_to_subscriptions(event, self._subscriptions, self._ring_buffer_depth, logger)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sleipnir/test_rabbitmq.py
+++ b/tests/test_sleipnir/test_rabbitmq.py
@@ -54,21 +54,16 @@ aio_pika = pytest.importorskip("aio_pika", reason="aio-pika not installed; skipp
 # ---------------------------------------------------------------------------
 
 
-class _AsyncContextManagerMock:
-    """A simple async context manager that does nothing."""
-
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, *_):
-        pass
-
-
 def _make_mock_message(body: bytes) -> MagicMock:
-    """Build a mock AMQP incoming message with the given body."""
+    """Build a mock AMQP incoming message with the given body.
+
+    Provides ``ack`` and ``nack`` as :class:`~unittest.mock.AsyncMock` so
+    tests can assert which acknowledgement path was taken.
+    """
     msg = MagicMock()
     msg.body = body
-    msg.process.return_value = _AsyncContextManagerMock()
+    msg.ack = AsyncMock()
+    msg.nack = AsyncMock()
     return msg
 
 
@@ -591,7 +586,7 @@ async def test_subscribe_star_binds_hash():
 
 
 async def test_on_message_dispatches_to_matching_handler():
-    """A matching subscription receives the event."""
+    """A matching subscription receives the event and the message is acked."""
     mocks = _make_amqp_mocks()
     received: list[SleipnirEvent] = []
     done = asyncio.Event()
@@ -614,10 +609,12 @@ async def test_on_message_dispatches_to_matching_handler():
 
     assert len(received) == 1
     assert received[0].event_id == "msg-1"
+    msg.ack.assert_called_once()
+    msg.nack.assert_not_called()
 
 
 async def test_on_message_does_not_dispatch_to_non_matching_handler():
-    """A non-matching subscription does not receive the event."""
+    """A non-matching subscription does not receive the event; message is acked."""
     mocks = _make_amqp_mocks()
     received: list[SleipnirEvent] = []
 
@@ -639,10 +636,12 @@ async def test_on_message_does_not_dispatch_to_non_matching_handler():
         await sub.stop()
 
     assert received == []
+    msg.ack.assert_called_once()
+    msg.nack.assert_not_called()
 
 
 async def test_on_message_drops_expired_ttl():
-    """Messages with ttl=0 are silently dropped after deserialization."""
+    """TTL=0 events are not dispatched but the message is acked (valid, just stale)."""
     mocks = _make_amqp_mocks()
     received: list[SleipnirEvent] = []
 
@@ -662,10 +661,13 @@ async def test_on_message_drops_expired_ttl():
         await sub.stop()
 
     assert received == []
+    # TTL-expired messages are acked (they are valid, just stale) — not nacked.
+    msg.ack.assert_called_once()
+    msg.nack.assert_not_called()
 
 
 async def test_on_message_handles_malformed_json(caplog):
-    """Malformed JSON body is silently dropped (no unhandled exception)."""
+    """Malformed JSON body is nacked without requeue so DLX receives it."""
     mocks = _make_amqp_mocks()
 
     async def handler(_: SleipnirEvent) -> None:
@@ -681,6 +683,9 @@ async def test_on_message_handles_malformed_json(caplog):
             await sub._on_message(msg)
 
         await sub.stop()
+
+    msg.nack.assert_called_once_with(requeue=False)
+    msg.ack.assert_not_called()
 
 
 async def test_on_message_dispatches_to_multiple_subscribers():
@@ -714,6 +719,8 @@ async def test_on_message_dispatches_to_multiple_subscribers():
 
     assert bucket_a == ["multi-sub"]
     assert bucket_b == ["multi-sub"]
+    msg.ack.assert_called_once()
+    msg.nack.assert_not_called()
 
 
 async def test_on_message_inactive_subscription_not_dispatched():

--- a/tests/test_sleipnir/test_rabbitmq.py
+++ b/tests/test_sleipnir/test_rabbitmq.py
@@ -1,0 +1,995 @@
+"""Tests for the RabbitMQ transport adapter (NIU-523).
+
+Test strategy
+-------------
+All tests mock aio-pika so no external RabbitMQ broker is required.
+The mock layer replaces ``aio_pika.connect_robust`` and all downstream
+AMQP objects (channels, exchanges, queues, messages).
+
+Coverage targets
+----------------
+- :func:`~sleipnir.adapters.rabbitmq._fnmatch_to_amqp` — routing key translation
+- :class:`~sleipnir.adapters.rabbitmq.RabbitMQPublisher` — lifecycle, TTL, delivery mode
+- :class:`~sleipnir.adapters.rabbitmq.RabbitMQSubscriber` — lifecycle, bindings, dispatch
+- :class:`~sleipnir.adapters.rabbitmq.RabbitMQTransport` — combined pub+sub delegation
+- Module-level helpers: ``rabbitmq_available``
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from sleipnir.adapters.rabbitmq import (
+    DEFAULT_AMQP_URL,
+    DEFAULT_DEAD_LETTER_EXCHANGE,
+    DEFAULT_DURABLE_THRESHOLD_URGENCY,
+    DEFAULT_EXCHANGE_NAME,
+    DEFAULT_PREFETCH_COUNT,
+    DEFAULT_RING_BUFFER_DEPTH,
+    RabbitMQPublisher,
+    RabbitMQSubscriber,
+    RabbitMQTransport,
+    _decode_event,
+    _encode_event,
+    _fnmatch_to_amqp,
+    rabbitmq_available,
+)
+from sleipnir.domain.events import SleipnirEvent
+from tests.test_sleipnir.conftest import make_event
+
+# ---------------------------------------------------------------------------
+# Skip guard — tests require aio-pika
+# ---------------------------------------------------------------------------
+
+aio_pika = pytest.importorskip("aio_pika", reason="aio-pika not installed; skipping rabbitmq tests")
+
+
+# ---------------------------------------------------------------------------
+# Mock helpers
+# ---------------------------------------------------------------------------
+
+
+class _AsyncContextManagerMock:
+    """A simple async context manager that does nothing."""
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_):
+        pass
+
+
+def _make_mock_message(body: bytes) -> MagicMock:
+    """Build a mock AMQP incoming message with the given body."""
+    msg = MagicMock()
+    msg.body = body
+    msg.process.return_value = _AsyncContextManagerMock()
+    return msg
+
+
+def _make_amqp_mocks():
+    """Return a bundle of AsyncMock AMQP objects wired together.
+
+    Returns a dict with keys: connection, channel, exchange, queue.
+    """
+    queue = AsyncMock()
+    queue.name = "test-queue"
+    queue.consume = AsyncMock(return_value="consumer-tag-1")
+    queue.cancel = AsyncMock()
+    queue.bind = AsyncMock()
+
+    exchange = AsyncMock()
+    exchange.publish = AsyncMock()
+
+    channel = AsyncMock()
+    channel.set_qos = AsyncMock()
+    channel.declare_exchange = AsyncMock(return_value=exchange)
+    channel.declare_queue = AsyncMock(return_value=queue)
+    channel.close = AsyncMock()
+
+    connection = AsyncMock()
+    connection.channel = AsyncMock(return_value=channel)
+    connection.close = AsyncMock()
+
+    return {
+        "connection": connection,
+        "channel": channel,
+        "exchange": exchange,
+        "queue": queue,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — _fnmatch_to_amqp
+# ---------------------------------------------------------------------------
+
+
+def test_fnmatch_to_amqp_star_wildcard():
+    """'*' should produce '#' (subscribe to everything)."""
+    assert _fnmatch_to_amqp("*") == "#"
+
+
+def test_fnmatch_to_amqp_namespace_wildcard():
+    """'ravn.*' → 'ravn.#' (all ravn events)."""
+    assert _fnmatch_to_amqp("ravn.*") == "ravn.#"
+
+
+def test_fnmatch_to_amqp_sub_namespace_wildcard():
+    """'ravn.tool.*' → 'ravn.tool.#'."""
+    assert _fnmatch_to_amqp("ravn.tool.*") == "ravn.tool.#"
+
+
+def test_fnmatch_to_amqp_exact_match():
+    """Exact event type passes through unchanged."""
+    assert _fnmatch_to_amqp("ravn.tool.complete") == "ravn.tool.complete"
+
+
+def test_fnmatch_to_amqp_question_mark_falls_back():
+    """Pattern with '?' → '#' (unsupported by AMQP topic rules)."""
+    assert _fnmatch_to_amqp("ravn.tool.?") == "#"
+
+
+def test_fnmatch_to_amqp_bracket_falls_back():
+    """Pattern with '[' → '#'."""
+    assert _fnmatch_to_amqp("ravn.[abc]*") == "#"
+
+
+def test_fnmatch_to_amqp_mid_star_falls_back():
+    """Pattern with '*' not at the trailing position → '#'."""
+    assert _fnmatch_to_amqp("ravn.*.complete") == "#"
+
+
+def test_fnmatch_to_amqp_deep_namespace():
+    """Three-level namespace wildcard is handled correctly."""
+    assert _fnmatch_to_amqp("tyr.saga.*") == "tyr.saga.#"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — rabbitmq_available / ImportError guard
+# ---------------------------------------------------------------------------
+
+
+def test_rabbitmq_available_returns_true():
+    assert rabbitmq_available() is True
+
+
+def test_rabbitmq_available_false_when_not_installed():
+    with patch("sleipnir.adapters.rabbitmq._AIO_PIKA_AVAILABLE", False):
+        assert rabbitmq_available() is False
+
+
+def test_import_error_when_aio_pika_not_available():
+    """Publisher/Subscriber/Transport raise ImportError if aio-pika is absent."""
+    with patch("sleipnir.adapters.rabbitmq._AIO_PIKA_AVAILABLE", False):
+        with pytest.raises(ImportError, match="aio-pika"):
+            RabbitMQPublisher()
+        with pytest.raises(ImportError, match="aio-pika"):
+            RabbitMQSubscriber()
+        with pytest.raises(ImportError, match="aio-pika"):
+            RabbitMQTransport()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — _encode_event / _decode_event
+# ---------------------------------------------------------------------------
+
+
+def test_encode_decode_round_trip():
+    """JSON encode → decode round-trip preserves all fields."""
+    event = make_event(event_id="json-rt", urgency=0.8, correlation_id="corr-1")
+    raw = _encode_event(event)
+    assert isinstance(raw, bytes)
+    decoded = _decode_event(raw)
+    assert decoded is not None
+    assert decoded.event_id == "json-rt"
+    assert decoded.urgency == pytest.approx(0.8)
+    assert decoded.correlation_id == "corr-1"
+
+
+def test_decode_event_returns_none_on_malformed(caplog):
+    """_decode_event returns None and logs on malformed input."""
+    with caplog.at_level(logging.ERROR, logger="sleipnir.adapters.rabbitmq"):
+        result = _decode_event(b"{not valid json}")
+    assert result is None
+
+
+def test_encode_event_produces_valid_json():
+    """Encoded bytes parse as valid JSON with expected keys."""
+    event = make_event()
+    raw = _encode_event(event)
+    data = json.loads(raw)
+    assert data["event_type"] == event.event_type
+    assert data["urgency"] == event.urgency
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — RabbitMQPublisher lifecycle
+# ---------------------------------------------------------------------------
+
+
+async def test_publisher_start_declares_exchange():
+    """start() declares the topic exchange."""
+    mocks = _make_amqp_mocks()
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]) as mock_connect:
+        pub = RabbitMQPublisher(url="amqp://test/")
+        await pub.start()
+
+        mock_connect.assert_called_once_with("amqp://test/")
+        mocks["channel"].declare_exchange.assert_called_once_with(
+            DEFAULT_EXCHANGE_NAME,
+            aio_pika.ExchangeType.TOPIC,
+            durable=True,
+        )
+        await pub.stop()
+
+
+async def test_publisher_stop_closes_channel_and_connection():
+    """stop() closes channel then connection."""
+    mocks = _make_amqp_mocks()
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        pub = RabbitMQPublisher()
+        await pub.start()
+        await pub.stop()
+
+    mocks["channel"].close.assert_called_once()
+    mocks["connection"].close.assert_called_once()
+    assert pub._exchange is None
+    assert pub._channel is None
+    assert pub._connection is None
+
+
+async def test_publisher_stop_idempotent():
+    """stop() called multiple times does not raise."""
+    mocks = _make_amqp_mocks()
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        pub = RabbitMQPublisher()
+        await pub.start()
+        await pub.stop()
+        await pub.stop()  # second call: no-op
+
+
+async def test_publisher_raises_without_start():
+    """publish() before start() raises RuntimeError."""
+    pub = RabbitMQPublisher()
+    with pytest.raises(RuntimeError, match="not started"):
+        await pub.publish(make_event())
+
+
+async def test_publisher_context_manager():
+    """Async context manager calls start() and stop()."""
+    mocks = _make_amqp_mocks()
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        async with RabbitMQPublisher() as pub:
+            assert pub._exchange is not None
+        assert pub._exchange is None
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — RabbitMQPublisher.publish delivery mode
+# ---------------------------------------------------------------------------
+
+
+async def test_publish_persistent_above_threshold():
+    """Events with urgency > threshold use PERSISTENT delivery mode."""
+    mocks = _make_amqp_mocks()
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        with patch("aio_pika.Message") as mock_message_cls:
+            mock_message_cls.return_value = MagicMock()
+            pub = RabbitMQPublisher(durable_threshold_urgency=0.4)
+            await pub.start()
+            event = make_event(event_id="pers", urgency=0.5)
+            await pub.publish(event)
+            await pub.stop()
+
+    mock_message_cls.assert_called_once()
+    _, kwargs = mock_message_cls.call_args
+    assert kwargs["delivery_mode"] == aio_pika.DeliveryMode.PERSISTENT
+
+
+async def test_publish_transient_at_threshold():
+    """Events with urgency == threshold use NOT_PERSISTENT delivery mode."""
+    mocks = _make_amqp_mocks()
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        with patch("aio_pika.Message") as mock_message_cls:
+            mock_message_cls.return_value = MagicMock()
+            pub = RabbitMQPublisher(durable_threshold_urgency=0.4)
+            await pub.start()
+            event = make_event(urgency=0.4)
+            await pub.publish(event)
+            await pub.stop()
+
+    _, kwargs = mock_message_cls.call_args
+    assert kwargs["delivery_mode"] == aio_pika.DeliveryMode.NOT_PERSISTENT
+
+
+async def test_publish_transient_below_threshold():
+    """Events with urgency < threshold use NOT_PERSISTENT delivery mode."""
+    mocks = _make_amqp_mocks()
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        with patch("aio_pika.Message") as mock_message_cls:
+            mock_message_cls.return_value = MagicMock()
+            pub = RabbitMQPublisher(durable_threshold_urgency=0.4)
+            await pub.start()
+            event = make_event(urgency=0.2)
+            await pub.publish(event)
+            await pub.stop()
+
+    _, kwargs = mock_message_cls.call_args
+    assert kwargs["delivery_mode"] == aio_pika.DeliveryMode.NOT_PERSISTENT
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — RabbitMQPublisher routing key & TTL
+# ---------------------------------------------------------------------------
+
+
+async def test_publish_uses_event_type_as_routing_key():
+    """publish() uses event.event_type as the AMQP routing key."""
+    mocks = _make_amqp_mocks()
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        pub = RabbitMQPublisher()
+        await pub.start()
+        event = make_event(event_type="ravn.tool.complete")
+        await pub.publish(event)
+        await pub.stop()
+
+    mocks["exchange"].publish.assert_called_once()
+    _, kwargs = mocks["exchange"].publish.call_args
+    assert kwargs["routing_key"] == "ravn.tool.complete"
+
+
+async def test_publish_drops_ttl_zero_event(caplog):
+    """Events with ttl=0 are silently dropped before publishing."""
+    mocks = _make_amqp_mocks()
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        pub = RabbitMQPublisher()
+        await pub.start()
+        await pub.publish(make_event(ttl=0))
+        await pub.stop()
+
+    mocks["exchange"].publish.assert_not_called()
+
+
+async def test_publish_batch_publishes_all_events():
+    """publish_batch() publishes every event in the batch."""
+    mocks = _make_amqp_mocks()
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        pub = RabbitMQPublisher()
+        await pub.start()
+        batch = [make_event(event_id=f"b{i}") for i in range(5)]
+        await pub.publish_batch(batch)
+        await pub.stop()
+
+    assert mocks["exchange"].publish.call_count == 5
+
+
+async def test_publish_message_content_type_is_json():
+    """Published messages have content_type='application/json'."""
+    mocks = _make_amqp_mocks()
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        with patch("aio_pika.Message") as mock_message_cls:
+            mock_message_cls.return_value = MagicMock()
+            pub = RabbitMQPublisher()
+            await pub.start()
+            await pub.publish(make_event())
+            await pub.stop()
+
+    _, kwargs = mock_message_cls.call_args
+    assert kwargs["content_type"] == "application/json"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — RabbitMQSubscriber lifecycle
+# ---------------------------------------------------------------------------
+
+
+async def test_subscriber_start_declares_exchanges_and_queue():
+    """start() declares DLX, main exchange, and subscriber queue."""
+    mocks = _make_amqp_mocks()
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        sub = RabbitMQSubscriber(service_id="ravn:test")
+        await sub.start()
+        await sub.stop()
+
+    declare_calls = mocks["channel"].declare_exchange.call_args_list
+    exchange_names = [c[0][0] for c in declare_calls]
+    assert DEFAULT_DEAD_LETTER_EXCHANGE in exchange_names
+    assert DEFAULT_EXCHANGE_NAME in exchange_names
+
+    mocks["channel"].declare_queue.assert_called_once()
+    mocks["queue"].consume.assert_called_once()
+
+
+async def test_subscriber_named_queue_is_durable():
+    """Named service_id produces a durable queue."""
+    mocks = _make_amqp_mocks()
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        sub = RabbitMQSubscriber(service_id="ravn:agent")
+        await sub.start()
+        await sub.stop()
+
+    _, kwargs = mocks["channel"].declare_queue.call_args
+    assert kwargs["durable"] is True
+    assert kwargs["auto_delete"] is False
+
+
+async def test_subscriber_anonymous_queue_is_auto_delete():
+    """No service_id produces an auto-delete, non-durable queue."""
+    mocks = _make_amqp_mocks()
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        sub = RabbitMQSubscriber()
+        await sub.start()
+        await sub.stop()
+
+    _, kwargs = mocks["channel"].declare_queue.call_args
+    assert kwargs["durable"] is False
+    assert kwargs["auto_delete"] is True
+
+
+async def test_subscriber_queue_has_dead_letter_argument():
+    """Subscriber queue is declared with x-dead-letter-exchange argument."""
+    mocks = _make_amqp_mocks()
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        sub = RabbitMQSubscriber()
+        await sub.start()
+        await sub.stop()
+
+    _, kwargs = mocks["channel"].declare_queue.call_args
+    assert kwargs["arguments"]["x-dead-letter-exchange"] == DEFAULT_DEAD_LETTER_EXCHANGE
+
+
+async def test_subscriber_sets_prefetch_count():
+    """start() calls set_qos with the configured prefetch_count."""
+    mocks = _make_amqp_mocks()
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        sub = RabbitMQSubscriber(prefetch_count=5)
+        await sub.start()
+        await sub.stop()
+
+    mocks["channel"].set_qos.assert_called_once_with(prefetch_count=5)
+
+
+async def test_subscriber_stop_cancels_consumer():
+    """stop() cancels the AMQP consumer and closes connection."""
+    mocks = _make_amqp_mocks()
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        sub = RabbitMQSubscriber()
+        await sub.start()
+        consumer_tag = sub._consumer_tag
+        await sub.stop()
+
+    mocks["queue"].cancel.assert_called_once_with(consumer_tag)
+    mocks["channel"].close.assert_called_once()
+    mocks["connection"].close.assert_called_once()
+    assert sub._connection is None
+    assert sub._channel is None
+    assert sub._queue is None
+
+
+async def test_subscriber_stop_idempotent():
+    """stop() called multiple times does not raise."""
+    mocks = _make_amqp_mocks()
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        sub = RabbitMQSubscriber()
+        await sub.start()
+        await sub.stop()
+        await sub.stop()
+
+
+async def test_subscriber_context_manager():
+    """Async context manager calls start() and stop()."""
+    mocks = _make_amqp_mocks()
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        async with RabbitMQSubscriber() as sub:
+            assert sub._queue is not None
+        assert sub._queue is None
+
+
+async def test_subscriber_rejects_zero_ring_buffer_depth():
+    with pytest.raises(ValueError, match="ring_buffer_depth"):
+        RabbitMQSubscriber(ring_buffer_depth=0)
+
+
+async def test_subscriber_raises_without_start():
+    """subscribe() before start() raises RuntimeError."""
+    sub = RabbitMQSubscriber()
+
+    async def handler(_: SleipnirEvent) -> None:
+        pass
+
+    with pytest.raises(RuntimeError, match="not started"):
+        await sub.subscribe(["*"], handler)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — RabbitMQSubscriber.subscribe bindings
+# ---------------------------------------------------------------------------
+
+
+async def test_subscribe_binds_amqp_routing_key():
+    """subscribe() binds the queue to the exchange with translated routing key."""
+    mocks = _make_amqp_mocks()
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        sub = RabbitMQSubscriber()
+        await sub.start()
+
+        async def handler(_: SleipnirEvent) -> None:
+            pass
+
+        handle = await sub.subscribe(["ravn.*"], handler)
+        await sub.stop()
+        await handle.unsubscribe()
+
+    mocks["queue"].bind.assert_called_once_with(mocks["exchange"], routing_key="ravn.#")
+
+
+async def test_subscribe_deduplicates_amqp_bindings():
+    """Two subscribe() calls with the same translated key bind only once."""
+    mocks = _make_amqp_mocks()
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        sub = RabbitMQSubscriber()
+        await sub.start()
+
+        async def handler(_: SleipnirEvent) -> None:
+            pass
+
+        h1 = await sub.subscribe(["ravn.*"], handler)
+        h2 = await sub.subscribe(["ravn.*"], handler)  # same AMQP key
+        await sub.stop()
+        await h1.unsubscribe()
+        await h2.unsubscribe()
+
+    # Should only bind once despite two subscribe() calls
+    assert mocks["queue"].bind.call_count == 1
+
+
+async def test_subscribe_multiple_patterns_each_binds():
+    """subscribe() with multiple patterns creates one binding per unique AMQP key."""
+    mocks = _make_amqp_mocks()
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        sub = RabbitMQSubscriber()
+        await sub.start()
+
+        async def handler(_: SleipnirEvent) -> None:
+            pass
+
+        handle = await sub.subscribe(["ravn.*", "tyr.*"], handler)
+        await sub.stop()
+        await handle.unsubscribe()
+
+    bound_keys = {c[1]["routing_key"] for c in mocks["queue"].bind.call_args_list}
+    assert "ravn.#" in bound_keys
+    assert "tyr.#" in bound_keys
+
+
+async def test_subscribe_star_binds_hash():
+    """'*' pattern produces '#' AMQP binding."""
+    mocks = _make_amqp_mocks()
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        sub = RabbitMQSubscriber()
+        await sub.start()
+
+        async def handler(_: SleipnirEvent) -> None:
+            pass
+
+        handle = await sub.subscribe(["*"], handler)
+        await sub.stop()
+        await handle.unsubscribe()
+
+    _, kwargs = mocks["queue"].bind.call_args
+    assert kwargs["routing_key"] == "#"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — RabbitMQSubscriber._on_message dispatch
+# ---------------------------------------------------------------------------
+
+
+async def test_on_message_dispatches_to_matching_handler():
+    """A matching subscription receives the event."""
+    mocks = _make_amqp_mocks()
+    received: list[SleipnirEvent] = []
+    done = asyncio.Event()
+
+    async def handler(evt: SleipnirEvent) -> None:
+        received.append(evt)
+        done.set()
+
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        sub = RabbitMQSubscriber()
+        await sub.start()
+        await sub.subscribe(["ravn.*"], handler)
+
+        event = make_event(event_id="msg-1", event_type="ravn.tool.complete")
+        msg = _make_mock_message(_encode_event(event))
+        await sub._on_message(msg)
+
+        await asyncio.wait_for(done.wait(), timeout=2.0)
+        await sub.stop()
+
+    assert len(received) == 1
+    assert received[0].event_id == "msg-1"
+
+
+async def test_on_message_does_not_dispatch_to_non_matching_handler():
+    """A non-matching subscription does not receive the event."""
+    mocks = _make_amqp_mocks()
+    received: list[SleipnirEvent] = []
+
+    async def handler(evt: SleipnirEvent) -> None:
+        received.append(evt)
+
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        sub = RabbitMQSubscriber()
+        await sub.start()
+        # Subscribe to tyr.* only
+        await sub.subscribe(["tyr.*"], handler)
+
+        event = make_event(event_type="ravn.tool.complete")
+        msg = _make_mock_message(_encode_event(event))
+        await sub._on_message(msg)
+
+        # Allow any async delivery
+        await asyncio.sleep(0.05)
+        await sub.stop()
+
+    assert received == []
+
+
+async def test_on_message_drops_expired_ttl():
+    """Messages with ttl=0 are silently dropped after deserialization."""
+    mocks = _make_amqp_mocks()
+    received: list[SleipnirEvent] = []
+
+    async def handler(evt: SleipnirEvent) -> None:
+        received.append(evt)
+
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        sub = RabbitMQSubscriber()
+        await sub.start()
+        await sub.subscribe(["*"], handler)
+
+        event = make_event(ttl=0)
+        msg = _make_mock_message(_encode_event(event))
+        await sub._on_message(msg)
+
+        await asyncio.sleep(0.05)
+        await sub.stop()
+
+    assert received == []
+
+
+async def test_on_message_handles_malformed_json(caplog):
+    """Malformed JSON body is silently dropped (no unhandled exception)."""
+    mocks = _make_amqp_mocks()
+
+    async def handler(_: SleipnirEvent) -> None:
+        pass
+
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        sub = RabbitMQSubscriber()
+        await sub.start()
+        await sub.subscribe(["*"], handler)
+
+        msg = _make_mock_message(b"{bad json")
+        with caplog.at_level(logging.ERROR, logger="sleipnir.adapters.rabbitmq"):
+            await sub._on_message(msg)
+
+        await sub.stop()
+
+
+async def test_on_message_dispatches_to_multiple_subscribers():
+    """All active subscriptions independently receive the same event."""
+    mocks = _make_amqp_mocks()
+    bucket_a: list[str] = []
+    bucket_b: list[str] = []
+    done_a = asyncio.Event()
+    done_b = asyncio.Event()
+
+    async def handler_a(evt: SleipnirEvent) -> None:
+        bucket_a.append(evt.event_id)
+        done_a.set()
+
+    async def handler_b(evt: SleipnirEvent) -> None:
+        bucket_b.append(evt.event_id)
+        done_b.set()
+
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        sub = RabbitMQSubscriber()
+        await sub.start()
+        await sub.subscribe(["*"], handler_a)
+        await sub.subscribe(["*"], handler_b)
+
+        event = make_event(event_id="multi-sub")
+        msg = _make_mock_message(_encode_event(event))
+        await sub._on_message(msg)
+
+        await asyncio.wait_for(asyncio.gather(done_a.wait(), done_b.wait()), timeout=2.0)
+        await sub.stop()
+
+    assert bucket_a == ["multi-sub"]
+    assert bucket_b == ["multi-sub"]
+
+
+async def test_on_message_inactive_subscription_not_dispatched():
+    """An unsubscribed handler does not receive events."""
+    mocks = _make_amqp_mocks()
+    received: list[str] = []
+    first_done = asyncio.Event()
+
+    async def handler(evt: SleipnirEvent) -> None:
+        received.append(evt.event_id)
+        first_done.set()
+
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        sub = RabbitMQSubscriber()
+        await sub.start()
+        handle = await sub.subscribe(["*"], handler)
+
+        # First message: delivered
+        event1 = make_event(event_id="before-unsub")
+        await sub._on_message(_make_mock_message(_encode_event(event1)))
+        await asyncio.wait_for(first_done.wait(), timeout=2.0)
+
+        # Unsubscribe and send second message
+        await handle.unsubscribe()
+        event2 = make_event(event_id="after-unsub")
+        await sub._on_message(_make_mock_message(_encode_event(event2)))
+        await asyncio.sleep(0.05)
+        await sub.stop()
+
+    assert "before-unsub" in received
+    assert "after-unsub" not in received
+
+
+async def test_flush_waits_for_event_processing():
+    """flush() blocks until all queued events are processed."""
+    mocks = _make_amqp_mocks()
+    processed: list[str] = []
+
+    async def slow_handler(evt: SleipnirEvent) -> None:
+        await asyncio.sleep(0.02)
+        processed.append(evt.event_id)
+
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        sub = RabbitMQSubscriber()
+        await sub.start()
+        await sub.subscribe(["*"], slow_handler)
+
+        event = make_event(event_id="flush-me")
+        await sub._on_message(_make_mock_message(_encode_event(event)))
+        await sub.flush()
+        await sub.stop()
+
+    assert "flush-me" in processed
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — ring buffer overflow
+# ---------------------------------------------------------------------------
+
+
+async def test_ring_buffer_overflow_drops_oldest_and_warns(caplog):
+    """When the ring buffer is full, the oldest event is dropped with a warning."""
+    mocks = _make_amqp_mocks()
+    released = asyncio.Event()
+
+    async def blocking_handler(_: SleipnirEvent) -> None:
+        await released.wait()
+
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        sub = RabbitMQSubscriber(ring_buffer_depth=2)
+        await sub.start()
+        await sub.subscribe(["*"], blocking_handler)
+
+        # Send more events than the ring buffer can hold.
+        with caplog.at_level(logging.WARNING, logger="sleipnir.adapters.rabbitmq"):
+            for i in range(10):
+                event = make_event(event_id=f"overflow-{i}")
+                await sub._on_message(_make_mock_message(_encode_event(event)))
+
+        overflow_warnings = [r for r in caplog.records if "Ring buffer overflow" in r.message]
+        assert len(overflow_warnings) >= 1
+
+        released.set()
+        await sub.stop()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — crashing handler isolation
+# ---------------------------------------------------------------------------
+
+
+async def test_crashing_handler_does_not_affect_sibling():
+    """A handler that raises must not prevent sibling subscriptions from receiving."""
+    mocks = _make_amqp_mocks()
+    received_by_stable: list[str] = []
+    n = 3
+    all_stable_done = asyncio.Event()
+
+    async def crashing_handler(_: SleipnirEvent) -> None:
+        raise RuntimeError("Simulated handler crash")
+
+    async def stable_handler(evt: SleipnirEvent) -> None:
+        received_by_stable.append(evt.event_id)
+        if len(received_by_stable) >= n:
+            all_stable_done.set()
+
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        sub = RabbitMQSubscriber()
+        await sub.start()
+        await sub.subscribe(["*"], crashing_handler)
+        await sub.subscribe(["*"], stable_handler)
+
+        for i in range(n):
+            event = make_event(event_id=f"crash-{i}")
+            await sub._on_message(_make_mock_message(_encode_event(event)))
+
+        await asyncio.wait_for(all_stable_done.wait(), timeout=2.0)
+        await sub.stop()
+
+    assert len(received_by_stable) == n
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — RabbitMQTransport
+# ---------------------------------------------------------------------------
+
+
+async def test_transport_start_starts_both_pub_and_sub():
+    """RabbitMQTransport.start() calls start on both publisher and subscriber."""
+    mocks = _make_amqp_mocks()
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        transport = RabbitMQTransport()
+        await transport.start()
+        assert transport._publisher._exchange is not None
+        assert transport._subscriber._queue is not None
+        await transport.stop()
+
+
+async def test_transport_stop_order():
+    """stop() calls subscriber.stop() before publisher.stop()."""
+    mocks = _make_amqp_mocks()
+    stop_order: list[str] = []
+
+    async def track_sub_stop(*_):
+        stop_order.append("sub")
+
+    async def track_pub_stop(*_):
+        stop_order.append("pub")
+
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        transport = RabbitMQTransport()
+        await transport.start()
+        transport._subscriber.stop = track_sub_stop
+        transport._publisher.stop = track_pub_stop
+        await transport.stop()
+
+    assert stop_order == ["sub", "pub"]
+
+
+async def test_transport_publish_delegates_to_publisher():
+    """publish() delegates to the internal RabbitMQPublisher."""
+    mocks = _make_amqp_mocks()
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        transport = RabbitMQTransport()
+        await transport.start()
+        event = make_event(event_id="transport-pub")
+        await transport.publish(event)
+        await transport.stop()
+
+    mocks["exchange"].publish.assert_called_once()
+
+
+async def test_transport_publish_batch_publishes_all():
+    """publish_batch() delivers all events via the internal publisher."""
+    mocks = _make_amqp_mocks()
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        transport = RabbitMQTransport()
+        await transport.start()
+        batch = [make_event(event_id=f"t{i}") for i in range(4)]
+        await transport.publish_batch(batch)
+        await transport.stop()
+
+    assert mocks["exchange"].publish.call_count == 4
+
+
+async def test_transport_subscribe_delegates_to_subscriber():
+    """subscribe() delegates to the internal RabbitMQSubscriber."""
+    mocks = _make_amqp_mocks()
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        transport = RabbitMQTransport()
+        await transport.start()
+
+        async def handler(_: SleipnirEvent) -> None:
+            pass
+
+        handle = await transport.subscribe(["ravn.*"], handler)
+        await transport.stop()
+        await handle.unsubscribe()
+
+    mocks["queue"].bind.assert_called_once()
+
+
+async def test_transport_flush_delegates_to_subscriber():
+    """flush() delegates to the internal RabbitMQSubscriber."""
+    mocks = _make_amqp_mocks()
+    processed: list[str] = []
+
+    async def handler(evt: SleipnirEvent) -> None:
+        processed.append(evt.event_id)
+
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        transport = RabbitMQTransport()
+        await transport.start()
+        await transport.subscribe(["*"], handler)
+
+        event = make_event(event_id="flush-transport")
+        msg = _make_mock_message(_encode_event(event))
+        await transport._subscriber._on_message(msg)
+
+        await transport.flush()
+        await transport.stop()
+
+    assert "flush-transport" in processed
+
+
+async def test_transport_context_manager():
+    """Async context manager starts and stops cleanly."""
+    mocks = _make_amqp_mocks()
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        async with RabbitMQTransport() as transport:
+            assert transport._publisher._exchange is not None
+        assert transport._publisher._exchange is None
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — default constants
+# ---------------------------------------------------------------------------
+
+
+def test_default_constants_are_sensible():
+    """Sanity check on module-level defaults."""
+    assert DEFAULT_AMQP_URL.startswith("amqp://")
+    assert "sleipnir" in DEFAULT_EXCHANGE_NAME
+    assert "dead_letter" in DEFAULT_DEAD_LETTER_EXCHANGE
+    assert DEFAULT_PREFETCH_COUNT == 1
+    assert 0.0 < DEFAULT_DURABLE_THRESHOLD_URGENCY < 1.0
+    assert DEFAULT_RING_BUFFER_DEPTH > 0
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — custom exchange name
+# ---------------------------------------------------------------------------
+
+
+async def test_custom_exchange_name_is_used():
+    """A custom exchange_name is used when declaring the exchange."""
+    mocks = _make_amqp_mocks()
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        pub = RabbitMQPublisher(exchange_name="my.custom.exchange")
+        await pub.start()
+        await pub.stop()
+
+    declare_call_names = [c[0][0] for c in mocks["channel"].declare_exchange.call_args_list]
+    assert "my.custom.exchange" in declare_call_names
+
+
+async def test_custom_dead_letter_exchange_name():
+    """A custom dead_letter_exchange is used when declaring the DLX."""
+    mocks = _make_amqp_mocks()
+    with patch("aio_pika.connect_robust", return_value=mocks["connection"]):
+        sub = RabbitMQSubscriber(dead_letter_exchange="my.dlx")
+        await sub.start()
+        await sub.stop()
+
+    declare_call_names = [c[0][0] for c in mocks["channel"].declare_exchange.call_args_list]
+    assert "my.dlx" in declare_call_names
+
+    _, kwargs = mocks["channel"].declare_queue.call_args
+    assert kwargs["arguments"]["x-dead-letter-exchange"] == "my.dlx"

--- a/tests/test_sleipnir/test_subscriber_support.py
+++ b/tests/test_sleipnir/test_subscriber_support.py
@@ -1,0 +1,229 @@
+"""Tests for shared subscriber support helpers.
+
+Covers :func:`dispatch_to_subscriptions` and the ``DEFAULT_RING_BUFFER_DEPTH``
+constant introduced by the code-review refactor (NIU-523).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from sleipnir.adapters._subscriber_support import (
+    DEFAULT_RING_BUFFER_DEPTH,
+    _BaseSubscription,
+    consume_queue,
+    dispatch_to_subscriptions,
+)
+from sleipnir.domain.events import SleipnirEvent
+from tests.test_sleipnir.conftest import make_event
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_sub(patterns: list[str], handler) -> tuple[_BaseSubscription, asyncio.Task]:
+    """Create a live _BaseSubscription with a running consumer task."""
+    queue: asyncio.Queue[SleipnirEvent] = asyncio.Queue(maxsize=DEFAULT_RING_BUFFER_DEPTH)
+    task = asyncio.create_task(consume_queue(queue, handler))
+    sub = _BaseSubscription(patterns, queue, task, lambda: None)
+    return sub, task
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — DEFAULT_RING_BUFFER_DEPTH
+# ---------------------------------------------------------------------------
+
+
+def test_default_ring_buffer_depth_is_positive():
+    assert DEFAULT_RING_BUFFER_DEPTH > 0
+
+
+def test_default_ring_buffer_depth_consistent_across_adapters():
+    """All three adapters expose the same value as _subscriber_support."""
+    import sleipnir.adapters.in_process as ip_mod
+    import sleipnir.adapters.nng_transport as nng_mod
+    import sleipnir.adapters.rabbitmq as rmq_mod
+
+    assert ip_mod.DEFAULT_RING_BUFFER_DEPTH == DEFAULT_RING_BUFFER_DEPTH
+    assert nng_mod.DEFAULT_RING_BUFFER_DEPTH == DEFAULT_RING_BUFFER_DEPTH
+    assert rmq_mod.DEFAULT_RING_BUFFER_DEPTH == DEFAULT_RING_BUFFER_DEPTH
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — dispatch_to_subscriptions
+# ---------------------------------------------------------------------------
+
+
+async def test_dispatch_delivers_to_matching_subscription():
+    """Event matching subscription pattern is enqueued."""
+    received: list[SleipnirEvent] = []
+    done = asyncio.Event()
+
+    async def handler(evt: SleipnirEvent) -> None:
+        received.append(evt)
+        done.set()
+
+    sub, task = _make_sub(["ravn.*"], handler)
+    try:
+        event = make_event(event_id="d-1", event_type="ravn.tool.complete")
+        await dispatch_to_subscriptions(
+            event, [sub], DEFAULT_RING_BUFFER_DEPTH, logging.getLogger(__name__)
+        )
+        await asyncio.wait_for(done.wait(), timeout=2.0)
+    finally:
+        await sub.unsubscribe()
+
+    assert len(received) == 1
+    assert received[0].event_id == "d-1"
+
+
+async def test_dispatch_skips_non_matching_subscription():
+    """Event not matching subscription pattern is not delivered."""
+    received: list[SleipnirEvent] = []
+
+    async def handler(evt: SleipnirEvent) -> None:
+        received.append(evt)
+
+    sub, _ = _make_sub(["tyr.*"], handler)
+    try:
+        event = make_event(event_type="ravn.tool.complete")
+        await dispatch_to_subscriptions(
+            event, [sub], DEFAULT_RING_BUFFER_DEPTH, logging.getLogger(__name__)
+        )
+        await asyncio.sleep(0.05)
+    finally:
+        await sub.unsubscribe()
+
+    assert received == []
+
+
+async def test_dispatch_skips_inactive_subscription():
+    """Inactive (unsubscribed) subscriptions are not dispatched to."""
+    received: list[SleipnirEvent] = []
+
+    async def handler(evt: SleipnirEvent) -> None:
+        received.append(evt)
+
+    sub, _ = _make_sub(["*"], handler)
+    await sub.unsubscribe()  # deactivate before dispatching
+
+    event = make_event(event_id="inactive")
+    await dispatch_to_subscriptions(
+        event, [sub], DEFAULT_RING_BUFFER_DEPTH, logging.getLogger(__name__)
+    )
+    await asyncio.sleep(0.05)
+
+    assert received == []
+
+
+async def test_dispatch_drops_ttl_zero_event(caplog):
+    """Events with ttl=0 are dropped with a DEBUG log; nothing is enqueued."""
+    received: list[SleipnirEvent] = []
+
+    async def handler(evt: SleipnirEvent) -> None:
+        received.append(evt)
+
+    sub, _ = _make_sub(["*"], handler)
+    try:
+        event = make_event(ttl=0)
+        log = logging.getLogger("sleipnir.adapters._subscriber_support")
+        with caplog.at_level(logging.DEBUG, logger=log.name):
+            await dispatch_to_subscriptions(event, [sub], DEFAULT_RING_BUFFER_DEPTH, log)
+        await asyncio.sleep(0.05)
+    finally:
+        await sub.unsubscribe()
+
+    assert received == []
+    assert any("ttl" in r.message.lower() or "expired" in r.message.lower() for r in caplog.records)
+
+
+async def test_dispatch_delivers_to_multiple_subscriptions():
+    """All matching subscriptions independently receive the event."""
+    bucket_a: list[str] = []
+    bucket_b: list[str] = []
+    done_a = asyncio.Event()
+    done_b = asyncio.Event()
+
+    async def handler_a(evt: SleipnirEvent) -> None:
+        bucket_a.append(evt.event_id)
+        done_a.set()
+
+    async def handler_b(evt: SleipnirEvent) -> None:
+        bucket_b.append(evt.event_id)
+        done_b.set()
+
+    sub_a, _ = _make_sub(["*"], handler_a)
+    sub_b, _ = _make_sub(["*"], handler_b)
+    try:
+        event = make_event(event_id="multi")
+        await dispatch_to_subscriptions(
+            event, [sub_a, sub_b], DEFAULT_RING_BUFFER_DEPTH, logging.getLogger(__name__)
+        )
+        await asyncio.wait_for(asyncio.gather(done_a.wait(), done_b.wait()), timeout=2.0)
+    finally:
+        await sub_a.unsubscribe()
+        await sub_b.unsubscribe()
+
+    assert bucket_a == ["multi"]
+    assert bucket_b == ["multi"]
+
+
+async def test_dispatch_star_pattern_matches_all_namespaces():
+    """'*' pattern dispatches events from any namespace."""
+    received_types: list[str] = []
+    all_done = asyncio.Event()
+    target = ["ravn.tool.complete", "tyr.task.started", "volundr.pr.opened"]
+
+    async def handler(evt: SleipnirEvent) -> None:
+        received_types.append(evt.event_type)
+        if all(t in received_types for t in target):
+            all_done.set()
+
+    sub, _ = _make_sub(["*"], handler)
+    try:
+        for et in target:
+            await dispatch_to_subscriptions(
+                make_event(event_type=et),
+                [sub],
+                DEFAULT_RING_BUFFER_DEPTH,
+                logging.getLogger(__name__),
+            )
+        await asyncio.wait_for(all_done.wait(), timeout=2.0)
+    finally:
+        await sub.unsubscribe()
+
+    assert sorted(received_types) == sorted(target)
+
+
+async def test_dispatch_empty_subscription_list_is_noop():
+    """Dispatching to an empty list does nothing and does not raise."""
+    event = make_event()
+    await dispatch_to_subscriptions(
+        event, [], DEFAULT_RING_BUFFER_DEPTH, logging.getLogger(__name__)
+    )
+
+
+async def test_dispatch_ring_buffer_overflow_warns(caplog):
+    """When the queue is full, dispatch drops the oldest event with a WARNING."""
+    released = asyncio.Event()
+
+    async def blocking_handler(_: SleipnirEvent) -> None:
+        await released.wait()
+
+    depth = 2
+    queue: asyncio.Queue[SleipnirEvent] = asyncio.Queue(maxsize=depth)
+    task = asyncio.create_task(consume_queue(queue, blocking_handler))
+    sub = _BaseSubscription(["*"], queue, task, lambda: None)
+
+    log = logging.getLogger("sleipnir.adapters._subscriber_support")
+    try:
+        with caplog.at_level(logging.WARNING, logger=log.name):
+            for i in range(depth + 3):
+                await dispatch_to_subscriptions(make_event(event_id=f"ov-{i}"), [sub], depth, log)
+        overflow_warnings = [r for r in caplog.records if "Ring buffer overflow" in r.message]
+        assert len(overflow_warnings) >= 1
+    finally:
+        released.set()
+        await sub.unsubscribe()


### PR DESCRIPTION
## Summary

- Adds `RabbitMQPublisher`, `RabbitMQSubscriber`, and `RabbitMQTransport` to `src/sleipnir/adapters/rabbitmq.py` using `aio-pika`
- Zero new infrastructure for teams already running ODIN (Yggdrasil's backbone is already RabbitMQ)
- JSON serialisation for compatibility with the RabbitMQ management UI

## Topology

| Concept | Value |
|---|---|
| Exchange | `sleipnir.events` (topic, durable) |
| Routing key | `event_type` (e.g. `ravn.tool.complete`) |
| Dead-letter exchange | `sleipnir.dead_letter` (fanout, durable) |
| Queue durability | durable for named services (`service_id`), auto-delete for ephemeral |
| Prefetch | 1 per subscriber (fair dispatch) |

## Durability

- `urgency > 0.4` → `delivery_mode=PERSISTENT`
- `urgency ≤ 0.4` → `delivery_mode=NOT_PERSISTENT`

## Routing key translation (fnmatch → AMQP)

| fnmatch | AMQP |
|---|---|
| `*` | `#` |
| `ravn.*` | `ravn.#` |
| `ravn.tool.*` | `ravn.tool.#` |
| `ravn.tool.complete` | `ravn.tool.complete` |
| Other wildcards (`?`, `[`) | `#` (app-level filtering) |

## Test plan

- [x] 59 unit tests, all mocked — no external RabbitMQ required
- [x] 98% branch coverage on the adapter module
- [x] `ruff check` + `ruff format` clean
- [x] Routing key translation (8 cases)
- [x] Publisher lifecycle, delivery mode, TTL, routing key, batch
- [x] Subscriber lifecycle, durability, prefetch, DLX argument
- [x] AMQP binding deduplication
- [x] Message dispatch: matching, non-matching, malformed JSON, TTL=0
- [x] Ring buffer overflow with warning
- [x] Crashing handler isolation
- [x] Transport delegation (pub+sub combined)

Closes NIU-523

🤖 Generated with [Claude Code](https://claude.com/claude-code)