### PR TITLE
feat(bifrost): NIU-482 provider key vault and agent authentication

### DIFF
--- a/bifrost.yaml.example
+++ b/bifrost.yaml.example
@@ -41,6 +41,7 @@ bifrost:
   providers:
     anthropic:
       api_key_env: ANTHROPIC_API_KEY       # env var holding the API key
+      # api_key_file: /run/secrets/anthropic_key  # alternative: read from file
       models:
         - claude-opus-4-6
         - claude-sonnet-4-6
@@ -95,6 +96,22 @@ bifrost:
 
   # pat_secret: ""   # Required when auth_mode = pat (or set PAT_SECRET env var)
 
+  # ── Key vault ────────────────────────────────────────────────────────────────
+  #
+  # Provider API keys are loaded at startup and cached in memory.
+  # They are never returned in responses or written to logs.
+  #
+  # Rotation without restart: send SIGHUP or POST /admin/reload-keys
+  #
+  # By default keys come from the api_key_env / api_key_file fields of each
+  # provider above.  Optionally, point to a single secrets file instead:
+  #
+  # key_vault:
+  #   secrets_file: /run/secrets/bifrost-keys.yaml
+  #   # Format of the secrets file:
+  #   #   anthropic: sk-ant-...
+  #   #   openai: sk-...
+
   # ── Pricing overrides ────────────────────────────────────────────────────────
   #
   # Override or extend the built-in pricing snapshot (USD per million tokens).
@@ -127,11 +144,21 @@ bifrost:
   #     max_requests_per_hour: 1000
 
   # agent_permissions:               # per-agent model access + optional budget
+  #                                  # keys support glob patterns: volundr-session-*
   #   my-agent-id:
   #     allowed_models:              # empty list = all models allowed
-  #       - claude-sonnet-4-6
+  #       - claude-sonnet-4-6        # exact model or alias name
+  #       # - '*'                    # unrestricted (same as empty list)
   #     quota:
   #       max_cost_per_day: 2.50
+  #
+  #   # Example: wildcard pattern matching agent IDs
+  #   volundr-session-*:
+  #     allowed_models: [balanced, fast, local]
+  #   tyr:
+  #     allowed_models: [best, balanced]
+  #   claude-code:
+  #     allowed_models: ['*']        # unrestricted
 
   # ── Usage storage ─────────────────────────────────────────────────────────────
   #

--- a/src/bifrost/adapters/auth/__init__.py
+++ b/src/bifrost/adapters/auth/__init__.py
@@ -1,0 +1,31 @@
+"""Auth adapter package — factory for the configured authentication mode."""
+
+from __future__ import annotations
+
+from bifrost.auth import AuthMode
+from bifrost.ports.auth import AuthPort
+
+
+def build_auth_adapter(mode: AuthMode, pat_secret: str = "") -> AuthPort:
+    """Instantiate the ``AuthPort`` adapter for *mode*.
+
+    Args:
+        mode:       Authentication mode (open / pat / mesh).
+        pat_secret: HS256 signing secret; required when ``mode`` is ``pat``.
+
+    Returns:
+        A configured ``AuthPort`` implementation.
+    """
+    match mode:
+        case AuthMode.PAT:
+            from bifrost.adapters.auth.pat import PATAuthAdapter
+
+            return PATAuthAdapter(secret=pat_secret)
+        case AuthMode.MESH:
+            from bifrost.adapters.auth.mesh import MeshAuthAdapter
+
+            return MeshAuthAdapter()
+        case _:
+            from bifrost.adapters.auth.open import OpenAuthAdapter
+
+            return OpenAuthAdapter()

--- a/src/bifrost/adapters/auth/mesh.py
+++ b/src/bifrost/adapters/auth/mesh.py
@@ -1,0 +1,69 @@
+"""Service-mesh (Envoy mTLS) authentication adapter.
+
+In service-mesh mode Envoy has already authenticated the caller via mutual
+TLS before the request reaches Bifröst.  The ``X-Forwarded-Client-Cert``
+(XFCC) header carries the peer certificate information, including its
+SPIFFE URI SAN (e.g. ``spiffe://cluster.local/ns/default/sa/volundr``).
+
+Identity extraction strategy:
+
+1. If the XFCC header is present and contains a ``URI=`` field, the last
+   path segment of the SPIFFE URI is used as the ``agent_id`` (e.g.
+   ``volundr`` from ``spiffe://…/sa/volundr``).
+2. If XFCC is absent or unparseable, fall back to the plain
+   ``X-Agent-Id`` header (set by the calling service).
+3. ``X-Tenant-Id`` is always read from the application-level header.
+
+This adapter must only be used when Envoy / the service mesh is trusted
+to inject accurate XFCC headers.  Never use it without a sidecar proxy.
+"""
+
+from __future__ import annotations
+
+import re
+
+from fastapi import Request
+
+from bifrost.auth import AgentIdentity, _read_attribution_headers
+from bifrost.ports.auth import AuthPort
+
+# Matches the URI field in an Envoy XFCC header segment, e.g.:
+#   By=spiffe://…;Hash=…;URI=spiffe://cluster.local/ns/default/sa/volundr;…
+_XFCC_URI_RE = re.compile(r"URI=([^,;]+)", re.IGNORECASE)
+
+
+def _parse_spiffe_workload(xfcc: str) -> str | None:
+    """Extract the workload name from an Envoy XFCC header value.
+
+    Returns the last path segment of the SPIFFE URI (the Kubernetes
+    service-account name) or ``None`` when the header cannot be parsed.
+    """
+    match = _XFCC_URI_RE.search(xfcc)
+    if not match:
+        return None
+    uri = match.group(1).rstrip("/")
+    # Last segment: spiffe://cluster.local/ns/foo/sa/<workload>
+    workload = uri.rsplit("/", 1)[-1]
+    return workload or None
+
+
+class MeshAuthAdapter(AuthPort):
+    """Trust Envoy-injected mTLS / XFCC headers for caller identity.
+
+    Identity is derived from the ``X-Forwarded-Client-Cert`` header set
+    by Envoy after successful mTLS verification.  Application-level
+    ``X-Agent-Id`` / ``X-Tenant-Id`` headers are used as fallbacks when
+    XFCC is absent.
+    """
+
+    def extract(self, request: Request) -> AgentIdentity:
+        session_id, saga_id = _read_attribution_headers(request)
+        xfcc = request.headers.get("x-forwarded-client-cert", "")
+        spiffe_agent = _parse_spiffe_workload(xfcc) if xfcc else None
+
+        return AgentIdentity(
+            agent_id=spiffe_agent or request.headers.get("x-agent-id", "anonymous"),
+            tenant_id=request.headers.get("x-tenant-id", "default"),
+            session_id=session_id,
+            saga_id=saga_id,
+        )

--- a/src/bifrost/adapters/auth/open.py
+++ b/src/bifrost/adapters/auth/open.py
@@ -1,0 +1,31 @@
+"""Open (no-auth) authentication adapter.
+
+All callers are trusted; identity is read verbatim from request headers.
+Suitable for Pi / local-network deployments or services behind a fully
+trusted proxy.
+"""
+
+from __future__ import annotations
+
+from fastapi import Request
+
+from bifrost.auth import AgentIdentity, _read_attribution_headers
+from bifrost.ports.auth import AuthPort
+
+
+class OpenAuthAdapter(AuthPort):
+    """Trust all callers and read identity from plain request headers.
+
+    No token validation is performed.  This mode is appropriate when
+    Bifröst runs in a fully trusted environment (localhost, closed LAN,
+    or behind a network-level access control layer).
+    """
+
+    def extract(self, request: Request) -> AgentIdentity:
+        session_id, saga_id = _read_attribution_headers(request)
+        return AgentIdentity(
+            agent_id=request.headers.get("x-agent-id", "anonymous"),
+            tenant_id=request.headers.get("x-tenant-id", "default"),
+            session_id=session_id,
+            saga_id=saga_id,
+        )

--- a/src/bifrost/adapters/auth/pat.py
+++ b/src/bifrost/adapters/auth/pat.py
@@ -1,0 +1,51 @@
+"""PAT (Personal Access Token) authentication adapter.
+
+Validates a long-lived HS256-signed Bearer JWT — the same token format
+used by Volundr's PAT system (NIU-222+).  The ``sub`` claim becomes the
+agent_id; the ``tenant_id`` claim is used as the tenant identifier.
+
+This adapter is appropriate for deployments where Bifröst is exposed
+beyond a trusted network boundary and callers are individual agents or
+users who have been issued a PAT by the platform.
+"""
+
+from __future__ import annotations
+
+import jwt
+from fastapi import HTTPException, Request
+
+from bifrost.auth import AgentIdentity, _read_attribution_headers
+from bifrost.ports.auth import AuthPort
+
+
+class PATAuthAdapter(AuthPort):
+    """Validate a Bearer JWT signed with a shared HS256 secret.
+
+    Args:
+        secret: The HS256 signing secret used to verify tokens.
+                Must be at least 32 bytes for adequate security.
+    """
+
+    def __init__(self, secret: str) -> None:
+        self._secret = secret
+
+    def extract(self, request: Request) -> AgentIdentity:
+        auth_header = request.headers.get("authorization", "")
+        if not auth_header.lower().startswith("bearer "):
+            raise HTTPException(status_code=401, detail="Missing Bearer token")
+
+        token = auth_header[7:]
+        try:
+            payload = jwt.decode(token, self._secret, algorithms=["HS256"])
+        except jwt.ExpiredSignatureError as exc:
+            raise HTTPException(status_code=401, detail="Token has expired") from exc
+        except jwt.InvalidTokenError as exc:
+            raise HTTPException(status_code=401, detail=f"Invalid token: {exc}") from exc
+
+        session_id, saga_id = _read_attribution_headers(request)
+        return AgentIdentity(
+            agent_id=payload.get("sub", "anonymous"),
+            tenant_id=payload.get("tenant_id", "default"),
+            session_id=session_id,
+            saga_id=saga_id,
+        )

--- a/src/bifrost/adapters/key_vault.py
+++ b/src/bifrost/adapters/key_vault.py
@@ -1,0 +1,143 @@
+"""Key vault adapter implementations for Bifröst.
+
+Two adapters are provided:
+
+- ``EnvKeyVault``         — reads API keys from environment variables.
+- ``SecretsFileKeyVault`` — reads API keys from a YAML secrets file.
+
+Both adapters cache keys in memory and support live rotation via ``reload()``.
+Keys are *never* written to logs or returned in any HTTP response.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+import yaml  # type: ignore[import-untyped]
+
+from bifrost.config import BifrostConfig
+from bifrost.ports.key_vault import KeyVaultPort
+
+logger = logging.getLogger(__name__)
+
+# Sentinel used in log messages in place of actual key values.
+_REDACTED = "***"
+
+
+class EnvKeyVault(KeyVaultPort):
+    """Load provider API keys from environment variables at startup.
+
+    Keys are resolved from the ``api_key_env`` field of each provider's
+    config, then cached in memory.  Call ``reload()`` to pick up rotated
+    values (e.g. after a secret manager rotation + SIGHUP) without
+    restarting the process.
+
+    If a provider also sets ``api_key_file``, the file is tried as a
+    fallback when the env var is absent or empty.
+
+    Keys are never written to logs — only provider names are logged.
+    """
+
+    def __init__(self, config: BifrostConfig) -> None:
+        self._config = config
+        self._keys: dict[str, str] = {}
+        self._load()
+
+    def _load(self) -> None:
+        """Populate the in-memory key cache from env vars and secret files."""
+        loaded: list[str] = []
+        for provider_name, provider_cfg in self._config.providers.items():
+            key = ""
+
+            # Prefer env var.
+            if provider_cfg.api_key_env:
+                key = os.environ.get(provider_cfg.api_key_env, "")
+
+            # Fall back to secrets file entry.
+            if not key and provider_cfg.api_key_file:
+                key = _read_secret_file(provider_cfg.api_key_file)
+
+            if key:
+                self._keys[provider_name] = key
+                loaded.append(provider_name)
+
+        logger.info("KeyVault: loaded keys for providers: %s", loaded)
+
+    def get_key(self, provider: str) -> str | None:
+        """Return the cached API key for *provider*, or ``None`` if absent."""
+        return self._keys.get(provider) or None
+
+    def reload(self) -> None:
+        """Re-read all provider keys from env vars / secret files."""
+        self._keys.clear()
+        self._load()
+        logger.info("KeyVault: keys reloaded")
+
+
+class SecretsFileKeyVault(KeyVaultPort):
+    """Load provider API keys from a YAML secrets file.
+
+    The file must map provider names to their API keys::
+
+        anthropic: sk-ant-...
+        openai: sk-...
+
+    This adapter is suitable for deployments where secrets are injected
+    as mounted files (e.g. Kubernetes ``secretKeyRef`` projected volumes).
+    Call ``reload()`` after the file is updated to pick up new values.
+    """
+
+    def __init__(self, path: str) -> None:
+        self._path = path
+        self._keys: dict[str, str] = {}
+        self._load()
+
+    def _load(self) -> None:
+        """Parse the secrets file and populate the in-memory cache."""
+        loaded: list[str] = []
+        raw = _read_secret_file(self._path)
+        if not raw:
+            logger.warning("KeyVault: secrets file '%s' is empty or missing", self._path)
+            return
+
+        try:
+            data: dict = yaml.safe_load(raw)
+        except yaml.YAMLError as exc:
+            logger.error("KeyVault: failed to parse secrets file '%s': %s", self._path, exc)
+            return
+
+        if not isinstance(data, dict):
+            logger.error("KeyVault: secrets file '%s' must be a YAML mapping", self._path)
+            return
+
+        for provider, key in data.items():
+            if isinstance(key, str) and key:
+                self._keys[provider] = key
+                loaded.append(provider)
+
+        logger.info("KeyVault: loaded keys for providers: %s", loaded)
+
+    def get_key(self, provider: str) -> str | None:
+        """Return the cached API key for *provider*, or ``None`` if absent."""
+        return self._keys.get(provider) or None
+
+    def reload(self) -> None:
+        """Re-parse the secrets file and refresh the in-memory cache."""
+        self._keys.clear()
+        self._load()
+        logger.info("KeyVault: secrets file keys reloaded")
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_secret_file(path: str) -> str:
+    """Read and return the stripped content of *path*, or ``""`` on error."""
+    try:
+        return Path(path).read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""

--- a/src/bifrost/app.py
+++ b/src/bifrost/app.py
@@ -1,8 +1,8 @@
 """Bifröst FastAPI application factory.
 
 Wires the inbound routing layer (route handlers, middleware) to the
-infrastructure adapters (usage store, model router) and returns a configured
-``FastAPI`` instance.
+infrastructure adapters (usage store, model router, key vault) and
+returns a configured ``FastAPI`` instance.
 
 The inbound HTTP layer lives in ``bifrost.inbound``:
   - ``inbound/routes.py``   — route handlers and quota/access enforcement
@@ -12,17 +12,24 @@ The inbound HTTP layer lives in ``bifrost.inbound``:
 
 from __future__ import annotations
 
+import logging
+import signal
 import uuid
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Request, Response
 
+from bifrost.adapters.auth import build_auth_adapter
+from bifrost.adapters.key_vault import EnvKeyVault
 from bifrost.config import BifrostConfig
 from bifrost.inbound.routes import create_router
+from bifrost.ports.key_vault import KeyVaultPort
 from bifrost.ports.rules import RuleEnginePort
 from bifrost.ports.usage_store import UsageStore
 from bifrost.pricing import ModelPricing
 from bifrost.router import ModelRouter
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Rule engine factory
@@ -54,6 +61,24 @@ def _build_usage_store(config: BifrostConfig) -> UsageStore:
             from bifrost.adapters.memory_store import MemoryUsageStore
 
             return MemoryUsageStore()
+
+
+# ---------------------------------------------------------------------------
+# Key vault factory
+# ---------------------------------------------------------------------------
+
+
+def _build_key_vault(config: BifrostConfig) -> KeyVaultPort:
+    """Instantiate the key vault from config.
+
+    Uses ``SecretsFileKeyVault`` when ``key_vault.secrets_file`` is set,
+    otherwise falls back to ``EnvKeyVault`` (reads ``api_key_env`` per provider).
+    """
+    if config.key_vault.secrets_file:
+        from bifrost.adapters.key_vault import SecretsFileKeyVault
+
+        return SecretsFileKeyVault(path=config.key_vault.secrets_file)
+    return EnvKeyVault(config)
 
 
 # ---------------------------------------------------------------------------
@@ -89,11 +114,22 @@ def create_app(config: BifrostConfig) -> FastAPI:
         A configured ``FastAPI`` instance.
     """
     rule_engine = _build_rule_engine(config)
-    router = ModelRouter(config, rule_engine=rule_engine)
+    key_vault = _build_key_vault(config)
+    router = ModelRouter(config, rule_engine=rule_engine, key_vault=key_vault)
     store = _build_usage_store(config)
     pricing_overrides = _pricing_overrides(config)
-    auth_mode = config.auth_mode
-    pat_secret = config.effective_pat_secret()
+    auth_adapter = build_auth_adapter(config.auth_mode, config.effective_pat_secret())
+
+    # ── SIGHUP handler — reload keys without restarting ──────────────────────
+    def _handle_sighup(signum: int, frame: object) -> None:  # noqa: ARG001
+        logger.info("Received SIGHUP — reloading provider keys")
+        router.reload_keys()
+
+    try:
+        signal.signal(signal.SIGHUP, _handle_sighup)
+    except (OSError, ValueError):
+        # SIGHUP is not available on Windows or in some restricted environments.
+        logger.debug("SIGHUP not available on this platform; key rotation via signal disabled")
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
@@ -122,8 +158,7 @@ def create_app(config: BifrostConfig) -> FastAPI:
         router=router,
         store=store,
         pricing_overrides=pricing_overrides,
-        auth_mode=auth_mode,
-        pat_secret=pat_secret,
+        auth_adapter=auth_adapter,
     )
     app.include_router(api_router)
 

--- a/src/bifrost/auth.py
+++ b/src/bifrost/auth.py
@@ -1,17 +1,15 @@
 """Agent authentication for Bifröst.
 
-Supports three modes:
+Defines the core identity types shared across all authentication modes:
 
-- ``open``  — No authentication required. Headers are trusted as-is
-              (suitable for local/Pi mode or behind a trusted proxy).
-- ``pat``   — Bearer token must be a valid Bifröst Personal Access Token
-              (HS256 JWT signed with ``pat_secret``).
-- ``mesh``  — Trust Envoy / service-mesh injected headers
-              (``X-Agent-Id``, ``X-Tenant-Id``, etc.).  Envoy has already
-              verified the caller's identity; no further validation needed.
+- ``AuthMode``         — enum of supported authentication modes.
+- ``AgentIdentity``    — caller identity attached to every tracked request.
+- ``_read_attribution_headers`` — helper used by auth adapters.
 
-In all modes the standard attribution headers (``X-Session-Id``,
-``X-Saga-Id``) are extracted from the request and forwarded to tracking.
+Authentication logic lives in the adapter layer:
+  ``bifrost.adapters.auth.open``  — Open / trust-all mode
+  ``bifrost.adapters.auth.pat``   — PAT Bearer-JWT mode
+  ``bifrost.adapters.auth.mesh``  — Service-mesh / Envoy mTLS mode
 """
 
 from __future__ import annotations
@@ -19,8 +17,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import StrEnum
 
-import jwt
-from fastapi import HTTPException, Request
+from fastapi import Request
 
 
 class AuthMode(StrEnum):
@@ -52,75 +49,3 @@ def _read_attribution_headers(request: Request) -> tuple[str, str]:
         request.headers.get("x-session-id", ""),
         request.headers.get("x-saga-id", ""),
     )
-
-
-def _extract_open(request: Request) -> AgentIdentity:
-    """Open mode: trust any headers the caller provides."""
-    session_id, saga_id = _read_attribution_headers(request)
-    return AgentIdentity(
-        agent_id=request.headers.get("x-agent-id", "anonymous"),
-        tenant_id=request.headers.get("x-tenant-id", "default"),
-        session_id=session_id,
-        saga_id=saga_id,
-    )
-
-
-def _extract_mesh(request: Request) -> AgentIdentity:
-    """Mesh mode: read Envoy-injected identity headers."""
-    session_id, saga_id = _read_attribution_headers(request)
-    return AgentIdentity(
-        agent_id=request.headers.get("x-agent-id", "anonymous"),
-        tenant_id=request.headers.get("x-tenant-id", "default"),
-        session_id=session_id,
-        saga_id=saga_id,
-    )
-
-
-def _extract_pat(request: Request, secret: str) -> AgentIdentity:
-    """PAT mode: validate Bearer JWT and extract claims."""
-    auth_header = request.headers.get("authorization", "")
-    if not auth_header.lower().startswith("bearer "):
-        raise HTTPException(status_code=401, detail="Missing Bearer token")
-
-    token = auth_header[7:]
-    try:
-        payload = jwt.decode(token, secret, algorithms=["HS256"])
-    except jwt.ExpiredSignatureError as exc:
-        raise HTTPException(status_code=401, detail="Token has expired") from exc
-    except jwt.InvalidTokenError as exc:
-        raise HTTPException(status_code=401, detail=f"Invalid token: {exc}") from exc
-
-    session_id, saga_id = _read_attribution_headers(request)
-    return AgentIdentity(
-        agent_id=payload.get("sub", "anonymous"),
-        tenant_id=payload.get("tenant_id", "default"),
-        session_id=session_id,
-        saga_id=saga_id,
-    )
-
-
-def extract_identity(
-    request: Request,
-    mode: AuthMode,
-    secret: str = "",
-) -> AgentIdentity:
-    """Extract caller identity from *request* according to *mode*.
-
-    Args:
-        request: The incoming FastAPI request.
-        mode:    Authentication mode (open / pat / mesh).
-        secret:  HS256 signing secret used in ``pat`` mode.
-
-    Returns:
-        ``AgentIdentity`` populated from request headers / JWT claims.
-
-    Raises:
-        HTTPException(401): In ``pat`` mode when the token is absent or invalid.
-    """
-    match mode:
-        case AuthMode.PAT:
-            return _extract_pat(request, secret)
-        case AuthMode.MESH:
-            return _extract_mesh(request)
-        case _:
-            return _extract_open(request)

--- a/src/bifrost/config.py
+++ b/src/bifrost/config.py
@@ -59,18 +59,9 @@ class ProviderConfig(BaseModel):
 
     @property
     def api_key(self) -> str:
-        if self.api_key_env:
-            value = os.environ.get(self.api_key_env, "")
-            if value:
-                return value
-        if self.api_key_file:
-            try:
-                from pathlib import Path
-
-                return Path(self.api_key_file).read_text(encoding="utf-8").strip()
-            except OSError:
-                pass
-        return ""
+        if not self.api_key_env:
+            return ""
+        return os.environ.get(self.api_key_env, "")
 
 
 class PricingOverride(BaseModel):

--- a/src/bifrost/config.py
+++ b/src/bifrost/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import fnmatch
 import os
 import re
 from enum import StrEnum
@@ -35,6 +36,14 @@ class ProviderConfig(BaseModel):
     """Configuration for a single LLM provider."""
 
     api_key_env: str = Field(default="", description="Environment variable holding the API key.")
+    api_key_file: str = Field(
+        default="",
+        description=(
+            "Path to a file whose contents are the API key. "
+            "Used as a fallback when api_key_env is absent or empty. "
+            "Suitable for Kubernetes secret mounts."
+        ),
+    )
     base_url: str = Field(default="", description="Base URL for the provider's API.")
     models: list[str] = Field(
         default_factory=list, description="Models supported by this provider."
@@ -50,9 +59,18 @@ class ProviderConfig(BaseModel):
 
     @property
     def api_key(self) -> str:
-        if not self.api_key_env:
-            return ""
-        return os.environ.get(self.api_key_env, "")
+        if self.api_key_env:
+            value = os.environ.get(self.api_key_env, "")
+            if value:
+                return value
+        if self.api_key_file:
+            try:
+                from pathlib import Path
+
+                return Path(self.api_key_file).read_text(encoding="utf-8").strip()
+            except OSError:
+                pass
+        return ""
 
 
 class PricingOverride(BaseModel):
@@ -208,6 +226,20 @@ class UsageStoreConfig(BaseModel):
     )
 
 
+class KeyVaultConfig(BaseModel):
+    """Configuration for the provider key vault."""
+
+    secrets_file: str = Field(
+        default="",
+        description=(
+            "Path to a YAML file mapping provider names to API keys. "
+            "When set, keys are loaded from this file instead of (or in "
+            "addition to) environment variables. "
+            "File format: ``provider_name: api_key_value``."
+        ),
+    )
+
+
 # Default base URLs per provider type.
 _DEFAULT_BASE_URLS: dict[str, str] = {
     "anthropic": "https://api.anthropic.com",
@@ -300,6 +332,15 @@ class BifrostConfig(BaseModel):
         description="Configuration for the usage persistence backend.",
     )
 
+    # ── Key vault ────────────────────────────────────────────────────────────
+    key_vault: KeyVaultConfig = Field(
+        default_factory=KeyVaultConfig,
+        description=(
+            "Provider API key vault configuration. "
+            "Keys are loaded at startup and never returned in responses or logs."
+        ),
+    )
+
     # ── Helpers ──────────────────────────────────────────────────────────────
 
     def resolve_alias(self, model: str) -> str:
@@ -333,5 +374,25 @@ class BifrostConfig(BaseModel):
         return self.tenant_quotas.get(tenant_id, self.default_quota)
 
     def permissions_for_agent(self, agent_id: str) -> AgentPermissions:
-        """Return the permissions for *agent_id* (empty = unrestricted)."""
-        return self.agent_permissions.get(agent_id, AgentPermissions())
+        """Return the permissions for *agent_id* (empty = unrestricted).
+
+        Exact matches take priority over glob patterns.  When multiple
+        patterns match, the first matching pattern (in config file order)
+        is used.
+
+        Examples of supported patterns::
+
+            volundr-session-*   # matches volundr-session-abc, volundr-session-xyz
+            tyr                 # exact match
+            claude-code         # exact match
+        """
+        # Exact match takes priority.
+        if agent_id in self.agent_permissions:
+            return self.agent_permissions[agent_id]
+
+        # Glob pattern match (first match wins, preserving config order).
+        for pattern, perms in self.agent_permissions.items():
+            if fnmatch.fnmatch(agent_id, pattern):
+                return perms
+
+        return AgentPermissions()

--- a/src/bifrost/inbound/routes.py
+++ b/src/bifrost/inbound/routes.py
@@ -232,12 +232,16 @@ def create_router(
         return {"status": "ok"}
 
     @api_router.post("/admin/reload-keys")
-    async def admin_reload_keys() -> dict:
+    async def admin_reload_keys(raw_request: Request) -> dict:
         """Reload provider API keys from their source without restarting.
 
         Triggers the same key-rotation logic as a SIGHUP signal.  Useful
         in environments where sending UNIX signals is inconvenient (e.g.
         containers without a shell, or Windows).
+
+        Authentication is enforced according to the configured auth mode —
+        in PAT or mesh mode a valid credential is required to call this
+        endpoint, preventing unauthenticated disruption of the adapter cache.
 
         After this call, all cached provider adapters are discarded and
         will be rebuilt with the freshly loaded keys on the next request.
@@ -245,6 +249,7 @@ def create_router(
         Returns:
             ``{"status": "ok"}``
         """
+        auth_adapter.extract(raw_request)
         router.reload_keys()
         return {"status": "ok"}
 

--- a/src/bifrost/inbound/routes.py
+++ b/src/bifrost/inbound/routes.py
@@ -16,7 +16,7 @@ from datetime import UTC, datetime
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 
-from bifrost.auth import AgentIdentity, extract_identity
+from bifrost.auth import AgentIdentity
 from bifrost.config import AgentPermissions, BifrostConfig
 from bifrost.domain.models import RequestLog, TokenUsage
 from bifrost.domain.routing import RuleRejectError
@@ -43,6 +43,7 @@ from bifrost.inbound.tracking import (
     _log_request,
     _stream_with_tracking,
 )
+from bifrost.ports.auth import AuthPort
 from bifrost.ports.usage_store import UsageRecord, UsageStore
 from bifrost.pricing import ModelPricing, calculate_cost
 from bifrost.router import ModelRouter, RouterError
@@ -141,12 +142,17 @@ def _check_model_access(
 ) -> None:
     """Raise 403 if the agent does not have permission to use *model*.
 
-    An empty ``allowed_models`` list means all models are permitted.
+    Rules:
+    - An empty ``allowed_models`` list means all models are permitted.
+    - ``'*'`` in the list means all models are permitted (unrestricted).
+    - Other entries are matched exactly against *model*.
 
     Args:
         agent_perms: Pre-resolved permissions for the caller.
     """
     if not agent_perms.allowed_models:
+        return
+    if "*" in agent_perms.allowed_models:
         return
     if model not in agent_perms.allowed_models:
         raise HTTPException(
@@ -205,18 +211,16 @@ def create_router(
     router: ModelRouter,
     store: UsageStore,
     pricing_overrides: dict[str, ModelPricing],
-    auth_mode: str,
-    pat_secret: str,
+    auth_adapter: AuthPort,
 ) -> APIRouter:
     """Build and return a configured ``APIRouter`` with all Bifröst routes.
 
     Args:
-        config: Gateway configuration.
-        router: Routing layer that dispatches to LLM providers.
-        store: Usage store for recording and querying usage records.
+        config:           Gateway configuration.
+        router:           Routing layer that dispatches to LLM providers.
+        store:            Usage store for recording and querying usage records.
         pricing_overrides: Per-model pricing overrides from config.
-        auth_mode: Authentication mode (``open``, ``pat``, or ``mesh``).
-        pat_secret: Secret used to validate PAT tokens.
+        auth_adapter:     Authentication adapter (open / pat / mesh).
 
     Returns:
         A ``fastapi.APIRouter`` with all routes registered.
@@ -225,6 +229,23 @@ def create_router(
 
     @api_router.get("/health")
     async def health() -> dict:
+        return {"status": "ok"}
+
+    @api_router.post("/admin/reload-keys")
+    async def admin_reload_keys() -> dict:
+        """Reload provider API keys from their source without restarting.
+
+        Triggers the same key-rotation logic as a SIGHUP signal.  Useful
+        in environments where sending UNIX signals is inconvenient (e.g.
+        containers without a shell, or Windows).
+
+        After this call, all cached provider adapters are discarded and
+        will be rebuilt with the freshly loaded keys on the next request.
+
+        Returns:
+            ``{"status": "ok"}``
+        """
+        router.reload_keys()
         return {"status": "ok"}
 
     @api_router.get("/v1/models")
@@ -256,7 +277,7 @@ def create_router(
         Token usage is tracked per-request and attributed to the caller.
         """
         # --- Authentication ---
-        identity = extract_identity(raw_request, auth_mode, pat_secret)
+        identity = auth_adapter.extract(raw_request)
 
         try:
             body = await raw_request.json()
@@ -441,7 +462,7 @@ def create_router(
         path is supported; token usage is extracted and logged on each request.
         """
         # --- Authentication ---
-        identity = extract_identity(raw_request, auth_mode, pat_secret)
+        identity = auth_adapter.extract(raw_request)
 
         try:
             body = await raw_request.json()
@@ -569,7 +590,7 @@ def create_router(
                 → dict`` — translates a non-streaming Anthropic response to Ollama
                 format.
         """
-        identity = extract_identity(raw_request, auth_mode, pat_secret)
+        identity = auth_adapter.extract(raw_request)
 
         try:
             body = await raw_request.json()

--- a/src/bifrost/ports/auth.py
+++ b/src/bifrost/ports/auth.py
@@ -1,0 +1,21 @@
+"""Authentication port — abstract interface for agent identity extraction."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from fastapi import Request
+
+from bifrost.auth import AgentIdentity
+
+
+class AuthPort(ABC):
+    """Extract a verified ``AgentIdentity`` from an incoming HTTP request."""
+
+    @abstractmethod
+    def extract(self, request: Request) -> AgentIdentity:
+        """Return the caller's verified identity.
+
+        Raises:
+            HTTPException(401): When the request cannot be authenticated.
+        """

--- a/src/bifrost/ports/key_vault.py
+++ b/src/bifrost/ports/key_vault.py
@@ -1,0 +1,30 @@
+"""Key vault port — abstract interface for provider API key management.
+
+Provider API keys must never be stored in agent configs or returned in
+responses.  They are held exclusively by the vault, which is the single
+source of truth for all outbound provider credentials.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class KeyVaultPort(ABC):
+    """Abstract interface for reading and rotating provider API keys."""
+
+    @abstractmethod
+    def get_key(self, provider: str) -> str | None:
+        """Return the API key for *provider*, or ``None`` if not configured.
+
+        Implementors MUST ensure the returned value is never written to
+        logs, response bodies, or any external system.
+        """
+
+    @abstractmethod
+    def reload(self) -> None:
+        """Reload all keys from their source (env vars, secrets file, etc.).
+
+        Safe to call at runtime — e.g. from a SIGHUP handler or an admin
+        endpoint — without restarting the process.
+        """

--- a/src/bifrost/router.py
+++ b/src/bifrost/router.py
@@ -15,6 +15,7 @@ import httpx
 
 from bifrost.config import BifrostConfig, ProviderConfig, RoutingStrategy
 from bifrost.domain.routing import RoutingContext, apply_rules
+from bifrost.ports.key_vault import KeyVaultPort
 from bifrost.ports.provider import ProviderError, ProviderPort
 from bifrost.ports.rules import RuleEnginePort
 from bifrost.translation.models import AnthropicRequest, AnthropicResponse
@@ -32,8 +33,18 @@ _PROVIDER_ADAPTER_MAP: dict[str, str] = {
 }
 
 
-def _load_adapter(provider_name: str, cfg: ProviderConfig, base_url: str) -> ProviderPort:
-    """Instantiate the appropriate adapter for *provider_name*."""
+def _load_adapter(
+    provider_name: str,
+    cfg: ProviderConfig,
+    base_url: str,
+    key_vault: KeyVaultPort | None = None,
+) -> ProviderPort:
+    """Instantiate the appropriate adapter for *provider_name*.
+
+    When a *key_vault* is provided, the provider's API key is read from
+    the vault (which holds the cached, rotatable value).  Otherwise the
+    key is read directly from ``cfg.api_key`` for backwards compatibility.
+    """
     dotted = _PROVIDER_ADAPTER_MAP.get(
         provider_name,
         "bifrost.adapters.openai_compat.OpenAICompatAdapter",
@@ -44,7 +55,7 @@ def _load_adapter(provider_name: str, cfg: ProviderConfig, base_url: str) -> Pro
     kwargs: dict = {}
     if base_url:
         kwargs["base_url"] = base_url
-    api_key = cfg.api_key
+    api_key = key_vault.get_key(provider_name) if key_vault else cfg.api_key
     if api_key:
         kwargs["api_key"] = api_key
     if cfg.timeout != 120.0:
@@ -67,9 +78,11 @@ class ModelRouter:
         self,
         config: BifrostConfig,
         rule_engine: RuleEnginePort | None = None,
+        key_vault: KeyVaultPort | None = None,
     ) -> None:
         self._config = config
         self._rule_engine = rule_engine
+        self._key_vault = key_vault
         self._adapters: dict[str, ProviderPort] = {}
         # Per-model request counter used by the round_robin strategy.
         self._round_robin_counters: dict[str, int] = {}
@@ -80,8 +93,23 @@ class ModelRouter:
         if provider_name not in self._adapters:
             cfg = self._config.providers.get(provider_name, ProviderConfig())
             base_url = self._config.effective_base_url(provider_name)
-            self._adapters[provider_name] = _load_adapter(provider_name, cfg, base_url)
+            self._adapters[provider_name] = _load_adapter(
+                provider_name, cfg, base_url, self._key_vault
+            )
         return self._adapters[provider_name]
+
+    def reload_keys(self) -> None:
+        """Reload provider API keys and discard cached adapters.
+
+        After a call to this method, adapters are re-instantiated on the
+        next request with the freshly loaded keys.  This is the hook
+        called by the SIGHUP handler and the admin reload endpoint.
+        """
+        if self._key_vault is not None:
+            self._key_vault.reload()
+        # Clear cached adapters so they are rebuilt with the new keys.
+        self._adapters.clear()
+        logger.info("ModelRouter: adapters cleared after key reload")
 
     def _record_latency(self, provider: str, elapsed: float) -> None:
         """Update the EWMA latency estimate for *provider*."""

--- a/tests/test_bifrost/test_auth.py
+++ b/tests/test_bifrost/test_auth.py
@@ -1,15 +1,15 @@
-"""Tests for bifrost.auth — agent identity extraction."""
+"""Tests for bifrost.auth — core identity types and integration."""
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from unittest.mock import AsyncMock, patch
 
 import jwt
-import pytest
 from fastapi.testclient import TestClient
 
 from bifrost.app import create_app
-from bifrost.auth import AgentIdentity, AuthMode, extract_identity
+from bifrost.auth import AgentIdentity, AuthMode
 from bifrost.config import BifrostConfig, ProviderConfig
 
 # ---------------------------------------------------------------------------
@@ -23,15 +23,6 @@ def _make_token(payload: dict) -> str:
     return jwt.encode(payload, _SECRET, algorithm="HS256")
 
 
-def _make_request(headers: dict | None = None):
-    """Create a minimal mock Request-like object."""
-    from unittest.mock import MagicMock
-
-    req = MagicMock()
-    req.headers = headers or {}
-    return req
-
-
 def _make_config(auth_mode: AuthMode = AuthMode.OPEN, secret: str = "") -> BifrostConfig:
     return BifrostConfig(
         providers={"anthropic": ProviderConfig(models=["claude-sonnet-4-6"])},
@@ -41,134 +32,27 @@ def _make_config(auth_mode: AuthMode = AuthMode.OPEN, secret: str = "") -> Bifro
 
 
 # ---------------------------------------------------------------------------
-# Open mode
+# AgentIdentity defaults
 # ---------------------------------------------------------------------------
 
 
-class TestOpenMode:
-    def test_anonymous_when_no_headers(self):
-        req = _make_request()
-        identity = extract_identity(req, AuthMode.OPEN)
+class TestAgentIdentity:
+    def test_default_values(self):
+        identity = AgentIdentity()
         assert identity.agent_id == "anonymous"
         assert identity.tenant_id == "default"
+        assert identity.session_id == ""
+        assert identity.saga_id == ""
 
-    def test_reads_agent_and_tenant_headers(self):
-        req = _make_request(
-            {
-                "x-agent-id": "agent-xyz",
-                "x-tenant-id": "tenant-abc",
-                "x-session-id": "sess-1",
-                "x-saga-id": "saga-2",
-            }
+    def test_custom_values(self):
+        identity = AgentIdentity(
+            agent_id="my-agent",
+            tenant_id="my-tenant",
+            session_id="s1",
+            saga_id="sg1",
         )
-        identity = extract_identity(req, AuthMode.OPEN)
-        assert identity.agent_id == "agent-xyz"
-        assert identity.tenant_id == "tenant-abc"
-        assert identity.session_id == "sess-1"
-        assert identity.saga_id == "saga-2"
-
-    def test_returns_agent_identity_type(self):
-        req = _make_request()
-        identity = extract_identity(req, AuthMode.OPEN)
-        assert isinstance(identity, AgentIdentity)
-
-
-# ---------------------------------------------------------------------------
-# Mesh mode
-# ---------------------------------------------------------------------------
-
-
-class TestMeshMode:
-    def test_reads_envoy_injected_headers(self):
-        req = _make_request(
-            {
-                "x-agent-id": "mesh-agent",
-                "x-tenant-id": "mesh-tenant",
-                "x-session-id": "s",
-                "x-saga-id": "sg",
-            }
-        )
-        identity = extract_identity(req, AuthMode.MESH)
-        assert identity.agent_id == "mesh-agent"
-        assert identity.tenant_id == "mesh-tenant"
-        assert identity.session_id == "s"
-        assert identity.saga_id == "sg"
-
-    def test_defaults_when_headers_absent(self):
-        req = _make_request()
-        identity = extract_identity(req, AuthMode.MESH)
-        assert identity.agent_id == "anonymous"
-        assert identity.tenant_id == "default"
-
-
-# ---------------------------------------------------------------------------
-# PAT mode
-# ---------------------------------------------------------------------------
-
-
-class TestPATMode:
-    def test_valid_token_extracts_claims(self):
-        token = _make_token({"sub": "agent-1", "tenant_id": "tenant-1"})
-        req = _make_request({"authorization": f"Bearer {token}"})
-        identity = extract_identity(req, AuthMode.PAT, _SECRET)
-        assert identity.agent_id == "agent-1"
-        assert identity.tenant_id == "tenant-1"
-
-    def test_missing_bearer_raises_401(self):
-        from fastapi import HTTPException
-
-        req = _make_request({})
-        with pytest.raises(HTTPException) as exc_info:
-            extract_identity(req, AuthMode.PAT, _SECRET)
-        assert exc_info.value.status_code == 401
-
-    def test_invalid_token_raises_401(self):
-        from fastapi import HTTPException
-
-        req = _make_request({"authorization": "Bearer not-a-jwt"})
-        with pytest.raises(HTTPException) as exc_info:
-            extract_identity(req, AuthMode.PAT, _SECRET)
-        assert exc_info.value.status_code == 401
-
-    def test_wrong_secret_raises_401(self):
-        from fastapi import HTTPException
-
-        token = _make_token({"sub": "agent-1"})
-        req = _make_request({"authorization": f"Bearer {token}"})
-        with pytest.raises(HTTPException) as exc_info:
-            extract_identity(req, AuthMode.PAT, "wrong-secret-that-is-at-least-32-bytes-long!")
-        assert exc_info.value.status_code == 401
-
-    def test_expired_token_raises_401(self):
-        import time
-
-        from fastapi import HTTPException
-
-        token = _make_token({"sub": "agent-1", "exp": int(time.time()) - 10})
-        req = _make_request({"authorization": f"Bearer {token}"})
-        with pytest.raises(HTTPException) as exc_info:
-            extract_identity(req, AuthMode.PAT, _SECRET)
-        assert exc_info.value.status_code == 401
-
-    def test_defaults_when_claims_absent(self):
-        token = _make_token({})
-        req = _make_request({"authorization": f"Bearer {token}"})
-        identity = extract_identity(req, AuthMode.PAT, _SECRET)
-        assert identity.agent_id == "anonymous"
-        assert identity.tenant_id == "default"
-
-    def test_reads_attribution_headers_alongside_jwt(self):
-        token = _make_token({"sub": "ag"})
-        req = _make_request(
-            {
-                "authorization": f"Bearer {token}",
-                "x-session-id": "sess",
-                "x-saga-id": "saga",
-            }
-        )
-        identity = extract_identity(req, AuthMode.PAT, _SECRET)
-        assert identity.session_id == "sess"
-        assert identity.saga_id == "saga"
+        assert identity.agent_id == "my-agent"
+        assert identity.tenant_id == "my-tenant"
 
 
 # ---------------------------------------------------------------------------
@@ -179,6 +63,7 @@ class TestPATMode:
 class TestAuthIntegration:
     """Verify the FastAPI app enforces the configured auth mode end-to-end."""
 
+    @contextmanager
     def _client_with_pat(self) -> TestClient:
         cfg = _make_config(AuthMode.PAT, _SECRET)
         app = create_app(cfg)
@@ -196,7 +81,7 @@ class TestAuthIntegration:
                 yield c
 
     def test_pat_mode_rejects_missing_token(self):
-        for client in self._client_with_pat():
+        with self._client_with_pat() as client:
             resp = client.post(
                 "/v1/messages",
                 json={
@@ -209,7 +94,7 @@ class TestAuthIntegration:
 
     def test_pat_mode_accepts_valid_token(self):
         token = _make_token({"sub": "agent-test"})
-        for client in self._client_with_pat():
+        with self._client_with_pat() as client:
             resp = client.post(
                 "/v1/messages",
                 headers={"Authorization": f"Bearer {token}"},
@@ -220,3 +105,18 @@ class TestAuthIntegration:
                 },
             )
             assert resp.status_code == 200
+
+    def test_pat_mode_rejects_admin_endpoint_without_token(self):
+        with self._client_with_pat() as client:
+            resp = client.post("/admin/reload-keys")
+            assert resp.status_code == 401
+
+    def test_pat_mode_accepts_admin_endpoint_with_valid_token(self):
+        token = _make_token({"sub": "operator"})
+        with self._client_with_pat() as client:
+            resp = client.post(
+                "/admin/reload-keys",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            assert resp.status_code == 200
+            assert resp.json() == {"status": "ok"}

--- a/tests/test_bifrost/test_auth_adapters.py
+++ b/tests/test_bifrost/test_auth_adapters.py
@@ -1,0 +1,244 @@
+"""Tests for bifrost auth port and adapters (open, pat, mesh)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import jwt
+import pytest
+from fastapi import HTTPException
+
+from bifrost.adapters.auth import build_auth_adapter
+from bifrost.adapters.auth.mesh import MeshAuthAdapter, _parse_spiffe_workload
+from bifrost.adapters.auth.open import OpenAuthAdapter
+from bifrost.adapters.auth.pat import PATAuthAdapter
+from bifrost.auth import AgentIdentity, AuthMode
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SECRET = "test-secret-key-that-is-at-least-32-bytes-long!"
+
+
+def _make_token(payload: dict) -> str:
+    return jwt.encode(payload, _SECRET, algorithm="HS256")
+
+
+def _req(headers: dict | None = None) -> MagicMock:
+    r = MagicMock()
+    r.headers = headers or {}
+    return r
+
+
+# ---------------------------------------------------------------------------
+# OpenAuthAdapter
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAuthAdapter:
+    def test_anonymous_defaults(self):
+        adapter = OpenAuthAdapter()
+        identity = adapter.extract(_req())
+        assert identity.agent_id == "anonymous"
+        assert identity.tenant_id == "default"
+        assert identity.session_id == ""
+        assert identity.saga_id == ""
+
+    def test_reads_all_headers(self):
+        adapter = OpenAuthAdapter()
+        identity = adapter.extract(
+            _req(
+                {
+                    "x-agent-id": "my-agent",
+                    "x-tenant-id": "my-tenant",
+                    "x-session-id": "sess-1",
+                    "x-saga-id": "saga-2",
+                }
+            )
+        )
+        assert identity.agent_id == "my-agent"
+        assert identity.tenant_id == "my-tenant"
+        assert identity.session_id == "sess-1"
+        assert identity.saga_id == "saga-2"
+
+    def test_returns_agent_identity(self):
+        adapter = OpenAuthAdapter()
+        assert isinstance(adapter.extract(_req()), AgentIdentity)
+
+
+# ---------------------------------------------------------------------------
+# PATAuthAdapter
+# ---------------------------------------------------------------------------
+
+
+class TestPATAuthAdapter:
+    def test_valid_token_extracts_claims(self):
+        token = _make_token({"sub": "agent-1", "tenant_id": "tenant-1"})
+        adapter = PATAuthAdapter(_SECRET)
+        identity = adapter.extract(_req({"authorization": f"Bearer {token}"}))
+        assert identity.agent_id == "agent-1"
+        assert identity.tenant_id == "tenant-1"
+
+    def test_missing_bearer_raises_401(self):
+        adapter = PATAuthAdapter(_SECRET)
+        with pytest.raises(HTTPException) as exc:
+            adapter.extract(_req({}))
+        assert exc.value.status_code == 401
+
+    def test_invalid_token_raises_401(self):
+        adapter = PATAuthAdapter(_SECRET)
+        with pytest.raises(HTTPException) as exc:
+            adapter.extract(_req({"authorization": "Bearer not-a-jwt"}))
+        assert exc.value.status_code == 401
+
+    def test_wrong_secret_raises_401(self):
+        token = _make_token({"sub": "agent-1"})
+        adapter = PATAuthAdapter("wrong-secret-that-is-at-least-32-bytes!")
+        with pytest.raises(HTTPException) as exc:
+            adapter.extract(_req({"authorization": f"Bearer {token}"}))
+        assert exc.value.status_code == 401
+
+    def test_expired_token_raises_401(self):
+        import time
+
+        token = _make_token({"sub": "agent-1", "exp": int(time.time()) - 10})
+        adapter = PATAuthAdapter(_SECRET)
+        with pytest.raises(HTTPException) as exc:
+            adapter.extract(_req({"authorization": f"Bearer {token}"}))
+        assert exc.value.status_code == 401
+        assert "expired" in exc.value.detail.lower()
+
+    def test_defaults_when_claims_absent(self):
+        token = _make_token({})
+        adapter = PATAuthAdapter(_SECRET)
+        identity = adapter.extract(_req({"authorization": f"Bearer {token}"}))
+        assert identity.agent_id == "anonymous"
+        assert identity.tenant_id == "default"
+
+    def test_reads_attribution_headers(self):
+        token = _make_token({"sub": "ag"})
+        adapter = PATAuthAdapter(_SECRET)
+        identity = adapter.extract(
+            _req(
+                {
+                    "authorization": f"Bearer {token}",
+                    "x-session-id": "sess",
+                    "x-saga-id": "saga",
+                }
+            )
+        )
+        assert identity.session_id == "sess"
+        assert identity.saga_id == "saga"
+
+    def test_case_insensitive_bearer_prefix(self):
+        token = _make_token({"sub": "agent-x"})
+        adapter = PATAuthAdapter(_SECRET)
+        # uppercase BEARER
+        identity = adapter.extract(_req({"authorization": f"BEARER {token}"}))
+        assert identity.agent_id == "agent-x"
+
+
+# ---------------------------------------------------------------------------
+# MeshAuthAdapter
+# ---------------------------------------------------------------------------
+
+
+class TestMeshAuthAdapter:
+    def test_reads_standard_headers_without_xfcc(self):
+        adapter = MeshAuthAdapter()
+        identity = adapter.extract(_req({"x-agent-id": "mesh-agent", "x-tenant-id": "mesh-tenant"}))
+        assert identity.agent_id == "mesh-agent"
+        assert identity.tenant_id == "mesh-tenant"
+
+    def test_defaults_when_headers_absent(self):
+        adapter = MeshAuthAdapter()
+        identity = adapter.extract(_req())
+        assert identity.agent_id == "anonymous"
+        assert identity.tenant_id == "default"
+
+    def test_extracts_spiffe_workload_from_xfcc(self):
+        xfcc = "By=spiffe://cluster.local/ns/default/sa/bifrost;URI=spiffe://cluster.local/ns/prod/sa/volundr"
+        adapter = MeshAuthAdapter()
+        identity = adapter.extract(
+            _req(
+                {
+                    "x-forwarded-client-cert": xfcc,
+                    "x-tenant-id": "prod",
+                }
+            )
+        )
+        assert identity.agent_id == "volundr"
+        assert identity.tenant_id == "prod"
+
+    def test_xfcc_takes_priority_over_x_agent_id(self):
+        xfcc = "URI=spiffe://cluster.local/ns/default/sa/tyr"
+        adapter = MeshAuthAdapter()
+        identity = adapter.extract(
+            _req({"x-forwarded-client-cert": xfcc, "x-agent-id": "should-be-ignored"})
+        )
+        assert identity.agent_id == "tyr"
+
+    def test_falls_back_to_x_agent_id_when_xfcc_unparseable(self):
+        adapter = MeshAuthAdapter()
+        identity = adapter.extract(
+            _req({"x-forwarded-client-cert": "By=hash;Hash=abc", "x-agent-id": "fallback-agent"})
+        )
+        assert identity.agent_id == "fallback-agent"
+
+    def test_reads_attribution_headers(self):
+        adapter = MeshAuthAdapter()
+        identity = adapter.extract(_req({"x-session-id": "s1", "x-saga-id": "sg1"}))
+        assert identity.session_id == "s1"
+        assert identity.saga_id == "sg1"
+
+
+# ---------------------------------------------------------------------------
+# _parse_spiffe_workload helper
+# ---------------------------------------------------------------------------
+
+
+class TestParseSpiffeWorkload:
+    def test_extracts_last_path_segment(self):
+        xfcc = "URI=spiffe://cluster.local/ns/default/sa/volundr"
+        assert _parse_spiffe_workload(xfcc) == "volundr"
+
+    def test_handles_trailing_slash(self):
+        xfcc = "URI=spiffe://cluster.local/ns/default/sa/tyr/"
+        assert _parse_spiffe_workload(xfcc) == "tyr"
+
+    def test_returns_none_when_no_uri_field(self):
+        assert _parse_spiffe_workload("By=spiffe://…;Hash=abc123") is None
+
+    def test_case_insensitive_match(self):
+        xfcc = "uri=spiffe://cluster.local/ns/default/sa/skuld"
+        assert _parse_spiffe_workload(xfcc) == "skuld"
+
+    def test_multipart_xfcc_header(self):
+        # Multiple cert entries separated by commas
+        xfcc = "By=x;Hash=y,URI=spiffe://cluster.local/ns/default/sa/niuu"
+        assert _parse_spiffe_workload(xfcc) == "niuu"
+
+
+# ---------------------------------------------------------------------------
+# build_auth_adapter factory
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAuthAdapter:
+    def test_open_mode(self):
+        adapter = build_auth_adapter(AuthMode.OPEN)
+        assert isinstance(adapter, OpenAuthAdapter)
+
+    def test_pat_mode(self):
+        adapter = build_auth_adapter(AuthMode.PAT, pat_secret=_SECRET)
+        assert isinstance(adapter, PATAuthAdapter)
+
+    def test_mesh_mode(self):
+        adapter = build_auth_adapter(AuthMode.MESH)
+        assert isinstance(adapter, MeshAuthAdapter)
+
+    def test_default_falls_back_to_open(self):
+        # Any unrecognised mode string should default to open
+        adapter = build_auth_adapter("unknown_mode")  # type: ignore[arg-type]
+        assert isinstance(adapter, OpenAuthAdapter)

--- a/tests/test_bifrost/test_key_vault.py
+++ b/tests/test_bifrost/test_key_vault.py
@@ -1,0 +1,168 @@
+"""Tests for the key vault port and adapters."""
+
+from __future__ import annotations
+
+from bifrost.adapters.key_vault import EnvKeyVault, SecretsFileKeyVault, _read_secret_file
+from bifrost.config import BifrostConfig, ProviderConfig
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(providers: dict | None = None) -> BifrostConfig:
+    return BifrostConfig(providers=providers or {})
+
+
+# ---------------------------------------------------------------------------
+# EnvKeyVault
+# ---------------------------------------------------------------------------
+
+
+class TestEnvKeyVault:
+    def test_loads_key_from_env(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_KEY", "sk-ant-test")
+        cfg = _make_config({"anthropic": ProviderConfig(api_key_env="ANTHROPIC_KEY")})
+        vault = EnvKeyVault(cfg)
+        assert vault.get_key("anthropic") == "sk-ant-test"
+
+    def test_returns_none_when_env_absent(self):
+        cfg = _make_config({"anthropic": ProviderConfig(api_key_env="NONEXISTENT_VAR_99999")})
+        vault = EnvKeyVault(cfg)
+        assert vault.get_key("anthropic") is None
+
+    def test_returns_none_for_unknown_provider(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_KEY", "sk-ant-test")
+        cfg = _make_config({"anthropic": ProviderConfig(api_key_env="ANTHROPIC_KEY")})
+        vault = EnvKeyVault(cfg)
+        assert vault.get_key("openai") is None
+
+    def test_loads_multiple_providers(self, monkeypatch):
+        monkeypatch.setenv("ANT_KEY", "ant-val")
+        monkeypatch.setenv("OAI_KEY", "oai-val")
+        cfg = _make_config(
+            {
+                "anthropic": ProviderConfig(api_key_env="ANT_KEY"),
+                "openai": ProviderConfig(api_key_env="OAI_KEY"),
+            }
+        )
+        vault = EnvKeyVault(cfg)
+        assert vault.get_key("anthropic") == "ant-val"
+        assert vault.get_key("openai") == "oai-val"
+
+    def test_reload_picks_up_new_value(self, monkeypatch):
+        monkeypatch.setenv("ROTATING_KEY", "old-key")
+        cfg = _make_config({"anthropic": ProviderConfig(api_key_env="ROTATING_KEY")})
+        vault = EnvKeyVault(cfg)
+        assert vault.get_key("anthropic") == "old-key"
+
+        monkeypatch.setenv("ROTATING_KEY", "new-key")
+        vault.reload()
+        assert vault.get_key("anthropic") == "new-key"
+
+    def test_reload_clears_removed_key(self, monkeypatch):
+        monkeypatch.setenv("TEMP_KEY", "temp-value")
+        cfg = _make_config({"anthropic": ProviderConfig(api_key_env="TEMP_KEY")})
+        vault = EnvKeyVault(cfg)
+        assert vault.get_key("anthropic") == "temp-value"
+
+        monkeypatch.delenv("TEMP_KEY")
+        vault.reload()
+        assert vault.get_key("anthropic") is None
+
+    def test_falls_back_to_api_key_file(self, tmp_path):
+        secret_file = tmp_path / "api_key"
+        secret_file.write_text("sk-from-file")
+        cfg = _make_config(
+            {"anthropic": ProviderConfig(api_key_env="", api_key_file=str(secret_file))}
+        )
+        vault = EnvKeyVault(cfg)
+        assert vault.get_key("anthropic") == "sk-from-file"
+
+    def test_env_var_takes_priority_over_file(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ANT_KEY", "env-value")
+        secret_file = tmp_path / "api_key"
+        secret_file.write_text("file-value")
+        cfg = _make_config(
+            {"anthropic": ProviderConfig(api_key_env="ANT_KEY", api_key_file=str(secret_file))}
+        )
+        vault = EnvKeyVault(cfg)
+        assert vault.get_key("anthropic") == "env-value"
+
+    def test_provider_without_key_env_skipped(self):
+        cfg = _make_config({"ollama": ProviderConfig(base_url="http://localhost:11434")})
+        vault = EnvKeyVault(cfg)
+        assert vault.get_key("ollama") is None
+
+    def test_key_not_in_logs(self, monkeypatch, caplog):
+        monkeypatch.setenv("SECRET_KEY", "very-secret-value-12345")
+        cfg = _make_config({"anthropic": ProviderConfig(api_key_env="SECRET_KEY")})
+        import logging
+
+        with caplog.at_level(logging.DEBUG, logger="bifrost.adapters.key_vault"):
+            vault = EnvKeyVault(cfg)
+            vault.reload()
+
+        for record in caplog.records:
+            assert "very-secret-value-12345" not in record.message
+
+
+# ---------------------------------------------------------------------------
+# SecretsFileKeyVault
+# ---------------------------------------------------------------------------
+
+
+class TestSecretsFileKeyVault:
+    def test_loads_keys_from_yaml_file(self, tmp_path):
+        secrets = tmp_path / "secrets.yaml"
+        secrets.write_text("anthropic: sk-ant-secret\nopenai: sk-oai-secret\n")
+        vault = SecretsFileKeyVault(str(secrets))
+        assert vault.get_key("anthropic") == "sk-ant-secret"
+        assert vault.get_key("openai") == "sk-oai-secret"
+
+    def test_returns_none_for_unknown_provider(self, tmp_path):
+        secrets = tmp_path / "secrets.yaml"
+        secrets.write_text("anthropic: sk-ant-secret\n")
+        vault = SecretsFileKeyVault(str(secrets))
+        assert vault.get_key("ollama") is None
+
+    def test_missing_file_returns_none(self, tmp_path):
+        vault = SecretsFileKeyVault(str(tmp_path / "nonexistent.yaml"))
+        assert vault.get_key("anthropic") is None
+
+    def test_reload_picks_up_new_keys(self, tmp_path):
+        secrets = tmp_path / "secrets.yaml"
+        secrets.write_text("anthropic: old-key\n")
+        vault = SecretsFileKeyVault(str(secrets))
+        assert vault.get_key("anthropic") == "old-key"
+
+        secrets.write_text("anthropic: new-key\n")
+        vault.reload()
+        assert vault.get_key("anthropic") == "new-key"
+
+    def test_malformed_file_returns_none(self, tmp_path):
+        secrets = tmp_path / "secrets.yaml"
+        secrets.write_text("not: valid: yaml: {[}")
+        vault = SecretsFileKeyVault(str(secrets))
+        assert vault.get_key("anthropic") is None
+
+    def test_non_mapping_file_returns_none(self, tmp_path):
+        secrets = tmp_path / "secrets.yaml"
+        secrets.write_text("- item1\n- item2\n")
+        vault = SecretsFileKeyVault(str(secrets))
+        assert vault.get_key("anthropic") is None
+
+
+# ---------------------------------------------------------------------------
+# _read_secret_file helper
+# ---------------------------------------------------------------------------
+
+
+class TestReadSecretFile:
+    def test_reads_file_content(self, tmp_path):
+        f = tmp_path / "secret"
+        f.write_text("  sk-ant-key  \n")
+        assert _read_secret_file(str(f)) == "sk-ant-key"
+
+    def test_returns_empty_on_missing_file(self, tmp_path):
+        assert _read_secret_file(str(tmp_path / "missing")) == ""

--- a/tests/test_bifrost/test_permissions.py
+++ b/tests/test_bifrost/test_permissions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from unittest.mock import AsyncMock, patch
 
 from fastapi.testclient import TestClient
@@ -71,10 +72,11 @@ class TestPermissionsForAgent:
 # ---------------------------------------------------------------------------
 
 
+@contextmanager
 def _make_app_with_permissions(
     agent_id: str,
     allowed_models: list[str],
-) -> TestClient:
+):
     from bifrost.translation.models import AnthropicResponse, TextBlock, UsageInfo
 
     cfg = BifrostConfig(
@@ -110,22 +112,22 @@ class TestModelAccessWildcard:
         )
 
     def test_star_wildcard_allows_any_model(self):
-        for client in _make_app_with_permissions("my-agent", ["*"]):
+        with _make_app_with_permissions("my-agent", ["*"]) as client:
             resp = self._post(client)
             assert resp.status_code == 200
 
     def test_explicit_model_allowed(self):
-        for client in _make_app_with_permissions("my-agent", ["claude-sonnet-4-6"]):
+        with _make_app_with_permissions("my-agent", ["claude-sonnet-4-6"]) as client:
             resp = self._post(client)
             assert resp.status_code == 200
 
     def test_model_not_in_list_rejected(self):
-        for client in _make_app_with_permissions("my-agent", ["gpt-4o"]):
+        with _make_app_with_permissions("my-agent", ["gpt-4o"]) as client:
             resp = self._post(client, model="claude-sonnet-4-6")
             assert resp.status_code == 403
 
     def test_empty_allowed_models_unrestricted(self):
-        for client in _make_app_with_permissions("my-agent", []):
+        with _make_app_with_permissions("my-agent", []) as client:
             resp = self._post(client)
             assert resp.status_code == 200
 
@@ -136,7 +138,8 @@ class TestModelAccessWildcard:
 
 
 class TestAdminReloadKeys:
-    def _client(self) -> TestClient:
+    @contextmanager
+    def _client(self):
         cfg = BifrostConfig(
             providers={"anthropic": ProviderConfig(models=["claude-sonnet-4-6"])},
         )
@@ -145,12 +148,12 @@ class TestAdminReloadKeys:
             yield client
 
     def test_reload_keys_returns_ok(self):
-        for client in self._client():
+        with self._client() as client:
             resp = client.post("/admin/reload-keys")
             assert resp.status_code == 200
             assert resp.json() == {"status": "ok"}
 
     def test_reload_keys_method_not_allowed_on_get(self):
-        for client in self._client():
+        with self._client() as client:
             resp = client.get("/admin/reload-keys")
             assert resp.status_code == 405

--- a/tests/test_bifrost/test_permissions.py
+++ b/tests/test_bifrost/test_permissions.py
@@ -1,0 +1,156 @@
+"""Tests for per-agent model permissions: wildcard agent IDs and '*' models."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from bifrost.app import create_app
+from bifrost.config import AgentPermissions, BifrostConfig, ProviderConfig
+
+# ---------------------------------------------------------------------------
+# Wildcard agent ID matching in BifrostConfig
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionsForAgent:
+    def _cfg(self, permissions: dict) -> BifrostConfig:
+        return BifrostConfig(
+            providers={"anthropic": ProviderConfig(models=["claude-sonnet-4-6"])},
+            agent_permissions=permissions,
+        )
+
+    def test_exact_match_takes_priority_over_glob(self):
+        cfg = self._cfg(
+            {
+                "tyr": AgentPermissions(allowed_models=["best"]),
+                "tyr-*": AgentPermissions(allowed_models=["fast"]),
+            }
+        )
+        perms = cfg.permissions_for_agent("tyr")
+        assert perms.allowed_models == ["best"]
+
+    def test_glob_pattern_matches_prefix_wildcard(self):
+        cfg = self._cfg(
+            {
+                "volundr-session-*": AgentPermissions(allowed_models=["balanced", "fast"]),
+            }
+        )
+        perms = cfg.permissions_for_agent("volundr-session-abc123")
+        assert perms.allowed_models == ["balanced", "fast"]
+
+    def test_glob_no_match_returns_empty_permissions(self):
+        cfg = self._cfg(
+            {
+                "volundr-session-*": AgentPermissions(allowed_models=["fast"]),
+            }
+        )
+        perms = cfg.permissions_for_agent("unknown-agent")
+        assert perms.allowed_models == []
+
+    def test_empty_agent_permissions_unrestricted(self):
+        cfg = self._cfg({})
+        perms = cfg.permissions_for_agent("any-agent")
+        assert perms.allowed_models == []
+
+    def test_first_glob_match_wins(self):
+        cfg = self._cfg(
+            {
+                "tyr-*": AgentPermissions(allowed_models=["best"]),
+                "tyr-worker-*": AgentPermissions(allowed_models=["fast"]),
+            }
+        )
+        # tyr-* matches first
+        perms = cfg.permissions_for_agent("tyr-worker-1")
+        assert perms.allowed_models == ["best"]
+
+
+# ---------------------------------------------------------------------------
+# Wildcard '*' in allowed_models
+# ---------------------------------------------------------------------------
+
+
+def _make_app_with_permissions(
+    agent_id: str,
+    allowed_models: list[str],
+) -> TestClient:
+    from bifrost.translation.models import AnthropicResponse, TextBlock, UsageInfo
+
+    cfg = BifrostConfig(
+        providers={"anthropic": ProviderConfig(models=["claude-sonnet-4-6"])},
+        agent_permissions={
+            agent_id: AgentPermissions(allowed_models=allowed_models),
+        },
+    )
+    app = create_app(cfg)
+    mock_response = AnthropicResponse(
+        id="msg",
+        content=[TextBlock(text="hi")],
+        model="claude-sonnet-4-6",
+        stop_reason="end_turn",
+        usage=UsageInfo(input_tokens=5, output_tokens=2),
+    )
+    with patch("bifrost.router.ModelRouter.complete", new_callable=AsyncMock) as m:
+        m.return_value = mock_response
+        with TestClient(app, raise_server_exceptions=False) as client:
+            yield client
+
+
+class TestModelAccessWildcard:
+    def _post(self, client, agent_id: str = "my-agent", model: str = "claude-sonnet-4-6"):
+        return client.post(
+            "/v1/messages",
+            headers={"x-agent-id": agent_id},
+            json={
+                "model": model,
+                "max_tokens": 10,
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+
+    def test_star_wildcard_allows_any_model(self):
+        for client in _make_app_with_permissions("my-agent", ["*"]):
+            resp = self._post(client)
+            assert resp.status_code == 200
+
+    def test_explicit_model_allowed(self):
+        for client in _make_app_with_permissions("my-agent", ["claude-sonnet-4-6"]):
+            resp = self._post(client)
+            assert resp.status_code == 200
+
+    def test_model_not_in_list_rejected(self):
+        for client in _make_app_with_permissions("my-agent", ["gpt-4o"]):
+            resp = self._post(client, model="claude-sonnet-4-6")
+            assert resp.status_code == 403
+
+    def test_empty_allowed_models_unrestricted(self):
+        for client in _make_app_with_permissions("my-agent", []):
+            resp = self._post(client)
+            assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Admin reload-keys endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestAdminReloadKeys:
+    def _client(self) -> TestClient:
+        cfg = BifrostConfig(
+            providers={"anthropic": ProviderConfig(models=["claude-sonnet-4-6"])},
+        )
+        app = create_app(cfg)
+        with TestClient(app) as client:
+            yield client
+
+    def test_reload_keys_returns_ok(self):
+        for client in self._client():
+            resp = client.post("/admin/reload-keys")
+            assert resp.status_code == 200
+            assert resp.json() == {"status": "ok"}
+
+    def test_reload_keys_method_not_allowed_on_get(self):
+        for client in self._client():
+            resp = client.get("/admin/reload-keys")
+            assert resp.status_code == 405


### PR DESCRIPTION
## Summary

- **Key vault**: `KeyVaultPort` + `EnvKeyVault` / `SecretsFileKeyVault` adapters — provider API keys are loaded at startup from env vars or a secrets file, cached in memory, and **never returned in responses or written to logs**. Key rotation is supported live via SIGHUP or `POST /admin/reload-keys`.
- **Auth adapters**: Three `AuthPort` implementations — `OpenAuthAdapter` (trust-all / Pi mode), `PATAuthAdapter` (HS256 Bearer JWT, niuu PAT format), `MeshAuthAdapter` (Envoy XFCC / SPIFFE identity).
- **Per-agent model permissions**: Glob wildcard patterns for agent IDs (`volundr-session-*`) and `'*'` wildcard in `allowed_models` for unrestricted access.
- **Admin endpoint**: `POST /admin/reload-keys` triggers the same key-rotation logic as SIGHUP.

## Changes

| File | What changed |
|------|--------------|
| `src/bifrost/ports/key_vault.py` | New `KeyVaultPort` ABC |
| `src/bifrost/ports/auth.py` | New `AuthPort` ABC |
| `src/bifrost/adapters/key_vault.py` | `EnvKeyVault` + `SecretsFileKeyVault` |
| `src/bifrost/adapters/auth/{open,pat,mesh}.py` | Three auth adapters |
| `src/bifrost/adapters/auth/__init__.py` | `build_auth_adapter()` factory |
| `src/bifrost/config.py` | `api_key_file` on `ProviderConfig`; `KeyVaultConfig`; glob `permissions_for_agent` |
| `src/bifrost/router.py` | Accept `KeyVaultPort`; `reload_keys()` |
| `src/bifrost/app.py` | Wire vault + auth adapter; SIGHUP handler |
| `src/bifrost/inbound/routes.py` | `POST /admin/reload-keys`; `*` in allowed_models; use `AuthPort` |
| `bifrost.yaml.example` | Document new config options |
| `tests/test_bifrost/test_key_vault.py` | 18 tests for vault adapters |
| `tests/test_bifrost/test_auth_adapters.py` | 26 tests for auth adapters |
| `tests/test_bifrost/test_permissions.py` | 11 tests for wildcard permissions + admin endpoint |

## Test plan

- [x] `uv run pytest tests/test_bifrost/` — 629 passed, 0 failed
- [x] Bifrost module coverage: **92%** (above 85% threshold)
- [x] `uv run ruff check src/bifrost/ tests/test_bifrost/` — 0 errors
- [x] Key not present in any log record (asserted in `test_key_not_in_logs`)
- [x] SIGHUP handler registered at app startup (POSIX-only; gracefully skipped on Windows)
- [x] Wildcard agent IDs (`volundr-session-*`) and `*` model permissions verified

## Linear

NIU-482 — Linear MCP server was not available in this environment; ticket should be updated to "In Review".

🤖 Generated with [Claude Code](https://claude.com/claude-code)