### PR TITLE
feat(adapters): episodic memory — SQLite backend, FTS5 search, episode extraction (NIU-432)

### DIFF
--- a/src/ravn/adapters/sqlite_memory.py
+++ b/src/ravn/adapters/sqlite_memory.py
@@ -16,6 +16,7 @@ import math
 import random
 import sqlite3
 import time
+from collections import defaultdict
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -76,6 +77,10 @@ END;
 
 # Approximate chars per token for budget estimation.
 _CHARS_PER_TOKEN = 4
+
+# Estimated average character length of a single episode row, used to compute
+# the FTS5 LIMIT when searching for sessions.
+_AVG_EPISODE_CHARS = 200
 
 # Outcome weights for combined scoring.
 _OUTCOME_WEIGHTS: dict[str, float] = {
@@ -394,7 +399,7 @@ class SqliteMemoryAdapter(MemoryPort):
                     ORDER BY bm25(episodes_fts)
                     LIMIT ?
                     """,
-                    (safe_query, self._session_search_truncate_chars // 200),
+                    (safe_query, self._session_search_truncate_chars // _AVG_EPISODE_CHARS),
                 ).fetchall()
             finally:
                 conn.close()
@@ -403,8 +408,6 @@ class SqliteMemoryAdapter(MemoryPort):
                 return []
 
             # Group episodes by session, collect tags and timestamps.
-            from collections import defaultdict
-
             session_episodes: dict[str, list[Episode]] = defaultdict(list)
             for row in rows:
                 ep = _row_to_episode(row)

--- a/src/ravn/adapters/sqlite_memory.py
+++ b/src/ravn/adapters/sqlite_memory.py
@@ -1,0 +1,446 @@
+"""SQLite episodic memory adapter.
+
+Uses WAL mode for concurrent access, FTS5 for full-text search, and BM25
+ranking for relevance.  Designed for low-resource environments (e.g. Pi).
+
+Retry strategy: up to ``max_retries`` attempts on SQLite "database is locked"
+errors with random jitter in [min_jitter_ms, max_jitter_ms] between attempts.
+WAL passive checkpoint fires every ``checkpoint_interval`` writes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import math
+import random
+import sqlite3
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+from ravn.domain.models import (
+    Episode,
+    EpisodeMatch,
+    Outcome,
+    SessionSummary,
+    SharedContext,
+)
+from ravn.ports.memory import MemoryPort
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS episodes (
+    episode_id      TEXT PRIMARY KEY,
+    session_id      TEXT NOT NULL,
+    timestamp       TEXT NOT NULL,
+    summary         TEXT NOT NULL,
+    task_description TEXT NOT NULL,
+    tools_used      TEXT NOT NULL,
+    outcome         TEXT NOT NULL,
+    tags            TEXT NOT NULL,
+    embedding       TEXT
+);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS episodes_fts USING fts5(
+    summary,
+    task_description,
+    tags,
+    content=episodes,
+    content_rowid=rowid
+);
+
+CREATE TRIGGER IF NOT EXISTS episodes_ai
+AFTER INSERT ON episodes BEGIN
+    INSERT INTO episodes_fts(rowid, summary, task_description, tags)
+    VALUES (new.rowid, new.summary, new.task_description, new.tags);
+END;
+
+CREATE TRIGGER IF NOT EXISTS episodes_ad
+AFTER DELETE ON episodes BEGIN
+    INSERT INTO episodes_fts(episodes_fts, rowid, summary, task_description, tags)
+    VALUES ('delete', old.rowid, old.summary, old.task_description, old.tags);
+END;
+
+CREATE TRIGGER IF NOT EXISTS episodes_au
+AFTER UPDATE ON episodes BEGIN
+    INSERT INTO episodes_fts(episodes_fts, rowid, summary, task_description, tags)
+    VALUES ('delete', old.rowid, old.summary, old.task_description, old.tags);
+    INSERT INTO episodes_fts(rowid, summary, task_description, tags)
+    VALUES (new.rowid, new.summary, new.task_description, new.tags);
+END;
+"""
+
+# Approximate chars per token for budget estimation.
+_CHARS_PER_TOKEN = 4
+
+# Outcome weights for combined scoring.
+_OUTCOME_WEIGHTS: dict[str, float] = {
+    Outcome.SUCCESS: 1.0,
+    Outcome.PARTIAL: 0.7,
+    Outcome.FAILURE: 0.3,
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _sanitize_fts_query(query: str) -> str:
+    """Escape FTS5 special characters and return a safe MATCH expression.
+
+    Each whitespace-delimited token is wrapped in double quotes so that
+    operators (AND, OR, NOT, -, *, ^) and hyphenated terms are treated as
+    literals rather than FTS5 syntax.
+    """
+    tokens = query.split()
+    if not tokens:
+        return '""'
+    sanitized = []
+    for token in tokens:
+        escaped = token.replace('"', '""')
+        sanitized.append(f'"{escaped}"')
+    return " ".join(sanitized)
+
+
+def _row_to_episode(row: sqlite3.Row) -> Episode:
+    """Convert a database row to an Episode dataclass."""
+    ts_str: str = row["timestamp"]
+    try:
+        ts = datetime.fromisoformat(ts_str)
+    except ValueError:
+        ts = datetime.now(UTC)
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=UTC)
+
+    tools: list[str] = json.loads(row["tools_used"])
+    tags: list[str] = json.loads(row["tags"])
+    emb_raw = row["embedding"]
+    embedding: list[float] | None = json.loads(emb_raw) if emb_raw else None
+
+    return Episode(
+        episode_id=row["episode_id"],
+        session_id=row["session_id"],
+        timestamp=ts,
+        summary=row["summary"],
+        task_description=row["task_description"],
+        tools_used=tools,
+        outcome=Outcome(row["outcome"]),
+        tags=tags,
+        embedding=embedding,
+    )
+
+
+def _recency_score(timestamp: datetime, half_life_days: float) -> float:
+    """Compute exponential decay recency in [0, 1] given episode age."""
+    now = datetime.now(UTC)
+    ts = timestamp if timestamp.tzinfo is not None else timestamp.replace(tzinfo=UTC)
+    age_days = (now - ts).total_seconds() / 86400.0
+    return math.exp(-age_days * math.log(2) / half_life_days)
+
+
+def _combined_score(
+    bm25: float,
+    max_abs_bm25: float,
+    timestamp: datetime,
+    outcome: Outcome,
+    half_life_days: float,
+) -> float:
+    """Combine BM25 relevance, recency decay, and outcome weight into [0, 1]."""
+    bm25_rel = abs(bm25) / max_abs_bm25 if max_abs_bm25 > 0 else 0.0
+    recency = _recency_score(timestamp, half_life_days)
+    weight = _OUTCOME_WEIGHTS.get(outcome, 0.5)
+    return bm25_rel * recency * weight
+
+
+def _format_episode_block(episode: Episode) -> str:
+    """Format a single episode for injection into the system prompt."""
+    ts = episode.timestamp.strftime("%Y-%m-%d")
+    outcome = episode.outcome.upper()
+    tags_str = ", ".join(episode.tags) if episode.tags else "general"
+    tools_str = ", ".join(episode.tools_used) if episode.tools_used else "none"
+    return (
+        f"[{ts}] [{outcome}] {episode.task_description}\n"
+        f"Tags: {tags_str} | Tools: {tools_str}\n"
+        f"{episode.summary}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Adapter
+# ---------------------------------------------------------------------------
+
+
+class SqliteMemoryAdapter(MemoryPort):
+    """Episodic memory backed by a local SQLite database with FTS5 search."""
+
+    def __init__(
+        self,
+        path: str = "~/.ravn/memory.db",
+        *,
+        max_retries: int = 15,
+        min_jitter_ms: float = 20.0,
+        max_jitter_ms: float = 150.0,
+        checkpoint_interval: int = 50,
+        prefetch_budget: int = 2000,
+        prefetch_limit: int = 5,
+        prefetch_min_relevance: float = 0.3,
+        recency_half_life_days: float = 14.0,
+        session_search_truncate_chars: int = 100_000,
+    ) -> None:
+        self._path = Path(path).expanduser()
+        self._max_retries = max_retries
+        self._min_jitter_ms = min_jitter_ms
+        self._max_jitter_ms = max_jitter_ms
+        self._checkpoint_interval = checkpoint_interval
+        self._prefetch_budget = prefetch_budget
+        self._prefetch_limit = prefetch_limit
+        self._prefetch_min_relevance = prefetch_min_relevance
+        self._recency_half_life_days = recency_half_life_days
+        self._session_search_truncate_chars = session_search_truncate_chars
+        self._write_count = 0
+        self._shared_context: SharedContext | None = None
+
+    # ------------------------------------------------------------------
+    # Public async API
+    # ------------------------------------------------------------------
+
+    async def initialize(self) -> None:
+        """Create the database directory and tables if they do not exist."""
+        await asyncio.to_thread(self._init_db)
+
+    async def record_episode(self, episode: Episode) -> None:
+        await asyncio.to_thread(self._record_episode_sync, episode)
+
+    async def query_episodes(
+        self,
+        query: str,
+        *,
+        limit: int = 5,
+        min_relevance: float = 0.3,
+    ) -> list[EpisodeMatch]:
+        return await asyncio.to_thread(self._query_episodes_sync, query, limit, min_relevance)
+
+    async def prefetch(self, context: str) -> str:
+        matches = await self.query_episodes(
+            context,
+            limit=self._prefetch_limit,
+            min_relevance=self._prefetch_min_relevance,
+        )
+        if not matches:
+            return ""
+
+        budget_chars = self._prefetch_budget * _CHARS_PER_TOKEN
+        blocks: list[str] = []
+        used = 0
+        for match in matches:
+            block = _format_episode_block(match.episode)
+            if used + len(block) > budget_chars:
+                break
+            blocks.append(block)
+            used += len(block) + 1  # +1 for separator
+
+        if not blocks:
+            return ""
+
+        separator = "\n\n---\n\n"
+        body = separator.join(blocks)
+        return f"## Relevant Past Context\n\n{body}"
+
+    async def search_sessions(
+        self,
+        query: str,
+        *,
+        limit: int = 3,
+    ) -> list[SessionSummary]:
+        return await asyncio.to_thread(self._search_sessions_sync, query, limit)
+
+    def inject_shared_context(self, context: SharedContext) -> None:
+        self._shared_context = context
+
+    def get_shared_context(self) -> SharedContext | None:
+        return self._shared_context
+
+    # ------------------------------------------------------------------
+    # Synchronous internals (run via to_thread)
+    # ------------------------------------------------------------------
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self._path), check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA foreign_keys=ON")
+        return conn
+
+    def _init_db(self) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        conn = self._connect()
+        try:
+            conn.executescript(_SCHEMA)
+            conn.commit()
+        finally:
+            conn.close()
+
+    def _with_retry(self, fn, *args):
+        """Execute *fn* with retry on SQLite locked errors."""
+        last_exc: Exception = RuntimeError("no attempts made")
+        for attempt in range(self._max_retries):
+            try:
+                return fn(*args)
+            except sqlite3.OperationalError as exc:
+                if "database is locked" not in str(exc).lower():
+                    raise
+                last_exc = exc
+                if attempt < self._max_retries - 1:
+                    jitter = random.uniform(self._min_jitter_ms, self._max_jitter_ms) / 1000.0
+                    time.sleep(jitter)
+        raise last_exc
+
+    def _record_episode_sync(self, episode: Episode) -> None:
+        def _do_insert() -> None:
+            conn = self._connect()
+            try:
+                conn.execute(
+                    """
+                    INSERT OR REPLACE INTO episodes
+                        (episode_id, session_id, timestamp, summary,
+                         task_description, tools_used, outcome, tags, embedding)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        episode.episode_id,
+                        episode.session_id,
+                        episode.timestamp.isoformat(),
+                        episode.summary,
+                        episode.task_description,
+                        json.dumps(episode.tools_used),
+                        episode.outcome.value,
+                        json.dumps(episode.tags),
+                        json.dumps(episode.embedding) if episode.embedding else None,
+                    ),
+                )
+                conn.commit()
+                self._write_count += 1
+                if self._write_count % self._checkpoint_interval == 0:
+                    conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
+            finally:
+                conn.close()
+
+        self._with_retry(_do_insert)
+
+    def _query_episodes_sync(
+        self, query: str, limit: int, min_relevance: float
+    ) -> list[EpisodeMatch]:
+        safe_query = _sanitize_fts_query(query)
+
+        def _do_query() -> list[EpisodeMatch]:
+            conn = self._connect()
+            try:
+                rows = conn.execute(
+                    """
+                    SELECT e.*, bm25(episodes_fts) AS bm25_score
+                    FROM episodes_fts
+                    JOIN episodes e ON e.rowid = episodes_fts.rowid
+                    WHERE episodes_fts MATCH ?
+                    ORDER BY bm25(episodes_fts)
+                    LIMIT ?
+                    """,
+                    (safe_query, limit * 3),  # fetch extra for post-filter
+                ).fetchall()
+            finally:
+                conn.close()
+
+            if not rows:
+                return []
+
+            # bm25 scores are negative; most negative = best match.
+            bm25_scores = [float(r["bm25_score"]) for r in rows]
+            max_abs = max(abs(s) for s in bm25_scores) if bm25_scores else 1.0
+
+            matches: list[EpisodeMatch] = []
+            for row, bm25 in zip(rows, bm25_scores):
+                episode = _row_to_episode(row)
+                score = _combined_score(
+                    bm25,
+                    max_abs,
+                    episode.timestamp,
+                    episode.outcome,
+                    self._recency_half_life_days,
+                )
+                if score >= min_relevance:
+                    matches.append(EpisodeMatch(episode=episode, relevance=score))
+
+            matches.sort(key=lambda m: m.relevance, reverse=True)
+            return matches[:limit]
+
+        return self._with_retry(_do_query)
+
+    def _search_sessions_sync(self, query: str, limit: int) -> list[SessionSummary]:
+        safe_query = _sanitize_fts_query(query)
+
+        def _do_search() -> list[SessionSummary]:
+            conn = self._connect()
+            try:
+                rows = conn.execute(
+                    """
+                    SELECT e.*
+                    FROM episodes_fts
+                    JOIN episodes e ON e.rowid = episodes_fts.rowid
+                    WHERE episodes_fts MATCH ?
+                    ORDER BY bm25(episodes_fts)
+                    LIMIT ?
+                    """,
+                    (safe_query, self._session_search_truncate_chars // 200),
+                ).fetchall()
+            finally:
+                conn.close()
+
+            if not rows:
+                return []
+
+            # Group episodes by session, collect tags and timestamps.
+            from collections import defaultdict
+
+            session_episodes: dict[str, list[Episode]] = defaultdict(list)
+            for row in rows:
+                ep = _row_to_episode(row)
+                session_episodes[ep.session_id].append(ep)
+
+            summaries: list[SessionSummary] = []
+            for session_id, episodes in session_episodes.items():
+                episodes.sort(key=lambda e: e.timestamp)
+                last_active = max(e.timestamp for e in episodes)
+                all_tags: list[str] = []
+                for ep in episodes:
+                    all_tags.extend(ep.tags)
+                unique_tags = list(dict.fromkeys(all_tags))
+
+                # Build a concise summary of the session's episodes.
+                lines: list[str] = []
+                total_chars = 0
+                for ep in episodes:
+                    line = f"- [{ep.outcome.upper()}] {ep.task_description}: {ep.summary}"
+                    if total_chars + len(line) > self._session_search_truncate_chars:
+                        break
+                    lines.append(line)
+                    total_chars += len(line)
+
+                summary_text = "\n".join(lines)
+                summaries.append(
+                    SessionSummary(
+                        session_id=session_id,
+                        summary=summary_text,
+                        episode_count=len(episodes),
+                        last_active=last_active,
+                        tags=unique_tags[:10],
+                    )
+                )
+
+            summaries.sort(key=lambda s: s.last_active, reverse=True)
+            return summaries[:limit]
+
+        return self._with_retry(_do_search)

--- a/src/ravn/adapters/tools/session_search.py
+++ b/src/ravn/adapters/tools/session_search.py
@@ -1,0 +1,86 @@
+"""session_search tool — lets the LLM search its own episodic memory.
+
+Two-stage search:
+1. FTS5 keyword search across all stored episodes.
+2. Group results by session and format per-session summaries.
+"""
+
+from __future__ import annotations
+
+from ravn.domain.models import ToolResult
+from ravn.ports.memory import MemoryPort
+from ravn.ports.tool import ToolPort
+
+
+class SessionSearchTool(ToolPort):
+    """Search episodic memory for sessions matching a keyword query."""
+
+    def __init__(self, memory: MemoryPort, *, limit: int = 3) -> None:
+        self._memory = memory
+        self._limit = limit
+
+    @property
+    def name(self) -> str:
+        return "session_search"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Search your episodic memory for past sessions and tasks matching a query. "
+            "Returns per-session summaries with outcome, tags, and episode details. "
+            "Use this when you need to recall what you did in a previous session, "
+            "look up how you solved a similar problem, or check past outcomes."
+        )
+
+    @property
+    def input_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Keywords to search for across past session summaries.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of sessions to return (default 3, max 10).",
+                    "minimum": 1,
+                    "maximum": 10,
+                },
+            },
+            "required": ["query"],
+        }
+
+    @property
+    def required_permission(self) -> str:
+        return "memory:read"
+
+    async def execute(self, input: dict) -> ToolResult:
+        query = input.get("query", "").strip()
+        if not query:
+            return ToolResult(
+                tool_call_id="",
+                content="Error: query must not be empty.",
+                is_error=True,
+            )
+
+        limit = min(int(input.get("limit", self._limit)), 10)
+        summaries = await self._memory.search_sessions(query, limit=limit)
+
+        if not summaries:
+            return ToolResult(
+                tool_call_id="",
+                content=f"No sessions found matching: {query!r}",
+            )
+
+        parts: list[str] = [f"Found {len(summaries)} session(s) matching {query!r}:\n"]
+        for i, s in enumerate(summaries, 1):
+            last = s.last_active.strftime("%Y-%m-%d %H:%M UTC")
+            tags_str = ", ".join(s.tags) if s.tags else "none"
+            parts.append(
+                f"### Session {i} (ID: {s.session_id[:8]}…)\n"
+                f"Last active: {last} | Episodes: {s.episode_count} | Tags: {tags_str}\n\n"
+                f"{s.summary}"
+            )
+
+        return ToolResult(tool_call_id="", content="\n\n".join(parts))

--- a/src/ravn/agent.py
+++ b/src/ravn/agent.py
@@ -72,6 +72,8 @@ class RavnAgent:
         post_tool_hooks: list[PostToolHook] | None = None,
         user_input_fn: UserInputFn | None = None,
         memory: MemoryPort | None = None,
+        episode_summary_max_chars: int = 500,
+        episode_task_max_chars: int = 200,
     ) -> None:
         self._llm = llm
         self._tools = {t.name: t for t in tools}
@@ -85,6 +87,8 @@ class RavnAgent:
         self._post_tool_hooks: list[PostToolHook] = post_tool_hooks or []
         self._user_input_fn = user_input_fn
         self._memory = memory
+        self._episode_summary_max_chars = episode_summary_max_chars
+        self._episode_task_max_chars = episode_task_max_chars
         self._session = Session()
 
     @property
@@ -191,6 +195,8 @@ class RavnAgent:
                     session_id=str(self._session.id),
                     user_input=user_input,
                     turn_result=result,
+                    summary_max_chars=self._episode_summary_max_chars,
+                    task_max_chars=self._episode_task_max_chars,
                 )
                 await self._memory.record_episode(episode)
             except Exception:
@@ -372,6 +378,9 @@ def _extract_episode(
     session_id: str,
     user_input: str,
     turn_result: TurnResult,
+    *,
+    summary_max_chars: int = 500,
+    task_max_chars: int = 200,
 ) -> Episode:
     """Derive an Episode from a completed agent turn.
 
@@ -382,16 +391,14 @@ def _extract_episode(
     outcome = _determine_outcome(turn_result.tool_results)
     tags = _infer_tags(tools_used)
 
-    # Summarise: truncate the response to a reasonable length.
-    max_summary = 500
-    summary = turn_result.response[:max_summary]
-    if len(turn_result.response) > max_summary:
+    summary = turn_result.response[:summary_max_chars]
+    if len(turn_result.response) > summary_max_chars:
         summary = summary.rstrip() + "…"
     if not summary:
         summary = f"Completed task with {len(tools_used)} tool(s) used."
 
-    task_description = user_input[:200]
-    if len(user_input) > 200:
+    task_description = user_input[:task_max_chars]
+    if len(user_input) > task_max_chars:
         task_description = task_description.rstrip() + "…"
 
     return Episode(

--- a/src/ravn/agent.py
+++ b/src/ravn/agent.py
@@ -3,14 +3,18 @@
 from __future__ import annotations
 
 import logging
+import uuid
 from collections.abc import Callable, Coroutine
+from datetime import UTC, datetime
 from typing import Any
 
 from ravn.domain.events import RavnEvent, RavnEventType
 from ravn.domain.exceptions import MaxIterationsError, PermissionDeniedError
 from ravn.domain.models import (
+    Episode,
     LLMResponse,
     Message,
+    Outcome,
     Session,
     StopReason,
     StreamEventType,
@@ -21,6 +25,7 @@ from ravn.domain.models import (
 )
 from ravn.ports.channel import ChannelPort
 from ravn.ports.llm import LLMPort
+from ravn.ports.memory import MemoryPort
 from ravn.ports.permission import PermissionPort
 from ravn.ports.tool import ToolPort
 
@@ -66,6 +71,7 @@ class RavnAgent:
         pre_tool_hooks: list[PreToolHook] | None = None,
         post_tool_hooks: list[PostToolHook] | None = None,
         user_input_fn: UserInputFn | None = None,
+        memory: MemoryPort | None = None,
     ) -> None:
         self._llm = llm
         self._tools = {t.name: t for t in tools}
@@ -78,6 +84,7 @@ class RavnAgent:
         self._pre_tool_hooks: list[PreToolHook] = pre_tool_hooks or []
         self._post_tool_hooks: list[PostToolHook] = post_tool_hooks or []
         self._user_input_fn = user_input_fn
+        self._memory = memory
         self._session = Session()
 
     @property
@@ -111,7 +118,21 @@ class RavnAgent:
 
         Runs the full tool-call loop until the LLM produces a final response
         or the maximum number of iterations is reached.
+
+        If a memory adapter is configured:
+        - Relevant past context is prefetched and appended to the system prompt.
+        - A new episode is recorded after the turn completes.
         """
+        # Prefetch memory context before appending the user message.
+        effective_system = self._system_prompt
+        if self._memory is not None:
+            try:
+                memory_ctx = await self._memory.prefetch(user_input)
+                if memory_ctx:
+                    effective_system = f"{self._system_prompt}\n\n{memory_ctx}"
+            except Exception:
+                logger.warning("Memory prefetch failed; continuing without context.")
+
         self._session.add_message(Message(role="user", content=user_input))
 
         turn_tool_calls: list[ToolCall] = []
@@ -120,7 +141,7 @@ class RavnAgent:
         final_response = ""
 
         for iteration in range(self._max_iterations):
-            llm_response = await self._call_llm_streaming()
+            llm_response = await self._call_llm_streaming(system_prompt=effective_system)
             cumulative_usage = cumulative_usage + llm_response.usage
 
             if llm_response.content:
@@ -157,24 +178,38 @@ class RavnAgent:
 
         self._session.record_turn(cumulative_usage)
 
-        return TurnResult(
+        result = TurnResult(
             response=final_response,
             tool_calls=turn_tool_calls,
             tool_results=turn_tool_results,
             usage=cumulative_usage,
         )
 
-    async def _call_llm_streaming(self) -> LLMResponse:
+        if self._memory is not None:
+            try:
+                episode = _extract_episode(
+                    session_id=str(self._session.id),
+                    user_input=user_input,
+                    turn_result=result,
+                )
+                await self._memory.record_episode(episode)
+            except Exception:
+                logger.warning("Memory episode recording failed; continuing.")
+
+        return result
+
+    async def _call_llm_streaming(self, system_prompt: str | None = None) -> LLMResponse:
         """Call the LLM with streaming and accumulate into an LLMResponse."""
         accumulated_text = ""
         tool_calls: list[ToolCall] = []
         final_usage = TokenUsage(input_tokens=0, output_tokens=0)
         stop_reason = StopReason.END_TURN
+        effective = system_prompt if system_prompt is not None else self._system_prompt
 
         async for event in self._llm.stream(
             self._build_api_messages(),
             tools=self._tool_defs(),
-            system=self._system_prompt,
+            system=effective,
             model=self._model,
             max_tokens=self._max_tokens,
         ):
@@ -289,6 +324,87 @@ class RavnAgent:
         result = ToolResult(tool_call_id=tool_call.id, content=answer)
         await self._channel.emit(RavnEvent.tool_result(_ASK_USER_TOOL_NAME, answer))
         return result
+
+
+_TAG_MAP: dict[str, list[str]] = {
+    "file": ["file_operations"],
+    "write_file": ["file_operations"],
+    "edit_file": ["file_operations"],
+    "read_file": ["file_operations"],
+    "search_files": ["file_operations"],
+    "git": ["git"],
+    "bash": ["shell"],
+    "terminal": ["shell"],
+    "web_search": ["web"],
+    "web_fetch": ["web"],
+    "session_search": ["memory"],
+    "todo": ["task_management"],
+}
+
+
+def _infer_tags(tool_names: list[str]) -> list[str]:
+    """Heuristically infer episode tags from the tools that were used."""
+    tags: list[str] = []
+    for name in tool_names:
+        for key, tag_list in _TAG_MAP.items():
+            if key in name.lower():
+                for t in tag_list:
+                    if t not in tags:
+                        tags.append(t)
+    if not tags:
+        tags.append("general")
+    return tags
+
+
+def _determine_outcome(tool_results: list[ToolResult]) -> Outcome:
+    """Determine episode outcome from tool results."""
+    if not tool_results:
+        return Outcome.SUCCESS
+    errors = [r for r in tool_results if r.is_error]
+    if len(errors) == len(tool_results):
+        return Outcome.FAILURE
+    if errors:
+        return Outcome.PARTIAL
+    return Outcome.SUCCESS
+
+
+def _extract_episode(
+    session_id: str,
+    user_input: str,
+    turn_result: TurnResult,
+) -> Episode:
+    """Derive an Episode from a completed agent turn.
+
+    Uses heuristics for tagging and outcome determination.  Embedding
+    generation is deferred to Phase 3.5.
+    """
+    tools_used = list({tc.name for tc in turn_result.tool_calls})
+    outcome = _determine_outcome(turn_result.tool_results)
+    tags = _infer_tags(tools_used)
+
+    # Summarise: truncate the response to a reasonable length.
+    max_summary = 500
+    summary = turn_result.response[:max_summary]
+    if len(turn_result.response) > max_summary:
+        summary = summary.rstrip() + "…"
+    if not summary:
+        summary = f"Completed task with {len(tools_used)} tool(s) used."
+
+    task_description = user_input[:200]
+    if len(user_input) > 200:
+        task_description = task_description.rstrip() + "…"
+
+    return Episode(
+        episode_id=str(uuid.uuid4()),
+        session_id=session_id,
+        timestamp=datetime.now(UTC),
+        summary=summary,
+        task_description=task_description,
+        tools_used=tools_used,
+        outcome=outcome,
+        tags=tags,
+        embedding=None,
+    )
 
 
 def _build_assistant_content(response: LLMResponse) -> list[dict]:

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -299,6 +299,42 @@ class MemoryConfig(BaseModel):
         default="",
         description="Env var name to read the DSN from (takes precedence over dsn).",
     )
+    prefetch_budget: int = Field(
+        default=2000,
+        description="Maximum approximate tokens of past context injected per turn.",
+    )
+    prefetch_limit: int = Field(
+        default=5,
+        description="Maximum number of episodes retrieved during prefetch.",
+    )
+    prefetch_min_relevance: float = Field(
+        default=0.3,
+        description="Minimum relevance score (0–1) for an episode to appear in prefetch.",
+    )
+    recency_half_life_days: float = Field(
+        default=14.0,
+        description="Half-life in days for the exponential recency decay applied to episodes.",
+    )
+    max_retries: int = Field(
+        default=15,
+        description="Maximum retry attempts on SQLite 'database is locked' errors.",
+    )
+    min_retry_jitter_ms: float = Field(
+        default=20.0,
+        description="Minimum random jitter (ms) between SQLite retry attempts.",
+    )
+    max_retry_jitter_ms: float = Field(
+        default=150.0,
+        description="Maximum random jitter (ms) between SQLite retry attempts.",
+    )
+    checkpoint_interval: int = Field(
+        default=50,
+        description="Number of writes between passive WAL checkpoints.",
+    )
+    session_search_truncate_chars: int = Field(
+        default=100_000,
+        description="Maximum characters of episode content returned per session in session_search.",
+    )
 
 
 class PermissionRuleConfig(BaseModel):

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -472,6 +472,14 @@ class AgentConfig(BaseModel):
             "Be concise, accurate, and use tools when they help."
         )
     )
+    episode_summary_max_chars: int = Field(
+        default=500,
+        description="Maximum characters of the agent response stored as an episode summary.",
+    )
+    episode_task_max_chars: int = Field(
+        default=200,
+        description="Maximum characters of the user input stored as the episode task description.",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/ravn/domain/models.py
+++ b/src/ravn/domain/models.py
@@ -19,6 +19,12 @@ class TodoStatus(StrEnum):
     CANCELLED = "cancelled"
 
 
+class Outcome(StrEnum):
+    SUCCESS = "success"
+    FAILURE = "failure"
+    PARTIAL = "partial"
+
+
 class StopReason(StrEnum):
     END_TURN = "end_turn"
     TOOL_USE = "tool_use"
@@ -30,6 +36,52 @@ class StreamEventType(StrEnum):
     TEXT_DELTA = "text_delta"
     TOOL_CALL = "tool_call"
     MESSAGE_DONE = "message_done"
+
+
+# ---------------------------------------------------------------------------
+# Episodic memory models
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Episode:
+    """A single recorded episode — what happened during one agent turn."""
+
+    episode_id: str
+    session_id: str
+    timestamp: datetime
+    summary: str
+    task_description: str
+    tools_used: list[str]
+    outcome: Outcome
+    tags: list[str]
+    embedding: list[float] | None = None
+
+
+@dataclass(frozen=True)
+class EpisodeMatch:
+    """An episode returned by a memory query, annotated with its relevance score."""
+
+    episode: Episode
+    relevance: float
+
+
+@dataclass(frozen=True)
+class SessionSummary:
+    """A summary of all episodes from a single session, returned by session search."""
+
+    session_id: str
+    summary: str
+    episode_count: int
+    last_active: datetime
+    tags: list[str]
+
+
+@dataclass
+class SharedContext:
+    """Shared blackboard context injected into a memory adapter from external regions."""
+
+    data: dict = field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------

--- a/src/ravn/ports/memory.py
+++ b/src/ravn/ports/memory.py
@@ -1,0 +1,70 @@
+"""Memory port — interface for episodic memory backends."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from ravn.domain.models import Episode, EpisodeMatch, SessionSummary, SharedContext
+
+
+class MemoryPort(ABC):
+    """Abstract interface for episodic memory storage and retrieval.
+
+    Implementations provide persistence for agent episodes across sessions,
+    enabling continuity of context and the ability to search past work.
+    """
+
+    @abstractmethod
+    async def record_episode(self, episode: Episode) -> None:
+        """Persist a completed episode to the memory store."""
+        ...
+
+    @abstractmethod
+    async def query_episodes(
+        self,
+        query: str,
+        *,
+        limit: int = 5,
+        min_relevance: float = 0.3,
+    ) -> list[EpisodeMatch]:
+        """Search for episodes relevant to *query*.
+
+        Returns at most *limit* results with relevance >= *min_relevance*,
+        ordered by descending combined score (relevance × recency × outcome).
+        """
+        ...
+
+    @abstractmethod
+    async def prefetch(self, context: str) -> str:
+        """Return a formatted "Relevant Past Context" block for the system prompt.
+
+        Searches memory using *context* (typically the current user input),
+        applies recency and outcome weighting, respects the token budget, and
+        formats the results as a Markdown block ready for injection.
+        Returns an empty string if no relevant episodes are found.
+        """
+        ...
+
+    @abstractmethod
+    async def search_sessions(
+        self,
+        query: str,
+        *,
+        limit: int = 3,
+    ) -> list[SessionSummary]:
+        """Return per-session summaries for sessions matching *query*.
+
+        Two-stage search: FTS5 keyword search across all episodes, then
+        grouping and summarisation per session.
+        """
+        ...
+
+    @abstractmethod
+    def inject_shared_context(self, context: SharedContext) -> None:
+        """Store a shared blackboard context for this adapter instance."""
+        ...
+
+    @abstractmethod
+    def get_shared_context(self) -> SharedContext | None:
+        """Return the most recently injected shared context, or None."""
+        ...

--- a/tests/test_ravn/test_agent_with_memory.py
+++ b/tests/test_ravn/test_agent_with_memory.py
@@ -1,0 +1,306 @@
+"""Tests for RavnAgent memory integration (prefetch + episode recording)."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock
+
+from ravn.adapters.permission_adapter import AllowAllPermission
+from ravn.agent import (
+    RavnAgent,
+    _determine_outcome,
+    _extract_episode,
+    _infer_tags,
+)
+from ravn.domain.models import (
+    Episode,
+    EpisodeMatch,
+    Outcome,
+    SessionSummary,
+    SharedContext,
+    StreamEvent,
+    StreamEventType,
+    TokenUsage,
+    ToolCall,
+    ToolResult,
+    TurnResult,
+)
+from ravn.ports.llm import LLMPort
+from ravn.ports.memory import MemoryPort
+from tests.ravn.fixtures.fakes import InMemoryChannel
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class RecordingMemory(MemoryPort):
+    """Memory stub that records all calls for assertion."""
+
+    def __init__(self, prefetch_result: str = "") -> None:
+        self.recorded_episodes: list[Episode] = []
+        self.prefetch_calls: list[str] = []
+        self._prefetch_result = prefetch_result
+        self._shared: SharedContext | None = None
+
+    async def record_episode(self, episode: Episode) -> None:
+        self.recorded_episodes.append(episode)
+
+    async def query_episodes(
+        self, query: str, *, limit: int = 5, min_relevance: float = 0.3
+    ) -> list[EpisodeMatch]:
+        return []
+
+    async def prefetch(self, context: str) -> str:
+        self.prefetch_calls.append(context)
+        return self._prefetch_result
+
+    async def search_sessions(self, query: str, *, limit: int = 3) -> list[SessionSummary]:
+        return []
+
+    def inject_shared_context(self, context: SharedContext) -> None:
+        self._shared = context
+
+    def get_shared_context(self) -> SharedContext | None:
+        return self._shared
+
+
+def make_simple_llm(response_text: str = "Done!") -> LLMPort:
+    async def _stream(*args, **kwargs) -> AsyncIterator[StreamEvent]:
+        yield StreamEvent(type=StreamEventType.TEXT_DELTA, text=response_text)
+        yield StreamEvent(
+            type=StreamEventType.MESSAGE_DONE,
+            usage=TokenUsage(input_tokens=10, output_tokens=5),
+        )
+
+    llm = AsyncMock(spec=LLMPort)
+    llm.stream = _stream
+    return llm
+
+
+def make_agent(
+    llm: LLMPort,
+    memory: MemoryPort | None = None,
+) -> tuple[RavnAgent, InMemoryChannel]:
+    ch = InMemoryChannel()
+    agent = RavnAgent(
+        llm=llm,
+        tools=[],
+        channel=ch,
+        permission=AllowAllPermission(),
+        system_prompt="You are a test assistant.",
+        model="claude-sonnet-4-6",
+        max_tokens=1024,
+        max_iterations=5,
+        memory=memory,
+    )
+    return agent, ch
+
+
+# ---------------------------------------------------------------------------
+# _infer_tags
+# ---------------------------------------------------------------------------
+
+
+class TestInferTags:
+    def test_file_tool(self) -> None:
+        tags = _infer_tags(["read_file", "write_file"])
+        assert "file_operations" in tags
+
+    def test_git_tool(self) -> None:
+        tags = _infer_tags(["git_commit", "git_push"])
+        assert "git" in tags
+
+    def test_bash_tool(self) -> None:
+        tags = _infer_tags(["bash"])
+        assert "shell" in tags
+
+    def test_web_tools(self) -> None:
+        tags = _infer_tags(["web_search", "web_fetch"])
+        assert "web" in tags
+
+    def test_no_tools_gives_general(self) -> None:
+        tags = _infer_tags([])
+        assert tags == ["general"]
+
+    def test_unknown_tool_gives_general(self) -> None:
+        tags = _infer_tags(["custom_tool_xyz"])
+        assert "general" in tags
+
+    def test_no_duplicate_tags(self) -> None:
+        tags = _infer_tags(["bash", "terminal"])
+        assert tags.count("shell") == 1
+
+    def test_session_search_tag(self) -> None:
+        tags = _infer_tags(["session_search"])
+        assert "memory" in tags
+
+
+# ---------------------------------------------------------------------------
+# _determine_outcome
+# ---------------------------------------------------------------------------
+
+
+class TestDetermineOutcome:
+    def test_no_tools_is_success(self) -> None:
+        assert _determine_outcome([]) == Outcome.SUCCESS
+
+    def test_all_success_is_success(self) -> None:
+        results = [
+            ToolResult(tool_call_id="1", content="ok"),
+            ToolResult(tool_call_id="2", content="ok"),
+        ]
+        assert _determine_outcome(results) == Outcome.SUCCESS
+
+    def test_all_errors_is_failure(self) -> None:
+        results = [
+            ToolResult(tool_call_id="1", content="err", is_error=True),
+            ToolResult(tool_call_id="2", content="err", is_error=True),
+        ]
+        assert _determine_outcome(results) == Outcome.FAILURE
+
+    def test_mixed_is_partial(self) -> None:
+        results = [
+            ToolResult(tool_call_id="1", content="ok"),
+            ToolResult(tool_call_id="2", content="err", is_error=True),
+        ]
+        assert _determine_outcome(results) == Outcome.PARTIAL
+
+
+# ---------------------------------------------------------------------------
+# _extract_episode
+# ---------------------------------------------------------------------------
+
+
+class TestExtractEpisode:
+    def _make_turn_result(
+        self,
+        response: str = "Done!",
+        tool_calls: list[ToolCall] | None = None,
+        tool_results: list[ToolResult] | None = None,
+    ) -> TurnResult:
+        return TurnResult(
+            response=response,
+            tool_calls=tool_calls or [],
+            tool_results=tool_results or [],
+            usage=TokenUsage(input_tokens=10, output_tokens=5),
+        )
+
+    def test_episode_id_is_uuid(self) -> None:
+        import re
+
+        ep = _extract_episode("sess-1", "do something", self._make_turn_result())
+        uuid_re = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+        assert uuid_re.match(ep.episode_id)
+
+    def test_session_id_preserved(self) -> None:
+        ep = _extract_episode("my-session", "task", self._make_turn_result())
+        assert ep.session_id == "my-session"
+
+    def test_task_description_truncated(self) -> None:
+        long_input = "a" * 300
+        ep = _extract_episode("s", long_input, self._make_turn_result())
+        assert len(ep.task_description) <= 203  # 200 chars + ellipsis
+
+    def test_summary_truncated(self) -> None:
+        long_response = "b" * 600
+        ep = _extract_episode("s", "task", self._make_turn_result(response=long_response))
+        assert len(ep.summary) <= 503  # 500 chars + ellipsis
+
+    def test_empty_response_uses_fallback(self) -> None:
+        ep = _extract_episode("s", "task", self._make_turn_result(response=""))
+        assert ep.summary  # not empty
+
+    def test_tools_used_deduplicated(self) -> None:
+        calls = [
+            ToolCall(id="1", name="bash", input={}),
+            ToolCall(id="2", name="bash", input={}),
+            ToolCall(id="3", name="read_file", input={}),
+        ]
+        ep = _extract_episode("s", "task", self._make_turn_result(tool_calls=calls))
+        assert ep.tools_used.count("bash") == 1
+
+    def test_outcome_determined_from_results(self) -> None:
+        results = [ToolResult(tool_call_id="1", content="err", is_error=True)]
+        ep = _extract_episode("s", "task", self._make_turn_result(tool_results=results))
+        assert ep.outcome == Outcome.FAILURE
+
+    def test_embedding_is_none(self) -> None:
+        ep = _extract_episode("s", "task", self._make_turn_result())
+        assert ep.embedding is None
+
+    def test_timestamp_is_utc(self) -> None:
+        ep = _extract_episode("s", "task", self._make_turn_result())
+        assert ep.timestamp.tzinfo is not None
+
+
+# ---------------------------------------------------------------------------
+# Agent integration
+# ---------------------------------------------------------------------------
+
+
+class TestAgentMemoryIntegration:
+    async def test_run_turn_records_episode(self) -> None:
+        mem = RecordingMemory()
+        agent, _ = make_agent(make_simple_llm(), memory=mem)
+        await agent.run_turn("hello world")
+        assert len(mem.recorded_episodes) == 1
+        assert mem.recorded_episodes[0].session_id == str(agent.session.id)
+
+    async def test_run_turn_calls_prefetch(self) -> None:
+        mem = RecordingMemory(prefetch_result="## Relevant Past Context\n\npast stuff")
+        agent, _ = make_agent(make_simple_llm(), memory=mem)
+        await agent.run_turn("do something")
+        assert mem.prefetch_calls == ["do something"]
+
+    async def test_prefetch_context_passed_to_llm(self) -> None:
+        mem = RecordingMemory(prefetch_result="## Relevant Past Context\n\npast data")
+        llm = make_simple_llm()
+        agent, _ = make_agent(llm, memory=mem)
+
+        # Capture the system prompt used in the LLM call.
+        captured_system: list[str] = []
+        original_stream = llm.stream
+
+        async def capturing_stream(*args, **kwargs):
+            captured_system.append(kwargs.get("system", ""))
+            async for event in original_stream(*args, **kwargs):
+                yield event
+
+        llm.stream = capturing_stream
+        await agent.run_turn("help me")
+        assert any("Relevant Past Context" in s for s in captured_system)
+
+    async def test_no_memory_works_normally(self) -> None:
+        agent, _ = make_agent(make_simple_llm(), memory=None)
+        result = await agent.run_turn("hello")
+        assert result.response == "Done!"
+
+    async def test_memory_prefetch_failure_does_not_crash(self) -> None:
+        mem = RecordingMemory()
+        mem.prefetch = AsyncMock(side_effect=RuntimeError("prefetch failed"))
+        agent, _ = make_agent(make_simple_llm(), memory=mem)
+        # Should complete without raising.
+        result = await agent.run_turn("hello")
+        assert result.response == "Done!"
+
+    async def test_memory_record_failure_does_not_crash(self) -> None:
+        mem = RecordingMemory()
+        mem.record_episode = AsyncMock(side_effect=RuntimeError("record failed"))
+        agent, _ = make_agent(make_simple_llm(), memory=mem)
+        result = await agent.run_turn("hello")
+        assert result.response == "Done!"
+
+    async def test_episode_task_description_matches_user_input(self) -> None:
+        mem = RecordingMemory()
+        agent, _ = make_agent(make_simple_llm(), memory=mem)
+        await agent.run_turn("deploy to production server")
+        ep = mem.recorded_episodes[0]
+        assert "deploy to production server" in ep.task_description
+
+    async def test_multiple_turns_record_multiple_episodes(self) -> None:
+        mem = RecordingMemory()
+        agent, _ = make_agent(make_simple_llm(), memory=mem)
+        await agent.run_turn("first task")
+        await agent.run_turn("second task")
+        assert len(mem.recorded_episodes) == 2

--- a/tests/test_ravn/test_memory_models.py
+++ b/tests/test_ravn/test_memory_models.py
@@ -1,0 +1,144 @@
+"""Tests for episodic memory domain models."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from ravn.domain.models import (
+    Episode,
+    EpisodeMatch,
+    Outcome,
+    SessionSummary,
+    SharedContext,
+)
+
+
+class TestOutcome:
+    def test_values(self) -> None:
+        assert Outcome.SUCCESS == "success"
+        assert Outcome.FAILURE == "failure"
+        assert Outcome.PARTIAL == "partial"
+
+    def test_from_string(self) -> None:
+        assert Outcome("success") is Outcome.SUCCESS
+        assert Outcome("failure") is Outcome.FAILURE
+        assert Outcome("partial") is Outcome.PARTIAL
+
+    def test_invalid_raises(self) -> None:
+        with pytest.raises(ValueError):
+            Outcome("unknown")
+
+
+class TestEpisode:
+    def _make(self, **kwargs) -> Episode:
+        defaults = dict(
+            episode_id="ep-1",
+            session_id="sess-1",
+            timestamp=datetime.now(UTC),
+            summary="Did something useful",
+            task_description="Do something useful",
+            tools_used=["file_read"],
+            outcome=Outcome.SUCCESS,
+            tags=["file_operations"],
+            embedding=None,
+        )
+        defaults.update(kwargs)
+        return Episode(**defaults)
+
+    def test_default_no_embedding(self) -> None:
+        ep = self._make()
+        assert ep.embedding is None
+
+    def test_with_embedding(self) -> None:
+        ep = self._make(embedding=[0.1, 0.2, 0.3])
+        assert ep.embedding == [0.1, 0.2, 0.3]
+
+    def test_tools_used_list(self) -> None:
+        ep = self._make(tools_used=["bash", "git_commit"])
+        assert "bash" in ep.tools_used
+        assert "git_commit" in ep.tools_used
+
+    def test_tags_list(self) -> None:
+        ep = self._make(tags=["shell", "git"])
+        assert ep.tags == ["shell", "git"]
+
+    def test_outcome_stored(self) -> None:
+        ep = self._make(outcome=Outcome.FAILURE)
+        assert ep.outcome == Outcome.FAILURE
+
+
+class TestEpisodeMatch:
+    def test_frozen(self) -> None:
+        ep = Episode(
+            episode_id="x",
+            session_id="s",
+            timestamp=datetime.now(UTC),
+            summary="s",
+            task_description="t",
+            tools_used=[],
+            outcome=Outcome.SUCCESS,
+            tags=[],
+        )
+        match = EpisodeMatch(episode=ep, relevance=0.85)
+        assert match.relevance == pytest.approx(0.85)
+        # frozen — can't reassign
+        with pytest.raises(Exception):
+            match.relevance = 0.5  # type: ignore[misc]
+
+    def test_relevance_range(self) -> None:
+        ep = Episode(
+            episode_id="x",
+            session_id="s",
+            timestamp=datetime.now(UTC),
+            summary="s",
+            task_description="t",
+            tools_used=[],
+            outcome=Outcome.SUCCESS,
+            tags=[],
+        )
+        match = EpisodeMatch(episode=ep, relevance=0.0)
+        assert match.relevance == 0.0
+
+
+class TestSessionSummary:
+    def test_frozen(self) -> None:
+        s = SessionSummary(
+            session_id="sess",
+            summary="did stuff",
+            episode_count=3,
+            last_active=datetime.now(UTC),
+            tags=["git"],
+        )
+        with pytest.raises(Exception):
+            s.episode_count = 5  # type: ignore[misc]
+
+    def test_fields(self) -> None:
+        ts = datetime(2024, 1, 1, tzinfo=UTC)
+        s = SessionSummary(
+            session_id="abc",
+            summary="summary text",
+            episode_count=2,
+            last_active=ts,
+            tags=["web"],
+        )
+        assert s.session_id == "abc"
+        assert s.episode_count == 2
+        assert s.last_active == ts
+
+
+class TestSharedContext:
+    def test_default_empty_data(self) -> None:
+        ctx = SharedContext()
+        assert ctx.data == {}
+
+    def test_custom_data(self) -> None:
+        ctx = SharedContext(data={"key": "value", "count": 42})
+        assert ctx.data["key"] == "value"
+        assert ctx.data["count"] == 42
+
+    def test_mutable(self) -> None:
+        ctx = SharedContext()
+        ctx.data["x"] = 1
+        assert ctx.data["x"] == 1

--- a/tests/test_ravn/test_memory_port.py
+++ b/tests/test_ravn/test_memory_port.py
@@ -1,0 +1,167 @@
+"""Tests for the MemoryPort abstract interface and in-memory stub."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from ravn.domain.models import Episode, EpisodeMatch, Outcome, SessionSummary, SharedContext
+from ravn.ports.memory import MemoryPort
+
+
+class InMemoryMemory(MemoryPort):
+    """Minimal in-memory implementation of MemoryPort for interface tests."""
+
+    def __init__(self) -> None:
+        self._episodes: list[Episode] = []
+        self._shared: SharedContext | None = None
+
+    async def record_episode(self, episode: Episode) -> None:
+        self._episodes.append(episode)
+
+    async def query_episodes(
+        self,
+        query: str,
+        *,
+        limit: int = 5,
+        min_relevance: float = 0.3,
+    ) -> list[EpisodeMatch]:
+        # Simple substring match for testing.
+        matches = [
+            EpisodeMatch(episode=ep, relevance=1.0)
+            for ep in self._episodes
+            if query.lower() in ep.summary.lower() or query.lower() in ep.task_description.lower()
+        ]
+        return matches[:limit]
+
+    async def prefetch(self, context: str) -> str:
+        matches = await self.query_episodes(context)
+        if not matches:
+            return ""
+        lines = [f"- {m.episode.summary}" for m in matches]
+        return "## Relevant Past Context\n\n" + "\n".join(lines)
+
+    async def search_sessions(
+        self,
+        query: str,
+        *,
+        limit: int = 3,
+    ) -> list[SessionSummary]:
+        matches = await self.query_episodes(query, limit=50)
+        sessions: dict[str, list[Episode]] = {}
+        for m in matches:
+            sessions.setdefault(m.episode.session_id, []).append(m.episode)
+        result = []
+        for sid, eps in list(sessions.items())[:limit]:
+            result.append(
+                SessionSummary(
+                    session_id=sid,
+                    summary="; ".join(e.summary for e in eps),
+                    episode_count=len(eps),
+                    last_active=max(e.timestamp for e in eps),
+                    tags=[t for e in eps for t in e.tags][:5],
+                )
+            )
+        return result
+
+    def inject_shared_context(self, context: SharedContext) -> None:
+        self._shared = context
+
+    def get_shared_context(self) -> SharedContext | None:
+        return self._shared
+
+
+def _make_episode(
+    episode_id: str = "ep-1",
+    session_id: str = "sess-1",
+    summary: str = "wrote tests",
+    task_description: str = "write tests",
+    tools_used: list[str] | None = None,
+    outcome: Outcome = Outcome.SUCCESS,
+    tags: list[str] | None = None,
+) -> Episode:
+    return Episode(
+        episode_id=episode_id,
+        session_id=session_id,
+        timestamp=datetime.now(UTC),
+        summary=summary,
+        task_description=task_description,
+        tools_used=tools_used or [],
+        outcome=outcome,
+        tags=tags or ["general"],
+    )
+
+
+class TestMemoryPortInterface:
+    """Verify the contract is fulfilled by InMemoryMemory."""
+
+    async def test_record_and_query(self) -> None:
+        mem = InMemoryMemory()
+        ep = _make_episode(summary="fixed the CI pipeline")
+        await mem.record_episode(ep)
+
+        results = await mem.query_episodes("CI pipeline")
+        assert len(results) == 1
+        assert results[0].episode.episode_id == ep.episode_id
+
+    async def test_query_no_match(self) -> None:
+        mem = InMemoryMemory()
+        await mem.record_episode(_make_episode(summary="deployed to prod"))
+        results = await mem.query_episodes("testing framework")
+        assert results == []
+
+    async def test_query_limit(self) -> None:
+        mem = InMemoryMemory()
+        for i in range(5):
+            await mem.record_episode(_make_episode(episode_id=f"ep-{i}", summary="python tests"))
+        results = await mem.query_episodes("python tests", limit=3)
+        assert len(results) <= 3
+
+    async def test_prefetch_returns_empty_when_no_match(self) -> None:
+        mem = InMemoryMemory()
+        result = await mem.prefetch("docker deployment")
+        assert result == ""
+
+    async def test_prefetch_returns_context_block(self) -> None:
+        mem = InMemoryMemory()
+        await mem.record_episode(_make_episode(summary="ran pytest suite"))
+        result = await mem.prefetch("pytest")
+        assert "Relevant Past Context" in result
+        assert "ran pytest suite" in result
+
+    async def test_search_sessions_groups_by_session(self) -> None:
+        mem = InMemoryMemory()
+        await mem.record_episode(
+            _make_episode(episode_id="e1", session_id="s1", summary="git commit message")
+        )
+        await mem.record_episode(
+            _make_episode(episode_id="e2", session_id="s1", summary="git push to remote")
+        )
+        await mem.record_episode(
+            _make_episode(episode_id="e3", session_id="s2", summary="git rebase main")
+        )
+
+        summaries = await mem.search_sessions("git")
+        session_ids = {s.session_id for s in summaries}
+        assert "s1" in session_ids
+        assert "s2" in session_ids
+        # s1 has 2 episodes
+        s1 = next(s for s in summaries if s.session_id == "s1")
+        assert s1.episode_count == 2
+
+    async def test_inject_and_get_shared_context(self) -> None:
+        mem = InMemoryMemory()
+        assert mem.get_shared_context() is None
+        ctx = SharedContext(data={"region": "sköll"})
+        mem.inject_shared_context(ctx)
+        retrieved = mem.get_shared_context()
+        assert retrieved is not None
+        assert retrieved.data["region"] == "sköll"
+
+    async def test_inject_replaces_previous_context(self) -> None:
+        mem = InMemoryMemory()
+        mem.inject_shared_context(SharedContext(data={"a": 1}))
+        mem.inject_shared_context(SharedContext(data={"b": 2}))
+        ctx = mem.get_shared_context()
+        assert ctx is not None
+        assert "b" in ctx.data
+        assert "a" not in ctx.data

--- a/tests/test_ravn/test_session_search_tool.py
+++ b/tests/test_ravn/test_session_search_tool.py
@@ -1,0 +1,146 @@
+"""Tests for the session_search tool."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+from ravn.adapters.tools.session_search import SessionSearchTool
+from ravn.domain.models import Episode, EpisodeMatch, SessionSummary, SharedContext
+from ravn.ports.memory import MemoryPort
+
+
+class StubMemory(MemoryPort):
+    """Configurable stub for MemoryPort."""
+
+    def __init__(self, summaries: list[SessionSummary] | None = None) -> None:
+        self._summaries = summaries or []
+        self._shared: SharedContext | None = None
+
+    async def record_episode(self, episode: Episode) -> None:
+        pass
+
+    async def query_episodes(
+        self, query: str, *, limit: int = 5, min_relevance: float = 0.3
+    ) -> list[EpisodeMatch]:
+        return []
+
+    async def prefetch(self, context: str) -> str:
+        return ""
+
+    async def search_sessions(self, query: str, *, limit: int = 3) -> list[SessionSummary]:
+        return self._summaries[:limit]
+
+    def inject_shared_context(self, context: SharedContext) -> None:
+        self._shared = context
+
+    def get_shared_context(self) -> SharedContext | None:
+        return self._shared
+
+
+def _make_summary(session_id: str = "sess-1", summary: str = "did stuff") -> SessionSummary:
+    return SessionSummary(
+        session_id=session_id,
+        summary=summary,
+        episode_count=2,
+        last_active=datetime(2025, 1, 1, tzinfo=UTC),
+        tags=["git"],
+    )
+
+
+class TestSessionSearchToolMetadata:
+    def test_name(self) -> None:
+        tool = SessionSearchTool(memory=StubMemory())
+        assert tool.name == "session_search"
+
+    def test_description_not_empty(self) -> None:
+        tool = SessionSearchTool(memory=StubMemory())
+        assert len(tool.description) > 20
+
+    def test_required_permission(self) -> None:
+        tool = SessionSearchTool(memory=StubMemory())
+        assert tool.required_permission == "memory:read"
+
+    def test_input_schema_has_query(self) -> None:
+        tool = SessionSearchTool(memory=StubMemory())
+        schema = tool.input_schema
+        assert "query" in schema["properties"]
+        assert "query" in schema["required"]
+
+    def test_input_schema_has_limit(self) -> None:
+        tool = SessionSearchTool(memory=StubMemory())
+        schema = tool.input_schema
+        assert "limit" in schema["properties"]
+
+
+class TestSessionSearchToolExecute:
+    async def test_empty_query_returns_error(self) -> None:
+        tool = SessionSearchTool(memory=StubMemory())
+        result = await tool.execute({"query": ""})
+        assert result.is_error
+
+    async def test_no_results_returns_not_found_message(self) -> None:
+        tool = SessionSearchTool(memory=StubMemory(summaries=[]))
+        result = await tool.execute({"query": "kubernetes deployment"})
+        assert not result.is_error
+        assert "No sessions found" in result.content
+
+    async def test_returns_session_content(self) -> None:
+        summaries = [_make_summary(session_id="abc123", summary="configured nginx proxy")]
+        tool = SessionSearchTool(memory=StubMemory(summaries=summaries))
+        result = await tool.execute({"query": "nginx"})
+        assert not result.is_error
+        assert "configured nginx proxy" in result.content
+
+    async def test_includes_session_id_prefix(self) -> None:
+        summaries = [_make_summary(session_id="deadbeef-1234")]
+        tool = SessionSearchTool(memory=StubMemory(summaries=summaries))
+        result = await tool.execute({"query": "test"})
+        assert "deadbeef" in result.content
+
+    async def test_default_limit_used(self) -> None:
+        memory_mock = AsyncMock(spec=MemoryPort)
+        memory_mock.search_sessions = AsyncMock(return_value=[])
+        tool = SessionSearchTool(memory=memory_mock, limit=3)
+        await tool.execute({"query": "test"})
+        memory_mock.search_sessions.assert_called_once()
+        _, kwargs = memory_mock.search_sessions.call_args
+        assert kwargs.get("limit") == 3
+
+    async def test_custom_limit_in_input(self) -> None:
+        memory_mock = AsyncMock(spec=MemoryPort)
+        memory_mock.search_sessions = AsyncMock(return_value=[])
+        tool = SessionSearchTool(memory=memory_mock)
+        await tool.execute({"query": "test", "limit": 7})
+        _, kwargs = memory_mock.search_sessions.call_args
+        assert kwargs.get("limit") == 7
+
+    async def test_limit_capped_at_10(self) -> None:
+        memory_mock = AsyncMock(spec=MemoryPort)
+        memory_mock.search_sessions = AsyncMock(return_value=[])
+        tool = SessionSearchTool(memory=memory_mock)
+        await tool.execute({"query": "test", "limit": 99})
+        _, kwargs = memory_mock.search_sessions.call_args
+        assert kwargs.get("limit") <= 10
+
+    async def test_multiple_sessions_formatted(self) -> None:
+        summaries = [
+            _make_summary(session_id="s1", summary="deployed to prod"),
+            _make_summary(session_id="s2", summary="ran migrations"),
+        ]
+        tool = SessionSearchTool(memory=StubMemory(summaries=summaries))
+        result = await tool.execute({"query": "deploy"})
+        assert "deployed to prod" in result.content
+        assert "ran migrations" in result.content
+
+    async def test_whitespace_only_query_treated_as_empty(self) -> None:
+        tool = SessionSearchTool(memory=StubMemory())
+        result = await tool.execute({"query": "   "})
+        assert result.is_error
+
+    async def test_to_api_dict_structure(self) -> None:
+        tool = SessionSearchTool(memory=StubMemory())
+        d = tool.to_api_dict()
+        assert d["name"] == "session_search"
+        assert "description" in d
+        assert "input_schema" in d

--- a/tests/test_ravn/test_sqlite_memory.py
+++ b/tests/test_ravn/test_sqlite_memory.py
@@ -1,0 +1,475 @@
+"""Tests for the SQLite episodic memory adapter."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from ravn.adapters.sqlite_memory import (
+    SqliteMemoryAdapter,
+    _combined_score,
+    _format_episode_block,
+    _recency_score,
+    _sanitize_fts_query,
+)
+from ravn.domain.models import Episode, Outcome, SharedContext
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ep(
+    episode_id: str = "ep-1",
+    session_id: str = "sess-1",
+    summary: str = "ran the test suite",
+    task_description: str = "run tests",
+    tools_used: list[str] | None = None,
+    outcome: Outcome = Outcome.SUCCESS,
+    tags: list[str] | None = None,
+    timestamp: datetime | None = None,
+) -> Episode:
+    return Episode(
+        episode_id=episode_id,
+        session_id=session_id,
+        timestamp=timestamp or datetime.now(UTC),
+        summary=summary,
+        task_description=task_description,
+        tools_used=tools_used or ["bash"],
+        outcome=outcome,
+        tags=tags or ["shell"],
+    )
+
+
+@pytest.fixture
+async def mem(tmp_path: Path) -> SqliteMemoryAdapter:
+    adapter = SqliteMemoryAdapter(
+        path=str(tmp_path / "memory.db"),
+        max_retries=3,
+        min_jitter_ms=1.0,
+        max_jitter_ms=5.0,
+        checkpoint_interval=5,
+        prefetch_budget=500,
+        prefetch_limit=5,
+        prefetch_min_relevance=0.0,  # no cutoff so tests pass regardless of score
+        recency_half_life_days=14.0,
+    )
+    await adapter.initialize()
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# Unit helpers
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeFtsQuery:
+    def test_basic_token(self) -> None:
+        result = _sanitize_fts_query("python")
+        assert result == '"python"'
+
+    def test_multiple_tokens(self) -> None:
+        result = _sanitize_fts_query("run tests")
+        assert result == '"run" "tests"'
+
+    def test_empty_query(self) -> None:
+        result = _sanitize_fts_query("")
+        assert result == '""'
+
+    def test_hyphenated_term(self) -> None:
+        # Hyphen should be treated literally, not as FTS5 NOT operator.
+        result = _sanitize_fts_query("pytest-asyncio")
+        assert result == '"pytest-asyncio"'
+
+    def test_fts5_special_chars_escaped(self) -> None:
+        result = _sanitize_fts_query('AND OR "test"')
+        # Each token wrapped in double quotes; internal quotes escaped.
+        assert '"AND"' in result
+        assert '"OR"' in result
+        assert '"""test"""' in result
+
+    def test_whitespace_only(self) -> None:
+        result = _sanitize_fts_query("   ")
+        assert result == '""'
+
+
+class TestRecencyScore:
+    def test_fresh_episode_high_score(self) -> None:
+        ts = datetime.now(UTC)
+        score = _recency_score(ts, half_life_days=14.0)
+        assert score > 0.99
+
+    def test_old_episode_low_score(self) -> None:
+        ts = datetime.now(UTC) - timedelta(days=100)
+        score = _recency_score(ts, half_life_days=14.0)
+        assert score < 0.01
+
+    def test_half_life(self) -> None:
+        ts = datetime.now(UTC) - timedelta(days=14)
+        score = _recency_score(ts, half_life_days=14.0)
+        assert abs(score - 0.5) < 0.01
+
+    def test_naive_datetime_treated_as_utc(self) -> None:
+        # Simulate a naive datetime (no tzinfo) as might come from an old DB row.
+        ts = datetime(2025, 1, 1, 12, 0, 0)  # naive, no tzinfo
+        score = _recency_score(ts, half_life_days=14.0)
+        assert 0.0 < score <= 1.0
+
+
+class TestCombinedScore:
+    def test_perfect_recent_success(self) -> None:
+        ts = datetime.now(UTC)
+        score = _combined_score(-5.0, 5.0, ts, Outcome.SUCCESS, half_life_days=14.0)
+        assert score > 0.9
+
+    def test_failure_lower_than_success(self) -> None:
+        ts = datetime.now(UTC)
+        success = _combined_score(-5.0, 5.0, ts, Outcome.SUCCESS, half_life_days=14.0)
+        failure = _combined_score(-5.0, 5.0, ts, Outcome.FAILURE, half_life_days=14.0)
+        assert success > failure
+
+    def test_zero_bm25_gives_zero(self) -> None:
+        ts = datetime.now(UTC)
+        score = _combined_score(0.0, 5.0, ts, Outcome.SUCCESS, half_life_days=14.0)
+        assert score == pytest.approx(0.0)
+
+    def test_zero_max_abs_bm25_safe(self) -> None:
+        ts = datetime.now(UTC)
+        score = _combined_score(0.0, 0.0, ts, Outcome.SUCCESS, half_life_days=14.0)
+        assert score == pytest.approx(0.0)
+
+
+class TestFormatEpisodeBlock:
+    def test_contains_outcome(self) -> None:
+        ep = _ep(outcome=Outcome.SUCCESS)
+        block = _format_episode_block(ep)
+        assert "SUCCESS" in block
+
+    def test_contains_task_description(self) -> None:
+        ep = _ep(task_description="deploy to production")
+        block = _format_episode_block(ep)
+        assert "deploy to production" in block
+
+    def test_contains_summary(self) -> None:
+        ep = _ep(summary="deployed without errors")
+        block = _format_episode_block(ep)
+        assert "deployed without errors" in block
+
+    def test_contains_date(self) -> None:
+        ts = datetime(2024, 3, 15, tzinfo=UTC)
+        ep = _ep(timestamp=ts)
+        block = _format_episode_block(ep)
+        assert "2024-03-15" in block
+
+
+# ---------------------------------------------------------------------------
+# Integration: SqliteMemoryAdapter
+# ---------------------------------------------------------------------------
+
+
+class TestSqliteInit:
+    async def test_creates_db_file(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "subdir" / "memory.db"
+        adapter = SqliteMemoryAdapter(path=str(db_path))
+        await adapter.initialize()
+        assert db_path.exists()
+
+    async def test_wal_mode(self, tmp_path: Path) -> None:
+        adapter = SqliteMemoryAdapter(path=str(tmp_path / "memory.db"))
+        await adapter.initialize()
+        conn = sqlite3.connect(str(tmp_path / "memory.db"))
+        row = conn.execute("PRAGMA journal_mode").fetchone()
+        conn.close()
+        assert row[0] == "wal"
+
+    async def test_fts5_table_exists(self, tmp_path: Path) -> None:
+        adapter = SqliteMemoryAdapter(path=str(tmp_path / "memory.db"))
+        await adapter.initialize()
+        conn = sqlite3.connect(str(tmp_path / "memory.db"))
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='episodes_fts'"
+        ).fetchall()
+        conn.close()
+        assert len(rows) == 1
+
+    async def test_idempotent_initialize(self, mem: SqliteMemoryAdapter) -> None:
+        # Second init should not raise.
+        await mem.initialize()
+
+
+class TestRecordEpisode:
+    async def test_record_stores_episode(self, mem: SqliteMemoryAdapter) -> None:
+        ep = _ep(episode_id="ep-store")
+        await mem.record_episode(ep)
+        matches = await mem.query_episodes("test suite", min_relevance=0.0)
+        ids = [m.episode.episode_id for m in matches]
+        assert "ep-store" in ids
+
+    async def test_record_multiple_episodes(self, mem: SqliteMemoryAdapter) -> None:
+        await mem.record_episode(_ep(episode_id="ep-a", summary="deployed to staging"))
+        await mem.record_episode(_ep(episode_id="ep-b", summary="deployed to production"))
+        matches = await mem.query_episodes("deployed", min_relevance=0.0)
+        ids = {m.episode.episode_id for m in matches}
+        assert ids == {"ep-a", "ep-b"}
+
+    async def test_record_upserts_by_id(self, mem: SqliteMemoryAdapter) -> None:
+        ep = _ep(episode_id="ep-upsert", summary="original summary")
+        await mem.record_episode(ep)
+        ep2 = _ep(episode_id="ep-upsert", summary="updated summary")
+        await mem.record_episode(ep2)
+        matches = await mem.query_episodes("updated summary", min_relevance=0.0)
+        assert len(matches) == 1
+        assert matches[0].episode.summary == "updated summary"
+
+    async def test_record_with_embedding(self, mem: SqliteMemoryAdapter) -> None:
+        ep = _ep(episode_id="ep-emb")
+        ep.embedding = [0.1, 0.2, 0.3]
+        await mem.record_episode(ep)
+        matches = await mem.query_episodes("test suite", min_relevance=0.0)
+        matched = next(m for m in matches if m.episode.episode_id == "ep-emb")
+        assert matched.episode.embedding == pytest.approx([0.1, 0.2, 0.3])
+
+    async def test_record_preserves_outcome(self, mem: SqliteMemoryAdapter) -> None:
+        ep = _ep(episode_id="ep-fail", outcome=Outcome.FAILURE, summary="failed deployment")
+        await mem.record_episode(ep)
+        matches = await mem.query_episodes("failed deployment", min_relevance=0.0)
+        assert matches[0].episode.outcome == Outcome.FAILURE
+
+    async def test_record_checkpoint_fires(self, tmp_path: Path) -> None:
+        adapter = SqliteMemoryAdapter(
+            path=str(tmp_path / "memory.db"),
+            checkpoint_interval=2,
+        )
+        await adapter.initialize()
+        for i in range(3):
+            await adapter.record_episode(_ep(episode_id=f"ep-{i}", summary=f"task {i}"))
+        # No exception means checkpoint was handled correctly.
+
+
+class TestQueryEpisodes:
+    async def test_returns_relevant_episodes(self, mem: SqliteMemoryAdapter) -> None:
+        await mem.record_episode(_ep(episode_id="e1", summary="wrote unit tests"))
+        await mem.record_episode(_ep(episode_id="e2", summary="deployed docker image"))
+        matches = await mem.query_episodes("unit tests", min_relevance=0.0)
+        ids = {m.episode.episode_id for m in matches}
+        assert "e1" in ids
+
+    async def test_returns_empty_for_no_match(self, mem: SqliteMemoryAdapter) -> None:
+        await mem.record_episode(_ep(summary="configured CI pipeline"))
+        matches = await mem.query_episodes("machine learning model", min_relevance=0.0)
+        assert matches == []
+
+    async def test_respects_limit(self, mem: SqliteMemoryAdapter) -> None:
+        for i in range(6):
+            await mem.record_episode(_ep(episode_id=f"e{i}", summary="python debugging"))
+        matches = await mem.query_episodes("python debugging", limit=3, min_relevance=0.0)
+        assert len(matches) <= 3
+
+    async def test_min_relevance_filters(self, mem: SqliteMemoryAdapter) -> None:
+        await mem.record_episode(_ep(summary="rare unique term xyzzy12345"))
+        # Fresh success episode should score well; min_relevance=0.99 might filter it
+        # but with combined score it depends on BM25. Just check the filter applies.
+        matches_low = await mem.query_episodes("xyzzy12345", min_relevance=0.0)
+        matches_high = await mem.query_episodes("xyzzy12345", min_relevance=0.9999)
+        assert len(matches_low) >= len(matches_high)
+
+    async def test_relevance_scores_in_range(self, mem: SqliteMemoryAdapter) -> None:
+        await mem.record_episode(_ep(summary="configured nginx reverse proxy"))
+        matches = await mem.query_episodes("nginx", min_relevance=0.0)
+        for m in matches:
+            assert 0.0 <= m.relevance <= 1.0
+
+    async def test_fts_handles_hyphenated_query(self, mem: SqliteMemoryAdapter) -> None:
+        await mem.record_episode(_ep(summary="pytest-asyncio migration"))
+        # Should not raise even with hyphens in the query.
+        matches = await mem.query_episodes("pytest-asyncio", min_relevance=0.0)
+        assert len(matches) >= 0  # just checking no exception
+
+    async def test_fts_handles_empty_query(self, mem: SqliteMemoryAdapter) -> None:
+        await mem.record_episode(_ep(summary="some episode"))
+        matches = await mem.query_episodes("", min_relevance=0.0)
+        # Empty query returns no results (no FTS match).
+        assert isinstance(matches, list)
+
+    async def test_sorted_by_relevance_desc(self, mem: SqliteMemoryAdapter) -> None:
+        await mem.record_episode(
+            _ep(
+                episode_id="recent",
+                summary="ran unit tests",
+                timestamp=datetime.now(UTC),
+                outcome=Outcome.SUCCESS,
+            )
+        )
+        await mem.record_episode(
+            _ep(
+                episode_id="old",
+                summary="ran unit tests",
+                timestamp=datetime.now(UTC) - timedelta(days=60),
+                outcome=Outcome.FAILURE,
+            )
+        )
+        matches = await mem.query_episodes("unit tests", min_relevance=0.0)
+        if len(matches) >= 2:
+            assert matches[0].relevance >= matches[1].relevance
+
+
+class TestPrefetch:
+    async def test_returns_empty_when_no_episodes(self, mem: SqliteMemoryAdapter) -> None:
+        result = await mem.prefetch("debug python crash")
+        assert result == ""
+
+    async def test_returns_context_block(self, mem: SqliteMemoryAdapter) -> None:
+        await mem.record_episode(_ep(summary="debugged python import error"))
+        result = await mem.prefetch("python error")
+        assert "Relevant Past Context" in result
+
+    async def test_respects_budget(self, tmp_path: Path) -> None:
+        adapter = SqliteMemoryAdapter(
+            path=str(tmp_path / "memory.db"),
+            prefetch_budget=10,  # very small budget
+            prefetch_min_relevance=0.0,
+        )
+        await adapter.initialize()
+        await adapter.record_episode(
+            _ep(
+                summary="a" * 200,
+                task_description="long task " + "b" * 100,
+            )
+        )
+        result = await adapter.prefetch("long task")
+        # Budget is tiny so we might get empty result or truncated.
+        assert isinstance(result, str)
+
+    async def test_prefetch_includes_outcome_and_date(self, mem: SqliteMemoryAdapter) -> None:
+        ts = datetime(2025, 6, 1, tzinfo=UTC)
+        await mem.record_episode(
+            _ep(summary="fixed database migration", timestamp=ts, outcome=Outcome.SUCCESS)
+        )
+        result = await mem.prefetch("database migration")
+        if result:  # only check if something was returned
+            assert "2025-06-01" in result
+            assert "SUCCESS" in result
+
+
+class TestSearchSessions:
+    async def test_groups_by_session(self, mem: SqliteMemoryAdapter) -> None:
+        await mem.record_episode(
+            _ep(episode_id="e1", session_id="s1", summary="git commit changes")
+        )
+        await mem.record_episode(
+            _ep(episode_id="e2", session_id="s1", summary="git push to remote")
+        )
+        await mem.record_episode(_ep(episode_id="e3", session_id="s2", summary="git merge main"))
+        summaries = await mem.search_sessions("git", limit=10)
+        session_ids = {s.session_id for s in summaries}
+        assert "s1" in session_ids
+        assert "s2" in session_ids
+
+    async def test_episode_count_correct(self, mem: SqliteMemoryAdapter) -> None:
+        for i in range(3):
+            await mem.record_episode(
+                _ep(episode_id=f"e{i}", session_id="s1", summary="refactored module")
+            )
+        summaries = await mem.search_sessions("refactored", limit=5)
+        s1 = next((s for s in summaries if s.session_id == "s1"), None)
+        assert s1 is not None
+        assert s1.episode_count == 3
+
+    async def test_empty_when_no_match(self, mem: SqliteMemoryAdapter) -> None:
+        await mem.record_episode(_ep(summary="configured redis cache"))
+        summaries = await mem.search_sessions("machine learning pipeline", limit=5)
+        assert summaries == []
+
+    async def test_respects_limit(self, mem: SqliteMemoryAdapter) -> None:
+        for i in range(5):
+            await mem.record_episode(
+                _ep(episode_id=f"e{i}", session_id=f"s{i}", summary="fixed bug in code")
+            )
+        summaries = await mem.search_sessions("fixed bug", limit=2)
+        assert len(summaries) <= 2
+
+    async def test_sorted_by_last_active_desc(self, mem: SqliteMemoryAdapter) -> None:
+        ts_old = datetime.now(UTC) - timedelta(days=10)
+        ts_new = datetime.now(UTC)
+        await mem.record_episode(
+            _ep(episode_id="old", session_id="s-old", summary="old task done", timestamp=ts_old)
+        )
+        await mem.record_episode(
+            _ep(episode_id="new", session_id="s-new", summary="old task done", timestamp=ts_new)
+        )
+        summaries = await mem.search_sessions("old task done", limit=5)
+        if len(summaries) >= 2:
+            assert summaries[0].last_active >= summaries[1].last_active
+
+
+class TestSharedContext:
+    async def test_default_none(self, mem: SqliteMemoryAdapter) -> None:
+        assert mem.get_shared_context() is None
+
+    async def test_inject_and_retrieve(self, mem: SqliteMemoryAdapter) -> None:
+        ctx = SharedContext(data={"agent": "sköll"})
+        mem.inject_shared_context(ctx)
+        assert mem.get_shared_context() is ctx
+
+    async def test_inject_replaces(self, mem: SqliteMemoryAdapter) -> None:
+        mem.inject_shared_context(SharedContext(data={"a": 1}))
+        mem.inject_shared_context(SharedContext(data={"b": 2}))
+        ctx = mem.get_shared_context()
+        assert ctx is not None
+        assert "b" in ctx.data
+
+
+class TestRetryMechanism:
+    async def test_raises_on_non_locked_error(self, tmp_path: Path) -> None:
+        adapter = SqliteMemoryAdapter(
+            path=str(tmp_path / "memory.db"),
+            max_retries=3,
+            min_jitter_ms=1.0,
+            max_jitter_ms=2.0,
+        )
+        await adapter.initialize()
+
+        def _fail():
+            raise sqlite3.OperationalError("no such table: xyz")
+
+        with pytest.raises(sqlite3.OperationalError, match="no such table"):
+            adapter._with_retry(_fail)
+
+    async def test_retries_on_locked(self, tmp_path: Path) -> None:
+        adapter = SqliteMemoryAdapter(
+            path=str(tmp_path / "memory.db"),
+            max_retries=3,
+            min_jitter_ms=1.0,
+            max_jitter_ms=2.0,
+        )
+        await adapter.initialize()
+
+        attempts = {"count": 0}
+
+        def _eventually_succeeds():
+            attempts["count"] += 1
+            if attempts["count"] < 3:
+                raise sqlite3.OperationalError("database is locked")
+            return "ok"
+
+        result = adapter._with_retry(_eventually_succeeds)
+        assert result == "ok"
+        assert attempts["count"] == 3
+
+    async def test_raises_after_max_retries(self, tmp_path: Path) -> None:
+        adapter = SqliteMemoryAdapter(
+            path=str(tmp_path / "memory.db"),
+            max_retries=3,
+            min_jitter_ms=1.0,
+            max_jitter_ms=2.0,
+        )
+        await adapter.initialize()
+
+        def _always_locked():
+            raise sqlite3.OperationalError("database is locked")
+
+        with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+            adapter._with_retry(_always_locked)


### PR DESCRIPTION
## Summary

- **MemoryPort** (`src/ravn/ports/memory.py`): abstract interface for episodic memory backends — `record_episode`, `query_episodes`, `prefetch`, `search_sessions`, `inject_shared_context`, `get_shared_context`
- **Domain models** (`src/ravn/domain/models.py`): `Episode`, `EpisodeMatch`, `SessionSummary`, `SharedContext`, `Outcome` (SUCCESS / FAILURE / PARTIAL)
- **SqliteMemoryAdapter** (`src/ravn/adapters/sqlite_memory.py`): SQLite backend at `~/.ravn/memory.db` with WAL mode, FTS5 virtual table, BM25 ranking, application-level retry (max 15, 20–150ms jitter), passive WAL checkpoint every 50 writes, and FTS5 query sanitisation (escape special chars, quote hyphenated terms)
- **MemoryConfig** (`src/ravn/config.py`): extended with `prefetch_budget`, `prefetch_limit`, `prefetch_min_relevance`, `recency_half_life_days`, retry settings, `checkpoint_interval`, `session_search_truncate_chars`
- **Agent integration** (`src/ravn/agent.py`): optional `memory: MemoryPort` — prefetch relevant past context before each turn (injected into system prompt), record episode after each turn using heuristic extraction (outcome from tool errors, tags from tool names, UUID IDs)
- **SessionSearchTool** (`src/ravn/adapters/tools/session_search.py`): `session_search` tool exposed to the LLM — FTS5 keyword search across all episodes grouped by session, returning per-session summaries with metadata

## Prefetch strategy

1. FTS5 search on current user input
2. Recency bias (exponential decay, configurable half-life, default 14 days)
3. Outcome weighting (SUCCESS=1.0, PARTIAL=0.7, FAILURE=0.3)
4. Token budget cap (default 2 000 tokens ≈ 8 000 chars)
5. Formatted as `## Relevant Past Context` Markdown block injected into system prompt

## Test plan

- [x] All 1 478 tests pass (`pytest tests/ravn/ tests/test_ravn/`)
- [x] Coverage 96.93% (threshold: 85%)
- [x] `ruff check` + `ruff format` — no errors
- [x] 118 new tests across 5 test files covering models, port interface, SQLite adapter (WAL, FTS5, BM25, retry), session_search tool, and agent integration

## Acceptance criteria coverage

- [x] Episodes recorded after each turn
- [x] FTS5 search returns relevant past episodes
- [x] Prefetch injects useful context into system prompt
- [x] Session search tool works (LLM can call `session_search`)
- [x] WAL + retry handles concurrent access on Pi (max 15 retries, jitter 20–150ms)
- [x] Memory persists across ravn restarts (SQLite file at `~/.ravn/memory.db`)

Closes NIU-432

🤖 Generated with [Claude Code](https://claude.com/claude-code)