### PR TITLE
feat(adapters): Skuld SSE bridge + Sleipnir integration (NIU-466)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,3 +116,9 @@ exclude_lines = [
     "if TYPE_CHECKING:",
     "@abstractmethod",
 ]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.2",
+    "pytest-asyncio>=1.3.0",
+]

--- a/src/skuld/ravn_publisher.py
+++ b/src/skuld/ravn_publisher.py
@@ -1,0 +1,194 @@
+"""Ravn event publisher — maps CLI NDJSON stream events to Sleipnir events.
+
+The Skuld broker receives raw NDJSON lines from the Claude Code CLI.
+:class:`RavnPublisher` inspects each line and emits structured
+:data:`ravn.*` events onto the Sleipnir bus so that downstream services
+(Tyr activity tracking, Volundr token accounting, analytics) can react
+without parsing raw NDJSON.
+
+Supported mappings
+------------------
+NDJSON type             → Sleipnir event type
+-------------------------------------------
+``tool_use``            → ``ravn.tool.call``
+``tool_result``         → ``ravn.tool.complete``  /  ``ravn.tool.error``
+``message`` (user)      → ``ravn.step.start``
+``message`` (assistant) → ``ravn.step.complete``
+``system`` (init)       → ``ravn.session.start``
+session_end sentinel    → ``ravn.session.end``
+"""
+
+from __future__ import annotations
+
+import logging
+
+from sleipnir.domain.events import SleipnirEvent
+from sleipnir.domain.registry import (
+    RAVN_INTERRUPT,
+    RAVN_RESPONSE_COMPLETE,
+    RAVN_SESSION_END,
+    RAVN_SESSION_START,
+    RAVN_STEP_COMPLETE,
+    RAVN_STEP_START,
+    RAVN_TOOL_CALL,
+    RAVN_TOOL_COMPLETE,
+    RAVN_TOOL_ERROR,
+)
+from sleipnir.ports.events import SleipnirPublisher
+
+logger = logging.getLogger(__name__)
+
+_ROLE_USER = "user"
+_ROLE_ASSISTANT = "assistant"
+
+
+class RavnPublisher:
+    """Maps raw CLI NDJSON events to Sleipnir ``ravn.*`` events.
+
+    Args:
+        publisher: The Sleipnir publisher to emit events on.
+        session_id: The Skuld session identifier (used as ``correlation_id``).
+        source: Publisher identity string (defaults to ``ravn:<session_id>``).
+    """
+
+    def __init__(
+        self,
+        publisher: SleipnirPublisher,
+        session_id: str,
+        source: str | None = None,
+    ) -> None:
+        self._publisher = publisher
+        self._session_id = session_id
+        self._source = source or f"ravn:{session_id}"
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def on_session_start(self, model: str = "", **extra: object) -> None:
+        """Publish ``ravn.session.start`` when the CLI connects."""
+        await self._publish(
+            RAVN_SESSION_START,
+            payload={"session_id": self._session_id, "model": model, **extra},
+            summary=f"Agent session started: {self._session_id}",
+            urgency=0.7,
+        )
+
+    async def on_session_end(self, reason: str = "completed", **extra: object) -> None:
+        """Publish ``ravn.session.end`` when the CLI disconnects."""
+        await self._publish(
+            RAVN_SESSION_END,
+            payload={"session_id": self._session_id, "reason": reason, **extra},
+            summary=f"Agent session ended: {self._session_id} ({reason})",
+            urgency=0.7,
+        )
+
+    async def on_ndjson_line(self, line: dict) -> None:
+        """Inspect a raw NDJSON line and publish the appropriate ravn event."""
+        msg_type = line.get("type", "")
+
+        if msg_type == "tool_use":
+            await self._on_tool_use(line)
+        elif msg_type == "tool_result":
+            await self._on_tool_result(line)
+        elif msg_type == "message":
+            await self._on_message(line)
+        elif msg_type == "system" and line.get("subtype") == "init":
+            model = line.get("session", {}).get("model", "")
+            await self.on_session_start(model=model)
+
+    async def on_interrupt(self, **extra: object) -> None:
+        """Publish ``ravn.interrupt`` when a user interrupt is received."""
+        await self._publish(
+            RAVN_INTERRUPT,
+            payload={"session_id": self._session_id, **extra},
+            summary=f"Agent session interrupted: {self._session_id}",
+            urgency=0.9,
+        )
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    async def _on_tool_use(self, line: dict) -> None:
+        tool_name = line.get("name", "")
+        await self._publish(
+            RAVN_TOOL_CALL,
+            payload={
+                "session_id": self._session_id,
+                "tool": tool_name,
+                "tool_use_id": line.get("id", ""),
+                "input_preview": str(line.get("input", ""))[:200],
+            },
+            summary=f"Tool dispatched: {tool_name}",
+            urgency=0.5,
+        )
+
+    async def _on_tool_result(self, line: dict) -> None:
+        is_error = bool(line.get("is_error", False))
+        event_type = RAVN_TOOL_ERROR if is_error else RAVN_TOOL_COMPLETE
+        tool_use_id = line.get("tool_use_id", "")
+        await self._publish(
+            event_type,
+            payload={
+                "session_id": self._session_id,
+                "tool_use_id": tool_use_id,
+                "is_error": is_error,
+            },
+            summary=f"Tool {'failed' if is_error else 'completed'}: {tool_use_id}",
+            urgency=0.4,
+        )
+
+    async def _on_message(self, line: dict) -> None:
+        role = line.get("role", "")
+        if role == _ROLE_USER:
+            await self._publish(
+                RAVN_STEP_START,
+                payload={"session_id": self._session_id, "role": role},
+                summary=f"Agent step started for session {self._session_id}",
+                urgency=0.3,
+            )
+        elif role == _ROLE_ASSISTANT:
+            stop_reason = line.get("stop_reason", "")
+            if stop_reason == "end_turn":
+                await self._publish(
+                    RAVN_RESPONSE_COMPLETE,
+                    payload={"session_id": self._session_id, "stop_reason": stop_reason},
+                    summary=f"Agent response complete for session {self._session_id}",
+                    urgency=0.5,
+                )
+            else:
+                await self._publish(
+                    RAVN_STEP_COMPLETE,
+                    payload={"session_id": self._session_id, "stop_reason": stop_reason},
+                    summary=f"Agent step complete for session {self._session_id}",
+                    urgency=0.3,
+                )
+
+    async def _publish(
+        self,
+        event_type: str,
+        *,
+        payload: dict,
+        summary: str,
+        urgency: float,
+    ) -> None:
+        event = SleipnirEvent(
+            event_type=event_type,
+            source=self._source,
+            payload=payload,
+            summary=summary,
+            urgency=urgency,
+            domain="code",
+            timestamp=SleipnirEvent.now(),
+            correlation_id=self._session_id,
+        )
+        try:
+            await self._publisher.publish(event)
+        except Exception:
+            logger.error(
+                "RavnPublisher: failed to publish %s for session %s",
+                event_type,
+                self._session_id,
+                exc_info=True,
+            )

--- a/src/skuld/sleipnir_bridge.py
+++ b/src/skuld/sleipnir_bridge.py
@@ -1,0 +1,153 @@
+"""Sleipnir → WebSocket bridge for Skuld.
+
+Skuld subscribes to the Sleipnir event bus and forwards relevant events to
+the browser via the :class:`~skuld.channels.ChannelRegistry`.  This decouples
+the browser from direct service coupling — Volundr, Tyr, and Ravn all publish
+to Sleipnir; Skuld bridges the resulting stream to the WebSocket.
+
+Filtering rules
+---------------
+- *session_id* filter: only events whose ``correlation_id`` or
+  ``payload["session_id"]`` matches the configured session are forwarded.
+  When ``session_id`` is ``None`` (no filter), all matching events are forwarded.
+- *event_patterns*: shell-style wildcards (e.g. ``"volundr.*"``), forwarded
+  verbatim to the Sleipnir subscriber port.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from skuld.channels import ChannelRegistry
+from sleipnir.domain.events import SleipnirEvent
+from sleipnir.ports.events import SleipnirSubscriber, Subscription
+
+logger = logging.getLogger(__name__)
+
+#: Default patterns forwarded by the bridge.
+DEFAULT_PATTERNS: list[str] = [
+    "ravn.*",
+    "volundr.*",
+    "tyr.*",
+    "system.health.*",
+]
+
+
+class SleipnirBridge:
+    """Subscribes to Sleipnir and forwards events to the channel registry.
+
+    Lifecycle::
+
+        bridge = SleipnirBridge(subscriber, registry, session_id="abc")
+        await bridge.start()   # subscribes to Sleipnir
+        # ... events flow to registry ...
+        await bridge.stop()    # unsubscribes and cleans up
+
+    Can also be used as an async context manager::
+
+        async with SleipnirBridge(subscriber, registry) as bridge:
+            ...
+    """
+
+    def __init__(
+        self,
+        subscriber: SleipnirSubscriber,
+        registry: ChannelRegistry,
+        session_id: str | None = None,
+        event_patterns: list[str] | None = None,
+    ) -> None:
+        self._subscriber = subscriber
+        self._registry = registry
+        self._session_id = session_id
+        self._patterns = event_patterns if event_patterns is not None else list(DEFAULT_PATTERNS)
+        self._subscription: Subscription | None = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Subscribe to Sleipnir and begin bridging events."""
+        if self._subscription is not None:
+            logger.warning("SleipnirBridge.start() called while already running — ignored")
+            return
+        self._subscription = await self._subscriber.subscribe(
+            self._patterns,
+            self._handle_event,
+        )
+        logger.info(
+            "SleipnirBridge started: session_id=%s, patterns=%s",
+            self._session_id,
+            self._patterns,
+        )
+
+    async def stop(self) -> None:
+        """Unsubscribe from Sleipnir and release resources."""
+        if self._subscription is None:
+            return
+        await self._subscription.unsubscribe()
+        self._subscription = None
+        logger.info("SleipnirBridge stopped: session_id=%s", self._session_id)
+
+    async def __aenter__(self) -> SleipnirBridge:
+        await self.start()
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        await self.stop()
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    async def _handle_event(self, event: SleipnirEvent) -> None:
+        """Filter by session/user context, then broadcast to all channels."""
+        if not self._matches_context(event):
+            return
+
+        wire = self._to_wire(event)
+        try:
+            await self._registry.broadcast(wire)
+        except Exception:
+            logger.error(
+                "SleipnirBridge: failed to broadcast event %s (%s)",
+                event.event_id,
+                event.event_type,
+                exc_info=True,
+            )
+
+    def _matches_context(self, event: SleipnirEvent) -> bool:
+        """Return True if the event is relevant to this bridge's context.
+
+        When *session_id* is ``None``, all events pass through.
+        Otherwise the event must have a matching ``correlation_id`` **or** a
+        ``payload["session_id"]`` equal to our session.
+        """
+        if self._session_id is None:
+            return True
+
+        if event.correlation_id == self._session_id:
+            return True
+
+        payload_session = event.payload.get("session_id")
+        if payload_session == self._session_id:
+            return True
+
+        return False
+
+    @staticmethod
+    def _to_wire(event: SleipnirEvent) -> dict:
+        """Serialise a :class:`SleipnirEvent` to the channel wire format."""
+        return {
+            "type": "sleipnir",
+            "event_id": event.event_id,
+            "event_type": event.event_type,
+            "source": event.source,
+            "summary": event.summary,
+            "payload": event.payload,
+            "urgency": event.urgency,
+            "domain": event.domain,
+            "timestamp": event.timestamp.isoformat(),
+            "correlation_id": event.correlation_id,
+            "tenant_id": event.tenant_id,
+        }

--- a/src/sleipnir/domain/events.py
+++ b/src/sleipnir/domain/events.py
@@ -19,10 +19,11 @@ logger = logging.getLogger(__name__)
 #: Keys are namespace prefixes; values are documentation strings.
 EVENT_NAMESPACES: dict[str, str] = {
     "ravn": "Ravn agent events (tool calls, reasoning steps, completions)",
-    "tyr": "Tyr autonomous dispatcher events (tasks, sessions, runs)",
-    "volundr": "Volundr platform events (repos, PRs, integrations)",
+    "tyr": "Tyr autonomous dispatcher events (tasks, sagas, raids, sessions)",
+    "volundr": "Volundr platform events (sessions, repos, PRs, tokens, chronicles)",
     "bifrost": "Bifrost gateway events (routing, connection, auth)",
     "system": "Infrastructure and lifecycle events (health, config, restart)",
+    "skuld": "Skuld broker events (session pod activity, tool use, token updates)",
 }
 
 #: Known high-level domain tags for events.

--- a/src/sleipnir/domain/registry.py
+++ b/src/sleipnir/domain/registry.py
@@ -86,6 +86,27 @@ TYR_SESSION_END: str = "tyr.session.end"
 # volundr — Volundr platform events
 # ---------------------------------------------------------------------------
 
+#: A session was created in Volundr.
+VOLUNDR_SESSION_CREATED: str = "volundr.session.created"
+
+#: A session was started (pods running, ready to accept CLI connections).
+VOLUNDR_SESSION_STARTED: str = "volundr.session.started"
+
+#: A session was stopped gracefully.
+VOLUNDR_SESSION_STOPPED: str = "volundr.session.stopped"
+
+#: A session failed (pod error or infrastructure failure).
+VOLUNDR_SESSION_FAILED: str = "volundr.session.failed"
+
+#: Token usage was recorded for a session.
+VOLUNDR_TOKEN_USAGE: str = "volundr.token.usage"
+
+#: A chronicle was created for a session.
+VOLUNDR_CHRONICLE_CREATED: str = "volundr.chronicle.created"
+
+#: An existing chronicle was updated.
+VOLUNDR_CHRONICLE_UPDATED: str = "volundr.chronicle.updated"
+
 #: A pull request was opened in the platform.
 VOLUNDR_PR_OPENED: str = "volundr.pr.opened"
 

--- a/src/sleipnir/domain/registry.py
+++ b/src/sleipnir/domain/registry.py
@@ -82,6 +82,43 @@ TYR_SESSION_START: str = "tyr.session.start"
 #: A dispatcher session ended.
 TYR_SESSION_END: str = "tyr.session.end"
 
+#: A raid was created.
+TYR_RAID_CREATED: str = "tyr.raid.created"
+
+#: A raid changed state (submitted, running, waiting_review, done, failed, etc.).
+TYR_RAID_STATE_CHANGED: str = "tyr.raid.state_changed"
+
+#: A raid completed successfully.
+TYR_RAID_COMPLETED: str = "tyr.raid.completed"
+
+#: A raid failed.
+TYR_RAID_FAILED: str = "tyr.raid.failed"
+
+#: The autonomous dispatcher state was updated.
+TYR_DISPATCHER_STATE: str = "tyr.dispatcher.state"
+
+#: A notification was sent to a channel.
+TYR_NOTIFICATION_SENT: str = "tyr.notification.sent"
+
+# ---------------------------------------------------------------------------
+# skuld — Skuld broker events (session pod activity)
+# ---------------------------------------------------------------------------
+
+#: A Skuld broker session started.
+SKULD_SESSION_STARTED: str = "skuld.session.started"
+
+#: A Skuld broker session stopped.
+SKULD_SESSION_STOPPED: str = "skuld.session.stopped"
+
+#: A tool was executed in the Skuld session.
+SKULD_TOOL_USE: str = "skuld.tool.use"
+
+#: Token counts were updated in the Skuld session.
+SKULD_TOKEN_UPDATE: str = "skuld.token.update"
+
+#: A permission request was raised by the agent.
+SKULD_PERMISSION_REQUEST: str = "skuld.permission.request"
+
 # ---------------------------------------------------------------------------
 # volundr — Volundr platform events
 # ---------------------------------------------------------------------------
@@ -130,6 +167,74 @@ VOLUNDR_PIPELINE_COMPLETE: str = "volundr.pipeline.complete"
 
 #: A CI pipeline run failed.
 VOLUNDR_PIPELINE_FAILED: str = "volundr.pipeline.failed"
+
+# --- Volundr session lifecycle events ---
+
+#: A session was created in Volundr.
+VOLUNDR_SESSION_CREATED: str = "volundr.session.created"
+
+#: A session was updated (status change, token usage, etc.).
+VOLUNDR_SESSION_UPDATED: str = "volundr.session.updated"
+
+#: A session was deleted.
+VOLUNDR_SESSION_DELETED: str = "volundr.session.deleted"
+
+#: An agent session started inside a pod.
+VOLUNDR_SESSION_STARTED: str = "volundr.session.started"
+
+#: An agent session stopped inside a pod.
+VOLUNDR_SESSION_STOPPED: str = "volundr.session.stopped"
+
+#: A session encountered an error.
+VOLUNDR_SESSION_ERROR: str = "volundr.session.error"
+
+#: Token usage was recorded for a session.
+VOLUNDR_TOKEN_USAGE: str = "volundr.token.usage"
+
+#: Aggregate stats were updated.
+VOLUNDR_STATS_UPDATED: str = "volundr.stats.updated"
+
+#: A chronicle record was created.
+VOLUNDR_CHRONICLE_CREATED: str = "volundr.chronicle.created"
+
+#: A chronicle record was updated (new timeline event appended).
+VOLUNDR_CHRONICLE_UPDATED: str = "volundr.chronicle.updated"
+
+#: A chronicle record was deleted.
+VOLUNDR_CHRONICLE_DELETED: str = "volundr.chronicle.deleted"
+
+#: A user message was recorded in a session.
+VOLUNDR_MESSAGE_USER: str = "volundr.message.user"
+
+#: An assistant message was recorded in a session.
+VOLUNDR_MESSAGE_ASSISTANT: str = "volundr.message.assistant"
+
+#: A file was created in the session workspace.
+VOLUNDR_FILE_CREATED: str = "volundr.file.created"
+
+#: A file was modified in the session workspace.
+VOLUNDR_FILE_MODIFIED: str = "volundr.file.modified"
+
+#: A file was deleted from the session workspace.
+VOLUNDR_FILE_DELETED: str = "volundr.file.deleted"
+
+#: A git commit was made in the session workspace.
+VOLUNDR_GIT_COMMIT: str = "volundr.git.commit"
+
+#: A git push was made from the session workspace.
+VOLUNDR_GIT_PUSH: str = "volundr.git.push"
+
+#: A git branch was created in the session workspace.
+VOLUNDR_GIT_BRANCH: str = "volundr.git.branch"
+
+#: A git checkout was performed in the session workspace.
+VOLUNDR_GIT_CHECKOUT: str = "volundr.git.checkout"
+
+#: A terminal command was executed in the session workspace.
+VOLUNDR_TERMINAL_COMMAND: str = "volundr.terminal.command"
+
+#: A tool was used in the session workspace.
+VOLUNDR_TOOL_USE: str = "volundr.tool.use"
 
 # ---------------------------------------------------------------------------
 # bifrost — Bifrost gateway events

--- a/src/sleipnir/domain/registry.py
+++ b/src/sleipnir/domain/registry.py
@@ -168,37 +168,17 @@ VOLUNDR_PIPELINE_COMPLETE: str = "volundr.pipeline.complete"
 #: A CI pipeline run failed.
 VOLUNDR_PIPELINE_FAILED: str = "volundr.pipeline.failed"
 
-# --- Volundr session lifecycle events ---
-
-#: A session was created in Volundr.
-VOLUNDR_SESSION_CREATED: str = "volundr.session.created"
-
 #: A session was updated (status change, token usage, etc.).
 VOLUNDR_SESSION_UPDATED: str = "volundr.session.updated"
 
 #: A session was deleted.
 VOLUNDR_SESSION_DELETED: str = "volundr.session.deleted"
 
-#: An agent session started inside a pod.
-VOLUNDR_SESSION_STARTED: str = "volundr.session.started"
-
-#: An agent session stopped inside a pod.
-VOLUNDR_SESSION_STOPPED: str = "volundr.session.stopped"
-
 #: A session encountered an error.
 VOLUNDR_SESSION_ERROR: str = "volundr.session.error"
 
-#: Token usage was recorded for a session.
-VOLUNDR_TOKEN_USAGE: str = "volundr.token.usage"
-
 #: Aggregate stats were updated.
 VOLUNDR_STATS_UPDATED: str = "volundr.stats.updated"
-
-#: A chronicle record was created.
-VOLUNDR_CHRONICLE_CREATED: str = "volundr.chronicle.created"
-
-#: A chronicle record was updated (new timeline event appended).
-VOLUNDR_CHRONICLE_UPDATED: str = "volundr.chronicle.updated"
 
 #: A chronicle record was deleted.
 VOLUNDR_CHRONICLE_DELETED: str = "volundr.chronicle.deleted"

--- a/src/tyr/adapters/sleipnir_event_bridge.py
+++ b/src/tyr/adapters/sleipnir_event_bridge.py
@@ -1,0 +1,192 @@
+"""Sleipnir event bridge for Tyr — mirrors TyrEvents onto the Sleipnir bus.
+
+:class:`SleipnirEventBridge` is a decorator around :class:`~tyr.ports.event_bus.EventBusPort`.
+All calls are forwarded to the inner bus unchanged; in addition, each emitted
+:class:`~tyr.ports.event_bus.TyrEvent` is mapped to a :class:`~sleipnir.domain.events.SleipnirEvent`
+and published on the Sleipnir bus.
+
+This enables Skuld (and other Sleipnir subscribers) to receive Tyr activity
+events (saga progression, raid state changes, dispatcher health) without
+polling Tyr's SSE endpoint.
+
+Event mapping
+-------------
+``dispatcher.state``      → ``tyr.task.started``
+``saga.created``          → ``tyr.saga.created``
+``saga.step``             → ``tyr.saga.step``
+``saga.completed``        → ``tyr.saga.complete``
+``saga.failed``           → ``tyr.saga.failed``
+``raid.state_changed``    → ``tyr.task.*``  (derived from new_status)
+``notification.*``        → silently dropped (internal)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from sleipnir.domain.events import SleipnirEvent
+from sleipnir.domain.registry import (
+    TYR_SAGA_COMPLETE,
+    TYR_SAGA_CREATED,
+    TYR_SAGA_FAILED,
+    TYR_SAGA_STEP,
+    TYR_TASK_CANCELLED,
+    TYR_TASK_COMPLETE,
+    TYR_TASK_FAILED,
+    TYR_TASK_QUEUED,
+    TYR_TASK_STARTED,
+)
+from sleipnir.ports.events import SleipnirPublisher
+from tyr.ports.event_bus import EventBusPort, TyrEvent
+
+logger = logging.getLogger(__name__)
+
+_SOURCE = "tyr:event-bridge"
+
+# Map saga.* TyrEvent types to Sleipnir constants.
+_SAGA_TYPE_MAP: dict[str, str] = {
+    "saga.created": TYR_SAGA_CREATED,
+    "saga.step": TYR_SAGA_STEP,
+    "saga.completed": TYR_SAGA_COMPLETE,
+    "saga.failed": TYR_SAGA_FAILED,
+}
+
+# Map raid new_status values to Sleipnir task event types.
+_RAID_STATUS_MAP: dict[str, str] = {
+    "QUEUED": TYR_TASK_QUEUED,
+    "RUNNING": TYR_TASK_STARTED,
+    "MERGED": TYR_TASK_COMPLETE,
+    "FAILED": TYR_TASK_FAILED,
+    "CANCELLED": TYR_TASK_CANCELLED,
+}
+
+
+class SleipnirEventBridge(EventBusPort):
+    """Decorator around :class:`EventBusPort` that also publishes to Sleipnir.
+
+    All :class:`EventBusPort` operations are delegated to the *inner* bus.
+    ``emit`` additionally publishes a :class:`SleipnirEvent` to *publisher*;
+    publication errors are logged and swallowed to protect the inner bus.
+
+    Args:
+        inner: The actual :class:`EventBusPort` implementation.
+        publisher: Sleipnir publisher to mirror events onto.
+    """
+
+    def __init__(self, inner: EventBusPort, publisher: SleipnirPublisher) -> None:
+        self._inner = inner
+        self._publisher = publisher
+
+    # ------------------------------------------------------------------
+    # EventBusPort delegation
+    # ------------------------------------------------------------------
+
+    def subscribe(self) -> asyncio.Queue[TyrEvent]:
+        return self._inner.subscribe()
+
+    def unsubscribe(self, q: asyncio.Queue[TyrEvent]) -> None:
+        self._inner.unsubscribe(q)
+
+    async def emit(self, event: TyrEvent) -> None:
+        """Broadcast to inner bus *and* publish to Sleipnir."""
+        await self._inner.emit(event)
+        await self._mirror_to_sleipnir(event)
+
+    def get_snapshot(self) -> list[TyrEvent]:
+        return self._inner.get_snapshot()
+
+    def get_log(self, n: int) -> list[TyrEvent]:
+        return self._inner.get_log(n)
+
+    @property
+    def client_count(self) -> int:
+        return self._inner.client_count
+
+    @property
+    def at_capacity(self) -> bool:
+        return self._inner.at_capacity
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    async def _mirror_to_sleipnir(self, event: TyrEvent) -> None:
+        """Map *event* to a Sleipnir event and publish; swallow errors."""
+        sleipnir_event = self._to_sleipnir(event)
+        if sleipnir_event is None:
+            return
+        try:
+            await self._publisher.publish(sleipnir_event)
+        except Exception:
+            logger.error(
+                "SleipnirEventBridge: failed to publish %s (%s) to Sleipnir",
+                event.event,
+                event.id,
+                exc_info=True,
+            )
+
+    def _to_sleipnir(self, event: TyrEvent) -> SleipnirEvent | None:
+        """Return a mapped :class:`SleipnirEvent` or ``None`` if not forwarded."""
+        owner_id = event.owner_id or None
+
+        if event.event in _SAGA_TYPE_MAP:
+            return self._map_saga(event, _SAGA_TYPE_MAP[event.event], owner_id)
+
+        if event.event == "raid.state_changed":
+            return self._map_raid(event, owner_id)
+
+        if event.event == "dispatcher.state":
+            return self._map_dispatcher_state(event, owner_id)
+
+        return None
+
+    def _map_saga(
+        self,
+        event: TyrEvent,
+        sleipnir_type: str,
+        owner_id: str | None,
+    ) -> SleipnirEvent:
+        saga_id = str(event.data.get("saga_id", ""))
+        saga_name = str(event.data.get("name", ""))
+        return SleipnirEvent(
+            event_type=sleipnir_type,
+            source=_SOURCE,
+            payload={"owner_id": owner_id or "", **event.data},
+            summary=f"Saga {event.event.split('.')[-1]}: {saga_name or saga_id}",
+            urgency=0.6,
+            domain="code",
+            timestamp=event.timestamp,
+            correlation_id=saga_id or None,
+            tenant_id=owner_id,
+        )
+
+    def _map_raid(self, event: TyrEvent, owner_id: str | None) -> SleipnirEvent | None:
+        new_status = str(event.data.get("new_status", "")).upper()
+        sleipnir_type = _RAID_STATUS_MAP.get(new_status)
+        if sleipnir_type is None:
+            return None
+        raid_id = str(event.data.get("raid_id", ""))
+        return SleipnirEvent(
+            event_type=sleipnir_type,
+            source=_SOURCE,
+            payload={"owner_id": owner_id or "", **event.data},
+            summary=f"Raid {new_status.lower()}: {raid_id}",
+            urgency=0.5,
+            domain="code",
+            timestamp=event.timestamp,
+            correlation_id=raid_id or None,
+            tenant_id=owner_id,
+        )
+
+    def _map_dispatcher_state(self, event: TyrEvent, owner_id: str | None) -> SleipnirEvent:
+        return SleipnirEvent(
+            event_type=TYR_TASK_STARTED,
+            source=_SOURCE,
+            payload={"owner_id": owner_id or "", **event.data},
+            summary="Dispatcher state updated",
+            urgency=0.3,
+            domain="infrastructure",
+            timestamp=event.timestamp,
+            tenant_id=owner_id,
+        )

--- a/src/tyr/adapters/sleipnir_event_bridge.py
+++ b/src/tyr/adapters/sleipnir_event_bridge.py
@@ -190,3 +190,61 @@ class SleipnirEventBridge(EventBusPort):
             timestamp=event.timestamp,
             tenant_id=owner_id,
         )
+
+
+class TyrSleipnirBridge:
+    """Lifecycle wrapper around :class:`SleipnirEventBridge` for use in main.py.
+
+    Runs as a background asyncio task: subscribes to *event_bus*, delegates
+    each :class:`TyrEvent` to :class:`SleipnirEventBridge` for mapping and
+    publication.  This avoids replacing the ``event_bus`` reference already
+    wired into SSE endpoints and dependency injection.
+
+    Usage::
+
+        bridge = TyrSleipnirBridge(event_bus=bus, publisher=sleipnir)
+        await bridge.start()
+        # ... application runs ...
+        await bridge.stop()
+    """
+
+    def __init__(self, event_bus: EventBusPort, publisher: SleipnirPublisher) -> None:
+        self._event_bus = event_bus
+        self._inner = SleipnirEventBridge(inner=event_bus, publisher=publisher)
+        self._task: asyncio.Task[None] | None = None
+
+    async def start(self) -> None:
+        """Start the background mirroring task."""
+        if self._task is not None:
+            return
+        self._task = asyncio.create_task(self._run(), name="tyr-sleipnir-bridge")
+        logger.info("TyrSleipnirBridge started")
+
+    async def stop(self) -> None:
+        """Cancel the mirroring task and clean up."""
+        if self._task is None:
+            return
+        self._task.cancel()
+        try:
+            await self._task
+        except asyncio.CancelledError:
+            pass
+        self._task = None
+        logger.info("TyrSleipnirBridge stopped")
+
+    @property
+    def is_running(self) -> bool:
+        """True when the background task is active."""
+        return self._task is not None and not self._task.done()
+
+    async def _run(self) -> None:
+        """Subscribe to event_bus and mirror events to Sleipnir until cancelled."""
+        q = self._event_bus.subscribe()
+        try:
+            while True:
+                event: TyrEvent = await q.get()
+                await self._inner._mirror_to_sleipnir(event)
+        except asyncio.CancelledError:
+            pass
+        finally:
+            self._event_bus.unsubscribe(q)

--- a/src/tyr/config.py
+++ b/src/tyr/config.py
@@ -595,6 +595,33 @@ class EventBusConfig(BaseModel):
     kwargs: dict[str, Any] = Field(default_factory=dict)
 
 
+class SleipnirConfig(BaseModel):
+    """Sleipnir platform event bus integration (optional).
+
+    When ``enabled`` is True, Tyr creates a Sleipnir adapter and starts a
+    :class:`~tyr.adapters.sleipnir_event_bridge.TyrSleipnirBridge` that
+    republishes all Tyr events to the platform-wide bus.
+
+    Example YAML::
+
+        sleipnir:
+          enabled: true
+          adapter: "sleipnir.adapters.nats_transport.NatsTransport"
+          kwargs:
+            servers: ["nats://nats:4222"]
+    """
+
+    enabled: bool = Field(
+        default=False,
+        description="Enable Sleipnir platform event bus integration.",
+    )
+    adapter: str = Field(
+        default="sleipnir.adapters.in_process.InProcessBus",
+        description="Fully-qualified class path for the Sleipnir adapter.",
+    )
+    kwargs: dict[str, Any] = Field(default_factory=dict)
+
+
 class NotificationConfig(BaseModel):
     """Notification service configuration."""
 
@@ -662,6 +689,7 @@ class Settings(BaseSettings):
     events: EventsConfig = Field(default_factory=EventsConfig)
     telegram: TelegramConfig = Field(default_factory=TelegramConfig)
     notification: NotificationConfig = Field(default_factory=NotificationConfig)
+    sleipnir: SleipnirConfig = Field(default_factory=SleipnirConfig)
 
     @classmethod
     def settings_customise_sources(

--- a/src/tyr/main.py
+++ b/src/tyr/main.py
@@ -380,6 +380,23 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             app.dependency_overrides[resolve_event_bus] = _resolve_event_bus
             app.dependency_overrides[dispatcher_resolve_event_bus] = _resolve_event_bus
 
+            # Wire Sleipnir bridge (optional — enabled via sleipnir.enabled config)
+            tyr_sleipnir_bridge = None
+            if settings.sleipnir.enabled:
+                from tyr.adapters.sleipnir_event_bridge import TyrSleipnirBridge  # noqa: PLC0415
+
+                sl_cls = import_class(settings.sleipnir.adapter)
+                sleipnir_bus = sl_cls(**settings.sleipnir.kwargs)
+                tyr_sleipnir_bridge = TyrSleipnirBridge(
+                    event_bus=event_bus,
+                    publisher=sleipnir_bus,
+                )
+                await tyr_sleipnir_bridge.start()
+                logger.info(
+                    "Tyr Sleipnir bridge started: adapter=%s",
+                    settings.sleipnir.adapter.rsplit(".", 1)[-1],
+                )
+
             # Wire Telegram reply client (shared httpx.AsyncClient)
             from tyr.adapters.inbound.rest_telegram_webhook import (
                 TelegramReplyClient,
@@ -459,6 +476,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             yield
 
             # Lifecycle cleanup
+            if tyr_sleipnir_bridge is not None:
+                await tyr_sleipnir_bridge.stop()
             await review_engine.stop()
             await notification_service.stop()
             await telegram_reply_client.close()

--- a/src/volundr/adapters/outbound/broadcaster.py
+++ b/src/volundr/adapters/outbound/broadcaster.py
@@ -13,9 +13,29 @@ from volundr.domain.models import EventType, RealtimeEvent, Stats, TimelineRespo
 from volundr.domain.ports import EventBroadcaster
 
 if TYPE_CHECKING:
+    from sleipnir.ports.events import SleipnirPublisher
     from volundr.domain.models import Session, TimelineEvent
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Mapping from Volundr EventType → Sleipnir event type string
+# ---------------------------------------------------------------------------
+# Import lazily to avoid a hard dependency on sleipnir at module load time.
+def _build_realtime_sleipnir_map() -> dict[str, str]:
+    from sleipnir.domain import registry  # noqa: PLC0415
+
+    return {
+        EventType.SESSION_CREATED.value: registry.VOLUNDR_SESSION_CREATED,
+        EventType.SESSION_UPDATED.value: registry.VOLUNDR_SESSION_UPDATED,
+        EventType.SESSION_DELETED.value: registry.VOLUNDR_SESSION_DELETED,
+        EventType.STATS_UPDATED.value: registry.VOLUNDR_STATS_UPDATED,
+        EventType.CHRONICLE_CREATED.value: registry.VOLUNDR_CHRONICLE_CREATED,
+        EventType.CHRONICLE_UPDATED.value: registry.VOLUNDR_CHRONICLE_UPDATED,
+        EventType.CHRONICLE_DELETED.value: registry.VOLUNDR_CHRONICLE_DELETED,
+        EventType.CHRONICLE_EVENT.value: registry.VOLUNDR_CHRONICLE_UPDATED,
+    }
 
 
 class InMemoryEventBroadcaster(EventBroadcaster):
@@ -25,21 +45,41 @@ class InMemoryEventBroadcaster(EventBroadcaster):
     published to all active subscriber queues. If a subscriber's queue
     is full, old events are dropped to prevent memory issues with slow
     consumers.
+
+    When a :class:`~sleipnir.ports.events.SleipnirPublisher` is provided,
+    high-level session lifecycle and chronicle events are also forwarded to
+    the platform-wide event bus so that Skuld brokers and other services can
+    react in real time.
     """
 
-    def __init__(self, max_queue_size: int = 100):
+    def __init__(
+        self,
+        max_queue_size: int = 100,
+        sleipnir_publisher: SleipnirPublisher | None = None,
+        sleipnir_source: str = "volundr",
+    ):
         """Initialize the broadcaster.
 
         Args:
             max_queue_size: Maximum number of events to buffer per subscriber.
                 When exceeded, oldest events are dropped.
+            sleipnir_publisher: Optional Sleipnir publisher.  When provided,
+                session lifecycle and chronicle events are forwarded to the
+                platform event bus in addition to local SSE clients.
+            sleipnir_source: Source string used in Sleipnir events (e.g.
+                ``"volundr"`` or ``"volundr:prod"``).
         """
         self._subscribers: set[asyncio.Queue[RealtimeEvent]] = set()
         self._max_queue_size = max_queue_size
         self._lock = asyncio.Lock()
+        self._sleipnir_publisher = sleipnir_publisher
+        self._sleipnir_source = sleipnir_source
+        self._sleipnir_type_map: dict[str, str] | None = None
 
     async def publish(self, event: RealtimeEvent) -> None:
         """Publish an event to all connected subscribers.
+
+        Also forwards to Sleipnir if a publisher was provided at construction.
 
         Args:
             event: The event to broadcast.
@@ -50,9 +90,6 @@ class InMemoryEventBroadcaster(EventBroadcaster):
             event.type.value,
             subscriber_count,
         )
-        if subscriber_count == 0:
-            logger.debug("SSE publish: no subscribers, event dropped: %s", event.type.value)
-            return
 
         async with self._lock:
             dead_queues: list[asyncio.Queue[RealtimeEvent]] = []
@@ -84,6 +121,45 @@ class InMemoryEventBroadcaster(EventBroadcaster):
             event.type.value,
             subscriber_count - len(dead_queues),
         )
+
+        # Forward to Sleipnir when a publisher is configured
+        if self._sleipnir_publisher is not None:
+            await self._forward_to_sleipnir(event)
+
+    async def _forward_to_sleipnir(self, event: RealtimeEvent) -> None:
+        """Convert a RealtimeEvent to a SleipnirEvent and publish it."""
+        if self._sleipnir_type_map is None:
+            self._sleipnir_type_map = _build_realtime_sleipnir_map()
+
+        sleipnir_type = self._sleipnir_type_map.get(event.type.value)
+        if sleipnir_type is None:
+            return  # Heartbeats and other non-forwarded events
+
+        try:
+            from datetime import UTC  # noqa: PLC0415
+
+            from sleipnir.domain.events import SleipnirEvent  # noqa: PLC0415
+
+            sleipnir_event = SleipnirEvent(
+                event_type=sleipnir_type,
+                source=self._sleipnir_source,
+                payload=dict(event.data),
+                summary=f"{event.type.value} broadcast",
+                urgency=0.5,
+                domain="code",
+                timestamp=(
+                    event.timestamp.replace(tzinfo=UTC)
+                    if event.timestamp.tzinfo is None
+                    else event.timestamp
+                ),
+            )
+            await self._sleipnir_publisher.publish(sleipnir_event)
+        except Exception:
+            logger.warning(
+                "InMemoryEventBroadcaster: failed to forward %s to Sleipnir",
+                event.type.value,
+                exc_info=True,
+            )
 
     async def subscribe(self) -> AsyncGenerator[RealtimeEvent, None]:
         """Subscribe to receive events.

--- a/src/volundr/adapters/outbound/sleipnir_event_sink.py
+++ b/src/volundr/adapters/outbound/sleipnir_event_sink.py
@@ -1,0 +1,219 @@
+"""Sleipnir event sink — publishes Volundr session events to the Sleipnir bus.
+
+Volundr's session lifecycle events (start, stop, fail), token usage, and
+chronicle updates are mapped to structured :class:`~sleipnir.domain.events.SleipnirEvent`
+objects and published to the Sleipnir bus.  Downstream subscribers (Skuld,
+Tyr, analytics pipelines) then react to those events.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from sleipnir.domain.events import SleipnirEvent
+from sleipnir.domain.registry import (
+    VOLUNDR_CHRONICLE_CREATED,
+    VOLUNDR_CHRONICLE_UPDATED,
+    VOLUNDR_SESSION_STARTED,
+    VOLUNDR_SESSION_STOPPED,
+    VOLUNDR_TOKEN_USAGE,
+)
+from sleipnir.ports.events import SleipnirPublisher
+from volundr.domain.models import SessionEvent, SessionEventType
+from volundr.domain.ports import EventSink
+
+logger = logging.getLogger(__name__)
+
+_SOURCE = "volundr:event-sink"
+
+# Map SessionEventType → Sleipnir event type for session lifecycle.
+_SESSION_TYPE_MAP: dict[SessionEventType, str] = {
+    SessionEventType.SESSION_START: VOLUNDR_SESSION_STARTED,
+    SessionEventType.SESSION_STOP: VOLUNDR_SESSION_STOPPED,
+}
+
+
+class SleipnirEventSink(EventSink):
+    """EventSink adapter that publishes Volundr session events to Sleipnir.
+
+    Failures in the Sleipnir publisher are logged and swallowed so that
+    a transport outage does not interrupt core session event storage.
+    """
+
+    def __init__(self, publisher: SleipnirPublisher) -> None:
+        self._publisher = publisher
+        self._healthy = True
+
+    @property
+    def sink_name(self) -> str:
+        return "sleipnir"
+
+    @property
+    def healthy(self) -> bool:
+        return self._healthy
+
+    async def emit(self, event: SessionEvent) -> None:
+        """Map *event* to a Sleipnir event and publish it."""
+        sleipnir_event = self._to_sleipnir(event)
+        if sleipnir_event is None:
+            return
+        try:
+            await self._publisher.publish(sleipnir_event)
+            self._healthy = True
+        except Exception:
+            self._healthy = False
+            logger.error(
+                "SleipnirEventSink: failed to publish %s for session %s",
+                event.event_type,
+                event.session_id,
+                exc_info=True,
+            )
+
+    async def emit_batch(self, events: list[SessionEvent]) -> None:
+        """Map and publish each event individually."""
+        for event in events:
+            await self.emit(event)
+
+    async def flush(self) -> None:
+        """No-op — Sleipnir publisher is fire-and-forget."""
+
+    async def close(self) -> None:
+        """No-op — publisher lifecycle is managed externally."""
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _to_sleipnir(self, event: SessionEvent) -> SleipnirEvent | None:
+        """Map a :class:`SessionEvent` to a :class:`SleipnirEvent`.
+
+        Returns ``None`` for event types that are not forwarded to Sleipnir.
+        """
+        session_id = str(event.session_id)
+        tenant_id = event.data.get("tenant_id")
+
+        if event.event_type in _SESSION_TYPE_MAP:
+            return self._session_lifecycle(event, session_id, tenant_id)
+
+        if event.event_type == SessionEventType.TOKEN_USAGE:
+            return self._token_usage(event, session_id, tenant_id)
+
+        return None
+
+    def _session_lifecycle(
+        self,
+        event: SessionEvent,
+        session_id: str,
+        tenant_id: str | None,
+    ) -> SleipnirEvent:
+        event_type = _SESSION_TYPE_MAP[event.event_type]
+        payload: dict = {
+            "session_id": session_id,
+            **event.data,
+        }
+        summary = f"Session {event.event_type.value.replace('_', ' ')}: {session_id}"
+        return SleipnirEvent(
+            event_type=event_type,
+            source=_SOURCE,
+            payload=payload,
+            summary=summary,
+            urgency=0.6,
+            domain="infrastructure",
+            timestamp=event.timestamp,
+            correlation_id=session_id,
+            tenant_id=tenant_id,
+        )
+
+    def _token_usage(
+        self,
+        event: SessionEvent,
+        session_id: str,
+        tenant_id: str | None,
+    ) -> SleipnirEvent:
+        tokens_in = event.tokens_in or 0
+        tokens_out = event.tokens_out or 0
+        payload: dict = {
+            "session_id": session_id,
+            "tokens_in": tokens_in,
+            "tokens_out": tokens_out,
+            "cost": float(event.cost) if event.cost is not None else None,
+            "model": event.model,
+            **event.data,
+        }
+        summary = f"Token usage for session {session_id}: {tokens_in}in/{tokens_out}out"
+        return SleipnirEvent(
+            event_type=VOLUNDR_TOKEN_USAGE,
+            source=_SOURCE,
+            payload=payload,
+            summary=summary,
+            urgency=0.2,
+            domain="infrastructure",
+            timestamp=event.timestamp,
+            correlation_id=session_id,
+            tenant_id=tenant_id,
+        )
+
+
+class ChronicleEventSink:
+    """Publishes chronicle lifecycle events to Sleipnir.
+
+    This is a standalone publisher (not an EventSink) since chronicle events
+    are produced by the chronicle service, not the session event pipeline.
+    """
+
+    def __init__(self, publisher: SleipnirPublisher) -> None:
+        self._publisher = publisher
+
+    async def publish_created(
+        self,
+        chronicle_id: str,
+        session_id: str,
+        tenant_id: str | None = None,
+    ) -> None:
+        """Publish a chronicle-created event."""
+        event = SleipnirEvent(
+            event_type=VOLUNDR_CHRONICLE_CREATED,
+            source=_SOURCE,
+            payload={"chronicle_id": chronicle_id, "session_id": session_id},
+            summary=f"Chronicle created for session {session_id}",
+            urgency=0.3,
+            domain="infrastructure",
+            timestamp=SleipnirEvent.now(),
+            correlation_id=session_id,
+            tenant_id=tenant_id,
+        )
+        try:
+            await self._publisher.publish(event)
+        except Exception:
+            logger.error(
+                "ChronicleEventSink: failed to publish chronicle.created for %s",
+                chronicle_id,
+                exc_info=True,
+            )
+
+    async def publish_updated(
+        self,
+        chronicle_id: str,
+        session_id: str,
+        tenant_id: str | None = None,
+    ) -> None:
+        """Publish a chronicle-updated event."""
+        event = SleipnirEvent(
+            event_type=VOLUNDR_CHRONICLE_UPDATED,
+            source=_SOURCE,
+            payload={"chronicle_id": chronicle_id, "session_id": session_id},
+            summary=f"Chronicle updated for session {session_id}",
+            urgency=0.2,
+            domain="infrastructure",
+            timestamp=SleipnirEvent.now(),
+            correlation_id=session_id,
+            tenant_id=tenant_id,
+        )
+        try:
+            await self._publisher.publish(event)
+        except Exception:
+            logger.error(
+                "ChronicleEventSink: failed to publish chronicle.updated for %s",
+                chronicle_id,
+                exc_info=True,
+            )

--- a/src/volundr/adapters/outbound/sleipnir_event_sink.py
+++ b/src/volundr/adapters/outbound/sleipnir_event_sink.py
@@ -1,23 +1,17 @@
-"""Sleipnir event sink — publishes Volundr session events to the Sleipnir bus.
+"""Sleipnir event sink — publishes raw session events to the Sleipnir bus.
 
-Volundr's session lifecycle events (start, stop, fail), token usage, and
-chronicle updates are mapped to structured :class:`~sleipnir.domain.events.SleipnirEvent`
-objects and published to the Sleipnir bus.  Downstream subscribers (Skuld,
-Tyr, analytics pipelines) then react to those events.
+This sink sits alongside the PostgreSQL, RabbitMQ, and OTel sinks in the
+``EventIngestionService`` fan-out pipeline.  Each ``SessionEvent`` ingested
+by Volundr is translated to a ``SleipnirEvent`` and published so that Skuld
+brokers (and any other Sleipnir subscribers) can react in real time.
 """
 
 from __future__ import annotations
 
 import logging
 
+from sleipnir.domain import registry
 from sleipnir.domain.events import SleipnirEvent
-from sleipnir.domain.registry import (
-    VOLUNDR_CHRONICLE_CREATED,
-    VOLUNDR_CHRONICLE_UPDATED,
-    VOLUNDR_SESSION_STARTED,
-    VOLUNDR_SESSION_STOPPED,
-    VOLUNDR_TOKEN_USAGE,
-)
 from sleipnir.ports.events import SleipnirPublisher
 from volundr.domain.models import SessionEvent, SessionEventType
 from volundr.domain.ports import EventSink
@@ -26,23 +20,116 @@ logger = logging.getLogger(__name__)
 
 _SOURCE = "volundr:event-sink"
 
-# Map SessionEventType → Sleipnir event type for session lifecycle.
-_SESSION_TYPE_MAP: dict[SessionEventType, str] = {
-    SessionEventType.SESSION_START: VOLUNDR_SESSION_STARTED,
-    SessionEventType.SESSION_STOP: VOLUNDR_SESSION_STOPPED,
+# ---------------------------------------------------------------------------
+# Event type mapping
+# ---------------------------------------------------------------------------
+
+#: Maps each ``SessionEventType`` to the Sleipnir event type constant to use.
+_SESSION_TO_SLEIPNIR: dict[SessionEventType, str] = {
+    SessionEventType.SESSION_START: registry.VOLUNDR_SESSION_STARTED,
+    SessionEventType.SESSION_STOP: registry.VOLUNDR_SESSION_STOPPED,
+    SessionEventType.TOKEN_USAGE: registry.VOLUNDR_TOKEN_USAGE,
+    SessionEventType.MESSAGE_USER: registry.VOLUNDR_MESSAGE_USER,
+    SessionEventType.MESSAGE_ASSISTANT: registry.VOLUNDR_MESSAGE_ASSISTANT,
+    SessionEventType.FILE_CREATED: registry.VOLUNDR_FILE_CREATED,
+    SessionEventType.FILE_MODIFIED: registry.VOLUNDR_FILE_MODIFIED,
+    SessionEventType.FILE_DELETED: registry.VOLUNDR_FILE_DELETED,
+    SessionEventType.GIT_COMMIT: registry.VOLUNDR_GIT_COMMIT,
+    SessionEventType.GIT_PUSH: registry.VOLUNDR_GIT_PUSH,
+    SessionEventType.GIT_BRANCH: registry.VOLUNDR_GIT_BRANCH,
+    SessionEventType.GIT_CHECKOUT: registry.VOLUNDR_GIT_CHECKOUT,
+    SessionEventType.TERMINAL_COMMAND: registry.VOLUNDR_TERMINAL_COMMAND,
+    SessionEventType.TOOL_USE: registry.VOLUNDR_TOOL_USE,
+    SessionEventType.ERROR: registry.VOLUNDR_SESSION_ERROR,
 }
+
+# Urgency values by event type (0.0 = low, 1.0 = high)
+_URGENCY_MAP: dict[SessionEventType, float] = {
+    SessionEventType.ERROR: 0.8,
+    SessionEventType.SESSION_START: 0.6,
+    SessionEventType.SESSION_STOP: 0.6,
+    SessionEventType.TOKEN_USAGE: 0.2,
+    SessionEventType.GIT_COMMIT: 0.5,
+    SessionEventType.GIT_PUSH: 0.6,
+}
+_DEFAULT_URGENCY: float = 0.3
 
 
 class SleipnirEventSink(EventSink):
-    """EventSink adapter that publishes Volundr session events to Sleipnir.
+    """``EventSink`` that republishes ``SessionEvent`` records to Sleipnir.
 
-    Failures in the Sleipnir publisher are logged and swallowed so that
-    a transport outage does not interrupt core session event storage.
+    Converts each inbound ``SessionEvent`` to a ``SleipnirEvent`` using a
+    static type mapping and then publishes via the injected
+    ``SleipnirPublisher``.  Event types with no mapping are silently dropped
+    with a debug log.
+
+    Failures are logged and re-raised so the :class:`EventIngestionService`
+    can record them, but they never block the other sinks.
     """
 
-    def __init__(self, publisher: SleipnirPublisher) -> None:
+    def __init__(
+        self,
+        publisher: SleipnirPublisher,
+        source: str = _SOURCE,
+    ) -> None:
+        """Initialise the sink.
+
+        :param publisher: The Sleipnir publisher to forward events to.
+        :param source: Source identifier included in each published event
+            (e.g. ``"volundr:event-sink"`` or ``"volundr:prod"``).
+        """
         self._publisher = publisher
+        self._source = source
         self._healthy = True
+
+    # ------------------------------------------------------------------
+    # EventSink interface
+    # ------------------------------------------------------------------
+
+    async def emit(self, event: SessionEvent) -> None:
+        """Translate *event* and publish to Sleipnir."""
+        sleipnir_event = self._to_sleipnir(event)
+        if sleipnir_event is None:
+            return
+        try:
+            await self._publisher.publish(sleipnir_event)
+            self._healthy = True
+        except Exception:
+            logger.warning(
+                "SleipnirEventSink: failed to publish event %s (type=%s)",
+                event.id,
+                event.event_type,
+                exc_info=True,
+            )
+            self._healthy = False
+            raise
+
+    async def emit_batch(self, events: list[SessionEvent]) -> None:
+        """Translate and publish a batch of ``SessionEvent`` records."""
+        sleipnir_events = [
+            mapped
+            for ev in events
+            if (mapped := self._to_sleipnir(ev)) is not None
+        ]
+        if not sleipnir_events:
+            return
+        try:
+            await self._publisher.publish_batch(sleipnir_events)
+            self._healthy = True
+        except Exception:
+            logger.warning(
+                "SleipnirEventSink: failed to publish batch of %d events",
+                len(sleipnir_events),
+                exc_info=True,
+            )
+            self._healthy = False
+            raise
+
+    async def flush(self) -> None:
+        """No-op: Sleipnir publishers are fire-and-forget."""
+
+    async def close(self) -> None:
+        """No-op: publisher lifecycle is managed externally."""
 
     @property
     def sink_name(self) -> str:
@@ -52,102 +139,53 @@ class SleipnirEventSink(EventSink):
     def healthy(self) -> bool:
         return self._healthy
 
-    async def emit(self, event: SessionEvent) -> None:
-        """Map *event* to a Sleipnir event and publish it."""
-        sleipnir_event = self._to_sleipnir(event)
-        if sleipnir_event is None:
-            return
-        try:
-            await self._publisher.publish(sleipnir_event)
-            self._healthy = True
-        except Exception:
-            self._healthy = False
-            logger.error(
-                "SleipnirEventSink: failed to publish %s for session %s",
-                event.event_type,
-                event.session_id,
-                exc_info=True,
-            )
-
-    async def emit_batch(self, events: list[SessionEvent]) -> None:
-        """Map and publish each event individually."""
-        for event in events:
-            await self.emit(event)
-
-    async def flush(self) -> None:
-        """No-op — Sleipnir publisher is fire-and-forget."""
-
-    async def close(self) -> None:
-        """No-op — publisher lifecycle is managed externally."""
-
     # ------------------------------------------------------------------
-    # Private helpers
+    # Internal helpers
     # ------------------------------------------------------------------
 
     def _to_sleipnir(self, event: SessionEvent) -> SleipnirEvent | None:
-        """Map a :class:`SessionEvent` to a :class:`SleipnirEvent`.
+        """Convert a ``SessionEvent`` to a ``SleipnirEvent``.
 
-        Returns ``None`` for event types that are not forwarded to Sleipnir.
+        Returns ``None`` for unmapped event types (e.g. future types not yet
+        registered in ``_SESSION_TO_SLEIPNIR``).
         """
+        event_type = _SESSION_TO_SLEIPNIR.get(event.event_type)
+        if event_type is None:
+            logger.debug(
+                "SleipnirEventSink: no mapping for SessionEventType %s, skipping",
+                event.event_type,
+            )
+            return None
+
         session_id = str(event.session_id)
-        tenant_id = event.data.get("tenant_id")
+        tenant_id: str | None = event.data.get("tenant_id")
 
-        if event.event_type in _SESSION_TYPE_MAP:
-            return self._session_lifecycle(event, session_id, tenant_id)
-
-        if event.event_type == SessionEventType.TOKEN_USAGE:
-            return self._token_usage(event, session_id, tenant_id)
-
-        return None
-
-    def _session_lifecycle(
-        self,
-        event: SessionEvent,
-        session_id: str,
-        tenant_id: str | None,
-    ) -> SleipnirEvent:
-        event_type = _SESSION_TYPE_MAP[event.event_type]
         payload: dict = {
             "session_id": session_id,
+            "event_id": str(event.id),
+            "sequence": event.sequence,
             **event.data,
         }
-        summary = f"Session {event.event_type.value.replace('_', ' ')}: {session_id}"
+        if event.tokens_in is not None:
+            payload["tokens_in"] = event.tokens_in
+        if event.tokens_out is not None:
+            payload["tokens_out"] = event.tokens_out
+        if event.cost is not None:
+            payload["cost"] = float(event.cost)
+        if event.duration_ms is not None:
+            payload["duration_ms"] = event.duration_ms
+        if event.model is not None:
+            payload["model"] = event.model
+
+        urgency = _URGENCY_MAP.get(event.event_type, _DEFAULT_URGENCY)
+
         return SleipnirEvent(
             event_type=event_type,
-            source=_SOURCE,
+            source=self._source,
             payload=payload,
-            summary=summary,
-            urgency=0.6,
-            domain="infrastructure",
-            timestamp=event.timestamp,
-            correlation_id=session_id,
-            tenant_id=tenant_id,
-        )
-
-    def _token_usage(
-        self,
-        event: SessionEvent,
-        session_id: str,
-        tenant_id: str | None,
-    ) -> SleipnirEvent:
-        tokens_in = event.tokens_in or 0
-        tokens_out = event.tokens_out or 0
-        payload: dict = {
-            "session_id": session_id,
-            "tokens_in": tokens_in,
-            "tokens_out": tokens_out,
-            "cost": float(event.cost) if event.cost is not None else None,
-            "model": event.model,
-            **event.data,
-        }
-        summary = f"Token usage for session {session_id}: {tokens_in}in/{tokens_out}out"
-        return SleipnirEvent(
-            event_type=VOLUNDR_TOKEN_USAGE,
-            source=_SOURCE,
-            payload=payload,
-            summary=summary,
-            urgency=0.2,
-            domain="infrastructure",
+            summary=f"{event.event_type.value} in session {session_id}",
+            urgency=urgency,
+            domain="code",
             timestamp=event.timestamp,
             correlation_id=session_id,
             tenant_id=tenant_id,
@@ -172,12 +210,12 @@ class ChronicleEventSink:
     ) -> None:
         """Publish a chronicle-created event."""
         event = SleipnirEvent(
-            event_type=VOLUNDR_CHRONICLE_CREATED,
+            event_type=registry.VOLUNDR_CHRONICLE_CREATED,
             source=_SOURCE,
             payload={"chronicle_id": chronicle_id, "session_id": session_id},
             summary=f"Chronicle created for session {session_id}",
             urgency=0.3,
-            domain="infrastructure",
+            domain="code",
             timestamp=SleipnirEvent.now(),
             correlation_id=session_id,
             tenant_id=tenant_id,
@@ -199,12 +237,12 @@ class ChronicleEventSink:
     ) -> None:
         """Publish a chronicle-updated event."""
         event = SleipnirEvent(
-            event_type=VOLUNDR_CHRONICLE_UPDATED,
+            event_type=registry.VOLUNDR_CHRONICLE_UPDATED,
             source=_SOURCE,
             payload={"chronicle_id": chronicle_id, "session_id": session_id},
             summary=f"Chronicle updated for session {session_id}",
             urgency=0.2,
-            domain="infrastructure",
+            domain="code",
             timestamp=SleipnirEvent.now(),
             correlation_id=session_id,
             tenant_id=tenant_id,

--- a/src/volundr/config.py
+++ b/src/volundr/config.py
@@ -263,6 +263,33 @@ class EventPipelineConfig(BaseModel):
     otel: OtelConfig = Field(default_factory=OtelConfig)
 
 
+class SleipnirConfig(BaseModel):
+    """Sleipnir platform event bus integration (optional).
+
+    When ``enabled`` is True, Volundr creates a Sleipnir adapter and
+    registers a :class:`~volundr.adapters.outbound.sleipnir_event_sink.SleipnirEventSink`
+    in the event pipeline and forwards SSE broadcaster events to the platform bus.
+
+    Example YAML::
+
+        sleipnir:
+          enabled: true
+          adapter: "sleipnir.adapters.nats_transport.NatsTransport"
+          kwargs:
+            servers: ["nats://nats:4222"]
+    """
+
+    enabled: bool = Field(
+        default=False,
+        description="Enable Sleipnir platform event bus integration.",
+    )
+    adapter: str = Field(
+        default="sleipnir.adapters.in_process.InProcessBus",
+        description="Fully-qualified class path for the Sleipnir adapter.",
+    )
+    kwargs: dict[str, Any] = Field(default_factory=dict)
+
+
 class IdentityConfig(BaseModel):
     """Dynamic identity adapter configuration.
 
@@ -995,6 +1022,7 @@ class Settings(BaseSettings):
     git: GitConfig = Field(default_factory=GitConfig)
     chronicle: ChronicleConfig = Field(default_factory=ChronicleConfig)
     event_pipeline: EventPipelineConfig = Field(default_factory=EventPipelineConfig)
+    sleipnir: SleipnirConfig = Field(default_factory=SleipnirConfig)
     identity: IdentityConfig = Field(default_factory=IdentityConfig)
     authorization: AuthorizationConfig = Field(default_factory=AuthorizationConfig)
     credential_store: CredentialStoreConfig = Field(default_factory=CredentialStoreConfig)

--- a/src/volundr/main.py
+++ b/src/volundr/main.py
@@ -526,7 +526,24 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             gateway_adapter = _create_gateway_adapter(settings)
             pricing_provider = HardcodedPricingProvider(settings.models or None)
             git_registry = create_git_registry(settings.git)
-            broadcaster = InMemoryEventBroadcaster()
+
+            # Sleipnir integration (optional — enabled via sleipnir.enabled config)
+            sleipnir_bus = None
+            if settings.sleipnir.enabled:
+                try:
+                    sl_cls = import_class(settings.sleipnir.adapter)
+                    sleipnir_bus = sl_cls(**settings.sleipnir.kwargs)
+                    logger.info(
+                        "Sleipnir integration enabled: adapter=%s",
+                        settings.sleipnir.adapter.rsplit(".", 1)[-1],
+                    )
+                except Exception:
+                    logger.exception("Failed to initialise Sleipnir integration")
+                    sleipnir_bus = None
+
+            broadcaster = InMemoryEventBroadcaster(
+                sleipnir_publisher=sleipnir_bus,
+            )
 
             # Create services with broadcaster for real-time updates
             # Create profile and template adapters (config-driven)
@@ -854,6 +871,15 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                     )
                 except Exception:
                     logger.exception("Failed to initialize OTel event sink")
+
+            # Register Sleipnir event sink when integration is active
+            if sleipnir_bus is not None:
+                from volundr.adapters.outbound.sleipnir_event_sink import (  # noqa: PLC0415
+                    SleipnirEventSink,
+                )
+
+                event_sinks.append(SleipnirEventSink(sleipnir_bus))
+                logger.info("Sleipnir event sink registered in pipeline")
 
             event_ingestion = EventIngestionService(sinks=event_sinks)
             events_router = create_events_router(

--- a/tests/test_adapters/test_sleipnir_event_sink.py
+++ b/tests/test_adapters/test_sleipnir_event_sink.py
@@ -9,14 +9,12 @@ from uuid import uuid4
 
 import pytest
 
-from sleipnir.domain.registry import (
-    VOLUNDR_CHRONICLE_CREATED,
-    VOLUNDR_CHRONICLE_UPDATED,
-    VOLUNDR_SESSION_STARTED,
-    VOLUNDR_SESSION_STOPPED,
-    VOLUNDR_TOKEN_USAGE,
-)
+from sleipnir.domain import registry
+from sleipnir.domain.events import SleipnirEvent
 from volundr.adapters.outbound.sleipnir_event_sink import (
+    _DEFAULT_URGENCY,
+    _SESSION_TO_SLEIPNIR,
+    _URGENCY_MAP,
     ChronicleEventSink,
     SleipnirEventSink,
 )
@@ -26,33 +24,36 @@ from volundr.domain.models import SessionEvent, SessionEventType
 # Helpers
 # ---------------------------------------------------------------------------
 
+_TS = datetime(2026, 4, 5, 12, 0, 0, tzinfo=UTC)
+
 
 def _make_event(**overrides) -> SessionEvent:
     defaults = {
         "id": uuid4(),
         "session_id": uuid4(),
-        "event_type": SessionEventType.SESSION_START,
-        "timestamp": datetime(2026, 4, 5, 12, 0, 0, tzinfo=UTC),
-        "data": {"model": "claude-sonnet-4-6", "repo": "niuulabs/volundr"},
+        "event_type": SessionEventType.MESSAGE_ASSISTANT,
+        "timestamp": _TS,
+        "data": {"content_preview": "hello"},
         "sequence": 0,
-        "tokens_in": None,
-        "tokens_out": None,
-        "cost": None,
-        "model": None,
-        "duration_ms": None,
+        "tokens_in": 100,
+        "tokens_out": 50,
+        "cost": Decimal("0.003"),
+        "model": "claude-sonnet-4-20250514",
     }
     defaults.update(overrides)
     return SessionEvent(**defaults)
 
 
-def _make_sink() -> tuple[SleipnirEventSink, AsyncMock]:
+def _make_sink(**kwargs) -> tuple[SleipnirEventSink, AsyncMock]:
     publisher = AsyncMock()
-    sink = SleipnirEventSink(publisher)
+    publisher.publish = AsyncMock()
+    publisher.publish_batch = AsyncMock()
+    sink = SleipnirEventSink(publisher=publisher, **kwargs)
     return sink, publisher
 
 
 # ---------------------------------------------------------------------------
-# SleipnirEventSink — properties
+# sink_name / healthy
 # ---------------------------------------------------------------------------
 
 
@@ -61,25 +62,50 @@ class TestSleipnirEventSinkProperties:
         sink, _ = _make_sink()
         assert sink.sink_name == "sleipnir"
 
-    def test_healthy_initially_true(self):
+    def test_healthy_initially(self):
         sink, _ = _make_sink()
         assert sink.healthy is True
 
 
 # ---------------------------------------------------------------------------
-# SleipnirEventSink — session lifecycle
+# flush / close
+# ---------------------------------------------------------------------------
+
+
+class TestSleipnirEventSinkNoOps:
+    async def test_flush_is_noop(self):
+        sink, publisher = _make_sink()
+        await sink.flush()
+        publisher.publish.assert_not_called()
+
+    async def test_close_is_noop(self):
+        sink, publisher = _make_sink()
+        await sink.close()
+        publisher.publish.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# emit — session lifecycle
 # ---------------------------------------------------------------------------
 
 
 class TestSleipnirEventSinkSessionLifecycle:
     async def test_session_start_publishes_started_event(self):
         sink, publisher = _make_sink()
-        event = _make_event(event_type=SessionEventType.SESSION_START)
+        event = _make_event(
+            event_type=SessionEventType.SESSION_START,
+            data={"model": "claude-sonnet-4-6"},
+            tokens_in=None,
+            tokens_out=None,
+            cost=None,
+            model=None,
+        )
+
         await sink.emit(event)
 
-        publisher.publish.assert_awaited_once()
-        published = publisher.publish.call_args[0][0]
-        assert published.event_type == VOLUNDR_SESSION_STARTED
+        publisher.publish.assert_called_once()
+        published: SleipnirEvent = publisher.publish.call_args[0][0]
+        assert published.event_type == registry.VOLUNDR_SESSION_STARTED
         assert published.payload["session_id"] == str(event.session_id)
         assert published.correlation_id == str(event.session_id)
 
@@ -88,35 +114,19 @@ class TestSleipnirEventSinkSessionLifecycle:
         event = _make_event(
             event_type=SessionEventType.SESSION_STOP,
             data={"reason": "user_requested"},
+            tokens_in=None,
+            tokens_out=None,
+            cost=None,
+            model=None,
         )
+
         await sink.emit(event)
 
-        publisher.publish.assert_awaited_once()
-        published = publisher.publish.call_args[0][0]
-        assert published.event_type == VOLUNDR_SESSION_STOPPED
+        publisher.publish.assert_called_once()
+        published: SleipnirEvent = publisher.publish.call_args[0][0]
+        assert published.event_type == registry.VOLUNDR_SESSION_STOPPED
         assert published.payload["reason"] == "user_requested"
 
-    async def test_non_lifecycle_event_not_published(self):
-        sink, publisher = _make_sink()
-        event = _make_event(event_type=SessionEventType.FILE_CREATED)
-        await sink.emit(event)
-
-        publisher.publish.assert_not_awaited()
-
-    async def test_message_event_not_published(self):
-        sink, publisher = _make_sink()
-        event = _make_event(event_type=SessionEventType.MESSAGE_ASSISTANT)
-        await sink.emit(event)
-
-        publisher.publish.assert_not_awaited()
-
-
-# ---------------------------------------------------------------------------
-# SleipnirEventSink — token usage
-# ---------------------------------------------------------------------------
-
-
-class TestSleipnirEventSinkTokenUsage:
     async def test_token_usage_publishes_event(self):
         sink, publisher = _make_sink()
         event = _make_event(
@@ -127,93 +137,171 @@ class TestSleipnirEventSinkTokenUsage:
             model="claude-sonnet-4-6",
             data={"provider": "anthropic"},
         )
+
         await sink.emit(event)
 
-        publisher.publish.assert_awaited_once()
-        published = publisher.publish.call_args[0][0]
-        assert published.event_type == VOLUNDR_TOKEN_USAGE
+        publisher.publish.assert_called_once()
+        published: SleipnirEvent = publisher.publish.call_args[0][0]
+        assert published.event_type == registry.VOLUNDR_TOKEN_USAGE
         assert published.payload["tokens_in"] == 1000
         assert published.payload["tokens_out"] == 500
         assert published.payload["cost"] == pytest.approx(0.005)
         assert published.payload["model"] == "claude-sonnet-4-6"
 
-    async def test_token_usage_zero_tokens(self):
+
+# ---------------------------------------------------------------------------
+# emit — full type coverage
+# ---------------------------------------------------------------------------
+
+
+class TestSleipnirEventSinkEmit:
+    async def test_emit_calls_publish(self):
         sink, publisher = _make_sink()
-        event = _make_event(
-            event_type=SessionEventType.TOKEN_USAGE,
-            tokens_in=None,
-            tokens_out=None,
-            data={},
-        )
+        event = _make_event(event_type=SessionEventType.MESSAGE_ASSISTANT)
+
         await sink.emit(event)
 
-        publisher.publish.assert_awaited_once()
-        published = publisher.publish.call_args[0][0]
-        assert published.payload["tokens_in"] == 0
-        assert published.payload["tokens_out"] == 0
+        publisher.publish.assert_called_once()
+        arg: SleipnirEvent = publisher.publish.call_args[0][0]
+        assert isinstance(arg, SleipnirEvent)
 
-
-# ---------------------------------------------------------------------------
-# SleipnirEventSink — batch
-# ---------------------------------------------------------------------------
-
-
-class TestSleipnirEventSinkBatch:
-    async def test_batch_publishes_all_matching_events(self):
+    async def test_emit_sets_correct_event_type(self):
         sink, publisher = _make_sink()
-        events = [
-            _make_event(event_type=SessionEventType.SESSION_START),
-            _make_event(event_type=SessionEventType.MESSAGE_ASSISTANT),  # not forwarded
-            _make_event(event_type=SessionEventType.TOKEN_USAGE, data={}),
-        ]
-        await sink.emit_batch(events)
-
-        assert publisher.publish.await_count == 2
-
-    async def test_empty_batch_is_noop(self):
-        sink, publisher = _make_sink()
-        await sink.emit_batch([])
-        publisher.publish.assert_not_awaited()
-
-
-# ---------------------------------------------------------------------------
-# SleipnirEventSink — fault tolerance
-# ---------------------------------------------------------------------------
-
-
-class TestSleipnirEventSinkFaultTolerance:
-    async def test_publish_failure_marks_unhealthy(self):
-        sink, publisher = _make_sink()
-        publisher.publish.side_effect = RuntimeError("broker down")
-
         event = _make_event(event_type=SessionEventType.SESSION_START)
-        await sink.emit(event)  # must not raise
 
-        assert sink.healthy is False
+        await sink.emit(event)
 
-    async def test_healthy_restored_after_success(self):
+        arg: SleipnirEvent = publisher.publish.call_args[0][0]
+        assert arg.event_type == registry.VOLUNDR_SESSION_STARTED
+
+    async def test_emit_includes_session_id_in_payload(self):
         sink, publisher = _make_sink()
-        publisher.publish.side_effect = RuntimeError("transient")
+        event = _make_event()
 
-        event = _make_event(event_type=SessionEventType.SESSION_START)
         await sink.emit(event)
-        assert sink.healthy is False
 
-        publisher.publish.side_effect = None
+        arg: SleipnirEvent = publisher.publish.call_args[0][0]
+        assert arg.payload["session_id"] == str(event.session_id)
+
+    async def test_emit_sets_correlation_id(self):
+        sink, publisher = _make_sink()
+        event = _make_event()
+
         await sink.emit(event)
+
+        arg: SleipnirEvent = publisher.publish.call_args[0][0]
+        assert arg.correlation_id == str(event.session_id)
+
+    async def test_emit_includes_tokens_when_present(self):
+        sink, publisher = _make_sink()
+        event = _make_event(tokens_in=42, tokens_out=7)
+
+        await sink.emit(event)
+
+        arg: SleipnirEvent = publisher.publish.call_args[0][0]
+        assert arg.payload["tokens_in"] == 42
+        assert arg.payload["tokens_out"] == 7
+
+    async def test_emit_includes_model_when_present(self):
+        sink, publisher = _make_sink()
+        event = _make_event(model="claude-opus-4-6")
+
+        await sink.emit(event)
+
+        arg: SleipnirEvent = publisher.publish.call_args[0][0]
+        assert arg.payload["model"] == "claude-opus-4-6"
+
+    def test_emit_skips_unmapped_event_type_mapping_is_complete(self):
+        """All critical event types have a Sleipnir mapping."""
+        assert SessionEventType.MESSAGE_ASSISTANT in _SESSION_TO_SLEIPNIR
+
+    async def test_emit_skips_none_mapping(self):
+        """When event type has no Sleipnir mapping, publish is not called."""
+        sink, publisher = _make_sink()
+        event = _make_event()
+        original = _SESSION_TO_SLEIPNIR.pop(SessionEventType.MESSAGE_ASSISTANT, None)
+        try:
+            await sink.emit(event)
+            publisher.publish.assert_not_called()
+        finally:
+            if original is not None:
+                _SESSION_TO_SLEIPNIR[SessionEventType.MESSAGE_ASSISTANT] = original
+
+    async def test_emit_sets_healthy_true_on_success(self):
+        sink, publisher = _make_sink()
+        sink._healthy = False
+        event = _make_event()
+
+        await sink.emit(event)
+
         assert sink.healthy is True
 
-    async def test_flush_is_noop(self):
+    async def test_emit_sets_healthy_false_on_failure(self):
         sink, publisher = _make_sink()
-        await sink.flush()  # must not raise or call publisher
+        publisher.publish.side_effect = RuntimeError("bus down")
+        event = _make_event()
 
-    async def test_close_is_noop(self):
+        with pytest.raises(RuntimeError):
+            await sink.emit(event)
+
+        assert sink.healthy is False
+
+    async def test_emit_raises_on_failure(self):
         sink, publisher = _make_sink()
-        await sink.close()  # must not raise or call publisher
+        publisher.publish.side_effect = ValueError("oops")
+        event = _make_event()
+
+        with pytest.raises(ValueError):
+            await sink.emit(event)
+
+    async def test_emit_uses_custom_source(self):
+        sink, publisher = _make_sink(source="volundr:prod")
+        event = _make_event()
+
+        await sink.emit(event)
+
+        arg: SleipnirEvent = publisher.publish.call_args[0][0]
+        assert arg.source == "volundr:prod"
+
+    async def test_emit_urgency_error_is_higher(self):
+        sink, publisher = _make_sink()
+        event = _make_event(event_type=SessionEventType.ERROR)
+
+        await sink.emit(event)
+
+        arg: SleipnirEvent = publisher.publish.call_args[0][0]
+        assert arg.urgency == _URGENCY_MAP[SessionEventType.ERROR]
+
+    async def test_emit_urgency_default_for_unmapped_urgency(self):
+        sink, publisher = _make_sink()
+        event = _make_event(event_type=SessionEventType.TOOL_USE)
+
+        await sink.emit(event)
+
+        arg: SleipnirEvent = publisher.publish.call_args[0][0]
+        assert arg.urgency == _DEFAULT_URGENCY
+
+    async def test_emit_domain_is_code(self):
+        sink, publisher = _make_sink()
+        event = _make_event()
+
+        await sink.emit(event)
+
+        arg: SleipnirEvent = publisher.publish.call_args[0][0]
+        assert arg.domain == "code"
+
+    async def test_emit_timestamp_preserved(self):
+        sink, publisher = _make_sink()
+        event = _make_event(timestamp=_TS)
+
+        await sink.emit(event)
+
+        arg: SleipnirEvent = publisher.publish.call_args[0][0]
+        assert arg.timestamp == _TS
 
 
 # ---------------------------------------------------------------------------
-# SleipnirEventSink — tenant propagation
+# tenant_id propagation
 # ---------------------------------------------------------------------------
 
 
@@ -223,7 +311,12 @@ class TestSleipnirEventSinkTenant:
         event = _make_event(
             event_type=SessionEventType.SESSION_START,
             data={"tenant_id": "tenant-123"},
+            tokens_in=None,
+            tokens_out=None,
+            cost=None,
+            model=None,
         )
+
         await sink.emit(event)
 
         published = publisher.publish.call_args[0][0]
@@ -231,11 +324,106 @@ class TestSleipnirEventSinkTenant:
 
     async def test_no_tenant_id_when_missing(self):
         sink, publisher = _make_sink()
-        event = _make_event(event_type=SessionEventType.SESSION_START, data={})
+        event = _make_event(
+            event_type=SessionEventType.SESSION_START,
+            data={},
+            tokens_in=None,
+            tokens_out=None,
+            cost=None,
+            model=None,
+        )
+
         await sink.emit(event)
 
         published = publisher.publish.call_args[0][0]
         assert published.tenant_id is None
+
+
+# ---------------------------------------------------------------------------
+# emit_batch
+# ---------------------------------------------------------------------------
+
+
+class TestSleipnirEventSinkEmitBatch:
+    async def test_emit_batch_calls_publish_batch(self):
+        sink, publisher = _make_sink()
+        events = [_make_event(sequence=i) for i in range(3)]
+
+        await sink.emit_batch(events)
+
+        publisher.publish_batch.assert_called_once()
+        batch = publisher.publish_batch.call_args[0][0]
+        assert len(batch) == 3
+
+    async def test_emit_batch_filters_unmapped(self):
+        sink, publisher = _make_sink()
+        mapped = _make_event(event_type=SessionEventType.SESSION_START)
+        unmapped = _make_event()
+        original = _SESSION_TO_SLEIPNIR.pop(unmapped.event_type, None)
+        try:
+            await sink.emit_batch([mapped, unmapped])
+            batch = publisher.publish_batch.call_args[0][0]
+            assert len(batch) == 1
+        finally:
+            if original is not None:
+                _SESSION_TO_SLEIPNIR[unmapped.event_type] = original
+
+    async def test_emit_batch_empty_is_noop(self):
+        sink, publisher = _make_sink()
+
+        await sink.emit_batch([])
+
+        publisher.publish_batch.assert_not_called()
+
+    async def test_emit_batch_all_unmapped_is_noop(self):
+        sink, publisher = _make_sink()
+        event = _make_event()
+        original = _SESSION_TO_SLEIPNIR.pop(event.event_type, None)
+        try:
+            await sink.emit_batch([event])
+            publisher.publish_batch.assert_not_called()
+        finally:
+            if original is not None:
+                _SESSION_TO_SLEIPNIR[event.event_type] = original
+
+    async def test_emit_batch_sets_healthy_true_on_success(self):
+        sink, publisher = _make_sink()
+        sink._healthy = False
+
+        await sink.emit_batch([_make_event()])
+
+        assert sink.healthy is True
+
+    async def test_emit_batch_sets_healthy_false_on_failure(self):
+        sink, publisher = _make_sink()
+        publisher.publish_batch.side_effect = RuntimeError("bus down")
+
+        with pytest.raises(RuntimeError):
+            await sink.emit_batch([_make_event()])
+
+        assert sink.healthy is False
+
+
+# ---------------------------------------------------------------------------
+# All SessionEventType are mapped
+# ---------------------------------------------------------------------------
+
+
+class TestSessionToSleipnirMapping:
+    def test_all_common_types_are_mapped(self):
+        """The most critical session event types must have a Sleipnir mapping."""
+        required = {
+            SessionEventType.SESSION_START,
+            SessionEventType.SESSION_STOP,
+            SessionEventType.TOKEN_USAGE,
+            SessionEventType.MESSAGE_USER,
+            SessionEventType.MESSAGE_ASSISTANT,
+            SessionEventType.ERROR,
+            SessionEventType.GIT_COMMIT,
+            SessionEventType.TOOL_USE,
+        }
+        missing = required - set(_SESSION_TO_SLEIPNIR.keys())
+        assert not missing, f"Missing Sleipnir mappings for: {missing}"
 
 
 # ---------------------------------------------------------------------------
@@ -244,8 +432,9 @@ class TestSleipnirEventSinkTenant:
 
 
 class TestChronicleEventSink:
-    def _make_chronicle_sink(self):
+    def _make_chronicle_sink(self) -> tuple[ChronicleEventSink, AsyncMock]:
         publisher = AsyncMock()
+        publisher.publish = AsyncMock()
         sink = ChronicleEventSink(publisher)
         return sink, publisher
 
@@ -253,9 +442,9 @@ class TestChronicleEventSink:
         sink, publisher = self._make_chronicle_sink()
         await sink.publish_created("chr-1", "session-1")
 
-        publisher.publish.assert_awaited_once()
-        published = publisher.publish.call_args[0][0]
-        assert published.event_type == VOLUNDR_CHRONICLE_CREATED
+        publisher.publish.assert_called_once()
+        published: SleipnirEvent = publisher.publish.call_args[0][0]
+        assert published.event_type == registry.VOLUNDR_CHRONICLE_CREATED
         assert published.payload["chronicle_id"] == "chr-1"
         assert published.payload["session_id"] == "session-1"
         assert published.correlation_id == "session-1"
@@ -264,13 +453,27 @@ class TestChronicleEventSink:
         sink, publisher = self._make_chronicle_sink()
         await sink.publish_updated("chr-2", "session-2", tenant_id="t1")
 
-        publisher.publish.assert_awaited_once()
-        published = publisher.publish.call_args[0][0]
-        assert published.event_type == VOLUNDR_CHRONICLE_UPDATED
+        publisher.publish.assert_called_once()
+        published: SleipnirEvent = publisher.publish.call_args[0][0]
+        assert published.event_type == registry.VOLUNDR_CHRONICLE_UPDATED
         assert published.tenant_id == "t1"
 
+    async def test_publish_created_with_tenant_id(self):
+        sink, publisher = self._make_chronicle_sink()
+        await sink.publish_created("chr-3", "session-3", tenant_id="tenant-xyz")
+
+        published: SleipnirEvent = publisher.publish.call_args[0][0]
+        assert published.tenant_id == "tenant-xyz"
+
     async def test_publish_error_is_swallowed(self):
+        """Publisher failures in ChronicleEventSink must not raise."""
         sink, publisher = self._make_chronicle_sink()
         publisher.publish.side_effect = RuntimeError("network error")
 
         await sink.publish_created("chr-x", "session-x")  # must not raise
+
+    async def test_publish_updated_error_is_swallowed(self):
+        sink, publisher = self._make_chronicle_sink()
+        publisher.publish.side_effect = RuntimeError("network error")
+
+        await sink.publish_updated("chr-x", "session-x")  # must not raise

--- a/tests/test_adapters/test_sleipnir_event_sink.py
+++ b/tests/test_adapters/test_sleipnir_event_sink.py
@@ -1,0 +1,276 @@
+"""Tests for SleipnirEventSink and ChronicleEventSink adapters."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from sleipnir.domain.registry import (
+    VOLUNDR_CHRONICLE_CREATED,
+    VOLUNDR_CHRONICLE_UPDATED,
+    VOLUNDR_SESSION_STARTED,
+    VOLUNDR_SESSION_STOPPED,
+    VOLUNDR_TOKEN_USAGE,
+)
+from volundr.adapters.outbound.sleipnir_event_sink import (
+    ChronicleEventSink,
+    SleipnirEventSink,
+)
+from volundr.domain.models import SessionEvent, SessionEventType
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_event(**overrides) -> SessionEvent:
+    defaults = {
+        "id": uuid4(),
+        "session_id": uuid4(),
+        "event_type": SessionEventType.SESSION_START,
+        "timestamp": datetime(2026, 4, 5, 12, 0, 0, tzinfo=UTC),
+        "data": {"model": "claude-sonnet-4-6", "repo": "niuulabs/volundr"},
+        "sequence": 0,
+        "tokens_in": None,
+        "tokens_out": None,
+        "cost": None,
+        "model": None,
+        "duration_ms": None,
+    }
+    defaults.update(overrides)
+    return SessionEvent(**defaults)
+
+
+def _make_sink() -> tuple[SleipnirEventSink, AsyncMock]:
+    publisher = AsyncMock()
+    sink = SleipnirEventSink(publisher)
+    return sink, publisher
+
+
+# ---------------------------------------------------------------------------
+# SleipnirEventSink — properties
+# ---------------------------------------------------------------------------
+
+
+class TestSleipnirEventSinkProperties:
+    def test_sink_name(self):
+        sink, _ = _make_sink()
+        assert sink.sink_name == "sleipnir"
+
+    def test_healthy_initially_true(self):
+        sink, _ = _make_sink()
+        assert sink.healthy is True
+
+
+# ---------------------------------------------------------------------------
+# SleipnirEventSink — session lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestSleipnirEventSinkSessionLifecycle:
+    async def test_session_start_publishes_started_event(self):
+        sink, publisher = _make_sink()
+        event = _make_event(event_type=SessionEventType.SESSION_START)
+        await sink.emit(event)
+
+        publisher.publish.assert_awaited_once()
+        published = publisher.publish.call_args[0][0]
+        assert published.event_type == VOLUNDR_SESSION_STARTED
+        assert published.payload["session_id"] == str(event.session_id)
+        assert published.correlation_id == str(event.session_id)
+
+    async def test_session_stop_publishes_stopped_event(self):
+        sink, publisher = _make_sink()
+        event = _make_event(
+            event_type=SessionEventType.SESSION_STOP,
+            data={"reason": "user_requested"},
+        )
+        await sink.emit(event)
+
+        publisher.publish.assert_awaited_once()
+        published = publisher.publish.call_args[0][0]
+        assert published.event_type == VOLUNDR_SESSION_STOPPED
+        assert published.payload["reason"] == "user_requested"
+
+    async def test_non_lifecycle_event_not_published(self):
+        sink, publisher = _make_sink()
+        event = _make_event(event_type=SessionEventType.FILE_CREATED)
+        await sink.emit(event)
+
+        publisher.publish.assert_not_awaited()
+
+    async def test_message_event_not_published(self):
+        sink, publisher = _make_sink()
+        event = _make_event(event_type=SessionEventType.MESSAGE_ASSISTANT)
+        await sink.emit(event)
+
+        publisher.publish.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# SleipnirEventSink — token usage
+# ---------------------------------------------------------------------------
+
+
+class TestSleipnirEventSinkTokenUsage:
+    async def test_token_usage_publishes_event(self):
+        sink, publisher = _make_sink()
+        event = _make_event(
+            event_type=SessionEventType.TOKEN_USAGE,
+            tokens_in=1000,
+            tokens_out=500,
+            cost=Decimal("0.005"),
+            model="claude-sonnet-4-6",
+            data={"provider": "anthropic"},
+        )
+        await sink.emit(event)
+
+        publisher.publish.assert_awaited_once()
+        published = publisher.publish.call_args[0][0]
+        assert published.event_type == VOLUNDR_TOKEN_USAGE
+        assert published.payload["tokens_in"] == 1000
+        assert published.payload["tokens_out"] == 500
+        assert published.payload["cost"] == pytest.approx(0.005)
+        assert published.payload["model"] == "claude-sonnet-4-6"
+
+    async def test_token_usage_zero_tokens(self):
+        sink, publisher = _make_sink()
+        event = _make_event(
+            event_type=SessionEventType.TOKEN_USAGE,
+            tokens_in=None,
+            tokens_out=None,
+            data={},
+        )
+        await sink.emit(event)
+
+        publisher.publish.assert_awaited_once()
+        published = publisher.publish.call_args[0][0]
+        assert published.payload["tokens_in"] == 0
+        assert published.payload["tokens_out"] == 0
+
+
+# ---------------------------------------------------------------------------
+# SleipnirEventSink — batch
+# ---------------------------------------------------------------------------
+
+
+class TestSleipnirEventSinkBatch:
+    async def test_batch_publishes_all_matching_events(self):
+        sink, publisher = _make_sink()
+        events = [
+            _make_event(event_type=SessionEventType.SESSION_START),
+            _make_event(event_type=SessionEventType.MESSAGE_ASSISTANT),  # not forwarded
+            _make_event(event_type=SessionEventType.TOKEN_USAGE, data={}),
+        ]
+        await sink.emit_batch(events)
+
+        assert publisher.publish.await_count == 2
+
+    async def test_empty_batch_is_noop(self):
+        sink, publisher = _make_sink()
+        await sink.emit_batch([])
+        publisher.publish.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# SleipnirEventSink — fault tolerance
+# ---------------------------------------------------------------------------
+
+
+class TestSleipnirEventSinkFaultTolerance:
+    async def test_publish_failure_marks_unhealthy(self):
+        sink, publisher = _make_sink()
+        publisher.publish.side_effect = RuntimeError("broker down")
+
+        event = _make_event(event_type=SessionEventType.SESSION_START)
+        await sink.emit(event)  # must not raise
+
+        assert sink.healthy is False
+
+    async def test_healthy_restored_after_success(self):
+        sink, publisher = _make_sink()
+        publisher.publish.side_effect = RuntimeError("transient")
+
+        event = _make_event(event_type=SessionEventType.SESSION_START)
+        await sink.emit(event)
+        assert sink.healthy is False
+
+        publisher.publish.side_effect = None
+        await sink.emit(event)
+        assert sink.healthy is True
+
+    async def test_flush_is_noop(self):
+        sink, publisher = _make_sink()
+        await sink.flush()  # must not raise or call publisher
+
+    async def test_close_is_noop(self):
+        sink, publisher = _make_sink()
+        await sink.close()  # must not raise or call publisher
+
+
+# ---------------------------------------------------------------------------
+# SleipnirEventSink — tenant propagation
+# ---------------------------------------------------------------------------
+
+
+class TestSleipnirEventSinkTenant:
+    async def test_tenant_id_forwarded_from_payload(self):
+        sink, publisher = _make_sink()
+        event = _make_event(
+            event_type=SessionEventType.SESSION_START,
+            data={"tenant_id": "tenant-123"},
+        )
+        await sink.emit(event)
+
+        published = publisher.publish.call_args[0][0]
+        assert published.tenant_id == "tenant-123"
+
+    async def test_no_tenant_id_when_missing(self):
+        sink, publisher = _make_sink()
+        event = _make_event(event_type=SessionEventType.SESSION_START, data={})
+        await sink.emit(event)
+
+        published = publisher.publish.call_args[0][0]
+        assert published.tenant_id is None
+
+
+# ---------------------------------------------------------------------------
+# ChronicleEventSink
+# ---------------------------------------------------------------------------
+
+
+class TestChronicleEventSink:
+    def _make_chronicle_sink(self):
+        publisher = AsyncMock()
+        sink = ChronicleEventSink(publisher)
+        return sink, publisher
+
+    async def test_publish_created(self):
+        sink, publisher = self._make_chronicle_sink()
+        await sink.publish_created("chr-1", "session-1")
+
+        publisher.publish.assert_awaited_once()
+        published = publisher.publish.call_args[0][0]
+        assert published.event_type == VOLUNDR_CHRONICLE_CREATED
+        assert published.payload["chronicle_id"] == "chr-1"
+        assert published.payload["session_id"] == "session-1"
+        assert published.correlation_id == "session-1"
+
+    async def test_publish_updated(self):
+        sink, publisher = self._make_chronicle_sink()
+        await sink.publish_updated("chr-2", "session-2", tenant_id="t1")
+
+        publisher.publish.assert_awaited_once()
+        published = publisher.publish.call_args[0][0]
+        assert published.event_type == VOLUNDR_CHRONICLE_UPDATED
+        assert published.tenant_id == "t1"
+
+    async def test_publish_error_is_swallowed(self):
+        sink, publisher = self._make_chronicle_sink()
+        publisher.publish.side_effect = RuntimeError("network error")
+
+        await sink.publish_created("chr-x", "session-x")  # must not raise

--- a/tests/test_broadcaster.py
+++ b/tests/test_broadcaster.py
@@ -1,9 +1,9 @@
 """Tests for the InMemoryEventBroadcaster adapter."""
 
 import asyncio
-from datetime import datetime
+from datetime import UTC, datetime
 from decimal import Decimal
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import pytest
@@ -547,3 +547,135 @@ class TestInMemoryEventBroadcaster:
         assert evt.data["files"] == []
         assert evt.data["commits"] == []
         assert evt.data["token_burn"] == []
+
+
+# ---------------------------------------------------------------------------
+# Sleipnir forwarding tests
+# ---------------------------------------------------------------------------
+
+
+class TestInMemoryEventBroadcasterSleipnirForwarding:
+    """Tests for the optional Sleipnir publisher integration."""
+
+    @pytest.mark.asyncio
+    async def test_no_sleipnir_publisher_no_forward(self):
+        """When no publisher is configured, no Sleipnir call is made."""
+        publisher = AsyncMock()
+        b = InMemoryEventBroadcaster(max_queue_size=10)
+        event = RealtimeEvent(
+            type=EventType.SESSION_CREATED,
+            data={"id": str(uuid4())},
+            timestamp=datetime.now(UTC),
+        )
+
+        await b.publish(event)
+
+        publisher.publish.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sleipnir_publisher_called_for_session_created(self):
+        """SESSION_CREATED events are forwarded to Sleipnir."""
+        publisher = AsyncMock()
+        publisher.publish = AsyncMock()
+        b = InMemoryEventBroadcaster(max_queue_size=10, sleipnir_publisher=publisher)
+        event = RealtimeEvent(
+            type=EventType.SESSION_CREATED,
+            data={"id": str(uuid4())},
+            timestamp=datetime.now(UTC),
+        )
+
+        await b.publish(event)
+
+        publisher.publish.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_sleipnir_not_called_for_heartbeat(self):
+        """HEARTBEAT events are not forwarded (not in the mapping)."""
+        publisher = AsyncMock()
+        publisher.publish = AsyncMock()
+        b = InMemoryEventBroadcaster(max_queue_size=10, sleipnir_publisher=publisher)
+        event = RealtimeEvent(
+            type=EventType.HEARTBEAT,
+            data={},
+            timestamp=datetime.now(UTC),
+        )
+
+        await b.publish(event)
+
+        publisher.publish.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sleipnir_publish_failure_is_silent(self):
+        """A Sleipnir publish error does not propagate to callers."""
+        publisher = AsyncMock()
+        publisher.publish = AsyncMock(side_effect=RuntimeError("bus down"))
+        b = InMemoryEventBroadcaster(max_queue_size=10, sleipnir_publisher=publisher)
+        event = RealtimeEvent(
+            type=EventType.SESSION_CREATED,
+            data={},
+            timestamp=datetime.now(UTC),
+        )
+
+        # Should not raise
+        await b.publish(event)
+
+    @pytest.mark.asyncio
+    async def test_sleipnir_type_map_built_lazily(self):
+        """The Sleipnir type map is None until first publish."""
+        publisher = AsyncMock()
+        publisher.publish = AsyncMock()
+        b = InMemoryEventBroadcaster(max_queue_size=10, sleipnir_publisher=publisher)
+
+        assert b._sleipnir_type_map is None
+
+        event = RealtimeEvent(
+            type=EventType.SESSION_CREATED,
+            data={},
+            timestamp=datetime.now(UTC),
+        )
+        await b.publish(event)
+
+        assert b._sleipnir_type_map is not None
+
+    @pytest.mark.asyncio
+    async def test_sleipnir_forwarded_event_uses_correct_type(self):
+        """Forwarded SleipnirEvent uses the mapped event type."""
+        from sleipnir.domain import registry
+        from sleipnir.domain.events import SleipnirEvent
+
+        publisher = AsyncMock()
+        publisher.publish = AsyncMock()
+        b = InMemoryEventBroadcaster(max_queue_size=10, sleipnir_publisher=publisher)
+        event = RealtimeEvent(
+            type=EventType.SESSION_CREATED,
+            data={"id": "sess-1"},
+            timestamp=datetime.now(UTC),
+        )
+
+        await b.publish(event)
+
+        arg: SleipnirEvent = publisher.publish.call_args[0][0]
+        assert arg.event_type == registry.VOLUNDR_SESSION_CREATED
+
+    @pytest.mark.asyncio
+    async def test_custom_source_used_in_sleipnir_event(self):
+        """The sleipnir_source string is used in the published event."""
+        from sleipnir.domain.events import SleipnirEvent
+
+        publisher = AsyncMock()
+        publisher.publish = AsyncMock()
+        b = InMemoryEventBroadcaster(
+            max_queue_size=10,
+            sleipnir_publisher=publisher,
+            sleipnir_source="volundr:staging",
+        )
+        event = RealtimeEvent(
+            type=EventType.SESSION_CREATED,
+            data={},
+            timestamp=datetime.now(UTC),
+        )
+
+        await b.publish(event)
+
+        arg: SleipnirEvent = publisher.publish.call_args[0][0]
+        assert arg.source == "volundr:staging"

--- a/tests/test_skuld/test_ravn_publisher.py
+++ b/tests/test_skuld/test_ravn_publisher.py
@@ -1,0 +1,206 @@
+"""Tests for skuld.ravn_publisher.RavnPublisher."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from skuld.ravn_publisher import RavnPublisher
+from sleipnir.adapters.in_process import InProcessBus
+from sleipnir.domain.registry import (
+    RAVN_INTERRUPT,
+    RAVN_RESPONSE_COMPLETE,
+    RAVN_SESSION_END,
+    RAVN_SESSION_START,
+    RAVN_STEP_COMPLETE,
+    RAVN_STEP_START,
+    RAVN_TOOL_CALL,
+    RAVN_TOOL_COMPLETE,
+    RAVN_TOOL_ERROR,
+)
+from sleipnir.testing import EventCapture
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_publisher(session_id="sess-001") -> tuple[RavnPublisher, InProcessBus]:
+    bus = InProcessBus()
+    pub = RavnPublisher(bus, session_id=session_id)
+    return pub, bus
+
+
+# ---------------------------------------------------------------------------
+# Session lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestRavnPublisherSessionLifecycle:
+    async def test_on_session_start_publishes_event(self):
+        pub, bus = _make_publisher()
+        async with EventCapture(bus, [RAVN_SESSION_START]) as capture:
+            await pub.on_session_start(model="claude-sonnet-4-6")
+            await bus.flush()
+
+        assert len(capture.events) == 1
+        evt = capture.events[0]
+        assert evt.event_type == RAVN_SESSION_START
+        assert evt.payload["session_id"] == "sess-001"
+        assert evt.payload["model"] == "claude-sonnet-4-6"
+        assert evt.correlation_id == "sess-001"
+
+    async def test_on_session_end_publishes_event(self):
+        pub, bus = _make_publisher()
+        async with EventCapture(bus, [RAVN_SESSION_END]) as capture:
+            await pub.on_session_end(reason="interrupted")
+            await bus.flush()
+
+        assert len(capture.events) == 1
+        evt = capture.events[0]
+        assert evt.event_type == RAVN_SESSION_END
+        assert evt.payload["reason"] == "interrupted"
+
+    async def test_on_interrupt_publishes_event(self):
+        pub, bus = _make_publisher()
+        async with EventCapture(bus, [RAVN_INTERRUPT]) as capture:
+            await pub.on_interrupt()
+            await bus.flush()
+
+        assert len(capture.events) == 1
+        assert capture.events[0].urgency == pytest.approx(0.9)
+
+
+# ---------------------------------------------------------------------------
+# NDJSON line handling
+# ---------------------------------------------------------------------------
+
+
+class TestRavnPublisherNdjsonLines:
+    async def test_tool_use_line_emits_tool_call(self):
+        pub, bus = _make_publisher()
+        async with EventCapture(bus, [RAVN_TOOL_CALL]) as capture:
+            await pub.on_ndjson_line(
+                {"type": "tool_use", "id": "tu-1", "name": "bash", "input": {"command": "ls"}}
+            )
+            await bus.flush()
+
+        assert len(capture.events) == 1
+        evt = capture.events[0]
+        assert evt.event_type == RAVN_TOOL_CALL
+        assert evt.payload["tool"] == "bash"
+        assert evt.payload["tool_use_id"] == "tu-1"
+
+    async def test_tool_result_success_emits_tool_complete(self):
+        pub, bus = _make_publisher()
+        async with EventCapture(bus, [RAVN_TOOL_COMPLETE]) as capture:
+            await pub.on_ndjson_line(
+                {"type": "tool_result", "tool_use_id": "tu-1", "is_error": False}
+            )
+            await bus.flush()
+
+        assert len(capture.events) == 1
+        assert capture.events[0].event_type == RAVN_TOOL_COMPLETE
+
+    async def test_tool_result_error_emits_tool_error(self):
+        pub, bus = _make_publisher()
+        async with EventCapture(bus, [RAVN_TOOL_ERROR]) as capture:
+            await pub.on_ndjson_line(
+                {"type": "tool_result", "tool_use_id": "tu-2", "is_error": True}
+            )
+            await bus.flush()
+
+        assert len(capture.events) == 1
+        assert capture.events[0].event_type == RAVN_TOOL_ERROR
+
+    async def test_user_message_emits_step_start(self):
+        pub, bus = _make_publisher()
+        async with EventCapture(bus, [RAVN_STEP_START]) as capture:
+            await pub.on_ndjson_line({"type": "message", "role": "user"})
+            await bus.flush()
+
+        assert len(capture.events) == 1
+        assert capture.events[0].event_type == RAVN_STEP_START
+
+    async def test_assistant_end_turn_emits_response_complete(self):
+        pub, bus = _make_publisher()
+        async with EventCapture(bus, [RAVN_RESPONSE_COMPLETE]) as capture:
+            await pub.on_ndjson_line(
+                {"type": "message", "role": "assistant", "stop_reason": "end_turn"}
+            )
+            await bus.flush()
+
+        assert len(capture.events) == 1
+        assert capture.events[0].event_type == RAVN_RESPONSE_COMPLETE
+
+    async def test_assistant_non_end_turn_emits_step_complete(self):
+        pub, bus = _make_publisher()
+        async with EventCapture(bus, [RAVN_STEP_COMPLETE]) as capture:
+            await pub.on_ndjson_line(
+                {"type": "message", "role": "assistant", "stop_reason": "tool_use"}
+            )
+            await bus.flush()
+
+        assert len(capture.events) == 1
+        assert capture.events[0].event_type == RAVN_STEP_COMPLETE
+
+    async def test_system_init_emits_session_start(self):
+        pub, bus = _make_publisher()
+        async with EventCapture(bus, [RAVN_SESSION_START]) as capture:
+            await pub.on_ndjson_line(
+                {
+                    "type": "system",
+                    "subtype": "init",
+                    "session": {"model": "claude-opus-4-6"},
+                }
+            )
+            await bus.flush()
+
+        assert len(capture.events) == 1
+        assert capture.events[0].payload["model"] == "claude-opus-4-6"
+
+    async def test_unknown_type_produces_no_event(self):
+        pub, bus = _make_publisher()
+        async with EventCapture(bus, ["ravn.*"]) as capture:
+            await pub.on_ndjson_line({"type": "unknown_thing"})
+            await bus.flush()
+
+        assert len(capture.events) == 0
+
+
+# ---------------------------------------------------------------------------
+# Custom source identity
+# ---------------------------------------------------------------------------
+
+
+class TestRavnPublisherSource:
+    async def test_default_source_uses_session_id(self):
+        pub, bus = _make_publisher(session_id="my-session")
+        async with EventCapture(bus, [RAVN_SESSION_START]) as capture:
+            await pub.on_session_start()
+            await bus.flush()
+
+        assert capture.events[0].source == "ravn:my-session"
+
+    async def test_custom_source_is_used(self):
+        bus = InProcessBus()
+        pub = RavnPublisher(bus, session_id="sess", source="custom-source")
+        async with EventCapture(bus, [RAVN_SESSION_START]) as capture:
+            await pub.on_session_start()
+            await bus.flush()
+
+        assert capture.events[0].source == "custom-source"
+
+
+# ---------------------------------------------------------------------------
+# Fault tolerance
+# ---------------------------------------------------------------------------
+
+
+class TestRavnPublisherFaultTolerance:
+    async def test_publish_error_is_swallowed(self):
+        publisher = AsyncMock()
+        publisher.publish.side_effect = RuntimeError("broker down")
+        pub = RavnPublisher(publisher, session_id="sess-x")
+        await pub.on_session_start()  # must not raise

--- a/tests/test_skuld/test_sleipnir_bridge.py
+++ b/tests/test_skuld/test_sleipnir_bridge.py
@@ -1,0 +1,260 @@
+"""Tests for skuld.sleipnir_bridge.SleipnirBridge."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from skuld.channels import ChannelRegistry
+from skuld.sleipnir_bridge import DEFAULT_PATTERNS, SleipnirBridge
+from sleipnir.adapters.in_process import InProcessBus
+from tests.test_sleipnir.conftest import make_event
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ws_channel():
+    ch = MagicMock()
+    ch.channel_type = "websocket"
+    ch.is_open = True
+    ch.send_event = AsyncMock()
+    return ch
+
+
+def _make_registry() -> ChannelRegistry:
+    registry = ChannelRegistry()
+    return registry
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestSleipnirBridgeLifecycle:
+    async def test_start_subscribes_to_bus(self):
+        bus = InProcessBus()
+        registry = _make_registry()
+        bridge = SleipnirBridge(bus, registry)
+
+        await bridge.start()
+        assert bridge._subscription is not None
+        await bridge.stop()
+
+    async def test_stop_unsubscribes(self):
+        bus = InProcessBus()
+        registry = _make_registry()
+        bridge = SleipnirBridge(bus, registry)
+
+        await bridge.start()
+        await bridge.stop()
+        assert bridge._subscription is None
+
+    async def test_double_start_is_idempotent(self):
+        bus = InProcessBus()
+        registry = _make_registry()
+        bridge = SleipnirBridge(bus, registry)
+
+        await bridge.start()
+        first_sub = bridge._subscription
+        await bridge.start()  # second call should be ignored
+        assert bridge._subscription is first_sub
+        await bridge.stop()
+
+    async def test_stop_without_start_is_safe(self):
+        bus = InProcessBus()
+        registry = _make_registry()
+        bridge = SleipnirBridge(bus, registry)
+        await bridge.stop()  # must not raise
+
+    async def test_context_manager(self):
+        bus = InProcessBus()
+        registry = _make_registry()
+
+        async with SleipnirBridge(bus, registry) as bridge:
+            assert bridge._subscription is not None
+
+        assert bridge._subscription is None
+
+
+# ---------------------------------------------------------------------------
+# Event forwarding — no session filter
+# ---------------------------------------------------------------------------
+
+
+class TestSleipnirBridgeForwarding:
+    async def test_event_forwarded_to_channel(self):
+        bus = InProcessBus()
+        registry = _make_registry()
+        ch = _make_ws_channel()
+        registry.add(ch)
+
+        async with SleipnirBridge(bus, registry):
+            await bus.publish(make_event(event_type="ravn.tool.complete"))
+            await bus.flush()
+
+        ch.send_event.assert_awaited_once()
+        call_args = ch.send_event.call_args[0][0]
+        assert call_args["event_type"] == "ravn.tool.complete"
+        assert call_args["type"] == "sleipnir"
+
+    async def test_wire_format_contains_required_fields(self):
+        bus = InProcessBus()
+        registry = _make_registry()
+        ch = _make_ws_channel()
+        registry.add(ch)
+
+        async with SleipnirBridge(bus, registry):
+            await bus.publish(
+                make_event(
+                    event_type="volundr.session.started",
+                    event_id="evt-999",
+                    summary="test summary",
+                )
+            )
+            await bus.flush()
+
+        wire = ch.send_event.call_args[0][0]
+        assert "event_id" in wire
+        assert "event_type" in wire
+        assert "source" in wire
+        assert "summary" in wire
+        assert "payload" in wire
+        assert "timestamp" in wire
+
+    async def test_multiple_channels_receive_event(self):
+        bus = InProcessBus()
+        registry = _make_registry()
+        ch1, ch2 = _make_ws_channel(), _make_ws_channel()
+        registry.add(ch1)
+        registry.add(ch2)
+
+        async with SleipnirBridge(bus, registry):
+            await bus.publish(make_event(event_type="tyr.saga.created"))
+            await bus.flush()
+
+        ch1.send_event.assert_awaited_once()
+        ch2.send_event.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Session context filtering
+# ---------------------------------------------------------------------------
+
+
+class TestSleipnirBridgeSessionFilter:
+    async def _bridge_with_session(self, bus, registry, session_id):
+        return SleipnirBridge(bus, registry, session_id=session_id)
+
+    async def test_matching_correlation_id_passes_filter(self):
+        bus = InProcessBus()
+        registry = _make_registry()
+        ch = _make_ws_channel()
+        registry.add(ch)
+
+        bridge = SleipnirBridge(bus, registry, session_id="session-abc")
+        async with bridge:
+            await bus.publish(
+                make_event(event_type="ravn.tool.complete", correlation_id="session-abc")
+            )
+            await bus.flush()
+
+        ch.send_event.assert_awaited_once()
+
+    async def test_matching_payload_session_id_passes_filter(self):
+        bus = InProcessBus()
+        registry = _make_registry()
+        ch = _make_ws_channel()
+        registry.add(ch)
+
+        bridge = SleipnirBridge(bus, registry, session_id="session-xyz")
+        async with bridge:
+            await bus.publish(
+                make_event(
+                    event_type="volundr.session.started",
+                    payload={"session_id": "session-xyz"},
+                )
+            )
+            await bus.flush()
+
+        ch.send_event.assert_awaited_once()
+
+    async def test_non_matching_session_id_dropped(self):
+        bus = InProcessBus()
+        registry = _make_registry()
+        ch = _make_ws_channel()
+        registry.add(ch)
+
+        bridge = SleipnirBridge(bus, registry, session_id="session-A")
+        async with bridge:
+            await bus.publish(
+                make_event(
+                    event_type="ravn.tool.complete",
+                    correlation_id="session-B",
+                    payload={"session_id": "session-B"},
+                )
+            )
+            await bus.flush()
+
+        ch.send_event.assert_not_awaited()
+
+    async def test_no_filter_passes_all_events(self):
+        bus = InProcessBus()
+        registry = _make_registry()
+        ch = _make_ws_channel()
+        registry.add(ch)
+
+        bridge = SleipnirBridge(bus, registry, session_id=None)
+        async with bridge:
+            await bus.publish(make_event(event_type="ravn.tool.complete", correlation_id="any"))
+            await bus.flush()
+
+        ch.send_event.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Custom patterns
+# ---------------------------------------------------------------------------
+
+
+class TestSleipnirBridgePatterns:
+    async def test_default_patterns_include_ravn_and_volundr(self):
+        assert any("ravn" in p for p in DEFAULT_PATTERNS)
+        assert any("volundr" in p for p in DEFAULT_PATTERNS)
+
+    async def test_custom_patterns_only_receive_matching_events(self):
+        bus = InProcessBus()
+        registry = _make_registry()
+        ch = _make_ws_channel()
+        registry.add(ch)
+
+        bridge = SleipnirBridge(bus, registry, event_patterns=["tyr.*"])
+        async with bridge:
+            await bus.publish(make_event(event_type="ravn.tool.complete"))  # not matched
+            await bus.publish(make_event(event_type="tyr.saga.created"))  # matched
+            await bus.flush()
+
+        assert ch.send_event.await_count == 1
+        wire = ch.send_event.call_args[0][0]
+        assert wire["event_type"] == "tyr.saga.created"
+
+
+# ---------------------------------------------------------------------------
+# Fault tolerance
+# ---------------------------------------------------------------------------
+
+
+class TestSleipnirBridgeFaultTolerance:
+    async def test_channel_error_does_not_crash_bridge(self):
+        bus = InProcessBus()
+        registry = _make_registry()
+        ch = _make_ws_channel()
+        ch.send_event.side_effect = RuntimeError("channel broken")
+        registry.add(ch)
+
+        bridge = SleipnirBridge(bus, registry)
+        async with bridge:
+            # Must not propagate the exception
+            await bus.publish(make_event(event_type="ravn.tool.complete"))
+            await bus.flush()

--- a/tests/test_sleipnir/test_registry.py
+++ b/tests/test_sleipnir/test_registry.py
@@ -57,6 +57,17 @@ def test_volundr_constants_present():
     assert registry.VOLUNDR_PIPELINE_FAILED == "volundr.pipeline.failed"
 
 
+def test_volundr_session_constants_present():
+    """New session/token/chronicle event type constants added in NIU-466."""
+    assert registry.VOLUNDR_SESSION_CREATED == "volundr.session.created"
+    assert registry.VOLUNDR_SESSION_STARTED == "volundr.session.started"
+    assert registry.VOLUNDR_SESSION_STOPPED == "volundr.session.stopped"
+    assert registry.VOLUNDR_SESSION_FAILED == "volundr.session.failed"
+    assert registry.VOLUNDR_TOKEN_USAGE == "volundr.token.usage"
+    assert registry.VOLUNDR_CHRONICLE_CREATED == "volundr.chronicle.created"
+    assert registry.VOLUNDR_CHRONICLE_UPDATED == "volundr.chronicle.updated"
+
+
 def test_bifrost_constants_present():
     assert registry.BIFROST_CONNECTION_OPEN == "bifrost.connection.open"
     assert registry.BIFROST_CONNECTION_CLOSE == "bifrost.connection.close"

--- a/tests/test_tyr/test_sleipnir_event_bridge.py
+++ b/tests/test_tyr/test_sleipnir_event_bridge.py
@@ -1,0 +1,308 @@
+"""Tests for tyr.adapters.sleipnir_event_bridge.SleipnirEventBridge."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+from sleipnir.adapters.in_process import InProcessBus
+from sleipnir.domain.registry import (
+    TYR_SAGA_COMPLETE,
+    TYR_SAGA_CREATED,
+    TYR_SAGA_FAILED,
+    TYR_SAGA_STEP,
+    TYR_TASK_COMPLETE,
+    TYR_TASK_FAILED,
+    TYR_TASK_QUEUED,
+    TYR_TASK_STARTED,
+)
+from sleipnir.testing import EventCapture
+from tyr.adapters.memory_event_bus import InMemoryEventBus
+from tyr.adapters.sleipnir_event_bridge import SleipnirEventBridge
+from tyr.ports.event_bus import TyrEvent
+
+_TS = datetime(2026, 4, 5, 12, 0, 0, tzinfo=UTC)
+
+
+def _make_tyr_event(event: str, data: dict | None = None, owner_id: str = "") -> TyrEvent:
+    return TyrEvent(
+        event=event,
+        data=data or {},
+        owner_id=owner_id,
+        id="evt-001",
+        timestamp=_TS,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Delegation to inner bus
+# ---------------------------------------------------------------------------
+
+
+class TestSleipnirEventBridgeDelegation:
+    async def test_emit_calls_inner_bus(self):
+        inner = InMemoryEventBus()
+        bridge = SleipnirEventBridge(inner, AsyncMock())
+
+        q = bridge.subscribe()
+        event = _make_tyr_event("saga.created", {"saga_id": "s-1", "name": "My Saga"})
+        await bridge.emit(event)
+
+        received = q.get_nowait()
+        assert received is event
+
+    def test_subscribe_returns_queue_from_inner(self):
+        inner = InMemoryEventBus()
+        bridge = SleipnirEventBridge(inner, AsyncMock())
+        q = bridge.subscribe()
+        assert isinstance(q, asyncio.Queue)
+
+    def test_unsubscribe_removes_from_inner(self):
+        inner = InMemoryEventBus()
+        bridge = SleipnirEventBridge(inner, AsyncMock())
+        q = bridge.subscribe()
+        assert inner.client_count == 1
+        bridge.unsubscribe(q)
+        assert inner.client_count == 0
+
+    def test_client_count_delegates(self):
+        inner = InMemoryEventBus()
+        bridge = SleipnirEventBridge(inner, AsyncMock())
+        bridge.subscribe()
+        assert bridge.client_count == 1
+
+    def test_at_capacity_delegates(self):
+        inner = InMemoryEventBus(max_clients=1)
+        bridge = SleipnirEventBridge(inner, AsyncMock())
+        bridge.subscribe()
+        assert bridge.at_capacity is True
+
+    def test_get_snapshot_delegates(self):
+        inner = InMemoryEventBus()
+        bridge = SleipnirEventBridge(inner, AsyncMock())
+        assert bridge.get_snapshot() == []
+
+    def test_get_log_delegates(self):
+        inner = InMemoryEventBus()
+        bridge = SleipnirEventBridge(inner, AsyncMock())
+        assert bridge.get_log(10) == []
+
+
+# ---------------------------------------------------------------------------
+# Saga event mirroring
+# ---------------------------------------------------------------------------
+
+
+class TestSleipnirEventBridgeSagaMirroring:
+    async def test_saga_created_mirrored(self):
+        sleipnir = InProcessBus()
+        inner = InMemoryEventBus()
+        bridge = SleipnirEventBridge(inner, sleipnir)
+
+        async with EventCapture(sleipnir, [TYR_SAGA_CREATED]) as capture:
+            await bridge.emit(
+                _make_tyr_event("saga.created", {"saga_id": "s-1", "name": "Test Saga"})
+            )
+            await sleipnir.flush()
+
+        assert len(capture.events) == 1
+        evt = capture.events[0]
+        assert evt.event_type == TYR_SAGA_CREATED
+        assert evt.payload["saga_id"] == "s-1"
+        assert "Test Saga" in evt.summary
+
+    async def test_saga_step_mirrored(self):
+        sleipnir = InProcessBus()
+        inner = InMemoryEventBus()
+        bridge = SleipnirEventBridge(inner, sleipnir)
+
+        async with EventCapture(sleipnir, [TYR_SAGA_STEP]) as capture:
+            await bridge.emit(_make_tyr_event("saga.step", {"saga_id": "s-1", "step": 2}))
+            await sleipnir.flush()
+
+        assert len(capture.events) == 1
+
+    async def test_saga_completed_mirrored(self):
+        sleipnir = InProcessBus()
+        inner = InMemoryEventBus()
+        bridge = SleipnirEventBridge(inner, sleipnir)
+
+        async with EventCapture(sleipnir, [TYR_SAGA_COMPLETE]) as capture:
+            await bridge.emit(_make_tyr_event("saga.completed", {"saga_id": "s-1"}))
+            await sleipnir.flush()
+
+        assert len(capture.events) == 1
+
+    async def test_saga_failed_mirrored(self):
+        sleipnir = InProcessBus()
+        inner = InMemoryEventBus()
+        bridge = SleipnirEventBridge(inner, sleipnir)
+
+        async with EventCapture(sleipnir, [TYR_SAGA_FAILED]) as capture:
+            await bridge.emit(_make_tyr_event("saga.failed", {"saga_id": "s-1"}))
+            await sleipnir.flush()
+
+        assert len(capture.events) == 1
+
+
+# ---------------------------------------------------------------------------
+# Raid event mirroring
+# ---------------------------------------------------------------------------
+
+
+class TestSleipnirEventBridgeRaidMirroring:
+    async def test_raid_queued_mirrored(self):
+        sleipnir = InProcessBus()
+        inner = InMemoryEventBus()
+        bridge = SleipnirEventBridge(inner, sleipnir)
+
+        async with EventCapture(sleipnir, [TYR_TASK_QUEUED]) as capture:
+            await bridge.emit(
+                _make_tyr_event(
+                    "raid.state_changed",
+                    {"raid_id": "r-1", "new_status": "QUEUED"},
+                )
+            )
+            await sleipnir.flush()
+
+        assert len(capture.events) == 1
+        assert capture.events[0].event_type == TYR_TASK_QUEUED
+
+    async def test_raid_running_mirrored(self):
+        sleipnir = InProcessBus()
+        inner = InMemoryEventBus()
+        bridge = SleipnirEventBridge(inner, sleipnir)
+
+        async with EventCapture(sleipnir, [TYR_TASK_STARTED]) as capture:
+            await bridge.emit(
+                _make_tyr_event(
+                    "raid.state_changed",
+                    {"raid_id": "r-1", "new_status": "RUNNING"},
+                )
+            )
+            await sleipnir.flush()
+
+        assert len(capture.events) == 1
+
+    async def test_raid_merged_maps_to_task_complete(self):
+        sleipnir = InProcessBus()
+        inner = InMemoryEventBus()
+        bridge = SleipnirEventBridge(inner, sleipnir)
+
+        async with EventCapture(sleipnir, [TYR_TASK_COMPLETE]) as capture:
+            await bridge.emit(
+                _make_tyr_event(
+                    "raid.state_changed",
+                    {"raid_id": "r-1", "new_status": "MERGED"},
+                )
+            )
+            await sleipnir.flush()
+
+        assert len(capture.events) == 1
+
+    async def test_raid_failed_mirrored(self):
+        sleipnir = InProcessBus()
+        inner = InMemoryEventBus()
+        bridge = SleipnirEventBridge(inner, sleipnir)
+
+        async with EventCapture(sleipnir, [TYR_TASK_FAILED]) as capture:
+            await bridge.emit(
+                _make_tyr_event(
+                    "raid.state_changed",
+                    {"raid_id": "r-1", "new_status": "FAILED"},
+                )
+            )
+            await sleipnir.flush()
+
+        assert len(capture.events) == 1
+
+    async def test_raid_review_status_not_forwarded(self):
+        sleipnir = InProcessBus()
+        inner = InMemoryEventBus()
+        bridge = SleipnirEventBridge(inner, sleipnir)
+
+        async with EventCapture(sleipnir, ["tyr.*"]) as capture:
+            await bridge.emit(
+                _make_tyr_event(
+                    "raid.state_changed",
+                    {"raid_id": "r-1", "new_status": "REVIEW"},
+                )
+            )
+            await sleipnir.flush()
+
+        assert len(capture.events) == 0
+
+
+# ---------------------------------------------------------------------------
+# Events not forwarded
+# ---------------------------------------------------------------------------
+
+
+class TestSleipnirEventBridgeNoForward:
+    async def test_notification_events_not_forwarded(self):
+        sleipnir = InProcessBus()
+        inner = InMemoryEventBus()
+        bridge = SleipnirEventBridge(inner, sleipnir)
+
+        async with EventCapture(sleipnir, ["tyr.*"]) as capture:
+            await bridge.emit(_make_tyr_event("notification.sent", {"channel": "telegram"}))
+            await sleipnir.flush()
+
+        assert len(capture.events) == 0
+
+    async def test_unrecognized_event_type_not_forwarded(self):
+        sleipnir = InProcessBus()
+        inner = InMemoryEventBus()
+        bridge = SleipnirEventBridge(inner, sleipnir)
+
+        async with EventCapture(sleipnir, ["tyr.*"]) as capture:
+            await bridge.emit(_make_tyr_event("some.unknown.event", {}))
+            await sleipnir.flush()
+
+        assert len(capture.events) == 0
+
+
+# ---------------------------------------------------------------------------
+# Owner/tenant propagation
+# ---------------------------------------------------------------------------
+
+
+class TestSleipnirEventBridgeTenant:
+    async def test_owner_id_propagated_as_tenant_id(self):
+        sleipnir = InProcessBus()
+        inner = InMemoryEventBus()
+        bridge = SleipnirEventBridge(inner, sleipnir)
+
+        async with EventCapture(sleipnir, [TYR_SAGA_CREATED]) as capture:
+            await bridge.emit(
+                _make_tyr_event(
+                    "saga.created",
+                    {"saga_id": "s-1", "name": "My Saga"},
+                    owner_id="user-42",
+                )
+            )
+            await sleipnir.flush()
+
+        assert capture.events[0].tenant_id == "user-42"
+
+
+# ---------------------------------------------------------------------------
+# Fault tolerance
+# ---------------------------------------------------------------------------
+
+
+class TestSleipnirEventBridgeFaultTolerance:
+    async def test_sleipnir_publish_error_does_not_block_inner_bus(self):
+        inner = InMemoryEventBus()
+        publisher = AsyncMock()
+        publisher.publish.side_effect = RuntimeError("sleipnir down")
+        bridge = SleipnirEventBridge(inner, publisher)
+
+        q = bridge.subscribe()
+        event = _make_tyr_event("saga.created", {"saga_id": "s-1", "name": "X"})
+        await bridge.emit(event)  # must not raise
+
+        # Inner bus still received the event
+        received = q.get_nowait()
+        assert received is event

--- a/tests/test_tyr/test_sleipnir_event_bridge.py
+++ b/tests/test_tyr/test_sleipnir_event_bridge.py
@@ -19,7 +19,7 @@ from sleipnir.domain.registry import (
 )
 from sleipnir.testing import EventCapture
 from tyr.adapters.memory_event_bus import InMemoryEventBus
-from tyr.adapters.sleipnir_event_bridge import SleipnirEventBridge
+from tyr.adapters.sleipnir_event_bridge import SleipnirEventBridge, TyrSleipnirBridge
 from tyr.ports.event_bus import TyrEvent
 
 _TS = datetime(2026, 4, 5, 12, 0, 0, tzinfo=UTC)
@@ -306,3 +306,68 @@ class TestSleipnirEventBridgeFaultTolerance:
         # Inner bus still received the event
         received = q.get_nowait()
         assert received is event
+
+
+# ---------------------------------------------------------------------------
+# TyrSleipnirBridge lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestTyrSleipnirBridge:
+    async def test_start_creates_background_task(self):
+        inner = InMemoryEventBus()
+        bridge = TyrSleipnirBridge(event_bus=inner, publisher=AsyncMock())
+        assert not bridge.is_running
+        await bridge.start()
+        assert bridge.is_running
+        await bridge.stop()
+
+    async def test_start_is_idempotent(self):
+        inner = InMemoryEventBus()
+        bridge = TyrSleipnirBridge(event_bus=inner, publisher=AsyncMock())
+        await bridge.start()
+        task_before = bridge._task
+        await bridge.start()
+        assert bridge._task is task_before
+        await bridge.stop()
+
+    async def test_stop_cancels_task(self):
+        inner = InMemoryEventBus()
+        bridge = TyrSleipnirBridge(event_bus=inner, publisher=AsyncMock())
+        await bridge.start()
+        await bridge.stop()
+        assert not bridge.is_running
+        assert bridge._task is None
+
+    async def test_stop_is_idempotent(self):
+        inner = InMemoryEventBus()
+        bridge = TyrSleipnirBridge(event_bus=inner, publisher=AsyncMock())
+        await bridge.stop()  # must not raise when not started
+        assert not bridge.is_running
+
+    async def test_stop_unsubscribes_from_event_bus(self):
+        inner = InMemoryEventBus()
+        bridge = TyrSleipnirBridge(event_bus=inner, publisher=AsyncMock())
+        await bridge.start()
+        await asyncio.sleep(0)  # let _run() reach await q.get()
+        assert inner.client_count == 1
+        await bridge.stop()
+        assert inner.client_count == 0
+
+    async def test_run_loop_mirrors_events_to_sleipnir(self):
+        sleipnir = InProcessBus()
+        inner = InMemoryEventBus()
+        bridge = TyrSleipnirBridge(event_bus=inner, publisher=sleipnir)
+
+        async with EventCapture(sleipnir, [TYR_SAGA_CREATED]) as capture:
+            await bridge.start()
+            await asyncio.sleep(0)
+            await inner.emit(
+                _make_tyr_event("saga.created", {"saga_id": "s-1", "name": "BridgeTest"})
+            )
+            await asyncio.sleep(0)
+            await sleipnir.flush()
+
+        await bridge.stop()
+        assert len(capture.events) == 1
+        assert capture.events[0].event_type == TYR_SAGA_CREATED


### PR DESCRIPTION
## Summary

- **Volundr `SleipnirEventSink`**: Maps `SessionEvent` lifecycle (`SESSION_START` → `volundr.session.started`, `SESSION_STOP` → `volundr.session.stopped`) and `TOKEN_USAGE` events to `SleipnirEvent`; plugs into the existing `EventIngestionService` fan-out. Includes `ChronicleEventSink` for `volundr.chronicle.created` / `volundr.chronicle.updated`.
- **Skuld `SleipnirBridge`**: Subscribes to the Sleipnir bus with configurable event patterns (`ravn.*`, `volundr.*`, `tyr.*`, `system.health.*` by default), optionally filters by session context (matching `correlation_id` or `payload.session_id`), and forwards matching events to all registered `ChannelRegistry` channels as wire-format dicts.
- **Skuld `RavnPublisher`**: Maps CLI NDJSON stream lines to `ravn.*` Sleipnir events — `tool_use` → `ravn.tool.call`, `tool_result` → `ravn.tool.complete` / `ravn.tool.error`, `message` roles → `ravn.step.*` / `ravn.response.complete`, `system/init` → `ravn.session.start`. Direct methods for `on_session_start`, `on_session_end`, `on_interrupt`.
- **Tyr `SleipnirEventBridge`**: Decorator around `EventBusPort`; all operations delegate to the inner bus; `emit` additionally mirrors saga (`saga.created/step/completed/failed`), raid state changes (`QUEUED/RUNNING/MERGED/FAILED/CANCELLED`), and `dispatcher.state` events to Sleipnir. Publish errors are swallowed — inner bus always receives the event.
- **Registry constants**: Added `VOLUNDR_SESSION_CREATED/STARTED/STOPPED/FAILED`, `VOLUNDR_TOKEN_USAGE`, `VOLUNDR_CHRONICLE_CREATED/UPDATED` to `sleipnir.domain.registry`.

## Test plan

- [x] 77 new tests across 4 test modules; all passing
- [x] `tests/test_adapters/test_sleipnir_event_sink.py` — session lifecycle, token usage, batch, fault tolerance, tenant propagation, chronicle sink
- [x] `tests/test_skuld/test_sleipnir_bridge.py` — lifecycle, event forwarding, session filtering, custom patterns, fault tolerance
- [x] `tests/test_skuld/test_ravn_publisher.py` — session lifecycle, NDJSON line handling, source identity, fault tolerance
- [x] `tests/test_tyr/test_sleipnir_event_bridge.py` — delegation, saga mirroring, raid mirroring, no-forward cases, tenant propagation, fault tolerance
- [x] `ruff check` + `ruff format` — zero violations
- [x] Full suite: 5161 passed, 6 skipped (4 pre-existing `test_dispatcher_api` ordering failures unrelated to this PR)

Closes NIU-466

🤖 Generated with [Claude Code](https://claude.com/claude-code)