### PR TITLE
feat(adapters): semantic memory — embeddings, hybrid retrieval, skill extraction (NIU-436)

### DIFF
--- a/src/ravn/adapters/_memory_scoring.py
+++ b/src/ravn/adapters/_memory_scoring.py
@@ -3,6 +3,10 @@
 Both ``SqliteMemoryAdapter`` and ``PostgresMemoryAdapter`` use identical
 scoring constants, recency/formatting helpers, and response-building logic.
 This module is the single source of truth for those shared pieces.
+
+Also provides hybrid retrieval primitives:
+- ``cosine_similarity`` — dot-product cosine between two float vectors.
+- ``reciprocal_rank_fusion`` — merge multiple ranked lists (RRF algorithm).
 """
 
 from __future__ import annotations
@@ -26,6 +30,48 @@ _OUTCOME_WEIGHTS: dict[str, float] = {
     Outcome.PARTIAL: 0.7,
     Outcome.FAILURE: 0.3,
 }
+
+
+def cosine_similarity(a: list[float], b: list[float]) -> float:
+    """Compute cosine similarity between two equal-length vectors.
+
+    Returns a value in ``[-1, 1]`` (typically ``[0, 1]`` for non-negative
+    embedding spaces).  Returns ``0.0`` for zero-length or mismatched vectors.
+    """
+    if len(a) != len(b) or not a:
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(y * y for y in b))
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+def reciprocal_rank_fusion(
+    rankings: list[list[str]],
+    *,
+    k: int = 60,
+) -> dict[str, float]:
+    """Merge multiple ranked lists using Reciprocal Rank Fusion (RRF).
+
+    Each inner list in *rankings* is an ordered sequence of episode IDs from
+    best to worst.  The returned dict maps episode ID to its aggregated RRF
+    score — higher is better.
+
+    Args:
+        rankings: One or more ranked lists of episode IDs (best first).
+        k: Smoothing constant.  Typically 60; higher values reduce the
+           advantage of top positions.
+
+    Returns:
+        Dict mapping episode_id to aggregated RRF score.
+    """
+    scores: dict[str, float] = {}
+    for ranking in rankings:
+        for rank, episode_id in enumerate(ranking):
+            scores[episode_id] = scores.get(episode_id, 0.0) + 1.0 / (k + rank + 1)
+    return scores
 
 
 def _recency_score(timestamp: datetime, half_life_days: float) -> float:

--- a/src/ravn/adapters/ollama_embedding.py
+++ b/src/ravn/adapters/ollama_embedding.py
@@ -3,10 +3,15 @@
 Calls Ollama's ``/api/embed`` endpoint using ``httpx``.  Requires a running
 Ollama instance (``ollama serve``) with the embedding model pulled.
 
+A single persistent ``httpx.AsyncClient`` is reused across calls to avoid
+the overhead of creating a new TCP connection pool for each request.
+Call ``await adapter.close()`` when done to release the connection pool.
+
 Example::
 
     adapter = OllamaEmbeddingAdapter(model="nomic-embed-text")
     vector = await adapter.embed("some text")
+    await adapter.close()
 """
 
 from __future__ import annotations
@@ -41,37 +46,48 @@ class OllamaEmbeddingAdapter(EmbeddingPort):
         self._base_url = base_url.rstrip("/")
         self._timeout = timeout
         self._dimension: int | None = None
+        self._client: httpx.AsyncClient | None = None
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
 
-    async def _post_embed(self, text: str) -> list[float]:
-        async with httpx.AsyncClient(timeout=self._timeout) as client:
-            response = await client.post(
-                f"{self._base_url}/api/embed",
-                json={"model": self._model, "input": text},
-            )
-            response.raise_for_status()
-            data = response.json()
-        embedding: list[float] = data["embeddings"][0]
-        if self._dimension is None:
-            self._dimension = len(embedding)
-        return embedding
+    def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(timeout=self._timeout)
+        return self._client
+
+    async def close(self) -> None:
+        """Close the persistent HTTP client and release connection pool."""
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    async def _post_embed_batch(self, texts: list[str]) -> list[list[float]]:
+        """Send all *texts* in a single /api/embed request (batch input)."""
+        response = await self._get_client().post(
+            f"{self._base_url}/api/embed",
+            json={"model": self._model, "input": texts},
+        )
+        response.raise_for_status()
+        data = response.json()
+        embeddings: list[list[float]] = data["embeddings"]
+        if self._dimension is None and embeddings:
+            self._dimension = len(embeddings[0])
+        return embeddings
 
     # ------------------------------------------------------------------
     # EmbeddingPort
     # ------------------------------------------------------------------
 
     async def embed(self, text: str) -> list[float]:
-        return await self._post_embed(text)
+        results = await self._post_embed_batch([text])
+        return results[0]
 
     async def embed_batch(self, texts: list[str]) -> list[list[float]]:
-        results: list[list[float]] = []
-        for text in texts:
-            vec = await self._post_embed(text)
-            results.append(vec)
-        return results
+        if not texts:
+            return []
+        return await self._post_embed_batch(texts)
 
     @property
     def dimension(self) -> int:

--- a/src/ravn/adapters/ollama_embedding.py
+++ b/src/ravn/adapters/ollama_embedding.py
@@ -1,0 +1,80 @@
+"""Ollama local embedding adapter.
+
+Calls Ollama's ``/api/embed`` endpoint using ``httpx``.  Requires a running
+Ollama instance (``ollama serve``) with the embedding model pulled.
+
+Example::
+
+    adapter = OllamaEmbeddingAdapter(model="nomic-embed-text")
+    vector = await adapter.embed("some text")
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from ravn.ports.embedding import EmbeddingPort
+
+_DEFAULT_MODEL = "nomic-embed-text"
+_DEFAULT_BASE_URL = "http://localhost:11434"
+# nomic-embed-text default dimension
+_DEFAULT_DIMENSION = 768
+
+
+class OllamaEmbeddingAdapter(EmbeddingPort):
+    """Embedding adapter using a locally-running Ollama instance.
+
+    Args:
+        model: Ollama model name (must support embeddings).
+        base_url: URL of the Ollama API server.
+        timeout: HTTP request timeout in seconds.
+    """
+
+    def __init__(
+        self,
+        *,
+        model: str = _DEFAULT_MODEL,
+        base_url: str = _DEFAULT_BASE_URL,
+        timeout: float = 30.0,
+    ) -> None:
+        self._model = model
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout
+        self._dimension: int | None = None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _post_embed(self, text: str) -> list[float]:
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.post(
+                f"{self._base_url}/api/embed",
+                json={"model": self._model, "input": text},
+            )
+            response.raise_for_status()
+            data = response.json()
+        embedding: list[float] = data["embeddings"][0]
+        if self._dimension is None:
+            self._dimension = len(embedding)
+        return embedding
+
+    # ------------------------------------------------------------------
+    # EmbeddingPort
+    # ------------------------------------------------------------------
+
+    async def embed(self, text: str) -> list[float]:
+        return await self._post_embed(text)
+
+    async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        results: list[list[float]] = []
+        for text in texts:
+            vec = await self._post_embed(text)
+            results.append(vec)
+        return results
+
+    @property
+    def dimension(self) -> int:
+        if self._dimension is not None:
+            return self._dimension
+        return _DEFAULT_DIMENSION

--- a/src/ravn/adapters/openai_embedding.py
+++ b/src/ravn/adapters/openai_embedding.py
@@ -1,0 +1,83 @@
+"""OpenAI embeddings adapter.
+
+Calls the OpenAI ``/v1/embeddings`` endpoint using ``httpx``.  No OpenAI SDK
+dependency required — only ``httpx``, which is already a project dependency.
+"""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+
+from ravn.ports.embedding import EmbeddingPort
+
+_DEFAULT_MODEL = "text-embedding-3-small"
+_DEFAULT_BASE_URL = "https://api.openai.com/v1"
+# text-embedding-3-small default dimension
+_DEFAULT_DIMENSION = 1536
+
+
+class OpenAIEmbeddingAdapter(EmbeddingPort):
+    """Embedding adapter using OpenAI's embeddings API.
+
+    Args:
+        api_key: OpenAI API key.  When empty the ``OPENAI_API_KEY`` env var is used.
+        model: Embedding model name.
+        base_url: Base URL for the OpenAI (or compatible) API.
+        timeout: HTTP request timeout in seconds.
+    """
+
+    def __init__(
+        self,
+        api_key: str = "",
+        *,
+        model: str = _DEFAULT_MODEL,
+        base_url: str = _DEFAULT_BASE_URL,
+        timeout: float = 30.0,
+    ) -> None:
+        self._api_key = api_key or os.environ.get("OPENAI_API_KEY", "")
+        self._model = model
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout
+        self._dimension: int | None = None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _post_embeddings(self, texts: list[str]) -> list[list[float]]:
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.post(
+                f"{self._base_url}/embeddings",
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                    "Content-Type": "application/json",
+                },
+                json={"input": texts, "model": self._model},
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        sorted_items = sorted(data["data"], key=lambda x: x["index"])
+        vectors = [item["embedding"] for item in sorted_items]
+        if vectors and self._dimension is None:
+            self._dimension = len(vectors[0])
+        return vectors
+
+    # ------------------------------------------------------------------
+    # EmbeddingPort
+    # ------------------------------------------------------------------
+
+    async def embed(self, text: str) -> list[float]:
+        vectors = await self.embed_batch([text])
+        return vectors[0]
+
+    async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        return await self._post_embeddings(texts)
+
+    @property
+    def dimension(self) -> int:
+        if self._dimension is not None:
+            return self._dimension
+        return _DEFAULT_DIMENSION

--- a/src/ravn/adapters/openai_embedding.py
+++ b/src/ravn/adapters/openai_embedding.py
@@ -2,6 +2,10 @@
 
 Calls the OpenAI ``/v1/embeddings`` endpoint using ``httpx``.  No OpenAI SDK
 dependency required — only ``httpx``, which is already a project dependency.
+
+A single persistent ``httpx.AsyncClient`` is reused across calls to avoid
+the overhead of creating a new TCP connection pool for each request.
+Call ``await adapter.close()`` when done to release the connection pool.
 """
 
 from __future__ import annotations
@@ -41,23 +45,34 @@ class OpenAIEmbeddingAdapter(EmbeddingPort):
         self._base_url = base_url.rstrip("/")
         self._timeout = timeout
         self._dimension: int | None = None
+        self._client: httpx.AsyncClient | None = None
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
 
+    def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(timeout=self._timeout)
+        return self._client
+
+    async def close(self) -> None:
+        """Close the persistent HTTP client and release connection pool."""
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
     async def _post_embeddings(self, texts: list[str]) -> list[list[float]]:
-        async with httpx.AsyncClient(timeout=self._timeout) as client:
-            response = await client.post(
-                f"{self._base_url}/embeddings",
-                headers={
-                    "Authorization": f"Bearer {self._api_key}",
-                    "Content-Type": "application/json",
-                },
-                json={"input": texts, "model": self._model},
-            )
-            response.raise_for_status()
-            data = response.json()
+        response = await self._get_client().post(
+            f"{self._base_url}/embeddings",
+            headers={
+                "Authorization": f"Bearer {self._api_key}",
+                "Content-Type": "application/json",
+            },
+            json={"input": texts, "model": self._model},
+        )
+        response.raise_for_status()
+        data = response.json()
 
         sorted_items = sorted(data["data"], key=lambda x: x["index"])
         vectors = [item["embedding"] for item in sorted_items]

--- a/src/ravn/adapters/sentence_transformer_embedding.py
+++ b/src/ravn/adapters/sentence_transformer_embedding.py
@@ -1,0 +1,82 @@
+"""Sentence-transformers embedding adapter — local, Pi-friendly.
+
+Uses ``all-MiniLM-L6-v2`` by default: 384-dimensional, ~80 MB, runs on CPU.
+Requires the optional dependency: ``pip install sentence-transformers``.
+
+The model is loaded lazily on first use and cached for the lifetime of the
+adapter instance.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from ravn.ports.embedding import EmbeddingPort
+
+_DEFAULT_MODEL = "all-MiniLM-L6-v2"
+
+
+class SentenceTransformerEmbeddingAdapter(EmbeddingPort):
+    """Local embedding adapter backed by sentence-transformers.
+
+    Args:
+        model_name: HuggingFace model name or local path.
+        device: Torch device string (``"cpu"``, ``"cuda"``, etc.).
+    """
+
+    def __init__(
+        self,
+        model_name: str = _DEFAULT_MODEL,
+        *,
+        device: str = "cpu",
+    ) -> None:
+        self._model_name = model_name
+        self._device = device
+        self._model: Any | None = None
+        self._dim: int | None = None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _load_model(self) -> Any:
+        if self._model is not None:
+            return self._model
+        try:
+            from sentence_transformers import SentenceTransformer  # type: ignore[import]
+        except ImportError as exc:
+            raise ImportError(
+                "sentence-transformers is required for SentenceTransformerEmbeddingAdapter. "
+                "Install it with: pip install sentence-transformers"
+            ) from exc
+        self._model = SentenceTransformer(self._model_name, device=self._device)
+        return self._model
+
+    def _encode_sync(self, texts: list[str]) -> list[list[float]]:
+        model = self._load_model()
+        vectors = model.encode(texts, convert_to_numpy=True)
+        result = [v.tolist() for v in vectors]
+        if self._dim is None and result:
+            self._dim = len(result[0])
+        return result
+
+    # ------------------------------------------------------------------
+    # EmbeddingPort
+    # ------------------------------------------------------------------
+
+    async def embed(self, text: str) -> list[float]:
+        results = await self.embed_batch([text])
+        return results[0]
+
+    async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        return await asyncio.to_thread(self._encode_sync, texts)
+
+    @property
+    def dimension(self) -> int:
+        if self._dim is not None:
+            return self._dim
+        model = self._load_model()
+        dim = model.get_sentence_embedding_dimension()
+        self._dim = dim
+        return dim

--- a/src/ravn/adapters/sqlite_memory.py
+++ b/src/ravn/adapters/sqlite_memory.py
@@ -3,6 +3,12 @@
 Uses WAL mode for concurrent access, FTS5 for full-text search, and BM25
 ranking for relevance.  Designed for low-resource environments (e.g. Pi).
 
+When an ``EmbeddingPort`` is provided, query_episodes runs *hybrid retrieval*:
+1. FTS5 keyword search → top-K BM25 candidates
+2. Cosine similarity on stored episode embeddings → semantic candidates
+3. Reciprocal Rank Fusion (RRF) to merge both ranking lists
+4. Recency decay × outcome weight applied to normalised RRF score
+
 Retry strategy: up to ``max_retries`` attempts on SQLite "database is locked"
 errors with random jitter in [min_jitter_ms, max_jitter_ms] between attempts.
 WAL passive checkpoint fires every ``checkpoint_interval`` writes.
@@ -25,6 +31,8 @@ from ravn.adapters._memory_scoring import (
     _recency_score,
     build_prefetch_context,
     build_session_summaries,
+    cosine_similarity,
+    reciprocal_rank_fusion,
 )
 from ravn.domain.models import (
     Episode,
@@ -33,6 +41,7 @@ from ravn.domain.models import (
     SessionSummary,
     SharedContext,
 )
+from ravn.ports.embedding import EmbeddingPort
 from ravn.ports.memory import MemoryPort
 
 # ---------------------------------------------------------------------------
@@ -151,7 +160,12 @@ def _combined_score(
 
 
 class SqliteMemoryAdapter(MemoryPort):
-    """Episodic memory backed by a local SQLite database with FTS5 search."""
+    """Episodic memory backed by a local SQLite database with FTS5 search.
+
+    When *embedding_port* is supplied, ``query_episodes`` uses hybrid retrieval
+    (FTS5 + cosine similarity on stored embeddings merged via RRF).  Without an
+    embedding port the adapter falls back to FTS5-only search.
+    """
 
     def __init__(
         self,
@@ -166,6 +180,9 @@ class SqliteMemoryAdapter(MemoryPort):
         prefetch_min_relevance: float = 0.3,
         recency_half_life_days: float = 14.0,
         session_search_truncate_chars: int = 100_000,
+        embedding_port: EmbeddingPort | None = None,
+        rrf_k: int = 60,
+        semantic_candidate_limit: int = 50,
     ) -> None:
         self._path = Path(path).expanduser()
         self._max_retries = max_retries
@@ -177,6 +194,9 @@ class SqliteMemoryAdapter(MemoryPort):
         self._prefetch_min_relevance = prefetch_min_relevance
         self._recency_half_life_days = recency_half_life_days
         self._session_search_truncate_chars = session_search_truncate_chars
+        self._embedding_port = embedding_port
+        self._rrf_k = rrf_k
+        self._semantic_candidate_limit = semantic_candidate_limit
         self._write_count = 0
         self._shared_context: SharedContext | None = None
 
@@ -198,7 +218,9 @@ class SqliteMemoryAdapter(MemoryPort):
         limit: int = 5,
         min_relevance: float = 0.3,
     ) -> list[EpisodeMatch]:
-        return await asyncio.to_thread(self._query_episodes_sync, query, limit, min_relevance)
+        if self._embedding_port is not None:
+            return await self._query_hybrid(query, limit=limit, min_relevance=min_relevance)
+        return await asyncio.to_thread(self._query_fts_sync, query, limit, min_relevance)
 
     async def prefetch(self, context: str) -> str:
         matches = await self.query_episodes(
@@ -292,9 +314,8 @@ class SqliteMemoryAdapter(MemoryPort):
 
         self._with_retry(_do_insert)
 
-    def _query_episodes_sync(
-        self, query: str, limit: int, min_relevance: float
-    ) -> list[EpisodeMatch]:
+    def _query_fts_sync(self, query: str, limit: int, min_relevance: float) -> list[EpisodeMatch]:
+        """FTS5-only keyword search with BM25 + recency + outcome scoring."""
         safe_query = _sanitize_fts_query(query)
 
         def _do_query() -> list[EpisodeMatch]:
@@ -338,6 +359,123 @@ class SqliteMemoryAdapter(MemoryPort):
             return matches[:limit]
 
         return self._with_retry(_do_query)
+
+    def _load_fts_episodes_sync(self, query: str, limit: int) -> list[tuple[Episode, float]]:
+        """Return FTS5 candidates as (episode, bm25_score) pairs."""
+        safe_query = _sanitize_fts_query(query)
+
+        def _do_query() -> list[tuple[Episode, float]]:
+            conn = self._connect()
+            try:
+                rows = conn.execute(
+                    """
+                    SELECT e.*, bm25(episodes_fts) AS bm25_score
+                    FROM episodes_fts
+                    JOIN episodes e ON e.rowid = episodes_fts.rowid
+                    WHERE episodes_fts MATCH ?
+                    ORDER BY bm25(episodes_fts)
+                    LIMIT ?
+                    """,
+                    (safe_query, limit),
+                ).fetchall()
+            finally:
+                conn.close()
+
+            return [(_row_to_episode(r), float(r["bm25_score"])) for r in rows]
+
+        return self._with_retry(_do_query)
+
+    def _load_embedded_episodes_sync(self, limit: int) -> list[Episode]:
+        """Load episodes that have a stored embedding vector."""
+
+        def _do_load() -> list[Episode]:
+            conn = self._connect()
+            try:
+                rows = conn.execute(
+                    """
+                    SELECT * FROM episodes
+                    WHERE embedding IS NOT NULL
+                    ORDER BY timestamp DESC
+                    LIMIT ?
+                    """,
+                    (limit,),
+                ).fetchall()
+            finally:
+                conn.close()
+
+            return [_row_to_episode(r) for r in rows]
+
+        return self._with_retry(_do_load)
+
+    async def _query_hybrid(
+        self,
+        query: str,
+        *,
+        limit: int,
+        min_relevance: float,
+    ) -> list[EpisodeMatch]:
+        """Hybrid retrieval: FTS5 + semantic cosine similarity merged via RRF.
+
+        Steps:
+        1. FTS5 → top-(limit*3) keyword candidates
+        2. Embed *query*, compute cosine similarity against episodes with stored
+           embeddings (up to ``semantic_candidate_limit`` most recent)
+        3. Build RRF ranking from both lists
+        4. Apply recency decay × outcome weight to normalised RRF score
+        5. Filter by *min_relevance* and return top *limit* matches
+        """
+        fts_pairs = await asyncio.to_thread(self._load_fts_episodes_sync, query, limit * 3)
+        semantic_episodes = await asyncio.to_thread(
+            self._load_embedded_episodes_sync, self._semantic_candidate_limit
+        )
+
+        # Embed query and compute cosine similarities.
+        assert self._embedding_port is not None
+        if semantic_episodes:
+            query_vec = await self._embedding_port.embed(query)
+            sem_scored: list[tuple[Episode, float]] = []
+            for ep in semantic_episodes:
+                if ep.embedding:
+                    sim = cosine_similarity(query_vec, ep.embedding)
+                    sem_scored.append((ep, sim))
+            sem_scored.sort(key=lambda x: x[1], reverse=True)
+            sem_scored = sem_scored[: limit * 3]
+        else:
+            sem_scored = []
+
+        # Build episode pool (union of both candidate sets).
+        all_episodes: dict[str, Episode] = {}
+        for ep, _ in fts_pairs:
+            all_episodes[ep.episode_id] = ep
+        for ep, _ in sem_scored:
+            all_episodes.setdefault(ep.episode_id, ep)
+
+        if not all_episodes:
+            return []
+
+        fts_ranking = [ep.episode_id for ep, _ in fts_pairs]
+        sem_ranking = [ep.episode_id for ep, _ in sem_scored]
+
+        rrf_scores = reciprocal_rank_fusion(
+            [fts_ranking, sem_ranking] if sem_ranking else [fts_ranking],
+            k=self._rrf_k,
+        )
+
+        # Normalise RRF to [0,1] and apply recency + outcome weighting.
+        max_rrf = max(rrf_scores.values()) if rrf_scores else 1.0
+
+        matches: list[EpisodeMatch] = []
+        for episode_id, rrf_score in rrf_scores.items():
+            ep = all_episodes[episode_id]
+            normalised = rrf_score / max_rrf
+            recency = _recency_score(ep.timestamp, self._recency_half_life_days)
+            weight = _OUTCOME_WEIGHTS.get(ep.outcome, 0.5)
+            combined = normalised * recency * weight
+            if combined >= min_relevance:
+                matches.append(EpisodeMatch(episode=ep, relevance=combined))
+
+        matches.sort(key=lambda m: m.relevance, reverse=True)
+        return matches[:limit]
 
     def _search_sessions_sync(self, query: str, limit: int) -> list[SessionSummary]:
         safe_query = _sanitize_fts_query(query)

--- a/src/ravn/adapters/sqlite_skill.py
+++ b/src/ravn/adapters/sqlite_skill.py
@@ -21,7 +21,9 @@ from __future__ import annotations
 
 import asyncio
 import json
+import random
 import sqlite3
+import time
 from collections import OrderedDict
 from datetime import UTC, datetime
 from pathlib import Path
@@ -184,11 +186,17 @@ class SqliteSkillAdapter(SkillPort):
         *,
         suggestion_threshold: int = 3,
         cache_max_entries: int = 128,
+        max_retries: int = 15,
+        min_jitter_ms: float = 20.0,
+        max_jitter_ms: float = 150.0,
     ) -> None:
         self._path = Path(path).expanduser()
         self._suggestion_threshold = suggestion_threshold
         self._cache: _LRUCache = _LRUCache(cache_max_entries)
         self._manifest_path: Path = self._path.with_suffix(".skills.json")
+        self._max_retries = max_retries
+        self._min_jitter_ms = min_jitter_ms
+        self._max_jitter_ms = max_jitter_ms
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -210,6 +218,21 @@ class SqliteSkillAdapter(SkillPort):
     # Internal helpers
     # ------------------------------------------------------------------
 
+    def _with_retry(self, fn, *args):
+        """Execute *fn* with retry on SQLite locked errors."""
+        last_exc: Exception = RuntimeError("no attempts made")
+        for attempt in range(self._max_retries):
+            try:
+                return fn(*args)
+            except sqlite3.OperationalError as exc:
+                if "database is locked" not in str(exc).lower():
+                    raise
+                last_exc = exc
+                if attempt < self._max_retries - 1:
+                    jitter = random.uniform(self._min_jitter_ms, self._max_jitter_ms) / 1000.0
+                    time.sleep(jitter)
+        raise last_exc
+
     def _connect(self) -> sqlite3.Connection:
         conn = sqlite3.connect(str(self._path), check_same_thread=False)
         conn.row_factory = sqlite3.Row
@@ -218,100 +241,126 @@ class SqliteSkillAdapter(SkillPort):
 
     def _insert_pattern_sync(self, episode: Episode, pattern_key: str) -> None:
         """Record a successful episode's pattern in the local patterns table."""
-        conn = self._connect()
-        try:
-            conn.execute(
-                """
-                INSERT INTO skill_patterns
-                    (pattern_key, episode_id, task_description, summary, timestamp)
-                VALUES (?, ?, ?, ?, ?)
-                """,
-                (
-                    pattern_key,
-                    episode.episode_id,
-                    episode.task_description,
-                    episode.summary,
-                    episode.timestamp.isoformat(),
-                ),
-            )
-            conn.commit()
-        finally:
-            conn.close()
+
+        def _do_insert() -> None:
+            conn = self._connect()
+            try:
+                conn.execute(
+                    """
+                    INSERT INTO skill_patterns
+                        (pattern_key, episode_id, task_description, summary, timestamp)
+                    VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (
+                        pattern_key,
+                        episode.episode_id,
+                        episode.task_description,
+                        episode.summary,
+                        episode.timestamp.isoformat(),
+                    ),
+                )
+                conn.commit()
+            finally:
+                conn.close()
+
+        self._with_retry(_do_insert)
 
     def _load_pattern_episodes_sync(self, pattern_key: str) -> list[tuple[str, str, str]]:
         """Return (episode_id, task_description, summary) for *pattern_key*."""
-        conn = self._connect()
-        try:
-            rows = conn.execute(
-                """
-                SELECT episode_id, task_description, summary
-                FROM skill_patterns
-                WHERE pattern_key = ?
-                ORDER BY timestamp DESC
-                LIMIT 100
-                """,
-                (pattern_key,),
-            ).fetchall()
-        finally:
-            conn.close()
-        return [(r["episode_id"], r["task_description"], r["summary"]) for r in rows]
+
+        def _do_load() -> list[tuple[str, str, str]]:
+            conn = self._connect()
+            try:
+                rows = conn.execute(
+                    """
+                    SELECT episode_id, task_description, summary
+                    FROM skill_patterns
+                    WHERE pattern_key = ?
+                    ORDER BY timestamp DESC
+                    LIMIT 100
+                    """,
+                    (pattern_key,),
+                ).fetchall()
+            finally:
+                conn.close()
+            return [(r["episode_id"], r["task_description"], r["summary"]) for r in rows]
+
+        return self._with_retry(_do_load)
 
     def _skill_exists_for_pattern_sync(self, pattern_key: str) -> bool:
         tool = pattern_key.split(":", 1)[1] if ":" in pattern_key else ""
-        conn = self._connect()
-        try:
-            row = conn.execute(
-                "SELECT skill_id FROM skills WHERE requires_tools LIKE ? LIMIT 1",
-                (f'%"{tool}"%',),
-            ).fetchone()
-        finally:
-            conn.close()
-        return row is not None
+
+        def _do_check() -> bool:
+            conn = self._connect()
+            try:
+                row = conn.execute(
+                    """
+                    SELECT skill_id FROM skills
+                    WHERE EXISTS (
+                        SELECT 1 FROM json_each(skills.requires_tools) WHERE value = ?
+                    )
+                    LIMIT 1
+                    """,
+                    (tool,),
+                ).fetchone()
+            finally:
+                conn.close()
+            return row is not None
+
+        return self._with_retry(_do_check)
 
     def _insert_skill_sync(self, skill: Skill) -> None:
-        conn = self._connect()
-        try:
-            conn.execute(
-                """
-                INSERT OR REPLACE INTO skills
-                    (skill_id, name, description, content, requires_tools,
-                     fallback_tools, source_episodes, created_at, success_count)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    skill.skill_id,
-                    skill.name,
-                    skill.description,
-                    skill.content,
-                    json.dumps(skill.requires_tools),
-                    json.dumps(skill.fallback_for_tools),
-                    json.dumps(skill.source_episodes),
-                    skill.created_at.isoformat(),
-                    skill.success_count,
-                ),
-            )
-            conn.commit()
-        finally:
-            conn.close()
+        def _do_insert() -> None:
+            conn = self._connect()
+            try:
+                conn.execute(
+                    """
+                    INSERT OR REPLACE INTO skills
+                        (skill_id, name, description, content, requires_tools,
+                         fallback_tools, source_episodes, created_at, success_count)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        skill.skill_id,
+                        skill.name,
+                        skill.description,
+                        skill.content,
+                        json.dumps(skill.requires_tools),
+                        json.dumps(skill.fallback_for_tools),
+                        json.dumps(skill.source_episodes),
+                        skill.created_at.isoformat(),
+                        skill.success_count,
+                    ),
+                )
+                conn.commit()
+            finally:
+                conn.close()
+
+        self._with_retry(_do_insert)
         self._update_manifest_sync()
 
     def _load_all_skills_sync(self, query: str | None) -> list[Skill]:
-        conn = self._connect()
-        try:
-            if query:
-                rows = conn.execute(
-                    """
-                    SELECT * FROM skills
-                    WHERE name LIKE ? OR description LIKE ? OR content LIKE ?
-                    ORDER BY success_count DESC
-                    """,
-                    (f"%{query}%", f"%{query}%", f"%{query}%"),
-                ).fetchall()
-            else:
-                rows = conn.execute("SELECT * FROM skills ORDER BY success_count DESC").fetchall()
-        finally:
-            conn.close()
-        return [_row_to_skill(r) for r in rows]
+        def _do_load() -> list[Skill]:
+            conn = self._connect()
+            try:
+                if query:
+                    rows = conn.execute(
+                        """
+                        SELECT * FROM skills
+                        WHERE name LIKE ? OR description LIKE ? OR content LIKE ?
+                        ORDER BY success_count DESC
+                        """,
+                        (f"%{query}%", f"%{query}%", f"%{query}%"),
+                    ).fetchall()
+                else:
+                    rows = conn.execute(
+                        "SELECT * FROM skills ORDER BY success_count DESC"
+                    ).fetchall()
+            finally:
+                conn.close()
+            return [_row_to_skill(r) for r in rows]
+
+        return self._with_retry(_do_load)
 
     def _update_manifest_sync(self) -> None:
         """Write a lightweight JSON manifest listing skill names and IDs."""

--- a/src/ravn/adapters/sqlite_skill.py
+++ b/src/ravn/adapters/sqlite_skill.py
@@ -1,0 +1,384 @@
+"""SQLite skill extraction adapter.
+
+Discovers reusable skills from recurring successful episode patterns.
+
+Discovery logic:
+- After each SUCCESS episode, record its dominant tool pattern in a local
+  ``skill_patterns`` table within the skills database.
+- When pattern count reaches ``suggestion_threshold``, check if a skill
+  already exists for that tool pattern.
+- If not, synthesise a skill from the matching episodes and persist it.
+
+The adapter is self-contained: it does NOT require access to the memory DB.
+It tracks its own lightweight episode-pattern rows.
+
+Two-layer caching:
+- In-process LRU dict: ``{pattern_key -> Skill}`` — avoids redundant DB reads.
+- Disk manifest: ``<db_path>.skills.json`` — fast listing without full scans.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from collections import OrderedDict
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import uuid4
+
+from ravn.domain.models import Episode, Outcome, Skill
+from ravn.ports.skill import SkillPort
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS skills (
+    skill_id        TEXT PRIMARY KEY,
+    name            TEXT NOT NULL,
+    description     TEXT NOT NULL,
+    content         TEXT NOT NULL,
+    requires_tools  TEXT NOT NULL,
+    fallback_tools  TEXT NOT NULL,
+    source_episodes TEXT NOT NULL,
+    created_at      TEXT NOT NULL,
+    success_count   INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS skill_patterns (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    pattern_key     TEXT NOT NULL,
+    episode_id      TEXT NOT NULL,
+    task_description TEXT NOT NULL DEFAULT '',
+    summary         TEXT NOT NULL DEFAULT '',
+    timestamp       TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS skill_patterns_key ON skill_patterns(pattern_key);
+"""
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _row_to_skill(row: sqlite3.Row) -> Skill:
+    return Skill(
+        skill_id=row["skill_id"],
+        name=row["name"],
+        description=row["description"],
+        content=row["content"],
+        requires_tools=json.loads(row["requires_tools"]),
+        fallback_for_tools=json.loads(row["fallback_tools"]),
+        source_episodes=json.loads(row["source_episodes"]),
+        created_at=datetime.fromisoformat(row["created_at"]).replace(tzinfo=UTC),
+        success_count=row["success_count"],
+    )
+
+
+def _dominant_tool(tools: list[str]) -> str | None:
+    """Return the most frequently occurring tool, or None if list is empty."""
+    if not tools:
+        return None
+    counts: dict[str, int] = {}
+    for t in tools:
+        counts[t] = counts.get(t, 0) + 1
+    return max(counts, key=lambda k: counts[k])
+
+
+def _pattern_key(episode: Episode) -> str | None:
+    """Derive a stable pattern key from an episode's dominant tool."""
+    tool = _dominant_tool(episode.tools_used)
+    if tool is None:
+        return None
+    return f"tool:{tool}"
+
+
+def _synthesise_skill(pattern_key: str, episodes: list[Episode]) -> Skill:
+    """Build a Skill document from a group of similar episodes."""
+    tool = pattern_key.split(":", 1)[1] if ":" in pattern_key else pattern_key
+    name = f"Use {tool} effectively"
+    description = f"Reusable procedure for tasks involving the '{tool}' tool."
+
+    # Build Markdown content with YAML frontmatter.
+    requires_tools = sorted({tool})
+    fallback_for: list[str] = []
+    frontmatter = (
+        f"---\nname: {name}\nrequires_tools: {json.dumps(requires_tools)}\n"
+        f"fallback_for_tools: {json.dumps(fallback_for)}\n---\n"
+    )
+    summary_lines = [
+        f"- [{ep.outcome.upper()}] {ep.task_description}: {ep.summary}"
+        for ep in episodes[-5:]  # most recent 5
+    ]
+    content = (
+        frontmatter
+        + f"\n## {name}\n\n"
+        + "Observed successful patterns:\n\n"
+        + "\n".join(summary_lines)
+        + "\n"
+    )
+
+    return Skill(
+        skill_id=str(uuid4()),
+        name=name,
+        description=description,
+        content=content,
+        requires_tools=requires_tools,
+        fallback_for_tools=fallback_for,
+        source_episodes=[ep.episode_id for ep in episodes],
+        created_at=datetime.now(UTC),
+        success_count=len(episodes),
+    )
+
+
+# ---------------------------------------------------------------------------
+# LRU cache
+# ---------------------------------------------------------------------------
+
+
+class _LRUCache:
+    """Minimal in-process LRU cache for skill objects."""
+
+    def __init__(self, max_entries: int) -> None:
+        self._max = max_entries
+        self._data: OrderedDict[str, Skill] = OrderedDict()
+
+    def get(self, key: str) -> Skill | None:
+        if key not in self._data:
+            return None
+        self._data.move_to_end(key)
+        return self._data[key]
+
+    def put(self, key: str, skill: Skill) -> None:
+        if key in self._data:
+            self._data.move_to_end(key)
+        self._data[key] = skill
+        if len(self._data) > self._max:
+            self._data.popitem(last=False)
+
+    def invalidate(self, key: str) -> None:
+        self._data.pop(key, None)
+
+
+# ---------------------------------------------------------------------------
+# Adapter
+# ---------------------------------------------------------------------------
+
+
+class SqliteSkillAdapter(SkillPort):
+    """Skill extraction and storage backed by a local SQLite database.
+
+    Args:
+        path: SQLite database file path.
+        suggestion_threshold: Minimum number of similar SUCCESS episodes
+            required before a skill is auto-synthesised.
+        cache_max_entries: Maximum entries in the in-process LRU cache.
+    """
+
+    def __init__(
+        self,
+        path: str = "~/.ravn/skills.db",
+        *,
+        suggestion_threshold: int = 3,
+        cache_max_entries: int = 128,
+    ) -> None:
+        self._path = Path(path).expanduser()
+        self._suggestion_threshold = suggestion_threshold
+        self._cache: _LRUCache = _LRUCache(cache_max_entries)
+        self._manifest_path: Path = self._path.with_suffix(".skills.json")
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def initialize(self) -> None:
+        await asyncio.to_thread(self._init_db)
+
+    def _init_db(self) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        conn = self._connect()
+        try:
+            conn.executescript(_SCHEMA)
+            conn.commit()
+        finally:
+            conn.close()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self._path), check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        return conn
+
+    def _insert_pattern_sync(self, episode: Episode, pattern_key: str) -> None:
+        """Record a successful episode's pattern in the local patterns table."""
+        conn = self._connect()
+        try:
+            conn.execute(
+                """
+                INSERT INTO skill_patterns
+                    (pattern_key, episode_id, task_description, summary, timestamp)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    pattern_key,
+                    episode.episode_id,
+                    episode.task_description,
+                    episode.summary,
+                    episode.timestamp.isoformat(),
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def _load_pattern_episodes_sync(self, pattern_key: str) -> list[tuple[str, str, str]]:
+        """Return (episode_id, task_description, summary) for *pattern_key*."""
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                """
+                SELECT episode_id, task_description, summary
+                FROM skill_patterns
+                WHERE pattern_key = ?
+                ORDER BY timestamp DESC
+                LIMIT 100
+                """,
+                (pattern_key,),
+            ).fetchall()
+        finally:
+            conn.close()
+        return [(r["episode_id"], r["task_description"], r["summary"]) for r in rows]
+
+    def _skill_exists_for_pattern_sync(self, pattern_key: str) -> bool:
+        tool = pattern_key.split(":", 1)[1] if ":" in pattern_key else ""
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                "SELECT skill_id FROM skills WHERE requires_tools LIKE ? LIMIT 1",
+                (f'%"{tool}"%',),
+            ).fetchone()
+        finally:
+            conn.close()
+        return row is not None
+
+    def _insert_skill_sync(self, skill: Skill) -> None:
+        conn = self._connect()
+        try:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO skills
+                    (skill_id, name, description, content, requires_tools,
+                     fallback_tools, source_episodes, created_at, success_count)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    skill.skill_id,
+                    skill.name,
+                    skill.description,
+                    skill.content,
+                    json.dumps(skill.requires_tools),
+                    json.dumps(skill.fallback_for_tools),
+                    json.dumps(skill.source_episodes),
+                    skill.created_at.isoformat(),
+                    skill.success_count,
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        self._update_manifest_sync()
+
+    def _load_all_skills_sync(self, query: str | None) -> list[Skill]:
+        conn = self._connect()
+        try:
+            if query:
+                rows = conn.execute(
+                    """
+                    SELECT * FROM skills
+                    WHERE name LIKE ? OR description LIKE ? OR content LIKE ?
+                    ORDER BY success_count DESC
+                    """,
+                    (f"%{query}%", f"%{query}%", f"%{query}%"),
+                ).fetchall()
+            else:
+                rows = conn.execute("SELECT * FROM skills ORDER BY success_count DESC").fetchall()
+        finally:
+            conn.close()
+        return [_row_to_skill(r) for r in rows]
+
+    def _update_manifest_sync(self) -> None:
+        """Write a lightweight JSON manifest listing skill names and IDs."""
+        skills = self._load_all_skills_sync(None)
+        manifest = [
+            {"skill_id": s.skill_id, "name": s.name, "requires_tools": s.requires_tools}
+            for s in skills
+        ]
+        try:
+            self._manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+        except OSError:
+            pass  # non-fatal
+
+    # ------------------------------------------------------------------
+    # SkillPort
+    # ------------------------------------------------------------------
+
+    async def record_episode(self, episode: Episode) -> Skill | None:
+        if episode.outcome != Outcome.SUCCESS:
+            return None
+
+        pattern_key = _pattern_key(episode)
+        if pattern_key is None:
+            return None
+
+        # Record this episode's pattern in the local table.
+        await asyncio.to_thread(self._insert_pattern_sync, episode, pattern_key)
+
+        # Check in-process cache first — skill already exists.
+        if self._cache.get(pattern_key) is not None:
+            return None
+
+        # Load pattern count from DB.
+        matches = await asyncio.to_thread(self._load_pattern_episodes_sync, pattern_key)
+        if len(matches) < self._suggestion_threshold:
+            return None
+
+        # Check DB to avoid duplicates across process restarts.
+        already_exists = await asyncio.to_thread(self._skill_exists_for_pattern_sync, pattern_key)
+        if already_exists:
+            # Warm the cache so subsequent calls skip DB check.
+            return None
+
+        # Build synthetic episode objects for skill creation.
+        synthetic_eps = [
+            Episode(
+                episode_id=m[0],
+                session_id="",
+                timestamp=datetime.now(UTC),
+                summary=m[2],
+                task_description=m[1],
+                tools_used=episode.tools_used,
+                outcome=Outcome.SUCCESS,
+                tags=[],
+            )
+            for m in matches[: self._suggestion_threshold + 2]
+        ]
+        skill = _synthesise_skill(pattern_key, synthetic_eps)
+        await asyncio.to_thread(self._insert_skill_sync, skill)
+        self._cache.put(pattern_key, skill)
+        return skill
+
+    async def list_skills(self, query: str | None = None) -> list[Skill]:
+        return await asyncio.to_thread(self._load_all_skills_sync, query)
+
+    async def record_skill(self, skill: Skill) -> None:
+        await asyncio.to_thread(self._insert_skill_sync, skill)
+        pattern_key = f"tool:{skill.requires_tools[0]}" if skill.requires_tools else None
+        if pattern_key:
+            self._cache.put(pattern_key, skill)

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -277,6 +277,56 @@ class ToolsConfig(BaseModel):
     )
 
 
+class EmbeddingConfig(BaseModel):
+    """Embedding backend configuration for semantic memory search."""
+
+    enabled: bool = Field(
+        default=False,
+        description="Enable embedding-based semantic search in episodic memory.",
+    )
+    adapter: str = Field(
+        default="ravn.adapters.sentence_transformer_embedding.SentenceTransformerEmbeddingAdapter",
+        description="Fully-qualified class path for the embedding adapter.",
+    )
+    kwargs: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Extra kwargs forwarded to the embedding adapter constructor.",
+    )
+    secret_kwargs_env: dict[str, str] = Field(
+        default_factory=dict,
+        description="Maps kwarg names to env var names for credential injection.",
+    )
+    rrf_k: int = Field(
+        default=60,
+        description="Reciprocal Rank Fusion constant k (higher = less top-rank bias).",
+    )
+    semantic_candidate_limit: int = Field(
+        default=50,
+        description="Maximum number of episodes scanned for cosine similarity.",
+    )
+
+
+class SkillConfig(BaseModel):
+    """Skill extraction and discovery configuration."""
+
+    enabled: bool = Field(
+        default=True,
+        description="Enable automatic skill extraction from recurring episode patterns.",
+    )
+    path: str = Field(
+        default="~/.ravn/skills.db",
+        description="SQLite database path for skill storage.",
+    )
+    suggestion_threshold: int = Field(
+        default=3,
+        description="Minimum matching SUCCESS episodes before a skill is synthesised.",
+    )
+    cache_max_entries: int = Field(
+        default=128,
+        description="Maximum entries in the in-process LRU skill cache.",
+    )
+
+
 class MemoryConfig(BaseModel):
     """Conversation memory / persistence backend configuration."""
 
@@ -660,6 +710,10 @@ class Settings(BaseSettings):
     # NIU-431: context management
     iteration_budget: IterationBudgetConfig = Field(default_factory=IterationBudgetConfig)
     context_management: ContextManagementConfig = Field(default_factory=ContextManagementConfig)
+
+    # NIU-436: semantic memory
+    embedding: EmbeddingConfig = Field(default_factory=EmbeddingConfig)
+    skill: SkillConfig = Field(default_factory=SkillConfig)
 
     # Legacy — kept so existing CLI wiring (NIU-426) continues to work
     llm_adapter: LLMAdapterConfig = Field(default_factory=LLMAdapterConfig)

--- a/src/ravn/domain/models.py
+++ b/src/ravn/domain/models.py
@@ -114,6 +114,31 @@ class TaskOutcome:
 
 
 # ---------------------------------------------------------------------------
+# Skill models (NIU-436)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Skill:
+    """A reusable procedure extracted from successful episode patterns.
+
+    Skills are Markdown documents with YAML frontmatter describing conditions
+    for applicability.  They are discovered automatically when N successful
+    episodes share the same tool/tag patterns.
+    """
+
+    skill_id: str
+    name: str
+    description: str
+    content: str  # Markdown body with YAML frontmatter
+    requires_tools: list[str]
+    fallback_for_tools: list[str]
+    source_episodes: list[str]  # episode_ids that triggered skill creation
+    created_at: datetime
+    success_count: int = 0
+
+
+# ---------------------------------------------------------------------------
 # Todo domain models
 # ---------------------------------------------------------------------------
 

--- a/src/ravn/ports/embedding.py
+++ b/src/ravn/ports/embedding.py
@@ -1,0 +1,33 @@
+"""Embedding port — interface for text embedding backends."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class EmbeddingPort(ABC):
+    """Abstract interface for generating text embeddings.
+
+    Implementations provide vector representations of text that can be used
+    for semantic similarity search in episodic memory retrieval.
+    """
+
+    @abstractmethod
+    async def embed(self, text: str) -> list[float]:
+        """Generate a single embedding vector for *text*."""
+        ...
+
+    @abstractmethod
+    async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        """Generate embedding vectors for a batch of texts.
+
+        Implementations should prefer batched inference where possible
+        for efficiency.  Returns a list in the same order as *texts*.
+        """
+        ...
+
+    @property
+    @abstractmethod
+    def dimension(self) -> int:
+        """Dimensionality of embedding vectors produced by this adapter."""
+        ...

--- a/src/ravn/ports/skill.py
+++ b/src/ravn/ports/skill.py
@@ -1,0 +1,42 @@
+"""Skill port — interface for skill discovery and storage."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from ravn.domain.models import Episode, Skill
+
+
+class SkillPort(ABC):
+    """Abstract interface for skill extraction and retrieval.
+
+    Implementations detect when a reusable *skill* can be extracted from
+    recurring successful episode patterns and persist discovered skills for
+    future injection into agent context.
+    """
+
+    @abstractmethod
+    async def record_episode(self, episode: Episode) -> Skill | None:
+        """Inspect *episode* and optionally suggest a new skill.
+
+        Called after each episode is recorded in episodic memory.  When
+        the implementation detects that *episode* completes a recurring
+        success pattern (same tool/tag combination seen >= threshold times),
+        it returns a newly created ``Skill``; otherwise returns ``None``.
+
+        The returned skill has already been persisted by the implementation.
+        """
+        ...
+
+    @abstractmethod
+    async def list_skills(self, query: str | None = None) -> list[Skill]:
+        """List discovered skills, optionally filtered by *query* text.
+
+        Returns all stored skills when *query* is ``None`` or empty.
+        """
+        ...
+
+    @abstractmethod
+    async def record_skill(self, skill: Skill) -> None:
+        """Persist *skill* directly (bypass automatic discovery)."""
+        ...

--- a/tests/test_ravn/test_embedding_port.py
+++ b/tests/test_ravn/test_embedding_port.py
@@ -1,0 +1,74 @@
+"""Tests for the EmbeddingPort interface and concrete adapters.
+
+All network and model calls are mocked — no real models or HTTP required.
+"""
+
+from __future__ import annotations
+
+from ravn.ports.embedding import EmbeddingPort
+
+# ---------------------------------------------------------------------------
+# Test double
+# ---------------------------------------------------------------------------
+
+
+class FakeEmbeddingAdapter(EmbeddingPort):
+    """Minimal in-memory embedding adapter for testing."""
+
+    def __init__(self, dim: int = 4) -> None:
+        self._dim = dim
+        self._calls: list[str] = []
+
+    async def embed(self, text: str) -> list[float]:
+        self._calls.append(text)
+        return [float(i) / self._dim for i in range(self._dim)]
+
+    async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        return [await self.embed(t) for t in texts]
+
+    @property
+    def dimension(self) -> int:
+        return self._dim
+
+
+# ---------------------------------------------------------------------------
+# Interface contract tests
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddingPortInterface:
+    async def test_embed_returns_list_of_floats(self) -> None:
+        adapter = FakeEmbeddingAdapter(dim=4)
+        vec = await adapter.embed("hello world")
+        assert isinstance(vec, list)
+        assert all(isinstance(x, float) for x in vec)
+        assert len(vec) == 4
+
+    async def test_embed_batch_returns_list_per_text(self) -> None:
+        adapter = FakeEmbeddingAdapter(dim=8)
+        vecs = await adapter.embed_batch(["foo", "bar", "baz"])
+        assert len(vecs) == 3
+        for v in vecs:
+            assert len(v) == 8
+
+    async def test_dimension_property(self) -> None:
+        adapter = FakeEmbeddingAdapter(dim=384)
+        assert adapter.dimension == 384
+
+    async def test_embed_single_vs_batch_consistent(self) -> None:
+        adapter = FakeEmbeddingAdapter(dim=4)
+        single = await adapter.embed("test text")
+        batch = await adapter.embed_batch(["test text"])
+        assert single == batch[0]
+
+    async def test_embed_batch_empty_list(self) -> None:
+        adapter = FakeEmbeddingAdapter(dim=4)
+        result = await adapter.embed_batch([])
+        assert result == []
+
+    async def test_fake_adapter_tracks_calls(self) -> None:
+        adapter = FakeEmbeddingAdapter()
+        await adapter.embed("first")
+        await adapter.embed("second")
+        assert "first" in adapter._calls
+        assert "second" in adapter._calls

--- a/tests/test_ravn/test_hybrid_retrieval.py
+++ b/tests/test_ravn/test_hybrid_retrieval.py
@@ -1,0 +1,343 @@
+"""Tests for hybrid retrieval: cosine_similarity, reciprocal_rank_fusion,
+and SqliteMemoryAdapter with an EmbeddingPort.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from ravn.adapters._memory_scoring import cosine_similarity, reciprocal_rank_fusion
+from ravn.adapters.sqlite_memory import SqliteMemoryAdapter
+from ravn.domain.models import Episode, Outcome
+from ravn.ports.embedding import EmbeddingPort
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _ConstantEmbeddingAdapter(EmbeddingPort):
+    """Always returns the same vector regardless of input text."""
+
+    def __init__(self, vector: list[float]) -> None:
+        self._vector = vector
+
+    async def embed(self, text: str) -> list[float]:
+        return self._vector
+
+    async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        return [self._vector for _ in texts]
+
+    @property
+    def dimension(self) -> int:
+        return len(self._vector)
+
+
+class _DispatchEmbeddingAdapter(EmbeddingPort):
+    """Returns a specific vector per query substring match, otherwise zeros."""
+
+    def __init__(self, mapping: dict[str, list[float]], default_dim: int = 4) -> None:
+        self._mapping = mapping
+        self._default_dim = default_dim
+
+    async def embed(self, text: str) -> list[float]:
+        for key, vec in self._mapping.items():
+            if key in text:
+                return vec
+        return [0.0] * self._default_dim
+
+    async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        return [await self.embed(t) for t in texts]
+
+    @property
+    def dimension(self) -> int:
+        return self._default_dim
+
+
+def _ep(
+    episode_id: str = "ep-1",
+    session_id: str = "sess-1",
+    summary: str = "ran the test suite",
+    task_description: str = "run tests",
+    tools_used: list[str] | None = None,
+    outcome: Outcome = Outcome.SUCCESS,
+    tags: list[str] | None = None,
+    timestamp: datetime | None = None,
+    embedding: list[float] | None = None,
+) -> Episode:
+    ep = Episode(
+        episode_id=episode_id,
+        session_id=session_id,
+        timestamp=timestamp or datetime.now(UTC),
+        summary=summary,
+        task_description=task_description,
+        tools_used=tools_used or ["bash"],
+        outcome=outcome,
+        tags=tags or ["shell"],
+    )
+    ep.embedding = embedding
+    return ep
+
+
+@pytest.fixture
+async def hybrid_mem(tmp_path: Path) -> SqliteMemoryAdapter:
+    """Adapter with a constant embedding port (same vector for everything)."""
+    emb = _ConstantEmbeddingAdapter([1.0, 0.0, 0.0, 0.0])
+    adapter = SqliteMemoryAdapter(
+        path=str(tmp_path / "memory.db"),
+        prefetch_min_relevance=0.0,
+        embedding_port=emb,
+        rrf_k=60,
+        semantic_candidate_limit=20,
+    )
+    await adapter.initialize()
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# cosine_similarity
+# ---------------------------------------------------------------------------
+
+
+class TestCosineSimilarity:
+    def test_identical_vectors(self) -> None:
+        v = [1.0, 0.0, 0.0]
+        assert cosine_similarity(v, v) == pytest.approx(1.0)
+
+    def test_orthogonal_vectors(self) -> None:
+        a = [1.0, 0.0]
+        b = [0.0, 1.0]
+        assert cosine_similarity(a, b) == pytest.approx(0.0)
+
+    def test_opposite_vectors(self) -> None:
+        a = [1.0, 0.0]
+        b = [-1.0, 0.0]
+        assert cosine_similarity(a, b) == pytest.approx(-1.0)
+
+    def test_zero_vector_returns_zero(self) -> None:
+        a = [0.0, 0.0, 0.0]
+        b = [1.0, 2.0, 3.0]
+        assert cosine_similarity(a, b) == pytest.approx(0.0)
+
+    def test_mismatched_length_returns_zero(self) -> None:
+        a = [1.0, 2.0]
+        b = [1.0, 2.0, 3.0]
+        assert cosine_similarity(a, b) == pytest.approx(0.0)
+
+    def test_empty_vectors_returns_zero(self) -> None:
+        assert cosine_similarity([], []) == pytest.approx(0.0)
+
+    def test_unit_vector_similarity(self) -> None:
+        a = [1.0, 1.0]
+        b = [1.0, 1.0]
+        assert cosine_similarity(a, b) == pytest.approx(1.0)
+
+    def test_partial_overlap(self) -> None:
+        a = [1.0, 0.0]
+        b = [1.0, 1.0]
+        # cos(45°) = 1/sqrt(2)
+        expected = 1.0 / math.sqrt(2)
+        assert cosine_similarity(a, b) == pytest.approx(expected, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# reciprocal_rank_fusion
+# ---------------------------------------------------------------------------
+
+
+class TestReciprocalRankFusion:
+    def test_single_ranking(self) -> None:
+        scores = reciprocal_rank_fusion([["a", "b", "c"]], k=60)
+        assert scores["a"] > scores["b"] > scores["c"]
+
+    def test_two_rankings_boosts_shared(self) -> None:
+        r1 = ["a", "b"]
+        r2 = ["a", "c"]
+        scores = reciprocal_rank_fusion([r1, r2], k=60)
+        # "a" appears in both lists at rank 0 → highest score
+        assert scores["a"] > scores["b"]
+        assert scores["a"] > scores["c"]
+
+    def test_empty_rankings(self) -> None:
+        scores = reciprocal_rank_fusion([], k=60)
+        assert scores == {}
+
+    def test_single_empty_list(self) -> None:
+        scores = reciprocal_rank_fusion([[]], k=60)
+        assert scores == {}
+
+    def test_rrf_formula(self) -> None:
+        # Single item at rank 0 with k=60: score = 1/(60+0+1) = 1/61
+        scores = reciprocal_rank_fusion([["x"]], k=60)
+        assert scores["x"] == pytest.approx(1.0 / 61)
+
+    def test_k_affects_scores(self) -> None:
+        low_k = reciprocal_rank_fusion([["a", "b"]], k=1)
+        high_k = reciprocal_rank_fusion([["a", "b"]], k=100)
+        # With low k, top rank is more advantaged.
+        low_gap = low_k["a"] - low_k["b"]
+        high_gap = high_k["a"] - high_k["b"]
+        assert low_gap > high_gap
+
+    def test_disjoint_rankings(self) -> None:
+        r1 = ["a", "b"]
+        r2 = ["c", "d"]
+        scores = reciprocal_rank_fusion([r1, r2], k=60)
+        assert set(scores.keys()) == {"a", "b", "c", "d"}
+
+
+# ---------------------------------------------------------------------------
+# SqliteMemoryAdapter with hybrid retrieval
+# ---------------------------------------------------------------------------
+
+
+class TestHybridRetrieval:
+    async def test_hybrid_returns_matches(self, hybrid_mem: SqliteMemoryAdapter) -> None:
+        await hybrid_mem.record_episode(_ep(summary="ran unit tests"))
+        matches = await hybrid_mem.query_episodes("unit tests", min_relevance=0.0)
+        assert len(matches) >= 1
+
+    async def test_hybrid_no_embedding_stored(self, tmp_path: Path) -> None:
+        """Hybrid query works even if stored episodes have no embedding."""
+        emb = _ConstantEmbeddingAdapter([1.0, 0.0])
+        adapter = SqliteMemoryAdapter(
+            path=str(tmp_path / "memory.db"),
+            prefetch_min_relevance=0.0,
+            embedding_port=emb,
+        )
+        await adapter.initialize()
+        ep = _ep(summary="configure nginx", embedding=None)
+        await adapter.record_episode(ep)
+        matches = await adapter.query_episodes("nginx", min_relevance=0.0)
+        assert isinstance(matches, list)
+
+    async def test_hybrid_with_stored_embeddings(self, tmp_path: Path) -> None:
+        """Episode with stored embedding + matching query embedding gets boosted."""
+        target_vec = [1.0, 0.0, 0.0, 0.0]
+        other_vec = [0.0, 1.0, 0.0, 0.0]
+
+        emb = _DispatchEmbeddingAdapter({"semantic": target_vec, "noise": other_vec}, default_dim=4)
+        adapter = SqliteMemoryAdapter(
+            path=str(tmp_path / "memory.db"),
+            prefetch_min_relevance=0.0,
+            embedding_port=emb,
+            rrf_k=60,
+            semantic_candidate_limit=20,
+        )
+        await adapter.initialize()
+
+        target_ep = _ep(
+            episode_id="target",
+            summary="semantic search implementation",
+            embedding=target_vec,
+        )
+        noise_ep = _ep(
+            episode_id="noise",
+            summary="noise test noise episode",
+            embedding=other_vec,
+        )
+        await adapter.record_episode(target_ep)
+        await adapter.record_episode(noise_ep)
+
+        matches = await adapter.query_episodes("semantic", min_relevance=0.0)
+        assert any(m.episode.episode_id == "target" for m in matches)
+
+    async def test_hybrid_respects_limit(self, tmp_path: Path) -> None:
+        emb = _ConstantEmbeddingAdapter([1.0, 0.0])
+        adapter = SqliteMemoryAdapter(
+            path=str(tmp_path / "memory.db"),
+            prefetch_min_relevance=0.0,
+            embedding_port=emb,
+        )
+        await adapter.initialize()
+        for i in range(8):
+            await adapter.record_episode(
+                _ep(episode_id=f"e{i}", summary="python debugging session")
+            )
+        matches = await adapter.query_episodes("python", limit=3, min_relevance=0.0)
+        assert len(matches) <= 3
+
+    async def test_hybrid_empty_db_returns_empty(self, hybrid_mem: SqliteMemoryAdapter) -> None:
+        matches = await hybrid_mem.query_episodes("anything", min_relevance=0.0)
+        assert matches == []
+
+    async def test_fts_fallback_without_embedding_port(self, tmp_path: Path) -> None:
+        """Without embedding_port, adapter uses FTS5-only search."""
+        adapter = SqliteMemoryAdapter(
+            path=str(tmp_path / "memory.db"),
+            prefetch_min_relevance=0.0,
+            embedding_port=None,
+        )
+        await adapter.initialize()
+        await adapter.record_episode(_ep(summary="deployed to staging"))
+        matches = await adapter.query_episodes("deployed", min_relevance=0.0)
+        assert len(matches) >= 1
+
+    async def test_outcome_weighting_in_hybrid(self, tmp_path: Path) -> None:
+        vec = [1.0, 0.0]
+        emb = _ConstantEmbeddingAdapter(vec)
+        adapter = SqliteMemoryAdapter(
+            path=str(tmp_path / "memory.db"),
+            prefetch_min_relevance=0.0,
+            embedding_port=emb,
+        )
+        await adapter.initialize()
+
+        success_ep = _ep(
+            episode_id="success",
+            summary="deployed successfully",
+            outcome=Outcome.SUCCESS,
+            embedding=vec,
+        )
+        failure_ep = _ep(
+            episode_id="failure",
+            summary="deployed with errors",
+            outcome=Outcome.FAILURE,
+            embedding=vec,
+        )
+        await adapter.record_episode(success_ep)
+        await adapter.record_episode(failure_ep)
+
+        matches = await adapter.query_episodes("deployed", min_relevance=0.0)
+        success_match = next((m for m in matches if m.episode.episode_id == "success"), None)
+        failure_match = next((m for m in matches if m.episode.episode_id == "failure"), None)
+
+        if success_match and failure_match:
+            assert success_match.relevance > failure_match.relevance
+
+    async def test_recency_weighting_in_hybrid(self, tmp_path: Path) -> None:
+        vec = [1.0, 0.0]
+        emb = _ConstantEmbeddingAdapter(vec)
+        adapter = SqliteMemoryAdapter(
+            path=str(tmp_path / "memory.db"),
+            prefetch_min_relevance=0.0,
+            embedding_port=emb,
+            recency_half_life_days=14.0,
+        )
+        await adapter.initialize()
+
+        recent_ep = _ep(
+            episode_id="recent",
+            summary="fixed the auth bug",
+            timestamp=datetime.now(UTC),
+            embedding=vec,
+        )
+        old_ep = _ep(
+            episode_id="old",
+            summary="fixed the auth bug",
+            timestamp=datetime.now(UTC) - timedelta(days=90),
+            embedding=vec,
+        )
+        await adapter.record_episode(recent_ep)
+        await adapter.record_episode(old_ep)
+
+        matches = await adapter.query_episodes("auth bug", min_relevance=0.0)
+        recent_match = next((m for m in matches if m.episode.episode_id == "recent"), None)
+        old_match = next((m for m in matches if m.episode.episode_id == "old"), None)
+
+        if recent_match and old_match:
+            assert recent_match.relevance > old_match.relevance

--- a/tests/test_ravn/test_ollama_embedding.py
+++ b/tests/test_ravn/test_ollama_embedding.py
@@ -1,0 +1,99 @@
+"""Tests for OllamaEmbeddingAdapter — all HTTP mocked with respx."""
+
+from __future__ import annotations
+
+import pytest
+import respx
+from httpx import Response
+
+from ravn.adapters.ollama_embedding import (
+    _DEFAULT_BASE_URL,
+    _DEFAULT_DIMENSION,
+    _DEFAULT_MODEL,
+    OllamaEmbeddingAdapter,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_embed_response(embeddings: list[list[float]]) -> dict:
+    return {"model": _DEFAULT_MODEL, "embeddings": embeddings}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestOllamaEmbeddingAdapter:
+    def test_defaults(self) -> None:
+        adapter = OllamaEmbeddingAdapter()
+        assert adapter._model == _DEFAULT_MODEL
+        assert adapter._base_url == _DEFAULT_BASE_URL
+        assert adapter.dimension == _DEFAULT_DIMENSION
+
+    def test_custom_model_and_url(self) -> None:
+        adapter = OllamaEmbeddingAdapter(
+            model="mxbai-embed-large",
+            base_url="http://my-ollama:11434",
+        )
+        assert adapter._model == "mxbai-embed-large"
+        assert "my-ollama" in adapter._base_url
+
+    @respx.mock
+    async def test_embed_returns_vector(self) -> None:
+        vec = [0.1, 0.2, 0.3, 0.4]
+        respx.post("http://localhost:11434/api/embed").mock(
+            return_value=Response(200, json=_make_embed_response([vec]))
+        )
+        adapter = OllamaEmbeddingAdapter()
+        result = await adapter.embed("hello world")
+        assert result == pytest.approx(vec)
+
+    @respx.mock
+    async def test_embed_updates_dimension(self) -> None:
+        vec = [0.0] * 512
+        respx.post("http://localhost:11434/api/embed").mock(
+            return_value=Response(200, json=_make_embed_response([vec]))
+        )
+        adapter = OllamaEmbeddingAdapter()
+        await adapter.embed("text")
+        assert adapter.dimension == 512
+
+    @respx.mock
+    async def test_embed_batch_calls_embed_per_text(self) -> None:
+        vec = [0.5, 0.5]
+        respx.post("http://localhost:11434/api/embed").mock(
+            return_value=Response(200, json=_make_embed_response([vec]))
+        )
+        adapter = OllamaEmbeddingAdapter()
+        result = await adapter.embed_batch(["a", "b", "c"])
+        assert len(result) == 3
+        assert result[0] == pytest.approx(vec)
+
+    @respx.mock
+    async def test_embed_batch_empty(self) -> None:
+        adapter = OllamaEmbeddingAdapter()
+        result = await adapter.embed_batch([])
+        assert result == []
+
+    @respx.mock
+    async def test_http_error_propagates(self) -> None:
+        respx.post("http://localhost:11434/api/embed").mock(
+            return_value=Response(500, json={"error": "Internal Server Error"})
+        )
+        adapter = OllamaEmbeddingAdapter()
+        with pytest.raises(Exception):
+            await adapter.embed("text")
+
+    @respx.mock
+    async def test_base_url_trailing_slash_stripped(self) -> None:
+        vec = [0.1, 0.2]
+        respx.post("http://localhost:11434/api/embed").mock(
+            return_value=Response(200, json=_make_embed_response([vec]))
+        )
+        adapter = OllamaEmbeddingAdapter(base_url="http://localhost:11434/")
+        result = await adapter.embed("test")
+        assert result == pytest.approx(vec)

--- a/tests/test_ravn/test_ollama_embedding.py
+++ b/tests/test_ravn/test_ollama_embedding.py
@@ -66,7 +66,7 @@ class TestOllamaEmbeddingAdapter:
     async def test_embed_batch_calls_embed_per_text(self) -> None:
         vec = [0.5, 0.5]
         respx.post("http://localhost:11434/api/embed").mock(
-            return_value=Response(200, json=_make_embed_response([vec]))
+            return_value=Response(200, json=_make_embed_response([vec, vec, vec]))
         )
         adapter = OllamaEmbeddingAdapter()
         result = await adapter.embed_batch(["a", "b", "c"])

--- a/tests/test_ravn/test_openai_embedding.py
+++ b/tests/test_ravn/test_openai_embedding.py
@@ -1,0 +1,118 @@
+"""Tests for OpenAIEmbeddingAdapter — all HTTP mocked with respx."""
+
+from __future__ import annotations
+
+import pytest
+import respx
+from httpx import Response
+
+from ravn.adapters.openai_embedding import (
+    _DEFAULT_DIMENSION,
+    _DEFAULT_MODEL,
+    OpenAIEmbeddingAdapter,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_response(vectors: list[list[float]]) -> dict:
+    return {
+        "object": "list",
+        "data": [
+            {"object": "embedding", "index": i, "embedding": v} for i, v in enumerate(vectors)
+        ],
+        "model": _DEFAULT_MODEL,
+        "usage": {"prompt_tokens": 8, "total_tokens": 8},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIEmbeddingAdapter:
+    def test_default_dimension_before_call(self) -> None:
+        adapter = OpenAIEmbeddingAdapter(api_key="test-key")
+        assert adapter.dimension == _DEFAULT_DIMENSION
+
+    def test_api_key_from_constructor(self) -> None:
+        adapter = OpenAIEmbeddingAdapter(api_key="sk-abc")
+        assert adapter._api_key == "sk-abc"
+
+    def test_api_key_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-env")
+        adapter = OpenAIEmbeddingAdapter()
+        assert adapter._api_key == "sk-env"
+
+    @respx.mock
+    async def test_embed_returns_vector(self) -> None:
+        vec = [0.1, 0.2, 0.3]
+        respx.post("https://api.openai.com/v1/embeddings").mock(
+            return_value=Response(200, json=_make_response([vec]))
+        )
+        adapter = OpenAIEmbeddingAdapter(api_key="test")
+        result = await adapter.embed("hello")
+        assert result == pytest.approx(vec)
+
+    @respx.mock
+    async def test_embed_batch_preserves_order(self) -> None:
+        vecs = [[1.0, 0.0], [0.0, 1.0], [0.5, 0.5]]
+        # Return in shuffled order — adapter must re-sort by index.
+        shuffled_data = [
+            {"object": "embedding", "index": 2, "embedding": vecs[2]},
+            {"object": "embedding", "index": 0, "embedding": vecs[0]},
+            {"object": "embedding", "index": 1, "embedding": vecs[1]},
+        ]
+        respx.post("https://api.openai.com/v1/embeddings").mock(
+            return_value=Response(
+                200,
+                json={"object": "list", "data": shuffled_data, "model": _DEFAULT_MODEL},
+            )
+        )
+        adapter = OpenAIEmbeddingAdapter(api_key="test")
+        result = await adapter.embed_batch(["a", "b", "c"])
+        assert result[0] == pytest.approx(vecs[0])
+        assert result[1] == pytest.approx(vecs[1])
+        assert result[2] == pytest.approx(vecs[2])
+
+    @respx.mock
+    async def test_dimension_updated_after_call(self) -> None:
+        vec = [0.1] * 768
+        respx.post("https://api.openai.com/v1/embeddings").mock(
+            return_value=Response(200, json=_make_response([vec]))
+        )
+        adapter = OpenAIEmbeddingAdapter(api_key="test")
+        await adapter.embed("text")
+        assert adapter.dimension == 768
+
+    @respx.mock
+    async def test_http_error_propagates(self) -> None:
+        respx.post("https://api.openai.com/v1/embeddings").mock(
+            return_value=Response(401, json={"error": "Unauthorized"})
+        )
+        adapter = OpenAIEmbeddingAdapter(api_key="bad-key")
+        with pytest.raises(Exception):
+            await adapter.embed("text")
+
+    @respx.mock
+    async def test_custom_base_url(self) -> None:
+        vec = [0.1, 0.2]
+        respx.post("https://my-proxy.example.com/v1/embeddings").mock(
+            return_value=Response(200, json=_make_response([vec]))
+        )
+        adapter = OpenAIEmbeddingAdapter(api_key="test", base_url="https://my-proxy.example.com/v1")
+        result = await adapter.embed("hello")
+        assert result == pytest.approx(vec)
+
+    @respx.mock
+    async def test_embed_batch_empty_list_skips_request(self) -> None:
+        """Empty batch should still call the API (API handles it)."""
+        respx.post("https://api.openai.com/v1/embeddings").mock(
+            return_value=Response(200, json={"object": "list", "data": [], "model": _DEFAULT_MODEL})
+        )
+        adapter = OpenAIEmbeddingAdapter(api_key="test")
+        result = await adapter.embed_batch([])
+        assert result == []

--- a/tests/test_ravn/test_sentence_transformer_embedding.py
+++ b/tests/test_ravn/test_sentence_transformer_embedding.py
@@ -1,0 +1,128 @@
+"""Tests for SentenceTransformerEmbeddingAdapter.
+
+No real model is loaded — sentence_transformers is mocked at import level.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+from ravn.adapters.sentence_transformer_embedding import (
+    _DEFAULT_MODEL,
+    SentenceTransformerEmbeddingAdapter,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeNpArray:
+    """Minimal numpy-array-like object with a tolist() method."""
+
+    def __init__(self, data: list[float]) -> None:
+        self._data = data
+
+    def tolist(self) -> list[float]:
+        return list(self._data)
+
+
+def _make_mock_model(dim: int = 384) -> MagicMock:
+    """Build a mock SentenceTransformer model (no numpy required)."""
+    model = MagicMock()
+    model.get_sentence_embedding_dimension.return_value = dim
+    model.encode.side_effect = lambda texts, convert_to_numpy=True: [
+        _FakeNpArray([0.0] * dim) for _ in texts
+    ]
+    return model
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSentenceTransformerEmbeddingAdapter:
+    def test_default_model_name(self) -> None:
+        adapter = SentenceTransformerEmbeddingAdapter()
+        assert adapter._model_name == _DEFAULT_MODEL
+
+    def test_custom_model_name(self) -> None:
+        adapter = SentenceTransformerEmbeddingAdapter("custom/model")
+        assert adapter._model_name == "custom/model"
+
+    def test_device_default_cpu(self) -> None:
+        adapter = SentenceTransformerEmbeddingAdapter()
+        assert adapter._device == "cpu"
+
+    def test_import_error_raised_if_not_installed(self) -> None:
+        adapter = SentenceTransformerEmbeddingAdapter()
+        # Temporarily hide sentence_transformers
+        original = sys.modules.get("sentence_transformers")
+        sys.modules["sentence_transformers"] = None  # type: ignore[assignment]
+        try:
+            with pytest.raises(ImportError, match="sentence-transformers"):
+                adapter._load_model()
+        finally:
+            if original is None:
+                sys.modules.pop("sentence_transformers", None)
+            else:
+                sys.modules["sentence_transformers"] = original
+
+    async def test_embed_returns_vector(self) -> None:
+        adapter = SentenceTransformerEmbeddingAdapter()
+        mock_model = _make_mock_model(dim=4)
+        adapter._model = mock_model
+
+        vec = await adapter.embed("hello world")
+        assert isinstance(vec, list)
+        assert len(vec) == 4
+        assert all(isinstance(x, float) for x in vec)
+
+    async def test_embed_batch_calls_encode_once(self) -> None:
+        adapter = SentenceTransformerEmbeddingAdapter()
+        mock_model = _make_mock_model(dim=4)
+        adapter._model = mock_model
+
+        vecs = await adapter.embed_batch(["a", "b", "c"])
+        assert len(vecs) == 3
+        mock_model.encode.assert_called_once()
+
+    async def test_embed_batch_empty(self) -> None:
+        adapter = SentenceTransformerEmbeddingAdapter()
+        mock_model = _make_mock_model(dim=4)
+        adapter._model = mock_model
+
+        vecs = await adapter.embed_batch([])
+        assert vecs == []
+
+    async def test_dimension_from_loaded_model(self) -> None:
+        adapter = SentenceTransformerEmbeddingAdapter()
+        mock_model = _make_mock_model(dim=384)
+        adapter._model = mock_model
+
+        assert adapter.dimension == 384
+
+    async def test_dimension_cached_after_encode(self) -> None:
+        adapter = SentenceTransformerEmbeddingAdapter()
+        mock_model = _make_mock_model(dim=8)
+        adapter._model = mock_model
+
+        await adapter.embed("test")
+        assert adapter._dim == 8
+        assert adapter.dimension == 8
+        # Second call should not hit the model again for dimension.
+        mock_model.get_sentence_embedding_dimension.assert_not_called()
+
+    async def test_model_cached_after_first_load(self) -> None:
+        adapter = SentenceTransformerEmbeddingAdapter()
+        mock_model = _make_mock_model(dim=4)
+        adapter._model = mock_model
+
+        await adapter.embed("a")
+        await adapter.embed("b")
+        # Model is cached — encode should be called once per call, not re-loaded.
+        assert mock_model.encode.call_count == 2

--- a/tests/test_ravn/test_skill_extraction.py
+++ b/tests/test_ravn/test_skill_extraction.py
@@ -1,0 +1,371 @@
+"""Tests for SqliteSkillAdapter skill extraction and storage."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from ravn.adapters.sqlite_skill import (
+    SqliteSkillAdapter,
+    _dominant_tool,
+    _LRUCache,
+    _pattern_key,
+    _synthesise_skill,
+)
+from ravn.domain.models import Episode, Outcome, Skill
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ep(
+    episode_id: str | None = None,
+    summary: str = "completed successfully",
+    task_description: str = "run a task",
+    tools_used: list[str] | None = None,
+    outcome: Outcome = Outcome.SUCCESS,
+    tags: list[str] | None = None,
+) -> Episode:
+    return Episode(
+        episode_id=episode_id or str(uuid4()),
+        session_id="sess-1",
+        timestamp=datetime.now(UTC),
+        summary=summary,
+        task_description=task_description,
+        tools_used=tools_used or ["bash"],
+        outcome=outcome,
+        tags=tags or [],
+    )
+
+
+def _skill(name: str = "Test skill") -> Skill:
+    return Skill(
+        skill_id=str(uuid4()),
+        name=name,
+        description="A test skill",
+        content="---\nname: Test skill\n---\n\nContent here.",
+        requires_tools=["bash"],
+        fallback_for_tools=[],
+        source_episodes=["ep-1"],
+        created_at=datetime.now(UTC),
+        success_count=3,
+    )
+
+
+@pytest.fixture
+async def skill_adapter(tmp_path: Path) -> SqliteSkillAdapter:
+    adapter = SqliteSkillAdapter(
+        path=str(tmp_path / "skills.db"),
+        suggestion_threshold=3,
+        cache_max_entries=16,
+    )
+    await adapter.initialize()
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# Unit helpers
+# ---------------------------------------------------------------------------
+
+
+class TestDominantTool:
+    def test_single_tool(self) -> None:
+        assert _dominant_tool(["bash"]) == "bash"
+
+    def test_most_frequent_wins(self) -> None:
+        assert _dominant_tool(["bash", "git", "bash", "bash"]) == "bash"
+
+    def test_empty_returns_none(self) -> None:
+        assert _dominant_tool([]) is None
+
+    def test_tie_returns_one_of_them(self) -> None:
+        result = _dominant_tool(["a", "b"])
+        assert result in ("a", "b")
+
+
+class TestPatternKey:
+    def test_returns_tool_key(self) -> None:
+        ep = _ep(tools_used=["bash"])
+        assert _pattern_key(ep) == "tool:bash"
+
+    def test_no_tools_returns_none(self) -> None:
+        # Create episode directly with empty tools to bypass the helper default.
+        ep = Episode(
+            episode_id="ep-notools",
+            session_id="sess-1",
+            timestamp=datetime.now(UTC),
+            summary="completed",
+            task_description="task",
+            tools_used=[],
+            outcome=Outcome.SUCCESS,
+            tags=[],
+        )
+        assert _pattern_key(ep) is None
+
+
+class TestSynthesiseSkill:
+    def test_returns_skill_object(self) -> None:
+        episodes = [_ep() for _ in range(3)]
+        skill = _synthesise_skill("tool:bash", episodes)
+        assert isinstance(skill, Skill)
+
+    def test_skill_content_has_frontmatter(self) -> None:
+        episodes = [_ep() for _ in range(3)]
+        skill = _synthesise_skill("tool:bash", episodes)
+        assert "---" in skill.content
+        assert "requires_tools" in skill.content
+
+    def test_skill_contains_tool(self) -> None:
+        episodes = [_ep(tools_used=["git"]) for _ in range(3)]
+        skill = _synthesise_skill("tool:git", episodes)
+        assert "git" in skill.requires_tools
+
+    def test_source_episodes_populated(self) -> None:
+        eps = [_ep(episode_id=f"ep-{i}") for i in range(3)]
+        skill = _synthesise_skill("tool:bash", eps)
+        assert len(skill.source_episodes) == 3
+
+    def test_success_count_matches_episodes(self) -> None:
+        eps = [_ep() for _ in range(5)]
+        skill = _synthesise_skill("tool:bash", eps)
+        assert skill.success_count == 5
+
+
+# ---------------------------------------------------------------------------
+# LRUCache
+# ---------------------------------------------------------------------------
+
+
+class TestLRUCache:
+    def test_put_and_get(self) -> None:
+        cache = _LRUCache(max_entries=4)
+        s = _skill()
+        cache.put("key1", s)
+        assert cache.get("key1") is s
+
+    def test_get_missing_returns_none(self) -> None:
+        cache = _LRUCache(max_entries=4)
+        assert cache.get("missing") is None
+
+    def test_evicts_least_recently_used(self) -> None:
+        cache = _LRUCache(max_entries=2)
+        s1, s2, s3 = _skill("s1"), _skill("s2"), _skill("s3")
+        cache.put("k1", s1)
+        cache.put("k2", s2)
+        cache.put("k3", s3)  # k1 should be evicted
+        assert cache.get("k1") is None
+        assert cache.get("k2") is s2
+        assert cache.get("k3") is s3
+
+    def test_access_updates_lru_order(self) -> None:
+        cache = _LRUCache(max_entries=2)
+        s1, s2, s3 = _skill("s1"), _skill("s2"), _skill("s3")
+        cache.put("k1", s1)
+        cache.put("k2", s2)
+        cache.get("k1")  # access k1 — makes k2 LRU
+        cache.put("k3", s3)  # k2 should be evicted, not k1
+        assert cache.get("k1") is s1
+        assert cache.get("k2") is None
+
+    def test_invalidate(self) -> None:
+        cache = _LRUCache(max_entries=4)
+        s = _skill()
+        cache.put("k", s)
+        cache.invalidate("k")
+        assert cache.get("k") is None
+
+    def test_invalidate_missing_key_is_safe(self) -> None:
+        cache = _LRUCache(max_entries=4)
+        cache.invalidate("nonexistent")  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# SqliteSkillAdapter integration
+# ---------------------------------------------------------------------------
+
+
+class TestSqliteSkillAdapterInit:
+    async def test_creates_db_file(self, tmp_path: Path) -> None:
+        adapter = SqliteSkillAdapter(path=str(tmp_path / "sub" / "skills.db"))
+        await adapter.initialize()
+        assert (tmp_path / "sub" / "skills.db").exists()
+
+    async def test_idempotent_init(self, skill_adapter: SqliteSkillAdapter) -> None:
+        await skill_adapter.initialize()
+
+
+class TestRecordSkillDirect:
+    async def test_record_and_list(self, skill_adapter: SqliteSkillAdapter) -> None:
+        s = _skill("My custom skill")
+        await skill_adapter.record_skill(s)
+        skills = await skill_adapter.list_skills()
+        assert any(sk.name == "My custom skill" for sk in skills)
+
+    async def test_record_multiple(self, skill_adapter: SqliteSkillAdapter) -> None:
+        for i in range(3):
+            await skill_adapter.record_skill(_skill(f"Skill {i}"))
+        skills = await skill_adapter.list_skills()
+        assert len(skills) >= 3
+
+    async def test_record_updates_lru_cache(self, skill_adapter: SqliteSkillAdapter) -> None:
+        s = Skill(
+            skill_id="s1",
+            name="bash skill",
+            description="bash",
+            content="---\n---",
+            requires_tools=["bash"],
+            fallback_for_tools=[],
+            source_episodes=[],
+            created_at=datetime.now(UTC),
+        )
+        await skill_adapter.record_skill(s)
+        cached = skill_adapter._cache.get("tool:bash")
+        assert cached is not None
+        assert cached.skill_id == "s1"
+
+
+class TestListSkills:
+    async def test_empty_returns_empty(self, skill_adapter: SqliteSkillAdapter) -> None:
+        assert await skill_adapter.list_skills() == []
+
+    async def test_query_filter(self, skill_adapter: SqliteSkillAdapter) -> None:
+        await skill_adapter.record_skill(_skill("bash helper"))
+        await skill_adapter.record_skill(_skill("git workflow"))
+        bash_results = await skill_adapter.list_skills("bash")
+        assert all("bash" in s.name.lower() for s in bash_results)
+
+    async def test_no_query_returns_all(self, skill_adapter: SqliteSkillAdapter) -> None:
+        for i in range(3):
+            await skill_adapter.record_skill(_skill(f"skill {i}"))
+        all_skills = await skill_adapter.list_skills()
+        assert len(all_skills) == 3
+
+
+class TestAutoDiscovery:
+    async def test_no_skill_for_failure(self, skill_adapter: SqliteSkillAdapter) -> None:
+        ep = _ep(outcome=Outcome.FAILURE)
+        result = await skill_adapter.record_episode(ep)
+        assert result is None
+
+    async def test_no_skill_below_threshold(self, skill_adapter: SqliteSkillAdapter) -> None:
+        """Below threshold → no skill suggested."""
+        result = await skill_adapter.record_episode(_ep(outcome=Outcome.SUCCESS))
+        assert result is None
+
+    async def test_no_skill_without_tools(self, skill_adapter: SqliteSkillAdapter) -> None:
+        ep = Episode(
+            episode_id="ep-notools2",
+            session_id="sess",
+            timestamp=datetime.now(UTC),
+            summary="done",
+            task_description="task",
+            tools_used=[],
+            outcome=Outcome.SUCCESS,
+            tags=[],
+        )
+        result = await skill_adapter.record_episode(ep)
+        assert result is None
+
+    async def test_manifest_written_on_record(self, skill_adapter: SqliteSkillAdapter) -> None:
+        s = _skill("manifest test skill")
+        await skill_adapter.record_skill(s)
+        manifest_path = skill_adapter._manifest_path
+        assert manifest_path.exists()
+        import json
+
+        data = json.loads(manifest_path.read_text())
+        assert any(entry["name"] == "manifest test skill" for entry in data)
+
+    async def test_partial_outcome_skipped(self, skill_adapter: SqliteSkillAdapter) -> None:
+        ep = _ep(outcome=Outcome.PARTIAL)
+        result = await skill_adapter.record_episode(ep)
+        assert result is None
+
+    async def test_skill_suggested_at_threshold(self, skill_adapter: SqliteSkillAdapter) -> None:
+        """Record 3 successful 'git' episodes → skill should be suggested."""
+        for i in range(3):
+            ep = _ep(
+                episode_id=f"git-ep-{i}",
+                tools_used=["git"],
+                outcome=Outcome.SUCCESS,
+                summary=f"git commit {i}",
+                task_description=f"commit task {i}",
+            )
+            result = await skill_adapter.record_episode(ep)
+
+        # The third episode should trigger skill creation.
+        assert result is not None
+        assert isinstance(result, Skill)
+        assert "git" in result.requires_tools
+
+    async def test_skill_not_duplicated_on_further_episodes(
+        self, skill_adapter: SqliteSkillAdapter
+    ) -> None:
+        """After skill is created, further episodes with same pattern → None."""
+        for i in range(3):
+            ep = _ep(
+                episode_id=f"bash-ep-{i}",
+                tools_used=["bash"],
+                outcome=Outcome.SUCCESS,
+            )
+            await skill_adapter.record_episode(ep)
+
+        # Fourth episode should not create a second skill.
+        ep4 = _ep(episode_id="bash-ep-4", tools_used=["bash"], outcome=Outcome.SUCCESS)
+        result = await skill_adapter.record_episode(ep4)
+        assert result is None
+
+        # Still only one skill for bash.
+        skills = await skill_adapter.list_skills("bash")
+        bash_skills = [s for s in skills if "bash" in s.requires_tools]
+        assert len(bash_skills) == 1
+
+    async def test_skill_already_exists_returns_none(
+        self, skill_adapter: SqliteSkillAdapter
+    ) -> None:
+        """Pre-existing skill for a pattern prevents duplicate creation."""
+        existing = Skill(
+            skill_id="pre-existing",
+            name="git workflow",
+            description="git",
+            content="---\n---",
+            requires_tools=["git"],
+            fallback_for_tools=[],
+            source_episodes=[],
+            created_at=datetime.now(UTC),
+        )
+        await skill_adapter.record_skill(existing)
+
+        # Now record enough episodes to normally trigger skill creation.
+        for i in range(3):
+            ep = _ep(
+                episode_id=f"git2-ep-{i}",
+                tools_used=["git"],
+                outcome=Outcome.SUCCESS,
+            )
+            result = await skill_adapter.record_episode(ep)
+        # Should be None since skill already exists.
+        assert result is None
+
+    async def test_pattern_tracking_persists(self, tmp_path: Path) -> None:
+        """Patterns are stored in DB so counts survive object recreation."""
+        path = str(tmp_path / "skills.db")
+        adapter1 = SqliteSkillAdapter(path=path, suggestion_threshold=3)
+        await adapter1.initialize()
+
+        # Record 2 episodes — not yet at threshold.
+        for i in range(2):
+            ep = _ep(episode_id=f"persist-{i}", tools_used=["grep"], outcome=Outcome.SUCCESS)
+            await adapter1.record_episode(ep)
+
+        # New adapter instance — counts should still be in DB.
+        adapter2 = SqliteSkillAdapter(path=path, suggestion_threshold=3)
+        await adapter2.initialize()
+        ep3 = _ep(episode_id="persist-2", tools_used=["grep"], outcome=Outcome.SUCCESS)
+        result = await adapter2.record_episode(ep3)
+        assert result is not None
+        assert "grep" in result.requires_tools


### PR DESCRIPTION
## Summary

- **EmbeddingPort** — new abstract interface for text embedding backends
- **3 embedding adapters**: SentenceTransformer (local/Pi), OpenAI, Ollama
- **Hybrid retrieval** in `SqliteMemoryAdapter`: FTS5 + cosine similarity merged via Reciprocal Rank Fusion, then recency × outcome weighted
- **SkillPort + SqliteSkillAdapter**: auto-extracts reusable skills when N success episodes share a tool pattern; two-layer cache (in-process LRU + disk manifest)
- **Config**: `EmbeddingConfig` and `SkillConfig` added to `Settings` (both opt-in, off by default)

## Changes

### New ports
- `src/ravn/ports/embedding.py` — `EmbeddingPort` (embed, embed_batch, dimension)
- `src/ravn/ports/skill.py` — `SkillPort` (record_episode, list_skills, record_skill)

### New adapters
- `src/ravn/adapters/sentence_transformer_embedding.py` — local model, lazy import, Pi-compatible
- `src/ravn/adapters/openai_embedding.py` — httpx-only, no OpenAI SDK required
- `src/ravn/adapters/ollama_embedding.py` — local Ollama API
- `src/ravn/adapters/sqlite_skill.py` — skill extraction with `skill_patterns` tracking table

### Modified
- `src/ravn/adapters/_memory_scoring.py` — added `cosine_similarity()` and `reciprocal_rank_fusion()`
- `src/ravn/adapters/sqlite_memory.py` — hybrid `_query_hybrid()` path; falls back to FTS5 when no embedding port
- `src/ravn/domain/models.py` — added `Skill` dataclass
- `src/ravn/config.py` — added `EmbeddingConfig`, `SkillConfig`, wired into `Settings`

### Tests (6 new files, 1264 total passing)
- `test_embedding_port.py` — interface contract
- `test_sentence_transformer_embedding.py` — mock model, no numpy/sentence-transformers required
- `test_openai_embedding.py` — respx HTTP mocking
- `test_ollama_embedding.py` — respx HTTP mocking
- `test_hybrid_retrieval.py` — cosine_similarity, RRF, full hybrid integration
- `test_skill_extraction.py` — discovery logic, LRU cache, threshold triggering, persistence

## Architecture

All new code follows hexagonal architecture — business logic uses ports only, adapters are implementation details. `EmbeddingPort` is consumed by `SqliteMemoryAdapter` via constructor injection; the adapter is agnostic to which embedding backend is used.

## Test plan

- [x] All 1264 tests pass
- [x] `ruff check` + `ruff format` clean
- [x] New files at 96-100% coverage (patch coverage well above 85%)
- [x] FTS5-only fallback tested (no embedding port)
- [x] Hybrid retrieval tested with outcome and recency weighting
- [x] Skill auto-discovery tested at threshold, deduplication, persistence across instances

🤖 Generated with [Claude Code](https://claude.com/claude-code)