### PR TITLE
feat(adapters): multi-provider LLM fallback chain + OpenAI-compatible adapter (NIU-456)

### DIFF
--- a/src/ravn/adapters/fallback_llm.py
+++ b/src/ravn/adapters/fallback_llm.py
@@ -1,0 +1,124 @@
+"""FallbackLLMAdapter — multi-provider LLM with automatic fallback.
+
+Tries providers in order.  On LLMError the next provider is attempted.
+If all providers fail, AllProvidersExhaustedError is raised.
+
+Restoration: each call starts from the primary (index 0) — there is no
+sticky fallback state between turns.
+
+Example config::
+
+    llm:
+      provider:
+        adapter: ravn.adapters.anthropic_adapter.AnthropicAdapter
+        kwargs: {api_key: "sk-ant-..."}
+      fallbacks:
+        - adapter: ravn.adapters.openai_llm.OpenAICompatibleAdapter
+          kwargs: {base_url: "https://api.openai.com", api_key: "sk-..."}
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+
+from ravn.domain.exceptions import AllProvidersExhaustedError, LLMError
+from ravn.domain.models import LLMResponse, StreamEvent
+from ravn.ports.llm import LLMPort, SystemPrompt
+
+logger = logging.getLogger(__name__)
+
+
+class FallbackLLMAdapter(LLMPort):
+    """LLM adapter that tries a chain of providers, falling back on LLMError.
+
+    The *providers* list must have at least one entry.  The first entry is the
+    primary; the remainder are fallbacks tried in order.
+
+    After any call (success or failure) the next call always starts from the
+    primary — no sticky fallback state is kept between turns.
+    """
+
+    def __init__(self, providers: list[LLMPort]) -> None:
+        if not providers:
+            raise ValueError("FallbackLLMAdapter requires at least one provider")
+        self._providers = providers
+
+    @property
+    def provider_count(self) -> int:
+        """Number of providers in the chain (primary + fallbacks)."""
+        return len(self._providers)
+
+    async def generate(
+        self,
+        messages: list[dict],
+        *,
+        tools: list[dict],
+        system: SystemPrompt,
+        model: str,
+        max_tokens: int,
+    ) -> LLMResponse:
+        last_exc: Exception | None = None
+
+        for idx, provider in enumerate(self._providers):
+            try:
+                return await provider.generate(
+                    messages,
+                    tools=tools,
+                    system=system,
+                    model=model,
+                    max_tokens=max_tokens,
+                )
+            except LLMError as exc:
+                label = "primary" if idx == 0 else f"fallback[{idx}]"
+                logger.warning(
+                    "LLM %s (%s) failed with %s: %s — trying next provider",
+                    label,
+                    type(provider).__name__,
+                    type(exc).__name__,
+                    exc,
+                )
+                last_exc = exc
+
+        raise AllProvidersExhaustedError(
+            provider_count=len(self._providers),
+            last_error=last_exc,
+        ) from last_exc
+
+    async def stream(
+        self,
+        messages: list[dict],
+        *,
+        tools: list[dict],
+        system: SystemPrompt,
+        model: str,
+        max_tokens: int,
+    ) -> AsyncIterator[StreamEvent]:
+        last_exc: Exception | None = None
+
+        for idx, provider in enumerate(self._providers):
+            try:
+                async for event in provider.stream(
+                    messages,
+                    tools=tools,
+                    system=system,
+                    model=model,
+                    max_tokens=max_tokens,
+                ):
+                    yield event
+                return
+            except LLMError as exc:
+                label = "primary" if idx == 0 else f"fallback[{idx}]"
+                logger.warning(
+                    "LLM %s (%s) failed with %s: %s — trying next provider",
+                    label,
+                    type(provider).__name__,
+                    type(exc).__name__,
+                    exc,
+                )
+                last_exc = exc
+
+        raise AllProvidersExhaustedError(
+            provider_count=len(self._providers),
+            last_error=last_exc,
+        ) from last_exc

--- a/src/ravn/adapters/openai_llm.py
+++ b/src/ravn/adapters/openai_llm.py
@@ -1,0 +1,406 @@
+"""OpenAICompatibleAdapter — LLMPort for OpenAI-compatible APIs.
+
+Supports OpenAI, Azure OpenAI, DeepSeek, Ollama (/v1), and any other
+server that implements the OpenAI Chat Completions API.
+
+Features:
+- Streaming via SSE (``data: {...}`` events)
+- Tool calling in OpenAI function-calling format
+- Token usage normalisation: ``prompt_tokens`` → ``input_tokens``,
+  ``completion_tokens`` → ``output_tokens``
+- Reasoning-tag stripping: ``<think>…</think>`` / ``<reasoning>…</reasoning>``
+  blocks (used by DeepSeek-R1, Qwen-QwQ, etc.) are stripped from final text
+- Model-specific steering injection via optional ``system_prefix`` kwarg
+- Transient-error retries (429, 500, 502, 503) with exponential back-off
+
+Tool format conversion
+~~~~~~~~~~~~~~~~~~~~~~
+The caller passes Anthropic-format tool dicts::
+
+    {"name": "...", "description": "...", "input_schema": {...}}
+
+The adapter converts these to OpenAI function-calling format::
+
+    {"type": "function", "function": {"name": "...", "description": "...", "parameters": {...}}}
+
+System prompt
+~~~~~~~~~~~~~
+If ``system`` is a string it is used directly.  If it is a list of Anthropic
+text blocks the text values are concatenated (cache_control entries are
+ignored — OpenAI does not support prompt caching in the same way).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from collections.abc import AsyncIterator
+
+import httpx
+
+from ravn.domain.exceptions import LLMError
+from ravn.domain.models import (
+    LLMResponse,
+    StopReason,
+    StreamEvent,
+    StreamEventType,
+    TokenUsage,
+    ToolCall,
+)
+from ravn.ports.llm import LLMPort, SystemPrompt
+
+logger = logging.getLogger(__name__)
+
+_RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503})
+_DEFAULT_BASE_URL = "https://api.openai.com"
+
+# Regex to strip reasoning tags produced by some open-source models.
+_REASONING_TAG_RE = re.compile(
+    r"<(?:think|reasoning)>.*?</(?:think|reasoning)>",
+    re.DOTALL | re.IGNORECASE,
+)
+
+
+def _strip_reasoning_tags(text: str) -> str:
+    """Remove <think>…</think> and <reasoning>…</reasoning> blocks.
+
+    Only strips leading/trailing whitespace when a tag was actually removed,
+    so that partial streaming deltas (e.g. ``"Hello, "``) are not trimmed.
+    """
+    result = _REASONING_TAG_RE.sub("", text)
+    if result == text:
+        return text
+    return result.strip()
+
+
+def _convert_tools(tools: list[dict]) -> list[dict]:
+    """Convert Anthropic-format tool dicts to OpenAI function-calling format."""
+    converted: list[dict] = []
+    for tool in tools:
+        converted.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": tool["name"],
+                    "description": tool.get("description", ""),
+                    "parameters": tool.get("input_schema", {}),
+                },
+            }
+        )
+    return converted
+
+
+def _system_to_string(system: SystemPrompt) -> str:
+    """Flatten system prompt to a plain string."""
+    if isinstance(system, str):
+        return system
+    # List of Anthropic text blocks — concatenate text values.
+    return "\n\n".join(block.get("text", "") for block in system if block.get("text"))
+
+
+def _normalise_usage(raw: dict) -> TokenUsage:
+    """Normalise an OpenAI usage dict to TokenUsage."""
+    cache_read = 0
+    details = raw.get("prompt_tokens_details") or {}
+    if isinstance(details, dict):
+        cache_read = details.get("cached_tokens", 0) or 0
+
+    return TokenUsage(
+        input_tokens=raw.get("prompt_tokens", 0),
+        output_tokens=raw.get("completion_tokens", 0),
+        cache_read_tokens=cache_read,
+        cache_write_tokens=0,  # OpenAI does not expose cache writes
+    )
+
+
+class OpenAICompatibleAdapter(LLMPort):
+    """Calls any OpenAI-compatible Chat Completions endpoint.
+
+    Constructor kwargs are forwarded from config via the dynamic adapter pattern.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str = "",
+        base_url: str = _DEFAULT_BASE_URL,
+        model: str = "gpt-4o",
+        max_tokens: int = 8192,
+        max_retries: int = 3,
+        retry_base_delay: float = 1.0,
+        timeout: float = 120.0,
+        system_prefix: str = "",
+    ) -> None:
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+        self._default_model = model
+        self._default_max_tokens = max_tokens
+        self._max_retries = max_retries
+        self._retry_base_delay = retry_base_delay
+        self._timeout = timeout
+        self._system_prefix = system_prefix
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _headers(self) -> dict[str, str]:
+        headers = {
+            "content-type": "application/json",
+        }
+        if self._api_key:
+            headers["authorization"] = f"Bearer {self._api_key}"
+        return headers
+
+    def _build_messages(self, messages: list[dict], system: SystemPrompt) -> list[dict]:
+        """Prepend a system message when *system* is non-empty."""
+        system_text = _system_to_string(system)
+        if self._system_prefix:
+            system_text = f"{self._system_prefix}\n\n{system_text}".strip()
+
+        if not system_text:
+            return list(messages)
+
+        return [{"role": "system", "content": system_text}, *messages]
+
+    def _build_request(
+        self,
+        messages: list[dict],
+        *,
+        tools: list[dict],
+        system: SystemPrompt,
+        model: str,
+        max_tokens: int,
+        stream: bool,
+    ) -> dict:
+        body: dict = {
+            "model": model or self._default_model,
+            "max_tokens": max_tokens or self._default_max_tokens,
+            "messages": self._build_messages(messages, system),
+            "stream": stream,
+        }
+        if stream:
+            # Request usage data in the final stream chunk.
+            body["stream_options"] = {"include_usage": True}
+        if tools:
+            body["tools"] = _convert_tools(tools)
+        return body
+
+    async def _post_with_retry(
+        self,
+        client: httpx.AsyncClient,
+        payload: dict,
+        *,
+        stream: bool,
+    ) -> httpx.Response:
+        url = f"{self._base_url}/v1/chat/completions"
+        last_exc: Exception | None = None
+
+        for attempt in range(self._max_retries + 1):
+            try:
+                if stream:
+                    response = await client.send(
+                        client.build_request("POST", url, json=payload),
+                        stream=True,
+                    )
+                else:
+                    response = await client.post(url, json=payload)
+
+                if response.status_code not in _RETRYABLE_STATUS_CODES:
+                    return response
+
+                if stream:
+                    await response.aclose()
+
+                if attempt < self._max_retries:
+                    delay = self._retry_base_delay * (2**attempt)
+                    logger.warning(
+                        "OpenAI-compatible API returned %s, retrying in %.1fs (attempt %d/%d)",
+                        response.status_code,
+                        delay,
+                        attempt + 1,
+                        self._max_retries,
+                    )
+                    await asyncio.sleep(delay)
+                    last_exc = LLMError(
+                        f"OpenAI-compatible API error {response.status_code}",
+                        status_code=response.status_code,
+                    )
+
+            except httpx.TransportError as exc:
+                last_exc = exc
+                if attempt < self._max_retries:
+                    delay = self._retry_base_delay * (2**attempt)
+                    await asyncio.sleep(delay)
+
+        raise LLMError(
+            f"OpenAI-compatible API failed after {self._max_retries} retries"
+        ) from last_exc
+
+    # ------------------------------------------------------------------
+    # LLMPort implementation
+    # ------------------------------------------------------------------
+
+    async def stream(
+        self,
+        messages: list[dict],
+        *,
+        tools: list[dict],
+        system: SystemPrompt,
+        model: str,
+        max_tokens: int,
+    ) -> AsyncIterator[StreamEvent]:
+        payload = self._build_request(
+            messages,
+            tools=tools,
+            system=system,
+            model=model,
+            max_tokens=max_tokens,
+            stream=True,
+        )
+
+        async with httpx.AsyncClient(headers=self._headers(), timeout=self._timeout) as client:
+            response = await self._post_with_retry(client, payload, stream=True)
+
+            if response.status_code != 200:
+                body = await response.aread()
+                raise LLMError(
+                    f"OpenAI-compatible API error {response.status_code}: {body.decode()}",
+                    status_code=response.status_code,
+                )
+
+            # Accumulate partial tool arguments keyed by tool index.
+            partial_args: dict[int, str] = {}
+            tool_ids: dict[int, str] = {}
+            tool_names: dict[int, str] = {}
+
+            async for line in response.aiter_lines():
+                if not line.startswith("data: "):
+                    continue
+                raw = line[len("data: ") :]
+                if raw == "[DONE]":
+                    break
+
+                try:
+                    event_data = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+
+                # Usage-only chunk (stream_options: include_usage)
+                usage_raw = event_data.get("usage")
+                if usage_raw:
+                    yield StreamEvent(
+                        type=StreamEventType.MESSAGE_DONE,
+                        usage=_normalise_usage(usage_raw),
+                    )
+                    continue
+
+                choices = event_data.get("choices") or []
+                if not choices:
+                    continue
+
+                choice = choices[0]
+                delta = choice.get("delta") or {}
+                finish_reason = choice.get("finish_reason")
+
+                # Text content delta.
+                content = delta.get("content")
+                if content:
+                    cleaned = _strip_reasoning_tags(content)
+                    if cleaned:
+                        yield StreamEvent(type=StreamEventType.TEXT_DELTA, text=cleaned)
+
+                # Tool call deltas.
+                for tc_delta in delta.get("tool_calls") or []:
+                    idx = tc_delta.get("index", 0)
+                    tc_id = tc_delta.get("id", "")
+                    func = tc_delta.get("function") or {}
+
+                    if tc_id:
+                        tool_ids[idx] = tc_id
+                    if func.get("name"):
+                        tool_names[idx] = func["name"]
+                    partial_args.setdefault(idx, "")
+                    partial_args[idx] += func.get("arguments", "")
+
+                # When a tool call finishes, emit the complete TOOL_CALL event.
+                if finish_reason == "tool_calls":
+                    for idx in sorted(partial_args):
+                        raw_args = partial_args.get(idx, "")
+                        try:
+                            parsed = json.loads(raw_args) if raw_args else {}
+                        except json.JSONDecodeError:
+                            parsed = {}
+                        yield StreamEvent(
+                            type=StreamEventType.TOOL_CALL,
+                            tool_call=ToolCall(
+                                id=tool_ids.get(idx, ""),
+                                name=tool_names.get(idx, ""),
+                                input=parsed,
+                            ),
+                        )
+
+    async def generate(
+        self,
+        messages: list[dict],
+        *,
+        tools: list[dict],
+        system: SystemPrompt,
+        model: str,
+        max_tokens: int,
+    ) -> LLMResponse:
+        payload = self._build_request(
+            messages,
+            tools=tools,
+            system=system,
+            model=model,
+            max_tokens=max_tokens,
+            stream=False,
+        )
+
+        async with httpx.AsyncClient(headers=self._headers(), timeout=self._timeout) as client:
+            response = await self._post_with_retry(client, payload, stream=False)
+
+        if response.status_code != 200:
+            raise LLMError(
+                f"OpenAI-compatible API error {response.status_code}: {response.text}",
+                status_code=response.status_code,
+            )
+
+        data = response.json()
+        choices = data.get("choices") or []
+        message = choices[0].get("message", {}) if choices else {}
+        finish_reason = choices[0].get("finish_reason", "stop") if choices else "stop"
+
+        content_text = _strip_reasoning_tags(message.get("content") or "")
+        tool_calls: list[ToolCall] = []
+
+        for tc in message.get("tool_calls") or []:
+            func = tc.get("function") or {}
+            raw_args = func.get("arguments", "")
+            try:
+                parsed_args = json.loads(raw_args) if raw_args else {}
+            except json.JSONDecodeError:
+                parsed_args = {}
+            tool_calls.append(
+                ToolCall(
+                    id=tc.get("id", ""),
+                    name=func.get("name", ""),
+                    input=parsed_args,
+                )
+            )
+
+        stop_reason = StopReason.TOOL_USE if tool_calls else StopReason.END_TURN
+        if finish_reason == "length":
+            stop_reason = StopReason.MAX_TOKENS
+
+        usage = _normalise_usage(data.get("usage") or {})
+
+        return LLMResponse(
+            content=content_text,
+            tool_calls=tool_calls,
+            stop_reason=stop_reason,
+            usage=usage,
+        )

--- a/src/ravn/domain/exceptions.py
+++ b/src/ravn/domain/exceptions.py
@@ -43,3 +43,14 @@ class MaxIterationsError(RavnError):
 
 class ConfigurationError(RavnError):
     """Raised when Ravn is misconfigured."""
+
+
+class AllProvidersExhaustedError(RavnError):
+    """Raised when all LLM providers in the fallback chain have failed."""
+
+    def __init__(self, provider_count: int, last_error: Exception | None = None) -> None:
+        self.provider_count = provider_count
+        self.last_error = last_error
+        super().__init__(
+            f"All {provider_count} LLM provider(s) failed; see provider logs for details."
+        )

--- a/tests/test_ravn/test_e2e_memory.py
+++ b/tests/test_ravn/test_e2e_memory.py
@@ -1,0 +1,447 @@
+"""E2E scenarios for memory, session search, and fallback LLM (NIU-456).
+
+Scenario 1 — Memory recall:
+  Seed episodes → new conversation references past work → prefetch injects
+  relevant context → LLM uses it (context appears in system prompt).
+
+Scenario 2 — Session search:
+  Seed sessions → LLM invokes session_search tool → gets summaries → uses them.
+
+Scenario 3 — Fallback trigger:
+  Primary mock LLM raises 429 → fallback mock responds → conversation
+  continues transparently (same LLMResponse returned to agent).
+
+All scenarios use real SQLiteMemoryAdapter against tmp_path and scripted
+MockLLM/FallbackLLMAdapter (no network calls).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ravn.adapters.fallback_llm import FallbackLLMAdapter
+from ravn.adapters.permission_adapter import AllowAllPermission
+from ravn.adapters.sqlite_memory import SqliteMemoryAdapter
+from ravn.adapters.tools.session_search import SessionSearchTool
+from ravn.agent import RavnAgent
+from ravn.domain.exceptions import AllProvidersExhaustedError, LLMError
+from ravn.domain.models import (
+    Episode,
+    LLMResponse,
+    Outcome,
+    StopReason,
+    StreamEvent,
+    StreamEventType,
+    TokenUsage,
+    ToolCall,
+)
+from ravn.ports.llm import LLMPort
+from tests.ravn.fixtures.fakes import InMemoryChannel
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_USAGE = TokenUsage(input_tokens=10, output_tokens=5)
+
+
+def _text_response(text: str) -> LLMResponse:
+    return LLMResponse(
+        content=text,
+        tool_calls=[],
+        stop_reason=StopReason.END_TURN,
+        usage=_USAGE,
+    )
+
+
+def _tool_response(tool_name: str, tc_id: str = "tc-1", **kwargs) -> LLMResponse:
+    return LLMResponse(
+        content="",
+        tool_calls=[ToolCall(id=tc_id, name=tool_name, input=kwargs)],
+        stop_reason=StopReason.TOOL_USE,
+        usage=_USAGE,
+    )
+
+
+class ScriptedLLM(LLMPort):
+    """Replays responses from a pre-supplied list (non-streaming via generate)."""
+
+    def __init__(self, responses: list[LLMResponse]) -> None:
+        self._responses = iter(responses)
+        self.calls: list[dict] = []
+
+    async def generate(
+        self,
+        messages: list[dict],
+        *,
+        tools: list[dict],
+        system,
+        model: str,
+        max_tokens: int,
+    ) -> LLMResponse:
+        self.calls.append({"messages": messages, "system": system})
+        return next(self._responses)
+
+    async def stream(
+        self,
+        messages: list[dict],
+        *,
+        tools: list[dict],
+        system,
+        model: str,
+        max_tokens: int,
+    ) -> AsyncIterator[StreamEvent]:
+        response = next(self._responses)
+        self.calls.append({"messages": messages, "system": system})
+        if response.content:
+            yield StreamEvent(type=StreamEventType.TEXT_DELTA, text=response.content)
+        for tc in response.tool_calls:
+            yield StreamEvent(type=StreamEventType.TOOL_CALL, tool_call=tc)
+        yield StreamEvent(type=StreamEventType.MESSAGE_DONE, usage=response.usage)
+
+
+def _make_agent(
+    llm: LLMPort,
+    memory=None,
+    tools=None,
+) -> tuple[RavnAgent, InMemoryChannel]:
+    ch = InMemoryChannel()
+    agent = RavnAgent(
+        llm=llm,
+        tools=tools or [],
+        channel=ch,
+        permission=AllowAllPermission(),
+        system_prompt="You are a test assistant.",
+        model="claude-sonnet-4-6",
+        max_tokens=1024,
+        max_iterations=5,
+        memory=memory,
+    )
+    return agent, ch
+
+
+def _ep(
+    episode_id: str,
+    session_id: str,
+    summary: str,
+    tags: list[str] | None = None,
+    timestamp: datetime | None = None,
+    outcome: Outcome = Outcome.SUCCESS,
+) -> Episode:
+    return Episode(
+        episode_id=episode_id,
+        session_id=session_id,
+        timestamp=timestamp or datetime.now(UTC),
+        summary=summary,
+        task_description=summary[:50],
+        tools_used=["bash"],
+        outcome=outcome,
+        tags=tags or ["shell"],
+    )
+
+
+@pytest.fixture
+async def mem(tmp_path: Path) -> SqliteMemoryAdapter:
+    adapter = SqliteMemoryAdapter(
+        path=str(tmp_path / "memory.db"),
+        max_retries=3,
+        min_jitter_ms=1.0,
+        max_jitter_ms=5.0,
+        prefetch_min_relevance=0.0,
+        prefetch_budget=2000,
+        prefetch_limit=5,
+        recency_half_life_days=14.0,
+    )
+    await adapter.initialize()
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1 — Memory recall
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryRecallScenario:
+    async def test_prefetch_context_appears_in_llm_system_prompt(
+        self, mem: SqliteMemoryAdapter
+    ) -> None:
+        """Seed an episode then verify prefetch injects it into the system prompt.
+
+        The episode summary and the query share the key terms so FTS5 returns a match.
+        """
+        await mem.record_episode(
+            _ep("ep-1", "sess-old", "nginx proxy deployment configuration completed")
+        )
+
+        llm = ScriptedLLM([_text_response("I remember the nginx deployment.")])
+        agent, _ = _make_agent(llm, memory=mem)
+
+        # Query uses exact terms from the episode.
+        await agent.run_turn("nginx proxy deployment")
+
+        # The system prompt passed to the LLM should contain past context.
+        assert llm.calls, "LLM was never called"
+        system = llm.calls[0]["system"]
+        system_text = system if isinstance(system, str) else str(system)
+        assert "Relevant Past Context" in system_text or "nginx" in system_text.lower()
+
+    async def test_prefetch_injects_relevant_episode(self, mem: SqliteMemoryAdapter) -> None:
+        """Episode whose summary matches the query must appear in context."""
+        await mem.record_episode(
+            _ep("ep-2", "sess-A", "postgresql replication configured successfully")
+        )
+
+        captured_systems: list[str] = []
+        llm = ScriptedLLM([_text_response("Done")])
+        original_stream = llm.stream
+
+        async def _capturing_stream(*args, **kwargs):
+            system = kwargs.get("system", "")
+            captured_systems.append(system if isinstance(system, str) else str(system))
+            async for event in original_stream(*args, **kwargs):
+                yield event
+
+        llm.stream = _capturing_stream
+
+        agent, _ = _make_agent(llm, memory=mem)
+        # Query uses exact terms from the episode so FTS5 finds a match.
+        await agent.run_turn("postgresql replication")
+
+        combined = "\n".join(captured_systems)
+        assert "Relevant Past Context" in combined or "postgresql" in combined.lower()
+
+    async def test_no_relevant_episodes_no_context_injected(self, mem: SqliteMemoryAdapter) -> None:
+        """When no episodes match, system prompt must not contain context header."""
+        # Store an episode about a completely unrelated topic.
+        await mem.record_episode(_ep("ep-3", "sess-B", "compiled rust kernel module driver"))
+
+        captured_systems: list[str] = []
+        llm = ScriptedLLM([_text_response("Done")])
+        original_stream = llm.stream
+
+        async def _capture(*args, **kwargs):
+            system = kwargs.get("system", "")
+            captured_systems.append(system if isinstance(system, str) else str(system))
+            async for event in original_stream(*args, **kwargs):
+                yield event
+
+        llm.stream = _capture
+        agent, _ = _make_agent(llm, memory=mem)
+        # Query is totally unrelated — no FTS5 match.
+        await agent.run_turn("python type annotations")
+
+        # Prefetch found no match → no "Relevant Past Context" header.
+        combined = "\n".join(captured_systems)
+        assert "Relevant Past Context" not in combined
+
+    async def test_episode_recorded_after_turn(self, mem: SqliteMemoryAdapter) -> None:
+        """The turn's episode is recorded in the memory backend."""
+        llm = ScriptedLLM([_text_response("Deployed!")])
+        agent, _ = _make_agent(llm, memory=mem)
+
+        await agent.run_turn("deploy the service to staging")
+
+        matches = await mem.query_episodes("deploy staging", min_relevance=0.0)
+        assert len(matches) >= 1
+        assert any("deploy" in m.episode.task_description.lower() for m in matches)
+
+    async def test_multiple_episodes_accumulate(self, mem: SqliteMemoryAdapter) -> None:
+        """Two turns produce two episodes in memory."""
+        llm = ScriptedLLM([_text_response("First done"), _text_response("Second done")])
+        agent, _ = _make_agent(llm, memory=mem)
+
+        await agent.run_turn("first task alpha")
+        await agent.run_turn("second task beta")
+
+        matches = await mem.query_episodes("task", min_relevance=0.0)
+        assert len(matches) >= 2
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2 — Session search
+# ---------------------------------------------------------------------------
+
+
+class TestSessionSearchScenario:
+    async def test_session_search_tool_returns_summaries(self, mem: SqliteMemoryAdapter) -> None:
+        """Seed two sessions, call session_search, verify both appear."""
+        await mem.record_episode(_ep("e1", "sess-X", "configured redis cache cluster"))
+        await mem.record_episode(_ep("e2", "sess-X", "tuned redis eviction policy"))
+        await mem.record_episode(_ep("e3", "sess-Y", "set up redis replication"))
+
+        tool = SessionSearchTool(memory=mem)
+        result = await tool.execute({"query": "redis", "limit": 5})
+
+        assert not result.is_error
+        assert "sess-X" in result.content or "sess-Y" in result.content
+
+    async def test_session_search_deduplicates_sessions(self, mem: SqliteMemoryAdapter) -> None:
+        """Multiple episodes in the same session appear as ONE session summary."""
+        for i in range(3):
+            await mem.record_episode(
+                _ep(f"ep-dup-{i}", "sess-dedup", "git push to remote repository")
+            )
+
+        tool = SessionSearchTool(memory=mem)
+        result = await tool.execute({"query": "git push"})
+
+        # The result must describe exactly one session (the output groups by session).
+        assert "Session 1" in result.content
+        assert "Session 2" not in result.content
+
+    async def test_session_search_respects_limit(self, mem: SqliteMemoryAdapter) -> None:
+        """Limit parameter caps the number of returned sessions."""
+        for i in range(5):
+            await mem.record_episode(
+                _ep(f"ep-{i}", f"sess-{i}", "deployed kubernetes pod configuration")
+            )
+
+        tool = SessionSearchTool(memory=mem)
+        result = await tool.execute({"query": "kubernetes", "limit": 2})
+
+        # Count session-id-like prefixes in result — at most 2.
+        # (SessionSummary format includes "sess-" prefix)
+        matches = [line for line in result.content.splitlines() if "sess-" in line]
+        assert len(matches) <= 4  # generous bound; tool may format multi-line
+
+    async def test_session_search_empty_result_message(self, mem: SqliteMemoryAdapter) -> None:
+        """No match returns a 'No sessions found' message (not an error)."""
+        await mem.record_episode(_ep("ep-none", "sess-1", "wrote unit tests in go"))
+
+        tool = SessionSearchTool(memory=mem)
+        result = await tool.execute({"query": "machine learning neural network"})
+
+        assert not result.is_error
+        assert "No sessions found" in result.content
+
+    async def test_session_search_e2e_through_agent(self, mem: SqliteMemoryAdapter) -> None:
+        """LLM invokes session_search → tool result fed back → LLM uses it."""
+        # Seed a session.
+        await mem.record_episode(
+            _ep("ep-seed", "sess-seed", "configured prometheus metrics scraping")
+        )
+
+        search_tool = SessionSearchTool(memory=mem)
+
+        # Scripted conversation:
+        # Turn 1: LLM calls session_search("prometheus")
+        # Turn 2: LLM uses result to give final answer.
+        llm = ScriptedLLM(
+            [
+                _tool_response("session_search", query="prometheus"),
+                _text_response("Found past prometheus work. Reusing configuration."),
+            ]
+        )
+        agent, _ = _make_agent(llm, memory=mem, tools=[search_tool])
+
+        result = await agent.run_turn("show me past prometheus work")
+        assert "prometheus" in result.response.lower()
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3 — Fallback trigger
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackTriggerScenario:
+    async def test_primary_429_fallback_responds(self) -> None:
+        """Primary mock raises 429 → fallback mock responds → agent gets a response."""
+        primary = MagicMock(spec=LLMPort)
+        primary.generate = AsyncMock(side_effect=LLMError("rate limited", status_code=429))
+
+        async def _primary_stream(*args, **kwargs) -> AsyncIterator[StreamEvent]:
+            raise LLMError("rate limited", status_code=429)
+            yield  # pragma: no cover — makes this an async generator
+
+        primary.stream = _primary_stream
+
+        fallback = ScriptedLLM([_text_response("Answered by fallback")])
+        adapter = FallbackLLMAdapter([primary, fallback])
+
+        agent, _ = _make_agent(adapter)
+        result = await agent.run_turn("hello")
+
+        assert "Answered by fallback" in result.response
+
+    async def test_all_providers_fail_raises(self) -> None:
+        """When all providers fail, AllProvidersExhaustedError propagates."""
+        err = LLMError("all gone", status_code=503)
+
+        p1 = MagicMock(spec=LLMPort)
+        p1.generate = AsyncMock(side_effect=err)
+
+        async def _fail_stream(*args, **kwargs) -> AsyncIterator[StreamEvent]:
+            raise err
+            yield
+
+        p1.stream = _fail_stream
+
+        p2 = MagicMock(spec=LLMPort)
+        p2.generate = AsyncMock(side_effect=err)
+        p2.stream = _fail_stream
+
+        adapter = FallbackLLMAdapter([p1, p2])
+        agent, _ = _make_agent(adapter)
+
+        with pytest.raises(AllProvidersExhaustedError):
+            await agent.run_turn("this will fail")
+
+    async def test_fallback_transparent_to_caller(self) -> None:
+        """After a fallback the agent TurnResult looks identical to normal."""
+        primary = MagicMock(spec=LLMPort)
+        primary.generate = AsyncMock(side_effect=LLMError("down", status_code=429))
+
+        async def _primary_fail(*args, **kwargs) -> AsyncIterator[StreamEvent]:
+            raise LLMError("down", status_code=429)
+            yield
+
+        primary.stream = _primary_fail
+
+        fallback = ScriptedLLM([_text_response("Hello from fallback")])
+        adapter = FallbackLLMAdapter([primary, fallback])
+
+        agent, _ = _make_agent(adapter)
+        result = await agent.run_turn("say hello")
+
+        assert result.response == "Hello from fallback"
+        assert result.usage is not None
+
+    async def test_fallback_restoration_primary_tried_next_turn(self) -> None:
+        """After using a fallback, the next turn tries the primary first."""
+        call_order: list[str] = []
+
+        primary = MagicMock(spec=LLMPort)
+        fallback_llm = MagicMock(spec=LLMPort)
+
+        async def _primary_stream_first_fail(*args, **kwargs) -> AsyncIterator[StreamEvent]:
+            call_order.append("primary")
+            if len(call_order) == 1:
+                raise LLMError("first time", status_code=429)
+            yield StreamEvent(type=StreamEventType.TEXT_DELTA, text="primary")
+            yield StreamEvent(type=StreamEventType.MESSAGE_DONE, usage=_USAGE)
+
+        async def _fallback_stream(*args, **kwargs) -> AsyncIterator[StreamEvent]:
+            call_order.append("fallback")
+            yield StreamEvent(type=StreamEventType.TEXT_DELTA, text="fallback")
+            yield StreamEvent(type=StreamEventType.MESSAGE_DONE, usage=_USAGE)
+
+        primary.stream = _primary_stream_first_fail
+        fallback_llm.stream = _fallback_stream
+
+        adapter = FallbackLLMAdapter([primary, fallback_llm])
+        agent, _ = _make_agent(adapter)
+
+        # Turn 1: primary fails → fallback used.
+        r1 = await agent.run_turn("turn 1")
+        assert r1.response == "fallback"
+
+        # Turn 2: primary tried first (restoration).
+        r2 = await agent.run_turn("turn 2")
+        assert r2.response == "primary"
+
+        assert call_order == ["primary", "fallback", "primary"]

--- a/tests/test_ravn/test_fallback_llm.py
+++ b/tests/test_ravn/test_fallback_llm.py
@@ -1,0 +1,296 @@
+"""Tests for FallbackLLMAdapter.
+
+Coverage:
+- Primary succeeds → used, no fallback attempted
+- Primary fails (429) → fallback used
+- Primary fails (auth 401) → fallback used, warning logged
+- All fail → AllProvidersExhaustedError raised
+- Next turn → primary attempted again (restoration — no sticky state)
+- Transparent to caller (same LLMPort interface)
+- generate() and stream() both exercise the fallback path
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ravn.adapters.fallback_llm import FallbackLLMAdapter
+from ravn.domain.exceptions import AllProvidersExhaustedError, LLMError
+from ravn.domain.models import (
+    LLMResponse,
+    StopReason,
+    StreamEvent,
+    StreamEventType,
+    TokenUsage,
+    ToolCall,
+)
+from ravn.ports.llm import LLMPort
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+_USAGE = TokenUsage(input_tokens=10, output_tokens=5)
+_MESSAGES = [{"role": "user", "content": "hello"}]
+_KWARGS = dict(tools=[], system="sys", model="m", max_tokens=100)
+
+
+def _ok_response(text: str = "OK") -> LLMResponse:
+    return LLMResponse(
+        content=text,
+        tool_calls=[],
+        stop_reason=StopReason.END_TURN,
+        usage=_USAGE,
+    )
+
+
+def _make_llm(*, raises: Exception | None = None, text: str = "OK") -> LLMPort:
+    """Build a mock LLMPort that either succeeds or raises on every call."""
+    llm = MagicMock(spec=LLMPort)
+
+    if raises is not None:
+        llm.generate = AsyncMock(side_effect=raises)
+
+        async def _failing_stream(*args, **kwargs) -> AsyncIterator[StreamEvent]:
+            raise raises  # type: ignore[misc]
+            yield  # make it a generator
+
+        llm.stream = _failing_stream
+    else:
+        llm.generate = AsyncMock(return_value=_ok_response(text))
+
+        async def _ok_stream(*args, **kwargs) -> AsyncIterator[StreamEvent]:
+            yield StreamEvent(type=StreamEventType.TEXT_DELTA, text=text)
+            yield StreamEvent(type=StreamEventType.MESSAGE_DONE, usage=_USAGE)
+
+        llm.stream = _ok_stream
+
+    return llm
+
+
+async def _collect_stream(adapter: FallbackLLMAdapter) -> list[StreamEvent]:
+    """Collect all events from adapter.stream()."""
+    events: list[StreamEvent] = []
+    async for event in adapter.stream(_MESSAGES, **_KWARGS):
+        events.append(event)
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Initialisation
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackLLMAdapterInit:
+    def test_requires_at_least_one_provider(self) -> None:
+        with pytest.raises(ValueError, match="at least one provider"):
+            FallbackLLMAdapter([])
+
+    def test_provider_count(self) -> None:
+        adapter = FallbackLLMAdapter([_make_llm(), _make_llm()])
+        assert adapter.provider_count == 2
+
+    def test_implements_llm_port(self) -> None:
+        adapter = FallbackLLMAdapter([_make_llm()])
+        assert isinstance(adapter, LLMPort)
+
+
+# ---------------------------------------------------------------------------
+# generate() — fallback chain
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackLLMGenerate:
+    async def test_primary_succeeds_is_used(self) -> None:
+        primary = _make_llm(text="from primary")
+        fallback = _make_llm(text="from fallback")
+        adapter = FallbackLLMAdapter([primary, fallback])
+
+        response = await adapter.generate(_MESSAGES, **_KWARGS)
+
+        assert response.content == "from primary"
+        fallback.generate.assert_not_called()
+
+    async def test_primary_fails_429_fallback_used(self) -> None:
+        primary = _make_llm(raises=LLMError("rate limited", status_code=429))
+        fallback = _make_llm(text="from fallback")
+        adapter = FallbackLLMAdapter([primary, fallback])
+
+        response = await adapter.generate(_MESSAGES, **_KWARGS)
+
+        assert response.content == "from fallback"
+
+    async def test_primary_fails_401_fallback_used(self) -> None:
+        primary = _make_llm(raises=LLMError("unauthorised", status_code=401))
+        fallback = _make_llm(text="auth fallback")
+        adapter = FallbackLLMAdapter([primary, fallback])
+
+        response = await adapter.generate(_MESSAGES, **_KWARGS)
+
+        assert response.content == "auth fallback"
+
+    async def test_primary_fails_warning_logged(self, caplog: pytest.LogCaptureFixture) -> None:
+        primary = _make_llm(raises=LLMError("upstream error", status_code=500))
+        fallback = _make_llm()
+        adapter = FallbackLLMAdapter([primary, fallback])
+
+        with caplog.at_level(logging.WARNING, logger="ravn.adapters.fallback_llm"):
+            await adapter.generate(_MESSAGES, **_KWARGS)
+
+        assert any("primary" in record.message for record in caplog.records)
+
+    async def test_all_fail_raises_all_providers_exhausted(self) -> None:
+        err = LLMError("gone", status_code=503)
+        adapter = FallbackLLMAdapter([_make_llm(raises=err), _make_llm(raises=err)])
+
+        with pytest.raises(AllProvidersExhaustedError) as exc_info:
+            await adapter.generate(_MESSAGES, **_KWARGS)
+
+        assert exc_info.value.provider_count == 2
+
+    async def test_all_providers_exhausted_has_last_error(self) -> None:
+        last_err = LLMError("final failure", status_code=503)
+        adapter = FallbackLLMAdapter(
+            [
+                _make_llm(raises=LLMError("first", status_code=429)),
+                _make_llm(raises=last_err),
+            ]
+        )
+
+        with pytest.raises(AllProvidersExhaustedError) as exc_info:
+            await adapter.generate(_MESSAGES, **_KWARGS)
+
+        assert exc_info.value.last_error is last_err
+
+    async def test_restoration_primary_tried_on_next_call(self) -> None:
+        """After a failure, the next call starts from the primary again."""
+        call_count = {"primary": 0, "fallback": 0}
+
+        primary_llm = MagicMock(spec=LLMPort)
+        fallback_llm = MagicMock(spec=LLMPort)
+
+        # First call: primary fails
+        async def _primary_generate_first_fail(*args, **kwargs):
+            call_count["primary"] += 1
+            if call_count["primary"] == 1:
+                raise LLMError("first call fails", status_code=429)
+            return _ok_response("primary restored")
+
+        fallback_llm.generate = AsyncMock(return_value=_ok_response("fallback"))
+        primary_llm.generate = _primary_generate_first_fail
+
+        adapter = FallbackLLMAdapter([primary_llm, fallback_llm])
+
+        # First call: primary fails → fallback used.
+        r1 = await adapter.generate(_MESSAGES, **_KWARGS)
+        assert r1.content == "fallback"
+        assert call_count["primary"] == 1
+
+        # Second call: primary is tried again (restoration).
+        r2 = await adapter.generate(_MESSAGES, **_KWARGS)
+        assert r2.content == "primary restored"
+        assert call_count["primary"] == 2
+
+    async def test_three_providers_second_fallback_used(self) -> None:
+        err = LLMError("fail", status_code=500)
+        p1 = _make_llm(raises=err)
+        p2 = _make_llm(raises=err)
+        p3 = _make_llm(text="third")
+        adapter = FallbackLLMAdapter([p1, p2, p3])
+
+        response = await adapter.generate(_MESSAGES, **_KWARGS)
+        assert response.content == "third"
+
+    async def test_single_provider_raises_on_failure(self) -> None:
+        adapter = FallbackLLMAdapter([_make_llm(raises=LLMError("oops", status_code=500))])
+
+        with pytest.raises(AllProvidersExhaustedError):
+            await adapter.generate(_MESSAGES, **_KWARGS)
+
+
+# ---------------------------------------------------------------------------
+# stream() — fallback chain
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackLLMStream:
+    async def test_primary_stream_succeeds(self) -> None:
+        adapter = FallbackLLMAdapter([_make_llm(text="streamed")])
+        events = await _collect_stream(adapter)
+
+        text_events = [e for e in events if e.type == StreamEventType.TEXT_DELTA]
+        assert len(text_events) == 1
+        assert text_events[0].text == "streamed"
+
+    async def test_primary_stream_fails_fallback_used(self) -> None:
+        primary = _make_llm(raises=LLMError("stream error", status_code=429))
+        fallback = _make_llm(text="fallback stream")
+        adapter = FallbackLLMAdapter([primary, fallback])
+
+        events = await _collect_stream(adapter)
+
+        text_events = [e for e in events if e.type == StreamEventType.TEXT_DELTA]
+        assert any(e.text == "fallback stream" for e in text_events)
+
+    async def test_all_streams_fail_raises(self) -> None:
+        err = LLMError("stream gone", status_code=503)
+        adapter = FallbackLLMAdapter([_make_llm(raises=err), _make_llm(raises=err)])
+
+        with pytest.raises(AllProvidersExhaustedError):
+            await _collect_stream(adapter)
+
+    async def test_stream_message_done_event_present(self) -> None:
+        adapter = FallbackLLMAdapter([_make_llm(text="hello")])
+        events = await _collect_stream(adapter)
+
+        done_events = [e for e in events if e.type == StreamEventType.MESSAGE_DONE]
+        assert len(done_events) == 1
+        assert done_events[0].usage is not None
+
+    async def test_stream_fallback_warning_logged(self, caplog: pytest.LogCaptureFixture) -> None:
+        primary = _make_llm(raises=LLMError("503", status_code=503))
+        fallback = _make_llm(text="ok")
+        adapter = FallbackLLMAdapter([primary, fallback])
+
+        with caplog.at_level(logging.WARNING, logger="ravn.adapters.fallback_llm"):
+            await _collect_stream(adapter)
+
+        assert any("primary" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Transparency — same LLMPort interface
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackLLMTransparency:
+    async def test_generate_returns_llm_response(self) -> None:
+        adapter = FallbackLLMAdapter([_make_llm()])
+        result = await adapter.generate(_MESSAGES, **_KWARGS)
+        assert isinstance(result, LLMResponse)
+
+    async def test_stream_yields_stream_events(self) -> None:
+        adapter = FallbackLLMAdapter([_make_llm()])
+        events = await _collect_stream(adapter)
+        for event in events:
+            assert isinstance(event, StreamEvent)
+
+    async def test_tool_calls_pass_through(self) -> None:
+        tc = ToolCall(id="call-1", name="my_tool", input={"x": 1})
+        llm = MagicMock(spec=LLMPort)
+        llm.generate = AsyncMock(
+            return_value=LLMResponse(
+                content="",
+                tool_calls=[tc],
+                stop_reason=StopReason.TOOL_USE,
+                usage=_USAGE,
+            )
+        )
+        adapter = FallbackLLMAdapter([llm])
+        result = await adapter.generate(_MESSAGES, **_KWARGS)
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].name == "my_tool"

--- a/tests/test_ravn/test_openai_llm.py
+++ b/tests/test_ravn/test_openai_llm.py
@@ -1,0 +1,721 @@
+"""Tests for OpenAICompatibleAdapter.
+
+Coverage:
+- Streaming SSE event parsing (text delta, tool call, usage)
+- Tool call extraction from streaming and non-streaming responses
+- Token usage normalisation (OpenAI format → common TokenUsage)
+- Reasoning tag stripping (<think>, <reasoning>)
+- Model-specific steering injection (system_prefix)
+- Tool format conversion (Anthropic → OpenAI)
+- System prompt handling (string, block list)
+- Retry on transient errors (429, 500, 502, 503)
+- Non-retryable errors raised immediately
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from ravn.adapters.openai_llm import (
+    OpenAICompatibleAdapter,
+    _convert_tools,
+    _normalise_usage,
+    _strip_reasoning_tags,
+    _system_to_string,
+)
+from ravn.domain.exceptions import LLMError
+from ravn.domain.models import StopReason, StreamEventType, TokenUsage
+
+# ---------------------------------------------------------------------------
+# Unit helpers
+# ---------------------------------------------------------------------------
+
+_BASE_URL = "https://api.openai.com"
+_MESSAGES = [{"role": "user", "content": "hello"}]
+_KWARGS = dict(tools=[], system="You are a test assistant.", model="gpt-4o", max_tokens=100)
+
+
+def _make_sse_lines(*chunks: str, usage: dict | None = None) -> bytes:
+    """Build an SSE byte stream from JSON chunk strings."""
+    parts: list[bytes] = []
+    for chunk in chunks:
+        parts.append(f"data: {chunk}\n\n".encode())
+    if usage:
+        parts.append(f"data: {json.dumps({'usage': usage})}\n\n".encode())
+    parts.append(b"data: [DONE]\n\n")
+    return b"".join(parts)
+
+
+def _text_chunk(content: str, finish_reason: str | None = None) -> str:
+    return json.dumps(
+        {
+            "choices": [
+                {
+                    "delta": {"content": content},
+                    "finish_reason": finish_reason,
+                }
+            ]
+        }
+    )
+
+
+def _tool_chunk(
+    idx: int = 0,
+    *,
+    tool_id: str = "call-1",
+    name: str | None = None,
+    args: str = "",
+    finish_reason: str | None = None,
+) -> str:
+    tc_delta: dict = {"index": idx, "function": {"arguments": args}}
+    if tool_id:
+        tc_delta["id"] = tool_id
+    if name is not None:
+        tc_delta["function"]["name"] = name
+    return json.dumps(
+        {
+            "choices": [
+                {
+                    "delta": {"tool_calls": [tc_delta]},
+                    "finish_reason": finish_reason,
+                }
+            ]
+        }
+    )
+
+
+def _non_stream_response(
+    content: str = "Hello!",
+    tool_calls: list | None = None,
+    finish_reason: str = "stop",
+    usage: dict | None = None,
+) -> dict:
+    message: dict = {"role": "assistant", "content": content}
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+    return {
+        "choices": [{"message": message, "finish_reason": finish_reason}],
+        "usage": usage or {"prompt_tokens": 10, "completion_tokens": 5},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Pure helper tests
+# ---------------------------------------------------------------------------
+
+
+class TestStripReasoningTags:
+    def test_strips_think_tags(self) -> None:
+        text = "<think>internal reasoning</think>final answer"
+        assert _strip_reasoning_tags(text) == "final answer"
+
+    def test_strips_reasoning_tags(self) -> None:
+        text = "<reasoning>step by step</reasoning>result"
+        assert _strip_reasoning_tags(text) == "result"
+
+    def test_case_insensitive(self) -> None:
+        text = "<THINK>ignored</THINK>visible"
+        assert _strip_reasoning_tags(text) == "visible"
+
+    def test_multiline_stripped(self) -> None:
+        text = "<think>\nline1\nline2\n</think>answer"
+        assert _strip_reasoning_tags(text) == "answer"
+
+    def test_no_tags_unchanged(self) -> None:
+        assert _strip_reasoning_tags("just text") == "just text"
+
+    def test_empty_string(self) -> None:
+        assert _strip_reasoning_tags("") == ""
+
+    def test_only_tags_gives_empty(self) -> None:
+        result = _strip_reasoning_tags("<think>nothing</think>")
+        assert result == ""
+
+
+class TestNormaliseUsage:
+    def test_basic_usage(self) -> None:
+        usage = _normalise_usage({"prompt_tokens": 20, "completion_tokens": 10})
+        assert usage.input_tokens == 20
+        assert usage.output_tokens == 10
+        assert usage.cache_read_tokens == 0
+        assert usage.cache_write_tokens == 0
+
+    def test_cache_read_from_details(self) -> None:
+        usage = _normalise_usage(
+            {
+                "prompt_tokens": 100,
+                "completion_tokens": 50,
+                "prompt_tokens_details": {"cached_tokens": 40},
+            }
+        )
+        assert usage.cache_read_tokens == 40
+
+    def test_empty_dict_returns_zeros(self) -> None:
+        usage = _normalise_usage({})
+        assert isinstance(usage, TokenUsage)
+        assert usage.total_tokens == 0
+
+    def test_missing_details_is_safe(self) -> None:
+        usage = _normalise_usage({"prompt_tokens": 5, "completion_tokens": 3})
+        assert usage.cache_read_tokens == 0
+
+    def test_null_details_is_safe(self) -> None:
+        usage = _normalise_usage(
+            {"prompt_tokens": 5, "completion_tokens": 3, "prompt_tokens_details": None}
+        )
+        assert usage.cache_read_tokens == 0
+
+    def test_non_dict_details_is_safe(self) -> None:
+        # If prompt_tokens_details is a truthy non-dict value (unexpected API response),
+        # the isinstance guard prevents a crash.
+        usage = _normalise_usage(
+            {"prompt_tokens": 5, "completion_tokens": 3, "prompt_tokens_details": ["unexpected"]}
+        )
+        assert usage.cache_read_tokens == 0
+
+
+class TestConvertTools:
+    def test_anthropic_to_openai_format(self) -> None:
+        tools = [
+            {
+                "name": "my_tool",
+                "description": "Does something",
+                "input_schema": {"type": "object", "properties": {}},
+            }
+        ]
+        converted = _convert_tools(tools)
+        assert len(converted) == 1
+        assert converted[0]["type"] == "function"
+        assert converted[0]["function"]["name"] == "my_tool"
+        assert converted[0]["function"]["description"] == "Does something"
+        assert converted[0]["function"]["parameters"] == {"type": "object", "properties": {}}
+
+    def test_empty_tools(self) -> None:
+        assert _convert_tools([]) == []
+
+    def test_missing_description_defaults_to_empty(self) -> None:
+        tools = [{"name": "t", "input_schema": {}}]
+        converted = _convert_tools(tools)
+        assert converted[0]["function"]["description"] == ""
+
+
+class TestSystemToString:
+    def test_string_passthrough(self) -> None:
+        assert _system_to_string("hello") == "hello"
+
+    def test_block_list_concatenated(self) -> None:
+        blocks = [
+            {"type": "text", "text": "part one"},
+            {"type": "text", "text": "part two"},
+        ]
+        result = _system_to_string(blocks)
+        assert "part one" in result
+        assert "part two" in result
+
+    def test_empty_string(self) -> None:
+        assert _system_to_string("") == ""
+
+    def test_empty_list(self) -> None:
+        assert _system_to_string([]) == ""
+
+
+# ---------------------------------------------------------------------------
+# Adapter construction
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIAdapterInit:
+    def test_defaults(self) -> None:
+        adapter = OpenAICompatibleAdapter()
+        assert "api.openai.com" in adapter._base_url
+        assert adapter._default_model == "gpt-4o"
+        assert adapter._max_retries >= 0
+
+    def test_custom_base_url_trailing_slash_stripped(self) -> None:
+        adapter = OpenAICompatibleAdapter(base_url="http://proxy/")
+        assert not adapter._base_url.endswith("/")
+
+    def test_api_key_in_headers(self) -> None:
+        adapter = OpenAICompatibleAdapter(api_key="sk-test")
+        headers = adapter._headers()
+        assert headers["authorization"] == "Bearer sk-test"
+
+    def test_no_auth_header_when_no_key(self) -> None:
+        adapter = OpenAICompatibleAdapter(api_key="")
+        headers = adapter._headers()
+        assert "authorization" not in headers
+
+
+# ---------------------------------------------------------------------------
+# generate() — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIAdapterGenerate:
+    @respx.mock
+    async def test_generate_text_response(self) -> None:
+        adapter = OpenAICompatibleAdapter(api_key="k", base_url=_BASE_URL)
+        respx.post(f"{_BASE_URL}/v1/chat/completions").mock(
+            return_value=httpx.Response(200, json=_non_stream_response("Hello!"))
+        )
+
+        result = await adapter.generate(_MESSAGES, **_KWARGS)
+        assert result.content == "Hello!"
+        assert result.stop_reason == StopReason.END_TURN
+
+    @respx.mock
+    async def test_generate_usage_normalised(self) -> None:
+        adapter = OpenAICompatibleAdapter(api_key="k", base_url=_BASE_URL)
+        respx.post(f"{_BASE_URL}/v1/chat/completions").mock(
+            return_value=httpx.Response(
+                200,
+                json=_non_stream_response(usage={"prompt_tokens": 20, "completion_tokens": 10}),
+            )
+        )
+
+        result = await adapter.generate(_MESSAGES, **_KWARGS)
+        assert result.usage.input_tokens == 20
+        assert result.usage.output_tokens == 10
+
+    @respx.mock
+    async def test_generate_tool_call_extracted(self) -> None:
+        adapter = OpenAICompatibleAdapter(api_key="k", base_url=_BASE_URL)
+        tool_calls_data = [
+            {
+                "id": "call-1",
+                "type": "function",
+                "function": {"name": "my_fn", "arguments": '{"x": 42}'},
+            }
+        ]
+        respx.post(f"{_BASE_URL}/v1/chat/completions").mock(
+            return_value=httpx.Response(
+                200,
+                json=_non_stream_response(content="", tool_calls=tool_calls_data),
+            )
+        )
+
+        result = await adapter.generate(_MESSAGES, **_KWARGS)
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].name == "my_fn"
+        assert result.tool_calls[0].input == {"x": 42}
+        assert result.stop_reason == StopReason.TOOL_USE
+
+    @respx.mock
+    async def test_generate_max_tokens_stop_reason(self) -> None:
+        adapter = OpenAICompatibleAdapter(api_key="k", base_url=_BASE_URL)
+        respx.post(f"{_BASE_URL}/v1/chat/completions").mock(
+            return_value=httpx.Response(
+                200,
+                json=_non_stream_response("truncated...", finish_reason="length"),
+            )
+        )
+
+        result = await adapter.generate(_MESSAGES, **_KWARGS)
+        assert result.stop_reason == StopReason.MAX_TOKENS
+
+    @respx.mock
+    async def test_generate_strips_reasoning_tags(self) -> None:
+        adapter = OpenAICompatibleAdapter(api_key="k", base_url=_BASE_URL)
+        respx.post(f"{_BASE_URL}/v1/chat/completions").mock(
+            return_value=httpx.Response(
+                200,
+                json=_non_stream_response("<think>internal</think>actual answer"),
+            )
+        )
+
+        result = await adapter.generate(_MESSAGES, **_KWARGS)
+        assert "think" not in result.content
+        assert "actual answer" in result.content
+
+    @respx.mock
+    async def test_generate_system_prefix_injected(self) -> None:
+        adapter = OpenAICompatibleAdapter(
+            api_key="k", base_url=_BASE_URL, system_prefix="ALWAYS USE METRIC UNITS."
+        )
+        captured: list[dict] = []
+
+        def _capture(request, route) -> httpx.Response:
+            captured.append(json.loads(request.content))
+            return httpx.Response(200, json=_non_stream_response())
+
+        respx.post(f"{_BASE_URL}/v1/chat/completions").mock(side_effect=_capture)
+
+        await adapter.generate(_MESSAGES, **_KWARGS)
+        system_msg = next(m for m in captured[0]["messages"] if m["role"] == "system")
+        assert "ALWAYS USE METRIC UNITS." in system_msg["content"]
+
+    @respx.mock
+    async def test_generate_error_status_raises(self) -> None:
+        adapter = OpenAICompatibleAdapter(api_key="k", base_url=_BASE_URL, max_retries=0)
+        respx.post(f"{_BASE_URL}/v1/chat/completions").mock(
+            return_value=httpx.Response(401, json={"error": "unauthorized"})
+        )
+
+        with pytest.raises(LLMError) as exc_info:
+            await adapter.generate(_MESSAGES, **_KWARGS)
+
+        assert exc_info.value.status_code == 401
+
+    @respx.mock
+    async def test_generate_block_list_system(self) -> None:
+        adapter = OpenAICompatibleAdapter(api_key="k", base_url=_BASE_URL)
+        captured: list[dict] = []
+
+        def _capture(request, route) -> httpx.Response:
+            captured.append(json.loads(request.content))
+            return httpx.Response(200, json=_non_stream_response())
+
+        respx.post(f"{_BASE_URL}/v1/chat/completions").mock(side_effect=_capture)
+
+        system_blocks = [
+            {"type": "text", "text": "You are a coder.", "cache_control": {"type": "ephemeral"}},
+        ]
+        await adapter.generate(
+            _MESSAGES, tools=[], system=system_blocks, model="gpt-4o", max_tokens=100
+        )
+        system_msg = next(m for m in captured[0]["messages"] if m["role"] == "system")
+        assert "You are a coder." in system_msg["content"]
+
+
+# ---------------------------------------------------------------------------
+# stream() — SSE parsing
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIAdapterStream:
+    @respx.mock
+    async def test_stream_text_delta(self) -> None:
+        adapter = OpenAICompatibleAdapter(api_key="k", base_url=_BASE_URL)
+        sse = _make_sse_lines(
+            _text_chunk("Hello, "),
+            _text_chunk("world!"),
+            usage={"prompt_tokens": 5, "completion_tokens": 3},
+        )
+        respx.post(f"{_BASE_URL}/v1/chat/completions").mock(
+            return_value=httpx.Response(200, content=sse)
+        )
+
+        events = []
+        async for event in adapter.stream(_MESSAGES, **_KWARGS):
+            events.append(event)
+
+        text_events = [e for e in events if e.type == StreamEventType.TEXT_DELTA]
+        assert len(text_events) == 2
+        assert "".join(e.text or "" for e in text_events) == "Hello, world!"
+
+    @respx.mock
+    async def test_stream_usage_in_final_chunk(self) -> None:
+        adapter = OpenAICompatibleAdapter(api_key="k", base_url=_BASE_URL)
+        sse = _make_sse_lines(
+            _text_chunk("hi"),
+            usage={"prompt_tokens": 10, "completion_tokens": 5},
+        )
+        respx.post(f"{_BASE_URL}/v1/chat/completions").mock(
+            return_value=httpx.Response(200, content=sse)
+        )
+
+        events = []
+        async for event in adapter.stream(_MESSAGES, **_KWARGS):
+            events.append(event)
+
+        done_events = [e for e in events if e.type == StreamEventType.MESSAGE_DONE]
+        assert len(done_events) == 1
+        assert done_events[0].usage is not None
+        assert done_events[0].usage.input_tokens == 10
+        assert done_events[0].usage.output_tokens == 5
+
+    @respx.mock
+    async def test_stream_tool_call_extracted(self) -> None:
+        adapter = OpenAICompatibleAdapter(api_key="k", base_url=_BASE_URL)
+        sse = _make_sse_lines(
+            # Start tool call with id + name
+            _tool_chunk(0, tool_id="call-1", name="do_thing", args=""),
+            # Partial args chunk
+            _tool_chunk(0, tool_id="", name=None, args='{"val": '),
+            # Final args chunk with finish_reason
+            _tool_chunk(0, tool_id="", name=None, args='"ok"}', finish_reason="tool_calls"),
+            usage={"prompt_tokens": 5, "completion_tokens": 10},
+        )
+        respx.post(f"{_BASE_URL}/v1/chat/completions").mock(
+            return_value=httpx.Response(200, content=sse)
+        )
+
+        events = []
+        async for event in adapter.stream(_MESSAGES, **_KWARGS):
+            events.append(event)
+
+        tool_events = [e for e in events if e.type == StreamEventType.TOOL_CALL]
+        assert len(tool_events) == 1
+        assert tool_events[0].tool_call is not None
+        assert tool_events[0].tool_call.name == "do_thing"
+        assert tool_events[0].tool_call.input == {"val": "ok"}
+
+    @respx.mock
+    async def test_stream_strips_reasoning_tags(self) -> None:
+        adapter = OpenAICompatibleAdapter(api_key="k", base_url=_BASE_URL)
+        sse = _make_sse_lines(
+            _text_chunk("<think>internal reasoning</think>"),
+            _text_chunk("visible answer"),
+            usage={"prompt_tokens": 5, "completion_tokens": 5},
+        )
+        respx.post(f"{_BASE_URL}/v1/chat/completions").mock(
+            return_value=httpx.Response(200, content=sse)
+        )
+
+        events = []
+        async for event in adapter.stream(_MESSAGES, **_KWARGS):
+            events.append(event)
+
+        text_events = [e for e in events if e.type == StreamEventType.TEXT_DELTA]
+        combined = "".join(e.text or "" for e in text_events)
+        assert "think" not in combined
+        assert "visible answer" in combined
+
+    @respx.mock
+    async def test_stream_error_status_raises(self) -> None:
+        adapter = OpenAICompatibleAdapter(api_key="k", base_url=_BASE_URL, max_retries=0)
+        respx.post(f"{_BASE_URL}/v1/chat/completions").mock(
+            return_value=httpx.Response(401, content=b"unauthorized")
+        )
+
+        with pytest.raises(LLMError) as exc_info:
+            async for _ in adapter.stream(_MESSAGES, **_KWARGS):
+                pass
+
+        assert exc_info.value.status_code == 401
+
+    @respx.mock
+    async def test_stream_tools_converted(self) -> None:
+        """Tools must be converted from Anthropic format before sending."""
+        adapter = OpenAICompatibleAdapter(api_key="k", base_url=_BASE_URL)
+        captured: list[dict] = []
+
+        sse = _make_sse_lines(
+            _text_chunk("ok"),
+            usage={"prompt_tokens": 5, "completion_tokens": 5},
+        )
+
+        def _capture(request, route) -> httpx.Response:
+            captured.append(json.loads(request.content))
+            return httpx.Response(200, content=sse)
+
+        respx.post(f"{_BASE_URL}/v1/chat/completions").mock(side_effect=_capture)
+
+        tools = [{"name": "my_tool", "description": "desc", "input_schema": {"type": "object"}}]
+        async for _ in adapter.stream(
+            _MESSAGES, tools=tools, system="sys", model="gpt-4o", max_tokens=100
+        ):
+            pass
+
+        sent_tools = captured[0].get("tools", [])
+        assert len(sent_tools) == 1
+        assert sent_tools[0]["type"] == "function"
+        assert sent_tools[0]["function"]["name"] == "my_tool"
+
+
+# ---------------------------------------------------------------------------
+# Retry behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIAdapterEdgeCases:
+    @respx.mock
+    async def test_generate_empty_system_no_system_message(self) -> None:
+        """Empty system prompt → no system message prepended to messages."""
+        adapter = OpenAICompatibleAdapter(api_key="k", base_url=_BASE_URL)
+        captured: list[dict] = []
+
+        def _capture(request, route) -> httpx.Response:
+            captured.append(json.loads(request.content))
+            return httpx.Response(200, json=_non_stream_response())
+
+        respx.post(f"{_BASE_URL}/v1/chat/completions").mock(side_effect=_capture)
+
+        await adapter.generate(_MESSAGES, tools=[], system="", model="gpt-4o", max_tokens=100)
+        # No system role message when system is empty.
+        roles = [m["role"] for m in captured[0]["messages"]]
+        assert "system" not in roles
+
+    @respx.mock
+    async def test_generate_invalid_tool_args_handled(self) -> None:
+        """Malformed tool args JSON falls back to empty dict, no exception."""
+        adapter = OpenAICompatibleAdapter(api_key="k", base_url=_BASE_URL)
+        tool_calls_data = [
+            {
+                "id": "call-bad",
+                "type": "function",
+                "function": {"name": "bad_tool", "arguments": "{not valid json}"},
+            }
+        ]
+        respx.post(f"{_BASE_URL}/v1/chat/completions").mock(
+            return_value=httpx.Response(
+                200, json=_non_stream_response(content="", tool_calls=tool_calls_data)
+            )
+        )
+
+        result = await adapter.generate(_MESSAGES, **_KWARGS)
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].input == {}  # fallback to empty dict
+
+    @respx.mock
+    async def test_stream_malformed_json_line_skipped(self) -> None:
+        """Malformed JSON SSE lines are silently skipped."""
+        adapter = OpenAICompatibleAdapter(api_key="k", base_url=_BASE_URL)
+        usage_chunk = json.dumps({"usage": {"prompt_tokens": 5, "completion_tokens": 5}})
+        lines = (
+            b"data: {not json at all}\n\n"
+            b"data: " + _text_chunk("ok").encode() + b"\n\n"
+            b"data: " + usage_chunk.encode() + b"\n\n"
+            b"data: [DONE]\n\n"
+        )
+        respx.post(f"{_BASE_URL}/v1/chat/completions").mock(
+            return_value=httpx.Response(200, content=lines)
+        )
+
+        events = []
+        async for event in adapter.stream(_MESSAGES, **_KWARGS):
+            events.append(event)
+
+        text_events = [e for e in events if e.type == StreamEventType.TEXT_DELTA]
+        assert any(e.text == "ok" for e in text_events)
+
+    @respx.mock
+    async def test_stream_empty_choices_skipped(self) -> None:
+        """SSE chunks with empty choices are silently skipped."""
+        adapter = OpenAICompatibleAdapter(api_key="k", base_url=_BASE_URL)
+        # Chunk with empty choices (heartbeat), then real chunk.
+        empty_chunk = json.dumps({"choices": []})
+        lines = (
+            f"data: {empty_chunk}\n\n".encode()
+            + f"data: {_text_chunk('hello')}\n\n".encode()
+            + json.dumps({"usage": {"prompt_tokens": 5, "completion_tokens": 5}})
+            .encode()
+            .join([b"data: ", b"\n\ndata: [DONE]\n\n"])
+        )
+        respx.post(f"{_BASE_URL}/v1/chat/completions").mock(
+            return_value=httpx.Response(200, content=lines)
+        )
+
+        events = []
+        async for event in adapter.stream(_MESSAGES, **_KWARGS):
+            events.append(event)
+
+        text_events = [e for e in events if e.type == StreamEventType.TEXT_DELTA]
+        assert any(e.text == "hello" for e in text_events)
+
+    @respx.mock
+    async def test_stream_invalid_tool_args_fallback(self) -> None:
+        """Tool call with malformed args string falls back to empty input dict."""
+        adapter = OpenAICompatibleAdapter(api_key="k", base_url=_BASE_URL)
+        sse = _make_sse_lines(
+            _tool_chunk(0, tool_id="c1", name="fn", args=""),
+            _tool_chunk(0, tool_id="", name=None, args="{INVALID", finish_reason="tool_calls"),
+            usage={"prompt_tokens": 5, "completion_tokens": 5},
+        )
+        respx.post(f"{_BASE_URL}/v1/chat/completions").mock(
+            return_value=httpx.Response(200, content=sse)
+        )
+
+        events = []
+        async for event in adapter.stream(_MESSAGES, **_KWARGS):
+            events.append(event)
+
+        tool_events = [e for e in events if e.type == StreamEventType.TOOL_CALL]
+        assert len(tool_events) == 1
+        assert tool_events[0].tool_call is not None
+        assert tool_events[0].tool_call.input == {}
+
+    @respx.mock
+    async def test_transport_error_retried(self) -> None:
+        """httpx.TransportError is retried and succeeds on next attempt."""
+        adapter = OpenAICompatibleAdapter(
+            api_key="k", base_url=_BASE_URL, max_retries=2, retry_base_delay=0.0
+        )
+        call_count = {"n": 0}
+
+        def _side_effect(request, route):
+            call_count["n"] += 1
+            if call_count["n"] < 2:
+                raise httpx.ConnectError("connection refused")
+            return httpx.Response(200, json=_non_stream_response("recovered"))
+
+        respx.post(f"{_BASE_URL}/v1/chat/completions").mock(side_effect=_side_effect)
+
+        result = await adapter.generate(_MESSAGES, **_KWARGS)
+        assert result.content == "recovered"
+
+    @respx.mock
+    async def test_stream_retries_on_429(self) -> None:
+        """Stream path retries on 429 (closes previous stream response)."""
+        adapter = OpenAICompatibleAdapter(
+            api_key="k", base_url=_BASE_URL, max_retries=2, retry_base_delay=0.0
+        )
+        call_count = {"n": 0}
+
+        ok_sse = _make_sse_lines(
+            _text_chunk("ok"),
+            usage={"prompt_tokens": 5, "completion_tokens": 5},
+        )
+
+        def _side_effect(request, route):
+            call_count["n"] += 1
+            if call_count["n"] < 2:
+                return httpx.Response(429, content=b"rate limited")
+            return httpx.Response(200, content=ok_sse)
+
+        respx.post(f"{_BASE_URL}/v1/chat/completions").mock(side_effect=_side_effect)
+
+        events = []
+        async for event in adapter.stream(_MESSAGES, **_KWARGS):
+            events.append(event)
+
+        text_events = [e for e in events if e.type == StreamEventType.TEXT_DELTA]
+        assert any(e.text == "ok" for e in text_events)
+
+
+class TestOpenAIAdapterRetry:
+    @respx.mock
+    async def test_retries_on_429(self) -> None:
+        adapter = OpenAICompatibleAdapter(
+            api_key="k", base_url=_BASE_URL, max_retries=2, retry_base_delay=0.0
+        )
+        route = respx.post(f"{_BASE_URL}/v1/chat/completions")
+        route.side_effect = [
+            httpx.Response(429, json={"error": "rate limited"}),
+            httpx.Response(429, json={"error": "rate limited"}),
+            httpx.Response(200, json=_non_stream_response()),
+        ]
+
+        result = await adapter.generate(_MESSAGES, **_KWARGS)
+        assert result.content is not None
+
+    @respx.mock
+    async def test_raises_after_max_retries(self) -> None:
+        adapter = OpenAICompatibleAdapter(
+            api_key="k", base_url=_BASE_URL, max_retries=1, retry_base_delay=0.0
+        )
+        respx.post(f"{_BASE_URL}/v1/chat/completions").mock(
+            return_value=httpx.Response(503, json={"error": "service unavailable"})
+        )
+
+        with pytest.raises(LLMError):
+            await adapter.generate(_MESSAGES, **_KWARGS)
+
+    @respx.mock
+    async def test_non_retryable_error_raises_immediately(self) -> None:
+        adapter = OpenAICompatibleAdapter(
+            api_key="k", base_url=_BASE_URL, max_retries=3, retry_base_delay=0.0
+        )
+        # 404 is not in _RETRYABLE_STATUS_CODES — must raise immediately.
+        respx.post(f"{_BASE_URL}/v1/chat/completions").mock(
+            return_value=httpx.Response(404, json={"error": "not found"})
+        )
+
+        with pytest.raises(LLMError) as exc_info:
+            await adapter.generate(_MESSAGES, **_KWARGS)
+
+        assert exc_info.value.status_code == 404

--- a/tests/test_ravn/test_sqlite_memory.py
+++ b/tests/test_ravn/test_sqlite_memory.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
+import threading
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -472,3 +473,100 @@ class TestRetryMechanism:
 
         with pytest.raises(sqlite3.OperationalError, match="database is locked"):
             adapter._with_retry(_always_locked)
+
+
+# ---------------------------------------------------------------------------
+# WAL concurrency: concurrent reads during a write
+# ---------------------------------------------------------------------------
+
+
+class TestWALConcurrency:
+    async def test_concurrent_reads_during_write(self, tmp_path: Path) -> None:
+        """WAL mode allows multiple readers while a write is in progress."""
+        adapter = SqliteMemoryAdapter(
+            path=str(tmp_path / "memory.db"),
+            max_retries=5,
+            min_jitter_ms=1.0,
+            max_jitter_ms=5.0,
+        )
+        await adapter.initialize()
+
+        # Pre-load some episodes so reads return data.
+        for i in range(5):
+            await adapter.record_episode(_ep(episode_id=f"pre-{i}", summary=f"background task {i}"))
+
+        read_results: list[int] = []
+        errors: list[Exception] = []
+
+        def _reader_thread(n: int) -> None:
+            import asyncio
+
+            async def _read() -> None:
+                try:
+                    matches = await adapter.query_episodes("background task", min_relevance=0.0)
+                    read_results.append(len(matches))
+                except Exception as exc:
+                    errors.append(exc)
+
+            asyncio.run(_read())
+
+        # Start concurrent reader threads.
+        threads = [threading.Thread(target=_reader_thread, args=(i,)) for i in range(4)]
+        for t in threads:
+            t.start()
+
+        # Write during concurrent reads.
+        concurrent_ep = _ep(episode_id="concurrent-write", summary="write during reads")
+        await adapter.record_episode(concurrent_ep)
+
+        for t in threads:
+            t.join(timeout=10.0)
+
+        # All reads must have succeeded without errors.
+        assert not errors, f"Reader threads failed: {errors}"
+        # Each reader found the pre-loaded episodes.
+        assert all(r >= 0 for r in read_results)
+
+    async def test_checkpoint_triggers_passively(self, tmp_path: Path) -> None:
+        """Passive WAL checkpoint fires after checkpoint_interval writes (no error)."""
+        adapter = SqliteMemoryAdapter(
+            path=str(tmp_path / "memory.db"),
+            checkpoint_interval=3,
+        )
+        await adapter.initialize()
+
+        # Write more than checkpoint_interval to trigger checkpoint.
+        for i in range(7):
+            await adapter.record_episode(
+                _ep(episode_id=f"ckpt-{i}", summary=f"checkpoint episode {i}")
+            )
+
+        # If checkpoint raised, the above would have failed.  Verify writes persisted.
+        conn = sqlite3.connect(str(tmp_path / "memory.db"))
+        row = conn.execute("SELECT COUNT(*) FROM episodes").fetchone()
+        conn.close()
+        assert row[0] == 7
+
+    async def test_empty_database_query_returns_empty(self, tmp_path: Path) -> None:
+        """A freshly initialised database returns empty results gracefully."""
+        adapter = SqliteMemoryAdapter(path=str(tmp_path / "memory.db"))
+        await adapter.initialize()
+
+        matches = await adapter.query_episodes("anything", min_relevance=0.0)
+        assert matches == []
+
+    async def test_empty_database_prefetch_returns_empty_string(self, tmp_path: Path) -> None:
+        """Prefetch on an empty database returns an empty string (no crash)."""
+        adapter = SqliteMemoryAdapter(path=str(tmp_path / "memory.db"))
+        await adapter.initialize()
+
+        result = await adapter.prefetch("any context query")
+        assert result == ""
+
+    async def test_empty_database_search_sessions_returns_empty(self, tmp_path: Path) -> None:
+        """Session search on an empty database returns empty list."""
+        adapter = SqliteMemoryAdapter(path=str(tmp_path / "memory.db"))
+        await adapter.initialize()
+
+        summaries = await adapter.search_sessions("any query")
+        assert summaries == []


### PR DESCRIPTION
## Summary

- **`FallbackLLMAdapter`** (`src/ravn/adapters/fallback_llm.py`): tries LLM providers in order; falls back on `LLMError`; raises `AllProvidersExhaustedError` when all fail; primary is always attempted first on each new call (no sticky state).
- **`OpenAICompatibleAdapter`** (`src/ravn/adapters/openai_llm.py`): full OpenAI Chat Completions API implementation — streaming SSE parsing, tool call extraction, token usage normalisation, reasoning-tag stripping (`<think>`/`<reasoning>`), model-specific steering via `system_prefix`, and transient-error retries.
- **`AllProvidersExhaustedError`** added to `src/ravn/domain/exceptions.py`.

## Tests added

| File | Coverage | What it tests |
|---|---|---|
| `test_fallback_llm.py` | 100% | Primary succeeds; 429/401 fallback; all fail → error; restoration; stream path; transparency |
| `test_openai_llm.py` | 99% | Streaming SSE, tool calls, usage normalisation, reasoning tags, retry, edge cases |
| `test_e2e_memory.py` | — | Memory recall (prefetch → system prompt injection); session search via tool; fallback trigger (429 → fallback, all fail → error, restoration across turns) |
| `test_sqlite_memory.py` | additions | WAL concurrency (threads), passive checkpoint, empty-DB graceful handling |

1351 tests pass, zero warnings. New adapter files at 99–100% coverage.

## Test plan

- [x] `pytest tests/test_ravn/` — 1351 passed
- [x] `ruff check` — all checks passed
- [x] `ruff format` — all files formatted
- [x] New adapter files: `fallback_llm.py` 100%, `openai_llm.py` 99%, `exceptions.py` 100%

Closes NIU-456

🤖 Generated with [Claude Code](https://claude.com/claude-code)