### PR TITLE
feat(adapters): RAVN.md project manifest — full implementation (NIU-499)

### DIFF
--- a/src/ravn/adapters/slash_commands.py
+++ b/src/ravn/adapters/slash_commands.py
@@ -42,99 +42,85 @@ Ravn slash commands:
   /init     — bootstrap a RAVN.md in the current directory\
 """
 
-_RAVN_MD_TEMPLATE_BASE = """\
-# RAVN Project: {project_name}
-
-persona: coding-agent
-allowed_tools: [file, git, terminal, web]
-forbidden_tools: []
-permission_mode: workspace_write
-primary_alias: balanced
-thinking_enabled: false
-iteration_budget: 20
-notes: >
-  Add project-specific instructions here.
-  Ravn will include these in its system prompt.
-"""
-
-_RAVN_MD_TEMPLATE_PYTHON = """\
-# RAVN Project: {project_name}
-
-persona: coding-agent
-allowed_tools: [file, git, terminal, web, todo]
-forbidden_tools: []
-permission_mode: workspace_write
-primary_alias: balanced
-thinking_enabled: false
-iteration_budget: 30
-notes: >
-  Python project. Python 3.12+ style preferred.
-  Run tests with: pytest -x
-  Lint with: ruff check . && ruff format .
-  Always type-annotate function signatures.
-  Use X | None instead of Optional[X].
-"""
-
-_RAVN_MD_TEMPLATE_GO = """\
-# RAVN Project: {project_name}
-
-persona: coding-agent
-allowed_tools: [file, git, terminal, web, todo]
-forbidden_tools: []
-permission_mode: workspace_write
-primary_alias: balanced
-thinking_enabled: false
-iteration_budget: 30
-notes: >
-  Go project.
-  Run tests with: go test ./...
-  Format with: gofmt -w .
-  Lint with: golangci-lint run
-  Follow standard Go idioms and error handling patterns.
-"""
-
-_RAVN_MD_TEMPLATE_NODE = """\
-# RAVN Project: {project_name}
-
-persona: coding-agent
-allowed_tools: [file, git, terminal, web, todo]
-forbidden_tools: []
-permission_mode: workspace_write
-primary_alias: balanced
-thinking_enabled: false
-iteration_budget: 30
-notes: >
-  Node.js project.
-  Run tests with: npm test
-  Lint/format with: npm run lint
-  Always type-annotate if TypeScript is used.
-"""
-
-_RAVN_MD_TEMPLATE_RUST = """\
-# RAVN Project: {project_name}
-
-persona: coding-agent
-allowed_tools: [file, git, terminal, web, todo]
-forbidden_tools: []
-permission_mode: workspace_write
-primary_alias: balanced
-thinking_enabled: false
-iteration_budget: 30
-notes: >
-  Rust project.
-  Run tests with: cargo test
-  Format with: cargo fmt
-  Lint with: cargo clippy
-  Prefer idiomatic Rust — use Result/Option, avoid unwrap() in library code.
-"""
-
-_RAVN_MD_TEMPLATES: dict[str, str] = {
-    "python": _RAVN_MD_TEMPLATE_PYTHON,
-    "go": _RAVN_MD_TEMPLATE_GO,
-    "node": _RAVN_MD_TEMPLATE_NODE,
-    "rust": _RAVN_MD_TEMPLATE_RUST,
-    "generic": _RAVN_MD_TEMPLATE_BASE,
+# Per-type overrides: (notes, iteration_budget, extra_tools).
+# Everything else is shared via _build_ravn_template().
+_PROJECT_TYPE_SPECS: dict[str, tuple[str, int, list[str]]] = {
+    "python": (
+        (
+            "Python project. Python 3.12+ style preferred.\n"
+            "  Run tests with: pytest -x\n"
+            "  Lint with: ruff check . && ruff format .\n"
+            "  Always type-annotate function signatures.\n"
+            "  Use X | None instead of Optional[X]."
+        ),
+        30,
+        ["todo"],
+    ),
+    "go": (
+        (
+            "Go project.\n"
+            "  Run tests with: go test ./...\n"
+            "  Format with: gofmt -w .\n"
+            "  Lint with: golangci-lint run\n"
+            "  Follow standard Go idioms and error handling patterns."
+        ),
+        30,
+        ["todo"],
+    ),
+    "node": (
+        (
+            "Node.js project.\n"
+            "  Run tests with: npm test\n"
+            "  Lint/format with: npm run lint\n"
+            "  Always type-annotate if TypeScript is used."
+        ),
+        30,
+        ["todo"],
+    ),
+    "rust": (
+        (
+            "Rust project.\n"
+            "  Run tests with: cargo test\n"
+            "  Format with: cargo fmt\n"
+            "  Lint with: cargo clippy\n"
+            "  Prefer idiomatic Rust — use Result/Option, avoid unwrap() in library code."
+        ),
+        30,
+        ["todo"],
+    ),
+    "generic": (
+        "Add project-specific instructions here.\n  Ravn will include these in its system prompt.",
+        20,
+        [],
+    ),
 }
+
+_BASE_TOOLS = ["file", "git", "terminal", "web"]
+
+
+def _build_ravn_template(
+    project_name: str,
+    notes: str,
+    iteration_budget: int = 20,
+    extra_tools: list[str] | None = None,
+) -> str:
+    """Build a RAVN.md file content string from the shared schema."""
+    tools = _BASE_TOOLS + (extra_tools or [])
+    tools_yaml = "[" + ", ".join(tools) + "]"
+    return (
+        f"# RAVN Project: {project_name}\n"
+        "\n"
+        "persona: coding-agent\n"
+        f"allowed_tools: {tools_yaml}\n"
+        "forbidden_tools: []\n"
+        "permission_mode: workspace_write\n"
+        "primary_alias: balanced\n"
+        "thinking_enabled: false\n"
+        f"iteration_budget: {iteration_budget}\n"
+        "notes: >\n"
+        f"  {notes}\n"
+    )
+
 
 _TODO_STATUS_ICONS: dict[str, str] = {
     "pending": "○",
@@ -306,7 +292,7 @@ def _cmd_init(ctx: SlashCommandContext) -> str:
         return f"RAVN.md already exists at {ravn_md}. Remove it first to re-initialise."
     project_name = cwd.name
     project_type = _detect_project_type(cwd)
-    template = _RAVN_MD_TEMPLATES.get(project_type, _RAVN_MD_TEMPLATE_BASE)
-    content = template.format(project_name=project_name)
+    notes, budget, extra_tools = _PROJECT_TYPE_SPECS[project_type]
+    content = _build_ravn_template(project_name, notes, budget, extra_tools)
     ravn_md.write_text(content, encoding="utf-8")
     return f"Bootstrapped RAVN.md at {ravn_md} (detected project type: {project_type})"

--- a/src/ravn/adapters/slash_commands.py
+++ b/src/ravn/adapters/slash_commands.py
@@ -42,18 +42,99 @@ Ravn slash commands:
   /init     — bootstrap a RAVN.md in the current directory\
 """
 
-_RAVN_MD_TEMPLATE = """\
+_RAVN_MD_TEMPLATE_BASE = """\
 # RAVN Project: {project_name}
 
 persona: coding-agent
 allowed_tools: [file, git, terminal, web]
 forbidden_tools: []
-permission_mode: allow_all
+permission_mode: workspace_write
+primary_alias: balanced
+thinking_enabled: false
 iteration_budget: 20
 notes: >
   Add project-specific instructions here.
   Ravn will include these in its system prompt.
 """
+
+_RAVN_MD_TEMPLATE_PYTHON = """\
+# RAVN Project: {project_name}
+
+persona: coding-agent
+allowed_tools: [file, git, terminal, web, todo]
+forbidden_tools: []
+permission_mode: workspace_write
+primary_alias: balanced
+thinking_enabled: false
+iteration_budget: 30
+notes: >
+  Python project. Python 3.12+ style preferred.
+  Run tests with: pytest -x
+  Lint with: ruff check . && ruff format .
+  Always type-annotate function signatures.
+  Use X | None instead of Optional[X].
+"""
+
+_RAVN_MD_TEMPLATE_GO = """\
+# RAVN Project: {project_name}
+
+persona: coding-agent
+allowed_tools: [file, git, terminal, web, todo]
+forbidden_tools: []
+permission_mode: workspace_write
+primary_alias: balanced
+thinking_enabled: false
+iteration_budget: 30
+notes: >
+  Go project.
+  Run tests with: go test ./...
+  Format with: gofmt -w .
+  Lint with: golangci-lint run
+  Follow standard Go idioms and error handling patterns.
+"""
+
+_RAVN_MD_TEMPLATE_NODE = """\
+# RAVN Project: {project_name}
+
+persona: coding-agent
+allowed_tools: [file, git, terminal, web, todo]
+forbidden_tools: []
+permission_mode: workspace_write
+primary_alias: balanced
+thinking_enabled: false
+iteration_budget: 30
+notes: >
+  Node.js project.
+  Run tests with: npm test
+  Lint/format with: npm run lint
+  Always type-annotate if TypeScript is used.
+"""
+
+_RAVN_MD_TEMPLATE_RUST = """\
+# RAVN Project: {project_name}
+
+persona: coding-agent
+allowed_tools: [file, git, terminal, web, todo]
+forbidden_tools: []
+permission_mode: workspace_write
+primary_alias: balanced
+thinking_enabled: false
+iteration_budget: 30
+notes: >
+  Rust project.
+  Run tests with: cargo test
+  Format with: cargo fmt
+  Lint with: cargo clippy
+  Prefer idiomatic Rust — use Result/Option, avoid unwrap() in library code.
+"""
+
+_RAVN_MD_TEMPLATES: dict[str, str] = {
+    "python": _RAVN_MD_TEMPLATE_PYTHON,
+    "go": _RAVN_MD_TEMPLATE_GO,
+    "node": _RAVN_MD_TEMPLATE_NODE,
+    "rust": _RAVN_MD_TEMPLATE_RUST,
+    "generic": _RAVN_MD_TEMPLATE_BASE,
+}
 
 _TODO_STATUS_ICONS: dict[str, str] = {
     "pending": "○",
@@ -200,12 +281,32 @@ def _cmd_status(ctx: SlashCommandContext) -> str:
     return "\n".join(lines)
 
 
+def _detect_project_type(cwd: Path) -> str:
+    """Return a project type string by inspecting files in *cwd*.
+
+    Checks for well-known marker files and returns one of:
+    ``"python"``, ``"go"``, ``"node"``, ``"rust"``, or ``"generic"``.
+    """
+    markers: list[tuple[str, list[str]]] = [
+        ("python", ["pyproject.toml", "setup.py", "setup.cfg", "requirements.txt"]),
+        ("go", ["go.mod"]),
+        ("rust", ["Cargo.toml"]),
+        ("node", ["package.json"]),
+    ]
+    for project_type, files in markers:
+        if any((cwd / f).exists() for f in files):
+            return project_type
+    return "generic"
+
+
 def _cmd_init(ctx: SlashCommandContext) -> str:
     cwd = ctx.cwd if ctx.cwd is not None else Path.cwd()
     ravn_md = cwd / "RAVN.md"
     if ravn_md.exists():
         return f"RAVN.md already exists at {ravn_md}. Remove it first to re-initialise."
     project_name = cwd.name
-    content = _RAVN_MD_TEMPLATE.format(project_name=project_name)
+    project_type = _detect_project_type(cwd)
+    template = _RAVN_MD_TEMPLATES.get(project_type, _RAVN_MD_TEMPLATE_BASE)
+    content = template.format(project_name=project_name)
     ravn_md.write_text(content, encoding="utf-8")
-    return f"Bootstrapped RAVN.md at {ravn_md}"
+    return f"Bootstrapped RAVN.md at {ravn_md} (detected project type: {project_type})"

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -753,6 +753,46 @@ def _safe_int(val: object, default: int = 0) -> int:
         return default
 
 
+def _safe_bool(val: object, default: bool = False) -> bool:
+    """Convert *val* to bool, returning *default* on unrecognised input."""
+    if isinstance(val, bool):
+        return val
+    if isinstance(val, str):
+        return val.lower() in ("true", "yes", "1", "on")
+    if isinstance(val, int):
+        return bool(val)
+    return default
+
+
+# ---------------------------------------------------------------------------
+# Valid schema values
+# ---------------------------------------------------------------------------
+
+_VALID_PERMISSION_MODES: frozenset[str] = frozenset(
+    {
+        "read_only",
+        "workspace_write",
+        "workspace-write",
+        "full_access",
+        "full-access",
+        "prompt",
+        # Legacy aliases
+        "allow_all",
+        "deny_all",
+    }
+)
+
+_VALID_PERSONAS: frozenset[str] = frozenset(
+    {
+        "coding-agent",
+        "assistant",
+        "researcher",
+        "reviewer",
+        "planner",
+    }
+)
+
+
 @dataclass
 class ProjectConfig:
     """Project-level configuration overlay parsed from a RAVN.md file.
@@ -770,9 +810,15 @@ class ProjectConfig:
         allowed_tools: [file, git, terminal, web]
         forbidden_tools: [volundr, cascade]
         permission_mode: workspace-write
+        primary_alias: balanced
+        thinking_enabled: true
         iteration_budget: 30
         notes: >
           This is a FastAPI service. Always run tests before committing.
+
+    Attributes:
+        warnings: Non-fatal schema validation messages populated by
+            ``from_text()``.  Callers may display these to the user.
     """
 
     project_name: str = ""
@@ -780,8 +826,11 @@ class ProjectConfig:
     allowed_tools: list[str] = field(default_factory=list)
     forbidden_tools: list[str] = field(default_factory=list)
     permission_mode: str = ""
+    primary_alias: str = ""
+    thinking_enabled: bool = False
     iteration_budget: int = 0
     notes: str = ""
+    warnings: list[str] = field(default_factory=list)
 
     @classmethod
     def from_text(cls, text: str) -> ProjectConfig:
@@ -791,6 +840,8 @@ class ProjectConfig:
         Everything after the header is treated as YAML.  If the header is
         absent or the YAML is malformed the method returns an empty
         ProjectConfig rather than raising.
+
+        Schema validation warnings are stored in ``ProjectConfig.warnings``.
         """
         import yaml  # PyYAML — present via pydantic-settings[yaml]
 
@@ -815,14 +866,37 @@ class ProjectConfig:
             except Exception:
                 pass
 
+        warnings: list[str] = []
+
+        permission_mode = str(raw.get("permission_mode", ""))
+        if permission_mode and permission_mode not in _VALID_PERMISSION_MODES:
+            warnings.append(
+                f"Unknown permission_mode {permission_mode!r}. "
+                f"Valid values: {sorted(_VALID_PERMISSION_MODES)}"
+            )
+
+        persona = str(raw.get("persona", ""))
+        if persona and persona not in _VALID_PERSONAS:
+            warnings.append(
+                f"Unknown persona {persona!r}. Known personas: {sorted(_VALID_PERSONAS)}"
+            )
+
+        iteration_budget = _safe_int(raw.get("iteration_budget", 0))
+        if iteration_budget < 0:
+            warnings.append(f"iteration_budget must be >= 0, got {iteration_budget}. Using 0.")
+            iteration_budget = 0
+
         return cls(
             project_name=project_name,
-            persona=str(raw.get("persona", "")),
+            persona=persona,
             allowed_tools=list(raw.get("allowed_tools", [])),
             forbidden_tools=list(raw.get("forbidden_tools", [])),
-            permission_mode=str(raw.get("permission_mode", "")),
-            iteration_budget=_safe_int(raw.get("iteration_budget", 0)),
+            permission_mode=permission_mode,
+            primary_alias=str(raw.get("primary_alias", "")),
+            thinking_enabled=_safe_bool(raw.get("thinking_enabled", False)),
+            iteration_budget=iteration_budget,
             notes=str(raw.get("notes", "")),
+            warnings=warnings,
         )
 
     @classmethod
@@ -838,8 +912,13 @@ class ProjectConfig:
     def discover(cls, cwd: Path | None = None) -> ProjectConfig | None:
         """Walk from *cwd* toward the filesystem root looking for RAVN.md.
 
-        Returns the first ProjectConfig found, or None if no RAVN.md exists
-        in any ancestor directory.
+        Discovery order:
+        1. *cwd* (defaults to ``Path.cwd()``)
+        2. Each ancestor directory up to the filesystem root
+        3. ``~/.ravn/default.md`` — user-level global default
+
+        Returns the first ``ProjectConfig`` found, or ``None`` if no file
+        exists in any of the above locations.
         """
         start = Path(cwd) if cwd is not None else Path.cwd()
         current = start.resolve()
@@ -851,4 +930,10 @@ class ProjectConfig:
             if parent == current:
                 break
             current = parent
+
+        # Global user default — ~/.ravn/default.md
+        global_default = Path.home() / ".ravn" / "default.md"
+        if global_default.is_file():
+            return cls.load(global_default)
+
         return None

--- a/tests/test_ravn/test_project_config.py
+++ b/tests/test_ravn/test_project_config.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
-from ravn.config import ProjectConfig
+from ravn.config import _VALID_PERMISSION_MODES, _VALID_PERSONAS, ProjectConfig
 
 _FULL_RAVN_MD = """\
 # RAVN Project: my-service
@@ -13,6 +14,8 @@ persona: coding-agent
 allowed_tools: [file, git, terminal, web]
 forbidden_tools: [volundr, cascade]
 permission_mode: workspace-write
+primary_alias: balanced
+thinking_enabled: true
 iteration_budget: 30
 notes: >
   This is a FastAPI service. Always run tests before committing.
@@ -179,3 +182,136 @@ class TestProjectConfigDiscover:
         assert cfg is not None
         assert cfg.project_name == "child"
         assert cfg.iteration_budget == 99
+
+    def test_discover_falls_back_to_global_default(self, tmp_path: Path) -> None:
+        """When no RAVN.md is found in the tree, ~/.ravn/default.md is tried."""
+        global_default = tmp_path / ".ravn" / "default.md"
+        global_default.parent.mkdir(parents=True)
+        global_default.write_text("# RAVN Project: global-default\n\niteration_budget: 5\n")
+
+        isolated = tmp_path / "project"
+        isolated.mkdir()
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            cfg = ProjectConfig.discover(cwd=isolated)
+
+        assert cfg is not None
+        assert cfg.project_name == "global-default"
+
+    def test_discover_project_file_beats_global_default(self, tmp_path: Path) -> None:
+        """A local RAVN.md takes precedence over ~/.ravn/default.md."""
+        global_default = tmp_path / ".ravn" / "default.md"
+        global_default.parent.mkdir(parents=True)
+        global_default.write_text("# RAVN Project: global-default\n")
+
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        (project_dir / "RAVN.md").write_text("# RAVN Project: local\n")
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            cfg = ProjectConfig.discover(cwd=project_dir)
+
+        assert cfg is not None
+        assert cfg.project_name == "local"
+
+    def test_discover_returns_none_when_no_files_anywhere(self, tmp_path: Path) -> None:
+        """Returns None when no RAVN.md exists anywhere and no global default."""
+        isolated = tmp_path / "project"
+        isolated.mkdir()
+
+        # Point home to a directory without .ravn/default.md
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            cfg = ProjectConfig.discover(cwd=isolated)
+
+        assert cfg is None
+
+
+# ---------------------------------------------------------------------------
+# New fields: primary_alias, thinking_enabled, warnings
+# ---------------------------------------------------------------------------
+
+
+class TestProjectConfigNewFields:
+    def test_parses_primary_alias(self) -> None:
+        cfg = ProjectConfig.from_text(_FULL_RAVN_MD)
+        assert cfg.primary_alias == "balanced"
+
+    def test_parses_thinking_enabled_true(self) -> None:
+        cfg = ProjectConfig.from_text(_FULL_RAVN_MD)
+        assert cfg.thinking_enabled is True
+
+    def test_thinking_enabled_defaults_false(self) -> None:
+        cfg = ProjectConfig.from_text("# RAVN Project: x\n\npersona: coding-agent\n")
+        assert cfg.thinking_enabled is False
+
+    def test_thinking_enabled_false_explicit(self) -> None:
+        cfg = ProjectConfig.from_text("# RAVN Project: x\n\nthinking_enabled: false\n")
+        assert cfg.thinking_enabled is False
+
+    def test_primary_alias_defaults_empty(self) -> None:
+        cfg = ProjectConfig.from_text("# RAVN Project: x\n\npersona: coding-agent\n")
+        assert cfg.primary_alias == ""
+
+    def test_no_warnings_for_valid_config(self) -> None:
+        cfg = ProjectConfig.from_text(_FULL_RAVN_MD)
+        assert cfg.warnings == []
+
+    def test_thinking_enabled_string_true(self) -> None:
+        cfg = ProjectConfig.from_text("# RAVN Project: x\n\nthinking_enabled: 'true'\n")
+        assert cfg.thinking_enabled is True
+
+    def test_thinking_enabled_integer_one(self) -> None:
+        cfg = ProjectConfig.from_text("# RAVN Project: x\n\nthinking_enabled: 1\n")
+        assert cfg.thinking_enabled is True
+
+
+# ---------------------------------------------------------------------------
+# Schema validation
+# ---------------------------------------------------------------------------
+
+
+class TestProjectConfigValidation:
+    def test_invalid_permission_mode_produces_warning(self) -> None:
+        cfg = ProjectConfig.from_text("# RAVN Project: x\n\npermission_mode: fly-mode\n")
+        assert any("permission_mode" in w for w in cfg.warnings)
+
+    def test_valid_permission_modes_no_warning(self) -> None:
+        for mode in _VALID_PERMISSION_MODES:
+            cfg = ProjectConfig.from_text(f"# RAVN Project: x\n\npermission_mode: {mode}\n")
+            assert not any("permission_mode" in w for w in cfg.warnings), (
+                f"Unexpected warning for valid mode {mode!r}"
+            )
+
+    def test_invalid_persona_produces_warning(self) -> None:
+        cfg = ProjectConfig.from_text("# RAVN Project: x\n\npersona: quantum-hacker\n")
+        assert any("persona" in w for w in cfg.warnings)
+
+    def test_valid_personas_no_warning(self) -> None:
+        for persona in _VALID_PERSONAS:
+            cfg = ProjectConfig.from_text(f"# RAVN Project: x\n\npersona: {persona}\n")
+            assert not any("persona" in w for w in cfg.warnings), (
+                f"Unexpected warning for valid persona {persona!r}"
+            )
+
+    def test_negative_iteration_budget_clamped_to_zero(self) -> None:
+        cfg = ProjectConfig.from_text("# RAVN Project: x\n\niteration_budget: -5\n")
+        assert cfg.iteration_budget == 0
+        assert any("iteration_budget" in w for w in cfg.warnings)
+
+    def test_empty_permission_mode_no_warning(self) -> None:
+        cfg = ProjectConfig.from_text("# RAVN Project: x\n\npersona: coding-agent\n")
+        assert not any("permission_mode" in w for w in cfg.warnings)
+
+    def test_empty_persona_no_warning(self) -> None:
+        cfg = ProjectConfig.from_text("# RAVN Project: x\n\nallowed_tools: [file]\n")
+        assert not any("persona" in w for w in cfg.warnings)
+
+    def test_multiple_warnings_accumulated(self) -> None:
+        cfg = ProjectConfig.from_text(
+            "# RAVN Project: x\n\npermission_mode: bad\npersona: robot\niteration_budget: -1\n"
+        )
+        assert len(cfg.warnings) >= 3
+
+    def test_valid_schema_constants_non_empty(self) -> None:
+        assert len(_VALID_PERMISSION_MODES) > 0
+        assert len(_VALID_PERSONAS) > 0

--- a/tests/test_ravn/test_slash_commands.py
+++ b/tests/test_ravn/test_slash_commands.py
@@ -325,3 +325,112 @@ class TestCmdInit:
         result = handle("/init", _ctx(cwd=None))
         assert result is not None
         assert (tmp_path / "RAVN.md").exists()
+
+    def test_ravn_md_contains_primary_alias(self, tmp_path: Path) -> None:
+        handle("/init", _ctx(cwd=tmp_path))
+        content = (tmp_path / "RAVN.md").read_text()
+        assert "primary_alias" in content
+
+    def test_ravn_md_contains_thinking_enabled(self, tmp_path: Path) -> None:
+        handle("/init", _ctx(cwd=tmp_path))
+        content = (tmp_path / "RAVN.md").read_text()
+        assert "thinking_enabled" in content
+
+    def test_python_project_detected(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text("[project]\nname = 'mylib'\n")
+        result = handle("/init", _ctx(cwd=tmp_path))
+        assert result is not None
+        assert "python" in result
+        content = (tmp_path / "RAVN.md").read_text()
+        assert "pytest" in content
+
+    def test_go_project_detected(self, tmp_path: Path) -> None:
+        (tmp_path / "go.mod").write_text("module example.com/myapp\n")
+        result = handle("/init", _ctx(cwd=tmp_path))
+        assert result is not None
+        assert "go" in result
+        content = (tmp_path / "RAVN.md").read_text()
+        assert "go test" in content
+
+    def test_rust_project_detected(self, tmp_path: Path) -> None:
+        (tmp_path / "Cargo.toml").write_text("[package]\nname = 'myapp'\n")
+        result = handle("/init", _ctx(cwd=tmp_path))
+        assert result is not None
+        assert "rust" in result
+        content = (tmp_path / "RAVN.md").read_text()
+        assert "cargo" in content.lower()
+
+    def test_node_project_detected(self, tmp_path: Path) -> None:
+        (tmp_path / "package.json").write_text('{"name": "myapp"}\n')
+        result = handle("/init", _ctx(cwd=tmp_path))
+        assert result is not None
+        assert "node" in result
+
+    def test_generic_project_no_markers(self, tmp_path: Path) -> None:
+        result = handle("/init", _ctx(cwd=tmp_path))
+        assert result is not None
+        assert "generic" in result
+
+    def test_generated_ravn_md_no_schema_warnings(self, tmp_path: Path) -> None:
+        from ravn.config import ProjectConfig
+
+        handle("/init", _ctx(cwd=tmp_path))
+        cfg = ProjectConfig.load(tmp_path / "RAVN.md")
+        assert cfg is not None
+        assert cfg.warnings == []
+
+
+# ---------------------------------------------------------------------------
+# _detect_project_type
+# ---------------------------------------------------------------------------
+
+
+class TestDetectProjectType:
+    def test_pyproject_toml(self, tmp_path: Path) -> None:
+        from ravn.adapters.slash_commands import _detect_project_type
+
+        (tmp_path / "pyproject.toml").write_text("")
+        assert _detect_project_type(tmp_path) == "python"
+
+    def test_setup_py(self, tmp_path: Path) -> None:
+        from ravn.adapters.slash_commands import _detect_project_type
+
+        (tmp_path / "setup.py").write_text("")
+        assert _detect_project_type(tmp_path) == "python"
+
+    def test_requirements_txt(self, tmp_path: Path) -> None:
+        from ravn.adapters.slash_commands import _detect_project_type
+
+        (tmp_path / "requirements.txt").write_text("")
+        assert _detect_project_type(tmp_path) == "python"
+
+    def test_go_mod(self, tmp_path: Path) -> None:
+        from ravn.adapters.slash_commands import _detect_project_type
+
+        (tmp_path / "go.mod").write_text("")
+        assert _detect_project_type(tmp_path) == "go"
+
+    def test_cargo_toml(self, tmp_path: Path) -> None:
+        from ravn.adapters.slash_commands import _detect_project_type
+
+        (tmp_path / "Cargo.toml").write_text("")
+        assert _detect_project_type(tmp_path) == "rust"
+
+    def test_package_json(self, tmp_path: Path) -> None:
+        from ravn.adapters.slash_commands import _detect_project_type
+
+        (tmp_path / "package.json").write_text("")
+        assert _detect_project_type(tmp_path) == "node"
+
+    def test_no_markers_returns_generic(self, tmp_path: Path) -> None:
+        from ravn.adapters.slash_commands import _detect_project_type
+
+        assert _detect_project_type(tmp_path) == "generic"
+
+    def test_python_priority_over_node(self, tmp_path: Path) -> None:
+        """Python markers are checked before Node when both exist."""
+        from ravn.adapters.slash_commands import _detect_project_type
+
+        (tmp_path / "pyproject.toml").write_text("")
+        (tmp_path / "package.json").write_text("")
+        assert _detect_project_type(tmp_path) == "python"

--- a/tests/test_ravn/test_slash_commands.py
+++ b/tests/test_ravn/test_slash_commands.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from ravn.adapters.slash_commands import SlashCommandContext, handle
 from ravn.domain.models import Session, TodoItem, TodoStatus
 
@@ -371,13 +373,33 @@ class TestCmdInit:
         assert result is not None
         assert "generic" in result
 
-    def test_generated_ravn_md_no_schema_warnings(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize(
+        "project_type,marker_file,marker_content",
+        [
+            ("python", "pyproject.toml", "[project]\nname = 'mylib'\n"),
+            ("go", "go.mod", "module example.com/myapp\n"),
+            ("rust", "Cargo.toml", "[package]\nname = 'myapp'\n"),
+            ("node", "package.json", '{"name": "myapp"}\n'),
+            ("generic", None, None),
+        ],
+    )
+    def test_generated_ravn_md_no_schema_warnings(
+        self,
+        tmp_path: Path,
+        project_type: str,
+        marker_file: str | None,
+        marker_content: str | None,
+    ) -> None:
         from ravn.config import ProjectConfig
 
+        if marker_file is not None:
+            (tmp_path / marker_file).write_text(marker_content or "")
         handle("/init", _ctx(cwd=tmp_path))
         cfg = ProjectConfig.load(tmp_path / "RAVN.md")
-        assert cfg is not None
-        assert cfg.warnings == []
+        assert cfg is not None, f"ProjectConfig.load returned None for {project_type} template"
+        assert cfg.warnings == [], (
+            f"{project_type} template produced schema warnings: {cfg.warnings}"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **New `ProjectConfig` fields**: `primary_alias` and `thinking_enabled` complete the full RAVN.md schema from the ticket spec
- **Schema validation**: `from_text()` now collects non-fatal warnings for unknown `permission_mode` / `persona` values and clamps negative `iteration_budget` to 0 — stored in `ProjectConfig.warnings`
- **Global default discovery**: `ProjectConfig.discover()` now falls back to `~/.ravn/default.md` after exhausting the CWD-to-root walk, giving users a user-level default manifest
- **`/init` project-type detection**: detects Python (`pyproject.toml`, `setup.py`, `requirements.txt`), Go (`go.mod`), Rust (`Cargo.toml`), Node (`package.json`), or generic; generates a project-type-specific template with all schema fields pre-populated and zero schema warnings

## Changed files

| File | Change |
|------|--------|
| `src/ravn/config.py` | Add `primary_alias`, `thinking_enabled`, `warnings` to `ProjectConfig`; add `_VALID_PERMISSION_MODES`, `_VALID_PERSONAS` constants; add `_safe_bool`; global default discovery in `discover()` |
| `src/ravn/adapters/slash_commands.py` | Five per-language RAVN.md templates; `_RAVN_MD_TEMPLATES` dispatch map; `_detect_project_type()` helper; updated `_cmd_init()` |
| `tests/test_ravn/test_project_config.py` | Tests for new fields, global default fallback, and all validation scenarios |
| `tests/test_ravn/test_slash_commands.py` | Tests for per-language `/init` templates and `_detect_project_type` helper |

## Test plan

- [x] `pytest tests/ravn/ tests/test_ravn/` — 2022 passed, 0 failed
- [x] Coverage: 96.25% (≥ 85% required); `slash_commands.py` 100%, `config.py` 99%
- [x] `ruff check` — no issues
- [x] `ruff format` — no diffs

## Notes

Linear MCP server was not available in this environment. Ticket NIU-499 could not be updated via MCP. Please update it manually to **In Review** and link this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)