### PR TITLE
feat(adapters): skill registry — user-defined reusable prompt sequences (NIU-500)

### DIFF
--- a/src/ravn/adapters/file_skill_registry.py
+++ b/src/ravn/adapters/file_skill_registry.py
@@ -151,7 +151,8 @@ class FileSkillRegistry(SkillPort):
             first).  When ``None``, uses the default three-layer discovery:
             ``.ravn/skills/`` → ``~/.ravn/skills/`` → built-in skills.
         include_builtin: Whether to include the skills shipped with the
-            ``ravn`` package.  Ignored when *skill_dirs* is set explicitly.
+            ``ravn`` package.  Controls whether built-in skills are appended
+            regardless of how *skill_dirs* is configured.
         cwd: Working directory used to resolve ``.ravn/skills/``.  Defaults to
             the process working directory at construction time.
     """

--- a/src/ravn/adapters/file_skill_registry.py
+++ b/src/ravn/adapters/file_skill_registry.py
@@ -1,0 +1,259 @@
+"""File-based skill registry.
+
+Discovers user-defined and built-in skills from Markdown files on the filesystem.
+
+Discovery order (highest priority first):
+1. Project-local:  ``.ravn/skills/`` in the current working directory.
+2. User-global:    ``~/.ravn/skills/``.
+3. Built-in:       skills shipped with the ``ravn`` package (``src/ravn/skills/``).
+
+When the same skill name appears in multiple locations, the highest-priority
+source wins.
+
+Skill file format
+-----------------
+A skill is a ``.md`` file.  The name is taken from the first line if it
+matches the ``# skill: <name>`` pattern; otherwise the filename stem is used.
+The description is the first non-empty, non-header line of content.
+
+Example::
+
+    # skill: fix-tests
+
+    Run the test suite, identify all failing tests, and fix them one by one.
+
+Configuration
+-------------
+Pass *skill_dirs* to override the default search paths entirely, or leave it
+as ``None`` to use the default three-layer discovery.  Set
+*include_builtin=False* to suppress the built-in skills.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import uuid4
+
+from ravn.domain.models import Episode, Skill
+from ravn.ports.skill import SkillPort
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_SKILL_HEADER_RE = re.compile(r"^#\s*skill:\s*(.+)$", re.IGNORECASE)
+_BUILTIN_SKILLS_DIR = Path(__file__).parent.parent / "skills"
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_skill_file(path: Path) -> Skill | None:
+    """Parse a single skill Markdown file and return a :class:`Skill`.
+
+    Returns ``None`` if the file cannot be read or contains no usable content.
+    """
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        logger.warning("file_skill_registry: cannot read %s: %s", path, exc)
+        return None
+
+    if not text.strip():
+        return None
+
+    lines = text.splitlines()
+    name: str = path.stem  # fallback: filename without extension
+    description: str = ""
+    content_start = 0
+
+    # Extract name from `# skill: <name>` header on the first non-empty line.
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        m = _SKILL_HEADER_RE.match(stripped)
+        if m:
+            name = m.group(1).strip()
+            content_start = i + 1
+        break
+
+    # Extract description from the first non-empty line after the header.
+    for line in lines[content_start:]:
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            description = stripped
+            break
+
+    if not description:
+        description = f"Skill: {name}"
+
+    return Skill(
+        skill_id=str(uuid4()),
+        name=name,
+        description=description,
+        content=text,
+        requires_tools=[],
+        fallback_for_tools=[],
+        source_episodes=[],
+        created_at=datetime.fromtimestamp(path.stat().st_mtime, tz=UTC),
+        success_count=0,
+    )
+
+
+def _discover_from_dir(directory: Path) -> dict[str, Skill]:
+    """Return a ``{name: Skill}`` mapping of skills found in *directory*.
+
+    Silently returns an empty dict if the directory does not exist.
+    """
+    if not directory.is_dir():
+        return {}
+
+    skills: dict[str, Skill] = {}
+    for md_file in sorted(directory.glob("*.md")):
+        skill = _parse_skill_file(md_file)
+        if skill is None:
+            continue
+        # Later entries overwrite earlier ones for the same name, so sort order
+        # determines tie-breaking within a single directory (alphabetical).
+        skills[skill.name.lower()] = skill
+
+    return skills
+
+
+def _filter_by_query(skills: list[Skill], query: str) -> list[Skill]:
+    q = query.lower()
+    return [
+        s
+        for s in skills
+        if q in s.name.lower() or q in s.description.lower() or q in s.content.lower()
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Adapter
+# ---------------------------------------------------------------------------
+
+
+class FileSkillRegistry(SkillPort):
+    """Skill registry backed by Markdown files on the filesystem.
+
+    Args:
+        skill_dirs: Explicit list of directories to search (highest priority
+            first).  When ``None``, uses the default three-layer discovery:
+            ``.ravn/skills/`` → ``~/.ravn/skills/`` → built-in skills.
+        include_builtin: Whether to include the skills shipped with the
+            ``ravn`` package.  Ignored when *skill_dirs* is set explicitly.
+        cwd: Working directory used to resolve ``.ravn/skills/``.  Defaults to
+            the process working directory at construction time.
+    """
+
+    def __init__(
+        self,
+        *,
+        skill_dirs: list[str] | None = None,
+        include_builtin: bool = True,
+        cwd: Path | None = None,
+    ) -> None:
+        self._include_builtin = include_builtin
+        self._cwd = cwd or Path.cwd()
+
+        if skill_dirs is not None:
+            self._skill_dirs: list[Path] | None = [Path(d).expanduser() for d in skill_dirs]
+        else:
+            self._skill_dirs = None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _resolve_dirs(self) -> list[Path]:
+        """Return the ordered list of directories to search.
+
+        When *skill_dirs* was supplied explicitly it forms the base list;
+        otherwise the default two-layer (project-local → user-global) paths
+        are used.  Built-in skills are appended last when *include_builtin*
+        is True, regardless of how *skill_dirs* was set.
+        """
+        if self._skill_dirs is not None:
+            dirs = list(self._skill_dirs)
+        else:
+            dirs = [
+                self._cwd / ".ravn" / "skills",
+                Path.home() / ".ravn" / "skills",
+            ]
+        if self._include_builtin:
+            dirs.append(_BUILTIN_SKILLS_DIR)
+        return dirs
+
+    def _load_all_sync(self) -> list[Skill]:
+        """Discover all skills from the filesystem (sync, for use with asyncio.to_thread)."""
+        # Merge priority layers: later (lower-priority) dirs fill in gaps for
+        # names not yet seen; earlier (higher-priority) dirs win conflicts.
+        merged: dict[str, Skill] = {}
+
+        for directory in reversed(self._resolve_dirs()):
+            layer = _discover_from_dir(directory)
+            merged.update(layer)
+
+        return list(merged.values())
+
+    # ------------------------------------------------------------------
+    # SkillPort
+    # ------------------------------------------------------------------
+
+    async def record_episode(self, episode: Episode) -> Skill | None:
+        """File-based skills are user-managed; episodes are not processed."""
+        return None
+
+    async def list_skills(self, query: str | None = None) -> list[Skill]:
+        """List all discovered skills, optionally filtered by *query*."""
+        skills = await asyncio.to_thread(self._load_all_sync)
+        if query:
+            skills = _filter_by_query(skills, query)
+        return sorted(skills, key=lambda s: s.name.lower())
+
+    async def record_skill(self, skill: Skill) -> None:
+        """Persist a skill to the user-global skills directory.
+
+        Creates ``~/.ravn/skills/<name>.md`` with the skill content.
+        Silently skips if the content is empty.
+        """
+        if not skill.content.strip():
+            return
+
+        dest_dir = Path.home() / ".ravn" / "skills"
+        await asyncio.to_thread(self._write_skill_file, dest_dir, skill)
+
+    def _write_skill_file(self, dest_dir: Path, skill: Skill) -> None:
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        safe_name = re.sub(r"[^\w\-]", "-", skill.name.lower())
+        dest = dest_dir / f"{safe_name}.md"
+        try:
+            dest.write_text(skill.content, encoding="utf-8")
+        except OSError as exc:
+            logger.warning("file_skill_registry: cannot write skill %s: %s", dest, exc)
+
+    async def get_skill(self, name: str) -> Skill | None:
+        """Return the skill with the given *name*, or ``None`` if not found.
+
+        Searches the filesystem in priority order.  The first match wins.
+        """
+        name_lower = name.lower()
+
+        def _find_sync() -> Skill | None:
+            for directory in self._resolve_dirs():
+                layer = _discover_from_dir(directory)
+                if name_lower in layer:
+                    return layer[name_lower]
+            return None
+
+        return await asyncio.to_thread(_find_sync)

--- a/src/ravn/adapters/slash_commands.py
+++ b/src/ravn/adapters/slash_commands.py
@@ -39,6 +39,7 @@ Ravn slash commands:
   /budget   — show iteration budget: used / remaining / limit
   /todo     — show current todo list
   /status   — full agent state dump
+  /skills   — list all available skills
   /init     — bootstrap a RAVN.md in the current directory\
 """
 
@@ -82,6 +83,10 @@ class SlashCommandContext:
     llm_adapter_name: str = ""
     permission_mode: str = "allow_all"
     cwd: Path | None = None
+    # Pre-fetched skill listing: list of (name, description) tuples.
+    # Populated by the caller before the REPL iteration so that _cmd_skills
+    # can display skills without running an async call.
+    skills_listing: list[tuple[str, str]] | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -118,6 +123,8 @@ def handle(user_input: str, ctx: SlashCommandContext) -> str | None:
             return _cmd_todo(ctx)
         case "/status":
             return _cmd_status(ctx)
+        case "/skills":
+            return _cmd_skills(ctx)
         case "/init":
             return _cmd_init(ctx)
         case _:
@@ -197,6 +204,22 @@ def _cmd_status(ctx: SlashCommandContext) -> str:
         f"Tools ({len(tool_names):>2}) : {', '.join(tool_names) if tool_names else 'none'}",
         f"Todos       : {len(s.todos)}",
     ]
+    return "\n".join(lines)
+
+
+def _cmd_skills(ctx: SlashCommandContext) -> str:
+    listing = ctx.skills_listing
+    if listing is None:
+        return (
+            "Skill listing not available. "
+            "Use the skill_list tool inside the agent to see available skills."
+        )
+    if not listing:
+        return "No skills available. Add .md files to .ravn/skills/ to define skills."
+
+    lines = [f"Skills ({len(listing)}):", ""]
+    for name, description in listing:
+        lines.append(f"  {name:<24}  {description}")
     return "\n".join(lines)
 
 

--- a/src/ravn/adapters/tools/skill_tools.py
+++ b/src/ravn/adapters/tools/skill_tools.py
@@ -1,0 +1,214 @@
+"""Skill tools — let the agent discover and execute user-defined skills.
+
+Two tools are provided:
+
+* ``skill_list`` — list all available skills with name and description.
+* ``skill_run``  — load a skill's instruction content and return it, causing
+  the agent to follow those instructions for the current task.
+
+Permission model
+----------------
+Both tools use ``skill:read`` as their required permission.  This string
+contains no write/delete/execute markers so it is granted in every standard
+mode (read_only, workspace_write, full_access).  Skills themselves may
+instruct the agent to perform actions that require additional permissions, but
+the *loading* of a skill is always a read-only operation.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from ravn.domain.models import ToolResult
+from ravn.ports.skill import SkillPort
+from ravn.ports.tool import ToolPort
+
+logger = logging.getLogger(__name__)
+
+_SKILL_PERMISSION = "skill:read"
+
+
+# ---------------------------------------------------------------------------
+# skill_list
+# ---------------------------------------------------------------------------
+
+
+class SkillListTool(ToolPort):
+    """List all available skills with their name and description.
+
+    Skills are discovered from:
+    1. ``.ravn/skills/`` in the current project directory (project-local).
+    2. ``~/.ravn/skills/`` (user-global).
+    3. Built-in skills shipped with Ravn.
+
+    Use this tool to discover what skills are available before running one
+    with ``skill_run``.
+    """
+
+    def __init__(self, skill_port: SkillPort) -> None:
+        self._skill_port = skill_port
+
+    @property
+    def name(self) -> str:
+        return "skill_list"
+
+    @property
+    def description(self) -> str:
+        return (
+            "List all available skills with their name and first-line description. "
+            "Skills are reusable instruction sequences stored as Markdown files in "
+            ".ravn/skills/ (project), ~/.ravn/skills/ (user), or built in to Ravn. "
+            "Use this to discover skills before running one with skill_run."
+        )
+
+    @property
+    def input_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": (
+                        "Optional filter string. Only skills whose name, description, "
+                        "or content contains this text (case-insensitive) are returned."
+                    ),
+                },
+            },
+        }
+
+    @property
+    def required_permission(self) -> str:
+        return _SKILL_PERMISSION
+
+    async def execute(self, input: dict) -> ToolResult:  # noqa: A002
+        query: str | None = input.get("query") or None
+
+        try:
+            skills = await self._skill_port.list_skills(query=query)
+        except Exception as exc:
+            logger.warning("skill_list: list_skills failed: %s", exc)
+            return ToolResult(
+                tool_call_id="",
+                content=f"Failed to list skills: {exc}",
+                is_error=True,
+            )
+
+        if not skills:
+            if query:
+                return ToolResult(
+                    tool_call_id="",
+                    content=f"No skills found matching {query!r}.",
+                )
+            return ToolResult(
+                tool_call_id="",
+                content=(
+                    "No skills available. Create a skill by adding a .md file to .ravn/skills/."
+                ),
+            )
+
+        lines = [f"Available skills ({len(skills)}):", ""]
+        for skill in skills:
+            lines.append(f"  {skill.name:<24}  {skill.description}")
+
+        if query:
+            lines.insert(0, f"Filtered by: {query!r}\n")
+
+        return ToolResult(tool_call_id="", content="\n".join(lines))
+
+
+# ---------------------------------------------------------------------------
+# skill_run
+# ---------------------------------------------------------------------------
+
+
+_ARGS_SEPARATOR = "\n\n---\n\n"
+
+
+class SkillRunTool(ToolPort):
+    """Load a skill and return its instruction content for execution.
+
+    The returned content is the full Markdown body of the skill.  The agent
+    reads this and uses it as the instruction set for the current task.
+    Optionally pass *args* to provide additional context or parameters that
+    are appended to the skill instructions.
+    """
+
+    def __init__(self, skill_port: SkillPort) -> None:
+        self._skill_port = skill_port
+
+    @property
+    def name(self) -> str:
+        return "skill_run"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Load a named skill and return its instruction content. "
+            "The skill content becomes your instruction set for the current task — "
+            "read it and follow the steps exactly. "
+            "Use skill_list first to discover available skill names."
+        )
+
+    @property
+    def input_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "skill_name": {
+                    "type": "string",
+                    "description": "Name of the skill to load (as shown by skill_list).",
+                },
+                "args": {
+                    "type": "string",
+                    "description": (
+                        "Optional additional context or parameters to append to the "
+                        "skill instructions (e.g. a specific file path or test name)."
+                    ),
+                },
+            },
+            "required": ["skill_name"],
+        }
+
+    @property
+    def required_permission(self) -> str:
+        return _SKILL_PERMISSION
+
+    @property
+    def parallelisable(self) -> bool:
+        return False
+
+    async def execute(self, input: dict) -> ToolResult:  # noqa: A002
+        skill_name = (input.get("skill_name") or "").strip()
+        if not skill_name:
+            return ToolResult(
+                tool_call_id="",
+                content="Error: skill_name must not be empty.",
+                is_error=True,
+            )
+
+        try:
+            skill = await self._skill_port.get_skill(skill_name)
+        except Exception as exc:
+            logger.warning("skill_run: get_skill(%r) failed: %s", skill_name, exc)
+            return ToolResult(
+                tool_call_id="",
+                content=f"Failed to load skill {skill_name!r}: {exc}",
+                is_error=True,
+            )
+
+        if skill is None:
+            return ToolResult(
+                tool_call_id="",
+                content=(
+                    f"Skill {skill_name!r} not found. Use skill_list to see available skills."
+                ),
+                is_error=True,
+            )
+
+        content = skill.content.strip()
+        args = (input.get("args") or "").strip()
+        if args:
+            content = content + _ARGS_SEPARATOR + args
+
+        header = f"## Skill: {skill.name}\n\n"
+        return ToolResult(tool_call_id="", content=header + content)

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -325,6 +325,18 @@ class SkillConfig(BaseModel):
         default=128,
         description="Maximum entries in the in-process LRU skill cache.",
     )
+    skill_dirs: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Extra directories to search for user-defined skill Markdown files, "
+            "in addition to the default .ravn/skills/ and ~/.ravn/skills/ paths. "
+            "Paths are searched in order; earlier entries have higher priority."
+        ),
+    )
+    include_builtin: bool = Field(
+        default=True,
+        description="Include the built-in skills shipped with Ravn in the skill registry.",
+    )
 
 
 class MemoryConfig(BaseModel):

--- a/src/ravn/ports/skill.py
+++ b/src/ravn/ports/skill.py
@@ -40,3 +40,17 @@ class SkillPort(ABC):
     async def record_skill(self, skill: Skill) -> None:
         """Persist *skill* directly (bypass automatic discovery)."""
         ...
+
+    async def get_skill(self, name: str) -> Skill | None:
+        """Return the skill with the given *name*, or None if not found.
+
+        The default implementation calls :meth:`list_skills` and filters by
+        name (case-insensitive).  Implementations may override this for
+        more efficient lookup.
+        """
+        skills = await self.list_skills()
+        name_lower = name.lower()
+        for skill in skills:
+            if skill.name.lower() == name_lower:
+                return skill
+        return None

--- a/src/ravn/skills/code-review.md
+++ b/src/ravn/skills/code-review.md
@@ -1,0 +1,32 @@
+# skill: code-review
+
+Review the staged changes and output a structured review covering correctness, style, and test coverage.
+
+## Output format
+
+Produce a review with the following sections:
+
+### Summary
+One paragraph describing what the change does.
+
+### Correctness
+List any bugs, edge cases, or logic errors found.
+If none: "No correctness issues found."
+
+### Style & conventions
+List any violations of the project's code style rules (naming, early returns, no magic numbers, etc.).
+If none: "No style issues found."
+
+### Test coverage
+List any code paths that are not covered by tests.
+If none: "Test coverage looks adequate."
+
+### Suggestions
+Optional list of improvements that are not blockers but would improve the code.
+
+## Steps
+
+1. Run `git diff --staged` to see the staged changes.
+2. Read each changed file in full to understand context.
+3. Produce the structured review above.
+4. Do not make any code changes — review only.

--- a/src/ravn/skills/fix-tests.md
+++ b/src/ravn/skills/fix-tests.md
@@ -1,0 +1,17 @@
+# skill: fix-tests
+
+Run the test suite, identify all failing tests, and fix them one by one.
+After each fix, re-run only the affected test to confirm it passes.
+Commit each fix separately with a descriptive message.
+Do not fix more than 5 tests in a single session.
+
+## Steps
+
+1. Run the full test suite and capture all failures.
+2. For each failing test (up to 5):
+   a. Read the test and the code under test.
+   b. Identify the root cause of the failure.
+   c. Apply the minimal fix needed to make the test pass.
+   d. Re-run only that test to confirm it passes.
+   e. Commit the fix with a message like `fix(<scope>): <what was broken>`.
+3. After all fixes are committed, run the full test suite once more to confirm no regressions.

--- a/src/ravn/skills/refactor.md
+++ b/src/ravn/skills/refactor.md
@@ -1,0 +1,25 @@
+# skill: refactor
+
+Identify code smells in the target module and refactor with all tests passing.
+
+## Code smells to look for
+
+- Functions longer than 50 lines
+- Deeply nested conditionals (more than 2 levels)
+- Magic numbers or hardcoded strings
+- Duplicated logic that could be extracted into a helper
+- Missing type annotations on public functions
+- Violations of the single-responsibility principle
+
+## Steps
+
+1. Identify the target module (from the task description or current context).
+2. Read the module in full.
+3. List all code smells found with their line numbers.
+4. For each smell:
+   a. Apply the minimal refactor needed to fix it.
+   b. Run the test suite to confirm nothing is broken.
+   c. If tests break, revert and note the smell as "needs manual attention".
+5. After all refactors, run the full test suite once more.
+6. Commit with `refactor(<scope>): <what was improved>`.
+7. Do not change observable behaviour — refactor only.

--- a/src/ravn/skills/write-docs.md
+++ b/src/ravn/skills/write-docs.md
@@ -1,0 +1,17 @@
+# skill: write-docs
+
+Generate docstrings for all undocumented public functions and classes in the target module.
+
+## Steps
+
+1. Identify the target module or file (from the task description or current context).
+2. List all public functions and classes that lack docstrings.
+3. For each undocumented symbol:
+   a. Read the function or class body carefully.
+   b. Write a concise, accurate docstring that describes:
+      - What the function/class does.
+      - Its parameters and return value (for functions).
+      - Any exceptions it may raise.
+   c. Apply the docstring using a file edit.
+4. Run the linter to confirm no formatting issues were introduced.
+5. Do not modify any logic — documentation only.

--- a/tests/ravn/unit/test_file_skill_registry.py
+++ b/tests/ravn/unit/test_file_skill_registry.py
@@ -1,0 +1,498 @@
+"""Unit tests for FileSkillRegistry — file-based skill discovery."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+
+from ravn.adapters.file_skill_registry import (
+    _BUILTIN_SKILLS_DIR,
+    FileSkillRegistry,
+    _discover_from_dir,
+    _filter_by_query,
+    _parse_skill_file,
+)
+from ravn.domain.models import Episode, Outcome, Skill
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_skill(tmp_path: Path, filename: str, content: str) -> Path:
+    p = tmp_path / filename
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def _make_episode(tools: list[str] | None = None) -> Episode:
+    return Episode(
+        episode_id="ep-1",
+        session_id="sess-1",
+        timestamp=datetime.now(UTC),
+        summary="some work",
+        task_description="task",
+        tools_used=tools or [],
+        outcome=Outcome.SUCCESS,
+        tags=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# _parse_skill_file
+# ---------------------------------------------------------------------------
+
+
+class TestParseSkillFile:
+    def test_name_from_header(self, tmp_path: Path) -> None:
+        p = _write_skill(tmp_path, "my-skill.md", "# skill: my-custom-skill\n\nDoes something.\n")
+        skill = _parse_skill_file(p)
+        assert skill is not None
+        assert skill.name == "my-custom-skill"
+
+    def test_name_from_filename_when_no_header(self, tmp_path: Path) -> None:
+        p = _write_skill(tmp_path, "deploy-app.md", "Deploy the application to production.\n")
+        skill = _parse_skill_file(p)
+        assert skill is not None
+        assert skill.name == "deploy-app"
+
+    def test_description_from_first_content_line(self, tmp_path: Path) -> None:
+        p = _write_skill(
+            tmp_path,
+            "skill.md",
+            "# skill: run-tests\n\nRun all tests and fix failures.\n",
+        )
+        skill = _parse_skill_file(p)
+        assert skill is not None
+        assert skill.description == "Run all tests and fix failures."
+
+    def test_description_skips_blank_lines(self, tmp_path: Path) -> None:
+        p = _write_skill(
+            tmp_path,
+            "skill.md",
+            "# skill: run-tests\n\n\nRun all tests.\n",
+        )
+        skill = _parse_skill_file(p)
+        assert skill is not None
+        assert skill.description == "Run all tests."
+
+    def test_description_skips_comment_lines(self, tmp_path: Path) -> None:
+        p = _write_skill(
+            tmp_path,
+            "skill.md",
+            "# skill: run-tests\n\n## Section header\n\nActual description.\n",
+        )
+        skill = _parse_skill_file(p)
+        assert skill is not None
+        assert skill.description == "Actual description."
+
+    def test_content_is_full_file_text(self, tmp_path: Path) -> None:
+        text = "# skill: foo\n\nDescription line.\n\nMore content here.\n"
+        p = _write_skill(tmp_path, "foo.md", text)
+        skill = _parse_skill_file(p)
+        assert skill is not None
+        assert skill.content == text
+
+    def test_returns_none_for_empty_file(self, tmp_path: Path) -> None:
+        p = _write_skill(tmp_path, "empty.md", "")
+        assert _parse_skill_file(p) is None
+
+    def test_returns_none_for_whitespace_only(self, tmp_path: Path) -> None:
+        p = _write_skill(tmp_path, "ws.md", "   \n\n  \n")
+        assert _parse_skill_file(p) is None
+
+    def test_returns_none_for_missing_file(self, tmp_path: Path) -> None:
+        missing = tmp_path / "does-not-exist.md"
+        assert _parse_skill_file(missing) is None
+
+    def test_skill_id_is_valid_uuid(self, tmp_path: Path) -> None:
+        p = _write_skill(tmp_path, "skill.md", "# skill: foo\n\nDoes something.\n")
+        skill = _parse_skill_file(p)
+        assert skill is not None
+        UUID(skill.skill_id)  # raises ValueError if invalid
+
+    def test_created_at_is_aware_utc(self, tmp_path: Path) -> None:
+        p = _write_skill(tmp_path, "skill.md", "# skill: foo\n\nDoes something.\n")
+        skill = _parse_skill_file(p)
+        assert skill is not None
+        assert skill.created_at.tzinfo is not None
+
+    def test_requires_tools_empty_by_default(self, tmp_path: Path) -> None:
+        p = _write_skill(tmp_path, "skill.md", "# skill: foo\n\nDesc.\n")
+        skill = _parse_skill_file(p)
+        assert skill is not None
+        assert skill.requires_tools == []
+
+    def test_fallback_description_when_no_content_lines(self, tmp_path: Path) -> None:
+        p = _write_skill(tmp_path, "my-thing.md", "# skill: my-thing\n\n## Header only\n")
+        skill = _parse_skill_file(p)
+        assert skill is not None
+        assert "my-thing" in skill.description
+
+    def test_header_case_insensitive(self, tmp_path: Path) -> None:
+        p = _write_skill(tmp_path, "skill.md", "# SKILL: upper-name\n\nDesc.\n")
+        skill = _parse_skill_file(p)
+        assert skill is not None
+        assert skill.name == "upper-name"
+
+
+# ---------------------------------------------------------------------------
+# _discover_from_dir
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverFromDir:
+    def test_returns_empty_for_missing_dir(self, tmp_path: Path) -> None:
+        result = _discover_from_dir(tmp_path / "nonexistent")
+        assert result == {}
+
+    def test_returns_empty_for_empty_dir(self, tmp_path: Path) -> None:
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        result = _discover_from_dir(skills_dir)
+        assert result == {}
+
+    def test_discovers_single_skill(self, tmp_path: Path) -> None:
+        d = tmp_path / "skills"
+        d.mkdir()
+        _write_skill(d, "fix-tests.md", "# skill: fix-tests\n\nFix failing tests.\n")
+        result = _discover_from_dir(d)
+        assert "fix-tests" in result
+        assert result["fix-tests"].name == "fix-tests"
+
+    def test_discovers_multiple_skills(self, tmp_path: Path) -> None:
+        d = tmp_path / "skills"
+        d.mkdir()
+        _write_skill(d, "fix-tests.md", "# skill: fix-tests\n\nFix tests.\n")
+        _write_skill(d, "write-docs.md", "# skill: write-docs\n\nWrite docs.\n")
+        result = _discover_from_dir(d)
+        assert "fix-tests" in result
+        assert "write-docs" in result
+
+    def test_ignores_non_md_files(self, tmp_path: Path) -> None:
+        d = tmp_path / "skills"
+        d.mkdir()
+        (d / "not-a-skill.txt").write_text("hello", encoding="utf-8")
+        _write_skill(d, "real-skill.md", "# skill: real-skill\n\nA skill.\n")
+        result = _discover_from_dir(d)
+        assert len(result) == 1
+        assert "real-skill" in result
+
+    def test_key_is_lowercase_name(self, tmp_path: Path) -> None:
+        d = tmp_path / "skills"
+        d.mkdir()
+        _write_skill(d, "My-Skill.md", "# skill: My-Skill\n\nA skill.\n")
+        result = _discover_from_dir(d)
+        assert "my-skill" in result
+
+
+# ---------------------------------------------------------------------------
+# _filter_by_query
+# ---------------------------------------------------------------------------
+
+
+class TestFilterByQuery:
+    def _make_skill(self, name: str, description: str, content: str = "") -> Skill:
+        return Skill(
+            skill_id="id-1",
+            name=name,
+            description=description,
+            content=content or f"# skill: {name}\n\n{description}\n",
+            requires_tools=[],
+            fallback_for_tools=[],
+            source_episodes=[],
+            created_at=datetime.now(UTC),
+        )
+
+    def test_matches_name(self) -> None:
+        skills = [self._make_skill("fix-tests", "Fix failing tests")]
+        result = _filter_by_query(skills, "fix")
+        assert len(result) == 1
+
+    def test_matches_description(self) -> None:
+        skills = [self._make_skill("skill-a", "Run the deployment pipeline")]
+        result = _filter_by_query(skills, "deployment")
+        assert len(result) == 1
+
+    def test_matches_content(self) -> None:
+        skills = [
+            self._make_skill(
+                "skill-a", "Something", content="# skill: skill-a\n\nkubernetes stuff\n"
+            )
+        ]
+        result = _filter_by_query(skills, "kubernetes")
+        assert len(result) == 1
+
+    def test_case_insensitive(self) -> None:
+        skills = [self._make_skill("Fix-Tests", "Fix failing tests")]
+        result = _filter_by_query(skills, "FIX")
+        assert len(result) == 1
+
+    def test_no_match_returns_empty(self) -> None:
+        skills = [self._make_skill("fix-tests", "Fix failing tests")]
+        result = _filter_by_query(skills, "deploy")
+        assert result == []
+
+    def test_multiple_skills_partial_match(self) -> None:
+        skills = [
+            self._make_skill("fix-tests", "Fix failing tests"),
+            self._make_skill("write-docs", "Write documentation"),
+        ]
+        result = _filter_by_query(skills, "fix")
+        assert len(result) == 1
+        assert result[0].name == "fix-tests"
+
+
+# ---------------------------------------------------------------------------
+# FileSkillRegistry — record_episode (no-op)
+# ---------------------------------------------------------------------------
+
+
+class TestFileSkillRegistryRecordEpisode:
+    @pytest.mark.asyncio
+    async def test_record_episode_returns_none(self, tmp_path: Path) -> None:
+        registry = FileSkillRegistry(skill_dirs=[], include_builtin=False)
+        result = await registry.record_episode(_make_episode())
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# FileSkillRegistry — list_skills
+# ---------------------------------------------------------------------------
+
+
+class TestFileSkillRegistryListSkills:
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_no_dirs(self) -> None:
+        registry = FileSkillRegistry(skill_dirs=[], include_builtin=False)
+        skills = await registry.list_skills()
+        assert skills == []
+
+    @pytest.mark.asyncio
+    async def test_discovers_skills_from_custom_dir(self, tmp_path: Path) -> None:
+        d = tmp_path / "skills"
+        d.mkdir()
+        _write_skill(d, "fix-tests.md", "# skill: fix-tests\n\nFix failing tests.\n")
+        registry = FileSkillRegistry(skill_dirs=[str(d)], include_builtin=False)
+        skills = await registry.list_skills()
+        assert len(skills) == 1
+        assert skills[0].name == "fix-tests"
+
+    @pytest.mark.asyncio
+    async def test_skills_sorted_alphabetically(self, tmp_path: Path) -> None:
+        d = tmp_path / "skills"
+        d.mkdir()
+        _write_skill(d, "zz-last.md", "# skill: zz-last\n\nLast.\n")
+        _write_skill(d, "aa-first.md", "# skill: aa-first\n\nFirst.\n")
+        registry = FileSkillRegistry(skill_dirs=[str(d)], include_builtin=False)
+        skills = await registry.list_skills()
+        assert skills[0].name == "aa-first"
+        assert skills[1].name == "zz-last"
+
+    @pytest.mark.asyncio
+    async def test_higher_priority_dir_wins_on_conflict(self, tmp_path: Path) -> None:
+        high = tmp_path / "high"
+        high.mkdir()
+        low = tmp_path / "low"
+        low.mkdir()
+        _write_skill(high, "skill.md", "# skill: my-skill\n\nHigh priority version.\n")
+        _write_skill(low, "skill.md", "# skill: my-skill\n\nLow priority version.\n")
+        registry = FileSkillRegistry(skill_dirs=[str(high), str(low)], include_builtin=False)
+        skills = await registry.list_skills()
+        assert len(skills) == 1
+        assert "High priority version" in skills[0].description
+
+    @pytest.mark.asyncio
+    async def test_missing_dir_silently_skipped(self, tmp_path: Path) -> None:
+        missing = tmp_path / "nonexistent"
+        registry = FileSkillRegistry(skill_dirs=[str(missing)], include_builtin=False)
+        skills = await registry.list_skills()
+        assert skills == []
+
+    @pytest.mark.asyncio
+    async def test_filter_by_query(self, tmp_path: Path) -> None:
+        d = tmp_path / "skills"
+        d.mkdir()
+        _write_skill(d, "fix-tests.md", "# skill: fix-tests\n\nFix failing tests.\n")
+        _write_skill(d, "write-docs.md", "# skill: write-docs\n\nWrite docs.\n")
+        registry = FileSkillRegistry(skill_dirs=[str(d)], include_builtin=False)
+        skills = await registry.list_skills(query="fix")
+        assert len(skills) == 1
+        assert skills[0].name == "fix-tests"
+
+    @pytest.mark.asyncio
+    async def test_includes_builtin_skills(self) -> None:
+        registry = FileSkillRegistry(skill_dirs=[], include_builtin=True)
+        skills = await registry.list_skills()
+        names = [s.name for s in skills]
+        assert any("fix-tests" in n or "fix" in n for n in names)
+
+    @pytest.mark.asyncio
+    async def test_excludes_builtin_when_disabled(self) -> None:
+        registry = FileSkillRegistry(skill_dirs=[], include_builtin=False)
+        skills = await registry.list_skills()
+        assert skills == []
+
+    @pytest.mark.asyncio
+    async def test_builtin_dir_exists(self) -> None:
+        assert _BUILTIN_SKILLS_DIR.is_dir(), f"Built-in skills dir missing: {_BUILTIN_SKILLS_DIR}"
+
+    @pytest.mark.asyncio
+    async def test_builtin_skills_have_required_names(self) -> None:
+        registry = FileSkillRegistry(skill_dirs=[], include_builtin=True)
+        skills = await registry.list_skills()
+        names = {s.name for s in skills}
+        for expected in ("fix-tests", "write-docs", "code-review", "refactor"):
+            assert expected in names, f"Built-in skill {expected!r} not found"
+
+
+# ---------------------------------------------------------------------------
+# FileSkillRegistry — get_skill
+# ---------------------------------------------------------------------------
+
+
+class TestFileSkillRegistryGetSkill:
+    @pytest.mark.asyncio
+    async def test_returns_skill_by_name(self, tmp_path: Path) -> None:
+        d = tmp_path / "skills"
+        d.mkdir()
+        _write_skill(d, "fix-tests.md", "# skill: fix-tests\n\nFix failing tests.\n")
+        registry = FileSkillRegistry(skill_dirs=[str(d)], include_builtin=False)
+        skill = await registry.get_skill("fix-tests")
+        assert skill is not None
+        assert skill.name == "fix-tests"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_unknown_name(self, tmp_path: Path) -> None:
+        registry = FileSkillRegistry(skill_dirs=[], include_builtin=False)
+        result = await registry.get_skill("does-not-exist")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_case_insensitive_lookup(self, tmp_path: Path) -> None:
+        d = tmp_path / "skills"
+        d.mkdir()
+        _write_skill(d, "Fix-Tests.md", "# skill: Fix-Tests\n\nFix tests.\n")
+        registry = FileSkillRegistry(skill_dirs=[str(d)], include_builtin=False)
+        skill = await registry.get_skill("fix-tests")
+        assert skill is not None
+
+    @pytest.mark.asyncio
+    async def test_high_priority_dir_returned_first(self, tmp_path: Path) -> None:
+        high = tmp_path / "high"
+        high.mkdir()
+        low = tmp_path / "low"
+        low.mkdir()
+        _write_skill(high, "skill.md", "# skill: my-skill\n\nHigh priority.\n")
+        _write_skill(low, "skill.md", "# skill: my-skill\n\nLow priority.\n")
+        registry = FileSkillRegistry(skill_dirs=[str(high), str(low)], include_builtin=False)
+        skill = await registry.get_skill("my-skill")
+        assert skill is not None
+        assert "High priority" in skill.description
+
+
+# ---------------------------------------------------------------------------
+# FileSkillRegistry — record_skill
+# ---------------------------------------------------------------------------
+
+
+class TestFileSkillRegistryRecordSkill:
+    @pytest.mark.asyncio
+    async def test_record_skill_writes_file(self, tmp_path: Path) -> None:
+        dest_dir = tmp_path / ".ravn" / "skills"
+        registry = FileSkillRegistry.__new__(FileSkillRegistry)
+        registry._include_builtin = False
+        registry._cwd = tmp_path
+        registry._skill_dirs = None
+
+        skill = Skill(
+            skill_id="id-1",
+            name="my-skill",
+            description="Does something.",
+            content="# skill: my-skill\n\nDoes something.\n",
+            requires_tools=[],
+            fallback_for_tools=[],
+            source_episodes=[],
+            created_at=datetime.now(UTC),
+        )
+
+        registry._write_skill_file(dest_dir, skill)
+        written = dest_dir / "my-skill.md"
+        assert written.exists()
+        assert "my-skill" in written.read_text(encoding="utf-8")
+
+    @pytest.mark.asyncio
+    async def test_record_skill_skips_empty_content(self, tmp_path: Path) -> None:
+        registry = FileSkillRegistry(skill_dirs=[], include_builtin=False)
+        skill = Skill(
+            skill_id="id-1",
+            name="empty",
+            description="",
+            content="   ",
+            requires_tools=[],
+            fallback_for_tools=[],
+            source_episodes=[],
+            created_at=datetime.now(UTC),
+        )
+        # Should not raise even though content is empty.
+        await registry.record_skill(skill)
+
+    @pytest.mark.asyncio
+    async def test_write_sanitises_skill_name(self, tmp_path: Path) -> None:
+        dest_dir = tmp_path / "skills"
+        registry = FileSkillRegistry(skill_dirs=[], include_builtin=False)
+
+        skill = Skill(
+            skill_id="id-1",
+            name="My Skill: v1.0",
+            description="Desc.",
+            content="# skill: My Skill\n\nDesc.\n",
+            requires_tools=[],
+            fallback_for_tools=[],
+            source_episodes=[],
+            created_at=datetime.now(UTC),
+        )
+        registry._write_skill_file(dest_dir, skill)
+        files = list(dest_dir.glob("*.md"))
+        assert len(files) == 1
+        # Name should be sanitised (no spaces or colons)
+        assert " " not in files[0].name
+        assert ":" not in files[0].name
+
+
+# ---------------------------------------------------------------------------
+# FileSkillRegistry — default three-layer discovery
+# ---------------------------------------------------------------------------
+
+
+class TestFileSkillRegistryDefaultDiscovery:
+    @pytest.mark.asyncio
+    async def test_default_dirs_include_cwd_ravn_skills(self, tmp_path: Path) -> None:
+        """Project-local .ravn/skills/ must be in default search paths."""
+        local_skills = tmp_path / ".ravn" / "skills"
+        local_skills.mkdir(parents=True)
+        _write_skill(local_skills, "local-skill.md", "# skill: local-skill\n\nLocal.\n")
+
+        registry = FileSkillRegistry(include_builtin=False, cwd=tmp_path)
+        skills = await registry.list_skills()
+        names = {s.name for s in skills}
+        assert "local-skill" in names
+
+    @pytest.mark.asyncio
+    async def test_project_local_overrides_builtin(self, tmp_path: Path) -> None:
+        """Project-local skill with same name as built-in must take priority."""
+        local_skills = tmp_path / ".ravn" / "skills"
+        local_skills.mkdir(parents=True)
+        _write_skill(
+            local_skills,
+            "fix-tests.md",
+            "# skill: fix-tests\n\nProject-local override.\n",
+        )
+
+        registry = FileSkillRegistry(include_builtin=True, cwd=tmp_path)
+        skill = await registry.get_skill("fix-tests")
+        assert skill is not None
+        assert "Project-local override" in skill.description

--- a/tests/ravn/unit/test_skill_tools.py
+++ b/tests/ravn/unit/test_skill_tools.py
@@ -1,0 +1,400 @@
+"""Unit tests for SkillListTool and SkillRunTool."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ravn.adapters.tools.skill_tools import (
+    _SKILL_PERMISSION,
+    SkillListTool,
+    SkillRunTool,
+)
+from ravn.domain.models import Skill
+from ravn.ports.skill import SkillPort
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_skill(
+    name: str = "fix-tests",
+    description: str = "Fix failing tests.",
+    content: str = "",
+) -> Skill:
+    return Skill(
+        skill_id="id-1",
+        name=name,
+        description=description,
+        content=content or f"# skill: {name}\n\n{description}\n",
+        requires_tools=[],
+        fallback_for_tools=[],
+        source_episodes=[],
+        created_at=datetime.now(UTC),
+    )
+
+
+class StubSkillPort(SkillPort):
+    """Configurable in-memory stub for SkillPort."""
+
+    def __init__(
+        self,
+        skills: list[Skill] | None = None,
+        raise_on_list: Exception | None = None,
+        raise_on_get: Exception | None = None,
+    ) -> None:
+        self._skills = skills or []
+        self._raise_on_list = raise_on_list
+        self._raise_on_get = raise_on_get
+
+    async def record_episode(self, episode) -> Skill | None:
+        return None
+
+    async def list_skills(self, query: str | None = None) -> list[Skill]:
+        if self._raise_on_list is not None:
+            raise self._raise_on_list
+        if query:
+            q = query.lower()
+            return [s for s in self._skills if q in s.name.lower() or q in s.description.lower()]
+        return list(self._skills)
+
+    async def record_skill(self, skill: Skill) -> None:
+        self._skills.append(skill)
+
+    async def get_skill(self, name: str) -> Skill | None:
+        if self._raise_on_get is not None:
+            raise self._raise_on_get
+        name_lower = name.lower()
+        for s in self._skills:
+            if s.name.lower() == name_lower:
+                return s
+        return None
+
+
+# ---------------------------------------------------------------------------
+# SkillListTool — metadata
+# ---------------------------------------------------------------------------
+
+
+class TestSkillListToolMetadata:
+    def test_name(self) -> None:
+        tool = SkillListTool(StubSkillPort())
+        assert tool.name == "skill_list"
+
+    def test_description_not_empty(self) -> None:
+        tool = SkillListTool(StubSkillPort())
+        assert len(tool.description) > 20
+
+    def test_required_permission(self) -> None:
+        tool = SkillListTool(StubSkillPort())
+        assert tool.required_permission == _SKILL_PERMISSION
+
+    def test_permission_has_no_blocked_keywords(self) -> None:
+        blocked = ("write", "delete", "execute", "bash", "shell")
+        for kw in blocked:
+            assert kw not in _SKILL_PERMISSION
+
+    def test_input_schema_type(self) -> None:
+        tool = SkillListTool(StubSkillPort())
+        assert tool.input_schema["type"] == "object"
+
+    def test_input_schema_has_optional_query(self) -> None:
+        tool = SkillListTool(StubSkillPort())
+        assert "query" in tool.input_schema["properties"]
+
+    def test_query_not_required(self) -> None:
+        tool = SkillListTool(StubSkillPort())
+        assert "required" not in tool.input_schema or "query" not in tool.input_schema.get(
+            "required", []
+        )
+
+    def test_parallelisable_default(self) -> None:
+        tool = SkillListTool(StubSkillPort())
+        assert tool.parallelisable is True
+
+    def test_to_api_dict_has_required_keys(self) -> None:
+        tool = SkillListTool(StubSkillPort())
+        d = tool.to_api_dict()
+        assert {"name", "description", "input_schema"} <= d.keys()
+
+
+# ---------------------------------------------------------------------------
+# SkillListTool — execute
+# ---------------------------------------------------------------------------
+
+
+class TestSkillListToolExecute:
+    @pytest.mark.asyncio
+    async def test_empty_skills_returns_no_skills_message(self) -> None:
+        tool = SkillListTool(StubSkillPort(skills=[]))
+        result = await tool.execute({})
+        assert not result.is_error
+        assert "No skills" in result.content
+
+    @pytest.mark.asyncio
+    async def test_empty_skills_with_no_query_suggests_creating_skills(self) -> None:
+        tool = SkillListTool(StubSkillPort(skills=[]))
+        result = await tool.execute({})
+        assert ".ravn/skills/" in result.content
+
+    @pytest.mark.asyncio
+    async def test_lists_skills_with_names(self) -> None:
+        skills = [
+            _make_skill("fix-tests", "Fix failing tests."),
+            _make_skill("write-docs", "Write documentation."),
+        ]
+        tool = SkillListTool(StubSkillPort(skills=skills))
+        result = await tool.execute({})
+        assert not result.is_error
+        assert "fix-tests" in result.content
+        assert "write-docs" in result.content
+
+    @pytest.mark.asyncio
+    async def test_lists_skills_with_descriptions(self) -> None:
+        skills = [_make_skill("fix-tests", "Run and fix all tests.")]
+        tool = SkillListTool(StubSkillPort(skills=skills))
+        result = await tool.execute({})
+        assert "Run and fix all tests." in result.content
+
+    @pytest.mark.asyncio
+    async def test_shows_skill_count(self) -> None:
+        skills = [_make_skill("s1", "d1"), _make_skill("s2", "d2"), _make_skill("s3", "d3")]
+        tool = SkillListTool(StubSkillPort(skills=skills))
+        result = await tool.execute({})
+        assert "3" in result.content
+
+    @pytest.mark.asyncio
+    async def test_filter_by_query_no_match(self) -> None:
+        skills = [_make_skill("fix-tests", "Fix tests.")]
+        tool = SkillListTool(StubSkillPort(skills=skills))
+        result = await tool.execute({"query": "deploy"})
+        assert not result.is_error
+        assert "No skills found" in result.content
+        assert "deploy" in result.content
+
+    @pytest.mark.asyncio
+    async def test_filter_by_query_with_match(self) -> None:
+        skills = [
+            _make_skill("fix-tests", "Fix tests."),
+            _make_skill("write-docs", "Write docs."),
+        ]
+        tool = SkillListTool(StubSkillPort(skills=skills))
+        result = await tool.execute({"query": "fix"})
+        assert not result.is_error
+        assert "fix-tests" in result.content
+        assert "write-docs" not in result.content
+
+    @pytest.mark.asyncio
+    async def test_empty_query_string_treated_as_no_filter(self) -> None:
+        skills = [_make_skill("fix-tests", "Fix tests.")]
+        tool = SkillListTool(StubSkillPort(skills=skills))
+        result = await tool.execute({"query": ""})
+        assert "fix-tests" in result.content
+
+    @pytest.mark.asyncio
+    async def test_list_skills_error_returns_error_result(self) -> None:
+        tool = SkillListTool(StubSkillPort(raise_on_list=RuntimeError("disk error")))
+        result = await tool.execute({})
+        assert result.is_error
+        assert "Failed to list skills" in result.content
+
+    @pytest.mark.asyncio
+    async def test_passes_query_to_skill_port(self) -> None:
+        port = AsyncMock(spec=SkillPort)
+        port.list_skills = AsyncMock(return_value=[])
+        tool = SkillListTool(port)
+        await tool.execute({"query": "fix"})
+        port.list_skills.assert_called_once_with(query="fix")
+
+    @pytest.mark.asyncio
+    async def test_passes_none_query_when_no_query_given(self) -> None:
+        port = AsyncMock(spec=SkillPort)
+        port.list_skills = AsyncMock(return_value=[])
+        tool = SkillListTool(port)
+        await tool.execute({})
+        port.list_skills.assert_called_once_with(query=None)
+
+
+# ---------------------------------------------------------------------------
+# SkillRunTool — metadata
+# ---------------------------------------------------------------------------
+
+
+class TestSkillRunToolMetadata:
+    def test_name(self) -> None:
+        tool = SkillRunTool(StubSkillPort())
+        assert tool.name == "skill_run"
+
+    def test_description_not_empty(self) -> None:
+        tool = SkillRunTool(StubSkillPort())
+        assert len(tool.description) > 20
+
+    def test_required_permission(self) -> None:
+        tool = SkillRunTool(StubSkillPort())
+        assert tool.required_permission == _SKILL_PERMISSION
+
+    def test_not_parallelisable(self) -> None:
+        tool = SkillRunTool(StubSkillPort())
+        assert tool.parallelisable is False
+
+    def test_schema_has_skill_name_required(self) -> None:
+        tool = SkillRunTool(StubSkillPort())
+        assert "skill_name" in tool.input_schema["properties"]
+        assert "skill_name" in tool.input_schema["required"]
+
+    def test_schema_has_optional_args(self) -> None:
+        tool = SkillRunTool(StubSkillPort())
+        assert "args" in tool.input_schema["properties"]
+
+    def test_args_not_required(self) -> None:
+        tool = SkillRunTool(StubSkillPort())
+        required = tool.input_schema.get("required", [])
+        assert "args" not in required
+
+    def test_to_api_dict(self) -> None:
+        tool = SkillRunTool(StubSkillPort())
+        d = tool.to_api_dict()
+        assert d["name"] == "skill_run"
+
+
+# ---------------------------------------------------------------------------
+# SkillRunTool — execute
+# ---------------------------------------------------------------------------
+
+
+class TestSkillRunToolExecute:
+    @pytest.mark.asyncio
+    async def test_empty_skill_name_returns_error(self) -> None:
+        tool = SkillRunTool(StubSkillPort())
+        result = await tool.execute({"skill_name": ""})
+        assert result.is_error
+        assert "empty" in result.content.lower()
+
+    @pytest.mark.asyncio
+    async def test_missing_skill_name_returns_error(self) -> None:
+        tool = SkillRunTool(StubSkillPort())
+        result = await tool.execute({})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_skill_name_returns_error(self) -> None:
+        tool = SkillRunTool(StubSkillPort())
+        result = await tool.execute({"skill_name": "   "})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_unknown_skill_returns_error(self) -> None:
+        tool = SkillRunTool(StubSkillPort(skills=[]))
+        result = await tool.execute({"skill_name": "unknown-skill"})
+        assert result.is_error
+        assert "not found" in result.content.lower() or "unknown-skill" in result.content
+
+    @pytest.mark.asyncio
+    async def test_skill_not_found_suggests_skill_list(self) -> None:
+        tool = SkillRunTool(StubSkillPort(skills=[]))
+        result = await tool.execute({"skill_name": "missing"})
+        assert "skill_list" in result.content
+
+    @pytest.mark.asyncio
+    async def test_returns_skill_content(self) -> None:
+        content = "# skill: fix-tests\n\nRun the test suite and fix failures.\n"
+        skills = [_make_skill("fix-tests", "Fix tests.", content)]
+        tool = SkillRunTool(StubSkillPort(skills=skills))
+        result = await tool.execute({"skill_name": "fix-tests"})
+        assert not result.is_error
+        assert "Run the test suite and fix failures." in result.content
+
+    @pytest.mark.asyncio
+    async def test_result_includes_skill_name_header(self) -> None:
+        skills = [_make_skill("fix-tests", "Fix tests.")]
+        tool = SkillRunTool(StubSkillPort(skills=skills))
+        result = await tool.execute({"skill_name": "fix-tests"})
+        assert "fix-tests" in result.content
+
+    @pytest.mark.asyncio
+    async def test_appends_args_when_provided(self) -> None:
+        content = "# skill: fix-tests\n\nRun tests.\n"
+        skills = [_make_skill("fix-tests", "Fix tests.", content)]
+        tool = SkillRunTool(StubSkillPort(skills=skills))
+        result = await tool.execute({"skill_name": "fix-tests", "args": "target: test_auth.py"})
+        assert not result.is_error
+        assert "target: test_auth.py" in result.content
+
+    @pytest.mark.asyncio
+    async def test_no_args_does_not_add_separator(self) -> None:
+        content = "# skill: fix-tests\n\nRun tests.\n"
+        skills = [_make_skill("fix-tests", "Fix tests.", content)]
+        tool = SkillRunTool(StubSkillPort(skills=skills))
+        result = await tool.execute({"skill_name": "fix-tests"})
+        assert "---" not in result.content
+
+    @pytest.mark.asyncio
+    async def test_empty_args_treated_as_no_args(self) -> None:
+        content = "# skill: fix-tests\n\nRun tests.\n"
+        skills = [_make_skill("fix-tests", "Fix tests.", content)]
+        tool = SkillRunTool(StubSkillPort(skills=skills))
+        result = await tool.execute({"skill_name": "fix-tests", "args": ""})
+        assert "---" not in result.content
+
+    @pytest.mark.asyncio
+    async def test_args_with_separator_when_provided(self) -> None:
+        content = "# skill: fix-tests\n\nRun tests.\n"
+        skills = [_make_skill("fix-tests", "Fix tests.", content)]
+        tool = SkillRunTool(StubSkillPort(skills=skills))
+        result = await tool.execute({"skill_name": "fix-tests", "args": "extra context"})
+        assert "---" in result.content
+        assert "extra context" in result.content
+
+    @pytest.mark.asyncio
+    async def test_get_skill_error_returns_error_result(self) -> None:
+        tool = SkillRunTool(StubSkillPort(raise_on_get=RuntimeError("io error")))
+        result = await tool.execute({"skill_name": "fix-tests"})
+        assert result.is_error
+        assert "Failed to load skill" in result.content
+
+    @pytest.mark.asyncio
+    async def test_calls_get_skill_with_name(self) -> None:
+        port = AsyncMock(spec=SkillPort)
+        port.get_skill = AsyncMock(return_value=None)
+        tool = SkillRunTool(port)
+        await tool.execute({"skill_name": "my-skill"})
+        port.get_skill.assert_called_once_with("my-skill")
+
+    @pytest.mark.asyncio
+    async def test_skill_name_stripped_before_lookup(self) -> None:
+        port = AsyncMock(spec=SkillPort)
+        port.get_skill = AsyncMock(return_value=None)
+        tool = SkillRunTool(port)
+        await tool.execute({"skill_name": "  fix-tests  "})
+        port.get_skill.assert_called_once_with("fix-tests")
+
+
+# ---------------------------------------------------------------------------
+# SkillPort — default get_skill (via port's default implementation)
+# ---------------------------------------------------------------------------
+
+
+class TestSkillPortDefaultGetSkill:
+    @pytest.mark.asyncio
+    async def test_default_get_skill_returns_matching_skill(self) -> None:
+        skill = _make_skill("fix-tests", "Fix tests.")
+        port = StubSkillPort(skills=[skill])
+        result = await port.get_skill("fix-tests")
+        assert result is not None
+        assert result.name == "fix-tests"
+
+    @pytest.mark.asyncio
+    async def test_default_get_skill_case_insensitive(self) -> None:
+        skill = _make_skill("Fix-Tests", "Fix tests.")
+        port = StubSkillPort(skills=[skill])
+        result = await port.get_skill("fix-tests")
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_default_get_skill_returns_none_for_missing(self) -> None:
+        port = StubSkillPort(skills=[])
+        result = await port.get_skill("nonexistent")
+        assert result is None

--- a/tests/ravn/unit/test_skill_tools.py
+++ b/tests/ravn/unit/test_skill_tools.py
@@ -377,11 +377,28 @@ class TestSkillRunToolExecute:
 # ---------------------------------------------------------------------------
 
 
+class _DefaultGetSkillStub(SkillPort):
+    """Minimal stub that does NOT override get_skill(), so the base-class
+    default implementation is exercised directly."""
+
+    def __init__(self, skills: list[Skill]) -> None:
+        self._skills = skills
+
+    async def record_episode(self, episode) -> Skill | None:
+        return None
+
+    async def list_skills(self, query: str | None = None) -> list[Skill]:
+        return list(self._skills)
+
+    async def record_skill(self, skill: Skill) -> None:
+        pass
+
+
 class TestSkillPortDefaultGetSkill:
     @pytest.mark.asyncio
     async def test_default_get_skill_returns_matching_skill(self) -> None:
         skill = _make_skill("fix-tests", "Fix tests.")
-        port = StubSkillPort(skills=[skill])
+        port = _DefaultGetSkillStub(skills=[skill])
         result = await port.get_skill("fix-tests")
         assert result is not None
         assert result.name == "fix-tests"
@@ -389,12 +406,12 @@ class TestSkillPortDefaultGetSkill:
     @pytest.mark.asyncio
     async def test_default_get_skill_case_insensitive(self) -> None:
         skill = _make_skill("Fix-Tests", "Fix tests.")
-        port = StubSkillPort(skills=[skill])
+        port = _DefaultGetSkillStub(skills=[skill])
         result = await port.get_skill("fix-tests")
         assert result is not None
 
     @pytest.mark.asyncio
     async def test_default_get_skill_returns_none_for_missing(self) -> None:
-        port = StubSkillPort(skills=[])
+        port = _DefaultGetSkillStub(skills=[])
         result = await port.get_skill("nonexistent")
         assert result is None


### PR DESCRIPTION
## Summary

- **FileSkillRegistry** adapter: discovers skills from `.ravn/skills/` (project-local), `~/.ravn/skills/` (user-global), and built-in skills shipped with Ravn — in priority order. Higher-priority sources win name conflicts.
- **Four built-in skills**: `fix-tests`, `write-docs`, `code-review`, `refactor` — stored as Markdown files in `src/ravn/skills/`.
- **`skill_list` tool**: lists all available skills with name and first-line description; supports optional query filter.
- **`skill_run` tool**: loads a named skill's instruction content and returns it so the agent follows those instructions; accepts an optional `args` string appended to the skill body.
- **`SkillPort.get_skill(name)`**: new default method on the port that calls `list_skills()` and filters by name (case-insensitive); overridden in `FileSkillRegistry` for priority-ordered lookup.
- **`SkillConfig`** gains `skill_dirs` (extra search paths) and `include_builtin` flag.
- **`/skills` slash command**: added to `SlashCommandContext` using a pre-fetched `skills_listing` list so it stays synchronous.

## Test plan

- [x] 91 new tests covering `FileSkillRegistry` (parse, discover, list, get, record) and `SkillListTool` / `SkillRunTool` (metadata + execute paths)
- [x] Full ravn test suite: 2077 tests, 96% coverage (above 85% threshold)
- [x] `ruff check` + `ruff format --check` pass on all changed files
- [x] Built-in skill discovery verified: all four skills (`fix-tests`, `write-docs`, `code-review`, `refactor`) discovered at runtime
- [x] Priority order verified: project-local overrides user-global, which overrides built-in

Closes NIU-500

🤖 Generated with [Claude Code](https://claude.com/claude-code)