### PR TITLE
feat(adapters): extended thinking integration (NIU-497)

### DIFF
--- a/src/ravn/adapters/anthropic_adapter.py
+++ b/src/ravn/adapters/anthropic_adapter.py
@@ -29,7 +29,8 @@ from ravn.ports.llm import LLMPort, SystemPrompt
 logger = logging.getLogger(__name__)
 
 ANTHROPIC_API_VERSION = "2023-06-01"
-ANTHROPIC_BETA_HEADER = "prompt-caching-2024-07-31"
+_BETA_PROMPT_CACHING = "prompt-caching-2024-07-31"
+_BETA_INTERLEAVED_THINKING = "interleaved-thinking-2025-05-14"
 
 _RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503})
 _DEFAULT_BASE_URL = "https://api.anthropic.com"
@@ -39,7 +40,18 @@ class AnthropicAdapter(LLMPort):
     """Calls the Anthropic Messages API with streaming and tool support.
 
     Constructor kwargs are forwarded from config via the dynamic adapter pattern.
+
+    Extended thinking is activated by passing
+    ``thinking={"type": "enabled", "budget_tokens": N}`` to ``stream()`` or
+    ``generate()``.  When enabled, the ``interleaved-thinking-2025-05-14`` beta
+    header is added automatically.  Thinking blocks are yielded as
+    ``StreamEvent(type=StreamEventType.THINKING, text=…)`` events and their
+    approximate token count is tracked in ``TokenUsage.thinking_tokens``.
     """
+
+    @property
+    def supports_thinking(self) -> bool:
+        return True
 
     def __init__(
         self,
@@ -60,11 +72,14 @@ class AnthropicAdapter(LLMPort):
         self._retry_base_delay = retry_base_delay
         self._timeout = timeout
 
-    def _headers(self) -> dict[str, str]:
+    def _headers(self, *, thinking_enabled: bool = False) -> dict[str, str]:
+        betas = [_BETA_PROMPT_CACHING]
+        if thinking_enabled:
+            betas.append(_BETA_INTERLEAVED_THINKING)
         return {
             "x-api-key": self._api_key,
             "anthropic-version": ANTHROPIC_API_VERSION,
-            "anthropic-beta": ANTHROPIC_BETA_HEADER,
+            "anthropic-beta": ",".join(betas),
             "content-type": "application/json",
         }
 
@@ -97,10 +112,12 @@ class AnthropicAdapter(LLMPort):
         model: str,
         max_tokens: int,
         stream: bool,
+        thinking: dict | None = None,
     ) -> dict:
+        effective_max_tokens = max_tokens or self._default_max_tokens
         body: dict = {
             "model": model or self._default_model,
-            "max_tokens": max_tokens or self._default_max_tokens,
+            "max_tokens": effective_max_tokens,
             "messages": messages,
             "stream": stream,
         }
@@ -109,6 +126,8 @@ class AnthropicAdapter(LLMPort):
             body["system"] = system_blocks
         if tools:
             body["tools"] = tools
+        if thinking is not None:
+            body["thinking"] = thinking
         return body
 
     async def _post_with_retry(
@@ -168,7 +187,9 @@ class AnthropicAdapter(LLMPort):
         system: SystemPrompt,
         model: str,
         max_tokens: int,
+        thinking: dict | None = None,
     ) -> AsyncIterator[StreamEvent]:
+        thinking_enabled = thinking is not None
         payload = self._build_request(
             messages,
             tools=tools,
@@ -176,9 +197,13 @@ class AnthropicAdapter(LLMPort):
             model=model,
             max_tokens=max_tokens,
             stream=True,
+            thinking=thinking,
         )
 
-        async with httpx.AsyncClient(headers=self._headers(), timeout=self._timeout) as client:
+        async with httpx.AsyncClient(
+            headers=self._headers(thinking_enabled=thinking_enabled),
+            timeout=self._timeout,
+        ) as client:
             response = await self._post_with_retry(client, payload, stream=True)
 
             if response.status_code != 200:
@@ -192,7 +217,10 @@ class AnthropicAdapter(LLMPort):
             partial_inputs: dict[int, dict] = {}
             tool_ids: dict[int, str] = {}
             tool_names: dict[int, str] = {}
+            # Accumulate thinking block text keyed by block index.
+            partial_thinking: dict[int, str] = {}
             current_block_index = -1
+            accumulated_thinking_chars = 0
 
             async for line in response.aiter_lines():
                 if not line.startswith("data: "):
@@ -216,6 +244,8 @@ class AnthropicAdapter(LLMPort):
                             tool_ids[current_block_index] = block.get("id", "")
                             tool_names[current_block_index] = block.get("name", "")
                             partial_inputs[current_block_index] = {}
+                        elif block.get("type") == "thinking":
+                            partial_thinking[current_block_index] = ""
 
                     case "content_block_delta":
                         delta = event_data.get("delta", {})
@@ -225,6 +255,16 @@ class AnthropicAdapter(LLMPort):
                                 yield StreamEvent(
                                     type=StreamEventType.TEXT_DELTA,
                                     text=delta.get("text", ""),
+                                )
+                            case "thinking_delta":
+                                chunk = delta.get("thinking", "")
+                                if idx not in partial_thinking:
+                                    partial_thinking[idx] = ""
+                                partial_thinking[idx] += chunk
+                                accumulated_thinking_chars += len(chunk)
+                                yield StreamEvent(
+                                    type=StreamEventType.THINKING,
+                                    text=chunk,
                                 )
                             case "input_json_delta":
                                 # Accumulate partial JSON — emit when block stops.
@@ -252,9 +292,13 @@ class AnthropicAdapter(LLMPort):
                                 ),
                             )
                             del partial_inputs[idx]
+                        if idx in partial_thinking:
+                            del partial_thinking[idx]
 
                     case "message_delta":
                         usage_data = event_data.get("usage", {})
+                        # Approximate thinking tokens from accumulated char count.
+                        thinking_tokens = accumulated_thinking_chars // 4
                         yield StreamEvent(
                             type=StreamEventType.MESSAGE_DONE,
                             usage=TokenUsage(
@@ -262,6 +306,7 @@ class AnthropicAdapter(LLMPort):
                                 output_tokens=usage_data.get("output_tokens", 0),
                                 cache_read_tokens=usage_data.get("cache_read_input_tokens", 0),
                                 cache_write_tokens=usage_data.get("cache_creation_input_tokens", 0),
+                                thinking_tokens=thinking_tokens,
                             ),
                         )
 
@@ -273,7 +318,9 @@ class AnthropicAdapter(LLMPort):
         system: SystemPrompt,
         model: str,
         max_tokens: int,
+        thinking: dict | None = None,
     ) -> LLMResponse:
+        thinking_enabled = thinking is not None
         payload = self._build_request(
             messages,
             tools=tools,
@@ -281,9 +328,13 @@ class AnthropicAdapter(LLMPort):
             model=model,
             max_tokens=max_tokens,
             stream=False,
+            thinking=thinking,
         )
 
-        async with httpx.AsyncClient(headers=self._headers(), timeout=self._timeout) as client:
+        async with httpx.AsyncClient(
+            headers=self._headers(thinking_enabled=thinking_enabled),
+            timeout=self._timeout,
+        ) as client:
             response = await self._post_with_retry(client, payload, stream=False)
 
         if response.status_code != 200:
@@ -295,9 +346,12 @@ class AnthropicAdapter(LLMPort):
         data = response.json()
         content_text = ""
         tool_calls: list[ToolCall] = []
+        thinking_chars = 0
 
         for block in data.get("content", []):
             match block.get("type"):
+                case "thinking":
+                    thinking_chars += len(block.get("thinking", ""))
                 case "text":
                     content_text += block.get("text", "")
                 case "tool_use":
@@ -325,5 +379,6 @@ class AnthropicAdapter(LLMPort):
                 output_tokens=usage_data.get("output_tokens", 0),
                 cache_read_tokens=usage_data.get("cache_read_input_tokens", 0),
                 cache_write_tokens=usage_data.get("cache_creation_input_tokens", 0),
+                thinking_tokens=thinking_chars // 4,
             ),
         )

--- a/src/ravn/adapters/fallback_llm.py
+++ b/src/ravn/adapters/fallback_llm.py
@@ -57,10 +57,13 @@ class FallbackLLMAdapter(LLMPort):
         system: SystemPrompt,
         model: str,
         max_tokens: int,
+        thinking: dict | None = None,
     ) -> LLMResponse:
         last_exc: Exception | None = None
 
         for idx, provider in enumerate(self._providers):
+            # Pass thinking only when the provider supports it; skip silently otherwise.
+            effective_thinking = thinking if provider.supports_thinking else None
             try:
                 return await provider.generate(
                     messages,
@@ -68,6 +71,7 @@ class FallbackLLMAdapter(LLMPort):
                     system=system,
                     model=model,
                     max_tokens=max_tokens,
+                    thinking=effective_thinking,
                 )
             except LLMError as exc:
                 label = "primary" if idx == 0 else f"fallback[{idx}]"
@@ -93,10 +97,13 @@ class FallbackLLMAdapter(LLMPort):
         system: SystemPrompt,
         model: str,
         max_tokens: int,
+        thinking: dict | None = None,
     ) -> AsyncIterator[StreamEvent]:
         last_exc: Exception | None = None
 
         for idx, provider in enumerate(self._providers):
+            # Pass thinking only when the provider supports it; skip silently otherwise.
+            effective_thinking = thinking if provider.supports_thinking else None
             try:
                 async for event in provider.stream(
                     messages,
@@ -104,6 +111,7 @@ class FallbackLLMAdapter(LLMPort):
                     system=system,
                     model=model,
                     max_tokens=max_tokens,
+                    thinking=effective_thinking,
                 ):
                     yield event
                 return

--- a/src/ravn/adapters/openai_llm.py
+++ b/src/ravn/adapters/openai_llm.py
@@ -295,6 +295,7 @@ class OpenAICompatibleAdapter(LLMPort):
         system: SystemPrompt,
         model: str,
         max_tokens: int,
+        thinking: dict | None = None,  # noqa: ARG002 — Anthropic-only, ignored here
     ) -> AsyncIterator[StreamEvent]:
         payload = self._build_request(
             messages,
@@ -413,6 +414,7 @@ class OpenAICompatibleAdapter(LLMPort):
         system: SystemPrompt,
         model: str,
         max_tokens: int,
+        thinking: dict | None = None,  # noqa: ARG002 — Anthropic-only, ignored here
     ) -> LLMResponse:
         payload = self._build_request(
             messages,

--- a/src/ravn/agent.py
+++ b/src/ravn/agent.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import time
 import uuid
 from collections.abc import Callable, Coroutine
@@ -782,45 +783,59 @@ def _compute_cost(
 
 
 _THINK_PREFIXES = ("think:", "think: ")
-_THINK_FLAG = "--think"
 
-_PLANNING_KEYWORDS = frozenset(
-    {
-        "plan",
-        "design",
-        "architect",
-        "architecture",
-        "strategy",
-        "roadmap",
-        "approach",
-        "how should",
-        "what approach",
-        "what's the best",
-        "best way to",
-        "how do i",
-    }
+# Matches --think only as a standalone flag (word boundary on both sides).
+# Captures any surrounding whitespace so collapsing leaves a single space.
+_THINK_FLAG_RE = re.compile(r"(?<!\S)--think(?!\S)")
+
+# Single-word planning keywords matched with \b to avoid substring false-positives
+# (e.g. "unplanned" must not match "plan").
+_PLANNING_WORD_RE = re.compile(
+    r"\b(?:plan|design|architect|architecture|strategy|roadmap|approach)\b",
+    re.IGNORECASE,
+)
+# Multi-word phrases can remain as plain substring checks.
+_PLANNING_PHRASES = (
+    "how should",
+    "what approach",
+    "what's the best",
+    "best way to",
+    "how do i",
 )
 
 
 def _parse_think_flag(user_input: str) -> tuple[bool, str]:
     """Return (explicit_thinking, cleaned_input).
 
-    Strips ``think:`` prefix or ``--think`` flag from user input and returns
-    a bool indicating whether explicit thinking was requested.
+    Strips ``think:`` prefix or ``--think`` standalone flag from user input
+    and returns a bool indicating whether explicit thinking was requested.
+
+    ``--think`` is only recognised as a standalone flag; ``--thinking`` and
+    other ``--think``-prefixed words are left untouched.
     """
     stripped = user_input
     for prefix in _THINK_PREFIXES:
         if stripped.lower().startswith(prefix):
             return True, stripped[len(prefix) :].lstrip()
-    if _THINK_FLAG in stripped:
-        return True, stripped.replace(_THINK_FLAG, "").strip()
+    if _THINK_FLAG_RE.search(stripped):
+        cleaned = _THINK_FLAG_RE.sub(" ", stripped).strip()
+        # Collapse any run of spaces introduced by the substitution.
+        cleaned = re.sub(r" {2,}", " ", cleaned)
+        return True, cleaned
     return False, stripped
 
 
 def _looks_like_planning_task(user_input: str) -> bool:
-    """Return True if the input looks like a planning or ambiguous task."""
+    """Return True if the input looks like a planning or ambiguous task.
+
+    Single-word keywords are matched with word boundaries to prevent
+    substring false-positives (e.g. ``unplanned`` must not match ``plan``).
+    Multi-word phrases are matched as plain substrings.
+    """
+    if _PLANNING_WORD_RE.search(user_input):
+        return True
     lower = user_input.lower()
-    return any(kw in lower for kw in _PLANNING_KEYWORDS)
+    return any(phrase in lower for phrase in _PLANNING_PHRASES)
 
 
 def _build_assistant_content(response: LLMResponse) -> list[dict]:

--- a/src/ravn/agent.py
+++ b/src/ravn/agent.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from ravn.budget import IterationBudget, TokenEstimator
 from ravn.compression import CompressionResult, ContextCompressor
-from ravn.config import OutcomeConfig
+from ravn.config import ExtendedThinkingConfig, OutcomeConfig
 from ravn.domain.events import RavnEvent, RavnEventType
 from ravn.domain.exceptions import MaxIterationsError, PermissionDeniedError
 from ravn.domain.models import (
@@ -86,6 +86,7 @@ class RavnAgent:
         prompt_builder: PromptBuilder | None = None,
         outcome_port: OutcomePort | None = None,
         outcome_config: OutcomeConfig | None = None,
+        extended_thinking: ExtendedThinkingConfig | None = None,
     ) -> None:
         self._llm = llm
         self._tools = {t.name: t for t in tools}
@@ -112,6 +113,7 @@ class RavnAgent:
         self._task_summary_max_chars = _oc.task_summary_max_chars
         self._input_token_cost_per_million = _oc.input_token_cost_per_million
         self._output_token_cost_per_million = _oc.output_token_cost_per_million
+        self._extended_thinking = extended_thinking
         self._session = Session()
         self._last_compression_result: CompressionResult | None = None
 
@@ -207,6 +209,9 @@ class RavnAgent:
             except Exception:
                 logger.warning("Outcome lessons retrieval failed; continuing without lessons.")
 
+        # Determine whether explicit thinking was requested for this turn.
+        explicit_thinking, user_input = _parse_think_flag(user_input)
+
         self._session.add_message(Message(role="user", content=user_input))
 
         turn_tool_calls: list[ToolCall] = []
@@ -215,6 +220,7 @@ class RavnAgent:
         final_response = ""
         self._last_compression_result = None
         iterations_used = 0
+        last_had_tool_error = False
 
         for iteration in range(self._max_iterations):
             iterations_used = iteration + 1
@@ -228,9 +234,17 @@ class RavnAgent:
                 effective_system, memory_summary=memory_ctx
             )
 
+            thinking_param = self._resolve_thinking(
+                user_input=user_input,
+                iteration=iteration,
+                explicit=explicit_thinking,
+                last_had_tool_error=last_had_tool_error,
+            )
+
             llm_response = await self._call_llm_streaming(
                 system_prompt=effective_system,
                 messages=messages_for_llm,
+                thinking=thinking_param,
             )
 
             # Consume one iteration from the budget.
@@ -253,6 +267,7 @@ class RavnAgent:
 
             # Execute all tool calls sequentially and collect results.
             tool_results_content = []
+            last_had_tool_error = False
             for tool_call in llm_response.tool_calls:
                 turn_tool_calls.append(tool_call)
                 result = await self._execute_tool(tool_call)
@@ -260,6 +275,8 @@ class RavnAgent:
                 # Inject budget warning into the tool result content.
                 result = _maybe_append_budget_warning(result, self._iteration_budget)
 
+                if result.is_error:
+                    last_had_tool_error = True
                 turn_tool_results.append(result)
                 tool_results_content.append(
                     {
@@ -475,10 +492,41 @@ class RavnAgent:
             logger.warning("Reflection LLM call failed: %s", exc)
             return f"Reflection unavailable: {exc}"
 
+    def _resolve_thinking(
+        self,
+        *,
+        user_input: str,
+        iteration: int,
+        explicit: bool,
+        last_had_tool_error: bool,
+    ) -> dict | None:
+        """Return the thinking parameter dict for this LLM call, or None.
+
+        Extended thinking is activated when:
+        - Explicitly requested (``think:`` prefix / ``--think`` flag).
+        - Auto-trigger is on AND the input looks like a planning/ambiguous task.
+        - Auto-trigger-on-retry is on AND a tool failed on the previous iteration.
+        """
+        et = self._extended_thinking
+        if et is None or not et.enabled:
+            return None
+
+        if explicit:
+            return {"type": "enabled", "budget_tokens": et.budget_tokens}
+
+        if et.auto_trigger_on_retry and iteration > 0 and last_had_tool_error:
+            return {"type": "enabled", "budget_tokens": et.budget_tokens}
+
+        if et.auto_trigger and _looks_like_planning_task(user_input):
+            return {"type": "enabled", "budget_tokens": et.budget_tokens}
+
+        return None
+
     async def _call_llm_streaming(
         self,
         system_prompt: SystemPrompt | None = None,
         messages: list[Message] | None = None,
+        thinking: dict | None = None,
     ) -> LLMResponse:
         """Call the LLM with streaming and accumulate into an LLMResponse."""
         accumulated_text = ""
@@ -500,12 +548,16 @@ class RavnAgent:
             system=effective,
             model=self._model,
             max_tokens=self._max_tokens,
+            thinking=thinking,
         ):
             match event.type:
                 case StreamEventType.TEXT_DELTA:
                     if event.text:
                         accumulated_text += event.text
                         await self._channel.emit(RavnEvent.thought(event.text))
+                case StreamEventType.THINKING:
+                    if event.text:
+                        await self._channel.emit(RavnEvent.thinking(event.text))
                 case StreamEventType.TOOL_CALL:
                     if event.tool_call:
                         tool_calls.append(event.tool_call)
@@ -727,6 +779,48 @@ def _compute_cost(
         usage.input_tokens * input_per_million / 1_000_000
         + usage.output_tokens * output_per_million / 1_000_000
     )
+
+
+_THINK_PREFIXES = ("think:", "think: ")
+_THINK_FLAG = "--think"
+
+_PLANNING_KEYWORDS = frozenset(
+    {
+        "plan",
+        "design",
+        "architect",
+        "architecture",
+        "strategy",
+        "roadmap",
+        "approach",
+        "how should",
+        "what approach",
+        "what's the best",
+        "best way to",
+        "how do i",
+    }
+)
+
+
+def _parse_think_flag(user_input: str) -> tuple[bool, str]:
+    """Return (explicit_thinking, cleaned_input).
+
+    Strips ``think:`` prefix or ``--think`` flag from user input and returns
+    a bool indicating whether explicit thinking was requested.
+    """
+    stripped = user_input
+    for prefix in _THINK_PREFIXES:
+        if stripped.lower().startswith(prefix):
+            return True, stripped[len(prefix) :].lstrip()
+    if _THINK_FLAG in stripped:
+        return True, stripped.replace(_THINK_FLAG, "").strip()
+    return False, stripped
+
+
+def _looks_like_planning_task(user_input: str) -> bool:
+    """Return True if the input looks like a planning or ambiguous task."""
+    lower = user_input.lower()
+    return any(kw in lower for kw in _PLANNING_KEYWORDS)
 
 
 def _build_assistant_content(response: LLMResponse) -> list[dict]:

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -86,6 +86,32 @@ class LLMProviderConfig(BaseModel):
     )
 
 
+class ExtendedThinkingConfig(BaseModel):
+    """Extended thinking (extended reasoning budget) configuration.
+
+    Extended thinking allocates a deliberate reasoning budget to hard problems
+    before the model produces its response.  Anthropic-only — FallbackAdapter
+    skips this when routing to a non-Anthropic provider.
+    """
+
+    enabled: bool = Field(
+        default=False,
+        description="Allow extended thinking to be activated.",
+    )
+    budget_tokens: int = Field(
+        default=8000,
+        description="Token budget allocated for thinking per activation.",
+    )
+    auto_trigger: bool = Field(
+        default=True,
+        description="Automatically activate thinking on planning/ambiguous inputs.",
+    )
+    auto_trigger_on_retry: bool = Field(
+        default=True,
+        description="Automatically activate thinking after the first tool failure.",
+    )
+
+
 class LLMConfig(BaseModel):
     """LLM provider configuration: primary provider and optional fallback chain."""
 
@@ -98,6 +124,10 @@ class LLMConfig(BaseModel):
     fallbacks: list[LLMProviderConfig] = Field(
         default_factory=list,
         description="Ordered list of fallback providers tried when the primary fails.",
+    )
+    extended_thinking: ExtendedThinkingConfig = Field(
+        default_factory=ExtendedThinkingConfig,
+        description="Extended thinking (deliberate reasoning budget) configuration.",
     )
 
 

--- a/src/ravn/domain/events.py
+++ b/src/ravn/domain/events.py
@@ -27,6 +27,11 @@ class RavnEvent:
         return cls(type=RavnEventType.THOUGHT, data=text)
 
     @classmethod
+    def thinking(cls, text: str) -> RavnEvent:
+        """Emit an extended-thinking block — rendered dimmed/collapsed in CLI."""
+        return cls(type=RavnEventType.THOUGHT, data=text, metadata={"thinking": True})
+
+    @classmethod
     def tool_start(
         cls,
         tool_name: str,

--- a/src/ravn/domain/models.py
+++ b/src/ravn/domain/models.py
@@ -37,6 +37,7 @@ class StreamEventType(StrEnum):
     TEXT_DELTA = "text_delta"
     TOOL_CALL = "tool_call"
     MESSAGE_DONE = "message_done"
+    THINKING = "thinking"  # Extended thinking block content (Anthropic-only)
 
 
 # ---------------------------------------------------------------------------
@@ -160,12 +161,19 @@ class TodoItem:
 
 @dataclass(frozen=True)
 class TokenUsage:
-    """Token usage for a single LLM call or cumulative across a session."""
+    """Token usage for a single LLM call or cumulative across a session.
+
+    ``thinking_tokens`` tracks the subset of ``output_tokens`` consumed by
+    extended-thinking blocks (Anthropic-only).  They are already included in
+    ``output_tokens``; this field provides a separate breakdown for cost
+    accounting (Bifrost).
+    """
 
     input_tokens: int
     output_tokens: int
     cache_read_tokens: int = 0
     cache_write_tokens: int = 0
+    thinking_tokens: int = 0
 
     @property
     def total_tokens(self) -> int:
@@ -177,6 +185,7 @@ class TokenUsage:
             output_tokens=self.output_tokens + other.output_tokens,
             cache_read_tokens=self.cache_read_tokens + other.cache_read_tokens,
             cache_write_tokens=self.cache_write_tokens + other.cache_write_tokens,
+            thinking_tokens=self.thinking_tokens + other.thinking_tokens,
         )
 
 

--- a/src/ravn/ports/llm.py
+++ b/src/ravn/ports/llm.py
@@ -17,6 +17,16 @@ SystemPrompt = str | list[dict]
 class LLMPort(ABC):
     """Abstract interface for LLM streaming and generation with tool support."""
 
+    @property
+    def supports_thinking(self) -> bool:
+        """Return True if this adapter supports extended thinking.
+
+        Defaults to False.  AnthropicAdapter overrides to True.
+        FallbackLLMAdapter uses this to decide whether to forward the
+        ``thinking`` parameter to a given provider.
+        """
+        return False
+
     @abstractmethod
     def stream(
         self,
@@ -26,12 +36,19 @@ class LLMPort(ABC):
         system: SystemPrompt,
         model: str,
         max_tokens: int,
+        thinking: dict | None = None,
     ) -> AsyncIterator[StreamEvent]:
         """Stream a response from the LLM, yielding events as they arrive.
 
-        Yields StreamEvent objects with TEXT_DELTA, TOOL_CALL, and MESSAGE_DONE types.
+        Yields StreamEvent objects with TEXT_DELTA, TOOL_CALL, THINKING, and
+        MESSAGE_DONE types.
+
         ``system`` may be a plain string or a list of Anthropic-format text blocks
         with optional ``cache_control`` entries for prompt caching.
+
+        ``thinking`` enables extended thinking when set to
+        ``{"type": "enabled", "budget_tokens": N}``.  Ignored by adapters that
+        do not support extended thinking (``supports_thinking == False``).
         """
         ...
 
@@ -44,6 +61,12 @@ class LLMPort(ABC):
         system: SystemPrompt,
         model: str,
         max_tokens: int,
+        thinking: dict | None = None,
     ) -> LLMResponse:
-        """Generate a complete (non-streaming) response from the LLM."""
+        """Generate a complete (non-streaming) response from the LLM.
+
+        ``thinking`` enables extended thinking when set to
+        ``{"type": "enabled", "budget_tokens": N}``.  Ignored by adapters that
+        do not support extended thinking (``supports_thinking == False``).
+        """
         ...

--- a/tests/ravn/conftest.py
+++ b/tests/ravn/conftest.py
@@ -56,6 +56,7 @@ class MockLLM(LLMPort):
         system: str,
         model: str,
         max_tokens: int,
+        thinking: dict | None = None,
     ) -> LLMResponse:
         return next(self._responses)
 
@@ -67,6 +68,7 @@ class MockLLM(LLMPort):
         system: str,
         model: str,
         max_tokens: int,
+        thinking: dict | None = None,
     ) -> AsyncIterator[StreamEvent]:
         response = next(self._responses)
 

--- a/tests/ravn/unit/test_extended_thinking.py
+++ b/tests/ravn/unit/test_extended_thinking.py
@@ -153,8 +153,13 @@ def test_anthropic_adapter_supports_thinking_true():
         ("think:write a plan", True, "write a plan"),
         ("THINK: hello", True, "hello"),
         ("normal message", False, "normal message"),
-        ("please --think about this", True, "please  about this"),
+        # Standalone --think: collapses to a single space between words
+        ("please --think about this", True, "please about this"),
         ("--think", True, ""),
+        # --thinking must NOT trigger the flag
+        ("explain --thinking process", False, "explain --thinking process"),
+        # mid-text --think with no surrounding whitespace must not trigger
+        ("I do not --thinking this works", False, "I do not --thinking this works"),
     ],
 )
 def test_parse_think_flag(user_input, expected_flag, expected_text):
@@ -179,6 +184,10 @@ def test_parse_think_flag(user_input, expected_flag, expected_text):
         ("just fix the bug", False),
         ("run the tests", False),
         ("", False),
+        # Word-boundary false-positive regression cases
+        ("this bug was unplanned, just fix it", False),
+        ("no replanning needed", False),
+        ("I need to re-architect the service", True),  # still matches "architect"
     ],
 )
 def test_looks_like_planning_task(user_input, expected):

--- a/tests/ravn/unit/test_extended_thinking.py
+++ b/tests/ravn/unit/test_extended_thinking.py
@@ -1,0 +1,772 @@
+"""Tests for extended thinking integration (NIU-497).
+
+Covers:
+- ExtendedThinkingConfig in config
+- TokenUsage.thinking_tokens tracking and arithmetic
+- StreamEventType.THINKING
+- RavnEvent.thinking() factory method
+- AnthropicAdapter: thinking param in request, THINKING stream events,
+  thinking_tokens in usage, headers, generate() with thinking blocks
+- FallbackLLMAdapter: passes thinking to supports_thinking providers, strips
+  it for non-supporting providers
+- LLMPort.supports_thinking property
+- Agent: _parse_think_flag, _looks_like_planning_task, _resolve_thinking,
+  THINKING events emitted in _call_llm_streaming, explicit/auto triggers
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+
+import httpx
+import pytest
+import respx
+
+from ravn.adapters.anthropic_adapter import AnthropicAdapter
+from ravn.adapters.fallback_llm import FallbackLLMAdapter
+from ravn.agent import (
+    RavnAgent,
+    _looks_like_planning_task,
+    _parse_think_flag,
+)
+from ravn.config import ExtendedThinkingConfig
+from ravn.domain.events import RavnEvent, RavnEventType
+from ravn.domain.models import (
+    LLMResponse,
+    StopReason,
+    StreamEvent,
+    StreamEventType,
+    TokenUsage,
+)
+from ravn.ports.llm import LLMPort
+from tests.ravn.conftest import MockLLM, make_text_response
+from tests.ravn.fixtures.fakes import InMemoryChannel
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+def test_extended_thinking_config_defaults():
+    cfg = ExtendedThinkingConfig()
+    assert cfg.enabled is False
+    assert cfg.budget_tokens == 8000
+    assert cfg.auto_trigger is True
+    assert cfg.auto_trigger_on_retry is True
+
+
+def test_extended_thinking_config_custom():
+    cfg = ExtendedThinkingConfig(
+        enabled=True,
+        budget_tokens=4000,
+        auto_trigger=False,
+        auto_trigger_on_retry=False,
+    )
+    assert cfg.enabled is True
+    assert cfg.budget_tokens == 4000
+    assert cfg.auto_trigger is False
+    assert cfg.auto_trigger_on_retry is False
+
+
+# ---------------------------------------------------------------------------
+# TokenUsage — thinking_tokens
+# ---------------------------------------------------------------------------
+
+
+def test_token_usage_thinking_tokens_default():
+    usage = TokenUsage(input_tokens=10, output_tokens=20)
+    assert usage.thinking_tokens == 0
+
+
+def test_token_usage_thinking_tokens_set():
+    usage = TokenUsage(input_tokens=10, output_tokens=20, thinking_tokens=50)
+    assert usage.thinking_tokens == 50
+
+
+def test_token_usage_add_propagates_thinking_tokens():
+    a = TokenUsage(input_tokens=5, output_tokens=10, thinking_tokens=30)
+    b = TokenUsage(input_tokens=3, output_tokens=7, thinking_tokens=20)
+    result = a + b
+    assert result.thinking_tokens == 50
+    assert result.input_tokens == 8
+    assert result.output_tokens == 17
+
+
+# ---------------------------------------------------------------------------
+# StreamEventType.THINKING
+# ---------------------------------------------------------------------------
+
+
+def test_stream_event_type_thinking_exists():
+    assert StreamEventType.THINKING == "thinking"
+
+
+def test_thinking_stream_event():
+    evt = StreamEvent(type=StreamEventType.THINKING, text="I need to think about this.")
+    assert evt.type == StreamEventType.THINKING
+    assert evt.text == "I need to think about this."
+
+
+# ---------------------------------------------------------------------------
+# RavnEvent.thinking factory
+# ---------------------------------------------------------------------------
+
+
+def test_ravn_event_thinking_type():
+    evt = RavnEvent.thinking("some reasoning")
+    assert evt.type == RavnEventType.THOUGHT
+    assert evt.data == "some reasoning"
+    assert evt.metadata.get("thinking") is True
+
+
+def test_ravn_event_thought_no_thinking_flag():
+    evt = RavnEvent.thought("text delta")
+    assert evt.type == RavnEventType.THOUGHT
+    assert evt.metadata.get("thinking") is None
+
+
+# ---------------------------------------------------------------------------
+# LLMPort.supports_thinking property
+# ---------------------------------------------------------------------------
+
+
+def test_llm_port_supports_thinking_default_false():
+    llm = MockLLM([make_text_response()])
+    assert llm.supports_thinking is False
+
+
+def test_anthropic_adapter_supports_thinking_true():
+    adapter = AnthropicAdapter(api_key="test")
+    assert adapter.supports_thinking is True
+
+
+# ---------------------------------------------------------------------------
+# _parse_think_flag helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "user_input, expected_flag, expected_text",
+    [
+        ("think: write a plan", True, "write a plan"),
+        ("think:write a plan", True, "write a plan"),
+        ("THINK: hello", True, "hello"),
+        ("normal message", False, "normal message"),
+        ("please --think about this", True, "please  about this"),
+        ("--think", True, ""),
+    ],
+)
+def test_parse_think_flag(user_input, expected_flag, expected_text):
+    flag, text = _parse_think_flag(user_input)
+    assert flag == expected_flag
+    assert text.strip() == expected_text.strip()
+
+
+# ---------------------------------------------------------------------------
+# _looks_like_planning_task helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "user_input, expected",
+    [
+        ("design a database schema", True),
+        ("plan the migration", True),
+        ("what approach should i use", True),
+        ("best way to implement this", True),
+        ("how should I structure this", True),
+        ("just fix the bug", False),
+        ("run the tests", False),
+        ("", False),
+    ],
+)
+def test_looks_like_planning_task(user_input, expected):
+    assert _looks_like_planning_task(user_input) == expected
+
+
+# ---------------------------------------------------------------------------
+# AnthropicAdapter — _headers with thinking enabled
+# ---------------------------------------------------------------------------
+
+
+def test_anthropic_adapter_headers_without_thinking():
+    adapter = AnthropicAdapter(api_key="sk-test")
+    headers = adapter._headers(thinking_enabled=False)
+    assert "interleaved-thinking-2025-05-14" not in headers["anthropic-beta"]
+    assert "prompt-caching-2024-07-31" in headers["anthropic-beta"]
+
+
+def test_anthropic_adapter_headers_with_thinking():
+    adapter = AnthropicAdapter(api_key="sk-test")
+    headers = adapter._headers(thinking_enabled=True)
+    assert "interleaved-thinking-2025-05-14" in headers["anthropic-beta"]
+    assert "prompt-caching-2024-07-31" in headers["anthropic-beta"]
+
+
+# ---------------------------------------------------------------------------
+# AnthropicAdapter — _build_request with thinking
+# ---------------------------------------------------------------------------
+
+
+def test_anthropic_adapter_build_request_no_thinking():
+    adapter = AnthropicAdapter(api_key="sk-test")
+    req = adapter._build_request(
+        [],
+        tools=[],
+        system="",
+        model="claude-sonnet-4-6",
+        max_tokens=1024,
+        stream=False,
+        thinking=None,
+    )
+    assert "thinking" not in req
+
+
+def test_anthropic_adapter_build_request_with_thinking():
+    adapter = AnthropicAdapter(api_key="sk-test")
+    thinking = {"type": "enabled", "budget_tokens": 4000}
+    req = adapter._build_request(
+        [],
+        tools=[],
+        system="",
+        model="claude-sonnet-4-6",
+        max_tokens=8192,
+        stream=False,
+        thinking=thinking,
+    )
+    assert req["thinking"] == thinking
+
+
+# ---------------------------------------------------------------------------
+# AnthropicAdapter — stream() with thinking blocks
+# ---------------------------------------------------------------------------
+
+
+def _make_sse_lines(*event_dicts: dict) -> str:
+    """Build SSE data lines from a list of event dicts."""
+    return "\n".join(f"data: {json.dumps(d)}" for d in event_dicts) + "\n"
+
+
+@pytest.mark.asyncio
+async def test_anthropic_adapter_stream_emits_thinking_events():
+    """THINKING stream events are emitted for thinking_delta blocks."""
+    adapter = AnthropicAdapter(api_key="sk-test", base_url="https://api.test")
+
+    sse_body = _make_sse_lines(
+        {"type": "content_block_start", "index": 0, "content_block": {"type": "thinking"}},
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "thinking_delta", "thinking": "I should consider..."},
+        },
+        {"type": "content_block_stop", "index": 0},
+        {"type": "content_block_start", "index": 1, "content_block": {"type": "text", "text": ""}},
+        {
+            "type": "content_block_delta",
+            "index": 1,
+            "delta": {"type": "text_delta", "text": "Answer."},
+        },
+        {"type": "content_block_stop", "index": 1},
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn"},
+            "usage": {"output_tokens": 25},
+        },
+    )
+
+    with respx.mock(base_url="https://api.test") as mock:
+        mock.post("/v1/messages").mock(return_value=httpx.Response(200, text=sse_body))
+
+        events: list[StreamEvent] = []
+        async for evt in adapter.stream(
+            [{"role": "user", "content": "hi"}],
+            tools=[],
+            system="",
+            model="claude-sonnet-4-6",
+            max_tokens=8192,
+            thinking={"type": "enabled", "budget_tokens": 4000},
+        ):
+            events.append(evt)
+
+    thinking_events = [e for e in events if e.type == StreamEventType.THINKING]
+    text_events = [e for e in events if e.type == StreamEventType.TEXT_DELTA]
+    done_events = [e for e in events if e.type == StreamEventType.MESSAGE_DONE]
+
+    assert len(thinking_events) == 1
+    assert thinking_events[0].text == "I should consider..."
+    assert len(text_events) == 1
+    assert text_events[0].text == "Answer."
+    assert len(done_events) == 1
+    # thinking_tokens should be char_count // 4
+    assert done_events[0].usage.thinking_tokens == len("I should consider...") // 4
+
+
+@pytest.mark.asyncio
+async def test_anthropic_adapter_stream_no_thinking_events_without_param():
+    """No THINKING events are emitted when thinking param is None."""
+    adapter = AnthropicAdapter(api_key="sk-test", base_url="https://api.test")
+
+    sse_body = _make_sse_lines(
+        {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": "Hello."},
+        },
+        {"type": "content_block_stop", "index": 0},
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn"},
+            "usage": {"output_tokens": 5},
+        },
+    )
+
+    with respx.mock(base_url="https://api.test") as mock:
+        mock.post("/v1/messages").mock(return_value=httpx.Response(200, text=sse_body))
+
+        events: list[StreamEvent] = []
+        async for evt in adapter.stream(
+            [{"role": "user", "content": "hi"}],
+            tools=[],
+            system="",
+            model="claude-sonnet-4-6",
+            max_tokens=8192,
+        ):
+            events.append(evt)
+
+    thinking_events = [e for e in events if e.type == StreamEventType.THINKING]
+    assert len(thinking_events) == 0
+
+
+# ---------------------------------------------------------------------------
+# AnthropicAdapter — generate() with thinking blocks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_anthropic_adapter_generate_with_thinking_blocks():
+    adapter = AnthropicAdapter(api_key="sk-test", base_url="https://api.test")
+
+    response_body = {
+        "content": [
+            {"type": "thinking", "thinking": "Let me reason about this carefully." * 10},
+            {"type": "text", "text": "Here is my answer."},
+        ],
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 50, "output_tokens": 120},
+    }
+
+    with respx.mock(base_url="https://api.test") as mock:
+        mock.post("/v1/messages").mock(return_value=httpx.Response(200, json=response_body))
+
+        result = await adapter.generate(
+            [{"role": "user", "content": "hard question"}],
+            tools=[],
+            system="",
+            model="claude-sonnet-4-6",
+            max_tokens=8192,
+            thinking={"type": "enabled", "budget_tokens": 4000},
+        )
+
+    assert result.content == "Here is my answer."
+    thinking_text = "Let me reason about this carefully." * 10
+    assert result.usage.thinking_tokens == len(thinking_text) // 4
+    assert result.usage.input_tokens == 50
+    assert result.usage.output_tokens == 120
+
+
+@pytest.mark.asyncio
+async def test_anthropic_adapter_generate_without_thinking():
+    adapter = AnthropicAdapter(api_key="sk-test", base_url="https://api.test")
+
+    response_body = {
+        "content": [{"type": "text", "text": "Simple answer."}],
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 10, "output_tokens": 5},
+    }
+
+    with respx.mock(base_url="https://api.test") as mock:
+        mock.post("/v1/messages").mock(return_value=httpx.Response(200, json=response_body))
+
+        result = await adapter.generate(
+            [{"role": "user", "content": "question"}],
+            tools=[],
+            system="",
+            model="claude-sonnet-4-6",
+            max_tokens=8192,
+        )
+
+    assert result.content == "Simple answer."
+    assert result.usage.thinking_tokens == 0
+
+
+# ---------------------------------------------------------------------------
+# FallbackLLMAdapter — thinking routing
+# ---------------------------------------------------------------------------
+
+
+class ThinkingCapableLLM(LLMPort):
+    """Mock LLM that records whether thinking was passed."""
+
+    def __init__(self) -> None:
+        self.last_thinking: dict | None = None
+
+    @property
+    def supports_thinking(self) -> bool:
+        return True
+
+    async def generate(
+        self,
+        messages: list[dict],
+        *,
+        tools: list[dict],
+        system,
+        model: str,
+        max_tokens: int,
+        thinking: dict | None = None,
+    ) -> LLMResponse:
+        self.last_thinking = thinking
+        return LLMResponse(
+            content="ok",
+            tool_calls=[],
+            stop_reason=StopReason.END_TURN,
+            usage=TokenUsage(input_tokens=1, output_tokens=1),
+        )
+
+    async def stream(
+        self,
+        messages: list[dict],
+        *,
+        tools: list[dict],
+        system,
+        model: str,
+        max_tokens: int,
+        thinking: dict | None = None,
+    ) -> AsyncIterator[StreamEvent]:
+        self.last_thinking = thinking
+        yield StreamEvent(
+            type=StreamEventType.MESSAGE_DONE,
+            usage=TokenUsage(input_tokens=1, output_tokens=1),
+        )
+
+
+class NonThinkingLLM(LLMPort):
+    """Mock LLM that does not support thinking."""
+
+    def __init__(self) -> None:
+        self.last_thinking: dict | None = "NOT_SET"
+
+    @property
+    def supports_thinking(self) -> bool:
+        return False
+
+    async def generate(
+        self,
+        messages: list[dict],
+        *,
+        tools: list[dict],
+        system,
+        model: str,
+        max_tokens: int,
+        thinking: dict | None = None,
+    ) -> LLMResponse:
+        self.last_thinking = thinking
+        return LLMResponse(
+            content="ok",
+            tool_calls=[],
+            stop_reason=StopReason.END_TURN,
+            usage=TokenUsage(input_tokens=1, output_tokens=1),
+        )
+
+    async def stream(
+        self,
+        messages: list[dict],
+        *,
+        tools: list[dict],
+        system,
+        model: str,
+        max_tokens: int,
+        thinking: dict | None = None,
+    ) -> AsyncIterator[StreamEvent]:
+        self.last_thinking = thinking
+        yield StreamEvent(
+            type=StreamEventType.MESSAGE_DONE,
+            usage=TokenUsage(input_tokens=1, output_tokens=1),
+        )
+
+
+@pytest.mark.asyncio
+async def test_fallback_passes_thinking_to_capable_provider():
+    capable = ThinkingCapableLLM()
+    fallback = FallbackLLMAdapter([capable])
+
+    thinking = {"type": "enabled", "budget_tokens": 4000}
+    await fallback.generate(
+        [{"role": "user", "content": "hi"}],
+        tools=[],
+        system="",
+        model="m",
+        max_tokens=1024,
+        thinking=thinking,
+    )
+    assert capable.last_thinking == thinking
+
+
+@pytest.mark.asyncio
+async def test_fallback_strips_thinking_for_non_capable_provider():
+    non_capable = NonThinkingLLM()
+    fallback = FallbackLLMAdapter([non_capable])
+
+    thinking = {"type": "enabled", "budget_tokens": 4000}
+    await fallback.generate(
+        [{"role": "user", "content": "hi"}],
+        tools=[],
+        system="",
+        model="m",
+        max_tokens=1024,
+        thinking=thinking,
+    )
+    # Should be stripped to None
+    assert non_capable.last_thinking is None
+
+
+@pytest.mark.asyncio
+async def test_fallback_stream_passes_thinking_to_capable_provider():
+    capable = ThinkingCapableLLM()
+    fallback = FallbackLLMAdapter([capable])
+
+    thinking = {"type": "enabled", "budget_tokens": 4000}
+    async for _ in fallback.stream(
+        [{"role": "user", "content": "hi"}],
+        tools=[],
+        system="",
+        model="m",
+        max_tokens=1024,
+        thinking=thinking,
+    ):
+        pass
+    assert capable.last_thinking == thinking
+
+
+@pytest.mark.asyncio
+async def test_fallback_stream_strips_thinking_for_non_capable():
+    non_capable = NonThinkingLLM()
+    fallback = FallbackLLMAdapter([non_capable])
+
+    thinking = {"type": "enabled", "budget_tokens": 4000}
+    async for _ in fallback.stream(
+        [{"role": "user", "content": "hi"}],
+        tools=[],
+        system="",
+        model="m",
+        max_tokens=1024,
+        thinking=thinking,
+    ):
+        pass
+    assert non_capable.last_thinking is None
+
+
+# ---------------------------------------------------------------------------
+# Agent — extended thinking triggers
+# ---------------------------------------------------------------------------
+
+
+class ThinkingRecordingLLM(LLMPort):
+    """Records thinking params passed to stream() for test assertions."""
+
+    def __init__(self, response: LLMResponse) -> None:
+        self._response = response
+        self.thinking_params: list[dict | None] = []
+
+    @property
+    def supports_thinking(self) -> bool:
+        return True
+
+    async def generate(
+        self,
+        messages: list[dict],
+        *,
+        tools: list[dict],
+        system,
+        model: str,
+        max_tokens: int,
+        thinking: dict | None = None,
+    ) -> LLMResponse:
+        self.thinking_params.append(thinking)
+        return self._response
+
+    async def stream(
+        self,
+        messages: list[dict],
+        *,
+        tools: list[dict],
+        system,
+        model: str,
+        max_tokens: int,
+        thinking: dict | None = None,
+    ) -> AsyncIterator[StreamEvent]:
+        self.thinking_params.append(thinking)
+        if self._response.content:
+            yield StreamEvent(type=StreamEventType.TEXT_DELTA, text=self._response.content)
+        yield StreamEvent(type=StreamEventType.MESSAGE_DONE, usage=self._response.usage)
+
+
+def make_thinking_agent(
+    budget_tokens: int = 4000,
+    auto_trigger: bool = True,
+    auto_trigger_on_retry: bool = True,
+) -> tuple[RavnAgent, InMemoryChannel, ThinkingRecordingLLM]:
+    et_config = ExtendedThinkingConfig(
+        enabled=True,
+        budget_tokens=budget_tokens,
+        auto_trigger=auto_trigger,
+        auto_trigger_on_retry=auto_trigger_on_retry,
+    )
+    response = make_text_response("Done.")
+    llm = ThinkingRecordingLLM(response)
+    ch = InMemoryChannel()
+    from ravn.adapters.permission_adapter import AllowAllPermission
+
+    agent = RavnAgent(
+        llm=llm,
+        tools=[],
+        channel=ch,
+        permission=AllowAllPermission(),
+        system_prompt="test",
+        model="m",
+        max_tokens=8192,
+        max_iterations=5,
+        extended_thinking=et_config,
+    )
+    return agent, ch, llm
+
+
+@pytest.mark.asyncio
+async def test_agent_explicit_think_prefix_activates_thinking():
+    agent, ch, llm = make_thinking_agent()
+    await agent.run_turn("think: design a better system")
+    assert llm.thinking_params[0] == {"type": "enabled", "budget_tokens": 4000}
+
+
+@pytest.mark.asyncio
+async def test_agent_explicit_think_flag_activates_thinking():
+    agent, ch, llm = make_thinking_agent()
+    await agent.run_turn("--think how do I fix this")
+    assert llm.thinking_params[0] == {"type": "enabled", "budget_tokens": 4000}
+
+
+@pytest.mark.asyncio
+async def test_agent_no_thinking_without_config():
+    """When extended_thinking is None, no thinking param is passed."""
+    response = make_text_response("Done.")
+    llm = ThinkingRecordingLLM(response)
+    ch = InMemoryChannel()
+    from ravn.adapters.permission_adapter import AllowAllPermission
+
+    agent = RavnAgent(
+        llm=llm,
+        tools=[],
+        channel=ch,
+        permission=AllowAllPermission(),
+        system_prompt="test",
+        model="m",
+        max_tokens=8192,
+        max_iterations=5,
+        extended_thinking=None,
+    )
+    await agent.run_turn("normal message")
+    assert llm.thinking_params[0] is None
+
+
+@pytest.mark.asyncio
+async def test_agent_auto_trigger_on_planning_input():
+    agent, ch, llm = make_thinking_agent(auto_trigger=True)
+    await agent.run_turn("plan the new architecture for this service")
+    assert llm.thinking_params[0] == {"type": "enabled", "budget_tokens": 4000}
+
+
+@pytest.mark.asyncio
+async def test_agent_no_auto_trigger_when_disabled():
+    agent, ch, llm = make_thinking_agent(auto_trigger=False)
+    await agent.run_turn("plan the new architecture for this service")
+    # auto_trigger off → should be None even for planning input
+    assert llm.thinking_params[0] is None
+
+
+@pytest.mark.asyncio
+async def test_agent_thinking_events_emitted_to_channel():
+    """THINKING stream events are emitted as THOUGHT events with thinking=True."""
+
+    class ThinkingStreamLLM(LLMPort):
+        @property
+        def supports_thinking(self) -> bool:
+            return True
+
+        async def generate(self, messages, *, tools, system, model, max_tokens, thinking=None):
+            return make_text_response()
+
+        async def stream(
+            self,
+            messages,
+            *,
+            tools,
+            system,
+            model,
+            max_tokens,
+            thinking=None,
+        ) -> AsyncIterator[StreamEvent]:
+            yield StreamEvent(type=StreamEventType.THINKING, text="reasoning step")
+            yield StreamEvent(type=StreamEventType.TEXT_DELTA, text="answer")
+            yield StreamEvent(
+                type=StreamEventType.MESSAGE_DONE,
+                usage=TokenUsage(input_tokens=5, output_tokens=10),
+            )
+
+    et = ExtendedThinkingConfig(enabled=True, budget_tokens=4000)
+    llm = ThinkingStreamLLM()
+    ch = InMemoryChannel()
+    from ravn.adapters.permission_adapter import AllowAllPermission
+
+    agent = RavnAgent(
+        llm=llm,
+        tools=[],
+        channel=ch,
+        permission=AllowAllPermission(),
+        system_prompt="test",
+        model="m",
+        max_tokens=8192,
+        max_iterations=5,
+        extended_thinking=et,
+    )
+    await agent.run_turn("think: do something")
+
+    thinking_events = [
+        e for e in ch.events if e.type == RavnEventType.THOUGHT and e.metadata.get("thinking")
+    ]
+    assert len(thinking_events) == 1
+    assert thinking_events[0].data == "reasoning step"
+
+
+@pytest.mark.asyncio
+async def test_agent_disabled_extended_thinking_no_thinking_param():
+    """When enabled=False, thinking param is never passed even with think: prefix."""
+    et = ExtendedThinkingConfig(enabled=False)
+    response = make_text_response("Done.")
+    llm = ThinkingRecordingLLM(response)
+    ch = InMemoryChannel()
+    from ravn.adapters.permission_adapter import AllowAllPermission
+
+    agent = RavnAgent(
+        llm=llm,
+        tools=[],
+        channel=ch,
+        permission=AllowAllPermission(),
+        system_prompt="test",
+        model="m",
+        max_tokens=8192,
+        max_iterations=5,
+        extended_thinking=et,
+    )
+    await agent.run_turn("think: do something")
+    assert llm.thinking_params[0] is None

--- a/tests/test_ravn/test_context_management.py
+++ b/tests/test_ravn/test_context_management.py
@@ -328,7 +328,7 @@ class TestAgentPromptBuilder:
 
         call_system: list = []
 
-        async def capturing_stream(messages, *, tools, system, model, max_tokens):
+        async def capturing_stream(messages, *, tools, system, model, max_tokens, thinking=None):
             call_system.append(system)
             yield StreamEvent(type=StreamEventType.TEXT_DELTA, text="OK")
             yield StreamEvent(
@@ -351,7 +351,7 @@ class TestAgentPromptBuilder:
         """Without a prompt_builder, system prompt is a plain string."""
         call_system: list = []
 
-        async def capturing_stream(messages, *, tools, system, model, max_tokens):
+        async def capturing_stream(messages, *, tools, system, model, max_tokens, thinking=None):
             call_system.append(system)
             yield StreamEvent(type=StreamEventType.TEXT_DELTA, text="OK")
             yield StreamEvent(
@@ -382,7 +382,7 @@ class TestAgentPromptBuilder:
 
         call_system: list = []
 
-        async def capturing_stream(messages, *, tools, system, model, max_tokens):
+        async def capturing_stream(messages, *, tools, system, model, max_tokens, thinking=None):
             call_system.append(system)
             yield StreamEvent(type=StreamEventType.TEXT_DELTA, text="OK")
             yield StreamEvent(
@@ -428,7 +428,7 @@ class TestAgentPromptBuilder:
         builder = PromptBuilder()
         builder.set_identity("You are Ravn.")
 
-        async def simple_stream(messages, *, tools, system, model, max_tokens):
+        async def simple_stream(messages, *, tools, system, model, max_tokens, thinking=None):
             yield StreamEvent(type=StreamEventType.TEXT_DELTA, text="OK")
             yield StreamEvent(
                 type=StreamEventType.MESSAGE_DONE,

--- a/tests/test_ravn/test_e2e_memory.py
+++ b/tests/test_ravn/test_e2e_memory.py
@@ -83,6 +83,7 @@ class ScriptedLLM(LLMPort):
         system,
         model: str,
         max_tokens: int,
+        thinking: dict | None = None,
     ) -> LLMResponse:
         self.calls.append({"messages": messages, "system": system})
         return next(self._responses)
@@ -95,6 +96,7 @@ class ScriptedLLM(LLMPort):
         system,
         model: str,
         max_tokens: int,
+        thinking: dict | None = None,
     ) -> AsyncIterator[StreamEvent]:
         response = next(self._responses)
         self.calls.append({"messages": messages, "system": system})


### PR DESCRIPTION
## Summary

- **ExtendedThinkingConfig** added to `LLMConfig` with `enabled`, `budget_tokens`, `auto_trigger`, and `auto_trigger_on_retry` fields
- **AnthropicAdapter** passes `thinking: {type: 'enabled', budget_tokens: N}` in requests, parses `thinking_delta` SSE events, adds `interleaved-thinking-2025-05-14` beta header, tracks `thinking_tokens` (char-count approximation for Bifrost cost accounting)
- **TokenUsage** gains `thinking_tokens` field — subset of `output_tokens` for separate cost breakdown
- **StreamEventType.THINKING** added; thinking blocks are streamed as THINKING events, emitted by the agent as THOUGHT events with `metadata={"thinking": True}` (rendered dimmed/collapsed in CLI)
- **LLMPort** gains `supports_thinking` property (default `False`; `True` in AnthropicAdapter)
- **FallbackLLMAdapter** forwards `thinking` param only to providers where `supports_thinking == True`; strips it silently for non-Anthropic providers
- **OpenAICompatibleAdapter** accepts (and ignores) the `thinking` param
- **RavnAgent** detects explicit `think:` prefix / `--think` flag; auto-triggers on planning keywords (`plan`, `design`, `architect`, …) and on tool-failure retries (2nd+ iteration)
- **44 new tests** covering all paths; total coverage 95.75% (threshold 85%)

## Configuration

```yaml
llm:
  extended_thinking:
    enabled: true
    budget_tokens: 8000
    auto_trigger: true
    auto_trigger_on_retry: true
```

## Test plan

- [x] All 2330 tests pass
- [x] `ruff check` clean
- [x] `ruff format` applied
- [x] Coverage 95.75% >= 85% threshold
- [x] Extended thinking unit tests: config, TokenUsage, StreamEventType, events, AnthropicAdapter (stream + generate), FallbackAdapter routing, agent triggers

Closes NIU-497

🤖 Generated with [Claude Code](https://claude.com/claude-code)