### PR TITLE
feat(adapters): Pi-mode gateway — Telegram polling + local HTTP (NIU-516)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ bifrost = "volundr.bifrost.__main__:main"
 tyr = "tyr.main:main"
 ravn = "ravn.cli.commands:app"
 ravn-approvals = "ravn.cli.commands:approvals_main"
+ravn-gateway = "ravn.cli.commands:gateway_main"
 
 [project.entry-points."niuu.plugins"]
 niuu = "niuu.plugin:NiuuPlugin"

--- a/src/ravn/adapters/bifrost_adapter.py
+++ b/src/ravn/adapters/bifrost_adapter.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 from ravn.adapters.anthropic_adapter import (
     ANTHROPIC_API_VERSION,  # noqa: F401 — re-exported for tests
-    ANTHROPIC_BETA_HEADER,  # noqa: F401 — re-exported for tests
     AnthropicAdapter,
 )
 
@@ -58,8 +57,8 @@ class BifrostAdapter(AnthropicAdapter):
         self._agent_id = agent_id
         self._session_id = session_id
 
-    def _headers(self) -> dict[str, str]:
-        headers = super()._headers()
+    def _headers(self, *, thinking_enabled: bool = False) -> dict[str, str]:
+        headers = super()._headers(thinking_enabled=thinking_enabled)
         # Bifrost manages API keys — remove the empty x-api-key header
         headers.pop("x-api-key", None)
         # Inject agent identity for per-agent usage tracking and cost attribution

--- a/src/ravn/adapters/channels/__init__.py
+++ b/src/ravn/adapters/channels/__init__.py
@@ -1,0 +1,1 @@
+"""Gateway channel adapters — Telegram polling and local HTTP."""

--- a/src/ravn/adapters/channels/gateway.py
+++ b/src/ravn/adapters/channels/gateway.py
@@ -1,0 +1,204 @@
+"""Gateway orchestrator — manages Telegram and HTTP channels for Ravn.
+
+Each channel+user combination gets its own isolated :class:`RavnAgent` session.
+The gateway runs as asyncio tasks alongside the main agent loop — no separate
+process, no broker, no open inbound ports required.
+
+Usage::
+
+    gateway = RavnGateway(config, agent_factory)
+    response = await gateway.handle_message("telegram:123456", "hello")
+
+    # or for SSE streaming:
+    async for event in gateway.handle_message_stream("http:default", "hello"):
+        ...
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator, Awaitable, Callable
+from dataclasses import dataclass, field
+
+from ravn.agent import RavnAgent
+from ravn.config import GatewayConfig
+from ravn.domain.events import RavnEvent, RavnEventType
+from ravn.ports.channel import ChannelPort
+
+logger = logging.getLogger(__name__)
+
+# Factory that creates a new RavnAgent bound to the supplied channel.
+AgentFactory = Callable[[ChannelPort], RavnAgent]
+
+# Optional broadcast callback invoked on every emitted event.
+BroadcastCallback = Callable[[RavnEvent], Awaitable[None]]
+
+
+class GatewayChannel(ChannelPort):
+    """Buffers :class:`RavnEvent` objects in an asyncio queue for gateway consumption.
+
+    Each :class:`GatewaySession` owns one channel instance.  When ``run_turn``
+    emits events they land in the queue; the gateway then drains them to
+    deliver to Telegram / HTTP.
+
+    An optional *broadcast_cb* is called for every event so the HTTP
+    ``GET /events`` broadcast stream can distribute events to all subscribers.
+    """
+
+    def __init__(
+        self,
+        *,
+        broadcast_cb: BroadcastCallback | None = None,
+    ) -> None:
+        self._queue: asyncio.Queue[RavnEvent | None] = asyncio.Queue()
+        self._broadcast_cb = broadcast_cb
+
+    async def emit(self, event: RavnEvent) -> None:
+        await self._queue.put(event)
+        if self._broadcast_cb is not None:
+            await self._broadcast_cb(event)
+
+    async def signal_done(self) -> None:
+        """Push a sentinel ``None`` to unblock any pending :meth:`stream` call."""
+        await self._queue.put(None)
+
+    async def collect_response(self) -> str:
+        """Drain the queue and return the final response text.
+
+        Reads events until a :attr:`~RavnEventType.RESPONSE` or
+        :attr:`~RavnEventType.ERROR` is received (or a sentinel ``None``).
+        Returns the response text, or ``"[error] …"`` on error.
+        """
+        while True:
+            event = await self._queue.get()
+            if event is None:
+                return ""
+            if event.type == RavnEventType.RESPONSE:
+                return event.data
+            if event.type == RavnEventType.ERROR:
+                return f"[error] {event.data}"
+
+    async def stream(self) -> AsyncIterator[RavnEvent]:
+        """Yield events until :attr:`~RavnEventType.RESPONSE`, ERROR, or sentinel.
+
+        Used by the HTTP SSE endpoint to stream events in real time.
+        """
+        while True:
+            event = await self._queue.get()
+            if event is None:
+                return
+            yield event
+            if event.type in (RavnEventType.RESPONSE, RavnEventType.ERROR):
+                return
+
+
+@dataclass
+class GatewaySession:
+    """A single isolated session bound to one user+channel pair."""
+
+    agent: RavnAgent
+    channel: GatewayChannel
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+
+class RavnGateway:
+    """Orchestrates per-session :class:`RavnAgent` instances across gateway channels.
+
+    Sessions are identified by a string key such as ``telegram:123456`` or
+    ``http:192.168.1.1``.  Each session gets its own :class:`RavnAgent` and
+    :class:`GatewayChannel` so conversation history and state are fully isolated.
+
+    All events emitted by any session's channel are also broadcast to
+    subscribers registered via :meth:`subscribe`.
+    """
+
+    def __init__(
+        self,
+        config: GatewayConfig,
+        agent_factory: AgentFactory,
+    ) -> None:
+        self._config = config
+        self._agent_factory = agent_factory
+        self._sessions: dict[str, GatewaySession] = {}
+        self._broadcast_queues: list[asyncio.Queue[RavnEvent | None]] = []
+
+    # ------------------------------------------------------------------
+    # Session management
+    # ------------------------------------------------------------------
+
+    def session_ids(self) -> list[str]:
+        """Return all active session IDs."""
+        return list(self._sessions.keys())
+
+    def get_or_create_session(self, session_id: str) -> GatewaySession:
+        """Return an existing session or create a fresh one."""
+        if session_id in self._sessions:
+            return self._sessions[session_id]
+        channel = GatewayChannel(broadcast_cb=self._broadcast)
+        agent = self._agent_factory(channel)
+        session = GatewaySession(agent=agent, channel=channel)
+        self._sessions[session_id] = session
+        logger.debug("Created gateway session %r.", session_id)
+        return session
+
+    # ------------------------------------------------------------------
+    # Message handling
+    # ------------------------------------------------------------------
+
+    async def handle_message(self, session_id: str, text: str) -> str:
+        """Process *text* and return the agent's complete response.
+
+        Serialises concurrent calls to the same session via a per-session lock.
+        Suitable for Telegram where we wait for the full response before sending.
+        """
+        session = self.get_or_create_session(session_id)
+        async with session.lock:
+            await session.agent.run_turn(text)
+            return await session.channel.collect_response()
+
+    async def handle_message_stream(self, session_id: str, text: str) -> AsyncIterator[RavnEvent]:
+        """Run *text* against *session_id* and yield events as they arrive.
+
+        The agent turn runs concurrently with the event drain so callers
+        receive events in real time.  Suitable for HTTP SSE.
+        """
+        session = self.get_or_create_session(session_id)
+        async with session.lock:
+            run_task: asyncio.Task[object] = asyncio.create_task(
+                self._run_and_signal(session, text)
+            )
+            try:
+                async for event in session.channel.stream():
+                    yield event
+            finally:
+                await run_task
+
+    async def _run_and_signal(self, session: GatewaySession, text: str) -> None:
+        """Run agent turn then push a sentinel so :meth:`stream` unblocks."""
+        try:
+            await session.agent.run_turn(text)
+        finally:
+            await session.channel.signal_done()
+
+    # ------------------------------------------------------------------
+    # Broadcast (GET /events)
+    # ------------------------------------------------------------------
+
+    def subscribe(self) -> asyncio.Queue[RavnEvent | None]:
+        """Register a new broadcast subscriber queue and return it."""
+        q: asyncio.Queue[RavnEvent | None] = asyncio.Queue()
+        self._broadcast_queues.append(q)
+        return q
+
+    def unsubscribe(self, q: asyncio.Queue[RavnEvent | None]) -> None:
+        """Remove *q* from the broadcast subscriber list."""
+        try:
+            self._broadcast_queues.remove(q)
+        except ValueError:
+            pass
+
+    async def _broadcast(self, event: RavnEvent) -> None:
+        """Fan out *event* to all registered broadcast subscribers."""
+        for q in self._broadcast_queues:
+            await q.put(event)

--- a/src/ravn/adapters/channels/gateway_http.py
+++ b/src/ravn/adapters/channels/gateway_http.py
@@ -1,0 +1,159 @@
+"""HTTP gateway — FastAPI server for local/LAN access to Ravn.
+
+Endpoints:
+  POST /chat    — send a message; response is an SSE stream of RavnEvents.
+  GET  /status  — JSON: active session IDs and count.
+  GET  /events  — SSE broadcast of *all* events across all sessions.
+
+Runs via uvicorn inside an asyncio task (no subprocess).
+Suitable for Home Assistant automations, local scripts, and cron jobs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections.abc import AsyncIterator
+
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+
+from ravn.adapters.channels.gateway import RavnGateway
+from ravn.config import HttpChannelConfig
+
+logger = logging.getLogger(__name__)
+
+
+class ChatRequest(BaseModel):
+    """Body schema for ``POST /chat``."""
+
+    message: str
+    session_id: str = "http:default"
+
+
+class HttpGateway:
+    """FastAPI-based HTTP gateway for Ravn.
+
+    Each call to ``POST /chat`` streams :class:`~ravn.domain.events.RavnEvent`
+    objects as Server-Sent Events so callers can display streaming output.
+
+    ``GET /events`` broadcasts *all* events from *all* active sessions to the
+    subscriber — useful for dashboards or Home Assistant integrations.
+    """
+
+    def __init__(
+        self,
+        config: HttpChannelConfig,
+        gateway: RavnGateway,
+    ) -> None:
+        self._config = config
+        self._gateway = gateway
+        self._app = self._build_app()
+
+    @property
+    def app(self) -> FastAPI:
+        """The underlying FastAPI application (useful for testing)."""
+        return self._app
+
+    # ------------------------------------------------------------------
+    # FastAPI application
+    # ------------------------------------------------------------------
+
+    def _build_app(self) -> FastAPI:
+        app = FastAPI(title="Ravn Gateway", docs_url=None, redoc_url=None)
+
+        @app.post("/chat")
+        async def chat(request: ChatRequest) -> StreamingResponse:
+            """Send a message to Ravn and receive a streaming SSE response."""
+            return StreamingResponse(
+                self._chat_stream(request.session_id, request.message),
+                media_type="text/event-stream",
+                headers={
+                    "Cache-Control": "no-cache",
+                    "X-Accel-Buffering": "no",
+                },
+            )
+
+        @app.get("/status")
+        async def status() -> dict:
+            """Return active session IDs and session count."""
+            ids = self._gateway.session_ids()
+            return {"session_count": len(ids), "active_sessions": ids}
+
+        @app.get("/events")
+        async def events() -> StreamingResponse:
+            """SSE broadcast stream — receive all events from all sessions."""
+            return StreamingResponse(
+                self._broadcast_stream(),
+                media_type="text/event-stream",
+                headers={
+                    "Cache-Control": "no-cache",
+                    "X-Accel-Buffering": "no",
+                },
+            )
+
+        return app
+
+    # ------------------------------------------------------------------
+    # Stream generators
+    # ------------------------------------------------------------------
+
+    async def _chat_stream(self, session_id: str, message: str) -> AsyncIterator[str]:
+        """Yield SSE-formatted lines for each event from a chat turn."""
+        async for event in self._gateway.handle_message_stream(session_id, message):
+            payload = json.dumps(
+                {
+                    "type": str(event.type),
+                    "data": event.data,
+                    "metadata": event.metadata,
+                }
+            )
+            yield f"data: {payload}\n\n"
+
+    async def _broadcast_stream(self) -> AsyncIterator[str]:
+        """Yield SSE-formatted lines for every event across all sessions."""
+        q = self._gateway.subscribe()
+        try:
+            while True:
+                event = await q.get()
+                if event is None:
+                    break
+                payload = json.dumps(
+                    {
+                        "type": str(event.type),
+                        "data": event.data,
+                        "metadata": event.metadata,
+                    }
+                )
+                yield f"data: {payload}\n\n"
+        finally:
+            self._gateway.unsubscribe(q)
+
+    # ------------------------------------------------------------------
+    # Server lifecycle
+    # ------------------------------------------------------------------
+
+    async def run(self) -> None:
+        """Start the uvicorn server and block until cancelled."""
+        import uvicorn
+
+        uv_config = uvicorn.Config(
+            app=self._app,
+            host=self._config.host,
+            port=self._config.port,
+            log_level="warning",
+            access_log=False,
+        )
+        server = uvicorn.Server(uv_config)
+        logger.info(
+            "HTTP gateway listening on %s:%s.",
+            self._config.host,
+            self._config.port,
+        )
+        try:
+            await server.serve()
+        except asyncio.CancelledError:
+            logger.info("HTTP gateway stopped.")
+            raise

--- a/src/ravn/adapters/channels/gateway_telegram.py
+++ b/src/ravn/adapters/channels/gateway_telegram.py
@@ -1,0 +1,195 @@
+"""Telegram gateway — long-polls the Bot API and routes messages to RavnGateway.
+
+Design principles:
+- Pure outbound polling (getUpdates with long-poll timeout).
+- No webhook, no open inbound port — works behind NAT and on a $35 Pi.
+- Per-chat session isolation via RavnGateway.
+- Only responds to pre-approved chat IDs (when allowed_chat_ids is set).
+- Slash commands (/stop, /status, /todo, /budget) are translated to natural-
+  language prompts and forwarded to the agent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any
+
+import httpx
+
+from ravn.adapters.channels.gateway import RavnGateway
+from ravn.config import TelegramChannelConfig
+
+logger = logging.getLogger(__name__)
+
+_TELEGRAM_API_BASE = "https://api.telegram.org/bot{token}/{method}"
+
+# Slash commands recognised by the gateway; translated to agent prompts.
+_SLASH_PROMPTS: dict[str, str] = {
+    "/stop": "Please acknowledge that you are stopping and summarise what you were working on.",
+    "/status": "What is your current task status? Summarise briefly.",
+    "/todo": "List your current todo items.",
+    "/budget": "How many iterations have you used and how many remain in your budget?",
+}
+
+# Bot command definitions registered with Telegram via setMyCommands.
+_BOT_COMMANDS: list[dict[str, str]] = [
+    {"command": "stop", "description": "Stop and summarise current work"},
+    {"command": "status", "description": "Show current task status"},
+    {"command": "todo", "description": "List todo items"},
+    {"command": "budget", "description": "Show iteration budget usage"},
+]
+
+
+class TelegramGateway:
+    """Polls Telegram and dispatches incoming messages to :class:`RavnGateway`.
+
+    Uses long-polling (``getUpdates?timeout=…``) so no webhook or open port is
+    required.  On error the loop waits :attr:`~TelegramChannelConfig.retry_delay`
+    seconds before retrying.
+    """
+
+    def __init__(
+        self,
+        config: TelegramChannelConfig,
+        gateway: RavnGateway,
+    ) -> None:
+        self._config = config
+        self._gateway = gateway
+        self._token: str = os.environ.get(config.token_env, "")
+        self._offset: int = 0
+
+    def _api_url(self, method: str) -> str:
+        return _TELEGRAM_API_BASE.format(token=self._token, method=method)
+
+    # ------------------------------------------------------------------
+    # Main loop
+    # ------------------------------------------------------------------
+
+    async def run(self) -> None:
+        """Poll Telegram indefinitely until the task is cancelled."""
+        if not self._token:
+            logger.error(
+                "Telegram token env var %r is not set; Telegram gateway disabled.",
+                self._config.token_env,
+            )
+            return
+
+        timeout = httpx.Timeout(self._config.poll_timeout + 10.0)
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            await self._register_commands(client)
+            logger.info("Telegram gateway started (polling).")
+            while True:
+                try:
+                    await self._poll_once(client)
+                except asyncio.CancelledError:
+                    logger.info("Telegram gateway stopped.")
+                    raise
+                except Exception:
+                    logger.exception(
+                        "Telegram poll error; retrying in %.1fs.",
+                        self._config.retry_delay,
+                    )
+                    await asyncio.sleep(self._config.retry_delay)
+
+    # ------------------------------------------------------------------
+    # Polling
+    # ------------------------------------------------------------------
+
+    async def _poll_once(self, client: httpx.AsyncClient) -> None:
+        params: dict[str, Any] = {
+            "offset": self._offset,
+            "timeout": self._config.poll_timeout,
+            "allowed_updates": ["message"],
+        }
+        resp = await client.get(self._api_url("getUpdates"), params=params)
+        resp.raise_for_status()
+        data = resp.json()
+        if not data.get("ok"):
+            logger.warning("getUpdates returned ok=false: %s", data)
+            return
+        for update in data.get("result", []):
+            self._offset = update["update_id"] + 1
+            await self._handle_update(client, update)
+
+    # ------------------------------------------------------------------
+    # Update handling
+    # ------------------------------------------------------------------
+
+    async def _handle_update(self, client: httpx.AsyncClient, update: dict[str, Any]) -> None:
+        message = update.get("message")
+        if not message:
+            return
+
+        chat_id: int = message["chat"]["id"]
+        if not self._is_allowed(chat_id):
+            logger.debug("Ignoring message from non-allowed chat_id %s.", chat_id)
+            return
+
+        text: str = message.get("text", "").strip()
+        if not text:
+            return
+
+        prompt = self._translate_command(text)
+        session_id = f"telegram:{chat_id}"
+
+        try:
+            await self._send_typing(client, chat_id)
+            response = await self._gateway.handle_message(session_id, prompt)
+        except Exception:
+            logger.exception("Error processing Telegram message from chat %s.", chat_id)
+            response = "Sorry, something went wrong. Please try again."
+
+        await self._send_message(client, chat_id, response or "(no response)")
+
+    def _is_allowed(self, chat_id: int) -> bool:
+        """Return True if *chat_id* is in the allow list (or the list is empty)."""
+        if not self._config.allowed_chat_ids:
+            return True
+        return chat_id in self._config.allowed_chat_ids
+
+    def _translate_command(self, text: str) -> str:
+        """Return the natural-language prompt for a slash command, or *text* as-is."""
+        if not text.startswith("/"):
+            return text
+        command = text.split()[0].lower()
+        return _SLASH_PROMPTS.get(command, text)
+
+    # ------------------------------------------------------------------
+    # Telegram API helpers
+    # ------------------------------------------------------------------
+
+    async def _send_typing(self, client: httpx.AsyncClient, chat_id: int) -> None:
+        """Send a typing indicator — best effort, errors are silenced."""
+        try:
+            await client.post(
+                self._api_url("sendChatAction"),
+                json={"chat_id": chat_id, "action": "typing"},
+            )
+        except Exception:
+            pass
+
+    async def _send_message(self, client: httpx.AsyncClient, chat_id: int, text: str) -> None:
+        """Send *text* to *chat_id*, truncating if it exceeds the API limit."""
+        limit = self._config.message_max_chars
+        if len(text) > limit:
+            text = text[: limit - 3] + "..."
+        try:
+            await client.post(
+                self._api_url("sendMessage"),
+                json={"chat_id": chat_id, "text": text},
+            )
+        except Exception:
+            logger.exception("Failed to send Telegram message to chat %s.", chat_id)
+
+    async def _register_commands(self, client: httpx.AsyncClient) -> None:
+        """Register slash commands with the Bot API (best effort)."""
+        try:
+            await client.post(
+                self._api_url("setMyCommands"),
+                json={"commands": _BOT_COMMANDS},
+            )
+            logger.debug("Telegram bot commands registered.")
+        except Exception:
+            logger.warning("Failed to register Telegram bot commands.")

--- a/src/ravn/cli/commands.py
+++ b/src/ravn/cli/commands.py
@@ -254,5 +254,148 @@ def approvals_revoke(
         raise typer.Exit(1)
 
 
+gateway_app = typer.Typer(
+    name="ravn-gateway",
+    help="Start the Ravn Pi-mode gateway (Telegram polling + local HTTP).",
+    add_completion=False,
+)
+
+
+@gateway_app.command()
+def gateway(
+    telegram: bool = typer.Option(False, "--telegram", help="Enable Telegram polling channel."),
+    http: bool = typer.Option(False, "--http", help="Enable local HTTP channel."),
+    config: str = typer.Option("", "--config", "-c", help="Path to ravn config YAML."),
+    persona: str = typer.Option(
+        "", "--persona", "-p", help="Persona name applied to all gateway sessions."
+    ),
+) -> None:
+    """Start the Ravn gateway (Telegram polling + local HTTP server).
+
+    Channels are enabled via flags or via the ``gateway:`` section of ravn.yaml.
+    The gateway runs as asyncio tasks — no separate process required.
+
+    Example config (ravn.yaml)::
+
+        gateway:
+          enabled: true
+          channels:
+            telegram:
+              enabled: true
+              token_env: TELEGRAM_BOT_TOKEN
+              allowed_chat_ids: [123456789]
+            http:
+              enabled: true
+              host: 0.0.0.0
+              port: 7477
+    """
+    import os
+
+    if config:
+        os.environ["RAVN_CONFIG"] = config
+
+    settings = Settings()
+    project_config = ProjectConfig.discover()
+    persona_config = _resolve_persona(persona, project_config)
+
+    # CLI flags override config file.
+    if telegram:
+        settings.gateway.channels.telegram.enabled = True
+    if http:
+        settings.gateway.channels.http.enabled = True
+
+    if (
+        not settings.gateway.channels.telegram.enabled
+        and not settings.gateway.channels.http.enabled
+    ):
+        typer.echo(
+            "No channels enabled. Use --telegram, --http, or set gateway.channels in config.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    asyncio.run(_run_gateway(settings, persona_config=persona_config))
+
+
+async def _run_gateway(
+    settings: Settings,
+    *,
+    persona_config: PersonaConfig | None = None,
+) -> None:
+    """Build and run the gateway until interrupted."""
+    from ravn.adapters.channels.gateway import RavnGateway
+    from ravn.adapters.channels.gateway_http import HttpGateway
+    from ravn.adapters.channels.gateway_telegram import TelegramGateway
+    from ravn.ports.channel import ChannelPort
+
+    api_key = settings.effective_api_key()
+    if not api_key:
+        typer.echo(
+            "Error: No API key found. Set ANTHROPIC_API_KEY or configure ravn.yaml.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    llm = AnthropicAdapter(
+        api_key=api_key,
+        base_url=settings.anthropic.base_url,
+        model=settings.agent.model,
+        max_tokens=settings.agent.max_tokens,
+        max_retries=settings.llm_adapter.max_retries,
+        retry_base_delay=settings.llm_adapter.retry_base_delay,
+        timeout=settings.llm_adapter.timeout,
+    )
+
+    system_prompt = settings.agent.system_prompt
+    max_iterations = settings.agent.max_iterations
+
+    if persona_config is not None:
+        if persona_config.system_prompt_template:
+            system_prompt = persona_config.system_prompt_template
+        if persona_config.iteration_budget:
+            max_iterations = persona_config.iteration_budget
+
+    def _agent_factory(channel: ChannelPort) -> RavnAgent:
+        return RavnAgent(
+            llm=llm,
+            tools=[],
+            channel=channel,
+            permission=AllowAllPermission(),
+            system_prompt=system_prompt,
+            model=settings.agent.model,
+            max_tokens=settings.agent.max_tokens,
+            max_iterations=max_iterations,
+        )
+
+    gw = RavnGateway(settings.gateway, _agent_factory)
+
+    tasks: list[asyncio.Task] = []
+
+    if settings.gateway.channels.telegram.enabled:
+        tg = TelegramGateway(settings.gateway.channels.telegram, gw)
+        tasks.append(asyncio.create_task(tg.run(), name="telegram"))
+
+    if settings.gateway.channels.http.enabled:
+        ht = HttpGateway(settings.gateway.channels.http, gw)
+        tasks.append(asyncio.create_task(ht.run(), name="http"))
+
+    typer.echo(f"Gateway started ({len(tasks)} channel(s) active). Press Ctrl+C to stop.")
+
+    try:
+        await asyncio.gather(*tasks)
+    except asyncio.CancelledError:
+        pass
+    except KeyboardInterrupt:
+        pass
+    finally:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
 def main() -> None:
     app()
+
+
+def gateway_main() -> None:
+    gateway_app()

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -769,6 +769,67 @@ class EvolutionConfig(BaseModel):
     )
 
 
+class TelegramChannelConfig(BaseModel):
+    """Telegram channel configuration."""
+
+    enabled: bool = Field(default=False)
+    token_env: str = Field(
+        default="TELEGRAM_BOT_TOKEN",
+        description="Environment variable name containing the Telegram bot token.",
+    )
+    allowed_chat_ids: list[int] = Field(
+        default_factory=list,
+        description="Chat IDs allowed to interact with the bot. Empty list means all.",
+    )
+    poll_timeout: int = Field(
+        default=30,
+        description="Long-poll timeout in seconds for getUpdates.",
+    )
+    retry_delay: float = Field(
+        default=5.0,
+        description="Seconds to wait after a poll error before retrying.",
+    )
+    message_max_chars: int = Field(
+        default=4096,
+        description="Maximum characters per outbound Telegram message (API limit).",
+    )
+
+
+class HttpChannelConfig(BaseModel):
+    """Local HTTP gateway channel configuration."""
+
+    enabled: bool = Field(default=False)
+    host: str = Field(
+        default="127.0.0.1",
+        description="Host/IP to bind the HTTP gateway server.",
+    )
+    port: int = Field(
+        default=7477,
+        description="TCP port for the HTTP gateway server.",
+    )
+
+
+class GatewayChannelsConfig(BaseModel):
+    """Per-channel gateway configuration."""
+
+    telegram: TelegramChannelConfig = Field(default_factory=TelegramChannelConfig)
+    http: HttpChannelConfig = Field(default_factory=HttpChannelConfig)
+
+
+class GatewayConfig(BaseModel):
+    """Pi-mode gateway — Telegram + local HTTP access without Kubernetes.
+
+    When enabled, Ravn runs two extra asyncio tasks:
+    - A Telegram long-poll loop (no webhook, no open inbound port required).
+    - A FastAPI HTTP server on localhost (or LAN IP).
+
+    Each channel+user pair gets its own isolated agent session.
+    """
+
+    enabled: bool = Field(default=False)
+    channels: GatewayChannelsConfig = Field(default_factory=GatewayChannelsConfig)
+
+
 class LoggingConfig(BaseModel):
     """Logging configuration."""
 
@@ -819,6 +880,9 @@ class Settings(BaseSettings):
 
     # NIU-501: self-improvement loop
     evolution: EvolutionConfig = Field(default_factory=EvolutionConfig)
+
+    # NIU-516: Pi-mode gateway
+    gateway: GatewayConfig = Field(default_factory=GatewayConfig)
 
     # Legacy — kept so existing CLI wiring (NIU-426) continues to work
     llm_adapter: LLMAdapterConfig = Field(default_factory=LLMAdapterConfig)

--- a/tests/test_ravn/test_bifrost_adapter.py
+++ b/tests/test_ravn/test_bifrost_adapter.py
@@ -575,7 +575,7 @@ async def test_bifrost_in_fallback_chain() -> None:
     from ravn.ports.llm import LLMPort
 
     class _StubLocal(LLMPort):
-        async def generate(self, messages, *, tools, system, model, max_tokens):
+        async def generate(self, messages, *, tools, system, model, max_tokens, thinking=None):
             from ravn.domain.models import LLMResponse, StopReason, TokenUsage
 
             return LLMResponse(
@@ -585,7 +585,7 @@ async def test_bifrost_in_fallback_chain() -> None:
                 usage=TokenUsage(input_tokens=1, output_tokens=1),
             )
 
-        async def stream(self, messages, *, tools, system, model, max_tokens):
+        async def stream(self, messages, *, tools, system, model, max_tokens, thinking=None):
             raise NotImplementedError
             yield  # make it an async generator
 

--- a/tests/test_ravn/test_gateway.py
+++ b/tests/test_ravn/test_gateway.py
@@ -1,0 +1,321 @@
+"""Tests for the gateway orchestrator (RavnGateway + GatewayChannel)."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from ravn.adapters.channels.gateway import (
+    AgentFactory,
+    GatewayChannel,
+    GatewaySession,
+    RavnGateway,
+)
+from ravn.config import GatewayConfig
+from ravn.domain.events import RavnEvent, RavnEventType
+from ravn.ports.channel import ChannelPort
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config() -> GatewayConfig:
+    return GatewayConfig()
+
+
+def _make_agent_factory(response: str = "Hello from agent") -> AgentFactory:
+    """Returns a factory that creates mock agents emitting a RESPONSE event."""
+
+    def factory(channel: ChannelPort) -> MagicMock:
+        agent = MagicMock()
+
+        async def run_turn(text: str):
+            await channel.emit(RavnEvent.response(response))
+
+        agent.run_turn = run_turn
+        return agent
+
+    return factory
+
+
+def _make_agent_factory_with_thought(thought: str, response: str) -> AgentFactory:
+    """Factory producing THOUGHT then RESPONSE events."""
+
+    def factory(channel: ChannelPort) -> MagicMock:
+        agent = MagicMock()
+
+        async def run_turn(text: str):
+            await channel.emit(RavnEvent.thought(thought))
+            await channel.emit(RavnEvent.response(response))
+
+        agent.run_turn = run_turn
+        return agent
+
+    return factory
+
+
+def _make_agent_factory_error(error_msg: str) -> AgentFactory:
+    """Factory producing an ERROR event."""
+
+    def factory(channel: ChannelPort) -> MagicMock:
+        agent = MagicMock()
+
+        async def run_turn(text: str):
+            await channel.emit(RavnEvent.error(error_msg))
+
+        agent.run_turn = run_turn
+        return agent
+
+    return factory
+
+
+# ---------------------------------------------------------------------------
+# GatewayChannel tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gateway_channel_emit_and_collect_response():
+    ch = GatewayChannel()
+    await ch.emit(RavnEvent.response("Hello!"))
+
+    result = await ch.collect_response()
+    assert result == "Hello!"
+
+
+@pytest.mark.asyncio
+async def test_gateway_channel_collect_response_on_error():
+    ch = GatewayChannel()
+    await ch.emit(RavnEvent.error("boom"))
+
+    result = await ch.collect_response()
+    assert result == "[error] boom"
+
+
+@pytest.mark.asyncio
+async def test_gateway_channel_collect_response_sentinel():
+    ch = GatewayChannel()
+    await ch.signal_done()
+
+    result = await ch.collect_response()
+    assert result == ""
+
+
+@pytest.mark.asyncio
+async def test_gateway_channel_collect_response_skips_thought():
+    """THOUGHT events are consumed but the RESPONSE data is used as the final answer."""
+    ch = GatewayChannel()
+    await ch.emit(RavnEvent.thought("thinking..."))
+    await ch.emit(RavnEvent.response("Final answer"))
+
+    result = await ch.collect_response()
+    assert result == "Final answer"
+
+
+@pytest.mark.asyncio
+async def test_gateway_channel_stream_yields_events_until_response():
+    ch = GatewayChannel()
+    await ch.emit(RavnEvent.thought("step 1"))
+    await ch.emit(RavnEvent.thought("step 2"))
+    await ch.emit(RavnEvent.response("Done"))
+
+    events: list[RavnEvent] = []
+    async for event in ch.stream():
+        events.append(event)
+
+    assert len(events) == 3
+    assert events[0].type == RavnEventType.THOUGHT
+    assert events[1].type == RavnEventType.THOUGHT
+    assert events[2].type == RavnEventType.RESPONSE
+
+
+@pytest.mark.asyncio
+async def test_gateway_channel_stream_stops_on_error():
+    ch = GatewayChannel()
+    await ch.emit(RavnEvent.error("oops"))
+    await ch.emit(RavnEvent.thought("should not appear"))
+
+    events: list[RavnEvent] = []
+    async for event in ch.stream():
+        events.append(event)
+
+    assert len(events) == 1
+    assert events[0].type == RavnEventType.ERROR
+
+
+@pytest.mark.asyncio
+async def test_gateway_channel_stream_stops_on_sentinel():
+    ch = GatewayChannel()
+    await ch.emit(RavnEvent.thought("t"))
+    await ch.signal_done()
+
+    events: list[RavnEvent] = []
+    async for event in ch.stream():
+        events.append(event)
+
+    assert len(events) == 1
+
+
+@pytest.mark.asyncio
+async def test_gateway_channel_broadcast_callback_called():
+    received: list[RavnEvent] = []
+
+    async def cb(event: RavnEvent) -> None:
+        received.append(event)
+
+    ch = GatewayChannel(broadcast_cb=cb)
+    evt = RavnEvent.response("hi")
+    await ch.emit(evt)
+
+    assert received == [evt]
+
+
+@pytest.mark.asyncio
+async def test_gateway_channel_no_broadcast_callback():
+    """Channel without callback must not raise."""
+    ch = GatewayChannel()
+    await ch.emit(RavnEvent.response("ok"))
+    result = await ch.collect_response()
+    assert result == "ok"
+
+
+# ---------------------------------------------------------------------------
+# RavnGateway.get_or_create_session
+# ---------------------------------------------------------------------------
+
+
+def test_gateway_creates_new_session():
+    gw = RavnGateway(_make_config(), _make_agent_factory())
+    s1 = gw.get_or_create_session("telegram:1")
+    assert isinstance(s1, GatewaySession)
+    assert "telegram:1" in gw.session_ids()
+
+
+def test_gateway_returns_same_session_on_second_call():
+    gw = RavnGateway(_make_config(), _make_agent_factory())
+    s1 = gw.get_or_create_session("telegram:1")
+    s2 = gw.get_or_create_session("telegram:1")
+    assert s1 is s2
+
+
+def test_gateway_separate_sessions_for_different_ids():
+    gw = RavnGateway(_make_config(), _make_agent_factory())
+    s1 = gw.get_or_create_session("telegram:1")
+    s2 = gw.get_or_create_session("telegram:2")
+    assert s1 is not s2
+    assert len(gw.session_ids()) == 2
+
+
+# ---------------------------------------------------------------------------
+# RavnGateway.handle_message
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gateway_handle_message_returns_response():
+    gw = RavnGateway(_make_config(), _make_agent_factory("Hello!"))
+    result = await gw.handle_message("s1", "hi")
+    assert result == "Hello!"
+
+
+@pytest.mark.asyncio
+async def test_gateway_handle_message_with_thought_and_response():
+    gw = RavnGateway(
+        _make_config(),
+        _make_agent_factory_with_thought("thinking", "Done"),
+    )
+    result = await gw.handle_message("s1", "go")
+    assert result == "Done"
+
+
+@pytest.mark.asyncio
+async def test_gateway_handle_message_error_response():
+    gw = RavnGateway(_make_config(), _make_agent_factory_error("fail"))
+    result = await gw.handle_message("s1", "hi")
+    assert result == "[error] fail"
+
+
+@pytest.mark.asyncio
+async def test_gateway_handle_message_serialises_concurrent_calls():
+    """Two concurrent calls to the same session should not interleave."""
+    order: list[str] = []
+
+    def factory(channel: ChannelPort) -> MagicMock:
+        agent = MagicMock()
+
+        async def run_turn(text: str):
+            order.append(f"start:{text}")
+            await asyncio.sleep(0)
+            await channel.emit(RavnEvent.response(f"resp:{text}"))
+            order.append(f"end:{text}")
+
+        agent.run_turn = run_turn
+        return agent
+
+    gw = RavnGateway(_make_config(), factory)
+    await asyncio.gather(
+        gw.handle_message("s1", "a"),
+        gw.handle_message("s1", "b"),
+    )
+    # Turns must not interleave — each must fully complete before the next.
+    a_done_before_b = order.index("end:a") < order.index("start:b")
+    b_done_before_a = order.index("end:b") < order.index("start:a")
+    assert a_done_before_b or b_done_before_a
+
+
+# ---------------------------------------------------------------------------
+# RavnGateway.handle_message_stream
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gateway_handle_message_stream_yields_events():
+    gw = RavnGateway(
+        _make_config(),
+        _make_agent_factory_with_thought("t", "r"),
+    )
+    events: list[RavnEvent] = []
+    async for event in gw.handle_message_stream("s1", "go"):
+        events.append(event)
+
+    types = [e.type for e in events]
+    assert RavnEventType.THOUGHT in types
+    assert RavnEventType.RESPONSE in types
+
+
+# ---------------------------------------------------------------------------
+# RavnGateway subscribe / unsubscribe / broadcast
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gateway_broadcast_reaches_subscriber():
+    gw = RavnGateway(_make_config(), _make_agent_factory("hi"))
+    q = gw.subscribe()
+
+    await gw.handle_message("s1", "hello")
+
+    # At least one event should have been broadcast (the RESPONSE event).
+    assert not q.empty()
+    event = q.get_nowait()
+    assert event is not None
+
+
+@pytest.mark.asyncio
+async def test_gateway_unsubscribe_removes_queue():
+    gw = RavnGateway(_make_config(), _make_agent_factory("hi"))
+    q = gw.subscribe()
+    gw.unsubscribe(q)
+
+    await gw.handle_message("s1", "hello")
+    assert q.empty()
+
+
+def test_gateway_unsubscribe_unknown_queue_is_safe():
+    gw = RavnGateway(_make_config(), _make_agent_factory())
+    q: asyncio.Queue = asyncio.Queue()
+    # Should not raise even if q was never subscribed.
+    gw.unsubscribe(q)

--- a/tests/test_ravn/test_gateway_http.py
+++ b/tests/test_ravn/test_gateway_http.py
@@ -1,0 +1,210 @@
+"""Tests for the HTTP gateway adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator
+from unittest.mock import MagicMock
+
+from fastapi.testclient import TestClient
+
+from ravn.adapters.channels.gateway import RavnGateway
+from ravn.adapters.channels.gateway_http import ChatRequest, HttpGateway
+from ravn.config import HttpChannelConfig
+from ravn.domain.events import RavnEvent
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_http_config(host: str = "127.0.0.1", port: int = 7477) -> HttpChannelConfig:
+    return HttpChannelConfig(enabled=True, host=host, port=port)
+
+
+def _make_gateway_mock(response: str = "agent reply") -> RavnGateway:
+    """Return a mock RavnGateway that returns a canned response."""
+    gw = MagicMock(spec=RavnGateway)
+    gw.session_ids.return_value = ["http:default"]
+
+    async def handle_stream(session_id: str, message: str) -> AsyncIterator[RavnEvent]:
+        yield RavnEvent.thought("thinking...")
+        yield RavnEvent.response(response)
+
+    gw.handle_message_stream = handle_stream
+
+    async def broadcast_stream():
+        yield RavnEvent.response("broadcast")
+
+    q: asyncio.Queue = asyncio.Queue()
+    gw.subscribe.return_value = q
+    gw.unsubscribe = MagicMock()
+    return gw
+
+
+def _make_http_gateway(gw: RavnGateway | None = None) -> HttpGateway:
+    if gw is None:
+        gw = _make_gateway_mock()
+    return HttpGateway(_make_http_config(), gw)
+
+
+def _get_test_client(gateway: HttpGateway | None = None) -> TestClient:
+    gw_obj = _make_http_gateway(gateway)
+    return TestClient(gw_obj.app, raise_server_exceptions=True)
+
+
+# ---------------------------------------------------------------------------
+# GET /status
+# ---------------------------------------------------------------------------
+
+
+def test_status_endpoint_returns_session_info():
+    client = _get_test_client()
+    resp = client.get("/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "session_count" in data
+    assert "active_sessions" in data
+    assert data["session_count"] == 1
+
+
+def test_status_endpoint_no_sessions():
+    gw = MagicMock(spec=RavnGateway)
+    gw.session_ids.return_value = []
+    ht = HttpGateway(_make_http_config(), gw)
+    client = TestClient(ht.app)
+    resp = client.get("/status")
+    assert resp.status_code == 200
+    assert resp.json()["session_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# POST /chat
+# ---------------------------------------------------------------------------
+
+
+def test_chat_endpoint_returns_sse_stream():
+    client = _get_test_client()
+    resp = client.post(
+        "/chat",
+        json={"message": "hello", "session_id": "http:default"},
+    )
+    assert resp.status_code == 200
+    assert "text/event-stream" in resp.headers["content-type"]
+
+
+def test_chat_endpoint_streams_events():
+    client = _get_test_client()
+    resp = client.post(
+        "/chat",
+        json={"message": "hello"},
+    )
+    body = resp.text
+    # Should contain SSE data lines
+    assert "data: " in body
+    lines = [ln for ln in body.splitlines() if ln.startswith("data: ")]
+    assert len(lines) >= 1
+
+    # Each line must be valid JSON
+    for line in lines:
+        payload = json.loads(line[len("data: ") :])
+        assert "type" in payload
+        assert "data" in payload
+
+
+def test_chat_endpoint_includes_thought_and_response():
+    client = _get_test_client()
+    resp = client.post("/chat", json={"message": "hi"})
+
+    lines = [ln for ln in resp.text.splitlines() if ln.startswith("data: ")]
+    types = [json.loads(ln[len("data: ") :])["type"] for ln in lines]
+
+    assert "thought" in types
+    assert "response" in types
+
+
+def test_chat_endpoint_default_session_id():
+    """Omitting session_id uses 'http:default'."""
+    gw = MagicMock(spec=RavnGateway)
+    gw.session_ids.return_value = []
+
+    async def handle_stream(session_id: str, message: str) -> AsyncIterator[RavnEvent]:
+        assert session_id == "http:default"
+        yield RavnEvent.response("ok")
+
+    gw.handle_message_stream = handle_stream
+
+    ht = HttpGateway(_make_http_config(), gw)
+    client = TestClient(ht.app)
+    resp = client.post("/chat", json={"message": "hi"})
+    assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# GET /events
+# ---------------------------------------------------------------------------
+
+
+def test_events_endpoint_returns_sse():
+    """GET /events returns text/event-stream with correct SSE framing."""
+    gw = MagicMock(spec=RavnGateway)
+
+    ht = HttpGateway(_make_http_config(), gw)
+
+    # Patch _broadcast_stream to yield one event and return so the
+    # TestClient receives a finite response instead of blocking forever.
+    async def finite_broadcast():
+        payload = '{"type": "response", "data": "hi", "metadata": {}}'
+        yield f"data: {payload}\n\n"
+
+    ht._broadcast_stream = finite_broadcast
+
+    client = TestClient(ht.app)
+    resp = client.get("/events")
+    assert resp.status_code == 200
+    assert "text/event-stream" in resp.headers["content-type"]
+    assert "data: " in resp.text
+
+
+# ---------------------------------------------------------------------------
+# HttpGateway.app property
+# ---------------------------------------------------------------------------
+
+
+def test_app_property_returns_fastapi_app():
+    from fastapi import FastAPI
+
+    ht = _make_http_gateway()
+    assert isinstance(ht.app, FastAPI)
+
+
+# ---------------------------------------------------------------------------
+# ChatRequest schema
+# ---------------------------------------------------------------------------
+
+
+def test_chat_request_default_session_id():
+    req = ChatRequest(message="hi")
+    assert req.session_id == "http:default"
+
+
+def test_chat_request_custom_session_id():
+    req = ChatRequest(message="hi", session_id="my-session")
+    assert req.session_id == "my-session"
+
+
+# ---------------------------------------------------------------------------
+# SSE format helpers
+# ---------------------------------------------------------------------------
+
+
+def test_sse_payload_contains_metadata():
+    """Verify metadata field is present in streamed events."""
+    client = _get_test_client()
+    resp = client.post("/chat", json={"message": "hi"})
+
+    lines = [ln for ln in resp.text.splitlines() if ln.startswith("data: ")]
+    for line in lines:
+        payload = json.loads(line[len("data: ") :])
+        assert "metadata" in payload

--- a/tests/test_ravn/test_gateway_http.py
+++ b/tests/test_ravn/test_gateway_http.py
@@ -7,6 +7,7 @@ import json
 from collections.abc import AsyncIterator
 from unittest.mock import MagicMock
 
+import pytest
 from fastapi.testclient import TestClient
 
 from ravn.adapters.channels.gateway import RavnGateway
@@ -208,3 +209,81 @@ def test_sse_payload_contains_metadata():
     for line in lines:
         payload = json.loads(line[len("data: ") :])
         assert "metadata" in payload
+
+
+# ---------------------------------------------------------------------------
+# _broadcast_stream — real queue-based implementation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_broadcast_stream_yields_events_from_queue():
+    """_broadcast_stream reads real events from the subscribe queue."""
+    gw = MagicMock(spec=RavnGateway)
+    q: asyncio.Queue = asyncio.Queue()
+    gw.subscribe.return_value = q
+    gw.unsubscribe = MagicMock()
+
+    ht = HttpGateway(_make_http_config(), gw)
+
+    # Push one event then the sentinel None.
+    event = RavnEvent.response("broadcast msg")
+    await q.put(event)
+    await q.put(None)
+
+    lines = []
+    async for chunk in ht._broadcast_stream():
+        lines.append(chunk)
+
+    gw.unsubscribe.assert_called_once_with(q)
+    assert len(lines) == 1
+    payload = json.loads(lines[0][len("data: ") :])
+    assert payload["data"] == "broadcast msg"
+
+
+@pytest.mark.asyncio
+async def test_broadcast_stream_unsubscribes_on_exit():
+    """unsubscribe is called even if the loop is exited via sentinel."""
+    gw = MagicMock(spec=RavnGateway)
+    q: asyncio.Queue = asyncio.Queue()
+    gw.subscribe.return_value = q
+    gw.unsubscribe = MagicMock()
+
+    ht = HttpGateway(_make_http_config(), gw)
+    await q.put(None)
+
+    async for _ in ht._broadcast_stream():
+        pass
+
+    gw.unsubscribe.assert_called_once_with(q)
+
+
+# ---------------------------------------------------------------------------
+# run() — uvicorn lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_starts_and_cancels_cleanly(monkeypatch):
+    """run() wires up uvicorn and re-raises CancelledError."""
+    import uvicorn
+
+    served = []
+
+    class FakeServer:
+        def __init__(self, config):
+            pass
+
+        async def serve(self):
+            served.append(True)
+            raise asyncio.CancelledError()
+
+    monkeypatch.setattr(uvicorn, "Server", FakeServer)
+
+    gw = MagicMock(spec=RavnGateway)
+    ht = HttpGateway(_make_http_config(), gw)
+
+    with pytest.raises(asyncio.CancelledError):
+        await ht.run()
+
+    assert served

--- a/tests/test_ravn/test_gateway_telegram.py
+++ b/tests/test_ravn/test_gateway_telegram.py
@@ -1,0 +1,337 @@
+"""Tests for the Telegram gateway adapter."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from ravn.adapters.channels.gateway_telegram import (
+    _BOT_COMMANDS,
+    _SLASH_PROMPTS,
+    TelegramGateway,
+)
+from ravn.config import TelegramChannelConfig
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(
+    allowed_chat_ids: list[int] | None = None,
+    token_env: str = "TG_TOKEN",
+) -> TelegramChannelConfig:
+    return TelegramChannelConfig(
+        enabled=True,
+        token_env=token_env,
+        allowed_chat_ids=allowed_chat_ids or [],
+        poll_timeout=1,
+        retry_delay=0.01,
+        message_max_chars=4096,
+    )
+
+
+def _make_gateway_mock(response: str = "agent reply") -> MagicMock:
+    gw = MagicMock()
+    gw.handle_message = AsyncMock(return_value=response)
+    return gw
+
+
+def _make_update(
+    update_id: int,
+    chat_id: int,
+    text: str,
+) -> dict[str, Any]:
+    return {
+        "update_id": update_id,
+        "message": {
+            "chat": {"id": chat_id},
+            "text": text,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# _is_allowed
+# ---------------------------------------------------------------------------
+
+
+def test_is_allowed_empty_list_permits_all():
+    cfg = _make_config(allowed_chat_ids=[])
+    tg = TelegramGateway(cfg, _make_gateway_mock())
+    assert tg._is_allowed(999999) is True
+
+
+def test_is_allowed_with_list_permits_listed():
+    cfg = _make_config(allowed_chat_ids=[111, 222])
+    tg = TelegramGateway(cfg, _make_gateway_mock())
+    assert tg._is_allowed(111) is True
+    assert tg._is_allowed(333) is False
+
+
+# ---------------------------------------------------------------------------
+# _translate_command
+# ---------------------------------------------------------------------------
+
+
+def test_translate_command_plain_text_unchanged():
+    tg = TelegramGateway(_make_config(), _make_gateway_mock())
+    assert tg._translate_command("hello world") == "hello world"
+
+
+@pytest.mark.parametrize("cmd", ["/stop", "/status", "/todo", "/budget"])
+def test_translate_command_slash_commands(cmd: str):
+    tg = TelegramGateway(_make_config(), _make_gateway_mock())
+    prompt = tg._translate_command(cmd)
+    assert prompt == _SLASH_PROMPTS[cmd]
+
+
+def test_translate_command_unknown_slash_passthrough():
+    tg = TelegramGateway(_make_config(), _make_gateway_mock())
+    assert tg._translate_command("/unknown") == "/unknown"
+
+
+def test_translate_command_slash_with_args():
+    tg = TelegramGateway(_make_config(), _make_gateway_mock())
+    # /status with extra args — command is matched, prompt returned
+    result = tg._translate_command("/status extra args")
+    assert result == _SLASH_PROMPTS["/status"]
+
+
+# ---------------------------------------------------------------------------
+# run() — token not set
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_returns_early_when_no_token(caplog):
+    cfg = _make_config(token_env="RAVN_TEST_MISSING_TOKEN_XYZ")
+    tg = TelegramGateway(cfg, _make_gateway_mock())
+    import logging
+
+    with caplog.at_level(logging.ERROR):
+        await tg.run()
+
+    assert "RAVN_TEST_MISSING_TOKEN_XYZ" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# _handle_update
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_update_dispatches_to_gateway(monkeypatch):
+    monkeypatch.setenv("TG_TOKEN", "test-token")
+    gw = _make_gateway_mock("hello")
+    cfg = _make_config(allowed_chat_ids=[42])
+    tg = TelegramGateway(cfg, gw)
+    tg._token = "test-token"
+
+    client = AsyncMock()
+    client.post = AsyncMock(return_value=MagicMock(raise_for_status=MagicMock()))
+
+    update = _make_update(1, 42, "hello bot")
+    await tg._handle_update(client, update)
+
+    gw.handle_message.assert_awaited_once_with("telegram:42", "hello bot")
+    # sendMessage should have been called
+    send_calls = [call for call in client.post.call_args_list if "sendMessage" in str(call)]
+    assert len(send_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_handle_update_ignores_disallowed_chat(monkeypatch):
+    gw = _make_gateway_mock()
+    cfg = _make_config(allowed_chat_ids=[111])
+    tg = TelegramGateway(cfg, gw)
+    tg._token = "test-token"
+
+    client = AsyncMock()
+    update = _make_update(1, 999, "hello")
+    await tg._handle_update(client, update)
+
+    gw.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_update_skips_non_text_message():
+    gw = _make_gateway_mock()
+    tg = TelegramGateway(_make_config(), gw)
+    tg._token = "test-token"
+
+    client = AsyncMock()
+    update = {
+        "update_id": 1,
+        "message": {"chat": {"id": 1}, "text": ""},
+    }
+    await tg._handle_update(client, update)
+
+    gw.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_update_skips_missing_message():
+    gw = _make_gateway_mock()
+    tg = TelegramGateway(_make_config(), gw)
+    tg._token = "test-token"
+
+    client = AsyncMock()
+    await tg._handle_update(client, {"update_id": 1})
+
+    gw.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_update_translates_slash_command():
+    gw = _make_gateway_mock("ok")
+    tg = TelegramGateway(_make_config(), gw)
+    tg._token = "test-token"
+
+    client = AsyncMock()
+    client.post = AsyncMock(return_value=MagicMock(raise_for_status=MagicMock()))
+
+    update = _make_update(1, 1, "/status")
+    await tg._handle_update(client, update)
+
+    called_text = gw.handle_message.call_args[0][1]
+    assert "status" in called_text.lower()
+
+
+@pytest.mark.asyncio
+async def test_handle_update_sends_error_message_on_agent_exception():
+    gw = MagicMock()
+    gw.handle_message = AsyncMock(side_effect=RuntimeError("agent crash"))
+    tg = TelegramGateway(_make_config(), gw)
+    tg._token = "test-token"
+
+    client = AsyncMock()
+    client.post = AsyncMock(return_value=MagicMock(raise_for_status=MagicMock()))
+
+    update = _make_update(1, 1, "hi")
+    await tg._handle_update(client, update)
+
+    # Still sends a message (the error fallback)
+    assert client.post.called
+
+
+# ---------------------------------------------------------------------------
+# _send_message truncation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_message_truncates_long_text():
+    tg = TelegramGateway(_make_config(token_env="TK"), _make_gateway_mock())
+    tg._token = "test-token"
+
+    client = AsyncMock()
+    client.post = AsyncMock(return_value=MagicMock())
+
+    long_text = "x" * 5000
+    await tg._send_message(client, 1, long_text)
+
+    sent_text = client.post.call_args[1]["json"]["text"]
+    assert len(sent_text) <= 4096
+    assert sent_text.endswith("...")
+
+
+@pytest.mark.asyncio
+async def test_send_message_short_text_unchanged():
+    tg = TelegramGateway(_make_config(token_env="TK"), _make_gateway_mock())
+    tg._token = "test-token"
+
+    client = AsyncMock()
+    client.post = AsyncMock(return_value=MagicMock())
+
+    await tg._send_message(client, 1, "hi")
+    sent_text = client.post.call_args[1]["json"]["text"]
+    assert sent_text == "hi"
+
+
+# ---------------------------------------------------------------------------
+# _poll_once — offset tracking
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_poll_once_advances_offset():
+    gw = _make_gateway_mock("ok")
+    tg = TelegramGateway(_make_config(), gw)
+    tg._token = "test-token"
+
+    client = AsyncMock()
+    client.get = AsyncMock(
+        return_value=MagicMock(
+            raise_for_status=MagicMock(),
+            json=MagicMock(
+                return_value={
+                    "ok": True,
+                    "result": [_make_update(10, 1, "hi"), _make_update(11, 1, "bye")],
+                }
+            ),
+        )
+    )
+    client.post = AsyncMock(return_value=MagicMock(raise_for_status=MagicMock()))
+
+    await tg._poll_once(client)
+
+    assert tg._offset == 12  # last update_id + 1
+
+
+@pytest.mark.asyncio
+async def test_poll_once_handles_not_ok_response():
+    gw = _make_gateway_mock()
+    tg = TelegramGateway(_make_config(), gw)
+    tg._token = "test-token"
+
+    client = AsyncMock()
+    client.get = AsyncMock(
+        return_value=MagicMock(
+            raise_for_status=MagicMock(),
+            json=MagicMock(return_value={"ok": False, "description": "Bad token"}),
+        )
+    )
+
+    await tg._poll_once(client)
+
+    gw.handle_message.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# _register_commands
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_commands_posts_commands():
+    tg = TelegramGateway(_make_config(token_env="TK"), _make_gateway_mock())
+    tg._token = "test-token"
+
+    client = AsyncMock()
+    client.post = AsyncMock(return_value=MagicMock())
+
+    await tg._register_commands(client)
+
+    assert client.post.called
+    posted_body = client.post.call_args[1]["json"]
+    assert "commands" in posted_body
+    assert len(posted_body["commands"]) == len(_BOT_COMMANDS)
+
+
+@pytest.mark.asyncio
+async def test_register_commands_swallows_exception(caplog):
+    import logging
+
+    tg = TelegramGateway(_make_config(token_env="TK"), _make_gateway_mock())
+    tg._token = "test-token"
+
+    client = AsyncMock()
+    client.post = AsyncMock(side_effect=httpx.ConnectError("fail"))
+
+    with caplog.at_level(logging.WARNING):
+        await tg._register_commands(client)
+    # Should not raise; warning logged instead.

--- a/tests/test_ravn/test_gateway_telegram.py
+++ b/tests/test_ravn/test_gateway_telegram.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -335,3 +336,116 @@ async def test_register_commands_swallows_exception(caplog):
     with caplog.at_level(logging.WARNING):
         await tg._register_commands(client)
     # Should not raise; warning logged instead.
+
+
+# ---------------------------------------------------------------------------
+# _send_typing — exception silencing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_typing_swallows_exception():
+    tg = TelegramGateway(_make_config(), _make_gateway_mock())
+    tg._token = "test-token"
+
+    client = AsyncMock()
+    client.post = AsyncMock(side_effect=httpx.ConnectError("fail"))
+
+    # Should not raise
+    await tg._send_typing(client, 42)
+
+
+# ---------------------------------------------------------------------------
+# _send_message — exception logging
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_message_logs_on_exception(caplog):
+    import logging
+
+    tg = TelegramGateway(_make_config(token_env="TK"), _make_gateway_mock())
+    tg._token = "test-token"
+
+    client = AsyncMock()
+    client.post = AsyncMock(side_effect=httpx.ConnectError("network fail"))
+
+    with caplog.at_level(logging.ERROR):
+        await tg._send_message(client, 99, "hello")
+
+    assert "99" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# run() — main polling loop (with token set)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_cancels_cleanly(monkeypatch):
+    """run() exits cleanly when the task is cancelled after one poll."""
+    monkeypatch.setenv("TG_TOKEN", "test-token")
+
+    gw = _make_gateway_mock("ok")
+    cfg = _make_config(token_env="TG_TOKEN")
+    tg = TelegramGateway(cfg, gw)
+    tg._token = "test-token"
+
+    poll_count = 0
+
+    async def fake_poll_once(client):
+        nonlocal poll_count
+        poll_count += 1
+        raise asyncio.CancelledError()
+
+    tg._poll_once = fake_poll_once
+
+    # Patch _register_commands so it doesn't need a real HTTP client.
+    async def fake_register(client):
+        pass
+
+    tg._register_commands = fake_register
+
+    with pytest.raises(asyncio.CancelledError):
+        await tg.run()
+
+    assert poll_count == 1
+
+
+@pytest.mark.asyncio
+async def test_run_retries_on_exception(monkeypatch):
+    """run() retries after a non-cancel exception."""
+    monkeypatch.setenv("TG_TOKEN", "test-token")
+
+    gw = _make_gateway_mock("ok")
+    cfg = TelegramChannelConfig(
+        enabled=True,
+        token_env="TG_TOKEN",
+        allowed_chat_ids=[],
+        poll_timeout=1,
+        retry_delay=0.0,
+        message_max_chars=4096,
+    )
+    tg = TelegramGateway(cfg, gw)
+    tg._token = "test-token"
+
+    call_count = 0
+
+    async def fake_poll_once(client):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError("transient error")
+        raise asyncio.CancelledError()
+
+    tg._poll_once = fake_poll_once
+
+    async def fake_register(client):
+        pass
+
+    tg._register_commands = fake_register
+
+    with pytest.raises(asyncio.CancelledError):
+        await tg.run()
+
+    assert call_count == 2


### PR DESCRIPTION
## Summary

Implements NIU-516: a self-contained gateway that lets you talk to Ravn from a phone or script without Kubernetes, Sleipnir, or any broker. Designed to work on a Raspberry Pi with just a network connection.

### New files
- **`src/ravn/adapters/channels/gateway.py`** — `GatewayChannel` (ChannelPort implementation that queues events) + `RavnGateway` (session manager + broadcast bus)
- **`src/ravn/adapters/channels/gateway_telegram.py`** — Telegram long-poll adapter: no webhook, no open inbound port, works behind NAT
- **`src/ravn/adapters/channels/gateway_http.py`** — FastAPI HTTP adapter: `POST /chat` (SSE stream), `GET /status`, `GET /events` (broadcast SSE)

### Modified files
- **`src/ravn/config.py`** — `TelegramChannelConfig`, `HttpChannelConfig`, `GatewayChannelsConfig`, `GatewayConfig` + `gateway` field on `Settings`
- **`src/ravn/cli/commands.py`** — `ravn-gateway` entry point (`gateway_app` Typer) with `--telegram` / `--http` flags; kept as a separate app to preserve single-command routing for `ravn run`
- **`pyproject.toml`** — `ravn-gateway` script entry point

### Tests
- `tests/test_ravn/test_gateway.py` — 20 tests for `GatewayChannel` and `RavnGateway`
- `tests/test_ravn/test_gateway_telegram.py` — 22 tests for `TelegramGateway`
- `tests/test_ravn/test_gateway_http.py` — 11 tests for `HttpGateway`

## Key design decisions

- **Zero extra infrastructure** — pure outbound polling, no webhook, no Redis, no broker
- **Per-session isolation** — each `(channel, user_id)` pair gets its own `RavnAgent` with its own conversation history; concurrent calls serialised via `asyncio.Lock`
- **Broadcast bus** — `GET /events` subscribers receive all events from all sessions via fan-out queues on `RavnGateway`
- **Separate CLI entry point** — `ravn-gateway` vs `ravn gateway` subcommand to keep Typer single-command routing intact for existing `ravn run` tests
- **Config-first** — all timing values (poll timeout, retry delay, message limits, port) in `GatewayConfig` with sensible defaults

## Pi config example
```yaml
gateway:
  enabled: true
  channels:
    telegram:
      enabled: true
      token_env: TELEGRAM_BOT_TOKEN
      allowed_chat_ids: [123456789]
    http:
      enabled: true
      host: 0.0.0.0
      port: 7477
```

## Test plan
- [x] 53 new tests (test_gateway, test_gateway_telegram, test_gateway_http) — all pass
- [x] Full suite: 2371 passed, 0 failures
- [x] Coverage: 94.48% (threshold: 85%)
- [x] ruff check — clean
- [x] ruff format — applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)