### PR TITLE
fix(adapters): review fixes for NIU-485 PG accounting/audit

### DIFF
--- a/src/bifrost/adapters/_sql_helpers.py
+++ b/src/bifrost/adapters/_sql_helpers.py
@@ -6,6 +6,11 @@ from datetime import UTC, datetime
 from typing import Any
 
 
+def filter_pairs(**kwargs: Any) -> list[tuple[str, Any]]:
+    """Build *(column, value)* pairs, discarding ``None`` values."""
+    return [(k, v) for k, v in kwargs.items() if v is not None]
+
+
 def to_utc(dt: datetime) -> datetime:
     """Normalise *dt* to UTC."""
     return dt.astimezone(UTC)

--- a/src/bifrost/adapters/accounting/postgres.py
+++ b/src/bifrost/adapters/accounting/postgres.py
@@ -12,14 +12,14 @@ Connection string is resolved in priority order:
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from datetime import UTC, datetime
+from typing import Any
 
 import asyncpg
 
 from bifrost.adapters._pg_base import PostgresBase
-from bifrost.adapters._sql_helpers import build_where_with_range, to_utc
+from bifrost.adapters._sql_helpers import build_where_with_range, filter_pairs, to_utc
 from bifrost.ports.accounting import (
     AccountingPort,
     AccountingSummary,
@@ -93,15 +93,8 @@ def _filters(
     agent_id: str | None,
     tenant_id: str | None,
     model: str | None,
-) -> list[tuple[str, str]]:
-    pairs: list[tuple[str, str]] = []
-    if agent_id is not None:
-        pairs.append(("agent_id", agent_id))
-    if tenant_id is not None:
-        pairs.append(("tenant_id", tenant_id))
-    if model is not None:
-        pairs.append(("model", model))
-    return pairs
+) -> list[tuple[str, Any]]:
+    return filter_pairs(agent_id=agent_id, tenant_id=tenant_id, model=model)
 
 
 class PostgresAccountingAdapter(PostgresBase, AccountingPort):
@@ -193,23 +186,21 @@ class PostgresAccountingAdapter(PostgresBase, AccountingPort):
         )
         pool = await self._get_pool()
         async with pool.acquire() as conn:
-            totals, model_rows, provider_rows = await asyncio.gather(
-                conn.fetchrow(
-                    f"SELECT COUNT(*), SUM(input_tokens), SUM(output_tokens), SUM(cost_usd) "
-                    f"FROM bifrost_requests {where}",
-                    *params,
-                ),
-                conn.fetch(
-                    f"SELECT model, COUNT(*), SUM(input_tokens), SUM(output_tokens), SUM(cost_usd) "
-                    f"FROM bifrost_requests {where} GROUP BY model",
-                    *params,
-                ),
-                conn.fetch(
-                    f"SELECT provider, COUNT(*), SUM(input_tokens),"
-                    f" SUM(output_tokens), SUM(cost_usd) "
-                    f"FROM bifrost_requests {where} GROUP BY provider",
-                    *params,
-                ),
+            totals = await conn.fetchrow(
+                f"SELECT COUNT(*), SUM(input_tokens), SUM(output_tokens), SUM(cost_usd) "
+                f"FROM bifrost_requests {where}",
+                *params,
+            )
+            model_rows = await conn.fetch(
+                f"SELECT model, COUNT(*), SUM(input_tokens), SUM(output_tokens), SUM(cost_usd) "
+                f"FROM bifrost_requests {where} GROUP BY model",
+                *params,
+            )
+            provider_rows = await conn.fetch(
+                f"SELECT provider, COUNT(*), SUM(input_tokens),"
+                f" SUM(output_tokens), SUM(cost_usd) "
+                f"FROM bifrost_requests {where} GROUP BY provider",
+                *params,
             )
 
         summary = AccountingSummary(

--- a/src/bifrost/adapters/audit/postgres.py
+++ b/src/bifrost/adapters/audit/postgres.py
@@ -15,11 +15,12 @@ from __future__ import annotations
 import json
 import logging
 from datetime import UTC, datetime
+from typing import Any
 
 import asyncpg
 
 from bifrost.adapters._pg_base import PostgresBase
-from bifrost.adapters._sql_helpers import build_where_with_range, to_utc
+from bifrost.adapters._sql_helpers import build_where_with_range, filter_pairs, to_utc
 from bifrost.ports.audit import AuditEvent, AuditPort
 
 logger = logging.getLogger(__name__)
@@ -88,17 +89,10 @@ def _filters(
     tenant_id: str | None,
     model: str | None,
     outcome: str | None,
-) -> list[tuple[str, str]]:
-    pairs: list[tuple[str, str]] = []
-    if agent_id is not None:
-        pairs.append(("agent_id", agent_id))
-    if tenant_id is not None:
-        pairs.append(("tenant_id", tenant_id))
-    if model is not None:
-        pairs.append(("model", model))
-    if outcome is not None:
-        pairs.append(("outcome", outcome))
-    return pairs
+) -> list[tuple[str, Any]]:
+    return filter_pairs(
+        agent_id=agent_id, tenant_id=tenant_id, model=model, outcome=outcome,
+    )
 
 
 class PostgresAuditAdapter(PostgresBase, AuditPort):

--- a/tests/test_bifrost/conftest.py
+++ b/tests/test_bifrost/conftest.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -37,6 +37,24 @@ def make_response(
         stop_reason="end_turn",
         usage=UsageInfo(input_tokens=input_tokens, output_tokens=output_tokens),
     )
+
+
+def make_pool_mock():
+    """Return a mocked asyncpg pool that works as an async context manager."""
+    conn = AsyncMock()
+    conn.execute = AsyncMock(return_value=None)
+    conn.fetchrow = AsyncMock()
+    conn.fetch = AsyncMock(return_value=[])
+
+    pool = MagicMock()
+    pool.acquire = MagicMock(
+        return_value=MagicMock(
+            __aenter__=AsyncMock(return_value=conn),
+            __aexit__=AsyncMock(return_value=False),
+        )
+    )
+    pool.close = AsyncMock()
+    return pool, conn
 
 
 @pytest.fixture

--- a/tests/test_bifrost/test_postgres_accounting.py
+++ b/tests/test_bifrost/test_postgres_accounting.py
@@ -9,6 +9,7 @@ import pytest
 
 from bifrost.adapters.accounting.postgres import PostgresAccountingAdapter
 from bifrost.ports.accounting import RequestRecord
+from tests.test_bifrost.conftest import make_pool_mock
 
 
 def _record(**kwargs) -> RequestRecord:
@@ -34,31 +35,13 @@ def _record(**kwargs) -> RequestRecord:
     return RequestRecord(**defaults)
 
 
-def _make_pool_mock():
-    """Return a mocked asyncpg pool that works as an async context manager."""
-    conn = AsyncMock()
-    conn.execute = AsyncMock(return_value=None)
-    conn.fetchrow = AsyncMock()
-    conn.fetch = AsyncMock(return_value=[])
-
-    pool = MagicMock()
-    pool.acquire = MagicMock(
-        return_value=MagicMock(
-            __aenter__=AsyncMock(return_value=conn),
-            __aexit__=AsyncMock(return_value=False),
-        )
-    )
-    pool.close = AsyncMock()
-    return pool, conn
-
-
 _PATCH_PATH = "bifrost.adapters._pg_base.asyncpg.create_pool"
 
 
 @pytest.fixture
 async def pg_accounting():
     """PostgresAccountingAdapter with asyncpg.create_pool stubbed out."""
-    pool, conn = _make_pool_mock()
+    pool, conn = make_pool_mock()
     with patch(_PATCH_PATH, new_callable=AsyncMock) as mock_cp:
         mock_cp.return_value = pool
         adapter = PostgresAccountingAdapter(dsn="postgresql://fake/db")
@@ -222,7 +205,7 @@ class TestPostgresAccountingQuotaHelpers:
 
 class TestPostgresAccountingClose:
     async def test_close_calls_pool_close(self):
-        pool, conn = _make_pool_mock()
+        pool, conn = make_pool_mock()
         with patch(_PATCH_PATH, new_callable=AsyncMock) as mock_cp:
             mock_cp.return_value = pool
             adapter = PostgresAccountingAdapter(dsn="postgresql://fake/db")
@@ -231,7 +214,7 @@ class TestPostgresAccountingClose:
         pool.close.assert_called_once()
 
     async def test_close_is_idempotent(self):
-        pool, conn = _make_pool_mock()
+        pool, conn = make_pool_mock()
         with patch(_PATCH_PATH, new_callable=AsyncMock) as mock_cp:
             mock_cp.return_value = pool
             adapter = PostgresAccountingAdapter(dsn="postgresql://fake/db")

--- a/tests/test_bifrost/test_postgres_audit.py
+++ b/tests/test_bifrost/test_postgres_audit.py
@@ -9,6 +9,7 @@ import pytest
 
 from bifrost.adapters.audit.postgres import PostgresAuditAdapter
 from bifrost.ports.audit import AuditEvent
+from tests.test_bifrost.conftest import make_pool_mock
 
 
 def _event(**kwargs) -> AuditEvent:
@@ -33,31 +34,13 @@ def _event(**kwargs) -> AuditEvent:
     return AuditEvent(**defaults)
 
 
-def _make_pool_mock():
-    """Return a mocked asyncpg pool that works as an async context manager."""
-    conn = AsyncMock()
-    conn.execute = AsyncMock(return_value=None)
-    conn.fetchrow = AsyncMock()
-    conn.fetch = AsyncMock(return_value=[])
-
-    pool = MagicMock()
-    pool.acquire = MagicMock(
-        return_value=MagicMock(
-            __aenter__=AsyncMock(return_value=conn),
-            __aexit__=AsyncMock(return_value=False),
-        )
-    )
-    pool.close = AsyncMock()
-    return pool, conn
-
-
 _PATCH_PATH = "bifrost.adapters._pg_base.asyncpg.create_pool"
 
 
 @pytest.fixture
 async def pg_audit():
     """PostgresAuditAdapter with asyncpg.create_pool stubbed out."""
-    pool, conn = _make_pool_mock()
+    pool, conn = make_pool_mock()
     with patch(_PATCH_PATH, new_callable=AsyncMock) as mock_cp:
         mock_cp.return_value = pool
         adapter = PostgresAuditAdapter(dsn="postgresql://fake/db")
@@ -156,7 +139,7 @@ class TestPostgresAuditQuery:
 
 class TestPostgresAuditClose:
     async def test_close_calls_pool_close(self):
-        pool, conn = _make_pool_mock()
+        pool, conn = make_pool_mock()
         with patch(_PATCH_PATH, new_callable=AsyncMock) as mock_cp:
             mock_cp.return_value = pool
             adapter = PostgresAuditAdapter(dsn="postgresql://fake/db")
@@ -165,7 +148,7 @@ class TestPostgresAuditClose:
         pool.close.assert_called_once()
 
     async def test_close_is_idempotent(self):
-        pool, conn = _make_pool_mock()
+        pool, conn = make_pool_mock()
         with patch(_PATCH_PATH, new_callable=AsyncMock) as mock_cp:
             mock_cp.return_value = pool
             adapter = PostgresAuditAdapter(dsn="postgresql://fake/db")
@@ -194,7 +177,7 @@ class TestPostgresAuditDsnEnv:
 
 class TestPostgresAuditSchemaInit:
     async def test_schema_created_on_first_pool_acquire(self):
-        pool, conn = _make_pool_mock()
+        pool, conn = make_pool_mock()
         with patch(_PATCH_PATH, new_callable=AsyncMock) as mock_cp:
             mock_cp.return_value = pool
             adapter = PostgresAuditAdapter(dsn="postgresql://fake/db")


### PR DESCRIPTION
## Summary
- **[bug fix]** `summarise()` used `asyncio.gather` with 3 queries on a single asyncpg connection — asyncpg connections don't support concurrent operations, causing `InterfaceError` at runtime. Fixed to run sequentially.
- **[reuse]** Extracted duplicated `_make_pool_mock()` helper from `test_postgres_accounting.py` and `test_postgres_audit.py` into shared `conftest.py`.
- **[reuse]** Extracted duplicated `_filters()` helper into `_sql_helpers.filter_pairs()` used by both accounting and audit adapters.

## Test plan
- [ ] Verify `pytest tests/test_bifrost/test_postgres_accounting.py` passes
- [ ] Verify `pytest tests/test_bifrost/test_postgres_audit.py` passes
- [ ] Verify `pytest tests/test_bifrost/test_accounting_audit_ports.py` passes
- [ ] codecov/patch meets 85% threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)