### PR TITLE
feat(adapters): NIU-487 Kubernetes deployment and Prometheus metrics

### DIFF
--- a/charts/bifrost/Chart.yaml
+++ b/charts/bifrost/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: bifrost
+description: "Bifröst — multi-provider LLM gateway with observability and quota enforcement"
+type: application
+version: 0.0.0
+appVersion: "0.0.0"
+keywords:
+  - llm
+  - gateway
+  - anthropic
+  - openai
+  - ai
+  - kubernetes
+maintainers:
+  - name: Niuu Labs
+    url: https://github.com/niuulabs
+home: https://github.com/niuulabs/volundr
+sources:
+  - https://github.com/niuulabs/volundr
+dependencies: []

--- a/charts/bifrost/templates/_helpers.tpl
+++ b/charts/bifrost/templates/_helpers.tpl
@@ -1,0 +1,83 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "bifrost.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "bifrost.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "bifrost.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "bifrost.labels" -}}
+helm.sh/chart: {{ include "bifrost.chart" . }}
+{{ include "bifrost.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: gateway
+app.kubernetes.io/part-of: niuu
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "bifrost.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "bifrost.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "bifrost.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "bifrost.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the proper image name
+*/}}
+{{- define "bifrost.image" -}}
+{{- $registry := .Values.image.registry | default "" }}
+{{- $repository := .Values.image.repository }}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion }}
+{{- if $registry }}
+{{- printf "%s/%s:%s" $registry $repository $tag }}
+{{- else }}
+{{- printf "%s:%s" $repository $tag }}
+{{- end }}
+{{- end }}
+
+{{/*
+Checksum annotations — force pod restarts when config changes
+*/}}
+{{- define "bifrost.checksumAnnotations" -}}
+checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+{{- end }}

--- a/charts/bifrost/templates/configmap.yaml
+++ b/charts/bifrost/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "bifrost.fullname" . }}
+  labels:
+    {{- include "bifrost.labels" . | nindent 4 }}
+data:
+  bifrost.yaml: |
+    {{- .Values.config | toYaml | nindent 4 }}

--- a/charts/bifrost/templates/deployment.yaml
+++ b/charts/bifrost/templates/deployment.yaml
@@ -1,0 +1,171 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "bifrost.fullname" . }}
+  labels:
+    {{- include "bifrost.labels" . | nindent 4 }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit | default 10 }}
+  selector:
+    matchLabels:
+      {{- include "bifrost.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      annotations:
+        {{- include "bifrost.checksumAnnotations" . | nindent 8 }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "bifrost.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "bifrost.serviceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      {{- with .Values.podSecurityContext }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 30 }}
+      containers:
+        - name: bifrost
+          image: {{ include "bifrost.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          {{- with .Values.securityContext }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          args:
+            - "--config"
+            - "/etc/bifrost/bifrost.yaml"
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort | default 8088 }}
+              protocol: TCP
+          env:
+            # Provider API keys sourced from Kubernetes Secrets (populated by ESO from OpenBao)
+            {{- range $providerName, $provider := .Values.providers }}
+            {{- if $provider.existingSecret }}
+            - name: {{ $provider.apiKeyEnv | upper }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $provider.existingSecret }}
+                  key: {{ $provider.secretKey | default "api-key" }}
+            {{- end }}
+            {{- end }}
+            # PAT signing secret (required when auth_mode = pat)
+            {{- if .Values.pat.existingSecret }}
+            - name: PAT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.pat.existingSecret }}
+                  key: {{ .Values.pat.secretKey | default "pat-secret" }}
+            {{- end }}
+            # Usage store DSN (when using postgres backend)
+            {{- if .Values.usageStore.existingSecret }}
+            - name: BIFROST_USAGE_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.usageStore.existingSecret }}
+                  key: {{ .Values.usageStore.secretKey | default "dsn" }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 15
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 5
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 12
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/bifrost
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "bifrost.fullname" . }}
+        - name: tmp
+          emptyDir: {}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/bifrost/templates/externalsecret.yaml
+++ b/charts/bifrost/templates/externalsecret.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.externalSecrets.enabled }}
+{{- range .Values.externalSecrets.secrets }}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ .name }}
+  labels:
+    {{- include "bifrost.labels" $ | nindent 4 }}
+spec:
+  refreshInterval: {{ .refreshInterval | default "1h" }}
+  secretStoreRef:
+    name: {{ $.Values.externalSecrets.secretStoreName }}
+    kind: {{ $.Values.externalSecrets.secretStoreKind | default "SecretStore" }}
+  target:
+    name: {{ .name }}
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    {{- range .data }}
+    - secretKey: {{ .secretKey }}
+      remoteRef:
+        key: {{ .remoteKey }}
+        property: {{ .remoteProperty | default .secretKey }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/bifrost/templates/hpa.yaml
+++ b/charts/bifrost/templates/hpa.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "bifrost.fullname" . }}
+  labels:
+    {{- include "bifrost.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "bifrost.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas | default 2 }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas | default 10 }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetRPS }}
+    # RPS-based scaling via Prometheus adapter
+    # Requires prometheus-adapter configured with the bifrost_requests_total metric.
+    - type: Pods
+      pods:
+        metric:
+          name: bifrost_requests_per_second
+        target:
+          type: AverageValue
+          averageValue: {{ .Values.autoscaling.targetRPS }}
+    {{- end }}
+    {{- with .Values.autoscaling.customMetrics }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/bifrost/templates/pdb.yaml
+++ b/charts/bifrost/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "bifrost.fullname" . }}
+  labels:
+    {{- include "bifrost.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "bifrost.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/bifrost/templates/service.yaml
+++ b/charts/bifrost/templates/service.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "bifrost.fullname" . }}
+  labels:
+    {{- include "bifrost.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type | default "ClusterIP" }}
+  ports:
+    - port: {{ .Values.service.port | default 80 }}
+      targetPort: {{ .Values.service.targetPort | default 8088 }}
+      protocol: TCP
+      name: http
+    {{- if .Values.metrics.enabled }}
+    - port: {{ .Values.metrics.port | default 9090 }}
+      targetPort: {{ .Values.service.targetPort | default 8088 }}
+      protocol: TCP
+      name: metrics
+    {{- end }}
+  selector:
+    {{- include "bifrost.selectorLabels" . | nindent 4 }}

--- a/charts/bifrost/templates/serviceaccount.yaml
+++ b/charts/bifrost/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "bifrost.fullname" . }}
+  labels:
+    {{- include "bifrost.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: false
+{{- end }}

--- a/charts/bifrost/values.yaml
+++ b/charts/bifrost/values.yaml
@@ -1,0 +1,233 @@
+# Default values for the Bifröst LLM gateway Helm chart.
+# Override these values in your environment-specific values file.
+
+# -- Number of replicas when autoscaling is disabled.
+replicaCount: 2
+
+# -- How many old ReplicaSets to retain.
+revisionHistoryLimit: 10
+
+image:
+  # -- Container image registry (leave blank to use Docker Hub).
+  registry: ""
+  # -- Container image repository.
+  repository: ghcr.io/niuulabs/bifrost
+  # -- Image tag. Defaults to Chart.appVersion.
+  tag: ""
+  # -- Image pull policy.
+  pullPolicy: IfNotPresent
+
+# -- Image pull secrets for private registries.
+imagePullSecrets: []
+
+# -- Override the chart name.
+nameOverride: ""
+# -- Override the full release name.
+fullnameOverride: ""
+
+serviceAccount:
+  # -- Create a ServiceAccount for the gateway pods.
+  create: true
+  # -- ServiceAccount name. Auto-generated when blank.
+  name: ""
+  # -- Annotations to add to the ServiceAccount.
+  annotations: {}
+
+# -- Annotations added to every pod.
+podAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/path: "/metrics"
+  prometheus.io/port: "8088"
+
+# -- Additional pod labels.
+podLabels: {}
+
+# -- Pod-level security context (merged with the hardened defaults in the template).
+podSecurityContext: {}
+
+# -- Container-level security context (merged with the hardened defaults in the template).
+securityContext: {}
+
+# -- Optional priority class name.
+priorityClassName: ""
+
+# -- Seconds the pod has to shut down gracefully.
+terminationGracePeriodSeconds: 30
+
+service:
+  # -- Service type.
+  type: ClusterIP
+  # -- Port exposed by the Service.
+  port: 80
+  # -- Port the container listens on.
+  targetPort: 8088
+  # -- Additional service annotations.
+  annotations: {}
+
+# Prometheus metrics scraping configuration.
+metrics:
+  # -- Expose a dedicated metrics port in the Service (same port as HTTP).
+  enabled: true
+  # -- Port number used when creating the metrics service port entry.
+  port: 9090
+
+# -- Container resource requests and limits.
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 1000m
+    memory: 512Mi
+
+autoscaling:
+  # -- Enable HorizontalPodAutoscaler.
+  enabled: true
+  # -- Minimum number of replicas.
+  minReplicas: 2
+  # -- Maximum number of replicas.
+  maxReplicas: 10
+  # -- Target CPU utilisation percentage (null to disable).
+  targetCPUUtilizationPercentage: 70
+  # -- Target memory utilisation percentage (null to disable).
+  targetMemoryUtilizationPercentage: null
+  # -- Target average requests-per-second per pod (requires prometheus-adapter).
+  # Set to null to disable RPS-based scaling.
+  targetRPS: 100
+  # -- Custom HPA metrics in addition to the built-in ones.
+  customMetrics: []
+  # -- HPA scale-up/down behaviour overrides.
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+        - type: Pods
+          value: 2
+          periodSeconds: 60
+
+podDisruptionBudget:
+  # -- Enable PodDisruptionBudget to maintain availability during disruptions.
+  enabled: true
+  # -- Minimum number of pods that must be available. Set one of minAvailable or
+  # maxUnavailable.
+  minAvailable: 1
+  # -- Maximum number of pods that can be unavailable (alternative to minAvailable).
+  maxUnavailable: null
+
+# -- Node selector for pod assignment.
+nodeSelector: {}
+# -- Tolerations for pod scheduling.
+tolerations: []
+# -- Affinity rules for pod scheduling.
+affinity: {}
+# -- Topology spread constraints for even distribution.
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: bifrost
+
+# -- Extra environment variables injected into the gateway container.
+extraEnv: []
+# -- Extra envFrom sources (ConfigMaps / Secrets).
+envFrom: []
+# -- Extra volume mounts added to the gateway container.
+extraVolumeMounts: []
+# -- Extra volumes added to the pod spec.
+extraVolumes: []
+# -- Annotations added to the Deployment resource.
+deploymentAnnotations: {}
+
+# ---------------------------------------------------------------------------
+# Provider secret references (keys populated from Kubernetes Secrets via ESO)
+# ---------------------------------------------------------------------------
+# Each entry maps a provider name to the Secret that holds its API key.
+# The Secret itself is created either manually or via externalSecrets below.
+#
+# Example:
+#   providers:
+#     anthropic:
+#       apiKeyEnv: ANTHROPIC_API_KEY
+#       existingSecret: bifrost-anthropic-secret
+#       secretKey: api-key
+#     openai:
+#       apiKeyEnv: OPENAI_API_KEY
+#       existingSecret: bifrost-openai-secret
+#       secretKey: api-key
+providers: {}
+
+# ---------------------------------------------------------------------------
+# PAT signing secret
+# ---------------------------------------------------------------------------
+pat:
+  # -- Name of the Secret containing the HS256 PAT signing secret.
+  # Required when the bifrost config sets auth_mode: pat.
+  existingSecret: ""
+  # -- Key within the Secret that holds the PAT secret value.
+  secretKey: "pat-secret"
+
+# ---------------------------------------------------------------------------
+# Usage store DSN secret
+# ---------------------------------------------------------------------------
+usageStore:
+  # -- Name of the Secret containing the PostgreSQL DSN for the usage store.
+  existingSecret: ""
+  # -- Key within the Secret that holds the DSN value.
+  secretKey: "dsn"
+
+# ---------------------------------------------------------------------------
+# External Secrets Operator (ESO) — OpenBao integration
+# ---------------------------------------------------------------------------
+externalSecrets:
+  # -- Enable ExternalSecret resources to sync secrets from OpenBao via ESO.
+  enabled: false
+  # -- Name of the (Cluster)SecretStore that points at OpenBao.
+  secretStoreName: openbao
+  # -- Kind of the secret store: SecretStore or ClusterSecretStore.
+  secretStoreKind: ClusterSecretStore
+  # -- List of ExternalSecret definitions to create.
+  # Each entry becomes a separate ExternalSecret manifest.
+  #
+  # Example:
+  #   secrets:
+  #     - name: bifrost-anthropic-secret
+  #       refreshInterval: 1h
+  #       data:
+  #         - secretKey: api-key
+  #           remoteKey: secret/bifrost/anthropic
+  #           remoteProperty: api_key
+  secrets: []
+
+# ---------------------------------------------------------------------------
+# Bifröst gateway configuration
+# ---------------------------------------------------------------------------
+# The contents of this section are rendered verbatim into the bifrost.yaml
+# ConfigMap that is mounted at /etc/bifrost/bifrost.yaml.
+# See bifrost.yaml.example in the repository root for all available options.
+config:
+  routing_strategy: failover
+  host: "0.0.0.0"
+  port: 8088
+  auth_mode: open
+  providers: {}
+  aliases: {}
+  default_quota: {}
+  tenant_quotas: {}
+  agent_permissions: {}
+  guardrails: {}
+  rules: []
+  usage_store:
+    adapter: memory
+  key_vault: {}
+  events:
+    adapter: "null"
+  cache:
+    mode: disabled

--- a/src/bifrost/app.py
+++ b/src/bifrost/app.py
@@ -22,6 +22,7 @@ from fastapi import FastAPI, Request, Response
 from bifrost.adapters.auth import build_auth_adapter
 from bifrost.adapters.key_vault import EnvKeyVault
 from bifrost.config import BifrostConfig, CacheMode
+from bifrost.inbound.observability import create_observability_router
 from bifrost.inbound.routes import create_router
 from bifrost.ports.cache import CachePort
 from bifrost.ports.events import CostEventEmitter
@@ -232,5 +233,8 @@ def create_app(config: BifrostConfig) -> FastAPI:
         cache=cache,
     )
     app.include_router(api_router)
+
+    obs_router = create_observability_router(config=config, router=router, store=store)
+    app.include_router(obs_router)
 
     return app

--- a/src/bifrost/app.py
+++ b/src/bifrost/app.py
@@ -199,6 +199,8 @@ def create_app(config: BifrostConfig) -> FastAPI:
         # SIGHUP is not available on Windows or in some restricted environments.
         logger.debug("SIGHUP not available on this platform; key rotation via signal disabled")
 
+    obs_router = create_observability_router(config=config, router=router, store=store)
+
     @asynccontextmanager
     async def lifespan(app: FastAPI):
         yield
@@ -207,6 +209,8 @@ def create_app(config: BifrostConfig) -> FastAPI:
             await store.close()
         await event_emitter.close()
         await cache.close()
+        if hasattr(obs_router, "http_client"):
+            await obs_router.http_client.aclose()
 
     app = FastAPI(
         title="Bifröst LLM Gateway",
@@ -233,8 +237,6 @@ def create_app(config: BifrostConfig) -> FastAPI:
         cache=cache,
     )
     app.include_router(api_router)
-
-    obs_router = create_observability_router(config=config, router=router, store=store)
     app.include_router(obs_router)
 
     return app

--- a/src/bifrost/domain/routing.py
+++ b/src/bifrost/domain/routing.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import logging
 
+import bifrost.metrics as _metrics
 from bifrost.ports.rules import RoutingContext, RuleAction, RuleEnginePort
 from bifrost.translation.models import AnthropicRequest, ImageBlock, TextBlock
 
@@ -77,6 +78,11 @@ def apply_rules(
     match_result = engine.evaluate(request, context)
     if match_result is None:
         return request
+
+    _metrics.record_rule_hit(
+        rule_name=match_result.rule_name,
+        action=match_result.action.value,
+    )
 
     match match_result.action:
         case RuleAction.ROUTE_TO:

--- a/src/bifrost/inbound/observability.py
+++ b/src/bifrost/inbound/observability.py
@@ -1,0 +1,130 @@
+"""Observability endpoints for Bifröst.
+
+Exposes three routes:
+
+* ``GET /metrics``  — Prometheus text-format metrics.
+* ``GET /healthz``  — Liveness probe (always 200 if the process is alive).
+* ``GET /readyz``   — Readiness probe (200 when at least one provider is
+                       reachable and the usage store is responsive).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+from fastapi import APIRouter
+from fastapi.responses import PlainTextResponse, Response
+
+from bifrost import metrics as _m
+from bifrost.config import BifrostConfig
+from bifrost.ports.usage_store import UsageStore
+from bifrost.router import ModelRouter
+
+logger = logging.getLogger(__name__)
+
+_CONTENT_TYPE_OPENMETRICS = "text/plain; version=0.0.4; charset=utf-8"
+
+
+def create_observability_router(
+    config: BifrostConfig,
+    router: ModelRouter,
+    store: UsageStore,
+) -> APIRouter:
+    """Build and return an ``APIRouter`` with /metrics, /healthz, and /readyz.
+
+    Args:
+        config: Gateway configuration (used to discover provider base URLs).
+        router: Model router (used for provider reachability checks).
+        store:  Usage store (used for DB liveness checks in /readyz).
+
+    Returns:
+        A configured ``APIRouter``.
+    """
+    obs_router = APIRouter()
+
+    @obs_router.get("/healthz", response_class=PlainTextResponse)
+    async def healthz() -> str:
+        """Liveness probe — always returns 200 while the process is alive."""
+        return "ok"
+
+    @obs_router.get("/readyz")
+    async def readyz() -> Response:
+        """Readiness probe — 200 when DB and at least one provider are reachable.
+
+        Checks:
+        1. Usage store is responsive (simple query).
+        2. At least one configured provider's base URL responds to an HTTP
+           request within a short timeout.
+
+        Returns:
+            200 with ``{"status": "ready"}`` when all checks pass.
+            503 with a JSON body listing failing checks otherwise.
+        """
+        failures: list[str] = []
+
+        # ── Store check ───────────────────────────────────────────────────
+        try:
+            # A summarise call with no filters is cheap and exercises the
+            # connection path without touching any real data.
+            await store.summarise()
+        except Exception as exc:
+            logger.warning("readyz: usage store check failed: %s", exc)
+            failures.append(f"usage_store: {exc}")
+
+        # ── Provider reachability check ───────────────────────────────────
+        # We just need at least one provider base URL to accept a connection.
+        # A HEAD request to the base URL is cheap and avoids consuming quota.
+        provider_ok = False
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            for provider_name, provider_cfg in config.providers.items():
+                base_url = config.effective_base_url(provider_name)
+                if not base_url:
+                    continue
+                try:
+                    resp = await client.head(base_url)
+                    # Any HTTP response (even 4xx) means the host is reachable.
+                    if resp.status_code < 600:  # noqa: PLR2004
+                        provider_ok = True
+                        break
+                except Exception as exc:
+                    logger.debug(
+                        "readyz: provider %s (%s) unreachable: %s", provider_name, base_url, exc
+                    )
+
+        if not provider_ok and config.providers:
+            failures.append("providers: no provider base URL is reachable")
+
+        if failures:
+            from fastapi.responses import JSONResponse
+
+            return JSONResponse(
+                status_code=503,
+                content={"status": "not_ready", "failures": failures},
+            )
+
+        from fastapi.responses import JSONResponse
+
+        return JSONResponse(content={"status": "ready"})
+
+    @obs_router.get("/metrics", response_class=PlainTextResponse)
+    async def metrics() -> PlainTextResponse:
+        """Prometheus text-format metrics endpoint.
+
+        Exposes all Bifröst gateway metrics in the standard Prometheus
+        text exposition format (version 0.0.4).
+
+        Metrics exposed:
+            bifrost_requests_total{provider,model,status}
+            bifrost_request_duration_seconds{provider,model}
+            bifrost_tokens_total{provider,model,type}
+            bifrost_cost_usd_total{provider,model}
+            bifrost_cache_hits_total{provider,model}
+            bifrost_cache_misses_total{provider,model}
+            bifrost_quota_rejections_total{agent_id}
+            bifrost_rule_hits_total{rule_name,action}
+        """
+        text = _m.REGISTRY.generate_text()
+        return PlainTextResponse(content=text, media_type=_CONTENT_TYPE_OPENMETRICS)
+
+    return obs_router

--- a/src/bifrost/inbound/observability.py
+++ b/src/bifrost/inbound/observability.py
@@ -14,7 +14,7 @@ import logging
 
 import httpx
 from fastapi import APIRouter
-from fastapi.responses import PlainTextResponse, Response
+from fastapi.responses import JSONResponse, PlainTextResponse, Response
 
 from bifrost import metrics as _m
 from bifrost.config import BifrostConfig
@@ -42,6 +42,9 @@ def create_observability_router(
         A configured ``APIRouter``.
     """
     obs_router = APIRouter()
+    _http_client = httpx.AsyncClient(timeout=5.0)
+    # Expose the client so the app lifespan can close it on shutdown.
+    obs_router.http_client = _http_client  # type: ignore[attr-defined]
 
     @obs_router.get("/healthz", response_class=PlainTextResponse)
     async def healthz() -> str:
@@ -76,34 +79,29 @@ def create_observability_router(
         # We just need at least one provider base URL to accept a connection.
         # A HEAD request to the base URL is cheap and avoids consuming quota.
         provider_ok = False
-        async with httpx.AsyncClient(timeout=5.0) as client:
-            for provider_name, provider_cfg in config.providers.items():
-                base_url = config.effective_base_url(provider_name)
-                if not base_url:
-                    continue
-                try:
-                    resp = await client.head(base_url)
-                    # Any HTTP response (even 4xx) means the host is reachable.
-                    if resp.status_code < 600:  # noqa: PLR2004
-                        provider_ok = True
-                        break
-                except Exception as exc:
-                    logger.debug(
-                        "readyz: provider %s (%s) unreachable: %s", provider_name, base_url, exc
-                    )
+        for provider_name, provider_cfg in config.providers.items():
+            base_url = config.effective_base_url(provider_name)
+            if not base_url:
+                continue
+            try:
+                resp = await _http_client.head(base_url)
+                # Any HTTP response (even 4xx) means the host is reachable.
+                if resp.status_code < 600:  # noqa: PLR2004
+                    provider_ok = True
+                    break
+            except Exception as exc:
+                logger.debug(
+                    "readyz: provider %s (%s) unreachable: %s", provider_name, base_url, exc
+                )
 
         if not provider_ok and config.providers:
             failures.append("providers: no provider base URL is reachable")
 
         if failures:
-            from fastapi.responses import JSONResponse
-
             return JSONResponse(
                 status_code=503,
                 content={"status": "not_ready", "failures": failures},
             )
-
-        from fastapi.responses import JSONResponse
 
         return JSONResponse(content={"status": "ready"})
 

--- a/src/bifrost/inbound/routes.py
+++ b/src/bifrost/inbound/routes.py
@@ -18,6 +18,7 @@ from datetime import UTC, datetime, timedelta
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 
+import bifrost.metrics as _metrics
 from bifrost.auth import AgentIdentity
 from bifrost.config import AgentPermissions, BifrostConfig
 from bifrost.domain.models import RequestLog, TokenUsage
@@ -157,9 +158,7 @@ async def _try_cache_hit(
     if cached is None:
         return None
     latency_ms = (time.monotonic() - start) * 1000
-    await store.record(
-        _cache_hit_record(request_id, identity, model, provider, latency_ms)
-    )
+    await store.record(_cache_hit_record(request_id, identity, model, provider, latency_ms))
     content = response_transform(cached) if response_transform else cached.model_dump()
     return JSONResponse(content=content)
 
@@ -233,6 +232,7 @@ async def _check_quotas(
         limit = tenant_quota.max_tokens_per_day
         fraction = used / limit
         if fraction >= 1.0:
+            _metrics.record_quota_rejection(agent_id=identity.agent_id)
             raise HTTPException(
                 status_code=429,
                 detail=f"Tenant daily token quota exceeded ({used}/{limit}).",
@@ -246,6 +246,7 @@ async def _check_quotas(
         limit_cost = tenant_quota.max_cost_per_day
         fraction = used_cost / limit_cost
         if fraction >= 1.0:
+            _metrics.record_quota_rejection(agent_id=identity.agent_id)
             raise HTTPException(
                 status_code=429,
                 detail=f"Tenant daily cost quota exceeded (${used_cost:.4f}/${limit_cost:.4f}).",
@@ -261,6 +262,7 @@ async def _check_quotas(
         limit_req = tenant_quota.max_requests_per_hour
         fraction = used_req / limit_req
         if fraction >= 1.0:
+            _metrics.record_quota_rejection(agent_id=identity.agent_id)
             raise HTTPException(
                 status_code=429,
                 detail=f"Tenant hourly request quota exceeded ({used_req}/{limit_req}).",
@@ -276,6 +278,7 @@ async def _check_quotas(
         limit_cost = agent_quota.max_cost_per_day
         fraction = agent_cost_today / limit_cost
         if fraction >= 1.0:
+            _metrics.record_quota_rejection(agent_id=identity.agent_id)
             raise HTTPException(
                 status_code=429,
                 detail=(
@@ -609,14 +612,22 @@ def create_router(
             # --- Exact response cache (non-streaming only) ---
             cache_key = _compute_cache_key(identity.tenant_id, request)
             hit_resp = await _try_cache_hit(
-                _cache, cache_key, identity, request_id,
-                request.model, provider, start, store,
+                _cache,
+                cache_key,
+                identity,
+                request_id,
+                request.model,
+                provider,
+                start,
+                store,
             )
             if hit_resp is not None:
+                _metrics.record_cache_hit(provider=provider, model=request.model)
                 if warnings:
                     hit_resp.headers[_HEADER_QUOTA_WARNING] = "; ".join(warnings)
                 return hit_resp
 
+            _metrics.record_cache_miss(provider=provider, model=request.model)
             response = await router.complete(request, routing_ctx)
             latency_ms = (time.monotonic() - start) * 1000
             data = response.model_dump()
@@ -639,6 +650,17 @@ def create_router(
             )
 
             cost = calculate_cost(request.model, usage, pricing_overrides)
+            _metrics.record_request(
+                provider=provider,
+                model=request.model,
+                status="200",
+                duration_seconds=latency_ms / 1000.0,
+                input_tokens=usage.input_tokens,
+                output_tokens=usage.output_tokens,
+                cache_read_tokens=usage.cache_read_input_tokens,
+                cache_write_tokens=usage.cache_creation_input_tokens,
+                cost_usd=cost,
+            )
             await store.record(
                 UsageRecord(
                     request_id=request_id,
@@ -660,8 +682,11 @@ def create_router(
                 )
             )
             await _emit_events(
-                identity, cost, usage.input_tokens + usage.output_tokens,
-                request.model, agent_budget_limit,
+                identity,
+                cost,
+                usage.input_tokens + usage.output_tokens,
+                request.model,
+                agent_budget_limit,
             )
             await _cache.set(cache_key, response, config.cache.default_ttl)
 
@@ -673,8 +698,20 @@ def create_router(
             return json_resp
 
         except RuleRejectError as exc:
+            _metrics.record_request(
+                provider=provider,
+                model=request.model,
+                status="400",
+                duration_seconds=(time.monotonic() - start),
+            )
             raise HTTPException(status_code=400, detail=exc.message) from exc
         except RouterError as exc:
+            _metrics.record_request(
+                provider=provider,
+                model=request.model,
+                status="502",
+                duration_seconds=(time.monotonic() - start),
+            )
             logger.error("Routing failed: %s", exc)
             raise HTTPException(status_code=502, detail=str(exc)) from exc
 
@@ -887,8 +924,14 @@ def create_router(
             # --- Exact response cache (non-streaming only) ---
             cache_key = _compute_cache_key(identity.tenant_id, request)
             hit_resp = await _try_cache_hit(
-                _cache, cache_key, identity, request_id,
-                request.model, provider, start, store,
+                _cache,
+                cache_key,
+                identity,
+                request_id,
+                request.model,
+                provider,
+                start,
+                store,
                 response_transform=anthropic_response_to_openai,
             )
             if hit_resp is not None:
@@ -937,8 +980,11 @@ def create_router(
                 )
             )
             await _emit_events(
-                identity, cost, usage.input_tokens + usage.output_tokens,
-                request.model, agent_budget_limit,
+                identity,
+                cost,
+                usage.input_tokens + usage.output_tokens,
+                request.model,
+                agent_budget_limit,
             )
             await _cache.set(cache_key, response, config.cache.default_ttl)
 
@@ -1050,8 +1096,14 @@ def create_router(
             # --- Exact response cache (non-streaming only) ---
             cache_key = _compute_cache_key(identity.tenant_id, request)
             hit_resp = await _try_cache_hit(
-                _cache, cache_key, identity, request_id,
-                request.model, provider, start, store,
+                _cache,
+                cache_key,
+                identity,
+                request_id,
+                request.model,
+                provider,
+                start,
+                store,
                 response_transform=lambda cached: response_translate_fn(
                     cached,
                     created_at=datetime.now(UTC).isoformat(),
@@ -1104,8 +1156,11 @@ def create_router(
                 )
             )
             await _emit_events(
-                identity, cost, usage.input_tokens + usage.output_tokens,
-                request.model, agent_budget_limit,
+                identity,
+                cost,
+                usage.input_tokens + usage.output_tokens,
+                request.model,
+                agent_budget_limit,
             )
             await _cache.set(cache_key, response, config.cache.default_ttl)
 

--- a/src/bifrost/inbound/routes.py
+++ b/src/bifrost/inbound/routes.py
@@ -935,10 +935,12 @@ def create_router(
                 response_transform=anthropic_response_to_openai,
             )
             if hit_resp is not None:
+                _metrics.record_cache_hit(provider=provider, model=request.model)
                 if warnings:
                     hit_resp.headers[_HEADER_QUOTA_WARNING] = "; ".join(warnings)
                 return hit_resp
 
+            _metrics.record_cache_miss(provider=provider, model=request.model)
             response = await router.complete(request, routing_ctx)
             latency_ms = (time.monotonic() - start) * 1000
             usage = TokenUsage(
@@ -959,6 +961,17 @@ def create_router(
             )
 
             cost = calculate_cost(request.model, usage, pricing_overrides)
+            _metrics.record_request(
+                provider=provider,
+                model=request.model,
+                status="200",
+                duration_seconds=latency_ms / 1000.0,
+                input_tokens=usage.input_tokens,
+                output_tokens=usage.output_tokens,
+                cache_read_tokens=0,
+                cache_write_tokens=0,
+                cost_usd=cost,
+            )
             await store.record(
                 UsageRecord(
                     request_id=request_id,
@@ -996,8 +1009,20 @@ def create_router(
             return json_resp
 
         except RuleRejectError as exc:
+            _metrics.record_request(
+                provider=provider,
+                model=request.model,
+                status="400",
+                duration_seconds=(time.monotonic() - start),
+            )
             return openai_error_response(400, exc.message, "invalid_request_error")
         except RouterError as exc:
+            _metrics.record_request(
+                provider=provider,
+                model=request.model,
+                status="502",
+                duration_seconds=(time.monotonic() - start),
+            )
             logger.error("Routing failed: %s", exc)
             return openai_error_response(502, str(exc), "server_error")
 
@@ -1111,10 +1136,12 @@ def create_router(
                 ),
             )
             if hit_resp is not None:
+                _metrics.record_cache_hit(provider=provider, model=request.model)
                 if warnings:
                     hit_resp.headers[_HEADER_QUOTA_WARNING] = "; ".join(warnings)
                 return hit_resp
 
+            _metrics.record_cache_miss(provider=provider, model=request.model)
             response = await router.complete(request, routing_ctx)
             latency_ms = (time.monotonic() - start) * 1000
             usage = TokenUsage(
@@ -1135,6 +1162,17 @@ def create_router(
             )
 
             cost = calculate_cost(request.model, usage, pricing_overrides)
+            _metrics.record_request(
+                provider=provider,
+                model=request.model,
+                status="200",
+                duration_seconds=latency_ms / 1000.0,
+                input_tokens=usage.input_tokens,
+                output_tokens=usage.output_tokens,
+                cache_read_tokens=0,
+                cache_write_tokens=0,
+                cost_usd=cost,
+            )
             await store.record(
                 UsageRecord(
                     request_id=request_id,
@@ -1178,6 +1216,12 @@ def create_router(
             return json_resp
 
         except RouterError as exc:
+            _metrics.record_request(
+                provider=provider,
+                model=request.model,
+                status="502",
+                duration_seconds=(time.monotonic() - start),
+            )
             logger.error("Routing failed: %s", exc)
             return ollama_error_response(502, str(exc))
 

--- a/src/bifrost/inbound/tracking.py
+++ b/src/bifrost/inbound/tracking.py
@@ -13,6 +13,7 @@ import time
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
 
+import bifrost.metrics as _metrics
 from bifrost.auth import AgentIdentity
 from bifrost.domain.models import RequestLog, TokenUsage
 from bifrost.ports.events import BudgetWarningEvent, CostEventEmitter, RequestCompletedEvent
@@ -149,6 +150,17 @@ async def _stream_with_tracking(
     )
 
     cost = calculate_cost(model, usage, pricing_overrides)
+    _metrics.record_request(
+        provider=provider,
+        model=model,
+        status="200",
+        duration_seconds=latency_ms / 1000.0,
+        input_tokens=usage.input_tokens,
+        output_tokens=usage.output_tokens,
+        cache_read_tokens=usage.cache_read_input_tokens,
+        cache_write_tokens=usage.cache_creation_input_tokens,
+        cost_usd=cost,
+    )
     await store.record(
         UsageRecord(
             request_id=request_id,

--- a/src/bifrost/metrics.py
+++ b/src/bifrost/metrics.py
@@ -1,0 +1,277 @@
+"""Bifröst Prometheus metrics registry.
+
+Provides a minimal thread-safe registry that generates Prometheus text-format
+output without requiring the ``prometheus_client`` package.  All metrics are
+module-level singletons so they accumulate across the process lifetime.
+
+Usage::
+
+    from bifrost.metrics import REGISTRY, record_request, record_cache_hit
+
+    record_request(provider="anthropic", model="claude-sonnet-4-6", status="200",
+                   duration_seconds=1.23, input_tokens=100, output_tokens=50,
+                   cost_usd=0.002)
+    record_cache_hit(provider="anthropic", model="claude-sonnet-4-6")
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, field
+from io import StringIO
+from typing import NamedTuple
+
+# ---------------------------------------------------------------------------
+# Internal metric primitives
+# ---------------------------------------------------------------------------
+
+
+class LabelKey(NamedTuple):
+    """Immutable tuple of label values (preserves order for text output)."""
+
+    values: tuple[str, ...]
+
+
+@dataclass
+class Counter:
+    """Thread-safe monotonically increasing counter."""
+
+    name: str
+    help: str
+    label_names: tuple[str, ...]
+    _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
+    _values: dict[LabelKey, float] = field(default_factory=dict, init=False, repr=False)
+
+    def inc(self, labels: tuple[str, ...], amount: float = 1.0) -> None:
+        key = LabelKey(labels)
+        with self._lock:
+            self._values[key] = self._values.get(key, 0.0) + amount
+
+    def collect(self) -> dict[LabelKey, float]:
+        with self._lock:
+            return dict(self._values)
+
+
+# Default histogram buckets suitable for request durations (seconds).
+_DURATION_BUCKETS = (0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0)
+
+
+@dataclass
+class Histogram:
+    """Thread-safe histogram with configurable buckets."""
+
+    name: str
+    help: str
+    label_names: tuple[str, ...]
+    buckets: tuple[float, ...] = _DURATION_BUCKETS
+    _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
+    # Maps label key → list of bucket counts (len == len(buckets)+1 for +Inf)
+    _buckets: dict[LabelKey, list[float]] = field(default_factory=dict, init=False, repr=False)
+    _sums: dict[LabelKey, float] = field(default_factory=dict, init=False, repr=False)
+    _counts: dict[LabelKey, float] = field(default_factory=dict, init=False, repr=False)
+
+    def observe(self, labels: tuple[str, ...], value: float) -> None:
+        key = LabelKey(labels)
+        with self._lock:
+            if key not in self._buckets:
+                self._buckets[key] = [0.0] * (len(self.buckets) + 1)
+                self._sums[key] = 0.0
+                self._counts[key] = 0.0
+            for i, bound in enumerate(self.buckets):
+                if value <= bound:
+                    self._buckets[key][i] += 1.0
+            # +Inf bucket always incremented
+            self._buckets[key][-1] += 1.0
+            self._sums[key] += value
+            self._counts[key] += 1.0
+
+    def collect(self) -> dict[LabelKey, tuple[list[float], float, float]]:
+        """Return {label_key: (bucket_counts, sum, count)}."""
+        with self._lock:
+            return {k: (list(v), self._sums[k], self._counts[k]) for k, v in self._buckets.items()}
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Registry:
+    """Container for all registered metrics."""
+
+    _metrics: list[Counter | Histogram] = field(default_factory=list, init=False)
+
+    def register(self, metric: Counter | Histogram) -> Counter | Histogram:
+        self._metrics.append(metric)
+        return metric
+
+    def generate_text(self) -> str:
+        """Render all metrics in Prometheus text exposition format."""
+        buf = StringIO()
+        for metric in self._metrics:
+            _write_metric(buf, metric)
+        return buf.getvalue()
+
+
+def _label_str(names: tuple[str, ...], values: tuple[str, ...]) -> str:
+    if not names:
+        return ""
+    pairs = ",".join(f'{n}="{_escape(v)}"' for n, v in zip(names, values, strict=True))
+    return "{" + pairs + "}"
+
+
+def _escape(s: str) -> str:
+    return s.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+def _write_metric(buf: StringIO, metric: Counter | Histogram) -> None:
+    buf.write(f"# HELP {metric.name} {metric.help}\n")
+    if isinstance(metric, Counter):
+        buf.write(f"# TYPE {metric.name} counter\n")
+        for key, value in metric.collect().items():
+            labels = _label_str(metric.label_names, key.values)
+            buf.write(f"{metric.name}{labels} {value}\n")
+    elif isinstance(metric, Histogram):
+        buf.write(f"# TYPE {metric.name} histogram\n")
+        for key, (buckets, total, count) in metric.collect().items():
+            base_labels = _label_str(metric.label_names, key.values)
+            # Strip trailing } to insert le label
+            prefix = base_labels[:-1] if base_labels else "{"
+            for i, bound in enumerate(metric.buckets):
+                le = f"{bound:g}"
+                if base_labels:
+                    bucket_labels = f'{prefix},le="{le}"}}'
+                else:
+                    bucket_labels = f'{{le="{le}"}}'
+                buf.write(f"{metric.name}_bucket{bucket_labels} {buckets[i]}\n")
+            # +Inf
+            if base_labels:
+                inf_labels = f'{prefix},le="+Inf"}}'
+            else:
+                inf_labels = '{le="+Inf"}'
+            buf.write(f"{metric.name}_bucket{inf_labels} {buckets[-1]}\n")
+            buf.write(f"{metric.name}_sum{base_labels} {total}\n")
+            buf.write(f"{metric.name}_count{base_labels} {count}\n")
+    buf.write("\n")
+
+
+# ---------------------------------------------------------------------------
+# Global registry and metric definitions
+# ---------------------------------------------------------------------------
+
+REGISTRY = Registry()
+
+# Counters
+requests_total = REGISTRY.register(
+    Counter(
+        name="bifrost_requests_total",
+        help="Total LLM proxy requests by provider, model, and HTTP status.",
+        label_names=("provider", "model", "status"),
+    )
+)
+
+tokens_total = REGISTRY.register(
+    Counter(
+        name="bifrost_tokens_total",
+        help="Total tokens processed by provider, model, and type (input/output/cache).",
+        label_names=("provider", "model", "type"),
+    )
+)
+
+cost_usd_total = REGISTRY.register(
+    Counter(
+        name="bifrost_cost_usd_total",
+        help="Cumulative USD cost of all LLM requests by provider and model.",
+        label_names=("provider", "model"),
+    )
+)
+
+cache_hits_total = REGISTRY.register(
+    Counter(
+        name="bifrost_cache_hits_total",
+        help="Number of requests served from the semantic response cache.",
+        label_names=("provider", "model"),
+    )
+)
+
+cache_misses_total = REGISTRY.register(
+    Counter(
+        name="bifrost_cache_misses_total",
+        help="Number of requests that missed the semantic response cache.",
+        label_names=("provider", "model"),
+    )
+)
+
+quota_rejections_total = REGISTRY.register(
+    Counter(
+        name="bifrost_quota_rejections_total",
+        help="Number of requests rejected due to quota limits, by agent_id.",
+        label_names=("agent_id",),
+    )
+)
+
+rule_hits_total = REGISTRY.register(
+    Counter(
+        name="bifrost_rule_hits_total",
+        help="Number of times a declarative routing rule fired, by rule name and action.",
+        label_names=("rule_name", "action"),
+    )
+)
+
+# Histograms
+request_duration_seconds = REGISTRY.register(
+    Histogram(
+        name="bifrost_request_duration_seconds",
+        help="End-to-end request duration in seconds by provider and model.",
+        label_names=("provider", "model"),
+    )
+)
+
+
+# ---------------------------------------------------------------------------
+# Convenience helpers called from route handlers
+# ---------------------------------------------------------------------------
+
+
+def record_request(
+    *,
+    provider: str,
+    model: str,
+    status: str,
+    duration_seconds: float,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cache_read_tokens: int = 0,
+    cache_write_tokens: int = 0,
+    cost_usd: float = 0.0,
+) -> None:
+    """Record a completed LLM request in all relevant metrics."""
+    requests_total.inc((provider, model, status))
+    request_duration_seconds.observe((provider, model), duration_seconds)
+    if input_tokens:
+        tokens_total.inc((provider, model, "input"), float(input_tokens))
+    if output_tokens:
+        tokens_total.inc((provider, model, "output"), float(output_tokens))
+    if cache_read_tokens:
+        tokens_total.inc((provider, model, "cache"), float(cache_read_tokens))
+    if cache_write_tokens:
+        tokens_total.inc((provider, model, "cache_write"), float(cache_write_tokens))
+    if cost_usd:
+        cost_usd_total.inc((provider, model), cost_usd)
+
+
+def record_cache_hit(*, provider: str, model: str) -> None:
+    cache_hits_total.inc((provider, model))
+
+
+def record_cache_miss(*, provider: str, model: str) -> None:
+    cache_misses_total.inc((provider, model))
+
+
+def record_quota_rejection(*, agent_id: str) -> None:
+    quota_rejections_total.inc((agent_id,))
+
+
+def record_rule_hit(*, rule_name: str, action: str) -> None:
+    rule_hits_total.inc((rule_name, action))

--- a/tests/test_bifrost/test_metrics.py
+++ b/tests/test_bifrost/test_metrics.py
@@ -1,0 +1,428 @@
+"""Tests for Bifröst Prometheus metrics registry and observability endpoints."""
+
+from __future__ import annotations
+
+import threading
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from bifrost.app import create_app
+from bifrost.config import BifrostConfig, ProviderConfig
+from bifrost.metrics import (
+    Counter,
+    Histogram,
+    LabelKey,
+    Registry,
+    _escape,
+    _label_str,
+    record_cache_hit,
+    record_cache_miss,
+    record_quota_rejection,
+    record_request,
+    record_rule_hit,
+)
+from tests.test_bifrost.conftest import make_config
+
+# ---------------------------------------------------------------------------
+# Unit tests for the metrics primitives
+# ---------------------------------------------------------------------------
+
+
+class TestCounter:
+    def test_starts_at_zero(self) -> None:
+        c = Counter(name="test_c", help="help", label_names=("a",))
+        assert c.collect() == {}
+
+    def test_inc_creates_entry(self) -> None:
+        c = Counter(name="test_c2", help="help", label_names=("a",))
+        c.inc(("x",))
+        assert c.collect()[LabelKey(("x",))] == 1.0
+
+    def test_inc_accumulates(self) -> None:
+        c = Counter(name="test_c3", help="help", label_names=("a",))
+        c.inc(("x",), 3.0)
+        c.inc(("x",), 2.0)
+        assert c.collect()[LabelKey(("x",))] == 5.0
+
+    def test_multiple_labels(self) -> None:
+        c = Counter(name="test_c4", help="help", label_names=("a", "b"))
+        c.inc(("x", "y"))
+        c.inc(("x", "z"))
+        data = c.collect()
+        assert data[LabelKey(("x", "y"))] == 1.0
+        assert data[LabelKey(("x", "z"))] == 1.0
+
+    def test_thread_safety(self) -> None:
+        c = Counter(name="test_c5", help="help", label_names=("a",))
+        errors: list[Exception] = []
+
+        def _inc() -> None:
+            try:
+                for _ in range(100):
+                    c.inc(("key",))
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=_inc) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        assert c.collect()[LabelKey(("key",))] == 1000.0
+
+
+class TestHistogram:
+    def test_observe_increments_buckets(self) -> None:
+        h = Histogram(name="test_h", help="help", label_names=("a",), buckets=(0.1, 1.0, 10.0))
+        h.observe(("x",), 0.5)
+        data = h.collect()
+        key = LabelKey(("x",))
+        buckets, total, count = data[key]
+        # 0.5 > 0.1, so bucket[0]=0 (0.5 not <= 0.1)
+        assert buckets[0] == 0.0  # le=0.1: not counted
+        assert buckets[1] == 1.0  # le=1.0: counted
+        assert buckets[2] == 1.0  # le=10.0: counted
+        assert buckets[3] == 1.0  # le=+Inf: always counted
+        assert total == 0.5
+        assert count == 1.0
+
+    def test_observe_multiple(self) -> None:
+        h = Histogram(name="test_h2", help="help", label_names=("a",), buckets=(1.0, 5.0))
+        h.observe(("x",), 0.5)
+        h.observe(("x",), 2.0)
+        h.observe(("x",), 10.0)
+        data = h.collect()
+        key = LabelKey(("x",))
+        buckets, total, count = data[key]
+        assert buckets[0] == 1.0  # le=1.0: only 0.5 counts
+        assert buckets[1] == 2.0  # le=5.0: 0.5 and 2.0 count
+        assert buckets[2] == 3.0  # +Inf: all three
+        assert total == pytest.approx(12.5)
+        assert count == 3.0
+
+
+class TestRegistry:
+    def test_generate_text_counter(self) -> None:
+        reg = Registry()
+        c = reg.register(Counter(name="my_counter", help="A counter.", label_names=("env",)))
+        c.inc(("prod",), 7.0)
+        text = reg.generate_text()
+        assert "# HELP my_counter A counter." in text
+        assert "# TYPE my_counter counter" in text
+        assert 'my_counter{env="prod"} 7.0' in text
+
+    def test_generate_text_histogram(self) -> None:
+        reg = Registry()
+        h = reg.register(
+            Histogram(name="my_hist", help="A histogram.", label_names=("env",), buckets=(1.0,))
+        )
+        h.observe(("prod",), 0.5)
+        text = reg.generate_text()
+        assert "# HELP my_hist A histogram." in text
+        assert "# TYPE my_hist histogram" in text
+        assert 'my_hist_bucket{env="prod",le="1"} 1.0' in text
+        assert 'my_hist_sum{env="prod"}' in text
+        assert 'my_hist_count{env="prod"}' in text
+
+    def test_generate_text_no_labels(self) -> None:
+        reg = Registry()
+        c = reg.register(Counter(name="nolabel_c", help="No labels.", label_names=()))
+        c.inc(())
+        text = reg.generate_text()
+        assert "nolabel_c 1.0" in text
+
+    def test_empty_registry(self) -> None:
+        reg = Registry()
+        assert reg.generate_text() == ""
+
+
+class TestLabelHelpers:
+    def test_escape_backslash(self) -> None:
+        assert _escape("a\\b") == "a\\\\b"
+
+    def test_escape_quote(self) -> None:
+        assert _escape('a"b') == 'a\\"b'
+
+    def test_escape_newline(self) -> None:
+        assert _escape("a\nb") == "a\\nb"
+
+    def test_label_str_empty(self) -> None:
+        assert _label_str((), ()) == ""
+
+    def test_label_str_single(self) -> None:
+        result = _label_str(("env",), ("prod",))
+        assert result == '{env="prod"}'
+
+    def test_label_str_multiple(self) -> None:
+        result = _label_str(("a", "b"), ("x", "y"))
+        assert result == '{a="x",b="y"}'
+
+
+# ---------------------------------------------------------------------------
+# Convenience helper tests
+# ---------------------------------------------------------------------------
+
+
+class TestHelpers:
+    def setup_method(self) -> None:
+        # Create a fresh private registry so each test is isolated from the
+        # global module-level singletons.
+        import bifrost.metrics as m
+
+        self._original_registry = m.REGISTRY
+        m.REGISTRY = Registry()
+        # Re-register metrics against the private registry
+        m.requests_total = m.REGISTRY.register(
+            Counter("bifrost_requests_total", "help", ("provider", "model", "status"))
+        )
+        m.tokens_total = m.REGISTRY.register(
+            Counter("bifrost_tokens_total", "help", ("provider", "model", "type"))
+        )
+        m.cost_usd_total = m.REGISTRY.register(
+            Counter("bifrost_cost_usd_total", "help", ("provider", "model"))
+        )
+        m.cache_hits_total = m.REGISTRY.register(
+            Counter("bifrost_cache_hits_total", "help", ("provider", "model"))
+        )
+        m.cache_misses_total = m.REGISTRY.register(
+            Counter("bifrost_cache_misses_total", "help", ("provider", "model"))
+        )
+        m.quota_rejections_total = m.REGISTRY.register(
+            Counter("bifrost_quota_rejections_total", "help", ("agent_id",))
+        )
+        m.rule_hits_total = m.REGISTRY.register(
+            Counter("bifrost_rule_hits_total", "help", ("rule_name", "action"))
+        )
+        m.request_duration_seconds = m.REGISTRY.register(
+            Histogram("bifrost_request_duration_seconds", "help", ("provider", "model"))
+        )
+
+    def teardown_method(self) -> None:
+        import bifrost.metrics as m
+
+        m.REGISTRY = self._original_registry
+
+    def test_record_request_increments_counter(self) -> None:
+        import bifrost.metrics as m
+
+        record_request(
+            provider="anthropic",
+            model="claude-sonnet-4-6",
+            status="200",
+            duration_seconds=1.0,
+            input_tokens=10,
+            output_tokens=5,
+            cost_usd=0.001,
+        )
+        data = m.requests_total.collect()
+        assert data[LabelKey(("anthropic", "claude-sonnet-4-6", "200"))] == 1.0
+
+    def test_record_request_increments_tokens(self) -> None:
+        import bifrost.metrics as m
+
+        record_request(
+            provider="anthropic",
+            model="claude-sonnet-4-6",
+            status="200",
+            duration_seconds=1.0,
+            input_tokens=100,
+            output_tokens=50,
+        )
+        data = m.tokens_total.collect()
+        assert data[LabelKey(("anthropic", "claude-sonnet-4-6", "input"))] == 100.0
+        assert data[LabelKey(("anthropic", "claude-sonnet-4-6", "output"))] == 50.0
+
+    def test_record_request_records_duration(self) -> None:
+        import bifrost.metrics as m
+
+        record_request(
+            provider="openai",
+            model="gpt-4o",
+            status="200",
+            duration_seconds=2.5,
+        )
+        data = m.request_duration_seconds.collect()
+        key = LabelKey(("openai", "gpt-4o"))
+        assert key in data
+        _, total, count = data[key]
+        assert total == pytest.approx(2.5)
+        assert count == 1.0
+
+    def test_record_cache_hit(self) -> None:
+        import bifrost.metrics as m
+
+        record_cache_hit(provider="anthropic", model="claude-haiku-4-5-20251001")
+        data = m.cache_hits_total.collect()
+        assert data[LabelKey(("anthropic", "claude-haiku-4-5-20251001"))] == 1.0
+
+    def test_record_cache_miss(self) -> None:
+        import bifrost.metrics as m
+
+        record_cache_miss(provider="anthropic", model="claude-sonnet-4-6")
+        data = m.cache_misses_total.collect()
+        assert data[LabelKey(("anthropic", "claude-sonnet-4-6"))] == 1.0
+
+    def test_record_quota_rejection(self) -> None:
+        import bifrost.metrics as m
+
+        record_quota_rejection(agent_id="tyr")
+        data = m.quota_rejections_total.collect()
+        assert data[LabelKey(("tyr",))] == 1.0
+
+    def test_record_rule_hit(self) -> None:
+        import bifrost.metrics as m
+
+        record_rule_hit(rule_name="no-images", action="strip_images")
+        data = m.rule_hits_total.collect()
+        assert data[LabelKey(("no-images", "strip_images"))] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# HTTP endpoint tests
+# ---------------------------------------------------------------------------
+
+
+def _make_app_client(config: BifrostConfig | None = None) -> TestClient:
+    cfg = config or make_config()
+    app = create_app(cfg)
+    return TestClient(app)
+
+
+class TestHealthzEndpoint:
+    def test_healthz_returns_200(self) -> None:
+        with _make_app_client() as client:
+            resp = client.get("/healthz")
+        assert resp.status_code == 200
+        assert resp.text == "ok"
+
+    def test_healthz_always_ok(self) -> None:
+        """Liveness probe must always return 200 if the process is alive."""
+        with _make_app_client() as client:
+            for _ in range(3):
+                resp = client.get("/healthz")
+                assert resp.status_code == 200
+
+
+class TestReadyzEndpoint:
+    def test_readyz_ok_when_store_and_providers_up(self) -> None:
+        """readyz returns 200 when the store summarise() succeeds and provider responds."""
+        config = BifrostConfig(
+            providers={"anthropic": ProviderConfig(models=["claude-sonnet-4-6"])}
+        )
+        app = create_app(config)
+        _store_patch = "bifrost.adapters.memory_store.MemoryUsageStore.summarise"
+        with (
+            patch("bifrost.inbound.observability.httpx.AsyncClient") as mock_client_cls,
+            patch(_store_patch, new_callable=AsyncMock) as mock_summarise,
+        ):
+            mock_summarise.return_value = MagicMock()
+            # Simulate a reachable provider
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_http = AsyncMock()
+            mock_http.head = AsyncMock(return_value=mock_resp)
+            mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+            mock_http.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_http
+
+            with TestClient(app) as client:
+                resp = client.get("/readyz")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ready"
+
+    def test_readyz_503_when_store_fails(self) -> None:
+        """readyz returns 503 when the store raises an exception."""
+        config = BifrostConfig(
+            providers={"anthropic": ProviderConfig(models=["claude-sonnet-4-6"])}
+        )
+        app = create_app(config)
+        _store_patch = "bifrost.adapters.memory_store.MemoryUsageStore.summarise"
+        with (
+            patch("bifrost.inbound.observability.httpx.AsyncClient") as mock_client_cls,
+            patch(_store_patch, new_callable=AsyncMock) as mock_summarise,
+        ):
+            mock_summarise.side_effect = RuntimeError("db down")
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_http = AsyncMock()
+            mock_http.head = AsyncMock(return_value=mock_resp)
+            mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+            mock_http.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_http
+
+            with TestClient(app) as client:
+                resp = client.get("/readyz")
+        assert resp.status_code == 503
+        assert "usage_store" in resp.json()["failures"][0]
+
+    def test_readyz_503_when_providers_unreachable(self) -> None:
+        """readyz returns 503 when no provider base URL can be reached."""
+        config = BifrostConfig(
+            providers={"anthropic": ProviderConfig(models=["claude-sonnet-4-6"])}
+        )
+        app = create_app(config)
+        _store_patch = "bifrost.adapters.memory_store.MemoryUsageStore.summarise"
+        with (
+            patch("bifrost.inbound.observability.httpx.AsyncClient") as mock_client_cls,
+            patch(_store_patch, new_callable=AsyncMock) as mock_summarise,
+        ):
+            mock_summarise.return_value = MagicMock()
+            mock_http = AsyncMock()
+            mock_http.head = AsyncMock(side_effect=Exception("connection refused"))
+            mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+            mock_http.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_http
+
+            with TestClient(app) as client:
+                resp = client.get("/readyz")
+        assert resp.status_code == 503
+        assert any("providers" in f for f in resp.json()["failures"])
+
+    def test_readyz_ok_when_no_providers_configured(self) -> None:
+        """readyz returns 200 when there are no providers (nothing to check)."""
+        config = BifrostConfig(providers={})
+        app = create_app(config)
+        _store_patch = "bifrost.adapters.memory_store.MemoryUsageStore.summarise"
+        with patch(_store_patch, new_callable=AsyncMock) as mock_summarise:
+            mock_summarise.return_value = MagicMock()
+            with TestClient(app) as client:
+                resp = client.get("/readyz")
+        assert resp.status_code == 200
+
+
+class TestMetricsEndpoint:
+    def test_metrics_returns_200(self) -> None:
+        with _make_app_client() as client:
+            resp = client.get("/metrics")
+        assert resp.status_code == 200
+
+    def test_metrics_content_type(self) -> None:
+        with _make_app_client() as client:
+            resp = client.get("/metrics")
+        assert "text/plain" in resp.headers["content-type"]
+
+    def test_metrics_contains_bifrost_metric_names(self) -> None:
+        with _make_app_client() as client:
+            resp = client.get("/metrics")
+        text = resp.text
+        assert "bifrost_requests_total" in text
+        assert "bifrost_request_duration_seconds" in text
+        assert "bifrost_tokens_total" in text
+        assert "bifrost_cost_usd_total" in text
+        assert "bifrost_cache_hits_total" in text
+        assert "bifrost_cache_misses_total" in text
+        assert "bifrost_quota_rejections_total" in text
+        assert "bifrost_rule_hits_total" in text
+
+    def test_metrics_has_help_and_type_lines(self) -> None:
+        with _make_app_client() as client:
+            resp = client.get("/metrics")
+        text = resp.text
+        assert "# HELP bifrost_requests_total" in text
+        assert "# TYPE bifrost_requests_total counter" in text
+        assert "# HELP bifrost_request_duration_seconds" in text
+        assert "# TYPE bifrost_request_duration_seconds histogram" in text

--- a/tests/test_bifrost/test_metrics.py
+++ b/tests/test_bifrost/test_metrics.py
@@ -313,22 +313,18 @@ class TestReadyzEndpoint:
         config = BifrostConfig(
             providers={"anthropic": ProviderConfig(models=["claude-sonnet-4-6"])}
         )
-        app = create_app(config)
         _store_patch = "bifrost.adapters.memory_store.MemoryUsageStore.summarise"
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_http = AsyncMock()
+        mock_http.head = AsyncMock(return_value=mock_resp)
+        mock_http.aclose = AsyncMock()
         with (
-            patch("bifrost.inbound.observability.httpx.AsyncClient") as mock_client_cls,
+            patch("bifrost.inbound.observability.httpx.AsyncClient", return_value=mock_http),
             patch(_store_patch, new_callable=AsyncMock) as mock_summarise,
         ):
             mock_summarise.return_value = MagicMock()
-            # Simulate a reachable provider
-            mock_resp = MagicMock()
-            mock_resp.status_code = 200
-            mock_http = AsyncMock()
-            mock_http.head = AsyncMock(return_value=mock_resp)
-            mock_http.__aenter__ = AsyncMock(return_value=mock_http)
-            mock_http.__aexit__ = AsyncMock(return_value=False)
-            mock_client_cls.return_value = mock_http
-
+            app = create_app(config)
             with TestClient(app) as client:
                 resp = client.get("/readyz")
         assert resp.status_code == 200
@@ -339,21 +335,18 @@ class TestReadyzEndpoint:
         config = BifrostConfig(
             providers={"anthropic": ProviderConfig(models=["claude-sonnet-4-6"])}
         )
-        app = create_app(config)
         _store_patch = "bifrost.adapters.memory_store.MemoryUsageStore.summarise"
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_http = AsyncMock()
+        mock_http.head = AsyncMock(return_value=mock_resp)
+        mock_http.aclose = AsyncMock()
         with (
-            patch("bifrost.inbound.observability.httpx.AsyncClient") as mock_client_cls,
+            patch("bifrost.inbound.observability.httpx.AsyncClient", return_value=mock_http),
             patch(_store_patch, new_callable=AsyncMock) as mock_summarise,
         ):
             mock_summarise.side_effect = RuntimeError("db down")
-            mock_resp = MagicMock()
-            mock_resp.status_code = 200
-            mock_http = AsyncMock()
-            mock_http.head = AsyncMock(return_value=mock_resp)
-            mock_http.__aenter__ = AsyncMock(return_value=mock_http)
-            mock_http.__aexit__ = AsyncMock(return_value=False)
-            mock_client_cls.return_value = mock_http
-
+            app = create_app(config)
             with TestClient(app) as client:
                 resp = client.get("/readyz")
         assert resp.status_code == 503
@@ -364,19 +357,16 @@ class TestReadyzEndpoint:
         config = BifrostConfig(
             providers={"anthropic": ProviderConfig(models=["claude-sonnet-4-6"])}
         )
-        app = create_app(config)
         _store_patch = "bifrost.adapters.memory_store.MemoryUsageStore.summarise"
+        mock_http = AsyncMock()
+        mock_http.head = AsyncMock(side_effect=Exception("connection refused"))
+        mock_http.aclose = AsyncMock()
         with (
-            patch("bifrost.inbound.observability.httpx.AsyncClient") as mock_client_cls,
+            patch("bifrost.inbound.observability.httpx.AsyncClient", return_value=mock_http),
             patch(_store_patch, new_callable=AsyncMock) as mock_summarise,
         ):
             mock_summarise.return_value = MagicMock()
-            mock_http = AsyncMock()
-            mock_http.head = AsyncMock(side_effect=Exception("connection refused"))
-            mock_http.__aenter__ = AsyncMock(return_value=mock_http)
-            mock_http.__aexit__ = AsyncMock(return_value=False)
-            mock_client_cls.return_value = mock_http
-
+            app = create_app(config)
             with TestClient(app) as client:
                 resp = client.get("/readyz")
         assert resp.status_code == 503


### PR DESCRIPTION
## Summary

- **Prometheus metrics** (`src/bifrost/metrics.py`): Zero-dependency thread-safe registry generating Prometheus text-format output. Records `bifrost_requests_total`, `bifrost_request_duration_seconds`, `bifrost_tokens_total`, `bifrost_cost_usd_total`, `bifrost_cache_hits_total/misses`, `bifrost_quota_rejections_total`, and `bifrost_rule_hits_total`.
- **Observability endpoints** (`src/bifrost/inbound/observability.py`): `GET /metrics` (Prometheus text), `GET /healthz` (liveness, always 200), `GET /readyz` (readiness — 200 when store + at least one provider are reachable).
- **Kubernetes Helm chart** (`charts/bifrost/`): Deployment (stateless, rolling update, hardened security), Service, ConfigMap (bifrost.yaml), ExternalSecret (OpenBao via ESO), HPA (CPU + RPS), PodDisruptionBudget.
- **Metric hooks**: `routes.py` records cache hit/miss, quota rejections, and request metrics; `tracking.py` records streaming request metrics; `domain/routing.py` records rule hits.

## Test plan

- [x] 34 new tests in `tests/test_bifrost/test_metrics.py` covering Counter, Histogram, Registry, label helpers, convenience helpers, and all three HTTP endpoints
- [x] All 874 bifrost tests pass (`pytest tests/test_bifrost/`)
- [x] Coverage >= 85% (overall 94%, `metrics.py` 94%, `observability.py` 95%)
- [x] `ruff check` and `ruff format` clean

## Linear ticket

NIU-487: https://linear.app/niuu/issue/NIU-487/kubernetes-deployment-and-prometheus-metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)