### PR TITLE
feat(adapters): MCP client integration — stdio, SSE, HTTP transports (NIU-430)

### DIFF
--- a/src/ravn/adapters/mcp/__init__.py
+++ b/src/ravn/adapters/mcp/__init__.py
@@ -1,0 +1,19 @@
+"""MCP (Model Context Protocol) client adapter for Ravn.
+
+Implements the full MCP lifecycle:
+  ConfigLoad → SpawnConnect → InitializeHandshake → ToolDiscovery
+  → ResourceDiscovery → Registration → Invocation → Shutdown
+
+Supports stdio and SSE/HTTP transports.
+"""
+
+from ravn.adapters.mcp.lifecycle import MCPLifecyclePhase, MCPServerState
+from ravn.adapters.mcp.manager import MCPManager
+from ravn.adapters.mcp.tool import MCPTool
+
+__all__ = [
+    "MCPLifecyclePhase",
+    "MCPManager",
+    "MCPServerState",
+    "MCPTool",
+]

--- a/src/ravn/adapters/mcp/client.py
+++ b/src/ravn/adapters/mcp/client.py
@@ -1,0 +1,220 @@
+"""MCPServerClient — manages the full lifecycle for a single MCP server."""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from ravn.adapters.mcp.lifecycle import MCPLifecyclePhase, MCPServerState
+from ravn.adapters.mcp.protocol import (
+    MCPProtocolError,
+    extract_result,
+    make_initialize_request,
+    make_initialized_notification,
+    make_resources_list_request,
+    make_tool_call_request,
+    make_tools_list_request,
+    parse_tool_call_result,
+    parse_tool_definitions,
+)
+from ravn.adapters.mcp.transport import MCPTransport, MCPTransportError
+from ravn.domain.models import ToolResult
+
+logger = logging.getLogger(__name__)
+
+# Characters that are illegal in normalised server names.
+_INVALID_NAME_RE = re.compile(r"[^a-zA-Z0-9_]")
+
+
+def normalise_server_name(name: str) -> str:
+    """Convert a server name to a safe identifier component.
+
+    Spaces become underscores; all other non-alphanumeric characters are
+    stripped.  The result is lowercased.
+
+    >>> normalise_server_name("My Server!")
+    'my_server'
+    """
+    return _INVALID_NAME_RE.sub("", name.replace(" ", "_")).lower()
+
+
+def make_tool_prefix(server_name: str) -> str:
+    """Return the tool name prefix for *server_name*."""
+    return f"mcp__{normalise_server_name(server_name)}__"
+
+
+@dataclass
+class MCPServerHealth:
+    """Tracks the health and lifecycle phase of a single server."""
+
+    state: MCPServerState = MCPServerState.DISCONNECTED
+    phase: MCPLifecyclePhase = MCPLifecyclePhase.CONFIG_LOAD
+    error: str = ""
+    server_info: dict[str, Any] = field(default_factory=dict)
+
+
+class MCPServerClient:
+    """Manages the complete lifecycle of a single MCP server connection.
+
+    Usage::
+
+        client = MCPServerClient(name="linear", transport=StdioTransport(...))
+        tools = await client.connect()   # list[ToolDefinition]
+        result = await client.call_tool("search_issues", {...})
+        await client.shutdown()
+
+    The caller is responsible for constructing the appropriate transport.
+    """
+
+    def __init__(self, name: str, transport: MCPTransport) -> None:
+        self._name = name
+        self._transport = transport
+        self._health = MCPServerHealth()
+        self._tool_defs: list[dict[str, Any]] = []
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def health(self) -> MCPServerHealth:
+        return self._health
+
+    @property
+    def tool_defs(self) -> list[dict[str, Any]]:
+        """Raw tool definitions returned by the server during discovery."""
+        return list(self._tool_defs)
+
+    @property
+    def is_healthy(self) -> bool:
+        return self._health.state == MCPServerState.CONNECTED
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def connect(self) -> list[dict[str, Any]]:
+        """Run the full connection + discovery lifecycle.
+
+        Returns the list of raw tool definitions on success.  On failure the
+        health state is set to ERROR and an empty list is returned — the
+        caller should check ``is_healthy`` before using returned tools.
+        """
+        await self._spawn_connect()
+        if not self.is_healthy:
+            return []
+
+        await self._initialize_handshake()
+        if not self.is_healthy:
+            return []
+
+        await self._discover_tools()
+        await self._discover_resources()
+
+        if self.is_healthy:
+            self._health.phase = MCPLifecyclePhase.READY
+            logger.info(
+                "MCP server %r ready — %d tool(s) available",
+                self._name,
+                len(self._tool_defs),
+            )
+
+        return list(self._tool_defs)
+
+    async def shutdown(self) -> None:
+        """Gracefully close the transport."""
+        self._health.phase = MCPLifecyclePhase.SHUTDOWN
+        try:
+            await self._transport.close()
+        except Exception as exc:
+            logger.debug("Error shutting down MCP server %r: %s", self._name, exc)
+        finally:
+            self._health.state = MCPServerState.DISCONNECTED
+
+    # ------------------------------------------------------------------
+    # Tool invocation
+    # ------------------------------------------------------------------
+
+    async def call_tool(self, tool_name: str, arguments: dict[str, Any]) -> ToolResult:
+        """Call a tool on the MCP server and return a ToolResult."""
+        if not self.is_healthy:
+            return ToolResult(
+                tool_call_id="",
+                content=f"MCP server {self._name!r} is not connected",
+                is_error=True,
+            )
+
+        self._health.phase = MCPLifecyclePhase.READY
+        request = make_tool_call_request(tool_name, arguments)
+        try:
+            await self._transport.send(request)
+            response = await self._transport.receive()
+            result = extract_result(response)
+            content, is_error = parse_tool_call_result(result)
+            return ToolResult(tool_call_id="", content=content, is_error=is_error)
+        except MCPProtocolError as exc:
+            return ToolResult(
+                tool_call_id="",
+                content=f"MCP tool error: {exc}",
+                is_error=True,
+            )
+        except MCPTransportError as exc:
+            self._set_error(str(exc))
+            return ToolResult(
+                tool_call_id="",
+                content=f"MCP transport error: {exc}",
+                is_error=True,
+            )
+
+    # ------------------------------------------------------------------
+    # Internal lifecycle steps
+    # ------------------------------------------------------------------
+
+    async def _spawn_connect(self) -> None:
+        self._health.state = MCPServerState.CONNECTING
+        self._health.phase = MCPLifecyclePhase.SPAWN_CONNECT
+        try:
+            await self._transport.start()
+            self._health.state = MCPServerState.CONNECTED
+        except MCPTransportError as exc:
+            self._set_error(str(exc))
+
+    async def _initialize_handshake(self) -> None:
+        self._health.phase = MCPLifecyclePhase.INITIALIZE_HANDSHAKE
+        try:
+            await self._transport.send(make_initialize_request())
+            response = await self._transport.receive()
+            result = extract_result(response)
+            self._health.server_info = result or {}
+            await self._transport.send(make_initialized_notification())
+        except (MCPTransportError, MCPProtocolError) as exc:
+            self._set_error(str(exc))
+
+    async def _discover_tools(self) -> None:
+        self._health.phase = MCPLifecyclePhase.TOOL_DISCOVERY
+        try:
+            await self._transport.send(make_tools_list_request())
+            response = await self._transport.receive()
+            result = extract_result(response)
+            self._tool_defs = parse_tool_definitions(result)
+        except (MCPTransportError, MCPProtocolError) as exc:
+            logger.warning("Tool discovery failed for %r: %s", self._name, exc)
+            # Tool discovery failure is non-fatal — server stays connected.
+            self._tool_defs = []
+
+    async def _discover_resources(self) -> None:
+        self._health.phase = MCPLifecyclePhase.RESOURCE_DISCOVERY
+        try:
+            await self._transport.send(make_resources_list_request())
+            response = await self._transport.receive()
+            extract_result(response)  # Ignore content; just validate no error.
+        except (MCPTransportError, MCPProtocolError) as exc:
+            logger.debug("Resource discovery for %r: %s", self._name, exc)
+            # Resource discovery failure is non-fatal.
+
+    def _set_error(self, message: str) -> None:
+        self._health.state = MCPServerState.ERROR
+        self._health.error = message
+        logger.warning("MCP server %r error: %s", self._name, message)

--- a/src/ravn/adapters/mcp/lifecycle.py
+++ b/src/ravn/adapters/mcp/lifecycle.py
@@ -1,0 +1,28 @@
+"""MCP lifecycle phase and server health state tracking."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class MCPLifecyclePhase(StrEnum):
+    """Phases in the MCP server connection lifecycle."""
+
+    CONFIG_LOAD = "config_load"
+    SPAWN_CONNECT = "spawn_connect"
+    INITIALIZE_HANDSHAKE = "initialize_handshake"
+    TOOL_DISCOVERY = "tool_discovery"
+    RESOURCE_DISCOVERY = "resource_discovery"
+    REGISTRATION = "registration"
+    READY = "ready"
+    SHUTDOWN = "shutdown"
+
+
+class MCPServerState(StrEnum):
+    """Per-server health states."""
+
+    DISCONNECTED = "disconnected"
+    CONNECTING = "connecting"
+    CONNECTED = "connected"
+    AUTH_REQUIRED = "auth_required"
+    ERROR = "error"

--- a/src/ravn/adapters/mcp/manager.py
+++ b/src/ravn/adapters/mcp/manager.py
@@ -1,0 +1,176 @@
+"""MCPManager — orchestrates multiple MCP servers with degraded-mode support.
+
+Responsibilities:
+- Parse ``MCPServerConfig`` entries from Settings.
+- Spawn/connect all enabled servers concurrently.
+- Register discovered tools with prefixed names in the Ravn ToolRegistry.
+- Detect naming collisions with built-in tools.
+- Operate in degraded mode: if some servers fail, healthy servers' tools
+  remain available.
+- Graceful shutdown: close all transports on agent exit.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from ravn.adapters.mcp.client import MCPServerClient, make_tool_prefix
+from ravn.adapters.mcp.lifecycle import MCPServerState
+from ravn.adapters.mcp.tool import MCPTool
+from ravn.adapters.mcp.transport import MCPTransport
+from ravn.config import MCPServerConfig
+from ravn.ports.tool import ToolPort
+
+logger = logging.getLogger(__name__)
+
+
+def _build_transport(cfg: MCPServerConfig) -> MCPTransport:
+    """Construct the appropriate transport for *cfg*."""
+    match cfg.transport:
+        case "stdio":
+            from ravn.adapters.mcp.stdio_transport import StdioTransport
+
+            return StdioTransport(
+                command=cfg.command,
+                args=list(cfg.args),
+                env=dict(cfg.env),
+            )
+        case "http":
+            from ravn.adapters.mcp.sse_transport import HTTPTransport
+
+            return HTTPTransport(url=cfg.url)
+        case "sse":
+            from ravn.adapters.mcp.sse_transport import SSETransport
+
+            return SSETransport(url=cfg.url)
+
+
+def _build_input_schema(tool_def: dict[str, Any]) -> dict[str, Any]:
+    """Extract or construct a valid JSON Schema from an MCP tool definition."""
+    schema = tool_def.get("inputSchema")
+    if isinstance(schema, dict):
+        return schema
+    return {"type": "object", "properties": {}}
+
+
+class MCPManager:
+    """Manages the lifecycle of all configured MCP servers.
+
+    Args:
+        configs: List of MCPServerConfig from Settings.mcp_servers.
+        builtin_tool_names: Set of already-registered tool names for
+            collision detection.
+    """
+
+    def __init__(
+        self,
+        configs: list[MCPServerConfig],
+        *,
+        builtin_tool_names: set[str] | None = None,
+    ) -> None:
+        self._configs = [c for c in configs if c.enabled]
+        self._builtin_names: set[str] = builtin_tool_names or set()
+        self._clients: list[MCPServerClient] = []
+        self._tools: list[MCPTool] = []
+
+    @property
+    def tools(self) -> list[ToolPort]:
+        """All successfully discovered and registered MCP tools."""
+        return list(self._tools)
+
+    @property
+    def server_states(self) -> dict[str, MCPServerState]:
+        """Per-server health states keyed by server name."""
+        return {c.name: c.health.state for c in self._clients}
+
+    async def start(self) -> list[ToolPort]:
+        """Connect all configured MCP servers and return discovered tools.
+
+        Servers that fail to connect are skipped (degraded mode).  Tools from
+        healthy servers are returned even if some servers are unhealthy.
+        """
+        if not self._configs:
+            return []
+
+        logger.debug("Starting %d MCP server(s)", len(self._configs))
+        tasks = [self._start_one(cfg) for cfg in self._configs]
+        await asyncio.gather(*tasks, return_exceptions=True)
+        return list(self._tools)
+
+    async def shutdown(self) -> None:
+        """Gracefully close all server connections."""
+        if not self._clients:
+            return
+        await asyncio.gather(
+            *(c.shutdown() for c in self._clients),
+            return_exceptions=True,
+        )
+        self._clients.clear()
+        self._tools.clear()
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    async def _start_one(self, cfg: MCPServerConfig) -> None:
+        """Connect a single server and register its tools."""
+        transport = _build_transport(cfg)
+        client = MCPServerClient(name=cfg.name, transport=transport)
+        self._clients.append(client)
+
+        tool_defs = await client.connect()
+
+        if not client.is_healthy:
+            logger.warning(
+                "MCP server %r failed to connect (%s): %s — degraded mode",
+                cfg.name,
+                client.health.phase,
+                client.health.error,
+            )
+            return
+
+        self._register_tools(client, tool_defs)
+
+    def _register_tools(
+        self,
+        client: MCPServerClient,
+        tool_defs: list[dict[str, Any]],
+    ) -> None:
+        """Create MCPTool instances for each discovered tool, with collision checks."""
+        prefix = make_tool_prefix(client.name)
+
+        for tool_def in tool_defs:
+            original_name = tool_def.get("name", "")
+            if not original_name:
+                continue
+
+            prefixed_name = f"{prefix}{original_name}"
+
+            if prefixed_name in self._builtin_names:
+                logger.warning(
+                    "MCP tool %r from server %r collides with a built-in tool — skipping",
+                    prefixed_name,
+                    client.name,
+                )
+                continue
+
+            description = tool_def.get("description", f"MCP tool: {original_name}")
+            input_schema = _build_input_schema(tool_def)
+
+            mcp_tool = MCPTool(
+                server_client=client,
+                original_name=original_name,
+                prefixed_name=prefixed_name,
+                description=description,
+                input_schema=input_schema,
+            )
+            self._tools.append(mcp_tool)
+            logger.debug("Registered MCP tool %r (server: %r)", prefixed_name, client.name)
+
+        logger.info(
+            "MCP server %r: registered %d tool(s)",
+            client.name,
+            sum(1 for t in self._tools if t.name.startswith(prefix)),
+        )

--- a/src/ravn/adapters/mcp/manager.py
+++ b/src/ravn/adapters/mcp/manager.py
@@ -36,15 +36,22 @@ def _build_transport(cfg: MCPServerConfig) -> MCPTransport:
                 command=cfg.command,
                 args=list(cfg.args),
                 env=dict(cfg.env),
+                read_timeout=cfg.timeout,
             )
         case "http":
             from ravn.adapters.mcp.sse_transport import HTTPTransport
 
-            return HTTPTransport(url=cfg.url)
+            return HTTPTransport(url=cfg.url, timeout=cfg.timeout)
         case "sse":
             from ravn.adapters.mcp.sse_transport import SSETransport
 
-            return SSETransport(url=cfg.url)
+            return SSETransport(
+                url=cfg.url,
+                timeout=cfg.timeout,
+                connect_timeout=cfg.connect_timeout,
+            )
+        case _:
+            raise ValueError(f"Unknown MCP transport type: {cfg.transport!r}")
 
 
 def _build_input_schema(tool_def: dict[str, Any]) -> dict[str, Any]:

--- a/src/ravn/adapters/mcp/protocol.py
+++ b/src/ravn/adapters/mcp/protocol.py
@@ -1,0 +1,125 @@
+"""MCP JSON-RPC 2.0 protocol helpers.
+
+Handles message construction and response parsing for the MCP wire protocol.
+"""
+
+from __future__ import annotations
+
+import itertools
+from typing import Any
+
+# MCP protocol version advertised during handshake.
+MCP_PROTOCOL_VERSION = "2024-11-05"
+
+_id_counter = itertools.count(1)
+
+
+def next_id() -> int:
+    return next(_id_counter)
+
+
+def make_request(method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Build a JSON-RPC 2.0 request."""
+    msg: dict[str, Any] = {
+        "jsonrpc": "2.0",
+        "id": next_id(),
+        "method": method,
+    }
+    if params is not None:
+        msg["params"] = params
+    return msg
+
+
+def make_notification(method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Build a JSON-RPC 2.0 notification (no id, no response expected)."""
+    msg: dict[str, Any] = {"jsonrpc": "2.0", "method": method}
+    if params is not None:
+        msg["params"] = params
+    return msg
+
+
+def make_initialize_request() -> dict[str, Any]:
+    return make_request(
+        "initialize",
+        {
+            "protocolVersion": MCP_PROTOCOL_VERSION,
+            "capabilities": {"tools": {}, "resources": {}},
+            "clientInfo": {"name": "ravn", "version": "1.0.0"},
+        },
+    )
+
+
+def make_initialized_notification() -> dict[str, Any]:
+    return make_notification("notifications/initialized")
+
+
+def make_tools_list_request() -> dict[str, Any]:
+    return make_request("tools/list")
+
+
+def make_resources_list_request() -> dict[str, Any]:
+    return make_request("resources/list")
+
+
+def make_tool_call_request(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    return make_request("tools/call", {"name": name, "arguments": arguments})
+
+
+# ---------------------------------------------------------------------------
+# Response parsing
+# ---------------------------------------------------------------------------
+
+
+class MCPProtocolError(Exception):
+    """Raised when the server returns a JSON-RPC error response."""
+
+    def __init__(self, code: int, message: str, data: Any = None) -> None:
+        self.code = code
+        self.data = data
+        super().__init__(f"MCP error {code}: {message}")
+
+
+def extract_result(response: dict[str, Any]) -> Any:
+    """Return the ``result`` field or raise MCPProtocolError on error."""
+    if "error" in response:
+        err = response["error"]
+        raise MCPProtocolError(
+            code=err.get("code", -1),
+            message=err.get("message", "unknown error"),
+            data=err.get("data"),
+        )
+    return response.get("result")
+
+
+def parse_tool_definitions(result: Any) -> list[dict[str, Any]]:
+    """Extract the list of tool defs from a ``tools/list`` result."""
+    if not isinstance(result, dict):
+        return []
+    return list(result.get("tools", []))
+
+
+def parse_tool_call_result(result: Any) -> tuple[str, bool]:
+    """Return (content_text, is_error) from a ``tools/call`` result."""
+    if not isinstance(result, dict):
+        return (str(result), False)
+
+    is_error: bool = bool(result.get("isError", False))
+    content_blocks = result.get("content", [])
+
+    if not content_blocks:
+        return ("", is_error)
+
+    parts: list[str] = []
+    for block in content_blocks:
+        if isinstance(block, dict):
+            block_type = block.get("type", "text")
+            if block_type == "text":
+                parts.append(str(block.get("text", "")))
+            elif block_type == "image":
+                parts.append(f"[image: {block.get('mimeType', 'unknown')}]")
+            else:
+                parts.append(str(block.get("text", str(block))))
+        else:
+            parts.append(str(block))
+
+    return ("\n".join(parts), is_error)

--- a/src/ravn/adapters/mcp/sse_transport.py
+++ b/src/ravn/adapters/mcp/sse_transport.py
@@ -1,0 +1,215 @@
+"""SSE and HTTP MCP transports.
+
+SSETransport — connects to a server-sent event endpoint.  The server sends
+an ``endpoint`` event containing the URL to POST messages to; responses
+arrive as ``message`` events on the SSE stream.
+
+HTTPTransport — simpler request/response: POST JSON-RPC, receive JSON reply.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any
+
+from ravn.adapters.mcp.transport import MCPTransport, MCPTransportError
+
+logger = logging.getLogger(__name__)
+
+_CONNECT_TIMEOUT_SECONDS = 10.0
+_REQUEST_TIMEOUT_SECONDS = 30.0
+_RECEIVE_QUEUE_SIZE = 256
+
+
+class HTTPTransport(MCPTransport):
+    """Simple HTTP transport: each JSON-RPC call is a POST → response pair.
+
+    Uses httpx for async HTTP; httpx is available in the project via the
+    web_fetch tool dependency.  Falls back gracefully if unavailable.
+    """
+
+    def __init__(self, url: str, *, timeout: float = _REQUEST_TIMEOUT_SECONDS) -> None:
+        self._url = url
+        self._timeout = timeout
+        self._client: Any = None
+        self._started = False
+
+    async def start(self) -> None:
+        try:
+            import httpx
+
+            self._client = httpx.AsyncClient(timeout=self._timeout)
+            self._started = True
+        except ImportError as exc:
+            raise MCPTransportError("httpx is required for HTTP transport") from exc
+
+    async def send(self, message: dict[str, Any]) -> None:
+        if not self._started:
+            raise MCPTransportError("Transport not started")
+        self._pending_message = message
+
+    async def receive(self) -> dict[str, Any]:
+        if not self._started:
+            raise MCPTransportError("Transport not started")
+        message = getattr(self, "_pending_message", None)
+        if message is None:
+            raise MCPTransportError("No pending message to send")
+        self._pending_message = None
+
+        try:
+            response = await self._client.post(
+                self._url,
+                json=message,
+                headers={"Content-Type": "application/json"},
+            )
+            response.raise_for_status()
+            return response.json()  # type: ignore[return-value]
+        except Exception as exc:
+            raise MCPTransportError(f"HTTP request failed: {exc}") from exc
+
+    async def close(self) -> None:
+        if self._client is not None:
+            try:
+                await self._client.aclose()
+            except Exception as exc:
+                logger.debug("Error closing HTTP transport: %s", exc)
+            self._client = None
+        self._started = False
+
+    @property
+    def is_alive(self) -> bool:
+        return self._started and self._client is not None
+
+
+class SSETransport(MCPTransport):
+    """Server-Sent Events MCP transport.
+
+    Protocol:
+    1. Connect to ``url`` as an SSE stream.
+    2. Wait for the server to emit an ``endpoint`` event with a POST URL.
+    3. POST JSON-RPC messages to that endpoint.
+    4. Receive responses as ``message`` events on the SSE stream.
+    """
+
+    def __init__(self, url: str, *, timeout: float = _REQUEST_TIMEOUT_SECONDS) -> None:
+        self._url = url
+        self._timeout = timeout
+        self._post_url: str | None = None
+        self._response_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(
+            maxsize=_RECEIVE_QUEUE_SIZE
+        )
+        self._client: Any = None
+        self._sse_task: asyncio.Task | None = None  # type: ignore[type-arg]
+        self._started = False
+
+    async def start(self) -> None:
+        try:
+            import httpx
+
+            self._client = httpx.AsyncClient(timeout=None)
+        except ImportError as exc:
+            raise MCPTransportError("httpx is required for SSE transport") from exc
+
+        # Start the SSE reader in the background and wait for the endpoint event.
+        endpoint_ready: asyncio.Future[str] = asyncio.get_event_loop().create_future()
+        self._sse_task = asyncio.create_task(
+            self._read_sse(endpoint_ready),
+            name="mcp-sse-reader",
+        )
+
+        try:
+            self._post_url = await asyncio.wait_for(
+                endpoint_ready,
+                timeout=_CONNECT_TIMEOUT_SECONDS,
+            )
+        except TimeoutError:
+            self._sse_task.cancel()
+            raise MCPTransportError("Timed out waiting for SSE endpoint event")
+
+        self._started = True
+
+    async def _read_sse(self, endpoint_ready: asyncio.Future[str]) -> None:
+        """Background task: read SSE stream, route events to queues."""
+        event_type = "message"
+        buffer: list[str] = []
+
+        try:
+            async with self._client.stream("GET", self._url) as response:
+                async for line in response.aiter_lines():
+                    if line.startswith("event:"):
+                        event_type = line[len("event:") :].strip()
+                        continue
+                    if line.startswith("data:"):
+                        buffer.append(line[len("data:") :].strip())
+                        continue
+                    if line == "":
+                        # End of event block — dispatch.
+                        data = "\n".join(buffer)
+                        buffer.clear()
+
+                        if event_type == "endpoint":
+                            if not endpoint_ready.done():
+                                endpoint_ready.set_result(data.strip())
+                        elif event_type == "message" and data:
+                            try:
+                                parsed = json.loads(data)
+                                await self._response_queue.put(parsed)
+                            except (ValueError, asyncio.QueueFull):
+                                logger.warning("Dropped SSE message (parse error or queue full)")
+
+                        event_type = "message"
+        except asyncio.CancelledError:
+            pass
+        except Exception as exc:
+            if not endpoint_ready.done():
+                endpoint_ready.set_exception(MCPTransportError(f"SSE stream error: {exc}"))
+            logger.debug("SSE stream ended: %s", exc)
+
+    async def send(self, message: dict[str, Any]) -> None:
+        if not self._started or self._post_url is None:
+            raise MCPTransportError("SSE transport not started")
+        try:
+            response = await self._client.post(
+                self._post_url,
+                json=message,
+                headers={"Content-Type": "application/json"},
+                timeout=self._timeout,
+            )
+            response.raise_for_status()
+        except Exception as exc:
+            raise MCPTransportError(f"SSE POST failed: {exc}") from exc
+
+    async def receive(self) -> dict[str, Any]:
+        if not self._started:
+            raise MCPTransportError("SSE transport not started")
+        try:
+            return await asyncio.wait_for(
+                self._response_queue.get(),
+                timeout=self._timeout,
+            )
+        except TimeoutError:
+            raise MCPTransportError("Timed out waiting for SSE response")
+
+    async def close(self) -> None:
+        if self._sse_task is not None:
+            self._sse_task.cancel()
+            try:
+                await self._sse_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._sse_task = None
+
+        if self._client is not None:
+            try:
+                await self._client.aclose()
+            except Exception as exc:
+                logger.debug("Error closing SSE client: %s", exc)
+            self._client = None
+
+        self._started = False
+
+    @property
+    def is_alive(self) -> bool:
+        return self._started and self._sse_task is not None and not self._sse_task.done()

--- a/src/ravn/adapters/mcp/sse_transport.py
+++ b/src/ravn/adapters/mcp/sse_transport.py
@@ -93,9 +93,16 @@ class SSETransport(MCPTransport):
     4. Receive responses as ``message`` events on the SSE stream.
     """
 
-    def __init__(self, url: str, *, timeout: float = _REQUEST_TIMEOUT_SECONDS) -> None:
+    def __init__(
+        self,
+        url: str,
+        *,
+        timeout: float = _REQUEST_TIMEOUT_SECONDS,
+        connect_timeout: float = _CONNECT_TIMEOUT_SECONDS,
+    ) -> None:
         self._url = url
         self._timeout = timeout
+        self._connect_timeout = connect_timeout
         self._post_url: str | None = None
         self._response_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(
             maxsize=_RECEIVE_QUEUE_SIZE
@@ -113,7 +120,7 @@ class SSETransport(MCPTransport):
             raise MCPTransportError("httpx is required for SSE transport") from exc
 
         # Start the SSE reader in the background and wait for the endpoint event.
-        endpoint_ready: asyncio.Future[str] = asyncio.get_event_loop().create_future()
+        endpoint_ready: asyncio.Future[str] = asyncio.get_running_loop().create_future()
         self._sse_task = asyncio.create_task(
             self._read_sse(endpoint_ready),
             name="mcp-sse-reader",
@@ -122,7 +129,7 @@ class SSETransport(MCPTransport):
         try:
             self._post_url = await asyncio.wait_for(
                 endpoint_ready,
-                timeout=_CONNECT_TIMEOUT_SECONDS,
+                timeout=self._connect_timeout,
             )
         except TimeoutError:
             self._sse_task.cancel()

--- a/src/ravn/adapters/mcp/stdio_transport.py
+++ b/src/ravn/adapters/mcp/stdio_transport.py
@@ -1,0 +1,108 @@
+"""Stdio MCP transport — spawns a subprocess and communicates via stdin/stdout."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any
+
+from ravn.adapters.mcp.transport import MCPTransport, MCPTransportError
+
+logger = logging.getLogger(__name__)
+
+_READ_TIMEOUT_SECONDS = 30.0
+_PROCESS_WAIT_TIMEOUT_SECONDS = 5.0
+
+
+class StdioTransport(MCPTransport):
+    """Communicates with an MCP server over stdin/stdout.
+
+    The server is spawned as a subprocess.  Messages are newline-delimited
+    JSON-RPC 2.0 frames sent over stdin; responses are read from stdout.
+    """
+
+    def __init__(
+        self,
+        command: str,
+        args: list[str],
+        env: dict[str, str] | None = None,
+        *,
+        read_timeout: float = _READ_TIMEOUT_SECONDS,
+    ) -> None:
+        self._command = command
+        self._args = args
+        self._env = env or {}
+        self._read_timeout = read_timeout
+        self._process: asyncio.subprocess.Process | None = None
+
+    async def start(self) -> None:
+        """Spawn the subprocess."""
+        merged_env = {**os.environ, **self._env}
+        try:
+            self._process = await asyncio.create_subprocess_exec(
+                self._command,
+                *self._args,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=merged_env,
+            )
+        except (FileNotFoundError, PermissionError) as exc:
+            raise MCPTransportError(f"Failed to spawn MCP server: {exc}") from exc
+
+        logger.debug("Spawned MCP stdio server pid=%s", self._process.pid)
+
+    async def send(self, message: dict[str, Any]) -> None:
+        if self._process is None or self._process.stdin is None:
+            raise MCPTransportError("Transport not started")
+        if self._process.returncode is not None:
+            raise MCPTransportError("MCP server process has exited")
+
+        data = self._encode(message)
+        self._process.stdin.write(data)
+        await self._process.stdin.drain()
+
+    async def receive(self) -> dict[str, Any]:
+        if self._process is None or self._process.stdout is None:
+            raise MCPTransportError("Transport not started")
+
+        try:
+            line = await asyncio.wait_for(
+                self._process.stdout.readline(),
+                timeout=self._read_timeout,
+            )
+        except TimeoutError:
+            raise MCPTransportError("Timed out waiting for MCP server response")
+
+        if not line:
+            raise MCPTransportError("MCP server closed stdout (EOF)")
+
+        try:
+            return self._decode(line)
+        except (ValueError, KeyError) as exc:
+            raise MCPTransportError(f"Invalid JSON from MCP server: {exc}") from exc
+
+    async def close(self) -> None:
+        if self._process is None:
+            return
+
+        try:
+            if self._process.stdin is not None:
+                self._process.stdin.close()
+            try:
+                await asyncio.wait_for(
+                    self._process.wait(),
+                    timeout=_PROCESS_WAIT_TIMEOUT_SECONDS,
+                )
+            except TimeoutError:
+                self._process.kill()
+                await self._process.wait()
+        except Exception as exc:
+            logger.debug("Error closing stdio transport: %s", exc)
+        finally:
+            self._process = None
+
+    @property
+    def is_alive(self) -> bool:
+        return self._process is not None and self._process.returncode is None

--- a/src/ravn/adapters/mcp/tool.py
+++ b/src/ravn/adapters/mcp/tool.py
@@ -1,0 +1,62 @@
+"""MCPTool — a ToolPort that proxies calls to an MCP server tool."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from ravn.domain.models import ToolResult
+from ravn.ports.tool import ToolPort
+
+if TYPE_CHECKING:
+    from ravn.adapters.mcp.client import MCPServerClient
+
+logger = logging.getLogger(__name__)
+
+
+class MCPTool(ToolPort):
+    """A ToolPort whose execution is proxied to a remote MCP server tool.
+
+    Registered in the Ravn tool registry under the prefixed name
+    ``mcp__{server_name}__{original_tool_name}``.
+
+    Args:
+        server_client: The live MCPServerClient managing the connection.
+        original_name: The tool name as advertised by the MCP server.
+        prefixed_name: The prefixed name used in the Ravn registry.
+        description: Tool description from the server.
+        input_schema: JSON Schema from the server.
+    """
+
+    def __init__(
+        self,
+        server_client: MCPServerClient,
+        original_name: str,
+        prefixed_name: str,
+        description: str,
+        input_schema: dict[str, Any],
+    ) -> None:
+        self._server_client = server_client
+        self._original_name = original_name
+        self._prefixed_name = prefixed_name
+        self._description = description
+        self._input_schema = input_schema
+
+    @property
+    def name(self) -> str:
+        return self._prefixed_name
+
+    @property
+    def description(self) -> str:
+        return self._description
+
+    @property
+    def input_schema(self) -> dict:
+        return self._input_schema
+
+    @property
+    def required_permission(self) -> str:
+        return "mcp:call"
+
+    async def execute(self, input: dict) -> ToolResult:
+        return await self._server_client.call_tool(self._original_name, input)

--- a/src/ravn/adapters/mcp/transport.py
+++ b/src/ravn/adapters/mcp/transport.py
@@ -1,0 +1,57 @@
+"""Abstract MCP transport protocol.
+
+Each concrete transport handles the wire-level JSON-RPC 2.0 communication
+with a single MCP server process or endpoint.
+"""
+
+from __future__ import annotations
+
+import abc
+import json
+from typing import Any
+
+
+class MCPTransportError(Exception):
+    """Raised when transport-level communication fails."""
+
+
+class MCPTransport(abc.ABC):
+    """Abstract base class for MCP transports.
+
+    Responsible for sending JSON-RPC requests and receiving responses.
+    Transport instances are not thread-safe; use one per server connection.
+    """
+
+    @abc.abstractmethod
+    async def start(self) -> None:
+        """Start the transport (spawn process, open connection, etc.)."""
+
+    @abc.abstractmethod
+    async def send(self, message: dict[str, Any]) -> None:
+        """Send a JSON-RPC message to the server."""
+
+    @abc.abstractmethod
+    async def receive(self) -> dict[str, Any]:
+        """Receive and parse the next JSON-RPC message from the server."""
+
+    @abc.abstractmethod
+    async def close(self) -> None:
+        """Gracefully shut down the transport."""
+
+    @property
+    @abc.abstractmethod
+    def is_alive(self) -> bool:
+        """Return True if the transport connection is alive."""
+
+    # ------------------------------------------------------------------
+    # Helpers shared by all transports
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _encode(message: dict[str, Any]) -> bytes:
+        return (json.dumps(message) + "\n").encode()
+
+    @staticmethod
+    def _decode(line: bytes | str) -> dict[str, Any]:
+        text = line.decode() if isinstance(line, bytes) else line
+        return json.loads(text.strip())  # type: ignore[return-value]

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -489,9 +489,9 @@ class MCPServerConfig(BaseModel):
     """Configuration for a single MCP server."""
 
     name: str = Field(description="Human-readable name for this server.")
-    transport: Literal["stdio", "http"] = Field(
+    transport: Literal["stdio", "sse", "http"] = Field(
         default="stdio",
-        description="Transport type: 'stdio' or 'http'.",
+        description="Transport type: 'stdio', 'sse', or 'http'.",
     )
     command: str = Field(
         default="",

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -504,7 +504,15 @@ class MCPServerConfig(BaseModel):
     )
     url: str = Field(
         default="",
-        description="URL for http transport.",
+        description="URL for http/sse transport.",
+    )
+    timeout: float = Field(
+        default=30.0,
+        description="Request/read timeout in seconds.",
+    )
+    connect_timeout: float = Field(
+        default=10.0,
+        description="Connection timeout in seconds (SSE transport).",
     )
     enabled: bool = Field(default=True)
 

--- a/tests/ravn/unit/test_mcp_client.py
+++ b/tests/ravn/unit/test_mcp_client.py
@@ -1,0 +1,782 @@
+"""Unit tests for the MCP client adapter (NIU-430).
+
+Tests cover:
+- MCPLifecyclePhase and MCPServerState enums
+- Protocol helpers (message construction, result parsing)
+- Tool name normalisation and prefix generation
+- MCPTool ToolPort implementation
+- MCPServerClient lifecycle (connect, discover, call_tool, shutdown)
+- MCPManager (multi-server startup, degraded mode, collision detection)
+- Stdio transport error paths
+- HTTP / SSE transport stubs
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from ravn.adapters.mcp.client import (
+    MCPServerClient,
+    MCPServerHealth,
+    make_tool_prefix,
+    normalise_server_name,
+)
+from ravn.adapters.mcp.lifecycle import MCPLifecyclePhase, MCPServerState
+from ravn.adapters.mcp.manager import MCPManager, _build_input_schema
+from ravn.adapters.mcp.protocol import (
+    MCPProtocolError,
+    extract_result,
+    make_initialize_request,
+    make_initialized_notification,
+    make_request,
+    make_tool_call_request,
+    make_tools_list_request,
+    next_id,
+    parse_tool_call_result,
+    parse_tool_definitions,
+)
+from ravn.adapters.mcp.tool import MCPTool
+from ravn.adapters.mcp.transport import MCPTransport, MCPTransportError
+from ravn.config import MCPServerConfig
+from ravn.domain.models import ToolResult
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class FakeTransport(MCPTransport):
+    """Controllable in-memory transport for tests."""
+
+    def __init__(self, responses: list[dict[str, Any]] | None = None) -> None:
+        self._responses = iter(responses or [])
+        self.started = False
+        self.closed = False
+        self.sent: list[dict[str, Any]] = []
+        self._fail_start = False
+        self._fail_send = False
+        self._fail_receive = False
+
+    async def start(self) -> None:
+        if self._fail_start:
+            raise MCPTransportError("start failed")
+        self.started = True
+
+    async def send(self, message: dict[str, Any]) -> None:
+        if self._fail_send:
+            raise MCPTransportError("send failed")
+        self.sent.append(message)
+
+    async def receive(self) -> dict[str, Any]:
+        if self._fail_receive:
+            raise MCPTransportError("receive failed")
+        try:
+            return next(self._responses)
+        except StopIteration:
+            raise MCPTransportError("no more responses")
+
+    async def close(self) -> None:
+        self.closed = True
+
+    @property
+    def is_alive(self) -> bool:
+        return self.started and not self.closed
+
+
+def _make_ok_response(request_id: int, result: Any) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": request_id, "result": result}
+
+
+def _make_error_response(request_id: int, code: int, msg: str) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": request_id, "error": {"code": code, "message": msg}}
+
+
+def _tool_def(name: str, description: str = "A tool") -> dict[str, Any]:
+    return {
+        "name": name,
+        "description": description,
+        "inputSchema": {"type": "object", "properties": {"query": {"type": "string"}}},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle enums
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycleEnums:
+    def test_lifecycle_phases_are_strings(self) -> None:
+        assert MCPLifecyclePhase.CONFIG_LOAD == "config_load"
+        assert MCPLifecyclePhase.READY == "ready"
+        assert MCPLifecyclePhase.SHUTDOWN == "shutdown"
+
+    def test_server_states_are_strings(self) -> None:
+        assert MCPServerState.DISCONNECTED == "disconnected"
+        assert MCPServerState.CONNECTED == "connected"
+        assert MCPServerState.ERROR == "error"
+        assert MCPServerState.AUTH_REQUIRED == "auth_required"
+        assert MCPServerState.CONNECTING == "connecting"
+
+
+# ---------------------------------------------------------------------------
+# Protocol helpers
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolHelpers:
+    def test_make_request_has_jsonrpc(self) -> None:
+        req = make_request("ping")
+        assert req["jsonrpc"] == "2.0"
+        assert req["method"] == "ping"
+        assert "id" in req
+
+    def test_make_request_with_params(self) -> None:
+        req = make_request("add", {"a": 1, "b": 2})
+        assert req["params"] == {"a": 1, "b": 2}
+
+    def test_make_request_without_params(self) -> None:
+        req = make_request("ping")
+        assert "params" not in req
+
+    def test_next_id_increments(self) -> None:
+        a = next_id()
+        b = next_id()
+        assert b > a
+
+    def test_make_initialize_request(self) -> None:
+        req = make_initialize_request()
+        assert req["method"] == "initialize"
+        assert req["params"]["clientInfo"]["name"] == "ravn"
+        assert "protocolVersion" in req["params"]
+
+    def test_make_initialized_notification_has_no_id(self) -> None:
+        notif = make_initialized_notification()
+        assert notif["method"] == "notifications/initialized"
+        assert "id" not in notif
+
+    def test_make_tools_list_request(self) -> None:
+        req = make_tools_list_request()
+        assert req["method"] == "tools/list"
+
+    def test_make_tool_call_request(self) -> None:
+        req = make_tool_call_request("search", {"q": "hello"})
+        assert req["method"] == "tools/call"
+        assert req["params"]["name"] == "search"
+        assert req["params"]["arguments"] == {"q": "hello"}
+
+    def test_extract_result_ok(self) -> None:
+        result = extract_result({"jsonrpc": "2.0", "id": 1, "result": {"data": 42}})
+        assert result == {"data": 42}
+
+    def test_extract_result_raises_on_error(self) -> None:
+        with pytest.raises(MCPProtocolError) as exc_info:
+            extract_result({"jsonrpc": "2.0", "id": 1, "error": {"code": -32600, "message": "bad"}})
+        assert exc_info.value.code == -32600
+
+    def test_parse_tool_definitions_returns_list(self) -> None:
+        tools = parse_tool_definitions({"tools": [_tool_def("search")]})
+        assert len(tools) == 1
+        assert tools[0]["name"] == "search"
+
+    def test_parse_tool_definitions_empty(self) -> None:
+        assert parse_tool_definitions({}) == []
+        assert parse_tool_definitions(None) == []
+
+    def test_parse_tool_call_result_text(self) -> None:
+        result = {"content": [{"type": "text", "text": "hello"}], "isError": False}
+        content, is_error = parse_tool_call_result(result)
+        assert content == "hello"
+        assert not is_error
+
+    def test_parse_tool_call_result_error_flag(self) -> None:
+        result = {"content": [{"type": "text", "text": "oops"}], "isError": True}
+        _, is_error = parse_tool_call_result(result)
+        assert is_error
+
+    def test_parse_tool_call_result_image_block(self) -> None:
+        result = {
+            "content": [{"type": "image", "mimeType": "image/png"}],
+            "isError": False,
+        }
+        content, _ = parse_tool_call_result(result)
+        assert "image" in content
+
+    def test_parse_tool_call_result_multiple_blocks(self) -> None:
+        result = {
+            "content": [
+                {"type": "text", "text": "first"},
+                {"type": "text", "text": "second"},
+            ],
+            "isError": False,
+        }
+        content, _ = parse_tool_call_result(result)
+        assert "first" in content
+        assert "second" in content
+
+    def test_parse_tool_call_result_empty_content(self) -> None:
+        content, _ = parse_tool_call_result({"content": [], "isError": False})
+        assert content == ""
+
+    def test_parse_tool_call_result_non_dict(self) -> None:
+        content, is_error = parse_tool_call_result("raw string")
+        assert content == "raw string"
+        assert not is_error
+
+
+# ---------------------------------------------------------------------------
+# Server name normalisation
+# ---------------------------------------------------------------------------
+
+
+class TestServerNameNormalisation:
+    def test_spaces_become_underscores(self) -> None:
+        assert normalise_server_name("my server") == "my_server"
+
+    def test_special_chars_stripped(self) -> None:
+        assert normalise_server_name("my-server!") == "myserver"
+
+    def test_lowercased(self) -> None:
+        assert normalise_server_name("MyServer") == "myserver"
+
+    def test_prefix_format(self) -> None:
+        assert make_tool_prefix("linear") == "mcp__linear__"
+        assert make_tool_prefix("My Server") == "mcp__my_server__"
+
+
+# ---------------------------------------------------------------------------
+# MCPTool
+# ---------------------------------------------------------------------------
+
+
+class TestMCPTool:
+    def _make_client(self) -> MCPServerClient:
+        t = FakeTransport()
+        return MCPServerClient(name="test", transport=t)
+
+    def test_name(self) -> None:
+        client = self._make_client()
+        tool = MCPTool(
+            server_client=client,
+            original_name="search",
+            prefixed_name="mcp__test__search",
+            description="Search",
+            input_schema={"type": "object", "properties": {}},
+        )
+        assert tool.name == "mcp__test__search"
+
+    def test_description(self) -> None:
+        client = self._make_client()
+        tool = MCPTool(
+            server_client=client,
+            original_name="search",
+            prefixed_name="mcp__test__search",
+            description="Finds things",
+            input_schema={},
+        )
+        assert tool.description == "Finds things"
+
+    def test_required_permission(self) -> None:
+        client = self._make_client()
+        tool = MCPTool(
+            server_client=client,
+            original_name="x",
+            prefixed_name="mcp__t__x",
+            description="x",
+            input_schema={},
+        )
+        assert tool.required_permission == "mcp:call"
+
+    def test_to_api_dict(self) -> None:
+        client = self._make_client()
+        schema = {"type": "object", "properties": {"q": {"type": "string"}}}
+        tool = MCPTool(
+            server_client=client,
+            original_name="x",
+            prefixed_name="mcp__t__x",
+            description="desc",
+            input_schema=schema,
+        )
+        api = tool.to_api_dict()
+        assert api["name"] == "mcp__t__x"
+        assert api["description"] == "desc"
+        assert api["input_schema"] == schema
+
+    @pytest.mark.asyncio
+    async def test_execute_delegates_to_client(self) -> None:
+        client = self._make_client()
+        client._health.state = MCPServerState.CONNECTED
+
+        expected = ToolResult(tool_call_id="", content="result text", is_error=False)
+        client.call_tool = AsyncMock(return_value=expected)  # type: ignore[method-assign]
+
+        tool = MCPTool(
+            server_client=client,
+            original_name="search",
+            prefixed_name="mcp__test__search",
+            description="Search",
+            input_schema={},
+        )
+        result = await tool.execute({"query": "hello"})
+        assert result.content == "result text"
+        client.call_tool.assert_called_once_with("search", {"query": "hello"})
+
+
+# ---------------------------------------------------------------------------
+# MCPServerClient
+# ---------------------------------------------------------------------------
+
+
+def _make_healthy_client(
+    tool_names: list[str] | None = None,
+) -> tuple[MCPServerClient, FakeTransport]:
+    """Create a client wired to a FakeTransport that simulates a successful handshake."""
+    tool_names = tool_names or ["search", "create_issue"]
+    tools_result = {"tools": [_tool_def(n) for n in tool_names]}
+    resources_result = {"resources": []}
+
+    responses = [
+        # initialize → result
+        _make_ok_response(1, {"protocolVersion": "2024-11-05", "serverInfo": {"name": "test"}}),
+        # tools/list → result
+        _make_ok_response(2, tools_result),
+        # resources/list → result
+        _make_ok_response(3, resources_result),
+    ]
+    # Responses are keyed by arrival order, but our counter started at some
+    # offset — we can't predict the exact IDs, so FakeTransport ignores them.
+    transport = FakeTransport(responses=responses)
+    client = MCPServerClient(name="test", transport=transport)
+    return client, transport
+
+
+class TestMCPServerClientConnect:
+    @pytest.mark.asyncio
+    async def test_successful_connect(self) -> None:
+        client, transport = _make_healthy_client(["search", "create_issue"])
+        tools = await client.connect()
+        assert client.is_healthy
+        assert len(tools) == 2
+        assert transport.started
+
+    @pytest.mark.asyncio
+    async def test_connect_phase_is_ready_after_success(self) -> None:
+        client, _ = _make_healthy_client()
+        await client.connect()
+        assert client.health.phase == MCPLifecyclePhase.READY
+
+    @pytest.mark.asyncio
+    async def test_transport_start_failure_sets_error(self) -> None:
+        transport = FakeTransport()
+        transport._fail_start = True
+        client = MCPServerClient(name="broken", transport=transport)
+        tools = await client.connect()
+        assert not client.is_healthy
+        assert client.health.state == MCPServerState.ERROR
+        assert tools == []
+
+    @pytest.mark.asyncio
+    async def test_handshake_send_failure_sets_error(self) -> None:
+        transport = FakeTransport(responses=[])
+        transport._fail_send = True
+        client = MCPServerClient(name="broken", transport=transport)
+        # start should succeed, but send during handshake fails
+        transport._fail_start = False
+        await client.connect()
+        assert not client.is_healthy
+
+    @pytest.mark.asyncio
+    async def test_handshake_receive_failure_sets_error(self) -> None:
+        transport = FakeTransport(responses=[])
+        transport._fail_receive = True
+        client = MCPServerClient(name="broken", transport=transport)
+        await client.connect()
+        assert not client.is_healthy
+
+    @pytest.mark.asyncio
+    async def test_protocol_error_in_handshake_sets_error(self) -> None:
+        error_response = _make_error_response(99, -32600, "invalid request")
+        transport = FakeTransport(responses=[error_response])
+        client = MCPServerClient(name="broken", transport=transport)
+        await client.connect()
+        assert not client.is_healthy
+
+    @pytest.mark.asyncio
+    async def test_tool_discovery_failure_is_non_fatal(self) -> None:
+        """If tool discovery fails, the server stays connected but returns no tools."""
+        ok_handshake = _make_ok_response(1, {"protocolVersion": "2024-11-05", "serverInfo": {}})
+        tool_error = _make_error_response(2, -32601, "method not found")
+        resources_ok = _make_ok_response(3, {"resources": []})
+        transport = FakeTransport(responses=[ok_handshake, tool_error, resources_ok])
+        client = MCPServerClient(name="partial", transport=transport)
+        tools = await client.connect()
+        assert client.is_healthy  # Still connected
+        assert tools == []
+
+    @pytest.mark.asyncio
+    async def test_resource_discovery_failure_is_non_fatal(self) -> None:
+        ok_handshake = _make_ok_response(1, {"protocolVersion": "2024-11-05", "serverInfo": {}})
+        tools_ok = _make_ok_response(2, {"tools": [_tool_def("ping")]})
+        resources_error = _make_error_response(3, -32601, "method not found")
+        transport = FakeTransport(responses=[ok_handshake, tools_ok, resources_error])
+        client = MCPServerClient(name="noresources", transport=transport)
+        tools = await client.connect()
+        assert client.is_healthy
+        assert len(tools) == 1
+
+    @pytest.mark.asyncio
+    async def test_shutdown_closes_transport(self) -> None:
+        client, transport = _make_healthy_client()
+        await client.connect()
+        await client.shutdown()
+        assert transport.closed
+        assert client.health.state == MCPServerState.DISCONNECTED
+
+
+class TestMCPServerClientCallTool:
+    @pytest.mark.asyncio
+    async def test_call_tool_success(self) -> None:
+        client, transport = _make_healthy_client()
+        await client.connect()
+
+        # Add a tool call response to the transport's queue.
+        call_result = {"content": [{"type": "text", "text": "found it"}], "isError": False}
+        transport._responses = iter([_make_ok_response(99, call_result)])
+
+        result = await client.call_tool("search", {"query": "hello"})
+        assert not result.is_error
+        assert result.content == "found it"
+
+    @pytest.mark.asyncio
+    async def test_call_tool_when_not_connected(self) -> None:
+        transport = FakeTransport()
+        transport._fail_start = True
+        client = MCPServerClient(name="broken", transport=transport)
+        await client.connect()
+
+        result = await client.call_tool("search", {})
+        assert result.is_error
+        assert "not connected" in result.content
+
+    @pytest.mark.asyncio
+    async def test_call_tool_transport_error_sets_health(self) -> None:
+        client, transport = _make_healthy_client()
+        await client.connect()
+
+        transport._fail_send = True
+        result = await client.call_tool("search", {})
+        assert result.is_error
+        assert client.health.state == MCPServerState.ERROR
+
+    @pytest.mark.asyncio
+    async def test_call_tool_server_error_response(self) -> None:
+        client, transport = _make_healthy_client()
+        await client.connect()
+
+        transport._responses = iter([_make_error_response(99, -32000, "tool crashed")])
+        result = await client.call_tool("crash", {})
+        assert result.is_error
+        assert "tool crashed" in result.content
+
+    @pytest.mark.asyncio
+    async def test_call_tool_is_error_flag_propagated(self) -> None:
+        client, transport = _make_healthy_client()
+        await client.connect()
+
+        call_result = {"content": [{"type": "text", "text": "oops"}], "isError": True}
+        transport._responses = iter([_make_ok_response(99, call_result)])
+
+        result = await client.call_tool("broken_tool", {})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# MCPManager
+# ---------------------------------------------------------------------------
+
+
+def _stdio_cfg(name: str, **kwargs: Any) -> MCPServerConfig:
+    return MCPServerConfig(
+        name=name,
+        transport="stdio",
+        command="npx",
+        args=["-y", f"@mcp/{name}"],
+        **kwargs,
+    )
+
+
+def _http_cfg(name: str, url: str = "http://localhost:3000") -> MCPServerConfig:
+    return MCPServerConfig(name=name, transport="http", url=url)
+
+
+class TestMCPManager:
+    @pytest.mark.asyncio
+    async def test_no_configs_returns_empty(self) -> None:
+        mgr = MCPManager(configs=[])
+        tools = await mgr.start()
+        assert tools == []
+
+    @pytest.mark.asyncio
+    async def test_disabled_server_skipped(self) -> None:
+        cfg = _stdio_cfg("linear", enabled=False)
+        mgr = MCPManager(configs=[cfg])
+        tools = await mgr.start()
+        assert tools == []
+
+    @pytest.mark.asyncio
+    async def test_successful_server_registers_tools(self) -> None:
+        # Patch _build_transport to inject our FakeTransport.
+        client, transport = _make_healthy_client(["search"])
+        cfg = _stdio_cfg("linear")
+
+        with patch("ravn.adapters.mcp.manager._build_transport", return_value=transport):
+            mgr = MCPManager(configs=[cfg])
+            tools = await mgr.start()
+
+        assert len(tools) == 1
+        assert tools[0].name == "mcp__linear__search"
+
+    @pytest.mark.asyncio
+    async def test_degraded_mode_partial_failure(self) -> None:
+        """One server fails; the other's tools are still available."""
+        # Server 1: healthy
+        _, good_transport = _make_healthy_client(["ping"])
+        cfg1 = _stdio_cfg("good")
+
+        # Server 2: fails to start
+        bad_transport = FakeTransport()
+        bad_transport._fail_start = True
+        cfg2 = _stdio_cfg("bad")
+
+        def _select_transport(cfg: MCPServerConfig) -> FakeTransport:
+            return good_transport if cfg.name == "good" else bad_transport
+
+        with patch("ravn.adapters.mcp.manager._build_transport", side_effect=_select_transport):
+            mgr = MCPManager(configs=[cfg1, cfg2])
+            tools = await mgr.start()
+
+        assert len(tools) == 1
+        assert tools[0].name == "mcp__good__ping"
+        states = mgr.server_states
+        assert states["good"] == MCPServerState.CONNECTED
+        assert states["bad"] == MCPServerState.ERROR
+
+    @pytest.mark.asyncio
+    async def test_collision_with_builtin_tool_skipped(self) -> None:
+        _, transport = _make_healthy_client(["search"])
+        cfg = _stdio_cfg("linear")
+
+        with patch("ravn.adapters.mcp.manager._build_transport", return_value=transport):
+            mgr = MCPManager(
+                configs=[cfg],
+                builtin_tool_names={"mcp__linear__search"},
+            )
+            tools = await mgr.start()
+
+        assert tools == []
+
+    @pytest.mark.asyncio
+    async def test_shutdown_clears_clients(self) -> None:
+        _, transport = _make_healthy_client(["ping"])
+        cfg = _stdio_cfg("test")
+
+        with patch("ravn.adapters.mcp.manager._build_transport", return_value=transport):
+            mgr = MCPManager(configs=[cfg])
+            await mgr.start()
+
+        await mgr.shutdown()
+        assert mgr.server_states == {}
+        assert mgr.tools == []
+        assert transport.closed
+
+    @pytest.mark.asyncio
+    async def test_multiple_servers_both_healthy(self) -> None:
+        _, t1 = _make_healthy_client(["tool_a"])
+        _, t2 = _make_healthy_client(["tool_b"])
+
+        cfg1 = _stdio_cfg("server1")
+        cfg2 = _stdio_cfg("server2")
+
+        transports = iter([t1, t2])
+
+        build = lambda _: next(transports)  # noqa: E731
+        with patch("ravn.adapters.mcp.manager._build_transport", side_effect=build):
+            mgr = MCPManager(configs=[cfg1, cfg2])
+            tools = await mgr.start()
+
+        names = {t.name for t in tools}
+        assert "mcp__server1__tool_a" in names
+        assert "mcp__server2__tool_b" in names
+
+    @pytest.mark.asyncio
+    async def test_tool_with_empty_name_skipped(self) -> None:
+        """Tool definitions with empty or missing names are silently dropped."""
+        ok_handshake = _make_ok_response(1, {"protocolVersion": "2024-11-05", "serverInfo": {}})
+        tools_result = {"tools": [{"name": "", "description": "bad"}, _tool_def("good")]}
+        tools_ok = _make_ok_response(2, tools_result)
+        resources_ok = _make_ok_response(3, {"resources": []})
+        transport = FakeTransport(responses=[ok_handshake, tools_ok, resources_ok])
+        cfg = _stdio_cfg("test")
+
+        with patch("ravn.adapters.mcp.manager._build_transport", return_value=transport):
+            mgr = MCPManager(configs=[cfg])
+            tools = await mgr.start()
+
+        assert len(tools) == 1
+        assert tools[0].name == "mcp__test__good"
+
+    def test_server_states_empty_when_not_started(self) -> None:
+        mgr = MCPManager(configs=[_stdio_cfg("x")])
+        assert mgr.server_states == {}
+
+    def test_tools_empty_when_not_started(self) -> None:
+        mgr = MCPManager(configs=[_stdio_cfg("x")])
+        assert mgr.tools == []
+
+
+# ---------------------------------------------------------------------------
+# _build_input_schema helper
+# ---------------------------------------------------------------------------
+
+
+class TestBuildInputSchema:
+    def test_uses_server_schema_when_present(self) -> None:
+        tool_def = {"inputSchema": {"type": "object", "properties": {"q": {"type": "string"}}}}
+        schema = _build_input_schema(tool_def)
+        assert schema["properties"]["q"]["type"] == "string"
+
+    def test_falls_back_to_empty_object_schema(self) -> None:
+        schema = _build_input_schema({"name": "tool"})
+        assert schema == {"type": "object", "properties": {}}
+
+    def test_non_dict_schema_replaced(self) -> None:
+        schema = _build_input_schema({"inputSchema": "not a dict"})
+        assert schema == {"type": "object", "properties": {}}
+
+
+# ---------------------------------------------------------------------------
+# Transport base helpers
+# ---------------------------------------------------------------------------
+
+
+class TestTransportHelpers:
+    def test_encode_decode_roundtrip(self) -> None:
+        msg = {"jsonrpc": "2.0", "id": 1, "method": "ping"}
+        encoded = MCPTransport._encode(msg)
+        decoded = MCPTransport._decode(encoded)
+        assert decoded == msg
+
+    def test_decode_from_string(self) -> None:
+        msg = {"jsonrpc": "2.0", "id": 1, "result": "ok"}
+        import json
+
+        decoded = MCPTransport._decode(json.dumps(msg))
+        assert decoded == msg
+
+
+# ---------------------------------------------------------------------------
+# Stdio transport error paths (no subprocess spawning)
+# ---------------------------------------------------------------------------
+
+
+class TestStdioTransportErrors:
+    @pytest.mark.asyncio
+    async def test_send_before_start_raises(self) -> None:
+        from ravn.adapters.mcp.stdio_transport import StdioTransport
+
+        t = StdioTransport("echo", [])
+        with pytest.raises(MCPTransportError, match="not started"):
+            await t.send({"jsonrpc": "2.0"})
+
+    @pytest.mark.asyncio
+    async def test_receive_before_start_raises(self) -> None:
+        from ravn.adapters.mcp.stdio_transport import StdioTransport
+
+        t = StdioTransport("echo", [])
+        with pytest.raises(MCPTransportError, match="not started"):
+            await t.receive()
+
+    @pytest.mark.asyncio
+    async def test_is_alive_false_before_start(self) -> None:
+        from ravn.adapters.mcp.stdio_transport import StdioTransport
+
+        t = StdioTransport("echo", [])
+        assert not t.is_alive
+
+    @pytest.mark.asyncio
+    async def test_start_raises_on_bad_command(self) -> None:
+        from ravn.adapters.mcp.stdio_transport import StdioTransport
+
+        t = StdioTransport("__no_such_command_xyz__", [])
+        with pytest.raises(MCPTransportError):
+            await t.start()
+
+    @pytest.mark.asyncio
+    async def test_close_is_safe_before_start(self) -> None:
+        from ravn.adapters.mcp.stdio_transport import StdioTransport
+
+        t = StdioTransport("echo", [])
+        await t.close()  # Should not raise
+
+
+# ---------------------------------------------------------------------------
+# HTTP transport error paths
+# ---------------------------------------------------------------------------
+
+
+class TestHTTPTransportErrors:
+    @pytest.mark.asyncio
+    async def test_send_before_start_raises(self) -> None:
+        from ravn.adapters.mcp.sse_transport import HTTPTransport
+
+        t = HTTPTransport("http://localhost:9999")
+        with pytest.raises(MCPTransportError, match="not started"):
+            await t.send({"jsonrpc": "2.0"})
+
+    @pytest.mark.asyncio
+    async def test_receive_before_start_raises(self) -> None:
+        from ravn.adapters.mcp.sse_transport import HTTPTransport
+
+        t = HTTPTransport("http://localhost:9999")
+        with pytest.raises(MCPTransportError, match="not started"):
+            await t.receive()
+
+    @pytest.mark.asyncio
+    async def test_is_alive_false_before_start(self) -> None:
+        from ravn.adapters.mcp.sse_transport import HTTPTransport
+
+        t = HTTPTransport("http://localhost:9999")
+        assert not t.is_alive
+
+    @pytest.mark.asyncio
+    async def test_start_with_httpx(self) -> None:
+        from ravn.adapters.mcp.sse_transport import HTTPTransport
+
+        t = HTTPTransport("http://localhost:9999")
+        # httpx is available in the project
+        await t.start()
+        assert t.is_alive
+        await t.close()
+
+    @pytest.mark.asyncio
+    async def test_close_is_safe_before_start(self) -> None:
+        from ravn.adapters.mcp.sse_transport import HTTPTransport
+
+        t = HTTPTransport("http://localhost:9999")
+        await t.close()  # Should not raise
+
+
+# ---------------------------------------------------------------------------
+# MCPServerHealth dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestMCPServerHealth:
+    def test_defaults(self) -> None:
+        h = MCPServerHealth()
+        assert h.state == MCPServerState.DISCONNECTED
+        assert h.phase == MCPLifecyclePhase.CONFIG_LOAD
+        assert h.error == ""
+        assert h.server_info == {}

--- a/tests/ravn/unit/test_mcp_transports.py
+++ b/tests/ravn/unit/test_mcp_transports.py
@@ -1,0 +1,425 @@
+"""Additional transport and manager tests to push coverage above 85%."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ravn.adapters.mcp.manager import MCPManager, _build_transport
+from ravn.adapters.mcp.transport import MCPTransportError
+from ravn.config import MCPServerConfig
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _cfg(transport: str = "stdio", **kwargs: Any) -> MCPServerConfig:
+    defaults: dict[str, Any] = {
+        "name": "test",
+        "transport": transport,
+        "command": "npx",
+        "args": [],
+        "env": {},
+        "url": "http://localhost:3000",
+    }
+    defaults.update(kwargs)
+    return MCPServerConfig(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# _build_transport factory
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTransport:
+    def test_stdio_returns_stdio_transport(self) -> None:
+        from ravn.adapters.mcp.stdio_transport import StdioTransport
+
+        t = _build_transport(_cfg("stdio", command="echo", args=["hello"]))
+        assert isinstance(t, StdioTransport)
+
+    def test_http_returns_http_transport(self) -> None:
+        from ravn.adapters.mcp.sse_transport import HTTPTransport
+
+        t = _build_transport(_cfg("http", url="http://localhost:9999"))
+        assert isinstance(t, HTTPTransport)
+
+    def test_sse_returns_sse_transport(self) -> None:
+        from ravn.adapters.mcp.sse_transport import SSETransport
+
+        t = _build_transport(_cfg("sse", url="http://localhost:9999"))
+        assert isinstance(t, SSETransport)
+
+
+# ---------------------------------------------------------------------------
+# StdioTransport with mocked subprocess
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_process(
+    stdout_data: bytes = b'{"jsonrpc":"2.0","id":1,"result":{}}\n',
+    returncode: int | None = None,
+) -> MagicMock:
+    """Create a mock asyncio subprocess with async methods as coroutine functions."""
+
+    async def _drain() -> None:
+        pass
+
+    async def _readline() -> bytes:
+        return stdout_data
+
+    async def _wait() -> int:
+        return 0
+
+    proc = MagicMock()
+    proc.pid = 12345
+    proc.returncode = returncode
+    proc.stdin = MagicMock()
+    proc.stdin.write = MagicMock()
+    proc.stdin.drain = _drain
+    proc.stdin.close = MagicMock()
+    proc.stdout = MagicMock()
+    proc.stdout.readline = _readline
+    proc.wait = _wait
+    proc.kill = MagicMock()
+    return proc
+
+
+class TestStdioTransportFull:
+    """Test full stdio transport lifecycle using a mocked subprocess."""
+
+    @pytest.mark.asyncio
+    async def test_start_and_is_alive(self) -> None:
+        from ravn.adapters.mcp.stdio_transport import StdioTransport
+
+        mock_proc = _make_mock_process()
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc) as m:
+            t = StdioTransport("echo", ["hello"])
+            await t.start()
+            assert t.is_alive
+            m.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_send_after_start(self) -> None:
+        from ravn.adapters.mcp.stdio_transport import StdioTransport
+
+        mock_proc = _make_mock_process()
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            t = StdioTransport("echo", [])
+            await t.start()
+            await t.send({"jsonrpc": "2.0", "id": 1, "method": "ping"})
+            mock_proc.stdin.write.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_receive_after_start(self) -> None:
+        from ravn.adapters.mcp.stdio_transport import StdioTransport
+
+        msg = {"jsonrpc": "2.0", "id": 1, "result": {"ok": True}}
+        mock_proc = _make_mock_process(stdout_data=(json.dumps(msg) + "\n").encode())
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            t = StdioTransport("echo", [])
+            await t.start()
+            result = await t.receive()
+            assert result == msg
+
+    @pytest.mark.asyncio
+    async def test_receive_eof_raises(self) -> None:
+        from ravn.adapters.mcp.stdio_transport import StdioTransport
+
+        mock_proc = _make_mock_process(stdout_data=b"")  # EOF
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            t = StdioTransport("echo", [])
+            await t.start()
+            with pytest.raises(MCPTransportError, match="closed stdout"):
+                await t.receive()
+
+    @pytest.mark.asyncio
+    async def test_receive_invalid_json_raises(self) -> None:
+        from ravn.adapters.mcp.stdio_transport import StdioTransport
+
+        mock_proc = _make_mock_process(stdout_data=b"not json\n")
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            t = StdioTransport("echo", [])
+            await t.start()
+            with pytest.raises(MCPTransportError, match="Invalid JSON"):
+                await t.receive()
+
+    @pytest.mark.asyncio
+    async def test_receive_timeout_raises(self) -> None:
+        from ravn.adapters.mcp.stdio_transport import StdioTransport
+
+        async def _slow_readline() -> bytes:
+            await asyncio.sleep(10)
+            return b""
+
+        mock_proc = _make_mock_process()
+        mock_proc.stdout.readline = _slow_readline
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            t = StdioTransport("echo", [], read_timeout=0.01)
+            await t.start()
+            with pytest.raises(MCPTransportError, match="Timed out"):
+                await t.receive()
+
+    @pytest.mark.asyncio
+    async def test_send_raises_when_process_exited(self) -> None:
+        from ravn.adapters.mcp.stdio_transport import StdioTransport
+
+        # Process exited (returncode=0) — send should fail immediately
+        mock_proc = _make_mock_process(returncode=0)
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            t = StdioTransport("echo", [])
+            await t.start()
+            with pytest.raises(MCPTransportError, match="process has exited"):
+                await t.send({"jsonrpc": "2.0"})
+
+    @pytest.mark.asyncio
+    async def test_close_kills_process_on_timeout(self) -> None:
+        from ravn.adapters.mcp.stdio_transport import StdioTransport
+
+        killed: list[bool] = []
+
+        async def slow_wait() -> int:
+            await asyncio.sleep(10)
+            return 0
+
+        mock_proc = _make_mock_process()
+        mock_proc.wait = slow_wait
+        mock_proc.kill = MagicMock(side_effect=lambda: killed.append(True))
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            with patch("ravn.adapters.mcp.stdio_transport._PROCESS_WAIT_TIMEOUT_SECONDS", 0.01):
+                t = StdioTransport("echo", [])
+                t._process = mock_proc
+                await t.close()
+                assert killed  # kill() was called
+
+    @pytest.mark.asyncio
+    async def test_close_after_start(self) -> None:
+        from ravn.adapters.mcp.stdio_transport import StdioTransport
+
+        mock_proc = _make_mock_process()
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            t = StdioTransport("echo", [])
+            await t.start()
+            await t.close()
+            assert not t.is_alive
+
+
+# ---------------------------------------------------------------------------
+# HTTPTransport with mocked httpx
+# ---------------------------------------------------------------------------
+
+
+class TestHTTPTransportFull:
+    @pytest.mark.asyncio
+    async def test_send_and_receive(self) -> None:
+        from ravn.adapters.mcp.sse_transport import HTTPTransport
+
+        expected = {"jsonrpc": "2.0", "id": 1, "result": {"data": "ok"}}
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json = MagicMock(return_value=expected)
+
+        mock_client = MagicMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.aclose = AsyncMock()
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            t = HTTPTransport("http://localhost:9999")
+            await t.start()
+            await t.send({"jsonrpc": "2.0", "id": 1, "method": "ping"})
+            result = await t.receive()
+            assert result == expected
+
+    @pytest.mark.asyncio
+    async def test_receive_without_pending_message_raises(self) -> None:
+        from ravn.adapters.mcp.sse_transport import HTTPTransport
+
+        mock_client = MagicMock()
+        mock_client.aclose = AsyncMock()
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            t = HTTPTransport("http://localhost:9999")
+            await t.start()
+            # No send() before receive()
+            with pytest.raises(MCPTransportError, match="No pending message"):
+                await t.receive()
+
+    @pytest.mark.asyncio
+    async def test_http_error_propagated(self) -> None:
+        from ravn.adapters.mcp.sse_transport import HTTPTransport
+
+        mock_client = MagicMock()
+        mock_client.post = AsyncMock(side_effect=Exception("connection refused"))
+        mock_client.aclose = AsyncMock()
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            t = HTTPTransport("http://localhost:9999")
+            await t.start()
+            await t.send({"jsonrpc": "2.0", "id": 1, "method": "ping"})
+            with pytest.raises(MCPTransportError, match="HTTP request failed"):
+                await t.receive()
+
+    @pytest.mark.asyncio
+    async def test_close_resets_state(self) -> None:
+        from ravn.adapters.mcp.sse_transport import HTTPTransport
+
+        mock_client = MagicMock()
+        mock_client.aclose = AsyncMock()
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            t = HTTPTransport("http://localhost:9999")
+            await t.start()
+            assert t.is_alive
+            await t.close()
+            assert not t.is_alive
+
+    @pytest.mark.asyncio
+    async def test_start_without_httpx_raises(self) -> None:
+        from ravn.adapters.mcp.sse_transport import HTTPTransport
+
+        t = HTTPTransport("http://localhost:9999")
+        with patch.dict("sys.modules", {"httpx": None}):
+            with pytest.raises(MCPTransportError, match="httpx is required"):
+                await t.start()
+
+
+# ---------------------------------------------------------------------------
+# SSETransport error paths
+# ---------------------------------------------------------------------------
+
+
+class TestSSETransportErrors:
+    @pytest.mark.asyncio
+    async def test_send_before_start_raises(self) -> None:
+        from ravn.adapters.mcp.sse_transport import SSETransport
+
+        t = SSETransport("http://localhost:9999")
+        with pytest.raises(MCPTransportError, match="not started"):
+            await t.send({"jsonrpc": "2.0"})
+
+    @pytest.mark.asyncio
+    async def test_receive_before_start_raises(self) -> None:
+        from ravn.adapters.mcp.sse_transport import SSETransport
+
+        t = SSETransport("http://localhost:9999")
+        with pytest.raises(MCPTransportError, match="not started"):
+            await t.receive()
+
+    @pytest.mark.asyncio
+    async def test_is_alive_false_before_start(self) -> None:
+        from ravn.adapters.mcp.sse_transport import SSETransport
+
+        t = SSETransport("http://localhost:9999")
+        assert not t.is_alive
+
+    @pytest.mark.asyncio
+    async def test_start_without_httpx_raises(self) -> None:
+        from ravn.adapters.mcp.sse_transport import SSETransport
+
+        t = SSETransport("http://localhost:9999")
+        with patch.dict("sys.modules", {"httpx": None}):
+            with pytest.raises(MCPTransportError, match="httpx is required"):
+                await t.start()
+
+    @pytest.mark.asyncio
+    async def test_start_timeout_raises(self) -> None:
+        """SSETransport.start() raises MCPTransportError when endpoint event times out."""
+        from ravn.adapters.mcp.sse_transport import SSETransport
+
+        mock_client = MagicMock()
+        mock_client.aclose = AsyncMock()
+
+        # stream() returns a context manager that yields lines slowly (never sends endpoint)
+        async def _slow_stream(*args: Any, **kwargs: Any) -> None:
+            await asyncio.sleep(10)
+            yield ""
+
+        mock_stream_ctx = MagicMock()
+        mock_stream_ctx.__aenter__ = AsyncMock(return_value=mock_stream_ctx)
+        mock_stream_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_stream_ctx.aiter_lines = MagicMock(return_value=_slow_stream())
+        mock_client.stream = MagicMock(return_value=mock_stream_ctx)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            t = SSETransport("http://localhost:9999")
+            with patch("ravn.adapters.mcp.sse_transport._CONNECT_TIMEOUT_SECONDS", 0.01):
+                with pytest.raises(MCPTransportError, match="Timed out"):
+                    await t.start()
+
+    @pytest.mark.asyncio
+    async def test_close_before_start_is_safe(self) -> None:
+        from ravn.adapters.mcp.sse_transport import SSETransport
+
+        t = SSETransport("http://localhost:9999")
+        await t.close()  # Should not raise
+
+    @pytest.mark.asyncio
+    async def test_receive_timeout_raises(self) -> None:
+        """Receiving when queue is empty and timeout fires raises MCPTransportError."""
+        from ravn.adapters.mcp.sse_transport import SSETransport
+
+        # Use a very short timeout; the empty queue will cause wait_for to fire
+        t = SSETransport("http://localhost:9999", timeout=0.01)
+        t._started = True  # Force into started state without full SSE setup
+        with pytest.raises(MCPTransportError, match="Timed out"):
+            await t.receive()
+
+
+# ---------------------------------------------------------------------------
+# MCPManager._build_transport integration with SSE/HTTP configs
+# ---------------------------------------------------------------------------
+
+
+class TestManagerTransportSelection:
+    @pytest.mark.asyncio
+    async def test_manager_uses_http_transport_for_http_config(self) -> None:
+        from ravn.adapters.mcp.sse_transport import HTTPTransport
+
+        cfg = MCPServerConfig(
+            name="api",
+            transport="http",
+            url="http://localhost:9999",
+        )
+        transport = _build_transport(cfg)
+        assert isinstance(transport, HTTPTransport)
+
+    @pytest.mark.asyncio
+    async def test_manager_uses_sse_transport_for_sse_config(self) -> None:
+        from ravn.adapters.mcp.manager import _build_transport as bt
+        from ravn.adapters.mcp.sse_transport import SSETransport
+
+        cfg = MCPServerConfig(
+            name="streaming",
+            transport="sse",
+            url="http://localhost:9999",
+        )
+        transport = bt(cfg)
+        assert isinstance(transport, SSETransport)
+
+    @pytest.mark.asyncio
+    async def test_manager_all_servers_fail_returns_empty_tools(self) -> None:
+        from ravn.adapters.mcp.transport import MCPTransportError
+
+        cfgs = [
+            MCPServerConfig(name="s1", transport="stdio", command="bad1"),
+            MCPServerConfig(name="s2", transport="stdio", command="bad2"),
+        ]
+
+        # Both transports fail to start
+        from ravn.adapters.mcp.stdio_transport import StdioTransport
+
+        with patch.object(StdioTransport, "start", side_effect=MCPTransportError("fail")):
+            mgr = MCPManager(configs=cfgs)
+            tools = await mgr.start()
+            assert tools == []
+            for state in mgr.server_states.values():
+                from ravn.adapters.mcp.lifecycle import MCPServerState
+
+                assert state == MCPServerState.ERROR


### PR DESCRIPTION
## Summary

Implements the MCP (Model Context Protocol) client so Ravn can discover and call tools from external MCP servers.

### What's included

- **`src/ravn/adapters/mcp/`** — new MCP adapter package:
  - `lifecycle.py` — `MCPLifecyclePhase` and `MCPServerState` enums for health tracking
  - `transport.py` — abstract `MCPTransport` base class (JSON-RPC 2.0 framing helpers)
  - `stdio_transport.py` — spawns subprocess, communicates via stdin/stdout
  - `sse_transport.py` — SSE transport (endpoint-event discovery + POST) and HTTP transport
  - `protocol.py` — MCP JSON-RPC 2.0 message builders and result parsers
  - `tool.py` — `MCPTool` implementing `ToolPort`, proxies calls to the remote server
  - `client.py` — `MCPServerClient` managing full lifecycle for a single server
  - `manager.py` — `MCPManager` orchestrating all configured servers

- **`src/ravn/config.py`** — added `"sse"` as a valid `MCPServerConfig` transport type

- **Tests** — 96 unit tests, 88% patch coverage, zero warnings

### Lifecycle phases

ConfigLoad → SpawnConnect → InitializeHandshake → ToolDiscovery → ResourceDiscovery → Registration → Invocation → Shutdown

### Acceptance criteria met

- [x] Stdio MCP servers spawn and communicate
- [x] Tools discovered and registered transparently (mcp__{server}__{tool} prefix)
- [x] Tool calls routed to correct server
- [x] Degraded mode: partial server failure leaves healthy servers' tools available
- [x] Graceful shutdown on agent exit
- [x] Error reporting includes lifecycle phase
- [x] Collision detection with built-in Ravn tools

### Notes

- Linear MCP server was unavailable in this environment; ticket NIU-430 could not be updated via MCP.

## Test plan

- [x] 96 tests pass, zero warnings
- [x] ruff check and ruff format clean
- [x] 88% coverage on ravn.adapters.mcp (above 85% threshold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)