### PR TITLE
fix(bifrost): audit task GC prevention and cache stats auth

### DIFF
--- a/src/bifrost/inbound/routes.py
+++ b/src/bifrost/inbound/routes.py
@@ -582,21 +582,26 @@ def create_router(
             budget_warning_threshold_pct=config.events.budget_warning_threshold_pct,
         )
 
+    _audit_tasks: set[asyncio.Task] = set()
+
     def _schedule_audit(event: AuditEvent) -> None:
         """Schedule audit logging as a fire-and-forget task."""
-        asyncio.create_task(_audit.log(event))  # noqa: RUF006
+        task = asyncio.create_task(_audit.log(event))
+        _audit_tasks.add(task)
+        task.add_done_callback(_audit_tasks.discard)
 
     @api_router.get("/health")
     async def health() -> dict:
         return {"status": "ok"}
 
     @api_router.get("/v1/cache/stats")
-    async def cache_stats() -> dict:
+    async def cache_stats(raw_request: Request) -> dict:
         """Return aggregate cache statistics.
 
         Returns hit/miss counts, hit rate, and saved token counts since the
         process started.  Statistics are per-instance and reset on restart.
         """
+        auth_adapter.extract(raw_request)
         s = _cache.stats()
         return {
             "hits": s.hits,


### PR DESCRIPTION
## Summary
- Store fire-and-forget audit tasks in a set with `add_done_callback` to prevent garbage collection before completion (was suppressed with `noqa: RUF006`)
- Add authentication to `/v1/cache/stats` endpoint — it was the only data endpoint without auth

## Context
Review follow-up from NIU-462 (#372). These were the two remaining findings after the working session addressed 4 of 6 issues.

## Test plan
- [x] All 60 `test_niu462.py` tests pass
- [ ] Verify cache stats endpoint returns 401/403 without valid credentials
- [ ] Verify audit tasks complete reliably under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)