### PR TITLE
chore(adapters): align bifrost helm chart with umbrella

### DIFF
--- a/charts/bifrost/templates/_helpers.tpl
+++ b/charts/bifrost/templates/_helpers.tpl
@@ -62,17 +62,44 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Return the proper image name
+Return the proper image name (global overrides local)
 */}}
 {{- define "bifrost.image" -}}
-{{- $registry := .Values.image.registry | default "" }}
-{{- $repository := .Values.image.repository }}
-{{- $tag := .Values.image.tag | default .Chart.AppVersion }}
-{{- if $registry }}
-{{- printf "%s/%s:%s" $registry $repository $tag }}
+{{- $registryName := .Values.image.registry -}}
+{{- $repositoryName := .Values.image.repository -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- if and .Values.global .Values.global.image -}}
+  {{- if .Values.global.image.registry -}}
+    {{- $registryName = .Values.global.image.registry -}}
+  {{- end -}}
+  {{- if .Values.global.image.tag -}}
+    {{- $tag = .Values.global.image.tag -}}
+  {{- end -}}
+{{- end -}}
+{{- if $registryName }}
+{{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- else }}
-{{- printf "%s:%s" $repository $tag }}
+{{- printf "%s:%s" $repositoryName $tag -}}
 {{- end }}
+{{- end }}
+
+{{/*
+Return image pull secrets (global, converts strings to objects)
+*/}}
+{{- define "bifrost.imagePullSecrets" -}}
+{{- $secrets := list -}}
+{{- if and .Values.global .Values.global.imagePullSecrets -}}
+  {{- $secrets = .Values.global.imagePullSecrets -}}
+{{- end -}}
+{{- if .Values.imagePullSecrets -}}
+  {{- $secrets = .Values.imagePullSecrets -}}
+{{- end -}}
+{{- if $secrets -}}
+imagePullSecrets:
+  {{- range $secrets }}
+  - name: {{ . }}
+  {{- end }}
+{{- end -}}
 {{- end }}
 
 {{/*

--- a/charts/bifrost/templates/deployment.yaml
+++ b/charts/bifrost/templates/deployment.yaml
@@ -34,10 +34,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "bifrost.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "bifrost.serviceAccountName" . }}
       securityContext:
         runAsNonRoot: true

--- a/charts/niuu/Chart.yaml
+++ b/charts/niuu/Chart.yaml
@@ -27,3 +27,7 @@ dependencies:
     version: ">=0.0.0-0"
     repository: "file://../niuu-shared"
     condition: niuu-shared.enabled
+  - name: bifrost
+    version: ">=0.0.0-0"
+    repository: "file://../bifrost"
+    condition: bifrost.enabled

--- a/charts/niuu/values.yaml
+++ b/charts/niuu/values.yaml
@@ -31,3 +31,6 @@ tyr:
 
 niuu-shared:
   enabled: true
+
+bifrost:
+  enabled: true


### PR DESCRIPTION
## Summary
- Update bifrost `_helpers.tpl` to support `global.image.registry`, `global.image.tag`, and `global.imagePullSecrets` — matching the pattern used by tyr and volundr
- Add bifrost as a conditional dependency (`bifrost.enabled`) in the niuu umbrella chart
- Add `bifrost.enabled: true` default in umbrella values

## Test plan
- [x] `helm template` renders bifrost standalone without errors
- [x] `helm template` renders bifrost within the niuu umbrella chart
- [x] Verified global image/pullSecrets overrides propagate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)