### PR TITLE
test(sleipnir): add broker integration tests for NATS, RabbitMQ, Redis

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -332,10 +332,69 @@ jobs:
           uv run pytest tests/integration/tyr/ -v --tb=short -m integration \
             --override-ini="addopts="
 
+  python-integration-test-sleipnir:
+    name: "Python: Integration Test Sleipnir"
+    needs: changes
+    if: needs.changes.outputs.tier == 'full' && needs.changes.outputs.python == 'true'
+    runs-on: ubuntu-latest
+    services:
+      rabbitmq:
+        image: rabbitmq:4-alpine
+        ports: ["5672:5672"]
+        options: >-
+          --health-cmd "rabbitmq-diagnostics -q ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+      redis:
+        image: redis:7-alpine
+        ports: ["6379:6379"]
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      # NATS requires --jetstream flag which GHA service containers can't pass.
+      # Start it manually with docker run instead.
+      - name: Start NATS with JetStream
+        run: |
+          docker run -d --name nats -p 4222:4222 -p 8222:8222 nats:2-alpine --jetstream --http_port 8222
+          for i in $(seq 1 10); do
+            curl -sf http://localhost:8222/healthz > /dev/null 2>&1 && break || sleep 1
+          done
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          version: "0.11.2"
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --extra test --extra nats --extra rabbitmq --extra redis --dev
+
+      - name: Run Sleipnir broker integration tests
+        env:
+          TEST_NATS_URL: "nats://localhost:4222"
+          TEST_RABBITMQ_URL: "amqp://guest:guest@localhost:5672/"
+          TEST_REDIS_URL: "redis://localhost:6379"
+        run: |
+          uv run pytest tests/integration/sleipnir/ -v --tb=short -m broker \
+            --override-ini="addopts="
+
   # Rollup gate — branch ruleset requires "Python: Integration Test"
   python-integration-test:
     name: "Python: Integration Test"
-    needs: [changes, python-integration-test-volundr, python-integration-test-tyr]
+    needs: [changes, python-integration-test-volundr, python-integration-test-tyr, python-integration-test-sleipnir]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -347,7 +406,8 @@ jobs:
             exit 0
           fi
           if [[ "${{ needs.python-integration-test-volundr.result }}" == "failure" ]] || \
-             [[ "${{ needs.python-integration-test-tyr.result }}" == "failure" ]]; then
+             [[ "${{ needs.python-integration-test-tyr.result }}" == "failure" ]] || \
+             [[ "${{ needs.python-integration-test-sleipnir.result }}" == "failure" ]]; then
             exit 1
           fi
 

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ PGVECTOR_VERSION := $(shell python3 -c "exec(open('$(PG_VERSIONS_PY)').read()); 
 PGINSTALL_DIR    := build/pginstall
 
 .PHONY: build build-web build-postgres build-cli copy-migrations clean lint test verify \
-       test-integration test-integration-volundr test-integration-tyr test-e2e test-e2e-ui test-all \
-       test-ravn
+       test-integration test-integration-volundr test-integration-tyr test-integration-sleipnir \
+       test-e2e test-e2e-ui test-all test-ravn
 
 # --------------------------------------------------------------------------
 # Full build: web assets → migrations → PostgreSQL → Nuitka binary
@@ -92,6 +92,9 @@ test-integration-volundr:
 
 test-integration-tyr:
 	uv run pytest tests/integration/tyr/ -v --tb=short -m integration
+
+test-integration-sleipnir:
+	uv run pytest tests/integration/sleipnir/ -v --tb=short -m broker --override-ini="addopts="
 
 test-e2e:
 	cd $(WEB_DIR) && npm run test:e2e

--- a/charts/bifrost/templates/_helpers.tpl
+++ b/charts/bifrost/templates/_helpers.tpl
@@ -62,17 +62,44 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Return the proper image name
+Return the proper image name (global overrides local)
 */}}
 {{- define "bifrost.image" -}}
-{{- $registry := .Values.image.registry | default "" }}
-{{- $repository := .Values.image.repository }}
-{{- $tag := .Values.image.tag | default .Chart.AppVersion }}
-{{- if $registry }}
-{{- printf "%s/%s:%s" $registry $repository $tag }}
+{{- $registryName := .Values.image.registry -}}
+{{- $repositoryName := .Values.image.repository -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- if and .Values.global .Values.global.image -}}
+  {{- if .Values.global.image.registry -}}
+    {{- $registryName = .Values.global.image.registry -}}
+  {{- end -}}
+  {{- if .Values.global.image.tag -}}
+    {{- $tag = .Values.global.image.tag -}}
+  {{- end -}}
+{{- end -}}
+{{- if $registryName }}
+{{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- else }}
-{{- printf "%s:%s" $repository $tag }}
+{{- printf "%s:%s" $repositoryName $tag -}}
 {{- end }}
+{{- end }}
+
+{{/*
+Return image pull secrets (global, converts strings to objects)
+*/}}
+{{- define "bifrost.imagePullSecrets" -}}
+{{- $secrets := list -}}
+{{- if and .Values.global .Values.global.imagePullSecrets -}}
+  {{- $secrets = .Values.global.imagePullSecrets -}}
+{{- end -}}
+{{- if .Values.imagePullSecrets -}}
+  {{- $secrets = .Values.imagePullSecrets -}}
+{{- end -}}
+{{- if $secrets -}}
+imagePullSecrets:
+  {{- range $secrets }}
+  - name: {{ . }}
+  {{- end }}
+{{- end -}}
 {{- end }}
 
 {{/*

--- a/charts/bifrost/templates/deployment.yaml
+++ b/charts/bifrost/templates/deployment.yaml
@@ -34,10 +34,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "bifrost.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "bifrost.serviceAccountName" . }}
       securityContext:
         runAsNonRoot: true

--- a/charts/niuu/Chart.yaml
+++ b/charts/niuu/Chart.yaml
@@ -27,3 +27,7 @@ dependencies:
     version: ">=0.0.0-0"
     repository: "file://../niuu-shared"
     condition: niuu-shared.enabled
+  - name: bifrost
+    version: ">=0.0.0-0"
+    repository: "file://../bifrost"
+    condition: bifrost.enabled

--- a/charts/niuu/values.yaml
+++ b/charts/niuu/values.yaml
@@ -31,3 +31,6 @@ tyr:
 
 niuu-shared:
   enabled: true
+
+bifrost:
+  enabled: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,9 +111,10 @@ packages = ["src/cli", "src/niuu", "src/volundr", "src/tyr", "src/skuld", "src/s
 testpaths = ["tests"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
-addopts = "-v --tb=short -m 'not integration'"
+addopts = "-v --tb=short -m 'not integration and not broker'"
 markers = [
     "integration: tests that require a real PostgreSQL database",
+    "broker: tests that require real message broker services (NATS, RabbitMQ, Redis)",
     "ravn: tests for the Ravn agent module",
     "e2e: end-to-end tests for full agent conversation flows",
 ]

--- a/tests/integration/sleipnir/conftest.py
+++ b/tests/integration/sleipnir/conftest.py
@@ -1,0 +1,121 @@
+"""Shared fixtures for Sleipnir broker integration tests.
+
+These tests require real broker services (NATS, RabbitMQ, Redis) and are
+excluded from the default test run.  Enable with ``-m broker``.
+
+Connection URLs default to localhost and can be overridden via env vars
+to match CI service containers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+
+from sleipnir.domain.events import SleipnirEvent
+
+# ---------------------------------------------------------------------------
+# Env-var connection URLs (same pattern as TEST_DATABASE_*)
+# ---------------------------------------------------------------------------
+
+NATS_URL = os.environ.get("TEST_NATS_URL", "nats://localhost:4222")
+RABBITMQ_URL = os.environ.get("TEST_RABBITMQ_URL", "amqp://guest:guest@localhost:5672/")
+REDIS_URL = os.environ.get("TEST_REDIS_URL", "redis://localhost:6379")
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+DEFAULT_TIMESTAMP = datetime(2026, 4, 6, 12, 0, 0, tzinfo=UTC)
+
+
+def make_event(**kwargs: object) -> SleipnirEvent:
+    """Return a SleipnirEvent with sensible defaults; all fields overridable."""
+    defaults: dict = {
+        "event_type": "ravn.tool.complete",
+        "source": "test:broker-integration",
+        "payload": {"tool": "bash", "exit_code": 0},
+        "summary": "Test event",
+        "urgency": 0.5,
+        "domain": "code",
+        "timestamp": DEFAULT_TIMESTAMP,
+    }
+    defaults.update(kwargs)
+    if "event_id" not in defaults:
+        defaults["event_id"] = str(uuid.uuid4())
+    return SleipnirEvent(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Async helper: collect N events with timeout
+# ---------------------------------------------------------------------------
+
+
+async def collect_events(
+    count: int,
+    received: list[SleipnirEvent],
+    timeout: float = 5.0,
+) -> list[SleipnirEvent]:
+    """Wait until *received* has at least *count* items, or *timeout* expires."""
+    deadline = asyncio.get_event_loop().time() + timeout
+    while len(received) < count:
+        remaining = deadline - asyncio.get_event_loop().time()
+        if remaining <= 0:
+            break
+        await asyncio.sleep(0.05)
+    return list(received)
+
+
+# ---------------------------------------------------------------------------
+# Transport fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def nats_transport():
+    """Yield a started NatsTransport connected to the test NATS server."""
+    from sleipnir.adapters.nats_transport import NatsTransport
+
+    stream_name = f"sleipnir_test_{uuid.uuid4().hex[:8]}"
+    transport = NatsTransport(
+        servers=[NATS_URL],
+        stream_name=stream_name,
+        subject_prefix=stream_name,
+        max_reconnect_attempts=3,
+        connect_timeout_s=5.0,
+    )
+    async with transport:
+        yield transport
+
+
+@pytest.fixture
+async def rabbitmq_transport():
+    """Yield a started RabbitMQTransport connected to the test RabbitMQ."""
+    from sleipnir.adapters.rabbitmq import RabbitMQTransport
+
+    exchange = f"sleipnir_test_{uuid.uuid4().hex[:8]}"
+    transport = RabbitMQTransport(
+        url=RABBITMQ_URL,
+        exchange_name=exchange,
+        dead_letter_exchange=f"{exchange}_dlx",
+    )
+    async with transport:
+        yield transport
+
+
+@pytest.fixture
+async def redis_transport():
+    """Yield a started RedisStreamsTransport connected to the test Redis."""
+    from sleipnir.adapters.redis_streams import RedisStreamsTransport
+
+    prefix = f"sleipnir_test_{uuid.uuid4().hex[:8]}"
+    transport = RedisStreamsTransport(
+        url=REDIS_URL,
+        stream_prefix=prefix,
+    )
+    async with transport:
+        yield transport

--- a/tests/integration/sleipnir/test_cross_service.py
+++ b/tests/integration/sleipnir/test_cross_service.py
@@ -1,0 +1,237 @@
+"""Cross-service integration tests: Volundr → Sleipnir → Skuld.
+
+Validates the full event chain across service boundaries using real
+broker transports.  Parameterised across NATS, RabbitMQ, and Redis.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from skuld.channels import ChannelRegistry, MessageChannel
+from skuld.sleipnir_bridge import SleipnirBridge
+from sleipnir.domain.events import SleipnirEvent
+from volundr.adapters.outbound.sleipnir_event_sink import SleipnirEventSink
+from volundr.domain.models import SessionEvent, SessionEventType
+
+from .conftest import NATS_URL, RABBITMQ_URL, REDIS_URL, collect_events, make_event
+
+pytestmark = pytest.mark.broker
+
+
+# ---------------------------------------------------------------------------
+# Mock channel for capturing Skuld broadcast output
+# ---------------------------------------------------------------------------
+
+
+class _CaptureChannel(MessageChannel):
+    """In-memory channel that records all broadcast events."""
+
+    def __init__(self) -> None:
+        self.events: list[dict] = []
+        self._open = True
+
+    async def send_event(self, event: dict) -> None:
+        self.events.append(event)
+
+    @property
+    def channel_type(self) -> str:
+        return "test"
+
+    @property
+    def is_open(self) -> bool:
+        return self._open
+
+    async def close(self) -> None:
+        self._open = False
+
+
+# ---------------------------------------------------------------------------
+# Transport factory (parameterised)
+# ---------------------------------------------------------------------------
+
+
+async def _make_nats():
+    from sleipnir.adapters.nats_transport import NatsTransport
+
+    name = f"sleipnir_test_{uuid.uuid4().hex[:8]}"
+    return NatsTransport(
+        servers=[NATS_URL],
+        stream_name=name,
+        subject_prefix=name,
+        max_reconnect_attempts=3,
+        connect_timeout_s=5.0,
+    )
+
+
+async def _make_rabbitmq():
+    from sleipnir.adapters.rabbitmq import RabbitMQTransport
+
+    exchange = f"sleipnir_test_{uuid.uuid4().hex[:8]}"
+    return RabbitMQTransport(
+        url=RABBITMQ_URL,
+        exchange_name=exchange,
+        dead_letter_exchange=f"{exchange}_dlx",
+    )
+
+
+async def _make_redis():
+    from sleipnir.adapters.redis_streams import RedisStreamsTransport
+
+    prefix = f"sleipnir_test_{uuid.uuid4().hex[:8]}"
+    return RedisStreamsTransport(url=REDIS_URL, stream_prefix=prefix)
+
+
+@pytest.fixture(params=["nats", "rabbitmq", "redis"])
+async def transport(request):
+    """Yield a started transport for each broker backend."""
+    factories = {
+        "nats": _make_nats,
+        "rabbitmq": _make_rabbitmq,
+        "redis": _make_redis,
+    }
+    t = await factories[request.param]()
+    async with t:
+        yield t
+
+
+# ---------------------------------------------------------------------------
+# Volundr → Sleipnir → Skuld end-to-end
+# ---------------------------------------------------------------------------
+
+
+async def test_volundr_sink_to_skuld_bridge(transport):
+    """SleipnirEventSink publishes → real broker → SleipnirBridge → channel."""
+    session_id = uuid4()
+    channel = _CaptureChannel()
+    registry = ChannelRegistry()
+    registry.add(channel)
+
+    # Set up Skuld bridge on the subscriber side
+    bridge = SleipnirBridge(
+        subscriber=transport,
+        registry=registry,
+        session_id=str(session_id),
+        event_patterns=["volundr.*"],
+    )
+    await bridge.start()
+
+    # Set up Volundr sink on the publisher side
+    sink = SleipnirEventSink(publisher=transport)
+
+    session_event = SessionEvent(
+        id=uuid4(),
+        session_id=session_id,
+        event_type=SessionEventType.SESSION_START,
+        timestamp=datetime.now(UTC),
+        data={"model": "claude-sonnet-4-6", "repo": "niuu/volundr", "branch": "main"},
+        sequence=1,
+    )
+
+    await sink.emit(session_event)
+
+    # Wait for the event to flow through the broker
+    deadline = asyncio.get_event_loop().time() + 5.0
+    while not channel.events:
+        if asyncio.get_event_loop().time() > deadline:
+            break
+        await asyncio.sleep(0.05)
+
+    await bridge.stop()
+
+    assert len(channel.events) == 1
+    wire = channel.events[0]
+    assert wire["type"] == "sleipnir"
+    assert wire["event_type"] == "volundr.session.started"
+    assert wire["correlation_id"] == str(session_id)
+    assert wire["payload"]["session_id"] == str(session_id)
+    assert wire["payload"]["model"] == "claude-sonnet-4-6"
+
+
+# ---------------------------------------------------------------------------
+# correlation_id filtering
+# ---------------------------------------------------------------------------
+
+
+async def test_correlation_id_filtering(transport):
+    """Skuld bridge only forwards events matching its session_id."""
+    target_session = str(uuid4())
+    other_session = str(uuid4())
+
+    channel = _CaptureChannel()
+    registry = ChannelRegistry()
+    registry.add(channel)
+
+    bridge = SleipnirBridge(
+        subscriber=transport,
+        registry=registry,
+        session_id=target_session,
+        event_patterns=["volundr.*"],
+    )
+    await bridge.start()
+
+    # Publish events for two different sessions
+    await transport.publish(make_event(
+        event_type="volundr.session.started",
+        correlation_id=target_session,
+        payload={"session_id": target_session},
+        summary="target session",
+    ))
+    await transport.publish(make_event(
+        event_type="volundr.session.started",
+        correlation_id=other_session,
+        payload={"session_id": other_session},
+        summary="other session",
+    ))
+
+    deadline = asyncio.get_event_loop().time() + 3.0
+    while not channel.events:
+        if asyncio.get_event_loop().time() > deadline:
+            break
+        await asyncio.sleep(0.05)
+    # Extra wait to confirm second event doesn't arrive
+    await asyncio.sleep(0.5)
+
+    await bridge.stop()
+
+    assert len(channel.events) == 1
+    assert channel.events[0]["correlation_id"] == target_session
+
+
+# ---------------------------------------------------------------------------
+# Multi-publisher
+# ---------------------------------------------------------------------------
+
+
+async def test_multi_publisher_single_subscriber(transport):
+    """Events from two publishers are received by a single subscriber."""
+    received: list[SleipnirEvent] = []
+
+    async def handler(event: SleipnirEvent) -> None:
+        received.append(event)
+
+    await transport.subscribe(["*"], handler)
+
+    # Simulate Volundr publishing
+    await transport.publish(make_event(
+        event_type="volundr.session.started",
+        source="volundr:event-sink",
+        summary="from-volundr",
+    ))
+    # Simulate Tyr publishing
+    await transport.publish(make_event(
+        event_type="tyr.saga.created",
+        source="tyr:event-bridge",
+        summary="from-tyr",
+    ))
+
+    await collect_events(2, received)
+
+    sources = {e.source for e in received}
+    assert "volundr:event-sink" in sources
+    assert "tyr:event-bridge" in sources

--- a/tests/integration/sleipnir/test_nats_broker.py
+++ b/tests/integration/sleipnir/test_nats_broker.py
@@ -1,0 +1,225 @@
+"""Integration tests for the NATS JetStream transport against a real broker.
+
+Requires a running NATS server with JetStream enabled (``nats-server --jetstream``).
+Set ``TEST_NATS_URL`` to override the default ``nats://localhost:4222``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from sleipnir.adapters.nats_transport import NatsTransport
+from sleipnir.domain.events import SleipnirEvent
+
+from .conftest import NATS_URL, collect_events, make_event
+
+pytestmark = pytest.mark.broker
+
+
+# ---------------------------------------------------------------------------
+# Basic pub/sub
+# ---------------------------------------------------------------------------
+
+
+async def test_publish_and_subscribe_round_trip(nats_transport: NatsTransport):
+    """A published event is received by a subscriber."""
+    received: list[SleipnirEvent] = []
+
+    async def handler(event: SleipnirEvent) -> None:
+        received.append(event)
+
+    await nats_transport.subscribe(["ravn.*"], handler)
+    event = make_event()
+    await nats_transport.publish(event)
+
+    await collect_events(1, received)
+
+    assert len(received) == 1
+    assert received[0].event_id == event.event_id
+    assert received[0].event_type == event.event_type
+    assert received[0].payload == event.payload
+
+
+async def test_batch_publish_preserves_order(nats_transport: NatsTransport):
+    """Events published via publish_batch arrive in order."""
+    received: list[SleipnirEvent] = []
+
+    async def handler(event: SleipnirEvent) -> None:
+        received.append(event)
+
+    await nats_transport.subscribe(["ravn.*"], handler)
+
+    events = [make_event(summary=f"event-{i}") for i in range(5)]
+    await nats_transport.publish_batch(events)
+
+    await collect_events(5, received)
+
+    assert [e.summary for e in received] == [f"event-{i}" for i in range(5)]
+
+
+# ---------------------------------------------------------------------------
+# Pattern matching
+# ---------------------------------------------------------------------------
+
+
+async def test_wildcard_pattern_matching(nats_transport: NatsTransport):
+    """Subscriber with 'ravn.*' receives ravn events but not tyr events."""
+    received: list[SleipnirEvent] = []
+
+    async def handler(event: SleipnirEvent) -> None:
+        received.append(event)
+
+    await nats_transport.subscribe(["ravn.*"], handler)
+
+    await nats_transport.publish(make_event(event_type="ravn.tool.complete"))
+    await nats_transport.publish(make_event(event_type="tyr.saga.created"))
+
+    await collect_events(1, received, timeout=2.0)
+    # Give a moment for the tyr event to *not* arrive
+    await asyncio.sleep(0.3)
+
+    assert len(received) == 1
+    assert received[0].event_type == "ravn.tool.complete"
+
+
+# ---------------------------------------------------------------------------
+# Multiple subscribers
+# ---------------------------------------------------------------------------
+
+
+async def test_multiple_subscribers_receive_independently(nats_transport: NatsTransport):
+    """Two subscribers to different patterns each receive matching events."""
+    ravn_received: list[SleipnirEvent] = []
+    tyr_received: list[SleipnirEvent] = []
+
+    async def ravn_handler(event: SleipnirEvent) -> None:
+        ravn_received.append(event)
+
+    async def tyr_handler(event: SleipnirEvent) -> None:
+        tyr_received.append(event)
+
+    await nats_transport.subscribe(["ravn.*"], ravn_handler)
+    await nats_transport.subscribe(["tyr.*"], tyr_handler)
+
+    await nats_transport.publish(make_event(event_type="ravn.tool.complete"))
+    await nats_transport.publish(make_event(event_type="tyr.saga.created"))
+
+    await collect_events(1, ravn_received)
+    await collect_events(1, tyr_received)
+
+    assert len(ravn_received) == 1
+    assert len(tyr_received) == 1
+
+
+# ---------------------------------------------------------------------------
+# Unsubscribe
+# ---------------------------------------------------------------------------
+
+
+async def test_unsubscribe_stops_delivery(nats_transport: NatsTransport):
+    """After unsubscribe, no more events are delivered."""
+    received: list[SleipnirEvent] = []
+
+    async def handler(event: SleipnirEvent) -> None:
+        received.append(event)
+
+    sub = await nats_transport.subscribe(["ravn.*"], handler)
+    await nats_transport.publish(make_event(summary="before"))
+    await collect_events(1, received)
+
+    await sub.unsubscribe()
+    await nats_transport.publish(make_event(summary="after"))
+    await asyncio.sleep(0.5)
+
+    assert len(received) == 1
+    assert received[0].summary == "before"
+
+
+# ---------------------------------------------------------------------------
+# Field preservation
+# ---------------------------------------------------------------------------
+
+
+async def test_correlation_id_and_urgency_preserved(nats_transport: NatsTransport):
+    """correlation_id and urgency survive the NATS round-trip."""
+    received: list[SleipnirEvent] = []
+
+    async def handler(event: SleipnirEvent) -> None:
+        received.append(event)
+
+    await nats_transport.subscribe(["ravn.*"], handler)
+    event = make_event(correlation_id="session-xyz", urgency=0.9)
+    await nats_transport.publish(event)
+
+    await collect_events(1, received)
+
+    assert received[0].correlation_id == "session-xyz"
+    assert received[0].urgency == 0.9
+
+
+# ---------------------------------------------------------------------------
+# TTL filtering
+# ---------------------------------------------------------------------------
+
+
+async def test_ttl_zero_events_not_delivered(nats_transport: NatsTransport):
+    """Events with ttl=0 are dropped by the publisher."""
+    received: list[SleipnirEvent] = []
+
+    async def handler(event: SleipnirEvent) -> None:
+        received.append(event)
+
+    await nats_transport.subscribe(["ravn.*"], handler)
+
+    await nats_transport.publish(make_event(ttl=0, summary="expired"))
+    await nats_transport.publish(make_event(ttl=300, summary="valid"))
+
+    await collect_events(1, received)
+    await asyncio.sleep(0.3)
+
+    assert len(received) == 1
+    assert received[0].summary == "valid"
+
+
+# ---------------------------------------------------------------------------
+# Replay from sequence
+# ---------------------------------------------------------------------------
+
+
+async def test_replay_from_sequence(nats_transport: NatsTransport):
+    """A new subscriber with replay_from_sequence receives historical events."""
+    # Publish 3 events before subscribing
+    events = [make_event(summary=f"event-{i}") for i in range(3)]
+    for event in events:
+        await nats_transport.publish(event)
+
+    # Allow events to be persisted
+    await asyncio.sleep(0.3)
+
+    # Create a new subscriber that replays from the beginning
+    stream_name = nats_transport._publisher._stream_name
+    subject_prefix = nats_transport._publisher._subject_prefix
+
+    replay_sub = NatsTransport(
+        servers=[NATS_URL],
+        stream_name=stream_name,
+        subject_prefix=subject_prefix,
+        replay_from_sequence=1,
+        max_reconnect_attempts=3,
+        connect_timeout_s=5.0,
+    )
+
+    received: list[SleipnirEvent] = []
+
+    async def handler(event: SleipnirEvent) -> None:
+        received.append(event)
+
+    async with replay_sub:
+        await replay_sub.subscribe(["ravn.*"], handler)
+        await collect_events(3, received)
+
+    assert len(received) >= 3
+    summaries = [e.summary for e in received[:3]]
+    assert summaries == ["event-0", "event-1", "event-2"]

--- a/tests/integration/sleipnir/test_rabbitmq_broker.py
+++ b/tests/integration/sleipnir/test_rabbitmq_broker.py
@@ -1,0 +1,209 @@
+"""Integration tests for the RabbitMQ transport against a real broker.
+
+Requires a running RabbitMQ server (default ``amqp://guest:guest@localhost:5672/``).
+Set ``TEST_RABBITMQ_URL`` to override.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+
+import pytest
+
+from sleipnir.adapters.rabbitmq import RabbitMQTransport
+from sleipnir.domain.events import SleipnirEvent
+
+from .conftest import RABBITMQ_URL, collect_events, make_event
+
+pytestmark = pytest.mark.broker
+
+
+# ---------------------------------------------------------------------------
+# Basic pub/sub
+# ---------------------------------------------------------------------------
+
+
+async def test_publish_and_subscribe_round_trip(rabbitmq_transport: RabbitMQTransport):
+    """A published event is received by a subscriber."""
+    received: list[SleipnirEvent] = []
+
+    async def handler(event: SleipnirEvent) -> None:
+        received.append(event)
+
+    await rabbitmq_transport.subscribe(["ravn.*"], handler)
+    event = make_event()
+    await rabbitmq_transport.publish(event)
+
+    await collect_events(1, received)
+
+    assert len(received) == 1
+    assert received[0].event_id == event.event_id
+    assert received[0].event_type == event.event_type
+    assert received[0].payload == event.payload
+
+
+async def test_batch_publish_ordering(rabbitmq_transport: RabbitMQTransport):
+    """Events published via publish_batch arrive in order."""
+    received: list[SleipnirEvent] = []
+
+    async def handler(event: SleipnirEvent) -> None:
+        received.append(event)
+
+    await rabbitmq_transport.subscribe(["ravn.*"], handler)
+
+    events = [make_event(summary=f"event-{i}") for i in range(5)]
+    await rabbitmq_transport.publish_batch(events)
+
+    await collect_events(5, received)
+
+    assert [e.summary for e in received] == [f"event-{i}" for i in range(5)]
+
+
+# ---------------------------------------------------------------------------
+# Topic routing
+# ---------------------------------------------------------------------------
+
+
+async def test_topic_exchange_routing(rabbitmq_transport: RabbitMQTransport):
+    """Subscriber with 'ravn.*' receives ravn events but not tyr events."""
+    received: list[SleipnirEvent] = []
+
+    async def handler(event: SleipnirEvent) -> None:
+        received.append(event)
+
+    await rabbitmq_transport.subscribe(["ravn.*"], handler)
+
+    await rabbitmq_transport.publish(make_event(event_type="ravn.tool.complete"))
+    await rabbitmq_transport.publish(make_event(event_type="tyr.saga.created"))
+
+    await collect_events(1, received, timeout=2.0)
+    await asyncio.sleep(0.3)
+
+    assert len(received) == 1
+    assert received[0].event_type == "ravn.tool.complete"
+
+
+# ---------------------------------------------------------------------------
+# Durable queue
+# ---------------------------------------------------------------------------
+
+
+async def test_durable_queue_with_service_id():
+    """A named service_id creates a durable queue that survives reconnection."""
+    exchange = f"sleipnir_test_{uuid.uuid4().hex[:8]}"
+    service_id = f"test-service-{uuid.uuid4().hex[:8]}"
+
+    received: list[SleipnirEvent] = []
+
+    async def handler(event: SleipnirEvent) -> None:
+        received.append(event)
+
+    # First connection: subscribe with durable queue, then disconnect
+    transport1 = RabbitMQTransport(
+        url=RABBITMQ_URL,
+        exchange_name=exchange,
+        dead_letter_exchange=f"{exchange}_dlx",
+        service_id=service_id,
+    )
+    async with transport1:
+        await transport1.subscribe(["ravn.*"], handler)
+    # transport1 is stopped; the durable queue remains on the broker
+
+    # Publish an event while the subscriber is disconnected
+    from sleipnir.adapters.rabbitmq import RabbitMQPublisher
+
+    publisher = RabbitMQPublisher(url=RABBITMQ_URL, exchange_name=exchange)
+    async with publisher:
+        await publisher.publish(make_event(summary="while-offline"))
+
+    # Second connection: same service_id should pick up the queued message
+    transport2 = RabbitMQTransport(
+        url=RABBITMQ_URL,
+        exchange_name=exchange,
+        dead_letter_exchange=f"{exchange}_dlx",
+        service_id=service_id,
+    )
+    async with transport2:
+        await transport2.subscribe(["ravn.*"], handler)
+        await collect_events(1, received)
+
+    assert len(received) == 1
+    assert received[0].summary == "while-offline"
+
+
+# ---------------------------------------------------------------------------
+# Multiple subscribers
+# ---------------------------------------------------------------------------
+
+
+async def test_multiple_independent_subscribers(rabbitmq_transport: RabbitMQTransport):
+    """Two subscribers each receive matching events independently."""
+    ravn_received: list[SleipnirEvent] = []
+    all_received: list[SleipnirEvent] = []
+
+    async def ravn_handler(event: SleipnirEvent) -> None:
+        ravn_received.append(event)
+
+    async def all_handler(event: SleipnirEvent) -> None:
+        all_received.append(event)
+
+    await rabbitmq_transport.subscribe(["ravn.*"], ravn_handler)
+    await rabbitmq_transport.subscribe(["*"], all_handler)
+
+    await rabbitmq_transport.publish(make_event(event_type="ravn.tool.complete"))
+    await rabbitmq_transport.publish(make_event(event_type="tyr.saga.created"))
+
+    await collect_events(1, ravn_received)
+    await collect_events(2, all_received)
+
+    assert len(ravn_received) == 1
+    assert len(all_received) == 2
+
+
+# ---------------------------------------------------------------------------
+# Unsubscribe
+# ---------------------------------------------------------------------------
+
+
+async def test_unsubscribe_stops_delivery(rabbitmq_transport: RabbitMQTransport):
+    """After unsubscribe, no more events are delivered."""
+    received: list[SleipnirEvent] = []
+
+    async def handler(event: SleipnirEvent) -> None:
+        received.append(event)
+
+    sub = await rabbitmq_transport.subscribe(["ravn.*"], handler)
+    await rabbitmq_transport.publish(make_event(summary="before"))
+    await collect_events(1, received)
+
+    await sub.unsubscribe()
+    await rabbitmq_transport.publish(make_event(summary="after"))
+    await asyncio.sleep(0.5)
+
+    assert len(received) == 1
+    assert received[0].summary == "before"
+
+
+# ---------------------------------------------------------------------------
+# TTL filtering
+# ---------------------------------------------------------------------------
+
+
+async def test_ttl_zero_events_not_published(rabbitmq_transport: RabbitMQTransport):
+    """Events with ttl=0 are dropped by the publisher."""
+    received: list[SleipnirEvent] = []
+
+    async def handler(event: SleipnirEvent) -> None:
+        received.append(event)
+
+    await rabbitmq_transport.subscribe(["ravn.*"], handler)
+
+    await rabbitmq_transport.publish(make_event(ttl=0, summary="expired"))
+    await rabbitmq_transport.publish(make_event(ttl=300, summary="valid"))
+
+    await collect_events(1, received)
+    await asyncio.sleep(0.3)
+
+    assert len(received) == 1
+    assert received[0].summary == "valid"

--- a/tests/integration/sleipnir/test_redis_broker.py
+++ b/tests/integration/sleipnir/test_redis_broker.py
@@ -1,0 +1,197 @@
+"""Integration tests for the Redis Streams transport against a real Redis.
+
+Requires a running Redis server (default ``redis://localhost:6379``).
+Set ``TEST_REDIS_URL`` to override.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+
+import pytest
+
+from sleipnir.adapters.redis_streams import RedisStreamsTransport
+from sleipnir.domain.events import SleipnirEvent
+
+from .conftest import REDIS_URL, collect_events, make_event
+
+pytestmark = pytest.mark.broker
+
+
+# ---------------------------------------------------------------------------
+# Basic pub/sub
+# ---------------------------------------------------------------------------
+
+
+async def test_publish_and_subscribe_round_trip(redis_transport: RedisStreamsTransport):
+    """A published event is received by a subscriber."""
+    received: list[SleipnirEvent] = []
+
+    async def handler(event: SleipnirEvent) -> None:
+        received.append(event)
+
+    await redis_transport.subscribe(["ravn.*"], handler)
+    event = make_event()
+    await redis_transport.publish(event)
+
+    await collect_events(1, received)
+
+    assert len(received) == 1
+    assert received[0].event_id == event.event_id
+    assert received[0].event_type == event.event_type
+    assert received[0].payload == event.payload
+
+
+async def test_batch_publish_ordering(redis_transport: RedisStreamsTransport):
+    """Events published via publish_batch (pipeline) arrive in order."""
+    received: list[SleipnirEvent] = []
+
+    async def handler(event: SleipnirEvent) -> None:
+        received.append(event)
+
+    await redis_transport.subscribe(["ravn.*"], handler)
+
+    events = [make_event(summary=f"event-{i}") for i in range(5)]
+    await redis_transport.publish_batch(events)
+
+    await collect_events(5, received)
+
+    assert [e.summary for e in received] == [f"event-{i}" for i in range(5)]
+
+
+# ---------------------------------------------------------------------------
+# Stream-per-namespace
+# ---------------------------------------------------------------------------
+
+
+async def test_stream_per_namespace_mapping(redis_transport: RedisStreamsTransport):
+    """Events land in namespace-specific streams (sleipnir:ravn, sleipnir:tyr)."""
+    received: list[SleipnirEvent] = []
+
+    async def handler(event: SleipnirEvent) -> None:
+        received.append(event)
+
+    # Subscribe to ravn only
+    await redis_transport.subscribe(["ravn.*"], handler)
+
+    await redis_transport.publish(make_event(event_type="ravn.tool.complete"))
+    await redis_transport.publish(make_event(event_type="tyr.saga.created"))
+
+    await collect_events(1, received, timeout=2.0)
+    await asyncio.sleep(0.3)
+
+    assert len(received) == 1
+    assert received[0].event_type == "ravn.tool.complete"
+
+
+# ---------------------------------------------------------------------------
+# Consumer group isolation
+# ---------------------------------------------------------------------------
+
+
+async def test_consumer_group_isolation(redis_transport: RedisStreamsTransport):
+    """Two subscriptions each get all events (fan-out via unique groups)."""
+    received_a: list[SleipnirEvent] = []
+    received_b: list[SleipnirEvent] = []
+
+    async def handler_a(event: SleipnirEvent) -> None:
+        received_a.append(event)
+
+    async def handler_b(event: SleipnirEvent) -> None:
+        received_b.append(event)
+
+    await redis_transport.subscribe(["ravn.*"], handler_a)
+    await redis_transport.subscribe(["ravn.*"], handler_b)
+
+    await redis_transport.publish(make_event(summary="shared-event"))
+
+    await collect_events(1, received_a)
+    await collect_events(1, received_b)
+
+    assert len(received_a) == 1
+    assert len(received_b) == 1
+    assert received_a[0].event_id == received_b[0].event_id
+
+
+# ---------------------------------------------------------------------------
+# Replay on startup
+# ---------------------------------------------------------------------------
+
+
+async def test_replay_on_startup():
+    """A subscriber with replay_on_startup=True receives historical events."""
+    prefix = f"sleipnir_test_{uuid.uuid4().hex[:8]}"
+
+    # Phase 1: publish events with replay disabled (default)
+    transport1 = RedisStreamsTransport(url=REDIS_URL, stream_prefix=prefix)
+    async with transport1:
+        for i in range(3):
+            await transport1.publish(make_event(summary=f"historical-{i}"))
+
+    # Phase 2: new transport with replay enabled
+    received: list[SleipnirEvent] = []
+
+    async def handler(event: SleipnirEvent) -> None:
+        received.append(event)
+
+    transport2 = RedisStreamsTransport(
+        url=REDIS_URL,
+        stream_prefix=prefix,
+        replay_on_startup=True,
+    )
+    async with transport2:
+        await transport2.subscribe(["ravn.*"], handler)
+        await collect_events(3, received)
+
+    assert len(received) >= 3
+    summaries = [e.summary for e in received[:3]]
+    assert summaries == ["historical-0", "historical-1", "historical-2"]
+
+
+# ---------------------------------------------------------------------------
+# Unsubscribe
+# ---------------------------------------------------------------------------
+
+
+async def test_unsubscribe_stops_delivery(redis_transport: RedisStreamsTransport):
+    """After unsubscribe, no more events are delivered."""
+    received: list[SleipnirEvent] = []
+
+    async def handler(event: SleipnirEvent) -> None:
+        received.append(event)
+
+    sub = await redis_transport.subscribe(["ravn.*"], handler)
+    await redis_transport.publish(make_event(summary="before"))
+    await collect_events(1, received)
+
+    await sub.unsubscribe()
+    await redis_transport.publish(make_event(summary="after"))
+    await asyncio.sleep(0.5)
+
+    assert len(received) == 1
+    assert received[0].summary == "before"
+
+
+# ---------------------------------------------------------------------------
+# TTL filtering
+# ---------------------------------------------------------------------------
+
+
+async def test_ttl_zero_events_not_published(redis_transport: RedisStreamsTransport):
+    """Events with ttl=0 are dropped by the publisher."""
+    received: list[SleipnirEvent] = []
+
+    async def handler(event: SleipnirEvent) -> None:
+        received.append(event)
+
+    await redis_transport.subscribe(["ravn.*"], handler)
+
+    await redis_transport.publish(make_event(ttl=0, summary="expired"))
+    await redis_transport.publish(make_event(ttl=300, summary="valid"))
+
+    await collect_events(1, received)
+    await asyncio.sleep(0.3)
+
+    assert len(received) == 1
+    assert received[0].summary == "valid"


### PR DESCRIPTION
## Summary
- Adds integration tests against real NATS JetStream, RabbitMQ, and Redis brokers for all three Sleipnir transport adapters
- Adds cross-service chain tests (Volundr sink → Sleipnir bus → Skuld bridge) parameterised across all transports
- New `integration-sleipnir` CI job in full tier with service containers for RabbitMQ/Redis and manual NATS (JetStream requires `--jetstream` flag)
- New `broker` pytest marker excluded by default; `make test-integration-sleipnir` target for local runs

## Test plan
- [ ] CI `Python: Integration Test Sleipnir` job passes on this PR
- [ ] Existing unit tests unaffected (`addopts` updated to exclude `broker` marker)
- [ ] Light tier PRs skip the new job (only runs on full tier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)