### PR TITLE
feat(adapters): Mímir — persistent compounding knowledge base (NIU-540)

### DIFF
--- a/src/ravn/adapters/mimir/__init__.py
+++ b/src/ravn/adapters/mimir/__init__.py
@@ -1,0 +1,1 @@
+"""Mímir knowledge base adapters."""

--- a/src/ravn/adapters/mimir/markdown.py
+++ b/src/ravn/adapters/mimir/markdown.py
@@ -1,0 +1,498 @@
+"""MarkdownMimirAdapter — filesystem-backed Mímir knowledge base.
+
+Directory layout (all paths relative to the configured ``root``):
+
+    wiki/
+      index.md          — content catalog, updated on every ingest/lint
+      log.md            — append-only chronological record
+      <category>/       — subdirectories per top-level category
+        <page>.md       — individual wiki pages
+    raw/
+      <source_id>.json  — immutable source metadata + content
+    MIMIR.md            — schema and conventions (seeded on first run)
+
+The adapter is intentionally LLM-free: it manages the *filesystem layer* only.
+All synthesis (writing page content, answering queries) is performed by the
+Ravn agent using the six mimir_* tool wrappers.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+
+from ravn.domain.models import (
+    MimirLintReport,
+    MimirPage,
+    MimirPageMeta,
+    MimirQueryResult,
+    MimirSource,
+)
+from ravn.ports.mimir import MimirPort
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_MIMIR_MD_SEED = """\
+# Mímir — wiki schema and conventions
+
+## Directory structure
+
+```
+wiki/
+  index.md          — content catalog, one line per page
+  log.md            — append-only chronological record
+  technical/        — infrastructure, codebase, how things work
+    volundr/        — platform architecture, session management, auth
+    ravn/           — agent architecture, tool configs, known quirks
+    valaskjalf/     — cluster layout, node specs, workload placement
+    k8s/            — kubernetes patterns, Kyverno policies
+  projects/         — KVM models, ODIN platform, active Linear sagas
+  research/         — topic deep-dives (one-time or ongoing)
+  household/        — Burlington home, Netherlands property, finances
+  self/             — patterns, preferences, rhythms (earned through observation)
+raw/                — immutable source documents (JSON metadata + content)
+MIMIR.md            — this file
+```
+
+## Page format
+
+- Filename: lowercase, hyphen-separated, `.md` extension
+- Title: first `# Heading` in the file
+- Summary: second line of the file (after the heading), one sentence
+- Links use relative paths: `[auth](../volundr/auth.md)`
+
+## Operations
+
+- **Ingest**: read source → identify takeaways → write or update wiki pages →
+  update `index.md` → append to `log.md`
+- **Query**: read `index.md` → read relevant pages → synthesise answer →
+  optionally write answer as new page → append to `log.md`
+- **Lint**: scan for orphans, contradictions, staleness, gaps →
+  fix or flag → update `index.md` and `log.md`
+
+## Log entry format
+
+```
+## [YYYY-MM-DD] ingest | <title>
+## [YYYY-MM-DD] query  | <question>
+## [YYYY-MM-DD] lint   | <pages> pages checked, <issues> issues found
+```
+
+## Categories
+
+- **technical/**: infrastructure, codebase, how things work
+- **projects/**: KVM models, ODIN platform, active Linear sagas
+- **research/**: topic deep-dives
+- **household/**: Burlington, Netherlands, finances
+- **self/**: earned through observation — patterns, preferences, rhythms
+
+## self/ conventions
+
+- Written in third person ("Jozef typically...", "Prefers...")
+- Only concrete observations, not inferences
+- Updated when a pattern is observed at least twice
+"""
+
+_LOG_INGEST_PREFIX = "ingest"
+_LOG_QUERY_PREFIX = "query"
+_LOG_LINT_PREFIX = "lint"
+
+_MIN_GAP_MENTION_COUNT = 3  # mentions before a concept is flagged as a gap
+
+
+# ---------------------------------------------------------------------------
+# Adapter
+# ---------------------------------------------------------------------------
+
+
+class MarkdownMimirAdapter(MimirPort):
+    """Filesystem-backed Mímir knowledge base adapter.
+
+    Args:
+        root: Root directory for the Mímir store (e.g. ``~/.ravn/mimir``).
+    """
+
+    def __init__(self, root: str | Path = "~/.ravn/mimir") -> None:
+        self._root = Path(root).expanduser()
+        self._wiki = self._root / "wiki"
+        self._raw = self._root / "raw"
+        self._schema = self._root / "MIMIR.md"
+        self._index = self._wiki / "index.md"
+        self._log = self._wiki / "log.md"
+        self._ensure_layout()
+
+    # ------------------------------------------------------------------
+    # Layout bootstrap
+    # ------------------------------------------------------------------
+
+    def _ensure_layout(self) -> None:
+        """Create the directory structure and seed MIMIR.md on first run."""
+        self._wiki.mkdir(parents=True, exist_ok=True)
+        self._raw.mkdir(parents=True, exist_ok=True)
+
+        if not self._schema.exists():
+            self._schema.write_text(_MIMIR_MD_SEED, encoding="utf-8")
+            logger.info("mimir: seeded MIMIR.md at %s", self._schema)
+
+        if not self._index.exists():
+            self._index.write_text("# Mímir — content catalog\n\n", encoding="utf-8")
+
+        if not self._log.exists():
+            self._log.write_text("# Mímir — activity log\n\n", encoding="utf-8")
+
+    # ------------------------------------------------------------------
+    # MimirPort implementation
+    # ------------------------------------------------------------------
+
+    async def ingest(self, source: MimirSource) -> list[str]:
+        """Persist a raw source and record the ingest in the log.
+
+        Returns an empty list — page creation is delegated to the agent via
+        ``upsert_page()``.  The raw source is stored for staleness tracking.
+        """
+        self._write_raw_source(source)
+        self._append_log(
+            _LOG_INGEST_PREFIX,
+            source.title,
+            f"source_id={source.source_id} type={source.source_type}",
+        )
+        logger.info("mimir: ingested source %r (%s)", source.title, source.source_id)
+        return []
+
+    async def query(self, question: str) -> MimirQueryResult:
+        """Return index content + relevant pages for the agent to synthesise.
+
+        The adapter performs keyword-based relevance ranking.  Full synthesis
+        is done by the agent via the ``mimir_query`` tool.
+        """
+        pages = await self.search(question)
+        self._append_log(_LOG_QUERY_PREFIX, question)
+        return MimirQueryResult(
+            question=question,
+            answer="",  # filled in by the agent after reading pages
+            sources=pages,
+        )
+
+    async def lint(self) -> MimirLintReport:
+        """Scan the wiki and return a health-check report."""
+        all_pages = await self.list_pages()
+        indexed = self._read_indexed_paths()
+
+        orphans = self._find_orphans(all_pages, indexed)
+        stale = self._find_stale(all_pages)
+        contradictions = self._find_contradictions(all_pages)
+        gaps = self._find_gaps(all_pages)
+
+        report = MimirLintReport(
+            orphans=orphans,
+            contradictions=contradictions,
+            stale=stale,
+            gaps=gaps,
+            pages_checked=len(all_pages),
+        )
+
+        issues = len(orphans) + len(contradictions) + len(stale) + len(gaps)
+        self._append_log(
+            _LOG_LINT_PREFIX,
+            f"{len(all_pages)} pages checked, {issues} issues found",
+        )
+        logger.info(
+            "mimir: lint complete — %d pages checked, %d issues",
+            len(all_pages),
+            issues,
+        )
+        return report
+
+    async def search(self, query: str) -> list[MimirPage]:
+        """Full-text search over wiki pages, ranked by keyword hits."""
+        if not query.strip():
+            return []
+
+        keywords = set(re.split(r"\W+", query.lower())) - {"", "the", "a", "an", "is", "in"}
+        results: list[tuple[int, MimirPage]] = []
+
+        for md_path in self._wiki.rglob("*.md"):
+            if md_path.name in {"index.md", "log.md"}:
+                continue
+            content = md_path.read_text(encoding="utf-8")
+            lower = content.lower()
+            score = sum(lower.count(kw) for kw in keywords)
+            if score == 0:
+                continue
+            meta = self._page_meta_from_path(md_path)
+            results.append((score, MimirPage(meta=meta, content=content)))
+
+        results.sort(key=lambda t: t[0], reverse=True)
+        return [page for _, page in results]
+
+    async def upsert_page(self, path: str, content: str) -> None:
+        """Create or replace a wiki page and update index.md."""
+        page_path = self._wiki / path
+        page_path.parent.mkdir(parents=True, exist_ok=True)
+
+        is_new = not page_path.exists()
+        page_path.write_text(content, encoding="utf-8")
+
+        if is_new:
+            self._add_to_index(path, content)
+        else:
+            self._update_index_entry(path, content)
+
+        logger.info("mimir: upserted page %s (new=%s)", path, is_new)
+
+    async def read_page(self, path: str) -> str:
+        """Return the raw Markdown content of the page at *path*."""
+        page_path = self._wiki / path
+        if not page_path.exists():
+            raise FileNotFoundError(f"Mímir page not found: {path}")
+        return page_path.read_text(encoding="utf-8")
+
+    async def list_pages(
+        self,
+        category: str | None = None,
+    ) -> list[MimirPageMeta]:
+        """List all wiki pages, optionally filtered by category."""
+        results: list[MimirPageMeta] = []
+        search_root = self._wiki / category if category else self._wiki
+
+        if not search_root.exists():
+            return results
+
+        for md_path in search_root.rglob("*.md"):
+            if md_path.name in {"index.md", "log.md"}:
+                continue
+            results.append(self._page_meta_from_path(md_path))
+
+        return results
+
+    # ------------------------------------------------------------------
+    # Raw source storage
+    # ------------------------------------------------------------------
+
+    def _write_raw_source(self, source: MimirSource) -> None:
+        """Persist a raw source as JSON in the raw/ directory."""
+        dest = self._raw / f"{source.source_id}.json"
+        data = {
+            "source_id": source.source_id,
+            "title": source.title,
+            "content": source.content,
+            "source_type": source.source_type,
+            "origin_url": source.origin_url,
+            "content_hash": source.content_hash,
+            "ingested_at": source.ingested_at.isoformat(),
+        }
+        dest.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+    def read_raw_source(self, source_id: str) -> MimirSource | None:
+        """Read a persisted raw source by ID.  Returns None if not found."""
+        dest = self._raw / f"{source_id}.json"
+        if not dest.exists():
+            return None
+        data = json.loads(dest.read_text(encoding="utf-8"))
+        return MimirSource(
+            source_id=data["source_id"],
+            title=data["title"],
+            content=data["content"],
+            source_type=data["source_type"],
+            origin_url=data.get("origin_url"),
+            content_hash=data["content_hash"],
+            ingested_at=datetime.fromisoformat(data["ingested_at"]),
+        )
+
+    @staticmethod
+    def compute_content_hash(content: str) -> str:
+        """Return the SHA-256 hex digest of *content*."""
+        return hashlib.sha256(content.encode()).hexdigest()
+
+    def is_source_stale(self, source_id: str, current_content: str) -> bool:
+        """Return True if the stored hash differs from the hash of *current_content*."""
+        existing = self.read_raw_source(source_id)
+        if existing is None:
+            return False
+        current_hash = self.compute_content_hash(current_content)
+        return existing.content_hash != current_hash
+
+    # ------------------------------------------------------------------
+    # Index management
+    # ------------------------------------------------------------------
+
+    def _read_indexed_paths(self) -> set[str]:
+        """Return the set of page paths currently listed in index.md."""
+        if not self._index.exists():
+            return set()
+        content = self._index.read_text(encoding="utf-8")
+        # Match markdown links: [text](path)
+        return set(re.findall(r"\[.*?\]\(([^)]+\.md)\)", content))
+
+    def _add_to_index(self, path: str, content: str) -> None:
+        """Append a new entry to index.md."""
+        title = _extract_title(content)
+        summary = _extract_summary(content)
+        category = path.split("/")[0] if "/" in path else "uncategorised"
+        date_str = datetime.now(UTC).strftime("%Y-%m-%d")
+        entry = f"- [{title}]({path}) — {summary} *(added {date_str}, {category})*\n"
+        with self._index.open("a", encoding="utf-8") as f:
+            f.write(entry)
+
+    def _update_index_entry(self, path: str, content: str) -> None:
+        """Update the summary in an existing index.md entry for *path*."""
+        if not self._index.exists():
+            return
+        index_content = self._index.read_text(encoding="utf-8")
+        title = _extract_title(content)
+        summary = _extract_summary(content)
+        # Replace the line containing the path link
+        new_lines = []
+        for line in index_content.splitlines(keepends=True):
+            if f"]({path})" in line:
+                # Preserve the date/category metadata if present
+                meta_match = re.search(r"\*\(.*?\)\*", line)
+                meta = meta_match.group(0) if meta_match else ""
+                line = f"- [{title}]({path}) — {summary} {meta}\n".rstrip() + "\n"
+            new_lines.append(line)
+        self._index.write_text("".join(new_lines), encoding="utf-8")
+
+    # ------------------------------------------------------------------
+    # Log management
+    # ------------------------------------------------------------------
+
+    def _append_log(self, prefix: str, subject: str, detail: str = "") -> None:
+        """Append a structured entry to log.md."""
+        date_str = datetime.now(UTC).strftime("%Y-%m-%d")
+        entry = f"\n## [{date_str}] {prefix} | {subject}\n"
+        if detail:
+            entry += f"{detail}\n"
+        with self._log.open("a", encoding="utf-8") as f:
+            f.write(entry)
+
+    # ------------------------------------------------------------------
+    # Lint helpers
+    # ------------------------------------------------------------------
+
+    def _find_orphans(self, pages: list[MimirPageMeta], indexed: set[str]) -> list[str]:
+        """Return paths of pages not linked in index.md."""
+        return [p.path for p in pages if p.path not in indexed]
+
+    def _find_stale(self, pages: list[MimirPageMeta]) -> list[str]:
+        """Return paths of pages whose source content hash has changed."""
+        stale = []
+        for page_meta in pages:
+            for source_id in page_meta.source_ids:
+                raw_path = self._raw / f"{source_id}.json"
+                if not raw_path.exists():
+                    continue
+                data = json.loads(raw_path.read_text(encoding="utf-8"))
+                stored_hash = data.get("content_hash", "")
+                current_hash = self.compute_content_hash(data.get("content", ""))
+                if stored_hash and stored_hash != current_hash:
+                    stale.append(page_meta.path)
+                    break
+        return stale
+
+    def _find_contradictions(self, pages: list[MimirPageMeta]) -> list[str]:
+        """Return paths of pages that contain a contradiction flag marker."""
+        contradictions = []
+        for page_meta in pages:
+            page_path = self._wiki / page_meta.path
+            if not page_path.exists():
+                continue
+            content = page_path.read_text(encoding="utf-8")
+            if "[CONTRADICTION]" in content or "⚠️ contradiction" in content.lower():
+                contradictions.append(page_meta.path)
+        return contradictions
+
+    def _find_gaps(self, pages: list[MimirPageMeta]) -> list[str]:
+        """Return concept names mentioned ≥ N times across wiki but without a page.
+
+        A concept without a page means the wiki text mentions it frequently but
+        no dedicated ``<concept>.md`` file exists.
+        """
+        existing_titles = {p.title.lower() for p in pages}
+        mention_counts: dict[str, int] = {}
+
+        for page_meta in pages:
+            page_path = self._wiki / page_meta.path
+            if not page_path.exists():
+                continue
+            content = page_path.read_text(encoding="utf-8")
+            # Extract wiki-link style references: [[Concept Name]]
+            for concept in re.findall(r"\[\[([^\]]+)\]\]", content):
+                key = concept.lower().strip()
+                if key not in existing_titles:
+                    mention_counts[key] = mention_counts.get(key, 0) + 1
+
+        return [
+            concept for concept, count in mention_counts.items() if count >= _MIN_GAP_MENTION_COUNT
+        ]
+
+    # ------------------------------------------------------------------
+    # Metadata helpers
+    # ------------------------------------------------------------------
+
+    def _page_meta_from_path(self, md_path: Path) -> MimirPageMeta:
+        """Build a MimirPageMeta from a wiki page path."""
+        content = md_path.read_text(encoding="utf-8")
+        rel = md_path.relative_to(self._wiki)
+        path_str = str(rel)
+        parts = path_str.split("/")
+        category = parts[0] if len(parts) > 1 else "uncategorised"
+        stat = md_path.stat()
+        updated_at = datetime.fromtimestamp(stat.st_mtime, tz=UTC)
+        source_ids = self._extract_source_ids(content)
+        return MimirPageMeta(
+            path=path_str,
+            title=_extract_title(content),
+            summary=_extract_summary(content),
+            category=category,
+            updated_at=updated_at,
+            source_ids=source_ids,
+        )
+
+    @staticmethod
+    def _extract_source_ids(content: str) -> list[str]:
+        """Extract source IDs from a page's frontmatter or footer.
+
+        Pages may embed source references as:
+        ``<!-- sources: id1,id2 -->``
+        """
+        match = re.search(r"<!--\s*sources:\s*([^-]+?)\s*-->", content)
+        if not match:
+            return []
+        return [s.strip() for s in match.group(1).split(",") if s.strip()]
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_title(content: str) -> str:
+    """Return the first H1 heading from *content*, or 'Untitled'."""
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("# "):
+            return stripped[2:].strip()
+    return "Untitled"
+
+
+def _extract_summary(content: str) -> str:
+    """Return the first non-heading, non-empty line from *content*."""
+    heading_seen = False
+    for line in content.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("#"):
+            heading_seen = True
+            continue
+        if heading_seen:
+            return stripped[:120]
+    return ""

--- a/src/ravn/adapters/mimir/markdown.py
+++ b/src/ravn/adapters/mimir/markdown.py
@@ -14,6 +14,15 @@ Directory layout (all paths relative to the configured ``root``):
 The adapter is intentionally LLM-free: it manages the *filesystem layer* only.
 All synthesis (writing page content, answering queries) is performed by the
 Ravn agent using the six mimir_* tool wrappers.
+
+Staleness detection note
+------------------------
+Lint-level staleness detection (checking whether a wiki page's source has
+changed) cannot re-fetch remote URLs, so the lint pass never populates the
+``stale`` field of ``MimirLintReport``.  Real staleness detection is triggered
+during re-ingest: call ``is_source_stale(source_id, current_content)`` *before*
+calling ``ingest()`` — if it returns True, the source has changed and the
+derived wiki pages should be reviewed and updated.
 """
 
 from __future__ import annotations
@@ -25,6 +34,7 @@ import re
 from datetime import UTC, datetime
 from pathlib import Path
 
+from ravn.adapters.tools.file_security import PathSecurityError
 from ravn.domain.models import (
     MimirLintReport,
     MimirPage,
@@ -75,8 +85,14 @@ MIMIR.md            — this file
   update `index.md` → append to `log.md`
 - **Query**: read `index.md` → read relevant pages → synthesise answer →
   optionally write answer as new page → append to `log.md`
-- **Lint**: scan for orphans, contradictions, staleness, gaps →
+- **Lint**: scan for orphans, contradictions, gaps →
   fix or flag → update `index.md` and `log.md`
+
+## Staleness detection
+
+Lint cannot re-fetch remote URLs so it does not populate the `stale` report
+field.  Call `is_source_stale(source_id, current_content)` before re-ingesting
+a source to detect whether the original content has changed.
 
 ## Log entry format
 
@@ -149,6 +165,26 @@ class MarkdownMimirAdapter(MimirPort):
             self._log.write_text("# Mímir — activity log\n\n", encoding="utf-8")
 
     # ------------------------------------------------------------------
+    # Path security
+    # ------------------------------------------------------------------
+
+    def _safe_wiki_path(self, path: str) -> Path:
+        """Resolve *path* to an absolute path that lies within the wiki root.
+
+        Raises ``PathSecurityError`` if the resolved path escapes the wiki
+        directory (e.g. due to ``../`` traversal components).
+        """
+        wiki_root = self._wiki.resolve()
+        resolved = (self._wiki / path).resolve()
+        try:
+            resolved.relative_to(wiki_root)
+        except ValueError:
+            raise PathSecurityError(
+                f"Path '{path}' resolves outside the wiki directory '{wiki_root}'"
+            )
+        return resolved
+
+    # ------------------------------------------------------------------
     # MimirPort implementation
     # ------------------------------------------------------------------
 
@@ -182,24 +218,30 @@ class MarkdownMimirAdapter(MimirPort):
         )
 
     async def lint(self) -> MimirLintReport:
-        """Scan the wiki and return a health-check report."""
-        all_pages = await self.list_pages()
+        """Scan the wiki and return a health-check report.
+
+        The ``stale`` field of the returned report is always empty — staleness
+        detection requires re-fetching source URLs, which the lint pass does
+        not do.  Use ``is_source_stale()`` during re-ingest instead.
+        """
+        pages_with_content = self._list_pages_with_content()
+        all_pages = [meta for meta, _ in pages_with_content]
+        content_map = {meta.path: content for meta, content in pages_with_content}
         indexed = self._read_indexed_paths()
 
         orphans = self._find_orphans(all_pages, indexed)
-        stale = self._find_stale(all_pages)
-        contradictions = self._find_contradictions(all_pages)
-        gaps = self._find_gaps(all_pages)
+        contradictions = self._find_contradictions(content_map)
+        gaps = self._find_gaps(all_pages, content_map)
 
         report = MimirLintReport(
             orphans=orphans,
             contradictions=contradictions,
-            stale=stale,
+            stale=[],  # populated by re-ingest flow, not lint pass
             gaps=gaps,
             pages_checked=len(all_pages),
         )
 
-        issues = len(orphans) + len(contradictions) + len(stale) + len(gaps)
+        issues = len(orphans) + len(contradictions) + len(gaps)
         self._append_log(
             _LOG_LINT_PREFIX,
             f"{len(all_pages)} pages checked, {issues} issues found",
@@ -227,7 +269,8 @@ class MarkdownMimirAdapter(MimirPort):
             score = sum(lower.count(kw) for kw in keywords)
             if score == 0:
                 continue
-            meta = self._page_meta_from_path(md_path)
+            # Pass pre-read content to avoid a second file read inside _build_page_meta.
+            meta = self._build_page_meta(md_path, content)
             results.append((score, MimirPage(meta=meta, content=content)))
 
         results.sort(key=lambda t: t[0], reverse=True)
@@ -235,7 +278,7 @@ class MarkdownMimirAdapter(MimirPort):
 
     async def upsert_page(self, path: str, content: str) -> None:
         """Create or replace a wiki page and update index.md."""
-        page_path = self._wiki / path
+        page_path = self._safe_wiki_path(path)
         page_path.parent.mkdir(parents=True, exist_ok=True)
 
         is_new = not page_path.exists()
@@ -250,7 +293,7 @@ class MarkdownMimirAdapter(MimirPort):
 
     async def read_page(self, path: str) -> str:
         """Return the raw Markdown content of the page at *path*."""
-        page_path = self._wiki / path
+        page_path = self._safe_wiki_path(path)
         if not page_path.exists():
             raise FileNotFoundError(f"Mímir page not found: {path}")
         return page_path.read_text(encoding="utf-8")
@@ -260,18 +303,7 @@ class MarkdownMimirAdapter(MimirPort):
         category: str | None = None,
     ) -> list[MimirPageMeta]:
         """List all wiki pages, optionally filtered by category."""
-        results: list[MimirPageMeta] = []
-        search_root = self._wiki / category if category else self._wiki
-
-        if not search_root.exists():
-            return results
-
-        for md_path in search_root.rglob("*.md"):
-            if md_path.name in {"index.md", "log.md"}:
-                continue
-            results.append(self._page_meta_from_path(md_path))
-
-        return results
+        return [meta for meta, _ in self._list_pages_with_content(category)]
 
     # ------------------------------------------------------------------
     # Raw source storage
@@ -313,7 +345,11 @@ class MarkdownMimirAdapter(MimirPort):
         return hashlib.sha256(content.encode()).hexdigest()
 
     def is_source_stale(self, source_id: str, current_content: str) -> bool:
-        """Return True if the stored hash differs from the hash of *current_content*."""
+        """Return True if the stored hash differs from the hash of *current_content*.
+
+        This is the correct staleness check: call it before re-ingesting a
+        source to see whether the content has changed since the last ingest.
+        """
         existing = self.read_raw_source(source_id)
         if existing is None:
             return False
@@ -381,35 +417,17 @@ class MarkdownMimirAdapter(MimirPort):
         """Return paths of pages not linked in index.md."""
         return [p.path for p in pages if p.path not in indexed]
 
-    def _find_stale(self, pages: list[MimirPageMeta]) -> list[str]:
-        """Return paths of pages whose source content hash has changed."""
-        stale = []
-        for page_meta in pages:
-            for source_id in page_meta.source_ids:
-                raw_path = self._raw / f"{source_id}.json"
-                if not raw_path.exists():
-                    continue
-                data = json.loads(raw_path.read_text(encoding="utf-8"))
-                stored_hash = data.get("content_hash", "")
-                current_hash = self.compute_content_hash(data.get("content", ""))
-                if stored_hash and stored_hash != current_hash:
-                    stale.append(page_meta.path)
-                    break
-        return stale
-
-    def _find_contradictions(self, pages: list[MimirPageMeta]) -> list[str]:
+    def _find_contradictions(self, content_map: dict[str, str]) -> list[str]:
         """Return paths of pages that contain a contradiction flag marker."""
-        contradictions = []
-        for page_meta in pages:
-            page_path = self._wiki / page_meta.path
-            if not page_path.exists():
-                continue
-            content = page_path.read_text(encoding="utf-8")
-            if "[CONTRADICTION]" in content or "⚠️ contradiction" in content.lower():
-                contradictions.append(page_meta.path)
-        return contradictions
+        return [
+            path
+            for path, content in content_map.items()
+            if "[CONTRADICTION]" in content or "⚠️ contradiction" in content.lower()
+        ]
 
-    def _find_gaps(self, pages: list[MimirPageMeta]) -> list[str]:
+    def _find_gaps(
+        self, pages: list[MimirPageMeta], content_map: dict[str, str]
+    ) -> list[str]:
         """Return concept names mentioned ≥ N times across wiki but without a page.
 
         A concept without a page means the wiki text mentions it frequently but
@@ -418,12 +436,7 @@ class MarkdownMimirAdapter(MimirPort):
         existing_titles = {p.title.lower() for p in pages}
         mention_counts: dict[str, int] = {}
 
-        for page_meta in pages:
-            page_path = self._wiki / page_meta.path
-            if not page_path.exists():
-                continue
-            content = page_path.read_text(encoding="utf-8")
-            # Extract wiki-link style references: [[Concept Name]]
+        for content in content_map.values():
             for concept in re.findall(r"\[\[([^\]]+)\]\]", content):
                 key = concept.lower().strip()
                 if key not in existing_titles:
@@ -437,9 +450,32 @@ class MarkdownMimirAdapter(MimirPort):
     # Metadata helpers
     # ------------------------------------------------------------------
 
-    def _page_meta_from_path(self, md_path: Path) -> MimirPageMeta:
-        """Build a MimirPageMeta from a wiki page path."""
-        content = md_path.read_text(encoding="utf-8")
+    def _list_pages_with_content(
+        self,
+        category: str | None = None,
+    ) -> list[tuple[MimirPageMeta, str]]:
+        """Return all wiki pages with their content, optionally filtered by category.
+
+        Each file is read exactly once; the content is returned alongside the
+        metadata so callers can avoid redundant I/O.
+        """
+        results: list[tuple[MimirPageMeta, str]] = []
+        search_root = self._wiki / category if category else self._wiki
+
+        if not search_root.exists():
+            return results
+
+        for md_path in search_root.rglob("*.md"):
+            if md_path.name in {"index.md", "log.md"}:
+                continue
+            content = md_path.read_text(encoding="utf-8")
+            meta = self._build_page_meta(md_path, content)
+            results.append((meta, content))
+
+        return results
+
+    def _build_page_meta(self, md_path: Path, content: str) -> MimirPageMeta:
+        """Build a MimirPageMeta from a path and its already-read content."""
         rel = md_path.relative_to(self._wiki)
         path_str = str(rel)
         parts = path_str.split("/")
@@ -455,6 +491,11 @@ class MarkdownMimirAdapter(MimirPort):
             updated_at=updated_at,
             source_ids=source_ids,
         )
+
+    def _page_meta_from_path(self, md_path: Path) -> MimirPageMeta:
+        """Build a MimirPageMeta from a wiki page path (reads the file)."""
+        content = md_path.read_text(encoding="utf-8")
+        return self._build_page_meta(md_path, content)
 
     @staticmethod
     def _extract_source_ids(content: str) -> list[str]:

--- a/src/ravn/adapters/tools/mimir_tools.py
+++ b/src/ravn/adapters/tools/mimir_tools.py
@@ -11,10 +11,10 @@ Tools:
 
 from __future__ import annotations
 
-import hashlib
 import logging
 from datetime import UTC, datetime
 
+from ravn.adapters.mimir.markdown import MarkdownMimirAdapter
 from ravn.domain.models import MimirSource, ToolResult
 from ravn.ports.mimir import MimirPort
 from ravn.ports.tool import ToolPort
@@ -25,12 +25,8 @@ _PERMISSION = "mimir:write"
 _PERMISSION_READ = "mimir:read"
 
 
-def _sha256(text: str) -> str:
-    return hashlib.sha256(text.encode()).hexdigest()
-
-
-def _source_id_from_title(title: str) -> str:
-    return "src_" + _sha256(title)[:16]
+def _source_id_from_content(title: str, content: str) -> str:
+    return "src_" + MarkdownMimirAdapter.compute_content_hash(f"{title}:{content}")[:16]
 
 
 # ---------------------------------------------------------------------------
@@ -98,12 +94,12 @@ class MimirIngestTool(ToolPort):
             return ToolResult(tool_call_id="", content="title is required", is_error=True)
 
         source = MimirSource(
-            source_id=_source_id_from_title(title),
+            source_id=_source_id_from_content(title, content),
             title=title,
             content=content,
             source_type=source_type,
             origin_url=origin_url,
-            content_hash=_sha256(content),
+            content_hash=MarkdownMimirAdapter.compute_content_hash(content),
             ingested_at=datetime.now(UTC),
         )
 
@@ -399,9 +395,12 @@ class MimirLintTool(ToolPort):
     async def execute(self, input: dict) -> ToolResult:
         report = await self._adapter.lint()
 
+        issue_count = (
+            len(report.orphans) + len(report.contradictions) + len(report.stale) + len(report.gaps)
+        )
         lines = [
             f"## Mímir lint — {report.pages_checked} pages checked\n",
-            f"Issues found: {report.issues_found}",
+            f"Issues found: {issue_count}",
             "",
         ]
 

--- a/src/ravn/adapters/tools/mimir_tools.py
+++ b/src/ravn/adapters/tools/mimir_tools.py
@@ -1,0 +1,452 @@
+"""Mímir agent tools — six tools for the persistent knowledge base (NIU-540).
+
+Tools:
+  mimir_ingest  — ingest a URL or raw text into the wiki
+  mimir_query   — search the wiki and synthesise an answer
+  mimir_read    — read a specific wiki page
+  mimir_write   — create or update a wiki page
+  mimir_search  — full-text search, returns list of matching pages
+  mimir_lint    — health-check: orphans, contradictions, staleness, gaps
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from datetime import UTC, datetime
+
+from ravn.domain.models import MimirSource, ToolResult
+from ravn.ports.mimir import MimirPort
+from ravn.ports.tool import ToolPort
+
+logger = logging.getLogger(__name__)
+
+_PERMISSION = "mimir:write"
+_PERMISSION_READ = "mimir:read"
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode()).hexdigest()
+
+
+def _source_id_from_title(title: str) -> str:
+    return "src_" + _sha256(title)[:16]
+
+
+# ---------------------------------------------------------------------------
+# mimir_ingest
+# ---------------------------------------------------------------------------
+
+
+class MimirIngestTool(ToolPort):
+    """Ingest a URL or raw text as a Mímir source document."""
+
+    def __init__(self, adapter: MimirPort) -> None:
+        self._adapter = adapter
+
+    @property
+    def name(self) -> str:
+        return "mimir_ingest"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Ingest a raw text or URL content into Mímir as an immutable source. "
+            "Records the source for staleness detection. "
+            "Use before writing wiki pages derived from this content."
+        )
+
+    @property
+    def input_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string",
+                    "description": "Raw text content to ingest.",
+                },
+                "title": {
+                    "type": "string",
+                    "description": "Human-readable title for the source.",
+                },
+                "source_type": {
+                    "type": "string",
+                    "enum": ["web", "document", "conversation", "tool_output", "research"],
+                    "description": "Category of source.",
+                },
+                "origin_url": {
+                    "type": "string",
+                    "description": "Original URL, if fetched from the web.",
+                },
+            },
+            "required": ["content", "title"],
+        }
+
+    @property
+    def required_permission(self) -> str:
+        return _PERMISSION
+
+    async def execute(self, input: dict) -> ToolResult:
+        content = input.get("content", "").strip()
+        title = input.get("title", "").strip()
+        source_type = input.get("source_type", "document")
+        origin_url = input.get("origin_url")
+
+        if not content:
+            return ToolResult(tool_call_id="", content="content is required", is_error=True)
+        if not title:
+            return ToolResult(tool_call_id="", content="title is required", is_error=True)
+
+        source = MimirSource(
+            source_id=_source_id_from_title(title),
+            title=title,
+            content=content,
+            source_type=source_type,
+            origin_url=origin_url,
+            content_hash=_sha256(content),
+            ingested_at=datetime.now(UTC),
+        )
+
+        page_paths = await self._adapter.ingest(source)
+        result = f"Ingested source '{title}' (id={source.source_id})"
+        if page_paths:
+            result += f"\nPages updated: {', '.join(page_paths)}"
+        return ToolResult(tool_call_id="", content=result)
+
+
+# ---------------------------------------------------------------------------
+# mimir_query
+# ---------------------------------------------------------------------------
+
+
+class MimirQueryTool(ToolPort):
+    """Search the Mímir wiki and return relevant pages for synthesis."""
+
+    def __init__(self, adapter: MimirPort) -> None:
+        self._adapter = adapter
+
+    @property
+    def name(self) -> str:
+        return "mimir_query"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Query the Mímir knowledge base. "
+            "Reads the wiki index to find relevant pages, then returns their content. "
+            "Call this before going to the web — check what you already know."
+        )
+
+    @property
+    def input_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "question": {
+                    "type": "string",
+                    "description": "The question or topic to search the wiki for.",
+                },
+            },
+            "required": ["question"],
+        }
+
+    @property
+    def required_permission(self) -> str:
+        return _PERMISSION_READ
+
+    async def execute(self, input: dict) -> ToolResult:
+        question = input.get("question", "").strip()
+        if not question:
+            return ToolResult(tool_call_id="", content="question is required", is_error=True)
+
+        result = await self._adapter.query(question)
+
+        if not result.sources:
+            return ToolResult(
+                tool_call_id="",
+                content=f"No wiki pages found for: {question}\n\nGo to the web to research.",
+            )
+
+        lines = [f"## Mímir: results for '{question}'\n"]
+        for page in result.sources:
+            lines.append(f"### {page.meta.title} ({page.meta.path})")
+            lines.append(page.content[:2000])
+            lines.append("")
+
+        return ToolResult(tool_call_id="", content="\n".join(lines))
+
+
+# ---------------------------------------------------------------------------
+# mimir_read
+# ---------------------------------------------------------------------------
+
+
+class MimirReadTool(ToolPort):
+    """Read a specific Mímir wiki page by path."""
+
+    def __init__(self, adapter: MimirPort) -> None:
+        self._adapter = adapter
+
+    @property
+    def name(self) -> str:
+        return "mimir_read"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Read the full content of a specific Mímir wiki page. "
+            "Use the path from mimir_search or mimir_query results."
+        )
+
+    @property
+    def input_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": (
+                        "Path to the wiki page relative to the wiki root, "
+                        "e.g. 'technical/ravn/tools.md'."
+                    ),
+                },
+            },
+            "required": ["path"],
+        }
+
+    @property
+    def required_permission(self) -> str:
+        return _PERMISSION_READ
+
+    async def execute(self, input: dict) -> ToolResult:
+        path = input.get("path", "").strip()
+        if not path:
+            return ToolResult(tool_call_id="", content="path is required", is_error=True)
+
+        try:
+            content = await self._adapter.read_page(path)
+        except FileNotFoundError:
+            return ToolResult(
+                tool_call_id="",
+                content=f"Page not found: {path}",
+                is_error=True,
+            )
+
+        return ToolResult(tool_call_id="", content=content)
+
+
+# ---------------------------------------------------------------------------
+# mimir_write
+# ---------------------------------------------------------------------------
+
+
+class MimirWriteTool(ToolPort):
+    """Create or update a Mímir wiki page."""
+
+    def __init__(self, adapter: MimirPort) -> None:
+        self._adapter = adapter
+
+    @property
+    def name(self) -> str:
+        return "mimir_write"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Create or update a Mímir wiki page. "
+            "Write synthesised, concise markdown — the wiki is for retrieval, not transcription. "
+            "Always start with a # Title heading."
+        )
+
+    @property
+    def input_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": (
+                        "Path relative to the wiki root, e.g. 'technical/ravn/tools.md'."
+                    ),
+                },
+                "content": {
+                    "type": "string",
+                    "description": "Full Markdown content for the page.",
+                },
+            },
+            "required": ["path", "content"],
+        }
+
+    @property
+    def required_permission(self) -> str:
+        return _PERMISSION
+
+    async def execute(self, input: dict) -> ToolResult:
+        path = input.get("path", "").strip()
+        content = input.get("content", "").strip()
+
+        if not path:
+            return ToolResult(tool_call_id="", content="path is required", is_error=True)
+        if not content:
+            return ToolResult(tool_call_id="", content="content is required", is_error=True)
+        if not path.endswith(".md"):
+            return ToolResult(
+                tool_call_id="",
+                content="path must end with .md",
+                is_error=True,
+            )
+
+        await self._adapter.upsert_page(path, content)
+        return ToolResult(tool_call_id="", content=f"Page written: {path}")
+
+
+# ---------------------------------------------------------------------------
+# mimir_search
+# ---------------------------------------------------------------------------
+
+
+class MimirSearchTool(ToolPort):
+    """Full-text search over Mímir wiki pages."""
+
+    def __init__(self, adapter: MimirPort) -> None:
+        self._adapter = adapter
+
+    @property
+    def name(self) -> str:
+        return "mimir_search"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Full-text search over Mímir wiki pages. "
+            "Returns a list of matching pages with titles, paths, and summaries. "
+            "Use mimir_read to fetch the full content of a specific page."
+        )
+
+    @property
+    def input_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Search terms to match against wiki page content.",
+                },
+            },
+            "required": ["query"],
+        }
+
+    @property
+    def required_permission(self) -> str:
+        return _PERMISSION_READ
+
+    async def execute(self, input: dict) -> ToolResult:
+        query = input.get("query", "").strip()
+        if not query:
+            return ToolResult(tool_call_id="", content="query is required", is_error=True)
+
+        pages = await self._adapter.search(query)
+
+        if not pages:
+            return ToolResult(
+                tool_call_id="",
+                content=f"No pages found for query: {query}",
+            )
+
+        lines = [f"## Mímir search results for '{query}'\n"]
+        for page in pages:
+            lines.append(f"- **{page.meta.title}** (`{page.meta.path}`)")
+            if page.meta.summary:
+                lines.append(f"  {page.meta.summary}")
+
+        return ToolResult(tool_call_id="", content="\n".join(lines))
+
+
+# ---------------------------------------------------------------------------
+# mimir_lint
+# ---------------------------------------------------------------------------
+
+
+class MimirLintTool(ToolPort):
+    """Run a Mímir wiki health-check: orphans, contradictions, staleness, gaps."""
+
+    def __init__(self, adapter: MimirPort) -> None:
+        self._adapter = adapter
+
+    @property
+    def name(self) -> str:
+        return "mimir_lint"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Health-check the Mímir wiki. "
+            "Finds orphan pages, flagged contradictions, stale sources, and concept gaps. "
+            "Run during idle time to keep the wiki healthy."
+        )
+
+    @property
+    def input_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {},
+        }
+
+    @property
+    def required_permission(self) -> str:
+        return _PERMISSION_READ
+
+    async def execute(self, input: dict) -> ToolResult:
+        report = await self._adapter.lint()
+
+        lines = [
+            f"## Mímir lint — {report.pages_checked} pages checked\n",
+            f"Issues found: {report.issues_found}",
+            "",
+        ]
+
+        if report.orphans:
+            lines.append(f"### Orphans ({len(report.orphans)})")
+            lines.append("Pages not linked from index.md:")
+            lines.extend(f"  - {p}" for p in report.orphans)
+            lines.append("")
+
+        if report.contradictions:
+            lines.append(f"### Contradictions ({len(report.contradictions)})")
+            lines.append("Pages with contradiction markers:")
+            lines.extend(f"  - {p}" for p in report.contradictions)
+            lines.append("")
+
+        if report.stale:
+            lines.append(f"### Stale ({len(report.stale)})")
+            lines.append("Pages whose source content hash has changed:")
+            lines.extend(f"  - {p}" for p in report.stale)
+            lines.append("")
+
+        if report.gaps:
+            lines.append(f"### Gaps ({len(report.gaps)})")
+            lines.append("Concepts mentioned frequently but lacking a page:")
+            lines.extend(f"  - {p}" for p in report.gaps)
+            lines.append("")
+
+        if not report.issues_found:
+            lines.append("All clear — no issues found.")
+
+        return ToolResult(tool_call_id="", content="\n".join(lines))
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+def build_mimir_tools(adapter: MimirPort) -> list[ToolPort]:
+    """Return all six Mímir tools wired to *adapter*."""
+    return [
+        MimirIngestTool(adapter),
+        MimirQueryTool(adapter),
+        MimirReadTool(adapter),
+        MimirWriteTool(adapter),
+        MimirSearchTool(adapter),
+        MimirLintTool(adapter),
+    ]

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -1068,6 +1068,68 @@ class LoggingConfig(BaseModel):
     format: str = Field(default="text")
 
 
+class MimirSearchConfig(BaseModel):
+    """Mímir search backend configuration."""
+
+    backend: Literal["fts", "vector"] = Field(
+        default="fts",
+        description="Search backend: 'fts' (full-text search) or 'vector' (embedding-based).",
+    )
+
+
+class MimirConfig(BaseModel):
+    """Mímir persistent compounding knowledge base configuration (NIU-540).
+
+    Mímir maintains a filesystem-backed wiki under ``path/wiki/`` and stores
+    raw immutable sources under ``path/raw/``.  The schema file ``MIMIR.md``
+    is seeded on first run if it does not exist.
+
+    Auto-distillation fires after sessions that meet the distillation criteria
+    (session duration, web calls made, documents written).  Idle lint fires
+    when the drive loop queue is empty and no human activity for
+    ``idle_lint_threshold_minutes``.
+    """
+
+    enabled: bool = Field(
+        default=True,
+        description="Enable the Mímir knowledge base.",
+    )
+    path: str = Field(
+        default="~/.ravn/mimir",
+        description="Root directory for the Mímir knowledge base.",
+    )
+    auto_distill: bool = Field(
+        default=True,
+        description=(
+            "Automatically distil session knowledge into the wiki after qualifying sessions."
+        ),
+    )
+    distill_min_session_minutes: int = Field(
+        default=5,
+        description="Minimum session duration (minutes) before auto-distillation is triggered.",
+    )
+    idle_lint_threshold_minutes: int = Field(
+        default=60,
+        description=(
+            "Minutes of drive-loop idle time + no human activity before the lint pass fires."
+        ),
+    )
+    continuation_threshold_minutes: int = Field(
+        default=30,
+        description=(
+            "Minutes since the last human message before an abandoned session is continued."
+        ),
+    )
+    categories: list[str] = Field(
+        default_factory=lambda: ["technical", "projects", "research", "household", "self"],
+        description="Top-level wiki categories.",
+    )
+    search: MimirSearchConfig = Field(
+        default_factory=MimirSearchConfig,
+        description="Search backend configuration.",
+    )
+
+
 class BuriConfig(BaseModel):
     """Búri knowledge memory substrate configuration (NIU-541).
 
@@ -1171,6 +1233,9 @@ class Settings(BaseSettings):
 
     # NIU-541: Búri knowledge memory substrate
     buri: BuriConfig = Field(default_factory=BuriConfig)
+
+    # NIU-540: Mímir persistent knowledge base
+    mimir: MimirConfig = Field(default_factory=MimirConfig)
 
     # Legacy — kept so existing CLI wiring (NIU-426) continues to work
     llm_adapter: LLMAdapterConfig = Field(default_factory=LLMAdapterConfig)

--- a/src/ravn/domain/models.py
+++ b/src/ravn/domain/models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 from uuid import UUID, uuid4
 
 if TYPE_CHECKING:
@@ -467,7 +467,7 @@ class MimirSource:
     source_id: str
     title: str
     content: str
-    source_type: str  # "web" | "document" | "conversation" | "tool_output" | "research"
+    source_type: Literal["web", "document", "conversation", "tool_output", "research"]
     ingested_at: datetime
     content_hash: str  # SHA-256 hex — used for staleness detection
     origin_url: str | None = None

--- a/src/ravn/domain/models.py
+++ b/src/ravn/domain/models.py
@@ -371,12 +371,12 @@ class AgentTask:
 class FactType(StrEnum):
     """Classification for knowledge facts stored in Búri memory."""
 
-    PREFERENCE = "preference"      # "I prefer early-return over nested if/else"
-    DECISION = "decision"          # "RabbitMQ chosen as Sleipnir primary transport"
-    GOAL = "goal"                  # "Retire in approximately 5 years"
-    DIRECTIVE = "directive"        # "All __init__ members prefixed with underscore"
+    PREFERENCE = "preference"  # "I prefer early-return over nested if/else"
+    DECISION = "decision"  # "RabbitMQ chosen as Sleipnir primary transport"
+    GOAL = "goal"  # "Retire in approximately 5 years"
+    DIRECTIVE = "directive"  # "All __init__ members prefixed with underscore"
     RELATIONSHIP = "relationship"  # "Astri is spouse. Tanngrisnir is a DGX Spark."
-    OBSERVATION = "observation"    # "Works late on Tuesdays typically"
+    OBSERVATION = "observation"  # "Works late on Tuesdays typically"
 
 
 @dataclass
@@ -393,7 +393,7 @@ class KnowledgeFact:
     content: str
     entities: list[str]
     confidence: float
-    source: str                       # "session:<id>" or "manual"
+    source: str  # "session:<id>" or "manual"
     valid_from: datetime
     embedding: list[float] | None = None
     valid_until: datetime | None = None
@@ -409,7 +409,7 @@ class KnowledgeRelationship:
 
     rel_id: str
     from_entity: str
-    relation: str          # e.g. "works_at", "prefers", "owns", "decided"
+    relation: str  # e.g. "works_at", "prefers", "owns", "decided"
     to_entity: str
     valid_from: datetime
     fact_id: str | None = None
@@ -448,3 +448,74 @@ class SessionState:
     active_entities: list[str]
     turn_count: int
     last_updated: datetime
+
+
+# ---------------------------------------------------------------------------
+# Mímir knowledge base models (NIU-540)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MimirSource:
+    """An immutable raw source ingested into the Mímir knowledge base.
+
+    Raw sources are never modified after ingestion.  ``content_hash`` (SHA-256)
+    is stored so staleness can be detected when the same URL is re-fetched and
+    its content has changed.
+    """
+
+    source_id: str
+    title: str
+    content: str
+    source_type: str  # "web" | "document" | "conversation" | "tool_output" | "research"
+    ingested_at: datetime
+    content_hash: str  # SHA-256 hex — used for staleness detection
+    origin_url: str | None = None
+
+
+@dataclass
+class MimirPageMeta:
+    """Lightweight metadata record for a Mímir wiki page."""
+
+    path: str  # e.g. "technical/volundr/auth.md"
+    title: str
+    summary: str  # one-line summary used in index.md
+    category: str  # top-level category: "technical", "projects", etc.
+    updated_at: datetime
+    source_ids: list[str]  # IDs of raw sources that contributed to this page
+
+
+@dataclass
+class MimirPage:
+    """A single Mímir wiki page with full content and metadata."""
+
+    meta: MimirPageMeta
+    content: str  # full Markdown content
+
+
+@dataclass
+class MimirQueryResult:
+    """Result returned by MimirPort.query()."""
+
+    question: str
+    answer: str  # LLM-synthesised answer from relevant pages
+    sources: list[MimirPage]  # pages consulted to produce the answer
+
+
+@dataclass
+class MimirLintReport:
+    """Health-check report produced by MimirPort.lint().
+
+    Each list contains paths (relative to wiki root) of affected pages.
+    ``issues_found`` is True when any list is non-empty.
+    """
+
+    orphans: list[str]  # pages not linked from index.md
+    contradictions: list[str]  # pages with flagged contradictions
+    stale: list[str]  # pages whose source content_hash has changed
+    gaps: list[str]  # concepts mentioned often but without a dedicated page
+    pages_checked: int
+
+    @property
+    def issues_found(self) -> bool:
+        return bool(self.orphans or self.contradictions or self.stale or self.gaps)

--- a/src/ravn/ports/mimir.py
+++ b/src/ravn/ports/mimir.py
@@ -1,0 +1,94 @@
+"""Mímir port — interface for the persistent compounding knowledge base."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from ravn.domain.models import (
+    MimirLintReport,
+    MimirPage,
+    MimirPageMeta,
+    MimirQueryResult,
+    MimirSource,
+)
+
+
+class MimirPort(ABC):
+    """Abstract interface for the Mímir wiki knowledge base.
+
+    Mímir maintains a persistent, LLM-written wiki that accumulates synthesised
+    knowledge between agent sessions.  Raw sources flow in via ``ingest()``;
+    the wiki layer is queried via ``query()`` and ``search()``; idle-time
+    maintenance is driven by ``lint()``.
+
+    The wiki lives at ``~/.ravn/mimir/wiki/`` and is backed by the filesystem.
+    Implementations may layer additional search or embedding indices on top.
+    """
+
+    @abstractmethod
+    async def ingest(self, source: MimirSource) -> list[str]:
+        """Ingest a raw source and update relevant wiki pages.
+
+        Returns a list of wiki page paths (relative to wiki root) that were
+        created or updated as a result of the ingest.
+        Appends an entry to ``wiki/log.md`` and updates ``wiki/index.md``.
+        """
+        ...
+
+    @abstractmethod
+    async def query(self, question: str) -> MimirQueryResult:
+        """Answer *question* from wiki knowledge.
+
+        Reads ``wiki/index.md`` to find relevant pages, reads those pages,
+        and synthesises an answer.  Does not call any external LLM — synthesis
+        is performed by the caller (the agent) using ``mimir_query`` tool output.
+        """
+        ...
+
+    @abstractmethod
+    async def lint(self) -> MimirLintReport:
+        """Health-check the wiki.
+
+        Scans for orphan pages (not linked in index.md), pages with
+        contradictions, pages whose raw source hash has changed (stale), and
+        concept gaps (frequently mentioned concepts without a dedicated page).
+        Appends a lint entry to ``wiki/log.md``.
+        """
+        ...
+
+    @abstractmethod
+    async def search(self, query: str) -> list[MimirPage]:
+        """Full-text search over wiki pages.
+
+        Returns matching pages ordered by relevance.  Does not call an LLM;
+        uses full-text search over the page content.
+        """
+        ...
+
+    @abstractmethod
+    async def upsert_page(self, path: str, content: str) -> None:
+        """Create or replace a wiki page at *path*.
+
+        *path* is relative to the wiki root (e.g. ``"technical/ravn/tools.md"``).
+        Updates ``wiki/index.md`` if the page is new.
+        """
+        ...
+
+    @abstractmethod
+    async def read_page(self, path: str) -> str:
+        """Return the raw Markdown content of the wiki page at *path*.
+
+        Raises ``FileNotFoundError`` if the page does not exist.
+        """
+        ...
+
+    @abstractmethod
+    async def list_pages(
+        self,
+        category: str | None = None,
+    ) -> list[MimirPageMeta]:
+        """List all wiki pages, optionally filtered to *category*.
+
+        Returns lightweight metadata records — does not read full page content.
+        """
+        ...

--- a/tests/ravn/unit/test_mimir.py
+++ b/tests/ravn/unit/test_mimir.py
@@ -438,23 +438,27 @@ def test_is_source_stale_returns_false_for_unknown_source(tmp_path: Path) -> Non
 
 
 @pytest.mark.asyncio
-async def test_lint_detects_stale_source(tmp_path: Path) -> None:
+async def test_lint_stale_always_empty(tmp_path: Path) -> None:
+    """Lint never populates the stale field.
+
+    Staleness requires re-fetching source URLs, which the lint pass does not do.
+    Use is_source_stale() before re-ingesting a source to detect changes.
+    """
     adapter = _make_adapter(tmp_path)
     src = _make_source(title="Stale Doc", content="original")
     await adapter.ingest(src)
 
-    # Write a page that references this source
     page_content = f"# Stale\n\nDerived from source.\n<!-- sources: {src.source_id} -->"
     await adapter.upsert_page("research/stale.md", page_content)
 
-    # Tamper with the stored hash to simulate changed source
+    # Even if the raw JSON hash is tampered with, lint always returns stale=[]
     raw_path = tmp_path / "mimir" / "raw" / f"{src.source_id}.json"
     data = json.loads(raw_path.read_text())
     data["content_hash"] = "badhash"
     raw_path.write_text(json.dumps(data))
 
     report = await adapter.lint()
-    assert "research/stale.md" in report.stale
+    assert report.stale == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ravn/unit/test_mimir.py
+++ b/tests/ravn/unit/test_mimir.py
@@ -1,0 +1,761 @@
+"""Unit tests for Mímir knowledge base (NIU-540).
+
+Tests cover:
+- MimirSource, MimirPage, MimirPageMeta, MimirQueryResult, MimirLintReport domain models
+- MarkdownMimirAdapter: ingest, upsert_page, read_page, search, list_pages, lint
+- Staleness detection (content_hash comparison)
+- Log and index maintenance
+- MIMIR.md seeding on first run
+- Six mimir_* tool wrappers: execute() paths, error handling
+- MimirConfig defaults
+- Auto-distillation trigger criteria (post-session drive loop)
+- Integration: session → ingest → wiki page created with log entry
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from ravn.adapters.mimir.markdown import (
+    MarkdownMimirAdapter,
+    _extract_summary,
+    _extract_title,
+)
+from ravn.adapters.tools.mimir_tools import (
+    MimirIngestTool,
+    MimirLintTool,
+    MimirQueryTool,
+    MimirReadTool,
+    MimirSearchTool,
+    MimirWriteTool,
+    build_mimir_tools,
+)
+from ravn.config import MimirConfig, Settings
+from ravn.domain.models import (
+    AgentTask,
+    MimirLintReport,
+    MimirPageMeta,
+    MimirQueryResult,
+    MimirSource,
+    OutputMode,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode()).hexdigest()
+
+
+def _make_source(
+    title: str = "Test Source",
+    content: str = "Hello world.",
+    source_type: str = "document",
+    origin_url: str | None = None,
+) -> MimirSource:
+    return MimirSource(
+        source_id=f"src_{_sha256(title)[:16]}",
+        title=title,
+        content=content,
+        source_type=source_type,
+        origin_url=origin_url,
+        content_hash=_sha256(content),
+        ingested_at=datetime.now(UTC),
+    )
+
+
+def _make_adapter(tmp_path: Path) -> MarkdownMimirAdapter:
+    return MarkdownMimirAdapter(root=tmp_path / "mimir")
+
+
+# ---------------------------------------------------------------------------
+# Domain model tests
+# ---------------------------------------------------------------------------
+
+
+def test_mimir_source_fields() -> None:
+    src = _make_source(content="some content")
+    assert src.source_id.startswith("src_")
+    assert src.content == "some content"
+    assert src.content_hash == _sha256("some content")
+    assert src.ingested_at.tzinfo is not None
+
+
+def test_mimir_page_meta_fields() -> None:
+    meta = MimirPageMeta(
+        path="technical/ravn/tools.md",
+        title="Ravn Tools",
+        summary="Overview of agent tools.",
+        category="technical",
+        updated_at=datetime.now(UTC),
+        source_ids=["src_abc"],
+    )
+    assert meta.path == "technical/ravn/tools.md"
+    assert meta.category == "technical"
+    assert meta.source_ids == ["src_abc"]
+
+
+def test_mimir_query_result_empty_answer() -> None:
+    result = MimirQueryResult(question="What is X?", answer="", sources=[])
+    assert result.question == "What is X?"
+    assert result.answer == ""
+    assert result.sources == []
+
+
+def test_mimir_lint_report_issues_found() -> None:
+    report = MimirLintReport(
+        orphans=["a.md"],
+        contradictions=[],
+        stale=[],
+        gaps=[],
+        pages_checked=5,
+    )
+    assert report.issues_found is True
+
+
+def test_mimir_lint_report_no_issues() -> None:
+    report = MimirLintReport(
+        orphans=[],
+        contradictions=[],
+        stale=[],
+        gaps=[],
+        pages_checked=3,
+    )
+    assert report.issues_found is False
+
+
+# ---------------------------------------------------------------------------
+# MarkdownMimirAdapter — layout bootstrap
+# ---------------------------------------------------------------------------
+
+
+def test_adapter_creates_directories(tmp_path: Path) -> None:
+    _make_adapter(tmp_path)
+    root = tmp_path / "mimir"
+    assert (root / "wiki").is_dir()
+    assert (root / "raw").is_dir()
+    assert (root / "MIMIR.md").is_file()
+    assert (root / "wiki" / "index.md").is_file()
+    assert (root / "wiki" / "log.md").is_file()
+
+
+def test_mimir_md_seeded_on_first_run(tmp_path: Path) -> None:
+    _make_adapter(tmp_path)
+    schema = (tmp_path / "mimir" / "MIMIR.md").read_text()
+    assert "self/ conventions" in schema
+    assert "third person" in schema
+
+
+def test_mimir_md_not_overwritten_on_second_run(tmp_path: Path) -> None:
+    _make_adapter(tmp_path)
+    custom = "custom content"
+    (tmp_path / "mimir" / "MIMIR.md").write_text(custom)
+    # Re-initialising should NOT overwrite existing file
+    MarkdownMimirAdapter(root=tmp_path / "mimir")
+    assert (tmp_path / "mimir" / "MIMIR.md").read_text() == custom
+
+
+# ---------------------------------------------------------------------------
+# MarkdownMimirAdapter — ingest
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ingest_stores_raw_source(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    src = _make_source(title="My Doc", content="Important content.")
+    await adapter.ingest(src)
+
+    raw_file = tmp_path / "mimir" / "raw" / f"{src.source_id}.json"
+    assert raw_file.exists()
+    data = json.loads(raw_file.read_text())
+    assert data["title"] == "My Doc"
+    assert data["content_hash"] == src.content_hash
+
+
+@pytest.mark.asyncio
+async def test_ingest_appends_to_log(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    src = _make_source(title="Log Test")
+    await adapter.ingest(src)
+
+    log = (tmp_path / "mimir" / "wiki" / "log.md").read_text()
+    assert "ingest" in log
+    assert "Log Test" in log
+
+
+@pytest.mark.asyncio
+async def test_ingest_returns_empty_list_by_default(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    result = await adapter.ingest(_make_source())
+    # Page creation is delegated to the agent; ingest() returns empty list
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# MarkdownMimirAdapter — upsert_page / read_page
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_page_creates_file(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    content = "# Ravn Tools\n\nOverview of agent tools."
+    await adapter.upsert_page("technical/ravn/tools.md", content)
+
+    page_file = tmp_path / "mimir" / "wiki" / "technical" / "ravn" / "tools.md"
+    assert page_file.exists()
+    assert page_file.read_text() == content
+
+
+@pytest.mark.asyncio
+async def test_upsert_page_adds_to_index(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    content = "# Auth Overview\n\nHow authentication works."
+    await adapter.upsert_page("technical/volundr/auth.md", content)
+
+    index = (tmp_path / "mimir" / "wiki" / "index.md").read_text()
+    assert "technical/volundr/auth.md" in index
+    assert "Auth Overview" in index
+
+
+@pytest.mark.asyncio
+async def test_upsert_page_updates_existing(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    await adapter.upsert_page("research/topic.md", "# Old Title\n\nOld summary.")
+    await adapter.upsert_page("research/topic.md", "# New Title\n\nNew summary.")
+
+    index = (tmp_path / "mimir" / "wiki" / "index.md").read_text()
+    assert "New Title" in index
+
+
+@pytest.mark.asyncio
+async def test_read_page_returns_content(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    content = "# Test\n\nBody text."
+    await adapter.upsert_page("projects/test.md", content)
+    result = await adapter.read_page("projects/test.md")
+    assert result == content
+
+
+@pytest.mark.asyncio
+async def test_read_page_raises_for_missing(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    with pytest.raises(FileNotFoundError):
+        await adapter.read_page("nonexistent/page.md")
+
+
+# ---------------------------------------------------------------------------
+# MarkdownMimirAdapter — list_pages
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_pages_returns_all(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    await adapter.upsert_page("technical/ravn/tools.md", "# Tools\n\nA.")
+    await adapter.upsert_page("projects/saga.md", "# Saga\n\nB.")
+    pages = await adapter.list_pages()
+    paths = [p.path for p in pages]
+    assert "technical/ravn/tools.md" in paths
+    assert "projects/saga.md" in paths
+
+
+@pytest.mark.asyncio
+async def test_list_pages_filtered_by_category(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    await adapter.upsert_page("technical/ravn/tools.md", "# Tools\n\nA.")
+    await adapter.upsert_page("research/k8s.md", "# K8s\n\nB.")
+    pages = await adapter.list_pages(category="technical")
+    paths = [p.path for p in pages]
+    assert "technical/ravn/tools.md" in paths
+    assert all("technical" in p for p in paths)
+
+
+@pytest.mark.asyncio
+async def test_list_pages_excludes_index_and_log(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    await adapter.upsert_page("technical/page.md", "# Page\n\nContent.")
+    pages = await adapter.list_pages()
+    paths = [p.path for p in pages]
+    assert "index.md" not in paths
+    assert "log.md" not in paths
+
+
+# ---------------------------------------------------------------------------
+# MarkdownMimirAdapter — search
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_finds_matching_pages(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    await adapter.upsert_page("technical/ravn/memory.md", "# Memory\n\nEpisodic storage.")
+    await adapter.upsert_page("technical/ravn/tools.md", "# Tools\n\nBash and file tools.")
+    results = await adapter.search("episodic storage")
+    titles = [p.meta.title for p in results]
+    assert "Memory" in titles
+
+
+@pytest.mark.asyncio
+async def test_search_returns_empty_for_no_match(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    await adapter.upsert_page("technical/ravn/tools.md", "# Tools\n\nBash tools.")
+    results = await adapter.search("kubernetes longhorn ceph")
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_search_excludes_index_and_log(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    # Write a keyword directly to index and log
+    index = tmp_path / "mimir" / "wiki" / "index.md"
+    index.write_text("# Catalog\n\nspecial_keyword here.", encoding="utf-8")
+    results = await adapter.search("special_keyword")
+    paths = [p.meta.path for p in results]
+    assert "index.md" not in paths
+    assert "log.md" not in paths
+
+
+# ---------------------------------------------------------------------------
+# MarkdownMimirAdapter — query
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_query_appends_to_log(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    await adapter.upsert_page("technical/page.md", "# Page\n\nSome content about Ravn.")
+    await adapter.query("what is Ravn?")
+    log = (tmp_path / "mimir" / "wiki" / "log.md").read_text()
+    assert "query" in log
+    assert "what is Ravn?" in log
+
+
+@pytest.mark.asyncio
+async def test_query_returns_result_struct(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    await adapter.upsert_page("technical/ravn/agent.md", "# Agent\n\nCore loop.")
+    result = await adapter.query("how does the agent work?")
+    assert isinstance(result, MimirQueryResult)
+    assert result.question == "how does the agent work?"
+    assert isinstance(result.sources, list)
+
+
+# ---------------------------------------------------------------------------
+# MarkdownMimirAdapter — lint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lint_finds_orphan_pages(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    # Write a page directly without going through upsert_page (so it's not in index)
+    (tmp_path / "mimir" / "wiki" / "research").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "mimir" / "wiki" / "research" / "orphan.md").write_text(
+        "# Orphan\n\nNot in index.", encoding="utf-8"
+    )
+    report = await adapter.lint()
+    assert "research/orphan.md" in report.orphans
+
+
+@pytest.mark.asyncio
+async def test_lint_finds_contradictions(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    content = "# Auth\n\n[CONTRADICTION] This conflicts with the session model."
+    await adapter.upsert_page("technical/auth.md", content)
+    report = await adapter.lint()
+    assert "technical/auth.md" in report.contradictions
+
+
+@pytest.mark.asyncio
+async def test_lint_pages_checked_count(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    await adapter.upsert_page("technical/a.md", "# A\n\nContent A.")
+    await adapter.upsert_page("technical/b.md", "# B\n\nContent B.")
+    report = await adapter.lint()
+    assert report.pages_checked == 2
+
+
+@pytest.mark.asyncio
+async def test_lint_appends_to_log(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    await adapter.lint()
+    log = (tmp_path / "mimir" / "wiki" / "log.md").read_text()
+    assert "lint" in log
+    assert "pages checked" in log
+
+
+@pytest.mark.asyncio
+async def test_lint_no_issues(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    await adapter.upsert_page("technical/page.md", "# Page\n\nClean content.")
+    report = await adapter.lint()
+    # page was indexed by upsert_page, so no orphans
+    assert "technical/page.md" not in report.orphans
+    assert report.pages_checked == 1
+
+
+# ---------------------------------------------------------------------------
+# Staleness detection
+# ---------------------------------------------------------------------------
+
+
+def test_compute_content_hash_is_sha256() -> None:
+    text = "hello world"
+    expected = hashlib.sha256(text.encode()).hexdigest()
+    assert MarkdownMimirAdapter.compute_content_hash(text) == expected
+
+
+@pytest.mark.asyncio
+async def test_is_source_stale_returns_false_when_unchanged(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    src = _make_source(content="original")
+    await adapter.ingest(src)
+    assert adapter.is_source_stale(src.source_id, "original") is False
+
+
+@pytest.mark.asyncio
+async def test_is_source_stale_returns_true_when_changed(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    src = _make_source(content="original")
+    await adapter.ingest(src)
+    assert adapter.is_source_stale(src.source_id, "completely different content") is True
+
+
+def test_is_source_stale_returns_false_for_unknown_source(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    # No source stored → not stale (nothing to compare)
+    assert adapter.is_source_stale("nonexistent_id", "content") is False
+
+
+@pytest.mark.asyncio
+async def test_lint_detects_stale_source(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    src = _make_source(title="Stale Doc", content="original")
+    await adapter.ingest(src)
+
+    # Write a page that references this source
+    page_content = f"# Stale\n\nDerived from source.\n<!-- sources: {src.source_id} -->"
+    await adapter.upsert_page("research/stale.md", page_content)
+
+    # Tamper with the stored hash to simulate changed source
+    raw_path = tmp_path / "mimir" / "raw" / f"{src.source_id}.json"
+    data = json.loads(raw_path.read_text())
+    data["content_hash"] = "badhash"
+    raw_path.write_text(json.dumps(data))
+
+    report = await adapter.lint()
+    assert "research/stale.md" in report.stale
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+def test_extract_title_from_h1() -> None:
+    assert _extract_title("# My Title\n\nContent.") == "My Title"
+
+
+def test_extract_title_fallback() -> None:
+    assert _extract_title("No heading here.") == "Untitled"
+
+
+def test_extract_summary_returns_first_body_line() -> None:
+    content = "# Title\n\nThis is the summary.\n\nMore text."
+    assert _extract_summary(content) == "This is the summary."
+
+
+def test_extract_summary_skips_headings() -> None:
+    content = "# Title\n## Subtitle\n\nActual summary."
+    assert _extract_summary(content) == "Actual summary."
+
+
+# ---------------------------------------------------------------------------
+# Tool wrapper tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mimir_ingest_tool_success(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    tool = MimirIngestTool(adapter)
+    result = await tool.execute(
+        {"content": "Some content.", "title": "My Source", "source_type": "document"}
+    )
+    assert not result.is_error
+    assert "Ingested source" in result.content
+
+
+@pytest.mark.asyncio
+async def test_mimir_ingest_tool_missing_content() -> None:
+    adapter = MagicMock(spec=["ingest"])
+    tool = MimirIngestTool(adapter)
+    result = await tool.execute({"title": "no content"})
+    assert result.is_error
+
+
+@pytest.mark.asyncio
+async def test_mimir_ingest_tool_missing_title() -> None:
+    adapter = MagicMock(spec=["ingest"])
+    tool = MimirIngestTool(adapter)
+    result = await tool.execute({"content": "some content"})
+    assert result.is_error
+
+
+@pytest.mark.asyncio
+async def test_mimir_query_tool_with_results(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    await adapter.upsert_page("technical/ravn/agent.md", "# Agent\n\nCore loop details.")
+    tool = MimirQueryTool(adapter)
+    result = await tool.execute({"question": "how does agent core loop work?"})
+    assert not result.is_error
+    assert "Agent" in result.content
+
+
+@pytest.mark.asyncio
+async def test_mimir_query_tool_no_results(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    tool = MimirQueryTool(adapter)
+    result = await tool.execute({"question": "something completely unknown"})
+    assert not result.is_error
+    assert "No wiki pages found" in result.content
+
+
+@pytest.mark.asyncio
+async def test_mimir_query_tool_missing_question() -> None:
+    adapter = MagicMock()
+    tool = MimirQueryTool(adapter)
+    result = await tool.execute({})
+    assert result.is_error
+
+
+@pytest.mark.asyncio
+async def test_mimir_read_tool_success(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    await adapter.upsert_page("projects/saga.md", "# Saga\n\nContent.")
+    tool = MimirReadTool(adapter)
+    result = await tool.execute({"path": "projects/saga.md"})
+    assert not result.is_error
+    assert "Saga" in result.content
+
+
+@pytest.mark.asyncio
+async def test_mimir_read_tool_not_found(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    tool = MimirReadTool(adapter)
+    result = await tool.execute({"path": "missing/page.md"})
+    assert result.is_error
+
+
+@pytest.mark.asyncio
+async def test_mimir_read_tool_missing_path() -> None:
+    adapter = MagicMock()
+    tool = MimirReadTool(adapter)
+    result = await tool.execute({})
+    assert result.is_error
+
+
+@pytest.mark.asyncio
+async def test_mimir_write_tool_success(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    tool = MimirWriteTool(adapter)
+    result = await tool.execute({"path": "research/new.md", "content": "# New Page\n\nBody."})
+    assert not result.is_error
+    assert "research/new.md" in result.content
+
+    # Verify the page was written
+    page_path = tmp_path / "mimir" / "wiki" / "research" / "new.md"
+    assert page_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_mimir_write_tool_non_md_extension() -> None:
+    adapter = MagicMock()
+    tool = MimirWriteTool(adapter)
+    result = await tool.execute({"path": "research/bad.txt", "content": "# Title"})
+    assert result.is_error
+    assert ".md" in result.content
+
+
+@pytest.mark.asyncio
+async def test_mimir_write_tool_missing_path() -> None:
+    adapter = MagicMock()
+    tool = MimirWriteTool(adapter)
+    result = await tool.execute({"content": "content"})
+    assert result.is_error
+
+
+@pytest.mark.asyncio
+async def test_mimir_write_tool_missing_content() -> None:
+    adapter = MagicMock()
+    tool = MimirWriteTool(adapter)
+    result = await tool.execute({"path": "test.md"})
+    assert result.is_error
+
+
+@pytest.mark.asyncio
+async def test_mimir_search_tool_success(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    await adapter.upsert_page("technical/ravn/memory.md", "# Memory\n\nEpisodic storage.")
+    tool = MimirSearchTool(adapter)
+    result = await tool.execute({"query": "episodic"})
+    assert not result.is_error
+    assert "Memory" in result.content
+
+
+@pytest.mark.asyncio
+async def test_mimir_search_tool_no_results(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    tool = MimirSearchTool(adapter)
+    result = await tool.execute({"query": "zzz_nonexistent_term_zzz"})
+    assert not result.is_error
+    assert "No pages found" in result.content
+
+
+@pytest.mark.asyncio
+async def test_mimir_search_tool_missing_query() -> None:
+    adapter = MagicMock()
+    tool = MimirSearchTool(adapter)
+    result = await tool.execute({})
+    assert result.is_error
+
+
+@pytest.mark.asyncio
+async def test_mimir_lint_tool_clean(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    await adapter.upsert_page("technical/page.md", "# Page\n\nClean content.")
+    tool = MimirLintTool(adapter)
+    result = await tool.execute({})
+    assert not result.is_error
+    assert "pages checked" in result.content
+
+
+@pytest.mark.asyncio
+async def test_mimir_lint_tool_reports_issues(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    # Add a page with contradiction marker
+    await adapter.upsert_page("technical/x.md", "# X\n\n[CONTRADICTION] Something wrong.")
+    tool = MimirLintTool(adapter)
+    result = await tool.execute({})
+    assert not result.is_error
+    assert "Contradictions" in result.content
+
+
+# ---------------------------------------------------------------------------
+# build_mimir_tools factory
+# ---------------------------------------------------------------------------
+
+
+def test_build_mimir_tools_returns_six(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    tools = build_mimir_tools(adapter)
+    assert len(tools) == 6
+    names = {t.name for t in tools}
+    assert names == {
+        "mimir_ingest",
+        "mimir_query",
+        "mimir_read",
+        "mimir_write",
+        "mimir_search",
+        "mimir_lint",
+    }
+
+
+# ---------------------------------------------------------------------------
+# MimirConfig defaults
+# ---------------------------------------------------------------------------
+
+
+def test_mimir_config_defaults() -> None:
+    cfg = MimirConfig()
+    assert cfg.enabled is True
+    assert cfg.path == "~/.ravn/mimir"
+    assert cfg.auto_distill is True
+    assert cfg.distill_min_session_minutes == 5
+    assert cfg.idle_lint_threshold_minutes == 60
+    assert cfg.continuation_threshold_minutes == 30
+    assert "technical" in cfg.categories
+    assert "self" in cfg.categories
+    assert cfg.search.backend == "fts"
+
+
+def test_mimir_config_in_settings() -> None:
+    settings = Settings()
+    assert hasattr(settings, "mimir")
+    assert isinstance(settings.mimir, MimirConfig)
+
+
+# ---------------------------------------------------------------------------
+# Integration: session → ingest → wiki page created with log entry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_integration_ingest_then_write_creates_page_with_log(tmp_path: Path) -> None:
+    """Simulate: ingest a source, agent writes a wiki page, log updated."""
+    adapter = _make_adapter(tmp_path)
+
+    # 1. Ingest a raw source
+    src = _make_source(
+        title="Kubernetes Pod Lifecycle",
+        content="Pods go through Pending, Running, Succeeded, Failed states.",
+        source_type="web",
+        origin_url="https://example.com/k8s-pods",
+    )
+    await adapter.ingest(src)
+
+    # 2. Agent writes a wiki page derived from the source
+    page_content = (
+        f"# Kubernetes Pod Lifecycle\n\n"
+        f"Pods transition through four states: Pending, Running, Succeeded, Failed.\n\n"
+        f"<!-- sources: {src.source_id} -->"
+    )
+    await adapter.upsert_page("technical/k8s/pod-lifecycle.md", page_content)
+
+    # 3. Verify page exists
+    written = await adapter.read_page("technical/k8s/pod-lifecycle.md")
+    assert "Pod Lifecycle" in written
+
+    # 4. Verify index updated
+    index = (tmp_path / "mimir" / "wiki" / "index.md").read_text()
+    assert "technical/k8s/pod-lifecycle.md" in index
+
+    # 5. Verify log has ingest entry
+    log = (tmp_path / "mimir" / "wiki" / "log.md").read_text()
+    assert "ingest" in log
+    assert "Kubernetes Pod Lifecycle" in log
+
+
+@pytest.mark.asyncio
+async def test_integration_distillation_trigger_creates_agent_task() -> None:
+    """Post-session distillation: verify AgentTask structure is correct."""
+    task = AgentTask(
+        task_id="task_abc_0001",
+        title="Mímir distillation — post-session",
+        initiative_context=(
+            "Review the conversation that just ended. Extract:\n"
+            "1. Any new factual knowledge worth preserving as Mímir wiki pages\n"
+            "2. Any findings that update or contradict existing pages\n"
+            "3. Decisions or patterns worth recording for future reference\n\n"
+            "Write or update wiki pages using mimir_write(). "
+            "Update index.md. Append to log.md. "
+            "Be concise — the wiki is for retrieval, not transcription."
+        ),
+        triggered_by="post_session:distillation",
+        output_mode=OutputMode.SILENT,
+        priority=15,
+    )
+    assert task.output_mode == OutputMode.SILENT
+    assert task.session_id == "daemon_task_abc_0001"
+    assert "mimir_write" in task.initiative_context
+    assert "log.md" in task.initiative_context


### PR DESCRIPTION
## Summary

Implements the Mímir wiki system — a persistent, filesystem-backed knowledge base that accumulates synthesised understanding between agent sessions. Closes NIU-540.

- **`MimirPort`** — abstract protocol with seven operations: `ingest`, `query`, `lint`, `search`, `upsert_page`, `read_page`, `list_pages`
- **`MarkdownMimirAdapter`** — filesystem adapter under `~/.ravn/mimir/` with wiki layout, index/log maintenance, full-text search, SHA-256 staleness detection, and lint pass (orphans, contradictions, stale sources, concept gaps)
- **Six agent tools** — `mimir_ingest`, `mimir_query`, `mimir_read`, `mimir_write`, `mimir_search`, `mimir_lint` (all `mimir_` prefixed)
- **`MimirConfig`** — added to `Settings` with `auto_distill`, `idle_lint_threshold_minutes`, `continuation_threshold_minutes`, `categories`, and `search.backend` config
- **Domain models** — `MimirSource`, `MimirPage`, `MimirPageMeta`, `MimirQueryResult`, `MimirLintReport` added to `domain/models.py`
- **MIMIR.md seeding** — schema file with `self/` conventions written on first run
- **Auto-distillation** — modelled as a post-session `AgentTask(output_mode=SILENT)` enqueued by the drive loop when criteria are met (session duration, web calls, document writes)
- **61 unit tests** — ingest, query, lint report structure, staleness detection, all six tool wrappers, config defaults, integration test (session → ingest → wiki page created with log entry)

## Test plan

- [x] All 61 new unit tests pass
- [x] Full ravn test suite: 88.39% coverage (above 85% threshold)
- [x] `ruff check` + `ruff format` — clean
- [x] Pre-existing failure (`test_tui_pages_returns_agents_page`, missing `textual` package) confirmed unrelated to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)