### PR TITLE
feat(adapters): flock discovery — realm-scoped peer detection, capability handshake, trust verification (NIU-538)

### DIFF
--- a/src/ravn/adapters/discovery/__init__.py
+++ b/src/ravn/adapters/discovery/__init__.py
@@ -1,0 +1,1 @@
+"""Discovery adapters — flock peer detection (NIU-538)."""

--- a/src/ravn/adapters/discovery/_identity.py
+++ b/src/ravn/adapters/discovery/_identity.py
@@ -26,6 +26,7 @@ def load_or_create_peer_id() -> str:
         return path.read_text().strip()
     peer_id = str(uuid.uuid4())
     path.write_text(peer_id)
+    path.chmod(0o600)
     return peer_id
 
 
@@ -38,6 +39,7 @@ def load_or_create_realm_key() -> bytes:
         return path.read_bytes()
     key = os.urandom(32)
     path.write_bytes(key)
+    path.chmod(0o600)
     return key
 
 

--- a/src/ravn/adapters/discovery/_identity.py
+++ b/src/ravn/adapters/discovery/_identity.py
@@ -1,0 +1,54 @@
+"""Peer identity persistence helpers (NIU-538).
+
+``peer_id`` is a stable UUID generated on first run, persisted to
+``~/.ravn/peer_id``.  ``realm.key`` is a 32-byte random secret
+used for HMAC handshakes — only the SHA-256 hash is ever transmitted.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import uuid
+from pathlib import Path
+
+
+def _ravn_dir() -> Path:
+    return Path.home() / ".ravn"
+
+
+def load_or_create_peer_id() -> str:
+    """Return the stable peer UUID, creating it on first run."""
+    ravn_dir = _ravn_dir()
+    ravn_dir.mkdir(parents=True, exist_ok=True)
+    path = ravn_dir / "peer_id"
+    if path.exists():
+        return path.read_text().strip()
+    peer_id = str(uuid.uuid4())
+    path.write_text(peer_id)
+    return peer_id
+
+
+def load_or_create_realm_key() -> bytes:
+    """Return the realm key bytes, creating a 32-byte random key on first run."""
+    ravn_dir = _ravn_dir()
+    ravn_dir.mkdir(parents=True, exist_ok=True)
+    path = ravn_dir / "realm.key"
+    if path.exists():
+        return path.read_bytes()
+    key = os.urandom(32)
+    path.write_bytes(key)
+    return key
+
+
+def realm_id_from_key(realm_key: bytes) -> str:
+    """Derive a stable realm_id string from the raw key bytes (hex of the key)."""
+    return realm_key.hex()
+
+
+def realm_id_hash(realm_key: bytes) -> str:
+    """Return SHA-256(realm_key)[:16] — the value transmitted in announcements.
+
+    This lets peers confirm they share a realm without revealing the secret.
+    """
+    return hashlib.sha256(realm_key).hexdigest()[:16]

--- a/src/ravn/adapters/discovery/composite.py
+++ b/src/ravn/adapters/discovery/composite.py
@@ -1,0 +1,154 @@
+"""CompositeDiscoveryAdapter — merges multiple discovery backends (NIU-538).
+
+Runs all configured backends simultaneously.  The merged peer table is the
+union of all verified peers from all backends.  Callbacks fire once per
+unique peer_id (join fires on first-seen, leave when evicted from all backends).
+
+Typical deployments:
+- Pi + cluster: mDNS (for LAN Pi peers) + Sleipnir (for infra peers)
+- Infra cold-start: K8s (initial pod listing) + Sleipnir (live pub/sub)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+
+from ravn.domain.models import RavnCandidate, RavnIdentity, RavnPeer
+
+logger = logging.getLogger(__name__)
+
+PeerCallback = Callable[[RavnPeer], None]
+
+
+class CompositeDiscoveryAdapter:
+    """Merges peer tables from multiple discovery backends.
+
+    Parameters
+    ----------
+    backends:
+        List of backend adapters.  Any object satisfying the DiscoveryPort
+        interface is accepted.
+    """
+
+    def __init__(self, backends: list[object]) -> None:
+        self._backends = backends
+        self._on_join: list[PeerCallback] = []
+        self._on_leave: list[PeerCallback] = []
+        # Count of backends that have seen a given peer (for leave eviction)
+        self._peer_backend_count: dict[str, int] = {}
+
+    # ------------------------------------------------------------------
+    # DiscoveryPort interface
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Start all backends in parallel and wire join/leave callbacks."""
+        for backend in self._backends:
+            await backend.watch(  # type: ignore[attr-defined]
+                on_join=self._make_join_callback(backend),
+                on_leave=self._make_leave_callback(backend),
+            )
+        await asyncio.gather(
+            *(backend.start() for backend in self._backends),  # type: ignore[attr-defined]
+            return_exceptions=True,
+        )
+        logger.info("composite_discovery: started %d backends", len(self._backends))
+
+    async def stop(self) -> None:
+        """Stop all backends in parallel."""
+        await asyncio.gather(
+            *(backend.stop() for backend in self._backends),  # type: ignore[attr-defined]
+            return_exceptions=True,
+        )
+        logger.info("composite_discovery: stopped")
+
+    async def announce(self) -> None:
+        """Re-announce via all backends."""
+        await asyncio.gather(
+            *(backend.announce() for backend in self._backends),  # type: ignore[attr-defined]
+            return_exceptions=True,
+        )
+
+    async def scan(self) -> list[RavnCandidate]:
+        """Return all candidates from all backends (deduplicated by peer_id)."""
+        results = await asyncio.gather(
+            *(backend.scan() for backend in self._backends),  # type: ignore[attr-defined]
+            return_exceptions=True,
+        )
+        seen: dict[str, RavnCandidate] = {}
+        for result in results:
+            if isinstance(result, list):
+                for candidate in result:
+                    seen.setdefault(candidate.peer_id, candidate)
+        return list(seen.values())
+
+    async def watch(self, on_join: PeerCallback, on_leave: PeerCallback) -> None:
+        """Register callbacks on the composite adapter (non-blocking)."""
+        self._on_join.append(on_join)
+        self._on_leave.append(on_leave)
+
+    async def handshake(self, candidate: RavnCandidate) -> RavnPeer | None:
+        """Delegate handshake to the first backend that succeeds."""
+        for backend in self._backends:
+            try:
+                peer = await backend.handshake(candidate)  # type: ignore[attr-defined]
+                if peer is not None:
+                    return peer
+            except Exception:
+                pass
+        return None
+
+    def peers(self) -> dict[str, RavnPeer]:
+        """Return the merged verified peer table from all backends."""
+        merged: dict[str, RavnPeer] = {}
+        for backend in self._backends:
+            try:
+                merged.update(backend.peers())  # type: ignore[attr-defined]
+            except Exception:
+                pass
+        return merged
+
+    async def own_identity(self) -> RavnIdentity:
+        """Return this Ravn's identity from the first backend."""
+        for backend in self._backends:
+            try:
+                return await backend.own_identity()  # type: ignore[attr-defined]
+            except Exception:
+                pass
+        raise RuntimeError("composite_discovery: no backend could return own_identity")
+
+    # ------------------------------------------------------------------
+    # Internal — callback wiring
+    # ------------------------------------------------------------------
+
+    def _make_join_callback(self, backend: object) -> PeerCallback:
+        def on_join(peer: RavnPeer) -> None:
+            count = self._peer_backend_count.get(peer.peer_id, 0)
+            self._peer_backend_count[peer.peer_id] = count + 1
+            if count == 0:
+                # First backend to see this peer — propagate
+                for cb in self._on_join:
+                    try:
+                        cb(peer)
+                    except Exception:
+                        pass
+
+        return on_join
+
+    def _make_leave_callback(self, backend: object) -> PeerCallback:
+        def on_leave(peer: RavnPeer) -> None:
+            count = self._peer_backend_count.get(peer.peer_id, 0)
+            if count <= 1:
+                self._peer_backend_count.pop(peer.peer_id, None)
+                # Last backend dropped this peer — propagate leave
+                for cb in self._on_leave:
+                    try:
+                        cb(peer)
+                    except Exception:
+                        pass
+            else:
+                self._peer_backend_count[peer.peer_id] = count - 1
+
+        return on_leave

--- a/src/ravn/adapters/discovery/composite.py
+++ b/src/ravn/adapters/discovery/composite.py
@@ -13,13 +13,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Callable
 
 from ravn.domain.models import RavnCandidate, RavnIdentity, RavnPeer
+from ravn.ports.discovery import PeerCallback
 
 logger = logging.getLogger(__name__)
-
-PeerCallback = Callable[[RavnPeer], None]
 
 
 class CompositeDiscoveryAdapter:

--- a/src/ravn/adapters/discovery/k8s.py
+++ b/src/ravn/adapters/discovery/k8s.py
@@ -1,0 +1,227 @@
+"""K8sDiscoveryAdapter — infra-mode cold-start flock discovery via Kubernetes labels (NIU-538).
+
+Lists pods with ``ravn.niuu.world/realm=<realm_id>`` label selector and reads
+peer identity from pod annotations.  Trust is delegated to K8s RBAC + SPIFFE
+for subsequent Sleipnir communication — no handshake socket is opened.
+
+**Pod annotations**::
+
+    ravn.niuu.world/peer-id: "<uuid>"
+    ravn.niuu.world/persona: "coding-agent"
+    ravn.niuu.world/capabilities: "bash,file,git,terminal,web"
+    ravn.niuu.world/permission-mode: "workspace-write"
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from ravn.domain.models import RavnCandidate, RavnIdentity, RavnPeer
+
+if TYPE_CHECKING:
+    from ravn.config import DiscoveryConfig
+
+try:
+    from kubernetes import client as k8s_client  # type: ignore[import-untyped]
+    from kubernetes import config as k8s_config  # type: ignore[import-untyped]
+except ImportError:  # pragma: no cover
+    k8s_client = None  # type: ignore[assignment]
+    k8s_config = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+PeerCallback = Callable[[RavnPeer], None]
+
+_ANN_PEER_ID = "ravn.niuu.world/peer-id"
+_ANN_PERSONA = "ravn.niuu.world/persona"
+_ANN_CAPABILITIES = "ravn.niuu.world/capabilities"
+_ANN_PERMISSION_MODE = "ravn.niuu.world/permission-mode"
+_LABEL_REALM = "ravn.niuu.world/realm"
+
+
+class K8sDiscoveryAdapter:
+    """Kubernetes pod label-based flock discovery for infra cold-start.
+
+    Parameters
+    ----------
+    config:
+        Root ``DiscoveryConfig`` from settings.
+    own_identity:
+        Pre-built ``RavnIdentity`` for this instance.
+    """
+
+    def __init__(
+        self,
+        config: DiscoveryConfig,
+        own_identity: RavnIdentity,
+    ) -> None:
+        self._config = config
+        self._identity = own_identity
+        self._peers: dict[str, RavnPeer] = {}
+        self._on_join: list[PeerCallback] = []
+        self._on_leave: list[PeerCallback] = []
+        self._poll_task: asyncio.Task | None = None
+
+    # ------------------------------------------------------------------
+    # DiscoveryPort interface
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Load K8s in-cluster config and run initial scan."""
+        if k8s_client is None:  # pragma: no cover
+            logger.warning("k8s_discovery: kubernetes not installed — discovery disabled")
+            return
+
+        try:
+            k8s_config.load_incluster_config()
+        except Exception:
+            try:
+                k8s_config.load_kube_config()
+            except Exception as exc:
+                logger.debug("k8s_discovery: could not load kubeconfig: %s", exc)
+
+        await self._do_scan()
+        self._poll_task = asyncio.create_task(self._poll_loop(), name="k8s_discovery_poll")
+        logger.info("k8s_discovery: started peer=%s", self._identity.peer_id)
+
+    async def stop(self) -> None:
+        """Cancel background poll task."""
+        if self._poll_task is not None:
+            self._poll_task.cancel()
+            try:
+                await self._poll_task
+            except asyncio.CancelledError:
+                pass
+            self._poll_task = None
+
+    async def announce(self) -> None:
+        """No-op — K8s identity is declared via pod labels/annotations."""
+
+    async def scan(self) -> list[RavnCandidate]:
+        """Query K8s for Ravn pods and return as candidates (no handshake)."""
+        return await asyncio.get_running_loop().run_in_executor(None, self._list_candidates)
+
+    async def watch(self, on_join: PeerCallback, on_leave: PeerCallback) -> None:
+        """Register join/leave callbacks (non-blocking)."""
+        self._on_join.append(on_join)
+        self._on_leave.append(on_leave)
+
+    async def handshake(self, candidate: RavnCandidate) -> RavnPeer | None:
+        """No handshake — trust is via K8s RBAC + SPIFFE."""
+        return None
+
+    def peers(self) -> dict[str, RavnPeer]:
+        """Return the cached verified peer table (synchronous)."""
+        return dict(self._peers)
+
+    async def own_identity(self) -> RavnIdentity:
+        """Return this Ravn's identity."""
+        return self._identity
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    async def _do_scan(self) -> None:
+        loop = asyncio.get_running_loop()
+        candidates = await loop.run_in_executor(None, self._list_candidates)
+        now = datetime.now(UTC)
+        seen_ids: set[str] = set()
+
+        for candidate in candidates:
+            peer_id = candidate.peer_id
+            seen_ids.add(peer_id)
+            if peer_id in self._peers:
+                self._peers[peer_id].last_seen = now
+                continue
+
+            peer = RavnPeer(
+                peer_id=peer_id,
+                realm_id=candidate.metadata.get("realm_id", ""),
+                persona=candidate.metadata.get("persona", ""),
+                capabilities=candidate.metadata.get("capabilities", "").split(",")
+                if candidate.metadata.get("capabilities")
+                else [],
+                permission_mode=candidate.metadata.get("permission_mode", ""),
+                version="",
+                rep_address=candidate.rep_address,
+                pub_address=candidate.pub_address,
+                trust_level="verified",
+                first_seen=now,
+                last_seen=now,
+                last_heartbeat=now,
+            )
+            self._peers[peer_id] = peer
+            for cb in self._on_join:
+                try:
+                    cb(peer)
+                except Exception:
+                    pass
+
+        # Evict peers no longer visible
+        to_remove = [pid for pid in self._peers if pid not in seen_ids]
+        for pid in to_remove:
+            peer = self._peers.pop(pid, None)
+            if peer is not None:
+                for cb in self._on_leave:
+                    try:
+                        cb(peer)
+                    except Exception:
+                        pass
+
+    def _list_candidates(self) -> list[RavnCandidate]:
+        if k8s_client is None:
+            return []
+        try:
+            v1 = k8s_client.CoreV1Api()
+            label_selector = (
+                f"{_LABEL_REALM}={self._identity.realm_id}," + self._config.k8s.label_selector
+            )
+            namespace = self._config.k8s.namespace or None
+            if namespace:
+                pods = v1.list_namespaced_pod(
+                    namespace=namespace,
+                    label_selector=label_selector,
+                )
+            else:
+                pods = v1.list_pod_for_all_namespaces(label_selector=label_selector)
+
+            candidates = []
+            for pod in pods.items:
+                annotations = pod.metadata.annotations or {}
+                peer_id = annotations.get(_ANN_PEER_ID, "")
+                if not peer_id or peer_id == self._identity.peer_id:
+                    continue
+                candidate = RavnCandidate(
+                    peer_id=peer_id,
+                    realm_id_hash="",  # K8s doesn't transmit the hash
+                    host=pod.status.pod_ip or "",
+                    rep_address=None,
+                    pub_address=None,
+                    handshake_port=None,
+                    metadata={
+                        "persona": annotations.get(_ANN_PERSONA, ""),
+                        "capabilities": annotations.get(_ANN_CAPABILITIES, ""),
+                        "permission_mode": annotations.get(_ANN_PERMISSION_MODE, ""),
+                        "realm_id": self._identity.realm_id,
+                    },
+                )
+                candidates.append(candidate)
+            return candidates
+        except Exception as exc:
+            logger.debug("k8s_discovery: list_candidates failed: %s", exc)
+            return []
+
+    async def _poll_loop(self) -> None:
+        while True:
+            try:
+                await asyncio.sleep(self._config.heartbeat_interval_s)
+                await self._do_scan()
+            except asyncio.CancelledError:
+                return
+            except Exception as exc:
+                logger.debug("k8s_discovery: poll_loop error: %s", exc)

--- a/src/ravn/adapters/discovery/k8s.py
+++ b/src/ravn/adapters/discovery/k8s.py
@@ -16,11 +16,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from ravn.domain.models import RavnCandidate, RavnIdentity, RavnPeer
+from ravn.ports.discovery import PeerCallback
 
 if TYPE_CHECKING:
     from ravn.config import DiscoveryConfig
@@ -33,8 +33,6 @@ except ImportError:  # pragma: no cover
     k8s_config = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
-
-PeerCallback = Callable[[RavnPeer], None]
 
 _ANN_PEER_ID = "ravn.niuu.world/peer-id"
 _ANN_PERSONA = "ravn.niuu.world/persona"

--- a/src/ravn/adapters/discovery/mdns.py
+++ b/src/ravn/adapters/discovery/mdns.py
@@ -1,0 +1,616 @@
+"""MdnsDiscoveryAdapter — Pi-mode flock discovery via mDNS + HMAC handshake (NIU-538).
+
+Uses ``zeroconf`` for mDNS service registration and browsing.
+
+**Announcement**
+
+Registers ``{peer_id}._ravn._tcp.local`` with TXT records:
+- ``realm_id``       — SHA-256(realm_key)[:16]  (hash, not raw secret)
+- ``peer_id``        — stable UUID
+- ``persona``        — active persona name
+- ``ver``            — ravn version
+- ``rep_addr``       — nng REP address for mesh.send()
+- ``pub_addr``       — nng PUB address for mesh.subscribe()
+- ``handshake_port`` — temporary nng PAIR port for HMAC exchange
+
+**Handshake (HMAC-SHA256 challenge-response)**
+
+::
+
+    A → B:  HELLO peer_id_A nonce_A
+    B → A:  CHALLENGE HMAC(realm_key, "ravn-handshake|nonce_A|peer_id_A|peer_id_B") nonce_B
+    A → B:  VERIFY HMAC(realm_key, "ravn-handshake|nonce_B|peer_id_B|peer_id_A")
+            + full RavnIdentity JSON
+    B → A:  ACCEPT + full RavnIdentity JSON   OR   REJECT
+
+**Liveness**
+
+Heartbeat fires every ``heartbeat_interval_s`` seconds (default 30s).
+Peers are evicted when ``last_heartbeat`` is older than ``peer_ttl_s`` (default 90s).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import hashlib
+import hmac
+import json
+import logging
+import secrets
+import socket
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from ravn.adapters.discovery._identity import (
+    load_or_create_realm_key,
+    realm_id_hash,
+)
+from ravn.domain.models import RavnCandidate, RavnIdentity, RavnPeer
+
+if TYPE_CHECKING:
+    from ravn.config import DiscoveryConfig
+
+try:
+    from zeroconf import ServiceBrowser, ServiceInfo, Zeroconf
+    from zeroconf.asyncio import AsyncServiceBrowser, AsyncZeroconf
+except ImportError:  # pragma: no cover
+    Zeroconf = None  # type: ignore[assignment,misc]
+    AsyncZeroconf = None  # type: ignore[assignment]
+    ServiceInfo = None  # type: ignore[assignment,misc]
+    ServiceBrowser = None  # type: ignore[assignment,misc]
+    AsyncServiceBrowser = None  # type: ignore[assignment,misc]
+
+try:
+    import pynng  # type: ignore[import-untyped]
+except ImportError:  # pragma: no cover
+    pynng = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+PeerCallback = Callable[[RavnPeer], None]
+
+_HANDSHAKE_PREFIX = "ravn-handshake"
+
+
+def _hmac_hex(key: bytes, *parts: str) -> str:
+    """Compute HMAC-SHA256 of ``"|".join(parts)`` with *key*, return hex digest."""
+    msg = "|".join(parts).encode()
+    return hmac.new(key, msg, hashlib.sha256).hexdigest()
+
+
+def _local_ip() -> str:
+    """Best-effort LAN IP address detection (falls back to 127.0.0.1)."""
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.connect(("8.8.8.8", 80))
+        ip = sock.getsockname()[0]
+        sock.close()
+        return ip
+    except Exception:
+        return "127.0.0.1"
+
+
+class MdnsDiscoveryAdapter:
+    """mDNS-based flock discovery for Pi mode (zeroconf + nng HMAC handshake).
+
+    Parameters
+    ----------
+    config:
+        Root ``DiscoveryConfig`` from settings.
+    own_identity:
+        Pre-built ``RavnIdentity`` for this instance (peer_id, realm_id,
+        persona, capabilities, etc.).  ``rep_address`` and ``pub_address``
+        should be populated by the mesh adapter before ``start()`` is called.
+    handshake_port:
+        Port for the nng PAIR socket used during handshake negotiation.
+        Defaults to 7482.
+    """
+
+    def __init__(
+        self,
+        config: DiscoveryConfig,
+        own_identity: RavnIdentity,
+        handshake_port: int = 7482,
+    ) -> None:
+        self._config = config
+        self._identity = own_identity
+        self._handshake_port = handshake_port
+
+        # Derive realm key — used only for HMAC, never transmitted raw.
+        self._realm_key: bytes = load_or_create_realm_key()
+
+        self._peers: dict[str, RavnPeer] = {}
+        self._candidates: dict[str, RavnCandidate] = {}
+        self._on_join: list[PeerCallback] = []
+        self._on_leave: list[PeerCallback] = []
+
+        self._zc: AsyncZeroconf | None = None
+        self._browser: AsyncServiceBrowser | None = None
+        self._service_info: ServiceInfo | None = None
+
+        self._heartbeat_task: asyncio.Task | None = None
+        self._handshake_listener_task: asyncio.Task | None = None
+        self._pending_handshakes: set[str] = set()
+
+    # ------------------------------------------------------------------
+    # DiscoveryPort interface
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Register mDNS service and start background loops."""
+        if AsyncZeroconf is None:  # pragma: no cover
+            logger.warning("mdns_discovery: zeroconf not installed — discovery disabled")
+            return
+
+        self._zc = AsyncZeroconf()
+        await self._register_service()
+        await self._start_browser()
+
+        self._heartbeat_task = asyncio.create_task(
+            self._heartbeat_loop(), name="mdns_discovery_heartbeat"
+        )
+        self._handshake_listener_task = asyncio.create_task(
+            self._handshake_listener(), name="mdns_discovery_hs_listener"
+        )
+        logger.info(
+            "mdns_discovery: started peer=%s handshake_port=%d",
+            self._identity.peer_id,
+            self._handshake_port,
+        )
+
+    async def stop(self) -> None:
+        """Unregister mDNS service and cancel background tasks."""
+        for task in (self._heartbeat_task, self._handshake_listener_task):
+            if task is not None:
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+
+        self._heartbeat_task = None
+        self._handshake_listener_task = None
+
+        if self._zc is not None:
+            if self._service_info is not None:
+                try:
+                    await self._zc.async_unregister_service(self._service_info)
+                except Exception:
+                    pass
+            try:
+                await self._zc.async_close()
+            except Exception:
+                pass
+            self._zc = None
+
+        logger.info("mdns_discovery: stopped peer=%s", self._identity.peer_id)
+
+    async def announce(self) -> None:
+        """Re-register the mDNS service (e.g. after address change)."""
+        if self._zc is None:
+            return
+        await self._register_service()
+
+    async def scan(self) -> list[RavnCandidate]:
+        """Return the current set of discovered candidates (snapshot)."""
+        return list(self._candidates.values())
+
+    async def watch(self, on_join: PeerCallback, on_leave: PeerCallback) -> None:
+        """Register join/leave callbacks (non-blocking)."""
+        self._on_join.append(on_join)
+        self._on_leave.append(on_leave)
+
+    async def handshake(self, candidate: RavnCandidate) -> RavnPeer | None:
+        """Run HMAC handshake with *candidate* as the initiating side (A).
+
+        Returns a verified ``RavnPeer`` on success, ``None`` on realm mismatch.
+        """
+        if pynng is None:  # pragma: no cover
+            logger.debug("mdns_discovery: pynng not installed — handshake skipped")
+            return None
+
+        if candidate.handshake_port is None:
+            logger.debug("mdns_discovery: candidate %s has no handshake_port", candidate.peer_id)
+            return None
+
+        addr = f"tcp://{candidate.host}:{candidate.handshake_port}"
+        timeout_ms = int(self._config.mdns.handshake_timeout_s * 1000)
+
+        try:
+            return await asyncio.get_running_loop().run_in_executor(
+                None,
+                self._run_handshake_initiator,
+                candidate,
+                addr,
+                timeout_ms,
+            )
+        except Exception as exc:
+            logger.debug("mdns_discovery: handshake with %s failed: %s", candidate.peer_id, exc)
+            return None
+
+    def peers(self) -> dict[str, RavnPeer]:
+        """Return the cached verified peer table (synchronous)."""
+        return dict(self._peers)
+
+    async def own_identity(self) -> RavnIdentity:
+        """Return this Ravn's identity."""
+        return self._identity
+
+    # ------------------------------------------------------------------
+    # Internal — mDNS registration
+    # ------------------------------------------------------------------
+
+    def _build_txt_records(self) -> dict[str, str]:
+        ip = _local_ip()
+        records: dict[str, str] = {
+            "realm_id": realm_id_hash(self._realm_key),
+            "peer_id": self._identity.peer_id,
+            "persona": self._identity.persona,
+            "ver": self._identity.version,
+            "handshake_port": str(self._handshake_port),
+        }
+        if self._identity.rep_address:
+            records["rep_addr"] = self._identity.rep_address
+        if self._identity.pub_address:
+            records["pub_addr"] = self._identity.pub_address
+        if not self._identity.rep_address and not self._identity.pub_address:
+            records["host"] = ip
+        return records
+
+    async def _register_service(self) -> None:
+        if self._zc is None:
+            return
+        ip = _local_ip()
+        txt = self._build_txt_records()
+        service_name = f"{self._identity.peer_id}.{self._config.mdns.service_type}"
+        info = ServiceInfo(  # type: ignore[call-arg]
+            type_=self._config.mdns.service_type,
+            name=service_name,
+            addresses=[socket.inet_aton(ip)],
+            port=self._handshake_port,
+            properties={k: v.encode() for k, v in txt.items()},
+        )
+        try:
+            await self._zc.async_register_service(info, ttl=60)
+            self._service_info = info
+            logger.debug(
+                "mdns_discovery: registered %s at %s:%d", service_name, ip, self._handshake_port
+            )
+        except Exception as exc:
+            logger.debug("mdns_discovery: service registration failed: %s", exc)
+
+    async def _start_browser(self) -> None:
+        if self._zc is None:
+            return
+
+        handlers = [self._on_service_state_change]
+        self._browser = AsyncServiceBrowser(  # type: ignore[call-arg]
+            self._zc.zeroconf,
+            self._config.mdns.service_type,
+            handlers=handlers,
+        )
+
+    def _on_service_state_change(
+        self,
+        zeroconf: object,
+        service_type: str,
+        name: str,
+        state_change: object,
+    ) -> None:
+        """mDNS browse callback — fires on add/remove/update."""
+        asyncio.get_event_loop().call_soon_threadsafe(
+            asyncio.ensure_future,
+            self._handle_service_event(zeroconf, service_type, name, state_change),
+        )
+
+    async def _handle_service_event(
+        self,
+        zeroconf: object,
+        service_type: str,
+        name: str,
+        state_change: object,
+    ) -> None:
+        from zeroconf import ServiceStateChange
+
+        if state_change == ServiceStateChange.Removed:
+            peer_id = name.split(".")[0]
+            self._remove_candidate(peer_id)
+            return
+
+        if state_change not in (ServiceStateChange.Added, ServiceStateChange.Updated):
+            return
+
+        info = ServiceInfo(type_=service_type, name=name)  # type: ignore[call-arg]
+        try:
+            await info.async_request(zeroconf, timeout=2000)  # type: ignore[attr-defined]
+        except Exception:
+            return
+
+        props = info.decoded_properties  # type: ignore[attr-defined]
+        peer_id = (props.get("peer_id") or "").strip()
+        if not peer_id or peer_id == self._identity.peer_id:
+            return
+
+        rid_hash = (props.get("realm_id") or "").strip()
+        own_hash = realm_id_hash(self._realm_key)
+        if rid_hash != own_hash:
+            logger.debug(
+                "mdns_discovery: ignoring peer %s — realm hash mismatch (%s != %s)",
+                peer_id,
+                rid_hash,
+                own_hash,
+            )
+            return
+
+        host = info.parsed_addresses()[0] if info.parsed_addresses() else ""  # type: ignore[attr-defined]
+        port = info.port  # type: ignore[attr-defined]
+        candidate = RavnCandidate(
+            peer_id=peer_id,
+            realm_id_hash=rid_hash,
+            host=host,
+            rep_address=(props.get("rep_addr") or "").strip() or None,
+            pub_address=(props.get("pub_addr") or "").strip() or None,
+            handshake_port=port,
+            metadata=dict(props),
+        )
+        self._candidates[peer_id] = candidate
+
+        if peer_id not in self._peers and peer_id not in self._pending_handshakes:
+            asyncio.ensure_future(self._initiate_handshake(candidate))
+
+    def _remove_candidate(self, peer_id: str) -> None:
+        self._candidates.pop(peer_id, None)
+        peer = self._peers.pop(peer_id, None)
+        if peer is not None:
+            for cb in self._on_leave:
+                try:
+                    cb(peer)
+                except Exception:
+                    pass
+
+    # ------------------------------------------------------------------
+    # Internal — handshake initiator (side A)
+    # ------------------------------------------------------------------
+
+    async def _initiate_handshake(self, candidate: RavnCandidate) -> None:
+        self._pending_handshakes.add(candidate.peer_id)
+        try:
+            peer = await self.handshake(candidate)
+            if peer is not None:
+                self._add_peer(peer)
+        finally:
+            self._pending_handshakes.discard(candidate.peer_id)
+
+    def _run_handshake_initiator(
+        self,
+        candidate: RavnCandidate,
+        addr: str,
+        timeout_ms: int,
+    ) -> RavnPeer | None:
+        """Blocking HMAC handshake — runs in executor."""
+        sock = pynng.Pair0(recv_timeout=timeout_ms, send_timeout=timeout_ms)  # type: ignore[attr-defined]
+        try:
+            sock.dial(addr)
+            nonce_a = secrets.token_hex(16)
+            own_id = self._identity.peer_id
+            peer_id = candidate.peer_id
+
+            # A → B: HELLO peer_id_A nonce_A
+            sock.send(f"HELLO {own_id} {nonce_a}".encode())
+
+            # B → A: CHALLENGE <hmac_b> <nonce_B>
+            reply = sock.recv().decode()
+            parts = reply.split(" ", 2)
+            if len(parts) != 3 or parts[0] != "CHALLENGE":
+                return None
+            hmac_b, nonce_b = parts[1], parts[2]
+
+            expected = _hmac_hex(
+                self._realm_key,
+                _HANDSHAKE_PREFIX,
+                nonce_a,
+                own_id,
+                peer_id,
+            )
+            if not hmac.compare_digest(hmac_b, expected):
+                logger.debug("mdns_discovery: CHALLENGE HMAC mismatch from %s", peer_id)
+                return None
+
+            # A → B: VERIFY <hmac_a> + identity JSON
+            hmac_a = _hmac_hex(
+                self._realm_key,
+                _HANDSHAKE_PREFIX,
+                nonce_b,
+                peer_id,
+                own_id,
+            )
+            identity_json = json.dumps(dataclasses.asdict(self._identity))
+            sock.send(f"VERIFY {hmac_a} {identity_json}".encode())
+
+            # B → A: ACCEPT <identity_json>  OR  REJECT
+            final = sock.recv().decode()
+            if final.startswith("REJECT"):
+                return None
+
+            if not final.startswith("ACCEPT "):
+                return None
+
+            peer_identity_raw = json.loads(final[len("ACCEPT ") :])
+            return self._peer_from_identity_dict(peer_identity_raw, candidate)
+        finally:
+            sock.close()
+
+    # ------------------------------------------------------------------
+    # Internal — handshake listener (side B)
+    # ------------------------------------------------------------------
+
+    async def _handshake_listener(self) -> None:
+        """Listen for incoming HMAC handshake requests from other Ravens."""
+        if pynng is None:  # pragma: no cover
+            return
+
+        loop = asyncio.get_running_loop()
+        sock = pynng.Pair0()  # type: ignore[attr-defined]
+        try:
+            sock.listen(f"tcp://*:{self._handshake_port}")
+            while True:
+                try:
+                    data = await loop.run_in_executor(None, sock.recv)
+                    await loop.run_in_executor(None, self._handle_handshake_responder, sock, data)
+                except asyncio.CancelledError:
+                    return
+                except Exception as exc:
+                    logger.debug("mdns_discovery: handshake_listener error: %s", exc)
+                    await asyncio.sleep(0.1)
+        except asyncio.CancelledError:
+            pass
+        finally:
+            sock.close()
+
+    def _handle_handshake_responder(self, sock: object, data: bytes) -> None:
+        """Blocking HMAC handshake — responder side (B)."""
+        try:
+            msg = data.decode()
+            parts = msg.split(" ", 2)
+            if len(parts) != 3 or parts[0] != "HELLO":
+                return
+
+            peer_id_a, nonce_a = parts[1], parts[2]
+            own_id = self._identity.peer_id
+            nonce_b = secrets.token_hex(16)
+
+            hmac_b = _hmac_hex(
+                self._realm_key,
+                _HANDSHAKE_PREFIX,
+                nonce_a,
+                peer_id_a,
+                own_id,
+            )
+            sock.send(f"CHALLENGE {hmac_b} {nonce_b}".encode())  # type: ignore[attr-defined]
+
+            reply = sock.recv().decode()  # type: ignore[attr-defined]
+            reply_parts = reply.split(" ", 2)
+            if len(reply_parts) < 3 or reply_parts[0] != "VERIFY":
+                sock.send(b"REJECT")  # type: ignore[attr-defined]
+                return
+
+            hmac_a_recv = reply_parts[1]
+            identity_json = reply_parts[2]
+
+            expected_a = _hmac_hex(
+                self._realm_key,
+                _HANDSHAKE_PREFIX,
+                nonce_b,
+                own_id,
+                peer_id_a,
+            )
+            if not hmac.compare_digest(hmac_a_recv, expected_a):
+                logger.debug("mdns_discovery: VERIFY HMAC mismatch from %s", peer_id_a)
+                sock.send(b"REJECT")  # type: ignore[attr-defined]
+                return
+
+            try:
+                peer_identity_raw = json.loads(identity_json)
+            except Exception:
+                sock.send(b"REJECT")  # type: ignore[attr-defined]
+                return
+
+            own_identity_json = json.dumps(dataclasses.asdict(self._identity))
+            sock.send(f"ACCEPT {own_identity_json}".encode())  # type: ignore[attr-defined]
+
+            candidate = self._candidates.get(peer_id_a)
+            peer = self._peer_from_identity_dict(peer_identity_raw, candidate)
+            asyncio.get_event_loop().call_soon_threadsafe(self._add_peer, peer)
+        except Exception as exc:
+            logger.debug("mdns_discovery: responder error: %s", exc)
+
+    # ------------------------------------------------------------------
+    # Internal — peer table management
+    # ------------------------------------------------------------------
+
+    def _add_peer(self, peer: RavnPeer) -> None:
+        is_new = peer.peer_id not in self._peers
+        self._peers[peer.peer_id] = peer
+        if is_new:
+            for cb in self._on_join:
+                try:
+                    cb(peer)
+                except Exception:
+                    pass
+
+    def _peer_from_identity_dict(
+        self,
+        raw: dict,
+        candidate: RavnCandidate | None,
+    ) -> RavnPeer:
+        now = datetime.now(UTC)
+        peer = RavnPeer(
+            peer_id=raw.get("peer_id", ""),
+            realm_id=raw.get("realm_id", ""),
+            persona=raw.get("persona", ""),
+            capabilities=raw.get("capabilities", []),
+            permission_mode=raw.get("permission_mode", ""),
+            version=raw.get("version", ""),
+            rep_address=raw.get("rep_address") or (candidate.rep_address if candidate else None),
+            pub_address=raw.get("pub_address") or (candidate.pub_address if candidate else None),
+            spiffe_id=raw.get("spiffe_id"),
+            sleipnir_routing_key=raw.get("sleipnir_routing_key"),
+            trust_level="verified",
+            first_seen=now,
+            last_seen=now,
+            last_heartbeat=now,
+        )
+        return peer
+
+    # ------------------------------------------------------------------
+    # Internal — heartbeat + eviction
+    # ------------------------------------------------------------------
+
+    async def _heartbeat_loop(self) -> None:
+        while True:
+            try:
+                await asyncio.sleep(self._config.heartbeat_interval_s)
+                await self.announce()
+                self._evict_stale_peers()
+            except asyncio.CancelledError:
+                return
+            except Exception as exc:
+                logger.debug("mdns_discovery: heartbeat_loop error: %s", exc)
+
+    def _evict_stale_peers(self) -> None:
+        now = datetime.now(UTC)
+        ttl = self._config.peer_ttl_s
+        to_evict = [
+            peer_id
+            for peer_id, peer in self._peers.items()
+            if (now - peer.last_heartbeat).total_seconds() > ttl
+        ]
+        for peer_id in to_evict:
+            peer = self._peers.pop(peer_id, None)
+            if peer is not None:
+                logger.debug("mdns_discovery: evicted stale peer %s", peer_id)
+                for cb in self._on_leave:
+                    try:
+                        cb(peer)
+                    except Exception:
+                        pass
+
+    def update_peer_heartbeat(
+        self,
+        peer_id: str,
+        *,
+        status: str = "idle",
+        task_count: int = 0,
+    ) -> None:
+        """Update liveness state for *peer_id* (called on heartbeat receipt)."""
+        peer = self._peers.get(peer_id)
+        if peer is None:
+            return
+        now = datetime.now(UTC)
+        # RavnPeer is a dataclass, reassign fields
+        peer.last_seen = now
+        peer.last_heartbeat = now
+        peer.status = status  # type: ignore[assignment]
+        peer.task_count = task_count

--- a/src/ravn/adapters/discovery/mdns.py
+++ b/src/ravn/adapters/discovery/mdns.py
@@ -39,7 +39,6 @@ import json
 import logging
 import secrets
 import socket
-from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
@@ -48,6 +47,7 @@ from ravn.adapters.discovery._identity import (
     realm_id_hash,
 )
 from ravn.domain.models import RavnCandidate, RavnIdentity, RavnPeer
+from ravn.ports.discovery import PeerCallback
 
 if TYPE_CHECKING:
     from ravn.config import DiscoveryConfig
@@ -68,8 +68,6 @@ except ImportError:  # pragma: no cover
     pynng = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
-
-PeerCallback = Callable[[RavnPeer], None]
 
 _HANDSHAKE_PREFIX = "ravn-handshake"
 
@@ -300,7 +298,7 @@ class MdnsDiscoveryAdapter:
         state_change: object,
     ) -> None:
         """mDNS browse callback — fires on add/remove/update."""
-        asyncio.get_event_loop().call_soon_threadsafe(
+        asyncio.get_running_loop().call_soon_threadsafe(
             asyncio.ensure_future,
             self._handle_service_event(zeroconf, service_type, name, state_change),
         )
@@ -344,7 +342,8 @@ class MdnsDiscoveryAdapter:
             )
             return
 
-        host = info.parsed_addresses()[0] if info.parsed_addresses() else ""  # type: ignore[attr-defined]
+        addresses = info.parsed_addresses()  # type: ignore[attr-defined]
+        host = addresses[0] if addresses else ""
         port = info.port  # type: ignore[attr-defined]
         candidate = RavnCandidate(
             peer_id=peer_id,
@@ -522,7 +521,7 @@ class MdnsDiscoveryAdapter:
 
             candidate = self._candidates.get(peer_id_a)
             peer = self._peer_from_identity_dict(peer_identity_raw, candidate)
-            asyncio.get_event_loop().call_soon_threadsafe(self._add_peer, peer)
+            asyncio.get_running_loop().call_soon_threadsafe(self._add_peer, peer)
         except Exception as exc:
             logger.debug("mdns_discovery: responder error: %s", exc)
 

--- a/src/ravn/adapters/discovery/sleipnir.py
+++ b/src/ravn/adapters/discovery/sleipnir.py
@@ -1,0 +1,378 @@
+"""SleipnirDiscoveryAdapter — infra-mode flock discovery via AMQP pub/sub (NIU-538).
+
+Ravens publish structured announce events on startup, reconnect, and heartbeat.
+SPIFFE JWT-SVID validation is used for trust — no separate handshake socket.
+
+**Announce event schema**::
+
+    {
+      "event_type": "ravn.mesh.announce",
+      "source": "ravn:{peer_id}",
+      "payload": {
+        "identity": { <RavnIdentity fields> },
+        "action": "join | leave | heartbeat",
+        "status": "idle | busy",
+        "task_count": 2
+      }
+    }
+
+**Trust**: Announce events without a valid SPIFFE JWT-SVID matching
+``spiffe://niuu.world/*/ravn/<peer_id>`` are silently dropped.
+
+**Cold-start convergence**: On startup, publish own announce and wait up to
+``convergence_wait_s`` for other peers to respond with theirs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from ravn.domain.models import RavnCandidate, RavnIdentity, RavnPeer
+
+if TYPE_CHECKING:
+    from ravn.config import DiscoveryConfig, SleipnirConfig
+
+try:
+    import aio_pika  # type: ignore[import-untyped]
+except ImportError:  # pragma: no cover
+    aio_pika = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+PeerCallback = Callable[[RavnPeer], None]
+
+_ANNOUNCE_ROUTING_KEY = "ravn.mesh.announce"
+_EXCHANGE_NAME = "ravn.mesh"
+
+
+class SleipnirDiscoveryAdapter:
+    """RabbitMQ-based flock discovery for infra mode.
+
+    Parameters
+    ----------
+    config:
+        Root ``DiscoveryConfig`` from settings.
+    sleipnir_config:
+        Shared Sleipnir AMQP settings (carries the URL env var).
+    own_identity:
+        Pre-built ``RavnIdentity`` for this instance.
+    """
+
+    def __init__(
+        self,
+        config: DiscoveryConfig,
+        sleipnir_config: SleipnirConfig,
+        own_identity: RavnIdentity,
+    ) -> None:
+        self._config = config
+        self._sleipnir_config = sleipnir_config
+        self._identity = own_identity
+
+        self._peers: dict[str, RavnPeer] = {}
+        self._on_join: list[PeerCallback] = []
+        self._on_leave: list[PeerCallback] = []
+
+        self._connection: object | None = None
+        self._channel: object | None = None
+        self._exchange: object | None = None
+
+        self._heartbeat_task: asyncio.Task | None = None
+        self._consumer_task: asyncio.Task | None = None
+
+    # ------------------------------------------------------------------
+    # DiscoveryPort interface
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Connect to AMQP, publish join announce, and start consumer + heartbeat."""
+        if aio_pika is None:  # pragma: no cover
+            logger.warning("sleipnir_discovery: aio_pika not installed — discovery disabled")
+            return
+
+        await self._connect()
+        await self.announce()
+
+        # Wait briefly for other peers to respond with their announces.
+        await asyncio.sleep(self._config.sleipnir.convergence_wait_s)
+
+        self._consumer_task = asyncio.create_task(
+            self._consume_loop(), name="sleipnir_discovery_consumer"
+        )
+        self._heartbeat_task = asyncio.create_task(
+            self._heartbeat_loop(), name="sleipnir_discovery_heartbeat"
+        )
+        logger.info("sleipnir_discovery: started peer=%s", self._identity.peer_id)
+
+    async def stop(self) -> None:
+        """Publish leave announce, cancel tasks, close connection."""
+        await self._publish_announce("leave")
+
+        for task in (self._heartbeat_task, self._consumer_task):
+            if task is not None:
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+
+        self._heartbeat_task = None
+        self._consumer_task = None
+
+        if self._connection is not None:
+            try:
+                await self._connection.close()  # type: ignore[union-attr]
+            except Exception:
+                pass
+            self._connection = None
+
+        logger.info("sleipnir_discovery: stopped peer=%s", self._identity.peer_id)
+
+    async def announce(self) -> None:
+        """Publish a join announce event."""
+        await self._publish_announce("join")
+
+    async def scan(self) -> list[RavnCandidate]:
+        """Return empty list — Sleipnir discovery is push-only (pub/sub)."""
+        return []
+
+    async def watch(self, on_join: PeerCallback, on_leave: PeerCallback) -> None:
+        """Register join/leave callbacks (non-blocking)."""
+        self._on_join.append(on_join)
+        self._on_leave.append(on_leave)
+
+    async def handshake(self, candidate: RavnCandidate) -> RavnPeer | None:
+        """No handshake in Sleipnir mode — trust is delegated to SPIFFE."""
+        return None
+
+    def peers(self) -> dict[str, RavnPeer]:
+        """Return the cached verified peer table (synchronous)."""
+        return dict(self._peers)
+
+    async def own_identity(self) -> RavnIdentity:
+        """Return this Ravn's identity."""
+        return self._identity
+
+    # ------------------------------------------------------------------
+    # Internal — AMQP
+    # ------------------------------------------------------------------
+
+    async def _connect(self) -> bool:
+        if aio_pika is None:
+            return False
+        amqp_url = os.environ.get(self._sleipnir_config.amqp_url_env, "")
+        if not amqp_url:
+            logger.debug(
+                "sleipnir_discovery: %s not set — discovery disabled",
+                self._sleipnir_config.amqp_url_env,
+            )
+            return False
+        try:
+            conn = await aio_pika.connect_robust(amqp_url)
+            channel = await conn.channel()
+            exchange = await channel.declare_exchange(
+                _EXCHANGE_NAME,
+                aio_pika.ExchangeType.TOPIC,
+                durable=True,
+            )
+            self._connection = conn
+            self._channel = channel
+            self._exchange = exchange
+            return True
+        except Exception as exc:
+            logger.debug("sleipnir_discovery: connection failed: %s", exc)
+            return False
+
+    async def _publish_announce(
+        self,
+        action: str,
+        *,
+        status: str = "idle",
+        task_count: int = 0,
+    ) -> None:
+        if self._exchange is None:
+            return
+        payload = {
+            "event_type": "ravn.mesh.announce",
+            "source": f"ravn:{self._identity.peer_id}",
+            "payload": {
+                "identity": self._identity_dict(),
+                "action": action,
+                "status": status,
+                "task_count": task_count,
+            },
+        }
+        body = json.dumps(payload).encode()
+        try:
+            msg = aio_pika.Message(body=body, content_type="application/json")  # type: ignore[union-attr]
+            await self._exchange.publish(msg, routing_key=_ANNOUNCE_ROUTING_KEY)  # type: ignore[union-attr]
+        except Exception as exc:
+            logger.debug("sleipnir_discovery: publish announce failed: %s", exc)
+
+    async def _consume_loop(self) -> None:
+        if self._channel is None or self._exchange is None:
+            return
+        try:
+            queue = await self._channel.declare_queue("", exclusive=True)  # type: ignore[union-attr]
+            await queue.bind(self._exchange, routing_key=_ANNOUNCE_ROUTING_KEY)
+
+            async def _on_message(message: object) -> None:
+                async with message.process():  # type: ignore[attr-defined]
+                    try:
+                        raw = json.loads(message.body)  # type: ignore[attr-defined]
+                        await self._handle_announce(raw)
+                    except Exception as exc:
+                        logger.debug("sleipnir_discovery: bad announce message: %s", exc)
+
+            await queue.consume(_on_message)  # type: ignore[union-attr]
+
+            # Keep alive until cancelled
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            pass
+        except Exception as exc:
+            logger.debug("sleipnir_discovery: consume_loop error: %s", exc)
+
+    async def _handle_announce(self, raw: dict) -> None:
+        if raw.get("event_type") != "ravn.mesh.announce":
+            return
+
+        payload = raw.get("payload", {})
+        action = payload.get("action", "join")
+        identity_raw = payload.get("identity", {})
+        peer_id = identity_raw.get("peer_id", "")
+
+        if not peer_id or peer_id == self._identity.peer_id:
+            return
+
+        if not self._validate_spiffe(raw, peer_id):
+            logger.debug("sleipnir_discovery: ignoring peer %s — SPIFFE validation failed", peer_id)
+            return
+
+        if action == "leave":
+            self._remove_peer(peer_id)
+            return
+
+        now = datetime.now(UTC)
+        status = payload.get("status", "idle")
+        task_count = int(payload.get("task_count", 0))
+
+        if peer_id in self._peers:
+            peer = self._peers[peer_id]
+            peer.last_seen = now
+            peer.last_heartbeat = now
+            peer.status = status  # type: ignore[assignment]
+            peer.task_count = task_count
+            return
+
+        peer = RavnPeer(
+            peer_id=peer_id,
+            realm_id=identity_raw.get("realm_id", ""),
+            persona=identity_raw.get("persona", ""),
+            capabilities=identity_raw.get("capabilities", []),
+            permission_mode=identity_raw.get("permission_mode", ""),
+            version=identity_raw.get("version", ""),
+            rep_address=identity_raw.get("rep_address"),
+            pub_address=identity_raw.get("pub_address"),
+            spiffe_id=identity_raw.get("spiffe_id"),
+            sleipnir_routing_key=identity_raw.get("sleipnir_routing_key"),
+            trust_level="verified",
+            first_seen=now,
+            last_seen=now,
+            last_heartbeat=now,
+            status=status,  # type: ignore[arg-type]
+            task_count=task_count,
+        )
+        self._peers[peer_id] = peer
+        for cb in self._on_join:
+            try:
+                cb(peer)
+            except Exception:
+                pass
+
+    def _validate_spiffe(self, raw: dict, peer_id: str) -> bool:
+        """Validate SPIFFE JWT-SVID on the announce message.
+
+        In environments without SPIFFE, skip validation (return True).
+        Real validation checks the JWT matches ``spiffe://niuu.world/*/ravn/<peer_id>``.
+        """
+        trust_domain = os.environ.get(self._config.sleipnir.spiffe_audience_env, "")
+        if not trust_domain:
+            # No SPIFFE configured — accept without validation
+            return True
+
+        jwt_svid = raw.get("spiffe_jwt", "")
+        if not jwt_svid:
+            return False
+
+        # Production: validate JWT-SVID via SPIRE workload API.
+        # For now, check the subject claim contains the peer_id.
+        try:
+            import base64
+
+            header, claims_b64, *_ = jwt_svid.split(".")
+            # Pad base64
+            padding = 4 - len(claims_b64) % 4
+            claims_raw = base64.urlsafe_b64decode(claims_b64 + "=" * padding)
+            claims = json.loads(claims_raw)
+            sub = claims.get("sub", "")
+            return f"/ravn/{peer_id}" in sub
+        except Exception:
+            return False
+
+    def _remove_peer(self, peer_id: str) -> None:
+        peer = self._peers.pop(peer_id, None)
+        if peer is not None:
+            for cb in self._on_leave:
+                try:
+                    cb(peer)
+                except Exception:
+                    pass
+
+    def _identity_dict(self) -> dict:
+        return {
+            "peer_id": self._identity.peer_id,
+            "realm_id": self._identity.realm_id,
+            "persona": self._identity.persona,
+            "capabilities": self._identity.capabilities,
+            "permission_mode": self._identity.permission_mode,
+            "version": self._identity.version,
+            "rep_address": self._identity.rep_address,
+            "pub_address": self._identity.pub_address,
+            "spiffe_id": self._identity.spiffe_id,
+            "sleipnir_routing_key": self._identity.sleipnir_routing_key,
+        }
+
+    async def _heartbeat_loop(self) -> None:
+        while True:
+            try:
+                await asyncio.sleep(self._config.sleipnir.heartbeat_interval_s)
+                await self._publish_announce("heartbeat")
+                self._evict_stale_peers()
+            except asyncio.CancelledError:
+                return
+            except Exception as exc:
+                logger.debug("sleipnir_discovery: heartbeat_loop error: %s", exc)
+
+    def _evict_stale_peers(self) -> None:
+        now = datetime.now(UTC)
+        ttl = self._config.peer_ttl_s
+        to_evict = [
+            pid
+            for pid, peer in self._peers.items()
+            if (now - peer.last_heartbeat).total_seconds() > ttl
+        ]
+        for pid in to_evict:
+            peer = self._peers.pop(pid, None)
+            if peer is not None:
+                logger.debug("sleipnir_discovery: evicted stale peer %s", pid)
+                for cb in self._on_leave:
+                    try:
+                        cb(peer)
+                    except Exception:
+                        pass

--- a/src/ravn/adapters/discovery/sleipnir.py
+++ b/src/ravn/adapters/discovery/sleipnir.py
@@ -29,11 +29,11 @@ import asyncio
 import json
 import logging
 import os
-from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from ravn.domain.models import RavnCandidate, RavnIdentity, RavnPeer
+from ravn.ports.discovery import PeerCallback
 
 if TYPE_CHECKING:
     from ravn.config import DiscoveryConfig, SleipnirConfig
@@ -44,8 +44,6 @@ except ImportError:  # pragma: no cover
     aio_pika = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
-
-PeerCallback = Callable[[RavnPeer], None]
 
 _ANNOUNCE_ROUTING_KEY = "ravn.mesh.announce"
 _EXCHANGE_NAME = "ravn.mesh"

--- a/src/ravn/cli/commands.py
+++ b/src/ravn/cli/commands.py
@@ -1627,35 +1627,33 @@ async def _run_peers(settings: Settings, *, verbose: bool, force_scan: bool) -> 
     await discovery.stop()
 
 
+_DISCOVERY_ALIASES: dict[str, str] = {
+    "mdns": "ravn.adapters.discovery.mdns.MdnsDiscoveryAdapter",
+    "sleipnir": "ravn.adapters.discovery.sleipnir.SleipnirDiscoveryAdapter",
+    "k8s": "ravn.adapters.discovery.k8s.K8sDiscoveryAdapter",
+    "composite": "ravn.adapters.discovery.composite.CompositeDiscoveryAdapter",
+}
+
+# Adapters that need sleipnir_config injected in addition to config + own_identity.
+_SLEIPNIR_KWARGS_ADAPTERS = {"ravn.adapters.discovery.sleipnir.SleipnirDiscoveryAdapter"}
+
+
 def _build_discovery_adapter(name: str, settings: Settings, identity: Any) -> Any:
-    """Instantiate a discovery adapter by name."""
-    if name == "mdns":
-        from ravn.adapters.discovery.mdns import MdnsDiscoveryAdapter
+    """Instantiate a discovery adapter by short name or fully-qualified class path.
 
-        return MdnsDiscoveryAdapter(config=settings.discovery, own_identity=identity)
+    Single-backend adapters are resolved via dynamic import (dynamic-adapters pattern).
+    The composite case is special: its sub-backends are wired explicitly.
+    """
+    fq_class = _DISCOVERY_ALIASES.get(name, name)
 
-    if name == "sleipnir":
-        from ravn.adapters.discovery.sleipnir import SleipnirDiscoveryAdapter
-
-        return SleipnirDiscoveryAdapter(
-            config=settings.discovery,
-            sleipnir_config=settings.sleipnir,
-            own_identity=identity,
-        )
-
-    if name == "k8s":
-        from ravn.adapters.discovery.k8s import K8sDiscoveryAdapter
-
-        return K8sDiscoveryAdapter(config=settings.discovery, own_identity=identity)
-
-    if name == "composite":
+    if fq_class == _DISCOVERY_ALIASES["composite"]:
         from ravn.adapters.discovery.composite import CompositeDiscoveryAdapter
-        from ravn.adapters.discovery.mdns import MdnsDiscoveryAdapter
-        from ravn.adapters.discovery.sleipnir import SleipnirDiscoveryAdapter
 
+        mdns_cls = _import_class(_DISCOVERY_ALIASES["mdns"])
+        sleipnir_cls = _import_class(_DISCOVERY_ALIASES["sleipnir"])
         backends: list[Any] = [
-            MdnsDiscoveryAdapter(config=settings.discovery, own_identity=identity),
-            SleipnirDiscoveryAdapter(
+            mdns_cls(config=settings.discovery, own_identity=identity),
+            sleipnir_cls(
                 config=settings.discovery,
                 sleipnir_config=settings.sleipnir,
                 own_identity=identity,
@@ -1663,10 +1661,11 @@ def _build_discovery_adapter(name: str, settings: Settings, identity: Any) -> An
         ]
         return CompositeDiscoveryAdapter(backends=backends)
 
-    logger.warning("Unknown discovery adapter %r — defaulting to mdns", name)
-    from ravn.adapters.discovery.mdns import MdnsDiscoveryAdapter
-
-    return MdnsDiscoveryAdapter(config=settings.discovery, own_identity=identity)
+    cls = _import_class(fq_class)
+    kwargs: dict[str, Any] = {"config": settings.discovery, "own_identity": identity}
+    if fq_class in _SLEIPNIR_KWARGS_ADAPTERS:
+        kwargs["sleipnir_config"] = settings.sleipnir
+    return cls(**kwargs)
 
 
 def main() -> None:

--- a/src/ravn/cli/commands.py
+++ b/src/ravn/cli/commands.py
@@ -1532,6 +1532,143 @@ def _wire_triggers(drive_loop: Any, initiative: InitiativeConfig) -> None:
             logger.error("Failed to wire trigger %r: %s", tc.name, exc)
 
 
+@app.command()
+def peers(
+    config: str = typer.Option("", "--config", "-c", help="Path to ravn config YAML."),
+    verbose: bool = typer.Option(
+        False, "--verbose", "-v", help="Show address, latency, task_count, last_seen."
+    ),
+    scan: bool = typer.Option(
+        False, "--scan", help="Force a fresh mDNS/K8s scan before displaying."
+    ),
+) -> None:
+    """List verified flock members with persona, capabilities, and status.
+
+    \b
+    Examples:
+      ravn peers               — list verified peers
+      ravn peers --verbose     — include address, latency, task_count
+      ravn peers --scan        — force a fresh network scan first
+    """
+    if config:
+        os.environ["RAVN_CONFIG"] = config
+
+    settings = Settings()
+    _configure_logging(settings)
+    asyncio.run(_run_peers(settings, verbose=verbose, force_scan=scan))
+
+
+async def _run_peers(settings: Settings, *, verbose: bool, force_scan: bool) -> None:
+    """Build a discovery adapter, optionally scan, and print the peer table."""
+    import importlib
+
+    from ravn.adapters.discovery._identity import (
+        load_or_create_peer_id,
+        load_or_create_realm_key,
+        realm_id_from_key,
+    )
+    from ravn.domain.models import RavnIdentity
+
+    peer_id = load_or_create_peer_id()
+    realm_key = load_or_create_realm_key()
+    realm_id = realm_id_from_key(realm_key)
+
+    import importlib.metadata
+
+    try:
+        version = importlib.metadata.version("ravn")
+    except Exception:
+        version = "0.0.0"
+
+    identity = RavnIdentity(
+        peer_id=peer_id,
+        realm_id=realm_id,
+        persona=settings.agent.system_prompt[:30] if settings.agent.system_prompt else "ravn",
+        capabilities=[],
+        permission_mode=settings.permission.mode,
+        version=version,
+    )
+
+    adapter_name = settings.discovery.adapter
+    discovery = _build_discovery_adapter(adapter_name, settings, identity)
+    if discovery is None:
+        typer.echo("No discovery adapter configured.", err=True)
+        return
+
+    await discovery.start()
+
+    if force_scan:
+        candidates = await discovery.scan()
+        typer.echo(f"Scan found {len(candidates)} candidate(s).")
+        for c in candidates:
+            if c.peer_id not in discovery.peers():
+                peer = await discovery.handshake(c)
+                if peer is not None:
+                    typer.echo(f"  Handshook with {c.peer_id}")
+
+    verified = discovery.peers()
+    if not verified:
+        typer.echo("No verified flock members found.")
+        await discovery.stop()
+        return
+
+    typer.echo(f"Flock members ({len(verified)}):")
+    for pid, peer in sorted(verified.items()):
+        caps = ", ".join(peer.capabilities) if peer.capabilities else "—"
+        line = f"  {pid[:8]}  {peer.persona:<20} [{peer.status}]  caps={caps}"
+        if verbose:
+            rep = peer.rep_address or "—"
+            pub = peer.pub_address or "—"
+            latency = f"{peer.latency_ms:.1f}ms" if peer.latency_ms is not None else "—"
+            line += f"\n    rep={rep}  pub={pub}  latency={latency}  tasks={peer.task_count}"
+            line += f"  last_seen={peer.last_seen.isoformat()}"
+        typer.echo(line)
+
+    await discovery.stop()
+
+
+def _build_discovery_adapter(name: str, settings: Settings, identity: Any) -> Any:
+    """Instantiate a discovery adapter by name."""
+    if name == "mdns":
+        from ravn.adapters.discovery.mdns import MdnsDiscoveryAdapter
+
+        return MdnsDiscoveryAdapter(config=settings.discovery, own_identity=identity)
+
+    if name == "sleipnir":
+        from ravn.adapters.discovery.sleipnir import SleipnirDiscoveryAdapter
+
+        return SleipnirDiscoveryAdapter(
+            config=settings.discovery,
+            sleipnir_config=settings.sleipnir,
+            own_identity=identity,
+        )
+
+    if name == "k8s":
+        from ravn.adapters.discovery.k8s import K8sDiscoveryAdapter
+
+        return K8sDiscoveryAdapter(config=settings.discovery, own_identity=identity)
+
+    if name == "composite":
+        from ravn.adapters.discovery.composite import CompositeDiscoveryAdapter
+        from ravn.adapters.discovery.mdns import MdnsDiscoveryAdapter
+        from ravn.adapters.discovery.sleipnir import SleipnirDiscoveryAdapter
+
+        backends: list[Any] = [
+            MdnsDiscoveryAdapter(config=settings.discovery, own_identity=identity),
+            SleipnirDiscoveryAdapter(
+                config=settings.discovery,
+                sleipnir_config=settings.sleipnir,
+                own_identity=identity,
+            ),
+        ]
+        return CompositeDiscoveryAdapter(backends=backends)
+
+    logger.warning("Unknown discovery adapter %r — defaulting to mdns", name)
+    from ravn.adapters.discovery.mdns import MdnsDiscoveryAdapter
+
+    return MdnsDiscoveryAdapter(config=settings.discovery, own_identity=identity)
+
+
 def main() -> None:
     app()
 

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -1156,6 +1156,80 @@ class MeshSleipnirConfig(BaseModel):
     )
 
 
+class DiscoveryMdnsConfig(BaseModel):
+    """mDNS-specific discovery settings (Pi mode)."""
+
+    service_type: str = Field(
+        default="_ravn._tcp.local",
+        description="mDNS service type for flock discovery.",
+    )
+    handshake_timeout_s: float = Field(
+        default=5.0,
+        description="Seconds to wait for HMAC handshake completion.",
+    )
+
+
+class DiscoverySleipnirConfig(BaseModel):
+    """Sleipnir-specific discovery settings (infra mode)."""
+
+    heartbeat_interval_s: float = Field(
+        default=60.0,
+        description="Seconds between Sleipnir announce heartbeats.",
+    )
+    convergence_wait_s: float = Field(
+        default=5.0,
+        description="Seconds to wait on startup for other peers to announce.",
+    )
+    spiffe_audience_env: str = Field(
+        default="SPIFFE_TRUST_DOMAIN",
+        description="Env var containing the SPIFFE trust domain for JWT-SVID validation.",
+    )
+
+
+class DiscoveryK8sConfig(BaseModel):
+    """Kubernetes label adapter settings (infra mode cold-start)."""
+
+    namespace: str = Field(
+        default="",
+        description="K8s namespace to query (empty = all namespaces).",
+    )
+    label_selector: str = Field(
+        default="ravn.niuu.world/role=agent",
+        description="Label selector used to list Ravn pods.",
+    )
+
+
+class DiscoveryConfig(BaseModel):
+    """Flock peer detection configuration (NIU-538).
+
+    ``adapter`` selects the discovery backend:
+    - ``mdns``      — Pi mode, mDNS + HMAC handshake (zeroconf)
+    - ``sleipnir``  — infra mode, pub/sub + SPIFFE JWT validation
+    - ``k8s``       — infra mode, K8s pod label selector
+    - ``composite`` — combines multiple backends
+    """
+
+    adapter: str = Field(
+        default="mdns",
+        description="Discovery backend: 'mdns', 'sleipnir', 'k8s', or 'composite'.",
+    )
+    realm_id_env: str = Field(
+        default="RAVN_REALM_ID",
+        description="Env var carrying the realm_id for infra mode (OpenBao / K8s label).",
+    )
+    heartbeat_interval_s: float = Field(
+        default=30.0,
+        description="Seconds between liveness heartbeats.",
+    )
+    peer_ttl_s: float = Field(
+        default=90.0,
+        description="Seconds of missed heartbeats before a peer is evicted (≈ 3 heartbeats).",
+    )
+    mdns: DiscoveryMdnsConfig = Field(default_factory=DiscoveryMdnsConfig)
+    sleipnir: DiscoverySleipnirConfig = Field(default_factory=DiscoverySleipnirConfig)
+    k8s: DiscoveryK8sConfig = Field(default_factory=DiscoveryK8sConfig)
+
+
 class MeshConfig(BaseModel):
     """Ravn-to-Ravn mesh transport configuration (NIU-517).
 
@@ -1294,6 +1368,9 @@ class Settings(BaseSettings):
 
     # NIU-517: Ravn-to-Ravn mesh transport
     mesh: MeshConfig = Field(default_factory=MeshConfig)
+
+    # NIU-538: flock peer discovery
+    discovery: DiscoveryConfig = Field(default_factory=DiscoveryConfig)
 
     # Legacy — kept so existing CLI wiring (NIU-426) continues to work
     llm_adapter: LLMAdapterConfig = Field(default_factory=LLMAdapterConfig)

--- a/src/ravn/domain/models.py
+++ b/src/ravn/domain/models.py
@@ -519,3 +519,64 @@ class MimirLintReport:
     @property
     def issues_found(self) -> bool:
         return bool(self.orphans or self.contradictions or self.stale or self.gaps)
+
+
+# ---------------------------------------------------------------------------
+# Flock discovery models (NIU-538)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RavnCandidate:
+    """Pre-handshake peer candidate discovered via mDNS or K8s (unverified).
+
+    Carries enough information to attempt a handshake but has not yet proven
+    realm membership.  ``realm_id_hash`` is SHA-256(realm_key)[:16] — the raw
+    secret is never transmitted.
+    """
+
+    peer_id: str
+    realm_id_hash: str  # SHA-256(realm_key)[:16] — not the raw secret
+    host: str
+    rep_address: str | None  # nng REP address
+    pub_address: str | None  # nng PUB address
+    handshake_port: int | None  # temp nng PAIR port for HMAC exchange
+    metadata: dict = field(default_factory=dict)  # raw TXT records / pod annotations
+
+
+@dataclass
+class RavnIdentity:
+    """This Ravn instance's own identity — announced to the flock.
+
+    ``rep_address`` and ``pub_address`` are set by the active mesh adapter
+    on startup so that peers know where to connect.
+    """
+
+    peer_id: str
+    realm_id: str  # raw realm secret (never transmitted — hashed before announcing)
+    persona: str
+    capabilities: list[str]
+    permission_mode: str  # read_only | workspace_write | full_access
+    version: str
+    rep_address: str | None = None  # nng REP address for mesh.send()
+    pub_address: str | None = None  # nng PUB address for mesh.subscribe()
+    spiffe_id: str | None = None  # infra mode only
+    sleipnir_routing_key: str | None = None  # for SleipnirMeshAdapter routing
+
+
+@dataclass
+class RavnPeer(RavnIdentity):
+    """A verified (or pending/rejected) flock member.
+
+    Extends ``RavnIdentity`` with trust metadata and liveness state.
+    ``status`` and ``task_count`` are updated via heartbeat so that the
+    cascade coordinator can pick idle peers.
+    """
+
+    trust_level: Literal["verified", "unverified", "rejected"] = "unverified"
+    first_seen: datetime = field(default_factory=lambda: datetime.now(UTC))
+    last_seen: datetime = field(default_factory=lambda: datetime.now(UTC))
+    last_heartbeat: datetime = field(default_factory=lambda: datetime.now(UTC))
+    latency_ms: float | None = None
+    status: Literal["idle", "busy"] = "idle"
+    task_count: int = 0

--- a/src/ravn/ports/discovery.py
+++ b/src/ravn/ports/discovery.py
@@ -1,0 +1,80 @@
+"""DiscoveryPort — realm-scoped flock peer detection (NIU-538).
+
+Discovery is orthogonal to transport (MeshPort).  This port covers:
+
+- **Announcing** this Ravn's presence to the network
+- **Scanning** for candidates and running the trust handshake
+- **Maintaining** a live, verified peer table
+- **Watching** for join/leave events
+
+``peers()`` is intentionally synchronous because the mesh adapters (NngMeshAdapter,
+SleipnirMeshAdapter) call it from synchronous helper methods during ``send()``
+and ``_connect_sub_to_peers()``.  Implementations maintain an in-memory peer
+table that is updated asynchronously by background tasks.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Protocol, runtime_checkable
+
+from ravn.domain.models import RavnCandidate, RavnIdentity, RavnPeer
+
+PeerCallback = Callable[[RavnPeer], None]
+
+
+@runtime_checkable
+class DiscoveryPort(Protocol):
+    """Realm-scoped flock peer detection and trust verification.
+
+    Implementations
+    ---------------
+    - ``MdnsDiscoveryAdapter``      — Pi mode, mDNS + HMAC handshake (zeroconf)
+    - ``SleipnirDiscoveryAdapter``  — infra mode, pub/sub + SPIFFE JWT validation
+    - ``K8sDiscoveryAdapter``       — infra mode, pod label selector query
+    - ``CompositeDiscoveryAdapter`` — merges multiple backends
+    """
+
+    async def start(self) -> None:
+        """Start background tasks (announce, heartbeat, eviction)."""
+        ...
+
+    async def stop(self) -> None:
+        """Graceful shutdown — cancel background tasks, unregister services."""
+        ...
+
+    async def announce(self) -> None:
+        """(Re-)announce this Ravn's presence to the network."""
+        ...
+
+    async def scan(self) -> list[RavnCandidate]:
+        """Return unverified candidates visible on the network right now."""
+        ...
+
+    async def watch(self, on_join: PeerCallback, on_leave: PeerCallback) -> None:
+        """Register callbacks fired when verified peers join or leave the flock.
+
+        Returns immediately — callbacks are fired from background tasks.
+        Multiple callers may register multiple callbacks.
+        """
+        ...
+
+    async def handshake(self, candidate: RavnCandidate) -> RavnPeer | None:
+        """Run the trust handshake with *candidate*.
+
+        Returns a verified ``RavnPeer`` on success, ``None`` if the candidate
+        is from a different realm (silently ignored — no error, DEBUG log only).
+        """
+        ...
+
+    def peers(self) -> dict[str, RavnPeer]:
+        """Return the current verified peer table, keyed by ``peer_id``.
+
+        Synchronous — returns the cached in-memory table.  Updated by
+        background tasks as peers join, send heartbeats, and are evicted.
+        """
+        ...
+
+    async def own_identity(self) -> RavnIdentity:
+        """Return this Ravn instance's own identity."""
+        ...

--- a/tests/test_ravn/test_discovery.py
+++ b/tests/test_ravn/test_discovery.py
@@ -1,0 +1,1100 @@
+"""Tests for NIU-538 flock discovery — DiscoveryPort, models, adapters."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ravn.adapters.discovery._identity import (
+    load_or_create_peer_id,
+    load_or_create_realm_key,
+    realm_id_from_key,
+    realm_id_hash,
+)
+from ravn.adapters.discovery.composite import CompositeDiscoveryAdapter
+from ravn.adapters.discovery.k8s import K8sDiscoveryAdapter
+from ravn.adapters.discovery.mdns import MdnsDiscoveryAdapter, _hmac_hex
+from ravn.adapters.discovery.sleipnir import SleipnirDiscoveryAdapter
+from ravn.config import DiscoveryConfig, DiscoveryMdnsConfig, SleipnirConfig
+from ravn.domain.models import RavnCandidate, RavnIdentity, RavnPeer
+from ravn.ports.discovery import DiscoveryPort
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_identity(
+    peer_id: str = "peer-a",
+    realm_id: str = "realm-xyz",
+) -> RavnIdentity:
+    return RavnIdentity(
+        peer_id=peer_id,
+        realm_id=realm_id,
+        persona="test-agent",
+        capabilities=["bash", "file"],
+        permission_mode="workspace_write",
+        version="0.1.0",
+        rep_address="tcp://127.0.0.1:7481",
+        pub_address="tcp://127.0.0.1:7480",
+    )
+
+
+def _make_peer(
+    peer_id: str = "peer-b",
+    trust_level: str = "verified",
+    status: str = "idle",
+) -> RavnPeer:
+    now = datetime.now(UTC)
+    return RavnPeer(
+        peer_id=peer_id,
+        realm_id="realm-xyz",
+        persona="test-peer",
+        capabilities=["bash"],
+        permission_mode="workspace_write",
+        version="0.1.0",
+        rep_address="tcp://127.0.0.1:7491",
+        pub_address="tcp://127.0.0.1:7490",
+        trust_level=trust_level,  # type: ignore[arg-type]
+        first_seen=now,
+        last_seen=now,
+        last_heartbeat=now,
+        status=status,  # type: ignore[arg-type]
+        task_count=0,
+    )
+
+
+def _make_candidate(peer_id: str = "peer-b", realm_id_hash_val: str = "abc123") -> RavnCandidate:
+    return RavnCandidate(
+        peer_id=peer_id,
+        realm_id_hash=realm_id_hash_val,
+        host="127.0.0.1",
+        rep_address="tcp://127.0.0.1:7491",
+        pub_address="tcp://127.0.0.1:7490",
+        handshake_port=7492,
+        metadata={},
+    )
+
+
+def _make_discovery_config(**kwargs: Any) -> DiscoveryConfig:
+    return DiscoveryConfig(
+        heartbeat_interval_s=kwargs.get("heartbeat_interval_s", 30.0),
+        peer_ttl_s=kwargs.get("peer_ttl_s", 90.0),
+        mdns=DiscoveryMdnsConfig(handshake_timeout_s=5.0),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Domain model tests
+# ---------------------------------------------------------------------------
+
+
+class TestRavnCandidate:
+    def test_fields(self) -> None:
+        c = _make_candidate("peer-x", "deadbeef")
+        assert c.peer_id == "peer-x"
+        assert c.realm_id_hash == "deadbeef"
+        assert c.host == "127.0.0.1"
+        assert c.handshake_port == 7492
+
+    def test_metadata_default_empty(self) -> None:
+        c = RavnCandidate(
+            peer_id="p",
+            realm_id_hash="h",
+            host="h",
+            rep_address=None,
+            pub_address=None,
+            handshake_port=None,
+        )
+        assert c.metadata == {}
+
+
+class TestRavnIdentity:
+    def test_optional_fields_default_none(self) -> None:
+        ident = RavnIdentity(
+            peer_id="p",
+            realm_id="r",
+            persona="ag",
+            capabilities=[],
+            permission_mode="read_only",
+            version="1.0",
+        )
+        assert ident.rep_address is None
+        assert ident.pub_address is None
+        assert ident.spiffe_id is None
+        assert ident.sleipnir_routing_key is None
+
+
+class TestRavnPeer:
+    def test_extends_identity(self) -> None:
+        peer = _make_peer()
+        assert peer.peer_id == "peer-b"
+        assert peer.trust_level == "verified"
+        assert peer.status == "idle"
+        assert peer.task_count == 0
+
+    def test_rep_pub_addresses(self) -> None:
+        peer = _make_peer()
+        assert peer.rep_address == "tcp://127.0.0.1:7491"
+        assert peer.pub_address == "tcp://127.0.0.1:7490"
+
+    def test_status_busy(self) -> None:
+        peer = _make_peer(status="busy")
+        assert peer.status == "busy"
+
+    def test_capabilities_list(self) -> None:
+        peer = _make_peer()
+        assert "bash" in peer.capabilities
+
+
+# ---------------------------------------------------------------------------
+# DiscoveryPort protocol tests
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoveryPortProtocol:
+    def test_mdns_adapter_satisfies_protocol(self) -> None:
+        config = _make_discovery_config()
+        identity = _make_identity()
+        adapter = MdnsDiscoveryAdapter(config=config, own_identity=identity)
+        assert isinstance(adapter, DiscoveryPort)
+
+    def test_sleipnir_adapter_satisfies_protocol(self) -> None:
+        config = _make_discovery_config()
+        identity = _make_identity()
+        sc = SleipnirConfig()
+        adapter = SleipnirDiscoveryAdapter(config=config, sleipnir_config=sc, own_identity=identity)
+        assert isinstance(adapter, DiscoveryPort)
+
+    def test_k8s_adapter_satisfies_protocol(self) -> None:
+        config = _make_discovery_config()
+        identity = _make_identity()
+        adapter = K8sDiscoveryAdapter(config=config, own_identity=identity)
+        assert isinstance(adapter, DiscoveryPort)
+
+    def test_composite_adapter_satisfies_protocol(self) -> None:
+        adapter = CompositeDiscoveryAdapter(backends=[])
+        assert isinstance(adapter, DiscoveryPort)
+
+
+# ---------------------------------------------------------------------------
+# Identity persistence tests
+# ---------------------------------------------------------------------------
+
+
+class TestIdentityPersistence:
+    def test_load_or_create_peer_id_creates_on_first_run(self, tmp_path: Path) -> None:
+        with patch("ravn.adapters.discovery._identity._ravn_dir", return_value=tmp_path):
+            peer_id = load_or_create_peer_id()
+        assert uuid.UUID(peer_id)  # valid UUID
+        assert (tmp_path / "peer_id").exists()
+
+    def test_load_or_create_peer_id_stable_across_calls(self, tmp_path: Path) -> None:
+        with patch("ravn.adapters.discovery._identity._ravn_dir", return_value=tmp_path):
+            a = load_or_create_peer_id()
+            b = load_or_create_peer_id()
+        assert a == b
+
+    def test_load_or_create_realm_key_creates_32_bytes(self, tmp_path: Path) -> None:
+        with patch("ravn.adapters.discovery._identity._ravn_dir", return_value=tmp_path):
+            key = load_or_create_realm_key()
+        assert isinstance(key, bytes)
+        assert len(key) == 32
+        assert (tmp_path / "realm.key").exists()
+
+    def test_load_or_create_realm_key_stable(self, tmp_path: Path) -> None:
+        with patch("ravn.adapters.discovery._identity._ravn_dir", return_value=tmp_path):
+            a = load_or_create_realm_key()
+            b = load_or_create_realm_key()
+        assert a == b
+
+    def test_realm_id_hash_prefix_16(self) -> None:
+        key = b"x" * 32
+        h = realm_id_hash(key)
+        assert len(h) == 16
+        assert h == hashlib.sha256(key).hexdigest()[:16]
+
+    def test_realm_id_from_key_hex(self) -> None:
+        key = bytes.fromhex("deadbeef" * 8)
+        rid = realm_id_from_key(key)
+        assert rid == key.hex()
+
+
+# ---------------------------------------------------------------------------
+# HMAC helper tests
+# ---------------------------------------------------------------------------
+
+
+class TestHmacHelper:
+    def test_hmac_hex_deterministic(self) -> None:
+        key = b"secret"
+        a = _hmac_hex(key, "ravn-handshake", "nonce_a", "peer_a", "peer_b")
+        b = _hmac_hex(key, "ravn-handshake", "nonce_a", "peer_a", "peer_b")
+        assert a == b
+
+    def test_hmac_hex_different_parts_differ(self) -> None:
+        key = b"secret"
+        a = _hmac_hex(key, "ravn-handshake", "nonce_a", "peer_a", "peer_b")
+        b = _hmac_hex(key, "ravn-handshake", "nonce_b", "peer_a", "peer_b")
+        assert a != b
+
+    def test_hmac_hex_different_key_differs(self) -> None:
+        a = _hmac_hex(b"key_a", "ravn-handshake", "n", "a", "b")
+        b = _hmac_hex(b"key_b", "ravn-handshake", "n", "a", "b")
+        assert a != b
+
+    def test_hmac_compare_digest_constant_time(self) -> None:
+        key = b"secret"
+        h = _hmac_hex(key, "ravn-handshake", "n", "a", "b")
+        assert hmac.compare_digest(h, h)
+        assert not hmac.compare_digest(h, "0" * len(h))
+
+
+# ---------------------------------------------------------------------------
+# MdnsDiscoveryAdapter tests (no real zeroconf/nng required)
+# ---------------------------------------------------------------------------
+
+
+class TestMdnsDiscoveryAdapter:
+    def _make_adapter(self, realm_key: bytes | None = None) -> MdnsDiscoveryAdapter:
+        config = _make_discovery_config()
+        identity = _make_identity()
+        adapter = MdnsDiscoveryAdapter(config=config, own_identity=identity)
+        if realm_key is not None:
+            adapter._realm_key = realm_key
+        return adapter
+
+    def test_peers_initially_empty(self) -> None:
+        adapter = self._make_adapter()
+        assert adapter.peers() == {}
+
+    def test_peers_returns_dict_copy(self) -> None:
+        adapter = self._make_adapter()
+        peer = _make_peer("peer-x")
+        adapter._peers["peer-x"] = peer
+        result = adapter.peers()
+        result["injected"] = peer  # mutate copy
+        assert "injected" not in adapter._peers
+
+    @pytest.mark.asyncio
+    async def test_watch_registers_callbacks(self) -> None:
+        adapter = self._make_adapter()
+        joins: list[RavnPeer] = []
+        leaves: list[RavnPeer] = []
+        await adapter.watch(on_join=joins.append, on_leave=leaves.append)
+        assert len(adapter._on_join) == 1
+        assert len(adapter._on_leave) == 1
+
+    def test_add_peer_fires_on_join(self) -> None:
+        adapter = self._make_adapter()
+        joins: list[RavnPeer] = []
+        adapter._on_join.append(joins.append)
+        peer = _make_peer("peer-x")
+        adapter._add_peer(peer)
+        assert len(joins) == 1
+        assert joins[0].peer_id == "peer-x"
+
+    def test_add_peer_not_duplicate_join(self) -> None:
+        adapter = self._make_adapter()
+        joins: list[RavnPeer] = []
+        adapter._on_join.append(joins.append)
+        peer = _make_peer("peer-x")
+        adapter._add_peer(peer)
+        adapter._add_peer(peer)  # second add — already in peers
+        assert len(joins) == 1
+
+    def test_remove_candidate_fires_on_leave(self) -> None:
+        adapter = self._make_adapter()
+        leaves: list[RavnPeer] = []
+        adapter._on_leave.append(leaves.append)
+        peer = _make_peer("peer-x")
+        adapter._peers["peer-x"] = peer
+        adapter._remove_candidate("peer-x")
+        assert len(leaves) == 1
+        assert "peer-x" not in adapter._peers
+
+    def test_remove_candidate_missing_peer_noop(self) -> None:
+        adapter = self._make_adapter()
+        leaves: list[RavnPeer] = []
+        adapter._on_leave.append(leaves.append)
+        adapter._remove_candidate("nonexistent")
+        assert leaves == []
+
+    def test_evict_stale_peers(self) -> None:
+        adapter = self._make_adapter()
+        config = _make_discovery_config(peer_ttl_s=10.0)
+        adapter._config = config
+        leaves: list[RavnPeer] = []
+        adapter._on_leave.append(leaves.append)
+
+        stale_peer = _make_peer("stale")
+        stale_peer.last_heartbeat = datetime.now(UTC) - timedelta(seconds=20)
+        fresh_peer = _make_peer("fresh")
+
+        adapter._peers["stale"] = stale_peer
+        adapter._peers["fresh"] = fresh_peer
+
+        adapter._evict_stale_peers()
+
+        assert "stale" not in adapter._peers
+        assert "fresh" in adapter._peers
+        assert len(leaves) == 1
+        assert leaves[0].peer_id == "stale"
+
+    def test_update_peer_heartbeat(self) -> None:
+        adapter = self._make_adapter()
+        peer = _make_peer("peer-x")
+        adapter._peers["peer-x"] = peer
+        adapter.update_peer_heartbeat("peer-x", status="busy", task_count=3)
+        assert adapter._peers["peer-x"].status == "busy"
+        assert adapter._peers["peer-x"].task_count == 3
+
+    def test_update_peer_heartbeat_missing_peer_noop(self) -> None:
+        adapter = self._make_adapter()
+        adapter.update_peer_heartbeat("nonexistent")  # should not raise
+
+    def test_realm_mismatch_silently_ignored(self) -> None:
+        """Service with different realm hash must be ignored without error."""
+        adapter = self._make_adapter(realm_key=b"realm_a" * 5)
+        joins: list[RavnPeer] = []
+        adapter._on_join.append(joins.append)
+
+        # Candidate has realm hash derived from a different key
+        other_key = b"realm_b" * 5
+        other_hash = realm_id_hash(other_key)
+        candidate = RavnCandidate(
+            peer_id="foreign-peer",
+            realm_id_hash=other_hash,
+            host="127.0.0.1",
+            rep_address=None,
+            pub_address=None,
+            handshake_port=7492,
+        )
+        # Should not add this peer to the verified table
+        assert candidate.peer_id not in adapter._peers
+        assert len(joins) == 0
+
+    def test_build_txt_records_includes_required_fields(self) -> None:
+        adapter = self._make_adapter()
+        txt = adapter._build_txt_records()
+        assert "realm_id" in txt
+        assert "peer_id" in txt
+        assert "persona" in txt
+        assert "handshake_port" in txt
+        # rep_addr and pub_addr when addresses are set
+        assert "rep_addr" in txt
+        assert "pub_addr" in txt
+
+    def test_realm_id_hash_in_txt_is_16_hex_chars(self) -> None:
+        adapter = self._make_adapter()
+        txt = adapter._build_txt_records()
+        assert len(txt["realm_id"]) == 16
+
+    @pytest.mark.asyncio
+    async def test_own_identity_returns_identity(self) -> None:
+        adapter = self._make_adapter()
+        identity = await adapter.own_identity()
+        assert identity.peer_id == "peer-a"
+
+    @pytest.mark.asyncio
+    async def test_scan_returns_current_candidates(self) -> None:
+        adapter = self._make_adapter()
+        candidate = _make_candidate()
+        adapter._candidates["peer-b"] = candidate
+        result = await adapter.scan()
+        assert len(result) == 1
+        assert result[0].peer_id == "peer-b"
+
+    @pytest.mark.asyncio
+    async def test_handshake_returns_none_without_pynng(self) -> None:
+        adapter = self._make_adapter()
+        candidate = _make_candidate()
+        with patch("ravn.adapters.discovery.mdns.pynng", None):
+            result = await adapter.handshake(candidate)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_handshake_returns_none_no_handshake_port(self) -> None:
+        adapter = self._make_adapter()
+        candidate = _make_candidate()
+        candidate.handshake_port = None
+        result = await adapter.handshake(candidate)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_start_skips_without_zeroconf(self) -> None:
+        adapter = self._make_adapter()
+        with patch("ravn.adapters.discovery.mdns.AsyncZeroconf", None):
+            await adapter.start()  # should not raise
+
+    @pytest.mark.asyncio
+    async def test_stop_noop_when_not_started(self) -> None:
+        adapter = self._make_adapter()
+        await adapter.stop()  # no error
+
+    def test_peer_from_identity_dict(self) -> None:
+        adapter = self._make_adapter()
+        raw = {
+            "peer_id": "peer-z",
+            "realm_id": "realm-xyz",
+            "persona": "test",
+            "capabilities": ["bash"],
+            "permission_mode": "read_only",
+            "version": "1.0",
+            "rep_address": "tcp://10.0.0.1:7481",
+            "pub_address": "tcp://10.0.0.1:7480",
+        }
+        peer = adapter._peer_from_identity_dict(raw, candidate=None)
+        assert peer.peer_id == "peer-z"
+        assert peer.trust_level == "verified"
+        assert peer.rep_address == "tcp://10.0.0.1:7481"
+
+
+# ---------------------------------------------------------------------------
+# Handshake protocol unit tests (in-process, no real nng)
+# ---------------------------------------------------------------------------
+
+
+class TestHandshakeProtocol:
+    """Test the HMAC challenge-response logic in isolation."""
+
+    def _run_initiator(
+        self,
+        realm_key: bytes,
+        own_id: str,
+        peer_id: str,
+        nonce_a: str,
+        nonce_b: str,
+        challenge_hmac: str,
+        accept_identity: dict,
+    ) -> RavnPeer | None:
+        """Simulate what _run_handshake_initiator does, using a mock socket."""
+        from ravn.adapters.discovery.mdns import _HANDSHAKE_PREFIX, _hmac_hex
+
+        # Verify challenge HMAC
+        expected = _hmac_hex(realm_key, _HANDSHAKE_PREFIX, nonce_a, own_id, peer_id)
+        if not hmac.compare_digest(challenge_hmac, expected):
+            return None
+
+        config = _make_discovery_config()
+        identity = _make_identity(peer_id=own_id)
+        adapter = MdnsDiscoveryAdapter(config=config, own_identity=identity)
+        adapter._realm_key = realm_key
+        candidate = _make_candidate(peer_id=peer_id)
+        return adapter._peer_from_identity_dict(accept_identity, candidate)
+
+    def test_correct_realm_produces_peer(self) -> None:
+        realm_key = b"shared-secret-key-32-bytes-long!"
+        own_id, peer_id = "peer-a", "peer-b"
+        nonce_a, nonce_b = "nonce_aaa", "nonce_bbb"
+        from ravn.adapters.discovery.mdns import _HANDSHAKE_PREFIX, _hmac_hex
+
+        challenge_hmac = _hmac_hex(realm_key, _HANDSHAKE_PREFIX, nonce_a, own_id, peer_id)
+        accept_identity = {
+            "peer_id": peer_id,
+            "realm_id": "realm-xyz",
+            "persona": "test",
+            "capabilities": ["bash"],
+            "permission_mode": "read_only",
+            "version": "0.1.0",
+        }
+        peer = self._run_initiator(
+            realm_key, own_id, peer_id, nonce_a, nonce_b, challenge_hmac, accept_identity
+        )
+        assert peer is not None
+        assert peer.peer_id == peer_id
+
+    def test_wrong_realm_key_rejected(self) -> None:
+        realm_key_a = b"realm-key-aaa-32-bytes-padding!!"
+        realm_key_b = b"realm-key-bbb-32-bytes-padding!!"
+        own_id, peer_id = "peer-a", "peer-b"
+        nonce_a, nonce_b = "nonce_aaa", "nonce_bbb"
+        from ravn.adapters.discovery.mdns import _HANDSHAKE_PREFIX, _hmac_hex
+
+        # B signs with its key, not the shared key
+        wrong_hmac = _hmac_hex(realm_key_b, _HANDSHAKE_PREFIX, nonce_a, own_id, peer_id)
+        accept_identity: dict = {}
+        peer = self._run_initiator(
+            realm_key_a, own_id, peer_id, nonce_a, nonce_b, wrong_hmac, accept_identity
+        )
+        assert peer is None
+
+
+# ---------------------------------------------------------------------------
+# SleipnirDiscoveryAdapter tests
+# ---------------------------------------------------------------------------
+
+
+class TestSleipnirDiscoveryAdapter:
+    def _make_adapter(self) -> SleipnirDiscoveryAdapter:
+        config = _make_discovery_config()
+        sc = SleipnirConfig()
+        identity = _make_identity()
+        return SleipnirDiscoveryAdapter(config=config, sleipnir_config=sc, own_identity=identity)
+
+    def test_peers_initially_empty(self) -> None:
+        adapter = self._make_adapter()
+        assert adapter.peers() == {}
+
+    @pytest.mark.asyncio
+    async def test_own_identity(self) -> None:
+        adapter = self._make_adapter()
+        ident = await adapter.own_identity()
+        assert ident.peer_id == "peer-a"
+
+    @pytest.mark.asyncio
+    async def test_scan_returns_empty(self) -> None:
+        adapter = self._make_adapter()
+        result = await adapter.scan()
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_handshake_returns_none(self) -> None:
+        adapter = self._make_adapter()
+        candidate = _make_candidate()
+        result = await adapter.handshake(candidate)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_watch_registers_callbacks(self) -> None:
+        adapter = self._make_adapter()
+        joins: list[RavnPeer] = []
+        await adapter.watch(on_join=joins.append, on_leave=lambda _: None)
+        assert len(adapter._on_join) == 1
+
+    @pytest.mark.asyncio
+    async def test_handle_announce_join_adds_peer(self) -> None:
+        adapter = self._make_adapter()
+        joins: list[RavnPeer] = []
+        adapter._on_join.append(joins.append)
+
+        raw = {
+            "event_type": "ravn.mesh.announce",
+            "source": "ravn:peer-b",
+            "payload": {
+                "identity": {
+                    "peer_id": "peer-b",
+                    "realm_id": "realm-xyz",
+                    "persona": "worker",
+                    "capabilities": ["bash"],
+                    "permission_mode": "read_only",
+                    "version": "0.1.0",
+                    "rep_address": "tcp://10.0.0.2:7481",
+                    "pub_address": "tcp://10.0.0.2:7480",
+                },
+                "action": "join",
+                "status": "idle",
+                "task_count": 0,
+            },
+        }
+        await adapter._handle_announce(raw)
+        assert "peer-b" in adapter._peers
+        assert adapter._peers["peer-b"].trust_level == "verified"
+        assert len(joins) == 1
+
+    @pytest.mark.asyncio
+    async def test_handle_announce_own_peer_ignored(self) -> None:
+        adapter = self._make_adapter()
+        raw = {
+            "event_type": "ravn.mesh.announce",
+            "source": "ravn:peer-a",
+            "payload": {
+                "identity": {"peer_id": "peer-a"},
+                "action": "join",
+            },
+        }
+        await adapter._handle_announce(raw)
+        assert "peer-a" not in adapter._peers
+
+    @pytest.mark.asyncio
+    async def test_handle_announce_leave_removes_peer(self) -> None:
+        adapter = self._make_adapter()
+        peer = _make_peer("peer-b")
+        adapter._peers["peer-b"] = peer
+        leaves: list[RavnPeer] = []
+        adapter._on_leave.append(leaves.append)
+
+        raw = {
+            "event_type": "ravn.mesh.announce",
+            "source": "ravn:peer-b",
+            "payload": {
+                "identity": {"peer_id": "peer-b"},
+                "action": "leave",
+            },
+        }
+        await adapter._handle_announce(raw)
+        assert "peer-b" not in adapter._peers
+        assert len(leaves) == 1
+
+    @pytest.mark.asyncio
+    async def test_handle_announce_wrong_event_type_ignored(self) -> None:
+        adapter = self._make_adapter()
+        raw = {"event_type": "something.else"}
+        await adapter._handle_announce(raw)  # should not raise
+
+    @pytest.mark.asyncio
+    async def test_handle_announce_heartbeat_updates_liveness(self) -> None:
+        adapter = self._make_adapter()
+        peer = _make_peer("peer-b")
+        peer.task_count = 0
+        adapter._peers["peer-b"] = peer
+
+        raw = {
+            "event_type": "ravn.mesh.announce",
+            "source": "ravn:peer-b",
+            "payload": {
+                "identity": {"peer_id": "peer-b"},
+                "action": "heartbeat",
+                "status": "busy",
+                "task_count": 3,
+            },
+        }
+        await adapter._handle_announce(raw)
+        assert adapter._peers["peer-b"].status == "busy"
+        assert adapter._peers["peer-b"].task_count == 3
+
+    def test_evict_stale_peers(self) -> None:
+        adapter = self._make_adapter()
+        adapter._config = _make_discovery_config(peer_ttl_s=5.0)
+        leaves: list[RavnPeer] = []
+        adapter._on_leave.append(leaves.append)
+
+        stale = _make_peer("stale")
+        stale.last_heartbeat = datetime.now(UTC) - timedelta(seconds=10)
+        adapter._peers["stale"] = stale
+
+        adapter._evict_stale_peers()
+        assert "stale" not in adapter._peers
+        assert len(leaves) == 1
+
+    def test_validate_spiffe_no_trust_domain_passes(self) -> None:
+        adapter = self._make_adapter()
+        # Without SPIFFE_TRUST_DOMAIN env var set, validation passes
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("SPIFFE_TRUST_DOMAIN", None)
+            assert adapter._validate_spiffe({}, "peer-x") is True
+
+    @pytest.mark.asyncio
+    async def test_start_skips_without_aio_pika(self) -> None:
+        adapter = self._make_adapter()
+        with patch("ravn.adapters.discovery.sleipnir.aio_pika", None):
+            await adapter.start()  # should not raise, just warn
+
+    def test_peers_returns_copy(self) -> None:
+        adapter = self._make_adapter()
+        peer = _make_peer("p")
+        adapter._peers["p"] = peer
+        result = adapter.peers()
+        result["injected"] = peer
+        assert "injected" not in adapter._peers
+
+
+# ---------------------------------------------------------------------------
+# K8sDiscoveryAdapter tests
+# ---------------------------------------------------------------------------
+
+
+class TestK8sDiscoveryAdapter:
+    def _make_adapter(self) -> K8sDiscoveryAdapter:
+        config = _make_discovery_config()
+        identity = _make_identity()
+        return K8sDiscoveryAdapter(config=config, own_identity=identity)
+
+    def test_peers_initially_empty(self) -> None:
+        adapter = self._make_adapter()
+        assert adapter.peers() == {}
+
+    @pytest.mark.asyncio
+    async def test_own_identity(self) -> None:
+        adapter = self._make_adapter()
+        ident = await adapter.own_identity()
+        assert ident.peer_id == "peer-a"
+
+    @pytest.mark.asyncio
+    async def test_announce_noop(self) -> None:
+        adapter = self._make_adapter()
+        await adapter.announce()  # should not raise
+
+    @pytest.mark.asyncio
+    async def test_handshake_returns_none(self) -> None:
+        adapter = self._make_adapter()
+        candidate = _make_candidate()
+        result = await adapter.handshake(candidate)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_watch_registers_callbacks(self) -> None:
+        adapter = self._make_adapter()
+        joins: list[RavnPeer] = []
+        await adapter.watch(on_join=joins.append, on_leave=lambda _: None)
+        assert len(adapter._on_join) == 1
+
+    def test_list_candidates_returns_empty_without_k8s(self) -> None:
+        adapter = self._make_adapter()
+        with patch("ravn.adapters.discovery.k8s.k8s_client", None):
+            candidates = adapter._list_candidates()
+        assert candidates == []
+
+    def test_list_candidates_with_mock_k8s(self) -> None:
+        adapter = self._make_adapter()
+        mock_pod = MagicMock()
+        mock_pod.metadata.annotations = {
+            "ravn.niuu.world/peer-id": "peer-z",
+            "ravn.niuu.world/persona": "worker",
+            "ravn.niuu.world/capabilities": "bash,file",
+            "ravn.niuu.world/permission-mode": "workspace_write",
+        }
+        mock_pod.status.pod_ip = "10.0.0.3"
+
+        mock_v1 = MagicMock()
+        mock_v1.list_pod_for_all_namespaces.return_value.items = [mock_pod]
+
+        with patch("ravn.adapters.discovery.k8s.k8s_client") as mock_k8s:
+            mock_k8s.CoreV1Api.return_value = mock_v1
+            candidates = adapter._list_candidates()
+
+        assert len(candidates) == 1
+        assert candidates[0].peer_id == "peer-z"
+        assert candidates[0].host == "10.0.0.3"
+
+    def test_list_candidates_skips_own_peer(self) -> None:
+        adapter = self._make_adapter()  # own peer_id = "peer-a"
+        mock_pod = MagicMock()
+        mock_pod.metadata.annotations = {
+            "ravn.niuu.world/peer-id": "peer-a",  # own
+        }
+        mock_pod.status.pod_ip = "10.0.0.1"
+        mock_v1 = MagicMock()
+        mock_v1.list_pod_for_all_namespaces.return_value.items = [mock_pod]
+
+        with patch("ravn.adapters.discovery.k8s.k8s_client") as mock_k8s:
+            mock_k8s.CoreV1Api.return_value = mock_v1
+            candidates = adapter._list_candidates()
+
+        assert candidates == []
+
+    @pytest.mark.asyncio
+    async def test_do_scan_adds_peers(self) -> None:
+        adapter = self._make_adapter()
+        joins: list[RavnPeer] = []
+        adapter._on_join.append(joins.append)
+
+        mock_candidate = _make_candidate("peer-z")
+        mock_candidate.metadata = {
+            "persona": "worker",
+            "capabilities": "bash",
+            "permission_mode": "read_only",
+            "realm_id": "realm-xyz",
+        }
+
+        with patch.object(adapter, "_list_candidates", return_value=[mock_candidate]):
+            await adapter._do_scan()
+
+        assert "peer-z" in adapter._peers
+        assert len(joins) == 1
+
+    @pytest.mark.asyncio
+    async def test_do_scan_evicts_departed_pods(self) -> None:
+        adapter = self._make_adapter()
+        # Pre-existing peer
+        peer = _make_peer("peer-old")
+        adapter._peers["peer-old"] = peer
+        leaves: list[RavnPeer] = []
+        adapter._on_leave.append(leaves.append)
+
+        # Scan returns no peers this time
+        with patch.object(adapter, "_list_candidates", return_value=[]):
+            await adapter._do_scan()
+
+        assert "peer-old" not in adapter._peers
+        assert len(leaves) == 1
+
+    @pytest.mark.asyncio
+    async def test_start_skips_without_k8s(self) -> None:
+        adapter = self._make_adapter()
+        with patch("ravn.adapters.discovery.k8s.k8s_client", None):
+            await adapter.start()  # should not raise
+
+    @pytest.mark.asyncio
+    async def test_stop_noop_when_not_started(self) -> None:
+        adapter = self._make_adapter()
+        await adapter.stop()  # no error
+
+
+# ---------------------------------------------------------------------------
+# CompositeDiscoveryAdapter tests
+# ---------------------------------------------------------------------------
+
+
+class _FakeBackend:
+    """Minimal fake DiscoveryPort for composite tests."""
+
+    def __init__(self, peer_table: dict | None = None) -> None:
+        self._peers_table: dict[str, RavnPeer] = peer_table or {}
+        self._on_join: list[Any] = []
+        self._on_leave: list[Any] = []
+        self.started = False
+        self.stopped = False
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+    async def announce(self) -> None:
+        pass
+
+    async def scan(self) -> list[RavnCandidate]:
+        return []
+
+    async def watch(self, on_join: Any, on_leave: Any) -> None:
+        self._on_join.append(on_join)
+        self._on_leave.append(on_leave)
+
+    async def handshake(self, candidate: RavnCandidate) -> RavnPeer | None:
+        return None
+
+    def peers(self) -> dict[str, RavnPeer]:
+        return dict(self._peers_table)
+
+    async def own_identity(self) -> RavnIdentity:
+        return _make_identity()
+
+    def fire_join(self, peer: RavnPeer) -> None:
+        for cb in self._on_join:
+            cb(peer)
+
+    def fire_leave(self, peer: RavnPeer) -> None:
+        for cb in self._on_leave:
+            cb(peer)
+
+
+class TestCompositeDiscoveryAdapter:
+    @pytest.mark.asyncio
+    async def test_start_starts_all_backends(self) -> None:
+        b1, b2 = _FakeBackend(), _FakeBackend()
+        comp = CompositeDiscoveryAdapter(backends=[b1, b2])
+        await comp.start()
+        assert b1.started and b2.started
+
+    @pytest.mark.asyncio
+    async def test_stop_stops_all_backends(self) -> None:
+        b1, b2 = _FakeBackend(), _FakeBackend()
+        comp = CompositeDiscoveryAdapter(backends=[b1, b2])
+        await comp.start()
+        await comp.stop()
+        assert b1.stopped and b2.stopped
+
+    @pytest.mark.asyncio
+    async def test_peers_merges_backends(self) -> None:
+        peer_a = _make_peer("peer-a")
+        peer_b = _make_peer("peer-b")
+        b1 = _FakeBackend({"peer-a": peer_a})
+        b2 = _FakeBackend({"peer-b": peer_b})
+        comp = CompositeDiscoveryAdapter(backends=[b1, b2])
+        merged = comp.peers()
+        assert "peer-a" in merged
+        assert "peer-b" in merged
+
+    @pytest.mark.asyncio
+    async def test_watch_fires_on_join(self) -> None:
+        b1 = _FakeBackend()
+        comp = CompositeDiscoveryAdapter(backends=[b1])
+        await comp.start()
+
+        joins: list[RavnPeer] = []
+        await comp.watch(on_join=joins.append, on_leave=lambda _: None)
+
+        peer = _make_peer("peer-x")
+        b1.fire_join(peer)
+
+        assert len(joins) == 1
+        assert joins[0].peer_id == "peer-x"
+
+    @pytest.mark.asyncio
+    async def test_watch_fires_on_leave(self) -> None:
+        b1 = _FakeBackend()
+        comp = CompositeDiscoveryAdapter(backends=[b1])
+        await comp.start()
+
+        leaves: list[RavnPeer] = []
+        await comp.watch(on_join=lambda _: None, on_leave=leaves.append)
+
+        peer = _make_peer("peer-x")
+        b1.fire_join(peer)  # join first
+        b1.fire_leave(peer)
+
+        assert len(leaves) == 1
+        assert leaves[0].peer_id == "peer-x"
+
+    @pytest.mark.asyncio
+    async def test_join_fires_once_per_peer(self) -> None:
+        """A peer seen by two backends should only fire on_join once."""
+        b1, b2 = _FakeBackend(), _FakeBackend()
+        comp = CompositeDiscoveryAdapter(backends=[b1, b2])
+        await comp.start()
+
+        joins: list[RavnPeer] = []
+        await comp.watch(on_join=joins.append, on_leave=lambda _: None)
+
+        peer = _make_peer("peer-x")
+        b1.fire_join(peer)
+        b2.fire_join(peer)
+
+        assert len(joins) == 1  # only fires once
+
+    @pytest.mark.asyncio
+    async def test_leave_fires_when_last_backend_drops(self) -> None:
+        b1, b2 = _FakeBackend(), _FakeBackend()
+        comp = CompositeDiscoveryAdapter(backends=[b1, b2])
+        await comp.start()
+
+        leaves: list[RavnPeer] = []
+        await comp.watch(on_join=lambda _: None, on_leave=leaves.append)
+
+        peer = _make_peer("peer-x")
+        b1.fire_join(peer)
+        b2.fire_join(peer)
+        b1.fire_leave(peer)  # one backend drops — NOT a leave yet
+        assert len(leaves) == 0
+
+        b2.fire_leave(peer)  # second backend drops — now leave fires
+        assert len(leaves) == 1
+
+    @pytest.mark.asyncio
+    async def test_scan_deduplicates_by_peer_id(self) -> None:
+        cand = _make_candidate("peer-x")
+
+        class ScanBackend(_FakeBackend):
+            async def scan(self) -> list[RavnCandidate]:
+                return [cand]
+
+        b1, b2 = ScanBackend(), ScanBackend()
+        comp = CompositeDiscoveryAdapter(backends=[b1, b2])
+        results = await comp.scan()
+        assert len(results) == 1
+        assert results[0].peer_id == "peer-x"
+
+    @pytest.mark.asyncio
+    async def test_own_identity_from_first_backend(self) -> None:
+        b1 = _FakeBackend()
+        comp = CompositeDiscoveryAdapter(backends=[b1])
+        ident = await comp.own_identity()
+        assert ident.peer_id == "peer-a"
+
+    @pytest.mark.asyncio
+    async def test_own_identity_raises_with_no_backends(self) -> None:
+        comp = CompositeDiscoveryAdapter(backends=[])
+        with pytest.raises(RuntimeError):
+            await comp.own_identity()
+
+    @pytest.mark.asyncio
+    async def test_announce_calls_all_backends(self) -> None:
+        announced: list[str] = []
+
+        class AnnBackend(_FakeBackend):
+            async def announce(self) -> None:
+                announced.append("x")
+
+        b1, b2 = AnnBackend(), AnnBackend()
+        comp = CompositeDiscoveryAdapter(backends=[b1, b2])
+        await comp.announce()
+        assert len(announced) == 2
+
+
+# ---------------------------------------------------------------------------
+# Capability routing test (NIU-435 cascade use case)
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilityRouting:
+    def test_filter_idle_bash_capable_verified(self) -> None:
+        """Verify the cascade can filter peers by capability + status + trust."""
+        peers: dict[str, RavnPeer] = {
+            "a": _make_peer("a", trust_level="verified", status="idle"),
+            "b": _make_peer("b", trust_level="verified", status="busy"),
+            "c": _make_peer("c", trust_level="unverified", status="idle"),
+        }
+        peers["a"].capabilities = ["bash", "file"]
+        peers["b"].capabilities = ["bash"]
+        peers["c"].capabilities = ["bash"]
+
+        workers = [
+            p
+            for p in peers.values()
+            if p.status == "idle" and "bash" in p.capabilities and p.trust_level == "verified"
+        ]
+        assert len(workers) == 1
+        assert workers[0].peer_id == "a"
+
+
+# ---------------------------------------------------------------------------
+# Integration test: two in-process mDNS adapters (mock handshake)
+# ---------------------------------------------------------------------------
+
+
+class TestInProcessDiscovery:
+    """Two MdnsDiscoveryAdapters sharing the same realm key — simulated discovery."""
+
+    @pytest.mark.asyncio
+    async def test_add_peer_and_watch_callback(self) -> None:
+        """Direct peer table manipulation simulates a successful discovery cycle."""
+        config = _make_discovery_config()
+        realm_key = b"shared-secret-key-32-bytes-long!"
+        identity_a = _make_identity("peer-a")
+        identity_b = _make_identity("peer-b")
+
+        adapter_a = MdnsDiscoveryAdapter(config=config, own_identity=identity_a)
+        adapter_b = MdnsDiscoveryAdapter(config=config, own_identity=identity_b)
+        adapter_a._realm_key = realm_key
+        adapter_b._realm_key = realm_key
+
+        joins_a: list[RavnPeer] = []
+        await adapter_a.watch(on_join=joins_a.append, on_leave=lambda _: None)
+
+        # Simulate B announcing and A successfully verifying
+        peer_b = RavnPeer(
+            peer_id="peer-b",
+            realm_id=realm_id_from_key(realm_key),
+            persona="test-agent",
+            capabilities=["bash"],
+            permission_mode="workspace_write",
+            version="0.1.0",
+            rep_address="tcp://127.0.0.1:7491",
+            pub_address="tcp://127.0.0.1:7490",
+            trust_level="verified",
+            first_seen=datetime.now(UTC),
+            last_seen=datetime.now(UTC),
+            last_heartbeat=datetime.now(UTC),
+        )
+        adapter_a._add_peer(peer_b)
+
+        assert "peer-b" in adapter_a.peers()
+        assert len(joins_a) == 1
+        assert joins_a[0].peer_id == "peer-b"
+
+    @pytest.mark.asyncio
+    async def test_peers_dict_shape_for_mesh_adapter(self) -> None:
+        """peers() returns dict[str, RavnPeer] with rep_address and pub_address."""
+        config = _make_discovery_config()
+        adapter = MdnsDiscoveryAdapter(config=config, own_identity=_make_identity())
+        peer = _make_peer("peer-b")
+        adapter._peers["peer-b"] = peer
+
+        table = adapter.peers()
+        assert isinstance(table, dict)
+        assert "peer-b" in table
+        found = table["peer-b"]
+        assert found.rep_address == "tcp://127.0.0.1:7491"
+        assert found.pub_address == "tcp://127.0.0.1:7490"
+        assert found.status in ("idle", "busy")
+        assert isinstance(found.task_count, int)


### PR DESCRIPTION
## Summary

Implements the full peer discovery stack for Ravn flocks (NIU-538). This is orthogonal to the mesh transport (NIU-517) — it covers *how peers find each other and prove realm membership* before any message is exchanged.

- **`RavnCandidate` / `RavnIdentity` / `RavnPeer`** domain models added to `domain/models.py`
  - `RavnPeer` has `rep_address`, `pub_address` (satisfying existing `NngMeshAdapter` / `SleipnirMeshAdapter` lookup requirements)
  - `status` (`idle|busy`) and `task_count` fields for NIU-435 cascade routing
- **`DiscoveryPort`** protocol in `ports/discovery.py`
  - `peers()` is synchronous (returns cached dict) — matches existing mesh adapter call sites
  - All other methods are async
- **Identity persistence** (`adapters/discovery/_identity.py`)
  - `peer_id` as stable UUID in `~/.ravn/peer_id`
  - `realm.key` as 32-byte random secret in `~/.ravn/realm.key`
  - `realm_id_hash()` — SHA-256(key)[:16] for announcements (raw secret never transmitted)
- **mDNS adapter** (`adapters/discovery/mdns.py`)
  - `_ravn._tcp.local` service registration with TXT records (`realm_id`, `rep_addr`, `pub_addr`, `handshake_port`)
  - HMAC-SHA256 challenge-response handshake over nng PAIR socket
  - Heartbeat every 30s, peer eviction after 90s (3 missed heartbeats)
  - Cross-realm peers silently ignored (DEBUG log only)
- **Sleipnir adapter** (`adapters/discovery/sleipnir.py`)
  - `ravn.mesh.announce` pub/sub with join/heartbeat/leave actions
  - SPIFFE JWT-SVID validation (gracefully skips when `SPIFFE_TRUST_DOMAIN` unset)
  - 5s cold-start convergence wait
- **K8s adapter** (`adapters/discovery/k8s.py`)
  - Lists pods with `ravn.niuu.world/realm=<realm_id>` label selector
  - Reads peer identity from pod annotations
  - Trust delegated to K8s RBAC + SPIFFE, no handshake required
- **Composite adapter** (`adapters/discovery/composite.py`)
  - Merges peer tables from multiple backends
  - `on_join` fires once per unique `peer_id`, `on_leave` fires when last backend drops the peer
- **`DiscoveryConfig`** added to `config.py` with sensible defaults
- **`ravn peers`** CLI command with `--verbose` and `--scan` flags
- **83 unit tests** covering all adapters, HMAC protocol, capability routing, and in-process integration

## Test plan

- [x] All 83 discovery tests pass
- [x] Full ravn test suite passes (86.28% coverage, above 85% threshold)
- [x] `ruff check` clean on all new/modified files
- [x] Pre-existing `test_plugin.py::test_tui_pages_returns_agents_page` failure confirmed unrelated (missing `textual` dependency in CI env)
- [x] `peers()` returns `dict[str, RavnPeer]` satisfying `NngMeshAdapter._resolve_peer_rep_address()` and `SleipnirMeshAdapter._assert_peer_trusted()` call sites

Closes NIU-538

🤖 Generated with [Claude Code](https://claude.com/claude-code)