### PR TITLE
feat(cascade): sub-agent stuck detection and replan watchdog (NIU-510)

### DIFF
--- a/src/ravn/cascade/__init__.py
+++ b/src/ravn/cascade/__init__.py
@@ -1,0 +1,1 @@
+"""Cascade sub-system — watchdog and coordination helpers (NIU-510)."""

--- a/src/ravn/cascade/watchdog.py
+++ b/src/ravn/cascade/watchdog.py
@@ -43,7 +43,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import socket
 import time
 from collections import deque
 from collections.abc import Awaitable, Callable
@@ -58,6 +57,12 @@ from ravn.ports.channel import ChannelPort
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
+# Strategy type — defined before constants so the annotation is valid
+# ---------------------------------------------------------------------------
+
+OnStuckStrategy = Literal["retry", "replan", "escalate", "abort"]
+
+# ---------------------------------------------------------------------------
 # Constants — overridden by CascadeConfig when wired through build_cascade_tools
 # ---------------------------------------------------------------------------
 
@@ -66,8 +71,6 @@ _DEFAULT_LOOP_THRESHOLD: int = 3
 _DEFAULT_ON_STUCK: OnStuckStrategy = "replan"
 _DEFAULT_MAX_RETRIES: int = 2
 _DEFAULT_POLL_INTERVAL_S: float = 5.0
-
-OnStuckStrategy = Literal["retry", "replan", "escalate", "abort"]
 
 
 # ---------------------------------------------------------------------------
@@ -317,11 +320,21 @@ async def _emit_task_stuck_event(
     task_id: str,
     reason: StuckReason,
     channel: ChannelPort,
+    *,
+    source: str,
 ) -> None:
-    """Emit a ``ravn.task.stuck`` event to *channel*."""
+    """Emit a ``ravn.task.stuck`` event to *channel*.
+
+    Parameters
+    ----------
+    source:
+        Agent identifier forwarded to :attr:`RavnEvent.source`.  Callers
+        should pass a stable agent ID rather than resolving the hostname here
+        so the value stays consistent across the lifetime of the agent.
+    """
     event = RavnEvent(
         type=RavnEventType.TASK_STUCK,
-        source=socket.gethostname(),
+        source=source,
         payload={"task_id": task_id, "reason": str(reason)},
         timestamp=datetime.now(UTC),
         urgency=0.9,
@@ -335,6 +348,7 @@ async def _emit_task_stuck_event(
 def build_stuck_handler(
     config: WatchdogConfig,
     *,
+    source: str = "watchdog",
     cancel_fn: Callable[[], Awaitable[None]] | None = None,
     escalate_channel: ChannelPort | None = None,
     replan_callback: Callable[[str, StuckReason], Awaitable[None]] | None = None,
@@ -354,6 +368,10 @@ def build_stuck_handler(
     ----------
     config:
         Watchdog configuration (determines the active strategy).
+    source:
+        Agent identifier forwarded to the ``ravn.task.stuck`` event's
+        ``source`` field.  Defaults to ``"watchdog"``; callers should pass
+        the agent's stable ID (e.g. hostname or peer_id).
     cancel_fn:
         Async callable that stops/cancels the monitored task.  All strategies
         call this; pass ``None`` only in tests where cancellation is a no-op.
@@ -370,7 +388,7 @@ def build_stuck_handler(
 
         if strategy == "escalate":
             if escalate_channel is not None:
-                await _emit_task_stuck_event(task_id, reason, escalate_channel)
+                await _emit_task_stuck_event(task_id, reason, escalate_channel, source=source)
             else:
                 logger.warning(
                     "watchdog: escalate strategy but no escalate_channel configured"

--- a/src/ravn/cascade/watchdog.py
+++ b/src/ravn/cascade/watchdog.py
@@ -1,0 +1,387 @@
+"""Sub-agent stuck detection and replan watchdog (NIU-510).
+
+The watchdog monitors a sub-agent task for progress and detects three stuck
+conditions:
+
+1. **Timeout** — no event emitted for > ``stuck_timeout_s`` seconds.
+2. **Loop**    — same tool called with identical args >= ``loop_detection_threshold``
+                 times consecutively.
+3. **Budget**  — task exceeded its iteration budget (reserved for future use).
+
+When stuck is detected the configured ``on_stuck`` strategy determines the
+response:
+
+* ``retry``    — cancel the task and restart it (up to ``max_retries`` times).
+* ``replan``   — invoke the replan callback so the orchestrator can rewrite the
+                 task description, then cancel.
+* ``escalate`` — emit a ``ravn.task.stuck`` event on the configured channel and
+                 cancel.
+* ``abort``    — cancel immediately; the cascade continues with remaining tasks.
+
+Usage
+-----
+::
+
+    watchdog = TaskWatchdog(task_id="task_001", config=WatchdogConfig())
+    channel  = WatchdogChannelWrapper(inner_channel, watchdog)
+
+    handler  = build_stuck_handler(
+        config=watchdog.config,
+        cancel_fn=lambda: drive_loop.cancel(task_id),
+        escalate_channel=sleipnir_channel,
+    )
+    outcome  = await watchdog.run(
+        is_done=lambda: drive_loop.task_status(task_id) == "unknown",
+        on_stuck=handler,
+    )
+
+Depends on NIU-435 (cascade system) and NIU-438 (Sleipnir event publishing).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import socket
+import time
+from collections import deque
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Literal
+
+from ravn.domain.events import RavnEvent, RavnEventType
+from ravn.ports.channel import ChannelPort
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants — overridden by CascadeConfig when wired through build_cascade_tools
+# ---------------------------------------------------------------------------
+
+_DEFAULT_STUCK_TIMEOUT_S: float = 60.0
+_DEFAULT_LOOP_THRESHOLD: int = 3
+_DEFAULT_ON_STUCK: OnStuckStrategy = "replan"
+_DEFAULT_MAX_RETRIES: int = 2
+_DEFAULT_POLL_INTERVAL_S: float = 5.0
+
+OnStuckStrategy = Literal["retry", "replan", "escalate", "abort"]
+
+
+# ---------------------------------------------------------------------------
+# Domain types
+# ---------------------------------------------------------------------------
+
+
+class StuckReason(StrEnum):
+    """The cause of a stuck detection."""
+
+    TIMEOUT = "timeout"
+    LOOP = "loop"
+    BUDGET = "budget"
+
+
+@dataclass
+class WatchdogConfig:
+    """Configuration for stuck detection on a single sub-agent task.
+
+    All timing values are in seconds.  This mirrors the fields added to
+    ``CascadeConfig`` so that per-task overrides can be threaded down from
+    YAML without coupling to pydantic.
+    """
+
+    stuck_timeout_s: float = _DEFAULT_STUCK_TIMEOUT_S
+    loop_detection_threshold: int = _DEFAULT_LOOP_THRESHOLD
+    on_stuck: OnStuckStrategy = _DEFAULT_ON_STUCK
+    max_retries: int = _DEFAULT_MAX_RETRIES
+    poll_interval_s: float = _DEFAULT_POLL_INTERVAL_S
+
+
+@dataclass
+class WatchdogOutcome:
+    """Describes what the watchdog observed over a task's lifetime."""
+
+    task_id: str
+    # None means the task completed normally without triggering the watchdog.
+    reason: StuckReason | None
+    retry_count: int
+    # None when the task completed normally.
+    action_taken: OnStuckStrategy | None
+
+
+# ---------------------------------------------------------------------------
+# TaskWatchdog
+# ---------------------------------------------------------------------------
+
+
+class TaskWatchdog:
+    """Monitors a sub-agent task for stuck conditions.
+
+    The watchdog runs as a concurrent asyncio task alongside the monitored
+    agent.  It is notified of events via :meth:`record_event`; typically a
+    :class:`WatchdogChannelWrapper` calls this automatically.
+
+    Parameters
+    ----------
+    task_id:
+        Stable identifier of the task being monitored.  Used in log messages
+        and in the ``WatchdogOutcome``.
+    config:
+        Watchdog tuning; defaults to ``WatchdogConfig()`` when omitted.
+    """
+
+    def __init__(
+        self,
+        task_id: str,
+        config: WatchdogConfig | None = None,
+    ) -> None:
+        self._task_id = task_id
+        self._config: WatchdogConfig = config or WatchdogConfig()
+        self._last_event_at: float = time.monotonic()
+        # Fixed-size deque: automatically discards entries older than the
+        # threshold so we only keep the most recent N tool calls.
+        self._recent_tool_calls: deque[tuple[str, str]] = deque(
+            maxlen=self._config.loop_detection_threshold
+        )
+        self._loop_detected: bool = False
+        self._retry_count: int = 0
+
+    # ------------------------------------------------------------------
+    # Public properties
+    # ------------------------------------------------------------------
+
+    @property
+    def config(self) -> WatchdogConfig:
+        return self._config
+
+    @property
+    def task_id(self) -> str:
+        return self._task_id
+
+    # ------------------------------------------------------------------
+    # Event notification
+    # ------------------------------------------------------------------
+
+    def record_event(self, event: RavnEvent) -> None:
+        """Record an event emitted by the monitored sub-agent.
+
+        Updates the last-event timestamp and checks for tool-call loops.
+        Safe to call from any coroutine — no I/O, no blocking.
+        """
+        self._last_event_at = time.monotonic()
+
+        if event.type != RavnEventType.TOOL_START:
+            return
+
+        tool_name = event.payload.get("tool_name", "")
+        tool_input_key = json.dumps(event.payload.get("input", {}), sort_keys=True)
+        call_key = (tool_name, tool_input_key)
+
+        self._recent_tool_calls.append(call_key)
+
+        threshold = self._config.loop_detection_threshold
+        if len(self._recent_tool_calls) == threshold and len(set(self._recent_tool_calls)) == 1:
+            self._loop_detected = True
+            logger.warning(
+                "watchdog: task %s — loop detected (%s called %d× with identical args)",
+                self._task_id,
+                tool_name,
+                threshold,
+            )
+
+    def seconds_since_last_event(self) -> float:
+        """Elapsed seconds since the last event from the sub-agent."""
+        return time.monotonic() - self._last_event_at
+
+    # ------------------------------------------------------------------
+    # Monitor loop
+    # ------------------------------------------------------------------
+
+    async def run(
+        self,
+        is_done: Callable[[], bool],
+        on_stuck: Callable[[StuckReason, str, int], Awaitable[None]],
+    ) -> WatchdogOutcome:
+        """Monitor the task until it completes or a stuck condition fires.
+
+        Parameters
+        ----------
+        is_done:
+            Zero-argument predicate that returns ``True`` once the task has
+            finished (e.g. ``drive_loop.task_status(task_id) == "unknown"``).
+        on_stuck:
+            Async callback invoked when stuck is detected.
+            Signature: ``(reason, task_id, retry_count) -> None``.
+
+        Returns
+        -------
+        WatchdogOutcome
+            Clean completion has ``reason=None``; stuck detection sets the
+            reason and the action that was taken.
+        """
+        while not is_done():
+            await asyncio.sleep(self._config.poll_interval_s)
+
+            if is_done():
+                break
+
+            reason = self._check_stuck()
+            if reason is None:
+                continue
+
+            self._retry_count += 1
+            logger.warning(
+                "watchdog: task %s stuck (reason=%s, attempt=%d/%d, strategy=%s)",
+                self._task_id,
+                reason,
+                self._retry_count,
+                self._config.max_retries,
+                self._config.on_stuck,
+            )
+            await on_stuck(reason, self._task_id, self._retry_count)
+
+            strategy = self._config.on_stuck
+            if strategy == "retry" and self._retry_count < self._config.max_retries:
+                # Reset state and keep watching; caller has restarted the task.
+                self._loop_detected = False
+                self._last_event_at = time.monotonic()
+                self._recent_tool_calls.clear()
+                continue
+
+            return WatchdogOutcome(
+                task_id=self._task_id,
+                reason=reason,
+                retry_count=self._retry_count,
+                action_taken=strategy,
+            )
+
+        return WatchdogOutcome(
+            task_id=self._task_id,
+            reason=None,
+            retry_count=self._retry_count,
+            action_taken=None,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _check_stuck(self) -> StuckReason | None:
+        """Return a ``StuckReason`` if a condition is active, else ``None``."""
+        if self._loop_detected:
+            return StuckReason.LOOP
+
+        if self.seconds_since_last_event() > self._config.stuck_timeout_s:
+            return StuckReason.TIMEOUT
+
+        return None
+
+
+# ---------------------------------------------------------------------------
+# WatchdogChannelWrapper
+# ---------------------------------------------------------------------------
+
+
+class WatchdogChannelWrapper(ChannelPort):
+    """Wraps a :class:`~ravn.ports.channel.ChannelPort` and notifies a watchdog.
+
+    Place this around the channel passed to an agent so that every emitted
+    event is transparently forwarded *and* recorded by the watchdog.
+
+    Parameters
+    ----------
+    inner:
+        The real output channel (CLI, web-socket, Sleipnir, …).
+    watchdog:
+        The :class:`TaskWatchdog` instance monitoring the same task.
+    """
+
+    def __init__(self, inner: ChannelPort, watchdog: TaskWatchdog) -> None:
+        self._inner = inner
+        self._watchdog = watchdog
+
+    async def emit(self, event: RavnEvent) -> None:
+        """Record the event with the watchdog then forward to the inner channel."""
+        self._watchdog.record_event(event)
+        await self._inner.emit(event)
+
+
+# ---------------------------------------------------------------------------
+# Strategy handler factory
+# ---------------------------------------------------------------------------
+
+
+async def _emit_task_stuck_event(
+    task_id: str,
+    reason: StuckReason,
+    channel: ChannelPort,
+) -> None:
+    """Emit a ``ravn.task.stuck`` event to *channel*."""
+    event = RavnEvent(
+        type=RavnEventType.TASK_STUCK,
+        source=socket.gethostname(),
+        payload={"task_id": task_id, "reason": str(reason)},
+        timestamp=datetime.now(UTC),
+        urgency=0.9,
+        correlation_id=task_id,
+        session_id="",
+        task_id=task_id,
+    )
+    await channel.emit(event)
+
+
+def build_stuck_handler(
+    config: WatchdogConfig,
+    *,
+    cancel_fn: Callable[[], Awaitable[None]] | None = None,
+    escalate_channel: ChannelPort | None = None,
+    replan_callback: Callable[[str, StuckReason], Awaitable[None]] | None = None,
+) -> Callable[[StuckReason, str, int], Awaitable[None]]:
+    """Build the ``on_stuck`` callback for :meth:`TaskWatchdog.run`.
+
+    The returned callable executes the strategy named by ``config.on_stuck``:
+
+    * ``retry``    — calls ``cancel_fn`` so the caller can restart the task.
+    * ``replan``   — calls ``replan_callback(task_id, reason)`` then
+                     ``cancel_fn``.
+    * ``escalate`` — emits a ``ravn.task.stuck`` event on ``escalate_channel``
+                     then calls ``cancel_fn``.
+    * ``abort``    — calls ``cancel_fn``; cascade continues with other tasks.
+
+    Parameters
+    ----------
+    config:
+        Watchdog configuration (determines the active strategy).
+    cancel_fn:
+        Async callable that stops/cancels the monitored task.  All strategies
+        call this; pass ``None`` only in tests where cancellation is a no-op.
+    escalate_channel:
+        Channel for emitting the stuck event.  Required for the ``escalate``
+        strategy; ignored otherwise.
+    replan_callback:
+        Async callable invoked with ``(task_id, reason)`` for the ``replan``
+        strategy; ignored otherwise.
+    """
+
+    async def handler(reason: StuckReason, task_id: str, retry_count: int) -> None:  # noqa: ARG001
+        strategy = config.on_stuck
+
+        if strategy == "escalate":
+            if escalate_channel is not None:
+                await _emit_task_stuck_event(task_id, reason, escalate_channel)
+            else:
+                logger.warning(
+                    "watchdog: escalate strategy but no escalate_channel configured"
+                    " for task %s — falling back to abort",
+                    task_id,
+                )
+
+        if strategy == "replan" and replan_callback is not None:
+            await replan_callback(task_id, reason)
+
+        if cancel_fn is not None:
+            await cancel_fn()
+
+    return handler

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -1097,7 +1097,7 @@ class CascadeConfig(BaseModel):
         default=3,
         description="Number of consecutive identical tool calls that trigger loop detection.",
     )
-    on_stuck: str = Field(
+    on_stuck: Literal["retry", "replan", "escalate", "abort"] = Field(
         default="replan",
         description="Strategy on stuck detection: retry | replan | escalate | abort.",
     )

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -1089,6 +1089,22 @@ class CascadeConfig(BaseModel):
         default=30.0,
         description="Timeout for mesh.send() during task delegation.",
     )
+    stuck_timeout_seconds: int = Field(
+        default=60,
+        description="Seconds of inactivity before a sub-agent is considered stuck.",
+    )
+    loop_detection_threshold: int = Field(
+        default=3,
+        description="Number of consecutive identical tool calls that trigger loop detection.",
+    )
+    on_stuck: str = Field(
+        default="replan",
+        description="Strategy when a stuck sub-agent is detected: retry | replan | escalate | abort.",
+    )
+    max_retries: int = Field(
+        default=2,
+        description="Maximum retry attempts before giving up (used with on_stuck=retry).",
+    )
 
 
 class LoggingConfig(BaseModel):

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -1099,7 +1099,7 @@ class CascadeConfig(BaseModel):
     )
     on_stuck: str = Field(
         default="replan",
-        description="Strategy when a stuck sub-agent is detected: retry | replan | escalate | abort.",
+        description="Strategy on stuck detection: retry | replan | escalate | abort.",
     )
     max_retries: int = Field(
         default=2,

--- a/src/ravn/domain/events.py
+++ b/src/ravn/domain/events.py
@@ -16,6 +16,7 @@ class RavnEventType(StrEnum):
     DECISION = "decision"
     TASK_COMPLETE = "task_complete"
     TASK_STARTED = "task_started"  # emitted by DriveLoop when a task begins execution
+    TASK_STUCK = "task_stuck"  # emitted by Watchdog on stuck detection (NIU-510)
 
 
 @dataclass(frozen=True)
@@ -24,11 +25,11 @@ class RavnEvent:
 
     # THOUGHT, TOOL_START, TOOL_RESULT, RESPONSE, ERROR, DECISION, TASK_COMPLETE, TASK_STARTED
     type: RavnEventType
-    source: str               # Agent instance ID
-    payload: dict             # Event-specific data
-    timestamp: datetime       # ISO8601 timestamp
-    urgency: float            # 0.0-1.0 (hint for Valkyrie attention model)
-    correlation_id: str       # Groups related events
+    source: str  # Agent instance ID
+    payload: dict  # Event-specific data
+    timestamp: datetime  # ISO8601 timestamp
+    urgency: float  # 0.0-1.0 (hint for Valkyrie attention model)
+    correlation_id: str  # Groups related events
     session_id: str
     task_id: str | None = None  # If from a sub-ravn
 
@@ -122,7 +123,11 @@ class RavnEvent:
 
     @classmethod
     def response(
-        cls, source: str, text: str, correlation_id: str, session_id: str,
+        cls,
+        source: str,
+        text: str,
+        correlation_id: str,
+        session_id: str,
         task_id: str | None = None,
     ) -> RavnEvent:
         return cls(
@@ -138,7 +143,11 @@ class RavnEvent:
 
     @classmethod
     def error(
-        cls, source: str, message: str, correlation_id: str, session_id: str,
+        cls,
+        source: str,
+        message: str,
+        correlation_id: str,
+        session_id: str,
         task_id: str | None = None,
     ) -> RavnEvent:
         return cls(
@@ -154,7 +163,11 @@ class RavnEvent:
 
     @classmethod
     def decision_required(
-        cls, source: str, prompt: str, correlation_id: str, session_id: str,
+        cls,
+        source: str,
+        prompt: str,
+        correlation_id: str,
+        session_id: str,
         task_id: str | None = None,
     ) -> RavnEvent:
         return cls(
@@ -185,7 +198,11 @@ class RavnEvent:
 
     @classmethod
     def task_complete(
-        cls, source: str, success: bool, correlation_id: str, session_id: str,
+        cls,
+        source: str,
+        success: bool,
+        correlation_id: str,
+        session_id: str,
         task_id: str | None = None,
     ) -> RavnEvent:
         return cls(

--- a/tests/test_ravn/test_events.py
+++ b/tests/test_ravn/test_events.py
@@ -22,7 +22,7 @@ class TestRavnEventType:
         assert RavnEventType.TASK_COMPLETE == "task_complete"
 
     def test_member_count(self) -> None:
-        assert len(RavnEventType) == 8
+        assert len(RavnEventType) == 9
 
 
 class TestRavnEvent:

--- a/tests/test_ravn/test_watchdog.py
+++ b/tests/test_ravn/test_watchdog.py
@@ -1,0 +1,543 @@
+"""Tests for NIU-510 — sub-agent stuck detection watchdog.
+
+Coverage targets:
+- WatchdogConfig defaults
+- TaskWatchdog.record_event: timestamp reset, loop detection
+- TaskWatchdog.run: clean completion, timeout, loop, budget (reserved)
+- TaskWatchdog.run: retry strategy resets state and continues
+- TaskWatchdog.run: abort/replan/escalate each exit after one detection
+- WatchdogChannelWrapper: forwards events to inner channel and watchdog
+- build_stuck_handler: all four strategies (retry, replan, escalate, abort)
+- _emit_task_stuck_event: emits TASK_STUCK event with correct payload
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ravn.cascade.watchdog import (
+    StuckReason,
+    TaskWatchdog,
+    WatchdogChannelWrapper,
+    WatchdogConfig,
+    WatchdogOutcome,
+    build_stuck_handler,
+)
+from ravn.domain.events import RavnEvent, RavnEventType
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _tool_start_event(tool_name: str, tool_input: dict | None = None) -> RavnEvent:
+    payload: dict = {"tool_name": tool_name, "input": tool_input or {}}
+    return RavnEvent(
+        type=RavnEventType.TOOL_START,
+        source="test-agent",
+        payload=payload,
+        timestamp=MagicMock(),
+        urgency=0.1,
+        correlation_id="cid-1",
+        session_id="sid-1",
+        task_id="task_001",
+    )
+
+
+def _other_event(event_type: RavnEventType = RavnEventType.THOUGHT) -> RavnEvent:
+    return RavnEvent(
+        type=event_type,
+        source="test-agent",
+        payload={"text": "thinking"},
+        timestamp=MagicMock(),
+        urgency=0.1,
+        correlation_id="cid-1",
+        session_id="sid-1",
+        task_id="task_001",
+    )
+
+
+def _fast_config(**kwargs) -> WatchdogConfig:
+    """Return a WatchdogConfig with a tiny poll_interval for tests."""
+    defaults = {"poll_interval_s": 0.01, "stuck_timeout_s": 0.05}
+    defaults.update(kwargs)
+    return WatchdogConfig(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# WatchdogConfig
+# ---------------------------------------------------------------------------
+
+
+class TestWatchdogConfig:
+    def test_defaults(self):
+        cfg = WatchdogConfig()
+        assert cfg.stuck_timeout_s == 60.0
+        assert cfg.loop_detection_threshold == 3
+        assert cfg.on_stuck == "replan"
+        assert cfg.max_retries == 2
+        assert cfg.poll_interval_s == 5.0
+
+    def test_custom_values(self):
+        cfg = WatchdogConfig(
+            stuck_timeout_s=30.0,
+            loop_detection_threshold=5,
+            on_stuck="abort",
+            max_retries=0,
+            poll_interval_s=1.0,
+        )
+        assert cfg.stuck_timeout_s == 30.0
+        assert cfg.loop_detection_threshold == 5
+        assert cfg.on_stuck == "abort"
+        assert cfg.max_retries == 0
+        assert cfg.poll_interval_s == 1.0
+
+
+# ---------------------------------------------------------------------------
+# TaskWatchdog.record_event
+# ---------------------------------------------------------------------------
+
+
+class TestRecordEvent:
+    def test_non_tool_start_resets_timestamp(self):
+        watchdog = TaskWatchdog("task_001", WatchdogConfig())
+        old_time = watchdog._last_event_at
+        watchdog.record_event(_other_event())
+        assert watchdog._last_event_at >= old_time
+
+    def test_tool_start_resets_timestamp(self):
+        watchdog = TaskWatchdog("task_001", WatchdogConfig())
+        old_time = watchdog._last_event_at
+        watchdog.record_event(_tool_start_event("my_tool"))
+        assert watchdog._last_event_at >= old_time
+
+    def test_no_loop_with_different_inputs(self):
+        cfg = WatchdogConfig(loop_detection_threshold=3)
+        watchdog = TaskWatchdog("task_001", cfg)
+        watchdog.record_event(_tool_start_event("tool_a", {"x": 1}))
+        watchdog.record_event(_tool_start_event("tool_a", {"x": 2}))
+        watchdog.record_event(_tool_start_event("tool_a", {"x": 3}))
+        assert not watchdog._loop_detected
+
+    def test_loop_detected_same_tool_same_args(self):
+        cfg = WatchdogConfig(loop_detection_threshold=3)
+        watchdog = TaskWatchdog("task_001", cfg)
+        ev = _tool_start_event("grep", {"pattern": "foo"})
+        watchdog.record_event(ev)
+        watchdog.record_event(ev)
+        watchdog.record_event(ev)
+        assert watchdog._loop_detected
+
+    def test_loop_detection_threshold_2(self):
+        cfg = WatchdogConfig(loop_detection_threshold=2)
+        watchdog = TaskWatchdog("task_001", cfg)
+        ev = _tool_start_event("grep", {"pattern": "foo"})
+        watchdog.record_event(ev)
+        assert not watchdog._loop_detected
+        watchdog.record_event(ev)
+        assert watchdog._loop_detected
+
+    def test_loop_resets_after_different_tool(self):
+        cfg = WatchdogConfig(loop_detection_threshold=3)
+        watchdog = TaskWatchdog("task_001", cfg)
+        ev = _tool_start_event("grep", {"pattern": "foo"})
+        watchdog.record_event(ev)
+        watchdog.record_event(ev)
+        # Different tool breaks the streak
+        watchdog.record_event(_tool_start_event("cat", {}))
+        watchdog.record_event(ev)
+        # Only 1 × grep at the end — not a loop
+        assert not watchdog._loop_detected
+
+    def test_non_tool_start_does_not_affect_loop_counter(self):
+        cfg = WatchdogConfig(loop_detection_threshold=3)
+        watchdog = TaskWatchdog("task_001", cfg)
+        ev = _tool_start_event("grep", {"pattern": "foo"})
+        watchdog.record_event(ev)
+        watchdog.record_event(ev)
+        # A THOUGHT event does not break the consecutive run
+        watchdog.record_event(_other_event())
+        # Still only 2 tool_start events in the deque — not a loop
+        assert not watchdog._loop_detected
+
+    def test_seconds_since_last_event(self):
+        watchdog = TaskWatchdog("task_001", WatchdogConfig())
+        elapsed = watchdog.seconds_since_last_event()
+        assert elapsed >= 0.0
+
+
+# ---------------------------------------------------------------------------
+# TaskWatchdog.run — clean completion
+# ---------------------------------------------------------------------------
+
+
+class TestRunCleanCompletion:
+    @pytest.mark.asyncio
+    async def test_returns_no_reason_when_done_immediately(self):
+        watchdog = TaskWatchdog("task_001", _fast_config())
+        on_stuck = AsyncMock()
+
+        outcome = await watchdog.run(is_done=lambda: True, on_stuck=on_stuck)
+
+        assert outcome.reason is None
+        assert outcome.action_taken is None
+        assert outcome.retry_count == 0
+        on_stuck.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_returns_no_reason_when_done_after_one_poll(self):
+        cfg = _fast_config()
+        watchdog = TaskWatchdog("task_001", cfg)
+        done_flag = {"v": False}
+
+        async def complete_after_delay():
+            await asyncio.sleep(cfg.poll_interval_s * 1.5)
+            done_flag["v"] = True
+
+        on_stuck = AsyncMock()
+
+        # Inject events so timeout does not fire during the wait
+        async def emit_events():
+            for _ in range(10):
+                watchdog.record_event(_other_event())
+                await asyncio.sleep(cfg.poll_interval_s * 0.3)
+
+        outcome, *_ = await asyncio.gather(
+            watchdog.run(is_done=lambda: done_flag["v"], on_stuck=on_stuck),
+            complete_after_delay(),
+            emit_events(),
+        )
+
+        assert outcome.reason is None
+        on_stuck.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TaskWatchdog.run — timeout detection
+# ---------------------------------------------------------------------------
+
+
+class TestRunTimeout:
+    @pytest.mark.asyncio
+    async def test_timeout_fires_when_no_events(self):
+        cfg = _fast_config(stuck_timeout_s=0.02, on_stuck="abort")
+        watchdog = TaskWatchdog("task_001", cfg)
+        on_stuck = AsyncMock()
+
+        outcome = await watchdog.run(is_done=lambda: False, on_stuck=on_stuck)
+
+        assert outcome.reason == StuckReason.TIMEOUT
+        assert outcome.action_taken == "abort"
+        assert outcome.retry_count == 1
+        on_stuck.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_timeout_reason_and_task_id_passed_to_callback(self):
+        cfg = _fast_config(stuck_timeout_s=0.02, on_stuck="abort")
+        watchdog = TaskWatchdog("task_001", cfg)
+        captured: list = []
+
+        async def on_stuck(reason, task_id, retry_count):
+            captured.append((reason, task_id, retry_count))
+
+        await watchdog.run(is_done=lambda: False, on_stuck=on_stuck)
+
+        assert captured == [(StuckReason.TIMEOUT, "task_001", 1)]
+
+
+# ---------------------------------------------------------------------------
+# TaskWatchdog.run — loop detection
+# ---------------------------------------------------------------------------
+
+
+class TestRunLoopDetection:
+    @pytest.mark.asyncio
+    async def test_loop_fires_on_consecutive_calls(self):
+        cfg = _fast_config(loop_detection_threshold=3, on_stuck="abort")
+        watchdog = TaskWatchdog("task_001", cfg)
+        on_stuck = AsyncMock()
+
+        ev = _tool_start_event("grep", {"pattern": "foo"})
+        # Pre-trigger loop before run() starts
+        watchdog.record_event(ev)
+        watchdog.record_event(ev)
+        watchdog.record_event(ev)
+
+        outcome = await watchdog.run(is_done=lambda: False, on_stuck=on_stuck)
+
+        assert outcome.reason == StuckReason.LOOP
+        assert outcome.action_taken == "abort"
+        on_stuck.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_loop_reason_in_callback(self):
+        cfg = _fast_config(loop_detection_threshold=2, on_stuck="replan")
+        watchdog = TaskWatchdog("task_001", cfg)
+        captured: list = []
+
+        async def on_stuck(reason, task_id, retry_count):
+            captured.append(reason)
+
+        ev = _tool_start_event("write_file", {"path": "/tmp/x"})
+        watchdog.record_event(ev)
+        watchdog.record_event(ev)
+
+        await watchdog.run(is_done=lambda: False, on_stuck=on_stuck)
+
+        assert captured == [StuckReason.LOOP]
+
+
+# ---------------------------------------------------------------------------
+# TaskWatchdog.run — retry strategy
+# ---------------------------------------------------------------------------
+
+
+class TestRunRetryStrategy:
+    @pytest.mark.asyncio
+    async def test_retry_resets_state_and_continues(self):
+        cfg = _fast_config(
+            stuck_timeout_s=0.02,
+            on_stuck="retry",
+            max_retries=2,
+        )
+        watchdog = TaskWatchdog("task_001", cfg)
+        call_count = {"n": 0}
+
+        async def on_stuck(reason, task_id, retry_count):
+            call_count["n"] += 1
+            # After first retry simulate events arriving so timeout clears
+            if retry_count == 1:
+                watchdog.record_event(_other_event())
+
+        outcome = await asyncio.wait_for(
+            watchdog.run(is_done=lambda: False, on_stuck=on_stuck),
+            timeout=2.0,
+        )
+
+        assert outcome.action_taken == "retry"
+        assert outcome.retry_count == 2
+
+    @pytest.mark.asyncio
+    async def test_retry_exhausted_returns_outcome(self):
+        cfg = _fast_config(
+            stuck_timeout_s=0.02,
+            on_stuck="retry",
+            max_retries=1,
+        )
+        watchdog = TaskWatchdog("task_001", cfg)
+        on_stuck = AsyncMock()
+
+        outcome = await asyncio.wait_for(
+            watchdog.run(is_done=lambda: False, on_stuck=on_stuck),
+            timeout=2.0,
+        )
+
+        # max_retries=1 → fires once then exits (retry_count == max_retries)
+        assert outcome.retry_count == 1
+        assert outcome.action_taken == "retry"
+
+
+# ---------------------------------------------------------------------------
+# WatchdogChannelWrapper
+# ---------------------------------------------------------------------------
+
+
+class TestWatchdogChannelWrapper:
+    @pytest.mark.asyncio
+    async def test_forwards_event_to_inner_channel(self):
+        inner = AsyncMock()
+        watchdog = MagicMock(spec=TaskWatchdog)
+        wrapper = WatchdogChannelWrapper(inner, watchdog)
+
+        ev = _other_event()
+        await wrapper.emit(ev)
+
+        inner.emit.assert_awaited_once_with(ev)
+
+    @pytest.mark.asyncio
+    async def test_notifies_watchdog(self):
+        inner = AsyncMock()
+        watchdog = MagicMock(spec=TaskWatchdog)
+        wrapper = WatchdogChannelWrapper(inner, watchdog)
+
+        ev = _tool_start_event("grep", {})
+        await wrapper.emit(ev)
+
+        watchdog.record_event.assert_called_once_with(ev)
+
+    @pytest.mark.asyncio
+    async def test_watchdog_called_before_inner(self):
+        """record_event must be called before inner.emit so state is up to date."""
+        call_order: list[str] = []
+
+        class _OrderedMockChannel(AsyncMock):
+            async def emit(self, event):  # noqa: ANN001, ARG002
+                call_order.append("inner")
+
+        class _OrderedMockWatchdog:
+            def record_event(self, event):  # noqa: ANN001, ARG002
+                call_order.append("watchdog")
+
+        wrapper = WatchdogChannelWrapper(_OrderedMockChannel(), _OrderedMockWatchdog())
+        await wrapper.emit(_other_event())
+
+        assert call_order == ["watchdog", "inner"]
+
+
+# ---------------------------------------------------------------------------
+# build_stuck_handler
+# ---------------------------------------------------------------------------
+
+
+class TestBuildStuckHandler:
+    @pytest.mark.asyncio
+    async def test_abort_calls_cancel(self):
+        cfg = WatchdogConfig(on_stuck="abort")
+        cancel_fn = AsyncMock()
+        handler = build_stuck_handler(cfg, cancel_fn=cancel_fn)
+
+        await handler(StuckReason.TIMEOUT, "task_001", 1)
+
+        cancel_fn.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_retry_calls_cancel(self):
+        cfg = WatchdogConfig(on_stuck="retry")
+        cancel_fn = AsyncMock()
+        handler = build_stuck_handler(cfg, cancel_fn=cancel_fn)
+
+        await handler(StuckReason.TIMEOUT, "task_001", 1)
+
+        cancel_fn.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_replan_calls_callback_then_cancel(self):
+        cfg = WatchdogConfig(on_stuck="replan")
+        cancel_fn = AsyncMock()
+        replan_callback = AsyncMock()
+        handler = build_stuck_handler(cfg, cancel_fn=cancel_fn, replan_callback=replan_callback)
+
+        await handler(StuckReason.LOOP, "task_001", 1)
+
+        replan_callback.assert_awaited_once_with("task_001", StuckReason.LOOP)
+        cancel_fn.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_replan_without_callback_still_cancels(self):
+        cfg = WatchdogConfig(on_stuck="replan")
+        cancel_fn = AsyncMock()
+        handler = build_stuck_handler(cfg, cancel_fn=cancel_fn)
+
+        await handler(StuckReason.TIMEOUT, "task_001", 1)
+
+        cancel_fn.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_escalate_emits_event_then_cancels(self):
+        cfg = WatchdogConfig(on_stuck="escalate")
+        cancel_fn = AsyncMock()
+        escalate_channel = AsyncMock()
+        handler = build_stuck_handler(cfg, cancel_fn=cancel_fn, escalate_channel=escalate_channel)
+
+        await handler(StuckReason.TIMEOUT, "task_001", 1)
+
+        escalate_channel.emit.assert_awaited_once()
+        emitted_event = escalate_channel.emit.call_args[0][0]
+        assert emitted_event.type == RavnEventType.TASK_STUCK
+        assert emitted_event.payload["task_id"] == "task_001"
+        assert emitted_event.payload["reason"] == str(StuckReason.TIMEOUT)
+        cancel_fn.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_escalate_without_channel_falls_back_gracefully(self):
+        """Missing escalate_channel must not raise — just log a warning."""
+        cfg = WatchdogConfig(on_stuck="escalate")
+        cancel_fn = AsyncMock()
+        handler = build_stuck_handler(cfg, cancel_fn=cancel_fn)
+
+        # Should not raise
+        await handler(StuckReason.TIMEOUT, "task_001", 1)
+
+        cancel_fn.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_no_cancel_fn_does_not_raise(self):
+        """cancel_fn=None must not raise for any strategy."""
+        for strategy in ("retry", "replan", "escalate", "abort"):
+            cfg = WatchdogConfig(on_stuck=strategy)  # type: ignore[arg-type]
+            handler = build_stuck_handler(cfg)
+            await handler(StuckReason.TIMEOUT, "task_001", 1)
+
+
+# ---------------------------------------------------------------------------
+# WatchdogOutcome
+# ---------------------------------------------------------------------------
+
+
+class TestWatchdogOutcome:
+    def test_fields(self):
+        outcome = WatchdogOutcome(
+            task_id="task_001",
+            reason=StuckReason.LOOP,
+            retry_count=2,
+            action_taken="replan",
+        )
+        assert outcome.task_id == "task_001"
+        assert outcome.reason == StuckReason.LOOP
+        assert outcome.retry_count == 2
+        assert outcome.action_taken == "replan"
+
+    def test_clean_completion_fields(self):
+        outcome = WatchdogOutcome(
+            task_id="task_002",
+            reason=None,
+            retry_count=0,
+            action_taken=None,
+        )
+        assert outcome.reason is None
+        assert outcome.action_taken is None
+
+
+# ---------------------------------------------------------------------------
+# CascadeConfig stuck-detection fields (regression)
+# ---------------------------------------------------------------------------
+
+
+class TestCascadeConfigStuckFields:
+    def test_defaults_present(self):
+        from ravn.config import CascadeConfig
+
+        cfg = CascadeConfig()
+        assert cfg.stuck_timeout_seconds == 60
+        assert cfg.loop_detection_threshold == 3
+        assert cfg.on_stuck == "replan"
+        assert cfg.max_retries == 2
+
+    def test_custom_values(self):
+        from ravn.config import CascadeConfig
+
+        cfg = CascadeConfig(
+            stuck_timeout_seconds=120,
+            loop_detection_threshold=5,
+            on_stuck="abort",
+            max_retries=0,
+        )
+        assert cfg.stuck_timeout_seconds == 120
+        assert cfg.loop_detection_threshold == 5
+        assert cfg.on_stuck == "abort"
+        assert cfg.max_retries == 0
+
+
+# ---------------------------------------------------------------------------
+# TASK_STUCK event type (regression)
+# ---------------------------------------------------------------------------
+
+
+class TestTaskStuckEventType:
+    def test_task_stuck_in_enum(self):
+        from ravn.domain.events import RavnEventType
+
+        assert RavnEventType.TASK_STUCK == "task_stuck"


### PR DESCRIPTION
## Summary

- Adds `TaskWatchdog` in `src/ravn/cascade/watchdog.py` — an asyncio task that monitors each sub-agent in a cascade for progress and detects stuck conditions
- Adds `WatchdogChannelWrapper` to intercept sub-agent events and forward them to the watchdog
- Adds `build_stuck_handler` factory to wire strategy callbacks (retry / replan / escalate / abort)
- Extends `CascadeConfig` with four new fields: `stuck_timeout_seconds`, `loop_detection_threshold`, `on_stuck`, `max_retries`
- Adds `RavnEventType.TASK_STUCK` for the escalate strategy's Sleipnir event

### Stuck conditions detected
| Condition | Mechanism |
|-----------|-----------|
| **Timeout** | No event emitted for > `stuck_timeout_seconds` (default 60 s) |
| **Loop** | Same tool called with identical args ≥ `loop_detection_threshold` times consecutively (default 3) |
| **Budget** | Reserved hook — wired when iteration-cap tracking lands |

### Response strategies
| Strategy | Behaviour |
|----------|-----------|
| `retry` | Cancel + restart the sub-agent (up to `max_retries`) |
| `replan` | Invoke `replan_callback(task_id, reason)` so orchestrator rewrites the task, then cancel |
| `escalate` | Emit `ravn.task.stuck` on the Sleipnir channel (urgency 0.9), then cancel |
| `abort` | Cancel immediately; cascade continues with remaining tasks |

### Config (cascade section)
```yaml
cascade:
  stuck_timeout_seconds: 60
  loop_detection_threshold: 3
  on_stuck: replan   # retry | replan | escalate | abort
  max_retries: 2
```

## Test plan
- [x] 33 unit tests in `tests/test_ravn/test_watchdog.py` — 99% line coverage on `src/ravn/cascade/`
- [x] `TestWatchdogConfig` — defaults and custom values
- [x] `TestRecordEvent` — timestamp reset, loop detection at threshold, mixed tool calls
- [x] `TestRunCleanCompletion` — immediate done + done-after-poll
- [x] `TestRunTimeout` — timeout fires, correct callback args
- [x] `TestRunLoopDetection` — loop fires, correct callback args
- [x] `TestRunRetryStrategy` — state reset on retry, exhaustion exits
- [x] `TestWatchdogChannelWrapper` — forward to inner, notify watchdog, order guarantee
- [x] `TestBuildStuckHandler` — all four strategies, missing deps handled gracefully
- [x] `TestCascadeConfigStuckFields` — regression for new config fields
- [x] `TestTaskStuckEventType` — regression for new event type
- [x] Full `tests/test_ravn/` suite: 1969 passed (pre-existing `textual` import failure in `test_plugin.py` unrelated to this PR)

Closes NIU-510

🤖 Generated with [Claude Code](https://claude.com/claude-code)