### PR TITLE
feat(adapters): remote task dispatch channel and autonomous listen mode (NIU-505)

### DIFF
--- a/src/ravn/adapters/channels/_rabbitmq_base.py
+++ b/src/ravn/adapters/channels/_rabbitmq_base.py
@@ -1,0 +1,153 @@
+"""Shared RabbitMQ publish mixin used by SleipnirChannel, RabbitMQEventPublisher,
+and TaskDispatchChannel.
+
+All three adapters need the same lazy-connect / reconnect-backoff / invalidate
+pattern for their publish connections.  This mixin centralises that logic so it
+lives in exactly one place.
+
+Usage
+-----
+1. Inherit ``RabbitMQPublishMixin`` (alongside the real base class).
+2. Set the ``_log_prefix`` class variable to a short identifier used in log messages.
+3. Call ``_init_publish_state()`` inside ``__init__`` *after* ``self._config`` is set.
+4. Use ``_ensure_exchange()`` / ``_publish_to_exchange(routing_key, body)`` in your
+   publish method.
+5. Call ``_invalidate()`` on close or after a publish failure.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ravn.config import SleipnirConfig
+
+try:
+    import aio_pika
+except ImportError:  # pragma: no cover
+    aio_pika = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+
+class RabbitMQPublishMixin:
+    """Mixin that provides lazy-connect RabbitMQ publish helpers.
+
+    Subclasses must set ``_log_prefix`` and call ``_init_publish_state()`` in
+    their ``__init__``.  They must also have ``self._config: SleipnirConfig``
+    available before calling any method on the mixin.
+    """
+
+    _log_prefix: str = "rabbitmq"
+
+    # Populated by _init_publish_state(); typed here for IDE / mypy.
+    _connection: object | None
+    _channel: object | None
+    _exchange: object | None
+    _connect_lock: asyncio.Lock
+    _last_connect_attempt: float
+
+    def _init_publish_state(self) -> None:
+        """Initialise the connection-state attributes.  Call from ``__init__``."""
+        self._connection = None
+        self._channel = None
+        self._exchange = None
+        self._connect_lock = asyncio.Lock()
+        self._last_connect_attempt = 0.0
+
+    # ------------------------------------------------------------------
+    # Public helpers
+    # ------------------------------------------------------------------
+
+    async def _ensure_exchange(self) -> object | None:
+        """Return the cached exchange, (re)connecting lazily if needed."""
+        if self._exchange is not None:
+            return self._exchange
+
+        async with self._connect_lock:
+            # Double-checked locking — another coroutine may have connected.
+            if self._exchange is not None:
+                return self._exchange
+
+            now = asyncio.get_running_loop().time()
+            config: SleipnirConfig = self._config  # type: ignore[attr-defined]
+            if now - self._last_connect_attempt < config.reconnect_delay_s:
+                return None
+
+            self._last_connect_attempt = now
+            return await self._connect()
+
+    async def _connect(self) -> object | None:
+        """Establish a RabbitMQ connection and declare the topic exchange."""
+        if aio_pika is None:
+            logger.debug("%s: aio_pika not installed, publishing disabled", self._log_prefix)
+            return None
+
+        config: SleipnirConfig = self._config  # type: ignore[attr-defined]
+        amqp_url = os.environ.get(config.amqp_url_env, "")
+        if not amqp_url:
+            logger.debug(
+                "%s: %s not set, publishing disabled",
+                self._log_prefix,
+                config.amqp_url_env,
+            )
+            return None
+
+        try:
+            connection = await aio_pika.connect_robust(amqp_url)  # type: ignore[union-attr]
+            channel = await connection.channel()
+            exchange = await channel.declare_exchange(
+                config.exchange,
+                aio_pika.ExchangeType.TOPIC,  # type: ignore[union-attr]
+                durable=True,
+            )
+            self._connection = connection
+            self._channel = channel
+            self._exchange = exchange
+            logger.debug(
+                "%s: connected to %s, exchange=%s",
+                self._log_prefix,
+                amqp_url,
+                config.exchange,
+            )
+            return exchange
+        except Exception as exc:
+            logger.debug("%s: connection failed (%s), will retry", self._log_prefix, exc)
+            return None
+
+    async def _invalidate(self) -> None:
+        """Drop cached connection state so the next publish attempts to reconnect."""
+        self._exchange = None
+        self._channel = None
+        if self._connection is not None:
+            try:
+                await self._connection.close()  # type: ignore[union-attr]
+            except Exception:
+                pass
+        self._connection = None
+
+    async def _publish_to_exchange(self, routing_key: str, body: bytes) -> None:
+        """Publish *body* to *routing_key*.  Never raises — failures are logged."""
+        exchange = await self._ensure_exchange()
+        if exchange is None:
+            logger.debug("%s: exchange unavailable, dropping %s", self._log_prefix, routing_key)
+            return
+
+        try:
+            if aio_pika is None:
+                return
+            config: SleipnirConfig = self._config  # type: ignore[attr-defined]
+            message = aio_pika.Message(  # type: ignore[union-attr]
+                body=body,
+                content_type="application/json",
+            )
+            await asyncio.wait_for(
+                exchange.publish(message, routing_key=routing_key),  # type: ignore[attr-defined]
+                timeout=config.publish_timeout_s,
+            )
+        except Exception as exc:
+            logger.debug("%s: publish failed (%s), dropping %s", self._log_prefix, exc, routing_key)
+            await self._invalidate()

--- a/src/ravn/adapters/channels/event.py
+++ b/src/ravn/adapters/channels/event.py
@@ -7,7 +7,7 @@ catalogue; unknown or untrusted personas are immediately rejected.
 Response events published to the same exchange:
 
   ravn.task.accepted  — persona valid, task enqueued for execution
-  ravn.task.rejected  — persona unknown or not trusted
+  ravn.task.rejected  — persona unknown, not trusted, or malformed payload
   ravn.task.progress  — periodic update during execution (caller-driven)
   ravn.task.completed — task finished successfully
   ravn.task.failed    — unrecoverable error during execution
@@ -28,6 +28,7 @@ from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+from ravn.adapters.channels._rabbitmq_base import RabbitMQPublishMixin
 from ravn.adapters.personas.loader import PersonaLoader
 from ravn.domain.models import AgentTask, OutputMode
 
@@ -81,7 +82,7 @@ def _build_initiative_context(task_text: str, context: dict) -> str:
 # ---------------------------------------------------------------------------
 
 
-class TaskDispatchChannel:
+class TaskDispatchChannel(RabbitMQPublishMixin):
     """Inbound task receiver and outbound response publisher for Sleipnir dispatch.
 
     Subscribes to ``ravn.task.dispatch`` (and the agent-targeted variant
@@ -89,7 +90,8 @@ class TaskDispatchChannel:
 
     For each inbound message:
 
-    1. Parse the dispatch payload.
+    1. Parse the dispatch payload — reject with ``ravn.task.rejected`` if JSON
+       is malformed or the ``task`` field is missing/empty.
     2. Validate the requested persona via ``PersonaLoader``.
     3. If persona unknown → publish ``ravn.task.rejected`` and discard.
     4. If persona valid → publish ``ravn.task.accepted`` and call ``enqueue``.
@@ -104,29 +106,20 @@ class TaskDispatchChannel:
     persona_loader:
         Used to validate persona names from dispatch payloads.  Defaults to a
         standard ``PersonaLoader`` (built-in personas + ``~/.ravn/personas``).
-    retry_delay_seconds:
-        Seconds to wait before reconnecting after a connection error.
     """
+
+    _log_prefix = "task_dispatch"
 
     def __init__(
         self,
         config: SleipnirConfig,
         *,
         persona_loader: PersonaLoader | None = None,
-        retry_delay_seconds: float = 5.0,
     ) -> None:
         self._config = config
         self._agent_id = config.agent_id or socket.gethostname()
         self._persona_loader = persona_loader or PersonaLoader()
-        self._retry_delay_seconds = retry_delay_seconds
-
-        # Lazy publish connection (separate from the consume connection so that
-        # a broken consume connection does not block publishing responses).
-        self._pub_connection: object | None = None
-        self._pub_channel: object | None = None
-        self._pub_exchange: object | None = None
-        self._pub_lock = asyncio.Lock()
-        self._last_pub_attempt: float = 0.0
+        self._init_publish_state()
 
     # ------------------------------------------------------------------
     # TriggerPort-compatible interface
@@ -156,9 +149,9 @@ class TaskDispatchChannel:
                 logger.warning(
                     "task_dispatch: connection error (%s) — retrying in %.0fs",
                     exc,
-                    self._retry_delay_seconds,
+                    self._config.reconnect_delay_s,
                 )
-                await asyncio.sleep(self._retry_delay_seconds)
+                await asyncio.sleep(self._config.reconnect_delay_s)
 
     # ------------------------------------------------------------------
     # Inbound — consume loop
@@ -172,7 +165,7 @@ class TaskDispatchChannel:
                 "task_dispatch: %s not set — subscription disabled, retrying",
                 self._config.amqp_url_env,
             )
-            await asyncio.sleep(self._retry_delay_seconds)
+            await asyncio.sleep(self._config.reconnect_delay_s)
             return
 
         connection = await aio_pika.connect_robust(amqp_url)  # type: ignore[union-attr]
@@ -211,17 +204,49 @@ class TaskDispatchChannel:
         enqueue: Callable[[AgentTask], Awaitable[None]],
     ) -> None:
         """Process one inbound dispatch message."""
+        # ----------------------------------------------------------------
+        # Parse — reject on malformed JSON
+        # ----------------------------------------------------------------
         try:
             payload: dict = json.loads(message.body)  # type: ignore[attr-defined]
         except Exception:
-            payload = {}
+            logger.warning("task_dispatch: malformed JSON — rejecting message")
+            await self._publish_response(
+                ROUTING_REJECTED,
+                {
+                    "task_id": f"dispatch_{int(time.time() * 1000)}",
+                    "reason": "malformed JSON payload",
+                    "agent_id": self._agent_id,
+                },
+            )
+            return
 
         task_id = str(payload.get("task_id") or f"dispatch_{int(time.time() * 1000)}")
         persona_name = str(payload.get("persona") or "autonomous-agent")
-        task_text = str(payload.get("task") or "")
+        task_text = str(payload.get("task") or "").strip()
         context: dict = payload.get("context") or {}
         deadline_str: str | None = payload.get("deadline")
         dispatched_by = str(payload.get("dispatched_by") or "unknown")
+
+        # ----------------------------------------------------------------
+        # Reject empty task
+        # ----------------------------------------------------------------
+        if not task_text:
+            logger.warning(
+                "task_dispatch: missing or empty task field for %s from %s — rejecting",
+                task_id,
+                dispatched_by,
+            )
+            await self._publish_response(
+                ROUTING_REJECTED,
+                {
+                    "task_id": task_id,
+                    "reason": "missing or empty task field",
+                    "dispatched_by": dispatched_by,
+                    "agent_id": self._agent_id,
+                },
+            )
+            return
 
         # ----------------------------------------------------------------
         # Persona validation — reject if unknown
@@ -250,7 +275,7 @@ class TaskDispatchChannel:
         # ----------------------------------------------------------------
         deadline = _parse_deadline(deadline_str)
         initiative_context = _build_initiative_context(task_text, context)
-        title = (task_text[:100] if task_text else f"task from {dispatched_by}").strip()
+        title = task_text[:100].strip()
 
         agent_task = AgentTask(
             task_id=task_id,
@@ -341,15 +366,7 @@ class TaskDispatchChannel:
     # ------------------------------------------------------------------
 
     async def _publish_response(self, routing_key: str, payload: dict) -> None:
-        """Publish *payload* to *routing_key* on the ravn.events exchange.
-
-        Never raises — failures are logged at DEBUG level.
-        """
-        exchange = await self._ensure_pub_exchange()
-        if exchange is None:
-            logger.debug("task_dispatch: pub exchange unavailable, dropping %s", routing_key)
-            return
-
+        """Publish *payload* to *routing_key* on the ravn.events exchange."""
         body = json.dumps(
             {
                 "routing_key": routing_key,
@@ -357,75 +374,4 @@ class TaskDispatchChannel:
                 "published_at": datetime.now(UTC).isoformat(),
             }
         ).encode("utf-8")
-
-        try:
-            if aio_pika is None:
-                return
-            message = aio_pika.Message(  # type: ignore[union-attr]
-                body=body,
-                content_type="application/json",
-            )
-            await asyncio.wait_for(
-                exchange.publish(message, routing_key=routing_key),  # type: ignore[attr-defined]
-                timeout=self._config.publish_timeout_s,
-            )
-        except Exception as exc:
-            logger.debug("task_dispatch: publish failed (%s), dropping %s", exc, routing_key)
-            await self._invalidate_pub()
-
-    async def _ensure_pub_exchange(self) -> object | None:
-        """Return cached publish exchange, reconnecting lazily when needed."""
-        if self._pub_exchange is not None:
-            return self._pub_exchange
-
-        async with self._pub_lock:
-            if self._pub_exchange is not None:
-                return self._pub_exchange
-
-            now = asyncio.get_running_loop().time()
-            if now - self._last_pub_attempt < self._config.reconnect_delay_s:
-                return None
-
-            self._last_pub_attempt = now
-            return await self._connect_pub()
-
-    async def _connect_pub(self) -> object | None:
-        """Establish a dedicated publish connection."""
-        if aio_pika is None:
-            return None
-
-        amqp_url = os.environ.get(self._config.amqp_url_env, "")
-        if not amqp_url:
-            return None
-
-        try:
-            connection = await aio_pika.connect_robust(amqp_url)  # type: ignore[union-attr]
-            channel = await connection.channel()
-            exchange = await channel.declare_exchange(
-                self._config.exchange,
-                aio_pika.ExchangeType.TOPIC,  # type: ignore[union-attr]
-                durable=True,
-            )
-            self._pub_connection = connection
-            self._pub_channel = channel
-            self._pub_exchange = exchange
-            logger.debug(
-                "task_dispatch: pub connected to %s exchange=%s",
-                amqp_url,
-                self._config.exchange,
-            )
-            return exchange
-        except Exception as exc:
-            logger.debug("task_dispatch: pub connection failed (%s), will retry", exc)
-            return None
-
-    async def _invalidate_pub(self) -> None:
-        """Drop cached publish connection so next call reconnects."""
-        self._pub_exchange = None
-        self._pub_channel = None
-        if self._pub_connection is not None:
-            try:
-                await self._pub_connection.close()  # type: ignore[union-attr]
-            except Exception:
-                pass
-        self._pub_connection = None
+        await self._publish_to_exchange(routing_key, body)

--- a/src/ravn/adapters/channels/event.py
+++ b/src/ravn/adapters/channels/event.py
@@ -1,0 +1,431 @@
+"""Task dispatch channel — inbound task reception from Sleipnir (NIU-505).
+
+Subscribes to ``ravn.task.dispatch`` on the ``ravn.events`` RabbitMQ topic
+exchange.  Each inbound message is validated against the known persona
+catalogue; unknown or untrusted personas are immediately rejected.
+
+Response events published to the same exchange:
+
+  ravn.task.accepted  — persona valid, task enqueued for execution
+  ravn.task.rejected  — persona unknown or not trusted
+  ravn.task.progress  — periodic update during execution (caller-driven)
+  ravn.task.completed — task finished successfully
+  ravn.task.failed    — unrecoverable error during execution
+
+Autonomous mode is activated via ``ravn daemon`` or ``ravn listen`` at the
+CLI level; both commands wire this channel into the drive loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import socket
+import time
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from ravn.adapters.personas.loader import PersonaLoader
+from ravn.domain.models import AgentTask, OutputMode
+
+if TYPE_CHECKING:
+    from ravn.config import SleipnirConfig
+
+try:
+    import aio_pika
+except ImportError:  # pragma: no cover
+    aio_pika = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Routing key constants
+# ---------------------------------------------------------------------------
+
+_INBOUND_ROUTING_KEY = "ravn.task.dispatch"
+
+ROUTING_ACCEPTED = "ravn.task.accepted"
+ROUTING_REJECTED = "ravn.task.rejected"
+ROUTING_PROGRESS = "ravn.task.progress"
+ROUTING_COMPLETED = "ravn.task.completed"
+ROUTING_FAILED = "ravn.task.failed"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_deadline(value: str | None) -> datetime | None:
+    """Parse an ISO-8601 deadline string, returning None on failure."""
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except (ValueError, TypeError):
+        return None
+
+
+def _build_initiative_context(task_text: str, context: dict) -> str:
+    """Combine the task description and optional context dict into a prompt."""
+    if not context:
+        return task_text
+    return f"{task_text}\n\nContext:\n{json.dumps(context, indent=2)}"
+
+
+# ---------------------------------------------------------------------------
+# TaskDispatchChannel
+# ---------------------------------------------------------------------------
+
+
+class TaskDispatchChannel:
+    """Inbound task receiver and outbound response publisher for Sleipnir dispatch.
+
+    Subscribes to ``ravn.task.dispatch`` (and the agent-targeted variant
+    ``ravn.task.dispatch.<agent_id>``) on the ``ravn.events`` topic exchange.
+
+    For each inbound message:
+
+    1. Parse the dispatch payload.
+    2. Validate the requested persona via ``PersonaLoader``.
+    3. If persona unknown → publish ``ravn.task.rejected`` and discard.
+    4. If persona valid → publish ``ravn.task.accepted`` and call ``enqueue``.
+
+    The caller (drive loop / CLI) can also use the ``publish_*`` methods to
+    emit progress, completed, and failed events back to the exchange.
+
+    Parameters
+    ----------
+    config:
+        Sleipnir section from Ravn settings.
+    persona_loader:
+        Used to validate persona names from dispatch payloads.  Defaults to a
+        standard ``PersonaLoader`` (built-in personas + ``~/.ravn/personas``).
+    retry_delay_seconds:
+        Seconds to wait before reconnecting after a connection error.
+    """
+
+    def __init__(
+        self,
+        config: SleipnirConfig,
+        *,
+        persona_loader: PersonaLoader | None = None,
+        retry_delay_seconds: float = 5.0,
+    ) -> None:
+        self._config = config
+        self._agent_id = config.agent_id or socket.gethostname()
+        self._persona_loader = persona_loader or PersonaLoader()
+        self._retry_delay_seconds = retry_delay_seconds
+
+        # Lazy publish connection (separate from the consume connection so that
+        # a broken consume connection does not block publishing responses).
+        self._pub_connection: object | None = None
+        self._pub_channel: object | None = None
+        self._pub_exchange: object | None = None
+        self._pub_lock = asyncio.Lock()
+        self._last_pub_attempt: float = 0.0
+
+    # ------------------------------------------------------------------
+    # TriggerPort-compatible interface
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        """Unique identifier for drive-loop logging."""
+        return f"task_dispatch:{self._agent_id}"
+
+    async def run(self, enqueue: Callable[[AgentTask], Awaitable[None]]) -> None:
+        """Subscribe to ``ravn.task.dispatch`` and run until cancelled.
+
+        Reconnects automatically on connection errors.  Returns only when the
+        task is cancelled (daemon shutdown).
+        """
+        if aio_pika is None:
+            logger.warning("task_dispatch: aio_pika not installed — TaskDispatchChannel disabled")
+            return
+
+        while True:
+            try:
+                await self._connect_and_consume(enqueue)
+            except asyncio.CancelledError:
+                return
+            except Exception as exc:
+                logger.warning(
+                    "task_dispatch: connection error (%s) — retrying in %.0fs",
+                    exc,
+                    self._retry_delay_seconds,
+                )
+                await asyncio.sleep(self._retry_delay_seconds)
+
+    # ------------------------------------------------------------------
+    # Inbound — consume loop
+    # ------------------------------------------------------------------
+
+    async def _connect_and_consume(self, enqueue: Callable[[AgentTask], Awaitable[None]]) -> None:
+        """Establish connection, declare topology, and consume until error."""
+        amqp_url = os.environ.get(self._config.amqp_url_env, "")
+        if not amqp_url:
+            logger.warning(
+                "task_dispatch: %s not set — subscription disabled, retrying",
+                self._config.amqp_url_env,
+            )
+            await asyncio.sleep(self._retry_delay_seconds)
+            return
+
+        connection = await aio_pika.connect_robust(amqp_url)  # type: ignore[union-attr]
+        async with connection:
+            channel = await connection.channel()
+            exchange = await channel.declare_exchange(
+                self._config.exchange,
+                aio_pika.ExchangeType.TOPIC,  # type: ignore[union-attr]
+                durable=True,
+            )
+            queue_name = f"ravn.dispatch.{self._agent_id}"
+            queue = await channel.declare_queue(queue_name, durable=True)
+
+            # Bind broadcast + agent-targeted routing keys.
+            await queue.bind(exchange, routing_key=_INBOUND_ROUTING_KEY)
+            await queue.bind(
+                exchange,
+                routing_key=f"{_INBOUND_ROUTING_KEY}.{self._agent_id}",
+            )
+
+            logger.info(
+                "task_dispatch: listening on exchange=%r queue=%r agent_id=%s",
+                self._config.exchange,
+                queue_name,
+                self._agent_id,
+            )
+
+            async with queue.iterator() as q_iter:
+                async for message in q_iter:
+                    async with message.process():
+                        await self._handle_message(message, enqueue)
+
+    async def _handle_message(
+        self,
+        message: object,
+        enqueue: Callable[[AgentTask], Awaitable[None]],
+    ) -> None:
+        """Process one inbound dispatch message."""
+        try:
+            payload: dict = json.loads(message.body)  # type: ignore[attr-defined]
+        except Exception:
+            payload = {}
+
+        task_id = str(payload.get("task_id") or f"dispatch_{int(time.time() * 1000)}")
+        persona_name = str(payload.get("persona") or "autonomous-agent")
+        task_text = str(payload.get("task") or "")
+        context: dict = payload.get("context") or {}
+        deadline_str: str | None = payload.get("deadline")
+        dispatched_by = str(payload.get("dispatched_by") or "unknown")
+
+        # ----------------------------------------------------------------
+        # Persona validation — reject if unknown
+        # ----------------------------------------------------------------
+        persona = self._persona_loader.load(persona_name)
+        if persona is None:
+            logger.warning(
+                "task_dispatch: unknown persona %r for task %s from %s — rejecting",
+                persona_name,
+                task_id,
+                dispatched_by,
+            )
+            await self._publish_response(
+                ROUTING_REJECTED,
+                {
+                    "task_id": task_id,
+                    "reason": f"unknown persona: {persona_name!r}",
+                    "dispatched_by": dispatched_by,
+                    "agent_id": self._agent_id,
+                },
+            )
+            return
+
+        # ----------------------------------------------------------------
+        # Enqueue accepted task
+        # ----------------------------------------------------------------
+        deadline = _parse_deadline(deadline_str)
+        initiative_context = _build_initiative_context(task_text, context)
+        title = (task_text[:100] if task_text else f"task from {dispatched_by}").strip()
+
+        agent_task = AgentTask(
+            task_id=task_id,
+            title=title,
+            initiative_context=initiative_context,
+            triggered_by=f"sleipnir:{dispatched_by}",
+            output_mode=OutputMode.AMBIENT,
+            persona=persona_name,
+            deadline=deadline,
+        )
+
+        logger.info(
+            "task_dispatch: accepted task %s (persona=%s dispatched_by=%s)",
+            task_id,
+            persona_name,
+            dispatched_by,
+        )
+
+        await self._publish_response(
+            ROUTING_ACCEPTED,
+            {
+                "task_id": task_id,
+                "persona": persona_name,
+                "dispatched_by": dispatched_by,
+                "agent_id": self._agent_id,
+            },
+        )
+        await enqueue(agent_task)
+
+    # ------------------------------------------------------------------
+    # Outbound — response events
+    # ------------------------------------------------------------------
+
+    async def publish_progress(
+        self,
+        task_id: str,
+        *,
+        iteration: int,
+        message: str = "",
+    ) -> None:
+        """Publish a ``ravn.task.progress`` event for a running task."""
+        await self._publish_response(
+            ROUTING_PROGRESS,
+            {
+                "task_id": task_id,
+                "iteration": iteration,
+                "message": message,
+                "agent_id": self._agent_id,
+            },
+        )
+
+    async def publish_completed(
+        self,
+        task_id: str,
+        *,
+        outcome: str = "success",
+        summary: str = "",
+    ) -> None:
+        """Publish a ``ravn.task.completed`` event when a task finishes."""
+        await self._publish_response(
+            ROUTING_COMPLETED,
+            {
+                "task_id": task_id,
+                "outcome": outcome,
+                "summary": summary,
+                "agent_id": self._agent_id,
+            },
+        )
+
+    async def publish_failed(
+        self,
+        task_id: str,
+        *,
+        error: str,
+    ) -> None:
+        """Publish a ``ravn.task.failed`` event on unrecoverable error."""
+        await self._publish_response(
+            ROUTING_FAILED,
+            {
+                "task_id": task_id,
+                "error": error,
+                "agent_id": self._agent_id,
+            },
+        )
+
+    # ------------------------------------------------------------------
+    # Internal publish helpers
+    # ------------------------------------------------------------------
+
+    async def _publish_response(self, routing_key: str, payload: dict) -> None:
+        """Publish *payload* to *routing_key* on the ravn.events exchange.
+
+        Never raises — failures are logged at DEBUG level.
+        """
+        exchange = await self._ensure_pub_exchange()
+        if exchange is None:
+            logger.debug("task_dispatch: pub exchange unavailable, dropping %s", routing_key)
+            return
+
+        body = json.dumps(
+            {
+                "routing_key": routing_key,
+                "payload": payload,
+                "published_at": datetime.now(UTC).isoformat(),
+            }
+        ).encode("utf-8")
+
+        try:
+            if aio_pika is None:
+                return
+            message = aio_pika.Message(  # type: ignore[union-attr]
+                body=body,
+                content_type="application/json",
+            )
+            await asyncio.wait_for(
+                exchange.publish(message, routing_key=routing_key),  # type: ignore[attr-defined]
+                timeout=self._config.publish_timeout_s,
+            )
+        except Exception as exc:
+            logger.debug("task_dispatch: publish failed (%s), dropping %s", exc, routing_key)
+            await self._invalidate_pub()
+
+    async def _ensure_pub_exchange(self) -> object | None:
+        """Return cached publish exchange, reconnecting lazily when needed."""
+        if self._pub_exchange is not None:
+            return self._pub_exchange
+
+        async with self._pub_lock:
+            if self._pub_exchange is not None:
+                return self._pub_exchange
+
+            now = asyncio.get_running_loop().time()
+            if now - self._last_pub_attempt < self._config.reconnect_delay_s:
+                return None
+
+            self._last_pub_attempt = now
+            return await self._connect_pub()
+
+    async def _connect_pub(self) -> object | None:
+        """Establish a dedicated publish connection."""
+        if aio_pika is None:
+            return None
+
+        amqp_url = os.environ.get(self._config.amqp_url_env, "")
+        if not amqp_url:
+            return None
+
+        try:
+            connection = await aio_pika.connect_robust(amqp_url)  # type: ignore[union-attr]
+            channel = await connection.channel()
+            exchange = await channel.declare_exchange(
+                self._config.exchange,
+                aio_pika.ExchangeType.TOPIC,  # type: ignore[union-attr]
+                durable=True,
+            )
+            self._pub_connection = connection
+            self._pub_channel = channel
+            self._pub_exchange = exchange
+            logger.debug(
+                "task_dispatch: pub connected to %s exchange=%s",
+                amqp_url,
+                self._config.exchange,
+            )
+            return exchange
+        except Exception as exc:
+            logger.debug("task_dispatch: pub connection failed (%s), will retry", exc)
+            return None
+
+    async def _invalidate_pub(self) -> None:
+        """Drop cached publish connection so next call reconnects."""
+        self._pub_exchange = None
+        self._pub_channel = None
+        if self._pub_connection is not None:
+            try:
+                await self._pub_connection.close()  # type: ignore[union-attr]
+            except Exception:
+                pass
+        self._pub_connection = None

--- a/src/ravn/adapters/channels/sleipnir.py
+++ b/src/ravn/adapters/channels/sleipnir.py
@@ -10,25 +10,19 @@ at DEBUG level so the agent never fails due to Sleipnir being down.
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
-import os
 import socket
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+from ravn.adapters.channels._rabbitmq_base import RabbitMQPublishMixin
 from ravn.domain.events import RavnEvent, RavnEventType
 from ravn.domain.models import SleipnirEnvelope
 from ravn.ports.channel import ChannelPort
 
 if TYPE_CHECKING:
     from ravn.config import SleipnirConfig
-
-try:
-    import aio_pika
-except ImportError:  # pragma: no cover
-    aio_pika = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
 
@@ -92,7 +86,7 @@ def _serialise_envelope(envelope: SleipnirEnvelope) -> bytes:
 # ---------------------------------------------------------------------------
 
 
-class SleipnirChannel(ChannelPort):
+class SleipnirChannel(RabbitMQPublishMixin, ChannelPort):
     """Publishes RavnEvents to RabbitMQ via the Sleipnir event backbone.
 
     Parameters
@@ -106,6 +100,8 @@ class SleipnirChannel(ChannelPort):
         interactive turns.
     """
 
+    _log_prefix = "sleipnir"
+
     def __init__(
         self,
         config: SleipnirConfig,
@@ -117,11 +113,7 @@ class SleipnirChannel(ChannelPort):
         self._session_id = session_id
         self._task_id = task_id
         self._agent_id = config.agent_id or socket.gethostname()
-        self._connection: object | None = None
-        self._channel: object | None = None
-        self._exchange: object | None = None
-        self._last_connect_attempt: float = 0.0
-        self._connect_lock = asyncio.Lock()
+        self._init_publish_state()
 
     # ------------------------------------------------------------------
     # ChannelPort interface
@@ -138,101 +130,6 @@ class SleipnirChannel(ChannelPort):
             correlation_id=event.correlation_id,
             published_at=datetime.now(UTC),
         )
-        await self._publish(envelope)
-
-    # ------------------------------------------------------------------
-    # Internal helpers
-    # ------------------------------------------------------------------
-
-    async def _publish(self, envelope: SleipnirEnvelope) -> None:
-        """Serialise *envelope* and publish to RabbitMQ, swallowing errors."""
-        exchange = await self._ensure_exchange()
-        if exchange is None:
-            logger.debug(
-                "sleipnir: exchange unavailable, dropping event %s",
-                envelope.event.type,
-            )
-            return
-
         routing_key = f"ravn.{envelope.event.type}.{self._agent_id}"
         body = _serialise_envelope(envelope)
-
-        try:
-            if aio_pika is None:
-                logger.debug("sleipnir: aio_pika not installed, dropping event")
-                return
-
-            message = aio_pika.Message(
-                body=body,
-                content_type="application/json",
-            )
-            await asyncio.wait_for(
-                exchange.publish(message, routing_key=routing_key),
-                timeout=self._config.publish_timeout_s,
-            )
-        except Exception as exc:
-            logger.debug("sleipnir: publish failed (%s), dropping event", exc)
-            await self._invalidate()
-
-    async def _ensure_exchange(self) -> object | None:
-        """Return the cached exchange, (re)connecting lazily if needed."""
-        if self._exchange is not None:
-            return self._exchange
-
-        async with self._connect_lock:
-            # Double-checked locking — another coroutine may have connected.
-            if self._exchange is not None:
-                return self._exchange
-
-            now = asyncio.get_running_loop().time()
-            if now - self._last_connect_attempt < self._config.reconnect_delay_s:
-                return None
-
-            self._last_connect_attempt = now
-            return await self._connect()
-
-    async def _connect(self) -> object | None:
-        """Establish a RabbitMQ connection and declare the topic exchange."""
-        if aio_pika is None:
-            logger.debug("sleipnir: aio_pika not installed, publishing disabled")
-            return None
-
-        amqp_url = os.environ.get(self._config.amqp_url_env, "")
-        if not amqp_url:
-            logger.debug(
-                "sleipnir: %s not set, publishing disabled",
-                self._config.amqp_url_env,
-            )
-            return None
-
-        try:
-            connection = await aio_pika.connect_robust(amqp_url)
-            channel = await connection.channel()
-            exchange = await channel.declare_exchange(
-                self._config.exchange,
-                aio_pika.ExchangeType.TOPIC,
-                durable=True,
-            )
-            self._connection = connection
-            self._channel = channel
-            self._exchange = exchange
-            logger.debug(
-                "sleipnir: connected to %s, exchange=%s",
-                amqp_url,
-                self._config.exchange,
-            )
-            return exchange
-        except Exception as exc:
-            logger.debug("sleipnir: connection failed (%s), will retry", exc)
-            return None
-
-    async def _invalidate(self) -> None:
-        """Drop cached connection state so the next emit attempts to reconnect."""
-        self._exchange = None
-        self._channel = None
-        if self._connection is not None:
-            try:
-                await self._connection.close()  # type: ignore[union-attr]
-            except Exception:
-                pass
-        self._connection = None
+        await self._publish_to_exchange(routing_key, body)

--- a/src/ravn/adapters/events/rabbitmq_publisher.py
+++ b/src/ravn/adapters/events/rabbitmq_publisher.py
@@ -2,24 +2,18 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
-import os
 import socket
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+from ravn.adapters.channels._rabbitmq_base import RabbitMQPublishMixin
 from ravn.domain.events import RavnEvent
 from ravn.ports.event_publisher import EventPublisherPort
 
 if TYPE_CHECKING:
     from ravn.config import SleipnirConfig
-
-try:
-    import aio_pika
-except ImportError:  # pragma: no cover
-    aio_pika = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +34,7 @@ def _serialise_event(event: RavnEvent) -> bytes:
     return json.dumps(data).encode("utf-8")
 
 
-class RabbitMQEventPublisher(EventPublisherPort):
+class RabbitMQEventPublisher(RabbitMQPublishMixin, EventPublisherPort):
     """Publishes drive-loop lifecycle events to RabbitMQ.
 
     Shares connection logic with SleipnirChannel (NIU-438) but operates
@@ -53,107 +47,19 @@ class RabbitMQEventPublisher(EventPublisherPort):
     Never raises — failures are logged at DEBUG level.
     """
 
+    _log_prefix = "rabbitmq_publisher"
+
     def __init__(self, config: SleipnirConfig) -> None:
         self._config = config
         self._agent_id = config.agent_id or socket.gethostname()
-        self._connection: object | None = None
-        self._channel: object | None = None
-        self._exchange: object | None = None
-        self._last_connect_attempt: float = 0.0
-        self._connect_lock = asyncio.Lock()
+        self._init_publish_state()
 
     async def publish(self, event: RavnEvent) -> None:
         """Publish *event* to RabbitMQ. Never raises — failures are logged."""
-        exchange = await self._ensure_exchange()
-        if exchange is None:
-            logger.debug(
-                "rabbitmq_publisher: exchange unavailable, dropping event %s",
-                event.type,
-            )
-            return
-
         routing_key = f"ravn.system.{event.type}.{self._agent_id}"
         body = _serialise_event(event)
-
-        try:
-            if aio_pika is None:
-                logger.debug("rabbitmq_publisher: aio_pika not installed, dropping event")
-                return
-
-            message = aio_pika.Message(
-                body=body,
-                content_type="application/json",
-            )
-            await asyncio.wait_for(
-                exchange.publish(message, routing_key=routing_key),
-                timeout=self._config.publish_timeout_s,
-            )
-        except Exception as exc:
-            logger.debug("rabbitmq_publisher: publish failed (%s), dropping event", exc)
-            await self._invalidate()
+        await self._publish_to_exchange(routing_key, body)
 
     async def close(self) -> None:
         """Close the RabbitMQ connection."""
         await self._invalidate()
-
-    async def _ensure_exchange(self) -> object | None:
-        """Return the cached exchange, (re)connecting lazily if needed."""
-        if self._exchange is not None:
-            return self._exchange
-
-        async with self._connect_lock:
-            if self._exchange is not None:
-                return self._exchange
-
-            now = asyncio.get_running_loop().time()
-            if now - self._last_connect_attempt < self._config.reconnect_delay_s:
-                return None
-
-            self._last_connect_attempt = now
-            return await self._connect()
-
-    async def _connect(self) -> object | None:
-        """Establish a RabbitMQ connection and declare the topic exchange."""
-        if aio_pika is None:
-            logger.debug("rabbitmq_publisher: aio_pika not installed, publishing disabled")
-            return None
-
-        amqp_url = os.environ.get(self._config.amqp_url_env, "")
-        if not amqp_url:
-            logger.debug(
-                "rabbitmq_publisher: %s not set, publishing disabled",
-                self._config.amqp_url_env,
-            )
-            return None
-
-        try:
-            connection = await aio_pika.connect_robust(amqp_url)
-            channel = await connection.channel()
-            exchange = await channel.declare_exchange(
-                self._config.exchange,
-                aio_pika.ExchangeType.TOPIC,
-                durable=True,
-            )
-            self._connection = connection
-            self._channel = channel
-            self._exchange = exchange
-            logger.debug(
-                "rabbitmq_publisher: connected to %s, exchange=%s",
-                amqp_url,
-                self._config.exchange,
-            )
-            return exchange
-        except Exception as exc:
-            logger.debug("rabbitmq_publisher: connection failed (%s), will retry", exc)
-            return None
-
-    async def _invalidate(self) -> None:
-        """Drop cached connection state so next publish attempts to reconnect."""
-        self._exchange = None
-        self._channel = None
-        if self._connection is not None:
-            try:
-                await self._connection.close()  # type: ignore[union-attr]
-            except Exception:
-                pass
-        self._connection = None

--- a/src/ravn/cli/commands.py
+++ b/src/ravn/cli/commands.py
@@ -1326,10 +1326,42 @@ def daemon(
     asyncio.run(_run_daemon(settings, persona_config=persona_config))
 
 
+@app.command()
+def listen(
+    config: str = typer.Option("", "--config", "-c", help="Path to ravn config YAML."),
+    persona: str = typer.Option(
+        "", "--persona", "-p", help="Default persona for dispatched tasks."
+    ),
+) -> None:
+    """Listen for remotely dispatched tasks via Sleipnir (NIU-505).
+
+    Subscribes to ``ravn.task.dispatch`` on the configured RabbitMQ exchange
+    and executes each incoming task autonomously.  Requires Sleipnir to be
+    enabled: set ``sleipnir.enabled: true`` in ravn.yaml and provide the
+    ``SLEIPNIR_AMQP_URL`` environment variable.
+
+    The persona requested in each dispatch event is validated; tasks with
+    unknown personas are rejected and a ``ravn.task.rejected`` event is
+    published back to the exchange.
+    """
+    if config:
+        os.environ["RAVN_CONFIG"] = config
+
+    settings = Settings()
+    _configure_logging(settings)
+    project_config = ProjectConfig.discover()
+    persona_config = _resolve_persona(persona, project_config)
+
+    asyncio.run(
+        _run_daemon(settings, persona_config=persona_config, task_dispatch=True)
+    )
+
+
 async def _run_daemon(
     settings: Settings,
     *,
     persona_config: Any | None = None,
+    task_dispatch: bool = False,
 ) -> None:
     """Build and run the gateway + drive loop until interrupted."""
     from ravn.adapters.channels.gateway import RavnGateway
@@ -1441,7 +1473,7 @@ async def _run_daemon(
     event_publisher: EventPublisherPort = NoOpEventPublisher()
     trigger_names: list[str] = []
     drive_loop: Any = None
-    if settings.initiative.enabled:
+    if settings.initiative.enabled or task_dispatch:
         if settings.sleipnir.enabled:
             event_publisher = RabbitMQEventPublisher(settings.sleipnir)
 
@@ -1452,6 +1484,16 @@ async def _run_daemon(
             event_publisher=event_publisher,
         )
         _wire_triggers(drive_loop, settings.initiative)
+
+        # Wire task dispatch subscription when requested (--listen / --daemon)
+        if task_dispatch and settings.sleipnir.enabled:
+            _wire_task_dispatch(drive_loop, settings.sleipnir)
+        elif task_dispatch:
+            logger.warning(
+                "task_dispatch: Sleipnir not enabled — ravn.task.dispatch subscription"
+                " requires sleipnir.enabled: true and %s to be set",
+                settings.sleipnir.amqp_url_env,
+            )
 
         # Wire cascade tools when enabled (Mode 1 local + optional mesh/spawn)
         if settings.cascade.enabled:
@@ -1536,6 +1578,15 @@ def _wire_triggers(drive_loop: Any, initiative: InitiativeConfig) -> None:
 
         except Exception as exc:
             logger.error("Failed to wire trigger %r: %s", tc.name, exc)
+
+
+def _wire_task_dispatch(drive_loop: Any, sleipnir_config: Any) -> None:
+    """Register a TaskDispatchChannel as a drive-loop trigger (NIU-505)."""
+    from ravn.adapters.channels.event import TaskDispatchChannel
+
+    channel = TaskDispatchChannel(sleipnir_config)
+    drive_loop.register_trigger(channel)
+    logger.info("task_dispatch: registered ravn.task.dispatch subscription")
 
 
 def _wire_cascade(drive_loop: Any, settings: Settings) -> None:

--- a/tests/ravn/unit/test_event_publisher.py
+++ b/tests/ravn/unit/test_event_publisher.py
@@ -156,8 +156,8 @@ async def test_rabbitmq_publisher_uses_system_routing_key() -> None:
     mock_message_instance = MagicMock()
     mock_pika.Message.return_value = mock_message_instance
 
-    # Patch the module-level aio_pika reference directly
-    with patch("ravn.adapters.events.rabbitmq_publisher.aio_pika", mock_pika):
+    # Patch the module-level aio_pika reference in the shared base
+    with patch("ravn.adapters.channels._rabbitmq_base.aio_pika", mock_pika):
         await pub.publish(_make_event(RavnEventType.TASK_STARTED))
 
     mock_exchange.publish.assert_called_once()

--- a/tests/ravn/unit/test_sleipnir_channel.py
+++ b/tests/ravn/unit/test_sleipnir_channel.py
@@ -182,6 +182,7 @@ class TestSleipnirChannelPublishFailure:
         with patch.dict("os.environ", {}, clear=False):
             # Remove the env var if present
             import os
+
             os.environ.pop("SLEIPNIR_AMQP_URL", None)
             # Must not raise
             await channel.emit(_event())
@@ -189,17 +190,19 @@ class TestSleipnirChannelPublishFailure:
     @pytest.mark.asyncio
     async def test_emit_does_not_raise_when_aio_pika_missing(self) -> None:
         """aio_pika ImportError → emit silently drops the event."""
+        import ravn.adapters.channels._rabbitmq_base as base_mod
+
         config = _config()
         channel = SleipnirChannel(config, session_id="sess-1")
 
         with patch.dict("os.environ", {"SLEIPNIR_AMQP_URL": "amqp://localhost"}):
-            with patch.dict("sys.modules", {"aio_pika": None}):
+            with patch.object(base_mod, "aio_pika", None):
                 await channel.emit(_event())
 
     @pytest.mark.asyncio
     async def test_emit_logs_debug_on_publish_failure(self) -> None:
         """A publish exception is logged at DEBUG and not re-raised."""
-        import ravn.adapters.channels.sleipnir as sleipnir_mod
+        import ravn.adapters.channels._rabbitmq_base as base_mod
 
         config = _config(reconnect_delay_s=0.0)
         channel = SleipnirChannel(config, session_id="sess-1")
@@ -215,8 +218,8 @@ class TestSleipnirChannelPublishFailure:
         fake_aio_pika = MagicMock()
         fake_aio_pika.Message = MagicMock(return_value=MagicMock())
 
-        with patch("ravn.adapters.channels.sleipnir.logger") as mock_logger:
-            with patch.object(sleipnir_mod, "aio_pika", fake_aio_pika):
+        with patch("ravn.adapters.channels._rabbitmq_base.logger") as mock_logger:
+            with patch.object(base_mod, "aio_pika", fake_aio_pika):
                 await channel.emit(_event())
 
         mock_logger.debug.assert_called()
@@ -224,7 +227,7 @@ class TestSleipnirChannelPublishFailure:
     @pytest.mark.asyncio
     async def test_emit_invalidates_connection_after_failure(self) -> None:
         """Exchange is cleared after a publish failure to force reconnect."""
-        import ravn.adapters.channels.sleipnir as sleipnir_mod
+        import ravn.adapters.channels._rabbitmq_base as base_mod
 
         config = _config(reconnect_delay_s=0.0)
         channel = SleipnirChannel(config, session_id="sess-1")
@@ -238,7 +241,7 @@ class TestSleipnirChannelPublishFailure:
         fake_aio_pika = MagicMock()
         fake_aio_pika.Message = MagicMock(return_value=MagicMock())
 
-        with patch.object(sleipnir_mod, "aio_pika", fake_aio_pika):
+        with patch.object(base_mod, "aio_pika", fake_aio_pika):
             await channel.emit(_event())
 
         assert channel._exchange is None
@@ -248,7 +251,7 @@ class TestSleipnirChannelPublishFailure:
         """SleipnirEnvelope.session_id matches the session passed to constructor."""
         import json
 
-        import ravn.adapters.channels.sleipnir as sleipnir_mod
+        import ravn.adapters.channels._rabbitmq_base as base_mod
 
         config = _config(reconnect_delay_s=0.0)
         channel = SleipnirChannel(config, session_id="my-special-session")
@@ -272,7 +275,7 @@ class TestSleipnirChannelPublishFailure:
         fake_aio_pika = MagicMock()
         fake_aio_pika.Message = FakeMessage
 
-        with patch.object(sleipnir_mod, "aio_pika", fake_aio_pika):
+        with patch.object(base_mod, "aio_pika", fake_aio_pika):
             await channel.emit(_event())
 
         assert len(captured) == 1
@@ -284,7 +287,7 @@ class TestSleipnirChannelPublishFailure:
         """SleipnirEnvelope.task_id matches the task_id passed to constructor."""
         import json
 
-        import ravn.adapters.channels.sleipnir as sleipnir_mod
+        import ravn.adapters.channels._rabbitmq_base as base_mod
 
         config = _config(reconnect_delay_s=0.0)
         channel = SleipnirChannel(config, session_id="sess", task_id="drive-task-42")
@@ -308,7 +311,7 @@ class TestSleipnirChannelPublishFailure:
         fake_aio_pika = MagicMock()
         fake_aio_pika.Message = FakeMessage
 
-        with patch.object(sleipnir_mod, "aio_pika", fake_aio_pika):
+        with patch.object(base_mod, "aio_pika", fake_aio_pika):
             await channel.emit(_event())
 
         assert len(captured) == 1
@@ -318,7 +321,7 @@ class TestSleipnirChannelPublishFailure:
     @pytest.mark.asyncio
     async def test_routing_key_format(self) -> None:
         """Routing key uses ravn.<event_type>.<agent_id> format."""
-        import ravn.adapters.channels.sleipnir as sleipnir_mod
+        import ravn.adapters.channels._rabbitmq_base as base_mod
 
         config = _config(agent_id="my-bot", reconnect_delay_s=0.0)
         channel = SleipnirChannel(config, session_id="sess")
@@ -343,7 +346,7 @@ class TestSleipnirChannelPublishFailure:
         fake_aio_pika.Message = FakeMessage
 
         event = _event(RavnEventType.THOUGHT)
-        with patch.object(sleipnir_mod, "aio_pika", fake_aio_pika):
+        with patch.object(base_mod, "aio_pika", fake_aio_pika):
             await channel.emit(event)
 
         assert routing_keys == ["ravn.thought.my-bot"]
@@ -351,7 +354,7 @@ class TestSleipnirChannelPublishFailure:
     @pytest.mark.asyncio
     async def test_reconnect_not_attempted_before_delay(self) -> None:
         """A second emit within reconnect_delay_s does not attempt a new connection."""
-        import ravn.adapters.channels.sleipnir as sleipnir_mod
+        import ravn.adapters.channels._rabbitmq_base as base_mod
 
         config = _config(reconnect_delay_s=999.0)
         channel = SleipnirChannel(config, session_id="sess")
@@ -363,7 +366,7 @@ class TestSleipnirChannelPublishFailure:
         fake_aio_pika.connect_robust = AsyncMock()
 
         with patch.dict("os.environ", {"SLEIPNIR_AMQP_URL": "amqp://localhost"}):
-            with patch.object(sleipnir_mod, "aio_pika", fake_aio_pika):
+            with patch.object(base_mod, "aio_pika", fake_aio_pika):
                 await channel.emit(_event())
                 fake_aio_pika.connect_robust.assert_not_called()
 

--- a/tests/ravn/unit/test_task_dispatch.py
+++ b/tests/ravn/unit/test_task_dispatch.py
@@ -271,22 +271,56 @@ class TestHandleMessage:
         assert enqueued[0].deadline is None
 
     @pytest.mark.asyncio
-    async def test_malformed_json_does_not_raise(self) -> None:
-        """A non-JSON message body should not raise — it's treated as empty payload."""
+    async def test_malformed_json_publishes_rejected(self) -> None:
+        """Non-JSON body → publish ravn.task.rejected, do not enqueue."""
         loader = _fake_persona_loader(["autonomous-agent"])
         ch = TaskDispatchChannel(_config(), persona_loader=loader)
 
         enqueued: list[AgentTask] = []
+        published: list[tuple[str, dict]] = []
 
         async def _enqueue(task: AgentTask) -> None:
             enqueued.append(task)
 
-        ch._publish_response = AsyncMock()  # type: ignore[method-assign]
+        async def _fake_publish(routing_key: str, payload: dict) -> None:
+            published.append((routing_key, payload))
+
+        ch._publish_response = _fake_publish  # type: ignore[method-assign]
 
         msg = FakeMessage(b"this is not json")
-        # Should not raise; persona defaults to autonomous-agent
-        # but autonomous-agent is in known personas, so it gets enqueued
         await ch._handle_message(msg, _enqueue)
+
+        assert len(enqueued) == 0
+        assert len(published) == 1
+        rk, payload = published[0]
+        assert rk == ROUTING_REJECTED
+        assert "malformed" in payload["reason"]
+
+    @pytest.mark.asyncio
+    async def test_empty_task_field_is_rejected(self) -> None:
+        """Empty/missing task field → publish ravn.task.rejected, do not enqueue."""
+        loader = _fake_persona_loader(["autonomous-agent"])
+        ch = TaskDispatchChannel(_config(), persona_loader=loader)
+
+        enqueued: list[AgentTask] = []
+        published: list[tuple[str, dict]] = []
+
+        async def _enqueue(task: AgentTask) -> None:
+            enqueued.append(task)
+
+        async def _fake_publish(routing_key: str, payload: dict) -> None:
+            published.append((routing_key, payload))
+
+        ch._publish_response = _fake_publish  # type: ignore[method-assign]
+
+        msg = FakeMessage(_dispatch_payload(task=""))
+        await ch._handle_message(msg, _enqueue)
+
+        assert len(enqueued) == 0
+        assert len(published) == 1
+        rk, payload = published[0]
+        assert rk == ROUTING_REJECTED
+        assert "task" in payload["reason"]
 
     @pytest.mark.asyncio
     async def test_context_included_in_initiative_context(self) -> None:
@@ -422,19 +456,19 @@ class TestPublishResponse:
     @pytest.mark.asyncio
     async def test_no_aio_pika_drops_silently(self) -> None:
         """aio_pika not installed → _publish_response drops silently."""
+        import ravn.adapters.channels._rabbitmq_base as base_mod
+
         ch = TaskDispatchChannel(_config())
-        ch._pub_exchange = MagicMock()
+        ch._exchange = MagicMock()
 
-        import ravn.adapters.channels.event as event_mod
-
-        with patch.object(event_mod, "aio_pika", None):
+        with patch.object(base_mod, "aio_pika", None):
             await ch._publish_response(ROUTING_ACCEPTED, {"task_id": "t1"})
         # No exception
 
     @pytest.mark.asyncio
     async def test_publish_uses_correct_routing_key(self) -> None:
         """_publish_response publishes to the exact routing_key passed in."""
-        import ravn.adapters.channels.event as event_mod
+        import ravn.adapters.channels._rabbitmq_base as base_mod
 
         ch = TaskDispatchChannel(_config(reconnect_delay_s=0.0))
 
@@ -450,14 +484,14 @@ class TestPublishResponse:
             published_keys.append(routing_key)
 
         mock_exchange.publish.side_effect = fake_publish
-        ch._pub_exchange = mock_exchange
-        ch._pub_connection = AsyncMock()
-        ch._pub_channel = AsyncMock()
+        ch._exchange = mock_exchange
+        ch._connection = AsyncMock()
+        ch._channel = AsyncMock()
 
         fake_pika = MagicMock()
         fake_pika.Message = FakeMsgCls
 
-        with patch.object(event_mod, "aio_pika", fake_pika):
+        with patch.object(base_mod, "aio_pika", fake_pika):
             await ch._publish_response(ROUTING_ACCEPTED, {"task_id": "t1"})
 
         assert published_keys == [ROUTING_ACCEPTED]
@@ -465,31 +499,31 @@ class TestPublishResponse:
     @pytest.mark.asyncio
     async def test_publish_failure_invalidates_connection(self) -> None:
         """Exchange is cleared after publish failure to force reconnect."""
-        import ravn.adapters.channels.event as event_mod
+        import ravn.adapters.channels._rabbitmq_base as base_mod
 
         ch = TaskDispatchChannel(_config(reconnect_delay_s=0.0))
 
         mock_exchange = AsyncMock()
         mock_exchange.publish.side_effect = RuntimeError("conn reset")
-        ch._pub_exchange = mock_exchange
-        ch._pub_connection = AsyncMock()
-        ch._pub_channel = AsyncMock()
+        ch._exchange = mock_exchange
+        ch._connection = AsyncMock()
+        ch._channel = AsyncMock()
 
         fake_pika = MagicMock()
         fake_pika.Message = MagicMock(return_value=MagicMock())
 
-        with patch.object(event_mod, "aio_pika", fake_pika):
+        with patch.object(base_mod, "aio_pika", fake_pika):
             await ch._publish_response(ROUTING_ACCEPTED, {"task_id": "t1"})
 
-        assert ch._pub_exchange is None
+        assert ch._exchange is None
 
     @pytest.mark.asyncio
     async def test_reconnect_delay_respected(self) -> None:
         """Reconnect is not attempted within reconnect_delay_s."""
         ch = TaskDispatchChannel(_config(reconnect_delay_s=999.0))
-        ch._last_pub_attempt = asyncio.get_event_loop().time()
+        ch._last_connect_attempt = asyncio.get_event_loop().time()
 
-        result = await ch._ensure_pub_exchange()
+        result = await ch._ensure_exchange()
         assert result is None
 
 
@@ -531,7 +565,7 @@ class TestRunMethod:
         """run() retries after a connection error."""
         import ravn.adapters.channels.event as event_mod
 
-        ch = TaskDispatchChannel(_config(reconnect_delay_s=0.0), retry_delay_seconds=0.0)
+        ch = TaskDispatchChannel(_config(reconnect_delay_s=0.0))
         call_count = 0
 
         async def failing_consume(*_args, **_kwargs):
@@ -570,17 +604,17 @@ class TestTriggerPortCompliance:
 
 
 # ---------------------------------------------------------------------------
-# TaskDispatchChannel — _connect_pub success / error paths
+# TaskDispatchChannel — _connect / _ensure_exchange / _invalidate paths
 # ---------------------------------------------------------------------------
 
 
 class TestConnectPub:
     @pytest.mark.asyncio
-    async def test_connect_pub_success_stores_exchange(self) -> None:
-        """_connect_pub sets pub_exchange when connection succeeds."""
+    async def test_connect_success_stores_exchange(self) -> None:
+        """_connect sets _exchange when connection succeeds."""
         import os
 
-        import ravn.adapters.channels.event as event_mod
+        import ravn.adapters.channels._rabbitmq_base as base_mod
 
         ch = TaskDispatchChannel(_config(reconnect_delay_s=0.0))
 
@@ -595,18 +629,18 @@ class TestConnectPub:
         fake_pika.ExchangeType.TOPIC = "topic"
 
         with patch.dict(os.environ, {"SLEIPNIR_AMQP_URL": "amqp://localhost"}):
-            with patch.object(event_mod, "aio_pika", fake_pika):
-                result = await ch._connect_pub()
+            with patch.object(base_mod, "aio_pika", fake_pika):
+                result = await ch._connect()
 
         assert result is mock_exchange
-        assert ch._pub_exchange is mock_exchange
+        assert ch._exchange is mock_exchange
 
     @pytest.mark.asyncio
-    async def test_connect_pub_failure_returns_none(self) -> None:
-        """_connect_pub returns None when connection raises."""
+    async def test_connect_failure_returns_none(self) -> None:
+        """_connect returns None when connection raises."""
         import os
 
-        import ravn.adapters.channels.event as event_mod
+        import ravn.adapters.channels._rabbitmq_base as base_mod
 
         ch = TaskDispatchChannel(_config(reconnect_delay_s=0.0))
 
@@ -614,72 +648,67 @@ class TestConnectPub:
         fake_pika.connect_robust = AsyncMock(side_effect=ConnectionError("refused"))
 
         with patch.dict(os.environ, {"SLEIPNIR_AMQP_URL": "amqp://localhost"}):
-            with patch.object(event_mod, "aio_pika", fake_pika):
-                result = await ch._connect_pub()
+            with patch.object(base_mod, "aio_pika", fake_pika):
+                result = await ch._connect()
 
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_connect_pub_no_aio_pika_returns_none(self) -> None:
-        import ravn.adapters.channels.event as event_mod
+    async def test_connect_no_aio_pika_returns_none(self) -> None:
+        import ravn.adapters.channels._rabbitmq_base as base_mod
 
         ch = TaskDispatchChannel(_config(reconnect_delay_s=0.0))
-        with patch.object(event_mod, "aio_pika", None):
-            result = await ch._connect_pub()
+        with patch.object(base_mod, "aio_pika", None):
+            result = await ch._connect()
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_ensure_pub_exchange_double_check_locking(self) -> None:
+    async def test_ensure_exchange_double_check_locking(self) -> None:
         """Second waiter in lock sees exchange already set."""
         ch = TaskDispatchChannel(_config(reconnect_delay_s=0.0))
 
         sentinel = MagicMock()
 
-        async def _slow_connect():
-            await asyncio.sleep(0)
-            ch._pub_exchange = sentinel
-            return sentinel
-
         # Pre-seed: exchange is None but gets set during the lock wait
         async def _acquire_then_check():
-            async with ch._pub_lock:
+            async with ch._connect_lock:
                 # Another coroutine already set it inside the lock
-                ch._pub_exchange = sentinel
-            return await ch._ensure_pub_exchange()
+                ch._exchange = sentinel
+            return await ch._ensure_exchange()
 
         result = await _acquire_then_check()
         assert result is sentinel
 
     @pytest.mark.asyncio
-    async def test_invalidate_pub_closes_connection(self) -> None:
-        """_invalidate_pub closes existing connection and clears all fields."""
+    async def test_invalidate_closes_connection(self) -> None:
+        """_invalidate closes existing connection and clears all fields."""
         ch = TaskDispatchChannel(_config())
 
         mock_conn = AsyncMock()
-        ch._pub_connection = mock_conn
-        ch._pub_exchange = MagicMock()
-        ch._pub_channel = MagicMock()
+        ch._connection = mock_conn
+        ch._exchange = MagicMock()
+        ch._channel = MagicMock()
 
-        await ch._invalidate_pub()
+        await ch._invalidate()
 
-        assert ch._pub_exchange is None
-        assert ch._pub_channel is None
-        assert ch._pub_connection is None
+        assert ch._exchange is None
+        assert ch._channel is None
+        assert ch._connection is None
         mock_conn.close.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_invalidate_pub_swallows_close_error(self) -> None:
-        """_invalidate_pub does not raise if connection.close() fails."""
+    async def test_invalidate_swallows_close_error(self) -> None:
+        """_invalidate does not raise if connection.close() fails."""
         ch = TaskDispatchChannel(_config())
 
         mock_conn = AsyncMock()
         mock_conn.close.side_effect = RuntimeError("already closed")
-        ch._pub_connection = mock_conn
-        ch._pub_exchange = MagicMock()
+        ch._connection = mock_conn
+        ch._exchange = MagicMock()
 
         # Must not raise
-        await ch._invalidate_pub()
-        assert ch._pub_connection is None
+        await ch._invalidate()
+        assert ch._connection is None
 
 
 # ---------------------------------------------------------------------------
@@ -695,7 +724,7 @@ class TestConnectAndConsume:
 
         import ravn.adapters.channels.event as event_mod
 
-        ch = TaskDispatchChannel(_config(retry_delay_seconds=0.0), retry_delay_seconds=0.0)
+        ch = TaskDispatchChannel(_config())
         enqueued: list = []
 
         async def _enqueue(task):

--- a/tests/ravn/unit/test_task_dispatch.py
+++ b/tests/ravn/unit/test_task_dispatch.py
@@ -1,0 +1,792 @@
+"""Unit tests for TaskDispatchChannel (NIU-505)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ravn.adapters.channels.event import (
+    ROUTING_ACCEPTED,
+    ROUTING_COMPLETED,
+    ROUTING_FAILED,
+    ROUTING_PROGRESS,
+    ROUTING_REJECTED,
+    TaskDispatchChannel,
+    _build_initiative_context,
+    _parse_deadline,
+)
+from ravn.adapters.personas.loader import PersonaConfig, PersonaLoader
+from ravn.config import SleipnirConfig
+from ravn.domain.models import AgentTask, OutputMode
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _config(**kwargs) -> SleipnirConfig:
+    defaults = dict(
+        enabled=True,
+        amqp_url_env="SLEIPNIR_AMQP_URL",
+        exchange="ravn.events",
+        agent_id="test-agent",
+        reconnect_delay_s=0.0,
+        publish_timeout_s=2.0,
+    )
+    defaults.update(kwargs)
+    return SleipnirConfig(**defaults)
+
+
+def _dispatch_payload(**kwargs) -> bytes:
+    """Build a valid ravn.task.dispatch message body."""
+    base = {
+        "type": "ravn.task.dispatch",
+        "task_id": "task-abc-123",
+        "persona": "autonomous-agent",
+        "task": "Review all open PRs and summarise status",
+        "context": {"org": "niuulabs"},
+        "deadline": None,
+        "dispatched_by": "tyr",
+    }
+    base.update(kwargs)
+    return json.dumps(base).encode("utf-8")
+
+
+def _fake_persona_loader(names: list[str]) -> PersonaLoader:
+    """Return a PersonaLoader that only knows the listed persona names."""
+    loader = MagicMock(spec=PersonaLoader)
+
+    def _load(name: str) -> PersonaConfig | None:
+        if name in names:
+            return PersonaConfig(name=name)
+        return None
+
+    loader.load.side_effect = _load
+    return loader
+
+
+class FakeMessage:
+    """Minimal aio_pika message stub for unit tests."""
+
+    def __init__(self, body: bytes, routing_key: str = "ravn.task.dispatch") -> None:
+        self.body = body
+        self.routing_key = routing_key
+
+
+# ---------------------------------------------------------------------------
+# Utility function tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseDeadline:
+    def test_none_returns_none(self) -> None:
+        assert _parse_deadline(None) is None
+
+    def test_empty_string_returns_none(self) -> None:
+        assert _parse_deadline("") is None
+
+    def test_valid_iso_string(self) -> None:
+        result = _parse_deadline("2026-04-05T00:00:00Z")
+        assert result is not None
+        assert result.year == 2026
+
+    def test_invalid_string_returns_none(self) -> None:
+        assert _parse_deadline("not-a-date") is None
+
+
+class TestBuildInitiativeContext:
+    def test_no_context(self) -> None:
+        result = _build_initiative_context("do the thing", {})
+        assert result == "do the thing"
+
+    def test_with_context(self) -> None:
+        result = _build_initiative_context("do the thing", {"key": "val"})
+        assert "do the thing" in result
+        assert "key" in result
+        assert "val" in result
+
+    def test_empty_task(self) -> None:
+        result = _build_initiative_context("", {"a": 1})
+        assert "a" in result
+
+
+# ---------------------------------------------------------------------------
+# Routing key constants
+# ---------------------------------------------------------------------------
+
+
+class TestRoutingKeyConstants:
+    def test_accepted_key(self) -> None:
+        assert ROUTING_ACCEPTED == "ravn.task.accepted"
+
+    def test_rejected_key(self) -> None:
+        assert ROUTING_REJECTED == "ravn.task.rejected"
+
+    def test_progress_key(self) -> None:
+        assert ROUTING_PROGRESS == "ravn.task.progress"
+
+    def test_completed_key(self) -> None:
+        assert ROUTING_COMPLETED == "ravn.task.completed"
+
+    def test_failed_key(self) -> None:
+        assert ROUTING_FAILED == "ravn.task.failed"
+
+
+# ---------------------------------------------------------------------------
+# TaskDispatchChannel — construction
+# ---------------------------------------------------------------------------
+
+
+class TestTaskDispatchChannelConstruction:
+    def test_name_includes_agent_id(self) -> None:
+        ch = TaskDispatchChannel(_config(agent_id="my-bot"))
+        assert "my-bot" in ch.name
+
+    def test_name_format(self) -> None:
+        ch = TaskDispatchChannel(_config(agent_id="x"))
+        assert ch.name == "task_dispatch:x"
+
+    def test_default_persona_loader(self) -> None:
+        ch = TaskDispatchChannel(_config())
+        assert isinstance(ch._persona_loader, PersonaLoader)
+
+    def test_custom_persona_loader(self) -> None:
+        loader = MagicMock(spec=PersonaLoader)
+        ch = TaskDispatchChannel(_config(), persona_loader=loader)
+        assert ch._persona_loader is loader
+
+
+# ---------------------------------------------------------------------------
+# TaskDispatchChannel — handle_message (persona validation)
+# ---------------------------------------------------------------------------
+
+
+class TestHandleMessage:
+    @pytest.mark.asyncio
+    async def test_unknown_persona_is_rejected(self) -> None:
+        """Unknown persona → publish ravn.task.rejected, do not enqueue."""
+        loader = _fake_persona_loader(["coding-agent"])  # not autonomous-agent
+        ch = TaskDispatchChannel(_config(), persona_loader=loader)
+
+        enqueued: list[AgentTask] = []
+        published: list[tuple[str, dict]] = []
+
+        async def _enqueue(task: AgentTask) -> None:
+            enqueued.append(task)
+
+        async def _fake_publish(routing_key: str, payload: dict) -> None:
+            published.append((routing_key, payload))
+
+        ch._publish_response = _fake_publish  # type: ignore[method-assign]
+
+        msg = FakeMessage(_dispatch_payload(persona="autonomous-agent"))
+        await ch._handle_message(msg, _enqueue)
+
+        assert len(enqueued) == 0
+        assert len(published) == 1
+        rk, payload = published[0]
+        assert rk == ROUTING_REJECTED
+        assert "autonomous-agent" in payload["reason"]
+
+    @pytest.mark.asyncio
+    async def test_known_persona_is_accepted_and_enqueued(self) -> None:
+        """Known persona → publish ravn.task.accepted and enqueue the task."""
+        loader = _fake_persona_loader(["autonomous-agent"])
+        ch = TaskDispatchChannel(_config(), persona_loader=loader)
+
+        enqueued: list[AgentTask] = []
+        published: list[tuple[str, dict]] = []
+
+        async def _enqueue(task: AgentTask) -> None:
+            enqueued.append(task)
+
+        async def _fake_publish(routing_key: str, payload: dict) -> None:
+            published.append((routing_key, payload))
+
+        ch._publish_response = _fake_publish  # type: ignore[method-assign]
+
+        msg = FakeMessage(_dispatch_payload())
+        await ch._handle_message(msg, _enqueue)
+
+        assert len(enqueued) == 1
+        assert enqueued[0].task_id == "task-abc-123"
+        assert enqueued[0].persona == "autonomous-agent"
+        assert enqueued[0].output_mode == OutputMode.AMBIENT
+
+        assert len(published) == 1
+        rk, _ = published[0]
+        assert rk == ROUTING_ACCEPTED
+
+    @pytest.mark.asyncio
+    async def test_task_id_from_payload(self) -> None:
+        loader = _fake_persona_loader(["autonomous-agent"])
+        ch = TaskDispatchChannel(_config(), persona_loader=loader)
+        enqueued: list[AgentTask] = []
+
+        async def _enqueue(task: AgentTask) -> None:
+            enqueued.append(task)
+
+        ch._publish_response = AsyncMock()  # type: ignore[method-assign]
+
+        msg = FakeMessage(_dispatch_payload(task_id="custom-id-42"))
+        await ch._handle_message(msg, _enqueue)
+
+        assert enqueued[0].task_id == "custom-id-42"
+
+    @pytest.mark.asyncio
+    async def test_deadline_parsed(self) -> None:
+        loader = _fake_persona_loader(["autonomous-agent"])
+        ch = TaskDispatchChannel(_config(), persona_loader=loader)
+        enqueued: list[AgentTask] = []
+
+        async def _enqueue(task: AgentTask) -> None:
+            enqueued.append(task)
+
+        ch._publish_response = AsyncMock()  # type: ignore[method-assign]
+
+        future = (datetime.now(UTC) + timedelta(days=1)).isoformat()
+        msg = FakeMessage(_dispatch_payload(deadline=future))
+        await ch._handle_message(msg, _enqueue)
+
+        assert enqueued[0].deadline is not None
+
+    @pytest.mark.asyncio
+    async def test_invalid_deadline_ignored(self) -> None:
+        loader = _fake_persona_loader(["autonomous-agent"])
+        ch = TaskDispatchChannel(_config(), persona_loader=loader)
+        enqueued: list[AgentTask] = []
+
+        async def _enqueue(task: AgentTask) -> None:
+            enqueued.append(task)
+
+        ch._publish_response = AsyncMock()  # type: ignore[method-assign]
+
+        msg = FakeMessage(_dispatch_payload(deadline="not-a-date"))
+        await ch._handle_message(msg, _enqueue)
+
+        assert enqueued[0].deadline is None
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_does_not_raise(self) -> None:
+        """A non-JSON message body should not raise — it's treated as empty payload."""
+        loader = _fake_persona_loader(["autonomous-agent"])
+        ch = TaskDispatchChannel(_config(), persona_loader=loader)
+
+        enqueued: list[AgentTask] = []
+
+        async def _enqueue(task: AgentTask) -> None:
+            enqueued.append(task)
+
+        ch._publish_response = AsyncMock()  # type: ignore[method-assign]
+
+        msg = FakeMessage(b"this is not json")
+        # Should not raise; persona defaults to autonomous-agent
+        # but autonomous-agent is in known personas, so it gets enqueued
+        await ch._handle_message(msg, _enqueue)
+
+    @pytest.mark.asyncio
+    async def test_context_included_in_initiative_context(self) -> None:
+        loader = _fake_persona_loader(["autonomous-agent"])
+        ch = TaskDispatchChannel(_config(), persona_loader=loader)
+        enqueued: list[AgentTask] = []
+
+        async def _enqueue(task: AgentTask) -> None:
+            enqueued.append(task)
+
+        ch._publish_response = AsyncMock()  # type: ignore[method-assign]
+
+        msg = FakeMessage(
+            _dispatch_payload(
+                task="do something",
+                context={"repo": "niuulabs/volundr"},
+            )
+        )
+        await ch._handle_message(msg, _enqueue)
+
+        assert "niuulabs/volundr" in enqueued[0].initiative_context
+
+    @pytest.mark.asyncio
+    async def test_accepted_payload_contains_task_id_and_agent(self) -> None:
+        loader = _fake_persona_loader(["autonomous-agent"])
+        ch = TaskDispatchChannel(_config(agent_id="my-agent"), persona_loader=loader)
+
+        published: list[tuple[str, dict]] = []
+
+        async def _fake_publish(routing_key: str, payload: dict) -> None:
+            published.append((routing_key, payload))
+
+        ch._publish_response = _fake_publish  # type: ignore[method-assign]
+
+        enqueued: list[AgentTask] = []
+
+        async def _enqueue(task: AgentTask) -> None:
+            enqueued.append(task)
+
+        msg = FakeMessage(_dispatch_payload(task_id="t-99"))
+        await ch._handle_message(msg, _enqueue)
+
+        _, payload = published[0]
+        assert payload["task_id"] == "t-99"
+        assert payload["agent_id"] == "my-agent"
+
+    @pytest.mark.asyncio
+    async def test_rejected_payload_contains_reason(self) -> None:
+        loader = _fake_persona_loader([])  # no known personas
+        ch = TaskDispatchChannel(_config(), persona_loader=loader)
+
+        published: list[tuple[str, dict]] = []
+
+        async def _fake_publish(routing_key: str, payload: dict) -> None:
+            published.append((routing_key, payload))
+
+        ch._publish_response = _fake_publish  # type: ignore[method-assign]
+
+        msg = FakeMessage(_dispatch_payload(persona="hacker-persona"))
+        await ch._handle_message(msg, AsyncMock())
+
+        _, payload = published[0]
+        assert "reason" in payload
+        assert "hacker-persona" in payload["reason"]
+
+
+# ---------------------------------------------------------------------------
+# TaskDispatchChannel — outbound publish methods
+# ---------------------------------------------------------------------------
+
+
+class TestOutboundPublishMethods:
+    @pytest.mark.asyncio
+    async def test_publish_progress(self) -> None:
+        ch = TaskDispatchChannel(_config())
+        ch._publish_response = AsyncMock()  # type: ignore[method-assign]
+
+        await ch.publish_progress("task-1", iteration=3, message="still running")
+
+        ch._publish_response.assert_awaited_once()
+        rk = ch._publish_response.call_args[0][0]
+        payload = ch._publish_response.call_args[0][1]
+        assert rk == ROUTING_PROGRESS
+        assert payload["task_id"] == "task-1"
+        assert payload["iteration"] == 3
+
+    @pytest.mark.asyncio
+    async def test_publish_completed(self) -> None:
+        ch = TaskDispatchChannel(_config())
+        ch._publish_response = AsyncMock()  # type: ignore[method-assign]
+
+        await ch.publish_completed("task-2", outcome="success", summary="done")
+
+        ch._publish_response.assert_awaited_once()
+        rk = ch._publish_response.call_args[0][0]
+        payload = ch._publish_response.call_args[0][1]
+        assert rk == ROUTING_COMPLETED
+        assert payload["task_id"] == "task-2"
+        assert payload["outcome"] == "success"
+
+    @pytest.mark.asyncio
+    async def test_publish_failed(self) -> None:
+        ch = TaskDispatchChannel(_config())
+        ch._publish_response = AsyncMock()  # type: ignore[method-assign]
+
+        await ch.publish_failed("task-3", error="agent exploded")
+
+        ch._publish_response.assert_awaited_once()
+        rk = ch._publish_response.call_args[0][0]
+        payload = ch._publish_response.call_args[0][1]
+        assert rk == ROUTING_FAILED
+        assert payload["task_id"] == "task-3"
+        assert payload["error"] == "agent exploded"
+
+
+# ---------------------------------------------------------------------------
+# TaskDispatchChannel — publish_response (outbound connection)
+# ---------------------------------------------------------------------------
+
+
+class TestPublishResponse:
+    @pytest.mark.asyncio
+    async def test_no_amqp_url_drops_silently(self) -> None:
+        """Missing AMQP URL → _publish_response drops event without raising."""
+        ch = TaskDispatchChannel(_config(amqp_url_env="NONEXISTENT_VAR"))
+
+        import os
+
+        os.environ.pop("NONEXISTENT_VAR", None)
+        # Must not raise
+        await ch._publish_response(ROUTING_ACCEPTED, {"task_id": "t1"})
+
+    @pytest.mark.asyncio
+    async def test_no_aio_pika_drops_silently(self) -> None:
+        """aio_pika not installed → _publish_response drops silently."""
+        ch = TaskDispatchChannel(_config())
+        ch._pub_exchange = MagicMock()
+
+        import ravn.adapters.channels.event as event_mod
+
+        with patch.object(event_mod, "aio_pika", None):
+            await ch._publish_response(ROUTING_ACCEPTED, {"task_id": "t1"})
+        # No exception
+
+    @pytest.mark.asyncio
+    async def test_publish_uses_correct_routing_key(self) -> None:
+        """_publish_response publishes to the exact routing_key passed in."""
+        import ravn.adapters.channels.event as event_mod
+
+        ch = TaskDispatchChannel(_config(reconnect_delay_s=0.0))
+
+        published_keys: list[str] = []
+
+        class FakeMsgCls:
+            def __init__(self, body, **kwargs):
+                self.body = body
+
+        mock_exchange = AsyncMock()
+
+        async def fake_publish(message, *, routing_key):
+            published_keys.append(routing_key)
+
+        mock_exchange.publish.side_effect = fake_publish
+        ch._pub_exchange = mock_exchange
+        ch._pub_connection = AsyncMock()
+        ch._pub_channel = AsyncMock()
+
+        fake_pika = MagicMock()
+        fake_pika.Message = FakeMsgCls
+
+        with patch.object(event_mod, "aio_pika", fake_pika):
+            await ch._publish_response(ROUTING_ACCEPTED, {"task_id": "t1"})
+
+        assert published_keys == [ROUTING_ACCEPTED]
+
+    @pytest.mark.asyncio
+    async def test_publish_failure_invalidates_connection(self) -> None:
+        """Exchange is cleared after publish failure to force reconnect."""
+        import ravn.adapters.channels.event as event_mod
+
+        ch = TaskDispatchChannel(_config(reconnect_delay_s=0.0))
+
+        mock_exchange = AsyncMock()
+        mock_exchange.publish.side_effect = RuntimeError("conn reset")
+        ch._pub_exchange = mock_exchange
+        ch._pub_connection = AsyncMock()
+        ch._pub_channel = AsyncMock()
+
+        fake_pika = MagicMock()
+        fake_pika.Message = MagicMock(return_value=MagicMock())
+
+        with patch.object(event_mod, "aio_pika", fake_pika):
+            await ch._publish_response(ROUTING_ACCEPTED, {"task_id": "t1"})
+
+        assert ch._pub_exchange is None
+
+    @pytest.mark.asyncio
+    async def test_reconnect_delay_respected(self) -> None:
+        """Reconnect is not attempted within reconnect_delay_s."""
+        ch = TaskDispatchChannel(_config(reconnect_delay_s=999.0))
+        ch._last_pub_attempt = asyncio.get_event_loop().time()
+
+        result = await ch._ensure_pub_exchange()
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# TaskDispatchChannel — run() entry point
+# ---------------------------------------------------------------------------
+
+
+class TestRunMethod:
+    @pytest.mark.asyncio
+    async def test_run_exits_on_cancellation(self) -> None:
+        """run() returns cleanly when the task is cancelled."""
+        import ravn.adapters.channels.event as event_mod
+
+        ch = TaskDispatchChannel(_config())
+
+        async def fake_connect_and_consume(*_args, **_kwargs):
+            await asyncio.sleep(999)
+
+        with patch.object(ch, "_connect_and_consume", fake_connect_and_consume):
+            with patch.object(event_mod, "aio_pika", MagicMock()):
+                task = asyncio.create_task(ch.run(AsyncMock()))
+                await asyncio.sleep(0)
+                task.cancel()
+                await asyncio.wait_for(asyncio.gather(task, return_exceptions=True), timeout=2.0)
+
+    @pytest.mark.asyncio
+    async def test_run_disabled_when_aio_pika_missing(self) -> None:
+        """run() exits immediately when aio_pika is not installed."""
+        import ravn.adapters.channels.event as event_mod
+
+        ch = TaskDispatchChannel(_config())
+        with patch.object(event_mod, "aio_pika", None):
+            # Should return without raising
+            await ch.run(AsyncMock())
+
+    @pytest.mark.asyncio
+    async def test_run_retries_on_connection_error(self) -> None:
+        """run() retries after a connection error."""
+        import ravn.adapters.channels.event as event_mod
+
+        ch = TaskDispatchChannel(_config(reconnect_delay_s=0.0), retry_delay_seconds=0.0)
+        call_count = 0
+
+        async def failing_consume(*_args, **_kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise ConnectionError("refused")
+            # Second call succeeds but suspends — let the test cancel us
+            await asyncio.sleep(999)
+
+        with patch.object(ch, "_connect_and_consume", failing_consume):
+            with patch.object(event_mod, "aio_pika", MagicMock()):
+                task = asyncio.create_task(ch.run(AsyncMock()))
+                # Wait until second attempt
+                for _ in range(50):
+                    await asyncio.sleep(0)
+                    if call_count >= 2:
+                        break
+                task.cancel()
+                await asyncio.gather(task, return_exceptions=True)
+
+        assert call_count >= 2
+
+
+# ---------------------------------------------------------------------------
+# TaskDispatchChannel — TriggerPort protocol compliance
+# ---------------------------------------------------------------------------
+
+
+class TestTriggerPortCompliance:
+    def test_satisfies_trigger_port(self) -> None:
+        from ravn.ports.trigger import TriggerPort
+
+        ch = TaskDispatchChannel(_config())
+        assert isinstance(ch, TriggerPort)
+
+
+# ---------------------------------------------------------------------------
+# TaskDispatchChannel — _connect_pub success / error paths
+# ---------------------------------------------------------------------------
+
+
+class TestConnectPub:
+    @pytest.mark.asyncio
+    async def test_connect_pub_success_stores_exchange(self) -> None:
+        """_connect_pub sets pub_exchange when connection succeeds."""
+        import os
+
+        import ravn.adapters.channels.event as event_mod
+
+        ch = TaskDispatchChannel(_config(reconnect_delay_s=0.0))
+
+        mock_exchange = MagicMock()
+        mock_channel = AsyncMock()
+        mock_channel.declare_exchange = AsyncMock(return_value=mock_exchange)
+        mock_connection = AsyncMock()
+        mock_connection.channel = AsyncMock(return_value=mock_channel)
+
+        fake_pika = MagicMock()
+        fake_pika.connect_robust = AsyncMock(return_value=mock_connection)
+        fake_pika.ExchangeType.TOPIC = "topic"
+
+        with patch.dict(os.environ, {"SLEIPNIR_AMQP_URL": "amqp://localhost"}):
+            with patch.object(event_mod, "aio_pika", fake_pika):
+                result = await ch._connect_pub()
+
+        assert result is mock_exchange
+        assert ch._pub_exchange is mock_exchange
+
+    @pytest.mark.asyncio
+    async def test_connect_pub_failure_returns_none(self) -> None:
+        """_connect_pub returns None when connection raises."""
+        import os
+
+        import ravn.adapters.channels.event as event_mod
+
+        ch = TaskDispatchChannel(_config(reconnect_delay_s=0.0))
+
+        fake_pika = MagicMock()
+        fake_pika.connect_robust = AsyncMock(side_effect=ConnectionError("refused"))
+
+        with patch.dict(os.environ, {"SLEIPNIR_AMQP_URL": "amqp://localhost"}):
+            with patch.object(event_mod, "aio_pika", fake_pika):
+                result = await ch._connect_pub()
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_connect_pub_no_aio_pika_returns_none(self) -> None:
+        import ravn.adapters.channels.event as event_mod
+
+        ch = TaskDispatchChannel(_config(reconnect_delay_s=0.0))
+        with patch.object(event_mod, "aio_pika", None):
+            result = await ch._connect_pub()
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_ensure_pub_exchange_double_check_locking(self) -> None:
+        """Second waiter in lock sees exchange already set."""
+        ch = TaskDispatchChannel(_config(reconnect_delay_s=0.0))
+
+        sentinel = MagicMock()
+
+        async def _slow_connect():
+            await asyncio.sleep(0)
+            ch._pub_exchange = sentinel
+            return sentinel
+
+        # Pre-seed: exchange is None but gets set during the lock wait
+        async def _acquire_then_check():
+            async with ch._pub_lock:
+                # Another coroutine already set it inside the lock
+                ch._pub_exchange = sentinel
+            return await ch._ensure_pub_exchange()
+
+        result = await _acquire_then_check()
+        assert result is sentinel
+
+    @pytest.mark.asyncio
+    async def test_invalidate_pub_closes_connection(self) -> None:
+        """_invalidate_pub closes existing connection and clears all fields."""
+        ch = TaskDispatchChannel(_config())
+
+        mock_conn = AsyncMock()
+        ch._pub_connection = mock_conn
+        ch._pub_exchange = MagicMock()
+        ch._pub_channel = MagicMock()
+
+        await ch._invalidate_pub()
+
+        assert ch._pub_exchange is None
+        assert ch._pub_channel is None
+        assert ch._pub_connection is None
+        mock_conn.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_invalidate_pub_swallows_close_error(self) -> None:
+        """_invalidate_pub does not raise if connection.close() fails."""
+        ch = TaskDispatchChannel(_config())
+
+        mock_conn = AsyncMock()
+        mock_conn.close.side_effect = RuntimeError("already closed")
+        ch._pub_connection = mock_conn
+        ch._pub_exchange = MagicMock()
+
+        # Must not raise
+        await ch._invalidate_pub()
+        assert ch._pub_connection is None
+
+
+# ---------------------------------------------------------------------------
+# TaskDispatchChannel — _connect_and_consume path
+# ---------------------------------------------------------------------------
+
+
+class TestConnectAndConsume:
+    @pytest.mark.asyncio
+    async def test_no_amqp_url_sleeps_and_returns(self) -> None:
+        """_connect_and_consume returns early when AMQP URL is not set."""
+        import os
+
+        import ravn.adapters.channels.event as event_mod
+
+        ch = TaskDispatchChannel(_config(retry_delay_seconds=0.0), retry_delay_seconds=0.0)
+        enqueued: list = []
+
+        async def _enqueue(task):
+            enqueued.append(task)
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("SLEIPNIR_AMQP_URL", None)
+            with patch.object(event_mod, "aio_pika", MagicMock()):
+                await ch._connect_and_consume(_enqueue)
+
+        assert len(enqueued) == 0
+
+    @pytest.mark.asyncio
+    async def test_messages_are_consumed(self) -> None:
+        """_connect_and_consume delivers messages via _handle_message."""
+        import os
+
+        import ravn.adapters.channels.event as event_mod
+
+        loader = _fake_persona_loader(["autonomous-agent"])
+        ch = TaskDispatchChannel(_config(reconnect_delay_s=0.0), persona_loader=loader)
+        enqueued: list = []
+
+        async def _enqueue(task):
+            enqueued.append(task)
+
+        # Build fake aio_pika infrastructure
+        fake_body = _dispatch_payload()
+
+        class FakeContextManager:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+        class FakeMessage:
+            body = fake_body
+            routing_key = "ravn.task.dispatch"
+
+            def process(self):
+                return FakeContextManager()
+
+        class FakeQueueIter:
+            def __init__(self):
+                self._msgs = [FakeMessage()]
+                self._idx = 0
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if self._idx >= len(self._msgs):
+                    raise StopAsyncIteration
+                msg = self._msgs[self._idx]
+                self._idx += 1
+                return msg
+
+        mock_queue = AsyncMock()
+        mock_queue.iterator = MagicMock(return_value=FakeQueueIter())
+        mock_queue.bind = AsyncMock()
+
+        mock_channel = AsyncMock()
+        mock_channel.declare_exchange = AsyncMock(return_value=MagicMock())
+        mock_channel.declare_queue = AsyncMock(return_value=mock_queue)
+
+        class FakeConnection:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+            async def channel(self):
+                return mock_channel
+
+        fake_pika = MagicMock()
+        fake_pika.connect_robust = AsyncMock(return_value=FakeConnection())
+        fake_pika.ExchangeType.TOPIC = "topic"
+
+        ch._publish_response = AsyncMock()  # type: ignore[method-assign]
+
+        with patch.dict(os.environ, {"SLEIPNIR_AMQP_URL": "amqp://localhost"}):
+            with patch.object(event_mod, "aio_pika", fake_pika):
+                await ch._connect_and_consume(_enqueue)
+
+        assert len(enqueued) == 1
+        assert enqueued[0].task_id == "task-abc-123"


### PR DESCRIPTION
## Summary

Implements NIU-505 — inbound task reception via Sleipnir and autonomous mode for Ravn.

### New file: `src/ravn/adapters/channels/event.py`

**`TaskDispatchChannel`** is the primary addition:

- **Inbound**: Subscribes to `ravn.task.dispatch` (broadcast) and `ravn.task.dispatch.<agent_id>` (targeted) on the `ravn.events` RabbitMQ topic exchange via a durable, per-agent queue (`ravn.dispatch.<agent_id>`)
- **Persona validation**: Each dispatch event specifies a persona; if the persona is unknown, the task is immediately rejected and `ravn.task.rejected` is published back to the exchange
- **Response events** (full contract per spec):
  - `ravn.task.accepted` — published when a task passes validation and is enqueued
  - `ravn.task.rejected` — published with reason when persona is unknown/untrusted
  - `ravn.task.progress` — caller-driven via `publish_progress()`
  - `ravn.task.completed` — caller-driven via `publish_completed()`
  - `ravn.task.failed` — caller-driven via `publish_failed()`
- **`TriggerPort` compatible**: implements `name` + `run(enqueue)` — registers as a drive-loop trigger with no glue code
- **Lazy publish connection** with reconnect backoff (matching existing `SleipnirChannel` pattern)

### CLI changes: `src/ravn/cli/commands.py`

- **`ravn listen`** — new command; forces the initiative engine on and wires `TaskDispatchChannel` when Sleipnir is configured (`sleipnir.enabled: true` + `SLEIPNIR_AMQP_URL` set). Canonical entry point for autonomous mode.
- **`ravn daemon`** — extended `_run_daemon` with `task_dispatch: bool` param; `_wire_task_dispatch` helper added

### Inbound event contract

```json
{
  "type": "ravn.task.dispatch",
  "task_id": "...",
  "persona": "autonomous-agent",
  "task": "Review all open PRs in the niuu org and summarise status",
  "context": {...},
  "deadline": "2026-04-05T00:00:00Z",
  "dispatched_by": "tyr"
}
```

### Safety

Tasks with an unknown `persona` are always rejected — `ravn.task.rejected` is published and the task is discarded without touching the drive loop.

## Test plan

- [x] 45 unit tests in `tests/ravn/unit/test_task_dispatch.py`
- [x] 97% coverage on `src/ravn/adapters/channels/event.py`
- [x] Full ravn unit suite: 1355 passed, 1 skipped (no regressions)
- [x] `ruff check` and `ruff format` clean

**Note**: Linear MCP server not available in this environment — NIU-505 ticket update could not be performed via MCP. Please update NIU-505 to "In Review" manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)