### PR TITLE
feat(adapters): browser automation — Playwright and Browserbase backends (NIU-532)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ otel = [
 encryption = [
     "cryptography>=42.0",
 ]
+browser = [
+    "playwright>=1.44",
+]
 infra = [
     "redis>=5.0",
 ]
@@ -117,6 +120,7 @@ markers = [
     "broker: tests that require real message broker services (NATS, RabbitMQ, Redis)",
     "ravn: tests for the Ravn agent module",
     "e2e: end-to-end tests for full agent conversation flows",
+    "browser: tests that require a real browser (Playwright + Chromium)",
 ]
 
 [tool.ruff]

--- a/src/ravn/adapters/browser/__init__.py
+++ b/src/ravn/adapters/browser/__init__.py
@@ -1,0 +1,1 @@
+"""Browser automation adapters."""

--- a/src/ravn/adapters/browser/_base.py
+++ b/src/ravn/adapters/browser/_base.py
@@ -1,0 +1,190 @@
+"""_PlaywrightBrowserBase — shared Playwright page-interaction logic.
+
+LocalPlaywrightAdapter and BrowserbaseAdapter inherit from this class.
+Subclasses must implement _ensure_browser() and close().
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from ravn.ports.browser import PageSummary
+
+logger = logging.getLogger(__name__)
+
+# Maximum characters of visible text included in the page summary preview.
+_PREVIEW_MAX_CHARS = 500
+
+# Pixel amounts per scroll step for the four directions.
+_SCROLL_AMOUNT_PX = 300
+
+
+def _ax_node_to_line(node: dict, counter: list[int]) -> str | None:
+    """Convert a single accessibility node to a compact text line.
+
+    Returns None for nodes that should be skipped (generic containers with
+    no useful label and no role worth surfacing).
+    """
+    role = node.get("role", "")
+    name = node.get("name", "").strip()
+
+    skip_roles = {"none", "presentation", "generic", "group"}
+    if role in skip_roles and not name:
+        return None
+
+    counter[0] += 1
+    handle = f"@e{counter[0]}"
+
+    extra: list[str] = []
+
+    if "level" in node:
+        extra.append(f"level={node['level']}")
+    if "type" in node:
+        extra.append(f"type={node['type']}")
+    if "placeholder" in node:
+        extra.append(f"placeholder=\"{node['placeholder']}\"")
+    if node.get("checked") is not None:
+        extra.append(f"checked={str(node['checked']).lower()}")
+    if node.get("disabled"):
+        extra.append("disabled")
+
+    parts = [role]
+    parts.extend(extra)
+    if name:
+        parts.append(f'"{name}"')
+    parts.append(handle)
+
+    return f"[{' '.join(parts)}]"
+
+
+def _serialise_ax_tree(tree: dict) -> tuple[str, dict[str, Any]]:
+    """Walk the Playwright accessibility tree and return compact text + handle map.
+
+    Returns:
+        (snapshot_text, handle_map) where handle_map maps ``@eN`` → node dict.
+    """
+    lines: list[str] = []
+    handles: dict[str, Any] = {}
+    counter = [0]
+
+    def _walk(node: dict) -> None:
+        line = _ax_node_to_line(node, counter)
+        if line is not None:
+            handle_key = f"@e{counter[0]}"
+            handles[handle_key] = node
+            lines.append(line)
+        for child in node.get("children", []):
+            _walk(child)
+
+    _walk(tree)
+    return "\n".join(lines), handles
+
+
+class _PlaywrightBrowserBase:
+    """Shared page-interaction methods for Playwright-based browser adapters.
+
+    Subclasses provide _ensure_browser() and close() to handle the differing
+    lifecycle logic (local Chromium vs Browserbase CDP session).
+
+    Args:
+        timeout_ms: Default navigation / action timeout in milliseconds.
+    """
+
+    def __init__(self, *, timeout_ms: int = 30_000) -> None:
+        self._timeout_ms = timeout_ms
+        self._playwright: Any = None
+        self._browser: Any = None
+        self._page: Any = None
+        # Maps @eN → accessibility node dict for the current page snapshot.
+        self._handle_map: dict[str, Any] = {}
+
+    # ------------------------------------------------------------------
+    # Lifecycle — overridden by subclasses
+    # ------------------------------------------------------------------
+
+    async def _ensure_browser(self) -> None:  # pragma: no cover
+        raise NotImplementedError
+
+    async def close(self) -> None:  # pragma: no cover
+        raise NotImplementedError
+
+    # ------------------------------------------------------------------
+    # BrowserPort implementation
+    # ------------------------------------------------------------------
+
+    async def navigate(self, url: str, *, wait_for: str = "domcontentloaded") -> PageSummary:
+        """Navigate to *url* and return a summary of the loaded page."""
+        await self._ensure_browser()
+        response = await self._page.goto(url, wait_until=wait_for)
+        status = response.status if response else 0
+        title = await self._page.title()
+        try:
+            body_text = await self._page.evaluate(
+                "() => document.body ? document.body.innerText : ''"
+            )
+        except Exception:  # noqa: BLE001
+            body_text = ""
+        preview = re.sub(r"\s{2,}", " ", body_text).strip()[:_PREVIEW_MAX_CHARS]
+        logger.debug("Navigated to %s (status=%d)", url, status)
+        return PageSummary(url=self._page.url, title=title, status=status, text_preview=preview)
+
+    async def snapshot(self) -> str:
+        """Return the accessibility tree as compact ``[role "label" @eN]`` text."""
+        await self._ensure_browser()
+        ax_tree = await self._page.accessibility.snapshot()
+        if ax_tree is None:
+            return "(empty page)"
+        text, handle_map = _serialise_ax_tree(ax_tree)
+        self._handle_map = handle_map
+        return text or "(no interactive elements)"
+
+    async def click(self, selector: str) -> None:
+        """Click the element identified by *selector* or ``@eN`` handle."""
+        await self._ensure_browser()
+        if selector in self._handle_map:
+            node = self._handle_map[selector]
+            name = node.get("name", "")
+            if name:
+                await self._page.get_by_role(node["role"], name=name).first.click()
+                return
+        await self._page.click(selector)
+
+    async def type(self, selector: str, text: str) -> None:
+        """Type *text* into the element identified by *selector* or ``@eN`` handle."""
+        await self._ensure_browser()
+        if selector in self._handle_map:
+            node = self._handle_map[selector]
+            name = node.get("name", "")
+            placeholder = node.get("placeholder", "")
+            if placeholder:
+                await self._page.get_by_placeholder(placeholder).fill(text)
+                return
+            if name:
+                await self._page.get_by_role(node["role"], name=name).first.fill(text)
+                return
+        await self._page.fill(selector, text)
+
+    async def scroll(self, direction: str, amount: int = 3) -> None:
+        """Scroll the page in *direction* by *amount* steps."""
+        await self._ensure_browser()
+        delta_map = {
+            "down": (0, _SCROLL_AMOUNT_PX),
+            "up": (0, -_SCROLL_AMOUNT_PX),
+            "right": (_SCROLL_AMOUNT_PX, 0),
+            "left": (-_SCROLL_AMOUNT_PX, 0),
+        }
+        dx, dy = delta_map.get(direction, (0, _SCROLL_AMOUNT_PX))
+        for _ in range(amount):
+            await self._page.mouse.wheel(dx, dy)
+
+    async def screenshot(self) -> bytes:
+        """Capture a full-page screenshot and return raw PNG bytes."""
+        await self._ensure_browser()
+        return await self._page.screenshot(full_page=True)
+
+    async def evaluate(self, js: str) -> Any:
+        """Evaluate a JavaScript expression and return the result."""
+        await self._ensure_browser()
+        return await self._page.evaluate(js)

--- a/src/ravn/adapters/browser/browserbase.py
+++ b/src/ravn/adapters/browser/browserbase.py
@@ -10,18 +10,16 @@ from __future__ import annotations
 
 import logging
 import os
-import re
 from typing import Any
 
-from ravn.adapters.browser.local import _PREVIEW_MAX_CHARS, _serialise_ax_tree
-from ravn.ports.browser import PageSummary
+from ravn.adapters.browser._base import _PlaywrightBrowserBase
 
 logger = logging.getLogger(__name__)
 
 _DEFAULT_CONNECT_URL = "wss://connect.browserbase.com"
 
 
-class BrowserbaseAdapter:
+class BrowserbaseAdapter(_PlaywrightBrowserBase):
     """Browser backend that executes in Browserbase's cloud infrastructure.
 
     Supports stealth mode and CAPTCHA solving (configured via the Browserbase
@@ -44,17 +42,12 @@ class BrowserbaseAdapter:
         headless: bool = True,
         timeout_ms: int = 30_000,
     ) -> None:
+        super().__init__(timeout_ms=timeout_ms)
         self._api_key = api_key or os.environ.get("BROWSERBASE_API_KEY", "")
         self._project_id = project_id or os.environ.get("BROWSERBASE_PROJECT_ID", "")
         self._stealth = stealth
         self._headless = headless
-        self._timeout_ms = timeout_ms
-
-        self._playwright: Any = None
-        self._browser: Any = None
-        self._page: Any = None
         self._session_id: str = ""
-        self._handle_map: dict[str, Any] = {}
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -88,14 +81,18 @@ class BrowserbaseAdapter:
             resp = await client.post(
                 "https://www.browserbase.com/v1/sessions",
                 json=payload,
-                headers={"X-BB-API-Key": self._api_key, "Content-Type": "application/json"},
+                headers={
+                    "X-BB-API-Key": self._api_key,
+                    "Content-Type": "application/json",
+                },
             )
             resp.raise_for_status()
             session_data = resp.json()
 
         self._session_id = session_data["id"]
         connect_url = session_data.get("connectUrl") or (
-            f"{_DEFAULT_CONNECT_URL}?apiKey={self._api_key}&sessionId={self._session_id}"
+            f"{_DEFAULT_CONNECT_URL}"
+            f"?apiKey={self._api_key}&sessionId={self._session_id}"
         )
 
         self._playwright = await async_playwright().start()
@@ -123,83 +120,3 @@ class BrowserbaseAdapter:
             self._playwright = None
         self._handle_map = {}
         logger.debug("Browserbase session closed (id=%s)", self._session_id)
-
-    # ------------------------------------------------------------------
-    # BrowserPort implementation
-    # ------------------------------------------------------------------
-
-    async def navigate(self, url: str, *, wait_for: str = "domcontentloaded") -> PageSummary:
-        """Navigate to *url* and return a summary of the loaded page."""
-        await self._ensure_browser()
-        response = await self._page.goto(url, wait_until=wait_for)
-        status = response.status if response else 0
-        title = await self._page.title()
-        try:
-            body_text = await self._page.evaluate(
-                "() => document.body ? document.body.innerText : ''"
-            )
-        except Exception:  # noqa: BLE001
-            body_text = ""
-        preview = re.sub(r"\s{2,}", " ", body_text).strip()[:_PREVIEW_MAX_CHARS]
-        return PageSummary(url=self._page.url, title=title, status=status, text_preview=preview)
-
-    async def snapshot(self) -> str:
-        """Return the accessibility tree as compact ``[role "label" @eN]`` text."""
-        await self._ensure_browser()
-        ax_tree = await self._page.accessibility.snapshot()
-        if ax_tree is None:
-            return "(empty page)"
-        text, handle_map = _serialise_ax_tree(ax_tree)
-        self._handle_map = handle_map
-        return text or "(no interactive elements)"
-
-    async def click(self, selector: str) -> None:
-        """Click the element identified by *selector* or ``@eN`` handle."""
-        await self._ensure_browser()
-        if selector in self._handle_map:
-            node = self._handle_map[selector]
-            name = node.get("name", "")
-            if name:
-                await self._page.get_by_role(node["role"], name=name).first.click()
-                return
-        await self._page.click(selector)
-
-    async def type(self, selector: str, text: str) -> None:
-        """Type *text* into the element identified by *selector* or ``@eN`` handle."""
-        await self._ensure_browser()
-        if selector in self._handle_map:
-            node = self._handle_map[selector]
-            placeholder = node.get("placeholder", "")
-            name = node.get("name", "")
-            if placeholder:
-                await self._page.get_by_placeholder(placeholder).fill(text)
-                return
-            if name:
-                await self._page.get_by_role(node["role"], name=name).first.fill(text)
-                return
-        await self._page.fill(selector, text)
-
-    async def scroll(self, direction: str, amount: int = 3) -> None:
-        """Scroll the page in *direction* by *amount* steps."""
-        await self._ensure_browser()
-        from ravn.adapters.browser.local import _SCROLL_AMOUNT_PX
-
-        delta_map = {
-            "down": (0, _SCROLL_AMOUNT_PX),
-            "up": (0, -_SCROLL_AMOUNT_PX),
-            "right": (_SCROLL_AMOUNT_PX, 0),
-            "left": (-_SCROLL_AMOUNT_PX, 0),
-        }
-        dx, dy = delta_map.get(direction, (0, _SCROLL_AMOUNT_PX))
-        for _ in range(amount):
-            await self._page.mouse.wheel(dx, dy)
-
-    async def screenshot(self) -> bytes:
-        """Capture a full-page screenshot and return raw PNG bytes."""
-        await self._ensure_browser()
-        return await self._page.screenshot(full_page=True)
-
-    async def evaluate(self, js: str) -> Any:
-        """Evaluate a JavaScript expression and return the result."""
-        await self._ensure_browser()
-        return await self._page.evaluate(js)

--- a/src/ravn/adapters/browser/browserbase.py
+++ b/src/ravn/adapters/browser/browserbase.py
@@ -1,0 +1,205 @@
+"""BrowserbaseAdapter — cloud browser backend via Browserbase.
+
+Activated automatically when ``BROWSERBASE_API_KEY`` is set (or via config).
+Falls back gracefully to an error if the ``playwright`` package is not installed.
+
+See: https://docs.browserbase.com/reference/api/create-a-session
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from typing import Any
+
+from ravn.adapters.browser.local import _PREVIEW_MAX_CHARS, _serialise_ax_tree
+from ravn.ports.browser import PageSummary
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_CONNECT_URL = "wss://connect.browserbase.com"
+
+
+class BrowserbaseAdapter:
+    """Browser backend that executes in Browserbase's cloud infrastructure.
+
+    Supports stealth mode and CAPTCHA solving (configured via the Browserbase
+    project settings — no extra kwargs required here).
+
+    Args:
+        api_key:    Browserbase API key. Falls back to ``BROWSERBASE_API_KEY`` env var.
+        project_id: Browserbase project ID. Falls back to ``BROWSERBASE_PROJECT_ID``.
+        stealth:    Enable stealth mode (anti-bot fingerprint masking).
+        headless:   Local browser headless flag (used for the CDP proxy connection).
+        timeout_ms: Default navigation / action timeout in milliseconds.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str = "",
+        project_id: str = "",
+        stealth: bool = False,
+        headless: bool = True,
+        timeout_ms: int = 30_000,
+    ) -> None:
+        self._api_key = api_key or os.environ.get("BROWSERBASE_API_KEY", "")
+        self._project_id = project_id or os.environ.get("BROWSERBASE_PROJECT_ID", "")
+        self._stealth = stealth
+        self._headless = headless
+        self._timeout_ms = timeout_ms
+
+        self._playwright: Any = None
+        self._browser: Any = None
+        self._page: Any = None
+        self._session_id: str = ""
+        self._handle_map: dict[str, Any] = {}
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def _ensure_browser(self) -> None:
+        """Create a Browserbase session and connect via CDP."""
+        if self._page is not None:
+            return
+
+        if not self._api_key:
+            raise RuntimeError(
+                "Browserbase API key is not set. "
+                "Set BROWSERBASE_API_KEY or configure browser.browserbase.api_key_env."
+            )
+
+        try:
+            import httpx
+            from playwright.async_api import async_playwright
+        except ImportError as exc:
+            raise RuntimeError(
+                "playwright is not installed. "
+                "Install it with: pip install 'ravn[browser]' && playwright install chromium"
+            ) from exc
+
+        # Create a remote Browserbase session via the REST API.
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            payload: dict[str, Any] = {"projectId": self._project_id}
+            if self._stealth:
+                payload["browserSettings"] = {"fingerprint": {"devices": ["desktop"]}}
+            resp = await client.post(
+                "https://www.browserbase.com/v1/sessions",
+                json=payload,
+                headers={"X-BB-API-Key": self._api_key, "Content-Type": "application/json"},
+            )
+            resp.raise_for_status()
+            session_data = resp.json()
+
+        self._session_id = session_data["id"]
+        connect_url = session_data.get("connectUrl") or (
+            f"{_DEFAULT_CONNECT_URL}?apiKey={self._api_key}&sessionId={self._session_id}"
+        )
+
+        self._playwright = await async_playwright().start()
+        self._browser = await self._playwright.chromium.connect_over_cdp(connect_url)
+        if self._browser.contexts:
+            context = self._browser.contexts[0]
+        else:
+            context = await self._browser.new_context()
+        self._page = context.pages[0] if context.pages else await context.new_page()
+        self._page.set_default_timeout(self._timeout_ms)
+        logger.debug(
+            "Browserbase session created (id=%s, stealth=%s)", self._session_id, self._stealth
+        )
+
+    async def close(self) -> None:
+        """Close the Browserbase session and clean up resources."""
+        if self._page is not None:
+            await self._page.close()
+            self._page = None
+        if self._browser is not None:
+            await self._browser.close()
+            self._browser = None
+        if self._playwright is not None:
+            await self._playwright.stop()
+            self._playwright = None
+        self._handle_map = {}
+        logger.debug("Browserbase session closed (id=%s)", self._session_id)
+
+    # ------------------------------------------------------------------
+    # BrowserPort implementation
+    # ------------------------------------------------------------------
+
+    async def navigate(self, url: str, *, wait_for: str = "domcontentloaded") -> PageSummary:
+        """Navigate to *url* and return a summary of the loaded page."""
+        await self._ensure_browser()
+        response = await self._page.goto(url, wait_until=wait_for)
+        status = response.status if response else 0
+        title = await self._page.title()
+        try:
+            body_text = await self._page.evaluate(
+                "() => document.body ? document.body.innerText : ''"
+            )
+        except Exception:  # noqa: BLE001
+            body_text = ""
+        preview = re.sub(r"\s{2,}", " ", body_text).strip()[:_PREVIEW_MAX_CHARS]
+        return PageSummary(url=self._page.url, title=title, status=status, text_preview=preview)
+
+    async def snapshot(self) -> str:
+        """Return the accessibility tree as compact ``[role "label" @eN]`` text."""
+        await self._ensure_browser()
+        ax_tree = await self._page.accessibility.snapshot()
+        if ax_tree is None:
+            return "(empty page)"
+        text, handle_map = _serialise_ax_tree(ax_tree)
+        self._handle_map = handle_map
+        return text or "(no interactive elements)"
+
+    async def click(self, selector: str) -> None:
+        """Click the element identified by *selector* or ``@eN`` handle."""
+        await self._ensure_browser()
+        if selector in self._handle_map:
+            node = self._handle_map[selector]
+            name = node.get("name", "")
+            if name:
+                await self._page.get_by_role(node["role"], name=name).first.click()
+                return
+        await self._page.click(selector)
+
+    async def type(self, selector: str, text: str) -> None:
+        """Type *text* into the element identified by *selector* or ``@eN`` handle."""
+        await self._ensure_browser()
+        if selector in self._handle_map:
+            node = self._handle_map[selector]
+            placeholder = node.get("placeholder", "")
+            name = node.get("name", "")
+            if placeholder:
+                await self._page.get_by_placeholder(placeholder).fill(text)
+                return
+            if name:
+                await self._page.get_by_role(node["role"], name=name).first.fill(text)
+                return
+        await self._page.fill(selector, text)
+
+    async def scroll(self, direction: str, amount: int = 3) -> None:
+        """Scroll the page in *direction* by *amount* steps."""
+        await self._ensure_browser()
+        from ravn.adapters.browser.local import _SCROLL_AMOUNT_PX
+
+        delta_map = {
+            "down": (0, _SCROLL_AMOUNT_PX),
+            "up": (0, -_SCROLL_AMOUNT_PX),
+            "right": (_SCROLL_AMOUNT_PX, 0),
+            "left": (-_SCROLL_AMOUNT_PX, 0),
+        }
+        dx, dy = delta_map.get(direction, (0, _SCROLL_AMOUNT_PX))
+        for _ in range(amount):
+            await self._page.mouse.wheel(dx, dy)
+
+    async def screenshot(self) -> bytes:
+        """Capture a full-page screenshot and return raw PNG bytes."""
+        await self._ensure_browser()
+        return await self._page.screenshot(full_page=True)
+
+    async def evaluate(self, js: str) -> Any:
+        """Evaluate a JavaScript expression and return the result."""
+        await self._ensure_browser()
+        return await self._page.evaluate(js)

--- a/src/ravn/adapters/browser/local.py
+++ b/src/ravn/adapters/browser/local.py
@@ -3,82 +3,15 @@
 from __future__ import annotations
 
 import logging
-import re
-from typing import Any
 
-from ravn.ports.browser import PageSummary
+from ravn.adapters.browser._base import _ax_node_to_line, _PlaywrightBrowserBase, _serialise_ax_tree
+
+__all__ = ["LocalPlaywrightAdapter", "_ax_node_to_line", "_serialise_ax_tree"]
 
 logger = logging.getLogger(__name__)
 
-# Maximum characters of visible text included in the page summary preview.
-_PREVIEW_MAX_CHARS = 500
 
-# Pixel amounts per scroll step for the four directions.
-_SCROLL_AMOUNT_PX = 300
-
-
-def _ax_node_to_line(node: dict, counter: list[int]) -> str | None:
-    """Convert a single accessibility node to a compact text line.
-
-    Returns None for nodes that should be skipped (generic containers with
-    no useful label and no role worth surfacing).
-    """
-    role = node.get("role", "")
-    name = node.get("name", "").strip()
-
-    skip_roles = {"none", "presentation", "generic", "group"}
-    if role in skip_roles and not name:
-        return None
-
-    counter[0] += 1
-    handle = f"@e{counter[0]}"
-
-    extra: list[str] = []
-
-    if "level" in node:
-        extra.append(f"level={node['level']}")
-    if "type" in node:
-        extra.append(f"type={node['type']}")
-    if "placeholder" in node:
-        extra.append(f"placeholder=\"{node['placeholder']}\"")
-    if node.get("checked") is not None:
-        extra.append(f"checked={str(node['checked']).lower()}")
-    if node.get("disabled"):
-        extra.append("disabled")
-
-    parts = [role]
-    parts.extend(extra)
-    if name:
-        parts.append(f'"{name}"')
-    parts.append(handle)
-
-    return f"[{' '.join(parts)}]"
-
-
-def _serialise_ax_tree(tree: dict) -> tuple[str, dict[str, Any]]:
-    """Walk the Playwright accessibility tree and return compact text + handle map.
-
-    Returns:
-        (snapshot_text, handle_map) where handle_map maps ``@eN`` → node dict.
-    """
-    lines: list[str] = []
-    handles: dict[str, Any] = {}
-    counter = [0]
-
-    def _walk(node: dict) -> None:
-        line = _ax_node_to_line(node, counter)
-        if line is not None:
-            handle_key = f"@e{counter[0]}"
-            handles[handle_key] = node
-            lines.append(line)
-        for child in node.get("children", []):
-            _walk(child)
-
-    _walk(tree)
-    return "\n".join(lines), handles
-
-
-class LocalPlaywrightAdapter:
+class LocalPlaywrightAdapter(_PlaywrightBrowserBase):
     """Browser backend using a local headless Chromium instance via Playwright.
 
     This adapter is instantiated lazily — the browser is not launched until
@@ -90,13 +23,8 @@ class LocalPlaywrightAdapter:
     """
 
     def __init__(self, *, headless: bool = True, timeout_ms: int = 30_000) -> None:
+        super().__init__(timeout_ms=timeout_ms)
         self._headless = headless
-        self._timeout_ms = timeout_ms
-        self._playwright: Any = None
-        self._browser: Any = None
-        self._page: Any = None
-        # Maps @eN → accessibility node dict for the current page snapshot.
-        self._handle_map: dict[str, Any] = {}
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -134,85 +62,3 @@ class LocalPlaywrightAdapter:
             self._playwright = None
         self._handle_map = {}
         logger.debug("Local Chromium browser closed")
-
-    # ------------------------------------------------------------------
-    # BrowserPort implementation
-    # ------------------------------------------------------------------
-
-    async def navigate(self, url: str, *, wait_for: str = "domcontentloaded") -> PageSummary:
-        """Navigate to *url* and return a summary of the loaded page."""
-        await self._ensure_browser()
-        response = await self._page.goto(url, wait_until=wait_for)
-        status = response.status if response else 0
-        title = await self._page.title()
-        # Extract a short text preview from the page body.
-        try:
-            body_text = await self._page.evaluate(
-                "() => document.body ? document.body.innerText : ''"
-            )
-        except Exception:  # noqa: BLE001
-            body_text = ""
-        preview = re.sub(r"\s{2,}", " ", body_text).strip()[:_PREVIEW_MAX_CHARS]
-        logger.debug("Navigated to %s (status=%d)", url, status)
-        return PageSummary(url=self._page.url, title=title, status=status, text_preview=preview)
-
-    async def snapshot(self) -> str:
-        """Return the accessibility tree as compact ``[role "label" @eN]`` text."""
-        await self._ensure_browser()
-        ax_tree = await self._page.accessibility.snapshot()
-        if ax_tree is None:
-            return "(empty page)"
-        text, handle_map = _serialise_ax_tree(ax_tree)
-        # Store for selector resolution in click / type calls.
-        self._handle_map = handle_map
-        return text or "(no interactive elements)"
-
-    async def click(self, selector: str) -> None:
-        """Click the element identified by *selector* or ``@eN`` handle."""
-        await self._ensure_browser()
-        if selector in self._handle_map:
-            node = self._handle_map[selector]
-            name = node.get("name", "")
-            # Use the node name as a text locator when available.
-            if name:
-                await self._page.get_by_role(node["role"], name=name).first.click()
-                return
-        await self._page.click(selector)
-
-    async def type(self, selector: str, text: str) -> None:
-        """Type *text* into the element identified by *selector* or ``@eN`` handle."""
-        await self._ensure_browser()
-        if selector in self._handle_map:
-            node = self._handle_map[selector]
-            name = node.get("name", "")
-            placeholder = node.get("placeholder", "")
-            if placeholder:
-                await self._page.get_by_placeholder(placeholder).fill(text)
-                return
-            if name:
-                await self._page.get_by_role(node["role"], name=name).first.fill(text)
-                return
-        await self._page.fill(selector, text)
-
-    async def scroll(self, direction: str, amount: int = 3) -> None:
-        """Scroll the page in *direction* by *amount* steps."""
-        await self._ensure_browser()
-        delta_map = {
-            "down": (0, _SCROLL_AMOUNT_PX),
-            "up": (0, -_SCROLL_AMOUNT_PX),
-            "right": (_SCROLL_AMOUNT_PX, 0),
-            "left": (-_SCROLL_AMOUNT_PX, 0),
-        }
-        dx, dy = delta_map.get(direction, (0, _SCROLL_AMOUNT_PX))
-        for _ in range(amount):
-            await self._page.mouse.wheel(dx, dy)
-
-    async def screenshot(self) -> bytes:
-        """Capture a full-page screenshot and return raw PNG bytes."""
-        await self._ensure_browser()
-        return await self._page.screenshot(full_page=True)
-
-    async def evaluate(self, js: str) -> Any:
-        """Evaluate a JavaScript expression and return the result."""
-        await self._ensure_browser()
-        return await self._page.evaluate(js)

--- a/src/ravn/adapters/browser/local.py
+++ b/src/ravn/adapters/browser/local.py
@@ -1,0 +1,218 @@
+"""LocalPlaywrightAdapter — headless Chromium browser backend via Playwright."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from ravn.ports.browser import PageSummary
+
+logger = logging.getLogger(__name__)
+
+# Maximum characters of visible text included in the page summary preview.
+_PREVIEW_MAX_CHARS = 500
+
+# Pixel amounts per scroll step for the four directions.
+_SCROLL_AMOUNT_PX = 300
+
+
+def _ax_node_to_line(node: dict, counter: list[int]) -> str | None:
+    """Convert a single accessibility node to a compact text line.
+
+    Returns None for nodes that should be skipped (generic containers with
+    no useful label and no role worth surfacing).
+    """
+    role = node.get("role", "")
+    name = node.get("name", "").strip()
+
+    skip_roles = {"none", "presentation", "generic", "group"}
+    if role in skip_roles and not name:
+        return None
+
+    counter[0] += 1
+    handle = f"@e{counter[0]}"
+
+    extra: list[str] = []
+
+    if "level" in node:
+        extra.append(f"level={node['level']}")
+    if "type" in node:
+        extra.append(f"type={node['type']}")
+    if "placeholder" in node:
+        extra.append(f"placeholder=\"{node['placeholder']}\"")
+    if node.get("checked") is not None:
+        extra.append(f"checked={str(node['checked']).lower()}")
+    if node.get("disabled"):
+        extra.append("disabled")
+
+    parts = [role]
+    parts.extend(extra)
+    if name:
+        parts.append(f'"{name}"')
+    parts.append(handle)
+
+    return f"[{' '.join(parts)}]"
+
+
+def _serialise_ax_tree(tree: dict) -> tuple[str, dict[str, Any]]:
+    """Walk the Playwright accessibility tree and return compact text + handle map.
+
+    Returns:
+        (snapshot_text, handle_map) where handle_map maps ``@eN`` → node dict.
+    """
+    lines: list[str] = []
+    handles: dict[str, Any] = {}
+    counter = [0]
+
+    def _walk(node: dict) -> None:
+        line = _ax_node_to_line(node, counter)
+        if line is not None:
+            handle_key = f"@e{counter[0]}"
+            handles[handle_key] = node
+            lines.append(line)
+        for child in node.get("children", []):
+            _walk(child)
+
+    _walk(tree)
+    return "\n".join(lines), handles
+
+
+class LocalPlaywrightAdapter:
+    """Browser backend using a local headless Chromium instance via Playwright.
+
+    This adapter is instantiated lazily — the browser is not launched until
+    the first call to ``navigate()``.
+
+    Args:
+        headless:    Launch browser headlessly (default True).
+        timeout_ms:  Default navigation / action timeout in milliseconds.
+    """
+
+    def __init__(self, *, headless: bool = True, timeout_ms: int = 30_000) -> None:
+        self._headless = headless
+        self._timeout_ms = timeout_ms
+        self._playwright: Any = None
+        self._browser: Any = None
+        self._page: Any = None
+        # Maps @eN → accessibility node dict for the current page snapshot.
+        self._handle_map: dict[str, Any] = {}
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def _ensure_browser(self) -> None:
+        """Launch browser if not already running."""
+        if self._page is not None:
+            return
+
+        try:
+            from playwright.async_api import async_playwright
+        except ImportError as exc:
+            raise RuntimeError(
+                "playwright is not installed. "
+                "Install it with: pip install 'ravn[browser]' && playwright install chromium"
+            ) from exc
+
+        self._playwright = await async_playwright().start()
+        self._browser = await self._playwright.chromium.launch(headless=self._headless)
+        self._page = await self._browser.new_page()
+        self._page.set_default_timeout(self._timeout_ms)
+        logger.debug("Local Chromium browser launched (headless=%s)", self._headless)
+
+    async def close(self) -> None:
+        """Close the browser and clean up Playwright resources."""
+        if self._page is not None:
+            await self._page.close()
+            self._page = None
+        if self._browser is not None:
+            await self._browser.close()
+            self._browser = None
+        if self._playwright is not None:
+            await self._playwright.stop()
+            self._playwright = None
+        self._handle_map = {}
+        logger.debug("Local Chromium browser closed")
+
+    # ------------------------------------------------------------------
+    # BrowserPort implementation
+    # ------------------------------------------------------------------
+
+    async def navigate(self, url: str, *, wait_for: str = "domcontentloaded") -> PageSummary:
+        """Navigate to *url* and return a summary of the loaded page."""
+        await self._ensure_browser()
+        response = await self._page.goto(url, wait_until=wait_for)
+        status = response.status if response else 0
+        title = await self._page.title()
+        # Extract a short text preview from the page body.
+        try:
+            body_text = await self._page.evaluate(
+                "() => document.body ? document.body.innerText : ''"
+            )
+        except Exception:  # noqa: BLE001
+            body_text = ""
+        preview = re.sub(r"\s{2,}", " ", body_text).strip()[:_PREVIEW_MAX_CHARS]
+        logger.debug("Navigated to %s (status=%d)", url, status)
+        return PageSummary(url=self._page.url, title=title, status=status, text_preview=preview)
+
+    async def snapshot(self) -> str:
+        """Return the accessibility tree as compact ``[role "label" @eN]`` text."""
+        await self._ensure_browser()
+        ax_tree = await self._page.accessibility.snapshot()
+        if ax_tree is None:
+            return "(empty page)"
+        text, handle_map = _serialise_ax_tree(ax_tree)
+        # Store for selector resolution in click / type calls.
+        self._handle_map = handle_map
+        return text or "(no interactive elements)"
+
+    async def click(self, selector: str) -> None:
+        """Click the element identified by *selector* or ``@eN`` handle."""
+        await self._ensure_browser()
+        if selector in self._handle_map:
+            node = self._handle_map[selector]
+            name = node.get("name", "")
+            # Use the node name as a text locator when available.
+            if name:
+                await self._page.get_by_role(node["role"], name=name).first.click()
+                return
+        await self._page.click(selector)
+
+    async def type(self, selector: str, text: str) -> None:
+        """Type *text* into the element identified by *selector* or ``@eN`` handle."""
+        await self._ensure_browser()
+        if selector in self._handle_map:
+            node = self._handle_map[selector]
+            name = node.get("name", "")
+            placeholder = node.get("placeholder", "")
+            if placeholder:
+                await self._page.get_by_placeholder(placeholder).fill(text)
+                return
+            if name:
+                await self._page.get_by_role(node["role"], name=name).first.fill(text)
+                return
+        await self._page.fill(selector, text)
+
+    async def scroll(self, direction: str, amount: int = 3) -> None:
+        """Scroll the page in *direction* by *amount* steps."""
+        await self._ensure_browser()
+        delta_map = {
+            "down": (0, _SCROLL_AMOUNT_PX),
+            "up": (0, -_SCROLL_AMOUNT_PX),
+            "right": (_SCROLL_AMOUNT_PX, 0),
+            "left": (-_SCROLL_AMOUNT_PX, 0),
+        }
+        dx, dy = delta_map.get(direction, (0, _SCROLL_AMOUNT_PX))
+        for _ in range(amount):
+            await self._page.mouse.wheel(dx, dy)
+
+    async def screenshot(self) -> bytes:
+        """Capture a full-page screenshot and return raw PNG bytes."""
+        await self._ensure_browser()
+        return await self._page.screenshot(full_page=True)
+
+    async def evaluate(self, js: str) -> Any:
+        """Evaluate a JavaScript expression and return the result."""
+        await self._ensure_browser()
+        return await self._page.evaluate(js)

--- a/src/ravn/adapters/tools/_url_security.py
+++ b/src/ravn/adapters/tools/_url_security.py
@@ -1,0 +1,48 @@
+"""Shared SSRF protection utilities for URL validation.
+
+Used by both web_fetch and browser tool adapters to block requests to
+private/reserved IP ranges.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+
+_PRIVATE_NETWORKS: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = [
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fc00::/7"),
+]
+
+
+def is_private_ip(ip: str) -> bool:
+    """Return True if the IP address falls within a private/reserved range."""
+    try:
+        addr = ipaddress.ip_address(ip)
+    except ValueError:
+        return True  # Unparseable — block by default.
+    return any(addr in net for net in _PRIVATE_NETWORKS)
+
+
+def check_ssrf(hostname: str) -> str | None:
+    """Resolve *hostname* and return an error string if it maps to a private address.
+
+    Returns None if the hostname is safe to connect to.
+    Blocks DNS rebinding: resolves the hostname and checks every returned address.
+    """
+    try:
+        results = socket.getaddrinfo(hostname, None)
+    except OSError:
+        return f"Blocked: could not resolve hostname '{hostname}'"
+
+    for _family, _type, _proto, _canonname, sockaddr in results:
+        ip = sockaddr[0]
+        if is_private_ip(ip):
+            return f"Blocked: '{hostname}' resolves to a private/reserved address"
+
+    return None

--- a/src/ravn/adapters/tools/browser.py
+++ b/src/ravn/adapters/tools/browser.py
@@ -20,6 +20,7 @@ import os
 from typing import Any
 from urllib.parse import urlparse
 
+from ravn.adapters.tools._url_security import check_ssrf
 from ravn.domain.models import ToolResult
 from ravn.ports.browser import BrowserPort, PageSummary
 from ravn.ports.tool import ToolPort
@@ -30,20 +31,17 @@ logger = logging.getLogger(__name__)
 # URL security
 # ---------------------------------------------------------------------------
 
-_DEFAULT_BLOCKED_ORIGINS: list[str] = []
-_DEFAULT_ALLOWED_ORIGINS: list[str] = []
-
 # Schemes permitted by browser_navigate.
 _ALLOWED_SCHEMES = {"http", "https"}
 
-# JS expressions that are always considered safe (read-only).
-_SAFE_JS_PATTERNS: list[str] = [
+# JS expressions that are always considered safe (read-only exact matches).
+_SAFE_JS_PATTERNS: frozenset[str] = frozenset({
     "document.title",
     "document.URL",
     "window.location",
     "document.body.innerText",
     "document.readyState",
-]
+})
 
 
 def _validate_browser_url(
@@ -57,6 +55,7 @@ def _validate_browser_url(
     1. Scheme must be http or https.
     2. URL must not match any ``blocked_origins`` glob pattern.
     3. If ``allowed_origins`` is non-empty, URL must match at least one pattern.
+    4. Hostname must not resolve to a private/reserved IP range (SSRF protection).
     """
     parsed = urlparse(url)
     if parsed.scheme not in _ALLOWED_SCHEMES:
@@ -77,13 +76,12 @@ def _validate_browser_url(
                 f"Allowed: {allowed_origins}"
             )
 
-    return None
+    return check_ssrf(hostname)
 
 
 def _is_safe_js(js: str) -> bool:
-    """Return True if the JS expression is in the read-only safe list."""
-    stripped = js.strip()
-    return any(stripped.startswith(p) for p in _SAFE_JS_PATTERNS)
+    """Return True if the JS expression exactly matches a read-only safe expression."""
+    return js.strip() in _SAFE_JS_PATTERNS
 
 
 # ---------------------------------------------------------------------------
@@ -135,8 +133,8 @@ class _BrowserToolBase(ToolPort):
     ) -> None:
         self._session_manager = session_manager
         self._task_id = task_id
-        self._allowed_origins: list[str] = allowed_origins or _DEFAULT_ALLOWED_ORIGINS
-        self._blocked_origins: list[str] = blocked_origins or _DEFAULT_BLOCKED_ORIGINS
+        self._allowed_origins: list[str] = allowed_origins if allowed_origins is not None else []
+        self._blocked_origins: list[str] = blocked_origins if blocked_origins is not None else []
         self._full_js = full_js
 
     @property

--- a/src/ravn/adapters/tools/browser.py
+++ b/src/ravn/adapters/tools/browser.py
@@ -1,0 +1,700 @@
+"""Browser automation tools — ToolPort implementations for browser control.
+
+All 8 tools share a single BrowserPort session scoped to the current task_id.
+The session is auto-closed when ``browser_session_close`` is called or when the
+adapter is garbage-collected.
+
+Permission tiers (from the design doc):
+- READ_ONLY  : browser_navigate, browser_snapshot, browser_screenshot
+- WORKSPACE_WRITE : browser_click, browser_type, browser_scroll
+- FULL_ACCESS : browser_evaluate (with full_js=true)
+"""
+
+from __future__ import annotations
+
+import base64
+import fnmatch
+import json
+import logging
+import os
+from typing import Any
+from urllib.parse import urlparse
+
+from ravn.domain.models import ToolResult
+from ravn.ports.browser import BrowserPort, PageSummary
+from ravn.ports.tool import ToolPort
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# URL security
+# ---------------------------------------------------------------------------
+
+_DEFAULT_BLOCKED_ORIGINS: list[str] = []
+_DEFAULT_ALLOWED_ORIGINS: list[str] = []
+
+# Schemes permitted by browser_navigate.
+_ALLOWED_SCHEMES = {"http", "https"}
+
+# JS expressions that are always considered safe (read-only).
+_SAFE_JS_PATTERNS: list[str] = [
+    "document.title",
+    "document.URL",
+    "window.location",
+    "document.body.innerText",
+    "document.readyState",
+]
+
+
+def _validate_browser_url(
+    url: str,
+    allowed_origins: list[str],
+    blocked_origins: list[str],
+) -> str | None:
+    """Return an error string if *url* is blocked, else None.
+
+    Checks:
+    1. Scheme must be http or https.
+    2. URL must not match any ``blocked_origins`` glob pattern.
+    3. If ``allowed_origins`` is non-empty, URL must match at least one pattern.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in _ALLOWED_SCHEMES:
+        return f"Blocked: only http/https URLs are allowed (got '{parsed.scheme}')"
+
+    hostname = parsed.hostname or ""
+    if not hostname:
+        return "Blocked: URL has no hostname"
+
+    for pattern in blocked_origins:
+        if fnmatch.fnmatch(hostname, pattern):
+            return f"Blocked: '{hostname}' matches blocked origin pattern '{pattern}'"
+
+    if allowed_origins:
+        if not any(fnmatch.fnmatch(hostname, p) for p in allowed_origins):
+            return (
+                f"Blocked: '{hostname}' is not in the allowed origins list. "
+                f"Allowed: {allowed_origins}"
+            )
+
+    return None
+
+
+def _is_safe_js(js: str) -> bool:
+    """Return True if the JS expression is in the read-only safe list."""
+    stripped = js.strip()
+    return any(stripped.startswith(p) for p in _SAFE_JS_PATTERNS)
+
+
+# ---------------------------------------------------------------------------
+# Session manager
+# ---------------------------------------------------------------------------
+
+
+class BrowserSessionManager:
+    """Holds one BrowserPort instance per task_id.
+
+    Ensures sessions don't bleed across concurrent agents.
+    """
+
+    def __init__(self) -> None:
+        self._sessions: dict[str, BrowserPort] = {}
+
+    def get(self, task_id: str) -> BrowserPort | None:
+        return self._sessions.get(task_id)
+
+    def set(self, task_id: str, browser: BrowserPort) -> None:
+        self._sessions[task_id] = browser
+
+    async def close(self, task_id: str) -> None:
+        browser = self._sessions.pop(task_id, None)
+        if browser is not None:
+            await browser.close()
+
+    async def close_all(self) -> None:
+        for task_id in list(self._sessions):
+            await self.close(task_id)
+
+
+# ---------------------------------------------------------------------------
+# Shared base for all browser tools
+# ---------------------------------------------------------------------------
+
+
+class _BrowserToolBase(ToolPort):
+    """Shared state and helper methods for all 8 browser tools."""
+
+    def __init__(
+        self,
+        session_manager: BrowserSessionManager,
+        task_id: str,
+        *,
+        allowed_origins: list[str] | None = None,
+        blocked_origins: list[str] | None = None,
+        full_js: bool = False,
+    ) -> None:
+        self._session_manager = session_manager
+        self._task_id = task_id
+        self._allowed_origins: list[str] = allowed_origins or _DEFAULT_ALLOWED_ORIGINS
+        self._blocked_origins: list[str] = blocked_origins or _DEFAULT_BLOCKED_ORIGINS
+        self._full_js = full_js
+
+    @property
+    def parallelisable(self) -> bool:
+        # Browser tools operate on a single shared page — never parallelise.
+        return False
+
+    def _get_browser(self) -> BrowserPort | None:
+        return self._session_manager.get(self._task_id)
+
+    def _ok(self, content: str) -> ToolResult:
+        return ToolResult(tool_call_id="", content=content)
+
+    def _err(self, content: str) -> ToolResult:
+        return ToolResult(tool_call_id="", content=content, is_error=True)
+
+    def _format_summary(self, summary: PageSummary) -> str:
+        lines = [
+            f"URL: {summary.url}",
+            f"Title: {summary.title}",
+            f"Status: {summary.status}",
+        ]
+        if summary.text_preview:
+            lines.append(f"\n{summary.text_preview}")
+        return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Tool: browser_navigate
+# ---------------------------------------------------------------------------
+
+
+class BrowserNavigateTool(_BrowserToolBase):
+    """Navigate the browser to a URL."""
+
+    def __init__(
+        self,
+        session_manager: BrowserSessionManager,
+        task_id: str,
+        browser_factory: Any,
+        *,
+        allowed_origins: list[str] | None = None,
+        blocked_origins: list[str] | None = None,
+        full_js: bool = False,
+    ) -> None:
+        super().__init__(
+            session_manager,
+            task_id,
+            allowed_origins=allowed_origins,
+            blocked_origins=blocked_origins,
+            full_js=full_js,
+        )
+        self._browser_factory = browser_factory
+
+    @property
+    def name(self) -> str:
+        return "browser_navigate"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Navigate the browser to a URL. Returns a summary of the loaded page "
+            "including title, status code, and a text preview. "
+            "Use browser_snapshot() after navigation to see interactive elements."
+        )
+
+    @property
+    def input_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "url": {"type": "string", "description": "The URL to navigate to."},
+                "wait_for": {
+                    "type": "string",
+                    "enum": ["load", "domcontentloaded", "networkidle"],
+                    "description": (
+                        "Event to wait for before returning (default: domcontentloaded)."
+                    ),
+                },
+            },
+            "required": ["url"],
+        }
+
+    @property
+    def required_permission(self) -> str:
+        return "browser:read"
+
+    async def execute(self, input: dict) -> ToolResult:
+        url = input.get("url", "").strip()
+        wait_for = input.get("wait_for", "domcontentloaded")
+
+        if not url:
+            return self._err("url is required")
+
+        err = _validate_browser_url(url, self._allowed_origins, self._blocked_origins)
+        if err:
+            return self._err(err)
+
+        browser = self._get_browser()
+        if browser is None:
+            browser = self._browser_factory()
+            self._session_manager.set(self._task_id, browser)
+
+        try:
+            summary = await browser.navigate(url, wait_for=wait_for)
+            return self._ok(self._format_summary(summary))
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("browser_navigate failed: %s", exc)
+            return self._err(f"Navigation error: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Tool: browser_snapshot
+# ---------------------------------------------------------------------------
+
+
+class BrowserSnapshotTool(_BrowserToolBase):
+    """Capture the current page accessibility tree."""
+
+    @property
+    def name(self) -> str:
+        return "browser_snapshot"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Return the accessibility tree of the current page as compact text. "
+            "Elements are listed as [role \"label\" @eN]. "
+            "Use @eN handles in browser_click and browser_type to reference elements. "
+            "Call browser_navigate first to load a page."
+        )
+
+    @property
+    def input_schema(self) -> dict:
+        return {"type": "object", "properties": {}, "required": []}
+
+    @property
+    def required_permission(self) -> str:
+        return "browser:read"
+
+    async def execute(self, input: dict) -> ToolResult:
+        browser = self._get_browser()
+        if browser is None:
+            return self._err("No active browser session. Call browser_navigate first.")
+        try:
+            snapshot = await browser.snapshot()
+            return self._ok(snapshot)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("browser_snapshot failed: %s", exc)
+            return self._err(f"Snapshot error: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Tool: browser_click
+# ---------------------------------------------------------------------------
+
+
+class BrowserClickTool(_BrowserToolBase):
+    """Click an element on the current page."""
+
+    @property
+    def name(self) -> str:
+        return "browser_click"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Click an element on the current page. "
+            "Use an @eN handle from browser_snapshot, or a CSS selector. "
+            "Requires an active browser session (call browser_navigate first)."
+        )
+
+    @property
+    def input_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "selector": {
+                    "type": "string",
+                    "description": "An @eN handle from browser_snapshot, or a CSS selector.",
+                },
+            },
+            "required": ["selector"],
+        }
+
+    @property
+    def required_permission(self) -> str:
+        return "browser:write"
+
+    async def execute(self, input: dict) -> ToolResult:
+        selector = input.get("selector", "").strip()
+        if not selector:
+            return self._err("selector is required")
+
+        browser = self._get_browser()
+        if browser is None:
+            return self._err("No active browser session. Call browser_navigate first.")
+
+        try:
+            await browser.click(selector)
+            return self._ok(f"Clicked '{selector}'")
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("browser_click failed for selector=%r: %s", selector, exc)
+            return self._err(f"Click error for '{selector}': {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Tool: browser_type
+# ---------------------------------------------------------------------------
+
+
+class BrowserTypeTool(_BrowserToolBase):
+    """Type text into an input element on the current page."""
+
+    @property
+    def name(self) -> str:
+        return "browser_type"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Type text into an input field on the current page. "
+            "Use an @eN handle from browser_snapshot, or a CSS selector. "
+            "Clears existing content before typing."
+        )
+
+    @property
+    def input_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "selector": {
+                    "type": "string",
+                    "description": "An @eN handle from browser_snapshot, or a CSS selector.",
+                },
+                "text": {
+                    "type": "string",
+                    "description": "Text to type into the element.",
+                },
+            },
+            "required": ["selector", "text"],
+        }
+
+    @property
+    def required_permission(self) -> str:
+        return "browser:write"
+
+    async def execute(self, input: dict) -> ToolResult:
+        selector = input.get("selector", "").strip()
+        text = input.get("text", "")
+
+        if not selector:
+            return self._err("selector is required")
+
+        browser = self._get_browser()
+        if browser is None:
+            return self._err("No active browser session. Call browser_navigate first.")
+
+        try:
+            await browser.type(selector, text)
+            return self._ok(f"Typed into '{selector}'")
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("browser_type failed for selector=%r: %s", selector, exc)
+            return self._err(f"Type error for '{selector}': {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Tool: browser_scroll
+# ---------------------------------------------------------------------------
+
+
+class BrowserScrollTool(_BrowserToolBase):
+    """Scroll the current page."""
+
+    @property
+    def name(self) -> str:
+        return "browser_scroll"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Scroll the current page. "
+            "Direction must be one of: up, down, left, right. "
+            "Amount is the number of scroll steps (default 3)."
+        )
+
+    @property
+    def input_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "direction": {
+                    "type": "string",
+                    "enum": ["up", "down", "left", "right"],
+                    "description": "Scroll direction.",
+                },
+                "amount": {
+                    "type": "integer",
+                    "description": "Number of scroll steps (default 3).",
+                    "minimum": 1,
+                },
+            },
+            "required": ["direction"],
+        }
+
+    @property
+    def required_permission(self) -> str:
+        return "browser:write"
+
+    async def execute(self, input: dict) -> ToolResult:
+        direction = input.get("direction", "").strip()
+        amount = int(input.get("amount", 3))
+
+        if direction not in ("up", "down", "left", "right"):
+            return self._err(f"Invalid direction '{direction}'. Must be up/down/left/right.")
+
+        browser = self._get_browser()
+        if browser is None:
+            return self._err("No active browser session. Call browser_navigate first.")
+
+        try:
+            await browser.scroll(direction, amount)
+            return self._ok(f"Scrolled {direction} ({amount} steps)")
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("browser_scroll failed: %s", exc)
+            return self._err(f"Scroll error: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Tool: browser_screenshot
+# ---------------------------------------------------------------------------
+
+
+class BrowserScreenshotTool(_BrowserToolBase):
+    """Capture a screenshot of the current page."""
+
+    @property
+    def name(self) -> str:
+        return "browser_screenshot"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Capture a full-page screenshot of the current page. "
+            "Returns a base64-encoded PNG suitable for vision-capable models."
+        )
+
+    @property
+    def input_schema(self) -> dict:
+        return {"type": "object", "properties": {}, "required": []}
+
+    @property
+    def required_permission(self) -> str:
+        return "browser:read"
+
+    async def execute(self, input: dict) -> ToolResult:
+        browser = self._get_browser()
+        if browser is None:
+            return self._err("No active browser session. Call browser_navigate first.")
+
+        try:
+            png_bytes = await browser.screenshot()
+            b64 = base64.b64encode(png_bytes).decode()
+            return self._ok(f"data:image/png;base64,{b64}")
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("browser_screenshot failed: %s", exc)
+            return self._err(f"Screenshot error: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Tool: browser_evaluate
+# ---------------------------------------------------------------------------
+
+
+class BrowserEvaluateTool(_BrowserToolBase):
+    """Execute a JavaScript expression in the current page context."""
+
+    @property
+    def name(self) -> str:
+        return "browser_evaluate"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Evaluate a JavaScript expression in the current page. "
+            "By default only read-only expressions are allowed. "
+            "Set full_js=true to allow unrestricted execution (requires FULL_ACCESS permission)."
+        )
+
+    @property
+    def input_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "js": {
+                    "type": "string",
+                    "description": "JavaScript expression to evaluate.",
+                },
+                "full_js": {
+                    "type": "boolean",
+                    "description": (
+                        "Set true to allow unrestricted JS execution. "
+                        "Requires FULL_ACCESS permission mode."
+                    ),
+                },
+            },
+            "required": ["js"],
+        }
+
+    @property
+    def required_permission(self) -> str:
+        return "browser:read"
+
+    async def execute(self, input: dict) -> ToolResult:
+        js = input.get("js", "").strip()
+        wants_full = bool(input.get("full_js", False))
+
+        if not js:
+            return self._err("js is required")
+
+        if wants_full and not self._full_js:
+            return self._err(
+                "full_js=true requires FULL_ACCESS permission mode. "
+                "The agent is not running in FULL_ACCESS mode."
+            )
+
+        if not wants_full and not _is_safe_js(js):
+            return self._err(
+                "This JavaScript expression is not in the read-only allow-list. "
+                "Use full_js=true (requires FULL_ACCESS permission) for arbitrary JS."
+            )
+
+        browser = self._get_browser()
+        if browser is None:
+            return self._err("No active browser session. Call browser_navigate first.")
+
+        try:
+            result = await browser.evaluate(js)
+            return self._ok(json.dumps(result, default=str))
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("browser_evaluate failed: %s", exc)
+            return self._err(f"Evaluate error: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Tool: browser_session_close
+# ---------------------------------------------------------------------------
+
+
+class BrowserSessionCloseTool(_BrowserToolBase):
+    """Close the active browser session."""
+
+    @property
+    def name(self) -> str:
+        return "browser_session_close"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Close the active browser session and release all resources. "
+            "Sessions are also auto-closed when the agent turn ends. "
+            "Call this explicitly to free resources during long tasks."
+        )
+
+    @property
+    def input_schema(self) -> dict:
+        return {"type": "object", "properties": {}, "required": []}
+
+    @property
+    def required_permission(self) -> str:
+        return "browser:read"
+
+    async def execute(self, input: dict) -> ToolResult:
+        browser = self._get_browser()
+        if browser is None:
+            return self._ok("No active browser session.")
+        try:
+            await self._session_manager.close(self._task_id)
+            return self._ok("Browser session closed.")
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("browser_session_close failed: %s", exc)
+            return self._err(f"Session close error: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Factory helper
+# ---------------------------------------------------------------------------
+
+
+def build_browser_tools(
+    task_id: str,
+    *,
+    backend: str = "local",
+    headless: bool = True,
+    timeout_ms: int = 30_000,
+    allowed_origins: list[str] | None = None,
+    blocked_origins: list[str] | None = None,
+    full_js: bool = False,
+    browserbase_api_key: str = "",
+    browserbase_project_id: str = "",
+    browserbase_stealth: bool = False,
+) -> list[ToolPort]:
+    """Construct and return all 8 browser ToolPort instances.
+
+    Args:
+        task_id:            Session scope identifier (e.g. conversation/task ID).
+        backend:            ``"local"`` (Playwright Chromium) or ``"browserbase"``.
+        headless:           Launch browser headlessly (local backend only).
+        timeout_ms:         Default navigation/action timeout in milliseconds.
+        allowed_origins:    Glob patterns for allowed hostnames (empty = all).
+        blocked_origins:    Glob patterns for blocked hostnames.
+        full_js:            Allow unrestricted JS via browser_evaluate.
+        browserbase_api_key:     Browserbase API key (or set BROWSERBASE_API_KEY env var).
+        browserbase_project_id:  Browserbase project ID.
+        browserbase_stealth:     Enable Browserbase stealth mode.
+
+    Returns:
+        List of 8 ToolPort instances sharing a single BrowserSessionManager.
+    """
+    session_manager = BrowserSessionManager()
+
+    def _browser_factory() -> BrowserPort:
+        if backend == "browserbase" or os.environ.get("BROWSERBASE_API_KEY"):
+            from ravn.adapters.browser.browserbase import BrowserbaseAdapter
+
+            return BrowserbaseAdapter(
+                api_key=browserbase_api_key,
+                project_id=browserbase_project_id,
+                stealth=browserbase_stealth,
+                headless=headless,
+                timeout_ms=timeout_ms,
+            )
+        from ravn.adapters.browser.local import LocalPlaywrightAdapter
+
+        return LocalPlaywrightAdapter(headless=headless, timeout_ms=timeout_ms)
+
+    common_kwargs: dict = {
+        "session_manager": session_manager,
+        "task_id": task_id,
+        "allowed_origins": allowed_origins,
+        "blocked_origins": blocked_origins,
+        "full_js": full_js,
+    }
+
+    return [
+        BrowserNavigateTool(
+            session_manager=session_manager,
+            task_id=task_id,
+            browser_factory=_browser_factory,
+            allowed_origins=allowed_origins,
+            blocked_origins=blocked_origins,
+            full_js=full_js,
+        ),
+        BrowserSnapshotTool(**common_kwargs),
+        BrowserClickTool(**common_kwargs),
+        BrowserTypeTool(**common_kwargs),
+        BrowserScrollTool(**common_kwargs),
+        BrowserScreenshotTool(**common_kwargs),
+        BrowserEvaluateTool(**common_kwargs),
+        BrowserSessionCloseTool(**common_kwargs),
+    ]

--- a/src/ravn/adapters/tools/web_fetch.py
+++ b/src/ravn/adapters/tools/web_fetch.py
@@ -2,15 +2,14 @@
 
 from __future__ import annotations
 
-import ipaddress
 import logging
 import re
-import socket
 from html.parser import HTMLParser
 from urllib.parse import urlparse
 
 import httpx
 
+from ravn.adapters.tools._url_security import check_ssrf
 from ravn.domain.models import ToolResult
 from ravn.ports.tool import ToolPort
 
@@ -106,25 +105,6 @@ def truncate_to_budget(text: str, budget: int) -> str:
 # SSRF protection
 # ---------------------------------------------------------------------------
 
-_PRIVATE_NETWORKS: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = [
-    ipaddress.ip_network("127.0.0.0/8"),
-    ipaddress.ip_network("10.0.0.0/8"),
-    ipaddress.ip_network("172.16.0.0/12"),
-    ipaddress.ip_network("192.168.0.0/16"),
-    ipaddress.ip_network("169.254.0.0/16"),
-    ipaddress.ip_network("::1/128"),
-    ipaddress.ip_network("fc00::/7"),
-]
-
-
-def _is_private_ip(ip: str) -> bool:
-    """Return True if the IP address falls within a private/reserved range."""
-    try:
-        addr = ipaddress.ip_address(ip)
-    except ValueError:
-        return True  # Unparseable — block by default.
-    return any(addr in net for net in _PRIVATE_NETWORKS)
-
 
 def _validate_url(url: str) -> str | None:
     """Return an error message if *url* is disallowed, else None.
@@ -141,17 +121,7 @@ def _validate_url(url: str) -> str | None:
     if not hostname:
         return "Blocked: URL has no hostname"
 
-    try:
-        results = socket.getaddrinfo(hostname, None)
-    except OSError:
-        return f"Blocked: could not resolve hostname '{hostname}'"
-
-    for _family, _type, _proto, _canonname, sockaddr in results:
-        ip = sockaddr[0]
-        if _is_private_ip(ip):
-            return f"Blocked: '{hostname}' resolves to a private/reserved address"
-
-    return None
+    return check_ssrf(hostname)
 
 
 # ---------------------------------------------------------------------------

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -1349,6 +1349,59 @@ class BuriConfig(BaseModel):
     )
 
 
+class BrowserbaseConfig(BaseModel):
+    """Browserbase cloud browser configuration."""
+
+    api_key_env: str = Field(
+        default="BROWSERBASE_API_KEY",
+        description="Environment variable name holding the Browserbase API key.",
+    )
+    project_id_env: str = Field(
+        default="BROWSERBASE_PROJECT_ID",
+        description="Environment variable name holding the Browserbase project ID.",
+    )
+    stealth: bool = Field(
+        default=False,
+        description="Enable stealth mode (anti-bot fingerprint masking).",
+    )
+
+
+class BrowserConfig(BaseModel):
+    """Browser automation tool configuration (NIU-532)."""
+
+    backend: Literal["local", "browserbase"] = Field(
+        default="local",
+        description=(
+            "Browser backend: 'local' (headless Chromium via Playwright) "
+            "or 'browserbase' (cloud execution with stealth / CAPTCHA support). "
+            "Browserbase is activated automatically when BROWSERBASE_API_KEY is set."
+        ),
+    )
+    headless: bool = Field(
+        default=True,
+        description="Launch browser headlessly (local backend only).",
+    )
+    timeout_ms: int = Field(
+        default=30_000,
+        description="Default navigation and action timeout in milliseconds.",
+    )
+    allowed_origins: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Glob patterns for hostnames the agent is allowed to navigate to. "
+            "Empty list means all origins are allowed (subject to blocked_origins)."
+        ),
+    )
+    blocked_origins: list[str] = Field(
+        default_factory=list,
+        description="Glob patterns for hostnames that are always blocked.",
+    )
+    browserbase: BrowserbaseConfig = Field(
+        default_factory=BrowserbaseConfig,
+        description="Browserbase cloud backend configuration.",
+    )
+
+
 class CheckpointConfig(BaseModel):
     """Task-interruption checkpoint configuration (NIU-504)."""
 
@@ -1432,6 +1485,9 @@ class Settings(BaseSettings):
 
     # NIU-504: task interruption / resume
     checkpoint: CheckpointConfig = Field(default_factory=CheckpointConfig)
+
+    # NIU-532: browser automation
+    browser: BrowserConfig = Field(default_factory=BrowserConfig)
 
     # Legacy — kept so existing CLI wiring (NIU-426) continues to work
     llm_adapter: LLMAdapterConfig = Field(default_factory=LLMAdapterConfig)

--- a/src/ravn/ports/browser.py
+++ b/src/ravn/ports/browser.py
@@ -1,0 +1,73 @@
+"""BrowserPort — interface for browser automation backends."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+
+@dataclass
+class PageSummary:
+    """Summary of a navigated page."""
+
+    url: str
+    title: str
+    status: int
+    text_preview: str  # First ~500 chars of visible text
+
+
+@runtime_checkable
+class BrowserPort(Protocol):
+    """Abstract interface for a browser automation backend.
+
+    Two backends are provided:
+    - LocalPlaywrightAdapter: headless Chromium via Playwright (zero external deps).
+    - BrowserbaseAdapter: cloud execution with stealth / CAPTCHA support.
+
+    Sessions are scoped to a task_id; the agent never sees which backend is active.
+    """
+
+    async def navigate(self, url: str, *, wait_for: str = "domcontentloaded") -> PageSummary:
+        """Navigate to *url* and return a page summary."""
+        ...  # pragma: no cover
+
+    async def snapshot(self) -> str:
+        """Return the page accessibility tree as compact text.
+
+        Each element is formatted as::
+
+            [role "label" @eN]
+
+        Handles are referenced by ``@eN`` in subsequent tool calls.
+        Typical output < 2 K tokens.
+        """
+        ...  # pragma: no cover
+
+    async def click(self, selector: str) -> None:
+        """Click the element identified by *selector* or ``@eN`` handle."""
+        ...  # pragma: no cover
+
+    async def type(self, selector: str, text: str) -> None:
+        """Type *text* into the element identified by *selector* or ``@eN`` handle."""
+        ...  # pragma: no cover
+
+    async def scroll(self, direction: str, amount: int = 3) -> None:
+        """Scroll the page.
+
+        Args:
+            direction: ``"up"`` | ``"down"`` | ``"left"`` | ``"right"``
+            amount:    Number of scroll steps (default 3).
+        """
+        ...  # pragma: no cover
+
+    async def screenshot(self) -> bytes:
+        """Capture a full-page screenshot and return raw PNG bytes."""
+        ...  # pragma: no cover
+
+    async def evaluate(self, js: str) -> Any:
+        """Evaluate a JavaScript expression and return the result."""
+        ...  # pragma: no cover
+
+    async def close(self) -> None:
+        """Close the browser session and release all resources."""
+        ...  # pragma: no cover

--- a/tests/ravn/unit/test_web_fetch.py
+++ b/tests/ravn/unit/test_web_fetch.py
@@ -6,10 +6,10 @@ import httpx
 import pytest
 import respx
 
+from ravn.adapters.tools._url_security import is_private_ip as _is_private_ip
 from ravn.adapters.tools.web_fetch import (
     _INJECTION_WARNING,
     WebFetchTool,
-    _is_private_ip,
     _validate_url,
     extract_text,
     scan_for_injection,

--- a/tests/test_ravn/test_browser_tools.py
+++ b/tests/test_ravn/test_browser_tools.py
@@ -1,0 +1,1178 @@
+"""Tests for the browser automation tool layer.
+
+All tests use a mock BrowserPort — no real browser or Playwright required.
+Integration tests that require a real browser are marked @pytest.mark.browser.
+"""
+
+from __future__ import annotations
+
+import base64
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ravn.adapters.browser.local import _ax_node_to_line, _serialise_ax_tree
+from ravn.adapters.tools.browser import (
+    BrowserClickTool,
+    BrowserEvaluateTool,
+    BrowserNavigateTool,
+    BrowserScreenshotTool,
+    BrowserScrollTool,
+    BrowserSessionCloseTool,
+    BrowserSessionManager,
+    BrowserSnapshotTool,
+    BrowserTypeTool,
+    _is_safe_js,
+    _validate_browser_url,
+    build_browser_tools,
+)
+from ravn.ports.browser import PageSummary
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def make_mock_browser(
+    *,
+    nav_summary: PageSummary | None = None,
+    snapshot_text: str = "[button \"Submit\" @e1]",
+    screenshot_bytes: bytes = b"\x89PNG\r\n",
+    evaluate_result: Any = "result",
+) -> AsyncMock:
+    """Return a mock BrowserPort with configurable return values."""
+    browser = AsyncMock()
+    browser.navigate.return_value = nav_summary or PageSummary(
+        url="https://example.com",
+        title="Example",
+        status=200,
+        text_preview="Hello world",
+    )
+    browser.snapshot.return_value = snapshot_text
+    browser.click.return_value = None
+    browser.type.return_value = None
+    browser.scroll.return_value = None
+    browser.screenshot.return_value = screenshot_bytes
+    browser.evaluate.return_value = evaluate_result
+    browser.close.return_value = None
+    return browser
+
+
+def make_session_manager(browser: AsyncMock, task_id: str = "task-1") -> BrowserSessionManager:
+    """Return a session manager pre-loaded with *browser* for *task_id*."""
+    sm = BrowserSessionManager()
+    sm.set(task_id, browser)
+    return sm
+
+
+# ---------------------------------------------------------------------------
+# URL validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidateBrowserUrl:
+    def test_http_allowed(self) -> None:
+        assert _validate_browser_url("http://example.com", [], []) is None
+
+    def test_https_allowed(self) -> None:
+        assert _validate_browser_url("https://example.com", [], []) is None
+
+    def test_non_http_scheme_blocked(self) -> None:
+        err = _validate_browser_url("ftp://example.com", [], [])
+        assert err is not None
+        assert "ftp" in err
+
+    def test_file_scheme_blocked(self) -> None:
+        err = _validate_browser_url("file:///etc/passwd", [], [])
+        assert err is not None
+
+    def test_blocked_origin_glob(self) -> None:
+        err = _validate_browser_url("https://internal.corp", [], ["*.corp"])
+        assert err is not None
+        assert "internal.corp" in err
+
+    def test_blocked_exact_host(self) -> None:
+        err = _validate_browser_url("https://bad.example.com", [], ["bad.example.com"])
+        assert err is not None
+
+    def test_blocked_origin_does_not_match_other(self) -> None:
+        assert _validate_browser_url("https://good.example.com", [], ["bad.example.com"]) is None
+
+    def test_allowed_origins_permits_match(self) -> None:
+        assert _validate_browser_url("https://allowed.com", ["allowed.com"], []) is None
+
+    def test_allowed_origins_blocks_non_match(self) -> None:
+        err = _validate_browser_url("https://other.com", ["allowed.com"], [])
+        assert err is not None
+        assert "allowed origins" in err
+
+    def test_no_hostname_blocked(self) -> None:
+        err = _validate_browser_url("https://", [], [])
+        assert err is not None
+
+    def test_blocked_takes_precedence_over_allowed(self) -> None:
+        err = _validate_browser_url("https://bad.corp", ["bad.corp"], ["bad.corp"])
+        assert err is not None
+
+
+# ---------------------------------------------------------------------------
+# JS safety check
+# ---------------------------------------------------------------------------
+
+
+class TestIsSafeJs:
+    def test_document_title_safe(self) -> None:
+        assert _is_safe_js("document.title") is True
+
+    def test_document_url_safe(self) -> None:
+        assert _is_safe_js("document.URL") is True
+
+    def test_innertext_safe(self) -> None:
+        assert _is_safe_js("document.body.innerText") is True
+
+    def test_arbitrary_js_not_safe(self) -> None:
+        assert _is_safe_js("fetch('https://evil.com')") is False
+
+    def test_delete_call_not_safe(self) -> None:
+        assert _is_safe_js("delete window.alert") is False
+
+
+# ---------------------------------------------------------------------------
+# Accessibility tree helpers
+# ---------------------------------------------------------------------------
+
+
+class TestAxNodeToLine:
+    def test_button_node(self) -> None:
+        counter = [0]
+        node = {"role": "button", "name": "Log in"}
+        line = _ax_node_to_line(node, counter)
+        assert line == '[button "Log in" @e1]'
+        assert counter[0] == 1
+
+    def test_input_node_with_placeholder(self) -> None:
+        counter = [0]
+        node = {
+            "role": "textbox",
+            "name": "Email",
+            "type": "email",
+            "placeholder": "you@example.com",
+        }
+        line = _ax_node_to_line(node, counter)
+        assert line is not None
+        assert "@e1" in line
+        assert 'placeholder="you@example.com"' in line
+
+    def test_heading_with_level(self) -> None:
+        counter = [0]
+        node = {"role": "heading", "name": "Sign in", "level": 1}
+        line = _ax_node_to_line(node, counter)
+        assert "level=1" in line
+        assert '"Sign in"' in line
+
+    def test_generic_no_name_skipped(self) -> None:
+        counter = [0]
+        node = {"role": "generic"}
+        line = _ax_node_to_line(node, counter)
+        assert line is None
+        assert counter[0] == 0
+
+    def test_none_role_skipped(self) -> None:
+        counter = [0]
+        node = {"role": "none"}
+        line = _ax_node_to_line(node, counter)
+        assert line is None
+
+    def test_disabled_attribute(self) -> None:
+        counter = [0]
+        node = {"role": "button", "name": "Submit", "disabled": True}
+        line = _ax_node_to_line(node, counter)
+        assert "disabled" in line
+
+
+class TestSerialiseAxTree:
+    def test_flat_tree(self) -> None:
+        tree = {
+            "role": "WebArea",
+            "name": "Page",
+            "children": [
+                {"role": "button", "name": "Click me"},
+                {"role": "textbox", "name": "Search", "placeholder": "Type here"},
+            ],
+        }
+        text, handles = _serialise_ax_tree(tree)
+        assert "@e1" in handles
+        assert "@e2" in handles
+        lines = text.splitlines()
+        assert len(lines) == 3  # WebArea + 2 children
+
+    def test_empty_tree(self) -> None:
+        tree = {"role": "WebArea", "name": "Empty"}
+        text, handles = _serialise_ax_tree(tree)
+        assert len(handles) == 1
+
+    def test_nested_tree(self) -> None:
+        tree = {
+            "role": "main",
+            "name": "Content",
+            "children": [
+                {
+                    "role": "navigation",
+                    "name": "Nav",
+                    "children": [
+                        {"role": "link", "name": "Home"},
+                    ],
+                }
+            ],
+        }
+        text, handles = _serialise_ax_tree(tree)
+        assert len(handles) == 3
+
+
+# ---------------------------------------------------------------------------
+# BrowserSessionManager
+# ---------------------------------------------------------------------------
+
+
+class TestBrowserSessionManager:
+    @pytest.mark.asyncio
+    async def test_set_and_get(self) -> None:
+        browser = make_mock_browser()
+        sm = BrowserSessionManager()
+        sm.set("t1", browser)
+        assert sm.get("t1") is browser
+
+    @pytest.mark.asyncio
+    async def test_get_missing_returns_none(self) -> None:
+        sm = BrowserSessionManager()
+        assert sm.get("missing") is None
+
+    @pytest.mark.asyncio
+    async def test_close_calls_browser_close(self) -> None:
+        browser = make_mock_browser()
+        sm = BrowserSessionManager()
+        sm.set("t1", browser)
+        await sm.close("t1")
+        browser.close.assert_awaited_once()
+        assert sm.get("t1") is None
+
+    @pytest.mark.asyncio
+    async def test_close_all(self) -> None:
+        b1, b2 = make_mock_browser(), make_mock_browser()
+        sm = BrowserSessionManager()
+        sm.set("t1", b1)
+        sm.set("t2", b2)
+        await sm.close_all()
+        b1.close.assert_awaited_once()
+        b2.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_close_nonexistent_task_is_noop(self) -> None:
+        sm = BrowserSessionManager()
+        await sm.close("nonexistent")  # Should not raise
+
+
+# ---------------------------------------------------------------------------
+# BrowserNavigateTool
+# ---------------------------------------------------------------------------
+
+
+class TestBrowserNavigateTool:
+    def _make_tool(self, browser: AsyncMock, task_id: str = "task-1") -> BrowserNavigateTool:
+        sm = BrowserSessionManager()
+        return BrowserNavigateTool(
+            session_manager=sm,
+            task_id=task_id,
+            browser_factory=lambda: browser,
+        )
+
+    @pytest.mark.asyncio
+    async def test_navigate_success(self) -> None:
+        browser = make_mock_browser()
+        tool = self._make_tool(browser)
+        result = await tool.execute({"url": "https://example.com"})
+        assert not result.is_error
+        assert "https://example.com" in result.content
+        assert "200" in result.content
+
+    @pytest.mark.asyncio
+    async def test_navigate_creates_session(self) -> None:
+        browser = make_mock_browser()
+        sm = BrowserSessionManager()
+        tool = BrowserNavigateTool(
+            session_manager=sm,
+            task_id="task-1",
+            browser_factory=lambda: browser,
+        )
+        await tool.execute({"url": "https://example.com"})
+        assert sm.get("task-1") is browser
+
+    @pytest.mark.asyncio
+    async def test_navigate_blocked_url(self) -> None:
+        browser = make_mock_browser()
+        sm = BrowserSessionManager()
+        tool = BrowserNavigateTool(
+            session_manager=sm,
+            task_id="t",
+            browser_factory=lambda: browser,
+            blocked_origins=["*.internal"],
+        )
+        result = await tool.execute({"url": "https://rancher.internal"})
+        assert result.is_error
+        assert "Blocked" in result.content
+
+    @pytest.mark.asyncio
+    async def test_navigate_missing_url(self) -> None:
+        browser = make_mock_browser()
+        tool = self._make_tool(browser)
+        result = await tool.execute({})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_navigate_non_http_scheme(self) -> None:
+        browser = make_mock_browser()
+        tool = self._make_tool(browser)
+        result = await tool.execute({"url": "ftp://example.com"})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_navigate_browser_exception_returns_error(self) -> None:
+        browser = AsyncMock()
+        browser.navigate.side_effect = RuntimeError("connection refused")
+        sm = BrowserSessionManager()
+        tool = BrowserNavigateTool(
+            session_manager=sm,
+            task_id="t",
+            browser_factory=lambda: browser,
+        )
+        result = await tool.execute({"url": "https://example.com"})
+        assert result.is_error
+        assert "Navigation error" in result.content
+
+    def test_name(self) -> None:
+        sm = BrowserSessionManager()
+        tool = BrowserNavigateTool(sm, "t", browser_factory=lambda: None)
+        assert tool.name == "browser_navigate"
+
+    def test_not_parallelisable(self) -> None:
+        sm = BrowserSessionManager()
+        tool = BrowserNavigateTool(sm, "t", browser_factory=lambda: None)
+        assert tool.parallelisable is False
+
+
+# ---------------------------------------------------------------------------
+# BrowserSnapshotTool
+# ---------------------------------------------------------------------------
+
+
+class TestBrowserSnapshotTool:
+    @pytest.mark.asyncio
+    async def test_snapshot_returns_ax_tree(self) -> None:
+        browser = make_mock_browser(snapshot_text='[button "Login" @e1]')
+        sm = make_session_manager(browser)
+        tool = BrowserSnapshotTool(session_manager=sm, task_id="task-1")
+        result = await tool.execute({})
+        assert not result.is_error
+        assert '[button "Login" @e1]' in result.content
+
+    @pytest.mark.asyncio
+    async def test_snapshot_no_session_returns_error(self) -> None:
+        sm = BrowserSessionManager()
+        tool = BrowserSnapshotTool(session_manager=sm, task_id="task-1")
+        result = await tool.execute({})
+        assert result.is_error
+        assert "browser_navigate" in result.content
+
+    @pytest.mark.asyncio
+    async def test_snapshot_browser_exception(self) -> None:
+        browser = AsyncMock()
+        browser.snapshot.side_effect = RuntimeError("page crashed")
+        sm = make_session_manager(browser)
+        tool = BrowserSnapshotTool(session_manager=sm, task_id="task-1")
+        result = await tool.execute({})
+        assert result.is_error
+
+    def test_name(self) -> None:
+        sm = BrowserSessionManager()
+        assert BrowserSnapshotTool(sm, "t").name == "browser_snapshot"
+
+
+# ---------------------------------------------------------------------------
+# BrowserClickTool
+# ---------------------------------------------------------------------------
+
+
+class TestBrowserClickTool:
+    @pytest.mark.asyncio
+    async def test_click_success(self) -> None:
+        browser = make_mock_browser()
+        sm = make_session_manager(browser)
+        tool = BrowserClickTool(session_manager=sm, task_id="task-1")
+        result = await tool.execute({"selector": "@e1"})
+        assert not result.is_error
+        assert "@e1" in result.content
+        browser.click.assert_awaited_once_with("@e1")
+
+    @pytest.mark.asyncio
+    async def test_click_missing_selector(self) -> None:
+        browser = make_mock_browser()
+        sm = make_session_manager(browser)
+        tool = BrowserClickTool(session_manager=sm, task_id="task-1")
+        result = await tool.execute({})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_click_no_session(self) -> None:
+        sm = BrowserSessionManager()
+        tool = BrowserClickTool(session_manager=sm, task_id="task-1")
+        result = await tool.execute({"selector": "#btn"})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_click_browser_exception(self) -> None:
+        browser = AsyncMock()
+        browser.click.side_effect = RuntimeError("element not found")
+        sm = make_session_manager(browser)
+        tool = BrowserClickTool(session_manager=sm, task_id="task-1")
+        result = await tool.execute({"selector": "#missing"})
+        assert result.is_error
+
+    def test_permission(self) -> None:
+        sm = BrowserSessionManager()
+        assert BrowserClickTool(sm, "t").required_permission == "browser:write"
+
+
+# ---------------------------------------------------------------------------
+# BrowserTypeTool
+# ---------------------------------------------------------------------------
+
+
+class TestBrowserTypeTool:
+    @pytest.mark.asyncio
+    async def test_type_success(self) -> None:
+        browser = make_mock_browser()
+        sm = make_session_manager(browser)
+        tool = BrowserTypeTool(session_manager=sm, task_id="task-1")
+        result = await tool.execute({"selector": "@e2", "text": "hello@example.com"})
+        assert not result.is_error
+        browser.type.assert_awaited_once_with("@e2", "hello@example.com")
+
+    @pytest.mark.asyncio
+    async def test_type_missing_selector(self) -> None:
+        browser = make_mock_browser()
+        sm = make_session_manager(browser)
+        tool = BrowserTypeTool(session_manager=sm, task_id="task-1")
+        result = await tool.execute({"text": "hello"})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_type_no_session(self) -> None:
+        sm = BrowserSessionManager()
+        tool = BrowserTypeTool(session_manager=sm, task_id="task-1")
+        result = await tool.execute({"selector": "#q", "text": "hello"})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# BrowserScrollTool
+# ---------------------------------------------------------------------------
+
+
+class TestBrowserScrollTool:
+    @pytest.mark.asyncio
+    async def test_scroll_down(self) -> None:
+        browser = make_mock_browser()
+        sm = make_session_manager(browser)
+        tool = BrowserScrollTool(session_manager=sm, task_id="task-1")
+        result = await tool.execute({"direction": "down", "amount": 2})
+        assert not result.is_error
+        browser.scroll.assert_awaited_once_with("down", 2)
+
+    @pytest.mark.asyncio
+    async def test_scroll_default_amount(self) -> None:
+        browser = make_mock_browser()
+        sm = make_session_manager(browser)
+        tool = BrowserScrollTool(session_manager=sm, task_id="task-1")
+        result = await tool.execute({"direction": "up"})
+        assert not result.is_error
+        browser.scroll.assert_awaited_once_with("up", 3)
+
+    @pytest.mark.asyncio
+    async def test_scroll_invalid_direction(self) -> None:
+        browser = make_mock_browser()
+        sm = make_session_manager(browser)
+        tool = BrowserScrollTool(session_manager=sm, task_id="task-1")
+        result = await tool.execute({"direction": "sideways"})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_scroll_no_session(self) -> None:
+        sm = BrowserSessionManager()
+        tool = BrowserScrollTool(session_manager=sm, task_id="task-1")
+        result = await tool.execute({"direction": "down"})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# BrowserScreenshotTool
+# ---------------------------------------------------------------------------
+
+
+class TestBrowserScreenshotTool:
+    @pytest.mark.asyncio
+    async def test_screenshot_returns_base64(self) -> None:
+        png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 20
+        browser = make_mock_browser(screenshot_bytes=png)
+        sm = make_session_manager(browser)
+        tool = BrowserScreenshotTool(session_manager=sm, task_id="task-1")
+        result = await tool.execute({})
+        assert not result.is_error
+        assert result.content.startswith("data:image/png;base64,")
+        # Verify it round-trips back to the original bytes.
+        b64_part = result.content.split(",", 1)[1]
+        assert base64.b64decode(b64_part) == png
+
+    @pytest.mark.asyncio
+    async def test_screenshot_no_session(self) -> None:
+        sm = BrowserSessionManager()
+        tool = BrowserScreenshotTool(session_manager=sm, task_id="task-1")
+        result = await tool.execute({})
+        assert result.is_error
+
+    def test_permission(self) -> None:
+        sm = BrowserSessionManager()
+        assert BrowserScreenshotTool(sm, "t").required_permission == "browser:read"
+
+
+# ---------------------------------------------------------------------------
+# BrowserEvaluateTool
+# ---------------------------------------------------------------------------
+
+
+class TestBrowserEvaluateTool:
+    @pytest.mark.asyncio
+    async def test_safe_js_allowed(self) -> None:
+        browser = make_mock_browser(evaluate_result="My Page")
+        sm = make_session_manager(browser)
+        tool = BrowserEvaluateTool(session_manager=sm, task_id="task-1")
+        result = await tool.execute({"js": "document.title"})
+        assert not result.is_error
+        assert "My Page" in result.content
+
+    @pytest.mark.asyncio
+    async def test_unsafe_js_blocked_by_default(self) -> None:
+        browser = make_mock_browser()
+        sm = make_session_manager(browser)
+        tool = BrowserEvaluateTool(session_manager=sm, task_id="task-1")
+        result = await tool.execute({"js": "fetch('https://evil.com')"})
+        assert result.is_error
+        assert "read-only" in result.content
+
+    @pytest.mark.asyncio
+    async def test_full_js_allowed_when_enabled(self) -> None:
+        browser = make_mock_browser(evaluate_result=42)
+        sm = make_session_manager(browser)
+        tool = BrowserEvaluateTool(session_manager=sm, task_id="task-1", full_js=True)
+        result = await tool.execute({"js": "1 + 1", "full_js": True})
+        assert not result.is_error
+        assert "42" in result.content
+
+    @pytest.mark.asyncio
+    async def test_full_js_flag_blocked_when_not_configured(self) -> None:
+        browser = make_mock_browser()
+        sm = make_session_manager(browser)
+        # full_js=False (default)
+        tool = BrowserEvaluateTool(session_manager=sm, task_id="task-1", full_js=False)
+        result = await tool.execute({"js": "document.cookie", "full_js": True})
+        assert result.is_error
+        assert "FULL_ACCESS" in result.content
+
+    @pytest.mark.asyncio
+    async def test_missing_js_returns_error(self) -> None:
+        browser = make_mock_browser()
+        sm = make_session_manager(browser)
+        tool = BrowserEvaluateTool(session_manager=sm, task_id="task-1")
+        result = await tool.execute({})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_no_session_returns_error(self) -> None:
+        sm = BrowserSessionManager()
+        tool = BrowserEvaluateTool(session_manager=sm, task_id="task-1")
+        result = await tool.execute({"js": "document.title"})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_json_serialisation(self) -> None:
+        browser = make_mock_browser(evaluate_result={"key": "value"})
+        sm = make_session_manager(browser)
+        tool = BrowserEvaluateTool(session_manager=sm, task_id="task-1")
+        result = await tool.execute({"js": "document.URL"})
+        assert not result.is_error
+        assert '"key"' in result.content
+
+
+# ---------------------------------------------------------------------------
+# BrowserSessionCloseTool
+# ---------------------------------------------------------------------------
+
+
+class TestBrowserSessionCloseTool:
+    @pytest.mark.asyncio
+    async def test_close_active_session(self) -> None:
+        browser = make_mock_browser()
+        sm = make_session_manager(browser)
+        tool = BrowserSessionCloseTool(session_manager=sm, task_id="task-1")
+        result = await tool.execute({})
+        assert not result.is_error
+        assert "closed" in result.content.lower()
+        browser.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_close_no_session_is_ok(self) -> None:
+        sm = BrowserSessionManager()
+        tool = BrowserSessionCloseTool(session_manager=sm, task_id="task-1")
+        result = await tool.execute({})
+        assert not result.is_error
+        assert "No active" in result.content
+
+    def test_name(self) -> None:
+        sm = BrowserSessionManager()
+        assert BrowserSessionCloseTool(sm, "t").name == "browser_session_close"
+
+
+# ---------------------------------------------------------------------------
+# build_browser_tools factory
+# ---------------------------------------------------------------------------
+
+
+class TestBuildBrowserTools:
+    def test_returns_eight_tools(self) -> None:
+        tools = build_browser_tools("task-1")
+        assert len(tools) == 8
+
+    def test_tool_names_unique(self) -> None:
+        tools = build_browser_tools("task-1")
+        names = [t.name for t in tools]
+        assert len(names) == len(set(names))
+
+    def test_expected_names(self) -> None:
+        tools = build_browser_tools("task-1")
+        names = {t.name for t in tools}
+        expected = {
+            "browser_navigate",
+            "browser_snapshot",
+            "browser_click",
+            "browser_type",
+            "browser_scroll",
+            "browser_screenshot",
+            "browser_evaluate",
+            "browser_session_close",
+        }
+        assert names == expected
+
+    def test_all_have_input_schema(self) -> None:
+        for tool in build_browser_tools("task-1"):
+            schema = tool.input_schema
+            assert isinstance(schema, dict)
+            assert schema.get("type") == "object"
+
+    def test_none_parallelisable(self) -> None:
+        for tool in build_browser_tools("task-1"):
+            assert tool.parallelisable is False, f"{tool.name} should not be parallelisable"
+
+
+# ---------------------------------------------------------------------------
+# Config integration
+# ---------------------------------------------------------------------------
+
+
+class TestBrowserConfig:
+    def test_default_config_loads(self) -> None:
+        from ravn.config import BrowserConfig
+
+        cfg = BrowserConfig()
+        assert cfg.backend == "local"
+        assert cfg.headless is True
+        assert cfg.timeout_ms == 30_000
+        assert cfg.allowed_origins == []
+        assert cfg.blocked_origins == []
+
+    def test_browserbase_config_defaults(self) -> None:
+        from ravn.config import BrowserbaseConfig
+
+        cfg = BrowserbaseConfig()
+        assert cfg.api_key_env == "BROWSERBASE_API_KEY"
+        assert cfg.stealth is False
+
+    def test_settings_has_browser_field(self) -> None:
+        from ravn.config import Settings
+
+        s = Settings()
+        assert hasattr(s, "browser")
+        assert s.browser.backend == "local"
+
+
+# ---------------------------------------------------------------------------
+# LocalPlaywrightAdapter — mocked page state (no real browser required)
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_page() -> MagicMock:
+    """Return a MagicMock mimicking a Playwright page object."""
+    page = MagicMock()
+    page.url = "https://example.com"
+    page.title = AsyncMock(return_value="Example")
+    page.goto = AsyncMock(return_value=MagicMock(status=200))
+    page.evaluate = AsyncMock(return_value="body text")
+    page.accessibility = MagicMock()
+    page.accessibility.snapshot = AsyncMock(
+        return_value={
+            "role": "WebArea",
+            "name": "Page",
+            "children": [{"role": "button", "name": "Click me"}],
+        }
+    )
+    page.click = AsyncMock()
+    page.fill = AsyncMock()
+    page.mouse = MagicMock()
+    page.mouse.wheel = AsyncMock()
+    page.screenshot = AsyncMock(return_value=b"\x89PNG")
+    page.close = AsyncMock()
+    page.set_default_timeout = MagicMock()
+
+    first_mock = MagicMock()
+    first_mock.click = AsyncMock()
+    first_mock.fill = AsyncMock()
+    locator_mock = MagicMock()
+    locator_mock.first = first_mock
+    locator_mock.fill = AsyncMock()
+    page.get_by_role = MagicMock(return_value=locator_mock)
+    page.get_by_placeholder = MagicMock(return_value=locator_mock)
+    return page
+
+
+def _inject_page(adapter: Any, page: Any) -> None:
+    """Inject a mock page directly into the adapter, bypassing _ensure_browser."""
+    adapter._page = page
+    adapter._browser = MagicMock()
+    adapter._browser.close = AsyncMock()
+    adapter._playwright = MagicMock()
+    adapter._playwright.stop = AsyncMock()
+
+
+class TestLocalPlaywrightAdapter:
+    @pytest.mark.asyncio
+    async def test_navigate_success(self) -> None:
+        from ravn.adapters.browser.local import LocalPlaywrightAdapter
+
+        adapter = LocalPlaywrightAdapter()
+        page = _make_mock_page()
+        _inject_page(adapter, page)
+        summary = await adapter.navigate("https://example.com")
+        assert summary.status == 200
+        assert summary.url == "https://example.com"
+        assert summary.title == "Example"
+
+    @pytest.mark.asyncio
+    async def test_navigate_evaluate_exception_still_returns(self) -> None:
+        from ravn.adapters.browser.local import LocalPlaywrightAdapter
+
+        adapter = LocalPlaywrightAdapter()
+        page = _make_mock_page()
+        page.evaluate = AsyncMock(side_effect=RuntimeError("no body"))
+        _inject_page(adapter, page)
+        summary = await adapter.navigate("https://example.com")
+        assert summary.text_preview == ""
+
+    @pytest.mark.asyncio
+    async def test_navigate_raises_when_playwright_missing(self) -> None:
+        from ravn.adapters.browser.local import LocalPlaywrightAdapter
+
+        adapter = LocalPlaywrightAdapter()
+        # No injected page — will try to import playwright.
+        import sys
+
+        orig = sys.modules.get("playwright.async_api")
+        sys.modules["playwright.async_api"] = None  # type: ignore[assignment]
+        try:
+            with pytest.raises((RuntimeError, ImportError)):
+                await adapter.navigate("https://example.com")
+        finally:
+            if orig is None:
+                sys.modules.pop("playwright.async_api", None)
+            else:
+                sys.modules["playwright.async_api"] = orig
+
+    @pytest.mark.asyncio
+    async def test_snapshot_returns_ax_tree_text(self) -> None:
+        from ravn.adapters.browser.local import LocalPlaywrightAdapter
+
+        adapter = LocalPlaywrightAdapter()
+        _inject_page(adapter, _make_mock_page())
+        snapshot = await adapter.snapshot()
+        assert "button" in snapshot
+        assert "@e" in snapshot
+
+    @pytest.mark.asyncio
+    async def test_snapshot_empty_page(self) -> None:
+        from ravn.adapters.browser.local import LocalPlaywrightAdapter
+
+        adapter = LocalPlaywrightAdapter()
+        page = _make_mock_page()
+        page.accessibility.snapshot = AsyncMock(return_value=None)
+        _inject_page(adapter, page)
+        snapshot = await adapter.snapshot()
+        assert snapshot == "(empty page)"
+
+    @pytest.mark.asyncio
+    async def test_close_releases_resources(self) -> None:
+        from ravn.adapters.browser.local import LocalPlaywrightAdapter
+
+        adapter = LocalPlaywrightAdapter()
+        page = _make_mock_page()
+        _inject_page(adapter, page)
+        await adapter.close()
+        page.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_close_without_open_is_noop(self) -> None:
+        from ravn.adapters.browser.local import LocalPlaywrightAdapter
+
+        adapter = LocalPlaywrightAdapter()
+        await adapter.close()  # Should not raise
+
+    @pytest.mark.asyncio
+    async def test_screenshot(self) -> None:
+        from ravn.adapters.browser.local import LocalPlaywrightAdapter
+
+        adapter = LocalPlaywrightAdapter()
+        _inject_page(adapter, _make_mock_page())
+        result = await adapter.screenshot()
+        assert result == b"\x89PNG"
+
+    @pytest.mark.asyncio
+    async def test_evaluate(self) -> None:
+        from ravn.adapters.browser.local import LocalPlaywrightAdapter
+
+        adapter = LocalPlaywrightAdapter()
+        page = _make_mock_page()
+        page.evaluate = AsyncMock(return_value="42")
+        _inject_page(adapter, page)
+        result = await adapter.evaluate("1 + 1")
+        assert result == "42"
+
+    @pytest.mark.asyncio
+    async def test_scroll_all_directions(self) -> None:
+        from ravn.adapters.browser.local import LocalPlaywrightAdapter
+
+        adapter = LocalPlaywrightAdapter()
+        page = _make_mock_page()
+        _inject_page(adapter, page)
+        for direction in ("up", "down", "left", "right"):
+            await adapter.scroll(direction, 1)
+        assert page.mouse.wheel.await_count == 4
+
+    @pytest.mark.asyncio
+    async def test_scroll_unknown_direction_defaults_to_down(self) -> None:
+        from ravn.adapters.browser.local import LocalPlaywrightAdapter
+
+        adapter = LocalPlaywrightAdapter()
+        page = _make_mock_page()
+        _inject_page(adapter, page)
+        await adapter.scroll("sideways", 1)
+        page.mouse.wheel.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_click_with_handle_uses_role_locator(self) -> None:
+        from ravn.adapters.browser.local import LocalPlaywrightAdapter
+
+        adapter = LocalPlaywrightAdapter()
+        page = _make_mock_page()
+        _inject_page(adapter, page)
+        # Load handle map via snapshot.
+        # Default snapshot: WebArea "Page" @e1, button "Click me" @e2.
+        await adapter.snapshot()
+        await adapter.click("@e2")
+        page.get_by_role.assert_called_once_with("button", name="Click me")
+
+    @pytest.mark.asyncio
+    async def test_click_with_css_selector(self) -> None:
+        from ravn.adapters.browser.local import LocalPlaywrightAdapter
+
+        adapter = LocalPlaywrightAdapter()
+        _inject_page(adapter, _make_mock_page())
+        await adapter.click("#submit")
+        adapter._page.click.assert_awaited_once_with("#submit")
+
+    @pytest.mark.asyncio
+    async def test_type_with_placeholder_handle(self) -> None:
+        from ravn.adapters.browser.local import LocalPlaywrightAdapter
+
+        adapter = LocalPlaywrightAdapter()
+        page = _make_mock_page()
+        # Custom snapshot: textbox with placeholder.
+        page.accessibility.snapshot = AsyncMock(
+            return_value={
+                "role": "WebArea",
+                "name": "Page",
+                "children": [
+                    {
+                        "role": "textbox",
+                        "name": "Email",
+                        "placeholder": "you@example.com",
+                    }
+                ],
+            }
+        )
+        _inject_page(adapter, page)
+        # After snapshot: WebArea @e1, textbox @e2.
+        await adapter.snapshot()
+        await adapter.type("@e2", "hello@test.com")
+        page.get_by_placeholder.assert_called_once_with("you@example.com")
+
+    @pytest.mark.asyncio
+    async def test_type_with_name_handle(self) -> None:
+        from ravn.adapters.browser.local import LocalPlaywrightAdapter
+
+        adapter = LocalPlaywrightAdapter()
+        page = _make_mock_page()
+        _inject_page(adapter, page)
+        # Default snapshot: WebArea @e1, button "Click me" @e2.
+        await adapter.snapshot()
+        await adapter.type("@e2", "hello")
+        # Should use get_by_role since button has name but no placeholder.
+        page.get_by_role.assert_called_once_with("button", name="Click me")
+
+    @pytest.mark.asyncio
+    async def test_type_with_css_selector(self) -> None:
+        from ravn.adapters.browser.local import LocalPlaywrightAdapter
+
+        adapter = LocalPlaywrightAdapter()
+        _inject_page(adapter, _make_mock_page())
+        await adapter.type("#q", "hello")
+        adapter._page.fill.assert_awaited_once_with("#q", "hello")
+
+
+# ---------------------------------------------------------------------------
+# build_browser_tools — factory backend selection
+# ---------------------------------------------------------------------------
+
+
+class TestBuildBrowserToolsBackendSelection:
+    def test_local_backend_creates_local_adapter(self) -> None:
+        tools = build_browser_tools("t", backend="local")
+        navigate_tool = next(t for t in tools if t.name == "browser_navigate")
+        with patch("ravn.adapters.browser.local.LocalPlaywrightAdapter") as mock_adapter:
+            mock_adapter.return_value = make_mock_browser()
+            navigate_tool._browser_factory()  # type: ignore[attr-defined]
+        mock_adapter.assert_called_once()
+
+    def test_browserbase_backend_creates_browserbase_adapter(self) -> None:
+        tools = build_browser_tools("t", backend="browserbase")
+        navigate_tool = next(t for t in tools if t.name == "browser_navigate")
+        with patch("ravn.adapters.browser.browserbase.BrowserbaseAdapter") as mock_adapter:
+            mock_adapter.return_value = make_mock_browser()
+            navigate_tool._browser_factory()  # type: ignore[attr-defined]
+        mock_adapter.assert_called_once()
+
+    def test_browserbase_backend_env_var_activates_browserbase(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("BROWSERBASE_API_KEY", "test-key")
+        tools = build_browser_tools("t", backend="local")  # env var overrides
+        navigate_tool = next(t for t in tools if t.name == "browser_navigate")
+        with patch("ravn.adapters.browser.browserbase.BrowserbaseAdapter") as mock_bb:
+            mock_bb.return_value = make_mock_browser()
+            navigate_tool._browser_factory()  # type: ignore[attr-defined]
+        mock_bb.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# BrowserbaseAdapter — mocked page state (no real browser required)
+# ---------------------------------------------------------------------------
+
+
+def _make_bb_page() -> MagicMock:
+    """Return a mock Playwright page suitable for Browserbase tests."""
+    return _make_mock_page()
+
+
+def _inject_bb_page(adapter: Any, page: Any) -> None:
+    """Inject a mock page directly into a BrowserbaseAdapter."""
+    adapter._page = page
+    adapter._browser = MagicMock()
+    adapter._browser.close = AsyncMock()
+    adapter._playwright = MagicMock()
+    adapter._playwright.stop = AsyncMock()
+    adapter._session_id = "bb-session-123"
+
+
+class TestBrowserbaseAdapter:
+    @pytest.mark.asyncio
+    async def test_navigate_success(self) -> None:
+        from ravn.adapters.browser.browserbase import BrowserbaseAdapter
+
+        adapter = BrowserbaseAdapter(api_key="test-key")
+        _inject_bb_page(adapter, _make_bb_page())
+        summary = await adapter.navigate("https://example.com")
+        assert summary.status == 200
+        assert summary.url == "https://example.com"
+
+    @pytest.mark.asyncio
+    async def test_snapshot_returns_ax_text(self) -> None:
+        from ravn.adapters.browser.browserbase import BrowserbaseAdapter
+
+        adapter = BrowserbaseAdapter(api_key="test-key")
+        _inject_bb_page(adapter, _make_bb_page())
+        snapshot = await adapter.snapshot()
+        assert "button" in snapshot
+        assert "@e" in snapshot
+
+    @pytest.mark.asyncio
+    async def test_snapshot_empty_page(self) -> None:
+        from ravn.adapters.browser.browserbase import BrowserbaseAdapter
+
+        adapter = BrowserbaseAdapter(api_key="test-key")
+        page = _make_bb_page()
+        page.accessibility.snapshot = AsyncMock(return_value=None)
+        _inject_bb_page(adapter, page)
+        snapshot = await adapter.snapshot()
+        assert snapshot == "(empty page)"
+
+    @pytest.mark.asyncio
+    async def test_close_releases_resources(self) -> None:
+        from ravn.adapters.browser.browserbase import BrowserbaseAdapter
+
+        adapter = BrowserbaseAdapter(api_key="test-key")
+        page = _make_bb_page()
+        _inject_bb_page(adapter, page)
+        await adapter.close()
+        page.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_close_without_open_is_noop(self) -> None:
+        from ravn.adapters.browser.browserbase import BrowserbaseAdapter
+
+        adapter = BrowserbaseAdapter(api_key="test-key")
+        await adapter.close()  # Should not raise
+
+    @pytest.mark.asyncio
+    async def test_screenshot(self) -> None:
+        from ravn.adapters.browser.browserbase import BrowserbaseAdapter
+
+        adapter = BrowserbaseAdapter(api_key="test-key")
+        _inject_bb_page(adapter, _make_bb_page())
+        result = await adapter.screenshot()
+        assert result == b"\x89PNG"
+
+    @pytest.mark.asyncio
+    async def test_evaluate(self) -> None:
+        from ravn.adapters.browser.browserbase import BrowserbaseAdapter
+
+        adapter = BrowserbaseAdapter(api_key="test-key")
+        page = _make_bb_page()
+        page.evaluate = AsyncMock(return_value="result")
+        _inject_bb_page(adapter, page)
+        result = await adapter.evaluate("document.title")
+        assert result == "result"
+
+    @pytest.mark.asyncio
+    async def test_scroll_all_directions(self) -> None:
+        from ravn.adapters.browser.browserbase import BrowserbaseAdapter
+
+        adapter = BrowserbaseAdapter(api_key="test-key")
+        page = _make_bb_page()
+        _inject_bb_page(adapter, page)
+        for direction in ("up", "down", "left", "right"):
+            await adapter.scroll(direction, 1)
+        assert page.mouse.wheel.await_count == 4
+
+    @pytest.mark.asyncio
+    async def test_scroll_unknown_direction_defaults(self) -> None:
+        from ravn.adapters.browser.browserbase import BrowserbaseAdapter
+
+        adapter = BrowserbaseAdapter(api_key="test-key")
+        page = _make_bb_page()
+        _inject_bb_page(adapter, page)
+        await adapter.scroll("sideways", 1)
+        page.mouse.wheel.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_click_with_handle(self) -> None:
+        from ravn.adapters.browser.browserbase import BrowserbaseAdapter
+
+        adapter = BrowserbaseAdapter(api_key="test-key")
+        page = _make_bb_page()
+        _inject_bb_page(adapter, page)
+        await adapter.snapshot()  # Load handle map; @e1=WebArea, @e2=button
+        await adapter.click("@e2")
+        page.get_by_role.assert_called_with("button", name="Click me")
+
+    @pytest.mark.asyncio
+    async def test_click_with_css_selector(self) -> None:
+        from ravn.adapters.browser.browserbase import BrowserbaseAdapter
+
+        adapter = BrowserbaseAdapter(api_key="test-key")
+        _inject_bb_page(adapter, _make_bb_page())
+        await adapter.click("#btn")
+        adapter._page.click.assert_awaited_once_with("#btn")
+
+    @pytest.mark.asyncio
+    async def test_type_with_placeholder(self) -> None:
+        from ravn.adapters.browser.browserbase import BrowserbaseAdapter
+
+        adapter = BrowserbaseAdapter(api_key="test-key")
+        page = _make_bb_page()
+        page.accessibility.snapshot = AsyncMock(
+            return_value={
+                "role": "WebArea",
+                "name": "Page",
+                "children": [{"role": "textbox", "name": "Email", "placeholder": "email"}],
+            }
+        )
+        _inject_bb_page(adapter, page)
+        await adapter.snapshot()
+        await adapter.type("@e2", "test@example.com")
+        page.get_by_placeholder.assert_called_with("email")
+
+    @pytest.mark.asyncio
+    async def test_type_with_css_selector(self) -> None:
+        from ravn.adapters.browser.browserbase import BrowserbaseAdapter
+
+        adapter = BrowserbaseAdapter(api_key="test-key")
+        _inject_bb_page(adapter, _make_bb_page())
+        await adapter.type("#q", "hello")
+        adapter._page.fill.assert_awaited_once_with("#q", "hello")
+
+    @pytest.mark.asyncio
+    async def test_ensure_browser_raises_without_api_key(self) -> None:
+        from ravn.adapters.browser.browserbase import BrowserbaseAdapter
+
+        adapter = BrowserbaseAdapter()  # no key, no env var
+        with pytest.raises(RuntimeError, match="API key"):
+            await adapter.navigate("https://example.com")
+
+    @pytest.mark.asyncio
+    async def test_navigate_evaluate_exception_still_returns(self) -> None:
+        from ravn.adapters.browser.browserbase import BrowserbaseAdapter
+
+        adapter = BrowserbaseAdapter(api_key="test-key")
+        page = _make_bb_page()
+        page.evaluate = AsyncMock(side_effect=RuntimeError("no body"))
+        _inject_bb_page(adapter, page)
+        summary = await adapter.navigate("https://example.com")
+        assert summary.text_preview == ""
+
+    @pytest.mark.asyncio
+    async def test_type_with_name_fallback(self) -> None:
+        from ravn.adapters.browser.browserbase import BrowserbaseAdapter
+
+        adapter = BrowserbaseAdapter(api_key="test-key")
+        page = _make_bb_page()
+        _inject_bb_page(adapter, page)
+        await adapter.snapshot()
+        # @e2 = button "Click me" — no placeholder, falls back to get_by_role
+        await adapter.type("@e2", "hello")
+        page.get_by_role.assert_called_with("button", name="Click me")

--- a/tests/test_ravn/test_browser_tools.py
+++ b/tests/test_ravn/test_browser_tools.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from ravn.adapters.browser.local import _ax_node_to_line, _serialise_ax_tree
+from ravn.adapters.browser._base import _ax_node_to_line, _serialise_ax_tree
 from ravn.adapters.tools.browser import (
     BrowserClickTool,
     BrowserEvaluateTool,
@@ -72,6 +72,18 @@ def make_session_manager(browser: AsyncMock, task_id: str = "task-1") -> Browser
 
 
 class TestValidateBrowserUrl:
+    @pytest.fixture(autouse=True)
+    def _mock_dns(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Patch socket.getaddrinfo so URL validation tests don't need real DNS."""
+
+        def _fake_getaddrinfo(host: str, port: object, *args: object, **kwargs: object) -> list:
+            # Return a benign public IP for any hostname lookup.
+            return [(2, 1, 6, "", ("93.184.216.34", 0))]
+
+        monkeypatch.setattr(
+            "ravn.adapters.tools._url_security.socket.getaddrinfo", _fake_getaddrinfo
+        )
+
     def test_http_allowed(self) -> None:
         assert _validate_browser_url("http://example.com", [], []) is None
 
@@ -136,6 +148,40 @@ class TestIsSafeJs:
 
     def test_delete_call_not_safe(self) -> None:
         assert _is_safe_js("delete window.alert") is False
+
+    def test_startswith_bypass_not_safe(self) -> None:
+        # Exact-match guard: chaining after a safe prefix must be rejected.
+        assert _is_safe_js("document.title; fetch('https://evil.com')") is False
+
+
+# ---------------------------------------------------------------------------
+# SSRF protection
+# ---------------------------------------------------------------------------
+
+
+class TestSsrfProtection:
+    """Tests for IP-based SSRF blocking in _validate_browser_url.
+
+    No DNS mock needed — loopback/private IPs are resolved by getaddrinfo
+    without any network activity.
+    """
+
+    def test_loopback_ip_blocked(self) -> None:
+        err = _validate_browser_url("http://127.0.0.1", [], [])
+        assert err is not None
+        assert "private" in err.lower() or "reserved" in err.lower()
+
+    def test_private_class_a_blocked(self) -> None:
+        err = _validate_browser_url("http://10.0.0.1", [], [])
+        assert err is not None
+
+    def test_ipv6_loopback_blocked(self) -> None:
+        err = _validate_browser_url("http://[::1]", [], [])
+        assert err is not None
+
+    def test_link_local_blocked(self) -> None:
+        err = _validate_browser_url("http://169.254.1.1", [], [])
+        assert err is not None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **`BrowserPort` protocol** (`src/ravn/ports/browser.py`) — structural typing interface defining `navigate`, `snapshot`, `click`, `type`, `scroll`, `screenshot`, `evaluate`, `close`.
- **Local Playwright adapter** (`src/ravn/adapters/browser/local.py`) — headless Chromium via Playwright async API; lazy browser launch; accessibility-tree snapshot with `@eN` element handles; no external dependencies beyond `playwright install chromium`.
- **Browserbase adapter** (`src/ravn/adapters/browser/browserbase.py`) — cloud execution; creates a Browserbase session via REST API, connects via CDP; stealth mode configurable; activated automatically when `BROWSERBASE_API_KEY` is set.
- **8 ToolPort tools** (`src/ravn/adapters/tools/browser.py`): `browser_navigate`, `browser_snapshot`, `browser_click`, `browser_type`, `browser_scroll`, `browser_screenshot`, `browser_evaluate`, `browser_session_close`.
- **`BrowserConfig`** added to `src/ravn/config.py` with `backend`, `headless`, `timeout_ms`, `allowed_origins`, `blocked_origins`, and Browserbase sub-config.
- **`ravn[browser]` optional extra** in `pyproject.toml` (`playwright>=1.44`).
- **110 unit tests** — all mocked, no real browser required; 90% patch coverage across new modules.

## Security model

- URL allowlist/blocklist validated before any navigation (glob patterns, http/https only).
- `browser_evaluate` restricted to a read-only safe-list by default; `full_js=true` requires `FULL_ACCESS` permission mode.
- Sessions scoped to `task_id` — cannot bleed across concurrent agents.
- Permissions: `browser:read` for navigate/snapshot/screenshot; `browser:write` for click/type/scroll.

## Test plan

- [x] 110 unit tests — all green, no real browser required
- [x] Coverage ≥ 85% on all new files (90% aggregate)
- [x] `ruff check` — zero warnings
- [ ] `@pytest.mark.browser` integration tests can be run with a real Chromium install (`playwright install chromium`)

Resolves NIU-532.

🤖 Generated with [Claude Code](https://claude.com/claude-code)