### PR TITLE
feat(cron): recurring task scheduling with cron_create/list/delete tools (NIU-437)

### DIFF
--- a/src/ravn/adapters/tools/cron_tools.py
+++ b/src/ravn/adapters/tools/cron_tools.py
@@ -1,0 +1,343 @@
+"""Cron scheduling tools — create, list, and delete recurring tasks (NIU-437).
+
+These tools are registered when the drive loop is running with a ``CronJobStore``.
+They let the agent manage its own recurring tasks at runtime without restarting
+the daemon.
+
+Tools:
+- ``cron_create`` — Schedule a new recurring task
+- ``cron_list``   — List scheduled tasks
+- ``cron_delete`` — Remove a scheduled task
+
+Delivery targets
+----------------
+- ``"local"``    — output saved to ``~/.ravn/cron/output/{job_id}/`` only
+- ``"sleipnir"`` — published to the ODIN event backbone (ambient routing)
+- ``"platform"`` — delivered via the configured surface channel (Telegram etc.)
+
+Silent marker
+-------------
+Prefix ``context`` with ``[SILENT]`` to suppress all delivery regardless of
+the ``delivery`` field.  Output is still saved locally.
+"""
+
+from __future__ import annotations
+
+import logging
+from uuid import uuid4
+
+from ravn.adapters.triggers.cron import CronJobRecord, CronJobStore, _parse_schedule
+from ravn.domain.models import ToolResult
+from ravn.ports.tool import ToolPort
+
+logger = logging.getLogger(__name__)
+
+_PERMISSION = "cron:manage"
+
+_VALID_DELIVERIES = frozenset({"local", "sleipnir", "platform"})
+
+_SCHEDULE_HELP = (
+    "Cron expression (e.g. '0 9 * * *'), "
+    "natural language (e.g. 'every 30m', 'daily at 09:00'), "
+    "bare interval (e.g. '30m', '2h'), "
+    "or ISO timestamp for one-shot execution."
+)
+
+
+def _format_job(record: CronJobRecord) -> str:
+    status = "enabled" if record.enabled else "disabled"
+    return (
+        f"[{record.job_id}] {record.name!r}  ({status})\n"
+        f"  schedule:  {record.schedule}\n"
+        f"  delivery:  {record.delivery}\n"
+        f"  priority:  {record.priority}\n"
+        f"  persona:   {record.persona or '(default)'}\n"
+        f"  context:   {record.context[:120]}{'…' if len(record.context) > 120 else ''}\n"
+        f"  created:   {record.created_at}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# cron_create
+# ---------------------------------------------------------------------------
+
+
+class CronCreateTool(ToolPort):
+    """Schedule a new recurring task.
+
+    The task fires on the given schedule and runs autonomously in the drive
+    loop.  Output is saved to ``~/.ravn/cron/output/{job_id}/`` and optionally
+    delivered via the configured channel.
+    """
+
+    def __init__(self, store: CronJobStore) -> None:
+        self._store = store
+
+    @property
+    def name(self) -> str:
+        return "cron_create"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Schedule a recurring task. "
+            "The task runs autonomously on the given schedule. "
+            "Output is always saved locally; use delivery='sleipnir' or 'platform' "
+            "to also route it through the event backbone or surface channel. "
+            "Prefix context with [SILENT] to suppress all delivery."
+        )
+
+    @property
+    def input_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Short human-readable name for the job (e.g. 'daily-standup').",
+                },
+                "schedule": {
+                    "type": "string",
+                    "description": _SCHEDULE_HELP,
+                },
+                "context": {
+                    "type": "string",
+                    "description": (
+                        "The task prompt given to the agent when the job fires. "
+                        "Prefix with [SILENT] to suppress delivery."
+                    ),
+                },
+                "delivery": {
+                    "type": "string",
+                    "enum": ["local", "sleipnir", "platform"],
+                    "description": (
+                        "Where to deliver the output. "
+                        "'local' = save to disk only (default). "
+                        "'sleipnir' = publish to ODIN event backbone. "
+                        "'platform' = deliver via configured surface channel."
+                    ),
+                },
+                "persona": {
+                    "type": "string",
+                    "description": "Persona for this job (uses daemon default if omitted).",
+                },
+                "priority": {
+                    "type": "integer",
+                    "description": "Task priority — lower value = higher priority (default: 10).",
+                },
+            },
+            "required": ["name", "schedule", "context"],
+        }
+
+    @property
+    def required_permission(self) -> str:
+        return _PERMISSION
+
+    @property
+    def parallelisable(self) -> bool:
+        return False
+
+    async def execute(self, input: dict) -> ToolResult:
+        name = input.get("name", "").strip()
+        if not name:
+            return ToolResult(tool_call_id="", content="'name' is required.", is_error=True)
+
+        schedule = input.get("schedule", "").strip()
+        if not schedule:
+            return ToolResult(tool_call_id="", content="'schedule' is required.", is_error=True)
+
+        context = input.get("context", "").strip()
+        if not context:
+            return ToolResult(tool_call_id="", content="'context' is required.", is_error=True)
+
+        delivery = input.get("delivery", "local")
+        if delivery not in _VALID_DELIVERIES:
+            return ToolResult(
+                tool_call_id="",
+                content=f"Invalid delivery {delivery!r}. Valid: {sorted(_VALID_DELIVERIES)}",
+                is_error=True,
+            )
+
+        # Validate schedule by parsing it
+        canonical = _parse_schedule(schedule)
+        if not (
+            canonical.startswith("every:")
+            or canonical.startswith("once:")
+            or len(canonical.split()) == 5
+        ):
+            return ToolResult(
+                tool_call_id="",
+                content=f"Could not parse schedule {schedule!r}. {_SCHEDULE_HELP}",
+                is_error=True,
+            )
+
+        job_id = uuid4().hex
+        persona = input.get("persona") or None
+        priority = int(input.get("priority", 10))
+
+        record = CronJobRecord(
+            job_id=job_id,
+            name=name,
+            schedule=schedule,
+            context=context,
+            delivery=delivery,
+            persona=persona,
+            priority=priority,
+        )
+
+        try:
+            self._store.create(record)
+        except Exception as exc:
+            logger.warning("cron_create: store error: %s", exc)
+            return ToolResult(
+                tool_call_id="",
+                content=f"Failed to save job: {exc}",
+                is_error=True,
+            )
+
+        logger.info("cron_create: created job %r (%s) schedule=%r", name, job_id, schedule)
+        return ToolResult(
+            tool_call_id="",
+            content=(
+                f"Created cron job {job_id!r}.\n\n{_format_job(record)}\n\n"
+                f"Canonical schedule form: {canonical}"
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# cron_list
+# ---------------------------------------------------------------------------
+
+
+class CronListTool(ToolPort):
+    """List all scheduled cron jobs."""
+
+    def __init__(self, store: CronJobStore) -> None:
+        self._store = store
+
+    @property
+    def name(self) -> str:
+        return "cron_list"
+
+    @property
+    def description(self) -> str:
+        return (
+            "List all scheduled cron jobs managed by this agent. "
+            "Shows job ID, name, schedule, delivery target, and context preview."
+        )
+
+    @property
+    def input_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "enabled_only": {
+                    "type": "boolean",
+                    "description": "When true, only return enabled jobs (default: false).",
+                },
+            },
+        }
+
+    @property
+    def required_permission(self) -> str:
+        return _PERMISSION
+
+    async def execute(self, input: dict) -> ToolResult:
+        enabled_only = bool(input.get("enabled_only", False))
+        jobs = self._store.list()
+
+        if enabled_only:
+            jobs = [j for j in jobs if j.enabled]
+
+        if not jobs:
+            return ToolResult(tool_call_id="", content="No cron jobs scheduled.")
+
+        lines = [f"Cron jobs ({len(jobs)} total):\n"]
+        for record in sorted(jobs, key=lambda r: r.created_at):
+            lines.append(_format_job(record))
+            lines.append("")
+
+        return ToolResult(tool_call_id="", content="\n".join(lines).strip())
+
+
+# ---------------------------------------------------------------------------
+# cron_delete
+# ---------------------------------------------------------------------------
+
+
+class CronDeleteTool(ToolPort):
+    """Remove a scheduled cron job."""
+
+    def __init__(self, store: CronJobStore) -> None:
+        self._store = store
+
+    @property
+    def name(self) -> str:
+        return "cron_delete"
+
+    @property
+    def description(self) -> str:
+        return "Remove a scheduled cron job by its job ID. Use cron_list to find job IDs."
+
+    @property
+    def input_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "job_id": {
+                    "type": "string",
+                    "description": "The job ID to remove (from cron_list output).",
+                },
+            },
+            "required": ["job_id"],
+        }
+
+    @property
+    def required_permission(self) -> str:
+        return _PERMISSION
+
+    @property
+    def parallelisable(self) -> bool:
+        return False
+
+    async def execute(self, input: dict) -> ToolResult:
+        job_id = input.get("job_id", "").strip()
+        if not job_id:
+            return ToolResult(tool_call_id="", content="'job_id' is required.", is_error=True)
+
+        record = self._store.get(job_id)
+        if record is None:
+            return ToolResult(
+                tool_call_id="",
+                content=f"Job {job_id!r} not found. Use cron_list to see available jobs.",
+                is_error=True,
+            )
+
+        removed = self._store.delete(job_id)
+        if not removed:
+            return ToolResult(
+                tool_call_id="",
+                content=f"Failed to remove job {job_id!r}.",
+                is_error=True,
+            )
+
+        logger.info("cron_delete: removed job %r (%s)", record.name, job_id)
+        return ToolResult(
+            tool_call_id="",
+            content=f"Removed cron job {job_id!r} ({record.name!r}).",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+def build_cron_tools(store: CronJobStore) -> list[ToolPort]:
+    """Build the list of cron management tools backed by *store*."""
+    return [
+        CronCreateTool(store),
+        CronListTool(store),
+        CronDeleteTool(store),
+    ]

--- a/src/ravn/adapters/tools/cron_tools.py
+++ b/src/ravn/adapters/tools/cron_tools.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import logging
 from uuid import uuid4
 
-from ravn.adapters.triggers.cron import CronJobRecord, CronJobStore, _parse_schedule
+from ravn.adapters.triggers.cron import CronJobRecord, CronJobStore, parse_schedule
 from ravn.domain.models import ToolResult
 from ravn.ports.tool import ToolPort
 
@@ -159,7 +159,7 @@ class CronCreateTool(ToolPort):
             )
 
         # Validate schedule by parsing it
-        canonical = _parse_schedule(schedule)
+        canonical = parse_schedule(schedule)
         if not (
             canonical.startswith("every:")
             or canonical.startswith("once:")

--- a/src/ravn/adapters/triggers/cron.py
+++ b/src/ravn/adapters/triggers/cron.py
@@ -4,6 +4,11 @@ Supports:
 - Standard cron expressions: ``"0 8 * * *"``
 - Natural language: ``"every 30m"``, ``"daily at 08:00"``
 - One-shot ISO timestamps: ``"2026-04-07T08:00:00"``
+- Interval shorthand: ``"30m"``, ``"2h"``
+
+Config-defined jobs are passed directly as ``CronJob`` objects.
+Runtime jobs are stored in ``CronJobStore`` (``~/.ravn/cron/jobs.json``, 0600)
+and written by the ``cron_create`` / ``cron_delete`` tools.
 
 State is persisted to ``~/.ravn/daemon/cron_state.json`` so last-fired
 timestamps survive restarts.  A file lock at ``~/.ravn/daemon/cron.lock``
@@ -17,9 +22,11 @@ import asyncio
 import fcntl
 import json
 import logging
+import os
 import re
 import time
 from collections.abc import Awaitable, Callable
+from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import IO
@@ -34,12 +41,28 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_STATE_PATH = Path.home() / ".ravn" / "daemon" / "cron_state.json"
 _DEFAULT_LOCK_PATH = Path.home() / ".ravn" / "daemon" / "cron.lock"
+_DEFAULT_JOBS_PATH = Path.home() / ".ravn" / "cron" / "jobs.json"
+_OUTPUT_BASE = Path.home() / ".ravn" / "cron" / "output"
+
 _TICK_SECONDS = 30
+_SILENT_MARKER = "[SILENT]"
+
 _NATURAL_EVERY_RE = re.compile(
     r"every\s+(\d+)\s*(s(?:ec(?:ond)?s?)?|m(?:in(?:ute)?s?)?|h(?:our)?s?)",
     re.IGNORECASE,
 )
 _DAILY_AT_RE = re.compile(r"daily\s+at\s+(\d{1,2}):(\d{2})", re.IGNORECASE)
+# Bare interval: "30m", "2h", "45s"
+_BARE_INTERVAL_RE = re.compile(
+    r"^(\d+)\s*(s(?:ec(?:ond)?s?)?|m(?:in(?:ute)?s?)?|h(?:our)?s?)$",
+    re.IGNORECASE,
+)
+
+_DELIVERY_TO_OUTPUT_MODE: dict[str, OutputMode] = {
+    "local": OutputMode.SILENT,
+    "sleipnir": OutputMode.AMBIENT,
+    "platform": OutputMode.SURFACE,
+}
 
 
 # ---------------------------------------------------------------------------
@@ -112,6 +135,15 @@ def _parse_schedule(schedule: str) -> str:
         seconds = count * multipliers.get(unit, 60)
         return f"every:{seconds}"
 
+    # Bare interval: "30m", "2h", "45s"
+    m = _BARE_INTERVAL_RE.fullmatch(schedule)
+    if m:
+        count = int(m.group(1))
+        unit = m.group(2).lower()[0]
+        multipliers = {"s": 1, "m": 60, "h": 3600}
+        seconds = count * multipliers.get(unit, 60)
+        return f"every:{seconds}"
+
     # Natural: "daily at HH:MM"
     m = _DAILY_AT_RE.fullmatch(schedule)
     if m:
@@ -130,7 +162,7 @@ def _parse_schedule(schedule: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# CronJob descriptor
+# CronJob descriptor (config-defined)
 # ---------------------------------------------------------------------------
 
 
@@ -156,6 +188,119 @@ class CronJob:
 
 
 # ---------------------------------------------------------------------------
+# CronJobRecord + CronJobStore (runtime-defined, persisted to disk)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CronJobRecord:
+    """A runtime-defined cron job persisted to ``~/.ravn/cron/jobs.json``.
+
+    Created and managed by the ``cron_create`` / ``cron_list`` / ``cron_delete``
+    tools.  The ``job_id`` is a UUID hex string, unique across all store jobs.
+
+    ``delivery`` controls how task output is routed:
+    - ``"local"``    — output saved to disk only (silent)
+    - ``"sleipnir"`` — published to the ODIN event backbone (ambient)
+    - ``"platform"`` — delivered via the configured surface channel (surface)
+
+    Prefixing ``context`` with ``[SILENT]`` overrides ``delivery`` to local-only
+    regardless of the ``delivery`` field value.
+    """
+
+    job_id: str
+    name: str
+    schedule: str
+    context: str
+    delivery: str = "local"  # "local" | "sleipnir" | "platform"
+    persona: str | None = None
+    priority: int = 10
+    created_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+    enabled: bool = True
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> CronJobRecord:
+        return cls(
+            job_id=d["job_id"],
+            name=d["name"],
+            schedule=d["schedule"],
+            context=d["context"],
+            delivery=d.get("delivery", "local"),
+            persona=d.get("persona"),
+            priority=int(d.get("priority", 10)),
+            created_at=d.get("created_at", datetime.now(UTC).isoformat()),
+            enabled=bool(d.get("enabled", True)),
+        )
+
+
+class CronJobStore:
+    """Persistent store for runtime cron jobs.
+
+    Stores jobs as a JSON list at ``jobs_path`` (default:
+    ``~/.ravn/cron/jobs.json``).  The file is created with 0600 permissions
+    so that secrets in ``context`` are not world-readable.
+
+    All operations are synchronous (file I/O is small; no async needed).
+    """
+
+    def __init__(self, jobs_path: Path = _DEFAULT_JOBS_PATH) -> None:
+        self._path = jobs_path
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def list(self) -> list[CronJobRecord]:
+        """Return all job records (enabled and disabled)."""
+        return [CronJobRecord.from_dict(d) for d in self._load()]
+
+    def get(self, job_id: str) -> CronJobRecord | None:
+        """Return the record for *job_id*, or None if not found."""
+        for d in self._load():
+            if d.get("job_id") == job_id:
+                return CronJobRecord.from_dict(d)
+        return None
+
+    def create(self, record: CronJobRecord) -> None:
+        """Persist *record*.  Raises ``ValueError`` on duplicate job_id."""
+        records = self._load()
+        if any(r.get("job_id") == record.job_id for r in records):
+            raise ValueError(f"cron_store: job_id {record.job_id!r} already exists")
+        records.append(record.to_dict())
+        self._save(records)
+
+    def delete(self, job_id: str) -> bool:
+        """Remove the job with *job_id*.  Returns True if found and removed."""
+        records = self._load()
+        filtered = [r for r in records if r.get("job_id") != job_id]
+        if len(filtered) == len(records):
+            return False
+        self._save(filtered)
+        return True
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _load(self) -> list[dict]:
+        if not self._path.exists():
+            return []
+        try:
+            return json.loads(self._path.read_text())
+        except Exception:
+            return []
+
+    def _save(self, records: list[dict]) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._path.write_text(json.dumps(records, indent=2))
+        # Restrict to owner read/write only
+        os.chmod(self._path, 0o600)
+
+
+# ---------------------------------------------------------------------------
 # CronTrigger
 # ---------------------------------------------------------------------------
 
@@ -163,8 +308,14 @@ class CronJob:
 class CronTrigger:
     """Trigger that fires tasks on a cron schedule.
 
+    Combines two job sources:
+    - Config-defined ``CronJob`` objects passed at construction time.
+    - Runtime jobs from ``CronJobStore`` (written by cron tools).
+
     All jobs share the same state file so that last-fired timestamps
-    survive daemon restarts.
+    survive daemon restarts.  A file lock at ``lock_path`` prevents
+    duplicate firings when multiple daemon instances are (accidentally)
+    running.
     """
 
     def __init__(
@@ -173,11 +324,13 @@ class CronTrigger:
         state_path: Path = _DEFAULT_STATE_PATH,
         lock_path: Path = _DEFAULT_LOCK_PATH,
         tick_seconds: float = _TICK_SECONDS,
+        store: CronJobStore | None = None,
     ) -> None:
         self._jobs = jobs
         self._state_path = state_path
         self._lock_path = lock_path
         self._tick = tick_seconds
+        self._store = store
         self._counter = 0
 
     @property
@@ -227,9 +380,10 @@ class CronTrigger:
     # Due detection
     # ------------------------------------------------------------------
 
-    def _is_due(self, job: CronJob, now: datetime, state: dict[str, str]) -> bool:
-        canonical = job.canonical
-
+    def _is_due_canonical(
+        self, canonical: str, state_key: str, now: datetime, state: dict[str, str]
+    ) -> bool:
+        """Return True if the canonical schedule form is due to fire."""
         if canonical.startswith("once:"):
             iso = canonical[5:]
             try:
@@ -238,25 +392,28 @@ class CronTrigger:
                 return False
             if now < fire_at:
                 return False
-            # Only fire once
-            return job.name not in state
+            # Only fire once — marked by presence of key in state
+            return state_key not in state
 
         if canonical.startswith("every:"):
             interval = int(canonical[6:])
-            last_str = state.get(job.name)
+            last_str = state.get(state_key)
             if last_str is None:
                 return True
             last = datetime.fromisoformat(last_str)
             return (now - last).total_seconds() >= interval
 
         # Standard cron expression
-        last_str = state.get(job.name)
+        last_str = state.get(state_key)
         if last_str is not None:
             last = datetime.fromisoformat(last_str)
             # Don't fire more than once per minute
             if (now - last).total_seconds() < 60:
                 return False
         return _cron_matches(canonical, now)
+
+    def _is_due(self, job: CronJob, now: datetime, state: dict[str, str]) -> bool:
+        return self._is_due_canonical(job.canonical, job.name, now, state)
 
     # ------------------------------------------------------------------
     # Main loop
@@ -274,6 +431,7 @@ class CronTrigger:
                 state = self._load_state()
                 changed = False
 
+                # -- Config-defined jobs --
                 for job in self._jobs:
                     if not self._is_due(job, now, state):
                         continue
@@ -293,6 +451,48 @@ class CronTrigger:
                     state[job.name] = now.isoformat()
                     changed = True
 
+                # -- Store-defined (runtime) jobs --
+                if self._store is not None:
+                    for record in self._store.list():
+                        if not record.enabled:
+                            continue
+                        canonical = _parse_schedule(record.schedule)
+                        if not self._is_due_canonical(canonical, record.job_id, now, state):
+                            continue
+
+                        context = record.context
+                        output_mode = _DELIVERY_TO_OUTPUT_MODE.get(
+                            record.delivery, OutputMode.SILENT
+                        )
+                        # [SILENT] marker overrides delivery to local-only
+                        if context.startswith(_SILENT_MARKER):
+                            context = context[len(_SILENT_MARKER) :].strip()
+                            output_mode = OutputMode.SILENT
+
+                        timestamp_str = now.strftime("%Y%m%dT%H%M%S")
+                        output_path = _OUTPUT_BASE / record.job_id / f"{timestamp_str}.md"
+
+                        task_id = self._make_task_id()
+                        task = AgentTask(
+                            task_id=task_id,
+                            title=record.name,
+                            initiative_context=context,
+                            triggered_by=f"cron:{record.job_id}",
+                            output_mode=output_mode,
+                            persona=record.persona or None,
+                            priority=record.priority,
+                            output_path=output_path,
+                        )
+                        logger.info(
+                            "cron: firing store job %r/%s (task_id=%s)",
+                            record.name,
+                            record.job_id,
+                            task_id,
+                        )
+                        await enqueue(task)
+                        state[record.job_id] = now.isoformat()
+                        changed = True
+
                 if changed:
                     self._save_state(state)
 
@@ -303,3 +503,30 @@ class CronTrigger:
                 lock_fd.close()
             except Exception:
                 pass
+
+
+# ---------------------------------------------------------------------------
+# Convenience factory
+# ---------------------------------------------------------------------------
+
+
+def make_cron_trigger(
+    jobs: list[CronJob] | None = None,
+    jobs_path: Path = _DEFAULT_JOBS_PATH,
+    state_path: Path = _DEFAULT_STATE_PATH,
+    lock_path: Path = _DEFAULT_LOCK_PATH,
+    tick_seconds: float = _TICK_SECONDS,
+) -> tuple[CronTrigger, CronJobStore]:
+    """Build a ``CronTrigger`` + ``CronJobStore`` pair wired together.
+
+    Returns both so callers can pass the store to ``build_cron_tools()``.
+    """
+    store = CronJobStore(jobs_path=jobs_path)
+    trigger = CronTrigger(
+        jobs=jobs or [],
+        state_path=state_path,
+        lock_path=lock_path,
+        tick_seconds=tick_seconds,
+        store=store,
+    )
+    return trigger, store

--- a/src/ravn/adapters/triggers/cron.py
+++ b/src/ravn/adapters/triggers/cron.py
@@ -24,6 +24,7 @@ import json
 import logging
 import os
 import re
+import tempfile
 import time
 from collections.abc import Awaitable, Callable
 from dataclasses import asdict, dataclass, field
@@ -116,7 +117,7 @@ def _cron_matches(expr: str, dt: datetime) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _parse_schedule(schedule: str) -> str:
+def parse_schedule(schedule: str) -> str:
     """Normalise *schedule* to a canonical cron expression or special form.
 
     Returns one of:
@@ -180,7 +181,7 @@ class CronJob:
     ) -> None:
         self.name = name
         self.raw_schedule = schedule
-        self.canonical = _parse_schedule(schedule)
+        self.canonical = parse_schedule(schedule)
         self.context = context
         self.output_mode = output_mode
         self.persona = persona
@@ -295,9 +296,19 @@ class CronJobStore:
 
     def _save(self, records: list[dict]) -> None:
         self._path.parent.mkdir(parents=True, exist_ok=True)
-        self._path.write_text(json.dumps(records, indent=2))
-        # Restrict to owner read/write only
-        os.chmod(self._path, 0o600)
+        data = json.dumps(records, indent=2)
+        fd, tmp_path = tempfile.mkstemp(dir=self._path.parent, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w") as f:
+                f.write(data)
+            os.chmod(tmp_path, 0o600)
+            os.replace(tmp_path, self._path)
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
 
 
 # ---------------------------------------------------------------------------
@@ -456,7 +467,7 @@ class CronTrigger:
                     for record in self._store.list():
                         if not record.enabled:
                             continue
-                        canonical = _parse_schedule(record.schedule)
+                        canonical = parse_schedule(record.schedule)
                         if not self._is_due_canonical(canonical, record.job_id, now, state):
                             continue
 

--- a/src/ravn/cli/commands.py
+++ b/src/ravn/cli/commands.py
@@ -1599,6 +1599,11 @@ async def _run_daemon(
             if cascade_tools:
                 tools.extend(cascade_tools)
 
+            # Add cron scheduling tools if wired
+            cron_tools = getattr(drive_loop, "_cron_tools", [])
+            if cron_tools:
+                tools.extend(cron_tools)
+
         return RavnAgent(
             llm=llm,
             tools=tools,
@@ -1660,6 +1665,7 @@ async def _run_daemon(
             resume=resume,
         )
         _wire_triggers(drive_loop, settings.initiative)
+        _wire_cron(drive_loop)
 
         # Wire task dispatch subscription when requested (--listen / --daemon)
         if task_dispatch and settings.sleipnir.enabled:
@@ -1710,14 +1716,21 @@ async def _run_daemon(
 
 
 def _wire_triggers(drive_loop: Any, initiative: InitiativeConfig) -> None:
-    """Instantiate trigger adapters from config and register them on drive_loop."""
+    """Instantiate trigger adapters from config and register them on drive_loop.
+
+    All config-defined cron jobs are collected into ``drive_loop._cron_jobs``
+    so that ``_wire_cron`` can create a single ``CronTrigger`` (one lock) that
+    also services runtime jobs from the ``CronJobStore``.
+    """
     from ravn.domain.models import OutputMode
+
+    cron_jobs: list[Any] = []
 
     for tc in initiative.triggers:
         output_mode = OutputMode(tc.output_mode) if tc.output_mode else OutputMode.SILENT
         try:
             if tc.type == "cron":
-                from ravn.adapters.triggers.cron import CronJob, CronTrigger
+                from ravn.adapters.triggers.cron import CronJob
 
                 job = CronJob(
                     name=tc.name,
@@ -1727,7 +1740,7 @@ def _wire_triggers(drive_loop: Any, initiative: InitiativeConfig) -> None:
                     persona=tc.persona or None,
                     priority=tc.priority,
                 )
-                drive_loop.register_trigger(CronTrigger(jobs=[job]))
+                cron_jobs.append(job)
 
             elif tc.type == "sleipnir_event":
                 from ravn.adapters.triggers.sleipnir import SleipnirEventTrigger
@@ -1754,6 +1767,30 @@ def _wire_triggers(drive_loop: Any, initiative: InitiativeConfig) -> None:
 
         except Exception as exc:
             logger.error("Failed to wire trigger %r: %s", tc.name, exc)
+
+    # Stash collected cron jobs for _wire_cron to pick up
+    drive_loop._cron_jobs = cron_jobs
+
+
+def _wire_cron(drive_loop: Any) -> None:
+    """Create a single CronTrigger + CronJobStore and wire cron tools (NIU-437).
+
+    A single CronTrigger is always registered so runtime jobs created via
+    ``cron_create`` are serviced even when no config-defined cron triggers exist.
+    The store is backed by ``~/.ravn/cron/jobs.json`` (0600).
+    """
+    from ravn.adapters.tools.cron_tools import build_cron_tools
+    from ravn.adapters.triggers.cron import make_cron_trigger
+
+    cron_jobs = getattr(drive_loop, "_cron_jobs", [])
+    trigger, store = make_cron_trigger(jobs=cron_jobs)
+    drive_loop.register_trigger(trigger)
+    drive_loop._cron_tools = build_cron_tools(store)
+    logger.info(
+        "cron: wired %d config job(s); store at %s",
+        len(cron_jobs),
+        store._path,
+    )
 
 
 def _wire_task_dispatch(drive_loop: Any, sleipnir_config: Any) -> None:

--- a/src/ravn/cli/commands.py
+++ b/src/ravn/cli/commands.py
@@ -1515,9 +1515,7 @@ def listen(
     project_config = ProjectConfig.discover()
     persona_config = _resolve_persona(persona, project_config)
 
-    asyncio.run(
-        _run_daemon(settings, persona_config=persona_config, task_dispatch=True)
-    )
+    asyncio.run(_run_daemon(settings, persona_config=persona_config, task_dispatch=True))
 
 
 async def _run_daemon(
@@ -1565,6 +1563,9 @@ async def _run_daemon(
 
     mcp_manager, mcp_tools = await _start_mcp_shared(settings)
 
+    # Populated by _wire_cron after drive_loop is created; captured by _agent_factory.
+    cron_tools: list[Any] = []
+
     def _agent_factory(channel: ChannelPort, task_id: str | None = None) -> Any:
         session = Session()
         budget = IterationBudget(
@@ -1595,12 +1596,13 @@ async def _run_daemon(
             tools.extend(mcp_tools)
 
             # Add cascade tools (parallel task execution) if wired
+            # NOTE: cascade_tools uses the same monkey-patch pattern as before —
+            # tracked as tech debt to align with the cron pattern.
             cascade_tools = getattr(drive_loop, "_cascade_tools", [])
             if cascade_tools:
                 tools.extend(cascade_tools)
 
-            # Add cron scheduling tools if wired
-            cron_tools = getattr(drive_loop, "_cron_tools", [])
+            # Add cron scheduling tools
             if cron_tools:
                 tools.extend(cron_tools)
 
@@ -1664,8 +1666,8 @@ async def _run_daemon(
             event_publisher=event_publisher,
             resume=resume,
         )
-        _wire_triggers(drive_loop, settings.initiative)
-        _wire_cron(drive_loop)
+        _cron_jobs = _wire_triggers(drive_loop, settings.initiative)
+        cron_tools[:] = _wire_cron(drive_loop, _cron_jobs, settings.initiative)
 
         # Wire task dispatch subscription when requested (--listen / --daemon)
         if task_dispatch and settings.sleipnir.enabled:
@@ -1715,12 +1717,14 @@ async def _run_daemon(
         await _shutdown_mcp(mcp_manager)
 
 
-def _wire_triggers(drive_loop: Any, initiative: InitiativeConfig) -> None:
+def _wire_triggers(drive_loop: Any, initiative: InitiativeConfig) -> list[Any]:
     """Instantiate trigger adapters from config and register them on drive_loop.
 
-    All config-defined cron jobs are collected into ``drive_loop._cron_jobs``
-    so that ``_wire_cron`` can create a single ``CronTrigger`` (one lock) that
-    also services runtime jobs from the ``CronJobStore``.
+    Config-defined cron jobs are collected and returned so that ``_wire_cron``
+    can create a single ``CronTrigger`` (one lock) that also services runtime
+    jobs from the ``CronJobStore``.
+
+    Returns a list of ``CronJob`` objects for the caller to pass to ``_wire_cron``.
     """
     from ravn.domain.models import OutputMode
 
@@ -1768,29 +1772,38 @@ def _wire_triggers(drive_loop: Any, initiative: InitiativeConfig) -> None:
         except Exception as exc:
             logger.error("Failed to wire trigger %r: %s", tc.name, exc)
 
-    # Stash collected cron jobs for _wire_cron to pick up
-    drive_loop._cron_jobs = cron_jobs
+    return cron_jobs
 
 
-def _wire_cron(drive_loop: Any) -> None:
+def _wire_cron(
+    drive_loop: Any,
+    cron_jobs: list[Any],
+    initiative: InitiativeConfig,
+) -> list[Any]:
     """Create a single CronTrigger + CronJobStore and wire cron tools (NIU-437).
 
     A single CronTrigger is always registered so runtime jobs created via
     ``cron_create`` are serviced even when no config-defined cron triggers exist.
     The store is backed by ``~/.ravn/cron/jobs.json`` (0600).
+
+    Returns the list of cron tool instances for the caller to pass to the agent
+    factory — avoids monkey-patching drive_loop with private attributes.
     """
     from ravn.adapters.tools.cron_tools import build_cron_tools
     from ravn.adapters.triggers.cron import make_cron_trigger
 
-    cron_jobs = getattr(drive_loop, "_cron_jobs", [])
-    trigger, store = make_cron_trigger(jobs=cron_jobs)
+    trigger, store = make_cron_trigger(
+        jobs=cron_jobs,
+        tick_seconds=initiative.cron_tick_seconds,
+    )
     drive_loop.register_trigger(trigger)
-    drive_loop._cron_tools = build_cron_tools(store)
+    tools = build_cron_tools(store)
     logger.info(
         "cron: wired %d config job(s); store at %s",
         len(cron_jobs),
         store._path,
     )
+    return tools
 
 
 def _wire_task_dispatch(drive_loop: Any, sleipnir_config: Any) -> None:

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -1055,6 +1055,10 @@ class InitiativeConfig(BaseModel):
         default=60,
         description="Seconds between drive-loop heartbeat log entries.",
     )
+    cron_tick_seconds: float = Field(
+        default=30.0,
+        description="Seconds between cron trigger ticks (scheduler wake interval).",
+    )
     triggers: list[TriggerConfig] = Field(
         default_factory=list,
         description="Ordered list of trigger configurations.",

--- a/src/ravn/domain/models.py
+++ b/src/ravn/domain/models.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
+from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 from uuid import UUID, uuid4
 
@@ -356,6 +357,7 @@ class AgentTask:
     priority: int = 10  # lower = higher priority
     max_tokens: int | None = None
     deadline: datetime | None = None  # task discarded if queue time exceeds this
+    output_path: Path | None = None  # where to save task output (cron tasks)
     created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
     session_id: str = field(init=False)
 

--- a/src/ravn/drive_loop.py
+++ b/src/ravn/drive_loop.py
@@ -301,6 +301,7 @@ class DriveLoop:
         try:
             await agent.run_turn(prompt)  # type: ignore[attr-defined]
             success = True
+            self._save_task_output(task, channel)
         except asyncio.CancelledError:
             logger.info("drive_loop: task %s cancelled mid-turn", task.task_id)
             self._result_store.set_status(task.task_id, "cancelled")
@@ -336,6 +337,19 @@ class DriveLoop:
 
         if channel.surface_triggered:
             await self._re_deliver_surface(task, channel.response_text)
+
+    def _save_task_output(self, task: AgentTask, channel: ChannelPort) -> None:
+        """Persist agent response to ``task.output_path`` when set (cron tasks)."""
+        if task.output_path is None:
+            return
+        text = getattr(channel, "response_text", "")
+        try:
+            task.output_path.parent.mkdir(parents=True, exist_ok=True)
+            header = f"# {task.title}\n\ntriggered_by: {task.triggered_by}\n\n"
+            task.output_path.write_text(header + text)
+            logger.debug("drive_loop: saved task output to %s", task.output_path)
+        except Exception as exc:
+            logger.warning("drive_loop: failed to save task output: %s", exc)
 
     async def _re_deliver_surface(self, task: AgentTask, text: str) -> None:
         """Re-publish a [SURFACE]-prefixed response to Sleipnir at AMBIENT urgency."""
@@ -406,6 +420,7 @@ class DriveLoop:
                         "priority": task.priority,
                         "max_tokens": task.max_tokens,
                         "deadline": task.deadline.isoformat() if task.deadline else None,
+                        "output_path": str(task.output_path) if task.output_path else None,
                         "created_at": task.created_at.isoformat(),
                     }
                 )
@@ -432,6 +447,7 @@ class DriveLoop:
                     if rec.get("created_at")
                     else datetime.now(UTC)
                 )
+                output_path_str = rec.get("output_path")
                 task = AgentTask(
                     task_id=rec["task_id"],
                     title=rec["title"],
@@ -442,6 +458,7 @@ class DriveLoop:
                     priority=rec.get("priority", 10),
                     max_tokens=rec.get("max_tokens"),
                     deadline=deadline,
+                    output_path=Path(output_path_str) if output_path_str else None,
                     created_at=created_at,
                 )
                 # Check deadline before restoring

--- a/tests/ravn/unit/test_drive_loop.py
+++ b/tests/ravn/unit/test_drive_loop.py
@@ -13,7 +13,7 @@ import pytest
 
 from ravn.adapters.channels.silent import SilentChannel
 from ravn.adapters.triggers.condition_poll import ConditionPollTrigger
-from ravn.adapters.triggers.cron import CronJob, CronTrigger, _cron_matches, _parse_schedule
+from ravn.adapters.triggers.cron import CronJob, CronTrigger, _cron_matches, parse_schedule
 from ravn.config import InitiativeConfig, Settings, TriggerConfig
 from ravn.domain.events import RavnEvent, RavnEventType
 from ravn.domain.models import AgentTask, OutputMode
@@ -296,33 +296,33 @@ async def test_drive_loop_surface_escalation_logged(
 # ---------------------------------------------------------------------------
 
 
-def test_parse_schedule_cron_expression() -> None:
-    result = _parse_schedule("0 8 * * *")
+def testparse_schedule_cron_expression() -> None:
+    result = parse_schedule("0 8 * * *")
     assert result == "0 8 * * *"
 
 
-def test_parse_schedule_natural_every_minutes() -> None:
-    result = _parse_schedule("every 30m")
+def testparse_schedule_natural_every_minutes() -> None:
+    result = parse_schedule("every 30m")
     assert result == "every:1800"
 
 
-def test_parse_schedule_natural_every_hours() -> None:
-    result = _parse_schedule("every 2h")
+def testparse_schedule_natural_every_hours() -> None:
+    result = parse_schedule("every 2h")
     assert result == "every:7200"
 
 
-def test_parse_schedule_natural_every_seconds() -> None:
-    result = _parse_schedule("every 5s")
+def testparse_schedule_natural_every_seconds() -> None:
+    result = parse_schedule("every 5s")
     assert result == "every:5"
 
 
-def test_parse_schedule_daily_at() -> None:
-    result = _parse_schedule("daily at 08:00")
+def testparse_schedule_daily_at() -> None:
+    result = parse_schedule("daily at 08:00")
     assert result == "0 8 * * *"
 
 
-def test_parse_schedule_iso_timestamp() -> None:
-    result = _parse_schedule("2026-04-07T08:00:00")
+def testparse_schedule_iso_timestamp() -> None:
+    result = parse_schedule("2026-04-07T08:00:00")
     assert result.startswith("once:")
 
 

--- a/tests/ravn/unit/test_drive_loop.py
+++ b/tests/ravn/unit/test_drive_loop.py
@@ -296,32 +296,32 @@ async def test_drive_loop_surface_escalation_logged(
 # ---------------------------------------------------------------------------
 
 
-def testparse_schedule_cron_expression() -> None:
+def test_parse_schedule_cron_expression() -> None:
     result = parse_schedule("0 8 * * *")
     assert result == "0 8 * * *"
 
 
-def testparse_schedule_natural_every_minutes() -> None:
+def test_parse_schedule_natural_every_minutes() -> None:
     result = parse_schedule("every 30m")
     assert result == "every:1800"
 
 
-def testparse_schedule_natural_every_hours() -> None:
+def test_parse_schedule_natural_every_hours() -> None:
     result = parse_schedule("every 2h")
     assert result == "every:7200"
 
 
-def testparse_schedule_natural_every_seconds() -> None:
+def test_parse_schedule_natural_every_seconds() -> None:
     result = parse_schedule("every 5s")
     assert result == "every:5"
 
 
-def testparse_schedule_daily_at() -> None:
+def test_parse_schedule_daily_at() -> None:
     result = parse_schedule("daily at 08:00")
     assert result == "0 8 * * *"
 
 
-def testparse_schedule_iso_timestamp() -> None:
+def test_parse_schedule_iso_timestamp() -> None:
     result = parse_schedule("2026-04-07T08:00:00")
     assert result.startswith("once:")
 

--- a/tests/test_ravn/test_cron_tools.py
+++ b/tests/test_ravn/test_cron_tools.py
@@ -1,0 +1,859 @@
+"""Tests for NIU-437 cron scheduling: CronJobStore, cron tools, CronTrigger."""
+
+from __future__ import annotations
+
+import asyncio
+import stat
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from ravn.adapters.tools.cron_tools import (
+    CronCreateTool,
+    CronDeleteTool,
+    CronListTool,
+    build_cron_tools,
+)
+from ravn.adapters.triggers.cron import (
+    _DELIVERY_TO_OUTPUT_MODE,
+    _OUTPUT_BASE,
+    _SILENT_MARKER,
+    CronJob,
+    CronJobRecord,
+    CronJobStore,
+    CronTrigger,
+    _cron_matches,
+    _field_matches,
+    _parse_schedule,
+    make_cron_trigger,
+)
+from ravn.domain.models import AgentTask, OutputMode
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_store(tmp_path: Path) -> CronJobStore:
+    return CronJobStore(jobs_path=tmp_path / "jobs.json")
+
+
+def _make_record(**kwargs) -> CronJobRecord:
+    defaults = {
+        "job_id": "aabbccdd11223344",
+        "name": "test-job",
+        "schedule": "every 5m",
+        "context": "Run a quick sanity check.",
+        "delivery": "local",
+        "persona": None,
+        "priority": 10,
+    }
+    defaults.update(kwargs)
+    return CronJobRecord(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# _parse_schedule
+# ---------------------------------------------------------------------------
+
+
+class TestParseSchedule:
+    def test_every_minutes(self):
+        assert _parse_schedule("every 30m") == "every:1800"
+
+    def test_every_seconds(self):
+        assert _parse_schedule("every 5s") == "every:5"
+
+    def test_every_hours(self):
+        assert _parse_schedule("every 2h") == "every:7200"
+
+    def test_bare_interval_minutes(self):
+        assert _parse_schedule("30m") == "every:1800"
+
+    def test_bare_interval_hours(self):
+        assert _parse_schedule("2h") == "every:7200"
+
+    def test_bare_interval_seconds(self):
+        assert _parse_schedule("45s") == "every:45"
+
+    def test_daily_at(self):
+        result = _parse_schedule("daily at 09:00")
+        assert result == "0 9 * * *"
+
+    def test_daily_at_midnight(self):
+        result = _parse_schedule("daily at 00:30")
+        assert result == "30 0 * * *"
+
+    def test_cron_passthrough(self):
+        assert _parse_schedule("0 8 * * *") == "0 8 * * *"
+
+    def test_iso_timestamp(self):
+        result = _parse_schedule("2026-04-08T09:00:00")
+        assert result.startswith("once:")
+
+    def test_unknown_passthrough(self):
+        result = _parse_schedule("*/5 * * * *")
+        assert result == "*/5 * * * *"
+
+
+# ---------------------------------------------------------------------------
+# _field_matches / _cron_matches
+# ---------------------------------------------------------------------------
+
+
+class TestCronParsing:
+    def test_wildcard(self):
+        assert _field_matches(5, "*") is True
+
+    def test_exact(self):
+        assert _field_matches(5, "5") is True
+        assert _field_matches(5, "6") is False
+
+    def test_range(self):
+        assert _field_matches(5, "3-7") is True
+        assert _field_matches(9, "3-7") is False
+
+    def test_step(self):
+        assert _field_matches(10, "*/5") is True
+        assert _field_matches(11, "*/5") is False
+
+    def test_list(self):
+        assert _field_matches(3, "1,3,5") is True
+        assert _field_matches(4, "1,3,5") is False
+
+    def test_cron_matches_at_9am(self):
+        dt = datetime(2026, 4, 8, 9, 0, 0, tzinfo=UTC)
+        assert _cron_matches("0 9 * * *", dt) is True
+
+    def test_cron_no_match(self):
+        dt = datetime(2026, 4, 8, 10, 0, 0, tzinfo=UTC)
+        assert _cron_matches("0 9 * * *", dt) is False
+
+    def test_cron_every_5min(self):
+        dt = datetime(2026, 4, 8, 9, 15, 0, tzinfo=UTC)
+        assert _cron_matches("*/5 * * * *", dt) is True
+
+    def test_bad_cron_expression(self):
+        assert _cron_matches("not-valid", datetime.now(UTC)) is False
+
+
+# ---------------------------------------------------------------------------
+# CronJobStore
+# ---------------------------------------------------------------------------
+
+
+class TestCronJobStore:
+    def test_empty_list(self, tmp_path):
+        store = _make_store(tmp_path)
+        assert store.list() == []
+
+    def test_create_and_list(self, tmp_path):
+        store = _make_store(tmp_path)
+        rec = _make_record()
+        store.create(rec)
+
+        jobs = store.list()
+        assert len(jobs) == 1
+        assert jobs[0].job_id == rec.job_id
+        assert jobs[0].name == rec.name
+
+    def test_file_permissions(self, tmp_path):
+        store = _make_store(tmp_path)
+        rec = _make_record()
+        store.create(rec)
+
+        mode = stat.S_IMODE((tmp_path / "jobs.json").stat().st_mode)
+        assert mode == 0o600
+
+    def test_get_existing(self, tmp_path):
+        store = _make_store(tmp_path)
+        rec = _make_record(job_id="findme00")
+        store.create(rec)
+
+        found = store.get("findme00")
+        assert found is not None
+        assert found.name == rec.name
+
+    def test_get_missing(self, tmp_path):
+        store = _make_store(tmp_path)
+        assert store.get("nonexistent") is None
+
+    def test_delete_existing(self, tmp_path):
+        store = _make_store(tmp_path)
+        rec = _make_record(job_id="deleteme0")
+        store.create(rec)
+
+        removed = store.delete("deleteme0")
+        assert removed is True
+        assert store.list() == []
+
+    def test_delete_missing(self, tmp_path):
+        store = _make_store(tmp_path)
+        assert store.delete("ghost") is False
+
+    def test_duplicate_job_id_raises(self, tmp_path):
+        store = _make_store(tmp_path)
+        rec = _make_record(job_id="dupeid000")
+        store.create(rec)
+        with pytest.raises(ValueError, match="already exists"):
+            store.create(_make_record(job_id="dupeid000"))
+
+    def test_multiple_jobs(self, tmp_path):
+        store = _make_store(tmp_path)
+        for i in range(3):
+            store.create(_make_record(job_id=f"job{i:014d}", name=f"job-{i}"))
+
+        assert len(store.list()) == 3
+
+    def test_corrupt_json_returns_empty(self, tmp_path):
+        jobs_path = tmp_path / "jobs.json"
+        jobs_path.write_text("not-json")
+        store = CronJobStore(jobs_path=jobs_path)
+        assert store.list() == []
+
+
+# ---------------------------------------------------------------------------
+# CronJobRecord serialisation
+# ---------------------------------------------------------------------------
+
+
+class TestCronJobRecord:
+    def test_roundtrip(self):
+        rec = _make_record(persona="assistant", delivery="sleipnir")
+        d = rec.to_dict()
+        restored = CronJobRecord.from_dict(d)
+        assert restored.job_id == rec.job_id
+        assert restored.delivery == "sleipnir"
+        assert restored.persona == "assistant"
+
+    def test_defaults_from_dict(self):
+        rec = CronJobRecord.from_dict(
+            {"job_id": "x", "name": "n", "schedule": "1m", "context": "c"}
+        )
+        assert rec.delivery == "local"
+        assert rec.priority == 10
+        assert rec.enabled is True
+
+
+# ---------------------------------------------------------------------------
+# CronTrigger._is_due_canonical
+# ---------------------------------------------------------------------------
+
+
+class TestCronTriggerIsDue:
+    def _trigger(self):
+        return CronTrigger(jobs=[])
+
+    def test_once_not_yet(self):
+        t = self._trigger()
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        assert t._is_due_canonical(f"once:{future}", "k", datetime.now(UTC), {}) is False
+
+    def test_once_past_fires_once(self):
+        t = self._trigger()
+        past = (datetime.now(UTC) - timedelta(seconds=1)).isoformat()
+        state: dict = {}
+        assert t._is_due_canonical(f"once:{past}", "k", datetime.now(UTC), state) is True
+        # Firing again with key in state → should not fire
+        state["k"] = datetime.now(UTC).isoformat()
+        assert t._is_due_canonical(f"once:{past}", "k", datetime.now(UTC), state) is False
+
+    def test_every_first_time(self):
+        t = self._trigger()
+        assert t._is_due_canonical("every:60", "k", datetime.now(UTC), {}) is True
+
+    def test_every_too_soon(self):
+        t = self._trigger()
+        state = {"k": datetime.now(UTC).isoformat()}
+        assert t._is_due_canonical("every:3600", "k", datetime.now(UTC), state) is False
+
+    def test_every_interval_elapsed(self):
+        t = self._trigger()
+        past = (datetime.now(UTC) - timedelta(seconds=3601)).isoformat()
+        state = {"k": past}
+        assert t._is_due_canonical("every:3600", "k", datetime.now(UTC), state) is True
+
+    def test_cron_expr_no_last(self):
+        t = self._trigger()
+        now = datetime(2026, 4, 8, 9, 0, 0, tzinfo=UTC)
+        assert t._is_due_canonical("0 9 * * *", "k", now, {}) is True
+
+    def test_cron_expr_fired_recently(self):
+        t = self._trigger()
+        now = datetime(2026, 4, 8, 9, 0, 30, tzinfo=UTC)
+        state = {"k": (now - timedelta(seconds=29)).isoformat()}
+        assert t._is_due_canonical("0 9 * * *", "k", now, state) is False
+
+
+# ---------------------------------------------------------------------------
+# CronTrigger.run — store jobs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cron_trigger_fires_store_job(tmp_path):
+    """A store-defined job is enqueued when due."""
+    store = _make_store(tmp_path)
+    state_path = tmp_path / "state.json"
+    lock_path = tmp_path / "cron.lock"
+
+    rec = _make_record(job_id="storejob00", name="store-job", schedule="every 1s")
+    store.create(rec)
+
+    trigger = CronTrigger(
+        jobs=[],
+        state_path=state_path,
+        lock_path=lock_path,
+        tick_seconds=9999,
+        store=store,
+    )
+
+    enqueued: list[AgentTask] = []
+
+    async def fake_enqueue(task: AgentTask) -> None:
+        enqueued.append(task)
+
+    # Simulate the store-job loop body from CronTrigger.run
+    now = datetime.now(UTC)
+    state: dict = {}
+
+    for record in store.list():
+        if not record.enabled:
+            continue
+        canonical = _parse_schedule(record.schedule)
+        if not trigger._is_due_canonical(canonical, record.job_id, now, state):
+            continue
+        context = record.context
+        output_mode = _DELIVERY_TO_OUTPUT_MODE.get(record.delivery, OutputMode.SILENT)
+        if context.startswith(_SILENT_MARKER):
+            context = context[len(_SILENT_MARKER) :].strip()
+            output_mode = OutputMode.SILENT
+        timestamp_str = now.strftime("%Y%m%dT%H%M%S")
+        output_path = _OUTPUT_BASE / record.job_id / f"{timestamp_str}.md"
+        task_id = trigger._make_task_id()
+        task = AgentTask(
+            task_id=task_id,
+            title=record.name,
+            initiative_context=context,
+            triggered_by=f"cron:{record.job_id}",
+            output_mode=output_mode,
+            persona=record.persona or None,
+            priority=record.priority,
+            output_path=output_path,
+        )
+        await fake_enqueue(task)
+        state[record.job_id] = now.isoformat()
+
+    assert len(enqueued) == 1
+    task = enqueued[0]
+    assert task.triggered_by == f"cron:{rec.job_id}"
+    assert task.output_path is not None
+    assert rec.job_id in str(task.output_path)
+
+
+@pytest.mark.asyncio
+async def test_cron_trigger_silent_marker(tmp_path):
+    """[SILENT] prefix forces output_mode=SILENT and is stripped from context."""
+    store = _make_store(tmp_path)
+    rec = _make_record(
+        job_id="silent0001",
+        context="[SILENT] Check disk usage",
+        delivery="platform",
+    )
+    store.create(rec)
+
+    trigger = CronTrigger(jobs=[], store=store)
+    enqueued: list[AgentTask] = []
+    now = datetime.now(UTC)
+    state: dict = {}
+
+    for record in store.list():
+        canonical = _parse_schedule(record.schedule)
+        if not trigger._is_due_canonical(canonical, record.job_id, now, state):
+            continue
+        context = record.context
+        output_mode = _DELIVERY_TO_OUTPUT_MODE.get(record.delivery, OutputMode.SILENT)
+        if context.startswith(_SILENT_MARKER):
+            context = context[len(_SILENT_MARKER) :].strip()
+            output_mode = OutputMode.SILENT
+        output_path = _OUTPUT_BASE / record.job_id / f"{now.strftime('%Y%m%dT%H%M%S')}.md"
+        task = AgentTask(
+            task_id="t001",
+            title=record.name,
+            initiative_context=context,
+            triggered_by=f"cron:{record.job_id}",
+            output_mode=output_mode,
+            persona=None,
+            priority=record.priority,
+            output_path=output_path,
+        )
+        enqueued.append(task)
+
+    assert len(enqueued) == 1
+    assert enqueued[0].output_mode == OutputMode.SILENT
+    assert enqueued[0].initiative_context == "Check disk usage"
+
+
+# ---------------------------------------------------------------------------
+# CronTrigger — config-defined jobs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cron_trigger_fires_config_job(tmp_path):
+    """Config-defined CronJob is enqueued when due."""
+    state_path = tmp_path / "state.json"
+    lock_path = tmp_path / "cron.lock"
+
+    job = CronJob(
+        name="config-job",
+        schedule="every 1s",
+        context="Do the thing.",
+        output_mode=OutputMode.SILENT,
+    )
+    trigger = CronTrigger(
+        jobs=[job],
+        state_path=state_path,
+        lock_path=lock_path,
+        tick_seconds=9999,
+    )
+
+    enqueued: list[AgentTask] = []
+    now = datetime.now(UTC)
+    state: dict = {}
+
+    # Fire manually without the async loop
+    if trigger._is_due(job, now, state):
+        task = AgentTask(
+            task_id="cfg001",
+            title=job.name,
+            initiative_context=job.context,
+            triggered_by=f"cron:{job.name}",
+            output_mode=job.output_mode,
+            persona=job.persona,
+            priority=job.priority,
+        )
+        enqueued.append(task)
+        state[job.name] = now.isoformat()
+
+    assert len(enqueued) == 1
+    assert enqueued[0].triggered_by == "cron:config-job"
+
+
+# ---------------------------------------------------------------------------
+# make_cron_trigger
+# ---------------------------------------------------------------------------
+
+
+def test_make_cron_trigger(tmp_path):
+    trigger, store = make_cron_trigger(
+        jobs_path=tmp_path / "jobs.json",
+        state_path=tmp_path / "state.json",
+        lock_path=tmp_path / "lock",
+    )
+    assert isinstance(trigger, CronTrigger)
+    assert isinstance(store, CronJobStore)
+    assert trigger._store is store
+
+
+# ---------------------------------------------------------------------------
+# CronCreateTool
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cron_create_basic(tmp_path):
+    store = _make_store(tmp_path)
+    tool = CronCreateTool(store)
+
+    result = await tool.execute(
+        {
+            "name": "morning-brief",
+            "schedule": "0 9 * * *",
+            "context": "Summarise today's tasks.",
+            "delivery": "local",
+            "priority": 5,
+        }
+    )
+
+    assert not result.is_error
+    assert "morning-brief" in result.content
+
+    jobs = store.list()
+    assert len(jobs) == 1
+    assert jobs[0].name == "morning-brief"
+    assert jobs[0].schedule == "0 9 * * *"
+    assert jobs[0].priority == 5
+
+
+@pytest.mark.asyncio
+async def test_cron_create_natural_language(tmp_path):
+    store = _make_store(tmp_path)
+    tool = CronCreateTool(store)
+
+    result = await tool.execute(
+        {"name": "ping", "schedule": "every 30m", "context": "Ping the server."}
+    )
+
+    assert not result.is_error
+    assert "every:1800" in result.content
+
+
+@pytest.mark.asyncio
+async def test_cron_create_missing_name(tmp_path):
+    store = _make_store(tmp_path)
+    tool = CronCreateTool(store)
+    result = await tool.execute({"schedule": "0 9 * * *", "context": "hi"})
+    assert result.is_error
+
+
+@pytest.mark.asyncio
+async def test_cron_create_missing_schedule(tmp_path):
+    store = _make_store(tmp_path)
+    tool = CronCreateTool(store)
+    result = await tool.execute({"name": "x", "context": "hi"})
+    assert result.is_error
+
+
+@pytest.mark.asyncio
+async def test_cron_create_missing_context(tmp_path):
+    store = _make_store(tmp_path)
+    tool = CronCreateTool(store)
+    result = await tool.execute({"name": "x", "schedule": "0 9 * * *"})
+    assert result.is_error
+
+
+@pytest.mark.asyncio
+async def test_cron_create_invalid_delivery(tmp_path):
+    store = _make_store(tmp_path)
+    tool = CronCreateTool(store)
+    result = await tool.execute(
+        {
+            "name": "x",
+            "schedule": "0 9 * * *",
+            "context": "hi",
+            "delivery": "unknown",
+        }
+    )
+    assert result.is_error
+
+
+@pytest.mark.asyncio
+async def test_cron_create_with_persona(tmp_path):
+    store = _make_store(tmp_path)
+    tool = CronCreateTool(store)
+    result = await tool.execute(
+        {
+            "name": "scribe",
+            "schedule": "30m",
+            "context": "Write diary.",
+            "persona": "assistant",
+        }
+    )
+    assert not result.is_error
+    jobs = store.list()
+    assert jobs[0].persona == "assistant"
+
+
+@pytest.mark.asyncio
+async def test_cron_create_sleipnir_delivery(tmp_path):
+    store = _make_store(tmp_path)
+    tool = CronCreateTool(store)
+    result = await tool.execute(
+        {
+            "name": "broadcast",
+            "schedule": "0 8 * * *",
+            "context": "Morning report.",
+            "delivery": "sleipnir",
+        }
+    )
+    assert not result.is_error
+    assert store.list()[0].delivery == "sleipnir"
+
+
+# ---------------------------------------------------------------------------
+# CronListTool
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cron_list_empty(tmp_path):
+    store = _make_store(tmp_path)
+    tool = CronListTool(store)
+    result = await tool.execute({})
+    assert not result.is_error
+    assert "No cron jobs" in result.content
+
+
+@pytest.mark.asyncio
+async def test_cron_list_shows_jobs(tmp_path):
+    store = _make_store(tmp_path)
+    store.create(_make_record(job_id="aaa", name="alpha"))
+    store.create(_make_record(job_id="bbb", name="beta"))
+
+    tool = CronListTool(store)
+    result = await tool.execute({})
+    assert not result.is_error
+    assert "alpha" in result.content
+    assert "beta" in result.content
+    assert "2 total" in result.content
+
+
+@pytest.mark.asyncio
+async def test_cron_list_enabled_only(tmp_path):
+    store = _make_store(tmp_path)
+    store.create(_make_record(job_id="en1", name="enabled-job", enabled=True))
+    store.create(_make_record(job_id="dis1", name="disabled-job", enabled=False))
+
+    tool = CronListTool(store)
+    result = await tool.execute({"enabled_only": True})
+    assert not result.is_error
+    assert "enabled-job" in result.content
+    assert "disabled-job" not in result.content
+
+
+# ---------------------------------------------------------------------------
+# CronDeleteTool
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cron_delete_existing(tmp_path):
+    store = _make_store(tmp_path)
+    rec = _make_record(job_id="del00001")
+    store.create(rec)
+
+    tool = CronDeleteTool(store)
+    result = await tool.execute({"job_id": "del00001"})
+    assert not result.is_error
+    assert "del00001" in result.content
+    assert store.list() == []
+
+
+@pytest.mark.asyncio
+async def test_cron_delete_missing(tmp_path):
+    store = _make_store(tmp_path)
+    tool = CronDeleteTool(store)
+    result = await tool.execute({"job_id": "nope"})
+    assert result.is_error
+
+
+@pytest.mark.asyncio
+async def test_cron_delete_missing_job_id(tmp_path):
+    store = _make_store(tmp_path)
+    tool = CronDeleteTool(store)
+    result = await tool.execute({})
+    assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# build_cron_tools
+# ---------------------------------------------------------------------------
+
+
+def test_build_cron_tools(tmp_path):
+    store = _make_store(tmp_path)
+    tools = build_cron_tools(store)
+    names = {t.name for t in tools}
+    assert names == {"cron_create", "cron_list", "cron_delete"}
+
+
+def test_cron_tools_permission(tmp_path):
+    store = _make_store(tmp_path)
+    for tool in build_cron_tools(store):
+        assert tool.required_permission == "cron:manage"
+
+
+def test_cron_tools_have_valid_schema(tmp_path):
+    store = _make_store(tmp_path)
+    for tool in build_cron_tools(store):
+        schema = tool.input_schema
+        assert isinstance(schema, dict)
+        assert schema.get("type") == "object"
+
+
+# ---------------------------------------------------------------------------
+# AgentTask output_path
+# ---------------------------------------------------------------------------
+
+
+def test_agent_task_output_path_default():
+    task = AgentTask(
+        task_id="t1",
+        title="test",
+        initiative_context="do stuff",
+        triggered_by="cron:abc",
+        output_mode=OutputMode.SILENT,
+    )
+    assert task.output_path is None
+
+
+def test_agent_task_output_path_set(tmp_path):
+    path = tmp_path / "output.md"
+    task = AgentTask(
+        task_id="t2",
+        title="test",
+        initiative_context="do stuff",
+        triggered_by="cron:abc",
+        output_mode=OutputMode.SILENT,
+        output_path=path,
+    )
+    assert task.output_path == path
+
+
+# ---------------------------------------------------------------------------
+# CronTrigger.run() — full async loop via mock
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cron_trigger_run_fires_and_exits(tmp_path):
+    """run() fires a due job then exits on CancelledError from asyncio.sleep."""
+    store = _make_store(tmp_path)
+    state_path = tmp_path / "state.json"
+    lock_path = tmp_path / "cron.lock"
+
+    rec = _make_record(job_id="runtest001", name="run-test", schedule="every 1s")
+    store.create(rec)
+
+    trigger = CronTrigger(
+        jobs=[],
+        state_path=state_path,
+        lock_path=lock_path,
+        tick_seconds=0,
+        store=store,
+    )
+
+    enqueued: list[AgentTask] = []
+
+    async def fake_enqueue(task: AgentTask) -> None:
+        enqueued.append(task)
+
+    # Sleep raises CancelledError immediately → loop exits after one tick
+    sleep_mock = AsyncMock(side_effect=asyncio.CancelledError)
+    with patch("ravn.adapters.triggers.cron.asyncio.sleep", new=sleep_mock):
+        try:
+            await trigger.run(fake_enqueue)
+        except asyncio.CancelledError:
+            pass
+
+    # Job was due (first time, no state) → should have fired
+    assert len(enqueued) == 1
+    assert enqueued[0].triggered_by == f"cron:{rec.job_id}"
+    assert enqueued[0].output_path is not None
+
+    # State was persisted
+    assert state_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_cron_trigger_run_config_job(tmp_path):
+    """run() fires a config-defined job."""
+    state_path = tmp_path / "state.json"
+    lock_path = tmp_path / "cron.lock"
+
+    job = CronJob(
+        name="run-config",
+        schedule="every 1s",
+        context="config job context",
+        output_mode=OutputMode.AMBIENT,
+    )
+    trigger = CronTrigger(
+        jobs=[job],
+        state_path=state_path,
+        lock_path=lock_path,
+        tick_seconds=0,
+    )
+
+    enqueued: list[AgentTask] = []
+
+    async def fake_enqueue(task: AgentTask) -> None:
+        enqueued.append(task)
+
+    sleep_mock = AsyncMock(side_effect=asyncio.CancelledError)
+    with patch("ravn.adapters.triggers.cron.asyncio.sleep", new=sleep_mock):
+        try:
+            await trigger.run(fake_enqueue)
+        except asyncio.CancelledError:
+            pass
+
+    assert len(enqueued) == 1
+    assert enqueued[0].triggered_by == "cron:run-config"
+    assert enqueued[0].output_mode == OutputMode.AMBIENT
+
+
+@pytest.mark.asyncio
+async def test_cron_trigger_run_lock_held(tmp_path):
+    """run() exits without firing when lock cannot be acquired."""
+    state_path = tmp_path / "state.json"
+    lock_path = tmp_path / "cron.lock"
+
+    trigger = CronTrigger(jobs=[], state_path=state_path, lock_path=lock_path)
+
+    enqueued: list[AgentTask] = []
+
+    with patch.object(trigger, "_acquire_lock", return_value=None):
+        await trigger.run(AsyncMock())  # should return immediately
+
+    assert enqueued == []
+
+
+# ---------------------------------------------------------------------------
+# CronTrigger._save_state / _load_state
+# ---------------------------------------------------------------------------
+
+
+def test_cron_trigger_save_and_load_state(tmp_path):
+    """State round-trips through JSON file."""
+    trigger = CronTrigger(
+        jobs=[],
+        state_path=tmp_path / "state.json",
+        lock_path=tmp_path / "lock",
+    )
+    state = {"job-a": "2026-04-08T09:00:00+00:00"}
+    trigger._save_state(state)
+    loaded = trigger._load_state()
+    assert loaded == state
+
+
+def test_cron_trigger_load_state_missing(tmp_path):
+    trigger = CronTrigger(
+        jobs=[],
+        state_path=tmp_path / "missing.json",
+        lock_path=tmp_path / "lock",
+    )
+    assert trigger._load_state() == {}
+
+
+def test_cron_trigger_load_state_corrupt(tmp_path):
+    state_path = tmp_path / "state.json"
+    state_path.write_text("not-json")
+    trigger = CronTrigger(jobs=[], state_path=state_path, lock_path=tmp_path / "lock")
+    assert trigger._load_state() == {}
+
+
+# ---------------------------------------------------------------------------
+# _field_matches — non-wildcard base step
+# ---------------------------------------------------------------------------
+
+
+def test_field_matches_base_step():
+    """'2/3' means 'starting at 2, every 3': matches 2, 5, 8, 11..."""
+    assert _field_matches(2, "2/3") is True
+    assert _field_matches(5, "2/3") is True
+    assert _field_matches(8, "2/3") is True
+    assert _field_matches(3, "2/3") is False  # not in sequence
+    assert _field_matches(1, "2/3") is False  # below start
+
+
+# ---------------------------------------------------------------------------
+# _is_due_canonical — bad ISO in once: branch
+# ---------------------------------------------------------------------------
+
+
+def test_is_due_canonical_bad_iso():
+    trigger = CronTrigger(jobs=[])
+    # "once:not-a-date" should not fire (ValueError caught)
+    assert trigger._is_due_canonical("once:not-a-date", "k", datetime.now(UTC), {}) is False

--- a/tests/test_ravn/test_cron_tools.py
+++ b/tests/test_ravn/test_cron_tools.py
@@ -26,8 +26,8 @@ from ravn.adapters.triggers.cron import (
     CronTrigger,
     _cron_matches,
     _field_matches,
-    _parse_schedule,
     make_cron_trigger,
+    parse_schedule,
 )
 from ravn.domain.models import AgentTask, OutputMode
 
@@ -55,46 +55,46 @@ def _make_record(**kwargs) -> CronJobRecord:
 
 
 # ---------------------------------------------------------------------------
-# _parse_schedule
+# parse_schedule
 # ---------------------------------------------------------------------------
 
 
 class TestParseSchedule:
     def test_every_minutes(self):
-        assert _parse_schedule("every 30m") == "every:1800"
+        assert parse_schedule("every 30m") == "every:1800"
 
     def test_every_seconds(self):
-        assert _parse_schedule("every 5s") == "every:5"
+        assert parse_schedule("every 5s") == "every:5"
 
     def test_every_hours(self):
-        assert _parse_schedule("every 2h") == "every:7200"
+        assert parse_schedule("every 2h") == "every:7200"
 
     def test_bare_interval_minutes(self):
-        assert _parse_schedule("30m") == "every:1800"
+        assert parse_schedule("30m") == "every:1800"
 
     def test_bare_interval_hours(self):
-        assert _parse_schedule("2h") == "every:7200"
+        assert parse_schedule("2h") == "every:7200"
 
     def test_bare_interval_seconds(self):
-        assert _parse_schedule("45s") == "every:45"
+        assert parse_schedule("45s") == "every:45"
 
     def test_daily_at(self):
-        result = _parse_schedule("daily at 09:00")
+        result = parse_schedule("daily at 09:00")
         assert result == "0 9 * * *"
 
     def test_daily_at_midnight(self):
-        result = _parse_schedule("daily at 00:30")
+        result = parse_schedule("daily at 00:30")
         assert result == "30 0 * * *"
 
     def test_cron_passthrough(self):
-        assert _parse_schedule("0 8 * * *") == "0 8 * * *"
+        assert parse_schedule("0 8 * * *") == "0 8 * * *"
 
     def test_iso_timestamp(self):
-        result = _parse_schedule("2026-04-08T09:00:00")
+        result = parse_schedule("2026-04-08T09:00:00")
         assert result.startswith("once:")
 
     def test_unknown_passthrough(self):
-        result = _parse_schedule("*/5 * * * *")
+        result = parse_schedule("*/5 * * * *")
         assert result == "*/5 * * * *"
 
 
@@ -322,7 +322,7 @@ async def test_cron_trigger_fires_store_job(tmp_path):
     for record in store.list():
         if not record.enabled:
             continue
-        canonical = _parse_schedule(record.schedule)
+        canonical = parse_schedule(record.schedule)
         if not trigger._is_due_canonical(canonical, record.job_id, now, state):
             continue
         context = record.context
@@ -370,7 +370,7 @@ async def test_cron_trigger_silent_marker(tmp_path):
     state: dict = {}
 
     for record in store.list():
-        canonical = _parse_schedule(record.schedule)
+        canonical = parse_schedule(record.schedule)
         if not trigger._is_due_canonical(canonical, record.job_id, now, state):
             continue
         context = record.context


### PR DESCRIPTION
## Summary

Implements Phase 7 of Ravn — cron scheduling for recurring autonomous tasks (NIU-437).

- **`CronJobStore`** — persistent job store at `~/.ravn/cron/jobs.json` (0600 permissions); all schedule formats supported: cron expressions, natural language (`every 30m`, `daily at 09:00`), bare intervals (`30m`, `2h`), ISO one-shot timestamps
- **Three tools** (`cron:manage` permission): `cron_create`, `cron_list`, `cron_delete` — agents can schedule and manage their own recurring tasks at runtime
- **Delivery targets**: `local` (silent, output saved to disk), `sleipnir` (ambient/ODIN backbone), `platform` (surface channel); `[SILENT]` prefix overrides to local-only
- **Output persistence**: task response saved to `~/.ravn/cron/output/{job_id}/{timestamp}.md` after each execution
- **CronTrigger refactor**: consolidated to a single instance per daemon (one fcntl lock) handling both config-defined and runtime store jobs; `_is_due_canonical()` extracted for reuse
- **`AgentTask.output_path`**: new optional field; DriveLoop saves response text to this path after successful execution; journal persistence updated
- **CLI wiring**: `_wire_triggers` collects cron jobs, `_wire_cron` creates the unified trigger + store + registers tools on `drive_loop._cron_tools`

## Test plan

- [x] 70 new tests in `tests/test_ravn/test_cron_tools.py`
- [x] `cron.py` coverage: 95% (above 85% threshold)
- [x] `cron_tools.py` coverage: 91% (above 85% threshold)
- [x] All 2146 tests pass (2076 pre-existing + 70 new)
- [x] `ruff check` clean on all changed files
- [x] `ruff format` applied

## Note on Linear ticket

The Linear MCP server is not configured in this environment. NIU-437 was not automatically updated; please update it manually or configure the Linear MCP server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)