### PR TITLE
feat(adapters): add Discord, Slack, Matrix, WhatsApp gateway adapters (NIU-536)

### DIFF
--- a/src/ravn/adapters/channels/_http_mixin.py
+++ b/src/ravn/adapters/channels/_http_mixin.py
@@ -1,0 +1,81 @@
+"""Shared HTTP client mixin for Ravn gateway adapters.
+
+All adapters need the same pattern: use an injected ``httpx.AsyncClient``
+when provided (enables unit testing), otherwise create an ephemeral one.
+This mixin centralises that boilerplate so each adapter only writes the
+business logic around it.
+
+Subclasses must declare ``_http_client: httpx.AsyncClient | None``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+
+class GatewayHttpMixin:
+    """Provides ``_http_get``, ``_http_post``, and ``_http_put`` helpers.
+
+    When ``_http_client`` is set (injected in tests), it is reused across
+    calls.  When it is ``None``, an ephemeral client is created per call —
+    the standard production path.
+    """
+
+    _http_client: httpx.AsyncClient | None
+
+    async def _http_get(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        params: dict[str, str | int] | None = None,
+        timeout: float | None = None,
+    ) -> dict[str, Any]:
+        client = self._http_client
+        if client is not None:
+            resp = await client.get(url, headers=headers, params=params)
+            resp.raise_for_status()
+            return resp.json()
+        kw: dict[str, Any] = {}
+        if timeout is not None:
+            kw["timeout"] = timeout
+        async with httpx.AsyncClient(**kw) as c:  # pragma: no cover
+            resp = await c.get(url, headers=headers, params=params)  # pragma: no cover
+            resp.raise_for_status()  # pragma: no cover
+            return resp.json()  # pragma: no cover
+
+    async def _http_post(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        client = self._http_client
+        if client is not None:
+            resp = await client.post(url, headers=headers, **kwargs)
+            resp.raise_for_status()
+            return resp.json()
+        async with httpx.AsyncClient() as c:  # pragma: no cover
+            resp = await c.post(url, headers=headers, **kwargs)  # pragma: no cover
+            resp.raise_for_status()  # pragma: no cover
+            return resp.json()  # pragma: no cover
+
+    async def _http_put(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        client = self._http_client
+        if client is not None:
+            resp = await client.put(url, headers=headers, **kwargs)
+            resp.raise_for_status()
+            return resp.json()
+        async with httpx.AsyncClient() as c:  # pragma: no cover
+            resp = await c.put(url, headers=headers, **kwargs)  # pragma: no cover
+            resp.raise_for_status()  # pragma: no cover
+            return resp.json()  # pragma: no cover

--- a/src/ravn/adapters/channels/_slash_commands.py
+++ b/src/ravn/adapters/channels/_slash_commands.py
@@ -1,0 +1,15 @@
+"""Shared slash command → agent prompt mapping for Ravn gateway adapters.
+
+Each adapter imports :data:`GATEWAY_SLASH_PROMPTS` and may extend it with
+platform-specific command aliases (e.g. Slack's ``/ravn-`` prefix variants).
+"""
+
+from __future__ import annotations
+
+GATEWAY_SLASH_PROMPTS: dict[str, str] = {
+    "/compact": "Please compact and summarise the current context.",
+    "/budget": "How many iterations have you used and how many remain in your budget?",
+    "/status": "What is your current task status? Summarise briefly.",
+    "/stop": "Please acknowledge that you are stopping and summarise what you were working on.",
+    "/todo": "List your current todo items.",
+}

--- a/src/ravn/adapters/channels/gateway_discord.py
+++ b/src/ravn/adapters/channels/gateway_discord.py
@@ -1,0 +1,359 @@
+"""Discord gateway adapter — Discord Gateway WebSocket + REST API.
+
+Design principles:
+- Connects to the Discord Gateway via WebSocket (OP 2 IDENTIFY).
+- Handles heartbeat, reconnect, and invalid-session flows.
+- Sends messages via the Discord REST API (no discord.py dependency).
+- chat_id format: ``"guild_id/channel_id"`` or bare ``"channel_id"``
+  (guild_id is optional when the bot only serves one guild).
+- Slash commands (/stop, /status, /todo, /budget) are translated to
+  natural-language prompts before being forwarded to RavnGateway.
+- Reaction-based approval: 👍 (approve) / 👎 (reject) on messages
+  that include an [APPROVAL_REQUESTED] marker call the on_message
+  handler with a synthetic approve/reject text.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import os
+from typing import Any
+
+import httpx
+import websockets
+
+from ravn.adapters.channels.gateway import RavnGateway
+from ravn.config import DiscordChannelConfig
+from ravn.ports.gateway_channel import GatewayChannelPort, MessageHandler
+
+logger = logging.getLogger(__name__)
+
+# Discord Gateway opcodes
+_OP_DISPATCH = 0
+_OP_HEARTBEAT = 1
+_OP_IDENTIFY = 2
+_OP_RECONNECT = 7
+_OP_INVALID_SESSION = 9
+_OP_HELLO = 10
+_OP_HEARTBEAT_ACK = 11
+
+# Discord Gateway close codes that allow resuming
+_RESUMABLE_CLOSE_CODES = {4000, 4001, 4002, 4003, 4005, 4007, 4008, 4009}
+
+# Slash commands recognised by the gateway; translated to agent prompts.
+_SLASH_PROMPTS: dict[str, str] = {
+    "/compact": "Please compact and summarise the current context.",
+    "/budget": "How many iterations have you used and how many remain in your budget?",
+    "/status": "What is your current task status? Summarise briefly.",
+    "/stop": "Please acknowledge that you are stopping and summarise what you were working on.",
+    "/todo": "List your current todo items.",
+}
+
+# Approval marker embedded in messages that need human confirmation.
+_APPROVAL_MARKER = "[APPROVAL_REQUESTED]"
+_APPROVE_EMOJI = "👍"
+_REJECT_EMOJI = "👎"
+
+# Discord intent flags — GUILD_MESSAGES (1<<9) + MESSAGE_CONTENT (1<<15)
+_INTENTS = (1 << 9) | (1 << 15)
+
+
+class DiscordGateway(GatewayChannelPort):
+    """Connects to Discord Gateway and routes messages through :class:`RavnGateway`.
+
+    WebSocket lifecycle:
+
+    1. Connect → receive ``OP 10 HELLO`` → start heartbeat task.
+    2. Send ``OP 2 IDENTIFY`` with bot token and intents.
+    3. Receive ``OP 0 READY`` → store session_id.
+    4. Listen for ``OP 0 MESSAGE_CREATE`` events → route to gateway.
+    5. On ``OP 7 RECONNECT`` or connection drop → reconnect.
+    """
+
+    def __init__(
+        self,
+        config: DiscordChannelConfig,
+        gateway: RavnGateway,
+        *,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._config = config
+        self._gateway = gateway
+        self._token: str = os.environ.get(config.token_env, "")
+        self._handler: MessageHandler | None = None
+        self._http_client = http_client
+        self._task: asyncio.Task[None] | None = None
+        self._stop_event = asyncio.Event()
+        # Per-message approval tracking: message_id → (chat_id, session_id)
+        self._pending_approvals: dict[str, tuple[str, str]] = {}
+
+    # ------------------------------------------------------------------
+    # GatewayChannelPort interface
+    # ------------------------------------------------------------------
+
+    def on_message(self, handler: MessageHandler) -> None:
+        self._handler = handler
+
+    async def start(self) -> None:
+        """Launch the WebSocket receive loop as a background asyncio task."""
+        if not self._token:
+            logger.error(
+                "Discord token env var %r is not set; Discord gateway disabled.",
+                self._config.token_env,
+            )
+            return
+        self._stop_event.clear()
+        self._task = asyncio.create_task(self._run(), name="discord-gateway")
+
+    async def stop(self) -> None:
+        """Signal the receive loop to stop and await its completion."""
+        self._stop_event.set()
+        if self._task is not None:
+            self._task.cancel()
+            await asyncio.gather(self._task, return_exceptions=True)
+            self._task = None
+
+    async def run(self) -> None:
+        """Start and run until cancelled (convenience for :func:`asyncio.create_task`)."""
+        await self.start()
+        if self._task is not None:
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+
+    async def send_text(self, chat_id: str, text: str) -> None:
+        """Send *text* to the Discord channel identified by *chat_id*."""
+        channel_id = self._channel_id(chat_id)
+        limit = self._config.message_max_chars
+        if len(text) > limit:
+            text = text[: limit - 3] + "..."
+        await self._rest_post(
+            f"/channels/{channel_id}/messages",
+            json={"content": text},
+        )
+
+    async def send_image(self, chat_id: str, image: bytes, caption: str = "") -> None:
+        """Send *image* bytes to *chat_id* as an attachment."""
+        channel_id = self._channel_id(chat_id)
+        # Encode as base64 data URI for the Discord attachment upload
+        b64 = base64.b64encode(image).decode()
+        payload: dict[str, Any] = {
+            "content": caption,
+            "attachments": [
+                {
+                    "id": 0,
+                    "filename": "image.png",
+                    "data_uri": f"data:image/png;base64,{b64}",
+                }
+            ],
+        }
+        await self._rest_post(f"/channels/{channel_id}/messages", json=payload)
+
+    async def send_audio(self, chat_id: str, audio: bytes) -> None:
+        """Send *audio* bytes to *chat_id* as a file attachment."""
+        channel_id = self._channel_id(chat_id)
+        b64 = base64.b64encode(audio).decode()
+        payload: dict[str, Any] = {
+            "attachments": [
+                {
+                    "id": 0,
+                    "filename": "audio.ogg",
+                    "data_uri": f"data:audio/ogg;base64,{b64}",
+                }
+            ],
+        }
+        await self._rest_post(f"/channels/{channel_id}/messages", json=payload)
+
+    # ------------------------------------------------------------------
+    # WebSocket receive loop
+    # ------------------------------------------------------------------
+
+    async def _run(self) -> None:
+        """Connect to Discord Gateway and run the event loop indefinitely."""
+        while not self._stop_event.is_set():
+            try:
+                await self._connect_and_listen()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception(
+                    "Discord gateway error; reconnecting in %.1fs.",
+                    self._config.retry_delay,
+                )
+                await asyncio.sleep(self._config.retry_delay)
+
+    async def _connect_and_listen(self) -> None:
+        """Open a single WebSocket session and process events until disconnected."""
+        logger.info("Discord gateway connecting to %s", self._config.gateway_url)
+        async with websockets.connect(self._config.gateway_url) as ws:
+            heartbeat_task: asyncio.Task[None] | None = None
+            try:
+                async for raw in ws:
+                    payload: dict[str, Any] = json.loads(raw)
+                    op: int = payload.get("op", -1)
+                    data: Any = payload.get("d")
+
+                    if op == _OP_HELLO:
+                        interval_ms: int = data["heartbeat_interval"]
+                        heartbeat_task = asyncio.create_task(
+                            self._heartbeat_loop(ws, interval_ms / 1000.0)
+                        )
+                        await self._identify(ws)
+
+                    elif op == _OP_DISPATCH:
+                        event_name: str = payload.get("t", "")
+                        await self._handle_dispatch(event_name, data)
+
+                    elif op == _OP_RECONNECT:
+                        logger.info("Discord requested reconnect.")
+                        break
+
+                    elif op == _OP_INVALID_SESSION:
+                        logger.warning("Discord invalid session; re-identifying.")
+                        await asyncio.sleep(1)
+                        await self._identify(ws)
+
+                    elif op == _OP_HEARTBEAT:
+                        # Discord asked us to heartbeat immediately
+                        await ws.send(json.dumps({"op": _OP_HEARTBEAT, "d": None}))
+
+            finally:
+                if heartbeat_task is not None:
+                    heartbeat_task.cancel()
+                    await asyncio.gather(heartbeat_task, return_exceptions=True)
+
+    async def _heartbeat_loop(
+        self, ws: Any, interval_seconds: float
+    ) -> None:
+        """Send OP 1 HEARTBEAT every *interval_seconds*."""
+        while True:
+            await asyncio.sleep(interval_seconds)
+            try:
+                await ws.send(json.dumps({"op": _OP_HEARTBEAT, "d": None}))
+            except Exception:
+                logger.debug("Discord heartbeat failed — WS closed.")
+                return
+
+    async def _identify(self, ws: Any) -> None:
+        """Send OP 2 IDENTIFY with bot token and intents."""
+        payload = {
+            "op": _OP_IDENTIFY,
+            "d": {
+                "token": self._token,
+                "intents": _INTENTS,
+                "properties": {
+                    "os": "linux",
+                    "browser": "ravn",
+                    "device": "ravn",
+                },
+            },
+        }
+        await ws.send(json.dumps(payload))
+
+    # ------------------------------------------------------------------
+    # Dispatch handling
+    # ------------------------------------------------------------------
+
+    async def _handle_dispatch(self, event_name: str, data: Any) -> None:
+        if event_name == "MESSAGE_CREATE":
+            await self._on_message_create(data)
+        elif event_name == "MESSAGE_REACTION_ADD":
+            await self._on_reaction_add(data)
+        elif event_name == "READY":
+            logger.info("Discord gateway ready (user: %s).", data.get("user", {}).get("username"))
+
+    async def _on_message_create(self, data: dict[str, Any]) -> None:
+        # Ignore messages from bots (including ourselves)
+        author = data.get("author", {})
+        if author.get("bot"):
+            return
+
+        channel_id: str = data.get("channel_id", "")
+        guild_id: str = data.get("guild_id", self._config.guild_id)
+        chat_id = f"{guild_id}/{channel_id}" if guild_id else channel_id
+        text: str = data.get("content", "").strip()
+
+        if not text:
+            return
+
+        # Track messages with approval markers so we can handle reactions
+        message_id: str = data.get("id", "")
+        if _APPROVAL_MARKER in text and message_id:
+            session_id = f"discord:{chat_id}"
+            self._pending_approvals[message_id] = (chat_id, session_id)
+
+        prompt = self._translate_slash(text)
+        session_id = f"discord:{chat_id}"
+
+        try:
+            response = await self._gateway.handle_message(session_id, prompt)
+        except Exception:
+            logger.exception("Error processing Discord message from %s.", chat_id)
+            response = "Sorry, something went wrong. Please try again."
+
+        await self.send_text(chat_id, response or "(no response)")
+
+        if self._handler is not None:
+            await self._handler(chat_id, prompt)
+
+    async def _on_reaction_add(self, data: dict[str, Any]) -> None:
+        """Handle 👍/👎 reactions on approval-requested messages."""
+        message_id: str = data.get("message_id", "")
+        if message_id not in self._pending_approvals:
+            return
+
+        emoji_name: str = data.get("emoji", {}).get("name", "")
+        if emoji_name == _APPROVE_EMOJI:
+            prompt = "approved"
+        elif emoji_name == _REJECT_EMOJI:
+            prompt = "rejected"
+        else:
+            return  # Leave the approval pending for the correct reaction
+
+        chat_id, session_id = self._pending_approvals.pop(message_id)
+
+        try:
+            response = await self._gateway.handle_message(session_id, prompt)
+        except Exception:
+            logger.exception("Error processing Discord reaction from %s.", chat_id)
+            response = "Sorry, something went wrong."
+
+        await self.send_text(chat_id, response or "(no response)")
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _channel_id(self, chat_id: str) -> str:
+        """Extract the channel ID from a ``guild_id/channel_id`` or bare channel ID."""
+        if "/" in chat_id:
+            return chat_id.split("/", 1)[1]
+        return chat_id
+
+    def _translate_slash(self, text: str) -> str:
+        """Return the natural-language prompt for a Ravn slash command, or *text* as-is."""
+        if not text.startswith("/"):
+            return text
+        command = text.split()[0].lower()
+        return _SLASH_PROMPTS.get(command, text)
+
+    async def _rest_post(self, path: str, **kwargs: Any) -> dict[str, Any]:
+        """POST to the Discord REST API; returns parsed JSON."""
+        url = f"{self._config.api_base}{path}"
+        headers = {
+            "Authorization": f"Bot {self._token}",
+            "Content-Type": "application/json",
+        }
+        if self._http_client is not None:
+            resp = await self._http_client.post(url, headers=headers, **kwargs)
+            resp.raise_for_status()
+            return resp.json()
+
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(url, headers=headers, **kwargs)
+            resp.raise_for_status()
+            return resp.json()

--- a/src/ravn/adapters/channels/gateway_discord.py
+++ b/src/ravn/adapters/channels/gateway_discord.py
@@ -16,7 +16,6 @@ Design principles:
 from __future__ import annotations
 
 import asyncio
-import base64
 import json
 import logging
 import os
@@ -25,6 +24,8 @@ from typing import Any
 import httpx
 import websockets
 
+from ravn.adapters.channels._http_mixin import GatewayHttpMixin
+from ravn.adapters.channels._slash_commands import GATEWAY_SLASH_PROMPTS
 from ravn.adapters.channels.gateway import RavnGateway
 from ravn.config import DiscordChannelConfig
 from ravn.ports.gateway_channel import GatewayChannelPort, MessageHandler
@@ -44,13 +45,7 @@ _OP_HEARTBEAT_ACK = 11
 _RESUMABLE_CLOSE_CODES = {4000, 4001, 4002, 4003, 4005, 4007, 4008, 4009}
 
 # Slash commands recognised by the gateway; translated to agent prompts.
-_SLASH_PROMPTS: dict[str, str] = {
-    "/compact": "Please compact and summarise the current context.",
-    "/budget": "How many iterations have you used and how many remain in your budget?",
-    "/status": "What is your current task status? Summarise briefly.",
-    "/stop": "Please acknowledge that you are stopping and summarise what you were working on.",
-    "/todo": "List your current todo items.",
-}
+_SLASH_PROMPTS: dict[str, str] = GATEWAY_SLASH_PROMPTS
 
 # Approval marker embedded in messages that need human confirmation.
 _APPROVAL_MARKER = "[APPROVAL_REQUESTED]"
@@ -61,7 +56,7 @@ _REJECT_EMOJI = "👎"
 _INTENTS = (1 << 9) | (1 << 15)
 
 
-class DiscordGateway(GatewayChannelPort):
+class DiscordGateway(GatewayHttpMixin, GatewayChannelPort):
     """Connects to Discord Gateway and routes messages through :class:`RavnGateway`.
 
     WebSocket lifecycle:
@@ -88,6 +83,7 @@ class DiscordGateway(GatewayChannelPort):
         self._task: asyncio.Task[None] | None = None
         self._stop_event = asyncio.Event()
         # Per-message approval tracking: message_id → (chat_id, session_id)
+        # Capped at max_pending_approvals to prevent unbounded growth.
         self._pending_approvals: dict[str, tuple[str, str]] = {}
 
     # ------------------------------------------------------------------
@@ -137,36 +133,25 @@ class DiscordGateway(GatewayChannelPort):
         )
 
     async def send_image(self, chat_id: str, image: bytes, caption: str = "") -> None:
-        """Send *image* bytes to *chat_id* as an attachment."""
+        """Send *image* bytes to *chat_id* as a multipart attachment."""
         channel_id = self._channel_id(chat_id)
-        # Encode as base64 data URI for the Discord attachment upload
-        b64 = base64.b64encode(image).decode()
-        payload: dict[str, Any] = {
-            "content": caption,
-            "attachments": [
-                {
-                    "id": 0,
-                    "filename": "image.png",
-                    "data_uri": f"data:image/png;base64,{b64}",
-                }
-            ],
-        }
-        await self._rest_post(f"/channels/{channel_id}/messages", json=payload)
+        limit = self._config.message_max_chars
+        if caption and len(caption) > limit:
+            caption = caption[: limit - 3] + "..."
+        await self._rest_post_multipart(
+            f"/channels/{channel_id}/messages",
+            payload_json={"content": caption},
+            files={"files[0]": ("image.png", image, "image/png")},
+        )
 
     async def send_audio(self, chat_id: str, audio: bytes) -> None:
-        """Send *audio* bytes to *chat_id* as a file attachment."""
+        """Send *audio* bytes to *chat_id* as a multipart attachment."""
         channel_id = self._channel_id(chat_id)
-        b64 = base64.b64encode(audio).decode()
-        payload: dict[str, Any] = {
-            "attachments": [
-                {
-                    "id": 0,
-                    "filename": "audio.ogg",
-                    "data_uri": f"data:audio/ogg;base64,{b64}",
-                }
-            ],
-        }
-        await self._rest_post(f"/channels/{channel_id}/messages", json=payload)
+        await self._rest_post_multipart(
+            f"/channels/{channel_id}/messages",
+            payload_json={},
+            files={"files[0]": ("audio.ogg", audio, "audio/ogg")},
+        )
 
     # ------------------------------------------------------------------
     # WebSocket receive loop
@@ -280,10 +265,14 @@ class DiscordGateway(GatewayChannelPort):
         if not text:
             return
 
-        # Track messages with approval markers so we can handle reactions
+        # Track messages with approval markers so we can handle reactions.
+        # Evict the oldest entry when the cap is reached to keep memory bounded.
         message_id: str = data.get("id", "")
         if _APPROVAL_MARKER in text and message_id:
             session_id = f"discord:{chat_id}"
+            if len(self._pending_approvals) >= self._config.max_pending_approvals:
+                oldest_key = next(iter(self._pending_approvals))
+                del self._pending_approvals[oldest_key]
             self._pending_approvals[message_id] = (chat_id, session_id)
 
         prompt = self._translate_slash(text)
@@ -341,19 +330,27 @@ class DiscordGateway(GatewayChannelPort):
         command = text.split()[0].lower()
         return _SLASH_PROMPTS.get(command, text)
 
-    async def _rest_post(self, path: str, **kwargs: Any) -> dict[str, Any]:
-        """POST to the Discord REST API; returns parsed JSON."""
-        url = f"{self._config.api_base}{path}"
-        headers = {
-            "Authorization": f"Bot {self._token}",
-            "Content-Type": "application/json",
-        }
-        if self._http_client is not None:
-            resp = await self._http_client.post(url, headers=headers, **kwargs)
-            resp.raise_for_status()
-            return resp.json()
+    def _auth_headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bot {self._token}"}
 
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(url, headers=headers, **kwargs)
-            resp.raise_for_status()
-            return resp.json()
+    async def _rest_post(self, path: str, **kwargs: Any) -> dict[str, Any]:
+        """POST JSON to the Discord REST API; returns parsed JSON."""
+        url = f"{self._config.api_base}{path}"
+        headers = {**self._auth_headers(), "Content-Type": "application/json"}
+        return await self._http_post(url, headers=headers, **kwargs)
+
+    async def _rest_post_multipart(
+        self,
+        path: str,
+        *,
+        payload_json: dict[str, Any],
+        files: dict[str, tuple[str, bytes, str]],
+    ) -> dict[str, Any]:
+        """POST multipart/form-data to the Discord REST API (for file uploads)."""
+        url = f"{self._config.api_base}{path}"
+        return await self._http_post(
+            url,
+            headers=self._auth_headers(),
+            data={"payload_json": json.dumps(payload_json)},
+            files=files,
+        )

--- a/src/ravn/adapters/channels/gateway_matrix.py
+++ b/src/ravn/adapters/channels/gateway_matrix.py
@@ -15,10 +15,13 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import uuid
 from typing import Any
+from urllib.parse import quote
 
 import httpx
 
+from ravn.adapters.channels._http_mixin import GatewayHttpMixin
 from ravn.adapters.channels.gateway import RavnGateway
 from ravn.config import MatrixChannelConfig
 from ravn.ports.gateway_channel import GatewayChannelPort, MessageHandler
@@ -30,7 +33,7 @@ _MSGTYPE_TEXT = "m.text"
 _EVENT_TYPE_MESSAGE = "m.room.message"
 
 
-class MatrixGateway(GatewayChannelPort):
+class MatrixGateway(GatewayHttpMixin, GatewayChannelPort):
     """Polls a Matrix homeserver via /sync and routes messages to :class:`RavnGateway`.
 
     Uses long-poll sync (``timeout`` query parameter) so events arrive quickly
@@ -100,7 +103,6 @@ class MatrixGateway(GatewayChannelPort):
         limit = self._config.message_max_chars
         if len(text) > limit:
             text = text[: limit - 3] + "..."
-        import uuid
         txn_id = uuid.uuid4().hex
         await self._cs_put(
             f"/rooms/{_quote(chat_id)}/send/{_EVENT_TYPE_MESSAGE}/{txn_id}",
@@ -113,7 +115,6 @@ class MatrixGateway(GatewayChannelPort):
     async def send_image(self, chat_id: str, image: bytes, caption: str = "") -> None:
         """Upload *image* to the homeserver and send an m.image event."""
         mxc_url = await self._upload_media(image, content_type="image/png", filename="image.png")
-        import uuid
         txn_id = uuid.uuid4().hex
         await self._cs_put(
             f"/rooms/{_quote(chat_id)}/send/m.room.message/{txn_id}",
@@ -127,7 +128,6 @@ class MatrixGateway(GatewayChannelPort):
     async def send_audio(self, chat_id: str, audio: bytes) -> None:
         """Upload *audio* to the homeserver and send an m.audio event."""
         mxc_url = await self._upload_media(audio, content_type="audio/ogg", filename="audio.ogg")
-        import uuid
         txn_id = uuid.uuid4().hex
         await self._cs_put(
             f"/rooms/{_quote(chat_id)}/send/m.room.message/{txn_id}",
@@ -212,7 +212,7 @@ class MatrixGateway(GatewayChannelPort):
     # HTTP helpers
     # ------------------------------------------------------------------
 
-    def _headers(self) -> dict[str, str]:
+    def _cs_headers(self) -> dict[str, str]:
         return {
             "Authorization": f"Bearer {self._access_token}",
             "Content-Type": "application/json",
@@ -222,29 +222,14 @@ class MatrixGateway(GatewayChannelPort):
         self, path: str, params: dict[str, str | int] | None = None
     ) -> dict[str, Any]:
         url = f"{self._config.homeserver}{path}"
-        client = self._http_client
-        if client is not None:
-            resp = await client.get(url, headers=self._headers(), params=params)
-            resp.raise_for_status()
-            return resp.json()
-
-        async with httpx.AsyncClient(timeout=self._config.sync_timeout_ms / 1000.0 + 10.0) as c:
-            resp = await c.get(url, headers=self._headers(), params=params)
-            resp.raise_for_status()
-            return resp.json()
+        timeout = self._config.sync_timeout_ms / 1000.0 + 10.0
+        return await self._http_get(
+            url, headers=self._cs_headers(), params=params, timeout=timeout
+        )
 
     async def _cs_put(self, path: str, json: dict[str, Any]) -> dict[str, Any]:
         url = f"{self._config.homeserver}{path}"
-        client = self._http_client
-        if client is not None:
-            resp = await client.put(url, headers=self._headers(), json=json)
-            resp.raise_for_status()
-            return resp.json()
-
-        async with httpx.AsyncClient() as c:
-            resp = await c.put(url, headers=self._headers(), json=json)
-            resp.raise_for_status()
-            return resp.json()
+        return await self._http_put(url, headers=self._cs_headers(), json=json)
 
     async def _upload_media(
         self,
@@ -254,24 +239,18 @@ class MatrixGateway(GatewayChannelPort):
         filename: str,
     ) -> str:
         """Upload *data* to the homeserver media repo; returns the mxc:// URL."""
-        url = f"{self._config.homeserver}/_matrix/media/v3/upload?filename={filename}"
+        url = (
+            f"{self._config.homeserver}/_matrix/media/v3/upload"
+            f"?filename={quote(filename, safe='')}"
+        )
         headers = {
             "Authorization": f"Bearer {self._access_token}",
             "Content-Type": content_type,
         }
-        client = self._http_client
-        if client is not None:
-            resp = await client.post(url, headers=headers, content=data)
-            resp.raise_for_status()
-            return resp.json()["content_uri"]
-
-        async with httpx.AsyncClient() as c:
-            resp = await c.post(url, headers=headers, content=data)
-            resp.raise_for_status()
-            return resp.json()["content_uri"]
+        result = await self._http_post(url, headers=headers, content=data)
+        return result["content_uri"]
 
 
 def _quote(room_id: str) -> str:
     """URL-encode a Matrix room ID for use in path segments."""
-    from urllib.parse import quote
     return quote(room_id, safe="")

--- a/src/ravn/adapters/channels/gateway_matrix.py
+++ b/src/ravn/adapters/channels/gateway_matrix.py
@@ -1,0 +1,277 @@
+"""Matrix gateway adapter — Matrix client-server API via /sync long-polling.
+
+Design principles:
+- Uses the Matrix CS API ``/_matrix/client/v3/sync`` with a 30-second
+  long-poll timeout; no external library required (httpx only).
+- Supports sovereign self-hosted homeservers — no dependency on matrix.org.
+- E2E encryption flag is surfaced in config but not yet implemented;
+  a warning is logged if ``e2e: true`` is set.
+- chat_id: full Matrix room ID (e.g. ``"!abc:matrix.niuu.world"``).
+- Ignores its own messages (compares ``sender`` with the configured user_id).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any
+
+import httpx
+
+from ravn.adapters.channels.gateway import RavnGateway
+from ravn.config import MatrixChannelConfig
+from ravn.ports.gateway_channel import GatewayChannelPort, MessageHandler
+
+logger = logging.getLogger(__name__)
+
+# Matrix message event type for plain text
+_MSGTYPE_TEXT = "m.text"
+_EVENT_TYPE_MESSAGE = "m.room.message"
+
+
+class MatrixGateway(GatewayChannelPort):
+    """Polls a Matrix homeserver via /sync and routes messages to :class:`RavnGateway`.
+
+    Uses long-poll sync (``timeout`` query parameter) so events arrive quickly
+    without hammering the server.  The ``next_batch`` token is carried across
+    calls to avoid reprocessing events.
+    """
+
+    def __init__(
+        self,
+        config: MatrixChannelConfig,
+        gateway: RavnGateway,
+        *,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._config = config
+        self._gateway = gateway
+        self._user_id: str = os.environ.get(config.user_id_env, "")
+        self._access_token: str = os.environ.get(config.access_token_env, "")
+        self._handler: MessageHandler | None = None
+        self._http_client = http_client
+        self._task: asyncio.Task[None] | None = None
+        self._stop_event = asyncio.Event()
+        self._next_batch: str | None = None
+
+    # ------------------------------------------------------------------
+    # GatewayChannelPort interface
+    # ------------------------------------------------------------------
+
+    def on_message(self, handler: MessageHandler) -> None:
+        self._handler = handler
+
+    async def start(self) -> None:
+        """Validate credentials and launch the sync loop."""
+        if not self._access_token:
+            logger.error(
+                "Matrix access token env var %r is not set; Matrix gateway disabled.",
+                self._config.access_token_env,
+            )
+            return
+        if self._config.e2e:
+            logger.warning(
+                "Matrix E2E encryption requested but not yet implemented; "
+                "messages will be sent and received in plaintext."
+            )
+        self._stop_event.clear()
+        self._task = asyncio.create_task(self._run(), name="matrix-gateway")
+
+    async def stop(self) -> None:
+        """Stop the sync loop."""
+        self._stop_event.set()
+        if self._task is not None:
+            self._task.cancel()
+            await asyncio.gather(self._task, return_exceptions=True)
+            self._task = None
+
+    async def run(self) -> None:
+        """Start and run until cancelled (convenience for :func:`asyncio.create_task`)."""
+        await self.start()
+        if self._task is not None:
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+
+    async def send_text(self, chat_id: str, text: str) -> None:
+        """Send a plain-text message to Matrix room *chat_id*."""
+        limit = self._config.message_max_chars
+        if len(text) > limit:
+            text = text[: limit - 3] + "..."
+        import uuid
+        txn_id = uuid.uuid4().hex
+        await self._cs_put(
+            f"/rooms/{_quote(chat_id)}/send/{_EVENT_TYPE_MESSAGE}/{txn_id}",
+            json={
+                "msgtype": _MSGTYPE_TEXT,
+                "body": text,
+            },
+        )
+
+    async def send_image(self, chat_id: str, image: bytes, caption: str = "") -> None:
+        """Upload *image* to the homeserver and send an m.image event."""
+        mxc_url = await self._upload_media(image, content_type="image/png", filename="image.png")
+        import uuid
+        txn_id = uuid.uuid4().hex
+        await self._cs_put(
+            f"/rooms/{_quote(chat_id)}/send/m.room.message/{txn_id}",
+            json={
+                "msgtype": "m.image",
+                "body": caption or "image.png",
+                "url": mxc_url,
+            },
+        )
+
+    async def send_audio(self, chat_id: str, audio: bytes) -> None:
+        """Upload *audio* to the homeserver and send an m.audio event."""
+        mxc_url = await self._upload_media(audio, content_type="audio/ogg", filename="audio.ogg")
+        import uuid
+        txn_id = uuid.uuid4().hex
+        await self._cs_put(
+            f"/rooms/{_quote(chat_id)}/send/m.room.message/{txn_id}",
+            json={
+                "msgtype": "m.audio",
+                "body": "audio.ogg",
+                "url": mxc_url,
+            },
+        )
+
+    # ------------------------------------------------------------------
+    # Sync loop
+    # ------------------------------------------------------------------
+
+    async def _run(self) -> None:
+        """Run the /sync long-poll loop indefinitely."""
+        logger.info("Matrix gateway started (user: %s).", self._user_id)
+        while not self._stop_event.is_set():
+            try:
+                await self._sync_once()
+            except asyncio.CancelledError:
+                logger.info("Matrix gateway stopped.")
+                raise
+            except Exception:
+                logger.exception(
+                    "Matrix sync error; retrying in %.1fs.",
+                    self._config.retry_delay,
+                )
+                await asyncio.sleep(self._config.retry_delay)
+
+    async def _sync_once(self) -> None:
+        """Perform a single /sync call and dispatch any new messages."""
+        params: dict[str, str | int] = {
+            "timeout": self._config.sync_timeout_ms,
+            "filter": '{"room":{"timeline":{"limit":50}}}',
+        }
+        if self._next_batch is not None:
+            params["since"] = self._next_batch
+
+        data = await self._cs_get("/_matrix/client/v3/sync", params=params)  # type: ignore[arg-type]
+        self._next_batch = data.get("next_batch")
+
+        rooms = data.get("rooms", {})
+        joined = rooms.get("join", {})
+        for room_id, room_data in joined.items():
+            timeline = room_data.get("timeline", {})
+            for event in timeline.get("events", []):
+                await self._handle_event(room_id, event)
+
+    async def _handle_event(self, room_id: str, event: dict[str, Any]) -> None:
+        """Process a single Matrix room event."""
+        if event.get("type") != _EVENT_TYPE_MESSAGE:
+            return
+
+        sender: str = event.get("sender", "")
+        if sender == self._user_id:
+            return  # ignore own messages
+
+        content = event.get("content", {})
+        if content.get("msgtype") != _MSGTYPE_TEXT:
+            return
+
+        text: str = content.get("body", "").strip()
+        if not text:
+            return
+
+        chat_id = room_id
+        session_id = f"matrix:{room_id}"
+
+        try:
+            response = await self._gateway.handle_message(session_id, text)
+        except Exception:
+            logger.exception("Error processing Matrix message from room %s.", room_id)
+            response = "Sorry, something went wrong. Please try again."
+
+        await self.send_text(chat_id, response or "(no response)")
+
+        if self._handler is not None:
+            await self._handler(chat_id, text)
+
+    # ------------------------------------------------------------------
+    # HTTP helpers
+    # ------------------------------------------------------------------
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._access_token}",
+            "Content-Type": "application/json",
+        }
+
+    async def _cs_get(
+        self, path: str, params: dict[str, str | int] | None = None
+    ) -> dict[str, Any]:
+        url = f"{self._config.homeserver}{path}"
+        client = self._http_client
+        if client is not None:
+            resp = await client.get(url, headers=self._headers(), params=params)
+            resp.raise_for_status()
+            return resp.json()
+
+        async with httpx.AsyncClient(timeout=self._config.sync_timeout_ms / 1000.0 + 10.0) as c:
+            resp = await c.get(url, headers=self._headers(), params=params)
+            resp.raise_for_status()
+            return resp.json()
+
+    async def _cs_put(self, path: str, json: dict[str, Any]) -> dict[str, Any]:
+        url = f"{self._config.homeserver}{path}"
+        client = self._http_client
+        if client is not None:
+            resp = await client.put(url, headers=self._headers(), json=json)
+            resp.raise_for_status()
+            return resp.json()
+
+        async with httpx.AsyncClient() as c:
+            resp = await c.put(url, headers=self._headers(), json=json)
+            resp.raise_for_status()
+            return resp.json()
+
+    async def _upload_media(
+        self,
+        data: bytes,
+        *,
+        content_type: str,
+        filename: str,
+    ) -> str:
+        """Upload *data* to the homeserver media repo; returns the mxc:// URL."""
+        url = f"{self._config.homeserver}/_matrix/media/v3/upload?filename={filename}"
+        headers = {
+            "Authorization": f"Bearer {self._access_token}",
+            "Content-Type": content_type,
+        }
+        client = self._http_client
+        if client is not None:
+            resp = await client.post(url, headers=headers, content=data)
+            resp.raise_for_status()
+            return resp.json()["content_uri"]
+
+        async with httpx.AsyncClient() as c:
+            resp = await c.post(url, headers=headers, content=data)
+            resp.raise_for_status()
+            return resp.json()["content_uri"]
+
+
+def _quote(room_id: str) -> str:
+    """URL-encode a Matrix room ID for use in path segments."""
+    from urllib.parse import quote
+    return quote(room_id, safe="")

--- a/src/ravn/adapters/channels/gateway_slack.py
+++ b/src/ravn/adapters/channels/gateway_slack.py
@@ -24,27 +24,26 @@ from typing import Any
 
 import httpx
 
+from ravn.adapters.channels._http_mixin import GatewayHttpMixin
+from ravn.adapters.channels._slash_commands import GATEWAY_SLASH_PROMPTS
 from ravn.adapters.channels.gateway import RavnGateway
 from ravn.config import SlackChannelConfig
 from ravn.ports.gateway_channel import GatewayChannelPort, MessageHandler
 
 logger = logging.getLogger(__name__)
 
-# Slack slash commands → agent prompts
+# Slack slash commands → agent prompts.
+# Uses ravn- prefixed variants to avoid collisions with other Slack apps.
 _SLASH_PROMPTS: dict[str, str] = {
-    "/ravn-stop": (
-        "Please acknowledge that you are stopping and summarise what you were working on."
-    ),
-    "/ravn-status": "What is your current task status? Summarise briefly.",
-    "/ravn-todo": "List your current todo items.",
-    "/ravn-budget": "How many iterations have you used and how many remain in your budget?",
+    f"/ravn-{cmd.lstrip('/')}": prompt
+    for cmd, prompt in GATEWAY_SLASH_PROMPTS.items()
 }
 
 # Mention pattern prefix that triggers the agent (e.g. "<@UBOT123> hello")
 _MENTION_PREFIX = "<@"
 
 
-class SlackGateway(GatewayChannelPort):
+class SlackGateway(GatewayHttpMixin, GatewayChannelPort):
     """Polls Slack channels and routes messages through :class:`RavnGateway`.
 
     Each call to :meth:`watch_channel` registers a channel to monitor.  On
@@ -279,32 +278,17 @@ class SlackGateway(GatewayChannelPort):
         command = text.split()[0].lower()
         return _SLASH_PROMPTS.get(command, text)
 
+    def _slack_headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self._bot_token}"}
+
     async def _api_post(self, method: str, **kwargs: Any) -> dict[str, Any]:
         """POST to the Slack Web API; raises on error."""
         url = f"{self._config.api_base}/{method}"
-        headers = {"Authorization": f"Bearer {self._bot_token}"}
-        client = self._http_client
-        if client is not None:
-            resp = await client.post(url, headers=headers, **kwargs)
-            resp.raise_for_status()
-            return resp.json()
+        return await self._http_post(url, headers=self._slack_headers(), **kwargs)
 
-        async with httpx.AsyncClient() as c:
-            resp = await c.post(url, headers=headers, **kwargs)
-            resp.raise_for_status()
-            return resp.json()
-
-    async def _api_get(self, method: str, params: dict[str, str] | None = None) -> dict[str, Any]:
+    async def _api_get(
+        self, method: str, params: dict[str, str] | None = None
+    ) -> dict[str, Any]:
         """GET from the Slack Web API."""
         url = f"{self._config.api_base}/{method}"
-        headers = {"Authorization": f"Bearer {self._bot_token}"}
-        client = self._http_client
-        if client is not None:
-            resp = await client.get(url, headers=headers, params=params)
-            resp.raise_for_status()
-            return resp.json()
-
-        async with httpx.AsyncClient() as c:
-            resp = await c.get(url, headers=headers, params=params)
-            resp.raise_for_status()
-            return resp.json()
+        return await self._http_get(url, headers=self._slack_headers(), params=params)

--- a/src/ravn/adapters/channels/gateway_slack.py
+++ b/src/ravn/adapters/channels/gateway_slack.py
@@ -1,0 +1,310 @@
+"""Slack gateway adapter — polling via conversations.history + REST API.
+
+Design principles:
+- Polls ``conversations.history`` on a configurable interval for each watched
+  channel; tracks the ``latest`` timestamp to avoid reprocessing messages.
+- Bot token authentication (xoxb-...).
+- ``@Ravn`` app mentions in any channel trigger an agent turn.
+- Slash commands forwarded to the bot DM are translated to agent prompts.
+- Block Kit used for structured tool output (code blocks, lists).
+- chat_id: Slack channel ID (e.g. ``"C0123ABCDE"``).
+
+Note: Socket Mode (real-time events without polling) requires an app-level
+token (xapp-...).  Configure ``app_token_env`` to enable it; falls back to
+polling when not set.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from typing import Any
+
+import httpx
+
+from ravn.adapters.channels.gateway import RavnGateway
+from ravn.config import SlackChannelConfig
+from ravn.ports.gateway_channel import GatewayChannelPort, MessageHandler
+
+logger = logging.getLogger(__name__)
+
+# Slack slash commands → agent prompts
+_SLASH_PROMPTS: dict[str, str] = {
+    "/ravn-stop": (
+        "Please acknowledge that you are stopping and summarise what you were working on."
+    ),
+    "/ravn-status": "What is your current task status? Summarise briefly.",
+    "/ravn-todo": "List your current todo items.",
+    "/ravn-budget": "How many iterations have you used and how many remain in your budget?",
+}
+
+# Mention pattern prefix that triggers the agent (e.g. "<@UBOT123> hello")
+_MENTION_PREFIX = "<@"
+
+
+class SlackGateway(GatewayChannelPort):
+    """Polls Slack channels and routes messages through :class:`RavnGateway`.
+
+    Each call to :meth:`watch_channel` registers a channel to monitor.  On
+    each poll tick, new messages are fetched and dispatched.  The bot's own
+    user ID is resolved on startup and used to filter self-messages.
+    """
+
+    def __init__(
+        self,
+        config: SlackChannelConfig,
+        gateway: RavnGateway,
+        *,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._config = config
+        self._gateway = gateway
+        self._bot_token: str = os.environ.get(config.bot_token_env, "")
+        self._handler: MessageHandler | None = None
+        self._http_client = http_client
+        self._task: asyncio.Task[None] | None = None
+        self._stop_event = asyncio.Event()
+        # channel_id → latest message timestamp seen
+        self._channel_cursors: dict[str, str] = {}
+        # Channels to monitor (populated on start from the bot's channel membership)
+        self._watched_channels: list[str] = []
+        self._bot_user_id: str = ""
+
+    # ------------------------------------------------------------------
+    # GatewayChannelPort interface
+    # ------------------------------------------------------------------
+
+    def on_message(self, handler: MessageHandler) -> None:
+        self._handler = handler
+
+    async def start(self) -> None:
+        """Resolve the bot identity and launch the polling loop."""
+        if not self._bot_token:
+            logger.error(
+                "Slack bot token env var %r is not set; Slack gateway disabled.",
+                self._config.bot_token_env,
+            )
+            return
+        self._stop_event.clear()
+        self._task = asyncio.create_task(self._run(), name="slack-gateway")
+
+    async def stop(self) -> None:
+        """Stop the polling loop."""
+        self._stop_event.set()
+        if self._task is not None:
+            self._task.cancel()
+            await asyncio.gather(self._task, return_exceptions=True)
+            self._task = None
+
+    async def run(self) -> None:
+        """Start and run until cancelled (convenience for :func:`asyncio.create_task`)."""
+        await self.start()
+        if self._task is not None:
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+
+    async def send_text(self, chat_id: str, text: str) -> None:
+        """Post *text* to the Slack channel *chat_id*."""
+        limit = self._config.message_max_chars
+        if len(text) > limit:
+            text = text[: limit - 3] + "..."
+        await self._api_post(
+            "chat.postMessage",
+            json={"channel": chat_id, "text": text},
+        )
+
+    async def send_image(self, chat_id: str, image: bytes, caption: str = "") -> None:
+        """Upload *image* bytes to *chat_id* via files.upload."""
+        await self._api_post(
+            "files.upload",
+            data={
+                "channels": chat_id,
+                "initial_comment": caption,
+                "filename": "image.png",
+            },
+            content=image,
+        )
+
+    async def send_audio(self, chat_id: str, audio: bytes) -> None:
+        """Upload *audio* bytes to *chat_id* via files.upload."""
+        await self._api_post(
+            "files.upload",
+            data={
+                "channels": chat_id,
+                "filename": "audio.ogg",
+            },
+            content=audio,
+        )
+
+    # ------------------------------------------------------------------
+    # Polling loop
+    # ------------------------------------------------------------------
+
+    async def _run(self) -> None:
+        """Resolve bot identity then poll indefinitely."""
+        try:
+            await self._resolve_bot_identity()
+            await self._discover_channels()
+            logger.info("Slack gateway started (bot: %s).", self._bot_user_id)
+        except Exception:
+            logger.exception("Slack gateway startup failed.")
+            return
+
+        while not self._stop_event.is_set():
+            try:
+                await self._poll_all_channels()
+            except asyncio.CancelledError:
+                logger.info("Slack gateway stopped.")
+                raise
+            except Exception:
+                logger.exception(
+                    "Slack poll error; retrying in %.1fs.",
+                    self._config.retry_delay,
+                )
+                await asyncio.sleep(self._config.retry_delay)
+                continue
+
+            await asyncio.sleep(self._config.poll_interval)
+
+    async def _resolve_bot_identity(self) -> None:
+        """Call auth.test to get the bot's user ID."""
+        data = await self._api_post("auth.test", json={})
+        self._bot_user_id = data.get("user_id", "")
+
+    async def _discover_channels(self) -> None:
+        """Fetch channels the bot is a member of."""
+        data = await self._api_get(
+            "conversations.list",
+            params={"types": "public_channel,private_channel,im,mpim", "exclude_archived": "true"},
+        )
+        channels = data.get("channels", [])
+        self._watched_channels = [
+            c["id"] for c in channels if c.get("is_member")
+        ]
+        # Seed cursors to current time so we only process new messages
+        now = str(time.time())
+        for cid in self._watched_channels:
+            self._channel_cursors.setdefault(cid, now)
+        logger.debug("Slack watching %d channel(s).", len(self._watched_channels))
+
+    async def _poll_all_channels(self) -> None:
+        """Poll each watched channel for new messages."""
+        for channel_id in list(self._watched_channels):
+            await self._poll_channel(channel_id)
+
+    async def _poll_channel(self, channel_id: str) -> None:
+        """Fetch new messages from *channel_id* since last cursor."""
+        oldest = self._channel_cursors.get(channel_id, "0")
+        params: dict[str, str] = {
+            "channel": channel_id,
+            "oldest": oldest,
+            "limit": "50",
+            "inclusive": "false",
+        }
+        try:
+            data = await self._api_get("conversations.history", params=params)
+        except Exception:
+            logger.warning("Failed to poll Slack channel %s.", channel_id)
+            return
+
+        messages: list[dict[str, Any]] = data.get("messages", [])
+        # Slack returns newest first; reverse to process oldest first
+        for msg in reversed(messages):
+            ts: str = msg.get("ts", "")
+            # Advance cursor
+            if ts > oldest:
+                self._channel_cursors[channel_id] = ts
+
+            # Skip bot messages and sub-type messages (edits, joins, etc.)
+            if msg.get("bot_id") or msg.get("subtype"):
+                continue
+            if msg.get("user") == self._bot_user_id:
+                continue
+
+            text: str = msg.get("text", "").strip()
+            if not text:
+                continue
+
+            # Only react if the bot is mentioned or it's a DM channel
+            if not self._should_handle(channel_id, text):
+                continue
+
+            # Strip the mention from the text
+            clean_text = self._strip_mention(text)
+            prompt = self._translate_slash(clean_text)
+            session_id = f"slack:{channel_id}"
+
+            try:
+                response = await self._gateway.handle_message(session_id, prompt)
+            except Exception:
+                logger.exception("Error processing Slack message from %s.", channel_id)
+                response = "Sorry, something went wrong. Please try again."
+
+            await self.send_text(channel_id, response or "(no response)")
+
+            if self._handler is not None:
+                await self._handler(channel_id, clean_text)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _should_handle(self, channel_id: str, text: str) -> bool:
+        """Return True if the message should be forwarded to the agent."""
+        # Always handle DMs (channel IDs starting with 'D')
+        if channel_id.startswith("D"):
+            return True
+        # Handle @mentions
+        if self._bot_user_id and f"<@{self._bot_user_id}>" in text:
+            return True
+        # Handle slash commands targeting Ravn
+        first_word = text.split()[0].lower() if text else ""
+        return first_word in _SLASH_PROMPTS
+
+    def _strip_mention(self, text: str) -> str:
+        """Remove the bot mention prefix from *text*."""
+        if self._bot_user_id:
+            mention = f"<@{self._bot_user_id}>"
+            text = text.replace(mention, "").strip()
+        return text
+
+    def _translate_slash(self, text: str) -> str:
+        """Return the natural-language prompt for a Ravn slash command, or *text*."""
+        if not text.startswith("/"):
+            return text
+        command = text.split()[0].lower()
+        return _SLASH_PROMPTS.get(command, text)
+
+    async def _api_post(self, method: str, **kwargs: Any) -> dict[str, Any]:
+        """POST to the Slack Web API; raises on error."""
+        url = f"{self._config.api_base}/{method}"
+        headers = {"Authorization": f"Bearer {self._bot_token}"}
+        client = self._http_client
+        if client is not None:
+            resp = await client.post(url, headers=headers, **kwargs)
+            resp.raise_for_status()
+            return resp.json()
+
+        async with httpx.AsyncClient() as c:
+            resp = await c.post(url, headers=headers, **kwargs)
+            resp.raise_for_status()
+            return resp.json()
+
+    async def _api_get(self, method: str, params: dict[str, str] | None = None) -> dict[str, Any]:
+        """GET from the Slack Web API."""
+        url = f"{self._config.api_base}/{method}"
+        headers = {"Authorization": f"Bearer {self._bot_token}"}
+        client = self._http_client
+        if client is not None:
+            resp = await client.get(url, headers=headers, params=params)
+            resp.raise_for_status()
+            return resp.json()
+
+        async with httpx.AsyncClient() as c:
+            resp = await c.get(url, headers=headers, params=params)
+            resp.raise_for_status()
+            return resp.json()

--- a/src/ravn/adapters/channels/gateway_telegram.py
+++ b/src/ravn/adapters/channels/gateway_telegram.py
@@ -18,6 +18,7 @@ from typing import Any
 
 import httpx
 
+from ravn.adapters.channels._slash_commands import GATEWAY_SLASH_PROMPTS
 from ravn.adapters.channels.gateway import RavnGateway
 from ravn.config import TelegramChannelConfig
 
@@ -26,12 +27,7 @@ logger = logging.getLogger(__name__)
 _TELEGRAM_API_BASE = "https://api.telegram.org/bot{token}/{method}"
 
 # Slash commands recognised by the gateway; translated to agent prompts.
-_SLASH_PROMPTS: dict[str, str] = {
-    "/stop": "Please acknowledge that you are stopping and summarise what you were working on.",
-    "/status": "What is your current task status? Summarise briefly.",
-    "/todo": "List your current todo items.",
-    "/budget": "How many iterations have you used and how many remain in your budget?",
-}
+_SLASH_PROMPTS: dict[str, str] = GATEWAY_SLASH_PROMPTS
 
 # Bot command definitions registered with Telegram via setMyCommands.
 _BOT_COMMANDS: list[dict[str, str]] = [

--- a/src/ravn/adapters/channels/gateway_whatsapp.py
+++ b/src/ravn/adapters/channels/gateway_whatsapp.py
@@ -1,0 +1,273 @@
+"""WhatsApp gateway adapter — Meta Cloud API (Business API mode).
+
+Design principles:
+- Sends messages via Meta Graph API: ``POST /v18.0/{phone_number_id}/messages``.
+- Receives messages via a Meta webhook (HTTP POST from Meta's servers).
+- Runs a lightweight FastAPI app on a configurable port for webhook delivery.
+- chat_id: E.164 phone number (e.g. ``"+4412345678"``) or group JID.
+- ``mode: local_bridge`` is a future extension (whatsapp-web.js); currently
+  raises :class:`NotImplementedError` to avoid silent misconfiguration.
+- The webhook GET endpoint handles Meta's challenge verification flow.
+- Voice messages are flagged and routed with a note (STT depends on NIU-533).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any
+
+import httpx
+
+from ravn.adapters.channels.gateway import RavnGateway
+from ravn.config import WhatsAppChannelConfig
+from ravn.ports.gateway_channel import GatewayChannelPort, MessageHandler
+
+logger = logging.getLogger(__name__)
+
+
+class WhatsAppGateway(GatewayChannelPort):
+    """Routes WhatsApp messages to :class:`RavnGateway` via the Meta Cloud API.
+
+    Start this adapter alongside the HTTP gateway to expose a webhook endpoint
+    that Meta's servers will POST incoming messages to.
+
+    Requires:
+    * ``WA_API_KEY`` env var — Meta bearer token.
+    * ``WA_PHONE_NUMBER_ID`` env var — phone number ID from Meta dashboard.
+    * ``WA_WEBHOOK_VERIFY_TOKEN`` env var — verification token registered in
+      the Meta developer console.
+    * An externally reachable URL configured in the Meta app console pointing
+      to ``http://<host>:<port>/webhook``.
+    """
+
+    def __init__(
+        self,
+        config: WhatsAppChannelConfig,
+        gateway: RavnGateway,
+        *,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        if config.mode == "local_bridge":
+            raise NotImplementedError(
+                "WhatsApp local_bridge mode (whatsapp-web.js) is not yet implemented. "
+                "Use mode: business_api with the Meta Cloud API."
+            )
+        self._config = config
+        self._gateway = gateway
+        self._api_key: str = os.environ.get(config.api_key_env, "")
+        self._phone_number_id: str = os.environ.get(config.phone_number_id_env, "")
+        self._verify_token: str = os.environ.get(config.webhook_verify_token_env, "")
+        self._handler: MessageHandler | None = None
+        self._http_client = http_client
+        self._server_task: asyncio.Task[None] | None = None
+
+    # ------------------------------------------------------------------
+    # GatewayChannelPort interface
+    # ------------------------------------------------------------------
+
+    def on_message(self, handler: MessageHandler) -> None:
+        self._handler = handler
+
+    async def start(self) -> None:
+        """Start the webhook HTTP server."""
+        if not self._api_key:
+            logger.error(
+                "WhatsApp API key env var %r is not set; WhatsApp gateway disabled.",
+                self._config.api_key_env,
+            )
+            return
+        self._server_task = asyncio.create_task(
+            self._run_webhook_server(), name="whatsapp-webhook"
+        )
+
+    async def stop(self) -> None:
+        """Stop the webhook HTTP server."""
+        if self._server_task is not None:
+            self._server_task.cancel()
+            await asyncio.gather(self._server_task, return_exceptions=True)
+            self._server_task = None
+
+    async def run(self) -> None:
+        """Start and run until cancelled (convenience for :func:`asyncio.create_task`)."""
+        await self.start()
+        if self._server_task is not None:
+            try:
+                await self._server_task
+            except asyncio.CancelledError:
+                pass
+
+    async def send_text(self, chat_id: str, text: str) -> None:
+        """Send a text message to *chat_id* via the Meta Cloud API."""
+        limit = self._config.message_max_chars
+        if len(text) > limit:
+            text = text[: limit - 3] + "..."
+        payload = {
+            "messaging_product": "whatsapp",
+            "to": chat_id,
+            "type": "text",
+            "text": {"body": text},
+        }
+        await self._graph_post(f"/{self._phone_number_id}/messages", json=payload)
+
+    async def send_image(self, chat_id: str, image: bytes, caption: str = "") -> None:
+        """Upload *image* via Meta and send as an image message."""
+        media_id = await self._upload_media(image, mime_type="image/png")
+        payload = {
+            "messaging_product": "whatsapp",
+            "to": chat_id,
+            "type": "image",
+            "image": {"id": media_id, "caption": caption},
+        }
+        await self._graph_post(f"/{self._phone_number_id}/messages", json=payload)
+
+    async def send_audio(self, chat_id: str, audio: bytes) -> None:
+        """Upload *audio* via Meta and send as an audio message."""
+        media_id = await self._upload_media(audio, mime_type="audio/ogg")
+        payload = {
+            "messaging_product": "whatsapp",
+            "to": chat_id,
+            "type": "audio",
+            "audio": {"id": media_id},
+        }
+        await self._graph_post(f"/{self._phone_number_id}/messages", json=payload)
+
+    # ------------------------------------------------------------------
+    # Webhook server
+    # ------------------------------------------------------------------
+
+    async def _run_webhook_server(self) -> None:  # pragma: no cover
+        """Run a FastAPI webhook server on the configured host:port."""
+        import uvicorn
+        from fastapi import FastAPI, Query, Request, Response
+
+        app = FastAPI(title="Ravn WhatsApp Webhook", docs_url=None, redoc_url=None)
+
+        @app.get("/webhook")
+        async def verify(
+            hub_mode: str = Query(default="", alias="hub.mode"),
+            hub_verify_token: str = Query(default="", alias="hub.verify_token"),
+            hub_challenge: str = Query(default="", alias="hub.challenge"),
+        ) -> Response:
+            """Meta webhook verification (GET challenge-response)."""
+            if hub_mode == "subscribe" and hub_verify_token == self._verify_token:
+                return Response(content=hub_challenge, media_type="text/plain")
+            return Response(status_code=403)
+
+        @app.post("/webhook")
+        async def receive(request: Request) -> dict[str, str]:
+            """Handle inbound message events from Meta."""
+            body: dict[str, Any] = await request.json()
+            await self._handle_webhook_body(body)
+            return {"status": "ok"}
+
+        config = uvicorn.Config(
+            app,
+            host=self._config.webhook_host,
+            port=self._config.webhook_port,
+            log_level="warning",
+        )
+        server = uvicorn.Server(config)
+        logger.info(
+            "WhatsApp webhook listening on %s:%s",
+            self._config.webhook_host,
+            self._config.webhook_port,
+        )
+        try:
+            await server.serve()
+        except asyncio.CancelledError:
+            logger.info("WhatsApp webhook server stopped.")
+            raise
+
+    async def _handle_webhook_body(self, body: dict[str, Any]) -> None:
+        """Parse and dispatch a Meta webhook payload."""
+        for entry in body.get("entry", []):
+            for change in entry.get("changes", []):
+                value = change.get("value", {})
+                messages: list[dict[str, Any]] = value.get("messages", [])
+                for msg in messages:
+                    await self._handle_message(msg)
+
+    async def _handle_message(self, msg: dict[str, Any]) -> None:
+        """Process a single WhatsApp message object."""
+        msg_type: str = msg.get("type", "")
+        from_number: str = msg.get("from", "")
+        chat_id = from_number
+
+        if msg_type == "text":
+            text: str = msg.get("text", {}).get("body", "").strip()
+        elif msg_type == "audio":
+            # Voice message — STT pipeline depends on NIU-533
+            text = "[Voice message received — STT transcription pending NIU-533]"
+        elif msg_type == "image":
+            caption = msg.get("image", {}).get("caption", "")
+            text = caption or "[Image received]"
+        else:
+            logger.debug("WhatsApp: ignoring message type %r from %s.", msg_type, from_number)
+            return
+
+        if not text:
+            return
+
+        session_id = f"whatsapp:{chat_id}"
+
+        try:
+            response = await self._gateway.handle_message(session_id, text)
+        except Exception:
+            logger.exception("Error processing WhatsApp message from %s.", chat_id)
+            response = "Sorry, something went wrong. Please try again."
+
+        await self.send_text(chat_id, response or "(no response)")
+
+        if self._handler is not None:
+            await self._handler(chat_id, text)
+
+    # ------------------------------------------------------------------
+    # HTTP helpers
+    # ------------------------------------------------------------------
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+        }
+
+    async def _graph_post(self, path: str, json: dict[str, Any]) -> dict[str, Any]:
+        """POST to the Meta Graph API."""
+        url = f"{self._config.api_base}{path}"
+        client = self._http_client
+        if client is not None:
+            resp = await client.post(url, headers=self._headers(), json=json)
+            resp.raise_for_status()
+            return resp.json()
+
+        async with httpx.AsyncClient() as c:  # pragma: no cover
+            resp = await c.post(url, headers=self._headers(), json=json)  # pragma: no cover
+            resp.raise_for_status()  # pragma: no cover
+            return resp.json()  # pragma: no cover
+
+    async def _upload_media(self, data: bytes, *, mime_type: str) -> str:
+        """Upload *data* to Meta's media endpoint; returns the media ID."""
+        url = f"{self._config.api_base}/{self._phone_number_id}/media"
+        headers = {"Authorization": f"Bearer {self._api_key}"}
+        client = self._http_client
+        if client is not None:
+            resp = await client.post(
+                url,
+                headers=headers,
+                files={"file": ("media", data, mime_type)},
+                data={"messaging_product": "whatsapp"},
+            )
+            resp.raise_for_status()
+            return resp.json()["id"]
+
+        async with httpx.AsyncClient() as c:  # pragma: no cover
+            resp = await c.post(  # pragma: no cover
+                url,
+                headers=headers,
+                files={"file": ("media", data, mime_type)},
+                data={"messaging_product": "whatsapp"},
+            )
+            resp.raise_for_status()  # pragma: no cover
+            return resp.json()["id"]  # pragma: no cover

--- a/src/ravn/adapters/channels/gateway_whatsapp.py
+++ b/src/ravn/adapters/channels/gateway_whatsapp.py
@@ -14,12 +14,16 @@ Design principles:
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import hmac
+import json
 import logging
 import os
 from typing import Any
 
 import httpx
 
+from ravn.adapters.channels._http_mixin import GatewayHttpMixin
 from ravn.adapters.channels.gateway import RavnGateway
 from ravn.config import WhatsAppChannelConfig
 from ravn.ports.gateway_channel import GatewayChannelPort, MessageHandler
@@ -27,7 +31,7 @@ from ravn.ports.gateway_channel import GatewayChannelPort, MessageHandler
 logger = logging.getLogger(__name__)
 
 
-class WhatsAppGateway(GatewayChannelPort):
+class WhatsAppGateway(GatewayHttpMixin, GatewayChannelPort):
     """Routes WhatsApp messages to :class:`RavnGateway` via the Meta Cloud API.
 
     Start this adapter alongside the HTTP gateway to expose a webhook endpoint
@@ -59,6 +63,7 @@ class WhatsAppGateway(GatewayChannelPort):
         self._api_key: str = os.environ.get(config.api_key_env, "")
         self._phone_number_id: str = os.environ.get(config.phone_number_id_env, "")
         self._verify_token: str = os.environ.get(config.webhook_verify_token_env, "")
+        self._webhook_secret: str = os.environ.get(config.webhook_secret_env, "")
         self._handler: MessageHandler | None = None
         self._http_client = http_client
         self._server_task: asyncio.Task[None] | None = None
@@ -156,9 +161,13 @@ class WhatsAppGateway(GatewayChannelPort):
             return Response(status_code=403)
 
         @app.post("/webhook")
-        async def receive(request: Request) -> dict[str, str]:
+        async def receive(request: Request) -> Response | dict[str, str]:
             """Handle inbound message events from Meta."""
-            body: dict[str, Any] = await request.json()
+            body_bytes = await request.body()
+            signature = request.headers.get("X-Hub-Signature-256", "")
+            if not self._verify_signature(body_bytes, signature):
+                return Response(status_code=403)
+            body: dict[str, Any] = json.loads(body_bytes)
             await self._handle_webhook_body(body)
             return {"status": "ok"}
 
@@ -227,7 +236,7 @@ class WhatsAppGateway(GatewayChannelPort):
     # HTTP helpers
     # ------------------------------------------------------------------
 
-    def _headers(self) -> dict[str, str]:
+    def _graph_headers(self) -> dict[str, str]:
         return {
             "Authorization": f"Bearer {self._api_key}",
             "Content-Type": "application/json",
@@ -236,38 +245,29 @@ class WhatsAppGateway(GatewayChannelPort):
     async def _graph_post(self, path: str, json: dict[str, Any]) -> dict[str, Any]:
         """POST to the Meta Graph API."""
         url = f"{self._config.api_base}{path}"
-        client = self._http_client
-        if client is not None:
-            resp = await client.post(url, headers=self._headers(), json=json)
-            resp.raise_for_status()
-            return resp.json()
-
-        async with httpx.AsyncClient() as c:  # pragma: no cover
-            resp = await c.post(url, headers=self._headers(), json=json)  # pragma: no cover
-            resp.raise_for_status()  # pragma: no cover
-            return resp.json()  # pragma: no cover
+        return await self._http_post(url, headers=self._graph_headers(), json=json)
 
     async def _upload_media(self, data: bytes, *, mime_type: str) -> str:
         """Upload *data* to Meta's media endpoint; returns the media ID."""
         url = f"{self._config.api_base}/{self._phone_number_id}/media"
         headers = {"Authorization": f"Bearer {self._api_key}"}
-        client = self._http_client
-        if client is not None:
-            resp = await client.post(
-                url,
-                headers=headers,
-                files={"file": ("media", data, mime_type)},
-                data={"messaging_product": "whatsapp"},
-            )
-            resp.raise_for_status()
-            return resp.json()["id"]
+        result = await self._http_post(
+            url,
+            headers=headers,
+            files={"file": ("media", data, mime_type)},
+            data={"messaging_product": "whatsapp"},
+        )
+        return result["id"]
 
-        async with httpx.AsyncClient() as c:  # pragma: no cover
-            resp = await c.post(  # pragma: no cover
-                url,
-                headers=headers,
-                files={"file": ("media", data, mime_type)},
-                data={"messaging_product": "whatsapp"},
-            )
-            resp.raise_for_status()  # pragma: no cover
-            return resp.json()["id"]  # pragma: no cover
+    def _verify_signature(self, body: bytes, signature: str) -> bool:
+        """Verify the Meta X-Hub-Signature-256 header.
+
+        Returns ``True`` when no secret is configured (verification disabled)
+        or when the HMAC digest matches.  Returns ``False`` on mismatch.
+        """
+        if not self._webhook_secret:
+            return True
+        expected = "sha256=" + hmac.new(
+            self._webhook_secret.encode(), body, hashlib.sha256
+        ).hexdigest()
+        return hmac.compare_digest(expected, signature)

--- a/src/ravn/cli/commands.py
+++ b/src/ravn/cli/commands.py
@@ -1329,6 +1329,44 @@ def gateway(
     asyncio.run(_run_gateway(settings, persona_config=persona_config))
 
 
+def _make_channel_tasks(
+    channels_cfg: Any,
+    gw: Any,
+) -> list[tuple[Any, str]]:
+    """Create asyncio tasks for the four extended gateway channel adapters.
+
+    Returns a list of ``(task, name)`` pairs so callers can populate both
+    a task list and a display list without duplicating the if-chain.
+    """
+    from ravn.adapters.channels.gateway_discord import DiscordGateway
+    from ravn.adapters.channels.gateway_matrix import MatrixGateway
+    from ravn.adapters.channels.gateway_slack import SlackGateway
+    from ravn.adapters.channels.gateway_whatsapp import WhatsAppGateway
+
+    pairs: list[tuple[Any, str]] = []
+    if channels_cfg.discord.enabled:
+        task = asyncio.create_task(
+            DiscordGateway(channels_cfg.discord, gw).run(), name="discord"
+        )
+        pairs.append((task, "discord"))
+    if channels_cfg.slack.enabled:
+        task = asyncio.create_task(
+            SlackGateway(channels_cfg.slack, gw).run(), name="slack"
+        )
+        pairs.append((task, "slack"))
+    if channels_cfg.matrix.enabled:
+        task = asyncio.create_task(
+            MatrixGateway(channels_cfg.matrix, gw).run(), name="matrix"
+        )
+        pairs.append((task, "matrix"))
+    if channels_cfg.whatsapp.enabled:
+        task = asyncio.create_task(
+            WhatsAppGateway(channels_cfg.whatsapp, gw).run(), name="whatsapp"
+        )
+        pairs.append((task, "whatsapp"))
+    return pairs
+
+
 async def _run_gateway(
     settings: Settings,
     *,
@@ -1336,12 +1374,8 @@ async def _run_gateway(
 ) -> None:
     """Build and run the gateway until interrupted."""
     from ravn.adapters.channels.gateway import RavnGateway
-    from ravn.adapters.channels.gateway_discord import DiscordGateway
     from ravn.adapters.channels.gateway_http import HttpGateway
-    from ravn.adapters.channels.gateway_matrix import MatrixGateway
-    from ravn.adapters.channels.gateway_slack import SlackGateway
     from ravn.adapters.channels.gateway_telegram import TelegramGateway
-    from ravn.adapters.channels.gateway_whatsapp import WhatsAppGateway
     from ravn.budget import IterationBudget
     from ravn.ports.channel import ChannelPort
 
@@ -1451,21 +1485,8 @@ async def _run_gateway(
         ht = HttpGateway(settings.gateway.channels.http, gw)
         tasks.append(asyncio.create_task(ht.run(), name="http"))
 
-    if settings.gateway.channels.discord.enabled:
-        dc = DiscordGateway(settings.gateway.channels.discord, gw)
-        tasks.append(asyncio.create_task(dc.run(), name="discord"))
-
-    if settings.gateway.channels.slack.enabled:
-        sl = SlackGateway(settings.gateway.channels.slack, gw)
-        tasks.append(asyncio.create_task(sl.run(), name="slack"))
-
-    if settings.gateway.channels.matrix.enabled:
-        mx = MatrixGateway(settings.gateway.channels.matrix, gw)
-        tasks.append(asyncio.create_task(mx.run(), name="matrix"))
-
-    if settings.gateway.channels.whatsapp.enabled:
-        wa = WhatsAppGateway(settings.gateway.channels.whatsapp, gw)
-        tasks.append(asyncio.create_task(wa.run(), name="whatsapp"))
+    for task, _ in _make_channel_tasks(settings.gateway.channels, gw):
+        tasks.append(task)
 
     typer.echo(f"Gateway started ({len(tasks)} channel(s) active). Press Ctrl+C to stop.")
 
@@ -1549,12 +1570,8 @@ async def _run_daemon(
 ) -> None:
     """Build and run the gateway + drive loop until interrupted."""
     from ravn.adapters.channels.gateway import RavnGateway
-    from ravn.adapters.channels.gateway_discord import DiscordGateway
     from ravn.adapters.channels.gateway_http import HttpGateway
-    from ravn.adapters.channels.gateway_matrix import MatrixGateway
-    from ravn.adapters.channels.gateway_slack import SlackGateway
     from ravn.adapters.channels.gateway_telegram import TelegramGateway
-    from ravn.adapters.channels.gateway_whatsapp import WhatsAppGateway
     from ravn.budget import IterationBudget
     from ravn.drive_loop import DriveLoop
     from ravn.ports.channel import ChannelPort
@@ -1673,25 +1690,9 @@ async def _run_daemon(
             tasks.append(asyncio.create_task(ht.run(), name="http"))
             gw_tasks.append("http")
 
-        if channels_cfg.discord.enabled:
-            dc = DiscordGateway(channels_cfg.discord, gw)
-            tasks.append(asyncio.create_task(dc.run(), name="discord"))
-            gw_tasks.append("discord")
-
-        if channels_cfg.slack.enabled:
-            sl = SlackGateway(channels_cfg.slack, gw)
-            tasks.append(asyncio.create_task(sl.run(), name="slack"))
-            gw_tasks.append("slack")
-
-        if channels_cfg.matrix.enabled:
-            mx = MatrixGateway(channels_cfg.matrix, gw)
-            tasks.append(asyncio.create_task(mx.run(), name="matrix"))
-            gw_tasks.append("matrix")
-
-        if channels_cfg.whatsapp.enabled:
-            wa = WhatsAppGateway(channels_cfg.whatsapp, gw)
-            tasks.append(asyncio.create_task(wa.run(), name="whatsapp"))
-            gw_tasks.append("whatsapp")
+        for task, name in _make_channel_tasks(channels_cfg, gw):
+            tasks.append(task)
+            gw_tasks.append(name)
 
     # Drive loop (initiative tasks)
     from ravn.adapters.events.noop_publisher import NoOpEventPublisher

--- a/src/ravn/cli/commands.py
+++ b/src/ravn/cli/commands.py
@@ -1336,8 +1336,12 @@ async def _run_gateway(
 ) -> None:
     """Build and run the gateway until interrupted."""
     from ravn.adapters.channels.gateway import RavnGateway
+    from ravn.adapters.channels.gateway_discord import DiscordGateway
     from ravn.adapters.channels.gateway_http import HttpGateway
+    from ravn.adapters.channels.gateway_matrix import MatrixGateway
+    from ravn.adapters.channels.gateway_slack import SlackGateway
     from ravn.adapters.channels.gateway_telegram import TelegramGateway
+    from ravn.adapters.channels.gateway_whatsapp import WhatsAppGateway
     from ravn.budget import IterationBudget
     from ravn.ports.channel import ChannelPort
 
@@ -1447,6 +1451,22 @@ async def _run_gateway(
         ht = HttpGateway(settings.gateway.channels.http, gw)
         tasks.append(asyncio.create_task(ht.run(), name="http"))
 
+    if settings.gateway.channels.discord.enabled:
+        dc = DiscordGateway(settings.gateway.channels.discord, gw)
+        tasks.append(asyncio.create_task(dc.run(), name="discord"))
+
+    if settings.gateway.channels.slack.enabled:
+        sl = SlackGateway(settings.gateway.channels.slack, gw)
+        tasks.append(asyncio.create_task(sl.run(), name="slack"))
+
+    if settings.gateway.channels.matrix.enabled:
+        mx = MatrixGateway(settings.gateway.channels.matrix, gw)
+        tasks.append(asyncio.create_task(mx.run(), name="matrix"))
+
+    if settings.gateway.channels.whatsapp.enabled:
+        wa = WhatsAppGateway(settings.gateway.channels.whatsapp, gw)
+        tasks.append(asyncio.create_task(wa.run(), name="whatsapp"))
+
     typer.echo(f"Gateway started ({len(tasks)} channel(s) active). Press Ctrl+C to stop.")
 
     try:
@@ -1529,8 +1549,12 @@ async def _run_daemon(
 ) -> None:
     """Build and run the gateway + drive loop until interrupted."""
     from ravn.adapters.channels.gateway import RavnGateway
+    from ravn.adapters.channels.gateway_discord import DiscordGateway
     from ravn.adapters.channels.gateway_http import HttpGateway
+    from ravn.adapters.channels.gateway_matrix import MatrixGateway
+    from ravn.adapters.channels.gateway_slack import SlackGateway
     from ravn.adapters.channels.gateway_telegram import TelegramGateway
+    from ravn.adapters.channels.gateway_whatsapp import WhatsAppGateway
     from ravn.budget import IterationBudget
     from ravn.drive_loop import DriveLoop
     from ravn.ports.channel import ChannelPort
@@ -1627,18 +1651,47 @@ async def _run_daemon(
 
     # Gateway channels (human-initiated turns)
     gw_tasks: list[str] = []
-    if settings.gateway.channels.telegram.enabled or settings.gateway.channels.http.enabled:
+    channels_cfg = settings.gateway.channels
+    _any_channel = (
+        channels_cfg.telegram.enabled
+        or channels_cfg.http.enabled
+        or channels_cfg.discord.enabled
+        or channels_cfg.slack.enabled
+        or channels_cfg.matrix.enabled
+        or channels_cfg.whatsapp.enabled
+    )
+    if _any_channel:
         gw = RavnGateway(settings.gateway, _agent_factory)
 
-        if settings.gateway.channels.telegram.enabled:
-            tg = TelegramGateway(settings.gateway.channels.telegram, gw)
+        if channels_cfg.telegram.enabled:
+            tg = TelegramGateway(channels_cfg.telegram, gw)
             tasks.append(asyncio.create_task(tg.run(), name="telegram"))
             gw_tasks.append("telegram")
 
-        if settings.gateway.channels.http.enabled:
-            ht = HttpGateway(settings.gateway.channels.http, gw)
+        if channels_cfg.http.enabled:
+            ht = HttpGateway(channels_cfg.http, gw)
             tasks.append(asyncio.create_task(ht.run(), name="http"))
             gw_tasks.append("http")
+
+        if channels_cfg.discord.enabled:
+            dc = DiscordGateway(channels_cfg.discord, gw)
+            tasks.append(asyncio.create_task(dc.run(), name="discord"))
+            gw_tasks.append("discord")
+
+        if channels_cfg.slack.enabled:
+            sl = SlackGateway(channels_cfg.slack, gw)
+            tasks.append(asyncio.create_task(sl.run(), name="slack"))
+            gw_tasks.append("slack")
+
+        if channels_cfg.matrix.enabled:
+            mx = MatrixGateway(channels_cfg.matrix, gw)
+            tasks.append(asyncio.create_task(mx.run(), name="matrix"))
+            gw_tasks.append("matrix")
+
+        if channels_cfg.whatsapp.enabled:
+            wa = WhatsAppGateway(channels_cfg.whatsapp, gw)
+            tasks.append(asyncio.create_task(wa.run(), name="whatsapp"))
+            gw_tasks.append("whatsapp")
 
     # Drive loop (initiative tasks)
     from ravn.adapters.events.noop_publisher import NoOpEventPublisher

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -923,12 +923,156 @@ class PlatformToolsConfig(BaseModel):
     timeout: float = Field(default=30.0)
 
 
+class DiscordChannelConfig(BaseModel):
+    """Discord bot gateway configuration."""
+
+    enabled: bool = Field(default=False)
+    token_env: str = Field(
+        default="DISCORD_BOT_TOKEN",
+        description="Environment variable name containing the Discord bot token.",
+    )
+    guild_id: str = Field(
+        default="",
+        description="Default guild (server) ID; used when chat_id has no guild prefix.",
+    )
+    command_prefix: str = Field(
+        default="/",
+        description="Prefix character for slash commands recognised by the bot.",
+    )
+    message_max_chars: int = Field(
+        default=2000,
+        description="Maximum characters per outbound Discord message (API limit).",
+    )
+    retry_delay: float = Field(
+        default=5.0,
+        description="Seconds to wait after a gateway error before reconnecting.",
+    )
+    gateway_url: str = Field(
+        default="wss://gateway.discord.gg/?v=10&encoding=json",
+        description="Discord Gateway WebSocket URL.",
+    )
+    api_base: str = Field(
+        default="https://discord.com/api/v10",
+        description="Discord REST API base URL.",
+    )
+
+
+class SlackChannelConfig(BaseModel):
+    """Slack bot gateway configuration."""
+
+    enabled: bool = Field(default=False)
+    bot_token_env: str = Field(
+        default="SLACK_BOT_TOKEN",
+        description="Environment variable name containing the Slack bot token (xoxb-).",
+    )
+    app_token_env: str = Field(
+        default="SLACK_APP_TOKEN",
+        description="Environment variable name for Socket Mode app token (xapp-).",
+    )
+    poll_interval: float = Field(
+        default=2.0,
+        description="Seconds between conversations.history polls (fallback polling mode).",
+    )
+    message_max_chars: int = Field(
+        default=3000,
+        description="Maximum characters per outbound Slack message before truncation.",
+    )
+    retry_delay: float = Field(
+        default=5.0,
+        description="Seconds to wait after an API error before retrying.",
+    )
+    api_base: str = Field(
+        default="https://slack.com/api",
+        description="Slack Web API base URL.",
+    )
+
+
+class MatrixChannelConfig(BaseModel):
+    """Matrix client-server gateway configuration."""
+
+    enabled: bool = Field(default=False)
+    homeserver: str = Field(
+        default="https://matrix.niuu.world",
+        description="Matrix homeserver base URL.",
+    )
+    user_id_env: str = Field(
+        default="MATRIX_USER_ID",
+        description="Environment variable name containing the Matrix user ID (@user:server).",
+    )
+    access_token_env: str = Field(
+        default="MATRIX_ACCESS_TOKEN",
+        description="Environment variable name containing the Matrix access token.",
+    )
+    e2e: bool = Field(
+        default=False,
+        description="Enable end-to-end encryption (requires libolm; not yet implemented).",
+    )
+    sync_timeout_ms: int = Field(
+        default=30000,
+        description="Long-poll timeout in milliseconds for the /sync endpoint.",
+    )
+    retry_delay: float = Field(
+        default=5.0,
+        description="Seconds to wait after a sync error before retrying.",
+    )
+    message_max_chars: int = Field(
+        default=32000,
+        description="Maximum characters per outbound Matrix message.",
+    )
+
+
+class WhatsAppChannelConfig(BaseModel):
+    """WhatsApp gateway configuration (Meta Cloud API)."""
+
+    enabled: bool = Field(default=False)
+    mode: str = Field(
+        default="business_api",
+        description="Adapter mode: 'business_api' (Meta Cloud) or 'local_bridge' (stub).",
+    )
+    api_key_env: str = Field(
+        default="WA_API_KEY",
+        description="Environment variable name containing the Meta API key (bearer token).",
+    )
+    phone_number_id_env: str = Field(
+        default="WA_PHONE_NUMBER_ID",
+        description="Environment variable name containing the WhatsApp phone number ID.",
+    )
+    webhook_verify_token_env: str = Field(
+        default="WA_WEBHOOK_VERIFY_TOKEN",
+        description="Environment variable name for Meta webhook verification token.",
+    )
+    webhook_host: str = Field(
+        default="0.0.0.0",
+        description="Host to bind the inbound webhook HTTP listener.",
+    )
+    webhook_port: int = Field(
+        default=7478,
+        description="Port for the inbound webhook HTTP listener.",
+    )
+    retry_delay: float = Field(
+        default=5.0,
+        description="Seconds to wait after an API error before retrying.",
+    )
+    message_max_chars: int = Field(
+        default=4096,
+        description="Maximum characters per outbound WhatsApp message.",
+    )
+    api_base: str = Field(
+        default="https://graph.facebook.com/v18.0",
+        description="Meta Graph API base URL.",
+    )
+
+
 class GatewayChannelsConfig(BaseModel):
     """Per-channel gateway configuration."""
 
     telegram: TelegramChannelConfig = Field(default_factory=TelegramChannelConfig)
     http: HttpChannelConfig = Field(default_factory=HttpChannelConfig)
     skuld: SkuldChannelConfig = Field(default_factory=SkuldChannelConfig)
+    discord: DiscordChannelConfig = Field(default_factory=DiscordChannelConfig)
+    slack: SlackChannelConfig = Field(default_factory=SlackChannelConfig)
+    matrix: MatrixChannelConfig = Field(default_factory=MatrixChannelConfig)
+    whatsapp: WhatsAppChannelConfig = Field(default_factory=WhatsAppChannelConfig)
 
 
 class GatewayConfig(BaseModel):

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -955,6 +955,10 @@ class DiscordChannelConfig(BaseModel):
         default="https://discord.com/api/v10",
         description="Discord REST API base URL.",
     )
+    max_pending_approvals: int = Field(
+        default=1000,
+        description="Maximum number of approval-requested messages tracked in memory.",
+    )
 
 
 class SlackChannelConfig(BaseModel):
@@ -1040,6 +1044,13 @@ class WhatsAppChannelConfig(BaseModel):
     webhook_verify_token_env: str = Field(
         default="WA_WEBHOOK_VERIFY_TOKEN",
         description="Environment variable name for Meta webhook verification token.",
+    )
+    webhook_secret_env: str = Field(
+        default="WA_WEBHOOK_SECRET",
+        description=(
+            "Environment variable name for Meta webhook HMAC secret "
+            "(X-Hub-Signature-256). Leave unset to skip signature verification."
+        ),
     )
     webhook_host: str = Field(
         default="0.0.0.0",

--- a/src/ravn/ports/gateway_channel.py
+++ b/src/ravn/ports/gateway_channel.py
@@ -1,0 +1,71 @@
+"""Gateway channel port — bidirectional messaging interface for external platforms.
+
+Each messaging platform adapter (Discord, Slack, Matrix, WhatsApp) implements
+this ABC so the gateway orchestrator can start/stop adapters uniformly and route
+inbound messages to :class:`~ravn.adapters.channels.gateway.RavnGateway`.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Callable
+
+# Called when an inbound message arrives: (chat_id, text) → None.
+# chat_id is platform-specific (see subclass docs).
+MessageHandler = Callable[[str, str], Awaitable[None]]
+
+
+class GatewayChannelPort(ABC):
+    """Abstract interface for a bidirectional gateway platform adapter.
+
+    Implementations connect to an external messaging platform and bridge
+    messages to/from :class:`~ravn.adapters.channels.gateway.RavnGateway`.
+
+    Lifecycle::
+
+        adapter.on_message(handler)    # register inbound handler once
+        await adapter.start()           # connect + begin receiving
+        await adapter.send_text(chat_id, "hello")
+        await adapter.stop()            # disconnect gracefully
+
+    ``chat_id`` is platform-specific:
+
+    * Discord  — ``"guild_id/channel_id"``
+    * Slack    — Slack channel ID (e.g. ``"C0123ABCDE"``)
+    * Matrix   — full room ID (e.g. ``"!abc:matrix.example.com"``)
+    * WhatsApp — E.164 phone number or group JID
+    """
+
+    @abstractmethod
+    async def start(self) -> None:
+        """Connect to the platform and begin receiving messages."""
+        ...
+
+    @abstractmethod
+    async def stop(self) -> None:
+        """Disconnect from the platform and release all resources."""
+        ...
+
+    @abstractmethod
+    async def send_text(self, chat_id: str, text: str) -> None:
+        """Send *text* to *chat_id*."""
+        ...
+
+    @abstractmethod
+    async def send_image(self, chat_id: str, image: bytes, caption: str = "") -> None:
+        """Send *image* bytes with optional *caption* to *chat_id*."""
+        ...
+
+    @abstractmethod
+    async def send_audio(self, chat_id: str, audio: bytes) -> None:
+        """Send *audio* bytes to *chat_id*."""
+        ...
+
+    @abstractmethod
+    def on_message(self, handler: MessageHandler) -> None:
+        """Register *handler* to be called for every inbound user message.
+
+        Must be called before :meth:`start`.  Only one handler is supported;
+        a second call replaces the first.
+        """
+        ...

--- a/tests/test_ravn/test_gateway_channel_port.py
+++ b/tests/test_ravn/test_gateway_channel_port.py
@@ -1,0 +1,116 @@
+"""Tests for the GatewayChannelPort ABC and config models."""
+
+from __future__ import annotations
+
+import pytest
+
+from ravn.config import (
+    DiscordChannelConfig,
+    MatrixChannelConfig,
+    SlackChannelConfig,
+    WhatsAppChannelConfig,
+)
+from ravn.ports.gateway_channel import (
+    GatewayChannelPort,
+    MessageHandler,
+)
+
+# ---------------------------------------------------------------------------
+# GatewayChannelPort — abstract methods
+# ---------------------------------------------------------------------------
+
+
+def test_gateway_channel_port_cannot_be_instantiated():
+    """GatewayChannelPort is abstract and cannot be directly instantiated."""
+    with pytest.raises(TypeError):
+        GatewayChannelPort()  # type: ignore[abstract]
+
+
+def test_gateway_channel_port_must_implement_all_methods():
+    """Partial implementation raises TypeError."""
+
+    class Incomplete(GatewayChannelPort):
+        async def start(self) -> None:
+            pass
+
+        # Missing stop, send_text, send_image, send_audio, on_message
+
+    with pytest.raises(TypeError):
+        Incomplete()
+
+
+def test_gateway_channel_port_full_implementation_works():
+    """A complete concrete implementation can be instantiated."""
+
+    class Complete(GatewayChannelPort):
+        async def start(self) -> None:
+            pass
+
+        async def stop(self) -> None:
+            pass
+
+        async def send_text(self, chat_id: str, text: str) -> None:
+            pass
+
+        async def send_image(self, chat_id: str, image: bytes, caption: str = "") -> None:
+            pass
+
+        async def send_audio(self, chat_id: str, audio: bytes) -> None:
+            pass
+
+        def on_message(self, handler: MessageHandler) -> None:
+            pass
+
+    obj = Complete()
+    assert isinstance(obj, GatewayChannelPort)
+
+
+# ---------------------------------------------------------------------------
+# Config defaults
+# ---------------------------------------------------------------------------
+
+
+def test_discord_config_defaults():
+    cfg = DiscordChannelConfig()
+    assert cfg.enabled is False
+    assert cfg.token_env == "DISCORD_BOT_TOKEN"
+    assert cfg.message_max_chars == 2000
+    assert cfg.retry_delay == 5.0
+
+
+def test_slack_config_defaults():
+    cfg = SlackChannelConfig()
+    assert cfg.enabled is False
+    assert cfg.bot_token_env == "SLACK_BOT_TOKEN"
+    assert cfg.poll_interval == 2.0
+    assert cfg.message_max_chars == 3000
+
+
+def test_matrix_config_defaults():
+    cfg = MatrixChannelConfig()
+    assert cfg.enabled is False
+    assert cfg.homeserver == "https://matrix.niuu.world"
+    assert cfg.e2e is False
+    assert cfg.sync_timeout_ms == 30000
+
+
+def test_whatsapp_config_defaults():
+    cfg = WhatsAppChannelConfig()
+    assert cfg.enabled is False
+    assert cfg.mode == "business_api"
+    assert cfg.api_key_env == "WA_API_KEY"
+    assert cfg.webhook_port == 7478
+
+
+def test_gateway_channels_config_includes_new_platforms():
+    from ravn.config import GatewayChannelsConfig
+
+    cfg = GatewayChannelsConfig()
+    assert hasattr(cfg, "discord")
+    assert hasattr(cfg, "slack")
+    assert hasattr(cfg, "matrix")
+    assert hasattr(cfg, "whatsapp")
+    assert isinstance(cfg.discord, DiscordChannelConfig)
+    assert isinstance(cfg.slack, SlackChannelConfig)
+    assert isinstance(cfg.matrix, MatrixChannelConfig)
+    assert isinstance(cfg.whatsapp, WhatsAppChannelConfig)

--- a/tests/test_ravn/test_gateway_channel_port.py
+++ b/tests/test_ravn/test_gateway_channel_port.py
@@ -114,3 +114,52 @@ def test_gateway_channels_config_includes_new_platforms():
     assert isinstance(cfg.slack, SlackChannelConfig)
     assert isinstance(cfg.matrix, MatrixChannelConfig)
     assert isinstance(cfg.whatsapp, WhatsAppChannelConfig)
+
+
+# ---------------------------------------------------------------------------
+# New config fields from review feedback
+# ---------------------------------------------------------------------------
+
+
+def test_discord_config_has_max_pending_approvals():
+    cfg = DiscordChannelConfig()
+    assert cfg.max_pending_approvals == 1000
+
+
+def test_whatsapp_config_has_webhook_secret_env():
+    cfg = WhatsAppChannelConfig()
+    assert cfg.webhook_secret_env == "WA_WEBHOOK_SECRET"
+
+
+# ---------------------------------------------------------------------------
+# _slash_commands shared module
+# ---------------------------------------------------------------------------
+
+
+def test_shared_slash_prompts_contains_expected_keys():
+    from ravn.adapters.channels._slash_commands import GATEWAY_SLASH_PROMPTS
+
+    for key in ("/compact", "/budget", "/status", "/stop", "/todo"):
+        assert key in GATEWAY_SLASH_PROMPTS
+        assert GATEWAY_SLASH_PROMPTS[key]
+
+
+def test_slack_slash_prompts_use_ravn_prefix():
+    from ravn.adapters.channels.gateway_slack import _SLASH_PROMPTS as SLACK_PROMPTS
+
+    for key in SLACK_PROMPTS:
+        assert key.startswith("/ravn-"), f"{key!r} does not start with /ravn-"
+
+
+def test_discord_slash_prompts_match_shared():
+    from ravn.adapters.channels._slash_commands import GATEWAY_SLASH_PROMPTS
+    from ravn.adapters.channels.gateway_discord import _SLASH_PROMPTS as DISCORD_PROMPTS
+
+    assert DISCORD_PROMPTS is GATEWAY_SLASH_PROMPTS
+
+
+def test_telegram_slash_prompts_match_shared():
+    from ravn.adapters.channels._slash_commands import GATEWAY_SLASH_PROMPTS
+    from ravn.adapters.channels.gateway_telegram import _SLASH_PROMPTS as TG_PROMPTS
+
+    assert TG_PROMPTS is GATEWAY_SLASH_PROMPTS

--- a/tests/test_ravn/test_gateway_discord.py
+++ b/tests/test_ravn/test_gateway_discord.py
@@ -1,0 +1,592 @@
+"""Tests for the Discord gateway adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ravn.adapters.channels.gateway_discord import (
+    _OP_HEARTBEAT_ACK,
+    _OP_HELLO,
+    _OP_IDENTIFY,
+    _SLASH_PROMPTS,
+    DiscordGateway,
+)
+from ravn.config import DiscordChannelConfig
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(
+    token_env: str = "DC_TOKEN",
+    guild_id: str = "111",
+    message_max_chars: int = 2000,
+) -> DiscordChannelConfig:
+    return DiscordChannelConfig(
+        enabled=True,
+        token_env=token_env,
+        guild_id=guild_id,
+        message_max_chars=message_max_chars,
+        retry_delay=0.01,
+        gateway_url="wss://fake.discord.gg",
+        api_base="https://discord.example.com/api/v10",
+    )
+
+
+def _make_gateway_mock(response: str = "agent reply") -> MagicMock:
+    gw = MagicMock()
+    gw.handle_message = AsyncMock(return_value=response)
+    return gw
+
+
+def _make_http_client(response_json: dict | None = None) -> AsyncMock:
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json = MagicMock(return_value=response_json or {"id": "msg123"})
+    client = AsyncMock()
+    client.post = AsyncMock(return_value=resp)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# GatewayChannelPort — on_message
+# ---------------------------------------------------------------------------
+
+
+def test_on_message_registers_handler():
+    cfg = _make_config()
+    gw = _make_gateway_mock()
+    adapter = DiscordGateway(cfg, gw)
+    handler = AsyncMock()
+    adapter.on_message(handler)
+    assert adapter._handler is handler
+
+
+# ---------------------------------------------------------------------------
+# send_text
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_text_posts_to_rest_api(monkeypatch):
+    monkeypatch.setenv("DC_TOKEN", "test-token")
+    client = _make_http_client()
+    cfg = _make_config()
+    adapter = DiscordGateway(cfg, _make_gateway_mock(), http_client=client)
+    adapter._token = "test-token"
+
+    await adapter.send_text("111/999", "hello world")
+
+    assert client.post.called
+    call_url = client.post.call_args[0][0]
+    assert "999/messages" in call_url
+    assert client.post.call_args[1]["json"]["content"] == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_send_text_truncates_long_message(monkeypatch):
+    monkeypatch.setenv("DC_TOKEN", "tok")
+    client = _make_http_client()
+    cfg = _make_config(message_max_chars=10)
+    adapter = DiscordGateway(cfg, _make_gateway_mock(), http_client=client)
+    adapter._token = "tok"
+
+    await adapter.send_text("0/1", "x" * 20)
+
+    sent_content = client.post.call_args[1]["json"]["content"]
+    assert len(sent_content) <= 10
+    assert sent_content.endswith("...")
+
+
+@pytest.mark.asyncio
+async def test_send_text_bare_channel_id(monkeypatch):
+    monkeypatch.setenv("DC_TOKEN", "tok")
+    client = _make_http_client()
+    cfg = _make_config()
+    adapter = DiscordGateway(cfg, _make_gateway_mock(), http_client=client)
+    adapter._token = "tok"
+
+    await adapter.send_text("555", "hi")
+
+    call_url = client.post.call_args[0][0]
+    assert "/channels/555/messages" in call_url
+
+
+# ---------------------------------------------------------------------------
+# send_image / send_audio
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_image_posts_with_attachment(monkeypatch):
+    monkeypatch.setenv("DC_TOKEN", "tok")
+    client = _make_http_client()
+    cfg = _make_config()
+    adapter = DiscordGateway(cfg, _make_gateway_mock(), http_client=client)
+    adapter._token = "tok"
+
+    await adapter.send_image("111/999", b"\x89PNG", caption="test cap")
+
+    assert client.post.called
+    payload = client.post.call_args[1]["json"]
+    assert payload["content"] == "test cap"
+    assert "attachments" in payload
+
+
+@pytest.mark.asyncio
+async def test_send_audio_posts_with_attachment(monkeypatch):
+    monkeypatch.setenv("DC_TOKEN", "tok")
+    client = _make_http_client()
+    cfg = _make_config()
+    adapter = DiscordGateway(cfg, _make_gateway_mock(), http_client=client)
+    adapter._token = "tok"
+
+    await adapter.send_audio("111/999", b"OGG_DATA")
+
+    assert client.post.called
+    payload = client.post.call_args[1]["json"]
+    assert "attachments" in payload
+    assert payload["attachments"][0]["filename"] == "audio.ogg"
+
+
+# ---------------------------------------------------------------------------
+# start() — token missing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_returns_early_when_no_token(caplog):
+    import logging
+
+    cfg = _make_config(token_env="DC_MISSING_TOKEN_XYZ")
+    adapter = DiscordGateway(cfg, _make_gateway_mock())
+
+    with caplog.at_level(logging.ERROR):
+        await adapter.start()
+
+    assert "DC_MISSING_TOKEN_XYZ" in caplog.text
+    assert adapter._task is None
+
+
+# ---------------------------------------------------------------------------
+# stop() — no task
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stop_when_not_started():
+    cfg = _make_config()
+    adapter = DiscordGateway(cfg, _make_gateway_mock())
+    # Should not raise
+    await adapter.stop()
+
+
+# ---------------------------------------------------------------------------
+# _translate_slash
+# ---------------------------------------------------------------------------
+
+
+def test_translate_slash_plain_text_unchanged():
+    adapter = DiscordGateway(_make_config(), _make_gateway_mock())
+    assert adapter._translate_slash("hello world") == "hello world"
+
+
+@pytest.mark.parametrize("cmd", ["/compact", "/budget", "/status", "/stop", "/todo"])
+def test_translate_slash_known_commands(cmd: str):
+    adapter = DiscordGateway(_make_config(), _make_gateway_mock())
+    result = adapter._translate_slash(cmd)
+    assert result == _SLASH_PROMPTS[cmd]
+
+
+def test_translate_slash_unknown_passthrough():
+    adapter = DiscordGateway(_make_config(), _make_gateway_mock())
+    assert adapter._translate_slash("/unknown") == "/unknown"
+
+
+# ---------------------------------------------------------------------------
+# _channel_id
+# ---------------------------------------------------------------------------
+
+
+def test_channel_id_extracts_from_composite():
+    adapter = DiscordGateway(_make_config(), _make_gateway_mock())
+    assert adapter._channel_id("123/456") == "456"
+
+
+def test_channel_id_bare():
+    adapter = DiscordGateway(_make_config(), _make_gateway_mock())
+    assert adapter._channel_id("456") == "456"
+
+
+# ---------------------------------------------------------------------------
+# _on_message_create
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_on_message_create_dispatches_to_gateway(monkeypatch):
+    monkeypatch.setenv("DC_TOKEN", "tok")
+    client = _make_http_client()
+    gw = _make_gateway_mock("hello reply")
+    cfg = _make_config()
+    adapter = DiscordGateway(cfg, gw, http_client=client)
+    adapter._token = "tok"
+
+    handler = AsyncMock()
+    adapter.on_message(handler)
+
+    event: dict[str, Any] = {
+        "channel_id": "999",
+        "guild_id": "111",
+        "id": "msg1",
+        "author": {"bot": False, "id": "user1"},
+        "content": "hello bot",
+    }
+    await adapter._on_message_create(event)
+
+    gw.handle_message.assert_awaited_once_with("discord:111/999", "hello bot")
+    handler.assert_awaited_once_with("111/999", "hello bot")
+    # send_text should have been called
+    assert client.post.called
+
+
+@pytest.mark.asyncio
+async def test_on_message_create_ignores_bot_messages():
+    gw = _make_gateway_mock()
+    adapter = DiscordGateway(_make_config(), gw)
+
+    event: dict[str, Any] = {
+        "channel_id": "1",
+        "guild_id": "1",
+        "id": "m1",
+        "author": {"bot": True},
+        "content": "bot message",
+    }
+    await adapter._on_message_create(event)
+    gw.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_on_message_create_ignores_empty_text():
+    gw = _make_gateway_mock()
+    adapter = DiscordGateway(_make_config(), gw)
+
+    event: dict[str, Any] = {
+        "channel_id": "1",
+        "guild_id": "1",
+        "id": "m1",
+        "author": {"bot": False},
+        "content": "",
+    }
+    await adapter._on_message_create(event)
+    gw.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_on_message_create_translates_slash(monkeypatch):
+    monkeypatch.setenv("DC_TOKEN", "tok")
+    client = _make_http_client()
+    gw = _make_gateway_mock("ok")
+    adapter = DiscordGateway(_make_config(), gw, http_client=client)
+    adapter._token = "tok"
+
+    event: dict[str, Any] = {
+        "channel_id": "1",
+        "guild_id": "111",
+        "id": "m1",
+        "author": {"bot": False},
+        "content": "/status",
+    }
+    await adapter._on_message_create(event)
+
+    called_prompt = gw.handle_message.call_args[0][1]
+    assert "status" in called_prompt.lower()
+
+
+@pytest.mark.asyncio
+async def test_on_message_create_handles_agent_exception(monkeypatch):
+    monkeypatch.setenv("DC_TOKEN", "tok")
+    client = _make_http_client()
+    gw = MagicMock()
+    gw.handle_message = AsyncMock(side_effect=RuntimeError("crash"))
+    adapter = DiscordGateway(_make_config(), gw, http_client=client)
+    adapter._token = "tok"
+
+    event: dict[str, Any] = {
+        "channel_id": "1",
+        "guild_id": "111",
+        "id": "m1",
+        "author": {"bot": False},
+        "content": "hello",
+    }
+    # Should not raise; sends error message instead
+    await adapter._on_message_create(event)
+    assert client.post.called  # error fallback message sent
+
+
+# ---------------------------------------------------------------------------
+# _on_reaction_add — approval workflow
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_on_reaction_add_approve(monkeypatch):
+    monkeypatch.setenv("DC_TOKEN", "tok")
+    client = _make_http_client()
+    gw = _make_gateway_mock("approved!")
+    adapter = DiscordGateway(_make_config(), gw, http_client=client)
+    adapter._token = "tok"
+
+    # Seed pending approval
+    adapter._pending_approvals["msg999"] = ("111/1", "discord:111/1")
+
+    reaction = {
+        "message_id": "msg999",
+        "emoji": {"name": "👍"},
+    }
+    await adapter._on_reaction_add(reaction)
+
+    gw.handle_message.assert_awaited_once_with("discord:111/1", "approved")
+    assert "msg999" not in adapter._pending_approvals
+
+
+@pytest.mark.asyncio
+async def test_on_reaction_add_reject(monkeypatch):
+    monkeypatch.setenv("DC_TOKEN", "tok")
+    client = _make_http_client()
+    gw = _make_gateway_mock("rejected!")
+    adapter = DiscordGateway(_make_config(), gw, http_client=client)
+    adapter._token = "tok"
+
+    adapter._pending_approvals["msg42"] = ("111/2", "discord:111/2")
+
+    reaction = {
+        "message_id": "msg42",
+        "emoji": {"name": "👎"},
+    }
+    await adapter._on_reaction_add(reaction)
+
+    gw.handle_message.assert_awaited_once_with("discord:111/2", "rejected")
+
+
+@pytest.mark.asyncio
+async def test_on_reaction_add_unknown_message_ignored():
+    gw = _make_gateway_mock()
+    adapter = DiscordGateway(_make_config(), gw)
+
+    reaction = {"message_id": "unknown", "emoji": {"name": "👍"}}
+    await adapter._on_reaction_add(reaction)
+    gw.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_on_reaction_add_other_emoji_ignored():
+    gw = _make_gateway_mock()
+    adapter = DiscordGateway(_make_config(), gw)
+
+    adapter._pending_approvals["m1"] = ("ch", "discord:ch")
+    reaction = {"message_id": "m1", "emoji": {"name": "🎉"}}
+    await adapter._on_reaction_add(reaction)
+    gw.handle_message.assert_not_awaited()
+    # Still in pending (not removed)
+    assert "m1" in adapter._pending_approvals
+
+
+# ---------------------------------------------------------------------------
+# _handle_dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_dispatch_ready_logs(caplog):
+    import logging
+
+    adapter = DiscordGateway(_make_config(), _make_gateway_mock())
+    data = {"user": {"username": "TestBot"}}
+    with caplog.at_level(logging.INFO):
+        await adapter._handle_dispatch("READY", data)
+    assert "TestBot" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# WebSocket loop — _connect_and_listen
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_connect_and_listen_identifies_on_hello(monkeypatch):
+    """The adapter should send IDENTIFY after receiving HELLO."""
+    sent_messages: list[str] = []
+
+    class FakeWS:
+        def __init__(self) -> None:
+            self._msgs = iter(
+                [
+                    json.dumps({"op": _OP_HELLO, "d": {"heartbeat_interval": 10000}}),
+                    json.dumps({"op": _OP_HEARTBEAT_ACK, "d": None}),
+                ]
+            )
+
+        async def send(self, msg: str) -> None:
+            sent_messages.append(msg)
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            try:
+                return next(self._msgs)
+            except StopIteration:
+                raise asyncio.CancelledError
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+    monkeypatch.setenv("DC_TOKEN", "fake-token")
+    cfg = _make_config()
+    adapter = DiscordGateway(cfg, _make_gateway_mock())
+    adapter._token = "fake-token"
+
+    fake_ws = FakeWS()
+
+    with patch("ravn.adapters.channels.gateway_discord.websockets") as mock_ws:
+        mock_ws.connect.return_value = fake_ws
+
+        try:
+            await asyncio.wait_for(adapter._connect_and_listen(), timeout=0.5)
+        except (asyncio.CancelledError, TimeoutError):
+            pass
+
+    # At least one IDENTIFY message should have been sent
+    identify_msgs = [m for m in sent_messages if json.loads(m).get("op") == _OP_IDENTIFY]
+    assert len(identify_msgs) >= 1
+
+
+# ---------------------------------------------------------------------------
+# run() — returns when not started (no token)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_returns_cleanly_when_no_token():
+    cfg = _make_config(token_env="DC_MISSING_XYZ")
+    adapter = DiscordGateway(cfg, _make_gateway_mock())
+    # run() should return promptly because start() finds no token
+    await asyncio.wait_for(adapter.run(), timeout=1.0)
+
+
+# ---------------------------------------------------------------------------
+# Additional coverage: start/stop with token, _run retry, _heartbeat_loop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_creates_task_and_stop_cancels(monkeypatch):
+    """start() creates _task; stop() cancels and clears it."""
+    monkeypatch.setenv("DC_TOKEN", "tok")
+    cancel_called = False
+
+    async def fake_run():
+        nonlocal cancel_called
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cancel_called = True
+            raise
+
+    adapter = DiscordGateway(_make_config(), _make_gateway_mock())
+    adapter._token = "tok"
+    adapter._run = fake_run
+
+    await adapter.start()
+    assert adapter._task is not None
+    await asyncio.sleep(0)  # allow task to start
+    await adapter.stop()
+    assert adapter._task is None
+    assert cancel_called
+
+
+@pytest.mark.asyncio
+async def test_run_retries_on_exception(monkeypatch):
+    """_run() reconnects after a non-cancel exception."""
+    monkeypatch.setenv("DC_TOKEN", "tok")
+    call_count = 0
+
+    async def fake_connect():
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise ConnectionError("first failure")
+        raise asyncio.CancelledError
+
+    adapter = DiscordGateway(_make_config(), _make_gateway_mock())
+    adapter._token = "tok"
+    adapter._connect_and_listen = fake_connect
+
+    with pytest.raises(asyncio.CancelledError):
+        await adapter._run()
+
+    assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_loop_sends_heartbeat():
+    """_heartbeat_loop sends OP 1 HEARTBEAT messages."""
+    sent: list[str] = []
+
+    class FakeWS:
+        async def send(self, msg: str) -> None:
+            sent.append(msg)
+
+    adapter = DiscordGateway(_make_config(), _make_gateway_mock())
+    ws = FakeWS()
+
+    # Run heartbeat for just long enough to send one beat
+    task = asyncio.create_task(adapter._heartbeat_loop(ws, 0.05))
+    await asyncio.sleep(0.12)
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+
+    import json as _json
+
+    beats = [_json.loads(m) for m in sent if _json.loads(m).get("op") == 1]
+    assert len(beats) >= 1
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_loop_exits_on_ws_close():
+    """_heartbeat_loop exits cleanly if the WS send fails."""
+
+    class BrokenWS:
+        async def send(self, msg: str) -> None:
+            raise ConnectionError("closed")
+
+    adapter = DiscordGateway(_make_config(), _make_gateway_mock())
+    ws = BrokenWS()
+    # Should return without exception
+    await asyncio.wait_for(adapter._heartbeat_loop(ws, 0.01), timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_run_convenience_wrapper(monkeypatch):
+    """run() wraps start() + awaiting the internal task."""
+    monkeypatch.setenv("DC_TOKEN", "tok")
+
+    async def quick_run():
+        raise asyncio.CancelledError
+
+    adapter = DiscordGateway(_make_config(), _make_gateway_mock())
+    adapter._token = "tok"
+    adapter._run = quick_run
+
+    # Should complete without raising
+    await asyncio.wait_for(adapter.run(), timeout=1.0)

--- a/tests/test_ravn/test_gateway_discord.py
+++ b/tests/test_ravn/test_gateway_discord.py
@@ -124,7 +124,7 @@ async def test_send_text_bare_channel_id(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_send_image_posts_with_attachment(monkeypatch):
+async def test_send_image_posts_multipart(monkeypatch):
     monkeypatch.setenv("DC_TOKEN", "tok")
     client = _make_http_client()
     cfg = _make_config()
@@ -134,13 +134,21 @@ async def test_send_image_posts_with_attachment(monkeypatch):
     await adapter.send_image("111/999", b"\x89PNG", caption="test cap")
 
     assert client.post.called
-    payload = client.post.call_args[1]["json"]
-    assert payload["content"] == "test cap"
-    assert "attachments" in payload
+    # Multipart upload: files= kwarg contains the image, data= has payload_json
+    call_kwargs = client.post.call_args[1]
+    assert "files" in call_kwargs
+    assert "files[0]" in call_kwargs["files"]
+    filename, data, mime = call_kwargs["files"]["files[0]"]
+    assert filename == "image.png"
+    assert data == b"\x89PNG"
+    assert mime == "image/png"
+    import json as _json
+    payload_json = _json.loads(call_kwargs["data"]["payload_json"])
+    assert payload_json["content"] == "test cap"
 
 
 @pytest.mark.asyncio
-async def test_send_audio_posts_with_attachment(monkeypatch):
+async def test_send_audio_posts_multipart(monkeypatch):
     monkeypatch.setenv("DC_TOKEN", "tok")
     client = _make_http_client()
     cfg = _make_config()
@@ -150,9 +158,12 @@ async def test_send_audio_posts_with_attachment(monkeypatch):
     await adapter.send_audio("111/999", b"OGG_DATA")
 
     assert client.post.called
-    payload = client.post.call_args[1]["json"]
-    assert "attachments" in payload
-    assert payload["attachments"][0]["filename"] == "audio.ogg"
+    call_kwargs = client.post.call_args[1]
+    assert "files" in call_kwargs
+    filename, data, mime = call_kwargs["files"]["files[0]"]
+    assert filename == "audio.ogg"
+    assert data == b"OGG_DATA"
+    assert mime == "audio/ogg"
 
 
 # ---------------------------------------------------------------------------
@@ -590,3 +601,45 @@ async def test_run_convenience_wrapper(monkeypatch):
 
     # Should complete without raising
     await asyncio.wait_for(adapter.run(), timeout=1.0)
+
+
+# ---------------------------------------------------------------------------
+# _pending_approvals cap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pending_approvals_cap_evicts_oldest(monkeypatch):
+    """When max_pending_approvals is reached, the oldest entry is evicted."""
+    monkeypatch.setenv("DC_TOKEN", "tok")
+    client = _make_http_client()
+    cfg = DiscordChannelConfig(
+        enabled=True,
+        token_env="DC_TOKEN",
+        guild_id="",
+        message_max_chars=2000,
+        retry_delay=0.01,
+        gateway_url="wss://fake",
+        api_base="https://discord.example.com/api/v10",
+        max_pending_approvals=2,
+    )
+    gw = _make_gateway_mock("ok")
+    adapter = DiscordGateway(cfg, gw, http_client=client)
+    adapter._token = "tok"
+
+    # Seed the dict to capacity
+    adapter._pending_approvals["old1"] = ("ch", "discord:ch")
+    adapter._pending_approvals["old2"] = ("ch", "discord:ch")
+
+    # A new approval message should evict the oldest ("old1")
+    msg: dict[str, Any] = {
+        "channel_id": "C1",
+        "content": "task done [APPROVAL_REQUESTED]",
+        "id": "new_msg",
+        "author": {},
+    }
+    await adapter._on_message_create(msg)
+
+    assert "old1" not in adapter._pending_approvals
+    assert "old2" in adapter._pending_approvals
+    assert "new_msg" in adapter._pending_approvals

--- a/tests/test_ravn/test_gateway_matrix.py
+++ b/tests/test_ravn/test_gateway_matrix.py
@@ -1,0 +1,455 @@
+"""Tests for the Matrix gateway adapter."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ravn.adapters.channels.gateway_matrix import MatrixGateway, _quote
+from ravn.config import MatrixChannelConfig
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(
+    user_id_env: str = "MX_USER",
+    access_token_env: str = "MX_TOKEN",
+    e2e: bool = False,
+) -> MatrixChannelConfig:
+    return MatrixChannelConfig(
+        enabled=True,
+        homeserver="https://matrix.example.com",
+        user_id_env=user_id_env,
+        access_token_env=access_token_env,
+        e2e=e2e,
+        sync_timeout_ms=100,
+        retry_delay=0.01,
+        message_max_chars=32000,
+    )
+
+
+def _make_gateway_mock(response: str = "agent reply") -> MagicMock:
+    gw = MagicMock()
+    gw.handle_message = AsyncMock(return_value=response)
+    return gw
+
+
+def _make_http_client(
+    get_json: dict | None = None,
+    put_json: dict | None = None,
+    post_json: dict | None = None,
+) -> AsyncMock:
+    get_resp = MagicMock()
+    get_resp.raise_for_status = MagicMock()
+    get_resp.json = MagicMock(return_value=get_json or {"next_batch": "t1", "rooms": {}})
+
+    put_resp = MagicMock()
+    put_resp.raise_for_status = MagicMock()
+    put_resp.json = MagicMock(return_value=put_json or {"event_id": "$evt1"})
+
+    post_resp = MagicMock()
+    post_resp.raise_for_status = MagicMock()
+    post_resp.json = MagicMock(return_value=post_json or {"content_uri": "mxc://example/abc"})
+
+    client = AsyncMock()
+    client.get = AsyncMock(return_value=get_resp)
+    client.put = AsyncMock(return_value=put_resp)
+    client.post = AsyncMock(return_value=post_resp)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# on_message
+# ---------------------------------------------------------------------------
+
+
+def test_on_message_registers_handler():
+    adapter = MatrixGateway(_make_config(), _make_gateway_mock())
+    handler = AsyncMock()
+    adapter.on_message(handler)
+    assert adapter._handler is handler
+
+
+# ---------------------------------------------------------------------------
+# start() — missing token
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_returns_early_when_no_token(caplog):
+    import logging
+
+    cfg = _make_config(access_token_env="MX_MISSING_TOKEN_XYZ")
+    adapter = MatrixGateway(cfg, _make_gateway_mock())
+
+    with caplog.at_level(logging.ERROR):
+        await adapter.start()
+
+    assert "MX_MISSING_TOKEN_XYZ" in caplog.text
+    assert adapter._task is None
+
+
+# ---------------------------------------------------------------------------
+# start() — e2e warning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_warns_for_e2e(monkeypatch, caplog):
+    import logging
+
+    monkeypatch.setenv("MX_TOKEN", "tok")
+    cfg = _make_config(e2e=True)
+    adapter = MatrixGateway(cfg, _make_gateway_mock())
+
+    with caplog.at_level(logging.WARNING):
+        await adapter.start()
+
+    warning_text = caplog.text.lower()
+    assert "e2e" in warning_text or "encryption" in warning_text
+    await adapter.stop()
+
+
+# ---------------------------------------------------------------------------
+# stop() — not started
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stop_when_not_started():
+    adapter = MatrixGateway(_make_config(), _make_gateway_mock())
+    await adapter.stop()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# send_text
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_text_puts_message_event(monkeypatch):
+    monkeypatch.setenv("MX_TOKEN", "tok")
+    client = _make_http_client()
+    adapter = MatrixGateway(_make_config(), _make_gateway_mock(), http_client=client)
+    adapter._access_token = "tok"
+
+    await adapter.send_text("!room:example.com", "hello matrix")
+
+    assert client.put.called
+    url = client.put.call_args[0][0]
+    assert "rooms" in url
+    assert "send" in url
+    body = client.put.call_args[1]["json"]
+    assert body["body"] == "hello matrix"
+    assert body["msgtype"] == "m.text"
+
+
+@pytest.mark.asyncio
+async def test_send_text_truncates_long_message(monkeypatch):
+    monkeypatch.setenv("MX_TOKEN", "tok")
+    client = _make_http_client()
+    cfg = MatrixChannelConfig(
+        enabled=True,
+        homeserver="https://matrix.example.com",
+        user_id_env="MX_USER",
+        access_token_env="MX_TOKEN",
+        message_max_chars=10,
+        retry_delay=0.0,
+    )
+    adapter = MatrixGateway(cfg, _make_gateway_mock(), http_client=client)
+    adapter._access_token = "tok"
+
+    await adapter.send_text("!r:h", "x" * 20)
+
+    body = client.put.call_args[1]["json"]["body"]
+    assert len(body) <= 10
+    assert body.endswith("...")
+
+
+# ---------------------------------------------------------------------------
+# send_image
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_image_uploads_then_sends_event(monkeypatch):
+    monkeypatch.setenv("MX_TOKEN", "tok")
+    client = _make_http_client(post_json={"content_uri": "mxc://host/abc"})
+    adapter = MatrixGateway(_make_config(), _make_gateway_mock(), http_client=client)
+    adapter._access_token = "tok"
+
+    await adapter.send_image("!r:h", b"\x89PNG", caption="test")
+
+    # First post = media upload, then put = message event
+    assert client.post.called
+    assert client.put.called
+    body = client.put.call_args[1]["json"]
+    assert body["msgtype"] == "m.image"
+    assert body["url"] == "mxc://host/abc"
+
+
+# ---------------------------------------------------------------------------
+# send_audio
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_audio_uploads_then_sends_event(monkeypatch):
+    monkeypatch.setenv("MX_TOKEN", "tok")
+    client = _make_http_client(post_json={"content_uri": "mxc://host/ogg"})
+    adapter = MatrixGateway(_make_config(), _make_gateway_mock(), http_client=client)
+    adapter._access_token = "tok"
+
+    await adapter.send_audio("!r:h", b"OGG")
+
+    assert client.post.called
+    assert client.put.called
+    body = client.put.call_args[1]["json"]
+    assert body["msgtype"] == "m.audio"
+
+
+# ---------------------------------------------------------------------------
+# _handle_event
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_event_dispatches_text_message(monkeypatch):
+    monkeypatch.setenv("MX_TOKEN", "tok")
+    client = _make_http_client()
+    gw = _make_gateway_mock("reply")
+    cfg = _make_config()
+    adapter = MatrixGateway(cfg, gw, http_client=client)
+    adapter._access_token = "tok"
+    adapter._user_id = "@bot:example.com"
+
+    handler = AsyncMock()
+    adapter.on_message(handler)
+
+    event: dict[str, Any] = {
+        "type": "m.room.message",
+        "sender": "@alice:example.com",
+        "content": {"msgtype": "m.text", "body": "hello matrix"},
+    }
+    await adapter._handle_event("!room:example.com", event)
+
+    gw.handle_message.assert_awaited_once_with("matrix:!room:example.com", "hello matrix")
+    handler.assert_awaited_once()
+    assert client.put.called
+
+
+@pytest.mark.asyncio
+async def test_handle_event_ignores_own_messages():
+    gw = _make_gateway_mock()
+    adapter = MatrixGateway(_make_config(), gw)
+    adapter._user_id = "@bot:example.com"
+
+    event: dict[str, Any] = {
+        "type": "m.room.message",
+        "sender": "@bot:example.com",
+        "content": {"msgtype": "m.text", "body": "own message"},
+    }
+    await adapter._handle_event("!room:h", event)
+    gw.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_event_ignores_non_message_events():
+    gw = _make_gateway_mock()
+    adapter = MatrixGateway(_make_config(), gw)
+    adapter._user_id = "@bot:h"
+
+    event: dict[str, Any] = {
+        "type": "m.room.member",
+        "sender": "@alice:h",
+        "content": {"membership": "join"},
+    }
+    await adapter._handle_event("!room:h", event)
+    gw.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_event_ignores_non_text_msgtype():
+    gw = _make_gateway_mock()
+    adapter = MatrixGateway(_make_config(), gw)
+    adapter._user_id = "@bot:h"
+
+    event: dict[str, Any] = {
+        "type": "m.room.message",
+        "sender": "@alice:h",
+        "content": {"msgtype": "m.image", "url": "mxc://h/abc"},
+    }
+    await adapter._handle_event("!room:h", event)
+    gw.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_event_agent_exception(monkeypatch):
+    monkeypatch.setenv("MX_TOKEN", "tok")
+    client = _make_http_client()
+    gw = MagicMock()
+    gw.handle_message = AsyncMock(side_effect=RuntimeError("crash"))
+    adapter = MatrixGateway(_make_config(), gw, http_client=client)
+    adapter._access_token = "tok"
+    adapter._user_id = "@bot:h"
+
+    event: dict[str, Any] = {
+        "type": "m.room.message",
+        "sender": "@alice:h",
+        "content": {"msgtype": "m.text", "body": "hi"},
+    }
+    # Should not raise
+    await adapter._handle_event("!room:h", event)
+    # Error fallback sent
+    assert client.put.called
+
+
+# ---------------------------------------------------------------------------
+# _sync_once
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sync_once_processes_timeline_events(monkeypatch):
+    monkeypatch.setenv("MX_TOKEN", "tok")
+    gw = _make_gateway_mock("ok")
+    client = _make_http_client(
+        get_json={
+            "next_batch": "t2",
+            "rooms": {
+                "join": {
+                    "!room:h": {
+                        "timeline": {
+                            "events": [
+                                {
+                                    "type": "m.room.message",
+                                    "sender": "@alice:h",
+                                    "content": {"msgtype": "m.text", "body": "hello"},
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+        }
+    )
+    adapter = MatrixGateway(_make_config(), gw, http_client=client)
+    adapter._access_token = "tok"
+    adapter._user_id = "@bot:h"
+
+    await adapter._sync_once()
+
+    assert adapter._next_batch == "t2"
+    gw.handle_message.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# _quote helper
+# ---------------------------------------------------------------------------
+
+
+def test_quote_encodes_room_id():
+    result = _quote("!abc:matrix.example.com")
+    assert "!" not in result or "%21" in result
+    assert ":" not in result
+
+
+# ---------------------------------------------------------------------------
+# run() — no token
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_returns_cleanly_when_no_token():
+    cfg = _make_config(access_token_env="MX_MISSING_XYZ")
+    adapter = MatrixGateway(cfg, _make_gateway_mock())
+    await asyncio.wait_for(adapter.run(), timeout=1.0)
+
+
+# ---------------------------------------------------------------------------
+# Additional coverage: start/stop with token, _run retry loop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_creates_task_and_stop_cancels(monkeypatch):
+    """start() creates task; stop() cancels and clears it."""
+    monkeypatch.setenv("MX_TOKEN", "tok")
+    cancel_called = False
+
+    async def fake_run() -> None:
+        nonlocal cancel_called
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cancel_called = True
+            raise
+
+    adapter = MatrixGateway(_make_config(), _make_gateway_mock())
+    adapter._access_token = "tok"
+    adapter._run = fake_run
+
+    await adapter.start()
+    assert adapter._task is not None
+    await asyncio.sleep(0)  # allow task to start
+    await adapter.stop()
+    assert adapter._task is None
+    assert cancel_called
+
+
+@pytest.mark.asyncio
+async def test_run_retries_on_sync_error(monkeypatch):
+    """_run() retries on sync error, stops on CancelledError."""
+    monkeypatch.setenv("MX_TOKEN", "tok")
+    call_count = 0
+
+    async def fake_sync() -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError("sync failure")
+        raise asyncio.CancelledError
+
+    adapter = MatrixGateway(_make_config(), _make_gateway_mock())
+    adapter._access_token = "tok"
+    adapter._sync_once = fake_sync
+
+    with pytest.raises(asyncio.CancelledError):
+        await adapter._run()
+
+    assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_run_convenience_wrapper(monkeypatch):
+    monkeypatch.setenv("MX_TOKEN", "tok")
+
+    async def quick_run() -> None:
+        raise asyncio.CancelledError
+
+    adapter = MatrixGateway(_make_config(), _make_gateway_mock())
+    adapter._access_token = "tok"
+    adapter._run = quick_run
+
+    await asyncio.wait_for(adapter.run(), timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_sync_once_with_next_batch_token(monkeypatch):
+    """_sync_once sends 'since' param when next_batch is set."""
+    monkeypatch.setenv("MX_TOKEN", "tok")
+    client = _make_http_client(get_json={"next_batch": "t99", "rooms": {}})
+    adapter = MatrixGateway(_make_config(), _make_gateway_mock(), http_client=client)
+    adapter._access_token = "tok"
+    adapter._next_batch = "t55"
+
+    await adapter._sync_once()
+
+    call_params = client.get.call_args[1]["params"]
+    assert call_params["since"] == "t55"
+    assert adapter._next_batch == "t99"

--- a/tests/test_ravn/test_gateway_slack.py
+++ b/tests/test_ravn/test_gateway_slack.py
@@ -1,0 +1,556 @@
+"""Tests for the Slack gateway adapter."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ravn.adapters.channels.gateway_slack import (
+    _SLASH_PROMPTS,
+    SlackGateway,
+)
+from ravn.config import SlackChannelConfig
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(
+    bot_token_env: str = "SLACK_TOKEN",
+    poll_interval: float = 0.0,
+) -> SlackChannelConfig:
+    return SlackChannelConfig(
+        enabled=True,
+        bot_token_env=bot_token_env,
+        poll_interval=poll_interval,
+        message_max_chars=3000,
+        retry_delay=0.01,
+        api_base="https://slack.example.com/api",
+    )
+
+
+def _make_gateway_mock(response: str = "agent reply") -> MagicMock:
+    gw = MagicMock()
+    gw.handle_message = AsyncMock(return_value=response)
+    return gw
+
+
+def _make_http_client(
+    post_json: dict | None = None,
+    get_json: dict | None = None,
+) -> AsyncMock:
+    post_resp = MagicMock()
+    post_resp.raise_for_status = MagicMock()
+    post_resp.json = MagicMock(return_value=post_json or {"ok": True})
+
+    get_resp = MagicMock()
+    get_resp.raise_for_status = MagicMock()
+    get_resp.json = MagicMock(return_value=get_json or {"ok": True, "channels": [], "messages": []})
+
+    client = AsyncMock()
+    client.post = AsyncMock(return_value=post_resp)
+    client.get = AsyncMock(return_value=get_resp)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# on_message
+# ---------------------------------------------------------------------------
+
+
+def test_on_message_registers_handler():
+    adapter = SlackGateway(_make_config(), _make_gateway_mock())
+    handler = AsyncMock()
+    adapter.on_message(handler)
+    assert adapter._handler is handler
+
+
+# ---------------------------------------------------------------------------
+# send_text
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_text_posts_to_api(monkeypatch):
+    monkeypatch.setenv("SLACK_TOKEN", "xoxb-test")
+    client = _make_http_client()
+    adapter = SlackGateway(_make_config(), _make_gateway_mock(), http_client=client)
+    adapter._bot_token = "xoxb-test"
+
+    await adapter.send_text("C0123", "hello slack")
+
+    assert client.post.called
+    call_json = client.post.call_args[1]["json"]
+    assert call_json["channel"] == "C0123"
+    assert call_json["text"] == "hello slack"
+
+
+@pytest.mark.asyncio
+async def test_send_text_truncates_long_message(monkeypatch):
+    monkeypatch.setenv("SLACK_TOKEN", "tok")
+    client = _make_http_client()
+    cfg = SlackChannelConfig(
+        enabled=True,
+        bot_token_env="SLACK_TOKEN",
+        message_max_chars=10,
+        retry_delay=0.0,
+        api_base="https://slack.example.com/api",
+    )
+    adapter = SlackGateway(cfg, _make_gateway_mock(), http_client=client)
+    adapter._bot_token = "tok"
+
+    await adapter.send_text("C1", "x" * 20)
+
+    sent = client.post.call_args[1]["json"]["text"]
+    assert len(sent) <= 10
+    assert sent.endswith("...")
+
+
+# ---------------------------------------------------------------------------
+# send_image / send_audio
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_image_calls_files_upload(monkeypatch):
+    monkeypatch.setenv("SLACK_TOKEN", "tok")
+    client = _make_http_client()
+    adapter = SlackGateway(_make_config(), _make_gateway_mock(), http_client=client)
+    adapter._bot_token = "tok"
+
+    await adapter.send_image("C1", b"\x89PNG", caption="cap")
+
+    assert client.post.called
+    call_url = client.post.call_args[0][0]
+    assert "files.upload" in call_url
+
+
+@pytest.mark.asyncio
+async def test_send_audio_calls_files_upload(monkeypatch):
+    monkeypatch.setenv("SLACK_TOKEN", "tok")
+    client = _make_http_client()
+    adapter = SlackGateway(_make_config(), _make_gateway_mock(), http_client=client)
+    adapter._bot_token = "tok"
+
+    await adapter.send_audio("C1", b"OGG_DATA")
+
+    assert client.post.called
+    call_url = client.post.call_args[0][0]
+    assert "files.upload" in call_url
+
+
+# ---------------------------------------------------------------------------
+# start() — missing token
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_returns_early_when_no_token(caplog):
+    import logging
+
+    cfg = _make_config(bot_token_env="SLACK_MISSING_TOKEN_XYZ")
+    adapter = SlackGateway(cfg, _make_gateway_mock())
+
+    with caplog.at_level(logging.ERROR):
+        await adapter.start()
+
+    assert "SLACK_MISSING_TOKEN_XYZ" in caplog.text
+    assert adapter._task is None
+
+
+# ---------------------------------------------------------------------------
+# stop() — not started
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stop_when_not_started():
+    adapter = SlackGateway(_make_config(), _make_gateway_mock())
+    await adapter.stop()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# _should_handle
+# ---------------------------------------------------------------------------
+
+
+def test_should_handle_dm_channel():
+    adapter = SlackGateway(_make_config(), _make_gateway_mock())
+    adapter._bot_user_id = "UBOT"
+    assert adapter._should_handle("D12345", "anything") is True
+
+
+def test_should_handle_mention():
+    adapter = SlackGateway(_make_config(), _make_gateway_mock())
+    adapter._bot_user_id = "UBOT"
+    assert adapter._should_handle("C12345", "<@UBOT> hello") is True
+
+
+def test_should_handle_not_mentioned():
+    adapter = SlackGateway(_make_config(), _make_gateway_mock())
+    adapter._bot_user_id = "UBOT"
+    assert adapter._should_handle("C12345", "hello everyone") is False
+
+
+def test_should_handle_slash_command():
+    adapter = SlackGateway(_make_config(), _make_gateway_mock())
+    adapter._bot_user_id = "UBOT"
+    assert adapter._should_handle("C12345", "/ravn-status") is True
+
+
+# ---------------------------------------------------------------------------
+# _strip_mention
+# ---------------------------------------------------------------------------
+
+
+def test_strip_mention_removes_bot_mention():
+    adapter = SlackGateway(_make_config(), _make_gateway_mock())
+    adapter._bot_user_id = "UBOT"
+    assert adapter._strip_mention("<@UBOT> hello world") == "hello world"
+
+
+def test_strip_mention_no_mention_unchanged():
+    adapter = SlackGateway(_make_config(), _make_gateway_mock())
+    adapter._bot_user_id = "UBOT"
+    assert adapter._strip_mention("hello world") == "hello world"
+
+
+# ---------------------------------------------------------------------------
+# _translate_slash
+# ---------------------------------------------------------------------------
+
+
+def test_translate_slash_plain_unchanged():
+    adapter = SlackGateway(_make_config(), _make_gateway_mock())
+    assert adapter._translate_slash("hello") == "hello"
+
+
+@pytest.mark.parametrize("cmd", list(_SLASH_PROMPTS.keys()))
+def test_translate_slash_known_commands(cmd: str):
+    adapter = SlackGateway(_make_config(), _make_gateway_mock())
+    assert adapter._translate_slash(cmd) == _SLASH_PROMPTS[cmd]
+
+
+# ---------------------------------------------------------------------------
+# _poll_channel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_poll_channel_dispatches_mention(monkeypatch):
+    monkeypatch.setenv("SLACK_TOKEN", "tok")
+    import time
+
+    old_ts = str(time.time() - 100)
+    new_ts = str(time.time())
+
+    gw = _make_gateway_mock("reply")
+    client = _make_http_client(
+        get_json={
+            "ok": True,
+            "messages": [
+                {
+                    "ts": new_ts,
+                    "user": "UUSER",
+                    "text": "<@UBOT> hello",
+                }
+            ],
+        }
+    )
+    adapter = SlackGateway(_make_config(), gw, http_client=client)
+    adapter._bot_token = "tok"
+    adapter._bot_user_id = "UBOT"
+    adapter._channel_cursors["C1"] = old_ts
+
+    handler = AsyncMock()
+    adapter.on_message(handler)
+
+    await adapter._poll_channel("C1")
+
+    gw.handle_message.assert_awaited_once()
+    session_id = gw.handle_message.call_args[0][0]
+    assert session_id == "slack:C1"
+    handler.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_poll_channel_skips_bot_messages(monkeypatch):
+    monkeypatch.setenv("SLACK_TOKEN", "tok")
+    import time
+
+    gw = _make_gateway_mock()
+    client = _make_http_client(
+        get_json={
+            "ok": True,
+            "messages": [
+                {
+                    "ts": str(time.time()),
+                    "bot_id": "BBOT",
+                    "text": "bot post",
+                }
+            ],
+        }
+    )
+    adapter = SlackGateway(_make_config(), gw, http_client=client)
+    adapter._bot_token = "tok"
+    adapter._bot_user_id = "UBOT"
+    adapter._channel_cursors["C1"] = "0"
+
+    await adapter._poll_channel("C1")
+    gw.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_poll_channel_skips_own_messages(monkeypatch):
+    monkeypatch.setenv("SLACK_TOKEN", "tok")
+    import time
+
+    gw = _make_gateway_mock()
+    client = _make_http_client(
+        get_json={
+            "ok": True,
+            "messages": [
+                {
+                    "ts": str(time.time()),
+                    "user": "UBOT",  # own user ID
+                    "text": "my own message",
+                }
+            ],
+        }
+    )
+    adapter = SlackGateway(_make_config(), gw, http_client=client)
+    adapter._bot_token = "tok"
+    adapter._bot_user_id = "UBOT"
+    adapter._channel_cursors["C1"] = "0"
+
+    await adapter._poll_channel("C1")
+    gw.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_poll_channel_handles_agent_exception(monkeypatch):
+    monkeypatch.setenv("SLACK_TOKEN", "tok")
+    import time
+
+    gw = MagicMock()
+    gw.handle_message = AsyncMock(side_effect=RuntimeError("crash"))
+    client = _make_http_client(
+        get_json={
+            "ok": True,
+            "messages": [
+                {
+                    "ts": str(time.time()),
+                    "user": "UUSER",
+                    "text": "<@UBOT> help",
+                }
+            ],
+        }
+    )
+    adapter = SlackGateway(_make_config(), gw, http_client=client)
+    adapter._bot_token = "tok"
+    adapter._bot_user_id = "UBOT"
+    adapter._channel_cursors["C1"] = "0"
+
+    # Should not raise
+    await adapter._poll_channel("C1")
+    # Error fallback message sent
+    assert client.post.called
+
+
+# ---------------------------------------------------------------------------
+# _resolve_bot_identity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_bot_identity(monkeypatch):
+    monkeypatch.setenv("SLACK_TOKEN", "tok")
+    client = _make_http_client(post_json={"ok": True, "user_id": "UBOT123"})
+    adapter = SlackGateway(_make_config(), _make_gateway_mock(), http_client=client)
+    adapter._bot_token = "tok"
+
+    await adapter._resolve_bot_identity()
+    assert adapter._bot_user_id == "UBOT123"
+
+
+# ---------------------------------------------------------------------------
+# run() — no token
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_returns_cleanly_when_no_token():
+    cfg = _make_config(bot_token_env="SLACK_MISSING_XYZ")
+    adapter = SlackGateway(cfg, _make_gateway_mock())
+    await asyncio.wait_for(adapter.run(), timeout=1.0)
+
+
+# ---------------------------------------------------------------------------
+# Additional coverage: _discover_channels, _poll_all_channels, _run loop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_discover_channels_populates_watched(monkeypatch):
+    monkeypatch.setenv("SLACK_TOKEN", "tok")
+    client = _make_http_client(
+        get_json={
+            "ok": True,
+            "channels": [
+                {"id": "C001", "is_member": True},
+                {"id": "C002", "is_member": False},
+                {"id": "C003", "is_member": True},
+            ],
+        }
+    )
+    adapter = SlackGateway(_make_config(), _make_gateway_mock(), http_client=client)
+    adapter._bot_token = "tok"
+
+    await adapter._discover_channels()
+
+    assert "C001" in adapter._watched_channels
+    assert "C002" not in adapter._watched_channels
+    assert "C003" in adapter._watched_channels
+    # Cursors seeded for watched channels
+    assert "C001" in adapter._channel_cursors
+    assert "C003" in adapter._channel_cursors
+
+
+@pytest.mark.asyncio
+async def test_poll_all_channels_calls_each(monkeypatch):
+    monkeypatch.setenv("SLACK_TOKEN", "tok")
+    client = _make_http_client(get_json={"ok": True, "messages": []})
+    adapter = SlackGateway(_make_config(), _make_gateway_mock(), http_client=client)
+    adapter._bot_token = "tok"
+    adapter._watched_channels = ["C001", "C002"]
+    adapter._channel_cursors = {"C001": "0", "C002": "0"}
+
+    await adapter._poll_all_channels()
+
+    # GET called once per channel
+    assert client.get.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_run_loop_stops_on_cancel(monkeypatch):
+    """_run() resolves identity, discovers channels, then stops on CancelledError."""
+    monkeypatch.setenv("SLACK_TOKEN", "tok")
+
+    call_count = 0
+
+    async def fake_resolve():
+        pass
+
+    async def fake_discover():
+        pass
+
+    async def fake_poll():
+        nonlocal call_count
+        call_count += 1
+        raise asyncio.CancelledError
+
+    adapter = SlackGateway(_make_config(), _make_gateway_mock())
+    adapter._bot_token = "tok"
+    adapter._resolve_bot_identity = fake_resolve
+    adapter._discover_channels = fake_discover
+    adapter._poll_all_channels = fake_poll
+
+    with pytest.raises(asyncio.CancelledError):
+        await adapter._run()
+
+    assert call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_run_loop_retries_on_exception(monkeypatch):
+    """_run() retries polling after a transient exception."""
+    monkeypatch.setenv("SLACK_TOKEN", "tok")
+    call_count = 0
+
+    async def fake_resolve():
+        pass
+
+    async def fake_discover():
+        pass
+
+    async def fake_poll():
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError("transient")
+        raise asyncio.CancelledError
+
+    adapter = SlackGateway(_make_config(poll_interval=0.0), _make_gateway_mock())
+    adapter._bot_token = "tok"
+    adapter._resolve_bot_identity = fake_resolve
+    adapter._discover_channels = fake_discover
+    adapter._poll_all_channels = fake_poll
+
+    with pytest.raises(asyncio.CancelledError):
+        await adapter._run()
+
+    assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_run_startup_exception_returns(caplog):
+    """_run() returns early if identity resolution fails."""
+    import logging
+
+    async def boom():
+        raise RuntimeError("startup fail")
+
+    adapter = SlackGateway(_make_config(), _make_gateway_mock())
+    adapter._bot_token = "tok"
+    adapter._resolve_bot_identity = boom
+
+    with caplog.at_level(logging.ERROR):
+        await adapter._run()
+
+    # No exception propagated; error logged
+    assert "startup" in caplog.text.lower() or "failed" in caplog.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_start_creates_task_and_stop_cancels(monkeypatch):
+    monkeypatch.setenv("SLACK_TOKEN", "tok")
+
+    cancel_called = False
+
+    async def fake_run():
+        nonlocal cancel_called
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cancel_called = True
+            raise
+
+    adapter = SlackGateway(_make_config(), _make_gateway_mock())
+    adapter._bot_token = "tok"
+    adapter._run = fake_run
+
+    await adapter.start()
+    assert adapter._task is not None
+    await asyncio.sleep(0)  # allow task to start
+    await adapter.stop()
+    assert adapter._task is None
+    assert cancel_called
+
+
+@pytest.mark.asyncio
+async def test_run_convenience_wrapper(monkeypatch):
+    """run() starts and awaits the internal task, handles CancelledError."""
+    monkeypatch.setenv("SLACK_TOKEN", "tok")
+
+    async def immediate_cancel():
+        raise asyncio.CancelledError
+
+    adapter = SlackGateway(_make_config(), _make_gateway_mock())
+    adapter._bot_token = "tok"
+    adapter._run = immediate_cancel
+
+    # run() should return cleanly (no propagation) even with no token scenario
+    await asyncio.wait_for(adapter.run(), timeout=1.0)

--- a/tests/test_ravn/test_gateway_whatsapp.py
+++ b/tests/test_ravn/test_gateway_whatsapp.py
@@ -1,0 +1,496 @@
+"""Tests for the WhatsApp gateway adapter."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ravn.adapters.channels.gateway_whatsapp import WhatsAppGateway
+from ravn.config import WhatsAppChannelConfig
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(
+    api_key_env: str = "WA_KEY",
+    phone_number_id_env: str = "WA_PHONE",
+    webhook_verify_token_env: str = "WA_VERIFY",
+    mode: str = "business_api",
+    message_max_chars: int = 4096,
+) -> WhatsAppChannelConfig:
+    return WhatsAppChannelConfig(
+        enabled=True,
+        mode=mode,
+        api_key_env=api_key_env,
+        phone_number_id_env=phone_number_id_env,
+        webhook_verify_token_env=webhook_verify_token_env,
+        webhook_host="127.0.0.1",
+        webhook_port=17478,
+        retry_delay=0.01,
+        message_max_chars=message_max_chars,
+        api_base="https://graph.example.com/v18.0",
+    )
+
+
+def _make_gateway_mock(response: str = "agent reply") -> MagicMock:
+    gw = MagicMock()
+    gw.handle_message = AsyncMock(return_value=response)
+    return gw
+
+
+def _make_http_client(post_json: dict | None = None) -> AsyncMock:
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json = MagicMock(return_value=post_json or {"messages": [{"id": "wamid.123"}]})
+
+    client = AsyncMock()
+    client.post = AsyncMock(return_value=resp)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# local_bridge mode raises NotImplementedError
+# ---------------------------------------------------------------------------
+
+
+def test_local_bridge_mode_raises():
+    cfg = _make_config(mode="local_bridge")
+    with pytest.raises(NotImplementedError, match="local_bridge"):
+        WhatsAppGateway(cfg, _make_gateway_mock())
+
+
+# ---------------------------------------------------------------------------
+# on_message
+# ---------------------------------------------------------------------------
+
+
+def test_on_message_registers_handler():
+    adapter = WhatsAppGateway(_make_config(), _make_gateway_mock())
+    handler = AsyncMock()
+    adapter.on_message(handler)
+    assert adapter._handler is handler
+
+
+# ---------------------------------------------------------------------------
+# start() — missing API key
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_returns_early_when_no_api_key(caplog):
+    import logging
+
+    cfg = _make_config(api_key_env="WA_MISSING_KEY_XYZ")
+    adapter = WhatsAppGateway(cfg, _make_gateway_mock())
+
+    with caplog.at_level(logging.ERROR):
+        await adapter.start()
+
+    assert "WA_MISSING_KEY_XYZ" in caplog.text
+    assert adapter._server_task is None
+
+
+# ---------------------------------------------------------------------------
+# stop() — not started
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stop_when_not_started():
+    adapter = WhatsAppGateway(_make_config(), _make_gateway_mock())
+    await adapter.stop()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# send_text
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_text_posts_to_graph_api(monkeypatch):
+    monkeypatch.setenv("WA_KEY", "Bearer tok")
+    monkeypatch.setenv("WA_PHONE", "12345678")
+    client = _make_http_client()
+    adapter = WhatsAppGateway(_make_config(), _make_gateway_mock(), http_client=client)
+    adapter._api_key = "Bearer tok"
+    adapter._phone_number_id = "12345678"
+
+    await adapter.send_text("+49123456", "hello whatsapp")
+
+    assert client.post.called
+    call_url = client.post.call_args[0][0]
+    assert "12345678/messages" in call_url
+    payload = client.post.call_args[1]["json"]
+    assert payload["to"] == "+49123456"
+    assert payload["text"]["body"] == "hello whatsapp"
+    assert payload["type"] == "text"
+
+
+@pytest.mark.asyncio
+async def test_send_text_truncates_long_message(monkeypatch):
+    monkeypatch.setenv("WA_KEY", "tok")
+    monkeypatch.setenv("WA_PHONE", "99999")
+    client = _make_http_client()
+    cfg = _make_config(message_max_chars=10)
+    adapter = WhatsAppGateway(cfg, _make_gateway_mock(), http_client=client)
+    adapter._api_key = "tok"
+    adapter._phone_number_id = "99999"
+
+    await adapter.send_text("+1", "x" * 20)
+
+    body = client.post.call_args[1]["json"]["text"]["body"]
+    assert len(body) <= 10
+    assert body.endswith("...")
+
+
+# ---------------------------------------------------------------------------
+# send_image / send_audio
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_image_uploads_and_sends(monkeypatch):
+    monkeypatch.setenv("WA_KEY", "tok")
+    monkeypatch.setenv("WA_PHONE", "99999")
+    media_resp = MagicMock()
+    media_resp.raise_for_status = MagicMock()
+    media_resp.json = MagicMock(return_value={"id": "media_id_123"})
+
+    msg_resp = MagicMock()
+    msg_resp.raise_for_status = MagicMock()
+    msg_resp.json = MagicMock(return_value={"messages": [{"id": "wamid1"}]})
+
+    client = AsyncMock()
+    client.post = AsyncMock(side_effect=[media_resp, msg_resp])
+
+    adapter = WhatsAppGateway(_make_config(), _make_gateway_mock(), http_client=client)
+    adapter._api_key = "tok"
+    adapter._phone_number_id = "99999"
+
+    await adapter.send_image("+1", b"\x89PNG", caption="img cap")
+
+    assert client.post.call_count == 2
+    msg_payload = client.post.call_args[1]["json"]
+    assert msg_payload["type"] == "image"
+    assert msg_payload["image"]["id"] == "media_id_123"
+    assert msg_payload["image"]["caption"] == "img cap"
+
+
+@pytest.mark.asyncio
+async def test_send_audio_uploads_and_sends(monkeypatch):
+    monkeypatch.setenv("WA_KEY", "tok")
+    monkeypatch.setenv("WA_PHONE", "99999")
+    media_resp = MagicMock()
+    media_resp.raise_for_status = MagicMock()
+    media_resp.json = MagicMock(return_value={"id": "audio_media_id"})
+
+    msg_resp = MagicMock()
+    msg_resp.raise_for_status = MagicMock()
+    msg_resp.json = MagicMock(return_value={"messages": [{"id": "wamid2"}]})
+
+    client = AsyncMock()
+    client.post = AsyncMock(side_effect=[media_resp, msg_resp])
+
+    adapter = WhatsAppGateway(_make_config(), _make_gateway_mock(), http_client=client)
+    adapter._api_key = "tok"
+    adapter._phone_number_id = "99999"
+
+    await adapter.send_audio("+1", b"OGG_DATA")
+
+    assert client.post.call_count == 2
+    msg_payload = client.post.call_args[1]["json"]
+    assert msg_payload["type"] == "audio"
+    assert msg_payload["audio"]["id"] == "audio_media_id"
+
+
+# ---------------------------------------------------------------------------
+# _handle_message
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_message_text(monkeypatch):
+    monkeypatch.setenv("WA_KEY", "tok")
+    monkeypatch.setenv("WA_PHONE", "99999")
+    client = _make_http_client()
+    gw = _make_gateway_mock("reply")
+    adapter = WhatsAppGateway(_make_config(), gw, http_client=client)
+    adapter._api_key = "tok"
+    adapter._phone_number_id = "99999"
+
+    handler = AsyncMock()
+    adapter.on_message(handler)
+
+    msg: dict[str, Any] = {
+        "type": "text",
+        "from": "+4912345",
+        "text": {"body": "hello"},
+    }
+    await adapter._handle_message(msg)
+
+    gw.handle_message.assert_awaited_once_with("whatsapp:+4912345", "hello")
+    handler.assert_awaited_once_with("+4912345", "hello")
+    assert client.post.called
+
+
+@pytest.mark.asyncio
+async def test_handle_message_audio_sends_stub():
+    """Voice messages are flagged with a stub pending NIU-533."""
+    gw = _make_gateway_mock("ok")
+    client = _make_http_client()
+    adapter = WhatsAppGateway(_make_config(), gw, http_client=client)
+    adapter._api_key = "tok"
+    adapter._phone_number_id = "99999"
+
+    msg: dict[str, Any] = {
+        "type": "audio",
+        "from": "+4912345",
+        "audio": {"id": "aud1"},
+    }
+    await adapter._handle_message(msg)
+
+    prompt = gw.handle_message.call_args[0][1]
+    assert "STT" in prompt or "Voice" in prompt
+
+
+@pytest.mark.asyncio
+async def test_handle_message_image_uses_caption():
+    gw = _make_gateway_mock("ok")
+    client = _make_http_client()
+    adapter = WhatsAppGateway(_make_config(), gw, http_client=client)
+    adapter._api_key = "tok"
+    adapter._phone_number_id = "99999"
+
+    msg: dict[str, Any] = {
+        "type": "image",
+        "from": "+49",
+        "image": {"id": "img1", "caption": "my photo"},
+    }
+    await adapter._handle_message(msg)
+
+    prompt = gw.handle_message.call_args[0][1]
+    assert "my photo" in prompt
+
+
+@pytest.mark.asyncio
+async def test_handle_message_unknown_type_ignored():
+    gw = _make_gateway_mock()
+    adapter = WhatsAppGateway(_make_config(), gw)
+
+    msg: dict[str, Any] = {"type": "sticker", "from": "+49"}
+    await adapter._handle_message(msg)
+    gw.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_message_agent_exception(monkeypatch):
+    monkeypatch.setenv("WA_KEY", "tok")
+    monkeypatch.setenv("WA_PHONE", "99")
+    client = _make_http_client()
+    gw = MagicMock()
+    gw.handle_message = AsyncMock(side_effect=RuntimeError("crash"))
+    adapter = WhatsAppGateway(_make_config(), gw, http_client=client)
+    adapter._api_key = "tok"
+    adapter._phone_number_id = "99"
+
+    msg: dict[str, Any] = {
+        "type": "text",
+        "from": "+49",
+        "text": {"body": "hi"},
+    }
+    # Should not raise
+    await adapter._handle_message(msg)
+    # Error fallback sent
+    assert client.post.called
+
+
+# ---------------------------------------------------------------------------
+# _handle_webhook_body
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_webhook_body_dispatches_messages():
+    gw = _make_gateway_mock("ok")
+    client = _make_http_client()
+    adapter = WhatsAppGateway(_make_config(), gw, http_client=client)
+    adapter._api_key = "tok"
+    adapter._phone_number_id = "99999"
+
+    body: dict[str, Any] = {
+        "entry": [
+            {
+                "changes": [
+                    {
+                        "value": {
+                            "messages": [
+                                {
+                                    "type": "text",
+                                    "from": "+49",
+                                    "text": {"body": "test"},
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+    await adapter._handle_webhook_body(body)
+
+    gw.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_webhook_body_empty_does_not_raise():
+    adapter = WhatsAppGateway(_make_config(), _make_gateway_mock())
+    await adapter._handle_webhook_body({})
+    await adapter._handle_webhook_body({"entry": []})
+
+
+# ---------------------------------------------------------------------------
+# run() — no API key
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_returns_cleanly_when_no_api_key():
+    cfg = _make_config(api_key_env="WA_MISSING_KEY_XYZ")
+    adapter = WhatsAppGateway(cfg, _make_gateway_mock())
+    await asyncio.wait_for(adapter.run(), timeout=1.0)
+
+
+# ---------------------------------------------------------------------------
+# GatewayChannelPort — port conformance
+# ---------------------------------------------------------------------------
+
+
+def test_port_conformance():
+    """WhatsAppGateway satisfies GatewayChannelPort."""
+    from ravn.ports.gateway_channel import GatewayChannelPort
+
+    adapter = WhatsAppGateway(_make_config(), _make_gateway_mock())
+    assert isinstance(adapter, GatewayChannelPort)
+
+
+# ---------------------------------------------------------------------------
+# Additional coverage: _handle_webhook_body edge cases, start/stop lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_creates_task_and_stop_cancels(monkeypatch):
+    """start() creates server_task; stop() cancels it."""
+    monkeypatch.setenv("WA_KEY", "tok")
+    monkeypatch.setenv("WA_PHONE", "99999")
+    cancel_called = False
+
+    async def fake_serve():
+        nonlocal cancel_called
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cancel_called = True
+            raise
+
+    adapter = WhatsAppGateway(_make_config(), _make_gateway_mock())
+    adapter._api_key = "tok"
+    adapter._run_webhook_server = fake_serve
+
+    await adapter.start()
+    assert adapter._server_task is not None
+    await asyncio.sleep(0)  # allow task to start
+    await adapter.stop()
+    assert adapter._server_task is None
+    assert cancel_called
+
+
+@pytest.mark.asyncio
+async def test_run_convenience_wrapper_no_api_key():
+    """run() returns cleanly when API key is missing."""
+    cfg = _make_config(api_key_env="WA_MISSING_KEY_XYZ")
+    adapter = WhatsAppGateway(cfg, _make_gateway_mock())
+    await asyncio.wait_for(adapter.run(), timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_handle_webhook_body_multiple_entries():
+    """_handle_webhook_body dispatches from multiple entries."""
+    gw = _make_gateway_mock("ok")
+    client = _make_http_client()
+    adapter = WhatsAppGateway(_make_config(), gw, http_client=client)
+    adapter._api_key = "tok"
+    adapter._phone_number_id = "99999"
+
+    body: dict = {
+        "entry": [
+            {
+                "changes": [
+                    {
+                        "value": {
+                            "messages": [{"type": "text", "from": "+49", "text": {"body": "a"}}]
+                        }
+                    }
+                ]
+            },
+            {
+                "changes": [
+                    {
+                        "value": {
+                            "messages": [{"type": "text", "from": "+44", "text": {"body": "b"}}]
+                        }
+                    }
+                ]
+            },
+        ]
+    }
+    await adapter._handle_webhook_body(body)
+    assert gw.handle_message.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_handle_message_image_no_caption():
+    """Image messages with no caption use fallback text."""
+    gw = _make_gateway_mock("ok")
+    client = _make_http_client()
+    adapter = WhatsAppGateway(_make_config(), gw, http_client=client)
+    adapter._api_key = "tok"
+    adapter._phone_number_id = "99999"
+
+    msg: dict = {"type": "image", "from": "+49", "image": {"id": "img1"}}
+    await adapter._handle_message(msg)
+
+    prompt = gw.handle_message.call_args[0][1]
+    assert "[Image received]" in prompt
+
+
+@pytest.mark.asyncio
+async def test_handle_message_text_empty_body_ignored():
+    """Text messages with an empty body are silently dropped."""
+    gw = _make_gateway_mock("ok")
+    adapter = WhatsAppGateway(_make_config(), gw)
+
+    msg: dict = {"type": "text", "from": "+49", "text": {"body": ""}}
+    await adapter._handle_message(msg)
+    gw.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_with_task_handles_cancel(monkeypatch):
+    """run() awaits the server task and swallows CancelledError."""
+    monkeypatch.setenv("WA_KEY", "tok")
+    monkeypatch.setenv("WA_PHONE", "99999")
+
+    async def immediate_cancel() -> None:
+        raise asyncio.CancelledError
+
+    adapter = WhatsAppGateway(_make_config(), _make_gateway_mock())
+    adapter._api_key = "tok"
+    adapter._run_webhook_server = immediate_cancel
+
+    await asyncio.wait_for(adapter.run(), timeout=1.0)

--- a/tests/test_ravn/test_gateway_whatsapp.py
+++ b/tests/test_ravn/test_gateway_whatsapp.py
@@ -494,3 +494,36 @@ async def test_run_with_task_handles_cancel(monkeypatch):
     adapter._run_webhook_server = immediate_cancel
 
     await asyncio.wait_for(adapter.run(), timeout=1.0)
+
+
+# ---------------------------------------------------------------------------
+# _verify_signature
+# ---------------------------------------------------------------------------
+
+
+def test_verify_signature_no_secret_always_passes():
+    """Without a webhook secret, all requests are allowed."""
+    adapter = WhatsAppGateway(_make_config(), _make_gateway_mock())
+    assert adapter._verify_signature(b"body", "") is True
+    assert adapter._verify_signature(b"body", "sha256=wrong") is True
+
+
+def test_verify_signature_correct_hmac():
+    """Correct HMAC digest passes verification."""
+    import hashlib
+    import hmac as _hmac
+
+    secret = "mysecret"
+    adapter = WhatsAppGateway(_make_config(), _make_gateway_mock())
+    adapter._webhook_secret = secret
+
+    body = b'{"entry": []}'
+    digest = "sha256=" + _hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    assert adapter._verify_signature(body, digest) is True
+
+
+def test_verify_signature_wrong_hmac():
+    """Wrong HMAC digest fails verification."""
+    adapter = WhatsAppGateway(_make_config(), _make_gateway_mock())
+    adapter._webhook_secret = "mysecret"
+    assert adapter._verify_signature(b"body", "sha256=deadbeef") is False


### PR DESCRIPTION
## Summary

- **New port**: `GatewayChannelPort` ABC in `src/ravn/ports/gateway_channel.py` — bidirectional interface for `start/stop`, `send_text/image/audio`, and `on_message` handler registration
- **DiscordGateway**: Discord Gateway WebSocket protocol (OP codes HELLO/IDENTIFY/DISPATCH/HEARTBEAT), slash command translation (`/compact`, `/budget`, `/status`, `/stop`, `/todo`), reaction-based approval (👍/👎) on messages with `[APPROVAL_REQUESTED]`
- **SlackGateway**: REST polling via `conversations.history`, DM/mention/slash-command routing, per-channel cursor tracking, bot identity resolution
- **MatrixGateway**: CS API `/sync` long-poll with `next_batch` token, media upload via `/media/v3/upload`, E2E warning, own-message filtering
- **WhatsAppGateway**: Meta Business API webhook receiver (FastAPI/uvicorn) + Graph API sender; text/image/audio routing with STT stub for voice messages
- **Config**: Added `DiscordChannelConfig`, `SlackChannelConfig`, `MatrixChannelConfig`, `WhatsAppChannelConfig`; wired into `GatewayChannelsConfig`
- **CLI**: Wired all four adapters into `_run_gateway` and `_run_daemon`
- **Tests**: 116 unit tests across 5 new test files; 91% coverage on new adapter files

## Test plan

- [x] All 2192 existing tests pass
- [x] `ruff check` clean on all modified/new files
- [x] Coverage 91% total on new files (Discord 87%, Slack 90%, Matrix 90%, WhatsApp 100%, port 100%)
- [x] `test_port_conformance` confirms each adapter satisfies `GatewayChannelPort`
- [x] Start/stop lifecycle tests confirm task cancellation propagates correctly
- [x] Error fallback messages sent on agent exceptions in all four adapters

Closes NIU-536

🤖 Generated with [Claude Code](https://claude.com/claude-code)