### PR TITLE
docs(ravn): comprehensive documentation for all features, config, and CLI

### DIFF
--- a/docs/site/ravn/advanced/cascade.md
+++ b/docs/site/ravn/advanced/cascade.md
@@ -1,0 +1,118 @@
+# Cascade & Parallel Execution
+
+Cascade enables Ravn to coordinate multiple sub-agents working in parallel.
+A coordinator agent breaks work into sub-tasks, dispatches them, monitors
+progress, and collects results.
+
+## Architecture
+
+```mermaid
+graph TD
+    Coordinator -->|task_create| SubAgent1["Sub-Agent 1"]
+    Coordinator -->|task_create| SubAgent2["Sub-Agent 2"]
+    Coordinator -->|task_create| SubAgent3["Sub-Agent 3"]
+    SubAgent1 -->|result| Coordinator
+    SubAgent2 -->|result| Coordinator
+    SubAgent3 -->|result| Coordinator
+    Coordinator -->|task_collect| Results
+```
+
+The coordinator runs the full agent loop with cascade tools available.
+Sub-agents run their own drive loops with a restricted tool set (typically
+the `worker` profile — core tools only).
+
+## Execution Modes
+
+### Mode 1: Local Parallel
+
+Sub-agents spawn as local subprocesses on the same machine. Best for
+single-machine workloads.
+
+### Mode 2: Networked Delegation
+
+Sub-tasks are sent to peer Ravn instances via the mesh transport. Requires
+`mesh.enabled` and at least one reachable peer.
+
+### Mode 3: Ephemeral Spawn
+
+Sub-agents are spawned in Kubernetes pods or Docker containers for isolated
+execution. Requires spawn adapter configuration.
+
+## Cascade Tools
+
+| Tool | Permission | Description |
+|------|-----------|-------------|
+| `task_create` | `cascade:write` | Create a sub-task with prompt, persona, and output mode. |
+| `task_collect` | `cascade:read` | Wait for and collect results from sub-tasks. Blocks until timeout. |
+| `task_status` | `cascade:read` | Check status of a specific sub-task by ID. |
+| `task_list` | `cascade:read` | List all active and completed sub-tasks. |
+| `task_stop` | `cascade:write` | Cancel a running sub-task. |
+
+## Tool Profiles
+
+The coordinator and workers typically use different tool sets:
+
+```yaml
+tools:
+  profiles:
+    coordinator:
+      include_groups: [core, extended, cascade]
+    worker:
+      include_groups: [core]
+```
+
+This prevents sub-agents from spawning their own sub-agents (no cascade
+tools in the worker profile).
+
+## Watchdog
+
+The cascade watchdog monitors sub-agent health:
+
+- **Stuck detection**: if a sub-agent makes no progress for
+  `stuck_timeout_seconds` (default: 60s), it's marked as stuck
+- **Loop detection**: if a sub-agent makes `loop_detection_threshold`
+  (default: 3) identical consecutive tool calls, it's marked as stuck
+
+**Stuck strategies:**
+
+| Strategy | Behavior |
+|----------|----------|
+| `retry` | Kill and restart the sub-agent with same prompt. |
+| `replan` | Ask the coordinator to reformulate the task. |
+| `escalate` | Surface the stuck task to the user. |
+| `abort` | Cancel the sub-task and report failure. |
+
+## Configuration
+
+```yaml
+cascade:
+  enabled: true
+  spawn_timeout_s: 30.0
+  collect_timeout_s: 300.0
+  collect_poll_interval_s: 2.0
+  mesh_delegation_timeout_s: 30.0
+  stuck_timeout_seconds: 60
+  loop_detection_threshold: 3
+  on_stuck: replan
+  max_retries: 2
+```
+
+See the [Configuration Reference](../configuration/reference.md#cascade) for all fields.
+
+## Example: Parallel Task Dispatch
+
+```
+Coordinator prompt: "Run tests for all three microservices in parallel"
+
+→ task_create("Run tests for auth-service", persona="coding-agent")
+→ task_create("Run tests for api-gateway", persona="coding-agent")
+→ task_create("Run tests for billing-service", persona="coding-agent")
+→ task_collect(timeout=300)
+
+Results:
+  - auth-service: 47/47 tests passed
+  - api-gateway: 23/24 tests passed (1 failure in rate_limit_test)
+  - billing-service: 31/31 tests passed
+```
+
+Related: [NIU-435](https://linear.app/niuulabs/issue/NIU-435), [NIU-510](https://linear.app/niuulabs/issue/NIU-510)

--- a/docs/site/ravn/advanced/context.md
+++ b/docs/site/ravn/advanced/context.md
@@ -1,0 +1,96 @@
+# Context Management
+
+Ravn manages the LLM context window to maximize useful information while
+staying within token limits. This involves compression, prompt building,
+and caching.
+
+## Compression
+
+When the conversation history approaches the context window limit, Ravn
+automatically compresses older messages to make room.
+
+### When Compression Fires
+
+Compression activates when the conversation uses more than
+`compression_threshold` (default: 80%) of the available context window.
+
+### What Happens
+
+1. **Protected messages** are preserved verbatim:
+   - First N messages (default: 2) — system prompt and initial context
+   - Last N messages (default: 6) — recent conversation
+   - Last N turns (default: 3) — preserved verbatim
+2. **Middle messages** are compressed into a summary document
+3. The summary replaces the original messages, freeing tokens
+
+### Compression Strategy
+
+The compressor generates a condensed summary (max `compression_max_tokens`,
+default: 1024) that captures:
+
+- Key decisions made
+- Important facts discovered
+- Tool results that are still relevant
+- Unresolved questions or pending work
+
+## Prompt Builder
+
+The prompt builder assembles the full prompt sent to the LLM on each turn:
+
+1. **System prompt** — base persona instructions
+2. **Project context** — from RAVN.md and context files
+3. **Prefetched memory** — relevant past episodes
+4. **Lessons learned** — from outcome reflection
+5. **Conversation history** — (potentially compressed)
+6. **Current user message**
+
+### Two-Layer Caching
+
+The prompt builder uses two cache layers:
+
+| Layer | Scope | Config |
+|-------|-------|--------|
+| In-process LRU | Per-session, in memory | `prompt_cache_max_entries` (default: 16) |
+| Persistent disk | Cross-session, on disk | `prompt_cache_dir` (default: `~/.ravn/prompt_cache`) |
+
+### Anthropic Prompt Caching
+
+When using the Anthropic adapter, Ravn leverages Anthropic's prompt caching
+feature. Static sections of the prompt (system prompt, persona instructions)
+are marked as cacheable, reducing input token costs on subsequent turns.
+
+## Iteration Budget
+
+The iteration budget limits total tool-call iterations across a session:
+
+```yaml
+iteration_budget:
+  total: 90
+  near_limit_threshold: 0.8
+```
+
+When the agent reaches 80% of the budget (72 iterations), it receives a
+"near limit" warning in the system prompt. This encourages the agent to
+wrap up or prioritize remaining work.
+
+## Configuration
+
+```yaml
+context_management:
+  compression_threshold: 0.8
+  protect_first_messages: 2
+  protect_last_messages: 6
+  compact_recent_turns: 3
+  compression_max_tokens: 1024
+  prompt_cache_max_entries: 16
+  prompt_cache_dir: "~/.ravn/prompt_cache"
+
+iteration_budget:
+  total: 90
+  near_limit_threshold: 0.8
+```
+
+See the [Configuration Reference](../configuration/reference.md#context_management)
+for all fields.
+
+Related: [NIU-431](https://linear.app/niuulabs/issue/NIU-431)

--- a/docs/site/ravn/advanced/drive-loop.md
+++ b/docs/site/ravn/advanced/drive-loop.md
@@ -1,0 +1,108 @@
+# Drive Loop & Triggers
+
+The drive loop (initiative engine) enables Ravn to act autonomously — executing
+tasks on schedules, responding to events, and managing a priority queue of work.
+
+## Architecture
+
+```mermaid
+graph TD
+    Triggers["Triggers (cron, event, webhook)"] -->|enqueue| Queue["Priority Queue"]
+    Queue -->|dispatch| Agent["Agent Instance"]
+    Agent -->|result| Output["Output Mode"]
+    Output -->|silent| Memory
+    Output -->|ambient| Sleipnir
+    Output -->|surface| Channel["Telegram / Discord / etc."]
+```
+
+The drive loop runs inside `ravn daemon`. It:
+
+1. Evaluates trigger conditions on a configurable tick interval
+2. Enqueues matching tasks into a priority queue
+3. Dispatches tasks to agent instances (up to `max_concurrent_tasks`)
+4. Routes results based on the task's output mode
+
+## Trigger Types
+
+### Cron Triggers
+
+Time-based scheduling using cron expressions:
+
+```yaml
+initiative:
+  trigger_adapters:
+    - adapter: "ravn.adapters.triggers.cron.CronTrigger"
+      schedule: "0 9 * * 1-5"  # Weekdays at 9 AM
+      prompt: "Check for open PRs that need review"
+      persona: coding-agent
+      output_mode: surface
+```
+
+Agents can also create cron jobs at runtime using the `cron_create` tool.
+
+### Event Triggers
+
+React to Sleipnir events:
+
+```yaml
+initiative:
+  trigger_adapters:
+    - adapter: "ravn.adapters.triggers.sleipnir.SleipnirEventTrigger"
+      event_type: "deployment.completed"
+      prompt: "Verify the deployment succeeded and run smoke tests"
+```
+
+### Webhook / Custom Triggers
+
+Custom trigger adapters can respond to any external signal:
+
+```yaml
+initiative:
+  trigger_adapters:
+    - adapter: "mypackage.triggers.WebhookTrigger"
+      port: 8888
+      path: "/trigger"
+```
+
+## Output Modes
+
+Each task has an output mode that controls where results go:
+
+| Mode | Behavior |
+|------|----------|
+| `silent` | Agent runs, results stored in memory. Nothing external. |
+| `ambient` | Results published to Sleipnir for the attention model. |
+| `surface` | Results delivered directly via configured channel (Telegram, etc.). |
+
+## Task Priority
+
+Tasks are dispatched from a priority queue (lower number = higher priority).
+Tasks can have deadlines — expired tasks are discarded without execution.
+
+## Queue Persistence
+
+The task queue is journaled to disk at `queue_journal_path`. On `ravn daemon --resume`,
+unfinished tasks are restored from the journal.
+
+```yaml
+initiative:
+  queue_journal_path: "~/.ravn/daemon/queue.json"
+```
+
+## Configuration
+
+```yaml
+initiative:
+  enabled: true
+  max_concurrent_tasks: 3
+  task_queue_max: 50
+  queue_journal_path: "~/.ravn/daemon/queue.json"
+  default_output_mode: silent
+  default_persona: ""
+  heartbeat_interval_seconds: 60
+  cron_tick_seconds: 30.0
+```
+
+See the [Configuration Reference](../configuration/reference.md#initiative) for all fields.
+
+Related: [NIU-539](https://linear.app/niuulabs/issue/NIU-539)

--- a/docs/site/ravn/advanced/flock.md
+++ b/docs/site/ravn/advanced/flock.md
@@ -1,0 +1,136 @@
+# Flock / Mesh Networking
+
+The Flock system enables multiple Ravn instances to discover each other, form
+clusters, and communicate. Mesh networking handles message transport between
+peers, while discovery handles finding and verifying peers.
+
+## Mesh Transport
+
+Mesh provides three operations for inter-agent communication:
+
+| Method | Description |
+|--------|-------------|
+| `publish(topic, payload)` | Broadcast to all peers subscribed to a topic. |
+| `subscribe(topic, handler)` | Listen for messages on a topic. |
+| `send(peer_id, payload)` | RPC-style direct message to a specific peer. |
+
+### Transport Adapters
+
+| Adapter | Use Case | Protocol |
+|---------|----------|----------|
+| `nng` | Pi mode / local network | nng PUB/SUB + REQ/REP sockets |
+| `sleipnir` | Infrastructure mode | RabbitMQ exchanges |
+| `composite` | Hybrid | Tries Sleipnir first, falls back to nng |
+
+Configure via:
+
+```yaml
+mesh:
+  enabled: true
+  adapter: nng          # nng | sleipnir | composite
+  rpc_timeout_s: 10.0
+  own_peer_id: ""       # auto: hostname
+
+  nng:
+    pub_address: "tcp://*:9001"
+    sub_address: "tcp://*:9002"
+    req_address: "tcp://*:9003"
+    realm_key_env: "RAVN_REALM_KEY"
+    heartbeat_interval_s: 15.0
+
+  sleipnir:
+    amqp_url_env: "SLEIPNIR_AMQP_URL"
+    exchange: "ravn.mesh"
+    rpc_timeout_s: 10.0
+```
+
+## Peer Discovery
+
+Discovery finds and verifies other Ravn instances in the network.
+
+| Method | Description |
+|--------|-------------|
+| `announce()` | Advertise presence to the network. |
+| `scan()` | Search for peers. |
+| `watch(handler)` | Receive notifications when peers join/leave. |
+| `handshake(candidate)` | Verify a candidate peer's identity. |
+| `peers()` | Get current list of verified peers. |
+
+### Discovery Adapters
+
+| Adapter | Use Case | Mechanism |
+|---------|----------|-----------|
+| `mdns` | Local network (Pi mode) | Zeroconf + HMAC handshake |
+| `sleipnir` | Infrastructure mode | RabbitMQ pub/sub + SPIFFE JWT |
+| `k8s` | Kubernetes | Pod label selector |
+| `composite` | Multiple backends | Union of all adapters |
+
+### mDNS Discovery (Pi Mode)
+
+Uses Zeroconf to advertise `_ravn._tcp.local.` services. Peers authenticate
+via HMAC handshake using a shared realm key.
+
+```yaml
+discovery:
+  adapter: mdns
+  heartbeat_interval_s: 30.0
+  peer_ttl_s: 90.0
+  mdns:
+    service_instance: "ravn-pi-01"
+    port: 9001
+    realm_key_env: "RAVN_REALM_KEY"
+```
+
+### Kubernetes Discovery
+
+Discovers peers via Kubernetes API — queries pods matching a label selector.
+
+```yaml
+discovery:
+  adapter: k8s
+  k8s:
+    namespace: ravn
+    label_selector: "app=ravn-agent"
+    service_port: 9001
+```
+
+### Sleipnir Discovery
+
+Peers announce themselves via RabbitMQ heartbeats. Authentication uses
+SPIFFE JWTs for identity verification.
+
+```yaml
+discovery:
+  adapter: sleipnir
+  sleipnir:
+    amqp_url_env: "SLEIPNIR_AMQP_URL"
+    exchange: "ravn.discovery"
+    trust_domain: "ravn.niuulabs.com"
+```
+
+## Security
+
+| Discovery | Authentication |
+|-----------|---------------|
+| mDNS | HMAC handshake (shared `realm_key`) |
+| Sleipnir | SPIFFE JWT verification |
+| Kubernetes | Service account + namespace isolation |
+
+## Flock Commands
+
+Use `ravn peers` to inspect the flock:
+
+```bash
+# Quick peer list
+ravn peers
+
+# Detailed info with fresh scan
+ravn peers -v --scan
+```
+
+## Configuration
+
+See the [Configuration Reference](../configuration/reference.md#mesh) for
+`mesh.*` and `discovery.*` fields.
+
+Related: [NIU-517](https://linear.app/niuulabs/issue/NIU-517), [NIU-538](https://linear.app/niuulabs/issue/NIU-538)

--- a/docs/site/ravn/advanced/memory.md
+++ b/docs/site/ravn/advanced/memory.md
@@ -1,0 +1,156 @@
+# Memory & Knowledge Systems
+
+Ravn has three complementary memory systems: episodic memory for raw recall,
+Búri for structured knowledge, and Mímir for curated wiki articles.
+
+## Episodic Memory
+
+Episodic memory records every agent turn as an `Episode` — a summary of what
+happened, which tools were used, the outcome, and optional embeddings for
+semantic search.
+
+### Backends
+
+| Backend | Description |
+|---------|-------------|
+| `sqlite` (default) | Local SQLite with FTS5 full-text search. Suitable for single-agent. |
+| `postgres` | PostgreSQL with FTS and optional embeddings. For shared deployments. |
+| `buri` | Búri knowledge substrate (see below). Includes episodic + typed facts. |
+
+### Prefetch
+
+Before each agent turn, Ravn prefetches relevant past episodes and injects
+them into the system prompt. This gives the agent context from previous sessions.
+
+| Config | Default | Description |
+|--------|---------|-------------|
+| `prefetch_budget` | 2000 | Max approximate tokens of past context. |
+| `prefetch_limit` | 5 | Max episodes retrieved. |
+| `prefetch_min_relevance` | 0.3 | Min relevance score (0–1). |
+
+### Relevance Scoring
+
+Episodes are scored by combining:
+
+- **Keyword relevance**: FTS match score or cosine similarity (with embeddings)
+- **Recency decay**: Exponential decay with configurable half-life (default: 14 days)
+- **Outcome weight**: SUCCESS=1.0, PARTIAL=0.5, FAILURE=0.0
+
+### Semantic Search
+
+Enable embeddings for semantic (meaning-based) search alongside keyword search:
+
+```yaml
+embedding:
+  enabled: true
+  adapter: "ravn.adapters.embedding.sentence_transformer.SentenceTransformerEmbeddingAdapter"
+  rrf_k: 60
+  semantic_candidate_limit: 50
+```
+
+Available embedding adapters:
+
+| Adapter | Description |
+|---------|-------------|
+| `SentenceTransformerEmbeddingAdapter` | Local sentence-transformers model. |
+| `OpenAIEmbeddingAdapter` | OpenAI embeddings API. |
+| `OllamaEmbeddingAdapter` | Ollama local embeddings. |
+
+When enabled, search uses Reciprocal Rank Fusion (RRF) to combine FTS and
+semantic results.
+
+## Outcome Recording & Reflection
+
+After each completed task, Ravn records a `TaskOutcome` with:
+
+- Task summary
+- Outcome status (SUCCESS, FAILURE, PARTIAL, INTERRUPTED)
+- Tools used
+- Token usage and estimated cost
+- Lessons learned (via reflection)
+
+The reflection step calls a lightweight model (default: `claude-haiku`) to
+extract 1–3 lessons from the interaction. These lessons are stored and
+surfaced in future prefetch.
+
+```yaml
+agent:
+  outcome:
+    enabled: true
+    reflection_model: "claude-haiku-4-5-20251001"
+    reflection_max_tokens: 512
+    lessons_limit: 3
+```
+
+## Búri — Typed Fact Graph
+
+Búri is a structured knowledge memory that maintains a graph of typed facts
+with confidence scores, temporal validity, and embedding-based clustering.
+
+### Fact Types
+
+| Type | Description |
+|------|-------------|
+| `PREFERENCE` | User preferences (e.g., "prefers dark mode") |
+| `DECISION` | Decisions made (e.g., "chose PostgreSQL over MySQL") |
+| `GOAL` | Active goals (e.g., "migrate to Python 3.12") |
+| `DIRECTIVE` | Standing instructions (e.g., "always run tests before committing") |
+| `RELATIONSHIP` | Entity relationships (e.g., "auth-service depends on user-db") |
+| `OBSERVATION` | Observed patterns (e.g., "tests fail on Mondays after deploys") |
+
+### How Facts Are Extracted
+
+1. **Inline detection**: Regex patterns match phrases like "remember that...",
+   "I prefer...", "from now on..." during conversation
+2. **LLM extraction**: After qualifying sessions, an LLM call extracts
+   structured facts from the conversation
+3. **Supersession**: New facts with high cosine similarity to existing facts
+   replace the old version (threshold: 0.85)
+
+### Proto-vMF Clustering
+
+Facts are grouped into clusters using proto-von Mises-Fisher (vMF) clustering
+based on embedding similarity. Clusters represent thematic groups (e.g., all
+facts about "database preferences").
+
+Retrieval is two-stage:
+1. Find relevant clusters by centroid similarity
+2. Within clusters, find specific facts
+3. Expand via 2-hop graph traversal (relationships)
+
+### Configuration
+
+```yaml
+buri:
+  enabled: true
+  cluster_merge_threshold: 0.15
+  extraction_model: ""          # default: reflection model
+  min_confidence: 0.6
+  session_summary_max_tokens: 400
+  supersession_cosine_threshold: 0.85
+```
+
+## Session Search
+
+The `session_search` tool searches across all past sessions:
+
+1. FTS keyword match across all episodes
+2. Group results by session
+3. Return session summaries with match highlights
+
+Useful for finding "that conversation last week about the auth refactor."
+
+## How the Three Systems Complement Each Other
+
+| System | What It Stores | How It's Updated | When to Use |
+|--------|---------------|-----------------|-------------|
+| **Episodic Memory** | Raw turns, tool calls, outcomes | Automatic after every turn | Recalling what happened in past sessions |
+| **Búri** | Typed facts, preferences, decisions | Auto-extracted + inline detection | Understanding user preferences, standing instructions |
+| **Mímir** | Curated wiki articles | Explicit write + auto-distill | Looking up documented knowledge, architecture |
+
+Together, they provide a complete memory architecture:
+- **Búri** knows what the agent believes
+- **Episodic memory** knows what the agent did
+- **Mímir** knows what the agent has documented
+
+See also: [Mímir documentation](../platform/mimir.md)

--- a/docs/site/ravn/advanced/skills.md
+++ b/docs/site/ravn/advanced/skills.md
@@ -1,0 +1,120 @@
+# Skill System
+
+Skills are reusable procedures that Ravn can discover, learn, and execute.
+They bridge the gap between one-off agent actions and repeatable workflows.
+
+## How Skills Work
+
+Skills are Markdown files with YAML frontmatter containing:
+
+- **Name and description** for discovery
+- **Tool requirements** (which tools the skill needs)
+- **Instructions** in natural language (the skill body)
+
+When the agent runs `skill_run`, the skill's instruction content is loaded
+and injected into the agent's context as a structured prompt.
+
+## Built-in Skills
+
+Ravn ships with four built-in skills:
+
+| Skill | Description |
+|-------|-------------|
+| `code-review` | Review code changes for quality, correctness, and style. |
+| `fix-tests` | Diagnose and fix failing tests. |
+| `refactor` | Refactor code for clarity, maintainability, or performance. |
+| `write-docs` | Write documentation for code or features. |
+
+Built-in skills are located in `src/ravn/skills/` and included by default
+(controllable via `skill.include_builtin`).
+
+## Automatic Skill Extraction
+
+Ravn's evolution system monitors task outcomes and automatically suggests
+skills when it detects recurring patterns:
+
+1. Track tool sequences across SUCCESS episodes
+2. When ≥ `suggestion_threshold` (default: 3) episodes share the same
+   tool pattern, suggest a skill
+3. Run `ravn evolve` to see suggestions
+
+This is suggestion-only — skills are not auto-created.
+
+## Skill Discovery
+
+Skills are loaded from three sources (in order):
+
+1. **Project-local**: `.ravn/skills/` in the current project
+2. **User-level**: `~/.ravn/skills/`
+3. **Built-in**: `src/ravn/skills/` (if `include_builtin` is true)
+4. **Extra directories**: paths in `skill.skill_dirs`
+
+## Skill Storage Backends
+
+| Backend | Description |
+|---------|-------------|
+| `file` (default) | Markdown files on disk. Simple, human-editable. |
+| `sqlite` | SQLite database. Better for large skill collections. |
+
+## Creating Custom Skills
+
+Create a Markdown file in `~/.ravn/skills/` or `.ravn/skills/`:
+
+```markdown
+---
+name: deploy-check
+description: Verify a deployment succeeded and run smoke tests
+tools:
+  - bash
+  - web_fetch
+  - git_log
+tags:
+  - deployment
+  - verification
+---
+
+## Deploy Verification Procedure
+
+1. Check the deployment status:
+   - Run `kubectl get pods -n production` to verify pod health
+   - Check that all replicas are ready
+
+2. Run smoke tests:
+   - Fetch the health endpoint and verify 200 response
+   - Check recent git log to confirm expected commit is deployed
+
+3. Report results:
+   - Summarize pod status, health check results, and deployed version
+   - Flag any issues found
+```
+
+### Frontmatter Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | str | Yes | Unique skill identifier. |
+| `description` | str | Yes | What the skill does (shown in `skill_list`). |
+| `tools` | list[str] | No | Tools the skill requires. |
+| `tags` | list[str] | No | Tags for categorization and search. |
+
+## Agent Tools
+
+| Tool | Permission | Description |
+|------|-----------|-------------|
+| `skill_list` | `skill:read` | List all available skills with names and descriptions. |
+| `skill_run` | `skill:read` | Execute a skill by name. Loads instructions into context. |
+
+## Configuration
+
+```yaml
+skill:
+  enabled: true
+  backend: file
+  path: "~/.ravn/skills.db"
+  suggestion_threshold: 3
+  cache_max_entries: 128
+  skill_dirs: []
+  include_builtin: true
+```
+
+Related: [NIU-436](https://linear.app/niuulabs/issue/NIU-436)

--- a/docs/site/ravn/advanced/thinking.md
+++ b/docs/site/ravn/advanced/thinking.md
@@ -1,0 +1,94 @@
+# Extended Thinking
+
+Extended thinking enables Claude to reason through complex problems before
+responding. When active, the model generates a "thinking" block with
+step-by-step reasoning, followed by the actual response.
+
+## How It Works
+
+Extended thinking is a Claude-only feature. When enabled, the Anthropic
+adapter sends the `thinking` parameter with a token budget. Claude uses
+this budget for internal reasoning that is visible in the response but
+not counted toward the output token limit.
+
+## Auto-Trigger Conditions
+
+When `auto_trigger` is enabled (default), thinking activates automatically on:
+
+- **Planning tasks** — when the agent needs to design an approach
+- **Ambiguous prompts** — when the user's intent is unclear
+- **Complex reasoning** — multi-step logical problems
+
+When `auto_trigger_on_retry` is enabled (default), thinking also activates
+after the first tool failure in a turn, giving the agent deeper reasoning
+for the retry.
+
+## Budget
+
+The thinking budget controls how many tokens the model can spend on reasoning:
+
+```yaml
+llm:
+  extended_thinking:
+    enabled: true
+    budget_tokens: 8000
+```
+
+Higher budgets allow deeper reasoning but increase latency and cost.
+Thinking tokens are priced at approximately 80% of output token cost.
+
+## Tracking
+
+Thinking tokens are tracked separately in the usage breakdown:
+
+- `input_tokens` — prompt tokens
+- `output_tokens` — response tokens
+- `thinking_tokens` — reasoning tokens
+- `cache_read_tokens` — prompt cache hits
+- `cache_creation_tokens` — prompt cache writes
+
+Use `--show-usage` with `ravn run` to see the breakdown after each turn.
+
+## Fallback for Non-Anthropic Providers
+
+When using the fallback adapter chain, thinking is automatically skipped
+for non-Anthropic providers. The `FallbackLLMAdapter` detects provider
+capabilities and only sends the thinking parameter to Anthropic.
+
+This means you can configure a fallback chain like:
+
+```yaml
+llm:
+  provider:
+    adapter: ravn.adapters.llm.anthropic.AnthropicAdapter
+  fallbacks:
+    - adapter: ravn.adapters.llm.openai.OpenAIAdapter
+      kwargs:
+        model: gpt-4o
+  extended_thinking:
+    enabled: true
+    budget_tokens: 8000
+```
+
+Thinking works on the primary (Anthropic) provider and is silently skipped
+on the fallback (OpenAI) provider.
+
+## Configuration
+
+```yaml
+llm:
+  extended_thinking:
+    enabled: false          # Allow thinking activation
+    budget_tokens: 8000     # Max reasoning tokens
+    auto_trigger: true      # Auto-activate on planning/ambiguous tasks
+    auto_trigger_on_retry: true  # Auto-activate after tool failure
+```
+
+Personas can override thinking settings:
+
+```yaml
+# autonomous-agent persona
+thinking:
+  enabled: true
+  budget_tokens: 10000
+```

--- a/docs/site/ravn/cli/reference.md
+++ b/docs/site/ravn/cli/reference.md
@@ -1,0 +1,294 @@
+# CLI Reference
+
+Ravn provides seven top-level commands and two subcommand groups.
+
+## `ravn run`
+
+Interactive agent session or single-prompt execution.
+
+```
+ravn run [PROMPT]
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--no-tools` | | Disable all tool execution |
+| `--show-usage` | | Print token usage after each turn |
+| `--config` | `-c` | Path to ravn config YAML |
+| `--persona` | `-p` | Persona name (built-in or `~/.ravn/personas/`) |
+| `--profile` | | Profile name (built-in or `~/.ravn/profiles/`) |
+| `--resume` | `-r` | Resume interrupted task by `task_id` |
+
+When `PROMPT` is omitted, Ravn enters an interactive REPL. When provided,
+Ravn executes the prompt and exits.
+
+**Examples:**
+
+```bash
+# Interactive REPL
+ravn run
+
+# Single prompt
+ravn run "explain the auth middleware in this repo"
+
+# With persona and thinking
+ravn run -p autonomous-agent "refactor the payment module"
+
+# Resume an interrupted task
+ravn run -r task_abc123
+```
+
+---
+
+## `ravn resume`
+
+Resume from a crash-recovery checkpoint or named snapshot.
+
+```
+ravn resume TASK_ID
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--checkpoint` | `-c` | Specific `checkpoint_id` to restore |
+| `--config` | | Path to ravn config YAML |
+| `--show-usage` | | Print token usage after each turn |
+
+**Examples:**
+
+```bash
+# Resume latest checkpoint for a task
+ravn resume task_abc123
+
+# Resume from a specific snapshot
+ravn resume task_abc123 -c ckpt_task_abc123_3
+```
+
+---
+
+## `ravn daemon`
+
+Long-lived service combining gateway channels with the initiative (drive loop)
+engine. Runs until `SIGINT` or `SIGTERM`.
+
+```
+ravn daemon
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--config` | `-c` | Path to ravn config YAML |
+| `--persona` | `-p` | Default persona for dispatched tasks |
+| `--profile` | | Profile name |
+| `--resume` | | Resume unfinished tasks from journal |
+
+The daemon:
+
+1. Starts all configured gateway channels (HTTP, Telegram, etc.)
+2. Runs the initiative engine (cron triggers, event triggers)
+3. Processes task queue with configurable concurrency
+4. Publishes events to Sleipnir (if configured)
+
+**Examples:**
+
+```bash
+# Start daemon with Telegram + drive loop
+ravn daemon -c ravn.yaml
+
+# Resume interrupted tasks from journal
+ravn daemon --resume
+```
+
+---
+
+## `ravn gateway`
+
+Pi-mode gateway — HTTP + messaging channels without the drive loop.
+
+```
+ravn gateway
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--telegram` | | Enable Telegram polling channel |
+| `--http` | | Enable local HTTP channel |
+| `--config` | `-c` | Path to ravn config YAML |
+| `--persona` | `-p` | Persona for all gateway sessions |
+| `--profile` | | Profile name |
+
+Each incoming message creates a per-session agent instance. The gateway
+manages session lifecycles and routes responses back to the originating channel.
+
+**Examples:**
+
+```bash
+# Pi-mode: Telegram + local HTTP
+ravn gateway --telegram --http
+
+# HTTP-only gateway
+ravn gateway --http -p coding-agent
+```
+
+---
+
+## `ravn listen`
+
+Subscribe to Sleipnir (RabbitMQ) for remote task dispatch. Executes
+tasks autonomously as they arrive.
+
+```
+ravn listen
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--config` | `-c` | Path to ravn config YAML |
+| `--persona` | `-p` | Default persona for dispatched tasks |
+| `--profile` | | Profile name |
+
+Listens on `ravn.task.dispatch` routing key. Tasks with unknown personas
+are rejected with `ravn.task.rejected`.
+
+**Examples:**
+
+```bash
+ravn listen -c ravn.yaml -p autonomous-agent
+```
+
+---
+
+## `ravn evolve`
+
+Run the self-improvement pattern extraction pass. Analyzes accumulated
+task outcomes and episodic memory, then prints suggested improvements.
+
+```
+ravn evolve
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--config` | | Path to ravn config YAML |
+
+Output includes:
+
+- **Skill suggestions** — recurring tool sequences across successful episodes
+- **System warnings** — systematic error patterns
+- **Strategy injections** — domain-specific success patterns
+
+No automatic modifications are made. Review the output and apply manually.
+
+---
+
+## `ravn peers`
+
+List verified flock members (peer Ravn instances).
+
+```
+ravn peers
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--config` | `-c` | Path to ravn config YAML |
+| `--verbose` | `-v` | Show address, latency, task count, last seen |
+| `--scan` | | Force fresh mDNS/K8s scan |
+
+**Examples:**
+
+```bash
+# Quick peer list
+ravn peers
+
+# Detailed peer info with fresh scan
+ravn peers -v --scan
+```
+
+---
+
+## `ravn tui`
+
+Terminal user interface for managing distributed Ravn clusters. Requires
+the `tui` extra: `pip install ravn[tui]`.
+
+```
+ravn tui
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--connect` | `-C` | Connect to Ravn daemon at `HOST:PORT` (repeatable) |
+| `--discover` | | Auto-discover peers via mDNS |
+| `--layout` | `-l` | Layout preset: `flokk`, `cascade`, `mimir`, `compare`, `broadcast` |
+| `--config` | `-c` | Path to ravn config YAML |
+
+**Layout presets:**
+
+| Layout | Purpose |
+|--------|---------|
+| `flokk` | Overview of all peers in the cluster |
+| `cascade` | Coordinator + sub-agent task tree |
+| `mimir` | Knowledge base browser |
+| `compare` | Side-by-side agent comparison |
+| `broadcast` | Send prompt to all connected agents |
+
+---
+
+## Subcommands
+
+### `ravn approvals`
+
+Manage per-project bash command approval patterns. Only relevant when
+`permission.mode` is `prompt`.
+
+#### `ravn approvals list`
+
+List all stored approval patterns for the current project.
+
+```bash
+ravn approvals list
+```
+
+#### `ravn approvals revoke`
+
+Revoke an approval pattern so the command is prompted again.
+
+```bash
+ravn approvals revoke "npm test"
+```
+
+---
+
+### `ravn mimir`
+
+Knowledge base CLI utilities.
+
+#### `ravn mimir ingest`
+
+Ingest a file or stdin into Mímir.
+
+```
+ravn mimir ingest PATH
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--title` | `-t` | Title override (defaults to filename) |
+| `--type` | | Source type: `document`, `web`, `research`, `conversation`, `tool_output` |
+| `--url` | `-u` | Original URL (metadata) |
+| `--mimir` | `-m` | Named instance (e.g., `local`, `shared`) |
+| `--config` | `-c` | Path to ravn config YAML |
+
+**Examples:**
+
+```bash
+# Ingest a document
+ravn mimir ingest ./architecture.md -t "System Architecture"
+
+# Ingest from URL metadata
+ravn mimir ingest ./page.html --type web -u "https://example.com/page"
+
+# Ingest into shared instance
+ravn mimir ingest ./runbook.md -m shared
+```

--- a/docs/site/ravn/configuration/reference.md
+++ b/docs/site/ravn/configuration/reference.md
@@ -467,7 +467,7 @@ gateway:
   enabled: true
   channels:
     telegram:
-      bot_token_env: TELEGRAM_BOT_TOKEN
+      token_env: TELEGRAM_BOT_TOKEN
       allowed_chat_ids: [123456789]
     http:
       host: "0.0.0.0"

--- a/docs/site/ravn/configuration/reference.md
+++ b/docs/site/ravn/configuration/reference.md
@@ -1,0 +1,536 @@
+# Configuration Reference
+
+Complete reference for every Ravn configuration section. All fields show their
+default values. Types use Python 3.12+ syntax.
+
+## `anthropic`
+
+Anthropic API connection settings. Typically set via environment variable.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `api_key` | str | `""` | API key. Prefer `ANTHROPIC_API_KEY` env var. |
+| `base_url` | str | `"https://api.anthropic.com"` | API base URL. |
+
+## `llm`
+
+LLM provider configuration with fallback chain support.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `model` | str | `"claude-sonnet-4-6"` | Model identifier or Bifrost alias. |
+| `max_tokens` | int | `8192` | Max output tokens per LLM call. |
+| `max_retries` | int | `3` | Retries on transient errors (429, 5xx). |
+| `retry_base_delay` | float | `1.0` | Base delay (seconds) for exponential backoff. |
+| `timeout` | float | `120.0` | Request timeout in seconds. |
+| `provider` | [LLMProviderConfig](#llmproviderconfig) | see below | Primary LLM adapter. |
+| `fallbacks` | list[[LLMProviderConfig](#llmproviderconfig)] | `[]` | Ordered fallback providers. |
+| `extended_thinking` | [ExtendedThinkingConfig](#extended_thinking) | see below | Thinking mode settings. |
+
+### `LLMProviderConfig`
+
+Dynamic adapter specification for LLM providers.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `adapter` | str | `"ravn.adapters.llm.anthropic.AnthropicAdapter"` | Fully-qualified class path. |
+| `kwargs` | dict | `{}` | Constructor arguments. |
+| `secret_kwargs_env` | dict | `{}` | Env var names for secret constructor args. |
+
+### `extended_thinking`
+
+Extended thinking (Claude-only). Enables deeper reasoning on complex tasks.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `false` | Allow thinking activation. |
+| `budget_tokens` | int | `8000` | Max reasoning tokens per activation. |
+| `auto_trigger` | bool | `true` | Auto-activate on planning/ambiguous tasks. |
+| `auto_trigger_on_retry` | bool | `true` | Auto-activate after first tool failure. |
+
+## `agent`
+
+Core agent behavior.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `model` | str | `"claude-sonnet-4-6"` | Legacy model field (use `llm.model` instead). |
+| `max_tokens` | int | `8192` | Legacy max tokens (use `llm.max_tokens`). |
+| `max_iterations` | int | `20` | Max tool-call iterations per turn. |
+| `system_prompt` | str | `"You are Ravn..."` | Base system prompt. |
+| `episode_summary_max_chars` | int | `500` | Max chars of response stored as episode summary. |
+| `episode_task_max_chars` | int | `200` | Max chars of user input stored as episode task. |
+| `outcome` | [OutcomeConfig](#outcome) | see below | Task outcome and reflection settings. |
+
+### `outcome`
+
+Controls task outcome recording and reflection.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `true` | Record task outcomes. |
+| `path` | str | `"~/.ravn/memory.db"` | Outcome storage path. |
+| `reflection_model` | str | `"claude-haiku-4-5-20251001"` | Model for post-task reflection. |
+| `reflection_max_tokens` | int | `512` | Max tokens for reflection output. |
+| `lessons_limit` | int | `3` | Max lessons extracted per outcome. |
+| `task_summary_max_chars` | int | `200` | Max chars for task summary. |
+| `lessons_token_budget` | int | `1500` | Token budget for lessons in prefetch. |
+| `input_token_cost_per_million` | float | `3.0` | Cost tracking: input token price. |
+| `output_token_cost_per_million` | float | `15.0` | Cost tracking: output token price. |
+
+## `context`
+
+Project context discovery — how Ravn loads project files into system prompt.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `per_file_limit` | int | `4096` | Max characters from a single context file. |
+| `total_budget` | int | `12288` | Max total context chars injected into system prompt. |
+
+## `tools`
+
+Tool availability, profiles, and sub-tool configuration.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | list[str] | `[]` | Allowlist of built-in tool names (empty = all). |
+| `disabled` | list[str] | `[]` | Blocklist of built-in tool names. |
+| `custom` | list[ToolAdapterConfig] | `[]` | Custom tool adapters (dynamic import). |
+| `profiles` | dict | `{}` | Named tool profiles. |
+| `file` | [FileToolsConfig](#toolsfile) | see below | File tool limits. |
+| `terminal` | [TerminalToolConfig](#toolsterminal) | see below | Terminal/shell settings. |
+| `web` | [WebToolsConfig](#toolsweb) | see below | Web tool settings. |
+| `bash` | [BashToolConfig](#toolsbash) | see below | Bash tool settings. |
+
+### `tools.file`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `max_read_bytes` | int | `1048576` | Max file read size (1 MB). |
+| `max_write_bytes` | int | `5242880` | Max file write size (5 MB). |
+| `binary_check_bytes` | int | `8192` | Bytes checked for binary detection (8 KB). |
+
+### `tools.terminal`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `backend` | str | `"local"` | `local` or `docker`. |
+| `persistent_shell` | bool | `true` | Keep shell alive across tool calls. |
+| `shell` | str | `"/bin/bash"` | Shell executable path. |
+| `timeout_seconds` | float | `30.0` | Per-command timeout. |
+| `docker` | DockerTerminalConfig | see below | Docker backend settings. |
+
+**`docker` sub-config:**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `image` | str | `"python:3.11-slim"` | Docker image. |
+| `network` | str | `"none"` | Docker network mode. |
+| `mount_workspace` | bool | `true` | Mount workspace into container. |
+| `extra_mounts` | list[str] | `[]` | Additional volume mounts. |
+
+### `tools.web`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `fetch.timeout` | float | `30.0` | Fetch timeout (seconds). |
+| `fetch.user_agent` | str | `"Ravn/1.0 (...)"` | HTTP User-Agent header. |
+| `fetch.content_budget` | int | `20000` | Max characters returned. |
+| `search.provider` | ToolAdapterConfig | MockWebSearchProvider | Search adapter. |
+| `search.num_results` | int | `5` | Results per search. |
+
+### `tools.bash`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `mode` | str | `"workspace_write"` | Permission mode for bash commands. |
+| `timeout_seconds` | float | `120.0` | Command timeout. |
+| `max_output_bytes` | int | `102400` | Max stdout+stderr (100 KB). |
+| `workspace_root` | str | `""` | Workspace root for path validation. |
+
+## `permission`
+
+Authorization enforcement.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `mode` | str | `"workspace_write"` | Default mode: `read_only`, `workspace_write`, `full_access`, `prompt`. |
+| `workspace_root` | str | `""` | Absolute path for workspace boundary. |
+| `allow` | list[str] | `[]` | Tool names always granted. |
+| `deny` | list[str] | `[]` | Tool names always denied. |
+| `ask` | list[str] | `[]` | Tool names that always prompt user. |
+| `rules` | list[PermissionRuleConfig] | `[]` | Ordered rules evaluated before default mode. |
+
+**PermissionRuleConfig:**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `pattern` | str | *(required)* | Permission name or glob pattern. |
+| `action` | str | `"ask"` | `allow`, `deny`, or `ask`. |
+
+## `memory`
+
+Episodic memory backend.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `backend` | str | `"sqlite"` | `sqlite`, `postgres`, `buri`, or custom class path. |
+| `path` | str | `"~/.ravn/memory.db"` | SQLite database path. |
+| `dsn` | str | `""` | PostgreSQL DSN. |
+| `dsn_env` | str | `""` | Env var name for DSN (takes precedence). |
+| `prefetch_budget` | int | `2000` | Max tokens of past context per turn. |
+| `prefetch_limit` | int | `5` | Max episodes in prefetch. |
+| `prefetch_min_relevance` | float | `0.3` | Min relevance score (0–1). |
+| `recency_half_life_days` | float | `14.0` | Half-life for recency decay. |
+| `max_retries` | int | `15` | Max retries on SQLite lock. |
+| `min_retry_jitter_ms` | float | `20.0` | Min jitter between retries. |
+| `max_retry_jitter_ms` | float | `150.0` | Max jitter between retries. |
+| `checkpoint_interval` | int | `50` | Writes between WAL checkpoints. |
+| `session_search_truncate_chars` | int | `100000` | Max chars per session in search. |
+
+## `embedding`
+
+Semantic search via vector embeddings.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `false` | Enable embedding-based search. |
+| `adapter` | str | `"ravn.adapters.embedding.sentence_transformer.SentenceTransformerEmbeddingAdapter"` | Embedding adapter class. |
+| `kwargs` | dict | `{}` | Adapter constructor args. |
+| `secret_kwargs_env` | dict | `{}` | Env var names for secret args. |
+| `rrf_k` | int | `60` | Reciprocal Rank Fusion constant. |
+| `semantic_candidate_limit` | int | `50` | Max episodes for cosine similarity. |
+
+## `skill`
+
+Skill extraction, storage, and discovery.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `true` | Enable skill system. |
+| `backend` | str | `"file"` | `file` (Markdown) or `sqlite`. |
+| `path` | str | `"~/.ravn/skills.db"` | SQLite path (when backend=sqlite). |
+| `suggestion_threshold` | int | `3` | Min SUCCESS episodes before synthesis. |
+| `cache_max_entries` | int | `128` | In-process LRU cache size. |
+| `skill_dirs` | list[str] | `[]` | Extra directories for user skills. |
+| `include_builtin` | bool | `true` | Include built-in skills. |
+
+## `iteration_budget`
+
+Session-wide iteration limits.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `total` | int | `90` | Total iterations allowed across session. |
+| `near_limit_threshold` | float | `0.8` | Fraction before "near limit" warnings. |
+
+## `context_management`
+
+Context window compression and prompt caching.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `compression_threshold` | float | `0.8` | Fires when 80% of context window used. |
+| `protect_first_messages` | int | `2` | Messages at start preserved from compression. |
+| `protect_last_messages` | int | `6` | Messages at end preserved from compression. |
+| `compact_recent_turns` | int | `3` | Recent turns preserved verbatim. |
+| `compression_max_tokens` | int | `1024` | Max tokens for compaction summary. |
+| `prompt_cache_max_entries` | int | `16` | In-process LRU prompt cache entries. |
+| `prompt_cache_dir` | str | `"~/.ravn/prompt_cache"` | Persistent prompt cache directory. |
+
+## `mcp_servers`
+
+Model Context Protocol server definitions. See [MCP Integration](../platform/mcp.md).
+
+```yaml
+mcp_servers:
+  - name: "evals"
+    enabled: true
+    transport: "stdio"          # stdio | http | sse
+    command: "node"
+    args: ["server.js"]
+    env:
+      NODE_ENV: "production"
+    timeout: 30.0
+    connect_timeout: 10.0
+    auth:
+      auth_type: "api_key"      # api_key | device_flow | client_credentials
+      api_key_env: "EVALS_KEY"
+```
+
+## `mcp_token_store`
+
+MCP authentication token persistence.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `backend` | str | `"local"` | `local` (encrypted file) or `openbao`. |
+| `local_path` | str | `"~/.ravn/mcp_tokens.json"` | Token file path. |
+
+## `hooks`
+
+Pre-tool and post-tool hook lifecycle.
+
+```yaml
+hooks:
+  pre_tool:
+    - adapter: "mypackage.hooks.AuditHook"
+      events: ["pre_tool"]
+  post_tool:
+    - adapter: "mypackage.hooks.MetricsHook"
+      events: ["post_tool"]
+```
+
+## `checkpoint`
+
+Crash recovery and named snapshots. See [Checkpointing](../operations/checkpointing.md).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `true` | Enable checkpointing. |
+| `backend` | str | `"local"` | `local` (disk) or `postgres`. |
+| `dir` | Path | `~/.ravn/checkpoints` | Checkpoint directory. |
+| `checkpoint_every_n_tools` | int | `10` | Auto-save interval (tool calls). |
+| `max_checkpoints_per_task` | int | `20` | Max snapshots per task. |
+| `auto_before_destructive` | bool | `true` | Save before destructive operations. |
+| `budget_milestone_fractions` | list[float] | `[0.5, 0.75, 0.9]` | Save at budget percentages. |
+
+## `sleipnir`
+
+RabbitMQ event backbone. See [Sleipnir](../operations/sleipnir.md).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `false` | Enable Sleipnir event publishing. |
+| `amqp_url_env` | str | `"SLEIPNIR_AMQP_URL"` | Env var for AMQP connection URL. |
+| `exchange` | str | `"ravn.events"` | RabbitMQ topic exchange name. |
+| `agent_id` | str | `""` | Agent identifier (auto: hostname). |
+| `reconnect_delay_s` | float | `5.0` | Delay between reconnection attempts. |
+| `publish_timeout_s` | float | `2.0` | Per-publish timeout. |
+
+## `initiative`
+
+Drive loop / initiative engine. See [Drive Loop](../advanced/drive-loop.md).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `false` | Enable autonomous drive loop. |
+| `max_concurrent_tasks` | int | `3` | Parallel task limit. |
+| `task_queue_max` | int | `50` | Queue capacity. |
+| `queue_journal_path` | str | `"~/.ravn/daemon/queue.json"` | Queue persistence file. |
+| `default_output_mode` | str | `"silent"` | `silent`, `ambient`, or `surface`. |
+| `default_persona` | str | `""` | Default persona for tasks. |
+| `heartbeat_interval_seconds` | int | `60` | Heartbeat interval. |
+| `cron_tick_seconds` | float | `30.0` | Cron scheduler tick interval. |
+| `trigger_adapters` | list[TriggerAdapterConfig] | `[]` | Custom trigger adapters. |
+
+## `cascade`
+
+Cascade coordinator for distributed task execution. See [Cascade](../advanced/cascade.md).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `false` | Enable cascade. |
+| `spawn_timeout_s` | float | `30.0` | Sub-agent spawn timeout. |
+| `collect_timeout_s` | float | `300.0` | Result collection timeout. |
+| `collect_poll_interval_s` | float | `2.0` | Poll interval for results. |
+| `mesh_delegation_timeout_s` | float | `30.0` | Mesh delegation RPC timeout. |
+| `stuck_timeout_seconds` | int | `60` | Stuck agent detection threshold. |
+| `loop_detection_threshold` | int | `3` | Identical consecutive calls to trigger detection. |
+| `on_stuck` | str | `"replan"` | Strategy: `retry`, `replan`, `escalate`, `abort`. |
+| `max_retries` | int | `2` | Max retries before escalation. |
+
+## `mesh`
+
+Ravn-to-Ravn mesh transport. See [Flock](../advanced/flock.md).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `false` | Enable mesh transport. |
+| `adapter` | str | `"nng"` | `nng`, `sleipnir`, or `composite`. |
+| `rpc_timeout_s` | float | `10.0` | RPC call timeout. |
+| `own_peer_id` | str | `""` | Own peer identifier (auto: hostname). |
+| `nng` | NngMeshConfig | see below | nng transport settings. |
+| `sleipnir` | MeshSleipnirConfig | see below | Sleipnir transport settings. |
+
+## `discovery`
+
+Flock peer discovery. See [Flock](../advanced/flock.md).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `adapter` | str | `"mdns"` | `mdns`, `sleipnir`, `k8s`, or `composite`. |
+| `realm_id_env` | str | `"RAVN_REALM_ID"` | Env var for realm identifier. |
+| `heartbeat_interval_s` | float | `30.0` | Heartbeat interval. |
+| `peer_ttl_s` | float | `90.0` | Seconds before peer eviction. |
+| `mdns` | DiscoveryMdnsConfig | see below | mDNS settings. |
+| `sleipnir` | DiscoverySleipnirConfig | see below | Sleipnir discovery settings. |
+| `k8s` | DiscoveryK8sConfig | see below | Kubernetes discovery settings. |
+
+## `gateway`
+
+Gateway channels for external communication. See [Gateway](../operations/gateway.md).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `false` | Enable gateway. |
+| `channels` | GatewayChannelsConfig | see below | Per-channel settings. |
+| `platform` | PlatformToolsConfig | see below | Platform integration. |
+
+Supported channels: `telegram`, `http`, `skuld`, `discord`, `slack`, `matrix`, `whatsapp`.
+
+## `mimir`
+
+Mímir persistent knowledge base. See [Mímir](../platform/mimir.md).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `true` | Enable Mímir. |
+| `path` | str | `"~/.ravn/mimir"` | Local wiki directory. |
+| `auto_distill` | bool | `true` | Auto-extract learnings from sessions. |
+| `distill_min_session_minutes` | int | `5` | Min session length for distillation. |
+| `idle_lint_threshold_minutes` | int | `60` | Idle time before auto-lint fires. |
+| `continuation_threshold_minutes` | int | `30` | Session continuation window. |
+| `categories` | list[str] | `["technical", "projects", "research", "household", "self"]` | Wiki categories. |
+| `search.backend` | str | `"fts"` | `fts` (full-text) or `vector`. |
+| `instances` | list[MimirInstanceConfig] | `[]` | Multi-instance configuration. |
+| `write_routing` | MimirWriteRoutingConfig | `{}` | Write distribution rules. |
+| `source_trigger` | MimirSourceTriggerConfig | see below | Auto-synthesis settings. |
+| `staleness_trigger` | MimirStalenessTriggerConfig | see below | Refresh trigger settings. |
+
+## `buri`
+
+Búri typed knowledge memory substrate. See [Memory Systems](../advanced/memory.md).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `true` | Enable Búri fact graph. |
+| `cluster_merge_threshold` | float | `0.15` | Cosine distance for cluster merging. |
+| `extraction_model` | str | `""` | Model for fact extraction (default: reflection model). |
+| `min_confidence` | float | `0.6` | Min confidence for extracted facts. |
+| `session_summary_max_tokens` | int | `400` | Max tokens for rolling session summary. |
+| `supersession_cosine_threshold` | float | `0.85` | Cosine threshold for fact supersession. |
+
+## `evolution`
+
+Self-improvement pattern extraction. See [Evolution](../operations/evolution.md).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `true` | Enable evolution system. |
+| `min_new_outcomes` | int | `10` | Trigger threshold for analysis. |
+| `state_path` | str | `"~/.ravn/evolution_state.json"` | Evolution state file. |
+| `max_episodes_to_analyze` | int | `100` | Max episodes per pass. |
+| `max_outcomes_to_analyze` | int | `50` | Max outcomes per pass. |
+| `skill_suggestion_min_occurrences` | int | `3` | Min pattern occurrences for skill suggestion. |
+| `error_warning_min_occurrences` | int | `3` | Min error occurrences for warning. |
+| `strategy_min_occurrences` | int | `3` | Min pattern occurrences for strategy. |
+| `max_skill_suggestions` | int | `5` | Max suggestions per pass. |
+| `max_system_warnings` | int | `5` | Max warnings per pass. |
+| `max_strategy_injections` | int | `3` | Max strategies per pass. |
+
+## `browser`
+
+Browser automation tool.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `backend` | str | `"local"` | `local` (Playwright) or `browserbase` (cloud). |
+| `headless` | bool | `true` | Run browser headless. |
+| `timeout_ms` | int | `30000` | Page load timeout. |
+| `allowed_origins` | list[str] | `[]` | Allowed hostname globs. |
+| `blocked_origins` | list[str] | `[]` | Blocked hostname globs. |
+
+## `logging`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `level` | str | `"warning"` | Log level: `debug`, `info`, `warning`, `error`. |
+| `format` | str | `"text"` | Log format: `text` or `json`. |
+
+## Example Configurations
+
+### Minimal
+
+```yaml
+anthropic:
+  api_key: "sk-ant-..."
+```
+
+### Pi Mode
+
+```yaml
+llm:
+  model: claude-sonnet-4-6
+
+gateway:
+  enabled: true
+  channels:
+    telegram:
+      bot_token_env: TELEGRAM_BOT_TOKEN
+      allowed_chat_ids: [123456789]
+    http:
+      host: "0.0.0.0"
+      port: 7477
+
+discovery:
+  adapter: mdns
+
+mesh:
+  enabled: true
+  adapter: nng
+
+permission:
+  mode: full_access
+```
+
+### Infrastructure Mode
+
+```yaml
+llm:
+  model: claude-sonnet-4-6
+  provider:
+    adapter: ravn.adapters.llm.bifrost.BifrostAdapter
+    kwargs:
+      base_url: "http://bifrost.ravn.svc:8080"
+
+sleipnir:
+  enabled: true
+  amqp_url_env: SLEIPNIR_AMQP_URL
+  exchange: ravn.events
+
+initiative:
+  enabled: true
+  max_concurrent_tasks: 5
+
+cascade:
+  enabled: true
+
+discovery:
+  adapter: k8s
+  k8s:
+    namespace: ravn
+    label_selector: "app=ravn-agent"
+
+memory:
+  backend: postgres
+  dsn_env: RAVN_POSTGRES_DSN
+```
+
+### Cascade Coordinator
+
+```yaml
+cascade:
+  enabled: true
+  spawn_timeout_s: 30.0
+  collect_timeout_s: 300.0
+  stuck_timeout_seconds: 60
+  on_stuck: replan
+
+tools:
+  profiles:
+    coordinator:
+      include_groups: [core, extended, cascade]
+    worker:
+      include_groups: [core]
+```

--- a/docs/site/ravn/developer/architecture.md
+++ b/docs/site/ravn/developer/architecture.md
@@ -1,0 +1,156 @@
+# Architecture
+
+Ravn follows hexagonal architecture (ports and adapters) with strict module
+boundaries. This guide covers the design principles for contributors.
+
+## Hexagonal Architecture
+
+```mermaid
+graph TD
+    CLI["CLI / Main (Composition Root)"] --> Ports
+    CLI --> Adapters
+    Ports["Ports (Interfaces)"]
+    Adapters["Adapters (Implementations)"]
+    Agent["Agent Loop"] --> Ports
+    Adapters -.->|implements| Ports
+```
+
+| Layer | Directory | Responsibility |
+|-------|-----------|---------------|
+| **Ports** | `src/ravn/ports/` | Abstract base classes defining interfaces. |
+| **Adapters** | `src/ravn/adapters/` | Concrete implementations of ports. |
+| **Domain** | `src/ravn/domain/` | Models, enums, exceptions — no dependencies. |
+| **Agent** | `src/ravn/agent.py` | Core agent loop — imports ports only. |
+| **CLI** | `src/ravn/cli/` | Composition root — wires adapters to ports. |
+
+### Rules
+
+- **Agent and domain** import from `ports/` only, never from `adapters/`
+- **Adapters** implement port interfaces
+- **CLI/main** is the composition root — it imports everything and wires it together
+- **No adapter may depend on another adapter** — use ports for cross-cutting
+
+## Port Inventory
+
+| Port | File | Methods |
+|------|------|---------|
+| `LLMPort` | `llm.py` | `complete()`, `stream()` |
+| `MemoryPort` | `memory.py` | `query()`, `prefetch()`, `save_episode()` |
+| `ToolPort` | `tool.py` | `name`, `description`, `input_schema`, `execute()` |
+| `PermissionPort` | `permission.py` | `check()`, `evaluate()` |
+| `CheckpointPort` | `checkpoint.py` | `save()`, `load()`, `delete()` |
+| `ChannelPort` | `channel.py` | `emit()` |
+| `MeshPort` | `mesh.py` | `publish()`, `subscribe()`, `send()` |
+| `DiscoveryPort` | `discovery.py` | `announce()`, `scan()`, `watch()` |
+| `EmbeddingPort` | `embedding.py` | `embed()`, `embed_batch()` |
+| `SkillPort` | `skill.py` | `list()`, `get()`, `save()` |
+| `EventPublisherPort` | `event_publisher.py` | `publish()` |
+| `MimirPort` | `mimir.py` | `query()`, `ingest()`, `write()`, `lint()` |
+| `OutcomePort` | `outcome.py` | `record()`, `query()` |
+| `BrowserPort` | `browser.py` | `navigate()`, `screenshot()`, `click()` |
+
+## Dynamic Adapter Pattern
+
+New adapters use dynamic import + kwargs for zero-code extensibility:
+
+```yaml
+llm:
+  provider:
+    adapter: "ravn.adapters.llm.anthropic.AnthropicAdapter"
+    kwargs:
+      timeout: 60
+```
+
+The composition root resolves this at startup:
+
+```python
+def _import_class(dotted_path: str) -> type:
+    module_path, class_name = dotted_path.rsplit(".", 1)
+    module = importlib.import_module(module_path)
+    return getattr(module, class_name)
+
+cls = _import_class(config["adapter"])
+kwargs = {k: v for k, v in config.items() if k != "adapter"}
+instance = cls(**kwargs)
+```
+
+Adding a new adapter = write the class + update YAML. No code changes
+elsewhere.
+
+## Module Boundaries
+
+```mermaid
+graph BT
+    Volundr["volundr"] --> Niuu["niuu (shared)"]
+    Tyr["tyr"] --> Niuu
+    Ravn["ravn"] --- Ravn
+```
+
+| Rule | Description |
+|------|-------------|
+| `tyr` cannot import from `volundr` | Strictly forbidden. |
+| `volundr` cannot import from `tyr` | Strictly forbidden. |
+| Both import from `niuu` | Shared code (models, ports, adapters). |
+| `niuu` imports from neither | No reverse dependencies. |
+| `ravn` is independent | Separate agent framework. |
+
+Extract to `niuu` when both Volundr and Tyr need the same interface.
+
+## Agent Loop
+
+The core agent loop (`agent.py`) follows this cycle:
+
+1. Receive user message
+2. Prefetch relevant memory
+3. Build prompt (system + context + history + message)
+4. Call LLM (streaming)
+5. Extract tool calls from response
+6. For each tool call:
+   - Run pre-tool hooks
+   - Check permissions
+   - Execute tool
+   - Run post-tool hooks
+7. Feed results back to LLM
+8. Repeat until `stop_reason != tool_use`
+9. Record episode to memory
+10. Return turn result
+
+The loop respects:
+- Iteration budget (max tool calls per session)
+- Context compression (when context window fills)
+- Checkpoint triggers (periodic saves)
+- Permission checks (per-tool authorization)
+
+## Directory Structure
+
+```
+src/ravn/
+├── adapters/
+│   ├── browser/          # Browser automation
+│   ├── channels/         # Communication (Telegram, Discord, etc.)
+│   ├── checkpoint/       # Persistence (disk, postgres)
+│   ├── discovery/        # Peer detection (mDNS, K8s, Sleipnir)
+│   ├── embedding/        # Vector embeddings
+│   ├── events/           # Event publishing (RabbitMQ)
+│   ├── llm/              # LLM providers (Anthropic, OpenAI, Bifrost)
+│   ├── mcp/              # Model Context Protocol
+│   ├── memory/           # Episodic memory (SQLite, Postgres, Búri)
+│   ├── mesh/             # Peer-to-peer transport (nng, Sleipnir)
+│   ├── mimir/            # Knowledge base (HTTP, Markdown, composite)
+│   ├── permission/       # Authorization enforcement
+│   ├── personas/         # Persona loader
+│   ├── skill/            # Skill storage (file, SQLite)
+│   ├── spawn/            # Process spawning (subprocess, K8s)
+│   ├── tools/            # Built-in tool implementations
+│   └── triggers/         # Drive loop triggers (cron, events)
+├── cascade/              # Task delegation watchdog
+├── cli/                  # CLI commands (Typer)
+├── context/              # Compression and evolution
+├── domain/               # Models, enums, exceptions
+├── ports/                # Interface definitions (ABCs)
+├── skills/               # Built-in skill Markdown files
+├── tui/                  # Terminal UI (Textual)
+├── agent.py              # Core agent loop
+├── config.py             # Configuration system
+└── __main__.py           # Entry point
+```

--- a/docs/site/ravn/developer/architecture.md
+++ b/docs/site/ravn/developer/architecture.md
@@ -34,7 +34,7 @@ graph TD
 
 | Port | File | Methods |
 |------|------|---------|
-| `LLMPort` | `llm.py` | `complete()`, `stream()` |
+| `LLMPort` | `llm.py` | `generate()`, `stream()` |
 | `MemoryPort` | `memory.py` | `query()`, `prefetch()`, `save_episode()` |
 | `ToolPort` | `tool.py` | `name`, `description`, `input_schema`, `execute()` |
 | `PermissionPort` | `permission.py` | `check()`, `evaluate()` |

--- a/docs/site/ravn/developer/new-channel.md
+++ b/docs/site/ravn/developer/new-channel.md
@@ -1,0 +1,181 @@
+# Adding a New Channel
+
+This guide walks through adding a new communication channel adapter to Ravn's
+gateway system.
+
+## Step 1: Implement ChannelPort
+
+Create a new adapter in `src/ravn/adapters/channels/`:
+
+```python
+# src/ravn/adapters/channels/my_channel.py
+from collections.abc import AsyncIterator
+
+from ravn.domain.events import RavnEvent
+from ravn.ports.channel import ChannelPort
+
+
+class MyChannelAdapter(ChannelPort):
+    """Adapter for MyChannel messaging platform."""
+
+    def __init__(
+        self,
+        api_key: str = "",
+        poll_interval: float = 1.0,
+    ):
+        self._api_key = api_key
+        self._poll_interval = poll_interval
+        self._running = False
+
+    async def start(self) -> None:
+        """Initialize connection to the messaging platform."""
+        self._running = True
+        # Connect to API, authenticate, etc.
+
+    async def stop(self) -> None:
+        """Gracefully disconnect."""
+        self._running = False
+        # Close connections, flush buffers
+
+    async def receive(self) -> AsyncIterator[dict]:
+        """Yield incoming messages from the platform."""
+        while self._running:
+            messages = await self._poll_messages()
+            for msg in messages:
+                yield {
+                    "session_id": msg.conversation_id,
+                    "content": msg.text,
+                    "sender": msg.author,
+                }
+
+    async def emit(self, event: RavnEvent) -> None:
+        """Send an event to the messaging platform."""
+        match event.type:
+            case "text_delta":
+                # Buffer text and send when complete
+                self._buffer.append(event.content)
+            case "message_done":
+                # Flush buffered text as a message
+                text = "".join(self._buffer)
+                await self._send_message(event.session_id, text)
+                self._buffer.clear()
+            case "tool_call":
+                # Optionally show tool usage
+                pass
+```
+
+### ChannelPort Interface
+
+| Method | Description |
+|--------|-------------|
+| `start()` | Initialize the channel connection. |
+| `stop()` | Gracefully shut down. |
+| `receive()` | Async iterator yielding incoming messages. |
+| `emit(event)` | Send an outbound event to the channel. |
+
+## Step 2: Event Translation
+
+Each channel needs to translate between Ravn's `StreamEvent` format and the
+platform's native message format.
+
+Ravn emits these event types:
+
+| Event | Action |
+|-------|--------|
+| `text_delta` | Buffer text content. |
+| `tool_call` | Optionally display tool usage to user. |
+| `tool_result` | Optionally display tool output. |
+| `message_done` | Flush buffered text as a complete message. |
+| `thinking` | Optionally show thinking indicator. |
+
+Most channels buffer `text_delta` events and send the complete message on
+`message_done`. Some channels (WebSocket, SSE) stream deltas directly.
+
+## Step 3: Add Channel Configuration
+
+Add a config class in `src/ravn/config.py`:
+
+```python
+class MyChannelConfig(BaseModel):
+    api_key_env: str = ""
+    poll_interval: float = 1.0
+    max_message_length: int = 4096
+```
+
+Add to `GatewayChannelsConfig`:
+
+```python
+class GatewayChannelsConfig(BaseModel):
+    # ... existing channels ...
+    my_channel: MyChannelConfig = MyChannelConfig()
+```
+
+## Step 4: Wire in Gateway
+
+Register the channel in the gateway startup logic so it's created when
+configured:
+
+```python
+if settings.gateway.channels.my_channel.api_key_env:
+    api_key = os.environ.get(settings.gateway.channels.my_channel.api_key_env, "")
+    if api_key:
+        channels.append(
+            MyChannelAdapter(
+                api_key=api_key,
+                poll_interval=settings.gateway.channels.my_channel.poll_interval,
+            )
+        )
+```
+
+## Step 5: Handle Platform Constraints
+
+Different platforms have different constraints:
+
+| Constraint | How to Handle |
+|-----------|---------------|
+| Message length limits | Split long responses into multiple messages. |
+| Rate limits | Add backoff/queuing logic. |
+| Markdown support | Convert Ravn's Markdown to platform format. |
+| Rich content (images, files) | Map to platform attachments or skip. |
+| Threading | Map Ravn sessions to platform threads. |
+
+## Step 6: Write Tests
+
+```python
+import pytest
+from ravn.adapters.channels.my_channel import MyChannelAdapter
+from ravn.domain.events import RavnEvent
+
+
+@pytest.fixture
+def channel():
+    return MyChannelAdapter(api_key="test")
+
+
+class TestMyChannelAdapter:
+    @pytest.mark.asyncio
+    async def test_start_stop(self, channel):
+        await channel.start()
+        await channel.stop()
+
+    @pytest.mark.asyncio
+    async def test_emit_text(self, channel):
+        await channel.start()
+        event = RavnEvent(type="text_delta", content="hello")
+        await channel.emit(event)
+        done = RavnEvent(type="message_done", session_id="s1")
+        await channel.emit(done)
+        await channel.stop()
+```
+
+## Configuration Example
+
+```yaml
+gateway:
+  enabled: true
+  channels:
+    my_channel:
+      api_key_env: "MY_CHANNEL_API_KEY"
+      poll_interval: 1.0
+      max_message_length: 4096
+```

--- a/docs/site/ravn/developer/new-channel.md
+++ b/docs/site/ravn/developer/new-channel.md
@@ -9,14 +9,17 @@ Create a new adapter in `src/ravn/adapters/channels/`:
 
 ```python
 # src/ravn/adapters/channels/my_channel.py
-from collections.abc import AsyncIterator
-
 from ravn.domain.events import RavnEvent
 from ravn.ports.channel import ChannelPort
 
 
 class MyChannelAdapter(ChannelPort):
-    """Adapter for MyChannel messaging platform."""
+    """Adapter for MyChannel messaging platform.
+
+    ChannelPort defines a single method: ``emit(event)``.  Lifecycle
+    management (start/stop) and inbound message handling are left to the
+    concrete adapter — typically orchestrated by the gateway runner.
+    """
 
     def __init__(
         self,
@@ -25,31 +28,10 @@ class MyChannelAdapter(ChannelPort):
     ):
         self._api_key = api_key
         self._poll_interval = poll_interval
-        self._running = False
-
-    async def start(self) -> None:
-        """Initialize connection to the messaging platform."""
-        self._running = True
-        # Connect to API, authenticate, etc.
-
-    async def stop(self) -> None:
-        """Gracefully disconnect."""
-        self._running = False
-        # Close connections, flush buffers
-
-    async def receive(self) -> AsyncIterator[dict]:
-        """Yield incoming messages from the platform."""
-        while self._running:
-            messages = await self._poll_messages()
-            for msg in messages:
-                yield {
-                    "session_id": msg.conversation_id,
-                    "content": msg.text,
-                    "sender": msg.author,
-                }
+        self._buffer: list[str] = []
 
     async def emit(self, event: RavnEvent) -> None:
-        """Send an event to the messaging platform."""
+        """Emit a Ravn event to the messaging platform."""
         match event.type:
             case "text_delta":
                 # Buffer text and send when complete
@@ -62,16 +44,33 @@ class MyChannelAdapter(ChannelPort):
             case "tool_call":
                 # Optionally show tool usage
                 pass
+
+    # --- Adapter-specific (not part of ChannelPort) ---
+
+    async def start(self) -> None:
+        """Connect to the messaging platform (adapter-specific)."""
+        ...
+
+    async def stop(self) -> None:
+        """Gracefully disconnect (adapter-specific)."""
+        ...
+
+    async def _send_message(self, session_id: str, text: str) -> None:
+        """Send a message via the platform API."""
+        ...
 ```
 
 ### ChannelPort Interface
 
+The port itself is intentionally minimal:
+
 | Method | Description |
 |--------|-------------|
-| `start()` | Initialize the channel connection. |
-| `stop()` | Gracefully shut down. |
-| `receive()` | Async iterator yielding incoming messages. |
-| `emit(event)` | Send an outbound event to the channel. |
+| `emit(event: RavnEvent)` | Emit a Ravn event to the output surface. |
+
+Lifecycle methods (`start()`, `stop()`) and inbound message polling are
+adapter-specific concerns handled outside the port interface, typically by
+the gateway runner that orchestrates channel adapters.
 
 ## Step 2: Event Translation
 

--- a/docs/site/ravn/developer/new-provider.md
+++ b/docs/site/ravn/developer/new-provider.md
@@ -1,0 +1,210 @@
+# Adding a New LLM Provider
+
+This guide walks through adding a new LLM provider adapter to Ravn.
+
+## Step 1: Implement LLMPort
+
+Create a new adapter in `src/ravn/adapters/llm/`:
+
+```python
+# src/ravn/adapters/llm/my_provider.py
+from collections.abc import AsyncIterator
+
+from ravn.domain.models import (
+    LLMResponse,
+    Message,
+    StreamEvent,
+    StreamEventType,
+    TokenUsage,
+    ToolCall,
+)
+from ravn.ports.llm import LLMPort
+
+
+class MyProviderAdapter(LLMPort):
+    """Adapter for MyProvider LLM API."""
+
+    def __init__(
+        self,
+        api_key: str = "",
+        model: str = "my-model-v1",
+        base_url: str = "https://api.myprovider.com",
+        max_tokens: int = 8192,
+        timeout: float = 120.0,
+    ):
+        self._api_key = api_key
+        self._model = model
+        self._base_url = base_url
+        self._max_tokens = max_tokens
+        self._timeout = timeout
+
+    async def complete(
+        self,
+        messages: list[Message],
+        tools: list[dict] | None = None,
+        system: str | None = None,
+        max_tokens: int | None = None,
+    ) -> LLMResponse:
+        """Non-streaming completion."""
+        # Convert messages to provider format
+        provider_messages = self._convert_messages(messages)
+        provider_tools = self._convert_tools(tools) if tools else None
+
+        # Make API call
+        response = await self._call_api(
+            provider_messages, provider_tools, system, max_tokens
+        )
+
+        # Convert response back to Ravn format
+        return self._parse_response(response)
+
+    async def stream(
+        self,
+        messages: list[Message],
+        tools: list[dict] | None = None,
+        system: str | None = None,
+        max_tokens: int | None = None,
+    ) -> AsyncIterator[StreamEvent]:
+        """Streaming completion."""
+        provider_messages = self._convert_messages(messages)
+        provider_tools = self._convert_tools(tools) if tools else None
+
+        async for chunk in self._stream_api(
+            provider_messages, provider_tools, system, max_tokens
+        ):
+            yield self._parse_stream_event(chunk)
+```
+
+## Step 2: Stream Event Types
+
+Your adapter must emit the correct `StreamEvent` types:
+
+| Event Type | When | Data |
+|-----------|------|------|
+| `TEXT_DELTA` | Text chunk received | `content: str` |
+| `TOOL_CALL` | Tool call detected | `tool_call: ToolCall` |
+| `THINKING` | Thinking block (if supported) | `content: str` |
+| `MESSAGE_DONE` | Response complete | `usage: TokenUsage, stop_reason: StopReason` |
+
+Example stream emission:
+
+```python
+async def stream(self, ...):
+    # Text chunks
+    yield StreamEvent(type=StreamEventType.TEXT_DELTA, content="Hello")
+    yield StreamEvent(type=StreamEventType.TEXT_DELTA, content=" world")
+
+    # Tool calls
+    yield StreamEvent(
+        type=StreamEventType.TOOL_CALL,
+        tool_call=ToolCall(
+            id="call_123",
+            name="read_file",
+            input={"path": "/tmp/file.txt"},
+        ),
+    )
+
+    # Done
+    yield StreamEvent(
+        type=StreamEventType.MESSAGE_DONE,
+        usage=TokenUsage(input_tokens=100, output_tokens=50),
+        stop_reason=StopReason.TOOL_USE,
+    )
+```
+
+## Step 3: Tool Format Conversion
+
+Different LLM providers use different tool schemas. Convert between Ravn's
+format and the provider's format:
+
+```python
+def _convert_tools(self, tools: list[dict]) -> list[dict]:
+    """Convert Ravn tool definitions to provider format."""
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": tool["name"],
+                "description": tool["description"],
+                "parameters": tool["input_schema"],
+            },
+        }
+        for tool in tools
+    ]
+```
+
+## Step 4: Register as Provider
+
+Configure in `ravn.yaml`:
+
+```yaml
+llm:
+  provider:
+    adapter: "ravn.adapters.llm.my_provider.MyProviderAdapter"
+    kwargs:
+      model: "my-model-v1"
+      base_url: "https://api.myprovider.com"
+    secret_kwargs_env:
+      api_key: "MY_PROVIDER_API_KEY"
+```
+
+## Step 5: Fallback Chain Integration
+
+Add as a fallback provider:
+
+```yaml
+llm:
+  provider:
+    adapter: ravn.adapters.llm.anthropic.AnthropicAdapter
+  fallbacks:
+    - adapter: ravn.adapters.llm.my_provider.MyProviderAdapter
+      kwargs:
+        model: "my-model-v1"
+      secret_kwargs_env:
+        api_key: "MY_PROVIDER_API_KEY"
+```
+
+The `FallbackLLMAdapter` tries the primary provider first, then falls back
+to each provider in order on 429/5xx errors.
+
+**Important:** Extended thinking is Anthropic-only. The fallback adapter
+automatically skips thinking parameters for non-Anthropic providers.
+
+## Step 6: Write Tests
+
+Test against the `LLMPort` interface:
+
+```python
+import pytest
+from ravn.adapters.llm.my_provider import MyProviderAdapter
+from ravn.domain.models import Message
+
+
+@pytest.fixture
+def adapter():
+    return MyProviderAdapter(api_key="test", model="test-model")
+
+
+class TestMyProviderAdapter:
+    @pytest.mark.asyncio
+    async def test_complete(self, adapter):
+        messages = [Message(role="user", content="hello")]
+        response = await adapter.complete(messages)
+        assert response.content
+        assert response.usage.input_tokens > 0
+
+    @pytest.mark.asyncio
+    async def test_stream(self, adapter):
+        messages = [Message(role="user", content="hello")]
+        events = []
+        async for event in adapter.stream(messages):
+            events.append(event)
+        assert any(e.type == StreamEventType.MESSAGE_DONE for e in events)
+
+    @pytest.mark.asyncio
+    async def test_tool_calls(self, adapter):
+        messages = [Message(role="user", content="read /tmp/test")]
+        tools = [{"name": "read_file", "description": "Read", "input_schema": {...}}]
+        response = await adapter.complete(messages, tools=tools)
+        # Verify tool calls are properly formatted
+```

--- a/docs/site/ravn/developer/new-provider.md
+++ b/docs/site/ravn/developer/new-provider.md
@@ -38,42 +38,59 @@ class MyProviderAdapter(LLMPort):
         self._max_tokens = max_tokens
         self._timeout = timeout
 
-    async def complete(
+    async def generate(
         self,
-        messages: list[Message],
-        tools: list[dict] | None = None,
-        system: str | None = None,
-        max_tokens: int | None = None,
+        messages: list[dict],
+        *,
+        tools: list[dict],
+        system: str | list[dict],
+        model: str,
+        max_tokens: int,
+        thinking: dict | None = None,
     ) -> LLMResponse:
         """Non-streaming completion."""
         # Convert messages to provider format
         provider_messages = self._convert_messages(messages)
-        provider_tools = self._convert_tools(tools) if tools else None
+        provider_tools = self._convert_tools(tools)
 
         # Make API call
         response = await self._call_api(
-            provider_messages, provider_tools, system, max_tokens
+            provider_messages, provider_tools, system, model, max_tokens
         )
 
         # Convert response back to Ravn format
         return self._parse_response(response)
 
-    async def stream(
+    def stream(
         self,
-        messages: list[Message],
-        tools: list[dict] | None = None,
-        system: str | None = None,
-        max_tokens: int | None = None,
+        messages: list[dict],
+        *,
+        tools: list[dict],
+        system: str | list[dict],
+        model: str,
+        max_tokens: int,
+        thinking: dict | None = None,
     ) -> AsyncIterator[StreamEvent]:
         """Streaming completion."""
         provider_messages = self._convert_messages(messages)
-        provider_tools = self._convert_tools(tools) if tools else None
+        provider_tools = self._convert_tools(tools)
 
         async for chunk in self._stream_api(
-            provider_messages, provider_tools, system, max_tokens
+            provider_messages, provider_tools, system, model, max_tokens
         ):
             yield self._parse_stream_event(chunk)
 ```
+
+### LLMPort Interface
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `stream(messages, *, tools, system, model, max_tokens, thinking)` | `AsyncIterator[StreamEvent]` | Stream response events as they arrive. |
+| `generate(messages, *, tools, system, model, max_tokens, thinking)` | `LLMResponse` | Non-streaming completion. |
+| `supports_thinking` (property) | `bool` | Whether adapter supports extended thinking (default: `False`). |
+
+All parameters after `messages` are **keyword-only** (`*`). The `system`
+parameter can be a plain string or a list of Anthropic-format text blocks.
 
 ## Step 2: Stream Event Types
 

--- a/docs/site/ravn/developer/new-tool.md
+++ b/docs/site/ravn/developer/new-tool.md
@@ -39,7 +39,7 @@ class MyTool(ToolPort):
         }
 
     @property
-    def permission(self) -> str:
+    def required_permission(self) -> str:
         return "my_tool:execute"
 
     async def execute(self, tool_input: dict) -> str:
@@ -56,7 +56,7 @@ class MyTool(ToolPort):
 | `name` | str | Unique tool identifier. |
 | `description` | str | Human-readable description (shown to LLM). |
 | `input_schema` | dict | JSON Schema for input parameters. |
-| `permission` | str | Permission string checked before execution. |
+| `required_permission` | str | Permission string checked before execution. |
 | `execute(tool_input)` | async → str | Execute the tool and return result. |
 
 ## Step 2: Register in Builtin Registry

--- a/docs/site/ravn/developer/new-tool.md
+++ b/docs/site/ravn/developer/new-tool.md
@@ -1,0 +1,164 @@
+# Adding a New Tool
+
+This guide walks through adding a new built-in tool to Ravn.
+
+## Step 1: Implement ToolPort
+
+Create a new adapter in `src/ravn/adapters/tools/`:
+
+```python
+# src/ravn/adapters/tools/my_tool.py
+from ravn.ports.tool import ToolPort
+
+
+class MyTool(ToolPort):
+    """Short description of what the tool does."""
+
+    def __init__(self, some_setting: str = "default"):
+        self._setting = some_setting
+
+    @property
+    def name(self) -> str:
+        return "my_tool"
+
+    @property
+    def description(self) -> str:
+        return "Does something useful. Accepts a 'query' parameter."
+
+    @property
+    def input_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "The query to process.",
+                },
+            },
+            "required": ["query"],
+        }
+
+    @property
+    def permission(self) -> str:
+        return "my_tool:execute"
+
+    async def execute(self, tool_input: dict) -> str:
+        query = tool_input["query"]
+        # Do the work
+        result = f"Processed: {query} with {self._setting}"
+        return result
+```
+
+### ToolPort Interface
+
+| Property/Method | Type | Description |
+|----------------|------|-------------|
+| `name` | str | Unique tool identifier. |
+| `description` | str | Human-readable description (shown to LLM). |
+| `input_schema` | dict | JSON Schema for input parameters. |
+| `permission` | str | Permission string checked before execution. |
+| `execute(tool_input)` | async → str | Execute the tool and return result. |
+
+## Step 2: Register in Builtin Registry
+
+Add the tool to `src/ravn/adapters/tools/builtin_registry.py`:
+
+```python
+BUILTIN_TOOLS["my_tool"] = BuiltinToolDef(
+    adapter="ravn.adapters.tools.my_tool.MyTool",
+    groups=frozenset({"extended"}),
+    kwargs_fn=lambda settings, ctx: {
+        "some_setting": "configured_value",
+    },
+    required_context=frozenset(),
+    condition=None,  # or lambda s: s.some_feature.enabled
+)
+```
+
+### Registration Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `adapter` | str | Fully-qualified class path. |
+| `groups` | frozenset | Tool groups: `core`, `extended`, `skill`, `platform`, `mimir`, `cascade`. |
+| `kwargs_fn` | callable | Builds constructor kwargs from settings + runtime context. |
+| `required_context` | frozenset | Runtime context keys that must be non-None. |
+| `condition` | callable or None | Predicate on Settings — tool is skipped if False. |
+
+## Step 3: Add Config (If Needed)
+
+If the tool needs configuration, add a config class in `src/ravn/config.py`:
+
+```python
+class MyToolConfig(BaseModel):
+    enabled: bool = True
+    some_setting: str = "default"
+```
+
+Add it to the `Settings` class:
+
+```python
+class Settings(BaseSettings):
+    # ... existing fields ...
+    my_tool: MyToolConfig = MyToolConfig()
+```
+
+Update the `kwargs_fn` to read from config:
+
+```python
+kwargs_fn=lambda settings, ctx: {
+    "some_setting": settings.my_tool.some_setting,
+},
+condition=lambda s: s.my_tool.enabled,
+```
+
+## Step 4: Write Tests
+
+Create tests in `tests/test_ravn/test_adapters/test_tools/`:
+
+```python
+# tests/test_ravn/test_adapters/test_tools/test_my_tool.py
+import pytest
+from ravn.adapters.tools.my_tool import MyTool
+
+
+@pytest.fixture
+def tool():
+    return MyTool(some_setting="test")
+
+
+class TestMyTool:
+    def test_name(self, tool):
+        assert tool.name == "my_tool"
+
+    def test_schema(self, tool):
+        schema = tool.input_schema
+        assert "query" in schema["properties"]
+        assert "query" in schema["required"]
+
+    @pytest.mark.asyncio
+    async def test_execute(self, tool):
+        result = await tool.execute({"query": "hello"})
+        assert "Processed: hello" in result
+
+    @pytest.mark.asyncio
+    async def test_execute_error(self, tool):
+        with pytest.raises(KeyError):
+            await tool.execute({})
+```
+
+## Custom Tools (No Registry)
+
+For tools that don't need to be built-in, use the dynamic adapter pattern
+in config:
+
+```yaml
+tools:
+  custom:
+    - adapter: "mypackage.tools.MyTool"
+      name: "my_custom_tool"
+      kwargs:
+        some_setting: "value"
+```
+
+This requires no code changes to Ravn itself.

--- a/docs/site/ravn/getting-started/quick-start.md
+++ b/docs/site/ravn/getting-started/quick-start.md
@@ -14,12 +14,10 @@
     uv pip install ravn
     ```
 
-=== "Docker"
+=== "Nuitka binary"
 
-    ```bash
-    docker pull ghcr.io/niuulabs/ravn:latest
-    docker run --rm -it -e ANTHROPIC_API_KEY ghcr.io/niuulabs/ravn run "hello"
-    ```
+    Ravn can be compiled into a standalone binary via `make ravn-binary`.
+    No Python installation required on the target machine.
 
 ### Optional Extras
 

--- a/docs/site/ravn/getting-started/quick-start.md
+++ b/docs/site/ravn/getting-started/quick-start.md
@@ -1,0 +1,137 @@
+# Getting Started
+
+## Installation
+
+=== "pip"
+
+    ```bash
+    pip install ravn
+    ```
+
+=== "uv"
+
+    ```bash
+    uv pip install ravn
+    ```
+
+=== "Docker"
+
+    ```bash
+    docker pull ghcr.io/niuulabs/ravn:latest
+    docker run --rm -it -e ANTHROPIC_API_KEY ghcr.io/niuulabs/ravn run "hello"
+    ```
+
+### Optional Extras
+
+```bash
+# TUI (terminal user interface for flock management)
+pip install ravn[tui]
+
+# Browser automation
+pip install ravn[browser]
+```
+
+## First Run
+
+The simplest way to use Ravn is a one-shot prompt:
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+ravn run "hello"
+```
+
+For an interactive REPL session, omit the prompt:
+
+```bash
+ravn run
+```
+
+Ravn will enter a read-eval-print loop where you can issue multiple prompts,
+and the agent retains context across turns.
+
+## Config File Locations
+
+Ravn discovers its configuration file in this order (first found wins):
+
+1. `$RAVN_CONFIG` — environment variable pointing to a YAML file
+2. `~/.ravn/config.yaml` — user home directory
+3. `./ravn.yaml` — current working directory
+4. `/etc/ravn/config.yaml` — system-wide
+
+Environment variable overrides use the format `RAVN_<SECTION>__<FIELD>`
+(double underscore for nesting). For example:
+
+```bash
+export RAVN_LLM__MODEL=claude-opus-4
+export RAVN_MEMORY__BACKEND=postgres
+```
+
+Precedence: **env vars > YAML file > defaults**.
+
+## Minimal Config Example
+
+Most defaults are sensible. A minimal `ravn.yaml` only needs an API key
+(or set `ANTHROPIC_API_KEY` in the environment):
+
+```yaml
+anthropic:
+  api_key: "sk-ant-..."
+```
+
+A more typical setup:
+
+```yaml
+llm:
+  model: "claude-sonnet-4-6"
+  max_tokens: 8192
+
+permission:
+  mode: workspace_write
+  workspace_root: "/home/user/projects/myapp"
+
+memory:
+  backend: sqlite
+  path: "~/.ravn/memory.db"
+
+logging:
+  level: info
+```
+
+## Project Configuration (RAVN.md)
+
+Drop a `RAVN.md` file in your project root to set per-project overrides.
+Ravn discovers it by walking from the current directory up to the filesystem
+root, then falls back to `~/.ravn/default.md`.
+
+```markdown
+# RAVN Project: my-api
+
+persona: coding-agent
+allowed_tools: [file, git, terminal, web]
+forbidden_tools: [cascade]
+permission_mode: workspace-write
+thinking_enabled: true
+iteration_budget: 30
+notes: >
+  FastAPI service. Always run tests before committing.
+```
+
+Supported fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `persona` | string | Built-in or custom persona name |
+| `allowed_tools` | list | Tool names or groups to enable |
+| `forbidden_tools` | list | Tool names or groups to disable |
+| `permission_mode` | string | `read_only`, `workspace_write`, `full_access`, `prompt` |
+| `primary_alias` | string | Bifrost model alias (`powerful`, `balanced`, `fast`) |
+| `thinking_enabled` | bool | Enable extended thinking |
+| `iteration_budget` | int | Max tool-call iterations per session |
+| `notes` | string | Free-text project context injected into system prompt |
+
+## What Next?
+
+- [Configuration Reference](../configuration/reference.md) — full config surface
+- [CLI Reference](../cli/reference.md) — all commands and flags
+- [Tool Reference](../tools/reference.md) — built-in tools
+- [Personas](../personas/reference.md) — persona system

--- a/docs/site/ravn/index.md
+++ b/docs/site/ravn/index.md
@@ -1,0 +1,68 @@
+# Ravn Documentation
+
+Ravn is an autonomous AI agent framework built on Claude. It provides a rich CLI,
+persistent memory, knowledge management, distributed coordination, and a deep
+configuration surface — all designed for both interactive and unattended operation.
+
+## Documentation Overview
+
+### Phase 1 — Core
+
+Everything a new user needs to get started and understand the basic surface area.
+
+| Section | Description |
+|---------|-------------|
+| [Getting Started](getting-started/quick-start.md) | Installation, first run, config discovery |
+| [Configuration Reference](configuration/reference.md) | Every config section with defaults, types, examples |
+| [CLI Reference](cli/reference.md) | All commands, flags, and subcommands |
+| [Tool Reference](tools/reference.md) | Built-in tools by group with permissions |
+| [Personas](personas/reference.md) | Built-in and custom personas, RAVN.md overlay |
+
+### Phase 2 — Platform Services
+
+Services that extend Ravn beyond a single-session agent.
+
+| Section | Description |
+|---------|-------------|
+| [Bifrost — LLM Proxy](platform/bifrost.md) | Model aliases, routing, cost tracking, budgets |
+| [Mímir — Knowledge Base](platform/mimir.md) | Persistent wiki, ingestion, search, lint |
+| [MCP Integration](platform/mcp.md) | Model Context Protocol servers, auth, transports |
+
+### Phase 3 — Advanced Agent Features
+
+Subsystems for distributed execution, memory, and self-improvement.
+
+| Section | Description |
+|---------|-------------|
+| [Cascade & Parallel Execution](advanced/cascade.md) | Coordinator, sub-agents, task tools |
+| [Flock / Mesh Networking](advanced/flock.md) | Mesh transports, peer discovery |
+| [Drive Loop & Triggers](advanced/drive-loop.md) | Initiative engine, cron, events |
+| [Memory & Knowledge Systems](advanced/memory.md) | Episodic memory, Búri fact graph, outcomes |
+| [Skill System](advanced/skills.md) | Automatic skill extraction, storage, execution |
+| [Context Management](advanced/context.md) | Compression, prompt builder, caching |
+| [Extended Thinking](advanced/thinking.md) | Claude thinking mode, budget, auto-trigger |
+
+### Phase 4 — Operations & Integration
+
+Deployment, security, and integration with external systems.
+
+| Section | Description |
+|---------|-------------|
+| [Sleipnir Event Backbone](operations/sleipnir.md) | RabbitMQ setup, exchange topology, events |
+| [Gateway Channels](operations/gateway.md) | HTTP, Telegram, Discord, Slack, Matrix, WebSocket |
+| [Security & Permissions](operations/security.md) | Permission modes, rules, approval memory, PATs |
+| [Hooks](operations/hooks.md) | Pre/post-tool lifecycle, custom hooks |
+| [Self-Improvement / Evolution](operations/evolution.md) | Pattern extraction, skill suggestion, strategy |
+| [Deployment](operations/deployment.md) | Pi mode, Kubernetes, Docker, config overlays |
+| [Checkpointing & Resume](operations/checkpointing.md) | Crash recovery, snapshots, `--resume` |
+
+### Phase 5 — Developer Reference
+
+For contributors building new tools, providers, or channels.
+
+| Section | Description |
+|---------|-------------|
+| [Architecture](developer/architecture.md) | Hexagonal design, ports, adapters, modules |
+| [Adding a New Tool](developer/new-tool.md) | Implement ToolPort, register, configure |
+| [Adding a New LLM Provider](developer/new-provider.md) | Implement LLMPort, streaming, fallback |
+| [Adding a New Channel](developer/new-channel.md) | Implement ChannelPort, event translation |

--- a/docs/site/ravn/operations/checkpointing.md
+++ b/docs/site/ravn/operations/checkpointing.md
@@ -1,0 +1,120 @@
+# Checkpointing & Resume
+
+Ravn's checkpoint system enables crash recovery and task resumption. It
+periodically saves agent state so that interrupted tasks can be resumed
+from the last checkpoint.
+
+## How It Works
+
+```mermaid
+graph LR
+    Agent -->|every N tools| Checkpoint["Save Checkpoint"]
+    Checkpoint -->|disk or postgres| Storage
+    Resume["ravn resume TASK_ID"] -->|load| Storage
+    Storage -->|restore| Agent
+```
+
+After every `checkpoint_every_n_tools` (default: 10) tool calls, the agent
+saves its state. On crash or interruption, `ravn resume` restores the
+session from the latest checkpoint.
+
+## Checkpoint Contents
+
+Each checkpoint captures:
+
+| Field | Description |
+|-------|-------------|
+| Session messages | Full conversation history |
+| Tool call count | Number of tools executed |
+| Current turn state | In-progress turn data |
+| Completion status | Whether the task is finished |
+| Todos | Current task list |
+
+## Crash-Recovery Checkpoints
+
+Crash-recovery checkpoints are per-task and overwritten on each save:
+
+| Operation | Description |
+|-----------|-------------|
+| `save(checkpoint)` | Persist after each trigger. |
+| `load(task_id)` | Load on resume. |
+| `delete(task_id)` | Clean up after completion. |
+| `list_task_ids()` | List available tasks. |
+
+## Named Snapshots
+
+Named snapshots allow multiple save points per task:
+
+| Operation | Description |
+|-----------|-------------|
+| `save_snapshot(checkpoint)` | Save as `ckpt_{task_id}_{seq}`. |
+| `load_snapshot(checkpoint_id)` | Load specific snapshot. |
+| `list_for_task(task_id)` | All snapshots for a task. |
+| `delete_snapshot(checkpoint_id)` | Remove a snapshot. |
+
+## Auto-Checkpoint Triggers
+
+Checkpoints are automatically saved:
+
+| Trigger | Config | Default |
+|---------|--------|---------|
+| Every N tool calls | `checkpoint_every_n_tools` | 10 |
+| Before destructive operations | `auto_before_destructive` | `true` |
+| At budget milestones | `budget_milestone_fractions` | `[0.5, 0.75, 0.9]` |
+
+"Destructive operations" include `rm`, `git reset`, `drop table`, etc.
+
+Budget milestones create snapshots at 50%, 75%, and 90% of the iteration
+budget, providing restore points if the agent goes off track.
+
+## Storage Backends
+
+| Backend | Description |
+|---------|-------------|
+| `local` (default) | Disk-based, stored in `~/.ravn/checkpoints/`. |
+| `postgres` | PostgreSQL-based, for shared/HA deployments. |
+
+## Resume Workflow
+
+### Resume Latest
+
+```bash
+# Resume from the latest crash-recovery checkpoint
+ravn resume task_abc123
+```
+
+### Resume Specific Snapshot
+
+```bash
+# List available snapshots
+ravn resume task_abc123 --list
+
+# Resume from a specific snapshot
+ravn resume task_abc123 -c ckpt_task_abc123_3
+```
+
+### Drive Loop Resume
+
+When running as a daemon, `--resume` restores unfinished tasks from the
+queue journal:
+
+```bash
+ravn daemon --resume
+```
+
+This loads the persisted task queue and resumes any interrupted tasks.
+
+## Configuration
+
+```yaml
+checkpoint:
+  enabled: true
+  backend: local
+  dir: "~/.ravn/checkpoints"
+  checkpoint_every_n_tools: 10
+  max_checkpoints_per_task: 20
+  auto_before_destructive: true
+  budget_milestone_fractions: [0.5, 0.75, 0.9]
+```
+
+Related: [NIU-504](https://linear.app/niuulabs/issue/NIU-504), [NIU-537](https://linear.app/niuulabs/issue/NIU-537)

--- a/docs/site/ravn/operations/deployment.md
+++ b/docs/site/ravn/operations/deployment.md
@@ -96,16 +96,12 @@ checkpoint:
   backend: postgres
 ```
 
-### Helm Chart
+### Deployment
 
-Deploy via the Volundr Helm chart:
-
-```bash
-helm install ravn charts/volundr \
-  --set ravn.enabled=true \
-  --set ravn.replicas=3 \
-  --set ravn.config.sleipnir.enabled=true
-```
+Ravn does not have its own Helm chart. In Kubernetes, deploy it as a
+standalone binary (Nuitka build) or container with a `ravn.yaml` ConfigMap.
+The platform charts (`charts/volundr`, `charts/tyr`, `charts/bifrost`,
+`charts/mimir`, etc.) handle their respective services.
 
 ## Docker
 
@@ -168,9 +164,8 @@ example configs:
 
 | File | Purpose |
 |------|---------|
-| `buri.example.yaml` | Minimal example with documentation |
-| `buri.docker.yaml` | Docker/container deployment |
-| `buri.mac.yaml` | macOS local development |
+| `ravn.tui.example.yaml` | TUI keybinding and layout configuration |
+| `bifrost.pi.example.yaml` | Bifrost proxy setup for Pi mode |
 
 Use the `RAVN_CONFIG` environment variable or `--config` flag to select
 the appropriate overlay.

--- a/docs/site/ravn/operations/deployment.md
+++ b/docs/site/ravn/operations/deployment.md
@@ -1,0 +1,188 @@
+# Deployment
+
+Ravn supports three deployment modes depending on your infrastructure.
+
+## Pi Mode (Local)
+
+Run Ravn on a single machine (Raspberry Pi, laptop, desktop) with local
+networking and mDNS discovery.
+
+```yaml
+# ravn.yaml — Pi mode
+llm:
+  model: claude-sonnet-4-6
+
+gateway:
+  enabled: true
+  channels:
+    telegram:
+      bot_token_env: TELEGRAM_BOT_TOKEN
+      allowed_chat_ids: [123456789]
+    http:
+      host: "0.0.0.0"
+      port: 7477
+
+discovery:
+  adapter: mdns
+  mdns:
+    realm_key_env: RAVN_REALM_KEY
+
+mesh:
+  enabled: true
+  adapter: nng
+
+permission:
+  mode: full_access
+```
+
+Start with:
+
+```bash
+ravn daemon -c ravn.yaml
+```
+
+### Multi-Pi Setup
+
+Run multiple Ravn instances on the local network. They discover each other
+via mDNS and form a flock:
+
+```bash
+# Pi 1 (coordinator)
+RAVN_REALM_KEY=secret123 ravn daemon -c ravn.yaml -p autonomous-agent
+
+# Pi 2 (worker)
+RAVN_REALM_KEY=secret123 ravn daemon -c ravn-worker.yaml -p coding-agent
+```
+
+All instances with the same `RAVN_REALM_KEY` discover each other and can
+delegate tasks via cascade.
+
+## Infrastructure Mode (Kubernetes)
+
+Run Ravn in Kubernetes with Sleipnir event backbone, PostgreSQL persistence,
+and Kubernetes-native discovery.
+
+```yaml
+# ravn.yaml — Infrastructure mode
+llm:
+  model: claude-sonnet-4-6
+  provider:
+    adapter: ravn.adapters.llm.bifrost.BifrostAdapter
+    kwargs:
+      base_url: "http://bifrost.ravn.svc:8080"
+
+sleipnir:
+  enabled: true
+  amqp_url_env: SLEIPNIR_AMQP_URL
+
+initiative:
+  enabled: true
+  max_concurrent_tasks: 5
+
+cascade:
+  enabled: true
+
+discovery:
+  adapter: k8s
+  k8s:
+    namespace: ravn
+    label_selector: "app=ravn-agent"
+
+memory:
+  backend: postgres
+  dsn_env: RAVN_POSTGRES_DSN
+
+checkpoint:
+  backend: postgres
+```
+
+### Helm Chart
+
+Deploy via the Volundr Helm chart:
+
+```bash
+helm install ravn charts/volundr \
+  --set ravn.enabled=true \
+  --set ravn.replicas=3 \
+  --set ravn.config.sleipnir.enabled=true
+```
+
+## Docker
+
+### Terminal Sandboxing
+
+Run agent bash commands in Docker containers for isolation:
+
+```yaml
+tools:
+  terminal:
+    backend: docker
+    docker:
+      image: "python:3.11-slim"
+      network: none
+      mount_workspace: true
+```
+
+### Docker Compose
+
+Example `docker-compose.yml` for a full Ravn stack:
+
+```yaml
+services:
+  ravn:
+    image: ghcr.io/niuulabs/ravn:latest
+    environment:
+      - ANTHROPIC_API_KEY
+      - SLEIPNIR_AMQP_URL=amqp://rabbitmq:5672
+      - RAVN_POSTGRES_DSN=postgresql://ravn:secret@postgres:5432/ravn
+    volumes:
+      - ./ravn.yaml:/etc/ravn/config.yaml
+      - ravn-data:/home/ravn/.ravn
+    depends_on:
+      - rabbitmq
+      - postgres
+
+  rabbitmq:
+    image: rabbitmq:3-management
+    ports:
+      - "15672:15672"
+
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: ravn
+      POSTGRES_USER: ravn
+      POSTGRES_PASSWORD: secret
+    volumes:
+      - pg-data:/var/lib/postgresql/data
+
+volumes:
+  ravn-data:
+  pg-data:
+```
+
+## Config Overlays
+
+Ravn supports environment-specific config files. The project includes
+example configs:
+
+| File | Purpose |
+|------|---------|
+| `buri.example.yaml` | Minimal example with documentation |
+| `buri.docker.yaml` | Docker/container deployment |
+| `buri.mac.yaml` | macOS local development |
+
+Use the `RAVN_CONFIG` environment variable or `--config` flag to select
+the appropriate overlay.
+
+## Nuitka Binary
+
+Ravn can be compiled into a single standalone binary using Nuitka:
+
+```bash
+# Build single binary (no Python required on target)
+make ravn-binary
+```
+
+This produces a self-contained executable suitable for deployment to
+minimal environments (containers, embedded systems, etc.).

--- a/docs/site/ravn/operations/deployment.md
+++ b/docs/site/ravn/operations/deployment.md
@@ -16,7 +16,7 @@ gateway:
   enabled: true
   channels:
     telegram:
-      bot_token_env: TELEGRAM_BOT_TOKEN
+      token_env: TELEGRAM_BOT_TOKEN
       allowed_chat_ids: [123456789]
     http:
       host: "0.0.0.0"

--- a/docs/site/ravn/operations/evolution.md
+++ b/docs/site/ravn/operations/evolution.md
@@ -1,0 +1,96 @@
+# Self-Improvement / Evolution
+
+Ravn's evolution system analyzes accumulated task outcomes and episodic memory
+to surface patterns that improve future performance. It extracts skill
+suggestions, error warnings, and effective strategies.
+
+## How It Works
+
+Run the evolution pass manually:
+
+```bash
+ravn evolve
+```
+
+The `PatternExtractor` analyzes:
+
+1. **Recent episodes** — up to `max_episodes_to_analyze` (default: 100)
+2. **Task outcomes** — up to `max_outcomes_to_analyze` (default: 50)
+
+And produces three categories of insights:
+
+### Skill Suggestions
+
+When ≥ `skill_suggestion_min_occurrences` (default: 3) SUCCESS episodes share
+the same tool sequence pattern, the system suggests extracting a reusable skill.
+
+Example output:
+
+```
+SKILL SUGGESTION: "test-fix-commit"
+  Pattern: [grep_search, edit_file, bash("pytest"), git_add, git_commit]
+  Seen in 5 SUCCESS episodes
+  → Consider creating a skill for this workflow
+```
+
+### System Warnings
+
+When ≥ `error_warning_min_occurrences` (default: 3) episodes contain the same
+error pattern, the system flags it as a systematic issue.
+
+Example output:
+
+```
+WARNING: "timeout on web_fetch"
+  Seen in 4 episodes (3 FAILURE, 1 PARTIAL)
+  → Consider increasing web.fetch.timeout or adding retry logic
+```
+
+### Strategy Injections
+
+When ≥ `strategy_min_occurrences` (default: 3) SUCCESS episodes share the
+same tag (domain/context), the system identifies effective strategies for
+that domain.
+
+Example output:
+
+```
+STRATEGY: "database migrations"
+  5/6 SUCCESS episodes used: [read_file(migration), bash("make test"), git_commit]
+  → When working on migrations, read existing migrations first
+```
+
+## Output Format
+
+`ravn evolve` prints a human-readable `PromptEvolution` diff. No automatic
+modifications are made — review and apply manually.
+
+The output includes:
+- Suggested skill definitions (Markdown with YAML frontmatter)
+- Warning summaries with affected episodes
+- Strategy descriptions with recommended approaches
+
+## Trigger Threshold
+
+Evolution analysis only runs when there are at least `min_new_outcomes`
+(default: 10) new outcomes since the last analysis. The state is tracked
+in `evolution_state.json`.
+
+## Configuration
+
+```yaml
+evolution:
+  enabled: true
+  min_new_outcomes: 10
+  state_path: "~/.ravn/evolution_state.json"
+  max_episodes_to_analyze: 100
+  max_outcomes_to_analyze: 50
+  skill_suggestion_min_occurrences: 3
+  error_warning_min_occurrences: 3
+  strategy_min_occurrences: 3
+  max_skill_suggestions: 5
+  max_system_warnings: 5
+  max_strategy_injections: 3
+```
+
+Related: [NIU-501](https://linear.app/niuulabs/issue/NIU-501)

--- a/docs/site/ravn/operations/gateway.md
+++ b/docs/site/ravn/operations/gateway.md
@@ -1,0 +1,163 @@
+# Gateway Channels
+
+The gateway enables Ravn to communicate through external messaging channels.
+Each channel translates between the channel's native format and Ravn's
+internal event stream.
+
+## Supported Channels
+
+| Channel | Transport | Use Case |
+|---------|-----------|----------|
+| HTTP | REST + WebSocket + SSE | Local API access, web integrations |
+| Telegram | Bot API polling | Mobile/desktop messaging |
+| Discord | Bot API | Team communication |
+| Slack | Socket Mode | Workplace messaging |
+| Matrix | Client-Server API | Federated messaging |
+| WhatsApp | Meta Cloud API | WhatsApp Business |
+| Skuld | WebSocket | Custom WebSocket broker |
+
+## HTTP Gateway
+
+The HTTP channel exposes a local API server:
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/v1/chat` | POST | Send a message, receive response. |
+| `/v1/chat/stream` | POST | Send a message, receive SSE stream. |
+| `/v1/ws` | WebSocket | Bidirectional conversation. |
+| `/health` | GET | Health check. |
+
+```yaml
+gateway:
+  channels:
+    http:
+      host: "0.0.0.0"
+      port: 7477
+```
+
+### WebSocket Protocol
+
+WebSocket connections use JSON frames:
+
+```json
+// Client → Server
+{ "type": "message", "content": "explain this code" }
+
+// Server → Client (streaming)
+{ "type": "text_delta", "content": "The code..." }
+{ "type": "tool_call", "name": "read_file", "input": {...} }
+{ "type": "tool_result", "content": "..." }
+{ "type": "message_done" }
+```
+
+### SSE Format
+
+Server-sent events use the CLI `stream-json` format:
+
+```
+data: {"type": "text_delta", "content": "The code..."}
+data: {"type": "tool_call", "name": "read_file"}
+data: {"type": "message_done"}
+```
+
+## Telegram Bot
+
+Poll-based Telegram bot integration:
+
+```yaml
+gateway:
+  channels:
+    telegram:
+      bot_token_env: "TELEGRAM_BOT_TOKEN"
+      allowed_chat_ids: [123456789, 987654321]
+      poll_timeout: 30
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `bot_token_env` | str | | Env var containing bot token. |
+| `allowed_chat_ids` | list[int] | `[]` | Restrict to specific chat IDs. Empty = all. |
+| `poll_timeout` | int | `30` | Long-poll timeout (seconds). |
+
+Setup:
+
+1. Create a bot via [@BotFather](https://t.me/BotFather)
+2. Set the token in an environment variable
+3. Get your chat ID (message the bot, check updates)
+4. Add the chat ID to `allowed_chat_ids`
+
+## Discord Bot
+
+```yaml
+gateway:
+  channels:
+    discord:
+      bot_token_env: "DISCORD_BOT_TOKEN"
+      guild_id: "123456789"
+      command_prefix: "!"
+```
+
+## Slack Bot
+
+Uses Slack Socket Mode for real-time messaging:
+
+```yaml
+gateway:
+  channels:
+    slack:
+      bot_token_env: "SLACK_BOT_TOKEN"
+      app_token_env: "SLACK_APP_TOKEN"
+      poll_interval: 1.0
+```
+
+## Matrix
+
+Federated messaging with optional end-to-end encryption:
+
+```yaml
+gateway:
+  channels:
+    matrix:
+      homeserver: "https://matrix.example.com"
+      user_id: "@ravn:example.com"
+      access_token_env: "MATRIX_TOKEN"
+      e2e_enabled: false
+      sync_timeout: 30000
+```
+
+## WhatsApp
+
+WhatsApp Business API via Meta Cloud API:
+
+```yaml
+gateway:
+  channels:
+    whatsapp:
+      api_key_env: "WHATSAPP_API_KEY"
+      phone_number_id: "123456789"
+      webhook_host: "0.0.0.0"
+      webhook_port: 8443
+```
+
+## Skuld WebSocket Broker
+
+Custom WebSocket broker for internal routing:
+
+```yaml
+gateway:
+  channels:
+    skuld:
+      broker_url: "ws://skuld.ravn.svc:8080/ws"
+```
+
+## Event Translation
+
+Each channel has an event translator that converts between Ravn's internal
+`StreamEvent` format and the channel's native message format. The HTTP
+channel's translator (`stream-json`) is the reference implementation.
+
+## Per-Session Agents
+
+Each incoming conversation creates a per-session agent instance. The gateway
+manages session lifecycles — creating agents on first message, routing
+subsequent messages to the correct session, and cleaning up idle sessions.

--- a/docs/site/ravn/operations/gateway.md
+++ b/docs/site/ravn/operations/gateway.md
@@ -68,14 +68,14 @@ Poll-based Telegram bot integration:
 gateway:
   channels:
     telegram:
-      bot_token_env: "TELEGRAM_BOT_TOKEN"
+      token_env: "TELEGRAM_BOT_TOKEN"
       allowed_chat_ids: [123456789, 987654321]
       poll_timeout: 30
 ```
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `bot_token_env` | str | | Env var containing bot token. |
+| `token_env` | str | `"TELEGRAM_BOT_TOKEN"` | Env var containing bot token. |
 | `allowed_chat_ids` | list[int] | `[]` | Restrict to specific chat IDs. Empty = all. |
 | `poll_timeout` | int | `30` | Long-poll timeout (seconds). |
 
@@ -119,10 +119,10 @@ gateway:
   channels:
     matrix:
       homeserver: "https://matrix.example.com"
-      user_id: "@ravn:example.com"
+      user_id_env: "MATRIX_USER_ID"
       access_token_env: "MATRIX_TOKEN"
-      e2e_enabled: false
-      sync_timeout: 30000
+      e2e: false
+      sync_timeout_ms: 30000
 ```
 
 ## WhatsApp

--- a/docs/site/ravn/operations/gateway.md
+++ b/docs/site/ravn/operations/gateway.md
@@ -92,7 +92,7 @@ Setup:
 gateway:
   channels:
     discord:
-      bot_token_env: "DISCORD_BOT_TOKEN"
+      token_env: "DISCORD_BOT_TOKEN"
       guild_id: "123456789"
       command_prefix: "!"
 ```

--- a/docs/site/ravn/operations/hooks.md
+++ b/docs/site/ravn/operations/hooks.md
@@ -1,0 +1,116 @@
+# Hooks
+
+Hooks allow custom code to run before or after tool executions. They are
+useful for auditing, metrics, sanitization, and custom validation.
+
+## Hook Lifecycle
+
+```mermaid
+sequenceDiagram
+    Agent->>+PreHooks: pre_tool(tool_name, input)
+    PreHooks-->>-Agent: allow / deny / modify
+    Agent->>+Tool: execute(input)
+    Tool-->>-Agent: result
+    Agent->>+PostHooks: post_tool(tool_name, input, result)
+    PostHooks-->>-Agent: log / transform
+```
+
+1. **Pre-tool hooks** run before tool execution. They can:
+   - Allow the call to proceed
+   - Deny the call (with reason)
+   - Modify the input
+
+2. **Post-tool hooks** run after tool execution. They can:
+   - Log the result
+   - Transform the output
+   - Trigger side effects
+
+## Configuration
+
+```yaml
+hooks:
+  pre_tool:
+    - adapter: "mypackage.hooks.AuditHook"
+      kwargs:
+        log_path: "/var/log/ravn/audit.log"
+      events: ["pre_tool"]
+
+    - adapter: "mypackage.hooks.SanitizeHook"
+      kwargs:
+        patterns: ["password", "secret", "token"]
+      events: ["pre_tool"]
+
+  post_tool:
+    - adapter: "mypackage.hooks.MetricsHook"
+      kwargs:
+        statsd_host: "localhost"
+        statsd_port: 8125
+      events: ["post_tool"]
+```
+
+### Hook Config Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `adapter` | str | Fully-qualified class path for the hook. |
+| `kwargs` | dict | Constructor arguments. |
+| `secret_kwargs_env` | dict | Env var names for secret constructor args. |
+| `events` | list[str] | Event types to subscribe to: `pre_tool`, `post_tool`. |
+
+## Built-in Hook Use Cases
+
+### Permission Hook
+
+The permission system itself operates as a pre-tool hook, checking every
+tool call against the active permission mode and rules before execution.
+
+### Approval Hook
+
+When `permission.mode` is `prompt`, the approval hook intercepts tool calls,
+prompts the user, and caches approved patterns.
+
+### Budget Hook
+
+Tracks iteration budget usage and injects "near limit" warnings when
+the agent approaches the configured threshold.
+
+## Custom Hook Development
+
+Implement a hook by creating a class with the appropriate method signatures:
+
+```python
+class MyHook:
+    def __init__(self, log_path: str):
+        self.log_path = log_path
+
+    async def pre_tool(
+        self, tool_name: str, tool_input: dict
+    ) -> dict | None:
+        """Return None to allow, or a dict with 'deny' key to block."""
+        # Log the call
+        with open(self.log_path, "a") as f:
+            f.write(f"{tool_name}: {tool_input}\n")
+        return None  # allow
+
+    async def post_tool(
+        self, tool_name: str, tool_input: dict, result: str
+    ) -> str | None:
+        """Return None to pass through, or a string to replace result."""
+        return None  # pass through
+```
+
+Register in config:
+
+```yaml
+hooks:
+  pre_tool:
+    - adapter: "mypackage.hooks.MyHook"
+      kwargs:
+        log_path: "/var/log/ravn/my_hook.log"
+      events: ["pre_tool"]
+  post_tool:
+    - adapter: "mypackage.hooks.MyHook"
+      kwargs:
+        log_path: "/var/log/ravn/my_hook.log"
+      events: ["post_tool"]
+```

--- a/docs/site/ravn/operations/security.md
+++ b/docs/site/ravn/operations/security.md
@@ -1,0 +1,127 @@
+# Security & Permissions
+
+Ravn's permission system controls what the agent can do — which tools it can
+call, which commands it can execute, and which files it can access.
+
+## Permission Modes
+
+| Mode | Description |
+|------|-------------|
+| `read_only` | No mutations. Bash limited to read-only commands, no network. |
+| `workspace_write` (default) | Writes allowed within `workspace_root` only. |
+| `full_access` | Unrestricted access. Explicit opt-in required. |
+| `prompt` | Interactive approval for each action. |
+
+Set the mode in config:
+
+```yaml
+permission:
+  mode: workspace_write
+  workspace_root: "/home/user/projects/myapp"
+```
+
+## Permission Rules
+
+Rules are evaluated in order before the default mode. First match wins.
+
+```yaml
+permission:
+  mode: workspace_write
+  rules:
+    - pattern: "bash:execute"
+      action: ask            # Always prompt for bash
+    - pattern: "git:write"
+      action: allow          # Auto-allow git writes
+    - pattern: "web:*"
+      action: deny           # Block all web tools
+  allow:
+    - read_file              # Always allow these tools
+    - glob_search
+  deny:
+    - terminal_docker        # Always block these tools
+```
+
+### Pattern Matching
+
+| Pattern | Matches |
+|---------|---------|
+| `bash:execute` | Exact permission name. |
+| `git:*` | All git permissions. |
+| `*:read` | All read permissions. |
+| `web:*` | All web permissions. |
+
+## Bash Command Validation
+
+The bash tool has a multi-stage security pipeline:
+
+### Stage 1: Command Intent Classification
+
+Every bash command is classified by intent:
+
+| Intent | Description | Examples |
+|--------|-------------|---------|
+| `READ_ONLY` | Safe information retrieval | `ls`, `cat`, `grep`, `find` |
+| `WRITE` | Data mutation (safe) | `echo > file`, `mkdir` |
+| `DESTRUCTIVE` | Dangerous mutations | `rm`, `rmdir`, `truncate` |
+| `NETWORK` | Network calls | `curl`, `wget`, `ssh` |
+| `PROCESS_MANAGEMENT` | Process control | `kill`, `pkill` |
+| `PACKAGE_MANAGEMENT` | Package operations | `apt`, `pip`, `npm` |
+| `SYSTEM_ADMIN` | System administration | `usermod`, `mount` |
+
+### Stage 2: Path Validation
+
+- **Symlink resolution** — follows symlinks to check real paths
+- **Path traversal detection** — blocks `../` escapes from workspace
+- **System path protection** — blocks writes to `/bin`, `/sys`, `/root`, etc.
+
+### Stage 3: Always-Blocked Commands
+
+Certain commands are always blocked regardless of mode:
+
+- `rm -rf` (directory deletion)
+- `dd` (raw disk writes)
+- `sudo` (privilege escalation)
+- `chmod 777` (dangerous permissions)
+
+### Stage 4: Permission Mode Check
+
+After classification and validation, the command is checked against the
+active permission mode.
+
+## Approval Memory
+
+When `permission.mode` is `prompt`, the agent asks the user before executing
+sensitive commands. Approved commands are remembered per-project:
+
+```bash
+# View approved patterns
+ravn approvals list
+
+# Revoke an approval
+ravn approvals revoke "npm test"
+```
+
+Approval data is stored in `.ravn/approvals.json` within the project.
+
+## Personal Access Tokens (PATs)
+
+For service-to-service authentication (e.g., Tyr calling Volundr), Ravn
+supports Personal Access Tokens. PATs are long-lived JWTs signed with the
+same symmetric key that Envoy validates.
+
+PATs exist in the shared `niuu` module and integrate with existing
+infrastructure without requiring identity provider changes.
+
+## Configuration
+
+```yaml
+permission:
+  mode: workspace_write
+  workspace_root: "/home/user/projects"
+  allow: []
+  deny: []
+  ask: []
+  rules: []
+```
+
+See the [Configuration Reference](../configuration/reference.md#permission) for all fields.

--- a/docs/site/ravn/operations/sleipnir.md
+++ b/docs/site/ravn/operations/sleipnir.md
@@ -1,0 +1,105 @@
+# Sleipnir Event Backbone
+
+Sleipnir is Ravn's event publishing system built on RabbitMQ. It enables
+agents to broadcast lifecycle events, task results, and system signals
+to other services and agents.
+
+## RabbitMQ Setup
+
+Sleipnir uses a **topic exchange** for flexible event routing:
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| Exchange | `ravn.events` | Topic exchange name. |
+| Routing key format | `ravn.<event_type>.<agent_id>` | Dot-separated routing key. |
+| Connection | `SLEIPNIR_AMQP_URL` env var | AMQP connection URL. |
+
+## Exchange Topology
+
+```mermaid
+graph LR
+    Agent1["Agent (pi-01)"] -->|publish| Exchange["ravn.events (topic)"]
+    Agent2["Agent (pi-02)"] -->|publish| Exchange
+    Exchange -->|ravn.task.*| TaskConsumer["Task Monitor"]
+    Exchange -->|ravn.*.pi-01| AgentConsumer["Agent-specific"]
+    Exchange -->|ravn.#| AllConsumer["Log Collector"]
+```
+
+Consumers bind queues with routing key patterns:
+
+- `ravn.task.*` — all task events from any agent
+- `ravn.*.pi-01` — all events from a specific agent
+- `ravn.#` — all events (wildcard)
+
+## Event Types
+
+Events are wrapped in a `SleipnirEnvelope` with metadata:
+
+| Field | Description |
+|-------|-------------|
+| `event_type` | Event category (see below). |
+| `agent_id` | Originating agent identifier. |
+| `timestamp` | ISO 8601 timestamp. |
+| `urgency` | Hint for consumers (e.g., `routine`, `urgent`). |
+| `payload` | Event-specific data. |
+
+Common event types:
+
+| Event | Published When |
+|-------|---------------|
+| `task.started` | Agent begins a task. |
+| `task.completed` | Task finishes (success or failure). |
+| `task.rejected` | Task dispatch rejected (unknown persona, etc.). |
+| `agent.heartbeat` | Periodic heartbeat from daemon. |
+| `agent.started` | Agent process starts. |
+| `agent.stopped` | Agent process stops. |
+| `flock.peer_joined` | New peer discovered. |
+| `flock.peer_left` | Peer evicted (TTL expired). |
+
+## Consumer Patterns
+
+### Direct Subscription
+
+Listen for specific events:
+
+```python
+# Subscribe to task completion events
+channel.queue_bind(queue_name, "ravn.events", routing_key="ravn.task.completed.*")
+```
+
+### Fan-out to Multiple Consumers
+
+Each consumer binds its own queue — RabbitMQ delivers to all matching queues.
+
+### Integration with Drive Loop
+
+The initiative engine subscribes to Sleipnir events as trigger sources.
+When a matching event arrives, it enqueues a task:
+
+```yaml
+initiative:
+  trigger_adapters:
+    - adapter: "ravn.adapters.triggers.sleipnir.SleipnirEventTrigger"
+      event_type: "deployment.completed"
+      prompt: "Verify deployment health"
+```
+
+## Connection Behavior
+
+- **Lazy connection**: First publish triggers AMQP connect
+- **Auto-reconnect**: Reconnects on failure with configurable delay
+- **Publish timeout**: Per-message timeout prevents blocking
+
+## Configuration
+
+```yaml
+sleipnir:
+  enabled: true
+  amqp_url_env: "SLEIPNIR_AMQP_URL"
+  exchange: "ravn.events"
+  agent_id: ""              # auto: hostname
+  reconnect_delay_s: 5.0
+  publish_timeout_s: 2.0
+```
+
+Related: [NIU-438](https://linear.app/niuulabs/issue/NIU-438)

--- a/docs/site/ravn/personas/reference.md
+++ b/docs/site/ravn/personas/reference.md
@@ -14,7 +14,7 @@ General-purpose software engineering agent.
 |---------|-------|
 | Tools | file, git, terminal, web, todo, introspection |
 | Forbidden | cascade, volundr |
-| Permission | `workspace_write` |
+| Permission | `workspace-write` |
 | Model alias | `balanced` |
 | Thinking | Enabled |
 | Budget | 40 iterations |
@@ -27,7 +27,7 @@ Information gathering and synthesis — no mutation.
 |---------|-------|
 | Tools | web, file, introspection |
 | Forbidden | git, terminal, cascade |
-| Permission | `read_only` |
+| Permission | `read-only` |
 | Model alias | `balanced` |
 | Thinking | Disabled |
 | Budget | 30 iterations |
@@ -40,7 +40,7 @@ Structured planning and architecture — read-only, high reasoning.
 |---------|-------|
 | Tools | file, introspection |
 | Forbidden | git, terminal, cascade, volundr |
-| Permission | `read_only` |
+| Permission | `read-only` |
 | Model alias | `powerful` |
 | Thinking | Enabled |
 | Budget | 20 iterations |
@@ -53,7 +53,7 @@ Fully unsupervised execution — all tools, all permissions.
 |---------|-------|
 | Tools | All |
 | Forbidden | None |
-| Permission | `full_access` |
+| Permission | `full-access` |
 | Model alias | `powerful` |
 | Thinking | Enabled |
 | Budget | 100 iterations |
@@ -64,10 +64,12 @@ Knowledge base synthesis and maintenance.
 
 | Setting | Value |
 |---------|-------|
-| Tools | mimir_query, mimir_ingest, mimir_write, mimir_lint |
-| Permission | `workspace_write` |
+| Tools | mimir, web, file, introspection |
+| Forbidden | git, terminal, cascade, volundr |
+| Permission | `workspace-write` |
 | Model alias | `balanced` |
-| Budget | 50 iterations |
+| Thinking | Disabled |
+| Budget | 60 iterations |
 
 ## Custom Personas
 
@@ -92,7 +94,7 @@ forbidden_tools:
   - cascade
   - volundr
 
-permission_mode: workspace_write
+permission_mode: workspace-write
 primary_alias: balanced
 
 thinking:
@@ -111,7 +113,7 @@ iteration_budget: 50
 | `system_prompt` | string | Override system prompt |
 | `allowed_tools` | list | Tool names or groups to enable |
 | `forbidden_tools` | list | Tool names or groups to disable |
-| `permission_mode` | string | `read_only`, `workspace_write`, `full_access`, `prompt` |
+| `permission_mode` | string | `read-only`, `workspace-write`, `full-access`, `prompt` |
 | `primary_alias` | string | Bifrost model alias: `powerful`, `balanced`, `fast` |
 | `thinking.enabled` | bool | Enable extended thinking |
 | `thinking.budget_tokens` | int | Thinking token budget |

--- a/docs/site/ravn/personas/reference.md
+++ b/docs/site/ravn/personas/reference.md
@@ -1,0 +1,160 @@
+# Personas
+
+Personas configure Ravn's behavior, tool access, permission mode, model selection,
+and iteration budget. They provide a coherent "role" that shapes the agent for
+specific workflows.
+
+## Built-in Personas
+
+### `coding-agent`
+
+General-purpose software engineering agent.
+
+| Setting | Value |
+|---------|-------|
+| Tools | file, git, terminal, web, todo, introspection |
+| Forbidden | cascade, volundr |
+| Permission | `workspace_write` |
+| Model alias | `balanced` |
+| Thinking | Enabled |
+| Budget | 40 iterations |
+
+### `research-agent`
+
+Information gathering and synthesis — no mutation.
+
+| Setting | Value |
+|---------|-------|
+| Tools | web, file, introspection |
+| Forbidden | git, terminal, cascade |
+| Permission | `read_only` |
+| Model alias | `balanced` |
+| Thinking | Disabled |
+| Budget | 30 iterations |
+
+### `planning-agent`
+
+Structured planning and architecture — read-only, high reasoning.
+
+| Setting | Value |
+|---------|-------|
+| Tools | file, introspection |
+| Forbidden | git, terminal, cascade, volundr |
+| Permission | `read_only` |
+| Model alias | `powerful` |
+| Thinking | Enabled |
+| Budget | 20 iterations |
+
+### `autonomous-agent`
+
+Fully unsupervised execution — all tools, all permissions.
+
+| Setting | Value |
+|---------|-------|
+| Tools | All |
+| Forbidden | None |
+| Permission | `full_access` |
+| Model alias | `powerful` |
+| Thinking | Enabled |
+| Budget | 100 iterations |
+
+### `mimir-curator`
+
+Knowledge base synthesis and maintenance.
+
+| Setting | Value |
+|---------|-------|
+| Tools | mimir_query, mimir_ingest, mimir_write, mimir_lint |
+| Permission | `workspace_write` |
+| Model alias | `balanced` |
+| Budget | 50 iterations |
+
+## Custom Personas
+
+Create custom personas as YAML files in `~/.ravn/personas/`:
+
+```yaml
+# ~/.ravn/personas/my-agent.yaml
+name: my-agent
+description: "Custom agent for my workflow"
+
+system_prompt: |
+  You are a specialized agent for data pipeline work.
+  Always validate schemas before writing.
+
+allowed_tools:
+  - file
+  - git
+  - bash
+  - web_fetch
+
+forbidden_tools:
+  - cascade
+  - volundr
+
+permission_mode: workspace_write
+primary_alias: balanced
+
+thinking:
+  enabled: true
+  budget_tokens: 10000
+
+iteration_budget: 50
+```
+
+### Persona Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Unique identifier |
+| `description` | string | Human-readable description |
+| `system_prompt` | string | Override system prompt |
+| `allowed_tools` | list | Tool names or groups to enable |
+| `forbidden_tools` | list | Tool names or groups to disable |
+| `permission_mode` | string | `read_only`, `workspace_write`, `full_access`, `prompt` |
+| `primary_alias` | string | Bifrost model alias: `powerful`, `balanced`, `fast` |
+| `thinking.enabled` | bool | Enable extended thinking |
+| `thinking.budget_tokens` | int | Thinking token budget |
+| `iteration_budget` | int | Max tool-call iterations |
+
+## RAVN.md Project Overlay
+
+A `RAVN.md` file in the project root merges with the active persona. Project
+settings take precedence for fields that are set.
+
+**Merge priority** (highest wins):
+
+1. **RAVN.md** — project-level overrides
+2. **Persona** — role-based defaults
+3. **Config YAML** — global configuration
+4. **Built-in defaults** — hardcoded fallbacks
+
+For example, if the persona sets `iteration_budget: 40` but `RAVN.md` sets
+`iteration_budget: 25`, the effective budget is 25.
+
+## Persona Loading Priority
+
+When `--persona` is specified on the CLI:
+
+1. Check `~/.ravn/personas/<name>.yaml` (user-defined)
+2. Check built-in personas (coding-agent, research-agent, etc.)
+3. Error if not found
+
+When loading from `RAVN.md`:
+
+1. Parse the `persona:` field from `RAVN.md`
+2. Resolve the named persona (user-defined or built-in)
+3. Merge `RAVN.md` fields on top
+
+## Persona Source Adapter
+
+The persona loading mechanism is pluggable via configuration:
+
+```yaml
+persona_source:
+  adapter: "ravn.adapters.personas.loader.PersonaLoader"
+  kwargs: {}
+```
+
+Custom persona sources can load personas from a database, API, or other
+backend by implementing the persona source interface.

--- a/docs/site/ravn/platform/bifrost.md
+++ b/docs/site/ravn/platform/bifrost.md
@@ -1,0 +1,158 @@
+# Bifrost — LLM Proxy & Cost Management
+
+Bifrost is Ravn's centralized LLM proxy layer. It sits between the agent and
+all LLM providers, managing API keys, tracking costs, routing requests, and
+enforcing budgets.
+
+## Architecture
+
+```mermaid
+graph LR
+    Agent -->|Messages API| Bifrost
+    Bifrost -->|Route| Anthropic
+    Bifrost -->|Route| OpenAI
+    Bifrost -->|Route| Ollama
+    Bifrost -->|Track| CostStore
+```
+
+Agents never hold API keys directly. All LLM traffic flows through Bifrost,
+which exposes an Anthropic Messages API-compatible endpoint. Bifrost is
+identity-aware: it tracks usage per agent and session via HTTP headers.
+
+## Model Aliases
+
+Aliases decouple agent code from specific model versions. When a persona or
+config references an alias, Bifrost resolves it to the current model mapping.
+
+| Alias | Purpose | Example Resolution |
+|-------|---------|-------------------|
+| `powerful` | Most capable model for complex reasoning | `claude-opus-4` |
+| `balanced` | Default production model for general tasks | `claude-sonnet-4-6` |
+| `fast` | Cheap/quick model for reflection, summaries | `claude-haiku-4-5-20251001` |
+
+Custom aliases are configurable:
+
+```yaml
+bifrost:
+  aliases:
+    powerful: claude-opus-4
+    balanced: claude-sonnet-4-6
+    fast: claude-haiku-4-5-20251001
+    code: claude-sonnet-4-6  # custom alias
+```
+
+Personas reference aliases via `primary_alias`:
+
+```yaml
+# coding-agent persona
+primary_alias: balanced
+```
+
+Reflection and outcome calls default to the `fast` alias.
+
+## Routing Strategies
+
+Bifrost supports five routing strategies that control how requests are
+distributed across configured providers.
+
+| Strategy | Behavior |
+|----------|----------|
+| `failover` (default) | Try primary provider, fall back on 429/5xx errors. |
+| `cost_optimised` | Cheapest provider first. |
+| `round_robin` | Cycle through providers evenly. |
+| `latency_optimised` | Fastest provider first, based on EWMA P99 latency. |
+| `direct` | Single provider, no failover. |
+
+Per-model overrides are available via `model_routing_strategies`.
+
+## Cost Tracking & Budgets
+
+Bifrost records per-request token counts and estimated costs.
+
+**Quota enforcement:**
+
+| Quota | Description |
+|-------|-------------|
+| `max_tokens_per_day` | Daily token cap across all requests. |
+| `max_cost_per_day` | Daily dollar cost cap. |
+| `max_requests_per_hour` | Hourly request rate limit. |
+
+**Soft limits:**
+
+A configurable warning threshold (default: 80%) triggers alerts before
+hard limits are hit. When near the limit, Bifrost can auto-route to a
+cheaper model via `warn_target`:
+
+```yaml
+bifrost:
+  guardrails:
+    warn_threshold: 0.8
+    warn_target: fast  # route to fast alias near limit
+```
+
+**Storage backends for usage data:**
+
+- `memory` — in-process (lost on restart)
+- `sqlite` — local persistence
+- `postgres` — shared across instances
+- `otel` — OpenTelemetry export
+
+**Audit trail** adapters: `null`, `sqlite`, `postgres`, `otel` with
+configurable detail levels.
+
+## Integration with Ravn
+
+The `BifrostAdapter` extends `AnthropicAdapter`, removing the API key and
+injecting identity headers:
+
+- `X-Ravn-Agent-Id` — identifies the calling agent
+- `X-Ravn-Session-Id` — identifies the session
+
+This integrates with Ravn's `FallbackAdapter` for additional layered failover:
+Bifrost handles provider-level failover, while the fallback adapter handles
+adapter-level failover.
+
+## Configuration
+
+```yaml
+llm:
+  provider:
+    adapter: ravn.adapters.llm.bifrost.BifrostAdapter
+    kwargs:
+      base_url: "http://bifrost.ravn.svc:8080"
+
+bifrost:
+  providers:
+    - name: anthropic
+      api_key_env: ANTHROPIC_API_KEY
+    - name: openai
+      api_key_env: OPENAI_API_KEY
+  aliases:
+    powerful: claude-opus-4
+    balanced: claude-sonnet-4-6
+    fast: claude-haiku-4-5-20251001
+  routing_strategy: failover
+  auth_mode: header
+  default_quota:
+    max_tokens_per_day: 1000000
+    max_cost_per_day: 50.0
+    max_requests_per_hour: 100
+  guardrails:
+    warn_threshold: 0.8
+    warn_target: fast
+  usage_store: sqlite
+  audit: sqlite
+```
+
+### Config Keys
+
+| Key | Description |
+|-----|-------------|
+| `bifrost.providers` | List of LLM provider backends. |
+| `bifrost.aliases` | Model alias → model ID mappings. |
+| `bifrost.routing_strategy` | Default routing strategy. |
+| `bifrost.auth_mode` | How agents authenticate to Bifrost. |
+| `bifrost.default_quota` | Default per-agent quotas. |
+| `bifrost.guardrails` | Budget guardrail configuration. |
+| `bifrost.usage_store` | Token/cost storage backend. |
+| `bifrost.audit` | Audit trail backend and detail level. |

--- a/docs/site/ravn/platform/mcp.md
+++ b/docs/site/ravn/platform/mcp.md
@@ -1,0 +1,167 @@
+# MCP Integration
+
+Ravn supports the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP)
+for connecting to external tool servers. MCP servers expose tools, prompts, and
+resources that Ravn can discover and use alongside built-in tools.
+
+## Configuring MCP Servers
+
+Define servers in `ravn.yaml`:
+
+```yaml
+mcp_servers:
+  - name: "evals"
+    enabled: true
+    transport: "stdio"
+    command: "node"
+    args: ["path/to/server.js"]
+    env:
+      NODE_ENV: "production"
+    timeout: 30.0
+    connect_timeout: 10.0
+    auth:
+      auth_type: "api_key"
+      api_key_env: "EVALS_API_KEY"
+```
+
+### Transport Types
+
+| Transport | Description | Config |
+|-----------|-------------|--------|
+| `stdio` | Spawn a local process, communicate via stdin/stdout. | `command`, `args`, `env` |
+| `http` | Direct HTTP calls to a remote server. | `url` |
+| `sse` | Server-sent events for streaming responses. | `url` |
+
+### Server Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | str | *(required)* | Unique server identifier. Used as tool name prefix. |
+| `transport` | str | `"stdio"` | Transport type. |
+| `command` | str | `""` | Command to spawn (stdio only). |
+| `args` | list[str] | `[]` | Command arguments (stdio only). |
+| `env` | dict | `{}` | Environment variables for spawned process. |
+| `url` | str | `""` | Server URL (http/sse only). |
+| `timeout` | float | `30.0` | Request timeout in seconds. |
+| `connect_timeout` | float | `10.0` | Connection timeout in seconds. |
+| `enabled` | bool | `true` | Enable/disable without removing config. |
+| `auth` | MCPAuthConfig | `{}` | Authentication configuration. |
+
+## Authentication
+
+MCP servers can require authentication. Ravn supports three auth patterns:
+
+### API Key
+
+Static API key passed as a header on every request.
+
+```yaml
+auth:
+  auth_type: "api_key"
+  api_key_env: "MY_SERVER_API_KEY"   # env var containing the key
+  api_key_header: "Authorization"     # header name (default)
+  api_key_prefix: "Bearer"            # prefix (default)
+```
+
+### Device Flow (OAuth2)
+
+Interactive browser-based authentication. Used when the server requires
+user consent (e.g., GitHub OAuth apps).
+
+```yaml
+auth:
+  auth_type: "device_flow"
+  token_url: "https://github.com/login/oauth/access_token"
+  client_id: "Iv1.abc123"
+  scope: "repo read:org"
+```
+
+The agent uses the `mcp_auth` tool to initiate the flow. The user completes
+authentication in a browser, and the token is cached for future use.
+
+### Client Credentials (OAuth2)
+
+Machine-to-machine authentication without user interaction.
+
+```yaml
+auth:
+  auth_type: "client_credentials"
+  token_url: "https://auth.example.com/oauth/token"
+  client_id: "ravn-agent"
+  client_secret_env: "MCP_CLIENT_SECRET"
+  scope: "api:read api:write"
+  audience: "https://api.example.com"
+```
+
+## Token Storage
+
+Tokens are cached to avoid re-authentication on every request.
+
+```yaml
+mcp_token_store:
+  backend: "local"                    # "local" or "openbao"
+  local_path: "~/.ravn/mcp_tokens.json"
+```
+
+| Backend | Description |
+|---------|-------------|
+| `local` | Encrypted JSON file on disk. |
+| `openbao` | HashiCorp OpenBao (Vault fork) for centralized secret storage. |
+
+Tokens are automatically refreshed when they expire (if the auth type supports
+refresh tokens).
+
+## Tool Discovery
+
+When Ravn starts, it connects to all enabled MCP servers and discovers their
+tools. Discovered tools are:
+
+1. **Prefixed** with the server name: `evals:run_test`, `github:create_issue`
+2. **Checked for collisions** with built-in tools (collision = warning, MCP tool skipped)
+3. **Available in the agent** alongside built-in tools
+
+Tool schemas (input parameters, descriptions) come from the MCP server.
+
+## Degraded Mode
+
+If an MCP server fails to connect or crashes, Ravn continues operating with
+its built-in tools. MCP failures are logged but do not block the agent.
+
+The `mcp_auth` tool allows the agent to re-authenticate with a failed server
+mid-session:
+
+```
+Tool: mcp_auth
+Input: { "server": "evals" }
+```
+
+## Example: Multiple Servers
+
+```yaml
+mcp_servers:
+  - name: "evals"
+    transport: "stdio"
+    command: "npx"
+    args: ["-y", "@company/evals-mcp"]
+    auth:
+      auth_type: "api_key"
+      api_key_env: "EVALS_KEY"
+
+  - name: "github"
+    transport: "sse"
+    url: "https://mcp.github.com/sse"
+    auth:
+      auth_type: "device_flow"
+      token_url: "https://github.com/login/oauth/access_token"
+      client_id: "Iv1.abc123"
+      scope: "repo"
+
+  - name: "internal-api"
+    transport: "http"
+    url: "http://internal-mcp.corp:8080"
+    auth:
+      auth_type: "client_credentials"
+      token_url: "https://sso.corp/oauth/token"
+      client_id: "ravn"
+      client_secret_env: "INTERNAL_CLIENT_SECRET"
+```

--- a/docs/site/ravn/platform/mimir.md
+++ b/docs/site/ravn/platform/mimir.md
@@ -105,7 +105,7 @@ mimir:
       url: "http://mimir.ravn.svc:8080"
       auth:
         type: bearer
-        token_env: MIMIR_TOKEN
+        token: "${MIMIR_TOKEN}"
       categories: [technical, projects]
     - name: domain
       role: domain
@@ -123,11 +123,11 @@ mimir:
   write_routing:
     rules:
       - prefix: "self/"
-        targets: [local]
+        mounts: [local]
       - prefix: "technical/"
-        targets: [local, shared]
+        mounts: [local, shared]
       - prefix: "research/"
-        targets: [shared, domain]
+        mounts: [shared, domain]
 ```
 
 ## How Mímir Differs from Búri

--- a/docs/site/ravn/platform/mimir.md
+++ b/docs/site/ravn/platform/mimir.md
@@ -1,0 +1,167 @@
+# Mímir — Persistent Knowledge Base
+
+Mímir is a markdown-backed wiki system where Ravn ingests, synthesizes, searches,
+and maintains persistent knowledge across sessions. Unlike episodic memory (raw
+recall), Mímir is curated knowledge — wiki articles that compound over time.
+
+## Architecture
+
+```mermaid
+graph TD
+    Agent -->|ingest/write| Mímir
+    Agent -->|query/search| Mímir
+    Mímir -->|read/write| FileSystem["~/.ravn/mimir/"]
+    Mímir -->|lint| HealthCheck
+    Sessions -->|auto-distill| Mímir
+```
+
+Mímir can run as:
+
+- **Local adapter** — filesystem-backed, for single-agent use
+- **HTTP service** — standalone FastAPI, for shared deployments
+- **Composite** — multiple instances with routing rules
+
+## Wiki Structure
+
+```
+~/.ravn/mimir/
+├── wiki/
+│   ├── index.md              # Auto-updated content catalog
+│   ├── log.md                # Append-only operation log
+│   ├── technical/            # Infrastructure, codebase docs
+│   │   ├── volundr/
+│   │   └── ravn/
+│   ├── projects/             # Project documentation
+│   ├── research/             # Topic deep-dives
+│   ├── household/            # Personal/home knowledge
+│   └── self/                 # Agent patterns, preferences
+├── raw/
+│   └── <source_id>.json      # Immutable source metadata + content
+└── MIMIR.md                  # Schema/conventions seed
+```
+
+## Agent Tools
+
+Mímir provides six tools for agent interaction:
+
+| Tool | Permission | Description |
+|------|-----------|-------------|
+| `mimir_ingest` | `mimir:write` | Ingest URL or raw text as immutable source. Records content hash for staleness detection. Optionally derives wiki pages via synthesis. |
+| `mimir_query` | `mimir:read` | Natural language question → relevant pages. For knowledge synthesis and answering questions from the wiki. |
+| `mimir_read` | `mimir:read` | Read full content of a wiki page by path. |
+| `mimir_write` | `mimir:write` | Create or update a wiki page. Pages are Markdown with a `# Title` header. |
+| `mimir_search` | `mimir:read` | Full-text keyword search. Returns matching page paths ranked by hit count. |
+| `mimir_lint` | `mimir:read` | Health check across the wiki. |
+
+## Auto-Distill
+
+After qualifying sessions (duration ≥ `distill_min_session_minutes`), Mímir
+automatically extracts learnings and writes them as wiki pages. This bridges
+ephemeral session context into persistent knowledge.
+
+Control via config:
+
+```yaml
+mimir:
+  auto_distill: true
+  distill_min_session_minutes: 5
+```
+
+## Lint System
+
+The lint tool checks wiki health across four dimensions:
+
+| Check | Description |
+|-------|-------------|
+| **Orphans** | Pages not linked from `index.md`. |
+| **Contradictions** | Pages with `<!-- contradiction -->` markers. |
+| **Stale** | Pages whose source content hash changed since ingest. |
+| **Gaps** | Concepts frequently mentioned but lacking dedicated pages. |
+
+Auto-lint fires after `idle_lint_threshold_minutes` of drive-loop inactivity
+(default: 60 minutes).
+
+## Search Backend
+
+Currently full-text search (FTS) — keyword-based substring matching ranked by
+hit count. Fast with no ML overhead.
+
+Future: vector search extension point (embeddings + cosine similarity) via the
+`mimir.search.backend` config.
+
+## Multi-Instance Deployment
+
+The composite adapter mounts multiple Mímir instances with routing rules:
+
+```yaml
+mimir:
+  instances:
+    - name: local
+      role: local
+      path: "~/.ravn/mimir"
+      categories: [self, household]
+    - name: shared
+      role: shared
+      url: "http://mimir.ravn.svc:8080"
+      auth:
+        type: bearer
+        token_env: MIMIR_TOKEN
+      categories: [technical, projects]
+    - name: domain
+      role: domain
+      url: "http://mimir-domain.ravn.svc:8080"
+      categories: [research]
+```
+
+**Read precedence:** lower priority first (local=0, shared=1, domain=2).
+Results merge across instances with de-duplication by path.
+
+**Write routing:** prefix rules control which instances receive writes:
+
+```yaml
+mimir:
+  write_routing:
+    rules:
+      - prefix: "self/"
+        targets: [local]
+      - prefix: "technical/"
+        targets: [local, shared]
+      - prefix: "research/"
+        targets: [shared, domain]
+```
+
+## How Mímir Differs from Búri
+
+| Aspect | Mímir | Búri |
+|--------|-------|------|
+| Purpose | Curated wiki (synthesis) | Typed fact graph (assertions) |
+| Format | Markdown articles | Structured facts with confidence |
+| Updates | Explicit write/ingest | Auto-extracted from sessions |
+| Search | Full-text keyword | Typed recall + vMF clustering |
+| Organization | Category directories | Fact types + temporal versioning |
+
+Mímir is what the agent *writes down and maintains*. Búri is what the agent
+*remembers and believes*. They complement each other: Búri captures raw
+assertions, Mímir synthesizes them into coherent documents.
+
+## Configuration
+
+```yaml
+mimir:
+  enabled: true
+  path: "~/.ravn/mimir"
+  auto_distill: true
+  distill_min_session_minutes: 5
+  idle_lint_threshold_minutes: 60
+  continuation_threshold_minutes: 30
+  categories:
+    - technical
+    - projects
+    - research
+    - household
+    - self
+  search:
+    backend: fts
+```
+
+See the [Configuration Reference](../configuration/reference.md#mimir) for all fields.

--- a/docs/site/ravn/tools/reference.md
+++ b/docs/site/ravn/tools/reference.md
@@ -1,0 +1,182 @@
+# Tool Reference
+
+Ravn ships with 35+ built-in tools organized into groups. Tools are loaded
+dynamically based on the active profile, persona, and configuration.
+
+## Tool Groups
+
+| Group | Always Active | Description |
+|-------|--------------|-------------|
+| `core` | Yes | File, git, bash, web fetch, terminal, todo, ask user |
+| `extended` | Default profile | Introspection, memory search, web search |
+| `skill` | If `skill.enabled` | Skill discovery and execution |
+| `platform` | If `gateway.platform.enabled` | Volundr/Tyr integration |
+| `mimir` | If `mimir.enabled` | Knowledge base tools |
+| `cascade` | If `cascade.enabled` in daemon | Distributed task delegation |
+
+## Core Tools
+
+### File Tools
+
+| Tool | Permission | Description |
+|------|-----------|-------------|
+| `read_file` | `file:read` | Read file contents with 1-based line numbers. Supports `offset` and `limit` for pagination. Max size: 1 MB (configurable via `tools.file.max_read_bytes`). |
+| `write_file` | `file:write` | Create or overwrite files within workspace. Max size: 5 MB (configurable via `tools.file.max_write_bytes`). |
+| `edit_file` | `file:write` | Modify file sections with semantic diff. Specify old text and replacement. |
+| `glob_search` | `file:read` | Find files using glob patterns (e.g., `src/**/*.py`). |
+| `grep_search` | `file:read` | Search file contents with regex patterns. Supports context lines. |
+
+### Git Tools
+
+| Tool | Permission | Description |
+|------|-----------|-------------|
+| `git_status` | `git:read` | Current branch, ahead/behind counts, staged/unstaged file list. |
+| `git_diff` | `git:read` | Unified diff of working-tree or staged changes. Supports `--cached`. |
+| `git_add` | `git:write` | Stage files for commit. Accepts file paths or `.` for all. |
+| `git_commit` | `git:write` | Create a commit with message and optional extended description. |
+| `git_checkout` | `git:write` | Switch branches or restore files. Supports `-b` for new branch. |
+| `git_log` | `git:read` | Commit history. Supports oneline/full format, `--since`, `-n`. |
+| `git_pr` | `git:write` | Create pull requests using `gh` CLI. Requires GitHub CLI installed. |
+
+### Execution Tools
+
+| Tool | Permission | Description |
+|------|-----------|-------------|
+| `bash` | `bash:execute` | Execute bash commands with multi-stage security validation. Fresh subprocess per call. Output limit: 100 KB. Timeout: 120s. |
+| `terminal` | `shell:execute` | Persistent shell session (local backend). State persists across calls — `cd`, `export`, shell variables carry over. Timeout: 30s per command. |
+| `terminal_docker` | `shell:execute` | Persistent shell in Docker container. Only active when `tools.terminal.backend` is `docker`. |
+
+### Web Tools
+
+| Tool | Permission | Description |
+|------|-----------|-------------|
+| `web_fetch` | `web:fetch` | Fetch a URL and return readable text content. Strips HTML, truncates to 20,000 characters. Detects prompt injection patterns. |
+
+### Task Management
+
+| Tool | Permission | Description |
+|------|-----------|-------------|
+| `todo_write` | `todo:write` | Create, update, or delete todo items with status and priority. |
+| `todo_read` | `todo:read` | Read the current session todo list. |
+
+### User Interaction
+
+| Tool | Permission | Description |
+|------|-----------|-------------|
+| `ask_user` | `ask_user` | Pause the agent loop and prompt the user for clarification or input. |
+
+## Extended Tools
+
+| Tool | Permission | Description |
+|------|-----------|-------------|
+| `web_search` | `web:search` | Search the web via configurable provider. Returns title, URL, snippet. Default: 5 results. |
+| `ravn_state` | `introspect:read` | Runtime introspection: iteration budget remaining, active tools, permission mode, memory status, current persona, model name. |
+| `ravn_reflect` | `introspect:read` | Mid-task reflection via LLM call: what has been accomplished, what remains, suggested next actions, course corrections. |
+| `ravn_memory_search` | `memory:read` | Semantic search over the agent's episodic memory. Returns past episodes ranked by relevance and recency. |
+| `session_search` | `memory:read` | Search all past sessions matching a query. Two-stage: FTS keyword match, then group by session. |
+
+## Skill Tools
+
+Available when `skill.enabled` is `true` (default).
+
+| Tool | Permission | Description |
+|------|-----------|-------------|
+| `skill_list` | `skill:read` | List available skills from project-local `.ravn/skills/`, user `~/.ravn/skills/`, and built-in skill definitions. |
+| `skill_run` | `skill:read` | Load and execute a skill's instruction content. Skills are Markdown files with YAML frontmatter. |
+
+## Platform Tools
+
+Available when `gateway.platform.enabled` is `true`.
+
+| Tool | Permission | Description |
+|------|-----------|-------------|
+| `volundr_session` | `platform:api` | Manage Volundr sessions: list, create, stop, delete. |
+| `volundr_git` | `platform:api` | Git operations via Volundr platform API. |
+| `tyr_saga` | `platform:api` | Decompose work into Tyr sagas (distributed task breakdowns). |
+| `tracker_issue` | `platform:api` | Manage issues via Tyr tracker adapters (Linear, GitHub Issues, etc.). |
+
+## Mímir Tools
+
+Available when `mimir.enabled` is `true` (default).
+
+| Tool | Permission | Description |
+|------|-----------|-------------|
+| `mimir_ingest` | `mimir:write` | Ingest URL or raw text as immutable source. Records source hash for staleness detection. Optionally auto-derives wiki pages. |
+| `mimir_query` | `mimir:read` | Natural language question → relevant wiki pages. Used for knowledge synthesis. |
+| `mimir_read` | `mimir:read` | Read full content of a specific wiki page by path. |
+| `mimir_write` | `mimir:write` | Create or update a wiki page (Markdown with `# Title` header). |
+| `mimir_search` | `mimir:read` | Full-text keyword search. Returns matching page paths ranked by hit count. |
+| `mimir_lint` | `mimir:read` | Health check: orphan pages, contradiction markers, stale sources, concept gaps. |
+
+## Cascade Tools
+
+Available in daemon mode when `cascade.enabled` is `true`. Built dynamically
+based on cascade mode (local parallel, mesh delegation, or ephemeral spawn).
+
+| Tool | Permission | Description |
+|------|-----------|-------------|
+| `task_create` | `cascade:write` | Create a sub-task for parallel execution. |
+| `task_collect` | `cascade:read` | Collect results from completed sub-tasks. |
+| `task_status` | `cascade:read` | Check status of a specific sub-task. |
+| `task_list` | `cascade:read` | List all active and completed sub-tasks. |
+| `task_stop` | `cascade:write` | Cancel a running sub-task. |
+
+## Cron Tools
+
+Available in daemon mode when `initiative.enabled` is `true`.
+
+| Tool | Permission | Description |
+|------|-----------|-------------|
+| `cron_create` | `cron:manage` | Schedule a recurring task on a cron expression or natural language schedule. |
+| `cron_list` | `cron:manage` | List all scheduled cron jobs. |
+| `cron_delete` | `cron:manage` | Remove a scheduled job by ID. |
+
+## MCP Tools
+
+Dynamically loaded from configured [MCP servers](../platform/mcp.md).
+Each tool is prefixed with the server name (e.g., `evals:run_test`).
+
+| Tool | Permission | Description |
+|------|-----------|-------------|
+| `mcp_auth` | `mcp:auth` | Authenticate with a named MCP server. Supports `api_key`, `client_credentials`, `device_flow`. |
+| *(dynamic)* | *(varies)* | All tools discovered from configured MCP servers. |
+
+## Tool Profiles
+
+Profiles control which tool groups are available. Define custom profiles in
+config:
+
+```yaml
+tools:
+  profiles:
+    default:
+      include_groups: [core, extended, skill, platform, cascade, mimir]
+      include_mcp: true
+    worker:
+      include_groups: [core]
+      include_mcp: false
+```
+
+Built-in profiles:
+
+| Profile | Groups | MCP |
+|---------|--------|-----|
+| `default` | core, extended, skill, platform, cascade, mimir | Yes |
+| `worker` | core | No |
+
+Personas can further filter tools via `allowed_tools` and `forbidden_tools`.
+
+## Custom Tools
+
+Register custom tools via config:
+
+```yaml
+tools:
+  custom:
+    - adapter: "mypackage.tools.MyTool"
+      name: "my_custom_tool"
+      description: "Does something custom"
+```
+
+The adapter class must implement the `ToolPort` interface. Remaining keys
+are passed as `**kwargs` to the constructor.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,43 @@ nav:
       - Events: api/events.md
       - Integrations: api/integrations.md
       - Issue Tracker: api/tracker.md
+  - Ravn (Agent):
+      - Overview: ravn/index.md
+      - Getting Started:
+          - Quick Start: ravn/getting-started/quick-start.md
+      - Configuration:
+          - Reference: ravn/configuration/reference.md
+      - CLI:
+          - Reference: ravn/cli/reference.md
+      - Tools:
+          - Reference: ravn/tools/reference.md
+      - Personas:
+          - Reference: ravn/personas/reference.md
+      - Platform Services:
+          - Bifrost — LLM Proxy: ravn/platform/bifrost.md
+          - Mímir — Knowledge Base: ravn/platform/mimir.md
+          - MCP Integration: ravn/platform/mcp.md
+      - Advanced Features:
+          - Cascade & Parallel Execution: ravn/advanced/cascade.md
+          - Flock / Mesh Networking: ravn/advanced/flock.md
+          - Drive Loop & Triggers: ravn/advanced/drive-loop.md
+          - Memory & Knowledge Systems: ravn/advanced/memory.md
+          - Skill System: ravn/advanced/skills.md
+          - Context Management: ravn/advanced/context.md
+          - Extended Thinking: ravn/advanced/thinking.md
+      - Operations:
+          - Sleipnir Event Backbone: ravn/operations/sleipnir.md
+          - Gateway Channels: ravn/operations/gateway.md
+          - Security & Permissions: ravn/operations/security.md
+          - Hooks: ravn/operations/hooks.md
+          - Self-Improvement / Evolution: ravn/operations/evolution.md
+          - Deployment: ravn/operations/deployment.md
+          - Checkpointing & Resume: ravn/operations/checkpointing.md
+      - Developer Reference:
+          - Architecture: ravn/developer/architecture.md
+          - Adding a New Tool: ravn/developer/new-tool.md
+          - Adding a New LLM Provider: ravn/developer/new-provider.md
+          - Adding a New Channel: ravn/developer/new-channel.md
   - Contributing:
       - Development: contributing/development.md
       - Code Style: contributing/code-style.md


### PR DESCRIPTION
## Summary

- Add complete Ravn documentation across 27 Markdown files covering all 5 phases specified in NIU-547
- **Phase 1 (Core)**: Getting started guide, configuration reference (~25 config sections with all fields/defaults/types), CLI reference (7 commands + subcommands), tool reference (35+ tools by group), personas (5 built-in + custom)
- **Phase 2 (Platform Services)**: Bifrost LLM proxy (aliases, routing strategies, cost tracking, budgets), Mímir knowledge base (wiki structure, auto-distill, lint, multi-instance), MCP integration (transports, auth patterns, token storage)
- **Phase 3 (Advanced Features)**: Cascade parallel execution, flock mesh networking, drive loop & triggers, memory & knowledge systems (episodic + Búri + Mímir), skill system, context management, extended thinking
- **Phase 4 (Operations)**: Sleipnir event backbone, gateway channels (HTTP, Telegram, Discord, Slack, Matrix, WhatsApp), security & permissions, hooks, evolution/self-improvement, deployment (Pi/K8s/Docker), checkpointing & resume
- **Phase 5 (Developer Reference)**: Hexagonal architecture overview, guides for adding new tools, LLM providers, and channels
- Update mkdocs.yml with full Ravn nav section integrated into existing site structure

## Test plan

- [ ] Verify mkdocs builds cleanly with new nav entries
- [ ] Review all cross-references between docs resolve correctly
- [ ] Confirm config reference matches `src/ravn/config.py` field names and defaults
- [ ] Check tool reference matches `src/ravn/adapters/tools/builtin_registry.py`
- [ ] Validate Mermaid diagrams render correctly

## CI Notes

- `Web: Test` failure is pre-existing and unrelated — the failing test (`Settings.test.tsx > renders textarea for SSH key field`) exists identically on `feat/ravn` and this branch has zero diff in `web/`. All Python tests, lint, and codecov/patch pass.

## Linear

- **Ticket**: NIU-547
- Linear MCP tools were not available in this environment. Please manually update NIU-547 to "In Review" status.

Closes NIU-547

🤖 Generated with [Claude Code](https://claude.com/claude-code)