### PR TITLE
feat(ports): extend MimirPageMeta with thread fields + add ThreadYamlSchema

### DIFF
--- a/src/niuu/domain/mimir.py
+++ b/src/niuu/domain/mimir.py
@@ -142,6 +142,8 @@ class MimirLintReport:
 # Thread YAML schema
 # ---------------------------------------------------------------------------
 
+_VALID_REF_TYPES: frozenset[str] = frozenset({"conversation", "ingest", "observation", "search"})
+
 
 class ThreadSchemaError(Exception):
     """Raised when a thread YAML file fails validation."""
@@ -281,20 +283,20 @@ class ThreadYamlSchema:
             raise ThreadSchemaError(path, "'state' is required")
         try:
             state = ThreadState(raw_state)
-        except ValueError:
+        except ValueError as exc:
             valid = ", ".join(s.value for s in ThreadState)
             raise ThreadSchemaError(
                 path,
                 f"'state' {raw_state!r} is not a valid ThreadState; valid: {valid}",
-            )
+            ) from exc
 
         raw_weight = data.get("weight")
         if raw_weight is None:
             raise ThreadSchemaError(path, "'weight' is required")
         try:
             weight = float(raw_weight)
-        except (TypeError, ValueError):
-            raise ThreadSchemaError(path, f"'weight' must be a float, got {raw_weight!r}")
+        except (TypeError, ValueError) as exc:
+            raise ThreadSchemaError(path, f"'weight' must be a float, got {raw_weight!r}") from exc
         if weight < 0.0:
             raise ThreadSchemaError(path, f"'weight' must be >= 0.0, got {weight!r}")
 
@@ -351,6 +353,12 @@ class ThreadYamlSchema:
         for key in ("ref_type", "ref_id", "ref_summary"):
             if key not in item:
                 raise ThreadSchemaError(path, f"context_refs entry missing required key {key!r}")
+        if item["ref_type"] not in _VALID_REF_TYPES:
+            raise ThreadSchemaError(
+                path,
+                f"context_refs entry has invalid ref_type {item['ref_type']!r}; "
+                f"valid: {', '.join(sorted(_VALID_REF_TYPES))}",
+            )
         return ThreadContextRef(
             ref_type=item["ref_type"],
             ref_id=item["ref_id"],

--- a/src/niuu/domain/mimir.py
+++ b/src/niuu/domain/mimir.py
@@ -8,8 +8,11 @@ the service) import from here so that neither module depends on the other.
 from __future__ import annotations
 
 import hashlib
+import os
 from dataclasses import dataclass, field
 from datetime import datetime
+from enum import StrEnum
+from pathlib import Path
 from typing import Literal
 
 
@@ -36,6 +39,37 @@ class MimirSource:
     origin_url: str | None = None
 
 
+# ---------------------------------------------------------------------------
+# Thread types
+# ---------------------------------------------------------------------------
+
+
+class ThreadState(StrEnum):
+    """Lifecycle state of a thread."""
+
+    open = "open"
+    pulling = "pulling"
+    blocked = "blocked"
+    waiting_for_peer = "waiting_for_peer"
+    waiting_for_operator = "waiting_for_operator"
+    closed = "closed"
+    dissolved = "dissolved"
+
+
+@dataclass
+class ThreadContextRef:
+    """A reference to an external artifact that provides context for a thread."""
+
+    ref_type: Literal["conversation", "ingest", "observation", "search"]
+    ref_id: str
+    ref_summary: str
+
+
+# ---------------------------------------------------------------------------
+# Wiki page types
+# ---------------------------------------------------------------------------
+
+
 @dataclass
 class MimirPageMeta:
     """Lightweight metadata record for a Mímir wiki page."""
@@ -46,6 +80,15 @@ class MimirPageMeta:
     category: str  # top-level category: "technical", "projects", etc.
     updated_at: datetime
     source_ids: list[str] = field(default_factory=list)
+
+    # Thread fields — all None / empty for non-thread pages
+    thread_state: ThreadState | None = None
+    thread_weight: float | None = None
+    thread_owner_id: str | None = None
+    thread_context_refs: list[ThreadContextRef] = field(default_factory=list)
+    thread_next_action_hint: str | None = None
+    thread_resolved_artifact_path: str | None = None
+    thread_weight_signals: dict | None = None
 
 
 @dataclass
@@ -93,3 +136,223 @@ class MimirLintReport:
     @property
     def issues_found(self) -> bool:
         return bool(self.orphans or self.contradictions or self.stale or self.gaps)
+
+
+# ---------------------------------------------------------------------------
+# Thread YAML schema
+# ---------------------------------------------------------------------------
+
+
+class ThreadSchemaError(Exception):
+    """Raised when a thread YAML file fails validation."""
+
+    def __init__(self, path: str, reason: str) -> None:
+        self.path = path
+        self.reason = reason
+        super().__init__(f"Invalid thread schema at {path!r}: {reason}")
+
+
+@dataclass
+class ThreadYamlSchema:
+    """Canonical, validated representation of a thread's ``.yaml`` file.
+
+    Shared by all adapters (``MarkdownMimirAdapter``, ``HttpMimirAdapter``)
+    and the Mímir service so that parsing and serialisation logic lives in
+    exactly one place.
+    """
+
+    title: str
+    state: ThreadState
+    weight: float
+    created_at: datetime
+    updated_at: datetime
+    owner_id: str | None = None
+    next_action_hint: str | None = None
+    resolved_artifact_path: str | None = None
+    context_refs: list[ThreadContextRef] = field(default_factory=list)
+    weight_signals: dict = field(default_factory=dict)
+
+    # ------------------------------------------------------------------
+    # Class-level helpers
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_yaml(cls, path: Path) -> ThreadYamlSchema:
+        """Parse and validate a thread YAML file.
+
+        Raises :class:`ThreadSchemaError` on missing required fields, invalid
+        state, or malformed dates.
+        """
+        import yaml  # local import — PyYAML is an optional dep for non-file adapters
+
+        try:
+            text = Path(path).read_text(encoding="utf-8")
+        except OSError as exc:
+            raise ThreadSchemaError(str(path), f"cannot read file: {exc}") from exc
+
+        try:
+            data = yaml.safe_load(text)
+        except yaml.YAMLError as exc:
+            raise ThreadSchemaError(str(path), f"YAML parse error: {exc}") from exc
+
+        if not isinstance(data, dict):
+            raise ThreadSchemaError(str(path), "expected a YAML mapping at top level")
+
+        return cls._validate(data, str(path))
+
+    @classmethod
+    def from_dict(cls, data: dict) -> ThreadYamlSchema:
+        """Parse and validate from a dict (for HTTP response deserialisation)."""
+        return cls._validate(data, "<dict>")
+
+    # ------------------------------------------------------------------
+    # Instance methods
+    # ------------------------------------------------------------------
+
+    def to_yaml(self, path: Path) -> None:
+        """Serialise to a YAML file atomically (write to ``.tmp``, then rename).
+
+        The atomic write prevents corrupt YAML on disk if the process crashes
+        mid-write.
+        """
+        import yaml  # local import
+
+        target = Path(path)
+        tmp = Path(str(path) + ".tmp")
+
+        tmp.write_text(
+            yaml.safe_dump(self.to_dict(), allow_unicode=True, sort_keys=False),
+            encoding="utf-8",
+        )
+        os.replace(tmp, target)
+
+    def to_dict(self) -> dict:
+        """Serialise to a dict (for HTTP request serialisation)."""
+        return {
+            "title": self.title,
+            "state": self.state.value,
+            "weight": self.weight,
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+            "owner_id": self.owner_id,
+            "next_action_hint": self.next_action_hint,
+            "resolved_artifact_path": self.resolved_artifact_path,
+            "context_refs": [
+                {
+                    "ref_type": ref.ref_type,
+                    "ref_id": ref.ref_id,
+                    "ref_summary": ref.ref_summary,
+                }
+                for ref in self.context_refs
+            ],
+            "weight_signals": self.weight_signals,
+        }
+
+    def to_page_meta(self, slug: str) -> MimirPageMeta:
+        """Produce a :class:`MimirPageMeta` for use in :class:`MimirPage` responses."""
+        return MimirPageMeta(
+            path=f"threads/{slug}.yaml",
+            title=self.title,
+            summary=self.next_action_hint or "",
+            category="threads",
+            updated_at=self.updated_at,
+            thread_state=self.state,
+            thread_weight=self.weight,
+            thread_owner_id=self.owner_id,
+            thread_context_refs=list(self.context_refs),
+            thread_next_action_hint=self.next_action_hint,
+            thread_resolved_artifact_path=self.resolved_artifact_path,
+            thread_weight_signals=self.weight_signals or None,
+        )
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def _validate(cls, data: dict, path: str) -> ThreadYamlSchema:
+        """Validate *data* and return a :class:`ThreadYamlSchema` instance."""
+        title = data.get("title")
+        if not title or not isinstance(title, str) or not title.strip():
+            raise ThreadSchemaError(path, "'title' must be a non-empty string")
+
+        raw_state = data.get("state")
+        if raw_state is None:
+            raise ThreadSchemaError(path, "'state' is required")
+        try:
+            state = ThreadState(raw_state)
+        except ValueError:
+            valid = ", ".join(s.value for s in ThreadState)
+            raise ThreadSchemaError(
+                path,
+                f"'state' {raw_state!r} is not a valid ThreadState; valid: {valid}",
+            )
+
+        raw_weight = data.get("weight")
+        if raw_weight is None:
+            raise ThreadSchemaError(path, "'weight' is required")
+        try:
+            weight = float(raw_weight)
+        except (TypeError, ValueError):
+            raise ThreadSchemaError(path, f"'weight' must be a float, got {raw_weight!r}")
+        if weight < 0.0:
+            raise ThreadSchemaError(path, f"'weight' must be >= 0.0, got {weight!r}")
+
+        created_at = cls._parse_datetime(data.get("created_at"), "created_at", path)
+        updated_at = cls._parse_datetime(data.get("updated_at"), "updated_at", path)
+
+        raw_refs = data.get("context_refs", [])
+        if not isinstance(raw_refs, list):
+            raise ThreadSchemaError(path, "'context_refs' must be a list")
+        context_refs = [cls._parse_context_ref(item, path) for item in raw_refs]
+
+        raw_signals = data.get("weight_signals", {})
+        if not isinstance(raw_signals, dict):
+            raise ThreadSchemaError(path, "'weight_signals' must be a mapping")
+
+        return cls(
+            title=title.strip(),
+            state=state,
+            weight=weight,
+            created_at=created_at,
+            updated_at=updated_at,
+            owner_id=data.get("owner_id"),
+            next_action_hint=data.get("next_action_hint"),
+            resolved_artifact_path=data.get("resolved_artifact_path"),
+            context_refs=context_refs,
+            weight_signals=raw_signals,
+        )
+
+    @staticmethod
+    def _parse_datetime(value: object, field_name: str, path: str) -> datetime:
+        if value is None:
+            raise ThreadSchemaError(path, f"'{field_name}' is required")
+        if isinstance(value, datetime):
+            return value
+        if not isinstance(value, str):
+            raise ThreadSchemaError(
+                path,
+                f"'{field_name}' must be an ISO-8601 string, got {value!r}",
+            )
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError as exc:
+            raise ThreadSchemaError(
+                path, f"'{field_name}' is not a valid ISO-8601 datetime: {exc}"
+            ) from exc
+
+    @staticmethod
+    def _parse_context_ref(item: object, path: str) -> ThreadContextRef:
+        if not isinstance(item, dict):
+            raise ThreadSchemaError(
+                path,
+                f"each 'context_refs' entry must be a mapping, got {item!r}",
+            )
+        for key in ("ref_type", "ref_id", "ref_summary"):
+            if key not in item:
+                raise ThreadSchemaError(path, f"context_refs entry missing required key {key!r}")
+        return ThreadContextRef(
+            ref_type=item["ref_type"],
+            ref_id=item["ref_id"],
+            ref_summary=item["ref_summary"],
+        )

--- a/tests/test_niuu/test_mimir_domain.py
+++ b/tests/test_niuu/test_mimir_domain.py
@@ -1,0 +1,516 @@
+"""Tests for niuu.domain.mimir — thread-related domain models.
+
+Covers:
+- ThreadState enum
+- ThreadContextRef dataclass
+- MimirPageMeta thread field defaults and population
+- ThreadSchemaError
+- ThreadYamlSchema: from_dict / to_dict roundtrip, from_yaml / to_yaml
+  (atomic write), validation rules, to_page_meta
+"""
+
+from __future__ import annotations
+
+import textwrap
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from niuu.domain.mimir import (
+    MimirPageMeta,
+    ThreadContextRef,
+    ThreadSchemaError,
+    ThreadState,
+    ThreadYamlSchema,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2026, 4, 10, 12, 0, 0, tzinfo=UTC)
+_LATER = datetime(2026, 4, 10, 13, 0, 0, tzinfo=UTC)
+
+
+def _minimal_dict() -> dict:
+    """Return the smallest valid thread dict."""
+    return {
+        "title": "My Thread",
+        "state": "open",
+        "weight": 1.5,
+        "created_at": _NOW.isoformat(),
+        "updated_at": _LATER.isoformat(),
+    }
+
+
+def _full_dict() -> dict:
+    """Return a fully-populated thread dict."""
+    return {
+        "title": "My Thread",
+        "state": "pulling",
+        "weight": 2.0,
+        "created_at": _NOW.isoformat(),
+        "updated_at": _LATER.isoformat(),
+        "owner_id": "user_42",
+        "next_action_hint": "Review PR",
+        "resolved_artifact_path": "artifacts/pr.md",
+        "context_refs": [
+            {
+                "ref_type": "conversation",
+                "ref_id": "conv_1",
+                "ref_summary": "Initial discussion",
+            }
+        ],
+        "weight_signals": {"urgency": 0.8},
+    }
+
+
+# ---------------------------------------------------------------------------
+# ThreadState
+# ---------------------------------------------------------------------------
+
+
+class TestThreadState:
+    def test_all_members_exist(self):
+        values = {s.value for s in ThreadState}
+        assert values == {
+            "open",
+            "pulling",
+            "blocked",
+            "waiting_for_peer",
+            "waiting_for_operator",
+            "closed",
+            "dissolved",
+        }
+
+    def test_is_str_subclass(self):
+        assert isinstance(ThreadState.open, str)
+
+    def test_round_trip(self):
+        for state in ThreadState:
+            assert ThreadState(state.value) is state
+
+    def test_invalid_raises_value_error(self):
+        with pytest.raises(ValueError):
+            ThreadState("nonexistent")
+
+
+# ---------------------------------------------------------------------------
+# ThreadContextRef
+# ---------------------------------------------------------------------------
+
+
+class TestThreadContextRef:
+    def test_construction(self):
+        ref = ThreadContextRef(
+            ref_type="conversation",
+            ref_id="conv_1",
+            ref_summary="A conversation",
+        )
+        assert ref.ref_type == "conversation"
+        assert ref.ref_id == "conv_1"
+        assert ref.ref_summary == "A conversation"
+
+    def test_all_ref_types_accepted(self):
+        for rt in ("conversation", "ingest", "observation", "search"):
+            ref = ThreadContextRef(ref_type=rt, ref_id="x", ref_summary="y")  # type: ignore[arg-type]
+            assert ref.ref_type == rt
+
+
+# ---------------------------------------------------------------------------
+# MimirPageMeta — thread field defaults
+# ---------------------------------------------------------------------------
+
+
+class TestMimirPageMetaThreadDefaults:
+    def test_defaults_are_none_or_empty(self):
+        meta = MimirPageMeta(
+            path="foo/bar.md",
+            title="Foo",
+            summary="A page",
+            category="technical",
+            updated_at=_NOW,
+        )
+        assert meta.thread_state is None
+        assert meta.thread_weight is None
+        assert meta.thread_owner_id is None
+        assert meta.thread_context_refs == []
+        assert meta.thread_next_action_hint is None
+        assert meta.thread_resolved_artifact_path is None
+        assert meta.thread_weight_signals is None
+
+    def test_thread_fields_set_independently(self):
+        meta = MimirPageMeta(
+            path="threads/t.yaml",
+            title="T",
+            summary="",
+            category="threads",
+            updated_at=_NOW,
+            thread_state=ThreadState.open,
+            thread_weight=1.0,
+        )
+        assert meta.thread_state is ThreadState.open
+        assert meta.thread_weight == 1.0
+
+
+# ---------------------------------------------------------------------------
+# ThreadSchemaError
+# ---------------------------------------------------------------------------
+
+
+class TestThreadSchemaError:
+    def test_attributes(self):
+        err = ThreadSchemaError("/path/to/file.yaml", "bad state")
+        assert err.path == "/path/to/file.yaml"
+        assert err.reason == "bad state"
+
+    def test_message_format(self):
+        err = ThreadSchemaError("/p.yaml", "missing title")
+        assert "/p.yaml" in str(err)
+        assert "missing title" in str(err)
+
+    def test_is_exception(self):
+        assert isinstance(ThreadSchemaError("x", "y"), Exception)
+
+
+# ---------------------------------------------------------------------------
+# ThreadYamlSchema.from_dict — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestFromDictHappyPath:
+    def test_minimal_fields(self):
+        schema = ThreadYamlSchema.from_dict(_minimal_dict())
+        assert schema.title == "My Thread"
+        assert schema.state is ThreadState.open
+        assert schema.weight == 1.5
+        assert schema.created_at == _NOW
+        assert schema.updated_at == _LATER
+        assert schema.owner_id is None
+        assert schema.next_action_hint is None
+        assert schema.resolved_artifact_path is None
+        assert schema.context_refs == []
+        assert schema.weight_signals == {}
+
+    def test_full_fields(self):
+        schema = ThreadYamlSchema.from_dict(_full_dict())
+        assert schema.title == "My Thread"
+        assert schema.state is ThreadState.pulling
+        assert schema.weight == 2.0
+        assert schema.owner_id == "user_42"
+        assert schema.next_action_hint == "Review PR"
+        assert schema.resolved_artifact_path == "artifacts/pr.md"
+        assert len(schema.context_refs) == 1
+        assert schema.context_refs[0].ref_type == "conversation"
+        assert schema.context_refs[0].ref_id == "conv_1"
+        assert schema.weight_signals == {"urgency": 0.8}
+
+    def test_unknown_keys_ignored(self):
+        data = {**_minimal_dict(), "future_field": "ignored"}
+        schema = ThreadYamlSchema.from_dict(data)
+        assert schema.title == "My Thread"
+
+    def test_datetime_object_accepted_for_created_at(self):
+        data = {**_minimal_dict(), "created_at": _NOW, "updated_at": _LATER}
+        schema = ThreadYamlSchema.from_dict(data)
+        assert schema.created_at == _NOW
+
+    def test_weight_as_integer(self):
+        data = {**_minimal_dict(), "weight": 3}
+        schema = ThreadYamlSchema.from_dict(data)
+        assert schema.weight == 3.0
+
+    def test_all_thread_states(self):
+        for state in ThreadState:
+            data = {**_minimal_dict(), "state": state.value}
+            schema = ThreadYamlSchema.from_dict(data)
+            assert schema.state is state
+
+
+# ---------------------------------------------------------------------------
+# ThreadYamlSchema.from_dict — validation errors
+# ---------------------------------------------------------------------------
+
+
+class TestFromDictValidation:
+    def test_missing_title(self):
+        data = _minimal_dict()
+        del data["title"]
+        with pytest.raises(ThreadSchemaError, match="title"):
+            ThreadYamlSchema.from_dict(data)
+
+    def test_empty_title(self):
+        data = {**_minimal_dict(), "title": "   "}
+        with pytest.raises(ThreadSchemaError, match="title"):
+            ThreadYamlSchema.from_dict(data)
+
+    def test_missing_state(self):
+        data = _minimal_dict()
+        del data["state"]
+        with pytest.raises(ThreadSchemaError, match="state"):
+            ThreadYamlSchema.from_dict(data)
+
+    def test_invalid_state(self):
+        data = {**_minimal_dict(), "state": "flying"}
+        with pytest.raises(ThreadSchemaError, match="state"):
+            ThreadYamlSchema.from_dict(data)
+
+    def test_missing_weight(self):
+        data = _minimal_dict()
+        del data["weight"]
+        with pytest.raises(ThreadSchemaError, match="weight"):
+            ThreadYamlSchema.from_dict(data)
+
+    def test_negative_weight(self):
+        data = {**_minimal_dict(), "weight": -0.1}
+        with pytest.raises(ThreadSchemaError, match="weight"):
+            ThreadYamlSchema.from_dict(data)
+
+    def test_non_numeric_weight(self):
+        data = {**_minimal_dict(), "weight": "heavy"}
+        with pytest.raises(ThreadSchemaError, match="weight"):
+            ThreadYamlSchema.from_dict(data)
+
+    def test_missing_created_at(self):
+        data = _minimal_dict()
+        del data["created_at"]
+        with pytest.raises(ThreadSchemaError, match="created_at"):
+            ThreadYamlSchema.from_dict(data)
+
+    def test_invalid_created_at(self):
+        data = {**_minimal_dict(), "created_at": "not-a-date"}
+        with pytest.raises(ThreadSchemaError, match="created_at"):
+            ThreadYamlSchema.from_dict(data)
+
+    def test_missing_updated_at(self):
+        data = _minimal_dict()
+        del data["updated_at"]
+        with pytest.raises(ThreadSchemaError, match="updated_at"):
+            ThreadYamlSchema.from_dict(data)
+
+    def test_invalid_updated_at(self):
+        data = {**_minimal_dict(), "updated_at": 12345}
+        with pytest.raises(ThreadSchemaError, match="updated_at"):
+            ThreadYamlSchema.from_dict(data)
+
+    def test_context_refs_not_list(self):
+        data = {**_minimal_dict(), "context_refs": "oops"}
+        with pytest.raises(ThreadSchemaError, match="context_refs"):
+            ThreadYamlSchema.from_dict(data)
+
+    def test_context_ref_not_dict(self):
+        data = {**_minimal_dict(), "context_refs": ["bad"]}
+        with pytest.raises(ThreadSchemaError, match="context_refs"):
+            ThreadYamlSchema.from_dict(data)
+
+    def test_context_ref_missing_key(self):
+        data = {
+            **_minimal_dict(),
+            "context_refs": [{"ref_type": "search", "ref_id": "x"}],  # missing ref_summary
+        }
+        with pytest.raises(ThreadSchemaError, match="ref_summary"):
+            ThreadYamlSchema.from_dict(data)
+
+    def test_weight_signals_not_dict(self):
+        data = {**_minimal_dict(), "weight_signals": ["bad"]}
+        with pytest.raises(ThreadSchemaError, match="weight_signals"):
+            ThreadYamlSchema.from_dict(data)
+
+
+# ---------------------------------------------------------------------------
+# ThreadYamlSchema.to_dict / roundtrip
+# ---------------------------------------------------------------------------
+
+
+class TestToDictRoundtrip:
+    def test_minimal_roundtrip(self):
+        schema = ThreadYamlSchema.from_dict(_minimal_dict())
+        restored = ThreadYamlSchema.from_dict(schema.to_dict())
+        assert restored.title == schema.title
+        assert restored.state == schema.state
+        assert restored.weight == schema.weight
+        assert restored.created_at == schema.created_at
+        assert restored.updated_at == schema.updated_at
+
+    def test_full_roundtrip(self):
+        schema = ThreadYamlSchema.from_dict(_full_dict())
+        d = schema.to_dict()
+        restored = ThreadYamlSchema.from_dict(d)
+        assert restored.owner_id == schema.owner_id
+        assert restored.next_action_hint == schema.next_action_hint
+        assert restored.resolved_artifact_path == schema.resolved_artifact_path
+        assert len(restored.context_refs) == len(schema.context_refs)
+        assert restored.context_refs[0].ref_id == schema.context_refs[0].ref_id
+        assert restored.weight_signals == schema.weight_signals
+
+    def test_to_dict_state_is_string(self):
+        schema = ThreadYamlSchema.from_dict(_minimal_dict())
+        d = schema.to_dict()
+        assert isinstance(d["state"], str)
+        assert d["state"] == "open"
+
+    def test_to_dict_datetimes_are_iso_strings(self):
+        schema = ThreadYamlSchema.from_dict(_minimal_dict())
+        d = schema.to_dict()
+        assert isinstance(d["created_at"], str)
+        assert isinstance(d["updated_at"], str)
+        # Should be parseable
+        datetime.fromisoformat(d["created_at"])
+        datetime.fromisoformat(d["updated_at"])
+
+
+# ---------------------------------------------------------------------------
+# ThreadYamlSchema.from_yaml / to_yaml
+# ---------------------------------------------------------------------------
+
+
+class TestYamlFileIO:
+    def test_round_trip_via_files(self, tmp_path: Path):
+        schema = ThreadYamlSchema.from_dict(_full_dict())
+        out = tmp_path / "thread.yaml"
+        schema.to_yaml(out)
+        restored = ThreadYamlSchema.from_yaml(out)
+        assert restored.title == schema.title
+        assert restored.state == schema.state
+        assert restored.weight == schema.weight
+        assert len(restored.context_refs) == 1
+
+    def test_atomic_write_no_tmp_file_left(self, tmp_path: Path):
+        schema = ThreadYamlSchema.from_dict(_minimal_dict())
+        out = tmp_path / "thread.yaml"
+        schema.to_yaml(out)
+        tmp_file = tmp_path / "thread.yaml.tmp"
+        assert out.exists()
+        assert not tmp_file.exists()
+
+    def test_from_yaml_missing_file(self, tmp_path: Path):
+        with pytest.raises(ThreadSchemaError, match="cannot read"):
+            ThreadYamlSchema.from_yaml(tmp_path / "nonexistent.yaml")
+
+    def test_from_yaml_invalid_yaml(self, tmp_path: Path):
+        bad = tmp_path / "bad.yaml"
+        bad.write_text(": : : invalid\n", encoding="utf-8")
+        with pytest.raises(ThreadSchemaError):
+            ThreadYamlSchema.from_yaml(bad)
+
+    def test_from_yaml_non_mapping_top_level(self, tmp_path: Path):
+        bad = tmp_path / "bad.yaml"
+        bad.write_text("- list item\n", encoding="utf-8")
+        with pytest.raises(ThreadSchemaError, match="mapping"):
+            ThreadYamlSchema.from_yaml(bad)
+
+    def test_from_yaml_validation_error(self, tmp_path: Path):
+        yaml_text = textwrap.dedent(
+            """\
+            title: My Thread
+            state: bogus
+            weight: 1.0
+            created_at: "2026-04-10T12:00:00+00:00"
+            updated_at: "2026-04-10T13:00:00+00:00"
+            """
+        )
+        bad = tmp_path / "bad.yaml"
+        bad.write_text(yaml_text, encoding="utf-8")
+        with pytest.raises(ThreadSchemaError, match="state"):
+            ThreadYamlSchema.from_yaml(bad)
+
+    def test_from_yaml_minimal_valid(self, tmp_path: Path):
+        yaml_text = textwrap.dedent(
+            """\
+            title: Hello
+            state: closed
+            weight: 0.0
+            created_at: "2026-01-01T00:00:00+00:00"
+            updated_at: "2026-01-01T00:00:00+00:00"
+            """
+        )
+        p = tmp_path / "t.yaml"
+        p.write_text(yaml_text, encoding="utf-8")
+        schema = ThreadYamlSchema.from_yaml(p)
+        assert schema.state is ThreadState.closed
+        assert schema.weight == 0.0
+
+
+# ---------------------------------------------------------------------------
+# ThreadYamlSchema.to_page_meta
+# ---------------------------------------------------------------------------
+
+
+class TestToPageMeta:
+    def test_produces_mimir_page_meta(self):
+        schema = ThreadYamlSchema.from_dict(_full_dict())
+        meta = schema.to_page_meta("my-thread")
+        assert isinstance(meta, MimirPageMeta)
+
+    def test_path_uses_slug(self):
+        schema = ThreadYamlSchema.from_dict(_minimal_dict())
+        meta = schema.to_page_meta("the-slug")
+        assert meta.path == "threads/the-slug.yaml"
+
+    def test_category_is_threads(self):
+        schema = ThreadYamlSchema.from_dict(_minimal_dict())
+        meta = schema.to_page_meta("s")
+        assert meta.category == "threads"
+
+    def test_thread_state_populated(self):
+        schema = ThreadYamlSchema.from_dict(_minimal_dict())
+        meta = schema.to_page_meta("s")
+        assert meta.thread_state is ThreadState.open
+
+    def test_thread_weight_populated(self):
+        schema = ThreadYamlSchema.from_dict(_minimal_dict())
+        meta = schema.to_page_meta("s")
+        assert meta.thread_weight == 1.5
+
+    def test_thread_owner_populated(self):
+        schema = ThreadYamlSchema.from_dict(_full_dict())
+        meta = schema.to_page_meta("s")
+        assert meta.thread_owner_id == "user_42"
+
+    def test_thread_context_refs_populated(self):
+        schema = ThreadYamlSchema.from_dict(_full_dict())
+        meta = schema.to_page_meta("s")
+        assert len(meta.thread_context_refs) == 1
+        assert meta.thread_context_refs[0].ref_id == "conv_1"
+
+    def test_thread_next_action_hint_populated(self):
+        schema = ThreadYamlSchema.from_dict(_full_dict())
+        meta = schema.to_page_meta("s")
+        assert meta.thread_next_action_hint == "Review PR"
+
+    def test_thread_resolved_artifact_path_populated(self):
+        schema = ThreadYamlSchema.from_dict(_full_dict())
+        meta = schema.to_page_meta("s")
+        assert meta.thread_resolved_artifact_path == "artifacts/pr.md"
+
+    def test_thread_weight_signals_populated(self):
+        schema = ThreadYamlSchema.from_dict(_full_dict())
+        meta = schema.to_page_meta("s")
+        assert meta.thread_weight_signals == {"urgency": 0.8}
+
+    def test_updated_at_propagated(self):
+        schema = ThreadYamlSchema.from_dict(_minimal_dict())
+        meta = schema.to_page_meta("s")
+        assert meta.updated_at == _LATER
+
+    def test_title_propagated(self):
+        schema = ThreadYamlSchema.from_dict(_minimal_dict())
+        meta = schema.to_page_meta("s")
+        assert meta.title == "My Thread"
+
+    def test_weight_signals_none_when_empty(self):
+        schema = ThreadYamlSchema.from_dict(_minimal_dict())
+        meta = schema.to_page_meta("s")
+        # empty weight_signals dict → None in page meta
+        assert meta.thread_weight_signals is None
+
+    def test_summary_is_next_action_hint(self):
+        schema = ThreadYamlSchema.from_dict(_full_dict())
+        meta = schema.to_page_meta("s")
+        assert meta.summary == "Review PR"
+
+    def test_summary_empty_when_no_hint(self):
+        schema = ThreadYamlSchema.from_dict(_minimal_dict())
+        meta = schema.to_page_meta("s")
+        assert meta.summary == ""

--- a/tests/test_niuu/test_mimir_domain.py
+++ b/tests/test_niuu/test_mimir_domain.py
@@ -317,6 +317,14 @@ class TestFromDictValidation:
         with pytest.raises(ThreadSchemaError, match="weight_signals"):
             ThreadYamlSchema.from_dict(data)
 
+    def test_context_ref_invalid_ref_type(self):
+        data = {
+            **_minimal_dict(),
+            "context_refs": [{"ref_type": "foobar", "ref_id": "x", "ref_summary": "y"}],
+        }
+        with pytest.raises(ThreadSchemaError, match="ref_type"):
+            ThreadYamlSchema.from_dict(data)
+
 
 # ---------------------------------------------------------------------------
 # ThreadYamlSchema.to_dict / roundtrip


### PR DESCRIPTION
## Summary

Extended `niuu.domain.mimir` with thread-related domain types required by NIU-556.

### New types

- **`ThreadState`** (`StrEnum`): lifecycle states — `open`, `pulling`, `blocked`, `waiting_for_peer`, `waiting_for_operator`, `closed`, `dissolved`
- **`ThreadContextRef`**: typed reference to an external artifact (`ref_type`, `ref_id`, `ref_summary`)
- **`ThreadSchemaError`**: validation exception carrying `path` + `reason`
- **`ThreadYamlSchema`**: canonical, validated representation of a thread's `.yaml` file — shared by all adapters and the Mímir service

### MimirPageMeta — new optional fields

Seven new optional thread fields added (all default to `None`/`[]`):
`thread_state`, `thread_weight`, `thread_owner_id`, `thread_context_refs`,
`thread_next_action_hint`, `thread_resolved_artifact_path`, `thread_weight_signals`

Existing `MimirPageMeta` construction without thread fields is unaffected.

### ThreadYamlSchema methods

- `from_yaml(path)` — parse + validate a YAML file; raises `ThreadSchemaError` on bad fields
- `from_dict(data)` — same validation from a dict (HTTP deserialisation)
- `to_yaml(path)` — atomic write (`.tmp` then rename) to prevent corrupt state on crash
- `to_dict()` — serialise to dict (HTTP serialisation)
- `to_page_meta(slug)` — produce a `MimirPageMeta` with all thread fields populated

### Validation enforced

- `title`: non-empty string
- `state`: valid `ThreadState` value
- `weight`: float >= 0.0
- `created_at`, `updated_at`: valid ISO-8601 datetimes
- `context_refs`: list of dicts with `ref_type`, `ref_id`, `ref_summary`
- Unknown keys silently ignored (forward-compatible)

## Test plan

- [x] 58 unit tests — all types, validation branches, roundtrips, atomic write, `to_page_meta`
- [x] 99% coverage on `niuu.domain.mimir` (branch: feat/vaka-ravn-wakefulness, working branch: niu-556)
- [x] `ruff check` and `ruff format` clean
- [x] Zero pytest warnings

## Notes

- Linear MCP tools were unavailable in this environment; NIU-556 could not be updated via MCP.

Closes NIU-556

Generated with [Claude Code](https://claude.com/claude-code)