### PR TITLE
feat(adapters): thread memory for Vaka wakefulness (NIU-555)

### DIFF
--- a/charts/volundr/templates/migrations-configmap.yaml
+++ b/charts/volundr/templates/migrations-configmap.yaml
@@ -886,4 +886,37 @@ data:
         DROP COLUMN IF EXISTS label,
         DROP COLUMN IF EXISTS tags,
         DROP COLUMN IF EXISTS memory_context;
+
+  000032_ravn_threads.up.sql: |
+    -- NIU-555: Vaka wakefulness — thread memory table.
+    --
+    -- A thread is a Mímir page that represents unfinished business.
+    -- The Sjón enrichment step populates this table after each ingest;
+    -- the Vaka tick loop (M2) reads from it ordered by weight descending.
+
+    CREATE TABLE IF NOT EXISTS ravn_threads (
+        thread_id        TEXT PRIMARY KEY,
+        page_path        TEXT NOT NULL,
+        title            TEXT NOT NULL DEFAULT '',
+        weight           DOUBLE PRECISION NOT NULL DEFAULT 0.5,
+        next_action      TEXT NOT NULL DEFAULT '',
+        tags             JSONB NOT NULL DEFAULT '[]',
+        status           TEXT NOT NULL DEFAULT 'open',
+        created_at       TIMESTAMPTZ NOT NULL,
+        last_seen_at     TIMESTAMPTZ NOT NULL
+    );
+
+    -- Uniqueness: one open thread per Mímir page path.
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_ravn_threads_page_path
+        ON ravn_threads (page_path)
+        WHERE status = 'open';
+
+    -- Queue scan: open threads ordered by weight descending (Vaka tick loop).
+    CREATE INDEX IF NOT EXISTS idx_ravn_threads_weight
+        ON ravn_threads (weight DESC)
+        WHERE status = 'open';
+
+  000032_ravn_threads.down.sql: |
+    -- NIU-555: rollback thread memory table.
+    DROP TABLE IF EXISTS ravn_threads;
 {{- end }}

--- a/migrations/000032_ravn_threads.down.sql
+++ b/migrations/000032_ravn_threads.down.sql
@@ -1,0 +1,2 @@
+-- NIU-555: rollback thread memory table.
+DROP TABLE IF EXISTS ravn_threads;

--- a/migrations/000032_ravn_threads.up.sql
+++ b/migrations/000032_ravn_threads.up.sql
@@ -1,0 +1,27 @@
+-- NIU-555: Vaka wakefulness — thread memory table.
+--
+-- A thread is a Mímir page that represents unfinished business.
+-- The Sjón enrichment step populates this table after each ingest;
+-- the Vaka tick loop (M2) reads from it ordered by weight descending.
+
+CREATE TABLE IF NOT EXISTS ravn_threads (
+    thread_id        TEXT PRIMARY KEY,
+    page_path        TEXT NOT NULL,
+    title            TEXT NOT NULL DEFAULT '',
+    weight           DOUBLE PRECISION NOT NULL DEFAULT 0.5,
+    next_action      TEXT NOT NULL DEFAULT '',
+    tags             JSONB NOT NULL DEFAULT '[]',
+    status           TEXT NOT NULL DEFAULT 'open',
+    created_at       TIMESTAMPTZ NOT NULL,
+    last_seen_at     TIMESTAMPTZ NOT NULL
+);
+
+-- Uniqueness: one open thread per Mímir page path.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ravn_threads_page_path
+    ON ravn_threads (page_path)
+    WHERE status = 'open';
+
+-- Queue scan: open threads ordered by weight descending (Vaka tick loop).
+CREATE INDEX IF NOT EXISTS idx_ravn_threads_weight
+    ON ravn_threads (weight DESC)
+    WHERE status = 'open';

--- a/src/ravn/adapters/thread/__init__.py
+++ b/src/ravn/adapters/thread/__init__.py
@@ -1,0 +1,1 @@
+"""Thread memory adapters (NIU-555)."""

--- a/src/ravn/adapters/thread/enrichment.py
+++ b/src/ravn/adapters/thread/enrichment.py
@@ -1,0 +1,192 @@
+"""Sjón enrichment adapter — classifies Mímir pages as threads or facts.
+
+For every newly ingested Mímir page, the enrichment adapter calls a cheap
+LLM to decide:
+
+1. Is this page *unfinished business* (an open question, half-explored idea,
+   or topic that deserves follow-up)?  → thread
+2. Or is it a settled fact / reference material?  → fact (ignored here)
+
+If the page is a thread, :meth:`SjonEnrichmentAdapter.enrich` creates a
+:class:`~ravn.domain.thread.RavnThread`, persists it via the
+:class:`~ravn.ports.thread.ThreadPort`, and returns it.  Otherwise it returns
+``None`` — no side-effects.
+
+The LLM response is a minimal JSON object::
+
+    {
+      "is_thread": true,
+      "importance": 0.8,
+      "next_action": "read and extract key claims",
+      "tags": ["paper", "ml"]
+    }
+
+``importance`` is in (0, 1] and is used as ``importance_factor`` when
+computing the initial composite weight.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+
+from niuu.domain.mimir import MimirPage
+from ravn.domain.thread import RavnThread, compute_weight
+from ravn.ports.llm import LLMPort
+from ravn.ports.thread import ThreadPort
+
+logger = logging.getLogger(__name__)
+
+_SYSTEM_PROMPT = """\
+You are Sjón, a classification assistant.  Given a Mímir wiki page you decide
+whether the page represents *unfinished business* for the AI agent Ravn.
+
+Unfinished business includes:
+- Open questions or hypotheses that have not been fully explored
+- Research papers whose implications have not been analysed
+- Topics the agent should follow up on
+- Half-formed ideas that deserve deeper thought
+- Observations that raise questions
+
+Settled facts, reference material, how-to guides, and completed summaries are
+NOT unfinished business.
+
+Respond with a JSON object and nothing else:
+{
+  "is_thread": <true|false>,
+  "importance": <float 0.1-1.0>,
+  "next_action": "<one-sentence hint for the agent, or empty string>",
+  "tags": ["<tag1>", "<tag2>"]
+}
+
+importance 1.0 = highest priority; 0.1 = lowest.
+next_action should be ≤ 80 characters.
+tags should be short lowercase labels (2-4 tags max).
+"""
+
+
+class SjonEnrichmentAdapter:
+    """Classifies a Mímir page as a thread or a fact.
+
+    Parameters
+    ----------
+    llm:
+        LLM adapter used for the classification call.
+    thread_store:
+        ThreadPort implementation that receives new threads.
+    enrichment_model:
+        Model alias passed to the LLM for the cheap classification call.
+    enrichment_max_tokens:
+        Maximum tokens in the LLM response.
+    decay_half_life_days:
+        Half-life for the recency decay applied to the initial weight.
+    initial_weight:
+        Base score used when ``importance`` is not provided by the LLM.
+    """
+
+    def __init__(
+        self,
+        llm: LLMPort,
+        thread_store: ThreadPort,
+        *,
+        enrichment_model: str = "claude-haiku-4-5-20251001",
+        enrichment_max_tokens: int = 256,
+        decay_half_life_days: float = 7.0,
+        initial_weight: float = 0.5,
+    ) -> None:
+        self._llm = llm
+        self._store = thread_store
+        self._model = enrichment_model
+        self._max_tokens = enrichment_max_tokens
+        self._half_life = decay_half_life_days
+        self._initial_weight = initial_weight
+
+    async def enrich(self, page: MimirPage) -> RavnThread | None:
+        """Classify *page* and create a thread if it is unfinished business.
+
+        Returns the persisted :class:`~ravn.domain.thread.RavnThread` if the
+        page was classified as a thread, or ``None`` if it is a fact.
+        """
+        classification = await self._classify(page)
+        if not classification.get("is_thread"):
+            return None
+
+        importance = float(classification.get("importance") or 1.0)
+        importance = max(0.01, min(1.0, importance))
+        next_action = str(classification.get("next_action") or "")
+        tags = list(classification.get("tags") or [])
+
+        tw = compute_weight(
+            base_score=self._initial_weight,
+            importance_factor=importance,
+            created_at=page.meta.updated_at,
+            half_life_days=self._half_life,
+        )
+
+        thread = RavnThread.create(
+            page_path=page.meta.path,
+            title=page.meta.title,
+            weight=tw.composite,
+            next_action=next_action,
+            tags=tags,
+        )
+        await self._store.upsert(thread)
+        logger.info(
+            "Sjón: thread created for %s (weight=%.3f, action=%r)",
+            page.meta.path,
+            thread.weight,
+            next_action,
+        )
+        return thread
+
+    async def _classify(self, page: MimirPage) -> dict:
+        """Call the LLM and return the parsed classification dict."""
+        user_content = (
+            f"Page path: {page.meta.path}\n"
+            f"Title: {page.meta.title}\n"
+            f"Summary: {page.meta.summary}\n\n"
+            f"Content (truncated to 800 chars):\n{page.content[:800]}"
+        )
+        messages = [{"role": "user", "content": user_content}]
+        try:
+            response = await self._llm.generate(
+                messages,
+                tools=[],
+                system=_SYSTEM_PROMPT,
+                model=self._model,
+                max_tokens=self._max_tokens,
+            )
+            raw = response.content.strip()
+            return _parse_json(raw)
+        except Exception:
+            logger.warning(
+                "Sjón: LLM classification failed for %s, defaulting to fact",
+                page.meta.path,
+                exc_info=True,
+            )
+            return {"is_thread": False}
+
+
+def _parse_json(raw: str) -> dict:
+    """Extract the first JSON object from *raw*, tolerating markdown fences."""
+    # Strip code fences if present
+    raw = re.sub(r"^```(?:json)?\s*", "", raw, flags=re.MULTILINE)
+    raw = re.sub(r"\s*```$", "", raw, flags=re.MULTILINE)
+    raw = raw.strip()
+    try:
+        result = json.loads(raw)
+        if isinstance(result, dict):
+            return result
+    except json.JSONDecodeError:
+        pass
+    # Try to find a JSON object inside the string
+    match = re.search(r"\{.*\}", raw, re.DOTALL)
+    if match:
+        try:
+            result = json.loads(match.group(0))
+            if isinstance(result, dict):
+                return result
+        except json.JSONDecodeError:
+            pass
+    return {"is_thread": False}

--- a/src/ravn/adapters/thread/postgres.py
+++ b/src/ravn/adapters/thread/postgres.py
@@ -1,0 +1,227 @@
+"""PostgreSQL thread adapter — persists RavnThread records to ravn_threads.
+
+Raw SQL with asyncpg — no ORM.
+
+Table schema is in migrations/000032_ravn_threads.up.sql.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+
+from ravn.domain.thread import RavnThread, ThreadStatus
+from ravn.ports.thread import ThreadPort
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# DDL (dev / test bootstrap — production uses the migrate tool)
+# ---------------------------------------------------------------------------
+
+_CREATE_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS ravn_threads (
+    thread_id        TEXT PRIMARY KEY,
+    page_path        TEXT NOT NULL,
+    title            TEXT NOT NULL DEFAULT '',
+    weight           DOUBLE PRECISION NOT NULL DEFAULT 0.5,
+    next_action      TEXT NOT NULL DEFAULT '',
+    tags             JSONB NOT NULL DEFAULT '[]',
+    status           TEXT NOT NULL DEFAULT 'open',
+    created_at       TIMESTAMPTZ NOT NULL,
+    last_seen_at     TIMESTAMPTZ NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ravn_threads_page_path
+    ON ravn_threads (page_path)
+    WHERE status = 'open';
+
+CREATE INDEX IF NOT EXISTS idx_ravn_threads_weight
+    ON ravn_threads (weight DESC)
+    WHERE status = 'open';
+"""
+
+# ---------------------------------------------------------------------------
+# DML
+# ---------------------------------------------------------------------------
+
+_UPSERT_SQL = """
+INSERT INTO ravn_threads (
+    thread_id, page_path, title, weight, next_action,
+    tags, status, created_at, last_seen_at
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+ON CONFLICT (thread_id) DO UPDATE SET
+    page_path    = EXCLUDED.page_path,
+    title        = EXCLUDED.title,
+    weight       = EXCLUDED.weight,
+    next_action  = EXCLUDED.next_action,
+    tags         = EXCLUDED.tags,
+    status       = EXCLUDED.status,
+    last_seen_at = EXCLUDED.last_seen_at;
+"""
+
+_SELECT_BY_ID_SQL = """
+SELECT thread_id, page_path, title, weight, next_action,
+       tags, status, created_at, last_seen_at
+FROM ravn_threads
+WHERE thread_id = $1;
+"""
+
+_SELECT_BY_PATH_SQL = """
+SELECT thread_id, page_path, title, weight, next_action,
+       tags, status, created_at, last_seen_at
+FROM ravn_threads
+WHERE page_path = $1 AND status = 'open'
+LIMIT 1;
+"""
+
+_PEEK_QUEUE_SQL = """
+SELECT thread_id, page_path, title, weight, next_action,
+       tags, status, created_at, last_seen_at
+FROM ravn_threads
+WHERE status = 'open'
+ORDER BY weight DESC
+LIMIT $1;
+"""
+
+_LIST_OPEN_SQL = """
+SELECT thread_id, page_path, title, weight, next_action,
+       tags, status, created_at, last_seen_at
+FROM ravn_threads
+WHERE status = 'open'
+ORDER BY created_at DESC
+LIMIT $1;
+"""
+
+_CLOSE_SQL = """
+UPDATE ravn_threads
+SET status = 'closed', last_seen_at = $2
+WHERE thread_id = $1;
+"""
+
+_UPDATE_WEIGHT_SQL = """
+UPDATE ravn_threads
+SET weight = $2, last_seen_at = $3
+WHERE thread_id = $1;
+"""
+
+
+# ---------------------------------------------------------------------------
+# Adapter
+# ---------------------------------------------------------------------------
+
+
+class PostgresThreadAdapter(ThreadPort):
+    """Thread adapter backed by PostgreSQL.
+
+    Parameters
+    ----------
+    dsn:
+        asyncpg-compatible connection string,
+        e.g. ``postgresql://user:pass@host/db``.
+    """
+
+    def __init__(self, dsn: str) -> None:
+        self._dsn = dsn
+        self._pool: object | None = None
+
+    async def _ensure_pool(self) -> object:
+        if self._pool is not None:
+            return self._pool
+        import asyncpg  # type: ignore[import]
+
+        self._pool = await asyncpg.create_pool(self._dsn)
+        async with self._pool.acquire() as conn:
+            await conn.execute(_CREATE_TABLE_SQL)
+        return self._pool
+
+    async def upsert(self, thread: RavnThread) -> None:
+        pool = await self._ensure_pool()
+        async with pool.acquire() as conn:
+            await conn.execute(
+                _UPSERT_SQL,
+                thread.thread_id,
+                thread.page_path,
+                thread.title,
+                thread.weight,
+                thread.next_action,
+                json.dumps(thread.tags),
+                thread.status.value,
+                thread.created_at,
+                thread.last_seen_at,
+            )
+        logger.debug("Thread upserted: %s (%s)", thread.thread_id, thread.page_path)
+
+    async def get(self, thread_id: str) -> RavnThread | None:
+        pool = await self._ensure_pool()
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(_SELECT_BY_ID_SQL, thread_id)
+        if row is None:
+            return None
+        return _row_to_thread(row)
+
+    async def get_by_path(self, page_path: str) -> RavnThread | None:
+        pool = await self._ensure_pool()
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(_SELECT_BY_PATH_SQL, page_path)
+        if row is None:
+            return None
+        return _row_to_thread(row)
+
+    async def peek_queue(self, *, limit: int = 10) -> list[RavnThread]:
+        pool = await self._ensure_pool()
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(_PEEK_QUEUE_SQL, limit)
+        return [_row_to_thread(r) for r in rows]
+
+    async def list_open(self, *, limit: int = 100) -> list[RavnThread]:
+        pool = await self._ensure_pool()
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(_LIST_OPEN_SQL, limit)
+        return [_row_to_thread(r) for r in rows]
+
+    async def close(self, thread_id: str) -> None:
+        pool = await self._ensure_pool()
+        async with pool.acquire() as conn:
+            await conn.execute(_CLOSE_SQL, thread_id, datetime.now(UTC))
+        logger.debug("Thread closed: %s", thread_id)
+
+    async def update_weight(self, thread_id: str, weight: float) -> None:
+        pool = await self._ensure_pool()
+        async with pool.acquire() as conn:
+            await conn.execute(_UPDATE_WEIGHT_SQL, thread_id, weight, datetime.now(UTC))
+        logger.debug("Thread weight updated: %s → %.4f", thread_id, weight)
+
+
+# ---------------------------------------------------------------------------
+# Row deserialisation
+# ---------------------------------------------------------------------------
+
+
+def _parse_ts(ts: datetime) -> datetime:
+    if ts.tzinfo is None:
+        return ts.replace(tzinfo=UTC)
+    return ts
+
+
+def _parse_tags(val: object) -> list[str]:
+    if isinstance(val, list):
+        return val
+    if isinstance(val, str):
+        return json.loads(val)
+    return []
+
+
+def _row_to_thread(row: object) -> RavnThread:
+    return RavnThread(
+        thread_id=row["thread_id"],
+        page_path=row["page_path"],
+        title=row["title"] or "",
+        weight=float(row["weight"]),
+        next_action=row["next_action"] or "",
+        tags=_parse_tags(row["tags"]),
+        status=ThreadStatus(row["status"]),
+        created_at=_parse_ts(row["created_at"]),
+        last_seen_at=_parse_ts(row["last_seen_at"]),
+    )

--- a/src/ravn/adapters/thread/queue_trigger.py
+++ b/src/ravn/adapters/thread/queue_trigger.py
@@ -1,0 +1,127 @@
+"""ThreadQueueTrigger — feeds open threads into the Vaka drive loop (NIU-555).
+
+This trigger reads the weighted work queue from :class:`~ravn.ports.thread.ThreadPort`
+and enqueues the highest-priority threads as :class:`~ravn.domain.models.AgentTask`
+objects for the drive loop to process.
+
+In **M1** (this milestone) the trigger exists but the drive loop does not
+activate autonomous ticks — it only runs on operator input.  The trigger is
+wired into the initiative config so that M2 can enable it by flipping
+``initiative.enabled = true`` without any code changes.
+
+The trigger runs on a configurable interval.  Each cycle it:
+
+1. Calls :meth:`~ravn.ports.thread.ThreadPort.peek_queue` to get the top-N
+   open threads by weight.
+2. Closes threads whose composite weight has decayed below ``weight_floor``.
+3. Enqueues the surviving threads as ``AgentTask`` objects.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+
+from ravn.domain.models import AgentTask, OutputMode
+from ravn.domain.thread import compute_weight
+from ravn.ports.thread import ThreadPort
+from ravn.ports.trigger import TriggerPort
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_INTERVAL_SECONDS = 300.0
+_DEFAULT_BATCH_SIZE = 10
+_DEFAULT_WEIGHT_FLOOR = 0.05
+_DEFAULT_HALF_LIFE_DAYS = 7.0
+
+
+class ThreadQueueTrigger(TriggerPort):
+    """Drive-loop trigger that surfaces threads from the work queue.
+
+    Parameters
+    ----------
+    thread_store:
+        :class:`~ravn.ports.thread.ThreadPort` backing the queue.
+    interval_seconds:
+        Seconds between queue sweeps.
+    batch_size:
+        Maximum threads enqueued per cycle.
+    weight_floor:
+        Threads with composite weight below this value are closed automatically.
+    half_life_days:
+        Used to recompute current weight for decay-floor checks.
+    """
+
+    def __init__(
+        self,
+        thread_store: ThreadPort,
+        *,
+        interval_seconds: float = _DEFAULT_INTERVAL_SECONDS,
+        batch_size: int = _DEFAULT_BATCH_SIZE,
+        weight_floor: float = _DEFAULT_WEIGHT_FLOOR,
+        half_life_days: float = _DEFAULT_HALF_LIFE_DAYS,
+    ) -> None:
+        self._store = thread_store
+        self._interval = interval_seconds
+        self._batch = batch_size
+        self._floor = weight_floor
+        self._half_life = half_life_days
+
+    @property
+    def name(self) -> str:
+        return "thread_queue"
+
+    async def run(self, enqueue: Callable[[AgentTask], Awaitable[None]]) -> None:
+        """Run forever.  Sweeps the thread queue every *interval_seconds*."""
+        while True:
+            await asyncio.sleep(self._interval)
+            await self._sweep(enqueue)
+
+    async def _sweep(self, enqueue: Callable[[AgentTask], Awaitable[None]]) -> None:
+        """One queue sweep: recompute weights, prune decayed threads, enqueue rest."""
+        try:
+            threads = await self._store.peek_queue(limit=self._batch)
+        except Exception:
+            logger.warning("ThreadQueueTrigger: queue peek failed", exc_info=True)
+            return
+
+        now = datetime.now(UTC)
+        for thread in threads:
+            tw = compute_weight(
+                base_score=thread.weight,
+                importance_factor=1.0,
+                created_at=thread.created_at,
+                half_life_days=self._half_life,
+                reference_time=now,
+            )
+            if tw.composite < self._floor:
+                await self._store.close(thread.thread_id)
+                logger.info(
+                    "ThreadQueueTrigger: auto-closed decayed thread %s (weight=%.4f)",
+                    thread.thread_id,
+                    tw.composite,
+                )
+                continue
+
+            await self._store.update_weight(thread.thread_id, tw.composite)
+            task_id = f"task_{int(time.time() * 1000):x}_thread_{thread.thread_id[:8]}"
+            task = AgentTask(
+                task_id=task_id,
+                title=f"Thread follow-up: {thread.title}",
+                initiative_context=(
+                    f"Thread follow-up: {thread.title}\n"
+                    f"Page: {thread.page_path}\n"
+                    f"Action: {thread.next_action}"
+                ),
+                triggered_by=self.name,
+                output_mode=OutputMode.SILENT,
+            )
+            await enqueue(task)
+            logger.debug(
+                "ThreadQueueTrigger: enqueued thread %s (weight=%.4f)",
+                thread.thread_id,
+                tw.composite,
+            )

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -1859,6 +1859,62 @@ class ProfileSourceConfig(BaseModel):
     )
 
 
+class ThreadConfig(BaseModel):
+    """Vaka wakefulness — thread memory configuration (NIU-555).
+
+    Controls how Sjón enrichment classifies Mímir pages as threads, the weight
+    decay applied to open threads, and the batch size the Vaka tick loop uses
+    when reading from the weighted work queue.
+    """
+
+    decay_half_life_days: float = Field(
+        default=7.0,
+        description=(
+            "Half-life in days for exponential recency decay on thread weights. "
+            "A thread created 7 days ago will have half the recency factor of a "
+            "brand-new thread (with the default value)."
+        ),
+    )
+    initial_weight: float = Field(
+        default=0.5,
+        description="Default base_score assigned by enrichment when no LLM score is available.",
+    )
+    importance_default: float = Field(
+        default=1.0,
+        description=(
+            "Default importance_factor when the enrichment LLM does not return one. "
+            "Must be in (0, 1]."
+        ),
+    )
+    weight_floor: float = Field(
+        default=0.05,
+        description=(
+            "Threads whose composite weight drops below this floor are automatically "
+            "closed during the next queue sweep."
+        ),
+    )
+    enrichment_model: str = Field(
+        default="claude-haiku-4-5-20251001",
+        description="Model alias used for the Sjón enrichment LLM call (cheap / fast).",
+    )
+    enrichment_max_tokens: int = Field(
+        default=256,
+        description="Maximum tokens for the Sjón enrichment LLM response.",
+    )
+    queue_batch_size: int = Field(
+        default=10,
+        description="Number of threads the Vaka tick loop dequeues per cycle (M2).",
+    )
+    dsn: str = Field(
+        default="",
+        description="PostgreSQL DSN for the thread backend (shared with checkpoint dsn).",
+    )
+    dsn_env: str = Field(
+        default="",
+        description="Env var name to read the thread backend DSN from.",
+    )
+
+
 class Settings(BaseSettings):
     """Ravn application settings.
 
@@ -1931,6 +1987,9 @@ class Settings(BaseSettings):
 
     # NIU-532: browser automation
     browser: BrowserConfig = Field(default_factory=BrowserConfig)
+
+    # NIU-555: Vaka wakefulness / thread memory
+    thread: ThreadConfig = Field(default_factory=lambda: ThreadConfig())
 
     # Plugin extension points
     slash_commands: list[SlashCommandAdapterConfig] = Field(

--- a/src/ravn/domain/thread.py
+++ b/src/ravn/domain/thread.py
@@ -1,0 +1,167 @@
+"""Thread domain models for Vaka wakefulness (NIU-555).
+
+A *thread* is a Mímir page that represents unfinished business — an open
+question, a half-explored idea, or a topic that deserves follow-up.  Not all
+Mímir pages are threads; the Sjón enrichment step decides which ones qualify
+and assigns them an initial weight and a next-action hint.
+
+Threads are NOT a separate knowledge store.  They are metadata stored in a
+``ravn_threads`` table that references Mímir pages by path.  The Mímir service
+itself is unchanged.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from uuid import uuid4
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class ThreadStatus(StrEnum):
+    OPEN = "open"
+    CLOSED = "closed"  # resolved / no longer relevant
+
+
+# ---------------------------------------------------------------------------
+# Domain models
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RavnThread:
+    """A single thread — a Mímir page tagged as unfinished business.
+
+    Parameters
+    ----------
+    thread_id:
+        UUID string, generated at creation time.
+    page_path:
+        Relative path of the Mímir page, e.g. ``papers/attention.md``.
+    title:
+        Human-readable title copied from the Mímir page.
+    weight:
+        Current composite weight (≥ 0).  Higher means more urgent / relevant.
+        Decays over time via :func:`compute_weight`.
+    next_action:
+        LLM-assigned hint describing what Ravn should do with this thread,
+        e.g. ``"read and summarise the implications"``.
+    tags:
+        Arbitrary labels for filtering, e.g. ``["paper", "ml"]``.
+    status:
+        ``open`` (active) or ``closed`` (resolved).
+    created_at:
+        When this thread was first created.
+    last_seen_at:
+        When this thread was last touched (enriched, queued, or actioned).
+    """
+
+    thread_id: str
+    page_path: str
+    title: str
+    weight: float
+    next_action: str
+    tags: list[str]
+    status: ThreadStatus
+    created_at: datetime
+    last_seen_at: datetime
+
+    @classmethod
+    def create(
+        cls,
+        page_path: str,
+        title: str,
+        weight: float,
+        next_action: str,
+        tags: list[str] | None = None,
+    ) -> RavnThread:
+        """Convenience constructor — generates a UUID and timestamps now."""
+        now = datetime.now(UTC)
+        return cls(
+            thread_id=str(uuid4()),
+            page_path=page_path,
+            title=title,
+            weight=weight,
+            next_action=next_action,
+            tags=tags or [],
+            status=ThreadStatus.OPEN,
+            created_at=now,
+            last_seen_at=now,
+        )
+
+
+@dataclass(frozen=True)
+class ThreadWeight:
+    """Decomposed weight factors for a thread.
+
+    The composite weight is computed as::
+
+        composite = base_score * recency_factor * importance_factor
+
+    where ``recency_factor`` uses exponential decay:
+
+        recency_factor = exp(-ln(2) / half_life_days * days_since_created)
+
+    Parameters
+    ----------
+    base_score:
+        Raw score from enrichment, in [0, 1].
+    recency_factor:
+        Exponential decay factor based on thread age.
+    importance_factor:
+        Multiplier assigned by the LLM enrichment step, in (0, 1].
+    composite:
+        Final composite weight (product of the above three).
+    computed_at:
+        When these factors were computed.
+    """
+
+    base_score: float
+    recency_factor: float
+    importance_factor: float
+    composite: float
+    computed_at: datetime
+
+
+def compute_weight(
+    base_score: float,
+    importance_factor: float,
+    created_at: datetime,
+    *,
+    half_life_days: float = 7.0,
+    reference_time: datetime | None = None,
+) -> ThreadWeight:
+    """Compute a :class:`ThreadWeight` for a thread.
+
+    Parameters
+    ----------
+    base_score:
+        Raw enrichment score in [0, 1].
+    importance_factor:
+        Importance multiplier from the LLM, in (0, 1].
+    created_at:
+        When the thread was created (used for recency decay).
+    half_life_days:
+        Days after which the recency factor halves.
+    reference_time:
+        Time to compute decay against.  Defaults to ``datetime.now(UTC)``.
+    """
+    now = reference_time or datetime.now(UTC)
+    if created_at.tzinfo is None:
+        created_at = created_at.replace(tzinfo=UTC)
+    days_old = max(0.0, (now - created_at).total_seconds() / 86400.0)
+    decay_lambda = math.log(2.0) / half_life_days
+    recency_factor = math.exp(-decay_lambda * days_old)
+    composite = base_score * recency_factor * importance_factor
+    return ThreadWeight(
+        base_score=base_score,
+        recency_factor=recency_factor,
+        importance_factor=importance_factor,
+        composite=composite,
+        computed_at=now,
+    )

--- a/src/ravn/ports/thread.py
+++ b/src/ravn/ports/thread.py
@@ -1,0 +1,58 @@
+"""Thread port — interface for thread persistence backends (NIU-555)."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from ravn.domain.thread import RavnThread
+
+
+class ThreadPort(ABC):
+    """Abstract interface for thread storage and retrieval.
+
+    Implementations persist :class:`~ravn.domain.thread.RavnThread` records
+    and expose the weighted work queue consumed by the Vaka tick loop.
+    """
+
+    @abstractmethod
+    async def upsert(self, thread: RavnThread) -> None:
+        """Insert or update a thread record.
+
+        Uses ``thread_id`` as the primary key.  All fields are overwritten on
+        conflict so that weight updates propagate correctly.
+        """
+        ...
+
+    @abstractmethod
+    async def get(self, thread_id: str) -> RavnThread | None:
+        """Return the thread with the given *thread_id*, or ``None``."""
+        ...
+
+    @abstractmethod
+    async def get_by_path(self, page_path: str) -> RavnThread | None:
+        """Return the open thread whose ``page_path`` matches, or ``None``."""
+        ...
+
+    @abstractmethod
+    async def peek_queue(self, *, limit: int = 10) -> list[RavnThread]:
+        """Return the top *limit* open threads ordered by weight descending.
+
+        Does **not** dequeue; callers read-only.  Used by the Vaka tick loop
+        in M2 to decide what to work on next.
+        """
+        ...
+
+    @abstractmethod
+    async def list_open(self, *, limit: int = 100) -> list[RavnThread]:
+        """Return up to *limit* open threads, newest first."""
+        ...
+
+    @abstractmethod
+    async def close(self, thread_id: str) -> None:
+        """Mark a thread as closed (resolved / no longer relevant)."""
+        ...
+
+    @abstractmethod
+    async def update_weight(self, thread_id: str, weight: float) -> None:
+        """Update the composite weight for *thread_id*."""
+        ...

--- a/tests/test_ravn/test_thread_config.py
+++ b/tests/test_ravn/test_thread_config.py
@@ -1,0 +1,41 @@
+"""Tests for ThreadConfig (NIU-555)."""
+
+from __future__ import annotations
+
+from ravn.config import Settings, ThreadConfig
+
+
+class TestThreadConfig:
+    def test_defaults(self) -> None:
+        c = ThreadConfig()
+        assert c.decay_half_life_days == 7.0
+        assert c.initial_weight == 0.5
+        assert c.importance_default == 1.0
+        assert c.weight_floor == 0.05
+        assert c.enrichment_model == "claude-haiku-4-5-20251001"
+        assert c.enrichment_max_tokens == 256
+        assert c.queue_batch_size == 10
+        assert c.dsn == ""
+        assert c.dsn_env == ""
+
+    def test_custom_values(self) -> None:
+        c = ThreadConfig(
+            decay_half_life_days=14.0,
+            initial_weight=0.8,
+            queue_batch_size=5,
+        )
+        assert c.decay_half_life_days == 14.0
+        assert c.initial_weight == 0.8
+        assert c.queue_batch_size == 5
+
+
+class TestSettingsHasThreadConfig:
+    def test_settings_has_thread_field(self) -> None:
+        s = Settings()
+        assert hasattr(s, "thread")
+        assert isinstance(s.thread, ThreadConfig)
+
+    def test_thread_defaults_in_settings(self) -> None:
+        s = Settings()
+        assert s.thread.decay_half_life_days == 7.0
+        assert s.thread.queue_batch_size == 10

--- a/tests/test_ravn/test_thread_domain.py
+++ b/tests/test_ravn/test_thread_domain.py
@@ -1,0 +1,172 @@
+"""Tests for the Thread domain models (NIU-555)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from ravn.domain.thread import (
+    RavnThread,
+    ThreadStatus,
+    ThreadWeight,
+    compute_weight,
+)
+
+
+class TestRavnThreadCreate:
+    def test_generates_uuid(self) -> None:
+        t = RavnThread.create(
+            page_path="papers/foo.md",
+            title="Foo Paper",
+            weight=0.5,
+            next_action="read it",
+        )
+        assert len(t.thread_id) == 36  # UUID4 string
+        assert t.thread_id.count("-") == 4
+
+    def test_defaults(self) -> None:
+        t = RavnThread.create(
+            page_path="papers/foo.md",
+            title="Foo Paper",
+            weight=0.5,
+            next_action="read it",
+        )
+        assert t.status == ThreadStatus.OPEN
+        assert t.tags == []
+        assert t.page_path == "papers/foo.md"
+        assert t.title == "Foo Paper"
+        assert t.weight == 0.5
+        assert t.next_action == "read it"
+
+    def test_custom_tags(self) -> None:
+        t = RavnThread.create(
+            page_path="papers/foo.md",
+            title="Foo",
+            weight=0.7,
+            next_action="analyse",
+            tags=["ml", "paper"],
+        )
+        assert t.tags == ["ml", "paper"]
+
+    def test_timestamps_utc(self) -> None:
+        t = RavnThread.create(
+            page_path="papers/foo.md",
+            title="Foo",
+            weight=0.5,
+            next_action="",
+        )
+        assert t.created_at.tzinfo is not None
+        assert t.last_seen_at.tzinfo is not None
+
+
+class TestThreadStatus:
+    def test_open_value(self) -> None:
+        assert ThreadStatus.OPEN == "open"
+
+    def test_closed_value(self) -> None:
+        assert ThreadStatus.CLOSED == "closed"
+
+
+class TestComputeWeight:
+    def test_brand_new_thread_recency_near_one(self) -> None:
+        now = datetime.now(UTC)
+        tw = compute_weight(
+            base_score=0.8,
+            importance_factor=1.0,
+            created_at=now,
+            half_life_days=7.0,
+            reference_time=now,
+        )
+        # recency_factor should be very close to 1.0 for 0-day-old thread
+        assert tw.recency_factor > 0.99
+        assert abs(tw.composite - 0.8) < 0.01
+
+    def test_half_life_halves_recency(self) -> None:
+        now = datetime.now(UTC)
+        seven_days_ago = now - timedelta(days=7)
+        tw = compute_weight(
+            base_score=1.0,
+            importance_factor=1.0,
+            created_at=seven_days_ago,
+            half_life_days=7.0,
+            reference_time=now,
+        )
+        assert abs(tw.recency_factor - 0.5) < 0.01
+
+    def test_composite_formula(self) -> None:
+        now = datetime.now(UTC)
+        tw = compute_weight(
+            base_score=0.6,
+            importance_factor=0.8,
+            created_at=now,
+            half_life_days=7.0,
+            reference_time=now,
+        )
+        expected = 0.6 * 1.0 * 0.8  # recency ≈ 1.0 for brand-new
+        assert abs(tw.composite - expected) < 0.01
+
+    def test_older_thread_has_lower_weight_than_newer(self) -> None:
+        now = datetime.now(UTC)
+        tw_new = compute_weight(
+            base_score=0.5,
+            importance_factor=1.0,
+            created_at=now,
+            half_life_days=7.0,
+            reference_time=now,
+        )
+        tw_old = compute_weight(
+            base_score=0.5,
+            importance_factor=1.0,
+            created_at=now - timedelta(days=30),
+            half_life_days=7.0,
+            reference_time=now,
+        )
+        assert tw_new.composite > tw_old.composite
+
+    def test_naive_datetime_handled(self) -> None:
+        naive_dt = datetime(2025, 1, 1, 12, 0, 0)  # no tzinfo
+        now = datetime.now(UTC)
+        # Should not raise
+        tw = compute_weight(
+            base_score=0.5,
+            importance_factor=1.0,
+            created_at=naive_dt,
+            half_life_days=7.0,
+            reference_time=now,
+        )
+        assert isinstance(tw, ThreadWeight)
+        assert tw.composite >= 0.0
+
+    def test_very_old_thread_near_zero(self) -> None:
+        now = datetime.now(UTC)
+        very_old = now - timedelta(days=365)
+        tw = compute_weight(
+            base_score=1.0,
+            importance_factor=1.0,
+            created_at=very_old,
+            half_life_days=7.0,
+            reference_time=now,
+        )
+        assert tw.composite < 0.001
+
+    def test_default_reference_time(self) -> None:
+        """compute_weight uses datetime.now(UTC) when reference_time is None."""
+        now = datetime.now(UTC)
+        tw = compute_weight(
+            base_score=1.0,
+            importance_factor=1.0,
+            created_at=now,
+        )
+        assert isinstance(tw, ThreadWeight)
+
+    def test_returns_threadweight_dataclass(self) -> None:
+        now = datetime.now(UTC)
+        tw = compute_weight(
+            base_score=0.5,
+            importance_factor=0.9,
+            created_at=now,
+            reference_time=now,
+        )
+        assert isinstance(tw, ThreadWeight)
+        assert tw.base_score == 0.5
+        assert tw.importance_factor == 0.9
+        assert tw.computed_at == now

--- a/tests/test_ravn/test_thread_enrichment.py
+++ b/tests/test_ravn/test_thread_enrichment.py
@@ -1,0 +1,245 @@
+"""Tests for SjonEnrichmentAdapter (NIU-555)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from niuu.domain.mimir import MimirPage, MimirPageMeta
+from ravn.adapters.thread.enrichment import SjonEnrichmentAdapter, _parse_json
+from ravn.domain.models import LLMResponse, StopReason, TokenUsage
+from ravn.domain.thread import RavnThread, ThreadStatus
+from ravn.ports.thread import ThreadPort
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_page(
+    path: str = "papers/attention.md",
+    title: str = "Attention Is All You Need",
+    summary: str = "Transformer architecture paper",
+    content: str = "Introduces the transformer model...",
+) -> MimirPage:
+    return MimirPage(
+        meta=MimirPageMeta(
+            path=path,
+            title=title,
+            summary=summary,
+            category="papers",
+            updated_at=datetime.now(UTC),
+        ),
+        content=content,
+    )
+
+
+def _make_llm_response(payload: dict) -> LLMResponse:
+    return LLMResponse(
+        content=json.dumps(payload),
+        stop_reason=StopReason.END_TURN,
+        usage=TokenUsage(input_tokens=50, output_tokens=30),
+        tool_calls=[],
+    )
+
+
+class FakeThreadStore(ThreadPort):
+    def __init__(self) -> None:
+        self.upserted: list[RavnThread] = []
+
+    async def upsert(self, thread: RavnThread) -> None:
+        self.upserted.append(thread)
+
+    async def get(self, thread_id: str) -> RavnThread | None:
+        return None
+
+    async def get_by_path(self, page_path: str) -> RavnThread | None:
+        return None
+
+    async def peek_queue(self, *, limit: int = 10) -> list[RavnThread]:
+        return []
+
+    async def list_open(self, *, limit: int = 100) -> list[RavnThread]:
+        return []
+
+    async def close(self, thread_id: str) -> None:
+        pass
+
+    async def update_weight(self, thread_id: str, weight: float) -> None:
+        pass
+
+
+def _make_llm(response_payload: dict) -> MagicMock:
+    llm = MagicMock()
+    llm.generate = AsyncMock(return_value=_make_llm_response(response_payload))
+    return llm
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSjonEnrichmentAdapter:
+    @pytest.mark.asyncio
+    async def test_classifies_thread(self) -> None:
+        store = FakeThreadStore()
+        llm = _make_llm(
+            {
+                "is_thread": True,
+                "importance": 0.8,
+                "next_action": "read and summarise",
+                "tags": ["paper", "ml"],
+            }
+        )
+        adapter = SjonEnrichmentAdapter(llm, store)
+        page = _make_page()
+
+        result = await adapter.enrich(page)
+
+        assert result is not None
+        assert isinstance(result, RavnThread)
+        assert result.page_path == "papers/attention.md"
+        assert result.status == ThreadStatus.OPEN
+        assert result.next_action == "read and summarise"
+        assert "paper" in result.tags
+        assert len(store.upserted) == 1
+
+    @pytest.mark.asyncio
+    async def test_classifies_fact_returns_none(self) -> None:
+        store = FakeThreadStore()
+        llm = _make_llm({"is_thread": False})
+        adapter = SjonEnrichmentAdapter(llm, store)
+        page = _make_page()
+
+        result = await adapter.enrich(page)
+
+        assert result is None
+        assert len(store.upserted) == 0
+
+    @pytest.mark.asyncio
+    async def test_weight_computed(self) -> None:
+        store = FakeThreadStore()
+        llm = _make_llm({"is_thread": True, "importance": 1.0, "next_action": "act", "tags": []})
+        adapter = SjonEnrichmentAdapter(llm, store, initial_weight=0.5)
+        page = _make_page()
+
+        result = await adapter.enrich(page)
+
+        assert result is not None
+        # Weight should be in range (0, 0.5] for a brand-new page (recency ≈ 1)
+        assert 0.0 < result.weight <= 0.5 + 0.01
+
+    @pytest.mark.asyncio
+    async def test_importance_clamped(self) -> None:
+        store = FakeThreadStore()
+        llm = _make_llm(
+            {
+                "is_thread": True,
+                "importance": 999.0,  # out of range
+                "next_action": "act",
+                "tags": [],
+            }
+        )
+        adapter = SjonEnrichmentAdapter(llm, store, initial_weight=0.5)
+        page = _make_page()
+
+        result = await adapter.enrich(page)
+
+        assert result is not None
+        assert result.weight <= 0.5 + 0.01  # importance clamped to 1.0
+
+    @pytest.mark.asyncio
+    async def test_llm_failure_defaults_to_fact(self) -> None:
+        store = FakeThreadStore()
+        llm = MagicMock()
+        llm.generate = AsyncMock(side_effect=RuntimeError("LLM exploded"))
+        adapter = SjonEnrichmentAdapter(llm, store)
+        page = _make_page()
+
+        result = await adapter.enrich(page)
+
+        assert result is None
+        assert len(store.upserted) == 0
+
+    @pytest.mark.asyncio
+    async def test_llm_garbage_json_defaults_to_fact(self) -> None:
+        store = FakeThreadStore()
+        llm = MagicMock()
+        llm.generate = AsyncMock(
+            return_value=LLMResponse(
+                content="this is not json at all",
+                stop_reason=StopReason.END_TURN,
+                usage=TokenUsage(input_tokens=10, output_tokens=10),
+                tool_calls=[],
+            )
+        )
+        adapter = SjonEnrichmentAdapter(llm, store)
+        page = _make_page()
+
+        result = await adapter.enrich(page)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_llm_json_in_markdown_fence(self) -> None:
+        store = FakeThreadStore()
+        llm = MagicMock()
+        fenced = (
+            "```json\n"
+            '{"is_thread": true, "importance": 0.7, "next_action": "act", "tags": ["ml"]}'
+            "\n```"
+        )
+        llm.generate = AsyncMock(
+            return_value=LLMResponse(
+                content=fenced,
+                stop_reason=StopReason.END_TURN,
+                usage=TokenUsage(input_tokens=10, output_tokens=20),
+                tool_calls=[],
+            )
+        )
+        adapter = SjonEnrichmentAdapter(llm, store)
+        page = _make_page()
+
+        result = await adapter.enrich(page)
+
+        assert result is not None
+        assert result.tags == ["ml"]
+
+    @pytest.mark.asyncio
+    async def test_missing_next_action_defaults_empty(self) -> None:
+        store = FakeThreadStore()
+        llm = _make_llm({"is_thread": True, "importance": 0.5, "tags": []})
+        adapter = SjonEnrichmentAdapter(llm, store)
+        page = _make_page()
+
+        result = await adapter.enrich(page)
+
+        assert result is not None
+        assert result.next_action == ""
+
+
+class TestParseJson:
+    def test_valid_json(self) -> None:
+        result = _parse_json('{"is_thread": true, "importance": 0.5}')
+        assert result["is_thread"] is True
+        assert result["importance"] == 0.5
+
+    def test_fenced_json(self) -> None:
+        result = _parse_json('```json\n{"is_thread": false}\n```')
+        assert result["is_thread"] is False
+
+    def test_garbage_returns_default(self) -> None:
+        result = _parse_json("not json")
+        assert result == {"is_thread": False}
+
+    def test_json_embedded_in_text(self) -> None:
+        result = _parse_json('Some preamble {"is_thread": true} and more text')
+        assert result["is_thread"] is True
+
+    def test_empty_string_returns_default(self) -> None:
+        result = _parse_json("")
+        assert result == {"is_thread": False}

--- a/tests/test_ravn/test_thread_port.py
+++ b/tests/test_ravn/test_thread_port.py
@@ -1,0 +1,200 @@
+"""Tests for ThreadPort via an in-memory fake adapter (NIU-555).
+
+These tests verify the ThreadPort contract without touching real infrastructure.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from ravn.domain.thread import RavnThread, ThreadStatus
+from ravn.ports.thread import ThreadPort
+
+
+class FakeThreadStore(ThreadPort):
+    """In-memory implementation of ThreadPort for testing."""
+
+    def __init__(self) -> None:
+        self._threads: dict[str, RavnThread] = {}
+
+    async def upsert(self, thread: RavnThread) -> None:
+        self._threads[thread.thread_id] = thread
+
+    async def get(self, thread_id: str) -> RavnThread | None:
+        return self._threads.get(thread_id)
+
+    async def get_by_path(self, page_path: str) -> RavnThread | None:
+        for t in self._threads.values():
+            if t.page_path == page_path and t.status == ThreadStatus.OPEN:
+                return t
+        return None
+
+    async def peek_queue(self, *, limit: int = 10) -> list[RavnThread]:
+        open_threads = [t for t in self._threads.values() if t.status == ThreadStatus.OPEN]
+        open_threads.sort(key=lambda t: t.weight, reverse=True)
+        return open_threads[:limit]
+
+    async def list_open(self, *, limit: int = 100) -> list[RavnThread]:
+        open_threads = [t for t in self._threads.values() if t.status == ThreadStatus.OPEN]
+        open_threads.sort(key=lambda t: t.created_at, reverse=True)
+        return open_threads[:limit]
+
+    async def close(self, thread_id: str) -> None:
+        if thread_id in self._threads:
+            t = self._threads[thread_id]
+            self._threads[thread_id] = RavnThread(
+                thread_id=t.thread_id,
+                page_path=t.page_path,
+                title=t.title,
+                weight=t.weight,
+                next_action=t.next_action,
+                tags=t.tags,
+                status=ThreadStatus.CLOSED,
+                created_at=t.created_at,
+                last_seen_at=datetime.now(UTC),
+            )
+
+    async def update_weight(self, thread_id: str, weight: float) -> None:
+        if thread_id in self._threads:
+            t = self._threads[thread_id]
+            self._threads[thread_id] = RavnThread(
+                thread_id=t.thread_id,
+                page_path=t.page_path,
+                title=t.title,
+                weight=weight,
+                next_action=t.next_action,
+                tags=t.tags,
+                status=t.status,
+                created_at=t.created_at,
+                last_seen_at=datetime.now(UTC),
+            )
+
+
+@pytest.fixture()
+def store() -> FakeThreadStore:
+    return FakeThreadStore()
+
+
+def _make_thread(path: str = "papers/foo.md", weight: float = 0.5) -> RavnThread:
+    return RavnThread.create(
+        page_path=path,
+        title="Test Thread",
+        weight=weight,
+        next_action="do something",
+        tags=["test"],
+    )
+
+
+class TestFakeThreadStore:
+    @pytest.mark.asyncio
+    async def test_upsert_and_get(self, store: FakeThreadStore) -> None:
+        t = _make_thread()
+        await store.upsert(t)
+        result = await store.get(t.thread_id)
+        assert result is not None
+        assert result.thread_id == t.thread_id
+
+    @pytest.mark.asyncio
+    async def test_get_missing_returns_none(self, store: FakeThreadStore) -> None:
+        result = await store.get("nonexistent-id")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_by_path(self, store: FakeThreadStore) -> None:
+        t = _make_thread("papers/bar.md")
+        await store.upsert(t)
+        result = await store.get_by_path("papers/bar.md")
+        assert result is not None
+        assert result.page_path == "papers/bar.md"
+
+    @pytest.mark.asyncio
+    async def test_get_by_path_missing_returns_none(self, store: FakeThreadStore) -> None:
+        result = await store.get_by_path("nonexistent/path.md")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_peek_queue_order(self, store: FakeThreadStore) -> None:
+        low = _make_thread("low.md", weight=0.1)
+        high = _make_thread("high.md", weight=0.9)
+        mid = _make_thread("mid.md", weight=0.5)
+        await store.upsert(low)
+        await store.upsert(high)
+        await store.upsert(mid)
+
+        queue = await store.peek_queue(limit=10)
+        weights = [t.weight for t in queue]
+        assert weights == sorted(weights, reverse=True)
+
+    @pytest.mark.asyncio
+    async def test_peek_queue_respects_limit(self, store: FakeThreadStore) -> None:
+        for i in range(5):
+            await store.upsert(_make_thread(f"page{i}.md", weight=float(i) / 10))
+        queue = await store.peek_queue(limit=3)
+        assert len(queue) == 3
+
+    @pytest.mark.asyncio
+    async def test_list_open_excludes_closed(self, store: FakeThreadStore) -> None:
+        t1 = _make_thread("open.md")
+        t2 = _make_thread("closed.md")
+        await store.upsert(t1)
+        await store.upsert(t2)
+        await store.close(t2.thread_id)
+
+        open_list = await store.list_open()
+        paths = [t.page_path for t in open_list]
+        assert "open.md" in paths
+        assert "closed.md" not in paths
+
+    @pytest.mark.asyncio
+    async def test_close_changes_status(self, store: FakeThreadStore) -> None:
+        t = _make_thread()
+        await store.upsert(t)
+        await store.close(t.thread_id)
+        result = await store.get(t.thread_id)
+        assert result is not None
+        assert result.status == ThreadStatus.CLOSED
+
+    @pytest.mark.asyncio
+    async def test_update_weight(self, store: FakeThreadStore) -> None:
+        t = _make_thread(weight=0.5)
+        await store.upsert(t)
+        await store.update_weight(t.thread_id, 0.9)
+        result = await store.get(t.thread_id)
+        assert result is not None
+        assert result.weight == 0.9
+
+    @pytest.mark.asyncio
+    async def test_peek_queue_excludes_closed(self, store: FakeThreadStore) -> None:
+        open_t = _make_thread("open.md", weight=0.9)
+        closed_t = _make_thread("closed.md", weight=1.0)
+        await store.upsert(open_t)
+        await store.upsert(closed_t)
+        await store.close(closed_t.thread_id)
+
+        queue = await store.peek_queue()
+        ids = [t.thread_id for t in queue]
+        assert open_t.thread_id in ids
+        assert closed_t.thread_id not in ids
+
+    @pytest.mark.asyncio
+    async def test_upsert_overwrites(self, store: FakeThreadStore) -> None:
+        t = _make_thread(weight=0.5)
+        await store.upsert(t)
+        updated = RavnThread(
+            thread_id=t.thread_id,
+            page_path=t.page_path,
+            title="Updated Title",
+            weight=0.8,
+            next_action="updated action",
+            tags=["updated"],
+            status=t.status,
+            created_at=t.created_at,
+            last_seen_at=t.last_seen_at,
+        )
+        await store.upsert(updated)
+        result = await store.get(t.thread_id)
+        assert result is not None
+        assert result.title == "Updated Title"
+        assert result.weight == 0.8

--- a/tests/test_ravn/test_thread_postgres_adapter.py
+++ b/tests/test_ravn/test_thread_postgres_adapter.py
@@ -1,0 +1,283 @@
+"""Tests for PostgresThreadAdapter (NIU-555).
+
+Helper tests cover pure Python functions without a real DB.
+Adapter tests mock asyncpg connection pool per project rules.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ravn.adapters.thread.postgres import (
+    PostgresThreadAdapter,
+    _parse_tags,
+    _parse_ts,
+    _row_to_thread,
+)
+from ravn.domain.thread import RavnThread, ThreadStatus
+
+
+class _FakeRow(dict):
+    """Minimal asyncpg-like row (dict subclass)."""
+
+
+class TestParseTags:
+    def test_list_passthrough(self) -> None:
+        assert _parse_tags(["ml", "paper"]) == ["ml", "paper"]
+
+    def test_json_string_decoded(self) -> None:
+        assert _parse_tags('["ml", "paper"]') == ["ml", "paper"]
+
+    def test_empty_json_string(self) -> None:
+        assert _parse_tags("[]") == []
+
+    def test_none_returns_empty(self) -> None:
+        assert _parse_tags(None) == []
+
+
+class TestParseTs:
+    def test_naive_datetime_gets_utc(self) -> None:
+        naive = datetime(2025, 1, 1, 0, 0, 0)
+        result = _parse_ts(naive)
+        assert result.tzinfo is not None
+
+    def test_aware_datetime_unchanged(self) -> None:
+        aware = datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC)
+        result = _parse_ts(aware)
+        assert result == aware
+
+
+class TestRowToThread:
+    def _make_row(self, **overrides: object) -> _FakeRow:
+        now = datetime.now(UTC)
+        defaults = {
+            "thread_id": "test-uuid",
+            "page_path": "papers/foo.md",
+            "title": "Test Thread",
+            "weight": 0.7,
+            "next_action": "read it",
+            "tags": ["paper"],
+            "status": "open",
+            "created_at": now,
+            "last_seen_at": now,
+        }
+        defaults.update(overrides)
+        return _FakeRow(defaults)
+
+    def test_basic_row(self) -> None:
+        row = self._make_row()
+        thread = _row_to_thread(row)
+        assert thread.thread_id == "test-uuid"
+        assert thread.page_path == "papers/foo.md"
+        assert thread.title == "Test Thread"
+        assert thread.weight == 0.7
+        assert thread.next_action == "read it"
+        assert thread.tags == ["paper"]
+        assert thread.status == ThreadStatus.OPEN
+
+    def test_closed_status(self) -> None:
+        row = self._make_row(status="closed")
+        thread = _row_to_thread(row)
+        assert thread.status == ThreadStatus.CLOSED
+
+    def test_empty_title_defaults(self) -> None:
+        row = self._make_row(title="")
+        thread = _row_to_thread(row)
+        assert thread.title == ""
+
+    def test_json_string_tags(self) -> None:
+        row = self._make_row(tags='["ml", "research"]')
+        thread = _row_to_thread(row)
+        assert thread.tags == ["ml", "research"]
+
+    def test_naive_timestamps_get_utc(self) -> None:
+        naive = datetime(2025, 6, 1, 12, 0, 0)
+        row = self._make_row(created_at=naive, last_seen_at=naive)
+        thread = _row_to_thread(row)
+        assert thread.created_at.tzinfo is not None
+        assert thread.last_seen_at.tzinfo is not None
+
+    def test_float_weight(self) -> None:
+        row = self._make_row(weight=0.123456)
+        thread = _row_to_thread(row)
+        assert abs(thread.weight - 0.123456) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# Mock-based adapter tests (no real PostgreSQL connection)
+# ---------------------------------------------------------------------------
+
+
+def _make_thread(path: str = "papers/foo.md", weight: float = 0.5) -> RavnThread:
+    return RavnThread.create(
+        page_path=path,
+        title="Test Thread",
+        weight=weight,
+        next_action="read it",
+        tags=["test"],
+    )
+
+
+def _make_fake_pool(rows: list | None = None, row: object | None = None) -> MagicMock:
+    """Build a fake asyncpg pool that returns predetermined results."""
+    conn = MagicMock()
+    conn.execute = AsyncMock(return_value=None)
+    conn.fetchrow = AsyncMock(return_value=row)
+    conn.fetch = AsyncMock(return_value=rows or [])
+
+    pool = MagicMock()
+    pool.acquire = MagicMock()
+    pool.acquire.return_value.__aenter__ = AsyncMock(return_value=conn)
+    pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+    return pool, conn
+
+
+class TestPostgresThreadAdapter:
+    def _make_row(self, **overrides: object) -> dict:
+        now = datetime.now(UTC)
+        defaults = {
+            "thread_id": "test-uuid",
+            "page_path": "papers/foo.md",
+            "title": "Test Thread",
+            "weight": 0.7,
+            "next_action": "read it",
+            "tags": ["test"],
+            "status": "open",
+            "created_at": now,
+            "last_seen_at": now,
+        }
+        defaults.update(overrides)
+        return defaults
+
+    @pytest.mark.asyncio
+    async def test_upsert_calls_execute(self) -> None:
+        pool, conn = _make_fake_pool()
+        adapter = PostgresThreadAdapter(dsn="postgresql://fake/db")
+        adapter._pool = pool
+
+        t = _make_thread()
+        await adapter.upsert(t)
+
+        conn.execute.assert_called_once()
+        args = conn.execute.call_args[0]
+        assert t.thread_id in args
+
+    @pytest.mark.asyncio
+    async def test_get_returns_thread(self) -> None:
+        row = self._make_row()
+        pool, conn = _make_fake_pool(row=row)
+        adapter = PostgresThreadAdapter(dsn="postgresql://fake/db")
+        adapter._pool = pool
+
+        result = await adapter.get("test-uuid")
+        assert result is not None
+        assert result.thread_id == "test-uuid"
+
+    @pytest.mark.asyncio
+    async def test_get_returns_none_when_missing(self) -> None:
+        pool, conn = _make_fake_pool(row=None)
+        adapter = PostgresThreadAdapter(dsn="postgresql://fake/db")
+        adapter._pool = pool
+
+        result = await adapter.get("nonexistent")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_by_path_returns_thread(self) -> None:
+        row = self._make_row(page_path="papers/bar.md")
+        pool, conn = _make_fake_pool(row=row)
+        adapter = PostgresThreadAdapter(dsn="postgresql://fake/db")
+        adapter._pool = pool
+
+        result = await adapter.get_by_path("papers/bar.md")
+        assert result is not None
+        assert result.page_path == "papers/bar.md"
+
+    @pytest.mark.asyncio
+    async def test_get_by_path_returns_none(self) -> None:
+        pool, conn = _make_fake_pool(row=None)
+        adapter = PostgresThreadAdapter(dsn="postgresql://fake/db")
+        adapter._pool = pool
+
+        result = await adapter.get_by_path("nonexistent")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_peek_queue_returns_threads(self) -> None:
+        rows = [self._make_row(thread_id=f"id-{i}", weight=float(i) / 10) for i in range(3)]
+        pool, conn = _make_fake_pool(rows=rows)
+        adapter = PostgresThreadAdapter(dsn="postgresql://fake/db")
+        adapter._pool = pool
+
+        result = await adapter.peek_queue(limit=3)
+        assert len(result) == 3
+
+    @pytest.mark.asyncio
+    async def test_list_open_returns_threads(self) -> None:
+        rows = [self._make_row(thread_id=f"id-{i}") for i in range(2)]
+        pool, conn = _make_fake_pool(rows=rows)
+        adapter = PostgresThreadAdapter(dsn="postgresql://fake/db")
+        adapter._pool = pool
+
+        result = await adapter.list_open(limit=10)
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_close_calls_execute(self) -> None:
+        pool, conn = _make_fake_pool()
+        adapter = PostgresThreadAdapter(dsn="postgresql://fake/db")
+        adapter._pool = pool
+
+        await adapter.close("test-uuid")
+        conn.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_update_weight_calls_execute(self) -> None:
+        pool, conn = _make_fake_pool()
+        adapter = PostgresThreadAdapter(dsn="postgresql://fake/db")
+        adapter._pool = pool
+
+        await adapter.update_weight("test-uuid", 0.9)
+        conn.execute.assert_called_once()
+        args = conn.execute.call_args[0]
+        assert 0.9 in args
+
+    @pytest.mark.asyncio
+    async def test_ensure_pool_creates_pool(self) -> None:
+        """_ensure_pool lazy-creates the asyncpg pool."""
+        import sys
+
+        adapter = PostgresThreadAdapter(dsn="postgresql://fake/db")
+        assert adapter._pool is None
+
+        fake_pool = MagicMock()
+        fake_conn = MagicMock()
+        fake_conn.execute = AsyncMock()
+        fake_pool.acquire = MagicMock()
+        fake_pool.acquire.return_value.__aenter__ = AsyncMock(return_value=fake_conn)
+        fake_pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        mock_asyncpg = MagicMock()
+        mock_asyncpg.create_pool = AsyncMock(return_value=fake_pool)
+
+        with patch.dict(sys.modules, {"asyncpg": mock_asyncpg}):
+            result = await adapter._ensure_pool()
+
+        assert result is fake_pool
+        assert adapter._pool is fake_pool
+        mock_asyncpg.create_pool.assert_called_once_with("postgresql://fake/db")
+
+    @pytest.mark.asyncio
+    async def test_ensure_pool_reuses_existing(self) -> None:
+        """_ensure_pool returns existing pool without re-creating."""
+        adapter = PostgresThreadAdapter(dsn="postgresql://fake/db")
+        existing_pool = MagicMock()
+        adapter._pool = existing_pool
+
+        # When pool already exists, _ensure_pool returns it immediately
+        result = await adapter._ensure_pool()
+
+        assert result is existing_pool

--- a/tests/test_ravn/test_thread_queue_trigger.py
+++ b/tests/test_ravn/test_thread_queue_trigger.py
@@ -1,0 +1,187 @@
+"""Tests for ThreadQueueTrigger (NIU-555)."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ravn.adapters.thread.queue_trigger import ThreadQueueTrigger
+from ravn.domain.models import AgentTask
+from ravn.domain.thread import RavnThread, ThreadStatus
+from ravn.ports.thread import ThreadPort
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class FakeThreadStore(ThreadPort):
+    def __init__(self, threads: list[RavnThread] | None = None) -> None:
+        self._threads: dict[str, RavnThread] = {t.thread_id: t for t in (threads or [])}
+        self.closed: list[str] = []
+        self.weight_updates: dict[str, float] = {}
+
+    async def upsert(self, thread: RavnThread) -> None:
+        self._threads[thread.thread_id] = thread
+
+    async def get(self, thread_id: str) -> RavnThread | None:
+        return self._threads.get(thread_id)
+
+    async def get_by_path(self, page_path: str) -> RavnThread | None:
+        return None
+
+    async def peek_queue(self, *, limit: int = 10) -> list[RavnThread]:
+        open_t = [t for t in self._threads.values() if t.status == ThreadStatus.OPEN]
+        open_t.sort(key=lambda t: t.weight, reverse=True)
+        return open_t[:limit]
+
+    async def list_open(self, *, limit: int = 100) -> list[RavnThread]:
+        return [t for t in self._threads.values() if t.status == ThreadStatus.OPEN]
+
+    async def close(self, thread_id: str) -> None:
+        self.closed.append(thread_id)
+        if thread_id in self._threads:
+            t = self._threads[thread_id]
+            self._threads[thread_id] = RavnThread(
+                thread_id=t.thread_id,
+                page_path=t.page_path,
+                title=t.title,
+                weight=t.weight,
+                next_action=t.next_action,
+                tags=t.tags,
+                status=ThreadStatus.CLOSED,
+                created_at=t.created_at,
+                last_seen_at=datetime.now(UTC),
+            )
+
+    async def update_weight(self, thread_id: str, weight: float) -> None:
+        self.weight_updates[thread_id] = weight
+
+
+def _make_thread(
+    path: str = "papers/foo.md",
+    weight: float = 0.5,
+    age_days: float = 0,
+) -> RavnThread:
+    now = datetime.now(UTC)
+    created = now - timedelta(days=age_days)
+    t = RavnThread.create(
+        page_path=path,
+        title="Test Thread",
+        weight=weight,
+        next_action="do something",
+        tags=["test"],
+    )
+    return RavnThread(
+        thread_id=t.thread_id,
+        page_path=t.page_path,
+        title=t.title,
+        weight=t.weight,
+        next_action=t.next_action,
+        tags=t.tags,
+        status=t.status,
+        created_at=created,
+        last_seen_at=created,
+    )
+
+
+class TestThreadQueueTrigger:
+    def test_name(self) -> None:
+        store = FakeThreadStore()
+        trigger = ThreadQueueTrigger(store)
+        assert trigger.name == "thread_queue"
+
+    @pytest.mark.asyncio
+    async def test_sweep_enqueues_open_threads(self) -> None:
+        t = _make_thread(weight=0.8)
+        store = FakeThreadStore([t])
+        trigger = ThreadQueueTrigger(store, weight_floor=0.01, half_life_days=7.0)
+
+        enqueued: list[AgentTask] = []
+
+        async def enqueue(task: AgentTask) -> None:
+            enqueued.append(task)
+
+        await trigger._sweep(enqueue)
+
+        assert len(enqueued) == 1
+        assert "Test Thread" in enqueued[0].title
+        assert enqueued[0].triggered_by == "thread_queue"
+
+    @pytest.mark.asyncio
+    async def test_sweep_closes_decayed_threads(self) -> None:
+        # Very old thread should have near-zero composite weight
+        old = _make_thread(weight=0.5, age_days=365)
+        store = FakeThreadStore([old])
+        trigger = ThreadQueueTrigger(
+            store,
+            weight_floor=0.05,
+            half_life_days=7.0,
+        )
+
+        enqueued: list[AgentTask] = []
+
+        async def enqueue(task: AgentTask) -> None:
+            enqueued.append(task)
+
+        await trigger._sweep(enqueue)
+
+        # 365-day-old thread at 7-day half-life → weight ≈ 0 → should be closed
+        assert old.thread_id in store.closed
+        assert len(enqueued) == 0
+
+    @pytest.mark.asyncio
+    async def test_sweep_updates_weight(self) -> None:
+        t = _make_thread(weight=0.9, age_days=1)
+        store = FakeThreadStore([t])
+        trigger = ThreadQueueTrigger(store, weight_floor=0.001, half_life_days=7.0)
+
+        await trigger._sweep(AsyncMock())
+
+        assert t.thread_id in store.weight_updates
+
+    @pytest.mark.asyncio
+    async def test_sweep_tolerates_peek_failure(self) -> None:
+        store = FakeThreadStore()
+        store.peek_queue = AsyncMock(side_effect=RuntimeError("db down"))
+        trigger = ThreadQueueTrigger(store)
+
+        # Should not raise
+        await trigger._sweep(AsyncMock())
+
+    @pytest.mark.asyncio
+    async def test_run_calls_sweep_after_interval(self) -> None:
+        store = FakeThreadStore([_make_thread(weight=0.8)])
+        trigger = ThreadQueueTrigger(store, interval_seconds=0.01, weight_floor=0.001)
+
+        enqueued: list[AgentTask] = []
+        count = 0
+
+        async def enqueue(task: AgentTask) -> None:
+            nonlocal count
+            count += 1
+            enqueued.append(task)
+
+        async def run_briefly() -> None:
+            task = asyncio.create_task(trigger.run(enqueue))
+            await asyncio.sleep(0.05)  # allow a few cycles
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        await run_briefly()
+        assert count >= 1
+
+    @pytest.mark.asyncio
+    async def test_empty_queue_no_enqueue(self) -> None:
+        store = FakeThreadStore()
+        trigger = ThreadQueueTrigger(store)
+
+        enqueued: list[AgentTask] = []
+        await trigger._sweep(lambda t: enqueued.append(t))
+        assert enqueued == []


### PR DESCRIPTION
## Summary

Implements the thread memory data model and infrastructure required by the Vaka wakefulness feature (M1). **No behavioral change to the Ravn drive loop** — this milestone wires the plumbing so M2 can activate autonomous thread processing by setting `initiative.enabled = true`.

### What changed

- **`src/ravn/domain/thread.py`** — `RavnThread` dataclass, `ThreadStatus` enum, `ThreadWeight` value-object, and `compute_weight()` with exponential recency decay
- **`src/ravn/ports/thread.py`** — `ThreadPort` abstract interface (upsert, get, get_by_path, peek_queue, list_open, close, update_weight)
- **`src/ravn/adapters/thread/postgres.py`** — `PostgresThreadAdapter` — raw SQL with asyncpg, lazy pool, DDL bootstrap for dev/test
- **`src/ravn/adapters/thread/enrichment.py`** — `SjonEnrichmentAdapter` — classifies Mímir pages as threads vs. facts via cheap LLM call; tolerates JSON in markdown fences and LLM failures
- **`src/ravn/adapters/thread/queue_trigger.py`** — `ThreadQueueTrigger` (TriggerPort) — sweeps the weighted queue, auto-closes decayed threads, enqueues survivors as AgentTask
- **`src/ravn/config.py`** — `ThreadConfig` added; wired into `Settings.thread`
- **`migrations/000032_ravn_threads.{up,down}.sql`** + Helm configmap updated

### Thread weight decay

```
weight = base_score × exp(-ln(2)/half_life_days × days_old) × importance_factor
```

Default half-life is 7 days; a thread ingested 7 days ago has half the recency factor of a brand-new thread.

## Test plan

- [x] 72 tests, 98% coverage on new code
- [x] ruff check + ruff format clean
- [x] Domain model tests: weight decay formula, half-life math, edge cases
- [x] Port tests: FakeThreadStore verifies full contract
- [x] Enrichment tests: LLM classification, JSON fence parsing, error fallback
- [x] Queue trigger tests: sweep logic, decay auto-close, interval firing
- [x] Postgres adapter tests: mock-based (no Docker per project rules)
- [x] Config tests: ThreadConfig defaults, Settings.thread field

🤖 Generated with [Claude Code](https://claude.com/claude-code)