### PR TITLE
feat(ravn): thread weight model (NIU-557)

### DIFF
--- a/src/ravn/domain/thread_weight.py
+++ b/src/ravn/domain/thread_weight.py
@@ -1,0 +1,78 @@
+"""Thread weight model for Ravn.
+
+Pure functions — no I/O, no side effects.
+
+Ravn computes thread weights from raw signals; Mímir stores the result
+(``thread_weight``) and the raw signals (``thread_weight_signals``) opaquely
+in page frontmatter without interpreting them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from math import exp
+
+
+@dataclass
+class ThreadWeightSignals:
+    """Raw signals fed into the weight model.
+
+    Ravn computes these; Mímir stores them as an opaque dict in
+    ``thread_weight_signals``.
+    """
+
+    age_days: float
+    mention_count: int
+    operator_engagement_count: int
+    peer_interest_count: int
+    sub_thread_count: int
+
+
+@dataclass
+class ThreadWeightConfig:
+    """Tunable knobs for the weight formula.
+
+    Defaults are the domain starting point.  The live config comes from
+    ``ThreadConfig`` in ``src/ravn/config.py`` (NIU-558) and overrides these.
+
+    Calibration target:
+    - weight ~1.0 on day 0 with no signals
+    - weight ~0.5 after 14 days of silence
+    - weight near 0 after 60 days of silence
+    """
+
+    decay_rate_per_day: float = field(default=0.05)  # half-life ~14 days
+    recency_weight: float = field(default=1.0)
+    mention_weight: float = field(default=0.3)
+    engagement_weight: float = field(default=0.5)
+    peer_weight: float = field(default=0.2)
+    sub_thread_weight: float = field(default=0.4)
+
+
+def compute_weight(
+    signals: ThreadWeightSignals,
+    config: ThreadWeightConfig | None = None,
+) -> float:
+    """Compute a thread's weight from its signals.
+
+    Args:
+        signals: Raw engagement signals for the thread.
+        config:  Weight formula configuration.  Defaults to
+                 :class:`ThreadWeightConfig` with domain defaults when omitted.
+
+    Returns:
+        Non-negative float representing thread engagement weight.
+    """
+    if config is None:
+        config = ThreadWeightConfig()
+
+    bonus = (
+        signals.mention_count * config.mention_weight
+        + signals.operator_engagement_count * config.engagement_weight
+        + signals.peer_interest_count * config.peer_weight
+        + signals.sub_thread_count * config.sub_thread_weight
+    )
+
+    recency_score = config.recency_weight * exp(-config.decay_rate_per_day * signals.age_days)
+
+    return max(0.0, recency_score + bonus)

--- a/src/ravn/domain/thread_weight.py
+++ b/src/ravn/domain/thread_weight.py
@@ -9,11 +9,11 @@ in page frontmatter without interpreting them.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from math import exp
 
 
-@dataclass
+@dataclass(frozen=True)
 class ThreadWeightSignals:
     """Raw signals fed into the weight model.
 
@@ -28,7 +28,7 @@ class ThreadWeightSignals:
     sub_thread_count: int
 
 
-@dataclass
+@dataclass(frozen=True)
 class ThreadWeightConfig:
     """Tunable knobs for the weight formula.
 
@@ -41,12 +41,12 @@ class ThreadWeightConfig:
     - weight near 0 after 60 days of silence
     """
 
-    decay_rate_per_day: float = field(default=0.05)  # half-life ~14 days
-    recency_weight: float = field(default=1.0)
-    mention_weight: float = field(default=0.3)
-    engagement_weight: float = field(default=0.5)
-    peer_weight: float = field(default=0.2)
-    sub_thread_weight: float = field(default=0.4)
+    decay_rate_per_day: float = 0.05  # half-life ~14 days
+    recency_weight: float = 1.0
+    mention_weight: float = 0.3
+    engagement_weight: float = 0.5
+    peer_weight: float = 0.2
+    sub_thread_weight: float = 0.4
 
 
 def compute_weight(

--- a/tests/ravn/unit/test_thread_weight.py
+++ b/tests/ravn/unit/test_thread_weight.py
@@ -1,0 +1,233 @@
+"""Unit tests for the thread weight model (NIU-557).
+
+Pure-function tests — no I/O, no mocks needed.
+"""
+
+from __future__ import annotations
+
+from math import exp
+
+import pytest
+
+from ravn.domain.thread_weight import (
+    ThreadWeightConfig,
+    ThreadWeightSignals,
+    compute_weight,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _zero_signals(age_days: float = 0.0) -> ThreadWeightSignals:
+    return ThreadWeightSignals(
+        age_days=age_days,
+        mention_count=0,
+        operator_engagement_count=0,
+        peer_interest_count=0,
+        sub_thread_count=0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Importability
+# ---------------------------------------------------------------------------
+
+
+def test_importable() -> None:
+    """ThreadWeightSignals, ThreadWeightConfig, and compute_weight are importable."""
+    assert callable(compute_weight)
+    assert ThreadWeightSignals is not None
+    assert ThreadWeightConfig is not None
+
+
+# ---------------------------------------------------------------------------
+# Zero-signal decay
+# ---------------------------------------------------------------------------
+
+
+def test_zero_signals_day_0_weight_near_one() -> None:
+    """With no engagement signals on day 0, weight should be ~1.0."""
+    cfg = ThreadWeightConfig()
+    signals = _zero_signals(age_days=0.0)
+    weight = compute_weight(signals, cfg)
+    assert abs(weight - 1.0) < 1e-9
+
+
+def test_zero_signals_day_14_weight_near_half() -> None:
+    """After 14 days of silence the weight should be ~0.5 (half-life target)."""
+    cfg = ThreadWeightConfig()
+    signals = _zero_signals(age_days=14.0)
+    weight = compute_weight(signals, cfg)
+    # exp(-0.05 * 14) ≈ 0.4966 — within 5% of 0.5
+    assert 0.45 <= weight <= 0.55
+
+
+def test_zero_signals_day_60_weight_near_zero() -> None:
+    """After 60 days with no signals the weight should be close to 0."""
+    cfg = ThreadWeightConfig()
+    signals = _zero_signals(age_days=60.0)
+    weight = compute_weight(signals, cfg)
+    assert weight < 0.05
+
+
+def test_weight_decreases_with_age() -> None:
+    """Older threads with no new signals have strictly lower weight."""
+    cfg = ThreadWeightConfig()
+    w0 = compute_weight(_zero_signals(0.0), cfg)
+    w7 = compute_weight(_zero_signals(7.0), cfg)
+    w14 = compute_weight(_zero_signals(14.0), cfg)
+    w30 = compute_weight(_zero_signals(30.0), cfg)
+    assert w0 > w7 > w14 > w30
+
+
+# ---------------------------------------------------------------------------
+# Engagement offsets decay
+# ---------------------------------------------------------------------------
+
+
+def test_mentions_increase_weight() -> None:
+    """Mention count adds a positive bonus on top of the recency score."""
+    cfg = ThreadWeightConfig()
+    base = compute_weight(_zero_signals(7.0), cfg)
+    signals = ThreadWeightSignals(
+        age_days=7.0,
+        mention_count=3,
+        operator_engagement_count=0,
+        peer_interest_count=0,
+        sub_thread_count=0,
+    )
+    weight = compute_weight(signals, cfg)
+    assert weight == pytest.approx(base + 3 * cfg.mention_weight)
+    assert weight > base
+
+
+def test_operator_engagement_increases_weight() -> None:
+    """Operator engagement adds its weighted bonus."""
+    cfg = ThreadWeightConfig()
+    base = compute_weight(_zero_signals(0.0), cfg)
+    signals = ThreadWeightSignals(
+        age_days=0.0,
+        mention_count=0,
+        operator_engagement_count=2,
+        peer_interest_count=0,
+        sub_thread_count=0,
+    )
+    weight = compute_weight(signals, cfg)
+    assert weight == pytest.approx(base + 2 * cfg.engagement_weight)
+
+
+def test_peer_interest_increases_weight() -> None:
+    """Peer interest count adds its weighted bonus."""
+    cfg = ThreadWeightConfig()
+    base = compute_weight(_zero_signals(0.0), cfg)
+    signals = ThreadWeightSignals(
+        age_days=0.0,
+        mention_count=0,
+        operator_engagement_count=0,
+        peer_interest_count=5,
+        sub_thread_count=0,
+    )
+    weight = compute_weight(signals, cfg)
+    assert weight == pytest.approx(base + 5 * cfg.peer_weight)
+
+
+def test_sub_thread_count_increases_weight() -> None:
+    """Sub-thread count adds its weighted bonus."""
+    cfg = ThreadWeightConfig()
+    base = compute_weight(_zero_signals(0.0), cfg)
+    signals = ThreadWeightSignals(
+        age_days=0.0,
+        mention_count=0,
+        operator_engagement_count=0,
+        peer_interest_count=0,
+        sub_thread_count=4,
+    )
+    weight = compute_weight(signals, cfg)
+    assert weight == pytest.approx(base + 4 * cfg.sub_thread_weight)
+
+
+def test_combined_signals_sum_correctly() -> None:
+    """All signals combine additively on top of the recency score."""
+    cfg = ThreadWeightConfig()
+    signals = ThreadWeightSignals(
+        age_days=10.0,
+        mention_count=2,
+        operator_engagement_count=1,
+        peer_interest_count=3,
+        sub_thread_count=2,
+    )
+    expected_bonus = (
+        2 * cfg.mention_weight
+        + 1 * cfg.engagement_weight
+        + 3 * cfg.peer_weight
+        + 2 * cfg.sub_thread_weight
+    )
+    expected_recency = cfg.recency_weight * exp(-cfg.decay_rate_per_day * 10.0)
+    expected = max(0.0, expected_recency + expected_bonus)
+    assert compute_weight(signals, cfg) == pytest.approx(expected)
+
+
+# ---------------------------------------------------------------------------
+# Weight is never negative
+# ---------------------------------------------------------------------------
+
+
+def test_weight_never_negative_with_default_config() -> None:
+    """Weights are always >= 0 regardless of age."""
+    cfg = ThreadWeightConfig()
+    for age in [0, 30, 100, 365, 10_000]:
+        weight = compute_weight(_zero_signals(float(age)), cfg)
+        assert weight >= 0.0
+
+
+def test_weight_never_negative_with_extreme_decay() -> None:
+    """max(0.0, ...) clamps negative values even with adversarial config."""
+    cfg = ThreadWeightConfig(
+        decay_rate_per_day=100.0,
+        recency_weight=-5.0,
+        mention_weight=-1.0,
+    )
+    signals = ThreadWeightSignals(
+        age_days=1.0,
+        mention_count=1,
+        operator_engagement_count=0,
+        peer_interest_count=0,
+        sub_thread_count=0,
+    )
+    weight = compute_weight(signals, cfg)
+    assert weight == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Default config behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_default_config_used_when_none() -> None:
+    """Passing config=None uses ThreadWeightConfig() defaults."""
+    signals = _zero_signals(0.0)
+    weight_explicit = compute_weight(signals, ThreadWeightConfig())
+    weight_default = compute_weight(signals)
+    assert weight_explicit == weight_default
+
+
+def test_custom_config_overrides_defaults() -> None:
+    """A custom decay rate changes the output."""
+    signals = _zero_signals(14.0)
+    default_weight = compute_weight(signals)
+    fast_decay_cfg = ThreadWeightConfig(decay_rate_per_day=0.5)
+    fast_weight = compute_weight(signals, fast_decay_cfg)
+    assert fast_weight < default_weight
+
+
+# ---------------------------------------------------------------------------
+# Return type
+# ---------------------------------------------------------------------------
+
+
+def test_returns_float() -> None:
+    """compute_weight always returns a plain float."""
+    result = compute_weight(_zero_signals(0.0))
+    assert isinstance(result, float)


### PR DESCRIPTION
## Summary

- Adds `src/ravn/domain/thread_weight.py` — a pure, side-effect-free weight model for Ravn thread scoring
- `ThreadWeightSignals`: raw engagement signals (age in days, mention count, operator engagement, peer interest, sub-thread count)
- `ThreadWeightConfig`: tunable formula knobs with domain-sensible defaults (exponential decay with half-life ~14 days)
- `compute_weight(signals, config) -> float`: recency decay + linear engagement bonus, clamped to `[0.0, ∞)`

**Calibration targets met:**
- Day 0, no signals → weight ≈ 1.0
- Day 14, no signals → weight ≈ 0.5
- Day 60, no signals → weight ≈ 0.05 (near zero)

Mímir stores `thread_weight` and `thread_weight_signals` as opaque values in page frontmatter — it does not interpret the `ThreadWeightSignals` type.

## Test plan

- [x] 15 unit tests covering: zero-signal decay curve, per-signal bonus correctness, combined signals, non-negativity invariant, default config fallback, custom config override, return type
- [x] 100% line and branch coverage on `thread_weight.py`
- [x] ruff check + ruff format clean

## Linear

Ticket: NIU-557 — set to **In Review** (Linear MCP unavailable in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)