### PR TITLE
feat(config): add ThreadConfig for wakefulness thread queue (NIU-558)

### DIFF
--- a/ravn.example.yaml
+++ b/ravn.example.yaml
@@ -1,0 +1,70 @@
+# ravn.example.yaml — Ravn application configuration reference
+#
+# Copy this file to one of the default search paths and edit to taste:
+#   ~/.ravn/config.yaml  (recommended for personal installs)
+#   ./ravn.yaml          (project-level override)
+#   /etc/ravn/config.yaml (system-wide)
+#
+# Override with RAVN_CONFIG env var to point to a custom path.
+#
+# Environment variable override format (RAVN_ prefix, __ for nesting):
+#   RAVN_ANTHROPIC__API_KEY=...
+#   RAVN_LLM__MODEL=claude-opus-4-6
+#   RAVN_THREAD__ENABLED=true
+#
+# Precedence (highest to lowest): env vars > yaml file > defaults
+
+# ---------------------------------------------------------------------------
+# Anthropic API
+# ---------------------------------------------------------------------------
+# anthropic:
+#   api_key: ""          # prefer ANTHROPIC_API_KEY env var
+#   base_url: "https://api.anthropic.com"
+
+# ---------------------------------------------------------------------------
+# LLM
+# ---------------------------------------------------------------------------
+# llm:
+#   model: claude-sonnet-4-6
+#   max_tokens: 8192
+#   max_retries: 3
+#   timeout: 120
+
+# ---------------------------------------------------------------------------
+# Thread enrichment queue (NIU-558)
+#
+# The thread enricher scores Mímir pages and queues them for wakefulness
+# processing.  It is DISABLED by default (M1 safe).  M2 sets enabled: true.
+#
+# All weight fields contribute to the composite thread score:
+#   score = (recency_weight * recency_signal)
+#         + (mention_weight * mention_signal)
+#         + (engagement_weight * engagement_signal)
+#         + (peer_weight * peer_signal)
+#         + (sub_thread_weight * sub_thread_signal)
+#   score *= exp(-decay_rate_per_day * days_since_last_activity)
+# ---------------------------------------------------------------------------
+# thread:
+#   enabled: false                      # flip to true in M2 deployment YAML
+#   max_queue_size: 200
+#   enricher_poll_interval_seconds: 300 # check Mímir every 5 minutes
+#   enricher_llm_alias: fast            # use cheapest/fastest model alias
+#   decay_rate_per_day: 0.05
+#   recency_weight: 1.0
+#   mention_weight: 0.3
+#   engagement_weight: 0.5
+#   peer_weight: 0.2
+#   sub_thread_weight: 0.4
+#   owner_id: null                      # defaults to this instance's own ID
+
+# ---------------------------------------------------------------------------
+# Memory
+# ---------------------------------------------------------------------------
+# memory:
+#   backend: sqlite
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+# logging:
+#   level: info

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -1414,8 +1414,7 @@ class MimirStalenessTriggerConfig(BaseModel):
     max_tokens: int | None = Field(
         default=4096,
         description=(
-            "Maximum output tokens for staleness refresh tasks. "
-            "None uses the LLM/settings default."
+            "Maximum output tokens for staleness refresh tasks. None uses the LLM/settings default."
         ),
     )
 
@@ -1763,6 +1762,79 @@ class CheckpointConfig(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# NIU-558: Thread enrichment config
+# ---------------------------------------------------------------------------
+
+
+class ThreadConfig(BaseModel):
+    """Thread enrichment queue configuration (NIU-558).
+
+    Controls the background enricher that scores and prioritises Mímir pages
+    into the wakefulness thread queue.  Disabled by default — M2 activates
+    it by setting ``thread.enabled: true`` in the deployment YAML.
+
+    All timing values and weight coefficients are overridable via environment
+    variables (``RAVN_THREAD__DECAY_RATE_PER_DAY``, etc.) or the ``thread:``
+    section of ``ravn.yaml``.
+    """
+
+    enabled: bool = Field(
+        default=False,
+        description=(
+            "Enable the thread enricher.  Off until M2 activates the trigger; "
+            "flip to true in the deployment ravn.yaml to start queueing."
+        ),
+    )
+    max_queue_size: int = Field(
+        default=200,
+        description="Maximum number of entries held in the wakefulness thread queue.",
+    )
+    enricher_poll_interval_seconds: int = Field(
+        default=300,
+        description="How often (seconds) the enricher checks Mímir for new pages.",
+    )
+    enricher_llm_alias: str = Field(
+        default="fast",
+        description=(
+            "LLM alias used by the enricher.  Should resolve to the cheapest/fastest "
+            "model configured in the llm aliases map."
+        ),
+    )
+    decay_rate_per_day: float = Field(
+        default=0.05,
+        description="Exponential score decay applied per calendar day of inactivity.",
+    )
+    recency_weight: float = Field(
+        default=1.0,
+        description="Weight applied to the recency signal when computing thread score.",
+    )
+    mention_weight: float = Field(
+        default=0.3,
+        description="Weight applied to the mention-count signal.",
+    )
+    engagement_weight: float = Field(
+        default=0.5,
+        description="Weight applied to the engagement signal.",
+    )
+    peer_weight: float = Field(
+        default=0.2,
+        description="Weight applied to the peer-reference signal.",
+    )
+    sub_thread_weight: float = Field(
+        default=0.4,
+        description="Weight applied to the sub-thread depth signal.",
+    )
+    owner_id: str | None = Field(
+        default=None,
+        description=(
+            "This Ravn instance's ID for ownership claims on queue entries.  "
+            "Defaults to the runtime instance ID when None; set explicitly in "
+            "the deployment YAML so co-deployed instances can share a queue."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
 # Root settings
 # ---------------------------------------------------------------------------
 
@@ -1910,6 +1982,9 @@ class Settings(BaseSettings):
 
     # NIU-539: drive loop / initiative engine
     initiative: InitiativeConfig = Field(default_factory=InitiativeConfig)
+
+    # NIU-558: thread enrichment queue
+    thread: ThreadConfig = Field(default_factory=ThreadConfig)
 
     # NIU-541: Búri knowledge memory substrate
     buri: BuriConfig = Field(default_factory=BuriConfig)

--- a/tests/test_ravn/test_config.py
+++ b/tests/test_ravn/test_config.py
@@ -480,12 +480,12 @@ class TestSettingsThread:
             assert s.thread.sub_thread_weight == 0.7
             assert s.thread.owner_id == "ravn-prod-1"
 
-    def test_env_var_thread_enabled(self, tmp_path) -> None:
+    def test_env_var_thread_enabled(self) -> None:
         with patch.dict(os.environ, {"RAVN_THREAD__ENABLED": "true"}):
             s = Settings()
             assert s.thread.enabled is True
 
-    def test_env_var_thread_decay_rate(self, tmp_path) -> None:
+    def test_env_var_thread_decay_rate(self) -> None:
         with patch.dict(os.environ, {"RAVN_THREAD__DECAY_RATE_PER_DAY": "0.2"}):
             s = Settings()
             assert s.thread.decay_rate_per_day == 0.2

--- a/tests/test_ravn/test_config.py
+++ b/tests/test_ravn/test_config.py
@@ -21,6 +21,7 @@ from ravn.config import (
     PermissionConfig,
     PermissionRuleConfig,
     Settings,
+    ThreadConfig,
     ToolAdapterConfig,
     ToolsConfig,
 )
@@ -406,3 +407,90 @@ class TestSettings:
             s = Settings()
             assert s.context.per_file_limit == 2048
             assert s.context.total_budget == 6144
+
+
+# ---------------------------------------------------------------------------
+# NIU-558: ThreadConfig
+# ---------------------------------------------------------------------------
+
+
+class TestThreadConfig:
+    def test_defaults(self) -> None:
+        c = ThreadConfig()
+        assert c.enabled is False
+        assert c.max_queue_size == 200
+        assert c.enricher_poll_interval_seconds == 300
+        assert c.enricher_llm_alias == "fast"
+        assert c.decay_rate_per_day == 0.05
+        assert c.recency_weight == 1.0
+        assert c.mention_weight == 0.3
+        assert c.engagement_weight == 0.5
+        assert c.peer_weight == 0.2
+        assert c.sub_thread_weight == 0.4
+        assert c.owner_id is None
+
+    def test_enabled_override(self) -> None:
+        c = ThreadConfig(enabled=True)
+        assert c.enabled is True
+
+    def test_custom_weights(self) -> None:
+        c = ThreadConfig(recency_weight=2.0, mention_weight=0.8)
+        assert c.recency_weight == 2.0
+        assert c.mention_weight == 0.8
+
+    def test_owner_id_set(self) -> None:
+        c = ThreadConfig(owner_id="ravn-instance-42")
+        assert c.owner_id == "ravn-instance-42"
+
+
+class TestSettingsThread:
+    def test_settings_thread_defaults(self) -> None:
+        s = Settings()
+        assert s.thread.enabled is False
+        assert s.thread.max_queue_size == 200
+        assert s.thread.owner_id is None
+
+    def test_yaml_thread_section(self, tmp_path) -> None:
+        cfg = tmp_path / "ravn.yaml"
+        cfg.write_text(
+            "thread:\n"
+            "  enabled: true\n"
+            "  max_queue_size: 500\n"
+            "  enricher_poll_interval_seconds: 60\n"
+            "  enricher_llm_alias: turbo\n"
+            "  decay_rate_per_day: 0.1\n"
+            "  recency_weight: 2.0\n"
+            "  mention_weight: 0.6\n"
+            "  engagement_weight: 0.9\n"
+            "  peer_weight: 0.4\n"
+            "  sub_thread_weight: 0.7\n"
+            "  owner_id: ravn-prod-1\n"
+        )
+        with patch.dict(os.environ, {"RAVN_CONFIG": str(cfg)}):
+            s = Settings()
+            assert s.thread.enabled is True
+            assert s.thread.max_queue_size == 500
+            assert s.thread.enricher_poll_interval_seconds == 60
+            assert s.thread.enricher_llm_alias == "turbo"
+            assert s.thread.decay_rate_per_day == 0.1
+            assert s.thread.recency_weight == 2.0
+            assert s.thread.mention_weight == 0.6
+            assert s.thread.engagement_weight == 0.9
+            assert s.thread.peer_weight == 0.4
+            assert s.thread.sub_thread_weight == 0.7
+            assert s.thread.owner_id == "ravn-prod-1"
+
+    def test_env_var_thread_enabled(self, tmp_path) -> None:
+        with patch.dict(os.environ, {"RAVN_THREAD__ENABLED": "true"}):
+            s = Settings()
+            assert s.thread.enabled is True
+
+    def test_env_var_thread_decay_rate(self, tmp_path) -> None:
+        with patch.dict(os.environ, {"RAVN_THREAD__DECAY_RATE_PER_DAY": "0.2"}):
+            s = Settings()
+            assert s.thread.decay_rate_per_day == 0.2
+
+    def test_env_var_thread_owner_id(self) -> None:
+        with patch.dict(os.environ, {"RAVN_THREAD__OWNER_ID": "instance-xyz"}):
+            s = Settings()
+            assert s.thread.owner_id == "instance-xyz"


### PR DESCRIPTION
## Summary

- Adds `ThreadConfig` to `src/ravn/config.py` with all fields from NIU-558: `enabled`, `max_queue_size`, `enricher_poll_interval_seconds`, `enricher_llm_alias`, `decay_rate_per_day`, and five scoring weight coefficients (`recency_weight`, `mention_weight`, `engagement_weight`, `peer_weight`, `sub_thread_weight`) plus `owner_id`
- Wires `thread: ThreadConfig` into the root `Settings` class (after `initiative`)
- All values are configurable via `ravn.yaml` or `RAVN_THREAD__*` env vars — no magic numbers
- `enabled` defaults to `false` so M1 deploys cleanly; M2 flips it in the deployment YAML
- Creates `ravn.example.yaml` with a commented `thread:` section showing all defaults
- Adds 9 new tests across `TestThreadConfig` and `TestSettingsThread` covering defaults, full YAML override, and env var injection

## Test plan

- [x] All 9 new ThreadConfig/Settings tests pass
- [x] Full ravn test suite: 55 tests in `test_config.py`, 4296 total pass
- [x] Coverage: 85.08% (>=85% requirement met)
- [x] `ruff check` + `ruff format` clean
- [x] Pre-existing `test_tui_pages_returns_agents_page` failure is unrelated (missing `textual` dev dep, not introduced by this PR)

Closes NIU-558

Generated with [Claude Code](https://claude.com/claude-code)