### PR TITLE
feat(adapters): extend thread support with assigned state, list_threads, and weight signals (NIU-559)

### DIFF
--- a/src/mimir/adapters/markdown.py
+++ b/src/mimir/adapters/markdown.py
@@ -529,7 +529,48 @@ class MarkdownMimirAdapter(MimirPort):
         schema.updated_at = datetime.now(UTC)
         schema.to_yaml(yaml_path)
 
-    async def update_thread_weight(self, path: str, weight: float) -> None:
+    async def list_threads(
+        self,
+        state: ThreadState | None = None,
+        limit: int = 100,
+    ) -> list[MimirPage]:
+        """List thread pages, optionally filtered by *state*."""
+        threads_dir = self._root / "threads"
+        if not threads_dir.exists():
+            return []
+        results: list[MimirPage] = []
+        for yaml_path in sorted(threads_dir.glob("*.yaml")):
+            try:
+                schema = ThreadYamlSchema.from_yaml(yaml_path)
+            except Exception:
+                continue
+            if state is not None and schema.state != state:
+                continue
+            slug = yaml_path.stem
+            path = f"threads/{slug}"
+            results.append(
+                MimirPage(
+                    meta=MimirPageMeta(
+                        path=path,
+                        title=schema.title,
+                        summary=schema.next_action_hint or "",
+                        category="threads",
+                        updated_at=schema.updated_at,
+                        source_ids=[],
+                    ),
+                    content="",
+                )
+            )
+            if len(results) >= limit:
+                break
+        return results
+
+    async def update_thread_weight(
+        self,
+        path: str,
+        weight: float,
+        signals: dict | None = None,
+    ) -> None:
         """Update the weight score for a thread — writes YAML only."""
         yaml_path = self._safe_thread_path(path)
         if not yaml_path.exists():
@@ -537,6 +578,8 @@ class MarkdownMimirAdapter(MimirPort):
         schema = ThreadYamlSchema.from_yaml(yaml_path)
         schema.weight = weight
         schema.updated_at = datetime.now(UTC)
+        if signals is not None:
+            schema.weight_signals = signals
         schema.to_yaml(yaml_path)
 
     async def assign_thread_owner(self, path: str, owner_id: str | None) -> None:

--- a/src/niuu/domain/mimir.py
+++ b/src/niuu/domain/mimir.py
@@ -33,6 +33,7 @@ class ThreadState(StrEnum):
     """Lifecycle states for a Mímir thread."""
 
     open = "open"
+    assigned = "assigned"
     closed = "closed"
     dissolved = "dissolved"
 

--- a/src/niuu/ports/mimir.py
+++ b/src/niuu/ports/mimir.py
@@ -171,11 +171,25 @@ class MimirPort(ABC):
         """
         raise NotImplementedError
 
-    async def update_thread_weight(self, path: str, weight: float) -> None:
+    async def list_threads(
+        self,
+        state: ThreadState | None = None,
+        limit: int = 100,
+    ) -> list[MimirPage]:
+        """List thread pages, optionally filtered by *state*."""
+        raise NotImplementedError
+
+    async def update_thread_weight(
+        self,
+        path: str,
+        weight: float,
+        signals: dict | None = None,
+    ) -> None:
         """Update the weight score for a thread.
 
         Writes only the YAML file.  Raises ``FileNotFoundError`` if the thread
-        does not exist.
+        does not exist.  If *signals* are provided they are stored alongside the
+        weight for later recomputation.
         """
         raise NotImplementedError
 

--- a/src/ravn/adapters/mimir/composite.py
+++ b/src/ravn/adapters/mimir/composite.py
@@ -46,6 +46,7 @@ from niuu.domain.mimir import (
     MimirQueryResult,
     MimirSource,
     MimirSourceMeta,
+    ThreadState,
 )
 from niuu.ports.mimir import MimirPort
 from ravn.domain.mimir import MimirMount, WriteRouting
@@ -191,9 +192,7 @@ class CompositeMimirAdapter(MimirPort):
                         meta.mount_name = mount.name
                         results.append(meta)
             except Exception as exc:
-                logger.debug(
-                    "composite mimir: list_sources failed on %r: %s", mount.name, exc
-                )
+                logger.debug("composite mimir: list_sources failed on %r: %s", mount.name, exc)
 
         return results
 
@@ -219,6 +218,51 @@ class CompositeMimirAdapter(MimirPort):
                 logger.warning("composite mimir: lint failed on %r: %s", mount.name, exc)
 
         return merged
+
+    async def list_threads(
+        self,
+        state: ThreadState | None = None,
+        limit: int = 100,
+    ) -> list[MimirPage]:
+        """List threads from all mounts in priority order, de-dup by path."""
+        seen_paths: set[str] = set()
+        results: list[MimirPage] = []
+
+        for mount in self._mounts:
+            try:
+                pages = await mount.port.list_threads(state=state, limit=limit)
+                for page in pages:
+                    if page.meta.path not in seen_paths:
+                        seen_paths.add(page.meta.path)
+                        results.append(page)
+                        if len(results) >= limit:
+                            return results
+            except Exception as exc:
+                logger.warning("composite mimir: list_threads failed on %r: %s", mount.name, exc)
+
+        return results
+
+    async def update_thread_weight(
+        self,
+        path: str,
+        weight: float,
+        signals: dict | None = None,
+    ) -> None:
+        """Update thread weight on routed mounts (same routing as upsert_page)."""
+        target_names = self._write_routing.resolve(path)
+        for name in target_names:
+            mount = self._mount_map.get(name)
+            if mount is None:
+                logger.warning(
+                    "composite mimir: write routing named unknown mount %r for path %r",
+                    name,
+                    path,
+                )
+                continue
+            try:
+                await mount.port.update_thread_weight(path, weight, signals)
+            except Exception as exc:
+                logger.warning("composite mimir: update_thread_weight failed on %r: %s", name, exc)
 
     # ------------------------------------------------------------------
     # MimirPort — write operations (routed)

--- a/src/ravn/adapters/mimir/http.py
+++ b/src/ravn/adapters/mimir/http.py
@@ -30,6 +30,7 @@ from niuu.domain.mimir import (
     MimirQueryResult,
     MimirSource,
     MimirSourceMeta,
+    ThreadState,
 )
 from niuu.ports.mimir import MimirPort
 from ravn.domain.mimir import MimirAuth
@@ -191,6 +192,26 @@ class HttpMimirAdapter(MimirPort):
             content_hash=data["content_hash"],
             ingested_at=datetime.fromisoformat(data["ingested_at"]),
         )
+
+    async def list_threads(
+        self,
+        state: ThreadState | None = None,
+        limit: int = 100,
+    ) -> list[MimirPage]:
+        """GET /mimir/threads — list threads, optionally filtered by state.
+
+        Not yet implemented in HttpMimirAdapter.
+        """
+        raise NotImplementedError("Thread listing not yet implemented in HttpMimirAdapter")
+
+    async def update_thread_weight(
+        self,
+        path: str,
+        weight: float,
+        signals: dict | None = None,
+    ) -> None:
+        """Update thread weight.  Not yet implemented in HttpMimirAdapter."""
+        raise NotImplementedError("Thread weight update not yet implemented in HttpMimirAdapter")
 
     async def list_sources(self, *, unprocessed_only: bool = False) -> list[MimirSourceMeta]:
         """GET /mimir/sources — list raw sources, optionally unprocessed only."""

--- a/tests/ravn/unit/test_composite_mimir.py
+++ b/tests/ravn/unit/test_composite_mimir.py
@@ -57,12 +57,12 @@ def _mock_port(
     pages = pages or []
 
     port.search = AsyncMock(return_value=pages)
-    port.query = AsyncMock(
-        return_value=MimirQueryResult(question="q", answer="", sources=pages)
-    )
+    port.query = AsyncMock(return_value=MimirQueryResult(question="q", answer="", sources=pages))
     port.list_pages = AsyncMock(return_value=[p.meta for p in pages])
+    port.list_threads = AsyncMock(return_value=pages)
     port.ingest = AsyncMock(return_value=[])
     port.upsert_page = AsyncMock(return_value=None)
+    port.update_thread_weight = AsyncMock(return_value=None)
     port.lint = AsyncMock(
         return_value=lint_report
         or MimirLintReport(orphans=[], contradictions=[], stale=[], gaps=[], pages_checked=0)
@@ -72,6 +72,7 @@ def _mock_port(
         port.read_page = AsyncMock(side_effect=FileNotFoundError("not found"))
         port.get_page = AsyncMock(side_effect=FileNotFoundError("not found"))
     else:
+
         async def _read(path: str) -> str:
             return f"content of {path}"
 
@@ -431,12 +432,14 @@ def _error_port(error: Exception = RuntimeError("mount down")) -> object:
     port.query = AsyncMock(side_effect=error)
     port.search = AsyncMock(side_effect=error)
     port.list_pages = AsyncMock(side_effect=error)
+    port.list_threads = AsyncMock(side_effect=error)
     port.list_sources = AsyncMock(side_effect=error)
     port.lint = AsyncMock(side_effect=error)
     port.read_source = AsyncMock(side_effect=error)
     port.read_page = AsyncMock(side_effect=error)
     port.get_page = AsyncMock(side_effect=error)
     port.upsert_page = AsyncMock(side_effect=error)
+    port.update_thread_weight = AsyncMock(side_effect=error)
     return port
 
 
@@ -449,8 +452,12 @@ async def test_ingest_exception_in_one_mount_continues_others() -> None:
     good = MimirMount(name="good", port=good_port, role="shared", read_priority=1)
     adapter = CompositeMimirAdapter(mounts=[bad, good])
     source = MimirSource(
-        source_id="s1", title="T", content="c", source_type="document",
-        ingested_at=datetime.now(UTC), content_hash=compute_content_hash("c"),
+        source_id="s1",
+        title="T",
+        content="c",
+        source_type="document",
+        ingested_at=datetime.now(UTC),
+        content_hash=compute_content_hash("c"),
     )
     result = await adapter.ingest(source)
     good_port.ingest.assert_called_once()
@@ -561,3 +568,81 @@ async def test_upsert_exception_in_mount_logged_not_raised() -> None:
     adapter = CompositeMimirAdapter(mounts=[bad])
     # Should not raise
     await adapter.upsert_page("wiki/page.md", "content")
+
+
+# ---------------------------------------------------------------------------
+# CompositeMimirAdapter — list_threads (NIU-559)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_threads_dedup_by_path() -> None:
+    page_a = _make_page("threads/alpha")
+    page_b = _make_page("threads/beta")
+
+    local = _make_mount("local", priority=0, pages=[page_a])
+    shared = _make_mount("shared", priority=1, role="shared", pages=[page_a, page_b])
+
+    adapter = CompositeMimirAdapter(mounts=[local, shared])
+    results = await adapter.list_threads()
+
+    paths = [p.meta.path for p in results]
+    assert paths.count("threads/alpha") == 1
+    assert "threads/beta" in paths
+
+
+@pytest.mark.asyncio
+async def test_list_threads_respects_limit() -> None:
+    pages = [_make_page(f"threads/t{i}") for i in range(5)]
+    local = _make_mount("local", priority=0, pages=pages)
+    adapter = CompositeMimirAdapter(mounts=[local])
+    results = await adapter.list_threads(limit=3)
+    assert len(results) == 3
+
+
+@pytest.mark.asyncio
+async def test_list_threads_exception_in_one_mount_continues_others() -> None:
+    bad_port = _error_port()
+    bad_port.list_threads = AsyncMock(side_effect=RuntimeError("down"))
+    good_port = _mock_port(pages=[_make_page("threads/alpha")])
+    bad = MimirMount(name="bad", port=bad_port, role="local", read_priority=0)
+    good = MimirMount(name="good", port=good_port, role="shared", read_priority=1)
+    adapter = CompositeMimirAdapter(mounts=[bad, good])
+    results = await adapter.list_threads()
+    assert isinstance(results, list)
+    good_port.list_threads.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# CompositeMimirAdapter — update_thread_weight (NIU-559)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_thread_weight_routes_to_default_mount() -> None:
+    local_port = _mock_port()
+    shared_port = _mock_port()
+
+    local = MimirMount(name="local", port=local_port, role="local", read_priority=0)
+    shared = MimirMount(name="shared", port=shared_port, role="shared", read_priority=1)
+
+    routing = WriteRouting(rules=[], default=["local"])
+    adapter = CompositeMimirAdapter(mounts=[local, shared], write_routing=routing)
+
+    await adapter.update_thread_weight("threads/my-thread", 0.75)
+
+    local_port.update_thread_weight.assert_called_once_with("threads/my-thread", 0.75, None)
+    shared_port.update_thread_weight.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_update_thread_weight_passes_signals() -> None:
+    local_port = _mock_port()
+    local = MimirMount(name="local", port=local_port, role="local", read_priority=0)
+    routing = WriteRouting(rules=[], default=["local"])
+    adapter = CompositeMimirAdapter(mounts=[local], write_routing=routing)
+
+    signals = {"age_days": 2.0, "mention_count": 3}
+    await adapter.update_thread_weight("threads/my-thread", 0.8, signals)
+
+    local_port.update_thread_weight.assert_called_once_with("threads/my-thread", 0.8, signals)

--- a/tests/ravn/unit/test_http_mimir.py
+++ b/tests/ravn/unit/test_http_mimir.py
@@ -101,9 +101,7 @@ async def test_search_returns_pages(adapter: HttpMimirAdapter) -> None:
 @pytest.mark.asyncio
 @respx.mock
 async def test_search_returns_empty_list(adapter: HttpMimirAdapter) -> None:
-    respx.get("http://mimir.test/mimir/search").mock(
-        return_value=Response(200, json=[])
-    )
+    respx.get("http://mimir.test/mimir/search").mock(return_value=Response(200, json=[]))
     pages = await adapter.search("nonexistent")
     assert pages == []
 
@@ -174,9 +172,7 @@ async def test_get_page_raises_file_not_found(adapter: HttpMimirAdapter) -> None
 @pytest.mark.asyncio
 @respx.mock
 async def test_upsert_page_sends_put(adapter: HttpMimirAdapter) -> None:
-    route = respx.put("http://mimir.test/mimir/page").mock(
-        return_value=Response(204)
-    )
+    route = respx.put("http://mimir.test/mimir/page").mock(return_value=Response(204))
     await adapter.upsert_page("technical/test.md", "# Test\ncontent")
     assert route.called
     assert route.calls[0].request.method == "PUT"
@@ -186,9 +182,7 @@ async def test_upsert_page_sends_put(adapter: HttpMimirAdapter) -> None:
 @respx.mock
 async def test_upsert_page_ignores_mimir_param(adapter: HttpMimirAdapter) -> None:
     """The mimir= param is for CompositeMimirAdapter routing; HttpMimirAdapter ignores it."""
-    route = respx.put("http://mimir.test/mimir/page").mock(
-        return_value=Response(204)
-    )
+    route = respx.put("http://mimir.test/mimir/page").mock(return_value=Response(204))
     await adapter.upsert_page("technical/test.md", "# Test\ncontent", mimir="shared")
     assert route.called
 
@@ -262,9 +256,7 @@ async def test_list_pages_returns_metadata(adapter: HttpMimirAdapter) -> None:
 @pytest.mark.asyncio
 @respx.mock
 async def test_list_pages_with_category(adapter: HttpMimirAdapter) -> None:
-    respx.get("http://mimir.test/mimir/pages").mock(
-        return_value=Response(200, json=[])
-    )
+    respx.get("http://mimir.test/mimir/pages").mock(return_value=Response(200, json=[]))
     result = await adapter.list_pages(category="technical")
     assert result == []
     # Verify category param was sent
@@ -307,13 +299,40 @@ async def test_lint_returns_report(adapter: HttpMimirAdapter) -> None:
 @pytest.mark.asyncio
 @respx.mock
 async def test_bearer_auth_header_is_sent(adapter_bearer: HttpMimirAdapter) -> None:
-    route = respx.get("http://mimir.test/mimir/pages").mock(
-        return_value=Response(200, json=[])
-    )
+    route = respx.get("http://mimir.test/mimir/pages").mock(return_value=Response(200, json=[]))
     await adapter_bearer.list_pages()
     assert route.called
     auth_header = route.calls[0].request.headers.get("authorization", "")
     assert auth_header == "Bearer test-token"
+
+
+# ---------------------------------------------------------------------------
+# HttpMimirAdapter — thread stubs (NIU-559)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_threads_raises_not_implemented() -> None:
+    """list_threads is a stub in HttpMimirAdapter — must raise NotImplementedError."""
+    adapter = HttpMimirAdapter(base_url="http://mimir.test")
+    with pytest.raises(NotImplementedError):
+        await adapter.list_threads()
+
+
+@pytest.mark.asyncio
+async def test_update_thread_weight_raises_not_implemented() -> None:
+    """update_thread_weight is a stub in HttpMimirAdapter — must raise NotImplementedError."""
+    adapter = HttpMimirAdapter(base_url="http://mimir.test")
+    with pytest.raises(NotImplementedError):
+        await adapter.update_thread_weight("threads/my-thread", 0.75)
+
+
+@pytest.mark.asyncio
+async def test_update_thread_weight_with_signals_raises_not_implemented() -> None:
+    """Signals param does not change the stub behaviour."""
+    adapter = HttpMimirAdapter(base_url="http://mimir.test")
+    with pytest.raises(NotImplementedError):
+        await adapter.update_thread_weight("threads/my-thread", 0.75, signals={"x": 1.0})
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ravn/unit/test_mimir_threads.py
+++ b/tests/ravn/unit/test_mimir_threads.py
@@ -88,13 +88,21 @@ def test_slugify_unicode_to_ascii() -> None:
 
 def test_thread_state_values() -> None:
     assert ThreadState.open == "open"
+    assert ThreadState.assigned == "assigned"
     assert ThreadState.closed == "closed"
     assert ThreadState.dissolved == "dissolved"
 
 
 def test_thread_state_from_string() -> None:
     assert ThreadState("open") == ThreadState.open
+    assert ThreadState("assigned") == ThreadState.assigned
     assert ThreadState("closed") == ThreadState.closed
+
+
+def test_thread_state_assigned_is_str() -> None:
+    """ThreadState.assigned must be a plain string (StrEnum behaviour)."""
+    assert isinstance(ThreadState.assigned, str)
+    assert str(ThreadState.assigned) == "assigned"
 
 
 # ---------------------------------------------------------------------------
@@ -489,6 +497,89 @@ async def test_update_thread_weight_raises_for_missing(tmp_path: Path) -> None:
     adapter = _make_adapter(tmp_path)
     with pytest.raises(FileNotFoundError):
         await adapter.update_thread_weight("threads/nonexistent", 0.5)
+
+
+@pytest.mark.asyncio
+async def test_update_thread_weight_stores_signals(tmp_path: Path) -> None:
+    """When signals are provided they must be persisted in the YAML."""
+    adapter = _make_adapter(tmp_path)
+    await adapter.create_thread(title="Signal Thread", weight=0.5)
+    signals = {"age_days": 3.0, "mention_count": 5}
+    await adapter.update_thread_weight("threads/signal-thread", 0.75, signals=signals)
+    schema = ThreadYamlSchema.from_yaml(tmp_path / "mimir" / "threads" / "signal-thread.yaml")
+    assert abs(schema.weight - 0.75) < 1e-9
+    assert schema.weight_signals["age_days"] == 3.0
+    assert schema.weight_signals["mention_count"] == 5
+
+
+@pytest.mark.asyncio
+async def test_update_thread_weight_signals_none_preserves_existing(tmp_path: Path) -> None:
+    """Passing signals=None must leave existing weight_signals untouched."""
+    adapter = _make_adapter(tmp_path)
+    await adapter.create_thread(title="Preserve Signals Thread", weight=0.5)
+    await adapter.update_thread_weight("threads/preserve-signals-thread", 0.6, signals={"x": 1.0})
+    await adapter.update_thread_weight("threads/preserve-signals-thread", 0.7)
+    schema = ThreadYamlSchema.from_yaml(
+        tmp_path / "mimir" / "threads" / "preserve-signals-thread.yaml"
+    )
+    assert schema.weight_signals == {"x": 1.0}
+
+
+# ---------------------------------------------------------------------------
+# list_threads
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_threads_returns_all_threads(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    await adapter.create_thread(title="Thread Alpha")
+    await adapter.create_thread(title="Thread Beta")
+    pages = await adapter.list_threads()
+    titles = [p.meta.title for p in pages]
+    assert "Thread Alpha" in titles
+    assert "Thread Beta" in titles
+
+
+@pytest.mark.asyncio
+async def test_list_threads_empty_when_no_threads(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    pages = await adapter.list_threads()
+    assert pages == []
+
+
+@pytest.mark.asyncio
+async def test_list_threads_filtered_by_state(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    await adapter.create_thread(title="Open Thread")
+    await adapter.create_thread(title="Closed Thread")
+    await adapter.update_thread_state("threads/closed-thread", ThreadState.closed)
+    open_pages = await adapter.list_threads(state=ThreadState.open)
+    titles = [p.meta.title for p in open_pages]
+    assert "Open Thread" in titles
+    assert "Closed Thread" not in titles
+
+
+@pytest.mark.asyncio
+async def test_list_threads_filtered_by_assigned_state(tmp_path: Path) -> None:
+    """ThreadState.assigned must work as a filter value."""
+    adapter = _make_adapter(tmp_path)
+    await adapter.create_thread(title="Open Thread 2")
+    await adapter.create_thread(title="Assigned Thread")
+    await adapter.update_thread_state("threads/assigned-thread", ThreadState.assigned)
+    pages = await adapter.list_threads(state=ThreadState.assigned)
+    titles = [p.meta.title for p in pages]
+    assert "Assigned Thread" in titles
+    assert "Open Thread 2" not in titles
+
+
+@pytest.mark.asyncio
+async def test_list_threads_respects_limit(tmp_path: Path) -> None:
+    adapter = _make_adapter(tmp_path)
+    for i in range(5):
+        await adapter.create_thread(title=f"Limited Thread {i}")
+    pages = await adapter.list_threads(limit=3)
+    assert len(pages) == 3
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Rework of NIU-559 to align with the design decisions established by NIU-560 (already merged to `feat/vaka-ravn-wakefulness`). This PR adds only what NIU-559 uniquely contributes that NIU-560 did not include:

- **`ThreadState.assigned`**: new lifecycle state for owner-claimed threads; validated in `ThreadYamlSchema.from_yaml()` alongside `open`/`closed`/`dissolved`.

- **`list_threads(state, limit)`**: new non-abstract `MimirPort` method (following NIU-560's `raise NotImplementedError` pattern). `MarkdownMimirAdapter` provides a real implementation scanning `threads/*.yaml` with optional state filtering and limit. `CompositeMimirAdapter` fans out across all mounts and de-duplicates by path. `HttpMimirAdapter` is a `NotImplementedError` stub.

- **`update_thread_weight` signals parameter**: adds `signals: dict | None = None` to the `MimirPort` method and `MarkdownMimirAdapter` implementation. When provided, signals are persisted in `weight_signals`; `None` leaves existing signals untouched. `CompositeMimirAdapter` passes signals through to routed mounts.

All thread methods remain non-abstract (`raise NotImplementedError`) and `ThreadOwnershipError` stays in `niuu.domain.mimir` — both as established by NIU-560.

## Test plan

- [x] `tests/ravn/unit/test_mimir_threads.py` — `ThreadState.assigned` enum tests, `list_threads` tests (empty dir, state filter, `assigned` state filter, limit), `update_thread_weight` signals tests
- [x] `tests/ravn/unit/test_http_mimir.py` — `list_threads` and `update_thread_weight` raise `NotImplementedError`
- [x] `tests/ravn/unit/test_composite_mimir.py` — `list_threads` fan-out de-dup, limit, exception isolation; `update_thread_weight` routing and signals pass-through
- [x] `ruff check` + `ruff format` clean
- [x] 113 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)