### PR TITLE
feat(adapters): ThreadQueueTrigger — connect Mímir thread queue to drive loop (NIU-563)

### DIFF
--- a/src/niuu/domain/mimir.py
+++ b/src/niuu/domain/mimir.py
@@ -34,6 +34,7 @@ class ThreadState(StrEnum):
 
     open = "open"
     assigned = "assigned"
+    pulling = "pulling"  # actively being worked by a Ravn instance
     closed = "closed"
     dissolved = "dissolved"
 

--- a/src/ravn/adapters/triggers/thread_queue.py
+++ b/src/ravn/adapters/triggers/thread_queue.py
@@ -1,0 +1,158 @@
+"""ThreadQueueTrigger — connects the Mímir thread queue to the Ravn drive loop.
+
+Polls ``MimirPort.get_thread_queue()`` on a configurable interval and converts
+the highest-weight open thread into an ``AgentTask`` for the drive loop.
+
+Ownership semantics
+-------------------
+Before enqueuing, the trigger atomically claims the thread via
+``assign_thread_owner``.  If another Ravn instance has already claimed the
+thread (``ThreadOwnershipError``), this cycle is skipped — the thread
+reappears on the next poll, so no retry logic is needed.
+
+Output mode
+-----------
+All wakefulness tasks use ``OutputMode.AMBIENT``: work produced during
+wakefulness is published to Sleipnir rather than surfaced directly to the
+operator.  The Recap (M3) surfaces results on the operator's return.
+
+Enabled flag
+------------
+``ThreadConfig.enabled`` defaults to ``False`` — the trigger is registered in
+M1 but never fires.  M2 flips the switch via ``thread.enabled: true`` in the
+deployment YAML.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+import uuid
+from collections.abc import Awaitable, Callable
+
+from niuu.domain.mimir import ThreadOwnershipError, ThreadState
+from niuu.ports.mimir import MimirPort
+from ravn.config import ThreadConfig
+from ravn.domain.models import AgentTask, OutputMode
+from ravn.ports.trigger import TriggerPort
+
+logger = logging.getLogger(__name__)
+
+# DriveLoop priority range (inclusive): 1 = highest urgency, 10 = lowest.
+_PRIORITY_MIN = 1
+_PRIORITY_MAX = 10
+
+
+class ThreadQueueTrigger(TriggerPort):
+    """TriggerPort that polls the Mímir thread queue and enqueues wakefulness tasks.
+
+    Args:
+        mimir:  The Mímir adapter to poll.
+        config: Thread enrichment configuration (poll interval, owner_id, …).
+    """
+
+    def __init__(self, mimir: MimirPort, config: ThreadConfig) -> None:
+        self._mimir = mimir
+        self._config = config
+        self._owner_id: str = config.owner_id or _generate_owner_id()
+
+    @property
+    def name(self) -> str:
+        return "thread_queue"
+
+    async def run(
+        self,
+        enqueue: Callable[[AgentTask], Awaitable[None]],
+    ) -> None:
+        """Poll loop — runs until cancelled by the DriveLoop."""
+        logger.info(
+            "ThreadQueueTrigger: starting (enabled=%s, poll_interval=%ds, owner=%r)",
+            self._config.enabled,
+            self._config.enricher_poll_interval_seconds,
+            self._owner_id,
+        )
+
+        while True:
+            try:
+                await self._poll_once(enqueue)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning("ThreadQueueTrigger: poll error: %s", exc)
+
+            await asyncio.sleep(self._config.enricher_poll_interval_seconds)
+
+    async def _poll_once(
+        self,
+        enqueue: Callable[[AgentTask], Awaitable[None]],
+    ) -> None:
+        """Single poll cycle: fetch queue → claim → transition → enqueue.
+
+        No-ops when ``config.enabled`` is ``False`` — the trigger exists in M1
+        but never fires until M2 sets ``thread.enabled: true``.
+        """
+        if not self._config.enabled:
+            return
+
+        queue = await self._mimir.get_thread_queue(owner_id=self._owner_id, limit=1)
+        if not queue:
+            return
+
+        thread = queue[0]
+        path = thread.meta.path
+        weight = thread.meta.thread_weight or 1.0
+
+        try:
+            await self._mimir.assign_thread_owner(path, self._owner_id)
+        except ThreadOwnershipError as exc:
+            logger.debug(
+                "ThreadQueueTrigger: thread %r already owned by %r — skipping cycle",
+                path,
+                exc.current_owner,
+            )
+            return
+
+        await self._mimir.update_thread_state(path, ThreadState.pulling)
+
+        # For thread MimirPages, meta.summary stores the next_action_hint
+        # (populated by MarkdownMimirAdapter._schema_to_page and _parse_thread_page).
+        next_action_hint = thread.meta.summary or ""
+        title = next_action_hint or _title_from_path(path)
+
+        initiative_context = (
+            f"Thread: {path}\n"
+            f"Weight: {weight:.2f}\n"
+            f"Next action: {next_action_hint}\n"
+            f"Page summary: {thread.meta.summary}\n"
+        )
+
+        priority = max(_PRIORITY_MIN, min(_PRIORITY_MAX, int(_PRIORITY_MAX - weight)))
+
+        task_id = f"task_{int(time.time() * 1000):x}_tq"
+        task = AgentTask(
+            task_id=task_id,
+            title=title,
+            initiative_context=initiative_context,
+            triggered_by=f"thread:{path}",
+            output_mode=OutputMode.AMBIENT,
+            priority=priority,
+        )
+        logger.info(
+            "ThreadQueueTrigger: enqueuing task for thread %r (weight=%.2f, priority=%d)",
+            path,
+            weight,
+            priority,
+        )
+        await enqueue(task)
+
+
+def _generate_owner_id() -> str:
+    """Return a stable owner ID for this process lifetime."""
+    return f"ravn-{uuid.uuid4().hex[:8]}"
+
+
+def _title_from_path(path: str) -> str:
+    """Derive a human-readable title from a thread path stem."""
+    slug = path.rsplit("/", 1)[-1]
+    return slug.replace("-", " ").title()

--- a/src/ravn/adapters/triggers/thread_queue.py
+++ b/src/ravn/adapters/triggers/thread_queue.py
@@ -124,7 +124,6 @@ class ThreadQueueTrigger(TriggerPort):
             f"Thread: {path}\n"
             f"Weight: {weight:.2f}\n"
             f"Next action: {next_action_hint}\n"
-            f"Page summary: {thread.meta.summary}\n"
         )
 
         priority = max(_PRIORITY_MIN, min(_PRIORITY_MAX, int(_PRIORITY_MAX - weight)))

--- a/src/ravn/cli/commands.py
+++ b/src/ravn/cli/commands.py
@@ -2051,6 +2051,16 @@ def _wire_mimir_triggers(drive_loop: Any, mimir: Any, settings: Settings) -> Non
             mc.staleness_trigger.persona,
         )
 
+    # Thread queue trigger — wired always; only fires when thread.enabled=True.
+    from ravn.adapters.triggers.thread_queue import ThreadQueueTrigger
+
+    drive_loop.register_trigger(ThreadQueueTrigger(mimir=mimir, config=settings.thread))
+    logger.info(
+        "thread: queue trigger registered (enabled=%s, poll_interval=%ds)",
+        settings.thread.enabled,
+        settings.thread.enricher_poll_interval_seconds,
+    )
+
 
 def _wire_cron(
     drive_loop: Any,

--- a/tests/ravn/unit/test_thread_queue_trigger.py
+++ b/tests/ravn/unit/test_thread_queue_trigger.py
@@ -1,0 +1,455 @@
+"""Unit tests for ThreadQueueTrigger (NIU-563).
+
+Covers:
+- name property
+- Disabled trigger never calls enqueue (thread.enabled=False)
+- Empty queue → no enqueue
+- Thread in queue → ownership claimed, state → pulling, enqueue called
+- ThreadOwnershipError → caught, logged, no exception raised, no enqueue
+- Priority mapping produces valid DriveLoop priority values (1–10)
+- Title derived from next_action_hint (meta.summary) when present
+- Title derived from path stem when meta.summary is empty
+- triggered_by is f"thread:{path}"
+- output_mode is AMBIENT
+- run() re-raises CancelledError
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from niuu.domain.mimir import ThreadOwnershipError, ThreadState
+from niuu.ports.mimir import MimirPage, MimirPageMeta
+from ravn.adapters.triggers.thread_queue import ThreadQueueTrigger, _title_from_path
+from ravn.config import ThreadConfig
+from ravn.domain.models import AgentTask, OutputMode
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _thread_config(
+    enabled: bool = True,
+    poll_interval: int = 10,
+    owner_id: str = "test-agent",
+) -> ThreadConfig:
+    return ThreadConfig(
+        enabled=enabled,
+        enricher_poll_interval_seconds=poll_interval,
+        owner_id=owner_id,
+    )
+
+
+def _make_trigger(
+    mimir: object | None = None,
+    enabled: bool = True,
+    owner_id: str = "test-agent",
+) -> ThreadQueueTrigger:
+    if mimir is None:
+        mimir = AsyncMock()
+        mimir.get_thread_queue = AsyncMock(return_value=[])
+    return ThreadQueueTrigger(
+        mimir=mimir,  # type: ignore[arg-type]
+        config=_thread_config(enabled=enabled, owner_id=owner_id),
+    )
+
+
+def _thread_page(
+    path: str = "threads/retrieval-architecture",
+    title: str = "Retrieval Architecture",
+    summary: str = "Compare HNSW vs flat",
+    weight: float = 5.0,
+    state: ThreadState = ThreadState.open,
+) -> MimirPage:
+    return MimirPage(
+        meta=MimirPageMeta(
+            path=path,
+            title=title,
+            summary=summary,
+            category="threads",
+            updated_at=datetime(2024, 1, 1, tzinfo=UTC),
+            is_thread=True,
+            thread_state=state,
+            thread_weight=weight,
+        ),
+        content="",
+    )
+
+
+# ---------------------------------------------------------------------------
+# name
+# ---------------------------------------------------------------------------
+
+
+def test_name() -> None:
+    assert _make_trigger().name == "thread_queue"
+
+
+# ---------------------------------------------------------------------------
+# disabled trigger
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_disabled_trigger_never_enqueues() -> None:
+    """thread.enabled=False → _poll_once returns immediately, never enqueues."""
+    mimir = AsyncMock()
+    mimir.get_thread_queue = AsyncMock(return_value=[_thread_page()])
+    trigger = _make_trigger(mimir=mimir, enabled=False)
+    enqueued: list[AgentTask] = []
+
+    async def _enqueue(task: AgentTask) -> None:
+        enqueued.append(task)
+
+    await trigger._poll_once(_enqueue)
+
+    assert enqueued == []
+    mimir.get_thread_queue.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# empty queue
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_queue_no_enqueue() -> None:
+    mimir = AsyncMock()
+    mimir.get_thread_queue = AsyncMock(return_value=[])
+    trigger = _make_trigger(mimir=mimir)
+    enqueued: list[AgentTask] = []
+
+    await trigger._poll_once(lambda t: enqueued.append(t) or asyncio.sleep(0))  # type: ignore[arg-type]
+    assert enqueued == []
+    mimir.assign_thread_owner.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# happy path: thread in queue → ownership + state + enqueue
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_thread_in_queue_claims_ownership() -> None:
+    mimir = AsyncMock()
+    page = _thread_page(path="threads/my-topic", weight=5.0)
+    mimir.get_thread_queue = AsyncMock(return_value=[page])
+    mimir.assign_thread_owner = AsyncMock()
+    mimir.update_thread_state = AsyncMock()
+    trigger = _make_trigger(mimir=mimir, owner_id="agent-1")
+    enqueued: list[AgentTask] = []
+
+    async def _enqueue(task: AgentTask) -> None:
+        enqueued.append(task)
+
+    await trigger._poll_once(_enqueue)
+
+    mimir.assign_thread_owner.assert_called_once_with("threads/my-topic", "agent-1")
+
+
+@pytest.mark.asyncio
+async def test_thread_in_queue_transitions_to_pulling() -> None:
+    mimir = AsyncMock()
+    page = _thread_page()
+    mimir.get_thread_queue = AsyncMock(return_value=[page])
+    mimir.assign_thread_owner = AsyncMock()
+    mimir.update_thread_state = AsyncMock()
+    trigger = _make_trigger(mimir=mimir)
+    enqueued: list[AgentTask] = []
+
+    async def _enqueue(task: AgentTask) -> None:
+        enqueued.append(task)
+
+    await trigger._poll_once(_enqueue)
+
+    mimir.update_thread_state.assert_called_once_with(
+        "threads/retrieval-architecture", ThreadState.pulling
+    )
+
+
+@pytest.mark.asyncio
+async def test_thread_in_queue_calls_enqueue() -> None:
+    mimir = AsyncMock()
+    page = _thread_page()
+    mimir.get_thread_queue = AsyncMock(return_value=[page])
+    mimir.assign_thread_owner = AsyncMock()
+    mimir.update_thread_state = AsyncMock()
+    trigger = _make_trigger(mimir=mimir)
+    enqueued: list[AgentTask] = []
+
+    async def _enqueue(task: AgentTask) -> None:
+        enqueued.append(task)
+
+    await trigger._poll_once(_enqueue)
+
+    assert len(enqueued) == 1
+
+
+@pytest.mark.asyncio
+async def test_enqueued_task_triggered_by_thread_path() -> None:
+    mimir = AsyncMock()
+    page = _thread_page(path="threads/retrieval-architecture")
+    mimir.get_thread_queue = AsyncMock(return_value=[page])
+    mimir.assign_thread_owner = AsyncMock()
+    mimir.update_thread_state = AsyncMock()
+    trigger = _make_trigger(mimir=mimir)
+    enqueued: list[AgentTask] = []
+
+    async def _enqueue(task: AgentTask) -> None:
+        enqueued.append(task)
+
+    await trigger._poll_once(_enqueue)
+
+    assert enqueued[0].triggered_by == "thread:threads/retrieval-architecture"
+
+
+@pytest.mark.asyncio
+async def test_enqueued_task_output_mode_ambient() -> None:
+    mimir = AsyncMock()
+    page = _thread_page()
+    mimir.get_thread_queue = AsyncMock(return_value=[page])
+    mimir.assign_thread_owner = AsyncMock()
+    mimir.update_thread_state = AsyncMock()
+    trigger = _make_trigger(mimir=mimir)
+    enqueued: list[AgentTask] = []
+
+    async def _enqueue(task: AgentTask) -> None:
+        enqueued.append(task)
+
+    await trigger._poll_once(_enqueue)
+
+    assert enqueued[0].output_mode == OutputMode.AMBIENT
+
+
+@pytest.mark.asyncio
+async def test_enqueued_task_title_uses_next_action_hint() -> None:
+    mimir = AsyncMock()
+    page = _thread_page(summary="Compare HNSW vs flat")
+    mimir.get_thread_queue = AsyncMock(return_value=[page])
+    mimir.assign_thread_owner = AsyncMock()
+    mimir.update_thread_state = AsyncMock()
+    trigger = _make_trigger(mimir=mimir)
+    enqueued: list[AgentTask] = []
+
+    async def _enqueue(task: AgentTask) -> None:
+        enqueued.append(task)
+
+    await trigger._poll_once(_enqueue)
+
+    assert enqueued[0].title == "Compare HNSW vs flat"
+
+
+@pytest.mark.asyncio
+async def test_enqueued_task_title_derived_from_path_when_no_summary() -> None:
+    mimir = AsyncMock()
+    page = _thread_page(path="threads/retrieval-architecture", summary="")
+    mimir.get_thread_queue = AsyncMock(return_value=[page])
+    mimir.assign_thread_owner = AsyncMock()
+    mimir.update_thread_state = AsyncMock()
+    trigger = _make_trigger(mimir=mimir)
+    enqueued: list[AgentTask] = []
+
+    async def _enqueue(task: AgentTask) -> None:
+        enqueued.append(task)
+
+    await trigger._poll_once(_enqueue)
+
+    assert enqueued[0].title == "Retrieval Architecture"
+
+
+@pytest.mark.asyncio
+async def test_enqueued_task_initiative_context_contains_path_and_weight() -> None:
+    mimir = AsyncMock()
+    page = _thread_page(path="threads/my-topic", weight=7.5)
+    mimir.get_thread_queue = AsyncMock(return_value=[page])
+    mimir.assign_thread_owner = AsyncMock()
+    mimir.update_thread_state = AsyncMock()
+    trigger = _make_trigger(mimir=mimir)
+    enqueued: list[AgentTask] = []
+
+    async def _enqueue(task: AgentTask) -> None:
+        enqueued.append(task)
+
+    await trigger._poll_once(_enqueue)
+
+    ctx = enqueued[0].initiative_context
+    assert "threads/my-topic" in ctx
+    assert "7.50" in ctx
+
+
+# ---------------------------------------------------------------------------
+# Priority mapping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_priority_is_within_valid_range() -> None:
+    """Priority must always be between 1 and 10 inclusive."""
+    for weight in (0.0, 0.5, 1.0, 5.0, 9.5, 10.0, 15.0, 0.01):
+        mimir = AsyncMock()
+        page = _thread_page(weight=weight)
+        mimir.get_thread_queue = AsyncMock(return_value=[page])
+        mimir.assign_thread_owner = AsyncMock()
+        mimir.update_thread_state = AsyncMock()
+        trigger = _make_trigger(mimir=mimir)
+        enqueued: list[AgentTask] = []
+
+        async def _enqueue(task: AgentTask) -> None:
+            enqueued.append(task)
+
+        await trigger._poll_once(_enqueue)
+        assert 1 <= enqueued[0].priority <= 10, (
+            f"weight={weight} → priority={enqueued[0].priority} out of range"
+        )
+
+
+@pytest.mark.asyncio
+async def test_high_weight_yields_lower_priority_number() -> None:
+    """Higher thread weight → lower priority number (more urgent)."""
+    mimir_lo = AsyncMock()
+    mimir_lo.get_thread_queue = AsyncMock(return_value=[_thread_page(weight=2.0)])
+    mimir_lo.assign_thread_owner = AsyncMock()
+    mimir_lo.update_thread_state = AsyncMock()
+
+    mimir_hi = AsyncMock()
+    mimir_hi.get_thread_queue = AsyncMock(return_value=[_thread_page(weight=8.0)])
+    mimir_hi.assign_thread_owner = AsyncMock()
+    mimir_hi.update_thread_state = AsyncMock()
+
+    enqueued_lo: list[AgentTask] = []
+    enqueued_hi: list[AgentTask] = []
+
+    async def _enqueue_lo(t: AgentTask) -> None:
+        enqueued_lo.append(t)
+
+    async def _enqueue_hi(t: AgentTask) -> None:
+        enqueued_hi.append(t)
+
+    await _make_trigger(mimir=mimir_lo)._poll_once(_enqueue_lo)
+    await _make_trigger(mimir=mimir_hi)._poll_once(_enqueue_hi)
+
+    assert enqueued_hi[0].priority < enqueued_lo[0].priority
+
+
+# ---------------------------------------------------------------------------
+# ThreadOwnershipError handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ownership_error_no_enqueue() -> None:
+    mimir = AsyncMock()
+    mimir.get_thread_queue = AsyncMock(return_value=[_thread_page()])
+    mimir.assign_thread_owner = AsyncMock(
+        side_effect=ThreadOwnershipError("threads/retrieval-architecture", "other-agent")
+    )
+    mimir.update_thread_state = AsyncMock()
+    trigger = _make_trigger(mimir=mimir)
+    enqueued: list[AgentTask] = []
+
+    async def _enqueue(task: AgentTask) -> None:
+        enqueued.append(task)
+
+    await trigger._poll_once(_enqueue)
+
+    assert enqueued == []
+
+
+@pytest.mark.asyncio
+async def test_ownership_error_no_state_transition() -> None:
+    mimir = AsyncMock()
+    mimir.get_thread_queue = AsyncMock(return_value=[_thread_page()])
+    mimir.assign_thread_owner = AsyncMock(
+        side_effect=ThreadOwnershipError("threads/retrieval-architecture", "other-agent")
+    )
+    mimir.update_thread_state = AsyncMock()
+    trigger = _make_trigger(mimir=mimir)
+
+    await trigger._poll_once(AsyncMock())
+
+    mimir.update_thread_state.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ownership_error_does_not_raise() -> None:
+    mimir = AsyncMock()
+    mimir.get_thread_queue = AsyncMock(return_value=[_thread_page()])
+    mimir.assign_thread_owner = AsyncMock(
+        side_effect=ThreadOwnershipError("threads/retrieval-architecture", "other-agent")
+    )
+    trigger = _make_trigger(mimir=mimir)
+
+    # Must not raise
+    await trigger._poll_once(AsyncMock())
+
+
+# ---------------------------------------------------------------------------
+# run() cancellation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_exits_on_cancellation() -> None:
+    mimir = AsyncMock()
+    mimir.get_thread_queue = AsyncMock(side_effect=asyncio.CancelledError())
+    trigger = _make_trigger(mimir=mimir, enabled=True)
+    with pytest.raises(asyncio.CancelledError):
+        await trigger.run(AsyncMock())
+
+
+# ---------------------------------------------------------------------------
+# get_thread_queue called with owner_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_thread_queue_called_with_owner_id_and_limit_1() -> None:
+    mimir = AsyncMock()
+    mimir.get_thread_queue = AsyncMock(return_value=[])
+    trigger = _make_trigger(mimir=mimir, owner_id="specific-agent")
+
+    await trigger._poll_once(AsyncMock())
+
+    mimir.get_thread_queue.assert_called_once_with(owner_id="specific-agent", limit=1)
+
+
+# ---------------------------------------------------------------------------
+# _title_from_path helper
+# ---------------------------------------------------------------------------
+
+
+def test_title_from_path_basic() -> None:
+    assert _title_from_path("threads/retrieval-architecture") == "Retrieval Architecture"
+
+
+def test_title_from_path_single_word() -> None:
+    assert _title_from_path("threads/auth") == "Auth"
+
+
+def test_title_from_path_no_slash() -> None:
+    assert _title_from_path("plain-slug") == "Plain Slug"
+
+
+# ---------------------------------------------------------------------------
+# owner_id defaults
+# ---------------------------------------------------------------------------
+
+
+def test_owner_id_generated_when_not_configured() -> None:
+    mimir = AsyncMock()
+    config = ThreadConfig(enabled=True, owner_id=None)
+    trigger = ThreadQueueTrigger(mimir=mimir, config=config)
+    assert trigger._owner_id.startswith("ravn-")
+    assert len(trigger._owner_id) > 5
+
+
+def test_owner_id_uses_config_when_set() -> None:
+    mimir = AsyncMock()
+    config = ThreadConfig(enabled=True, owner_id="my-ravn")
+    trigger = ThreadQueueTrigger(mimir=mimir, config=config)
+    assert trigger._owner_id == "my-ravn"


### PR DESCRIPTION
## Summary

- **Add `ThreadState.pulling`** to `niuu/domain/mimir.py` — new lifecycle state for threads actively being worked by a Ravn instance
- **Implement `ThreadQueueTrigger`** (`src/ravn/adapters/triggers/thread_queue.py`) — `TriggerPort` that polls `MimirPort.get_thread_queue()` and converts the top-weight thread into a drive-loop `AgentTask`
- **Wire trigger** in `_wire_mimir_triggers` (`cli/commands.py`) — registered on every daemon start alongside Mímir source/staleness triggers

## Behaviour

1. Polls `get_thread_queue(owner_id, limit=1)` on `thread.enricher_poll_interval_seconds` interval
2. `thread.enabled=False` (default) — `_poll_once` returns immediately, never enqueues (M1 default, M2 flips the switch)
3. Empty queue — skip
4. Thread found — `assign_thread_owner` (mutual exclusion) then `update_thread_state(pulling)` then enqueue `AgentTask`
5. `ThreadOwnershipError` — caught, logged at DEBUG, skip cycle (thread reappears on next poll)

## AgentTask

- `output_mode`: `AMBIENT` (work goes to Sleipnir, not directly to operator)
- `priority`: `max(1, min(10, int(10 - weight)))` — higher weight = more urgent
- `triggered_by`: `f"thread:{path}"`
- `title`: `page.meta.summary` (stores next_action_hint) or title-cased path stem

## Tests

23 unit tests, 95% coverage on new trigger file. All existing 1899+ tests still pass.

## Linear

Ticket: NIU-563 (Linear MCP unavailable in this session — ticket update noted here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)