### PR TITLE
feat(adapters): research-and-distill persona + ThreadQueueTrigger persona selection (NIU-566)

### DIFF
--- a/src/ravn/adapters/personas/loader.py
+++ b/src/ravn/adapters/personas/loader.py
@@ -177,6 +177,42 @@ _BUILTIN_PERSONAS: dict[str, PersonaConfig] = {
         llm=PersonaLLMConfig(primary_alias="balanced", thinking_enabled=False),
         iteration_budget=60,
     ),
+    "research-and-distill": PersonaConfig(
+        name="research-and-distill",
+        system_prompt_template=(
+            "You are a research and distillation agent for the Mímir knowledge base.\n\n"
+            "## Your task\n"
+            "Given an open question or thread, read available sources, synthesise the key "
+            "findings, and write a single distilled Mímir page under `research/{slug}.md`.\n\n"
+            "## Approach\n"
+            "1. Call `mimir_search` to check whether a relevant page already exists — "
+            "avoid duplicates.\n"
+            "2. Use `mimir_list` to browse related sections if needed.\n"
+            "3. Gather current information with `web_search` and `web_fetch`.\n"
+            "4. Read related Mímir pages with `mimir_read` to incorporate existing knowledge.\n"
+            "5. Synthesise findings into a concise, factual page — under 1500 words. "
+            "Prefer tables and bullet points over prose.\n"
+            "6. Write the page with `mimir_write` to `research/{slug}.md`. "
+            "Include `produced_by_thread: true` in the front matter.\n\n"
+            "## Constraints\n"
+            "- Do not copy-paste source text. Restate in your own words.\n"
+            "- Cross-link related pages using relative markdown links.\n"
+            "- Only create pages under `research/` — never modify existing pages.\n"
+            "- Keep output under 1500 words. Tables and bullet points preferred."
+        ),
+        allowed_tools=[
+            "mimir_search",
+            "mimir_read",
+            "mimir_write",
+            "mimir_list",
+            "web_search",
+            "web_fetch",
+        ],
+        forbidden_tools=["bash", "edit_file", "write_file", "terminal"],
+        permission_mode="read-only",
+        llm=PersonaLLMConfig(primary_alias="balanced", thinking_enabled=False),
+        iteration_budget=15,
+    ),
 }
 
 # ---------------------------------------------------------------------------

--- a/src/ravn/adapters/triggers/thread_queue.py
+++ b/src/ravn/adapters/triggers/thread_queue.py
@@ -46,9 +46,17 @@ _PRIORITY_MAX = 10
 # Keyword → persona mapping for wakefulness action shapes.
 # Keywords are matched case-insensitively against the next_action_hint.
 # Order matters: first match wins.
+# Note: "draft-a-note" is a forward reference — it does not exist in
+# ``_BUILTIN_PERSONAS`` yet and will be added in a follow-up ticket (NIU-567).
+# ``PersonaLoader.load("draft-a-note")`` returns ``None`` until then, causing
+# the DriveLoop to fall back to default settings.  This is intentional:
+# routing is wired ahead of the persona definition so the trigger does not
+# need to change when the persona lands.
 _PERSONA_KEYWORDS: list[tuple[str, list[str]]] = [
     ("draft-a-note", ["draft", "note", "capture", "observe"]),
 ]
+
+_DEFAULT_PERSONA = "research-and-distill"
 
 
 class ThreadQueueTrigger(TriggerPort):
@@ -125,10 +133,30 @@ class ThreadQueueTrigger(TriggerPort):
         # For thread MimirPages, meta.summary stores the next_action_hint
         # (populated by MarkdownMimirAdapter._schema_to_page and _parse_thread_page).
         next_action_hint = thread.meta.summary or ""
-        title = next_action_hint or _title_from_path(path)
+        thread_title = thread.meta.title or _title_from_path(path)
+        title = next_action_hint or thread_title
+
+        persona = _select_persona(next_action_hint)
+
+        if persona == "research-and-distill":
+            action_instruction = (
+                "Read relevant sources, synthesise findings, and write a distilled Mímir page "
+                "under research/ that answers the thread's open question. "
+                "Mark the output with produced_by_thread: true."
+            )
+        else:
+            action_instruction = (
+                "Draft a concise note capturing the thread's key points. "
+                "Mark the output with produced_by_thread: true."
+            )
 
         initiative_context = (
-            f"Thread: {path}\nWeight: {weight:.2f}\nNext action: {next_action_hint}\n"
+            f"Thread: {path}\n"
+            f"Title: {thread_title}\n"
+            f"Weight: {weight:.2f}\n"
+            f"Next action: {next_action_hint}\n"
+            f"\n"
+            f"{action_instruction}\n"
         )
 
         priority = max(_PRIORITY_MIN, min(_PRIORITY_MAX, int(_PRIORITY_MAX - weight)))
@@ -141,7 +169,7 @@ class ThreadQueueTrigger(TriggerPort):
             triggered_by=f"thread:{path}",
             output_mode=OutputMode.AMBIENT,
             priority=priority,
-            persona=_select_persona(next_action_hint),
+            persona=persona,
         )
         logger.info(
             "ThreadQueueTrigger: enqueuing task for thread %r (weight=%.2f, priority=%d)",
@@ -157,19 +185,19 @@ def _generate_owner_id() -> str:
     return f"ravn-{uuid.uuid4().hex[:8]}"
 
 
-def _select_persona(hint: str) -> str | None:
+def _select_persona(hint: str) -> str:
     """Map a next_action_hint to a persona name via keyword matching.
 
     Iterates ``_PERSONA_KEYWORDS`` in order; returns the first persona whose
     keyword list contains any word present in *hint* (case-insensitive).
-    Returns ``None`` when no keyword matches — the drive loop then falls back
-    to the default agent settings.
+    Falls back to ``_DEFAULT_PERSONA`` (``"research-and-distill"``) when no
+    keyword matches.
     """
     hint_lower = hint.lower()
     for persona_name, keywords in _PERSONA_KEYWORDS:
         if any(kw in hint_lower for kw in keywords):
             return persona_name
-    return None
+    return _DEFAULT_PERSONA
 
 
 def _title_from_path(path: str) -> str:

--- a/src/ravn/adapters/triggers/thread_queue.py
+++ b/src/ravn/adapters/triggers/thread_queue.py
@@ -46,12 +46,6 @@ _PRIORITY_MAX = 10
 # Keyword → persona mapping for wakefulness action shapes.
 # Keywords are matched case-insensitively against the next_action_hint.
 # Order matters: first match wins.
-# Note: "draft-a-note" is a forward reference — it does not exist in
-# ``_BUILTIN_PERSONAS`` yet and will be added in a follow-up ticket (NIU-567).
-# ``PersonaLoader.load("draft-a-note")`` returns ``None`` until then, causing
-# the DriveLoop to fall back to default settings.  This is intentional:
-# routing is wired ahead of the persona definition so the trigger does not
-# need to change when the persona lands.
 _PERSONA_KEYWORDS: list[tuple[str, list[str]]] = [
     ("draft-a-note", ["draft", "note", "capture", "observe"]),
 ]

--- a/tests/ravn/unit/test_thread_queue_trigger.py
+++ b/tests/ravn/unit/test_thread_queue_trigger.py
@@ -464,10 +464,6 @@ def test_owner_id_uses_config_when_set() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_select_persona_default_returns_research_and_distill() -> None:
-    assert _select_persona("") == "research-and-distill"
-
-
 def test_select_persona_empty_hint_returns_research_and_distill() -> None:
     assert _select_persona("") == "research-and-distill"
 

--- a/tests/ravn/unit/test_thread_queue_trigger.py
+++ b/tests/ravn/unit/test_thread_queue_trigger.py
@@ -24,7 +24,11 @@ import pytest
 
 from niuu.domain.mimir import ThreadOwnershipError, ThreadState
 from niuu.ports.mimir import MimirPage, MimirPageMeta
-from ravn.adapters.triggers.thread_queue import ThreadQueueTrigger, _title_from_path
+from ravn.adapters.triggers.thread_queue import (
+    ThreadQueueTrigger,
+    _select_persona,
+    _title_from_path,
+)
 from ravn.config import ThreadConfig
 from ravn.domain.models import AgentTask, OutputMode
 
@@ -453,3 +457,117 @@ def test_owner_id_uses_config_when_set() -> None:
     config = ThreadConfig(enabled=True, owner_id="my-ravn")
     trigger = ThreadQueueTrigger(mimir=mimir, config=config)
     assert trigger._owner_id == "my-ravn"
+
+
+# ---------------------------------------------------------------------------
+# _select_persona helper
+# ---------------------------------------------------------------------------
+
+
+def test_select_persona_default_returns_research_and_distill() -> None:
+    assert _select_persona("") == "research-and-distill"
+
+
+def test_select_persona_empty_hint_returns_research_and_distill() -> None:
+    assert _select_persona("") == "research-and-distill"
+
+
+def test_select_persona_generic_hint_returns_research_and_distill() -> None:
+    assert _select_persona("Compare HNSW vs flat index") == "research-and-distill"
+
+
+@pytest.mark.parametrize(
+    "hint",
+    [
+        "draft a summary",
+        "write a note about this",
+        "capture the key points",
+        "observe and record findings",
+        "Draft the outline",
+        "quick NOTE for later",
+    ],
+)
+def test_select_persona_draft_keywords_return_draft_a_note(hint: str) -> None:
+    assert _select_persona(hint) == "draft-a-note"
+
+
+# ---------------------------------------------------------------------------
+# persona field set on enqueued task
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_enqueued_task_has_persona_set() -> None:
+    mimir = AsyncMock()
+    page = _thread_page(summary="Compare HNSW vs flat")
+    mimir.get_thread_queue = AsyncMock(return_value=[page])
+    mimir.assign_thread_owner = AsyncMock()
+    mimir.update_thread_state = AsyncMock()
+    trigger = _make_trigger(mimir=mimir)
+    enqueued: list[AgentTask] = []
+
+    async def _enqueue(task: AgentTask) -> None:
+        enqueued.append(task)
+
+    await trigger._poll_once(_enqueue)
+
+    assert enqueued[0].persona == "research-and-distill"
+
+
+@pytest.mark.asyncio
+async def test_enqueued_task_persona_draft_a_note_for_draft_hint() -> None:
+    mimir = AsyncMock()
+    page = _thread_page(summary="draft outline for the new auth flow")
+    mimir.get_thread_queue = AsyncMock(return_value=[page])
+    mimir.assign_thread_owner = AsyncMock()
+    mimir.update_thread_state = AsyncMock()
+    trigger = _make_trigger(mimir=mimir)
+    enqueued: list[AgentTask] = []
+
+    async def _enqueue(task: AgentTask) -> None:
+        enqueued.append(task)
+
+    await trigger._poll_once(_enqueue)
+
+    assert enqueued[0].persona == "draft-a-note"
+
+
+# ---------------------------------------------------------------------------
+# initiative_context includes title
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_initiative_context_contains_title() -> None:
+    mimir = AsyncMock()
+    page = _thread_page(path="threads/retrieval-architecture", title="Retrieval Architecture")
+    mimir.get_thread_queue = AsyncMock(return_value=[page])
+    mimir.assign_thread_owner = AsyncMock()
+    mimir.update_thread_state = AsyncMock()
+    trigger = _make_trigger(mimir=mimir)
+    enqueued: list[AgentTask] = []
+
+    async def _enqueue(task: AgentTask) -> None:
+        enqueued.append(task)
+
+    await trigger._poll_once(_enqueue)
+
+    assert "Retrieval Architecture" in enqueued[0].initiative_context
+
+
+@pytest.mark.asyncio
+async def test_initiative_context_contains_produced_by_thread_instruction() -> None:
+    mimir = AsyncMock()
+    page = _thread_page()
+    mimir.get_thread_queue = AsyncMock(return_value=[page])
+    mimir.assign_thread_owner = AsyncMock()
+    mimir.update_thread_state = AsyncMock()
+    trigger = _make_trigger(mimir=mimir)
+    enqueued: list[AgentTask] = []
+
+    async def _enqueue(task: AgentTask) -> None:
+        enqueued.append(task)
+
+    await trigger._poll_once(_enqueue)
+
+    assert "produced_by_thread" in enqueued[0].initiative_context

--- a/tests/test_ravn/test_persona_loader.py
+++ b/tests/test_ravn/test_persona_loader.py
@@ -226,6 +226,8 @@ class TestListBuiltinNames:
         assert "research-agent" in names
         assert "planning-agent" in names
         assert "autonomous-agent" in names
+        assert "draft-a-note" in names
+        assert "research-and-distill" in names
 
     def test_returns_sorted_list(self) -> None:
         names = PersonaLoader().list_builtin_names()
@@ -302,6 +304,30 @@ class TestBuiltinPersonas:
     def test_draft_a_note_system_prompt_mentions_notes_path(self) -> None:
         cfg = _BUILTIN_PERSONAS["draft-a-note"]
         assert "notes/" in cfg.system_prompt_template
+
+    def test_research_and_distill_exists(self) -> None:
+        cfg = _BUILTIN_PERSONAS["research-and-distill"]
+        assert cfg.name == "research-and-distill"
+        assert cfg.permission_mode == "read-only"
+        assert cfg.iteration_budget == 15
+        assert "mimir_search" in cfg.allowed_tools
+        assert "mimir_read" in cfg.allowed_tools
+        assert "mimir_write" in cfg.allowed_tools
+        assert "mimir_list" in cfg.allowed_tools
+        assert "web_search" in cfg.allowed_tools
+        assert "web_fetch" in cfg.allowed_tools
+        assert "bash" in cfg.forbidden_tools
+        assert "terminal" in cfg.forbidden_tools
+        assert "edit_file" in cfg.forbidden_tools
+        assert "write_file" in cfg.forbidden_tools
+
+    def test_research_and_distill_system_prompt_mentions_produced_by_thread(self) -> None:
+        cfg = _BUILTIN_PERSONAS["research-and-distill"]
+        assert "produced_by_thread" in cfg.system_prompt_template
+
+    def test_research_and_distill_system_prompt_mentions_word_limit(self) -> None:
+        cfg = _BUILTIN_PERSONAS["research-and-distill"]
+        assert "1500" in cfg.system_prompt_template
 
     def test_all_builtins_have_system_prompts(self) -> None:
         for name, cfg in _BUILTIN_PERSONAS.items():

--- a/tests/test_ravn/test_thread_queue_trigger.py
+++ b/tests/test_ravn/test_thread_queue_trigger.py
@@ -375,11 +375,11 @@ class TestSelectPersona:
     def test_case_insensitive_matching(self) -> None:
         assert _select_persona("Draft a quick NOTE") == "draft-a-note"
 
-    def test_unrecognised_hint_returns_none(self) -> None:
-        assert _select_persona("process the backlog items") is None
+    def test_unrecognised_hint_returns_default(self) -> None:
+        assert _select_persona("process the backlog items") == "research-and-distill"
 
-    def test_empty_hint_returns_none(self) -> None:
-        assert _select_persona("") is None
+    def test_empty_hint_returns_default(self) -> None:
+        assert _select_persona("") == "research-and-distill"
 
 
 # ---------------------------------------------------------------------------
@@ -402,7 +402,7 @@ class TestPersonaSelection:
         assert enqueued[0].persona == "draft-a-note"
 
     @pytest.mark.asyncio
-    async def test_unrecognised_hint_leaves_persona_none(self) -> None:
+    async def test_unrecognised_hint_uses_default_persona(self) -> None:
         mimir = AsyncMock()
         page = _thread_page(summary="process the next batch of items")
         mimir.get_thread_queue = AsyncMock(return_value=[page])
@@ -412,10 +412,10 @@ class TestPersonaSelection:
 
         enqueued = await _collect_enqueued(trigger)
 
-        assert enqueued[0].persona is None
+        assert enqueued[0].persona == "research-and-distill"
 
     @pytest.mark.asyncio
-    async def test_no_hint_leaves_persona_none(self) -> None:
+    async def test_no_hint_uses_default_persona(self) -> None:
         mimir = AsyncMock()
         page = _thread_page(summary="")
         mimir.get_thread_queue = AsyncMock(return_value=[page])
@@ -425,7 +425,7 @@ class TestPersonaSelection:
 
         enqueued = await _collect_enqueued(trigger)
 
-        assert enqueued[0].persona is None
+        assert enqueued[0].persona == "research-and-distill"
 
     @pytest.mark.asyncio
     async def test_capture_hint_sets_draft_a_note_persona(self) -> None:


### PR DESCRIPTION
## Summary

Implements build-order step 4a from the Vaka vision — the first action shape (NIU-566).

- **New `research-and-distill` persona** added to `_BUILTIN_PERSONAS` in `src/ravn/adapters/personas/loader.py`:
  - Reads sources via `mimir_search`, `mimir_read`, `mimir_list`, `web_search`, `web_fetch`
  - Writes a distilled Mímir page under `research/{slug}.md` with `produced_by_thread: true` in front matter
  - `permission_mode: read-only`, `iteration_budget: 15`, output capped at 1500 words, tables/bullets preferred
  - Forbidden tools: `bash`, `edit_file`, `write_file`, `terminal`

- **`_select_persona(hint)` function** added to `src/ravn/adapters/triggers/thread_queue.py`:
  - Keywords `draft`, `note`, `capture`, `observe` in `next_action_hint` → `"draft-a-note"`
  - All other hints (and `None`) → `"research-and-distill"` (default)

- **`ThreadQueueTrigger._poll_once`** updated to:
  - Call `_select_persona` and set `persona` on the enqueued `AgentTask`
  - Enrich `initiative_context` with thread title and instructions to produce a `produced_by_thread: true` artifact

## Test plan

- [x] `test_research_and_distill_exists` — validates all tools, permission_mode, iteration_budget
- [x] `test_research_and_distill_system_prompt_mentions_produced_by_thread` — checks front matter instruction
- [x] `test_research_and_distill_system_prompt_mentions_word_limit` — checks 1500-word constraint
- [x] `_select_persona` parametrized tests — draft keywords → `draft-a-note`, default → `research-and-distill`
- [x] `test_enqueued_task_has_persona_set` — verifies `persona` field on `AgentTask`
- [x] `test_initiative_context_contains_title` — thread title present in context
- [x] `test_initiative_context_contains_produced_by_thread_instruction` — instruction present in context

## Notes

Pre-existing CI issues (present on `feat/vaka-ravn-wakefulness` before this PR):
- `test_tui_pages_returns_agents_page` fails due to missing `textual` module in the CI environment
- Total coverage sits at ~84.97% (just under the 85% threshold by 0.03%); new code added in this PR is fully covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)