### PR TITLE
feat(config): trust gradient as configuration (NIU-571)

### DIFF
--- a/ravn.example.yaml
+++ b/ravn.example.yaml
@@ -58,6 +58,29 @@
 #   owner_id: null                      # defaults to this instance's own ID
 
 # ---------------------------------------------------------------------------
+# Trust gradient (NIU-571)
+#
+# Constrains what the Ravn can do autonomously during wakefulness.
+# Each category maps to a trust level:
+#   "free"     — action allowed without operator intervention
+#   "approval" — tool forbidden; agent writes an approval request to approvals/
+#   "never"    — tool unconditionally forbidden
+# ---------------------------------------------------------------------------
+# trust:
+#   reading: free
+#   writing_notes: free
+#   sandbox_experiments: free
+#   consulting_peers: free
+#   drafting_tickets: free
+#   producing_recaps: free
+#   opening_tickets: approval
+#   closing_tickets: approval
+#   pushing_branches: approval
+#   pushing_main: never
+#   external_messages: approval
+#   spending_beyond_cap: approval
+
+# ---------------------------------------------------------------------------
 # Memory
 # ---------------------------------------------------------------------------
 # memory:

--- a/src/ravn/cli/commands.py
+++ b/src/ravn/cli/commands.py
@@ -483,6 +483,21 @@ def _in_groups(name: str, groups: set[str]) -> bool:
     return any(name == g or name.startswith(g + "_") for g in groups)
 
 
+def _apply_trust_filter(
+    tools: list[Any],
+    settings: Settings,
+    triggered_by: str | None,
+) -> list[Any]:
+    """Remove tools forbidden by the trust gradient for thread-triggered tasks."""
+    if not triggered_by or not triggered_by.startswith("thread:"):
+        return tools
+    _allowed, forbidden = resolve_trust_tools(settings.trust)
+    if not forbidden:
+        return tools
+    forbidden_set = set(forbidden)
+    return [t for t in tools if not _in_groups(t.name, forbidden_set)]
+
+
 def _filter_tools(
     tools: list[Any],
     settings: Settings,
@@ -1877,11 +1892,7 @@ async def _run_daemon(
                 tools.extend(cron_tools)
 
         # NIU-571: Apply trust gradient constraints for thread-triggered tasks
-        if triggered_by and triggered_by.startswith("thread:"):
-            _trust_allowed, trust_forbidden = resolve_trust_tools(settings.trust)
-            if trust_forbidden:
-                forbidden_set = set(trust_forbidden)
-                tools = [t for t in tools if not _in_groups(t.name, forbidden_set)]
+        tools = _apply_trust_filter(tools, settings, triggered_by)
 
         return RavnAgent(
             llm=llm,

--- a/src/ravn/cli/commands.py
+++ b/src/ravn/cli/commands.py
@@ -14,7 +14,14 @@ from typing import Any
 import typer
 
 from ravn.agent import PostToolHook, PreToolHook, RavnAgent
-from ravn.config import InitiativeConfig, OutcomeConfig, ProjectConfig, Settings, ToolGroupConfig
+from ravn.config import (
+    InitiativeConfig,
+    OutcomeConfig,
+    ProjectConfig,
+    Settings,
+    ToolGroupConfig,
+    resolve_trust_tools,
+)
 from ravn.domain.checkpoint import InterruptReason
 from ravn.domain.models import (
     Message,
@@ -467,6 +474,15 @@ def _build_tools(
     return tools
 
 
+def _in_groups(name: str, groups: set[str]) -> bool:
+    """Return True if *name* matches any group prefix in *groups*.
+
+    A match means either an exact hit (``name == group``) or a prefixed
+    hit (``name`` starts with ``group_``).
+    """
+    return any(name == g or name.startswith(g + "_") for g in groups)
+
+
 def _filter_tools(
     tools: list[Any],
     settings: Settings,
@@ -488,9 +504,6 @@ def _filter_tools(
             allowed_groups = set(persona_config.allowed_tools)
         if persona_config.forbidden_tools:
             forbidden_groups = set(persona_config.forbidden_tools)
-
-    def _in_groups(name: str, groups: set[str]) -> bool:
-        return any(name == g or name.startswith(g + "_") for g in groups)
 
     if allowed_groups or enabled_names:
         tools = [
@@ -1865,25 +1878,10 @@ async def _run_daemon(
 
         # NIU-571: Apply trust gradient constraints for thread-triggered tasks
         if triggered_by and triggered_by.startswith("thread:"):
-            from ravn.config import resolve_trust_tools
-
-            persona_allowed = resolved_persona.allowed_tools if resolved_persona else None
-            persona_forbidden = resolved_persona.forbidden_tools if resolved_persona else None
-            _trust_allowed, trust_forbidden = resolve_trust_tools(
-                settings.trust,
-                persona_allowed=persona_allowed,
-                persona_forbidden=persona_forbidden,
-            )
+            _trust_allowed, trust_forbidden = resolve_trust_tools(settings.trust)
             if trust_forbidden:
                 forbidden_set = set(trust_forbidden)
-                tools = [
-                    t
-                    for t in tools
-                    if not any(
-                        t.name == prefix or t.name.startswith(prefix + "_")
-                        for prefix in forbidden_set
-                    )
-                ]
+                tools = [t for t in tools if not _in_groups(t.name, forbidden_set)]
 
         return RavnAgent(
             llm=llm,

--- a/src/ravn/cli/commands.py
+++ b/src/ravn/cli/commands.py
@@ -1800,6 +1800,7 @@ async def _run_daemon(
         channel: ChannelPort,
         task_id: str | None = None,
         task_persona: str | None = None,
+        triggered_by: str | None = None,
     ) -> Any:
         # Resolve per-task persona — triggered tasks may request a different persona.
         resolved_persona = persona_config
@@ -1861,6 +1862,28 @@ async def _run_daemon(
             # Add cron scheduling tools
             if cron_tools:
                 tools.extend(cron_tools)
+
+        # NIU-571: Apply trust gradient constraints for thread-triggered tasks
+        if triggered_by and triggered_by.startswith("thread:"):
+            from ravn.config import resolve_trust_tools
+
+            persona_allowed = resolved_persona.allowed_tools if resolved_persona else None
+            persona_forbidden = resolved_persona.forbidden_tools if resolved_persona else None
+            _trust_allowed, trust_forbidden = resolve_trust_tools(
+                settings.trust,
+                persona_allowed=persona_allowed,
+                persona_forbidden=persona_forbidden,
+            )
+            if trust_forbidden:
+                forbidden_set = set(trust_forbidden)
+                tools = [
+                    t
+                    for t in tools
+                    if not any(
+                        t.name == prefix or t.name.startswith(prefix + "_")
+                        for prefix in forbidden_set
+                    )
+                ]
 
         return RavnAgent(
             llm=llm,

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -2038,7 +2038,7 @@ def resolve_trust_tools(
     if persona_allowed:
         # Intersection: only tools allowed by BOTH persona and trust gradient
         trust_allowed_set = set(trust_allowed)
-        all_trust = _all_trust_tools()
+        all_trust = _ALL_TRUST_TOOLS
         merged_allowed = [
             t for t in persona_allowed if t in trust_allowed_set or t not in all_trust
         ]
@@ -2054,12 +2054,7 @@ def _iter_trust_categories(config: TrustGradientConfig):
         yield field_name, getattr(config, field_name)
 
 
-def _all_trust_tools() -> set[str]:
-    """Return the set of all tool prefixes governed by the trust gradient."""
-    result: set[str] = set()
-    for tools in TRUST_CATEGORY_TOOLS.values():
-        result.update(tools)
-    return result
+_ALL_TRUST_TOOLS: set[str] = {t for tools in TRUST_CATEGORY_TOOLS.values() for t in tools}
 
 
 # ---------------------------------------------------------------------------

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -1902,6 +1902,167 @@ class WakefulnessConfig(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# NIU-571: Trust gradient — constrains tool availability per category
+# ---------------------------------------------------------------------------
+
+TrustLevel = Literal["free", "approval", "never"]
+
+
+class TrustGradientConfig(BaseModel):
+    """Trust gradient policy for wakefulness personas (NIU-571).
+
+    Each category maps to a trust level that controls whether the Ravn can
+    perform the action freely, must request operator approval (by writing a
+    Mímir page under ``approvals/``), or is permanently forbidden.
+
+    Levels:
+      - ``"free"``     — action is allowed without operator intervention.
+      - ``"approval"`` — tool is forbidden at runtime; agent writes an
+                         approval request to ``approvals/{slug}.md``.
+      - ``"never"``    — tool is unconditionally forbidden.
+
+    Override via ``trust:`` section in ``ravn.yaml`` or ``RAVN_TRUST__*``
+    environment variables.
+    """
+
+    reading: TrustLevel = Field(
+        default="free",
+        description="Papers, docs, code, ingest.",
+    )
+    writing_notes: TrustLevel = Field(
+        default="free",
+        description="Drafts to Mímir.",
+    )
+    sandbox_experiments: TrustLevel = Field(
+        default="free",
+        description="Völundr sessions.",
+    )
+    consulting_peers: TrustLevel = Field(
+        default="free",
+        description="Bifröst cloud calls within budget.",
+    )
+    drafting_tickets: TrustLevel = Field(
+        default="free",
+        description="Linear drafts (not creation).",
+    )
+    producing_recaps: TrustLevel = Field(
+        default="free",
+        description="Recap generation.",
+    )
+    opening_tickets: TrustLevel = Field(
+        default="approval",
+        description="Creating Linear tickets.",
+    )
+    closing_tickets: TrustLevel = Field(
+        default="approval",
+        description="Closing Linear tickets.",
+    )
+    pushing_branches: TrustLevel = Field(
+        default="approval",
+        description="Git push to feature branches.",
+    )
+    pushing_main: TrustLevel = Field(
+        default="never",
+        description="Git push to main.",
+    )
+    external_messages: TrustLevel = Field(
+        default="approval",
+        description="Slack, email, Telegram to non-operator.",
+    )
+    spending_beyond_cap: TrustLevel = Field(
+        default="approval",
+        description="Exceeding daily budget.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# NIU-571: Trust gradient tool resolution
+# ---------------------------------------------------------------------------
+
+# Maps trust categories → concrete tool name prefixes.  A category may map to
+# multiple tools (e.g. ``reading`` covers several tool prefixes).  Tool names
+# are matched by prefix — ``"mimir"`` matches ``mimir_query``, ``mimir_write``,
+# etc. — consistent with PersonaConfig's existing prefix-match convention.
+TRUST_CATEGORY_TOOLS: dict[str, list[str]] = {
+    "reading": ["file_read", "web_search", "web_fetch", "mimir_query", "mimir_search"],
+    "writing_notes": ["mimir_write", "mimir_ingest"],
+    "sandbox_experiments": ["volundr", "bash", "terminal"],
+    "consulting_peers": ["cascade", "bifrost"],
+    "drafting_tickets": ["linear_draft"],
+    "producing_recaps": ["recap"],
+    "opening_tickets": ["linear_create"],
+    "closing_tickets": ["linear_close", "linear_update"],
+    "pushing_branches": ["git_push"],
+    "pushing_main": ["git_push_main"],
+    "external_messages": ["slack", "email", "telegram"],
+    "spending_beyond_cap": ["budget_override"],
+}
+
+
+def resolve_trust_tools(
+    config: TrustGradientConfig,
+    persona_allowed: list[str] | None = None,
+    persona_forbidden: list[str] | None = None,
+) -> tuple[list[str], list[str]]:
+    """Map trust gradient config to concrete allowed/forbidden tool lists.
+
+    Returns ``(allowed, forbidden)`` where each list contains tool name
+    prefixes.  The caller should apply these as additional constraints on
+    top of the persona's own tool lists.
+
+    When *persona_allowed* or *persona_forbidden* are provided, the result
+    is merged via intersection semantics:
+
+    - A tool is allowed only if **both** the trust gradient and persona
+      permit it (intersection, not union).
+    - A tool is forbidden if **either** the trust gradient or persona
+      forbids it (union of forbidden sets).
+    """
+    trust_allowed: list[str] = []
+    trust_forbidden: list[str] = []
+
+    for category, level in _iter_trust_categories(config):
+        tools = TRUST_CATEGORY_TOOLS.get(category, [])
+        if level == "free":
+            trust_allowed.extend(tools)
+        else:
+            # Both "approval" and "never" result in tools being forbidden
+            trust_forbidden.extend(tools)
+
+    # Merge with persona constraints
+    if persona_forbidden:
+        merged_forbidden = list(dict.fromkeys(trust_forbidden + persona_forbidden))
+    else:
+        merged_forbidden = trust_forbidden
+
+    if persona_allowed:
+        # Intersection: only tools allowed by BOTH persona and trust gradient
+        trust_allowed_set = set(trust_allowed)
+        all_trust = _all_trust_tools()
+        merged_allowed = [
+            t for t in persona_allowed if t in trust_allowed_set or t not in all_trust
+        ]
+    else:
+        merged_allowed = trust_allowed
+
+    return merged_allowed, merged_forbidden
+
+
+def _iter_trust_categories(config: TrustGradientConfig):
+    """Yield ``(category_name, trust_level)`` for each field."""
+    for field_name in TrustGradientConfig.model_fields:
+        yield field_name, getattr(config, field_name)
+
+
+def _all_trust_tools() -> set[str]:
+    """Return the set of all tool prefixes governed by the trust gradient."""
+    result: set[str] = set()
+    for tools in TRUST_CATEGORY_TOOLS.values():
+        result.update(tools)
+    return result
+
+
+# ---------------------------------------------------------------------------
 # Root settings
 # ---------------------------------------------------------------------------
 
@@ -2055,6 +2216,9 @@ class Settings(BaseSettings):
 
     # NIU-565: wakefulness trigger
     wakefulness: WakefulnessConfig = Field(default_factory=WakefulnessConfig)
+
+    # NIU-571: trust gradient — constrains wakefulness tool availability
+    trust: TrustGradientConfig = Field(default_factory=TrustGradientConfig)
 
     # NIU-541: Búri knowledge memory substrate
     buri: BuriConfig = Field(default_factory=BuriConfig)

--- a/src/ravn/drive_loop.py
+++ b/src/ravn/drive_loop.py
@@ -52,7 +52,7 @@ class DriveLoop:
 
     def __init__(
         self,
-        agent_factory: Callable[[ChannelPort, str | None, str | None], object],
+        agent_factory: Callable[[ChannelPort, str | None, str | None, str | None], object],
         config: InitiativeConfig,
         settings: Settings,
         event_publisher: EventPublisherPort | None = None,
@@ -271,7 +271,7 @@ class DriveLoop:
             channel: ChannelPort = CaptureChannel(task.task_id, self._result_store)
         else:
             channel = SilentChannel()
-        agent = self._agent_factory(channel, task.task_id, task.persona)
+        agent = self._agent_factory(channel, task.task_id, task.persona, task.triggered_by)
         prompt = build_initiative_prompt(task)
 
         logger.info(

--- a/src/ravn/drive_loop.py
+++ b/src/ravn/drive_loop.py
@@ -39,11 +39,13 @@ MeshRpcHandler = Callable[[dict], Awaitable[dict]]
 class DriveLoop:
     """Perpetually-running initiative engine.
 
-    ``agent_factory(channel, task_id, persona)`` is called per task to create an
-    isolated :class:`ravn.agent.RavnAgent` instance.  The ``task_id``
-    parameter lets the agent (and its SleipnirChannel) tag all emitted
-    events with the correct task correlation ID.  The ``persona`` parameter
-    allows per-task persona overrides (may be ``None`` to use the default).
+    ``agent_factory(channel, task_id, persona, triggered_by)`` is called per
+    task to create an isolated :class:`ravn.agent.RavnAgent` instance.  The
+    ``task_id`` parameter lets the agent (and its SleipnirChannel) tag all
+    emitted events with the correct task correlation ID.  The ``persona``
+    parameter allows per-task persona overrides (may be ``None`` to use the
+    default).  The ``triggered_by`` parameter carries the trigger source
+    (e.g. ``"thread:<slug>"``) so the factory can apply trust constraints.
 
     Human-initiated turns (from the gateway) are NOT subject to the
     ``max_concurrent_tasks`` cap — that cap only applies to initiative tasks

--- a/tests/ravn/unit/test_drive_loop.py
+++ b/tests/ravn/unit/test_drive_loop.py
@@ -936,7 +936,7 @@ async def test_drive_loop_runs_agent_turn_from_cron(tmp_path: Path) -> None:
 
     mock_agent.run_turn = _capture_run_turn
 
-    def agent_factory(channel, task_id=None, persona=None):
+    def agent_factory(channel, task_id=None, persona=None, triggered_by=None):
         return mock_agent
 
     drive_loop = DriveLoop(agent_factory=agent_factory, config=config, settings=settings)

--- a/tests/test_ravn/test_capture.py
+++ b/tests/test_ravn/test_capture.py
@@ -331,7 +331,7 @@ class TestDriveLoopCaptureIntegration:
         mock_agent = MagicMock()
         mock_agent.run_turn = _mock_run_turn
 
-        def _agent_factory(channel, task_id=None, persona=None):  # noqa: ANN001
+        def _agent_factory(channel, task_id=None, persona=None, triggered_by=None):  # noqa: ANN001
             captured_channels.append(channel)
             return mock_agent
 
@@ -370,7 +370,7 @@ class TestDriveLoopCaptureIntegration:
         mock_agent = MagicMock()
         mock_agent.run_turn = _mock_run_turn
 
-        def _agent_factory(channel, task_id=None, persona=None):  # noqa: ANN001
+        def _agent_factory(channel, task_id=None, persona=None, triggered_by=None):  # noqa: ANN001
             captured_channels.append(channel)
             return mock_agent
 
@@ -403,7 +403,7 @@ class TestDriveLoopCaptureIntegration:
         mock_agent = MagicMock()
         mock_agent.run_turn = _mock_run_turn_raises
 
-        def _agent_factory(channel, task_id=None, persona=None):  # noqa: ANN001
+        def _agent_factory(channel, task_id=None, persona=None, triggered_by=None):  # noqa: ANN001
             return mock_agent
 
         cfg = InitiativeConfig(enabled=True, max_concurrent_tasks=1, task_queue_max=10)
@@ -606,7 +606,7 @@ async def test_integration_two_local_tasks_progress_and_collect():
 
     run_turn_map = {task_1: _run_task1, task_2: _run_task2}
 
-    def _agent_factory(channel, task_id=None, persona=None):  # noqa: ANN001
+    def _agent_factory(channel, task_id=None, persona=None, triggered_by=None):  # noqa: ANN001
         if task_id is not None:
             channel_map[task_id] = channel
         agent = MagicMock()

--- a/tests/test_ravn/test_cascade.py
+++ b/tests/test_ravn/test_cascade.py
@@ -670,7 +670,7 @@ async def test_mode1_local_parallel_tasks():
     mock_agent = MagicMock()
     mock_agent.run_turn = _mock_run_turn
 
-    def _agent_factory(channel, task_id=None, persona=None):  # noqa: ANN001
+    def _agent_factory(channel, task_id=None, persona=None, triggered_by=None):  # noqa: ANN001
         return mock_agent
 
     cfg = InitiativeConfig(enabled=True, max_concurrent_tasks=3, task_queue_max=50)

--- a/tests/test_ravn/test_cascade_delegation.py
+++ b/tests/test_ravn/test_cascade_delegation.py
@@ -197,7 +197,7 @@ class TestDriveLoopDeadline:
         executed: list[str] = []
         barrier = asyncio.Event()
 
-        def _factory(channel, task_id=None, persona=None):  # noqa: ANN001
+        def _factory(channel, task_id=None, persona=None, triggered_by=None):  # noqa: ANN001
             mock = MagicMock()
 
             async def _run(prompt: str) -> None:
@@ -278,7 +278,7 @@ class TestDriveLoopEventPublishing:
         publisher = _RecordingPublisher()
         finished = asyncio.Event()
 
-        def _factory(channel, task_id=None, persona=None):  # noqa: ANN001
+        def _factory(channel, task_id=None, persona=None, triggered_by=None):  # noqa: ANN001
             mock = MagicMock()
 
             async def _run(prompt: str) -> None:
@@ -305,7 +305,7 @@ class TestDriveLoopEventPublishing:
         publisher = _RecordingPublisher()
         finished = asyncio.Event()
 
-        def _factory(channel, task_id=None, persona=None):  # noqa: ANN001
+        def _factory(channel, task_id=None, persona=None, triggered_by=None):  # noqa: ANN001
             mock = MagicMock()
 
             async def _run(prompt: str) -> None:
@@ -333,7 +333,7 @@ class TestDriveLoopEventPublishing:
         publisher = _RecordingPublisher()
         finished = asyncio.Event()
 
-        def _factory(channel, task_id=None, persona=None):  # noqa: ANN001
+        def _factory(channel, task_id=None, persona=None, triggered_by=None):  # noqa: ANN001
             mock = MagicMock()
 
             async def _run(prompt: str) -> None:
@@ -363,7 +363,7 @@ class TestDriveLoopEventPublishing:
         publisher = _RecordingPublisher()
         finished = asyncio.Event()
 
-        def _factory(channel, task_id=None, persona=None):  # noqa: ANN001
+        def _factory(channel, task_id=None, persona=None, triggered_by=None):  # noqa: ANN001
             mock = MagicMock()
 
             async def _run(prompt: str) -> None:
@@ -401,7 +401,7 @@ class TestDriveLoopLifecycle:
         started = asyncio.Event()
         done = asyncio.Event()
 
-        def _factory(channel, task_id=None, persona=None):  # noqa: ANN001
+        def _factory(channel, task_id=None, persona=None, triggered_by=None):  # noqa: ANN001
             mock = MagicMock()
 
             async def _run(prompt: str) -> None:
@@ -432,7 +432,7 @@ class TestDriveLoopLifecycle:
         """A task that raises an exception is removed from _active_tasks."""
         finished = asyncio.Event()
 
-        def _factory(channel, task_id=None, persona=None):  # noqa: ANN001
+        def _factory(channel, task_id=None, persona=None, triggered_by=None):  # noqa: ANN001
             mock = MagicMock()
 
             async def _run(prompt: str) -> None:
@@ -460,7 +460,7 @@ class TestDriveLoopLifecycle:
         publisher = _RecordingPublisher()
         started = asyncio.Event()
 
-        def _factory(channel, task_id=None, persona=None):  # noqa: ANN001
+        def _factory(channel, task_id=None, persona=None, triggered_by=None):  # noqa: ANN001
             mock = MagicMock()
 
             async def _run(prompt: str) -> None:
@@ -499,7 +499,7 @@ class TestDriveLoopSurfaceEscalation:
         publisher = _RecordingPublisher()
         finished = asyncio.Event()
 
-        def _factory(channel, task_id=None, persona=None):  # noqa: ANN001
+        def _factory(channel, task_id=None, persona=None, triggered_by=None):  # noqa: ANN001
             mock = MagicMock()
 
             async def _run(prompt: str) -> None:
@@ -825,7 +825,7 @@ class TestEpistemicSovereignty:
         done_count = [0]
         all_done = asyncio.Event()
 
-        def _factory(channel, task_id=None, persona=None):  # noqa: ANN001
+        def _factory(channel, task_id=None, persona=None, triggered_by=None):  # noqa: ANN001
             instance = MagicMock()
 
             async def _run(prompt: str) -> None:
@@ -867,7 +867,7 @@ class TestTeamSimulation:
         done_count = [0]
         all_done = asyncio.Event()
 
-        def _factory(channel, task_id=None, persona=None):  # noqa: ANN001
+        def _factory(channel, task_id=None, persona=None, triggered_by=None):  # noqa: ANN001
             mock = MagicMock()
 
             async def _run(prompt: str) -> None:
@@ -900,7 +900,7 @@ class TestTeamSimulation:
         done_count = [0]
         all_done = asyncio.Event()
 
-        def _factory(channel, task_id=None, persona=None):  # noqa: ANN001
+        def _factory(channel, task_id=None, persona=None, triggered_by=None):  # noqa: ANN001
             mock = MagicMock()
 
             async def _run(prompt: str) -> None:
@@ -933,7 +933,7 @@ class TestTeamSimulation:
         """TaskCollectTool reports complete=True once the task is no longer active."""
         done = asyncio.Event()
 
-        def _factory(channel, task_id=None, persona=None):  # noqa: ANN001
+        def _factory(channel, task_id=None, persona=None, triggered_by=None):  # noqa: ANN001
             mock = MagicMock()
 
             async def _run(prompt: str) -> None:
@@ -973,7 +973,7 @@ class TestErrorHandling:
         executed: list[str] = []
         success_done = asyncio.Event()
 
-        def _factory(channel, task_id=None, persona=None):  # noqa: ANN001
+        def _factory(channel, task_id=None, persona=None, triggered_by=None):  # noqa: ANN001
             mock = MagicMock()
 
             async def _run(prompt: str) -> None:
@@ -1034,7 +1034,7 @@ class TestE2EDelegation:
         """E2E: parent calls task_create → task runs → parent calls task_collect → result."""
         done = asyncio.Event()
 
-        def _factory(channel, task_id=None, persona=None):  # noqa: ANN001
+        def _factory(channel, task_id=None, persona=None, triggered_by=None):  # noqa: ANN001
             mock = MagicMock()
 
             async def _run(prompt: str) -> None:
@@ -1078,7 +1078,7 @@ class TestE2EDelegation:
         done_count = [0]
         all_done = asyncio.Event()
 
-        def _factory(channel, task_id=None, persona=None):  # noqa: ANN001
+        def _factory(channel, task_id=None, persona=None, triggered_by=None):  # noqa: ANN001
             mock = MagicMock()
 
             async def _run(prompt: str) -> None:
@@ -1124,7 +1124,7 @@ class TestE2EDelegation:
         """Sub-ravn fails → task status is 'unknown' → parent can detect and handle."""
         failed = asyncio.Event()
 
-        def _factory(channel, task_id=None, persona=None):  # noqa: ANN001
+        def _factory(channel, task_id=None, persona=None, triggered_by=None):  # noqa: ANN001
             mock = MagicMock()
 
             async def _run(prompt: str) -> None:

--- a/tests/test_ravn/test_config.py
+++ b/tests/test_ravn/test_config.py
@@ -694,3 +694,106 @@ class TestSettingsTrust:
         with patch.dict(os.environ, {"RAVN_TRUST__PUSHING_MAIN": "approval"}):
             s = Settings()
             assert s.trust.pushing_main == "approval"
+
+
+class TestInGroups:
+    """Tests for the module-level _in_groups helper in commands.py."""
+
+    def test_exact_match(self) -> None:
+        from ravn.cli.commands import _in_groups
+
+        assert _in_groups("mimir", {"mimir"}) is True
+
+    def test_prefix_match(self) -> None:
+        from ravn.cli.commands import _in_groups
+
+        assert _in_groups("mimir_query", {"mimir"}) is True
+
+    def test_no_match(self) -> None:
+        from ravn.cli.commands import _in_groups
+
+        assert _in_groups("git_push", {"mimir"}) is False
+
+    def test_partial_no_match(self) -> None:
+        from ravn.cli.commands import _in_groups
+
+        # "mimir" should NOT match "mimirx" (no underscore separator)
+        assert _in_groups("mimirx", {"mimir"}) is False
+
+    def test_empty_groups(self) -> None:
+        from ravn.cli.commands import _in_groups
+
+        assert _in_groups("mimir", set()) is False
+
+    def test_multiple_groups(self) -> None:
+        from ravn.cli.commands import _in_groups
+
+        assert _in_groups("slack_post", {"mimir", "slack"}) is True
+
+
+class TestTrustGradientWiring:
+    """Tests for the trust gradient filtering logic applied in _agent_factory.
+
+    These verify that resolve_trust_tools output correctly filters tools
+    when combined with _in_groups, mirroring the wiring block in commands.py.
+    """
+
+    def test_thread_triggered_filters_forbidden_tools(self) -> None:
+        """Simulate the wiring: forbidden tools from trust gradient are removed."""
+        from ravn.cli.commands import _in_groups
+
+        config = TrustGradientConfig(pushing_main="never", reading="free")
+        _allowed, forbidden = resolve_trust_tools(config)
+
+        # pushing_main tools should be in forbidden
+        assert "git_push_main" in forbidden
+
+        # Simulate the filtering from commands.py
+        class FakeTool:
+            def __init__(self, name: str):
+                self.name = name
+
+        tools = [
+            FakeTool("file_read"),
+            FakeTool("git_push_main"),
+            FakeTool("mimir_query"),
+            FakeTool("linear_create"),
+        ]
+        forbidden_set = set(forbidden)
+        filtered = [t for t in tools if not _in_groups(t.name, forbidden_set)]
+
+        filtered_names = [t.name for t in filtered]
+        assert "file_read" in filtered_names
+        assert "mimir_query" in filtered_names
+        assert "git_push_main" not in filtered_names
+        # linear_create is "approval" by default → also forbidden
+        assert "linear_create" not in filtered_names
+
+    def test_all_free_no_filtering(self) -> None:
+        """When all categories are free, nothing is filtered."""
+        from ravn.cli.commands import _in_groups
+
+        config = TrustGradientConfig(
+            **{field: "free" for field in TrustGradientConfig.model_fields},
+        )
+        _allowed, forbidden = resolve_trust_tools(config)
+        assert forbidden == []
+
+        class FakeTool:
+            def __init__(self, name: str):
+                self.name = name
+
+        tools = [FakeTool("git_push_main"), FakeTool("linear_create")]
+        forbidden_set = set(forbidden)
+        filtered = [t for t in tools if not _in_groups(t.name, forbidden_set)]
+        assert len(filtered) == len(tools)
+
+    def test_non_thread_trigger_skips_filtering(self) -> None:
+        """The wiring only applies when triggered_by starts with 'thread:'."""
+        # This tests the conditional check: only thread-triggered tasks
+        # get trust gradient filtering.  Non-thread triggers should not filter.
+        triggered_by = "cron:daily"
+        assert not triggered_by.startswith("thread:")
+
+        triggered_by_thread = "thread:some-slug"
+        assert triggered_by_thread.startswith("thread:")

--- a/tests/test_ravn/test_config.py
+++ b/tests/test_ravn/test_config.py
@@ -731,69 +731,91 @@ class TestInGroups:
         assert _in_groups("slack_post", {"mimir", "slack"}) is True
 
 
-class TestTrustGradientWiring:
-    """Tests for the trust gradient filtering logic applied in _agent_factory.
+class TestApplyTrustFilter:
+    """Tests for the _apply_trust_filter helper in commands.py.
 
-    These verify that resolve_trust_tools output correctly filters tools
-    when combined with _in_groups, mirroring the wiring block in commands.py.
+    This is the extracted function that the _agent_factory calls for
+    thread-triggered tasks.
     """
 
-    def test_thread_triggered_filters_forbidden_tools(self) -> None:
-        """Simulate the wiring: forbidden tools from trust gradient are removed."""
-        from ravn.cli.commands import _in_groups
-
-        config = TrustGradientConfig(pushing_main="never", reading="free")
-        _allowed, forbidden = resolve_trust_tools(config)
-
-        # pushing_main tools should be in forbidden
-        assert "git_push_main" in forbidden
-
-        # Simulate the filtering from commands.py
+    def _fake_tool(self, name: str):
         class FakeTool:
-            def __init__(self, name: str):
-                self.name = name
+            def __init__(self, n: str):
+                self.name = n
 
+        return FakeTool(name)
+
+    def test_thread_triggered_filters_forbidden_tools(self) -> None:
+        """Thread-triggered tasks have forbidden tools removed."""
+        from ravn.cli.commands import _apply_trust_filter
+
+        s = Settings()
         tools = [
-            FakeTool("file_read"),
-            FakeTool("git_push_main"),
-            FakeTool("mimir_query"),
-            FakeTool("linear_create"),
+            self._fake_tool("file_read"),
+            self._fake_tool("git_push_main"),
+            self._fake_tool("mimir_query"),
+            self._fake_tool("linear_create"),
         ]
-        forbidden_set = set(forbidden)
-        filtered = [t for t in tools if not _in_groups(t.name, forbidden_set)]
+        filtered = _apply_trust_filter(tools, s, "thread:test")
+        names = [t.name for t in filtered]
+        assert "file_read" in names
+        assert "mimir_query" in names
+        # pushing_main defaults to "never" → forbidden
+        assert "git_push_main" not in names
+        # opening_tickets defaults to "approval" → forbidden
+        assert "linear_create" not in names
 
-        filtered_names = [t.name for t in filtered]
-        assert "file_read" in filtered_names
-        assert "mimir_query" in filtered_names
-        assert "git_push_main" not in filtered_names
-        # linear_create is "approval" by default → also forbidden
-        assert "linear_create" not in filtered_names
+    def test_non_thread_trigger_skips_filtering(self) -> None:
+        """Non-thread triggers bypass trust gradient filtering."""
+        from ravn.cli.commands import _apply_trust_filter
+
+        s = Settings()
+        tools = [self._fake_tool("git_push_main"), self._fake_tool("linear_create")]
+        filtered = _apply_trust_filter(tools, s, "cron:daily")
+        assert len(filtered) == len(tools)
+
+    def test_none_triggered_by_skips_filtering(self) -> None:
+        """None triggered_by bypasses trust gradient filtering."""
+        from ravn.cli.commands import _apply_trust_filter
+
+        s = Settings()
+        tools = [self._fake_tool("git_push_main")]
+        filtered = _apply_trust_filter(tools, s, None)
+        assert len(filtered) == len(tools)
 
     def test_all_free_no_filtering(self) -> None:
         """When all categories are free, nothing is filtered."""
-        from ravn.cli.commands import _in_groups
+        from ravn.cli.commands import _apply_trust_filter
 
-        config = TrustGradientConfig(
+        s = Settings()
+        s.trust = TrustGradientConfig(
             **{field: "free" for field in TrustGradientConfig.model_fields},
         )
-        _allowed, forbidden = resolve_trust_tools(config)
-        assert forbidden == []
-
-        class FakeTool:
-            def __init__(self, name: str):
-                self.name = name
-
-        tools = [FakeTool("git_push_main"), FakeTool("linear_create")]
-        forbidden_set = set(forbidden)
-        filtered = [t for t in tools if not _in_groups(t.name, forbidden_set)]
+        tools = [self._fake_tool("git_push_main"), self._fake_tool("linear_create")]
+        filtered = _apply_trust_filter(tools, s, "thread:test")
         assert len(filtered) == len(tools)
 
-    def test_non_thread_trigger_skips_filtering(self) -> None:
-        """The wiring only applies when triggered_by starts with 'thread:'."""
-        # This tests the conditional check: only thread-triggered tasks
-        # get trust gradient filtering.  Non-thread triggers should not filter.
-        triggered_by = "cron:daily"
-        assert not triggered_by.startswith("thread:")
+    def test_prefix_matching(self) -> None:
+        """Tool names are matched by prefix (e.g. 'mimir' matches 'mimir_write')."""
+        from ravn.cli.commands import _apply_trust_filter
 
-        triggered_by_thread = "thread:some-slug"
-        assert triggered_by_thread.startswith("thread:")
+        s = Settings()
+        s.trust = TrustGradientConfig(writing_notes="never")
+        tools = [
+            self._fake_tool("mimir_write"),
+            self._fake_tool("mimir_ingest"),
+            self._fake_tool("mimir_query"),
+        ]
+        filtered = _apply_trust_filter(tools, s, "thread:test")
+        names = [t.name for t in filtered]
+        assert "mimir_write" not in names
+        assert "mimir_ingest" not in names
+        # mimir_query is under "reading" which defaults to "free"
+        assert "mimir_query" in names
+
+    def test_empty_tools_returns_empty(self) -> None:
+        """Empty tool list returns empty."""
+        from ravn.cli.commands import _apply_trust_filter
+
+        s = Settings()
+        assert _apply_trust_filter([], s, "thread:test") == []

--- a/tests/test_ravn/test_config.py
+++ b/tests/test_ravn/test_config.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import os
 from unittest.mock import patch
 
+import pytest
+
 from ravn.config import (
+    TRUST_CATEGORY_TOOLS,
     AgentConfig,
     AnthropicConfig,
     ChannelConfig,
@@ -24,6 +27,8 @@ from ravn.config import (
     ThreadConfig,
     ToolAdapterConfig,
     ToolsConfig,
+    TrustGradientConfig,
+    resolve_trust_tools,
 )
 
 
@@ -494,3 +499,198 @@ class TestSettingsThread:
         with patch.dict(os.environ, {"RAVN_THREAD__OWNER_ID": "instance-xyz"}):
             s = Settings()
             assert s.thread.owner_id == "instance-xyz"
+
+
+# ---------------------------------------------------------------------------
+# NIU-571: Trust gradient config
+# ---------------------------------------------------------------------------
+
+
+class TestTrustGradientConfig:
+    def test_defaults_match_vision_doc(self) -> None:
+        """Default config matches vaka-vision.md §5 table."""
+        c = TrustGradientConfig()
+        assert c.reading == "free"
+        assert c.writing_notes == "free"
+        assert c.sandbox_experiments == "free"
+        assert c.consulting_peers == "free"
+        assert c.drafting_tickets == "free"
+        assert c.producing_recaps == "free"
+        assert c.opening_tickets == "approval"
+        assert c.closing_tickets == "approval"
+        assert c.pushing_branches == "approval"
+        assert c.pushing_main == "never"
+        assert c.external_messages == "approval"
+        assert c.spending_beyond_cap == "approval"
+
+    def test_custom_override(self) -> None:
+        c = TrustGradientConfig(reading="approval", pushing_main="approval")
+        assert c.reading == "approval"
+        assert c.pushing_main == "approval"
+
+    def test_all_free(self) -> None:
+        c = TrustGradientConfig(
+            opening_tickets="free",
+            closing_tickets="free",
+            pushing_branches="free",
+            pushing_main="free",
+            external_messages="free",
+            spending_beyond_cap="free",
+        )
+        assert c.opening_tickets == "free"
+        assert c.pushing_main == "free"
+
+    def test_all_never(self) -> None:
+        c = TrustGradientConfig(
+            reading="never",
+            writing_notes="never",
+            sandbox_experiments="never",
+            consulting_peers="never",
+            drafting_tickets="never",
+            producing_recaps="never",
+            opening_tickets="never",
+            closing_tickets="never",
+            pushing_branches="never",
+            pushing_main="never",
+            external_messages="never",
+            spending_beyond_cap="never",
+        )
+        for field_name in TrustGradientConfig.model_fields:
+            assert getattr(c, field_name) == "never"
+
+    def test_invalid_level_rejected(self) -> None:
+        import pydantic
+
+        with pytest.raises(pydantic.ValidationError):
+            TrustGradientConfig(reading="maybe")  # type: ignore[arg-type]
+
+
+class TestResolveTrustTools:
+    def test_free_tools_in_allowed(self) -> None:
+        c = TrustGradientConfig()
+        allowed, forbidden = resolve_trust_tools(c)
+        # reading is free, so its tools should be in allowed
+        for tool in TRUST_CATEGORY_TOOLS["reading"]:
+            assert tool in allowed
+
+    def test_approval_tools_in_forbidden(self) -> None:
+        c = TrustGradientConfig()
+        allowed, forbidden = resolve_trust_tools(c)
+        # opening_tickets is approval, so its tools should be in forbidden
+        for tool in TRUST_CATEGORY_TOOLS["opening_tickets"]:
+            assert tool in forbidden
+
+    def test_never_tools_in_forbidden(self) -> None:
+        c = TrustGradientConfig()
+        allowed, forbidden = resolve_trust_tools(c)
+        # pushing_main is never, so its tools should be in forbidden
+        for tool in TRUST_CATEGORY_TOOLS["pushing_main"]:
+            assert tool in forbidden
+
+    def test_free_tools_not_in_forbidden(self) -> None:
+        c = TrustGradientConfig()
+        allowed, forbidden = resolve_trust_tools(c)
+        for tool in TRUST_CATEGORY_TOOLS["reading"]:
+            assert tool not in forbidden
+
+    def test_approval_tools_not_in_allowed(self) -> None:
+        c = TrustGradientConfig()
+        allowed, forbidden = resolve_trust_tools(c)
+        for tool in TRUST_CATEGORY_TOOLS["opening_tickets"]:
+            assert tool not in allowed
+
+    def test_merge_with_persona_constraints_intersection(self) -> None:
+        """Tool resolution merges with persona constraints (intersection)."""
+        c = TrustGradientConfig()
+        # Persona allows only "file_read" and "mimir_query" — both trust-free
+        persona_allowed = ["file_read", "mimir_query"]
+        allowed, forbidden = resolve_trust_tools(
+            c,
+            persona_allowed=persona_allowed,
+        )
+        # Only persona-allowed tools that are also trust-free should appear
+        assert "file_read" in allowed
+        assert "mimir_query" in allowed
+
+    def test_merge_persona_forbidden_union(self) -> None:
+        """Persona forbidden list is unioned with trust forbidden list."""
+        c = TrustGradientConfig()
+        persona_forbidden = ["custom_tool"]
+        allowed, forbidden = resolve_trust_tools(
+            c,
+            persona_forbidden=persona_forbidden,
+        )
+        # Both trust-forbidden and persona-forbidden should appear
+        assert "custom_tool" in forbidden
+        for tool in TRUST_CATEGORY_TOOLS["opening_tickets"]:
+            assert tool in forbidden
+
+    def test_persona_allowed_tool_not_in_trust_categories_passes_through(self) -> None:
+        """Persona-allowed tools not governed by trust gradient pass through."""
+        c = TrustGradientConfig()
+        persona_allowed = ["file_read", "custom_untracked_tool"]
+        allowed, _ = resolve_trust_tools(c, persona_allowed=persona_allowed)
+        # custom_untracked_tool is not in any trust category, so it passes through
+        assert "custom_untracked_tool" in allowed
+
+    def test_all_categories_have_tool_mappings(self) -> None:
+        """Every trust category has a corresponding entry in TRUST_CATEGORY_TOOLS."""
+        for field_name in TrustGradientConfig.model_fields:
+            assert field_name in TRUST_CATEGORY_TOOLS, (
+                f"Category {field_name!r} missing from TRUST_CATEGORY_TOOLS"
+            )
+
+    def test_no_persona_constraints(self) -> None:
+        """Without persona constraints, returns raw trust lists."""
+        c = TrustGradientConfig()
+        allowed, forbidden = resolve_trust_tools(c)
+        # All free-category tools in allowed
+        free_tools = []
+        for cat in [
+            "reading",
+            "writing_notes",
+            "sandbox_experiments",
+            "consulting_peers",
+            "drafting_tickets",
+            "producing_recaps",
+        ]:
+            free_tools.extend(TRUST_CATEGORY_TOOLS[cat])
+        for tool in free_tools:
+            assert tool in allowed
+
+    def test_custom_trust_config(self) -> None:
+        """Changing a category from free to never moves tools to forbidden."""
+        c = TrustGradientConfig(reading="never")
+        allowed, forbidden = resolve_trust_tools(c)
+        for tool in TRUST_CATEGORY_TOOLS["reading"]:
+            assert tool in forbidden
+            assert tool not in allowed
+
+
+class TestSettingsTrust:
+    def test_settings_trust_defaults(self) -> None:
+        s = Settings()
+        assert s.trust.reading == "free"
+        assert s.trust.pushing_main == "never"
+        assert s.trust.opening_tickets == "approval"
+
+    def test_yaml_trust_section(self, tmp_path) -> None:
+        cfg = tmp_path / "ravn.yaml"
+        cfg.write_text(
+            "trust:\n  reading: approval\n  pushing_main: approval\n  opening_tickets: free\n"
+        )
+        with patch.dict(os.environ, {"RAVN_CONFIG": str(cfg)}):
+            s = Settings()
+            assert s.trust.reading == "approval"
+            assert s.trust.pushing_main == "approval"
+            assert s.trust.opening_tickets == "free"
+
+    def test_env_var_trust_override(self) -> None:
+        with patch.dict(os.environ, {"RAVN_TRUST__READING": "never"}):
+            s = Settings()
+            assert s.trust.reading == "never"
+
+    def test_env_var_trust_pushing_main(self) -> None:
+        with patch.dict(os.environ, {"RAVN_TRUST__PUSHING_MAIN": "approval"}):
+            s = Settings()
+            assert s.trust.pushing_main == "approval"


### PR DESCRIPTION
## Summary

- **TrustGradientConfig** — 12-category trust policy (reading, writing_notes, sandbox_experiments, etc.) with `free`/`approval`/`never` levels. Defaults match vaka-vision §5.
- **resolve_trust_tools()** — maps trust categories to concrete tool name prefixes, merges with persona constraints via intersection (allowed) and union (forbidden) semantics.
- **Agent factory wiring** — thread-triggered tasks (`triggered_by.startswith("thread:")`) apply trust gradient constraints to filter tools before agent creation.
- **DriveLoop** — passes `triggered_by` through to agent factory.
- **ravn.example.yaml** — documented trust section with all defaults.

Closes NIU-571

## Test plan

- [x] Default config matches vision doc §5 table (all 12 categories)
- [x] `"free"` tools appear in allowed list
- [x] `"approval"` tools appear in forbidden list
- [x] `"never"` tools appear in forbidden list
- [x] Tool resolution merges with persona constraints (intersection, not override)
- [x] Persona-forbidden list unioned with trust-forbidden list
- [x] Tools not governed by trust gradient pass through unchanged
- [x] Config loads from YAML correctly
- [x] Environment variable overrides work (RAVN_TRUST__*)
- [x] Invalid trust levels rejected by Pydantic validation
- [x] Every category has tool mappings in TRUST_CATEGORY_TOOLS
- [x] Zero pytest warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)