### PR TITLE
feat(drive_loop): post-task thread state transitions (NIU-568)

### DIFF
--- a/src/ravn/cli/commands.py
+++ b/src/ravn/cli/commands.py
@@ -1977,6 +1977,7 @@ async def _run_daemon(
             settings=settings,
             event_publisher=event_publisher,
             resume=resume,
+            mimir=daemon_mimir,
         )
         _cron_jobs = _wire_triggers(drive_loop, settings.initiative)
         cron_tools[:] = _wire_cron(drive_loop, _cron_jobs, settings.initiative)

--- a/src/ravn/drive_loop.py
+++ b/src/ravn/drive_loop.py
@@ -19,6 +19,8 @@ from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from pathlib import Path
 
+from niuu.domain.mimir import ThreadState
+from niuu.ports.mimir import MimirPort
 from ravn.adapters.channels.capture import CaptureChannel, TaskResult, TaskResultStore
 from ravn.adapters.channels.silent import SilentChannel
 from ravn.adapters.events.noop_publisher import NoOpEventPublisher
@@ -61,12 +63,14 @@ class DriveLoop:
         event_publisher: EventPublisherPort | None = None,
         resume: bool = False,
         budget: DailyBudgetTracker | None = None,
+        mimir: MimirPort | None = None,
     ) -> None:
         self._agent_factory = agent_factory
         self._config = config
         self._settings = settings
         self._event_publisher: EventPublisherPort = event_publisher or NoOpEventPublisher()
         self._resume = resume
+        self._mimir = mimir
         self._triggers: list[TriggerPort] = []
         # (priority, counter, AgentTask)
         self._queue: asyncio.PriorityQueue = asyncio.PriorityQueue(maxsize=config.task_queue_max)
@@ -377,6 +381,10 @@ class DriveLoop:
         if channel.surface_triggered:
             await self._re_deliver_surface(task, channel.response_text)
 
+        if task.triggered_by and task.triggered_by.startswith("thread:"):
+            thread_path = task.triggered_by.removeprefix("thread:")
+            await self._finalise_thread(thread_path, success)
+
     def _save_task_output(self, task: AgentTask, channel: ChannelPort) -> None:
         """Persist agent response to ``task.output_path`` when set (cron tasks)."""
         if task.output_path is None:
@@ -470,6 +478,26 @@ class DriveLoop:
             task_id=task.task_id,
         )
         await self._event_publisher.publish(event)
+
+    async def _finalise_thread(self, thread_path: str, success: bool) -> None:
+        """Transition thread state after task completion.
+
+        On success: ``pulling → closed``.
+        On failure: ``pulling → open`` and ownership is released.
+        All Mímir errors are caught and logged; never propagated.
+        """
+        if self._mimir is None:
+            return
+        try:
+            if success:
+                await self._mimir.update_thread_state(thread_path, ThreadState.closed)
+                logger.info("drive_loop: thread %r closed after successful task", thread_path)
+            else:
+                await self._mimir.update_thread_state(thread_path, ThreadState.open)
+                await self._mimir.assign_thread_owner(thread_path, None)
+                logger.info("drive_loop: thread %r returned to open after failed task", thread_path)
+        except Exception as exc:
+            logger.warning("drive_loop: failed to finalise thread %r: %s", thread_path, exc)
 
     async def _heartbeat(self) -> None:
         """Publish periodic heartbeat events via the event publisher."""

--- a/src/ravn/drive_loop.py
+++ b/src/ravn/drive_loop.py
@@ -360,6 +360,9 @@ class DriveLoop:
                     task_id=task.task_id,
                 )
             )
+            if task.triggered_by and task.triggered_by.startswith("thread:"):
+                thread_path = task.triggered_by.removeprefix("thread:")
+                await self._finalise_thread(thread_path, False)
             return
         except Exception as exc:
             logger.error("drive_loop: task %s failed: %s", task.task_id, exc)

--- a/tests/ravn/unit/test_drive_loop.py
+++ b/tests/ravn/unit/test_drive_loop.py
@@ -1079,3 +1079,23 @@ async def test_finalise_thread_no_mimir_skips_gracefully(tmp_path: Path) -> None
     task = _make_thread_task("threads/no-mimir-thread")
     # Should complete without error even though mimir is None
     await loop._run_task(task)
+
+
+@pytest.mark.asyncio
+async def test_finalise_thread_on_cancelled_task(tmp_path: Path) -> None:
+    """Cancelled thread task → state returns to open, ownership released."""
+    from niuu.domain.mimir import ThreadState
+
+    loop, factory, mock_mimir = _make_drive_loop_with_mimir(tmp_path)
+
+    mock_agent = AsyncMock()
+    mock_agent.run_turn = AsyncMock(side_effect=asyncio.CancelledError())
+    factory.return_value = mock_agent
+
+    task = _make_thread_task("threads/cancelled-thread")
+    await loop._run_task(task)
+
+    mock_mimir.update_thread_state.assert_awaited_once_with(
+        "threads/cancelled-thread", ThreadState.open
+    )
+    mock_mimir.assign_thread_owner.assert_awaited_once_with("threads/cancelled-thread", None)

--- a/tests/ravn/unit/test_drive_loop.py
+++ b/tests/ravn/unit/test_drive_loop.py
@@ -961,3 +961,121 @@ async def test_drive_loop_runs_agent_turn_from_cron(tmp_path: Path) -> None:
     assert "INITIATIVE TASK" in turn_inputs[0]
     assert "integration_test" in turn_inputs[0]
     assert "run integration check" in turn_inputs[0]
+
+
+# ---------------------------------------------------------------------------
+# DriveLoop — thread lifecycle (_finalise_thread)
+# ---------------------------------------------------------------------------
+
+
+def _make_thread_task(path: str = "threads/test-thread") -> AgentTask:
+    hex_ts = hex(int(time.time() * 1000))[2:]
+    return AgentTask(
+        task_id=f"task_{hex_ts}_thread",
+        title="thread task",
+        initiative_context="work on thread",
+        triggered_by=f"thread:{path}",
+        output_mode=OutputMode.AMBIENT,
+        priority=5,
+    )
+
+
+def _make_drive_loop_with_mimir(tmp_path: Path) -> tuple[DriveLoop, MagicMock, AsyncMock]:
+    journal = tmp_path / "queue.json"
+    config = _make_initiative_config(queue_journal_path=str(journal))
+    settings = Settings()
+    factory = MagicMock(return_value=MagicMock())
+    mock_mimir = AsyncMock()
+    mock_mimir.update_thread_state = AsyncMock()
+    mock_mimir.assign_thread_owner = AsyncMock()
+    loop = DriveLoop(agent_factory=factory, config=config, settings=settings, mimir=mock_mimir)
+    return loop, factory, mock_mimir
+
+
+@pytest.mark.asyncio
+async def test_finalise_thread_success_closes_thread(tmp_path: Path) -> None:
+    """Thread-triggered task success → state becomes closed."""
+    from niuu.domain.mimir import ThreadState
+
+    loop, factory, mock_mimir = _make_drive_loop_with_mimir(tmp_path)
+
+    mock_agent = AsyncMock()
+    mock_agent.run_turn = AsyncMock(return_value=None)
+    factory.return_value = mock_agent
+
+    task = _make_thread_task("threads/my-thread")
+    await loop._run_task(task)
+
+    mock_mimir.update_thread_state.assert_awaited_once_with("threads/my-thread", ThreadState.closed)
+    mock_mimir.assign_thread_owner.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_finalise_thread_failure_reopens_and_releases(tmp_path: Path) -> None:
+    """Thread-triggered task failure → state returns to open, ownership released."""
+    from niuu.domain.mimir import ThreadState
+
+    loop, factory, mock_mimir = _make_drive_loop_with_mimir(tmp_path)
+
+    mock_agent = AsyncMock()
+    mock_agent.run_turn = AsyncMock(side_effect=RuntimeError("agent exploded"))
+    factory.return_value = mock_agent
+
+    task = _make_thread_task("threads/failing-thread")
+    await loop._run_task(task)
+
+    mock_mimir.update_thread_state.assert_awaited_once_with(
+        "threads/failing-thread", ThreadState.open
+    )
+    mock_mimir.assign_thread_owner.assert_awaited_once_with("threads/failing-thread", None)
+
+
+@pytest.mark.asyncio
+async def test_finalise_thread_skipped_for_non_thread_task(tmp_path: Path) -> None:
+    """Non-thread task (cron, event) → no thread lifecycle logic runs."""
+    loop, factory, mock_mimir = _make_drive_loop_with_mimir(tmp_path)
+
+    mock_agent = AsyncMock()
+    mock_agent.run_turn = AsyncMock(return_value=None)
+    factory.return_value = mock_agent
+
+    task = _make_task()  # triggered_by="cron:test"
+    await loop._run_task(task)
+
+    mock_mimir.update_thread_state.assert_not_awaited()
+    mock_mimir.assign_thread_owner.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_finalise_thread_mimir_error_is_logged_not_raised(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Mímir errors during finalisation → logged, not propagated."""
+    import logging
+
+    loop, factory, mock_mimir = _make_drive_loop_with_mimir(tmp_path)
+    mock_mimir.update_thread_state = AsyncMock(side_effect=Exception("mimir down"))
+
+    mock_agent = AsyncMock()
+    mock_agent.run_turn = AsyncMock(return_value=None)
+    factory.return_value = mock_agent
+
+    task = _make_thread_task("threads/error-thread")
+    with caplog.at_level(logging.WARNING, logger="ravn.drive_loop"):
+        await loop._run_task(task)  # must not raise
+
+    assert any("failed to finalise thread" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_finalise_thread_no_mimir_skips_gracefully(tmp_path: Path) -> None:
+    """Drive loop without mimir (None) → finalisation skipped gracefully."""
+    loop, factory = _make_drive_loop(tmp_path)  # no mimir
+
+    mock_agent = AsyncMock()
+    mock_agent.run_turn = AsyncMock(return_value=None)
+    factory.return_value = mock_agent
+
+    task = _make_thread_task("threads/no-mimir-thread")
+    # Should complete without error even though mimir is None
+    await loop._run_task(task)


### PR DESCRIPTION
## Summary

After a thread-triggered task completes, the drive loop now transitions the thread's lifecycle state instead of leaving it stuck in `pulling` forever.

- **Success path**: `pulling → closed` via `mimir.update_thread_state(path, ThreadState.closed)`
- **Failure path**: `pulling → open` + ownership released via `mimir.assign_thread_owner(path, None)`
- **No mimir wired**: finalisation is skipped gracefully (no-op)
- **Mímir errors**: caught, logged as warning, never propagated

## Changes

- `src/ravn/drive_loop.py`: Add `mimir: MimirPort | None = None` param to `DriveLoop.__init__`; add `_finalise_thread(path, success)` method; call it from `_run_task` when `triggered_by.startswith("thread:")`
- `src/ravn/cli/commands.py`: Pass `daemon_mimir` to `DriveLoop` constructor so thread finalisation is active when Mímir is configured
- `tests/ravn/unit/test_drive_loop.py`: 5 new tests covering success, failure, non-thread task, Mímir error handling, and no-mimir graceful skip

## Test plan

- [x] Thread-triggered task success → state becomes `closed`
- [x] Thread-triggered task failure → state returns to `open`, ownership released
- [x] Non-thread task (cron, event) → no thread lifecycle logic runs
- [x] Mímir errors during finalisation → logged, not propagated
- [x] Drive loop without mimir (None) → finalisation skipped gracefully
- [x] All 2004 tests pass, ruff clean

Closes NIU-568

🤖 Generated with [Claude Code](https://claude.com/claude-code)