### PR TITLE
feat(mimir): compiled truth + timeline page format (NIU-573)

### DIFF
--- a/src/mimir/FORMAT.md
+++ b/src/mimir/FORMAT.md
@@ -1,0 +1,141 @@
+# Mímir Page Format Specification
+
+Version 1.0 — 2026-04-12
+
+## Overview
+
+Mímir pages use a **compiled truth + timeline** two-zone format that separates
+synthesis ("what we know") from evidence ("how we know it"). This separation is
+the intellectual core of the compounding-knowledge system: the compiled-truth
+zone is rewritten as understanding evolves, while the timeline zone is
+append-only and never edited.
+
+---
+
+## Frontmatter
+
+Every page MUST begin with a YAML frontmatter block delimited by `---`.
+
+```yaml
+---
+type: directive | decision | goal | preference | observation | entity | topic
+confidence: high | medium | low
+entity_type: person | project | concept | technology | organization | strategy  # required when type=entity
+related_entities: [slug-1, slug-2]   # wikilink slugs for related pages
+source_ids: [src_abc123]             # raw source IDs that back this page
+---
+```
+
+### Field reference
+
+| Field | Required | Values | Notes |
+|-------|----------|--------|-------|
+| `type` | Yes | `directive`, `decision`, `goal`, `preference`, `observation`, `entity`, `topic` | Controls which body sections are required |
+| `confidence` | No | `high`, `medium`, `low` | Epistemic confidence in the compiled truth |
+| `entity_type` | Conditional | `person`, `project`, `concept`, `technology`, `organization`, `strategy` | Required when `type: entity` |
+| `related_entities` | No | list of slugs | Slugs map to `wiki/entities/<slug>.md` |
+| `source_ids` | No | list of source IDs | References to raw ingested sources |
+
+---
+
+## Body Zones
+
+Pages of type `entity`, `directive`, or `decision` MUST contain both zones.
+Other types (goal, preference, observation, topic) SHOULD include both zones
+but validators emit warnings, not errors, for their absence.
+
+### Zone 1 — Compiled Truth
+
+```markdown
+## Compiled Truth
+
+### Key Facts
+- Bullet-point facts that are currently believed to be true.
+
+### Relationships
+- [[entity-slug]] — brief description of the relationship.
+
+### Assessment
+Free-form synthesis: interpretation, implications, open questions.
+```
+
+**Rules:**
+
+- The `## Compiled Truth` heading is the canonical zone marker (case-sensitive).
+- The entire zone may be rewritten by `rewrite_compiled_truth()` as understanding
+  matures.
+- `[[entity-slug]]` wikilinks reference other Mímir entity pages.  The slug must
+  match the filename stem under `wiki/entities/`.
+
+### Zone 2 — Timeline
+
+```markdown
+## Timeline
+
+- YYYY-MM-DD: Description of the event or observation. [Source: who, channel, date]
+- YYYY-MM-DD: Another entry. [Source: name, slack-#channel, 2026-03-15]
+```
+
+**Rules:**
+
+- The `## Timeline` heading is the canonical zone marker (case-sensitive).
+- Entries are **append-only** — existing entries MUST NOT be edited, deleted, or
+  reordered.
+- Each entry MUST match the pattern:
+  `- YYYY-MM-DD: <description>. [Source: <attribution>]`
+- The `[Source: ...]` attribution is mandatory.  Entries without it fail
+  validation.
+
+---
+
+## Wikilink Syntax
+
+Use `[[slug]]` to link from any page to a named entity page.
+
+- `[[person-karpathy]]` resolves to `wiki/entities/person-karpathy.md`
+- Slugs are lowercase, hyphen-separated (produced by `slugify()`).
+- Unresolved wikilinks (target file does not exist) are flagged by the linter
+  but are not hard errors at write time.
+
+---
+
+## Example Page
+
+```markdown
+---
+type: entity
+confidence: high
+entity_type: person
+related_entities: [project-niuu, concept-compounding-knowledge]
+source_ids: [src_abc123, src_def456]
+---
+
+# Andrej Karpathy
+
+## Compiled Truth
+
+### Key Facts
+- AI researcher, former Tesla AI director.
+- Advocates for small, focused language models.
+
+### Relationships
+- [[project-niuu]] — referenced as an inspiration for the compounding knowledge design.
+
+### Assessment
+High-signal follow; outputs are consistently practical and well-reasoned.
+
+## Timeline
+
+- 2026-03-10: Shared post on X about minimal LLM architectures. [Source: @karpathy, X/Twitter, 2026-03-10]
+- 2026-04-01: Published blog post on memory systems. [Source: karpathy.github.io, web, 2026-04-01]
+```
+
+---
+
+## Backwards Compatibility
+
+The compiled-truth format is **additive**.  Existing pages without frontmatter
+or without the two zones continue to be readable; validators emit structured
+`ValidationError` objects but do not raise exceptions.  The `mimir_write` tool
+will eventually enforce the format, but legacy pages are not broken by this
+specification.

--- a/src/mimir/compiled_truth.py
+++ b/src/mimir/compiled_truth.py
@@ -19,7 +19,9 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
+from enum import StrEnum
 from pathlib import Path
+from typing import TypeVar
 
 import yaml
 
@@ -29,6 +31,8 @@ from niuu.domain.mimir import (
     PageType,
 )
 
+_E = TypeVar("_E", bound=StrEnum)
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -37,12 +41,6 @@ _FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n?", re.DOTALL)
 
 _COMPILED_TRUTH_HEADING = "## Compiled Truth"
 _TIMELINE_HEADING = "## Timeline"
-
-# Pattern for a single timeline entry: - YYYY-MM-DD: text. [Source: ...]
-_TIMELINE_ENTRY_RE = re.compile(
-    r"^- \d{4}-\d{2}-\d{2}: .+\[Source: .+\]",
-    re.MULTILINE,
-)
 
 _WIKILINK_RE = re.compile(r"\[\[([^\[\]]+)\]\]")
 
@@ -159,7 +157,7 @@ def _parse_timeline_entries(timeline_body: str) -> list[TimelineEntry]:
     return entries
 
 
-def _parse_enum_field(raw: dict, key: str, enum_cls: type) -> object | None:
+def _parse_enum_field(raw: dict, key: str, enum_cls: type[_E]) -> _E | None:
     value = raw.get(key)
     if value is None:
         return None

--- a/src/mimir/compiled_truth.py
+++ b/src/mimir/compiled_truth.py
@@ -1,0 +1,358 @@
+"""Compiled-truth page parser, validator, and mutation helpers.
+
+This module implements the two-zone Mímir page format defined in FORMAT.md:
+
+  - ``## Compiled Truth`` — rewritable synthesis zone
+  - ``## Timeline``       — append-only evidence trail
+
+The public API:
+
+  parse_page(content)                     → CompiledTruthPage
+  validate_page(content)                  → list[ValidationError]
+  append_timeline_entry(content, entry)   → str
+  rewrite_compiled_truth(content, truth)  → str
+  extract_wikilinks(content)              → list[str]
+  resolve_wikilink(slug, wiki_root)       → Path | None
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+from niuu.domain.mimir import (
+    EntityType,
+    PageConfidence,
+    PageType,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n?", re.DOTALL)
+
+_COMPILED_TRUTH_HEADING = "## Compiled Truth"
+_TIMELINE_HEADING = "## Timeline"
+
+# Pattern for a single timeline entry: - YYYY-MM-DD: text. [Source: ...]
+_TIMELINE_ENTRY_RE = re.compile(
+    r"^- \d{4}-\d{2}-\d{2}: .+\[Source: .+\]",
+    re.MULTILINE,
+)
+
+_WIKILINK_RE = re.compile(r"\[\[([^\[\]]+)\]\]")
+
+# Page types that MUST have both zones (errors if absent)
+_MANDATORY_ZONES: frozenset[PageType] = frozenset(
+    {PageType.entity, PageType.directive, PageType.decision}
+)
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TimelineEntry:
+    """A single parsed timeline entry."""
+
+    raw: str  # the full line including the leading "- "
+    date: str  # YYYY-MM-DD
+    description: str  # text before [Source:]
+    source: str  # content inside [Source: ...]
+    has_source: bool = True
+
+
+@dataclass
+class CompiledTruthPage:
+    """Structured representation of a compiled-truth page."""
+
+    frontmatter: dict
+    compiled_truth: str  # body of the Compiled Truth zone (may be empty)
+    timeline_entries: list[TimelineEntry]
+    raw_content: str  # the original full content string
+    # Parsed frontmatter fields (None if absent or invalid)
+    page_type: PageType | None = None
+    confidence: PageConfidence | None = None
+    entity_type: EntityType | None = None
+    related_entities: list[str] = field(default_factory=list)
+    source_ids: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ValidationError:
+    """A single structural compliance error."""
+
+    code: str  # machine-readable error code
+    message: str  # human-readable description
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _strip_frontmatter(content: str) -> str:
+    """Return *content* with the leading YAML frontmatter block removed."""
+    match = _FRONTMATTER_RE.match(content)
+    if not match:
+        return content
+    return content[match.end() :]
+
+
+def _parse_frontmatter(content: str) -> dict:
+    match = _FRONTMATTER_RE.match(content)
+    if not match:
+        return {}
+    try:
+        return yaml.safe_load(match.group(1)) or {}
+    except yaml.YAMLError:
+        return {}
+
+
+def _extract_zone(body: str, heading: str) -> str:
+    """Return the text that follows *heading* up to the next ``##`` heading."""
+    pattern = re.compile(
+        rf"^{re.escape(heading)}\s*\n(.*?)(?=^## |\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(body)
+    if not match:
+        return ""
+    return match.group(1).rstrip()
+
+
+def _parse_timeline_entries(timeline_body: str) -> list[TimelineEntry]:
+    """Parse individual timeline entries from the timeline zone body."""
+    entries: list[TimelineEntry] = []
+    for line in timeline_body.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("- "):
+            continue
+        text = stripped[2:]
+        # Extract date
+        date_match = re.match(r"^(\d{4}-\d{2}-\d{2}): (.+)", text)
+        if not date_match:
+            entries.append(
+                TimelineEntry(raw=stripped, date="", description=text, source="", has_source=False)
+            )
+            continue
+        date = date_match.group(1)
+        rest = date_match.group(2)
+        source_match = re.search(r"\[Source: ([^\]]+)\]", rest)
+        if source_match:
+            source = source_match.group(1)
+            description = rest[: source_match.start()].rstrip(". ")
+            entries.append(
+                TimelineEntry(raw=stripped, date=date, description=description, source=source)
+            )
+        else:
+            entries.append(
+                TimelineEntry(
+                    raw=stripped, date=date, description=rest, source="", has_source=False
+                )
+            )
+    return entries
+
+
+def _parse_enum_field(raw: dict, key: str, enum_cls: type) -> object | None:
+    value = raw.get(key)
+    if value is None:
+        return None
+    try:
+        return enum_cls(str(value))
+    except ValueError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def parse_page(content: str) -> CompiledTruthPage:
+    """Parse *content* into a :class:`CompiledTruthPage`.
+
+    This function is non-strict: it returns whatever structure it can extract
+    even if the page does not fully conform to the format.  Use
+    :func:`validate_page` to check compliance.
+    """
+    raw_fm = _parse_frontmatter(content)
+    body = _strip_frontmatter(content)
+    compiled_truth = _extract_zone(body, _COMPILED_TRUTH_HEADING)
+    timeline_body = _extract_zone(body, _TIMELINE_HEADING)
+    timeline_entries = _parse_timeline_entries(timeline_body)
+
+    page_type = _parse_enum_field(raw_fm, "type", PageType)
+    confidence = _parse_enum_field(raw_fm, "confidence", PageConfidence)
+    entity_type = _parse_enum_field(raw_fm, "entity_type", EntityType)
+
+    related = raw_fm.get("related_entities") or []
+    source_ids = raw_fm.get("source_ids") or []
+
+    return CompiledTruthPage(
+        frontmatter=raw_fm,
+        compiled_truth=compiled_truth,
+        timeline_entries=timeline_entries,
+        raw_content=content,
+        page_type=page_type,
+        confidence=confidence,
+        entity_type=entity_type,
+        related_entities=list(related),
+        source_ids=list(source_ids),
+    )
+
+
+def validate_page(content: str) -> list[ValidationError]:
+    """Check *content* for structural compliance and return any errors found.
+
+    Detected error codes:
+
+    - ``MISSING_COMPILED_TRUTH``  — the ``## Compiled Truth`` section is absent
+    - ``MISSING_TIMELINE``        — the ``## Timeline`` section is absent
+    - ``TIMELINE_ENTRY_NO_SOURCE``— a timeline entry lacks ``[Source: ...]``
+    - ``ENTITY_TYPE_MISMATCH``    — ``type: entity`` but ``entity_type`` absent
+    """
+    errors: list[ValidationError] = []
+    page = parse_page(content)
+    body = _strip_frontmatter(content)
+
+    requires_zones = page.page_type in _MANDATORY_ZONES if page.page_type else False
+
+    if requires_zones and _COMPILED_TRUTH_HEADING not in body:
+        errors.append(
+            ValidationError(
+                code="MISSING_COMPILED_TRUTH",
+                message=(
+                    f"Pages of type '{page.page_type}' must contain a "
+                    f"'{_COMPILED_TRUTH_HEADING}' section."
+                ),
+            )
+        )
+
+    if requires_zones and _TIMELINE_HEADING not in body:
+        errors.append(
+            ValidationError(
+                code="MISSING_TIMELINE",
+                message=(
+                    f"Pages of type '{page.page_type}' must contain a "
+                    f"'{_TIMELINE_HEADING}' section."
+                ),
+            )
+        )
+
+    for entry in page.timeline_entries:
+        if not entry.has_source:
+            errors.append(
+                ValidationError(
+                    code="TIMELINE_ENTRY_NO_SOURCE",
+                    message=(f"Timeline entry is missing '[Source: ...]': {entry.raw!r}"),
+                )
+            )
+
+    if page.page_type == PageType.entity and page.entity_type is None:
+        errors.append(
+            ValidationError(
+                code="ENTITY_TYPE_MISMATCH",
+                message="Pages with 'type: entity' must specify 'entity_type'.",
+            )
+        )
+
+    return errors
+
+
+def append_timeline_entry(content: str, entry: str) -> str:
+    """Append *entry* to the ``## Timeline`` section of *content*.
+
+    *entry* should be a single line in the format::
+
+        - YYYY-MM-DD: Description. [Source: who, channel, date]
+
+    If the Timeline section does not exist it is created at the end of the
+    document.  Existing content is never modified.
+    """
+    entry_line = entry.rstrip("\n")
+
+    if _TIMELINE_HEADING in content:
+        # Find where the timeline section ends (next ## heading or EOF).
+        pattern = re.compile(
+            rf"({re.escape(_TIMELINE_HEADING)}\s*\n)(.*?)(\n(?=## )|\Z)",
+            re.DOTALL,
+        )
+        match = pattern.search(content)
+        if match:
+            existing_body = match.group(2).rstrip("\n")
+            separator = "\n" if existing_body else ""
+            new_body = f"{existing_body}{separator}\n{entry_line}"
+            return content[: match.start(2)] + new_body + content[match.end(2) :]
+
+        # Fallback: find the heading and append after it
+        idx = content.index(_TIMELINE_HEADING) + len(_TIMELINE_HEADING)
+        return content[:idx] + "\n\n" + entry_line + content[idx:]
+
+    # Timeline section absent — append it
+    trailer = "" if content.endswith("\n") else "\n"
+    return f"{content}{trailer}\n{_TIMELINE_HEADING}\n\n{entry_line}\n"
+
+
+def rewrite_compiled_truth(content: str, new_truth: str) -> str:
+    """Replace the ``## Compiled Truth`` zone body with *new_truth*.
+
+    The Timeline zone and all other content are preserved intact.
+
+    If the Compiled Truth section is absent it is inserted before the Timeline
+    section (or appended if neither exists).
+    """
+    new_truth_body = new_truth.rstrip("\n") + "\n"
+
+    if _COMPILED_TRUTH_HEADING in content:
+        pattern = re.compile(
+            rf"({re.escape(_COMPILED_TRUTH_HEADING)}\s*\n)(.*?)(?=^## |\Z)",
+            re.MULTILINE | re.DOTALL,
+        )
+        match = pattern.search(content)
+        if match:
+            return content[: match.start(2)] + new_truth_body + "\n" + content[match.end(2) :]
+
+    # Section absent — insert before Timeline or append
+    if _TIMELINE_HEADING in content:
+        idx = content.index(_TIMELINE_HEADING)
+        return (
+            content[:idx] + _COMPILED_TRUTH_HEADING + "\n\n" + new_truth_body + "\n" + content[idx:]
+        )
+
+    trailer = "" if content.endswith("\n") else "\n"
+    return f"{content}{trailer}\n{_COMPILED_TRUTH_HEADING}\n\n{new_truth_body}"
+
+
+def extract_wikilinks(content: str) -> list[str]:
+    """Return a deduplicated list of wikilink slugs found in *content*.
+
+    ``[[person-karpathy]]`` → ``"person-karpathy"``
+
+    Order is preserved (first occurrence wins for deduplication).
+    """
+    seen: set[str] = set()
+    result: list[str] = []
+    for match in _WIKILINK_RE.finditer(content):
+        slug = match.group(1).strip()
+        if slug not in seen:
+            seen.add(slug)
+            result.append(slug)
+    return result
+
+
+def resolve_wikilink(slug: str, wiki_root: Path) -> Path | None:
+    """Return the absolute path for *slug* if the entity file exists.
+
+    Resolves ``[[slug]]`` → ``<wiki_root>/entities/<slug>.md``.
+    Returns ``None`` if the file does not exist.
+    """
+    candidate = wiki_root / "entities" / f"{slug}.md"
+    if candidate.exists():
+        return candidate
+    return None

--- a/src/niuu/domain/mimir.py
+++ b/src/niuu/domain/mimir.py
@@ -18,6 +18,41 @@ from typing import Literal
 
 import yaml
 
+# ---------------------------------------------------------------------------
+# Compiled-truth page taxonomy enums
+# ---------------------------------------------------------------------------
+
+
+class PageType(StrEnum):
+    """Controlled vocabulary for the ``type`` frontmatter field."""
+
+    directive = "directive"
+    decision = "decision"
+    goal = "goal"
+    preference = "preference"
+    observation = "observation"
+    entity = "entity"
+    topic = "topic"
+
+
+class PageConfidence(StrEnum):
+    """Epistemic confidence level for a Mímir page."""
+
+    high = "high"
+    medium = "medium"
+    low = "low"
+
+
+class EntityType(StrEnum):
+    """Sub-type for pages whose ``type`` is ``entity``."""
+
+    person = "person"
+    project = "project"
+    concept = "concept"
+    technology = "technology"
+    organization = "organization"
+    strategy = "strategy"
+
 
 def compute_content_hash(content: str) -> str:
     """Return the SHA-256 hex digest of *content*."""
@@ -226,6 +261,11 @@ class MimirPageMeta:
     category: str  # top-level category: "technical", "projects", "threads", etc.
     updated_at: datetime
     source_ids: list[str] = field(default_factory=list)
+    # Compiled-truth frontmatter fields (additive — all optional for backwards compat)
+    page_type: PageType | None = None
+    confidence: PageConfidence | None = None
+    entity_type: EntityType | None = None
+    related_entities: list[str] = field(default_factory=list)
     # Thread-specific fields (None for wiki pages)
     thread_state: ThreadState | None = None
     thread_weight: float | None = None

--- a/tests/test_mimir/unit/test_compiled_truth.py
+++ b/tests/test_mimir/unit/test_compiled_truth.py
@@ -1,0 +1,707 @@
+"""Unit tests for mimir.compiled_truth (NIU-573).
+
+Covers:
+- parse_page: frontmatter extraction, compiled-truth zone, timeline entries
+- validate_page: all four error codes
+- append_timeline_entry: safe append without disturbing existing content
+- rewrite_compiled_truth: zone replacement while preserving timeline
+- extract_wikilinks: deduplication, ordering
+- resolve_wikilink: existing and missing files
+- CompiledTruthPage, ValidationError, TimelineEntry data classes
+- MimirPageMeta new frontmatter fields (PageType, PageConfidence, EntityType)
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from mimir.compiled_truth import (
+    ValidationError,
+    append_timeline_entry,
+    extract_wikilinks,
+    parse_page,
+    resolve_wikilink,
+    rewrite_compiled_truth,
+    validate_page,
+)
+from niuu.domain.mimir import (
+    EntityType,
+    PageConfidence,
+    PageType,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+WELL_FORMED_PAGE = textwrap.dedent("""\
+    ---
+    type: entity
+    confidence: high
+    entity_type: person
+    related_entities: [project-niuu]
+    source_ids: [src_abc123]
+    ---
+
+    # Andrej Karpathy
+
+    ## Compiled Truth
+
+    ### Key Facts
+    - AI researcher.
+
+    ### Relationships
+    - [[project-niuu]] — inspiration.
+
+    ### Assessment
+    High signal.
+
+    ## Timeline
+
+    - 2026-03-10: Shared post about LLMs. [Source: @karpathy, X/Twitter, 2026-03-10]
+    - 2026-04-01: Published blog post. [Source: karpathy.github.io, web, 2026-04-01]
+""")
+
+NO_FRONTMATTER_PAGE = textwrap.dedent("""\
+    # Plain Page
+
+    ## Compiled Truth
+
+    Some facts here.
+
+    ## Timeline
+
+    - 2026-01-01: Initial entry. [Source: notes, internal, 2026-01-01]
+""")
+
+ENTITY_PAGE_MISSING_SECTIONS = textwrap.dedent("""\
+    ---
+    type: entity
+    entity_type: person
+    ---
+
+    # Bare Entity Page
+
+    Some random text here.
+""")
+
+ENTITY_PAGE_MISSING_ENTITY_TYPE = textwrap.dedent("""\
+    ---
+    type: entity
+    confidence: medium
+    ---
+
+    # Entity Without entity_type
+
+    ## Compiled Truth
+
+    Something.
+
+    ## Timeline
+
+    - 2026-01-01: Entry. [Source: internal, 2026-01-01]
+""")
+
+TIMELINE_ENTRY_NO_SOURCE = textwrap.dedent("""\
+    ---
+    type: entity
+    entity_type: concept
+    ---
+
+    ## Compiled Truth
+
+    Facts.
+
+    ## Timeline
+
+    - 2026-01-01: No source here.
+    - 2026-02-01: Has source. [Source: person, channel, 2026-02-01]
+""")
+
+DIRECTIVE_PAGE = textwrap.dedent("""\
+    ---
+    type: directive
+    confidence: high
+    ---
+
+    ## Compiled Truth
+
+    Always do X.
+
+    ## Timeline
+
+    - 2026-01-01: Directive created. [Source: team, slack, 2026-01-01]
+""")
+
+
+# ---------------------------------------------------------------------------
+# parse_page
+# ---------------------------------------------------------------------------
+
+
+class TestParsePage:
+    def test_parses_frontmatter(self) -> None:
+        page = parse_page(WELL_FORMED_PAGE)
+        assert page.frontmatter["type"] == "entity"
+        assert page.frontmatter["confidence"] == "high"
+        assert page.frontmatter["entity_type"] == "person"
+
+    def test_page_type_enum(self) -> None:
+        page = parse_page(WELL_FORMED_PAGE)
+        assert page.page_type == PageType.entity
+
+    def test_confidence_enum(self) -> None:
+        page = parse_page(WELL_FORMED_PAGE)
+        assert page.confidence == PageConfidence.high
+
+    def test_entity_type_enum(self) -> None:
+        page = parse_page(WELL_FORMED_PAGE)
+        assert page.entity_type == EntityType.person
+
+    def test_related_entities(self) -> None:
+        page = parse_page(WELL_FORMED_PAGE)
+        assert page.related_entities == ["project-niuu"]
+
+    def test_source_ids(self) -> None:
+        page = parse_page(WELL_FORMED_PAGE)
+        assert page.source_ids == ["src_abc123"]
+
+    def test_compiled_truth_extracted(self) -> None:
+        page = parse_page(WELL_FORMED_PAGE)
+        assert "AI researcher" in page.compiled_truth
+        assert "High signal" in page.compiled_truth
+
+    def test_timeline_entry_count(self) -> None:
+        page = parse_page(WELL_FORMED_PAGE)
+        assert len(page.timeline_entries) == 2
+
+    def test_first_timeline_entry_date(self) -> None:
+        page = parse_page(WELL_FORMED_PAGE)
+        assert page.timeline_entries[0].date == "2026-03-10"
+
+    def test_first_timeline_entry_source(self) -> None:
+        page = parse_page(WELL_FORMED_PAGE)
+        assert "@karpathy" in page.timeline_entries[0].source
+
+    def test_second_timeline_entry_date(self) -> None:
+        page = parse_page(WELL_FORMED_PAGE)
+        assert page.timeline_entries[1].date == "2026-04-01"
+
+    def test_timeline_entry_has_source_true(self) -> None:
+        page = parse_page(WELL_FORMED_PAGE)
+        assert page.timeline_entries[0].has_source is True
+
+    def test_no_frontmatter_returns_empty_dict(self) -> None:
+        page = parse_page(NO_FRONTMATTER_PAGE)
+        assert page.frontmatter == {}
+        assert page.page_type is None
+
+    def test_no_frontmatter_extracts_zones(self) -> None:
+        page = parse_page(NO_FRONTMATTER_PAGE)
+        assert "Some facts" in page.compiled_truth
+        assert len(page.timeline_entries) == 1
+
+    def test_raw_content_preserved(self) -> None:
+        page = parse_page(WELL_FORMED_PAGE)
+        assert page.raw_content == WELL_FORMED_PAGE
+
+    def test_empty_related_entities_defaults(self) -> None:
+        content = "---\ntype: topic\n---\n\n# Hello\n"
+        page = parse_page(content)
+        assert page.related_entities == []
+
+    def test_empty_source_ids_defaults(self) -> None:
+        content = "---\ntype: topic\n---\n\n# Hello\n"
+        page = parse_page(content)
+        assert page.source_ids == []
+
+    def test_unknown_type_returns_none(self) -> None:
+        content = "---\ntype: unknown_value\n---\n\n# Hello\n"
+        page = parse_page(content)
+        assert page.page_type is None
+
+    def test_unknown_confidence_returns_none(self) -> None:
+        content = "---\nconfidence: ultra\n---\n\n# Hello\n"
+        page = parse_page(content)
+        assert page.confidence is None
+
+    def test_all_page_types_parse(self) -> None:
+        for pt in PageType:
+            content = f"---\ntype: {pt.value}\n---\n\n# Test\n"
+            page = parse_page(content)
+            assert page.page_type == pt
+
+    def test_all_confidence_values_parse(self) -> None:
+        for conf in PageConfidence:
+            content = f"---\nconfidence: {conf.value}\n---\n\n# Test\n"
+            page = parse_page(content)
+            assert page.confidence == conf
+
+    def test_all_entity_types_parse(self) -> None:
+        for et in EntityType:
+            content = f"---\nentity_type: {et.value}\n---\n\n# Test\n"
+            page = parse_page(content)
+            assert page.entity_type == et
+
+    def test_directive_type_parses(self) -> None:
+        page = parse_page(DIRECTIVE_PAGE)
+        assert page.page_type == PageType.directive
+
+    def test_decision_type_parses(self) -> None:
+        content = "---\ntype: decision\n---\n\n# Test\n"
+        page = parse_page(content)
+        assert page.page_type == PageType.decision
+
+    def test_empty_page(self) -> None:
+        page = parse_page("")
+        assert page.frontmatter == {}
+        assert page.compiled_truth == ""
+        assert page.timeline_entries == []
+
+
+# ---------------------------------------------------------------------------
+# validate_page
+# ---------------------------------------------------------------------------
+
+
+class TestValidatePage:
+    def test_well_formed_page_has_no_errors(self) -> None:
+        errors = validate_page(WELL_FORMED_PAGE)
+        assert errors == []
+
+    def test_directive_well_formed_no_errors(self) -> None:
+        errors = validate_page(DIRECTIVE_PAGE)
+        assert errors == []
+
+    def test_missing_compiled_truth_for_entity(self) -> None:
+        errors = validate_page(ENTITY_PAGE_MISSING_SECTIONS)
+        codes = {e.code for e in errors}
+        assert "MISSING_COMPILED_TRUTH" in codes
+
+    def test_missing_timeline_for_entity(self) -> None:
+        errors = validate_page(ENTITY_PAGE_MISSING_SECTIONS)
+        codes = {e.code for e in errors}
+        assert "MISSING_TIMELINE" in codes
+
+    def test_entity_type_mismatch(self) -> None:
+        errors = validate_page(ENTITY_PAGE_MISSING_ENTITY_TYPE)
+        codes = {e.code for e in errors}
+        assert "ENTITY_TYPE_MISMATCH" in codes
+
+    def test_timeline_entry_no_source(self) -> None:
+        errors = validate_page(TIMELINE_ENTRY_NO_SOURCE)
+        codes = [e.code for e in errors]
+        assert "TIMELINE_ENTRY_NO_SOURCE" in codes
+
+    def test_no_source_error_includes_entry_text(self) -> None:
+        errors = validate_page(TIMELINE_ENTRY_NO_SOURCE)
+        no_src = [e for e in errors if e.code == "TIMELINE_ENTRY_NO_SOURCE"]
+        assert len(no_src) == 1
+        assert "No source here" in no_src[0].message
+
+    def test_non_mandatory_type_no_zone_errors(self) -> None:
+        content = "---\ntype: topic\n---\n\n# Topic\n\nSome text.\n"
+        errors = validate_page(content)
+        codes = {e.code for e in errors}
+        assert "MISSING_COMPILED_TRUTH" not in codes
+        assert "MISSING_TIMELINE" not in codes
+
+    def test_missing_compiled_truth_for_directive(self) -> None:
+        content = textwrap.dedent("""\
+            ---
+            type: directive
+            ---
+
+            ## Timeline
+
+            - 2026-01-01: Entry. [Source: team, 2026-01-01]
+        """)
+        errors = validate_page(content)
+        codes = {e.code for e in errors}
+        assert "MISSING_COMPILED_TRUTH" in codes
+
+    def test_missing_timeline_for_decision(self) -> None:
+        content = textwrap.dedent("""\
+            ---
+            type: decision
+            ---
+
+            ## Compiled Truth
+
+            We decided to do X.
+        """)
+        errors = validate_page(content)
+        codes = {e.code for e in errors}
+        assert "MISSING_TIMELINE" in codes
+
+    def test_errors_are_validation_error_instances(self) -> None:
+        errors = validate_page(ENTITY_PAGE_MISSING_SECTIONS)
+        for e in errors:
+            assert isinstance(e, ValidationError)
+            assert isinstance(e.code, str)
+            assert isinstance(e.message, str)
+
+    def test_multiple_no_source_entries(self) -> None:
+        content = textwrap.dedent("""\
+            ---
+            type: entity
+            entity_type: concept
+            ---
+
+            ## Compiled Truth
+
+            Facts.
+
+            ## Timeline
+
+            - 2026-01-01: No source.
+            - 2026-01-02: Also no source.
+        """)
+        errors = validate_page(content)
+        no_src = [e for e in errors if e.code == "TIMELINE_ENTRY_NO_SOURCE"]
+        assert len(no_src) == 2
+
+    def test_no_frontmatter_page_no_zone_errors(self) -> None:
+        # Pages without frontmatter have no page_type → no mandatory zones
+        errors = validate_page(NO_FRONTMATTER_PAGE)
+        codes = {e.code for e in errors}
+        assert "MISSING_COMPILED_TRUTH" not in codes
+        assert "MISSING_TIMELINE" not in codes
+
+
+# ---------------------------------------------------------------------------
+# append_timeline_entry
+# ---------------------------------------------------------------------------
+
+
+class TestAppendTimelineEntry:
+    def test_appends_to_existing_timeline(self) -> None:
+        new_entry = "- 2026-05-01: New event. [Source: me, notes, 2026-05-01]"
+        result = append_timeline_entry(WELL_FORMED_PAGE, new_entry)
+        assert new_entry in result
+
+    def test_existing_entries_preserved(self) -> None:
+        new_entry = "- 2026-05-01: New event. [Source: me, notes, 2026-05-01]"
+        result = append_timeline_entry(WELL_FORMED_PAGE, new_entry)
+        assert "Shared post about LLMs" in result
+        assert "Published blog post" in result
+
+    def test_compiled_truth_preserved(self) -> None:
+        new_entry = "- 2026-05-01: New event. [Source: me, notes, 2026-05-01]"
+        result = append_timeline_entry(WELL_FORMED_PAGE, new_entry)
+        assert "AI researcher" in result
+        assert "High signal" in result
+
+    def test_new_entry_after_existing_entries(self) -> None:
+        new_entry = "- 2026-05-01: New event. [Source: me, notes, 2026-05-01]"
+        result = append_timeline_entry(WELL_FORMED_PAGE, new_entry)
+        old_idx = result.index("Published blog post")
+        new_idx = result.index("New event")
+        assert new_idx > old_idx
+
+    def test_appends_to_page_without_timeline(self) -> None:
+        content = "---\ntype: topic\n---\n\n# Hello\n"
+        new_entry = "- 2026-01-01: Entry. [Source: me, notes, 2026-01-01]"
+        result = append_timeline_entry(content, new_entry)
+        assert "## Timeline" in result
+        assert new_entry in result
+
+    def test_appends_to_page_without_timeline_preserves_existing(self) -> None:
+        content = "---\ntype: topic\n---\n\n# Hello\n"
+        new_entry = "- 2026-01-01: Entry. [Source: me, notes, 2026-01-01]"
+        result = append_timeline_entry(content, new_entry)
+        assert "# Hello" in result
+
+    def test_round_trip_parse_after_append(self) -> None:
+        new_entry = "- 2026-05-01: New event. [Source: me, notes, 2026-05-01]"
+        result = append_timeline_entry(WELL_FORMED_PAGE, new_entry)
+        page = parse_page(result)
+        assert len(page.timeline_entries) == 3
+
+    def test_entry_not_duplicated(self) -> None:
+        new_entry = "- 2026-05-01: New event. [Source: me, notes, 2026-05-01]"
+        result = append_timeline_entry(WELL_FORMED_PAGE, new_entry)
+        assert result.count(new_entry) == 1
+
+    def test_trailing_newline_stripped_from_entry(self) -> None:
+        new_entry = "- 2026-05-01: New event. [Source: me, notes, 2026-05-01]\n"
+        result = append_timeline_entry(WELL_FORMED_PAGE, new_entry)
+        assert "New event" in result
+
+    def test_empty_timeline_section_append(self) -> None:
+        content = textwrap.dedent("""\
+            ---
+            type: entity
+            entity_type: concept
+            ---
+
+            ## Compiled Truth
+
+            Facts.
+
+            ## Timeline
+        """)
+        new_entry = "- 2026-01-01: Entry. [Source: internal, 2026-01-01]"
+        result = append_timeline_entry(content, new_entry)
+        page = parse_page(result)
+        assert len(page.timeline_entries) == 1
+
+
+# ---------------------------------------------------------------------------
+# rewrite_compiled_truth
+# ---------------------------------------------------------------------------
+
+
+class TestRewriteCompiledTruth:
+    NEW_TRUTH = textwrap.dedent("""\
+        ### Key Facts
+        - Updated fact one.
+        - Updated fact two.
+
+        ### Assessment
+        Revised synthesis.
+    """)
+
+    def test_compiled_truth_replaced(self) -> None:
+        result = rewrite_compiled_truth(WELL_FORMED_PAGE, self.NEW_TRUTH)
+        assert "Updated fact one" in result
+        assert "Updated fact two" in result
+
+    def test_old_compiled_truth_removed(self) -> None:
+        result = rewrite_compiled_truth(WELL_FORMED_PAGE, self.NEW_TRUTH)
+        assert "AI researcher" not in result
+
+    def test_timeline_preserved(self) -> None:
+        result = rewrite_compiled_truth(WELL_FORMED_PAGE, self.NEW_TRUTH)
+        assert "Shared post about LLMs" in result
+        assert "Published blog post" in result
+
+    def test_frontmatter_preserved(self) -> None:
+        result = rewrite_compiled_truth(WELL_FORMED_PAGE, self.NEW_TRUTH)
+        page = parse_page(result)
+        assert page.page_type == PageType.entity
+        assert page.confidence == PageConfidence.high
+
+    def test_timeline_heading_still_present(self) -> None:
+        result = rewrite_compiled_truth(WELL_FORMED_PAGE, self.NEW_TRUTH)
+        assert "## Timeline" in result
+
+    def test_round_trip_validate_after_rewrite(self) -> None:
+        result = rewrite_compiled_truth(WELL_FORMED_PAGE, self.NEW_TRUTH)
+        errors = validate_page(result)
+        assert errors == []
+
+    def test_rewrite_creates_section_if_absent(self) -> None:
+        content = "---\ntype: topic\n---\n\n# Hello\n"
+        result = rewrite_compiled_truth(content, "New truth.\n")
+        assert "## Compiled Truth" in result
+        assert "New truth" in result
+
+    def test_rewrite_inserts_before_timeline_if_no_compiled_truth(self) -> None:
+        content = textwrap.dedent("""\
+            ---
+            type: topic
+            ---
+
+            # Hello
+
+            ## Timeline
+
+            - 2026-01-01: Entry. [Source: me, 2026-01-01]
+        """)
+        result = rewrite_compiled_truth(content, "New truth.\n")
+        ct_idx = result.index("## Compiled Truth")
+        tl_idx = result.index("## Timeline")
+        assert ct_idx < tl_idx
+
+    def test_rewrite_multiple_times(self) -> None:
+        r1 = rewrite_compiled_truth(WELL_FORMED_PAGE, "First rewrite.\n")
+        r2 = rewrite_compiled_truth(r1, "Second rewrite.\n")
+        assert "Second rewrite" in r2
+        assert "First rewrite" not in r2
+        assert "## Timeline" in r2
+
+
+# ---------------------------------------------------------------------------
+# extract_wikilinks
+# ---------------------------------------------------------------------------
+
+
+class TestExtractWikilinks:
+    def test_extracts_single_wikilink(self) -> None:
+        content = "See [[project-niuu]] for context."
+        assert extract_wikilinks(content) == ["project-niuu"]
+
+    def test_extracts_multiple_wikilinks(self) -> None:
+        content = "See [[project-niuu]] and [[person-karpathy]]."
+        assert extract_wikilinks(content) == ["project-niuu", "person-karpathy"]
+
+    def test_deduplicates_wikilinks(self) -> None:
+        content = "[[project-niuu]] and again [[project-niuu]]."
+        assert extract_wikilinks(content) == ["project-niuu"]
+
+    def test_preserves_first_occurrence_order(self) -> None:
+        content = "[[b]] then [[a]] then [[b]] then [[c]]."
+        assert extract_wikilinks(content) == ["b", "a", "c"]
+
+    def test_no_wikilinks_returns_empty(self) -> None:
+        assert extract_wikilinks("No links here.") == []
+
+    def test_wikilinks_from_well_formed_page(self) -> None:
+        links = extract_wikilinks(WELL_FORMED_PAGE)
+        assert "project-niuu" in links
+
+    def test_empty_content(self) -> None:
+        assert extract_wikilinks("") == []
+
+    def test_strips_whitespace_from_slug(self) -> None:
+        content = "[[ project-niuu ]]"
+        assert extract_wikilinks(content) == ["project-niuu"]
+
+    def test_ignores_malformed_single_bracket(self) -> None:
+        content = "[not-a-link] but [[real-link]] works."
+        assert extract_wikilinks(content) == ["real-link"]
+
+    def test_wikilinks_in_frontmatter_also_extracted(self) -> None:
+        content = "---\ntype: entity\n---\n\nSee [[concept-foo]].\n"
+        assert extract_wikilinks(content) == ["concept-foo"]
+
+
+# ---------------------------------------------------------------------------
+# resolve_wikilink
+# ---------------------------------------------------------------------------
+
+
+class TestResolveWikilink:
+    def test_returns_path_when_file_exists(self, tmp_path: Path) -> None:
+        entities_dir = tmp_path / "entities"
+        entities_dir.mkdir()
+        (entities_dir / "person-karpathy.md").write_text("content", encoding="utf-8")
+        result = resolve_wikilink("person-karpathy", tmp_path)
+        assert result is not None
+        assert result.name == "person-karpathy.md"
+
+    def test_returns_none_when_file_missing(self, tmp_path: Path) -> None:
+        result = resolve_wikilink("nonexistent-slug", tmp_path)
+        assert result is None
+
+    def test_resolves_to_entities_subdir(self, tmp_path: Path) -> None:
+        entities_dir = tmp_path / "entities"
+        entities_dir.mkdir()
+        (entities_dir / "project-niuu.md").write_text("content", encoding="utf-8")
+        result = resolve_wikilink("project-niuu", tmp_path)
+        assert result == entities_dir / "project-niuu.md"
+
+    def test_returns_none_for_empty_entities_dir(self, tmp_path: Path) -> None:
+        (tmp_path / "entities").mkdir()
+        result = resolve_wikilink("some-slug", tmp_path)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# MimirPageMeta new frontmatter fields
+# ---------------------------------------------------------------------------
+
+
+class TestMimirPageMetaNewFields:
+    """Verify the new compiled-truth fields added to MimirPageMeta."""
+
+    def _make_meta(self, **overrides):
+        from datetime import UTC, datetime
+
+        from niuu.domain.mimir import MimirPageMeta
+
+        defaults = dict(
+            path="entities/person-karpathy.md",
+            title="Andrej Karpathy",
+            summary="AI researcher",
+            category="entities",
+            updated_at=datetime(2026, 4, 12, tzinfo=UTC),
+        )
+        defaults.update(overrides)
+        return MimirPageMeta(**defaults)
+
+    def test_page_type_defaults_none(self) -> None:
+        assert self._make_meta().page_type is None
+
+    def test_confidence_defaults_none(self) -> None:
+        assert self._make_meta().confidence is None
+
+    def test_entity_type_defaults_none(self) -> None:
+        assert self._make_meta().entity_type is None
+
+    def test_related_entities_defaults_empty(self) -> None:
+        assert self._make_meta().related_entities == []
+
+    def test_page_type_set(self) -> None:
+        meta = self._make_meta(page_type=PageType.entity)
+        assert meta.page_type == PageType.entity
+
+    def test_confidence_set(self) -> None:
+        meta = self._make_meta(confidence=PageConfidence.high)
+        assert meta.confidence == PageConfidence.high
+
+    def test_entity_type_set(self) -> None:
+        meta = self._make_meta(entity_type=EntityType.person)
+        assert meta.entity_type == EntityType.person
+
+    def test_related_entities_set(self) -> None:
+        meta = self._make_meta(related_entities=["project-niuu", "concept-foo"])
+        assert meta.related_entities == ["project-niuu", "concept-foo"]
+
+    def test_all_new_fields_together(self) -> None:
+        meta = self._make_meta(
+            page_type=PageType.entity,
+            confidence=PageConfidence.medium,
+            entity_type=EntityType.technology,
+            related_entities=["concept-bar"],
+        )
+        assert meta.page_type == PageType.entity
+        assert meta.confidence == PageConfidence.medium
+        assert meta.entity_type == EntityType.technology
+        assert meta.related_entities == ["concept-bar"]
+
+
+# ---------------------------------------------------------------------------
+# PageType / PageConfidence / EntityType enums
+# ---------------------------------------------------------------------------
+
+
+class TestPageTypeEnum:
+    def test_all_values(self) -> None:
+        values = {pt.value for pt in PageType}
+        assert values == {
+            "directive",
+            "decision",
+            "goal",
+            "preference",
+            "observation",
+            "entity",
+            "topic",
+        }
+
+    def test_str_enum_comparison(self) -> None:
+        assert PageType.entity == "entity"
+
+    def test_round_trip(self) -> None:
+        for pt in PageType:
+            assert PageType(pt.value) is pt
+
+
+class TestPageConfidenceEnum:
+    def test_all_values(self) -> None:
+        values = {c.value for c in PageConfidence}
+        assert values == {"high", "medium", "low"}
+
+    def test_str_enum_comparison(self) -> None:
+        assert PageConfidence.high == "high"
+
+
+class TestEntityTypeEnum:
+    def test_all_values(self) -> None:
+        values = {et.value for et in EntityType}
+        assert values == {"person", "project", "concept", "technology", "organization", "strategy"}
+
+    def test_str_enum_comparison(self) -> None:
+        assert EntityType.person == "person"


### PR DESCRIPTION
## Summary

- **FORMAT.md** — Defines the two-zone compiled-truth + timeline page format: frontmatter schema (`type`, `confidence`, `entity_type`, `related_entities`, `source_ids`), body zone rules (Compiled Truth rewritable, Timeline append-only), and `[[wikilink]]` syntax.
- **`niuu.domain.mimir`** — Adds `PageType`, `PageConfidence`, `EntityType` enums and four new optional fields on `MimirPageMeta` (`page_type`, `confidence`, `entity_type`, `related_entities`). Fully backwards-compatible — all fields default to `None`/`[]`.
- **`mimir.compiled_truth`** — New module with:
  - `parse_page(content) → CompiledTruthPage` — extracts frontmatter, compiled-truth zone, timeline entries
  - `validate_page(content) → list[ValidationError]` — checks for missing zones, sourceless timeline entries, entity_type mismatches
  - `append_timeline_entry(content, entry) → str` — safely appends without touching existing entries
  - `rewrite_compiled_truth(content, new_truth) → str` — replaces synthesis while preserving timeline intact
  - `extract_wikilinks(content) → list[str]` — deduplicates and orders `[[slug]]` references
  - `resolve_wikilink(slug, wiki_root) → Path | None` — checks `wiki/entities/<slug>.md` existence

## Test plan

- [x] 87 unit tests in `tests/test_mimir/unit/test_compiled_truth.py`
- [x] 87% coverage on new code (above 85% threshold)
- [x] All 135 tests pass (new + existing mimir/niuu tests)
- [x] `ruff check` clean, `ruff format` clean on changed files
- [x] Existing `MimirPageMeta` tests still pass (additive fields, no breaking changes)

## Notes

- Linear ticket NIU-573 could not be updated via MCP (no Linear MCP server configured in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)