### PR TITLE
feat(bifrost): persona-aware model routing via X-Ravn-Agent-Id (NIU-583)

### DIFF
--- a/src/bifrost/adapters/events/null.py
+++ b/src/bifrost/adapters/events/null.py
@@ -5,7 +5,12 @@ Used in Pi / local mode where no event backbone is available.
 
 from __future__ import annotations
 
-from bifrost.ports.events import BudgetWarningEvent, CostEventEmitter, RequestCompletedEvent
+from bifrost.ports.events import (
+    BudgetDegradedEvent,
+    BudgetWarningEvent,
+    CostEventEmitter,
+    RequestCompletedEvent,
+)
 
 
 class NullEventEmitter(CostEventEmitter):
@@ -15,4 +20,7 @@ class NullEventEmitter(CostEventEmitter):
         pass
 
     async def emit_budget_warning(self, event: BudgetWarningEvent) -> None:
+        pass
+
+    async def emit_budget_degraded(self, event: BudgetDegradedEvent) -> None:
         pass

--- a/src/bifrost/adapters/events/sleipnir.py
+++ b/src/bifrost/adapters/events/sleipnir.py
@@ -18,7 +18,12 @@ import json
 import logging
 from dataclasses import asdict
 
-from bifrost.ports.events import BudgetWarningEvent, CostEventEmitter, RequestCompletedEvent
+from bifrost.ports.events import (
+    BudgetDegradedEvent,
+    BudgetWarningEvent,
+    CostEventEmitter,
+    RequestCompletedEvent,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -81,6 +86,9 @@ class SleipnirEventEmitter(CostEventEmitter):
         await self._publish(event.type, asdict(event))
 
     async def emit_budget_warning(self, event: BudgetWarningEvent) -> None:
+        await self._publish(event.type, asdict(event))
+
+    async def emit_budget_degraded(self, event: BudgetDegradedEvent) -> None:
         await self._publish(event.type, asdict(event))
 
     async def close(self) -> None:

--- a/src/bifrost/adapters/rules/yaml_engine.py
+++ b/src/bifrost/adapters/rules/yaml_engine.py
@@ -238,6 +238,8 @@ class YamlRuleEngine(RuleEnginePort):
                 return False
 
         if condition.agent_id is not None:
+            if not context.agent_id:
+                return False
             if not fnmatch.fnmatch(context.agent_id, condition.agent_id):
                 return False
 

--- a/src/bifrost/adapters/rules/yaml_engine.py
+++ b/src/bifrost/adapters/rules/yaml_engine.py
@@ -17,6 +17,7 @@ Supported conditions
 * ``system_prompt_matches`` — regex applied to the system prompt text.
 * ``message_count``         — numeric comparison on the number of messages.
 * ``has_image``             — request contains image blocks (bool).
+* ``agent_id``              — fnmatch pattern on the X-Ravn-Agent-Id header (e.g. ``'reviewer*'``).
 
 Numeric comparison expressions
 -------------------------------
@@ -26,6 +27,7 @@ A plain number is treated as an equality check (``== N``).
 
 from __future__ import annotations
 
+import fnmatch
 import re
 
 from bifrost.config import BifrostConfig, RuleCondition, RuleConfig
@@ -233,6 +235,10 @@ class YamlRuleEngine(RuleEnginePort):
         if condition.has_image is not None:
             req_has_image = _request_has_image(request)
             if req_has_image != condition.has_image:
+                return False
+
+        if condition.agent_id is not None:
+            if not fnmatch.fnmatch(context.agent_id, condition.agent_id):
                 return False
 
         return True

--- a/src/bifrost/config.py
+++ b/src/bifrost/config.py
@@ -243,6 +243,15 @@ class BudgetGuardrailConfig(BaseModel):
         ),
     )
 
+    @model_validator(mode="after")
+    def _validate_degradation_chain(self) -> BudgetGuardrailConfig:
+        seen: set[str] = set()
+        for model_id in self.degradation_chain:
+            if model_id in seen:
+                raise ValueError(f"degradation_chain contains duplicate model ID: {model_id!r}")
+            seen.add(model_id)
+        return self
+
 
 class ContextWindowGuardrailConfig(BaseModel):
     """Context-window guardrail: reject requests that exceed a message count threshold."""

--- a/src/bifrost/config.py
+++ b/src/bifrost/config.py
@@ -159,6 +159,14 @@ class RuleCondition(BaseModel):
         default=None,
         description="Match when the request contains image blocks (true) or not (false).",
     )
+    agent_id: str | None = Field(
+        default=None,
+        description=(
+            "fnmatch pattern matched against the X-Ravn-Agent-Id header value. "
+            "Use '*' as a wildcard (e.g. 'reviewer*' matches 'reviewer', 'reviewer-bot'). "
+            "Non-empty patterns only match when the header is present."
+        ),
+    )
 
     @model_validator(mode="after")
     def _validate_regex_fields(self) -> RuleCondition:
@@ -222,6 +230,16 @@ class BudgetGuardrailConfig(BaseModel):
         default="reject",
         description=(
             "Action to take when the budget is fully exhausted (100%). Only 'reject' is supported."
+        ),
+    )
+    degradation_chain: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Ordered list of model IDs (most capable → cheapest) for automatic downgrade. "
+            "When the warn threshold is reached, the request model is looked up in this list "
+            "and downgraded to the next cheaper entry. "
+            "Example: ['claude-opus-4-6', 'claude-sonnet-4-6', 'claude-haiku-4-5-20251001']. "
+            "When empty, warn_target is used instead (legacy behaviour)."
         ),
     )
 
@@ -378,8 +396,7 @@ class AuditConfig(BaseModel):
     adapter: AuditAdapter = Field(
         default=AuditAdapter.NULL,
         description=(
-            "Audit backend. Accepted values: 'null' (default, no-op), "
-            "'postgres', 'sqlite', 'otel'."
+            "Audit backend. Accepted values: 'null' (default, no-op), 'postgres', 'sqlite', 'otel'."
         ),
     )
     level: AuditDetailLevel = Field(

--- a/src/bifrost/inbound/routes.py
+++ b/src/bifrost/inbound/routes.py
@@ -51,7 +51,7 @@ from bifrost.inbound.tracking import (
 from bifrost.ports.audit import AuditEvent, AuditPort
 from bifrost.ports.auth import AuthPort
 from bifrost.ports.cache import CachePort
-from bifrost.ports.events import CostEventEmitter
+from bifrost.ports.events import BudgetDegradedEvent, CostEventEmitter
 from bifrost.ports.rules import RoutingContext
 from bifrost.ports.usage_store import UsageRecord, UsageStore
 from bifrost.pricing import ModelPricing, calculate_cost
@@ -329,19 +329,50 @@ def _check_model_access(
 # ---------------------------------------------------------------------------
 
 
+def _resolve_degraded_model(current_model: str, budget_cfg) -> str:  # noqa: ANN001
+    """Return the next cheaper model in the degradation chain for *current_model*.
+
+    When the degradation chain is configured, the current model is looked up
+    and the next entry (one step cheaper) is returned.  If the model is not
+    found or is already the last in the chain, the chain's final entry is
+    returned.  Falls back to ``budget_cfg.warn_target`` when the chain is empty.
+
+    Args:
+        current_model: The model ID from the inbound request.
+        budget_cfg:    ``BudgetGuardrailConfig`` with chain and fallback.
+
+    Returns:
+        The model ID to route to.
+    """
+    chain = budget_cfg.degradation_chain
+    if not chain:
+        return budget_cfg.warn_target
+
+    try:
+        idx = chain.index(current_model)
+    except ValueError:
+        # Model not in chain — use final (cheapest) entry as safe fallback.
+        return chain[-1]
+
+    next_idx = min(idx + 1, len(chain) - 1)
+    return chain[next_idx]
+
+
 async def _evaluate_guardrails(
     request: AnthropicRequest,
     identity: AgentIdentity,
     config: BifrostConfig,
     store: UsageStore,
     agent_perms: AgentPermissions,
+    event_emitter: CostEventEmitter | None = None,
     agent_cost_today: float | None = None,
 ) -> tuple[AnthropicRequest, RoutingContext, str | None]:
     """Evaluate budget and context-window guardrails before routing.
 
     This runs *after* ``_check_quotas`` so the hard-limit 429 (agent budget
     exhausted) is always raised there first.  This function handles the
-    *soft* budget path: routing to a cheaper model and injecting the
+    *soft* budget path: routing to a cheaper model, emitting a
+    ``bifrost.budget.degraded`` event, and injecting the
     ``X-Bifrost-Budget-Warning`` response header.
 
     Args:
@@ -351,6 +382,7 @@ async def _evaluate_guardrails(
         store:            Usage store (queried only when ``agent_cost_today``
                           is not supplied).
         agent_perms:      Pre-resolved permissions for the caller.
+        event_emitter:    Optional emitter for budget degradation events.
         agent_cost_today: Agent cost already fetched by ``_check_quotas``
                           (avoids a duplicate store round-trip).  When
                           ``None``, the store is queried directly.
@@ -358,9 +390,8 @@ async def _evaluate_guardrails(
     Returns:
         A 3-tuple of:
         - ``request``      — possibly with model overridden (budget warn_action).
-        - ``context``      — ``RoutingContext`` with ``agent_budget_pct`` set so
-                             that declarative budget rules in the rule engine also
-                             fire correctly.
+        - ``context``      — ``RoutingContext`` with ``agent_budget_pct`` and
+                             ``agent_id`` set so that declarative rules fire.
         - ``budget_warn``  — header value for ``X-Bifrost-Budget-Warning``, or
                              ``None`` when no warning is applicable.
 
@@ -394,15 +425,41 @@ async def _evaluate_guardrails(
         agent_budget_pct = pct_consumed
 
         if pct_consumed >= budget_cfg.warn_at_pct:
+            original_model = request.model
+            degraded_model = _resolve_degraded_model(original_model, budget_cfg)
             if budget_cfg.warn_action == "route_to":
-                request = request.model_copy(update={"model": budget_cfg.warn_target})
+                request = request.model_copy(update={"model": degraded_model})
             budget_warn = (
                 f"budget_consumed={pct_consumed:.1f}% "
                 f"(${agent_cost:.4f}/${limit:.4f}); "
-                f"routed_to={budget_cfg.warn_target}"
+                f"routed_to={degraded_model}"
             )
+            logger.info(
+                "Budget degradation: agent=%s pct=%.1f%% model %s -> %s (spent=$%.4f limit=$%.4f)",
+                identity.agent_id,
+                pct_consumed,
+                original_model,
+                degraded_model,
+                agent_cost,
+                limit,
+            )
+            if event_emitter is not None:
+                await event_emitter.emit_budget_degraded(
+                    BudgetDegradedEvent(
+                        agent_id=identity.agent_id,
+                        session_id=identity.session_id,
+                        original_model=original_model,
+                        degraded_model=degraded_model,
+                        budget_pct_consumed=pct_consumed,
+                        daily_limit_usd=limit,
+                        spent_usd=agent_cost,
+                    )
+                )
 
-    context = RoutingContext(agent_budget_pct=agent_budget_pct)
+    context = RoutingContext(
+        agent_budget_pct=agent_budget_pct,
+        agent_id=identity.agent_id,
+    )
     return request, context, budget_warn
 
 
@@ -684,7 +741,7 @@ def create_router(
         # --- Guardrail evaluation (budget + context-window) ---
         # Pass agent_cost_today to avoid a duplicate store query.
         request, routing_ctx, budget_warn = await _evaluate_guardrails(
-            request, identity, config, store, agent_perms, agent_cost_today
+            request, identity, config, store, agent_perms, event_emitter, agent_cost_today
         )
 
         request_id = str(raw_request.state.correlation_id)
@@ -1050,7 +1107,7 @@ def create_router(
         # Pass agent_cost_today to avoid a duplicate store query.
         try:
             request, routing_ctx, budget_warn = await _evaluate_guardrails(
-                request, identity, config, store, agent_perms, agent_cost_today
+                request, identity, config, store, agent_perms, event_emitter, agent_cost_today
             )
         except HTTPException as exc:
             return openai_error_response(exc.status_code, exc.detail, "rate_limit_error")
@@ -1312,7 +1369,7 @@ def create_router(
         # Pass agent_cost_today to avoid a duplicate store query.
         try:
             request, routing_ctx, budget_warn = await _evaluate_guardrails(
-                request, identity, config, store, agent_perms, agent_cost_today
+                request, identity, config, store, agent_perms, event_emitter, agent_cost_today
             )
         except HTTPException as exc:
             return ollama_error_response(exc.status_code, exc.detail)

--- a/src/bifrost/inbound/routes.py
+++ b/src/bifrost/inbound/routes.py
@@ -21,7 +21,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 import bifrost.metrics as _metrics
 from bifrost.auth import AgentIdentity
-from bifrost.config import AgentPermissions, AuditDetailLevel, BifrostConfig
+from bifrost.config import AgentPermissions, AuditDetailLevel, BifrostConfig, BudgetGuardrailConfig
 from bifrost.domain.models import RequestLog, TokenUsage
 from bifrost.domain.routing import RuleRejectError
 from bifrost.inbound.chat_completions import (
@@ -329,21 +329,8 @@ def _check_model_access(
 # ---------------------------------------------------------------------------
 
 
-def _resolve_degraded_model(current_model: str, budget_cfg) -> str:  # noqa: ANN001
-    """Return the next cheaper model in the degradation chain for *current_model*.
-
-    When the degradation chain is configured, the current model is looked up
-    and the next entry (one step cheaper) is returned.  If the model is not
-    found or is already the last in the chain, the chain's final entry is
-    returned.  Falls back to ``budget_cfg.warn_target`` when the chain is empty.
-
-    Args:
-        current_model: The model ID from the inbound request.
-        budget_cfg:    ``BudgetGuardrailConfig`` with chain and fallback.
-
-    Returns:
-        The model ID to route to.
-    """
+def _resolve_degraded_model(current_model: str, budget_cfg: BudgetGuardrailConfig) -> str:
+    """Return the next cheaper model in the degradation chain, or warn_target if chain is empty."""
     chain = budget_cfg.degradation_chain
     if not chain:
         return budget_cfg.warn_target

--- a/src/bifrost/ports/events.py
+++ b/src/bifrost/ports/events.py
@@ -36,6 +36,20 @@ class BudgetWarningEvent:
     type: str = "bifrost.cost.budget_warning"
 
 
+@dataclass
+class BudgetDegradedEvent:
+    """Emitted when a request is routed to a cheaper model due to budget pressure."""
+
+    agent_id: str
+    session_id: str
+    original_model: str
+    degraded_model: str
+    budget_pct_consumed: float
+    daily_limit_usd: float
+    spent_usd: float
+    type: str = "bifrost.budget.degraded"
+
+
 class CostEventEmitter(ABC):
     """Port for publishing cost events to downstream consumers."""
 
@@ -46,6 +60,10 @@ class CostEventEmitter(ABC):
     @abstractmethod
     async def emit_budget_warning(self, event: BudgetWarningEvent) -> None:
         """Publish a budget-warning event."""
+
+    @abstractmethod
+    async def emit_budget_degraded(self, event: BudgetDegradedEvent) -> None:
+        """Publish a budget-degraded event when a request is downgraded to a cheaper model."""
 
     async def close(self) -> None:
         """Release resources held by this emitter."""

--- a/src/bifrost/ports/rules.py
+++ b/src/bifrost/ports/rules.py
@@ -53,7 +53,7 @@ class RoutingContext:
     """Per-request context passed alongside the request during rule evaluation.
 
     Carries computed values that are not present in the raw request body, such
-    as the remaining agent budget percentage.
+    as the remaining agent budget percentage and the agent identity header.
     """
 
     agent_budget_pct: float | None = field(
@@ -64,6 +64,16 @@ class RoutingContext:
 
     ``None`` when the usage store has not been queried or when there is no
     per-agent budget configured (M4 feature).
+    """
+
+    agent_id: str = field(
+        default="",
+        metadata={"description": "Value of the X-Ravn-Agent-Id header; empty string when absent."},
+    )
+    """Agent identifier from the X-Ravn-Agent-Id request header.
+
+    Used by ``agent_id`` rule conditions to route requests based on the
+    persona name or agent identity set by the Ravn BifrostAdapter.
     """
 
 

--- a/src/sleipnir/domain/registry.py
+++ b/src/sleipnir/domain/registry.py
@@ -265,6 +265,9 @@ BIFROST_PROVIDER_DOWN: str = "bifrost.provider.down"
 #: The upstream LLM provider recovered and is healthy again.
 BIFROST_PROVIDER_RECOVERED: str = "bifrost.provider.recovered"
 
+#: A request was automatically routed to a cheaper model due to budget pressure.
+BIFROST_BUDGET_DEGRADED: str = "bifrost.budget.degraded"
+
 # ---------------------------------------------------------------------------
 # system — Infrastructure and lifecycle events
 # ---------------------------------------------------------------------------

--- a/tests/test_bifrost/test_events.py
+++ b/tests/test_bifrost/test_events.py
@@ -32,7 +32,12 @@ from bifrost.config import (
     QuotaConfig,
 )
 from bifrost.inbound.tracking import _compute_budget_pct, emit_cost_events
-from bifrost.ports.events import BudgetWarningEvent, CostEventEmitter, RequestCompletedEvent
+from bifrost.ports.events import (
+    BudgetDegradedEvent,
+    BudgetWarningEvent,
+    CostEventEmitter,
+    RequestCompletedEvent,
+)
 from bifrost.ports.usage_store import UsageRecord
 
 # ---------------------------------------------------------------------------
@@ -393,7 +398,7 @@ class TestEmitCostEvents:
             async def emit_budget_warning(self, event: BudgetWarningEvent) -> None:
                 pass
 
-            async def emit_budget_degraded(self, event) -> None:
+            async def emit_budget_degraded(self, event: BudgetDegradedEvent) -> None:
                 pass
 
         store = MemoryUsageStore()
@@ -486,7 +491,7 @@ class TestEndToEndEventEmission:
             async def emit_budget_warning(self, event: BudgetWarningEvent) -> None:
                 captured_warnings.append(event)
 
-            async def emit_budget_degraded(self, event) -> None:
+            async def emit_budget_degraded(self, event: BudgetDegradedEvent) -> None:
                 pass
 
         cfg = BifrostConfig(
@@ -539,7 +544,7 @@ class TestEndToEndEventEmission:
             async def emit_budget_warning(self, event: BudgetWarningEvent) -> None:
                 captured_warnings.append(event)
 
-            async def emit_budget_degraded(self, event) -> None:
+            async def emit_budget_degraded(self, event: BudgetDegradedEvent) -> None:
                 pass
 
         # Agent has a $1.00 daily limit; store already has $0.95 spent

--- a/tests/test_bifrost/test_events.py
+++ b/tests/test_bifrost/test_events.py
@@ -393,6 +393,9 @@ class TestEmitCostEvents:
             async def emit_budget_warning(self, event: BudgetWarningEvent) -> None:
                 pass
 
+            async def emit_budget_degraded(self, event) -> None:
+                pass
+
         store = MemoryUsageStore()
         identity = _identity(agent_id="agt", session_id="sess-abc")
 
@@ -483,6 +486,9 @@ class TestEndToEndEventEmission:
             async def emit_budget_warning(self, event: BudgetWarningEvent) -> None:
                 captured_warnings.append(event)
 
+            async def emit_budget_degraded(self, event) -> None:
+                pass
+
         cfg = BifrostConfig(
             providers={"anthropic": ProviderConfig(models=["claude-sonnet-4-6"])},
         )
@@ -532,6 +538,9 @@ class TestEndToEndEventEmission:
 
             async def emit_budget_warning(self, event: BudgetWarningEvent) -> None:
                 captured_warnings.append(event)
+
+            async def emit_budget_degraded(self, event) -> None:
+                pass
 
         # Agent has a $1.00 daily limit; store already has $0.95 spent
         cfg = BifrostConfig(

--- a/tests/test_bifrost/test_persona_routing.py
+++ b/tests/test_bifrost/test_persona_routing.py
@@ -1,0 +1,659 @@
+"""Tests for NIU-583 — persona-aware model routing via X-Ravn-Agent-Id.
+
+Covers:
+ - RoutingContext.agent_id field
+ - RuleCondition.agent_id fnmatch pattern condition
+ - YamlRuleEngine matching agent_id patterns (exact, wildcard, no-match)
+ - BifrostConfig.degradation_chain in BudgetGuardrailConfig
+ - _resolve_degraded_model() — downgrade chain logic
+ - BudgetDegradedEvent structure
+ - _evaluate_guardrails() — degradation chain + event emission + agent_id in context
+ - Header-based routing: reviewer* → Opus, ship* → Haiku, no header → default
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from bifrost.adapters.memory_store import MemoryUsageStore
+from bifrost.adapters.rules.yaml_engine import YamlRuleEngine
+from bifrost.auth import AgentIdentity
+from bifrost.config import (
+    AgentPermissions,
+    BifrostConfig,
+    BudgetGuardrailConfig,
+    GuardrailsConfig,
+    ProviderConfig,
+    QuotaConfig,
+    RuleCondition,
+    RuleConfig,
+)
+from bifrost.inbound.routes import _evaluate_guardrails, _resolve_degraded_model
+from bifrost.ports.events import BudgetDegradedEvent, CostEventEmitter
+from bifrost.ports.rules import RoutingContext
+from bifrost.ports.usage_store import UsageRecord
+from bifrost.translation.models import AnthropicRequest, Message
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _req(model: str = "claude-sonnet-4-6") -> AnthropicRequest:
+    return AnthropicRequest(
+        model=model,
+        max_tokens=100,
+        messages=[Message(role="user", content="hi")],
+    )
+
+
+def _identity(agent_id: str = "agent-1", session_id: str = "sess-1") -> AgentIdentity:
+    return AgentIdentity(agent_id=agent_id, tenant_id="tenant-1", session_id=session_id)
+
+
+def _now_record(agent_id: str = "agent-1", cost_usd: float = 0.0) -> UsageRecord:
+    return UsageRecord(
+        request_id="",
+        agent_id=agent_id,
+        tenant_id="tenant-1",
+        session_id="",
+        saga_id="",
+        model="claude-sonnet-4-6",
+        input_tokens=0,
+        output_tokens=0,
+        cost_usd=cost_usd,
+        timestamp=datetime.now(UTC),
+    )
+
+
+def _seeded_store(*records: UsageRecord) -> MemoryUsageStore:
+    store = MemoryUsageStore()
+    store._records.extend(records)
+    return store
+
+
+def _cfg() -> BifrostConfig:
+    return BifrostConfig(
+        providers={
+            "anthropic": ProviderConfig(
+                models=[
+                    "claude-opus-4-6",
+                    "claude-sonnet-4-6",
+                    "claude-haiku-4-5-20251001",
+                ]
+            )
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# RoutingContext.agent_id
+# ---------------------------------------------------------------------------
+
+
+class TestRoutingContextAgentId:
+    def test_default_agent_id_is_empty_string(self):
+        ctx = RoutingContext()
+        assert ctx.agent_id == ""
+
+    def test_agent_id_can_be_set(self):
+        ctx = RoutingContext(agent_id="reviewer-bot")
+        assert ctx.agent_id == "reviewer-bot"
+
+    def test_agent_id_and_budget_pct_independent(self):
+        ctx = RoutingContext(agent_id="qa-agent", agent_budget_pct=42.0)
+        assert ctx.agent_id == "qa-agent"
+        assert ctx.agent_budget_pct == 42.0
+
+
+# ---------------------------------------------------------------------------
+# RuleCondition.agent_id field
+# ---------------------------------------------------------------------------
+
+
+class TestRuleConditionAgentId:
+    def test_agent_id_defaults_to_none(self):
+        cond = RuleCondition()
+        assert cond.agent_id is None
+
+    def test_agent_id_can_be_set(self):
+        cond = RuleCondition(agent_id="reviewer*")
+        assert cond.agent_id == "reviewer*"
+
+    def test_agent_id_deserialized_from_dict(self):
+        rule = RuleConfig.model_validate(
+            {
+                "name": "reviewer-to-opus",
+                "when": {"agent_id": "reviewer*"},
+                "action": "route_to",
+                "target": "claude-opus-4-6",
+            }
+        )
+        assert rule.when.agent_id == "reviewer*"
+        assert rule.action == "route_to"
+        assert rule.target == "claude-opus-4-6"
+
+
+# ---------------------------------------------------------------------------
+# YamlRuleEngine — agent_id condition matching
+# ---------------------------------------------------------------------------
+
+
+class TestYamlRuleEngineAgentIdCondition:
+    def _engine(self, pattern: str) -> YamlRuleEngine:
+        cfg = _cfg()
+        return YamlRuleEngine(
+            rules=[
+                RuleConfig(
+                    name="agent-rule",
+                    when=RuleCondition(agent_id=pattern),
+                    action="log",
+                )
+            ],
+            config=cfg,
+        )
+
+    def test_exact_match_fires(self):
+        engine = self._engine("reviewer")
+        ctx = RoutingContext(agent_id="reviewer")
+        assert engine.evaluate(_req(), ctx) is not None
+
+    def test_wildcard_suffix_matches(self):
+        engine = self._engine("reviewer*")
+        ctx = RoutingContext(agent_id="reviewer-bot")
+        assert engine.evaluate(_req(), ctx) is not None
+
+    def test_wildcard_suffix_matches_base_name(self):
+        engine = self._engine("reviewer*")
+        ctx = RoutingContext(agent_id="reviewer")
+        assert engine.evaluate(_req(), ctx) is not None
+
+    def test_wildcard_suffix_does_not_match_different_prefix(self):
+        engine = self._engine("reviewer*")
+        ctx = RoutingContext(agent_id="ship-agent")
+        assert engine.evaluate(_req(), ctx) is None
+
+    def test_ship_wildcard_matches_ship_agent(self):
+        engine = self._engine("ship*")
+        ctx = RoutingContext(agent_id="ship-agent")
+        assert engine.evaluate(_req(), ctx) is not None
+
+    def test_qa_wildcard_matches_qa_bot(self):
+        engine = self._engine("qa*")
+        ctx = RoutingContext(agent_id="qa-bot")
+        assert engine.evaluate(_req(), ctx) is not None
+
+    def test_empty_agent_id_does_not_match_specific_pattern(self):
+        engine = self._engine("reviewer*")
+        ctx = RoutingContext(agent_id="")
+        assert engine.evaluate(_req(), ctx) is None
+
+    def test_wildcard_star_matches_any_agent_id(self):
+        engine = self._engine("*")
+        ctx = RoutingContext(agent_id="anything-at-all")
+        assert engine.evaluate(_req(), ctx) is not None
+
+    def test_agent_id_combined_with_model_condition(self):
+        cfg = _cfg()
+        engine = YamlRuleEngine(
+            rules=[
+                RuleConfig(
+                    name="combo-rule",
+                    when=RuleCondition(agent_id="reviewer*", model="claude-opus-4-6"),
+                    action="log",
+                )
+            ],
+            config=cfg,
+        )
+        # Both match
+        ctx_match = RoutingContext(agent_id="reviewer-bot")
+        assert engine.evaluate(_req(model="claude-opus-4-6"), ctx_match) is not None
+        # Only agent_id matches
+        ctx_match2 = RoutingContext(agent_id="reviewer-bot")
+        assert engine.evaluate(_req(model="claude-sonnet-4-6"), ctx_match2) is None
+        # Only model matches
+        ctx_no_match = RoutingContext(agent_id="ship-agent")
+        assert engine.evaluate(_req(model="claude-opus-4-6"), ctx_no_match) is None
+
+
+class TestPersonaRoutingRules:
+    """Validate the three canonical persona rules from the task spec."""
+
+    def _engine_with_persona_rules(self) -> YamlRuleEngine:
+        cfg = _cfg()
+        rules = [
+            RuleConfig(
+                name="reviewer-to-opus",
+                when=RuleCondition(agent_id="reviewer*"),
+                action="route_to",
+                target="claude-opus-4-6",
+            ),
+            RuleConfig(
+                name="ship-to-haiku",
+                when=RuleCondition(agent_id="ship*"),
+                action="route_to",
+                target="claude-haiku-4-5-20251001",
+            ),
+            RuleConfig(
+                name="qa-to-sonnet",
+                when=RuleCondition(agent_id="qa*"),
+                action="route_to",
+                target="claude-sonnet-4-6",
+            ),
+        ]
+        return YamlRuleEngine(rules=rules, config=cfg)
+
+    def test_reviewer_routes_to_opus(self):
+        engine = self._engine_with_persona_rules()
+        result = engine.evaluate(_req(), RoutingContext(agent_id="reviewer"))
+        assert result is not None
+        assert result.target == "claude-opus-4-6"
+
+    def test_reviewer_bot_routes_to_opus(self):
+        engine = self._engine_with_persona_rules()
+        result = engine.evaluate(_req(), RoutingContext(agent_id="reviewer-bot"))
+        assert result is not None
+        assert result.target == "claude-opus-4-6"
+
+    def test_ship_agent_routes_to_haiku(self):
+        engine = self._engine_with_persona_rules()
+        result = engine.evaluate(_req(), RoutingContext(agent_id="ship-agent"))
+        assert result is not None
+        assert result.target == "claude-haiku-4-5-20251001"
+
+    def test_qa_agent_routes_to_sonnet(self):
+        engine = self._engine_with_persona_rules()
+        result = engine.evaluate(_req(), RoutingContext(agent_id="qa-bot"))
+        assert result is not None
+        assert result.target == "claude-sonnet-4-6"
+
+    def test_no_agent_id_falls_through_all_rules(self):
+        engine = self._engine_with_persona_rules()
+        result = engine.evaluate(_req(), RoutingContext(agent_id=""))
+        assert result is None
+
+    def test_unknown_agent_id_falls_through(self):
+        engine = self._engine_with_persona_rules()
+        result = engine.evaluate(_req(), RoutingContext(agent_id="unknown-agent"))
+        assert result is None
+
+    def test_first_match_wins_reviewer_not_qa(self):
+        cfg = _cfg()
+        rules = [
+            RuleConfig(
+                name="reviewer-to-opus",
+                when=RuleCondition(agent_id="reviewer*"),
+                action="route_to",
+                target="claude-opus-4-6",
+            ),
+            RuleConfig(
+                name="catch-all-to-haiku",
+                when=RuleCondition(agent_id="*"),
+                action="route_to",
+                target="claude-haiku-4-5-20251001",
+            ),
+        ]
+        engine = YamlRuleEngine(rules=rules, config=cfg)
+        result = engine.evaluate(_req(), RoutingContext(agent_id="reviewer"))
+        assert result is not None
+        assert result.target == "claude-opus-4-6"
+        assert result.rule_name == "reviewer-to-opus"
+
+
+# ---------------------------------------------------------------------------
+# BudgetGuardrailConfig.degradation_chain
+# ---------------------------------------------------------------------------
+
+
+_CHAIN = ["claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5-20251001"]
+
+
+class TestBudgetGuardrailConfigDegradationChain:
+    def test_default_chain_is_empty(self):
+        cfg = BudgetGuardrailConfig()
+        assert cfg.degradation_chain == []
+
+    def test_chain_can_be_configured(self):
+        cfg = BudgetGuardrailConfig(degradation_chain=_CHAIN)
+        assert cfg.degradation_chain == _CHAIN
+
+    def test_chain_deserialized_from_dict(self):
+        cfg = BudgetGuardrailConfig.model_validate(
+            {
+                "warn_at_pct": 80,
+                "warn_action": "route_to",
+                "warn_target": "fast",
+                "hard_limit_action": "reject",
+                "degradation_chain": _CHAIN,
+            }
+        )
+        assert cfg.degradation_chain == _CHAIN
+
+
+# ---------------------------------------------------------------------------
+# _resolve_degraded_model
+# ---------------------------------------------------------------------------
+
+
+class TestResolveDegradedModel:
+    def _budget_cfg(self, chain: list[str], warn_target: str = "fast") -> BudgetGuardrailConfig:
+        return BudgetGuardrailConfig(
+            degradation_chain=chain,
+            warn_target=warn_target,
+        )
+
+    def test_empty_chain_returns_warn_target(self):
+        cfg = self._budget_cfg(chain=[], warn_target="claude-haiku-4-5-20251001")
+        assert _resolve_degraded_model("claude-opus-4-6", cfg) == "claude-haiku-4-5-20251001"
+
+    def test_opus_downgrades_to_sonnet(self):
+        cfg = self._budget_cfg(chain=_CHAIN)
+        assert _resolve_degraded_model("claude-opus-4-6", cfg) == "claude-sonnet-4-6"
+
+    def test_sonnet_downgrades_to_haiku(self):
+        cfg = self._budget_cfg(chain=_CHAIN)
+        result = _resolve_degraded_model("claude-sonnet-4-6", cfg)
+        assert result == "claude-haiku-4-5-20251001"
+
+    def test_haiku_stays_at_haiku(self):
+        cfg = self._budget_cfg(chain=_CHAIN)
+        result = _resolve_degraded_model("claude-haiku-4-5-20251001", cfg)
+        assert result == "claude-haiku-4-5-20251001"
+
+    def test_unknown_model_returns_last_in_chain(self):
+        cfg = self._budget_cfg(chain=_CHAIN)
+        result = _resolve_degraded_model("unknown-model", cfg)
+        assert result == "claude-haiku-4-5-20251001"
+
+    def test_single_item_chain_returns_itself(self):
+        cfg = self._budget_cfg(chain=["claude-haiku-4-5-20251001"])
+        result = _resolve_degraded_model("claude-haiku-4-5-20251001", cfg)
+        assert result == "claude-haiku-4-5-20251001"
+
+
+# ---------------------------------------------------------------------------
+# BudgetDegradedEvent
+# ---------------------------------------------------------------------------
+
+
+class TestBudgetDegradedEvent:
+    def test_event_type(self):
+        evt = BudgetDegradedEvent(
+            agent_id="reviewer",
+            session_id="sess-1",
+            original_model="claude-opus-4-6",
+            degraded_model="claude-sonnet-4-6",
+            budget_pct_consumed=85.0,
+            daily_limit_usd=10.0,
+            spent_usd=8.5,
+        )
+        assert evt.type == "bifrost.budget.degraded"
+
+    def test_fields_are_set(self):
+        evt = BudgetDegradedEvent(
+            agent_id="ship-agent",
+            session_id="sess-abc",
+            original_model="claude-opus-4-6",
+            degraded_model="claude-haiku-4-5-20251001",
+            budget_pct_consumed=95.0,
+            daily_limit_usd=5.0,
+            spent_usd=4.75,
+        )
+        assert evt.agent_id == "ship-agent"
+        assert evt.session_id == "sess-abc"
+        assert evt.original_model == "claude-opus-4-6"
+        assert evt.degraded_model == "claude-haiku-4-5-20251001"
+        assert evt.budget_pct_consumed == 95.0
+        assert evt.daily_limit_usd == 5.0
+        assert evt.spent_usd == 4.75
+
+
+# ---------------------------------------------------------------------------
+# _evaluate_guardrails — degradation chain + event emission + agent_id context
+# ---------------------------------------------------------------------------
+
+
+class FakeEmitter(CostEventEmitter):
+    """Test double that records all emitted events."""
+
+    def __init__(self) -> None:
+        self.degraded_events: list[BudgetDegradedEvent] = []
+
+    async def emit_request_completed(self, event) -> None:  # noqa: ANN001
+        pass
+
+    async def emit_budget_warning(self, event) -> None:  # noqa: ANN001
+        pass
+
+    async def emit_budget_degraded(self, event: BudgetDegradedEvent) -> None:
+        self.degraded_events.append(event)
+
+
+class TestEvaluateGuardrailsAgentIdInContext:
+    """RoutingContext.agent_id is populated from identity.agent_id."""
+
+    async def test_agent_id_propagated_to_context(self):
+        config = BifrostConfig(
+            providers={"anthropic": ProviderConfig(models=["claude-sonnet-4-6"])},
+        )
+        store = MemoryUsageStore()
+        identity = _identity(agent_id="reviewer-bot")
+        agent_perms = AgentPermissions()
+
+        _, ctx, _ = await _evaluate_guardrails(_req(), identity, config, store, agent_perms)
+
+        assert ctx.agent_id == "reviewer-bot"
+
+    async def test_agent_id_empty_string_when_anonymous(self):
+        config = BifrostConfig(
+            providers={"anthropic": ProviderConfig(models=["claude-sonnet-4-6"])},
+        )
+        store = MemoryUsageStore()
+        identity = _identity(agent_id="")
+        agent_perms = AgentPermissions()
+
+        _, ctx, _ = await _evaluate_guardrails(_req(), identity, config, store, agent_perms)
+
+        assert ctx.agent_id == ""
+
+
+class TestEvaluateGuardrailsDegradationChain:
+    """_evaluate_guardrails uses the chain when budget threshold is hit."""
+
+    async def test_opus_downgrades_to_sonnet_via_chain(self):
+        config = BifrostConfig(
+            providers={
+                "anthropic": ProviderConfig(models=["claude-opus-4-6", "claude-sonnet-4-6"])
+            },
+            guardrails=GuardrailsConfig(
+                budget=BudgetGuardrailConfig(
+                    warn_at_pct=80.0,
+                    degradation_chain=_CHAIN,
+                )
+            ),
+        )
+        store = _seeded_store(_now_record(cost_usd=0.85))
+        identity = _identity()
+        agent_perms = AgentPermissions(quota=QuotaConfig(max_cost_per_day=1.0))
+
+        new_req, _, budget_warn = await _evaluate_guardrails(
+            _req(model="claude-opus-4-6"), identity, config, store, agent_perms
+        )
+
+        assert new_req.model == "claude-sonnet-4-6"
+        assert "routed_to=claude-sonnet-4-6" in budget_warn
+
+    async def test_sonnet_downgrades_to_haiku_via_chain(self):
+        config = BifrostConfig(
+            providers={
+                "anthropic": ProviderConfig(
+                    models=["claude-sonnet-4-6", "claude-haiku-4-5-20251001"]
+                )
+            },
+            guardrails=GuardrailsConfig(
+                budget=BudgetGuardrailConfig(
+                    warn_at_pct=80.0,
+                    degradation_chain=_CHAIN,
+                )
+            ),
+        )
+        store = _seeded_store(_now_record(cost_usd=0.85))
+        identity = _identity()
+        agent_perms = AgentPermissions(quota=QuotaConfig(max_cost_per_day=1.0))
+
+        new_req, _, _ = await _evaluate_guardrails(
+            _req(model="claude-sonnet-4-6"), identity, config, store, agent_perms
+        )
+
+        assert new_req.model == "claude-haiku-4-5-20251001"
+
+    async def test_empty_chain_falls_back_to_warn_target(self):
+        config = BifrostConfig(
+            providers={
+                "anthropic": ProviderConfig(models=["claude-opus-4-6", "claude-haiku-4-5-20251001"])
+            },
+            guardrails=GuardrailsConfig(
+                budget=BudgetGuardrailConfig(
+                    warn_at_pct=80.0,
+                    warn_target="claude-haiku-4-5-20251001",
+                    degradation_chain=[],
+                )
+            ),
+        )
+        store = _seeded_store(_now_record(cost_usd=0.85))
+        identity = _identity()
+        agent_perms = AgentPermissions(quota=QuotaConfig(max_cost_per_day=1.0))
+
+        new_req, _, _ = await _evaluate_guardrails(
+            _req(model="claude-opus-4-6"), identity, config, store, agent_perms
+        )
+
+        assert new_req.model == "claude-haiku-4-5-20251001"
+
+
+class TestEvaluateGuardrailsBudgetDegradedEvent:
+    """bifrost.budget.degraded is emitted when degradation fires."""
+
+    async def test_event_emitted_on_degradation(self):
+        config = BifrostConfig(
+            providers={
+                "anthropic": ProviderConfig(models=["claude-opus-4-6", "claude-sonnet-4-6"])
+            },
+            guardrails=GuardrailsConfig(
+                budget=BudgetGuardrailConfig(
+                    warn_at_pct=80.0,
+                    degradation_chain=_CHAIN,
+                )
+            ),
+        )
+        store = _seeded_store(_now_record(agent_id="reviewer-bot", cost_usd=0.85))
+        identity = _identity(agent_id="reviewer-bot", session_id="sess-xyz")
+        agent_perms = AgentPermissions(quota=QuotaConfig(max_cost_per_day=1.0))
+        emitter = FakeEmitter()
+
+        await _evaluate_guardrails(
+            _req(model="claude-opus-4-6"),
+            identity,
+            config,
+            store,
+            agent_perms,
+            emitter,
+        )
+
+        assert len(emitter.degraded_events) == 1
+        evt = emitter.degraded_events[0]
+        assert evt.agent_id == "reviewer-bot"
+        assert evt.session_id == "sess-xyz"
+        assert evt.original_model == "claude-opus-4-6"
+        assert evt.degraded_model == "claude-sonnet-4-6"
+        assert evt.type == "bifrost.budget.degraded"
+
+    async def test_no_event_when_below_threshold(self):
+        config = BifrostConfig(
+            providers={"anthropic": ProviderConfig(models=["claude-opus-4-6"])},
+            guardrails=GuardrailsConfig(
+                budget=BudgetGuardrailConfig(
+                    warn_at_pct=80.0,
+                    degradation_chain=_CHAIN,
+                )
+            ),
+        )
+        store = _seeded_store(_now_record(cost_usd=0.50))  # 50% — below threshold
+        identity = _identity()
+        agent_perms = AgentPermissions(quota=QuotaConfig(max_cost_per_day=1.0))
+        emitter = FakeEmitter()
+
+        await _evaluate_guardrails(
+            _req(model="claude-opus-4-6"),
+            identity,
+            config,
+            store,
+            agent_perms,
+            emitter,
+        )
+
+        assert len(emitter.degraded_events) == 0
+
+    async def test_no_event_when_no_emitter(self):
+        """When event_emitter=None, no error is raised."""
+        config = BifrostConfig(
+            providers={
+                "anthropic": ProviderConfig(models=["claude-opus-4-6", "claude-sonnet-4-6"])
+            },
+            guardrails=GuardrailsConfig(
+                budget=BudgetGuardrailConfig(
+                    warn_at_pct=80.0,
+                    degradation_chain=_CHAIN,
+                )
+            ),
+        )
+        store = _seeded_store(_now_record(cost_usd=0.85))
+        identity = _identity()
+        agent_perms = AgentPermissions(quota=QuotaConfig(max_cost_per_day=1.0))
+
+        new_req, _, budget_warn = await _evaluate_guardrails(
+            _req(model="claude-opus-4-6"),
+            identity,
+            config,
+            store,
+            agent_perms,
+            None,  # no emitter
+        )
+
+        assert new_req.model == "claude-sonnet-4-6"
+        assert budget_warn is not None
+
+
+# ---------------------------------------------------------------------------
+# Sleipnir registry constant
+# ---------------------------------------------------------------------------
+
+
+class TestSleipnirRegistry:
+    def test_budget_degraded_event_type_registered(self):
+        from sleipnir.domain.registry import BIFROST_BUDGET_DEGRADED
+
+        assert BIFROST_BUDGET_DEGRADED == "bifrost.budget.degraded"
+
+
+# ---------------------------------------------------------------------------
+# NullEventEmitter and SleipnirEventEmitter implement emit_budget_degraded
+# ---------------------------------------------------------------------------
+
+
+class TestNullEmitterBudgetDegraded:
+    async def test_emit_budget_degraded_is_noop(self):
+        from bifrost.adapters.events.null import NullEventEmitter
+
+        emitter = NullEventEmitter()
+        evt = BudgetDegradedEvent(
+            agent_id="a",
+            session_id="s",
+            original_model="claude-opus-4-6",
+            degraded_model="claude-sonnet-4-6",
+            budget_pct_consumed=85.0,
+            daily_limit_usd=10.0,
+            spent_usd=8.5,
+        )
+        # Should not raise
+        await emitter.emit_budget_degraded(evt)

--- a/tests/test_bifrost/test_persona_routing.py
+++ b/tests/test_bifrost/test_persona_routing.py
@@ -193,6 +193,12 @@ class TestYamlRuleEngineAgentIdCondition:
         ctx = RoutingContext(agent_id="anything-at-all")
         assert engine.evaluate(_req(), ctx) is not None
 
+    def test_wildcard_star_does_not_match_empty_agent_id(self):
+        """fnmatch('', '*') is True, but an absent header must never match."""
+        engine = self._engine("*")
+        ctx = RoutingContext(agent_id="")
+        assert engine.evaluate(_req(), ctx) is None
+
     def test_agent_id_combined_with_model_condition(self):
         cfg = _cfg()
         engine = YamlRuleEngine(
@@ -328,6 +334,14 @@ class TestBudgetGuardrailConfigDegradationChain:
             }
         )
         assert cfg.degradation_chain == _CHAIN
+
+    def test_duplicate_in_chain_raises(self):
+        import pytest
+
+        with pytest.raises(Exception, match="duplicate"):
+            BudgetGuardrailConfig(
+                degradation_chain=["claude-opus-4-6", "claude-sonnet-4-6", "claude-opus-4-6"]
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Header-based routing**: `X-Ravn-Agent-Id` header value is now propagated into `RoutingContext.agent_id` and matched against YAML rule conditions using `fnmatch` patterns (e.g. `reviewer*` → Opus, `ship*` → Haiku, `qa*` → Sonnet)
- **Budget degradation chain**: `BudgetGuardrailConfig.degradation_chain` configures an ordered list of models (most capable → cheapest); when a session hits the warn threshold the request model is downgraded to the next cheaper entry in the chain
- **`BudgetDegradedEvent`**: new event type emitted via `CostEventEmitter` on every degradation; registered as `BIFROST_BUDGET_DEGRADED` in the Sleipnir event registry and published by `SleipnirEventEmitter`
- 43 new unit tests in `tests/test_bifrost/test_persona_routing.py` covering rule matching, degradation chain resolution, event emission, and end-to-end `_evaluate_guardrails` behaviour

## Test plan

- [x] All 1004 bifrost tests pass (`uv run pytest tests/test_bifrost/`)
- [x] `ruff check` and `ruff format` clean
- [x] New tests: 43/43 pass
- [x] Existing `test_events.py` mocks updated to implement the new `emit_budget_degraded` abstract method

🤖 Generated with [Claude Code](https://claude.com/claude-code)