### PR TITLE
feat(adapters): add LLM entity detection to mimir_ingest (NIU-578)

### DIFF
--- a/ravn.example.yaml
+++ b/ravn.example.yaml
@@ -131,6 +131,15 @@ trust:
   spending_beyond_cap: approval
 
 # ---------------------------------------------------------------------------
+# Mímir
+# ---------------------------------------------------------------------------
+# mimir:
+#   ingest:
+#     entity_detection: true           # enable LLM entity extraction on ingest
+#     entity_model: claude-haiku-4-5-20251001  # cheap/fast model for extraction
+#     entity_max_tokens: 1024
+
+# ---------------------------------------------------------------------------
 # Memory
 # ---------------------------------------------------------------------------
 # memory:

--- a/src/ravn/adapters/tools/entity_extractor.py
+++ b/src/ravn/adapters/tools/entity_extractor.py
@@ -1,0 +1,343 @@
+"""Entity extractor — LLM-based entity detection during Mímir ingest (NIU-578).
+
+After a raw source is persisted, the extractor calls a cheap LLM to identify
+named entities (people, projects, technologies, etc.) and auto-creates or
+updates compiled-truth entity pages in the wiki.
+
+Confidence gating
+-----------------
+- ``high``   — create new pages and update existing ones
+- ``medium`` — append timeline entry to existing pages only (never create new)
+- ``low``    — log only, no writes
+
+Idempotency
+-----------
+Timeline entries include the ``source_id`` so re-ingesting the same source
+will not add a duplicate entry (the existing entry already cites the source).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+from mimir.compiled_truth import (
+    append_timeline_entry,
+    parse_page,
+    rewrite_compiled_truth,
+)
+from niuu.domain.mimir import EntityType, MimirSource, PageConfidence, slugify
+from niuu.ports.mimir import MimirPort
+from ravn.config import MimirIngestConfig
+from ravn.ports.llm import LLMPort
+
+logger = logging.getLogger(__name__)
+
+_EXTRACTION_SYSTEM = (
+    "You are an entity extraction assistant. "
+    "Extract named entities from the provided text and respond only with valid JSON."
+)
+
+_EXTRACTION_PROMPT = """\
+Extract named entities from the following source document.
+
+Source title: {title}
+Source content (first 3000 chars):
+{content}
+
+Return a JSON object with a single key "entities" containing an array of objects.
+Each object must have:
+  - "name":        string — the canonical entity name
+  - "type":        one of "person", "project", "concept", "technology", "organization", "strategy"
+  - "confidence":  one of "high", "medium", "low"
+  - "key_facts":   array of strings — 2-5 concise facts extracted from the source
+
+Only include entities that are clearly named and meaningfully discussed.
+Respond with valid JSON only, no prose.\
+"""
+
+
+@dataclass
+class ExtractedEntity:
+    """A single entity detected by the LLM extractor."""
+
+    name: str
+    entity_type: EntityType
+    confidence: PageConfidence
+    key_facts: list[str] = field(default_factory=list)
+
+
+class EntityExtractor:
+    """Extracts entities from a MimirSource and applies them to the wiki.
+
+    Args:
+        mimir:  Mímir adapter for reading and writing entity pages.
+        llm:    LLM adapter for the extraction call.
+        config: Ingest configuration (model, max_tokens, enabled flag).
+    """
+
+    def __init__(
+        self,
+        mimir: MimirPort,
+        llm: LLMPort,
+        config: MimirIngestConfig,
+    ) -> None:
+        self._mimir = mimir
+        self._llm = llm
+        self._config = config
+
+    async def run(self, source: MimirSource) -> list[str]:
+        """Extract entities from *source* and upsert entity pages.
+
+        Returns a list of wiki paths that were created or updated.
+        """
+        if not self._config.entity_detection:
+            return []
+
+        entities = await self._extract(source)
+        if not entities:
+            return []
+
+        date_str = datetime.now(UTC).strftime("%Y-%m-%d")
+        updated_paths: list[str] = []
+
+        for entity in entities:
+            try:
+                path = await self._apply(entity, source, date_str)
+                if path:
+                    updated_paths.append(path)
+            except Exception as exc:
+                logger.warning(
+                    "entity_extractor: failed to apply entity %r: %s",
+                    entity.name,
+                    exc,
+                )
+
+        return updated_paths
+
+    # ------------------------------------------------------------------
+    # LLM call
+    # ------------------------------------------------------------------
+
+    async def _extract(self, source: MimirSource) -> list[ExtractedEntity]:
+        """Call the LLM and parse the entity list.  Returns [] on failure."""
+        prompt = _EXTRACTION_PROMPT.format(
+            title=source.title,
+            content=source.content[:3000],
+        )
+        try:
+            response = await self._llm.generate(
+                messages=[{"role": "user", "content": prompt}],
+                tools=[],
+                system=_EXTRACTION_SYSTEM,
+                model=self._config.entity_model,
+                max_tokens=self._config.entity_max_tokens,
+            )
+            raw = json.loads(response.content)
+            return self._parse_entities(raw.get("entities", []))
+        except Exception as exc:
+            logger.warning(
+                "entity_extractor: LLM extraction failed for source %r: %s",
+                source.source_id,
+                exc,
+            )
+            return []
+
+    def _parse_entities(self, raw: list[dict]) -> list[ExtractedEntity]:
+        """Validate and convert the raw LLM response into ExtractedEntity objects."""
+        entities: list[ExtractedEntity] = []
+        for item in raw:
+            try:
+                entity_type = EntityType(item.get("type", ""))
+                confidence = PageConfidence(item.get("confidence", ""))
+                name = str(item.get("name", "")).strip()
+                if not name:
+                    continue
+                key_facts = [str(f) for f in item.get("key_facts", []) if f]
+                entities.append(
+                    ExtractedEntity(
+                        name=name,
+                        entity_type=entity_type,
+                        confidence=confidence,
+                        key_facts=key_facts,
+                    )
+                )
+            except (ValueError, KeyError) as exc:
+                logger.debug("entity_extractor: skipping malformed entity entry: %s", exc)
+        return entities
+
+    # ------------------------------------------------------------------
+    # Page creation / update
+    # ------------------------------------------------------------------
+
+    async def _apply(
+        self,
+        entity: ExtractedEntity,
+        source: MimirSource,
+        date_str: str,
+    ) -> str | None:
+        """Create or update the entity page for *entity*.
+
+        Returns the page path on write, None when the action is skipped (low
+        confidence, or medium confidence with no existing page).
+        """
+        if entity.confidence == PageConfidence.low:
+            logger.debug(
+                "entity_extractor: skipping low-confidence entity %r",
+                entity.name,
+            )
+            return None
+
+        page_path = self._entity_page_path(entity)
+        timeline_entry = self._build_timeline_entry(entity, source, date_str)
+
+        try:
+            existing_content = await self._mimir.read_page(page_path)
+        except FileNotFoundError:
+            existing_content = None
+
+        if existing_content is not None:
+            return await self._update_page(
+                page_path, existing_content, entity, source, timeline_entry
+            )
+
+        if entity.confidence == PageConfidence.medium:
+            logger.debug(
+                "entity_extractor: medium-confidence entity %r has no existing page — skipping",
+                entity.name,
+            )
+            return None
+
+        # high confidence, new page
+        return await self._create_page(page_path, entity, source, timeline_entry)
+
+    async def _create_page(
+        self,
+        page_path: str,
+        entity: ExtractedEntity,
+        source: MimirSource,
+        timeline_entry: str,
+    ) -> str:
+        """Build and write a new compiled-truth entity page."""
+        content = self._build_entity_page(entity, source, timeline_entry)
+        await self._mimir.upsert_page(page_path, content)
+        logger.info(
+            "entity_extractor: created entity page %r for %r",
+            page_path,
+            entity.name,
+        )
+        return page_path
+
+    async def _update_page(
+        self,
+        page_path: str,
+        existing_content: str,
+        entity: ExtractedEntity,
+        source: MimirSource,
+        timeline_entry: str,
+    ) -> str | None:
+        """Merge new facts and append timeline entry to an existing page.
+
+        Returns None if the source is already cited (idempotency guard).
+        """
+        parsed = parse_page(existing_content)
+
+        # Idempotency: don't add a duplicate timeline entry for the same source
+        for entry in parsed.timeline_entries:
+            if source.source_id in entry.source:
+                logger.debug(
+                    "entity_extractor: source %r already cited in %r — skipping",
+                    source.source_id,
+                    page_path,
+                )
+                return None
+
+        # Append timeline entry
+        updated = append_timeline_entry(existing_content, timeline_entry)
+
+        # For high confidence, also merge in new facts into Compiled Truth
+        if entity.confidence == PageConfidence.high and entity.key_facts:
+            updated = self._merge_facts(updated, entity)
+
+        await self._mimir.upsert_page(page_path, updated)
+        logger.info(
+            "entity_extractor: updated entity page %r for %r",
+            page_path,
+            entity.name,
+        )
+        return page_path
+
+    # ------------------------------------------------------------------
+    # Content builders
+    # ------------------------------------------------------------------
+
+    def _entity_page_path(self, entity: ExtractedEntity) -> str:
+        """Return the wiki-relative path for an entity page.
+
+        Format: ``entities/{type}-{slug}.md``
+        """
+        slug = slugify(entity.name)
+        return f"entities/{entity.entity_type}-{slug}.md"
+
+    def _build_timeline_entry(
+        self,
+        entity: ExtractedEntity,
+        source: MimirSource,
+        date_str: str,
+    ) -> str:
+        """Return a single timeline line for this entity/source pair."""
+        return (
+            f"- {date_str}: Detected in source '{source.title}'. "
+            f"[Source: mimir_ingest, {source.source_id}, {date_str}]"
+        )
+
+    def _build_entity_page(
+        self,
+        entity: ExtractedEntity,
+        source: MimirSource,
+        timeline_entry: str,
+    ) -> str:
+        """Return the full Markdown content for a new entity page."""
+        facts_block = (
+            "\n".join(f"- {f}" for f in entity.key_facts)
+            if entity.key_facts
+            else "- (no facts extracted)"
+        )
+
+        return (
+            f"---\n"
+            f"type: entity\n"
+            f"confidence: {entity.confidence}\n"
+            f"entity_type: {entity.entity_type}\n"
+            f"source_ids: [{source.source_id}]\n"
+            f"---\n\n"
+            f"# {entity.name}\n\n"
+            f"## Compiled Truth\n\n"
+            f"### Key Facts\n\n"
+            f"{facts_block}\n\n"
+            f"### Relationships\n\n"
+            f"### Assessment\n\n"
+            f"## Timeline\n\n"
+            f"{timeline_entry}\n"
+        )
+
+    def _merge_facts(self, content: str, entity: ExtractedEntity) -> str:
+        """Merge *entity.key_facts* into the Compiled Truth section.
+
+        New facts are appended under Key Facts; existing content is preserved.
+        """
+        parsed = parse_page(content)
+        existing_truth = parsed.compiled_truth
+
+        new_facts_block = "\n".join(f"- {f}" for f in entity.key_facts)
+
+        if existing_truth.strip():
+            merged_truth = f"{existing_truth.rstrip()}\n{new_facts_block}"
+        else:
+            merged_truth = (
+                f"### Key Facts\n\n{new_facts_block}\n\n### Relationships\n\n### Assessment"
+            )
+
+        return rewrite_compiled_truth(content, merged_truth)

--- a/src/ravn/adapters/tools/mimir_tools.py
+++ b/src/ravn/adapters/tools/mimir_tools.py
@@ -15,6 +15,7 @@ import logging
 from datetime import UTC, datetime
 
 from niuu.domain.mimir import MimirSource, compute_content_hash
+from ravn.adapters.tools.entity_extractor import EntityExtractor
 from ravn.domain.models import ToolResult
 from ravn.ports.mimir import MimirPort
 from ravn.ports.tool import ToolPort
@@ -37,8 +38,13 @@ def _source_id_from_content(title: str, content: str) -> str:
 class MimirIngestTool(ToolPort):
     """Ingest a URL or raw text as a Mímir source document."""
 
-    def __init__(self, adapter: MimirPort) -> None:
+    def __init__(
+        self,
+        adapter: MimirPort,
+        entity_extractor: EntityExtractor | None = None,
+    ) -> None:
         self._adapter = adapter
+        self._entity_extractor = entity_extractor
 
     @property
     def name(self) -> str:
@@ -104,6 +110,11 @@ class MimirIngestTool(ToolPort):
         )
 
         page_paths = await self._adapter.ingest(source)
+
+        if self._entity_extractor is not None:
+            entity_paths = await self._entity_extractor.run(source)
+            page_paths = page_paths + entity_paths
+
         result = f"Ingested source '{title}' (id={source.source_id})"
         if page_paths:
             result += f"\nPages updated: {', '.join(page_paths)}"
@@ -452,10 +463,17 @@ class MimirLintTool(ToolPort):
 # ---------------------------------------------------------------------------
 
 
-def build_mimir_tools(adapter: MimirPort) -> list[ToolPort]:
-    """Return all six Mímir tools wired to *adapter*."""
+def build_mimir_tools(
+    adapter: MimirPort,
+    entity_extractor: EntityExtractor | None = None,
+) -> list[ToolPort]:
+    """Return all six Mímir tools wired to *adapter*.
+
+    When *entity_extractor* is provided it is wired into :class:`MimirIngestTool`
+    so that LLM-based entity detection runs automatically on every ingest.
+    """
     return [
-        MimirIngestTool(adapter),
+        MimirIngestTool(adapter, entity_extractor=entity_extractor),
         MimirQueryTool(adapter),
         MimirReadTool(adapter),
         MimirWriteTool(adapter),

--- a/src/ravn/cli/commands.py
+++ b/src/ravn/cli/commands.py
@@ -430,9 +430,15 @@ def _build_tools(
 
     # -- Mímir tools (injected when adapter is wired and "mimir" group is active) --
     if mimir is not None and "mimir" in include_groups:
+        from ravn.adapters.tools.entity_extractor import EntityExtractor
         from ravn.adapters.tools.mimir_tools import build_mimir_tools
 
-        tools.extend(build_mimir_tools(mimir))
+        entity_extractor = None
+        if settings.mimir.ingest.entity_detection and llm is not None:
+            entity_extractor = EntityExtractor(
+                mimir=mimir, llm=llm, config=settings.mimir.ingest
+            )
+        tools.extend(build_mimir_tools(mimir, entity_extractor=entity_extractor))
 
     # -- Custom tools from config --
     for ct in settings.tools.custom:

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -1419,6 +1419,23 @@ class MimirStalenessTriggerConfig(BaseModel):
     )
 
 
+class MimirIngestConfig(BaseModel):
+    """Configuration for the Mímir ingest entity detection step (NIU-578)."""
+
+    entity_detection: bool = Field(
+        default=True,
+        description="Enable LLM-based entity extraction during ingest.",
+    )
+    entity_model: str = Field(
+        default="claude-haiku-4-5-20251001",
+        description="LLM model alias used for entity extraction (prefer cheap/fast).",
+    )
+    entity_max_tokens: int = Field(
+        default=1024,
+        description="Maximum output tokens for the entity extraction LLM call.",
+    )
+
+
 class MimirConfig(BaseModel):
     """Mímir persistent compounding knowledge base configuration (NIU-540).
 
@@ -1490,6 +1507,10 @@ class MimirConfig(BaseModel):
     staleness_trigger: MimirStalenessTriggerConfig = Field(
         default_factory=MimirStalenessTriggerConfig,
         description="Scheduled staleness refresh for frequently-used pages.",
+    )
+    ingest: MimirIngestConfig = Field(
+        default_factory=lambda: MimirIngestConfig(),
+        description="Entity detection settings for ingest.",
     )
 
 

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -1509,7 +1509,7 @@ class MimirConfig(BaseModel):
         description="Scheduled staleness refresh for frequently-used pages.",
     )
     ingest: MimirIngestConfig = Field(
-        default_factory=lambda: MimirIngestConfig(),
+        default_factory=MimirIngestConfig,
         description="Entity detection settings for ingest.",
     )
 

--- a/tests/test_ravn/test_entity_extractor.py
+++ b/tests/test_ravn/test_entity_extractor.py
@@ -1,0 +1,618 @@
+"""Unit tests for EntityExtractor (NIU-578).
+
+Uses mocked LLMPort and MimirPort — no real filesystem or network calls.
+
+Covers:
+- Entity extraction returns entities from LLM JSON response
+- High confidence entities create new pages
+- Medium confidence entities only update existing pages, not create new
+- Low confidence entities are logged only (no writes)
+- Re-ingesting same source skips duplicate timeline entries (idempotency)
+- LLM failure returns empty list and does not crash
+- entity_detection=False disables all writes
+- MimirIngestTool wires EntityExtractor and reports created paths
+- build_mimir_tools accepts optional entity_extractor
+- MimirIngestConfig defaults
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from niuu.domain.mimir import EntityType, MimirSource, PageConfidence
+from ravn.adapters.tools.entity_extractor import EntityExtractor, ExtractedEntity
+from ravn.adapters.tools.mimir_tools import MimirIngestTool, build_mimir_tools
+from ravn.config import MimirIngestConfig
+from ravn.domain.models import LLMResponse, StopReason, TokenUsage
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _pg_entity(confidence: str = "high", key_facts: list | None = None) -> dict:
+    return {
+        "name": "PostgreSQL",
+        "type": "technology",
+        "confidence": confidence,
+        "key_facts": key_facts or [],
+    }
+
+
+def _config(
+    entity_detection: bool = True,
+    entity_model: str = "claude-haiku-4-5-20251001",
+    entity_max_tokens: int = 1024,
+) -> MimirIngestConfig:
+    return MimirIngestConfig(
+        entity_detection=entity_detection,
+        entity_model=entity_model,
+        entity_max_tokens=entity_max_tokens,
+    )
+
+
+def _source(
+    source_id: str = "src_abc123",
+    title: str = "PostgreSQL vs MongoDB",
+    content: str = "PostgreSQL is a relational database. MongoDB is a document database.",
+) -> MimirSource:
+    return MimirSource(
+        source_id=source_id,
+        title=title,
+        content=content,
+        source_type="document",
+        content_hash="deadbeef",
+        ingested_at=datetime(2026, 4, 12, tzinfo=UTC),
+    )
+
+
+def _llm_response(entities: list[dict]) -> LLMResponse:
+    payload = json.dumps({"entities": entities})
+    return LLMResponse(
+        content=payload,
+        tool_calls=[],
+        stop_reason=StopReason.END_TURN,
+        usage=TokenUsage(input_tokens=100, output_tokens=200),
+    )
+
+
+def _make_extractor(
+    mimir: object | None = None,
+    llm: object | None = None,
+    config: MimirIngestConfig | None = None,
+) -> EntityExtractor:
+    if mimir is None:
+        mimir = AsyncMock()
+        mimir.read_page = AsyncMock(side_effect=FileNotFoundError("not found"))
+        mimir.upsert_page = AsyncMock()
+    if llm is None:
+        llm = AsyncMock()
+        llm.generate = AsyncMock(return_value=_llm_response([]))
+    if config is None:
+        config = _config()
+    return EntityExtractor(mimir=mimir, llm=llm, config=config)
+
+
+# ---------------------------------------------------------------------------
+# MimirIngestConfig defaults
+# ---------------------------------------------------------------------------
+
+
+class TestMimirIngestConfig:
+    def test_defaults(self) -> None:
+        cfg = MimirIngestConfig()
+        assert cfg.entity_detection is True
+        assert cfg.entity_model == "claude-haiku-4-5-20251001"
+        assert cfg.entity_max_tokens == 1024
+
+    def test_disabled(self) -> None:
+        cfg = MimirIngestConfig(entity_detection=False)
+        assert cfg.entity_detection is False
+
+
+# ---------------------------------------------------------------------------
+# EntityExtractor._extract
+# ---------------------------------------------------------------------------
+
+
+class TestExtractEntities:
+    @pytest.mark.asyncio
+    async def test_parses_valid_response(self) -> None:
+        llm = AsyncMock()
+        llm.generate = AsyncMock(
+            return_value=_llm_response(
+                [
+                    {
+                        "name": "PostgreSQL",
+                        "type": "technology",
+                        "confidence": "high",
+                        "key_facts": ["Relational DB", "Uses SQL"],
+                    },
+                    {
+                        "name": "MongoDB",
+                        "type": "technology",
+                        "confidence": "medium",
+                        "key_facts": ["Document DB"],
+                    },
+                ]
+            )
+        )
+        extractor = _make_extractor(llm=llm)
+        source = _source()
+        entities = await extractor._extract(source)
+
+        assert len(entities) == 2
+        assert entities[0].name == "PostgreSQL"
+        assert entities[0].entity_type == EntityType.technology
+        assert entities[0].confidence == PageConfidence.high
+        assert entities[0].key_facts == ["Relational DB", "Uses SQL"]
+        assert entities[1].name == "MongoDB"
+        assert entities[1].confidence == PageConfidence.medium
+
+    @pytest.mark.asyncio
+    async def test_llm_json_error_returns_empty(self) -> None:
+        llm = AsyncMock()
+        bad_response = LLMResponse(
+            content="not valid json {{{",
+            tool_calls=[],
+            stop_reason=StopReason.END_TURN,
+            usage=TokenUsage(input_tokens=10, output_tokens=5),
+        )
+        llm.generate = AsyncMock(return_value=bad_response)
+        extractor = _make_extractor(llm=llm)
+        entities = await extractor._extract(_source())
+        assert entities == []
+
+    @pytest.mark.asyncio
+    async def test_llm_exception_returns_empty(self) -> None:
+        llm = AsyncMock()
+        llm.generate = AsyncMock(side_effect=RuntimeError("network error"))
+        extractor = _make_extractor(llm=llm)
+        entities = await extractor._extract(_source())
+        assert entities == []
+
+    @pytest.mark.asyncio
+    async def test_skips_malformed_entity(self) -> None:
+        llm = AsyncMock()
+        llm.generate = AsyncMock(
+            return_value=_llm_response(
+                [
+                    {"name": "Valid", "type": "technology", "confidence": "high", "key_facts": []},
+                    {"name": "Bad", "type": "INVALID_TYPE", "confidence": "high", "key_facts": []},
+                ]
+            )
+        )
+        extractor = _make_extractor(llm=llm)
+        entities = await extractor._extract(_source())
+        assert len(entities) == 1
+        assert entities[0].name == "Valid"
+
+    @pytest.mark.asyncio
+    async def test_skips_empty_name(self) -> None:
+        llm = AsyncMock()
+        llm.generate = AsyncMock(
+            return_value=_llm_response(
+                [{"name": "  ", "type": "technology", "confidence": "high", "key_facts": []}]
+            )
+        )
+        extractor = _make_extractor(llm=llm)
+        entities = await extractor._extract(_source())
+        assert entities == []
+
+
+# ---------------------------------------------------------------------------
+# EntityExtractor.run — confidence gating
+# ---------------------------------------------------------------------------
+
+
+class TestConfidenceGating:
+    @pytest.mark.asyncio
+    async def test_high_confidence_creates_new_page(self) -> None:
+        mimir = AsyncMock()
+        mimir.read_page = AsyncMock(side_effect=FileNotFoundError())
+        mimir.upsert_page = AsyncMock()
+
+        llm = AsyncMock()
+        llm.generate = AsyncMock(
+            return_value=_llm_response(
+                [_pg_entity()]
+            )
+        )
+        extractor = _make_extractor(mimir=mimir, llm=llm)
+        paths = await extractor.run(_source())
+
+        assert paths == ["entities/technology-postgresql.md"]
+        mimir.upsert_page.assert_awaited_once()
+        call_path = mimir.upsert_page.call_args[0][0]
+        assert call_path == "entities/technology-postgresql.md"
+
+    @pytest.mark.asyncio
+    async def test_medium_confidence_no_existing_page_skipped(self) -> None:
+        mimir = AsyncMock()
+        mimir.read_page = AsyncMock(side_effect=FileNotFoundError())
+        mimir.upsert_page = AsyncMock()
+
+        llm = AsyncMock()
+        llm.generate = AsyncMock(
+            return_value=_llm_response(
+                [_pg_entity("medium")]
+            )
+        )
+        extractor = _make_extractor(mimir=mimir, llm=llm)
+        paths = await extractor.run(_source())
+
+        assert paths == []
+        mimir.upsert_page.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_medium_confidence_updates_existing_page(self) -> None:
+        existing_content = (
+            "---\ntype: entity\nconfidence: high\nentity_type: technology\n"
+            "source_ids: [src_old]\n---\n\n# PostgreSQL\n\n"
+            "## Compiled Truth\n\n### Key Facts\n\n- Old fact\n\n"
+            "## Timeline\n\n- 2026-01-01: Old entry. [Source: mimir_ingest, src_old, 2026-01-01]\n"
+        )
+        mimir = AsyncMock()
+        mimir.read_page = AsyncMock(return_value=existing_content)
+        mimir.upsert_page = AsyncMock()
+
+        llm = AsyncMock()
+        llm.generate = AsyncMock(
+            return_value=_llm_response(
+                [_pg_entity("medium")]
+            )
+        )
+        extractor = _make_extractor(mimir=mimir, llm=llm)
+        paths = await extractor.run(_source())
+
+        assert paths == ["entities/technology-postgresql.md"]
+        mimir.upsert_page.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_low_confidence_never_writes(self) -> None:
+        mimir = AsyncMock()
+        mimir.read_page = AsyncMock(side_effect=FileNotFoundError())
+        mimir.upsert_page = AsyncMock()
+
+        llm = AsyncMock()
+        llm.generate = AsyncMock(
+            return_value=_llm_response(
+                [{"name": "PostgreSQL", "type": "technology", "confidence": "low", "key_facts": []}]
+            )
+        )
+        extractor = _make_extractor(mimir=mimir, llm=llm)
+        paths = await extractor.run(_source())
+
+        assert paths == []
+        mimir.upsert_page.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_low_confidence_ignores_existing_page(self) -> None:
+        existing = "# Some content\n\n## Timeline\n\n- 2026-01-01: Entry. [Source: x, y, z]\n"
+        mimir = AsyncMock()
+        mimir.read_page = AsyncMock(return_value=existing)
+        mimir.upsert_page = AsyncMock()
+
+        llm = AsyncMock()
+        llm.generate = AsyncMock(
+            return_value=_llm_response(
+                [{"name": "PostgreSQL", "type": "technology", "confidence": "low", "key_facts": []}]
+            )
+        )
+        extractor = _make_extractor(mimir=mimir, llm=llm)
+        paths = await extractor.run(_source())
+
+        assert paths == []
+        mimir.upsert_page.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotency:
+    @pytest.mark.asyncio
+    async def test_same_source_no_duplicate_entry(self) -> None:
+        source = _source(source_id="src_abc123")
+        existing_content = (
+            "---\ntype: entity\nconfidence: high\nentity_type: technology\n"
+            "source_ids: [src_abc123]\n---\n\n# PostgreSQL\n\n"
+            "## Compiled Truth\n\n### Key Facts\n\n- A fact\n\n"
+            "## Timeline\n\n"
+            "- 2026-04-12: Detected in source 'PostgreSQL vs MongoDB'. "
+            "[Source: mimir_ingest, src_abc123, 2026-04-12]\n"
+        )
+        mimir = AsyncMock()
+        mimir.read_page = AsyncMock(return_value=existing_content)
+        mimir.upsert_page = AsyncMock()
+
+        llm = AsyncMock()
+        llm.generate = AsyncMock(
+            return_value=_llm_response(
+                [_pg_entity()]
+            )
+        )
+        extractor = _make_extractor(mimir=mimir, llm=llm)
+        paths = await extractor.run(source)
+
+        assert paths == []
+        mimir.upsert_page.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_different_source_does_append(self) -> None:
+        source = _source(source_id="src_new456")
+        existing_content = (
+            "---\ntype: entity\nconfidence: high\nentity_type: technology\n"
+            "source_ids: [src_abc123]\n---\n\n# PostgreSQL\n\n"
+            "## Compiled Truth\n\n### Key Facts\n\n- A fact\n\n"
+            "## Timeline\n\n"
+            "- 2026-01-01: Old entry. [Source: mimir_ingest, src_abc123, 2026-01-01]\n"
+        )
+        mimir = AsyncMock()
+        mimir.read_page = AsyncMock(return_value=existing_content)
+        mimir.upsert_page = AsyncMock()
+
+        llm = AsyncMock()
+        llm.generate = AsyncMock(
+            return_value=_llm_response(
+                [_pg_entity()]
+            )
+        )
+        extractor = _make_extractor(mimir=mimir, llm=llm)
+        paths = await extractor.run(source)
+
+        assert paths == ["entities/technology-postgresql.md"]
+        mimir.upsert_page.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# entity_detection disabled
+# ---------------------------------------------------------------------------
+
+
+class TestDetectionDisabled:
+    @pytest.mark.asyncio
+    async def test_disabled_config_no_llm_call(self) -> None:
+        mimir = AsyncMock()
+        llm = AsyncMock()
+        llm.generate = AsyncMock()
+        extractor = EntityExtractor(mimir=mimir, llm=llm, config=_config(entity_detection=False))
+        paths = await extractor.run(_source())
+
+        assert paths == []
+        llm.generate.assert_not_awaited()
+        mimir.upsert_page.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Page content format
+# ---------------------------------------------------------------------------
+
+
+class TestPageContent:
+    @pytest.mark.asyncio
+    async def test_new_page_has_compiled_truth_and_timeline(self) -> None:
+        mimir = AsyncMock()
+        mimir.read_page = AsyncMock(side_effect=FileNotFoundError())
+        mimir.upsert_page = AsyncMock()
+
+        llm = AsyncMock()
+        llm.generate = AsyncMock(
+            return_value=_llm_response(
+                [
+                    {
+                        "name": "PostgreSQL",
+                        "type": "technology",
+                        "confidence": "high",
+                        "key_facts": ["Relational DB", "Uses SQL"],
+                    }
+                ]
+            )
+        )
+        extractor = _make_extractor(mimir=mimir, llm=llm)
+        await extractor.run(_source())
+
+        written_content = mimir.upsert_page.call_args[0][1]
+        assert "## Compiled Truth" in written_content
+        assert "## Timeline" in written_content
+        assert "Relational DB" in written_content
+        assert "Uses SQL" in written_content
+        assert "[Source: mimir_ingest, src_abc123," in written_content
+        assert "type: entity" in written_content
+        assert "entity_type: technology" in written_content
+
+    @pytest.mark.asyncio
+    async def test_timeline_entry_cites_source_id(self) -> None:
+        mimir = AsyncMock()
+        mimir.read_page = AsyncMock(side_effect=FileNotFoundError())
+        mimir.upsert_page = AsyncMock()
+
+        llm = AsyncMock()
+        llm.generate = AsyncMock(
+            return_value=_llm_response(
+                [{"name": "MongoDB", "type": "technology", "confidence": "high", "key_facts": []}]
+            )
+        )
+        extractor = _make_extractor(mimir=mimir, llm=llm)
+        source = _source(source_id="src_mongo99")
+        await extractor.run(source)
+
+        written_content = mimir.upsert_page.call_args[0][1]
+        assert "src_mongo99" in written_content
+
+    def test_entity_page_path_format(self) -> None:
+        extractor = _make_extractor()
+        entity = ExtractedEntity(
+            name="PostgreSQL",
+            entity_type=EntityType.technology,
+            confidence=PageConfidence.high,
+            key_facts=[],
+        )
+        path = extractor._entity_page_path(entity)
+        assert path == "entities/technology-postgresql.md"
+
+    def test_entity_page_path_person(self) -> None:
+        extractor = _make_extractor()
+        entity = ExtractedEntity(
+            name="Andrej Karpathy",
+            entity_type=EntityType.person,
+            confidence=PageConfidence.high,
+            key_facts=[],
+        )
+        path = extractor._entity_page_path(entity)
+        assert path == "entities/person-andrej-karpathy.md"
+
+
+# ---------------------------------------------------------------------------
+# MimirIngestTool integration
+# ---------------------------------------------------------------------------
+
+
+class TestMimirIngestToolWithExtractor:
+    @pytest.mark.asyncio
+    async def test_ingest_reports_entity_pages(self) -> None:
+        adapter = AsyncMock()
+        adapter.ingest = AsyncMock(return_value=[])
+
+        mimir = AsyncMock()
+        mimir.read_page = AsyncMock(side_effect=FileNotFoundError())
+        mimir.upsert_page = AsyncMock()
+
+        llm = AsyncMock()
+        llm.generate = AsyncMock(
+            return_value=_llm_response(
+                [
+                    {
+                        "name": "PostgreSQL",
+                        "type": "technology",
+                        "confidence": "high",
+                        "key_facts": [],
+                    },
+                    {
+                        "name": "MongoDB",
+                        "type": "technology",
+                        "confidence": "high",
+                        "key_facts": [],
+                    },
+                ]
+            )
+        )
+        extractor = EntityExtractor(mimir=mimir, llm=llm, config=_config())
+        tool = MimirIngestTool(adapter=adapter, entity_extractor=extractor)
+
+        result = await tool.execute(
+            {
+                "content": "PostgreSQL vs MongoDB comparison.",
+                "title": "DB Comparison",
+                "source_type": "document",
+            }
+        )
+
+        assert not result.is_error
+        assert "entities/technology-postgresql.md" in result.content
+        assert "entities/technology-mongodb.md" in result.content
+
+    @pytest.mark.asyncio
+    async def test_ingest_without_extractor_returns_base_result(self) -> None:
+        adapter = AsyncMock()
+        adapter.ingest = AsyncMock(return_value=[])
+        tool = MimirIngestTool(adapter=adapter)
+
+        result = await tool.execute(
+            {"content": "Some content", "title": "Some Title", "source_type": "document"}
+        )
+
+        assert not result.is_error
+        assert "Ingested source" in result.content
+
+    @pytest.mark.asyncio
+    async def test_extractor_failure_does_not_crash_ingest(self) -> None:
+        adapter = AsyncMock()
+        adapter.ingest = AsyncMock(return_value=[])
+
+        mimir = AsyncMock()
+        mimir.read_page = AsyncMock(side_effect=FileNotFoundError())
+        mimir.upsert_page = AsyncMock(side_effect=RuntimeError("disk full"))
+
+        llm = AsyncMock()
+        llm.generate = AsyncMock(
+            return_value=_llm_response(
+                [_pg_entity()]
+            )
+        )
+        extractor = EntityExtractor(mimir=mimir, llm=llm, config=_config())
+        tool = MimirIngestTool(adapter=adapter, entity_extractor=extractor)
+
+        result = await tool.execute(
+            {"content": "Some content", "title": "Some Title"}
+        )
+
+        assert not result.is_error
+        assert "Ingested source" in result.content
+
+
+# ---------------------------------------------------------------------------
+# build_mimir_tools
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMimirTools:
+    def test_build_without_extractor(self) -> None:
+        adapter = MagicMock()
+        tools = build_mimir_tools(adapter)
+        assert len(tools) == 6
+        ingest_tool = tools[0]
+        assert isinstance(ingest_tool, MimirIngestTool)
+        assert ingest_tool._entity_extractor is None
+
+    def test_build_with_extractor(self) -> None:
+        adapter = MagicMock()
+        extractor = MagicMock(spec=EntityExtractor)
+        tools = build_mimir_tools(adapter, entity_extractor=extractor)
+        ingest_tool = tools[0]
+        assert isinstance(ingest_tool, MimirIngestTool)
+        assert ingest_tool._entity_extractor is extractor
+
+
+# ---------------------------------------------------------------------------
+# High confidence page updates existing with merged facts
+# ---------------------------------------------------------------------------
+
+
+class TestHighConfidenceMergesFacts:
+    @pytest.mark.asyncio
+    async def test_high_confidence_merges_facts_into_existing(self) -> None:
+        existing_content = (
+            "---\ntype: entity\nconfidence: high\nentity_type: technology\n"
+            "source_ids: [src_old]\n---\n\n# PostgreSQL\n\n"
+            "## Compiled Truth\n\n### Key Facts\n\n- Old fact\n\n"
+            "## Timeline\n\n- 2026-01-01: Old entry. [Source: mimir_ingest, src_old, 2026-01-01]\n"
+        )
+        mimir = AsyncMock()
+        mimir.read_page = AsyncMock(return_value=existing_content)
+        mimir.upsert_page = AsyncMock()
+
+        llm = AsyncMock()
+        llm.generate = AsyncMock(
+            return_value=_llm_response(
+                [
+                    {
+                        "name": "PostgreSQL",
+                        "type": "technology",
+                        "confidence": "high",
+                        "key_facts": ["New fact A", "New fact B"],
+                    }
+                ]
+            )
+        )
+        extractor = _make_extractor(mimir=mimir, llm=llm)
+        await extractor.run(_source(source_id="src_new"))
+
+        written = mimir.upsert_page.call_args[0][1]
+        assert "New fact A" in written
+        assert "New fact B" in written


### PR DESCRIPTION
## Summary

- Adds `EntityExtractor` class (`src/ravn/adapters/tools/entity_extractor.py`) that calls a cheap LLM (default: `claude-haiku-4-5-20251001`) to extract named entities from ingested sources
- Wires `EntityExtractor` into `MimirIngestTool` via an optional constructor parameter; `build_mimir_tools` accepts the extractor too
- Entity pages created at `wiki/entities/{type}-{slug}.md` in compiled-truth format (`## Compiled Truth` + `## Timeline`)
- Confidence gating: `high` → create + update, `medium` → update existing only, `low` → log only
- Idempotency: timeline entries are skipped if the source_id is already cited
- New `MimirIngestConfig` added to `MimirConfig` with `entity_detection` (default `true`) and `entity_model` fields

## Test plan

- [x] 25 unit tests covering entity extraction, confidence gating, idempotency, page content format, and tool integration
- [x] 97% coverage on `entity_extractor.py`
- [x] Existing mimir tests (84 tests) still pass
- [x] `ruff check` passes clean

## Linear

Closes NIU-578

> Note: Linear MCP server tools were not available in this session — ticket status updates (In Progress / In Review) could not be performed automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)