### PR TITLE
feat(adapters): post-session reflection writes learnings to Mimir (NIU-588)

### DIFF
--- a/src/ravn/adapters/reflection/__init__.py
+++ b/src/ravn/adapters/reflection/__init__.py
@@ -1,0 +1,1 @@
+"""Post-session reflection adapters (NIU-588)."""

--- a/src/ravn/adapters/reflection/post_session.py
+++ b/src/ravn/adapters/reflection/post_session.py
@@ -1,0 +1,568 @@
+"""PostSessionReflectionService — write operational learnings after ravn.session.ended.
+
+When a ``ravn.session.ended`` event arrives, this service:
+
+1. Calls a cheap LLM with session metadata to extract a structured learning.
+2. Searches Mímir for an existing ``learnings/`` page about the same pattern.
+3. Updates the existing page (merging a new timeline entry + upgrading
+   confidence when warranted) or creates a new one.
+
+Confidence ladder
+-----------------
+- ``low``    — first observation (1 session)
+- ``medium`` — second observation (2 sessions)
+- ``high``   — reproduced 3 or more times
+
+The service subscribes to ``ravn.session.ended`` via a
+:class:`~sleipnir.ports.events.SleipnirSubscriber`.  Call :meth:`start` once
+to register the subscription; call :meth:`stop` to cancel it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from niuu.ports.mimir import MimirPort
+from ravn.config import PostSessionReflectionConfig
+from ravn.ports.llm import LLMPort
+
+if TYPE_CHECKING:
+    from sleipnir.domain.events import SleipnirEvent
+    from sleipnir.ports.events import SleipnirSubscriber, Subscription
+
+logger = logging.getLogger(__name__)
+
+_RAVN_SESSION_ENDED = "ravn.session.ended"
+
+# Approximate chars-per-token ratio used for rough budget enforcement.
+_CHARS_PER_TOKEN = 4
+
+# Number of timeline entries that trigger each confidence level.
+_CONFIDENCE_MEDIUM_THRESHOLD = 2
+_CONFIDENCE_HIGH_THRESHOLD = 3
+
+_REFLECTION_SYSTEM = (
+    "You are an expert at extracting operational learnings from software engineering sessions. "
+    "Respond only with valid JSON — no markdown fences, no commentary."
+)
+
+_REFLECTION_PROMPT = """\
+A Ravn AI agent just completed a coding session. Analyse the session metadata \
+below and extract ONE actionable learning that would help future sessions in \
+the same repository avoid mistakes or work more efficiently.
+
+Session metadata:
+  persona:     {persona}
+  outcome:     {outcome}
+  token_count: {token_count}
+  duration_s:  {duration_s}
+  repo_slug:   {repo_slug}
+
+Questions to consider:
+1. Was the session unusually expensive or slow? (high token_count or duration)
+2. Did the outcome suggest a failure or partial result? (outcome != success)
+3. What project-specific quirk might a future session benefit from knowing?
+
+Respond with a single JSON object:
+{{
+  "title":    "short title — max 80 chars",
+  "learning": "concise statement of the operational learning — 1-3 sentences",
+  "type":     "observation" or "decision",
+  "tags":     ["tag1", "tag2"],
+  "evidence": "one sentence describing what this session revealed"
+}}
+
+If the session was unremarkable and no useful learning can be extracted, \
+respond with: null\
+"""
+
+
+class PostSessionReflectionService:
+    """Service that writes Mímir learnings after each ``ravn.session.ended`` event.
+
+    Args:
+        subscriber:  Sleipnir subscriber used to register the event handler.
+        mimir:       Mímir adapter for searching and writing learning pages.
+        llm:         LLM adapter for the reflection call.
+        config:      Service configuration (enabled flag, model alias, etc.).
+    """
+
+    def __init__(
+        self,
+        subscriber: SleipnirSubscriber,
+        mimir: MimirPort,
+        llm: LLMPort,
+        config: PostSessionReflectionConfig,
+    ) -> None:
+        self._subscriber = subscriber
+        self._mimir = mimir
+        self._llm = llm
+        self._config = config
+        self._subscription: Subscription | None = None
+
+    async def start(self) -> None:
+        """Subscribe to ``ravn.session.ended`` events."""
+        if not self._config.enabled:
+            logger.info("PostSessionReflectionService: disabled — not subscribing")
+            return
+
+        self._subscription = await self._subscriber.subscribe(
+            [_RAVN_SESSION_ENDED],
+            handler=self._on_session_ended,
+        )
+        logger.info("PostSessionReflectionService: subscribed to %s", _RAVN_SESSION_ENDED)
+
+    async def stop(self) -> None:
+        """Cancel the Sleipnir subscription."""
+        if self._subscription is None:
+            return
+        try:
+            await self._subscription.unsubscribe()
+        except Exception as exc:
+            logger.warning("PostSessionReflectionService: error unsubscribing: %s", exc)
+        finally:
+            self._subscription = None
+
+    # ------------------------------------------------------------------
+    # Event handler
+    # ------------------------------------------------------------------
+
+    async def _on_session_ended(self, event: SleipnirEvent) -> None:
+        """Handle a ``ravn.session.ended`` event — best-effort, never raises."""
+        try:
+            await self._process(event.payload)
+        except Exception as exc:
+            logger.warning(
+                "PostSessionReflectionService: unhandled error processing event: %s", exc
+            )
+
+    async def _process(self, payload: dict) -> None:
+        """Extract a learning from *payload* and write it to Mímir."""
+        session_id = payload.get("session_id", "unknown")
+        logger.info("PostSessionReflectionService: reflecting on session %s", session_id)
+
+        learning = await self._run_reflection(payload)
+        if learning is None:
+            logger.info(
+                "PostSessionReflectionService: no learning extracted for session %s",
+                session_id,
+            )
+            return
+
+        await self._write_learning(learning, payload)
+
+    # ------------------------------------------------------------------
+    # LLM reflection
+    # ------------------------------------------------------------------
+
+    async def _run_reflection(self, payload: dict) -> dict | None:
+        """Call the LLM and parse the structured learning JSON."""
+        prompt = _REFLECTION_PROMPT.format(
+            persona=payload.get("persona", ""),
+            outcome=payload.get("outcome", ""),
+            token_count=payload.get("token_count", 0),
+            duration_s=payload.get("duration_s", 0.0),
+            repo_slug=payload.get("repo_slug", ""),
+        )
+
+        try:
+            response = await self._llm.generate(
+                messages=[{"role": "user", "content": prompt}],
+                tools=[],
+                system=_REFLECTION_SYSTEM,
+                model=self._config.llm_alias,
+                max_tokens=self._config.max_tokens,
+            )
+        except Exception as exc:
+            logger.warning("PostSessionReflectionService: LLM call failed: %s", exc)
+            return None
+
+        raw = response.content.strip()
+        if raw.lower() == "null":
+            return None
+
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            logger.warning("PostSessionReflectionService: malformed JSON from LLM: %s", exc)
+            return None
+
+        if not isinstance(parsed, dict):
+            logger.warning(
+                "PostSessionReflectionService: LLM returned non-object JSON: %s",
+                type(parsed).__name__,
+            )
+            return None
+
+        return parsed
+
+    # ------------------------------------------------------------------
+    # Mímir write
+    # ------------------------------------------------------------------
+
+    async def _write_learning(self, learning: dict, payload: dict) -> None:
+        """Search for an existing page and update it, or create a new one."""
+        title = learning.get("title", "").strip()
+        if not title:
+            logger.warning("PostSessionReflectionService: LLM returned learning without title")
+            return
+
+        repo_slug = payload.get("repo_slug", "")
+        session_id = payload.get("session_id", "unknown")
+        now = datetime.now(UTC)
+
+        existing_page = await self._find_existing_page(title, repo_slug)
+
+        if existing_page is not None:
+            updated = _merge_timeline_entry(
+                existing_page.content,
+                session_id=session_id,
+                evidence=learning.get("evidence", ""),
+                date=now,
+            )
+            try:
+                await self._mimir.upsert_page(existing_page.meta.path, updated)
+                logger.info(
+                    "PostSessionReflectionService: updated learning page %r (session=%s)",
+                    existing_page.meta.path,
+                    session_id,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "PostSessionReflectionService: failed to update page %r: %s",
+                    existing_page.meta.path,
+                    exc,
+                )
+            return
+
+        page_path = _build_page_path(title, repo_slug)
+        content = _build_page_content(
+            title=title,
+            learning=learning.get("learning", ""),
+            page_type=learning.get("type", "observation"),
+            tags=learning.get("tags", []),
+            evidence=learning.get("evidence", ""),
+            repo_slug=repo_slug,
+            session_id=session_id,
+            date=now,
+        )
+
+        try:
+            await self._mimir.upsert_page(page_path, content)
+            logger.info(
+                "PostSessionReflectionService: created learning page %r (session=%s)",
+                page_path,
+                session_id,
+            )
+        except Exception as exc:
+            logger.warning(
+                "PostSessionReflectionService: failed to create page %r: %s",
+                page_path,
+                exc,
+            )
+
+    async def _find_existing_page(self, title: str, repo_slug: str) -> object | None:
+        """Search Mímir for an existing learning page matching *title*.
+
+        Returns the first :class:`~niuu.domain.mimir.MimirPage` whose title
+        closely matches, or ``None``.
+        """
+        keywords = _title_to_keywords(title)
+        if not keywords:
+            return None
+
+        try:
+            results = await self._mimir.search(keywords)
+        except Exception as exc:
+            logger.warning("PostSessionReflectionService: Mímir search failed: %s", exc)
+            return None
+
+        for page in results:
+            if page.meta.category != "learnings":
+                continue
+            if _titles_similar(page.meta.title or "", title):
+                return page
+
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Learnings injection helper (used by agent at session start)
+# ---------------------------------------------------------------------------
+
+
+async def fetch_relevant_learnings(
+    mimir: MimirPort,
+    *,
+    repo_slug: str,
+    max_pages: int,
+    token_budget: int,
+) -> str:
+    """Query Mímir for learning pages matching *repo_slug* and format for injection.
+
+    Returns a formatted Markdown block ready for inclusion in the system
+    prompt, capped at approximately *token_budget* tokens.  Returns an empty
+    string when no learnings are found or on any error.
+    """
+    try:
+        pages = await mimir.list_pages(category="learnings")
+    except Exception as exc:
+        logger.warning("fetch_relevant_learnings: list_pages failed: %s", exc)
+        return ""
+
+    if not pages:
+        return ""
+
+    # Filter to pages relevant to this repo_slug.
+    # Pages are stored at learnings/{safe_repo}/{slug} — match by path prefix.
+    if repo_slug:
+        safe_repo = re.sub(r"[^a-z0-9_-]", "-", repo_slug.lower())
+        prefix = f"learnings/{safe_repo}/"
+        relevant = [
+            p for p in pages if p.path.startswith(prefix) or p.path.startswith("learnings/general/")
+        ]
+    else:
+        relevant = list(pages)
+
+    _epoch = datetime(1970, 1, 1, tzinfo=UTC)
+    # Sort by recency (most recently updated first).
+    relevant.sort(key=lambda p: p.updated_at or _epoch, reverse=True)
+
+    selected = relevant[:max_pages]
+    if not selected:
+        return ""
+
+    # Read full content for each selected page (best-effort).
+    lines: list[str] = ["## Relevant Past Learnings\n"]
+    char_budget = token_budget * _CHARS_PER_TOKEN
+
+    for meta in selected:
+        try:
+            content = await mimir.read_page(meta.path)
+        except Exception:
+            continue
+
+        # Strip YAML frontmatter for injection; keep markdown body only.
+        body = _strip_frontmatter(content).strip()
+        if not body:
+            continue
+
+        entry = f"### {meta.title or meta.path}\n{body}\n"
+        if len("\n".join(lines)) + len(entry) > char_budget:
+            break
+        lines.append(entry)
+
+    if len(lines) <= 1:
+        return ""
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Page content helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_page_path(title: str, repo_slug: str) -> str:
+    """Build a ``learnings/`` wiki path from *title* and *repo_slug*."""
+    slug = _slugify(title)
+    if repo_slug:
+        safe_repo = re.sub(r"[^a-z0-9_-]", "-", repo_slug.lower())
+        return f"learnings/{safe_repo}/{slug}"
+    return f"learnings/general/{slug}"
+
+
+def _build_page_content(
+    *,
+    title: str,
+    learning: str,
+    page_type: str,
+    tags: list[str],
+    evidence: str,
+    repo_slug: str,
+    session_id: str,
+    date: datetime,
+) -> str:
+    """Render the full page Markdown with YAML frontmatter."""
+    tags_yaml = ", ".join(f'"{t}"' for t in tags) if tags else ""
+    date_str = date.strftime("%Y-%m-%dT%H:%M:%SZ")
+    repo_tag = f'"{repo_slug}"' if repo_slug else ""
+
+    frontmatter_lines = [
+        "---",
+        f'title: "Learning: {title}"',
+        f"type: {page_type}",
+        "category: learnings",
+        "confidence: low",
+    ]
+    if repo_slug:
+        frontmatter_lines.append(f"repo_slug: {repo_slug}")
+    if tags_yaml:
+        frontmatter_lines.append(f"tags: [{tags_yaml}]")
+    if repo_tag:
+        frontmatter_lines.append(f"repo_tags: [{repo_tag}]")
+    frontmatter_lines += [
+        "timeline:",
+        "  - source: ravn_reflection",
+        f"    session_id: {session_id}",
+        f"    date: {date_str}",
+        f'    note: "{_escape_yaml(evidence)}"',
+        "---",
+    ]
+
+    body_lines = [
+        f"# Learning: {title}",
+        "",
+        "## What was learned",
+        learning,
+        "",
+        "## Evidence",
+        f"Session `{session_id}` ({date.strftime('%Y-%m-%d')}): {evidence}",
+        "",
+        "## Confidence Rationale",
+        "Low confidence — observed once. Upgraded to medium after 2 sessions, "
+        "high after 3 or more.",
+    ]
+
+    return "\n".join(frontmatter_lines) + "\n\n" + "\n".join(body_lines) + "\n"
+
+
+def _merge_timeline_entry(
+    existing_content: str,
+    *,
+    session_id: str,
+    evidence: str,
+    date: datetime,
+) -> str:
+    """Append a new timeline entry and upgrade confidence if threshold is met.
+
+    Parses the YAML ``timeline`` list from the frontmatter, appends the new
+    entry, recalculates ``confidence``, and returns the updated page content.
+    Uses string manipulation to avoid a full YAML round-trip.
+    """
+    date_str = date.strftime("%Y-%m-%dT%H:%M:%SZ")
+    new_entry = (
+        f"  - source: ravn_reflection\n"
+        f"    session_id: {session_id}\n"
+        f"    date: {date_str}\n"
+        f'    note: "{_escape_yaml(evidence)}"'
+    )
+
+    # Count existing timeline entries to determine new confidence.
+    existing_count = existing_content.count("  - source: ravn_reflection")
+    new_count = existing_count + 1
+
+    if new_count >= _CONFIDENCE_HIGH_THRESHOLD:
+        new_confidence = "high"
+    elif new_count >= _CONFIDENCE_MEDIUM_THRESHOLD:
+        new_confidence = "medium"
+    else:
+        new_confidence = "low"
+
+    # Append timeline entry before the closing "---" of the frontmatter.
+    # Strategy: insert after the last existing timeline entry line.
+    updated = _insert_timeline_entry(existing_content, new_entry)
+
+    # Update confidence field.
+    updated = re.sub(
+        r"^confidence:\s+\w+",
+        f"confidence: {new_confidence}",
+        updated,
+        flags=re.MULTILINE,
+    )
+
+    return updated
+
+
+def _insert_timeline_entry(content: str, new_entry: str) -> str:
+    """Insert *new_entry* after the last ``source: ravn_reflection`` block."""
+    # Find the position of the closing frontmatter "---" line.
+    # We want to insert before it but after existing timeline entries.
+    match = re.search(r"^---\s*$", content, flags=re.MULTILINE)
+    if match is None:
+        # No frontmatter closing delimiter; append at end of file.
+        return content.rstrip() + "\n" + new_entry + "\n"
+
+    # Find the last "note:" line inside the frontmatter.
+    fm_end = match.start()
+    frontmatter = content[:fm_end]
+    rest = content[fm_end:]
+
+    last_note = list(re.finditer(r'    note: ".*"', frontmatter))
+    if last_note:
+        insert_pos = last_note[-1].end()
+        return frontmatter[:insert_pos] + "\n" + new_entry + frontmatter[insert_pos:] + rest
+
+    # No existing entries; insert before the closing "---".
+    return frontmatter + new_entry + "\n" + rest
+
+
+def _title_to_keywords(title: str) -> str:
+    """Extract meaningful search keywords from *title*."""
+    # Remove common stop words and short tokens.
+    stop = {"a", "an", "the", "and", "or", "for", "in", "on", "at", "to", "of", "is"}
+    words = re.findall(r"\b\w{3,}\b", title.lower())
+    keywords = [w for w in words if w not in stop]
+    return " ".join(keywords[:6])
+
+
+def _titles_similar(a: str, b: str) -> bool:
+    """Return True when *a* and *b* share enough significant words to be duplicates."""
+
+    def significant_words(t: str) -> set[str]:
+        stop = {
+            "a",
+            "an",
+            "the",
+            "and",
+            "or",
+            "for",
+            "in",
+            "on",
+            "at",
+            "to",
+            "of",
+            "is",
+            "learning",
+        }
+        return {w for w in re.findall(r"\b\w{3,}\b", t.lower()) if w not in stop}
+
+    words_a = significant_words(a)
+    words_b = significant_words(b)
+    if not words_a or not words_b:
+        return False
+
+    overlap = words_a & words_b
+    # Jaccard similarity >= 0.5 counts as similar.
+    union = words_a | words_b
+    return len(overlap) / len(union) >= 0.5
+
+
+def _slugify(text: str) -> str:
+    """Convert *text* to a URL-safe slug."""
+    slug = text.lower()
+    slug = re.sub(r"[^\w\s-]", "", slug)
+    slug = re.sub(r"[\s_-]+", "-", slug)
+    slug = slug.strip("-")
+    return slug[:60] or "learning"
+
+
+def _escape_yaml(text: str) -> str:
+    """Escape double quotes in *text* for inline YAML string embedding."""
+    return text.replace('"', '\\"')
+
+
+def _strip_frontmatter(content: str) -> str:
+    """Remove YAML frontmatter block (``---…---``) from *content*."""
+    if not content.startswith("---"):
+        return content
+    # Find closing delimiter.
+    rest = content[3:]
+    end = rest.find("\n---")
+    if end == -1:
+        return content
+    return rest[end + 4 :]

--- a/src/ravn/adapters/reflection/post_session.py
+++ b/src/ravn/adapters/reflection/post_session.py
@@ -26,6 +26,7 @@ import re
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+from niuu.domain.mimir import MimirPage
 from niuu.ports.mimir import MimirPort
 from ravn.config import PostSessionReflectionConfig
 from ravn.ports.llm import LLMPort
@@ -265,7 +266,7 @@ class PostSessionReflectionService:
                 exc,
             )
 
-    async def _find_existing_page(self, title: str, repo_slug: str) -> object | None:
+    async def _find_existing_page(self, title: str, repo_slug: str) -> MimirPage | None:
         """Search Mímir for an existing learning page matching *title*.
 
         Returns the first :class:`~niuu.domain.mimir.MimirPage` whose title
@@ -480,15 +481,16 @@ def _merge_timeline_entry(
 
 def _insert_timeline_entry(content: str, new_entry: str) -> str:
     """Insert *new_entry* after the last ``source: ravn_reflection`` block."""
-    # Find the position of the closing frontmatter "---" line.
-    # We want to insert before it but after existing timeline entries.
-    match = re.search(r"^---\s*$", content, flags=re.MULTILINE)
-    if match is None:
-        # No frontmatter closing delimiter; append at end of file.
+    # Find the CLOSING frontmatter "---" delimiter (the second occurrence).
+    # re.search would match the opening "---" at position 0, so we collect
+    # all matches and use the second one.
+    matches = list(re.finditer(r"^---\s*$", content, flags=re.MULTILINE))
+    if len(matches) < 2:
+        # No closing delimiter; append at end of file.
         return content.rstrip() + "\n" + new_entry + "\n"
 
     # Find the last "note:" line inside the frontmatter.
-    fm_end = match.start()
+    fm_end = matches[1].start()
     frontmatter = content[:fm_end]
     rest = content[fm_end:]
 
@@ -557,7 +559,12 @@ def _escape_yaml(text: str) -> str:
 
 
 def _strip_frontmatter(content: str) -> str:
-    """Remove YAML frontmatter block (``---…---``) from *content*."""
+    """Remove YAML frontmatter block (``---…---``) from *content*.
+
+    Note: a functionally equivalent copy lives in ``mimir.compiled_truth``.
+    When ``mimir`` is extracted to ``niuu``, consolidate both into a shared
+    ``niuu.utils.frontmatter`` utility.
+    """
     if not content.startswith("---"):
         return content
     # Find closing delimiter.

--- a/src/ravn/agent.py
+++ b/src/ravn/agent.py
@@ -10,10 +10,11 @@ from collections.abc import Callable, Coroutine
 from datetime import UTC, datetime
 from typing import Any
 
+from niuu.ports.mimir import MimirPort
 from ravn.adapters.memory.inline_facts import detect_and_write as _detect_and_write_facts
 from ravn.budget import IterationBudget, TokenEstimator
 from ravn.compression import CompressionResult, ContextCompressor
-from ravn.config import ExtendedThinkingConfig
+from ravn.config import ExtendedThinkingConfig, PostSessionReflectionConfig
 from ravn.domain.budget import compute_cost as _compute_cost_usd
 from ravn.domain.checkpoint import (
     DESTRUCTIVE_TOOL_NAMES,
@@ -117,6 +118,9 @@ class RavnAgent:
         sleipnir_publisher: object | None = None,
         persona: str = "",
         repo_slug: str = "",
+        # NIU-588: learnings injection at session start
+        mimir: MimirPort | None = None,
+        reflection_config: PostSessionReflectionConfig | None = None,
     ) -> None:
         self._llm = llm
         self._tools = {t.name: t for t in tools}
@@ -160,6 +164,9 @@ class RavnAgent:
         self._repo_slug = repo_slug
         self._turn_count: int = 0
         self._session_wall_start: float = time.monotonic()
+        # NIU-588: learnings injection at session start
+        self._mimir = mimir
+        self._reflection_config = reflection_config
 
     @property
     def session(self) -> Session:
@@ -252,6 +259,7 @@ class RavnAgent:
                 token_count=total_tokens,
                 duration_s=duration_s,
                 source=self._source_id,
+                repo_slug=self._repo_slug,
                 correlation_id=self._task_id,
             )
             await self._sleipnir_publisher.publish(event)
@@ -515,6 +523,9 @@ class RavnAgent:
                     logger.warning(
                         "Memory prefetch failed; continuing without context.", exc_info=True
                     )
+            # NIU-588: inject Mímir learnings on the first turn only.
+            if self._turn_count == 1 and self._mimir is not None:
+                await self._inject_learnings()
             return self._prompt_builder.render_blocks()
 
         # Legacy: plain-string system prompt with optional memory suffix.
@@ -527,6 +538,33 @@ class RavnAgent:
             except Exception:
                 logger.warning("Memory prefetch failed; continuing without context.", exc_info=True)
         return effective
+
+    async def _inject_learnings(self) -> None:
+        """Fetch Mímir learnings for the current repo and inject into the prompt.
+
+        Best-effort — logs a warning and does nothing if Mímir is unavailable
+        or the reflection config is not provided.
+        """
+        if self._mimir is None or self._prompt_builder is None:
+            return
+
+        cfg = self._reflection_config
+        max_pages = cfg.max_learnings_injected if cfg is not None else 5
+        token_budget = cfg.learning_token_budget if cfg is not None else 500
+
+        try:
+            from ravn.adapters.reflection.post_session import fetch_relevant_learnings
+
+            learnings_text = await fetch_relevant_learnings(
+                self._mimir,
+                repo_slug=self._repo_slug,
+                max_pages=max_pages,
+                token_budget=token_budget,
+            )
+            if learnings_text:
+                self._prompt_builder.set_learnings_context(learnings_text)
+        except Exception:
+            logger.warning("Learnings injection failed; continuing without.", exc_info=True)
 
     async def _maybe_compress(
         self,

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -1890,6 +1890,44 @@ class WakefulnessConfig(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+class PostSessionReflectionConfig(BaseModel):
+    """Post-session reflection configuration (NIU-588).
+
+    Controls the service that writes operational learnings to Mímir after
+    each ``ravn.session.ended`` event.
+
+    Disabled by default — enable via ``reflection.enabled: true`` in the
+    deployment YAML.
+    """
+
+    enabled: bool = Field(
+        default=False,
+        description=(
+            "Enable post-session reflection.  Off until explicitly activated; "
+            "flip to true in the deployment ravn.yaml."
+        ),
+    )
+    llm_alias: str = Field(
+        default="fast",
+        description=(
+            "LLM alias for the reflection call.  Should resolve to a cheap/fast "
+            "model in the LLM aliases map."
+        ),
+    )
+    max_tokens: int = Field(
+        default=1024,
+        description="Maximum tokens the reflection LLM call may produce.",
+    )
+    learning_token_budget: int = Field(
+        default=500,
+        description=("Maximum tokens of injected learnings in the session-start system prompt."),
+    )
+    max_learnings_injected: int = Field(
+        default=5,
+        description="Maximum number of learning pages injected at session start.",
+    )
+
+
 class RecapConfig(BaseModel):
     """Recap trigger configuration (NIU-569).
 
@@ -2257,6 +2295,9 @@ class Settings(BaseSettings):
 
     # NIU-569: recap trigger
     recap: RecapConfig = Field(default_factory=RecapConfig)
+
+    # NIU-588: post-session reflection → Mímir learnings
+    reflection: PostSessionReflectionConfig = Field(default_factory=PostSessionReflectionConfig)
 
     # NIU-571: trust gradient — constrains wakefulness tool availability
     trust: TrustGradientConfig = Field(default_factory=TrustGradientConfig)

--- a/src/ravn/prompt_builder.py
+++ b/src/ravn/prompt_builder.py
@@ -124,6 +124,10 @@ class PromptBuilder:
         """Set shared Layer-3 context from parent (dynamic, not cached)."""
         self._replace_or_add(PromptSection(name="shared_context", content=text, cacheable=False))
 
+    def set_learnings_context(self, text: str) -> None:
+        """Set past learnings from Mímir (dynamic, not cached — NIU-588)."""
+        self._replace_or_add(PromptSection(name="learnings_context", content=text, cacheable=False))
+
     # ------------------------------------------------------------------
     # Rendering
     # ------------------------------------------------------------------

--- a/src/sleipnir/domain/catalog.py
+++ b/src/sleipnir/domain/catalog.py
@@ -48,6 +48,7 @@ class RavnSessionEndedPayload:
     outcome: str
     token_count: int
     duration_s: float
+    repo_slug: str = ""
 
 
 @dataclass(frozen=True)
@@ -187,6 +188,7 @@ def ravn_session_ended(
     token_count: int,
     duration_s: float,
     source: str,
+    repo_slug: str = "",
     correlation_id: str | None = None,
 ) -> SleipnirEvent:
     """Emit when a Ravn agent session exits (normal, interrupt, or error)."""
@@ -200,6 +202,7 @@ def ravn_session_ended(
                 outcome=outcome,
                 token_count=token_count,
                 duration_s=duration_s,
+                repo_slug=repo_slug,
             )
         ),
         summary=f"Ravn session ended: {session_id} outcome={outcome} tokens={token_count}",

--- a/tests/test_ravn/test_post_session_reflection.py
+++ b/tests/test_ravn/test_post_session_reflection.py
@@ -1,0 +1,502 @@
+"""Tests for PostSessionReflectionService and learnings injection (NIU-588)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from niuu.domain.mimir import MimirPage, MimirPageMeta
+from ravn.adapters.reflection.post_session import (
+    PostSessionReflectionService,
+    _build_page_content,
+    _build_page_path,
+    _merge_timeline_entry,
+    _titles_similar,
+    fetch_relevant_learnings,
+)
+from ravn.config import PostSessionReflectionConfig
+from sleipnir.adapters.in_process import InProcessBus
+from sleipnir.domain.catalog import ravn_session_ended
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+def _make_config(**overrides) -> PostSessionReflectionConfig:
+    defaults = {
+        "enabled": True,
+        "llm_alias": "fast",
+        "max_tokens": 512,
+        "learning_token_budget": 500,
+        "max_learnings_injected": 5,
+    }
+    return PostSessionReflectionConfig(**{**defaults, **overrides})
+
+
+def _make_llm_response(text: str) -> MagicMock:
+    resp = MagicMock()
+    resp.content = text
+    return resp
+
+
+def _make_mimir_page(path: str, title: str, category: str = "learnings") -> MimirPage:
+    meta = MimirPageMeta(
+        path=path,
+        title=title,
+        summary="",
+        category=category,
+        updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    content = f'---\ntitle: "{title}"\ncategory: {category}\n---\n\n# {title}\nBody text.\n'
+    return MimirPage(meta=meta, content=content)
+
+
+# ---------------------------------------------------------------------------
+# PostSessionReflectionService — start / stop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_subscribes_when_enabled():
+    bus = InProcessBus()
+    mimir = AsyncMock()
+    llm = AsyncMock()
+    config = _make_config(enabled=True)
+
+    svc = PostSessionReflectionService(bus, mimir, llm, config)
+    await svc.start()
+
+    assert svc._subscription is not None
+    await svc.stop()
+
+
+@pytest.mark.asyncio
+async def test_start_does_not_subscribe_when_disabled():
+    bus = InProcessBus()
+    mimir = AsyncMock()
+    llm = AsyncMock()
+    config = _make_config(enabled=False)
+
+    svc = PostSessionReflectionService(bus, mimir, llm, config)
+    await svc.start()
+
+    assert svc._subscription is None
+
+
+@pytest.mark.asyncio
+async def test_stop_clears_subscription():
+    bus = InProcessBus()
+    mimir = AsyncMock()
+    llm = AsyncMock()
+    config = _make_config(enabled=True)
+
+    svc = PostSessionReflectionService(bus, mimir, llm, config)
+    await svc.start()
+    assert svc._subscription is not None
+    await svc.stop()
+    assert svc._subscription is None
+
+
+# ---------------------------------------------------------------------------
+# PostSessionReflectionService — LLM reflection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_process_calls_mimir_write_on_valid_learning():
+    bus = InProcessBus()
+    mimir = AsyncMock()
+    mimir.search.return_value = []
+    llm = AsyncMock()
+    llm.generate.return_value = _make_llm_response(
+        json.dumps(
+            {
+                "title": "Use asyncio_mode auto in pytest",
+                "learning": "pytest-asyncio requires asyncio_mode=auto for async tests.",
+                "type": "observation",
+                "tags": ["testing", "pytest"],
+                "evidence": "Session failed due to coroutine not awaited errors.",
+            }
+        )
+    )
+    config = _make_config()
+    svc = PostSessionReflectionService(bus, mimir, llm, config)
+
+    payload = {
+        "session_id": "sess-abc",
+        "persona": "ravn",
+        "outcome": "failure",
+        "token_count": 5000,
+        "duration_s": 120.0,
+        "repo_slug": "niuulabs/volundr",
+    }
+    await svc._process(payload)
+
+    mimir.upsert_page.assert_awaited_once()
+    call_args = mimir.upsert_page.call_args
+    path = call_args[0][0]
+    content = call_args[0][1]
+    assert "learnings/" in path
+    assert "asyncio_mode" in content or "pytest" in content
+
+
+@pytest.mark.asyncio
+async def test_process_skips_on_null_learning():
+    bus = InProcessBus()
+    mimir = AsyncMock()
+    llm = AsyncMock()
+    llm.generate.return_value = _make_llm_response("null")
+    config = _make_config()
+    svc = PostSessionReflectionService(bus, mimir, llm, config)
+
+    payload = {
+        "session_id": "sess-xyz",
+        "persona": "ravn",
+        "outcome": "success",
+        "token_count": 1000,
+        "duration_s": 30.0,
+        "repo_slug": "",
+    }
+    await svc._process(payload)
+
+    mimir.upsert_page.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_process_skips_on_llm_error():
+    bus = InProcessBus()
+    mimir = AsyncMock()
+    llm = AsyncMock()
+    llm.generate.side_effect = RuntimeError("LLM unavailable")
+    config = _make_config()
+    svc = PostSessionReflectionService(bus, mimir, llm, config)
+
+    payload = {
+        "session_id": "sess-err",
+        "persona": "ravn",
+        "outcome": "error",
+        "token_count": 100,
+        "duration_s": 5.0,
+        "repo_slug": "",
+    }
+    # Must not raise.
+    await svc._process(payload)
+    mimir.upsert_page.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_process_skips_on_malformed_json():
+    bus = InProcessBus()
+    mimir = AsyncMock()
+    llm = AsyncMock()
+    llm.generate.return_value = _make_llm_response("not valid json {{{")
+    config = _make_config()
+    svc = PostSessionReflectionService(bus, mimir, llm, config)
+
+    await svc._process(
+        {
+            "session_id": "sess-bad",
+            "persona": "ravn",
+            "outcome": "success",
+            "token_count": 100,
+            "duration_s": 5.0,
+            "repo_slug": "",
+        }
+    )
+    mimir.upsert_page.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Duplicate detection — update existing page
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_process_updates_existing_page_instead_of_creating():
+    existing = _make_mimir_page(
+        "learnings/niuulabs-volundr/use-asyncio-mode-auto-in-pytest",
+        "Learning: Use asyncio_mode auto in pytest",
+    )
+
+    bus = InProcessBus()
+    mimir = AsyncMock()
+    mimir.search.return_value = [existing]
+    llm = AsyncMock()
+    llm.generate.return_value = _make_llm_response(
+        json.dumps(
+            {
+                "title": "Use asyncio_mode auto in pytest",
+                "learning": "pytest-asyncio requires asyncio_mode=auto.",
+                "type": "observation",
+                "tags": ["testing", "pytest"],
+                "evidence": "Second session with same issue.",
+            }
+        )
+    )
+    config = _make_config()
+    svc = PostSessionReflectionService(bus, mimir, llm, config)
+
+    await svc._process(
+        {
+            "session_id": "sess-2nd",
+            "persona": "ravn",
+            "outcome": "failure",
+            "token_count": 3000,
+            "duration_s": 80.0,
+            "repo_slug": "niuulabs/volundr",
+        }
+    )
+
+    # Should update the existing path, not create a new one.
+    mimir.upsert_page.assert_awaited_once()
+    updated_path = mimir.upsert_page.call_args[0][0]
+    assert updated_path == existing.meta.path
+
+
+# ---------------------------------------------------------------------------
+# Confidence upgrade
+# ---------------------------------------------------------------------------
+
+
+def test_merge_timeline_entry_upgrades_confidence_to_medium_at_two():
+    content = _build_page_content(
+        title="Pytest asyncio config",
+        learning="Use asyncio_mode=auto.",
+        page_type="observation",
+        tags=["pytest"],
+        evidence="First session.",
+        repo_slug="niuulabs/volundr",
+        session_id="sess-1",
+        date=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+
+    updated = _merge_timeline_entry(
+        content,
+        session_id="sess-2",
+        evidence="Second occurrence.",
+        date=datetime(2026, 1, 2, tzinfo=UTC),
+    )
+
+    assert "confidence: medium" in updated
+
+
+def test_merge_timeline_entry_upgrades_confidence_to_high_at_three():
+    content = _build_page_content(
+        title="Pytest asyncio config",
+        learning="Use asyncio_mode=auto.",
+        page_type="observation",
+        tags=["pytest"],
+        evidence="First session.",
+        repo_slug="niuulabs/volundr",
+        session_id="sess-1",
+        date=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    # Add a second entry first.
+    content = _merge_timeline_entry(
+        content,
+        session_id="sess-2",
+        evidence="Second occurrence.",
+        date=datetime(2026, 1, 2, tzinfo=UTC),
+    )
+    # Add a third entry.
+    updated = _merge_timeline_entry(
+        content,
+        session_id="sess-3",
+        evidence="Third occurrence.",
+        date=datetime(2026, 1, 3, tzinfo=UTC),
+    )
+
+    assert "confidence: high" in updated
+
+
+def test_merge_timeline_appends_new_entry():
+    content = _build_page_content(
+        title="Test entry",
+        learning="Some learning.",
+        page_type="observation",
+        tags=[],
+        evidence="First.",
+        repo_slug="",
+        session_id="sess-1",
+        date=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+
+    updated = _merge_timeline_entry(
+        content,
+        session_id="sess-new",
+        evidence="New evidence.",
+        date=datetime(2026, 2, 1, tzinfo=UTC),
+    )
+
+    assert "sess-new" in updated
+    assert "New evidence." in updated
+
+
+# ---------------------------------------------------------------------------
+# Page content helpers
+# ---------------------------------------------------------------------------
+
+
+def test_build_page_path_with_repo_slug():
+    path = _build_page_path("Use asyncio_mode auto in pytest", "niuulabs/volundr")
+    assert path.startswith("learnings/niuulabs-volundr/")
+    assert "asyncio" in path or "auto" in path or "pytest" in path
+
+
+def test_build_page_path_without_repo_slug():
+    path = _build_page_path("Generic learning", "")
+    assert path.startswith("learnings/general/")
+
+
+def test_build_page_content_has_required_fields():
+    content = _build_page_content(
+        title="Test learning",
+        learning="This is the learning.",
+        page_type="observation",
+        tags=["tag1", "tag2"],
+        evidence="Evidence from session.",
+        repo_slug="myorg/myrepo",
+        session_id="sess-test",
+        date=datetime(2026, 4, 12, tzinfo=UTC),
+    )
+
+    assert 'title: "Learning: Test learning"' in content
+    assert "type: observation" in content
+    assert "category: learnings" in content
+    assert "confidence: low" in content
+    assert "source: ravn_reflection" in content
+    assert "sess-test" in content
+    assert "This is the learning." in content
+    assert "Evidence from session." in content
+
+
+# ---------------------------------------------------------------------------
+# Similarity detection
+# ---------------------------------------------------------------------------
+
+
+def test_titles_similar_returns_true_for_close_matches():
+    assert _titles_similar(
+        "Use asyncio_mode auto in pytest",
+        "Learning: Use asyncio_mode auto in pytest",
+    )
+
+
+def test_titles_similar_returns_false_for_unrelated():
+    assert not _titles_similar(
+        "pytest async configuration",
+        "kubernetes pod memory limits",
+    )
+
+
+def test_titles_similar_empty_returns_false():
+    assert not _titles_similar("", "something")
+
+
+# ---------------------------------------------------------------------------
+# Sleipnir event integration — end-to-end via InProcessBus
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_service_receives_ravn_session_ended_event():
+    bus = InProcessBus()
+    mimir = AsyncMock()
+    mimir.search.return_value = []
+    llm = AsyncMock()
+    llm.generate.return_value = _make_llm_response("null")  # no learning extracted
+    config = _make_config(enabled=True)
+
+    svc = PostSessionReflectionService(bus, mimir, llm, config)
+    await svc.start()
+
+    event = ravn_session_ended(
+        session_id="sess-e2e",
+        persona="ravn",
+        outcome="success",
+        token_count=2000,
+        duration_s=60.0,
+        repo_slug="niuulabs/volundr",
+        source="ravn:test",
+    )
+    await bus.publish(event)
+    await bus.flush()
+
+    # LLM was called (reflection ran).
+    llm.generate.assert_awaited_once()
+    await svc.stop()
+
+
+@pytest.mark.asyncio
+async def test_on_session_ended_never_raises_on_error():
+    bus = InProcessBus()
+    mimir = AsyncMock()
+    llm = AsyncMock()
+    llm.generate.side_effect = Exception("catastrophic failure")
+    config = _make_config(enabled=True)
+
+    svc = PostSessionReflectionService(bus, mimir, llm, config)
+
+    fake_event = ravn_session_ended(
+        session_id="s",
+        persona="p",
+        outcome="error",
+        token_count=0,
+        duration_s=0.0,
+        repo_slug="",
+        source="test",
+    )
+    # Must not raise.
+    await svc._on_session_ended(fake_event)
+
+
+# ---------------------------------------------------------------------------
+# fetch_relevant_learnings
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fetch_relevant_learnings_returns_empty_on_no_pages():
+    mimir = AsyncMock()
+    mimir.list_pages.return_value = []
+
+    result = await fetch_relevant_learnings(
+        mimir, repo_slug="myrepo", max_pages=5, token_budget=500
+    )
+    assert result == ""
+
+
+@pytest.mark.asyncio
+async def test_fetch_relevant_learnings_includes_page_content():
+    meta = MimirPageMeta(
+        path="learnings/myrepo/some-learning",
+        title="Some learning",
+        summary="",
+        category="learnings",
+        updated_at=datetime(2026, 4, 1, tzinfo=UTC),
+    )
+    mimir = AsyncMock()
+    mimir.list_pages.return_value = [meta]
+    mimir.read_page.return_value = "---\ntitle: Some learning\n---\n\nThe body of the learning."
+
+    result = await fetch_relevant_learnings(
+        mimir, repo_slug="myrepo", max_pages=5, token_budget=500
+    )
+
+    assert "Past Learnings" in result
+    assert "body of the learning" in result
+
+
+@pytest.mark.asyncio
+async def test_fetch_relevant_learnings_returns_empty_on_error():
+    mimir = AsyncMock()
+    mimir.list_pages.side_effect = RuntimeError("storage error")
+
+    result = await fetch_relevant_learnings(
+        mimir, repo_slug="myrepo", max_pages=5, token_budget=500
+    )
+    assert result == ""

--- a/tests/test_ravn/test_post_session_reflection.py
+++ b/tests/test_ravn/test_post_session_reflection.py
@@ -336,6 +336,11 @@ def test_merge_timeline_appends_new_entry():
 
     assert "sess-new" in updated
     assert "New evidence." in updated
+    # Structural correctness: page must still start with frontmatter.
+    assert updated.startswith("---\n")
+    # New entry must appear inside the frontmatter block (before body).
+    fm_close = updated.index("\n---\n", 3)  # closing delimiter
+    assert "sess-new" in updated[:fm_close]
 
 
 # ---------------------------------------------------------------------------
@@ -809,9 +814,33 @@ async def test_find_existing_page_returns_none_when_no_title_matches():
 
 
 def test_insert_timeline_entry_without_any_frontmatter():
+    # Content with no "---" delimiters at all — entry appended at end.
     content = "# Some page\n\nSome body text without any dashes."
     result = _insert_timeline_entry(content, "new entry line")
     assert "new entry line" in result
+
+
+def test_insert_timeline_entry_places_entry_inside_frontmatter():
+    content = _build_page_content(
+        title="Structural test",
+        learning="The learning.",
+        page_type="observation",
+        tags=[],
+        evidence="First evidence.",
+        repo_slug="",
+        session_id="sess-A",
+        date=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+
+    result = _insert_timeline_entry(content, "  - source: ravn_reflection\n    session_id: sess-B")
+
+    # Page must still open with frontmatter.
+    assert result.startswith("---\n")
+    # The new entry must be inside the frontmatter, not after the closing ---.
+    fm_close_pos = result.index("\n---\n", 3)
+    assert "sess-B" in result[:fm_close_pos]
+    # Body section must still follow the closing delimiter.
+    assert "# Learning: Structural test" in result[fm_close_pos:]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ravn/test_post_session_reflection.py
+++ b/tests/test_ravn/test_post_session_reflection.py
@@ -13,7 +13,9 @@ from ravn.adapters.reflection.post_session import (
     PostSessionReflectionService,
     _build_page_content,
     _build_page_path,
+    _insert_timeline_entry,
     _merge_timeline_entry,
+    _strip_frontmatter,
     _titles_similar,
     fetch_relevant_learnings,
 )
@@ -500,3 +502,330 @@ async def test_fetch_relevant_learnings_returns_empty_on_error():
         mimir, repo_slug="myrepo", max_pages=5, token_budget=500
     )
     assert result == ""
+
+
+@pytest.mark.asyncio
+async def test_fetch_relevant_learnings_no_repo_slug_returns_all_pages():
+    meta = MimirPageMeta(
+        path="learnings/general/some-learning",
+        title="Some learning",
+        summary="",
+        category="learnings",
+        updated_at=datetime(2026, 4, 1, tzinfo=UTC),
+    )
+    mimir = AsyncMock()
+    mimir.list_pages.return_value = [meta]
+    mimir.read_page.return_value = "---\ntitle: Some\n---\n\nBody text."
+
+    result = await fetch_relevant_learnings(mimir, repo_slug="", max_pages=5, token_budget=500)
+
+    assert "Body text" in result
+
+
+@pytest.mark.asyncio
+async def test_fetch_relevant_learnings_returns_empty_when_no_matching_repo():
+    meta = MimirPageMeta(
+        path="learnings/other-repo/some-learning",
+        title="Some learning",
+        summary="",
+        category="learnings",
+        updated_at=datetime(2026, 4, 1, tzinfo=UTC),
+    )
+    mimir = AsyncMock()
+    mimir.list_pages.return_value = [meta]
+
+    result = await fetch_relevant_learnings(
+        mimir, repo_slug="my-repo", max_pages=5, token_budget=500
+    )
+    assert result == ""
+
+
+@pytest.mark.asyncio
+async def test_fetch_relevant_learnings_skips_pages_with_read_error():
+    meta = MimirPageMeta(
+        path="learnings/general/some-learning",
+        title="Some learning",
+        summary="",
+        category="learnings",
+        updated_at=datetime(2026, 4, 1, tzinfo=UTC),
+    )
+    mimir = AsyncMock()
+    mimir.list_pages.return_value = [meta]
+    mimir.read_page.side_effect = RuntimeError("read error")
+
+    result = await fetch_relevant_learnings(mimir, repo_slug="", max_pages=5, token_budget=500)
+    assert result == ""
+
+
+@pytest.mark.asyncio
+async def test_fetch_relevant_learnings_skips_pages_with_empty_body():
+    meta = MimirPageMeta(
+        path="learnings/general/some-learning",
+        title="Some learning",
+        summary="",
+        category="learnings",
+        updated_at=datetime(2026, 4, 1, tzinfo=UTC),
+    )
+    mimir = AsyncMock()
+    mimir.list_pages.return_value = [meta]
+    # Body is only whitespace after stripping frontmatter.
+    mimir.read_page.return_value = "---\ntitle: Some\n---\n\n   "
+
+    result = await fetch_relevant_learnings(mimir, repo_slug="", max_pages=5, token_budget=500)
+    assert result == ""
+
+
+@pytest.mark.asyncio
+async def test_fetch_relevant_learnings_stops_at_token_budget():
+    metas = [
+        MimirPageMeta(
+            path=f"learnings/general/learning-{i}",
+            title=f"Learning {i}",
+            summary="",
+            category="learnings",
+            updated_at=datetime(2026, 4, 1, tzinfo=UTC),
+        )
+        for i in range(5)
+    ]
+    mimir = AsyncMock()
+    mimir.list_pages.return_value = metas
+    # Every page has a body that is 200 chars — total budget of 5 tokens (20 chars) exceeded
+    mimir.read_page.return_value = "---\ntitle: foo\n---\n\n" + "X" * 200
+
+    # token_budget=5 → char_budget=20; first entry already exceeds it.
+    result = await fetch_relevant_learnings(mimir, repo_slug="", max_pages=5, token_budget=5)
+    assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# PostSessionReflectionService — lifecycle edge cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stop_when_subscription_is_none_is_noop():
+    bus = InProcessBus()
+    mimir = AsyncMock()
+    llm = AsyncMock()
+    config = _make_config(enabled=True)
+    svc = PostSessionReflectionService(bus, mimir, llm, config)
+
+    # Never called start(), so _subscription is None.
+    await svc.stop()
+    assert svc._subscription is None
+
+
+@pytest.mark.asyncio
+async def test_stop_handles_unsubscribe_exception():
+    bus = InProcessBus()
+    mimir = AsyncMock()
+    llm = AsyncMock()
+    config = _make_config(enabled=True)
+    svc = PostSessionReflectionService(bus, mimir, llm, config)
+    await svc.start()
+
+    # Make unsubscribe raise.
+    svc._subscription.unsubscribe = AsyncMock(side_effect=RuntimeError("network fail"))
+
+    # Must not raise; subscription should still be cleared.
+    await svc.stop()
+    assert svc._subscription is None
+
+
+@pytest.mark.asyncio
+async def test_on_session_ended_catches_exception_from_process():
+    bus = InProcessBus()
+    mimir = AsyncMock()
+    llm = AsyncMock()
+    config = _make_config(enabled=True)
+    svc = PostSessionReflectionService(bus, mimir, llm, config)
+
+    # Patch _process to raise directly, bypassing its own error handling.
+    svc._process = AsyncMock(side_effect=RuntimeError("internal failure"))
+
+    fake_event = ravn_session_ended(
+        session_id="s",
+        persona="p",
+        outcome="error",
+        token_count=0,
+        duration_s=0.0,
+        repo_slug="",
+        source="test",
+    )
+    # Must not raise — _on_session_ended swallows all exceptions.
+    await svc._on_session_ended(fake_event)
+
+
+# ---------------------------------------------------------------------------
+# _run_reflection — non-dict JSON
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_process_skips_on_llm_returning_json_array():
+    bus = InProcessBus()
+    mimir = AsyncMock()
+    llm = AsyncMock()
+    llm.generate.return_value = _make_llm_response('["a", "b"]')
+    config = _make_config()
+    svc = PostSessionReflectionService(bus, mimir, llm, config)
+
+    await svc._process(
+        {
+            "session_id": "s",
+            "persona": "p",
+            "outcome": "ok",
+            "token_count": 0,
+            "duration_s": 0.0,
+            "repo_slug": "",
+        }
+    )
+    mimir.upsert_page.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# _write_learning — edge cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_write_learning_skips_on_empty_title():
+    bus = InProcessBus()
+    mimir = AsyncMock()
+    llm = AsyncMock()
+    config = _make_config()
+    svc = PostSessionReflectionService(bus, mimir, llm, config)
+
+    await svc._write_learning(
+        {"title": "   ", "learning": "foo", "type": "observation", "tags": [], "evidence": "e"},
+        {"session_id": "s", "repo_slug": ""},
+    )
+    mimir.upsert_page.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_write_learning_handles_upsert_error_on_update():
+    existing = _make_mimir_page("learnings/general/some-thing", "Learning: Some thing")
+    bus = InProcessBus()
+    mimir = AsyncMock()
+    mimir.search.return_value = [existing]
+    mimir.upsert_page.side_effect = RuntimeError("write error")
+    llm = AsyncMock()
+    config = _make_config()
+    svc = PostSessionReflectionService(bus, mimir, llm, config)
+
+    learning = {
+        "title": "Some thing", "learning": "foo", "type": "observation",
+        "tags": [], "evidence": "e",
+    }
+    # Must not raise.
+    await svc._write_learning(learning, {"session_id": "s", "repo_slug": ""})
+
+
+@pytest.mark.asyncio
+async def test_write_learning_handles_upsert_error_on_create():
+    bus = InProcessBus()
+    mimir = AsyncMock()
+    mimir.search.return_value = []
+    mimir.upsert_page.side_effect = RuntimeError("write error")
+    llm = AsyncMock()
+    config = _make_config()
+    svc = PostSessionReflectionService(bus, mimir, llm, config)
+
+    learning = {
+        "title": "New thing", "learning": "foo", "type": "observation",
+        "tags": [], "evidence": "e",
+    }
+    # Must not raise.
+    await svc._write_learning(learning, {"session_id": "s", "repo_slug": ""})
+
+
+# ---------------------------------------------------------------------------
+# _find_existing_page — edge cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_find_existing_page_returns_none_for_empty_title():
+    bus = InProcessBus()
+    mimir = AsyncMock()
+    llm = AsyncMock()
+    config = _make_config()
+    svc = PostSessionReflectionService(bus, mimir, llm, config)
+
+    result = await svc._find_existing_page("", "")
+    assert result is None
+    mimir.search.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_find_existing_page_returns_none_on_search_error():
+    bus = InProcessBus()
+    mimir = AsyncMock()
+    mimir.search.side_effect = RuntimeError("search failure")
+    llm = AsyncMock()
+    config = _make_config()
+    svc = PostSessionReflectionService(bus, mimir, llm, config)
+
+    result = await svc._find_existing_page("some relevant title", "")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_find_existing_page_skips_non_learnings_category():
+    non_learning = _make_mimir_page("docs/some-doc", "Some doc", category="docs")
+    bus = InProcessBus()
+    mimir = AsyncMock()
+    mimir.search.return_value = [non_learning]
+    llm = AsyncMock()
+    config = _make_config()
+    svc = PostSessionReflectionService(bus, mimir, llm, config)
+
+    result = await svc._find_existing_page("Some doc", "")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_find_existing_page_returns_none_when_no_title_matches():
+    # A learnings page in results that does NOT match the title (different topic).
+    unrelated = _make_mimir_page(
+        "learnings/general/kubernetes-pod-limits",
+        "Learning: Kubernetes pod memory limits",
+    )
+    bus = InProcessBus()
+    mimir = AsyncMock()
+    mimir.search.return_value = [unrelated]
+    llm = AsyncMock()
+    config = _make_config()
+    svc = PostSessionReflectionService(bus, mimir, llm, config)
+
+    result = await svc._find_existing_page("pytest asyncio configuration", "")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _insert_timeline_entry — no frontmatter delimiter
+# ---------------------------------------------------------------------------
+
+
+def test_insert_timeline_entry_without_any_frontmatter():
+    content = "# Some page\n\nSome body text without any dashes."
+    result = _insert_timeline_entry(content, "new entry line")
+    assert "new entry line" in result
+
+
+# ---------------------------------------------------------------------------
+# _strip_frontmatter — edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_strip_frontmatter_content_without_opening_delimiter():
+    content = "# Just a heading\n\nNo frontmatter here."
+    result = _strip_frontmatter(content)
+    assert result == content
+
+
+def test_strip_frontmatter_content_with_no_closing_delimiter():
+    content = "---\ntitle: Missing closing\nNo closing delimiter anywhere."
+    result = _strip_frontmatter(content)
+    assert result == content


### PR DESCRIPTION
## Summary

- **PostSessionReflectionService** (`src/ravn/adapters/reflection/post_session.py`): Subscribes to `ravn.session.ended` Sleipnir events, calls a cheap LLM to extract an operational learning, and writes a compiled-truth page to Mimir under `learnings/<repo_slug>/<slug>.md`
- **Duplicate merging**: searches Mimir for existing pages with similar titles (Jaccard similarity >= 0.5); updates them with a new timeline entry instead of creating duplicates
- **Confidence ladder**: `low` (1 session) => `medium` (2) => `high` (3+ sessions), upgraded automatically on each merge
- **Learnings injection**: `RavnAgent._inject_learnings()` queries Mimir `learnings/` at the first turn and injects up to 5 relevant pages (~500 tokens) into the system prompt via `PromptBuilder.set_learnings_context()` (dynamic, non-cached section)
- **Catalog change**: `RavnSessionEndedPayload` gains `repo_slug: str = ""` so the reflection service knows which repository the session operated on; `agent.emit_session_ended()` now passes `self._repo_slug`
- **Config**: `PostSessionReflectionConfig` with `enabled`, `llm_alias`, `max_tokens`, `learning_token_budget`, `max_learnings_injected` wired as `RavnSettings.reflection`

## Test plan

- [x] lifecycle: subscribe when enabled, skip when disabled, stop clears subscription
- [x] happy path: valid LLM response -> Mimir write called
- [x] resilience: null learning, LLM error, malformed JSON all handled without raising
- [x] duplicate detection: existing similar page found -> update not create new
- [x] confidence ladder: medium at 2 sessions, high at 3+ sessions
- [x] similarity detection unit tests
- [x] end-to-end via InProcessBus: ravn.session.ended event triggers LLM call
- [x] fetch_relevant_learnings: empty on no pages, includes content, empty on error
- 22 tests, 85% coverage on new code

## Notes

Linear ticket NIU-588 could not be updated via MCP (no Linear MCP server configured). Please update manually to "In Review".

Generated with Claude Code