### PR TITLE
feat(adapters): build 4 Tyr saga templates with multi-phase sequential dispatch (NIU-589)

### DIFF
--- a/src/tyr/adapters/event_trigger.py
+++ b/src/tyr/adapters/event_trigger.py
@@ -27,7 +27,6 @@ from pathlib import Path
 
 from sleipnir.domain.events import SleipnirEvent
 from sleipnir.ports.events import SleipnirSubscriber, Subscription
-from tyr.api.tracker import _slugify
 from tyr.domain.models import (
     Phase,
     PhaseStatus,
@@ -43,28 +42,12 @@ from tyr.domain.templates import (
     TemplateRaid,
     load_template,
 )
+from tyr.domain.utils import _slugify
 from tyr.ports.event_bus import EventBusPort, TyrEvent
 from tyr.ports.saga_repository import SagaRepository
 from tyr.ports.volundr import SpawnRequest, VolundrFactory, VolundrPort
 
 logger = logging.getLogger(__name__)
-
-# Re-export load_template and related names so existing import paths keep working.
-__all__ = [
-    "EventTriggerAdapter",
-    "build_event_trigger_adapter",
-    "load_template",
-    "matches_filter",
-    "SagaTemplate",
-    "TemplatePhase",
-    "TemplateRaid",
-    "BUNDLED_TEMPLATES_DIR",
-    "_TriggerRule",
-    "_BUNDLED_TEMPLATES_DIR",
-]
-
-# Backward-compat alias (tests import this name).
-_BUNDLED_TEMPLATES_DIR = BUNDLED_TEMPLATES_DIR
 
 
 # ---------------------------------------------------------------------------
@@ -435,8 +418,9 @@ class EventTriggerAdapter:
         """
         phases = self._saga_phases.get(saga_id)
         if not phases:
-            logger.debug(
-                "EventTriggerAdapter.advance_phase: saga %s not tracked in memory, skipping",
+            logger.warning(
+                "EventTriggerAdapter.advance_phase: saga %s not in in-memory tracking "
+                "(adapter may have restarted); cannot advance phase without DB query",
                 saga_id,
             )
             return
@@ -488,6 +472,21 @@ class EventTriggerAdapter:
             next_tpl.needs_approval,
         )
         await self._activate_phase(saga, activated, next_raids, next_tpl)
+
+        # Keep in-memory status in sync with DB: if the phase was gated,
+        # update the entry from ACTIVE → GATED so subsequent advance_phase
+        # calls reflect the real state.
+        if next_tpl.needs_approval:
+            gated = Phase(
+                id=activated.id,
+                saga_id=activated.saga_id,
+                tracker_id=activated.tracker_id,
+                number=activated.number,
+                name=activated.name,
+                status=PhaseStatus.GATED,
+                confidence=activated.confidence,
+            )
+            phases[idx] = (gated, next_raids, next_tpl)
 
     # ------------------------------------------------------------------
     # Dispatch helpers

--- a/src/tyr/adapters/event_trigger.py
+++ b/src/tyr/adapters/event_trigger.py
@@ -6,9 +6,11 @@ event patterns match.  Supports:
 - Pattern matching via fnmatch (``github.pr.*``, ``ravn.session.ended``, etc.)
 - Payload filter matching (key=value pairs that all must match)
 - Saga templates loaded from YAML files
-- ``auto_start: true``  — spawn Volundr sessions immediately
+- ``auto_start: true``  — spawn Volundr sessions immediately for Phase 1
 - ``auto_start: false`` — create PENDING raids, emit ``tyr.raid.needs_approval``
 - Deduplication via correlation_id to avoid creating duplicate sagas
+- Multi-phase sequential execution: Phase 1 dispatched on creation;
+  subsequent phases advance via :meth:`advance_phase`
 """
 
 from __future__ import annotations
@@ -22,9 +24,6 @@ from collections import deque
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
-
-import yaml
 
 from sleipnir.domain.events import SleipnirEvent
 from sleipnir.ports.events import SleipnirSubscriber, Subscription
@@ -37,135 +36,35 @@ from tyr.domain.models import (
     Saga,
     SagaStatus,
 )
+from tyr.domain.templates import (
+    BUNDLED_TEMPLATES_DIR,
+    SagaTemplate,
+    TemplatePhase,
+    TemplateRaid,
+    load_template,
+)
 from tyr.ports.event_bus import EventBusPort, TyrEvent
 from tyr.ports.saga_repository import SagaRepository
-from tyr.ports.volundr import SpawnRequest, VolundrFactory
+from tyr.ports.volundr import SpawnRequest, VolundrFactory, VolundrPort
 
 logger = logging.getLogger(__name__)
 
-# Path to bundled templates shipped with the package.
-_BUNDLED_TEMPLATES_DIR = Path(__file__).parent.parent / "templates"
+# Re-export load_template and related names so existing import paths keep working.
+__all__ = [
+    "EventTriggerAdapter",
+    "build_event_trigger_adapter",
+    "load_template",
+    "matches_filter",
+    "SagaTemplate",
+    "TemplatePhase",
+    "TemplateRaid",
+    "BUNDLED_TEMPLATES_DIR",
+    "_TriggerRule",
+    "_BUNDLED_TEMPLATES_DIR",
+]
 
-# Regex matching {event.field_name} placeholders in template strings.
-_EVENT_PLACEHOLDER_RE = re.compile(r"\{event\.([^}]+)\}")
-
-
-# ---------------------------------------------------------------------------
-# Template data classes
-# ---------------------------------------------------------------------------
-
-
-@dataclass(frozen=True)
-class TemplateRaid:
-    name: str
-    description: str
-    acceptance_criteria: list[str]
-    declared_files: list[str]
-    estimate_hours: float
-    prompt: str
-
-
-@dataclass(frozen=True)
-class TemplatePhase:
-    name: str
-    raids: list[TemplateRaid]
-
-
-@dataclass(frozen=True)
-class SagaTemplate:
-    name: str
-    feature_branch: str
-    base_branch: str
-    repos: list[str]
-    phases: list[TemplatePhase]
-
-
-# ---------------------------------------------------------------------------
-# Template loading
-# ---------------------------------------------------------------------------
-
-
-def _interpolate(text: str, payload: dict) -> str:
-    """Replace ``{event.field}`` placeholders with values from *payload*.
-
-    Unknown fields are left as-is so templates remain renderable even when
-    some payload keys are absent.
-    """
-
-    def _replace(m: re.Match) -> str:
-        key = m.group(1)
-        value = payload.get(key)
-        if value is None:
-            return m.group(0)
-        return str(value)
-
-    return _EVENT_PLACEHOLDER_RE.sub(_replace, text)
-
-
-def _interpolate_value(value: Any, payload: dict) -> Any:
-    """Recursively interpolate ``{event.*}`` placeholders in parsed YAML data.
-
-    Operates on already-parsed Python objects (dicts, lists, strings) so that
-    payload values containing YAML metacharacters cannot alter the document
-    structure.
-    """
-    if isinstance(value, str):
-        return _interpolate(value, payload)
-    if isinstance(value, dict):
-        return {k: _interpolate_value(v, payload) for k, v in value.items()}
-    if isinstance(value, list):
-        return [_interpolate_value(item, payload) for item in value]
-    return value
-
-
-def load_template(name: str, templates_dir: Path, payload: dict) -> SagaTemplate:
-    """Load and interpolate a YAML saga template.
-
-    :param name: Template name without extension (e.g. ``"review"``).
-    :param templates_dir: Directory to search first; falls back to bundled dir.
-    :param payload: Sleipnir event payload used for ``{event.*}`` substitution.
-    :raises FileNotFoundError: When the template cannot be found.
-    """
-    candidates = [
-        templates_dir / f"{name}.yaml",
-        _BUNDLED_TEMPLATES_DIR / f"{name}.yaml",
-    ]
-    path = next((p for p in candidates if p.exists()), None)
-    if path is None:
-        raise FileNotFoundError(
-            f"Saga template {name!r} not found in {templates_dir} or bundled templates"
-        )
-
-    raw = path.read_text(encoding="utf-8")
-    # Parse YAML first, then interpolate — prevents payload values with YAML
-    # metacharacters from altering the document structure.
-    data = _interpolate_value(yaml.safe_load(raw), payload)
-
-    phases = [
-        TemplatePhase(
-            name=p["name"],
-            raids=[
-                TemplateRaid(
-                    name=r["name"],
-                    description=r.get("description", ""),
-                    acceptance_criteria=r.get("acceptance_criteria", []),
-                    declared_files=r.get("declared_files", []),
-                    estimate_hours=float(r.get("estimate_hours", 2.0)),
-                    prompt=r.get("prompt", ""),
-                )
-                for r in p.get("raids", [])
-            ],
-        )
-        for p in data.get("phases", [])
-    ]
-
-    return SagaTemplate(
-        name=data["name"],
-        feature_branch=data.get("feature_branch", "main"),
-        base_branch=data.get("base_branch", "main"),
-        repos=data.get("repos", []),
-        phases=phases,
-    )
+# Backward-compat alias (tests import this name).
+_BUNDLED_TEMPLATES_DIR = BUNDLED_TEMPLATES_DIR
 
 
 # ---------------------------------------------------------------------------
@@ -209,9 +108,20 @@ class EventTriggerAdapter:
         # ... application runs ...
         await adapter.stop()    # unsubscribe; clean up
 
-    Deduplication is based on the event's ``correlation_id`` (falling back to
-    ``event_id``).  The same correlation-id+rule combination will not create a
-    second saga within the lifetime of the adapter.
+    **Multi-phase execution**
+
+    When a template has more than one phase, only Phase 1 is dispatched at saga
+    creation.  Subsequent phases are created in PENDING state.  Call
+    :meth:`advance_phase` once all raids in the active phase complete to
+    dispatch the next phase.  If a phase has ``needs_approval: true`` the
+    adapter emits ``phase.needs_approval`` and gates (GATED status) the phase
+    instead of dispatching its raids automatically.
+
+    **Deduplication**
+
+    Based on the event's ``correlation_id`` (falling back to ``event_id``).
+    The same correlation-id+rule combination will not create a second saga
+    within the lifetime of the adapter.
 
     The dedup cache is a bounded ``deque`` of fixed maximum size
     (``dedup_cache_size``).  The oldest entries are evicted when the cache is
@@ -247,6 +157,11 @@ class EventTriggerAdapter:
         self._seen: deque[str] = deque(maxlen=dedup_cache_size)
         self._seen_set: set[str] = set()
         self._pending_tasks: set[asyncio.Task[None]] = set()
+
+        # Maps saga_id → ordered list of (Phase, [Raid], TemplatePhase).
+        # Used by advance_phase to know what to dispatch next without an
+        # extra round-trip to the database.
+        self._saga_phases: dict[str, list[tuple[Phase, list[Raid], TemplatePhase]]] = {}
 
     @property
     def is_running(self) -> bool:
@@ -324,7 +239,7 @@ class EventTriggerAdapter:
         self._seen_set.add(key)
 
     async def _trigger_saga(self, event: SleipnirEvent, rule: _TriggerRule) -> None:
-        """Create saga from template and optionally auto-dispatch it."""
+        """Create saga from template and dispatch Phase 1 (or gate it)."""
         try:
             template = load_template(rule.saga_template, self._templates_dir, event.payload)
         except FileNotFoundError:
@@ -358,49 +273,10 @@ class EventTriggerAdapter:
         )
         await self._saga_repo.save_saga(saga)
 
-        raid_status = RaidStatus.QUEUED if rule.auto_start else RaidStatus.PENDING
-        phases: list[tuple[Phase, list[Raid]]] = []
+        phases = await self._create_phases(saga, template, now, rule.auto_start)
 
-        for phase_num, tpl_phase in enumerate(template.phases, start=1):
-            phase_id = uuid.uuid4()
-            phase = Phase(
-                id=phase_id,
-                saga_id=saga_id,
-                tracker_id=str(phase_id),
-                number=phase_num,
-                name=tpl_phase.name,
-                status=PhaseStatus.ACTIVE,
-                confidence=self._initial_confidence,
-            )
-            await self._saga_repo.save_phase(phase)
-
-            raids: list[Raid] = []
-            for tpl_raid in tpl_phase.raids:
-                raid_id = uuid.uuid4()
-                raid = Raid(
-                    id=raid_id,
-                    phase_id=phase_id,
-                    tracker_id=str(raid_id),
-                    name=tpl_raid.name,
-                    description=tpl_raid.description,
-                    acceptance_criteria=tpl_raid.acceptance_criteria,
-                    declared_files=tpl_raid.declared_files,
-                    estimate_hours=tpl_raid.estimate_hours,
-                    status=raid_status,
-                    confidence=self._initial_confidence,
-                    session_id=None,
-                    branch=None,
-                    chronicle_summary=None,
-                    pr_url=None,
-                    pr_id=None,
-                    retry_count=0,
-                    created_at=now,
-                    updated_at=now,
-                )
-                await self._saga_repo.save_raid(raid)
-                raids.append(raid)
-
-            phases.append((phase, raids))
+        # Track phases in memory for advance_phase calls.
+        self._saga_phases[str(saga_id)] = phases
 
         await self._event_bus.emit(
             TyrEvent(
@@ -419,41 +295,207 @@ class EventTriggerAdapter:
         )
 
         logger.info(
-            "EventTriggerAdapter: created saga %s (template=%s, auto_start=%s)",
+            "EventTriggerAdapter: created saga %s (template=%s, auto_start=%s, phases=%d)",
             slug,
             rule.saga_template,
             rule.auto_start,
+            len(template.phases),
         )
 
+        if not template.phases:
+            return
+
+        first_phase, first_raids, first_tpl_phase = phases[0]
         if rule.auto_start:
-            await self._dispatch_all(saga, phases, template)
+            await self._activate_phase(saga, first_phase, first_raids, first_tpl_phase)
         else:
             await self._emit_needs_approval(saga, phases)
 
-    async def _dispatch_all(
+    async def _create_phases(
         self,
         saga: Saga,
-        phases: list[tuple[Phase, list[Raid]]],
         template: SagaTemplate,
+        now: datetime,
+        auto_start: bool,
+    ) -> list[tuple[Phase, list[Raid], TemplatePhase]]:
+        """Persist all phases and raids; return them for in-memory tracking.
+
+        Only Phase 1 gets ACTIVE status; subsequent phases are PENDING.
+        All raids are PENDING regardless — they are transitioned to QUEUED
+        or RUNNING in :meth:`_activate_phase`.
+        """
+        phases: list[tuple[Phase, list[Raid], TemplatePhase]] = []
+
+        for phase_num, tpl_phase in enumerate(template.phases, start=1):
+            phase_status = PhaseStatus.ACTIVE if phase_num == 1 else PhaseStatus.PENDING
+            phase_id = uuid.uuid4()
+            phase = Phase(
+                id=phase_id,
+                saga_id=saga.id,
+                tracker_id=str(phase_id),
+                number=phase_num,
+                name=tpl_phase.name,
+                status=phase_status,
+                confidence=self._initial_confidence,
+            )
+            await self._saga_repo.save_phase(phase)
+
+            raids: list[Raid] = []
+            for tpl_raid in tpl_phase.raids:
+                raid_id = uuid.uuid4()
+                raid = Raid(
+                    id=raid_id,
+                    phase_id=phase_id,
+                    tracker_id=str(raid_id),
+                    name=tpl_raid.name,
+                    description=tpl_raid.description,
+                    acceptance_criteria=tpl_raid.acceptance_criteria,
+                    declared_files=tpl_raid.declared_files,
+                    estimate_hours=tpl_raid.estimate_hours,
+                    status=RaidStatus.PENDING,
+                    confidence=self._initial_confidence,
+                    session_id=None,
+                    branch=None,
+                    chronicle_summary=None,
+                    pr_url=None,
+                    pr_id=None,
+                    retry_count=0,
+                    created_at=now,
+                    updated_at=now,
+                )
+                await self._saga_repo.save_raid(raid)
+                raids.append(raid)
+
+            phases.append((phase, raids, tpl_phase))
+
+        return phases
+
+    async def _activate_phase(
+        self,
+        saga: Saga,
+        phase: Phase,
+        raids: list[Raid],
+        tpl_phase: TemplatePhase,
     ) -> None:
-        """Spawn Volundr sessions for all raids in the saga."""
-        volundr = await self._volundr_factory.primary_for_owner(self._owner_id)
-        if volundr is None:
-            logger.error(
-                "EventTriggerAdapter: no Volundr adapter for owner %s, cannot dispatch saga %s",
-                self._owner_id,
+        """Dispatch a phase's raids or gate it for human approval."""
+        if tpl_phase.needs_approval:
+            # Gate the phase — emit event and wait for human approval.
+            gated_phase = Phase(
+                id=phase.id,
+                saga_id=phase.saga_id,
+                tracker_id=phase.tracker_id,
+                number=phase.number,
+                name=phase.name,
+                status=PhaseStatus.GATED,
+                confidence=phase.confidence,
+            )
+            await self._saga_repo.save_phase(gated_phase)
+            await self._event_bus.emit(
+                TyrEvent(
+                    event="phase.needs_approval",
+                    data={
+                        "phase_id": str(phase.id),
+                        "phase_name": phase.name,
+                        "phase_number": phase.number,
+                        "saga_id": str(saga.id),
+                        "saga_name": saga.name,
+                        "owner_id": self._owner_id,
+                    },
+                    owner_id=self._owner_id,
+                )
+            )
+            logger.info(
+                "EventTriggerAdapter: phase '%s' (saga=%s) gated — awaiting human approval",
+                phase.name,
                 saga.slug,
             )
             return
 
-        for phase_idx, (phase, raids) in enumerate(phases):
-            tpl_phase = template.phases[phase_idx]
-            for raid, tpl_raid in zip(raids, tpl_phase.raids):
-                await self._spawn_raid(volundr, saga, phase, raid, tpl_raid)
+        volundr = await self._volundr_factory.primary_for_owner(self._owner_id)
+        if volundr is None:
+            logger.error(
+                "EventTriggerAdapter: no Volundr adapter for owner %s, cannot dispatch phase '%s'",
+                self._owner_id,
+                phase.name,
+            )
+            return
+
+        for raid, tpl_raid in zip(raids, tpl_phase.raids):
+            await self._spawn_raid(volundr, saga, phase, raid, tpl_raid)
+
+    async def advance_phase(self, saga_id: str) -> None:
+        """Advance to the next PENDING phase for *saga_id*.
+
+        Called after all raids in the current active phase have completed.
+        Retrieves the next PENDING phase from the in-memory tracking dict and
+        either dispatches its raids or gates it for human approval.
+
+        If the saga is not tracked (e.g. after an adapter restart) this is a
+        no-op.
+        """
+        phases = self._saga_phases.get(saga_id)
+        if not phases:
+            logger.debug(
+                "EventTriggerAdapter.advance_phase: saga %s not tracked in memory, skipping",
+                saga_id,
+            )
+            return
+
+        saga = await self._saga_repo.get_saga(
+            next(
+                (phase.saga_id for phase, _, _ in phases),
+                None,  # type: ignore[arg-type]
+            )
+        )
+        if saga is None:
+            return
+
+        # Find the first PENDING phase.
+        next_phase_info = next(
+            (
+                (phase, raids, tpl)
+                for phase, raids, tpl in phases
+                if phase.status == PhaseStatus.PENDING
+            ),
+            None,
+        )
+        if next_phase_info is None:
+            logger.debug(
+                "EventTriggerAdapter.advance_phase: no pending phases for saga %s",
+                saga_id,
+            )
+            return
+
+        next_phase, next_raids, next_tpl = next_phase_info
+
+        # Mark as ACTIVE in memory (the activate_phase call will set GATED if needed).
+        idx = next(i for i, (p, _, _) in enumerate(phases) if p.id == next_phase.id)
+        activated = Phase(
+            id=next_phase.id,
+            saga_id=next_phase.saga_id,
+            tracker_id=next_phase.tracker_id,
+            number=next_phase.number,
+            name=next_phase.name,
+            status=PhaseStatus.ACTIVE,
+            confidence=next_phase.confidence,
+        )
+        phases[idx] = (activated, next_raids, next_tpl)
+
+        logger.info(
+            "EventTriggerAdapter: advancing saga %s to phase '%s' (needs_approval=%s)",
+            saga_id,
+            next_phase.name,
+            next_tpl.needs_approval,
+        )
+        await self._activate_phase(saga, activated, next_raids, next_tpl)
+
+    # ------------------------------------------------------------------
+    # Dispatch helpers
+    # ------------------------------------------------------------------
 
     async def _spawn_raid(
         self,
-        volundr: object,
+        volundr: VolundrPort,
         saga: Saga,
         phase: Phase,
         raid: Raid,
@@ -464,7 +506,7 @@ class EventTriggerAdapter:
         session_name = re.sub(r"[^a-z0-9]+", "-", raid.name.lower()).strip("-")[:48]
 
         try:
-            session = await volundr.spawn_session(  # type: ignore[union-attr]
+            session = await volundr.spawn_session(
                 request=SpawnRequest(
                     name=session_name,
                     repo=repo,
@@ -475,6 +517,7 @@ class EventTriggerAdapter:
                     tracker_issue_url="",
                     system_prompt="",
                     initial_prompt=tpl_raid.prompt,
+                    profile=tpl_raid.persona or None,
                     integration_ids=[],
                 ),
             )
@@ -515,9 +558,10 @@ class EventTriggerAdapter:
                 )
             )
             logger.info(
-                "EventTriggerAdapter: dispatched raid %s → session %s",
+                "EventTriggerAdapter: dispatched raid %s → session %s (persona=%s)",
                 raid.name,
                 session.id,
+                tpl_raid.persona or "(none)",
             )
         except Exception:
             logger.exception("EventTriggerAdapter: failed to spawn session for raid %s", raid.name)
@@ -525,10 +569,10 @@ class EventTriggerAdapter:
     async def _emit_needs_approval(
         self,
         saga: Saga,
-        phases: list[tuple[Phase, list[Raid]]],
+        phases: list[tuple[Phase, list[Raid], TemplatePhase]],
     ) -> None:
         """Emit tyr.raid.needs_approval events for all PENDING raids."""
-        for _phase, raids in phases:
+        for _phase, raids, _tpl in phases:
             for raid in raids:
                 await self._event_bus.emit(
                     TyrEvent(
@@ -581,7 +625,7 @@ def build_event_trigger_adapter(
         for r in cfg.rules
     ]
 
-    templates_dir = Path(cfg.templates_dir) if cfg.templates_dir else _BUNDLED_TEMPLATES_DIR
+    templates_dir = Path(cfg.templates_dir) if cfg.templates_dir else BUNDLED_TEMPLATES_DIR
 
     return EventTriggerAdapter(
         subscriber=subscriber,

--- a/src/tyr/adapters/postgres_sagas.py
+++ b/src/tyr/adapters/postgres_sagas.py
@@ -33,7 +33,7 @@ class PostgresSagaRepository(SagaRepository):
             """
             INSERT INTO phases (id, saga_id, tracker_id, number, name, status, confidence)
             VALUES ($1, $2, $3, $4, $5, $6, $7)
-            ON CONFLICT (id) DO NOTHING
+            ON CONFLICT (id) DO UPDATE SET status = EXCLUDED.status
             """,
             phase.id,
             phase.saga_id,

--- a/src/tyr/api/tracker.py
+++ b/src/tyr/api/tracker.py
@@ -8,7 +8,6 @@ via a FastAPI dependency. Supports multiple trackers in parallel.
 from __future__ import annotations
 
 import logging
-import re
 from datetime import UTC, datetime
 from uuid import uuid4
 
@@ -18,17 +17,11 @@ from pydantic import BaseModel, Field
 from niuu.domain.models import Principal
 from tyr.adapters.inbound.auth import extract_principal
 from tyr.domain.models import Saga, SagaStatus, TrackerIssue, TrackerMilestone, TrackerProject
+from tyr.domain.utils import _slugify
 from tyr.ports.saga_repository import SagaRepository
 from tyr.ports.tracker import TrackerPort
 
 logger = logging.getLogger(__name__)
-
-
-def _slugify(name: str) -> str:
-    """Convert a project name to a clean slug for branch names."""
-    slug = name.lower()
-    slug = re.sub(r"[^a-z0-9]+", "-", slug)
-    return slug.strip("-")
 
 
 # ---------------------------------------------------------------------------

--- a/src/tyr/domain/services/dispatch_service.py
+++ b/src/tyr/domain/services/dispatch_service.py
@@ -21,7 +21,6 @@ try:
 except ImportError:
     _catalog_saga_completed = None  # type: ignore[assignment]
 
-from tyr.api.tracker import _slugify
 from tyr.domain.models import (
     Phase,
     PhaseStatus,
@@ -32,7 +31,8 @@ from tyr.domain.models import (
     TrackerIssue,
     TrackerProject,
 )
-from tyr.domain.templates import BUNDLED_TEMPLATES_DIR, load_template
+from tyr.domain.templates import BUNDLED_TEMPLATES_DIR, TemplatePhase, load_template
+from tyr.domain.utils import _slugify
 from tyr.ports.dispatcher_repository import DispatcherRepository
 from tyr.ports.event_bus import EventBusPort, TyrEvent
 from tyr.ports.saga_repository import SagaRepository
@@ -523,7 +523,7 @@ class DispatchService:
         saga: Saga,
         phase: Phase,
         raids: list[Raid],
-        tpl_phase: object,
+        tpl_phase: TemplatePhase,
         owner_id: str,
     ) -> None:
         """Spawn Volundr sessions for all raids in a template phase."""
@@ -537,7 +537,7 @@ class DispatchService:
             return
 
         repo = saga.repos[0] if saga.repos else ""
-        for raid, tpl_raid in zip(raids, tpl_phase.raids):  # type: ignore[union-attr]
+        for raid, tpl_raid in zip(raids, tpl_phase.raids):
             session_name = re.sub(r"[^a-z0-9]+", "-", raid.name.lower()).strip("-")[:48]
             try:
                 session = await volundr.spawn_session(

--- a/src/tyr/domain/services/dispatch_service.py
+++ b/src/tyr/domain/services/dispatch_service.py
@@ -8,17 +8,33 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import string
+import uuid
 from collections import defaultdict
 from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
 
 try:
     from sleipnir.domain.catalog import tyr_saga_completed as _catalog_saga_completed
 except ImportError:
     _catalog_saga_completed = None  # type: ignore[assignment]
 
-from tyr.domain.models import RaidStatus, Saga, SagaStatus, TrackerIssue, TrackerProject
+from tyr.api.tracker import _slugify
+from tyr.domain.models import (
+    Phase,
+    PhaseStatus,
+    Raid,
+    RaidStatus,
+    Saga,
+    SagaStatus,
+    TrackerIssue,
+    TrackerProject,
+)
+from tyr.domain.templates import BUNDLED_TEMPLATES_DIR, load_template
 from tyr.ports.dispatcher_repository import DispatcherRepository
+from tyr.ports.event_bus import EventBusPort, TyrEvent
 from tyr.ports.saga_repository import SagaRepository
 from tyr.ports.tracker import TrackerFactory, TrackerPort
 from tyr.ports.volundr import SpawnRequest, VolundrFactory, VolundrPort
@@ -167,6 +183,8 @@ class DispatchConfig:
     default_model: str = "claude-sonnet-4-6"
     dispatch_prompt_template: str = ""
     max_cached_issues: int = 10_000
+    templates_dir: Path = BUNDLED_TEMPLATES_DIR
+    initial_confidence: float = 0.5
 
 
 class DispatchService:
@@ -184,6 +202,7 @@ class DispatchService:
         dispatcher_repo: DispatcherRepository,
         config: DispatchConfig,
         sleipnir_publisher: object | None = None,
+        event_bus: EventBusPort | None = None,
     ) -> None:
         self._tracker_factory = tracker_factory
         self._volundr_factory = volundr_factory
@@ -192,6 +211,7 @@ class DispatchService:
         self._config = config
         self._locks: defaultdict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
         self._sleipnir_publisher = sleipnir_publisher
+        self._event_bus = event_bus
 
     async def find_ready_issues(
         self,
@@ -381,6 +401,191 @@ class DispatchService:
                 saga_tracker_id,
             )
             return results
+
+    async def create_saga_from_template(
+        self,
+        template_name: str,
+        payload: dict,
+        owner_id: str,
+        *,
+        auto_start: bool = True,
+    ) -> str:
+        """Create a saga from a YAML template and dispatch Phase 1.
+
+        Loads the named template, substitutes ``{event.*}`` placeholders from
+        *payload*, persists the saga + phases + raids, and — when
+        *auto_start* is True — spawns Volundr sessions for all raids in the
+        first phase.
+
+        :param template_name: Template name without extension (e.g. ``"ship"``).
+        :param payload: Key/value pairs substituted into ``{event.field}`` placeholders.
+        :param owner_id: Owner for the created saga.
+        :param auto_start: Dispatch Phase 1 raids immediately when True.
+        :returns: The new saga ID as a string.
+        :raises FileNotFoundError: When the template cannot be found.
+        :raises ValueError: When the template fails validation.
+        """
+        template = load_template(template_name, self._config.templates_dir, payload)
+
+        now = datetime.now(UTC)
+        saga_id = uuid.uuid4()
+        slug = _slugify(template.name)[:60]
+
+        saga = Saga(
+            id=saga_id,
+            tracker_id=str(saga_id),
+            tracker_type="native",
+            slug=slug,
+            name=template.name,
+            repos=template.repos,
+            feature_branch=template.feature_branch,
+            base_branch=template.base_branch,
+            status=SagaStatus.ACTIVE,
+            confidence=self._config.initial_confidence,
+            created_at=now,
+            owner_id=owner_id,
+        )
+        await self._saga_repo.save_saga(saga)
+
+        phases_data = []
+        for phase_num, tpl_phase in enumerate(template.phases, start=1):
+            phase_status = PhaseStatus.ACTIVE if phase_num == 1 else PhaseStatus.PENDING
+            phase_id = uuid.uuid4()
+            phase = Phase(
+                id=phase_id,
+                saga_id=saga_id,
+                tracker_id=str(phase_id),
+                number=phase_num,
+                name=tpl_phase.name,
+                status=phase_status,
+                confidence=self._config.initial_confidence,
+            )
+            await self._saga_repo.save_phase(phase)
+
+            raids: list[Raid] = []
+            for tpl_raid in tpl_phase.raids:
+                raid_id = uuid.uuid4()
+                raid = Raid(
+                    id=raid_id,
+                    phase_id=phase_id,
+                    tracker_id=str(raid_id),
+                    name=tpl_raid.name,
+                    description=tpl_raid.description,
+                    acceptance_criteria=tpl_raid.acceptance_criteria,
+                    declared_files=tpl_raid.declared_files,
+                    estimate_hours=tpl_raid.estimate_hours,
+                    status=RaidStatus.PENDING,
+                    confidence=self._config.initial_confidence,
+                    session_id=None,
+                    branch=None,
+                    chronicle_summary=None,
+                    pr_url=None,
+                    pr_id=None,
+                    retry_count=0,
+                    created_at=now,
+                    updated_at=now,
+                )
+                await self._saga_repo.save_raid(raid)
+                raids.append(raid)
+            phases_data.append((phase, raids, tpl_phase))
+
+        if self._event_bus is not None:
+            await self._event_bus.emit(
+                TyrEvent(
+                    event="saga.created",
+                    data={
+                        "saga_id": str(saga_id),
+                        "saga_name": saga.name,
+                        "slug": slug,
+                        "template": template_name,
+                        "auto_start": auto_start,
+                        "owner_id": owner_id,
+                    },
+                    owner_id=owner_id,
+                )
+            )
+
+        logger.info(
+            "DispatchService: created saga %s from template '%s' (phases=%d)",
+            slug,
+            template_name,
+            len(template.phases),
+        )
+
+        if auto_start and phases_data:
+            first_phase, first_raids, first_tpl = phases_data[0]
+            await self._dispatch_template_phase(saga, first_phase, first_raids, first_tpl, owner_id)
+
+        return str(saga_id)
+
+    async def _dispatch_template_phase(
+        self,
+        saga: Saga,
+        phase: Phase,
+        raids: list[Raid],
+        tpl_phase: object,
+        owner_id: str,
+    ) -> None:
+        """Spawn Volundr sessions for all raids in a template phase."""
+        volundr = await self._volundr_factory.primary_for_owner(owner_id)
+        if volundr is None:
+            logger.error(
+                "DispatchService: no Volundr adapter for owner %s, cannot dispatch phase '%s'",
+                owner_id,
+                phase.name,
+            )
+            return
+
+        repo = saga.repos[0] if saga.repos else ""
+        for raid, tpl_raid in zip(raids, tpl_phase.raids):  # type: ignore[union-attr]
+            session_name = re.sub(r"[^a-z0-9]+", "-", raid.name.lower()).strip("-")[:48]
+            try:
+                session = await volundr.spawn_session(
+                    request=SpawnRequest(
+                        name=session_name,
+                        repo=repo,
+                        branch=saga.feature_branch,
+                        base_branch=saga.base_branch,
+                        model=self._config.default_model,
+                        tracker_issue_id=raid.tracker_id,
+                        tracker_issue_url="",
+                        system_prompt=self._config.default_system_prompt,
+                        initial_prompt=tpl_raid.prompt,
+                        profile=tpl_raid.persona or None,
+                        integration_ids=[],
+                    ),
+                )
+                updated = Raid(
+                    id=raid.id,
+                    phase_id=raid.phase_id,
+                    tracker_id=raid.tracker_id,
+                    name=raid.name,
+                    description=raid.description,
+                    acceptance_criteria=raid.acceptance_criteria,
+                    declared_files=raid.declared_files,
+                    estimate_hours=raid.estimate_hours,
+                    status=RaidStatus.RUNNING,
+                    confidence=raid.confidence,
+                    session_id=session.id,
+                    branch=raid.branch,
+                    chronicle_summary=raid.chronicle_summary,
+                    pr_url=raid.pr_url,
+                    pr_id=raid.pr_id,
+                    retry_count=raid.retry_count,
+                    created_at=raid.created_at,
+                    updated_at=datetime.now(UTC),
+                )
+                await self._saga_repo.save_raid(updated)
+                logger.info(
+                    "DispatchService: dispatched template raid %s → session %s (persona=%s)",
+                    raid.name,
+                    session.id,
+                    tpl_raid.persona or "(none)",
+                )
+            except Exception:
+                logger.exception(
+                    "DispatchService: failed to spawn session for template raid %s", raid.name
+                )
 
     # -------------------------------------------------------------------
     # Private helpers

--- a/src/tyr/domain/templates.py
+++ b/src/tyr/domain/templates.py
@@ -1,0 +1,225 @@
+"""Saga template dataclasses and YAML loader.
+
+Templates describe predefined saga workflows as YAML files.  The loader
+parses a template, substitutes ``{event.field}`` placeholders, validates the
+structure, and returns a :class:`SagaTemplate` ready for execution.
+
+Template format (YAML)::
+
+    name: "Review: {event.repo}#{event.pr_number}"
+    feature_branch: "{event.branch}"
+    base_branch: "{event.base_branch}"
+    repos:
+      - "{event.repo}"
+    phases:
+      - name: Code Review
+        raids:
+          - name: "Review PR #{event.pr_number}"
+            description: "..."
+            acceptance_criteria:
+              - "All files reviewed"
+            declared_files: []
+            estimate_hours: 1.0
+            persona: reviewer
+            prompt: |
+              ...
+      - name: Human Approval
+        needs_approval: true
+        raids:
+          - name: "Approve PR #{event.pr_number}"
+            description: "Human sign-off gate."
+            acceptance_criteria: []
+            declared_files: []
+            estimate_hours: 0.0
+            persona: ""
+            prompt: ""
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# Regex matching {event.field_name} placeholders in template strings.
+_EVENT_PLACEHOLDER_RE = re.compile(r"\{event\.([^}]+)\}")
+
+
+# ---------------------------------------------------------------------------
+# Template data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TemplateRaid:
+    """A single raid within a template phase."""
+
+    name: str
+    description: str
+    acceptance_criteria: list[str]
+    declared_files: list[str]
+    estimate_hours: float
+    prompt: str
+    persona: str = ""
+
+
+@dataclass(frozen=True)
+class TemplatePhase:
+    """A phase within a saga template."""
+
+    name: str
+    raids: list[TemplateRaid]
+    needs_approval: bool = False
+
+
+@dataclass(frozen=True)
+class SagaTemplate:
+    """A fully-loaded and interpolated saga template."""
+
+    name: str
+    feature_branch: str
+    base_branch: str
+    repos: list[str]
+    phases: list[TemplatePhase]
+
+
+# ---------------------------------------------------------------------------
+# Interpolation
+# ---------------------------------------------------------------------------
+
+
+def _interpolate(text: str, payload: dict) -> str:
+    """Replace ``{event.field}`` placeholders with values from *payload*.
+
+    Unknown fields are left as-is so templates remain renderable even when
+    some payload keys are absent.
+    """
+
+    def _replace(m: re.Match) -> str:
+        key = m.group(1)
+        value = payload.get(key)
+        if value is None:
+            return m.group(0)
+        return str(value)
+
+    return _EVENT_PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _interpolate_value(value: Any, payload: dict) -> Any:
+    """Recursively interpolate ``{event.*}`` placeholders in parsed YAML data.
+
+    Operates on already-parsed Python objects (dicts, lists, strings) so that
+    payload values containing YAML metacharacters cannot alter the document
+    structure.
+    """
+    if isinstance(value, str):
+        return _interpolate(value, payload)
+    if isinstance(value, dict):
+        return {k: _interpolate_value(v, payload) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_interpolate_value(item, payload) for item in value]
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_template(data: dict) -> None:
+    """Validate parsed (and interpolated) template data.
+
+    :raises ValueError: When mandatory fields are missing or the template
+        structure is invalid.
+    """
+    if not data.get("name"):
+        raise ValueError("Template is missing required field 'name'")
+
+    phases = data.get("phases", [])
+    for phase_idx, phase in enumerate(phases):
+        phase_name = phase.get("name") or f"phase[{phase_idx}]"
+        if not phase.get("name"):
+            raise ValueError(f"Phase at index {phase_idx} is missing required field 'name'")
+        raids = phase.get("raids", [])
+        if not raids:
+            raise ValueError(
+                f"Phase '{phase_name}' has no raids — every phase must have at least one raid"
+            )
+        for raid_idx, raid in enumerate(raids):
+            raid_name = raid.get("name") or f"raid[{raid_idx}]"
+            if not raid.get("name"):
+                raise ValueError(
+                    f"Raid at index {raid_idx} in phase '{phase_name}'"
+                    " is missing required field 'name'"
+                )
+            if not raid.get("persona"):
+                raise ValueError(
+                    f"Raid '{raid_name}' in phase '{phase_name}'"
+                    " is missing required field 'persona'"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Loader
+# ---------------------------------------------------------------------------
+
+# Path to bundled templates shipped with the package.
+BUNDLED_TEMPLATES_DIR = Path(__file__).parent.parent / "templates"
+
+
+def load_template(name: str, templates_dir: Path, payload: dict) -> SagaTemplate:
+    """Load and interpolate a YAML saga template.
+
+    :param name: Template name without extension (e.g. ``"review"``).
+    :param templates_dir: Directory to search first; falls back to bundled dir.
+    :param payload: Sleipnir event payload used for ``{event.*}`` substitution.
+    :raises FileNotFoundError: When the template cannot be found.
+    :raises ValueError: When the template fails validation.
+    """
+    candidates = [
+        templates_dir / f"{name}.yaml",
+        BUNDLED_TEMPLATES_DIR / f"{name}.yaml",
+    ]
+    path = next((p for p in candidates if p.exists()), None)
+    if path is None:
+        raise FileNotFoundError(
+            f"Saga template {name!r} not found in {templates_dir} or bundled templates"
+        )
+
+    raw = path.read_text(encoding="utf-8")
+    # Parse YAML first, then interpolate — prevents payload values with YAML
+    # metacharacters from altering the document structure.
+    data = _interpolate_value(yaml.safe_load(raw), payload)
+
+    _validate_template(data)
+
+    phases = [
+        TemplatePhase(
+            name=p["name"],
+            needs_approval=bool(p.get("needs_approval", False)),
+            raids=[
+                TemplateRaid(
+                    name=r["name"],
+                    description=r.get("description", ""),
+                    acceptance_criteria=r.get("acceptance_criteria", []),
+                    declared_files=r.get("declared_files", []),
+                    estimate_hours=float(r.get("estimate_hours", 2.0)),
+                    prompt=r.get("prompt", ""),
+                    persona=r.get("persona", ""),
+                )
+                for r in p.get("raids", [])
+            ],
+        )
+        for p in data.get("phases", [])
+    ]
+
+    return SagaTemplate(
+        name=data["name"],
+        feature_branch=data.get("feature_branch", "main"),
+        base_branch=data.get("base_branch", "main"),
+        repos=data.get("repos", []),
+        phases=phases,
+    )

--- a/src/tyr/domain/utils.py
+++ b/src/tyr/domain/utils.py
@@ -1,0 +1,12 @@
+"""Shared pure utility functions for the Tyr domain layer."""
+
+from __future__ import annotations
+
+import re
+
+
+def _slugify(name: str) -> str:
+    """Convert a name to a clean slug for branch names and identifiers."""
+    slug = name.lower()
+    slug = re.sub(r"[^a-z0-9]+", "-", slug)
+    return slug.strip("-")

--- a/src/tyr/ports/saga_repository.py
+++ b/src/tyr/ports/saga_repository.py
@@ -13,7 +13,7 @@ from contextlib import asynccontextmanager
 from typing import Any
 from uuid import UUID
 
-from tyr.domain.models import Phase, Raid, Saga, SagaStatus
+from tyr.domain.models import Phase, PhaseStatus, Raid, Saga, SagaStatus
 
 
 class SagaRepository(ABC):
@@ -26,7 +26,7 @@ class SagaRepository(ABC):
 
     @abstractmethod
     async def save_phase(self, phase: Phase, *, conn: Any | None = None) -> None:
-        """Persist a phase. Uses *conn* when inside a transaction."""
+        """Persist a phase (insert-or-update). Uses *conn* when inside a transaction."""
         ...
 
     @abstractmethod

--- a/src/tyr/ports/saga_repository.py
+++ b/src/tyr/ports/saga_repository.py
@@ -13,7 +13,7 @@ from contextlib import asynccontextmanager
 from typing import Any
 from uuid import UUID
 
-from tyr.domain.models import Phase, PhaseStatus, Raid, Saga, SagaStatus
+from tyr.domain.models import Phase, Raid, Saga, SagaStatus
 
 
 class SagaRepository(ABC):

--- a/src/tyr/templates/deploy.yaml
+++ b/src/tyr/templates/deploy.yaml
@@ -1,43 +1,124 @@
 # Saga template: deploy
 # Triggered by: github.pr.merged (filter: branch=main)
-# Creates a deployment verification saga after a merge to main.
+# Creates a 3-phase deployment saga after a merge to main.
+# Phase 1: Smoke test against staging (persona: qa-agent)
+# Phase 2: Monitor health endpoint for 10 minutes (persona: qa-agent)
+# Phase 3: Document release in Mimir (persona: retro-analyst)
 name: "Deploy: {event.repo}@{event.sha_short}"
 feature_branch: "main"
 base_branch: "main"
 repos:
   - "{event.repo}"
 phases:
-  - name: Deploy
+  - name: Smoke Test
     raids:
-      - name: "Verify deployment of {event.sha_short}"
+      - name: "Smoke test after deploying {event.sha_short}"
         description: |
-          Verify the deployment triggered by merging {event.title} into main.
+          Run smoke tests against the staging/production environment after deploying the merge of {event.title} into main.
 
           Repository: {event.repo}
           Commit: {event.sha}
           Merged PR: {event.pr_url}
           Author: {event.author}
         acceptance_criteria:
-          - Deployment succeeded without errors
-          - All health checks pass post-deployment
-          - No regressions introduced by the merged changes
+          - Deployment pipeline succeeded without errors
+          - All health check endpoints return 200 OK
+          - Critical user flows respond correctly (no 5xx errors)
+          - No error spikes in logs within 2 minutes of deployment
         declared_files: []
-        estimate_hours: 0.5
+        estimate_hours: 0.25
+        persona: qa-agent
         prompt: |
-          # Deployment Verification Task
+          # Smoke Test Task
 
-          A PR was merged to main — please verify the deployment succeeded.
+          Verify the deployment triggered by merging {event.title} into main.
 
           **Repository**: {event.repo}
           **Commit**: {event.sha}
           **PR**: {event.pr_url}
-          **Title**: {event.title}
 
           ## Instructions
 
-          1. Check the CI/CD pipeline status for this commit.
-          2. Verify all health checks pass.
-          3. Look for any error reports or regression signals.
-          4. If the deployment failed, open an incident issue and escalate.
+          1. Check CI/CD pipeline status for this commit:
+             `gh run list --repo {event.repo} --commit {event.sha} --limit 5`
+          2. Verify the deployment step succeeded (look for deploy job status).
+          3. Hit the health endpoint and verify 200 OK.
+          4. Check application logs for error spikes in the 2 minutes post-deploy.
+          5. Run a quick smoke test of critical endpoints.
 
-          Report your findings in a summary.
+          If deployment failed, open an incident issue immediately and escalate.
+
+          Report: PASS (deployment healthy) or FAIL (with details).
+
+  - name: Monitor
+    raids:
+      - name: "Monitor health for {event.repo}@{event.sha_short}"
+        description: |
+          Monitor the health endpoint and error rates for 10 minutes following the deployment of {event.sha_short} to {event.repo}.
+
+          Commit: {event.sha}
+          PR: {event.pr_url}
+        acceptance_criteria:
+          - Health endpoint returns 200 OK throughout the monitoring window
+          - Error rate does not exceed baseline by more than 5%
+          - No critical alerts fired during the monitoring window
+          - P95 response time remains within acceptable bounds
+        declared_files: []
+        estimate_hours: 0.25
+        persona: qa-agent
+        prompt: |
+          # Health Monitoring Task
+
+          Monitor the deployment of {event.sha_short} to {event.repo} for 10 minutes.
+
+          **Commit**: {event.sha}
+          **PR**: {event.pr_url}
+
+          ## Instructions
+
+          1. Poll the health endpoint every 60 seconds for 10 minutes (10 checks).
+          2. After each check, record: status code, response time, timestamp.
+          3. Watch for any alerting or error-rate anomalies.
+          4. After 10 minutes, summarise: all-green, degraded, or incident.
+
+          If any check fails, stop polling and escalate immediately.
+
+          Report a summary table of all 10 health checks with timestamps.
+
+  - name: Release Documentation
+    raids:
+      - name: "Document release {event.sha_short} in Mimir"
+        description: |
+          Write structured release notes to Mimir for the deployment of {event.sha_short} to {event.repo}.
+
+          PR: {event.pr_url}
+          Author: {event.author}
+        acceptance_criteria:
+          - Release notes written to Mimir with correct metadata (repo, sha, date)
+          - Changes summary extracted from PR description and commits
+          - Deployment health outcome recorded (smoke test + monitor results)
+          - Searchable by repo, sha, and date in Mimir
+        declared_files: []
+        estimate_hours: 0.25
+        persona: retro-analyst
+        prompt: |
+          # Release Documentation Task
+
+          Write release notes for the deployment of {event.sha_short} to {event.repo}.
+
+          **Repository**: {event.repo}
+          **Commit**: {event.sha}
+          **PR**: {event.pr_url}
+          **Author**: {event.author}
+
+          ## Instructions
+
+          1. Read the PR description: `gh pr view {event.pr_url} --json body,title,commits`
+          2. Summarise the changes (features, fixes, breaking changes).
+          3. Note the deployment outcome from the previous monitoring phase.
+          4. Write structured release notes to Mimir:
+             - Title: `Release {event.repo}@{event.sha_short} — {event.title}`
+             - Sections: Summary, Changes, Deployment Health, Rollback Steps
+          5. Tag the entry with: repo={event.repo}, sha={event.sha}, type=release
+
+          Output the Mimir entry content before writing it.

--- a/src/tyr/templates/investigate.yaml
+++ b/src/tyr/templates/investigate.yaml
@@ -28,6 +28,7 @@ phases:
           - PR created and CI passing
         declared_files: []
         estimate_hours: 2.0
+        persona: qa-agent
         prompt: |
           # Bug Investigation Task
 

--- a/src/tyr/templates/reflect.yaml
+++ b/src/tyr/templates/reflect.yaml
@@ -24,6 +24,7 @@ phases:
           - Any patterns worth remembering are captured
         declared_files: []
         estimate_hours: 0.5
+        persona: retro-analyst
         prompt: |
           # Post-Session Reflection Task
 

--- a/src/tyr/templates/retro.yaml
+++ b/src/tyr/templates/retro.yaml
@@ -1,0 +1,82 @@
+# Saga template: retro
+# Triggered by: cron.weekly (0 9 * * 1 — Monday 9am)
+# Creates a 2-phase weekly retrospective saga.
+# Phase 1: Retrospective analysis (persona: retro-analyst)
+# Phase 2: Write retrospective to Mimir (persona: retro-analyst)
+name: "Weekly Retro: {event.week}"
+feature_branch: "main"
+base_branch: "main"
+repos: []
+phases:
+  - name: Retrospective Analysis
+    raids:
+      - name: "Retrospective analysis for week {event.week}"
+        description: |
+          Analyse the past week's engineering activity, identify patterns, blockers, and learnings.
+
+          Week: {event.week}
+        acceptance_criteria:
+          - Git commit history for the week reviewed
+          - Open PRs and recently merged PRs reviewed
+          - Blockers and incidents identified and documented
+          - Key learnings and patterns extracted
+          - Action items for the coming week drafted
+        declared_files: []
+        estimate_hours: 1.0
+        persona: retro-analyst
+        prompt: |
+          # Weekly Retrospective Analysis Task
+
+          Perform a retrospective for week {event.week}.
+
+          ## Instructions
+
+          1. Review git activity for the past week:
+             `git log --since="7 days ago" --oneline --all`
+          2. Check open and recently merged PRs:
+             `gh pr list --state all --limit 20`
+          3. Review any Linear tickets closed or moved this week.
+          4. Identify:
+             - What went well (wins, smooth deliveries)
+             - What was blocked or slowed (friction points)
+             - Surprises or incidents
+             - Patterns worth capturing as learnings
+          5. Draft 3–5 action items for the coming week.
+
+          Output a structured retro document with sections:
+          - Wins
+          - Friction Points
+          - Surprises / Incidents
+          - Learnings
+          - Action Items
+
+  - name: Write to Mimir
+    raids:
+      - name: "Write retro for week {event.week} to Mimir"
+        description: |
+          Write the completed retrospective for week {event.week} to Mimir for long-term storage and searchability.
+        acceptance_criteria:
+          - Retrospective written to Mimir with correct metadata (week, date, team)
+          - Structured sections: Wins, Friction Points, Surprises, Learnings, Action Items
+          - Searchable by week and date in Mimir
+          - Action items tagged for follow-up
+        declared_files: []
+        estimate_hours: 0.25
+        persona: retro-analyst
+        prompt: |
+          # Write Retrospective to Mimir Task
+
+          Write the weekly retrospective for week {event.week} to Mimir.
+
+          ## Instructions
+
+          1. Read the retrospective analysis from the previous phase output.
+          2. Format it as a structured Mimir entry:
+             - Title: `Weekly Retro — {event.week}`
+             - Tags: week={event.week}, type=retro, team=engineering
+             - Sections: Wins, Friction Points, Surprises/Incidents, Learnings, Action Items
+          3. Write to Mimir using the available Mimir tool.
+          4. Verify the entry is searchable: search Mimir for "retro week:{event.week}".
+          5. Create follow-up tasks for each action item if a task tracker is configured.
+
+          Confirm the Mimir entry URL or ID after writing.

--- a/src/tyr/templates/review.yaml
+++ b/src/tyr/templates/review.yaml
@@ -1,17 +1,21 @@
 # Saga template: review
 # Triggered by: github.pr.opened
-# Creates a code review saga for an open pull request.
+# Creates a 4-phase code-review saga for an open pull request.
+# Phase 1: Code review  (persona: reviewer)
+# Phase 2: Security audit (persona: security-auditor)
+# Phase 3: QA test run  (persona: qa-agent)
+# Phase 4: Human approval gate (needs_approval: true)
 name: "Review: {event.repo}#{event.pr_number}"
 feature_branch: "{event.branch}"
 base_branch: "{event.base_branch}"
 repos:
   - "{event.repo}"
 phases:
-  - name: Review
+  - name: Code Review
     raids:
-      - name: "Review PR #{event.pr_number}"
+      - name: "Code review for PR #{event.pr_number}"
         description: |
-          Review the pull request opened against {event.repo}.
+          Review code quality, conventions, and architecture for PR #{event.pr_number} in {event.repo}.
 
           PR URL: {event.pr_url}
           Author: {event.author}
@@ -21,10 +25,11 @@ phases:
           - All changed files have been read and understood
           - Code follows project conventions (CLAUDE.md and .claude/rules/)
           - Tests are present and coverage meets the 85% threshold
-          - CI is passing on the PR
-          - All review findings have been addressed or acknowledged
+          - Architecture boundaries are respected (no layer violations)
+          - Review findings addressed or acknowledged
         declared_files: []
         estimate_hours: 1.0
+        persona: reviewer
         prompt: |
           # Code Review Task
 
@@ -43,11 +48,120 @@ phases:
           3. Read every changed file (not just the diff lines) to understand context.
           4. Check CI status: `gh pr checks {event.pr_number} --repo {event.repo}`
           5. Verify all acceptance criteria are met.
-          6. If changes are needed, push fixes; otherwise approve and merge.
+          6. If changes are needed, push fixes; otherwise note findings for escalation.
 
-          ## Completion
+          Report your findings clearly, including file:line references.
 
-          When satisfied, merge the PR:
+  - name: Security Audit
+    raids:
+      - name: "Security audit for PR #{event.pr_number}"
+        description: |
+          Perform a security review of the changes in PR #{event.pr_number} ({event.repo}).
+
+          PR URL: {event.pr_url}
+          Branch: {event.branch}
+        acceptance_criteria:
+          - OWASP Top 10 vulnerabilities checked (injection, XSS, auth bypass, etc.)
+          - No secrets, tokens, or credentials hardcoded in changed files
+          - Input validation present at system boundaries
+          - No unsafe deserialization or unsafe direct object references
+          - Dependencies introduced have no known critical CVEs
+        declared_files: []
+        estimate_hours: 0.5
+        persona: security-auditor
+        prompt: |
+          # Security Audit Task
+
+          Perform a security review of PR #{event.pr_number} in {event.repo}.
+
+          **PR**: {event.pr_url}
+          **Branch**: {event.branch}
+
+          ## Instructions
+
+          1. Fetch the PR diff: `gh pr diff {event.pr_number} --repo {event.repo}`
+          2. Check for OWASP Top 10 issues (injection, XSS, CSRF, insecure direct object refs, etc.).
+          3. Search for hardcoded secrets, API keys, or passwords in changed files.
+          4. Verify input validation at system boundaries (API endpoints, user input handlers).
+          5. Review any new dependencies for known CVEs.
+          6. Document all findings with severity (CRITICAL / HIGH / MEDIUM / LOW).
+
+          Report findings with file:line references and suggested fixes.
+
+  - name: QA Test Run
+    raids:
+      - name: "QA test run for PR #{event.pr_number}"
+        description: |
+          Run the full test suite and verify quality gates for PR #{event.pr_number} ({event.repo}).
+
+          Branch: {event.branch}
+        acceptance_criteria:
+          - All backend tests pass (pytest with zero warnings)
+          - All frontend tests pass (vitest)
+          - Coverage is at or above 85% (codecov/patch is green)
+          - No regressions introduced by the changes
+          - Linting is clean (ruff check + ruff format)
+        declared_files: []
+        estimate_hours: 0.5
+        persona: qa-agent
+        prompt: |
+          # QA Test Run Task
+
+          Run the test suite for PR #{event.pr_number} in {event.repo}.
+
+          **Branch**: {event.branch}
+
+          ## Instructions
+
+          1. Check out or verify the PR branch is current.
+          2. Run backend tests: `make test` (or `pytest -v`).
+          3. Run frontend tests: `cd web && npm run test:coverage`.
+          4. Run linting: `make verify` (ruff check + ruff format).
+          5. Check CI status: `gh pr checks {event.pr_number} --repo {event.repo}`.
+          6. Verify `codecov/patch` is green (85% coverage gate).
+
+          Report pass/fail for each suite with any failure details.
+
+  - name: Human Approval
+    needs_approval: true
+    raids:
+      - name: "Human approval gate for PR #{event.pr_number}"
+        description: |
+          All automated checks have completed for PR #{event.pr_number} ({event.repo}).
+          Awaiting human review and final approval before merging.
+
+          PR URL: {event.pr_url}
+          Branch: {event.branch} → {event.base_branch}
+        acceptance_criteria:
+          - Human reviewer has read the code review findings
+          - Human reviewer has read the security audit findings
+          - Human reviewer has confirmed all tests pass
+          - PR is approved and ready to merge
+        declared_files: []
+        estimate_hours: 0.25
+        persona: reviewer
+        prompt: |
+          # Human Approval Gate
+
+          All automated phases have completed for PR #{event.pr_number}.
+
+          **PR**: {event.pr_url}
+          **Repository**: {event.repo}
+          **Branch**: {event.branch} → {event.base_branch}
+
+          ## Summary
+
+          - Code review: complete
+          - Security audit: complete
+          - QA test run: complete
+
+          ## Instructions
+
+          Review the findings from the previous phases and either:
+          - Approve the PR if all checks pass and no blockers remain.
+          - Request changes if any blocking issues were found.
+
+          When approved, merge the PR:
           ```bash
           gh pr merge {event.pr_number} --repo {event.repo} --squash --delete-branch
           ```

--- a/src/tyr/templates/ship.yaml
+++ b/src/tyr/templates/ship.yaml
@@ -1,0 +1,144 @@
+# Saga template: ship
+# Triggered by: manual dispatch or Tyr API
+# Creates a 4-phase ship saga to test, review, version-bump, and open a release PR.
+# Phase 1: Run tests   (persona: qa-agent)
+# Phase 2: Code review (persona: reviewer)
+# Phase 3: Version bump + changelog (persona: ship-agent)
+# Phase 4: Create release PR (persona: ship-agent)
+name: "Ship: {event.repo}"
+feature_branch: "{event.branch}"
+base_branch: "{event.base_branch}"
+repos:
+  - "{event.repo}"
+phases:
+  - name: Test Suite
+    raids:
+      - name: "Run test suite for {event.repo}"
+        description: |
+          Run the full test suite for {event.repo} on branch {event.branch} to verify it is release-ready.
+        acceptance_criteria:
+          - All backend tests pass (pytest, zero warnings)
+          - All frontend tests pass (vitest)
+          - Coverage is at or above 85%
+          - Linting is clean (ruff check + ruff format)
+          - CI is green on the feature branch
+        declared_files: []
+        estimate_hours: 0.5
+        persona: qa-agent
+        prompt: |
+          # Test Suite Task
+
+          Verify that {event.repo} (branch: {event.branch}) is release-ready.
+
+          ## Instructions
+
+          1. Run backend tests: `make test` (or `pytest -v --tb=short`).
+          2. Run frontend tests: `cd web && npm run test:coverage`.
+          3. Run linting: `make verify`.
+          4. Check CI status: `gh run list --repo {event.repo} --branch {event.branch} --limit 3`.
+          5. Fix any failures before proceeding.
+
+          Report: PASS or FAIL with details of any failures.
+
+  - name: Pre-ship Code Review
+    raids:
+      - name: "Pre-ship review of {event.repo}"
+        description: |
+          Review the changes accumulated on {event.branch} since the last release of {event.repo}.
+        acceptance_criteria:
+          - All changes since last release reviewed for quality and correctness
+          - No outstanding security issues
+          - CLAUDE.md and .claude/rules/ conventions followed
+          - No unintentional breaking changes
+        declared_files: []
+        estimate_hours: 1.0
+        persona: reviewer
+        prompt: |
+          # Pre-ship Code Review Task
+
+          Review all changes on {event.branch} in {event.repo} since the last release.
+
+          ## Instructions
+
+          1. Read CLAUDE.md and `.claude/rules/` for conventions.
+          2. Identify changed commits since last tag:
+             `git log $(git describe --tags --abbrev=0)..HEAD --oneline`
+          3. Review each changed file for quality, correctness, and convention compliance.
+          4. Check for breaking changes and document them.
+          5. Flag any security concerns.
+
+          Report all findings. Block shipping if any blocking issues remain.
+
+  - name: Version Bump and Changelog
+    raids:
+      - name: "Bump version and update changelog for {event.repo}"
+        description: |
+          Determine the next version for {event.repo} following semantic versioning, update the changelog, and commit.
+        acceptance_criteria:
+          - Version bumped according to semver (MAJOR.MINOR.PATCH)
+          - CHANGELOG.md updated with all changes since last release
+          - Version bump committed to {event.branch} with a conventional commit
+          - Git tag created for the new version
+        declared_files:
+          - CHANGELOG.md
+        estimate_hours: 0.5
+        persona: ship-agent
+        prompt: |
+          # Version Bump and Changelog Task
+
+          Prepare the release of {event.repo} (branch: {event.branch}).
+
+          ## Instructions
+
+          1. Determine the current version: `git describe --tags --abbrev=0`.
+          2. Analyse commits since last tag to determine bump type:
+             - `feat:` → minor bump
+             - `fix:` → patch bump
+             - `BREAKING CHANGE` in footer → major bump
+          3. Update the version in relevant files (pyproject.toml, package.json, etc.).
+          4. Update CHANGELOG.md:
+             - Add a new section: `## [X.Y.Z] — YYYY-MM-DD`
+             - List all commits grouped by type (Features, Fixes, etc.)
+          5. Commit: `chore(release): bump version to X.Y.Z`
+          6. Create a git tag: `git tag -a vX.Y.Z -m "Release X.Y.Z"`
+          7. Push the tag: `git push origin vX.Y.Z`
+
+  - name: Create Release PR
+    raids:
+      - name: "Create release PR for {event.repo}"
+        description: |
+          Open a pull request from {event.branch} to {event.base_branch} for the release of {event.repo}.
+        acceptance_criteria:
+          - PR created from {event.branch} to {event.base_branch}
+          - PR title follows convention: "chore(release): vX.Y.Z"
+          - PR description includes full changelog for this release
+          - PR CI is green
+          - PR is ready for merge
+        declared_files: []
+        estimate_hours: 0.25
+        persona: ship-agent
+        prompt: |
+          # Create Release PR Task
+
+          Open a release pull request for {event.repo}.
+
+          **From**: {event.branch}
+          **To**: {event.base_branch}
+
+          ## Instructions
+
+          1. Ensure branch is up to date and pushed:
+             `git push origin {event.branch}`
+          2. Extract the changelog section for this release from CHANGELOG.md.
+          3. Create the PR:
+             ```bash
+             gh pr create \
+               --repo {event.repo} \
+               --head {event.branch} \
+               --base {event.base_branch} \
+               --title "chore(release): $(git describe --tags --abbrev=0)" \
+               --body "$(cat RELEASE_NOTES.md)"
+             ```
+          4. Verify CI is green: `gh pr checks --repo {event.repo}`
+
+          Report the PR URL when created.

--- a/tests/test_tyr/stubs.py
+++ b/tests/test_tyr/stubs.py
@@ -1,0 +1,142 @@
+"""Shared in-memory stubs reused across Tyr test modules."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import Any
+from uuid import UUID
+
+from tyr.domain.models import Phase, Raid, Saga, SagaStatus
+from tyr.ports.saga_repository import SagaRepository
+from tyr.ports.volundr import (
+    ActivityEvent,
+    PRStatus,
+    SpawnRequest,
+    VolundrPort,
+    VolundrSession,
+)
+
+
+class InMemorySagaRepository(SagaRepository):
+    """In-memory saga repository for tests."""
+
+    def __init__(self) -> None:
+        self.sagas: dict[UUID, Saga] = {}
+        self.phases: dict[UUID, Phase] = {}
+        self.raids: dict[UUID, Raid] = {}
+
+    async def save_saga(self, saga: Saga, *, conn: Any = None) -> None:
+        self.sagas[saga.id] = saga
+
+    async def save_phase(self, phase: Phase, *, conn: Any = None) -> None:
+        self.phases[phase.id] = phase
+
+    async def save_raid(self, raid: Raid, *, conn: Any = None) -> None:
+        self.raids[raid.id] = raid
+
+    async def list_sagas(self, *, owner_id: str | None = None) -> list[Saga]:
+        if owner_id is None:
+            return list(self.sagas.values())
+        return [s for s in self.sagas.values() if s.owner_id == owner_id]
+
+    async def get_saga(self, saga_id: UUID, *, owner_id: str | None = None) -> Saga | None:
+        return self.sagas.get(saga_id)
+
+    async def get_saga_by_slug(self, slug: str) -> Saga | None:
+        return next((s for s in self.sagas.values() if s.slug == slug), None)
+
+    async def delete_saga(self, saga_id: UUID, *, owner_id: str | None = None) -> bool:
+        return self.sagas.pop(saga_id, None) is not None
+
+    async def update_saga_status(self, saga_id: UUID, status: SagaStatus) -> None:
+        saga = self.sagas.get(saga_id)
+        if saga:
+            self.sagas[saga_id] = Saga(
+                id=saga.id,
+                tracker_id=saga.tracker_id,
+                tracker_type=saga.tracker_type,
+                slug=saga.slug,
+                name=saga.name,
+                repos=saga.repos,
+                feature_branch=saga.feature_branch,
+                base_branch=saga.base_branch,
+                status=status,
+                confidence=saga.confidence,
+                created_at=saga.created_at,
+                owner_id=saga.owner_id,
+            )
+
+    async def count_by_status(self) -> dict[str, int]:
+        return {}
+
+
+class StubVolundrPort(VolundrPort):
+    """Stub Volundr port that records spawn requests."""
+
+    def __init__(self, session_id: str = "sess-001") -> None:
+        self._session_id = session_id
+        self.spawned: list[SpawnRequest] = []
+
+    async def spawn_session(
+        self, request: SpawnRequest, *, auth_token: str | None = None
+    ) -> VolundrSession:
+        self.spawned.append(request)
+        return VolundrSession(
+            id=self._session_id,
+            name=request.name,
+            status="running",
+            tracker_issue_id=request.tracker_issue_id,
+        )
+
+    async def get_session(
+        self, session_id: str, *, auth_token: str | None = None
+    ) -> VolundrSession | None:
+        return None
+
+    async def list_sessions(self, *, auth_token: str | None = None) -> list[VolundrSession]:
+        return []
+
+    async def get_pr_status(self, session_id: str) -> PRStatus:
+        return PRStatus(exists=False, merged=False, url=None, ci_passed=False)
+
+    async def get_chronicle_summary(self, session_id: str) -> str:
+        return ""
+
+    async def send_message(
+        self, session_id: str, message: str, *, auth_token: str | None = None
+    ) -> None:
+        pass
+
+    async def stop_session(self, session_id: str, *, auth_token: str | None = None) -> None:
+        pass
+
+    async def list_integration_ids(self, *, auth_token: str | None = None) -> list[str]:
+        return []
+
+    async def list_repos(self, *, auth_token: str | None = None) -> list[dict]:
+        return []
+
+    async def get_last_assistant_message(self, session_id: str) -> str:
+        return ""
+
+    async def get_conversation(self, session_id: str) -> dict:
+        return {}
+
+    async def subscribe_activity(self) -> AsyncGenerator[ActivityEvent, None]:
+        return
+        yield  # type: ignore[misc]
+
+
+class StubVolundrFactory:
+    """Factory that always returns the same stub adapter."""
+
+    def __init__(self, volundr: VolundrPort | None = None) -> None:
+        self._volundr = volundr or StubVolundrPort()
+
+    async def for_owner(self, owner_id: str) -> list[VolundrPort]:
+        if self._volundr is None:
+            return []
+        return [self._volundr]
+
+    async def primary_for_owner(self, owner_id: str) -> VolundrPort | None:
+        return self._volundr

--- a/tests/test_tyr/test_event_trigger.py
+++ b/tests/test_tyr/test_event_trigger.py
@@ -268,8 +268,13 @@ class TestLoadTemplate:
         tpl = load_template("review", _BUNDLED_TEMPLATES_DIR, payload)
 
         assert "99" in tpl.name
-        assert len(tpl.phases) == 1
+        # review.yaml has 4 phases: Code Review, Security Audit, QA Test Run, Human Approval
+        assert len(tpl.phases) == 4
+        assert tpl.phases[0].name == "Code Review"
+        assert tpl.phases[3].name == "Human Approval"
+        assert tpl.phases[3].needs_approval is True
         assert len(tpl.phases[0].raids) == 1
+        assert tpl.phases[0].raids[0].persona == "reviewer"
 
     def test_missing_template_raises(self, tmp_path):
         with pytest.raises(FileNotFoundError):
@@ -292,6 +297,7 @@ class TestLoadTemplate:
                         acceptance_criteria: ["Done"]
                         declared_files: []
                         estimate_hours: 1.0
+                        persona: executor
                         prompt: "Do something in {event.repo}"
             """),
             encoding="utf-8",
@@ -320,7 +326,7 @@ class TestLoadTemplate:
             encoding="utf-8",
         )
         # A crafted title that would break structure if interpolated before parsing
-        malicious_title = 'legit\\ninjected_key: injected_value'
+        malicious_title = "legit\\ninjected_key: injected_value"
         tpl = load_template("safe", tmp_path, {"title": malicious_title})
         # Name should contain the raw string, no injected keys
         assert malicious_title in tpl.name
@@ -1075,7 +1081,678 @@ def _write_minimal_template(tmp_path: Path, name: str) -> None:
                       - "Task completed"
                     declared_files: []
                     estimate_hours: 1.0
+                    persona: executor
                     prompt: "Execute the task in {event.repo}"
         """),
         encoding="utf-8",
     )
+
+
+# ---------------------------------------------------------------------------
+# Template validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestTemplateValidation:
+    """Tests for load_template validation rules."""
+
+    def test_missing_raid_persona_raises(self, tmp_path):
+        (tmp_path / "bad.yaml").write_text(
+            textwrap.dedent("""\
+                name: "Bad template"
+                feature_branch: main
+                base_branch: main
+                repos: []
+                phases:
+                  - name: Phase 1
+                    raids:
+                      - name: "Raid without persona"
+                        description: "Missing persona field"
+                        acceptance_criteria: []
+                        declared_files: []
+                        estimate_hours: 1.0
+                        prompt: "Do something"
+            """),
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="persona"):
+            load_template("bad", tmp_path, {})
+
+    def test_missing_raid_name_raises(self, tmp_path):
+        (tmp_path / "bad.yaml").write_text(
+            textwrap.dedent("""\
+                name: "Bad template"
+                feature_branch: main
+                base_branch: main
+                repos: []
+                phases:
+                  - name: Phase 1
+                    raids:
+                      - description: "No name field"
+                        acceptance_criteria: []
+                        declared_files: []
+                        estimate_hours: 1.0
+                        persona: executor
+                        prompt: "Do something"
+            """),
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="name"):
+            load_template("bad", tmp_path, {})
+
+    def test_phase_without_raids_raises(self, tmp_path):
+        (tmp_path / "bad.yaml").write_text(
+            textwrap.dedent("""\
+                name: "Bad template"
+                feature_branch: main
+                base_branch: main
+                repos: []
+                phases:
+                  - name: Empty Phase
+                    raids: []
+            """),
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="no raids"):
+            load_template("bad", tmp_path, {})
+
+    def test_missing_phase_name_raises(self, tmp_path):
+        (tmp_path / "bad.yaml").write_text(
+            textwrap.dedent("""\
+                name: "Bad template"
+                feature_branch: main
+                base_branch: main
+                repos: []
+                phases:
+                  - raids:
+                      - name: "Raid"
+                        persona: executor
+                        prompt: "Do"
+                        acceptance_criteria: []
+                        declared_files: []
+                        estimate_hours: 1.0
+            """),
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="name"):
+            load_template("bad", tmp_path, {})
+
+    def test_empty_phases_list_passes_validation(self, tmp_path):
+        (tmp_path / "ok.yaml").write_text(
+            textwrap.dedent("""\
+                name: "Empty saga"
+                feature_branch: main
+                base_branch: main
+                repos: []
+                phases: []
+            """),
+            encoding="utf-8",
+        )
+        tpl = load_template("ok", tmp_path, {})
+        assert tpl.phases == []
+
+    def test_valid_template_with_needs_approval_loads(self, tmp_path):
+        (tmp_path / "gated.yaml").write_text(
+            textwrap.dedent("""\
+                name: "Gated saga"
+                feature_branch: main
+                base_branch: main
+                repos: []
+                phases:
+                  - name: Work
+                    raids:
+                      - name: "Do work"
+                        persona: worker
+                        prompt: "Work hard"
+                        acceptance_criteria: ["Done"]
+                        declared_files: []
+                        estimate_hours: 1.0
+                  - name: Gate
+                    needs_approval: true
+                    raids:
+                      - name: "Approve"
+                        persona: approver
+                        prompt: "Approve this"
+                        acceptance_criteria: ["Approved"]
+                        declared_files: []
+                        estimate_hours: 0.0
+            """),
+            encoding="utf-8",
+        )
+        tpl = load_template("gated", tmp_path, {})
+        assert len(tpl.phases) == 2
+        assert tpl.phases[0].needs_approval is False
+        assert tpl.phases[1].needs_approval is True
+
+
+# ---------------------------------------------------------------------------
+# Template data-class fields
+# ---------------------------------------------------------------------------
+
+
+class TestTemplateDataclasses:
+    def test_template_raid_has_persona_field(self, tmp_path):
+        _write_minimal_template(tmp_path, "tpl")
+        tpl = load_template("tpl", tmp_path, {"repo": "r"})
+        assert tpl.phases[0].raids[0].persona == "executor"
+
+    def test_template_phase_needs_approval_defaults_false(self, tmp_path):
+        _write_minimal_template(tmp_path, "tpl")
+        tpl = load_template("tpl", tmp_path, {"repo": "r"})
+        assert tpl.phases[0].needs_approval is False
+
+    def test_template_phase_needs_approval_true(self, tmp_path):
+        (tmp_path / "gated.yaml").write_text(
+            textwrap.dedent("""\
+                name: "Gate saga"
+                feature_branch: main
+                base_branch: main
+                repos: []
+                phases:
+                  - name: Approve
+                    needs_approval: true
+                    raids:
+                      - name: "Gate"
+                        persona: gatekeeper
+                        prompt: "Gate"
+                        acceptance_criteria: []
+                        declared_files: []
+                        estimate_hours: 0.0
+            """),
+            encoding="utf-8",
+        )
+        tpl = load_template("gated", tmp_path, {})
+        assert tpl.phases[0].needs_approval is True
+
+
+# ---------------------------------------------------------------------------
+# Multi-phase sequential dispatch
+# ---------------------------------------------------------------------------
+
+
+def _write_two_phase_template(tmp_path: Path, name: str) -> None:
+    """Write a two-phase template for sequential dispatch tests."""
+    (tmp_path / f"{name}.yaml").write_text(
+        textwrap.dedent("""\
+            name: "Two-phase saga"
+            feature_branch: feat/test
+            base_branch: main
+            repos:
+              - "test/repo"
+            phases:
+              - name: Phase One
+                raids:
+                  - name: "Phase 1 raid"
+                    description: "First phase work"
+                    acceptance_criteria: ["Done"]
+                    declared_files: []
+                    estimate_hours: 1.0
+                    persona: worker
+                    prompt: "Do phase 1 work"
+              - name: Phase Two
+                raids:
+                  - name: "Phase 2 raid"
+                    description: "Second phase work"
+                    acceptance_criteria: ["Done"]
+                    declared_files: []
+                    estimate_hours: 1.0
+                    persona: worker
+                    prompt: "Do phase 2 work"
+        """),
+        encoding="utf-8",
+    )
+
+
+def _write_gated_template(tmp_path: Path, name: str) -> None:
+    """Write a two-phase template where Phase 2 needs approval."""
+    (tmp_path / f"{name}.yaml").write_text(
+        textwrap.dedent("""\
+            name: "Gated saga"
+            feature_branch: feat/test
+            base_branch: main
+            repos:
+              - "test/repo"
+            phases:
+              - name: Work Phase
+                raids:
+                  - name: "Work raid"
+                    description: "Work"
+                    acceptance_criteria: ["Done"]
+                    declared_files: []
+                    estimate_hours: 1.0
+                    persona: worker
+                    prompt: "Do work"
+              - name: Approval Gate
+                needs_approval: true
+                raids:
+                  - name: "Approval raid"
+                    description: "Awaiting approval"
+                    acceptance_criteria: ["Approved"]
+                    declared_files: []
+                    estimate_hours: 0.0
+                    persona: approver
+                    prompt: "Approve"
+        """),
+        encoding="utf-8",
+    )
+
+
+class TestMultiPhaseDispatch:
+    async def test_multi_phase_only_phase_1_raids_dispatched_initially(self, tmp_path):
+        _write_two_phase_template(tmp_path, "two")
+        volundr = StubVolundrPort()
+        saga_repo = InMemorySagaRepository()
+        bus = InProcessBus()
+        adapter = _make_adapter(
+            subscriber=bus,
+            saga_repo=saga_repo,
+            volundr_factory=StubVolundrFactory(volundr),
+            templates_dir=tmp_path,
+            rules=[_make_rule("test.event", saga_template="two", auto_start=True)],
+        )
+        await adapter.start()
+        await bus.publish(_make_sleipnir_event("test.event", {"repo": "r"}))
+        await bus.flush()
+        await asyncio.sleep(0)
+
+        # Only the Phase 1 raid should be spawned
+        assert len(volundr.spawned) == 1
+        assert volundr.spawned[0].name == "phase-1-raid"
+
+        await adapter.stop()
+
+    async def test_multi_phase_creates_all_phases_in_db(self, tmp_path):
+        _write_two_phase_template(tmp_path, "two")
+        saga_repo = InMemorySagaRepository()
+        bus = InProcessBus()
+        adapter = _make_adapter(
+            subscriber=bus,
+            saga_repo=saga_repo,
+            templates_dir=tmp_path,
+            rules=[_make_rule("test.event", saga_template="two", auto_start=True)],
+        )
+        await adapter.start()
+        await bus.publish(_make_sleipnir_event("test.event", {"repo": "r"}))
+        await bus.flush()
+        await asyncio.sleep(0)
+
+        assert len(saga_repo.phases) == 2
+        assert len(saga_repo.raids) == 2
+
+        await adapter.stop()
+
+    async def test_multi_phase_phase_2_starts_pending(self, tmp_path):
+        _write_two_phase_template(tmp_path, "two")
+        saga_repo = InMemorySagaRepository()
+        bus = InProcessBus()
+        adapter = _make_adapter(
+            subscriber=bus,
+            saga_repo=saga_repo,
+            templates_dir=tmp_path,
+            rules=[_make_rule("test.event", saga_template="two", auto_start=True)],
+        )
+        await adapter.start()
+        await bus.publish(_make_sleipnir_event("test.event", {"repo": "r"}))
+        await bus.flush()
+        await asyncio.sleep(0)
+
+        from tyr.domain.models import PhaseStatus
+
+        phases_by_num = {p.number: p for p in saga_repo.phases.values()}
+        assert phases_by_num[1].status == PhaseStatus.ACTIVE
+        assert phases_by_num[2].status == PhaseStatus.PENDING
+
+        await adapter.stop()
+
+    async def test_multi_phase_all_raids_start_pending(self, tmp_path):
+        _write_two_phase_template(tmp_path, "two")
+        saga_repo = InMemorySagaRepository()
+        bus = InProcessBus()
+        adapter = _make_adapter(
+            subscriber=bus,
+            saga_repo=saga_repo,
+            templates_dir=tmp_path,
+            rules=[_make_rule("test.event", saga_template="two", auto_start=True)],
+        )
+        await adapter.start()
+        await bus.publish(_make_sleipnir_event("test.event", {"repo": "r"}))
+        await bus.flush()
+        await asyncio.sleep(0)
+
+        # Phase 1 raid: RUNNING (was dispatched); Phase 2 raid: PENDING
+        raids_by_name = {r.name: r for r in saga_repo.raids.values()}
+        assert raids_by_name["Phase 1 raid"].status == RaidStatus.RUNNING
+        assert raids_by_name["Phase 2 raid"].status == RaidStatus.PENDING
+
+        await adapter.stop()
+
+
+# ---------------------------------------------------------------------------
+# advance_phase tests
+# ---------------------------------------------------------------------------
+
+
+class TestAdvancePhase:
+    async def test_advance_phase_dispatches_next_phase_raids(self, tmp_path):
+        _write_two_phase_template(tmp_path, "two")
+        volundr = StubVolundrPort()
+        saga_repo = InMemorySagaRepository()
+        bus = InProcessBus()
+        adapter = _make_adapter(
+            subscriber=bus,
+            saga_repo=saga_repo,
+            volundr_factory=StubVolundrFactory(volundr),
+            templates_dir=tmp_path,
+            rules=[_make_rule("test.event", saga_template="two", auto_start=True)],
+        )
+        await adapter.start()
+        await bus.publish(_make_sleipnir_event("test.event", {"repo": "r"}))
+        await bus.flush()
+        await asyncio.sleep(0)
+
+        saga_id = str(list(saga_repo.sagas.keys())[0])
+        assert len(volundr.spawned) == 1
+
+        # Advance to Phase 2
+        await adapter.advance_phase(saga_id)
+
+        assert len(volundr.spawned) == 2
+        assert volundr.spawned[1].name == "phase-2-raid"
+
+        await adapter.stop()
+
+    async def test_advance_phase_with_needs_approval_emits_event(self, tmp_path):
+        _write_gated_template(tmp_path, "gated")
+        event_bus = InMemoryEventBus()
+        q = event_bus.subscribe()
+        saga_repo = InMemorySagaRepository()
+        bus = InProcessBus()
+        adapter = _make_adapter(
+            subscriber=bus,
+            saga_repo=saga_repo,
+            event_bus=event_bus,
+            templates_dir=tmp_path,
+            rules=[_make_rule("test.event", saga_template="gated", auto_start=True)],
+        )
+        await adapter.start()
+        await bus.publish(_make_sleipnir_event("test.event", {"repo": "r"}))
+        await bus.flush()
+        await asyncio.sleep(0)
+
+        saga_id = str(list(saga_repo.sagas.keys())[0])
+        # Drain events from Phase 1
+        while not q.empty():
+            q.get_nowait()
+
+        await adapter.advance_phase(saga_id)
+
+        events: list[TyrEvent] = []
+        while not q.empty():
+            events.append(q.get_nowait())
+
+        approval_events = [e for e in events if e.event == "phase.needs_approval"]
+        assert len(approval_events) == 1
+        assert approval_events[0].data["phase_name"] == "Approval Gate"
+
+        await adapter.stop()
+
+    async def test_advance_phase_with_needs_approval_does_not_spawn(self, tmp_path):
+        _write_gated_template(tmp_path, "gated")
+        volundr = StubVolundrPort()
+        saga_repo = InMemorySagaRepository()
+        bus = InProcessBus()
+        adapter = _make_adapter(
+            subscriber=bus,
+            saga_repo=saga_repo,
+            volundr_factory=StubVolundrFactory(volundr),
+            templates_dir=tmp_path,
+            rules=[_make_rule("test.event", saga_template="gated", auto_start=True)],
+        )
+        await adapter.start()
+        await bus.publish(_make_sleipnir_event("test.event", {"repo": "r"}))
+        await bus.flush()
+        await asyncio.sleep(0)
+
+        saga_id = str(list(saga_repo.sagas.keys())[0])
+        spawned_before = len(volundr.spawned)
+
+        await adapter.advance_phase(saga_id)
+
+        # No new sessions — phase is gated
+        assert len(volundr.spawned) == spawned_before
+
+        await adapter.stop()
+
+    async def test_advance_phase_with_needs_approval_sets_gated_status(self, tmp_path):
+        from tyr.domain.models import PhaseStatus
+
+        _write_gated_template(tmp_path, "gated")
+        saga_repo = InMemorySagaRepository()
+        bus = InProcessBus()
+        adapter = _make_adapter(
+            subscriber=bus,
+            saga_repo=saga_repo,
+            templates_dir=tmp_path,
+            rules=[_make_rule("test.event", saga_template="gated", auto_start=True)],
+        )
+        await adapter.start()
+        await bus.publish(_make_sleipnir_event("test.event", {"repo": "r"}))
+        await bus.flush()
+        await asyncio.sleep(0)
+
+        saga_id = str(list(saga_repo.sagas.keys())[0])
+        await adapter.advance_phase(saga_id)
+
+        phases_by_num = {p.number: p for p in saga_repo.phases.values()}
+        assert phases_by_num[2].status == PhaseStatus.GATED
+
+        await adapter.stop()
+
+    async def test_advance_phase_unknown_saga_is_noop(self):
+        adapter = _make_adapter()
+        # Must not raise
+        await adapter.advance_phase("non-existent-saga-id")
+
+
+# ---------------------------------------------------------------------------
+# Persona → profile in SpawnRequest
+# ---------------------------------------------------------------------------
+
+
+class TestPersonaPassedToSpawnRequest:
+    async def test_persona_passed_as_profile_in_spawn_request(self, tmp_path):
+        volundr = StubVolundrPort()
+        bus = InProcessBus()
+        (tmp_path / "profiled.yaml").write_text(
+            textwrap.dedent("""\
+                name: "Profiled saga"
+                feature_branch: main
+                base_branch: main
+                repos:
+                  - "test/repo"
+                phases:
+                  - name: Review
+                    raids:
+                      - name: "Code review raid"
+                        description: "Review code"
+                        acceptance_criteria: ["Reviewed"]
+                        declared_files: []
+                        estimate_hours: 1.0
+                        persona: code-reviewer
+                        prompt: "Review the code"
+            """),
+            encoding="utf-8",
+        )
+        adapter = _make_adapter(
+            subscriber=bus,
+            volundr_factory=StubVolundrFactory(volundr),
+            templates_dir=tmp_path,
+            rules=[_make_rule("test.event", saga_template="profiled", auto_start=True)],
+        )
+        await adapter.start()
+        await bus.publish(_make_sleipnir_event("test.event", {}))
+        await bus.flush()
+        await asyncio.sleep(0)
+
+        assert len(volundr.spawned) == 1
+        assert volundr.spawned[0].profile == "code-reviewer"
+
+        await adapter.stop()
+
+    async def test_empty_persona_sets_profile_to_none(self, tmp_path):
+        """An explicitly-empty persona is passed as None profile."""
+        volundr = StubVolundrPort()
+        bus = InProcessBus()
+        # Use a phase with needs_approval=True (persona allowed to be empty by template design,
+        # but the validator would normally reject empty persona).
+        # We bypass validation by NOT using needs_approval and using a non-empty persona.
+        # Instead test the None path by calling _spawn_raid with empty persona directly.
+        from tyr.domain.templates import TemplateRaid
+
+        adapter_obj = _make_adapter(
+            subscriber=bus,
+            volundr_factory=StubVolundrFactory(volundr),
+            templates_dir=tmp_path,
+        )
+        import uuid
+        from datetime import UTC, datetime
+
+        from tyr.domain.models import Phase, PhaseStatus, Raid, RaidStatus, Saga, SagaStatus
+
+        now = datetime.now(UTC)
+        saga_id = uuid.uuid4()
+        saga = Saga(
+            id=saga_id,
+            tracker_id=str(saga_id),
+            tracker_type="native",
+            slug="test",
+            name="test",
+            repos=["r"],
+            feature_branch="main",
+            base_branch="main",
+            status=SagaStatus.ACTIVE,
+            confidence=0.5,
+            created_at=now,
+            owner_id=_OWNER,
+        )
+        phase_id = uuid.uuid4()
+        phase = Phase(
+            id=phase_id,
+            saga_id=saga_id,
+            tracker_id=str(phase_id),
+            number=1,
+            name="P1",
+            status=PhaseStatus.ACTIVE,
+            confidence=0.5,
+        )
+        raid_id = uuid.uuid4()
+        raid = Raid(
+            id=raid_id,
+            phase_id=phase_id,
+            tracker_id=str(raid_id),
+            name="r1",
+            description="",
+            acceptance_criteria=[],
+            declared_files=[],
+            estimate_hours=1.0,
+            status=RaidStatus.PENDING,
+            confidence=0.5,
+            session_id=None,
+            branch=None,
+            chronicle_summary=None,
+            pr_url=None,
+            pr_id=None,
+            retry_count=0,
+            created_at=now,
+            updated_at=now,
+        )
+        tpl_raid = TemplateRaid(
+            name="r1",
+            description="",
+            acceptance_criteria=[],
+            declared_files=[],
+            estimate_hours=1.0,
+            prompt="p",
+            persona="",  # empty persona
+        )
+        await adapter_obj._spawn_raid(volundr, saga, phase, raid, tpl_raid)
+
+        assert len(volundr.spawned) == 1
+        assert volundr.spawned[0].profile is None
+
+
+# ---------------------------------------------------------------------------
+# Bundled template smoke tests (ship + retro)
+# ---------------------------------------------------------------------------
+
+
+class TestBundledShipRetroTemplates:
+    def test_ship_template_loads(self):
+        from tyr.adapters.event_trigger import _BUNDLED_TEMPLATES_DIR
+
+        payload = {
+            "repo": "niuulabs/volundr",
+            "branch": "feat/release",
+            "base_branch": "main",
+        }
+        tpl = load_template("ship", _BUNDLED_TEMPLATES_DIR, payload)
+        assert tpl.name
+        assert len(tpl.phases) == 4
+        assert tpl.phases[0].name == "Test Suite"
+        assert tpl.phases[1].name == "Pre-ship Code Review"
+        assert tpl.phases[2].name == "Version Bump and Changelog"
+        assert tpl.phases[3].name == "Create Release PR"
+        # All phases have personas
+        for phase in tpl.phases:
+            for raid in phase.raids:
+                assert raid.persona
+
+    def test_retro_template_loads(self):
+        from tyr.adapters.event_trigger import _BUNDLED_TEMPLATES_DIR
+
+        payload = {"week": "2026-W15"}
+        tpl = load_template("retro", _BUNDLED_TEMPLATES_DIR, payload)
+        assert tpl.name
+        assert "2026-W15" in tpl.name
+        assert len(tpl.phases) == 2
+        assert tpl.phases[0].name == "Retrospective Analysis"
+        assert tpl.phases[1].name == "Write to Mimir"
+        for phase in tpl.phases:
+            for raid in phase.raids:
+                assert raid.persona == "retro-analyst"
+
+    def test_deploy_template_has_3_phases(self):
+        from tyr.adapters.event_trigger import _BUNDLED_TEMPLATES_DIR
+
+        payload = {
+            "repo": "niuulabs/v",
+            "sha": "abc123def456",
+            "sha_short": "abc123d",
+            "title": "Merge feat/x",
+            "pr_url": "https://github.com/niuulabs/v/pull/1",
+            "author": "bob",
+        }
+        tpl = load_template("deploy", _BUNDLED_TEMPLATES_DIR, payload)
+        assert len(tpl.phases) == 3
+        assert tpl.phases[0].name == "Smoke Test"
+        assert tpl.phases[1].name == "Monitor"
+        assert tpl.phases[2].name == "Release Documentation"
+
+    def test_review_template_has_4_phases_with_approval_gate(self):
+        from tyr.adapters.event_trigger import _BUNDLED_TEMPLATES_DIR
+
+        payload = {
+            "repo": "niuulabs/v",
+            "pr_number": "42",
+            "branch": "feat/x",
+            "base_branch": "main",
+            "title": "My PR",
+            "author": "bob",
+            "pr_url": "https://github.com/niuulabs/v/pull/42",
+        }
+        tpl = load_template("review", _BUNDLED_TEMPLATES_DIR, payload)
+        assert len(tpl.phases) == 4
+        assert tpl.phases[3].needs_approval is True
+        assert tpl.phases[0].raids[0].persona == "reviewer"
+        assert tpl.phases[1].raids[0].persona == "security-auditor"
+        assert tpl.phases[2].raids[0].persona == "qa-agent"

--- a/tests/test_tyr/test_event_trigger.py
+++ b/tests/test_tyr/test_event_trigger.py
@@ -4,165 +4,31 @@ from __future__ import annotations
 
 import asyncio
 import textwrap
-from collections.abc import AsyncGenerator
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
-from uuid import UUID
 
 import pytest
 
 from sleipnir.adapters.in_process import InProcessBus
 from sleipnir.domain.events import SleipnirEvent
+from tests.test_tyr.stubs import InMemorySagaRepository, StubVolundrFactory, StubVolundrPort
 from tyr.adapters.event_trigger import (
     EventTriggerAdapter,
     _TriggerRule,
-    load_template,
     matches_filter,
 )
 from tyr.adapters.memory_event_bus import InMemoryEventBus
 from tyr.domain.models import Phase, Raid, RaidStatus, Saga, SagaStatus
+from tyr.domain.templates import BUNDLED_TEMPLATES_DIR, load_template
 from tyr.ports.event_bus import TyrEvent
 from tyr.ports.saga_repository import SagaRepository
-from tyr.ports.volundr import (
-    ActivityEvent,
-    PRStatus,
-    SpawnRequest,
-    VolundrPort,
-    VolundrSession,
-)
 
 # ---------------------------------------------------------------------------
-# Stubs
+# Constants
 # ---------------------------------------------------------------------------
 
 _TS = datetime(2026, 4, 12, 10, 0, 0, tzinfo=UTC)
 _OWNER = "test-owner"
-
-
-class InMemorySagaRepository(SagaRepository):
-    """In-memory saga repository for tests."""
-
-    def __init__(self) -> None:
-        self.sagas: dict[UUID, Saga] = {}
-        self.phases: dict[UUID, Phase] = {}
-        self.raids: dict[UUID, Raid] = {}
-
-    async def save_saga(self, saga: Saga, *, conn: Any = None) -> None:
-        self.sagas[saga.id] = saga
-
-    async def save_phase(self, phase: Phase, *, conn: Any = None) -> None:
-        self.phases[phase.id] = phase
-
-    async def save_raid(self, raid: Raid, *, conn: Any = None) -> None:
-        self.raids[raid.id] = raid
-
-    async def list_sagas(self, *, owner_id: str | None = None) -> list[Saga]:
-        if owner_id is None:
-            return list(self.sagas.values())
-        return [s for s in self.sagas.values() if s.owner_id == owner_id]
-
-    async def get_saga(self, saga_id: UUID, *, owner_id: str | None = None) -> Saga | None:
-        return self.sagas.get(saga_id)
-
-    async def get_saga_by_slug(self, slug: str) -> Saga | None:
-        return next((s for s in self.sagas.values() if s.slug == slug), None)
-
-    async def delete_saga(self, saga_id: UUID, *, owner_id: str | None = None) -> bool:
-        return self.sagas.pop(saga_id, None) is not None
-
-    async def update_saga_status(self, saga_id: UUID, status: SagaStatus) -> None:
-        saga = self.sagas.get(saga_id)
-        if saga:
-            self.sagas[saga_id] = Saga(
-                id=saga.id,
-                tracker_id=saga.tracker_id,
-                tracker_type=saga.tracker_type,
-                slug=saga.slug,
-                name=saga.name,
-                repos=saga.repos,
-                feature_branch=saga.feature_branch,
-                base_branch=saga.base_branch,
-                status=status,
-                confidence=saga.confidence,
-                created_at=saga.created_at,
-                owner_id=saga.owner_id,
-            )
-
-    async def count_by_status(self) -> dict[str, int]:
-        return {}
-
-
-class StubVolundrPort(VolundrPort):
-    """Stub Volundr port that records spawn requests."""
-
-    def __init__(self, session_id: str = "sess-001") -> None:
-        self._session_id = session_id
-        self.spawned: list[SpawnRequest] = []
-
-    async def spawn_session(
-        self, request: SpawnRequest, *, auth_token: str | None = None
-    ) -> VolundrSession:
-        self.spawned.append(request)
-        return VolundrSession(
-            id=self._session_id,
-            name=request.name,
-            status="running",
-            tracker_issue_id=request.tracker_issue_id,
-        )
-
-    async def get_session(
-        self, session_id: str, *, auth_token: str | None = None
-    ) -> VolundrSession | None:
-        return None
-
-    async def list_sessions(self, *, auth_token: str | None = None) -> list[VolundrSession]:
-        return []
-
-    async def get_pr_status(self, session_id: str) -> PRStatus:
-        return PRStatus(exists=False, merged=False, url=None, ci_passed=False)
-
-    async def get_chronicle_summary(self, session_id: str) -> str:
-        return ""
-
-    async def send_message(
-        self, session_id: str, message: str, *, auth_token: str | None = None
-    ) -> None:
-        pass
-
-    async def stop_session(self, session_id: str, *, auth_token: str | None = None) -> None:
-        pass
-
-    async def list_integration_ids(self, *, auth_token: str | None = None) -> list[str]:
-        return []
-
-    async def list_repos(self, *, auth_token: str | None = None) -> list[dict]:
-        return []
-
-    async def get_last_assistant_message(self, session_id: str) -> str:
-        return ""
-
-    async def get_conversation(self, session_id: str) -> dict:
-        return {}
-
-    async def subscribe_activity(self) -> AsyncGenerator[ActivityEvent, None]:
-        return
-        yield  # type: ignore[misc]
-
-
-class StubVolundrFactory:
-    """Factory that always returns the same stub adapter."""
-
-    def __init__(self, volundr: VolundrPort | None = None) -> None:
-        self._volundr = volundr or StubVolundrPort()
-
-    async def for_owner(self, owner_id: str) -> list[VolundrPort]:
-        if self._volundr is None:
-            return []
-        return [self._volundr]
-
-    async def primary_for_owner(self, owner_id: str) -> VolundrPort | None:
-        return self._volundr
 
 
 def _make_sleipnir_event(
@@ -206,15 +72,13 @@ def _make_adapter(
     rules: list[_TriggerRule] | None = None,
     templates_dir: Path | None = None,
 ) -> EventTriggerAdapter:
-    from tyr.adapters.event_trigger import _BUNDLED_TEMPLATES_DIR
-
     return EventTriggerAdapter(
         subscriber=subscriber or InProcessBus(),
         saga_repo=saga_repo or InMemorySagaRepository(),
         volundr_factory=volundr_factory or StubVolundrFactory(),
         event_bus=event_bus or InMemoryEventBus(),
         rules=rules if rules is not None else [_make_rule()],
-        templates_dir=templates_dir or _BUNDLED_TEMPLATES_DIR,
+        templates_dir=templates_dir or BUNDLED_TEMPLATES_DIR,
         owner_id=_OWNER,
     )
 
@@ -254,8 +118,6 @@ class TestMatchesFilter:
 
 class TestLoadTemplate:
     def test_loads_bundled_review_template(self, tmp_path):
-        from tyr.adapters.event_trigger import _BUNDLED_TEMPLATES_DIR
-
         payload = {
             "repo": "niuulabs/volundr",
             "pr_number": "99",
@@ -265,7 +127,7 @@ class TestLoadTemplate:
             "author": "alice",
             "pr_url": "https://github.com/niuulabs/volundr/pull/99",
         }
-        tpl = load_template("review", _BUNDLED_TEMPLATES_DIR, payload)
+        tpl = load_template("review", BUNDLED_TEMPLATES_DIR, payload)
 
         assert "99" in tpl.name
         # review.yaml has 4 phases: Code Review, Security Audit, QA Test Run, Human Approval
@@ -803,8 +665,6 @@ class TestEventTriggerMissingTemplate:
 
 class TestBundledTemplates:
     def test_review_template_loads(self):
-        from tyr.adapters.event_trigger import _BUNDLED_TEMPLATES_DIR
-
         payload = {
             "repo": "niuulabs/v",
             "pr_number": "1",
@@ -814,13 +674,11 @@ class TestBundledTemplates:
             "author": "bob",
             "pr_url": "https://github.com/niuulabs/v/pull/1",
         }
-        tpl = load_template("review", _BUNDLED_TEMPLATES_DIR, payload)
+        tpl = load_template("review", BUNDLED_TEMPLATES_DIR, payload)
         assert tpl.name
         assert len(tpl.phases) >= 1
 
     def test_deploy_template_loads(self):
-        from tyr.adapters.event_trigger import _BUNDLED_TEMPLATES_DIR
-
         payload = {
             "repo": "niuulabs/v",
             "sha": "abc123def456",
@@ -829,12 +687,10 @@ class TestBundledTemplates:
             "pr_url": "https://github.com/niuulabs/v/pull/1",
             "author": "bob",
         }
-        tpl = load_template("deploy", _BUNDLED_TEMPLATES_DIR, payload)
+        tpl = load_template("deploy", BUNDLED_TEMPLATES_DIR, payload)
         assert tpl.name
 
     def test_investigate_template_loads(self):
-        from tyr.adapters.event_trigger import _BUNDLED_TEMPLATES_DIR
-
         payload = {
             "repo": "niuulabs/v",
             "issue_number": "42",
@@ -843,19 +699,17 @@ class TestBundledTemplates:
             "issue_url": "https://github.com/niuulabs/v/issues/42",
             "body": "It crashes on startup.",
         }
-        tpl = load_template("investigate", _BUNDLED_TEMPLATES_DIR, payload)
+        tpl = load_template("investigate", BUNDLED_TEMPLATES_DIR, payload)
         assert tpl.name
 
     def test_reflect_template_loads(self):
-        from tyr.adapters.event_trigger import _BUNDLED_TEMPLATES_DIR
-
         payload = {
             "session_id": "sess-xyz",
             "repo": "niuulabs/v",
             "outcome": "success",
             "duration_seconds": "120",
         }
-        tpl = load_template("reflect", _BUNDLED_TEMPLATES_DIR, payload)
+        tpl = load_template("reflect", BUNDLED_TEMPLATES_DIR, payload)
         assert tpl.name
 
 
@@ -898,10 +752,7 @@ class TestBuildEventTriggerAdapter:
         assert adapter._default_model == "claude-haiku-4-5-20251001"
 
     def test_build_with_default_templates_dir(self):
-        from tyr.adapters.event_trigger import (
-            _BUNDLED_TEMPLATES_DIR,
-            build_event_trigger_adapter,
-        )
+        from tyr.adapters.event_trigger import build_event_trigger_adapter
         from tyr.config import EventTriggerConfig
 
         cfg = EventTriggerConfig(enabled=True)
@@ -913,7 +764,7 @@ class TestBuildEventTriggerAdapter:
             config=cfg,
             initial_confidence=0.5,
         )
-        assert adapter._templates_dir == _BUNDLED_TEMPLATES_DIR
+        assert adapter._templates_dir == BUNDLED_TEMPLATES_DIR
 
 
 # ---------------------------------------------------------------------------
@@ -1617,7 +1468,7 @@ class TestPersonaPassedToSpawnRequest:
         import uuid
         from datetime import UTC, datetime
 
-        from tyr.domain.models import Phase, PhaseStatus, Raid, RaidStatus, Saga, SagaStatus
+        from tyr.domain.models import PhaseStatus, RaidStatus, SagaStatus
 
         now = datetime.now(UTC)
         saga_id = uuid.uuid4()
@@ -1688,14 +1539,12 @@ class TestPersonaPassedToSpawnRequest:
 
 class TestBundledShipRetroTemplates:
     def test_ship_template_loads(self):
-        from tyr.adapters.event_trigger import _BUNDLED_TEMPLATES_DIR
-
         payload = {
             "repo": "niuulabs/volundr",
             "branch": "feat/release",
             "base_branch": "main",
         }
-        tpl = load_template("ship", _BUNDLED_TEMPLATES_DIR, payload)
+        tpl = load_template("ship", BUNDLED_TEMPLATES_DIR, payload)
         assert tpl.name
         assert len(tpl.phases) == 4
         assert tpl.phases[0].name == "Test Suite"
@@ -1708,10 +1557,8 @@ class TestBundledShipRetroTemplates:
                 assert raid.persona
 
     def test_retro_template_loads(self):
-        from tyr.adapters.event_trigger import _BUNDLED_TEMPLATES_DIR
-
         payload = {"week": "2026-W15"}
-        tpl = load_template("retro", _BUNDLED_TEMPLATES_DIR, payload)
+        tpl = load_template("retro", BUNDLED_TEMPLATES_DIR, payload)
         assert tpl.name
         assert "2026-W15" in tpl.name
         assert len(tpl.phases) == 2
@@ -1722,8 +1569,6 @@ class TestBundledShipRetroTemplates:
                 assert raid.persona == "retro-analyst"
 
     def test_deploy_template_has_3_phases(self):
-        from tyr.adapters.event_trigger import _BUNDLED_TEMPLATES_DIR
-
         payload = {
             "repo": "niuulabs/v",
             "sha": "abc123def456",
@@ -1732,15 +1577,13 @@ class TestBundledShipRetroTemplates:
             "pr_url": "https://github.com/niuulabs/v/pull/1",
             "author": "bob",
         }
-        tpl = load_template("deploy", _BUNDLED_TEMPLATES_DIR, payload)
+        tpl = load_template("deploy", BUNDLED_TEMPLATES_DIR, payload)
         assert len(tpl.phases) == 3
         assert tpl.phases[0].name == "Smoke Test"
         assert tpl.phases[1].name == "Monitor"
         assert tpl.phases[2].name == "Release Documentation"
 
     def test_review_template_has_4_phases_with_approval_gate(self):
-        from tyr.adapters.event_trigger import _BUNDLED_TEMPLATES_DIR
-
         payload = {
             "repo": "niuulabs/v",
             "pr_number": "42",
@@ -1750,7 +1593,7 @@ class TestBundledShipRetroTemplates:
             "author": "bob",
             "pr_url": "https://github.com/niuulabs/v/pull/42",
         }
-        tpl = load_template("review", _BUNDLED_TEMPLATES_DIR, payload)
+        tpl = load_template("review", BUNDLED_TEMPLATES_DIR, payload)
         assert len(tpl.phases) == 4
         assert tpl.phases[3].needs_approval is True
         assert tpl.phases[0].raids[0].persona == "reviewer"

--- a/tests/test_tyr/test_template_dispatch.py
+++ b/tests/test_tyr/test_template_dispatch.py
@@ -1,0 +1,421 @@
+"""Tests for DispatchService.create_saga_from_template."""
+
+from __future__ import annotations
+
+import textwrap
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+from tyr.adapters.memory_event_bus import InMemoryEventBus
+from tyr.domain.models import Phase, Raid, Saga, SagaStatus
+from tyr.domain.services.dispatch_service import DispatchConfig, DispatchService
+from tyr.ports.event_bus import TyrEvent
+from tyr.ports.saga_repository import SagaRepository
+from tyr.ports.volundr import (
+    ActivityEvent,
+    PRStatus,
+    SpawnRequest,
+    VolundrPort,
+    VolundrSession,
+)
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+_TS = datetime(2026, 4, 12, 10, 0, 0, tzinfo=UTC)
+_OWNER = "test-owner"
+
+
+class InMemorySagaRepository(SagaRepository):
+    def __init__(self) -> None:
+        self.sagas: dict[UUID, Saga] = {}
+        self.phases: dict[UUID, Phase] = {}
+        self.raids: dict[UUID, Raid] = {}
+
+    async def save_saga(self, saga: Saga, *, conn: Any = None) -> None:
+        self.sagas[saga.id] = saga
+
+    async def save_phase(self, phase: Phase, *, conn: Any = None) -> None:
+        self.phases[phase.id] = phase
+
+    async def save_raid(self, raid: Raid, *, conn: Any = None) -> None:
+        self.raids[raid.id] = raid
+
+    async def list_sagas(self, *, owner_id: str | None = None) -> list[Saga]:
+        if owner_id is None:
+            return list(self.sagas.values())
+        return [s for s in self.sagas.values() if s.owner_id == owner_id]
+
+    async def get_saga(self, saga_id: UUID, *, owner_id: str | None = None) -> Saga | None:
+        return self.sagas.get(saga_id)
+
+    async def get_saga_by_slug(self, slug: str) -> Saga | None:
+        return next((s for s in self.sagas.values() if s.slug == slug), None)
+
+    async def delete_saga(self, saga_id: UUID, *, owner_id: str | None = None) -> bool:
+        return self.sagas.pop(saga_id, None) is not None
+
+    async def update_saga_status(self, saga_id: UUID, status: SagaStatus) -> None:
+        saga = self.sagas.get(saga_id)
+        if saga:
+            self.sagas[saga_id] = Saga(
+                id=saga.id,
+                tracker_id=saga.tracker_id,
+                tracker_type=saga.tracker_type,
+                slug=saga.slug,
+                name=saga.name,
+                repos=saga.repos,
+                feature_branch=saga.feature_branch,
+                base_branch=saga.base_branch,
+                status=status,
+                confidence=saga.confidence,
+                created_at=saga.created_at,
+                owner_id=saga.owner_id,
+            )
+
+    async def count_by_status(self) -> dict[str, int]:
+        return {}
+
+
+class StubVolundrPort(VolundrPort):
+    def __init__(self, session_id: str = "sess-001") -> None:
+        self._session_id = session_id
+        self.spawned: list[SpawnRequest] = []
+
+    async def spawn_session(
+        self, request: SpawnRequest, *, auth_token: str | None = None
+    ) -> VolundrSession:
+        self.spawned.append(request)
+        return VolundrSession(
+            id=self._session_id,
+            name=request.name,
+            status="running",
+            tracker_issue_id=request.tracker_issue_id,
+        )
+
+    async def get_session(
+        self, session_id: str, *, auth_token: str | None = None
+    ) -> VolundrSession | None:
+        return None
+
+    async def list_sessions(self, *, auth_token: str | None = None) -> list[VolundrSession]:
+        return []
+
+    async def get_pr_status(self, session_id: str) -> PRStatus:
+        return PRStatus(exists=False, merged=False, url=None, ci_passed=False)
+
+    async def get_chronicle_summary(self, session_id: str) -> str:
+        return ""
+
+    async def send_message(
+        self, session_id: str, message: str, *, auth_token: str | None = None
+    ) -> None:
+        pass
+
+    async def stop_session(self, session_id: str, *, auth_token: str | None = None) -> None:
+        pass
+
+    async def list_integration_ids(self, *, auth_token: str | None = None) -> list[str]:
+        return []
+
+    async def list_repos(self, *, auth_token: str | None = None) -> list[dict]:
+        return []
+
+    async def get_last_assistant_message(self, session_id: str) -> str:
+        return ""
+
+    async def get_conversation(self, session_id: str) -> dict:
+        return {}
+
+    async def subscribe_activity(self) -> AsyncGenerator[ActivityEvent, None]:
+        return
+        yield  # type: ignore[misc]
+
+
+class StubVolundrFactory:
+    def __init__(self, volundr: VolundrPort | None = None) -> None:
+        self._volundr = volundr or StubVolundrPort()
+
+    async def for_owner(self, owner_id: str) -> list[VolundrPort]:
+        if self._volundr is None:
+            return []
+        return [self._volundr]
+
+    async def primary_for_owner(self, owner_id: str) -> VolundrPort | None:
+        return self._volundr
+
+
+class StubTrackerFactory:
+    async def for_owner(self, owner_id: str):
+        return []
+
+
+class StubDispatcherRepo:
+    async def get_or_create(self, owner_id: str):
+        return None
+
+    async def update(self, owner_id: str, **kwargs):
+        pass
+
+
+def _make_service(
+    saga_repo: InMemorySagaRepository | None = None,
+    volundr: StubVolundrPort | None = None,
+    event_bus: InMemoryEventBus | None = None,
+    templates_dir: Path | None = None,
+) -> DispatchService:
+    from tyr.domain.templates import BUNDLED_TEMPLATES_DIR
+
+    _volundr = volundr or StubVolundrPort()
+    config = DispatchConfig(
+        templates_dir=templates_dir or BUNDLED_TEMPLATES_DIR,
+    )
+    return DispatchService(
+        tracker_factory=StubTrackerFactory(),
+        volundr_factory=StubVolundrFactory(_volundr),
+        saga_repo=saga_repo or InMemorySagaRepository(),
+        dispatcher_repo=StubDispatcherRepo(),
+        config=config,
+        event_bus=event_bus,
+    )
+
+
+def _write_minimal_template(tmp_path: Path, name: str) -> None:
+    (tmp_path / f"{name}.yaml").write_text(
+        textwrap.dedent("""\
+            name: "Template saga for {event.repo}"
+            feature_branch: "{event.branch}"
+            base_branch: main
+            repos:
+              - "{event.repo}"
+            phases:
+              - name: Execute
+                raids:
+                  - name: "Execute task in {event.repo}"
+                    description: "Do the work"
+                    acceptance_criteria:
+                      - "Task completed"
+                    declared_files: []
+                    estimate_hours: 1.0
+                    persona: executor
+                    prompt: "Execute task in {event.repo} on {event.branch}"
+        """),
+        encoding="utf-8",
+    )
+
+
+def _write_two_phase_template(tmp_path: Path, name: str) -> None:
+    (tmp_path / f"{name}.yaml").write_text(
+        textwrap.dedent("""\
+            name: "Two-phase"
+            feature_branch: main
+            base_branch: main
+            repos: []
+            phases:
+              - name: Phase 1
+                raids:
+                  - name: "Phase 1 raid"
+                    description: "First"
+                    acceptance_criteria: []
+                    declared_files: []
+                    estimate_hours: 1.0
+                    persona: worker
+                    prompt: "Do phase 1"
+              - name: Phase 2
+                raids:
+                  - name: "Phase 2 raid"
+                    description: "Second"
+                    acceptance_criteria: []
+                    declared_files: []
+                    estimate_hours: 1.0
+                    persona: worker
+                    prompt: "Do phase 2"
+        """),
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCreateSagaFromTemplate:
+    async def test_creates_saga_in_repository(self, tmp_path):
+        _write_minimal_template(tmp_path, "simple")
+        saga_repo = InMemorySagaRepository()
+        svc = _make_service(saga_repo=saga_repo, templates_dir=tmp_path)
+
+        saga_id = await svc.create_saga_from_template(
+            "simple", {"repo": "myrepo", "branch": "feat/x"}, _OWNER
+        )
+
+        assert saga_id
+        assert len(saga_repo.sagas) == 1
+        saga = list(saga_repo.sagas.values())[0]
+        assert saga.owner_id == _OWNER
+        assert saga.status == SagaStatus.ACTIVE
+        assert "myrepo" in saga.name
+
+    async def test_creates_phases_and_raids_in_repository(self, tmp_path):
+        _write_minimal_template(tmp_path, "simple")
+        saga_repo = InMemorySagaRepository()
+        svc = _make_service(saga_repo=saga_repo, templates_dir=tmp_path)
+
+        await svc.create_saga_from_template(
+            "simple", {"repo": "myrepo", "branch": "feat/x"}, _OWNER
+        )
+
+        assert len(saga_repo.phases) == 1
+        assert len(saga_repo.raids) == 1
+
+    async def test_auto_start_spawns_phase_1_sessions(self, tmp_path):
+        _write_minimal_template(tmp_path, "simple")
+        volundr = StubVolundrPort()
+        saga_repo = InMemorySagaRepository()
+        svc = _make_service(saga_repo=saga_repo, volundr=volundr, templates_dir=tmp_path)
+
+        await svc.create_saga_from_template(
+            "simple", {"repo": "myrepo", "branch": "feat/x"}, _OWNER, auto_start=True
+        )
+
+        assert len(volundr.spawned) == 1
+        assert volundr.spawned[0].profile == "executor"
+
+    async def test_auto_start_false_does_not_spawn(self, tmp_path):
+        _write_minimal_template(tmp_path, "simple")
+        volundr = StubVolundrPort()
+        svc = _make_service(volundr=volundr, templates_dir=tmp_path)
+
+        await svc.create_saga_from_template(
+            "simple", {"repo": "myrepo", "branch": "feat/x"}, _OWNER, auto_start=False
+        )
+
+        assert len(volundr.spawned) == 0
+
+    async def test_multi_phase_only_phase_1_spawned(self, tmp_path):
+        _write_two_phase_template(tmp_path, "two")
+        volundr = StubVolundrPort()
+        saga_repo = InMemorySagaRepository()
+        svc = _make_service(saga_repo=saga_repo, volundr=volundr, templates_dir=tmp_path)
+
+        await svc.create_saga_from_template("two", {}, _OWNER, auto_start=True)
+
+        assert len(volundr.spawned) == 1
+        assert volundr.spawned[0].name == "phase-1-raid"
+
+    async def test_interpolation_applied_to_payload(self, tmp_path):
+        _write_minimal_template(tmp_path, "simple")
+        saga_repo = InMemorySagaRepository()
+        svc = _make_service(saga_repo=saga_repo, templates_dir=tmp_path)
+
+        await svc.create_saga_from_template(
+            "simple", {"repo": "custom-repo", "branch": "my-branch"}, _OWNER
+        )
+
+        saga = list(saga_repo.sagas.values())[0]
+        assert "custom-repo" in saga.name
+        raid = list(saga_repo.raids.values())[0]
+        assert "custom-repo" in raid.description or "custom-repo" in raid.name
+
+    async def test_missing_template_raises(self, tmp_path):
+        svc = _make_service(templates_dir=tmp_path)
+        with pytest.raises(FileNotFoundError):
+            await svc.create_saga_from_template("nonexistent", {}, _OWNER)
+
+    async def test_invalid_template_raises_value_error(self, tmp_path):
+        (tmp_path / "bad.yaml").write_text(
+            textwrap.dedent("""\
+                name: "Bad"
+                feature_branch: main
+                base_branch: main
+                repos: []
+                phases:
+                  - name: P
+                    raids:
+                      - name: "R"
+                        persona: ""
+                        prompt: "x"
+                        acceptance_criteria: []
+                        declared_files: []
+                        estimate_hours: 1.0
+            """),
+            encoding="utf-8",
+        )
+        svc = _make_service(templates_dir=tmp_path)
+        with pytest.raises(ValueError, match="persona"):
+            await svc.create_saga_from_template("bad", {}, _OWNER)
+
+    async def test_emits_saga_created_event_when_event_bus_provided(self, tmp_path):
+        _write_minimal_template(tmp_path, "simple")
+        event_bus = InMemoryEventBus()
+        q = event_bus.subscribe()
+        svc = _make_service(event_bus=event_bus, templates_dir=tmp_path)
+
+        await svc.create_saga_from_template("simple", {"repo": "r", "branch": "main"}, _OWNER)
+
+        events: list[TyrEvent] = []
+        while not q.empty():
+            events.append(q.get_nowait())
+
+        assert any(e.event == "saga.created" for e in events)
+
+    async def test_no_event_bus_does_not_raise(self, tmp_path):
+        _write_minimal_template(tmp_path, "simple")
+        svc = _make_service(event_bus=None, templates_dir=tmp_path)
+
+        # Must not raise even without an event bus
+        saga_id = await svc.create_saga_from_template(
+            "simple", {"repo": "r", "branch": "main"}, _OWNER
+        )
+        assert saga_id
+
+    async def test_returns_saga_id_string(self, tmp_path):
+        _write_minimal_template(tmp_path, "simple")
+        svc = _make_service(templates_dir=tmp_path)
+
+        saga_id = await svc.create_saga_from_template(
+            "simple", {"repo": "r", "branch": "main"}, _OWNER
+        )
+
+        assert isinstance(saga_id, str)
+        # Must be a valid UUID string
+        import uuid
+
+        uuid.UUID(saga_id)  # raises if invalid
+
+
+# ---------------------------------------------------------------------------
+# Bundled templates through DispatchService
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchServiceBundledTemplates:
+    """Smoke-load each bundled template through DispatchService."""
+
+    async def test_ship_template_via_dispatch_service(self):
+
+        saga_repo = InMemorySagaRepository()
+        svc = _make_service(saga_repo=saga_repo)
+        payload = {"repo": "niuulabs/volundr", "branch": "feat/release", "base_branch": "main"}
+
+        saga_id = await svc.create_saga_from_template("ship", payload, _OWNER, auto_start=False)
+
+        assert saga_id
+        assert len(saga_repo.phases) == 4
+
+    async def test_retro_template_via_dispatch_service(self):
+        saga_repo = InMemorySagaRepository()
+        svc = _make_service(saga_repo=saga_repo)
+        payload = {"week": "2026-W15"}
+
+        saga_id = await svc.create_saga_from_template("retro", payload, _OWNER, auto_start=False)
+
+        assert saga_id
+        assert len(saga_repo.phases) == 2

--- a/tests/test_tyr/test_template_dispatch.py
+++ b/tests/test_tyr/test_template_dispatch.py
@@ -3,152 +3,23 @@
 from __future__ import annotations
 
 import textwrap
-from collections.abc import AsyncGenerator
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
-from uuid import UUID
 
 import pytest
 
+from tests.test_tyr.stubs import InMemorySagaRepository, StubVolundrFactory, StubVolundrPort
 from tyr.adapters.memory_event_bus import InMemoryEventBus
-from tyr.domain.models import Phase, Raid, Saga, SagaStatus
+from tyr.domain.models import SagaStatus
 from tyr.domain.services.dispatch_service import DispatchConfig, DispatchService
 from tyr.ports.event_bus import TyrEvent
-from tyr.ports.saga_repository import SagaRepository
-from tyr.ports.volundr import (
-    ActivityEvent,
-    PRStatus,
-    SpawnRequest,
-    VolundrPort,
-    VolundrSession,
-)
 
 # ---------------------------------------------------------------------------
-# Stubs
+# Constants
 # ---------------------------------------------------------------------------
 
 _TS = datetime(2026, 4, 12, 10, 0, 0, tzinfo=UTC)
 _OWNER = "test-owner"
-
-
-class InMemorySagaRepository(SagaRepository):
-    def __init__(self) -> None:
-        self.sagas: dict[UUID, Saga] = {}
-        self.phases: dict[UUID, Phase] = {}
-        self.raids: dict[UUID, Raid] = {}
-
-    async def save_saga(self, saga: Saga, *, conn: Any = None) -> None:
-        self.sagas[saga.id] = saga
-
-    async def save_phase(self, phase: Phase, *, conn: Any = None) -> None:
-        self.phases[phase.id] = phase
-
-    async def save_raid(self, raid: Raid, *, conn: Any = None) -> None:
-        self.raids[raid.id] = raid
-
-    async def list_sagas(self, *, owner_id: str | None = None) -> list[Saga]:
-        if owner_id is None:
-            return list(self.sagas.values())
-        return [s for s in self.sagas.values() if s.owner_id == owner_id]
-
-    async def get_saga(self, saga_id: UUID, *, owner_id: str | None = None) -> Saga | None:
-        return self.sagas.get(saga_id)
-
-    async def get_saga_by_slug(self, slug: str) -> Saga | None:
-        return next((s for s in self.sagas.values() if s.slug == slug), None)
-
-    async def delete_saga(self, saga_id: UUID, *, owner_id: str | None = None) -> bool:
-        return self.sagas.pop(saga_id, None) is not None
-
-    async def update_saga_status(self, saga_id: UUID, status: SagaStatus) -> None:
-        saga = self.sagas.get(saga_id)
-        if saga:
-            self.sagas[saga_id] = Saga(
-                id=saga.id,
-                tracker_id=saga.tracker_id,
-                tracker_type=saga.tracker_type,
-                slug=saga.slug,
-                name=saga.name,
-                repos=saga.repos,
-                feature_branch=saga.feature_branch,
-                base_branch=saga.base_branch,
-                status=status,
-                confidence=saga.confidence,
-                created_at=saga.created_at,
-                owner_id=saga.owner_id,
-            )
-
-    async def count_by_status(self) -> dict[str, int]:
-        return {}
-
-
-class StubVolundrPort(VolundrPort):
-    def __init__(self, session_id: str = "sess-001") -> None:
-        self._session_id = session_id
-        self.spawned: list[SpawnRequest] = []
-
-    async def spawn_session(
-        self, request: SpawnRequest, *, auth_token: str | None = None
-    ) -> VolundrSession:
-        self.spawned.append(request)
-        return VolundrSession(
-            id=self._session_id,
-            name=request.name,
-            status="running",
-            tracker_issue_id=request.tracker_issue_id,
-        )
-
-    async def get_session(
-        self, session_id: str, *, auth_token: str | None = None
-    ) -> VolundrSession | None:
-        return None
-
-    async def list_sessions(self, *, auth_token: str | None = None) -> list[VolundrSession]:
-        return []
-
-    async def get_pr_status(self, session_id: str) -> PRStatus:
-        return PRStatus(exists=False, merged=False, url=None, ci_passed=False)
-
-    async def get_chronicle_summary(self, session_id: str) -> str:
-        return ""
-
-    async def send_message(
-        self, session_id: str, message: str, *, auth_token: str | None = None
-    ) -> None:
-        pass
-
-    async def stop_session(self, session_id: str, *, auth_token: str | None = None) -> None:
-        pass
-
-    async def list_integration_ids(self, *, auth_token: str | None = None) -> list[str]:
-        return []
-
-    async def list_repos(self, *, auth_token: str | None = None) -> list[dict]:
-        return []
-
-    async def get_last_assistant_message(self, session_id: str) -> str:
-        return ""
-
-    async def get_conversation(self, session_id: str) -> dict:
-        return {}
-
-    async def subscribe_activity(self) -> AsyncGenerator[ActivityEvent, None]:
-        return
-        yield  # type: ignore[misc]
-
-
-class StubVolundrFactory:
-    def __init__(self, volundr: VolundrPort | None = None) -> None:
-        self._volundr = volundr or StubVolundrPort()
-
-    async def for_owner(self, owner_id: str) -> list[VolundrPort]:
-        if self._volundr is None:
-            return []
-        return [self._volundr]
-
-    async def primary_for_owner(self, owner_id: str) -> VolundrPort | None:
-        return self._volundr
 
 
 class StubTrackerFactory:


### PR DESCRIPTION
## Summary

- **4 new bundled YAML saga templates**: `review.yaml` (4 phases, human approval gate), `ship.yaml` (4 phases), `deploy.yaml` (3 phases), `retro.yaml` (2 phases)
- **`src/tyr/domain/templates.py`**: template loader extracted to domain layer — `load_template()`, `_interpolate_value()`, `_validate_template()`, `SagaTemplate`/`TemplatePhase`/`TemplateRaid` dataclasses
- **`DispatchService.create_saga_from_template()`**: manual template dispatch; creates Saga + Phase + Raid DB records; optionally auto-starts Phase 1 via Volundr
- **Multi-phase sequential dispatch** in `EventTriggerAdapter`: only Phase 1 dispatched on saga creation; `advance_phase()` activates subsequent phases; `needs_approval: true` → `PhaseStatus.GATED` + event
- **Persona → profile mapping**: `SpawnRequest.profile` receives raid persona field
- **`postgres_sagas.py`**: `save_phase()` changed from `ON CONFLICT DO NOTHING` to `ON CONFLICT DO UPDATE SET status = EXCLUDED.status` to support phase status progression
- **Existing templates** (`investigate.yaml`, `reflect.yaml`): added required `persona` field to pass new validation

## Test plan

- [x] `tests/test_tyr/test_template_dispatch.py` — 10 tests for `create_saga_from_template()` (crud, auto_start, multi-phase, interpolation, validation errors, event emission, UUID return)
- [x] `TestDispatchServiceBundledTemplates` — smoke loads `ship` and `retro` via DispatchService
- [x] `tests/test_tyr/test_event_trigger.py` — updated for 4-phase review template, multi-phase dispatch, advance_phase, persona passthrough, bundled ship/retro templates
- [x] Coverage: `domain/templates` 98%, `event_trigger` 90%, `dispatch_service` 91% (all ≥85%)
- [x] `ruff check` + `ruff format` — clean

> **Linear NIU-589**: Could not update via MCP (tools unavailable in session). Ticket should be moved to "In Review" manually with a link to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)