### PR TITLE
feat(personas): extend PersonaConfig with produces/consumes/fan_in event contracts (NIU-593)

### DIFF
--- a/src/ravn/adapters/personas/loader.py
+++ b/src/ravn/adapters/personas/loader.py
@@ -24,14 +24,30 @@ Persona YAML format::
       primary_alias: balanced
       thinking_enabled: true
     iteration_budget: 40
+    produces:
+      event_type: review.completed
+      schema:
+        verdict:
+          type: enum
+          values: [pass, fail, needs_changes]
+        summary:
+          type: string
+    consumes:
+      event_types: [code.changed, review.requested]
+      injects: [repo, branch, diff_url]
+    fan_in:
+      strategy: all_must_pass
+      contributes_to: review.verdict
 """
 
 from __future__ import annotations
 
+import dataclasses
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
+from niuu.domain.outcome import OutcomeField, OutcomeSchema, generate_outcome_instruction
 from ravn.config import ProjectConfig, _safe_int
 from ravn.ports.persona import PersonaPort
 
@@ -52,6 +68,30 @@ class PersonaLLMConfig:
 
 
 @dataclass
+class PersonaProduces:
+    """What this persona outputs when it completes."""
+
+    event_type: str = ""
+    schema: dict[str, OutcomeField] = field(default_factory=dict)
+
+
+@dataclass
+class PersonaConsumes:
+    """What input this persona expects from previous stages."""
+
+    event_types: list[str] = field(default_factory=list)
+    injects: list[str] = field(default_factory=list)
+
+
+@dataclass
+class PersonaFanIn:
+    """How this persona's output combines with parallel peers."""
+
+    strategy: Literal["all_must_pass", "any_pass", "majority", "merge"] = "merge"
+    contributes_to: str = ""
+
+
+@dataclass
 class PersonaConfig:
     """A fully-resolved persona configuration.
 
@@ -67,6 +107,9 @@ class PersonaConfig:
     permission_mode: str = ""
     llm: PersonaLLMConfig = field(default_factory=PersonaLLMConfig)
     iteration_budget: int = 0
+    produces: PersonaProduces = field(default_factory=PersonaProduces)
+    consumes: PersonaConsumes = field(default_factory=PersonaConsumes)
+    fan_in: PersonaFanIn = field(default_factory=PersonaFanIn)
 
 
 # ---------------------------------------------------------------------------
@@ -217,6 +260,22 @@ _BUILTIN_PERSONAS: dict[str, PersonaConfig] = {
         permission_mode="workspace-write",
         llm=PersonaLLMConfig(primary_alias="balanced", thinking_enabled=False),
         iteration_budget=60,
+        produces=PersonaProduces(
+            event_type="dream.completed",
+            schema={
+                "pages_updated": OutcomeField(
+                    type="number", description="number of wiki pages updated"
+                ),
+                "entities_created": OutcomeField(
+                    type="number", description="number of entities created"
+                ),
+                "lint_fixes": OutcomeField(
+                    type="number", description="number of lint fixes applied"
+                ),
+                "summary": OutcomeField(type="string", description="one-line summary"),
+            },
+        ),
+        consumes=PersonaConsumes(event_types=["cron.weekly", "mimir.dream.requested"]),
     ),
     "produce-recap": PersonaConfig(
         name="produce-recap",
@@ -298,6 +357,191 @@ _BUILTIN_PERSONAS: dict[str, PersonaConfig] = {
         llm=PersonaLLMConfig(primary_alias="balanced", thinking_enabled=False),
         iteration_budget=15,
     ),
+    # --- Specialist pipeline personas ---
+    "reviewer": PersonaConfig(
+        name="reviewer",
+        system_prompt_template=(
+            "You are a code reviewer. You read diffs, identify issues, and produce a "
+            "structured verdict with detailed findings.\n\n"
+            "## Your responsibilities\n"
+            "- Review the diff or files at the provided repo/branch.\n"
+            "- Count all findings, distinguishing critical from non-critical.\n"
+            "- Apply `pass` when changes are ready to merge with no blocking issues.\n"
+            "- Apply `needs_changes` for non-critical issues requiring revision.\n"
+            "- Apply `fail` for critical issues blocking merge.\n"
+            "- Write a concise one-line summary of the overall review."
+        ),
+        allowed_tools=["file", "git", "web", "ravn"],
+        forbidden_tools=["terminal", "cascade"],
+        permission_mode="read-only",
+        llm=PersonaLLMConfig(primary_alias="balanced", thinking_enabled=True),
+        iteration_budget=20,
+        produces=PersonaProduces(
+            event_type="review.completed",
+            schema={
+                "verdict": OutcomeField(
+                    type="enum",
+                    description="review verdict",
+                    enum_values=["pass", "fail", "needs_changes"],
+                ),
+                "findings_count": OutcomeField(
+                    type="number", description="total number of findings"
+                ),
+                "critical_count": OutcomeField(
+                    type="number", description="number of critical findings"
+                ),
+                "summary": OutcomeField(type="string", description="one-line review summary"),
+            },
+        ),
+        consumes=PersonaConsumes(
+            event_types=["code.changed", "review.requested"],
+            injects=["repo", "branch", "diff_url"],
+        ),
+        fan_in=PersonaFanIn(strategy="all_must_pass", contributes_to="review.verdict"),
+    ),
+    "security-auditor": PersonaConfig(
+        name="security-auditor",
+        system_prompt_template=(
+            "You are a security auditor. You analyse code changes for security "
+            "vulnerabilities and produce a structured security verdict.\n\n"
+            "## Your responsibilities\n"
+            "- Review the diff or files at the provided repo/branch for security issues.\n"
+            "- Look for OWASP Top 10 vulnerabilities, secrets in code, insecure patterns.\n"
+            "- Count critical security findings (e.g. injection, auth bypass, data exposure).\n"
+            "- Apply `pass` when no security issues are found.\n"
+            "- Apply `needs_review` for issues requiring attention but not blocking.\n"
+            "- Apply `fail` for critical security vulnerabilities blocking merge.\n"
+            "- Write a concise one-line summary of your security assessment."
+        ),
+        allowed_tools=["file", "git", "web", "ravn"],
+        forbidden_tools=["terminal", "cascade"],
+        permission_mode="read-only",
+        llm=PersonaLLMConfig(primary_alias="balanced", thinking_enabled=True),
+        iteration_budget=20,
+        produces=PersonaProduces(
+            event_type="security.completed",
+            schema={
+                "verdict": OutcomeField(
+                    type="enum",
+                    description="security verdict",
+                    enum_values=["pass", "fail", "needs_review"],
+                ),
+                "critical_findings": OutcomeField(
+                    type="number", description="number of critical security findings"
+                ),
+                "summary": OutcomeField(
+                    type="string", description="one-line security assessment summary"
+                ),
+            },
+        ),
+        consumes=PersonaConsumes(
+            event_types=["code.changed"],
+            injects=["repo", "branch"],
+        ),
+        fan_in=PersonaFanIn(strategy="all_must_pass", contributes_to="review.verdict"),
+    ),
+    "qa-agent": PersonaConfig(
+        name="qa-agent",
+        system_prompt_template=(
+            "You are a QA agent. You validate that code changes pass quality checks "
+            "and produce a structured test verdict.\n\n"
+            "## Your responsibilities\n"
+            "- Run or evaluate tests for the provided repo/branch.\n"
+            "- Report the total number of tests run and how many failed.\n"
+            "- Apply `pass` when all tests pass.\n"
+            "- Apply `fail` when one or more tests fail.\n"
+            "- Write a concise one-line summary of the test results."
+        ),
+        allowed_tools=["file", "git", "terminal", "ravn"],
+        forbidden_tools=["cascade", "volundr"],
+        permission_mode="workspace-write",
+        llm=PersonaLLMConfig(primary_alias="balanced", thinking_enabled=False),
+        iteration_budget=30,
+        produces=PersonaProduces(
+            event_type="qa.completed",
+            schema={
+                "verdict": OutcomeField(
+                    type="enum",
+                    description="QA verdict",
+                    enum_values=["pass", "fail"],
+                ),
+                "tests_run": OutcomeField(type="number", description="total tests run"),
+                "tests_failed": OutcomeField(type="number", description="tests that failed"),
+                "summary": OutcomeField(type="string", description="one-line test results summary"),
+            },
+        ),
+        consumes=PersonaConsumes(
+            event_types=["review.completed", "test.requested"],
+            injects=["repo", "branch", "previous_verdicts"],
+        ),
+    ),
+    "ship-agent": PersonaConfig(
+        name="ship-agent",
+        system_prompt_template=(
+            "You are a ship agent. You merge approved changes, tag releases, and "
+            "produce a structured shipping verdict.\n\n"
+            "## Your responsibilities\n"
+            "- Verify that all upstream verdicts (review, QA) pass before shipping.\n"
+            "- Merge the branch and create a release tag.\n"
+            "- Record the version and PR URL.\n"
+            "- Apply `shipped` when the change is successfully merged and released.\n"
+            "- Apply `blocked` when any upstream gate has not passed.\n"
+            "- Write a concise one-line summary of the shipping action."
+        ),
+        allowed_tools=["file", "git", "terminal", "web", "ravn"],
+        forbidden_tools=["cascade"],
+        permission_mode="workspace-write",
+        llm=PersonaLLMConfig(primary_alias="balanced", thinking_enabled=False),
+        iteration_budget=15,
+        produces=PersonaProduces(
+            event_type="ship.completed",
+            schema={
+                "verdict": OutcomeField(
+                    type="enum",
+                    description="ship verdict",
+                    enum_values=["shipped", "blocked"],
+                ),
+                "version": OutcomeField(type="string", description="released version tag"),
+                "pr_url": OutcomeField(type="string", description="pull request URL"),
+                "summary": OutcomeField(type="string", description="one-line shipping summary"),
+            },
+        ),
+        consumes=PersonaConsumes(
+            event_types=["qa.completed", "ship.requested"],
+            injects=["repo", "branch", "previous_verdicts"],
+        ),
+    ),
+    "retro-analyst": PersonaConfig(
+        name="retro-analyst",
+        system_prompt_template=(
+            "You are a retrospective analyst. You review shipped work over a time period, "
+            "identify patterns, and produce a structured retrospective report.\n\n"
+            "## Your responsibilities\n"
+            "- Count the items shipped since the last retrospective.\n"
+            "- Identify recurring patterns (positive and negative) in the work.\n"
+            "- Write a concise one-line summary of the retrospective findings."
+        ),
+        allowed_tools=["mimir", "file", "ravn"],
+        forbidden_tools=["terminal", "cascade"],
+        permission_mode="read-only",
+        llm=PersonaLLMConfig(primary_alias="balanced", thinking_enabled=False),
+        iteration_budget=15,
+        produces=PersonaProduces(
+            event_type="retro.completed",
+            schema={
+                "items_shipped": OutcomeField(type="number", description="number of items shipped"),
+                "patterns_found": OutcomeField(
+                    type="number", description="number of patterns identified"
+                ),
+                "summary": OutcomeField(
+                    type="string", description="one-line retrospective summary"
+                ),
+            },
+        ),
+        consumes=PersonaConsumes(
+            event_types=["retro.requested", "cron.weekly"],
+        ),
+    ),
 }
 
 # ---------------------------------------------------------------------------
@@ -312,6 +556,81 @@ def _safe_bool(val: Any, default: bool = False) -> bool:
     if isinstance(val, str):
         return val.lower() in {"true", "yes", "1"}
     return default
+
+
+_VALID_FAN_IN_STRATEGIES = {"all_must_pass", "any_pass", "majority", "merge"}
+
+
+def _parse_outcome_field(name: str, raw: Any) -> OutcomeField | None:
+    """Parse a single outcome field dict from YAML into an OutcomeField."""
+    if not isinstance(raw, dict):
+        return None
+    field_type = str(raw.get("type", "string"))
+    description = str(raw.get("description", name))
+    required = _safe_bool(raw.get("required", True), default=True)
+    enum_values: list[str] | None = None
+    if field_type == "enum":
+        vals = raw.get("values") or raw.get("enum_values")
+        if isinstance(vals, list):
+            enum_values = [str(v) for v in vals]
+    return OutcomeField(
+        type=field_type,  # type: ignore[arg-type]
+        description=description,
+        enum_values=enum_values,
+        required=required,
+    )
+
+
+def _parse_produces(raw: Any) -> PersonaProduces:
+    """Parse the ``produces:`` section of a persona YAML dict."""
+    if not isinstance(raw, dict):
+        return PersonaProduces()
+    event_type = str(raw.get("event_type", ""))
+    schema: dict[str, OutcomeField] = {}
+    schema_raw = raw.get("schema")
+    if isinstance(schema_raw, dict):
+        for fname, fval in schema_raw.items():
+            parsed = _parse_outcome_field(fname, fval)
+            if parsed is not None:
+                schema[fname] = parsed
+    return PersonaProduces(event_type=event_type, schema=schema)
+
+
+def _parse_consumes(raw: Any) -> PersonaConsumes:
+    """Parse the ``consumes:`` section of a persona YAML dict."""
+    if not isinstance(raw, dict):
+        return PersonaConsumes()
+    event_types_raw = raw.get("event_types", [])
+    injects_raw = raw.get("injects", [])
+    event_types = list(event_types_raw) if isinstance(event_types_raw, list) else []
+    injects = list(injects_raw) if isinstance(injects_raw, list) else []
+    return PersonaConsumes(event_types=event_types, injects=injects)
+
+
+def _parse_fan_in(raw: Any) -> PersonaFanIn:
+    """Parse the ``fan_in:`` section of a persona YAML dict."""
+    if not isinstance(raw, dict):
+        return PersonaFanIn()
+    strategy = str(raw.get("strategy", "merge"))
+    if strategy not in _VALID_FAN_IN_STRATEGIES:
+        strategy = "merge"
+    contributes_to = str(raw.get("contributes_to", ""))
+    return PersonaFanIn(
+        strategy=strategy,  # type: ignore[arg-type]
+        contributes_to=contributes_to,
+    )
+
+
+def _apply_outcome_instruction(persona: PersonaConfig) -> PersonaConfig:
+    """Append outcome block instruction to system prompt when schema is declared."""
+    if not persona.produces.schema:
+        return persona
+    schema = OutcomeSchema(fields=persona.produces.schema)
+    instruction = generate_outcome_instruction(schema)
+    return dataclasses.replace(
+        persona,
+        system_prompt_template=persona.system_prompt_template + "\n\n" + instruction,
+    )
 
 
 class PersonaLoader(PersonaPort):
@@ -334,22 +653,33 @@ class PersonaLoader(PersonaPort):
     # ------------------------------------------------------------------
 
     def load(self, name: str) -> PersonaConfig | None:
-        """Load a persona by name.
+        """Load a persona by name, with outcome instruction injected if applicable.
 
         Returns the persona from ``personas_dir/<name>.yaml`` if it exists,
         otherwise falls back to the built-in set.  Returns ``None`` when the
         name cannot be resolved.
+
+        If the persona declares a ``produces.schema``, the outcome block
+        instruction is automatically appended to its system prompt.
         """
         file_path = self._personas_dir / f"{name}.yaml"
         if file_path.is_file():
-            return self.load_from_file(file_path)
-        return _BUILTIN_PERSONAS.get(name)
+            persona = self.load_from_file(file_path)
+        else:
+            persona = _BUILTIN_PERSONAS.get(name)
+
+        if persona is None:
+            return None
+
+        return _apply_outcome_instruction(persona)
 
     def load_from_file(self, path: Path) -> PersonaConfig | None:
-        """Parse a persona YAML file.
+        """Parse a persona YAML file without injecting outcome instructions.
 
         Returns ``None`` when the file is unreadable or malformed rather than
         raising, so callers can treat missing personas as a soft error.
+
+        Note: outcome instruction injection happens in :meth:`load`, not here.
         """
         try:
             text = path.read_text(encoding="utf-8", errors="replace")
@@ -374,6 +704,32 @@ class PersonaLoader(PersonaPort):
         """Return a sorted list of built-in persona names."""
         return sorted(_BUILTIN_PERSONAS)
 
+    def find_consumers(self, event_type: str) -> list[PersonaConfig]:
+        """Return all personas that declare they consume the given event type.
+
+        Used by the pipeline executor to validate pipeline definitions.
+        Returns personas with outcome instructions already injected (via :meth:`load`).
+        """
+        result: list[PersonaConfig] = []
+        for name in self.list_names():
+            persona = self.load(name)
+            if persona and event_type in persona.consumes.event_types:
+                result.append(persona)
+        return result
+
+    def find_producers(self, event_type: str) -> list[PersonaConfig]:
+        """Return all personas that produce the given event type.
+
+        Used by the pipeline executor to validate pipeline definitions.
+        Returns personas with outcome instructions already injected (via :meth:`load`).
+        """
+        result: list[PersonaConfig] = []
+        for name in self.list_names():
+            persona = self.load(name)
+            if persona and persona.produces.event_type == event_type:
+                result.append(persona)
+        return result
+
     # ------------------------------------------------------------------
     # Static helpers
     # ------------------------------------------------------------------
@@ -383,6 +739,7 @@ class PersonaLoader(PersonaPort):
         """Parse a persona YAML *text* string.
 
         Returns ``None`` on empty input or parse failure.
+        Handles ``produces``, ``consumes``, and ``fan_in`` sections.
         """
         import yaml  # PyYAML — present via pydantic-settings[yaml]
 
@@ -422,6 +779,9 @@ class PersonaLoader(PersonaPort):
             permission_mode=str(raw.get("permission_mode", "")),
             llm=llm,
             iteration_budget=_safe_int(raw.get("iteration_budget", 0)),
+            produces=_parse_produces(raw.get("produces")),
+            consumes=_parse_consumes(raw.get("consumes")),
+            fan_in=_parse_fan_in(raw.get("fan_in")),
         )
 
     @staticmethod
@@ -429,8 +789,9 @@ class PersonaLoader(PersonaPort):
         """Return a new PersonaConfig with RAVN.md *project* overrides applied.
 
         Non-empty / non-zero project fields take precedence over persona fields.
-        The persona's ``name`` and ``llm`` settings are never overridden by
-        ProjectConfig (which has no equivalent fields).
+        The persona's ``name``, ``llm``, ``produces``, ``consumes``, and
+        ``fan_in`` settings are never overridden by ProjectConfig (which has no
+        equivalent fields).
         """
         return PersonaConfig(
             name=persona.name,
@@ -446,4 +807,7 @@ class PersonaLoader(PersonaPort):
             iteration_budget=(
                 project.iteration_budget if project.iteration_budget else persona.iteration_budget
             ),
+            produces=persona.produces,
+            consumes=persona.consumes,
+            fan_in=persona.fan_in,
         )

--- a/tests/test_ravn/test_persona_contracts.py
+++ b/tests/test_ravn/test_persona_contracts.py
@@ -1,0 +1,744 @@
+"""Tests for persona event contracts — produces, consumes, fan_in, and outcome injection.
+
+Covers NIU-593: PersonaConfig extended with event contract fields.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from niuu.domain.outcome import OutcomeField
+from ravn.adapters.personas.loader import (
+    _BUILTIN_PERSONAS,
+    PersonaConfig,
+    PersonaConsumes,
+    PersonaFanIn,
+    PersonaLoader,
+    PersonaProduces,
+    _apply_outcome_instruction,
+    _parse_consumes,
+    _parse_fan_in,
+    _parse_produces,
+)
+
+# ---------------------------------------------------------------------------
+# YAML fixtures — specialist personas
+# ---------------------------------------------------------------------------
+
+_REVIEWER_YAML = """\
+name: reviewer
+system_prompt_template: |
+  You are a code reviewer.
+allowed_tools: [file, git]
+permission_mode: read-only
+produces:
+  event_type: review.completed
+  schema:
+    verdict:
+      type: enum
+      values: [pass, fail, needs_changes]
+    findings_count:
+      type: number
+    critical_count:
+      type: number
+    summary:
+      type: string
+consumes:
+  event_types: [code.changed, review.requested]
+  injects: [repo, branch, diff_url]
+fan_in:
+  strategy: all_must_pass
+  contributes_to: review.verdict
+"""
+
+_SECURITY_AUDITOR_YAML = """\
+name: security-auditor
+system_prompt_template: You are a security auditor.
+produces:
+  event_type: security.completed
+  schema:
+    verdict:
+      type: enum
+      values: [pass, fail, needs_review]
+    critical_findings:
+      type: number
+    summary:
+      type: string
+consumes:
+  event_types: [code.changed]
+  injects: [repo, branch]
+fan_in:
+  strategy: all_must_pass
+  contributes_to: review.verdict
+"""
+
+_QA_AGENT_YAML = """\
+name: qa-agent
+system_prompt_template: You are a QA agent.
+produces:
+  event_type: qa.completed
+  schema:
+    verdict:
+      type: enum
+      values: [pass, fail]
+    tests_run:
+      type: number
+    tests_failed:
+      type: number
+    summary:
+      type: string
+consumes:
+  event_types: [review.completed, test.requested]
+  injects: [repo, branch, previous_verdicts]
+"""
+
+_SHIP_AGENT_YAML = """\
+name: ship-agent
+system_prompt_template: You are a ship agent.
+produces:
+  event_type: ship.completed
+  schema:
+    verdict:
+      type: enum
+      values: [shipped, blocked]
+    version:
+      type: string
+    pr_url:
+      type: string
+    summary:
+      type: string
+consumes:
+  event_types: [qa.completed, ship.requested]
+  injects: [repo, branch, previous_verdicts]
+"""
+
+_RETRO_ANALYST_YAML = """\
+name: retro-analyst
+system_prompt_template: You are a retro analyst.
+produces:
+  event_type: retro.completed
+  schema:
+    items_shipped:
+      type: number
+    patterns_found:
+      type: number
+    summary:
+      type: string
+consumes:
+  event_types: [retro.requested, cron.weekly]
+"""
+
+_NO_CONTRACT_YAML = """\
+name: simple-agent
+system_prompt_template: You are a simple agent.
+allowed_tools: [file]
+permission_mode: read-only
+"""
+
+
+# ---------------------------------------------------------------------------
+# PersonaProduces / PersonaConsumes / PersonaFanIn dataclass defaults
+# ---------------------------------------------------------------------------
+
+
+class TestPersonaContractDefaults:
+    def test_produces_defaults(self) -> None:
+        p = PersonaProduces()
+        assert p.event_type == ""
+        assert p.schema == {}
+
+    def test_consumes_defaults(self) -> None:
+        c = PersonaConsumes()
+        assert c.event_types == []
+        assert c.injects == []
+
+    def test_fan_in_defaults(self) -> None:
+        f = PersonaFanIn()
+        assert f.strategy == "merge"
+        assert f.contributes_to == ""
+
+    def test_persona_config_contract_defaults(self) -> None:
+        cfg = PersonaConfig(name="x")
+        assert cfg.produces.event_type == ""
+        assert cfg.produces.schema == {}
+        assert cfg.consumes.event_types == []
+        assert cfg.fan_in.strategy == "merge"
+
+
+# ---------------------------------------------------------------------------
+# _parse_produces
+# ---------------------------------------------------------------------------
+
+
+class TestParseProduces:
+    def test_none_returns_empty(self) -> None:
+        p = _parse_produces(None)
+        assert p.event_type == ""
+        assert p.schema == {}
+
+    def test_non_dict_returns_empty(self) -> None:
+        p = _parse_produces("invalid")
+        assert p.event_type == ""
+        assert p.schema == {}
+
+    def test_parses_event_type(self) -> None:
+        p = _parse_produces({"event_type": "review.completed", "schema": {}})
+        assert p.event_type == "review.completed"
+
+    def test_parses_enum_field(self) -> None:
+        raw = {
+            "event_type": "x",
+            "schema": {
+                "verdict": {
+                    "type": "enum",
+                    "values": ["pass", "fail"],
+                }
+            },
+        }
+        p = _parse_produces(raw)
+        assert "verdict" in p.schema
+        f = p.schema["verdict"]
+        assert f.type == "enum"
+        assert f.enum_values == ["pass", "fail"]
+
+    def test_parses_number_field(self) -> None:
+        raw = {"schema": {"count": {"type": "number"}}}
+        p = _parse_produces(raw)
+        assert p.schema["count"].type == "number"
+
+    def test_parses_string_field(self) -> None:
+        raw = {"schema": {"summary": {"type": "string"}}}
+        p = _parse_produces(raw)
+        assert p.schema["summary"].type == "string"
+
+    def test_field_description_defaults_to_field_name(self) -> None:
+        raw = {"schema": {"my_field": {"type": "string"}}}
+        p = _parse_produces(raw)
+        assert p.schema["my_field"].description == "my_field"
+
+    def test_field_description_from_yaml(self) -> None:
+        raw = {"schema": {"summary": {"type": "string", "description": "a summary"}}}
+        p = _parse_produces(raw)
+        assert p.schema["summary"].description == "a summary"
+
+    def test_field_required_defaults_true(self) -> None:
+        raw = {"schema": {"x": {"type": "string"}}}
+        p = _parse_produces(raw)
+        assert p.schema["x"].required is True
+
+    def test_field_required_false(self) -> None:
+        raw = {"schema": {"x": {"type": "string", "required": False}}}
+        p = _parse_produces(raw)
+        assert p.schema["x"].required is False
+
+    def test_invalid_field_value_skipped(self) -> None:
+        raw = {"schema": {"good": {"type": "string"}, "bad": "not-a-dict"}}
+        p = _parse_produces(raw)
+        assert "good" in p.schema
+        assert "bad" not in p.schema
+
+    def test_missing_schema_section(self) -> None:
+        p = _parse_produces({"event_type": "x"})
+        assert p.schema == {}
+
+
+# ---------------------------------------------------------------------------
+# _parse_consumes
+# ---------------------------------------------------------------------------
+
+
+class TestParseConsumes:
+    def test_none_returns_empty(self) -> None:
+        c = _parse_consumes(None)
+        assert c.event_types == []
+        assert c.injects == []
+
+    def test_non_dict_returns_empty(self) -> None:
+        c = _parse_consumes("bad")
+        assert c.event_types == []
+
+    def test_parses_event_types(self) -> None:
+        c = _parse_consumes({"event_types": ["code.changed", "review.requested"]})
+        assert c.event_types == ["code.changed", "review.requested"]
+
+    def test_parses_injects(self) -> None:
+        c = _parse_consumes({"injects": ["repo", "branch"]})
+        assert c.injects == ["repo", "branch"]
+
+    def test_non_list_event_types_becomes_empty(self) -> None:
+        c = _parse_consumes({"event_types": "not-a-list"})
+        assert c.event_types == []
+
+    def test_non_list_injects_becomes_empty(self) -> None:
+        c = _parse_consumes({"injects": 42})
+        assert c.injects == []
+
+
+# ---------------------------------------------------------------------------
+# _parse_fan_in
+# ---------------------------------------------------------------------------
+
+
+class TestParseFanIn:
+    def test_none_returns_defaults(self) -> None:
+        f = _parse_fan_in(None)
+        assert f.strategy == "merge"
+        assert f.contributes_to == ""
+
+    def test_non_dict_returns_defaults(self) -> None:
+        f = _parse_fan_in("bad")
+        assert f.strategy == "merge"
+
+    def test_parses_strategy(self) -> None:
+        f = _parse_fan_in({"strategy": "all_must_pass"})
+        assert f.strategy == "all_must_pass"
+
+    def test_parses_contributes_to(self) -> None:
+        f = _parse_fan_in({"contributes_to": "review.verdict"})
+        assert f.contributes_to == "review.verdict"
+
+    def test_invalid_strategy_defaults_to_merge(self) -> None:
+        f = _parse_fan_in({"strategy": "unknown_strategy"})
+        assert f.strategy == "merge"
+
+    def test_all_valid_strategies(self) -> None:
+        for strategy in ("all_must_pass", "any_pass", "majority", "merge"):
+            f = _parse_fan_in({"strategy": strategy})
+            assert f.strategy == strategy
+
+
+# ---------------------------------------------------------------------------
+# PersonaLoader.parse — new sections
+# ---------------------------------------------------------------------------
+
+
+class TestPersonaLoaderParseContracts:
+    def test_reviewer_yaml_parses_produces(self) -> None:
+        cfg = PersonaLoader.parse(_REVIEWER_YAML)
+        assert cfg is not None
+        assert cfg.produces.event_type == "review.completed"
+        assert "verdict" in cfg.produces.schema
+        assert cfg.produces.schema["verdict"].enum_values == ["pass", "fail", "needs_changes"]
+        assert "findings_count" in cfg.produces.schema
+        assert "critical_count" in cfg.produces.schema
+        assert "summary" in cfg.produces.schema
+
+    def test_reviewer_yaml_parses_consumes(self) -> None:
+        cfg = PersonaLoader.parse(_REVIEWER_YAML)
+        assert cfg is not None
+        assert "code.changed" in cfg.consumes.event_types
+        assert "review.requested" in cfg.consumes.event_types
+        assert "repo" in cfg.consumes.injects
+        assert "branch" in cfg.consumes.injects
+        assert "diff_url" in cfg.consumes.injects
+
+    def test_reviewer_yaml_parses_fan_in(self) -> None:
+        cfg = PersonaLoader.parse(_REVIEWER_YAML)
+        assert cfg is not None
+        assert cfg.fan_in.strategy == "all_must_pass"
+        assert cfg.fan_in.contributes_to == "review.verdict"
+
+    def test_security_auditor_yaml_parses_contract(self) -> None:
+        cfg = PersonaLoader.parse(_SECURITY_AUDITOR_YAML)
+        assert cfg is not None
+        assert cfg.produces.event_type == "security.completed"
+        assert "verdict" in cfg.produces.schema
+        assert cfg.produces.schema["verdict"].enum_values == ["pass", "fail", "needs_review"]
+        assert "code.changed" in cfg.consumes.event_types
+        assert cfg.fan_in.strategy == "all_must_pass"
+
+    def test_qa_agent_yaml_parses_contract(self) -> None:
+        cfg = PersonaLoader.parse(_QA_AGENT_YAML)
+        assert cfg is not None
+        assert cfg.produces.event_type == "qa.completed"
+        assert cfg.produces.schema["verdict"].enum_values == ["pass", "fail"]
+        assert "tests_run" in cfg.produces.schema
+        assert "tests_failed" in cfg.produces.schema
+        assert "review.completed" in cfg.consumes.event_types
+        assert "test.requested" in cfg.consumes.event_types
+
+    def test_ship_agent_yaml_parses_contract(self) -> None:
+        cfg = PersonaLoader.parse(_SHIP_AGENT_YAML)
+        assert cfg is not None
+        assert cfg.produces.event_type == "ship.completed"
+        assert cfg.produces.schema["verdict"].enum_values == ["shipped", "blocked"]
+        assert "version" in cfg.produces.schema
+        assert "pr_url" in cfg.produces.schema
+        assert "qa.completed" in cfg.consumes.event_types
+
+    def test_retro_analyst_yaml_parses_contract(self) -> None:
+        cfg = PersonaLoader.parse(_RETRO_ANALYST_YAML)
+        assert cfg is not None
+        assert cfg.produces.event_type == "retro.completed"
+        assert "items_shipped" in cfg.produces.schema
+        assert "patterns_found" in cfg.produces.schema
+        assert "retro.requested" in cfg.consumes.event_types
+        assert "cron.weekly" in cfg.consumes.event_types
+        # No fan_in section → defaults
+        assert cfg.fan_in.strategy == "merge"
+
+    def test_persona_without_contract_keeps_defaults(self) -> None:
+        cfg = PersonaLoader.parse(_NO_CONTRACT_YAML)
+        assert cfg is not None
+        assert cfg.produces.event_type == ""
+        assert cfg.produces.schema == {}
+        assert cfg.consumes.event_types == []
+        assert cfg.fan_in.strategy == "merge"
+
+
+# ---------------------------------------------------------------------------
+# _apply_outcome_instruction
+# ---------------------------------------------------------------------------
+
+
+class TestApplyOutcomeInstruction:
+    def test_no_schema_returns_persona_unchanged(self) -> None:
+        persona = PersonaConfig(name="x", system_prompt_template="hello")
+        result = _apply_outcome_instruction(persona)
+        assert result is persona  # same object, not a copy
+
+    def test_with_schema_appends_instruction(self) -> None:
+        persona = PersonaConfig(
+            name="x",
+            system_prompt_template="hello",
+            produces=PersonaProduces(
+                event_type="x.done",
+                schema={"summary": OutcomeField(type="string", description="summary")},
+            ),
+        )
+        result = _apply_outcome_instruction(persona)
+        assert result is not persona
+        assert "---outcome---" in result.system_prompt_template
+        assert "---end---" in result.system_prompt_template
+
+    def test_with_enum_schema_includes_values_in_instruction(self) -> None:
+        persona = PersonaConfig(
+            name="x",
+            system_prompt_template="base",
+            produces=PersonaProduces(
+                event_type="x.done",
+                schema={
+                    "verdict": OutcomeField(
+                        type="enum",
+                        description="verdict",
+                        enum_values=["pass", "fail"],
+                    )
+                },
+            ),
+        )
+        result = _apply_outcome_instruction(persona)
+        assert "pass | fail" in result.system_prompt_template
+
+    def test_original_prompt_preserved_before_instruction(self) -> None:
+        persona = PersonaConfig(
+            name="x",
+            system_prompt_template="original prompt",
+            produces=PersonaProduces(
+                event_type="x.done",
+                schema={"v": OutcomeField(type="string", description="v")},
+            ),
+        )
+        result = _apply_outcome_instruction(persona)
+        assert result.system_prompt_template.startswith("original prompt")
+
+    def test_other_fields_unchanged(self) -> None:
+        persona = PersonaConfig(
+            name="x",
+            allowed_tools=["file"],
+            permission_mode="read-only",
+            produces=PersonaProduces(
+                event_type="x.done",
+                schema={"v": OutcomeField(type="string", description="v")},
+            ),
+        )
+        result = _apply_outcome_instruction(persona)
+        assert result.allowed_tools == ["file"]
+        assert result.permission_mode == "read-only"
+
+
+# ---------------------------------------------------------------------------
+# PersonaLoader.load — outcome injection
+# ---------------------------------------------------------------------------
+
+
+class TestPersonaLoaderLoadInjection:
+    def test_reviewer_builtin_has_outcome_instruction(self) -> None:
+        loader = PersonaLoader()
+        persona = loader.load("reviewer")
+        assert persona is not None
+        assert "---outcome---" in persona.system_prompt_template
+        assert "---end---" in persona.system_prompt_template
+
+    def test_reviewer_outcome_includes_verdict_field(self) -> None:
+        loader = PersonaLoader()
+        persona = loader.load("reviewer")
+        assert persona is not None
+        assert "verdict:" in persona.system_prompt_template
+        assert "pass | fail | needs_changes" in persona.system_prompt_template
+
+    def test_coding_agent_no_outcome_instruction(self) -> None:
+        loader = PersonaLoader()
+        persona = loader.load("coding-agent")
+        assert persona is not None
+        assert "---outcome---" not in persona.system_prompt_template
+
+    def test_security_auditor_has_outcome_instruction(self) -> None:
+        loader = PersonaLoader()
+        persona = loader.load("security-auditor")
+        assert persona is not None
+        assert "---outcome---" in persona.system_prompt_template
+        assert "pass | fail | needs_review" in persona.system_prompt_template
+
+    def test_qa_agent_has_outcome_instruction(self) -> None:
+        loader = PersonaLoader()
+        persona = loader.load("qa-agent")
+        assert persona is not None
+        assert "---outcome---" in persona.system_prompt_template
+        assert "tests_run" in persona.system_prompt_template
+
+    def test_ship_agent_has_outcome_instruction(self) -> None:
+        loader = PersonaLoader()
+        persona = loader.load("ship-agent")
+        assert persona is not None
+        assert "---outcome---" in persona.system_prompt_template
+        assert "shipped | blocked" in persona.system_prompt_template
+
+    def test_retro_analyst_has_outcome_instruction(self) -> None:
+        loader = PersonaLoader()
+        persona = loader.load("retro-analyst")
+        assert persona is not None
+        assert "---outcome---" in persona.system_prompt_template
+        assert "items_shipped" in persona.system_prompt_template
+
+    def test_mimir_curator_has_outcome_instruction(self) -> None:
+        loader = PersonaLoader()
+        persona = loader.load("mimir-curator")
+        assert persona is not None
+        assert "---outcome---" in persona.system_prompt_template
+
+    def test_file_persona_with_contract_gets_injection(self, tmp_path: Path) -> None:
+        p = tmp_path / "my-persona.yaml"
+        p.write_text(_REVIEWER_YAML, encoding="utf-8")
+        loader = PersonaLoader(personas_dir=tmp_path)
+        persona = loader.load("my-persona")
+        assert persona is not None
+        assert "---outcome---" in persona.system_prompt_template
+
+    def test_file_persona_without_contract_no_injection(self, tmp_path: Path) -> None:
+        p = tmp_path / "simple.yaml"
+        p.write_text(_NO_CONTRACT_YAML, encoding="utf-8")
+        loader = PersonaLoader(personas_dir=tmp_path)
+        persona = loader.load("simple")
+        assert persona is not None
+        assert "---outcome---" not in persona.system_prompt_template
+
+
+# ---------------------------------------------------------------------------
+# PersonaLoader E2E — matches delivery criteria
+# ---------------------------------------------------------------------------
+
+
+class TestPersonaContractE2E:
+    def test_persona_outcome_instruction_injected(self) -> None:
+        """Loading reviewer persona → effective system prompt ends with outcome block."""
+        loader = PersonaLoader()
+        persona = loader.load("reviewer")
+        assert persona is not None
+        assert "---outcome---" in persona.system_prompt_template
+        assert "verdict:" in persona.system_prompt_template
+        assert "pass | fail | needs_changes" in persona.system_prompt_template
+
+    def test_persona_without_contract_unchanged(self) -> None:
+        """Loading coding-agent → no outcome block in system prompt."""
+        loader = PersonaLoader()
+        persona = loader.load("coding-agent")
+        assert "---outcome---" not in persona.system_prompt_template
+
+
+# ---------------------------------------------------------------------------
+# PersonaLoader.find_consumers / find_producers
+# ---------------------------------------------------------------------------
+
+
+class TestFindConsumersProducers:
+    def test_find_consumers_code_changed_returns_reviewer_and_security_auditor(self) -> None:
+        loader = PersonaLoader()
+        consumers = loader.find_consumers("code.changed")
+        names = [p.name for p in consumers]
+        assert "reviewer" in names
+        assert "security-auditor" in names
+
+    def test_find_consumers_review_completed_returns_qa_agent(self) -> None:
+        loader = PersonaLoader()
+        consumers = loader.find_consumers("review.completed")
+        names = [p.name for p in consumers]
+        assert "qa-agent" in names
+
+    def test_find_consumers_unknown_event_returns_empty(self) -> None:
+        loader = PersonaLoader()
+        consumers = loader.find_consumers("does.not.exist")
+        assert consumers == []
+
+    def test_find_producers_review_completed_returns_reviewer(self) -> None:
+        loader = PersonaLoader()
+        producers = loader.find_producers("review.completed")
+        names = [p.name for p in producers]
+        assert "reviewer" in names
+
+    def test_find_producers_qa_completed_returns_qa_agent(self) -> None:
+        loader = PersonaLoader()
+        producers = loader.find_producers("qa.completed")
+        names = [p.name for p in producers]
+        assert "qa-agent" in names
+
+    def test_find_producers_unknown_event_returns_empty(self) -> None:
+        loader = PersonaLoader()
+        producers = loader.find_producers("no.such.event")
+        assert producers == []
+
+    def test_find_consumers_returns_personas_with_injected_instructions(self) -> None:
+        loader = PersonaLoader()
+        consumers = loader.find_consumers("code.changed")
+        for persona in consumers:
+            if persona.produces.schema:
+                assert "---outcome---" in persona.system_prompt_template
+
+    def test_find_consumers_with_custom_dir_includes_file_personas(self, tmp_path: Path) -> None:
+        p = tmp_path / "custom-reviewer.yaml"
+        p.write_text(_REVIEWER_YAML.replace("name: reviewer", "name: custom-reviewer"), "utf-8")
+        loader = PersonaLoader(personas_dir=tmp_path)
+        consumers = loader.find_consumers("code.changed")
+        names = [p.name for p in consumers]
+        # Built-in reviewer still present, plus our custom one from file
+        assert "reviewer" in names
+        assert "custom-reviewer" in names
+
+    def test_find_producers_dream_completed_returns_mimir_curator(self) -> None:
+        loader = PersonaLoader()
+        producers = loader.find_producers("dream.completed")
+        names = [p.name for p in producers]
+        assert "mimir-curator" in names
+
+
+# ---------------------------------------------------------------------------
+# Built-in specialist personas — contract fields
+# ---------------------------------------------------------------------------
+
+
+class TestBuiltinSpecialistContracts:
+    def test_reviewer_builtin_produces_review_completed(self) -> None:
+        cfg = _BUILTIN_PERSONAS["reviewer"]
+        assert cfg.produces.event_type == "review.completed"
+        assert "verdict" in cfg.produces.schema
+        assert "findings_count" in cfg.produces.schema
+        assert "critical_count" in cfg.produces.schema
+
+    def test_reviewer_builtin_consumes_code_changed(self) -> None:
+        cfg = _BUILTIN_PERSONAS["reviewer"]
+        assert "code.changed" in cfg.consumes.event_types
+        assert "review.requested" in cfg.consumes.event_types
+
+    def test_reviewer_fan_in_all_must_pass(self) -> None:
+        cfg = _BUILTIN_PERSONAS["reviewer"]
+        assert cfg.fan_in.strategy == "all_must_pass"
+        assert cfg.fan_in.contributes_to == "review.verdict"
+
+    def test_security_auditor_builtin_produces_security_completed(self) -> None:
+        cfg = _BUILTIN_PERSONAS["security-auditor"]
+        assert cfg.produces.event_type == "security.completed"
+        assert "verdict" in cfg.produces.schema
+        assert "critical_findings" in cfg.produces.schema
+
+    def test_security_auditor_fan_in_all_must_pass(self) -> None:
+        cfg = _BUILTIN_PERSONAS["security-auditor"]
+        assert cfg.fan_in.strategy == "all_must_pass"
+
+    def test_qa_agent_builtin_produces_qa_completed(self) -> None:
+        cfg = _BUILTIN_PERSONAS["qa-agent"]
+        assert cfg.produces.event_type == "qa.completed"
+        assert "tests_run" in cfg.produces.schema
+        assert "tests_failed" in cfg.produces.schema
+
+    def test_ship_agent_builtin_produces_ship_completed(self) -> None:
+        cfg = _BUILTIN_PERSONAS["ship-agent"]
+        assert cfg.produces.event_type == "ship.completed"
+        assert cfg.produces.schema["verdict"].enum_values == ["shipped", "blocked"]
+
+    def test_retro_analyst_builtin_produces_retro_completed(self) -> None:
+        cfg = _BUILTIN_PERSONAS["retro-analyst"]
+        assert cfg.produces.event_type == "retro.completed"
+        assert "items_shipped" in cfg.produces.schema
+        assert "patterns_found" in cfg.produces.schema
+
+    def test_mimir_curator_builtin_produces_dream_completed(self) -> None:
+        cfg = _BUILTIN_PERSONAS["mimir-curator"]
+        assert cfg.produces.event_type == "dream.completed"
+        assert "pages_updated" in cfg.produces.schema
+
+    def test_all_specialist_personas_have_system_prompts(self) -> None:
+        specialist_names = [
+            "reviewer",
+            "security-auditor",
+            "qa-agent",
+            "ship-agent",
+            "retro-analyst",
+        ]
+        for name in specialist_names:
+            cfg = _BUILTIN_PERSONAS[name]
+            assert cfg.system_prompt_template, f"{name} missing system_prompt_template"
+
+    def test_all_specialist_personas_have_positive_budgets(self) -> None:
+        specialist_names = [
+            "reviewer",
+            "security-auditor",
+            "qa-agent",
+            "ship-agent",
+            "retro-analyst",
+        ]
+        for name in specialist_names:
+            cfg = _BUILTIN_PERSONAS[name]
+            assert cfg.iteration_budget > 0, f"{name} has non-positive iteration_budget"
+
+
+# ---------------------------------------------------------------------------
+# PersonaLoader.merge — new fields preserved
+# ---------------------------------------------------------------------------
+
+
+class TestPersonaLoaderMergeWithContracts:
+    def _make_project(self):  # type: ignore[return]
+        from ravn.config import ProjectConfig
+
+        return ProjectConfig(
+            project_name="proj",
+            persona="",
+            allowed_tools=[],
+            forbidden_tools=[],
+            permission_mode="",
+            iteration_budget=0,
+            notes="",
+        )
+
+    def test_merge_preserves_produces(self) -> None:
+        produces = PersonaProduces(
+            event_type="x.done",
+            schema={"v": OutcomeField(type="string", description="v")},
+        )
+        persona = PersonaConfig(name="x", produces=produces)
+        merged = PersonaLoader.merge(persona, self._make_project())
+        assert merged.produces.event_type == "x.done"
+        assert "v" in merged.produces.schema
+
+    def test_merge_preserves_consumes(self) -> None:
+        consumes = PersonaConsumes(event_types=["a.b"], injects=["x"])
+        persona = PersonaConfig(name="x", consumes=consumes)
+        merged = PersonaLoader.merge(persona, self._make_project())
+        assert merged.consumes.event_types == ["a.b"]
+        assert merged.consumes.injects == ["x"]
+
+    def test_merge_preserves_fan_in(self) -> None:
+        fan_in = PersonaFanIn(strategy="all_must_pass", contributes_to="verdict")
+        persona = PersonaConfig(name="x", fan_in=fan_in)
+        merged = PersonaLoader.merge(persona, self._make_project())
+        assert merged.fan_in.strategy == "all_must_pass"
+        assert merged.fan_in.contributes_to == "verdict"


### PR DESCRIPTION
## Summary

- **Extended `PersonaConfig`** with three new dataclasses: `PersonaProduces`, `PersonaConsumes`, and `PersonaFanIn`
- **Auto-injects outcome instruction** at load time when `persona.produces.schema` is non-empty
- **Extended YAML parser** to handle `produces`, `consumes`, and `fan_in` sections with zero-value semantics
- **5 specialist built-in personas** added with full contracts: `reviewer`, `security-auditor`, `qa-agent`, `ship-agent`, `retro-analyst`
- **`mimir-curator`** updated with `dream.completed` produces contract
- **`find_consumers()`** and **`find_producers()`** registry query methods added

## Test plan

- [x] 76 new tests, 99% coverage on personas module
- [x] All existing persona loader tests pass unchanged
- [x] ruff check + ruff format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)