### PR TITLE
feat(skuld): extract outcome block and emit ravn.session.ended on session end (NIU-595)

### DIFF
--- a/src/skuld/broker.py
+++ b/src/skuld/broker.py
@@ -20,6 +20,7 @@ from contextlib import asynccontextmanager
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 import httpx
 from fastapi import FastAPI, HTTPException, Query, UploadFile, WebSocket, WebSocketDisconnect
@@ -28,6 +29,7 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
 from niuu.domain.logging import LoggingConfig
+from niuu.domain.outcome import parse_outcome_block
 from niuu.utils import import_class
 from skuld.channels import (
     ChannelRegistry,
@@ -42,6 +44,9 @@ from skuld.service_manager import (
     ServiceStatus,
 )
 from skuld.transport import CLITransport
+from sleipnir.adapters.in_process import InProcessBus
+from sleipnir.domain.catalog import ravn_session_ended
+from sleipnir.ports.events import SleipnirPublisher
 
 # ---------------------------------------------------------------------------
 # In-memory log buffer (Part 2: Pod Log Retrieval)
@@ -138,6 +143,11 @@ class SessionArtifacts:
     files_changed: list[str] = field(default_factory=list)
     turn_count: int = 0
     started_at: float = field(default_factory=time.monotonic)
+    total_tokens: int = 0
+    structured_outcome: dict[str, Any] | None = None
+    outcome_valid: bool = False
+    saga_id: str | None = None
+    raid_id: str | None = None
     _known_files: set[str] = field(default_factory=set)
     _pending_tool_results: dict[str, dict] = field(default_factory=dict)
 
@@ -386,7 +396,11 @@ class Broker:
     implementation selected by configuration.
     """
 
-    def __init__(self, settings: SkuldSettings | None = None):
+    def __init__(
+        self,
+        settings: SkuldSettings | None = None,
+        sleipnir_publisher: SleipnirPublisher | None = None,
+    ):
         self._settings = settings or SkuldSettings()
         self.session_id = self._settings.session.id
         self.model = self._settings.session.model
@@ -397,7 +411,11 @@ class Broker:
         self._channels = ChannelRegistry()
         self._http_client: httpx.AsyncClient | None = None
         self._http_client_jwt: str | None = None  # JWT used to create _http_client
-        self._artifacts = SessionArtifacts()
+        self._sleipnir_publisher: SleipnirPublisher = sleipnir_publisher or InProcessBus()
+        self._artifacts = SessionArtifacts(
+            saga_id=self._settings.session.saga_id,
+            raid_id=self._settings.session.raid_id,
+        )
         self._session_start_reported = False
         self._event_sequence = 0
         self._activity_state: str = "idle"
@@ -809,6 +827,7 @@ class Broker:
                     result_cost = (result_cost or 0) + usage["costUSD"]
 
             if total_tokens > 0:
+                self._artifacts.total_tokens += total_tokens
                 asyncio.create_task(
                     self._report_timeline_event(
                         {
@@ -1305,12 +1324,83 @@ class Broker:
             "unfinished_work": None,
         }
 
+    def _build_transcript(self) -> str:
+        """Concatenate all assistant turns to form the session transcript."""
+        return "\n\n".join(
+            turn.content
+            for turn in self._conversation_turns
+            if turn.role == "assistant" and turn.content
+        )
+
+    def _extract_and_store_outcome(self) -> None:
+        """Extract outcome block from the session transcript and store in artifacts.
+
+        No-ops silently when no outcome block is present or parsing fails.
+        """
+        transcript = self._build_transcript()
+        if not transcript:
+            return
+        try:
+            outcome = parse_outcome_block(transcript)
+            if outcome is None:
+                return
+            self._artifacts.structured_outcome = outcome.fields
+            self._artifacts.outcome_valid = outcome.valid
+        except Exception:
+            logger.warning("Failed to extract outcome block from transcript", exc_info=True)
+
+    async def _emit_session_ended_event(self) -> None:
+        """Emit ravn.session.ended via Sleipnir with structured outcome and saga/raid context.
+
+        Always emits the event — even when outcome extraction failed — so that
+        downstream Tyr pipeline executors receive session completion signals.
+        """
+        outcome_str = (
+            "SUCCESS" if self._artifacts.outcome_valid else "PARTIAL"
+        )
+        source = f"ravn:{self.session_id}"
+        persona = self._settings.session.name
+
+        try:
+            event = ravn_session_ended(
+                session_id=self.session_id,
+                persona=persona,
+                outcome=outcome_str,
+                token_count=self._artifacts.total_tokens,
+                duration_s=self._artifacts.duration_seconds,
+                source=source,
+                correlation_id=self.session_id,
+            )
+            if self._artifacts.structured_outcome is not None:
+                event.payload["structured_outcome"] = self._artifacts.structured_outcome
+                event.payload["outcome_valid"] = self._artifacts.outcome_valid
+            if self._artifacts.raid_id:
+                event.payload["raid_id"] = self._artifacts.raid_id
+            if self._artifacts.saga_id:
+                event.payload["saga_id"] = self._artifacts.saga_id
+            await self._sleipnir_publisher.publish(event)
+            logger.info(
+                "Session ended event emitted: session=%s outcome=%s saga=%s raid=%s",
+                self.session_id,
+                outcome_str,
+                self._artifacts.saga_id,
+                self._artifacts.raid_id,
+            )
+        except Exception:
+            logger.warning("Failed to emit session ended event", exc_info=True)
+
     async def _report_chronicle(self) -> None:
         """Report chronicle summary data to the Volundr API on shutdown.
 
         Mirrors ``_report_usage`` — fires once during shutdown, best-effort,
         never raises.
+
+        Also extracts the outcome block from the session transcript and emits
+        the ``ravn.session.ended`` Sleipnir event so Tyr can track raid completion.
         """
+        self._extract_and_store_outcome()
+        await self._emit_session_ended_event()
+
         if not self.volundr_api_url:
             return
 

--- a/src/skuld/config.py
+++ b/src/skuld/config.py
@@ -66,6 +66,8 @@ class SkuldSessionConfig(BaseModel):
     workspace_dir: str | None = Field(default=None)
     system_prompt: str = Field(default="")
     initial_prompt: str = Field(default="")
+    saga_id: str | None = Field(default=None)
+    raid_id: str | None = Field(default=None)
 
 
 class SkuldSettings(BaseSettings):

--- a/tests/test_skuld/test_outcome_extraction.py
+++ b/tests/test_skuld/test_outcome_extraction.py
@@ -1,0 +1,393 @@
+"""Tests for NIU-595: Skuld outcome extraction and ravn.session.ended event emission."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from skuld.broker import Broker, SessionArtifacts
+from skuld.config import SkuldSessionConfig, SkuldSettings
+from sleipnir.adapters.in_process import InProcessBus
+from sleipnir.domain.registry import RAVN_SESSION_ENDED
+from sleipnir.testing import EventCapture
+
+# ---------------------------------------------------------------------------
+# SessionArtifacts tests
+# ---------------------------------------------------------------------------
+
+
+class TestSessionArtifactsNewFields:
+    def test_default_values(self):
+        artifacts = SessionArtifacts()
+        assert artifacts.structured_outcome is None
+        assert artifacts.outcome_valid is False
+        assert artifacts.saga_id is None
+        assert artifacts.raid_id is None
+        assert artifacts.total_tokens == 0
+
+    def test_explicit_saga_and_raid(self):
+        artifacts = SessionArtifacts(saga_id="saga-1", raid_id="raid-1")
+        assert artifacts.saga_id == "saga-1"
+        assert artifacts.raid_id == "raid-1"
+
+
+# ---------------------------------------------------------------------------
+# SkuldSessionConfig saga/raid fields
+# ---------------------------------------------------------------------------
+
+
+class TestSkuldSessionConfigSagaRaid:
+    def test_defaults_to_none(self):
+        cfg = SkuldSessionConfig()
+        assert cfg.saga_id is None
+        assert cfg.raid_id is None
+
+    def test_can_be_set(self):
+        cfg = SkuldSessionConfig(saga_id="s1", raid_id="r1")
+        assert cfg.saga_id == "s1"
+        assert cfg.raid_id == "r1"
+
+
+# ---------------------------------------------------------------------------
+# Broker initialization wires saga/raid into artifacts
+# ---------------------------------------------------------------------------
+
+
+class TestBrokerSagaRaidInit:
+    def test_saga_and_raid_stored_in_artifacts(self, tmp_path):
+        settings = SkuldSettings(
+            session={
+                "id": "sess-1",
+                "workspace_dir": str(tmp_path),
+                "saga_id": "s-42",
+                "raid_id": "r-99",
+            },
+        )
+        b = Broker(settings=settings)
+        assert b._artifacts.saga_id == "s-42"
+        assert b._artifacts.raid_id == "r-99"
+
+    def test_no_saga_raid_when_not_configured(self, tmp_path):
+        settings = SkuldSettings(
+            session={"id": "sess-2", "workspace_dir": str(tmp_path)},
+        )
+        b = Broker(settings=settings)
+        assert b._artifacts.saga_id is None
+        assert b._artifacts.raid_id is None
+
+
+# ---------------------------------------------------------------------------
+# Broker._build_transcript
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTranscript:
+    def _make_broker(self, tmp_path):
+        settings = SkuldSettings(
+            session={"id": "sess-t", "workspace_dir": str(tmp_path)},
+        )
+        return Broker(settings=settings)
+
+    def test_empty_when_no_turns(self, tmp_path):
+        b = self._make_broker(tmp_path)
+        assert b._build_transcript() == ""
+
+    def test_only_assistant_turns_included(self, tmp_path):
+        from skuld.broker import ConversationTurn
+        b = self._make_broker(tmp_path)
+        b._conversation_turns = [
+            ConversationTurn(id="1", role="user", content="hello"),
+            ConversationTurn(id="2", role="assistant", content="world"),
+        ]
+        assert b._build_transcript() == "world"
+
+    def test_multiple_assistant_turns_joined(self, tmp_path):
+        from skuld.broker import ConversationTurn
+        b = self._make_broker(tmp_path)
+        b._conversation_turns = [
+            ConversationTurn(id="1", role="assistant", content="first"),
+            ConversationTurn(id="2", role="user", content="mid"),
+            ConversationTurn(id="3", role="assistant", content="second"),
+        ]
+        assert b._build_transcript() == "first\n\nsecond"
+
+    def test_empty_content_skipped(self, tmp_path):
+        from skuld.broker import ConversationTurn
+        b = self._make_broker(tmp_path)
+        b._conversation_turns = [
+            ConversationTurn(id="1", role="assistant", content=""),
+            ConversationTurn(id="2", role="assistant", content="real"),
+        ]
+        assert b._build_transcript() == "real"
+
+
+# ---------------------------------------------------------------------------
+# Broker._extract_and_store_outcome
+# ---------------------------------------------------------------------------
+
+
+class TestExtractAndStoreOutcome:
+    def _make_broker(self, tmp_path):
+        settings = SkuldSettings(
+            session={"id": "sess-o", "workspace_dir": str(tmp_path)},
+        )
+        return Broker(settings=settings)
+
+    def test_no_outcome_block_leaves_artifact_none(self, tmp_path):
+        from skuld.broker import ConversationTurn
+        b = self._make_broker(tmp_path)
+        b._conversation_turns = [
+            ConversationTurn(id="1", role="assistant", content="No outcome here."),
+        ]
+        b._extract_and_store_outcome()
+        assert b._artifacts.structured_outcome is None
+        assert b._artifacts.outcome_valid is False
+
+    def test_outcome_block_extracted(self, tmp_path):
+        from skuld.broker import ConversationTurn
+        b = self._make_broker(tmp_path)
+        b._conversation_turns = [
+            ConversationTurn(
+                id="1",
+                role="assistant",
+                content=(
+                    "I reviewed the code.\n\n"
+                    "---outcome---\n"
+                    "verdict: fail\n"
+                    "findings_count: 5\n"
+                    "critical_count: 2\n"
+                    "summary: Critical auth bypass\n"
+                    "---end---"
+                ),
+            ),
+        ]
+        b._extract_and_store_outcome()
+        assert b._artifacts.structured_outcome is not None
+        assert b._artifacts.structured_outcome["verdict"] == "fail"
+        assert b._artifacts.structured_outcome["critical_count"] == 2
+        assert b._artifacts.outcome_valid is True
+
+    def test_empty_transcript_is_noop(self, tmp_path):
+        b = self._make_broker(tmp_path)
+        b._extract_and_store_outcome()
+        assert b._artifacts.structured_outcome is None
+
+    def test_parse_exception_swallowed(self, tmp_path):
+        b = self._make_broker(tmp_path)
+        with patch("skuld.broker.parse_outcome_block", side_effect=RuntimeError("boom")):
+            from skuld.broker import ConversationTurn
+            b._conversation_turns = [
+                ConversationTurn(
+                    id="1",
+                    role="assistant",
+                    content="---outcome---\nfoo: bar\n---end---",
+                ),
+            ]
+            b._extract_and_store_outcome()  # must not raise
+        assert b._artifacts.structured_outcome is None
+
+
+# ---------------------------------------------------------------------------
+# Broker._emit_session_ended_event
+# ---------------------------------------------------------------------------
+
+
+class TestEmitSessionEndedEvent:
+    async def test_event_published_with_correct_fields(self, tmp_path):
+        bus = InProcessBus()
+        settings = SkuldSettings(
+            session={"id": "sess-e", "name": "ravn-audit", "workspace_dir": str(tmp_path)},
+        )
+        b = Broker(settings=settings, sleipnir_publisher=bus)
+        b._artifacts.total_tokens = 1234
+        b._artifacts.structured_outcome = {"verdict": "pass"}
+        b._artifacts.outcome_valid = True
+        b._artifacts.saga_id = "saga-abc"
+        b._artifacts.raid_id = "raid-xyz"
+
+        async with EventCapture(bus, [RAVN_SESSION_ENDED]) as capture:
+            await b._emit_session_ended_event()
+            await bus.flush()
+
+        assert len(capture.events) == 1
+        evt = capture.events[0]
+        assert evt.event_type == RAVN_SESSION_ENDED
+        assert evt.payload["session_id"] == "sess-e"
+        assert evt.payload["persona"] == "ravn-audit"
+        assert evt.payload["outcome"] == "SUCCESS"
+        assert evt.payload["token_count"] == 1234
+        assert evt.payload["structured_outcome"] == {"verdict": "pass"}
+        assert evt.payload["outcome_valid"] is True
+        assert evt.payload["raid_id"] == "raid-xyz"
+        assert evt.payload["saga_id"] == "saga-abc"
+        assert evt.correlation_id == "sess-e"
+
+    async def test_event_emitted_without_outcome(self, tmp_path):
+        bus = InProcessBus()
+        settings = SkuldSettings(
+            session={"id": "sess-no-outcome", "workspace_dir": str(tmp_path)},
+        )
+        b = Broker(settings=settings, sleipnir_publisher=bus)
+
+        async with EventCapture(bus, [RAVN_SESSION_ENDED]) as capture:
+            await b._emit_session_ended_event()
+            await bus.flush()
+
+        assert len(capture.events) == 1
+        evt = capture.events[0]
+        assert evt.payload["outcome"] == "PARTIAL"
+        assert "structured_outcome" not in evt.payload
+        assert "raid_id" not in evt.payload
+        assert "saga_id" not in evt.payload
+
+    async def test_event_emitted_without_saga_raid(self, tmp_path):
+        bus = InProcessBus()
+        settings = SkuldSettings(
+            session={"id": "sess-plain", "workspace_dir": str(tmp_path)},
+        )
+        b = Broker(settings=settings, sleipnir_publisher=bus)
+        b._artifacts.structured_outcome = {"verdict": "pass"}
+        b._artifacts.outcome_valid = True
+
+        async with EventCapture(bus, [RAVN_SESSION_ENDED]) as capture:
+            await b._emit_session_ended_event()
+            await bus.flush()
+
+        assert len(capture.events) == 1
+        evt = capture.events[0]
+        assert "raid_id" not in evt.payload
+        assert "saga_id" not in evt.payload
+
+    async def test_publish_failure_is_swallowed(self, tmp_path):
+        failing_publisher = AsyncMock()
+        failing_publisher.publish.side_effect = RuntimeError("bus down")
+        settings = SkuldSettings(
+            session={"id": "sess-fail", "workspace_dir": str(tmp_path)},
+        )
+        b = Broker(settings=settings, sleipnir_publisher=failing_publisher)
+        await b._emit_session_ended_event()  # must not raise
+
+    async def test_outcome_invalid_maps_to_partial(self, tmp_path):
+        bus = InProcessBus()
+        settings = SkuldSettings(
+            session={"id": "sess-invalid", "workspace_dir": str(tmp_path)},
+        )
+        b = Broker(settings=settings, sleipnir_publisher=bus)
+        b._artifacts.structured_outcome = {"verdict": "unknown"}
+        b._artifacts.outcome_valid = False
+
+        async with EventCapture(bus, [RAVN_SESSION_ENDED]) as capture:
+            await b._emit_session_ended_event()
+            await bus.flush()
+
+        assert capture.events[0].payload["outcome"] == "PARTIAL"
+
+
+# ---------------------------------------------------------------------------
+# E2E: full session completion flow
+# ---------------------------------------------------------------------------
+
+
+class TestSessionCompletionE2E:
+    async def test_transcript_with_outcome_block_emits_structured_event(self, tmp_path):
+        """Simulate session with outcome block → verify event emitted with structured payload."""
+        bus = InProcessBus()
+        settings = SkuldSettings(
+            session={
+                "id": "e2e-session",
+                "workspace_dir": str(tmp_path),
+                "saga_id": "saga-1",
+                "raid_id": "raid-1",
+            },
+        )
+        b = Broker(settings=settings, sleipnir_publisher=bus)
+
+        # Simulate assistant messages culminating in an outcome block
+        from skuld.broker import ConversationTurn
+        b._conversation_turns = [
+            ConversationTurn(id="1", role="user", content="Review the auth code"),
+            ConversationTurn(
+                id="2",
+                role="assistant",
+                content=(
+                    "I reviewed the code and found 2 critical issues in the auth middleware.\n\n"
+                    "---outcome---\n"
+                    "verdict: fail\n"
+                    "findings_count: 5\n"
+                    "critical_count: 2\n"
+                    "summary: Critical auth bypass in middleware\n"
+                    "---end---"
+                ),
+            ),
+        ]
+
+        async with EventCapture(bus, [RAVN_SESSION_ENDED]) as capture:
+            b._extract_and_store_outcome()
+            await b._emit_session_ended_event()
+            await bus.flush()
+
+        assert b._artifacts.structured_outcome is not None
+        assert b._artifacts.structured_outcome["verdict"] == "fail"
+        assert b._artifacts.structured_outcome["critical_count"] == 2
+
+        events = [e for e in capture.events if e.event_type == RAVN_SESSION_ENDED]
+        assert len(events) == 1
+        evt = events[0]
+        assert evt.payload["raid_id"] == "raid-1"
+        assert evt.payload["saga_id"] == "saga-1"
+        assert evt.payload["structured_outcome"]["verdict"] == "fail"
+        assert evt.payload["outcome"] == "SUCCESS"  # outcome_valid is True when YAML parses cleanly
+
+    async def test_transcript_without_outcome_emits_partial_event(self, tmp_path):
+        """Session without outcome block still emits ravn.session.ended with PARTIAL."""
+        bus = InProcessBus()
+        settings = SkuldSettings(
+            session={
+                "id": "e2e-no-outcome",
+                "workspace_dir": str(tmp_path),
+                "saga_id": "saga-2",
+                "raid_id": "raid-2",
+            },
+        )
+        b = Broker(settings=settings, sleipnir_publisher=bus)
+
+        from skuld.broker import ConversationTurn
+        b._conversation_turns = [
+            ConversationTurn(
+                id="1",
+                role="assistant",
+                content="I looked at the code but found nothing.",
+            ),
+        ]
+
+        async with EventCapture(bus, [RAVN_SESSION_ENDED]) as capture:
+            b._extract_and_store_outcome()
+            await b._emit_session_ended_event()
+            await bus.flush()
+
+        assert b._artifacts.structured_outcome is None
+
+        events = [e for e in capture.events if e.event_type == RAVN_SESSION_ENDED]
+        assert len(events) == 1
+        evt = events[0]
+        assert evt.payload["outcome"] == "PARTIAL"
+        assert "structured_outcome" not in evt.payload
+        assert evt.payload["raid_id"] == "raid-2"
+
+    async def test_total_tokens_accumulated_across_turns(self, tmp_path):
+        """Verify total_tokens in artifacts is accumulated from multiple result events."""
+        bus = InProcessBus()
+        settings = SkuldSettings(
+            session={"id": "sess-tokens", "workspace_dir": str(tmp_path)},
+        )
+        b = Broker(settings=settings, sleipnir_publisher=bus)
+        b._artifacts.total_tokens = 0
+
+        # Simulate two result events contributing tokens
+        b._artifacts.total_tokens += 500
+        b._artifacts.total_tokens += 750
+
+        async with EventCapture(bus, [RAVN_SESSION_ENDED]) as capture:
+            await b._emit_session_ended_event()
+            await bus.flush()
+
+        assert capture.events[0].payload["token_count"] == 1250


### PR DESCRIPTION
## Summary

- **Outcome extraction**: When a Skuld session ends, the last \`---outcome---\` block is parsed from the session transcript (via \`niuu.domain.outcome.parse_outcome_block\`) and stored on \`SessionArtifacts.structured_outcome\`
- **\`ravn.session.ended\` event**: Emitted via Sleipnir at shutdown with \`structured_outcome\`, \`outcome_valid\`, \`raid_id\`, \`saga_id\`, and \`token_count\` in the payload — always fires so Tyr receives a completion signal even when outcome extraction fails
- **Saga/raid context**: \`SkuldSessionConfig\` now carries \`saga_id\` and \`raid_id\` (passed by Tyr dispatch via Volundr session spec), wired into \`SessionArtifacts\` at Broker init
- **Token tracking**: \`SessionArtifacts.total_tokens\` accumulates across all result events so the session-ended event has accurate token counts
- **Injected publisher**: \`Broker\` accepts an optional \`sleipnir_publisher\` for clean testing; defaults to \`InProcessBus\` in production

## Files changed

| File | Change |
|------|--------|
| \`src/skuld/config.py\` | Add \`saga_id\`, \`raid_id\` to \`SkuldSessionConfig\` |
| \`src/skuld/broker.py\` | Extend \`SessionArtifacts\`; add \`_build_transcript\`, \`_extract_and_store_outcome\`, \`_emit_session_ended_event\`; accumulate \`total_tokens\`; call from \`_report_chronicle\` |
| \`tests/test_skuld/test_outcome_extraction.py\` | 22 new tests (artifacts, config, broker methods, E2E) |

## Test plan

- [x] \`pytest tests/test_skuld/test_outcome_extraction.py\` — 22 tests, all pass
- [x] \`pytest tests/test_skuld/\` — 663 pass, 38 skipped (no regressions)
- [x] Coverage: skuld 87%, broker.py 85% (at threshold)
- [x] \`ruff check\` — clean

Closes NIU-595

🤖 Generated with [Claude Code](https://claude.com/claude-code)