### PR TITLE
feat(ravn): parse outcome block and emit Sleipnir event on session end (NIU-594)

### DIFF
--- a/src/ravn/agent.py
+++ b/src/ravn/agent.py
@@ -8,7 +8,7 @@ import time
 import uuid
 from collections.abc import Callable, Coroutine
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from niuu.ports.mimir import MimirPort
 from ravn.adapters.memory.inline_facts import detect_and_write as _detect_and_write_facts
@@ -43,6 +43,10 @@ from ravn.ports.memory import MemoryPort
 from ravn.ports.permission import PermissionPort
 from ravn.ports.tool import ToolPort
 from ravn.prompt_builder import PromptBuilder
+
+if TYPE_CHECKING:
+    from niuu.domain.outcome import ParsedOutcome
+    from ravn.adapters.personas.loader import PersonaConfig
 
 try:
     from sleipnir.domain.catalog import ravn_session_ended, ravn_session_started
@@ -121,7 +125,7 @@ class RavnAgent:
         mimir: MimirPort | None = None,
         reflection_config: PostSessionReflectionConfig | None = None,
         # NIU-594: persona config for outcome block parsing
-        persona_config: object | None = None,
+        persona_config: PersonaConfig | None = None,
     ) -> None:
         self._llm = llm
         self._tools = {t.name: t for t in tools}
@@ -243,6 +247,25 @@ class RavnAgent:
         except Exception:
             logger.warning("Failed to emit ravn.session.started; continuing.", exc_info=True)
 
+    def _build_session_ended_event(self, outcome: str) -> object:
+        """Build a ravn.session.ended SleipnirEvent with the given outcome string.
+
+        Centralises the token/duration computation and ravn_session_ended() call
+        so both emit_session_ended() and _emit_session_ended_with_outcome() stay DRY.
+        """
+        total_tokens = self._session.total_usage.total_tokens
+        duration_s = round(time.monotonic() - self._session_wall_start, 3)
+        return ravn_session_ended(
+            session_id=str(self._session.id),
+            persona=self._persona,
+            outcome=outcome,
+            token_count=total_tokens,
+            duration_s=duration_s,
+            source=self._source_id,
+            repo_slug=self._repo_slug,
+            correlation_id=self._task_id,
+        )
+
     async def emit_session_ended(self, outcome: str) -> None:
         """Publish ravn.session.ended to Sleipnir.
 
@@ -257,23 +280,13 @@ class RavnAgent:
         if self._session_ended_emitted:
             return
         try:
-            total_tokens = self._session.total_usage.total_tokens
-            duration_s = round(time.monotonic() - self._session_wall_start, 3)
-            event = ravn_session_ended(
-                session_id=str(self._session.id),
-                persona=self._persona,
-                outcome=outcome,
-                token_count=total_tokens,
-                duration_s=duration_s,
-                source=self._source_id,
-                repo_slug=self._repo_slug,
-                correlation_id=self._task_id,
-            )
+            event = self._build_session_ended_event(outcome)
             await self._sleipnir_publisher.publish(event)
+            self._session_ended_emitted = True
         except Exception:
             logger.warning("Failed to emit ravn.session.ended; continuing.", exc_info=True)
 
-    async def _emit_session_ended_with_outcome(self, parsed_outcome: object) -> None:
+    async def _emit_session_ended_with_outcome(self, parsed_outcome: ParsedOutcome) -> None:
         """Publish ravn.session.ended enriched with structured outcome fields.
 
         Called from run_turn() when the agent produces a valid outcome block.
@@ -283,24 +296,12 @@ class RavnAgent:
         if self._sleipnir_publisher is None or ravn_session_ended is None:
             return
         try:
-            total_tokens = self._session.total_usage.total_tokens
-            duration_s = round(time.monotonic() - self._session_wall_start, 3)
-            outcome_str = "success" if getattr(parsed_outcome, "valid", False) else "partial"
-            event = ravn_session_ended(
-                session_id=str(self._session.id),
-                persona=self._persona,
-                outcome=outcome_str,
-                token_count=total_tokens,
-                duration_s=duration_s,
-                source=self._source_id,
-                repo_slug=self._repo_slug,
-                correlation_id=self._task_id,
-            )
-            event.payload["structured_outcome"] = getattr(parsed_outcome, "fields", {})
-            event.payload["outcome_valid"] = getattr(parsed_outcome, "valid", False)
-            produces = getattr(self._persona_config, "produces", None)
-            if produces is not None:
-                event.payload["outcome_event_type"] = getattr(produces, "event_type", "")
+            outcome_str = "success" if parsed_outcome.valid else "partial"
+            event = self._build_session_ended_event(outcome_str)
+            event.payload["structured_outcome"] = parsed_outcome.fields
+            event.payload["outcome_valid"] = parsed_outcome.valid
+            if self._persona_config is not None:
+                event.payload["outcome_event_type"] = self._persona_config.produces.event_type
             await self._sleipnir_publisher.publish(event)
             self._session_ended_emitted = True
         except Exception:
@@ -1235,8 +1236,8 @@ def _extract_episode(
 
 def _parse_outcome_block_for_persona(
     text: str,
-    persona_config: object | None,
-) -> object | None:
+    persona_config: PersonaConfig | None,
+) -> ParsedOutcome | None:
     """Parse the ---outcome--- block from *text* using the persona's declared schema.
 
     Returns a :class:`niuu.domain.outcome.ParsedOutcome` when an outcome block is
@@ -1244,10 +1245,10 @@ def _parse_outcome_block_for_persona(
     """
     if persona_config is None:
         return None
-    produces = getattr(persona_config, "produces", None)
+    produces = persona_config.produces
     if produces is None:
         return None
-    schema_fields = getattr(produces, "schema", None)
+    schema_fields = produces.schema
     if not schema_fields:
         return None
     try:

--- a/src/ravn/agent.py
+++ b/src/ravn/agent.py
@@ -120,6 +120,8 @@ class RavnAgent:
         # NIU-588: learnings injection at session start
         mimir: MimirPort | None = None,
         reflection_config: PostSessionReflectionConfig | None = None,
+        # NIU-594: persona config for outcome block parsing
+        persona_config: object | None = None,
     ) -> None:
         self._llm = llm
         self._tools = {t.name: t for t in tools}
@@ -163,9 +165,12 @@ class RavnAgent:
         self._repo_slug = repo_slug
         self._turn_count: int = 0
         self._session_wall_start: float = time.monotonic()
+        self._session_ended_emitted: bool = False
         # NIU-588: learnings injection at session start
         self._mimir = mimir
         self._reflection_config = reflection_config
+        # NIU-594: persona config for outcome block parsing
+        self._persona_config = persona_config
 
     @property
     def session(self) -> Session:
@@ -242,11 +247,14 @@ class RavnAgent:
         """Publish ravn.session.ended to Sleipnir.
 
         Call this once the entire session is complete (all turns done, normal
-        exit, interrupt, or error).  No-op when no publisher is configured.
+        exit, interrupt, or error).  No-op when no publisher is configured or
+        when the event was already emitted (e.g. by outcome block capture).
 
         :param outcome: One of ``"success"``, ``"interrupted"``, or ``"error"``.
         """
         if self._sleipnir_publisher is None or ravn_session_ended is None:
+            return
+        if self._session_ended_emitted:
             return
         try:
             total_tokens = self._session.total_usage.total_tokens
@@ -264,6 +272,41 @@ class RavnAgent:
             await self._sleipnir_publisher.publish(event)
         except Exception:
             logger.warning("Failed to emit ravn.session.ended; continuing.", exc_info=True)
+
+    async def _emit_session_ended_with_outcome(self, parsed_outcome: object) -> None:
+        """Publish ravn.session.ended enriched with structured outcome fields.
+
+        Called from run_turn() when the agent produces a valid outcome block.
+        Sets ``_session_ended_emitted`` so the external emit_session_ended()
+        becomes a no-op and no double-emission occurs.
+        """
+        if self._sleipnir_publisher is None or ravn_session_ended is None:
+            return
+        try:
+            total_tokens = self._session.total_usage.total_tokens
+            duration_s = round(time.monotonic() - self._session_wall_start, 3)
+            outcome_str = "success" if getattr(parsed_outcome, "valid", False) else "partial"
+            event = ravn_session_ended(
+                session_id=str(self._session.id),
+                persona=self._persona,
+                outcome=outcome_str,
+                token_count=total_tokens,
+                duration_s=duration_s,
+                source=self._source_id,
+                repo_slug=self._repo_slug,
+                correlation_id=self._task_id,
+            )
+            event.payload["structured_outcome"] = getattr(parsed_outcome, "fields", {})
+            event.payload["outcome_valid"] = getattr(parsed_outcome, "valid", False)
+            produces = getattr(self._persona_config, "produces", None)
+            if produces is not None:
+                event.payload["outcome_event_type"] = getattr(produces, "event_type", "")
+            await self._sleipnir_publisher.publish(event)
+            self._session_ended_emitted = True
+        except Exception:
+            logger.warning(
+                "Failed to emit ravn.session.ended with outcome; continuing.", exc_info=True
+            )
 
     async def run_turn(self, user_input: str) -> TurnResult:
         """Process one user turn and return the result.
@@ -468,31 +511,43 @@ class RavnAgent:
         self._session.record_turn(cumulative_usage)
         duration_seconds = time.monotonic() - start_time
 
-        result = TurnResult(
+        # NIU-594: build a partial result to pass into episode extraction
+        partial_result = TurnResult(
             response=final_response,
             tool_calls=turn_tool_calls,
             tool_results=turn_tool_results,
             usage=cumulative_usage,
         )
 
-        if self._memory is not None:
-            try:
-                episode = _extract_episode(
-                    session_id=str(self._session.id),
-                    user_input=user_input,
-                    turn_result=result,
-                    summary_max_chars=self._episode_summary_max_chars,
-                    task_max_chars=self._episode_task_max_chars,
-                )
+        # NIU-594: parse ---outcome--- block from final response when persona declares a schema
+        parsed_outcome = _parse_outcome_block_for_persona(final_response, self._persona_config)
+
+        # Extract episode (always, so TurnResult.episode is populated for outcome capture)
+        recorded_episode: Episode | None = None
+        try:
+            episode = _extract_episode(
+                session_id=str(self._session.id),
+                user_input=user_input,
+                turn_result=partial_result,
+                summary_max_chars=self._episode_summary_max_chars,
+                task_max_chars=self._episode_task_max_chars,
+            )
+            # Attach structured outcome to episode before enrichment/recording
+            if parsed_outcome is not None:
+                episode.structured_outcome = parsed_outcome.fields
+                episode.outcome_valid = parsed_outcome.valid
+
+            if self._memory is not None:
                 episode = await self._enrich_episode(
                     episode=episode,
-                    turn_result=result,
+                    turn_result=partial_result,
                     duration_seconds=duration_seconds,
                     past_context=memory_ctx,
                 )
                 await self._memory.record_episode(episode)
-            except Exception:
-                logger.warning("Memory episode recording failed; continuing.", exc_info=True)
+            recorded_episode = episode
+        except Exception:
+            logger.warning("Episode extraction/recording failed; continuing.", exc_info=True)
 
         if self._memory is not None:
             try:
@@ -504,7 +559,17 @@ class RavnAgent:
             except Exception:
                 logger.warning("Memory on_turn_complete failed; continuing.", exc_info=True)
 
-        return result
+        # NIU-594: emit ravn.session.ended enriched with structured outcome
+        if parsed_outcome is not None:
+            await self._emit_session_ended_with_outcome(parsed_outcome)
+
+        return TurnResult(
+            response=final_response,
+            tool_calls=turn_tool_calls,
+            tool_results=turn_tool_results,
+            usage=cumulative_usage,
+            episode=recorded_episode,
+        )
 
     async def _build_effective_system(self, user_input: str) -> SystemPrompt:
         """Build the effective system prompt for this turn.
@@ -1166,6 +1231,33 @@ def _extract_episode(
         tags=tags,
         embedding=None,
     )
+
+
+def _parse_outcome_block_for_persona(
+    text: str,
+    persona_config: object | None,
+) -> object | None:
+    """Parse the ---outcome--- block from *text* using the persona's declared schema.
+
+    Returns a :class:`niuu.domain.outcome.ParsedOutcome` when an outcome block is
+    found, or ``None`` when no persona schema is configured or no block is present.
+    """
+    if persona_config is None:
+        return None
+    produces = getattr(persona_config, "produces", None)
+    if produces is None:
+        return None
+    schema_fields = getattr(produces, "schema", None)
+    if not schema_fields:
+        return None
+    try:
+        from niuu.domain.outcome import OutcomeSchema, parse_outcome_block
+
+        schema = OutcomeSchema(fields=schema_fields)
+        return parse_outcome_block(text, schema)
+    except Exception:
+        logger.warning("Outcome block parsing failed; continuing without.", exc_info=True)
+        return None
 
 
 _THINK_PREFIXES = ("think:", "think: ")

--- a/src/ravn/domain/models.py
+++ b/src/ravn/domain/models.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 from uuid import UUID, uuid4
 
 from niuu.domain.mimir import (  # noqa: F401 — re-exported for existing importers
@@ -84,6 +84,9 @@ class Episode:
     errors: list[str] = field(default_factory=list)
     cost_usd: float | None = None
     duration_seconds: float | None = None
+    # NIU-594: structured outcome parsed from ---outcome--- block
+    structured_outcome: dict[str, Any] | None = None
+    outcome_valid: bool = False
 
 
 @dataclass(frozen=True)
@@ -241,6 +244,8 @@ class TurnResult:
     tool_calls: list[ToolCall]
     tool_results: list[ToolResult]
     usage: TokenUsage
+    # NIU-594: episode recorded for this turn (None if no memory configured and no outcome block)
+    episode: Episode | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ravn/test_outcome_capture.py
+++ b/tests/test_ravn/test_outcome_capture.py
@@ -1,0 +1,458 @@
+"""Tests for NIU-594: outcome block parsing, episode enrichment, and Sleipnir emission.
+
+Covers:
+- _parse_outcome_block_for_persona helper
+- Episode.structured_outcome / Episode.outcome_valid fields
+- TurnResult.episode field populated after run_turn()
+- ravn.session.ended emitted with structured_outcome in payload
+- ravn.session.started emitted on first turn
+- Agent without persona_config produces no outcome parsing
+- emit_session_ended() is a no-op when already emitted by outcome capture
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ravn.adapters.personas.loader import (
+    PersonaConfig,
+)
+from ravn.agent import RavnAgent, _parse_outcome_block_for_persona
+from ravn.domain.models import (
+    Episode,
+    LLMResponse,
+    Outcome,
+    StopReason,
+    StreamEvent,
+    StreamEventType,
+    TokenUsage,
+    TurnResult,
+)
+from ravn.ports.llm import LLMPort
+from sleipnir.adapters.in_process import InProcessBus
+from sleipnir.domain.events import SleipnirEvent
+from tests.ravn.fixtures.fakes import InMemoryChannel
+from tests.test_ravn.conftest import AllowAllPermission
+
+# ---------------------------------------------------------------------------
+# LLM helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_llm_with_response(response_text: str) -> LLMPort:
+    """Build a mock LLM that streams *response_text* as a single text delta."""
+
+    async def _stream(*args, **kwargs) -> AsyncIterator[StreamEvent]:
+        yield StreamEvent(type=StreamEventType.TEXT_DELTA, text=response_text)
+        yield StreamEvent(
+            type=StreamEventType.MESSAGE_DONE,
+            usage=TokenUsage(input_tokens=10, output_tokens=5),
+        )
+
+    llm = AsyncMock(spec=LLMPort)
+    llm.stream = _stream
+    llm.generate = AsyncMock(
+        return_value=LLMResponse(
+            content="reflection",
+            tool_calls=[],
+            stop_reason=StopReason.END_TURN,
+            usage=TokenUsage(input_tokens=2, output_tokens=2),
+        )
+    )
+    return llm
+
+
+def _reviewer_persona() -> PersonaConfig:
+    """Return the built-in reviewer persona config (with schema)."""
+    from ravn.adapters.personas.loader import PersonaLoader
+
+    persona = PersonaLoader().load("reviewer")
+    assert persona is not None, "reviewer persona must exist in built-ins"
+    return persona
+
+
+def _make_agent(
+    llm: LLMPort,
+    *,
+    persona_config: object | None = None,
+    sleipnir_publisher: object | None = None,
+    persona_name: str = "",
+) -> tuple[RavnAgent, InMemoryChannel]:
+    ch = InMemoryChannel()
+    agent = RavnAgent(
+        llm=llm,
+        tools=[],
+        channel=ch,
+        permission=AllowAllPermission(),
+        system_prompt="You are a test assistant.",
+        model="claude-sonnet-4-6",
+        max_tokens=1024,
+        max_iterations=10,
+        persona_config=persona_config,
+        sleipnir_publisher=sleipnir_publisher,
+        persona=persona_name,
+    )
+    return agent, ch
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _parse_outcome_block_for_persona
+# ---------------------------------------------------------------------------
+
+
+class TestParseOutcomeBlockForPersona:
+    def test_returns_none_when_no_persona(self) -> None:
+        result = _parse_outcome_block_for_persona("some text", None)
+        assert result is None
+
+    def test_returns_none_when_persona_has_no_schema(self) -> None:
+        persona = PersonaConfig(name="minimal")
+        result = _parse_outcome_block_for_persona("some text", persona)
+        assert result is None
+
+    def test_returns_none_when_response_has_no_block(self) -> None:
+        persona = _reviewer_persona()
+        result = _parse_outcome_block_for_persona("No outcome block here.", persona)
+        assert result is None
+
+    def test_parses_valid_outcome_block(self) -> None:
+        persona = _reviewer_persona()
+        text = (
+            "I reviewed the code.\n"
+            "---outcome---\n"
+            "verdict: pass\n"
+            "findings_count: 0\n"
+            "critical_count: 0\n"
+            "summary: All good\n"
+            "---end---\n"
+        )
+        result = _parse_outcome_block_for_persona(text, persona)
+        assert result is not None
+        assert result.valid is True  # type: ignore[union-attr]
+        assert result.fields["verdict"] == "pass"  # type: ignore[union-attr]
+
+    def test_parses_invalid_outcome_block_marks_valid_false(self) -> None:
+        persona = _reviewer_persona()
+        text = (
+            "---outcome---\n"
+            "verdict: maybe\n"  # not in enum
+            "---end---\n"
+        )
+        result = _parse_outcome_block_for_persona(text, persona)
+        assert result is not None
+        assert result.valid is False  # type: ignore[union-attr]
+
+    def test_returns_none_when_produces_attr_is_none(self) -> None:
+        """Cover the produces-is-None branch in the helper."""
+
+        class _FakePersona:
+            produces = None
+
+        result = _parse_outcome_block_for_persona("some text", _FakePersona())
+        assert result is None
+
+    def test_returns_none_on_import_or_parse_exception(self) -> None:
+        """Cover the exception handler in _parse_outcome_block_for_persona."""
+        from unittest.mock import patch
+
+        from niuu.domain.outcome import OutcomeField
+
+        class _FakeProduces:
+            schema = {"bad_field": OutcomeField(type="string", description="x")}
+
+        class _FakePersona:
+            produces = _FakeProduces()
+
+        text = "---outcome---\nbad_field: hello\n---end---\n"
+        # Force parse_outcome_block to raise to cover the except branch
+        with patch(
+            "niuu.domain.outcome.parse_outcome_block", side_effect=RuntimeError("forced")
+        ):
+            result = _parse_outcome_block_for_persona(text, _FakePersona())
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: Episode model fields
+# ---------------------------------------------------------------------------
+
+
+class TestEpisodeStructuredOutcomeFields:
+    def test_defaults_to_none_and_false(self) -> None:
+        from datetime import UTC, datetime
+
+        ep = Episode(
+            episode_id="e1",
+            session_id="s1",
+            timestamp=datetime.now(UTC),
+            summary="test",
+            task_description="task",
+            tools_used=[],
+            outcome=Outcome.SUCCESS,
+            tags=[],
+        )
+        assert ep.structured_outcome is None
+        assert ep.outcome_valid is False
+
+    def test_can_set_structured_outcome(self) -> None:
+        from datetime import UTC, datetime
+
+        ep = Episode(
+            episode_id="e2",
+            session_id="s2",
+            timestamp=datetime.now(UTC),
+            summary="test",
+            task_description="task",
+            tools_used=[],
+            outcome=Outcome.SUCCESS,
+            tags=[],
+        )
+        ep.structured_outcome = {"verdict": "pass", "summary": "ok"}
+        ep.outcome_valid = True
+        assert ep.structured_outcome["verdict"] == "pass"
+        assert ep.outcome_valid is True
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: TurnResult.episode field
+# ---------------------------------------------------------------------------
+
+
+class TestTurnResultEpisodeField:
+    def test_episode_defaults_to_none(self) -> None:
+        result = TurnResult(
+            response="hello",
+            tool_calls=[],
+            tool_results=[],
+            usage=TokenUsage(input_tokens=1, output_tokens=1),
+        )
+        assert result.episode is None
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: agent with reviewer persona
+# ---------------------------------------------------------------------------
+
+
+_REVIEWER_RESPONSE_WITH_OUTCOME = (
+    "I reviewed the diff thoroughly.\n\n"
+    "The code looks clean with no blocking issues.\n\n"
+    "---outcome---\n"
+    "verdict: pass\n"
+    "findings_count: 1\n"
+    "critical_count: 0\n"
+    "summary: Minor style issue only\n"
+    "---end---\n"
+)
+
+_REVIEWER_RESPONSE_NO_OUTCOME = "I reviewed the diff thoroughly. The code looks clean."
+
+
+class TestAgentOutcomeCapture:
+    @pytest.mark.asyncio
+    async def test_outcome_stored_on_episode_when_block_found(self) -> None:
+        persona = _reviewer_persona()
+        llm = _make_llm_with_response(_REVIEWER_RESPONSE_WITH_OUTCOME)
+        agent, _ = _make_agent(llm, persona_config=persona, persona_name="reviewer")
+
+        result = await agent.run_turn("Review the diff")
+
+        assert result.episode is not None
+        assert result.episode.structured_outcome is not None
+        assert result.episode.structured_outcome["verdict"] == "pass"
+        assert result.episode.outcome_valid is True
+
+    @pytest.mark.asyncio
+    async def test_no_outcome_when_persona_has_no_schema(self) -> None:
+        persona = PersonaConfig(name="minimal")
+        llm = _make_llm_with_response(_REVIEWER_RESPONSE_WITH_OUTCOME)
+        agent, _ = _make_agent(llm, persona_config=persona)
+
+        result = await agent.run_turn("Do something")
+
+        assert result.episode is not None
+        assert result.episode.structured_outcome is None
+        assert result.episode.outcome_valid is False
+
+    @pytest.mark.asyncio
+    async def test_no_outcome_when_no_persona_config(self) -> None:
+        llm = _make_llm_with_response(_REVIEWER_RESPONSE_WITH_OUTCOME)
+        agent, _ = _make_agent(llm)
+
+        result = await agent.run_turn("Do something")
+
+        assert result.episode is not None
+        assert result.episode.structured_outcome is None
+
+    @pytest.mark.asyncio
+    async def test_episode_is_set_even_without_memory(self) -> None:
+        """Episode is always set on TurnResult so callers can inspect outcome."""
+        persona = _reviewer_persona()
+        llm = _make_llm_with_response(_REVIEWER_RESPONSE_WITH_OUTCOME)
+        agent, _ = _make_agent(llm, persona_config=persona)
+
+        result = await agent.run_turn("Review")
+
+        assert result.episode is not None
+
+    @pytest.mark.asyncio
+    async def test_no_outcome_when_response_lacks_block(self) -> None:
+        persona = _reviewer_persona()
+        llm = _make_llm_with_response(_REVIEWER_RESPONSE_NO_OUTCOME)
+        agent, _ = _make_agent(llm, persona_config=persona)
+
+        result = await agent.run_turn("Review")
+
+        assert result.episode is not None
+        assert result.episode.structured_outcome is None
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: Sleipnir event emission
+# ---------------------------------------------------------------------------
+
+
+class TestAgentSleipnirOutcomeEvent:
+    @pytest.mark.asyncio
+    async def test_session_ended_emitted_with_structured_outcome(self) -> None:
+        events: list[SleipnirEvent] = []
+        bus = InProcessBus()
+        await bus.subscribe(["ravn.session.*"], lambda e: events.append(e))
+
+        persona = _reviewer_persona()
+        llm = _make_llm_with_response(_REVIEWER_RESPONSE_WITH_OUTCOME)
+        agent, _ = _make_agent(
+            llm,
+            persona_config=persona,
+            sleipnir_publisher=bus,
+            persona_name="reviewer",
+        )
+
+        await agent.run_turn("Review the diff in this repo")
+        await bus.flush()
+
+        ended = [e for e in events if e.event_type == "ravn.session.ended"]
+        assert len(ended) == 1
+        payload = ended[0].payload
+        assert "structured_outcome" in payload
+        assert payload["structured_outcome"]["verdict"] == "pass"
+        assert payload["outcome_valid"] is True
+        assert payload["outcome_event_type"] == "review.completed"
+
+    @pytest.mark.asyncio
+    async def test_session_started_emitted_on_first_turn(self) -> None:
+        events: list[SleipnirEvent] = []
+        bus = InProcessBus()
+        await bus.subscribe(["ravn.session.*"], lambda e: events.append(e))
+
+        persona = _reviewer_persona()
+        llm = _make_llm_with_response(_REVIEWER_RESPONSE_WITH_OUTCOME)
+        agent, _ = _make_agent(
+            llm,
+            persona_config=persona,
+            sleipnir_publisher=bus,
+            persona_name="reviewer",
+        )
+
+        await agent.run_turn("Review the diff in this repo")
+        await bus.flush()
+
+        started = [e for e in events if e.event_type == "ravn.session.started"]
+        assert len(started) == 1
+        assert started[0].payload["persona"] == "reviewer"
+
+    @pytest.mark.asyncio
+    async def test_session_ended_not_emitted_when_no_outcome_block(self) -> None:
+        events: list[SleipnirEvent] = []
+        bus = InProcessBus()
+        await bus.subscribe(["ravn.session.*"], lambda e: events.append(e))
+
+        persona = _reviewer_persona()
+        llm = _make_llm_with_response(_REVIEWER_RESPONSE_NO_OUTCOME)
+        agent, _ = _make_agent(
+            llm,
+            persona_config=persona,
+            sleipnir_publisher=bus,
+            persona_name="reviewer",
+        )
+
+        await agent.run_turn("Review")
+        await bus.flush()
+
+        ended = [e for e in events if e.event_type == "ravn.session.ended"]
+        assert len(ended) == 0
+
+    @pytest.mark.asyncio
+    async def test_emit_session_ended_is_noop_after_outcome_emitted(self) -> None:
+        """emit_session_ended() must not double-emit when outcome block already triggered it."""
+        events: list[SleipnirEvent] = []
+        bus = InProcessBus()
+        await bus.subscribe(["ravn.session.*"], lambda e: events.append(e))
+
+        persona = _reviewer_persona()
+        llm = _make_llm_with_response(_REVIEWER_RESPONSE_WITH_OUTCOME)
+        agent, _ = _make_agent(
+            llm,
+            persona_config=persona,
+            sleipnir_publisher=bus,
+            persona_name="reviewer",
+        )
+
+        await agent.run_turn("Review")
+        await agent.emit_session_ended("success")  # should be ignored
+        await bus.flush()
+
+        ended = [e for e in events if e.event_type == "ravn.session.ended"]
+        assert len(ended) == 1  # only one, from outcome capture
+
+    @pytest.mark.asyncio
+    async def test_no_event_emitted_when_no_publisher(self) -> None:
+        """Agent works fine without a Sleipnir publisher — no errors."""
+        persona = _reviewer_persona()
+        llm = _make_llm_with_response(_REVIEWER_RESPONSE_WITH_OUTCOME)
+        agent, _ = _make_agent(llm, persona_config=persona)
+
+        # Should not raise
+        result = await agent.run_turn("Review")
+        assert result.episode is not None
+        assert result.episode.structured_outcome is not None
+
+
+# ---------------------------------------------------------------------------
+# E2E test matching the delivery spec
+# ---------------------------------------------------------------------------
+
+
+class TestRavnOutcomeE2E:
+    @pytest.mark.asyncio
+    async def test_ravn_outcome_emitted(self) -> None:
+        """Run agent with reviewer persona → verify outcome extracted and event emitted."""
+        events: list[SleipnirEvent] = []
+        bus = InProcessBus()
+        await bus.subscribe(["ravn.session.*"], lambda e: events.append(e))
+
+        persona = _reviewer_persona()
+        llm = _make_llm_with_response(_REVIEWER_RESPONSE_WITH_OUTCOME)
+        agent, _ = _make_agent(
+            llm,
+            persona_config=persona,
+            sleipnir_publisher=bus,
+            persona_name="reviewer",
+        )
+
+        result = await agent.run_turn("Review the diff in this repo")
+
+        # Verify outcome parsed
+        assert result.episode is not None
+        assert result.episode.structured_outcome is not None
+        assert result.episode.structured_outcome["verdict"] in ("pass", "fail", "needs_changes")
+
+        # Verify event emitted
+        await bus.flush()
+        ended_events = [e for e in events if e.event_type == "ravn.session.ended"]
+        assert len(ended_events) == 1
+        assert "structured_outcome" in ended_events[0].payload
+        assert ended_events[0].payload["outcome_event_type"] == "review.completed"


### PR DESCRIPTION
## Summary

Implements NIU-594: Ravn outcome capture — parse \`---outcome---\` block from the agent's final response, store structured outcome on the episode, and emit a Sleipnir \`ravn.session.ended\` event enriched with the structured payload.

- **\`Episode\` model**: Added \`structured_outcome: dict[str, Any] | None\` and \`outcome_valid: bool\` fields to hold parsed outcome block data
- **\`TurnResult\` model**: Added \`episode: Episode | None\` field so callers can inspect the recorded episode and its structured outcome after each turn
- **\`RavnAgent\`**: Added \`persona_config\` parameter (duck-typed \`object | None\`) to carry the persona's produces schema without coupling the agent to the adapters layer
- **\`_parse_outcome_block_for_persona()\`**: New module-level helper that delegates to \`niuu.domain.outcome.parse_outcome_block\` when a persona schema exists
- **\`run_turn()\`**: Always extracts an episode (lightweight, no LLM call without memory); attaches structured outcome fields before memory recording; calls \`_emit_session_ended_with_outcome()\` when an outcome block is found
- **\`_emit_session_ended_with_outcome()\`**: New method that publishes \`ravn.session.ended\` enriched with \`structured_outcome\`, \`outcome_valid\`, and \`outcome_event_type\` from the persona's produces declaration
- **Double-emission guard**: \`_session_ended_emitted\` flag ensures \`emit_session_ended()\` is a no-op when outcome block capture already fired the event
- **\`ravn.session.started\`**: Already emits on first turn via existing \`_emit_session_started()\` (no change needed)

## Test plan

- [x] 21 new tests in \`tests/test_ravn/test_outcome_capture.py\` covering all delivery criteria:
  - \`_parse_outcome_block_for_persona\` unit tests (no persona, no schema, no block, valid block, invalid block, produces=None, exception handler)
  - \`Episode.structured_outcome\` / \`Episode.outcome_valid\` field defaults and mutation
  - \`TurnResult.episode\` field default
  - Agent with reviewer persona: outcome stored on episode, no outcome without schema, no outcome without block
  - Sleipnir: \`ravn.session.ended\` emitted with structured_outcome, \`ravn.session.started\` emitted on first turn, no event when no block, no double-emission, graceful when no publisher
  - E2E test matching the delivery spec exactly
- [x] All 21 new tests pass
- [x] All existing ravn/niuu/sleipnir tests pass (3557 pass, 1 pre-existing textual failure unrelated to this change)
- [x] ruff check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)