### PR TITLE
feat(tyr): pipeline context injection for downstream stages (NIU-597)

### DIFF
--- a/src/tyr/domain/pipeline_executor.py
+++ b/src/tyr/domain/pipeline_executor.py
@@ -153,16 +153,7 @@ def build_stage_context_from_outcomes(
     :param outcomes: Mapping of participant name → structured outcome dict.
     :returns: Markdown-formatted context block.
     """
-    lines: list[str] = ["## Previous Stage Outcomes\n", f"### {stage_name}"]
-    for participant, outcome in outcomes.items():
-        if outcome:
-            lines.append(f"**{participant}**:")
-            for k, v in outcome.items():
-                lines.append(f"  - {k}: {v}")
-        else:
-            lines.append(f"**{participant}**: completed (no structured outcome)")
-    lines.append("")
-    return "\n".join(lines)
+    return _build_full_stage_context([(stage_name, outcomes)])
 
 
 def merge_stage_outcomes(
@@ -196,6 +187,8 @@ def merge_stage_outcomes(
                 merged[k] = merged.get(k, 0) + v
             else:
                 merged[k] = v
+    merged.pop("verdicts", None)
+    merged.pop("summaries", None)
     return merged
 
 

--- a/src/tyr/domain/pipeline_executor.py
+++ b/src/tyr/domain/pipeline_executor.py
@@ -31,6 +31,7 @@ Usage::
 from __future__ import annotations
 
 import logging
+import re
 import uuid
 from dataclasses import replace
 from datetime import UTC, datetime
@@ -118,6 +119,127 @@ def merge_outcomes(outcomes: list[dict[str, Any]]) -> dict[str, Any]:
             break
 
     return merged
+
+
+# ---------------------------------------------------------------------------
+# Stage context injection (NIU-597)
+# ---------------------------------------------------------------------------
+
+_STAGE_REF_RE = re.compile(r"\{stages\.[^}]+\}")
+
+
+def _evaluate_verdict(verdicts: list[str], fan_in: str) -> str:
+    """Compute aggregate verdict from multiple participants based on fan-in strategy."""
+    if not verdicts:
+        return "pass"
+    if fan_in == "all_must_pass":
+        return "fail" if any(v == "fail" for v in verdicts) else "pass"
+    if fan_in == "any_pass":
+        return "pass" if any(v == "pass" for v in verdicts) else "fail"
+    if fan_in == "majority":
+        passing = sum(1 for v in verdicts if v == "pass")
+        return "pass" if passing > len(verdicts) / 2 else "fail"
+    # "merge" default: fail if any fail
+    return "fail" if any(v == "fail" for v in verdicts) else "pass"
+
+
+def build_stage_context_from_outcomes(
+    stage_name: str,
+    outcomes: dict[str, dict[str, Any]],
+) -> str:
+    """Build a context block summarising one completed stage.
+
+    :param stage_name: Human-readable stage name (e.g. ``"review"``).
+    :param outcomes: Mapping of participant name → structured outcome dict.
+    :returns: Markdown-formatted context block.
+    """
+    lines: list[str] = ["## Previous Stage Outcomes\n", f"### {stage_name}"]
+    for participant, outcome in outcomes.items():
+        if outcome:
+            lines.append(f"**{participant}**:")
+            for k, v in outcome.items():
+                lines.append(f"  - {k}: {v}")
+        else:
+            lines.append(f"**{participant}**: completed (no structured outcome)")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def merge_stage_outcomes(
+    outcomes: dict[str, dict[str, Any]],
+    fan_in: str = "merge",
+) -> dict[str, Any]:
+    """Merge parallel participant outcomes into a single stage outcome dict.
+
+    Handles:
+
+    - ``verdict``: aggregated across participants using *fan_in* strategy
+    - ``summary``: concatenated as ``"participant: summary"`` joined by `` | ``
+    - Numeric fields: summed across participants
+    - Other string/misc fields: last-writer wins
+
+    :param outcomes: Mapping of participant name → structured outcome dict.
+    :param fan_in: Aggregation strategy for verdict (``merge``, ``all_must_pass``,
+        ``any_pass``, ``majority``).
+    :returns: Merged outcome dict suitable for ``{stages.name.field}`` interpolation.
+    """
+    merged: dict[str, Any] = {}
+    for participant, outcome in outcomes.items():
+        for k, v in outcome.items():
+            if k == "verdict":
+                merged.setdefault("verdicts", []).append(v)
+                merged["verdict"] = _evaluate_verdict(merged["verdicts"], fan_in)
+            elif k == "summary":
+                merged.setdefault("summaries", []).append(f"{participant}: {v}")
+                merged["summary"] = " | ".join(merged["summaries"])
+            elif isinstance(v, (int, float)):
+                merged[k] = merged.get(k, 0) + v
+            else:
+                merged[k] = v
+    return merged
+
+
+def interpolate_stage_refs(
+    prompt: str,
+    stage_outcomes: dict[str, dict[str, Any]],
+) -> str:
+    """Replace ``{stages.<name>.<field>}`` placeholders with actual outcome values.
+
+    Unknown ``{stages.*}`` references are replaced with an empty string so
+    downstream text is always clean.
+
+    :param prompt: Prompt template that may contain ``{stages.*}`` refs.
+    :param stage_outcomes: Mapping of stage name → merged outcome dict.
+    :returns: Interpolated prompt with all ``{stages.*}`` refs resolved.
+    """
+    for stage_name, outcome in stage_outcomes.items():
+        for field_name, value in outcome.items():
+            prompt = prompt.replace(f"{{stages.{stage_name}.{field_name}}}", str(value))
+    return _STAGE_REF_RE.sub("", prompt)
+
+
+def _build_full_stage_context(
+    stage_data: list[tuple[str, dict[str, dict[str, Any]]]],
+) -> str:
+    """Build a combined context block from multiple completed stages.
+
+    :param stage_data: Ordered list of ``(stage_name, {participant: outcome})`` pairs.
+    :returns: Combined markdown context block, or empty string when *stage_data* is empty.
+    """
+    if not stage_data:
+        return ""
+    lines: list[str] = ["## Previous Stage Outcomes\n"]
+    for stage_name, outcomes in stage_data:
+        lines.append(f"### {stage_name}")
+        for participant, outcome in outcomes.items():
+            if outcome:
+                lines.append(f"**{participant}**:")
+                for k, v in outcome.items():
+                    lines.append(f"  - {k}: {v}")
+            else:
+                lines.append(f"**{participant}**: completed (no structured outcome)")
+        lines.append("")
+    return "\n".join(lines)
 
 
 # ---------------------------------------------------------------------------
@@ -789,7 +911,7 @@ class TemplateAwarePipelineExecutor(PipelineExecutor):
         await self._advance_phase(saga, next_phase=next_phase)
 
     async def _advance_phase(self, saga: Saga, *, next_phase: Phase) -> None:
-        """Template-aware advance: uses stored template prompt and persona."""
+        """Template-aware advance: injects prior stage context and uses stored template."""
         active = Phase(
             id=next_phase.id,
             saga_id=next_phase.saga_id,
@@ -816,12 +938,37 @@ class TemplateAwarePipelineExecutor(PipelineExecutor):
             None,
         )
 
+        # Build stage context from all completed phases for injection into prompts.
+        all_phases = await self._saga_repo.get_phases_by_saga(saga.id)
+        completed_phases = [p for p in all_phases if p.status == PhaseStatus.COMPLETE]
+
+        stage_data: list[tuple[str, dict[str, dict[str, Any]]]] = []
+        stage_outcomes_for_interp: dict[str, dict[str, Any]] = {}
+
+        for phase in completed_phases:
+            phase_raids = await self._saga_repo.get_raids_by_phase(phase.id)
+            raid_outcomes: dict[str, dict[str, Any]] = {
+                r.name: (r.structured_outcome or {}) for r in phase_raids
+            }
+            tpl_for_phase = next(
+                (tpl for ph, tpl in template_pairs if ph.id == phase.id),
+                None,
+            )
+            fan_in = tpl_for_phase.fan_in if tpl_for_phase else "merge"
+            stage_data.append((phase.name, raid_outcomes))
+            stage_outcomes_for_interp[phase.name] = merge_stage_outcomes(raid_outcomes, fan_in)
+
+        context_block = _build_full_stage_context(stage_data)
+
         raids = await self._saga_repo.get_raids_by_phase(next_phase.id)
         repo = saga.repos[0] if saga.repos else ""
         for i, raid in enumerate(raids):
             tpl_raid = tpl_phase.raids[i] if tpl_phase and i < len(tpl_phase.raids) else None
             session_name = _session_name(raid.name)
-            initial_prompt = tpl_raid.prompt if tpl_raid else raid.description
+            base_prompt = tpl_raid.prompt if tpl_raid else raid.description
+            prompt = interpolate_stage_refs(base_prompt, stage_outcomes_for_interp)
+            if context_block:
+                prompt = f"{context_block}\n\n{prompt}"
             persona = tpl_raid.persona or None if tpl_raid else None
             try:
                 session = await volundr.spawn_session(
@@ -834,7 +981,7 @@ class TemplateAwarePipelineExecutor(PipelineExecutor):
                         tracker_issue_id=raid.tracker_id,
                         tracker_issue_url="",
                         system_prompt="",
-                        initial_prompt=initial_prompt,
+                        initial_prompt=prompt,
                         profile=persona,
                         integration_ids=[],
                     ),

--- a/tests/test_tyr/test_pipeline_executor.py
+++ b/tests/test_tyr/test_pipeline_executor.py
@@ -906,6 +906,15 @@ class TestMergeStageOutcomes:
     def test_empty_outcomes_returns_empty_dict(self):
         assert merge_stage_outcomes({}) == {}
 
+    def test_internal_accumulators_not_in_result(self):
+        outcomes = {
+            "a": {"verdict": "pass", "summary": "ok"},
+            "b": {"verdict": "pass", "summary": "fine"},
+        }
+        merged = merge_stage_outcomes(outcomes)
+        assert "verdicts" not in merged
+        assert "summaries" not in merged
+
     def test_float_numeric_fields_summed(self):
         outcomes = {
             "a": {"score": 1.5},

--- a/tests/test_tyr/test_pipeline_executor.py
+++ b/tests/test_tyr/test_pipeline_executor.py
@@ -12,8 +12,11 @@ from tyr.adapters.memory_event_bus import InMemoryEventBus
 from tyr.domain.models import PhaseStatus, RaidStatus, SagaStatus
 from tyr.domain.pipeline_executor import (
     TemplateAwarePipelineExecutor,
+    build_stage_context_from_outcomes,
     evaluate_fan_in,
+    interpolate_stage_refs,
     merge_outcomes,
+    merge_stage_outcomes,
 )
 
 # ---------------------------------------------------------------------------
@@ -735,3 +738,314 @@ class TestConditionBasedAdvancement:
 
         saga = await executor.create_from_yaml(_SINGLE_STAGE_PIPELINE, auto_start=False)
         assert saga.id in repo.sagas
+
+
+# ---------------------------------------------------------------------------
+# NIU-597: Stage context injection
+# ---------------------------------------------------------------------------
+
+_STAGE_REF_PIPELINE = textwrap.dedent(
+    """
+    name: "ref-pipeline"
+    feature_branch: "feat/refs"
+    base_branch: "main"
+    repos:
+      - "test/repo"
+    stages:
+      - name: review
+        sequential:
+          - name: "Reviewer"
+            persona: reviewer
+            prompt: "Review the code"
+      - name: test
+        sequential:
+          - name: "Tester"
+            persona: qa-agent
+            prompt: "Run tests. Review verdict: {stages.review.verdict}"
+    """
+)
+
+
+class TestBuildStageContextFromOutcomes:
+    def test_participant_names_in_context(self):
+        outcomes = {
+            "reviewer": {"verdict": "pass", "findings_count": 3, "summary": "Minor issues only"},
+            "security-auditor": {
+                "verdict": "pass",
+                "critical_findings": 0,
+                "summary": "No security issues",
+            },
+        }
+        context = build_stage_context_from_outcomes("review", outcomes)
+        assert "reviewer" in context
+        assert "security-auditor" in context
+
+    def test_verdict_in_context(self):
+        outcomes = {"reviewer": {"verdict": "pass"}}
+        context = build_stage_context_from_outcomes("review", outcomes)
+        assert "verdict: pass" in context
+
+    def test_summary_in_context(self):
+        outcomes = {"reviewer": {"summary": "Minor issues only"}}
+        context = build_stage_context_from_outcomes("review", outcomes)
+        assert "Minor issues only" in context
+
+    def test_stage_name_in_context(self):
+        context = build_stage_context_from_outcomes("stage-one", {"agent": {"verdict": "pass"}})
+        assert "stage-one" in context
+
+    def test_empty_outcome_shows_completed_message(self):
+        outcomes = {"reviewer": {}}
+        context = build_stage_context_from_outcomes("review", outcomes)
+        assert "completed (no structured outcome)" in context
+
+    def test_header_present(self):
+        context = build_stage_context_from_outcomes("s", {"a": {"x": "y"}})
+        assert "## Previous Stage Outcomes" in context
+
+
+class TestMergeStageOutcomes:
+    def test_verdicts_aggregated_pass(self):
+        outcomes = {
+            "reviewer": {"verdict": "pass"},
+            "auditor": {"verdict": "pass"},
+        }
+        merged = merge_stage_outcomes(outcomes)
+        assert merged["verdict"] == "pass"
+
+    def test_any_fail_gives_fail_merge(self):
+        outcomes = {
+            "reviewer": {"verdict": "pass"},
+            "auditor": {"verdict": "fail"},
+        }
+        merged = merge_stage_outcomes(outcomes)
+        assert merged["verdict"] == "fail"
+
+    def test_summaries_concatenated_with_participant_prefix(self):
+        outcomes = {
+            "reviewer": {"summary": "Minor issues"},
+            "auditor": {"summary": "No security issues"},
+        }
+        merged = merge_stage_outcomes(outcomes)
+        assert "reviewer: Minor issues" in merged["summary"]
+        assert "auditor: No security issues" in merged["summary"]
+
+    def test_summary_joined_by_pipe(self):
+        outcomes = {
+            "a": {"summary": "first"},
+            "b": {"summary": "second"},
+        }
+        merged = merge_stage_outcomes(outcomes)
+        assert " | " in merged["summary"]
+
+    def test_numeric_fields_summed(self):
+        outcomes = {
+            "reviewer": {"findings_count": 3},
+            "auditor": {"findings_count": 2},
+        }
+        merged = merge_stage_outcomes(outcomes)
+        assert merged["findings_count"] == 5
+
+    def test_non_numeric_fields_last_writer_wins(self):
+        outcomes = {
+            "a": {"tag": "alpha"},
+            "b": {"tag": "beta"},
+        }
+        merged = merge_stage_outcomes(outcomes)
+        assert merged["tag"] == "beta"
+
+    def test_all_must_pass_fan_in_one_fail(self):
+        outcomes = {
+            "a": {"verdict": "pass"},
+            "b": {"verdict": "fail"},
+        }
+        merged = merge_stage_outcomes(outcomes, fan_in="all_must_pass")
+        assert merged["verdict"] == "fail"
+
+    def test_all_must_pass_fan_in_all_pass(self):
+        outcomes = {
+            "a": {"verdict": "pass"},
+            "b": {"verdict": "pass"},
+        }
+        merged = merge_stage_outcomes(outcomes, fan_in="all_must_pass")
+        assert merged["verdict"] == "pass"
+
+    def test_any_pass_fan_in_one_pass(self):
+        outcomes = {
+            "a": {"verdict": "fail"},
+            "b": {"verdict": "pass"},
+        }
+        merged = merge_stage_outcomes(outcomes, fan_in="any_pass")
+        assert merged["verdict"] == "pass"
+
+    def test_any_pass_fan_in_all_fail(self):
+        outcomes = {
+            "a": {"verdict": "fail"},
+            "b": {"verdict": "fail"},
+        }
+        merged = merge_stage_outcomes(outcomes, fan_in="any_pass")
+        assert merged["verdict"] == "fail"
+
+    def test_majority_fan_in_majority_pass(self):
+        outcomes = {
+            "a": {"verdict": "pass"},
+            "b": {"verdict": "pass"},
+            "c": {"verdict": "fail"},
+        }
+        merged = merge_stage_outcomes(outcomes, fan_in="majority")
+        assert merged["verdict"] == "pass"
+
+    def test_majority_fan_in_exactly_half(self):
+        outcomes = {
+            "a": {"verdict": "pass"},
+            "b": {"verdict": "fail"},
+        }
+        merged = merge_stage_outcomes(outcomes, fan_in="majority")
+        assert merged["verdict"] == "fail"
+
+    def test_empty_outcomes_returns_empty_dict(self):
+        assert merge_stage_outcomes({}) == {}
+
+    def test_float_numeric_fields_summed(self):
+        outcomes = {
+            "a": {"score": 1.5},
+            "b": {"score": 2.5},
+        }
+        merged = merge_stage_outcomes(outcomes)
+        assert merged["score"] == pytest.approx(4.0)
+
+
+class TestInterpolateStageRefs:
+    def test_basic_interpolation(self):
+        prompt = "Result: {stages.review.verdict}"
+        resolved = interpolate_stage_refs(prompt, {"review": {"verdict": "pass"}})
+        assert resolved == "Result: pass"
+
+    def test_missing_field_becomes_empty_string(self):
+        prompt = "Result: {stages.review.missing_field}"
+        resolved = interpolate_stage_refs(prompt, {"review": {"verdict": "pass"}})
+        assert resolved == "Result: "
+
+    def test_missing_stage_becomes_empty_string(self):
+        prompt = "Result: {stages.nonexistent.verdict}"
+        resolved = interpolate_stage_refs(prompt, {})
+        assert resolved == "Result: "
+
+    def test_multiple_refs_resolved(self):
+        prompt = "{stages.review.verdict} - {stages.review.summary}"
+        resolved = interpolate_stage_refs(
+            prompt, {"review": {"verdict": "pass", "summary": "All good"}}
+        )
+        assert "pass" in resolved
+        assert "All good" in resolved
+
+    def test_no_refs_unchanged(self):
+        prompt = "No stage refs here."
+        resolved = interpolate_stage_refs(prompt, {"review": {"verdict": "pass"}})
+        assert resolved == "No stage refs here."
+
+    def test_numeric_value_converted_to_string(self):
+        prompt = "Count: {stages.review.findings_count}"
+        resolved = interpolate_stage_refs(prompt, {"review": {"findings_count": 5}})
+        assert resolved == "Count: 5"
+
+
+class TestContextInjectionE2E:
+    @pytest.mark.asyncio
+    async def test_stage2_receives_stage1_outcomes_in_prompt(self):
+        """Stage 2 persona gets stage 1 outcomes injected into its initial_prompt."""
+        volundr = StubVolundrPort()
+        executor, repo, _ = _make_executor(volundr=volundr)
+        saga = await executor.create_from_yaml(_PARALLEL_PIPELINE, auto_start=True)
+
+        phases = await repo.get_phases_by_saga(saga.id)
+        phase1 = phases[0]
+        raids = await repo.get_raids_by_phase(phase1.id)
+
+        # Complete both stage 1 raids
+        await executor.receive_outcome(
+            raid_id=raids[0].id,
+            outcome={"verdict": "pass", "summary": "Minor issues only"},
+        )
+        await executor.receive_outcome(
+            raid_id=raids[1].id,
+            outcome={"verdict": "pass", "critical_findings": 0},
+        )
+
+        # Phase 1 spawned 2 raids, phase 2 spawns 1 raid → 3 total
+        assert len(volundr.spawned) == 3
+        stage2_prompt = volundr.spawned[2].initial_prompt
+        assert "## Previous Stage Outcomes" in stage2_prompt
+        assert "review" in stage2_prompt
+
+    @pytest.mark.asyncio
+    async def test_stage2_context_includes_stage1_verdicts(self):
+        """The context block contains participant verdicts from stage 1."""
+        volundr = StubVolundrPort()
+        executor, repo, _ = _make_executor(volundr=volundr)
+        saga = await executor.create_from_yaml(_PARALLEL_PIPELINE, auto_start=True)
+
+        phases = await repo.get_phases_by_saga(saga.id)
+        raids = await repo.get_raids_by_phase(phases[0].id)
+
+        await executor.receive_outcome(
+            raid_id=raids[0].id, outcome={"verdict": "pass", "summary": "looks good"}
+        )
+        await executor.receive_outcome(
+            raid_id=raids[1].id, outcome={"verdict": "pass", "critical_findings": 0}
+        )
+
+        stage2_prompt = volundr.spawned[2].initial_prompt
+        assert "verdict: pass" in stage2_prompt
+
+    @pytest.mark.asyncio
+    async def test_stage_ref_interpolation_in_template_prompt(self):
+        """Template {stages.review.verdict} is resolved to the actual verdict value."""
+        volundr = StubVolundrPort()
+        executor, repo, _ = _make_executor(volundr=volundr)
+        saga = await executor.create_from_yaml(_STAGE_REF_PIPELINE, auto_start=True)
+
+        phases = await repo.get_phases_by_saga(saga.id)
+        raids = await repo.get_raids_by_phase(phases[0].id)
+
+        await executor.receive_outcome(raid_id=raids[0].id, outcome={"verdict": "pass"})
+
+        # Stage 2 dispatched — prompt should have {stages.review.verdict} resolved
+        assert len(volundr.spawned) == 2
+        stage2_prompt = volundr.spawned[1].initial_prompt
+        assert "pass" in stage2_prompt
+        assert "{stages.review.verdict}" not in stage2_prompt
+
+    @pytest.mark.asyncio
+    async def test_no_context_injected_for_first_phase(self):
+        """First phase dispatched without any context block."""
+        volundr = StubVolundrPort()
+        executor, repo, _ = _make_executor(volundr=volundr)
+        await executor.create_from_yaml(_SINGLE_STAGE_PIPELINE, auto_start=True)
+
+        assert len(volundr.spawned) == 1
+        # First phase has no prior stages → no context block
+        assert "## Previous Stage Outcomes" not in volundr.spawned[0].initial_prompt
+
+    @pytest.mark.asyncio
+    async def test_context_injection_e2e(self):
+        """E2E: Stage 2 persona gets stage 1 outcomes injected (spec test case)."""
+        stage1_outcomes = {
+            "reviewer": {"verdict": "pass", "findings_count": 3, "summary": "Minor issues only"},
+            "security-auditor": {
+                "verdict": "pass",
+                "critical_findings": 0,
+                "summary": "No security issues",
+            },
+        }
+
+        context = build_stage_context_from_outcomes("review", stage1_outcomes)
+        assert "reviewer" in context
+        assert "verdict: pass" in context
+        assert "Minor issues only" in context
+        assert "security-auditor" in context
+
+        prompt = "Run tests. Review result: {stages.review.verdict}. {stages.review.summary}"
+        resolved = interpolate_stage_refs(prompt, {"review": merge_stage_outcomes(stage1_outcomes)})
+        assert "pass" in resolved
+        assert "Minor issues only" in resolved


### PR DESCRIPTION
## Summary

- Downstream stages now receive a `## Previous Stage Outcomes` block at the top of their initial prompts, injected from all completed stages' structured outcomes
- New `build_stage_context_from_outcomes` function formats participant outcomes as markdown for the context block
- New `merge_stage_outcomes` function merges parallel participant outcomes: verdicts aggregated by fan-in strategy, summaries concatenated with participant prefix joined by ` | `, numeric fields summed, other fields last-writer wins
- New `interpolate_stage_refs` function resolves `{stages.<name>.<field>}` placeholders in template prompts; unresolved refs collapse to empty string
- `TemplateAwarePipelineExecutor._advance_phase` now collects all completed phases, builds the context and merged outcomes, interpolates stage refs, and prepends the context block to each raid's prompt

## Test plan

- [x] `TestBuildStageContextFromOutcomes` — 6 unit tests covering context format, header, empty outcomes, stage name
- [x] `TestMergeStageOutcomes` — 14 unit tests covering all fan-in strategies, summary concatenation, numeric summing, float fields, empty input
- [x] `TestInterpolateStageRefs` — 6 unit tests covering basic ref, missing field→empty, missing stage→empty, multiple refs, no refs unchanged, numeric conversion
- [x] `TestContextInjectionE2E` — 5 integration tests verifying actual prompt injection in 2-phase pipeline (parallel + sequential), stage ref resolution, no context on first phase, spec E2E test
- [x] All 84 tests in `test_pipeline_executor.py` + `test_pipelines_api.py` pass
- [x] Coverage: 85.22% on `pipeline_executor.py` (≥ 85% threshold)
- [x] `ruff check` and `ruff format` clean

Closes NIU-597

🤖 Generated with [Claude Code](https://claude.com/claude-code)