### PR TITLE
feat(skuld): RoomBridge — Ravn WebSocket ingress and event aggregation (NIU-602)

### DIFF
--- a/src/ravn/adapters/channels/skuld_channel.py
+++ b/src/ravn/adapters/channels/skuld_channel.py
@@ -39,8 +39,13 @@ class SkuldChannel(ChannelPort):
 
     Args:
         broker_url:    WebSocket URL of the Skuld broker endpoint
-                       (e.g. ``ws://localhost:9000/ws/ravn/{session_id}``).
+                       (e.g. ``ws://localhost:9000/ws/ravn/{peer_id}``).
         session_id:    Agent session identifier forwarded in each event frame.
+        peer_id:       Stable participant identifier for this Ravn daemon.
+                       Included as ``source`` in each NDJSON frame so the
+                       RoomBridge can route events to the correct participant.
+        persona:       Display name for this Ravn in the room UI.  Included
+                       in each frame for late-joining RoomBridge registration.
         reconnect_delay: Seconds to wait between reconnection attempts.
         max_reconnect_attempts: Maximum number of reconnection attempts before
                                giving up and buffering events locally.
@@ -51,11 +56,15 @@ class SkuldChannel(ChannelPort):
         broker_url: str,
         session_id: str,
         *,
+        peer_id: str | None = None,
+        persona: str | None = None,
         reconnect_delay: float = _DEFAULT_RECONNECT_DELAY_SECONDS,
         max_reconnect_attempts: int = _DEFAULT_MAX_RECONNECT_ATTEMPTS,
     ) -> None:
         self._broker_url = broker_url
         self._session_id = session_id
+        self._peer_id = peer_id
+        self._persona = persona
         self._reconnect_delay = reconnect_delay
         self._max_reconnect_attempts = max_reconnect_attempts
         self._ws: websockets.WebSocketClientProtocol | None = None
@@ -193,10 +202,17 @@ class SkuldChannel(ChannelPort):
                 data = str(payload)
                 metadata = {}
 
-        frame = {
+        frame: dict = {
             "session_id": self._session_id,
             "type": str(event.type),
             "data": data,
             "metadata": metadata,
         }
+        # Include source/persona for RoomBridge participant identification.
+        # Existing Skuld deployments that do not understand these fields will
+        # ignore them (backward-compatible addition).
+        if self._peer_id is not None:
+            frame["source"] = self._peer_id
+        if self._persona is not None:
+            frame["persona"] = self._persona
         return json.dumps(frame) + "\n"

--- a/src/skuld/broker.py
+++ b/src/skuld/broker.py
@@ -38,6 +38,7 @@ from skuld.channels import (
 )
 from skuld.chronicle_watcher import ChronicleWatcher
 from skuld.config import SkuldSettings
+from skuld.room_bridge import RoomBridge
 from skuld.service_manager import (
     ServiceCreateRequest,
     ServiceManager,
@@ -431,6 +432,17 @@ class Broker:
         self._pending_block_type: str = ""
         self._pending_reasoning_text: str = ""
         self._chronicle_watcher: ChronicleWatcher | None = None
+
+        # Room bridge — only active when room.enabled is True
+        self._room_bridge: RoomBridge | None = (
+            RoomBridge(
+                config=self._settings.room,
+                channels=self._channels,
+                append_turn=self._append_turn,
+            )
+            if self._settings.room.enabled
+            else None
+        )
 
         # JWT identity state — populated on first browser WebSocket connection
         self._user_jwt: str | None = None
@@ -966,6 +978,21 @@ class Broker:
                     "mcp_set_servers",
                     servers=servers,
                 )
+
+            # Room: forward a directed message to a specific Ravn participant
+            case "directed_message":
+                if self._room_bridge is None:
+                    logger.warning("directed_message received but room mode is disabled")
+                    if sender_ws:
+                        await sender_ws.send_json(
+                            {"type": "error", "content": "Room mode is not enabled"}
+                        )
+                    return
+                target = data.get("targetPeerId", "")
+                content = data.get("content", "")
+                if not target or not content:
+                    return
+                await self._room_bridge.route_directed_message(target, content)
 
             # Default: treat as user message (backward compat with {"content": "..."})
             case _:
@@ -1580,6 +1607,10 @@ class Broker:
                     }
                 )
 
+            # Send current room state to late-joining browsers when room mode active
+            if self._room_bridge is not None:
+                await websocket.send_json(self._room_bridge.get_room_state_event())
+
             # Handle messages from browser
             while True:
                 data = await websocket.receive_json()
@@ -1643,6 +1674,64 @@ class Broker:
         await self._transport.wait_for_cli_disconnect()
         logger.info("handle_cli_websocket: CLI disconnected, handler returning")
 
+    async def handle_ravn_websocket(self, websocket: WebSocket, peer_id: str) -> None:
+        """Handle a Ravn WebSocket connection at /ws/ravn/{peer_id}.
+
+        Accepts NDJSON frames from Ravn daemons and forwards them to the
+        RoomBridge for translation and broadcast. Only active when room mode
+        is enabled.
+        """
+        if self._room_bridge is None:
+            logger.warning(
+                "handle_ravn_websocket: room mode disabled, rejecting peer_id=%s",
+                peer_id,
+            )
+            await websocket.close(code=1008, reason="Room mode is not enabled")
+            return
+
+        await websocket.accept()
+        logger.info("handle_ravn_websocket: Ravn connected peer_id=%s", peer_id)
+
+        # Use persona from first frame header; fall back to peer_id
+        meta = await self._room_bridge.register(
+            peer_id=peer_id,
+            persona=peer_id,
+            websocket=websocket,
+        )
+
+        try:
+            while True:
+                raw = await websocket.receive_text()
+                for line in raw.splitlines():
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        frame = json.loads(line)
+                    except json.JSONDecodeError:
+                        logger.warning(
+                            "handle_ravn_websocket: invalid JSON from peer_id=%s", peer_id
+                        )
+                        continue
+
+                    # Extract persona from first frame if present
+                    if frame.get("persona") and meta.persona == peer_id:
+                        # Re-register with the actual persona name
+                        meta = await self._room_bridge.register(
+                            peer_id=peer_id,
+                            persona=frame["persona"],
+                            websocket=websocket,
+                        )
+
+                    await self._room_bridge.handle_ravn_frame(peer_id, frame)
+
+        except WebSocketDisconnect:
+            logger.info("handle_ravn_websocket: Ravn disconnected peer_id=%s", peer_id)
+        except Exception:
+            logger.exception("handle_ravn_websocket: error from peer_id=%s", peer_id)
+        finally:
+            await self._room_bridge.unregister(peer_id)
+
 
 # Global broker instance
 broker = Broker()
@@ -1703,6 +1792,12 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
 async def cli_websocket_endpoint(websocket: WebSocket, session_id: str) -> None:
     """WebSocket endpoint for Claude Code CLI (via --sdk-url)."""
     await broker.handle_cli_websocket(websocket, session_id)
+
+
+@app.websocket("/ws/ravn/{peer_id}")
+async def ravn_websocket_endpoint(websocket: WebSocket, peer_id: str) -> None:
+    """WebSocket endpoint for Ravn daemon connections (room mode)."""
+    await broker.handle_ravn_websocket(websocket, peer_id)
 
 
 # --- Broker Log API ---

--- a/src/skuld/config.py
+++ b/src/skuld/config.py
@@ -64,6 +64,7 @@ class RoomConfig(BaseModel):
     enabled: bool = Field(default=False)
     max_participants: int = Field(default=8)
     participant_colors: list[str] = Field(default_factory=lambda: list(_DEFAULT_PARTICIPANT_COLORS))
+    activity_detail_max_length: int = Field(default=200)
 
 
 class TelegramConfig(BaseModel):

--- a/src/skuld/room_bridge.py
+++ b/src/skuld/room_bridge.py
@@ -1,0 +1,252 @@
+"""RoomBridge — Ravn WebSocket ingress and event aggregation for multi-agent rooms.
+
+Accepts WebSocket connections from Ravn daemons, translates their NDJSON event
+frames into browser-facing room events, and broadcasts them via ChannelRegistry.
+
+Only active when ``room.enabled = true`` in the broker configuration.
+
+Wire events emitted to browsers:
+    participant_joined   {participant: ParticipantMeta}
+    participant_left     {participantId: str}
+    room_state           {participants: list[ParticipantMeta]}
+    room_message         {id, participantId, participant, content, threadId?, visibility}
+    room_activity        {participantId, activityType, detail?}
+"""
+
+from __future__ import annotations
+
+import itertools
+import json
+import logging
+import uuid
+from dataclasses import asdict
+from typing import TYPE_CHECKING
+
+from fastapi import WebSocket
+
+from skuld.room_models import ParticipantMeta
+
+if TYPE_CHECKING:
+    from skuld.channels import ChannelRegistry
+    from skuld.config import RoomConfig
+
+logger = logging.getLogger(__name__)
+
+# Maps RavnEvent type strings to room activity types
+_RAVN_ACTIVITY_MAP: dict[str, str] = {
+    "thought": "thinking",
+    "thinking": "thinking",
+    "tool_start": "tool_executing",
+    "tool_result": "idle",
+}
+
+
+class RoomBridge:
+    """Bridges Ravn WebSocket connections into the multi-agent room.
+
+    Manages participant registration, color assignment, event translation,
+    history persistence, and directed message routing.
+
+    Args:
+        config:   Room configuration (colors pool, max participants, etc.).
+        channels: Shared channel registry used to broadcast room events.
+        append_turn: Callback to persist a ConversationTurn (injected by Broker).
+    """
+
+    def __init__(
+        self,
+        config: RoomConfig,
+        channels: ChannelRegistry,
+        append_turn: object = None,
+    ) -> None:
+        self._config = config
+        self._channels = channels
+        self._append_turn = append_turn  # Callable[[ConversationTurn], None] | None
+        self._participants: dict[str, ParticipantMeta] = {}
+        self._websockets: dict[str, WebSocket] = {}
+        self._color_cycle = itertools.cycle(list(config.participant_colors))
+
+    # ------------------------------------------------------------------
+    # Participant management
+    # ------------------------------------------------------------------
+
+    async def register(
+        self,
+        peer_id: str,
+        persona: str,
+        websocket: WebSocket,
+    ) -> ParticipantMeta:
+        """Register a new Ravn participant and broadcast ``participant_joined``.
+
+        If a participant with *peer_id* already exists (reconnect), the
+        existing record is reused and a fresh ``participant_joined`` is broadcast.
+        """
+        if peer_id not in self._participants:
+            color = next(self._color_cycle)
+            meta = ParticipantMeta(
+                peer_id=peer_id,
+                persona=persona,
+                color=color,
+                participant_type="ravn",
+            )
+            self._participants[peer_id] = meta
+        else:
+            meta = self._participants[peer_id]
+
+        self._websockets[peer_id] = websocket
+        logger.info("RoomBridge: participant registered peer_id=%s persona=%s", peer_id, persona)
+
+        await self._channels.broadcast({"type": "participant_joined", "participant": asdict(meta)})
+        return meta
+
+    async def unregister(self, peer_id: str) -> None:
+        """Remove a participant and broadcast ``participant_left``."""
+        self._participants.pop(peer_id, None)
+        self._websockets.pop(peer_id, None)
+        logger.info("RoomBridge: participant unregistered peer_id=%s", peer_id)
+
+        await self._channels.broadcast({"type": "participant_left", "participantId": peer_id})
+
+    # ------------------------------------------------------------------
+    # Event translation
+    # ------------------------------------------------------------------
+
+    async def handle_ravn_frame(self, peer_id: str, frame: dict) -> None:
+        """Translate a raw NDJSON frame from a Ravn into room wire events.
+
+        Frame schema (from SkuldChannel):
+            session_id, type, data, metadata, source (peer_id), persona
+
+        Routing:
+            type "response"             → room_message
+            type "error"                → room_message (error=True)
+            type "thought"/"tool_start"/"tool_result" → room_activity
+        """
+        meta = self._participants.get(peer_id)
+        if meta is None:
+            logger.warning("RoomBridge: frame from unknown peer_id=%s, dropping", peer_id)
+            return
+
+        event_type = frame.get("type", "")
+        data = frame.get("data", "")
+
+        if event_type in ("response", "error"):
+            await self._handle_response_frame(meta, frame, is_error=(event_type == "error"))
+            return
+
+        activity_type = _RAVN_ACTIVITY_MAP.get(event_type)
+        if activity_type:
+            await self._handle_activity_frame(meta, activity_type, data)
+
+    async def _handle_response_frame(
+        self,
+        meta: ParticipantMeta,
+        frame: dict,
+        is_error: bool,
+    ) -> None:
+        """Translate a response/error frame into a room_message event."""
+        msg_id = str(uuid.uuid4())
+        content = frame.get("data", "")
+        thread_id = frame.get("metadata", {}).get("thread_id")
+
+        room_event: dict = {
+            "type": "room_message",
+            "id": msg_id,
+            "participantId": meta.peer_id,
+            "participant": asdict(meta),
+            "content": content,
+            "visibility": "public",
+        }
+        if is_error:
+            room_event["error"] = True
+        if thread_id:
+            room_event["threadId"] = thread_id
+
+        await self._channels.broadcast(room_event)
+
+        # Persist as ConversationTurn
+        if self._append_turn is not None:
+            from skuld.broker import ConversationTurn  # late import — avoids circular
+
+            turn = ConversationTurn(
+                id=msg_id,
+                role="assistant",
+                content=content,
+                participant_id=meta.peer_id,
+                participant_meta=asdict(meta),
+                thread_id=thread_id,
+                visibility="public",
+            )
+            self._append_turn(turn)
+
+    async def _handle_activity_frame(
+        self,
+        meta: ParticipantMeta,
+        activity_type: str,
+        detail: str,
+    ) -> None:
+        """Translate a thought/tool frame into a room_activity event."""
+        event: dict = {
+            "type": "room_activity",
+            "participantId": meta.peer_id,
+            "activityType": activity_type,
+        }
+        if detail:
+            event["detail"] = detail[:200]
+
+        await self._channels.broadcast(event)
+
+    # ------------------------------------------------------------------
+    # Directed routing
+    # ------------------------------------------------------------------
+
+    async def route_directed_message(
+        self,
+        target_peer_id: str,
+        content: str,
+    ) -> bool:
+        """Forward a directed message from the browser to a specific Ravn WebSocket.
+
+        Returns True if the message was delivered, False if the target is not connected.
+        """
+        ws = self._websockets.get(target_peer_id)
+        if ws is None:
+            logger.warning(
+                "RoomBridge: directed_message to unknown peer_id=%s, dropping",
+                target_peer_id,
+            )
+            return False
+
+        try:
+            payload = json.dumps({"type": "directed_message", "content": content})
+            await ws.send_text(payload)
+            logger.debug("RoomBridge: directed_message sent to peer_id=%s", target_peer_id)
+            return True
+        except Exception:
+            logger.warning(
+                "RoomBridge: failed to send directed_message to peer_id=%s",
+                target_peer_id,
+                exc_info=True,
+            )
+            return False
+
+    # ------------------------------------------------------------------
+    # Room state
+    # ------------------------------------------------------------------
+
+    def get_room_state_event(self) -> dict:
+        """Return a ``room_state`` event with the current participant list."""
+        return {
+            "type": "room_state",
+            "participants": [asdict(p) for p in self._participants.values()],
+        }
+
+    @property
+    def participant_count(self) -> int:
+        """Number of currently registered participants."""
+        return len(self._participants)
+
+    @property
+    def participants(self) -> dict[str, ParticipantMeta]:
+        """Snapshot of current participants (copy)."""
+        return dict(self._participants)

--- a/src/skuld/room_bridge.py
+++ b/src/skuld/room_bridge.py
@@ -19,8 +19,9 @@ import itertools
 import json
 import logging
 import uuid
+from collections.abc import Callable
 from dataclasses import asdict
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from fastapi import WebSocket
 
@@ -57,11 +58,11 @@ class RoomBridge:
         self,
         config: RoomConfig,
         channels: ChannelRegistry,
-        append_turn: object = None,
+        append_turn: Callable[[Any], None] | None = None,
     ) -> None:
         self._config = config
         self._channels = channels
-        self._append_turn = append_turn  # Callable[[ConversationTurn], None] | None
+        self._append_turn = append_turn
         self._participants: dict[str, ParticipantMeta] = {}
         self._websockets: dict[str, WebSocket] = {}
         self._color_cycle = itertools.cycle(list(config.participant_colors))
@@ -92,6 +93,14 @@ class RoomBridge:
             self._participants[peer_id] = meta
         else:
             meta = self._participants[peer_id]
+            if meta.persona != persona:
+                meta = ParticipantMeta(
+                    peer_id=peer_id,
+                    persona=persona,
+                    color=meta.color,
+                    participant_type=meta.participant_type,
+                )
+                self._participants[peer_id] = meta
 
         self._websockets[peer_id] = websocket
         logger.info("RoomBridge: participant registered peer_id=%s persona=%s", peer_id, persona)
@@ -192,7 +201,7 @@ class RoomBridge:
             "activityType": activity_type,
         }
         if detail:
-            event["detail"] = detail[:200]
+            event["detail"] = detail[: self._config.activity_detail_max_length]
 
         await self._channels.broadcast(event)
 

--- a/tests/test_ravn/test_skuld_channel.py
+++ b/tests/test_ravn/test_skuld_channel.py
@@ -214,3 +214,62 @@ async def test_connect_logs_and_gives_up_after_max_retries():
 
     # After exhausting retries, ws remains None.
     assert ch._ws is None
+
+
+# ---------------------------------------------------------------------------
+# source / persona fields (NIU-602)
+# ---------------------------------------------------------------------------
+
+
+def test_serialise_includes_source_when_peer_id_provided():
+    ch = SkuldChannel(
+        broker_url="ws://localhost:9000/ws/ravn/p1",
+        session_id="sess-1",
+        peer_id="ravn-agent-1",
+    )
+    line = ch._serialise(RavnEvent.response(_SRC, "Hello", _CID, _SID))
+    data = json.loads(line.strip())
+    assert data["source"] == "ravn-agent-1"
+
+
+def test_serialise_includes_persona_when_provided():
+    ch = SkuldChannel(
+        broker_url="ws://localhost:9000/ws/ravn/p1",
+        session_id="sess-1",
+        peer_id="ravn-agent-1",
+        persona="Aria",
+    )
+    line = ch._serialise(RavnEvent.response(_SRC, "Hello", _CID, _SID))
+    data = json.loads(line.strip())
+    assert data["persona"] == "Aria"
+
+
+def test_serialise_omits_source_when_peer_id_not_provided():
+    ch = _make_channel()  # no peer_id
+    line = ch._serialise(RavnEvent.response(_SRC, "Hello", _CID, _SID))
+    data = json.loads(line.strip())
+    assert "source" not in data
+
+
+def test_serialise_omits_persona_when_not_provided():
+    ch = _make_channel()  # no persona
+    line = ch._serialise(RavnEvent.response(_SRC, "Hello", _CID, _SID))
+    data = json.loads(line.strip())
+    assert "persona" not in data
+
+
+def test_serialise_with_peer_id_preserves_existing_fields():
+    ch = SkuldChannel(
+        broker_url="ws://localhost:9000/ws/ravn/p1",
+        session_id="sess-2",
+        peer_id="agent-x",
+        persona="Ravn",
+    )
+    event = RavnEvent.tool_start(_SRC, "BashTool", {"command": "ls"}, _CID, _SID)
+    line = ch._serialise(event)
+    data = json.loads(line.strip())
+    assert data["type"] == "tool_start"
+    assert data["data"] == "BashTool"
+    assert data["session_id"] == "sess-2"
+    assert data["source"] == "agent-x"
+    assert data["persona"] == "Ravn"

--- a/tests/test_skuld/test_broker.py
+++ b/tests/test_skuld/test_broker.py
@@ -2106,3 +2106,212 @@ class TestTokenRedactFilter:
                             assert has_redact, f"{name} missing _TokenRedactFilter"
 
         asyncio.run(check())
+
+
+# ---------------------------------------------------------------------------
+# Room bridge integration in Broker (NIU-602)
+# ---------------------------------------------------------------------------
+
+
+class TestBrokerRoomBridge:
+    """Tests for RoomBridge wiring inside Broker."""
+
+    @pytest.fixture
+    def room_settings(self, tmp_path):
+        return SkuldSettings(
+            session={"id": "room-session", "workspace_dir": str(tmp_path)},
+            transport="sdk",
+            room={"enabled": True},
+        )
+
+    @pytest.fixture
+    def no_room_settings(self, tmp_path):
+        return SkuldSettings(
+            session={"id": "noroom-session", "workspace_dir": str(tmp_path)},
+            transport="sdk",
+            room={"enabled": False},
+        )
+
+    def test_room_bridge_created_when_enabled(self, room_settings):
+        from skuld.room_bridge import RoomBridge
+
+        b = Broker(settings=room_settings)
+        assert b._room_bridge is not None
+        assert isinstance(b._room_bridge, RoomBridge)
+
+    def test_room_bridge_none_when_disabled(self, no_room_settings):
+        b = Broker(settings=no_room_settings)
+        assert b._room_bridge is None
+
+    # -----------------------------------------------------------------------
+    # directed_message dispatch
+    # -----------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_dispatch_directed_message_with_room_bridge(self, room_settings):
+        b = Broker(settings=room_settings)
+        b._transport = AsyncMock()
+        mock_bridge = AsyncMock()
+        b._room_bridge = mock_bridge
+
+        await b._dispatch_browser_message(
+            {"type": "directed_message", "targetPeerId": "agent-1", "content": "Hi!"}
+        )
+
+        mock_bridge.route_directed_message.assert_awaited_once_with("agent-1", "Hi!")
+
+    @pytest.mark.asyncio
+    async def test_dispatch_directed_message_empty_target_ignored(self, room_settings):
+        b = Broker(settings=room_settings)
+        b._transport = AsyncMock()
+        mock_bridge = AsyncMock()
+        b._room_bridge = mock_bridge
+
+        await b._dispatch_browser_message(
+            {"type": "directed_message", "targetPeerId": "", "content": "Hi!"}
+        )
+
+        mock_bridge.route_directed_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_directed_message_room_disabled_sends_error(self, no_room_settings):
+        b = Broker(settings=no_room_settings)
+        b._transport = AsyncMock()
+        mock_ws = AsyncMock()
+
+        await b._dispatch_browser_message(
+            {"type": "directed_message", "targetPeerId": "p1", "content": "Hi!"},
+            sender_ws=mock_ws,
+        )
+
+        mock_ws.send_json.assert_awaited_once()
+        sent = mock_ws.send_json.call_args[0][0]
+        assert sent["type"] == "error"
+
+    # -----------------------------------------------------------------------
+    # room_state on browser connect
+    # -----------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_handle_websocket_sends_room_state_when_room_enabled(self, room_settings):
+        b = Broker(settings=room_settings)
+        mock_transport = AsyncMock()
+        mock_transport.is_alive = True
+        mock_transport.capabilities = TransportCapabilities()
+        b._transport = mock_transport
+
+        mock_ws = AsyncMock()
+        mock_ws.receive_json = AsyncMock(side_effect=WebSocketDisconnect())
+
+        await b.handle_websocket(mock_ws)
+
+        calls = [c[0][0] for c in mock_ws.send_json.call_args_list]
+        room_state_calls = [c for c in calls if c.get("type") == "room_state"]
+        assert len(room_state_calls) == 1
+        assert "participants" in room_state_calls[0]
+
+    @pytest.mark.asyncio
+    async def test_handle_websocket_no_room_state_when_room_disabled(self, no_room_settings):
+        b = Broker(settings=no_room_settings)
+        mock_transport = AsyncMock()
+        mock_transport.is_alive = True
+        mock_transport.capabilities = TransportCapabilities()
+        b._transport = mock_transport
+
+        mock_ws = AsyncMock()
+        mock_ws.receive_json = AsyncMock(side_effect=WebSocketDisconnect())
+
+        await b.handle_websocket(mock_ws)
+
+        calls = [c[0][0] for c in mock_ws.send_json.call_args_list]
+        room_state_calls = [c for c in calls if c.get("type") == "room_state"]
+        assert len(room_state_calls) == 0
+
+    # -----------------------------------------------------------------------
+    # handle_ravn_websocket
+    # -----------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_handle_ravn_websocket_rejects_when_room_disabled(self, no_room_settings):
+        b = Broker(settings=no_room_settings)
+        mock_ws = AsyncMock()
+
+        await b.handle_ravn_websocket(mock_ws, "agent-1")
+
+        mock_ws.close.assert_awaited_once()
+        assert mock_ws.close.call_args[1]["code"] == 1008
+
+    @pytest.mark.asyncio
+    async def test_handle_ravn_websocket_registers_on_connect(self, room_settings):
+        b = Broker(settings=room_settings)
+        mock_bridge = AsyncMock()
+        mock_bridge.register = AsyncMock(
+            return_value=MagicMock(peer_id="agent-1", persona="agent-1")
+        )
+        b._room_bridge = mock_bridge
+
+        mock_ws = AsyncMock()
+        mock_ws.receive_text = AsyncMock(side_effect=WebSocketDisconnect())
+
+        await b.handle_ravn_websocket(mock_ws, "agent-1")
+
+        mock_ws.accept.assert_awaited_once()
+        mock_bridge.register.assert_awaited()
+        mock_bridge.unregister.assert_awaited_once_with("agent-1")
+
+    @pytest.mark.asyncio
+    async def test_handle_ravn_websocket_forwards_frames(self, room_settings):
+        import json as _json
+
+        b = Broker(settings=room_settings)
+        mock_bridge = AsyncMock()
+        mock_bridge.register = AsyncMock(
+            return_value=MagicMock(peer_id="agent-1", persona="agent-1")
+        )
+        b._room_bridge = mock_bridge
+
+        frame = _json.dumps({"type": "response", "data": "Hello", "metadata": {}}) + "\n"
+        mock_ws = AsyncMock()
+        mock_ws.receive_text = AsyncMock(side_effect=[frame, WebSocketDisconnect()])
+
+        await b.handle_ravn_websocket(mock_ws, "agent-1")
+
+        mock_bridge.handle_ravn_frame.assert_awaited_once()
+        call_args = mock_bridge.handle_ravn_frame.call_args[0]
+        assert call_args[0] == "agent-1"
+        assert call_args[1]["type"] == "response"
+
+    @pytest.mark.asyncio
+    async def test_handle_ravn_websocket_skips_invalid_json(self, room_settings):
+        b = Broker(settings=room_settings)
+        mock_bridge = AsyncMock()
+        mock_bridge.register = AsyncMock(
+            return_value=MagicMock(peer_id="agent-1", persona="agent-1")
+        )
+        b._room_bridge = mock_bridge
+
+        mock_ws = AsyncMock()
+        mock_ws.receive_text = AsyncMock(
+            side_effect=["not valid json\n", WebSocketDisconnect()]
+        )
+
+        await b.handle_ravn_websocket(mock_ws, "agent-1")
+
+        mock_bridge.handle_ravn_frame.assert_not_awaited()
+        mock_bridge.unregister.assert_awaited_once_with("agent-1")
+
+    @pytest.mark.asyncio
+    async def test_handle_ravn_websocket_unregisters_on_exception(self, room_settings):
+        b = Broker(settings=room_settings)
+        mock_bridge = AsyncMock()
+        mock_bridge.register = AsyncMock(
+            return_value=MagicMock(peer_id="agent-1", persona="agent-1")
+        )
+        b._room_bridge = mock_bridge
+
+        mock_ws = AsyncMock()
+        mock_ws.receive_text = AsyncMock(side_effect=RuntimeError("unexpected"))
+
+        await b.handle_ravn_websocket(mock_ws, "agent-1")
+
+        mock_bridge.unregister.assert_awaited_once_with("agent-1")

--- a/tests/test_skuld/test_room_bridge.py
+++ b/tests/test_skuld/test_room_bridge.py
@@ -1,0 +1,397 @@
+"""Unit tests for skuld.room_bridge.RoomBridge."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from skuld.config import RoomConfig
+from skuld.room_bridge import RoomBridge
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_registry() -> MagicMock:
+    """Return a mock ChannelRegistry with async broadcast."""
+    reg = MagicMock()
+    reg.broadcast = AsyncMock()
+    return reg
+
+
+def _make_bridge(
+    colors: list[str] | None = None,
+    append_turn=None,
+) -> tuple[RoomBridge, MagicMock]:
+    registry = _make_registry()
+    config = RoomConfig(
+        enabled=True,
+        participant_colors=colors or ["amber", "cyan", "emerald"],
+    )
+    bridge = RoomBridge(config=config, channels=registry, append_turn=append_turn)
+    return bridge, registry
+
+
+def _fake_ws() -> MagicMock:
+    ws = MagicMock()
+    ws.send_text = AsyncMock()
+    return ws
+
+
+# ---------------------------------------------------------------------------
+# Registration & color assignment
+# ---------------------------------------------------------------------------
+
+
+class TestParticipantRegistration:
+    @pytest.mark.asyncio
+    async def test_register_creates_participant(self):
+        bridge, registry = _make_bridge()
+        ws = _fake_ws()
+
+        meta = await bridge.register("peer-1", "Alice", ws)
+
+        assert meta.peer_id == "peer-1"
+        assert meta.persona == "Alice"
+        assert meta.participant_type == "ravn"
+        assert meta.color in {"amber", "cyan", "emerald"}
+        assert "peer-1" in bridge.participants
+
+    @pytest.mark.asyncio
+    async def test_register_broadcasts_participant_joined(self):
+        bridge, registry = _make_bridge()
+        ws = _fake_ws()
+
+        await bridge.register("peer-1", "Alice", ws)
+
+        registry.broadcast.assert_awaited_once()
+        event = registry.broadcast.call_args[0][0]
+        assert event["type"] == "participant_joined"
+        assert event["participant"]["peer_id"] == "peer-1"
+
+    @pytest.mark.asyncio
+    async def test_register_assigns_colors_from_pool(self):
+        bridge, registry = _make_bridge(colors=["amber", "cyan", "emerald"])
+
+        meta1 = await bridge.register("p1", "A", _fake_ws())
+        meta2 = await bridge.register("p2", "B", _fake_ws())
+        meta3 = await bridge.register("p3", "C", _fake_ws())
+
+        colors = {meta1.color, meta2.color, meta3.color}
+        assert colors == {"amber", "cyan", "emerald"}
+
+    @pytest.mark.asyncio
+    async def test_register_cycles_colors_beyond_pool(self):
+        bridge, registry = _make_bridge(colors=["amber", "cyan"])
+
+        await bridge.register("p1", "A", _fake_ws())
+        await bridge.register("p2", "B", _fake_ws())
+        meta = await bridge.register("p3", "C", _fake_ws())
+
+        assert meta.color == "amber"  # cycles back
+
+    @pytest.mark.asyncio
+    async def test_register_reconnect_reuses_existing_meta(self):
+        bridge, registry = _make_bridge()
+        ws1 = _fake_ws()
+        ws2 = _fake_ws()
+
+        meta1 = await bridge.register("peer-1", "Alice", ws1)
+        registry.broadcast.reset_mock()
+
+        meta2 = await bridge.register("peer-1", "Alice", ws2)
+
+        assert meta1 == meta2
+        assert bridge.participant_count == 1
+        # Still broadcasts participant_joined on reconnect
+        registry.broadcast.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_unregister_removes_participant(self):
+        bridge, registry = _make_bridge()
+        await bridge.register("peer-1", "Alice", _fake_ws())
+        registry.broadcast.reset_mock()
+
+        await bridge.unregister("peer-1")
+
+        assert "peer-1" not in bridge.participants
+
+    @pytest.mark.asyncio
+    async def test_unregister_broadcasts_participant_left(self):
+        bridge, registry = _make_bridge()
+        await bridge.register("peer-1", "Alice", _fake_ws())
+        registry.broadcast.reset_mock()
+
+        await bridge.unregister("peer-1")
+
+        registry.broadcast.assert_awaited_once()
+        event = registry.broadcast.call_args[0][0]
+        assert event["type"] == "participant_left"
+        assert event["participantId"] == "peer-1"
+
+    @pytest.mark.asyncio
+    async def test_unregister_unknown_peer_is_noop(self):
+        bridge, registry = _make_bridge()
+        # Should not raise
+        await bridge.unregister("nonexistent")
+        registry.broadcast.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Room state
+# ---------------------------------------------------------------------------
+
+
+class TestRoomState:
+    @pytest.mark.asyncio
+    async def test_get_room_state_event_empty(self):
+        bridge, _ = _make_bridge()
+        event = bridge.get_room_state_event()
+        assert event["type"] == "room_state"
+        assert event["participants"] == []
+
+    @pytest.mark.asyncio
+    async def test_get_room_state_event_with_participants(self):
+        bridge, _ = _make_bridge()
+        await bridge.register("p1", "Alice", _fake_ws())
+        await bridge.register("p2", "Bob", _fake_ws())
+
+        event = bridge.get_room_state_event()
+        assert len(event["participants"]) == 2
+        peer_ids = {p["peer_id"] for p in event["participants"]}
+        assert peer_ids == {"p1", "p2"}
+
+    def test_participant_count_empty(self):
+        bridge, _ = _make_bridge()
+        assert bridge.participant_count == 0
+
+    @pytest.mark.asyncio
+    async def test_participant_count_after_register(self):
+        bridge, _ = _make_bridge()
+        await bridge.register("p1", "A", _fake_ws())
+        await bridge.register("p2", "B", _fake_ws())
+        assert bridge.participant_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Event translation — response / error → room_message
+# ---------------------------------------------------------------------------
+
+
+class TestResponseFrameTranslation:
+    @pytest.mark.asyncio
+    async def test_response_frame_broadcasts_room_message(self):
+        bridge, registry = _make_bridge()
+        await bridge.register("p1", "Alice", _fake_ws())
+        registry.broadcast.reset_mock()
+
+        await bridge.handle_ravn_frame("p1", {"type": "response", "data": "Hello!", "metadata": {}})
+
+        calls = [c[0][0] for c in registry.broadcast.call_args_list]
+        room_msgs = [e for e in calls if e["type"] == "room_message"]
+        assert len(room_msgs) == 1
+        msg = room_msgs[0]
+        assert msg["content"] == "Hello!"
+        assert msg["participantId"] == "p1"
+        assert msg["participant"]["persona"] == "Alice"
+        assert msg["visibility"] == "public"
+
+    @pytest.mark.asyncio
+    async def test_error_frame_broadcasts_room_message_with_error_flag(self):
+        bridge, registry = _make_bridge()
+        await bridge.register("p1", "Alice", _fake_ws())
+        registry.broadcast.reset_mock()
+
+        await bridge.handle_ravn_frame("p1", {"type": "error", "data": "boom", "metadata": {}})
+
+        calls = [c[0][0] for c in registry.broadcast.call_args_list]
+        room_msgs = [e for e in calls if e["type"] == "room_message"]
+        assert len(room_msgs) == 1
+        assert room_msgs[0]["error"] is True
+
+    @pytest.mark.asyncio
+    async def test_response_includes_thread_id_when_present(self):
+        bridge, registry = _make_bridge()
+        await bridge.register("p1", "Alice", _fake_ws())
+        registry.broadcast.reset_mock()
+
+        await bridge.handle_ravn_frame(
+            "p1",
+            {"type": "response", "data": "Hi", "metadata": {"thread_id": "t-123"}},
+        )
+
+        calls = [c[0][0] for c in registry.broadcast.call_args_list]
+        msg = next(e for e in calls if e["type"] == "room_message")
+        assert msg["threadId"] == "t-123"
+
+    @pytest.mark.asyncio
+    async def test_response_omits_thread_id_when_absent(self):
+        bridge, registry = _make_bridge()
+        await bridge.register("p1", "Alice", _fake_ws())
+        registry.broadcast.reset_mock()
+
+        await bridge.handle_ravn_frame("p1", {"type": "response", "data": "Hi", "metadata": {}})
+
+        calls = [c[0][0] for c in registry.broadcast.call_args_list]
+        msg = next(e for e in calls if e["type"] == "room_message")
+        assert "threadId" not in msg
+
+
+# ---------------------------------------------------------------------------
+# Event translation — activity types
+# ---------------------------------------------------------------------------
+
+
+class TestActivityFrameTranslation:
+    @pytest.mark.asyncio
+    async def test_thought_frame_broadcasts_room_activity_thinking(self):
+        bridge, registry = _make_bridge()
+        await bridge.register("p1", "Alice", _fake_ws())
+        registry.broadcast.reset_mock()
+
+        await bridge.handle_ravn_frame(
+            "p1", {"type": "thought", "data": "pondering", "metadata": {}}
+        )
+
+        calls = [c[0][0] for c in registry.broadcast.call_args_list]
+        activities = [e for e in calls if e["type"] == "room_activity"]
+        assert len(activities) == 1
+        assert activities[0]["activityType"] == "thinking"
+        assert activities[0]["participantId"] == "p1"
+
+    @pytest.mark.asyncio
+    async def test_tool_start_frame_broadcasts_tool_executing(self):
+        bridge, registry = _make_bridge()
+        await bridge.register("p1", "Alice", _fake_ws())
+        registry.broadcast.reset_mock()
+
+        await bridge.handle_ravn_frame(
+            "p1", {"type": "tool_start", "data": "BashTool", "metadata": {}}
+        )
+
+        calls = [c[0][0] for c in registry.broadcast.call_args_list]
+        activities = [e for e in calls if e["type"] == "room_activity"]
+        assert activities[0]["activityType"] == "tool_executing"
+
+    @pytest.mark.asyncio
+    async def test_tool_result_frame_broadcasts_idle(self):
+        bridge, registry = _make_bridge()
+        await bridge.register("p1", "Alice", _fake_ws())
+        registry.broadcast.reset_mock()
+
+        await bridge.handle_ravn_frame("p1", {"type": "tool_result", "data": "ok", "metadata": {}})
+
+        calls = [c[0][0] for c in registry.broadcast.call_args_list]
+        activities = [e for e in calls if e["type"] == "room_activity"]
+        assert activities[0]["activityType"] == "idle"
+
+    @pytest.mark.asyncio
+    async def test_unknown_frame_type_is_silently_ignored(self):
+        bridge, registry = _make_bridge()
+        await bridge.register("p1", "Alice", _fake_ws())
+        registry.broadcast.reset_mock()
+
+        await bridge.handle_ravn_frame(
+            "p1", {"type": "unknown_future_type", "data": "x", "metadata": {}}
+        )
+
+        # No room_message or room_activity should be broadcast
+        for call in registry.broadcast.call_args_list:
+            ev = call[0][0]
+            assert ev["type"] not in ("room_message", "room_activity")
+
+    @pytest.mark.asyncio
+    async def test_frame_from_unknown_peer_is_dropped(self):
+        bridge, registry = _make_bridge()
+        registry.broadcast.reset_mock()
+
+        await bridge.handle_ravn_frame("ghost", {"type": "response", "data": "hi", "metadata": {}})
+
+        registry.broadcast.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# History persistence via append_turn callback
+# ---------------------------------------------------------------------------
+
+
+class TestHistoryPersistence:
+    @pytest.mark.asyncio
+    async def test_response_frame_calls_append_turn(self):
+        turns = []
+        bridge, _ = _make_bridge(append_turn=turns.append)
+        await bridge.register("p1", "Alice", _fake_ws())
+
+        await bridge.handle_ravn_frame("p1", {"type": "response", "data": "Hello", "metadata": {}})
+
+        assert len(turns) == 1
+        turn = turns[0]
+        assert turn.role == "assistant"
+        assert turn.content == "Hello"
+        assert turn.participant_id == "p1"
+        assert turn.participant_meta["persona"] == "Alice"
+        assert turn.visibility == "public"
+
+    @pytest.mark.asyncio
+    async def test_activity_frame_does_not_persist_turn(self):
+        turns = []
+        bridge, _ = _make_bridge(append_turn=turns.append)
+        await bridge.register("p1", "Alice", _fake_ws())
+
+        await bridge.handle_ravn_frame(
+            "p1", {"type": "thought", "data": "thinking", "metadata": {}}
+        )
+
+        assert len(turns) == 0
+
+    @pytest.mark.asyncio
+    async def test_no_append_turn_callback_does_not_crash(self):
+        bridge, _ = _make_bridge(append_turn=None)
+        await bridge.register("p1", "Alice", _fake_ws())
+
+        # Should not raise even without a persistence callback
+        await bridge.handle_ravn_frame("p1", {"type": "response", "data": "Hello", "metadata": {}})
+
+
+# ---------------------------------------------------------------------------
+# Directed routing
+# ---------------------------------------------------------------------------
+
+
+class TestDirectedRouting:
+    @pytest.mark.asyncio
+    async def test_route_directed_message_sends_to_target_ws(self):
+        bridge, _ = _make_bridge()
+        ws = _fake_ws()
+        await bridge.register("p1", "Alice", ws)
+
+        result = await bridge.route_directed_message("p1", "Hey Alice!")
+
+        assert result is True
+        ws.send_text.assert_awaited_once()
+        sent = ws.send_text.call_args[0][0]
+        payload = json.loads(sent)
+        assert payload["type"] == "directed_message"
+        assert payload["content"] == "Hey Alice!"
+
+    @pytest.mark.asyncio
+    async def test_route_directed_message_returns_false_for_unknown_target(self):
+        bridge, _ = _make_bridge()
+
+        result = await bridge.route_directed_message("ghost", "Hey!")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_route_directed_message_returns_false_on_send_error(self):
+        bridge, _ = _make_bridge()
+        ws = _fake_ws()
+        ws.send_text.side_effect = RuntimeError("connection closed")
+        await bridge.register("p1", "Alice", ws)
+
+        result = await bridge.route_directed_message("p1", "Hey!")
+
+        assert result is False

--- a/tests/test_skuld/test_room_bridge.py
+++ b/tests/test_skuld/test_room_bridge.py
@@ -94,6 +94,21 @@ class TestParticipantRegistration:
         assert meta.color == "amber"  # cycles back
 
     @pytest.mark.asyncio
+    async def test_register_reconnect_updates_persona(self):
+        bridge, registry = _make_bridge()
+        ws1 = _fake_ws()
+        ws2 = _fake_ws()
+
+        meta1 = await bridge.register("peer-1", "Alice", ws1)
+        assert meta1.persona == "Alice"
+
+        meta2 = await bridge.register("peer-1", "AliceV2", ws2)
+
+        assert meta2.persona == "AliceV2"
+        assert meta2.color == meta1.color  # color is preserved
+        assert bridge.participants["peer-1"].persona == "AliceV2"
+
+    @pytest.mark.asyncio
     async def test_register_reconnect_reuses_existing_meta(self):
         bridge, registry = _make_bridge()
         ws1 = _fake_ws()


### PR DESCRIPTION
## Summary

Phase 2 of the Althing multi-participant room chat feature. Implements the RoomBridge that accepts WebSocket connections from Ravn daemons and bridges their events into the conversation room.

- **New `src/skuld/room_bridge.py`**: `RoomBridge` class with participant registry, accent color assignment (cycling from `RoomConfig.participant_colors`), event translation (response → `room_message`, thought/tool → `room_activity`), history persistence via `ConversationTurn` with participant metadata, and directed message routing to specific Ravn WebSockets
- **`src/skuld/broker.py`**: New `/ws/ravn/{peer_id}` WebSocket endpoint; `room_state` sent to late-joining browsers on `/session` connect; `directed_message` dispatch case routes to `RoomBridge.route_directed_message()`; `RoomBridge` lifecycle in `Broker.__init__` (only created when `room.enabled = true`)
- **`src/ravn/adapters/channels/skuld_channel.py`**: Added optional `peer_id` / `persona` constructor params; serialised as `source` / `persona` fields in NDJSON frames — backward-compatible, existing Skuld ignores unknown fields

## New wire events (Skuld → Browser)

| Event | Payload |
|---|---|
| `participant_joined` | `{participant: ParticipantMeta}` |
| `participant_left` | `{participantId: string}` |
| `room_state` | `{participants: ParticipantMeta[]}` |
| `room_message` | `{id, participantId, participant, content, threadId?, visibility, error?}` |
| `room_activity` | `{participantId, activityType: "thinking"\|"tool_executing"\|"idle", detail?}` |

## Browser → Skuld

`directed_message {targetPeerId: string, content: string}` — routes to RoomBridge

## Test plan

- [x] 27 new unit tests for `RoomBridge` (participant registration, color cycling, event translation, directed routing, history persistence)
- [x] 5 new tests for `SkuldChannel` source/persona frame fields
- [x] Full skuld test suite: 730 passed, 38 skipped (pre-existing), 0 new warnings
- [x] Coverage on new code: `room_bridge.py` 99%, `skuld_channel.py` 81% (uncovered lines are pre-existing reconnect logic)
- [x] `ruff check` + `ruff format` clean

Closes NIU-602.

🤖 Generated with [Claude Code](https://claude.com/claude-code)