### PR TITLE
feat(personas): REST CRUD router over PersonaLoader (NIU-606)

### DIFF
--- a/src/volundr/adapters/inbound/rest_personas.py
+++ b/src/volundr/adapters/inbound/rest_personas.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import replace as _dc_replace
 
 from fastapi import APIRouter, HTTPException, Path, Query, Response, status
 from pydantic import BaseModel, Field
 
 from ravn.adapters.personas.loader import PersonaConfig, PersonaLoader
+from ravn.ports.persona import PersonaRegistryPort
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +65,7 @@ class PersonaSummary(BaseModel):
     consumes_events: list[str] = Field(description="Event types this persona consumes")
 
     @classmethod
-    def from_persona(cls, config: PersonaConfig, loader: PersonaLoader) -> PersonaSummary:
+    def from_persona(cls, config: PersonaConfig, loader: PersonaRegistryPort) -> PersonaSummary:
         """Build summary from a PersonaConfig."""
         name = config.name
         is_builtin = loader.is_builtin(name)
@@ -85,7 +87,7 @@ class PersonaDetail(PersonaSummary):
     """Full detail view of a persona."""
 
     system_prompt_template: str = Field(
-        description="Raw system prompt template (without outcome injection)",
+        description="System prompt template (may include outcome injection)",
     )
     forbidden_tools: list[str] = Field(description="Explicitly forbidden tool groups")
     llm: PersonaLLMResponse = Field(description="LLM configuration")
@@ -95,7 +97,9 @@ class PersonaDetail(PersonaSummary):
     yaml_source: str = Field(description="File path providing this persona, or '[built-in]'")
 
     @classmethod
-    def from_persona(cls, config: PersonaConfig, loader: PersonaLoader) -> PersonaDetail:  # type: ignore[override]
+    def from_persona(  # type: ignore[override]
+        cls, config: PersonaConfig, loader: PersonaRegistryPort
+    ) -> PersonaDetail:
         """Build detail from a PersonaConfig."""
         name = config.name
         is_builtin = loader.is_builtin(name)
@@ -148,6 +152,8 @@ class PersonaDetail(PersonaSummary):
 # Request models
 # ---------------------------------------------------------------------------
 
+_NAME_PATTERN = r"^[a-zA-Z0-9][a-zA-Z0-9_-]*$"
+
 
 class PersonaCreate(BaseModel):
     """Request body for creating a new persona."""
@@ -155,7 +161,8 @@ class PersonaCreate(BaseModel):
     name: str = Field(
         min_length=1,
         max_length=128,
-        description="Unique persona name (alphanumeric + hyphens)",
+        pattern=_NAME_PATTERN,
+        description="Unique persona name (alphanumeric, hyphens, underscores)",
     )
     system_prompt_template: str = Field(default="", description="System prompt template text")
     allowed_tools: list[str] = Field(default_factory=list, description="Allowed tool groups")
@@ -210,7 +217,12 @@ class PersonaCreate(BaseModel):
 class PersonaForkRequest(BaseModel):
     """Request body for forking a persona to a new name."""
 
-    new_name: str = Field(min_length=1, max_length=128, description="Name for the forked persona")
+    new_name: str = Field(
+        min_length=1,
+        max_length=128,
+        pattern=_NAME_PATTERN,
+        description="Name for the forked persona (alphanumeric, hyphens, underscores)",
+    )
 
 
 class ErrorResponse(BaseModel):
@@ -224,7 +236,7 @@ class ErrorResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-def create_personas_router(loader: PersonaLoader) -> APIRouter:
+def create_personas_router(loader: PersonaRegistryPort) -> APIRouter:
     """Create FastAPI router for Ravn persona endpoints."""
     router = APIRouter(prefix="/api/v1/ravn")
 
@@ -310,7 +322,6 @@ def create_personas_router(loader: PersonaLoader) -> APIRouter:
     def create_persona(data: PersonaCreate) -> PersonaDetail:
         """Create a new custom persona. Returns 409 if name already exists as a custom file."""
         existing_source = loader.source(data.name)
-        # Reject if there's already a user file (non-builtin or builtin override)
         if existing_source and existing_source != "[built-in]":
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
@@ -344,11 +355,7 @@ def create_personas_router(loader: PersonaLoader) -> APIRouter:
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"Persona not found: {name}",
             )
-        config = data.to_persona_config()
-        # Ensure the saved name matches the path parameter
-        from dataclasses import replace as _replace
-
-        config = _replace(config, name=name)
+        config = _dc_replace(data.to_persona_config(), name=name)
         loader.save(config)
         saved = loader.load(name)
         if saved is None:
@@ -412,9 +419,7 @@ def create_personas_router(loader: PersonaLoader) -> APIRouter:
                 status_code=status.HTTP_409_CONFLICT,
                 detail=f"Persona already exists as built-in: {body.new_name}",
             )
-        from dataclasses import replace as _replace
-
-        forked = _replace(source_config, name=body.new_name)
+        forked = _dc_replace(source_config, name=body.new_name)
         loader.save(forked)
         saved = loader.load(body.new_name)
         if saved is None:

--- a/src/volundr/adapters/inbound/rest_personas.py
+++ b/src/volundr/adapters/inbound/rest_personas.py
@@ -1,0 +1,424 @@
+"""FastAPI REST adapter for Ravn persona CRUD."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, HTTPException, Path, Query, Response, status
+from pydantic import BaseModel, Field
+
+from ravn.adapters.personas.loader import PersonaConfig, PersonaLoader
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+
+
+class PersonaLLMResponse(BaseModel):
+    """LLM configuration embedded in a persona response."""
+
+    primary_alias: str = Field(description="LLM alias (e.g. 'balanced', 'powerful')")
+    thinking_enabled: bool = Field(description="Whether extended thinking is enabled")
+    max_tokens: int = Field(description="Max tokens override (0 = use settings default)")
+
+
+class PersonaProducesResponse(BaseModel):
+    """Output event schema for a persona."""
+
+    event_type: str = Field(description="Event type produced on completion")
+    schema_def: dict = Field(alias="schema", description="Output schema field definitions")
+
+    model_config = {"populate_by_name": True}
+
+
+class PersonaConsumesResponse(BaseModel):
+    """Input event configuration for a persona."""
+
+    event_types: list[str] = Field(description="Event types this persona consumes")
+    injects: list[str] = Field(description="Context fields injected from consumed events")
+
+
+class PersonaFanInResponse(BaseModel):
+    """Fan-in strategy configuration for a persona."""
+
+    strategy: str = Field(description="Fan-in strategy (all_must_pass, any_pass, majority, merge)")
+    contributes_to: str = Field(description="Parent event type this persona contributes to")
+
+
+class PersonaSummary(BaseModel):
+    """Summary view of a persona for list responses."""
+
+    name: str = Field(description="Unique persona name")
+    permission_mode: str = Field(
+        description="Permission mode (e.g. 'read-only', 'workspace-write')",
+    )
+    allowed_tools: list[str] = Field(description="Explicitly allowed tool groups")
+    iteration_budget: int = Field(description="Maximum agent iterations (0 = unlimited)")
+    is_builtin: bool = Field(description="Whether this is a built-in persona")
+    has_override: bool = Field(description="Whether a user file overrides the built-in")
+    produces_event: str = Field(description="Event type produced on completion (empty if none)")
+    consumes_events: list[str] = Field(description="Event types this persona consumes")
+
+    @classmethod
+    def from_persona(cls, config: PersonaConfig, loader: PersonaLoader) -> PersonaSummary:
+        """Build summary from a PersonaConfig."""
+        name = config.name
+        is_builtin = loader.is_builtin(name)
+        source = loader.source(name)
+        has_override = is_builtin and source != "[built-in]"
+        return cls(
+            name=name,
+            permission_mode=config.permission_mode,
+            allowed_tools=config.allowed_tools,
+            iteration_budget=config.iteration_budget,
+            is_builtin=is_builtin,
+            has_override=has_override,
+            produces_event=config.produces.event_type,
+            consumes_events=config.consumes.event_types,
+        )
+
+
+class PersonaDetail(PersonaSummary):
+    """Full detail view of a persona."""
+
+    system_prompt_template: str = Field(
+        description="Raw system prompt template (without outcome injection)",
+    )
+    forbidden_tools: list[str] = Field(description="Explicitly forbidden tool groups")
+    llm: PersonaLLMResponse = Field(description="LLM configuration")
+    produces: PersonaProducesResponse = Field(description="Output event schema")
+    consumes: PersonaConsumesResponse = Field(description="Input event configuration")
+    fan_in: PersonaFanInResponse = Field(description="Fan-in strategy configuration")
+    yaml_source: str = Field(description="File path providing this persona, or '[built-in]'")
+
+    @classmethod
+    def from_persona(cls, config: PersonaConfig, loader: PersonaLoader) -> PersonaDetail:  # type: ignore[override]
+        """Build detail from a PersonaConfig."""
+        name = config.name
+        is_builtin = loader.is_builtin(name)
+        source = loader.source(name)
+        has_override = is_builtin and source != "[built-in]"
+
+        # Serialize produces schema — OutcomeField dataclasses → plain dicts
+        produces_schema: dict = {}
+        for fname, f in config.produces.schema.items():
+            fd: dict = {"type": f.type, "description": f.description}
+            if f.enum_values:
+                fd["values"] = list(f.enum_values)
+            if not f.required:
+                fd["required"] = False
+            produces_schema[fname] = fd
+
+        return cls(
+            name=name,
+            permission_mode=config.permission_mode,
+            allowed_tools=config.allowed_tools,
+            iteration_budget=config.iteration_budget,
+            is_builtin=is_builtin,
+            has_override=has_override,
+            produces_event=config.produces.event_type,
+            consumes_events=config.consumes.event_types,
+            system_prompt_template=config.system_prompt_template,
+            forbidden_tools=config.forbidden_tools,
+            llm=PersonaLLMResponse(
+                primary_alias=config.llm.primary_alias,
+                thinking_enabled=config.llm.thinking_enabled,
+                max_tokens=config.llm.max_tokens,
+            ),
+            produces=PersonaProducesResponse(
+                event_type=config.produces.event_type,
+                schema=produces_schema,
+            ),  # type: ignore[call-arg]
+            consumes=PersonaConsumesResponse(
+                event_types=config.consumes.event_types,
+                injects=config.consumes.injects,
+            ),
+            fan_in=PersonaFanInResponse(
+                strategy=config.fan_in.strategy,
+                contributes_to=config.fan_in.contributes_to,
+            ),
+            yaml_source=source or "[unknown]",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Request models
+# ---------------------------------------------------------------------------
+
+
+class PersonaCreate(BaseModel):
+    """Request body for creating a new persona."""
+
+    name: str = Field(
+        min_length=1,
+        max_length=128,
+        description="Unique persona name (alphanumeric + hyphens)",
+    )
+    system_prompt_template: str = Field(default="", description="System prompt template text")
+    allowed_tools: list[str] = Field(default_factory=list, description="Allowed tool groups")
+    forbidden_tools: list[str] = Field(default_factory=list, description="Forbidden tool groups")
+    permission_mode: str = Field(default="", description="Permission mode")
+    iteration_budget: int = Field(default=0, ge=0, description="Max iterations (0 = unlimited)")
+    llm_primary_alias: str = Field(default="", description="LLM alias")
+    llm_thinking_enabled: bool = Field(default=False, description="Enable extended thinking")
+    llm_max_tokens: int = Field(default=0, ge=0, description="Max tokens override")
+    produces_event_type: str = Field(default="", description="Event type produced on completion")
+    consumes_event_types: list[str] = Field(
+        default_factory=list,
+        description="Consumed event types",
+    )
+    consumes_injects: list[str] = Field(default_factory=list, description="Injected context fields")
+    fan_in_strategy: str = Field(default="merge", description="Fan-in strategy")
+    fan_in_contributes_to: str = Field(default="", description="Parent event type")
+
+    def to_persona_config(self) -> PersonaConfig:
+        """Build a PersonaConfig from this request."""
+        from ravn.adapters.personas.loader import (
+            PersonaConsumes,
+            PersonaFanIn,
+            PersonaLLMConfig,
+            PersonaProduces,
+        )
+
+        return PersonaConfig(
+            name=self.name,
+            system_prompt_template=self.system_prompt_template,
+            allowed_tools=self.allowed_tools,
+            forbidden_tools=self.forbidden_tools,
+            permission_mode=self.permission_mode,
+            iteration_budget=self.iteration_budget,
+            llm=PersonaLLMConfig(
+                primary_alias=self.llm_primary_alias,
+                thinking_enabled=self.llm_thinking_enabled,
+                max_tokens=self.llm_max_tokens,
+            ),
+            produces=PersonaProduces(event_type=self.produces_event_type),
+            consumes=PersonaConsumes(
+                event_types=self.consumes_event_types,
+                injects=self.consumes_injects,
+            ),
+            fan_in=PersonaFanIn(
+                strategy=self.fan_in_strategy,  # type: ignore[arg-type]
+                contributes_to=self.fan_in_contributes_to,
+            ),
+        )
+
+
+class PersonaForkRequest(BaseModel):
+    """Request body for forking a persona to a new name."""
+
+    new_name: str = Field(min_length=1, max_length=128, description="Name for the forked persona")
+
+
+class ErrorResponse(BaseModel):
+    """Response model for errors."""
+
+    detail: str = Field(description="Human-readable error message")
+
+
+# ---------------------------------------------------------------------------
+# Router factory
+# ---------------------------------------------------------------------------
+
+
+def create_personas_router(loader: PersonaLoader) -> APIRouter:
+    """Create FastAPI router for Ravn persona endpoints."""
+    router = APIRouter(prefix="/api/v1/ravn")
+
+    @router.get(
+        "/personas",
+        response_model=list[PersonaSummary],
+        tags=["Personas"],
+    )
+    def list_personas(
+        source: str | None = Query(
+            default=None,
+            description="Filter by source: 'builtin', 'custom', or 'all' (default: all)",
+        ),
+    ) -> list[PersonaSummary]:
+        """List all available personas with summary info."""
+        names = loader.list_names()
+        result: list[PersonaSummary] = []
+
+        for name in names:
+            is_builtin = loader.is_builtin(name)
+            persona_source = loader.source(name)
+            has_file = persona_source != "[built-in]" and bool(persona_source)
+
+            if source == "builtin" and not is_builtin:
+                continue
+            if source == "custom" and (is_builtin and not has_file):
+                continue
+
+            config = loader.load(name)
+            if config is None:
+                continue
+            result.append(PersonaSummary.from_persona(config, loader))
+
+        return result
+
+    @router.get(
+        "/personas/{name}",
+        response_model=PersonaDetail,
+        responses={404: {"model": ErrorResponse}},
+        tags=["Personas"],
+    )
+    def get_persona(
+        name: str = Path(description="Persona name"),
+    ) -> PersonaDetail:
+        """Get full detail for a named persona."""
+        config = loader.load(name)
+        if config is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Persona not found: {name}",
+            )
+        return PersonaDetail.from_persona(config, loader)
+
+    @router.get(
+        "/personas/{name}/yaml",
+        response_class=Response,
+        responses={
+            200: {"content": {"text/yaml": {}}, "description": "Raw YAML source"},
+            404: {"model": ErrorResponse},
+        },
+        tags=["Personas"],
+    )
+    def get_persona_yaml(
+        name: str = Path(description="Persona name"),
+    ) -> Response:
+        """Return the raw YAML text for a named persona."""
+        config = loader.load(name)
+        if config is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Persona not found: {name}",
+            )
+        yaml_text = PersonaLoader.to_yaml(config)
+        return Response(content=yaml_text, media_type="text/yaml")
+
+    @router.post(
+        "/personas",
+        response_model=PersonaDetail,
+        status_code=status.HTTP_201_CREATED,
+        responses={409: {"model": ErrorResponse}},
+        tags=["Personas"],
+    )
+    def create_persona(data: PersonaCreate) -> PersonaDetail:
+        """Create a new custom persona. Returns 409 if name already exists as a custom file."""
+        existing_source = loader.source(data.name)
+        # Reject if there's already a user file (non-builtin or builtin override)
+        if existing_source and existing_source != "[built-in]":
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"Persona already exists as custom: {data.name}",
+            )
+        if loader.is_builtin(data.name):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"Persona already exists as built-in: {data.name}",
+            )
+        config = data.to_persona_config()
+        loader.save(config)
+        saved = loader.load(data.name)
+        if saved is None:
+            saved = config
+        return PersonaDetail.from_persona(saved, loader)
+
+    @router.put(
+        "/personas/{name}",
+        response_model=PersonaDetail,
+        responses={404: {"model": ErrorResponse}},
+        tags=["Personas"],
+    )
+    def replace_persona(
+        name: str = Path(description="Persona name"),
+        data: PersonaCreate = ...,
+    ) -> PersonaDetail:
+        """Full replace a persona. Creates an override file for built-ins."""
+        if not loader.load(name):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Persona not found: {name}",
+            )
+        config = data.to_persona_config()
+        # Ensure the saved name matches the path parameter
+        from dataclasses import replace as _replace
+
+        config = _replace(config, name=name)
+        loader.save(config)
+        saved = loader.load(name)
+        if saved is None:
+            saved = config
+        return PersonaDetail.from_persona(saved, loader)
+
+    @router.delete(
+        "/personas/{name}",
+        status_code=status.HTTP_204_NO_CONTENT,
+        responses={
+            400: {"model": ErrorResponse},
+            404: {"model": ErrorResponse},
+        },
+        tags=["Personas"],
+    )
+    def delete_persona(
+        name: str = Path(description="Persona name"),
+    ) -> None:
+        """Delete a custom persona file. Returns 400 for built-ins without an override."""
+        if not loader.load(name):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Persona not found: {name}",
+            )
+        deleted = loader.delete(name)
+        if not deleted:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Cannot delete built-in persona without an override file: {name}",
+            )
+
+    @router.post(
+        "/personas/{name}/fork",
+        response_model=PersonaDetail,
+        status_code=status.HTTP_201_CREATED,
+        responses={
+            404: {"model": ErrorResponse},
+            409: {"model": ErrorResponse},
+        },
+        tags=["Personas"],
+    )
+    def fork_persona(
+        name: str = Path(description="Source persona name"),
+        body: PersonaForkRequest = ...,
+    ) -> PersonaDetail:
+        """Fork a persona to a new name. Returns 409 if new_name already exists as custom."""
+        source_config = loader.load(name)
+        if source_config is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Persona not found: {name}",
+            )
+        new_source = loader.source(body.new_name)
+        if new_source and new_source != "[built-in]":
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"Persona already exists as custom: {body.new_name}",
+            )
+        if loader.is_builtin(body.new_name):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"Persona already exists as built-in: {body.new_name}",
+            )
+        from dataclasses import replace as _replace
+
+        forked = _replace(source_config, name=body.new_name)
+        loader.save(forked)
+        saved = loader.load(body.new_name)
+        if saved is None:
+            saved = forked
+        return PersonaDetail.from_persona(saved, loader)
+
+    return router

--- a/src/volundr/config.py
+++ b/src/volundr/config.py
@@ -991,6 +991,19 @@ class WebhooksConfig(BaseModel):
     github: GitHubWebhookConfig = Field(default_factory=GitHubWebhookConfig)
 
 
+class RavnConfig(BaseModel):
+    """Ravn agent runtime configuration."""
+
+    persona_dirs: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Additional directories to search for persona YAML files "
+            "(highest priority first). When empty, PersonaLoader uses its "
+            "default two-layer discovery: <cwd>/.ravn/personas/ → ~/.ravn/personas/."
+        ),
+    )
+
+
 class LinearConfig(BaseModel):
     """Linear issue tracker configuration."""
 
@@ -1072,6 +1085,7 @@ class Settings(BaseSettings):
         default_factory=_default_feature_modules,
         description="Feature module catalog — defines available UI modules.",
     )
+    ravn: RavnConfig = Field(default_factory=RavnConfig)
 
     @classmethod
     def settings_customise_sources(

--- a/src/volundr/main.py
+++ b/src/volundr/main.py
@@ -22,6 +22,7 @@ from volundr.adapters.inbound.rest_git import create_git_router
 from volundr.adapters.inbound.rest_integrations import create_integrations_router
 from volundr.adapters.inbound.rest_issues import create_issues_router
 from volundr.adapters.inbound.rest_oauth import create_oauth_router
+from volundr.adapters.inbound.rest_personas import create_personas_router
 from volundr.adapters.inbound.rest_presets import create_presets_router
 from volundr.adapters.inbound.rest_profiles import create_profiles_router
 from volundr.adapters.inbound.rest_prompts import create_prompts_router
@@ -686,6 +687,15 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             preset_service = PresetService(preset_repository)
             presets_router = create_presets_router(preset_service)
             app.include_router(presets_router)
+
+            # Ravn persona management
+            from ravn.adapters.personas.loader import PersonaLoader
+
+            persona_loader = PersonaLoader(
+                persona_dirs=settings.ravn.persona_dirs or None,
+            )
+            personas_router = create_personas_router(persona_loader)
+            app.include_router(personas_router)
 
             # Personal access tokens
             from volundr.adapters.outbound.postgres_pats import PostgresPATRepository

--- a/tests/test_volundr/test_rest_personas.py
+++ b/tests/test_volundr/test_rest_personas.py
@@ -17,6 +17,12 @@ from volundr.adapters.inbound.rest_personas import create_personas_router
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _redirect_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Redirect Path.home() to tmp_path so saves never touch the real home dir."""
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+
+
 @pytest.fixture()
 def tmp_persona_dir(tmp_path: Path) -> Path:
     """Return a temporary directory for persona YAML files."""
@@ -162,7 +168,7 @@ def test_get_yaml_nonexistent_returns_404(client: TestClient) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_create_persona_writes_file(client: TestClient, tmp_persona_dir: Path) -> None:
+def test_create_persona_writes_file(client: TestClient, tmp_path: Path) -> None:
     payload = {
         "name": "new-agent",
         "system_prompt_template": "You are new.",
@@ -173,10 +179,9 @@ def test_create_persona_writes_file(client: TestClient, tmp_persona_dir: Path) -
     assert resp.status_code == 201
     data = resp.json()
     assert data["name"] == "new-agent"
-    # Verify file on disk
-    saved_file = Path.home() / ".ravn" / "personas" / "new-agent.yaml"
+    # Verify file on disk (Path.home() is redirected to tmp_path by autouse fixture)
+    saved_file = tmp_path / ".ravn" / "personas" / "new-agent.yaml"
     assert saved_file.exists()
-    saved_file.unlink()  # cleanup
 
 
 def test_create_persona_409_if_custom_exists(client: TestClient, tmp_persona_dir: Path) -> None:
@@ -192,12 +197,18 @@ def test_create_persona_409_if_builtin(client: TestClient) -> None:
     assert resp.status_code == 409
 
 
+def test_create_persona_rejects_path_traversal(client: TestClient) -> None:
+    payload = {"name": "../../evil"}
+    resp = client.post("/api/v1/ravn/personas", json=payload)
+    assert resp.status_code == 422
+
+
 # ---------------------------------------------------------------------------
 # PUT /api/v1/ravn/personas/{name} — full replace
 # ---------------------------------------------------------------------------
 
 
-def test_put_builtin_creates_override(client: TestClient) -> None:
+def test_put_builtin_creates_override(client: TestClient, tmp_path: Path) -> None:
     payload = {
         "name": "coding-agent",
         "system_prompt_template": "Overridden.",
@@ -207,10 +218,9 @@ def test_put_builtin_creates_override(client: TestClient) -> None:
     assert resp.status_code == 200
     data = resp.json()
     assert data["name"] == "coding-agent"
-    # Override file should now exist at default save location
-    override_file = Path.home() / ".ravn" / "personas" / "coding-agent.yaml"
+    # Override file should now exist (Path.home() is redirected to tmp_path)
+    override_file = tmp_path / ".ravn" / "personas" / "coding-agent.yaml"
     assert override_file.exists()
-    override_file.unlink()  # cleanup
 
 
 def test_put_nonexistent_returns_404(client: TestClient) -> None:
@@ -247,7 +257,9 @@ def test_delete_nonexistent_returns_404(client: TestClient) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_fork_creates_copy_with_new_name(client: TestClient, tmp_persona_dir: Path) -> None:
+def test_fork_creates_copy_with_new_name(
+    client: TestClient, tmp_persona_dir: Path, tmp_path: Path
+) -> None:
     write_persona(tmp_persona_dir, "source-agent", _CUSTOM_PERSONA | {"name": "source-agent"})
     resp = client.post(
         "/api/v1/ravn/personas/source-agent/fork",
@@ -256,13 +268,11 @@ def test_fork_creates_copy_with_new_name(client: TestClient, tmp_persona_dir: Pa
     assert resp.status_code == 201
     data = resp.json()
     assert data["name"] == "forked-agent"
-    # Verify file on disk (saved to ~/.ravn/personas/)
-    forked_file = Path.home() / ".ravn" / "personas" / "forked-agent.yaml"
+    forked_file = tmp_path / ".ravn" / "personas" / "forked-agent.yaml"
     assert forked_file.exists()
-    forked_file.unlink()  # cleanup
 
 
-def test_fork_builtin_creates_custom(client: TestClient) -> None:
+def test_fork_builtin_creates_custom(client: TestClient, tmp_path: Path) -> None:
     resp = client.post(
         "/api/v1/ravn/personas/coding-agent/fork",
         json={"new_name": "my-coding-agent"},
@@ -270,9 +280,8 @@ def test_fork_builtin_creates_custom(client: TestClient) -> None:
     assert resp.status_code == 201
     data = resp.json()
     assert data["name"] == "my-coding-agent"
-    forked_file = Path.home() / ".ravn" / "personas" / "my-coding-agent.yaml"
+    forked_file = tmp_path / ".ravn" / "personas" / "my-coding-agent.yaml"
     assert forked_file.exists()
-    forked_file.unlink()  # cleanup
 
 
 def test_fork_nonexistent_source_returns_404(client: TestClient) -> None:
@@ -298,3 +307,11 @@ def test_fork_409_if_new_name_is_builtin(client: TestClient) -> None:
         json={"new_name": "research-agent"},
     )
     assert resp.status_code == 409
+
+
+def test_fork_rejects_path_traversal_new_name(client: TestClient) -> None:
+    resp = client.post(
+        "/api/v1/ravn/personas/coding-agent/fork",
+        json={"new_name": "../../evil"},
+    )
+    assert resp.status_code == 422

--- a/tests/test_volundr/test_rest_personas.py
+++ b/tests/test_volundr/test_rest_personas.py
@@ -1,0 +1,300 @@
+"""Tests for the Ravn personas REST API."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from ravn.adapters.personas.loader import PersonaLoader
+from volundr.adapters.inbound.rest_personas import create_personas_router
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def tmp_persona_dir(tmp_path: Path) -> Path:
+    """Return a temporary directory for persona YAML files."""
+    d = tmp_path / "personas"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture()
+def loader(tmp_persona_dir: Path) -> PersonaLoader:
+    """PersonaLoader with a single custom dir + built-ins enabled."""
+    return PersonaLoader(persona_dirs=[str(tmp_persona_dir)], include_builtin=True)
+
+
+@pytest.fixture()
+def client(loader: PersonaLoader) -> TestClient:
+    """TestClient with the personas router mounted."""
+    app = FastAPI()
+    app.include_router(create_personas_router(loader))
+    return TestClient(app, raise_server_exceptions=True)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_CUSTOM_PERSONA = {
+    "name": "test-agent",
+    "system_prompt_template": "You are a test agent.",
+    "allowed_tools": ["file"],
+    "permission_mode": "read-only",
+    "iteration_budget": 5,
+}
+
+
+def write_persona(directory: Path, name: str, data: dict) -> None:
+    """Write a persona YAML file into directory."""
+    (directory / f"{name}.yaml").write_text(yaml.dump(data), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/ravn/personas — list
+# ---------------------------------------------------------------------------
+
+
+def test_list_returns_builtins(client: TestClient) -> None:
+    resp = client.get("/api/v1/ravn/personas")
+    assert resp.status_code == 200
+    names = [p["name"] for p in resp.json()]
+    # All 13 built-ins should be present
+    assert "coding-agent" in names
+    assert "research-agent" in names
+    assert "reviewer" in names
+    assert len(names) >= 13
+
+
+def test_list_source_builtin_filter(client: TestClient) -> None:
+    resp = client.get("/api/v1/ravn/personas?source=builtin")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert all(p["is_builtin"] for p in data)
+
+
+def test_list_source_custom_filter(client: TestClient, tmp_persona_dir: Path) -> None:
+    write_persona(tmp_persona_dir, "test-agent", _CUSTOM_PERSONA)
+    resp = client.get("/api/v1/ravn/personas?source=custom")
+    assert resp.status_code == 200
+    # Custom-only: should include the custom file but not pure built-ins
+    names = [p["name"] for p in resp.json()]
+    assert "test-agent" in names
+
+
+def test_list_all_includes_custom_and_builtin(client: TestClient, tmp_persona_dir: Path) -> None:
+    write_persona(tmp_persona_dir, "test-agent", _CUSTOM_PERSONA)
+    resp = client.get("/api/v1/ravn/personas")
+    assert resp.status_code == 200
+    names = [p["name"] for p in resp.json()]
+    assert "test-agent" in names
+    assert "coding-agent" in names
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/ravn/personas/{name} — detail
+# ---------------------------------------------------------------------------
+
+
+def test_get_builtin_returns_correct_fields(client: TestClient) -> None:
+    resp = client.get("/api/v1/ravn/personas/coding-agent")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["name"] == "coding-agent"
+    assert data["is_builtin"] is True
+    assert data["has_override"] is False
+    assert data["yaml_source"] == "[built-in]"
+    assert "system_prompt_template" in data
+    assert "llm" in data
+    assert "produces" in data
+    assert "consumes" in data
+    assert "fan_in" in data
+    # coding-agent specific checks
+    assert data["permission_mode"] == "workspace-write"
+    assert data["iteration_budget"] == 40
+    assert "file" in data["allowed_tools"]
+
+
+def test_get_custom_persona(client: TestClient, tmp_persona_dir: Path) -> None:
+    write_persona(tmp_persona_dir, "test-agent", _CUSTOM_PERSONA)
+    resp = client.get("/api/v1/ravn/personas/test-agent")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["name"] == "test-agent"
+    assert data["is_builtin"] is False
+    assert data["permission_mode"] == "read-only"
+    assert data["iteration_budget"] == 5
+
+
+def test_get_nonexistent_returns_404(client: TestClient) -> None:
+    resp = client.get("/api/v1/ravn/personas/does-not-exist")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/ravn/personas/{name}/yaml — raw YAML
+# ---------------------------------------------------------------------------
+
+
+def test_get_yaml_returns_parseable_yaml(client: TestClient) -> None:
+    resp = client.get("/api/v1/ravn/personas/coding-agent/yaml")
+    assert resp.status_code == 200
+    assert "text/yaml" in resp.headers["content-type"]
+    parsed = yaml.safe_load(resp.text)
+    assert isinstance(parsed, dict)
+    assert parsed["name"] == "coding-agent"
+
+
+def test_get_yaml_nonexistent_returns_404(client: TestClient) -> None:
+    resp = client.get("/api/v1/ravn/personas/ghost/yaml")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/ravn/personas — create
+# ---------------------------------------------------------------------------
+
+
+def test_create_persona_writes_file(client: TestClient, tmp_persona_dir: Path) -> None:
+    payload = {
+        "name": "new-agent",
+        "system_prompt_template": "You are new.",
+        "permission_mode": "read-only",
+        "iteration_budget": 10,
+    }
+    resp = client.post("/api/v1/ravn/personas", json=payload)
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["name"] == "new-agent"
+    # Verify file on disk
+    saved_file = Path.home() / ".ravn" / "personas" / "new-agent.yaml"
+    assert saved_file.exists()
+    saved_file.unlink()  # cleanup
+
+
+def test_create_persona_409_if_custom_exists(client: TestClient, tmp_persona_dir: Path) -> None:
+    write_persona(tmp_persona_dir, "already-exists", {"name": "already-exists"})
+    payload = {"name": "already-exists"}
+    resp = client.post("/api/v1/ravn/personas", json=payload)
+    assert resp.status_code == 409
+
+
+def test_create_persona_409_if_builtin(client: TestClient) -> None:
+    payload = {"name": "coding-agent"}
+    resp = client.post("/api/v1/ravn/personas", json=payload)
+    assert resp.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/v1/ravn/personas/{name} — full replace
+# ---------------------------------------------------------------------------
+
+
+def test_put_builtin_creates_override(client: TestClient) -> None:
+    payload = {
+        "name": "coding-agent",
+        "system_prompt_template": "Overridden.",
+        "permission_mode": "read-only",
+    }
+    resp = client.put("/api/v1/ravn/personas/coding-agent", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["name"] == "coding-agent"
+    # Override file should now exist at default save location
+    override_file = Path.home() / ".ravn" / "personas" / "coding-agent.yaml"
+    assert override_file.exists()
+    override_file.unlink()  # cleanup
+
+
+def test_put_nonexistent_returns_404(client: TestClient) -> None:
+    payload = {"name": "phantom"}
+    resp = client.put("/api/v1/ravn/personas/phantom", json=payload)
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/v1/ravn/personas/{name}
+# ---------------------------------------------------------------------------
+
+
+def test_delete_custom_removes_file(client: TestClient, tmp_persona_dir: Path) -> None:
+    write_persona(tmp_persona_dir, "to-delete", {"name": "to-delete"})
+    assert (tmp_persona_dir / "to-delete.yaml").exists()
+    resp = client.delete("/api/v1/ravn/personas/to-delete")
+    assert resp.status_code == 204
+    assert not (tmp_persona_dir / "to-delete.yaml").exists()
+
+
+def test_delete_pure_builtin_returns_400(client: TestClient) -> None:
+    resp = client.delete("/api/v1/ravn/personas/coding-agent")
+    assert resp.status_code == 400
+
+
+def test_delete_nonexistent_returns_404(client: TestClient) -> None:
+    resp = client.delete("/api/v1/ravn/personas/nope")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/ravn/personas/{name}/fork
+# ---------------------------------------------------------------------------
+
+
+def test_fork_creates_copy_with_new_name(client: TestClient, tmp_persona_dir: Path) -> None:
+    write_persona(tmp_persona_dir, "source-agent", _CUSTOM_PERSONA | {"name": "source-agent"})
+    resp = client.post(
+        "/api/v1/ravn/personas/source-agent/fork",
+        json={"new_name": "forked-agent"},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["name"] == "forked-agent"
+    # Verify file on disk (saved to ~/.ravn/personas/)
+    forked_file = Path.home() / ".ravn" / "personas" / "forked-agent.yaml"
+    assert forked_file.exists()
+    forked_file.unlink()  # cleanup
+
+
+def test_fork_builtin_creates_custom(client: TestClient) -> None:
+    resp = client.post(
+        "/api/v1/ravn/personas/coding-agent/fork",
+        json={"new_name": "my-coding-agent"},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["name"] == "my-coding-agent"
+    forked_file = Path.home() / ".ravn" / "personas" / "my-coding-agent.yaml"
+    assert forked_file.exists()
+    forked_file.unlink()  # cleanup
+
+
+def test_fork_nonexistent_source_returns_404(client: TestClient) -> None:
+    resp = client.post(
+        "/api/v1/ravn/personas/nonexistent/fork",
+        json={"new_name": "new-fork"},
+    )
+    assert resp.status_code == 404
+
+
+def test_fork_409_if_new_name_exists_as_custom(client: TestClient, tmp_persona_dir: Path) -> None:
+    write_persona(tmp_persona_dir, "existing", {"name": "existing"})
+    resp = client.post(
+        "/api/v1/ravn/personas/coding-agent/fork",
+        json={"new_name": "existing"},
+    )
+    assert resp.status_code == 409
+
+
+def test_fork_409_if_new_name_is_builtin(client: TestClient) -> None:
+    resp = client.post(
+        "/api/v1/ravn/personas/coding-agent/fork",
+        json={"new_name": "research-agent"},
+    )
+    assert resp.status_code == 409


### PR DESCRIPTION
## Summary

- **New file**: `src/volundr/adapters/inbound/rest_personas.py` — thin REST router factory `create_personas_router(loader: PersonaLoader) -> APIRouter` following the `rest_presets.py` pattern
- **Modified**: `src/volundr/config.py` — added `RavnConfig` with optional `persona_dirs` list and wired it into `Settings`
- **Modified**: `src/volundr/main.py` — instantiates `PersonaLoader` from `settings.ravn.persona_dirs` and includes the personas router
- **New file**: `tests/test_volundr/test_rest_personas.py` — 22 unit tests covering all endpoints

## Endpoints

| Method | Path | Status codes |
|--------|------|-------------|
| GET | `/api/v1/ravn/personas` | 200 |
| GET | `/api/v1/ravn/personas/{name}` | 200, 404 |
| GET | `/api/v1/ravn/personas/{name}/yaml` | 200 (text/yaml), 404 |
| POST | `/api/v1/ravn/personas` | 201, 409 |
| PUT | `/api/v1/ravn/personas/{name}` | 200, 404 |
| DELETE | `/api/v1/ravn/personas/{name}` | 204, 400, 404 |
| POST | `/api/v1/ravn/personas/{name}/fork` | 201, 404, 409 |

## Test plan

- [x] 22 unit tests pass with zero warnings
- [x] `ruff check` clean, `ruff format` applied
- [x] All 13 built-in personas returned by list endpoint
- [x] GET detail returns correct fields for built-in persona
- [x] GET yaml returns parseable YAML with correct content-type
- [x] POST creates file on disk, verified with filesystem check
- [x] PUT on built-in creates override file
- [x] DELETE removes custom file; returns 400 for pure built-in
- [x] Fork creates copy with new name
- [x] 404 for non-existent persona names
- [x] 409 for duplicate create (both custom file and built-in)

> Note: Linear MCP server not configured in this environment — ticket NIU-606 could not be updated via MCP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)