### PR TITLE
feat(ravn): persona creation skill, validate/save tools, /persona command (NIU-610)

### DIFF
--- a/src/ravn/adapters/slash_commands.py
+++ b/src/ravn/adapters/slash_commands.py
@@ -376,6 +376,161 @@ class InitCommand(SlashCommandPort):
         return f"Bootstrapped RAVN.md at {ravn_md} (detected project type: {project_type})"
 
 
+class PersonaCommand(SlashCommandPort):
+    """Manage Ravn personas.
+
+    Subcommands:
+        (no args) / create — print guidance message to start persona creation
+        list               — list all personas with source and permission mode
+        show <name>        — display formatted config for a named persona
+        delete <name>      — delete a custom persona file (refuses built-ins)
+    """
+
+    @property
+    def name(self) -> str:
+        return "/persona"
+
+    @property
+    def aliases(self) -> list[str]:
+        return ["/personas"]
+
+    @property
+    def description(self) -> str:
+        return "manage personas (list / show / delete / create)"
+
+    def handle(self, args: str, ctx: SlashCommandContext) -> str:
+        sub_parts = args.split(maxsplit=1)
+        subcommand = sub_parts[0].lower() if sub_parts else ""
+        rest = sub_parts[1].strip() if len(sub_parts) > 1 else ""
+
+        match subcommand:
+            case "list":
+                return self._list()
+            case "show":
+                return self._show(rest)
+            case "delete":
+                return self._delete(rest)
+            case "" | "create":
+                return (
+                    "Describe the persona you want and I'll help you create it.\n\n"
+                    "I'll guide you through: role, name, system prompt, tools, "
+                    "permissions, LLM settings, and (optionally) pipeline config.\n\n"
+                    "Or use '/persona list' to see existing personas, "
+                    "'/persona show <name>' to inspect one."
+                )
+            case _:
+                return (
+                    f"Unknown subcommand: {subcommand!r}.\n"
+                    "Usage: /persona [list | show <name> | delete <name> | create]"
+                )
+
+    def _list(self) -> str:
+        from ravn.adapters.personas.loader import PersonaLoader  # noqa: PLC0415
+
+        loader = PersonaLoader()
+        names = loader.list_names()
+        if not names:
+            return "No personas found."
+
+        lines = [f"Personas ({len(names)}):", ""]
+        for persona_name in names:
+            source = loader.source(persona_name)
+            persona = loader.load(persona_name)
+            perm = persona.permission_mode if persona else ""
+            source_display = source if source else "(unknown)"
+            perm_display = f"  [{perm}]" if perm else ""
+            lines.append(f"  {persona_name:<28} {source_display}{perm_display}")
+        return "\n".join(lines)
+
+    def _show(self, name: str) -> str:
+        if not name:
+            return "Usage: /persona show <name>"
+
+        from ravn.adapters.personas.loader import PersonaLoader  # noqa: PLC0415
+
+        loader = PersonaLoader()
+        persona = loader.load(name)
+        if persona is None:
+            return f"Persona '{name}' not found. Use '/persona list' to see available personas."
+
+        source = loader.source(name)
+        lines = [
+            f"Persona: {persona.name}",
+            f"Source : {source or '(unknown)'}",
+            "",
+        ]
+
+        if persona.permission_mode:
+            lines.append(f"Permission mode : {persona.permission_mode}")
+        if persona.iteration_budget:
+            lines.append(f"Iteration budget: {persona.iteration_budget}")
+
+        if persona.llm.primary_alias or persona.llm.thinking_enabled or persona.llm.max_tokens:
+            llm_parts = []
+            if persona.llm.primary_alias:
+                llm_parts.append(f"alias={persona.llm.primary_alias}")
+            if persona.llm.thinking_enabled:
+                llm_parts.append("thinking=true")
+            if persona.llm.max_tokens:
+                llm_parts.append(f"max_tokens={persona.llm.max_tokens}")
+            lines.append(f"LLM             : {', '.join(llm_parts)}")
+
+        if persona.allowed_tools:
+            lines.append(f"Allowed tools   : {persona.allowed_tools}")
+        if persona.forbidden_tools:
+            lines.append(f"Forbidden tools : {persona.forbidden_tools}")
+
+        if persona.produces.event_type:
+            lines.append(f"Produces        : {persona.produces.event_type}")
+            if persona.produces.schema:
+                schema_fields = list(persona.produces.schema)
+                lines.append(f"  Schema fields : {schema_fields}")
+        if persona.consumes.event_types:
+            lines.append(f"Consumes        : {persona.consumes.event_types}")
+        if persona.fan_in.contributes_to or persona.fan_in.strategy != "merge":
+            lines.append(
+                f"Fan-in          : strategy={persona.fan_in.strategy}"
+                + (
+                    f", contributes_to={persona.fan_in.contributes_to}"
+                    if persona.fan_in.contributes_to
+                    else ""
+                )
+            )
+
+        if persona.system_prompt_template:
+            preview = persona.system_prompt_template[:200]
+            if len(persona.system_prompt_template) > 200:
+                preview += "…"
+            lines.append("")
+            lines.append("System prompt preview:")
+            lines.append(f"  {preview}")
+
+        return "\n".join(lines)
+
+    def _delete(self, name: str) -> str:
+        if not name:
+            return "Usage: /persona delete <name>"
+
+        from ravn.adapters.personas.loader import PersonaLoader  # noqa: PLC0415
+
+        loader = PersonaLoader()
+
+        source = loader.source(name)
+        if not source:
+            return f"Persona '{name}' not found."
+
+        if source == "[built-in]":
+            return (
+                f"Cannot delete '{name}': it is a built-in persona. "
+                "Built-in personas cannot be removed."
+            )
+
+        deleted = loader.delete(name)
+        if deleted:
+            return f"Persona '{name}' deleted (was at {source})."
+        return f"Persona '{name}' could not be deleted."
+
+
 class CheckpointCommand(SlashCommandPort):
     """Manage session checkpoints.
 
@@ -570,6 +725,7 @@ default_registry.register(TodoCommand())
 default_registry.register(StatusCommand())
 default_registry.register(SkillsCommand())
 default_registry.register(InitCommand())
+default_registry.register(PersonaCommand())
 default_registry.register(CheckpointCommand())
 # HelpCommand registered last — it enumerates the registry at call time
 default_registry.register(HelpCommand(default_registry))

--- a/src/ravn/adapters/tools/builtin_registry.py
+++ b/src/ravn/adapters/tools/builtin_registry.py
@@ -336,4 +336,15 @@ BUILTIN_TOOLS: dict[str, BuiltinToolDef] = {
             "pat_token": s.gateway.platform.pat_token,
         },
     ),
+    # =========================================================================
+    # ravn — persona management tools
+    # =========================================================================
+    "persona_validate": BuiltinToolDef(
+        adapter="ravn.adapters.tools.persona_tools.PersonaValidateTool",
+        groups=frozenset({"ravn"}),
+    ),
+    "persona_save": BuiltinToolDef(
+        adapter="ravn.adapters.tools.persona_tools.PersonaSaveTool",
+        groups=frozenset({"ravn"}),
+    ),
 }

--- a/src/ravn/adapters/tools/persona_tools.py
+++ b/src/ravn/adapters/tools/persona_tools.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 import yaml as _yaml
 
+from ravn.adapters.personas.loader import _VALID_FAN_IN_STRATEGIES
 from ravn.domain.models import ToolResult
 from ravn.ports.tool import ToolPort
 
@@ -27,14 +28,17 @@ logger = logging.getLogger(__name__)
 
 _VALID_PERMISSION_MODES = {"read-only", "workspace-write", "full-access"}
 _VALID_LLM_ALIASES = {"balanced", "powerful", "fast"}
-_VALID_FAN_IN_STRATEGIES = {"all_must_pass", "any_pass", "majority", "merge"}
 _VALID_OUTCOME_FIELD_TYPES = {"string", "number", "boolean", "enum"}
 
 _DEFAULT_PERSONAS_DIR = Path.home() / ".ravn" / "personas"
 
 
-def _validate_yaml(yaml_content: str) -> tuple[list[str], list[str]]:
-    """Return (errors, warnings) for *yaml_content* without writing anything.
+def _validate_yaml(yaml_content: str) -> tuple[list[str], list[str], dict | None]:
+    """Return (errors, warnings, parsed_dict) for *yaml_content*.
+
+    ``parsed_dict`` is the already-parsed YAML mapping when validation
+    succeeds, so callers can use it directly without re-parsing.
+    It is ``None`` whenever ``errors`` is non-empty.
 
     Errors are fatal (save will be refused).
     Warnings are non-fatal advisory messages.
@@ -44,7 +48,7 @@ def _validate_yaml(yaml_content: str) -> tuple[list[str], list[str]]:
 
     if not yaml_content or not yaml_content.strip():
         errors.append("YAML content is empty.")
-        return errors, warnings
+        return errors, warnings, None
 
     try:
         raw = _yaml.safe_load(yaml_content)
@@ -57,11 +61,11 @@ def _validate_yaml(yaml_content: str) -> tuple[list[str], list[str]]:
             )
         else:
             errors.append(f"YAML syntax error: {exc}")
-        return errors, warnings
+        return errors, warnings, None
 
     if not isinstance(raw, dict):
         errors.append("YAML must be a mapping (dict), got a different type.")
-        return errors, warnings
+        return errors, warnings, None
 
     name = str(raw.get("name", "")).strip()
     if not name:
@@ -121,7 +125,7 @@ def _validate_yaml(yaml_content: str) -> tuple[list[str], list[str]]:
                         )
 
     if errors:
-        return errors, warnings
+        return errors, warnings, None
 
     from ravn.adapters.personas.loader import PersonaLoader  # noqa: PLC0415
 
@@ -131,8 +135,9 @@ def _validate_yaml(yaml_content: str) -> tuple[list[str], list[str]]:
             "PersonaLoader.parse() returned None — the YAML is structurally invalid. "
             "Ensure 'name' is present and the document is a valid YAML mapping."
         )
+        return errors, warnings, None
 
-    return errors, warnings
+    return errors, warnings, raw
 
 
 def _format_validation_result(
@@ -208,17 +213,9 @@ class PersonaValidateTool(ToolPort):
     async def execute(self, input: dict) -> ToolResult:  # noqa: A002
         yaml_content: str = input.get("yaml_content") or ""
 
-        errors, warnings = _validate_yaml(yaml_content)
+        errors, warnings, raw = _validate_yaml(yaml_content)
 
-        name = ""
-        if not errors and yaml_content.strip():
-            try:
-                raw = _yaml.safe_load(yaml_content)
-                if isinstance(raw, dict):
-                    name = str(raw.get("name", "")).strip()
-            except Exception:
-                pass
-
+        name = str(raw.get("name", "")).strip() if raw is not None else ""
         message, is_error = _format_validation_result(errors, warnings, name)
         return ToolResult(tool_call_id="", content=message, is_error=is_error)
 
@@ -282,20 +279,12 @@ class PersonaSaveTool(ToolPort):
         yaml_content: str = input.get("yaml_content") or ""
         directory_str: str = (input.get("directory") or "").strip()
 
-        errors, warnings = _validate_yaml(yaml_content)
+        errors, warnings, raw = _validate_yaml(yaml_content)
         if errors:
             message, _ = _format_validation_result(errors, warnings)
             return ToolResult(tool_call_id="", content=message, is_error=True)
 
-        try:
-            raw = _yaml.safe_load(yaml_content)
-        except Exception as exc:
-            return ToolResult(
-                tool_call_id="",
-                content=f"Failed to parse YAML: {exc}",
-                is_error=True,
-            )
-
+        assert raw is not None  # guaranteed when errors is empty
         name = str(raw.get("name", "")).strip()
 
         target_dir = Path(directory_str).expanduser() if directory_str else _DEFAULT_PERSONAS_DIR

--- a/src/ravn/adapters/tools/persona_tools.py
+++ b/src/ravn/adapters/tools/persona_tools.py
@@ -1,0 +1,345 @@
+"""Persona tools — validate and save persona YAML configs.
+
+Two tools are provided:
+
+* ``persona_validate`` — validate a persona YAML string, returning errors or a
+  summary.  No side effects; safe to call repeatedly during creation.
+* ``persona_save``     — validate then write a persona YAML file to disk.
+  Verifies round-trip loading before confirming success.
+
+Permission model
+----------------
+``persona_validate`` uses ``ravn:read`` — no side effects.
+``persona_save`` uses ``ravn:write`` — creates/overwrites a file on disk.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import yaml as _yaml
+
+from ravn.domain.models import ToolResult
+from ravn.ports.tool import ToolPort
+
+logger = logging.getLogger(__name__)
+
+_VALID_PERMISSION_MODES = {"read-only", "workspace-write", "full-access"}
+_VALID_LLM_ALIASES = {"balanced", "powerful", "fast"}
+_VALID_FAN_IN_STRATEGIES = {"all_must_pass", "any_pass", "majority", "merge"}
+_VALID_OUTCOME_FIELD_TYPES = {"string", "number", "boolean", "enum"}
+
+_DEFAULT_PERSONAS_DIR = Path.home() / ".ravn" / "personas"
+
+
+def _validate_yaml(yaml_content: str) -> tuple[list[str], list[str]]:
+    """Return (errors, warnings) for *yaml_content* without writing anything.
+
+    Errors are fatal (save will be refused).
+    Warnings are non-fatal advisory messages.
+    """
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    if not yaml_content or not yaml_content.strip():
+        errors.append("YAML content is empty.")
+        return errors, warnings
+
+    try:
+        raw = _yaml.safe_load(yaml_content)
+    except _yaml.YAMLError as exc:
+        mark = getattr(exc, "problem_mark", None)
+        if mark is not None:
+            errors.append(
+                f"YAML syntax error at line {mark.line + 1}, "
+                f"column {mark.column + 1}: {exc.problem}"
+            )
+        else:
+            errors.append(f"YAML syntax error: {exc}")
+        return errors, warnings
+
+    if not isinstance(raw, dict):
+        errors.append("YAML must be a mapping (dict), got a different type.")
+        return errors, warnings
+
+    name = str(raw.get("name", "")).strip()
+    if not name:
+        errors.append("Missing required field: 'name' must be a non-empty string.")
+
+    system_prompt = str(raw.get("system_prompt_template", "")).strip()
+    if not system_prompt:
+        warnings.append("'system_prompt_template' is empty — the agent will have no identity.")
+
+    permission_mode = str(raw.get("permission_mode", "")).strip()
+    if permission_mode and permission_mode not in _VALID_PERMISSION_MODES:
+        warnings.append(
+            f"Unknown 'permission_mode': {permission_mode!r}. "
+            f"Known modes: {sorted(_VALID_PERMISSION_MODES)}."
+        )
+
+    llm_raw = raw.get("llm")
+    if isinstance(llm_raw, dict):
+        alias = str(llm_raw.get("primary_alias", "")).strip()
+        if alias and alias not in _VALID_LLM_ALIASES:
+            warnings.append(
+                f"Unknown 'llm.primary_alias': {alias!r}. "
+                f"Known aliases: {sorted(_VALID_LLM_ALIASES)}."
+            )
+
+    fan_in_raw = raw.get("fan_in")
+    if isinstance(fan_in_raw, dict):
+        strategy = str(fan_in_raw.get("strategy", "")).strip()
+        if strategy and strategy not in _VALID_FAN_IN_STRATEGIES:
+            errors.append(
+                f"Invalid 'fan_in.strategy': {strategy!r}. "
+                f"Must be one of: {sorted(_VALID_FAN_IN_STRATEGIES)}."
+            )
+
+    produces_raw = raw.get("produces")
+    if isinstance(produces_raw, dict):
+        schema_raw = produces_raw.get("schema")
+        if isinstance(schema_raw, dict):
+            for field_name, field_def in schema_raw.items():
+                if not isinstance(field_def, dict):
+                    errors.append(
+                        f"'produces.schema.{field_name}' must be a mapping, "
+                        f"got {type(field_def).__name__}."
+                    )
+                    continue
+                field_type = str(field_def.get("type", "")).strip()
+                if field_type and field_type not in _VALID_OUTCOME_FIELD_TYPES:
+                    errors.append(
+                        f"'produces.schema.{field_name}.type': {field_type!r} is not a valid "
+                        f"OutcomeField type. Must be one of: {sorted(_VALID_OUTCOME_FIELD_TYPES)}."
+                    )
+                if field_type == "enum":
+                    values = field_def.get("values") or field_def.get("enum_values")
+                    if not isinstance(values, list) or not values:
+                        errors.append(
+                            f"'produces.schema.{field_name}' has type 'enum' but no 'values' list."
+                        )
+
+    if errors:
+        return errors, warnings
+
+    from ravn.adapters.personas.loader import PersonaLoader  # noqa: PLC0415
+
+    parsed = PersonaLoader.parse(yaml_content)
+    if parsed is None:
+        errors.append(
+            "PersonaLoader.parse() returned None — the YAML is structurally invalid. "
+            "Ensure 'name' is present and the document is a valid YAML mapping."
+        )
+
+    return errors, warnings
+
+
+def _format_validation_result(
+    errors: list[str],
+    warnings: list[str],
+    name: str = "",
+) -> tuple[str, bool]:
+    """Return (message, is_error) for the validation result."""
+    if errors:
+        lines = ["Validation failed:"]
+        for err in errors:
+            lines.append(f"  ✗ {err}")
+        if warnings:
+            lines.append("")
+            lines.append("Warnings:")
+            for warn in warnings:
+                lines.append(f"  ⚠ {warn}")
+        return "\n".join(lines), True
+
+    lines = [f"Validation passed: persona '{name}' is valid."]
+    if warnings:
+        lines.append("")
+        lines.append("Warnings:")
+        for warn in warnings:
+            lines.append(f"  ⚠ {warn}")
+    return "\n".join(lines), False
+
+
+# ---------------------------------------------------------------------------
+# PersonaValidateTool
+# ---------------------------------------------------------------------------
+
+
+class PersonaValidateTool(ToolPort):
+    """Validate a persona YAML string without writing anything.
+
+    Checks syntax, required fields, known enum values, and verifies that
+    ``PersonaLoader.parse()`` can parse the result.  Returns a success
+    summary or detailed diagnostic messages with line numbers.
+    """
+
+    @property
+    def name(self) -> str:
+        return "persona_validate"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Validate a persona YAML string without saving it. "
+            "Checks syntax, required fields (name), known permission modes, "
+            "LLM aliases, fan_in strategies, and OutcomeField types. "
+            "Returns a success summary or detailed error messages. "
+            "Call this before persona_save to catch problems early."
+        )
+
+    @property
+    def input_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "yaml_content": {
+                    "type": "string",
+                    "description": "Full persona YAML content to validate.",
+                },
+            },
+            "required": ["yaml_content"],
+        }
+
+    @property
+    def required_permission(self) -> str:
+        return "ravn:read"
+
+    async def execute(self, input: dict) -> ToolResult:  # noqa: A002
+        yaml_content: str = input.get("yaml_content") or ""
+
+        errors, warnings = _validate_yaml(yaml_content)
+
+        name = ""
+        if not errors and yaml_content.strip():
+            try:
+                raw = _yaml.safe_load(yaml_content)
+                if isinstance(raw, dict):
+                    name = str(raw.get("name", "")).strip()
+            except Exception:
+                pass
+
+        message, is_error = _format_validation_result(errors, warnings, name)
+        return ToolResult(tool_call_id="", content=message, is_error=is_error)
+
+
+# ---------------------------------------------------------------------------
+# PersonaSaveTool
+# ---------------------------------------------------------------------------
+
+
+class PersonaSaveTool(ToolPort):
+    """Validate and save a persona YAML file to disk.
+
+    Validates the YAML first (same checks as ``persona_validate``).
+    On success, writes ``<name>.yaml`` to the target directory, then
+    verifies the round-trip by loading it back with ``PersonaLoader``.
+
+    The optional ``directory`` parameter lets you save to a project-local
+    ``.ravn/personas/`` instead of the default ``~/.ravn/personas/``.
+    """
+
+    @property
+    def name(self) -> str:
+        return "persona_save"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Validate and save a persona YAML file to disk. "
+            "Validates first; fails fast with diagnostics on any error. "
+            "Writes <name>.yaml to ~/.ravn/personas/ by default. "
+            "Pass 'directory' to save to a project-local .ravn/personas/ instead. "
+            "Verifies round-trip loading after writing."
+        )
+
+    @property
+    def input_schema(self) -> dict:
+        return {
+            "type": "object",
+            "properties": {
+                "yaml_content": {
+                    "type": "string",
+                    "description": "Full persona YAML content to save.",
+                },
+                "directory": {
+                    "type": "string",
+                    "description": (
+                        "Optional target directory path. "
+                        "Defaults to ~/.ravn/personas/. "
+                        "Use a project-local path like .ravn/personas/ for project-scoped personas."
+                    ),
+                },
+            },
+            "required": ["yaml_content"],
+        }
+
+    @property
+    def required_permission(self) -> str:
+        return "ravn:write"
+
+    async def execute(self, input: dict) -> ToolResult:  # noqa: A002
+        yaml_content: str = input.get("yaml_content") or ""
+        directory_str: str = (input.get("directory") or "").strip()
+
+        errors, warnings = _validate_yaml(yaml_content)
+        if errors:
+            message, _ = _format_validation_result(errors, warnings)
+            return ToolResult(tool_call_id="", content=message, is_error=True)
+
+        try:
+            raw = _yaml.safe_load(yaml_content)
+        except Exception as exc:
+            return ToolResult(
+                tool_call_id="",
+                content=f"Failed to parse YAML: {exc}",
+                is_error=True,
+            )
+
+        name = str(raw.get("name", "")).strip()
+
+        target_dir = Path(directory_str).expanduser() if directory_str else _DEFAULT_PERSONAS_DIR
+        try:
+            target_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            return ToolResult(
+                tool_call_id="",
+                content=f"Failed to create directory {target_dir}: {exc}",
+                is_error=True,
+            )
+
+        dest = target_dir / f"{name}.yaml"
+        try:
+            dest.write_text(yaml_content, encoding="utf-8")
+        except OSError as exc:
+            return ToolResult(
+                tool_call_id="",
+                content=f"Failed to write {dest}: {exc}",
+                is_error=True,
+            )
+
+        from ravn.adapters.personas.loader import PersonaLoader  # noqa: PLC0415
+
+        loader = PersonaLoader(
+            persona_dirs=[str(target_dir)],
+            include_builtin=False,
+        )
+        loaded = loader.load(name)
+        if loaded is None:
+            dest.unlink(missing_ok=True)
+            return ToolResult(
+                tool_call_id="",
+                content=(
+                    f"Round-trip verification failed: PersonaLoader could not load '{name}' "
+                    f"from {dest}. The file was not saved."
+                ),
+                is_error=True,
+            )
+
+        lines = [f"Persona '{name}' saved to {dest}."]
+        if warnings:
+            lines.append("")
+            lines.append("Warnings:")
+            for warn in warnings:
+                lines.append(f"  ⚠ {warn}")
+        return ToolResult(tool_call_id="", content="\n".join(lines))

--- a/src/ravn/skills/create-persona.md
+++ b/src/ravn/skills/create-persona.md
@@ -1,0 +1,197 @@
+# skill: create-persona
+
+Guide the user through creating a new Ravn persona interactively — like cookiecutter but LLM-driven.
+
+## PersonaConfig schema reference
+
+### Top-level fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | string | **required** | Kebab-case identifier (e.g. `draft-a-note`, `code-reviewer`) |
+| `system_prompt_template` | string | `""` | The agent's identity and behaviour instructions |
+| `allowed_tools` | list[string] | `[]` | Tool groups or names the agent may use |
+| `forbidden_tools` | list[string] | `[]` | Tool groups or names explicitly denied |
+| `permission_mode` | string | `""` | File-system permission level |
+| `iteration_budget` | int | `0` (use settings default) | Maximum agent turns before stopping |
+
+### Tool groups
+
+| Group | Includes |
+|-------|---------|
+| `file` | read_file, write_file, edit_file, glob_search, grep_search |
+| `git` | git_status, git_diff, git_add, git_commit, git_checkout, git_log, git_pr |
+| `web` | web_fetch, web_search |
+| `terminal` | terminal (bash, shell) |
+| `mimir` | mimir_read, mimir_write, mimir_search, mimir_list, mimir_ingest |
+| `cascade` | cascade_delegate, cascade_broadcast |
+| `ravn` | persona_validate, persona_save, skill_list, skill_run |
+| `volundr` | volundr_session, volundr_git |
+
+### Permission modes
+
+| Value | Meaning |
+|-------|---------|
+| `read-only` | Can read files, cannot write or execute |
+| `workspace-write` | Can read and write within the workspace |
+| `full-access` | Unrestricted — use with care |
+
+### LLM config (`llm:` section)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `primary_alias` | string | `""` | Model tier alias |
+| `thinking_enabled` | bool | `false` | Enable extended thinking |
+| `max_tokens` | int | `0` | Override max output tokens (0 = settings default) |
+
+**LLM aliases:**
+
+| Alias | Meaning |
+|-------|---------|
+| `balanced` | Mid-tier model — good for most tasks |
+| `powerful` | Large model — for complex reasoning |
+| `fast` | Small/nano model — for quick tasks |
+
+### Pipeline fields
+
+These are optional — only used when the persona participates in a multi-agent pipeline.
+
+#### `produces:` — structured output this persona emits
+
+```yaml
+produces:
+  event_type: review.completed   # dot-separated event name
+  schema:
+    verdict:
+      type: enum
+      values: [pass, fail, needs_changes]
+      description: review verdict
+    summary:
+      type: string
+      description: one-line review summary
+```
+
+**OutcomeField types:** `string`, `number`, `boolean`, `enum`
+
+For `enum`, include a `values` list. All fields default to `required: true`.
+
+#### `consumes:` — what input this persona expects
+
+```yaml
+consumes:
+  event_types: [code.changed, review.requested]
+  injects: [repo, branch, diff_url]
+```
+
+#### `fan_in:` — how output combines with parallel peers
+
+```yaml
+fan_in:
+  strategy: all_must_pass   # how to combine verdicts
+  contributes_to: review.verdict
+```
+
+**Fan-in strategies:**
+
+| Strategy | Meaning |
+|----------|---------|
+| `all_must_pass` | All parallel agents must succeed |
+| `any_pass` | At least one agent must succeed |
+| `majority` | More than half must succeed |
+| `merge` | Combine all outputs (default) |
+
+---
+
+## Examples
+
+### Simple persona (no pipeline)
+
+```yaml
+name: draft-a-note
+system_prompt_template: |
+  You are a note-taking agent for the Mímir knowledge base.
+  Given a topic, draft a concise, well-structured page.
+  Write in clear prose. Keep pages under 500 words.
+  Always add front matter with title, tags, and date.
+allowed_tools: [mimir, web]
+forbidden_tools: [terminal, git]
+permission_mode: read-only
+llm:
+  primary_alias: balanced
+  thinking_enabled: false
+iteration_budget: 10
+```
+
+### Pipeline persona (produces/consumes/fan_in)
+
+```yaml
+name: reviewer
+system_prompt_template: |
+  You are a code reviewer. Read diffs, identify issues, and produce
+  a structured verdict with detailed findings.
+  Apply 'pass' when ready to merge, 'needs_changes' for non-blocking
+  issues, 'fail' for blocking problems.
+allowed_tools: [file, git, web, ravn]
+forbidden_tools: [terminal, cascade]
+permission_mode: read-only
+llm:
+  primary_alias: balanced
+  thinking_enabled: true
+iteration_budget: 20
+produces:
+  event_type: review.completed
+  schema:
+    verdict:
+      type: enum
+      values: [pass, fail, needs_changes]
+      description: review verdict
+    findings_count:
+      type: number
+      description: total number of findings
+    summary:
+      type: string
+      description: one-line review summary
+consumes:
+  event_types: [code.changed, review.requested]
+  injects: [repo, branch, diff_url]
+fan_in:
+  strategy: all_must_pass
+  contributes_to: review.verdict
+```
+
+---
+
+## Conversational creation flow
+
+Follow these steps — be conversational, use sensible defaults, and don't dump all fields at once.
+
+1. **Ask what the persona should do.** One open question: "What should this persona do? Describe its role and main purpose."
+
+2. **Suggest a kebab-case name.** Based on the description, propose a name like `code-reviewer` or `data-analyst`. Confirm with the user.
+
+3. **Draft `system_prompt_template`.** Write a concise system prompt that captures the role. Show it to the user for approval. Offer to refine.
+
+4. **Determine `allowed_tools` and `forbidden_tools`.** Ask which tool groups the persona needs. Suggest sensible defaults based on the role (e.g. a read-only research agent probably needs `[web, mimir]` but not `terminal`).
+
+5. **Set `permission_mode`.** Suggest `read-only` for agents that only read, `workspace-write` for agents that create or edit files, `full-access` for autonomous agents.
+
+6. **Configure `llm`.** Ask if the default `balanced` model is suitable, or whether the persona needs `powerful` (complex reasoning) or `fast` (quick tasks). Ask about `thinking_enabled` only if it seems relevant.
+
+7. **Set `iteration_budget`.** Suggest a default based on complexity (5–10 for simple, 20–40 for complex). Ask if the user wants to change it.
+
+8. **Ask if this is a pipeline persona.** "Will this persona run as part of a multi-agent pipeline (producing structured output for other agents)?" If no, skip to step 9. If yes, help configure `produces`, `consumes`, and `fan_in`.
+
+9. **Call `persona_validate`** with the assembled YAML. If validation fails, show the errors and fix them with the user.
+
+10. **Fix any validation errors** by going back to the relevant step and revising.
+
+11. **Call `persona_save`** to write the file. Confirm the save path with the user first. Use the optional `directory` parameter to save to a project-local `.ravn/personas/` if the user wants that.
+
+12. **Confirm with the user.** Show the final file path and a summary of the persona's key settings.
+
+**Style notes:**
+- Be conversational and guide the user one step at a time
+- Offer sensible defaults so the user does not have to know every field
+- Validate early and often — call `persona_validate` before saving
+- Explain what each field does when it might be unclear
+- For most users, skip pipeline fields entirely unless they ask

--- a/tests/ravn/unit/test_builtin_registry.py
+++ b/tests/ravn/unit/test_builtin_registry.py
@@ -48,7 +48,7 @@ class TestRegistryStructure:
             assert val.groups, f"{key!r} has no groups"
 
     def test_known_groups_only(self) -> None:
-        valid_groups = {"core", "extended", "skill", "platform"}
+        valid_groups = {"core", "extended", "skill", "platform", "ravn"}
         for key, val in BUILTIN_TOOLS.items():
             unknown = val.groups - valid_groups
             assert not unknown, f"{key!r} has unknown groups: {unknown}"

--- a/tests/test_ravn/test_persona_slash_command.py
+++ b/tests/test_ravn/test_persona_slash_command.py
@@ -1,0 +1,206 @@
+"""Tests for the /persona slash command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ravn.adapters.slash_commands import PersonaCommand, SlashCommandContext, default_registry
+from ravn.domain.models import Session
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_CUSTOM_PERSONA_YAML = """\
+name: custom-agent
+system_prompt_template: |
+  You are a custom agent for testing.
+permission_mode: workspace-write
+llm:
+  primary_alias: balanced
+iteration_budget: 15
+"""
+
+
+def _ctx() -> SlashCommandContext:
+    return SlashCommandContext(session=Session())
+
+
+def _make_custom_persona(tmp_path: Path, name: str = "custom-agent") -> Path:
+    """Write a custom persona YAML to tmp_path and return the file path."""
+    content = f"name: {name}\nsystem_prompt_template: 'Test persona {name}.'\n"
+    path = tmp_path / f"{name}.yaml"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for PersonaCommand
+# ---------------------------------------------------------------------------
+
+
+class TestPersonaCommandCreate:
+    def setup_method(self):
+        self.cmd = PersonaCommand()
+        self.ctx = _ctx()
+
+    def test_no_args_returns_guidance(self):
+        result = self.cmd.handle("", self.ctx)
+        assert "Describe" in result or "describe" in result
+        assert "persona" in result.lower()
+
+    def test_create_subcommand_returns_guidance(self):
+        result = self.cmd.handle("create", self.ctx)
+        assert "persona" in result.lower()
+        assert len(result) > 10
+
+    def test_unknown_subcommand_returns_usage(self):
+        result = self.cmd.handle("explode", self.ctx)
+        assert "explode" in result
+        assert "Usage" in result or "usage" in result.lower()
+
+
+class TestPersonaCommandList:
+    def setup_method(self):
+        self.cmd = PersonaCommand()
+        self.ctx = _ctx()
+
+    def test_list_returns_builtin_personas(self):
+        result = self.cmd.handle("list", self.ctx)
+        # Built-in personas should always be present
+        assert "coding-agent" in result or "Personas" in result
+
+    def test_list_shows_source(self):
+        result = self.cmd.handle("list", self.ctx)
+        # Should show either "[built-in]" or a file path for each persona
+        assert "[built-in]" in result or "personas" in result.lower()
+
+    def test_list_includes_custom_persona(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        from ravn.adapters.personas import loader as _loader_module
+
+        # Monkeypatch the default directories to include tmp_path
+        monkeypatch.setattr(
+            _loader_module,
+            "_DEFAULT_PERSONAS_DIR",
+            tmp_path,
+        )
+        _make_custom_persona(tmp_path, "my-test-persona")
+
+        # PersonaLoader uses _DEFAULT_PERSONAS_DIR indirectly via Path.home()
+        # We need to patch PersonaLoader construction inside PersonaCommand._list
+        original_loader_init = _loader_module.PersonaLoader.__init__
+
+        def patched_init(self_loader, persona_dirs=None, *, include_builtin=True, cwd=None):
+            if persona_dirs is None:
+                persona_dirs = [str(tmp_path)]
+            original_loader_init(
+                self_loader, persona_dirs=persona_dirs, include_builtin=include_builtin, cwd=cwd
+            )
+
+        monkeypatch.setattr(_loader_module.PersonaLoader, "__init__", patched_init)
+
+        result = self.cmd.handle("list", self.ctx)
+        assert "my-test-persona" in result
+
+
+class TestPersonaCommandShow:
+    def setup_method(self):
+        self.cmd = PersonaCommand()
+        self.ctx = _ctx()
+
+    def test_show_existing_builtin(self):
+        result = self.cmd.handle("show coding-agent", self.ctx)
+        assert "coding-agent" in result
+        assert "permission" in result.lower() or "Permission" in result
+
+    def test_show_nonexistent_returns_not_found(self):
+        result = self.cmd.handle("show nonexistent-persona-xyz", self.ctx)
+        assert "not found" in result.lower()
+
+    def test_show_no_name_returns_usage(self):
+        result = self.cmd.handle("show", self.ctx)
+        assert "Usage" in result or "usage" in result.lower()
+
+    def test_show_displays_permission_mode(self):
+        result = self.cmd.handle("show coding-agent", self.ctx)
+        assert "workspace-write" in result or "permission" in result.lower()
+
+    def test_show_displays_allowed_tools(self):
+        result = self.cmd.handle("show coding-agent", self.ctx)
+        assert "tools" in result.lower() or "file" in result
+
+    def test_show_pipeline_persona_displays_produces(self):
+        result = self.cmd.handle("show reviewer", self.ctx)
+        assert "reviewer" in result
+        # reviewer has produces
+        assert "review.completed" in result or "produces" in result.lower() or "Produces" in result
+
+
+class TestPersonaCommandDelete:
+    def setup_method(self):
+        self.cmd = PersonaCommand()
+        self.ctx = _ctx()
+
+    def test_delete_no_name_returns_usage(self):
+        result = self.cmd.handle("delete", self.ctx)
+        assert "Usage" in result or "usage" in result.lower()
+
+    def test_delete_builtin_is_refused(self):
+        result = self.cmd.handle("delete coding-agent", self.ctx)
+        assert "built-in" in result.lower() or "Cannot" in result
+
+    def test_delete_custom_persona_removes_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        from ravn.adapters.personas import loader as _loader_module
+
+        persona_name = "delete-test-persona"
+        _make_custom_persona(tmp_path, persona_name)
+
+        original_loader_init = _loader_module.PersonaLoader.__init__
+
+        def patched_init(self_loader, persona_dirs=None, *, include_builtin=True, cwd=None):
+            if persona_dirs is None:
+                persona_dirs = [str(tmp_path)]
+            original_loader_init(
+                self_loader, persona_dirs=persona_dirs, include_builtin=include_builtin, cwd=cwd
+            )
+
+        monkeypatch.setattr(_loader_module.PersonaLoader, "__init__", patched_init)
+
+        result = self.cmd.handle(f"delete {persona_name}", self.ctx)
+        assert "deleted" in result.lower()
+        assert not (tmp_path / f"{persona_name}.yaml").exists()
+
+    def test_delete_nonexistent_returns_not_found(self):
+        result = self.cmd.handle("delete nonexistent-xyz-abc", self.ctx)
+        assert "not found" in result.lower()
+
+
+class TestPersonaCommandRegistration:
+    def test_persona_command_registered_in_default_registry(self):
+        result = default_registry.handle("/persona", _ctx())
+        assert result is not None
+        assert "persona" in result.lower()
+
+    def test_personas_alias_works(self):
+        result = default_registry.handle("/personas", _ctx())
+        assert result is not None
+        assert "persona" in result.lower()
+
+    def test_persona_appears_in_help(self):
+        result = default_registry.handle("/help", _ctx())
+        assert result is not None
+        assert "/persona" in result
+
+    def test_persona_list_via_registry(self):
+        result = default_registry.handle("/persona list", _ctx())
+        assert result is not None
+        assert len(result) > 0
+
+    def test_persona_show_via_registry(self):
+        result = default_registry.handle("/persona show coding-agent", _ctx())
+        assert result is not None
+        assert "coding-agent" in result

--- a/tests/test_ravn/test_persona_tools.py
+++ b/tests/test_ravn/test_persona_tools.py
@@ -1,0 +1,308 @@
+"""Tests for PersonaValidateTool and PersonaSaveTool."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from ravn.adapters.tools.persona_tools import PersonaSaveTool, PersonaValidateTool
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_MINIMAL_YAML = """\
+name: test-persona
+system_prompt_template: |
+  You are a test persona.
+permission_mode: read-only
+"""
+
+_FULL_YAML = """\
+name: reviewer
+system_prompt_template: |
+  You are a code reviewer. Read diffs and produce a structured verdict.
+allowed_tools: [file, git, web, ravn]
+forbidden_tools: [terminal, cascade]
+permission_mode: read-only
+llm:
+  primary_alias: balanced
+  thinking_enabled: true
+iteration_budget: 20
+produces:
+  event_type: review.completed
+  schema:
+    verdict:
+      type: enum
+      values: [pass, fail, needs_changes]
+      description: review verdict
+    summary:
+      type: string
+      description: one-line review summary
+consumes:
+  event_types: [code.changed, review.requested]
+  injects: [repo, branch, diff_url]
+fan_in:
+  strategy: all_must_pass
+  contributes_to: review.verdict
+"""
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# PersonaValidateTool
+# ---------------------------------------------------------------------------
+
+
+class TestPersonaValidateTool:
+    def setup_method(self):
+        self.tool = PersonaValidateTool()
+
+    def test_valid_minimal_yaml_succeeds(self):
+        result = _run(self.tool.execute({"yaml_content": _MINIMAL_YAML}))
+        assert not result.is_error
+        assert "test-persona" in result.content
+        assert "valid" in result.content.lower()
+
+    def test_valid_full_yaml_succeeds_with_summary(self):
+        result = _run(self.tool.execute({"yaml_content": _FULL_YAML}))
+        assert not result.is_error
+        assert "reviewer" in result.content
+
+    def test_missing_name_returns_error(self):
+        yaml_no_name = "system_prompt_template: 'hello'\npermission_mode: read-only\n"
+        result = _run(self.tool.execute({"yaml_content": yaml_no_name}))
+        assert result.is_error
+        assert "name" in result.content.lower()
+
+    def test_invalid_yaml_syntax_returns_error_with_line_info(self):
+        bad_yaml = "name: foo\n  bad: indent:\n  - wrong"
+        result = _run(self.tool.execute({"yaml_content": bad_yaml}))
+        assert result.is_error
+        assert "syntax" in result.content.lower() or "error" in result.content.lower()
+
+    def test_empty_string_returns_error(self):
+        result = _run(self.tool.execute({"yaml_content": ""}))
+        assert result.is_error
+        assert "empty" in result.content.lower()
+
+    def test_whitespace_only_returns_error(self):
+        result = _run(self.tool.execute({"yaml_content": "   \n  "}))
+        assert result.is_error
+
+    def test_unknown_permission_mode_returns_warning(self):
+        yaml_unknown_perm = "name: x\nsystem_prompt_template: hi\npermission_mode: superuser\n"
+        result = _run(self.tool.execute({"yaml_content": yaml_unknown_perm}))
+        assert not result.is_error
+        assert "superuser" in result.content
+        assert "warning" in result.content.lower() or "⚠" in result.content
+
+    def test_empty_system_prompt_returns_warning(self):
+        yaml_no_prompt = "name: x\npermission_mode: read-only\n"
+        result = _run(self.tool.execute({"yaml_content": yaml_no_prompt}))
+        assert not result.is_error
+        assert "system_prompt_template" in result.content
+        assert "⚠" in result.content or "warning" in result.content.lower()
+
+    def test_unknown_llm_alias_returns_warning(self):
+        yaml_bad_alias = "name: x\nsystem_prompt_template: hi\nllm:\n  primary_alias: turbo\n"
+        result = _run(self.tool.execute({"yaml_content": yaml_bad_alias}))
+        assert not result.is_error
+        assert "turbo" in result.content
+        assert "⚠" in result.content or "warning" in result.content.lower()
+
+    def test_invalid_fan_in_strategy_returns_error(self):
+        yaml_bad_fan_in = "name: x\nsystem_prompt_template: hi\nfan_in:\n  strategy: bad_strategy\n"
+        result = _run(self.tool.execute({"yaml_content": yaml_bad_fan_in}))
+        assert result.is_error
+        assert "bad_strategy" in result.content
+
+    def test_invalid_outcome_field_type_returns_error(self):
+        yaml_bad_type = (
+            "name: x\n"
+            "system_prompt_template: hi\n"
+            "produces:\n"
+            "  event_type: test.done\n"
+            "  schema:\n"
+            "    result:\n"
+            "      type: fancytype\n"
+            "      description: something\n"
+        )
+        result = _run(self.tool.execute({"yaml_content": yaml_bad_type}))
+        assert result.is_error
+        assert "fancytype" in result.content
+
+    def test_enum_field_without_values_returns_error(self):
+        yaml_enum_no_vals = (
+            "name: x\n"
+            "system_prompt_template: hi\n"
+            "produces:\n"
+            "  event_type: test.done\n"
+            "  schema:\n"
+            "    verdict:\n"
+            "      type: enum\n"
+            "      description: the verdict\n"
+        )
+        result = _run(self.tool.execute({"yaml_content": yaml_enum_no_vals}))
+        assert result.is_error
+        assert "values" in result.content.lower() or "enum" in result.content.lower()
+
+    def test_name_and_description_properties(self):
+        assert self.tool.name == "persona_validate"
+        assert self.tool.required_permission == "ravn:read"
+        assert "validate" in self.tool.description.lower()
+
+    def test_input_schema_has_yaml_content(self):
+        schema = self.tool.input_schema
+        assert "yaml_content" in schema["properties"]
+
+    def test_non_dict_yaml_returns_error(self):
+        # YAML that parses but is a list, not a dict
+        result = _run(self.tool.execute({"yaml_content": "- foo\n- bar\n"}))
+        assert result.is_error
+        assert "mapping" in result.content.lower() or "dict" in result.content.lower()
+
+    def test_schema_field_not_a_dict_returns_error(self):
+        yaml_bad_schema_field = (
+            "name: x\n"
+            "system_prompt_template: hi\n"
+            "produces:\n"
+            "  event_type: test.done\n"
+            "  schema:\n"
+            "    verdict: just-a-string\n"  # field_def is a string, not a dict
+        )
+        result = _run(self.tool.execute({"yaml_content": yaml_bad_schema_field}))
+        assert result.is_error
+        assert "verdict" in result.content
+
+    def test_errors_and_warnings_shown_together(self):
+        # Invalid fan_in strategy (error) + unknown permission_mode (warning)
+        yaml_both = (
+            "name: x\n"
+            "system_prompt_template: hi\n"
+            "permission_mode: super-mode\n"
+            "fan_in:\n"
+            "  strategy: bad_strat\n"
+        )
+        result = _run(self.tool.execute({"yaml_content": yaml_both}))
+        assert result.is_error
+        assert "bad_strat" in result.content
+        assert "super-mode" in result.content
+
+    def test_produces_with_no_schema_dict_branch(self):
+        # produces section with schema: null — branch 101->121 not taken in loop
+        yaml_no_schema = (
+            "name: x\nsystem_prompt_template: hi\nproduces:\n  event_type: test.done\n  schema: ~\n"
+        )
+        result = _run(self.tool.execute({"yaml_content": yaml_no_schema}))
+        assert not result.is_error
+
+    def test_persona_loader_parse_none_returns_error(self, monkeypatch):
+        from ravn.adapters.personas import loader as _loader_module
+
+        monkeypatch.setattr(_loader_module.PersonaLoader, "parse", staticmethod(lambda _: None))
+        # Valid YAML but mocked parse returns None
+        result = _run(self.tool.execute({"yaml_content": _MINIMAL_YAML}))
+        assert result.is_error
+        assert "PersonaLoader" in result.content or "parse" in result.content.lower()
+
+
+# ---------------------------------------------------------------------------
+# PersonaSaveTool
+# ---------------------------------------------------------------------------
+
+
+class TestPersonaSaveTool:
+    def setup_method(self):
+        self.tool = PersonaSaveTool()
+
+    def test_save_valid_yaml_writes_file(self, tmp_path: Path):
+        result = _run(
+            self.tool.execute(
+                {
+                    "yaml_content": _MINIMAL_YAML,
+                    "directory": str(tmp_path),
+                }
+            )
+        )
+        assert not result.is_error
+        assert "test-persona" in result.content
+        saved = tmp_path / "test-persona.yaml"
+        assert saved.exists()
+
+    def test_save_to_custom_directory(self, tmp_path: Path):
+        custom_dir = tmp_path / "custom" / "personas"
+        result = _run(
+            self.tool.execute(
+                {
+                    "yaml_content": _MINIMAL_YAML,
+                    "directory": str(custom_dir),
+                }
+            )
+        )
+        assert not result.is_error
+        assert (custom_dir / "test-persona.yaml").exists()
+
+    def test_save_invalid_yaml_returns_error_no_file(self, tmp_path: Path):
+        result = _run(
+            self.tool.execute(
+                {
+                    "yaml_content": "system_prompt_template: hi\n",
+                    "directory": str(tmp_path),
+                }
+            )
+        )
+        assert result.is_error
+        assert not list(tmp_path.glob("*.yaml"))
+
+    def test_save_roundtrip_verified(self, tmp_path: Path):
+        result = _run(
+            self.tool.execute(
+                {
+                    "yaml_content": _FULL_YAML,
+                    "directory": str(tmp_path),
+                }
+            )
+        )
+        assert not result.is_error
+        saved = tmp_path / "reviewer.yaml"
+        assert saved.exists()
+
+        from ravn.adapters.personas.loader import PersonaLoader
+
+        loader = PersonaLoader(persona_dirs=[str(tmp_path)], include_builtin=False)
+        persona = loader.load("reviewer")
+        assert persona is not None
+        assert persona.name == "reviewer"
+        assert persona.produces.event_type == "review.completed"
+
+    def test_save_missing_name_returns_error(self, tmp_path: Path):
+        yaml_no_name = "system_prompt_template: hello\npermission_mode: read-only\n"
+        result = _run(self.tool.execute({"yaml_content": yaml_no_name, "directory": str(tmp_path)}))
+        assert result.is_error
+        assert not list(tmp_path.glob("*.yaml"))
+
+    def test_save_with_warnings_shows_them(self, tmp_path: Path):
+        # Persona with unknown permission_mode → saves but shows warning
+        yaml_with_warning = (
+            "name: warn-persona\nsystem_prompt_template: hi\npermission_mode: super-mode\n"
+        )
+        result = _run(
+            self.tool.execute({"yaml_content": yaml_with_warning, "directory": str(tmp_path)})
+        )
+        assert not result.is_error
+        assert "warn-persona" in result.content
+        assert "super-mode" in result.content or "⚠" in result.content
+
+    def test_name_and_description_properties(self):
+        assert self.tool.name == "persona_save"
+        assert self.tool.required_permission == "ravn:write"
+        assert "save" in self.tool.description.lower()
+
+    def test_input_schema_has_yaml_content_and_directory(self):
+        schema = self.tool.input_schema
+        assert "yaml_content" in schema["properties"]
+        assert "directory" in schema["properties"]


### PR DESCRIPTION
## Summary

- **`src/ravn/skills/create-persona.md`** — Built-in skill auto-discovered by `FileSkillRegistry`. Full PersonaConfig schema reference, two YAML examples, 12-step conversational creation flow.

- **`src/ravn/adapters/tools/persona_tools.py`** — Two new tools:
  - `PersonaValidateTool` (`persona_validate`, `ravn:read`): validates YAML syntax, required name, known permission_mode/LLM aliases (warnings), fan_in.strategy, OutcomeField types, PersonaLoader.parse() final check.
  - `PersonaSaveTool` (`persona_save`, `ravn:write`): validates then writes name.yaml to target dir (default ~/.ravn/personas/), verifies round-trip.

- **`src/ravn/adapters/tools/builtin_registry.py`** — Registers both tools under the ravn group.

- **`src/ravn/adapters/slash_commands.py`** — Adds PersonaCommand (/persona, alias /personas): list, show, delete, create subcommands.

## Test plan

- [x] 48 tests, zero warnings, 94% coverage on persona_tools.py
- [x] ruff check + ruff format clean
- [x] Covers: valid/invalid YAML, missing name, syntax errors, all warnings, all error types, save round-trip, custom directory, all /persona subcommands

## Notes

Linear MCP tools not available in this environment; NIU-610 linked via this PR description.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>