### PR TITLE
feat(web): agent detail panel — drill-down into Ravn thinking and tool stream (NIU-609)

### DIFF
--- a/web/src/modules/shared/components/SessionChat/AgentDetailPanel/AgentDetailPanel.module.css
+++ b/web/src/modules/shared/components/SessionChat/AgentDetailPanel/AgentDetailPanel.module.css
@@ -1,0 +1,186 @@
+.panel {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background-color: var(--color-bg-primary);
+  border-left: 1px solid var(--color-border-subtle);
+  overflow: hidden;
+}
+
+/* ── Header ──────────────────────────────────────────────── */
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-2) var(--space-4);
+  background-color: color-mix(in srgb, var(--color-bg-tertiary) 60%, transparent);
+  border-bottom: 1px solid var(--color-border-subtle);
+  flex-shrink: 0;
+}
+
+.headerLeft {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.headerRight {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
+
+.personaDot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-full);
+  background-color: var(--agent-color, var(--color-text-muted));
+  flex-shrink: 0;
+}
+
+.personaName {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  font-family: var(--font-sans);
+  color: var(--agent-color, var(--color-text-primary));
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── Status & activity ──────────────────────────────────── */
+
+.statusIndicator {
+  display: flex;
+  align-items: center;
+  color: var(--color-text-faint);
+  transition: color var(--transition-fast);
+}
+
+.statusIndicator[data-connected='true'] {
+  color: var(--color-accent-emerald);
+}
+
+.statusIcon {
+  width: 12px;
+  height: 12px;
+}
+
+.activityBadge {
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-full);
+  background-color: color-mix(in srgb, var(--color-bg-elevated) 60%, transparent);
+  color: var(--color-text-muted);
+  transition: all var(--transition-fast);
+}
+
+.activityBadge[data-status='active'] {
+  background-color: color-mix(in srgb, var(--color-accent-amber) 20%, transparent);
+  color: var(--color-accent-amber);
+}
+
+/* ── Close button ───────────────────────────────────────── */
+
+.closeBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-1);
+  border: none;
+  background: none;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: all var(--transition-fast);
+}
+
+.closeBtn:hover {
+  color: var(--color-text-primary);
+  background-color: color-mix(in srgb, var(--color-bg-elevated) 60%, transparent);
+}
+
+.closeIcon {
+  width: 14px;
+  height: 14px;
+}
+
+/* ── Messages container ─────────────────────────────────── */
+
+.messagesContainer {
+  flex: 1;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: var(--space-4);
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-bg-elevated) transparent;
+}
+
+.messagesInner {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+/* ── Empty state ────────────────────────────────────────── */
+
+.emptyState {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-8);
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+  color: var(--color-text-faint);
+  text-align: center;
+}
+
+/* ── Scroll to bottom ───────────────────────────────────── */
+
+.scrollToBottom {
+  position: sticky;
+  bottom: var(--space-2);
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  background-color: var(--color-bg-secondary);
+  color: var(--color-text-secondary);
+  font-size: var(--text-xs);
+  cursor: pointer;
+  box-shadow: var(--shadow-lg);
+  transition: all var(--transition-fast);
+  z-index: 10;
+}
+
+.scrollToBottom:hover {
+  background-color: var(--color-bg-tertiary);
+  color: var(--color-text-primary);
+}
+
+.scrollIcon {
+  width: 12px;
+  height: 12px;
+}
+
+.scrollBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.1rem;
+  height: 1.1rem;
+  padding: 0 var(--space-1);
+  border-radius: var(--radius-full);
+  background-color: var(--color-brand);
+  color: white;
+  font-size: 10px;
+  font-weight: 700;
+}

--- a/web/src/modules/shared/components/SessionChat/AgentDetailPanel/AgentDetailPanel.test.tsx
+++ b/web/src/modules/shared/components/SessionChat/AgentDetailPanel/AgentDetailPanel.test.tsx
@@ -1,0 +1,200 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { AgentDetailPanel } from './AgentDetailPanel';
+import type { ParticipantMeta, SkuldChatMessage } from '@/modules/shared/hooks/useSkuldChat';
+
+// ── Mock useAgentDetail ───────────────────────────────────────────────
+
+vi.mock('@/modules/shared/hooks/useAgentDetail', () => ({
+  useAgentDetail: vi.fn(),
+}));
+
+// ── Mock child message components ─────────────────────────────────────
+
+vi.mock('../ChatMessages', () => ({
+  AssistantMessage: ({ message }: { message: SkuldChatMessage }) => (
+    <div data-testid="assistant-message">{message.content}</div>
+  ),
+  StreamingMessage: ({ content }: { content: string }) => (
+    <div data-testid="streaming-message">{content}</div>
+  ),
+  SystemMessage: ({ message }: { message: SkuldChatMessage }) => (
+    <div data-testid="system-message">{message.content}</div>
+  ),
+  UserMessage: ({ message }: { message: SkuldChatMessage }) => (
+    <div data-testid="user-message">{message.content}</div>
+  ),
+}));
+
+import { useAgentDetail } from '@/modules/shared/hooks/useAgentDetail';
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function makeParticipant(overrides: Partial<ParticipantMeta> = {}): ParticipantMeta {
+  return {
+    peerId: 'ravn-1',
+    persona: 'Ravn Alpha',
+    color: 'cyan',
+    participantType: 'ravn',
+    gatewayUrl: 'http://ravn-1:8080',
+    ...overrides,
+  };
+}
+
+function makeMessage(overrides: Partial<SkuldChatMessage> = {}): SkuldChatMessage {
+  return {
+    id: 'msg-1',
+    role: 'assistant',
+    content: 'Thinking about it',
+    createdAt: new Date(),
+    status: 'complete',
+    ...overrides,
+  };
+}
+
+function setupDetailMock(options: {
+  messages?: SkuldChatMessage[];
+  connected?: boolean;
+  isRunning?: boolean;
+} = {}) {
+  vi.mocked(useAgentDetail).mockReturnValue({
+    messages: options.messages ?? [],
+    connected: options.connected ?? false,
+    isRunning: options.isRunning ?? false,
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe('AgentDetailPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Header', () => {
+    it('renders persona name', () => {
+      setupDetailMock();
+      render(<AgentDetailPanel participant={makeParticipant()} onClose={vi.fn()} />);
+      expect(screen.getByTestId('agent-persona-name')).toHaveTextContent('Ravn Alpha');
+    });
+
+    it('renders close button', () => {
+      setupDetailMock();
+      render(<AgentDetailPanel participant={makeParticipant()} onClose={vi.fn()} />);
+      expect(screen.getByTestId('agent-detail-close')).toBeInTheDocument();
+    });
+
+    it('calls onClose when close button is clicked', () => {
+      setupDetailMock();
+      const onClose = vi.fn();
+      render(<AgentDetailPanel participant={makeParticipant()} onClose={onClose} />);
+      fireEvent.click(screen.getByTestId('agent-detail-close'));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClose when Escape key is pressed', () => {
+      setupDetailMock();
+      const onClose = vi.fn();
+      render(<AgentDetailPanel participant={makeParticipant()} onClose={onClose} />);
+      fireEvent.keyDown(document, { key: 'Escape' });
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows idle activity status when not running', () => {
+      setupDetailMock({ isRunning: false });
+      render(<AgentDetailPanel participant={makeParticipant()} onClose={vi.fn()} />);
+      expect(screen.getByTestId('agent-activity-status')).toHaveTextContent('idle');
+    });
+
+    it('shows thinking activity status when running', () => {
+      setupDetailMock({ isRunning: true });
+      render(<AgentDetailPanel participant={makeParticipant()} onClose={vi.fn()} />);
+      expect(screen.getByTestId('agent-activity-status')).toHaveTextContent('thinking');
+    });
+  });
+
+  describe('Message rendering', () => {
+    it('shows empty state when no messages and disconnected', () => {
+      setupDetailMock({ messages: [], connected: false });
+      render(<AgentDetailPanel participant={makeParticipant()} onClose={vi.fn()} />);
+      expect(screen.getByTestId('agent-detail-empty')).toBeInTheDocument();
+    });
+
+    it('shows connecting message in empty state when disconnected', () => {
+      setupDetailMock({ messages: [], connected: false });
+      render(<AgentDetailPanel participant={makeParticipant()} onClose={vi.fn()} />);
+      expect(screen.getByTestId('agent-detail-empty')).toHaveTextContent('Connecting to agent');
+    });
+
+    it('shows waiting message in empty state when connected', () => {
+      setupDetailMock({ messages: [], connected: true });
+      render(<AgentDetailPanel participant={makeParticipant()} onClose={vi.fn()} />);
+      expect(screen.getByTestId('agent-detail-empty')).toHaveTextContent('Waiting for agent');
+    });
+
+    it('renders assistant messages', () => {
+      const msg = makeMessage({ role: 'assistant', content: 'I have a plan', status: 'complete' });
+      setupDetailMock({ messages: [msg] });
+      render(<AgentDetailPanel participant={makeParticipant()} onClose={vi.fn()} />);
+      expect(screen.getByTestId('assistant-message')).toHaveTextContent('I have a plan');
+    });
+
+    it('renders streaming messages for running status', () => {
+      const msg = makeMessage({ role: 'assistant', content: 'Still thinking', status: 'running' });
+      setupDetailMock({ messages: [msg] });
+      render(<AgentDetailPanel participant={makeParticipant()} onClose={vi.fn()} />);
+      expect(screen.getByTestId('streaming-message')).toBeInTheDocument();
+    });
+
+    it('renders user messages', () => {
+      const msg = makeMessage({ role: 'user', content: 'Go do the task', status: 'complete' });
+      setupDetailMock({ messages: [msg] });
+      render(<AgentDetailPanel participant={makeParticipant()} onClose={vi.fn()} />);
+      expect(screen.getByTestId('user-message')).toHaveTextContent('Go do the task');
+    });
+
+    it('filters out empty complete assistant messages', () => {
+      const msg = makeMessage({ role: 'assistant', content: '   ', status: 'complete' });
+      setupDetailMock({ messages: [msg] });
+      render(<AgentDetailPanel participant={makeParticipant()} onClose={vi.fn()} />);
+      expect(screen.queryByTestId('assistant-message')).not.toBeInTheDocument();
+      expect(screen.getByTestId('agent-detail-empty')).toBeInTheDocument();
+    });
+
+    it('filters out system role messages', () => {
+      const msg = makeMessage({ role: 'system', content: 'Session started', status: 'complete' });
+      setupDetailMock({ messages: [msg] });
+      render(<AgentDetailPanel participant={makeParticipant()} onClose={vi.fn()} />);
+      // System role messages are filtered out entirely (not shown as system messages)
+      expect(screen.queryByTestId('system-message')).not.toBeInTheDocument();
+    });
+
+    it('renders system metadata messages with SystemMessage component', () => {
+      const msg = makeMessage({
+        role: 'assistant',
+        content: 'hook event',
+        status: 'complete',
+        metadata: { messageType: 'system' },
+      });
+      setupDetailMock({ messages: [msg] });
+      render(<AgentDetailPanel participant={makeParticipant()} onClose={vi.fn()} />);
+      expect(screen.getByTestId('system-message')).toBeInTheDocument();
+    });
+  });
+
+  describe('with different participant colors', () => {
+    it('renders the panel for amber participants', () => {
+      setupDetailMock();
+      const participant = makeParticipant({ color: 'amber', persona: 'Amber Agent' });
+      render(<AgentDetailPanel participant={participant} onClose={vi.fn()} />);
+      expect(screen.getByTestId('agent-persona-name')).toHaveTextContent('Amber Agent');
+    });
+
+    it('renders the panel for participants with unknown colors', () => {
+      setupDetailMock();
+      const participant = makeParticipant({ color: 'unknown-color', persona: 'Mystery Agent' });
+      render(<AgentDetailPanel participant={participant} onClose={vi.fn()} />);
+      expect(screen.getByTestId('agent-persona-name')).toHaveTextContent('Mystery Agent');
+    });
+  });
+});

--- a/web/src/modules/shared/components/SessionChat/AgentDetailPanel/AgentDetailPanel.test.tsx
+++ b/web/src/modules/shared/components/SessionChat/AgentDetailPanel/AgentDetailPanel.test.tsx
@@ -102,6 +102,30 @@ describe('AgentDetailPanel', () => {
       expect(onClose).toHaveBeenCalledTimes(1);
     });
 
+    it('does not call onClose when Escape is pressed inside an input', () => {
+      setupDetailMock();
+      const onClose = vi.fn();
+      render(<AgentDetailPanel participant={makeParticipant()} onClose={onClose} />);
+      const input = document.createElement('input');
+      document.body.appendChild(input);
+      input.focus();
+      fireEvent.keyDown(input, { key: 'Escape', target: input });
+      expect(onClose).not.toHaveBeenCalled();
+      document.body.removeChild(input);
+    });
+
+    it('does not call onClose when Escape is pressed inside a textarea', () => {
+      setupDetailMock();
+      const onClose = vi.fn();
+      render(<AgentDetailPanel participant={makeParticipant()} onClose={onClose} />);
+      const textarea = document.createElement('textarea');
+      document.body.appendChild(textarea);
+      textarea.focus();
+      fireEvent.keyDown(textarea, { key: 'Escape', target: textarea });
+      expect(onClose).not.toHaveBeenCalled();
+      document.body.removeChild(textarea);
+    });
+
     it('shows idle activity status when not running', () => {
       setupDetailMock({ isRunning: false });
       render(<AgentDetailPanel participant={makeParticipant()} onClose={vi.fn()} />);

--- a/web/src/modules/shared/components/SessionChat/AgentDetailPanel/AgentDetailPanel.test.tsx
+++ b/web/src/modules/shared/components/SessionChat/AgentDetailPanel/AgentDetailPanel.test.tsx
@@ -52,11 +52,13 @@ function makeMessage(overrides: Partial<SkuldChatMessage> = {}): SkuldChatMessag
   };
 }
 
-function setupDetailMock(options: {
-  messages?: SkuldChatMessage[];
-  connected?: boolean;
-  isRunning?: boolean;
-} = {}) {
+function setupDetailMock(
+  options: {
+    messages?: SkuldChatMessage[];
+    connected?: boolean;
+    isRunning?: boolean;
+  } = {}
+) {
   vi.mocked(useAgentDetail).mockReturnValue({
     messages: options.messages ?? [],
     connected: options.connected ?? false,

--- a/web/src/modules/shared/components/SessionChat/AgentDetailPanel/AgentDetailPanel.tsx
+++ b/web/src/modules/shared/components/SessionChat/AgentDetailPanel/AgentDetailPanel.tsx
@@ -1,0 +1,207 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { X, Wifi, WifiOff, ArrowDownIcon } from 'lucide-react';
+import { cn } from '@/utils';
+import type { ParticipantMeta } from '@/modules/shared/hooks/useSkuldChat';
+import { useAgentDetail } from '@/modules/shared/hooks/useAgentDetail';
+import { AssistantMessage, StreamingMessage, SystemMessage, UserMessage } from '../ChatMessages';
+import styles from './AgentDetailPanel.module.css';
+
+const SCROLL_THRESHOLD = 150;
+
+const COLOR_MAP: Record<string, string> = {
+  amber: 'var(--color-accent-amber)',
+  cyan: 'var(--color-accent-cyan)',
+  emerald: 'var(--color-accent-emerald)',
+  purple: 'var(--color-accent-purple)',
+  red: 'var(--color-accent-red)',
+  indigo: 'var(--color-accent-indigo)',
+  orange: 'var(--color-accent-orange)',
+};
+
+function resolveColor(color: string): string {
+  return COLOR_MAP[color] ?? 'var(--color-text-secondary)';
+}
+
+interface AgentDetailPanelProps {
+  /** The participant whose event stream should be shown */
+  participant: ParticipantMeta;
+  /** Called when the close button is pressed or Escape is pressed */
+  onClose: () => void;
+}
+
+/**
+ * Slide-out right panel that displays the full event stream (thinking blocks,
+ * tool calls, streaming messages) for a single Ravn agent.
+ *
+ * Connects to the agent's gateway WebSocket via `useAgentDetail` and renders
+ * using the same shared message components as the main chat pane.
+ */
+export function AgentDetailPanel({ participant, onClose }: AgentDetailPanelProps) {
+  const { messages, connected, isRunning } = useAgentDetail(participant.gatewayUrl ?? null);
+
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const isNearBottomRef = useRef(true);
+  const prevCountRef = useRef(0);
+  const [showScrollBtn, setShowScrollBtn] = useState(false);
+  const [newCount, setNewCount] = useState(0);
+
+  const accentColor = resolveColor(participant.color);
+
+  // Determine activity status label
+  const activityStatus = isRunning ? 'active' : 'idle';
+
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
+    messagesEndRef.current?.scrollIntoView?.({ behavior });
+    setNewCount(0);
+  }, []);
+
+  // Track scroll position
+  useEffect(() => {
+    const el = scrollContainerRef.current;
+    if (!el) return;
+
+    const handleScroll = () => {
+      const dist = el.scrollHeight - el.scrollTop - el.clientHeight;
+      isNearBottomRef.current = dist <= SCROLL_THRESHOLD;
+      setShowScrollBtn(dist > SCROLL_THRESHOLD * 2);
+      if (isNearBottomRef.current) setNewCount(0);
+    };
+
+    el.addEventListener('scroll', handleScroll, { passive: true });
+    return () => el.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  // Auto-scroll on new messages
+  useEffect(() => {
+    const count = messages.length;
+    const delta = count - prevCountRef.current;
+    prevCountRef.current = count;
+
+    if (delta === 0) return;
+
+    if (isNearBottomRef.current) {
+      messagesEndRef.current?.scrollIntoView?.({ behavior: 'smooth' });
+      return;
+    }
+
+    setNewCount(prev => prev + delta);
+  }, [messages.length]);
+
+  // Close on Escape key
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [onClose]);
+
+  const visibleMessages = messages.filter(m => {
+    if (m.role === 'system') return false;
+    if (m.role === 'assistant' && m.status === 'complete' && !m.content.trim()) return false;
+    return true;
+  });
+
+  return (
+    <div className={styles.panel} data-testid="agent-detail-panel">
+      {/* ── Header ── */}
+      <div className={styles.header}>
+        <div className={styles.headerLeft}>
+          <span
+            className={styles.personaDot}
+            style={{ '--agent-color': accentColor } as React.CSSProperties}
+          />
+          <span
+            className={styles.personaName}
+            style={{ '--agent-color': accentColor } as React.CSSProperties}
+            data-testid="agent-persona-name"
+          >
+            {participant.persona}
+          </span>
+        </div>
+
+        <div className={styles.headerRight}>
+          <div className={styles.statusIndicator} data-connected={connected}>
+            {connected ? (
+              <Wifi className={styles.statusIcon} />
+            ) : (
+              <WifiOff className={styles.statusIcon} />
+            )}
+          </div>
+
+          <span
+            className={styles.activityBadge}
+            data-status={activityStatus}
+            data-testid="agent-activity-status"
+          >
+            {isRunning ? 'thinking' : 'idle'}
+          </span>
+
+          <button
+            type="button"
+            className={styles.closeBtn}
+            onClick={onClose}
+            aria-label="Close agent detail panel"
+            data-testid="agent-detail-close"
+          >
+            <X className={styles.closeIcon} />
+          </button>
+        </div>
+      </div>
+
+      {/* ── Messages ── */}
+      <div className={styles.messagesContainer} ref={scrollContainerRef}>
+        <div className={styles.messagesInner}>
+          {visibleMessages.length === 0 ? (
+            <div className={styles.emptyState} data-testid="agent-detail-empty">
+              {connected ? 'Waiting for agent activity…' : 'Connecting to agent…'}
+            </div>
+          ) : (
+            visibleMessages.map(msg => {
+              if (msg.metadata?.messageType === 'system') {
+                return <SystemMessage key={msg.id} message={msg} />;
+              }
+
+              if (msg.role === 'user') {
+                return <UserMessage key={msg.id} message={msg} />;
+              }
+
+              if (msg.status === 'running') {
+                return (
+                  <StreamingMessage
+                    key={msg.id}
+                    content={msg.content}
+                    parts={msg.parts}
+                  />
+                );
+              }
+
+              return (
+                <AssistantMessage
+                  key={msg.id}
+                  message={msg}
+                />
+              );
+            })
+          )}
+          <div ref={messagesEndRef} />
+        </div>
+
+        {showScrollBtn && (
+          <button
+            type="button"
+            className={styles.scrollToBottom}
+            onClick={() => scrollToBottom('smooth')}
+            aria-label="Scroll to bottom"
+          >
+            <ArrowDownIcon className={styles.scrollIcon} />
+            {newCount > 0 && (
+              <span className={styles.scrollBadge}>{newCount > 99 ? '99+' : newCount}</span>
+            )}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/modules/shared/components/SessionChat/AgentDetailPanel/AgentDetailPanel.tsx
+++ b/web/src/modules/shared/components/SessionChat/AgentDetailPanel/AgentDetailPanel.tsx
@@ -167,21 +167,10 @@ export function AgentDetailPanel({ participant, onClose }: AgentDetailPanelProps
               }
 
               if (msg.status === 'running') {
-                return (
-                  <StreamingMessage
-                    key={msg.id}
-                    content={msg.content}
-                    parts={msg.parts}
-                  />
-                );
+                return <StreamingMessage key={msg.id} content={msg.content} parts={msg.parts} />;
               }
 
-              return (
-                <AssistantMessage
-                  key={msg.id}
-                  message={msg}
-                />
-              );
+              return <AssistantMessage key={msg.id} message={msg} />;
             })
           )}
           <div ref={messagesEndRef} />

--- a/web/src/modules/shared/components/SessionChat/AgentDetailPanel/AgentDetailPanel.tsx
+++ b/web/src/modules/shared/components/SessionChat/AgentDetailPanel/AgentDetailPanel.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { X, Wifi, WifiOff, ArrowDownIcon } from 'lucide-react';
-import { cn } from '@/utils';
 import type { ParticipantMeta } from '@/modules/shared/hooks/useSkuldChat';
 import { useAgentDetail } from '@/modules/shared/hooks/useAgentDetail';
 import { AssistantMessage, StreamingMessage, SystemMessage, UserMessage } from '../ChatMessages';

--- a/web/src/modules/shared/components/SessionChat/AgentDetailPanel/AgentDetailPanel.tsx
+++ b/web/src/modules/shared/components/SessionChat/AgentDetailPanel/AgentDetailPanel.tsx
@@ -2,24 +2,11 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { X, Wifi, WifiOff, ArrowDownIcon } from 'lucide-react';
 import type { ParticipantMeta } from '@/modules/shared/hooks/useSkuldChat';
 import { useAgentDetail } from '@/modules/shared/hooks/useAgentDetail';
+import { resolveParticipantColor } from '@/modules/shared/utils/participantColor';
 import { AssistantMessage, StreamingMessage, SystemMessage, UserMessage } from '../ChatMessages';
 import styles from './AgentDetailPanel.module.css';
 
 const SCROLL_THRESHOLD = 150;
-
-const COLOR_MAP: Record<string, string> = {
-  amber: 'var(--color-accent-amber)',
-  cyan: 'var(--color-accent-cyan)',
-  emerald: 'var(--color-accent-emerald)',
-  purple: 'var(--color-accent-purple)',
-  red: 'var(--color-accent-red)',
-  indigo: 'var(--color-accent-indigo)',
-  orange: 'var(--color-accent-orange)',
-};
-
-function resolveColor(color: string): string {
-  return COLOR_MAP[color] ?? 'var(--color-text-secondary)';
-}
 
 interface AgentDetailPanelProps {
   /** The participant whose event stream should be shown */
@@ -45,7 +32,7 @@ export function AgentDetailPanel({ participant, onClose }: AgentDetailPanelProps
   const [showScrollBtn, setShowScrollBtn] = useState(false);
   const [newCount, setNewCount] = useState(0);
 
-  const accentColor = resolveColor(participant.color);
+  const accentColor = resolveParticipantColor(participant.color);
 
   // Determine activity status label
   const activityStatus = isRunning ? 'active' : 'idle';
@@ -87,10 +74,13 @@ export function AgentDetailPanel({ participant, onClose }: AgentDetailPanelProps
     setNewCount(prev => prev + delta);
   }, [messages.length]);
 
-  // Close on Escape key
+  // Close on Escape key (skip when focus is inside an input/textarea/select)
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
+      if (e.key !== 'Escape') return;
+      const tag = (e.target as HTMLElement)?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+      onClose();
     };
     document.addEventListener('keydown', handleKey);
     return () => document.removeEventListener('keydown', handleKey);

--- a/web/src/modules/shared/components/SessionChat/AgentDetailPanel/index.ts
+++ b/web/src/modules/shared/components/SessionChat/AgentDetailPanel/index.ts
@@ -1,0 +1,1 @@
+export { AgentDetailPanel } from './AgentDetailPanel';

--- a/web/src/modules/shared/components/SessionChat/RoomMessage/RoomMessage.module.css
+++ b/web/src/modules/shared/components/SessionChat/RoomMessage/RoomMessage.module.css
@@ -63,7 +63,9 @@
   cursor: pointer;
   border-radius: var(--radius-sm);
   opacity: 0;
-  transition: opacity var(--transition-fast), color var(--transition-fast);
+  transition:
+    opacity var(--transition-fast),
+    color var(--transition-fast);
 }
 
 .participantRow:hover .detailBtn {

--- a/web/src/modules/shared/components/SessionChat/RoomMessage/RoomMessage.module.css
+++ b/web/src/modules/shared/components/SessionChat/RoomMessage/RoomMessage.module.css
@@ -1,0 +1,86 @@
+.roomMessageWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+/* ── Participant label row ───────────────────────────────────── */
+
+.participantRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.participantLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 0;
+  border: none;
+  background: none;
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-text-muted);
+  cursor: default;
+}
+
+.participantLabelClickable {
+  cursor: pointer;
+  transition: color var(--transition-fast);
+}
+
+.participantLabelClickable:hover {
+  color: var(--participant-color, var(--color-text-secondary));
+}
+
+.participantLabelClickable[data-selected] {
+  color: var(--participant-color, var(--color-text-secondary));
+}
+
+.participantDot {
+  width: 6px;
+  height: 6px;
+  border-radius: var(--radius-full);
+  background-color: var(--participant-color, var(--color-text-muted));
+  flex-shrink: 0;
+}
+
+.participantName {
+  font-weight: 500;
+}
+
+/* ── View detail button ─────────────────────────────────────── */
+
+.detailBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-1);
+  border: none;
+  background: none;
+  color: var(--color-text-faint);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  opacity: 0;
+  transition: opacity var(--transition-fast), color var(--transition-fast);
+}
+
+.participantRow:hover .detailBtn {
+  opacity: 1;
+}
+
+.detailBtn:hover {
+  color: var(--color-text-secondary);
+  background-color: color-mix(in srgb, var(--color-bg-tertiary) 60%, transparent);
+}
+
+.detailBtnActive {
+  opacity: 1;
+  color: var(--color-accent-cyan);
+}
+
+.detailIcon {
+  width: 12px;
+  height: 12px;
+}

--- a/web/src/modules/shared/components/SessionChat/RoomMessage/RoomMessage.test.tsx
+++ b/web/src/modules/shared/components/SessionChat/RoomMessage/RoomMessage.test.tsx
@@ -162,18 +162,14 @@ describe('RoomMessage', () => {
     it('marks participant label as selected when selectedAgentId matches', () => {
       const participant = makeParticipant({ peerId: 'ravn-1' });
       const msg = makeMessage({ participant });
-      render(
-        <RoomMessage message={msg} onSelectAgent={vi.fn()} selectedAgentId="ravn-1" />
-      );
+      render(<RoomMessage message={msg} onSelectAgent={vi.fn()} selectedAgentId="ravn-1" />);
       expect(screen.getByTestId('participant-label')).toHaveAttribute('data-selected', 'true');
     });
 
     it('does not mark participant label as selected when id differs', () => {
       const participant = makeParticipant({ peerId: 'ravn-1' });
       const msg = makeMessage({ participant });
-      render(
-        <RoomMessage message={msg} onSelectAgent={vi.fn()} selectedAgentId="ravn-2" />
-      );
+      render(<RoomMessage message={msg} onSelectAgent={vi.fn()} selectedAgentId="ravn-2" />);
       expect(screen.getByTestId('participant-label')).not.toHaveAttribute('data-selected');
     });
   });

--- a/web/src/modules/shared/components/SessionChat/RoomMessage/RoomMessage.test.tsx
+++ b/web/src/modules/shared/components/SessionChat/RoomMessage/RoomMessage.test.tsx
@@ -1,0 +1,180 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { RoomMessage } from './RoomMessage';
+import type { SkuldChatMessage, ParticipantMeta } from '@/modules/shared/hooks/useSkuldChat';
+
+// ── Mock child message components ────────────────────────────────────
+
+vi.mock('../ChatMessages', () => ({
+  AssistantMessage: ({ message }: { message: SkuldChatMessage }) => (
+    <div data-testid="assistant-message">{message.content}</div>
+  ),
+  StreamingMessage: ({ content }: { content: string }) => (
+    <div data-testid="streaming-message">{content}</div>
+  ),
+  SystemMessage: ({ message }: { message: SkuldChatMessage }) => (
+    <div data-testid="system-message">{message.content}</div>
+  ),
+  UserMessage: ({ message }: { message: SkuldChatMessage }) => (
+    <div data-testid="user-message">{message.content}</div>
+  ),
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function makeParticipant(overrides: Partial<ParticipantMeta> = {}): ParticipantMeta {
+  return {
+    peerId: 'ravn-1',
+    persona: 'Ravn Alpha',
+    color: 'cyan',
+    participantType: 'ravn',
+    gatewayUrl: 'http://ravn-1:8080',
+    ...overrides,
+  };
+}
+
+function makeMessage(overrides: Partial<SkuldChatMessage> = {}): SkuldChatMessage {
+  return {
+    id: 'msg-1',
+    role: 'assistant',
+    content: 'Hello from agent',
+    createdAt: new Date(),
+    status: 'complete',
+    ...overrides,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe('RoomMessage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('participant label', () => {
+    it('renders participant label for Ravn messages', () => {
+      const msg = makeMessage({ participant: makeParticipant() });
+      render(<RoomMessage message={msg} />);
+      expect(screen.getByTestId('participant-label')).toBeInTheDocument();
+    });
+
+    it('shows persona name in label', () => {
+      const msg = makeMessage({ participant: makeParticipant({ persona: 'Agent X' }) });
+      render(<RoomMessage message={msg} />);
+      expect(screen.getByTestId('participant-label')).toHaveTextContent('Agent X');
+    });
+
+    it('does not render label for human participants', () => {
+      const msg = makeMessage({
+        participant: makeParticipant({ participantType: 'human' }),
+      });
+      render(<RoomMessage message={msg} />);
+      expect(screen.queryByTestId('participant-label')).not.toBeInTheDocument();
+    });
+
+    it('does not render label when no participant metadata', () => {
+      const msg = makeMessage({ participant: undefined });
+      render(<RoomMessage message={msg} />);
+      expect(screen.queryByTestId('participant-label')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('view detail button', () => {
+    it('renders detail button for Ravn with gatewayUrl and onSelectAgent', () => {
+      const msg = makeMessage({ participant: makeParticipant() });
+      render(<RoomMessage message={msg} onSelectAgent={vi.fn()} />);
+      expect(screen.getByTestId('view-agent-detail-btn')).toBeInTheDocument();
+    });
+
+    it('does not render detail button when no onSelectAgent prop', () => {
+      const msg = makeMessage({ participant: makeParticipant() });
+      render(<RoomMessage message={msg} />);
+      expect(screen.queryByTestId('view-agent-detail-btn')).not.toBeInTheDocument();
+    });
+
+    it('does not render detail button when participant has no gatewayUrl', () => {
+      const participant = makeParticipant({ gatewayUrl: undefined });
+      const msg = makeMessage({ participant });
+      render(<RoomMessage message={msg} onSelectAgent={vi.fn()} />);
+      expect(screen.queryByTestId('view-agent-detail-btn')).not.toBeInTheDocument();
+    });
+
+    it('calls onSelectAgent with peerId when detail button is clicked', () => {
+      const onSelectAgent = vi.fn();
+      const participant = makeParticipant({ peerId: 'ravn-42' });
+      const msg = makeMessage({ participant });
+      render(<RoomMessage message={msg} onSelectAgent={onSelectAgent} />);
+      fireEvent.click(screen.getByTestId('view-agent-detail-btn'));
+      expect(onSelectAgent).toHaveBeenCalledWith('ravn-42');
+    });
+
+    it('calls onSelectAgent when participant label is clicked', () => {
+      const onSelectAgent = vi.fn();
+      const participant = makeParticipant({ peerId: 'ravn-42' });
+      const msg = makeMessage({ participant });
+      render(<RoomMessage message={msg} onSelectAgent={onSelectAgent} />);
+      fireEvent.click(screen.getByTestId('participant-label'));
+      expect(onSelectAgent).toHaveBeenCalledWith('ravn-42');
+    });
+  });
+
+  describe('message component delegation', () => {
+    it('renders AssistantMessage for complete assistant role', () => {
+      const msg = makeMessage({ role: 'assistant', status: 'complete' });
+      render(<RoomMessage message={msg} />);
+      expect(screen.getByTestId('assistant-message')).toBeInTheDocument();
+    });
+
+    it('renders StreamingMessage for running assistant role', () => {
+      const msg = makeMessage({ role: 'assistant', status: 'running' });
+      render(<RoomMessage message={msg} />);
+      expect(screen.getByTestId('streaming-message')).toBeInTheDocument();
+    });
+
+    it('renders UserMessage for user role', () => {
+      const msg = makeMessage({ role: 'user', status: 'complete' });
+      render(<RoomMessage message={msg} />);
+      expect(screen.getByTestId('user-message')).toBeInTheDocument();
+    });
+
+    it('renders SystemMessage for system metadata messages', () => {
+      const msg = makeMessage({
+        role: 'assistant',
+        status: 'complete',
+        metadata: { messageType: 'system' },
+      });
+      render(<RoomMessage message={msg} />);
+      expect(screen.getByTestId('system-message')).toBeInTheDocument();
+    });
+  });
+
+  describe('participant color fallback', () => {
+    it('renders with unknown color falling back to secondary', () => {
+      const participant = makeParticipant({ color: 'unknown-color' });
+      const msg = makeMessage({ participant });
+      render(<RoomMessage message={msg} onSelectAgent={vi.fn()} />);
+      // Verify the label still renders even with an unknown color
+      expect(screen.getByTestId('participant-label')).toBeInTheDocument();
+    });
+  });
+
+  describe('selected state', () => {
+    it('marks participant label as selected when selectedAgentId matches', () => {
+      const participant = makeParticipant({ peerId: 'ravn-1' });
+      const msg = makeMessage({ participant });
+      render(
+        <RoomMessage message={msg} onSelectAgent={vi.fn()} selectedAgentId="ravn-1" />
+      );
+      expect(screen.getByTestId('participant-label')).toHaveAttribute('data-selected', 'true');
+    });
+
+    it('does not mark participant label as selected when id differs', () => {
+      const participant = makeParticipant({ peerId: 'ravn-1' });
+      const msg = makeMessage({ participant });
+      render(
+        <RoomMessage message={msg} onSelectAgent={vi.fn()} selectedAgentId="ravn-2" />
+      );
+      expect(screen.getByTestId('participant-label')).not.toHaveAttribute('data-selected');
+    });
+  });
+});

--- a/web/src/modules/shared/components/SessionChat/RoomMessage/RoomMessage.tsx
+++ b/web/src/modules/shared/components/SessionChat/RoomMessage/RoomMessage.tsx
@@ -1,0 +1,141 @@
+import { Eye } from 'lucide-react';
+import { cn } from '@/utils';
+import type { SkuldChatMessage, ParticipantMeta } from '@/modules/shared/hooks/useSkuldChat';
+import { UserMessage, AssistantMessage, StreamingMessage, SystemMessage } from '../ChatMessages';
+import styles from './RoomMessage.module.css';
+
+interface RoomMessageProps {
+  message: SkuldChatMessage;
+  /** Called when the user clicks the participant label or the detail button */
+  onSelectAgent?: (peerId: string) => void;
+  /** The peerId of the currently selected agent (for active styling) */
+  selectedAgentId?: string | null;
+  onCopy?: (text: string) => void;
+  onRegenerate?: (messageId: string) => void;
+  onBookmark?: (messageId: string, bookmarked: boolean) => void;
+  bookmarked?: boolean;
+}
+
+function participantColor(color: string): string {
+  const colorMap: Record<string, string> = {
+    amber: 'var(--color-accent-amber)',
+    cyan: 'var(--color-accent-cyan)',
+    emerald: 'var(--color-accent-emerald)',
+    purple: 'var(--color-accent-purple)',
+    red: 'var(--color-accent-red)',
+    indigo: 'var(--color-accent-indigo)',
+    orange: 'var(--color-accent-orange)',
+  };
+  return colorMap[color] ?? 'var(--color-text-secondary)';
+}
+
+interface ParticipantLabelProps {
+  participant: ParticipantMeta;
+  onSelectAgent?: (peerId: string) => void;
+  isSelected?: boolean;
+}
+
+function ParticipantLabel({ participant, onSelectAgent, isSelected }: ParticipantLabelProps) {
+  const color = participantColor(participant.color);
+  const isRavn = participant.participantType === 'ravn';
+  const canSelect = isRavn && participant.gatewayUrl && onSelectAgent;
+
+  const handleClick = () => {
+    onSelectAgent!(participant.peerId);
+  };
+
+  return (
+    <div className={styles.participantRow}>
+      <button
+        type="button"
+        className={cn(styles.participantLabel, canSelect && styles.participantLabelClickable)}
+        style={{ '--participant-color': color } as React.CSSProperties}
+        onClick={canSelect ? handleClick : undefined}
+        title={canSelect ? `View ${participant.persona} details` : participant.persona}
+        data-selected={isSelected || undefined}
+        data-testid="participant-label"
+      >
+        <span className={styles.participantDot} />
+        <span className={styles.participantName}>{participant.persona}</span>
+      </button>
+
+      {canSelect && (
+        <button
+          type="button"
+          className={cn(styles.detailBtn, isSelected && styles.detailBtnActive)}
+          onClick={handleClick}
+          title={`View ${participant.persona} event stream`}
+          aria-label={`View ${participant.persona} details`}
+          data-testid="view-agent-detail-btn"
+        >
+          <Eye className={styles.detailIcon} />
+        </button>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Wraps an existing message component with a participant label for room view.
+ *
+ * Only renders the label when the message carries participant metadata and the
+ * participant is a Ravn agent. Non-participant messages fall through to the
+ * standard message components directly.
+ */
+export function RoomMessage({
+  message,
+  onSelectAgent,
+  selectedAgentId,
+  onCopy,
+  onRegenerate,
+  onBookmark,
+  bookmarked = false,
+}: RoomMessageProps) {
+  const participant = message.participant;
+  const isSelectedAgent = participant ? selectedAgentId === participant.peerId : false;
+
+  const label =
+    participant?.participantType === 'ravn' ? (
+      <ParticipantLabel
+        participant={participant}
+        onSelectAgent={onSelectAgent}
+        isSelected={isSelectedAgent}
+      />
+    ) : null;
+
+  // System messages are always rendered without participant framing
+  if (message.metadata?.messageType === 'system') {
+    return <SystemMessage message={message} />;
+  }
+
+  if (message.role === 'user') {
+    return (
+      <div className={styles.roomMessageWrapper}>
+        {label}
+        <UserMessage message={message} />
+      </div>
+    );
+  }
+
+  if (message.status === 'running') {
+    return (
+      <div className={styles.roomMessageWrapper}>
+        {label}
+        <StreamingMessage content={message.content} parts={message.parts} />
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.roomMessageWrapper}>
+      {label}
+      <AssistantMessage
+        message={message}
+        onCopy={onCopy}
+        onRegenerate={onRegenerate}
+        onBookmark={onBookmark}
+        bookmarked={bookmarked}
+      />
+    </div>
+  );
+}

--- a/web/src/modules/shared/components/SessionChat/RoomMessage/RoomMessage.tsx
+++ b/web/src/modules/shared/components/SessionChat/RoomMessage/RoomMessage.tsx
@@ -1,6 +1,7 @@
 import { Eye } from 'lucide-react';
 import { cn } from '@/utils';
 import type { SkuldChatMessage, ParticipantMeta } from '@/modules/shared/hooks/useSkuldChat';
+import { resolveParticipantColor } from '@/modules/shared/utils/participantColor';
 import { UserMessage, AssistantMessage, StreamingMessage, SystemMessage } from '../ChatMessages';
 import styles from './RoomMessage.module.css';
 
@@ -16,19 +17,6 @@ interface RoomMessageProps {
   bookmarked?: boolean;
 }
 
-function participantColor(color: string): string {
-  const colorMap: Record<string, string> = {
-    amber: 'var(--color-accent-amber)',
-    cyan: 'var(--color-accent-cyan)',
-    emerald: 'var(--color-accent-emerald)',
-    purple: 'var(--color-accent-purple)',
-    red: 'var(--color-accent-red)',
-    indigo: 'var(--color-accent-indigo)',
-    orange: 'var(--color-accent-orange)',
-  };
-  return colorMap[color] ?? 'var(--color-text-secondary)';
-}
-
 interface ParticipantLabelProps {
   participant: ParticipantMeta;
   onSelectAgent?: (peerId: string) => void;
@@ -36,7 +24,7 @@ interface ParticipantLabelProps {
 }
 
 function ParticipantLabel({ participant, onSelectAgent, isSelected }: ParticipantLabelProps) {
-  const color = participantColor(participant.color);
+  const color = resolveParticipantColor(participant.color);
   const isRavn = participant.participantType === 'ravn';
   const canSelect = isRavn && participant.gatewayUrl && onSelectAgent;
 

--- a/web/src/modules/shared/components/SessionChat/RoomMessage/index.ts
+++ b/web/src/modules/shared/components/SessionChat/RoomMessage/index.ts
@@ -1,0 +1,1 @@
+export { RoomMessage } from './RoomMessage';

--- a/web/src/modules/shared/components/SessionChat/SessionChat.module.css
+++ b/web/src/modules/shared/components/SessionChat/SessionChat.module.css
@@ -1,8 +1,23 @@
+/* ── Outer grid — splits into two panes when detail panel is open ── */
+
+.outerGrid {
+  display: grid;
+  grid-template-columns: 1fr;
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+  transition: grid-template-columns 200ms ease;
+}
+
+.outerGrid[data-detail-open] {
+  grid-template-columns: 1fr 1fr;
+}
+
 .wrapper {
   display: flex;
   flex-direction: column;
-  flex: 1;
   min-height: 0;
+  min-width: 0;
   border-radius: var(--radius-lg);
   overflow: hidden;
   background-color: var(--color-bg-primary);

--- a/web/src/modules/shared/components/SessionChat/SessionChat.test.tsx
+++ b/web/src/modules/shared/components/SessionChat/SessionChat.test.tsx
@@ -8,7 +8,13 @@ vi.mock('@/modules/shared/hooks/useSkuldChat', () => ({
 
 // Mock RoomMessage and AgentDetailPanel so SessionChat tests stay focused
 vi.mock('./RoomMessage', () => ({
-  RoomMessage: ({ message, onSelectAgent }: { message: { id: string; content: string }; onSelectAgent?: (id: string) => void }) => (
+  RoomMessage: ({
+    message,
+    onSelectAgent,
+  }: {
+    message: { id: string; content: string };
+    onSelectAgent?: (id: string) => void;
+  }) => (
     <div data-testid="room-message" data-message-id={message.id}>
       {message.content}
       {onSelectAgent && (
@@ -25,7 +31,13 @@ vi.mock('./RoomMessage', () => ({
 }));
 
 vi.mock('./AgentDetailPanel', () => ({
-  AgentDetailPanel: ({ participant, onClose }: { participant: { peerId: string; persona: string }; onClose: () => void }) => (
+  AgentDetailPanel: ({
+    participant,
+    onClose,
+  }: {
+    participant: { peerId: string; persona: string };
+    onClose: () => void;
+  }) => (
     <div data-testid="agent-detail-panel" data-peer-id={participant.peerId}>
       {participant.persona}
       <button type="button" data-testid="detail-close" onClick={onClose}>

--- a/web/src/modules/shared/components/SessionChat/SessionChat.test.tsx
+++ b/web/src/modules/shared/components/SessionChat/SessionChat.test.tsx
@@ -6,6 +6,35 @@ vi.mock('@/modules/shared/hooks/useSkuldChat', () => ({
   useSkuldChat: vi.fn(),
 }));
 
+// Mock RoomMessage and AgentDetailPanel so SessionChat tests stay focused
+vi.mock('./RoomMessage', () => ({
+  RoomMessage: ({ message, onSelectAgent }: { message: { id: string; content: string }; onSelectAgent?: (id: string) => void }) => (
+    <div data-testid="room-message" data-message-id={message.id}>
+      {message.content}
+      {onSelectAgent && (
+        <button
+          type="button"
+          data-testid="room-select-agent"
+          onClick={() => onSelectAgent('ravn-1')}
+        >
+          Select
+        </button>
+      )}
+    </div>
+  ),
+}));
+
+vi.mock('./AgentDetailPanel', () => ({
+  AgentDetailPanel: ({ participant, onClose }: { participant: { peerId: string; persona: string }; onClose: () => void }) => (
+    <div data-testid="agent-detail-panel" data-peer-id={participant.peerId}>
+      {participant.persona}
+      <button type="button" data-testid="detail-close" onClick={onClose}>
+        Close
+      </button>
+    </div>
+  ),
+}));
+
 import { useSkuldChat } from '@/modules/shared/hooks/useSkuldChat';
 import type {
   SkuldChatMessage,
@@ -627,5 +656,118 @@ describe('SessionChat', () => {
     expect(screen.getByTestId('rewind-files')).toBeInTheDocument();
     const stopBtn = screen.getByTestId('stop-btn');
     expect(stopBtn).not.toBeDisabled();
+  });
+
+  // ── Room session (multi-participant) ─────────────────────────
+
+  it('uses RoomMessage when messages have participant metadata', () => {
+    const messages: SkuldChatMessage[] = [
+      {
+        id: 'u1',
+        role: 'user',
+        content: 'User message',
+        createdAt: new Date(),
+        status: 'complete',
+        participant: {
+          peerId: 'ravn-1',
+          persona: 'Ravn Alpha',
+          color: 'cyan',
+          participantType: 'ravn',
+          gatewayUrl: 'http://ravn-1:8080',
+        },
+      },
+    ];
+    mockSkuldChat({ connected: true, messages });
+    render(<SessionChat url="wss://test/session" />);
+
+    expect(screen.getByTestId('room-message')).toBeInTheDocument();
+  });
+
+  it('renders AgentDetailPanel when an agent is selected via room message', () => {
+    const messages: SkuldChatMessage[] = [
+      {
+        id: 'msg-1',
+        role: 'assistant',
+        content: 'Agent response',
+        createdAt: new Date(),
+        status: 'complete',
+        participant: {
+          peerId: 'ravn-1',
+          persona: 'Ravn Alpha',
+          color: 'cyan',
+          participantType: 'ravn',
+          gatewayUrl: 'http://ravn-1:8080',
+        },
+      },
+    ];
+    mockSkuldChat({ connected: true, messages });
+    render(<SessionChat url="wss://test/session" />);
+
+    // Agent detail panel not shown yet
+    expect(screen.queryByTestId('agent-detail-panel')).not.toBeInTheDocument();
+
+    // Click the "Select" button in the RoomMessage mock to trigger onSelectAgent
+    fireEvent.click(screen.getByTestId('room-select-agent'));
+
+    // Panel should now appear
+    expect(screen.getByTestId('agent-detail-panel')).toBeInTheDocument();
+  });
+
+  it('closes AgentDetailPanel when onClose is called', () => {
+    const messages: SkuldChatMessage[] = [
+      {
+        id: 'msg-1',
+        role: 'assistant',
+        content: 'Agent response',
+        createdAt: new Date(),
+        status: 'complete',
+        participant: {
+          peerId: 'ravn-1',
+          persona: 'Ravn Alpha',
+          color: 'cyan',
+          participantType: 'ravn',
+          gatewayUrl: 'http://ravn-1:8080',
+        },
+      },
+    ];
+    mockSkuldChat({ connected: true, messages });
+    render(<SessionChat url="wss://test/session" />);
+
+    // Open the panel
+    fireEvent.click(screen.getByTestId('room-select-agent'));
+    expect(screen.getByTestId('agent-detail-panel')).toBeInTheDocument();
+
+    // Close via the panel's close button
+    fireEvent.click(screen.getByTestId('detail-close'));
+    expect(screen.queryByTestId('agent-detail-panel')).not.toBeInTheDocument();
+  });
+
+  it('toggles agent selection when same agent is clicked twice', () => {
+    const messages: SkuldChatMessage[] = [
+      {
+        id: 'msg-1',
+        role: 'assistant',
+        content: 'Agent response',
+        createdAt: new Date(),
+        status: 'complete',
+        participant: {
+          peerId: 'ravn-1',
+          persona: 'Ravn Alpha',
+          color: 'cyan',
+          participantType: 'ravn',
+          gatewayUrl: 'http://ravn-1:8080',
+        },
+      },
+    ];
+    mockSkuldChat({ connected: true, messages });
+    render(<SessionChat url="wss://test/session" />);
+
+    // Select once — panel opens
+    fireEvent.click(screen.getByTestId('room-select-agent'));
+    expect(screen.getByTestId('agent-detail-panel')).toBeInTheDocument();
+
+    // Select same agent again — panel closes (toggle)
+    fireEvent.click(screen.getByTestId('room-select-agent'));
+    expect(screen.queryByTestId('agent-detail-panel')).not.toBeInTheDocument();
   });
 });

--- a/web/src/modules/shared/components/SessionChat/SessionChat.tsx
+++ b/web/src/modules/shared/components/SessionChat/SessionChat.tsx
@@ -322,126 +322,160 @@ export function SessionChat({
       className={cn(styles.outerGrid, className)}
       data-detail-open={selectedParticipant ? 'true' : undefined}
     >
-    <div className={styles.wrapper}>
-      <div className={styles.toolbar}>
-        <div className={styles.toolbarLeft}>
-          <div className={styles.statusIndicator} data-connected={connected}>
-            {connected ? (
-              <Wifi className={styles.statusIcon} />
-            ) : (
-              <WifiOff className={styles.statusIcon} />
-            )}
-            <span>{connected ? 'Connected' : 'Disconnected'}</span>
-          </div>
-          <span className={styles.messageCount}>
-            {visibleMessages.length} message{visibleMessages.length !== 1 ? 's' : ''}
-          </span>
-        </div>
-
-        {connected && (
-          <div className={styles.toolbarRight}>
-            <div className={styles.controlGroup}>
-              {capabilities.set_model && (
-                <button
-                  type="button"
-                  className={styles.controlBtn}
-                  onClick={() => setShowModelInput(prev => !prev)}
-                  title="Switch model"
-                  data-testid="model-switch-toggle"
-                >
-                  <BrainCircuitIcon className={styles.controlIcon} />
-                </button>
+      <div className={styles.wrapper}>
+        <div className={styles.toolbar}>
+          <div className={styles.toolbarLeft}>
+            <div className={styles.statusIndicator} data-connected={connected}>
+              {connected ? (
+                <Wifi className={styles.statusIcon} />
+              ) : (
+                <WifiOff className={styles.statusIcon} />
               )}
+              <span>{connected ? 'Connected' : 'Disconnected'}</span>
+            </div>
+            <span className={styles.messageCount}>
+              {visibleMessages.length} message{visibleMessages.length !== 1 ? 's' : ''}
+            </span>
+          </div>
 
-              {capabilities.set_thinking_tokens && (
-                <div className={styles.thinkingWrapper}>
+          {connected && (
+            <div className={styles.toolbarRight}>
+              <div className={styles.controlGroup}>
+                {capabilities.set_model && (
                   <button
                     type="button"
                     className={styles.controlBtn}
-                    onClick={() => setShowThinkingMenu(prev => !prev)}
-                    title="Set thinking budget"
-                    data-testid="thinking-budget-toggle"
+                    onClick={() => setShowModelInput(prev => !prev)}
+                    title="Switch model"
+                    data-testid="model-switch-toggle"
                   >
-                    <span className={styles.controlLabel}>Thinking</span>
+                    <BrainCircuitIcon className={styles.controlIcon} />
                   </button>
-                  {showThinkingMenu && (
-                    <div className={styles.thinkingMenu} data-testid="thinking-menu">
-                      {THINKING_PRESETS.map(preset => (
-                        <button
-                          key={preset.value}
-                          type="button"
-                          className={styles.thinkingOption}
-                          onClick={() => handleThinkingSelect(preset.value)}
-                          data-testid={`thinking-${preset.label}`}
-                        >
-                          {preset.label}
-                        </button>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              )}
+                )}
 
-              {capabilities.rewind_files && (
-                <button
-                  type="button"
-                  className={styles.controlBtn}
-                  onClick={sendRewindFiles}
-                  title="Rewind files"
-                  data-testid="rewind-files"
-                >
-                  <RotateCcwIcon className={styles.controlIcon} />
-                </button>
-              )}
+                {capabilities.set_thinking_tokens && (
+                  <div className={styles.thinkingWrapper}>
+                    <button
+                      type="button"
+                      className={styles.controlBtn}
+                      onClick={() => setShowThinkingMenu(prev => !prev)}
+                      title="Set thinking budget"
+                      data-testid="thinking-budget-toggle"
+                    >
+                      <span className={styles.controlLabel}>Thinking</span>
+                    </button>
+                    {showThinkingMenu && (
+                      <div className={styles.thinkingMenu} data-testid="thinking-menu">
+                        {THINKING_PRESETS.map(preset => (
+                          <button
+                            key={preset.value}
+                            type="button"
+                            className={styles.thinkingOption}
+                            onClick={() => handleThinkingSelect(preset.value)}
+                            data-testid={`thinking-${preset.label}`}
+                          >
+                            {preset.label}
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {capabilities.rewind_files && (
+                  <button
+                    type="button"
+                    className={styles.controlBtn}
+                    onClick={sendRewindFiles}
+                    title="Rewind files"
+                    data-testid="rewind-files"
+                  >
+                    <RotateCcwIcon className={styles.controlIcon} />
+                  </button>
+                )}
+              </div>
             </div>
+          )}
+        </div>
+
+        {showModelInput && connected && capabilities.set_model && (
+          <div className={styles.modelInputBar} data-testid="model-input-bar">
+            <input
+              type="text"
+              className={styles.modelInput}
+              value={modelInput}
+              onChange={e => setModelInput(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter') handleModelSubmit();
+                if (e.key === 'Escape') setShowModelInput(false);
+              }}
+              placeholder="Model ID (e.g. claude-opus-4-6)"
+              autoFocus
+              aria-label="Model ID input"
+            />
+            <button
+              type="button"
+              className={styles.modelSubmitBtn}
+              onClick={handleModelSubmit}
+              data-testid="model-submit"
+            >
+              Switch
+            </button>
           </div>
         )}
-      </div>
 
-      {showModelInput && connected && capabilities.set_model && (
-        <div className={styles.modelInputBar} data-testid="model-input-bar">
-          <input
-            type="text"
-            className={styles.modelInput}
-            value={modelInput}
-            onChange={e => setModelInput(e.target.value)}
-            onKeyDown={e => {
-              if (e.key === 'Enter') handleModelSubmit();
-              if (e.key === 'Escape') setShowModelInput(false);
-            }}
-            placeholder="Model ID (e.g. claude-opus-4-6)"
-            autoFocus
-            aria-label="Model ID input"
-          />
-          <button
-            type="button"
-            className={styles.modelSubmitBtn}
-            onClick={handleModelSubmit}
-            data-testid="model-submit"
-          >
-            Switch
-          </button>
-        </div>
-      )}
+        {!historyLoaded && connected && (
+          <div className={styles.historyLoading} data-testid="history-loading">
+            Loading conversation...
+          </div>
+        )}
 
-      {!historyLoaded && connected && (
-        <div className={styles.historyLoading} data-testid="history-loading">
-          Loading conversation...
-        </div>
-      )}
+        {hasConversation ? (
+          <div className={styles.messagesContainer} ref={scrollContainerRef}>
+            <div className={styles.messagesInner}>
+              {visibleMessages.map(msg => {
+                // Room session messages — wrap with participant label and detail button
+                if (isRoomSession) {
+                  return (
+                    <RoomMessage
+                      key={msg.id}
+                      message={msg}
+                      onSelectAgent={handleSelectAgent}
+                      selectedAgentId={selectedAgentId}
+                      onCopy={handleCopy}
+                      onRegenerate={handleRegenerate}
+                      onBookmark={handleBookmark}
+                      bookmarked={(() => {
+                        try {
+                          return localStorage.getItem(`bookmark:${msg.id}`) === '1';
+                        } catch {
+                          return false;
+                        }
+                      })()}
+                    />
+                  );
+                }
 
-      {hasConversation ? (
-        <div className={styles.messagesContainer} ref={scrollContainerRef}>
-          <div className={styles.messagesInner}>
-            {visibleMessages.map(msg => {
-              // Room session messages — wrap with participant label and detail button
-              if (isRoomSession) {
+                // Single-agent session messages — standard rendering
+                // System messages rendered as compact inline notifications
+                if (msg.metadata?.messageType === 'system') {
+                  return <SystemMessage key={msg.id} message={msg} />;
+                }
+
+                if (msg.role === 'user') {
+                  return <UserMessage key={msg.id} message={msg} />;
+                }
+
+                // Streaming assistant message
+                if (msg.status === 'running') {
+                  return <StreamingMessage key={msg.id} content={msg.content} parts={msg.parts} />;
+                }
+
+                // Complete assistant message
                 return (
-                  <RoomMessage
+                  <AssistantMessage
                     key={msg.id}
                     message={msg}
-                    onSelectAgent={handleSelectAgent}
-                    selectedAgentId={selectedAgentId}
                     onCopy={handleCopy}
                     onRegenerate={handleRegenerate}
                     onBookmark={handleBookmark}
@@ -454,93 +488,56 @@ export function SessionChat({
                     })()}
                   />
                 );
-              }
-
-              // Single-agent session messages — standard rendering
-              // System messages rendered as compact inline notifications
-              if (msg.metadata?.messageType === 'system') {
-                return <SystemMessage key={msg.id} message={msg} />;
-              }
-
-              if (msg.role === 'user') {
-                return <UserMessage key={msg.id} message={msg} />;
-              }
-
-              // Streaming assistant message
-              if (msg.status === 'running') {
-                return (
-                  <StreamingMessage
-                    key={msg.id}
-                    content={msg.content}
-                    parts={msg.parts}
-                  />
-                );
-              }
-
-              // Complete assistant message
-              return (
-                <AssistantMessage
-                  key={msg.id}
-                  message={msg}
-                  onCopy={handleCopy}
-                  onRegenerate={handleRegenerate}
-                  onBookmark={handleBookmark}
-                  bookmarked={(() => {
-                    try {
-                      return localStorage.getItem(`bookmark:${msg.id}`) === '1';
-                    } catch {
-                      return false;
-                    }
-                  })()}
-                />
-              );
-            })}
-            <div ref={messagesEndRef} />
+              })}
+              <div ref={messagesEndRef} />
+            </div>
+            {showScrollBtn && (
+              <button
+                type="button"
+                className={styles.scrollToBottom}
+                onClick={() => scrollToBottom('smooth')}
+                aria-label="Scroll to bottom"
+              >
+                <ArrowDownIcon className={styles.scrollToBottomIcon} />
+                {newMessageCount > 0 && (
+                  <span className={styles.scrollToBottomBadge}>
+                    {newMessageCount > 99 ? '99+' : newMessageCount}
+                  </span>
+                )}
+              </button>
+            )}
           </div>
-          {showScrollBtn && (
-            <button
-              type="button"
-              className={styles.scrollToBottom}
-              onClick={() => scrollToBottom('smooth')}
-              aria-label="Scroll to bottom"
-            >
-              <ArrowDownIcon className={styles.scrollToBottomIcon} />
-              {newMessageCount > 0 && (
-                <span className={styles.scrollToBottomBadge}>
-                  {newMessageCount > 99 ? '99+' : newMessageCount}
-                </span>
-              )}
-            </button>
-          )}
-        </div>
-      ) : (
-        <SessionEmptyChat sessionName="Volundr" onSuggestionClick={text => handleSend(text, [])} />
-      )}
-
-      <div className={styles.inputArea}>
-        <div className={styles.inputInner}>
-          {pendingPermissions.length > 0 && (
-            <PermissionStack permissions={pendingPermissions} onRespond={handlePermissionRespond} />
-          )}
-          <ChatInput
-            onSend={handleSend}
-            isLoading={isRunning}
-            onStop={handleStop}
-            disabled={!connected}
-            stopDisabled={!capabilities.interrupt}
-            sessionHost={sessionHost}
-            chatEndpoint={chatEndpoint}
-            availableCommands={availableCommands}
+        ) : (
+          <SessionEmptyChat
+            sessionName="Volundr"
+            onSuggestionClick={text => handleSend(text, [])}
           />
+        )}
+
+        <div className={styles.inputArea}>
+          <div className={styles.inputInner}>
+            {pendingPermissions.length > 0 && (
+              <PermissionStack
+                permissions={pendingPermissions}
+                onRespond={handlePermissionRespond}
+              />
+            )}
+            <ChatInput
+              onSend={handleSend}
+              isLoading={isRunning}
+              onStop={handleStop}
+              disabled={!connected}
+              stopDisabled={!capabilities.interrupt}
+              sessionHost={sessionHost}
+              chatEndpoint={chatEndpoint}
+              availableCommands={availableCommands}
+            />
+          </div>
         </div>
       </div>
-    </div>
 
       {selectedParticipant && (
-        <AgentDetailPanel
-          participant={selectedParticipant}
-          onClose={handleCloseDetail}
-        />
+        <AgentDetailPanel participant={selectedParticipant} onClose={handleCloseDetail} />
       )}
     </div>
   );

--- a/web/src/modules/shared/components/SessionChat/SessionChat.tsx
+++ b/web/src/modules/shared/components/SessionChat/SessionChat.tsx
@@ -6,11 +6,14 @@ import type {
   PermissionBehavior,
   ContentBlock,
   AttachmentMeta,
+  ParticipantMeta,
 } from '@/modules/shared/hooks/useSkuldChat';
 import { cn } from '@/utils';
 import { UserMessage, AssistantMessage, StreamingMessage, SystemMessage } from './ChatMessages';
 import { ChatInput } from './ChatInput';
 import { SessionEmptyChat } from './ChatEmptyStates';
+import { RoomMessage } from './RoomMessage';
+import { AgentDetailPanel } from './AgentDetailPanel';
 import type { FileAttachment } from './useFileAttachments';
 import styles from './SessionChat.module.css';
 
@@ -65,12 +68,34 @@ export function SessionChat({
   const [showThinkingMenu, setShowThinkingMenu] = useState(false);
   const [showScrollBtn, setShowScrollBtn] = useState(false);
   const [newMessageCount, setNewMessageCount] = useState(0);
+  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const isNearBottomRef = useRef(true);
   const userSentRef = useRef(false);
   const prevMessageCountRef = useRef(0);
   const scrollLockUntilRef = useRef(0);
+
+  // Build a map of peerId → ParticipantMeta from all messages that carry participant data
+  const participantsMap = useMemo<Map<string, ParticipantMeta>>(() => {
+    const map = new Map<string, ParticipantMeta>();
+    for (const msg of messages) {
+      if (msg.participant) {
+        map.set(msg.participant.peerId, msg.participant);
+      }
+    }
+    return map;
+  }, [messages]);
+
+  const isRoomSession = participantsMap.size > 0;
+
+  const handleSelectAgent = useCallback((peerId: string) => {
+    setSelectedAgentId(prev => (prev === peerId ? null : peerId));
+  }, []);
+
+  const handleCloseDetail = useCallback(() => {
+    setSelectedAgentId(null);
+  }, []);
 
   // Show welcome when only system messages exist (no real user/assistant conversation)
   const hasConversation = useMemo(
@@ -290,8 +315,14 @@ export function SessionChat({
     onMessageCountChange?.(visibleMessages.length);
   }, [visibleMessages.length, onMessageCountChange]);
 
+  const selectedParticipant = selectedAgentId ? participantsMap.get(selectedAgentId) : undefined;
+
   return (
-    <div className={cn(styles.wrapper, className)}>
+    <div
+      className={cn(styles.outerGrid, className)}
+      data-detail-open={selectedParticipant ? 'true' : undefined}
+    >
+    <div className={styles.wrapper}>
       <div className={styles.toolbar}>
         <div className={styles.toolbarLeft}>
           <div className={styles.statusIndicator} data-connected={connected}>
@@ -403,6 +434,29 @@ export function SessionChat({
         <div className={styles.messagesContainer} ref={scrollContainerRef}>
           <div className={styles.messagesInner}>
             {visibleMessages.map(msg => {
+              // Room session messages — wrap with participant label and detail button
+              if (isRoomSession) {
+                return (
+                  <RoomMessage
+                    key={msg.id}
+                    message={msg}
+                    onSelectAgent={handleSelectAgent}
+                    selectedAgentId={selectedAgentId}
+                    onCopy={handleCopy}
+                    onRegenerate={handleRegenerate}
+                    onBookmark={handleBookmark}
+                    bookmarked={(() => {
+                      try {
+                        return localStorage.getItem(`bookmark:${msg.id}`) === '1';
+                      } catch {
+                        return false;
+                      }
+                    })()}
+                  />
+                );
+              }
+
+              // Single-agent session messages — standard rendering
               // System messages rendered as compact inline notifications
               if (msg.metadata?.messageType === 'system') {
                 return <SystemMessage key={msg.id} message={msg} />;
@@ -419,7 +473,6 @@ export function SessionChat({
                     key={msg.id}
                     content={msg.content}
                     parts={msg.parts}
-                    model={msg.metadata?.messageType !== 'system' ? undefined : undefined}
                   />
                 );
               }
@@ -481,6 +534,14 @@ export function SessionChat({
           />
         </div>
       </div>
+    </div>
+
+      {selectedParticipant && (
+        <AgentDetailPanel
+          participant={selectedParticipant}
+          onClose={handleCloseDetail}
+        />
+      )}
     </div>
   );
 }

--- a/web/src/modules/shared/hooks/useAgentDetail.test.ts
+++ b/web/src/modules/shared/hooks/useAgentDetail.test.ts
@@ -1,0 +1,154 @@
+import { renderHook } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { useAgentDetail } from './useAgentDetail';
+
+// ── Mock useSkuldChat ──────────────────────────────────────────────────
+
+vi.mock('./useSkuldChat', () => ({
+  useSkuldChat: vi.fn(),
+  DEFAULT_CAPABILITIES: {
+    send_message: true,
+    cli_websocket: false,
+    session_resume: false,
+    interrupt: false,
+    set_model: false,
+    set_thinking_tokens: false,
+    set_permission_mode: false,
+    rewind_files: false,
+    mcp_set_servers: false,
+    permission_requests: false,
+    slash_commands: false,
+    skills: false,
+  },
+}));
+
+// Mock chat store (required by useSkuldChat in non-mocked path)
+vi.mock('@/modules/shared/store/chat.store', () => ({
+  useChatStore: vi.fn(() => ({
+    getMessages: vi.fn(() => []),
+    setMessages: vi.fn(),
+    clearSession: vi.fn(),
+  })),
+}));
+
+import { useSkuldChat } from './useSkuldChat';
+
+const mockMessages = [
+  {
+    id: 'msg-1',
+    role: 'assistant' as const,
+    content: 'Hello',
+    createdAt: new Date(),
+    status: 'complete' as const,
+  },
+];
+
+function setupSkuldMock(options: { connected?: boolean; isRunning?: boolean } = {}) {
+  vi.mocked(useSkuldChat).mockReturnValue({
+    messages: mockMessages,
+    connected: options.connected ?? false,
+    isRunning: options.isRunning ?? false,
+    historyLoaded: true,
+    pendingPermissions: [],
+    availableCommands: [],
+    capabilities: {
+      send_message: true,
+      cli_websocket: false,
+      session_resume: false,
+      interrupt: false,
+      set_model: false,
+      set_thinking_tokens: false,
+      set_permission_mode: false,
+      rewind_files: false,
+      mcp_set_servers: false,
+      permission_requests: false,
+      slash_commands: false,
+      skills: false,
+    },
+    sendMessage: vi.fn(),
+    respondToPermission: vi.fn(),
+    sendInterrupt: vi.fn(),
+    sendSetModel: vi.fn(),
+    sendSetMaxThinkingTokens: vi.fn(),
+    sendRewindFiles: vi.fn(),
+    clearMessages: vi.fn(),
+  });
+}
+
+describe('useAgentDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('when gatewayUrl is null', () => {
+    it('returns empty messages', () => {
+      setupSkuldMock();
+      const { result } = renderHook(() => useAgentDetail(null));
+      expect(result.current.messages).toEqual([]);
+    });
+
+    it('returns connected: false', () => {
+      setupSkuldMock({ connected: true });
+      const { result } = renderHook(() => useAgentDetail(null));
+      expect(result.current.connected).toBe(false);
+    });
+
+    it('returns isRunning: false', () => {
+      setupSkuldMock({ isRunning: true });
+      const { result } = renderHook(() => useAgentDetail(null));
+      expect(result.current.isRunning).toBe(false);
+    });
+  });
+
+  describe('WebSocket URL construction', () => {
+    it('converts http:// to ws:// and appends /ws', () => {
+      setupSkuldMock({ connected: true });
+      renderHook(() => useAgentDetail('http://host:8080'));
+      expect(vi.mocked(useSkuldChat)).toHaveBeenCalledWith('ws://host:8080/ws');
+    });
+
+    it('converts https:// to wss:// and appends /ws', () => {
+      setupSkuldMock({ connected: true });
+      renderHook(() => useAgentDetail('https://host:8080'));
+      expect(vi.mocked(useSkuldChat)).toHaveBeenCalledWith('wss://host:8080/ws');
+    });
+
+    it('handles URL with trailing slash', () => {
+      setupSkuldMock({ connected: true });
+      renderHook(() => useAgentDetail('http://host:8080/'));
+      expect(vi.mocked(useSkuldChat)).toHaveBeenCalledWith('ws://host:8080/ws');
+    });
+
+    it('handles URL with existing path prefix', () => {
+      setupSkuldMock({ connected: true });
+      renderHook(() => useAgentDetail('http://host:8080/gateway'));
+      expect(vi.mocked(useSkuldChat)).toHaveBeenCalledWith('ws://host:8080/gateway/ws');
+    });
+
+    it('passes ws:// URLs through with /ws appended', () => {
+      setupSkuldMock({ connected: true });
+      renderHook(() => useAgentDetail('ws://host:8080'));
+      expect(vi.mocked(useSkuldChat)).toHaveBeenCalledWith('ws://host:8080/ws');
+    });
+  });
+
+  describe('when gatewayUrl is provided', () => {
+    it('returns messages from useSkuldChat', () => {
+      setupSkuldMock({ connected: true });
+      const { result } = renderHook(() => useAgentDetail('http://host:8080'));
+      expect(result.current.messages).toEqual(mockMessages);
+    });
+
+    it('returns connected state from useSkuldChat', () => {
+      setupSkuldMock({ connected: true });
+      const { result } = renderHook(() => useAgentDetail('http://host:8080'));
+      expect(result.current.connected).toBe(true);
+    });
+
+    it('returns isRunning state from useSkuldChat', () => {
+      setupSkuldMock({ isRunning: true });
+      const { result } = renderHook(() => useAgentDetail('http://host:8080'));
+      expect(result.current.isRunning).toBe(true);
+    });
+  });
+});

--- a/web/src/modules/shared/hooks/useAgentDetail.ts
+++ b/web/src/modules/shared/hooks/useAgentDetail.ts
@@ -1,0 +1,62 @@
+import { useMemo } from 'react';
+import { useSkuldChat } from './useSkuldChat';
+import type { SkuldChatMessage } from './useSkuldChat';
+
+export interface UseAgentDetailReturn {
+  readonly messages: readonly SkuldChatMessage[];
+  readonly connected: boolean;
+  readonly isRunning: boolean;
+}
+
+const EMPTY: UseAgentDetailReturn = {
+  messages: [],
+  connected: false,
+  isRunning: false,
+};
+
+/**
+ * Convert an HTTP(S) gateway URL to a WebSocket URL by appending /ws and
+ * swapping the scheme.  Returns null when gatewayUrl is null/empty.
+ *
+ * Examples:
+ *   http://host:8080  → ws://host:8080/ws
+ *   https://host:8080 → wss://host:8080/ws
+ *   ws://host:8080    → ws://host:8080/ws  (scheme already correct)
+ */
+function toWsUrl(gatewayUrl: string): string | null {
+  try {
+    const url = new URL(gatewayUrl);
+    if (url.protocol === 'http:') {
+      url.protocol = 'ws:';
+    } else if (url.protocol === 'https:') {
+      url.protocol = 'wss:';
+    }
+    // Append /ws path — strip any trailing slash first
+    url.pathname = url.pathname.replace(/\/$/, '') + '/ws';
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Thin wrapper around `useSkuldChat` scoped to a single Ravn agent gateway.
+ *
+ * Constructs the WebSocket URL from the HTTP gateway URL (http→ws, appending
+ * /ws) and returns the full event stream — thinking blocks, tool calls, and
+ * streaming messages — for display in the agent detail panel.
+ *
+ * Returns empty state when gatewayUrl is null (no agent selected).
+ */
+export function useAgentDetail(gatewayUrl: string | null): UseAgentDetailReturn {
+  const wsUrl = useMemo(() => {
+    if (!gatewayUrl) return null;
+    return toWsUrl(gatewayUrl);
+  }, [gatewayUrl]);
+
+  const { messages, connected, isRunning } = useSkuldChat(wsUrl);
+
+  if (!gatewayUrl) return EMPTY;
+
+  return { messages, connected, isRunning };
+}

--- a/web/src/modules/shared/utils/participantColor.test.ts
+++ b/web/src/modules/shared/utils/participantColor.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { resolveParticipantColor, PARTICIPANT_COLOR_MAP } from './participantColor';
+
+describe('resolveParticipantColor', () => {
+  it('resolves known colors to CSS vars', () => {
+    expect(resolveParticipantColor('amber')).toBe('var(--color-accent-amber)');
+    expect(resolveParticipantColor('cyan')).toBe('var(--color-accent-cyan)');
+    expect(resolveParticipantColor('emerald')).toBe('var(--color-accent-emerald)');
+    expect(resolveParticipantColor('purple')).toBe('var(--color-accent-purple)');
+    expect(resolveParticipantColor('red')).toBe('var(--color-accent-red)');
+    expect(resolveParticipantColor('indigo')).toBe('var(--color-accent-indigo)');
+    expect(resolveParticipantColor('orange')).toBe('var(--color-accent-orange)');
+  });
+
+  it('falls back to secondary text color for unknown colors', () => {
+    expect(resolveParticipantColor('unknown')).toBe('var(--color-text-secondary)');
+    expect(resolveParticipantColor('')).toBe('var(--color-text-secondary)');
+  });
+
+  it('PARTICIPANT_COLOR_MAP contains all expected keys', () => {
+    const keys = Object.keys(PARTICIPANT_COLOR_MAP);
+    expect(keys).toContain('amber');
+    expect(keys).toContain('cyan');
+    expect(keys).toContain('emerald');
+    expect(keys).toContain('purple');
+    expect(keys).toContain('red');
+    expect(keys).toContain('indigo');
+    expect(keys).toContain('orange');
+  });
+});

--- a/web/src/modules/shared/utils/participantColor.ts
+++ b/web/src/modules/shared/utils/participantColor.ts
@@ -1,0 +1,13 @@
+export const PARTICIPANT_COLOR_MAP: Record<string, string> = {
+  amber: 'var(--color-accent-amber)',
+  cyan: 'var(--color-accent-cyan)',
+  emerald: 'var(--color-accent-emerald)',
+  purple: 'var(--color-accent-purple)',
+  red: 'var(--color-accent-red)',
+  indigo: 'var(--color-accent-indigo)',
+  orange: 'var(--color-accent-orange)',
+};
+
+export function resolveParticipantColor(color: string): string {
+  return PARTICIPANT_COLOR_MAP[color] ?? 'var(--color-text-secondary)';
+}


### PR DESCRIPTION
## Summary

- **New hook `useAgentDetail`**: thin wrapper around `useSkuldChat` that converts an HTTP gateway URL to a WebSocket URL (`http→ws`, append `/ws`) and returns the full event stream for a Ravn agent. Returns empty state when no agent is selected.

- **New component `AgentDetailPanel`**: slide-out right panel showing full event stream for a selected Ravn. Header shows persona name with accent color, connection status (WiFi icon), activity badge (idle / thinking), and a close button. Body renders existing `AssistantMessage`, `StreamingMessage`, `ToolBlock`, and `SystemMessage` components — no new rendering primitives.

- **New component `RoomMessage`**: wrapper that adds a participant label (colored dot + persona name) and a hover-reveal "view details" eye button to any message in a room session. Clicking either the label or the eye button calls `onSelectAgent(peerId)`.

- **`SessionChat` changes**: adds `selectedAgentId` state, builds a `participantsMap` from message participant metadata, uses `RoomMessage` for all messages in room sessions, renders `AgentDetailPanel` for the selected agent. Escape key and close button both close the panel. Clicking the same agent again toggles the panel closed.

- **`SessionChat.module.css`**: adds `outerGrid` wrapper with `grid-template-columns: 1fr` (no panel) → `1fr 1fr` (panel open) with a 200ms CSS transition.

## Test plan

- [x] `useAgentDetail`: constructs correct WebSocket URLs from http/https/ws gateway URLs; returns empty state when null; relays messages/connected/isRunning from useSkuldChat
- [x] `AgentDetailPanel`: renders persona name; close button calls onClose; Escape key calls onClose; activity badge shows idle/thinking; message filtering; empty state text differs by connected state
- [x] `RoomMessage`: participant label rendered for Ravn only; detail button appears only when onSelectAgent + gatewayUrl provided; delegates to correct message component; selected styling
- [x] `SessionChat`: uses RoomMessage in room sessions; AgentDetailPanel opens on agent selection; panel closes via close button; toggle behavior
- [x] All 203 test files pass, 3135 tests green, coverage ≥ 85% on all metrics

## Linear ticket

[NIU-609](https://linear.app/niuu/issue/NIU-609)

> **Note**: Linear MCP server was not available in this environment. Please manually set ticket to "In Review" and add PR link comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)