### PR TITLE
feat(ravn): Personas tab with list, detail, and edit UI (NIU-608)

### DIFF
--- a/web/src/modules/ravn/api/client.test.ts
+++ b/web/src/modules/ravn/api/client.test.ts
@@ -53,7 +53,7 @@ describe('listPersonas', () => {
     const result = await listPersonas();
     expect(mockFetch).toHaveBeenCalledWith(
       expect.stringContaining('/personas?source=all'),
-      expect.any(Object),
+      expect.any(Object)
     );
     expect(result).toHaveLength(1);
   });
@@ -78,7 +78,7 @@ describe('listPersonas', () => {
     await listPersonas('builtin');
     expect(mockFetch).toHaveBeenCalledWith(
       expect.stringContaining('source=builtin'),
-      expect.any(Object),
+      expect.any(Object)
     );
   });
 
@@ -87,7 +87,7 @@ describe('listPersonas', () => {
     await listPersonas('custom');
     expect(mockFetch).toHaveBeenCalledWith(
       expect.stringContaining('source=custom'),
-      expect.any(Object),
+      expect.any(Object)
     );
   });
 });
@@ -98,7 +98,7 @@ describe('getPersona', () => {
     await getPersona('coding-agent');
     expect(mockFetch).toHaveBeenCalledWith(
       expect.stringContaining('/personas/coding-agent'),
-      expect.any(Object),
+      expect.any(Object)
     );
   });
 
@@ -128,7 +128,7 @@ describe('getPersonaYaml', () => {
     const result = await getPersonaYaml('coding-agent');
     expect(mockFetch).toHaveBeenCalledWith(
       expect.stringContaining('/personas/coding-agent/yaml'),
-      expect.any(Object),
+      expect.any(Object)
     );
     expect(result).toBe('name: coding-agent\n');
   });
@@ -157,7 +157,7 @@ describe('createPersona', () => {
     await createPersona(req);
     expect(mockFetch).toHaveBeenCalledWith(
       expect.stringContaining('/personas'),
-      expect.objectContaining({ method: 'POST' }),
+      expect.objectContaining({ method: 'POST' })
     );
   });
 
@@ -201,7 +201,7 @@ describe('updatePersona', () => {
     await updatePersona('coding-agent', req);
     expect(mockFetch).toHaveBeenCalledWith(
       expect.stringContaining('/personas/coding-agent'),
-      expect.objectContaining({ method: 'PUT' }),
+      expect.objectContaining({ method: 'PUT' })
     );
   });
 });
@@ -212,7 +212,7 @@ describe('deletePersona', () => {
     await deletePersona('my-agent');
     expect(mockFetch).toHaveBeenCalledWith(
       expect.stringContaining('/personas/my-agent'),
-      expect.objectContaining({ method: 'DELETE' }),
+      expect.objectContaining({ method: 'DELETE' })
     );
   });
 });
@@ -223,7 +223,7 @@ describe('forkPersona', () => {
     await forkPersona('coding-agent', { newName: 'my-fork' });
     expect(mockFetch).toHaveBeenCalledWith(
       expect.stringContaining('/personas/coding-agent/fork'),
-      expect.objectContaining({ method: 'POST' }),
+      expect.objectContaining({ method: 'POST' })
     );
   });
 

--- a/web/src/modules/ravn/api/client.test.ts
+++ b/web/src/modules/ravn/api/client.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  listPersonas,
+  getPersona,
+  getPersonaYaml,
+  createPersona,
+  updatePersona,
+  deletePersona,
+  forkPersona,
+} from './client';
+import type { PersonaCreateRequest } from './types';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+const rawSummary = {
+  name: 'coding-agent',
+  permission_mode: 'workspace-write',
+  allowed_tools: ['file', 'git'],
+  iteration_budget: 40,
+  is_builtin: true,
+  has_override: false,
+  produces_event: 'code.done',
+  consumes_events: ['task.assigned'],
+};
+
+const rawDetail = {
+  ...rawSummary,
+  system_prompt_template: 'You are a coder.',
+  forbidden_tools: ['cascade'],
+  llm: { primary_alias: 'balanced', thinking_enabled: true, max_tokens: 0 },
+  produces: { event_type: 'code.done', schema_def: {} },
+  consumes: { event_types: ['task.assigned'], injects: ['repo'] },
+  fan_in: { strategy: 'merge', contributes_to: '' },
+  yaml_source: '[built-in]',
+};
+
+function mockOk(data: unknown, status = 200) {
+  mockFetch.mockResolvedValue({
+    status,
+    ok: true,
+    json: async () => data,
+  });
+}
+
+describe('listPersonas', () => {
+  it('fetches all personas with source=all by default', async () => {
+    mockOk([rawSummary]);
+    const result = await listPersonas();
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/personas?source=all'),
+      expect.any(Object),
+    );
+    expect(result).toHaveLength(1);
+  });
+
+  it('transforms snake_case to camelCase', async () => {
+    mockOk([rawSummary]);
+    const result = await listPersonas();
+    expect(result[0]).toMatchObject({
+      name: 'coding-agent',
+      permissionMode: 'workspace-write',
+      allowedTools: ['file', 'git'],
+      iterationBudget: 40,
+      isBuiltin: true,
+      hasOverride: false,
+      producesEvent: 'code.done',
+      consumesEvents: ['task.assigned'],
+    });
+  });
+
+  it('fetches builtin personas with source=builtin', async () => {
+    mockOk([]);
+    await listPersonas('builtin');
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('source=builtin'),
+      expect.any(Object),
+    );
+  });
+
+  it('fetches custom personas with source=custom', async () => {
+    mockOk([]);
+    await listPersonas('custom');
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('source=custom'),
+      expect.any(Object),
+    );
+  });
+});
+
+describe('getPersona', () => {
+  it('fetches persona by name', async () => {
+    mockOk(rawDetail);
+    await getPersona('coding-agent');
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/personas/coding-agent'),
+      expect.any(Object),
+    );
+  });
+
+  it('transforms detail response to camelCase', async () => {
+    mockOk(rawDetail);
+    const result = await getPersona('coding-agent');
+    expect(result).toMatchObject({
+      name: 'coding-agent',
+      systemPromptTemplate: 'You are a coder.',
+      forbiddenTools: ['cascade'],
+      llm: { primaryAlias: 'balanced', thinkingEnabled: true, maxTokens: 0 },
+      produces: { eventType: 'code.done', schemaDef: {} },
+      consumes: { eventTypes: ['task.assigned'], injects: ['repo'] },
+      fanIn: { strategy: 'merge', contributesTo: '' },
+      yamlSource: '[built-in]',
+    });
+  });
+});
+
+describe('getPersonaYaml', () => {
+  it('fetches yaml endpoint', async () => {
+    mockFetch.mockResolvedValue({
+      status: 200,
+      ok: true,
+      json: async () => 'name: coding-agent\n',
+    });
+    const result = await getPersonaYaml('coding-agent');
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/personas/coding-agent/yaml'),
+      expect.any(Object),
+    );
+    expect(result).toBe('name: coding-agent\n');
+  });
+});
+
+describe('createPersona', () => {
+  const req: PersonaCreateRequest = {
+    name: 'new-agent',
+    systemPromptTemplate: 'You are helpful.',
+    allowedTools: ['file'],
+    forbiddenTools: [],
+    permissionMode: 'read-only',
+    iterationBudget: 10,
+    llmPrimaryAlias: 'balanced',
+    llmThinkingEnabled: false,
+    llmMaxTokens: 0,
+    producesEventType: '',
+    consumesEventTypes: [],
+    consumesInjects: [],
+    fanInStrategy: 'merge',
+    fanInContributesTo: '',
+  };
+
+  it('sends POST to /personas', async () => {
+    mockOk(rawDetail, 201);
+    await createPersona(req);
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/personas'),
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('converts camelCase request to snake_case body', async () => {
+    mockOk(rawDetail, 201);
+    await createPersona(req);
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body).toMatchObject({
+      name: 'new-agent',
+      system_prompt_template: 'You are helpful.',
+      allowed_tools: ['file'],
+      permission_mode: 'read-only',
+      iteration_budget: 10,
+      llm_primary_alias: 'balanced',
+      llm_thinking_enabled: false,
+      llm_max_tokens: 0,
+    });
+  });
+});
+
+describe('updatePersona', () => {
+  const req: PersonaCreateRequest = {
+    name: 'coding-agent',
+    systemPromptTemplate: 'Updated.',
+    allowedTools: [],
+    forbiddenTools: [],
+    permissionMode: '',
+    iterationBudget: 0,
+    llmPrimaryAlias: '',
+    llmThinkingEnabled: false,
+    llmMaxTokens: 0,
+    producesEventType: '',
+    consumesEventTypes: [],
+    consumesInjects: [],
+    fanInStrategy: 'merge',
+    fanInContributesTo: '',
+  };
+
+  it('sends PUT to /personas/:name', async () => {
+    mockOk(rawDetail);
+    await updatePersona('coding-agent', req);
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/personas/coding-agent'),
+      expect.objectContaining({ method: 'PUT' }),
+    );
+  });
+});
+
+describe('deletePersona', () => {
+  it('sends DELETE to /personas/:name', async () => {
+    mockFetch.mockResolvedValue({ status: 204, ok: true, json: async () => undefined });
+    await deletePersona('my-agent');
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/personas/my-agent'),
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+});
+
+describe('forkPersona', () => {
+  it('sends POST to /personas/:name/fork', async () => {
+    mockOk(rawDetail, 201);
+    await forkPersona('coding-agent', { newName: 'my-fork' });
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/personas/coding-agent/fork'),
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('sends new_name in request body', async () => {
+    mockOk(rawDetail, 201);
+    await forkPersona('coding-agent', { newName: 'my-fork' });
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.new_name).toBe('my-fork');
+  });
+});

--- a/web/src/modules/ravn/api/client.ts
+++ b/web/src/modules/ravn/api/client.ts
@@ -153,8 +153,14 @@ export async function createPersona(req: PersonaCreateRequest): Promise<PersonaD
 }
 
 /** PUT /personas/:name */
-export async function updatePersona(name: string, req: PersonaCreateRequest): Promise<PersonaDetail> {
-  const raw = await api.put<RawPersonaDetail>(`/personas/${encodeURIComponent(name)}`, toRequestBody(req));
+export async function updatePersona(
+  name: string,
+  req: PersonaCreateRequest
+): Promise<PersonaDetail> {
+  const raw = await api.put<RawPersonaDetail>(
+    `/personas/${encodeURIComponent(name)}`,
+    toRequestBody(req)
+  );
   return toDetail(raw);
 }
 

--- a/web/src/modules/ravn/api/client.ts
+++ b/web/src/modules/ravn/api/client.ts
@@ -1,0 +1,172 @@
+/**
+ * Ravn API client.
+ *
+ * Wraps the shared ApiClient for Ravn persona endpoints.
+ * All persona routes are under /api/v1/ravn.
+ */
+
+import { createApiClient } from '@/modules/shared/api/client';
+import type {
+  PersonaSummary,
+  PersonaDetail,
+  PersonaCreateRequest,
+  PersonaForkRequest,
+  PersonaFilter,
+} from './types';
+
+// ---------------------------------------------------------------------------
+// Internal raw types (snake_case server responses)
+// ---------------------------------------------------------------------------
+
+const api = createApiClient('/api/v1/ravn');
+
+interface RawPersonaLLM {
+  primary_alias: string;
+  thinking_enabled: boolean;
+  max_tokens: number;
+}
+
+interface RawPersonaProduces {
+  event_type: string;
+  schema_def: Record<string, unknown>;
+}
+
+interface RawPersonaConsumes {
+  event_types: string[];
+  injects: string[];
+}
+
+interface RawPersonaFanIn {
+  strategy: string;
+  contributes_to: string;
+}
+
+interface RawPersonaSummary {
+  name: string;
+  permission_mode: string;
+  allowed_tools: string[];
+  iteration_budget: number;
+  is_builtin: boolean;
+  has_override: boolean;
+  produces_event: string;
+  consumes_events: string[];
+}
+
+interface RawPersonaDetail extends RawPersonaSummary {
+  system_prompt_template: string;
+  forbidden_tools: string[];
+  llm: RawPersonaLLM;
+  produces: RawPersonaProduces;
+  consumes: RawPersonaConsumes;
+  fan_in: RawPersonaFanIn;
+  yaml_source: string;
+}
+
+// ---------------------------------------------------------------------------
+// Transform functions
+// ---------------------------------------------------------------------------
+
+function toSummary(raw: RawPersonaSummary): PersonaSummary {
+  return {
+    name: raw.name,
+    permissionMode: raw.permission_mode,
+    allowedTools: raw.allowed_tools,
+    iterationBudget: raw.iteration_budget,
+    isBuiltin: raw.is_builtin,
+    hasOverride: raw.has_override,
+    producesEvent: raw.produces_event,
+    consumesEvents: raw.consumes_events,
+  };
+}
+
+function toDetail(raw: RawPersonaDetail): PersonaDetail {
+  return {
+    ...toSummary(raw),
+    systemPromptTemplate: raw.system_prompt_template,
+    forbiddenTools: raw.forbidden_tools,
+    llm: {
+      primaryAlias: raw.llm.primary_alias,
+      thinkingEnabled: raw.llm.thinking_enabled,
+      maxTokens: raw.llm.max_tokens,
+    },
+    produces: {
+      eventType: raw.produces.event_type,
+      schemaDef: raw.produces.schema_def,
+    },
+    consumes: {
+      eventTypes: raw.consumes.event_types,
+      injects: raw.consumes.injects,
+    },
+    fanIn: {
+      strategy: raw.fan_in.strategy,
+      contributesTo: raw.fan_in.contributes_to,
+    },
+    yamlSource: raw.yaml_source,
+  };
+}
+
+function toRequestBody(req: PersonaCreateRequest): Record<string, unknown> {
+  return {
+    name: req.name,
+    system_prompt_template: req.systemPromptTemplate,
+    allowed_tools: req.allowedTools,
+    forbidden_tools: req.forbiddenTools,
+    permission_mode: req.permissionMode,
+    iteration_budget: req.iterationBudget,
+    llm_primary_alias: req.llmPrimaryAlias,
+    llm_thinking_enabled: req.llmThinkingEnabled,
+    llm_max_tokens: req.llmMaxTokens,
+    produces_event_type: req.producesEventType,
+    consumes_event_types: req.consumesEventTypes,
+    consumes_injects: req.consumesInjects,
+    fan_in_strategy: req.fanInStrategy,
+    fan_in_contributes_to: req.fanInContributesTo,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/** GET /personas?source= */
+export async function listPersonas(filter: PersonaFilter = 'all'): Promise<PersonaSummary[]> {
+  const source = filter === 'all' ? 'all' : filter === 'builtin' ? 'builtin' : 'custom';
+  const raw = await api.get<RawPersonaSummary[]>(`/personas?source=${source}`);
+  return raw.map(toSummary);
+}
+
+/** GET /personas/:name */
+export async function getPersona(name: string): Promise<PersonaDetail> {
+  const raw = await api.get<RawPersonaDetail>(`/personas/${encodeURIComponent(name)}`);
+  return toDetail(raw);
+}
+
+/** GET /personas/:name/yaml */
+export async function getPersonaYaml(name: string): Promise<string> {
+  return api.get<string>(`/personas/${encodeURIComponent(name)}/yaml`);
+}
+
+/** POST /personas */
+export async function createPersona(req: PersonaCreateRequest): Promise<PersonaDetail> {
+  const raw = await api.post<RawPersonaDetail>('/personas', toRequestBody(req));
+  return toDetail(raw);
+}
+
+/** PUT /personas/:name */
+export async function updatePersona(name: string, req: PersonaCreateRequest): Promise<PersonaDetail> {
+  const raw = await api.put<RawPersonaDetail>(`/personas/${encodeURIComponent(name)}`, toRequestBody(req));
+  return toDetail(raw);
+}
+
+/** DELETE /personas/:name */
+export async function deletePersona(name: string): Promise<void> {
+  await api.delete<void>(`/personas/${encodeURIComponent(name)}`);
+}
+
+/** POST /personas/:name/fork */
+export async function forkPersona(name: string, req: PersonaForkRequest): Promise<PersonaDetail> {
+  const raw = await api.post<RawPersonaDetail>(`/personas/${encodeURIComponent(name)}/fork`, {
+    new_name: req.newName,
+  });
+  return toDetail(raw);
+}

--- a/web/src/modules/ravn/api/client.ts
+++ b/web/src/modules/ravn/api/client.ts
@@ -130,8 +130,7 @@ function toRequestBody(req: PersonaCreateRequest): Record<string, unknown> {
 
 /** GET /personas?source= */
 export async function listPersonas(filter: PersonaFilter = 'all'): Promise<PersonaSummary[]> {
-  const source = filter === 'all' ? 'all' : filter === 'builtin' ? 'builtin' : 'custom';
-  const raw = await api.get<RawPersonaSummary[]>(`/personas?source=${source}`);
+  const raw = await api.get<RawPersonaSummary[]>(`/personas?source=${filter}`);
   return raw.map(toSummary);
 }
 

--- a/web/src/modules/ravn/api/types.ts
+++ b/web/src/modules/ravn/api/types.ts
@@ -1,0 +1,94 @@
+/**
+ * Ravn Persona domain types.
+ *
+ * Camel-case client representation of the snake_case server responses.
+ */
+
+// ---------------------------------------------------------------------------
+// Persona sub-types
+// ---------------------------------------------------------------------------
+
+export interface PersonaLLM {
+  primaryAlias: string;
+  thinkingEnabled: boolean;
+  maxTokens: number;
+}
+
+export interface PersonaProduces {
+  eventType: string;
+  schemaDef: Record<string, unknown>;
+}
+
+export interface PersonaConsumes {
+  eventTypes: string[];
+  injects: string[];
+}
+
+export interface PersonaFanIn {
+  strategy: string;
+  contributesTo: string;
+}
+
+// ---------------------------------------------------------------------------
+// Persona summary (list view)
+// ---------------------------------------------------------------------------
+
+export interface PersonaSummary {
+  name: string;
+  permissionMode: string;
+  allowedTools: string[];
+  iterationBudget: number;
+  isBuiltin: boolean;
+  hasOverride: boolean;
+  producesEvent: string;
+  consumesEvents: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Persona detail (full view)
+// ---------------------------------------------------------------------------
+
+export interface PersonaDetail extends PersonaSummary {
+  systemPromptTemplate: string;
+  forbiddenTools: string[];
+  llm: PersonaLLM;
+  produces: PersonaProduces;
+  consumes: PersonaConsumes;
+  fanIn: PersonaFanIn;
+  yamlSource: string;
+}
+
+// ---------------------------------------------------------------------------
+// Create / update request
+// ---------------------------------------------------------------------------
+
+export interface PersonaCreateRequest {
+  name: string;
+  systemPromptTemplate: string;
+  allowedTools: string[];
+  forbiddenTools: string[];
+  permissionMode: string;
+  iterationBudget: number;
+  llmPrimaryAlias: string;
+  llmThinkingEnabled: boolean;
+  llmMaxTokens: number;
+  producesEventType: string;
+  consumesEventTypes: string[];
+  consumesInjects: string[];
+  fanInStrategy: string;
+  fanInContributesTo: string;
+}
+
+// ---------------------------------------------------------------------------
+// Fork request
+// ---------------------------------------------------------------------------
+
+export interface PersonaForkRequest {
+  newName: string;
+}
+
+// ---------------------------------------------------------------------------
+// Filter
+// ---------------------------------------------------------------------------
+
+export type PersonaFilter = 'all' | 'builtin' | 'custom';

--- a/web/src/modules/ravn/components/PersonaCard/PersonaCard.module.css
+++ b/web/src/modules/ravn/components/PersonaCard/PersonaCard.module.css
@@ -47,30 +47,6 @@
   flex-shrink: 0;
 }
 
-.badge {
-  display: inline-flex;
-  align-items: center;
-  padding: 0 var(--space-2);
-  height: 18px;
-  border-radius: var(--radius-full);
-  font-size: var(--text-xs);
-  font-family: var(--font-sans);
-  font-weight: 500;
-  white-space: nowrap;
-}
-
-.builtinBadge {
-  background-color: color-mix(in srgb, var(--color-accent-amber) 15%, transparent);
-  color: var(--color-accent-amber);
-  border: 1px solid color-mix(in srgb, var(--color-accent-amber) 25%, transparent);
-}
-
-.overrideBadge {
-  background-color: color-mix(in srgb, var(--color-accent-orange) 15%, transparent);
-  color: var(--color-accent-orange);
-  border: 1px solid color-mix(in srgb, var(--color-accent-orange) 25%, transparent);
-}
-
 /* -- Meta row -- */
 
 .meta {

--- a/web/src/modules/ravn/components/PersonaCard/PersonaCard.module.css
+++ b/web/src/modules/ravn/components/PersonaCard/PersonaCard.module.css
@@ -1,0 +1,112 @@
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  background-color: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  text-decoration: none;
+  color: inherit;
+  transition:
+    border-color var(--transition-fast),
+    background-color var(--transition-fast);
+  cursor: pointer;
+}
+
+.card:hover {
+  border-color: var(--color-brand);
+  background-color: var(--color-bg-tertiary);
+  text-decoration: none;
+}
+
+.card[data-builtin='false'] {
+  border-color: color-mix(in srgb, var(--color-accent-purple) 30%, var(--color-border));
+}
+
+/* -- Header row -- */
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.name {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  font-family: var(--font-mono);
+  color: var(--color-text-primary);
+  word-break: break-all;
+}
+
+.badges {
+  display: flex;
+  gap: var(--space-1);
+  flex-shrink: 0;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 var(--space-2);
+  height: 18px;
+  border-radius: var(--radius-full);
+  font-size: var(--text-xs);
+  font-family: var(--font-sans);
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.builtinBadge {
+  background-color: color-mix(in srgb, var(--color-accent-amber) 15%, transparent);
+  color: var(--color-accent-amber);
+  border: 1px solid color-mix(in srgb, var(--color-accent-amber) 25%, transparent);
+}
+
+.overrideBadge {
+  background-color: color-mix(in srgb, var(--color-accent-orange) 15%, transparent);
+  color: var(--color-accent-orange);
+  border: 1px solid color-mix(in srgb, var(--color-accent-orange) 25%, transparent);
+}
+
+/* -- Meta row -- */
+
+.meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+
+.metaItem {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-size: var(--text-xs);
+}
+
+.metaLabel {
+  color: var(--color-text-muted);
+  font-family: var(--font-sans);
+}
+
+.metaValue {
+  color: var(--color-text-secondary);
+  font-family: var(--font-mono);
+}
+
+/* -- Tools row -- */
+
+.tools {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+  align-items: center;
+}
+
+.extraTools {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+}

--- a/web/src/modules/ravn/components/PersonaCard/PersonaCard.test.tsx
+++ b/web/src/modules/ravn/components/PersonaCard/PersonaCard.test.tsx
@@ -66,7 +66,11 @@ describe('PersonaCard', () => {
   });
 
   it('shows +N for extra tools beyond 4', () => {
-    wrap(<PersonaCard persona={mkPersona({ allowedTools: ['file', 'git', 'terminal', 'web', 'todo'] })} />);
+    wrap(
+      <PersonaCard
+        persona={mkPersona({ allowedTools: ['file', 'git', 'terminal', 'web', 'todo'] })}
+      />
+    );
     expect(screen.getByText('+1')).toBeInTheDocument();
   });
 

--- a/web/src/modules/ravn/components/PersonaCard/PersonaCard.test.tsx
+++ b/web/src/modules/ravn/components/PersonaCard/PersonaCard.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { PersonaCard } from './PersonaCard';
+import type { PersonaSummary } from '../../api/types';
+
+function mkPersona(overrides: Partial<PersonaSummary> = {}): PersonaSummary {
+  return {
+    name: 'coding-agent',
+    permissionMode: 'workspace-write',
+    allowedTools: ['file', 'git', 'terminal'],
+    iterationBudget: 40,
+    isBuiltin: true,
+    hasOverride: false,
+    producesEvent: '',
+    consumesEvents: [],
+    ...overrides,
+  };
+}
+
+function wrap(element: React.ReactElement) {
+  return render(<MemoryRouter>{element}</MemoryRouter>);
+}
+
+describe('PersonaCard', () => {
+  it('renders persona name', () => {
+    wrap(<PersonaCard persona={mkPersona()} />);
+    expect(screen.getByText('coding-agent')).toBeInTheDocument();
+  });
+
+  it('renders built-in badge for built-in persona', () => {
+    wrap(<PersonaCard persona={mkPersona({ isBuiltin: true })} />);
+    expect(screen.getByText('built-in')).toBeInTheDocument();
+  });
+
+  it('does not render built-in badge for custom persona', () => {
+    wrap(<PersonaCard persona={mkPersona({ isBuiltin: false })} />);
+    expect(screen.queryByText('built-in')).not.toBeInTheDocument();
+  });
+
+  it('renders override badge when persona has override', () => {
+    wrap(<PersonaCard persona={mkPersona({ isBuiltin: true, hasOverride: true })} />);
+    expect(screen.getByText('override')).toBeInTheDocument();
+  });
+
+  it('renders permission mode', () => {
+    wrap(<PersonaCard persona={mkPersona({ permissionMode: 'read-only' })} />);
+    expect(screen.getByText('read-only')).toBeInTheDocument();
+  });
+
+  it('renders iteration budget', () => {
+    wrap(<PersonaCard persona={mkPersona({ iterationBudget: 40 })} />);
+    expect(screen.getByText('40')).toBeInTheDocument();
+  });
+
+  it('does not render budget when 0', () => {
+    wrap(<PersonaCard persona={mkPersona({ iterationBudget: 0 })} />);
+    expect(screen.queryByText('0')).not.toBeInTheDocument();
+  });
+
+  it('renders tool badges', () => {
+    wrap(<PersonaCard persona={mkPersona({ allowedTools: ['file', 'git', 'terminal'] })} />);
+    expect(screen.getByText('file')).toBeInTheDocument();
+    expect(screen.getByText('git')).toBeInTheDocument();
+    expect(screen.getByText('terminal')).toBeInTheDocument();
+  });
+
+  it('shows +N for extra tools beyond 4', () => {
+    wrap(<PersonaCard persona={mkPersona({ allowedTools: ['file', 'git', 'terminal', 'web', 'todo'] })} />);
+    expect(screen.getByText('+1')).toBeInTheDocument();
+  });
+
+  it('renders produces event', () => {
+    wrap(<PersonaCard persona={mkPersona({ producesEvent: 'review.completed' })} />);
+    expect(screen.getByText('review.completed')).toBeInTheDocument();
+  });
+
+  it('does not render produces when empty', () => {
+    wrap(<PersonaCard persona={mkPersona({ producesEvent: '' })} />);
+    expect(screen.queryByText('produces')).not.toBeInTheDocument();
+  });
+
+  it('renders link pointing to persona detail page', () => {
+    wrap(<PersonaCard persona={mkPersona({ name: 'my-agent' })} />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/ravn/personas/my-agent');
+  });
+
+  it('shows dash for empty permission mode', () => {
+    wrap(<PersonaCard persona={mkPersona({ permissionMode: '' })} />);
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+});

--- a/web/src/modules/ravn/components/PersonaCard/PersonaCard.tsx
+++ b/web/src/modules/ravn/components/PersonaCard/PersonaCard.tsx
@@ -1,0 +1,64 @@
+import { Link } from 'react-router-dom';
+import { cn } from '@/modules/shared/utils/classnames';
+import { ToolBadge } from '../ToolBadge';
+import type { PersonaSummary } from '../../api/types';
+import styles from './PersonaCard.module.css';
+
+interface PersonaCardProps {
+  persona: PersonaSummary;
+}
+
+export function PersonaCard({ persona }: PersonaCardProps) {
+  const visibleTools = persona.allowedTools.slice(0, 4);
+  const extraCount = persona.allowedTools.length - visibleTools.length;
+
+  return (
+    <Link
+      to={`/ravn/personas/${encodeURIComponent(persona.name)}`}
+      className={styles.card}
+      data-builtin={persona.isBuiltin}
+    >
+      <div className={styles.header}>
+        <span className={styles.name}>{persona.name}</span>
+        <div className={styles.badges}>
+          {persona.isBuiltin && (
+            <span className={cn(styles.badge, styles.builtinBadge)}>built-in</span>
+          )}
+          {persona.hasOverride && (
+            <span className={cn(styles.badge, styles.overrideBadge)}>override</span>
+          )}
+        </div>
+      </div>
+
+      <div className={styles.meta}>
+        <span className={styles.metaItem}>
+          <span className={styles.metaLabel}>mode</span>
+          <span className={styles.metaValue}>{persona.permissionMode || '—'}</span>
+        </span>
+        {persona.iterationBudget > 0 && (
+          <span className={styles.metaItem}>
+            <span className={styles.metaLabel}>budget</span>
+            <span className={styles.metaValue}>{persona.iterationBudget}</span>
+          </span>
+        )}
+        {persona.producesEvent && (
+          <span className={styles.metaItem}>
+            <span className={styles.metaLabel}>produces</span>
+            <span className={styles.metaValue}>{persona.producesEvent}</span>
+          </span>
+        )}
+      </div>
+
+      {visibleTools.length > 0 && (
+        <div className={styles.tools}>
+          {visibleTools.map(tool => (
+            <ToolBadge key={tool} tool={tool} />
+          ))}
+          {extraCount > 0 && (
+            <span className={styles.extraTools}>+{extraCount}</span>
+          )}
+        </div>
+      )}
+    </Link>
+  );
+}

--- a/web/src/modules/ravn/components/PersonaCard/PersonaCard.tsx
+++ b/web/src/modules/ravn/components/PersonaCard/PersonaCard.tsx
@@ -3,6 +3,7 @@ import { cn } from '@/modules/shared/utils/classnames';
 import { ToolBadge } from '../ToolBadge';
 import type { PersonaSummary } from '../../api/types';
 import styles from './PersonaCard.module.css';
+import badgeStyles from '../../styles/badges.module.css';
 
 interface PersonaCardProps {
   persona: PersonaSummary;
@@ -22,10 +23,10 @@ export function PersonaCard({ persona }: PersonaCardProps) {
         <span className={styles.name}>{persona.name}</span>
         <div className={styles.badges}>
           {persona.isBuiltin && (
-            <span className={cn(styles.badge, styles.builtinBadge)}>built-in</span>
+            <span className={cn(badgeStyles.badge, badgeStyles.builtinBadge)}>built-in</span>
           )}
           {persona.hasOverride && (
-            <span className={cn(styles.badge, styles.overrideBadge)}>override</span>
+            <span className={cn(badgeStyles.badge, badgeStyles.overrideBadge)}>override</span>
           )}
         </div>
       </div>

--- a/web/src/modules/ravn/components/PersonaCard/PersonaCard.tsx
+++ b/web/src/modules/ravn/components/PersonaCard/PersonaCard.tsx
@@ -54,9 +54,7 @@ export function PersonaCard({ persona }: PersonaCardProps) {
           {visibleTools.map(tool => (
             <ToolBadge key={tool} tool={tool} />
           ))}
-          {extraCount > 0 && (
-            <span className={styles.extraTools}>+{extraCount}</span>
-          )}
+          {extraCount > 0 && <span className={styles.extraTools}>+{extraCount}</span>}
         </div>
       )}
     </Link>

--- a/web/src/modules/ravn/components/PersonaCard/index.ts
+++ b/web/src/modules/ravn/components/PersonaCard/index.ts
@@ -1,0 +1,1 @@
+export { PersonaCard } from './PersonaCard';

--- a/web/src/modules/ravn/components/PersonaForm/PersonaForm.module.css
+++ b/web/src/modules/ravn/components/PersonaForm/PersonaForm.module.css
@@ -1,0 +1,208 @@
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+  padding: var(--space-6);
+  max-width: 680px;
+}
+
+/* -- Section -- */
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.sectionTitle {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--color-text-primary);
+  font-family: var(--font-sans);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+/* -- Fields -- */
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.fieldRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.label {
+  font-size: var(--text-xs);
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  font-family: var(--font-sans);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.hint {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  font-family: var(--font-sans);
+}
+
+.error {
+  font-size: var(--text-xs);
+  color: var(--color-accent-red);
+  font-family: var(--font-sans);
+}
+
+.toolPreview {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+  margin-top: var(--space-1);
+}
+
+/* -- Inputs -- */
+
+.input,
+.inputError {
+  padding: var(--space-2) var(--space-3);
+  background-color: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+  color: var(--color-text-primary);
+  outline: none;
+  transition: border-color var(--transition-fast);
+}
+
+.input:focus {
+  border-color: var(--color-brand);
+}
+
+.inputError {
+  border-color: var(--color-accent-red);
+}
+
+.inputError:focus {
+  border-color: var(--color-accent-red);
+}
+
+.textarea,
+.textareaError {
+  padding: var(--space-3);
+  background-color: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+  color: var(--color-text-primary);
+  outline: none;
+  resize: vertical;
+  line-height: 1.6;
+  transition: border-color var(--transition-fast);
+}
+
+.textarea:focus {
+  border-color: var(--color-brand);
+}
+
+.textareaError {
+  border-color: var(--color-accent-red);
+}
+
+.select {
+  padding: var(--space-2) var(--space-3);
+  background-color: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+  color: var(--color-text-primary);
+  outline: none;
+  cursor: pointer;
+}
+
+.select:focus {
+  border-color: var(--color-brand);
+}
+
+.checkbox {
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+  accent-color: var(--color-brand);
+}
+
+.checkboxLabel {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  font-family: var(--font-sans);
+  cursor: pointer;
+  user-select: none;
+}
+
+/* -- Actions -- */
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-3);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--color-border-subtle);
+}
+
+.cancelButton {
+  padding: var(--space-2) var(--space-4);
+  background-color: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
+  font-family: var(--font-sans);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition:
+    color var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.cancelButton:hover {
+  color: var(--color-text-primary);
+  border-color: var(--color-text-secondary);
+}
+
+.cancelButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.submitButton {
+  padding: var(--space-2) var(--space-4);
+  background-color: var(--color-brand);
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
+  font-family: var(--font-sans);
+  color: var(--color-bg-primary);
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity var(--transition-fast);
+}
+
+.submitButton:hover {
+  opacity: 0.9;
+}
+
+.submitButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/web/src/modules/ravn/components/PersonaForm/PersonaForm.test.tsx
+++ b/web/src/modules/ravn/components/PersonaForm/PersonaForm.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { PersonaForm } from './PersonaForm';
+import type { PersonaDetail } from '../../api/types';
+
+function mkDetail(overrides: Partial<PersonaDetail> = {}): PersonaDetail {
+  return {
+    name: 'test-persona',
+    permissionMode: 'read-only',
+    allowedTools: ['file', 'git'],
+    forbiddenTools: [],
+    iterationBudget: 10,
+    isBuiltin: false,
+    hasOverride: false,
+    producesEvent: '',
+    consumesEvents: [],
+    systemPromptTemplate: 'You are a test agent.',
+    llm: { primaryAlias: 'balanced', thinkingEnabled: false, maxTokens: 0 },
+    produces: { eventType: '', schemaDef: {} },
+    consumes: { eventTypes: [], injects: [] },
+    fanIn: { strategy: 'merge', contributesTo: '' },
+    yamlSource: '[built-in]',
+    ...overrides,
+  };
+}
+
+describe('PersonaForm', () => {
+  it('renders name field', () => {
+    render(<PersonaForm onSubmit={vi.fn()} onCancel={vi.fn()} />);
+    expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+  });
+
+  it('renders system prompt field', () => {
+    render(<PersonaForm onSubmit={vi.fn()} onCancel={vi.fn()} />);
+    expect(screen.getByLabelText(/template/i)).toBeInTheDocument();
+  });
+
+  it('renders submit button with default label', () => {
+    render(<PersonaForm onSubmit={vi.fn()} onCancel={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument();
+  });
+
+  it('renders custom submit label', () => {
+    render(<PersonaForm onSubmit={vi.fn()} onCancel={vi.fn()} submitLabel="Create" />);
+    expect(screen.getByRole('button', { name: /create/i })).toBeInTheDocument();
+  });
+
+  it('renders cancel button', () => {
+    render(<PersonaForm onSubmit={vi.fn()} onCancel={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+  });
+
+  it('calls onCancel when cancel button clicked', () => {
+    const onCancel = vi.fn();
+    render(<PersonaForm onSubmit={vi.fn()} onCancel={onCancel} />);
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it('shows validation error when name is empty', async () => {
+    render(<PersonaForm onSubmit={vi.fn()} onCancel={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/name is required/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows validation error when system prompt is empty', async () => {
+    render(<PersonaForm onSubmit={vi.fn()} onCancel={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText(/^name/i), { target: { value: 'my-agent' } });
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/system prompt is required/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows validation error for invalid name characters', async () => {
+    render(<PersonaForm onSubmit={vi.fn()} onCancel={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText(/^name/i), { target: { value: 'invalid name!' } });
+    fireEvent.change(screen.getByLabelText(/template/i), { target: { value: 'prompt' } });
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/letters, numbers, hyphens/i)).toBeInTheDocument();
+    });
+  });
+
+  it('calls onSubmit with correct data when form is valid', async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(<PersonaForm onSubmit={onSubmit} onCancel={vi.fn()} />);
+
+    fireEvent.change(screen.getByLabelText(/^name/i), { target: { value: 'my-agent' } });
+    fireEvent.change(screen.getByLabelText(/template/i), { target: { value: 'You are helpful.' } });
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledOnce();
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+        name: 'my-agent',
+        systemPromptTemplate: 'You are helpful.',
+      }));
+    });
+  });
+
+  it('pre-fills form with initial persona data', () => {
+    render(<PersonaForm initial={mkDetail()} onSubmit={vi.fn()} onCancel={vi.fn()} />);
+    expect(screen.getByLabelText(/^name/i)).toHaveValue('test-persona');
+    expect(screen.getByLabelText(/template/i)).toHaveValue('You are a test agent.');
+  });
+
+  it('name field is disabled when initial persona provided', () => {
+    render(<PersonaForm initial={mkDetail()} onSubmit={vi.fn()} onCancel={vi.fn()} />);
+    expect(screen.getByLabelText(/^name/i)).toBeDisabled();
+  });
+
+  it('renders all section headings', () => {
+    render(<PersonaForm onSubmit={vi.fn()} onCancel={vi.fn()} />);
+    expect(screen.getByText('Identity')).toBeInTheDocument();
+    expect(screen.getByText('System Prompt')).toBeInTheDocument();
+    expect(screen.getByText('Tools & Permissions')).toBeInTheDocument();
+    expect(screen.getByText('LLM Settings')).toBeInTheDocument();
+    expect(screen.getByText('Pipeline Contract')).toBeInTheDocument();
+  });
+
+  it('renders tool preview when allowed tools typed', async () => {
+    render(<PersonaForm onSubmit={vi.fn()} onCancel={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText(/allowed tools/i), { target: { value: 'file, git' } });
+    await waitFor(() => {
+      expect(screen.getByText('file')).toBeInTheDocument();
+      expect(screen.getByText('git')).toBeInTheDocument();
+    });
+  });
+
+  it('renders iteration budget field', () => {
+    render(<PersonaForm onSubmit={vi.fn()} onCancel={vi.fn()} />);
+    expect(screen.getByLabelText(/iteration budget/i)).toBeInTheDocument();
+  });
+
+  it('renders extended thinking checkbox', () => {
+    render(<PersonaForm onSubmit={vi.fn()} onCancel={vi.fn()} />);
+    expect(screen.getByLabelText(/extended thinking/i)).toBeInTheDocument();
+  });
+});

--- a/web/src/modules/ravn/components/PersonaForm/PersonaForm.test.tsx
+++ b/web/src/modules/ravn/components/PersonaForm/PersonaForm.test.tsx
@@ -94,10 +94,12 @@ describe('PersonaForm', () => {
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledOnce();
-      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
-        name: 'my-agent',
-        systemPromptTemplate: 'You are helpful.',
-      }));
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'my-agent',
+          systemPromptTemplate: 'You are helpful.',
+        })
+      );
     });
   });
 

--- a/web/src/modules/ravn/components/PersonaForm/PersonaForm.tsx
+++ b/web/src/modules/ravn/components/PersonaForm/PersonaForm.tsx
@@ -20,7 +20,12 @@ function parseToolList(raw: string): string[] {
     .filter(Boolean);
 }
 
-export function PersonaForm({ initial, onSubmit, onCancel, submitLabel = 'Save' }: PersonaFormProps) {
+export function PersonaForm({
+  initial,
+  onSubmit,
+  onCancel,
+  submitLabel = 'Save',
+}: PersonaFormProps) {
   const [name, setName] = useState(initial?.name ?? '');
   const [systemPrompt, setSystemPrompt] = useState(initial?.systemPromptTemplate ?? '');
   const [allowedTools, setAllowedTools] = useState(initial?.allowedTools.join(', ') ?? '');
@@ -31,8 +36,12 @@ export function PersonaForm({ initial, onSubmit, onCancel, submitLabel = 'Save' 
   const [llmThinking, setLlmThinking] = useState(initial?.llm.thinkingEnabled ?? false);
   const [llmMaxTokens, setLlmMaxTokens] = useState(String(initial?.llm.maxTokens ?? 0));
   const [producesEvent, setProducesEvent] = useState(initial?.produces.eventType ?? '');
-  const [consumesEvents, setConsumesEvents] = useState(initial?.consumes.eventTypes.join(', ') ?? '');
-  const [consumesInjects, setConsumesInjects] = useState(initial?.consumes.injects.join(', ') ?? '');
+  const [consumesEvents, setConsumesEvents] = useState(
+    initial?.consumes.eventTypes.join(', ') ?? ''
+  );
+  const [consumesInjects, setConsumesInjects] = useState(
+    initial?.consumes.injects.join(', ') ?? ''
+  );
   const [fanInStrategy, setFanInStrategy] = useState(initial?.fanIn.strategy ?? 'merge');
   const [fanInContributesTo, setFanInContributesTo] = useState(initial?.fanIn.contributesTo ?? '');
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -93,7 +102,9 @@ export function PersonaForm({ initial, onSubmit, onCancel, submitLabel = 'Save' 
         <h3 className={styles.sectionTitle}>Identity</h3>
 
         <div className={styles.field}>
-          <label className={styles.label} htmlFor="pf-name">Name</label>
+          <label className={styles.label} htmlFor="pf-name">
+            Name
+          </label>
           <input
             id="pf-name"
             className={errors.name ? styles.inputError : styles.input}
@@ -107,7 +118,9 @@ export function PersonaForm({ initial, onSubmit, onCancel, submitLabel = 'Save' 
         </div>
 
         <div className={styles.field}>
-          <label className={styles.label} htmlFor="pf-permission">Permission Mode</label>
+          <label className={styles.label} htmlFor="pf-permission">
+            Permission Mode
+          </label>
           <select
             id="pf-permission"
             className={styles.select}
@@ -115,13 +128,17 @@ export function PersonaForm({ initial, onSubmit, onCancel, submitLabel = 'Save' 
             onChange={e => setPermissionMode(e.target.value)}
           >
             {PERMISSION_MODES.map(m => (
-              <option key={m} value={m}>{m || '(inherit)'}</option>
+              <option key={m} value={m}>
+                {m || '(inherit)'}
+              </option>
             ))}
           </select>
         </div>
 
         <div className={styles.field}>
-          <label className={styles.label} htmlFor="pf-budget">Iteration Budget</label>
+          <label className={styles.label} htmlFor="pf-budget">
+            Iteration Budget
+          </label>
           <input
             id="pf-budget"
             className={styles.input}
@@ -139,7 +156,9 @@ export function PersonaForm({ initial, onSubmit, onCancel, submitLabel = 'Save' 
         <h3 className={styles.sectionTitle}>System Prompt</h3>
 
         <div className={styles.field}>
-          <label className={styles.label} htmlFor="pf-prompt">Template</label>
+          <label className={styles.label} htmlFor="pf-prompt">
+            Template
+          </label>
           <textarea
             id="pf-prompt"
             className={errors.systemPrompt ? styles.textareaError : styles.textarea}
@@ -157,7 +176,9 @@ export function PersonaForm({ initial, onSubmit, onCancel, submitLabel = 'Save' 
         <h3 className={styles.sectionTitle}>Tools & Permissions</h3>
 
         <div className={styles.field}>
-          <label className={styles.label} htmlFor="pf-allowed">Allowed Tools</label>
+          <label className={styles.label} htmlFor="pf-allowed">
+            Allowed Tools
+          </label>
           <input
             id="pf-allowed"
             className={styles.input}
@@ -169,13 +190,17 @@ export function PersonaForm({ initial, onSubmit, onCancel, submitLabel = 'Save' 
           <span className={styles.hint}>Comma-separated tool group names</span>
           {parsedAllowedTools.length > 0 && (
             <div className={styles.toolPreview}>
-              {parsedAllowedTools.map(t => <ToolBadge key={t} tool={t} />)}
+              {parsedAllowedTools.map(t => (
+                <ToolBadge key={t} tool={t} />
+              ))}
             </div>
           )}
         </div>
 
         <div className={styles.field}>
-          <label className={styles.label} htmlFor="pf-forbidden">Forbidden Tools</label>
+          <label className={styles.label} htmlFor="pf-forbidden">
+            Forbidden Tools
+          </label>
           <input
             id="pf-forbidden"
             className={styles.input}
@@ -193,7 +218,9 @@ export function PersonaForm({ initial, onSubmit, onCancel, submitLabel = 'Save' 
         <h3 className={styles.sectionTitle}>LLM Settings</h3>
 
         <div className={styles.field}>
-          <label className={styles.label} htmlFor="pf-alias">Primary Alias</label>
+          <label className={styles.label} htmlFor="pf-alias">
+            Primary Alias
+          </label>
           <input
             id="pf-alias"
             className={styles.input}
@@ -217,7 +244,9 @@ export function PersonaForm({ initial, onSubmit, onCancel, submitLabel = 'Save' 
         </div>
 
         <div className={styles.field}>
-          <label className={styles.label} htmlFor="pf-maxtokens">Max Tokens</label>
+          <label className={styles.label} htmlFor="pf-maxtokens">
+            Max Tokens
+          </label>
           <input
             id="pf-maxtokens"
             className={styles.input}
@@ -235,7 +264,9 @@ export function PersonaForm({ initial, onSubmit, onCancel, submitLabel = 'Save' 
         <h3 className={styles.sectionTitle}>Pipeline Contract</h3>
 
         <div className={styles.field}>
-          <label className={styles.label} htmlFor="pf-produces">Produces Event</label>
+          <label className={styles.label} htmlFor="pf-produces">
+            Produces Event
+          </label>
           <input
             id="pf-produces"
             className={styles.input}
@@ -247,7 +278,9 @@ export function PersonaForm({ initial, onSubmit, onCancel, submitLabel = 'Save' 
         </div>
 
         <div className={styles.field}>
-          <label className={styles.label} htmlFor="pf-consumes">Consumes Events</label>
+          <label className={styles.label} htmlFor="pf-consumes">
+            Consumes Events
+          </label>
           <input
             id="pf-consumes"
             className={styles.input}
@@ -260,7 +293,9 @@ export function PersonaForm({ initial, onSubmit, onCancel, submitLabel = 'Save' 
         </div>
 
         <div className={styles.field}>
-          <label className={styles.label} htmlFor="pf-injects">Context Injects</label>
+          <label className={styles.label} htmlFor="pf-injects">
+            Context Injects
+          </label>
           <input
             id="pf-injects"
             className={styles.input}
@@ -273,7 +308,9 @@ export function PersonaForm({ initial, onSubmit, onCancel, submitLabel = 'Save' 
         </div>
 
         <div className={styles.field}>
-          <label className={styles.label} htmlFor="pf-fanin">Fan-in Strategy</label>
+          <label className={styles.label} htmlFor="pf-fanin">
+            Fan-in Strategy
+          </label>
           <select
             id="pf-fanin"
             className={styles.select}
@@ -281,13 +318,17 @@ export function PersonaForm({ initial, onSubmit, onCancel, submitLabel = 'Save' 
             onChange={e => setFanInStrategy(e.target.value)}
           >
             {FAN_IN_STRATEGIES.map(s => (
-              <option key={s} value={s}>{s}</option>
+              <option key={s} value={s}>
+                {s}
+              </option>
             ))}
           </select>
         </div>
 
         <div className={styles.field}>
-          <label className={styles.label} htmlFor="pf-contributes">Contributes To</label>
+          <label className={styles.label} htmlFor="pf-contributes">
+            Contributes To
+          </label>
           <input
             id="pf-contributes"
             className={styles.input}
@@ -301,7 +342,12 @@ export function PersonaForm({ initial, onSubmit, onCancel, submitLabel = 'Save' 
 
       {/* Actions */}
       <div className={styles.actions}>
-        <button type="button" className={styles.cancelButton} onClick={onCancel} disabled={submitting}>
+        <button
+          type="button"
+          className={styles.cancelButton}
+          onClick={onCancel}
+          disabled={submitting}
+        >
           Cancel
         </button>
         <button type="submit" className={styles.submitButton} disabled={submitting}>

--- a/web/src/modules/ravn/components/PersonaForm/PersonaForm.tsx
+++ b/web/src/modules/ravn/components/PersonaForm/PersonaForm.tsx
@@ -1,0 +1,313 @@
+import { useState } from 'react';
+import type { PersonaDetail, PersonaCreateRequest } from '../../api/types';
+import { ToolBadge } from '../ToolBadge';
+import styles from './PersonaForm.module.css';
+
+interface PersonaFormProps {
+  initial?: PersonaDetail;
+  onSubmit: (req: PersonaCreateRequest) => Promise<void>;
+  onCancel: () => void;
+  submitLabel?: string;
+}
+
+const PERMISSION_MODES = ['read-only', 'workspace-write', 'workspace-full', ''];
+const FAN_IN_STRATEGIES = ['merge', 'all_must_pass', 'any_pass', 'majority'];
+
+function parseToolList(raw: string): string[] {
+  return raw
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+}
+
+export function PersonaForm({ initial, onSubmit, onCancel, submitLabel = 'Save' }: PersonaFormProps) {
+  const [name, setName] = useState(initial?.name ?? '');
+  const [systemPrompt, setSystemPrompt] = useState(initial?.systemPromptTemplate ?? '');
+  const [allowedTools, setAllowedTools] = useState(initial?.allowedTools.join(', ') ?? '');
+  const [forbiddenTools, setForbiddenTools] = useState(initial?.forbiddenTools.join(', ') ?? '');
+  const [permissionMode, setPermissionMode] = useState(initial?.permissionMode ?? '');
+  const [iterationBudget, setIterationBudget] = useState(String(initial?.iterationBudget ?? 0));
+  const [llmAlias, setLlmAlias] = useState(initial?.llm.primaryAlias ?? '');
+  const [llmThinking, setLlmThinking] = useState(initial?.llm.thinkingEnabled ?? false);
+  const [llmMaxTokens, setLlmMaxTokens] = useState(String(initial?.llm.maxTokens ?? 0));
+  const [producesEvent, setProducesEvent] = useState(initial?.produces.eventType ?? '');
+  const [consumesEvents, setConsumesEvents] = useState(initial?.consumes.eventTypes.join(', ') ?? '');
+  const [consumesInjects, setConsumesInjects] = useState(initial?.consumes.injects.join(', ') ?? '');
+  const [fanInStrategy, setFanInStrategy] = useState(initial?.fanIn.strategy ?? 'merge');
+  const [fanInContributesTo, setFanInContributesTo] = useState(initial?.fanIn.contributesTo ?? '');
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [submitting, setSubmitting] = useState(false);
+
+  function validate(): boolean {
+    const newErrors: Record<string, string> = {};
+
+    if (!name.trim()) {
+      newErrors.name = 'Name is required';
+    } else if (!/^[a-zA-Z0-9_-]+$/.test(name.trim())) {
+      newErrors.name = 'Name must contain only letters, numbers, hyphens, underscores';
+    }
+
+    if (!systemPrompt.trim()) {
+      newErrors.systemPrompt = 'System prompt is required';
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!validate()) return;
+
+    const req: PersonaCreateRequest = {
+      name: name.trim(),
+      systemPromptTemplate: systemPrompt,
+      allowedTools: parseToolList(allowedTools),
+      forbiddenTools: parseToolList(forbiddenTools),
+      permissionMode,
+      iterationBudget: parseInt(iterationBudget, 10) || 0,
+      llmPrimaryAlias: llmAlias,
+      llmThinkingEnabled: llmThinking,
+      llmMaxTokens: parseInt(llmMaxTokens, 10) || 0,
+      producesEventType: producesEvent,
+      consumesEventTypes: parseToolList(consumesEvents),
+      consumesInjects: parseToolList(consumesInjects),
+      fanInStrategy,
+      fanInContributesTo,
+    };
+
+    setSubmitting(true);
+    try {
+      await onSubmit(req);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const parsedAllowedTools = parseToolList(allowedTools);
+
+  return (
+    <form className={styles.form} onSubmit={handleSubmit} noValidate>
+      {/* Identity */}
+      <section className={styles.section}>
+        <h3 className={styles.sectionTitle}>Identity</h3>
+
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="pf-name">Name</label>
+          <input
+            id="pf-name"
+            className={errors.name ? styles.inputError : styles.input}
+            type="text"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            placeholder="my-persona"
+            disabled={!!initial}
+          />
+          {errors.name && <span className={styles.error}>{errors.name}</span>}
+        </div>
+
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="pf-permission">Permission Mode</label>
+          <select
+            id="pf-permission"
+            className={styles.select}
+            value={permissionMode}
+            onChange={e => setPermissionMode(e.target.value)}
+          >
+            {PERMISSION_MODES.map(m => (
+              <option key={m} value={m}>{m || '(inherit)'}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="pf-budget">Iteration Budget</label>
+          <input
+            id="pf-budget"
+            className={styles.input}
+            type="number"
+            min="0"
+            value={iterationBudget}
+            onChange={e => setIterationBudget(e.target.value)}
+          />
+          <span className={styles.hint}>0 = unlimited</span>
+        </div>
+      </section>
+
+      {/* System Prompt */}
+      <section className={styles.section}>
+        <h3 className={styles.sectionTitle}>System Prompt</h3>
+
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="pf-prompt">Template</label>
+          <textarea
+            id="pf-prompt"
+            className={errors.systemPrompt ? styles.textareaError : styles.textarea}
+            value={systemPrompt}
+            onChange={e => setSystemPrompt(e.target.value)}
+            rows={10}
+            placeholder="You are a focused agent that…"
+          />
+          {errors.systemPrompt && <span className={styles.error}>{errors.systemPrompt}</span>}
+        </div>
+      </section>
+
+      {/* Tools & Permissions */}
+      <section className={styles.section}>
+        <h3 className={styles.sectionTitle}>Tools & Permissions</h3>
+
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="pf-allowed">Allowed Tools</label>
+          <input
+            id="pf-allowed"
+            className={styles.input}
+            type="text"
+            value={allowedTools}
+            onChange={e => setAllowedTools(e.target.value)}
+            placeholder="file, git, terminal, web"
+          />
+          <span className={styles.hint}>Comma-separated tool group names</span>
+          {parsedAllowedTools.length > 0 && (
+            <div className={styles.toolPreview}>
+              {parsedAllowedTools.map(t => <ToolBadge key={t} tool={t} />)}
+            </div>
+          )}
+        </div>
+
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="pf-forbidden">Forbidden Tools</label>
+          <input
+            id="pf-forbidden"
+            className={styles.input}
+            type="text"
+            value={forbiddenTools}
+            onChange={e => setForbiddenTools(e.target.value)}
+            placeholder="cascade, volundr"
+          />
+          <span className={styles.hint}>Comma-separated tool group names</span>
+        </div>
+      </section>
+
+      {/* LLM Settings */}
+      <section className={styles.section}>
+        <h3 className={styles.sectionTitle}>LLM Settings</h3>
+
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="pf-alias">Primary Alias</label>
+          <input
+            id="pf-alias"
+            className={styles.input}
+            type="text"
+            value={llmAlias}
+            onChange={e => setLlmAlias(e.target.value)}
+            placeholder="balanced"
+          />
+        </div>
+
+        <div className={styles.fieldRow}>
+          <label className={styles.checkboxLabel}>
+            <input
+              type="checkbox"
+              className={styles.checkbox}
+              checked={llmThinking}
+              onChange={e => setLlmThinking(e.target.checked)}
+            />
+            Extended Thinking
+          </label>
+        </div>
+
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="pf-maxtokens">Max Tokens</label>
+          <input
+            id="pf-maxtokens"
+            className={styles.input}
+            type="number"
+            min="0"
+            value={llmMaxTokens}
+            onChange={e => setLlmMaxTokens(e.target.value)}
+          />
+          <span className={styles.hint}>0 = use settings default</span>
+        </div>
+      </section>
+
+      {/* Pipeline Contract */}
+      <section className={styles.section}>
+        <h3 className={styles.sectionTitle}>Pipeline Contract</h3>
+
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="pf-produces">Produces Event</label>
+          <input
+            id="pf-produces"
+            className={styles.input}
+            type="text"
+            value={producesEvent}
+            onChange={e => setProducesEvent(e.target.value)}
+            placeholder="review.completed"
+          />
+        </div>
+
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="pf-consumes">Consumes Events</label>
+          <input
+            id="pf-consumes"
+            className={styles.input}
+            type="text"
+            value={consumesEvents}
+            onChange={e => setConsumesEvents(e.target.value)}
+            placeholder="code.changed, review.requested"
+          />
+          <span className={styles.hint}>Comma-separated</span>
+        </div>
+
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="pf-injects">Context Injects</label>
+          <input
+            id="pf-injects"
+            className={styles.input}
+            type="text"
+            value={consumesInjects}
+            onChange={e => setConsumesInjects(e.target.value)}
+            placeholder="repo, branch, diff_url"
+          />
+          <span className={styles.hint}>Comma-separated</span>
+        </div>
+
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="pf-fanin">Fan-in Strategy</label>
+          <select
+            id="pf-fanin"
+            className={styles.select}
+            value={fanInStrategy}
+            onChange={e => setFanInStrategy(e.target.value)}
+          >
+            {FAN_IN_STRATEGIES.map(s => (
+              <option key={s} value={s}>{s}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="pf-contributes">Contributes To</label>
+          <input
+            id="pf-contributes"
+            className={styles.input}
+            type="text"
+            value={fanInContributesTo}
+            onChange={e => setFanInContributesTo(e.target.value)}
+            placeholder="review.verdict"
+          />
+        </div>
+      </section>
+
+      {/* Actions */}
+      <div className={styles.actions}>
+        <button type="button" className={styles.cancelButton} onClick={onCancel} disabled={submitting}>
+          Cancel
+        </button>
+        <button type="submit" className={styles.submitButton} disabled={submitting}>
+          {submitting ? 'Saving…' : submitLabel}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/web/src/modules/ravn/components/PersonaForm/index.ts
+++ b/web/src/modules/ravn/components/PersonaForm/index.ts
@@ -1,0 +1,1 @@
+export { PersonaForm } from './PersonaForm';

--- a/web/src/modules/ravn/components/ToolBadge/ToolBadge.module.css
+++ b/web/src/modules/ravn/components/ToolBadge/ToolBadge.module.css
@@ -1,0 +1,14 @@
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 var(--space-2);
+  height: 20px;
+  border-radius: var(--radius-full);
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  font-weight: 500;
+  background-color: color-mix(in srgb, var(--color-accent-cyan) 15%, transparent);
+  color: var(--color-accent-cyan);
+  border: 1px solid color-mix(in srgb, var(--color-accent-cyan) 25%, transparent);
+  white-space: nowrap;
+}

--- a/web/src/modules/ravn/components/ToolBadge/ToolBadge.test.tsx
+++ b/web/src/modules/ravn/components/ToolBadge/ToolBadge.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ToolBadge } from './ToolBadge';
+
+describe('ToolBadge', () => {
+  it('renders the tool name', () => {
+    render(<ToolBadge tool="file" />);
+    expect(screen.getByText('file')).toBeInTheDocument();
+  });
+
+  it('renders git tool', () => {
+    render(<ToolBadge tool="git" />);
+    expect(screen.getByText('git')).toBeInTheDocument();
+  });
+
+  it('renders terminal tool', () => {
+    render(<ToolBadge tool="terminal" />);
+    expect(screen.getByText('terminal')).toBeInTheDocument();
+  });
+
+  it('renders web tool', () => {
+    render(<ToolBadge tool="web" />);
+    expect(screen.getByText('web')).toBeInTheDocument();
+  });
+
+  it('renders todo tool', () => {
+    render(<ToolBadge tool="todo" />);
+    expect(screen.getByText('todo')).toBeInTheDocument();
+  });
+});

--- a/web/src/modules/ravn/components/ToolBadge/ToolBadge.tsx
+++ b/web/src/modules/ravn/components/ToolBadge/ToolBadge.tsx
@@ -1,0 +1,9 @@
+import styles from './ToolBadge.module.css';
+
+interface ToolBadgeProps {
+  tool: string;
+}
+
+export function ToolBadge({ tool }: ToolBadgeProps) {
+  return <span className={styles.badge}>{tool}</span>;
+}

--- a/web/src/modules/ravn/components/ToolBadge/index.ts
+++ b/web/src/modules/ravn/components/ToolBadge/index.ts
@@ -1,0 +1,1 @@
+export { ToolBadge } from './ToolBadge';

--- a/web/src/modules/ravn/pages/PersonaDetailView.module.css
+++ b/web/src/modules/ravn/pages/PersonaDetailView.module.css
@@ -79,30 +79,6 @@
   gap: var(--space-1);
 }
 
-.badge {
-  display: inline-flex;
-  align-items: center;
-  padding: 0 var(--space-2);
-  height: 20px;
-  border-radius: var(--radius-full);
-  font-size: var(--text-xs);
-  font-weight: 500;
-  font-family: var(--font-sans);
-  white-space: nowrap;
-}
-
-.builtinBadge {
-  background-color: color-mix(in srgb, var(--color-accent-amber) 15%, transparent);
-  color: var(--color-accent-amber);
-  border: 1px solid color-mix(in srgb, var(--color-accent-amber) 25%, transparent);
-}
-
-.overrideBadge {
-  background-color: color-mix(in srgb, var(--color-accent-orange) 15%, transparent);
-  color: var(--color-accent-orange);
-  border: 1px solid color-mix(in srgb, var(--color-accent-orange) 25%, transparent);
-}
-
 .actions {
   display: flex;
   gap: var(--space-2);

--- a/web/src/modules/ravn/pages/PersonaDetailView.module.css
+++ b/web/src/modules/ravn/pages/PersonaDetailView.module.css
@@ -1,0 +1,308 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: var(--space-6);
+  gap: var(--space-6);
+  max-width: 900px;
+}
+
+/* -- Status / loading / error -- */
+
+.status {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-4);
+  flex: 1;
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  font-family: var(--font-sans);
+}
+
+.errorText {
+  color: var(--color-accent-red);
+}
+
+/* -- Page header -- */
+
+.pageHeader {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+  flex-shrink: 0;
+}
+
+.backButton {
+  padding: var(--space-1) var(--space-3);
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
+  font-family: var(--font-sans);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition:
+    color var(--transition-fast),
+    border-color var(--transition-fast);
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.backButton:hover {
+  color: var(--color-text-primary);
+  border-color: var(--color-text-secondary);
+}
+
+.titleRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex: 1;
+  min-width: 0;
+}
+
+.pageTitle {
+  font-size: var(--text-xl);
+  font-weight: 700;
+  font-family: var(--font-mono);
+  color: var(--color-text-primary);
+  word-break: break-all;
+}
+
+.titleBadges {
+  display: flex;
+  gap: var(--space-1);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 var(--space-2);
+  height: 20px;
+  border-radius: var(--radius-full);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  font-family: var(--font-sans);
+  white-space: nowrap;
+}
+
+.builtinBadge {
+  background-color: color-mix(in srgb, var(--color-accent-amber) 15%, transparent);
+  color: var(--color-accent-amber);
+  border: 1px solid color-mix(in srgb, var(--color-accent-amber) 25%, transparent);
+}
+
+.overrideBadge {
+  background-color: color-mix(in srgb, var(--color-accent-orange) 15%, transparent);
+  color: var(--color-accent-orange);
+  border: 1px solid color-mix(in srgb, var(--color-accent-orange) 25%, transparent);
+}
+
+.actions {
+  display: flex;
+  gap: var(--space-2);
+  margin-left: auto;
+}
+
+.actionButton {
+  padding: var(--space-1) var(--space-3);
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
+  font-family: var(--font-sans);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition:
+    color var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.actionButton:hover {
+  color: var(--color-text-primary);
+  border-color: var(--color-text-secondary);
+}
+
+.actionButton:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.deleteButton {
+  color: var(--color-accent-red);
+  border-color: color-mix(in srgb, var(--color-accent-red) 30%, var(--color-border));
+}
+
+.deleteButton:hover {
+  color: var(--color-accent-red);
+  border-color: var(--color-accent-red);
+  background-color: color-mix(in srgb, var(--color-accent-red) 10%, transparent);
+}
+
+/* -- Action error banner -- */
+
+.actionError {
+  padding: var(--space-3) var(--space-4);
+  background-color: color-mix(in srgb, var(--color-accent-red) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-accent-red) 30%, transparent);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
+  color: var(--color-accent-red);
+  font-family: var(--font-sans);
+}
+
+/* -- Fork panel -- */
+
+.forkPanel {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  background-color: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  flex-wrap: wrap;
+}
+
+.forkLabel {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  font-family: var(--font-sans);
+  white-space: nowrap;
+}
+
+.forkInput {
+  flex: 1;
+  min-width: 200px;
+  padding: var(--space-2) var(--space-3);
+  background-color: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+  color: var(--color-text-primary);
+  outline: none;
+}
+
+.forkInput:focus {
+  border-color: var(--color-brand);
+}
+
+.cancelForkButton {
+  padding: var(--space-1) var(--space-3);
+  background: transparent;
+  border: none;
+  font-size: var(--text-sm);
+  font-family: var(--font-sans);
+  color: var(--color-text-muted);
+  cursor: pointer;
+}
+
+.cancelForkButton:hover {
+  color: var(--color-text-secondary);
+}
+
+/* -- Detail sections -- */
+
+.sections {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.sectionTitle {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--color-text-muted);
+  font-family: var(--font-sans);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+/* -- Definition list -- */
+
+.dl {
+  display: grid;
+  grid-template-columns: 160px 1fr;
+  gap: var(--space-2) var(--space-4);
+  align-items: start;
+}
+
+.dt {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  font-family: var(--font-sans);
+  font-weight: 500;
+  padding-top: 2px;
+}
+
+.dd {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  font-family: var(--font-mono);
+}
+
+.tagRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+}
+
+/* -- System prompt -- */
+
+.prompt {
+  padding: var(--space-4);
+  background-color: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+  color: var(--color-text-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.6;
+}
+
+/* -- YAML preview -- */
+
+.toggleYaml {
+  background: transparent;
+  border: none;
+  font-size: var(--text-sm);
+  font-family: var(--font-sans);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  padding: 0;
+  text-align: left;
+}
+
+.toggleYaml:hover {
+  color: var(--color-text-secondary);
+}
+
+.yaml {
+  padding: var(--space-4);
+  background-color: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-text-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.5;
+  overflow-x: auto;
+}

--- a/web/src/modules/ravn/pages/PersonaDetailView.test.tsx
+++ b/web/src/modules/ravn/pages/PersonaDetailView.test.tsx
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { PersonaDetailView } from './PersonaDetailView';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+const mockDetail = {
+  name: 'coding-agent',
+  permission_mode: 'workspace-write',
+  allowed_tools: ['file', 'git', 'terminal'],
+  forbidden_tools: ['cascade'],
+  iteration_budget: 40,
+  is_builtin: true,
+  has_override: false,
+  produces_event: 'code.completed',
+  consumes_events: ['task.assigned'],
+  system_prompt_template: 'You are a coding agent.',
+  llm: { primary_alias: 'balanced', thinking_enabled: true, max_tokens: 0 },
+  produces: { event_type: 'code.completed', schema_def: {} },
+  consumes: { event_types: ['task.assigned'], injects: ['repo', 'branch'] },
+  fan_in: { strategy: 'merge', contributes_to: '' },
+  yaml_source: '[built-in]',
+};
+
+function mockDetailAndYaml() {
+  mockFetch
+    .mockResolvedValueOnce({ status: 200, ok: true, json: async () => mockDetail })
+    .mockResolvedValueOnce({ status: 200, ok: true, json: async () => 'name: coding-agent\n' });
+}
+
+function wrap(name: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/ravn/personas/${name}`]}>
+      <Routes>
+        <Route path="/ravn/personas/:name" element={<PersonaDetailView />} />
+        <Route path="/ravn/personas" element={<div>Personas List</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('PersonaDetailView', () => {
+  it('shows loading state initially', () => {
+    mockDetailAndYaml();
+    wrap('coding-agent');
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+  });
+
+  it('renders persona name after load', async () => {
+    mockDetailAndYaml();
+    wrap('coding-agent');
+    await waitFor(() => {
+      expect(screen.getByText('coding-agent')).toBeInTheDocument();
+    });
+  });
+
+  it('renders built-in badge', async () => {
+    mockDetailAndYaml();
+    wrap('coding-agent');
+    await waitFor(() => {
+      expect(screen.getByText('built-in')).toBeInTheDocument();
+    });
+  });
+
+  it('renders Identity section', async () => {
+    mockDetailAndYaml();
+    wrap('coding-agent');
+    await waitFor(() => {
+      expect(screen.getByText('Identity')).toBeInTheDocument();
+    });
+  });
+
+  it('renders permission mode', async () => {
+    mockDetailAndYaml();
+    wrap('coding-agent');
+    await waitFor(() => {
+      expect(screen.getByText('workspace-write')).toBeInTheDocument();
+    });
+  });
+
+  it('renders iteration budget', async () => {
+    mockDetailAndYaml();
+    wrap('coding-agent');
+    await waitFor(() => {
+      expect(screen.getByText('40')).toBeInTheDocument();
+    });
+  });
+
+  it('renders Tools & Permissions section', async () => {
+    mockDetailAndYaml();
+    wrap('coding-agent');
+    await waitFor(() => {
+      expect(screen.getByText('Tools & Permissions')).toBeInTheDocument();
+    });
+  });
+
+  it('renders allowed tools', async () => {
+    mockDetailAndYaml();
+    wrap('coding-agent');
+    await waitFor(() => {
+      expect(screen.getByText('file')).toBeInTheDocument();
+      expect(screen.getByText('git')).toBeInTheDocument();
+      expect(screen.getByText('terminal')).toBeInTheDocument();
+    });
+  });
+
+  it('renders forbidden tools', async () => {
+    mockDetailAndYaml();
+    wrap('coding-agent');
+    await waitFor(() => {
+      expect(screen.getByText('cascade')).toBeInTheDocument();
+    });
+  });
+
+  it('renders LLM Settings section', async () => {
+    mockDetailAndYaml();
+    wrap('coding-agent');
+    await waitFor(() => {
+      expect(screen.getByText('LLM Settings')).toBeInTheDocument();
+    });
+  });
+
+  it('renders llm alias', async () => {
+    mockDetailAndYaml();
+    wrap('coding-agent');
+    await waitFor(() => {
+      expect(screen.getByText('balanced')).toBeInTheDocument();
+    });
+  });
+
+  it('renders thinking enabled', async () => {
+    mockDetailAndYaml();
+    wrap('coding-agent');
+    await waitFor(() => {
+      expect(screen.getByText('enabled')).toBeInTheDocument();
+    });
+  });
+
+  it('renders Pipeline Contract section', async () => {
+    mockDetailAndYaml();
+    wrap('coding-agent');
+    await waitFor(() => {
+      expect(screen.getByText('Pipeline Contract')).toBeInTheDocument();
+    });
+  });
+
+  it('renders produces event', async () => {
+    mockDetailAndYaml();
+    wrap('coding-agent');
+    await waitFor(() => {
+      expect(screen.getByText('code.completed')).toBeInTheDocument();
+    });
+  });
+
+  it('renders System Prompt section', async () => {
+    mockDetailAndYaml();
+    wrap('coding-agent');
+    await waitFor(() => {
+      expect(screen.getByText('System Prompt')).toBeInTheDocument();
+    });
+  });
+
+  it('renders system prompt text', async () => {
+    mockDetailAndYaml();
+    wrap('coding-agent');
+    await waitFor(() => {
+      expect(screen.getByText('You are a coding agent.')).toBeInTheDocument();
+    });
+  });
+
+  it('renders action buttons', async () => {
+    mockDetailAndYaml();
+    wrap('coding-agent');
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /fork/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
+    });
+  });
+
+  it('does not render delete button for built-in personas', async () => {
+    mockDetailAndYaml();
+    wrap('coding-agent');
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /delete/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it('renders delete button for custom personas', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        status: 200, ok: true,
+        json: async () => ({ ...mockDetail, is_builtin: false }),
+      })
+      .mockResolvedValueOnce({ status: 200, ok: true, json: async () => 'yaml: content\n' });
+
+    wrap('my-custom');
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
+    });
+  });
+
+  it('shows YAML panel when Raw YAML toggle clicked', async () => {
+    mockDetailAndYaml();
+    wrap('coding-agent');
+    await waitFor(() => screen.getByText('coding-agent'));
+    fireEvent.click(screen.getByText(/raw yaml/i));
+    await waitFor(() => {
+      expect(screen.getByText(/name: coding-agent/)).toBeInTheDocument();
+    });
+  });
+
+  it('shows fork panel when Fork clicked', async () => {
+    mockDetailAndYaml();
+    wrap('coding-agent');
+    await waitFor(() => screen.getByText('coding-agent'));
+    fireEvent.click(screen.getByRole('button', { name: /fork/i }));
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('new-persona-name')).toBeInTheDocument();
+    });
+  });
+
+  it('shows edit form when Edit clicked', async () => {
+    mockDetailAndYaml();
+    wrap('coding-agent');
+    await waitFor(() => screen.getByText('coding-agent'));
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/edit:/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows error state on fetch failure', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 404, json: async () => ({ detail: 'not found' }) });
+    wrap('nonexistent');
+    await waitFor(() => {
+      expect(screen.getByText(/failed to load/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows create form for ~new sentinel', () => {
+    wrap('~new');
+    expect(screen.getByText('New Persona')).toBeInTheDocument();
+  });
+
+  it('renders back button', async () => {
+    mockDetailAndYaml();
+    wrap('coding-agent');
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /← back/i })).toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/modules/ravn/pages/PersonaDetailView.test.tsx
+++ b/web/src/modules/ravn/pages/PersonaDetailView.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { PersonaDetailView } from './PersonaDetailView';
@@ -8,6 +8,10 @@ vi.stubGlobal('fetch', mockFetch);
 
 beforeEach(() => {
   mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 const mockDetail = {
@@ -258,6 +262,226 @@ describe('PersonaDetailView', () => {
     wrap('coding-agent');
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /← back/i })).toBeInTheDocument();
+    });
+  });
+
+  it('renders override badge when hasOverride is true', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        json: async () => ({ ...mockDetail, has_override: true }),
+      })
+      .mockResolvedValueOnce({ status: 200, ok: true, json: async () => 'yaml: content\n' });
+    wrap('coding-agent');
+    await waitFor(() => {
+      expect(screen.getByText('override')).toBeInTheDocument();
+    });
+  });
+
+  it('shows unlimited when iterationBudget is 0', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        json: async () => ({ ...mockDetail, iteration_budget: 0 }),
+      })
+      .mockResolvedValueOnce({ status: 200, ok: true, json: async () => 'yaml: content\n' });
+    wrap('coding-agent');
+    await waitFor(() => {
+      expect(screen.getByText('unlimited')).toBeInTheDocument();
+    });
+  });
+
+  it('calls create API when create form submitted and navigates', async () => {
+    mockFetch.mockResolvedValue({
+      status: 201,
+      ok: true,
+      json: async () => ({ ...mockDetail, name: 'new-agent' }),
+    });
+    wrap('~new');
+
+    fireEvent.change(screen.getByLabelText(/^name/i), { target: { value: 'new-agent' } });
+    fireEvent.change(screen.getByLabelText(/template/i), {
+      target: { value: 'You are helpful.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/personas'),
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+  });
+
+  it('shows action error when create fails', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ detail: 'Name already taken' }),
+    });
+    wrap('~new');
+
+    fireEvent.change(screen.getByLabelText(/^name/i), { target: { value: 'new-agent' } });
+    fireEvent.change(screen.getByLabelText(/template/i), {
+      target: { value: 'You are helpful.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Name already taken')).toBeInTheDocument();
+    });
+  });
+
+  it('saves updates and returns to view mode on successful edit', async () => {
+    mockDetailAndYaml();
+    wrap('coding-agent');
+    await waitFor(() => screen.getByText('coding-agent'));
+
+    mockFetch.mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      json: async () => ({ ...mockDetail }),
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+    await waitFor(() => screen.getByText(/edit:/i));
+
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Identity')).toBeInTheDocument();
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/coding-agent'),
+        expect.objectContaining({ method: 'PUT' })
+      );
+    });
+  });
+
+  it('shows action error when update fails', async () => {
+    mockDetailAndYaml();
+    wrap('coding-agent');
+    await waitFor(() => screen.getByText('coding-agent'));
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ detail: 'Server update error' }),
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+    await waitFor(() => screen.getByText(/edit:/i));
+
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Server update error')).toBeInTheDocument();
+    });
+  });
+
+  it('navigates to personas list after successful delete', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        json: async () => ({ ...mockDetail, is_builtin: false }),
+      })
+      .mockResolvedValueOnce({ status: 200, ok: true, json: async () => 'yaml: content\n' })
+      .mockResolvedValueOnce({ status: 204, ok: true, json: async () => ({}) });
+
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    wrap('coding-agent');
+    await waitFor(() => screen.getByRole('button', { name: /delete/i }));
+
+    fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Personas List')).toBeInTheDocument();
+    });
+  });
+
+  it('does not navigate when delete confirm is declined', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        json: async () => ({ ...mockDetail, is_builtin: false }),
+      })
+      .mockResolvedValueOnce({ status: 200, ok: true, json: async () => 'yaml: content\n' });
+
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    wrap('coding-agent');
+    await waitFor(() => screen.getByRole('button', { name: /delete/i }));
+
+    fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+
+    expect(screen.queryByText('Personas List')).not.toBeInTheDocument();
+  });
+
+  it('calls fork API when fork form submitted', async () => {
+    mockDetailAndYaml();
+    wrap('coding-agent');
+    await waitFor(() => screen.getByText('coding-agent'));
+
+    mockFetch.mockResolvedValue({
+      status: 201,
+      ok: true,
+      json: async () => ({ ...mockDetail, name: 'forked-agent', is_builtin: false }),
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Fork' }));
+    await waitFor(() => screen.getByPlaceholderText('new-persona-name'));
+
+    fireEvent.change(screen.getByPlaceholderText('new-persona-name'), {
+      target: { value: 'forked-agent' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create fork/i }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('fork'),
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+  });
+
+  it('shows action error when fork fails', async () => {
+    mockDetailAndYaml();
+    wrap('coding-agent');
+    await waitFor(() => screen.getByText('coding-agent'));
+
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: async () => ({ detail: 'Fork name already exists' }),
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Fork' }));
+    await waitFor(() => screen.getByPlaceholderText('new-persona-name'));
+
+    fireEvent.change(screen.getByPlaceholderText('new-persona-name'), {
+      target: { value: 'taken-name' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create fork/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Fork name already exists')).toBeInTheDocument();
+    });
+  });
+
+  it('cancel fork returns to view mode', async () => {
+    mockDetailAndYaml();
+    wrap('coding-agent');
+    await waitFor(() => screen.getByText('coding-agent'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Fork' }));
+    await waitFor(() => screen.getByPlaceholderText('new-persona-name'));
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText('new-persona-name')).not.toBeInTheDocument();
     });
   });
 });

--- a/web/src/modules/ravn/pages/PersonaDetailView.test.tsx
+++ b/web/src/modules/ravn/pages/PersonaDetailView.test.tsx
@@ -41,7 +41,7 @@ function wrap(name: string) {
         <Route path="/ravn/personas/:name" element={<PersonaDetailView />} />
         <Route path="/ravn/personas" element={<div>Personas List</div>} />
       </Routes>
-    </MemoryRouter>,
+    </MemoryRouter>
   );
 }
 
@@ -194,7 +194,8 @@ describe('PersonaDetailView', () => {
   it('renders delete button for custom personas', async () => {
     mockFetch
       .mockResolvedValueOnce({
-        status: 200, ok: true,
+        status: 200,
+        ok: true,
         json: async () => ({ ...mockDetail, is_builtin: false }),
       })
       .mockResolvedValueOnce({ status: 200, ok: true, json: async () => 'yaml: content\n' });
@@ -236,7 +237,11 @@ describe('PersonaDetailView', () => {
   });
 
   it('shows error state on fetch failure', async () => {
-    mockFetch.mockResolvedValue({ ok: false, status: 404, json: async () => ({ detail: 'not found' }) });
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({ detail: 'not found' }),
+    });
     wrap('nonexistent');
     await waitFor(() => {
       expect(screen.getByText(/failed to load/i)).toBeInTheDocument();

--- a/web/src/modules/ravn/pages/PersonaDetailView.test.tsx
+++ b/web/src/modules/ravn/pages/PersonaDetailView.test.tsx
@@ -401,6 +401,32 @@ describe('PersonaDetailView', () => {
     });
   });
 
+  it('does not navigate when delete API fails', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        json: async () => ({ ...mockDetail, is_builtin: false }),
+      })
+      .mockResolvedValueOnce({ status: 200, ok: true, json: async () => 'yaml: content\n' })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: async () => ({ detail: 'Delete failed on server' }),
+      });
+
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    wrap('coding-agent');
+    await waitFor(() => screen.getByRole('button', { name: /delete/i }));
+
+    fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Delete failed on server')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Personas List')).not.toBeInTheDocument();
+  });
+
   it('does not navigate when delete confirm is declined', async () => {
     mockFetch
       .mockResolvedValueOnce({

--- a/web/src/modules/ravn/pages/PersonaDetailView.tsx
+++ b/web/src/modules/ravn/pages/PersonaDetailView.tsx
@@ -111,20 +111,25 @@ export function PersonaDetailView() {
     return (
       <div className={styles.container}>
         <div className={styles.pageHeader}>
-          <button className={styles.backButton} onClick={() => {
-            if (isCreate) {
-              navigate('/ravn/personas');
-            } else {
-              setMode('view');
-            }
-          }}>
+          <button
+            className={styles.backButton}
+            onClick={() => {
+              if (isCreate) {
+                navigate('/ravn/personas');
+              } else {
+                setMode('view');
+              }
+            }}
+          >
             ← Back
           </button>
-          <h2 className={styles.pageTitle}>{isCreate ? 'New Persona' : `Edit: ${persona?.name}`}</h2>
+          <h2 className={styles.pageTitle}>
+            {isCreate ? 'New Persona' : `Edit: ${persona?.name}`}
+          </h2>
         </div>
         {actionError && <div className={styles.actionError}>{actionError}</div>}
         <PersonaForm
-          initial={mode === 'edit' ? persona ?? undefined : undefined}
+          initial={mode === 'edit' ? (persona ?? undefined) : undefined}
           onSubmit={isCreate ? handleCreate : handleUpdate}
           onCancel={() => {
             if (isCreate) {
@@ -151,8 +156,12 @@ export function PersonaDetailView() {
         <div className={styles.titleRow}>
           <h2 className={styles.pageTitle}>{persona.name}</h2>
           <div className={styles.titleBadges}>
-            {persona.isBuiltin && <span className={cn(styles.badge, styles.builtinBadge)}>built-in</span>}
-            {persona.hasOverride && <span className={cn(styles.badge, styles.overrideBadge)}>override</span>}
+            {persona.isBuiltin && (
+              <span className={cn(styles.badge, styles.builtinBadge)}>built-in</span>
+            )}
+            {persona.hasOverride && (
+              <span className={cn(styles.badge, styles.overrideBadge)}>override</span>
+            )}
           </div>
         </div>
         <div className={styles.actions}>
@@ -163,10 +172,7 @@ export function PersonaDetailView() {
             Edit
           </button>
           {!persona.isBuiltin && (
-            <button
-              className={cn(styles.actionButton, styles.deleteButton)}
-              onClick={handleDelete}
-            >
+            <button className={cn(styles.actionButton, styles.deleteButton)} onClick={handleDelete}>
               Delete
             </button>
           )}
@@ -187,11 +193,7 @@ export function PersonaDetailView() {
             placeholder="new-persona-name"
             autoFocus
           />
-          <button
-            className={styles.actionButton}
-            onClick={handleFork}
-            disabled={!forkName.trim()}
-          >
+          <button className={styles.actionButton} onClick={handleFork} disabled={!forkName.trim()}>
             Create Fork
           </button>
           <button className={styles.cancelForkButton} onClick={() => setMode('view')}>
@@ -209,7 +211,9 @@ export function PersonaDetailView() {
             <dt className={styles.dt}>Permission Mode</dt>
             <dd className={styles.dd}>{persona.permissionMode || '—'}</dd>
             <dt className={styles.dt}>Iteration Budget</dt>
-            <dd className={styles.dd}>{persona.iterationBudget === 0 ? 'unlimited' : persona.iterationBudget}</dd>
+            <dd className={styles.dd}>
+              {persona.iterationBudget === 0 ? 'unlimited' : persona.iterationBudget}
+            </dd>
             <dt className={styles.dt}>Source</dt>
             <dd className={styles.dd}>{persona.yamlSource}</dd>
           </dl>
@@ -223,17 +227,25 @@ export function PersonaDetailView() {
             <dd className={styles.dd}>
               {persona.allowedTools.length > 0 ? (
                 <div className={styles.tagRow}>
-                  {persona.allowedTools.map(t => <ToolBadge key={t} tool={t} />)}
+                  {persona.allowedTools.map(t => (
+                    <ToolBadge key={t} tool={t} />
+                  ))}
                 </div>
-              ) : '—'}
+              ) : (
+                '—'
+              )}
             </dd>
             <dt className={styles.dt}>Forbidden Tools</dt>
             <dd className={styles.dd}>
               {persona.forbiddenTools.length > 0 ? (
                 <div className={styles.tagRow}>
-                  {persona.forbiddenTools.map(t => <ToolBadge key={t} tool={t} />)}
+                  {persona.forbiddenTools.map(t => (
+                    <ToolBadge key={t} tool={t} />
+                  ))}
                 </div>
-              ) : '—'}
+              ) : (
+                '—'
+              )}
             </dd>
           </dl>
         </section>
@@ -247,7 +259,9 @@ export function PersonaDetailView() {
             <dt className={styles.dt}>Extended Thinking</dt>
             <dd className={styles.dd}>{persona.llm.thinkingEnabled ? 'enabled' : 'disabled'}</dd>
             <dt className={styles.dt}>Max Tokens</dt>
-            <dd className={styles.dd}>{persona.llm.maxTokens === 0 ? 'default' : persona.llm.maxTokens}</dd>
+            <dd className={styles.dd}>
+              {persona.llm.maxTokens === 0 ? 'default' : persona.llm.maxTokens}
+            </dd>
           </dl>
         </section>
 
@@ -265,9 +279,7 @@ export function PersonaDetailView() {
             </dd>
             <dt className={styles.dt}>Context Injects</dt>
             <dd className={styles.dd}>
-              {persona.consumes.injects.length > 0
-                ? persona.consumes.injects.join(', ')
-                : '—'}
+              {persona.consumes.injects.length > 0 ? persona.consumes.injects.join(', ') : '—'}
             </dd>
             <dt className={styles.dt}>Fan-in Strategy</dt>
             <dd className={styles.dd}>{persona.fanIn.strategy || '—'}</dd>
@@ -284,15 +296,10 @@ export function PersonaDetailView() {
 
         {/* YAML Preview */}
         <section className={styles.section}>
-          <button
-            className={styles.toggleYaml}
-            onClick={() => setShowYaml(v => !v)}
-          >
+          <button className={styles.toggleYaml} onClick={() => setShowYaml(v => !v)}>
             {showYaml ? '▾' : '▸'} Raw YAML
           </button>
-          {showYaml && yaml && (
-            <pre className={styles.yaml}>{yaml}</pre>
-          )}
+          {showYaml && yaml && <pre className={styles.yaml}>{yaml}</pre>}
         </section>
       </div>
     </div>

--- a/web/src/modules/ravn/pages/PersonaDetailView.tsx
+++ b/web/src/modules/ravn/pages/PersonaDetailView.tsx
@@ -1,0 +1,300 @@
+import { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import {
+  getPersona,
+  getPersonaYaml,
+  createPersona,
+  updatePersona,
+  deletePersona,
+  forkPersona,
+} from '../api/client';
+import type { PersonaDetail, PersonaCreateRequest } from '../api/types';
+import { PersonaForm } from '../components/PersonaForm';
+import { ToolBadge } from '../components/ToolBadge';
+import { cn } from '@/modules/shared/utils/classnames';
+import styles from './PersonaDetailView.module.css';
+
+type ViewMode = 'view' | 'edit' | 'fork' | 'create';
+
+const NEW_SENTINEL = '~new';
+
+export function PersonaDetailView() {
+  const { name } = useParams<{ name: string }>();
+  const navigate = useNavigate();
+
+  const isCreate = name === NEW_SENTINEL;
+
+  const [persona, setPersona] = useState<PersonaDetail | null>(null);
+  const [yaml, setYaml] = useState<string | null>(null);
+  const [loading, setLoading] = useState(!isCreate);
+  const [error, setError] = useState<string | null>(null);
+  const [mode, setMode] = useState<ViewMode>(isCreate ? 'create' : 'view');
+  const [showYaml, setShowYaml] = useState(false);
+  const [forkName, setForkName] = useState('');
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (isCreate || !name) return;
+
+    Promise.all([getPersona(name), getPersonaYaml(name)])
+      .then(([detail, rawYaml]) => {
+        setPersona(detail);
+        setYaml(rawYaml);
+        setLoading(false);
+      })
+      .catch(() => {
+        setError('Failed to load persona');
+        setLoading(false);
+      });
+  }, [name, isCreate]);
+
+  async function handleCreate(req: PersonaCreateRequest) {
+    setActionError(null);
+    const created = await createPersona(req).catch(err => {
+      setActionError(err.detail ?? 'Create failed');
+      return null;
+    });
+    if (!created) return;
+    navigate(`/ravn/personas/${encodeURIComponent(created.name)}`);
+  }
+
+  async function handleUpdate(req: PersonaCreateRequest) {
+    if (!persona) return;
+    setActionError(null);
+    const updated = await updatePersona(persona.name, req).catch(err => {
+      setActionError(err.detail ?? 'Update failed');
+      return null;
+    });
+    if (!updated) return;
+    setPersona(updated);
+    setMode('view');
+  }
+
+  async function handleDelete() {
+    if (!persona) return;
+    if (!window.confirm(`Delete persona "${persona.name}"? This cannot be undone.`)) return;
+    setActionError(null);
+    await deletePersona(persona.name).catch(err => {
+      setActionError(err.detail ?? 'Delete failed');
+      return;
+    });
+    navigate('/ravn/personas');
+  }
+
+  async function handleFork() {
+    if (!persona || !forkName.trim()) return;
+    setActionError(null);
+    const forked = await forkPersona(persona.name, { newName: forkName.trim() }).catch(err => {
+      setActionError(err.detail ?? 'Fork failed');
+      return null;
+    });
+    if (!forked) return;
+    navigate(`/ravn/personas/${encodeURIComponent(forked.name)}`);
+  }
+
+  if (loading) {
+    return <div className={styles.status}>Loading…</div>;
+  }
+
+  if (error) {
+    return (
+      <div className={styles.status}>
+        <span className={styles.errorText}>{error}</span>
+        <button className={styles.backButton} onClick={() => navigate('/ravn/personas')}>
+          ← Back
+        </button>
+      </div>
+    );
+  }
+
+  if (isCreate || mode === 'edit') {
+    return (
+      <div className={styles.container}>
+        <div className={styles.pageHeader}>
+          <button className={styles.backButton} onClick={() => {
+            if (isCreate) {
+              navigate('/ravn/personas');
+            } else {
+              setMode('view');
+            }
+          }}>
+            ← Back
+          </button>
+          <h2 className={styles.pageTitle}>{isCreate ? 'New Persona' : `Edit: ${persona?.name}`}</h2>
+        </div>
+        {actionError && <div className={styles.actionError}>{actionError}</div>}
+        <PersonaForm
+          initial={mode === 'edit' ? persona ?? undefined : undefined}
+          onSubmit={isCreate ? handleCreate : handleUpdate}
+          onCancel={() => {
+            if (isCreate) {
+              navigate('/ravn/personas');
+            } else {
+              setMode('view');
+            }
+          }}
+          submitLabel={isCreate ? 'Create' : 'Save Changes'}
+        />
+      </div>
+    );
+  }
+
+  if (!persona) return null;
+
+  return (
+    <div className={styles.container}>
+      {/* Page header */}
+      <div className={styles.pageHeader}>
+        <button className={styles.backButton} onClick={() => navigate('/ravn/personas')}>
+          ← Back
+        </button>
+        <div className={styles.titleRow}>
+          <h2 className={styles.pageTitle}>{persona.name}</h2>
+          <div className={styles.titleBadges}>
+            {persona.isBuiltin && <span className={cn(styles.badge, styles.builtinBadge)}>built-in</span>}
+            {persona.hasOverride && <span className={cn(styles.badge, styles.overrideBadge)}>override</span>}
+          </div>
+        </div>
+        <div className={styles.actions}>
+          <button className={styles.actionButton} onClick={() => setMode('fork')}>
+            Fork
+          </button>
+          <button className={styles.actionButton} onClick={() => setMode('edit')}>
+            Edit
+          </button>
+          {!persona.isBuiltin && (
+            <button
+              className={cn(styles.actionButton, styles.deleteButton)}
+              onClick={handleDelete}
+            >
+              Delete
+            </button>
+          )}
+        </div>
+      </div>
+
+      {actionError && <div className={styles.actionError}>{actionError}</div>}
+
+      {/* Fork panel */}
+      {mode === 'fork' && (
+        <div className={styles.forkPanel}>
+          <span className={styles.forkLabel}>Fork as:</span>
+          <input
+            className={styles.forkInput}
+            type="text"
+            value={forkName}
+            onChange={e => setForkName(e.target.value)}
+            placeholder="new-persona-name"
+            autoFocus
+          />
+          <button
+            className={styles.actionButton}
+            onClick={handleFork}
+            disabled={!forkName.trim()}
+          >
+            Create Fork
+          </button>
+          <button className={styles.cancelForkButton} onClick={() => setMode('view')}>
+            Cancel
+          </button>
+        </div>
+      )}
+
+      {/* Detail sections */}
+      <div className={styles.sections}>
+        {/* Identity */}
+        <section className={styles.section}>
+          <h3 className={styles.sectionTitle}>Identity</h3>
+          <dl className={styles.dl}>
+            <dt className={styles.dt}>Permission Mode</dt>
+            <dd className={styles.dd}>{persona.permissionMode || '—'}</dd>
+            <dt className={styles.dt}>Iteration Budget</dt>
+            <dd className={styles.dd}>{persona.iterationBudget === 0 ? 'unlimited' : persona.iterationBudget}</dd>
+            <dt className={styles.dt}>Source</dt>
+            <dd className={styles.dd}>{persona.yamlSource}</dd>
+          </dl>
+        </section>
+
+        {/* Tools & Permissions */}
+        <section className={styles.section}>
+          <h3 className={styles.sectionTitle}>Tools & Permissions</h3>
+          <dl className={styles.dl}>
+            <dt className={styles.dt}>Allowed Tools</dt>
+            <dd className={styles.dd}>
+              {persona.allowedTools.length > 0 ? (
+                <div className={styles.tagRow}>
+                  {persona.allowedTools.map(t => <ToolBadge key={t} tool={t} />)}
+                </div>
+              ) : '—'}
+            </dd>
+            <dt className={styles.dt}>Forbidden Tools</dt>
+            <dd className={styles.dd}>
+              {persona.forbiddenTools.length > 0 ? (
+                <div className={styles.tagRow}>
+                  {persona.forbiddenTools.map(t => <ToolBadge key={t} tool={t} />)}
+                </div>
+              ) : '—'}
+            </dd>
+          </dl>
+        </section>
+
+        {/* LLM Settings */}
+        <section className={styles.section}>
+          <h3 className={styles.sectionTitle}>LLM Settings</h3>
+          <dl className={styles.dl}>
+            <dt className={styles.dt}>Primary Alias</dt>
+            <dd className={styles.dd}>{persona.llm.primaryAlias || '—'}</dd>
+            <dt className={styles.dt}>Extended Thinking</dt>
+            <dd className={styles.dd}>{persona.llm.thinkingEnabled ? 'enabled' : 'disabled'}</dd>
+            <dt className={styles.dt}>Max Tokens</dt>
+            <dd className={styles.dd}>{persona.llm.maxTokens === 0 ? 'default' : persona.llm.maxTokens}</dd>
+          </dl>
+        </section>
+
+        {/* Pipeline Contract */}
+        <section className={styles.section}>
+          <h3 className={styles.sectionTitle}>Pipeline Contract</h3>
+          <dl className={styles.dl}>
+            <dt className={styles.dt}>Produces</dt>
+            <dd className={styles.dd}>{persona.produces.eventType || '—'}</dd>
+            <dt className={styles.dt}>Consumes</dt>
+            <dd className={styles.dd}>
+              {persona.consumes.eventTypes.length > 0
+                ? persona.consumes.eventTypes.join(', ')
+                : '—'}
+            </dd>
+            <dt className={styles.dt}>Context Injects</dt>
+            <dd className={styles.dd}>
+              {persona.consumes.injects.length > 0
+                ? persona.consumes.injects.join(', ')
+                : '—'}
+            </dd>
+            <dt className={styles.dt}>Fan-in Strategy</dt>
+            <dd className={styles.dd}>{persona.fanIn.strategy || '—'}</dd>
+            <dt className={styles.dt}>Contributes To</dt>
+            <dd className={styles.dd}>{persona.fanIn.contributesTo || '—'}</dd>
+          </dl>
+        </section>
+
+        {/* System Prompt */}
+        <section className={styles.section}>
+          <h3 className={styles.sectionTitle}>System Prompt</h3>
+          <pre className={styles.prompt}>{persona.systemPromptTemplate || '—'}</pre>
+        </section>
+
+        {/* YAML Preview */}
+        <section className={styles.section}>
+          <button
+            className={styles.toggleYaml}
+            onClick={() => setShowYaml(v => !v)}
+          >
+            {showYaml ? '▾' : '▸'} Raw YAML
+          </button>
+          {showYaml && yaml && (
+            <pre className={styles.yaml}>{yaml}</pre>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/web/src/modules/ravn/pages/PersonaDetailView.tsx
+++ b/web/src/modules/ravn/pages/PersonaDetailView.tsx
@@ -13,6 +13,7 @@ import { PersonaForm } from '../components/PersonaForm';
 import { ToolBadge } from '../components/ToolBadge';
 import { cn } from '@/modules/shared/utils/classnames';
 import styles from './PersonaDetailView.module.css';
+import badgeStyles from '../styles/badges.module.css';
 
 type ViewMode = 'view' | 'edit' | 'fork' | 'create';
 
@@ -74,10 +75,13 @@ export function PersonaDetailView() {
     if (!persona) return;
     if (!window.confirm(`Delete persona "${persona.name}"? This cannot be undone.`)) return;
     setActionError(null);
-    await deletePersona(persona.name).catch(err => {
-      setActionError(err.detail ?? 'Delete failed');
-      return;
-    });
+    const ok = await deletePersona(persona.name)
+      .then(() => true)
+      .catch(err => {
+        setActionError(err.detail ?? 'Delete failed');
+        return false;
+      });
+    if (!ok) return;
     navigate('/ravn/personas');
   }
 
@@ -157,10 +161,10 @@ export function PersonaDetailView() {
           <h2 className={styles.pageTitle}>{persona.name}</h2>
           <div className={styles.titleBadges}>
             {persona.isBuiltin && (
-              <span className={cn(styles.badge, styles.builtinBadge)}>built-in</span>
+              <span className={cn(badgeStyles.badge, badgeStyles.builtinBadge)}>built-in</span>
             )}
             {persona.hasOverride && (
-              <span className={cn(styles.badge, styles.overrideBadge)}>override</span>
+              <span className={cn(badgeStyles.badge, badgeStyles.overrideBadge)}>override</span>
             )}
           </div>
         </div>

--- a/web/src/modules/ravn/pages/PersonasView.module.css
+++ b/web/src/modules/ravn/pages/PersonasView.module.css
@@ -1,0 +1,100 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: var(--space-6);
+  gap: var(--space-6);
+}
+
+/* -- Toolbar -- */
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  flex-shrink: 0;
+}
+
+.filterBar {
+  display: flex;
+  gap: var(--space-1);
+  background-color: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-1);
+}
+
+.filterButton {
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
+  font-family: var(--font-sans);
+  color: var(--color-text-secondary);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition:
+    color var(--transition-fast),
+    background-color var(--transition-fast);
+}
+
+.filterButton:hover {
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-tertiary);
+}
+
+.filterButtonActive {
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-tertiary);
+}
+
+.newButton {
+  padding: var(--space-2) var(--space-4);
+  background-color: var(--color-brand);
+  border: none;
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
+  font-family: var(--font-sans);
+  color: var(--color-bg-primary);
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity var(--transition-fast);
+}
+
+.newButton:hover {
+  opacity: 0.85;
+}
+
+/* -- States -- */
+
+.status {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  font-family: var(--font-sans);
+}
+
+.error {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  font-size: var(--text-sm);
+  color: var(--color-accent-red);
+  font-family: var(--font-sans);
+}
+
+/* -- Grid -- */
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: var(--space-4);
+  align-content: start;
+}

--- a/web/src/modules/ravn/pages/PersonasView.test.tsx
+++ b/web/src/modules/ravn/pages/PersonasView.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { PersonasView } from './PersonasView';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+function mkSummary(name: string, isBuiltin = true) {
+  return {
+    name,
+    permission_mode: 'workspace-write',
+    allowed_tools: ['file', 'git'],
+    iteration_budget: 40,
+    is_builtin: isBuiltin,
+    has_override: false,
+    produces_event: '',
+    consumes_events: [],
+  };
+}
+
+function mockOk(data: unknown) {
+  mockFetch.mockResolvedValue({
+    status: 200,
+    ok: true,
+    json: async () => data,
+  });
+}
+
+function wrap(element: React.ReactElement) {
+  return render(<MemoryRouter>{element}</MemoryRouter>);
+}
+
+describe('PersonasView', () => {
+  it('shows loading state initially', () => {
+    mockOk([]);
+    wrap(<PersonasView />);
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+  });
+
+  it('shows empty state when no personas returned', async () => {
+    mockOk([]);
+    wrap(<PersonasView />);
+    await waitFor(() => {
+      expect(screen.getByText(/no personas found/i)).toBeInTheDocument();
+    });
+  });
+
+  it('renders persona cards from API', async () => {
+    mockOk([mkSummary('coding-agent'), mkSummary('research-agent')]);
+    wrap(<PersonasView />);
+    await waitFor(() => {
+      expect(screen.getByText('coding-agent')).toBeInTheDocument();
+      expect(screen.getByText('research-agent')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error message on API failure', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 500, json: async () => ({ detail: 'error' }) });
+    wrap(<PersonasView />);
+    await waitFor(() => {
+      expect(screen.getByText(/failed to load/i)).toBeInTheDocument();
+    });
+  });
+
+  it('renders filter buttons', () => {
+    mockOk([]);
+    wrap(<PersonasView />);
+    expect(screen.getByRole('button', { name: 'All' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Built-in' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Custom' })).toBeInTheDocument();
+  });
+
+  it('renders New Persona button', () => {
+    mockOk([]);
+    wrap(<PersonasView />);
+    expect(screen.getByRole('button', { name: /new persona/i })).toBeInTheDocument();
+  });
+
+  it('changes filter to Built-in on click', async () => {
+    mockOk([mkSummary('coding-agent')]);
+    wrap(<PersonasView />);
+
+    await waitFor(() => screen.getByText('coding-agent'));
+
+    mockOk([mkSummary('coding-agent')]);
+    fireEvent.click(screen.getByRole('button', { name: 'Built-in' }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('source=builtin'),
+        expect.any(Object),
+      );
+    });
+  });
+
+  it('changes filter to Custom on click', async () => {
+    mockOk([]);
+    wrap(<PersonasView />);
+
+    await waitFor(() => screen.getByText(/no personas/i));
+
+    mockOk([mkSummary('my-custom', false)]);
+    fireEvent.click(screen.getByRole('button', { name: 'Custom' }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('source=custom'),
+        expect.any(Object),
+      );
+    });
+  });
+
+  it('renders built-in badge on built-in persona card', async () => {
+    mockOk([mkSummary('coding-agent', true)]);
+    wrap(<PersonasView />);
+    await waitFor(() => {
+      expect(screen.getByText('built-in')).toBeInTheDocument();
+    });
+  });
+
+  it('renders multiple personas as a grid of cards', async () => {
+    mockOk([
+      mkSummary('coding-agent'),
+      mkSummary('research-agent'),
+      mkSummary('planning-agent'),
+    ]);
+    wrap(<PersonasView />);
+    await waitFor(() => {
+      expect(screen.getAllByRole('link')).toHaveLength(3);
+    });
+  });
+});

--- a/web/src/modules/ravn/pages/PersonasView.test.tsx
+++ b/web/src/modules/ravn/pages/PersonasView.test.tsx
@@ -60,7 +60,11 @@ describe('PersonasView', () => {
   });
 
   it('shows error message on API failure', async () => {
-    mockFetch.mockResolvedValue({ ok: false, status: 500, json: async () => ({ detail: 'error' }) });
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ detail: 'error' }),
+    });
     wrap(<PersonasView />);
     await waitFor(() => {
       expect(screen.getByText(/failed to load/i)).toBeInTheDocument();
@@ -93,7 +97,7 @@ describe('PersonasView', () => {
     await waitFor(() => {
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining('source=builtin'),
-        expect.any(Object),
+        expect.any(Object)
       );
     });
   });
@@ -110,7 +114,7 @@ describe('PersonasView', () => {
     await waitFor(() => {
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining('source=custom'),
-        expect.any(Object),
+        expect.any(Object)
       );
     });
   });
@@ -124,11 +128,7 @@ describe('PersonasView', () => {
   });
 
   it('renders multiple personas as a grid of cards', async () => {
-    mockOk([
-      mkSummary('coding-agent'),
-      mkSummary('research-agent'),
-      mkSummary('planning-agent'),
-    ]);
+    mockOk([mkSummary('coding-agent'), mkSummary('research-agent'), mkSummary('planning-agent')]);
     wrap(<PersonasView />);
     await waitFor(() => {
       expect(screen.getAllByRole('link')).toHaveLength(3);

--- a/web/src/modules/ravn/pages/PersonasView.tsx
+++ b/web/src/modules/ravn/pages/PersonasView.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { listPersonas } from '../api/client';
+import type { PersonaSummary, PersonaFilter } from '../api/types';
+import { PersonaCard } from '../components/PersonaCard';
+import { cn } from '@/modules/shared/utils/classnames';
+import styles from './PersonasView.module.css';
+
+const FILTERS: { key: PersonaFilter; label: string }[] = [
+  { key: 'all', label: 'All' },
+  { key: 'builtin', label: 'Built-in' },
+  { key: 'custom', label: 'Custom' },
+];
+
+export function PersonasView() {
+  const navigate = useNavigate();
+  const [personas, setPersonas] = useState<PersonaSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState<PersonaFilter>('all');
+
+  useEffect(() => {
+    listPersonas(filter)
+      .then(data => {
+        setPersonas(data);
+        setError(null);
+        setLoading(false);
+      })
+      .catch(() => {
+        setError('Failed to load personas');
+        setLoading(false);
+      });
+  }, [filter]);
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.toolbar}>
+        <div className={styles.filterBar}>
+          {FILTERS.map(f => (
+            <button
+              key={f.key}
+              className={cn(styles.filterButton, filter === f.key && styles.filterButtonActive)}
+              onClick={() => setFilter(f.key)}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+        <button
+          className={styles.newButton}
+          onClick={() => navigate('/ravn/personas/~new')}
+        >
+          New Persona
+        </button>
+      </div>
+
+      {loading && <div className={styles.status}>Loading personas…</div>}
+
+      {!loading && error && <div className={styles.error}>{error}</div>}
+
+      {!loading && !error && personas.length === 0 && (
+        <div className={styles.status}>No personas found.</div>
+      )}
+
+      {!loading && !error && personas.length > 0 && (
+        <div className={styles.grid}>
+          {personas.map(persona => (
+            <PersonaCard key={persona.name} persona={persona} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/modules/ravn/pages/PersonasView.tsx
+++ b/web/src/modules/ravn/pages/PersonasView.tsx
@@ -46,10 +46,7 @@ export function PersonasView() {
             </button>
           ))}
         </div>
-        <button
-          className={styles.newButton}
-          onClick={() => navigate('/ravn/personas/~new')}
-        >
+        <button className={styles.newButton} onClick={() => navigate('/ravn/personas/~new')}>
           New Persona
         </button>
       </div>

--- a/web/src/modules/ravn/pages/PersonasView.tsx
+++ b/web/src/modules/ravn/pages/PersonasView.tsx
@@ -15,20 +15,22 @@ const FILTERS: { key: PersonaFilter; label: string }[] = [
 export function PersonasView() {
   const navigate = useNavigate();
   const [personas, setPersonas] = useState<PersonaSummary[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loadedFilter, setLoadedFilter] = useState<PersonaFilter | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [filter, setFilter] = useState<PersonaFilter>('all');
+
+  const loading = loadedFilter !== filter;
 
   useEffect(() => {
     listPersonas(filter)
       .then(data => {
         setPersonas(data);
         setError(null);
-        setLoading(false);
+        setLoadedFilter(filter);
       })
       .catch(() => {
         setError('Failed to load personas');
-        setLoading(false);
+        setLoadedFilter(filter);
       });
   }, [filter]);
 

--- a/web/src/modules/ravn/pages/RavnLayout.module.css
+++ b/web/src/modules/ravn/pages/RavnLayout.module.css
@@ -1,0 +1,80 @@
+.layout {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
+/* -- Top navigation bar -- */
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  padding: 0 var(--space-6);
+  height: 52px;
+  background-color: var(--color-bg-secondary);
+  border-bottom: 1px solid var(--color-border);
+  flex-shrink: 0;
+  z-index: 10;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
+
+.rune {
+  font-size: var(--text-xl);
+  color: var(--color-brand);
+}
+
+.brandName {
+  font-size: var(--text-base);
+  font-weight: 600;
+  color: var(--color-text-primary);
+  font-family: var(--font-mono);
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  margin-left: auto;
+}
+
+.navLink {
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  font-family: var(--font-sans);
+  color: var(--color-text-secondary);
+  transition:
+    color var(--transition-fast),
+    background-color var(--transition-fast);
+  text-decoration: none;
+}
+
+.navLink:hover {
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-tertiary);
+  text-decoration: none;
+}
+
+.navLinkActive {
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-tertiary);
+}
+
+/* -- Content area -- */
+
+.content {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}

--- a/web/src/modules/ravn/pages/RavnLayout.test.tsx
+++ b/web/src/modules/ravn/pages/RavnLayout.test.tsx
@@ -14,7 +14,7 @@ function wrap(initialPath = '/ravn/chat') {
           <Route path="config" element={<div>Config Content</div>} />
         </Route>
       </Routes>
-    </MemoryRouter>,
+    </MemoryRouter>
   );
 }
 
@@ -44,12 +44,18 @@ describe('RavnLayout', () => {
 
   it('Personas nav link points to correct path', () => {
     wrap();
-    expect(screen.getByRole('link', { name: 'Personas' })).toHaveAttribute('href', '/ravn/personas');
+    expect(screen.getByRole('link', { name: 'Personas' })).toHaveAttribute(
+      'href',
+      '/ravn/personas'
+    );
   });
 
   it('Sessions nav link points to correct path', () => {
     wrap();
-    expect(screen.getByRole('link', { name: 'Sessions' })).toHaveAttribute('href', '/ravn/sessions');
+    expect(screen.getByRole('link', { name: 'Sessions' })).toHaveAttribute(
+      'href',
+      '/ravn/sessions'
+    );
   });
 
   it('Config nav link points to correct path', () => {

--- a/web/src/modules/ravn/pages/RavnLayout.test.tsx
+++ b/web/src/modules/ravn/pages/RavnLayout.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { RavnLayout } from './RavnLayout';
+
+function wrap(initialPath = '/ravn/chat') {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route path="/ravn" element={<RavnLayout />}>
+          <Route path="chat" element={<div>Chat Content</div>} />
+          <Route path="sessions" element={<div>Sessions Content</div>} />
+          <Route path="personas" element={<div>Personas Content</div>} />
+          <Route path="config" element={<div>Config Content</div>} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('RavnLayout', () => {
+  it('renders the brand name', () => {
+    wrap();
+    expect(screen.getByText('Ravn')).toBeInTheDocument();
+  });
+
+  it('renders all nav links', () => {
+    wrap();
+    expect(screen.getByRole('link', { name: 'Chat' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Sessions' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Personas' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Config' })).toBeInTheDocument();
+  });
+
+  it('renders outlet content', () => {
+    wrap('/ravn/chat');
+    expect(screen.getByText('Chat Content')).toBeInTheDocument();
+  });
+
+  it('Chat nav link points to correct path', () => {
+    wrap();
+    expect(screen.getByRole('link', { name: 'Chat' })).toHaveAttribute('href', '/ravn/chat');
+  });
+
+  it('Personas nav link points to correct path', () => {
+    wrap();
+    expect(screen.getByRole('link', { name: 'Personas' })).toHaveAttribute('href', '/ravn/personas');
+  });
+
+  it('Sessions nav link points to correct path', () => {
+    wrap();
+    expect(screen.getByRole('link', { name: 'Sessions' })).toHaveAttribute('href', '/ravn/sessions');
+  });
+
+  it('Config nav link points to correct path', () => {
+    wrap();
+    expect(screen.getByRole('link', { name: 'Config' })).toHaveAttribute('href', '/ravn/config');
+  });
+});

--- a/web/src/modules/ravn/pages/RavnLayout.tsx
+++ b/web/src/modules/ravn/pages/RavnLayout.tsx
@@ -1,0 +1,37 @@
+import { NavLink, Outlet } from 'react-router-dom';
+import { cn } from '@/modules/shared/utils/classnames';
+import styles from './RavnLayout.module.css';
+
+const navItems = [
+  { to: 'chat', label: 'Chat' },
+  { to: 'sessions', label: 'Sessions' },
+  { to: 'personas', label: 'Personas' },
+  { to: 'config', label: 'Config' },
+];
+
+export function RavnLayout() {
+  return (
+    <div className={styles.layout}>
+      <header className={styles.header}>
+        <div className={styles.brand}>
+          <span className={styles.rune}>&#x16B3;</span>
+          <span className={styles.brandName}>Ravn</span>
+        </div>
+        <nav className={styles.nav}>
+          {navItems.map(item => (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              className={({ isActive }) => cn(styles.navLink, isActive && styles.navLinkActive)}
+            >
+              {item.label}
+            </NavLink>
+          ))}
+        </nav>
+      </header>
+      <main className={styles.content}>
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/web/src/modules/ravn/register.ts
+++ b/web/src/modules/ravn/register.ts
@@ -6,6 +6,7 @@ registerModuleDefinition({
   label: 'Ravn',
   icon: RaidhoRune,
   basePath: '/ravn',
+  layout: () => import('./pages/RavnLayout').then(m => ({ default: m.RavnLayout })),
   routes: [
     { path: '', index: true, redirectTo: 'chat' },
     {
@@ -19,6 +20,14 @@ registerModuleDefinition({
     {
       path: 'config',
       load: () => import('./pages/AgentsView').then(m => ({ default: m.AgentsView })),
+    },
+    {
+      path: 'personas',
+      load: () => import('./pages/PersonasView').then(m => ({ default: m.PersonasView })),
+    },
+    {
+      path: 'personas/:name',
+      load: () => import('./pages/PersonaDetailView').then(m => ({ default: m.PersonaDetailView })),
     },
   ],
 });

--- a/web/src/modules/ravn/styles/badges.module.css
+++ b/web/src/modules/ravn/styles/badges.module.css
@@ -1,0 +1,23 @@
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 var(--space-2);
+  height: 20px;
+  border-radius: var(--radius-full);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  font-family: var(--font-sans);
+  white-space: nowrap;
+}
+
+.builtinBadge {
+  background-color: color-mix(in srgb, var(--color-accent-amber) 15%, transparent);
+  color: var(--color-accent-amber);
+  border: 1px solid color-mix(in srgb, var(--color-accent-amber) 25%, transparent);
+}
+
+.overrideBadge {
+  background-color: color-mix(in srgb, var(--color-accent-orange) 15%, transparent);
+  color: var(--color-accent-orange);
+  border: 1px solid color-mix(in srgb, var(--color-accent-orange) 25%, transparent);
+}


### PR DESCRIPTION
## Summary

- **API layer**: `types.ts` with camelCase domain interfaces + `client.ts` with 7 functions (listPersonas, getPersona, getPersonaYaml, createPersona, updatePersona, deletePersona, forkPersona) with snake_case to camelCase transforms
- **RavnLayout**: tab bar (Chat | Sessions | Personas | Config) following MimirLayout pattern; `register.ts` updated with layout wrapper and two new routes
- **PersonaCard**: card grid component with name, built-in/override badges, permission mode, iteration budget, produces event, and tool badges
- **ToolBadge**: monospace chip for tool group names
- **PersonaForm**: full create/edit form with validation and live tool preview
- **PersonasView**: card grid with All/Built-in/Custom filter bar and New Persona button
- **PersonaDetailView**: view mode (all sections + raw YAML toggle), edit/create mode via PersonaForm, fork panel, delete (custom only)

All components use CSS Modules with design tokens only — no inline styles, no Tailwind.

## Test plan

- [x] 105 tests passing (vitest run)
- [x] ESLint clean (eslint --max-warnings=0)
- [x] TypeScript clean (tsc --noEmit)
- [x] PersonaCard: name, badges, tool tags, link target
- [x] PersonaForm: required field validation, invalid name pattern, onSubmit payload, pre-fill, tool preview
- [x] PersonasView: loading/empty/error states, card grid, filter buttons
- [x] PersonaDetailView: all sections, action buttons, YAML toggle, fork/edit/create flows
- [x] API client: camelCase transforms, correct HTTP methods for all 7 functions

Closes NIU-608

🤖 Generated with [Claude Code](https://claude.com/claude-code)