### PR TITLE
feat(tyr): NIU-614 — ingest ravn.task.completed and map to raid confidence

### DIFF
--- a/src/tyr/adapters/ravn_outcome_handler.py
+++ b/src/tyr/adapters/ravn_outcome_handler.py
@@ -1,0 +1,184 @@
+"""RavnOutcomeHandler — Sleipnir subscriber for ``ravn.task.completed`` events.
+
+Consumes structured task outcomes published by the ravn flock coordinator and
+routes them through the :class:`~tyr.domain.services.review_engine.ReviewEngine`
+decision pipeline.
+
+Lifecycle::
+
+    handler = RavnOutcomeHandler(...)
+    await handler.start()   # subscribe to ravn.task.completed
+    # ... application runs ...
+    await handler.stop()    # unsubscribe; clean up
+
+**Correlation**
+
+The ``SleipnirEvent.correlation_id`` carries the Volundr session ID.  The
+handler uses this to look up the corresponding raid via
+``TrackerPort.get_raid_by_session``.
+
+**Coexistence with ActivitySubscriber**
+
+Both paths remain active.  ``ActivitySubscriber`` (SSE-based) is the fallback
+for standard Claude Code sessions.  ``RavnOutcomeHandler`` is the primary path
+for flock sessions.  When both fire for the same raid the explicit ravn outcome
+takes precedence — ``ReviewEngine.handle_ravn_outcome`` is idempotent and skips
+raids that are no longer in RUNNING or REVIEW state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from sleipnir.domain.events import SleipnirEvent
+from sleipnir.ports.events import SleipnirSubscriber, Subscription
+from tyr.domain.models import RavnOutcome
+from tyr.domain.services.review_engine import ReviewEngine
+from tyr.ports.tracker import TrackerFactory
+
+logger = logging.getLogger(__name__)
+
+RAVN_TASK_COMPLETED = "ravn.task.completed"
+
+
+class RavnOutcomeHandler:
+    """Subscribes to ``ravn.task.completed`` events and routes outcomes through ReviewEngine.
+
+    Parameters
+    ----------
+    subscriber:
+        Sleipnir subscriber used to receive events.
+    tracker_factory:
+        Factory for resolving per-owner tracker adapters.
+    review_engine:
+        The ReviewEngine instance to delegate decisions to.
+    owner_id:
+        Owner ID used when looking up tracker adapters.
+    scope_adherence_threshold:
+        ``scope_adherence`` values below this threshold trigger a
+        :attr:`~tyr.domain.models.ConfidenceEventType.SCOPE_BREACH` signal.
+    """
+
+    def __init__(
+        self,
+        *,
+        subscriber: SleipnirSubscriber,
+        tracker_factory: TrackerFactory,
+        review_engine: ReviewEngine,
+        owner_id: str,
+        scope_adherence_threshold: float = 0.7,
+    ) -> None:
+        self._subscriber = subscriber
+        self._tracker_factory = tracker_factory
+        self._review_engine = review_engine
+        self._owner_id = owner_id
+        self._scope_adherence_threshold = scope_adherence_threshold
+
+        self._subscription: Subscription | None = None
+        self._pending_tasks: set[asyncio.Task[None]] = set()
+
+    @property
+    def is_running(self) -> bool:
+        return self._subscription is not None
+
+    async def start(self) -> None:
+        """Subscribe to ``ravn.task.completed`` on Sleipnir."""
+        if self._subscription is not None:
+            return
+        self._subscription = await self._subscriber.subscribe(
+            [RAVN_TASK_COMPLETED], self._handle_event
+        )
+        logger.info("RavnOutcomeHandler started: subscribed to %s", RAVN_TASK_COMPLETED)
+
+    async def stop(self) -> None:
+        """Unsubscribe and cancel in-flight tasks."""
+        if self._subscription is not None:
+            await self._subscription.unsubscribe()
+            self._subscription = None
+
+        for task in list(self._pending_tasks):
+            task.cancel()
+        if self._pending_tasks:
+            await asyncio.gather(*self._pending_tasks, return_exceptions=True)
+        self._pending_tasks.clear()
+
+        logger.info("RavnOutcomeHandler stopped")
+
+    # ------------------------------------------------------------------
+    # Internal event handling
+    # ------------------------------------------------------------------
+
+    async def _handle_event(self, event: SleipnirEvent) -> None:
+        task = asyncio.create_task(
+            self._process_event(event),
+            name=f"ravn-outcome:{event.event_id}",
+        )
+        self._pending_tasks.add(task)
+        task.add_done_callback(self._pending_tasks.discard)
+
+    async def _process_event(self, event: SleipnirEvent) -> None:
+        session_id = event.correlation_id
+        if not session_id:
+            logger.warning(
+                "RavnOutcomeHandler: event %s has no correlation_id — dropping",
+                event.event_id,
+            )
+            return
+
+        outcome = _extract_outcome(event.payload)
+
+        raid = None
+        trackers = await self._tracker_factory.for_owner(self._owner_id)
+        for tracker in trackers:
+            raid = await tracker.get_raid_by_session(session_id)
+            if raid is not None:
+                break
+
+        if raid is None:
+            logger.warning(
+                "RavnOutcomeHandler: no raid for session_id=%s (event=%s) — dropping",
+                session_id,
+                event.event_id,
+            )
+            return
+
+        logger.info(
+            "RavnOutcomeHandler: processing outcome for raid %s "
+            "(verdict=%s, tests_passing=%s, session=%s)",
+            raid.tracker_id,
+            outcome.verdict,
+            outcome.tests_passing,
+            session_id,
+        )
+
+        try:
+            decision = await self._review_engine.handle_ravn_outcome(
+                raid.tracker_id,
+                self._owner_id,
+                outcome,
+                scope_adherence_threshold=self._scope_adherence_threshold,
+            )
+            logger.info(
+                "RavnOutcomeHandler: raid %s → %s (reason=%s)",
+                raid.tracker_id,
+                decision.action,
+                decision.reason,
+            )
+        except Exception:
+            logger.exception(
+                "RavnOutcomeHandler: failed to process outcome for raid %s",
+                raid.tracker_id,
+            )
+
+
+def _extract_outcome(payload: dict) -> RavnOutcome:
+    """Parse a ``ravn.task.completed`` payload into a typed :class:`RavnOutcome`."""
+    return RavnOutcome(
+        verdict=payload.get("verdict", "escalate"),
+        tests_passing=payload.get("tests_passing"),
+        scope_adherence=payload.get("scope_adherence"),
+        pr_url=payload.get("pr_url"),
+        files_changed=list(payload.get("files_changed") or []),
+        summary=str(payload.get("summary") or ""),
+    )

--- a/src/tyr/config.py
+++ b/src/tyr/config.py
@@ -715,6 +715,10 @@ class RavnOutcomeConfig(BaseModel):
         default=False,
         description="Enable the ravn.task.completed outcome subscriber.",
     )
+    owner_id: str = Field(
+        default="api",
+        description="Owner ID used when looking up raids from ravn outcome events.",
+    )
     scope_adherence_threshold: float = Field(
         default=0.7,
         description=(

--- a/src/tyr/config.py
+++ b/src/tyr/config.py
@@ -701,6 +701,28 @@ class EventTriggerConfig(BaseModel):
     )
 
 
+class RavnOutcomeConfig(BaseModel):
+    """Configuration for the RavnOutcomeHandler adapter.
+
+    Example YAML::
+
+        ravn_outcome:
+          enabled: true
+          scope_adherence_threshold: 0.7
+    """
+
+    enabled: bool = Field(
+        default=False,
+        description="Enable the ravn.task.completed outcome subscriber.",
+    )
+    scope_adherence_threshold: float = Field(
+        default=0.7,
+        description=(
+            "scope_adherence values below this threshold flag a scope breach. Range 0.0–1.0."
+        ),
+    )
+
+
 class NotificationConfig(BaseModel):
     """Notification service configuration."""
 
@@ -771,6 +793,7 @@ class Settings(BaseSettings):
     notification: NotificationConfig = Field(default_factory=NotificationConfig)
     sleipnir: SleipnirConfig = Field(default_factory=SleipnirConfig)
     event_triggers: EventTriggerConfig = Field(default_factory=EventTriggerConfig)
+    ravn_outcome: RavnOutcomeConfig = Field(default_factory=RavnOutcomeConfig)
 
     @classmethod
     def settings_customise_sources(

--- a/src/tyr/domain/models.py
+++ b/src/tyr/domain/models.py
@@ -165,6 +165,34 @@ class SessionMessage:
 
 
 @dataclass(frozen=True)
+class RavnOutcome:
+    """Structured outcome from a ``ravn.task.completed`` event payload.
+
+    Published by the ravn flock coordinator at the end of a task session.
+    Fields map directly to the ``produces.schema`` declared by the coordinator
+    persona.
+    """
+
+    verdict: str
+    """Final verdict from the coordinator: ``"approve"`` | ``"retry"`` | ``"escalate"``."""
+
+    tests_passing: bool | None
+    """Whether all CI / test suite checks pass. ``None`` means unknown."""
+
+    scope_adherence: float | None
+    """Fraction (0.0–1.0) of work that stayed within declared scope. ``None`` means unknown."""
+
+    pr_url: str | None
+    """URL of the pull request created by the session, if any."""
+
+    files_changed: list[str]
+    """List of file paths changed in the session."""
+
+    summary: str
+    """Human-readable one-line summary from the coordinator."""
+
+
+@dataclass(frozen=True)
 class DispatcherState:
     id: UUID
     owner_id: str

--- a/src/tyr/domain/services/review_engine.py
+++ b/src/tyr/domain/services/review_engine.py
@@ -523,12 +523,34 @@ class ReviewEngine:
 
         match outcome.verdict:
             case "retry":
-                return await self._auto_retry(
-                    tracker,
+                if raid.retry_count < self._cfg.max_retries:
+                    attempt = f"attempt {raid.retry_count + 1}/{self._cfg.max_retries}"
+                    return await self._auto_retry(
+                        tracker,
+                        tracker_id,
+                        owner_id,
+                        raid,
+                        reason=f"ravn coordinator requested retry ({attempt})",
+                    )
+
+                # Retries exhausted → FAILED
+                validate_transition(raid.status, RaidStatus.FAILED)
+                updated = await tracker.update_raid_progress(
                     tracker_id,
-                    owner_id,
-                    raid,
-                    reason="ravn coordinator requested retry",
+                    status=RaidStatus.FAILED,
+                    reason="ravn coordinator requested retry but retries exhausted",
+                )
+                if raid.session_id:
+                    await self._attach_working_transcript(tracker, tracker_id, owner_id, raid)
+                    await self._stop_session(owner_id, raid.session_id, "working session")
+                await self._emit_state_changed(updated, owner_id=owner_id, action="failed")
+                return ReviewDecision(
+                    raid=updated,
+                    action="failed",
+                    reason=(
+                        f"ravn coordinator requested retry after"
+                        f" {self._cfg.max_retries} retries exhausted"
+                    ),
                 )
             case "approve":
                 if score >= self._cfg.auto_approve_threshold:

--- a/src/tyr/domain/services/review_engine.py
+++ b/src/tyr/domain/services/review_engine.py
@@ -35,6 +35,7 @@ from tyr.domain.models import (
     PRStatus,
     Raid,
     RaidStatus,
+    RavnOutcome,
     Saga,
     validate_transition,
 )
@@ -445,6 +446,105 @@ class ReviewEngine:
             return await self._handle_auto_approve(tracker, tracker_id, owner_id, raid, score)
 
         return await self._handle_escalation(tracker, tracker_id, owner_id, raid, score)
+
+    async def handle_ravn_outcome(
+        self,
+        tracker_id: str,
+        owner_id: str,
+        outcome: RavnOutcome,
+        *,
+        scope_adherence_threshold: float,
+    ) -> ReviewDecision:
+        """Process a structured outcome from a ``ravn.task.completed`` event.
+
+        Maps the ravn coordinator's outcome fields to :class:`ConfidenceEvent`
+        entries and routes to the appropriate decision handler based on the
+        explicit verdict.
+
+        Accepts raids in RUNNING or REVIEW state:
+
+        - RUNNING → transitions to REVIEW first (ravn outcome is authoritative).
+        - REVIEW → processes directly (ActivitySubscriber may have beaten us).
+        - Any other status → skipped (already handled or terminal).
+        """
+        trackers = await self._tracker_factory.for_owner(owner_id)
+        if not trackers:
+            raise ValueError(f"No tracker adapter found for owner {owner_id}")
+        tracker = trackers[0]
+
+        raid = await tracker.get_raid(tracker_id)
+
+        if raid.status not in (RaidStatus.RUNNING, RaidStatus.REVIEW):
+            logger.info(
+                "handle_ravn_outcome: raid %s is %s — already handled, skipping",
+                tracker_id,
+                raid.status,
+            )
+            return ReviewDecision(
+                raid=raid,
+                action="skipped",
+                reason=f"Raid already in {raid.status} state",
+            )
+
+        if raid.status == RaidStatus.RUNNING:
+            validate_transition(raid.status, RaidStatus.REVIEW)
+            raid = await tracker.update_raid_progress(tracker_id, status=RaidStatus.REVIEW)
+
+        score = raid.confidence
+
+        if outcome.tests_passing is True:
+            event = _make_event(
+                raid.id, ConfidenceEventType.CI_PASS, self._cfg.confidence_delta_ci_pass, score
+            )
+            await tracker.add_confidence_event(tracker_id, event)
+            await self._emit_confidence_updated(raid.id, event)
+            score = event.score_after
+        elif outcome.tests_passing is False:
+            event = _make_event(
+                raid.id, ConfidenceEventType.CI_FAIL, self._cfg.confidence_delta_ci_fail, score
+            )
+            await tracker.add_confidence_event(tracker_id, event)
+            await self._emit_confidence_updated(raid.id, event)
+            score = event.score_after
+
+        if (
+            outcome.scope_adherence is not None
+            and outcome.scope_adherence < scope_adherence_threshold
+        ):
+            event = _make_event(
+                raid.id,
+                ConfidenceEventType.SCOPE_BREACH,
+                self._cfg.confidence_delta_scope_breach,
+                score,
+            )
+            await tracker.add_confidence_event(tracker_id, event)
+            await self._emit_confidence_updated(raid.id, event)
+            score = event.score_after
+
+        match outcome.verdict:
+            case "retry":
+                return await self._auto_retry(
+                    tracker,
+                    tracker_id,
+                    owner_id,
+                    raid,
+                    reason="ravn coordinator requested retry",
+                )
+            case "approve":
+                if score >= self._cfg.auto_approve_threshold:
+                    return await self._handle_auto_approve(
+                        tracker, tracker_id, owner_id, raid, score
+                    )
+                return await self._handle_escalation(tracker, tracker_id, owner_id, raid, score)
+            case "escalate":
+                return await self._handle_escalation(tracker, tracker_id, owner_id, raid, score)
+            case _:
+                logger.warning(
+                    "handle_ravn_outcome: unknown verdict %r for raid %s — escalating",
+                    outcome.verdict,
+                    tracker_id,
+                )
+                return await self._handle_escalation(tracker, tracker_id, owner_id, raid, score)
 
     # -- Signal fetchers --
 

--- a/src/tyr/main.py
+++ b/src/tyr/main.py
@@ -533,9 +533,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                     subscriber=sleipnir_bus,
                     tracker_factory=app.state.tracker_factory,
                     review_engine=review_engine,
-                    owner_id=settings.event_triggers.owner_id
-                    if settings.event_triggers.enabled
-                    else "api",
+                    owner_id=settings.ravn_outcome.owner_id,
                     scope_adherence_threshold=settings.ravn_outcome.scope_adherence_threshold,
                 )
                 await ravn_outcome_handler.start()

--- a/src/tyr/main.py
+++ b/src/tyr/main.py
@@ -520,6 +520,28 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                         len(et_cfg.rules),
                     )
 
+            # Wire RavnOutcomeHandler (Sleipnir subscriber for ravn.task.completed)
+            ravn_outcome_handler = None
+            if (
+                settings.ravn_outcome.enabled
+                and sleipnir_bus is not None
+                and hasattr(sleipnir_bus, "subscribe")
+            ):
+                from tyr.adapters.ravn_outcome_handler import RavnOutcomeHandler  # noqa: PLC0415
+
+                ravn_outcome_handler = RavnOutcomeHandler(
+                    subscriber=sleipnir_bus,
+                    tracker_factory=app.state.tracker_factory,
+                    review_engine=review_engine,
+                    owner_id=settings.event_triggers.owner_id
+                    if settings.event_triggers.enabled
+                    else "api",
+                    scope_adherence_threshold=settings.ravn_outcome.scope_adherence_threshold,
+                )
+                await ravn_outcome_handler.start()
+                app.state.ravn_outcome_handler = ravn_outcome_handler
+                logger.info("RavnOutcomeHandler started")
+
             # Wire PipelineExecutor (dynamic pipeline creation via API)
             from tyr.domain.pipeline_executor import TemplateAwarePipelineExecutor  # noqa: PLC0415
 
@@ -544,6 +566,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             yield
 
             # Lifecycle cleanup
+            if ravn_outcome_handler is not None:
+                await ravn_outcome_handler.stop()
             if event_trigger_adapter is not None:
                 await event_trigger_adapter.stop()
             if tyr_sleipnir_bridge is not None:

--- a/tests/test_tyr/stubs.py
+++ b/tests/test_tyr/stubs.py
@@ -5,10 +5,23 @@ from __future__ import annotations
 from collections.abc import AsyncGenerator
 from datetime import UTC, datetime
 from typing import Any
-from uuid import UUID
+from uuid import UUID, uuid4
 
-from tyr.domain.models import Phase, Raid, RaidStatus, Saga, SagaStatus
+from tyr.domain.models import (
+    ConfidenceEvent,
+    Phase,
+    PhaseStatus,
+    Raid,
+    RaidStatus,
+    Saga,
+    SagaStatus,
+    SessionMessage,
+    TrackerIssue,
+    TrackerMilestone,
+    TrackerProject,
+)
 from tyr.ports.saga_repository import SagaRepository
+from tyr.ports.tracker import TrackerPort
 from tyr.ports.volundr import (
     ActivityEvent,
     PRStatus,
@@ -193,3 +206,226 @@ class StubVolundrFactory:
 
     async def primary_for_owner(self, owner_id: str) -> VolundrPort | None:
         return self._volundr
+
+
+# ---------------------------------------------------------------------------
+# Tracker stubs (used by ravn outcome tests and review engine tests)
+# ---------------------------------------------------------------------------
+
+_NOW = datetime.now(UTC)
+_DEFAULT_OWNER = "test-owner"
+_DEFAULT_TRACKER_ID = "raid-tracker-001"
+_DEFAULT_SESSION = "sess-ravn-001"
+
+
+class StubTracker(TrackerPort):
+    """Minimal in-memory tracker for Tyr unit tests."""
+
+    def __init__(self, raid: Raid | None = None) -> None:
+        self._raid = raid
+        self._raids_by_session: dict[str, Raid] = {}
+        if raid is not None:
+            self._raids_by_id = {raid.tracker_id: raid}
+            if raid.session_id:
+                self._raids_by_session[raid.session_id] = raid
+        else:
+            self._raids_by_id: dict[str, Raid] = {}
+        self.confidence_events: dict[str, list[ConfidenceEvent]] = {}
+        self.phase: Phase | None = None
+        self.saga: Saga | None = None
+        self._phases: list[Phase] = []
+        self._all_merged: bool = False
+        self.closed_raids: list[str] = []
+
+    # -- CRUD: create entities --
+
+    async def create_saga(self, saga: Saga, *, description: str = "") -> str:
+        return saga.tracker_id
+
+    async def create_phase(self, phase: Phase, *, project_id: str = "") -> str:
+        return phase.tracker_id
+
+    async def create_raid(self, raid: Raid, *, project_id: str = "", milestone_id: str = "") -> str:
+        self._raids_by_id[raid.tracker_id] = raid
+        if raid.session_id:
+            self._raids_by_session[raid.session_id] = raid
+        return raid.tracker_id
+
+    async def update_raid_state(self, raid_id: str, state: RaidStatus) -> None:
+        pass
+
+    async def close_raid(self, raid_id: str) -> None:
+        self.closed_raids.append(raid_id)
+
+    # -- Read --
+
+    async def get_saga(self, saga_id: str) -> Saga:
+        if self.saga is None:
+            raise ValueError("No saga")
+        return self.saga
+
+    async def get_phase(self, tracker_id: str) -> Phase:
+        if self.phase is None:
+            raise ValueError("No phase")
+        return self.phase
+
+    async def get_raid(self, tracker_id: str) -> Raid:
+        raid = self._raids_by_id.get(tracker_id)
+        if raid is None:
+            raise ValueError(f"Raid not found: {tracker_id}")
+        return raid
+
+    async def list_pending_raids(self, phase_id: str) -> list[Raid]:
+        return []
+
+    async def list_projects(self) -> list[TrackerProject]:
+        return []
+
+    async def get_project(self, project_id: str) -> TrackerProject:
+        raise NotImplementedError
+
+    async def list_milestones(self, project_id: str) -> list[TrackerMilestone]:
+        return []
+
+    async def list_issues(
+        self, project_id: str, milestone_id: str | None = None
+    ) -> list[TrackerIssue]:
+        return []
+
+    # -- Raid progress --
+
+    async def update_raid_progress(
+        self,
+        tracker_id: str,
+        *,
+        status: RaidStatus | None = None,
+        session_id: str | None = None,
+        confidence: float | None = None,
+        pr_url: str | None = None,
+        pr_id: str | None = None,
+        retry_count: int | None = None,
+        reason: str | None = None,
+        owner_id: str | None = None,
+        phase_tracker_id: str | None = None,
+        saga_tracker_id: str | None = None,
+        chronicle_summary: str | None = None,
+        reviewer_session_id: str | None = None,
+        review_round: int | None = None,
+    ) -> Raid:
+        raid = self._raids_by_id.get(tracker_id)
+        if raid is None:
+            raise ValueError(f"Raid not found: {tracker_id}")
+        events = self.confidence_events.get(tracker_id, [])
+        new_confidence = events[-1].score_after if events else raid.confidence
+        updated = Raid(
+            id=raid.id,
+            phase_id=raid.phase_id,
+            tracker_id=raid.tracker_id,
+            name=raid.name,
+            description=raid.description,
+            acceptance_criteria=raid.acceptance_criteria,
+            declared_files=raid.declared_files,
+            estimate_hours=raid.estimate_hours,
+            status=status if status is not None else raid.status,
+            confidence=confidence if confidence is not None else new_confidence,
+            session_id=session_id if session_id is not None else raid.session_id,
+            branch=raid.branch,
+            chronicle_summary=raid.chronicle_summary,
+            pr_url=pr_url if pr_url is not None else raid.pr_url,
+            pr_id=pr_id if pr_id is not None else raid.pr_id,
+            retry_count=retry_count if retry_count is not None else raid.retry_count,
+            created_at=raid.created_at,
+            updated_at=datetime.now(UTC),
+            reviewer_session_id=(
+                reviewer_session_id if reviewer_session_id is not None else raid.reviewer_session_id
+            ),
+            review_round=review_round if review_round is not None else raid.review_round,
+        )
+        self._raids_by_id[tracker_id] = updated
+        if updated.session_id:
+            self._raids_by_session[updated.session_id] = updated
+        return updated
+
+    async def get_raid_progress_for_saga(self, saga_tracker_id: str) -> list[Raid]:
+        return list(self._raids_by_id.values())
+
+    async def get_raid_by_session(self, session_id: str) -> Raid | None:
+        return self._raids_by_session.get(session_id)
+
+    async def list_raids_by_status(self, status: RaidStatus) -> list[Raid]:
+        return [r for r in self._raids_by_id.values() if r.status == status]
+
+    async def get_raid_by_id(self, raid_id: UUID) -> Raid | None:
+        return next((r for r in self._raids_by_id.values() if r.id == raid_id), None)
+
+    async def add_confidence_event(self, tracker_id: str, event: ConfidenceEvent) -> None:
+        self.confidence_events.setdefault(tracker_id, []).append(event)
+
+    async def get_confidence_events(self, tracker_id: str) -> list[ConfidenceEvent]:
+        return self.confidence_events.get(tracker_id, [])
+
+    async def all_raids_merged(self, phase_tracker_id: str) -> bool:
+        return self._all_merged
+
+    async def list_phases_for_saga(self, saga_tracker_id: str) -> list[Phase]:
+        return self._phases
+
+    async def update_phase_status(self, phase_tracker_id: str, status: PhaseStatus) -> Phase | None:
+        return None
+
+    async def get_saga_for_raid(self, tracker_id: str) -> Saga | None:
+        return self.saga
+
+    async def get_phase_for_raid(self, tracker_id: str) -> Phase | None:
+        return self.phase
+
+    async def get_owner_for_raid(self, tracker_id: str) -> str | None:
+        return _DEFAULT_OWNER
+
+    async def save_session_message(self, message: SessionMessage) -> None:
+        pass
+
+    async def get_session_messages(self, tracker_id: str) -> list[SessionMessage]:
+        return []
+
+    async def attach_issue_document(self, issue_id: str, title: str, content: str) -> str:
+        return "doc-1"
+
+
+class StubTrackerFactory:
+    def __init__(self, tracker: StubTracker) -> None:
+        self._tracker = tracker
+
+    async def for_owner(self, owner_id: str) -> list[StubTracker]:
+        return [self._tracker]
+
+
+def make_raid(
+    *,
+    status: RaidStatus = RaidStatus.REVIEW,
+    confidence: float = 0.5,
+    session_id: str | None = _DEFAULT_SESSION,
+    retry_count: int = 0,
+    tracker_id: str = _DEFAULT_TRACKER_ID,
+) -> Raid:
+    """Build a minimal Raid for use in tests."""
+    return Raid(
+        id=uuid4(),
+        phase_id=uuid4(),
+        tracker_id=tracker_id,
+        name="test-raid",
+        description="A test raid",
+        acceptance_criteria=[],
+        declared_files=[],
+        estimate_hours=1.0,
+        status=status,
+        confidence=confidence,
+        session_id=session_id,
+        branch=None,
+        chronicle_summary=None,
+        pr_url=None,
+        pr_id=None,
+        retry_count=retry_count,
+        created_at=_NOW,
+        updated_at=_NOW,
+    )

--- a/tests/test_tyr/test_ravn_outcome_handler.py
+++ b/tests/test_tyr/test_ravn_outcome_handler.py
@@ -1,0 +1,897 @@
+"""Tests for NIU-614 — Tyr ravn.task.completed outcome ingestion.
+
+Covers:
+  - _extract_outcome: payload → RavnOutcome mapping
+  - ReviewEngine.handle_ravn_outcome: confidence signals + decision logic
+  - RavnOutcomeHandler._process_event: correlation lookup, missing raid, happy path
+  - Integration: InProcessBus round-trip (publish → state transition)
+  - Coexistence: raid already terminal when outcome arrives → skipped
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+import pytest
+
+from sleipnir.adapters.in_process import InProcessBus
+from sleipnir.domain.events import SleipnirEvent
+from tests.test_tyr.stubs import StubVolundrFactory
+from tyr.adapters.memory_event_bus import InMemoryEventBus
+from tyr.adapters.ravn_outcome_handler import RavnOutcomeHandler, _extract_outcome
+from tyr.config import ReviewConfig
+from tyr.domain.models import (
+    ConfidenceEvent,
+    ConfidenceEventType,
+    Phase,
+    PhaseStatus,
+    PRStatus,
+    Raid,
+    RaidStatus,
+    RavnOutcome,
+    Saga,
+    SessionMessage,
+    TrackerIssue,
+    TrackerMilestone,
+    TrackerProject,
+)
+from tyr.domain.services.review_engine import ReviewEngine
+from tyr.ports.git import GitPort
+from tyr.ports.tracker import TrackerPort
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+NOW = datetime.now(UTC)
+_OWNER = "test-owner"
+_SESSION = "sess-ravn-001"
+_TRACKER_ID = "raid-tracker-001"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_raid(
+    *,
+    status: RaidStatus = RaidStatus.REVIEW,
+    confidence: float = 0.5,
+    session_id: str | None = _SESSION,
+    retry_count: int = 0,
+) -> Raid:
+    return Raid(
+        id=uuid4(),
+        phase_id=uuid4(),
+        tracker_id=_TRACKER_ID,
+        name="test-raid",
+        description="A test raid",
+        acceptance_criteria=[],
+        declared_files=[],
+        estimate_hours=1.0,
+        status=status,
+        confidence=confidence,
+        session_id=session_id,
+        branch=None,
+        chronicle_summary=None,
+        pr_url=None,
+        pr_id=None,
+        retry_count=retry_count,
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+
+def _make_sleipnir_event(
+    payload: dict | None = None,
+    *,
+    correlation_id: str | None = _SESSION,
+) -> SleipnirEvent:
+    return SleipnirEvent(
+        event_type="ravn.task.completed",
+        source="ravn:coordinator",
+        payload=payload or {},
+        summary="task completed",
+        urgency=0.8,
+        domain="code",
+        timestamp=NOW,
+        correlation_id=correlation_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+
+class StubGit(GitPort):
+    async def create_branch(self, repo: str, branch: str, base: str) -> None:
+        pass
+
+    async def merge_branch(self, repo: str, source: str, target: str) -> None:
+        pass
+
+    async def delete_branch(self, repo: str, branch: str) -> None:
+        pass
+
+    async def create_pr(self, repo: str, source: str, target: str, title: str) -> str:
+        return "pr-1"
+
+    async def get_pr_status(self, pr_id: str) -> PRStatus:
+        raise RuntimeError("no PR in stub")
+
+    async def get_pr_changed_files(self, pr_id: str) -> list[str]:
+        return []
+
+
+class StubTracker(TrackerPort):
+    """Minimal in-memory tracker for ravn outcome tests."""
+
+    def __init__(self, raid: Raid | None = None) -> None:
+        self._raid = raid
+        self._raids_by_session: dict[str, Raid] = {}
+        if raid is not None:
+            self._raids_by_id = {raid.tracker_id: raid}
+            if raid.session_id:
+                self._raids_by_session[raid.session_id] = raid
+        else:
+            self._raids_by_id: dict[str, Raid] = {}
+        self.confidence_events: dict[str, list[ConfidenceEvent]] = {}
+        self.phase: Phase | None = None
+        self.saga: Saga | None = None
+        self._phases: list[Phase] = []
+        self._all_merged: bool = False
+        self.closed_raids: list[str] = []
+
+    # -- CRUD: create entities --
+
+    async def create_saga(self, saga: Saga, *, description: str = "") -> str:
+        return saga.tracker_id
+
+    async def create_phase(self, phase: Phase, *, project_id: str = "") -> str:
+        return phase.tracker_id
+
+    async def create_raid(self, raid: Raid, *, project_id: str = "", milestone_id: str = "") -> str:
+        self._raids_by_id[raid.tracker_id] = raid
+        if raid.session_id:
+            self._raids_by_session[raid.session_id] = raid
+        return raid.tracker_id
+
+    async def update_raid_state(self, raid_id: str, state: RaidStatus) -> None:
+        pass
+
+    async def close_raid(self, raid_id: str) -> None:
+        self.closed_raids.append(raid_id)
+
+    # -- Read --
+
+    async def get_saga(self, saga_id: str) -> Saga:
+        if self.saga is None:
+            raise ValueError("No saga")
+        return self.saga
+
+    async def get_phase(self, tracker_id: str) -> Phase:
+        if self.phase is None:
+            raise ValueError("No phase")
+        return self.phase
+
+    async def get_raid(self, tracker_id: str) -> Raid:
+        raid = self._raids_by_id.get(tracker_id)
+        if raid is None:
+            raise ValueError(f"Raid not found: {tracker_id}")
+        return raid
+
+    async def list_pending_raids(self, phase_id: str) -> list[Raid]:
+        return []
+
+    async def list_projects(self) -> list[TrackerProject]:
+        return []
+
+    async def get_project(self, project_id: str) -> TrackerProject:
+        raise NotImplementedError
+
+    async def list_milestones(self, project_id: str) -> list[TrackerMilestone]:
+        return []
+
+    async def list_issues(
+        self, project_id: str, milestone_id: str | None = None
+    ) -> list[TrackerIssue]:
+        return []
+
+    # -- Raid progress --
+
+    async def update_raid_progress(
+        self,
+        tracker_id: str,
+        *,
+        status: RaidStatus | None = None,
+        session_id: str | None = None,
+        confidence: float | None = None,
+        pr_url: str | None = None,
+        pr_id: str | None = None,
+        retry_count: int | None = None,
+        reason: str | None = None,
+        owner_id: str | None = None,
+        phase_tracker_id: str | None = None,
+        saga_tracker_id: str | None = None,
+        chronicle_summary: str | None = None,
+        reviewer_session_id: str | None = None,
+        review_round: int | None = None,
+    ) -> Raid:
+        raid = self._raids_by_id.get(tracker_id)
+        if raid is None:
+            raise ValueError(f"Raid not found: {tracker_id}")
+        events = self.confidence_events.get(tracker_id, [])
+        new_confidence = events[-1].score_after if events else raid.confidence
+        updated = Raid(
+            id=raid.id,
+            phase_id=raid.phase_id,
+            tracker_id=raid.tracker_id,
+            name=raid.name,
+            description=raid.description,
+            acceptance_criteria=raid.acceptance_criteria,
+            declared_files=raid.declared_files,
+            estimate_hours=raid.estimate_hours,
+            status=status if status is not None else raid.status,
+            confidence=confidence if confidence is not None else new_confidence,
+            session_id=session_id if session_id is not None else raid.session_id,
+            branch=raid.branch,
+            chronicle_summary=raid.chronicle_summary,
+            pr_url=pr_url if pr_url is not None else raid.pr_url,
+            pr_id=pr_id if pr_id is not None else raid.pr_id,
+            retry_count=retry_count if retry_count is not None else raid.retry_count,
+            created_at=raid.created_at,
+            updated_at=NOW,
+            reviewer_session_id=(
+                reviewer_session_id if reviewer_session_id is not None else raid.reviewer_session_id
+            ),
+            review_round=review_round if review_round is not None else raid.review_round,
+        )
+        self._raids_by_id[tracker_id] = updated
+        if updated.session_id:
+            self._raids_by_session[updated.session_id] = updated
+        return updated
+
+    async def get_raid_progress_for_saga(self, saga_tracker_id: str) -> list[Raid]:
+        return list(self._raids_by_id.values())
+
+    async def get_raid_by_session(self, session_id: str) -> Raid | None:
+        return self._raids_by_session.get(session_id)
+
+    async def list_raids_by_status(self, status: RaidStatus) -> list[Raid]:
+        return [r for r in self._raids_by_id.values() if r.status == status]
+
+    async def get_raid_by_id(self, raid_id: UUID) -> Raid | None:
+        return next((r for r in self._raids_by_id.values() if r.id == raid_id), None)
+
+    async def add_confidence_event(self, tracker_id: str, event: ConfidenceEvent) -> None:
+        self.confidence_events.setdefault(tracker_id, []).append(event)
+
+    async def get_confidence_events(self, tracker_id: str) -> list[ConfidenceEvent]:
+        return self.confidence_events.get(tracker_id, [])
+
+    async def all_raids_merged(self, phase_tracker_id: str) -> bool:
+        return self._all_merged
+
+    async def list_phases_for_saga(self, saga_tracker_id: str) -> list[Phase]:
+        return self._phases
+
+    async def update_phase_status(self, phase_tracker_id: str, status: PhaseStatus) -> Phase | None:
+        return None
+
+    async def get_saga_for_raid(self, tracker_id: str) -> Saga | None:
+        return self.saga
+
+    async def get_phase_for_raid(self, tracker_id: str) -> Phase | None:
+        return self.phase
+
+    async def get_owner_for_raid(self, tracker_id: str) -> str | None:
+        return _OWNER
+
+    async def save_session_message(self, message: SessionMessage) -> None:
+        pass
+
+    async def get_session_messages(self, tracker_id: str) -> list[SessionMessage]:
+        return []
+
+    async def attach_issue_document(self, issue_id: str, title: str, content: str) -> str:
+        return "doc-1"
+
+
+class StubTrackerFactory:
+    def __init__(self, tracker: StubTracker) -> None:
+        self._tracker = tracker
+
+    async def for_owner(self, owner_id: str) -> list[StubTracker]:
+        return [self._tracker]
+
+
+def _make_engine(tracker: StubTracker, event_bus: InMemoryEventBus | None = None) -> ReviewEngine:
+    factory = StubTrackerFactory(tracker)
+    return ReviewEngine(
+        tracker_factory=factory,
+        volundr_factory=StubVolundrFactory(),
+        git=StubGit(),
+        review_config=ReviewConfig(
+            reviewer_session_enabled=False,
+            auto_approve_threshold=0.80,
+        ),
+        event_bus=event_bus,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit: _extract_outcome
+# ---------------------------------------------------------------------------
+
+
+class TestExtractOutcome:
+    def test_full_payload(self):
+        payload = {
+            "verdict": "approve",
+            "tests_passing": True,
+            "scope_adherence": 0.95,
+            "pr_url": "https://github.com/pr/1",
+            "files_changed": ["a.py", "b.py"],
+            "summary": "All done",
+        }
+        outcome = _extract_outcome(payload)
+        assert outcome.verdict == "approve"
+        assert outcome.tests_passing is True
+        assert outcome.scope_adherence == 0.95
+        assert outcome.pr_url == "https://github.com/pr/1"
+        assert outcome.files_changed == ["a.py", "b.py"]
+        assert outcome.summary == "All done"
+
+    def test_minimal_payload_defaults(self):
+        outcome = _extract_outcome({})
+        assert outcome.verdict == "escalate"
+        assert outcome.tests_passing is None
+        assert outcome.scope_adherence is None
+        assert outcome.pr_url is None
+        assert outcome.files_changed == []
+        assert outcome.summary == ""
+
+    def test_tests_passing_false(self):
+        outcome = _extract_outcome({"tests_passing": False, "verdict": "retry"})
+        assert outcome.tests_passing is False
+        assert outcome.verdict == "retry"
+
+    def test_null_files_changed_coerced_to_empty(self):
+        outcome = _extract_outcome({"files_changed": None})
+        assert outcome.files_changed == []
+
+
+# ---------------------------------------------------------------------------
+# Unit: ReviewEngine.handle_ravn_outcome — confidence signals
+# ---------------------------------------------------------------------------
+
+
+class TestHandleRavnOutcomeSignals:
+    @pytest.mark.asyncio
+    async def test_tests_passing_true_emits_ci_pass(self):
+        raid = _make_raid(status=RaidStatus.REVIEW, confidence=0.5)
+        tracker = StubTracker(raid)
+        engine = _make_engine(tracker)
+
+        outcome = RavnOutcome(
+            verdict="escalate",
+            tests_passing=True,
+            scope_adherence=1.0,
+            pr_url=None,
+            files_changed=[],
+            summary="",
+        )
+        await engine.handle_ravn_outcome(
+            _TRACKER_ID, _OWNER, outcome, scope_adherence_threshold=0.7
+        )
+
+        event_types = [e.event_type for e in tracker.confidence_events.get(_TRACKER_ID, [])]
+        assert ConfidenceEventType.CI_PASS in event_types
+
+    @pytest.mark.asyncio
+    async def test_tests_passing_false_emits_ci_fail(self):
+        raid = _make_raid(status=RaidStatus.REVIEW, confidence=0.5)
+        tracker = StubTracker(raid)
+        engine = _make_engine(tracker)
+
+        outcome = RavnOutcome(
+            verdict="escalate",
+            tests_passing=False,
+            scope_adherence=1.0,
+            pr_url=None,
+            files_changed=[],
+            summary="",
+        )
+        await engine.handle_ravn_outcome(
+            _TRACKER_ID, _OWNER, outcome, scope_adherence_threshold=0.7
+        )
+
+        event_types = [e.event_type for e in tracker.confidence_events.get(_TRACKER_ID, [])]
+        assert ConfidenceEventType.CI_FAIL in event_types
+
+    @pytest.mark.asyncio
+    async def test_tests_passing_none_no_ci_event(self):
+        raid = _make_raid(status=RaidStatus.REVIEW)
+        tracker = StubTracker(raid)
+        engine = _make_engine(tracker)
+
+        outcome = RavnOutcome(
+            verdict="escalate",
+            tests_passing=None,
+            scope_adherence=1.0,
+            pr_url=None,
+            files_changed=[],
+            summary="",
+        )
+        await engine.handle_ravn_outcome(
+            _TRACKER_ID, _OWNER, outcome, scope_adherence_threshold=0.7
+        )
+
+        event_types = [e.event_type for e in tracker.confidence_events.get(_TRACKER_ID, [])]
+        assert ConfidenceEventType.CI_PASS not in event_types
+        assert ConfidenceEventType.CI_FAIL not in event_types
+
+    @pytest.mark.asyncio
+    async def test_low_scope_adherence_emits_scope_breach(self):
+        raid = _make_raid(status=RaidStatus.REVIEW, confidence=0.8)
+        tracker = StubTracker(raid)
+        engine = _make_engine(tracker)
+
+        outcome = RavnOutcome(
+            verdict="escalate",
+            tests_passing=None,
+            scope_adherence=0.5,  # below threshold of 0.7
+            pr_url=None,
+            files_changed=[],
+            summary="",
+        )
+        await engine.handle_ravn_outcome(
+            _TRACKER_ID, _OWNER, outcome, scope_adherence_threshold=0.7
+        )
+
+        event_types = [e.event_type for e in tracker.confidence_events.get(_TRACKER_ID, [])]
+        assert ConfidenceEventType.SCOPE_BREACH in event_types
+
+    @pytest.mark.asyncio
+    async def test_high_scope_adherence_no_breach(self):
+        raid = _make_raid(status=RaidStatus.REVIEW, confidence=0.8)
+        tracker = StubTracker(raid)
+        engine = _make_engine(tracker)
+
+        outcome = RavnOutcome(
+            verdict="approve",
+            tests_passing=True,
+            scope_adherence=0.9,  # above threshold
+            pr_url=None,
+            files_changed=[],
+            summary="",
+        )
+        await engine.handle_ravn_outcome(
+            _TRACKER_ID, _OWNER, outcome, scope_adherence_threshold=0.7
+        )
+
+        event_types = [e.event_type for e in tracker.confidence_events.get(_TRACKER_ID, [])]
+        assert ConfidenceEventType.SCOPE_BREACH not in event_types
+
+    @pytest.mark.asyncio
+    async def test_scope_adherence_none_no_breach(self):
+        raid = _make_raid(status=RaidStatus.REVIEW)
+        tracker = StubTracker(raid)
+        engine = _make_engine(tracker)
+
+        outcome = RavnOutcome(
+            verdict="escalate",
+            tests_passing=None,
+            scope_adherence=None,
+            pr_url=None,
+            files_changed=[],
+            summary="",
+        )
+        await engine.handle_ravn_outcome(
+            _TRACKER_ID, _OWNER, outcome, scope_adherence_threshold=0.7
+        )
+
+        event_types = [e.event_type for e in tracker.confidence_events.get(_TRACKER_ID, [])]
+        assert ConfidenceEventType.SCOPE_BREACH not in event_types
+
+
+# ---------------------------------------------------------------------------
+# Unit: ReviewEngine.handle_ravn_outcome — decision logic
+# ---------------------------------------------------------------------------
+
+
+class TestHandleRavnOutcomeDecisions:
+    @pytest.mark.asyncio
+    async def test_verdict_approve_high_confidence_auto_approved(self):
+        # ci_pass delta=0.30, starting at 0.6 → 0.9 >= 0.8 threshold → auto_approved
+        raid = _make_raid(status=RaidStatus.REVIEW, confidence=0.6)
+        tracker = StubTracker(raid)
+        engine = _make_engine(tracker)
+
+        outcome = RavnOutcome(
+            verdict="approve",
+            tests_passing=True,  # ci_pass +0.30 → score=0.9
+            scope_adherence=1.0,
+            pr_url=None,
+            files_changed=[],
+            summary="",
+        )
+        decision = await engine.handle_ravn_outcome(
+            _TRACKER_ID, _OWNER, outcome, scope_adherence_threshold=0.7
+        )
+
+        assert decision.action == "auto_approved"
+        updated_raid = tracker._raids_by_id[_TRACKER_ID]
+        assert updated_raid.status == RaidStatus.MERGED
+
+    @pytest.mark.asyncio
+    async def test_verdict_approve_low_confidence_escalated(self):
+        # Starting at 0.4, ci_fail -0.30 → 0.1 < 0.8 threshold → escalated even with "approve"
+        raid = _make_raid(status=RaidStatus.REVIEW, confidence=0.4)
+        tracker = StubTracker(raid)
+        engine = _make_engine(tracker)
+
+        outcome = RavnOutcome(
+            verdict="approve",
+            tests_passing=False,  # ci_fail -0.30 → score=0.1
+            scope_adherence=1.0,
+            pr_url=None,
+            files_changed=[],
+            summary="",
+        )
+        decision = await engine.handle_ravn_outcome(
+            _TRACKER_ID, _OWNER, outcome, scope_adherence_threshold=0.7
+        )
+
+        assert decision.action == "escalated"
+        updated_raid = tracker._raids_by_id[_TRACKER_ID]
+        assert updated_raid.status == RaidStatus.ESCALATED
+
+    @pytest.mark.asyncio
+    async def test_verdict_retry_transitions_to_pending(self):
+        raid = _make_raid(status=RaidStatus.REVIEW, confidence=0.5, retry_count=0)
+        tracker = StubTracker(raid)
+        engine = _make_engine(tracker)
+
+        outcome = RavnOutcome(
+            verdict="retry",
+            tests_passing=False,
+            scope_adherence=1.0,
+            pr_url=None,
+            files_changed=[],
+            summary="",
+        )
+        decision = await engine.handle_ravn_outcome(
+            _TRACKER_ID, _OWNER, outcome, scope_adherence_threshold=0.7
+        )
+
+        assert decision.action == "retried"
+        updated_raid = tracker._raids_by_id[_TRACKER_ID]
+        assert updated_raid.status == RaidStatus.PENDING
+        assert updated_raid.retry_count == 1
+
+    @pytest.mark.asyncio
+    async def test_verdict_escalate_direct_escalation(self):
+        raid = _make_raid(status=RaidStatus.REVIEW, confidence=0.9)
+        tracker = StubTracker(raid)
+        engine = _make_engine(tracker)
+
+        outcome = RavnOutcome(
+            verdict="escalate",
+            tests_passing=True,
+            scope_adherence=1.0,
+            pr_url=None,
+            files_changed=[],
+            summary="",
+        )
+        decision = await engine.handle_ravn_outcome(
+            _TRACKER_ID, _OWNER, outcome, scope_adherence_threshold=0.7
+        )
+
+        assert decision.action == "escalated"
+        updated_raid = tracker._raids_by_id[_TRACKER_ID]
+        assert updated_raid.status == RaidStatus.ESCALATED
+
+    @pytest.mark.asyncio
+    async def test_unknown_verdict_escalates(self):
+        raid = _make_raid(status=RaidStatus.REVIEW, confidence=0.5)
+        tracker = StubTracker(raid)
+        engine = _make_engine(tracker)
+
+        outcome = RavnOutcome(
+            verdict="something_unknown",
+            tests_passing=None,
+            scope_adherence=None,
+            pr_url=None,
+            files_changed=[],
+            summary="",
+        )
+        decision = await engine.handle_ravn_outcome(
+            _TRACKER_ID, _OWNER, outcome, scope_adherence_threshold=0.7
+        )
+
+        assert decision.action == "escalated"
+
+    @pytest.mark.asyncio
+    async def test_running_raid_transitions_to_review_first(self):
+        raid = _make_raid(status=RaidStatus.RUNNING, confidence=0.6)
+        tracker = StubTracker(raid)
+        engine = _make_engine(tracker)
+
+        outcome = RavnOutcome(
+            verdict="approve",
+            tests_passing=True,
+            scope_adherence=1.0,
+            pr_url=None,
+            files_changed=[],
+            summary="",
+        )
+        decision = await engine.handle_ravn_outcome(
+            _TRACKER_ID, _OWNER, outcome, scope_adherence_threshold=0.7
+        )
+
+        # After ci_pass (+0.30) starting at 0.6 → 0.9 ≥ 0.8 → auto_approved
+        assert decision.action == "auto_approved"
+        updated_raid = tracker._raids_by_id[_TRACKER_ID]
+        assert updated_raid.status == RaidStatus.MERGED
+
+    @pytest.mark.asyncio
+    async def test_terminal_raid_skipped(self):
+        raid = _make_raid(status=RaidStatus.MERGED, confidence=1.0)
+        tracker = StubTracker(raid)
+        engine = _make_engine(tracker)
+
+        outcome = RavnOutcome(
+            verdict="approve",
+            tests_passing=True,
+            scope_adherence=1.0,
+            pr_url=None,
+            files_changed=[],
+            summary="",
+        )
+        decision = await engine.handle_ravn_outcome(
+            _TRACKER_ID, _OWNER, outcome, scope_adherence_threshold=0.7
+        )
+
+        assert decision.action == "skipped"
+        updated_raid = tracker._raids_by_id[_TRACKER_ID]
+        assert updated_raid.status == RaidStatus.MERGED  # unchanged
+
+
+# ---------------------------------------------------------------------------
+# Unit: RavnOutcomeHandler — correlation lookup
+# ---------------------------------------------------------------------------
+
+
+class TestRavnOutcomeHandlerCorrelation:
+    def _make_handler(self, tracker: StubTracker) -> tuple[RavnOutcomeHandler, InMemoryEventBus]:
+        bus = InMemoryEventBus()
+        factory = StubTrackerFactory(tracker)
+        engine = ReviewEngine(
+            tracker_factory=factory,
+            volundr_factory=StubVolundrFactory(),
+            git=StubGit(),
+            review_config=ReviewConfig(reviewer_session_enabled=False),
+            event_bus=bus,
+        )
+        handler = RavnOutcomeHandler(
+            subscriber=InProcessBus(),
+            tracker_factory=factory,
+            review_engine=engine,
+            owner_id=_OWNER,
+        )
+        return handler, bus
+
+    @pytest.mark.asyncio
+    async def test_missing_correlation_id_drops_silently(self, caplog):
+        tracker = StubTracker()
+        handler, _ = self._make_handler(tracker)
+
+        event = _make_sleipnir_event(correlation_id=None)
+        await handler._process_event(event)
+
+        assert "no correlation_id" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_no_matching_raid_drops_silently(self, caplog):
+        tracker = StubTracker()  # no raids
+        handler, _ = self._make_handler(tracker)
+
+        event = _make_sleipnir_event({"verdict": "approve"}, correlation_id="unknown-session")
+        await handler._process_event(event)
+
+        assert "no raid for session_id" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_valid_correlation_processes_raid(self):
+        raid = _make_raid(status=RaidStatus.REVIEW, confidence=0.6)
+        tracker = StubTracker(raid)
+        handler, _ = self._make_handler(tracker)
+
+        payload = {"verdict": "approve", "tests_passing": True, "scope_adherence": 1.0}
+        event = _make_sleipnir_event(payload, correlation_id=_SESSION)
+        await handler._process_event(event)
+
+        updated_raid = tracker._raids_by_id[_TRACKER_ID]
+        assert updated_raid.status == RaidStatus.MERGED
+
+
+# ---------------------------------------------------------------------------
+# Integration: InProcessBus round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestRavnOutcomeHandlerIntegration:
+    @pytest.mark.asyncio
+    async def test_publish_ravn_task_completed_transitions_raid(self):
+        """Publish event on InProcessBus → raid transitions to MERGED."""
+        raid = _make_raid(status=RaidStatus.REVIEW, confidence=0.6)
+        tracker = StubTracker(raid)
+        bus = InProcessBus()
+        factory = StubTrackerFactory(tracker)
+        engine = ReviewEngine(
+            tracker_factory=factory,
+            volundr_factory=StubVolundrFactory(),
+            git=StubGit(),
+            review_config=ReviewConfig(reviewer_session_enabled=False),
+        )
+        handler = RavnOutcomeHandler(
+            subscriber=bus,
+            tracker_factory=factory,
+            review_engine=engine,
+            owner_id=_OWNER,
+        )
+
+        await handler.start()
+        try:
+            event = SleipnirEvent(
+                event_type="ravn.task.completed",
+                source="ravn:coordinator",
+                payload={
+                    "verdict": "approve",
+                    "tests_passing": True,
+                    "scope_adherence": 0.95,
+                    "summary": "All tests pass",
+                },
+                summary="task done",
+                urgency=0.9,
+                domain="code",
+                timestamp=NOW,
+                correlation_id=_SESSION,
+            )
+            await bus.publish(event)
+
+            # Give the event loop a chance to process the task
+            for _ in range(10):
+                await asyncio.sleep(0)
+
+            updated = tracker._raids_by_id[_TRACKER_ID]
+            assert updated.status == RaidStatus.MERGED
+        finally:
+            await handler.stop()
+
+    @pytest.mark.asyncio
+    async def test_retry_verdict_transitions_to_pending(self):
+        raid = _make_raid(status=RaidStatus.REVIEW, confidence=0.5, retry_count=0)
+        tracker = StubTracker(raid)
+        bus = InProcessBus()
+        factory = StubTrackerFactory(tracker)
+        engine = ReviewEngine(
+            tracker_factory=factory,
+            volundr_factory=StubVolundrFactory(),
+            git=StubGit(),
+            review_config=ReviewConfig(reviewer_session_enabled=False),
+        )
+        handler = RavnOutcomeHandler(
+            subscriber=bus,
+            tracker_factory=factory,
+            review_engine=engine,
+            owner_id=_OWNER,
+        )
+
+        await handler.start()
+        try:
+            event = SleipnirEvent(
+                event_type="ravn.task.completed",
+                source="ravn:coordinator",
+                payload={"verdict": "retry", "tests_passing": False},
+                summary="retry needed",
+                urgency=0.8,
+                domain="code",
+                timestamp=NOW,
+                correlation_id=_SESSION,
+            )
+            await bus.publish(event)
+
+            for _ in range(10):
+                await asyncio.sleep(0)
+
+            updated = tracker._raids_by_id[_TRACKER_ID]
+            assert updated.status == RaidStatus.PENDING
+            assert updated.retry_count == 1
+        finally:
+            await handler.stop()
+
+    @pytest.mark.asyncio
+    async def test_stop_cancels_in_flight_tasks(self):
+        """stop() should cancel pending tasks without raising."""
+        bus = InProcessBus()
+        handler = RavnOutcomeHandler(
+            subscriber=bus,
+            tracker_factory=StubTrackerFactory(StubTracker()),
+            review_engine=ReviewEngine(
+                tracker_factory=StubTrackerFactory(StubTracker()),
+                volundr_factory=StubVolundrFactory(),
+                git=StubGit(),
+                review_config=ReviewConfig(reviewer_session_enabled=False),
+            ),
+            owner_id=_OWNER,
+        )
+        await handler.start()
+        assert handler.is_running
+        await handler.stop()
+        assert not handler.is_running
+
+
+# ---------------------------------------------------------------------------
+# Integration: coexistence — ActivitySubscriber and RavnOutcomeHandler
+# ---------------------------------------------------------------------------
+
+
+class TestCoexistence:
+    @pytest.mark.asyncio
+    async def test_explicit_outcome_takes_precedence_over_terminal_state(self):
+        """When ActivitySubscriber has already merged the raid, ravn outcome is skipped."""
+        raid = _make_raid(status=RaidStatus.MERGED, confidence=1.0)
+        tracker = StubTracker(raid)
+        factory = StubTrackerFactory(tracker)
+        engine = ReviewEngine(
+            tracker_factory=factory,
+            volundr_factory=StubVolundrFactory(),
+            git=StubGit(),
+            review_config=ReviewConfig(reviewer_session_enabled=False),
+        )
+        handler = RavnOutcomeHandler(
+            subscriber=InProcessBus(),
+            tracker_factory=factory,
+            review_engine=engine,
+            owner_id=_OWNER,
+        )
+
+        event = _make_sleipnir_event(
+            {"verdict": "approve", "tests_passing": True}, correlation_id=_SESSION
+        )
+        await handler._process_event(event)
+
+        # Raid should still be MERGED — handler skips terminal raids
+        assert tracker._raids_by_id[_TRACKER_ID].status == RaidStatus.MERGED
+
+    @pytest.mark.asyncio
+    async def test_escalated_raid_skipped(self):
+        """If ActivitySubscriber already escalated, ravn outcome is skipped."""
+        raid = _make_raid(status=RaidStatus.ESCALATED, confidence=0.4)
+        tracker = StubTracker(raid)
+        factory = StubTrackerFactory(tracker)
+        engine = ReviewEngine(
+            tracker_factory=factory,
+            volundr_factory=StubVolundrFactory(),
+            git=StubGit(),
+            review_config=ReviewConfig(reviewer_session_enabled=False),
+        )
+        handler = RavnOutcomeHandler(
+            subscriber=InProcessBus(),
+            tracker_factory=factory,
+            review_engine=engine,
+            owner_id=_OWNER,
+        )
+
+        event = _make_sleipnir_event(
+            {"verdict": "approve", "tests_passing": True}, correlation_id=_SESSION
+        )
+        await handler._process_event(event)
+
+        assert tracker._raids_by_id[_TRACKER_ID].status == RaidStatus.ESCALATED

--- a/tests/test_tyr/test_ravn_outcome_handler.py
+++ b/tests/test_tyr/test_ravn_outcome_handler.py
@@ -12,34 +12,28 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime
-from uuid import UUID, uuid4
 
 import pytest
 
 from sleipnir.adapters.in_process import InProcessBus
 from sleipnir.domain.events import SleipnirEvent
-from tests.test_tyr.stubs import StubVolundrFactory
+from tests.test_tyr.stubs import (
+    StubTracker,
+    StubTrackerFactory,
+    StubVolundrFactory,
+    make_raid,
+)
 from tyr.adapters.memory_event_bus import InMemoryEventBus
 from tyr.adapters.ravn_outcome_handler import RavnOutcomeHandler, _extract_outcome
 from tyr.config import ReviewConfig
 from tyr.domain.models import (
-    ConfidenceEvent,
     ConfidenceEventType,
-    Phase,
-    PhaseStatus,
     PRStatus,
-    Raid,
     RaidStatus,
     RavnOutcome,
-    Saga,
-    SessionMessage,
-    TrackerIssue,
-    TrackerMilestone,
-    TrackerProject,
 )
 from tyr.domain.services.review_engine import ReviewEngine
 from tyr.ports.git import GitPort
-from tyr.ports.tracker import TrackerPort
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -54,35 +48,6 @@ _TRACKER_ID = "raid-tracker-001"
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _make_raid(
-    *,
-    status: RaidStatus = RaidStatus.REVIEW,
-    confidence: float = 0.5,
-    session_id: str | None = _SESSION,
-    retry_count: int = 0,
-) -> Raid:
-    return Raid(
-        id=uuid4(),
-        phase_id=uuid4(),
-        tracker_id=_TRACKER_ID,
-        name="test-raid",
-        description="A test raid",
-        acceptance_criteria=[],
-        declared_files=[],
-        estimate_hours=1.0,
-        status=status,
-        confidence=confidence,
-        session_id=session_id,
-        branch=None,
-        chronicle_summary=None,
-        pr_url=None,
-        pr_id=None,
-        retry_count=retry_count,
-        created_at=NOW,
-        updated_at=NOW,
-    )
 
 
 def _make_sleipnir_event(
@@ -125,188 +90,6 @@ class StubGit(GitPort):
 
     async def get_pr_changed_files(self, pr_id: str) -> list[str]:
         return []
-
-
-class StubTracker(TrackerPort):
-    """Minimal in-memory tracker for ravn outcome tests."""
-
-    def __init__(self, raid: Raid | None = None) -> None:
-        self._raid = raid
-        self._raids_by_session: dict[str, Raid] = {}
-        if raid is not None:
-            self._raids_by_id = {raid.tracker_id: raid}
-            if raid.session_id:
-                self._raids_by_session[raid.session_id] = raid
-        else:
-            self._raids_by_id: dict[str, Raid] = {}
-        self.confidence_events: dict[str, list[ConfidenceEvent]] = {}
-        self.phase: Phase | None = None
-        self.saga: Saga | None = None
-        self._phases: list[Phase] = []
-        self._all_merged: bool = False
-        self.closed_raids: list[str] = []
-
-    # -- CRUD: create entities --
-
-    async def create_saga(self, saga: Saga, *, description: str = "") -> str:
-        return saga.tracker_id
-
-    async def create_phase(self, phase: Phase, *, project_id: str = "") -> str:
-        return phase.tracker_id
-
-    async def create_raid(self, raid: Raid, *, project_id: str = "", milestone_id: str = "") -> str:
-        self._raids_by_id[raid.tracker_id] = raid
-        if raid.session_id:
-            self._raids_by_session[raid.session_id] = raid
-        return raid.tracker_id
-
-    async def update_raid_state(self, raid_id: str, state: RaidStatus) -> None:
-        pass
-
-    async def close_raid(self, raid_id: str) -> None:
-        self.closed_raids.append(raid_id)
-
-    # -- Read --
-
-    async def get_saga(self, saga_id: str) -> Saga:
-        if self.saga is None:
-            raise ValueError("No saga")
-        return self.saga
-
-    async def get_phase(self, tracker_id: str) -> Phase:
-        if self.phase is None:
-            raise ValueError("No phase")
-        return self.phase
-
-    async def get_raid(self, tracker_id: str) -> Raid:
-        raid = self._raids_by_id.get(tracker_id)
-        if raid is None:
-            raise ValueError(f"Raid not found: {tracker_id}")
-        return raid
-
-    async def list_pending_raids(self, phase_id: str) -> list[Raid]:
-        return []
-
-    async def list_projects(self) -> list[TrackerProject]:
-        return []
-
-    async def get_project(self, project_id: str) -> TrackerProject:
-        raise NotImplementedError
-
-    async def list_milestones(self, project_id: str) -> list[TrackerMilestone]:
-        return []
-
-    async def list_issues(
-        self, project_id: str, milestone_id: str | None = None
-    ) -> list[TrackerIssue]:
-        return []
-
-    # -- Raid progress --
-
-    async def update_raid_progress(
-        self,
-        tracker_id: str,
-        *,
-        status: RaidStatus | None = None,
-        session_id: str | None = None,
-        confidence: float | None = None,
-        pr_url: str | None = None,
-        pr_id: str | None = None,
-        retry_count: int | None = None,
-        reason: str | None = None,
-        owner_id: str | None = None,
-        phase_tracker_id: str | None = None,
-        saga_tracker_id: str | None = None,
-        chronicle_summary: str | None = None,
-        reviewer_session_id: str | None = None,
-        review_round: int | None = None,
-    ) -> Raid:
-        raid = self._raids_by_id.get(tracker_id)
-        if raid is None:
-            raise ValueError(f"Raid not found: {tracker_id}")
-        events = self.confidence_events.get(tracker_id, [])
-        new_confidence = events[-1].score_after if events else raid.confidence
-        updated = Raid(
-            id=raid.id,
-            phase_id=raid.phase_id,
-            tracker_id=raid.tracker_id,
-            name=raid.name,
-            description=raid.description,
-            acceptance_criteria=raid.acceptance_criteria,
-            declared_files=raid.declared_files,
-            estimate_hours=raid.estimate_hours,
-            status=status if status is not None else raid.status,
-            confidence=confidence if confidence is not None else new_confidence,
-            session_id=session_id if session_id is not None else raid.session_id,
-            branch=raid.branch,
-            chronicle_summary=raid.chronicle_summary,
-            pr_url=pr_url if pr_url is not None else raid.pr_url,
-            pr_id=pr_id if pr_id is not None else raid.pr_id,
-            retry_count=retry_count if retry_count is not None else raid.retry_count,
-            created_at=raid.created_at,
-            updated_at=NOW,
-            reviewer_session_id=(
-                reviewer_session_id if reviewer_session_id is not None else raid.reviewer_session_id
-            ),
-            review_round=review_round if review_round is not None else raid.review_round,
-        )
-        self._raids_by_id[tracker_id] = updated
-        if updated.session_id:
-            self._raids_by_session[updated.session_id] = updated
-        return updated
-
-    async def get_raid_progress_for_saga(self, saga_tracker_id: str) -> list[Raid]:
-        return list(self._raids_by_id.values())
-
-    async def get_raid_by_session(self, session_id: str) -> Raid | None:
-        return self._raids_by_session.get(session_id)
-
-    async def list_raids_by_status(self, status: RaidStatus) -> list[Raid]:
-        return [r for r in self._raids_by_id.values() if r.status == status]
-
-    async def get_raid_by_id(self, raid_id: UUID) -> Raid | None:
-        return next((r for r in self._raids_by_id.values() if r.id == raid_id), None)
-
-    async def add_confidence_event(self, tracker_id: str, event: ConfidenceEvent) -> None:
-        self.confidence_events.setdefault(tracker_id, []).append(event)
-
-    async def get_confidence_events(self, tracker_id: str) -> list[ConfidenceEvent]:
-        return self.confidence_events.get(tracker_id, [])
-
-    async def all_raids_merged(self, phase_tracker_id: str) -> bool:
-        return self._all_merged
-
-    async def list_phases_for_saga(self, saga_tracker_id: str) -> list[Phase]:
-        return self._phases
-
-    async def update_phase_status(self, phase_tracker_id: str, status: PhaseStatus) -> Phase | None:
-        return None
-
-    async def get_saga_for_raid(self, tracker_id: str) -> Saga | None:
-        return self.saga
-
-    async def get_phase_for_raid(self, tracker_id: str) -> Phase | None:
-        return self.phase
-
-    async def get_owner_for_raid(self, tracker_id: str) -> str | None:
-        return _OWNER
-
-    async def save_session_message(self, message: SessionMessage) -> None:
-        pass
-
-    async def get_session_messages(self, tracker_id: str) -> list[SessionMessage]:
-        return []
-
-    async def attach_issue_document(self, issue_id: str, title: str, content: str) -> str:
-        return "doc-1"
-
-
-class StubTrackerFactory:
-    def __init__(self, tracker: StubTracker) -> None:
-        self._tracker = tracker
-
-    async def for_owner(self, owner_id: str) -> list[StubTracker]:
-        return [self._tracker]
 
 
 def _make_engine(tracker: StubTracker, event_bus: InMemoryEventBus | None = None) -> ReviewEngine:
@@ -373,7 +156,7 @@ class TestExtractOutcome:
 class TestHandleRavnOutcomeSignals:
     @pytest.mark.asyncio
     async def test_tests_passing_true_emits_ci_pass(self):
-        raid = _make_raid(status=RaidStatus.REVIEW, confidence=0.5)
+        raid = make_raid(status=RaidStatus.REVIEW, confidence=0.5)
         tracker = StubTracker(raid)
         engine = _make_engine(tracker)
 
@@ -394,7 +177,7 @@ class TestHandleRavnOutcomeSignals:
 
     @pytest.mark.asyncio
     async def test_tests_passing_false_emits_ci_fail(self):
-        raid = _make_raid(status=RaidStatus.REVIEW, confidence=0.5)
+        raid = make_raid(status=RaidStatus.REVIEW, confidence=0.5)
         tracker = StubTracker(raid)
         engine = _make_engine(tracker)
 
@@ -415,7 +198,7 @@ class TestHandleRavnOutcomeSignals:
 
     @pytest.mark.asyncio
     async def test_tests_passing_none_no_ci_event(self):
-        raid = _make_raid(status=RaidStatus.REVIEW)
+        raid = make_raid(status=RaidStatus.REVIEW)
         tracker = StubTracker(raid)
         engine = _make_engine(tracker)
 
@@ -437,7 +220,7 @@ class TestHandleRavnOutcomeSignals:
 
     @pytest.mark.asyncio
     async def test_low_scope_adherence_emits_scope_breach(self):
-        raid = _make_raid(status=RaidStatus.REVIEW, confidence=0.8)
+        raid = make_raid(status=RaidStatus.REVIEW, confidence=0.8)
         tracker = StubTracker(raid)
         engine = _make_engine(tracker)
 
@@ -458,7 +241,7 @@ class TestHandleRavnOutcomeSignals:
 
     @pytest.mark.asyncio
     async def test_high_scope_adherence_no_breach(self):
-        raid = _make_raid(status=RaidStatus.REVIEW, confidence=0.8)
+        raid = make_raid(status=RaidStatus.REVIEW, confidence=0.8)
         tracker = StubTracker(raid)
         engine = _make_engine(tracker)
 
@@ -479,7 +262,7 @@ class TestHandleRavnOutcomeSignals:
 
     @pytest.mark.asyncio
     async def test_scope_adherence_none_no_breach(self):
-        raid = _make_raid(status=RaidStatus.REVIEW)
+        raid = make_raid(status=RaidStatus.REVIEW)
         tracker = StubTracker(raid)
         engine = _make_engine(tracker)
 
@@ -508,7 +291,7 @@ class TestHandleRavnOutcomeDecisions:
     @pytest.mark.asyncio
     async def test_verdict_approve_high_confidence_auto_approved(self):
         # ci_pass delta=0.30, starting at 0.6 → 0.9 >= 0.8 threshold → auto_approved
-        raid = _make_raid(status=RaidStatus.REVIEW, confidence=0.6)
+        raid = make_raid(status=RaidStatus.REVIEW, confidence=0.6)
         tracker = StubTracker(raid)
         engine = _make_engine(tracker)
 
@@ -531,7 +314,7 @@ class TestHandleRavnOutcomeDecisions:
     @pytest.mark.asyncio
     async def test_verdict_approve_low_confidence_escalated(self):
         # Starting at 0.4, ci_fail -0.30 → 0.1 < 0.8 threshold → escalated even with "approve"
-        raid = _make_raid(status=RaidStatus.REVIEW, confidence=0.4)
+        raid = make_raid(status=RaidStatus.REVIEW, confidence=0.4)
         tracker = StubTracker(raid)
         engine = _make_engine(tracker)
 
@@ -553,7 +336,7 @@ class TestHandleRavnOutcomeDecisions:
 
     @pytest.mark.asyncio
     async def test_verdict_retry_transitions_to_pending(self):
-        raid = _make_raid(status=RaidStatus.REVIEW, confidence=0.5, retry_count=0)
+        raid = make_raid(status=RaidStatus.REVIEW, confidence=0.5, retry_count=0)
         tracker = StubTracker(raid)
         engine = _make_engine(tracker)
 
@@ -575,8 +358,31 @@ class TestHandleRavnOutcomeDecisions:
         assert updated_raid.retry_count == 1
 
     @pytest.mark.asyncio
+    async def test_verdict_retry_exhausted_transitions_to_failed(self):
+        raid = make_raid(status=RaidStatus.REVIEW, confidence=0.5, retry_count=3)
+        tracker = StubTracker(raid)
+        # max_retries default is 3, so retry_count=3 means retries exhausted
+        engine = _make_engine(tracker)
+
+        outcome = RavnOutcome(
+            verdict="retry",
+            tests_passing=False,
+            scope_adherence=1.0,
+            pr_url=None,
+            files_changed=[],
+            summary="",
+        )
+        decision = await engine.handle_ravn_outcome(
+            _TRACKER_ID, _OWNER, outcome, scope_adherence_threshold=0.7
+        )
+
+        assert decision.action == "failed"
+        updated_raid = tracker._raids_by_id[_TRACKER_ID]
+        assert updated_raid.status == RaidStatus.FAILED
+
+    @pytest.mark.asyncio
     async def test_verdict_escalate_direct_escalation(self):
-        raid = _make_raid(status=RaidStatus.REVIEW, confidence=0.9)
+        raid = make_raid(status=RaidStatus.REVIEW, confidence=0.9)
         tracker = StubTracker(raid)
         engine = _make_engine(tracker)
 
@@ -598,7 +404,7 @@ class TestHandleRavnOutcomeDecisions:
 
     @pytest.mark.asyncio
     async def test_unknown_verdict_escalates(self):
-        raid = _make_raid(status=RaidStatus.REVIEW, confidence=0.5)
+        raid = make_raid(status=RaidStatus.REVIEW, confidence=0.5)
         tracker = StubTracker(raid)
         engine = _make_engine(tracker)
 
@@ -618,7 +424,7 @@ class TestHandleRavnOutcomeDecisions:
 
     @pytest.mark.asyncio
     async def test_running_raid_transitions_to_review_first(self):
-        raid = _make_raid(status=RaidStatus.RUNNING, confidence=0.6)
+        raid = make_raid(status=RaidStatus.RUNNING, confidence=0.6)
         tracker = StubTracker(raid)
         engine = _make_engine(tracker)
 
@@ -641,7 +447,7 @@ class TestHandleRavnOutcomeDecisions:
 
     @pytest.mark.asyncio
     async def test_terminal_raid_skipped(self):
-        raid = _make_raid(status=RaidStatus.MERGED, confidence=1.0)
+        raid = make_raid(status=RaidStatus.MERGED, confidence=1.0)
         tracker = StubTracker(raid)
         engine = _make_engine(tracker)
 
@@ -708,7 +514,7 @@ class TestRavnOutcomeHandlerCorrelation:
 
     @pytest.mark.asyncio
     async def test_valid_correlation_processes_raid(self):
-        raid = _make_raid(status=RaidStatus.REVIEW, confidence=0.6)
+        raid = make_raid(status=RaidStatus.REVIEW, confidence=0.6)
         tracker = StubTracker(raid)
         handler, _ = self._make_handler(tracker)
 
@@ -729,7 +535,7 @@ class TestRavnOutcomeHandlerIntegration:
     @pytest.mark.asyncio
     async def test_publish_ravn_task_completed_transitions_raid(self):
         """Publish event on InProcessBus → raid transitions to MERGED."""
-        raid = _make_raid(status=RaidStatus.REVIEW, confidence=0.6)
+        raid = make_raid(status=RaidStatus.REVIEW, confidence=0.6)
         tracker = StubTracker(raid)
         bus = InProcessBus()
         factory = StubTrackerFactory(tracker)
@@ -776,7 +582,7 @@ class TestRavnOutcomeHandlerIntegration:
 
     @pytest.mark.asyncio
     async def test_retry_verdict_transitions_to_pending(self):
-        raid = _make_raid(status=RaidStatus.REVIEW, confidence=0.5, retry_count=0)
+        raid = make_raid(status=RaidStatus.REVIEW, confidence=0.5, retry_count=0)
         tracker = StubTracker(raid)
         bus = InProcessBus()
         factory = StubTrackerFactory(tracker)
@@ -846,7 +652,7 @@ class TestCoexistence:
     @pytest.mark.asyncio
     async def test_explicit_outcome_takes_precedence_over_terminal_state(self):
         """When ActivitySubscriber has already merged the raid, ravn outcome is skipped."""
-        raid = _make_raid(status=RaidStatus.MERGED, confidence=1.0)
+        raid = make_raid(status=RaidStatus.MERGED, confidence=1.0)
         tracker = StubTracker(raid)
         factory = StubTrackerFactory(tracker)
         engine = ReviewEngine(
@@ -873,7 +679,7 @@ class TestCoexistence:
     @pytest.mark.asyncio
     async def test_escalated_raid_skipped(self):
         """If ActivitySubscriber already escalated, ravn outcome is skipped."""
-        raid = _make_raid(status=RaidStatus.ESCALATED, confidence=0.4)
+        raid = make_raid(status=RaidStatus.ESCALATED, confidence=0.4)
         tracker = StubTracker(raid)
         factory = StubTrackerFactory(tracker)
         engine = ReviewEngine(


### PR DESCRIPTION
## Summary

Closes the feedback loop for flock sessions. Previously, Tyr inferred raid completion from Volundr SSE idle events. Now, when a ravn flock coordinator finishes a task, it publishes a structured `ravn.task.completed` event on Sleipnir and Tyr consumes it directly.

- **`RavnOutcome` domain model** (`tyr.domain.models`) — typed representation of the coordinator's outcome payload (`verdict`, `tests_passing`, `scope_adherence`, `pr_url`, `files_changed`, `summary`)
- **`ReviewEngine.handle_ravn_outcome()`** — maps outcome fields to `ConfidenceEvent` entries (`ci_pass`/`ci_fail`, `scope_breach`) and routes to the existing decision handlers based on verdict (`approve` → auto-approve if confidence ≥ threshold, else escalate; `retry` → auto-retry; `escalate` → direct escalation). Accepts raids in RUNNING or REVIEW state; skips terminal raids so `ActivitySubscriber` and `RavnOutcomeHandler` coexist safely without conflicts
- **`RavnOutcomeHandler` adapter** (`tyr.adapters.ravn_outcome_handler`) — subscribes to `ravn.task.completed` on Sleipnir, resolves the raid via `correlation_id` → `session_id`, and delegates to `ReviewEngine`
- **`RavnOutcomeConfig`** added to `tyr.config` with `enabled` flag and `scope_adherence_threshold` (default `0.7`)
- **Wired in `main.py`** alongside `EventTriggerAdapter`; started and stopped in the lifespan context

## Test plan

25 tests in `tests/test_tyr/test_ravn_outcome_handler.py`:

- [ ] `_extract_outcome`: full payload, minimal defaults, null coercion
- [ ] Confidence signal mapping: `tests_passing=True` → `ci_pass`, `=False` → `ci_fail`, `=None` → no event; `scope_adherence < 0.7` → `scope_breach`
- [ ] Decision logic: approve+high-conf → `auto_approved`; approve+low-conf → `escalated`; `retry` → `pending`; `escalate` → `escalated`; unknown verdict → `escalated`
- [ ] RUNNING raid transitions to REVIEW before decision
- [ ] Terminal raid (MERGED, ESCALATED) → `skipped` (idempotent)
- [ ] Correlation lookup: missing `correlation_id` → warning; no matching raid → warning; valid → processes raid
- [ ] Integration: `InProcessBus` round-trip — publish event → raid transitions to MERGED / PENDING
- [ ] Coexistence: raid already MERGED when outcome arrives → skipped

Coverage: 88% tyr module, 89% on `ravn_outcome_handler.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)