### PR TITLE
feat(adapters): RavnFlockContributor — flock pod spec builder (NIU-613)

### DIFF
--- a/src/niuu/mesh.py
+++ b/src/niuu/mesh.py
@@ -134,3 +134,25 @@ def build_in_process_mesh(own_peer_id: str, rpc_timeout_s: float) -> Any:
 def resolve_peer_id(configured_id: str) -> str:
     """Return *configured_id* if non-empty, else the machine hostname."""
     return configured_id or socket.gethostname()
+
+
+def nng_ports_for(index: int, base_port: int) -> tuple[int, int, int]:
+    """Return (pub_port, rep_port, handshake_port) for the nng node at *index*.
+
+    Port allocation scheme (mirrors ravn flock init):
+      pub       = base_port + index * 2
+      rep       = base_port + index * 2 + 1
+      handshake = base_port + 100 + index
+    """
+    pub = base_port + (index * 2)
+    rep = base_port + (index * 2) + 1
+    hs = base_port + 100 + index
+    return pub, rep, hs
+
+
+def nng_gateway_port_for(index: int, base_port: int) -> int:
+    """Return the HTTP/WS gateway port for the nng node at *index*.
+
+    gateway = base_port + 200 + index
+    """
+    return base_port + 200 + index

--- a/src/ravn/cli/flock.py
+++ b/src/ravn/cli/flock.py
@@ -38,6 +38,8 @@ from pathlib import Path
 
 import typer
 
+from niuu.mesh import nng_gateway_port_for, nng_ports_for
+
 # ---------------------------------------------------------------------------
 # Typer app
 # ---------------------------------------------------------------------------
@@ -195,17 +197,8 @@ def _delete_runtime(flock_dir: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _ports_for(index: int, base_port: int) -> tuple[int, int, int]:
-    """Return (pub_port, rep_port, handshake_port) for node at *index*."""
-    pub = base_port + (index * 2)
-    rep = base_port + (index * 2) + 1
-    hs = base_port + 100 + index
-    return pub, rep, hs
-
-
-def _gateway_port_for(index: int, base_port: int) -> int:
-    """Return the HTTP/WS gateway port for node at *index*."""
-    return base_port + 200 + index
+_ports_for = nng_ports_for
+_gateway_port_for = nng_gateway_port_for
 
 
 def _port_free(port: int) -> bool:

--- a/src/volundr/adapters/outbound/contributors/__init__.py
+++ b/src/volundr/adapters/outbound/contributors/__init__.py
@@ -5,6 +5,7 @@ from volundr.adapters.outbound.contributors.gateway import GatewayContributor
 from volundr.adapters.outbound.contributors.git import GitContributor
 from volundr.adapters.outbound.contributors.integrations import IntegrationContributor
 from volundr.adapters.outbound.contributors.isolation import IsolationContributor
+from volundr.adapters.outbound.contributors.ravn_flock import RavnFlockContributor
 from volundr.adapters.outbound.contributors.secrets import (
     SecretInjectionContributor,
     SecretsContributor,
@@ -18,6 +19,7 @@ __all__ = [
     "GitContributor",
     "IntegrationContributor",
     "IsolationContributor",
+    "RavnFlockContributor",
     "SecretInjectionContributor",
     "StorageContributor",
     "TemplateContributor",

--- a/src/volundr/adapters/outbound/contributors/ravn_flock.py
+++ b/src/volundr/adapters/outbound/contributors/ravn_flock.py
@@ -1,0 +1,349 @@
+"""RavnFlockContributor — pod spec builder for raiding party (flock) pods.
+
+When workload_type == "ravn_flock", this contributor replaces the default
+single-CLI layout with:
+  - Skuld container with mesh.enabled=true + nng ports + Sleipnir webhook
+  - N ravn daemon sidecar containers (one per persona in workload_config.personas)
+  - nng mesh ports allocated via the same scheme as ravn flock init
+  - Mimir emptyDir volume for ephemeral local memory
+  - Sleipnir webhook transport config in both skuld and ravn containers
+
+Port allocation (mirrors ravn/cli/flock.py):
+  pub       = base_port + index * 2
+  rep       = base_port + index * 2 + 1
+  handshake = base_port + 100 + index
+  gateway   = base_port + 200 + index
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from volundr.domain.models import ForgeProfile, PodSpecAdditions, Session, WorkspaceTemplate
+from volundr.domain.ports import (
+    ProfileProvider,
+    SessionContext,
+    SessionContribution,
+    SessionContributor,
+    TemplateProvider,
+)
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BASE_PORT = 7480
+_MIMIR_VOLUME_NAME = "mimir-local"
+_MIMIR_MOUNT_PATH = "/mimir/local"
+_WORKSPACE_VOLUME_NAME = "workspace"
+_WORKSPACE_MOUNT_PATH = "/workspace"
+_RAVN_IMAGE_DEFAULT = "ghcr.io/niuulabs/ravn:latest"
+
+
+def _ports_for(index: int, base_port: int) -> tuple[int, int, int]:
+    """Return (pub_port, rep_port, handshake_port) for the node at *index*."""
+    pub = base_port + (index * 2)
+    rep = base_port + (index * 2) + 1
+    hs = base_port + 100 + index
+    return pub, rep, hs
+
+
+def _gateway_port_for(index: int, base_port: int) -> int:
+    """Return the HTTP/WS gateway port for the node at *index*."""
+    return base_port + 200 + index
+
+
+def _build_ravn_config(
+    index: int,
+    persona: str,
+    peer_id: str,
+    base_port: int,
+    all_personas: list[str],
+    mimir_hosted_url: str | None,
+    sleipnir_publish_urls: list[str],
+) -> str:
+    """Generate the ravn daemon YAML config for a single flock node."""
+    pub, rep, hs = _ports_for(index, base_port)
+    gw = _gateway_port_for(index, base_port)
+
+    peers_block = "\n".join(f'    - peer_id: "flock-{p}"' for p in all_personas if p != persona)
+
+    mimir_block = (
+        "memory:\n"
+        "  backend: composite\n"
+        "  composite:\n"
+        "    backends:\n"
+        "      - type: local\n"
+        "        path: /mimir/local"
+    )
+    if mimir_hosted_url:
+        mimir_block += f"\n      - type: hosted\n        url: {mimir_hosted_url!r}"
+
+    sleipnir_urls = "\n".join(f'      - "{u}"' for u in sleipnir_publish_urls)
+    sleipnir_block = ""
+    if sleipnir_publish_urls:
+        sleipnir_block = (
+            "sleipnir:\n"
+            "  enabled: true\n"
+            "  transport: webhook\n"
+            "  webhook:\n"
+            "    publish_urls:\n"
+            f"{sleipnir_urls}\n"
+        )
+
+    peers_section = ""
+    if peers_block:
+        peers_section = f"  peers:\n{peers_block}\n"
+
+    return (
+        f"persona: {persona!r}\n"
+        f"\n"
+        f"mesh:\n"
+        f"  enabled: true\n"
+        f"  adapter: nng\n"
+        f'  own_peer_id: "{peer_id}"\n'
+        f"  nng:\n"
+        f'    pub_sub_address: "tcp://0.0.0.0:{pub}"\n'
+        f'    req_rep_address: "tcp://0.0.0.0:{rep}"\n'
+        f"{peers_section}"
+        f"\n"
+        f"discovery:\n"
+        f"  enabled: true\n"
+        f"  adapter: static\n"
+        f"\n"
+        f"cascade:\n"
+        f"  enabled: true\n"
+        f"\n"
+        f"gateway:\n"
+        f"  enabled: true\n"
+        f"  channels:\n"
+        f"    http:\n"
+        f"      enabled: true\n"
+        f"      host: '0.0.0.0'\n"
+        f"      port: {gw}\n"
+        f"\n"
+        f"initiative:\n"
+        f"  enabled: true\n"
+        f"  max_concurrent_tasks: 3\n"
+        f"\n"
+        f"{mimir_block}\n"
+        f"\n"
+        f"{sleipnir_block}"
+        f"logging:\n"
+        f"  level: INFO\n"
+    )
+
+
+class RavnFlockContributor(SessionContributor):
+    """Contributes flock pod spec when workload_type == 'ravn_flock'.
+
+    Resolves the profile or template from the session context, reads
+    workload_config.personas + mesh/mimir/sleipnir settings, then:
+      - Emits skuld mesh env vars (MESH_ENABLED, MESH_PEER_ID, nng addresses)
+      - Emits one ravn sidecar container per persona with RAVN_CONFIG env
+      - Emits a Mimir emptyDir volume
+      - Emits Sleipnir webhook env vars for both skuld and ravn containers
+
+    No-ops silently when workload_type != 'ravn_flock'.
+    """
+
+    def __init__(
+        self,
+        *,
+        template_provider: TemplateProvider | None = None,
+        profile_provider: ProfileProvider | None = None,
+        ravn_image: str = _RAVN_IMAGE_DEFAULT,
+        base_port: int = _DEFAULT_BASE_PORT,
+        **_extra: object,
+    ) -> None:
+        self._template_provider = template_provider
+        self._profile_provider = profile_provider
+        self._ravn_image = ravn_image
+        self._base_port = base_port
+
+    @property
+    def name(self) -> str:
+        return "ravn_flock"
+
+    async def contribute(
+        self,
+        session: Session,
+        context: SessionContext,
+    ) -> SessionContribution:
+        source = self._resolve_source(context)
+
+        if source is None:
+            return SessionContribution()
+
+        if source.workload_type != "ravn_flock":
+            return SessionContribution()
+
+        wc = source.workload_config
+        personas: list[str] = list(wc.get("personas", []))
+
+        if not personas:
+            logger.warning(
+                "ravn_flock workload_config has no personas — skipping flock contribution"
+            )
+            return SessionContribution()
+
+        mesh_cfg: dict = wc.get("mesh", {})
+        mimir_cfg: dict = wc.get("mimir", {})
+        sleipnir_cfg: dict = wc.get("sleipnir", {})
+
+        mimir_hosted_url: str | None = mimir_cfg.get("hosted_url")
+        sleipnir_publish_urls: list[str] = sleipnir_cfg.get("publish_urls", [])
+        mesh_transport: str = mesh_cfg.get("transport", "nng")
+
+        values, pod_spec = self._build_flock_spec(
+            session=session,
+            personas=personas,
+            mesh_transport=mesh_transport,
+            mimir_hosted_url=mimir_hosted_url,
+            sleipnir_publish_urls=sleipnir_publish_urls,
+        )
+
+        return SessionContribution(values=values, pod_spec=pod_spec)
+
+    def _resolve_source(self, context: SessionContext) -> WorkspaceTemplate | ForgeProfile | None:
+        if context.template_name and self._template_provider is not None:
+            template = self._template_provider.get(context.template_name)
+            if template is not None:
+                return template
+
+        if self._profile_provider is not None:
+            if context.profile_name:
+                profile = self._profile_provider.get(context.profile_name)
+                if profile is not None:
+                    return profile
+            default = self._profile_provider.get_default("ravn_flock")
+            if default is not None:
+                return default
+
+        return None
+
+    def _build_flock_spec(
+        self,
+        session: Session,
+        personas: list[str],
+        mesh_transport: str,
+        mimir_hosted_url: str | None,
+        sleipnir_publish_urls: list[str],
+    ) -> tuple[dict[str, Any], PodSpecAdditions]:
+        session_id = str(session.id)
+        base_port = self._base_port
+
+        # Skuld (index 0) + ravn nodes start at index 1
+        skuld_peer_id = f"skuld-{session_id[:8]}"
+        skuld_pub, skuld_rep, skuld_hs = _ports_for(0, base_port)
+
+        skuld_env: list[dict] = [
+            {"name": "MESH_ENABLED", "value": "true"},
+            {"name": "MESH_TRANSPORT", "value": mesh_transport},
+            {"name": "MESH_PEER_ID", "value": skuld_peer_id},
+            {"name": "MESH_PUB_ADDRESS", "value": f"tcp://0.0.0.0:{skuld_pub}"},
+            {"name": "MESH_REP_ADDRESS", "value": f"tcp://0.0.0.0:{skuld_rep}"},
+            {"name": "MESH_HANDSHAKE_PORT", "value": str(skuld_hs)},
+        ]
+
+        if sleipnir_publish_urls:
+            skuld_env.append(
+                {
+                    "name": "SLEIPNIR_PUBLISH_URLS",
+                    "value": ",".join(sleipnir_publish_urls),
+                }
+            )
+
+        # nng ports for skuld as Helm values
+        skuld_ports: list[dict] = [
+            {"containerPort": skuld_pub, "name": "mesh-pub", "protocol": "TCP"},
+            {"containerPort": skuld_rep, "name": "mesh-rep", "protocol": "TCP"},
+            {"containerPort": skuld_hs, "name": "mesh-hs", "protocol": "TCP"},
+        ]
+
+        # Ravn sidecar containers (indices 1..N)
+        extra_containers: list[dict] = []
+        for i, persona in enumerate(personas):
+            ravn_index = i + 1
+            peer_id = f"flock-{persona}"
+            pub, rep, hs = _ports_for(ravn_index, base_port)
+            gw = _gateway_port_for(ravn_index, base_port)
+
+            config_yaml = _build_ravn_config(
+                index=ravn_index,
+                persona=persona,
+                peer_id=peer_id,
+                base_port=base_port,
+                all_personas=personas,
+                mimir_hosted_url=mimir_hosted_url,
+                sleipnir_publish_urls=sleipnir_publish_urls,
+            )
+
+            ravn_env: list[dict] = [
+                {"name": "RAVN_PERSONA", "value": persona},
+                {"name": "RAVN_PEER_ID", "value": peer_id},
+                {"name": "RAVN_CONFIG_INLINE", "value": config_yaml},
+            ]
+
+            if sleipnir_publish_urls:
+                ravn_env.append(
+                    {
+                        "name": "SLEIPNIR_PUBLISH_URLS",
+                        "value": ",".join(sleipnir_publish_urls),
+                    }
+                )
+
+            container: dict[str, Any] = {
+                "name": f"ravn-{persona}",
+                "image": self._ravn_image,
+                "env": ravn_env,
+                "ports": [
+                    {"containerPort": pub, "name": f"r{ravn_index}-pub", "protocol": "TCP"},
+                    {"containerPort": rep, "name": f"r{ravn_index}-rep", "protocol": "TCP"},
+                    {"containerPort": hs, "name": f"r{ravn_index}-hs", "protocol": "TCP"},
+                    {"containerPort": gw, "name": f"r{ravn_index}-gw", "protocol": "TCP"},
+                ],
+                "volumeMounts": [
+                    {"name": _MIMIR_VOLUME_NAME, "mountPath": _MIMIR_MOUNT_PATH},
+                    {
+                        "name": _WORKSPACE_VOLUME_NAME,
+                        "mountPath": _WORKSPACE_MOUNT_PATH,
+                        "readOnly": True,
+                    },
+                ],
+            }
+            extra_containers.append(container)
+
+        pod_spec = PodSpecAdditions(
+            volumes=(
+                {
+                    "name": _MIMIR_VOLUME_NAME,
+                    "emptyDir": {},
+                },
+            ),
+            env=tuple(skuld_env),
+            extra_containers=tuple(extra_containers),
+        )
+
+        values: dict[str, Any] = {
+            "mesh": {
+                "enabled": True,
+                "transport": mesh_transport,
+                "peerPorts": skuld_ports,
+            },
+        }
+
+        if mimir_hosted_url:
+            values["mimir"] = {"hostedUrl": mimir_hosted_url}
+
+        if sleipnir_publish_urls:
+            values["sleipnir"] = {"publishUrls": sleipnir_publish_urls}
+
+        logger.info(
+            "ravn_flock: session=%s skuld peer=%s ravn personas=%s base_port=%d",
+            session_id[:8],
+            skuld_peer_id,
+            personas,
+            base_port,
+        )
+
+        return values, pod_spec

--- a/src/volundr/adapters/outbound/contributors/ravn_flock.py
+++ b/src/volundr/adapters/outbound/contributors/ravn_flock.py
@@ -8,7 +8,7 @@ single-CLI layout with:
   - Mimir emptyDir volume for ephemeral local memory
   - Sleipnir webhook transport config in both skuld and ravn containers
 
-Port allocation (mirrors ravn/cli/flock.py):
+Port allocation (mirrors ravn/cli/flock.py via niuu.mesh):
   pub       = base_port + index * 2
   rep       = base_port + index * 2 + 1
   handshake = base_port + 100 + index
@@ -20,6 +20,10 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+import yaml
+
+from niuu.mesh import nng_gateway_port_for as _gateway_port_for
+from niuu.mesh import nng_ports_for as _ports_for
 from volundr.domain.models import ForgeProfile, PodSpecAdditions, Session, WorkspaceTemplate
 from volundr.domain.ports import (
     ProfileProvider,
@@ -32,24 +36,12 @@ from volundr.domain.ports import (
 logger = logging.getLogger(__name__)
 
 _DEFAULT_BASE_PORT = 7480
+_DEFAULT_MAX_CONCURRENT_TASKS = 3
 _MIMIR_VOLUME_NAME = "mimir-local"
 _MIMIR_MOUNT_PATH = "/mimir/local"
 _WORKSPACE_VOLUME_NAME = "workspace"
 _WORKSPACE_MOUNT_PATH = "/workspace"
 _RAVN_IMAGE_DEFAULT = "ghcr.io/niuulabs/ravn:latest"
-
-
-def _ports_for(index: int, base_port: int) -> tuple[int, int, int]:
-    """Return (pub_port, rep_port, handshake_port) for the node at *index*."""
-    pub = base_port + (index * 2)
-    rep = base_port + (index * 2) + 1
-    hs = base_port + 100 + index
-    return pub, rep, hs
-
-
-def _gateway_port_for(index: int, base_port: int) -> int:
-    """Return the HTTP/WS gateway port for the node at *index*."""
-    return base_port + 200 + index
 
 
 def _build_ravn_config(
@@ -58,79 +50,62 @@ def _build_ravn_config(
     peer_id: str,
     base_port: int,
     all_personas: list[str],
+    skuld_peer_id: str,
     mimir_hosted_url: str | None,
     sleipnir_publish_urls: list[str],
+    max_concurrent_tasks: int,
 ) -> str:
     """Generate the ravn daemon YAML config for a single flock node."""
-    pub, rep, hs = _ports_for(index, base_port)
+    pub, rep, _hs = _ports_for(index, base_port)
     gw = _gateway_port_for(index, base_port)
 
-    peers_block = "\n".join(f'    - peer_id: "flock-{p}"' for p in all_personas if p != persona)
+    peers: list[dict[str, str]] = [{"peer_id": skuld_peer_id}] + [
+        {"peer_id": f"flock-{p}"} for p in all_personas if p != persona
+    ]
 
-    mimir_block = (
-        "memory:\n"
-        "  backend: composite\n"
-        "  composite:\n"
-        "    backends:\n"
-        "      - type: local\n"
-        "        path: /mimir/local"
-    )
+    mimir_backends: list[dict[str, Any]] = [{"type": "local", "path": _MIMIR_MOUNT_PATH}]
     if mimir_hosted_url:
-        mimir_block += f"\n      - type: hosted\n        url: {mimir_hosted_url!r}"
+        mimir_backends.append({"type": "hosted", "url": mimir_hosted_url})
 
-    sleipnir_urls = "\n".join(f'      - "{u}"' for u in sleipnir_publish_urls)
-    sleipnir_block = ""
+    config: dict[str, Any] = {
+        "persona": persona,
+        "mesh": {
+            "enabled": True,
+            "adapter": "nng",
+            "own_peer_id": peer_id,
+            "nng": {
+                "pub_sub_address": f"tcp://0.0.0.0:{pub}",
+                "req_rep_address": f"tcp://0.0.0.0:{rep}",
+            },
+            "peers": peers,
+        },
+        "discovery": {"enabled": True, "adapter": "static"},
+        "cascade": {"enabled": True},
+        "gateway": {
+            "enabled": True,
+            "channels": {
+                "http": {"enabled": True, "host": "0.0.0.0", "port": gw},
+            },
+        },
+        "initiative": {
+            "enabled": True,
+            "max_concurrent_tasks": max_concurrent_tasks,
+        },
+        "memory": {
+            "backend": "composite",
+            "composite": {"backends": mimir_backends},
+        },
+        "logging": {"level": "INFO"},
+    }
+
     if sleipnir_publish_urls:
-        sleipnir_block = (
-            "sleipnir:\n"
-            "  enabled: true\n"
-            "  transport: webhook\n"
-            "  webhook:\n"
-            "    publish_urls:\n"
-            f"{sleipnir_urls}\n"
-        )
+        config["sleipnir"] = {
+            "enabled": True,
+            "transport": "webhook",
+            "webhook": {"publish_urls": sleipnir_publish_urls},
+        }
 
-    peers_section = ""
-    if peers_block:
-        peers_section = f"  peers:\n{peers_block}\n"
-
-    return (
-        f"persona: {persona!r}\n"
-        f"\n"
-        f"mesh:\n"
-        f"  enabled: true\n"
-        f"  adapter: nng\n"
-        f'  own_peer_id: "{peer_id}"\n'
-        f"  nng:\n"
-        f'    pub_sub_address: "tcp://0.0.0.0:{pub}"\n'
-        f'    req_rep_address: "tcp://0.0.0.0:{rep}"\n'
-        f"{peers_section}"
-        f"\n"
-        f"discovery:\n"
-        f"  enabled: true\n"
-        f"  adapter: static\n"
-        f"\n"
-        f"cascade:\n"
-        f"  enabled: true\n"
-        f"\n"
-        f"gateway:\n"
-        f"  enabled: true\n"
-        f"  channels:\n"
-        f"    http:\n"
-        f"      enabled: true\n"
-        f"      host: '0.0.0.0'\n"
-        f"      port: {gw}\n"
-        f"\n"
-        f"initiative:\n"
-        f"  enabled: true\n"
-        f"  max_concurrent_tasks: 3\n"
-        f"\n"
-        f"{mimir_block}\n"
-        f"\n"
-        f"{sleipnir_block}"
-        f"logging:\n"
-        f"  level: INFO\n"
-    )
+    return yaml.safe_dump(config, default_flow_style=False, sort_keys=False)
 
 
 class RavnFlockContributor(SessionContributor):
@@ -193,6 +168,7 @@ class RavnFlockContributor(SessionContributor):
         mimir_hosted_url: str | None = mimir_cfg.get("hosted_url")
         sleipnir_publish_urls: list[str] = sleipnir_cfg.get("publish_urls", [])
         mesh_transport: str = mesh_cfg.get("transport", "nng")
+        max_concurrent_tasks: int = wc.get("max_concurrent_tasks", _DEFAULT_MAX_CONCURRENT_TASKS)
 
         values, pod_spec = self._build_flock_spec(
             session=session,
@@ -200,6 +176,7 @@ class RavnFlockContributor(SessionContributor):
             mesh_transport=mesh_transport,
             mimir_hosted_url=mimir_hosted_url,
             sleipnir_publish_urls=sleipnir_publish_urls,
+            max_concurrent_tasks=max_concurrent_tasks,
         )
 
         return SessionContribution(values=values, pod_spec=pod_spec)
@@ -228,6 +205,7 @@ class RavnFlockContributor(SessionContributor):
         mesh_transport: str,
         mimir_hosted_url: str | None,
         sleipnir_publish_urls: list[str],
+        max_concurrent_tasks: int,
     ) -> tuple[dict[str, Any], PodSpecAdditions]:
         session_id = str(session.id)
         base_port = self._base_port
@@ -274,8 +252,10 @@ class RavnFlockContributor(SessionContributor):
                 peer_id=peer_id,
                 base_port=base_port,
                 all_personas=personas,
+                skuld_peer_id=skuld_peer_id,
                 mimir_hosted_url=mimir_hosted_url,
                 sleipnir_publish_urls=sleipnir_publish_urls,
+                max_concurrent_tasks=max_concurrent_tasks,
             )
 
             ravn_env: list[dict] = [

--- a/src/volundr/domain/models.py
+++ b/src/volundr/domain/models.py
@@ -962,6 +962,7 @@ class PodSpecAdditions:
     annotations: dict[str, str] = ()  # type: ignore[assignment]
     env: tuple[dict, ...] = ()
     service_account: str | None = None
+    extra_containers: tuple[dict, ...] = ()
 
     def __post_init__(self) -> None:
         # Ensure dict fields default to empty dicts, not empty tuples
@@ -1414,4 +1415,5 @@ def _merge_pod_specs(a: PodSpecAdditions, b: PodSpecAdditions) -> PodSpecAdditio
         annotations={**a.annotations, **b.annotations},
         env=a.env + b.env,
         service_account=b.service_account or a.service_account,
+        extra_containers=a.extra_containers + b.extra_containers,
     )

--- a/tests/test_adapters/test_contributors/test_ravn_flock.py
+++ b/tests/test_adapters/test_contributors/test_ravn_flock.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock
 import pytest
 
 from volundr.adapters.outbound.contributors.core import CoreSessionContributor
-from volundr.adapters.outbound.contributors.git import GitContributor
 from volundr.adapters.outbound.contributors.ravn_flock import (
     RavnFlockContributor,
     _gateway_port_for,
@@ -18,8 +17,7 @@ from volundr.domain.models import (
     SessionSpec,
     WorkspaceTemplate,
 )
-from volundr.domain.ports import SessionContext, SessionContribution
-
+from volundr.domain.ports import SessionContext
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -503,7 +501,9 @@ class TestProfileProviderPath:
         assert result.pod_spec is not None
         assert len(result.pod_spec.extra_containers) == 2
 
-    async def test_template_takes_precedence_over_profile(self, session, flock_template, session_template):
+    async def test_template_takes_precedence_over_profile(
+        self, session, flock_template, session_template
+    ):
         template_provider = MagicMock()
         template_provider.get.return_value = session_template
         profile_provider = MagicMock()

--- a/tests/test_adapters/test_contributors/test_ravn_flock.py
+++ b/tests/test_adapters/test_contributors/test_ravn_flock.py
@@ -1,0 +1,538 @@
+"""Tests for RavnFlockContributor."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from volundr.adapters.outbound.contributors.core import CoreSessionContributor
+from volundr.adapters.outbound.contributors.git import GitContributor
+from volundr.adapters.outbound.contributors.ravn_flock import (
+    RavnFlockContributor,
+    _gateway_port_for,
+    _ports_for,
+)
+from volundr.domain.models import (
+    ForgeProfile,
+    GitSource,
+    Session,
+    SessionSpec,
+    WorkspaceTemplate,
+)
+from volundr.domain.ports import SessionContext, SessionContribution
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def session():
+    return Session(name="test-flock", model="claude-sonnet-4-20250514", source=GitSource())
+
+
+@pytest.fixture
+def flock_template():
+    return WorkspaceTemplate(
+        name="ravn-flock",
+        workload_type="ravn_flock",
+        workload_config={
+            "personas": ["coordinator", "reviewer"],
+            "mesh": {"transport": "nng"},
+            "mimir": {"hosted_url": "https://mimir.niuu.internal/api/v1"},
+            "sleipnir": {
+                "publish_urls": [
+                    "http://tyr:8080/sleipnir/events",
+                    "http://volundr:8000/sleipnir/events",
+                ]
+            },
+        },
+    )
+
+
+@pytest.fixture
+def flock_profile():
+    return ForgeProfile(
+        name="ravn-flock",
+        workload_type="ravn_flock",
+        workload_config={
+            "personas": ["coordinator", "reviewer"],
+            "mesh": {"transport": "nng"},
+            "mimir": {},
+            "sleipnir": {"publish_urls": ["http://tyr:8080/sleipnir/events"]},
+        },
+    )
+
+
+@pytest.fixture
+def session_template():
+    return WorkspaceTemplate(
+        name="default",
+        workload_type="session",
+        workload_config={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Port allocation
+# ---------------------------------------------------------------------------
+
+
+class TestPortAllocation:
+    def test_ports_for_index_0(self):
+        pub, rep, hs = _ports_for(0, 7480)
+        assert pub == 7480
+        assert rep == 7481
+        assert hs == 7580
+
+    def test_ports_for_index_1(self):
+        pub, rep, hs = _ports_for(1, 7480)
+        assert pub == 7482
+        assert rep == 7483
+        assert hs == 7581
+
+    def test_ports_for_index_2(self):
+        pub, rep, hs = _ports_for(2, 7480)
+        assert pub == 7484
+        assert rep == 7485
+        assert hs == 7582
+
+    def test_gateway_port_for_index_0(self):
+        assert _gateway_port_for(0, 7480) == 7680
+
+    def test_gateway_port_for_index_1(self):
+        assert _gateway_port_for(1, 7480) == 7681
+
+    def test_no_port_collisions_for_n_ravens(self):
+        """Verify skuld + N ravn nodes have unique ports."""
+        n_personas = 5
+        all_ports: set[int] = set()
+
+        for i in range(n_personas + 1):  # index 0 = skuld, 1..N = ravn
+            pub, rep, hs = _ports_for(i, 7480)
+            gw = _gateway_port_for(i, 7480)
+            for p in (pub, rep, hs, gw):
+                assert p not in all_ports, f"Port collision at index {i}: port {p}"
+                all_ports.add(p)
+
+    def test_custom_base_port(self):
+        pub, rep, hs = _ports_for(0, 8000)
+        assert pub == 8000
+        assert rep == 8001
+        assert hs == 8100
+
+
+# ---------------------------------------------------------------------------
+# Name
+# ---------------------------------------------------------------------------
+
+
+class TestRavnFlockContributorName:
+    def test_name(self):
+        c = RavnFlockContributor()
+        assert c.name == "ravn_flock"
+
+
+# ---------------------------------------------------------------------------
+# Workload type routing
+# ---------------------------------------------------------------------------
+
+
+class TestWorkloadTypeRouting:
+    async def test_session_workload_type_returns_empty(self, session, session_template):
+        provider = MagicMock()
+        provider.get.return_value = session_template
+        c = RavnFlockContributor(template_provider=provider)
+        ctx = SessionContext(template_name="default")
+        result = await c.contribute(session, ctx)
+        assert result.values == {}
+        assert result.pod_spec is None
+
+    async def test_ravn_flock_workload_type_contributes(self, session, flock_template):
+        provider = MagicMock()
+        provider.get.return_value = flock_template
+        c = RavnFlockContributor(template_provider=provider)
+        ctx = SessionContext(template_name="ravn-flock")
+        result = await c.contribute(session, ctx)
+        assert result.values != {} or result.pod_spec is not None
+
+    async def test_no_provider_returns_empty(self, session):
+        c = RavnFlockContributor()
+        result = await c.contribute(session, SessionContext())
+        assert result.values == {}
+        assert result.pod_spec is None
+
+    async def test_no_personas_returns_empty(self, session):
+        template = WorkspaceTemplate(
+            name="no-personas",
+            workload_type="ravn_flock",
+            workload_config={"personas": []},
+        )
+        provider = MagicMock()
+        provider.get.return_value = template
+        c = RavnFlockContributor(template_provider=provider)
+        ctx = SessionContext(template_name="no-personas")
+        result = await c.contribute(session, ctx)
+        assert result.values == {}
+        assert result.pod_spec is None
+
+
+# ---------------------------------------------------------------------------
+# Contributor output — 2 personas
+# ---------------------------------------------------------------------------
+
+
+class TestContributorOutput:
+    async def test_two_ravn_containers_produced(self, session, flock_template):
+        provider = MagicMock()
+        provider.get.return_value = flock_template
+        c = RavnFlockContributor(template_provider=provider)
+        ctx = SessionContext(template_name="ravn-flock")
+        result = await c.contribute(session, ctx)
+
+        assert result.pod_spec is not None
+        assert len(result.pod_spec.extra_containers) == 2
+
+    async def test_ravn_container_names(self, session, flock_template):
+        provider = MagicMock()
+        provider.get.return_value = flock_template
+        c = RavnFlockContributor(template_provider=provider)
+        ctx = SessionContext(template_name="ravn-flock")
+        result = await c.contribute(session, ctx)
+
+        names = [ctr["name"] for ctr in result.pod_spec.extra_containers]
+        assert "ravn-coordinator" in names
+        assert "ravn-reviewer" in names
+
+    async def test_skuld_mesh_enabled_in_env(self, session, flock_template):
+        provider = MagicMock()
+        provider.get.return_value = flock_template
+        c = RavnFlockContributor(template_provider=provider)
+        ctx = SessionContext(template_name="ravn-flock")
+        result = await c.contribute(session, ctx)
+
+        env_names = {e["name"]: e["value"] for e in result.pod_spec.env}
+        assert env_names.get("MESH_ENABLED") == "true"
+        assert "MESH_PEER_ID" in env_names
+        assert "MESH_PUB_ADDRESS" in env_names
+        assert "MESH_REP_ADDRESS" in env_names
+
+    async def test_mimir_volume_added(self, session, flock_template):
+        provider = MagicMock()
+        provider.get.return_value = flock_template
+        c = RavnFlockContributor(template_provider=provider)
+        ctx = SessionContext(template_name="ravn-flock")
+        result = await c.contribute(session, ctx)
+
+        volume_names = [v["name"] for v in result.pod_spec.volumes]
+        assert "mimir-local" in volume_names
+
+    async def test_ravn_container_has_mimir_mount(self, session, flock_template):
+        provider = MagicMock()
+        provider.get.return_value = flock_template
+        c = RavnFlockContributor(template_provider=provider)
+        ctx = SessionContext(template_name="ravn-flock")
+        result = await c.contribute(session, ctx)
+
+        ravn_ctr = result.pod_spec.extra_containers[0]
+        mount_paths = {m["mountPath"] for m in ravn_ctr["volumeMounts"]}
+        assert "/mimir/local" in mount_paths
+
+    async def test_ravn_container_has_workspace_mount(self, session, flock_template):
+        provider = MagicMock()
+        provider.get.return_value = flock_template
+        c = RavnFlockContributor(template_provider=provider)
+        ctx = SessionContext(template_name="ravn-flock")
+        result = await c.contribute(session, ctx)
+
+        ravn_ctr = result.pod_spec.extra_containers[0]
+        mount_paths = {m["mountPath"] for m in ravn_ctr["volumeMounts"]}
+        assert "/workspace" in mount_paths
+
+    async def test_ravn_container_workspace_readonly(self, session, flock_template):
+        provider = MagicMock()
+        provider.get.return_value = flock_template
+        c = RavnFlockContributor(template_provider=provider)
+        ctx = SessionContext(template_name="ravn-flock")
+        result = await c.contribute(session, ctx)
+
+        ravn_ctr = result.pod_spec.extra_containers[0]
+        ws_mount = next(m for m in ravn_ctr["volumeMounts"] if m["mountPath"] == "/workspace")
+        assert ws_mount.get("readOnly") is True
+
+    async def test_sleipnir_publish_urls_in_skuld_env(self, session, flock_template):
+        provider = MagicMock()
+        provider.get.return_value = flock_template
+        c = RavnFlockContributor(template_provider=provider)
+        ctx = SessionContext(template_name="ravn-flock")
+        result = await c.contribute(session, ctx)
+
+        env_names = {e["name"]: e["value"] for e in result.pod_spec.env}
+        assert "SLEIPNIR_PUBLISH_URLS" in env_names
+        assert "tyr:8080" in env_names["SLEIPNIR_PUBLISH_URLS"]
+
+    async def test_sleipnir_publish_urls_in_ravn_env(self, session, flock_template):
+        provider = MagicMock()
+        provider.get.return_value = flock_template
+        c = RavnFlockContributor(template_provider=provider)
+        ctx = SessionContext(template_name="ravn-flock")
+        result = await c.contribute(session, ctx)
+
+        for ctr in result.pod_spec.extra_containers:
+            env = {e["name"]: e["value"] for e in ctr["env"]}
+            assert "SLEIPNIR_PUBLISH_URLS" in env
+
+    async def test_mimir_hosted_url_in_values(self, session, flock_template):
+        provider = MagicMock()
+        provider.get.return_value = flock_template
+        c = RavnFlockContributor(template_provider=provider)
+        ctx = SessionContext(template_name="ravn-flock")
+        result = await c.contribute(session, ctx)
+
+        assert result.values.get("mimir", {}).get("hostedUrl") == "https://mimir.niuu.internal/api/v1"
+
+    async def test_mesh_values_present(self, session, flock_template):
+        provider = MagicMock()
+        provider.get.return_value = flock_template
+        c = RavnFlockContributor(template_provider=provider)
+        ctx = SessionContext(template_name="ravn-flock")
+        result = await c.contribute(session, ctx)
+
+        assert result.values.get("mesh", {}).get("enabled") is True
+        assert result.values["mesh"]["transport"] == "nng"
+
+
+# ---------------------------------------------------------------------------
+# Config generation
+# ---------------------------------------------------------------------------
+
+
+class TestConfigGeneration:
+    async def test_ravn_config_inline_has_persona(self, session, flock_template):
+        provider = MagicMock()
+        provider.get.return_value = flock_template
+        c = RavnFlockContributor(template_provider=provider)
+        ctx = SessionContext(template_name="ravn-flock")
+        result = await c.contribute(session, ctx)
+
+        for ctr in result.pod_spec.extra_containers:
+            env = {e["name"]: e["value"] for e in ctr["env"]}
+            assert "RAVN_PEER_ID" in env
+            assert env["RAVN_PEER_ID"].startswith("flock-")
+
+            inline_cfg = env.get("RAVN_CONFIG_INLINE", "")
+            persona = env["RAVN_PERSONA"]
+            assert persona in inline_cfg
+
+    async def test_ravn_config_has_mesh_section(self, session, flock_template):
+        provider = MagicMock()
+        provider.get.return_value = flock_template
+        c = RavnFlockContributor(template_provider=provider)
+        ctx = SessionContext(template_name="ravn-flock")
+        result = await c.contribute(session, ctx)
+
+        for ctr in result.pod_spec.extra_containers:
+            env = {e["name"]: e["value"] for e in ctr["env"]}
+            inline_cfg = env.get("RAVN_CONFIG_INLINE", "")
+            assert "mesh:" in inline_cfg
+            assert "enabled: true" in inline_cfg
+
+    async def test_ravn_config_has_mimir_composite(self, session, flock_template):
+        provider = MagicMock()
+        provider.get.return_value = flock_template
+        c = RavnFlockContributor(template_provider=provider)
+        ctx = SessionContext(template_name="ravn-flock")
+        result = await c.contribute(session, ctx)
+
+        for ctr in result.pod_spec.extra_containers:
+            env = {e["name"]: e["value"] for e in ctr["env"]}
+            inline_cfg = env.get("RAVN_CONFIG_INLINE", "")
+            assert "composite" in inline_cfg
+            assert "/mimir/local" in inline_cfg
+
+    async def test_ravn_config_sleipnir_webhook(self, session, flock_template):
+        provider = MagicMock()
+        provider.get.return_value = flock_template
+        c = RavnFlockContributor(template_provider=provider)
+        ctx = SessionContext(template_name="ravn-flock")
+        result = await c.contribute(session, ctx)
+
+        for ctr in result.pod_spec.extra_containers:
+            env = {e["name"]: e["value"] for e in ctr["env"]}
+            inline_cfg = env.get("RAVN_CONFIG_INLINE", "")
+            assert "sleipnir:" in inline_cfg
+            assert "webhook" in inline_cfg
+
+
+# ---------------------------------------------------------------------------
+# NNG port allocation
+# ---------------------------------------------------------------------------
+
+
+class TestNngPortAllocation:
+    async def test_ravn_containers_have_nng_ports(self, session, flock_template):
+        provider = MagicMock()
+        provider.get.return_value = flock_template
+        c = RavnFlockContributor(template_provider=provider)
+        ctx = SessionContext(template_name="ravn-flock")
+        result = await c.contribute(session, ctx)
+
+        for ctr in result.pod_spec.extra_containers:
+            port_nums = {p["containerPort"] for p in ctr["ports"]}
+            # Each ravn container must have pub, rep, hs, gw ports
+            assert len(port_nums) == 4
+
+    async def test_skuld_and_ravn_ports_do_not_collide(self, session, flock_template):
+        provider = MagicMock()
+        provider.get.return_value = flock_template
+        c = RavnFlockContributor(template_provider=provider)
+        ctx = SessionContext(template_name="ravn-flock")
+        result = await c.contribute(session, ctx)
+
+        all_ports: list[int] = []
+        # Skuld ports from env
+        skuld_env = {e["name"]: e["value"] for e in result.pod_spec.env}
+        for key in ("MESH_PUB_ADDRESS", "MESH_REP_ADDRESS"):
+            addr = skuld_env.get(key, "")
+            port = int(addr.rsplit(":", 1)[-1])
+            all_ports.append(port)
+
+        # Ravn container ports
+        for ctr in result.pod_spec.extra_containers:
+            for p in ctr["ports"]:
+                all_ports.append(p["containerPort"])
+
+        assert len(all_ports) == len(set(all_ports)), "Port collision detected"
+
+
+# ---------------------------------------------------------------------------
+# Integration: contributor pipeline merge
+# ---------------------------------------------------------------------------
+
+
+class TestContributorPipelineMerge:
+    async def test_merge_with_core_contributor(self, session, flock_template):
+        template_provider = MagicMock()
+        template_provider.get.return_value = flock_template
+
+        core = CoreSessionContributor(base_domain="example.com")
+        flock = RavnFlockContributor(template_provider=template_provider)
+
+        ctx = SessionContext(template_name="ravn-flock")
+        contributions = [
+            await core.contribute(session, ctx),
+            await flock.contribute(session, ctx),
+        ]
+
+        spec = SessionSpec.merge(contributions)
+
+        # Core values present
+        assert "session" in spec.values
+        assert spec.values["session"]["name"] == "test-flock"
+
+        # Flock values present
+        assert "mesh" in spec.values
+        assert spec.values["mesh"]["enabled"] is True
+
+        # Ravn containers in pod spec
+        assert len(spec.pod_spec.extra_containers) == 2
+
+        # Mimir volume present
+        volume_names = [v["name"] for v in spec.pod_spec.volumes]
+        assert "mimir-local" in volume_names
+
+    async def test_merge_preserves_skuld_env(self, session, flock_template):
+        template_provider = MagicMock()
+        template_provider.get.return_value = flock_template
+
+        core = CoreSessionContributor(base_domain="example.com")
+        flock = RavnFlockContributor(template_provider=template_provider)
+
+        ctx = SessionContext(template_name="ravn-flock")
+        contributions = [
+            await core.contribute(session, ctx),
+            await flock.contribute(session, ctx),
+        ]
+        spec = SessionSpec.merge(contributions)
+
+        env_names = {e["name"] for e in spec.pod_spec.env}
+        assert "MESH_ENABLED" in env_names
+        assert "MESH_PEER_ID" in env_names
+
+    async def test_non_flock_session_no_ravn_containers(self, session, session_template):
+        template_provider = MagicMock()
+        template_provider.get.return_value = session_template
+
+        core = CoreSessionContributor(base_domain="example.com")
+        flock = RavnFlockContributor(template_provider=template_provider)
+
+        ctx = SessionContext(template_name="default")
+        contributions = [
+            await core.contribute(session, ctx),
+            await flock.contribute(session, ctx),
+        ]
+        spec = SessionSpec.merge(contributions)
+
+        assert spec.pod_spec.extra_containers == ()
+
+
+# ---------------------------------------------------------------------------
+# Profile provider path
+# ---------------------------------------------------------------------------
+
+
+class TestProfileProviderPath:
+    async def test_profile_provider_resolves_flock(self, session, flock_profile):
+        profile_provider = MagicMock()
+        profile_provider.get.return_value = flock_profile
+        c = RavnFlockContributor(profile_provider=profile_provider)
+        ctx = SessionContext(profile_name="ravn-flock")
+        result = await c.contribute(session, ctx)
+
+        assert result.pod_spec is not None
+        assert len(result.pod_spec.extra_containers) == 2
+
+    async def test_default_profile_fallback(self, session, flock_profile):
+        profile_provider = MagicMock()
+        profile_provider.get.return_value = None
+        profile_provider.get_default.return_value = flock_profile
+        c = RavnFlockContributor(profile_provider=profile_provider)
+        ctx = SessionContext(profile_name="nonexistent")
+        result = await c.contribute(session, ctx)
+
+        assert result.pod_spec is not None
+        assert len(result.pod_spec.extra_containers) == 2
+
+    async def test_template_takes_precedence_over_profile(self, session, flock_template, session_template):
+        template_provider = MagicMock()
+        template_provider.get.return_value = session_template
+        profile_provider = MagicMock()
+        profile_provider.get.return_value = MagicMock(workload_type="ravn_flock")
+
+        c = RavnFlockContributor(
+            template_provider=template_provider,
+            profile_provider=profile_provider,
+        )
+        ctx = SessionContext(template_name="default", profile_name="ravn-flock")
+        result = await c.contribute(session, ctx)
+
+        # Template has workload_type='session' — should no-op
+        assert result.values == {}
+        assert result.pod_spec is None
+
+
+# ---------------------------------------------------------------------------
+# Extra kwargs ignored
+# ---------------------------------------------------------------------------
+
+
+class TestExtraKwargs:
+    def test_extra_kwargs_ignored(self):
+        c = RavnFlockContributor(
+            template_provider=None,
+            profile_provider=None,
+            storage=None,
+            gateway=None,
+            unknown_kwarg="ignored",
+        )
+        assert c.name == "ravn_flock"


### PR DESCRIPTION
## Summary

- **New `RavnFlockContributor`** (`src/volundr/adapters/outbound/contributors/ravn_flock.py`): session contributor that triggers when `workload_type == "ravn_flock"`. Resolves the profile/template from context (same pattern as `TemplateContributor`), then builds a flock pod spec with:
  - Skuld mesh env vars (`MESH_ENABLED`, `MESH_PEER_ID`, nng pub/rep/hs addresses, `SLEIPNIR_PUBLISH_URLS`) via `PodSpecAdditions.env`
  - One ravn sidecar container per persona in `workload_config.personas`, each with `RAVN_CONFIG_INLINE` (composite Mimir + Sleipnir webhook YAML), four nng ports, and workspace/mimir volume mounts
  - Mimir `emptyDir` volume for ephemeral local memory at `/mimir/local`
  - Helm values: `mesh.enabled`, `mesh.transport`, `mesh.peerPorts`, `mimir.hostedUrl`, `sleipnir.publishUrls`

- **Port allocation** mirrors `ravn/cli/flock.py`: skuld at index 0, ravn nodes at 1..N (`pub=base+idx*2`, `rep=base+idx*2+1`, `hs=base+100+idx`, `gw=base+200+idx`). No port collisions by construction.

- **`PodSpecAdditions.extra_containers`** — new field (`tuple[dict, ...]`) added to the existing dataclass. `_merge_pod_specs` concatenates this field. Downstream pod managers can render these as K8s sidecar containers.

- **Exported** from `volundr.adapters.outbound.contributors`.

- **36 new tests** covering: port allocation, workload_type routing, contributor output (containers, env vars, volumes, mounts), config generation (mesh/mimir/sleipnir YAML), nng port collision checks, contributor pipeline merge, and profile provider path. Coverage on contributors module: **94%**.

## Test plan

- [x] `pytest tests/test_adapters/test_contributors/test_ravn_flock.py` — 36 passed
- [x] `pytest tests/test_adapters/ tests/test_domain/ tests/test_services/` — 1663 passed, 94% coverage on contributors
- [x] `ruff check` + `ruff format` — clean

## Notes

- Linear ticket NIU-613 could not be updated via MCP (no Linear MCP tools available in this session). Status: **In Progress → In Review**.
- No changes to `SessionService` — `RavnFlockContributor` follows the no-special-casing rule: it no-ops when `workload_type != "ravn_flock"` and is always present in the pipeline via config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)