### PR TITLE
feat(adapters): hosted Mimir write routing for flock pods (NIU-616)

### DIFF
--- a/src/volundr/adapters/outbound/contributors/ravn_flock.py
+++ b/src/volundr/adapters/outbound/contributors/ravn_flock.py
@@ -63,9 +63,27 @@ def _build_ravn_config(
         {"peer_id": f"flock-{p}"} for p in all_personas if p != persona
     ]
 
-    mimir_backends: list[dict[str, Any]] = [{"type": "local", "path": _MIMIR_MOUNT_PATH}]
+    mimir_instances: list[dict[str, Any]] = [
+        {"name": "local", "role": "local", "path": _MIMIR_MOUNT_PATH},
+    ]
+    mimir_write_rules: list[dict[str, Any]] = [
+        {"prefix": "self/", "mounts": ["local"]},
+    ]
     if mimir_hosted_url:
-        mimir_backends.append({"type": "hosted", "url": mimir_hosted_url})
+        mimir_instances.append(
+            {
+                "name": "hosted",
+                "role": "shared",
+                "url": mimir_hosted_url,
+                "categories": ["entity", "decision", "directive", "topic"],
+            }
+        )
+        mimir_write_rules.extend(
+            [
+                {"prefix": "project/", "mounts": ["hosted"]},
+                {"prefix": "entity/", "mounts": ["hosted"]},
+            ]
+        )
 
     config: dict[str, Any] = {
         "persona": persona,
@@ -91,9 +109,13 @@ def _build_ravn_config(
             "enabled": True,
             "max_concurrent_tasks": max_concurrent_tasks,
         },
-        "memory": {
-            "backend": "composite",
-            "composite": {"backends": mimir_backends},
+        "mimir": {
+            "enabled": True,
+            "instances": mimir_instances,
+            "write_routing": {
+                "rules": mimir_write_rules,
+                "default": ["local"],
+            },
         },
         "logging": {"level": "INFO"},
     }

--- a/tests/ravn/integration/test_http_mimir_integration.py
+++ b/tests/ravn/integration/test_http_mimir_integration.py
@@ -1,0 +1,259 @@
+"""Integration tests for HttpMimirAdapter + Mimir HTTP service (NIU-616).
+
+Tests run the FastAPI Mimir router in-process via an ASGI transport — no
+network required.  Covers:
+
+1. Round-trip: write a page via HttpMimirAdapter, read it back.
+2. Round-trip: search returns the written page.
+3. Composite: CompositeMimirAdapter with local (tmp_path) + hosted (ASGI).
+   - upsert_page("project/…") routes to hosted only.
+   - upsert_page("self/…") routes to local only.
+   - Hosted pages survive after local dir is deleted.
+4. Adapter factory: _build_mimir() instantiates HttpMimirAdapter when instance
+   has url, MarkdownMimirAdapter when instance has path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from mimir.adapters.markdown import MarkdownMimirAdapter
+from mimir.router import MimirRouter
+from ravn.adapters.mimir.composite import CompositeMimirAdapter
+from ravn.adapters.mimir.http import HttpMimirAdapter
+from ravn.domain.mimir import MimirMount, WriteRouting
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_HOSTED_BASE = "http://mimir-test"
+
+
+def _make_mimir_app(root: Path) -> FastAPI:
+    """Return a FastAPI app backed by MarkdownMimirAdapter at *root*."""
+    adapter = MarkdownMimirAdapter(root=root)
+    router = MimirRouter(adapter=adapter, name="test-hosted", role="shared")
+    app = FastAPI()
+    app.include_router(router.router, prefix="/mimir")
+    return app
+
+
+def _http_adapter_over_asgi(app: FastAPI) -> HttpMimirAdapter:
+    """Return an HttpMimirAdapter whose HTTP calls go through the ASGI app."""
+    transport = httpx.ASGITransport(app=app)
+    adapter = HttpMimirAdapter(base_url=_HOSTED_BASE)
+    adapter._client = httpx.AsyncClient(transport=transport, base_url=_HOSTED_BASE, timeout=30.0)
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# Integration: round-trip via HttpMimirAdapter + ASGI Mimir service
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_round_trip_upsert_and_read_page(tmp_path: Path) -> None:
+    """Write a page via HttpMimirAdapter, read it back."""
+    app = _make_mimir_app(tmp_path / "hosted")
+    adapter = _http_adapter_over_asgi(app)
+
+    await adapter.upsert_page("technical/test.md", "# Test\nHello world.")
+    content = await adapter.read_page("technical/test.md")
+
+    assert "Hello world" in content
+
+
+@pytest.mark.asyncio
+async def test_round_trip_get_page_returns_metadata(tmp_path: Path) -> None:
+    """get_page returns a MimirPage with correct path and content."""
+    app = _make_mimir_app(tmp_path / "hosted")
+    adapter = _http_adapter_over_asgi(app)
+
+    await adapter.upsert_page("projects/decisions/foo.md", "# Decision\nUse Python.")
+    page = await adapter.get_page("projects/decisions/foo.md")
+
+    assert page.meta.path == "projects/decisions/foo.md"
+    assert "Use Python" in page.content
+
+
+@pytest.mark.asyncio
+async def test_round_trip_read_page_raises_not_found(tmp_path: Path) -> None:
+    """read_page raises FileNotFoundError for a missing page."""
+    app = _make_mimir_app(tmp_path / "hosted")
+    adapter = _http_adapter_over_asgi(app)
+
+    with pytest.raises(FileNotFoundError):
+        await adapter.read_page("missing/page.md")
+
+
+@pytest.mark.asyncio
+async def test_round_trip_list_pages(tmp_path: Path) -> None:
+    """list_pages returns the upserted page."""
+    app = _make_mimir_app(tmp_path / "hosted")
+    adapter = _http_adapter_over_asgi(app)
+
+    await adapter.upsert_page("entity/person/alice.md", "# Alice\nKey person.")
+    pages = await adapter.list_pages()
+
+    paths = [m.path for m in pages]
+    assert "entity/person/alice.md" in paths
+
+
+@pytest.mark.asyncio
+async def test_round_trip_search_returns_page(tmp_path: Path) -> None:
+    """search finds the upserted page by its content."""
+    app = _make_mimir_app(tmp_path / "hosted")
+    adapter = _http_adapter_over_asgi(app)
+
+    await adapter.upsert_page("technical/ravn.md", "# Ravn\nDistributed AI agent.")
+    results = await adapter.search("distributed")
+
+    paths = [p.meta.path for p in results]
+    assert "technical/ravn.md" in paths
+
+
+# ---------------------------------------------------------------------------
+# Integration: CompositeMimirAdapter — local + hosted write routing (NIU-616)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_composite_project_routes_to_hosted(tmp_path: Path) -> None:
+    """upsert_page('project/…') routes only to the hosted mount."""
+    app = _make_mimir_app(tmp_path / "hosted")
+    hosted_adapter = _http_adapter_over_asgi(app)
+    local_adapter = MarkdownMimirAdapter(root=tmp_path / "local")
+
+    routing = WriteRouting(
+        rules=[
+            ("self/", ["local"]),
+            ("project/", ["hosted"]),
+            ("entity/", ["hosted"]),
+        ],
+        default=["local"],
+    )
+    composite = CompositeMimirAdapter(
+        mounts=[
+            MimirMount(name="local", port=local_adapter, role="local", read_priority=0),
+            MimirMount(name="hosted", port=hosted_adapter, role="shared", read_priority=1),
+        ],
+        write_routing=routing,
+    )
+
+    await composite.upsert_page("project/decisions/arch.md", "# Arch\nHexagonal.")
+
+    # Page should be in hosted only
+    hosted_pages = await hosted_adapter.list_pages()
+    hosted_paths = [m.path for m in hosted_pages]
+    assert "project/decisions/arch.md" in hosted_paths
+
+    local_pages = await local_adapter.list_pages()
+    local_paths = [m.path for m in local_pages]
+    assert "project/decisions/arch.md" not in local_paths
+
+
+@pytest.mark.asyncio
+async def test_composite_self_routes_to_local(tmp_path: Path) -> None:
+    """upsert_page('self/…') routes only to the local mount."""
+    app = _make_mimir_app(tmp_path / "hosted")
+    hosted_adapter = _http_adapter_over_asgi(app)
+    local_adapter = MarkdownMimirAdapter(root=tmp_path / "local")
+
+    routing = WriteRouting(
+        rules=[
+            ("self/", ["local"]),
+            ("project/", ["hosted"]),
+        ],
+        default=["local"],
+    )
+    composite = CompositeMimirAdapter(
+        mounts=[
+            MimirMount(name="local", port=local_adapter, role="local", read_priority=0),
+            MimirMount(name="hosted", port=hosted_adapter, role="shared", read_priority=1),
+        ],
+        write_routing=routing,
+    )
+
+    await composite.upsert_page("self/notes/personal.md", "# Notes\nPrivate note.")
+
+    local_pages = await local_adapter.list_pages()
+    local_paths = [m.path for m in local_pages]
+    assert "self/notes/personal.md" in local_paths
+
+    hosted_pages = await hosted_adapter.list_pages()
+    hosted_paths = [m.path for m in hosted_pages]
+    assert "self/notes/personal.md" not in hosted_paths
+
+
+@pytest.mark.asyncio
+async def test_composite_entity_routes_to_hosted(tmp_path: Path) -> None:
+    """upsert_page('entity/…') routes only to the hosted mount."""
+    app = _make_mimir_app(tmp_path / "hosted")
+    hosted_adapter = _http_adapter_over_asgi(app)
+    local_adapter = MarkdownMimirAdapter(root=tmp_path / "local")
+
+    routing = WriteRouting(
+        rules=[
+            ("self/", ["local"]),
+            ("entity/", ["hosted"]),
+        ],
+        default=["local"],
+    )
+    composite = CompositeMimirAdapter(
+        mounts=[
+            MimirMount(name="local", port=local_adapter, role="local", read_priority=0),
+            MimirMount(name="hosted", port=hosted_adapter, role="shared", read_priority=1),
+        ],
+        write_routing=routing,
+    )
+
+    await composite.upsert_page("entity/org/niuu.md", "# Niuu\nAI platform.")
+
+    hosted_pages = await hosted_adapter.list_pages()
+    hosted_paths = [m.path for m in hosted_pages]
+    assert "entity/org/niuu.md" in hosted_paths
+
+    local_pages = await local_adapter.list_pages()
+    local_paths = [m.path for m in local_pages]
+    assert "entity/org/niuu.md" not in local_paths
+
+
+@pytest.mark.asyncio
+async def test_composite_hosted_pages_survive_local_deletion(tmp_path: Path) -> None:
+    """Pages written to hosted remain readable even after the local dir is removed."""
+    hosted_root = tmp_path / "hosted"
+    local_root = tmp_path / "local"
+    app = _make_mimir_app(hosted_root)
+    hosted_adapter = _http_adapter_over_asgi(app)
+    local_adapter = MarkdownMimirAdapter(root=local_root)
+
+    routing = WriteRouting(
+        rules=[
+            ("self/", ["local"]),
+            ("project/", ["hosted"]),
+        ],
+        default=["local"],
+    )
+    composite = CompositeMimirAdapter(
+        mounts=[
+            MimirMount(name="local", port=local_adapter, role="local", read_priority=0),
+            MimirMount(name="hosted", port=hosted_adapter, role="shared", read_priority=1),
+        ],
+        write_routing=routing,
+    )
+
+    await composite.upsert_page("project/core/design.md", "# Design\nHexagonal arch.")
+
+    # Simulate local pod deletion by removing the local dir
+    import shutil
+
+    shutil.rmtree(local_root, ignore_errors=True)
+
+    # Composite read should still find the page via hosted mount
+    content = await composite.read_page("project/core/design.md")
+    assert "Hexagonal" in content

--- a/tests/ravn/unit/test_composition_root.py
+++ b/tests/ravn/unit/test_composition_root.py
@@ -684,3 +684,158 @@ class TestEffectiveModelResolution:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             assert s.effective_max_tokens() == 2048
+
+
+# ---------------------------------------------------------------------------
+# _build_mimir — adapter factory (NIU-616)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMimir:
+    def test_disabled_returns_none(self, settings: Settings) -> None:
+        from ravn.cli.commands import _build_mimir
+
+        settings.mimir.enabled = False
+        result = _build_mimir(settings)
+        assert result is None
+
+    def test_single_local_instance_returns_markdown_adapter(
+        self, settings: Settings, tmp_path: Path
+    ) -> None:
+        from mimir.adapters.markdown import MarkdownMimirAdapter
+        from ravn.cli.commands import _build_mimir
+
+        settings.mimir.enabled = True
+        settings.mimir.instances = []
+        settings.mimir.path = str(tmp_path / "mimir")
+        result = _build_mimir(settings)
+        assert isinstance(result, MarkdownMimirAdapter)
+
+    def test_instance_with_path_returns_markdown_adapter(
+        self, settings: Settings, tmp_path: Path
+    ) -> None:
+        from mimir.adapters.markdown import MarkdownMimirAdapter
+        from ravn.adapters.mimir.composite import CompositeMimirAdapter
+        from ravn.cli.commands import _build_mimir
+        from ravn.config import MimirInstanceConfig
+
+        settings.mimir.enabled = True
+        settings.mimir.instances = [
+            MimirInstanceConfig(
+                name="local",
+                role="local",
+                path=str(tmp_path / "mimir"),
+            )
+        ]
+        result = _build_mimir(settings)
+        assert isinstance(result, CompositeMimirAdapter)
+        # The single mount should be a MarkdownMimirAdapter
+        assert isinstance(result._mounts[0].port, MarkdownMimirAdapter)
+
+    def test_instance_with_url_returns_http_adapter(self, settings: Settings) -> None:
+        from ravn.adapters.mimir.composite import CompositeMimirAdapter
+        from ravn.adapters.mimir.http import HttpMimirAdapter
+        from ravn.cli.commands import _build_mimir
+        from ravn.config import MimirInstanceConfig
+
+        settings.mimir.enabled = True
+        settings.mimir.instances = [
+            MimirInstanceConfig(
+                name="hosted",
+                role="shared",
+                url="https://mimir.niuu.internal",
+            )
+        ]
+        result = _build_mimir(settings)
+        assert isinstance(result, CompositeMimirAdapter)
+        assert isinstance(result._mounts[0].port, HttpMimirAdapter)
+
+    def test_mixed_instances_returns_composite(self, settings: Settings, tmp_path: Path) -> None:
+        from mimir.adapters.markdown import MarkdownMimirAdapter
+        from ravn.adapters.mimir.composite import CompositeMimirAdapter
+        from ravn.adapters.mimir.http import HttpMimirAdapter
+        from ravn.cli.commands import _build_mimir
+        from ravn.config import MimirInstanceConfig
+
+        settings.mimir.enabled = True
+        settings.mimir.instances = [
+            MimirInstanceConfig(
+                name="local",
+                role="local",
+                path=str(tmp_path / "local"),
+            ),
+            MimirInstanceConfig(
+                name="hosted",
+                role="shared",
+                url="https://mimir.niuu.internal",
+            ),
+        ]
+        result = _build_mimir(settings)
+        assert isinstance(result, CompositeMimirAdapter)
+        assert len(result._mounts) == 2
+        port_types = {m.name: type(m.port) for m in result._mounts}
+        assert port_types["local"] is MarkdownMimirAdapter
+        assert port_types["hosted"] is HttpMimirAdapter
+
+    def test_instance_without_path_or_url_skipped(self, settings: Settings, tmp_path: Path) -> None:
+        from mimir.adapters.markdown import MarkdownMimirAdapter
+        from ravn.adapters.mimir.composite import CompositeMimirAdapter
+        from ravn.cli.commands import _build_mimir
+        from ravn.config import MimirInstanceConfig
+
+        settings.mimir.enabled = True
+        settings.mimir.instances = [
+            MimirInstanceConfig(name="bad", role="local"),  # neither path nor url
+            MimirInstanceConfig(
+                name="local",
+                role="local",
+                path=str(tmp_path / "local"),
+            ),
+        ]
+        result = _build_mimir(settings)
+        assert isinstance(result, CompositeMimirAdapter)
+        assert len(result._mounts) == 1
+        assert isinstance(result._mounts[0].port, MarkdownMimirAdapter)
+
+    def test_all_instances_invalid_returns_none(self, settings: Settings) -> None:
+        from ravn.cli.commands import _build_mimir
+        from ravn.config import MimirInstanceConfig
+
+        settings.mimir.enabled = True
+        settings.mimir.instances = [
+            MimirInstanceConfig(name="bad", role="local"),  # neither path nor url
+        ]
+        result = _build_mimir(settings)
+        assert result is None
+
+    def test_write_routing_applied_to_composite(self, settings: Settings, tmp_path: Path) -> None:
+        from ravn.adapters.mimir.composite import CompositeMimirAdapter
+        from ravn.cli.commands import _build_mimir
+        from ravn.config import MimirInstanceConfig, MimirWriteRoutingConfig
+
+        settings.mimir.enabled = True
+        settings.mimir.instances = [
+            MimirInstanceConfig(
+                name="local",
+                role="local",
+                path=str(tmp_path / "local"),
+            ),
+            MimirInstanceConfig(
+                name="hosted",
+                role="shared",
+                url="https://mimir.niuu.internal",
+            ),
+        ]
+        settings.mimir.write_routing = MimirWriteRoutingConfig(
+            rules=[
+                {"prefix": "self/", "mounts": ["local"]},
+                {"prefix": "project/", "mounts": ["hosted"]},
+            ],
+            default=["local"],
+        )
+        result = _build_mimir(settings)
+        assert isinstance(result, CompositeMimirAdapter)
+        # Routing: self/ → local, project/ → hosted, default → local
+        assert result._write_routing.resolve("self/notes.md") == ["local"]
+        assert result._write_routing.resolve("project/arch.md") == ["hosted"]
+        assert result._write_routing.resolve("other/page.md") == ["local"]

--- a/tests/test_adapters/test_contributors/test_ravn_flock.py
+++ b/tests/test_adapters/test_contributors/test_ravn_flock.py
@@ -287,7 +287,9 @@ class TestContributorOutput:
         ctx = SessionContext(template_name="ravn-flock")
         result = await c.contribute(session, ctx)
 
-        assert result.values.get("mimir", {}).get("hostedUrl") == "https://mimir.niuu.internal/api/v1"
+        assert (
+            result.values.get("mimir", {}).get("hostedUrl") == "https://mimir.niuu.internal/api/v1"
+        )
 
     async def test_mesh_values_present(self, session, flock_template):
         provider = MagicMock()
@@ -335,7 +337,7 @@ class TestConfigGeneration:
             assert "mesh:" in inline_cfg
             assert "enabled: true" in inline_cfg
 
-    async def test_ravn_config_has_mimir_composite(self, session, flock_template):
+    async def test_ravn_config_has_mimir_instances(self, session, flock_template):
         provider = MagicMock()
         provider.get.return_value = flock_template
         c = RavnFlockContributor(template_provider=provider)
@@ -345,8 +347,55 @@ class TestConfigGeneration:
         for ctr in result.pod_spec.extra_containers:
             env = {e["name"]: e["value"] for e in ctr["env"]}
             inline_cfg = env.get("RAVN_CONFIG_INLINE", "")
-            assert "composite" in inline_cfg
+            assert "mimir:" in inline_cfg
+            assert "instances:" in inline_cfg
             assert "/mimir/local" in inline_cfg
+
+    async def test_ravn_config_has_write_routing(self, session, flock_template):
+        provider = MagicMock()
+        provider.get.return_value = flock_template
+        c = RavnFlockContributor(template_provider=provider)
+        ctx = SessionContext(template_name="ravn-flock")
+        result = await c.contribute(session, ctx)
+
+        for ctr in result.pod_spec.extra_containers:
+            env = {e["name"]: e["value"] for e in ctr["env"]}
+            inline_cfg = env.get("RAVN_CONFIG_INLINE", "")
+            assert "write_routing:" in inline_cfg
+            # self/ always routes to local
+            assert "self/" in inline_cfg
+
+    async def test_ravn_config_hosted_url_in_instances(self, session, flock_template):
+        provider = MagicMock()
+        provider.get.return_value = flock_template
+        c = RavnFlockContributor(template_provider=provider)
+        ctx = SessionContext(template_name="ravn-flock")
+        result = await c.contribute(session, ctx)
+
+        for ctr in result.pod_spec.extra_containers:
+            env = {e["name"]: e["value"] for e in ctr["env"]}
+            inline_cfg = env.get("RAVN_CONFIG_INLINE", "")
+            # Hosted URL from flock_template is present as a mimir instance
+            assert "https://mimir.niuu.internal/api/v1" in inline_cfg
+            # Hosted instance routes project/ and entity/ pages
+            assert "project/" in inline_cfg
+            assert "entity/" in inline_cfg
+
+    async def test_ravn_config_no_hosted_url_only_local(self, session, flock_profile):
+        """When no hosted URL configured, config only has local mimir instance."""
+        provider = MagicMock()
+        provider.get.return_value = flock_profile  # flock_profile has mimir: {}
+        c = RavnFlockContributor(profile_provider=provider)
+        ctx = SessionContext(profile_name="ravn-flock")
+        result = await c.contribute(session, ctx)
+
+        for ctr in result.pod_spec.extra_containers:
+            env = {e["name"]: e["value"] for e in ctr["env"]}
+            inline_cfg = env.get("RAVN_CONFIG_INLINE", "")
+            assert "/mimir/local" in inline_cfg
+            # No hosted instance — project/ and entity/ prefixes absent
+            assert "project/" not in inline_cfg
+            assert "entity/" not in inline_cfg
 
     async def test_ravn_config_sleipnir_webhook(self, session, flock_template):
         provider = MagicMock()


### PR DESCRIPTION
## Summary

- Updates `RavnFlockContributor._build_ravn_config()` to generate the `mimir.instances` + `write_routing` config schema instead of the legacy `memory.composite.backends` format
- Flock pods now declare two Mimir instances when a hosted URL is configured: `local` (MarkdownMimirAdapter on ephemeral emptyDir) and `hosted` (HttpMimirAdapter at the configured URL)
- Write routing: `self/*` → local only; `project/*` and `entity/*` → hosted only; all other paths default to local

## New tests

- **Integration: HttpMimirAdapter round-trip** — upsert/read/search pages via an in-process ASGI transport (no network required)
- **Integration: composite write routing** — verifies `project/*` routes to hosted only, `self/*` routes to local only, hosted pages survive local dir deletion
- **Unit: `_build_mimir()` adapter factory** — verifies path → `MarkdownMimirAdapter`, url → `HttpMimirAdapter`, mixed instances, invalid instances skipped, write routing applied

## Notes

Linear ticket NIU-616 could not be updated via MCP (Linear MCP tools not available in this environment). Please update manually to "In Review".

## Test plan

- [x] `tests/test_adapters/test_contributors/test_ravn_flock.py` — 39 tests pass
- [x] `tests/ravn/integration/test_http_mimir_integration.py` — 9 new integration tests pass
- [x] `tests/ravn/unit/test_composition_root.py::TestBuildMimir` — 8 new factory tests pass
- [x] `tests/ravn/unit/test_http_mimir.py` — existing tests unaffected
- [x] `tests/ravn/unit/test_composite_mimir.py` — existing tests unaffected
- [x] ruff check + ruff format — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)