### PR TITLE
feat(adapters): NIU-619 — review-arbiter and decomposer ravn personas replace imperative logic

### DIFF
--- a/src/ravn/personas/decomposer.yaml
+++ b/src/ravn/personas/decomposer.yaml
@@ -1,0 +1,67 @@
+name: decomposer
+system_prompt_template: |
+  You are a saga decomposer for the Niuu platform. Your job is to read a
+  feature specification and decompose it into phases and raids that a
+  raiding party can execute autonomously.
+
+  ## Before you decompose
+
+  1. Read the codebase first — use glob and file_read to understand the
+     existing structure, patterns, and conventions.
+  2. Query Mimir for prior decisions and patterns in this repository.
+  3. Only then produce the decomposition, informed by what you found.
+
+  ## Decomposition rules
+
+  - Each raid must be completable in a single Völundr session (2–8 hours).
+  - Raids over 8 hours MUST be split into smaller raids.
+  - `declared_files` MUST be non-empty — specify which files each raid touches.
+  - `acceptance_criteria` MUST have at least one item per raid.
+  - Phases run sequentially. Within a phase, raids can run in parallel.
+  - Order phases: foundations first, features next, polish last.
+  - Self-score `confidence` for each raid:
+    - 1.0 = highly specific, well-bounded, clear acceptance criteria
+    - 0.5 = moderate clarity, some ambiguity remains
+    - 0.0 = vague, risky, or poorly scoped
+
+  ## Output format
+
+  Your outcome block must encode the full SagaStructure as JSON in the
+  `phases` field. Use this exact schema:
+
+  ```json
+  {
+    "name": "<saga name>",
+    "phases": [
+      {
+        "name": "<phase name>",
+        "raids": [
+          {
+            "name": "<raid name>",
+            "description": "<what this raid accomplishes>",
+            "acceptance_criteria": ["<criterion 1>"],
+            "declared_files": ["<file path 1>"],
+            "estimate_hours": 3.0,
+            "confidence": 0.85
+          }
+        ]
+      }
+    ]
+  }
+  ```
+
+  Encode the entire structure as a JSON string in the `phases` outcome field.
+
+produces:
+  schema:
+    phases:
+      type: string
+      description: JSON-encoded SagaStructure with name and phases array
+
+allowed_tools: [file_read, glob, grep, mimir_query, mimir_search]
+
+iteration_budget: 20
+
+permission_mode: read_only
+
+stop_on_outcome: true

--- a/src/ravn/personas/review-arbiter.yaml
+++ b/src/ravn/personas/review-arbiter.yaml
@@ -41,10 +41,6 @@ produces:
     reason:
       type: string
       description: one-line explanation of the verdict
-    confidence_adjustment:
-      type: number
-      description: suggested confidence delta (-0.3 to +0.3, 0.0 means no change)
-      required: false
 
 allowed_tools: [mimir_query, file_read, glob, grep]
 

--- a/src/ravn/personas/review-arbiter.yaml
+++ b/src/ravn/personas/review-arbiter.yaml
@@ -1,0 +1,55 @@
+name: review-arbiter
+system_prompt_template: |
+  You are Tyr's review arbiter. Given a raid's acceptance criteria, PR diff,
+  CI status, and confidence signals, decide: approve, retry, or escalate.
+
+  Consider nuance that binary rules cannot capture:
+  - Scope breach on test helpers, fixture files, or auto-generated files is
+    acceptable. Scope breach on core business logic, models, or APIs is not.
+  - CI failures with "flake" indicators (intermittent timeouts, rate limits,
+    resource exhaustion) deserve retry. Real logic failures need fixes.
+  - A retry is warranted when the confidence is low but fixable with one more
+    attempt. Escalate when the underlying issue requires human judgment.
+  - High confidence with passing CI and a mergeable PR → approve.
+
+  ## Confidence interpretation
+
+  | Range       | Meaning                                        |
+  |-------------|------------------------------------------------|
+  | >= 0.80     | Auto-approve if CI passes and PR is mergeable  |
+  | 0.60–0.79   | Retry if retries remain, escalate otherwise    |
+  | < 0.60      | Escalate — confidence too low to auto-decide   |
+
+  ## Verdict meanings
+
+  - **approve**: Raid is ready to merge. CI passes, no blocking issues.
+  - **retry**: Raid has fixable issues. Send back for another attempt.
+  - **escalate**: Raid needs human judgment. Issues are ambiguous or blocking.
+
+  ## Your task
+
+  Read the context carefully. Weigh the signals. Produce a verdict with a
+  clear, concise reason so that Tyr can act on it.
+
+produces:
+  event_type: "tyr.review.decided"
+  schema:
+    verdict:
+      type: enum
+      enum_values: [approve, retry, escalate]
+      description: review decision
+    reason:
+      type: string
+      description: one-line explanation of the verdict
+    confidence_adjustment:
+      type: number
+      description: suggested confidence delta (-0.3 to +0.3, 0.0 means no change)
+      required: false
+
+allowed_tools: [mimir_query, file_read, glob, grep]
+
+iteration_budget: 5
+
+permission_mode: read_only
+
+stop_on_outcome: true

--- a/src/tyr/adapters/anthropic_client.py
+++ b/src/tyr/adapters/anthropic_client.py
@@ -1,0 +1,61 @@
+"""Shared Anthropic-compatible Messages API call helper.
+
+Used by BifrostAdapter and RavnDispatcher to avoid duplicating HTTP
+infrastructure for the same /v1/messages endpoint.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import httpx
+
+ANTHROPIC_API_VERSION = "2023-06-01"
+
+
+async def anthropic_messages_call(
+    client: httpx.AsyncClient,
+    *,
+    base_url: str,
+    api_key: str,
+    model: str,
+    max_tokens: int,
+    messages: list[dict[str, Any]],
+    system: str | None = None,
+) -> tuple[str, dict[str, Any]]:
+    """POST to the Anthropic-compatible /v1/messages endpoint.
+
+    Returns a ``(text, usage)`` tuple where *usage* contains
+    ``input_tokens``, ``output_tokens``, and ``latency_ms``.
+    """
+    headers: dict[str, str] = {
+        "anthropic-version": ANTHROPIC_API_VERSION,
+        "content-type": "application/json",
+    }
+    if api_key:
+        headers["x-api-key"] = api_key
+
+    payload: dict[str, Any] = {
+        "model": model,
+        "max_tokens": max_tokens,
+        "messages": messages,
+    }
+    if system:
+        payload["system"] = system
+
+    t0 = time.monotonic()
+    resp = await client.post(f"{base_url}/v1/messages", headers=headers, json=payload)
+    latency_ms = (time.monotonic() - t0) * 1000
+    resp.raise_for_status()
+
+    data = resp.json()
+    content_blocks = data.get("content", [])
+    text_parts = [b["text"] for b in content_blocks if b.get("type") == "text"]
+    raw_usage = data.get("usage", {})
+    usage: dict[str, Any] = {
+        "input_tokens": int(raw_usage.get("input_tokens", 0)),
+        "output_tokens": int(raw_usage.get("output_tokens", 0)),
+        "latency_ms": latency_ms,
+    }
+    return "".join(text_parts), usage

--- a/src/tyr/adapters/bifrost.py
+++ b/src/tyr/adapters/bifrost.py
@@ -8,19 +8,17 @@ from __future__ import annotations
 
 import json
 import logging
-import time
 
 import httpx
 
+from tyr.adapters.anthropic_client import anthropic_messages_call
 from tyr.adapters.bifrost_publisher import BifrostPublisher
+from tyr.adapters.ravn_dispatcher import RavnDispatcher
 from tyr.domain.models import SagaStructure
-from tyr.domain.services.ravn_dispatcher import RavnDispatcher
 from tyr.domain.validation import ValidationError, parse_and_validate
 from tyr.ports.llm import LLMPort
 
 logger = logging.getLogger(__name__)
-
-ANTHROPIC_API_VERSION = "2023-06-01"
 
 DECOMPOSITION_PROMPT = """\
 You are a saga decomposition engine for the Niuu platform.
@@ -145,15 +143,6 @@ class BifrostAdapter(LLMPort):
         """Inject the Sleipnir publisher.  Called from main.py after wiring."""
         self._publisher = publisher
 
-    def _headers(self) -> dict[str, str]:
-        headers: dict[str, str] = {
-            "anthropic-version": ANTHROPIC_API_VERSION,
-            "content-type": "application/json",
-        }
-        if self._api_key:
-            headers["x-api-key"] = self._api_key
-        return headers
-
     async def decompose_spec(self, spec: str, repo: str, *, model: str) -> SagaStructure:
         # Try decomposer ravn persona first when enabled
         if self._ravn_decomposer_enabled and self._ravn is not None:
@@ -252,28 +241,14 @@ class BifrostAdapter(LLMPort):
             A ``(text, usage)`` tuple where *usage* contains ``input_tokens``
             and ``output_tokens`` as reported by the API.
         """
-        t0 = time.monotonic()
-        resp = await self._client.post(
-            f"{self._base_url}/v1/messages",
-            headers=self._headers(),
-            json={
-                "model": model,
-                "max_tokens": self._max_tokens,
-                "messages": [{"role": "user", "content": prompt}],
-            },
+        return await anthropic_messages_call(
+            self._client,
+            base_url=self._base_url,
+            api_key=self._api_key,
+            model=model,
+            max_tokens=self._max_tokens,
+            messages=[{"role": "user", "content": prompt}],
         )
-        latency_ms = (time.monotonic() - t0) * 1000
-        resp.raise_for_status()
-        data = resp.json()
-        content_blocks = data.get("content", [])
-        text_parts = [block["text"] for block in content_blocks if block.get("type") == "text"]
-        raw_usage = data.get("usage", {})
-        usage = {
-            "input_tokens": int(raw_usage.get("input_tokens", 0)),
-            "output_tokens": int(raw_usage.get("output_tokens", 0)),
-            "latency_ms": latency_ms,
-        }
-        return "".join(text_parts), usage
 
     async def close(self) -> None:
         """Close the underlying HTTP clients."""

--- a/src/tyr/adapters/bifrost.py
+++ b/src/tyr/adapters/bifrost.py
@@ -14,6 +14,7 @@ import httpx
 
 from tyr.adapters.bifrost_publisher import BifrostPublisher
 from tyr.domain.models import SagaStructure
+from tyr.domain.services.ravn_dispatcher import RavnDispatcher
 from tyr.domain.validation import ValidationError, parse_and_validate
 from tyr.ports.llm import LLMPort
 
@@ -111,6 +112,8 @@ class BifrostAdapter(LLMPort):
         budget_tokens: int = 0,
         quota_warning_threshold: float = 0.8,
         agent_id: str = "",
+        ravn_decomposer_enabled: bool = False,
+        ravn_decomposer_timeout: float = 120.0,
     ) -> None:
         self._base_url = base_url.rstrip("/")
         self._api_key = api_key
@@ -123,12 +126,20 @@ class BifrostAdapter(LLMPort):
         self._budget_tokens = budget_tokens
         self._quota_warning_threshold = quota_warning_threshold
         self._agent_id = agent_id
+        self._ravn_decomposer_enabled = ravn_decomposer_enabled
         # Runtime state
         self._publisher: BifrostPublisher | None = None
         self._provider_healthy: bool = True
         self._total_tokens: int = 0
         self._quota_warning_emitted: bool = False
         self._quota_exceeded_emitted: bool = False
+        self._ravn: RavnDispatcher | None = None
+        if ravn_decomposer_enabled:
+            self._ravn = RavnDispatcher(
+                base_url=base_url,
+                api_key=api_key,
+                timeout=ravn_decomposer_timeout,
+            )
 
     def set_publisher(self, publisher: BifrostPublisher) -> None:
         """Inject the Sleipnir publisher.  Called from main.py after wiring."""
@@ -144,6 +155,17 @@ class BifrostAdapter(LLMPort):
         return headers
 
     async def decompose_spec(self, spec: str, repo: str, *, model: str) -> SagaStructure:
+        # Try decomposer ravn persona first when enabled
+        if self._ravn_decomposer_enabled and self._ravn is not None:
+            result = await self._try_decomposer_ravn(spec, repo, model=model)
+            if result is not None:
+                return result
+            logger.info("decomposer ravn returned no result — falling back to direct API call")
+
+        return await self._decompose_via_api(spec, repo, model=model)
+
+    async def _decompose_via_api(self, spec: str, repo: str, *, model: str) -> SagaStructure:
+        """Direct Anthropic API decomposition — original imperative path."""
         prompt = self._decomposition_prompt.format(spec=spec, repo=repo)
         last_error: Exception | None = None
 
@@ -181,6 +203,48 @@ class BifrostAdapter(LLMPort):
             f"Failed to decompose spec after {self._max_retries} attempts: {last_error}"
         )
 
+    async def _try_decomposer_ravn(
+        self, spec: str, repo: str, *, model: str
+    ) -> SagaStructure | None:
+        """Dispatch to the decomposer ravn persona and validate the result.
+
+        Returns a :class:`SagaStructure` on success, ``None`` to fall back.
+        """
+        if self._ravn is None:
+            return None
+
+        context = f"Repository: {repo}\n\nSpecification:\n{spec}"
+
+        try:
+            outcome = await self._ravn.dispatch("decomposer", context, model=model)
+        except Exception:
+            logger.warning("decomposer ravn dispatch failed", exc_info=True)
+            return None
+
+        if outcome is None:
+            return None
+
+        phases_raw = outcome.get("phases")
+        if not phases_raw:
+            logger.warning("decomposer ravn outcome missing 'phases' field")
+            return None
+
+        try:
+            result = parse_and_validate(
+                str(phases_raw),
+                min_estimate_hours=self._min_estimate_hours,
+                max_estimate_hours=self._max_estimate_hours,
+            )
+            logger.info(
+                "decomposer ravn produced saga %r with %d phase(s)",
+                result.name,
+                len(result.phases),
+            )
+            return result
+        except (json.JSONDecodeError, ValidationError) as exc:
+            logger.warning("decomposer ravn outcome failed validation: %s", exc)
+            return None
+
     async def _call_api(self, prompt: str, *, model: str) -> tuple[str, dict]:
         """Call the Anthropic-compatible Messages API.
 
@@ -212,8 +276,10 @@ class BifrostAdapter(LLMPort):
         return "".join(text_parts), usage
 
     async def close(self) -> None:
-        """Close the underlying HTTP client."""
+        """Close the underlying HTTP clients."""
         await self._client.aclose()
+        if self._ravn is not None:
+            await self._ravn.close()
 
     # ------------------------------------------------------------------
     # Event emission helpers

--- a/src/tyr/adapters/ravn_dispatcher.py
+++ b/src/tyr/adapters/ravn_dispatcher.py
@@ -16,14 +16,9 @@ import httpx
 
 from niuu.domain.outcome import OutcomeSchema, parse_outcome_block
 from ravn.adapters.personas.loader import PersonaConfig, PersonaLoader
+from tyr.adapters.anthropic_client import anthropic_messages_call
 
 logger = logging.getLogger(__name__)
-
-ANTHROPIC_API_VERSION = "2023-06-01"
-
-
-class DispatchError(Exception):
-    """Raised when the dispatcher cannot produce a valid outcome."""
 
 
 class RavnDispatcher:
@@ -117,10 +112,14 @@ class RavnDispatcher:
         used_model = model or self._model
 
         try:
-            response_text = await self._call_llm(
-                system_prompt=system_prompt,
-                user_message=initiative_context,
+            text, _ = await anthropic_messages_call(
+                self._client,
+                base_url=self._base_url,
+                api_key=self._api_key,
                 model=used_model,
+                max_tokens=self._max_tokens,
+                messages=[{"role": "user", "content": initiative_context}],
+                system=system_prompt or None,
             )
         except Exception:
             logger.warning(
@@ -130,7 +129,7 @@ class RavnDispatcher:
             )
             return None
 
-        outcome = parse_outcome_block(response_text, schema=schema)
+        outcome = parse_outcome_block(text, schema=schema)
         if outcome is None:
             logger.warning(
                 "RavnDispatcher: no ---outcome--- block in response for persona %r",
@@ -147,41 +146,3 @@ class RavnDispatcher:
             return None
 
         return outcome.fields
-
-    async def _call_llm(
-        self,
-        *,
-        system_prompt: str,
-        user_message: str,
-        model: str,
-    ) -> str:
-        """Make a single Anthropic-compatible Messages API call.
-
-        Returns the text content of the response.
-        """
-        headers: dict[str, str] = {
-            "anthropic-version": ANTHROPIC_API_VERSION,
-            "content-type": "application/json",
-        }
-        if self._api_key:
-            headers["x-api-key"] = self._api_key
-
-        payload: dict[str, Any] = {
-            "model": model,
-            "max_tokens": self._max_tokens,
-            "messages": [{"role": "user", "content": user_message}],
-        }
-        if system_prompt:
-            payload["system"] = system_prompt
-
-        resp = await self._client.post(
-            f"{self._base_url}/v1/messages",
-            headers=headers,
-            json=payload,
-        )
-        resp.raise_for_status()
-
-        data = resp.json()
-        content_blocks = data.get("content", [])
-        text_parts = [b["text"] for b in content_blocks if b.get("type") == "text"]
-        return "".join(text_parts)

--- a/src/tyr/config.py
+++ b/src/tyr/config.py
@@ -147,6 +147,21 @@ class ReviewConfig(BaseModel):
         ge=6,
         description="Maximum review rounds before escalating. Minimum 6.",
     )
+    ravn_arbiter_enabled: bool = Field(
+        default=False,
+        description=(
+            "When True, ReviewEngine dispatches to the review-arbiter ravn persona "
+            "before falling back to imperative signal-based decisions."
+        ),
+    )
+    ravn_arbiter_model: str = Field(
+        default="claude-sonnet-4-6",
+        description="AI model used by the review-arbiter ravn persona.",
+    )
+    ravn_arbiter_timeout: float = Field(
+        default=60.0,
+        description="HTTP timeout in seconds for review-arbiter ravn dispatch calls.",
+    )
     reviewer_system_prompt: str = Field(
         default=(
             "You are a senior code reviewer for the Niuu platform. You do not just check\n"
@@ -559,6 +574,17 @@ class LLMConfig(BaseModel):
             "Optional identifier for the agent/saga making LLM calls. "
             "Used as correlation_id in Sleipnir events."
         ),
+    )
+    ravn_decomposer_enabled: bool = Field(
+        default=False,
+        description=(
+            "When True, BifrostAdapter dispatches to the decomposer ravn persona "
+            "before falling back to the direct Anthropic API call."
+        ),
+    )
+    ravn_decomposer_timeout: float = Field(
+        default=120.0,
+        description="HTTP timeout in seconds for decomposer ravn dispatch calls.",
     )
 
 

--- a/src/tyr/domain/services/ravn_dispatcher.py
+++ b/src/tyr/domain/services/ravn_dispatcher.py
@@ -1,0 +1,187 @@
+"""Thin in-process ravn dispatcher for single-turn agent calls.
+
+Runs a single LLM turn with a persona's system prompt and parses the
+``---outcome---`` block from the response.  No DriveLoop, no mesh, no
+discovery — just a persona, an initiative context, and one turn.
+
+Used by ReviewEngine (review-arbiter) and BifrostAdapter (decomposer).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from niuu.domain.outcome import OutcomeSchema, parse_outcome_block
+from ravn.adapters.personas.loader import PersonaConfig, PersonaLoader
+
+logger = logging.getLogger(__name__)
+
+ANTHROPIC_API_VERSION = "2023-06-01"
+
+
+class DispatchError(Exception):
+    """Raised when the dispatcher cannot produce a valid outcome."""
+
+
+class RavnDispatcher:
+    """Single-turn in-process ravn dispatcher.
+
+    Loads a persona by name, builds a prompt from the persona's system
+    prompt template plus the supplied initiative context, makes one
+    Anthropic-compatible API call, and returns the parsed outcome fields.
+
+    Parameters
+    ----------
+    base_url:
+        Anthropic-compatible endpoint (default: ``https://api.anthropic.com``).
+    api_key:
+        API key forwarded as ``x-api-key``.
+    model:
+        Default model; callers may override per-dispatch.
+    timeout:
+        HTTP timeout in seconds.
+    max_tokens:
+        Maximum tokens for the LLM response.
+    persona_loader:
+        Loader used to resolve persona configs.  When ``None`` the default
+        :class:`~ravn.adapters.personas.loader.PersonaLoader` is used.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str = "https://api.anthropic.com",
+        api_key: str = "",
+        model: str = "claude-sonnet-4-6",
+        timeout: float = 60.0,
+        max_tokens: int = 4096,
+        persona_loader: PersonaLoader | None = None,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._api_key = api_key
+        self._model = model
+        self._max_tokens = max_tokens
+        self._client = httpx.AsyncClient(timeout=timeout)
+        self._loader = persona_loader or PersonaLoader()
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client."""
+        await self._client.aclose()
+
+    def load_persona(self, name: str) -> PersonaConfig | None:
+        """Return a persona config by name, or ``None`` if not found."""
+        return self._loader.load(name)
+
+    async def dispatch(
+        self,
+        persona_name: str,
+        initiative_context: str,
+        *,
+        model: str | None = None,
+    ) -> dict[str, Any] | None:
+        """Run a single LLM turn for the named persona.
+
+        Loads the persona, prepends its system prompt, sends the
+        *initiative_context* as the user message, and parses the
+        ``---outcome---`` block from the response.
+
+        Parameters
+        ----------
+        persona_name:
+            Name of the persona to load (e.g. ``"review-arbiter"``).
+        initiative_context:
+            The user-facing context string passed to the agent.
+        model:
+            Override the default model for this dispatch.
+
+        Returns
+        -------
+        dict | None
+            Parsed outcome fields on success.  ``None`` when the persona
+            cannot be loaded, the API call fails, or no outcome block is
+            present.
+        """
+        persona = self._loader.load(persona_name)
+        if persona is None:
+            logger.warning("RavnDispatcher: persona %r not found", persona_name)
+            return None
+
+        schema: OutcomeSchema | None = None
+        if persona.produces.schema:
+            schema = OutcomeSchema(fields=persona.produces.schema)
+
+        system_prompt = persona.system_prompt_template.strip()
+        used_model = model or self._model
+
+        try:
+            response_text = await self._call_llm(
+                system_prompt=system_prompt,
+                user_message=initiative_context,
+                model=used_model,
+            )
+        except Exception:
+            logger.warning(
+                "RavnDispatcher: LLM call failed for persona %r",
+                persona_name,
+                exc_info=True,
+            )
+            return None
+
+        outcome = parse_outcome_block(response_text, schema=schema)
+        if outcome is None:
+            logger.warning(
+                "RavnDispatcher: no ---outcome--- block in response for persona %r",
+                persona_name,
+            )
+            return None
+
+        if not outcome.valid:
+            logger.warning(
+                "RavnDispatcher: invalid outcome for persona %r: %s",
+                persona_name,
+                outcome.errors,
+            )
+            return None
+
+        return outcome.fields
+
+    async def _call_llm(
+        self,
+        *,
+        system_prompt: str,
+        user_message: str,
+        model: str,
+    ) -> str:
+        """Make a single Anthropic-compatible Messages API call.
+
+        Returns the text content of the response.
+        """
+        headers: dict[str, str] = {
+            "anthropic-version": ANTHROPIC_API_VERSION,
+            "content-type": "application/json",
+        }
+        if self._api_key:
+            headers["x-api-key"] = self._api_key
+
+        payload: dict[str, Any] = {
+            "model": model,
+            "max_tokens": self._max_tokens,
+            "messages": [{"role": "user", "content": user_message}],
+        }
+        if system_prompt:
+            payload["system"] = system_prompt
+
+        resp = await self._client.post(
+            f"{self._base_url}/v1/messages",
+            headers=headers,
+            json=payload,
+        )
+        resp.raise_for_status()
+
+        data = resp.json()
+        content_blocks = data.get("content", [])
+        text_parts = [b["text"] for b in content_blocks if b.get("type") == "text"]
+        return "".join(text_parts)

--- a/src/tyr/domain/services/review_engine.py
+++ b/src/tyr/domain/services/review_engine.py
@@ -27,6 +27,7 @@ from datetime import UTC, datetime
 from uuid import UUID, uuid4
 
 from niuu.ports.integrations import IntegrationRepository
+from tyr.adapters.ravn_dispatcher import RavnDispatcher
 from tyr.config import ReviewConfig
 from tyr.domain.models import (
     ConfidenceEvent,
@@ -40,7 +41,6 @@ from tyr.domain.models import (
     validate_transition,
 )
 from tyr.domain.services.dispatch_service import DispatchService
-from tyr.domain.services.ravn_dispatcher import RavnDispatcher
 from tyr.domain.services.reviewer_session import (
     ReviewerSessionService,
     parse_reviewer_response,
@@ -726,6 +726,8 @@ class ReviewEngine:
             ci_label = {True: "passed", False: "failed", None: "unknown"}[pr_status.ci_passed]
             lines.append(f"CI: {ci_label}")
 
+        declared_set = set(raid.declared_files)
+
         lines.append("")
         lines.append("## Declared files")
         for f in raid.declared_files:
@@ -735,12 +737,12 @@ class ReviewEngine:
         lines.append("## Changed files in PR")
         if changed_files:
             for f in changed_files:
-                declared = " [declared]" if f in raid.declared_files else " [undeclared]"
+                declared = " [declared]" if f in declared_set else " [undeclared]"
                 lines.append(f"- {f}{declared}")
         else:
             lines.append("No changed files available.")
 
-        undeclared = [f for f in changed_files if f not in set(raid.declared_files)]
+        undeclared = [f for f in changed_files if f not in declared_set]
         if undeclared:
             ratio = len(undeclared) / len(changed_files) if changed_files else 0.0
             lines.append(f"\nScope breach ratio: {ratio:.1%} undeclared")

--- a/src/tyr/domain/services/review_engine.py
+++ b/src/tyr/domain/services/review_engine.py
@@ -40,6 +40,7 @@ from tyr.domain.models import (
     validate_transition,
 )
 from tyr.domain.services.dispatch_service import DispatchService
+from tyr.domain.services.ravn_dispatcher import RavnDispatcher
 from tyr.domain.services.reviewer_session import (
     ReviewerSessionService,
     parse_reviewer_response,
@@ -135,6 +136,7 @@ class ReviewEngine:
         integration_repo: IntegrationRepository | None = None,
         dispatcher_repo: DispatcherRepository | None = None,
         dispatch_service: DispatchService | None = None,
+        ravn_dispatcher: RavnDispatcher | None = None,
     ) -> None:
         self._tracker_factory = tracker_factory
         self._volundr_factory = volundr_factory
@@ -145,6 +147,7 @@ class ReviewEngine:
         self._integration_repo = integration_repo
         self._dispatcher_repo = dispatcher_repo
         self._dispatch_service = dispatch_service
+        self._ravn = ravn_dispatcher
         self._task: asyncio.Task[None] | None = None
         self._processed: set[str] = set()
         # Maps reviewer_session_id → (raid_tracker_id, owner_id)
@@ -433,7 +436,15 @@ class ReviewEngine:
                 reason="Reviewer session spawned, awaiting completion",
             )
 
-        # No reviewer — decide immediately based on signals
+        # Try review-arbiter ravn for nuanced judgment (falls back to imperative logic)
+        if self._cfg.ravn_arbiter_enabled and self._ravn is not None:
+            arbiter_decision = await self._dispatch_to_arbiter(
+                tracker, tracker_id, owner_id, raid, pr_status, changed_files, score
+            )
+            if arbiter_decision is not None:
+                return arbiter_decision
+
+        # Imperative fallback: decide based on confidence signals
         if pr_status and not pr_status.ci_passed:
             return await self._handle_ci_failure(
                 tracker, tracker_id, owner_id, raid, pr_status, score
@@ -680,6 +691,140 @@ class ReviewEngine:
         await tracker.add_confidence_event(tracker_id, event)
         await self._emit_confidence_updated(raid_id, event)
         return event.score_after
+
+    # -- Review-arbiter ravn dispatch --
+
+    def _assemble_arbiter_context(
+        self,
+        raid: Raid,
+        pr_status: PRStatus | None,
+        changed_files: list[str],
+        score: float,
+    ) -> str:
+        """Assemble the initiative context string for the review-arbiter persona."""
+        lines: list[str] = [
+            f"# Review arbiter context for raid: {raid.name}",
+            f"Tracker ID: {raid.tracker_id}",
+            f"Confidence score (after signals): {score:.3f}",
+            f"Auto-approve threshold: {self._cfg.auto_approve_threshold:.3f}",
+            f"Retry count: {raid.retry_count} / {self._cfg.max_retries}",
+            "",
+            "## Acceptance criteria",
+        ]
+        for criterion in raid.acceptance_criteria:
+            lines.append(f"- {criterion}")
+
+        lines.append("")
+        lines.append("## PR status")
+        if pr_status is None:
+            lines.append("No PR found.")
+        else:
+            lines.append(f"PR ID: {pr_status.pr_id}")
+            lines.append(f"PR URL: {pr_status.url}")
+            lines.append(f"State: {pr_status.state}")
+            lines.append(f"Mergeable: {pr_status.mergeable}")
+            ci_label = {True: "passed", False: "failed", None: "unknown"}[pr_status.ci_passed]
+            lines.append(f"CI: {ci_label}")
+
+        lines.append("")
+        lines.append("## Declared files")
+        for f in raid.declared_files:
+            lines.append(f"- {f}")
+
+        lines.append("")
+        lines.append("## Changed files in PR")
+        if changed_files:
+            for f in changed_files:
+                declared = " [declared]" if f in raid.declared_files else " [undeclared]"
+                lines.append(f"- {f}{declared}")
+        else:
+            lines.append("No changed files available.")
+
+        undeclared = [f for f in changed_files if f not in set(raid.declared_files)]
+        if undeclared:
+            ratio = len(undeclared) / len(changed_files) if changed_files else 0.0
+            lines.append(f"\nScope breach ratio: {ratio:.1%} undeclared")
+
+        lines.append("")
+        lines.append(
+            "Based on the above context, decide: approve, retry, or escalate. "
+            "Produce your outcome block."
+        )
+        return "\n".join(lines)
+
+    async def _dispatch_to_arbiter(
+        self,
+        tracker: TrackerPort,
+        tracker_id: str,
+        owner_id: str,
+        raid: Raid,
+        pr_status: PRStatus | None,
+        changed_files: list[str],
+        score: float,
+    ) -> ReviewDecision | None:
+        """Dispatch to the review-arbiter ravn persona.
+
+        Returns a :class:`ReviewDecision` if the arbiter produced a valid
+        outcome, or ``None`` to fall back to imperative logic.
+        """
+        if self._ravn is None:
+            return None
+
+        context = self._assemble_arbiter_context(raid, pr_status, changed_files, score)
+
+        try:
+            outcome = await self._ravn.dispatch(
+                "review-arbiter",
+                context,
+                model=self._cfg.ravn_arbiter_model,
+            )
+        except Exception:
+            logger.warning(
+                "review-arbiter dispatch failed for raid %s — using imperative fallback",
+                tracker_id,
+                exc_info=True,
+            )
+            return None
+
+        if outcome is None:
+            logger.info(
+                "review-arbiter returned no outcome for raid %s — using imperative fallback",
+                tracker_id,
+            )
+            return None
+
+        verdict = str(outcome.get("verdict", "")).lower()
+        reason = str(outcome.get("reason", "review-arbiter decision"))
+
+        logger.info(
+            "review-arbiter verdict for raid %s: %s (reason=%s)",
+            tracker_id,
+            verdict,
+            reason,
+        )
+
+        match verdict:
+            case "approve":
+                return await self._handle_auto_approve(tracker, tracker_id, owner_id, raid, score)
+            case "retry":
+                if raid.retry_count < self._cfg.max_retries:
+                    return await self._auto_retry(
+                        tracker,
+                        tracker_id,
+                        owner_id,
+                        raid,
+                        reason=f"review-arbiter: {reason}",
+                    )
+                return await self._handle_escalation(tracker, tracker_id, owner_id, raid, score)
+            case "escalate":
+                return await self._handle_escalation(tracker, tracker_id, owner_id, raid, score)
+            case _:
+                logger.warning(
+                    "review-arbiter returned unknown verdict %r for raid %s — imperative fallback",
+                    verdict,
+                    tracker_id,
+                )
+                return None
 
     # -- Reviewer session --
 

--- a/tests/test_tyr/stubs.py
+++ b/tests/test_tyr/stubs.py
@@ -237,6 +237,11 @@ class StubTracker(TrackerPort):
         self._all_merged: bool = False
         self.closed_raids: list[str] = []
 
+    @property
+    def raids(self) -> dict[str, Raid]:
+        """Public alias for _raids_by_id used in tests."""
+        return self._raids_by_id
+
     # -- CRUD: create entities --
 
     async def create_saga(self, saga: Saga, *, description: str = "") -> str:
@@ -398,6 +403,35 @@ class StubTrackerFactory:
 
     async def for_owner(self, owner_id: str) -> list[StubTracker]:
         return [self._tracker]
+
+
+class StubGit:
+    """Minimal in-memory git stub for Tyr unit tests."""
+
+    def __init__(self) -> None:
+        self.pr_statuses: dict[str, PRStatus] = {}
+        self.changed_files: dict[str, list[str]] = {}
+
+    async def create_branch(self, repo: str, branch: str, base: str) -> None:
+        pass
+
+    async def merge_branch(self, repo: str, source: str, target: str) -> None:
+        pass
+
+    async def delete_branch(self, repo: str, branch: str) -> None:
+        pass
+
+    async def create_pr(self, repo: str, source: str, target: str, title: str) -> str:
+        return "pr-1"
+
+    async def get_pr_status(self, pr_id: str) -> PRStatus:
+        pr = self.pr_statuses.get(pr_id)
+        if pr is None:
+            raise RuntimeError(f"No PR: {pr_id}")
+        return pr
+
+    async def get_pr_changed_files(self, pr_id: str) -> list[str]:
+        return self.changed_files.get(pr_id, [])
 
 
 def make_raid(

--- a/tests/test_tyr/test_bifrost.py
+++ b/tests/test_tyr/test_bifrost.py
@@ -17,8 +17,8 @@ from sleipnir.domain.registry import (
     BIFROST_REQUEST_COMPLETE,
 )
 from sleipnir.testing import EventCapture
+from tyr.adapters.anthropic_client import ANTHROPIC_API_VERSION
 from tyr.adapters.bifrost import (
-    ANTHROPIC_API_VERSION,
     DECOMPOSITION_PROMPT,
     BifrostAdapter,
     DecompositionError,

--- a/tests/test_tyr/test_decomposer_ravn.py
+++ b/tests/test_tyr/test_decomposer_ravn.py
@@ -301,7 +301,7 @@ class TestRavnDispatcher:
     @respx.mock
     async def test_dispatch_returns_parsed_outcome(self) -> None:
         """RavnDispatcher.dispatch() returns parsed outcome fields."""
-        from tyr.domain.services.ravn_dispatcher import RavnDispatcher
+        from tyr.adapters.ravn_dispatcher import RavnDispatcher
 
         response_text = (
             "Some reasoning...\n\n---outcome---\nverdict: approve\nreason: all good\n---end---"
@@ -331,7 +331,7 @@ class TestRavnDispatcher:
     @respx.mock
     async def test_dispatch_unknown_persona_returns_none(self) -> None:
         """Dispatching an unknown persona returns None without calling the API."""
-        from tyr.domain.services.ravn_dispatcher import RavnDispatcher
+        from tyr.adapters.ravn_dispatcher import RavnDispatcher
 
         dispatcher = RavnDispatcher(
             base_url="http://dispatch.test",
@@ -348,7 +348,7 @@ class TestRavnDispatcher:
     @respx.mock
     async def test_dispatch_no_outcome_block_returns_none(self) -> None:
         """When LLM response has no ---outcome--- block, dispatch returns None."""
-        from tyr.domain.services.ravn_dispatcher import RavnDispatcher
+        from tyr.adapters.ravn_dispatcher import RavnDispatcher
 
         respx.post("http://dispatch.test/v1/messages").mock(
             return_value=httpx.Response(
@@ -372,7 +372,7 @@ class TestRavnDispatcher:
     @respx.mock
     async def test_dispatch_http_error_returns_none(self) -> None:
         """When the API returns an error, dispatch returns None."""
-        from tyr.domain.services.ravn_dispatcher import RavnDispatcher
+        from tyr.adapters.ravn_dispatcher import RavnDispatcher
 
         respx.post("http://dispatch.test/v1/messages").mock(
             return_value=httpx.Response(500, json={"error": "server error"})
@@ -391,7 +391,7 @@ class TestRavnDispatcher:
 
     def test_load_persona_review_arbiter(self) -> None:
         """RavnDispatcher.load_persona() can resolve 'review-arbiter'."""
-        from tyr.domain.services.ravn_dispatcher import RavnDispatcher
+        from tyr.adapters.ravn_dispatcher import RavnDispatcher
 
         dispatcher = RavnDispatcher()
         persona = dispatcher.load_persona("review-arbiter")
@@ -400,7 +400,7 @@ class TestRavnDispatcher:
 
     def test_load_persona_decomposer(self) -> None:
         """RavnDispatcher.load_persona() can resolve 'decomposer'."""
-        from tyr.domain.services.ravn_dispatcher import RavnDispatcher
+        from tyr.adapters.ravn_dispatcher import RavnDispatcher
 
         dispatcher = RavnDispatcher()
         persona = dispatcher.load_persona("decomposer")

--- a/tests/test_tyr/test_decomposer_ravn.py
+++ b/tests/test_tyr/test_decomposer_ravn.py
@@ -1,0 +1,408 @@
+"""Tests for the decomposer ravn persona and BifrostAdapter decomposer integration.
+
+Test harness from NIU-619 spec:
+  6. Unit: decomposer persona — load YAML, verify schema matches SagaStructure
+  7. Integration: decompose round-trip — mock dispatcher returning canned SagaStructure;
+     BifrostAdapter dispatches to decomposer → validated → returned correctly
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from tyr.adapters.bifrost import BifrostAdapter
+from tyr.domain.models import SagaStructure
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+VALID_SAGA = {
+    "name": "Auth Rework Saga",
+    "phases": [
+        {
+            "name": "Phase 1 — Core",
+            "raids": [
+                {
+                    "name": "Add JWT validation",
+                    "description": "Implement JWT token validation middleware",
+                    "acceptance_criteria": ["tokens validated", "tests pass"],
+                    "declared_files": ["src/auth/jwt.py", "tests/test_jwt.py"],
+                    "estimate_hours": 3.0,
+                    "confidence": 0.85,
+                }
+            ],
+        }
+    ],
+}
+
+VALID_SAGA_JSON = json.dumps(VALID_SAGA)
+
+OUTCOME_BLOCK = f"---outcome---\nphases: '{VALID_SAGA_JSON}'\n---end---"
+
+
+def _make_adapter(
+    *,
+    ravn_decomposer_enabled: bool = False,
+    api_url: str = "http://bifrost.test",
+    ravn_decomposer_timeout: float = 5.0,
+) -> BifrostAdapter:
+    return BifrostAdapter(
+        base_url=api_url,
+        api_key="test-key",
+        ravn_decomposer_enabled=ravn_decomposer_enabled,
+        ravn_decomposer_timeout=ravn_decomposer_timeout,
+    )
+
+
+def _api_response(text: str) -> dict:
+    """Wrap text as Anthropic-style response."""
+    return {
+        "content": [{"type": "text", "text": text}],
+        "usage": {"input_tokens": 100, "output_tokens": 200},
+    }
+
+
+# ---------------------------------------------------------------------------
+# 6. Unit: decomposer persona YAML
+# ---------------------------------------------------------------------------
+
+
+class TestDecomposerPersona:
+    def test_persona_loads(self) -> None:
+        """decomposer.yaml must be loadable by PersonaLoader."""
+        from ravn.adapters.personas.loader import PersonaLoader
+
+        loader = PersonaLoader()
+        persona = loader.load("decomposer")
+        assert persona is not None, "decomposer persona not found"
+
+    def test_persona_name(self) -> None:
+        from ravn.adapters.personas.loader import PersonaLoader
+
+        persona = PersonaLoader().load("decomposer")
+        assert persona is not None
+        assert persona.name == "decomposer"
+
+    def test_persona_has_system_prompt(self) -> None:
+        from ravn.adapters.personas.loader import PersonaLoader
+
+        persona = PersonaLoader().load("decomposer")
+        assert persona is not None
+        assert len(persona.system_prompt_template) > 50
+
+    def test_persona_schema_has_phases_field(self) -> None:
+        """decomposer must declare a 'phases' field in its produces schema."""
+        from ravn.adapters.personas.loader import PersonaLoader
+
+        persona = PersonaLoader().load("decomposer")
+        assert persona is not None
+        assert "phases" in persona.produces.schema
+
+    def test_persona_phases_field_is_string(self) -> None:
+        """'phases' field must be type 'string' (JSON-encoded SagaStructure)."""
+        from ravn.adapters.personas.loader import PersonaLoader
+
+        persona = PersonaLoader().load("decomposer")
+        assert persona is not None
+        phases_field = persona.produces.schema["phases"]
+        assert phases_field.type == "string"
+
+    def test_persona_iteration_budget(self) -> None:
+        from ravn.adapters.personas.loader import PersonaLoader
+
+        persona = PersonaLoader().load("decomposer")
+        assert persona is not None
+        assert persona.iteration_budget == 20
+
+    def test_persona_stop_on_outcome(self) -> None:
+        from ravn.adapters.personas.loader import PersonaLoader
+
+        persona = PersonaLoader().load("decomposer")
+        assert persona is not None
+        assert persona.stop_on_outcome is True
+
+    def test_persona_allowed_tools_include_file_tools(self) -> None:
+        from ravn.adapters.personas.loader import PersonaLoader
+
+        persona = PersonaLoader().load("decomposer")
+        assert persona is not None
+        assert "file_read" in persona.allowed_tools or "glob" in persona.allowed_tools
+
+    def test_persona_allowed_tools_include_mimir(self) -> None:
+        from ravn.adapters.personas.loader import PersonaLoader
+
+        persona = PersonaLoader().load("decomposer")
+        assert persona is not None
+        assert any("mimir" in t for t in persona.allowed_tools)
+
+
+# ---------------------------------------------------------------------------
+# 7. Integration: decompose round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestDecomposerRoundTrip:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_decomposer_ravn_success(self) -> None:
+        """When decomposer ravn returns valid JSON, BifrostAdapter returns SagaStructure."""
+        # Mock the ravn dispatcher LLM call (same endpoint, same api)
+        respx.post("http://bifrost.test/v1/messages").mock(
+            return_value=httpx.Response(
+                200,
+                json=_api_response(OUTCOME_BLOCK),
+            )
+        )
+
+        adapter = _make_adapter(ravn_decomposer_enabled=True, api_url="http://bifrost.test")
+        try:
+            result = await adapter.decompose_spec(
+                spec="Add JWT auth to the platform",
+                repo="org/repo",
+                model="claude-sonnet-4-6",
+            )
+        finally:
+            await adapter.close()
+
+        assert isinstance(result, SagaStructure)
+        assert result.name == "Auth Rework Saga"
+        assert len(result.phases) == 1
+        assert result.phases[0].name == "Phase 1 — Core"
+        assert len(result.phases[0].raids) == 1
+        assert result.phases[0].raids[0].name == "Add JWT validation"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_decomposer_ravn_fallback_on_no_outcome(self) -> None:
+        """When decomposer ravn returns no outcome block, fall back to direct API."""
+        call_count = 0
+
+        def response_handler(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # First call (ravn dispatcher): no outcome block
+                return httpx.Response(200, json=_api_response("I am thinking..."))
+            # Second call (direct API fallback): valid JSON
+            return httpx.Response(200, json=_api_response(VALID_SAGA_JSON))
+
+        respx.post("http://bifrost.test/v1/messages").mock(side_effect=response_handler)
+
+        adapter = _make_adapter(ravn_decomposer_enabled=True, api_url="http://bifrost.test")
+        try:
+            result = await adapter.decompose_spec(
+                spec="Add JWT auth",
+                repo="org/repo",
+                model="claude-sonnet-4-6",
+            )
+        finally:
+            await adapter.close()
+
+        assert isinstance(result, SagaStructure)
+        # Two API calls: one for ravn, one for fallback
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_decomposer_disabled_goes_direct(self) -> None:
+        """When ravn_decomposer_enabled=False, only direct API is called."""
+        call_count = 0
+
+        def response_handler(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            return httpx.Response(200, json=_api_response(VALID_SAGA_JSON))
+
+        respx.post("http://bifrost.test/v1/messages").mock(side_effect=response_handler)
+
+        adapter = _make_adapter(ravn_decomposer_enabled=False, api_url="http://bifrost.test")
+        try:
+            result = await adapter.decompose_spec(
+                spec="Add JWT auth",
+                repo="org/repo",
+                model="claude-sonnet-4-6",
+            )
+        finally:
+            await adapter.close()
+
+        assert isinstance(result, SagaStructure)
+        assert call_count == 1  # Only direct call
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_decomposer_ravn_invalid_json_fallback(self) -> None:
+        """When decomposer ravn outcome has invalid JSON in 'phases', fall back."""
+        bad_outcome = "---outcome---\nphases: 'not valid json {{{'\n---end---"
+        call_count = 0
+
+        def response_handler(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return httpx.Response(200, json=_api_response(bad_outcome))
+            return httpx.Response(200, json=_api_response(VALID_SAGA_JSON))
+
+        respx.post("http://bifrost.test/v1/messages").mock(side_effect=response_handler)
+
+        adapter = _make_adapter(ravn_decomposer_enabled=True, api_url="http://bifrost.test")
+        try:
+            result = await adapter.decompose_spec(
+                spec="Add JWT auth",
+                repo="org/repo",
+                model="claude-sonnet-4-6",
+            )
+        finally:
+            await adapter.close()
+
+        assert isinstance(result, SagaStructure)
+        assert call_count == 2  # ravn failed → fallback
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_decomposer_ravn_context_includes_spec_and_repo(self) -> None:
+        """The context passed to the decomposer ravn must include spec and repo."""
+        captured_bodies: list[dict] = []
+
+        def capture_handler(request: httpx.Request) -> httpx.Response:
+            captured_bodies.append(json.loads(request.content))
+            # Return valid saga JSON directly so we get a result
+            return httpx.Response(200, json=_api_response(OUTCOME_BLOCK))
+
+        respx.post("http://bifrost.test/v1/messages").mock(side_effect=capture_handler)
+
+        adapter = _make_adapter(ravn_decomposer_enabled=True, api_url="http://bifrost.test")
+        try:
+            await adapter.decompose_spec(
+                spec="Implement OAuth2 login flow",
+                repo="org/platform",
+                model="claude-sonnet-4-6",
+            )
+        finally:
+            await adapter.close()
+
+        assert len(captured_bodies) >= 1
+        user_content = captured_bodies[0]["messages"][0]["content"]
+        assert "Implement OAuth2 login flow" in user_content
+        assert "org/platform" in user_content
+
+
+# ---------------------------------------------------------------------------
+# Unit: RavnDispatcher
+# ---------------------------------------------------------------------------
+
+
+class TestRavnDispatcher:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_dispatch_returns_parsed_outcome(self) -> None:
+        """RavnDispatcher.dispatch() returns parsed outcome fields."""
+        from tyr.domain.services.ravn_dispatcher import RavnDispatcher
+
+        response_text = (
+            "Some reasoning...\n\n---outcome---\nverdict: approve\nreason: all good\n---end---"
+        )
+        respx.post("http://dispatch.test/v1/messages").mock(
+            return_value=httpx.Response(
+                200,
+                json={"content": [{"type": "text", "text": response_text}]},
+            )
+        )
+
+        dispatcher = RavnDispatcher(
+            base_url="http://dispatch.test",
+            api_key="test",
+            model="claude-sonnet-4-6",
+        )
+        try:
+            result = await dispatcher.dispatch("review-arbiter", "context here")
+        finally:
+            await dispatcher.close()
+
+        assert result is not None
+        assert result["verdict"] == "approve"
+        assert result["reason"] == "all good"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_dispatch_unknown_persona_returns_none(self) -> None:
+        """Dispatching an unknown persona returns None without calling the API."""
+        from tyr.domain.services.ravn_dispatcher import RavnDispatcher
+
+        dispatcher = RavnDispatcher(
+            base_url="http://dispatch.test",
+            api_key="test",
+        )
+        try:
+            result = await dispatcher.dispatch("nonexistent-persona-xyz", "context")
+        finally:
+            await dispatcher.close()
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_dispatch_no_outcome_block_returns_none(self) -> None:
+        """When LLM response has no ---outcome--- block, dispatch returns None."""
+        from tyr.domain.services.ravn_dispatcher import RavnDispatcher
+
+        respx.post("http://dispatch.test/v1/messages").mock(
+            return_value=httpx.Response(
+                200,
+                json={"content": [{"type": "text", "text": "Just some text, no outcome."}]},
+            )
+        )
+
+        dispatcher = RavnDispatcher(
+            base_url="http://dispatch.test",
+            api_key="test",
+        )
+        try:
+            result = await dispatcher.dispatch("review-arbiter", "context")
+        finally:
+            await dispatcher.close()
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_dispatch_http_error_returns_none(self) -> None:
+        """When the API returns an error, dispatch returns None."""
+        from tyr.domain.services.ravn_dispatcher import RavnDispatcher
+
+        respx.post("http://dispatch.test/v1/messages").mock(
+            return_value=httpx.Response(500, json={"error": "server error"})
+        )
+
+        dispatcher = RavnDispatcher(
+            base_url="http://dispatch.test",
+            api_key="test",
+        )
+        try:
+            result = await dispatcher.dispatch("review-arbiter", "context")
+        finally:
+            await dispatcher.close()
+
+        assert result is None
+
+    def test_load_persona_review_arbiter(self) -> None:
+        """RavnDispatcher.load_persona() can resolve 'review-arbiter'."""
+        from tyr.domain.services.ravn_dispatcher import RavnDispatcher
+
+        dispatcher = RavnDispatcher()
+        persona = dispatcher.load_persona("review-arbiter")
+        assert persona is not None
+        assert persona.name == "review-arbiter"
+
+    def test_load_persona_decomposer(self) -> None:
+        """RavnDispatcher.load_persona() can resolve 'decomposer'."""
+        from tyr.domain.services.ravn_dispatcher import RavnDispatcher
+
+        dispatcher = RavnDispatcher()
+        persona = dispatcher.load_persona("decomposer")
+        assert persona is not None
+        assert persona.name == "decomposer"

--- a/tests/test_tyr/test_ravn_arbiter.py
+++ b/tests/test_tyr/test_ravn_arbiter.py
@@ -11,17 +11,21 @@ Test harness from NIU-619 spec:
 
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator
-from datetime import UTC, datetime
 from typing import Any
 from uuid import uuid4
 
 import pytest
 
+from tests.test_tyr.stubs import (
+    StubGit,
+    StubTracker,
+    StubTrackerFactory,
+    StubVolundrFactory,
+    StubVolundrPort,
+)
 from tyr.adapters.memory_event_bus import InMemoryEventBus
 from tyr.config import ReviewConfig
 from tyr.domain.models import (
-    ConfidenceEvent,
     Phase,
     PhaseStatus,
     PRStatus,
@@ -32,257 +36,16 @@ from tyr.domain.models import (
 )
 from tyr.domain.services.review_engine import ReviewEngine
 
-NOW = datetime.now(UTC)
+NOW = __import__("datetime").datetime.now(__import__("datetime").timezone.utc)
 PHASE_ID = uuid4()
 SAGA_ID = uuid4()
 OWNER_ID = "user-arbiter"
 TRACKER_ID = "NIU-619"
 
+
 # ---------------------------------------------------------------------------
-# Stubs (mirrors test_review_engine.py stubs to avoid import coupling)
+# Stub: RavnDispatcher (genuinely new — not in stubs.py)
 # ---------------------------------------------------------------------------
-
-
-class StubTracker:
-    """Minimal tracker stub for arbiter tests."""
-
-    def __init__(self) -> None:
-        self.raids: dict[str, Raid] = {}
-        self.events: dict[str, list[ConfidenceEvent]] = {}
-        self.saga: Saga | None = None
-        self.phase: Phase | None = None
-        self.phases: list[Phase] = []
-        self._all_merged: bool = False
-        self.phase_status_updates: list[tuple[str, PhaseStatus]] = []
-        self.attached_documents: list[tuple[str, str, str]] = []
-
-    async def create_saga(self, saga, **kwargs):
-        return saga.tracker_id
-
-    async def create_phase(self, phase, **kwargs):
-        return phase.tracker_id
-
-    async def create_raid(self, raid, **kwargs):
-        self.raids[raid.tracker_id] = raid
-        return raid.tracker_id
-
-    async def update_raid_state(self, raid_id, state):
-        pass
-
-    async def close_raid(self, raid_id):
-        pass
-
-    async def attach_issue_document(self, issue_id, title, content):
-        self.attached_documents.append((issue_id, title, content))
-        return "doc-stub"
-
-    async def get_saga(self, saga_id):
-        if self.saga is None:
-            raise ValueError(f"Not found: {saga_id}")
-        return self.saga
-
-    async def get_phase(self, tracker_id):
-        if self.phase is None:
-            raise ValueError(f"Not found: {tracker_id}")
-        return self.phase
-
-    async def get_raid(self, tracker_id):
-        raid = self.raids.get(tracker_id)
-        if raid is None:
-            raise ValueError(f"Raid not found: {tracker_id}")
-        return raid
-
-    async def list_pending_raids(self, phase_id):
-        return []
-
-    async def list_projects(self):
-        return []
-
-    async def get_project(self, project_id):
-        raise NotImplementedError
-
-    async def list_milestones(self, project_id):
-        return []
-
-    async def list_issues(self, project_id, milestone_id=None):
-        return []
-
-    async def update_raid_progress(
-        self,
-        tracker_id,
-        *,
-        status=None,
-        session_id=None,
-        confidence=None,
-        pr_url=None,
-        pr_id=None,
-        retry_count=None,
-        reason=None,
-        owner_id=None,
-        phase_tracker_id=None,
-        saga_tracker_id=None,
-        chronicle_summary=None,
-        reviewer_session_id=None,
-        review_round=None,
-    ):
-        raid = self.raids.get(tracker_id)
-        if raid is None:
-            raise ValueError(f"Raid not found: {tracker_id}")
-        events = self.events.get(tracker_id, [])
-        new_confidence = events[-1].score_after if events else raid.confidence
-        updated = Raid(
-            id=raid.id,
-            phase_id=raid.phase_id,
-            tracker_id=raid.tracker_id,
-            name=raid.name,
-            description=raid.description,
-            acceptance_criteria=raid.acceptance_criteria,
-            declared_files=raid.declared_files,
-            estimate_hours=raid.estimate_hours,
-            status=status if status is not None else raid.status,
-            confidence=confidence if confidence is not None else new_confidence,
-            session_id=session_id if session_id is not None else raid.session_id,
-            branch=raid.branch,
-            chronicle_summary=raid.chronicle_summary,
-            pr_url=pr_url if pr_url is not None else raid.pr_url,
-            pr_id=pr_id if pr_id is not None else raid.pr_id,
-            retry_count=retry_count if retry_count is not None else raid.retry_count,
-            created_at=raid.created_at,
-            updated_at=datetime.now(UTC),
-        )
-        self.raids[tracker_id] = updated
-        return updated
-
-    async def get_raid_progress_for_saga(self, saga_tracker_id):
-        return list(self.raids.values())
-
-    async def get_raid_by_session(self, session_id):
-        return None
-
-    async def list_raids_by_status(self, status):
-        return []
-
-    async def get_raid_by_id(self, raid_id):
-        return None
-
-    async def add_confidence_event(self, tracker_id, event):
-        self.events.setdefault(tracker_id, []).append(event)
-
-    async def get_confidence_events(self, tracker_id):
-        return self.events.get(tracker_id, [])
-
-    async def all_raids_merged(self, phase_tracker_id):
-        return self._all_merged
-
-    async def list_phases_for_saga(self, saga_tracker_id):
-        return self.phases
-
-    async def update_phase_status(self, phase_tracker_id, status):
-        return None
-
-    async def get_saga_for_raid(self, tracker_id):
-        return self.saga
-
-    async def get_phase_for_raid(self, tracker_id):
-        return self.phase
-
-    async def get_owner_for_raid(self, tracker_id):
-        return OWNER_ID
-
-    async def save_session_message(self, message):
-        pass
-
-    async def get_session_messages(self, tracker_id):
-        return []
-
-
-class StubTrackerFactory:
-    def __init__(self, tracker: StubTracker) -> None:
-        self._tracker = tracker
-
-    async def for_owner(self, owner_id: str) -> list[StubTracker]:
-        return [self._tracker]
-
-
-class StubVolundr:
-    def __init__(self) -> None:
-        self.messages: list[tuple[str, str]] = []
-        self.stopped_sessions: list[str] = []
-
-    async def spawn_session(self, request, **kwargs):
-        raise NotImplementedError
-
-    async def get_session(self, session_id, **kwargs):
-        return None
-
-    async def list_sessions(self, **kwargs):
-        return []
-
-    async def get_pr_status(self, session_id):
-        raise NotImplementedError
-
-    async def get_chronicle_summary(self, session_id):
-        return ""
-
-    async def send_message(self, session_id, message, **kwargs):
-        self.messages.append((session_id, message))
-
-    async def stop_session(self, session_id, **kwargs):
-        self.stopped_sessions.append(session_id)
-
-    async def list_integration_ids(self, **kwargs):
-        return []
-
-    async def list_repos(self, **kwargs):
-        return []
-
-    async def get_conversation(self, session_id):
-        return {"turns": []}
-
-    async def get_last_assistant_message(self, session_id):
-        return ""
-
-    async def subscribe_activity(self) -> AsyncGenerator:
-        return
-        yield  # type: ignore[misc]
-
-
-class StubVolundrFactory:
-    def __init__(self, volundr: StubVolundr) -> None:
-        self._v = volundr
-
-    async def for_owner(self, owner_id: str) -> list[StubVolundr]:
-        return [self._v]
-
-    async def primary_for_owner(self, owner_id: str) -> StubVolundr | None:
-        return self._v
-
-
-class StubGit:
-    def __init__(self) -> None:
-        self.pr_statuses: dict[str, PRStatus] = {}
-        self.changed_files: dict[str, list[str]] = {}
-
-    async def create_branch(self, repo, branch, base):
-        pass
-
-    async def merge_branch(self, repo, source, target):
-        pass
-
-    async def delete_branch(self, repo, branch):
-        pass
-
-    async def create_pr(self, repo, source, target, title):
-        return "pr-1"
-
-    async def get_pr_status(self, pr_id):
-        pr = self.pr_statuses.get(pr_id)
-        if pr is None:
-            raise RuntimeError(f"No PR: {pr_id}")
-        return pr
-
-    async def get_pr_changed_files(self, pr_id):
-        return self.changed_files.get(pr_id, [])
 
 
 class StubRavnDispatcher:
@@ -378,11 +141,11 @@ def _make_engine(
     ravn: StubRavnDispatcher | None = None,
     tracker: StubTracker | None = None,
     git: StubGit | None = None,
-    volundr: StubVolundr | None = None,
-) -> tuple[ReviewEngine, StubTracker, StubGit, StubVolundr]:
+    volundr: StubVolundrPort | None = None,
+) -> tuple[ReviewEngine, StubTracker, StubGit, StubVolundrPort]:
     t = tracker or StubTracker()
     g = git or StubGit()
-    v = volundr or StubVolundr()
+    v = volundr or StubVolundrPort()
     cfg = config or ReviewConfig(reviewer_session_enabled=False)
 
     engine = ReviewEngine(

--- a/tests/test_tyr/test_ravn_arbiter.py
+++ b/tests/test_tyr/test_ravn_arbiter.py
@@ -11,6 +11,7 @@ Test harness from NIU-619 spec:
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import Any
 from uuid import uuid4
 
@@ -36,7 +37,7 @@ from tyr.domain.models import (
 )
 from tyr.domain.services.review_engine import ReviewEngine
 
-NOW = __import__("datetime").datetime.now(__import__("datetime").timezone.utc)
+NOW = datetime.now(UTC)
 PHASE_ID = uuid4()
 SAGA_ID = uuid4()
 OWNER_ID = "user-arbiter"

--- a/tests/test_tyr/test_ravn_arbiter.py
+++ b/tests/test_tyr/test_ravn_arbiter.py
@@ -1,0 +1,836 @@
+"""Tests for the review-arbiter ravn persona and ReviewEngine arbiter integration.
+
+Test harness from NIU-619 spec:
+  1. Unit: review-arbiter persona — load YAML, verify schema, tools, budget
+  2. Unit: context assembly — given raid with CI fail + scope breach, verify signals present
+  3. Unit: outcome mapping — given arbiter outcome, verify maps to correct action
+  4. Unit: fallback — simulate ravn failure; verify imperative logic runs
+  5. Integration: review round-trip — mock dispatcher returning canned outcome;
+     ReviewEngine dispatches to arbiter → outcome parsed → raid state transitions
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from tyr.adapters.memory_event_bus import InMemoryEventBus
+from tyr.config import ReviewConfig
+from tyr.domain.models import (
+    ConfidenceEvent,
+    Phase,
+    PhaseStatus,
+    PRStatus,
+    Raid,
+    RaidStatus,
+    Saga,
+    SagaStatus,
+)
+from tyr.domain.services.review_engine import ReviewEngine
+
+NOW = datetime.now(UTC)
+PHASE_ID = uuid4()
+SAGA_ID = uuid4()
+OWNER_ID = "user-arbiter"
+TRACKER_ID = "NIU-619"
+
+# ---------------------------------------------------------------------------
+# Stubs (mirrors test_review_engine.py stubs to avoid import coupling)
+# ---------------------------------------------------------------------------
+
+
+class StubTracker:
+    """Minimal tracker stub for arbiter tests."""
+
+    def __init__(self) -> None:
+        self.raids: dict[str, Raid] = {}
+        self.events: dict[str, list[ConfidenceEvent]] = {}
+        self.saga: Saga | None = None
+        self.phase: Phase | None = None
+        self.phases: list[Phase] = []
+        self._all_merged: bool = False
+        self.phase_status_updates: list[tuple[str, PhaseStatus]] = []
+        self.attached_documents: list[tuple[str, str, str]] = []
+
+    async def create_saga(self, saga, **kwargs):
+        return saga.tracker_id
+
+    async def create_phase(self, phase, **kwargs):
+        return phase.tracker_id
+
+    async def create_raid(self, raid, **kwargs):
+        self.raids[raid.tracker_id] = raid
+        return raid.tracker_id
+
+    async def update_raid_state(self, raid_id, state):
+        pass
+
+    async def close_raid(self, raid_id):
+        pass
+
+    async def attach_issue_document(self, issue_id, title, content):
+        self.attached_documents.append((issue_id, title, content))
+        return "doc-stub"
+
+    async def get_saga(self, saga_id):
+        if self.saga is None:
+            raise ValueError(f"Not found: {saga_id}")
+        return self.saga
+
+    async def get_phase(self, tracker_id):
+        if self.phase is None:
+            raise ValueError(f"Not found: {tracker_id}")
+        return self.phase
+
+    async def get_raid(self, tracker_id):
+        raid = self.raids.get(tracker_id)
+        if raid is None:
+            raise ValueError(f"Raid not found: {tracker_id}")
+        return raid
+
+    async def list_pending_raids(self, phase_id):
+        return []
+
+    async def list_projects(self):
+        return []
+
+    async def get_project(self, project_id):
+        raise NotImplementedError
+
+    async def list_milestones(self, project_id):
+        return []
+
+    async def list_issues(self, project_id, milestone_id=None):
+        return []
+
+    async def update_raid_progress(
+        self,
+        tracker_id,
+        *,
+        status=None,
+        session_id=None,
+        confidence=None,
+        pr_url=None,
+        pr_id=None,
+        retry_count=None,
+        reason=None,
+        owner_id=None,
+        phase_tracker_id=None,
+        saga_tracker_id=None,
+        chronicle_summary=None,
+        reviewer_session_id=None,
+        review_round=None,
+    ):
+        raid = self.raids.get(tracker_id)
+        if raid is None:
+            raise ValueError(f"Raid not found: {tracker_id}")
+        events = self.events.get(tracker_id, [])
+        new_confidence = events[-1].score_after if events else raid.confidence
+        updated = Raid(
+            id=raid.id,
+            phase_id=raid.phase_id,
+            tracker_id=raid.tracker_id,
+            name=raid.name,
+            description=raid.description,
+            acceptance_criteria=raid.acceptance_criteria,
+            declared_files=raid.declared_files,
+            estimate_hours=raid.estimate_hours,
+            status=status if status is not None else raid.status,
+            confidence=confidence if confidence is not None else new_confidence,
+            session_id=session_id if session_id is not None else raid.session_id,
+            branch=raid.branch,
+            chronicle_summary=raid.chronicle_summary,
+            pr_url=pr_url if pr_url is not None else raid.pr_url,
+            pr_id=pr_id if pr_id is not None else raid.pr_id,
+            retry_count=retry_count if retry_count is not None else raid.retry_count,
+            created_at=raid.created_at,
+            updated_at=datetime.now(UTC),
+        )
+        self.raids[tracker_id] = updated
+        return updated
+
+    async def get_raid_progress_for_saga(self, saga_tracker_id):
+        return list(self.raids.values())
+
+    async def get_raid_by_session(self, session_id):
+        return None
+
+    async def list_raids_by_status(self, status):
+        return []
+
+    async def get_raid_by_id(self, raid_id):
+        return None
+
+    async def add_confidence_event(self, tracker_id, event):
+        self.events.setdefault(tracker_id, []).append(event)
+
+    async def get_confidence_events(self, tracker_id):
+        return self.events.get(tracker_id, [])
+
+    async def all_raids_merged(self, phase_tracker_id):
+        return self._all_merged
+
+    async def list_phases_for_saga(self, saga_tracker_id):
+        return self.phases
+
+    async def update_phase_status(self, phase_tracker_id, status):
+        return None
+
+    async def get_saga_for_raid(self, tracker_id):
+        return self.saga
+
+    async def get_phase_for_raid(self, tracker_id):
+        return self.phase
+
+    async def get_owner_for_raid(self, tracker_id):
+        return OWNER_ID
+
+    async def save_session_message(self, message):
+        pass
+
+    async def get_session_messages(self, tracker_id):
+        return []
+
+
+class StubTrackerFactory:
+    def __init__(self, tracker: StubTracker) -> None:
+        self._tracker = tracker
+
+    async def for_owner(self, owner_id: str) -> list[StubTracker]:
+        return [self._tracker]
+
+
+class StubVolundr:
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, str]] = []
+        self.stopped_sessions: list[str] = []
+
+    async def spawn_session(self, request, **kwargs):
+        raise NotImplementedError
+
+    async def get_session(self, session_id, **kwargs):
+        return None
+
+    async def list_sessions(self, **kwargs):
+        return []
+
+    async def get_pr_status(self, session_id):
+        raise NotImplementedError
+
+    async def get_chronicle_summary(self, session_id):
+        return ""
+
+    async def send_message(self, session_id, message, **kwargs):
+        self.messages.append((session_id, message))
+
+    async def stop_session(self, session_id, **kwargs):
+        self.stopped_sessions.append(session_id)
+
+    async def list_integration_ids(self, **kwargs):
+        return []
+
+    async def list_repos(self, **kwargs):
+        return []
+
+    async def get_conversation(self, session_id):
+        return {"turns": []}
+
+    async def get_last_assistant_message(self, session_id):
+        return ""
+
+    async def subscribe_activity(self) -> AsyncGenerator:
+        return
+        yield  # type: ignore[misc]
+
+
+class StubVolundrFactory:
+    def __init__(self, volundr: StubVolundr) -> None:
+        self._v = volundr
+
+    async def for_owner(self, owner_id: str) -> list[StubVolundr]:
+        return [self._v]
+
+    async def primary_for_owner(self, owner_id: str) -> StubVolundr | None:
+        return self._v
+
+
+class StubGit:
+    def __init__(self) -> None:
+        self.pr_statuses: dict[str, PRStatus] = {}
+        self.changed_files: dict[str, list[str]] = {}
+
+    async def create_branch(self, repo, branch, base):
+        pass
+
+    async def merge_branch(self, repo, source, target):
+        pass
+
+    async def delete_branch(self, repo, branch):
+        pass
+
+    async def create_pr(self, repo, source, target, title):
+        return "pr-1"
+
+    async def get_pr_status(self, pr_id):
+        pr = self.pr_statuses.get(pr_id)
+        if pr is None:
+            raise RuntimeError(f"No PR: {pr_id}")
+        return pr
+
+    async def get_pr_changed_files(self, pr_id):
+        return self.changed_files.get(pr_id, [])
+
+
+class StubRavnDispatcher:
+    """Stub RavnDispatcher that returns a canned outcome dict."""
+
+    def __init__(self, outcome: dict[str, Any] | None = None, *, raises: bool = False) -> None:
+        self.outcome = outcome
+        self.raises = raises
+        self.calls: list[tuple[str, str]] = []  # (persona_name, context)
+
+    async def dispatch(self, persona_name: str, context: str, **kwargs) -> dict | None:
+        self.calls.append((persona_name, context))
+        if self.raises:
+            raise RuntimeError("simulated ravn failure")
+        return self.outcome
+
+    async def close(self) -> None:
+        pass
+
+    def load_persona(self, name: str):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+PR_ID = "https://api.github.com/repos/org/repo/pulls/42"
+
+
+def _make_raid(
+    tracker_id: str = TRACKER_ID,
+    status: RaidStatus = RaidStatus.REVIEW,
+    confidence: float = 0.5,
+    pr_id: str | None = PR_ID,
+    declared_files: list[str] | None = None,
+    retry_count: int = 0,
+) -> Raid:
+    return Raid(
+        id=uuid4(),
+        phase_id=PHASE_ID,
+        tracker_id=tracker_id,
+        name="Test raid",
+        description="A test raid",
+        acceptance_criteria=["tests pass", "coverage >= 85%"],
+        declared_files=declared_files or ["src/main.py", "tests/test_main.py"],
+        estimate_hours=3.0,
+        status=status,
+        confidence=confidence,
+        session_id="session-arbiter",
+        branch="raid/test",
+        chronicle_summary="",
+        pr_url="https://github.com/org/repo/pull/42",
+        pr_id=pr_id,
+        retry_count=retry_count,
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+
+def _make_saga() -> Saga:
+    return Saga(
+        id=SAGA_ID,
+        tracker_id="proj-arbiter",
+        tracker_type="linear",
+        slug="arbiter",
+        name="Arbiter Saga",
+        repos=["org/repo"],
+        feature_branch="feat/arbiter",
+        status=SagaStatus.ACTIVE,
+        confidence=0.5,
+        created_at=NOW,
+        base_branch="dev",
+        owner_id=OWNER_ID,
+    )
+
+
+def _make_phase() -> Phase:
+    return Phase(
+        id=PHASE_ID,
+        saga_id=SAGA_ID,
+        tracker_id="phase-1",
+        number=1,
+        name="Phase 1",
+        status=PhaseStatus.ACTIVE,
+        confidence=0.5,
+    )
+
+
+def _make_engine(
+    config: ReviewConfig | None = None,
+    ravn: StubRavnDispatcher | None = None,
+    tracker: StubTracker | None = None,
+    git: StubGit | None = None,
+    volundr: StubVolundr | None = None,
+) -> tuple[ReviewEngine, StubTracker, StubGit, StubVolundr]:
+    t = tracker or StubTracker()
+    g = git or StubGit()
+    v = volundr or StubVolundr()
+    cfg = config or ReviewConfig(reviewer_session_enabled=False)
+
+    engine = ReviewEngine(
+        tracker_factory=StubTrackerFactory(t),
+        volundr_factory=StubVolundrFactory(v),
+        git=g,
+        review_config=cfg,
+        event_bus=InMemoryEventBus(),
+        ravn_dispatcher=ravn,
+    )
+    return engine, t, g, v
+
+
+def _passing_pr(git: StubGit, pr_id: str) -> None:
+    git.pr_statuses[pr_id] = PRStatus(
+        pr_id=pr_id,
+        url="https://github.com/org/repo/pull/42",
+        state="open",
+        mergeable=True,
+        ci_passed=True,
+    )
+
+
+def _failing_pr(git: StubGit, pr_id: str) -> None:
+    git.pr_statuses[pr_id] = PRStatus(
+        pr_id=pr_id,
+        url="https://github.com/org/repo/pull/42",
+        state="open",
+        mergeable=True,
+        ci_passed=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Unit: review-arbiter persona YAML
+# ---------------------------------------------------------------------------
+
+
+class TestReviewArbiterPersona:
+    def test_persona_loads(self) -> None:
+        """review-arbiter.yaml must be loadable by PersonaLoader."""
+        from ravn.adapters.personas.loader import PersonaLoader
+
+        loader = PersonaLoader()
+        persona = loader.load("review-arbiter")
+        assert persona is not None, "review-arbiter persona not found"
+
+    def test_persona_name(self) -> None:
+        from ravn.adapters.personas.loader import PersonaLoader
+
+        persona = PersonaLoader().load("review-arbiter")
+        assert persona is not None
+        assert persona.name == "review-arbiter"
+
+    def test_persona_has_system_prompt(self) -> None:
+        from ravn.adapters.personas.loader import PersonaLoader
+
+        persona = PersonaLoader().load("review-arbiter")
+        assert persona is not None
+        assert len(persona.system_prompt_template) > 50
+
+    def test_persona_schema_has_verdict(self) -> None:
+        from ravn.adapters.personas.loader import PersonaLoader
+
+        persona = PersonaLoader().load("review-arbiter")
+        assert persona is not None
+        assert "verdict" in persona.produces.schema
+
+    def test_persona_verdict_enum_values(self) -> None:
+        from ravn.adapters.personas.loader import PersonaLoader
+
+        persona = PersonaLoader().load("review-arbiter")
+        assert persona is not None
+        verdict_field = persona.produces.schema["verdict"]
+        assert verdict_field.enum_values is not None
+        assert set(verdict_field.enum_values) == {"approve", "retry", "escalate"}
+
+    def test_persona_has_reason_field(self) -> None:
+        from ravn.adapters.personas.loader import PersonaLoader
+
+        persona = PersonaLoader().load("review-arbiter")
+        assert persona is not None
+        assert "reason" in persona.produces.schema
+
+    def test_persona_iteration_budget(self) -> None:
+        from ravn.adapters.personas.loader import PersonaLoader
+
+        persona = PersonaLoader().load("review-arbiter")
+        assert persona is not None
+        assert persona.iteration_budget == 5
+
+    def test_persona_stop_on_outcome(self) -> None:
+        from ravn.adapters.personas.loader import PersonaLoader
+
+        persona = PersonaLoader().load("review-arbiter")
+        assert persona is not None
+        assert persona.stop_on_outcome is True
+
+    def test_persona_allowed_tools_non_empty(self) -> None:
+        from ravn.adapters.personas.loader import PersonaLoader
+
+        persona = PersonaLoader().load("review-arbiter")
+        assert persona is not None
+        assert len(persona.allowed_tools) > 0
+
+
+# ---------------------------------------------------------------------------
+# 2. Unit: context assembly
+# ---------------------------------------------------------------------------
+
+
+class TestContextAssembly:
+    def test_context_includes_acceptance_criteria(self) -> None:
+        """Context string must include the raid's acceptance criteria."""
+        engine, _, _, _ = _make_engine()
+        raid = _make_raid()
+        pr_status = PRStatus(
+            pr_id=PR_ID,
+            url="https://github.com/org/repo/pull/42",
+            state="open",
+            mergeable=True,
+            ci_passed=False,
+        )
+        context = engine._assemble_arbiter_context(raid, pr_status, [], 0.3)
+        for criterion in raid.acceptance_criteria:
+            assert criterion in context
+
+    def test_context_includes_ci_status(self) -> None:
+        """Context must mention CI failed when CI has failed."""
+        engine, _, _, _ = _make_engine()
+        raid = _make_raid()
+        pr_status = PRStatus(
+            pr_id=PR_ID,
+            url="https://github.com/org/repo/pull/42",
+            state="open",
+            mergeable=True,
+            ci_passed=False,
+        )
+        context = engine._assemble_arbiter_context(raid, pr_status, [], 0.3)
+        assert "failed" in context.lower()
+
+    def test_context_includes_scope_breach_ratio(self) -> None:
+        """Context must include scope breach info when undeclared files exist."""
+        engine, _, _, _ = _make_engine()
+        raid = _make_raid(declared_files=["src/main.py"])
+        changed = ["src/main.py", "src/extra1.py", "src/extra2.py", "src/extra3.py"]
+        context = engine._assemble_arbiter_context(raid, None, changed, 0.2)
+        assert "undeclared" in context.lower()
+
+    def test_context_includes_confidence_score(self) -> None:
+        """Context must include the current confidence score."""
+        engine, _, _, _ = _make_engine()
+        raid = _make_raid()
+        context = engine._assemble_arbiter_context(raid, None, [], 0.42)
+        assert "0.420" in context
+
+    def test_context_includes_tracker_id(self) -> None:
+        engine, _, _, _ = _make_engine()
+        raid = _make_raid()
+        context = engine._assemble_arbiter_context(raid, None, [], 0.5)
+        assert TRACKER_ID in context
+
+    def test_context_no_pr_shows_message(self) -> None:
+        engine, _, _, _ = _make_engine()
+        raid = _make_raid()
+        context = engine._assemble_arbiter_context(raid, None, [], 0.5)
+        assert "No PR found" in context
+
+    def test_context_declared_files_listed(self) -> None:
+        engine, _, _, _ = _make_engine()
+        raid = _make_raid(declared_files=["src/foo.py", "src/bar.py"])
+        context = engine._assemble_arbiter_context(raid, None, [], 0.5)
+        assert "src/foo.py" in context
+        assert "src/bar.py" in context
+
+    def test_context_marks_declared_vs_undeclared(self) -> None:
+        engine, _, _, _ = _make_engine()
+        raid = _make_raid(declared_files=["src/main.py"])
+        changed = ["src/main.py", "src/extra.py"]
+        context = engine._assemble_arbiter_context(raid, None, changed, 0.5)
+        assert "[declared]" in context
+        assert "[undeclared]" in context
+
+
+# ---------------------------------------------------------------------------
+# 3. Unit: outcome mapping
+# ---------------------------------------------------------------------------
+
+
+class TestOutcomeMapping:
+    @pytest.mark.asyncio
+    async def test_approve_verdict_auto_approves(self) -> None:
+        """Arbiter verdict 'approve' → auto_approved action."""
+        ravn = StubRavnDispatcher(outcome={"verdict": "approve", "reason": "all good"})
+        config = ReviewConfig(
+            reviewer_session_enabled=False,
+            ravn_arbiter_enabled=True,
+        )
+        engine, tracker, git, _ = _make_engine(config=config, ravn=ravn)
+        raid = _make_raid(confidence=0.9)
+        tracker.raids[raid.tracker_id] = raid
+        tracker.saga = _make_saga()
+        tracker.phase = _make_phase()
+        _passing_pr(git, PR_ID)
+        git.changed_files[PR_ID] = list(raid.declared_files)
+
+        result = await engine.evaluate(raid.tracker_id, OWNER_ID)
+
+        assert result.action == "auto_approved"
+        assert tracker.raids[raid.tracker_id].status == RaidStatus.MERGED
+
+    @pytest.mark.asyncio
+    async def test_retry_verdict_retries(self) -> None:
+        """Arbiter verdict 'retry' → retried action when retries remain."""
+        ravn = StubRavnDispatcher(outcome={"verdict": "retry", "reason": "CI flake"})
+        config = ReviewConfig(
+            reviewer_session_enabled=False,
+            ravn_arbiter_enabled=True,
+            max_retries=3,
+        )
+        engine, tracker, git, _ = _make_engine(config=config, ravn=ravn)
+        raid = _make_raid(confidence=0.5, retry_count=0)
+        tracker.raids[raid.tracker_id] = raid
+        _passing_pr(git, PR_ID)
+
+        result = await engine.evaluate(raid.tracker_id, OWNER_ID)
+
+        assert result.action == "retried"
+        assert tracker.raids[raid.tracker_id].status == RaidStatus.PENDING
+
+    @pytest.mark.asyncio
+    async def test_retry_verdict_exhausted_escalates(self) -> None:
+        """Arbiter 'retry' when retries exhausted → escalated."""
+        ravn = StubRavnDispatcher(outcome={"verdict": "retry", "reason": "still failing"})
+        config = ReviewConfig(
+            reviewer_session_enabled=False,
+            ravn_arbiter_enabled=True,
+            max_retries=3,
+        )
+        engine, tracker, git, _ = _make_engine(config=config, ravn=ravn)
+        raid = _make_raid(confidence=0.4, retry_count=3)
+        tracker.raids[raid.tracker_id] = raid
+        _passing_pr(git, PR_ID)
+
+        result = await engine.evaluate(raid.tracker_id, OWNER_ID)
+
+        assert result.action == "escalated"
+        assert tracker.raids[raid.tracker_id].status == RaidStatus.ESCALATED
+
+    @pytest.mark.asyncio
+    async def test_escalate_verdict_escalates(self) -> None:
+        """Arbiter verdict 'escalate' → escalated action."""
+        ravn = StubRavnDispatcher(outcome={"verdict": "escalate", "reason": "needs human"})
+        config = ReviewConfig(
+            reviewer_session_enabled=False,
+            ravn_arbiter_enabled=True,
+        )
+        engine, tracker, git, _ = _make_engine(config=config, ravn=ravn)
+        raid = _make_raid(confidence=0.5)
+        tracker.raids[raid.tracker_id] = raid
+        _passing_pr(git, PR_ID)
+
+        result = await engine.evaluate(raid.tracker_id, OWNER_ID)
+
+        assert result.action == "escalated"
+        assert tracker.raids[raid.tracker_id].status == RaidStatus.ESCALATED
+
+    @pytest.mark.asyncio
+    async def test_unknown_verdict_falls_back(self) -> None:
+        """Unknown arbiter verdict → imperative fallback (auto_approved for passing PR)."""
+        ravn = StubRavnDispatcher(outcome={"verdict": "unknown_word", "reason": "???"})
+        config = ReviewConfig(
+            reviewer_session_enabled=False,
+            ravn_arbiter_enabled=True,
+        )
+        engine, tracker, git, _ = _make_engine(config=config, ravn=ravn)
+        raid = _make_raid(confidence=0.5)
+        tracker.raids[raid.tracker_id] = raid
+        tracker.saga = _make_saga()
+        tracker.phase = _make_phase()
+        _passing_pr(git, PR_ID)
+        git.changed_files[PR_ID] = list(raid.declared_files)
+
+        result = await engine.evaluate(raid.tracker_id, OWNER_ID)
+
+        # Fallback path → auto_approved since PR passes and confidence is sufficient
+        assert result.action == "auto_approved"
+
+
+# ---------------------------------------------------------------------------
+# 4. Unit: fallback on ravn failure
+# ---------------------------------------------------------------------------
+
+
+class TestArbiterFallback:
+    @pytest.mark.asyncio
+    async def test_ravn_exception_falls_back_to_imperative(self) -> None:
+        """When ravn raises an exception, imperative logic runs as fallback."""
+        ravn = StubRavnDispatcher(raises=True)
+        config = ReviewConfig(
+            reviewer_session_enabled=False,
+            ravn_arbiter_enabled=True,
+        )
+        engine, tracker, git, _ = _make_engine(config=config, ravn=ravn)
+        raid = _make_raid(confidence=0.5)
+        tracker.raids[raid.tracker_id] = raid
+        tracker.saga = _make_saga()
+        tracker.phase = _make_phase()
+        _passing_pr(git, PR_ID)
+        git.changed_files[PR_ID] = list(raid.declared_files)
+
+        result = await engine.evaluate(raid.tracker_id, OWNER_ID)
+
+        # Imperative fallback: passing PR + enough confidence → auto_approved
+        assert result.action == "auto_approved"
+
+    @pytest.mark.asyncio
+    async def test_ravn_returns_none_falls_back(self) -> None:
+        """When ravn returns None (no outcome), imperative logic runs."""
+        ravn = StubRavnDispatcher(outcome=None)
+        config = ReviewConfig(
+            reviewer_session_enabled=False,
+            ravn_arbiter_enabled=True,
+        )
+        engine, tracker, git, _ = _make_engine(config=config, ravn=ravn)
+        raid = _make_raid(confidence=0.5)
+        tracker.raids[raid.tracker_id] = raid
+        tracker.saga = _make_saga()
+        tracker.phase = _make_phase()
+        _passing_pr(git, PR_ID)
+        git.changed_files[PR_ID] = list(raid.declared_files)
+
+        result = await engine.evaluate(raid.tracker_id, OWNER_ID)
+
+        assert result.action == "auto_approved"
+
+    @pytest.mark.asyncio
+    async def test_arbiter_disabled_skips_ravn(self) -> None:
+        """When ravn_arbiter_enabled=False, ravn is never called."""
+        ravn = StubRavnDispatcher(outcome={"verdict": "escalate", "reason": "test"})
+        config = ReviewConfig(
+            reviewer_session_enabled=False,
+            ravn_arbiter_enabled=False,
+        )
+        engine, tracker, git, _ = _make_engine(config=config, ravn=ravn)
+        raid = _make_raid(confidence=0.5)
+        tracker.raids[raid.tracker_id] = raid
+        tracker.saga = _make_saga()
+        tracker.phase = _make_phase()
+        _passing_pr(git, PR_ID)
+        git.changed_files[PR_ID] = list(raid.declared_files)
+
+        result = await engine.evaluate(raid.tracker_id, OWNER_ID)
+
+        # Arbiter skipped → imperative logic → auto_approved
+        assert result.action == "auto_approved"
+        assert len(ravn.calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_no_ravn_dispatcher_skips_arbiter(self) -> None:
+        """When no RavnDispatcher is injected, arbiter is silently skipped."""
+        config = ReviewConfig(
+            reviewer_session_enabled=False,
+            ravn_arbiter_enabled=True,
+        )
+        engine, tracker, git, _ = _make_engine(config=config, ravn=None)
+        raid = _make_raid(confidence=0.5)
+        tracker.raids[raid.tracker_id] = raid
+        tracker.saga = _make_saga()
+        tracker.phase = _make_phase()
+        _passing_pr(git, PR_ID)
+        git.changed_files[PR_ID] = list(raid.declared_files)
+
+        result = await engine.evaluate(raid.tracker_id, OWNER_ID)
+
+        assert result.action == "auto_approved"
+
+
+# ---------------------------------------------------------------------------
+# 5. Integration: review round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestReviewArbiterRoundTrip:
+    @pytest.mark.asyncio
+    async def test_arbiter_approve_transitions_to_merged(self) -> None:
+        """Full round-trip: arbiter 'approve' → raid transitions to MERGED."""
+        ravn = StubRavnDispatcher(outcome={"verdict": "approve", "reason": "clean code"})
+        config = ReviewConfig(
+            reviewer_session_enabled=False,
+            ravn_arbiter_enabled=True,
+        )
+        engine, tracker, git, _ = _make_engine(config=config, ravn=ravn)
+        raid = _make_raid(confidence=0.85)
+        tracker.raids[raid.tracker_id] = raid
+        tracker.saga = _make_saga()
+        tracker.phase = _make_phase()
+        _passing_pr(git, PR_ID)
+        git.changed_files[PR_ID] = list(raid.declared_files)
+
+        result = await engine.evaluate(raid.tracker_id, OWNER_ID)
+
+        assert result.action == "auto_approved"
+        assert tracker.raids[raid.tracker_id].status == RaidStatus.MERGED
+        # Verify arbiter was actually called
+        assert len(ravn.calls) == 1
+        assert ravn.calls[0][0] == "review-arbiter"
+
+    @pytest.mark.asyncio
+    async def test_arbiter_retry_transitions_to_pending(self) -> None:
+        """Full round-trip: arbiter 'retry' → raid transitions to PENDING."""
+        ravn = StubRavnDispatcher(outcome={"verdict": "retry", "reason": "test coverage gap"})
+        config = ReviewConfig(
+            reviewer_session_enabled=False,
+            ravn_arbiter_enabled=True,
+            max_retries=3,
+        )
+        engine, tracker, git, vol = _make_engine(config=config, ravn=ravn)
+        raid = _make_raid(confidence=0.6, retry_count=1)
+        tracker.raids[raid.tracker_id] = raid
+        _passing_pr(git, PR_ID)
+
+        result = await engine.evaluate(raid.tracker_id, OWNER_ID)
+
+        assert result.action == "retried"
+        updated = tracker.raids[raid.tracker_id]
+        assert updated.status == RaidStatus.PENDING
+        assert updated.retry_count == 2
+
+    @pytest.mark.asyncio
+    async def test_arbiter_context_passed_to_dispatcher(self) -> None:
+        """Verify the context string passed to the dispatcher contains key signals."""
+        ravn = StubRavnDispatcher(outcome={"verdict": "escalate", "reason": "test"})
+        config = ReviewConfig(
+            reviewer_session_enabled=False,
+            ravn_arbiter_enabled=True,
+        )
+        engine, tracker, git, _ = _make_engine(config=config, ravn=ravn)
+        raid = _make_raid(confidence=0.4, declared_files=["src/core.py"])
+        tracker.raids[raid.tracker_id] = raid
+        _failing_pr(git, PR_ID)
+        git.changed_files[PR_ID] = ["src/core.py", "src/extra.py"]
+
+        await engine.evaluate(raid.tracker_id, OWNER_ID)
+
+        assert len(ravn.calls) == 1
+        _, context = ravn.calls[0]
+        # Check all key signals appear in the context
+        assert TRACKER_ID in context
+        assert "acceptance_criteria" in context.lower() or "tests pass" in context
+        assert "undeclared" in context.lower()


### PR DESCRIPTION
## Summary

- **`review-arbiter` persona** (`src/ravn/personas/review-arbiter.yaml`): new ravn persona that replaces the imperative approve/retry/escalate decision in `ReviewEngine`. Receives acceptance criteria, PR diff signals, CI status, scope breach ratio, and confidence score; emits a structured `verdict` + `reason` (+ optional `confidence_adjustment`).
- **`decomposer` persona** (`src/ravn/personas/decomposer.yaml`): new ravn persona that replaces direct Anthropic API calls in `BifrostAdapter`. Reads the codebase before decomposing specs; produces a JSON-encoded `SagaStructure` in its `phases` outcome field.
- **`RavnDispatcher`** (`src/tyr/domain/services/ravn_dispatcher.py`): thin in-process single-turn LLM executor. Loads persona → builds prompt → calls Anthropic-compatible API → parses `---outcome---` block. Returns `dict | None` (None on unknown persona, HTTP error, or missing outcome block).
- **`ReviewEngine`** extended with optional `ravn_dispatcher` injection. When `ravn_arbiter_enabled=True`, context is assembled and dispatched to `review-arbiter` before the imperative fallback; failed/None dispatch falls through transparently.
- **`BifrostAdapter`** extended with `ravn_decomposer_enabled` flag. When enabled, tries `_try_decomposer_ravn()` first; on failure/None falls back to `_decompose_via_api()`.
- **Config** (`src/tyr/config.py`): added `ravn_arbiter_enabled`, `ravn_arbiter_model`, `ravn_arbiter_timeout` to `ReviewConfig`; added `ravn_decomposer_enabled`, `ravn_decomposer_timeout` to `LLMConfig`. Both default to `False`/`off` — no behaviour change without explicit opt-in.
- **Tests**: 49 new tests across `test_ravn_arbiter.py` and `test_decomposer_ravn.py` covering persona YAML schema, context assembly, outcome→decision mapping, fallback paths, and full round-trips via `respx` HTTP mocks.

## Test plan

- [x] All 1341 tests pass (`pytest --ignore=tests/test_tyr/test_tui_pages.py`)
- [x] Ruff lint clean (`ruff check`, `ruff format --check`)
- [x] Coverage: `bifrost.py` 95%, `ravn_dispatcher.py` 91%, `review_engine.py` 87% (all ≥ 85%)
- [x] Both new features default to disabled — zero behaviour change without config opt-in
- [x] Fallback to imperative logic tested for: exception in dispatch, None outcome, unknown verdict, feature flag off, no dispatcher injected

🤖 Generated with [Claude Code](https://claude.com/claude-code)