### PR TITLE
fix(skuld): propagate ravn activity state and CLI participant color to room UI

### DIFF
--- a/src/skuld/broker.py
+++ b/src/skuld/broker.py
@@ -866,6 +866,11 @@ class Broker:
         # Report activity state transitions to Volundr
         if event_type == "assistant":
             asyncio.create_task(self._report_activity_state("active"))
+            # Emit room activity for CLI participant so room UI shows "thinking"
+            if self._room_bridge is not None and self._mesh_adapter is not None:
+                await self._room_bridge.broadcast_cli_activity(
+                    self._mesh_adapter.peer_id, "thinking"
+                )
         elif event_type == "result":
             asyncio.create_task(self._report_activity_state("idle"))
             asyncio.create_task(self._on_result_publish_mesh())
@@ -985,6 +990,12 @@ class Broker:
                     "model": result_model,
                 }
             )
+
+            # Emit CLI turn as room_message so it shows participant color
+            if self._room_bridge is not None and self._mesh_adapter is not None and content:
+                await self._room_bridge.broadcast_cli_message(self._mesh_adapter.peer_id, content)
+                await self._room_bridge.broadcast_cli_activity(self._mesh_adapter.peer_id, "idle")
+
             first_line = ""
             if content:
                 for line in content.strip().splitlines():

--- a/src/skuld/room_bridge.py
+++ b/src/skuld/room_bridge.py
@@ -42,6 +42,8 @@ _RAVN_ACTIVITY_MAP: dict[str, str] = {
     "thinking": "thinking",
     "tool_start": "tool_executing",
     "tool_result": "idle",
+    "task_started": "busy",
+    "decision": "thinking",
 }
 
 
@@ -415,6 +417,32 @@ class RoomBridge:
             meta.peer_id,
             event_type,
         )
+
+    # ------------------------------------------------------------------
+    # CLI participant helpers
+    # ------------------------------------------------------------------
+
+    async def broadcast_cli_activity(self, peer_id: str, activity_type: str) -> None:
+        """Broadcast a ``room_activity`` event for the local CLI participant.
+
+        Called by the Broker when the CLI transport changes activity state
+        so the room UI can show the Skuld participant as thinking/idle.
+        """
+        meta = self._participants.get(peer_id)
+        if meta is None:
+            return
+        await self._handle_activity_frame(meta, activity_type, "")
+
+    async def broadcast_cli_message(self, peer_id: str, content: str) -> None:
+        """Broadcast a ``room_message`` for the local CLI participant.
+
+        Called by the Broker when a CLI assistant turn completes so the
+        message appears in the room chat with participant color.
+        """
+        meta = self._participants.get(peer_id)
+        if meta is None:
+            return
+        await self._handle_response_frame(meta, {"data": content, "metadata": {}}, is_error=False)
 
     # ------------------------------------------------------------------
     # Directed routing

--- a/tests/test_skuld/test_room_bridge.py
+++ b/tests/test_skuld/test_room_bridge.py
@@ -304,6 +304,37 @@ class TestActivityFrameTranslation:
         assert activities[0]["activityType"] == "idle"
 
     @pytest.mark.asyncio
+    async def test_task_started_frame_broadcasts_busy(self):
+        bridge, registry = _make_bridge()
+        await bridge.register("p1", "Alice", _fake_ws())
+        registry.broadcast.reset_mock()
+
+        await bridge.handle_ravn_frame(
+            "p1", {"type": "task_started", "data": "starting", "metadata": {}}
+        )
+
+        calls = [c[0][0] for c in registry.broadcast.call_args_list]
+        activities = [e for e in calls if e["type"] == "room_activity"]
+        assert len(activities) == 1
+        assert activities[0]["activityType"] == "busy"
+        assert activities[0]["participantId"] == "p1"
+
+    @pytest.mark.asyncio
+    async def test_decision_frame_broadcasts_thinking(self):
+        bridge, registry = _make_bridge()
+        await bridge.register("p1", "Alice", _fake_ws())
+        registry.broadcast.reset_mock()
+
+        await bridge.handle_ravn_frame(
+            "p1", {"type": "decision", "data": "deciding", "metadata": {}}
+        )
+
+        calls = [c[0][0] for c in registry.broadcast.call_args_list]
+        activities = [e for e in calls if e["type"] == "room_activity"]
+        assert len(activities) == 1
+        assert activities[0]["activityType"] == "thinking"
+
+    @pytest.mark.asyncio
     async def test_unknown_frame_type_is_silently_ignored(self):
         bridge, registry = _make_bridge()
         await bridge.register("p1", "Alice", _fake_ws())
@@ -369,6 +400,76 @@ class TestHistoryPersistence:
 
         # Should not raise even without a persistence callback
         await bridge.handle_ravn_frame("p1", {"type": "response", "data": "Hello", "metadata": {}})
+
+
+# ---------------------------------------------------------------------------
+# CLI participant helpers
+# ---------------------------------------------------------------------------
+
+
+class TestCliParticipantHelpers:
+    @pytest.mark.asyncio
+    async def test_broadcast_cli_activity_emits_room_activity(self):
+        bridge, registry = _make_bridge()
+        await bridge.register_mesh_peer("skuld-1", "coder", display_name="skuld")
+        registry.broadcast.reset_mock()
+
+        await bridge.broadcast_cli_activity("skuld-1", "thinking")
+
+        registry.broadcast.assert_awaited_once()
+        event = registry.broadcast.call_args[0][0]
+        assert event["type"] == "room_activity"
+        assert event["participantId"] == "skuld-1"
+        assert event["activityType"] == "thinking"
+
+    @pytest.mark.asyncio
+    async def test_broadcast_cli_activity_noop_for_unknown_peer(self):
+        bridge, registry = _make_bridge()
+        registry.broadcast.reset_mock()
+
+        await bridge.broadcast_cli_activity("ghost", "thinking")
+
+        registry.broadcast.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_broadcast_cli_message_emits_room_message(self):
+        bridge, registry = _make_bridge()
+        await bridge.register_mesh_peer("skuld-1", "coder", display_name="skuld")
+        registry.broadcast.reset_mock()
+
+        await bridge.broadcast_cli_message("skuld-1", "Hello from CLI")
+
+        calls = [c[0][0] for c in registry.broadcast.call_args_list]
+        room_msgs = [e for e in calls if e["type"] == "room_message"]
+        assert len(room_msgs) == 1
+        msg = room_msgs[0]
+        assert msg["content"] == "Hello from CLI"
+        assert msg["participantId"] == "skuld-1"
+        assert msg["participant"]["persona"] == "coder"
+        assert msg["participant"]["color"] in {"amber", "cyan", "emerald"}
+
+    @pytest.mark.asyncio
+    async def test_broadcast_cli_message_noop_for_unknown_peer(self):
+        bridge, registry = _make_bridge()
+        registry.broadcast.reset_mock()
+
+        await bridge.broadcast_cli_message("ghost", "Hello")
+
+        registry.broadcast.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_broadcast_cli_message_persists_turn(self):
+        turns = []
+        bridge, _ = _make_bridge(append_turn=turns.append)
+        await bridge.register_mesh_peer("skuld-1", "coder", display_name="skuld")
+
+        await bridge.broadcast_cli_message("skuld-1", "Completed task")
+
+        assert len(turns) == 1
+        turn = turns[0]
+        assert turn.role == "assistant"
+        assert turn.content == "Completed task"
+        assert turn.participant_id == "skuld-1"
 
 
 # ---------------------------------------------------------------------------

--- a/web/src/modules/shared/hooks/useSkuldChat.test.ts
+++ b/web/src/modules/shared/hooks/useSkuldChat.test.ts
@@ -2452,6 +2452,34 @@ describe('useSkuldChat', () => {
       expect(result.current.participants.size).toBe(0);
     });
 
+    it('room_message with camelCase participantId resolves sender', () => {
+      const { handlers } = setupMock();
+      const { result } = renderHook(() => useSkuldChat('wss://test/session'));
+
+      act(() => handlers.onOpen?.());
+      act(() =>
+        handlers.onMessage?.(
+          JSON.stringify({
+            type: 'room_message',
+            id: 'rm-camel',
+            content: 'camelCase test',
+            participantId: 'peer-2',
+            participant: {
+              peer_id: 'peer-2',
+              persona: 'Skuld',
+              color: 'cyan',
+              participant_type: 'ravn',
+            },
+          })
+        )
+      );
+
+      expect(result.current.messages).toHaveLength(1);
+      const msg = result.current.messages[0];
+      expect(msg.participantId).toBe('peer-2');
+      expect(msg.participant?.color).toBe('cyan');
+    });
+
     it('ignores room_activity with empty peer_id', () => {
       const { handlers } = setupMock();
       const { result } = renderHook(() => useSkuldChat('wss://test/session'));

--- a/web/src/modules/shared/hooks/useSkuldChat.ts
+++ b/web/src/modules/shared/hooks/useSkuldChat.ts
@@ -1100,7 +1100,8 @@ export function useSkuldChat(
         // ── room_message: append multi-participant message ────────
         if (eventType === 'room_message') {
           const raw = event as unknown as Record<string, unknown>;
-          const senderId = raw.participant_id ? String(raw.participant_id) : undefined;
+          const rawSenderId = raw.participantId ?? raw.participant_id;
+          const senderId = rawSenderId ? String(rawSenderId) : undefined;
 
           // Finalize any running internal stream for this participant —
           // a room_message means their turn produced a response.


### PR DESCRIPTION
## Summary
- **Ravn activity state**: Added `task_started` → `busy` and `decision` → `thinking` mappings to `_RAVN_ACTIVITY_MAP` so the room UI sidebar shows the correct participant status while a ravn is executing a task (previously showed "idle").
- **CLI participant color**: When room mode is active, the broker now emits `room_message` and `room_activity` events for the local CLI (Skuld) participant, so its messages appear in the room chat with the assigned participant color.
- **Frontend casing fix**: Fixed `participantId` field resolution in the `room_message` handler — the server sends camelCase (`participantId`) but the frontend was only checking snake_case (`participant_id`).

## Test plan
- [x] New backend tests for `task_started` and `decision` activity type mappings
- [x] New backend tests for `broadcast_cli_activity` and `broadcast_cli_message` helpers
- [x] New frontend test for camelCase `participantId` in `room_message` events
- [x] All 35 room_bridge tests pass, all 800 skuld tests pass
- [ ] Verify reviewer ravn shows "busy"/"thinking" in room UI during task execution
- [ ] Verify Skuld messages show participant color in room chat
- [ ] Verify activity state updates propagate through WebSocket to browser

Closes NIU-627

🤖 Generated with [Claude Code](https://claude.com/claude-code)