### PR TITLE
feat(adapters): NIU-626 — enrich code.changed event for reviewer context

### DIFF
--- a/src/ravn/drive_loop.py
+++ b/src/ravn/drive_loop.py
@@ -291,13 +291,7 @@ class FanInBuffer:
 
     @staticmethod
     def _format_single_event(event_type: str, payload: dict) -> str:
-        """Format a single event payload as initiative context.
-
-        When the payload contains enriched fields (workspace_path,
-        files_changed, diff_summary, task_description) they are
-        included so downstream personas (e.g. reviewer) have enough
-        context to do useful work.
-        """
+        """Format a single event payload as initiative context."""
         source_persona = payload.get("persona", "")
         source_task = payload.get("task_id", "unknown")
         outcome = payload.get("outcome", {})

--- a/src/ravn/drive_loop.py
+++ b/src/ravn/drive_loop.py
@@ -291,7 +291,13 @@ class FanInBuffer:
 
     @staticmethod
     def _format_single_event(event_type: str, payload: dict) -> str:
-        """Format a single event payload as initiative context."""
+        """Format a single event payload as initiative context.
+
+        When the payload contains enriched fields (workspace_path,
+        files_changed, diff_summary, task_description) they are
+        included so downstream personas (e.g. reviewer) have enough
+        context to do useful work.
+        """
         source_persona = payload.get("persona", "")
         source_task = payload.get("task_id", "unknown")
         outcome = payload.get("outcome", {})
@@ -300,6 +306,25 @@ class FanInBuffer:
             f"From persona: {source_persona}",
             f"Source task: {source_task}",
         ]
+
+        task_desc = payload.get("task_description")
+        if task_desc:
+            parts.append(f"Task description: {task_desc}")
+
+        workspace = payload.get("workspace_path")
+        if workspace:
+            parts.append(f"Workspace path: {workspace}")
+
+        files = payload.get("files_changed")
+        if files:
+            parts.append(f"Files changed ({len(files)}):")
+            for f in files:
+                parts.append(f"  - {f}")
+
+        diff = payload.get("diff_summary")
+        if diff:
+            parts.append(f"Git diff:\n{diff}")
+
         if outcome:
             parts.append(f"Outcome: {json.dumps(outcome)}")
         return "\n".join(parts)

--- a/src/skuld/broker.py
+++ b/src/skuld/broker.py
@@ -217,9 +217,17 @@ class SessionArtifacts:
 
         Returns a list of timeline-reportable tool events extracted
         from the content blocks.
+
+        Handles both the HTTP streaming format (``data["content"]``)
+        and the SDK WebSocket format (``data["message"]["content"]``).
         """
         tool_events: list[dict] = []
         content = data.get("content", [])
+        if not isinstance(content, list) or not content:
+            # SDK WebSocket transport nests content under message.content
+            msg = data.get("message")
+            if isinstance(msg, dict):
+                content = msg.get("content", [])
         if not isinstance(content, list):
             return tool_events
 
@@ -1600,6 +1608,29 @@ class Broker:
         self._extract_and_store_outcome()
         await self._publish_mesh_outcome()
 
+    async def _git_diff_summary(self, max_bytes: int = 8192) -> str:
+        """Return a truncated ``git diff HEAD`` from the workspace.
+
+        Best-effort: returns an empty string on any failure so mesh
+        publishing is never blocked by git issues.
+        """
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "git",
+                "diff",
+                "HEAD",
+                cwd=self.workspace_dir,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10)
+        except Exception:
+            return ""
+        raw = stdout.decode(errors="replace")
+        if len(raw) > max_bytes:
+            return raw[:max_bytes] + "\n... (truncated)"
+        return raw
+
     async def _publish_mesh_outcome(self) -> None:
         """Publish a ``code.changed`` event on the mesh so flock peers react.
 
@@ -1611,6 +1642,8 @@ class Broker:
 
         from ravn.domain.events import RavnEvent, RavnEventType
 
+        diff_summary = await self._git_diff_summary()
+
         outcome_payload: dict = {
             "event_type": "code.changed",
             "session_id": self.session_id,
@@ -1620,7 +1653,16 @@ class Broker:
                 f" ({self._artifacts.turn_count} turns,"
                 f" {len(self._artifacts.files_changed)} files)"
             ),
+            "workspace_path": self.workspace_dir,
         }
+
+        initial_prompt = self._settings.session.initial_prompt
+        if initial_prompt:
+            outcome_payload["task_description"] = initial_prompt
+
+        if diff_summary:
+            outcome_payload["diff_summary"] = diff_summary
+
         if self._artifacts.structured_outcome is not None:
             outcome_payload["outcome"] = self._artifacts.structured_outcome
         if self._artifacts.files_changed:

--- a/src/skuld/broker.py
+++ b/src/skuld/broker.py
@@ -1608,28 +1608,36 @@ class Broker:
         self._extract_and_store_outcome()
         await self._publish_mesh_outcome()
 
-    async def _git_diff_summary(self, max_bytes: int = 8192) -> str:
-        """Return a truncated ``git diff HEAD`` from the workspace.
+    async def _git_diff_summary(self) -> str:
+        """Return a truncated git diff from the workspace.
 
         Best-effort: returns an empty string on any failure so mesh
         publishing is never blocked by git issues.
         """
-        try:
-            proc = await asyncio.create_subprocess_exec(
-                "git",
-                "diff",
-                "HEAD",
-                cwd=self.workspace_dir,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
-            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10)
-        except Exception:
-            return ""
-        raw = stdout.decode(errors="replace")
-        if len(raw) > max_bytes:
-            return raw[:max_bytes] + "\n... (truncated)"
-        return raw
+        max_bytes = self._settings.mesh.diff_max_bytes
+        timeout = self._settings.mesh.diff_timeout_s
+
+        # Try committed changes first (HEAD~1..HEAD) since the coder
+        # session typically commits before finishing.  Fall back to
+        # uncommitted working-tree changes (diff HEAD).
+        for diff_args in (["git", "diff", "HEAD~1..HEAD"], ["git", "diff", "HEAD"]):
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    *diff_args,
+                    cwd=self.workspace_dir,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+            except Exception:
+                return ""
+            raw = stdout.decode(errors="replace")
+            if raw.strip():
+                if len(raw) > max_bytes:
+                    return raw[:max_bytes] + "\n... (truncated)"
+                return raw
+
+        return ""
 
     async def _publish_mesh_outcome(self) -> None:
         """Publish a ``code.changed`` event on the mesh so flock peers react.

--- a/src/skuld/config.py
+++ b/src/skuld/config.py
@@ -94,6 +94,8 @@ class MeshConfig(BaseModel):
     rpc_timeout_s: float = Field(default=10.0)
     default_work_timeout_s: float = Field(default=120.0)
     default_response_urgency: float = Field(default=0.3)
+    diff_max_bytes: int = Field(default=8192)
+    diff_timeout_s: float = Field(default=10.0)
     consumes_event_types: list[str] = Field(
         default_factory=lambda: ["code.requested"],
     )

--- a/tests/test_ravn/test_fan_in_buffer.py
+++ b/tests/test_ravn/test_fan_in_buffer.py
@@ -1,10 +1,6 @@
 """Unit tests for the FanInBuffer in drive_loop.py."""
 
-from datetime import UTC, datetime, timedelta
-
-import pytest
-
-from ravn.drive_loop import FanInBuffer, _FanInResult
+from ravn.drive_loop import FanInBuffer
 
 
 class TestMergeStrategy:
@@ -190,6 +186,95 @@ class TestProducerAggregation:
         assert buf.pending_count == 0
 
 
+class TestFormatSingleEvent:
+    """Tests for _format_single_event enriched payload formatting."""
+
+    def test_basic_format(self):
+        ctx = FanInBuffer._format_single_event(
+            "code.changed",
+            {"persona": "coder", "task_id": "t1"},
+        )
+        assert "Event type: code.changed" in ctx
+        assert "From persona: coder" in ctx
+        assert "Source task: t1" in ctx
+
+    def test_includes_task_description(self):
+        ctx = FanInBuffer._format_single_event(
+            "code.changed",
+            {"persona": "coder", "task_description": "Fix the login bug"},
+        )
+        assert "Task description: Fix the login bug" in ctx
+
+    def test_includes_workspace_path(self):
+        ctx = FanInBuffer._format_single_event(
+            "code.changed",
+            {"persona": "coder", "workspace_path": "/tmp/workspace"},
+        )
+        assert "Workspace path: /tmp/workspace" in ctx
+
+    def test_includes_files_changed(self):
+        ctx = FanInBuffer._format_single_event(
+            "code.changed",
+            {
+                "persona": "coder",
+                "files_changed": ["/src/auth.py", "/src/login.py"],
+            },
+        )
+        assert "Files changed (2):" in ctx
+        assert "  - /src/auth.py" in ctx
+        assert "  - /src/login.py" in ctx
+
+    def test_includes_diff_summary(self):
+        ctx = FanInBuffer._format_single_event(
+            "code.changed",
+            {
+                "persona": "coder",
+                "diff_summary": "diff --git a/main.py\n+new line",
+            },
+        )
+        assert "Git diff:" in ctx
+        assert "diff --git a/main.py" in ctx
+
+    def test_includes_outcome(self):
+        ctx = FanInBuffer._format_single_event(
+            "code.changed",
+            {"persona": "coder", "outcome": {"verdict": "pass"}},
+        )
+        assert "Outcome:" in ctx
+        assert "pass" in ctx
+
+    def test_enriched_payload_all_fields(self):
+        """Full enriched payload includes all fields in correct order."""
+        ctx = FanInBuffer._format_single_event(
+            "code.changed",
+            {
+                "persona": "coder",
+                "task_description": "Fix auth",
+                "workspace_path": "/ws",
+                "files_changed": ["/src/a.py"],
+                "diff_summary": "diff text",
+                "outcome": {"verdict": "pass"},
+            },
+        )
+        lines = ctx.split("\n")
+        # Task description should come before diff
+        task_idx = next(i for i, line in enumerate(lines) if "Task description" in line)
+        diff_idx = next(i for i, line in enumerate(lines) if "Git diff" in line)
+        assert task_idx < diff_idx
+
+    def test_omits_empty_enriched_fields(self):
+        """Empty enriched fields should not appear in context."""
+        ctx = FanInBuffer._format_single_event(
+            "code.changed",
+            {"persona": "coder"},
+        )
+        assert "Task description" not in ctx
+        assert "Workspace path" not in ctx
+        assert "Files changed" not in ctx
+        assert "Git diff" not in ctx
+        assert "Outcome" not in ctx
+
+
 class TestExpiry:
     def test_sweep_removes_expired_slots(self):
         buf = FanInBuffer(ttl_seconds=0.001)
@@ -204,6 +289,7 @@ class TestExpiry:
         assert buf.pending_count == 1
 
         import time
+
         time.sleep(0.01)
 
         expired = buf.sweep_expired()

--- a/tests/test_skuld/test_broker.py
+++ b/tests/test_skuld/test_broker.py
@@ -915,6 +915,79 @@ class TestSessionArtifacts:
         # duration should be >= 0
         assert artifacts.duration_seconds >= 0
 
+    def test_record_tool_use_sdk_message_format(self):
+        """SDK WebSocket transport nests content under message.content."""
+        from skuld.broker import SessionArtifacts
+
+        artifacts = SessionArtifacts()
+        data = {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "name": "Edit",
+                        "input": {"file_path": "/src/main.py"},
+                        "id": "tu_1",
+                    },
+                    {
+                        "type": "tool_use",
+                        "name": "Write",
+                        "input": {"file_path": "/src/new_file.py"},
+                        "id": "tu_2",
+                    },
+                ]
+            },
+        }
+        events = artifacts.record_tool_use(data)
+        assert artifacts.files_changed == ["/src/main.py", "/src/new_file.py"]
+        assert len(events) == 2
+
+    def test_record_tool_use_sdk_format_no_top_level_content(self):
+        """When top-level content is absent, falls back to message.content."""
+        from skuld.broker import SessionArtifacts
+
+        artifacts = SessionArtifacts()
+        data = {
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "name": "Edit",
+                        "input": {"file_path": "/src/fix.py"},
+                        "id": "tu_3",
+                    },
+                ]
+            },
+        }
+        artifacts.record_tool_use(data)
+        assert artifacts.files_changed == ["/src/fix.py"]
+
+    def test_record_tool_use_prefers_top_level_content(self):
+        """When both top-level and message.content exist, uses top-level."""
+        from skuld.broker import SessionArtifacts
+
+        artifacts = SessionArtifacts()
+        data = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "input": {"file_path": "/src/top.py"},
+                },
+            ],
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "input": {"file_path": "/src/nested.py"},
+                    },
+                ]
+            },
+        }
+        artifacts.record_tool_use(data)
+        assert artifacts.files_changed == ["/src/top.py"]
+        assert "/src/nested.py" not in artifacts.files_changed
+
 
 class TestHandleCliEventArtifacts:
     """Tests for artifact accumulation in _handle_cli_event."""
@@ -944,6 +1017,146 @@ class TestHandleCliEventArtifacts:
         data = {"type": "result", "modelUsage": {}}
         await test_broker._handle_cli_event(data)
         assert test_broker._artifacts.turn_count == 1
+
+
+class TestHandleCliEventSdkFormat:
+    """Tests for artifact accumulation from SDK WebSocket message format."""
+
+    @pytest.fixture
+    def test_broker(self, tmp_path):
+        settings = SkuldSettings(
+            session={"id": "test-session-sdk", "workspace_dir": str(tmp_path)},
+            transport="subprocess",
+        )
+        return Broker(settings=settings)
+
+    @pytest.mark.asyncio
+    async def test_assistant_event_sdk_format_records_tool_use(self, test_broker):
+        """SDK format: content nested under message.content."""
+        data = {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "name": "Edit",
+                        "input": {"file_path": "/src/module.py"},
+                        "id": "tu_sdk_1",
+                    },
+                ]
+            },
+        }
+        await test_broker._handle_cli_event(data)
+        assert "/src/module.py" in test_broker._artifacts.files_changed
+
+
+class TestGitDiffSummary:
+    """Tests for Broker._git_diff_summary."""
+
+    @pytest.fixture
+    def test_broker(self, tmp_path):
+        settings = SkuldSettings(
+            session={"id": "test-diff", "workspace_dir": str(tmp_path)},
+        )
+        return Broker(settings=settings)
+
+    @pytest.mark.asyncio
+    async def test_returns_diff_output(self, test_broker):
+        diff_text = "diff --git a/main.py b/main.py\n+hello"
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(diff_text.encode(), b""))
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            result = await test_broker._git_diff_summary()
+        assert "diff --git" in result
+
+    @pytest.mark.asyncio
+    async def test_truncates_large_diff(self, test_broker):
+        diff_text = "x" * 10000
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(diff_text.encode(), b""))
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            result = await test_broker._git_diff_summary(max_bytes=100)
+        assert len(result) < 200
+        assert "truncated" in result
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_error(self, test_broker):
+        with patch("asyncio.create_subprocess_exec", side_effect=OSError("no git")):
+            result = await test_broker._git_diff_summary()
+        assert result == ""
+
+
+class TestPublishMeshOutcome:
+    """Tests for Broker._publish_mesh_outcome with enriched payload."""
+
+    @pytest.fixture
+    def test_broker(self, tmp_path):
+        settings = SkuldSettings(
+            session={
+                "id": "test-mesh-pub",
+                "workspace_dir": str(tmp_path),
+                "initial_prompt": "Fix the login bug",
+            },
+        )
+        b = Broker(settings=settings)
+        b._artifacts.files_changed = ["/src/auth.py", "/src/login.py"]
+        b._artifacts.turn_count = 5
+        return b
+
+    @pytest.mark.asyncio
+    async def test_payload_includes_workspace_and_task(self, test_broker):
+        mock_mesh = AsyncMock()
+        mock_adapter = MagicMock()
+        mock_adapter.peer_id = "peer-1"
+        mock_adapter._mesh = mock_mesh
+        test_broker._mesh_adapter = mock_adapter
+
+        with patch.object(test_broker, "_git_diff_summary", return_value="diff content"):
+            await test_broker._publish_mesh_outcome()
+
+        call_args = mock_mesh.publish.call_args
+        event = call_args[0][0]
+        payload = event.payload
+
+        assert payload["workspace_path"] == test_broker.workspace_dir
+        assert payload["task_description"] == "Fix the login bug"
+        assert payload["diff_summary"] == "diff content"
+        assert payload["files_changed"] == ["/src/auth.py", "/src/login.py"]
+        assert "5 turns" in payload["summary"]
+        assert "2 files" in payload["summary"]
+
+    @pytest.mark.asyncio
+    async def test_no_mesh_adapter_returns_early(self, test_broker):
+        test_broker._mesh_adapter = None
+        # Should not raise
+        await test_broker._publish_mesh_outcome()
+
+    @pytest.mark.asyncio
+    async def test_payload_omits_empty_fields(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("SESSION_INITIAL_PROMPT", raising=False)
+        settings = SkuldSettings(
+            session={
+                "id": "test-mesh-empty",
+                "workspace_dir": str(tmp_path),
+                "initial_prompt": "",
+            },
+        )
+        b = Broker(settings=settings)
+        mock_mesh = AsyncMock()
+        mock_adapter = MagicMock()
+        mock_adapter.peer_id = "peer-2"
+        mock_adapter._mesh = mock_mesh
+        b._mesh_adapter = mock_adapter
+        b._room_bridge = None
+
+        with patch.object(b, "_git_diff_summary", return_value=""):
+            await b._publish_mesh_outcome()
+
+        event = mock_mesh.publish.call_args[0][0]
+        payload = event.payload
+        assert "task_description" not in payload
+        assert "diff_summary" not in payload
+        assert "files_changed" not in payload
 
 
 class TestReportChronicle:
@@ -2291,9 +2504,7 @@ class TestBrokerRoomBridge:
         b._room_bridge = mock_bridge
 
         mock_ws = AsyncMock()
-        mock_ws.receive_text = AsyncMock(
-            side_effect=["not valid json\n", WebSocketDisconnect()]
-        )
+        mock_ws.receive_text = AsyncMock(side_effect=["not valid json\n", WebSocketDisconnect()])
 
         await b.handle_ravn_websocket(mock_ws, "agent-1")
 

--- a/tests/test_skuld/test_broker.py
+++ b/tests/test_skuld/test_broker.py
@@ -1,5 +1,6 @@
 """Tests for Skuld broker service."""
 
+import asyncio
 import logging
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1061,7 +1062,8 @@ class TestGitDiffSummary:
         return Broker(settings=settings)
 
     @pytest.mark.asyncio
-    async def test_returns_diff_output(self, test_broker):
+    async def test_returns_committed_diff(self, test_broker):
+        """HEAD~1..HEAD is tried first and returned when non-empty."""
         diff_text = "diff --git a/main.py b/main.py\n+hello"
         mock_proc = AsyncMock()
         mock_proc.communicate = AsyncMock(return_value=(diff_text.encode(), b""))
@@ -1070,12 +1072,35 @@ class TestGitDiffSummary:
         assert "diff --git" in result
 
     @pytest.mark.asyncio
+    async def test_falls_back_to_uncommitted_diff(self, test_broker):
+        """When HEAD~1..HEAD is empty, falls back to diff HEAD."""
+        call_count = 0
+
+        async def mock_exec(*args, **kwargs):
+            nonlocal call_count
+            proc = AsyncMock()
+            if call_count == 0:
+                # HEAD~1..HEAD returns empty
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+            else:
+                # diff HEAD returns content
+                proc.communicate = AsyncMock(return_value=(b"diff --git uncommitted\n+new", b""))
+            call_count += 1
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=mock_exec):
+            result = await test_broker._git_diff_summary()
+        assert "uncommitted" in result
+        assert call_count == 2
+
+    @pytest.mark.asyncio
     async def test_truncates_large_diff(self, test_broker):
+        test_broker._settings.mesh.diff_max_bytes = 100
         diff_text = "x" * 10000
         mock_proc = AsyncMock()
         mock_proc.communicate = AsyncMock(return_value=(diff_text.encode(), b""))
         with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
-            result = await test_broker._git_diff_summary(max_bytes=100)
+            result = await test_broker._git_diff_summary()
         assert len(result) < 200
         assert "truncated" in result
 
@@ -1084,6 +1109,19 @@ class TestGitDiffSummary:
         with patch("asyncio.create_subprocess_exec", side_effect=OSError("no git")):
             result = await test_broker._git_diff_summary()
         assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_uses_config_timeout(self, test_broker):
+        """Timeout value comes from settings.mesh.diff_timeout_s."""
+        test_broker._settings.mesh.diff_timeout_s = 5.0
+        diff_text = "diff content"
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(diff_text.encode(), b""))
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            with patch("asyncio.wait_for", wraps=asyncio.wait_for) as mock_wait:
+                result = await test_broker._git_diff_summary()
+                assert mock_wait.call_args[1]["timeout"] == 5.0
+        assert result == "diff content"
 
 
 class TestPublishMeshOutcome:


### PR DESCRIPTION
## Summary

- **Fix `files_changed` tracking**: `SessionArtifacts.record_tool_use` now handles the SDK WebSocket message format (`message.content`) in addition to the HTTP streaming format (`content`), fixing the bug where `files_changed` was always `0`
- **Enrich `code.changed` event payload**: adds `workspace_path`, `task_description` (from initial prompt), `diff_summary` (truncated `git diff HEAD`), and `files_changed` so the reviewer has actionable context
- **Enrich reviewer initiative context**: `FanInBuffer._format_single_event` now formats all enriched fields (task description, workspace path, file list, git diff, outcome) into the context string passed to downstream personas

## Test plan

- [x] New tests for `record_tool_use` with SDK message format (3 tests)
- [x] New tests for `_git_diff_summary` (3 tests: normal, truncation, error)
- [x] New tests for `_publish_mesh_outcome` enriched payload (3 tests)
- [x] New tests for `_format_single_event` enriched formatting (8 tests)
- [x] All 184 existing broker + fan-in tests still pass
- [x] `ruff check` and `ruff format` clean

Closes NIU-626

🤖 Generated with [Claude Code](https://claude.com/claude-code)