### PR TITLE
refactor(adapters): NIU-629 — dynamic adapter pattern for sleipnir transport

### DIFF
--- a/src/ravn/cli/commands.py
+++ b/src/ravn/cli/commands.py
@@ -2782,81 +2782,76 @@ def _read_cluster_pub_addresses(settings: Settings) -> list[str]:
     return addresses
 
 
+_TRANSPORT_ALIASES: dict[str, str] = {
+    "nng": "sleipnir.adapters.nng_transport.NngTransport",
+    "sleipnir": "sleipnir.adapters.rabbitmq.RabbitMQTransport",
+    "rabbitmq": "sleipnir.adapters.rabbitmq.RabbitMQTransport",
+    "nats": "sleipnir.adapters.nats_transport.NatsTransport",
+    "redis": "sleipnir.adapters.redis_streams.RedisStreamsTransport",
+    "in_process": "sleipnir.adapters.in_process.InProcessBus",
+}
+
+
+def _resolve_transport_kwargs(
+    settings: Settings,
+    adapter: str,
+) -> dict[str, Any]:
+    """Build constructor kwargs for a Sleipnir transport from settings."""
+    import os
+
+    if adapter == "nng":
+        nng_cfg = settings.mesh.nng
+        peer_addresses = _read_cluster_pub_addresses(settings)
+        return {
+            "address": nng_cfg.pub_sub_address,
+            "service_id": f"ravn:{settings.mesh.own_peer_id}",
+            "peer_addresses": peer_addresses or None,
+        }
+
+    if adapter in ("sleipnir", "rabbitmq"):
+        amqp_url = os.environ.get(settings.sleipnir.amqp_url_env, "")
+        if not amqp_url:
+            logger.warning(
+                "mesh: %s not set, rabbitmq transport unavailable",
+                settings.sleipnir.amqp_url_env,
+            )
+            return {}
+        return {"amqp_url": amqp_url}
+
+    if adapter == "nats":
+        nats_url = os.environ.get("NATS_URL", "nats://localhost:4222")
+        return {"servers": [nats_url]}
+
+    if adapter == "redis":
+        redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379")
+        return {"redis_url": redis_url}
+
+    return {}
+
+
 def _build_sleipnir_transport(
     settings: Settings,
     adapter: str,
     discovery: Any = None,
 ) -> Any:
-    """Build the Sleipnir transport based on adapter config."""
-    if adapter == "nng":
-        try:
-            from sleipnir.adapters.nng_transport import NngTransport
+    """Build the Sleipnir transport using the dynamic adapter pattern."""
+    fq_class = _TRANSPORT_ALIASES.get(adapter, adapter)
 
-            nng_cfg = settings.mesh.nng
-            service_id = f"ravn:{settings.mesh.own_peer_id}"
+    try:
+        cls = _import_class(fq_class)
+    except Exception as exc:
+        logger.warning("mesh: failed to import transport %s: %s", fq_class, exc)
+        return None
 
-            # Read peer pub addresses from cluster.yaml so the NNG subscriber
-            # dials them on startup (discovery.peers() loads async — too late).
-            peer_addresses = _read_cluster_pub_addresses(settings)
+    kwargs = _resolve_transport_kwargs(settings, adapter)
+    if adapter in ("sleipnir", "rabbitmq") and not kwargs:
+        return None
 
-            return NngTransport(
-                address=nng_cfg.pub_sub_address,
-                service_id=service_id,
-                peer_addresses=peer_addresses or None,
-            )
-        except ImportError:
-            logger.warning("mesh: pynng not installed, nng transport unavailable")
-            return None
-
-    if adapter in ("sleipnir", "rabbitmq"):
-        try:
-            import os
-
-            from sleipnir.adapters.rabbitmq import RabbitMQTransport
-
-            amqp_url = os.environ.get(settings.sleipnir.amqp_url_env, "")
-            if not amqp_url:
-                logger.warning(
-                    "mesh: %s not set, rabbitmq transport unavailable",
-                    settings.sleipnir.amqp_url_env,
-                )
-                return None
-            return RabbitMQTransport(amqp_url=amqp_url)
-        except ImportError:
-            logger.warning("mesh: aio_pika not installed, rabbitmq transport unavailable")
-            return None
-
-    if adapter == "nats":
-        try:
-            import os
-
-            from sleipnir.adapters.nats_transport import NatsTransport
-
-            nats_url = os.environ.get("NATS_URL", "nats://localhost:4222")
-            return NatsTransport(servers=[nats_url])
-        except ImportError:
-            logger.warning("mesh: nats-py not installed, nats transport unavailable")
-            return None
-
-    if adapter == "redis":
-        try:
-            import os
-
-            from sleipnir.adapters.redis_streams import RedisStreamsTransport
-
-            redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379")
-            return RedisStreamsTransport(redis_url=redis_url)
-        except ImportError:
-            logger.warning("mesh: redis not installed, redis transport unavailable")
-            return None
-
-    if adapter == "in_process":
-        from sleipnir.adapters.in_process import InProcessBus
-
-        return InProcessBus()
-
-    logger.warning("mesh: unknown adapter %r", adapter)
-    return None
+    try:
+        return cls(**kwargs)
+    except Exception as exc:
+        logger.warning("mesh: failed to instantiate transport %s: %s", fq_class, exc)
+        return None
 
 
 def _build_discovery(

--- a/src/ravn/cli/commands.py
+++ b/src/ravn/cli/commands.py
@@ -2797,8 +2797,6 @@ def _resolve_transport_kwargs(
     adapter: str,
 ) -> dict[str, Any]:
     """Build constructor kwargs for a Sleipnir transport from settings."""
-    import os
-
     if adapter == "nng":
         nng_cfg = settings.mesh.nng
         peer_addresses = _read_cluster_pub_addresses(settings)

--- a/tests/test_ravn/test_build_sleipnir_transport.py
+++ b/tests/test_ravn/test_build_sleipnir_transport.py
@@ -1,0 +1,188 @@
+"""Tests for _build_sleipnir_transport dynamic adapter pattern (NIU-629)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from ravn.cli.commands import (
+    _TRANSPORT_ALIASES,
+    _build_sleipnir_transport,
+    _resolve_transport_kwargs,
+)
+from ravn.config import Settings
+
+
+def _make_settings(**overrides: Any) -> Settings:
+    """Create a minimal Settings with sensible defaults for transport tests."""
+    s = Settings()
+    # Wire up mesh.nng defaults
+    s.mesh.nng.pub_sub_address = "ipc:///tmp/test.ipc"
+    s.mesh.own_peer_id = "test-peer"
+    for key, val in overrides.items():
+        parts = key.split(".")
+        obj = s
+        for part in parts[:-1]:
+            obj = getattr(obj, part)
+        setattr(obj, parts[-1], val)
+    return s
+
+
+class TestTransportAliases:
+    """Verify the alias map covers all known transport short names."""
+
+    def test_all_short_names_present(self):
+        expected = {"nng", "sleipnir", "rabbitmq", "nats", "redis", "in_process"}
+        assert set(_TRANSPORT_ALIASES.keys()) == expected
+
+    def test_aliases_are_fully_qualified(self):
+        for alias, fq in _TRANSPORT_ALIASES.items():
+            parts = fq.rsplit(".", 1)
+            assert len(parts) == 2, f"alias {alias!r} is not a dotted class path"
+
+    def test_sleipnir_and_rabbitmq_resolve_to_same_class(self):
+        assert _TRANSPORT_ALIASES["sleipnir"] == _TRANSPORT_ALIASES["rabbitmq"]
+
+
+class TestResolveTransportKwargs:
+    """Verify _resolve_transport_kwargs returns correct kwargs per adapter."""
+
+    def test_nng_kwargs(self):
+        settings = _make_settings()
+        kwargs = _resolve_transport_kwargs(settings, "nng")
+        assert kwargs["address"] == "ipc:///tmp/test.ipc"
+        assert kwargs["service_id"] == "ravn:test-peer"
+        assert "peer_addresses" in kwargs
+
+    def test_rabbitmq_kwargs_with_env(self):
+        settings = _make_settings()
+        with patch.dict("os.environ", {"SLEIPNIR_AMQP_URL": "amqp://host"}):
+            kwargs = _resolve_transport_kwargs(settings, "rabbitmq")
+        assert kwargs == {"amqp_url": "amqp://host"}
+
+    def test_rabbitmq_kwargs_empty_when_env_missing(self):
+        settings = _make_settings()
+        with patch.dict("os.environ", {}, clear=True):
+            kwargs = _resolve_transport_kwargs(settings, "rabbitmq")
+        assert kwargs == {}
+
+    def test_sleipnir_alias_same_as_rabbitmq(self):
+        settings = _make_settings()
+        with patch.dict("os.environ", {"SLEIPNIR_AMQP_URL": "amqp://host"}):
+            kwargs = _resolve_transport_kwargs(settings, "sleipnir")
+        assert kwargs == {"amqp_url": "amqp://host"}
+
+    def test_nats_kwargs(self):
+        settings = _make_settings()
+        with patch.dict("os.environ", {"NATS_URL": "nats://custom:4222"}):
+            kwargs = _resolve_transport_kwargs(settings, "nats")
+        assert kwargs == {"servers": ["nats://custom:4222"]}
+
+    def test_nats_kwargs_default(self):
+        settings = _make_settings()
+        with patch.dict("os.environ", {}, clear=True):
+            kwargs = _resolve_transport_kwargs(settings, "nats")
+        assert kwargs == {"servers": ["nats://localhost:4222"]}
+
+    def test_redis_kwargs(self):
+        settings = _make_settings()
+        with patch.dict("os.environ", {"REDIS_URL": "redis://custom:6379"}):
+            kwargs = _resolve_transport_kwargs(settings, "redis")
+        assert kwargs == {"redis_url": "redis://custom:6379"}
+
+    def test_redis_kwargs_default(self):
+        settings = _make_settings()
+        with patch.dict("os.environ", {}, clear=True):
+            kwargs = _resolve_transport_kwargs(settings, "redis")
+        assert kwargs == {"redis_url": "redis://localhost:6379"}
+
+    def test_in_process_kwargs_empty(self):
+        settings = _make_settings()
+        kwargs = _resolve_transport_kwargs(settings, "in_process")
+        assert kwargs == {}
+
+    def test_unknown_adapter_returns_empty(self):
+        settings = _make_settings()
+        kwargs = _resolve_transport_kwargs(settings, "unknown_thing")
+        assert kwargs == {}
+
+
+class TestBuildSleipnirTransport:
+    """Verify _build_sleipnir_transport uses dynamic import via _import_class."""
+
+    def test_uses_import_class_for_known_alias(self):
+        settings = _make_settings()
+        mock_cls = MagicMock(return_value=MagicMock())
+        with patch("ravn.cli.commands._import_class", return_value=mock_cls) as imp:
+            result = _build_sleipnir_transport(settings, "nng")
+
+        imp.assert_called_once_with("sleipnir.adapters.nng_transport.NngTransport")
+        assert result is mock_cls.return_value
+
+    def test_uses_import_class_for_fq_path(self):
+        """A fully-qualified class path bypasses the alias map."""
+        settings = _make_settings()
+        mock_cls = MagicMock(return_value=MagicMock())
+        fq = "my.custom.transport.CustomTransport"
+        with patch("ravn.cli.commands._import_class", return_value=mock_cls) as imp:
+            result = _build_sleipnir_transport(settings, fq)
+
+        imp.assert_called_once_with(fq)
+        assert result is mock_cls.return_value
+
+    def test_returns_none_on_import_error(self):
+        settings = _make_settings()
+        with patch(
+            "ravn.cli.commands._import_class",
+            side_effect=ImportError("no module"),
+        ):
+            result = _build_sleipnir_transport(settings, "nng")
+        assert result is None
+
+    def test_returns_none_on_instantiation_error(self):
+        settings = _make_settings()
+        mock_cls = MagicMock(side_effect=RuntimeError("bad init"))
+        with patch("ravn.cli.commands._import_class", return_value=mock_cls):
+            result = _build_sleipnir_transport(settings, "nng")
+        assert result is None
+
+    def test_rabbitmq_returns_none_when_env_missing(self):
+        settings = _make_settings()
+        mock_cls = MagicMock(return_value=MagicMock())
+        with patch("ravn.cli.commands._import_class", return_value=mock_cls):
+            with patch.dict("os.environ", {}, clear=True):
+                result = _build_sleipnir_transport(settings, "rabbitmq")
+        assert result is None
+        mock_cls.assert_not_called()
+
+    def test_rabbitmq_returns_transport_when_env_set(self):
+        settings = _make_settings()
+        mock_cls = MagicMock(return_value=MagicMock())
+        with patch("ravn.cli.commands._import_class", return_value=mock_cls):
+            with patch.dict("os.environ", {"SLEIPNIR_AMQP_URL": "amqp://host"}):
+                result = _build_sleipnir_transport(settings, "rabbitmq")
+        assert result is mock_cls.return_value
+        mock_cls.assert_called_once_with(amqp_url="amqp://host")
+
+    def test_in_process_instantiated_with_no_args(self):
+        settings = _make_settings()
+        mock_cls = MagicMock(return_value=MagicMock())
+        with patch("ravn.cli.commands._import_class", return_value=mock_cls):
+            result = _build_sleipnir_transport(settings, "in_process")
+        assert result is mock_cls.return_value
+        mock_cls.assert_called_once_with()
+
+    def test_nng_passes_correct_kwargs(self):
+        settings = _make_settings()
+        mock_cls = MagicMock(return_value=MagicMock())
+        with patch("ravn.cli.commands._import_class", return_value=mock_cls):
+            with patch(
+                "ravn.cli.commands._read_cluster_pub_addresses",
+                return_value=["tcp://peer1:7480"],
+            ):
+                _build_sleipnir_transport(settings, "nng")
+        mock_cls.assert_called_once_with(
+            address="ipc:///tmp/test.ipc",
+            service_id="ravn:test-peer",
+            peer_addresses=["tcp://peer1:7480"],
+        )

--- a/tests/test_ravn/test_fan_in_buffer.py
+++ b/tests/test_ravn/test_fan_in_buffer.py
@@ -1,10 +1,6 @@
 """Unit tests for the FanInBuffer in drive_loop.py."""
 
-from datetime import UTC, datetime, timedelta
-
-import pytest
-
-from ravn.drive_loop import FanInBuffer, _FanInResult
+from ravn.drive_loop import FanInBuffer
 
 
 class TestMergeStrategy:


### PR DESCRIPTION
## Summary

- Replaced hardcoded `try: from ... import` blocks in `_build_sleipnir_transport` with the dynamic adapter pattern (`_import_class()` + `_TRANSPORT_ALIASES` lookup table), matching the pattern used by mesh adapters, discovery adapters, and all other dynamic adapter instantiation in the codebase.
- Extracted kwargs-building logic into `_resolve_transport_kwargs()` for clarity and testability.
- Added 21 unit tests covering alias resolution, kwargs building, dynamic import, error handling, and full-qualified class path passthrough.

## Why

`_build_sleipnir_transport` was the last holdout using imperative `try/import` chains. This broke the extensibility contract — adding a new transport adapter required code changes instead of just config. Now a new transport can be added by writing the class and referencing it via fully-qualified path in config, with zero code changes elsewhere.

## Test plan

- [x] All 21 new tests pass (`tests/test_ravn/test_build_sleipnir_transport.py`)
- [x] `ruff check` and `ruff format` clean
- [x] Full test suite: no new failures (33 pre-existing failures unrelated to this change)
- [x] Verified pre-existing failures exist on parent branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes NIU-629