### PR TITLE
feat(adapters): NIU-624 — Sleipnir as single event backbone for room bridge + mesh

### DIFF
--- a/src/ravn/adapters/mesh/sleipnir_mesh.py
+++ b/src/ravn/adapters/mesh/sleipnir_mesh.py
@@ -21,13 +21,12 @@ import logging
 import uuid
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from ravn.domain.events import RavnEvent, RavnEventType
 from ravn.ports.mesh import PeerNotFoundError
 
-if TYPE_CHECKING:
-    from sleipnir.ports.events import SleipnirPublisher, SleipnirSubscriber, Subscription
+from sleipnir.ports.events import SleipnirPublisher, SleipnirSubscriber, Subscription
 
 logger = logging.getLogger(__name__)
 
@@ -281,6 +280,11 @@ class SleipnirMeshAdapter:
             await self._subscriber.stop()
 
         logger.info("sleipnir_mesh: stopped peer=%s", self._own_peer_id)
+
+    @property
+    def subscriber(self) -> SleipnirSubscriber:
+        """Expose the underlying Sleipnir subscriber port."""
+        return self._subscriber
 
     def set_rpc_handler(self, handler: Callable[[dict], Awaitable[dict]]) -> None:
         """Register handler for incoming RPC requests."""

--- a/src/ravn/adapters/mesh/sleipnir_mesh.py
+++ b/src/ravn/adapters/mesh/sleipnir_mesh.py
@@ -25,7 +25,6 @@ from typing import Any
 
 from ravn.domain.events import RavnEvent, RavnEventType
 from ravn.ports.mesh import PeerNotFoundError
-
 from sleipnir.ports.events import SleipnirPublisher, SleipnirSubscriber, Subscription
 
 logger = logging.getLogger(__name__)

--- a/src/skuld/broker.py
+++ b/src/skuld/broker.py
@@ -606,18 +606,27 @@ class Broker:
             # Start room mesh bridge so outcomes from any mesh peer flow to the
             # room UI via Sleipnir — eliminates the dual-publish pattern.
             if self._room_bridge is not None:
-                sleipnir_subscriber = getattr(
-                    self._mesh_adapter._mesh, "_subscriber", None
-                )
+                from sleipnir.ports.events import SleipnirSubscriber
+
+                sleipnir_subscriber = self._mesh_adapter.sleipnir_subscriber
                 if sleipnir_subscriber is None:
-                    sleipnir_subscriber = self._sleipnir_publisher
-                self._room_mesh_bridge = RoomMeshBridge(
-                    subscriber=sleipnir_subscriber,
-                    room_bridge=self._room_bridge,
-                    session_id=self.session_id,
-                )
-                await self._room_mesh_bridge.start()
-                logger.info("RoomMeshBridge started (session_id=%s)", self.session_id)
+                    # Fallback: InProcessBus implements both Publisher and Subscriber.
+                    # Only use it if it actually satisfies the Subscriber interface.
+                    if isinstance(self._sleipnir_publisher, SleipnirSubscriber):
+                        sleipnir_subscriber = self._sleipnir_publisher
+                    else:
+                        logger.warning(
+                            "Sleipnir publisher does not implement SleipnirSubscriber"
+                            " — RoomMeshBridge disabled"
+                        )
+                if sleipnir_subscriber is not None:
+                    self._room_mesh_bridge = RoomMeshBridge(
+                        subscriber=sleipnir_subscriber,
+                        room_bridge=self._room_bridge,
+                        session_id=self.session_id,
+                    )
+                    await self._room_mesh_bridge.start()
+                    logger.info("RoomMeshBridge started (session_id=%s)", self.session_id)
 
         except Exception as exc:
             logger.error("Mesh adapter start failed: %r", exc, exc_info=True)

--- a/src/skuld/broker.py
+++ b/src/skuld/broker.py
@@ -40,6 +40,7 @@ from skuld.channels import (
 from skuld.chronicle_watcher import ChronicleWatcher
 from skuld.config import SkuldSettings
 from skuld.room_bridge import RoomBridge
+from skuld.room_mesh_bridge import RoomMeshBridge
 from skuld.service_manager import (
     ServiceCreateRequest,
     ServiceManager,
@@ -462,6 +463,10 @@ class Broker:
         # Mesh adapter — only active when mesh.enabled is True
         self._mesh_adapter: Any = None
 
+        # Room mesh bridge — translates ravn.mesh.* Sleipnir events to room wire events.
+        # Active when both mesh.enabled and room.enabled are True.
+        self._room_mesh_bridge: RoomMeshBridge | None = None
+
         # Room bridge — only active when room.enabled is True
         self._room_bridge: RoomBridge | None = (
             RoomBridge(
@@ -597,6 +602,22 @@ class Broker:
                         display_name=peer.persona,
                         subscribes_to=list(getattr(peer, "capabilities", [])),
                     )
+
+            # Start room mesh bridge so outcomes from any mesh peer flow to the
+            # room UI via Sleipnir — eliminates the dual-publish pattern.
+            if self._room_bridge is not None:
+                sleipnir_subscriber = getattr(
+                    self._mesh_adapter._mesh, "_subscriber", None
+                )
+                if sleipnir_subscriber is None:
+                    sleipnir_subscriber = self._sleipnir_publisher
+                self._room_mesh_bridge = RoomMeshBridge(
+                    subscriber=sleipnir_subscriber,
+                    room_bridge=self._room_bridge,
+                    session_id=self.session_id,
+                )
+                await self._room_mesh_bridge.start()
+                logger.info("RoomMeshBridge started (session_id=%s)", self.session_id)
 
         except Exception as exc:
             logger.error("Mesh adapter start failed: %r", exc, exc_info=True)
@@ -801,6 +822,11 @@ class Broker:
 
         # Report chronicle BEFORE stopping the transport (CLI must be alive)
         await self._report_chronicle()
+
+        # Stop room mesh bridge before mesh adapter
+        if self._room_mesh_bridge is not None:
+            await self._room_mesh_bridge.stop()
+            self._room_mesh_bridge = None
 
         # Stop mesh adapter before transport (deregister from discovery)
         if self._mesh_adapter is not None:
@@ -1693,24 +1719,8 @@ class Broker:
                 self._mesh_adapter.peer_id,
                 len(self._artifacts.files_changed),
             )
-
-            # Broadcast outcome to browser via room bridge
-            if self._room_bridge is not None:
-                from dataclasses import asdict
-
-                meta = self._room_bridge._participants.get(self._mesh_adapter.peer_id)
-                if meta is not None:
-                    await self._channels.broadcast(
-                        {
-                            "type": "room_outcome",
-                            "participantId": meta.peer_id,
-                            "participant": asdict(meta),
-                            "persona": meta.persona,
-                            "eventType": "code.changed",
-                            "fields": outcome_payload,
-                            "summary": outcome_payload.get("summary", ""),
-                        }
-                    )
+            # Room UI receives this via RoomMeshBridge subscribing to
+            # ravn.mesh.* — no separate broadcast needed here.
 
         except Exception:
             logger.warning("Mesh: failed to publish code.changed", exc_info=True)

--- a/src/skuld/mesh_adapter.py
+++ b/src/skuld/mesh_adapter.py
@@ -20,6 +20,8 @@ from ravn.ports.mesh import MeshPort
 from skuld.config import MeshConfig
 from skuld.transports import CLITransport
 
+from sleipnir.ports.events import SleipnirSubscriber
+
 logger = logging.getLogger("skuld.mesh_adapter")
 
 
@@ -56,6 +58,15 @@ class SkuldMeshAdapter:
     @property
     def is_running(self) -> bool:
         return self._running
+
+    @property
+    def sleipnir_subscriber(self) -> SleipnirSubscriber | None:
+        """Expose the Sleipnir subscriber from the underlying mesh transport.
+
+        Returns None when the mesh is not a SleipnirMeshAdapter (e.g. in-process
+        test mesh that has no dedicated subscriber port).
+        """
+        return getattr(self._mesh, "subscriber", None)
 
     async def start(self) -> None:
         """Register with discovery and subscribe to task topics."""

--- a/src/skuld/mesh_adapter.py
+++ b/src/skuld/mesh_adapter.py
@@ -19,7 +19,6 @@ from ravn.domain.events import RavnEvent, RavnEventType
 from ravn.ports.mesh import MeshPort
 from skuld.config import MeshConfig
 from skuld.transports import CLITransport
-
 from sleipnir.ports.events import SleipnirSubscriber
 
 logger = logging.getLogger("skuld.mesh_adapter")

--- a/src/skuld/room_bridge.py
+++ b/src/skuld/room_bridge.py
@@ -470,3 +470,7 @@ class RoomBridge:
     def participants(self) -> dict[str, ParticipantMeta]:
         """Snapshot of current participants (copy)."""
         return dict(self._participants)
+
+    def has_participant(self, peer_id: str) -> bool:
+        """Return True if *peer_id* is already a registered participant."""
+        return peer_id in self._participants

--- a/src/skuld/room_mesh_bridge.py
+++ b/src/skuld/room_mesh_bridge.py
@@ -1,0 +1,265 @@
+"""RoomMeshBridge — Sleipnir mesh subscriber that feeds room wire events.
+
+Subscribes to ``ravn.mesh.*`` Sleipnir events so that outcomes from any mesh
+peer (Skuld coder, reviewer, security scanner, …) flow into the room UI
+without the publisher needing to broadcast them separately.
+
+Architecture
+------------
+Before NIU-624 the broker had a dual-publish pattern:
+
+    mesh.publish(outcome_event, "code.changed")   # → other ravens
+    channels.broadcast(room_outcome)              # → browser (manual copy)
+
+After NIU-624 the broker publishes once to the mesh, and this bridge
+translates the resulting ``ravn.mesh.*`` Sleipnir events into room wire
+events:
+
+    mesh.publish(outcome_event, "code.changed")
+        ↓  (via Sleipnir)
+    RoomMeshBridge._handle_event()
+        ↓
+    RoomBridge._handle_outcome_frame()  /  _handle_activity_frame()
+        ↓
+    ChannelRegistry.broadcast()  →  browser WebSocket
+
+Session filtering
+-----------------
+When *session_id* is set, only events whose ``correlation_id`` or
+``payload["ravn_session_id"]`` match are forwarded.  Pass ``None`` to
+receive all mesh events (useful in shared-bus deployments).
+
+Multiple Skuld support
+-----------------------
+Each Skuld instance is a distinct mesh peer.  The bridge auto-registers
+unknown peers as room participants via
+:meth:`~skuld.room_bridge.RoomBridge.register_mesh_peer` when their first
+event arrives, so the browser learns about them without any extra wiring.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from sleipnir.domain.events import SleipnirEvent
+from sleipnir.ports.events import SleipnirSubscriber, Subscription
+
+if TYPE_CHECKING:
+    from skuld.room_bridge import RoomBridge
+
+logger = logging.getLogger(__name__)
+
+#: Sleipnir event-type patterns this bridge subscribes to.
+MESH_PATTERNS: list[str] = ["ravn.mesh.*"]
+
+#: RavnEventType string fragments → room activity type.
+_RAVN_TYPE_TO_ACTIVITY: dict[str, str] = {
+    "TOOL_START": "tool_executing",
+    "TOOL_RESULT": "idle",
+    "THOUGHT": "thinking",
+}
+
+
+def _extract_peer_id(event: SleipnirEvent) -> str:
+    """Return the originating peer_id from a mesh Sleipnir event.
+
+    Tries ``payload["ravn_source"]`` first (set by :func:`_ravn_to_sleipnir`),
+    then falls back to stripping the ``"ravn:"`` / ``"skuld:"`` prefix from
+    the ``source`` field.
+    """
+    ravn_source = event.payload.get("ravn_source", "")
+    if ravn_source:
+        # ravn_source may already be a plain peer_id or "<prefix>:<peer_id>"
+        if ":" in ravn_source:
+            return ravn_source.split(":", 1)[1]
+        return ravn_source
+
+    source = event.source or ""
+    if ":" in source:
+        return source.split(":", 1)[1]
+    return source
+
+
+def _extract_persona(event: SleipnirEvent, peer_id: str) -> str:
+    """Return the best persona name for a peer from the event payload."""
+    ravn_event = event.payload.get("ravn_event", {})
+    return ravn_event.get("persona", peer_id)
+
+
+class RoomMeshBridge:
+    """Subscribes to Sleipnir mesh events and translates them to room wire events.
+
+    This makes the room the single downstream consumer of all mesh activity.
+    Any peer that publishes to the mesh (regardless of transport) will have
+    its events appear in the browser room UI automatically.
+
+    Lifecycle::
+
+        bridge = RoomMeshBridge(subscriber, room_bridge, session_id="abc")
+        await bridge.start()   # subscribes to ravn.mesh.*
+        # … events translated and broadcast …
+        await bridge.stop()    # unsubscribes
+
+    Also usable as an async context manager::
+
+        async with RoomMeshBridge(subscriber, room_bridge, session_id="abc"):
+            ...
+    """
+
+    def __init__(
+        self,
+        subscriber: SleipnirSubscriber,
+        room_bridge: RoomBridge,
+        session_id: str | None = None,
+        patterns: list[str] | None = None,
+    ) -> None:
+        self._subscriber = subscriber
+        self._room_bridge = room_bridge
+        self._session_id = session_id
+        self._patterns = patterns if patterns is not None else list(MESH_PATTERNS)
+        self._subscription: Subscription | None = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Subscribe to mesh event patterns and begin bridging."""
+        if self._subscription is not None:
+            logger.warning("RoomMeshBridge.start() called while already running — ignored")
+            return
+        self._subscription = await self._subscriber.subscribe(
+            self._patterns,
+            self._handle_event,
+        )
+        logger.info(
+            "RoomMeshBridge started: session_id=%s, patterns=%s",
+            self._session_id,
+            self._patterns,
+        )
+
+    async def stop(self) -> None:
+        """Unsubscribe and release resources."""
+        if self._subscription is None:
+            return
+        await self._subscription.unsubscribe()
+        self._subscription = None
+        logger.info("RoomMeshBridge stopped: session_id=%s", self._session_id)
+
+    async def __aenter__(self) -> RoomMeshBridge:
+        await self.start()
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        await self.stop()
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    async def _handle_event(self, event: SleipnirEvent) -> None:
+        """Translate a single mesh Sleipnir event into room wire events."""
+        if not self._matches_session(event):
+            return
+
+        peer_id = _extract_peer_id(event)
+        if not peer_id:
+            logger.debug("RoomMeshBridge: cannot determine peer_id for event %s", event.event_type)
+            return
+
+        await self._ensure_peer_registered(event, peer_id)
+
+        ravn_type = event.payload.get("ravn_type", "")
+        ravn_event_payload = event.payload.get("ravn_event", {})
+
+        # Mesh topic derived from event_type: "ravn.mesh.<topic>"
+        parts = event.event_type.split(".", 2)
+        mesh_topic = parts[2] if len(parts) == 3 else ""
+
+        if "OUTCOME" in ravn_type:
+            await self._translate_outcome(peer_id, mesh_topic, ravn_event_payload)
+            return
+
+        activity_type = self._ravn_type_to_activity(ravn_type)
+        if activity_type:
+            await self._translate_activity(peer_id, activity_type, ravn_event_payload)
+
+    def _matches_session(self, event: SleipnirEvent) -> bool:
+        """Return True if the event belongs to this bridge's session context."""
+        if self._session_id is None:
+            return True
+
+        if event.correlation_id == self._session_id:
+            return True
+
+        if event.payload.get("ravn_session_id") == self._session_id:
+            return True
+
+        return False
+
+    async def _ensure_peer_registered(self, event: SleipnirEvent, peer_id: str) -> None:
+        """Auto-register *peer_id* as a mesh participant if not already known."""
+        if peer_id in self._room_bridge.participants:
+            return
+
+        persona = _extract_persona(event, peer_id)
+        await self._room_bridge.register_mesh_peer(
+            peer_id=peer_id,
+            persona=persona,
+            display_name=persona,
+        )
+        logger.info("RoomMeshBridge: auto-registered peer_id=%s persona=%s", peer_id, persona)
+
+    async def _translate_outcome(
+        self,
+        peer_id: str,
+        mesh_topic: str,
+        ravn_event_payload: dict,
+    ) -> None:
+        """Translate an OUTCOME mesh event into a ``room_outcome`` wire event."""
+        # Build a frame in the shape that RoomBridge.handle_ravn_frame() expects
+        frame: dict = {
+            "type": "outcome",
+            "data": ravn_event_payload,
+            "metadata": {
+                "event_type": ravn_event_payload.get("event_type", mesh_topic),
+            },
+        }
+        await self._room_bridge.handle_ravn_frame(peer_id, frame)
+
+    async def _translate_activity(
+        self,
+        peer_id: str,
+        activity_type: str,
+        ravn_event_payload: dict,
+    ) -> None:
+        """Translate a tool/thought mesh event into a ``room_activity`` wire event."""
+        frame: dict = {
+            "type": activity_type.replace("_executing", "_start")
+            if activity_type == "tool_executing"
+            else activity_type,
+            "data": ravn_event_payload.get("detail", ""),
+        }
+        # Map activity strings back to NDJSON frame types for handle_ravn_frame
+        ravn_frame_type = _ACTIVITY_TO_FRAME_TYPE.get(activity_type, "")
+        if ravn_frame_type:
+            frame["type"] = ravn_frame_type
+        await self._room_bridge.handle_ravn_frame(peer_id, frame)
+
+    @staticmethod
+    def _ravn_type_to_activity(ravn_type: str) -> str:
+        """Map a RavnEventType string to a room activity type, or '' if unknown."""
+        for fragment, activity in _RAVN_TYPE_TO_ACTIVITY.items():
+            if fragment in ravn_type:
+                return activity
+        return ""
+
+
+#: Maps room activity types back to the NDJSON frame type names that
+#: RoomBridge.handle_ravn_frame() understands.
+_ACTIVITY_TO_FRAME_TYPE: dict[str, str] = {
+    "tool_executing": "tool_start",
+    "idle": "tool_result",
+    "thinking": "thought",
+}

--- a/src/skuld/room_mesh_bridge.py
+++ b/src/skuld/room_mesh_bridge.py
@@ -200,7 +200,7 @@ class RoomMeshBridge:
 
     async def _ensure_peer_registered(self, event: SleipnirEvent, peer_id: str) -> None:
         """Auto-register *peer_id* as a mesh participant if not already known."""
-        if peer_id in self._room_bridge.participants:
+        if self._room_bridge.has_participant(peer_id):
             return
 
         persona = _extract_persona(event, peer_id)
@@ -235,16 +235,10 @@ class RoomMeshBridge:
         ravn_event_payload: dict,
     ) -> None:
         """Translate a tool/thought mesh event into a ``room_activity`` wire event."""
-        frame: dict = {
-            "type": activity_type.replace("_executing", "_start")
-            if activity_type == "tool_executing"
-            else activity_type,
-            "data": ravn_event_payload.get("detail", ""),
-        }
-        # Map activity strings back to NDJSON frame types for handle_ravn_frame
-        ravn_frame_type = _ACTIVITY_TO_FRAME_TYPE.get(activity_type, "")
-        if ravn_frame_type:
-            frame["type"] = ravn_frame_type
+        ravn_frame_type = _ACTIVITY_TO_FRAME_TYPE.get(activity_type)
+        if not ravn_frame_type:
+            return
+        frame = {"type": ravn_frame_type, "data": ravn_event_payload.get("detail", "")}
         await self._room_bridge.handle_ravn_frame(peer_id, frame)
 
     @staticmethod

--- a/tests/test_skuld/test_room_mesh_bridge.py
+++ b/tests/test_skuld/test_room_mesh_bridge.py
@@ -1,0 +1,545 @@
+"""Unit tests for skuld.room_mesh_bridge.RoomMeshBridge.
+
+Covers:
+- Lifecycle (start / stop / context manager / idempotent calls)
+- Session filtering (correlation_id and ravn_session_id)
+- OUTCOME events → room_outcome via RoomBridge
+- Non-OUTCOME events → room_activity via RoomBridge
+- Auto-registration of unknown mesh peers
+- _extract_peer_id and _extract_persona helpers
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from skuld.room_mesh_bridge import (
+    MESH_PATTERNS,
+    RoomMeshBridge,
+    _extract_peer_id,
+    _extract_persona,
+)
+from sleipnir.adapters.in_process import InProcessBus
+from sleipnir.domain.events import SleipnirEvent
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_TS = datetime(2026, 4, 17, 10, 0, 0, tzinfo=UTC)
+
+
+def _make_event(**kwargs) -> SleipnirEvent:
+    defaults: dict = dict(
+        event_type="ravn.mesh.code.changed",
+        source="ravn:skuld-01",
+        payload={
+            "ravn_event": {
+                "event_type": "code.changed",
+                "persona": "coder",
+                "source_peer_id": "skuld-01",
+                "output": "done",
+            },
+            "ravn_type": "RavnEventType.OUTCOME",
+            "ravn_source": "skuld-01",
+            "ravn_urgency": 0.8,
+            "ravn_session_id": "sess-abc",
+            "ravn_task_id": None,
+        },
+        summary="Mesh event: code.changed",
+        urgency=0.8,
+        domain="code",
+        timestamp=_TS,
+        correlation_id="sess-abc",
+    )
+    defaults.update(kwargs)
+    return SleipnirEvent(**defaults)
+
+
+def _make_room_bridge(known_peers: list[str] | None = None) -> MagicMock:
+    """Return a mock RoomBridge."""
+    bridge = MagicMock()
+    bridge.handle_ravn_frame = AsyncMock()
+    bridge.register_mesh_peer = AsyncMock()
+    # Participants dict: peer_id → meta
+    bridge.participants = {pid: MagicMock(peer_id=pid) for pid in (known_peers or [])}
+    return bridge
+
+
+# ---------------------------------------------------------------------------
+# Helper function tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPeerId:
+    def test_from_ravn_source_plain(self):
+        evt = _make_event(payload={"ravn_source": "skuld-01"})
+        assert _extract_peer_id(evt) == "skuld-01"
+
+    def test_from_ravn_source_with_prefix(self):
+        evt = _make_event(payload={"ravn_source": "skuld:skuld-01"})
+        assert _extract_peer_id(evt) == "skuld-01"
+
+    def test_from_source_field_fallback(self):
+        evt = _make_event(payload={}, source="ravn:peer-99")
+        assert _extract_peer_id(evt) == "peer-99"
+
+    def test_source_without_prefix(self):
+        evt = _make_event(payload={}, source="plain-peer")
+        assert _extract_peer_id(evt) == "plain-peer"
+
+    def test_empty_source(self):
+        evt = _make_event(payload={}, source="")
+        assert _extract_peer_id(evt) == ""
+
+
+class TestExtractPersona:
+    def test_persona_from_ravn_event(self):
+        evt = _make_event(payload={"ravn_event": {"persona": "reviewer"}})
+        assert _extract_persona(evt, "peer-01") == "reviewer"
+
+    def test_persona_fallback_to_peer_id(self):
+        evt = _make_event(payload={"ravn_event": {}})
+        assert _extract_persona(evt, "peer-01") == "peer-01"
+
+    def test_no_ravn_event(self):
+        evt = _make_event(payload={})
+        assert _extract_persona(evt, "fallback") == "fallback"
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestRoomMeshBridgeLifecycle:
+    @pytest.mark.asyncio
+    async def test_start_subscribes(self):
+        bus = InProcessBus()
+        bridge = RoomMeshBridge(subscriber=bus, room_bridge=_make_room_bridge())
+        await bridge.start()
+        assert bridge._subscription is not None
+        await bridge.stop()
+
+    @pytest.mark.asyncio
+    async def test_stop_unsubscribes(self):
+        bus = InProcessBus()
+        bridge = RoomMeshBridge(subscriber=bus, room_bridge=_make_room_bridge())
+        await bridge.start()
+        await bridge.stop()
+        assert bridge._subscription is None
+
+    @pytest.mark.asyncio
+    async def test_stop_without_start_is_safe(self):
+        bus = InProcessBus()
+        bridge = RoomMeshBridge(subscriber=bus, room_bridge=_make_room_bridge())
+        await bridge.stop()  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_double_start_is_idempotent(self):
+        bus = InProcessBus()
+        bridge = RoomMeshBridge(subscriber=bus, room_bridge=_make_room_bridge())
+        await bridge.start()
+        first_sub = bridge._subscription
+        await bridge.start()  # second call ignored
+        assert bridge._subscription is first_sub
+        await bridge.stop()
+
+    @pytest.mark.asyncio
+    async def test_context_manager(self):
+        bus = InProcessBus()
+        async with RoomMeshBridge(subscriber=bus, room_bridge=_make_room_bridge()) as b:
+            assert b._subscription is not None
+        assert b._subscription is None
+
+    @pytest.mark.asyncio
+    async def test_default_patterns_are_mesh_patterns(self):
+        bus = InProcessBus()
+        bridge = RoomMeshBridge(subscriber=bus, room_bridge=_make_room_bridge())
+        assert bridge._patterns == MESH_PATTERNS
+
+    @pytest.mark.asyncio
+    async def test_custom_patterns_accepted(self):
+        bus = InProcessBus()
+        custom = ["ravn.mesh.code.*"]
+        bridge = RoomMeshBridge(
+            subscriber=bus,
+            room_bridge=_make_room_bridge(),
+            patterns=custom,
+        )
+        assert bridge._patterns == custom
+
+
+# ---------------------------------------------------------------------------
+# Session filtering
+# ---------------------------------------------------------------------------
+
+
+class TestSessionFiltering:
+    @pytest.mark.asyncio
+    async def test_matching_correlation_id_passes(self):
+        room = _make_room_bridge()
+        bus = InProcessBus()
+        bridge = RoomMeshBridge(subscriber=bus, room_bridge=room, session_id="sess-abc")
+        await bridge.start()
+
+        evt = _make_event(correlation_id="sess-abc")
+        await bridge._handle_event(evt)
+
+        room.handle_ravn_frame.assert_awaited_once()
+        await bridge.stop()
+
+    @pytest.mark.asyncio
+    async def test_matching_ravn_session_id_passes(self):
+        room = _make_room_bridge()
+        bus = InProcessBus()
+        bridge = RoomMeshBridge(subscriber=bus, room_bridge=room, session_id="sess-abc")
+        await bridge.start()
+
+        evt = _make_event(
+            correlation_id="other",
+            payload={
+                "ravn_event": {"persona": "coder"},
+                "ravn_type": "RavnEventType.OUTCOME",
+                "ravn_source": "skuld-01",
+                "ravn_session_id": "sess-abc",
+                "ravn_urgency": 0.5,
+                "ravn_task_id": None,
+            },
+        )
+        await bridge._handle_event(evt)
+
+        room.handle_ravn_frame.assert_awaited_once()
+        await bridge.stop()
+
+    @pytest.mark.asyncio
+    async def test_non_matching_session_is_dropped(self):
+        room = _make_room_bridge()
+        bus = InProcessBus()
+        bridge = RoomMeshBridge(subscriber=bus, room_bridge=room, session_id="sess-abc")
+        await bridge.start()
+
+        evt = _make_event(
+            correlation_id="sess-OTHER",
+            payload={
+                "ravn_event": {},
+                "ravn_type": "RavnEventType.OUTCOME",
+                "ravn_source": "skuld-01",
+                "ravn_session_id": "sess-OTHER",
+                "ravn_urgency": 0.5,
+                "ravn_task_id": None,
+            },
+        )
+        await bridge._handle_event(evt)
+
+        room.handle_ravn_frame.assert_not_awaited()
+        await bridge.stop()
+
+    @pytest.mark.asyncio
+    async def test_no_session_filter_passes_all(self):
+        room = _make_room_bridge()
+        bus = InProcessBus()
+        bridge = RoomMeshBridge(subscriber=bus, room_bridge=room, session_id=None)
+        await bridge.start()
+
+        evt = _make_event(correlation_id="any-session")
+        await bridge._handle_event(evt)
+
+        room.handle_ravn_frame.assert_awaited_once()
+        await bridge.stop()
+
+
+# ---------------------------------------------------------------------------
+# Event translation
+# ---------------------------------------------------------------------------
+
+
+class TestOutcomeTranslation:
+    @pytest.mark.asyncio
+    async def test_outcome_event_calls_handle_ravn_frame(self):
+        room = _make_room_bridge(known_peers=["skuld-01"])
+        bus = InProcessBus()
+        bridge = RoomMeshBridge(
+            subscriber=bus,
+            room_bridge=room,
+            session_id="sess-abc",
+        )
+        await bridge.start()
+
+        evt = _make_event()  # OUTCOME event
+        await bridge._handle_event(evt)
+
+        room.handle_ravn_frame.assert_awaited_once()
+        call_args = room.handle_ravn_frame.call_args
+        peer_id, frame = call_args[0]
+        assert peer_id == "skuld-01"
+        assert frame["type"] == "outcome"
+
+    @pytest.mark.asyncio
+    async def test_outcome_frame_includes_event_type(self):
+        room = _make_room_bridge(known_peers=["skuld-01"])
+        bus = InProcessBus()
+        bridge = RoomMeshBridge(
+            subscriber=bus,
+            room_bridge=room,
+            session_id="sess-abc",
+        )
+        await bridge.start()
+
+        evt = _make_event()
+        await bridge._handle_event(evt)
+
+        _, frame = room.handle_ravn_frame.call_args[0]
+        assert frame["metadata"]["event_type"] == "code.changed"
+        await bridge.stop()
+
+    @pytest.mark.asyncio
+    async def test_outcome_data_is_ravn_event_payload(self):
+        ravn_payload = {
+            "event_type": "code.changed",
+            "persona": "reviewer",
+            "output": "lgtm",
+        }
+        room = _make_room_bridge(known_peers=["skuld-02"])
+        bus = InProcessBus()
+        bridge = RoomMeshBridge(
+            subscriber=bus,
+            room_bridge=room,
+            session_id="sess-abc",
+        )
+        await bridge.start()
+
+        evt = _make_event(
+            source="ravn:skuld-02",
+            payload={
+                "ravn_event": ravn_payload,
+                "ravn_type": "RavnEventType.OUTCOME",
+                "ravn_source": "skuld-02",
+                "ravn_session_id": "sess-abc",
+                "ravn_urgency": 0.5,
+                "ravn_task_id": None,
+            },
+        )
+        await bridge._handle_event(evt)
+
+        _, frame = room.handle_ravn_frame.call_args[0]
+        assert frame["data"] == ravn_payload
+        await bridge.stop()
+
+
+class TestActivityTranslation:
+    @pytest.mark.asyncio
+    async def test_tool_start_event_translated_to_tool_start_frame(self):
+        room = _make_room_bridge(known_peers=["skuld-01"])
+        bus = InProcessBus()
+        bridge = RoomMeshBridge(
+            subscriber=bus,
+            room_bridge=room,
+            session_id="sess-abc",
+        )
+        await bridge.start()
+
+        evt = _make_event(
+            payload={
+                "ravn_event": {"detail": "running bash"},
+                "ravn_type": "RavnEventType.TOOL_START",
+                "ravn_source": "skuld-01",
+                "ravn_session_id": "sess-abc",
+                "ravn_urgency": 0.4,
+                "ravn_task_id": None,
+            }
+        )
+        await bridge._handle_event(evt)
+
+        room.handle_ravn_frame.assert_awaited_once()
+        _, frame = room.handle_ravn_frame.call_args[0]
+        assert frame["type"] == "tool_start"
+        await bridge.stop()
+
+    @pytest.mark.asyncio
+    async def test_thought_event_translated_to_thought_frame(self):
+        room = _make_room_bridge(known_peers=["skuld-01"])
+        bus = InProcessBus()
+        bridge = RoomMeshBridge(
+            subscriber=bus,
+            room_bridge=room,
+            session_id="sess-abc",
+        )
+        await bridge.start()
+
+        evt = _make_event(
+            payload={
+                "ravn_event": {},
+                "ravn_type": "RavnEventType.THOUGHT",
+                "ravn_source": "skuld-01",
+                "ravn_session_id": "sess-abc",
+                "ravn_urgency": 0.3,
+                "ravn_task_id": None,
+            }
+        )
+        await bridge._handle_event(evt)
+
+        room.handle_ravn_frame.assert_awaited_once()
+        _, frame = room.handle_ravn_frame.call_args[0]
+        assert frame["type"] == "thought"
+        await bridge.stop()
+
+    @pytest.mark.asyncio
+    async def test_unknown_ravn_type_is_ignored(self):
+        room = _make_room_bridge(known_peers=["skuld-01"])
+        bus = InProcessBus()
+        bridge = RoomMeshBridge(
+            subscriber=bus,
+            room_bridge=room,
+            session_id="sess-abc",
+        )
+        await bridge.start()
+
+        evt = _make_event(
+            payload={
+                "ravn_event": {},
+                "ravn_type": "RavnEventType.RESPONSE",
+                "ravn_source": "skuld-01",
+                "ravn_session_id": "sess-abc",
+                "ravn_urgency": 0.3,
+                "ravn_task_id": None,
+            }
+        )
+        await bridge._handle_event(evt)
+
+        room.handle_ravn_frame.assert_not_awaited()
+        await bridge.stop()
+
+
+# ---------------------------------------------------------------------------
+# Auto-registration of mesh peers
+# ---------------------------------------------------------------------------
+
+
+class TestPeerAutoRegistration:
+    @pytest.mark.asyncio
+    async def test_unknown_peer_is_auto_registered(self):
+        room = _make_room_bridge(known_peers=[])
+        bus = InProcessBus()
+        bridge = RoomMeshBridge(
+            subscriber=bus,
+            room_bridge=room,
+            session_id="sess-abc",
+        )
+        await bridge.start()
+
+        evt = _make_event()  # peer "skuld-01" not in room
+        await bridge._handle_event(evt)
+
+        room.register_mesh_peer.assert_awaited_once()
+        call_kwargs = room.register_mesh_peer.call_args[1]
+        assert call_kwargs["peer_id"] == "skuld-01"
+        await bridge.stop()
+
+    @pytest.mark.asyncio
+    async def test_known_peer_is_not_re_registered(self):
+        room = _make_room_bridge(known_peers=["skuld-01"])
+        bus = InProcessBus()
+        bridge = RoomMeshBridge(
+            subscriber=bus,
+            room_bridge=room,
+            session_id="sess-abc",
+        )
+        await bridge.start()
+
+        evt = _make_event()  # "skuld-01" already registered
+        await bridge._handle_event(evt)
+
+        room.register_mesh_peer.assert_not_awaited()
+        await bridge.stop()
+
+    @pytest.mark.asyncio
+    async def test_auto_registered_peer_has_correct_persona(self):
+        room = _make_room_bridge(known_peers=[])
+        bus = InProcessBus()
+        bridge = RoomMeshBridge(
+            subscriber=bus,
+            room_bridge=room,
+            session_id="sess-abc",
+        )
+        await bridge.start()
+
+        evt = _make_event(
+            payload={
+                "ravn_event": {"persona": "reviewer", "event_type": "code.reviewed"},
+                "ravn_type": "RavnEventType.OUTCOME",
+                "ravn_source": "ravn-reviewer-01",
+                "ravn_session_id": "sess-abc",
+                "ravn_urgency": 0.6,
+                "ravn_task_id": None,
+            },
+            source="ravn:ravn-reviewer-01",
+        )
+        await bridge._handle_event(evt)
+
+        call_kwargs = room.register_mesh_peer.call_args[1]
+        assert call_kwargs["persona"] == "reviewer"
+        await bridge.stop()
+
+    @pytest.mark.asyncio
+    async def test_empty_peer_id_is_skipped(self):
+        room = _make_room_bridge(known_peers=[])
+        bus = InProcessBus()
+        bridge = RoomMeshBridge(
+            subscriber=bus,
+            room_bridge=room,
+            session_id="sess-abc",
+        )
+        await bridge.start()
+
+        # Event with no source information
+        evt = _make_event(
+            payload={
+                "ravn_event": {},
+                "ravn_type": "RavnEventType.OUTCOME",
+                "ravn_source": "",
+                "ravn_session_id": "sess-abc",
+                "ravn_urgency": 0.5,
+                "ravn_task_id": None,
+            },
+            source="",
+        )
+        await bridge._handle_event(evt)
+
+        room.register_mesh_peer.assert_not_awaited()
+        room.handle_ravn_frame.assert_not_awaited()
+        await bridge.stop()
+
+
+# ---------------------------------------------------------------------------
+# Integration: InProcessBus end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestInProcessBusIntegration:
+    @pytest.mark.asyncio
+    async def test_outcome_event_published_to_bus_reaches_room_bridge(self):
+        """Full round-trip: publish to bus → RoomMeshBridge → RoomBridge."""
+        import asyncio
+
+        bus = InProcessBus()
+        room = _make_room_bridge(known_peers=["skuld-01"])
+        bridge = RoomMeshBridge(
+            subscriber=bus,
+            room_bridge=room,
+            session_id="sess-abc",
+        )
+        await bridge.start()
+
+        # Publish a mesh outcome event directly to the Sleipnir bus
+        evt = _make_event()
+        await bus.publish(evt)
+
+        # Give the asyncio event loop a tick to process the subscriber queue
+        await asyncio.sleep(0)
+
+        room.handle_ravn_frame.assert_awaited_once()
+        await bridge.stop()

--- a/tests/test_skuld/test_room_mesh_bridge.py
+++ b/tests/test_skuld/test_room_mesh_bridge.py
@@ -66,6 +66,7 @@ def _make_room_bridge(known_peers: list[str] | None = None) -> MagicMock:
     bridge.register_mesh_peer = AsyncMock()
     # Participants dict: peer_id → meta
     bridge.participants = {pid: MagicMock(peer_id=pid) for pid in (known_peers or [])}
+    bridge.has_participant = MagicMock(side_effect=lambda pid: pid in bridge.participants)
     return bridge
 
 

--- a/tests/test_skuld/test_room_mesh_bridge.py
+++ b/tests/test_skuld/test_room_mesh_bridge.py
@@ -12,7 +12,7 @@ Covers:
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 


### PR DESCRIPTION
## Summary

- **New `RoomMeshBridge`** (`src/skuld/room_mesh_bridge.py`) subscribes to `ravn.mesh.*` Sleipnir events and translates them into room wire events via the existing `RoomBridge` path — making the room bridge a first-class Sleipnir subscriber instead of a manual broadcast target.
- **Removed dual-publish pattern** in `Broker._publish_mesh_outcome()`: the broker now publishes once to the mesh; `RoomMeshBridge` fans the Sleipnir event into the room UI automatically. No more `channels.broadcast(room_outcome)` after `mesh.publish(...)`.
- **Auto-registers mesh peers**: when an unknown peer's event arrives on the mesh, `RoomMeshBridge` calls `register_mesh_peer()` automatically — enabling multiple Skuld instances (coder, reviewer, security scanner) to share one room bridge without manual wiring.
- **Multiple Skuld support**: each Skuld instance is a distinct mesh peer; the bridge handles N peers transparently.

## Architecture change

```
Before:
  Broker._publish_mesh_outcome()
    ├─ mesh.publish(event, "code.changed")   → other ravens
    └─ channels.broadcast(room_outcome)      → browser (manual copy)

After:
  Broker._publish_mesh_outcome()
    └─ mesh.publish(event, "code.changed")   → other ravens
         ↓ (via Sleipnir ravn.mesh.*)
       RoomMeshBridge._handle_event()
         └─ RoomBridge.handle_ravn_frame()
              └─ ChannelRegistry.broadcast() → browser
```

## Test plan

- [x] 30 unit tests: lifecycle, session filtering, OUTCOME/activity translation, peer auto-registration, InProcessBus end-to-end round-trip
- [x] 99% coverage on `room_mesh_bridge.py`
- [x] All 835 passing skuld tests still pass (1 pre-existing failure in `test_build_mesh_with_adapters_list` unrelated to this change)
- [x] `ruff check` + `ruff format` clean

## Linear

Ticket: NIU-624 — Linear MCP was unavailable; please update manually to **In Review**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)