### PR TITLE
feat(adapters): NIU-625 — configurable LLM provider for flock ravn daemons

### DIFF
--- a/src/tyr/config.py
+++ b/src/tyr/config.py
@@ -407,6 +407,14 @@ class FlockConfig(BaseModel):
         default_factory=list,
         description="Sleipnir publish URLs for flock task event routing.",
     )
+    llm_config: dict = Field(
+        default_factory=dict,
+        description=(
+            "LLM provider config for ravn flock nodes. "
+            "Dict matching ravn's `llm:` config block (model, max_tokens, timeout, provider). "
+            "When empty, ravn nodes use their own default or image-baked config."
+        ),
+    )
 
 
 class DispatchConfig(BaseModel):

--- a/src/tyr/domain/services/dispatch_service.py
+++ b/src/tyr/domain/services/dispatch_service.py
@@ -225,6 +225,7 @@ class DispatchConfig:
     flock_default_personas: list[str] = field(default_factory=lambda: ["coordinator", "reviewer"])
     flock_mimir_hosted_url: str = ""
     flock_sleipnir_publish_urls: list[str] = field(default_factory=list)
+    flock_llm_config: dict = field(default_factory=dict)
 
 
 class DispatchService:
@@ -808,6 +809,8 @@ class DispatchService:
             workload_config["sleipnir_publish_urls"] = self._config.flock_sleipnir_publish_urls
         if self._config.flock_mimir_hosted_url:
             workload_config["mimir_hosted_url"] = self._config.flock_mimir_hosted_url
+        if self._config.flock_llm_config:
+            workload_config["llm_config"] = self._config.flock_llm_config
 
         return SpawnRequest(
             name=session_name,

--- a/src/tyr/main.py
+++ b/src/tyr/main.py
@@ -291,6 +291,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                     flock_default_personas=list(settings.dispatch.flock.default_personas),
                     flock_mimir_hosted_url=settings.dispatch.flock.mimir_hosted_url,
                     flock_sleipnir_publish_urls=list(settings.dispatch.flock.sleipnir_publish_urls),
+                    flock_llm_config=dict(settings.dispatch.flock.llm_config),
                 ),
                 sleipnir_publisher=sleipnir_bus,
             )

--- a/src/volundr/adapters/outbound/contributors/ravn_flock.py
+++ b/src/volundr/adapters/outbound/contributors/ravn_flock.py
@@ -55,6 +55,7 @@ def _build_ravn_config(
     sleipnir_publish_urls: list[str],
     max_concurrent_tasks: int,
     mesh_host: str = "0.0.0.0",
+    llm_config: dict | None = None,
 ) -> str:
     """Generate the ravn daemon YAML config for a single flock node."""
     pub, rep, _hs = _ports_for(index, base_port)
@@ -88,38 +89,46 @@ def _build_ravn_config(
 
     config: dict[str, Any] = {
         "persona": persona,
-        "mesh": {
-            "enabled": True,
-            "adapter": "nng",
-            "own_peer_id": peer_id,
-            "nng": {
-                "pub_sub_address": f"tcp://{mesh_host}:{pub}",
-                "req_rep_address": f"tcp://{mesh_host}:{rep}",
-            },
-            "peers": peers,
-        },
-        "discovery": {"enabled": True, "adapter": "static"},
-        "cascade": {"enabled": True},
-        "gateway": {
-            "enabled": True,
-            "channels": {
-                "http": {"enabled": True, "host": "0.0.0.0", "port": gw},
-            },
-        },
-        "initiative": {
-            "enabled": True,
-            "max_concurrent_tasks": max_concurrent_tasks,
-        },
-        "mimir": {
-            "enabled": True,
-            "instances": mimir_instances,
-            "write_routing": {
-                "rules": mimir_write_rules,
-                "default": ["local"],
-            },
-        },
-        "logging": {"level": "INFO"},
     }
+
+    if llm_config:
+        config["llm"] = llm_config
+
+    config.update(
+        {
+            "mesh": {
+                "enabled": True,
+                "adapter": "nng",
+                "own_peer_id": peer_id,
+                "nng": {
+                    "pub_sub_address": f"tcp://{mesh_host}:{pub}",
+                    "req_rep_address": f"tcp://{mesh_host}:{rep}",
+                },
+                "peers": peers,
+            },
+            "discovery": {"enabled": True, "adapter": "static"},
+            "cascade": {"enabled": True},
+            "gateway": {
+                "enabled": True,
+                "channels": {
+                    "http": {"enabled": True, "host": "0.0.0.0", "port": gw},
+                },
+            },
+            "initiative": {
+                "enabled": True,
+                "max_concurrent_tasks": max_concurrent_tasks,
+            },
+            "mimir": {
+                "enabled": True,
+                "instances": mimir_instances,
+                "write_routing": {
+                    "rules": mimir_write_rules,
+                    "default": ["local"],
+                },
+            },
+            "logging": {"level": "INFO"},
+        }
+    )
 
     if sleipnir_publish_urls:
         config["sleipnir"] = {
@@ -194,6 +203,7 @@ class RavnFlockContributor(SessionContributor):
         sleipnir_publish_urls: list[str] = sleipnir_cfg.get("publish_urls", [])
         mesh_transport: str = mesh_cfg.get("transport", "nng")
         max_concurrent_tasks: int = wc.get("max_concurrent_tasks", _DEFAULT_MAX_CONCURRENT_TASKS)
+        llm_config: dict | None = wc.get("llm_config") or None
 
         values, pod_spec = self._build_flock_spec(
             session=session,
@@ -202,6 +212,7 @@ class RavnFlockContributor(SessionContributor):
             mimir_hosted_url=mimir_hosted_url,
             sleipnir_publish_urls=sleipnir_publish_urls,
             max_concurrent_tasks=max_concurrent_tasks,
+            llm_config=llm_config,
         )
 
         return SessionContribution(values=values, pod_spec=pod_spec)
@@ -231,6 +242,7 @@ class RavnFlockContributor(SessionContributor):
         mimir_hosted_url: str | None,
         sleipnir_publish_urls: list[str],
         max_concurrent_tasks: int,
+        llm_config: dict | None = None,
     ) -> tuple[dict[str, Any], PodSpecAdditions]:
         session_id = str(session.id)
         base_port = self._base_port
@@ -282,6 +294,7 @@ class RavnFlockContributor(SessionContributor):
                 sleipnir_publish_urls=sleipnir_publish_urls,
                 max_concurrent_tasks=max_concurrent_tasks,
                 mesh_host=self._mesh_host,
+                llm_config=llm_config,
             )
 
             ravn_env: list[dict] = [

--- a/src/volundr/adapters/outbound/contributors/ravn_flock.py
+++ b/src/volundr/adapters/outbound/contributors/ravn_flock.py
@@ -89,46 +89,41 @@ def _build_ravn_config(
 
     config: dict[str, Any] = {
         "persona": persona,
+        "mesh": {
+            "enabled": True,
+            "adapter": "nng",
+            "own_peer_id": peer_id,
+            "nng": {
+                "pub_sub_address": f"tcp://{mesh_host}:{pub}",
+                "req_rep_address": f"tcp://{mesh_host}:{rep}",
+            },
+            "peers": peers,
+        },
+        "discovery": {"enabled": True, "adapter": "static"},
+        "cascade": {"enabled": True},
+        "gateway": {
+            "enabled": True,
+            "channels": {
+                "http": {"enabled": True, "host": "0.0.0.0", "port": gw},
+            },
+        },
+        "initiative": {
+            "enabled": True,
+            "max_concurrent_tasks": max_concurrent_tasks,
+        },
+        "mimir": {
+            "enabled": True,
+            "instances": mimir_instances,
+            "write_routing": {
+                "rules": mimir_write_rules,
+                "default": ["local"],
+            },
+        },
+        "logging": {"level": "INFO"},
     }
 
     if llm_config:
         config["llm"] = llm_config
-
-    config.update(
-        {
-            "mesh": {
-                "enabled": True,
-                "adapter": "nng",
-                "own_peer_id": peer_id,
-                "nng": {
-                    "pub_sub_address": f"tcp://{mesh_host}:{pub}",
-                    "req_rep_address": f"tcp://{mesh_host}:{rep}",
-                },
-                "peers": peers,
-            },
-            "discovery": {"enabled": True, "adapter": "static"},
-            "cascade": {"enabled": True},
-            "gateway": {
-                "enabled": True,
-                "channels": {
-                    "http": {"enabled": True, "host": "0.0.0.0", "port": gw},
-                },
-            },
-            "initiative": {
-                "enabled": True,
-                "max_concurrent_tasks": max_concurrent_tasks,
-            },
-            "mimir": {
-                "enabled": True,
-                "instances": mimir_instances,
-                "write_routing": {
-                    "rules": mimir_write_rules,
-                    "default": ["local"],
-                },
-            },
-            "logging": {"level": "INFO"},
-        }
-    )
 
     if sleipnir_publish_urls:
         config["sleipnir"] = {

--- a/tests/test_adapters/test_contributors/test_ravn_flock.py
+++ b/tests/test_adapters/test_contributors/test_ravn_flock.py
@@ -585,3 +585,119 @@ class TestExtraKwargs:
             unknown_kwarg="ignored",
         )
         assert c.name == "ravn_flock"
+
+
+# ---------------------------------------------------------------------------
+# LLM config passthrough
+# ---------------------------------------------------------------------------
+
+_LLM_CONFIG = {
+    "model": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
+    "max_tokens": 8192,
+    "timeout": 300.0,
+    "provider": {
+        "adapter": "ravn.adapters.llm.openai.OpenAICompatibleAdapter",
+        "kwargs": {
+            "base_url": "https://vllm.valaskjalf.asgard.niuu.world",
+            "api_key": "",
+        },
+    },
+}
+
+
+@pytest.fixture
+def flock_template_with_llm():
+    return WorkspaceTemplate(
+        name="ravn-flock-llm",
+        workload_type="ravn_flock",
+        workload_config={
+            "personas": ["coordinator", "reviewer"],
+            "mesh": {"transport": "nng"},
+            "mimir": {},
+            "sleipnir": {},
+            "llm_config": _LLM_CONFIG,
+        },
+    )
+
+
+class TestLLMConfigPassthrough:
+    async def test_llm_block_in_ravn_config_when_provided(self, session, flock_template_with_llm):
+        provider = MagicMock()
+        provider.get.return_value = flock_template_with_llm
+        c = RavnFlockContributor(template_provider=provider)
+        ctx = SessionContext(template_name="ravn-flock-llm")
+        result = await c.contribute(session, ctx)
+
+        for ctr in result.pod_spec.extra_containers:
+            env = {e["name"]: e["value"] for e in ctr["env"]}
+            inline_cfg = env.get("RAVN_CONFIG_INLINE", "")
+            assert "llm:" in inline_cfg
+            assert "Qwen/Qwen3-Coder-30B-A3B-Instruct" in inline_cfg
+            assert "vllm.valaskjalf.asgard.niuu.world" in inline_cfg
+
+    async def test_no_llm_block_when_not_provided(self, session, flock_template):
+        """flock_template has no llm_config — no llm: block emitted."""
+        provider = MagicMock()
+        provider.get.return_value = flock_template
+        c = RavnFlockContributor(template_provider=provider)
+        ctx = SessionContext(template_name="ravn-flock")
+        result = await c.contribute(session, ctx)
+
+        for ctr in result.pod_spec.extra_containers:
+            env = {e["name"]: e["value"] for e in ctr["env"]}
+            inline_cfg = env.get("RAVN_CONFIG_INLINE", "")
+            assert "llm:" not in inline_cfg
+
+    async def test_llm_config_from_workload_context(self, session):
+        """When workload_type comes directly via SessionContext (SpawnRequest path)."""
+        c = RavnFlockContributor()
+        ctx = SessionContext(
+            workload_type="ravn_flock",
+            workload_config={
+                "personas": ["coordinator"],
+                "llm_config": _LLM_CONFIG,
+            },
+        )
+        result = await c.contribute(session, ctx)
+
+        assert result.pod_spec is not None
+        ravn_ctr = result.pod_spec.extra_containers[0]
+        env = {e["name"]: e["value"] for e in ravn_ctr["env"]}
+        inline_cfg = env.get("RAVN_CONFIG_INLINE", "")
+        assert "llm:" in inline_cfg
+        assert "Qwen/Qwen3-Coder-30B-A3B-Instruct" in inline_cfg
+
+    async def test_empty_llm_config_dict_not_emitted(self, session):
+        """An empty llm_config dict should not produce an llm: block."""
+        c = RavnFlockContributor()
+        ctx = SessionContext(
+            workload_type="ravn_flock",
+            workload_config={
+                "personas": ["coordinator"],
+                "llm_config": {},
+            },
+        )
+        result = await c.contribute(session, ctx)
+
+        ravn_ctr = result.pod_spec.extra_containers[0]
+        env = {e["name"]: e["value"] for e in ravn_ctr["env"]}
+        inline_cfg = env.get("RAVN_CONFIG_INLINE", "")
+        assert "llm:" not in inline_cfg
+
+    async def test_different_models_per_persona(self, session):
+        """All ravn nodes in a flock receive the same llm_config."""
+        llm = {"model": "anthropic/claude-sonnet-4-6", "max_tokens": 4096}
+        c = RavnFlockContributor()
+        ctx = SessionContext(
+            workload_type="ravn_flock",
+            workload_config={
+                "personas": ["coordinator", "reviewer"],
+                "llm_config": llm,
+            },
+        )
+        result = await c.contribute(session, ctx)
+
+        for ctr in result.pod_spec.extra_containers:
+            env = {e["name"]: e["value"] for e in ctr["env"]}
+            inline_cfg = env.get("RAVN_CONFIG_INLINE", "")
+            assert "claude-sonnet-4-6" in inline_cfg

--- a/tests/test_adapters/test_contributors/test_ravn_flock.py
+++ b/tests/test_adapters/test_contributors/test_ravn_flock.py
@@ -684,7 +684,7 @@ class TestLLMConfigPassthrough:
         inline_cfg = env.get("RAVN_CONFIG_INLINE", "")
         assert "llm:" not in inline_cfg
 
-    async def test_different_models_per_persona(self, session):
+    async def test_all_nodes_receive_same_llm_config(self, session):
         """All ravn nodes in a flock receive the same llm_config."""
         llm = {"model": "anthropic/claude-sonnet-4-6", "max_tokens": 4096}
         c = RavnFlockContributor()

--- a/tests/test_tyr/test_flock_dispatch.py
+++ b/tests/test_tyr/test_flock_dispatch.py
@@ -218,6 +218,51 @@ class TestBuildSpawnRequestFlockEnabled:
 
         assert "mimir_hosted_url" not in req.workload_config
 
+    def test_workload_config_contains_llm_config(self) -> None:
+        llm = {
+            "model": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
+            "max_tokens": 8192,
+            "provider": {"adapter": "ravn.adapters.llm.openai.OpenAICompatibleAdapter"},
+        }
+        config = _make_flock_config(flock_llm_config=llm)
+        saga = _make_saga()
+        issue = _make_issue()
+        item = DispatchItem(saga_id=str(saga.id), issue_id="i-1", repo="org/repo-a")
+
+        svc = MagicMock()
+        svc._config = config
+        req = DispatchService._build_spawn_request(
+            svc,
+            item=item,
+            saga=saga,
+            issue=issue,
+            effective_model="claude-sonnet-4-6",
+            effective_prompt="",
+            integration_ids=[],
+        )
+
+        assert req.workload_config["llm_config"] == llm
+
+    def test_no_llm_config_key_when_empty(self) -> None:
+        config = _make_flock_config(flock_llm_config={})
+        saga = _make_saga()
+        issue = _make_issue()
+        item = DispatchItem(saga_id=str(saga.id), issue_id="i-1", repo="org/repo-a")
+
+        svc = MagicMock()
+        svc._config = config
+        req = DispatchService._build_spawn_request(
+            svc,
+            item=item,
+            saga=saga,
+            issue=issue,
+            effective_model="claude-sonnet-4-6",
+            effective_prompt="",
+            integration_ids=[],
+        )
+
+        assert "llm_config" not in req.workload_config
+
 
 # ---------------------------------------------------------------------------
 # 2. SpawnRequest construction — flock disabled


### PR DESCRIPTION
## Summary

- Add `llm_config` dict field to `FlockConfig` in `tyr/config.py` so operators can specify any LLM provider/model in `tyr.yaml` under `dispatch.flock.llm_config`
- Wire `flock_llm_config` through `tyr/main.py` → `DispatchServiceConfig` → `_build_spawn_request` into `workload_config["llm_config"]`
- `RavnFlockContributor` reads `llm_config` from `workload_config` and passes it to `_build_ravn_config`, which emits it as the `llm:` block in each ravn node's `RAVN_CONFIG_INLINE` env var
- When `llm_config` is absent or empty, no `llm:` block is emitted — ravn nodes use their own image-baked defaults

## Example config

```yaml
dispatch:
  flock:
    enabled: true
    default_personas: [coordinator, reviewer]
    llm_config:
      model: Qwen/Qwen3-Coder-30B-A3B-Instruct
      max_tokens: 8192
      timeout: 300.0
      provider:
        adapter: ravn.adapters.llm.openai.OpenAICompatibleAdapter
        kwargs:
          base_url: "https://vllm.valaskjalf.asgard.niuu.world"
          api_key: ""
```

## Test plan

- [x] `TestLLMConfigPassthrough` — 5 new tests in `test_ravn_flock.py`: llm block present when config provided, absent when not, from direct workload context, empty dict not emitted, all personas receive same config
- [x] `TestBuildSpawnRequestFlockEnabled` — 2 new tests in `test_flock_dispatch.py`: llm_config in workload_config when set, absent when empty
- [x] All 70 tests in both files pass; `ravn_flock.py` at 98% coverage
- [x] Pre-existing failures (fan-in/discovery/mesh) are unrelated to this change

Closes NIU-625
Linear ticket: NIU-625 (update to In Review pending MCP availability)

🤖 Generated with [Claude Code](https://claude.com/claude-code)