### PR TITLE
feat(adapters): mount ravn config via initContainer (NIU-635)

### DIFF
--- a/src/ravn/cli/commands.py
+++ b/src/ravn/cli/commands.py
@@ -101,6 +101,23 @@ def _configure_logging(settings: Settings) -> None:
     logging.basicConfig(level=level, format=fmt, force=True)
 
 
+def _log_effective_config(settings: Settings) -> None:
+    """Emit an INFO log with the effective config for drift detection."""
+    source = os.environ.get("RAVN_CONFIG", "defaults")
+    persona = os.environ.get("RAVN_PERSONA", "default")
+    llm_alias = settings.effective_model()
+    thinking = settings.llm.extended_thinking.enabled
+    budget = settings.llm.extended_thinking.budget_tokens
+    logger.info(
+        "ravn effective config: persona=%s llm_alias=%s thinking=%s budget=%d source=%s",
+        persona,
+        llm_alias,
+        thinking,
+        budget,
+        source,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Builder: LLM
 # ---------------------------------------------------------------------------
@@ -1764,6 +1781,7 @@ def daemon(
 
     settings = Settings()
     _configure_logging(settings)
+    _log_effective_config(settings)
     project_config = ProjectConfig.discover()
     ravn_profile = _resolve_profile(profile)
     effective_persona = persona or (ravn_profile.persona if ravn_profile else "")
@@ -1800,6 +1818,7 @@ def listen(
 
     settings = Settings()
     _configure_logging(settings)
+    _log_effective_config(settings)
     project_config = ProjectConfig.discover()
     ravn_profile = _resolve_profile(profile)
     effective_persona = persona or (ravn_profile.persona if ravn_profile else "")

--- a/src/volundr/adapters/outbound/contributors/ravn_flock.py
+++ b/src/volundr/adapters/outbound/contributors/ravn_flock.py
@@ -4,6 +4,8 @@ When workload_type == "ravn_flock", this contributor replaces the default
 single-CLI layout with:
   - Skuld container with mesh.enabled=true + nng ports + Sleipnir webhook
   - N ravn daemon sidecar containers (one per persona in workload_config.personas)
+  - Per-sidecar initContainer that writes YAML config to an emptyDir volume
+    mounted read-only at /etc/ravn/config.yaml (RAVN_CONFIG env var points here)
   - nng mesh ports allocated via the same scheme as ravn flock init
   - Mimir emptyDir volume for ephemeral local memory
   - Sleipnir webhook transport config in both skuld and ravn containers
@@ -42,6 +44,10 @@ _MIMIR_MOUNT_PATH = "/mimir/local"
 _WORKSPACE_VOLUME_NAME = "workspace"
 _WORKSPACE_MOUNT_PATH = "/workspace"
 _RAVN_IMAGE_DEFAULT = "ghcr.io/niuulabs/ravn:latest"
+_RAVN_CONFIG_MOUNT_PATH = "/etc/ravn/config.yaml"
+_RAVN_CONFIG_VOLUME_PREFIX = "ravn-cfg"
+_RAVN_CONFIG_DIR = "/etc/ravn"
+_INIT_WRITER_IMAGE = "busybox:latest"
 
 
 def _build_ravn_config(
@@ -142,6 +148,7 @@ class RavnFlockContributor(SessionContributor):
     workload_config.personas + mesh/mimir/sleipnir settings, then:
       - Emits skuld mesh env vars (MESH_ENABLED, MESH_PEER_ID, nng addresses)
       - Emits one ravn sidecar container per persona with RAVN_CONFIG env
+      - Emits per-sidecar initContainer + emptyDir volume for mounted config
       - Emits a Mimir emptyDir volume
       - Emits Sleipnir webhook env vars for both skuld and ravn containers
 
@@ -272,6 +279,9 @@ class RavnFlockContributor(SessionContributor):
 
         # Ravn sidecar containers (indices 1..N)
         extra_containers: list[dict] = []
+        config_volumes: list[dict] = []
+        init_containers: list[dict] = []
+
         for i, persona in enumerate(personas):
             ravn_index = i + 1
             peer_id = f"flock-{persona}"
@@ -292,10 +302,29 @@ class RavnFlockContributor(SessionContributor):
                 llm_config=llm_config,
             )
 
+            # Per-sidecar emptyDir volume for the mounted config file
+            cfg_vol_name = f"{_RAVN_CONFIG_VOLUME_PREFIX}-{persona}"
+            config_volumes.append({"name": cfg_vol_name, "emptyDir": {}})
+
+            # Init container writes YAML into the volume
+            heredoc = (
+                f"cat > {_RAVN_CONFIG_MOUNT_PATH} <<'__RAVN_EOF__'\n{config_yaml}__RAVN_EOF__\n"
+            )
+            init_containers.append(
+                {
+                    "name": f"write-ravn-cfg-{persona}",
+                    "image": _INIT_WRITER_IMAGE,
+                    "command": ["sh", "-c", heredoc],
+                    "volumeMounts": [
+                        {"name": cfg_vol_name, "mountPath": _RAVN_CONFIG_DIR},
+                    ],
+                }
+            )
+
             ravn_env: list[dict] = [
                 {"name": "RAVN_PERSONA", "value": persona},
                 {"name": "RAVN_PEER_ID", "value": peer_id},
-                {"name": "RAVN_CONFIG_INLINE", "value": config_yaml},
+                {"name": "RAVN_CONFIG", "value": _RAVN_CONFIG_MOUNT_PATH},
             ]
 
             if sleipnir_publish_urls:
@@ -323,19 +352,23 @@ class RavnFlockContributor(SessionContributor):
                         "mountPath": _WORKSPACE_MOUNT_PATH,
                         "readOnly": True,
                     },
+                    {
+                        "name": cfg_vol_name,
+                        "mountPath": _RAVN_CONFIG_DIR,
+                        "readOnly": True,
+                    },
                 ],
             }
             extra_containers.append(container)
 
         pod_spec = PodSpecAdditions(
             volumes=(
-                {
-                    "name": _MIMIR_VOLUME_NAME,
-                    "emptyDir": {},
-                },
+                {"name": _MIMIR_VOLUME_NAME, "emptyDir": {}},
+                *config_volumes,
             ),
             env=tuple(skuld_env),
             extra_containers=tuple(extra_containers),
+            init_containers=tuple(init_containers),
         )
 
         values: dict[str, Any] = {

--- a/src/volundr/adapters/outbound/direct_k8s_pod_manager.py
+++ b/src/volundr/adapters/outbound/direct_k8s_pod_manager.py
@@ -517,6 +517,10 @@ echo "Git credential helper configured"
             }
         )
 
+        # Append contributor-provided init containers (e.g. ravn config writers).
+        if spec.pod_spec:
+            containers.extend(spec.pod_spec.init_containers)
+
         return containers
 
     def _build_deployment_manifest(

--- a/src/volundr/domain/models.py
+++ b/src/volundr/domain/models.py
@@ -963,6 +963,7 @@ class PodSpecAdditions:
     env: tuple[dict, ...] = ()
     service_account: str | None = None
     extra_containers: tuple[dict, ...] = ()
+    init_containers: tuple[dict, ...] = ()
 
     def __post_init__(self) -> None:
         # Ensure dict fields default to empty dicts, not empty tuples
@@ -1416,4 +1417,5 @@ def _merge_pod_specs(a: PodSpecAdditions, b: PodSpecAdditions) -> PodSpecAdditio
         env=a.env + b.env,
         service_account=b.service_account or a.service_account,
         extra_containers=a.extra_containers + b.extra_containers,
+        init_containers=a.init_containers + b.init_containers,
     )

--- a/tests/test_adapters/test_contributors/test_ravn_flock.py
+++ b/tests/test_adapters/test_contributors/test_ravn_flock.py
@@ -20,6 +20,29 @@ from volundr.domain.models import (
 from volundr.domain.ports import SessionContext
 
 # ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_mounted_config(pod_spec, persona: str) -> str:
+    """Extract the YAML written by the init container for *persona*.
+
+    The heredoc format is:
+      cat > /etc/ravn/config.yaml <<'__RAVN_EOF__'\\n<yaml>__RAVN_EOF__\\n
+    """
+    init_name = f"write-ravn-cfg-{persona}"
+    for ic in pod_spec.init_containers:
+        if ic["name"] == init_name:
+            cmd = ic["command"][2]
+            open_marker = "'__RAVN_EOF__'\n"
+            close_marker = "__RAVN_EOF__\n"
+            start = cmd.index(open_marker) + len(open_marker)
+            end = cmd.rindex(close_marker)
+            return cmd[start:end]
+    raise AssertionError(f"init container {init_name!r} not found")
+
+
+# ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
 
@@ -303,12 +326,95 @@ class TestContributorOutput:
 
 
 # ---------------------------------------------------------------------------
-# Config generation
+# Mounted config (replaces RAVN_CONFIG_INLINE)
+# ---------------------------------------------------------------------------
+
+
+class TestMountedConfig:
+    async def test_ravn_config_inline_absent(self, session, flock_template):
+        """RAVN_CONFIG_INLINE must not appear in any container env."""
+        provider = MagicMock()
+        provider.get.return_value = flock_template
+        c = RavnFlockContributor(template_provider=provider)
+        ctx = SessionContext(template_name="ravn-flock")
+        result = await c.contribute(session, ctx)
+
+        for ctr in result.pod_spec.extra_containers:
+            env_names = {e["name"] for e in ctr["env"]}
+            assert "RAVN_CONFIG_INLINE" not in env_names
+
+    async def test_ravn_config_env_points_to_mount(self, session, flock_template):
+        """Each sidecar has RAVN_CONFIG=/etc/ravn/config.yaml."""
+        provider = MagicMock()
+        provider.get.return_value = flock_template
+        c = RavnFlockContributor(template_provider=provider)
+        ctx = SessionContext(template_name="ravn-flock")
+        result = await c.contribute(session, ctx)
+
+        for ctr in result.pod_spec.extra_containers:
+            env = {e["name"]: e["value"] for e in ctr["env"]}
+            assert env["RAVN_CONFIG"] == "/etc/ravn/config.yaml"
+
+    async def test_per_sidecar_config_volume(self, session, flock_template):
+        """Each persona gets its own config emptyDir volume."""
+        provider = MagicMock()
+        provider.get.return_value = flock_template
+        c = RavnFlockContributor(template_provider=provider)
+        ctx = SessionContext(template_name="ravn-flock")
+        result = await c.contribute(session, ctx)
+
+        vol_names = [v["name"] for v in result.pod_spec.volumes]
+        assert "ravn-cfg-coordinator" in vol_names
+        assert "ravn-cfg-reviewer" in vol_names
+
+    async def test_per_sidecar_init_container(self, session, flock_template):
+        """Each persona gets an init container that writes its config."""
+        provider = MagicMock()
+        provider.get.return_value = flock_template
+        c = RavnFlockContributor(template_provider=provider)
+        ctx = SessionContext(template_name="ravn-flock")
+        result = await c.contribute(session, ctx)
+
+        ic_names = [ic["name"] for ic in result.pod_spec.init_containers]
+        assert "write-ravn-cfg-coordinator" in ic_names
+        assert "write-ravn-cfg-reviewer" in ic_names
+
+    async def test_init_container_writes_to_correct_volume(self, session, flock_template):
+        """Init container mounts the matching config volume."""
+        provider = MagicMock()
+        provider.get.return_value = flock_template
+        c = RavnFlockContributor(template_provider=provider)
+        ctx = SessionContext(template_name="ravn-flock")
+        result = await c.contribute(session, ctx)
+
+        for ic in result.pod_spec.init_containers:
+            persona = ic["name"].replace("write-ravn-cfg-", "")
+            vol_name = f"ravn-cfg-{persona}"
+            mounts = {m["name"]: m["mountPath"] for m in ic["volumeMounts"]}
+            assert mounts[vol_name] == "/etc/ravn"
+
+    async def test_sidecar_mounts_config_readonly(self, session, flock_template):
+        """Sidecar mounts the config volume read-only at /etc/ravn."""
+        provider = MagicMock()
+        provider.get.return_value = flock_template
+        c = RavnFlockContributor(template_provider=provider)
+        ctx = SessionContext(template_name="ravn-flock")
+        result = await c.contribute(session, ctx)
+
+        for ctr in result.pod_spec.extra_containers:
+            persona = ctr["name"].replace("ravn-", "")
+            cfg_mount = next(m for m in ctr["volumeMounts"] if m["mountPath"] == "/etc/ravn")
+            assert cfg_mount["name"] == f"ravn-cfg-{persona}"
+            assert cfg_mount.get("readOnly") is True
+
+
+# ---------------------------------------------------------------------------
+# Config generation (via init container command)
 # ---------------------------------------------------------------------------
 
 
 class TestConfigGeneration:
-    async def test_ravn_config_inline_has_persona(self, session, flock_template):
+    async def test_mounted_config_has_persona(self, session, flock_template):
         provider = MagicMock()
         provider.get.return_value = flock_template
         c = RavnFlockContributor(template_provider=provider)
@@ -320,95 +426,85 @@ class TestConfigGeneration:
             assert "RAVN_PEER_ID" in env
             assert env["RAVN_PEER_ID"].startswith("flock-")
 
-            inline_cfg = env.get("RAVN_CONFIG_INLINE", "")
             persona = env["RAVN_PERSONA"]
-            assert persona in inline_cfg
+            cfg = _extract_mounted_config(result.pod_spec, persona)
+            assert persona in cfg
 
-    async def test_ravn_config_has_mesh_section(self, session, flock_template):
+    async def test_mounted_config_has_mesh_section(self, session, flock_template):
         provider = MagicMock()
         provider.get.return_value = flock_template
         c = RavnFlockContributor(template_provider=provider)
         ctx = SessionContext(template_name="ravn-flock")
         result = await c.contribute(session, ctx)
 
-        for ctr in result.pod_spec.extra_containers:
-            env = {e["name"]: e["value"] for e in ctr["env"]}
-            inline_cfg = env.get("RAVN_CONFIG_INLINE", "")
-            assert "mesh:" in inline_cfg
-            assert "enabled: true" in inline_cfg
+        for persona in ("coordinator", "reviewer"):
+            cfg = _extract_mounted_config(result.pod_spec, persona)
+            assert "mesh:" in cfg
+            assert "enabled: true" in cfg
 
-    async def test_ravn_config_has_mimir_instances(self, session, flock_template):
+    async def test_mounted_config_has_mimir_instances(self, session, flock_template):
         provider = MagicMock()
         provider.get.return_value = flock_template
         c = RavnFlockContributor(template_provider=provider)
         ctx = SessionContext(template_name="ravn-flock")
         result = await c.contribute(session, ctx)
 
-        for ctr in result.pod_spec.extra_containers:
-            env = {e["name"]: e["value"] for e in ctr["env"]}
-            inline_cfg = env.get("RAVN_CONFIG_INLINE", "")
-            assert "mimir:" in inline_cfg
-            assert "instances:" in inline_cfg
-            assert "/mimir/local" in inline_cfg
+        for persona in ("coordinator", "reviewer"):
+            cfg = _extract_mounted_config(result.pod_spec, persona)
+            assert "mimir:" in cfg
+            assert "instances:" in cfg
+            assert "/mimir/local" in cfg
 
-    async def test_ravn_config_has_write_routing(self, session, flock_template):
+    async def test_mounted_config_has_write_routing(self, session, flock_template):
         provider = MagicMock()
         provider.get.return_value = flock_template
         c = RavnFlockContributor(template_provider=provider)
         ctx = SessionContext(template_name="ravn-flock")
         result = await c.contribute(session, ctx)
 
-        for ctr in result.pod_spec.extra_containers:
-            env = {e["name"]: e["value"] for e in ctr["env"]}
-            inline_cfg = env.get("RAVN_CONFIG_INLINE", "")
-            assert "write_routing:" in inline_cfg
-            # self/ always routes to local
-            assert "self/" in inline_cfg
+        for persona in ("coordinator", "reviewer"):
+            cfg = _extract_mounted_config(result.pod_spec, persona)
+            assert "write_routing:" in cfg
+            assert "self/" in cfg
 
-    async def test_ravn_config_hosted_url_in_instances(self, session, flock_template):
+    async def test_mounted_config_hosted_url_in_instances(self, session, flock_template):
         provider = MagicMock()
         provider.get.return_value = flock_template
         c = RavnFlockContributor(template_provider=provider)
         ctx = SessionContext(template_name="ravn-flock")
         result = await c.contribute(session, ctx)
 
-        for ctr in result.pod_spec.extra_containers:
-            env = {e["name"]: e["value"] for e in ctr["env"]}
-            inline_cfg = env.get("RAVN_CONFIG_INLINE", "")
-            # Hosted URL from flock_template is present as a mimir instance
-            assert "https://mimir.niuu.internal/api/v1" in inline_cfg
-            # Hosted instance routes project/ and entity/ pages
-            assert "project/" in inline_cfg
-            assert "entity/" in inline_cfg
+        for persona in ("coordinator", "reviewer"):
+            cfg = _extract_mounted_config(result.pod_spec, persona)
+            assert "https://mimir.niuu.internal/api/v1" in cfg
+            assert "project/" in cfg
+            assert "entity/" in cfg
 
-    async def test_ravn_config_no_hosted_url_only_local(self, session, flock_profile):
+    async def test_mounted_config_no_hosted_url_only_local(self, session, flock_profile):
         """When no hosted URL configured, config only has local mimir instance."""
         provider = MagicMock()
-        provider.get.return_value = flock_profile  # flock_profile has mimir: {}
+        provider.get.return_value = flock_profile
         c = RavnFlockContributor(profile_provider=provider)
         ctx = SessionContext(profile_name="ravn-flock")
         result = await c.contribute(session, ctx)
 
-        for ctr in result.pod_spec.extra_containers:
-            env = {e["name"]: e["value"] for e in ctr["env"]}
-            inline_cfg = env.get("RAVN_CONFIG_INLINE", "")
-            assert "/mimir/local" in inline_cfg
-            # No hosted instance — project/ and entity/ prefixes absent
-            assert "project/" not in inline_cfg
-            assert "entity/" not in inline_cfg
+        for persona in ("coordinator", "reviewer"):
+            cfg = _extract_mounted_config(result.pod_spec, persona)
+            assert "/mimir/local" in cfg
+            assert "project/" not in cfg
+            assert "entity/" not in cfg
 
-    async def test_ravn_config_sleipnir_webhook(self, session, flock_template):
+    async def test_mounted_config_sleipnir_webhook(self, session, flock_template):
         provider = MagicMock()
         provider.get.return_value = flock_template
         c = RavnFlockContributor(template_provider=provider)
         ctx = SessionContext(template_name="ravn-flock")
         result = await c.contribute(session, ctx)
 
-        for ctr in result.pod_spec.extra_containers:
-            env = {e["name"]: e["value"] for e in ctr["env"]}
-            inline_cfg = env.get("RAVN_CONFIG_INLINE", "")
-            assert "sleipnir:" in inline_cfg
-            assert "webhook" in inline_cfg
+        for persona in ("coordinator", "reviewer"):
+            cfg = _extract_mounted_config(result.pod_spec, persona)
+            assert "sleipnir:" in cfg
+            assert "webhook" in cfg
 
 
 # ---------------------------------------------------------------------------
@@ -487,6 +583,9 @@ class TestContributorPipelineMerge:
         # Mimir volume present
         volume_names = [v["name"] for v in spec.pod_spec.volumes]
         assert "mimir-local" in volume_names
+
+        # Init containers merged
+        assert len(spec.pod_spec.init_containers) == 2
 
     async def test_merge_preserves_skuld_env(self, session, flock_template):
         template_provider = MagicMock()
@@ -628,12 +727,11 @@ class TestLLMConfigPassthrough:
         ctx = SessionContext(template_name="ravn-flock-llm")
         result = await c.contribute(session, ctx)
 
-        for ctr in result.pod_spec.extra_containers:
-            env = {e["name"]: e["value"] for e in ctr["env"]}
-            inline_cfg = env.get("RAVN_CONFIG_INLINE", "")
-            assert "llm:" in inline_cfg
-            assert "Qwen/Qwen3-Coder-30B-A3B-Instruct" in inline_cfg
-            assert "vllm.valaskjalf.asgard.niuu.world" in inline_cfg
+        for persona in ("coordinator", "reviewer"):
+            cfg = _extract_mounted_config(result.pod_spec, persona)
+            assert "llm:" in cfg
+            assert "Qwen/Qwen3-Coder-30B-A3B-Instruct" in cfg
+            assert "vllm.valaskjalf.asgard.niuu.world" in cfg
 
     async def test_no_llm_block_when_not_provided(self, session, flock_template):
         """flock_template has no llm_config — no llm: block emitted."""
@@ -643,10 +741,9 @@ class TestLLMConfigPassthrough:
         ctx = SessionContext(template_name="ravn-flock")
         result = await c.contribute(session, ctx)
 
-        for ctr in result.pod_spec.extra_containers:
-            env = {e["name"]: e["value"] for e in ctr["env"]}
-            inline_cfg = env.get("RAVN_CONFIG_INLINE", "")
-            assert "llm:" not in inline_cfg
+        for persona in ("coordinator", "reviewer"):
+            cfg = _extract_mounted_config(result.pod_spec, persona)
+            assert "llm:" not in cfg
 
     async def test_llm_config_from_workload_context(self, session):
         """When workload_type comes directly via SessionContext (SpawnRequest path)."""
@@ -661,11 +758,9 @@ class TestLLMConfigPassthrough:
         result = await c.contribute(session, ctx)
 
         assert result.pod_spec is not None
-        ravn_ctr = result.pod_spec.extra_containers[0]
-        env = {e["name"]: e["value"] for e in ravn_ctr["env"]}
-        inline_cfg = env.get("RAVN_CONFIG_INLINE", "")
-        assert "llm:" in inline_cfg
-        assert "Qwen/Qwen3-Coder-30B-A3B-Instruct" in inline_cfg
+        cfg = _extract_mounted_config(result.pod_spec, "coordinator")
+        assert "llm:" in cfg
+        assert "Qwen/Qwen3-Coder-30B-A3B-Instruct" in cfg
 
     async def test_empty_llm_config_dict_not_emitted(self, session):
         """An empty llm_config dict should not produce an llm: block."""
@@ -679,10 +774,8 @@ class TestLLMConfigPassthrough:
         )
         result = await c.contribute(session, ctx)
 
-        ravn_ctr = result.pod_spec.extra_containers[0]
-        env = {e["name"]: e["value"] for e in ravn_ctr["env"]}
-        inline_cfg = env.get("RAVN_CONFIG_INLINE", "")
-        assert "llm:" not in inline_cfg
+        cfg = _extract_mounted_config(result.pod_spec, "coordinator")
+        assert "llm:" not in cfg
 
     async def test_all_nodes_receive_same_llm_config(self, session):
         """All ravn nodes in a flock receive the same llm_config."""
@@ -697,7 +790,6 @@ class TestLLMConfigPassthrough:
         )
         result = await c.contribute(session, ctx)
 
-        for ctr in result.pod_spec.extra_containers:
-            env = {e["name"]: e["value"] for e in ctr["env"]}
-            inline_cfg = env.get("RAVN_CONFIG_INLINE", "")
-            assert "claude-sonnet-4-6" in inline_cfg
+        for persona in ("coordinator", "reviewer"):
+            cfg = _extract_mounted_config(result.pod_spec, persona)
+            assert "claude-sonnet-4-6" in cfg

--- a/tests/test_ravn/test_startup_echo.py
+++ b/tests/test_ravn/test_startup_echo.py
@@ -1,0 +1,97 @@
+"""Tests for ravn daemon startup config echo (NIU-635)."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import pytest
+
+from ravn.cli.commands import _log_effective_config
+from ravn.config import Settings
+
+
+@pytest.fixture
+def _clean_env(monkeypatch):
+    """Remove RAVN_ env vars that interfere with Settings() defaults."""
+    for key in list(os.environ):
+        if key.startswith("RAVN_"):
+            monkeypatch.delenv(key, raising=False)
+
+
+class TestStartupEcho:
+    @pytest.mark.usefixtures("_clean_env")
+    def test_log_contains_required_fields(self, caplog):
+        """The startup log line must contain persona, llm_alias, thinking, budget, source."""
+        settings = Settings()
+        with caplog.at_level(logging.INFO, logger="ravn.cli.commands"):
+            _log_effective_config(settings)
+
+        assert len(caplog.records) == 1
+        msg = caplog.records[0].message
+        assert "persona=" in msg
+        assert "llm_alias=" in msg
+        assert "thinking=" in msg
+        assert "budget=" in msg
+        assert "source=" in msg
+
+    @pytest.mark.usefixtures("_clean_env")
+    def test_source_reflects_ravn_config_env(self, caplog, monkeypatch):
+        """When RAVN_CONFIG is set, source= shows that path."""
+        monkeypatch.setenv("RAVN_CONFIG", "/etc/ravn/config.yaml")
+        settings = Settings()
+        with caplog.at_level(logging.INFO, logger="ravn.cli.commands"):
+            _log_effective_config(settings)
+
+        assert "source=/etc/ravn/config.yaml" in caplog.records[0].message
+
+    @pytest.mark.usefixtures("_clean_env")
+    def test_source_defaults_when_no_env(self, caplog):
+        """Without RAVN_CONFIG, source=defaults."""
+        settings = Settings()
+        with caplog.at_level(logging.INFO, logger="ravn.cli.commands"):
+            _log_effective_config(settings)
+
+        assert "source=defaults" in caplog.records[0].message
+
+    @pytest.mark.usefixtures("_clean_env")
+    def test_persona_from_env(self, caplog, monkeypatch):
+        """RAVN_PERSONA env var is reflected in the log."""
+        monkeypatch.setenv("RAVN_PERSONA", "coordinator")
+        settings = Settings()
+        with caplog.at_level(logging.INFO, logger="ravn.cli.commands"):
+            _log_effective_config(settings)
+
+        assert "persona=coordinator" in caplog.records[0].message
+
+    @pytest.mark.usefixtures("_clean_env")
+    def test_default_persona(self, caplog):
+        """Without RAVN_PERSONA, persona=default."""
+        settings = Settings()
+        with caplog.at_level(logging.INFO, logger="ravn.cli.commands"):
+            _log_effective_config(settings)
+
+        assert "persona=default" in caplog.records[0].message
+
+    @pytest.mark.usefixtures("_clean_env")
+    def test_llm_alias_from_settings(self, caplog):
+        """llm_alias reflects the effective model from settings."""
+        settings = Settings()
+        with caplog.at_level(logging.INFO, logger="ravn.cli.commands"):
+            _log_effective_config(settings)
+
+        expected = settings.effective_model()
+        assert f"llm_alias={expected}" in caplog.records[0].message
+
+    @pytest.mark.usefixtures("_clean_env")
+    def test_thinking_and_budget_from_settings(self, caplog):
+        """thinking and budget reflect extended_thinking config."""
+        settings = Settings()
+        with caplog.at_level(logging.INFO, logger="ravn.cli.commands"):
+            _log_effective_config(settings)
+
+        msg = caplog.records[0].message
+        thinking = settings.llm.extended_thinking.enabled
+        budget = settings.llm.extended_thinking.budget_tokens
+        assert f"thinking={thinking}" in msg
+        assert f"budget={budget}" in msg

--- a/tests/test_ravn/test_startup_echo.py
+++ b/tests/test_ravn/test_startup_echo.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 import logging
 import os
+from unittest.mock import patch
 
 import pytest
+from typer.testing import CliRunner
 
-from ravn.cli.commands import _log_effective_config
+from ravn.cli.commands import _log_effective_config, app
 from ravn.config import Settings
+
+runner = CliRunner()
 
 
 @pytest.fixture
@@ -95,3 +99,27 @@ class TestStartupEcho:
         budget = settings.llm.extended_thinking.budget_tokens
         assert f"thinking={thinking}" in msg
         assert f"budget={budget}" in msg
+
+
+class TestDaemonCallsConfigEcho:
+    """Verify daemon and listen commands call _log_effective_config."""
+
+    @pytest.mark.usefixtures("_clean_env")
+    def test_daemon_emits_config_log(self):
+        with (
+            patch("ravn.cli.commands._log_effective_config") as mock_log,
+            patch("ravn.cli.commands.asyncio.run"),
+        ):
+            runner.invoke(app, ["daemon"])
+
+        mock_log.assert_called_once()
+
+    @pytest.mark.usefixtures("_clean_env")
+    def test_listen_emits_config_log(self):
+        with (
+            patch("ravn.cli.commands._log_effective_config") as mock_log,
+            patch("ravn.cli.commands.asyncio.run"),
+        ):
+            runner.invoke(app, ["listen"])
+
+        mock_log.assert_called_once()


### PR DESCRIPTION
## Summary

- **Replace `RAVN_CONFIG_INLINE` env var with mounted config files**: Each ravn sidecar now gets a per-persona emptyDir volume and an initContainer that writes the materialized YAML config to `/etc/ravn/config.yaml`. Sidecars mount the volume read-only and set `RAVN_CONFIG=/etc/ravn/config.yaml`.
- **Add `init_containers` to `PodSpecAdditions`**: New field on the model, with merge support in `_merge_pod_specs` and integration in `_build_init_containers` on the pod manager.
- **Add startup config echo to ravn daemon**: `_log_effective_config()` emits an INFO log with `persona`, `llm_alias`, `thinking`, `budget`, and `source` fields for drift detection.
- **Zero `RAVN_CONFIG_INLINE` references remain** in the source after merge.

## Files Changed

| File | Change |
|------|--------|
| `src/volundr/domain/models.py` | Add `init_containers` field to `PodSpecAdditions`, update merge |
| `src/volundr/adapters/outbound/contributors/ravn_flock.py` | Replace inline env var with initContainer + volume mount |
| `src/volundr/adapters/outbound/direct_k8s_pod_manager.py` | Append contributor init containers to pod manifest |
| `src/ravn/cli/commands.py` | Add `_log_effective_config()` startup echo |
| `tests/test_adapters/test_contributors/test_ravn_flock.py` | Rewrite config tests to assert mounted config |
| `tests/test_ravn/test_startup_echo.py` | New — test startup config echo fields |

## Test plan

- [x] All 50 contributor tests pass (including 6 new mounted config tests)
- [x] All 7 startup echo tests pass
- [x] `ruff check` and `ruff format` clean
- [x] `grep RAVN_CONFIG_INLINE src/` returns zero hits
- [ ] CI passes (tests, lint, coverage)

> **Note**: Linear MCP tools were not available in this environment. Ticket NIU-635 should be manually set to "In Review" with a link to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)