### PR TITLE
feat(adapters): per-persona LLM overrides in flock dispatch config (NIU-637)

### DIFF
--- a/src/tyr/config.py
+++ b/src/tyr/config.py
@@ -16,7 +16,7 @@ import os
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from pydantic_settings import (
     BaseSettings,
     PydanticBaseSettingsSource,
@@ -388,6 +388,40 @@ class PlannerConfig(BaseModel):
     )
 
 
+class PersonaOverride(BaseModel):
+    """Per-persona LLM and iteration override for flock dispatch.
+
+    Accepted in ``FlockConfig.default_personas`` alongside bare strings (legacy).
+    The ``llm`` dict is forwarded verbatim as the per-persona ``llm`` key in
+    ``workload_config.personas``; ravn merges it over the global ``llm_config``.
+    """
+
+    name: str = Field(description="Ravn persona name (e.g. 'coordinator', 'reviewer').")
+    llm: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Per-persona LLM override merged over the global llm_config.",
+    )
+    system_prompt_extra: str | None = Field(
+        default=None,
+        description="Extra instructions appended to this persona's system prompt.",
+    )
+    iteration_budget: int | None = Field(
+        default=None,
+        description="Max iterations for this persona; overrides the persona's own default.",
+    )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to the wire dict format consumed by workload_config.personas."""
+        d: dict[str, Any] = {"name": self.name}
+        if self.llm:
+            d["llm"] = dict(self.llm)
+        if self.system_prompt_extra:
+            d["system_prompt_extra"] = self.system_prompt_extra
+        if self.iteration_budget is not None:
+            d["iteration_budget"] = self.iteration_budget
+        return d
+
+
 class FlockConfig(BaseModel):
     """Flock dispatch configuration."""
 
@@ -395,10 +429,31 @@ class FlockConfig(BaseModel):
         default=False,
         description="When True, eligible raids are dispatched as ravn_flock sessions.",
     )
-    default_personas: list[str] = Field(
-        default=["coordinator", "reviewer"],
-        description="Ravn persona names included in every flock session.",
+    default_personas: list[PersonaOverride] = Field(
+        default_factory=lambda: [
+            PersonaOverride(name="coordinator"),
+            PersonaOverride(name="reviewer"),
+        ],
+        description=(
+            "Ravn persona names included in every flock session. "
+            "Accepts bare strings (legacy) or per-persona override objects."
+        ),
     )
+
+    @field_validator("default_personas", mode="before")
+    @classmethod
+    def _coerce_personas(cls, v: Any) -> list[Any]:
+        """Accept both legacy list[str] and new list[dict|PersonaOverride]."""
+        if not isinstance(v, list):
+            return v
+        result = []
+        for item in v:
+            if isinstance(item, str):
+                result.append({"name": item})
+            else:
+                result.append(item)
+        return result
+
     mimir_hosted_url: str = Field(
         default="",
         description="URL of the Mimir knowledge base for coordinator context queries.",

--- a/src/tyr/domain/services/dispatch_service.py
+++ b/src/tyr/domain/services/dispatch_service.py
@@ -192,6 +192,26 @@ def build_flock_prompt(
     return "\n".join(parts)
 
 
+def _format_persona_label(persona: dict) -> str:
+    """Return a log-friendly label for one persona dict.
+
+    Examples:
+      ``coordinator`` → ``coordinator(inherit)``
+      ``reviewer`` with ``llm.primary_alias=powerful, thinking_enabled=True``
+        → ``reviewer(powerful/thinking)``
+      ``security-auditor`` with ``llm.primary_alias=balanced``
+        → ``security-auditor(balanced)``
+    """
+    name = persona.get("name", "?")
+    llm = persona.get("llm", {})
+    alias = llm.get("primary_alias", "")
+    thinking = llm.get("thinking_enabled", False)
+    if not alias:
+        return f"{name}(inherit)"
+    suffix = "/thinking" if thinking else ""
+    return f"{name}({alias}{suffix})"
+
+
 def resolve_target_adapter(
     connection_id: str | None,
     adapter_by_name: dict[str, VolundrPort],
@@ -222,7 +242,9 @@ class DispatchConfig:
     templates_dir: Path = BUNDLED_TEMPLATES_DIR
     initial_confidence: float = 0.5
     flock_enabled: bool = False
-    flock_default_personas: list[str] = field(default_factory=lambda: ["coordinator", "reviewer"])
+    flock_default_personas: list[dict] = field(
+        default_factory=lambda: [{"name": "coordinator"}, {"name": "reviewer"}]
+    )
     flock_mimir_hosted_url: str = ""
     flock_sleipnir_publish_urls: list[str] = field(default_factory=list)
     flock_llm_config: dict = field(default_factory=dict)
@@ -796,8 +818,14 @@ class DispatchService:
                 integration_ids=integration_ids,
             )
 
+        personas = self._config.flock_default_personas
+        logger.info(
+            "flock dispatch session=%s personas=[%s]",
+            session_name,
+            ", ".join(_format_persona_label(p) for p in personas),
+        )
         workload_config: dict = {
-            "personas": self._config.flock_default_personas,
+            "personas": personas,
             "initiative_context": build_flock_prompt(
                 issue,
                 item.repo,

--- a/src/tyr/main.py
+++ b/src/tyr/main.py
@@ -288,7 +288,9 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                     default_model=settings.dispatch.default_model,
                     dispatch_prompt_template=settings.dispatch.dispatch_prompt_template,
                     flock_enabled=settings.dispatch.flock.enabled,
-                    flock_default_personas=list(settings.dispatch.flock.default_personas),
+                    flock_default_personas=[
+                        p.to_dict() for p in settings.dispatch.flock.default_personas
+                    ],
                     flock_mimir_hosted_url=settings.dispatch.flock.mimir_hosted_url,
                     flock_sleipnir_publish_urls=list(settings.dispatch.flock.sleipnir_publish_urls),
                     flock_llm_config=dict(settings.dispatch.flock.llm_config),

--- a/tests/test_tyr/test_flock_dispatch.py
+++ b/tests/test_tyr/test_flock_dispatch.py
@@ -77,7 +77,7 @@ def _make_issue(
 def _make_flock_config(**overrides) -> DispatchConfig:
     defaults = dict(
         flock_enabled=True,
-        flock_default_personas=["coordinator", "reviewer"],
+        flock_default_personas=[{"name": "coordinator"}, {"name": "reviewer"}],
         flock_mimir_hosted_url="https://mimir.example.com",
         flock_sleipnir_publish_urls=["nats://sleipnir.example.com"],
     )
@@ -114,7 +114,9 @@ class TestBuildSpawnRequestFlockEnabled:
         assert req.workload_type == "ravn_flock"
 
     def test_workload_config_contains_personas(self) -> None:
-        config = _make_flock_config(flock_default_personas=["coordinator", "reviewer"])
+        config = _make_flock_config(
+            flock_default_personas=[{"name": "coordinator"}, {"name": "reviewer"}]
+        )
         saga = _make_saga()
         issue = _make_issue()
         item = DispatchItem(saga_id=str(saga.id), issue_id="i-1", repo="org/repo-a")
@@ -131,7 +133,7 @@ class TestBuildSpawnRequestFlockEnabled:
             integration_ids=[],
         )
 
-        assert req.workload_config["personas"] == ["coordinator", "reviewer"]
+        assert req.workload_config["personas"] == [{"name": "coordinator"}, {"name": "reviewer"}]
 
     def test_workload_config_contains_sleipnir_publish_urls(self) -> None:
         config = _make_flock_config(

--- a/tests/test_tyr/test_services/test_dispatch_service.py
+++ b/tests/test_tyr/test_services/test_dispatch_service.py
@@ -6,11 +6,15 @@ find_ready_issues and dispatch_issues behave correctly.
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
+from unittest.mock import MagicMock
 from uuid import uuid4
 
 import pytest
+import yaml
 
+from tyr.config import FlockConfig, PersonaOverride
 from tyr.domain.models import (
     Saga,
     SagaStatus,
@@ -22,6 +26,7 @@ from tyr.domain.services.dispatch_service import (
     DispatchConfig,
     DispatchItem,
     DispatchService,
+    _format_persona_label,
     build_prompt,
     is_ready,
     resolve_target_adapter,
@@ -733,3 +738,240 @@ class TestActiveSagaFiltering:
         # Fallback returns None for project → no auto-archive, issues still returned
         items = await svc.find_ready_issues("dev-user")
         assert len(items) > 0
+
+
+# -------------------------------------------------------------------
+# Per-persona LLM override tests (NIU-637)
+# -------------------------------------------------------------------
+
+
+class TestFormatPersonaLabel:
+    """_format_persona_label produces the correct log string."""
+
+    def test_no_llm_shows_inherit(self):
+        assert _format_persona_label({"name": "coordinator"}) == "coordinator(inherit)"
+
+    def test_alias_shown(self):
+        assert (
+            _format_persona_label({"name": "auditor", "llm": {"primary_alias": "balanced"}})
+            == "auditor(balanced)"
+        )
+
+    def test_alias_with_thinking(self):
+        assert (
+            _format_persona_label(
+                {"name": "reviewer", "llm": {"primary_alias": "powerful", "thinking_enabled": True}}
+            )
+            == "reviewer(powerful/thinking)"
+        )
+
+    def test_thinking_false_no_suffix(self):
+        persona = {
+            "name": "reviewer",
+            "llm": {"primary_alias": "powerful", "thinking_enabled": False},
+        }
+        assert _format_persona_label(persona) == "reviewer(powerful)"
+
+    def test_empty_llm_shows_inherit(self):
+        assert _format_persona_label({"name": "coder", "llm": {}}) == "coder(inherit)"
+
+
+class TestPersonaOverrideModel:
+    """PersonaOverride pydantic model: construction and serialisation."""
+
+    def test_bare_string_coerced_by_flock_config(self):
+        cfg = FlockConfig(default_personas=["coordinator", "reviewer"])  # type: ignore[arg-type]
+        assert len(cfg.default_personas) == 2
+        assert all(isinstance(p, PersonaOverride) for p in cfg.default_personas)
+        assert cfg.default_personas[0].name == "coordinator"
+        assert cfg.default_personas[1].name == "reviewer"
+
+    def test_dict_accepted(self):
+        cfg = FlockConfig(
+            default_personas=[
+                {"name": "coordinator"},
+                {"name": "reviewer", "llm": {"primary_alias": "powerful"}, "iteration_budget": 40},
+            ]
+        )
+        assert cfg.default_personas[1].llm == {"primary_alias": "powerful"}
+        assert cfg.default_personas[1].iteration_budget == 40
+
+    def test_to_dict_minimal(self):
+        p = PersonaOverride(name="coordinator")
+        assert p.to_dict() == {"name": "coordinator"}
+
+    def test_to_dict_with_overrides(self):
+        p = PersonaOverride(
+            name="reviewer",
+            llm={"primary_alias": "powerful", "thinking_enabled": True},
+            iteration_budget=40,
+        )
+        d = p.to_dict()
+        assert d == {
+            "name": "reviewer",
+            "llm": {"primary_alias": "powerful", "thinking_enabled": True},
+            "iteration_budget": 40,
+        }
+
+    def test_to_dict_omits_empty_llm(self):
+        p = PersonaOverride(name="coordinator")
+        assert "llm" not in p.to_dict()
+
+    def test_to_dict_omits_none_iteration_budget(self):
+        p = PersonaOverride(name="coordinator")
+        assert "iteration_budget" not in p.to_dict()
+
+    def test_to_dict_omits_none_system_prompt_extra(self):
+        p = PersonaOverride(name="coordinator")
+        assert "system_prompt_extra" not in p.to_dict()
+
+
+class TestFlockConfigYamlParse:
+    """FlockConfig handles legacy string lists and per-persona dicts from YAML."""
+
+    def test_legacy_string_list(self):
+        raw = yaml.safe_load(
+            """
+            enabled: true
+            default_personas:
+              - coordinator
+              - reviewer
+            """
+        )
+        cfg = FlockConfig(**raw)
+        assert [p.name for p in cfg.default_personas] == ["coordinator", "reviewer"]
+        assert all(p.llm == {} for p in cfg.default_personas)
+
+    def test_per_persona_dict_list(self):
+        raw = yaml.safe_load(
+            """
+            enabled: true
+            default_personas:
+              - name: coordinator
+              - name: reviewer
+                llm:
+                  primary_alias: powerful
+                  thinking_enabled: true
+                iteration_budget: 40
+              - name: security-auditor
+                llm:
+                  primary_alias: balanced
+            """
+        )
+        cfg = FlockConfig(**raw)
+        names = [p.name for p in cfg.default_personas]
+        assert names == ["coordinator", "reviewer", "security-auditor"]
+        coordinator = cfg.default_personas[0]
+        reviewer = cfg.default_personas[1]
+        auditor = cfg.default_personas[2]
+        assert coordinator.llm == {}
+        assert reviewer.llm == {"primary_alias": "powerful", "thinking_enabled": True}
+        assert reviewer.iteration_budget == 40
+        assert auditor.llm == {"primary_alias": "balanced"}
+
+
+class TestBuildSpawnRequestPersonaOverrides:
+    """_build_spawn_request emits the correct personas list-of-dicts."""
+
+    def _make_saga(self) -> Saga:
+        return Saga(
+            id=uuid4(),
+            tracker_id="proj-1",
+            tracker_type="linear",
+            slug="alpha",
+            name="Alpha",
+            repos=["org/repo"],
+            feature_branch="feat/alpha",
+            base_branch="main",
+            status=SagaStatus.ACTIVE,
+            confidence=0.5,
+            created_at=datetime.now(UTC),
+        )
+
+    def _make_issue(self) -> TrackerIssue:
+        return TrackerIssue(
+            id="i-1",
+            identifier="ALPHA-1",
+            title="Task",
+            description="Do it",
+            status="Todo",
+            url="https://linear.app/i-1",
+        )
+
+    def _call(self, config: DispatchConfig, saga, issue):
+        svc = MagicMock()
+        svc._config = config
+        item = DispatchItem(saga_id=str(saga.id), issue_id="i-1", repo="org/repo")
+        return DispatchService._build_spawn_request(
+            svc,
+            item=item,
+            saga=saga,
+            issue=issue,
+            effective_model="claude-sonnet-4-6",
+            effective_prompt="",
+            integration_ids=[],
+        )
+
+    def test_legacy_string_personas_emit_dicts(self):
+        """Legacy list[str] → list-of-dicts in workload_config."""
+        config = DispatchConfig(
+            flock_enabled=True,
+            flock_default_personas=[{"name": "coordinator"}, {"name": "reviewer"}],
+        )
+        req = self._call(config, self._make_saga(), self._make_issue())
+        assert req.workload_config["personas"] == [{"name": "coordinator"}, {"name": "reviewer"}]
+
+    def test_per_persona_overrides_forwarded(self):
+        """Per-persona llm dict and iteration_budget are included in workload_config."""
+        personas = [
+            {"name": "coordinator"},
+            {
+                "name": "reviewer",
+                "llm": {"primary_alias": "powerful", "thinking_enabled": True},
+                "iteration_budget": 40,
+            },
+            {"name": "security-auditor", "llm": {"primary_alias": "balanced"}},
+        ]
+        config = DispatchConfig(flock_enabled=True, flock_default_personas=personas)
+        req = self._call(config, self._make_saga(), self._make_issue())
+        emitted = req.workload_config["personas"]
+        assert emitted[0] == {"name": "coordinator"}
+        assert emitted[1] == {
+            "name": "reviewer",
+            "llm": {"primary_alias": "powerful", "thinking_enabled": True},
+            "iteration_budget": 40,
+        }
+        assert emitted[2] == {"name": "security-auditor", "llm": {"primary_alias": "balanced"}}
+
+    def test_global_llm_config_still_present(self):
+        """Global llm_config key is still included alongside per-persona personas."""
+        llm = {"primary_alias": "balanced"}
+        config = DispatchConfig(
+            flock_enabled=True,
+            flock_default_personas=[{"name": "coordinator"}],
+            flock_llm_config=llm,
+        )
+        req = self._call(config, self._make_saga(), self._make_issue())
+        assert req.workload_config["llm_config"] == llm
+        assert req.workload_config["personas"] == [{"name": "coordinator"}]
+
+    def test_info_log_emitted(self, caplog):
+        """INFO log includes session name and formatted persona labels."""
+        config = DispatchConfig(
+            flock_enabled=True,
+            flock_default_personas=[
+                {"name": "coordinator"},
+                {
+                    "name": "reviewer",
+                    "llm": {"primary_alias": "powerful", "thinking_enabled": True},
+                },
+                {"name": "security-auditor", "llm": {"primary_alias": "balanced"}},
+            ],
+        )
+        saga = self._make_saga()
+        issue = self._make_issue()
+        with caplog.at_level(logging.INFO, logger="tyr.domain.services.dispatch_service"):
+            self._call(config, saga, issue)
+        assert any("coordinator(inherit)" in r.message for r in caplog.records)
+        assert any("reviewer(powerful/thinking)" in r.message for r in caplog.records)
+        assert any("security-auditor(balanced)" in r.message for r in caplog.records)

--- a/tyr.yaml.example
+++ b/tyr.yaml.example
@@ -28,6 +28,41 @@ dispatch:
   default_model: claude-sonnet-4-6
   default_system_prompt: ""
 
+  # ---------------------------------------------------------------------------
+  # Flock — multi-agent ravn_flock sessions
+  # ---------------------------------------------------------------------------
+  # When enabled, raids are dispatched as multi-agent flock sessions instead of
+  # solo coding sessions.  default_personas accepts either bare names (legacy)
+  # or per-persona override objects with llm/iteration_budget overrides.
+  #
+  # Legacy (all personas share global llm_config):
+  #   flock:
+  #     enabled: true
+  #     default_personas:
+  #       - coordinator
+  #       - reviewer
+  #
+  # Per-persona overrides (each persona can specify its own LLM alias):
+  #   flock:
+  #     enabled: true
+  #     default_personas:
+  #       - name: coordinator          # inherits global llm_config
+  #       - name: reviewer
+  #         llm:
+  #           primary_alias: powerful  # use the powerful alias for review
+  #           thinking_enabled: true
+  #         iteration_budget: 40
+  #       - name: security-auditor
+  #         llm:
+  #           primary_alias: balanced
+  #     llm_config:                    # global fallback for all personas
+  #       primary_alias: balanced
+  flock:
+    enabled: false
+    default_personas:
+      - coordinator
+      - reviewer
+
   # Template for the initial prompt sent to coding sessions.
   # Placeholders: {identifier}, {title}, {description}, {repo},
   #               {feature_branch}, {raid_branch}


### PR DESCRIPTION
## Summary

- Adds `PersonaOverride` pydantic model to `src/tyr/config.py` with a `to_dict()` serialiser
- Extends `FlockConfig.default_personas` to accept both legacy `list[str]` and new `list[PersonaOverride]` via a `field_validator` that coerces bare strings into `PersonaOverride(name=...)`
- Changes `DispatchConfig.flock_default_personas` from `list[str]` to `list[dict]` (already-normalised wire format)
- `_build_spawn_request()` now emits `workload_config.personas` as a list-of-dicts that round-trips through the NIU-2 normaliser in Volundr
- Adds `_format_persona_label()` helper and INFO log at dispatch time: `flock dispatch session=<id> personas=[coordinator(inherit), reviewer(powerful/thinking), security-auditor(balanced)]`
- Updates `src/tyr/main.py` wiring to call `p.to_dict()` on each `PersonaOverride`
- Annotates `tyr.yaml.example` with commented per-persona override examples

## Test plan

- [x] `TestFormatPersonaLabel` — label formatting for inherit / alias / alias+thinking
- [x] `TestPersonaOverrideModel` — Pydantic construction, `to_dict()` serialisation, field omission rules
- [x] `TestFlockConfigYamlParse` — legacy `list[str]` YAML and per-persona dict YAML both parse correctly
- [x] `TestBuildSpawnRequestPersonaOverrides` — legacy format emits list-of-dicts, per-persona overrides forwarded, global `llm_config` still present, INFO log contains correct labels
- [x] All existing `test_flock_dispatch.py` tests updated and passing (personas now list-of-dicts)
- [x] Full tyr test suite: 1361 passed, 88% coverage (≥ 85% threshold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)