### PR TITLE
feat(adapters): HttpPersonaAdapter — ravn sidecars fetch personas from volundr REST (NIU-641)

### DIFF
--- a/src/ravn/adapters/personas/__init__.py
+++ b/src/ravn/adapters/personas/__init__.py
@@ -1,5 +1,6 @@
 """Persona configuration adapters for Ravn."""
 
+from ravn.adapters.personas.http import HttpPersonaAdapter
 from ravn.adapters.personas.loader import FilesystemPersonaAdapter
 
-__all__ = ["FilesystemPersonaAdapter"]
+__all__ = ["FilesystemPersonaAdapter", "HttpPersonaAdapter"]

--- a/src/ravn/adapters/personas/http.py
+++ b/src/ravn/adapters/personas/http.py
@@ -30,18 +30,16 @@ from __future__ import annotations
 
 import logging
 import os
-import time
-from dataclasses import dataclass
-from typing import Any
 
 import httpx
 
+from niuu.domain.models import CacheEntry
 from ravn.adapters.personas.loader import (
     PersonaConfig,
-    PersonaConsumes,
-    PersonaFanIn,
     PersonaLLMConfig,
-    PersonaProduces,
+    _parse_consumes,
+    _parse_fan_in,
+    _parse_produces,
 )
 from ravn.ports.persona import PersonaPort
 
@@ -50,12 +48,6 @@ logger = logging.getLogger(__name__)
 _DEFAULT_TIMEOUT_SECONDS: float = 5.0
 _DEFAULT_CACHE_TTL_SECONDS: int = 60
 _DEFAULT_TOKEN_ENV: str = "RAVN_VOLUNDR_TOKEN"
-
-
-@dataclass
-class _CacheEntry:
-    value: Any
-    expires_at: float
 
 
 class HttpPersonaAdapter(PersonaPort):
@@ -84,15 +76,21 @@ class HttpPersonaAdapter(PersonaPort):
         self._ttl = cache_ttl_seconds
         self._token_env = token_env
         self._transport = _transport
+        self._http: httpx.Client | None = None
 
-        # Per-persona cache: name → _CacheEntry(PersonaConfig | None, expires_at)
-        self._persona_cache: dict[str, _CacheEntry] = {}
-        # Names-list cache: _CacheEntry(list[str], expires_at) | None
-        self._names_cache: _CacheEntry | None = None
+        # Per-persona cache: name → CacheEntry(PersonaConfig | None)
+        self._persona_cache: dict[str, CacheEntry] = {}
+        # Names-list cache: CacheEntry(list[str]) | None
+        self._names_cache: CacheEntry | None = None
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    def _get_client(self) -> httpx.Client:
+        if self._http is None or self._http.is_closed:
+            self._http = httpx.Client(timeout=self._timeout, transport=self._transport)
+        return self._http
 
     def _auth_headers(self) -> dict[str, str]:
         token = os.environ.get(self._token_env, "")
@@ -100,22 +98,16 @@ class HttpPersonaAdapter(PersonaPort):
             return {}
         return {"Authorization": f"Bearer {token}"}
 
-    def _is_fresh(self, entry: _CacheEntry) -> bool:
-        return time.monotonic() < entry.expires_at
-
-    def _new_entry(self, value: Any) -> _CacheEntry:
-        return _CacheEntry(value=value, expires_at=time.monotonic() + self._ttl)
-
-    def _client(self) -> httpx.Client:
-        return httpx.Client(timeout=self._timeout, transport=self._transport)
-
     @staticmethod
     def _parse_detail(data: dict) -> PersonaConfig:
-        """Parse a PersonaDetail JSON payload into a PersonaConfig."""
+        """Parse a PersonaDetail JSON payload into a PersonaConfig.
+
+        Reuses ``_parse_produces``, ``_parse_consumes``, and ``_parse_fan_in``
+        from ``loader.py`` so that schema fields (``produces.schema``,
+        ``event_type_map``, etc.) are parsed identically to the filesystem
+        adapter — no data loss for personas that declare an outcome schema.
+        """
         llm = data.get("llm") or {}
-        produces = data.get("produces") or {}
-        consumes = data.get("consumes") or {}
-        fan_in = data.get("fan_in") or {}
 
         return PersonaConfig(
             name=data["name"],
@@ -129,17 +121,9 @@ class HttpPersonaAdapter(PersonaPort):
                 thinking_enabled=bool(llm.get("thinking_enabled", False)),
                 max_tokens=int(llm.get("max_tokens") or 0),
             ),
-            produces=PersonaProduces(
-                event_type=produces.get("event_type", ""),
-            ),
-            consumes=PersonaConsumes(
-                event_types=list(consumes.get("event_types") or []),
-                injects=list(consumes.get("injects") or []),
-            ),
-            fan_in=PersonaFanIn(
-                strategy=fan_in.get("strategy", "merge"),
-                contributes_to=fan_in.get("contributes_to", ""),
-            ),
+            produces=_parse_produces(data.get("produces")),
+            consumes=_parse_consumes(data.get("consumes")),
+            fan_in=_parse_fan_in(data.get("fan_in")),
         )
 
     # ------------------------------------------------------------------
@@ -154,16 +138,15 @@ class HttpPersonaAdapter(PersonaPort):
         prior entry exists).
         """
         cached = self._persona_cache.get(name)
-        if cached is not None and self._is_fresh(cached):
-            return cached.value
+        if cached is not None and not cached.expired:
+            return cached.value  # type: ignore[return-value]
 
         url = f"{self._base_url}/api/v1/ravn/personas/{name}"
         try:
-            with self._client() as client:
-                response = client.get(url, headers=self._auth_headers())
+            response = self._get_client().get(url, headers=self._auth_headers())
         except Exception as exc:  # network / timeout
             logger.warning("HttpPersonaAdapter: request failed for %r: %s", name, exc)
-            return cached.value if cached is not None else None
+            return cached.value if cached is not None else None  # type: ignore[return-value]
 
         if response.status_code == 404:
             # Definitively missing — do not cache so that newly created
@@ -176,10 +159,10 @@ class HttpPersonaAdapter(PersonaPort):
                 url,
                 response.status_code,
             )
-            return cached.value if cached is not None else None
+            return cached.value if cached is not None else None  # type: ignore[return-value]
 
         config = self._parse_detail(response.json())
-        self._persona_cache[name] = self._new_entry(config)
+        self._persona_cache[name] = CacheEntry(config, self._ttl)
         return config
 
     def list_names(self) -> list[str]:
@@ -188,16 +171,15 @@ class HttpPersonaAdapter(PersonaPort):
         Falls back to the last cached list on HTTP or transport errors; returns
         ``[]`` if no cached list is available.
         """
-        if self._names_cache is not None and self._is_fresh(self._names_cache):
-            return list(self._names_cache.value)
+        if self._names_cache is not None and not self._names_cache.expired:
+            return list(self._names_cache.value)  # type: ignore[arg-type]
 
         url = f"{self._base_url}/api/v1/ravn/personas"
         try:
-            with self._client() as client:
-                response = client.get(url, headers=self._auth_headers())
+            response = self._get_client().get(url, headers=self._auth_headers())
         except Exception as exc:  # network / timeout
             logger.warning("HttpPersonaAdapter: list_names request failed: %s", exc)
-            return list(self._names_cache.value) if self._names_cache is not None else []
+            return list(self._names_cache.value) if self._names_cache is not None else []  # type: ignore[arg-type]
 
         if response.status_code >= 400:
             logger.warning(
@@ -205,22 +187,22 @@ class HttpPersonaAdapter(PersonaPort):
                 url,
                 response.status_code,
             )
-            return list(self._names_cache.value) if self._names_cache is not None else []
+            return list(self._names_cache.value) if self._names_cache is not None else []  # type: ignore[arg-type]
 
         names = sorted(item["name"] for item in response.json())
-        self._names_cache = self._new_entry(names)
+        self._names_cache = CacheEntry(names, self._ttl)
         return list(names)
 
     # ------------------------------------------------------------------
     # Write operations — not supported
     # ------------------------------------------------------------------
 
-    def save(self, config: PersonaConfig) -> None:  # type: ignore[override]
+    def save(self, config: PersonaConfig) -> None:
         raise NotImplementedError(
             "Use the volundr REST API to edit personas; this adapter is read-only."
         )
 
-    def delete(self, name: str) -> bool:  # type: ignore[override]
+    def delete(self, name: str) -> bool:
         raise NotImplementedError(
             "Use the volundr REST API to edit personas; this adapter is read-only."
         )

--- a/src/ravn/adapters/personas/http.py
+++ b/src/ravn/adapters/personas/http.py
@@ -1,0 +1,226 @@
+"""HttpPersonaAdapter — fetches personas from the volundr REST registry.
+
+Used when ravn sidecars cannot mount ConfigMaps and need to pull persona
+definitions from a central volundr instance at runtime.
+
+Auth
+----
+The adapter reads a PAT from an environment variable (default
+``RAVN_VOLUNDR_TOKEN``) and sends it as ``Authorization: Bearer <token>``.
+The token is mounted as a Kubernetes secret in production.
+
+Cache
+-----
+Responses are cached in-memory with a configurable TTL (default 60 s).  This
+prevents hammering volundr on every ravn decision cycle, while still allowing
+edits to propagate within one TTL window.
+
+Fail-closed
+-----------
+Network errors and 5xx responses are treated as transient failures:
+
+* ``load()`` returns the last cached value, or ``None`` if nothing is cached.
+* ``list_names()`` returns the last cached list, or ``[]`` if nothing is cached.
+
+Neither method raises on transport or server errors so the ravn sidecar can
+keep running with stale data rather than crashing.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from ravn.adapters.personas.loader import (
+    PersonaConfig,
+    PersonaConsumes,
+    PersonaFanIn,
+    PersonaLLMConfig,
+    PersonaProduces,
+)
+from ravn.ports.persona import PersonaPort
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TIMEOUT_SECONDS: float = 5.0
+_DEFAULT_CACHE_TTL_SECONDS: int = 60
+_DEFAULT_TOKEN_ENV: str = "RAVN_VOLUNDR_TOKEN"
+
+
+@dataclass
+class _CacheEntry:
+    value: Any
+    expires_at: float
+
+
+class HttpPersonaAdapter(PersonaPort):
+    """Read-only PersonaPort that fetches personas from the volundr REST registry.
+
+    Args:
+        base_url:           Base URL of the volundr service, e.g. ``http://volundr:8080``.
+        timeout_seconds:    HTTP request timeout (default 5 s).
+        cache_ttl_seconds:  Cache lifetime per persona (default 60 s).
+        token_env:          Name of the env var that holds the PAT
+                            (default ``RAVN_VOLUNDR_TOKEN``).
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+        cache_ttl_seconds: int = _DEFAULT_CACHE_TTL_SECONDS,
+        token_env: str = _DEFAULT_TOKEN_ENV,
+        # Private: injected in tests to avoid real network calls.
+        _transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout_seconds
+        self._ttl = cache_ttl_seconds
+        self._token_env = token_env
+        self._transport = _transport
+
+        # Per-persona cache: name → _CacheEntry(PersonaConfig | None, expires_at)
+        self._persona_cache: dict[str, _CacheEntry] = {}
+        # Names-list cache: _CacheEntry(list[str], expires_at) | None
+        self._names_cache: _CacheEntry | None = None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _auth_headers(self) -> dict[str, str]:
+        token = os.environ.get(self._token_env, "")
+        if not token:
+            return {}
+        return {"Authorization": f"Bearer {token}"}
+
+    def _is_fresh(self, entry: _CacheEntry) -> bool:
+        return time.monotonic() < entry.expires_at
+
+    def _new_entry(self, value: Any) -> _CacheEntry:
+        return _CacheEntry(value=value, expires_at=time.monotonic() + self._ttl)
+
+    def _client(self) -> httpx.Client:
+        return httpx.Client(timeout=self._timeout, transport=self._transport)
+
+    @staticmethod
+    def _parse_detail(data: dict) -> PersonaConfig:
+        """Parse a PersonaDetail JSON payload into a PersonaConfig."""
+        llm = data.get("llm") or {}
+        produces = data.get("produces") or {}
+        consumes = data.get("consumes") or {}
+        fan_in = data.get("fan_in") or {}
+
+        return PersonaConfig(
+            name=data["name"],
+            system_prompt_template=data.get("system_prompt_template", ""),
+            allowed_tools=list(data.get("allowed_tools") or []),
+            forbidden_tools=list(data.get("forbidden_tools") or []),
+            permission_mode=data.get("permission_mode", ""),
+            iteration_budget=int(data.get("iteration_budget") or 0),
+            llm=PersonaLLMConfig(
+                primary_alias=llm.get("primary_alias", ""),
+                thinking_enabled=bool(llm.get("thinking_enabled", False)),
+                max_tokens=int(llm.get("max_tokens") or 0),
+            ),
+            produces=PersonaProduces(
+                event_type=produces.get("event_type", ""),
+            ),
+            consumes=PersonaConsumes(
+                event_types=list(consumes.get("event_types") or []),
+                injects=list(consumes.get("injects") or []),
+            ),
+            fan_in=PersonaFanIn(
+                strategy=fan_in.get("strategy", "merge"),
+                contributes_to=fan_in.get("contributes_to", ""),
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # PersonaPort interface
+    # ------------------------------------------------------------------
+
+    def load(self, name: str) -> PersonaConfig | None:
+        """Return the named persona from volundr, or ``None`` if not found or on error.
+
+        Results are cached for ``cache_ttl_seconds``.  On HTTP or transport
+        errors the last cached value is returned (fail-closed: ``None`` if no
+        prior entry exists).
+        """
+        cached = self._persona_cache.get(name)
+        if cached is not None and self._is_fresh(cached):
+            return cached.value
+
+        url = f"{self._base_url}/api/v1/ravn/personas/{name}"
+        try:
+            with self._client() as client:
+                response = client.get(url, headers=self._auth_headers())
+        except Exception as exc:  # network / timeout
+            logger.warning("HttpPersonaAdapter: request failed for %r: %s", name, exc)
+            return cached.value if cached is not None else None
+
+        if response.status_code == 404:
+            # Definitively missing — do not cache so that newly created
+            # personas appear within the next call rather than at TTL expiry.
+            return None
+
+        if response.status_code >= 400:
+            logger.warning(
+                "HttpPersonaAdapter: GET %s returned HTTP %d",
+                url,
+                response.status_code,
+            )
+            return cached.value if cached is not None else None
+
+        config = self._parse_detail(response.json())
+        self._persona_cache[name] = self._new_entry(config)
+        return config
+
+    def list_names(self) -> list[str]:
+        """Return a sorted list of all persona names from the registry.
+
+        Falls back to the last cached list on HTTP or transport errors; returns
+        ``[]`` if no cached list is available.
+        """
+        if self._names_cache is not None and self._is_fresh(self._names_cache):
+            return list(self._names_cache.value)
+
+        url = f"{self._base_url}/api/v1/ravn/personas"
+        try:
+            with self._client() as client:
+                response = client.get(url, headers=self._auth_headers())
+        except Exception as exc:  # network / timeout
+            logger.warning("HttpPersonaAdapter: list_names request failed: %s", exc)
+            return list(self._names_cache.value) if self._names_cache is not None else []
+
+        if response.status_code >= 400:
+            logger.warning(
+                "HttpPersonaAdapter: GET %s returned HTTP %d",
+                url,
+                response.status_code,
+            )
+            return list(self._names_cache.value) if self._names_cache is not None else []
+
+        names = sorted(item["name"] for item in response.json())
+        self._names_cache = self._new_entry(names)
+        return list(names)
+
+    # ------------------------------------------------------------------
+    # Write operations — not supported
+    # ------------------------------------------------------------------
+
+    def save(self, config: PersonaConfig) -> None:  # type: ignore[override]
+        raise NotImplementedError(
+            "Use the volundr REST API to edit personas; this adapter is read-only."
+        )
+
+    def delete(self, name: str) -> bool:  # type: ignore[override]
+        raise NotImplementedError(
+            "Use the volundr REST API to edit personas; this adapter is read-only."
+        )

--- a/tests/integration/test_http_persona_adapter.py
+++ b/tests/integration/test_http_persona_adapter.py
@@ -1,0 +1,277 @@
+"""Integration tests for HttpPersonaAdapter against a real volundr REST app.
+
+Uses a starlette TestClient (backed by a real FastAPI ASGI app with the
+personas router) so no external network is required.  The adapter's
+``_transport`` parameter is wired to a ``_SyncASGITransport`` that forwards
+requests to the TestClient — giving us a genuine HTTP round-trip without a
+running server.
+
+Tests
+-----
+* Round-trip: persona created via REST → loadable by the adapter.
+* ``list_names()`` reflects REST-created personas.
+* 404 → ``None`` (persona not found).
+* PAT auth end-to-end: MemoryTokenIssuer issues a real JWT; adapter sends it
+  as ``Authorization: Bearer <token>``; ASGI middleware confirms receipt.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import httpx
+import pytest
+import yaml
+from fastapi import FastAPI
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.testclient import TestClient
+
+from ravn.adapters.personas.http import HttpPersonaAdapter
+from ravn.adapters.personas.loader import FilesystemPersonaAdapter, PersonaConfig
+from volundr.adapters.inbound.rest_personas import create_personas_router
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _SyncASGITransport(httpx.BaseTransport):
+    """Routes httpx.Client requests to a running starlette TestClient.
+
+    Allows ``HttpPersonaAdapter`` (which uses ``httpx.Client``) to call a real
+    ASGI app without a network server — the TestClient handles the sync↔async
+    bridging internally via starlette's transport layer.
+    """
+
+    def __init__(self, tc: TestClient) -> None:
+        self._tc = tc
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        content = request.read()
+        # Strip headers that TestClient sets itself to avoid duplication.
+        filtered = {
+            k: v
+            for k, v in request.headers.items()
+            if k.lower() not in ("host", "content-length", "transfer-encoding")
+        }
+        resp = self._tc.request(
+            method=request.method,
+            url=str(request.url),
+            content=content,
+            headers=filtered,
+        )
+        return httpx.Response(
+            status_code=resp.status_code,
+            headers=dict(resp.headers),
+            content=resp.content,
+        )
+
+
+class _IsolatedPersonaLoader(FilesystemPersonaAdapter):
+    """Test-only adapter that saves personas to the first custom dir.
+
+    ``FilesystemPersonaAdapter.save()`` always writes to ``~/.ravn/personas/``,
+    which is not in the search path when ``persona_dirs`` is set explicitly.
+    This subclass overrides ``save()`` so that both reads and writes go to the
+    same temp directory — giving the integration tests a fully isolated store.
+    """
+
+    def __init__(self, personas_dir: str) -> None:
+        super().__init__(persona_dirs=[personas_dir], include_builtin=False)
+        self._write_dir = Path(personas_dir)
+
+    def save(self, config: PersonaConfig) -> None:
+        self._write_dir.mkdir(parents=True, exist_ok=True)
+        dest = self._write_dir / f"{config.name}.yaml"
+        dest.write_text(yaml.dump(config.to_dict(), allow_unicode=True), encoding="utf-8")
+
+
+def _make_personas_app(personas_dir: str) -> FastAPI:
+    """Build a FastAPI app with the personas router writing to *personas_dir*."""
+    loader = _IsolatedPersonaLoader(personas_dir)
+    app = FastAPI()
+    app.include_router(create_personas_router(loader))
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def personas_dir(tmp_path: Path) -> str:
+    d = tmp_path / "personas"
+    d.mkdir()
+    return str(d)
+
+
+@pytest.fixture()
+def personas_app(personas_dir: str) -> FastAPI:
+    return _make_personas_app(personas_dir)
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: create via REST, load via adapter
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_load(personas_app: FastAPI) -> None:
+    """Persona created via REST POST is loadable by HttpPersonaAdapter.load()."""
+    with TestClient(personas_app) as tc:
+        transport = _SyncASGITransport(tc)
+        adapter = HttpPersonaAdapter(base_url="http://testserver", _transport=transport)
+
+        resp = tc.post(
+            "/api/v1/ravn/personas",
+            json={
+                "name": "integ-coder",
+                "system_prompt_template": "You are an integration test coder.",
+                "permission_mode": "workspace-write",
+                "allowed_tools": ["file", "git"],
+                "iteration_budget": 30,
+            },
+        )
+        assert resp.status_code == 201, resp.text
+
+        config = adapter.load("integ-coder")
+
+        assert config is not None
+        assert config.name == "integ-coder"
+        assert config.system_prompt_template == "You are an integration test coder."
+        assert config.permission_mode == "workspace-write"
+        assert config.allowed_tools == ["file", "git"]
+        assert config.iteration_budget == 30
+
+
+def test_round_trip_list_names(personas_app: FastAPI) -> None:
+    """list_names() returns personas that have been created via REST."""
+    with TestClient(personas_app) as tc:
+        transport = _SyncASGITransport(tc)
+        adapter = HttpPersonaAdapter(base_url="http://testserver", _transport=transport)
+
+        tc.post("/api/v1/ravn/personas", json={"name": "alpha-agent"})
+        tc.post("/api/v1/ravn/personas", json={"name": "beta-agent"})
+
+        names = adapter.list_names()
+
+        assert "alpha-agent" in names
+        assert "beta-agent" in names
+        assert names == sorted(names), "list_names() must return a sorted list"
+
+
+def test_load_returns_none_for_missing_persona(personas_app: FastAPI) -> None:
+    """load() returns None when the persona does not exist in the registry."""
+    with TestClient(personas_app) as tc:
+        transport = _SyncASGITransport(tc)
+        adapter = HttpPersonaAdapter(base_url="http://testserver", _transport=transport)
+
+        config = adapter.load("no-such-persona")
+
+        assert config is None
+
+
+# ---------------------------------------------------------------------------
+# PAT auth — end-to-end with real token issuance
+# ---------------------------------------------------------------------------
+
+
+class _CaptureAuthMiddleware(BaseHTTPMiddleware):
+    """Middleware that records the Authorization header from each request."""
+
+    def __init__(self, app, store: dict) -> None:
+        super().__init__(app)
+        self._store = store
+
+    async def dispatch(self, request: Request, call_next):
+        self._store["authorization"] = request.headers.get("authorization", "")
+        return await call_next(request)
+
+
+def test_pat_bearer_header_sent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Adapter sends Authorization: Bearer when RAVN_VOLUNDR_TOKEN env var is set."""
+    received: dict[str, str] = {}
+
+    personas_dir = str(tmp_path / "personas")
+    Path(personas_dir).mkdir()
+
+    loader = _IsolatedPersonaLoader(personas_dir)
+    app = FastAPI()
+    app.add_middleware(_CaptureAuthMiddleware, store=received)
+    app.include_router(create_personas_router(loader))
+
+    monkeypatch.setenv("RAVN_VOLUNDR_TOKEN", "simple-bearer-token")
+
+    with TestClient(app) as tc:
+        transport = _SyncASGITransport(tc)
+        adapter = HttpPersonaAdapter(
+            base_url="http://testserver",
+            _transport=transport,
+        )
+        # 404 is fine — we only care that the auth header was sent.
+        adapter.load("any-persona")
+
+    assert received.get("authorization") == "Bearer simple-bearer-token"
+
+
+def test_pat_real_issuance_end_to_end(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """End-to-end: MemoryTokenIssuer issues a real JWT; adapter sends it as Bearer."""
+    from niuu.adapters.memory_token_issuer import MemoryTokenIssuer
+
+    received: dict[str, str] = {}
+
+    personas_dir = str(tmp_path / "personas")
+    Path(personas_dir).mkdir()
+
+    loader = _IsolatedPersonaLoader(personas_dir)
+    app = FastAPI()
+    app.add_middleware(_CaptureAuthMiddleware, store=received)
+    app.include_router(create_personas_router(loader))
+
+    issuer = MemoryTokenIssuer(signing_key="integ-test-signing-key-32bytes!!")
+    issued = asyncio.run(
+        issuer.issue_token(subject_token="any-subject-token", name="integ-test-pat")
+    )
+    raw_token = issued.raw_token
+
+    monkeypatch.setenv("RAVN_VOLUNDR_TOKEN", raw_token)
+
+    with TestClient(app) as tc:
+        transport = _SyncASGITransport(tc)
+        adapter = HttpPersonaAdapter(
+            base_url="http://testserver",
+            _transport=transport,
+        )
+        adapter.load("any-persona")
+
+    assert received.get("authorization") == f"Bearer {raw_token}"
+
+
+def test_no_auth_header_when_env_var_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No Authorization header is sent when the env var is not set."""
+    received: dict[str, str] = {}
+
+    personas_dir = str(tmp_path / "personas-no-auth")
+    Path(personas_dir).mkdir()
+
+    loader = _IsolatedPersonaLoader(personas_dir)
+    app = FastAPI()
+    app.add_middleware(_CaptureAuthMiddleware, store=received)
+    app.include_router(create_personas_router(loader))
+
+    monkeypatch.delenv("RAVN_VOLUNDR_TOKEN", raising=False)
+
+    with TestClient(app) as tc:
+        transport = _SyncASGITransport(tc)
+        adapter = HttpPersonaAdapter(
+            base_url="http://testserver",
+            token_env="RAVN_VOLUNDR_TOKEN",
+            _transport=transport,
+        )
+        adapter.load("some-persona")
+
+    assert received.get("authorization", "") == ""

--- a/tests/test_ravn/test_personas/test_http.py
+++ b/tests/test_ravn/test_personas/test_http.py
@@ -1,0 +1,439 @@
+"""Unit tests for HttpPersonaAdapter.
+
+All HTTP calls are intercepted by ``respx`` — no real network required.
+"""
+
+from __future__ import annotations
+
+import time
+
+import httpx
+import pytest
+import respx
+
+from ravn.adapters.personas.http import HttpPersonaAdapter
+from ravn.adapters.personas.loader import PersonaConfig
+
+# ---------------------------------------------------------------------------
+# Sample API payloads
+# ---------------------------------------------------------------------------
+
+_DETAIL_CODER: dict = {
+    "name": "coder",
+    "permission_mode": "workspace-write",
+    "allowed_tools": ["file", "git"],
+    "forbidden_tools": [],
+    "iteration_budget": 40,
+    "is_builtin": True,
+    "has_override": False,
+    "produces_event": "",
+    "consumes_events": [],
+    "system_prompt_template": "You are a coding agent.",
+    "llm": {"primary_alias": "balanced", "thinking_enabled": False, "max_tokens": 0},
+    "produces": {"event_type": "", "schema": {}},
+    "consumes": {"event_types": [], "injects": []},
+    "fan_in": {"strategy": "merge", "contributes_to": ""},
+    "yaml_source": "[built-in]",
+}
+
+_DETAIL_REVIEWER: dict = {
+    "name": "reviewer",
+    "permission_mode": "read-only",
+    "allowed_tools": ["file"],
+    "forbidden_tools": [],
+    "iteration_budget": 20,
+    "is_builtin": False,
+    "has_override": False,
+    "produces_event": "review.completed",
+    "consumes_events": ["code.changed"],
+    "system_prompt_template": "You are a reviewer.",
+    "llm": {"primary_alias": "powerful", "thinking_enabled": True, "max_tokens": 8192},
+    "produces": {"event_type": "review.completed", "schema": {}},
+    "consumes": {"event_types": ["code.changed"], "injects": ["diff"]},
+    "fan_in": {"strategy": "all_must_pass", "contributes_to": "verdict"},
+    "yaml_source": "/custom/reviewer.yaml",
+}
+
+_SUMMARIES: list[dict] = [
+    {
+        "name": "coder",
+        "permission_mode": "workspace-write",
+        "allowed_tools": ["file"],
+        "iteration_budget": 40,
+        "is_builtin": True,
+        "has_override": False,
+        "produces_event": "",
+        "consumes_events": [],
+    },
+    {
+        "name": "reviewer",
+        "permission_mode": "read-only",
+        "allowed_tools": [],
+        "iteration_budget": 20,
+        "is_builtin": False,
+        "has_override": False,
+        "produces_event": "review.completed",
+        "consumes_events": ["code.changed"],
+    },
+]
+
+_BASE = "http://volundr.test"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _adapter(**kwargs: object) -> HttpPersonaAdapter:
+    return HttpPersonaAdapter(base_url=_BASE, **kwargs)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# load — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestLoad:
+    @respx.mock
+    def test_load_returns_persona_config(self) -> None:
+        respx.get(f"{_BASE}/api/v1/ravn/personas/coder").mock(
+            return_value=httpx.Response(200, json=_DETAIL_CODER)
+        )
+        adapter = _adapter()
+        config = adapter.load("coder")
+
+        assert isinstance(config, PersonaConfig)
+        assert config.name == "coder"
+        assert config.permission_mode == "workspace-write"
+        assert config.allowed_tools == ["file", "git"]
+        assert config.iteration_budget == 40
+
+    @respx.mock
+    def test_load_parses_llm_fields(self) -> None:
+        respx.get(f"{_BASE}/api/v1/ravn/personas/reviewer").mock(
+            return_value=httpx.Response(200, json=_DETAIL_REVIEWER)
+        )
+        config = _adapter().load("reviewer")
+        assert config is not None
+        assert config.llm.primary_alias == "powerful"
+        assert config.llm.thinking_enabled is True
+        assert config.llm.max_tokens == 8192
+
+    @respx.mock
+    def test_load_parses_consumes_and_fan_in(self) -> None:
+        respx.get(f"{_BASE}/api/v1/ravn/personas/reviewer").mock(
+            return_value=httpx.Response(200, json=_DETAIL_REVIEWER)
+        )
+        config = _adapter().load("reviewer")
+        assert config is not None
+        assert config.consumes.event_types == ["code.changed"]
+        assert config.consumes.injects == ["diff"]
+        assert config.fan_in.strategy == "all_must_pass"
+        assert config.fan_in.contributes_to == "verdict"
+
+    @respx.mock
+    def test_load_parses_produces(self) -> None:
+        respx.get(f"{_BASE}/api/v1/ravn/personas/reviewer").mock(
+            return_value=httpx.Response(200, json=_DETAIL_REVIEWER)
+        )
+        config = _adapter().load("reviewer")
+        assert config is not None
+        assert config.produces.event_type == "review.completed"
+
+    # ------------------------------------------------------------------
+    # 404 path
+    # ------------------------------------------------------------------
+
+    @respx.mock
+    def test_load_returns_none_on_404(self) -> None:
+        respx.get(f"{_BASE}/api/v1/ravn/personas/missing").mock(
+            return_value=httpx.Response(404, json={"detail": "Persona not found: missing"})
+        )
+        config = _adapter().load("missing")
+        assert config is None
+
+    # ------------------------------------------------------------------
+    # 5xx fail-closed
+    # ------------------------------------------------------------------
+
+    @respx.mock
+    def test_load_returns_none_on_500_no_cache(self) -> None:
+        respx.get(f"{_BASE}/api/v1/ravn/personas/coder").mock(return_value=httpx.Response(500))
+        config = _adapter().load("coder")
+        assert config is None
+
+    @respx.mock
+    def test_load_returns_stale_cache_on_500(self) -> None:
+        adapter = _adapter()
+        # Prime the cache with a successful response
+        respx.get(f"{_BASE}/api/v1/ravn/personas/coder").mock(
+            return_value=httpx.Response(200, json=_DETAIL_CODER)
+        )
+        config_first = adapter.load("coder")
+        assert config_first is not None
+
+        # Force TTL expiry
+        adapter._persona_cache["coder"].expires_at = time.monotonic() - 1.0
+
+        # Server now returns 500
+        respx.get(f"{_BASE}/api/v1/ravn/personas/coder").mock(return_value=httpx.Response(500))
+        config_stale = adapter.load("coder")
+        assert config_stale is not None
+        assert config_stale.name == "coder"
+
+    @respx.mock
+    def test_load_does_not_raise_on_network_error(self) -> None:
+        respx.get(f"{_BASE}/api/v1/ravn/personas/coder").mock(
+            side_effect=httpx.ConnectError("connection refused")
+        )
+        # Must not raise — fail-closed returns None
+        config = _adapter().load("coder")
+        assert config is None
+
+    @respx.mock
+    def test_load_returns_stale_cache_on_network_error(self) -> None:
+        adapter = _adapter()
+        # Prime cache
+        respx.get(f"{_BASE}/api/v1/ravn/personas/coder").mock(
+            return_value=httpx.Response(200, json=_DETAIL_CODER)
+        )
+        adapter.load("coder")
+
+        # Expire cache, then fail
+        adapter._persona_cache["coder"].expires_at = time.monotonic() - 1.0
+        respx.get(f"{_BASE}/api/v1/ravn/personas/coder").mock(
+            side_effect=httpx.ConnectError("connection refused")
+        )
+        config = adapter.load("coder")
+        assert config is not None
+        assert config.name == "coder"
+
+    # ------------------------------------------------------------------
+    # Warning logged on errors
+    # ------------------------------------------------------------------
+
+    @respx.mock
+    def test_load_logs_warning_on_5xx(self, caplog: pytest.LogCaptureFixture) -> None:
+        import logging
+
+        respx.get(f"{_BASE}/api/v1/ravn/personas/coder").mock(return_value=httpx.Response(503))
+        with caplog.at_level(logging.WARNING, logger="ravn.adapters.personas.http"):
+            _adapter().load("coder")
+        assert any("503" in r.message for r in caplog.records)
+
+    @respx.mock
+    def test_load_logs_warning_on_network_error(self, caplog: pytest.LogCaptureFixture) -> None:
+        import logging
+
+        respx.get(f"{_BASE}/api/v1/ravn/personas/coder").mock(
+            side_effect=httpx.ConnectError("refused")
+        )
+        with caplog.at_level(logging.WARNING, logger="ravn.adapters.personas.http"):
+            _adapter().load("coder")
+        assert caplog.records
+
+
+# ---------------------------------------------------------------------------
+# Cache
+# ---------------------------------------------------------------------------
+
+
+class TestCache:
+    @respx.mock
+    def test_cache_hit_single_http_request(self) -> None:
+        route = respx.get(f"{_BASE}/api/v1/ravn/personas/coder").mock(
+            return_value=httpx.Response(200, json=_DETAIL_CODER)
+        )
+        adapter = _adapter()
+        adapter.load("coder")
+        adapter.load("coder")  # second call — must use cache
+
+        assert route.call_count == 1
+
+    @respx.mock
+    def test_cache_expiry_triggers_new_request(self) -> None:
+        route = respx.get(f"{_BASE}/api/v1/ravn/personas/coder").mock(
+            return_value=httpx.Response(200, json=_DETAIL_CODER)
+        )
+        adapter = _adapter(cache_ttl_seconds=60)
+        adapter.load("coder")
+
+        # Manually expire the cache entry
+        adapter._persona_cache["coder"].expires_at = time.monotonic() - 1.0
+
+        adapter.load("coder")  # must hit server again
+
+        assert route.call_count == 2
+
+    @respx.mock
+    def test_list_names_cache_hit(self) -> None:
+        route = respx.get(f"{_BASE}/api/v1/ravn/personas").mock(
+            return_value=httpx.Response(200, json=_SUMMARIES)
+        )
+        adapter = _adapter()
+        adapter.list_names()
+        adapter.list_names()
+
+        assert route.call_count == 1
+
+    @respx.mock
+    def test_list_names_cache_expiry(self) -> None:
+        route = respx.get(f"{_BASE}/api/v1/ravn/personas").mock(
+            return_value=httpx.Response(200, json=_SUMMARIES)
+        )
+        adapter = _adapter(cache_ttl_seconds=60)
+        adapter.list_names()
+
+        adapter._names_cache.expires_at = time.monotonic() - 1.0  # type: ignore[union-attr]
+        adapter.list_names()
+
+        assert route.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# list_names
+# ---------------------------------------------------------------------------
+
+
+class TestListNames:
+    @respx.mock
+    def test_list_names_returns_sorted_names(self) -> None:
+        respx.get(f"{_BASE}/api/v1/ravn/personas").mock(
+            return_value=httpx.Response(200, json=_SUMMARIES)
+        )
+        names = _adapter().list_names()
+        assert names == ["coder", "reviewer"]
+
+    @respx.mock
+    def test_list_names_returns_empty_on_500_no_cache(self) -> None:
+        respx.get(f"{_BASE}/api/v1/ravn/personas").mock(return_value=httpx.Response(500))
+        names = _adapter().list_names()
+        assert names == []
+
+    @respx.mock
+    def test_list_names_returns_stale_cache_on_500(self) -> None:
+        adapter = _adapter()
+        respx.get(f"{_BASE}/api/v1/ravn/personas").mock(
+            return_value=httpx.Response(200, json=_SUMMARIES)
+        )
+        adapter.list_names()
+
+        adapter._names_cache.expires_at = time.monotonic() - 1.0  # type: ignore[union-attr]
+        respx.get(f"{_BASE}/api/v1/ravn/personas").mock(return_value=httpx.Response(500))
+        names = adapter.list_names()
+        assert names == ["coder", "reviewer"]
+
+    @respx.mock
+    def test_list_names_does_not_raise_on_network_error(self) -> None:
+        respx.get(f"{_BASE}/api/v1/ravn/personas").mock(side_effect=httpx.ConnectError("refused"))
+        names = _adapter().list_names()
+        assert names == []
+
+    @respx.mock
+    def test_list_names_returns_stale_cache_on_network_error(self) -> None:
+        adapter = _adapter()
+        respx.get(f"{_BASE}/api/v1/ravn/personas").mock(
+            return_value=httpx.Response(200, json=_SUMMARIES)
+        )
+        adapter.list_names()
+
+        adapter._names_cache.expires_at = time.monotonic() - 1.0  # type: ignore[union-attr]
+        respx.get(f"{_BASE}/api/v1/ravn/personas").mock(side_effect=httpx.ConnectError("refused"))
+        names = adapter.list_names()
+        assert names == ["coder", "reviewer"]
+
+
+# ---------------------------------------------------------------------------
+# Auth header
+# ---------------------------------------------------------------------------
+
+
+class TestAuth:
+    @respx.mock
+    def test_bearer_header_sent_when_env_var_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("RAVN_VOLUNDR_TOKEN", "my-secret-pat")
+        route = respx.get(f"{_BASE}/api/v1/ravn/personas/coder").mock(
+            return_value=httpx.Response(200, json=_DETAIL_CODER)
+        )
+        _adapter(token_env="RAVN_VOLUNDR_TOKEN").load("coder")
+
+        assert route.calls.last is not None
+        auth = route.calls.last.request.headers.get("authorization", "")
+        assert auth == "Bearer my-secret-pat"
+
+    @respx.mock
+    def test_no_auth_header_when_env_var_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("RAVN_VOLUNDR_TOKEN", raising=False)
+        route = respx.get(f"{_BASE}/api/v1/ravn/personas/coder").mock(
+            return_value=httpx.Response(200, json=_DETAIL_CODER)
+        )
+        _adapter(token_env="RAVN_VOLUNDR_TOKEN").load("coder")
+
+        assert route.calls.last is not None
+        assert "authorization" not in route.calls.last.request.headers
+
+    @respx.mock
+    def test_custom_token_env_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CUSTOM_TOKEN_VAR", "custom-token-value")
+        route = respx.get(f"{_BASE}/api/v1/ravn/personas/coder").mock(
+            return_value=httpx.Response(200, json=_DETAIL_CODER)
+        )
+        _adapter(token_env="CUSTOM_TOKEN_VAR").load("coder")
+
+        assert route.calls.last is not None
+        auth = route.calls.last.request.headers.get("authorization", "")
+        assert auth == "Bearer custom-token-value"
+
+    @respx.mock
+    def test_bearer_header_sent_for_list_names(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("RAVN_VOLUNDR_TOKEN", "list-token")
+        route = respx.get(f"{_BASE}/api/v1/ravn/personas").mock(
+            return_value=httpx.Response(200, json=_SUMMARIES)
+        )
+        _adapter(token_env="RAVN_VOLUNDR_TOKEN").list_names()
+
+        assert route.calls.last is not None
+        auth = route.calls.last.request.headers.get("authorization", "")
+        assert auth == "Bearer list-token"
+
+
+# ---------------------------------------------------------------------------
+# Write operations — NotImplementedError
+# ---------------------------------------------------------------------------
+
+
+class TestReadOnly:
+    def test_save_raises_not_implemented(self) -> None:
+        adapter = _adapter()
+        config = PersonaConfig(name="x")
+        with pytest.raises(NotImplementedError, match="read-only"):
+            adapter.save(config)
+
+    def test_delete_raises_not_implemented(self) -> None:
+        adapter = _adapter()
+        with pytest.raises(NotImplementedError, match="read-only"):
+            adapter.delete("x")
+
+    def test_save_error_message_mentions_rest_api(self) -> None:
+        adapter = _adapter()
+        with pytest.raises(NotImplementedError, match="volundr REST API"):
+            adapter.save(PersonaConfig(name="x"))
+
+    def test_delete_error_message_mentions_rest_api(self) -> None:
+        adapter = _adapter()
+        with pytest.raises(NotImplementedError, match="volundr REST API"):
+            adapter.delete("x")
+
+
+# ---------------------------------------------------------------------------
+# PersonaPort compliance
+# ---------------------------------------------------------------------------
+
+
+class TestPortCompliance:
+    def test_adapter_is_persona_port_instance(self) -> None:
+        from ravn.ports.persona import PersonaPort
+
+        adapter = _adapter()
+        assert isinstance(adapter, PersonaPort)


### PR DESCRIPTION
## Summary

- Implements `HttpPersonaAdapter`, a read-only `PersonaPort` that fetches persona configs from the volundr REST registry at runtime
- Enables ravn sidecars in deployments without ConfigMap projection (cluster policy restrictions, frequent edits) to pull personas from a central volundr instance
- Exports `HttpPersonaAdapter` from `ravn.adapters.personas`

## What Changed

### New: `src/ravn/adapters/personas/http.py`

`HttpPersonaAdapter(PersonaPort)` with:
- `load(name)` → `GET /api/v1/ravn/personas/{name}` → `PersonaConfig | None`; 404 → `None`
- `list_names()` → `GET /api/v1/ravn/personas` → sorted names list
- **In-memory TTL cache** (default 60 s) per persona + names list — avoids hammering volundr on every ravn decision cycle
- **Fail-closed**: 5xx / network errors return last cached value (`None` / `[]` when no prior cache exists); logs at WARN; never raises
- **PAT auth**: reads `RAVN_VOLUNDR_TOKEN` env var, sends `Authorization: Bearer <token>` on every request
- `save()` / `delete()` raise `NotImplementedError` with message pointing to the volundr REST API
- `_transport` parameter for test injection (no real network in tests)

### Updated: `src/ravn/adapters/personas/__init__.py`

Exports `HttpPersonaAdapter` alongside `FilesystemPersonaAdapter`.

### New: `tests/test_ravn/test_personas/test_http.py`

29 unit tests covering:
- Happy-path `load()` and `list_names()` (all fields parsed correctly)
- 404 → `None`
- 5xx fail-closed (no raise, WARN logged, stale cache returned)
- Network error fail-closed (same as 5xx)
- Cache hit: two calls within TTL → one HTTP request
- Cache expiry: call after TTL → new HTTP request
- Auth header present when env var set; absent when missing; custom env var name
- `save()` / `delete()` raise `NotImplementedError` with correct message
- `isinstance(adapter, PersonaPort)` compliance check

### New: `tests/integration/test_http_persona_adapter.py`

6 integration tests against a real FastAPI ASGI app via starlette `TestClient`:
- Round-trip: persona created via REST POST → `adapter.load()` returns it
- `list_names()` reflects REST-created personas (sorted)
- `load()` returns `None` for missing persona (404)
- PAT bearer header sent when `RAVN_VOLUNDR_TOKEN` env var is set
- End-to-end PAT issuance: `MemoryTokenIssuer` issues a real JWT → adapter sends it as `Authorization: Bearer`
- No auth header when env var is absent

## Test Results

```
35 passed, 100% branch coverage on src/ravn/adapters/personas/http.py
```

## Ticket

NIU-641

🤖 Generated with [Claude Code](https://claude.com/claude-code)