### PR TITLE
feat(adapters): wire MeshParticipant into Skuld+Ravn, unify event flow through Sleipnir (NIU-634)

### DIFF
--- a/src/ravn/adapters/channels/mesh_channel.py
+++ b/src/ravn/adapters/channels/mesh_channel.py
@@ -1,0 +1,40 @@
+"""MeshActivityChannel — publishes agent activity events to the Ravn mesh (NIU-634).
+
+Bridges the ChannelPort interface to the MeshPort so that DriveLoop
+can forward thought/tool_start/tool_result/response events to any mesh
+peer without a direct WebSocket connection to Skuld.
+
+Topic: ``activity.{peer_id}``
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from ravn.domain.events import RavnEvent
+from ravn.ports.channel import ChannelPort
+
+if TYPE_CHECKING:
+    from ravn.ports.mesh import MeshPort
+
+logger = logging.getLogger(__name__)
+
+
+class MeshActivityChannel(ChannelPort):
+    """Publishes each emitted RavnEvent to the mesh under ``activity.{peer_id}``.
+
+    Used alongside SkuldChannel in a CompositeChannel so that activity events
+    are delivered via Sleipnir mesh in addition to (or instead of) WebSocket.
+    RoomMeshBridge picks them up and translates them to room wire events.
+    """
+
+    def __init__(self, mesh: MeshPort, peer_id: str) -> None:
+        self._mesh = mesh
+        self._topic = f"activity.{peer_id}"
+
+    async def emit(self, event: RavnEvent) -> None:
+        try:
+            await self._mesh.publish(event, topic=self._topic)
+        except Exception:
+            logger.warning("MeshActivityChannel: failed to publish event", exc_info=True)

--- a/src/ravn/cli/commands.py
+++ b/src/ravn/cli/commands.py
@@ -2679,13 +2679,14 @@ def _build_mesh(settings: Settings, discovery: Any = None) -> Any:
     # New list-based config: delegate to shared niuu.mesh helper
     if mesh_cfg.adapters:
         from niuu.mesh import build_mesh_from_adapters_list  # noqa: PLC0415
+        from niuu.mesh.transport_builder import build_transport  # noqa: PLC0415
 
         def _sleipnir_tb(entry: dict[str, Any]) -> Any:
-            return _build_sleipnir_transport(
-                settings,
-                entry.get("transport", mesh_cfg.adapter or "nng"),
-                discovery=discovery,
-            )
+            adapter = entry.get("transport", mesh_cfg.adapter or "nng")
+            kwargs = _resolve_transport_kwargs(settings, adapter)
+            if adapter in ("sleipnir", "rabbitmq") and not kwargs:
+                return None
+            return build_transport(adapter, **kwargs)
 
         return build_mesh_from_adapters_list(
             adapters=mesh_cfg.adapters,
@@ -2696,14 +2697,17 @@ def _build_mesh(settings: Settings, discovery: Any = None) -> Any:
         )
 
     # Legacy single-adapter mode for backward compatibility
-    legacy_adapter = mesh_cfg.adapter
-    if not legacy_adapter:
-        # Default to nng for local mesh
-        legacy_adapter = "nng"
+    legacy_adapter = mesh_cfg.adapter or "nng"
 
-    from ravn.adapters.mesh.sleipnir_mesh import SleipnirMeshAdapter
+    from niuu.mesh.transport_builder import build_transport  # noqa: PLC0415
+    from ravn.adapters.mesh.sleipnir_mesh import SleipnirMeshAdapter  # noqa: PLC0415
 
-    transport = _build_sleipnir_transport(settings, legacy_adapter, discovery=discovery)
+    kwargs = _resolve_transport_kwargs(settings, legacy_adapter)
+    if legacy_adapter in ("sleipnir", "rabbitmq") and not kwargs:
+        logger.warning("mesh: failed to build transport, mesh disabled")
+        return None
+
+    transport = build_transport(legacy_adapter, **kwargs)
     if transport is None:
         logger.warning("mesh: failed to build transport, mesh disabled")
         return None
@@ -2717,30 +2721,17 @@ def _build_mesh(settings: Settings, discovery: Any = None) -> Any:
     )
 
 
-def _read_cluster_pub_addresses(settings: Settings) -> list[str]:
-    """Read peer pub addresses from cluster.yaml files in discovery config.
-
-    Returns an empty list when no static discovery is configured or the
-    cluster file doesn't exist yet.
-    """
-    from niuu.mesh.cluster import read_cluster_pub_addresses
-
-    discovery_cfg = getattr(settings, "discovery", None)
-    if discovery_cfg is None:
-        return []
-
-    adapters_config = list(getattr(discovery_cfg, "adapters", []))
-    return read_cluster_pub_addresses(adapters_config)
-
-
 def _resolve_transport_kwargs(
     settings: Settings,
     adapter: str,
 ) -> dict[str, Any]:
     """Build constructor kwargs for a Sleipnir transport from settings."""
     if adapter == "nng":
+        from niuu.mesh.cluster import read_cluster_pub_addresses  # noqa: PLC0415
+
         nng_cfg = settings.mesh.nng
-        peer_addresses = _read_cluster_pub_addresses(settings)
+        adapters_config = list(getattr(getattr(settings, "discovery", None), "adapters", []))
+        peer_addresses = read_cluster_pub_addresses(adapters_config)
         return {
             "address": nng_cfg.pub_sub_address,
             "service_id": f"ravn:{settings.mesh.own_peer_id}",
@@ -2766,21 +2757,6 @@ def _resolve_transport_kwargs(
         return {"redis_url": redis_url}
 
     return {}
-
-
-def _build_sleipnir_transport(
-    settings: Settings,
-    adapter: str,
-    discovery: Any = None,
-) -> Any:
-    """Build the Sleipnir transport using the dynamic adapter pattern."""
-    from niuu.mesh.transport_builder import build_transport
-
-    kwargs = _resolve_transport_kwargs(settings, adapter)
-    if adapter in ("sleipnir", "rabbitmq") and not kwargs:
-        return None
-
-    return build_transport(adapter, **kwargs)
 
 
 def _build_discovery(
@@ -2834,7 +2810,14 @@ def _build_discovery(
         pub_address=pub_address,
     )
 
-    return _build_discovery_adapters(settings, identity)
+    from niuu.mesh.discovery_builder import build_discovery_adapters  # noqa: PLC0415
+
+    return build_discovery_adapters(
+        adapters_config=list(getattr(settings.discovery, "adapters", [])),
+        own_identity=identity,
+        heartbeat_interval_s=settings.discovery.heartbeat_interval_s,
+        peer_ttl_s=settings.discovery.peer_ttl_s,
+    )
 
 
 @app.command()
@@ -2894,7 +2877,14 @@ async def _run_peers(settings: Settings, *, verbose: bool, force_scan: bool) -> 
         version=version,
     )
 
-    discovery = _build_discovery_adapters(settings, identity)
+    from niuu.mesh.discovery_builder import build_discovery_adapters  # noqa: PLC0415
+
+    discovery = build_discovery_adapters(
+        adapters_config=list(getattr(settings.discovery, "adapters", [])),
+        own_identity=identity,
+        heartbeat_interval_s=settings.discovery.heartbeat_interval_s,
+        peer_ttl_s=settings.discovery.peer_ttl_s,
+    )
     if discovery is None:
         typer.echo("No discovery adapter configured.", err=True)
         return
@@ -2933,73 +2923,6 @@ async def _run_peers(settings: Settings, *, verbose: bool, force_scan: bool) -> 
         typer.echo(line)
 
     await discovery.stop()
-
-
-# Legacy aliases for backward compatibility with `adapter: mdns` style config
-_DISCOVERY_ALIASES: dict[str, str] = {
-    "mdns": "ravn.adapters.discovery.mdns.MdnsDiscoveryAdapter",
-    "sleipnir": "ravn.adapters.discovery.sleipnir.SleipnirDiscoveryAdapter",
-    "k8s": "ravn.adapters.discovery.k8s.K8sDiscoveryAdapter",
-    "static": "ravn.adapters.discovery.static.StaticDiscoveryAdapter",
-}
-
-
-def _build_discovery_adapters(
-    settings: Settings,
-    identity: Any,
-) -> Any:
-    """Build discovery adapters using dynamic import from config.
-
-    If settings.discovery.adapters is non-empty, delegates to the shared
-    ``niuu.mesh.discovery_builder`` for list-based config.
-    Falls back to legacy single-adapter mode for backward compatibility.
-    """
-    from niuu.mesh.discovery_builder import build_discovery_adapters
-
-    adapters_config = settings.discovery.adapters
-
-    # New list-based config: delegate to shared niuu builder
-    if adapters_config:
-        return build_discovery_adapters(
-            adapters_config=adapters_config,
-            own_identity=identity,
-            heartbeat_interval_s=settings.discovery.heartbeat_interval_s,
-            peer_ttl_s=settings.discovery.peer_ttl_s,
-        )
-
-    # Legacy single-adapter mode for backward compatibility
-    legacy_adapter = settings.discovery.adapter
-    if not legacy_adapter:
-        # Default to mdns if no adapter specified
-        legacy_adapter = "mdns"
-
-    fq_class = _DISCOVERY_ALIASES.get(legacy_adapter, legacy_adapter)
-
-    try:
-        cls = _import_class(fq_class)
-    except Exception as exc:
-        logger.warning("discovery: failed to import legacy adapter %s: %s", fq_class, exc)
-        return None
-
-    # Legacy adapters use config object for backward compatibility
-    kwargs: dict[str, Any] = {
-        "own_identity": identity,
-        "config": settings.discovery,
-    }
-
-    # Add sleipnir_config for Sleipnir adapter
-    if "sleipnir" in fq_class.lower():
-        kwargs["sleipnir_config"] = settings.sleipnir
-
-    # Add handshake_port for mDNS adapter
-    if "mdns" in fq_class.lower():
-        kwargs["handshake_port"] = settings.discovery.mdns.handshake_port
-
-    try:
-        return cls(**kwargs)
-    except Exception as exc:
-        logger.warning("discovery: failed to instantiate legacy adapter %s: %s", fq_class, exc)
-        return None
 
 
 @app.command()

--- a/src/ravn/drive_loop.py
+++ b/src/ravn/drive_loop.py
@@ -26,6 +26,7 @@ from niuu.domain.outcome import parse_outcome_block
 from niuu.ports.mimir import MimirPort
 from ravn.adapters.channels.capture import CaptureChannel, TaskResult, TaskResultStore
 from ravn.adapters.channels.composite import CompositeChannel
+from ravn.adapters.channels.mesh_channel import MeshActivityChannel
 from ravn.adapters.channels.silent import SilentChannel
 from ravn.adapters.channels.skuld_channel import SkuldChannel
 from ravn.adapters.events.noop_publisher import NoOpEventPublisher
@@ -729,19 +730,29 @@ class DriveLoop:
 
         # Track the capture channel separately for response_text access
         capture_channel: CaptureChannel | None = None
+        peer_id = self._settings.mesh.own_peer_id if self._settings.mesh.enabled else ""
         if self._settings.cascade.enabled:
             self._result_store.start(task.task_id, task.triggered_by)
             capture_channel = CaptureChannel(task.task_id, self._result_store)
-            # Wrap with skuld channel for browser delivery when enabled
+            extra: list[ChannelPort] = []
             if self._skuld_channel is not None:
                 self._skuld_channel._persona = task.persona  # Update persona for this task
-                channel: ChannelPort = CompositeChannel([capture_channel, self._skuld_channel])
+                extra.append(self._skuld_channel)
+            if self._mesh is not None and peer_id:
+                extra.append(MeshActivityChannel(self._mesh, peer_id))
+            if extra:
+                channel: ChannelPort = CompositeChannel([capture_channel, *extra])
             else:
                 channel = capture_channel
         else:
+            sinks: list[ChannelPort] = []
             if self._skuld_channel is not None:
                 self._skuld_channel._persona = task.persona
-                channel = self._skuld_channel
+                sinks.append(self._skuld_channel)
+            if self._mesh is not None and peer_id:
+                sinks.append(MeshActivityChannel(self._mesh, peer_id))
+            if sinks:
+                channel = CompositeChannel(sinks) if len(sinks) > 1 else sinks[0]
             else:
                 channel = SilentChannel()
         agent = self._agent_factory(channel, task.task_id, task.persona, task.triggered_by)

--- a/src/skuld/broker.py
+++ b/src/skuld/broker.py
@@ -541,23 +541,75 @@ class Broker:
         self._pending_reasoning_text = ""
 
     async def _start_mesh_adapter(self) -> None:
-        """Build and start the mesh adapter when mesh.enabled is True."""
+        """Build and start the mesh adapter when mesh.enabled is True.
+
+        Uses niuu.mesh functions to build transport and discovery, then wraps
+        them in a MeshParticipant for unified lifecycle management (NIU-634).
+        """
+        from niuu.mesh import build_in_process_mesh, resolve_peer_id
+        from niuu.mesh.participant import MeshParticipant
+        from niuu.mesh.transport_builder import build_nng_transport
         from skuld.mesh_adapter import SkuldMeshAdapter
 
         mesh_cfg = self._settings.mesh
-        mesh = self._build_mesh(mesh_cfg)
-        if mesh is None:
-            logger.warning("Mesh enabled but no mesh transport could be built")
-            return
+        own_peer_id = resolve_peer_id(mesh_cfg.peer_id)
 
-        discovery = self._build_discovery(mesh_cfg)
+        # Build mesh transport (nng preferred, in-process fallback)
+        mesh = None
+        if mesh_cfg.transport != "in_process":
+            try:
+                from ravn.adapters.mesh.sleipnir_mesh import SleipnirMeshAdapter  # noqa: PLC0415
+
+                nng_cfg = getattr(mesh_cfg, "nng", None)
+                address = (
+                    getattr(nng_cfg, "pub_sub_address", "tcp://127.0.0.1:0")
+                    if nng_cfg
+                    else "tcp://127.0.0.1:0"
+                )
+                peer_addresses = read_cluster_pub_addresses(mesh_cfg.adapters)
+                nng = build_nng_transport(
+                    address=address,
+                    service_id=f"skuld:{own_peer_id}",
+                    peer_addresses=peer_addresses or None,
+                )
+                if nng is not None:
+                    mesh = SleipnirMeshAdapter(
+                        publisher=nng,
+                        subscriber=nng,
+                        own_peer_id=own_peer_id,
+                        rpc_timeout_s=mesh_cfg.rpc_timeout_s,
+                    )
+            except ImportError:
+                logger.warning("mesh: nng transport not available, falling back to in-process")
+
+        if mesh is None:
+            mesh = build_in_process_mesh(own_peer_id, mesh_cfg.rpc_timeout_s)
+
+        # Build discovery adapter using shared niuu.mesh.discovery_builder
+        own_identity = MeshIdentity(
+            peer_id=mesh_cfg.peer_id or self.session_id or "skuld",
+            realm_id="",
+            persona=mesh_cfg.persona,
+            capabilities=list(mesh_cfg.capabilities),
+            permission_mode="full_access",
+            version="0.1.0",
+        )
+        discovery = build_discovery_adapters(
+            adapters_config=mesh_cfg.adapters,
+            own_identity=own_identity,
+        )
+
+        participant = MeshParticipant(
+            mesh=mesh,
+            discovery=discovery,
+            peer_id=own_peer_id,
+        )
 
         self._mesh_adapter = SkuldMeshAdapter(
-            mesh=mesh,
+            participant=participant,
             transport=self._transport,
             config=mesh_cfg,
             session_id=self.session_id,
-            discovery=discovery,
         )
 
         try:
@@ -616,70 +668,6 @@ class Broker:
         except Exception as exc:
             logger.error("Mesh adapter start failed: %r", exc, exc_info=True)
             self._mesh_adapter = None
-
-    def _build_mesh(self, mesh_cfg: Any) -> Any:
-        """Build mesh transport from config.
-
-        The ``adapters`` list in mesh config is reserved for **discovery**
-        adapters (handled by ``_build_discovery``).  Mesh transport is always
-        built from the ``transport`` field (nng or in_process).
-        """
-        from niuu.mesh import (
-            build_in_process_mesh,
-            resolve_peer_id,
-        )
-
-        own_peer_id = resolve_peer_id(mesh_cfg.peer_id)
-
-        # Build nng transport (fallback to in-process)
-        if mesh_cfg.transport != "in_process":
-            try:
-                from niuu.mesh.transport_builder import build_nng_transport  # noqa: PLC0415
-                from ravn.adapters.mesh.sleipnir_mesh import SleipnirMeshAdapter  # noqa: PLC0415
-
-                nng_cfg = getattr(mesh_cfg, "nng", None)
-                address = (
-                    getattr(nng_cfg, "pub_sub_address", "tcp://127.0.0.1:0")
-                    if nng_cfg
-                    else "tcp://127.0.0.1:0"
-                )
-                peer_addresses = read_cluster_pub_addresses(mesh_cfg.adapters)
-                nng = build_nng_transport(
-                    address=address,
-                    service_id=f"skuld:{own_peer_id}",
-                    peer_addresses=peer_addresses or None,
-                )
-                if nng is not None:
-                    return SleipnirMeshAdapter(
-                        publisher=nng,
-                        subscriber=nng,
-                        own_peer_id=own_peer_id,
-                        rpc_timeout_s=mesh_cfg.rpc_timeout_s,
-                    )
-            except ImportError:
-                logger.warning("mesh: nng transport not available, falling back to in-process")
-
-        return build_in_process_mesh(own_peer_id, mesh_cfg.rpc_timeout_s)
-
-    def _build_discovery(self, mesh_cfg: Any) -> Any:
-        """Build discovery adapter from mesh config, or return None.
-
-        Uses ``niuu.mesh.discovery_builder`` with a :class:`MeshIdentity`
-        constructed from Skuld's mesh config.  No cross-import from ravn.
-        """
-        own_identity = MeshIdentity(
-            peer_id=mesh_cfg.peer_id or self.session_id or "skuld",
-            realm_id="",
-            persona=mesh_cfg.persona,
-            capabilities=list(mesh_cfg.capabilities),
-            permission_mode="full_access",
-            version="0.1.0",
-        )
-
-        return build_discovery_adapters(
-            adapters_config=mesh_cfg.adapters,
-            own_identity=own_identity,
-        )
 
     def _build_transport_kwargs(self) -> dict:
         """Return superset of kwargs that any transport constructor might need."""

--- a/src/skuld/mesh_adapter.py
+++ b/src/skuld/mesh_adapter.py
@@ -3,6 +3,8 @@
 Gives Skuld a mesh identity so it can participate in a ravn flock as a peer.
 Subscribes to task topics and feeds received prompts to the CLI transport.
 Results (including outcome blocks) are published back as response events.
+
+NIU-634: wired to use niuu.mesh.MeshParticipant for lifecycle management.
 """
 
 from __future__ import annotations
@@ -15,6 +17,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from niuu.domain.outcome import parse_outcome_block
+from niuu.mesh.participant import MeshParticipant
 from ravn.domain.events import RavnEvent, RavnEventType
 from ravn.ports.mesh import MeshPort
 from skuld.config import MeshConfig
@@ -28,24 +31,23 @@ class SkuldMeshAdapter:
     """Bridge between the ravn mesh and the CLI transport.
 
     Lifecycle:
-        start() — register with discovery, subscribe to task topics
-        stop()  — unsubscribe, deregister from discovery
+        start() — start participant (mesh + discovery), subscribe to task topics
+        stop()  — unsubscribe, stop participant (mesh + discovery)
     """
 
     def __init__(
         self,
-        mesh: MeshPort,
+        participant: MeshParticipant,
         transport: CLITransport,
         config: MeshConfig,
         session_id: str,
-        discovery: Any | None = None,
     ) -> None:
-        self._mesh = mesh
+        self._participant = participant
+        self._mesh: MeshPort | None = participant.mesh
         self._transport = transport
         self._config = config
         self._session_id = session_id
-        self._discovery = discovery
-        self._peer_id = config.peer_id or socket.gethostname()
+        self._peer_id = participant.peer_id or config.peer_id or socket.gethostname()
         self._running = False
         self._pending_responses: dict[str, asyncio.Future[str]] = {}
         self._execute_lock = asyncio.Lock()
@@ -68,26 +70,23 @@ class SkuldMeshAdapter:
         return getattr(self._mesh, "subscriber", None)
 
     async def start(self) -> None:
-        """Register with discovery and subscribe to task topics."""
+        """Start participant (mesh + discovery) and subscribe to task topics."""
         if self._running:
             return
 
-        await self._mesh.start()
-        logger.info("mesh adapter: mesh transport started (peer_id=%s)", self._peer_id)
-
-        if self._discovery is not None:
-            await self._discovery.start()
-            logger.info("mesh adapter: discovery started")
+        await self._participant.start()
+        logger.info("mesh adapter: participant started (peer_id=%s)", self._peer_id)
 
         # Set up RPC handler for work_request messages
-        if hasattr(self._mesh, "set_rpc_handler"):
+        if self._mesh is not None and hasattr(self._mesh, "set_rpc_handler"):
             self._mesh.set_rpc_handler(self._handle_rpc)
             logger.info("mesh adapter: RPC handler registered")
 
         # Subscribe to consumed event types
-        for event_type in self._config.consumes_event_types:
-            await self._mesh.subscribe(event_type, self._handle_outcome_event)
-            logger.info("mesh adapter: subscribed to topic %r", event_type)
+        if self._mesh is not None:
+            for event_type in self._config.consumes_event_types:
+                await self._mesh.subscribe(event_type, self._handle_outcome_event)
+                logger.info("mesh adapter: subscribed to topic %r", event_type)
 
         self._running = True
         logger.info(
@@ -98,14 +97,15 @@ class SkuldMeshAdapter:
         )
 
     async def stop(self) -> None:
-        """Unsubscribe from topics and deregister from discovery."""
+        """Unsubscribe from topics and stop participant (mesh + discovery)."""
         if not self._running:
             return
 
         self._running = False
 
-        for event_type in self._config.consumes_event_types:
-            await self._mesh.unsubscribe(event_type)
+        if self._mesh is not None:
+            for event_type in self._config.consumes_event_types:
+                await self._mesh.unsubscribe(event_type)
 
         # Cancel any pending response futures
         for fut in self._pending_responses.values():
@@ -113,10 +113,7 @@ class SkuldMeshAdapter:
                 fut.cancel()
         self._pending_responses.clear()
 
-        await self._mesh.stop()
-
-        if self._discovery is not None:
-            await self._discovery.stop()
+        await self._participant.stop()
 
         logger.info("mesh adapter: stopped (peer_id=%s)", self._peer_id)
 
@@ -293,6 +290,7 @@ class SkuldMeshAdapter:
             session_id=self._session_id,
         )
 
-        topic = f"{self._config.persona}.completed"
-        await self._mesh.publish(response_event, topic=topic)
-        logger.info("mesh adapter: published response to topic %r", topic)
+        if self._mesh is not None:
+            topic = f"{self._config.persona}.completed"
+            await self._mesh.publish(response_event, topic=topic)
+            logger.info("mesh adapter: published response to topic %r", topic)

--- a/src/skuld/room_mesh_bridge.py
+++ b/src/skuld/room_mesh_bridge.py
@@ -58,6 +58,7 @@ _RAVN_TYPE_TO_ACTIVITY: dict[str, str] = {
     "tool_start": "tool_executing",
     "tool_result": "idle",
     "thought": "thinking",
+    "response": "response",
 }
 
 
@@ -263,4 +264,5 @@ _ACTIVITY_TO_FRAME_TYPE: dict[str, str] = {
     "tool_executing": "tool_start",
     "idle": "tool_result",
     "thinking": "thought",
+    "response": "response",
 }

--- a/src/volundr/adapters/outbound/local_process.py
+++ b/src/volundr/adapters/outbound/local_process.py
@@ -248,7 +248,7 @@ class LocalProcessPodManager(PodManager):
 
             # Spawn ravn flock sidecars if the contributor produced extra containers
             if spec.pod_spec and spec.pod_spec.extra_containers:
-                flock_dir = await self._start_flock(spec, workspace, skuld_port=port)
+                flock_dir = await self._start_flock(spec, workspace)
                 info.flock_dir = str(flock_dir)
                 self._persist_state()
 
@@ -598,8 +598,6 @@ class LocalProcessPodManager(PodManager):
         self,
         spec: SessionSpec,
         workspace: Path,
-        *,
-        skuld_port: int = 0,
     ) -> Path:
         """Init and start a ravn flock alongside the Skuld session.
 
@@ -675,20 +673,6 @@ class LocalProcessPodManager(PodManager):
                 )
                 cluster_path.write_text(yaml.safe_dump(cluster, default_flow_style=False))
                 logger.info("Added Skuld peer to cluster.yaml: %s", skuld_peer_id)
-
-        # Patch each node config with skuld broker_url so ravn daemons
-        # connect via WebSocket and appear in the room UI.
-        if skuld_port:
-            broker_url = f"ws://127.0.0.1:{skuld_port}/ws/ravn"
-            for node_cfg_path in flock_dir.glob("node-*.yaml"):
-                node_cfg = yaml.safe_load(node_cfg_path.read_text()) or {}
-                node_cfg["skuld"] = {
-                    "enabled": True,
-                    "broker_url": broker_url,
-                    "display_name": node_cfg.get("persona", "ravn"),
-                }
-                node_cfg_path.write_text(yaml.safe_dump(node_cfg, default_flow_style=False))
-            logger.info("Patched flock node configs with skuld broker_url: %s", broker_url)
 
         # ravn flock start
         sp.run(

--- a/tests/test_flock/harness.py
+++ b/tests/test_flock/harness.py
@@ -410,8 +410,15 @@ class FlockTestHarness:
             consumes_event_types=[],
             default_work_timeout_s=10.0,
         )
-        self.skuld = SkuldMeshAdapter(
+        from niuu.mesh.participant import MeshParticipant
+
+        _skuld_participant = MeshParticipant(
             mesh=self.mesh,
+            discovery=None,
+            peer_id=mesh_config.peer_id,
+        )
+        self.skuld = SkuldMeshAdapter(
+            participant=_skuld_participant,
             transport=self.cli,
             config=mesh_config,
             session_id=skuld_session_id,

--- a/tests/test_ravn/test_build_sleipnir_transport.py
+++ b/tests/test_ravn/test_build_sleipnir_transport.py
@@ -1,15 +1,16 @@
-"""Tests for _build_sleipnir_transport dynamic adapter pattern (NIU-629)."""
+"""Tests for transport builder and _resolve_transport_kwargs (NIU-629, NIU-634).
+
+_build_sleipnir_transport was deleted in NIU-634; the logic now lives in
+_build_mesh via niuu.mesh.transport_builder.build_transport directly.
+"""
 
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from niuu.mesh.transport_builder import TRANSPORT_ALIASES as _TRANSPORT_ALIASES
-from ravn.cli.commands import (
-    _build_sleipnir_transport,
-    _resolve_transport_kwargs,
-)
+from ravn.cli.commands import _resolve_transport_kwargs
 from ravn.config import Settings
 
 
@@ -107,82 +108,36 @@ class TestResolveTransportKwargs:
         assert kwargs == {}
 
 
-class TestBuildSleipnirTransport:
-    """Verify _build_sleipnir_transport delegates to niuu.mesh.transport_builder."""
+class TestBuildMeshTransport:
+    """Verify _resolve_transport_kwargs + niuu.mesh.transport_builder.build_transport
+    together produce the correct kwargs for each transport type.
 
-    def test_uses_import_class_for_known_alias(self):
+    _build_sleipnir_transport was deleted in NIU-634; these tests cover
+    _resolve_transport_kwargs, which is still used by _build_mesh.
+    """
+
+    def test_nng_kwargs_with_cluster(self):
+        """NNG kwargs include peer addresses from cluster.yaml."""
         settings = _make_settings()
-        mock_cls = MagicMock(return_value=MagicMock())
-        with patch("niuu.mesh.transport_builder.import_class", return_value=mock_cls) as imp:
-            result = _build_sleipnir_transport(settings, "nng")
-
-        imp.assert_called_once_with("sleipnir.adapters.nng_transport.NngTransport")
-        assert result is mock_cls.return_value
-
-    def test_uses_import_class_for_fq_path(self):
-        """A fully-qualified class path bypasses the alias map."""
-        settings = _make_settings()
-        mock_cls = MagicMock(return_value=MagicMock())
-        fq = "my.custom.transport.CustomTransport"
-        with patch("niuu.mesh.transport_builder.import_class", return_value=mock_cls) as imp:
-            result = _build_sleipnir_transport(settings, fq)
-
-        imp.assert_called_once_with(fq)
-        assert result is mock_cls.return_value
-
-    def test_returns_none_on_import_error(self):
-        settings = _make_settings()
-        with patch(
-            "niuu.mesh.transport_builder.import_class",
-            side_effect=ImportError("no module"),
-        ):
-            result = _build_sleipnir_transport(settings, "nng")
-        assert result is None
-
-    def test_returns_none_on_instantiation_error(self):
-        settings = _make_settings()
-        mock_cls = MagicMock(side_effect=RuntimeError("bad init"))
-        with patch("niuu.mesh.transport_builder.import_class", return_value=mock_cls):
-            result = _build_sleipnir_transport(settings, "nng")
-        assert result is None
+        with patch("niuu.mesh.cluster.read_cluster_pub_addresses", return_value=["tcp://p:7480"]):
+            kwargs = _resolve_transport_kwargs(settings, "nng")
+        assert kwargs["address"] == "ipc:///tmp/test.ipc"
+        assert kwargs["service_id"] == "ravn:test-peer"
+        assert kwargs["peer_addresses"] == ["tcp://p:7480"]
 
     def test_rabbitmq_returns_none_when_env_missing(self):
         settings = _make_settings()
-        mock_cls = MagicMock(return_value=MagicMock())
-        with patch("niuu.mesh.transport_builder.import_class", return_value=mock_cls):
-            with patch.dict("os.environ", {}, clear=True):
-                result = _build_sleipnir_transport(settings, "rabbitmq")
-        assert result is None
-        mock_cls.assert_not_called()
+        with patch.dict("os.environ", {}, clear=True):
+            kwargs = _resolve_transport_kwargs(settings, "rabbitmq")
+        assert kwargs == {}
 
-    def test_rabbitmq_returns_transport_when_env_set(self):
+    def test_rabbitmq_kwargs_with_env(self):
         settings = _make_settings()
-        mock_cls = MagicMock(return_value=MagicMock())
-        with patch("niuu.mesh.transport_builder.import_class", return_value=mock_cls):
-            with patch.dict("os.environ", {"SLEIPNIR_AMQP_URL": "amqp://host"}):
-                result = _build_sleipnir_transport(settings, "rabbitmq")
-        assert result is mock_cls.return_value
-        mock_cls.assert_called_once_with(amqp_url="amqp://host")
+        with patch.dict("os.environ", {"SLEIPNIR_AMQP_URL": "amqp://host"}):
+            kwargs = _resolve_transport_kwargs(settings, "rabbitmq")
+        assert kwargs == {"amqp_url": "amqp://host"}
 
-    def test_in_process_instantiated_with_no_args(self):
+    def test_in_process_kwargs_empty(self):
         settings = _make_settings()
-        mock_cls = MagicMock(return_value=MagicMock())
-        with patch("niuu.mesh.transport_builder.import_class", return_value=mock_cls):
-            result = _build_sleipnir_transport(settings, "in_process")
-        assert result is mock_cls.return_value
-        mock_cls.assert_called_once_with()
-
-    def test_nng_passes_correct_kwargs(self):
-        settings = _make_settings()
-        mock_cls = MagicMock(return_value=MagicMock())
-        with patch("niuu.mesh.transport_builder.import_class", return_value=mock_cls):
-            with patch(
-                "ravn.cli.commands._read_cluster_pub_addresses",
-                return_value=["tcp://peer1:7480"],
-            ):
-                _build_sleipnir_transport(settings, "nng")
-        mock_cls.assert_called_once_with(
-            address="ipc:///tmp/test.ipc",
-            service_id="ravn:test-peer",
-            peer_addresses=["tcp://peer1:7480"],
-        )
+        kwargs = _resolve_transport_kwargs(settings, "in_process")
+        assert kwargs == {}

--- a/tests/test_ravn/test_build_sleipnir_transport.py
+++ b/tests/test_ravn/test_build_sleipnir_transport.py
@@ -7,7 +7,9 @@ _build_mesh via niuu.mesh.transport_builder.build_transport directly.
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from niuu.mesh.transport_builder import TRANSPORT_ALIASES as _TRANSPORT_ALIASES
 from ravn.cli.commands import _resolve_transport_kwargs
@@ -101,6 +103,146 @@ class TestResolveTransportKwargs:
         settings = _make_settings()
         kwargs = _resolve_transport_kwargs(settings, "in_process")
         assert kwargs == {}
+
+
+class TestBuildMesh:
+    """Verify _build_mesh creates the correct mesh adapter (legacy + list paths)."""
+
+    def test_legacy_nng_returns_sleipnir_adapter(self):
+        """Legacy nng adapter (default) → SleipnirMeshAdapter is constructed."""
+        from ravn.cli.commands import _build_mesh
+
+        settings = _make_settings()
+        with (
+            patch("niuu.mesh.transport_builder.build_transport", return_value=MagicMock()),
+            patch("ravn.adapters.mesh.sleipnir_mesh.SleipnirMeshAdapter") as mock_cls,
+            patch("niuu.mesh.cluster.read_cluster_pub_addresses", return_value=[]),
+        ):
+            _build_mesh(settings)
+        mock_cls.assert_called_once()
+
+    def test_legacy_rabbitmq_no_env_returns_none(self):
+        """Legacy rabbitmq adapter with no AMQP_URL env → returns None (guard fires)."""
+        from ravn.cli.commands import _build_mesh
+
+        settings = _make_settings()
+        settings.mesh.adapter = "rabbitmq"
+        with patch.dict("os.environ", {}, clear=True):
+            result = _build_mesh(settings)
+        assert result is None
+
+    def test_adapters_list_exercises_closure_body(self):
+        """When mesh.adapters list is set, _sleipnir_tb closure body is exercised."""
+        from ravn.cli.commands import _build_mesh
+
+        settings = _make_settings()
+        settings.mesh.adapters = [{"role": "pub_sub", "transport": "nng"}]
+
+        captured: list = []
+
+        def _fake_build_mesh(
+            adapters, own_peer_id, rpc_timeout_s, discovery, sleipnir_transport_builder
+        ):
+            captured.append(sleipnir_transport_builder)
+            return MagicMock()
+
+        with (
+            patch("niuu.mesh.build_mesh_from_adapters_list", side_effect=_fake_build_mesh),
+            patch("niuu.mesh.transport_builder.build_transport", return_value=MagicMock()),
+            patch("niuu.mesh.cluster.read_cluster_pub_addresses", return_value=[]),
+        ):
+            _build_mesh(settings)
+            assert captured, "sleipnir_transport_builder was not passed to helper"
+            nng_result = captured[0]({"transport": "nng"})
+        assert nng_result is not None
+
+    def test_adapters_list_closure_rabbitmq_no_env_returns_none(self):
+        """_sleipnir_tb closure returns None when rabbitmq env is missing."""
+        from ravn.cli.commands import _build_mesh
+
+        settings = _make_settings()
+        settings.mesh.adapters = [{"role": "pub_sub", "transport": "rabbitmq"}]
+
+        captured: list = []
+
+        def _fake_build_mesh(
+            adapters, own_peer_id, rpc_timeout_s, discovery, sleipnir_transport_builder
+        ):
+            captured.append(sleipnir_transport_builder)
+            return MagicMock()
+
+        with (
+            patch("niuu.mesh.build_mesh_from_adapters_list", side_effect=_fake_build_mesh),
+            patch("niuu.mesh.transport_builder.build_transport", return_value=MagicMock()),
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            _build_mesh(settings)
+            assert captured
+            result = captured[0]({"transport": "rabbitmq"})
+        assert result is None
+
+
+class TestBuildDiscovery:
+    """Verify _build_discovery delegates to niuu.mesh.discovery_builder."""
+
+    def test_returns_discovery_adapter(self):
+        """_build_discovery calls build_discovery_adapters and returns its result."""
+        from ravn.cli.commands import _build_discovery
+
+        settings = _make_settings()
+        mock_discovery = MagicMock()
+        with (
+            patch(
+                "ravn.adapters.discovery._identity.load_or_create_peer_id",
+                return_value="p1",
+            ),
+            patch(
+                "ravn.adapters.discovery._identity.load_or_create_realm_key",
+                return_value=b"key",
+            ),
+            patch(
+                "ravn.adapters.discovery._identity.realm_id_from_key",
+                return_value="realm-1",
+            ),
+            patch("importlib.metadata.version", return_value="0.0.0"),
+            patch(
+                "niuu.mesh.discovery_builder.build_discovery_adapters",
+                return_value=mock_discovery,
+            ),
+        ):
+            result = _build_discovery(settings)
+        assert result is mock_discovery
+
+
+class TestRunPeers:
+    """Verify _run_peers calls build_discovery_adapters and exits early when None."""
+
+    @pytest.mark.asyncio
+    async def test_run_peers_no_discovery_returns_early(self):
+        """_run_peers exits early (no exception) when discovery is None."""
+        from ravn.cli.commands import _run_peers
+
+        settings = _make_settings()
+        with (
+            patch(
+                "ravn.adapters.discovery._identity.load_or_create_peer_id",
+                return_value="p1",
+            ),
+            patch(
+                "ravn.adapters.discovery._identity.load_or_create_realm_key",
+                return_value=b"key",
+            ),
+            patch(
+                "ravn.adapters.discovery._identity.realm_id_from_key",
+                return_value="realm-1",
+            ),
+            patch("importlib.metadata.version", return_value="0.0.0"),
+            patch(
+                "niuu.mesh.discovery_builder.build_discovery_adapters",
+                return_value=None,
+            ),
+        ):
+            await _run_peers(settings, verbose=False, force_scan=False)
 
     def test_unknown_adapter_returns_empty(self):
         settings = _make_settings()

--- a/tests/test_ravn/test_drive_loop_channel_construction.py
+++ b/tests/test_ravn/test_drive_loop_channel_construction.py
@@ -142,3 +142,18 @@ class TestDriveLoopChannelConstruction:
         assert isinstance(captured[0], CompositeChannel)
         channel_types = [type(ch) for ch in captured[0]._channels]
         assert MeshActivityChannel in channel_types
+
+    @pytest.mark.asyncio
+    async def test_cascade_skuld_and_mesh_uses_composite_with_all(self):
+        """cascade + skuld_channel + mesh → CompositeChannel([capture, skuld, mesh])."""
+        dl, captured = _make_drive_loop_with_mesh(cascade_enabled=True)
+        mock_skuld = MagicMock()
+        mock_skuld.emit = AsyncMock()
+        dl._skuld_channel = mock_skuld
+        dl._mesh = AsyncMock()
+
+        await dl._run_task(_make_task())
+
+        assert isinstance(captured[0], CompositeChannel)
+        channel_types = [type(ch) for ch in captured[0]._channels]
+        assert MeshActivityChannel in channel_types

--- a/tests/test_ravn/test_drive_loop_channel_construction.py
+++ b/tests/test_ravn/test_drive_loop_channel_construction.py
@@ -1,0 +1,135 @@
+"""Tests for DriveLoop channel construction with mesh (NIU-634).
+
+Verifies that MeshActivityChannel is included in the composite channel
+when mesh is enabled, and that the channel construction falls back
+correctly when mesh is not available.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ravn.adapters.channels.composite import CompositeChannel
+from ravn.adapters.channels.mesh_channel import MeshActivityChannel
+from ravn.adapters.channels.silent import SilentChannel
+from ravn.config import InitiativeConfig
+from ravn.domain.models import AgentTask, OutputMode
+from ravn.drive_loop import DriveLoop
+
+
+def _make_task(task_id: str = "t1") -> AgentTask:
+    return AgentTask(
+        task_id=task_id,
+        title="test",
+        initiative_context="do it",
+        triggered_by="test",
+        output_mode=OutputMode.SILENT,
+    )
+
+
+def _make_drive_loop_with_mesh(
+    *,
+    cascade_enabled: bool = False,
+    skuld_enabled: bool = False,
+    mesh_enabled: bool = True,
+    peer_id: str = "ravn-peer",
+) -> tuple[DriveLoop, list]:
+    """Build a DriveLoop with mesh configured; return (loop, captured_channels)."""
+    captured: list = []
+
+    def _agent_factory(channel, task_id, persona, triggered_by):
+        captured.append(channel)
+        agent = AsyncMock()
+        fake_usage = MagicMock(input_tokens=0, output_tokens=0)
+        agent.run_turn = AsyncMock(
+            return_value=MagicMock(usage=fake_usage, cost_usd=0.0)
+        )
+        return agent
+
+    cfg = InitiativeConfig(
+        enabled=True,
+        max_concurrent_tasks=1,
+        task_queue_max=10,
+        queue_journal_path="/proc/no_such_dir/queue.json",
+    )
+    settings = MagicMock()
+    settings.skuld.enabled = skuld_enabled
+    settings.cascade.enabled = cascade_enabled
+    settings.mesh.enabled = mesh_enabled
+    settings.mesh.own_peer_id = peer_id
+    settings.budget.daily_cap_usd = 100.0
+    settings.budget.warn_at_percent = 80
+    settings.budget.input_token_cost_per_million = 3.0
+    settings.budget.output_token_cost_per_million = 15.0
+
+    dl = DriveLoop(agent_factory=_agent_factory, config=cfg, settings=settings)
+    return dl, captured
+
+
+class TestDriveLoopChannelConstruction:
+    """Verify channel composition logic in _run_task."""
+
+    @pytest.mark.asyncio
+    async def test_mesh_enabled_no_cascade_uses_mesh_channel(self):
+        """Mesh enabled, no cascade → channel is MeshActivityChannel."""
+        dl, captured = _make_drive_loop_with_mesh(cascade_enabled=False)
+        mock_mesh = AsyncMock()
+        dl._mesh = mock_mesh
+
+        await dl._run_task(_make_task())
+
+        assert len(captured) == 1
+        channel = captured[0]
+        assert isinstance(channel, MeshActivityChannel)
+
+    @pytest.mark.asyncio
+    async def test_mesh_disabled_no_cascade_uses_silent(self):
+        """Mesh disabled, no cascade → SilentChannel."""
+        dl, captured = _make_drive_loop_with_mesh(
+            cascade_enabled=False, mesh_enabled=False
+        )
+        dl._mesh = None
+
+        await dl._run_task(_make_task())
+
+        assert isinstance(captured[0], SilentChannel)
+
+    @pytest.mark.asyncio
+    async def test_mesh_no_peer_id_uses_silent(self):
+        """Mesh enabled but peer_id empty → SilentChannel (no publish target)."""
+        dl, captured = _make_drive_loop_with_mesh(
+            cascade_enabled=False, peer_id=""
+        )
+        dl._mesh = AsyncMock()
+
+        await dl._run_task(_make_task())
+
+        assert isinstance(captured[0], SilentChannel)
+
+    @pytest.mark.asyncio
+    async def test_cascade_with_mesh_uses_composite(self):
+        """cascade.enabled=True + mesh → CompositeChannel including MeshActivityChannel."""
+        dl, captured = _make_drive_loop_with_mesh(cascade_enabled=True)
+        mock_mesh = AsyncMock()
+        dl._mesh = mock_mesh
+
+        await dl._run_task(_make_task())
+
+        assert isinstance(captured[0], CompositeChannel)
+        channel_types = [type(ch) for ch in captured[0]._channels]
+        assert MeshActivityChannel in channel_types
+
+    @pytest.mark.asyncio
+    async def test_cascade_without_mesh_uses_capture_only(self):
+        """cascade.enabled=True, mesh=None → CaptureChannel only (no composite)."""
+        from ravn.adapters.channels.capture import CaptureChannel
+
+        dl, captured = _make_drive_loop_with_mesh(cascade_enabled=True)
+        dl._mesh = None
+
+        await dl._run_task(_make_task())
+
+        # With cascade and no mesh/skuld_channel, channel is capture_channel alone
+        assert isinstance(captured[0], CaptureChannel)

--- a/tests/test_ravn/test_drive_loop_channel_construction.py
+++ b/tests/test_ravn/test_drive_loop_channel_construction.py
@@ -43,9 +43,7 @@ def _make_drive_loop_with_mesh(
         captured.append(channel)
         agent = AsyncMock()
         fake_usage = MagicMock(input_tokens=0, output_tokens=0)
-        agent.run_turn = AsyncMock(
-            return_value=MagicMock(usage=fake_usage, cost_usd=0.0)
-        )
+        agent.run_turn = AsyncMock(return_value=MagicMock(usage=fake_usage, cost_usd=0.0))
         return agent
 
     cfg = InitiativeConfig(
@@ -87,9 +85,7 @@ class TestDriveLoopChannelConstruction:
     @pytest.mark.asyncio
     async def test_mesh_disabled_no_cascade_uses_silent(self):
         """Mesh disabled, no cascade → SilentChannel."""
-        dl, captured = _make_drive_loop_with_mesh(
-            cascade_enabled=False, mesh_enabled=False
-        )
+        dl, captured = _make_drive_loop_with_mesh(cascade_enabled=False, mesh_enabled=False)
         dl._mesh = None
 
         await dl._run_task(_make_task())
@@ -99,9 +95,7 @@ class TestDriveLoopChannelConstruction:
     @pytest.mark.asyncio
     async def test_mesh_no_peer_id_uses_silent(self):
         """Mesh enabled but peer_id empty → SilentChannel (no publish target)."""
-        dl, captured = _make_drive_loop_with_mesh(
-            cascade_enabled=False, peer_id=""
-        )
+        dl, captured = _make_drive_loop_with_mesh(cascade_enabled=False, peer_id="")
         dl._mesh = AsyncMock()
 
         await dl._run_task(_make_task())
@@ -133,3 +127,18 @@ class TestDriveLoopChannelConstruction:
 
         # With cascade and no mesh/skuld_channel, channel is capture_channel alone
         assert isinstance(captured[0], CaptureChannel)
+
+    @pytest.mark.asyncio
+    async def test_no_cascade_skuld_and_mesh_uses_composite(self):
+        """No cascade, skuld_channel + mesh → CompositeChannel(sinks) with both."""
+        dl, captured = _make_drive_loop_with_mesh(cascade_enabled=False)
+        mock_skuld = MagicMock()
+        mock_skuld.emit = AsyncMock()
+        dl._skuld_channel = mock_skuld
+        dl._mesh = AsyncMock()
+
+        await dl._run_task(_make_task())
+
+        assert isinstance(captured[0], CompositeChannel)
+        channel_types = [type(ch) for ch in captured[0]._channels]
+        assert MeshActivityChannel in channel_types

--- a/tests/test_ravn/test_mesh_channel.py
+++ b/tests/test_ravn/test_mesh_channel.py
@@ -1,0 +1,88 @@
+"""Tests for MeshActivityChannel (NIU-634)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ravn.adapters.channels.mesh_channel import MeshActivityChannel
+from ravn.domain.events import RavnEvent, RavnEventType
+
+
+def _make_event(event_type: RavnEventType = RavnEventType.THOUGHT) -> RavnEvent:
+    return RavnEvent(
+        type=event_type,
+        source="ravn-test",
+        payload={"text": "hello"},
+        timestamp=datetime.now(UTC),
+        urgency=0.3,
+        correlation_id="c1",
+        session_id="s1",
+    )
+
+
+def _make_mesh() -> MagicMock:
+    mesh = MagicMock()
+    mesh.publish = AsyncMock()
+    return mesh
+
+
+class TestMeshActivityChannel:
+    def test_topic_uses_peer_id(self):
+        mesh = _make_mesh()
+        ch = MeshActivityChannel(mesh, "my-peer")
+        assert ch._topic == "activity.my-peer"
+
+    @pytest.mark.asyncio
+    async def test_emit_publishes_to_mesh(self):
+        mesh = _make_mesh()
+        ch = MeshActivityChannel(mesh, "peer-01")
+        event = _make_event()
+        await ch.emit(event)
+        mesh.publish.assert_awaited_once_with(event, topic="activity.peer-01")
+
+    @pytest.mark.asyncio
+    async def test_emit_thought_event(self):
+        mesh = _make_mesh()
+        ch = MeshActivityChannel(mesh, "p1")
+        event = _make_event(RavnEventType.THOUGHT)
+        await ch.emit(event)
+        call_args = mesh.publish.call_args
+        assert call_args[0][0].type == RavnEventType.THOUGHT
+        assert call_args[1]["topic"] == "activity.p1"
+
+    @pytest.mark.asyncio
+    async def test_emit_response_event(self):
+        mesh = _make_mesh()
+        ch = MeshActivityChannel(mesh, "p1")
+        event = _make_event(RavnEventType.RESPONSE)
+        await ch.emit(event)
+        mesh.publish.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_emit_tool_start_event(self):
+        mesh = _make_mesh()
+        ch = MeshActivityChannel(mesh, "p1")
+        event = _make_event(RavnEventType.TOOL_START)
+        await ch.emit(event)
+        mesh.publish.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_emit_suppresses_publish_exception(self):
+        """Publish failures must not propagate to callers."""
+        mesh = _make_mesh()
+        mesh.publish.side_effect = RuntimeError("mesh down")
+        ch = MeshActivityChannel(mesh, "p1")
+        # Must not raise
+        await ch.emit(_make_event())
+
+    @pytest.mark.asyncio
+    async def test_emit_logs_warning_on_exception(self):
+        mesh = _make_mesh()
+        mesh.publish.side_effect = RuntimeError("mesh down")
+        ch = MeshActivityChannel(mesh, "p1")
+        with patch("ravn.adapters.channels.mesh_channel.logger") as mock_logger:
+            await ch.emit(_make_event())
+        mock_logger.warning.assert_called_once()

--- a/tests/test_skuld/test_mesh_adapter.py
+++ b/tests/test_skuld/test_mesh_adapter.py
@@ -11,7 +11,7 @@ Covers:
 
 import asyncio
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -939,4 +939,68 @@ class TestBrokerMeshIntegration:
         assert b._mesh_adapter is not None
         assert b._mesh_adapter.is_running is True
 
+        await b._mesh_adapter.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_mesh_adapter_nng_builds_sleipnir(self, tmp_path):
+        """_start_mesh_adapter with nng transport builds SleipnirMeshAdapter (NIU-634)."""
+        from skuld.broker import Broker
+
+        settings = SkuldSettings(
+            session={"id": "s1", "workspace_dir": str(tmp_path)},
+            transport="subprocess",
+            mesh={"enabled": True, "peer_id": "test-peer", "transport": "nng"},
+        )
+        b = Broker(settings=settings)
+        b._transport = MagicMock()
+
+        mock_nng = MagicMock()
+        mock_mesh = MagicMock()
+        mock_mesh.start = AsyncMock()
+        mock_mesh.stop = AsyncMock()
+        mock_mesh.subscribe = AsyncMock()
+        mock_mesh.unsubscribe = AsyncMock()
+
+        with (
+            patch(
+                "niuu.mesh.transport_builder.build_nng_transport",
+                return_value=mock_nng,
+            ),
+            patch(
+                "ravn.adapters.mesh.sleipnir_mesh.SleipnirMeshAdapter",
+                return_value=mock_mesh,
+            ),
+            patch("skuld.broker.build_discovery_adapters", return_value=None),
+            patch("niuu.mesh.cluster.read_cluster_pub_addresses", return_value=[]),
+        ):
+            await b._start_mesh_adapter()
+
+        assert b._mesh_adapter is not None
+        assert b._mesh_adapter.is_running is True
+        await b._mesh_adapter.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_mesh_adapter_nng_import_error_falls_back(self, tmp_path):
+        """_start_mesh_adapter falls back to in-process when nng raises ImportError."""
+        from skuld.broker import Broker
+
+        settings = SkuldSettings(
+            session={"id": "s1", "workspace_dir": str(tmp_path)},
+            transport="subprocess",
+            mesh={"enabled": True, "peer_id": "test-peer", "transport": "nng"},
+        )
+        b = Broker(settings=settings)
+        b._transport = MagicMock()
+
+        with (
+            patch(
+                "niuu.mesh.transport_builder.build_nng_transport",
+                side_effect=ImportError("nng not available"),
+            ),
+            patch("skuld.broker.build_discovery_adapters", return_value=None),
+        ):
+            await b._start_mesh_adapter()
+
+        assert b._mesh_adapter is not None
+        assert b._mesh_adapter.is_running is True
         await b._mesh_adapter.stop()

--- a/tests/test_skuld/test_mesh_adapter.py
+++ b/tests/test_skuld/test_mesh_adapter.py
@@ -79,8 +79,11 @@ def mock_transport():
 
 @pytest.fixture
 def adapter(mock_mesh, mock_transport, mesh_config):
+    from niuu.mesh.participant import MeshParticipant
+
+    participant = MeshParticipant(mesh=mock_mesh, discovery=None, peer_id=mesh_config.peer_id)
     return SkuldMeshAdapter(
-        mesh=mock_mesh,
+        participant=participant,
         transport=mock_transport,
         config=mesh_config,
         session_id="test-session-42",
@@ -177,13 +180,15 @@ class TestSkuldMeshAdapterLifecycle:
 
     @pytest.mark.asyncio
     async def test_start_with_discovery(self, mock_mesh, mock_transport, mesh_config):
+        from niuu.mesh.participant import MeshParticipant
+
         discovery = AsyncMock()
+        participant = MeshParticipant(mesh=mock_mesh, discovery=discovery, peer_id="s1")
         adapter = SkuldMeshAdapter(
-            mesh=mock_mesh,
+            participant=participant,
             transport=mock_transport,
             config=mesh_config,
             session_id="s1",
-            discovery=discovery,
         )
         await adapter.start()
 
@@ -200,13 +205,15 @@ class TestSkuldMeshAdapterLifecycle:
 
     @pytest.mark.asyncio
     async def test_stop_with_discovery(self, mock_mesh, mock_transport, mesh_config):
+        from niuu.mesh.participant import MeshParticipant
+
         discovery = AsyncMock()
+        participant = MeshParticipant(mesh=mock_mesh, discovery=discovery, peer_id="s1")
         adapter = SkuldMeshAdapter(
-            mesh=mock_mesh,
+            participant=participant,
             transport=mock_transport,
             config=mesh_config,
             session_id="s1",
-            discovery=discovery,
         )
         await adapter.start()
         await adapter.stop()
@@ -231,26 +238,32 @@ class TestSkuldMeshAdapterLifecycle:
 
     @pytest.mark.asyncio
     async def test_peer_id_defaults_to_hostname(self, mock_mesh, mock_transport):
+        import socket
+
+        from niuu.mesh.participant import MeshParticipant
+
         cfg = MeshConfig(enabled=True, peer_id="")
+        participant = MeshParticipant(mesh=mock_mesh, discovery=None, peer_id="")
         adapter = SkuldMeshAdapter(
-            mesh=mock_mesh,
+            participant=participant,
             transport=mock_transport,
             config=cfg,
             session_id="s1",
         )
-        import socket
-
         assert adapter.peer_id == socket.gethostname()
 
     @pytest.mark.asyncio
     async def test_multiple_event_type_subscriptions(self, mock_mesh, mock_transport):
+        from niuu.mesh.participant import MeshParticipant
+
         cfg = MeshConfig(
             enabled=True,
             peer_id="s1",
             consumes_event_types=["code.requested", "review.requested"],
         )
+        participant = MeshParticipant(mesh=mock_mesh, discovery=None, peer_id="s1")
         adapter = SkuldMeshAdapter(
-            mesh=mock_mesh,
+            participant=participant,
             transport=mock_transport,
             config=cfg,
             session_id="s1",
@@ -363,13 +376,16 @@ class TestWorkRequestHandling:
     @pytest.mark.asyncio
     async def test_work_request_uses_config_default_timeout(self, mock_mesh, mock_transport):
         """When no timeout_s in message, use config.default_work_timeout_s."""
+        from niuu.mesh.participant import MeshParticipant
+
         cfg = MeshConfig(
             enabled=True,
             peer_id="s1",
             default_work_timeout_s=0.05,
         )
+        participant = MeshParticipant(mesh=mock_mesh, discovery=None, peer_id="s1")
         adapter = SkuldMeshAdapter(
-            mesh=mock_mesh,
+            participant=participant,
             transport=mock_transport,
             config=cfg,
             session_id="s1",
@@ -611,13 +627,16 @@ class TestOutcomeEventHandling:
     @pytest.mark.asyncio
     async def test_outcome_uses_config_response_urgency(self, mock_mesh, mock_transport):
         """Published outcome event uses config.default_response_urgency."""
+        from niuu.mesh.participant import MeshParticipant
+
         cfg = MeshConfig(
             enabled=True,
             peer_id="urg-test",
             default_response_urgency=0.7,
         )
+        participant = MeshParticipant(mesh=mock_mesh, discovery=None, peer_id="urg-test")
         adapter = SkuldMeshAdapter(
-            mesh=mock_mesh,
+            participant=participant,
             transport=mock_transport,
             config=cfg,
             session_id="s1",
@@ -726,8 +745,11 @@ class TestMeshRoundTrip:
             consumes_event_types=["code.requested"],
         )
 
+        from niuu.mesh.participant import MeshParticipant
+
+        participant = MeshParticipant(mesh=mesh, discovery=None, peer_id="skuld-integration")
         adapter = SkuldMeshAdapter(
-            mesh=mesh,
+            participant=participant,
             transport=transport,
             config=config,
             session_id="int-session",
@@ -889,55 +911,6 @@ class TestBrokerMeshIntegration:
         b = Broker(settings=settings)
         # Before startup, mesh_adapter is None
         assert b._mesh_adapter is None
-
-    @pytest.mark.asyncio
-    async def test_build_mesh_in_process(self, tmp_path):
-        from skuld.broker import Broker
-
-        settings = SkuldSettings(
-            session={"id": "s1", "workspace_dir": str(tmp_path)},
-            mesh={"enabled": True, "peer_id": "test", "transport": "in_process"},
-        )
-        b = Broker(settings=settings)
-        mesh = b._build_mesh(settings.mesh)
-        assert mesh is not None
-
-    @pytest.mark.asyncio
-    async def test_build_mesh_with_adapters_list_falls_back_to_in_process(self, tmp_path):
-        """adapters list in MeshConfig is for discovery, not mesh transport.
-
-        _build_mesh uses the transport field (nng / in_process).  When NNG is
-        unavailable it falls back to in-process, which always succeeds.
-        """
-        from skuld.broker import Broker
-
-        settings = SkuldSettings(
-            session={"id": "s1", "workspace_dir": str(tmp_path)},
-            mesh={
-                "enabled": True,
-                "peer_id": "test",
-                "adapters": [
-                    {
-                        "adapter": "ravn.adapters.discovery.static.StaticDiscoveryAdapter",
-                    }
-                ],
-            },
-        )
-        b = Broker(settings=settings)
-        mesh = b._build_mesh(settings.mesh)
-        # Falls back to in-process when NNG unavailable — always non-None
-        assert mesh is not None
-
-    @pytest.mark.asyncio
-    async def test_build_discovery_returns_none(self, tmp_path):
-        from skuld.broker import Broker
-
-        settings = SkuldSettings(
-            session={"id": "s1", "workspace_dir": str(tmp_path)},
-            mesh={"enabled": True},
-        )
-        b = Broker(settings=settings)
-        assert b._build_discovery(settings.mesh) is None
 
     @pytest.mark.asyncio
     async def test_start_mesh_adapter_integrates(self, tmp_path):

--- a/tests/test_skuld/test_room_mesh_bridge.py
+++ b/tests/test_skuld/test_room_mesh_bridge.py
@@ -389,6 +389,34 @@ class TestActivityTranslation:
         await bridge.stop()
 
     @pytest.mark.asyncio
+    async def test_response_event_translated_to_response_frame(self):
+        room = _make_room_bridge(known_peers=["skuld-01"])
+        bus = InProcessBus()
+        bridge = RoomMeshBridge(
+            subscriber=bus,
+            room_bridge=room,
+            session_id="sess-abc",
+        )
+        await bridge.start()
+
+        evt = _make_event(
+            payload={
+                "ravn_event": {"text": "Here is the answer"},
+                "ravn_type": "RavnEventType.RESPONSE",
+                "ravn_source": "skuld-01",
+                "ravn_session_id": "sess-abc",
+                "ravn_urgency": 0.3,
+                "ravn_task_id": None,
+            }
+        )
+        await bridge._handle_event(evt)
+
+        room.handle_ravn_frame.assert_awaited_once()
+        _, frame = room.handle_ravn_frame.call_args[0]
+        assert frame["type"] == "response"
+        await bridge.stop()
+
+    @pytest.mark.asyncio
     async def test_unknown_ravn_type_is_ignored(self):
         room = _make_room_bridge(known_peers=["skuld-01"])
         bus = InProcessBus()
@@ -402,7 +430,7 @@ class TestActivityTranslation:
         evt = _make_event(
             payload={
                 "ravn_event": {},
-                "ravn_type": "RavnEventType.RESPONSE",
+                "ravn_type": "RavnEventType.DECISION",
                 "ravn_source": "skuld-01",
                 "ravn_session_id": "sess-abc",
                 "ravn_urgency": 0.3,


### PR DESCRIPTION
## Summary

- **Phase 1**: Replace duplicated mesh/discovery builders in `skuld/broker.py` and `ravn/cli/commands.py` with `niuu.mesh.MeshParticipant`. Deleted `_build_mesh()`, `_build_discovery()` from broker; deleted `_build_sleipnir_transport()`, `_build_discovery_adapters()`, `_read_cluster_pub_addresses()`, `_DISCOVERY_ALIASES` from commands. `SkuldMeshAdapter` constructor updated to accept `participant: MeshParticipant` instead of individual `mesh=`/`discovery=` kwargs.
- **Phase 2**: Add `MeshActivityChannel` (new `ChannelPort` adapter) that publishes thought/tool_start/tool_result/response events to mesh topic `activity.{peer_id}`. DriveLoop adds it to `CompositeChannel` when mesh is enabled. `RoomMeshBridge` gains `response` ravn_type → room_message routing.
- **Phase 3**: Remove skuld WebSocket patching (`skuld.broker_url` in `node-*.yaml`) from `local_process._start_flock()`. Ravn flock daemons now reach the room UI via Sleipnir mesh instead of direct WebSocket.

## Test plan

- [x] All 13,478 tests pass (`tests/` + `tests/test_ravn/`)
- [x] `ruff check` and `ruff format --check` clean
- [x] `test_mesh_adapter.py` updated for new `MeshParticipant` API (49 tests)
- [x] `test_build_sleipnir_transport.py` updated for deleted functions (17 tests)
- [x] `harness.py` updated for flock e2e tests
- [x] `test_room_mesh_bridge.py` updated: `RESPONSE` now handled, test added

Fixes: NIU-634

🤖 Generated with [Claude Code](https://claude.com/claude-code)