### PR TITLE
feat(adapters): FlockFlowConfig model, pluggable providers, REST CRUD, dispatch snapshotting (NIU-643)

### DIFF
--- a/charts/tyr/templates/configmap-flock-flows.yaml
+++ b/charts/tyr/templates/configmap-flock-flows.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.flockFlows.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "tyr.fullname" . }}-flock-flows
+  labels:
+    {{- include "tyr.labels" . | nindent 4 }}
+data:
+  flows.yaml: |
+    {{- .Values.flockFlows.flows | toYaml | nindent 4 }}
+{{- end }}

--- a/charts/tyr/templates/rbac-flock-flows.yaml
+++ b/charts/tyr/templates/rbac-flock-flows.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.flockFlows.enabled (eq .Values.flockFlows.adapter "tyr.adapters.flows.configmap.KubernetesConfigMapFlockFlowProvider") }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "tyr.fullname" . }}-flock-flows
+  labels:
+    {{- include "tyr.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: [{{ include "tyr.fullname" . }}-flock-flows]
+    verbs: ["get", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "tyr.fullname" . }}-flock-flows
+  labels:
+    {{- include "tyr.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "tyr.fullname" . }}-flock-flows
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "tyr.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/tyr/values.yaml
+++ b/charts/tyr/values.yaml
@@ -236,6 +236,24 @@ envoy:
   # -- Extra upstream clusters
   extraClusters: []
 
+# Flock flow configuration — reusable named persona compositions
+flockFlows:
+  # -- Enable flock flow ConfigMap and RBAC
+  enabled: false
+  # -- Fully-qualified adapter class path
+  adapter: "tyr.adapters.flows.config.ConfigFlockFlowProvider"
+  # -- Extra kwargs forwarded to the adapter constructor
+  kwargs: {}
+  # -- Predefined flows (rendered into the ConfigMap)
+  flows: []
+  #   - name: code-review-flow
+  #     description: "Standard code review with coordinator + reviewer"
+  #     personas:
+  #       - name: coordinator
+  #       - name: reviewer
+  #     mesh_transport: nng
+  #     max_concurrent_tasks: 3
+
 credentialStore:
   # -- Fully-qualified class path for the credential store adapter
   adapter: "niuu.adapters.memory_credential_store.MemoryCredentialStore"

--- a/src/tyr/adapters/flows/__init__.py
+++ b/src/tyr/adapters/flows/__init__.py
@@ -1,0 +1,1 @@
+"""Flock flow provider adapters."""

--- a/src/tyr/adapters/flows/config.py
+++ b/src/tyr/adapters/flows/config.py
@@ -1,0 +1,55 @@
+"""YAML-file-backed flock flow provider.
+
+Loads flows from a YAML file at startup and keeps in-memory runtime
+additions. Mirrors the pattern of ConfigProfileProvider.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import yaml
+
+from tyr.domain.flock_flow import FlockFlowConfig
+from tyr.ports.flock_flow import FlockFlowProvider
+
+logger = logging.getLogger(__name__)
+
+
+class ConfigFlockFlowProvider(FlockFlowProvider):
+    """Loads flows from a local YAML file plus runtime additions."""
+
+    def __init__(self, path: str = "") -> None:
+        self._flows: dict[str, FlockFlowConfig] = {}
+        if path:
+            self._load_from_file(Path(path))
+
+    def _load_from_file(self, path: Path) -> None:
+        if not path.exists():
+            logger.warning("Flock flow config file not found: %s", path)
+            return
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        if not isinstance(data, list):
+            logger.warning("Flock flow config must be a YAML list, got %s", type(data).__name__)
+            return
+        for entry in data:
+            try:
+                flow = FlockFlowConfig.from_dict(entry)
+                self._flows[flow.name] = flow
+            except (KeyError, TypeError):
+                logger.warning("Skipping invalid flow entry: %s", entry)
+        logger.info("Loaded %d flock flow(s) from %s", len(self._flows), path)
+
+    def get(self, name: str) -> FlockFlowConfig | None:
+        return self._flows.get(name)
+
+    def list(self) -> list[FlockFlowConfig]:
+        return list(self._flows.values())
+
+    def save(self, flow: FlockFlowConfig) -> None:
+        self._flows[flow.name] = flow
+
+    def delete(self, name: str) -> bool:
+        return self._flows.pop(name, None) is not None

--- a/src/tyr/adapters/flows/configmap.py
+++ b/src/tyr/adapters/flows/configmap.py
@@ -67,24 +67,18 @@ class KubernetesConfigMapFlockFlowProvider(FlockFlowProvider):
             return []
 
     def _write_configmap(self, flows: list[dict]) -> None:
-        """Write flows YAML back to the ConfigMap."""
+        """Write flows YAML back to the ConfigMap.
+
+        Raises on failure so callers know the write did not persist.
+        """
         if self._client is None:
-            logger.error("No k8s client available; cannot write ConfigMap")
-            return
+            raise RuntimeError("No k8s client available; cannot write ConfigMap")
         body = {"data": {_DATA_KEY: yaml.dump(flows, default_flow_style=False)}}
-        try:
-            self._client.patch_namespaced_config_map(
-                name=self._configmap_name,
-                namespace=self._namespace,
-                body=body,
-            )
-        except Exception:
-            logger.error(
-                "Failed to write ConfigMap %s/%s",
-                self._namespace,
-                self._configmap_name,
-                exc_info=True,
-            )
+        self._client.patch_namespaced_config_map(
+            name=self._configmap_name,
+            namespace=self._namespace,
+            body=body,
+        )
 
     def get(self, name: str) -> FlockFlowConfig | None:
         for entry in self._read_configmap():

--- a/src/tyr/adapters/flows/configmap.py
+++ b/src/tyr/adapters/flows/configmap.py
@@ -1,0 +1,122 @@
+"""Kubernetes ConfigMap-backed flock flow provider.
+
+Reads and writes flock flow definitions through the Kubernetes API,
+storing them in a ConfigMap. Same RBAC approach as the persona ConfigMap.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import yaml
+
+from tyr.domain.flock_flow import FlockFlowConfig
+from tyr.ports.flock_flow import FlockFlowProvider
+
+logger = logging.getLogger(__name__)
+
+_DATA_KEY = "flows.yaml"
+
+
+class KubernetesConfigMapFlockFlowProvider(FlockFlowProvider):
+    """Read/write flock flows through a Kubernetes ConfigMap."""
+
+    def __init__(
+        self,
+        namespace: str = "tyr",
+        configmap_name: str = "flock-flows",
+        kube_client: object | None = None,
+    ) -> None:
+        self._namespace = namespace
+        self._configmap_name = configmap_name
+        self._client = kube_client or self._default_client()
+
+    @staticmethod
+    def _default_client() -> object:
+        """Create a default Kubernetes client (in-cluster config)."""
+        try:
+            from kubernetes import client, config  # type: ignore[import-untyped]
+
+            config.load_incluster_config()
+            return client.CoreV1Api()
+        except Exception:
+            logger.warning("Failed to create in-cluster k8s client; operations will fail")
+            return None
+
+    def _read_configmap(self) -> list[dict]:
+        """Read and parse the flows YAML from the ConfigMap."""
+        if self._client is None:
+            return []
+        try:
+            cm = self._client.read_namespaced_config_map(
+                name=self._configmap_name,
+                namespace=self._namespace,
+            )
+            raw = (cm.data or {}).get(_DATA_KEY, "")
+            if not raw:
+                return []
+            data = yaml.safe_load(raw)
+            return data if isinstance(data, list) else []
+        except Exception:
+            logger.warning(
+                "Failed to read ConfigMap %s/%s",
+                self._namespace,
+                self._configmap_name,
+                exc_info=True,
+            )
+            return []
+
+    def _write_configmap(self, flows: list[dict]) -> None:
+        """Write flows YAML back to the ConfigMap."""
+        if self._client is None:
+            logger.error("No k8s client available; cannot write ConfigMap")
+            return
+        body = {"data": {_DATA_KEY: yaml.dump(flows, default_flow_style=False)}}
+        try:
+            self._client.patch_namespaced_config_map(
+                name=self._configmap_name,
+                namespace=self._namespace,
+                body=body,
+            )
+        except Exception:
+            logger.error(
+                "Failed to write ConfigMap %s/%s",
+                self._namespace,
+                self._configmap_name,
+                exc_info=True,
+            )
+
+    def get(self, name: str) -> FlockFlowConfig | None:
+        for entry in self._read_configmap():
+            if entry.get("name") == name:
+                return FlockFlowConfig.from_dict(entry)
+        return None
+
+    def list(self) -> list[FlockFlowConfig]:
+        result: list[FlockFlowConfig] = []
+        for entry in self._read_configmap():
+            try:
+                result.append(FlockFlowConfig.from_dict(entry))
+            except (KeyError, TypeError):
+                logger.warning("Skipping invalid flow entry in ConfigMap: %s", entry)
+        return result
+
+    def save(self, flow: FlockFlowConfig) -> None:
+        entries = self._read_configmap()
+        replaced = False
+        for i, entry in enumerate(entries):
+            if entry.get("name") == flow.name:
+                entries[i] = flow.to_dict()
+                replaced = True
+                break
+        if not replaced:
+            entries.append(flow.to_dict())
+        self._write_configmap(entries)
+
+    def delete(self, name: str) -> bool:
+        entries = self._read_configmap()
+        new_entries = [e for e in entries if e.get("name") != name]
+        if len(new_entries) == len(entries):
+            return False
+        self._write_configmap(new_entries)
+        return True

--- a/src/tyr/api/flock_flows.py
+++ b/src/tyr/api/flock_flows.py
@@ -1,0 +1,204 @@
+"""REST API for flock flow configuration — CRUD for reusable persona compositions."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from niuu.domain.models import Principal
+from tyr.adapters.inbound.auth import extract_principal
+from tyr.domain.flock_flow import FlockFlowConfig, FlockPersonaOverride
+from tyr.ports.flock_flow import FlockFlowProvider
+
+# ---------------------------------------------------------------------------
+# Request / Response models
+# ---------------------------------------------------------------------------
+
+
+class PersonaOverrideBody(BaseModel):
+    name: str
+    llm: dict | None = None
+    system_prompt_extra: str = ""
+    iteration_budget: int = 0
+    max_concurrent_tasks: int = 0
+
+
+class FlockFlowBody(BaseModel):
+    name: str = Field(min_length=1, max_length=128)
+    description: str = ""
+    personas: list[PersonaOverrideBody] = Field(default_factory=list)
+    mesh_transport: str = "nng"
+    mimir_hosted_url: str = ""
+    sleipnir_publish_urls: list[str] = Field(default_factory=list)
+    max_concurrent_tasks: int = Field(default=3, ge=1, le=100)
+
+
+class FlockFlowResponse(BaseModel):
+    name: str
+    description: str
+    personas: list[PersonaOverrideBody]
+    mesh_transport: str
+    mimir_hosted_url: str
+    sleipnir_publish_urls: list[str]
+    max_concurrent_tasks: int
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _to_response(flow: FlockFlowConfig) -> FlockFlowResponse:
+    return FlockFlowResponse(
+        name=flow.name,
+        description=flow.description,
+        personas=[
+            PersonaOverrideBody(
+                name=p.name,
+                llm=p.llm,
+                system_prompt_extra=p.system_prompt_extra,
+                iteration_budget=p.iteration_budget,
+                max_concurrent_tasks=p.max_concurrent_tasks,
+            )
+            for p in flow.personas
+        ],
+        mesh_transport=flow.mesh_transport,
+        mimir_hosted_url=flow.mimir_hosted_url,
+        sleipnir_publish_urls=flow.sleipnir_publish_urls,
+        max_concurrent_tasks=flow.max_concurrent_tasks,
+    )
+
+
+def _body_to_domain(body: FlockFlowBody) -> FlockFlowConfig:
+    return FlockFlowConfig(
+        name=body.name,
+        description=body.description,
+        personas=[
+            FlockPersonaOverride(
+                name=p.name,
+                llm=p.llm,
+                system_prompt_extra=p.system_prompt_extra,
+                iteration_budget=p.iteration_budget,
+                max_concurrent_tasks=p.max_concurrent_tasks,
+            )
+            for p in body.personas
+        ],
+        mesh_transport=body.mesh_transport,
+        mimir_hosted_url=body.mimir_hosted_url,
+        sleipnir_publish_urls=body.sleipnir_publish_urls,
+        max_concurrent_tasks=body.max_concurrent_tasks,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dependencies
+# ---------------------------------------------------------------------------
+
+_persona_source = None
+
+
+async def resolve_flow_provider() -> FlockFlowProvider:
+    raise HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail="Flock flow provider not configured",
+    )
+
+
+async def resolve_persona_names() -> set[str]:
+    """Return the set of known persona names from the configured persona source.
+
+    Overridden at startup when a persona source is wired.
+    """
+    return set()
+
+
+# ---------------------------------------------------------------------------
+# Router
+# ---------------------------------------------------------------------------
+
+
+def create_flock_flows_router() -> APIRouter:
+    router = APIRouter(prefix="/api/v1/tyr/flock_flows", tags=["Flock Flows"])
+
+    @router.get("", response_model=list[FlockFlowResponse])
+    async def list_flows(
+        _principal: Principal = Depends(extract_principal),
+        provider: FlockFlowProvider = Depends(resolve_flow_provider),
+    ) -> list[FlockFlowResponse]:
+        """List all flock flow configurations."""
+        return [_to_response(f) for f in provider.list()]
+
+    @router.get("/{name}", response_model=FlockFlowResponse)
+    async def get_flow(
+        name: str,
+        _principal: Principal = Depends(extract_principal),
+        provider: FlockFlowProvider = Depends(resolve_flow_provider),
+    ) -> FlockFlowResponse:
+        """Get a single flock flow by name."""
+        flow = provider.get(name)
+        if flow is None:
+            raise HTTPException(status_code=404, detail=f"Flow '{name}' not found")
+        return _to_response(flow)
+
+    @router.post("", response_model=FlockFlowResponse, status_code=201)
+    async def create_flow(
+        body: FlockFlowBody,
+        _principal: Principal = Depends(extract_principal),
+        provider: FlockFlowProvider = Depends(resolve_flow_provider),
+        known_personas: set[str] = Depends(resolve_persona_names),
+    ) -> FlockFlowResponse:
+        """Create a new flock flow configuration."""
+        if provider.get(body.name) is not None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"Flow '{body.name}' already exists",
+            )
+        _validate_persona_names(body, known_personas)
+        flow = _body_to_domain(body)
+        provider.save(flow)
+        return _to_response(flow)
+
+    @router.put("/{name}", response_model=FlockFlowResponse)
+    async def update_flow(
+        name: str,
+        body: FlockFlowBody,
+        _principal: Principal = Depends(extract_principal),
+        provider: FlockFlowProvider = Depends(resolve_flow_provider),
+        known_personas: set[str] = Depends(resolve_persona_names),
+    ) -> FlockFlowResponse:
+        """Update an existing flock flow configuration."""
+        if provider.get(name) is None:
+            raise HTTPException(status_code=404, detail=f"Flow '{name}' not found")
+        _validate_persona_names(body, known_personas)
+        flow = _body_to_domain(body)
+        provider.save(flow)
+        return _to_response(flow)
+
+    @router.delete("/{name}", status_code=204)
+    async def delete_flow(
+        name: str,
+        _principal: Principal = Depends(extract_principal),
+        provider: FlockFlowProvider = Depends(resolve_flow_provider),
+    ) -> None:
+        """Delete a flock flow configuration."""
+        if not provider.delete(name):
+            raise HTTPException(status_code=404, detail=f"Flow '{name}' not found")
+
+    return router
+
+
+def _validate_persona_names(body: FlockFlowBody, known_personas: set[str]) -> None:
+    """Validate that all persona names in the body resolve against the known set.
+
+    When the known set is empty (no persona source configured), validation is
+    skipped — the provider may be running without a persona source in dev mode.
+    """
+    if not known_personas:
+        return
+    requested = {p.name for p in body.personas}
+    missing = requested - known_personas
+    if missing:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=f"Unknown persona name(s): {sorted(missing)}",
+        )

--- a/src/tyr/config.py
+++ b/src/tyr/config.py
@@ -875,6 +875,24 @@ class RavnOutcomeConfig(BaseModel):
     )
 
 
+class FlockFlowsConfig(BaseModel):
+    """Flock flow provider configuration (dynamic adapter pattern).
+
+    Example YAML::
+
+        flock_flows:
+          adapter: "tyr.adapters.flows.config.ConfigFlockFlowProvider"
+          kwargs:
+            path: /etc/tyr/flock_flows.yaml
+    """
+
+    adapter: str = Field(
+        default="tyr.adapters.flows.config.ConfigFlockFlowProvider",
+        description="Fully-qualified class path for the flock flow provider.",
+    )
+    kwargs: dict[str, Any] = Field(default_factory=dict)
+
+
 class NotificationConfig(BaseModel):
     """Notification service configuration."""
 
@@ -946,6 +964,7 @@ class Settings(BaseSettings):
     sleipnir: SleipnirConfig = Field(default_factory=SleipnirConfig)
     event_triggers: EventTriggerConfig = Field(default_factory=EventTriggerConfig)
     ravn_outcome: RavnOutcomeConfig = Field(default_factory=RavnOutcomeConfig)
+    flock_flows: FlockFlowsConfig = Field(default_factory=FlockFlowsConfig)
 
     @classmethod
     def settings_customise_sources(

--- a/src/tyr/domain/flock_flow.py
+++ b/src/tyr/domain/flock_flow.py
@@ -1,0 +1,82 @@
+"""Domain models for flock flow configurations.
+
+A FlockFlowConfig is a reusable, named composition of personas that can be
+referenced by dispatches and pipelines instead of repeating persona lists
+inline.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class FlockPersonaOverride:
+    """Per-persona overrides within a flow definition."""
+
+    name: str
+    llm: dict | None = None
+    system_prompt_extra: str = ""
+    iteration_budget: int = 0
+    max_concurrent_tasks: int = 0
+
+    def to_dict(self) -> dict:
+        """Serialize to the wire dict format consumed by workload_config.personas."""
+        d: dict = {"name": self.name}
+        if self.llm:
+            d["llm"] = dict(self.llm)
+        if self.system_prompt_extra:
+            d["system_prompt_extra"] = self.system_prompt_extra
+        if self.iteration_budget:
+            d["iteration_budget"] = self.iteration_budget
+        if self.max_concurrent_tasks:
+            d["max_concurrent_tasks"] = self.max_concurrent_tasks
+        return d
+
+
+@dataclass
+class FlockFlowConfig:
+    """A named, reusable flock persona composition."""
+
+    name: str
+    description: str = ""
+    personas: list[FlockPersonaOverride] = field(default_factory=list)
+    mesh_transport: str = "nng"
+    mimir_hosted_url: str = ""
+    sleipnir_publish_urls: list[str] = field(default_factory=list)
+    max_concurrent_tasks: int = 3
+
+    def to_dict(self) -> dict:
+        """Serialize to a plain dict for YAML/JSON round-tripping."""
+        return {
+            "name": self.name,
+            "description": self.description,
+            "personas": [p.to_dict() for p in self.personas],
+            "mesh_transport": self.mesh_transport,
+            "mimir_hosted_url": self.mimir_hosted_url,
+            "sleipnir_publish_urls": list(self.sleipnir_publish_urls),
+            "max_concurrent_tasks": self.max_concurrent_tasks,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> FlockFlowConfig:
+        """Deserialize from a plain dict."""
+        personas = [
+            FlockPersonaOverride(
+                name=p["name"],
+                llm=p.get("llm"),
+                system_prompt_extra=p.get("system_prompt_extra", ""),
+                iteration_budget=p.get("iteration_budget", 0),
+                max_concurrent_tasks=p.get("max_concurrent_tasks", 0),
+            )
+            for p in data.get("personas", [])
+        ]
+        return cls(
+            name=data["name"],
+            description=data.get("description", ""),
+            personas=personas,
+            mesh_transport=data.get("mesh_transport", "nng"),
+            mimir_hosted_url=data.get("mimir_hosted_url", ""),
+            sleipnir_publish_urls=data.get("sleipnir_publish_urls", []),
+            max_concurrent_tasks=data.get("max_concurrent_tasks", 3),
+        )

--- a/src/tyr/domain/services/dispatch_service.py
+++ b/src/tyr/domain/services/dispatch_service.py
@@ -7,6 +7,8 @@ auto-continue and future consumers without an HTTP request context.
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import json
 import logging
 import re
 import string
@@ -35,6 +37,7 @@ from tyr.domain.templates import BUNDLED_TEMPLATES_DIR, TemplatePhase, load_temp
 from tyr.domain.utils import _slugify
 from tyr.ports.dispatcher_repository import DispatcherRepository
 from tyr.ports.event_bus import EventBusPort, TyrEvent
+from tyr.ports.flock_flow import FlockFlowProvider
 from tyr.ports.saga_repository import SagaRepository
 from tyr.ports.tracker import TrackerFactory, TrackerPort
 from tyr.ports.volundr import SpawnRequest, VolundrFactory, VolundrPort
@@ -212,6 +215,12 @@ def _format_persona_label(persona: dict) -> str:
     return f"{name}({alias}{suffix})"
 
 
+def _snapshot_hash(personas: list[dict]) -> str:
+    """Return a short hash of the persona snapshot for log correlation."""
+    raw = json.dumps(personas, sort_keys=True, default=str)
+    return hashlib.sha256(raw.encode()).hexdigest()[:8]
+
+
 def resolve_target_adapter(
     connection_id: str | None,
     adapter_by_name: dict[str, VolundrPort],
@@ -266,6 +275,7 @@ class DispatchService:
         config: DispatchConfig,
         sleipnir_publisher: object | None = None,
         event_bus: EventBusPort | None = None,
+        flow_provider: FlockFlowProvider | None = None,
     ) -> None:
         self._tracker_factory = tracker_factory
         self._volundr_factory = volundr_factory
@@ -275,6 +285,7 @@ class DispatchService:
         self._locks: defaultdict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
         self._sleipnir_publisher = sleipnir_publisher
         self._event_bus = event_bus
+        self._flow_provider = flow_provider
 
     async def find_ready_issues(
         self,
@@ -796,8 +807,16 @@ class DispatchService:
         effective_model: str,
         effective_prompt: str,
         integration_ids: list[str],
+        flock_flow: str = "",
+        persona_overrides: list[dict] | None = None,
     ) -> SpawnRequest:
-        """Build a SpawnRequest — flock or solo — based on config."""
+        """Build a SpawnRequest — flock or solo — based on config.
+
+        When *flock_flow* names a registered flow, the flow is resolved via the
+        ``FlockFlowProvider`` and **snapshotted** inline into the workload config.
+        Per-dispatch *persona_overrides* take precedence over flow-level overrides
+        which in turn take precedence over persona defaults.
+        """
         session_name = issue.identifier.lower()
         if not self._config.flock_enabled:
             return SpawnRequest(
@@ -818,25 +837,72 @@ class DispatchService:
                 integration_ids=integration_ids,
             )
 
-        personas = self._config.flock_default_personas
-        logger.info(
-            "flock dispatch session=%s personas=[%s]",
-            session_name,
-            ", ".join(_format_persona_label(p) for p in personas),
-        )
+        # Resolve personas — flow snapshot takes precedence over config defaults
+        personas = list(self._config.flock_default_personas)
+        flow_name_for_log = ""
+        mimir_url = self._config.flock_mimir_hosted_url
+        sleipnir_urls = list(self._config.flock_sleipnir_publish_urls)
+
+        if flock_flow and self._flow_provider is not None:
+            flow = self._flow_provider.get(flock_flow)
+            if flow is not None:
+                flow_name_for_log = flow.name
+                # SNAPSHOT: expand flow personas inline
+                personas = [p.to_dict() for p in flow.personas]
+                if flow.mimir_hosted_url:
+                    mimir_url = flow.mimir_hosted_url
+                if flow.sleipnir_publish_urls:
+                    sleipnir_urls = list(flow.sleipnir_publish_urls)
+            else:
+                logger.warning("Flock flow '%s' not found, using default personas", flock_flow)
+
+        # Apply per-dispatch persona overrides (precedence: dispatch > flow > defaults)
+        if persona_overrides:
+            override_map = {o["name"]: o for o in persona_overrides}
+            merged: list[dict] = []
+            for p in personas:
+                name = p.get("name", p) if isinstance(p, dict) else p
+                if name in override_map:
+                    base = dict(p) if isinstance(p, dict) else {"name": p}
+                    base.update(override_map.pop(name))
+                    merged.append(base)
+                else:
+                    merged.append(p if isinstance(p, dict) else {"name": p})
+            # Append any overrides that aren't already in the list
+            for remaining in override_map.values():
+                merged.append(remaining)
+            personas = merged
+
+        # Snapshot hash for log correlation
+        snapshot_hash = _snapshot_hash(personas)
+        if flow_name_for_log:
+            logger.info(
+                "flock dispatch session=%s flow=%s snapshot=%s personas=[%s]",
+                session_name,
+                flow_name_for_log,
+                snapshot_hash,
+                ", ".join(_format_persona_label(p) for p in personas),
+            )
+        else:
+            logger.info(
+                "flock dispatch session=%s personas=[%s]",
+                session_name,
+                ", ".join(_format_persona_label(p) for p in personas),
+            )
+
         workload_config: dict = {
             "personas": personas,
             "initiative_context": build_flock_prompt(
                 issue,
                 item.repo,
                 saga.feature_branch,
-                mimir_hosted_url=self._config.flock_mimir_hosted_url,
+                mimir_hosted_url=mimir_url,
             ),
         }
-        if self._config.flock_sleipnir_publish_urls:
-            workload_config["sleipnir_publish_urls"] = self._config.flock_sleipnir_publish_urls
-        if self._config.flock_mimir_hosted_url:
-            workload_config["mimir_hosted_url"] = self._config.flock_mimir_hosted_url
+        if sleipnir_urls:
+            workload_config["sleipnir_publish_urls"] = sleipnir_urls
+        if mimir_url:
+            workload_config["mimir_hosted_url"] = mimir_url
         if self._config.flock_llm_config:
             workload_config["llm_config"] = self._config.flock_llm_config
 

--- a/src/tyr/domain/services/dispatch_service.py
+++ b/src/tyr/domain/services/dispatch_service.py
@@ -7,6 +7,7 @@ auto-continue and future consumers without an HTTP request context.
 from __future__ import annotations
 
 import asyncio
+import copy
 import hashlib
 import json
 import logging
@@ -838,23 +839,20 @@ class DispatchService:
             )
 
         # Resolve personas — flow snapshot takes precedence over config defaults
-        personas = list(self._config.flock_default_personas)
+        personas = copy.deepcopy(self._config.flock_default_personas)
         flow_name_for_log = ""
         mimir_url = self._config.flock_mimir_hosted_url
         sleipnir_urls = list(self._config.flock_sleipnir_publish_urls)
 
-        if flock_flow and self._flow_provider is not None:
-            flow = self._flow_provider.get(flock_flow)
-            if flow is not None:
-                flow_name_for_log = flow.name
-                # SNAPSHOT: expand flow personas inline
-                personas = [p.to_dict() for p in flow.personas]
-                if flow.mimir_hosted_url:
-                    mimir_url = flow.mimir_hosted_url
-                if flow.sleipnir_publish_urls:
-                    sleipnir_urls = list(flow.sleipnir_publish_urls)
-            else:
-                logger.warning("Flock flow '%s' not found, using default personas", flock_flow)
+        flow = self._flow_provider.get(flock_flow) if flock_flow and self._flow_provider else None
+        if flow is None and flock_flow:
+            logger.warning("Flock flow '%s' not found, using default personas", flock_flow)
+        if flow is not None:
+            flow_name_for_log = flow.name
+            personas = [p.to_dict() for p in flow.personas]
+            mimir_url = flow.mimir_hosted_url or mimir_url
+            if flow.sleipnir_publish_urls:
+                sleipnir_urls = list(flow.sleipnir_publish_urls)
 
         # Apply per-dispatch persona overrides (precedence: dispatch > flow > defaults)
         if persona_overrides:

--- a/src/tyr/main.py
+++ b/src/tyr/main.py
@@ -41,6 +41,10 @@ from tyr.api.dispatch import resolve_saga_repo as dispatch_resolve_saga_repo
 from tyr.api.dispatcher import create_dispatcher_router, resolve_dispatcher_repo
 from tyr.api.dispatcher import resolve_event_bus as dispatcher_resolve_event_bus
 from tyr.api.events import create_events_router, resolve_event_bus
+from tyr.api.flock_flows import (
+    create_flock_flows_router,
+    resolve_flow_provider,
+)
 from tyr.api.health import create_health_router
 from tyr.api.pipelines import create_pipelines_router, resolve_pipeline_executor
 from tyr.api.raids import create_raids_router, resolve_git, resolve_raid_repo
@@ -64,6 +68,7 @@ from tyr.domain.services.reviewer_session import ReviewerSessionService
 from tyr.infrastructure.database import database_pool
 from tyr.ports.dispatcher_repository import DispatcherRepository
 from tyr.ports.event_bus import EventBusPort
+from tyr.ports.flock_flow import FlockFlowProvider
 from tyr.ports.git import GitPort
 from tyr.ports.saga_repository import SagaRepository
 from tyr.ports.tracker import TrackerPort
@@ -175,6 +180,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(create_dispatcher_router())
     app.include_router(create_events_router(settings.events.keepalive_interval))
     app.include_router(create_pipelines_router())
+    app.include_router(create_flock_flows_router())
     from tyr.adapters.inbound.auth import extract_principal as _extract_principal
 
     app.include_router(create_pats_router(_extract_principal))
@@ -277,6 +283,18 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 sl_cls = import_class(settings.sleipnir.adapter)
                 sleipnir_bus = sl_cls(**settings.sleipnir.kwargs)
 
+            # Wire flock flow provider (dynamic adapter pattern)
+            ff_cfg = settings.flock_flows
+            ff_cls = import_class(ff_cfg.adapter)
+            flow_provider: FlockFlowProvider = ff_cls(**ff_cfg.kwargs)
+            app.state.flow_provider = flow_provider
+            logger.info("Flock flow provider: %s", ff_cfg.adapter.rsplit(".", 1)[-1])
+
+            async def _resolve_flow_provider() -> FlockFlowProvider:
+                return flow_provider
+
+            app.dependency_overrides[resolve_flow_provider] = _resolve_flow_provider
+
             # Wire DispatchService
             dispatch_svc = DispatchService(
                 tracker_factory=app.state.tracker_factory,
@@ -296,6 +314,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                     flock_llm_config=dict(settings.dispatch.flock.llm_config),
                 ),
                 sleipnir_publisher=sleipnir_bus,
+                flow_provider=flow_provider,
             )
             app.state.dispatch_service = dispatch_svc
 

--- a/src/tyr/ports/flock_flow.py
+++ b/src/tyr/ports/flock_flow.py
@@ -1,0 +1,27 @@
+"""Port for flock flow configuration providers."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from tyr.domain.flock_flow import FlockFlowConfig
+
+
+class FlockFlowProvider(ABC):
+    """Abstract interface for flock flow CRUD operations."""
+
+    @abstractmethod
+    def get(self, name: str) -> FlockFlowConfig | None:
+        """Return the flow with the given name, or None."""
+
+    @abstractmethod
+    def list(self) -> list[FlockFlowConfig]:
+        """Return all known flows."""
+
+    @abstractmethod
+    def save(self, flow: FlockFlowConfig) -> None:
+        """Create or update a flow."""
+
+    @abstractmethod
+    def delete(self, name: str) -> bool:
+        """Delete a flow by name. Returns True if it existed."""

--- a/tests/test_tyr/test_flock_flows/contract.py
+++ b/tests/test_tyr/test_flock_flows/contract.py
@@ -1,0 +1,81 @@
+"""Shared contract tests for FlockFlowProvider implementations.
+
+Each provider test module subclasses ``FlockFlowProviderContract`` and
+implements the ``make_provider`` fixture so the same behavioural assertions
+run against every adapter.
+"""
+
+from __future__ import annotations
+
+from tyr.domain.flock_flow import FlockFlowConfig, FlockPersonaOverride
+from tyr.ports.flock_flow import FlockFlowProvider
+
+
+def make_flow(name: str = "test-flow") -> FlockFlowConfig:
+    return FlockFlowConfig(
+        name=name,
+        description="A test flow",
+        personas=[
+            FlockPersonaOverride(name="coordinator"),
+            FlockPersonaOverride(name="reviewer", llm={"model": "claude-opus-4-6"}),
+        ],
+        mesh_transport="nng",
+        mimir_hosted_url="http://mimir:8080",
+        sleipnir_publish_urls=["http://sleipnir:4222"],
+        max_concurrent_tasks=5,
+    )
+
+
+class FlockFlowProviderContract:
+    """Contract tests that every FlockFlowProvider must satisfy.
+
+    Subclasses MUST define a ``provider`` pytest fixture that returns a
+    fresh, empty ``FlockFlowProvider`` instance.
+    """
+
+    def test_implements_port(self, provider: FlockFlowProvider) -> None:
+        assert isinstance(provider, FlockFlowProvider)
+
+    def test_empty_by_default(self, provider: FlockFlowProvider) -> None:
+        assert provider.list() == []
+        assert provider.get("nonexistent") is None
+
+    def test_save_and_get(self, provider: FlockFlowProvider) -> None:
+        flow = make_flow()
+        provider.save(flow)
+
+        result = provider.get("test-flow")
+        assert result is not None
+        assert result.name == "test-flow"
+        assert result.description == "A test flow"
+        assert len(result.personas) == 2
+        assert result.personas[0].name == "coordinator"
+        assert result.personas[1].llm == {"model": "claude-opus-4-6"}
+        assert result.max_concurrent_tasks == 5
+
+    def test_save_overwrites(self, provider: FlockFlowProvider) -> None:
+        provider.save(make_flow())
+
+        updated = FlockFlowConfig(name="test-flow", description="Updated")
+        provider.save(updated)
+
+        result = provider.get("test-flow")
+        assert result is not None
+        assert result.description == "Updated"
+
+    def test_list(self, provider: FlockFlowProvider) -> None:
+        provider.save(make_flow("flow-a"))
+        provider.save(make_flow("flow-b"))
+
+        flows = provider.list()
+        names = {f.name for f in flows}
+        assert names == {"flow-a", "flow-b"}
+
+    def test_delete_existing(self, provider: FlockFlowProvider) -> None:
+        provider.save(make_flow())
+
+        assert provider.delete("test-flow") is True
+        assert provider.get("test-flow") is None
+
+    def test_delete_nonexistent(self, provider: FlockFlowProvider) -> None:
+        assert provider.delete("nonexistent") is False

--- a/tests/test_tyr/test_flock_flows/test_config_provider.py
+++ b/tests/test_tyr/test_flock_flows/test_config_provider.py
@@ -1,86 +1,26 @@
-"""Tests for ConfigFlockFlowProvider — YAML round-trip + runtime additions."""
+"""Tests for ConfigFlockFlowProvider — contract + YAML round-trip + runtime additions."""
 
 from __future__ import annotations
 
 import textwrap
 from pathlib import Path
 
+import pytest
+
+from tests.test_tyr.test_flock_flows.contract import (
+    FlockFlowProviderContract,
+    make_flow,
+)
 from tyr.adapters.flows.config import ConfigFlockFlowProvider
-from tyr.domain.flock_flow import FlockFlowConfig, FlockPersonaOverride
-from tyr.ports.flock_flow import FlockFlowProvider
+from tyr.domain.flock_flow import FlockFlowConfig
 
 
-def _make_flow(name: str = "test-flow") -> FlockFlowConfig:
-    return FlockFlowConfig(
-        name=name,
-        description="A test flow",
-        personas=[
-            FlockPersonaOverride(name="coordinator"),
-            FlockPersonaOverride(name="reviewer", llm={"model": "claude-opus-4-6"}),
-        ],
-        mesh_transport="nng",
-        mimir_hosted_url="http://mimir:8080",
-        sleipnir_publish_urls=["http://sleipnir:4222"],
-        max_concurrent_tasks=5,
-    )
+class TestConfigFlockFlowProvider(FlockFlowProviderContract):
+    """Runs the shared contract suite against ConfigFlockFlowProvider."""
 
-
-class TestConfigFlockFlowProvider:
-    """Contract tests for ConfigFlockFlowProvider."""
-
-    def test_implements_port(self) -> None:
-        provider = ConfigFlockFlowProvider()
-        assert isinstance(provider, FlockFlowProvider)
-
-    def test_empty_by_default(self) -> None:
-        provider = ConfigFlockFlowProvider()
-        assert provider.list() == []
-        assert provider.get("nonexistent") is None
-
-    def test_save_and_get(self) -> None:
-        provider = ConfigFlockFlowProvider()
-        flow = _make_flow()
-        provider.save(flow)
-
-        result = provider.get("test-flow")
-        assert result is not None
-        assert result.name == "test-flow"
-        assert result.description == "A test flow"
-        assert len(result.personas) == 2
-        assert result.personas[0].name == "coordinator"
-        assert result.personas[1].llm == {"model": "claude-opus-4-6"}
-        assert result.max_concurrent_tasks == 5
-
-    def test_save_overwrites(self) -> None:
-        provider = ConfigFlockFlowProvider()
-        provider.save(_make_flow())
-
-        updated = FlockFlowConfig(name="test-flow", description="Updated")
-        provider.save(updated)
-
-        result = provider.get("test-flow")
-        assert result is not None
-        assert result.description == "Updated"
-
-    def test_list(self) -> None:
-        provider = ConfigFlockFlowProvider()
-        provider.save(_make_flow("flow-a"))
-        provider.save(_make_flow("flow-b"))
-
-        flows = provider.list()
-        names = {f.name for f in flows}
-        assert names == {"flow-a", "flow-b"}
-
-    def test_delete_existing(self) -> None:
-        provider = ConfigFlockFlowProvider()
-        provider.save(_make_flow())
-
-        assert provider.delete("test-flow") is True
-        assert provider.get("test-flow") is None
-
-    def test_delete_nonexistent(self) -> None:
-        provider = ConfigFlockFlowProvider()
-        assert provider.delete("nonexistent") is False
+    @pytest.fixture()
+    def provider(self) -> ConfigFlockFlowProvider:
+        return ConfigFlockFlowProvider()
 
 
 class TestConfigFlockFlowProviderYAML:
@@ -133,7 +73,7 @@ class TestConfigFlockFlowProviderYAML:
         yaml_file.write_text(yaml_content)
 
         provider = ConfigFlockFlowProvider(path=str(yaml_file))
-        provider.save(_make_flow("runtime-flow"))
+        provider.save(make_flow("runtime-flow"))
 
         assert len(provider.list()) == 2
         assert provider.get("initial-flow") is not None
@@ -154,8 +94,8 @@ class TestConfigFlockFlowProviderYAML:
         assert provider.list() == []
 
     def test_yaml_round_trip(self, tmp_path: Path) -> None:
-        """Test that to_dict → from_dict round-trips correctly."""
-        original = _make_flow("roundtrip")
+        """Test that to_dict -> from_dict round-trips correctly."""
+        original = make_flow("roundtrip")
         d = original.to_dict()
         restored = FlockFlowConfig.from_dict(d)
 

--- a/tests/test_tyr/test_flock_flows/test_config_provider.py
+++ b/tests/test_tyr/test_flock_flows/test_config_provider.py
@@ -1,0 +1,168 @@
+"""Tests for ConfigFlockFlowProvider — YAML round-trip + runtime additions."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from tyr.adapters.flows.config import ConfigFlockFlowProvider
+from tyr.domain.flock_flow import FlockFlowConfig, FlockPersonaOverride
+from tyr.ports.flock_flow import FlockFlowProvider
+
+
+def _make_flow(name: str = "test-flow") -> FlockFlowConfig:
+    return FlockFlowConfig(
+        name=name,
+        description="A test flow",
+        personas=[
+            FlockPersonaOverride(name="coordinator"),
+            FlockPersonaOverride(name="reviewer", llm={"model": "claude-opus-4-6"}),
+        ],
+        mesh_transport="nng",
+        mimir_hosted_url="http://mimir:8080",
+        sleipnir_publish_urls=["http://sleipnir:4222"],
+        max_concurrent_tasks=5,
+    )
+
+
+class TestConfigFlockFlowProvider:
+    """Contract tests for ConfigFlockFlowProvider."""
+
+    def test_implements_port(self) -> None:
+        provider = ConfigFlockFlowProvider()
+        assert isinstance(provider, FlockFlowProvider)
+
+    def test_empty_by_default(self) -> None:
+        provider = ConfigFlockFlowProvider()
+        assert provider.list() == []
+        assert provider.get("nonexistent") is None
+
+    def test_save_and_get(self) -> None:
+        provider = ConfigFlockFlowProvider()
+        flow = _make_flow()
+        provider.save(flow)
+
+        result = provider.get("test-flow")
+        assert result is not None
+        assert result.name == "test-flow"
+        assert result.description == "A test flow"
+        assert len(result.personas) == 2
+        assert result.personas[0].name == "coordinator"
+        assert result.personas[1].llm == {"model": "claude-opus-4-6"}
+        assert result.max_concurrent_tasks == 5
+
+    def test_save_overwrites(self) -> None:
+        provider = ConfigFlockFlowProvider()
+        provider.save(_make_flow())
+
+        updated = FlockFlowConfig(name="test-flow", description="Updated")
+        provider.save(updated)
+
+        result = provider.get("test-flow")
+        assert result is not None
+        assert result.description == "Updated"
+
+    def test_list(self) -> None:
+        provider = ConfigFlockFlowProvider()
+        provider.save(_make_flow("flow-a"))
+        provider.save(_make_flow("flow-b"))
+
+        flows = provider.list()
+        names = {f.name for f in flows}
+        assert names == {"flow-a", "flow-b"}
+
+    def test_delete_existing(self) -> None:
+        provider = ConfigFlockFlowProvider()
+        provider.save(_make_flow())
+
+        assert provider.delete("test-flow") is True
+        assert provider.get("test-flow") is None
+
+    def test_delete_nonexistent(self) -> None:
+        provider = ConfigFlockFlowProvider()
+        assert provider.delete("nonexistent") is False
+
+
+class TestConfigFlockFlowProviderYAML:
+    """YAML file loading tests."""
+
+    def test_loads_from_yaml(self, tmp_path: Path) -> None:
+        yaml_content = textwrap.dedent("""\
+            - name: code-review-flow
+              description: Standard code review
+              personas:
+                - name: coordinator
+                - name: reviewer
+                  llm:
+                    model: claude-opus-4-6
+              mesh_transport: nng
+              mimir_hosted_url: http://mimir:8080
+              max_concurrent_tasks: 3
+            - name: security-audit
+              description: Security-focused review
+              personas:
+                - name: security-auditor
+                  system_prompt_extra: Focus on OWASP top 10
+                  iteration_budget: 10
+        """)
+        yaml_file = tmp_path / "flows.yaml"
+        yaml_file.write_text(yaml_content)
+
+        provider = ConfigFlockFlowProvider(path=str(yaml_file))
+
+        assert len(provider.list()) == 2
+
+        flow = provider.get("code-review-flow")
+        assert flow is not None
+        assert flow.description == "Standard code review"
+        assert len(flow.personas) == 2
+        assert flow.personas[1].llm == {"model": "claude-opus-4-6"}
+
+        audit = provider.get("security-audit")
+        assert audit is not None
+        assert audit.personas[0].system_prompt_extra == "Focus on OWASP top 10"
+        assert audit.personas[0].iteration_budget == 10
+
+    def test_runtime_additions_after_yaml_load(self, tmp_path: Path) -> None:
+        yaml_content = textwrap.dedent("""\
+            - name: initial-flow
+              personas:
+                - name: coordinator
+        """)
+        yaml_file = tmp_path / "flows.yaml"
+        yaml_file.write_text(yaml_content)
+
+        provider = ConfigFlockFlowProvider(path=str(yaml_file))
+        provider.save(_make_flow("runtime-flow"))
+
+        assert len(provider.list()) == 2
+        assert provider.get("initial-flow") is not None
+        assert provider.get("runtime-flow") is not None
+
+    def test_missing_file_is_warning(self) -> None:
+        provider = ConfigFlockFlowProvider(path="/nonexistent/path.yaml")
+        assert provider.list() == []
+
+    def test_empty_path_no_load(self) -> None:
+        provider = ConfigFlockFlowProvider(path="")
+        assert provider.list() == []
+
+    def test_invalid_yaml_format(self, tmp_path: Path) -> None:
+        yaml_file = tmp_path / "bad.yaml"
+        yaml_file.write_text("not_a_list: true")
+        provider = ConfigFlockFlowProvider(path=str(yaml_file))
+        assert provider.list() == []
+
+    def test_yaml_round_trip(self, tmp_path: Path) -> None:
+        """Test that to_dict → from_dict round-trips correctly."""
+        original = _make_flow("roundtrip")
+        d = original.to_dict()
+        restored = FlockFlowConfig.from_dict(d)
+
+        assert restored.name == original.name
+        assert restored.description == original.description
+        assert len(restored.personas) == len(original.personas)
+        assert restored.personas[1].llm == original.personas[1].llm
+        assert restored.mimir_hosted_url == original.mimir_hosted_url
+        assert restored.sleipnir_publish_urls == original.sleipnir_publish_urls
+        assert restored.max_concurrent_tasks == original.max_concurrent_tasks

--- a/tests/test_tyr/test_flock_flows/test_configmap_provider.py
+++ b/tests/test_tyr/test_flock_flows/test_configmap_provider.py
@@ -1,6 +1,7 @@
 """Tests for KubernetesConfigMapFlockFlowProvider — mocked k8s client.
 
-Contract-test parity with ConfigFlockFlowProvider.
+Contract-test parity with ConfigFlockFlowProvider via shared contract suite,
+plus k8s-specific edge-case tests.
 """
 
 from __future__ import annotations
@@ -8,26 +9,15 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
 import yaml
 
+from tests.test_tyr.test_flock_flows.contract import (
+    FlockFlowProviderContract,
+    make_flow,
+)
 from tyr.adapters.flows.configmap import KubernetesConfigMapFlockFlowProvider
-from tyr.domain.flock_flow import FlockFlowConfig, FlockPersonaOverride
-from tyr.ports.flock_flow import FlockFlowProvider
-
-
-def _make_flow(name: str = "test-flow") -> FlockFlowConfig:
-    return FlockFlowConfig(
-        name=name,
-        description="A test flow",
-        personas=[
-            FlockPersonaOverride(name="coordinator"),
-            FlockPersonaOverride(name="reviewer", llm={"model": "claude-opus-4-6"}),
-        ],
-        mesh_transport="nng",
-        mimir_hosted_url="http://mimir:8080",
-        sleipnir_publish_urls=["http://sleipnir:4222"],
-        max_concurrent_tasks=5,
-    )
+from tyr.domain.flock_flow import FlockFlowConfig
 
 
 def _make_configmap(flows: list[dict] | None = None) -> SimpleNamespace:
@@ -38,13 +28,24 @@ def _make_configmap(flows: list[dict] | None = None) -> SimpleNamespace:
     return SimpleNamespace(data=data)
 
 
+def _make_stateful_client(initial_flows: list[dict] | None = None) -> MagicMock:
+    """Build a mock k8s client that reflects writes back to reads."""
+    client = MagicMock()
+    cm = _make_configmap(initial_flows or [])
+
+    def _patch(*, name: str, namespace: str, body: dict) -> None:
+        cm.data = body["data"]
+
+    client.read_namespaced_config_map.return_value = cm
+    client.patch_namespaced_config_map.side_effect = _patch
+    return client
+
+
 def _make_provider(
     flows: list[dict] | None = None,
 ) -> tuple[KubernetesConfigMapFlockFlowProvider, MagicMock]:
     """Build a provider with a mocked k8s client pre-loaded with flows."""
-    client = MagicMock()
-    cm = _make_configmap(flows)
-    client.read_namespaced_config_map.return_value = cm
+    client = _make_stateful_client(flows)
     provider = KubernetesConfigMapFlockFlowProvider(
         namespace="tyr",
         configmap_name="flock-flows",
@@ -53,51 +54,31 @@ def _make_provider(
     return provider, client
 
 
-class TestKubernetesConfigMapFlockFlowProvider:
-    """Contract tests — same interface as ConfigFlockFlowProvider."""
+class TestKubernetesConfigMapFlockFlowProviderContract(FlockFlowProviderContract):
+    """Run the shared contract suite against the ConfigMap provider."""
 
-    def test_implements_port(self) -> None:
-        provider, _ = _make_provider()
-        assert isinstance(provider, FlockFlowProvider)
+    @pytest.fixture()
+    def provider(self) -> KubernetesConfigMapFlockFlowProvider:
+        client = _make_stateful_client([])
+        return KubernetesConfigMapFlockFlowProvider(
+            namespace="tyr",
+            configmap_name="flock-flows",
+            kube_client=client,
+        )
 
-    def test_empty_configmap(self) -> None:
-        provider, _ = _make_provider(flows=[])
-        assert provider.list() == []
-        assert provider.get("nonexistent") is None
 
-    def test_save_and_get(self) -> None:
+class TestKubernetesConfigMapFlockFlowProviderSpecific:
+    """K8s-specific tests beyond the shared contract."""
+
+    def test_save_calls_patch(self) -> None:
         provider, client = _make_provider(flows=[])
-        flow = _make_flow()
-        provider.save(flow)
-
-        # Verify patch was called
+        provider.save(make_flow())
         client.patch_namespaced_config_map.assert_called_once()
         call_kwargs = client.patch_namespaced_config_map.call_args
         assert call_kwargs.kwargs["name"] == "flock-flows"
 
-    def test_get_from_existing(self) -> None:
-        flow_data = [_make_flow("existing").to_dict()]
-        provider, _ = _make_provider(flows=flow_data)
-
-        result = provider.get("existing")
-        assert result is not None
-        assert result.name == "existing"
-        assert len(result.personas) == 2
-
-    def test_get_nonexistent(self) -> None:
-        provider, _ = _make_provider(flows=[_make_flow().to_dict()])
-        assert provider.get("nonexistent") is None
-
-    def test_list(self) -> None:
-        flow_data = [_make_flow("flow-a").to_dict(), _make_flow("flow-b").to_dict()]
-        provider, _ = _make_provider(flows=flow_data)
-
-        flows = provider.list()
-        names = {f.name for f in flows}
-        assert names == {"flow-a", "flow-b"}
-
     def test_save_overwrites_existing(self) -> None:
-        flow_data = [_make_flow("test-flow").to_dict()]
+        flow_data = [make_flow("test-flow").to_dict()]
         provider, client = _make_provider(flows=flow_data)
 
         updated = FlockFlowConfig(name="test-flow", description="Updated")
@@ -109,17 +90,17 @@ class TestKubernetesConfigMapFlockFlowProvider:
         assert saved_data[0]["description"] == "Updated"
 
     def test_save_appends_new(self) -> None:
-        flow_data = [_make_flow("existing").to_dict()]
+        flow_data = [make_flow("existing").to_dict()]
         provider, client = _make_provider(flows=flow_data)
 
-        provider.save(_make_flow("new-flow"))
+        provider.save(make_flow("new-flow"))
 
         call_body = client.patch_namespaced_config_map.call_args.kwargs["body"]
         saved_data = yaml.safe_load(call_body["data"]["flows.yaml"])
         assert len(saved_data) == 2
 
-    def test_delete_existing(self) -> None:
-        flow_data = [_make_flow("to-delete").to_dict()]
+    def test_delete_calls_patch(self) -> None:
+        flow_data = [make_flow("to-delete").to_dict()]
         provider, client = _make_provider(flows=flow_data)
 
         assert provider.delete("to-delete") is True
@@ -128,10 +109,10 @@ class TestKubernetesConfigMapFlockFlowProvider:
         saved_data = yaml.safe_load(call_body["data"]["flows.yaml"])
         assert saved_data == []
 
-    def test_delete_nonexistent(self) -> None:
-        provider, client = _make_provider(flows=[])
-        assert provider.delete("nonexistent") is False
-        client.patch_namespaced_config_map.assert_not_called()
+    def test_no_client_raises_on_save(self) -> None:
+        provider = KubernetesConfigMapFlockFlowProvider(kube_client=None)
+        with pytest.raises(RuntimeError, match="No k8s client"):
+            provider.save(make_flow())
 
     def test_no_client_returns_empty(self) -> None:
         provider = KubernetesConfigMapFlockFlowProvider(kube_client=None)
@@ -141,6 +122,12 @@ class TestKubernetesConfigMapFlockFlowProvider:
     def test_no_client_delete_returns_false(self) -> None:
         provider = KubernetesConfigMapFlockFlowProvider(kube_client=None)
         assert provider.delete("anything") is False
+
+    def test_write_failure_propagates(self) -> None:
+        provider, client = _make_provider(flows=[])
+        client.patch_namespaced_config_map.side_effect = RuntimeError("k8s write error")
+        with pytest.raises(RuntimeError, match="k8s write error"):
+            provider.save(make_flow())
 
     def test_read_error_returns_empty(self) -> None:
         client = MagicMock()

--- a/tests/test_tyr/test_flock_flows/test_configmap_provider.py
+++ b/tests/test_tyr/test_flock_flows/test_configmap_provider.py
@@ -1,0 +1,155 @@
+"""Tests for KubernetesConfigMapFlockFlowProvider — mocked k8s client.
+
+Contract-test parity with ConfigFlockFlowProvider.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import yaml
+
+from tyr.adapters.flows.configmap import KubernetesConfigMapFlockFlowProvider
+from tyr.domain.flock_flow import FlockFlowConfig, FlockPersonaOverride
+from tyr.ports.flock_flow import FlockFlowProvider
+
+
+def _make_flow(name: str = "test-flow") -> FlockFlowConfig:
+    return FlockFlowConfig(
+        name=name,
+        description="A test flow",
+        personas=[
+            FlockPersonaOverride(name="coordinator"),
+            FlockPersonaOverride(name="reviewer", llm={"model": "claude-opus-4-6"}),
+        ],
+        mesh_transport="nng",
+        mimir_hosted_url="http://mimir:8080",
+        sleipnir_publish_urls=["http://sleipnir:4222"],
+        max_concurrent_tasks=5,
+    )
+
+
+def _make_configmap(flows: list[dict] | None = None) -> SimpleNamespace:
+    """Build a mock ConfigMap response."""
+    data = {}
+    if flows is not None:
+        data["flows.yaml"] = yaml.dump(flows, default_flow_style=False)
+    return SimpleNamespace(data=data)
+
+
+def _make_provider(
+    flows: list[dict] | None = None,
+) -> tuple[KubernetesConfigMapFlockFlowProvider, MagicMock]:
+    """Build a provider with a mocked k8s client pre-loaded with flows."""
+    client = MagicMock()
+    cm = _make_configmap(flows)
+    client.read_namespaced_config_map.return_value = cm
+    provider = KubernetesConfigMapFlockFlowProvider(
+        namespace="tyr",
+        configmap_name="flock-flows",
+        kube_client=client,
+    )
+    return provider, client
+
+
+class TestKubernetesConfigMapFlockFlowProvider:
+    """Contract tests — same interface as ConfigFlockFlowProvider."""
+
+    def test_implements_port(self) -> None:
+        provider, _ = _make_provider()
+        assert isinstance(provider, FlockFlowProvider)
+
+    def test_empty_configmap(self) -> None:
+        provider, _ = _make_provider(flows=[])
+        assert provider.list() == []
+        assert provider.get("nonexistent") is None
+
+    def test_save_and_get(self) -> None:
+        provider, client = _make_provider(flows=[])
+        flow = _make_flow()
+        provider.save(flow)
+
+        # Verify patch was called
+        client.patch_namespaced_config_map.assert_called_once()
+        call_kwargs = client.patch_namespaced_config_map.call_args
+        assert call_kwargs.kwargs["name"] == "flock-flows"
+
+    def test_get_from_existing(self) -> None:
+        flow_data = [_make_flow("existing").to_dict()]
+        provider, _ = _make_provider(flows=flow_data)
+
+        result = provider.get("existing")
+        assert result is not None
+        assert result.name == "existing"
+        assert len(result.personas) == 2
+
+    def test_get_nonexistent(self) -> None:
+        provider, _ = _make_provider(flows=[_make_flow().to_dict()])
+        assert provider.get("nonexistent") is None
+
+    def test_list(self) -> None:
+        flow_data = [_make_flow("flow-a").to_dict(), _make_flow("flow-b").to_dict()]
+        provider, _ = _make_provider(flows=flow_data)
+
+        flows = provider.list()
+        names = {f.name for f in flows}
+        assert names == {"flow-a", "flow-b"}
+
+    def test_save_overwrites_existing(self) -> None:
+        flow_data = [_make_flow("test-flow").to_dict()]
+        provider, client = _make_provider(flows=flow_data)
+
+        updated = FlockFlowConfig(name="test-flow", description="Updated")
+        provider.save(updated)
+
+        call_body = client.patch_namespaced_config_map.call_args.kwargs["body"]
+        saved_data = yaml.safe_load(call_body["data"]["flows.yaml"])
+        assert len(saved_data) == 1
+        assert saved_data[0]["description"] == "Updated"
+
+    def test_save_appends_new(self) -> None:
+        flow_data = [_make_flow("existing").to_dict()]
+        provider, client = _make_provider(flows=flow_data)
+
+        provider.save(_make_flow("new-flow"))
+
+        call_body = client.patch_namespaced_config_map.call_args.kwargs["body"]
+        saved_data = yaml.safe_load(call_body["data"]["flows.yaml"])
+        assert len(saved_data) == 2
+
+    def test_delete_existing(self) -> None:
+        flow_data = [_make_flow("to-delete").to_dict()]
+        provider, client = _make_provider(flows=flow_data)
+
+        assert provider.delete("to-delete") is True
+        client.patch_namespaced_config_map.assert_called_once()
+        call_body = client.patch_namespaced_config_map.call_args.kwargs["body"]
+        saved_data = yaml.safe_load(call_body["data"]["flows.yaml"])
+        assert saved_data == []
+
+    def test_delete_nonexistent(self) -> None:
+        provider, client = _make_provider(flows=[])
+        assert provider.delete("nonexistent") is False
+        client.patch_namespaced_config_map.assert_not_called()
+
+    def test_no_client_returns_empty(self) -> None:
+        provider = KubernetesConfigMapFlockFlowProvider(kube_client=None)
+        assert provider.list() == []
+        assert provider.get("anything") is None
+
+    def test_no_client_delete_returns_false(self) -> None:
+        provider = KubernetesConfigMapFlockFlowProvider(kube_client=None)
+        assert provider.delete("anything") is False
+
+    def test_read_error_returns_empty(self) -> None:
+        client = MagicMock()
+        client.read_namespaced_config_map.side_effect = RuntimeError("k8s error")
+        provider = KubernetesConfigMapFlockFlowProvider(kube_client=client)
+        assert provider.list() == []
+
+    def test_configmap_with_no_data_key(self) -> None:
+        client = MagicMock()
+        client.read_namespaced_config_map.return_value = SimpleNamespace(data={})
+        provider = KubernetesConfigMapFlockFlowProvider(kube_client=client)
+        assert provider.list() == []

--- a/tests/test_tyr/test_flock_flows/test_dispatch_integration.py
+++ b/tests/test_tyr/test_flock_flows/test_dispatch_integration.py
@@ -1,0 +1,425 @@
+"""Tests for dispatch integration — flow resolution, snapshotting, and log output."""
+
+from __future__ import annotations
+
+import copy
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+# Reuse stubs from existing test infrastructure
+from tests.test_tyr.stubs import (
+    InMemorySagaRepository,
+    StubTracker,
+    StubTrackerFactory,
+    StubVolundrFactory,
+)
+from tyr.adapters.flows.config import ConfigFlockFlowProvider
+from tyr.domain.flock_flow import FlockFlowConfig, FlockPersonaOverride
+from tyr.domain.models import (
+    Saga,
+    SagaStatus,
+    TrackerIssue,
+)
+from tyr.domain.services.dispatch_service import (
+    DispatchConfig,
+    DispatchItem,
+    DispatchService,
+    _snapshot_hash,
+)
+
+_NOW = datetime.now(UTC)
+
+
+def _make_saga(saga_id=None, repos=None) -> Saga:
+    return Saga(
+        id=saga_id or uuid4(),
+        tracker_id="proj-1",
+        tracker_type="linear",
+        slug="test-saga",
+        name="Test Saga",
+        repos=repos or ["github.com/test/repo"],
+        feature_branch="feat/test",
+        base_branch="main",
+        status=SagaStatus.ACTIVE,
+        confidence=0.5,
+        created_at=_NOW,
+        owner_id="test-owner",
+    )
+
+
+def _make_issue(identifier: str = "NIU-100") -> TrackerIssue:
+    return TrackerIssue(
+        id="issue-1",
+        identifier=identifier,
+        title="Test Issue",
+        description="A test issue description",
+        status="todo",
+        priority=1,
+        priority_label="High",
+        estimate=2.0,
+        url="https://linear.app/test/NIU-100",
+    )
+
+
+def _make_dispatch_config(flock_enabled: bool = True) -> DispatchConfig:
+    return DispatchConfig(
+        flock_enabled=flock_enabled,
+        flock_default_personas=[
+            {"name": "coordinator"},
+            {"name": "reviewer"},
+        ],
+    )
+
+
+def _make_dispatch_item(saga_id: str) -> DispatchItem:
+    return DispatchItem(
+        saga_id=saga_id,
+        issue_id="issue-1",
+        repo="github.com/test/repo",
+    )
+
+
+def _make_flow(name: str = "code-review-flow") -> FlockFlowConfig:
+    return FlockFlowConfig(
+        name=name,
+        description="Standard code review",
+        personas=[
+            FlockPersonaOverride(name="coordinator", llm={"model": "claude-opus-4-6"}),
+            FlockPersonaOverride(
+                name="reviewer",
+                system_prompt_extra="Focus on test coverage",
+            ),
+            FlockPersonaOverride(name="security-auditor"),
+        ],
+        mimir_hosted_url="http://mimir:8080",
+        sleipnir_publish_urls=["http://sleipnir:4222"],
+        max_concurrent_tasks=5,
+    )
+
+
+class TestFlowResolution:
+    """Test that dispatching with flock_flow resolves the flow and snapshots it."""
+
+    def test_build_spawn_request_with_flow(self) -> None:
+        flow_provider = ConfigFlockFlowProvider()
+        flow_provider.save(_make_flow())
+
+        saga = _make_saga()
+        svc = DispatchService(
+            tracker_factory=StubTrackerFactory(StubTracker()),
+            volundr_factory=StubVolundrFactory(),
+            saga_repo=InMemorySagaRepository(),
+            dispatcher_repo=AsyncMock(),
+            config=_make_dispatch_config(),
+            flow_provider=flow_provider,
+        )
+
+        request = svc._build_spawn_request(
+            item=_make_dispatch_item(str(saga.id)),
+            saga=saga,
+            issue=_make_issue(),
+            effective_model="claude-sonnet-4-6",
+            effective_prompt="",
+            integration_ids=[],
+            flock_flow="code-review-flow",
+        )
+
+        assert request.workload_type == "ravn_flock"
+        personas = request.workload_config["personas"]
+        assert len(personas) == 3
+        assert personas[0]["name"] == "coordinator"
+        assert personas[0]["llm"] == {"model": "claude-opus-4-6"}
+        assert personas[1]["name"] == "reviewer"
+        assert personas[1]["system_prompt_extra"] == "Focus on test coverage"
+        assert personas[2]["name"] == "security-auditor"
+
+    def test_build_spawn_request_flow_not_found_uses_defaults(self) -> None:
+        flow_provider = ConfigFlockFlowProvider()
+        saga = _make_saga()
+        svc = DispatchService(
+            tracker_factory=StubTrackerFactory(StubTracker()),
+            volundr_factory=StubVolundrFactory(),
+            saga_repo=InMemorySagaRepository(),
+            dispatcher_repo=AsyncMock(),
+            config=_make_dispatch_config(),
+            flow_provider=flow_provider,
+        )
+
+        request = svc._build_spawn_request(
+            item=_make_dispatch_item(str(saga.id)),
+            saga=saga,
+            issue=_make_issue(),
+            effective_model="claude-sonnet-4-6",
+            effective_prompt="",
+            integration_ids=[],
+            flock_flow="nonexistent-flow",
+        )
+
+        personas = request.workload_config["personas"]
+        assert len(personas) == 2
+        assert personas[0]["name"] == "coordinator"
+        assert personas[1]["name"] == "reviewer"
+
+    def test_build_spawn_request_no_flow_provider(self) -> None:
+        saga = _make_saga()
+        svc = DispatchService(
+            tracker_factory=StubTrackerFactory(StubTracker()),
+            volundr_factory=StubVolundrFactory(),
+            saga_repo=InMemorySagaRepository(),
+            dispatcher_repo=AsyncMock(),
+            config=_make_dispatch_config(),
+            flow_provider=None,
+        )
+
+        request = svc._build_spawn_request(
+            item=_make_dispatch_item(str(saga.id)),
+            saga=saga,
+            issue=_make_issue(),
+            effective_model="claude-sonnet-4-6",
+            effective_prompt="",
+            integration_ids=[],
+            flock_flow="code-review-flow",
+        )
+
+        # Falls back to defaults since no provider
+        personas = request.workload_config["personas"]
+        assert len(personas) == 2
+
+    def test_build_spawn_request_without_flow(self) -> None:
+        saga = _make_saga()
+        svc = DispatchService(
+            tracker_factory=StubTrackerFactory(StubTracker()),
+            volundr_factory=StubVolundrFactory(),
+            saga_repo=InMemorySagaRepository(),
+            dispatcher_repo=AsyncMock(),
+            config=_make_dispatch_config(),
+        )
+
+        request = svc._build_spawn_request(
+            item=_make_dispatch_item(str(saga.id)),
+            saga=saga,
+            issue=_make_issue(),
+            effective_model="claude-sonnet-4-6",
+            effective_prompt="",
+            integration_ids=[],
+        )
+
+        personas = request.workload_config["personas"]
+        assert len(personas) == 2
+
+
+class TestSnapshotIsolation:
+    """Snapshot test: mutate a flow after dispatch — in-flight config unaffected."""
+
+    def test_flow_mutation_does_not_affect_snapshot(self) -> None:
+        flow_provider = ConfigFlockFlowProvider()
+        flow_provider.save(_make_flow())
+
+        saga = _make_saga()
+        svc = DispatchService(
+            tracker_factory=StubTrackerFactory(StubTracker()),
+            volundr_factory=StubVolundrFactory(),
+            saga_repo=InMemorySagaRepository(),
+            dispatcher_repo=AsyncMock(),
+            config=_make_dispatch_config(),
+            flow_provider=flow_provider,
+        )
+
+        # Build the spawn request (snapshot taken)
+        request = svc._build_spawn_request(
+            item=_make_dispatch_item(str(saga.id)),
+            saga=saga,
+            issue=_make_issue(),
+            effective_model="claude-sonnet-4-6",
+            effective_prompt="",
+            integration_ids=[],
+            flock_flow="code-review-flow",
+        )
+        snapshot_personas = copy.deepcopy(request.workload_config["personas"])
+
+        # Mutate the flow in the provider
+        mutated_flow = FlockFlowConfig(
+            name="code-review-flow",
+            personas=[FlockPersonaOverride(name="completely-different-persona")],
+        )
+        flow_provider.save(mutated_flow)
+
+        # The snapshot from before the mutation is unaffected
+        assert request.workload_config["personas"] == snapshot_personas
+        assert len(request.workload_config["personas"]) == 3
+
+    def test_flow_deletion_does_not_affect_snapshot(self) -> None:
+        flow_provider = ConfigFlockFlowProvider()
+        flow_provider.save(_make_flow())
+
+        saga = _make_saga()
+        svc = DispatchService(
+            tracker_factory=StubTrackerFactory(StubTracker()),
+            volundr_factory=StubVolundrFactory(),
+            saga_repo=InMemorySagaRepository(),
+            dispatcher_repo=AsyncMock(),
+            config=_make_dispatch_config(),
+            flow_provider=flow_provider,
+        )
+
+        request = svc._build_spawn_request(
+            item=_make_dispatch_item(str(saga.id)),
+            saga=saga,
+            issue=_make_issue(),
+            effective_model="claude-sonnet-4-6",
+            effective_prompt="",
+            integration_ids=[],
+            flock_flow="code-review-flow",
+        )
+
+        flow_provider.delete("code-review-flow")
+
+        # Snapshot still has the original personas
+        assert len(request.workload_config["personas"]) == 3
+
+
+class TestPersonaOverridePrecedence:
+    """Per-dispatch persona_overrides take precedence over flow-level."""
+
+    def test_dispatch_override_merges_into_flow(self) -> None:
+        flow_provider = ConfigFlockFlowProvider()
+        flow_provider.save(_make_flow())
+
+        saga = _make_saga()
+        svc = DispatchService(
+            tracker_factory=StubTrackerFactory(StubTracker()),
+            volundr_factory=StubVolundrFactory(),
+            saga_repo=InMemorySagaRepository(),
+            dispatcher_repo=AsyncMock(),
+            config=_make_dispatch_config(),
+            flow_provider=flow_provider,
+        )
+
+        request = svc._build_spawn_request(
+            item=_make_dispatch_item(str(saga.id)),
+            saga=saga,
+            issue=_make_issue(),
+            effective_model="claude-sonnet-4-6",
+            effective_prompt="",
+            integration_ids=[],
+            flock_flow="code-review-flow",
+            persona_overrides=[
+                {"name": "coordinator", "llm": {"model": "claude-sonnet-4-6"}},
+            ],
+        )
+
+        personas = request.workload_config["personas"]
+        coordinator = next(p for p in personas if p["name"] == "coordinator")
+        # Dispatch override takes precedence
+        assert coordinator["llm"] == {"model": "claude-sonnet-4-6"}
+
+    def test_dispatch_override_adds_new_persona(self) -> None:
+        flow_provider = ConfigFlockFlowProvider()
+        flow_provider.save(_make_flow())
+
+        saga = _make_saga()
+        svc = DispatchService(
+            tracker_factory=StubTrackerFactory(StubTracker()),
+            volundr_factory=StubVolundrFactory(),
+            saga_repo=InMemorySagaRepository(),
+            dispatcher_repo=AsyncMock(),
+            config=_make_dispatch_config(),
+            flow_provider=flow_provider,
+        )
+
+        request = svc._build_spawn_request(
+            item=_make_dispatch_item(str(saga.id)),
+            saga=saga,
+            issue=_make_issue(),
+            effective_model="claude-sonnet-4-6",
+            effective_prompt="",
+            integration_ids=[],
+            flock_flow="code-review-flow",
+            persona_overrides=[
+                {"name": "new-persona", "llm": {"model": "claude-opus-4-6"}},
+            ],
+        )
+
+        personas = request.workload_config["personas"]
+        names = [p["name"] for p in personas]
+        assert "new-persona" in names
+        assert len(personas) == 4  # 3 from flow + 1 new
+
+
+class TestFlowMimirAndSleipnir:
+    """Flow-level mimir and sleipnir URLs override config defaults."""
+
+    def test_flow_overrides_mimir_url(self) -> None:
+        flow_provider = ConfigFlockFlowProvider()
+        flow = _make_flow()
+        flow_provider.save(flow)
+
+        saga = _make_saga()
+        svc = DispatchService(
+            tracker_factory=StubTrackerFactory(StubTracker()),
+            volundr_factory=StubVolundrFactory(),
+            saga_repo=InMemorySagaRepository(),
+            dispatcher_repo=AsyncMock(),
+            config=_make_dispatch_config(),
+            flow_provider=flow_provider,
+        )
+
+        request = svc._build_spawn_request(
+            item=_make_dispatch_item(str(saga.id)),
+            saga=saga,
+            issue=_make_issue(),
+            effective_model="claude-sonnet-4-6",
+            effective_prompt="",
+            integration_ids=[],
+            flock_flow="code-review-flow",
+        )
+
+        assert request.workload_config["mimir_hosted_url"] == "http://mimir:8080"
+        assert request.workload_config["sleipnir_publish_urls"] == ["http://sleipnir:4222"]
+
+
+class TestFlockDisabled:
+    """When flock is disabled, flows are not resolved."""
+
+    def test_solo_dispatch_ignores_flow(self) -> None:
+        flow_provider = ConfigFlockFlowProvider()
+        flow_provider.save(_make_flow())
+
+        saga = _make_saga()
+        svc = DispatchService(
+            tracker_factory=StubTrackerFactory(StubTracker()),
+            volundr_factory=StubVolundrFactory(),
+            saga_repo=InMemorySagaRepository(),
+            dispatcher_repo=AsyncMock(),
+            config=_make_dispatch_config(flock_enabled=False),
+            flow_provider=flow_provider,
+        )
+
+        request = svc._build_spawn_request(
+            item=_make_dispatch_item(str(saga.id)),
+            saga=saga,
+            issue=_make_issue(),
+            effective_model="claude-sonnet-4-6",
+            effective_prompt="",
+            integration_ids=[],
+            flock_flow="code-review-flow",
+        )
+
+        # Solo mode — no flock personas; workload_type is the default, not ravn_flock
+        assert request.workload_type != "ravn_flock"
+        assert "personas" not in (request.workload_config or {})
+
+
+class TestSnapshotHash:
+    def test_deterministic(self) -> None:
+        personas = [{"name": "coordinator"}, {"name": "reviewer"}]
+        h1 = _snapshot_hash(personas)
+        h2 = _snapshot_hash(personas)
+        assert h1 == h2
+        assert len(h1) == 8
+
+    def test_different_input_different_hash(self) -> None:
+        h1 = _snapshot_hash([{"name": "coordinator"}])
+        h2 = _snapshot_hash([{"name": "reviewer"}])
+        assert h1 != h2

--- a/tests/test_tyr/test_flock_flows/test_rest_api.py
+++ b/tests/test_tyr/test_flock_flows/test_rest_api.py
@@ -1,0 +1,247 @@
+"""Tests for flock flows REST API — full CRUD + validation failures."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tyr.adapters.flows.config import ConfigFlockFlowProvider
+from tyr.api.flock_flows import (
+    create_flock_flows_router,
+    resolve_flow_provider,
+    resolve_persona_names,
+)
+from tyr.domain.flock_flow import FlockFlowConfig, FlockPersonaOverride
+from tyr.ports.flock_flow import FlockFlowProvider
+
+
+def _auth_headers(user_id: str = "test-user") -> dict[str, str]:
+    return {"x-auth-user-id": user_id}
+
+
+def _make_app(
+    provider: FlockFlowProvider | None = None,
+    known_personas: set[str] | None = None,
+) -> FastAPI:
+    app = FastAPI()
+    app.include_router(create_flock_flows_router())
+
+    p = provider or ConfigFlockFlowProvider()
+
+    async def _resolve_provider() -> FlockFlowProvider:
+        return p
+
+    async def _resolve_personas() -> set[str]:
+        return known_personas or set()
+
+    app.dependency_overrides[resolve_flow_provider] = _resolve_provider
+    app.dependency_overrides[resolve_persona_names] = _resolve_personas
+    return app
+
+
+def _flow_body(
+    name: str = "test-flow",
+    personas: list[dict] | None = None,
+) -> dict:
+    return {
+        "name": name,
+        "description": "A test flow",
+        "personas": personas or [{"name": "coordinator"}, {"name": "reviewer"}],
+        "mesh_transport": "nng",
+        "max_concurrent_tasks": 3,
+    }
+
+
+class TestListFlows:
+    def test_empty_list(self) -> None:
+        client = TestClient(_make_app())
+        resp = client.get("/api/v1/tyr/flock_flows", headers=_auth_headers())
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_list_with_flows(self) -> None:
+        provider = ConfigFlockFlowProvider()
+        provider.save(FlockFlowConfig(name="flow-a"))
+        provider.save(FlockFlowConfig(name="flow-b"))
+
+        client = TestClient(_make_app(provider=provider))
+        resp = client.get("/api/v1/tyr/flock_flows", headers=_auth_headers())
+        assert resp.status_code == 200
+        names = {f["name"] for f in resp.json()}
+        assert names == {"flow-a", "flow-b"}
+
+
+class TestGetFlow:
+    def test_get_existing(self) -> None:
+        provider = ConfigFlockFlowProvider()
+        provider.save(
+            FlockFlowConfig(
+                name="my-flow",
+                description="Test",
+                personas=[FlockPersonaOverride(name="coordinator")],
+            )
+        )
+
+        client = TestClient(_make_app(provider=provider))
+        resp = client.get("/api/v1/tyr/flock_flows/my-flow", headers=_auth_headers())
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["name"] == "my-flow"
+        assert data["description"] == "Test"
+        assert len(data["personas"]) == 1
+
+    def test_get_nonexistent(self) -> None:
+        client = TestClient(_make_app())
+        resp = client.get("/api/v1/tyr/flock_flows/nonexistent", headers=_auth_headers())
+        assert resp.status_code == 404
+
+
+class TestCreateFlow:
+    def test_create_success(self) -> None:
+        client = TestClient(_make_app())
+        resp = client.post(
+            "/api/v1/tyr/flock_flows",
+            json=_flow_body(),
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["name"] == "test-flow"
+        assert len(data["personas"]) == 2
+
+    def test_create_duplicate_returns_409(self) -> None:
+        provider = ConfigFlockFlowProvider()
+        provider.save(FlockFlowConfig(name="existing"))
+
+        client = TestClient(_make_app(provider=provider))
+        resp = client.post(
+            "/api/v1/tyr/flock_flows",
+            json=_flow_body("existing"),
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 409
+
+    def test_create_with_unknown_persona_returns_422(self) -> None:
+        client = TestClient(_make_app(known_personas={"coordinator", "reviewer"}))
+        resp = client.post(
+            "/api/v1/tyr/flock_flows",
+            json=_flow_body(personas=[{"name": "unknown-persona"}]),
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 422
+        assert "unknown-persona" in resp.json()["detail"]
+
+    def test_create_skips_validation_when_no_persona_source(self) -> None:
+        client = TestClient(_make_app(known_personas=set()))
+        resp = client.post(
+            "/api/v1/tyr/flock_flows",
+            json=_flow_body(personas=[{"name": "any-persona"}]),
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 201
+
+    def test_create_empty_name_returns_422(self) -> None:
+        client = TestClient(_make_app())
+        body = _flow_body()
+        body["name"] = ""
+        resp = client.post(
+            "/api/v1/tyr/flock_flows",
+            json=body,
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 422
+
+
+class TestUpdateFlow:
+    def test_update_success(self) -> None:
+        provider = ConfigFlockFlowProvider()
+        provider.save(FlockFlowConfig(name="update-me"))
+
+        client = TestClient(_make_app(provider=provider))
+        resp = client.put(
+            "/api/v1/tyr/flock_flows/update-me",
+            json=_flow_body("update-me"),
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["description"] == "A test flow"
+
+    def test_update_nonexistent_returns_404(self) -> None:
+        client = TestClient(_make_app())
+        resp = client.put(
+            "/api/v1/tyr/flock_flows/nonexistent",
+            json=_flow_body("nonexistent"),
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 404
+
+    def test_update_with_unknown_persona_returns_422(self) -> None:
+        provider = ConfigFlockFlowProvider()
+        provider.save(FlockFlowConfig(name="update-me"))
+
+        client = TestClient(_make_app(provider=provider, known_personas={"coordinator"}))
+        resp = client.put(
+            "/api/v1/tyr/flock_flows/update-me",
+            json=_flow_body("update-me", personas=[{"name": "bad-persona"}]),
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 422
+
+
+class TestDeleteFlow:
+    def test_delete_success(self) -> None:
+        provider = ConfigFlockFlowProvider()
+        provider.save(FlockFlowConfig(name="delete-me"))
+
+        client = TestClient(_make_app(provider=provider))
+        resp = client.delete(
+            "/api/v1/tyr/flock_flows/delete-me",
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 204
+
+    def test_delete_nonexistent_returns_404(self) -> None:
+        client = TestClient(_make_app())
+        resp = client.delete(
+            "/api/v1/tyr/flock_flows/nonexistent",
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 404
+
+
+class TestFullCRUDCycle:
+    def test_create_read_update_delete(self) -> None:
+        client = TestClient(_make_app())
+        headers = _auth_headers()
+
+        # Create
+        resp = client.post(
+            "/api/v1/tyr/flock_flows",
+            json=_flow_body("lifecycle"),
+            headers=headers,
+        )
+        assert resp.status_code == 201
+
+        # Read
+        resp = client.get("/api/v1/tyr/flock_flows/lifecycle", headers=headers)
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "lifecycle"
+
+        # Update
+        updated_body = _flow_body("lifecycle")
+        updated_body["description"] = "Updated description"
+        resp = client.put(
+            "/api/v1/tyr/flock_flows/lifecycle",
+            json=updated_body,
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["description"] == "Updated description"
+
+        # Delete
+        resp = client.delete("/api/v1/tyr/flock_flows/lifecycle", headers=headers)
+        assert resp.status_code == 204
+
+        # Verify gone
+        resp = client.get("/api/v1/tyr/flock_flows/lifecycle", headers=headers)
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary

- **FlockFlowConfig domain model** (`FlockPersonaOverride` + `FlockFlowConfig`) with full `to_dict`/`from_dict` round-tripping
- **FlockFlowProvider port** (ABC): `get`, `list`, `save`, `delete` interface
- **ConfigFlockFlowProvider**: YAML file-backed provider with in-memory runtime additions (mirrors `ConfigProfileProvider`)
- **KubernetesConfigMapFlockFlowProvider**: reads/writes flock flows through a k8s ConfigMap (same RBAC pattern as persona ConfigMap)
- **REST CRUD** at `GET/POST/PUT/DELETE /api/v1/tyr/flock_flows[/{name}]` with persona name validation (422 on unknown names)
- **Dispatch-time flow resolution + snapshotting**: `_build_spawn_request()` resolves `flock_flow: <name>` via the provider, expands personas inline (snapshot is immutable after dispatch), applies per-dispatch `persona_overrides` with precedence: dispatch > flow > config defaults
- **Snapshot hash** logged for cross-log correlation (`flow=code-review-flow snapshot=a1b2c3d4`)
- **Dynamic adapter wiring** via `FlockFlowsConfig` in Settings + `import_class()` in `main.py`
- **Helm chart**: `configmap-flock-flows.yaml`, `rbac-flock-flows.yaml`, `flockFlows` values block

## Test plan

- [x] 13 ConfigFlockFlowProvider tests — YAML round-trip, runtime additions, edge cases
- [x] 14 KubernetesConfigMapFlockFlowProvider tests — mocked k8s client, contract-test parity
- [x] 15 REST API tests — full CRUD, 409 conflict, 422 unknown persona, 404 not found, complete lifecycle
- [x] 12 dispatch integration tests — flow resolution, snapshot isolation (mutate after dispatch), persona override precedence, mimir/sleipnir URL override, flock-disabled passthrough, snapshot hash determinism
- [x] 54 tests total, 93% coverage on new code
- [x] ruff check + ruff format clean
- [x] Full test suite: 12,983 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)