### PR TITLE
feat(adapters): flock UI controls, session badges, settings, dispatch toggle (NIU-648)

### DIFF
--- a/src/tyr/api/dispatch.py
+++ b/src/tyr/api/dispatch.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, Field
 
 from niuu.domain.models import IntegrationType, Principal
 from tyr.adapters.inbound.auth import extract_bearer_token, extract_principal
+from tyr.api.flock_config import FlockPersonaResponse
 from tyr.domain.services.dispatch_service import (
     DispatchItem as ServiceDispatchItem,
 )
@@ -62,13 +63,6 @@ class ModelOption(BaseModel):
     name: str
 
 
-class PersonaConfig(BaseModel):
-    """A flock persona with optional LLM override."""
-
-    name: str
-    llm: dict = {}
-
-
 class DispatchConfigResponse(BaseModel):
     """Dispatch defaults from server config."""
 
@@ -76,7 +70,7 @@ class DispatchConfigResponse(BaseModel):
     default_model: str = "claude-sonnet-4-6"
     models: list[ModelOption] = []
     flock_enabled: bool = False
-    flock_default_personas: list[PersonaConfig] = []
+    flock_default_personas: list[FlockPersonaResponse] = []
     flock_llm_config: dict = {}
     flock_sleipnir_publish_urls: list[str] = []
 
@@ -90,6 +84,14 @@ class DispatchRequest(BaseModel):
     connection_id: str | None = Field(
         default=None,
         description="Target a specific Volundr cluster by connection ID",
+    )
+    workload_type: str = Field(
+        default="solo",
+        description="'solo' for a single Ravn session or 'ravn_flock' for a multi-agent flock",
+    )
+    workload_config: dict = Field(
+        default_factory=dict,
+        description="Flock config — passes 'personas' list to override server defaults",
     )
 
 
@@ -226,7 +228,7 @@ def create_dispatch_router() -> APIRouter:
             models=[ModelOption(id=m.id, name=m.name) for m in settings.ai_models],
             flock_enabled=flock.enabled,
             flock_default_personas=[
-                PersonaConfig(name=p.name, llm=dict(p.llm)) for p in flock.default_personas
+                FlockPersonaResponse(name=p.name, llm=dict(p.llm)) for p in flock.default_personas
             ],
             flock_llm_config=dict(flock.llm_config),
             flock_sleipnir_publish_urls=list(flock.sleipnir_publish_urls),
@@ -268,6 +270,12 @@ def create_dispatch_router() -> APIRouter:
             for item in body.items
         ]
 
+        persona_overrides: list[dict] | None = None
+        if body.workload_type == "ravn_flock":
+            raw = body.workload_config.get("personas")
+            if isinstance(raw, list) and raw:
+                persona_overrides = [{"name": p} if isinstance(p, str) else p for p in raw]
+
         results = await service.dispatch_issues(
             owner_id=principal.user_id,
             items=service_items,
@@ -275,6 +283,7 @@ def create_dispatch_router() -> APIRouter:
             model=body.model or settings.dispatch.default_model,
             system_prompt=body.system_prompt or settings.dispatch.default_system_prompt,
             connection_id=body.connection_id,
+            persona_overrides=persona_overrides,
         )
         return [_result_to_response(r) for r in results]
 

--- a/src/tyr/api/dispatch.py
+++ b/src/tyr/api/dispatch.py
@@ -62,12 +62,23 @@ class ModelOption(BaseModel):
     name: str
 
 
+class PersonaConfig(BaseModel):
+    """A flock persona with optional LLM override."""
+
+    name: str
+    llm: dict = {}
+
+
 class DispatchConfigResponse(BaseModel):
     """Dispatch defaults from server config."""
 
     default_system_prompt: str = ""
     default_model: str = "claude-sonnet-4-6"
     models: list[ModelOption] = []
+    flock_enabled: bool = False
+    flock_default_personas: list[PersonaConfig] = []
+    flock_llm_config: dict = {}
+    flock_sleipnir_publish_urls: list[str] = []
 
 
 class DispatchRequest(BaseModel):
@@ -208,10 +219,17 @@ def create_dispatch_router() -> APIRouter:
     ) -> DispatchConfigResponse:
         """Get dispatch defaults from server configuration."""
         settings = request.app.state.settings
+        flock = settings.dispatch.flock
         return DispatchConfigResponse(
             default_system_prompt=settings.dispatch.default_system_prompt,
             default_model=settings.dispatch.default_model,
             models=[ModelOption(id=m.id, name=m.name) for m in settings.ai_models],
+            flock_enabled=flock.enabled,
+            flock_default_personas=[
+                PersonaConfig(name=p.name, llm=dict(p.llm)) for p in flock.default_personas
+            ],
+            flock_llm_config=dict(flock.llm_config),
+            flock_sleipnir_publish_urls=list(flock.sleipnir_publish_urls),
         )
 
     @router.get("/queue", response_model=list[QueueItemResponse])

--- a/src/tyr/api/flock_config.py
+++ b/src/tyr/api/flock_config.py
@@ -1,0 +1,110 @@
+"""REST API for flock configuration — read and update flock dispatch settings.
+
+Updates are applied in-memory and take effect immediately. They are not
+persisted to disk; the YAML config remains authoritative across restarts.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, Request
+from pydantic import BaseModel
+
+from niuu.domain.models import Principal
+from tyr.adapters.inbound.auth import extract_principal
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Request / Response models
+# ---------------------------------------------------------------------------
+
+
+class FlockPersonaResponse(BaseModel):
+    name: str
+    llm: dict = {}
+
+
+class FlockConfigResponse(BaseModel):
+    flock_enabled: bool
+    flock_default_personas: list[FlockPersonaResponse]
+    flock_llm_config: dict
+    flock_sleipnir_publish_urls: list[str]
+
+
+class PatchFlockConfigRequest(BaseModel):
+    flock_enabled: bool | None = None
+    flock_default_personas: list[str] | None = None
+    flock_llm_config: dict | None = None
+    flock_sleipnir_publish_urls: list[str] | None = None
+
+
+# ---------------------------------------------------------------------------
+# Router
+# ---------------------------------------------------------------------------
+
+
+def create_flock_config_router() -> APIRouter:
+    router = APIRouter(prefix="/api/v1/tyr/flock", tags=["Flock"])
+
+    @router.get("/config", response_model=FlockConfigResponse)
+    async def get_flock_config(
+        request: Request,
+        _principal: Principal = Depends(extract_principal),
+    ) -> FlockConfigResponse:
+        """Return the current flock configuration."""
+        flock = request.app.state.settings.dispatch.flock
+        return FlockConfigResponse(
+            flock_enabled=flock.enabled,
+            flock_default_personas=[
+                FlockPersonaResponse(name=p.name, llm=dict(p.llm)) for p in flock.default_personas
+            ],
+            flock_llm_config=dict(flock.llm_config),
+            flock_sleipnir_publish_urls=list(flock.sleipnir_publish_urls),
+        )
+
+    @router.patch("/config", response_model=FlockConfigResponse)
+    async def patch_flock_config(
+        request: Request,
+        body: PatchFlockConfigRequest,
+        _principal: Principal = Depends(extract_principal),
+    ) -> FlockConfigResponse:
+        """Update flock configuration in-memory.
+
+        Changes take effect immediately but are not persisted to disk.
+        """
+        flock = request.app.state.settings.dispatch.flock
+
+        if body.flock_enabled is not None:
+            flock.enabled = body.flock_enabled
+            logger.info("Flock enabled set to %s", flock.enabled)
+
+        if body.flock_llm_config is not None:
+            flock.llm_config = body.flock_llm_config
+            logger.info("Flock llm_config updated")
+
+        if body.flock_sleipnir_publish_urls is not None:
+            flock.sleipnir_publish_urls = body.flock_sleipnir_publish_urls
+            n = len(flock.sleipnir_publish_urls)
+            logger.info("Flock sleipnir_publish_urls updated: %d URLs", n)
+
+        if body.flock_default_personas is not None:
+            from tyr.config import PersonaOverride
+
+            flock.default_personas = [
+                PersonaOverride(name=name) for name in body.flock_default_personas
+            ]
+            logger.info("Flock default_personas updated: %s", body.flock_default_personas)
+
+        return FlockConfigResponse(
+            flock_enabled=flock.enabled,
+            flock_default_personas=[
+                FlockPersonaResponse(name=p.name, llm=dict(p.llm)) for p in flock.default_personas
+            ],
+            flock_llm_config=dict(flock.llm_config),
+            flock_sleipnir_publish_urls=list(flock.sleipnir_publish_urls),
+        )
+
+    return router

--- a/src/tyr/domain/services/dispatch_service.py
+++ b/src/tyr/domain/services/dispatch_service.py
@@ -364,6 +364,7 @@ class DispatchService:
         model: str = "",
         system_prompt: str = "",
         connection_id: str | None = None,
+        persona_overrides: list[dict] | None = None,
     ) -> list[DispatchResult]:
         """Spawn Volundr sessions for the given items."""
         await self._dispatcher_repo.get_or_create(owner_id)
@@ -426,6 +427,7 @@ class DispatchService:
                 integration_ids=integration_ids,
                 auth_token=auth_token,
                 owner_id=owner_id,
+                persona_overrides=persona_overrides,
             )
             results.append(result)
 
@@ -932,6 +934,7 @@ class DispatchService:
         integration_ids: list[str],
         auth_token: str | None,
         owner_id: str,
+        persona_overrides: list[dict] | None = None,
     ) -> DispatchResult:
         """Spawn a single session and update raid progress."""
         try:
@@ -942,6 +945,7 @@ class DispatchService:
                 effective_model=effective_model,
                 effective_prompt=effective_prompt,
                 integration_ids=integration_ids,
+                persona_overrides=persona_overrides,
             )
             session = await target_volundr.spawn_session(
                 request=request,

--- a/src/tyr/main.py
+++ b/src/tyr/main.py
@@ -41,6 +41,7 @@ from tyr.api.dispatch import resolve_saga_repo as dispatch_resolve_saga_repo
 from tyr.api.dispatcher import create_dispatcher_router, resolve_dispatcher_repo
 from tyr.api.dispatcher import resolve_event_bus as dispatcher_resolve_event_bus
 from tyr.api.events import create_events_router, resolve_event_bus
+from tyr.api.flock_config import create_flock_config_router
 from tyr.api.flock_flows import (
     create_flock_flows_router,
     resolve_flow_provider,
@@ -181,6 +182,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(create_events_router(settings.events.keepalive_interval))
     app.include_router(create_pipelines_router())
     app.include_router(create_flock_flows_router())
+    app.include_router(create_flock_config_router())
     from tyr.adapters.inbound.auth import extract_principal as _extract_principal
 
     app.include_router(create_pats_router(_extract_principal))

--- a/tests/test_tyr/test_flock_config_api.py
+++ b/tests/test_tyr/test_flock_config_api.py
@@ -1,0 +1,126 @@
+"""Tests for flock configuration REST API endpoints."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tyr.api.flock_config import create_flock_config_router
+from tyr.config import AuthConfig, FlockConfig, PersonaOverride, Settings
+
+
+def _make_app(flock: FlockConfig | None = None) -> FastAPI:
+    """Build a minimal FastAPI app with the flock config router."""
+    settings = Settings(auth=AuthConfig(allow_anonymous_dev=True, default_user_id="dev-user"))
+    if flock is not None:
+        settings.dispatch.flock = flock
+
+    app = FastAPI()
+    app.state.settings = settings
+    app.include_router(create_flock_config_router())
+    return app
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    return TestClient(_make_app())
+
+
+@pytest.fixture()
+def client_enabled() -> TestClient:
+    flock = FlockConfig(
+        enabled=True,
+        default_personas=[PersonaOverride(name="coordinator"), PersonaOverride(name="reviewer")],
+        llm_config={"model": "claude-sonnet-4-6"},
+        sleipnir_publish_urls=["http://sleipnir:4222"],
+    )
+    return TestClient(_make_app(flock=flock))
+
+
+class TestGetFlockConfig:
+    def test_returns_disabled_by_default(self, client: TestClient) -> None:
+        resp = client.get("/api/v1/tyr/flock/config")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["flock_enabled"] is False
+
+    def test_returns_enabled_when_configured(self, client_enabled: TestClient) -> None:
+        resp = client_enabled.get("/api/v1/tyr/flock/config")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["flock_enabled"] is True
+
+    def test_returns_personas(self, client_enabled: TestClient) -> None:
+        resp = client_enabled.get("/api/v1/tyr/flock/config")
+        data = resp.json()
+        names = [p["name"] for p in data["flock_default_personas"]]
+        assert "coordinator" in names
+        assert "reviewer" in names
+
+    def test_returns_llm_config(self, client_enabled: TestClient) -> None:
+        resp = client_enabled.get("/api/v1/tyr/flock/config")
+        data = resp.json()
+        assert data["flock_llm_config"]["model"] == "claude-sonnet-4-6"
+
+    def test_returns_sleipnir_urls(self, client_enabled: TestClient) -> None:
+        resp = client_enabled.get("/api/v1/tyr/flock/config")
+        data = resp.json()
+        assert "http://sleipnir:4222" in data["flock_sleipnir_publish_urls"]
+
+
+class TestPatchFlockConfig:
+    def test_toggle_flock_enabled(self, client: TestClient) -> None:
+        resp = client.patch("/api/v1/tyr/flock/config", json={"flock_enabled": True})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["flock_enabled"] is True
+
+    def test_toggle_flock_disabled(self, client_enabled: TestClient) -> None:
+        resp = client_enabled.patch("/api/v1/tyr/flock/config", json={"flock_enabled": False})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["flock_enabled"] is False
+
+    def test_update_personas(self, client: TestClient) -> None:
+        resp = client.patch(
+            "/api/v1/tyr/flock/config",
+            json={"flock_default_personas": ["coordinator", "security-auditor"]},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        names = [p["name"] for p in data["flock_default_personas"]]
+        assert names == ["coordinator", "security-auditor"]
+
+    def test_update_llm_config(self, client: TestClient) -> None:
+        resp = client.patch(
+            "/api/v1/tyr/flock/config",
+            json={"flock_llm_config": {"model": "Qwen/Qwen2.5-Coder-32B", "provider": "openai"}},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["flock_llm_config"]["model"] == "Qwen/Qwen2.5-Coder-32B"
+
+    def test_update_sleipnir_urls(self, client: TestClient) -> None:
+        resp = client.patch(
+            "/api/v1/tyr/flock/config",
+            json={"flock_sleipnir_publish_urls": ["http://bus1:4222", "http://bus2:4222"]},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["flock_sleipnir_publish_urls"] == ["http://bus1:4222", "http://bus2:4222"]
+
+    def test_patch_is_idempotent_for_unchanged_fields(self, client_enabled: TestClient) -> None:
+        resp = client_enabled.patch(
+            "/api/v1/tyr/flock/config",
+            json={"flock_enabled": True},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["flock_enabled"] is True
+
+    def test_empty_patch_returns_current(self, client_enabled: TestClient) -> None:
+        resp = client_enabled.patch("/api/v1/tyr/flock/config", json={})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "flock_enabled" in data

--- a/web/src/modules/shared/components/Toggle/Toggle.module.css
+++ b/web/src/modules/shared/components/Toggle/Toggle.module.css
@@ -1,0 +1,42 @@
+.toggle {
+  position: relative;
+  width: 2.75rem;
+  height: 1.5rem;
+  border-radius: var(--radius-full);
+  border: none;
+  background-color: var(--color-bg-elevated);
+  cursor: pointer;
+  padding: 0;
+  flex-shrink: 0;
+  transition: background-color 0.15s ease;
+}
+
+.toggle:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Default accent: brand */
+.toggle[aria-checked='true'] {
+  background-color: var(--color-brand);
+}
+
+/* Purple accent variant */
+.toggle[data-accent='purple'][aria-checked='true'] {
+  background-color: var(--color-accent-purple);
+}
+
+.toggleThumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: var(--radius-full);
+  background-color: var(--color-text-primary);
+  transition: transform 0.15s ease;
+}
+
+.toggle[aria-checked='true'] .toggleThumb {
+  transform: translateX(1.25rem);
+}

--- a/web/src/modules/shared/components/Toggle/Toggle.test.tsx
+++ b/web/src/modules/shared/components/Toggle/Toggle.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Toggle } from './Toggle';
+
+describe('Toggle', () => {
+  it('renders with aria-checked false when unchecked', () => {
+    render(<Toggle checked={false} onChange={vi.fn()} label="Test toggle" />);
+    expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('renders with aria-checked true when checked', () => {
+    render(<Toggle checked={true} onChange={vi.fn()} label="Test toggle" />);
+    expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('calls onChange with negated value on click', () => {
+    const onChange = vi.fn();
+    render(<Toggle checked={false} onChange={onChange} label="Test toggle" />);
+    fireEvent.click(screen.getByRole('switch'));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it('is findable by label', () => {
+    render(<Toggle checked={false} onChange={vi.fn()} label="My feature" />);
+    expect(screen.getByRole('switch', { name: 'My feature' })).toBeInTheDocument();
+  });
+
+  it('sets data-accent to brand by default', () => {
+    render(<Toggle checked={false} onChange={vi.fn()} label="Test toggle" />);
+    expect(screen.getByRole('switch')).toHaveAttribute('data-accent', 'brand');
+  });
+
+  it('sets data-accent to purple when specified', () => {
+    render(<Toggle checked={false} onChange={vi.fn()} label="Test toggle" accent="purple" />);
+    expect(screen.getByRole('switch')).toHaveAttribute('data-accent', 'purple');
+  });
+
+  it('is disabled when disabled prop is true', () => {
+    render(<Toggle checked={false} onChange={vi.fn()} label="Test toggle" disabled />);
+    expect(screen.getByRole('switch')).toBeDisabled();
+  });
+});

--- a/web/src/modules/shared/components/Toggle/Toggle.tsx
+++ b/web/src/modules/shared/components/Toggle/Toggle.tsx
@@ -1,0 +1,26 @@
+import styles from './Toggle.module.css';
+
+export interface ToggleProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  label: string;
+  disabled?: boolean;
+  accent?: 'brand' | 'purple';
+}
+
+export function Toggle({ checked, onChange, label, disabled, accent = 'brand' }: ToggleProps) {
+  return (
+    <button
+      type="button"
+      className={styles.toggle}
+      role="switch"
+      aria-label={label}
+      aria-checked={checked}
+      data-accent={accent}
+      disabled={disabled}
+      onClick={() => onChange(!checked)}
+    >
+      <span className={styles.toggleThumb} />
+    </button>
+  );
+}

--- a/web/src/modules/shared/components/Toggle/index.ts
+++ b/web/src/modules/shared/components/Toggle/index.ts
@@ -1,0 +1,2 @@
+export { Toggle } from './Toggle';
+export type { ToggleProps } from './Toggle';

--- a/web/src/modules/shared/index.ts
+++ b/web/src/modules/shared/index.ts
@@ -29,6 +29,9 @@ export type { CollapsibleSectionProps, AccentColor } from './components/Collapsi
 export { LoadingIndicator } from './components/LoadingIndicator';
 export type { LoadingIndicatorProps } from './components/LoadingIndicator';
 
+export { Toggle } from './components/Toggle';
+export type { ToggleProps } from './components/Toggle';
+
 export { AppShell } from './components/AppShell';
 export type { AppShellProps } from './components/AppShell';
 export { Sidebar } from './components/AppShell';

--- a/web/src/modules/tyr/components/FlockBadge/FlockBadge.module.css
+++ b/web/src/modules/tyr/components/FlockBadge/FlockBadge.module.css
@@ -1,0 +1,15 @@
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-full);
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  font-weight: 500;
+  white-space: nowrap;
+  background-color: color-mix(in srgb, var(--color-accent-purple) 20%, transparent);
+  color: var(--color-accent-purple);
+  border: 1px solid color-mix(in srgb, var(--color-accent-purple) 30%, transparent);
+  flex-shrink: 0;
+}

--- a/web/src/modules/tyr/components/FlockBadge/FlockBadge.test.tsx
+++ b/web/src/modules/tyr/components/FlockBadge/FlockBadge.test.tsx
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { FlockBadge } from './FlockBadge';
+
+describe('FlockBadge', () => {
+  it('renders flock label without count', () => {
+    render(<FlockBadge />);
+    expect(screen.getByText('⬡ flock')).toBeInTheDocument();
+  });
+
+  it('renders participant count when provided', () => {
+    render(<FlockBadge participantCount={3} />);
+    expect(screen.getByText('⬡ flock ×3')).toBeInTheDocument();
+  });
+
+  it('accepts custom className', () => {
+    const { container } = render(<FlockBadge className="extra" />);
+    expect(container.firstChild).toHaveClass('extra');
+  });
+});

--- a/web/src/modules/tyr/components/FlockBadge/FlockBadge.tsx
+++ b/web/src/modules/tyr/components/FlockBadge/FlockBadge.tsx
@@ -1,0 +1,15 @@
+import { cn } from '@/modules/shared/utils/classnames';
+import styles from './FlockBadge.module.css';
+
+interface FlockBadgeProps {
+  participantCount?: number;
+  className?: string;
+}
+
+export function FlockBadge({ participantCount, className }: FlockBadgeProps) {
+  return (
+    <span className={cn(styles.badge, className)}>
+      ⬡ flock{participantCount != null ? ` ×${participantCount}` : ''}
+    </span>
+  );
+}

--- a/web/src/modules/tyr/components/FlockBadge/index.ts
+++ b/web/src/modules/tyr/components/FlockBadge/index.ts
@@ -1,0 +1,1 @@
+export { FlockBadge } from './FlockBadge';

--- a/web/src/modules/tyr/components/FlockToggle/FlockToggle.module.css
+++ b/web/src/modules/tyr/components/FlockToggle/FlockToggle.module.css
@@ -21,38 +21,6 @@
   color: var(--color-accent-purple);
 }
 
-.toggle {
-  position: relative;
-  width: 2.75rem;
-  height: 1.5rem;
-  border-radius: var(--radius-full);
-  border: none;
-  background-color: var(--color-bg-elevated);
-  cursor: pointer;
-  padding: 0;
-  flex-shrink: 0;
-  transition: background-color 0.15s ease;
-}
-
-.toggle[aria-checked='true'] {
-  background-color: var(--color-accent-purple);
-}
-
-.toggleThumb {
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 1.25rem;
-  height: 1.25rem;
-  border-radius: var(--radius-full);
-  background-color: var(--color-text-primary);
-  transition: transform 0.15s ease;
-}
-
-.toggle[aria-checked='true'] .toggleThumb {
-  transform: translateX(1.25rem);
-}
-
 .personas {
   display: flex;
   flex-direction: column;

--- a/web/src/modules/tyr/components/FlockToggle/FlockToggle.module.css
+++ b/web/src/modules/tyr/components/FlockToggle/FlockToggle.module.css
@@ -1,0 +1,92 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  background-color: color-mix(in srgb, var(--color-accent-purple) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-accent-purple) 20%, transparent);
+  border-radius: var(--radius-sm);
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.label {
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--color-accent-purple);
+}
+
+.toggle {
+  position: relative;
+  width: 2.75rem;
+  height: 1.5rem;
+  border-radius: var(--radius-full);
+  border: none;
+  background-color: var(--color-bg-elevated);
+  cursor: pointer;
+  padding: 0;
+  flex-shrink: 0;
+  transition: background-color 0.15s ease;
+}
+
+.toggle[aria-checked='true'] {
+  background-color: var(--color-accent-purple);
+}
+
+.toggleThumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: var(--radius-full);
+  background-color: var(--color-text-primary);
+  transition: transform 0.15s ease;
+}
+
+.toggle[aria-checked='true'] .toggleThumb {
+  transform: translateX(1.25rem);
+}
+
+.personas {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.personasLabel {
+  font-size: var(--text-xs);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-secondary);
+}
+
+.personaList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+}
+
+.personaChip {
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-text-secondary);
+  background-color: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  cursor: pointer;
+  transition: all 0.1s ease;
+}
+
+.personaChip[aria-pressed='true'] {
+  color: var(--color-accent-purple);
+  background-color: color-mix(in srgb, var(--color-accent-purple) 15%, transparent);
+  border-color: color-mix(in srgb, var(--color-accent-purple) 30%, transparent);
+}

--- a/web/src/modules/tyr/components/FlockToggle/FlockToggle.test.tsx
+++ b/web/src/modules/tyr/components/FlockToggle/FlockToggle.test.tsx
@@ -2,11 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { FlockToggle } from './FlockToggle';
 
-const personas = [
-  { name: 'coordinator' },
-  { name: 'reviewer' },
-  { name: 'security-auditor' },
-];
+const personas = [{ name: 'coordinator' }, { name: 'reviewer' }, { name: 'security-auditor' }];
 
 describe('FlockToggle', () => {
   it('renders toggle switch', () => {

--- a/web/src/modules/tyr/components/FlockToggle/FlockToggle.test.tsx
+++ b/web/src/modules/tyr/components/FlockToggle/FlockToggle.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FlockToggle } from './FlockToggle';
+
+const personas = [
+  { name: 'coordinator' },
+  { name: 'reviewer' },
+  { name: 'security-auditor' },
+];
+
+describe('FlockToggle', () => {
+  it('renders toggle switch', () => {
+    render(
+      <FlockToggle
+        enabled={false}
+        onToggle={vi.fn()}
+        personas={personas}
+        selectedPersonas={[]}
+        onPersonasChange={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('switch', { name: /dispatch as flock/i })).toBeInTheDocument();
+  });
+
+  it('shows aria-checked=false when disabled', () => {
+    render(
+      <FlockToggle
+        enabled={false}
+        onToggle={vi.fn()}
+        personas={personas}
+        selectedPersonas={[]}
+        onPersonasChange={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('shows aria-checked=true when enabled', () => {
+    render(
+      <FlockToggle
+        enabled={true}
+        onToggle={vi.fn()}
+        personas={personas}
+        selectedPersonas={[]}
+        onPersonasChange={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('calls onToggle with negated value on click', () => {
+    const onToggle = vi.fn();
+    render(
+      <FlockToggle
+        enabled={false}
+        onToggle={onToggle}
+        personas={personas}
+        selectedPersonas={[]}
+        onPersonasChange={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole('switch'));
+    expect(onToggle).toHaveBeenCalledWith(true);
+  });
+
+  it('hides persona list when disabled', () => {
+    render(
+      <FlockToggle
+        enabled={false}
+        onToggle={vi.fn()}
+        personas={personas}
+        selectedPersonas={[]}
+        onPersonasChange={vi.fn()}
+      />
+    );
+    expect(screen.queryByText('coordinator')).not.toBeInTheDocument();
+  });
+
+  it('shows persona chips when enabled', () => {
+    render(
+      <FlockToggle
+        enabled={true}
+        onToggle={vi.fn()}
+        personas={personas}
+        selectedPersonas={[]}
+        onPersonasChange={vi.fn()}
+      />
+    );
+    expect(screen.getByText('coordinator')).toBeInTheDocument();
+    expect(screen.getByText('reviewer')).toBeInTheDocument();
+  });
+
+  it('marks selected personas as pressed', () => {
+    render(
+      <FlockToggle
+        enabled={true}
+        onToggle={vi.fn()}
+        personas={personas}
+        selectedPersonas={['reviewer']}
+        onPersonasChange={vi.fn()}
+      />
+    );
+    expect(screen.getByText('reviewer')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByText('coordinator')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('adds persona to selection on click', () => {
+    const onPersonasChange = vi.fn();
+    render(
+      <FlockToggle
+        enabled={true}
+        onToggle={vi.fn()}
+        personas={personas}
+        selectedPersonas={[]}
+        onPersonasChange={onPersonasChange}
+      />
+    );
+    fireEvent.click(screen.getByText('coordinator'));
+    expect(onPersonasChange).toHaveBeenCalledWith(['coordinator']);
+  });
+
+  it('removes persona from selection on second click', () => {
+    const onPersonasChange = vi.fn();
+    render(
+      <FlockToggle
+        enabled={true}
+        onToggle={vi.fn()}
+        personas={personas}
+        selectedPersonas={['coordinator']}
+        onPersonasChange={onPersonasChange}
+      />
+    );
+    fireEvent.click(screen.getByText('coordinator'));
+    expect(onPersonasChange).toHaveBeenCalledWith([]);
+  });
+});

--- a/web/src/modules/tyr/components/FlockToggle/FlockToggle.tsx
+++ b/web/src/modules/tyr/components/FlockToggle/FlockToggle.tsx
@@ -1,3 +1,4 @@
+import { Toggle } from '@/modules/shared';
 import styles from './FlockToggle.module.css';
 
 interface PersonaOption {
@@ -31,16 +32,7 @@ export function FlockToggle({
     <div className={styles.container}>
       <div className={styles.row}>
         <span className={styles.label}>Dispatch as flock</span>
-        <button
-          type="button"
-          className={styles.toggle}
-          role="switch"
-          aria-label="Dispatch as flock"
-          aria-checked={enabled}
-          onClick={() => onToggle(!enabled)}
-        >
-          <span className={styles.toggleThumb} />
-        </button>
+        <Toggle checked={enabled} onChange={onToggle} label="Dispatch as flock" accent="purple" />
       </div>
       {enabled && personas.length > 0 && (
         <div className={styles.personas}>

--- a/web/src/modules/tyr/components/FlockToggle/FlockToggle.tsx
+++ b/web/src/modules/tyr/components/FlockToggle/FlockToggle.tsx
@@ -1,0 +1,65 @@
+import styles from './FlockToggle.module.css';
+
+interface PersonaOption {
+  name: string;
+}
+
+interface FlockToggleProps {
+  enabled: boolean;
+  onToggle: (enabled: boolean) => void;
+  personas: PersonaOption[];
+  selectedPersonas: string[];
+  onPersonasChange: (personas: string[]) => void;
+}
+
+export function FlockToggle({
+  enabled,
+  onToggle,
+  personas,
+  selectedPersonas,
+  onPersonasChange,
+}: FlockToggleProps) {
+  const togglePersona = (name: string) => {
+    if (selectedPersonas.includes(name)) {
+      onPersonasChange(selectedPersonas.filter(p => p !== name));
+      return;
+    }
+    onPersonasChange([...selectedPersonas, name]);
+  };
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.row}>
+        <span className={styles.label}>Dispatch as flock</span>
+        <button
+          type="button"
+          className={styles.toggle}
+          role="switch"
+          aria-label="Dispatch as flock"
+          aria-checked={enabled}
+          onClick={() => onToggle(!enabled)}
+        >
+          <span className={styles.toggleThumb} />
+        </button>
+      </div>
+      {enabled && personas.length > 0 && (
+        <div className={styles.personas}>
+          <span className={styles.personasLabel}>Personas</span>
+          <div className={styles.personaList}>
+            {personas.map(p => (
+              <button
+                key={p.name}
+                type="button"
+                className={styles.personaChip}
+                aria-pressed={selectedPersonas.includes(p.name)}
+                onClick={() => togglePersona(p.name)}
+              >
+                {p.name}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/modules/tyr/components/FlockToggle/index.ts
+++ b/web/src/modules/tyr/components/FlockToggle/index.ts
@@ -1,0 +1,1 @@
+export { FlockToggle } from './FlockToggle';

--- a/web/src/modules/tyr/hooks/useDispatchQueue.ts
+++ b/web/src/modules/tyr/hooks/useDispatchQueue.ts
@@ -1,5 +1,8 @@
 import { useState, useEffect, useCallback } from 'react';
 import { createApiClient } from '@/modules/shared/api/client';
+import type { PersonaConfig } from './useFlockConfig';
+
+export type { PersonaConfig };
 
 const api = createApiClient('/api/v1/tyr/dispatch');
 
@@ -24,11 +27,6 @@ export interface QueueItem {
 export interface ModelOption {
   id: string;
   name: string;
-}
-
-export interface PersonaConfig {
-  name: string;
-  llm: Record<string, unknown>;
 }
 
 export interface DispatchDefaults {
@@ -75,7 +73,9 @@ interface UseDispatchQueueResult {
     items: DispatchItem[],
     model: string,
     systemPrompt: string,
-    connectionId?: string
+    connectionId?: string,
+    workloadType?: string,
+    workloadConfig?: Record<string, unknown>
   ) => Promise<DispatchResult[]>;
 }
 
@@ -123,7 +123,9 @@ export function useDispatchQueue(): UseDispatchQueueResult {
       items: DispatchItem[],
       model: string,
       systemPrompt: string,
-      connectionId?: string
+      connectionId?: string,
+      workloadType?: string,
+      workloadConfig?: Record<string, unknown>
     ): Promise<DispatchResult[]> => {
       setDispatching(true);
       try {
@@ -132,6 +134,8 @@ export function useDispatchQueue(): UseDispatchQueueResult {
           model,
           system_prompt: systemPrompt,
           ...(connectionId ? { connection_id: connectionId } : {}),
+          ...(workloadType ? { workload_type: workloadType } : {}),
+          ...(workloadConfig ? { workload_config: workloadConfig } : {}),
         });
         // Remove dispatched items from queue locally
         const dispatched = new Set(

--- a/web/src/modules/tyr/hooks/useDispatchQueue.ts
+++ b/web/src/modules/tyr/hooks/useDispatchQueue.ts
@@ -26,10 +26,19 @@ export interface ModelOption {
   name: string;
 }
 
+export interface PersonaConfig {
+  name: string;
+  llm: Record<string, unknown>;
+}
+
 export interface DispatchDefaults {
   default_system_prompt: string;
   default_model: string;
   models: ModelOption[];
+  flock_enabled: boolean;
+  flock_default_personas: PersonaConfig[];
+  flock_llm_config: Record<string, unknown>;
+  flock_sleipnir_publish_urls: string[];
 }
 
 export interface ClusterInfo {
@@ -76,6 +85,10 @@ export function useDispatchQueue(): UseDispatchQueueResult {
     default_system_prompt: '',
     default_model: 'claude-sonnet-4-6',
     models: [],
+    flock_enabled: false,
+    flock_default_personas: [],
+    flock_llm_config: {},
+    flock_sleipnir_publish_urls: [],
   });
   const [clusters, setClusters] = useState<ClusterInfo[]>([]);
   const [loading, setLoading] = useState(true);

--- a/web/src/modules/tyr/hooks/useFlockConfig.test.ts
+++ b/web/src/modules/tyr/hooks/useFlockConfig.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useFlockConfig } from './useFlockConfig';
+
+const mockPatch = vi.hoisted(() => vi.fn());
+
+vi.mock('@/modules/shared/api/client', () => ({
+  createApiClient: () => ({
+    patch: mockPatch,
+  }),
+}));
+
+const successResponse = {
+  flock_enabled: true,
+  flock_default_personas: [],
+  flock_llm_config: {},
+  flock_sleipnir_publish_urls: [],
+};
+
+describe('useFlockConfig', () => {
+  beforeEach(() => {
+    mockPatch.mockResolvedValue(successResponse);
+  });
+
+  it('starts with no error and not updating', () => {
+    const { result } = renderHook(() => useFlockConfig());
+    expect(result.current.updating).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('setFlockEnabled resolves without error', async () => {
+    const { result } = renderHook(() => useFlockConfig());
+    await act(async () => {
+      await result.current.setFlockEnabled(true);
+    });
+    expect(result.current.error).toBeNull();
+    expect(result.current.updating).toBe(false);
+  });
+
+  it('setDefaultPersonas resolves without error', async () => {
+    const { result } = renderHook(() => useFlockConfig());
+    await act(async () => {
+      await result.current.setDefaultPersonas(['coordinator', 'reviewer']);
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it('setLlmConfig resolves without error', async () => {
+    const { result } = renderHook(() => useFlockConfig());
+    await act(async () => {
+      await result.current.setLlmConfig({ model: 'claude-sonnet-4-6' });
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it('setSleipnirUrls resolves without error', async () => {
+    const { result } = renderHook(() => useFlockConfig());
+    await act(async () => {
+      await result.current.setSleipnirUrls(['http://sleipnir:4222']);
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it('captures error on API failure', async () => {
+    mockPatch.mockRejectedValueOnce(new Error('Network error'));
+
+    const { result } = renderHook(() => useFlockConfig());
+    await act(async () => {
+      await result.current.setFlockEnabled(true);
+    });
+    expect(result.current.error).toBe('Network error');
+    expect(result.current.updating).toBe(false);
+  });
+});

--- a/web/src/modules/tyr/hooks/useFlockConfig.test.ts
+++ b/web/src/modules/tyr/hooks/useFlockConfig.test.ts
@@ -2,10 +2,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useFlockConfig } from './useFlockConfig';
 
+const mockGet = vi.hoisted(() => vi.fn());
 const mockPatch = vi.hoisted(() => vi.fn());
 
 vi.mock('@/modules/shared/api/client', () => ({
   createApiClient: () => ({
+    get: mockGet,
     patch: mockPatch,
   }),
 }));
@@ -19,13 +21,26 @@ const successResponse = {
 
 describe('useFlockConfig', () => {
   beforeEach(() => {
+    mockGet.mockResolvedValue(successResponse);
     mockPatch.mockResolvedValue(successResponse);
   });
 
-  it('starts with no error and not updating', () => {
+  it('starts with loading true and no error', () => {
+    const { result } = renderHook(() => useFlockConfig());
+    expect(result.current.loading).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('loads config on mount', async () => {
+    const { result } = renderHook(() => useFlockConfig());
+    await act(async () => {});
+    expect(result.current.loading).toBe(false);
+    expect(result.current.config).toEqual(successResponse);
+  });
+
+  it('starts with not updating', () => {
     const { result } = renderHook(() => useFlockConfig());
     expect(result.current.updating).toBe(false);
-    expect(result.current.error).toBeNull();
   });
 
   it('setFlockEnabled resolves without error', async () => {

--- a/web/src/modules/tyr/hooks/useFlockConfig.ts
+++ b/web/src/modules/tyr/hooks/useFlockConfig.ts
@@ -1,11 +1,16 @@
-import { useState, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { createApiClient } from '@/modules/shared/api/client';
 
 const api = createApiClient('/api/v1/tyr/flock');
 
+export interface PersonaConfig {
+  name: string;
+  llm: Record<string, unknown>;
+}
+
 export interface FlockConfig {
   flock_enabled: boolean;
-  flock_default_personas: Array<{ name: string; llm: Record<string, unknown> }>;
+  flock_default_personas: PersonaConfig[];
   flock_llm_config: Record<string, unknown>;
   flock_sleipnir_publish_urls: string[];
 }
@@ -18,6 +23,8 @@ interface PatchFlockConfig {
 }
 
 interface UseFlockConfigResult {
+  config: FlockConfig | null;
+  loading: boolean;
   updating: boolean;
   error: string | null;
   setFlockEnabled: (enabled: boolean) => Promise<void>;
@@ -27,14 +34,27 @@ interface UseFlockConfigResult {
 }
 
 export function useFlockConfig(): UseFlockConfigResult {
+  const [config, setConfig] = useState<FlockConfig | null>(null);
+  const [loading, setLoading] = useState(true);
   const [updating, setUpdating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    api
+      .get<FlockConfig>('/config')
+      .then(setConfig)
+      .catch(() => {
+        /* flock config is optional — silently ignore fetch failures */
+      })
+      .finally(() => setLoading(false));
+  }, []);
 
   const patch = useCallback(async (updates: PatchFlockConfig): Promise<void> => {
     setUpdating(true);
     setError(null);
     try {
-      await api.patch<FlockConfig>('/config', updates);
+      const updated = await api.patch<FlockConfig>('/config', updates);
+      setConfig(updated);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -62,5 +82,14 @@ export function useFlockConfig(): UseFlockConfigResult {
     [patch]
   );
 
-  return { updating, error, setFlockEnabled, setDefaultPersonas, setLlmConfig, setSleipnirUrls };
+  return {
+    config,
+    loading,
+    updating,
+    error,
+    setFlockEnabled,
+    setDefaultPersonas,
+    setLlmConfig,
+    setSleipnirUrls,
+  };
 }

--- a/web/src/modules/tyr/hooks/useFlockConfig.ts
+++ b/web/src/modules/tyr/hooks/useFlockConfig.ts
@@ -1,0 +1,66 @@
+import { useState, useCallback } from 'react';
+import { createApiClient } from '@/modules/shared/api/client';
+
+const api = createApiClient('/api/v1/tyr/flock');
+
+export interface FlockConfig {
+  flock_enabled: boolean;
+  flock_default_personas: Array<{ name: string; llm: Record<string, unknown> }>;
+  flock_llm_config: Record<string, unknown>;
+  flock_sleipnir_publish_urls: string[];
+}
+
+interface PatchFlockConfig {
+  flock_enabled?: boolean;
+  flock_default_personas?: string[];
+  flock_llm_config?: Record<string, unknown>;
+  flock_sleipnir_publish_urls?: string[];
+}
+
+interface UseFlockConfigResult {
+  updating: boolean;
+  error: string | null;
+  setFlockEnabled: (enabled: boolean) => Promise<void>;
+  setDefaultPersonas: (personas: string[]) => Promise<void>;
+  setLlmConfig: (config: Record<string, unknown>) => Promise<void>;
+  setSleipnirUrls: (urls: string[]) => Promise<void>;
+}
+
+export function useFlockConfig(): UseFlockConfigResult {
+  const [updating, setUpdating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const patch = useCallback(async (updates: PatchFlockConfig): Promise<void> => {
+    setUpdating(true);
+    setError(null);
+    try {
+      await api.patch<FlockConfig>('/config', updates);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setUpdating(false);
+    }
+  }, []);
+
+  const setFlockEnabled = useCallback(
+    (enabled: boolean) => patch({ flock_enabled: enabled }),
+    [patch]
+  );
+
+  const setDefaultPersonas = useCallback(
+    (personas: string[]) => patch({ flock_default_personas: personas }),
+    [patch]
+  );
+
+  const setLlmConfig = useCallback(
+    (config: Record<string, unknown>) => patch({ flock_llm_config: config }),
+    [patch]
+  );
+
+  const setSleipnirUrls = useCallback(
+    (urls: string[]) => patch({ flock_sleipnir_publish_urls: urls }),
+    [patch]
+  );
+
+  return { updating, error, setFlockEnabled, setDefaultPersonas, setLlmConfig, setSleipnirUrls };
+}

--- a/web/src/modules/tyr/hooks/useTyrSessions.ts
+++ b/web/src/modules/tyr/hooks/useTyrSessions.ts
@@ -22,6 +22,8 @@ export interface VolundrSession {
   tracker_issue_id: string | null;
   issue_tracker_url: string | null;
   error: string | null;
+  workload_type: string | null;
+  mesh_participants: string[] | null;
 }
 
 export interface TimelineEvent {

--- a/web/src/modules/tyr/pages/DashboardView/DashboardView.module.css
+++ b/web/src/modules/tyr/pages/DashboardView/DashboardView.module.css
@@ -71,3 +71,29 @@
   color: var(--color-brand);
   font-weight: 600;
 }
+
+.flockStats {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-4) var(--space-3);
+}
+
+.flockStat {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.flockStatLabel {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.flockStatValue {
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-text-secondary);
+}

--- a/web/src/modules/tyr/pages/DashboardView/DashboardView.module.css
+++ b/web/src/modules/tyr/pages/DashboardView/DashboardView.module.css
@@ -82,7 +82,7 @@
 .flockStat {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--space-1);
 }
 
 .flockStatLabel {

--- a/web/src/modules/tyr/pages/DashboardView/DashboardView.tsx
+++ b/web/src/modules/tyr/pages/DashboardView/DashboardView.tsx
@@ -7,6 +7,7 @@ import {
   useHealthDetailed,
   useSagas,
 } from '../../hooks';
+import { useDispatchQueue } from '../../hooks/useDispatchQueue';
 import type { SseEvent } from '../../hooks';
 import type { RaidStatus } from '../../models';
 import { DashboardTopBar } from '../../components/DashboardTopBar';
@@ -16,6 +17,7 @@ import { RaidsTable } from '../../components/RaidsTable';
 import { SagasSidebar } from '../../components/SagasSidebar';
 import { SystemsHealth } from '../../components/SystemsHealth';
 import { EventLog } from '../../components/EventLog';
+import { FlockBadge } from '../../components/FlockBadge';
 import styles from './DashboardView.module.css';
 
 export function DashboardView() {
@@ -25,6 +27,7 @@ export function DashboardView() {
   const [showCompleted, setShowCompleted] = useState(false);
 
   const { raids, loading: raidsLoading, refresh: refreshRaids, patchRaid } = useActiveRaids();
+  const { defaults: dispatchDefaults } = useDispatchQueue();
 
   const summary = useMemo(() => {
     const counts: Record<string, number> = {};
@@ -141,6 +144,31 @@ export function DashboardView() {
             </div>
             <SystemsHealth health={health} loading={healthLoading} />
           </div>
+          {dispatchDefaults.flock_enabled && (
+            <div className={styles.panel}>
+              <div className={styles.panelHeader}>
+                <span className={styles.panelTitle}>Flock</span>
+                <FlockBadge />
+              </div>
+              <div className={styles.flockStats}>
+                <span className={styles.flockStat}>
+                  <span className={styles.flockStatLabel}>Personas</span>
+                  <span className={styles.flockStatValue}>
+                    {dispatchDefaults.flock_default_personas.map(p => p.name).join(', ') || '—'}
+                  </span>
+                </span>
+                {dispatchDefaults.flock_llm_config &&
+                  Object.keys(dispatchDefaults.flock_llm_config).length > 0 && (
+                    <span className={styles.flockStat}>
+                      <span className={styles.flockStatLabel}>Model</span>
+                      <span className={styles.flockStatValue}>
+                        {String(dispatchDefaults.flock_llm_config.model ?? '—')}
+                      </span>
+                    </span>
+                  )}
+              </div>
+            </div>
+          )}
           <div className={styles.eventPanel}>
             <div className={styles.panelHeader}>
               <span className={styles.panelTitle}>Event Log</span>

--- a/web/src/modules/tyr/pages/DashboardView/DashboardView.tsx
+++ b/web/src/modules/tyr/pages/DashboardView/DashboardView.tsx
@@ -7,7 +7,7 @@ import {
   useHealthDetailed,
   useSagas,
 } from '../../hooks';
-import { useDispatchQueue } from '../../hooks/useDispatchQueue';
+import { useFlockConfig } from '../../hooks/useFlockConfig';
 import type { SseEvent } from '../../hooks';
 import type { RaidStatus } from '../../models';
 import { DashboardTopBar } from '../../components/DashboardTopBar';
@@ -27,7 +27,7 @@ export function DashboardView() {
   const [showCompleted, setShowCompleted] = useState(false);
 
   const { raids, loading: raidsLoading, refresh: refreshRaids, patchRaid } = useActiveRaids();
-  const { defaults: dispatchDefaults } = useDispatchQueue();
+  const { config: flockConfig } = useFlockConfig();
 
   const summary = useMemo(() => {
     const counts: Record<string, number> = {};
@@ -144,7 +144,7 @@ export function DashboardView() {
             </div>
             <SystemsHealth health={health} loading={healthLoading} />
           </div>
-          {dispatchDefaults.flock_enabled && (
+          {flockConfig?.flock_enabled && (
             <div className={styles.panel}>
               <div className={styles.panelHeader}>
                 <span className={styles.panelTitle}>Flock</span>
@@ -154,15 +154,15 @@ export function DashboardView() {
                 <span className={styles.flockStat}>
                   <span className={styles.flockStatLabel}>Personas</span>
                   <span className={styles.flockStatValue}>
-                    {dispatchDefaults.flock_default_personas.map(p => p.name).join(', ') || '—'}
+                    {flockConfig.flock_default_personas.map(p => p.name).join(', ') || '—'}
                   </span>
                 </span>
-                {dispatchDefaults.flock_llm_config &&
-                  Object.keys(dispatchDefaults.flock_llm_config).length > 0 && (
+                {flockConfig.flock_llm_config &&
+                  Object.keys(flockConfig.flock_llm_config).length > 0 && (
                     <span className={styles.flockStat}>
                       <span className={styles.flockStatLabel}>Model</span>
                       <span className={styles.flockStatValue}>
-                        {String(dispatchDefaults.flock_llm_config.model ?? '—')}
+                        {String(flockConfig.flock_llm_config.model ?? '—')}
                       </span>
                     </span>
                   )}

--- a/web/src/modules/tyr/pages/DispatcherView/DispatcherView.test.tsx
+++ b/web/src/modules/tyr/pages/DispatcherView/DispatcherView.test.tsx
@@ -275,7 +275,9 @@ describe('DispatcherView', () => {
         expect.any(Array),
         'claude-sonnet-4-6',
         'test prompt',
-        'c2'
+        'c2',
+        undefined,
+        undefined
       );
     });
   });

--- a/web/src/modules/tyr/pages/DispatcherView/DispatcherView.tsx
+++ b/web/src/modules/tyr/pages/DispatcherView/DispatcherView.tsx
@@ -50,11 +50,16 @@ export function DispatcherView() {
       return;
     }
 
+    const workloadType = flockEnabled ? 'ravn_flock' : undefined;
+    const workloadConfig = flockEnabled ? { personas: selectedPersonas } : undefined;
+
     const results = await dispatch(
       items,
       modelOverride ?? defaults.default_model,
       promptOverride ?? defaults.default_system_prompt,
-      selectedCluster || undefined
+      selectedCluster || undefined,
+      workloadType,
+      workloadConfig
     );
     setLastResults(results);
     setSelected(new Set());

--- a/web/src/modules/tyr/pages/DispatcherView/DispatcherView.tsx
+++ b/web/src/modules/tyr/pages/DispatcherView/DispatcherView.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { LoadingIndicator } from '@/modules/shared';
 import { useDispatchQueue } from '../../hooks/useDispatchQueue';
 import type { QueueItem } from '../../hooks/useDispatchQueue';
+import { FlockToggle } from '../../components/FlockToggle';
 import styles from './DispatcherView.module.css';
 
 export function DispatcherView() {
@@ -10,6 +11,8 @@ export function DispatcherView() {
   const [modelOverride, setModelOverride] = useState<string | null>(null);
   const [promptOverride, setPromptOverride] = useState<string | null>(null);
   const [selectedCluster, setSelectedCluster] = useState<string>('');
+  const [flockEnabled, setFlockEnabled] = useState(false);
+  const [selectedPersonas, setSelectedPersonas] = useState<string[]>([]);
   const [lastResults, setLastResults] = useState<
     { issue_id: string; session_name: string; status: string; cluster_name: string }[] | null
   >(null);
@@ -152,6 +155,15 @@ export function DispatcherView() {
             </button>
           </div>
         </div>
+      )}
+      {queue.length > 0 && defaults.flock_enabled && (
+        <FlockToggle
+          enabled={flockEnabled}
+          onToggle={setFlockEnabled}
+          personas={defaults.flock_default_personas}
+          selectedPersonas={selectedPersonas}
+          onPersonasChange={setSelectedPersonas}
+        />
       )}
 
       {Object.entries(bySaga).map(([sagaId, { sagaName, items }]) => (

--- a/web/src/modules/tyr/pages/SessionsView/SessionsView.tsx
+++ b/web/src/modules/tyr/pages/SessionsView/SessionsView.tsx
@@ -1,8 +1,10 @@
 import { useState } from 'react';
 import { LoadingIndicator } from '@/modules/shared';
 import { useTyrSessions } from '../../hooks';
+import { useDispatchQueue } from '../../hooks/useDispatchQueue';
 import type { VolundrSession, TimelineResponse, TimelineEvent } from '../../hooks/useTyrSessions';
 import { BranchTag } from '../../components/BranchTag';
+import { FlockBadge } from '../../components/FlockBadge';
 import styles from './SessionsView.module.css';
 
 function statusColor(status: string): string {
@@ -102,13 +104,18 @@ function SessionRow({
   expanded,
   timeline,
   timelineLoading,
+  flockEnabled,
 }: {
   session: VolundrSession;
   onExpand: () => void;
   expanded: boolean;
   timeline: TimelineResponse | null;
   timelineLoading: boolean;
+  flockEnabled: boolean;
 }) {
+  const isFlock = session.workload_type === 'ravn_flock';
+  const participantCount = session.mesh_participants?.length;
+
   return (
     <div className={styles.sessionCard}>
       <button type="button" className={styles.sessionHeader} onClick={onExpand}>
@@ -121,6 +128,7 @@ function SessionRow({
         {session.tracker_issue_id && (
           <span className={styles.issueTag}>{session.tracker_issue_id}</span>
         )}
+        {flockEnabled && isFlock && <FlockBadge participantCount={participantCount} />}
         <span className={styles.sessionTokens}>{session.tokens_used.toLocaleString()} tokens</span>
         <span className={styles.chevron} data-expanded={expanded}>
           {'\u25B6'}
@@ -168,6 +176,7 @@ function SessionRow({
 
 export function SessionsView() {
   const { sessions, loading, error, getTimeline } = useTyrSessions();
+  const { defaults } = useDispatchQueue();
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [timelines, setTimelines] = useState<Record<string, TimelineResponse | null>>({});
   const [loadingTimelines, setLoadingTimelines] = useState<Set<string>>(new Set());
@@ -216,6 +225,11 @@ export function SessionsView() {
     return (statusOrder[a.status] ?? 9) - (statusOrder[b.status] ?? 9);
   });
 
+  const flockEnabled = defaults.flock_enabled;
+  const flockCount = flockEnabled
+    ? sessions.filter(s => s.workload_type === 'ravn_flock').length
+    : 0;
+
   return (
     <div className={styles.container}>
       <div className={styles.stats}>
@@ -223,6 +237,9 @@ export function SessionsView() {
           {sessions.filter(s => s.status === 'running').length} running
         </span>
         <span className={styles.statItem}>{sessions.length} total</span>
+        {flockEnabled && flockCount > 0 && (
+          <span className={styles.statItem}>{flockCount} flock</span>
+        )}
       </div>
       <div className={styles.list}>
         {sorted.map(session => (
@@ -233,6 +250,7 @@ export function SessionsView() {
             onExpand={() => handleExpand(session.id)}
             timeline={timelines[session.id] ?? null}
             timelineLoading={loadingTimelines.has(session.id)}
+            flockEnabled={flockEnabled}
           />
         ))}
       </div>

--- a/web/src/modules/tyr/pages/SessionsView/SessionsView.tsx
+++ b/web/src/modules/tyr/pages/SessionsView/SessionsView.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { LoadingIndicator } from '@/modules/shared';
 import { useTyrSessions } from '../../hooks';
-import { useDispatchQueue } from '../../hooks/useDispatchQueue';
+import { useFlockConfig } from '../../hooks/useFlockConfig';
 import type { VolundrSession, TimelineResponse, TimelineEvent } from '../../hooks/useTyrSessions';
 import { BranchTag } from '../../components/BranchTag';
 import { FlockBadge } from '../../components/FlockBadge';
@@ -176,7 +176,7 @@ function SessionRow({
 
 export function SessionsView() {
   const { sessions, loading, error, getTimeline } = useTyrSessions();
-  const { defaults } = useDispatchQueue();
+  const { config: flockConfig } = useFlockConfig();
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [timelines, setTimelines] = useState<Record<string, TimelineResponse | null>>({});
   const [loadingTimelines, setLoadingTimelines] = useState<Set<string>>(new Set());
@@ -225,7 +225,7 @@ export function SessionsView() {
     return (statusOrder[a.status] ?? 9) - (statusOrder[b.status] ?? 9);
   });
 
-  const flockEnabled = defaults.flock_enabled;
+  const flockEnabled = flockConfig?.flock_enabled ?? false;
   const flockCount = flockEnabled
     ? sessions.filter(s => s.workload_type === 'ravn_flock').length
     : 0;

--- a/web/src/modules/tyr/pages/Settings/TyrSettings.tsx
+++ b/web/src/modules/tyr/pages/Settings/TyrSettings.tsx
@@ -5,6 +5,7 @@ import { useTyrIntegrations } from '@/modules/tyr/hooks/useTyrIntegrations';
 import { INTEGRATION_TYPES } from '@/modules/tyr/constants';
 import { VolundrConnectionSection } from './sections/VolundrConnectionSection';
 import { DispatcherSettingsSection } from './sections/DispatcherSettingsSection';
+import { FlockSettingsSection } from './sections/FlockSettingsSection';
 import styles from './TyrSettings.module.css';
 
 interface TyrSettingsProps {
@@ -53,6 +54,7 @@ export function TyrSettings({ service }: TyrSettingsProps) {
         onShowFormChange={setShowAddForm}
       />
       <DispatcherSettingsSection />
+      <FlockSettingsSection />
     </div>
   );
 }

--- a/web/src/modules/tyr/pages/Settings/sections/DispatcherSettingsSection/DispatcherSettingsSection.module.css
+++ b/web/src/modules/tyr/pages/Settings/sections/DispatcherSettingsSection/DispatcherSettingsSection.module.css
@@ -51,34 +51,4 @@
   color: var(--color-text-secondary);
 }
 
-.toggle {
-  position: relative;
-  width: 2.75rem;
-  height: 1.5rem;
-  border-radius: var(--radius-full);
-  border: none;
-  background-color: var(--color-bg-elevated);
-  cursor: pointer;
-  padding: 0;
-  flex-shrink: 0;
-  transition: background-color 0.15s ease;
-}
 
-.toggle[aria-checked='true'] {
-  background-color: var(--color-brand);
-}
-
-.toggleThumb {
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 1.25rem;
-  height: 1.25rem;
-  border-radius: var(--radius-full);
-  background-color: var(--color-text-primary);
-  transition: transform 0.15s ease;
-}
-
-.toggle[aria-checked='true'] .toggleThumb {
-  transform: translateX(1.25rem);
-}

--- a/web/src/modules/tyr/pages/Settings/sections/DispatcherSettingsSection/DispatcherSettingsSection.module.css
+++ b/web/src/modules/tyr/pages/Settings/sections/DispatcherSettingsSection/DispatcherSettingsSection.module.css
@@ -50,5 +50,3 @@
   font-size: var(--text-xs);
   color: var(--color-text-secondary);
 }
-
-

--- a/web/src/modules/tyr/pages/Settings/sections/DispatcherSettingsSection/DispatcherSettingsSection.tsx
+++ b/web/src/modules/tyr/pages/Settings/sections/DispatcherSettingsSection/DispatcherSettingsSection.tsx
@@ -41,11 +41,7 @@ export function DispatcherSettingsSection() {
             Automatically dispatch newly unblocked raids after merge
           </span>
         </div>
-        <Toggle
-          checked={state.auto_continue}
-          onChange={handleToggle}
-          label="Auto-continue"
-        />
+        <Toggle checked={state.auto_continue} onChange={handleToggle} label="Auto-continue" />
       </div>
     </section>
   );

--- a/web/src/modules/tyr/pages/Settings/sections/DispatcherSettingsSection/DispatcherSettingsSection.tsx
+++ b/web/src/modules/tyr/pages/Settings/sections/DispatcherSettingsSection/DispatcherSettingsSection.tsx
@@ -1,3 +1,4 @@
+import { Toggle } from '@/modules/shared';
 import { useDispatcher } from '@/modules/tyr/hooks/useDispatcher';
 import styles from './DispatcherSettingsSection.module.css';
 
@@ -26,8 +27,8 @@ export function DispatcherSettingsSection() {
     return null;
   }
 
-  const handleToggle = () => {
-    void setAutoContinue(!state.auto_continue);
+  const handleToggle = (next: boolean) => {
+    void setAutoContinue(next);
   };
 
   return (
@@ -40,15 +41,11 @@ export function DispatcherSettingsSection() {
             Automatically dispatch newly unblocked raids after merge
           </span>
         </div>
-        <button
-          type="button"
-          className={styles.toggle}
-          role="switch"
-          aria-checked={state.auto_continue}
-          onClick={handleToggle}
-        >
-          <span className={styles.toggleThumb} />
-        </button>
+        <Toggle
+          checked={state.auto_continue}
+          onChange={handleToggle}
+          label="Auto-continue"
+        />
       </div>
     </section>
   );

--- a/web/src/modules/tyr/pages/Settings/sections/FlockSettingsSection/FlockSettingsSection.module.css
+++ b/web/src/modules/tyr/pages/Settings/sections/FlockSettingsSection/FlockSettingsSection.module.css
@@ -1,0 +1,195 @@
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.sectionTitle {
+  font-size: var(--text-lg);
+  font-weight: 600;
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+.sectionDescription {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
+.loadingText {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.errorText {
+  font-size: var(--text-sm);
+  color: var(--color-accent-red);
+  margin: 0;
+}
+
+.settingRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding: var(--space-4);
+  background-color: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+}
+
+.settingInfo {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.settingLabel {
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--color-text-primary);
+}
+
+.settingDescription {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+}
+
+.toggle {
+  position: relative;
+  width: 2.75rem;
+  height: 1.5rem;
+  border-radius: var(--radius-full);
+  border: none;
+  background-color: var(--color-bg-elevated);
+  cursor: pointer;
+  padding: 0;
+  flex-shrink: 0;
+  transition: background-color 0.15s ease;
+}
+
+.toggle:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.toggle[aria-checked='true'] {
+  background-color: var(--color-accent-purple);
+}
+
+.toggleThumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: var(--radius-full);
+  background-color: var(--color-text-primary);
+  transition: transform 0.15s ease;
+}
+
+.toggle[aria-checked='true'] .toggleThumb {
+  transform: translateX(1.25rem);
+}
+
+.settingBlock {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-4);
+  background-color: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+}
+
+.blockLabel {
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--color-text-primary);
+}
+
+.blockDescription {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
+.inputRow {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.textInput {
+  flex: 1;
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-sm);
+  font-family: var(--font-sans);
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.textInput:focus {
+  border-color: var(--color-accent-purple);
+}
+
+.presetRow {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.select {
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--text-xs);
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.jsonTextarea,
+.urlsTextarea {
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  outline: none;
+  resize: vertical;
+  transition: border-color 0.15s;
+}
+
+.jsonTextarea:focus,
+.urlsTextarea:focus {
+  border-color: var(--color-accent-purple);
+}
+
+.saveButton {
+  align-self: flex-start;
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--color-accent-purple);
+  background-color: color-mix(in srgb, var(--color-accent-purple) 15%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-accent-purple) 30%, transparent);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.saveButton:hover:not(:disabled) {
+  background-color: color-mix(in srgb, var(--color-accent-purple) 25%, transparent);
+}
+
+.saveButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/web/src/modules/tyr/pages/Settings/sections/FlockSettingsSection/FlockSettingsSection.module.css
+++ b/web/src/modules/tyr/pages/Settings/sections/FlockSettingsSection/FlockSettingsSection.module.css
@@ -57,43 +57,6 @@
   color: var(--color-text-secondary);
 }
 
-.toggle {
-  position: relative;
-  width: 2.75rem;
-  height: 1.5rem;
-  border-radius: var(--radius-full);
-  border: none;
-  background-color: var(--color-bg-elevated);
-  cursor: pointer;
-  padding: 0;
-  flex-shrink: 0;
-  transition: background-color 0.15s ease;
-}
-
-.toggle:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.toggle[aria-checked='true'] {
-  background-color: var(--color-accent-purple);
-}
-
-.toggleThumb {
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 1.25rem;
-  height: 1.25rem;
-  border-radius: var(--radius-full);
-  background-color: var(--color-text-primary);
-  transition: transform 0.15s ease;
-}
-
-.toggle[aria-checked='true'] .toggleThumb {
-  transform: translateX(1.25rem);
-}
-
 .settingBlock {
   display: flex;
   flex-direction: column;

--- a/web/src/modules/tyr/pages/Settings/sections/FlockSettingsSection/FlockSettingsSection.test.tsx
+++ b/web/src/modules/tyr/pages/Settings/sections/FlockSettingsSection/FlockSettingsSection.test.tsx
@@ -18,7 +18,10 @@ const mockDefaults = {
   default_model: 'claude-sonnet-4-6',
   models: [],
   flock_enabled: false,
-  flock_default_personas: [{ name: 'coordinator', llm: {} }, { name: 'reviewer', llm: {} }],
+  flock_default_personas: [
+    { name: 'coordinator', llm: {} },
+    { name: 'reviewer', llm: {} },
+  ],
   flock_llm_config: {},
   flock_sleipnir_publish_urls: [],
 };

--- a/web/src/modules/tyr/pages/Settings/sections/FlockSettingsSection/FlockSettingsSection.test.tsx
+++ b/web/src/modules/tyr/pages/Settings/sections/FlockSettingsSection/FlockSettingsSection.test.tsx
@@ -2,31 +2,23 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { FlockSettingsSection } from './FlockSettingsSection';
 
-vi.mock('@/modules/tyr/hooks/useDispatchQueue', () => ({
-  useDispatchQueue: vi.fn(),
-}));
-
 vi.mock('@/modules/tyr/hooks/useFlockConfig', () => ({
   useFlockConfig: vi.fn(),
 }));
 
-import { useDispatchQueue } from '@/modules/tyr/hooks/useDispatchQueue';
 import { useFlockConfig } from '@/modules/tyr/hooks/useFlockConfig';
 
-const mockDefaults = {
-  default_system_prompt: '',
-  default_model: 'claude-sonnet-4-6',
-  models: [],
-  flock_enabled: false,
-  flock_default_personas: [
-    { name: 'coordinator', llm: {} },
-    { name: 'reviewer', llm: {} },
-  ],
-  flock_llm_config: {},
-  flock_sleipnir_publish_urls: [],
-};
-
 const mockFlockConfig = {
+  config: {
+    flock_enabled: false,
+    flock_default_personas: [
+      { name: 'coordinator', llm: {} },
+      { name: 'reviewer', llm: {} },
+    ],
+    flock_llm_config: {},
+    flock_sleipnir_publish_urls: [],
+  },
+  loading: false,
   updating: false,
   error: null,
   setFlockEnabled: vi.fn().mockResolvedValue(undefined),
@@ -37,16 +29,6 @@ const mockFlockConfig = {
 
 describe('FlockSettingsSection', () => {
   beforeEach(() => {
-    vi.mocked(useDispatchQueue).mockReturnValue({
-      queue: [],
-      defaults: mockDefaults,
-      clusters: [],
-      loading: false,
-      error: null,
-      dispatching: false,
-      refresh: vi.fn(),
-      dispatch: vi.fn(),
-    });
     vi.mocked(useFlockConfig).mockReturnValue(mockFlockConfig);
   });
 
@@ -56,15 +38,9 @@ describe('FlockSettingsSection', () => {
   });
 
   it('renders loading state', () => {
-    vi.mocked(useDispatchQueue).mockReturnValue({
-      queue: [],
-      defaults: mockDefaults,
-      clusters: [],
+    vi.mocked(useFlockConfig).mockReturnValue({
+      ...mockFlockConfig,
       loading: true,
-      error: null,
-      dispatching: false,
-      refresh: vi.fn(),
-      dispatch: vi.fn(),
     });
     render(<FlockSettingsSection />);
     expect(screen.getByText(/loading flock settings/i)).toBeInTheDocument();
@@ -82,15 +58,9 @@ describe('FlockSettingsSection', () => {
   });
 
   it('shows sub-settings when flock enabled', () => {
-    vi.mocked(useDispatchQueue).mockReturnValue({
-      queue: [],
-      defaults: { ...mockDefaults, flock_enabled: true },
-      clusters: [],
-      loading: false,
-      error: null,
-      dispatching: false,
-      refresh: vi.fn(),
-      dispatch: vi.fn(),
+    vi.mocked(useFlockConfig).mockReturnValue({
+      ...mockFlockConfig,
+      config: { ...mockFlockConfig.config, flock_enabled: true },
     });
     render(<FlockSettingsSection />);
     expect(screen.getByText('Default personas')).toBeInTheDocument();
@@ -114,15 +84,9 @@ describe('FlockSettingsSection', () => {
   });
 
   it('shows preset selector when flock enabled', () => {
-    vi.mocked(useDispatchQueue).mockReturnValue({
-      queue: [],
-      defaults: { ...mockDefaults, flock_enabled: true },
-      clusters: [],
-      loading: false,
-      error: null,
-      dispatching: false,
-      refresh: vi.fn(),
-      dispatch: vi.fn(),
+    vi.mocked(useFlockConfig).mockReturnValue({
+      ...mockFlockConfig,
+      config: { ...mockFlockConfig.config, flock_enabled: true },
     });
     render(<FlockSettingsSection />);
     expect(screen.getByText('Local vLLM (Qwen)')).toBeInTheDocument();

--- a/web/src/modules/tyr/pages/Settings/sections/FlockSettingsSection/FlockSettingsSection.test.tsx
+++ b/web/src/modules/tyr/pages/Settings/sections/FlockSettingsSection/FlockSettingsSection.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FlockSettingsSection } from './FlockSettingsSection';
+
+vi.mock('@/modules/tyr/hooks/useDispatchQueue', () => ({
+  useDispatchQueue: vi.fn(),
+}));
+
+vi.mock('@/modules/tyr/hooks/useFlockConfig', () => ({
+  useFlockConfig: vi.fn(),
+}));
+
+import { useDispatchQueue } from '@/modules/tyr/hooks/useDispatchQueue';
+import { useFlockConfig } from '@/modules/tyr/hooks/useFlockConfig';
+
+const mockDefaults = {
+  default_system_prompt: '',
+  default_model: 'claude-sonnet-4-6',
+  models: [],
+  flock_enabled: false,
+  flock_default_personas: [{ name: 'coordinator', llm: {} }, { name: 'reviewer', llm: {} }],
+  flock_llm_config: {},
+  flock_sleipnir_publish_urls: [],
+};
+
+const mockFlockConfig = {
+  updating: false,
+  error: null,
+  setFlockEnabled: vi.fn().mockResolvedValue(undefined),
+  setDefaultPersonas: vi.fn().mockResolvedValue(undefined),
+  setLlmConfig: vi.fn().mockResolvedValue(undefined),
+  setSleipnirUrls: vi.fn().mockResolvedValue(undefined),
+};
+
+describe('FlockSettingsSection', () => {
+  beforeEach(() => {
+    vi.mocked(useDispatchQueue).mockReturnValue({
+      queue: [],
+      defaults: mockDefaults,
+      clusters: [],
+      loading: false,
+      error: null,
+      dispatching: false,
+      refresh: vi.fn(),
+      dispatch: vi.fn(),
+    });
+    vi.mocked(useFlockConfig).mockReturnValue(mockFlockConfig);
+  });
+
+  it('renders section title', () => {
+    render(<FlockSettingsSection />);
+    expect(screen.getByText('Flock Dispatch')).toBeInTheDocument();
+  });
+
+  it('renders loading state', () => {
+    vi.mocked(useDispatchQueue).mockReturnValue({
+      queue: [],
+      defaults: mockDefaults,
+      clusters: [],
+      loading: true,
+      error: null,
+      dispatching: false,
+      refresh: vi.fn(),
+      dispatch: vi.fn(),
+    });
+    render(<FlockSettingsSection />);
+    expect(screen.getByText(/loading flock settings/i)).toBeInTheDocument();
+  });
+
+  it('renders flock enabled toggle', () => {
+    render(<FlockSettingsSection />);
+    expect(screen.getByRole('switch')).toBeInTheDocument();
+    expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('hides sub-settings when flock disabled', () => {
+    render(<FlockSettingsSection />);
+    expect(screen.queryByText('Default personas')).not.toBeInTheDocument();
+  });
+
+  it('shows sub-settings when flock enabled', () => {
+    vi.mocked(useDispatchQueue).mockReturnValue({
+      queue: [],
+      defaults: { ...mockDefaults, flock_enabled: true },
+      clusters: [],
+      loading: false,
+      error: null,
+      dispatching: false,
+      refresh: vi.fn(),
+      dispatch: vi.fn(),
+    });
+    render(<FlockSettingsSection />);
+    expect(screen.getByText('Default personas')).toBeInTheDocument();
+    expect(screen.getByText('LLM config')).toBeInTheDocument();
+    expect(screen.getByText('Sleipnir publish URLs')).toBeInTheDocument();
+  });
+
+  it('calls setFlockEnabled on toggle click', () => {
+    render(<FlockSettingsSection />);
+    fireEvent.click(screen.getByRole('switch'));
+    expect(mockFlockConfig.setFlockEnabled).toHaveBeenCalledWith(true);
+  });
+
+  it('shows error when present', () => {
+    vi.mocked(useFlockConfig).mockReturnValue({
+      ...mockFlockConfig,
+      error: 'Update failed',
+    });
+    render(<FlockSettingsSection />);
+    expect(screen.getByText('Update failed')).toBeInTheDocument();
+  });
+
+  it('shows preset selector when flock enabled', () => {
+    vi.mocked(useDispatchQueue).mockReturnValue({
+      queue: [],
+      defaults: { ...mockDefaults, flock_enabled: true },
+      clusters: [],
+      loading: false,
+      error: null,
+      dispatching: false,
+      refresh: vi.fn(),
+      dispatch: vi.fn(),
+    });
+    render(<FlockSettingsSection />);
+    expect(screen.getByText('Local vLLM (Qwen)')).toBeInTheDocument();
+    expect(screen.getByText('Anthropic (Claude Sonnet)')).toBeInTheDocument();
+  });
+});

--- a/web/src/modules/tyr/pages/Settings/sections/FlockSettingsSection/FlockSettingsSection.tsx
+++ b/web/src/modules/tyr/pages/Settings/sections/FlockSettingsSection/FlockSettingsSection.tsx
@@ -41,15 +41,9 @@ export function FlockSettingsSection() {
   }
 
   const flockEnabled = localEnabled ?? defaults.flock_enabled;
-  const personasText =
-    localPersonas ??
-    defaults.flock_default_personas
-      .map(p => p.name)
-      .join(', ');
-  const urlsText =
-    localUrls ?? defaults.flock_sleipnir_publish_urls.join('\n');
-  const llmJson =
-    localLlmJson ?? JSON.stringify(defaults.flock_llm_config, null, 2);
+  const personasText = localPersonas ?? defaults.flock_default_personas.map(p => p.name).join(', ');
+  const urlsText = localUrls ?? defaults.flock_sleipnir_publish_urls.join('\n');
+  const llmJson = localLlmJson ?? JSON.stringify(defaults.flock_llm_config, null, 2);
 
   const handleToggle = async () => {
     const next = !flockEnabled;
@@ -106,8 +100,8 @@ export function FlockSettingsSection() {
     <section className={styles.section}>
       <h3 className={styles.sectionTitle}>Flock Dispatch</h3>
       <p className={styles.sectionDescription}>
-        Enable multi-agent flock sessions. When enabled, raids are dispatched as ravn_flock
-        sessions with multiple collaborating personas.
+        Enable multi-agent flock sessions. When enabled, raids are dispatched as ravn_flock sessions
+        with multiple collaborating personas.
       </p>
 
       {error && <p className={styles.errorText}>{error}</p>}
@@ -137,7 +131,9 @@ export function FlockSettingsSection() {
           {/* Default personas */}
           <div className={styles.settingBlock}>
             <label className={styles.blockLabel}>Default personas</label>
-            <p className={styles.blockDescription}>Comma-separated persona names for every flock session.</p>
+            <p className={styles.blockDescription}>
+              Comma-separated persona names for every flock session.
+            </p>
             <div className={styles.inputRow}>
               <input
                 className={styles.textInput}
@@ -193,7 +189,9 @@ export function FlockSettingsSection() {
           {/* Sleipnir publish URLs */}
           <div className={styles.settingBlock}>
             <label className={styles.blockLabel}>Sleipnir publish URLs</label>
-            <p className={styles.blockDescription}>One URL per line. Event routing for flock task lifecycle.</p>
+            <p className={styles.blockDescription}>
+              One URL per line. Event routing for flock task lifecycle.
+            </p>
             <textarea
               className={styles.urlsTextarea}
               value={urlsText}

--- a/web/src/modules/tyr/pages/Settings/sections/FlockSettingsSection/FlockSettingsSection.tsx
+++ b/web/src/modules/tyr/pages/Settings/sections/FlockSettingsSection/FlockSettingsSection.tsx
@@ -49,8 +49,8 @@ export function FlockSettingsSection() {
 
   const flockEnabled = localEnabled ?? config?.flock_enabled ?? false;
   const personasText =
-    localPersonas ?? (config?.flock_default_personas.map(p => p.name).join(', ') ?? '');
-  const urlsText = localUrls ?? (config?.flock_sleipnir_publish_urls.join('\n') ?? '');
+    localPersonas ?? config?.flock_default_personas.map(p => p.name).join(', ') ?? '';
+  const urlsText = localUrls ?? config?.flock_sleipnir_publish_urls.join('\n') ?? '';
   const llmJson = localLlmJson ?? JSON.stringify(config?.flock_llm_config ?? {}, null, 2);
 
   const handleToggle = async () => {

--- a/web/src/modules/tyr/pages/Settings/sections/FlockSettingsSection/FlockSettingsSection.tsx
+++ b/web/src/modules/tyr/pages/Settings/sections/FlockSettingsSection/FlockSettingsSection.tsx
@@ -1,0 +1,217 @@
+import { useState } from 'react';
+import { useDispatchQueue } from '@/modules/tyr/hooks/useDispatchQueue';
+import { useFlockConfig } from '@/modules/tyr/hooks/useFlockConfig';
+import styles from './FlockSettingsSection.module.css';
+
+const LLM_PRESETS: Record<string, Record<string, unknown>> = {
+  'local-vllm': {
+    model: 'Qwen/Qwen2.5-Coder-32B-Instruct',
+    provider: 'openai',
+    base_url: 'http://vllm:8000/v1',
+  },
+  'anthropic-sonnet': {
+    model: 'claude-sonnet-4-6',
+    provider: 'anthropic',
+  },
+  'anthropic-opus': {
+    model: 'claude-opus-4-6',
+    provider: 'anthropic',
+  },
+};
+
+export function FlockSettingsSection() {
+  const { defaults, loading } = useDispatchQueue();
+  const { updating, error, setFlockEnabled, setDefaultPersonas, setLlmConfig, setSleipnirUrls } =
+    useFlockConfig();
+
+  const [localEnabled, setLocalEnabled] = useState<boolean | null>(null);
+  const [localPersonas, setLocalPersonas] = useState<string | null>(null);
+  const [localLlmPreset, setLocalLlmPreset] = useState('');
+  const [localLlmJson, setLocalLlmJson] = useState<string | null>(null);
+  const [localUrls, setLocalUrls] = useState<string | null>(null);
+  const [jsonError, setJsonError] = useState<string | null>(null);
+
+  if (loading) {
+    return (
+      <section className={styles.section}>
+        <h3 className={styles.sectionTitle}>Flock Dispatch</h3>
+        <p className={styles.loadingText}>Loading flock settings…</p>
+      </section>
+    );
+  }
+
+  const flockEnabled = localEnabled ?? defaults.flock_enabled;
+  const personasText =
+    localPersonas ??
+    defaults.flock_default_personas
+      .map(p => p.name)
+      .join(', ');
+  const urlsText =
+    localUrls ?? defaults.flock_sleipnir_publish_urls.join('\n');
+  const llmJson =
+    localLlmJson ?? JSON.stringify(defaults.flock_llm_config, null, 2);
+
+  const handleToggle = async () => {
+    const next = !flockEnabled;
+    setLocalEnabled(next);
+    await setFlockEnabled(next);
+  };
+
+  const handlePersonasSave = async () => {
+    const names = personasText
+      .split(',')
+      .map(s => s.trim())
+      .filter(Boolean);
+    await setDefaultPersonas(names);
+  };
+
+  const handlePresetChange = (preset: string) => {
+    setLocalLlmPreset(preset);
+    if (preset && LLM_PRESETS[preset]) {
+      setLocalLlmJson(JSON.stringify(LLM_PRESETS[preset], null, 2));
+      setJsonError(null);
+    }
+  };
+
+  const handleLlmJsonChange = (value: string) => {
+    setLocalLlmJson(value);
+    setLocalLlmPreset('');
+    try {
+      JSON.parse(value);
+      setJsonError(null);
+    } catch {
+      setJsonError('Invalid JSON');
+    }
+  };
+
+  const handleLlmSave = async () => {
+    if (jsonError) return;
+    try {
+      const config = JSON.parse(llmJson);
+      await setLlmConfig(config);
+    } catch {
+      setJsonError('Invalid JSON');
+    }
+  };
+
+  const handleUrlsSave = async () => {
+    const urls = urlsText
+      .split('\n')
+      .map(s => s.trim())
+      .filter(Boolean);
+    await setSleipnirUrls(urls);
+  };
+
+  return (
+    <section className={styles.section}>
+      <h3 className={styles.sectionTitle}>Flock Dispatch</h3>
+      <p className={styles.sectionDescription}>
+        Enable multi-agent flock sessions. When enabled, raids are dispatched as ravn_flock
+        sessions with multiple collaborating personas.
+      </p>
+
+      {error && <p className={styles.errorText}>{error}</p>}
+
+      {/* Enabled toggle */}
+      <div className={styles.settingRow}>
+        <div className={styles.settingInfo}>
+          <span className={styles.settingLabel}>Flock enabled</span>
+          <span className={styles.settingDescription}>
+            Gate all flock UI and dispatch behaviour
+          </span>
+        </div>
+        <button
+          type="button"
+          className={styles.toggle}
+          role="switch"
+          aria-checked={flockEnabled}
+          onClick={() => void handleToggle()}
+          disabled={updating}
+        >
+          <span className={styles.toggleThumb} />
+        </button>
+      </div>
+
+      {flockEnabled && (
+        <>
+          {/* Default personas */}
+          <div className={styles.settingBlock}>
+            <label className={styles.blockLabel}>Default personas</label>
+            <p className={styles.blockDescription}>Comma-separated persona names for every flock session.</p>
+            <div className={styles.inputRow}>
+              <input
+                className={styles.textInput}
+                value={personasText}
+                onChange={e => setLocalPersonas(e.target.value)}
+                placeholder="coordinator, reviewer, security-auditor"
+              />
+              <button
+                type="button"
+                className={styles.saveButton}
+                onClick={() => void handlePersonasSave()}
+                disabled={updating}
+              >
+                Save
+              </button>
+            </div>
+          </div>
+
+          {/* LLM config */}
+          <div className={styles.settingBlock}>
+            <label className={styles.blockLabel}>LLM config</label>
+            <p className={styles.blockDescription}>Provider and model for ravn sidecar nodes.</p>
+            <div className={styles.presetRow}>
+              <select
+                className={styles.select}
+                value={localLlmPreset}
+                onChange={e => handlePresetChange(e.target.value)}
+              >
+                <option value="">Custom…</option>
+                <option value="local-vllm">Local vLLM (Qwen)</option>
+                <option value="anthropic-sonnet">Anthropic (Claude Sonnet)</option>
+                <option value="anthropic-opus">Anthropic (Claude Opus)</option>
+              </select>
+            </div>
+            <textarea
+              className={styles.jsonTextarea}
+              value={llmJson}
+              onChange={e => handleLlmJsonChange(e.target.value)}
+              rows={6}
+              spellCheck={false}
+            />
+            {jsonError && <p className={styles.errorText}>{jsonError}</p>}
+            <button
+              type="button"
+              className={styles.saveButton}
+              onClick={() => void handleLlmSave()}
+              disabled={updating || !!jsonError}
+            >
+              Save LLM config
+            </button>
+          </div>
+
+          {/* Sleipnir publish URLs */}
+          <div className={styles.settingBlock}>
+            <label className={styles.blockLabel}>Sleipnir publish URLs</label>
+            <p className={styles.blockDescription}>One URL per line. Event routing for flock task lifecycle.</p>
+            <textarea
+              className={styles.urlsTextarea}
+              value={urlsText}
+              onChange={e => setLocalUrls(e.target.value)}
+              rows={3}
+              placeholder="http://sleipnir:4222"
+            />
+            <button
+              type="button"
+              className={styles.saveButton}
+              onClick={() => void handleUrlsSave()}
+              disabled={updating}
+            >
+              Save URLs
+            </button>
+          </div>
+        </>
+      )}
+    </section>
+  );
+}

--- a/web/src/modules/tyr/pages/Settings/sections/FlockSettingsSection/FlockSettingsSection.tsx
+++ b/web/src/modules/tyr/pages/Settings/sections/FlockSettingsSection/FlockSettingsSection.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useDispatchQueue } from '@/modules/tyr/hooks/useDispatchQueue';
+import { Toggle } from '@/modules/shared';
 import { useFlockConfig } from '@/modules/tyr/hooks/useFlockConfig';
 import styles from './FlockSettingsSection.module.css';
 
@@ -20,9 +20,16 @@ const LLM_PRESETS: Record<string, Record<string, unknown>> = {
 };
 
 export function FlockSettingsSection() {
-  const { defaults, loading } = useDispatchQueue();
-  const { updating, error, setFlockEnabled, setDefaultPersonas, setLlmConfig, setSleipnirUrls } =
-    useFlockConfig();
+  const {
+    config,
+    loading,
+    updating,
+    error,
+    setFlockEnabled,
+    setDefaultPersonas,
+    setLlmConfig,
+    setSleipnirUrls,
+  } = useFlockConfig();
 
   const [localEnabled, setLocalEnabled] = useState<boolean | null>(null);
   const [localPersonas, setLocalPersonas] = useState<string | null>(null);
@@ -40,15 +47,16 @@ export function FlockSettingsSection() {
     );
   }
 
-  const flockEnabled = localEnabled ?? defaults.flock_enabled;
-  const personasText = localPersonas ?? defaults.flock_default_personas.map(p => p.name).join(', ');
-  const urlsText = localUrls ?? defaults.flock_sleipnir_publish_urls.join('\n');
-  const llmJson = localLlmJson ?? JSON.stringify(defaults.flock_llm_config, null, 2);
+  const flockEnabled = localEnabled ?? config?.flock_enabled ?? false;
+  const personasText =
+    localPersonas ?? (config?.flock_default_personas.map(p => p.name).join(', ') ?? '');
+  const urlsText = localUrls ?? (config?.flock_sleipnir_publish_urls.join('\n') ?? '');
+  const llmJson = localLlmJson ?? JSON.stringify(config?.flock_llm_config ?? {}, null, 2);
 
   const handleToggle = async () => {
     const next = !flockEnabled;
-    setLocalEnabled(next);
     await setFlockEnabled(next);
+    setLocalEnabled(next);
   };
 
   const handlePersonasSave = async () => {
@@ -114,16 +122,13 @@ export function FlockSettingsSection() {
             Gate all flock UI and dispatch behaviour
           </span>
         </div>
-        <button
-          type="button"
-          className={styles.toggle}
-          role="switch"
-          aria-checked={flockEnabled}
-          onClick={() => void handleToggle()}
+        <Toggle
+          checked={flockEnabled}
+          onChange={() => void handleToggle()}
+          label="Flock enabled"
+          accent="purple"
           disabled={updating}
-        >
-          <span className={styles.toggleThumb} />
-        </button>
+        />
       </div>
 
       {flockEnabled && (

--- a/web/src/modules/tyr/pages/Settings/sections/FlockSettingsSection/index.ts
+++ b/web/src/modules/tyr/pages/Settings/sections/FlockSettingsSection/index.ts
@@ -1,0 +1,1 @@
+export { FlockSettingsSection } from './FlockSettingsSection';


### PR DESCRIPTION
## Summary

Implements the Tyr flock UI for NIU-648. All flock UI is gated behind `dispatch.flock_enabled` from `GET /api/v1/tyr/dispatch/config`.

### Backend
- Extended `GET /api/v1/tyr/dispatch/config` with `flock_enabled`, `flock_default_personas`, `flock_llm_config`, `flock_sleipnir_publish_urls`
- Added `GET /api/v1/tyr/flock/config` — returns current flock config
- Added `PATCH /api/v1/tyr/flock/config` — in-memory flock config mutation (non-persistent)
- Full test coverage for new endpoints (`tests/test_tyr/test_flock_config_api.py`, 12 tests)

### Frontend
- **`FlockBadge`** — purple-accented badge for flock sessions; shows participant count when provided
- **`FlockToggle`** — toggle switch + persona multi-selector chips; shown in DispatcherView when flock enabled
- **`useFlockConfig`** — hook wrapping `PATCH /api/v1/tyr/flock/config` with `updating`/`error` state
- **`FlockSettingsSection`** — full settings UI: enabled toggle, default personas, LLM config presets (local-vllm Qwen, Anthropic Sonnet/Opus), Sleipnir URLs
- **DashboardView** — flock stats panel (personas, model) visible when flock enabled
- **SessionsView** — `FlockBadge` on flock sessions (`workload_type === 'ravn_flock'`), flock count stat
- **DispatcherView** — `FlockToggle` shown when flock enabled
- **TyrSettings** — `FlockSettingsSection` added below `DispatcherSettingsSection`

## Test plan

- [x] Backend: `uv run pytest tests/test_tyr/test_flock_config_api.py` — 12 tests green
- [x] Backend: full tyr test suite — 1442 tests green
- [x] Frontend: `npm run test:coverage` — all tests green, coverage thresholds met
- [x] Ruff check + format clean

> **Note:** Linear ticket NIU-648 could not be updated via MCP (Linear MCP server unavailable in this environment). Please update manually to "In Review".

🤖 Generated with [Claude Code](https://claude.com/claude-code)