### PR TITLE
feat(domain): add @niuulabs/domain shared cross-plugin types

### DIFF
--- a/web-next/packages/domain/package.json
+++ b/web-next/packages/domain/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@niuulabs/domain",
+  "version": "0.0.1",
+  "description": "Shared cross-plugin domain types and Zod schemas for the Niuu platform",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "dev": "tsup --watch"
+  },
+  "dependencies": {
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "tsup": "^8.3.5",
+    "typescript": "^5.7.3"
+  }
+}

--- a/web-next/packages/domain/src/budget.test.ts
+++ b/web-next/packages/domain/src/budget.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { budgetStateSchema } from './budget.js';
+
+const VALID_BUDGET = {
+  spentUsd: 12.5,
+  capUsd: 50.0,
+  warnAt: 40.0,
+};
+
+describe('budgetStateSchema', () => {
+  it('round-trips a valid budget state', () => {
+    const parsed = budgetStateSchema.parse(VALID_BUDGET);
+    expect(parsed).toEqual(VALID_BUDGET);
+  });
+
+  it('round-trips zero spend', () => {
+    const input = { spentUsd: 0, capUsd: 100, warnAt: 80 };
+    expect(budgetStateSchema.parse(input)).toEqual(input);
+  });
+
+  it('round-trips zero warnAt', () => {
+    const input = { spentUsd: 5, capUsd: 100, warnAt: 0 };
+    expect(budgetStateSchema.parse(input)).toEqual(input);
+  });
+
+  it('preserves data through JSON round-trip', () => {
+    const json = JSON.stringify(VALID_BUDGET);
+    const parsed = budgetStateSchema.parse(JSON.parse(json));
+    expect(JSON.stringify(parsed)).toBe(json);
+  });
+
+  it('rejects negative spentUsd', () => {
+    expect(() => budgetStateSchema.parse({ ...VALID_BUDGET, spentUsd: -1 })).toThrow();
+  });
+
+  it('rejects zero capUsd', () => {
+    expect(() => budgetStateSchema.parse({ ...VALID_BUDGET, capUsd: 0 })).toThrow();
+  });
+
+  it('rejects negative capUsd', () => {
+    expect(() => budgetStateSchema.parse({ ...VALID_BUDGET, capUsd: -10 })).toThrow();
+  });
+
+  it('rejects negative warnAt', () => {
+    expect(() => budgetStateSchema.parse({ ...VALID_BUDGET, warnAt: -1 })).toThrow();
+  });
+
+  it('rejects missing fields', () => {
+    expect(() => budgetStateSchema.parse({ spentUsd: 10 })).toThrow();
+  });
+});

--- a/web-next/packages/domain/src/budget.ts
+++ b/web-next/packages/domain/src/budget.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+/**
+ * Budget state for a raven or the fleet.
+ *
+ * Tracks daily USD spend against a configured cap with an early-warning
+ * threshold (`warnAt`). The Budget view uses this to render BudgetBar,
+ * BudgetRunwayBar, and the attention columns (burning fast / near cap / idle).
+ *
+ * @canonical Ravn — budget stream, per-raven budget field.
+ * @consumers Tyr (dispatch feasibility — budget check),
+ *            Observatory (raven entity drawer — token throughput section).
+ */
+export const budgetStateSchema = z.object({
+  spentUsd: z.number().nonnegative(),
+  capUsd: z.number().positive(),
+  warnAt: z.number().nonnegative(),
+});
+
+export type BudgetState = z.infer<typeof budgetStateSchema>;

--- a/web-next/packages/domain/src/entity-type.test.ts
+++ b/web-next/packages/domain/src/entity-type.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from 'vitest';
+import {
+  entityShapeSchema,
+  entityCategorySchema,
+  entityBorderSchema,
+  entityFieldTypeSchema,
+  entityFieldSchema,
+  entityTypeSchema,
+} from './entity-type.js';
+
+const VALID_ENTITY_FIELD = {
+  key: 'status',
+  label: 'Status',
+  type: 'select' as const,
+  required: true,
+  options: ['healthy', 'degraded', 'down'],
+};
+
+const VALID_ENTITY_TYPE = {
+  id: 'realm',
+  label: 'Realm',
+  rune: 'ᚱ',
+  icon: 'globe',
+  shape: 'ring' as const,
+  color: 'brand',
+  size: 50,
+  border: 'solid' as const,
+  canContain: ['cluster', 'host', 'service'],
+  parentTypes: [],
+  category: 'topology' as const,
+  description: 'A logical grouping of clusters, hosts, and services',
+  fields: [VALID_ENTITY_FIELD, { key: 'location', label: 'Location', type: 'string' as const }],
+};
+
+describe('entityShapeSchema', () => {
+  it('accepts all valid shapes', () => {
+    const shapes = [
+      'ring',
+      'ring-dashed',
+      'rounded-rect',
+      'diamond',
+      'triangle',
+      'hex',
+      'chevron',
+      'square',
+      'square-sm',
+      'pentagon',
+      'halo',
+      'mimir',
+      'mimir-small',
+      'dot',
+    ];
+    for (const shape of shapes) {
+      expect(entityShapeSchema.parse(shape)).toBe(shape);
+    }
+  });
+
+  it('rejects invalid shapes', () => {
+    expect(() => entityShapeSchema.parse('circle')).toThrow();
+  });
+});
+
+describe('entityCategorySchema', () => {
+  it('accepts all valid categories', () => {
+    const categories = [
+      'topology',
+      'hardware',
+      'agent',
+      'coordinator',
+      'knowledge',
+      'infrastructure',
+      'device',
+      'composite',
+    ];
+    for (const cat of categories) {
+      expect(entityCategorySchema.parse(cat)).toBe(cat);
+    }
+  });
+
+  it('rejects invalid categories', () => {
+    expect(() => entityCategorySchema.parse('misc')).toThrow();
+  });
+});
+
+describe('entityBorderSchema', () => {
+  it('accepts all valid border styles', () => {
+    for (const border of ['solid', 'dashed']) {
+      expect(entityBorderSchema.parse(border)).toBe(border);
+    }
+  });
+
+  it('rejects invalid border styles', () => {
+    expect(() => entityBorderSchema.parse('dotted')).toThrow();
+  });
+});
+
+describe('entityFieldTypeSchema', () => {
+  it('accepts all valid field types', () => {
+    for (const type of ['string', 'number', 'select', 'tags']) {
+      expect(entityFieldTypeSchema.parse(type)).toBe(type);
+    }
+  });
+
+  it('rejects invalid field types', () => {
+    expect(() => entityFieldTypeSchema.parse('boolean')).toThrow();
+  });
+});
+
+describe('entityFieldSchema', () => {
+  it('round-trips a full field definition', () => {
+    const parsed = entityFieldSchema.parse(VALID_ENTITY_FIELD);
+    expect(parsed).toEqual(VALID_ENTITY_FIELD);
+  });
+
+  it('round-trips without optional fields', () => {
+    const minimal = { key: 'name', label: 'Name', type: 'string' as const };
+    expect(entityFieldSchema.parse(minimal)).toEqual(minimal);
+  });
+
+  it('preserves data through JSON round-trip', () => {
+    const json = JSON.stringify(VALID_ENTITY_FIELD);
+    const parsed = entityFieldSchema.parse(JSON.parse(json));
+    expect(JSON.stringify(parsed)).toBe(json);
+  });
+
+  it('rejects empty key', () => {
+    expect(() => entityFieldSchema.parse({ ...VALID_ENTITY_FIELD, key: '' })).toThrow();
+  });
+
+  it('rejects empty label', () => {
+    expect(() => entityFieldSchema.parse({ ...VALID_ENTITY_FIELD, label: '' })).toThrow();
+  });
+
+  it('rejects invalid type', () => {
+    expect(() => entityFieldSchema.parse({ ...VALID_ENTITY_FIELD, type: 'boolean' })).toThrow();
+  });
+});
+
+describe('entityTypeSchema', () => {
+  it('round-trips a full entity type', () => {
+    const parsed = entityTypeSchema.parse(VALID_ENTITY_TYPE);
+    expect(parsed).toEqual(VALID_ENTITY_TYPE);
+  });
+
+  it('round-trips with empty arrays', () => {
+    const input = {
+      ...VALID_ENTITY_TYPE,
+      canContain: [],
+      parentTypes: [],
+      fields: [],
+    };
+    const parsed = entityTypeSchema.parse(input);
+    expect(parsed).toEqual(input);
+  });
+
+  it('preserves data through JSON round-trip', () => {
+    const json = JSON.stringify(VALID_ENTITY_TYPE);
+    const parsed = entityTypeSchema.parse(JSON.parse(json));
+    expect(JSON.stringify(parsed)).toBe(json);
+  });
+
+  it('rejects missing required fields', () => {
+    const { id, ...noId } = VALID_ENTITY_TYPE;
+    void id;
+    expect(() => entityTypeSchema.parse(noId)).toThrow();
+  });
+
+  it('rejects invalid shape', () => {
+    expect(() => entityTypeSchema.parse({ ...VALID_ENTITY_TYPE, shape: 'circle' })).toThrow();
+  });
+
+  it('rejects invalid category', () => {
+    expect(() => entityTypeSchema.parse({ ...VALID_ENTITY_TYPE, category: 'misc' })).toThrow();
+  });
+
+  it('rejects invalid border', () => {
+    expect(() => entityTypeSchema.parse({ ...VALID_ENTITY_TYPE, border: 'dotted' })).toThrow();
+  });
+
+  it('rejects non-positive size', () => {
+    expect(() => entityTypeSchema.parse({ ...VALID_ENTITY_TYPE, size: 0 })).toThrow();
+  });
+
+  it('rejects invalid field in fields array', () => {
+    expect(() =>
+      entityTypeSchema.parse({
+        ...VALID_ENTITY_TYPE,
+        fields: [{ key: '', label: 'X', type: 'string' }],
+      }),
+    ).toThrow();
+  });
+});

--- a/web-next/packages/domain/src/entity-type.ts
+++ b/web-next/packages/domain/src/entity-type.ts
@@ -1,0 +1,119 @@
+import { z } from 'zod';
+
+/**
+ * Visual shape primitive used in the topology canvas and registry editor.
+ *
+ * All 14 shapes are rendered as 20×20 SVG viewBox paths via `ShapeSvg`.
+ *
+ * @canonical Observatory — `data.jsx::ShapeSvg`, registry type definitions.
+ * @consumers All plugins (PersonaAvatar uses a subset: role → shape mapping).
+ */
+export const entityShapeSchema = z.enum([
+  'ring',
+  'ring-dashed',
+  'rounded-rect',
+  'diamond',
+  'triangle',
+  'hex',
+  'chevron',
+  'square',
+  'square-sm',
+  'pentagon',
+  'halo',
+  'mimir',
+  'mimir-small',
+  'dot',
+]);
+
+export type EntityShape = z.infer<typeof entityShapeSchema>;
+
+/**
+ * Semantic category grouping entity types in the registry.
+ *
+ * @canonical Observatory — registry editor, "Types" tab groups.
+ * @consumers All plugins (filter and group entities by category).
+ */
+export const entityCategorySchema = z.enum([
+  'topology',
+  'hardware',
+  'agent',
+  'coordinator',
+  'knowledge',
+  'infrastructure',
+  'device',
+  'composite',
+]);
+
+export type EntityCategory = z.infer<typeof entityCategorySchema>;
+
+/**
+ * Border style for entity shapes in the canvas.
+ *
+ * @canonical Observatory — topology canvas stroke rendering.
+ * @consumers Observatory.
+ */
+export const entityBorderSchema = z.enum(['solid', 'dashed']);
+
+export type EntityBorder = z.infer<typeof entityBorderSchema>;
+
+/**
+ * Field type for entity-type schema definitions.
+ *
+ * @canonical Observatory — registry editor, entity drawer property grids.
+ * @consumers All plugins (entity detail rendering).
+ */
+export const entityFieldTypeSchema = z.enum(['string', 'number', 'select', 'tags']);
+
+export type EntityFieldType = z.infer<typeof entityFieldTypeSchema>;
+
+/**
+ * A field definition within an entity type's schema.
+ *
+ * Fields appear as editable rows in the entity drawer and registry editor.
+ * `select` fields include a set of valid `options`.
+ *
+ * @canonical Observatory — registry type definitions in `data.jsx`.
+ * @consumers Observatory (entity drawer), all plugins (entity rendering).
+ */
+export const entityFieldSchema = z.object({
+  key: z.string().min(1),
+  label: z.string().min(1),
+  type: entityFieldTypeSchema,
+  required: z.boolean().optional(),
+  options: z.array(z.string()).optional(),
+});
+
+export type EntityField = z.infer<typeof entityFieldSchema>;
+
+/**
+ * An entity type in the Observatory type registry.
+ *
+ * Defines the visual, structural, and data schema for a class of entities
+ * in the Niuu topology (realms, clusters, hosts, ravens, coordinators, etc.).
+ *
+ * The registry is versioned: edits bump `TypeRegistry.version` and
+ * `TypeRegistry.updatedAt`. Containment rules (`canContain` / `parentTypes`)
+ * form a DAG — cycles are rejected by the registry editor.
+ *
+ * @canonical Observatory — `DEFAULT_REGISTRY.types[]` in `data.jsx`,
+ *            registry editor (Types / Containment / JSON tabs).
+ * @consumers All plugins (topology canvas nodes, entity drawers,
+ *            PersonaAvatar shape mapping, MountChip role glyph).
+ */
+export const entityTypeSchema = z.object({
+  id: z.string().min(1),
+  label: z.string().min(1),
+  rune: z.string().min(1),
+  icon: z.string().min(1),
+  shape: entityShapeSchema,
+  color: z.string().min(1),
+  size: z.number().positive(),
+  border: entityBorderSchema,
+  canContain: z.array(z.string()),
+  parentTypes: z.array(z.string()),
+  category: entityCategorySchema,
+  description: z.string(),
+  fields: z.array(entityFieldSchema),
+});
+
+export type EntityType = z.infer<typeof entityTypeSchema>;

--- a/web-next/packages/domain/src/event.test.ts
+++ b/web-next/packages/domain/src/event.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { eventSpecSchema, eventCatalogSchema } from './event.js';
+
+const VALID_EVENT_SPEC = {
+  name: 'code.changed',
+  schema: { path: 'string', diff: 'string', language: 'string' },
+};
+
+describe('eventSpecSchema', () => {
+  it('round-trips a valid event spec', () => {
+    const parsed = eventSpecSchema.parse(VALID_EVENT_SPEC);
+    expect(parsed).toEqual(VALID_EVENT_SPEC);
+  });
+
+  it('round-trips with empty schema', () => {
+    const input = { name: 'heartbeat', schema: {} };
+    expect(eventSpecSchema.parse(input)).toEqual(input);
+  });
+
+  it('preserves data through JSON round-trip', () => {
+    const json = JSON.stringify(VALID_EVENT_SPEC);
+    const parsed = eventSpecSchema.parse(JSON.parse(json));
+    expect(JSON.stringify(parsed)).toBe(json);
+  });
+
+  it('rejects empty name', () => {
+    expect(() => eventSpecSchema.parse({ name: '', schema: {} })).toThrow();
+  });
+
+  it('rejects missing schema', () => {
+    expect(() => eventSpecSchema.parse({ name: 'test' })).toThrow();
+  });
+});
+
+describe('eventCatalogSchema', () => {
+  it('round-trips a catalog with multiple events', () => {
+    const catalog = [
+      VALID_EVENT_SPEC,
+      { name: 'review.done', schema: { verdict: 'string', score: 'number' } },
+      { name: 'deploy.complete', schema: { env: 'string', success: 'boolean' } },
+    ];
+    const parsed = eventCatalogSchema.parse(catalog);
+    expect(parsed).toEqual(catalog);
+  });
+
+  it('round-trips an empty catalog', () => {
+    expect(eventCatalogSchema.parse([])).toEqual([]);
+  });
+
+  it('preserves data through JSON round-trip', () => {
+    const catalog = [VALID_EVENT_SPEC];
+    const json = JSON.stringify(catalog);
+    const parsed = eventCatalogSchema.parse(JSON.parse(json));
+    expect(JSON.stringify(parsed)).toBe(json);
+  });
+
+  it('rejects catalog with invalid event', () => {
+    expect(() => eventCatalogSchema.parse([{ name: '' }])).toThrow();
+  });
+});

--- a/web-next/packages/domain/src/event.ts
+++ b/web-next/packages/domain/src/event.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+/**
+ * An event specification — a named event with a typed payload schema.
+ *
+ * The `schema` maps field names to their types (string representations:
+ * `"string"`, `"number"`, `"boolean"`, `"object"`, `"array"`, `"any"`).
+ *
+ * @canonical Ravn — EVENT_CATALOG, ProducesSection schema editor.
+ * @consumers Tyr (workflow validation — `no_producer` / `no_consumer` rules),
+ *            Observatory (event log decoration).
+ */
+export const eventSpecSchema = z.object({
+  name: z.string().min(1),
+  schema: z.record(z.string(), z.string()),
+});
+
+export type EventSpec = z.infer<typeof eventSpecSchema>;
+
+/**
+ * The full event catalog — all produceable event names and their schemas.
+ *
+ * @canonical Ravn — EVENT_CATALOG in `data.jsx`.
+ * @consumers Tyr (workflow validation, EventPicker),
+ *            Observatory (event log type column).
+ */
+export const eventCatalogSchema = z.array(eventSpecSchema);
+
+export type EventCatalog = z.infer<typeof eventCatalogSchema>;

--- a/web-next/packages/domain/src/index.ts
+++ b/web-next/packages/domain/src/index.ts
@@ -1,0 +1,53 @@
+export {
+  personaRoleSchema,
+  permissionModeSchema,
+  mimirWriteRoutingSchema,
+  fanInStrategyNameSchema,
+  fanInConfigSchema,
+  personaLlmSchema,
+  consumedEventSchema,
+  personaProducesSchema,
+  personaConsumesSchema,
+  personaSchema,
+} from './persona.js';
+export type {
+  PersonaRole,
+  PermissionMode,
+  MimirWriteRouting,
+  FanInStrategyName,
+  FanInConfig,
+  PersonaLlm,
+  ConsumedEvent,
+  PersonaProduces,
+  PersonaConsumes,
+  Persona,
+} from './persona.js';
+
+export { mountRoleSchema, mountStatusSchema, mountSchema } from './mount.js';
+export type { MountRole, MountStatus, Mount } from './mount.js';
+
+export { toolGroupSchema, toolSchema, toolRegistrySchema } from './tool.js';
+export type { ToolGroup, Tool, ToolRegistry } from './tool.js';
+
+export { eventSpecSchema, eventCatalogSchema } from './event.js';
+export type { EventSpec, EventCatalog } from './event.js';
+
+export { budgetStateSchema } from './budget.js';
+export type { BudgetState } from './budget.js';
+
+export {
+  entityShapeSchema,
+  entityCategorySchema,
+  entityBorderSchema,
+  entityFieldTypeSchema,
+  entityFieldSchema,
+  entityTypeSchema,
+} from './entity-type.js';
+export type {
+  EntityShape,
+  EntityCategory,
+  EntityBorder,
+  EntityFieldType,
+  EntityField,
+  EntityType,
+} from './entity-type.js';

--- a/web-next/packages/domain/src/mount.test.ts
+++ b/web-next/packages/domain/src/mount.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { mountRoleSchema, mountStatusSchema, mountSchema } from './mount.js';
+
+const VALID_MOUNT = {
+  name: 'asgard-shared',
+  role: 'shared' as const,
+  host: 'mimir-shared.asgard.niuu.internal',
+  url: 'https://mimir-shared.asgard.niuu.internal',
+  priority: 10,
+  categories: ['ops', 'infra'],
+  status: 'healthy' as const,
+  pages: 1234,
+  sources: 567,
+  lintIssues: 3,
+  lastWrite: '2026-04-19T10:30:00Z',
+  embedding: 'all-MiniLM-L6-v2',
+  sizeKb: 48200,
+  desc: 'Shared Asgard knowledge mount',
+};
+
+describe('mountRoleSchema', () => {
+  it('accepts all valid roles', () => {
+    for (const role of ['local', 'shared', 'domain']) {
+      expect(mountRoleSchema.parse(role)).toBe(role);
+    }
+  });
+
+  it('rejects invalid roles', () => {
+    expect(() => mountRoleSchema.parse('global')).toThrow();
+  });
+});
+
+describe('mountStatusSchema', () => {
+  it('accepts all valid statuses', () => {
+    for (const status of ['healthy', 'degraded', 'down']) {
+      expect(mountStatusSchema.parse(status)).toBe(status);
+    }
+  });
+
+  it('rejects invalid statuses', () => {
+    expect(() => mountStatusSchema.parse('unknown')).toThrow();
+  });
+});
+
+describe('mountSchema', () => {
+  it('round-trips a full mount', () => {
+    const parsed = mountSchema.parse(VALID_MOUNT);
+    expect(parsed).toEqual(VALID_MOUNT);
+  });
+
+  it('round-trips with null categories', () => {
+    const mount = { ...VALID_MOUNT, categories: null };
+    const parsed = mountSchema.parse(mount);
+    expect(parsed).toEqual(mount);
+    expect(parsed.categories).toBeNull();
+  });
+
+  it('preserves data through JSON round-trip', () => {
+    const json = JSON.stringify(VALID_MOUNT);
+    const parsed = mountSchema.parse(JSON.parse(json));
+    expect(JSON.stringify(parsed)).toBe(json);
+  });
+
+  it('rejects missing required fields', () => {
+    const { name, ...noName } = VALID_MOUNT;
+    void name;
+    expect(() => mountSchema.parse(noName)).toThrow();
+  });
+
+  it('rejects invalid url', () => {
+    expect(() => mountSchema.parse({ ...VALID_MOUNT, url: 'not-a-url' })).toThrow();
+  });
+
+  it('rejects negative priority', () => {
+    expect(() => mountSchema.parse({ ...VALID_MOUNT, priority: -1 })).toThrow();
+  });
+
+  it('rejects negative page count', () => {
+    expect(() => mountSchema.parse({ ...VALID_MOUNT, pages: -5 })).toThrow();
+  });
+
+  it('rejects invalid status', () => {
+    expect(() => mountSchema.parse({ ...VALID_MOUNT, status: 'offline' })).toThrow();
+  });
+});

--- a/web-next/packages/domain/src/mount.ts
+++ b/web-next/packages/domain/src/mount.ts
@@ -1,0 +1,56 @@
+import { z } from 'zod';
+
+/**
+ * Mount role within the Mimir knowledge system.
+ *
+ * - `local` — operator's own instance.
+ * - `shared` — realm-wide instance.
+ * - `domain` — prefix-scoped instance.
+ *
+ * @canonical Mimir — mount configuration.
+ * @consumers Ravn (MountChip, raven detail), Volundr (session mounts).
+ */
+export const mountRoleSchema = z.enum(['local', 'shared', 'domain']);
+
+export type MountRole = z.infer<typeof mountRoleSchema>;
+
+/**
+ * Health status of a mount.
+ *
+ * @canonical Mimir — mount health monitoring.
+ * @consumers Observatory (topology canvas), Ravn (raven overview).
+ */
+export const mountStatusSchema = z.enum(['healthy', 'degraded', 'down']);
+
+export type MountStatus = z.infer<typeof mountStatusSchema>;
+
+/**
+ * A Mimir mount — a standalone knowledge-graph instance.
+ *
+ * Each mount has its own host, embedding model, and page/source store.
+ * Write routing rules determine which mount(s) receive writes for a
+ * given page path prefix.
+ *
+ * @canonical Mimir — mount overview, routing editor.
+ * @consumers Ravn (MountChip in raven detail — name + role + priority),
+ *            Volundr (session mount bindings),
+ *            Observatory (topology canvas — mimir_sub entities).
+ */
+export const mountSchema = z.object({
+  name: z.string().min(1),
+  role: mountRoleSchema,
+  host: z.string().min(1),
+  url: z.string().url(),
+  priority: z.number().int().nonnegative(),
+  categories: z.array(z.string()).nullable(),
+  status: mountStatusSchema,
+  pages: z.number().int().nonnegative(),
+  sources: z.number().int().nonnegative(),
+  lintIssues: z.number().int().nonnegative(),
+  lastWrite: z.string(),
+  embedding: z.string().min(1),
+  sizeKb: z.number().nonnegative(),
+  desc: z.string(),
+});
+
+export type Mount = z.infer<typeof mountSchema>;

--- a/web-next/packages/domain/src/persona.test.ts
+++ b/web-next/packages/domain/src/persona.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect } from 'vitest';
+import {
+  personaRoleSchema,
+  permissionModeSchema,
+  mimirWriteRoutingSchema,
+  fanInStrategyNameSchema,
+  fanInConfigSchema,
+  personaLlmSchema,
+  consumedEventSchema,
+  personaProducesSchema,
+  personaConsumesSchema,
+  personaSchema,
+} from './persona.js';
+
+const VALID_PERSONA = {
+  name: 'Fjölnir',
+  role: 'index' as const,
+  color: '#a855f7',
+  letter: 'F',
+  summary: 'Knowledge indexer and compiler',
+  description: 'Fjölnir reads sources, extracts entities, and compiles pages.',
+  llm: { alias: 'claude-3-opus', thinking: true, maxTokens: 4096, temperature: 0.7 },
+  permissionMode: 'safe' as const,
+  allowed: ['read', 'mimir.write', 'mimir.read'],
+  forbidden: ['bash', 'write'],
+  produces: { event: 'index.complete', schema: { pages: 'number', entities: 'number' } },
+  consumes: {
+    events: [
+      { name: 'source.ingested', injects: ['source_text'], trust: 0.8 },
+      { name: 'dream.start' },
+    ],
+  },
+  fanIn: { strategy: 'merge' as const, params: { dedup: true } },
+  mimirWriteRouting: 'shared' as const,
+};
+
+describe('personaRoleSchema', () => {
+  it('accepts all valid roles', () => {
+    const roles = ['plan', 'build', 'verify', 'review', 'gate', 'audit', 'ship', 'index', 'report'];
+    for (const role of roles) {
+      expect(personaRoleSchema.parse(role)).toBe(role);
+    }
+  });
+
+  it('rejects invalid roles', () => {
+    expect(() => personaRoleSchema.parse('wizard')).toThrow();
+  });
+});
+
+describe('permissionModeSchema', () => {
+  it('accepts all valid modes', () => {
+    for (const mode of ['default', 'safe', 'loose']) {
+      expect(permissionModeSchema.parse(mode)).toBe(mode);
+    }
+  });
+
+  it('rejects invalid modes', () => {
+    expect(() => permissionModeSchema.parse('admin')).toThrow();
+  });
+});
+
+describe('mimirWriteRoutingSchema', () => {
+  it('accepts all valid routings', () => {
+    for (const routing of ['local', 'shared', 'domain']) {
+      expect(mimirWriteRoutingSchema.parse(routing)).toBe(routing);
+    }
+  });
+
+  it('rejects invalid routings', () => {
+    expect(() => mimirWriteRoutingSchema.parse('global')).toThrow();
+  });
+});
+
+describe('fanInStrategyNameSchema', () => {
+  it('accepts all valid strategies', () => {
+    const strategies = [
+      'all_must_pass',
+      'any_passes',
+      'quorum',
+      'merge',
+      'first_wins',
+      'weighted_score',
+    ];
+    for (const s of strategies) {
+      expect(fanInStrategyNameSchema.parse(s)).toBe(s);
+    }
+  });
+
+  it('rejects invalid strategies', () => {
+    expect(() => fanInStrategyNameSchema.parse('random')).toThrow();
+  });
+});
+
+describe('fanInConfigSchema', () => {
+  it('round-trips a valid config', () => {
+    const input = { strategy: 'quorum' as const, params: { n: 3, timeoutMs: 5000 } };
+    const parsed = fanInConfigSchema.parse(input);
+    expect(parsed).toEqual(input);
+  });
+
+  it('rejects missing strategy', () => {
+    expect(() => fanInConfigSchema.parse({ params: {} })).toThrow();
+  });
+});
+
+describe('personaLlmSchema', () => {
+  it('round-trips a valid LLM config with temperature', () => {
+    const input = { alias: 'claude-3-opus', thinking: true, maxTokens: 4096, temperature: 0.7 };
+    expect(personaLlmSchema.parse(input)).toEqual(input);
+  });
+
+  it('round-trips without optional temperature', () => {
+    const input = { alias: 'gpt-4', thinking: false, maxTokens: 2048 };
+    expect(personaLlmSchema.parse(input)).toEqual(input);
+  });
+
+  it('rejects empty alias', () => {
+    expect(() => personaLlmSchema.parse({ alias: '', thinking: true, maxTokens: 1 })).toThrow();
+  });
+
+  it('rejects non-positive maxTokens', () => {
+    expect(() =>
+      personaLlmSchema.parse({ alias: 'model', thinking: true, maxTokens: 0 }),
+    ).toThrow();
+  });
+
+  it('rejects temperature out of range', () => {
+    expect(() =>
+      personaLlmSchema.parse({ alias: 'model', thinking: true, maxTokens: 1, temperature: 3 }),
+    ).toThrow();
+  });
+});
+
+describe('consumedEventSchema', () => {
+  it('round-trips with all fields', () => {
+    const input = { name: 'code.changed', injects: ['diff', 'path'], trust: 0.9 };
+    expect(consumedEventSchema.parse(input)).toEqual(input);
+  });
+
+  it('round-trips with only required fields', () => {
+    const input = { name: 'code.changed' };
+    expect(consumedEventSchema.parse(input)).toEqual(input);
+  });
+
+  it('rejects empty name', () => {
+    expect(() => consumedEventSchema.parse({ name: '' })).toThrow();
+  });
+
+  it('rejects trust out of range', () => {
+    expect(() => consumedEventSchema.parse({ name: 'x', trust: 1.5 })).toThrow();
+  });
+});
+
+describe('personaProducesSchema', () => {
+  it('round-trips a valid produces spec', () => {
+    const input = { event: 'review.done', schema: { verdict: 'string', score: 'number' } };
+    expect(personaProducesSchema.parse(input)).toEqual(input);
+  });
+
+  it('rejects empty event name', () => {
+    expect(() => personaProducesSchema.parse({ event: '', schema: {} })).toThrow();
+  });
+});
+
+describe('personaConsumesSchema', () => {
+  it('round-trips with multiple events', () => {
+    const input = {
+      events: [
+        { name: 'code.changed', trust: 0.8 },
+        { name: 'review.requested', injects: ['pr_body'] },
+      ],
+    };
+    expect(personaConsumesSchema.parse(input)).toEqual(input);
+  });
+
+  it('round-trips with empty events array', () => {
+    const input = { events: [] };
+    expect(personaConsumesSchema.parse(input)).toEqual(input);
+  });
+});
+
+describe('personaSchema', () => {
+  it('round-trips a full persona', () => {
+    const parsed = personaSchema.parse(VALID_PERSONA);
+    expect(parsed).toEqual(VALID_PERSONA);
+  });
+
+  it('round-trips without optional fields', () => {
+    const { fanIn, mimirWriteRouting, ...minimal } = VALID_PERSONA;
+    void fanIn;
+    void mimirWriteRouting;
+    const parsed = personaSchema.parse(minimal);
+    expect(parsed).toEqual(minimal);
+  });
+
+  it('preserves data through JSON round-trip', () => {
+    const json = JSON.stringify(VALID_PERSONA);
+    const parsed = personaSchema.parse(JSON.parse(json));
+    expect(JSON.stringify(parsed)).toBe(json);
+  });
+
+  it('rejects missing required fields', () => {
+    const { name, ...noName } = VALID_PERSONA;
+    void name;
+    expect(() => personaSchema.parse(noName)).toThrow();
+  });
+
+  it('rejects invalid role', () => {
+    expect(() => personaSchema.parse({ ...VALID_PERSONA, role: 'wizard' })).toThrow();
+  });
+
+  it('rejects letter longer than 1 char', () => {
+    expect(() => personaSchema.parse({ ...VALID_PERSONA, letter: 'AB' })).toThrow();
+  });
+});

--- a/web-next/packages/domain/src/persona.ts
+++ b/web-next/packages/domain/src/persona.ts
@@ -1,0 +1,166 @@
+import { z } from 'zod';
+
+/**
+ * The nine canonical persona roles in the Niuu system.
+ *
+ * Each role maps to a deterministic visual shape in the UI (PersonaAvatar).
+ *
+ * @canonical Ravn — owns the persona library (`src/ravn/personas/*.yaml`).
+ * @consumers Tyr (workflow editor, dispatch), Observatory (topology canvas),
+ *            Volundr (session binding), Mimir (write routing).
+ */
+export const personaRoleSchema = z.enum([
+  'plan',
+  'build',
+  'verify',
+  'review',
+  'gate',
+  'audit',
+  'ship',
+  'index',
+  'report',
+]);
+
+export type PersonaRole = z.infer<typeof personaRoleSchema>;
+
+/**
+ * Permission mode governing tool access for a persona.
+ *
+ * - `default` — standard guardrails.
+ * - `safe` — restricted to non-destructive tools only.
+ * - `loose` — all tools allowed unless explicitly forbidden.
+ *
+ * @canonical Ravn — persona editor.
+ * @consumers Tyr (dispatch feasibility), Volundr (session tool allowlist).
+ */
+export const permissionModeSchema = z.enum(['default', 'safe', 'loose']);
+
+export type PermissionMode = z.infer<typeof permissionModeSchema>;
+
+/**
+ * Mimir write routing target for a persona.
+ *
+ * Controls which mount a persona writes knowledge to during operation.
+ *
+ * @canonical Ravn — persona editor.
+ * @consumers Mimir (route-write resolution).
+ */
+export const mimirWriteRoutingSchema = z.enum(['local', 'shared', 'domain']);
+
+export type MimirWriteRouting = z.infer<typeof mimirWriteRoutingSchema>;
+
+/**
+ * Fan-in strategy names for multi-producer event aggregation.
+ *
+ * @canonical Ravn — fan-in configurator.
+ * @consumers Tyr (workflow validation — `fan_in_misconfig` rule).
+ */
+export const fanInStrategyNameSchema = z.enum([
+  'all_must_pass',
+  'any_passes',
+  'quorum',
+  'merge',
+  'first_wins',
+  'weighted_score',
+]);
+
+export type FanInStrategyName = z.infer<typeof fanInStrategyNameSchema>;
+
+/**
+ * Fan-in configuration: a strategy name with strategy-specific parameters.
+ *
+ * @canonical Ravn — FanInSection in persona editor.
+ * @consumers Tyr (workflow validation).
+ */
+export const fanInConfigSchema = z.object({
+  strategy: fanInStrategyNameSchema,
+  params: z.record(z.string(), z.unknown()),
+});
+
+export type FanInConfig = z.infer<typeof fanInConfigSchema>;
+
+/**
+ * LLM configuration bound to a persona.
+ *
+ * @canonical Ravn — persona LLM section.
+ * @consumers Tyr (dispatch), Observatory (entity detail drawer).
+ */
+export const personaLlmSchema = z.object({
+  alias: z.string().min(1),
+  thinking: z.boolean(),
+  maxTokens: z.number().int().positive(),
+  temperature: z.number().min(0).max(2).optional(),
+});
+
+export type PersonaLlm = z.infer<typeof personaLlmSchema>;
+
+/**
+ * A single event that a persona consumes, with optional inject snippets
+ * and a producer-trust threshold.
+ *
+ * @canonical Ravn — ConsumesSection in persona editor.
+ * @consumers Tyr (workflow validation — `no_producer` / `no_consumer` rules).
+ */
+export const consumedEventSchema = z.object({
+  name: z.string().min(1),
+  injects: z.array(z.string()).optional(),
+  trust: z.number().min(0).max(1).optional(),
+});
+
+export type ConsumedEvent = z.infer<typeof consumedEventSchema>;
+
+/**
+ * The event a persona produces, including the payload schema.
+ *
+ * @canonical Ravn — ProducesSection in persona editor.
+ * @consumers Tyr (workflow validation).
+ */
+export const personaProducesSchema = z.object({
+  event: z.string().min(1),
+  schema: z.record(z.string(), z.string()),
+});
+
+export type PersonaProduces = z.infer<typeof personaProducesSchema>;
+
+/**
+ * Events a persona consumes.
+ *
+ * @canonical Ravn — ConsumesSection in persona editor.
+ * @consumers Tyr (workflow validation).
+ */
+export const personaConsumesSchema = z.object({
+  events: z.array(consumedEventSchema),
+});
+
+export type PersonaConsumes = z.infer<typeof personaConsumesSchema>;
+
+/**
+ * A persona template — the canonical shape for the raven personality library.
+ *
+ * Matches `src/ravn/personas/*.yaml` and `data.jsx::PERSONAS` from the Ravn
+ * handoff prototype. Any number of ravens can bind to a single persona.
+ *
+ * @canonical Ravn — persona editor + library browser.
+ * @consumers Tyr (workflow editor, plan wizard, dispatch),
+ *            Observatory (topology canvas — persona-colored nodes),
+ *            Volundr (session binding — persona → pod template),
+ *            Mimir (write routing — `mimirWriteRouting`).
+ */
+export const personaSchema = z.object({
+  name: z.string().min(1),
+  role: personaRoleSchema,
+  color: z.string().min(1),
+  letter: z.string().length(1),
+  summary: z.string(),
+  description: z.string(),
+  llm: personaLlmSchema,
+  permissionMode: permissionModeSchema,
+  allowed: z.array(z.string()),
+  forbidden: z.array(z.string()),
+  produces: personaProducesSchema,
+  consumes: personaConsumesSchema,
+  fanIn: fanInConfigSchema.optional(),
+  mimirWriteRouting: mimirWriteRoutingSchema.optional(),
+});
+
+export type Persona = z.infer<typeof personaSchema>;

--- a/web-next/packages/domain/src/tool.test.ts
+++ b/web-next/packages/domain/src/tool.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { toolGroupSchema, toolSchema, toolRegistrySchema } from './tool.js';
+
+const VALID_TOOL = {
+  id: 'git.checkout',
+  group: 'git' as const,
+  destructive: true,
+  desc: 'Switch branches or restore working tree files',
+};
+
+describe('toolGroupSchema', () => {
+  it('accepts all valid groups', () => {
+    const groups = ['fs', 'shell', 'git', 'mimir', 'observe', 'security', 'bus'];
+    for (const group of groups) {
+      expect(toolGroupSchema.parse(group)).toBe(group);
+    }
+  });
+
+  it('rejects invalid groups', () => {
+    expect(() => toolGroupSchema.parse('network')).toThrow();
+  });
+});
+
+describe('toolSchema', () => {
+  it('round-trips a valid tool', () => {
+    const parsed = toolSchema.parse(VALID_TOOL);
+    expect(parsed).toEqual(VALID_TOOL);
+  });
+
+  it('preserves data through JSON round-trip', () => {
+    const json = JSON.stringify(VALID_TOOL);
+    const parsed = toolSchema.parse(JSON.parse(json));
+    expect(JSON.stringify(parsed)).toBe(json);
+  });
+
+  it('rejects empty id', () => {
+    expect(() => toolSchema.parse({ ...VALID_TOOL, id: '' })).toThrow();
+  });
+
+  it('rejects missing destructive flag', () => {
+    const { destructive, ...noDestructive } = VALID_TOOL;
+    void destructive;
+    expect(() => toolSchema.parse(noDestructive)).toThrow();
+  });
+
+  it('rejects invalid group', () => {
+    expect(() => toolSchema.parse({ ...VALID_TOOL, group: 'network' })).toThrow();
+  });
+});
+
+describe('toolRegistrySchema', () => {
+  it('round-trips a registry with multiple tools', () => {
+    const registry = [
+      VALID_TOOL,
+      { id: 'read', group: 'fs' as const, destructive: false, desc: 'Read a file' },
+      { id: 'write', group: 'fs' as const, destructive: true, desc: 'Write a file' },
+    ];
+    const parsed = toolRegistrySchema.parse(registry);
+    expect(parsed).toEqual(registry);
+  });
+
+  it('round-trips an empty registry', () => {
+    expect(toolRegistrySchema.parse([])).toEqual([]);
+  });
+
+  it('preserves data through JSON round-trip', () => {
+    const registry = [VALID_TOOL];
+    const json = JSON.stringify(registry);
+    const parsed = toolRegistrySchema.parse(JSON.parse(json));
+    expect(JSON.stringify(parsed)).toBe(json);
+  });
+
+  it('rejects registry with invalid tool', () => {
+    expect(() => toolRegistrySchema.parse([{ id: '' }])).toThrow();
+  });
+});

--- a/web-next/packages/domain/src/tool.ts
+++ b/web-next/packages/domain/src/tool.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+
+/**
+ * Tool group / provider category.
+ *
+ * Groups tools by their origin system for the ToolPicker UI.
+ *
+ * @canonical Ravn — TOOL_REGISTRY in `data.jsx`.
+ * @consumers Tyr (workflow inspector — tool access review),
+ *            Volundr (template editor — tool allowlist).
+ */
+export const toolGroupSchema = z.enum([
+  'fs',
+  'shell',
+  'git',
+  'mimir',
+  'observe',
+  'security',
+  'bus',
+]);
+
+export type ToolGroup = z.infer<typeof toolGroupSchema>;
+
+/**
+ * A single tool in the Niuu tool registry.
+ *
+ * Every tool has a unique `id`, belongs to a `group`, and may be flagged
+ * `destructive`. Destructive tools render with a warning stripe in allow
+ * lists and a red dot in the UI.
+ *
+ * @canonical Ravn — TOOL_REGISTRY, ToolPicker, persona editor tool-access section.
+ * @consumers Tyr (workflow inspector — tool validation),
+ *            Volundr (template tool allowlist).
+ */
+export const toolSchema = z.object({
+  id: z.string().min(1),
+  group: toolGroupSchema,
+  destructive: z.boolean(),
+  desc: z.string(),
+});
+
+export type Tool = z.infer<typeof toolSchema>;
+
+/**
+ * The full tool registry — an ordered collection of available tools.
+ *
+ * @canonical Ravn — TOOL_REGISTRY.
+ * @consumers Tyr, Volundr.
+ */
+export const toolRegistrySchema = z.array(toolSchema);
+
+export type ToolRegistry = z.infer<typeof toolRegistrySchema>;

--- a/web-next/packages/domain/tsconfig.json
+++ b/web-next/packages/domain/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "**/*.stories.tsx"]
+}

--- a/web-next/packages/domain/tsup.config.ts
+++ b/web-next/packages/domain/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  external: [],
+});

--- a/web-next/pnpm-lock.yaml
+++ b/web-next/pnpm-lock.yaml
@@ -169,6 +169,19 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/domain:
+    dependencies:
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
+    devDependencies:
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(postcss@8.5.10)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
   packages/plugin-hello:
     dependencies:
       '@niuulabs/plugin-sdk':


### PR DESCRIPTION
## Summary

- Add `@niuulabs/domain` package — framework-free TypeScript types + Zod schemas for entities that cross plugin boundaries.
- **Persona** — full persona template shape matching `src/ravn/personas/*.yaml` and the Ravn handoff prototype, with LLM config, tool access, produces/consumes events, fan-in strategies, and Mimir write routing.
- **Mount** — Mimir mount spec (role, host, priority, categories, status, embedding model).
- **Tool / ToolRegistry** — tool ID, group, destructive flag, description. Registry is an ordered array.
- **EventSpec / EventCatalog** — named events with typed payload schemas.
- **BudgetState** — daily USD spend/cap/warn-at for ravens.
- **EntityType** — Observatory registry schema (shape, rune, icon, category, containment rules, field definitions).
- Each type has JSDoc explaining canonical owner plugin and consumer plugins.
- Zero framework imports (no React, no TanStack).
- Zod round-trip tests for every schema — 100% coverage on the domain package.

Closes NIU-652

## Test plan

- [x] All 93 domain-specific Zod round-trip tests pass
- [x] All 130 workspace tests pass (including existing packages)
- [x] 100% coverage on `@niuulabs/domain` (statements, branches, functions, lines)
- [x] Overall workspace coverage ≥ 85% threshold met
- [x] ESLint clean (zero warnings)
- [x] Prettier clean
- [x] Build succeeds (`pnpm build`)

> **Note:** Linear ticket NIU-652 could not be updated via MCP tools (unavailable). Will update manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)