### PR TITLE
feat(web-next): lift shared infra from web/ (HTTP client, identity + feature-catalog ports)

### DIFF
--- a/web-next/apps/niuu/src/services.ts
+++ b/web-next/apps/niuu/src/services.ts
@@ -1,8 +1,15 @@
-import { createMockHelloService } from '@niuulabs/plugin-hello';
+import { createMockHelloService, createHttpHelloService } from '@niuulabs/plugin-hello';
+import { createApiClient } from '@niuulabs/query';
 import type { NiuuConfig, ServicesMap } from '@niuulabs/plugin-sdk';
 
-export function buildServices(_config: NiuuConfig): ServicesMap {
+export function buildServices(config: NiuuConfig): ServicesMap {
+  const helloConfig = config.services.hello;
+  const helloService =
+    helloConfig?.mode === 'http' && helloConfig.baseUrl
+      ? createHttpHelloService(createApiClient(helloConfig.baseUrl))
+      : createMockHelloService();
+
   return {
-    hello: createMockHelloService(),
+    hello: helloService,
   };
 }

--- a/web-next/e2e/http-client.spec.ts
+++ b/web-next/e2e/http-client.spec.ts
@@ -1,16 +1,17 @@
 import { test, expect } from '@playwright/test';
 
 /**
- * E2E: Hello plugin round-trips through the HTTP client + mocked token provider.
+ * E2E: Hello plugin round-trips through the HTTP client.
  *
  * Strategy:
  * 1. Override config.json to set hello service to HTTP mode
- * 2. Intercept the API call and verify Authorization header
- * 3. Return mock greeting data
- * 4. Verify the UI renders the API-supplied greetings
+ * 2. Intercept the API call and return mock greeting data
+ * 3. Verify the UI renders the API-supplied greetings
+ *
+ * Token provider integration is covered by unit tests in client.test.ts.
  */
-test.describe('HTTP client + token provider', () => {
-  test('hello plugin fetches greetings via HTTP client with auth token', async ({ page }) => {
+test.describe('HTTP client', () => {
+  test('hello plugin fetches greetings via HTTP client', async ({ page }) => {
     const mockGreetings = [
       { id: 'e2e-1', text: 'greeting from API', mood: 'warm' },
       { id: 'e2e-2', text: 'token was accepted', mood: 'curious' },
@@ -30,7 +31,6 @@ test.describe('HTTP client + token provider', () => {
       });
     });
 
-    // Track whether the API was called with the right auth header
     // Intercept the hello API call
     await page.route('**/api/v1/hello/greetings', async (route) => {
       await route.fulfill({
@@ -39,35 +39,14 @@ test.describe('HTTP client + token provider', () => {
       });
     });
 
-    // Set a token provider before the app loads
-    await page.addInitScript(() => {
-      // The app will call setTokenProvider; we hook into it by pre-setting
-      // a global that services.ts or App.tsx can pick up.
-      // For the e2e test, we inject the token provider after modules load.
-      (window as unknown as Record<string, unknown>).__E2E_TOKEN__ = 'e2e-test-jwt';
-    });
-
     await page.goto('/');
-
-    // Inject the token provider into the running app
-    await page.evaluate(() => {
-      // Access the @niuulabs/query module via the app's module system.
-      // Vite exposes the module in the page scope.
-      const token = (window as unknown as Record<string, unknown>).__E2E_TOKEN__ as string;
-      if (token) {
-        // Dynamic import to set the token provider
-        import('/src/e2e-token-setup.ts').catch(() => {
-          // Module might not exist in non-e2e builds — that's fine
-        });
-      }
-    });
 
     // The greetings should render from the mocked API response
     await expect(page.getByText('greeting from API')).toBeVisible({ timeout: 5000 });
     await expect(page.getByText('token was accepted')).toBeVisible();
 
-    // The greeting UI should show both items
-    expect(mockGreetings).toHaveLength(2);
+    // Verify the page rendered both greeting items
+    await expect(page.locator('li')).toHaveCount(2);
   });
 
   test('hello plugin shows loading state before data resolves', async ({ page }) => {

--- a/web-next/e2e/http-client.spec.ts
+++ b/web-next/e2e/http-client.spec.ts
@@ -1,0 +1,134 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E: Hello plugin round-trips through the HTTP client + mocked token provider.
+ *
+ * Strategy:
+ * 1. Override config.json to set hello service to HTTP mode
+ * 2. Intercept the API call and verify Authorization header
+ * 3. Return mock greeting data
+ * 4. Verify the UI renders the API-supplied greetings
+ */
+test.describe('HTTP client + token provider', () => {
+  test('hello plugin fetches greetings via HTTP client with auth token', async ({ page }) => {
+    const mockGreetings = [
+      { id: 'e2e-1', text: 'greeting from API', mood: 'warm' },
+      { id: 'e2e-2', text: 'token was accepted', mood: 'curious' },
+    ];
+
+    // Intercept config.json to enable HTTP mode for hello service
+    await page.route('**/config.json', async (route) => {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          theme: 'ice',
+          plugins: { hello: { enabled: true, order: 1 } },
+          services: {
+            hello: { baseUrl: '/api/v1/hello', mode: 'http' },
+          },
+        }),
+      });
+    });
+
+    // Track whether the API was called with the right auth header
+    // Intercept the hello API call
+    await page.route('**/api/v1/hello/greetings', async (route) => {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify(mockGreetings),
+      });
+    });
+
+    // Set a token provider before the app loads
+    await page.addInitScript(() => {
+      // The app will call setTokenProvider; we hook into it by pre-setting
+      // a global that services.ts or App.tsx can pick up.
+      // For the e2e test, we inject the token provider after modules load.
+      (window as unknown as Record<string, unknown>).__E2E_TOKEN__ = 'e2e-test-jwt';
+    });
+
+    await page.goto('/');
+
+    // Inject the token provider into the running app
+    await page.evaluate(() => {
+      // Access the @niuulabs/query module via the app's module system.
+      // Vite exposes the module in the page scope.
+      const token = (window as unknown as Record<string, unknown>).__E2E_TOKEN__ as string;
+      if (token) {
+        // Dynamic import to set the token provider
+        import('/src/e2e-token-setup.ts').catch(() => {
+          // Module might not exist in non-e2e builds — that's fine
+        });
+      }
+    });
+
+    // The greetings should render from the mocked API response
+    await expect(page.getByText('greeting from API')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('token was accepted')).toBeVisible();
+
+    // The greeting UI should show both items
+    expect(mockGreetings).toHaveLength(2);
+  });
+
+  test('hello plugin shows loading state before data resolves', async ({ page }) => {
+    // Intercept config for HTTP mode
+    await page.route('**/config.json', async (route) => {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          theme: 'ice',
+          plugins: { hello: { enabled: true, order: 1 } },
+          services: {
+            hello: { baseUrl: '/api/v1/hello', mode: 'http' },
+          },
+        }),
+      });
+    });
+
+    // Delay the API response to observe loading state
+    await page.route('**/api/v1/hello/greetings', async (route) => {
+      await new Promise((r) => setTimeout(r, 500));
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify([{ id: '1', text: 'delayed greeting', mood: 'warm' }]),
+      });
+    });
+
+    await page.goto('/');
+
+    // Loading state should appear first
+    await expect(page.getByText('loading…')).toBeVisible({ timeout: 3000 });
+
+    // Then data should appear
+    await expect(page.getByText('delayed greeting')).toBeVisible({ timeout: 5000 });
+  });
+
+  test('hello plugin shows error state when API fails', async ({ page }) => {
+    await page.route('**/config.json', async (route) => {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          theme: 'ice',
+          plugins: { hello: { enabled: true, order: 1 } },
+          services: {
+            hello: { baseUrl: '/api/v1/hello', mode: 'http' },
+          },
+        }),
+      });
+    });
+
+    // Return an error from the API
+    await page.route('**/api/v1/hello/greetings', async (route) => {
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ detail: 'Internal server error' }),
+      });
+    });
+
+    await page.goto('/');
+
+    // Error state should appear
+    await expect(page.getByText(/error|failed/i)).toBeVisible({ timeout: 5000 });
+  });
+});

--- a/web-next/packages/plugin-hello/package.json
+++ b/web-next/packages/plugin-hello/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@niuulabs/plugin-sdk": "workspace:*",
+    "@niuulabs/query": "workspace:*",
     "@niuulabs/ui": "workspace:*"
   },
   "devDependencies": {

--- a/web-next/packages/plugin-hello/src/adapters/http.test.ts
+++ b/web-next/packages/plugin-hello/src/adapters/http.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { ApiClient } from '@niuulabs/query';
+import { createHttpHelloService } from './http';
+
+function mockApiClient(overrides: Partial<ApiClient> = {}): ApiClient {
+  return {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('createHttpHelloService', () => {
+  it('fetches greetings from /greetings', async () => {
+    const greetings = [
+      { id: '1', text: 'hello', mood: 'warm' },
+      { id: '2', text: 'hi', mood: 'cold' },
+    ];
+    const client = mockApiClient({
+      get: vi.fn().mockResolvedValue(greetings),
+    });
+
+    const service = createHttpHelloService(client);
+    const result = await service.listGreetings();
+
+    expect(client.get).toHaveBeenCalledWith('/greetings');
+    expect(result).toEqual(greetings);
+  });
+
+  it('propagates API errors', async () => {
+    const client = mockApiClient({
+      get: vi.fn().mockRejectedValue(new Error('network error')),
+    });
+
+    const service = createHttpHelloService(client);
+    await expect(service.listGreetings()).rejects.toThrow('network error');
+  });
+
+  it('implements IHelloService interface', () => {
+    const client = mockApiClient();
+    const service = createHttpHelloService(client);
+    expect(typeof service.listGreetings).toBe('function');
+  });
+});

--- a/web-next/packages/plugin-hello/src/adapters/http.ts
+++ b/web-next/packages/plugin-hello/src/adapters/http.ts
@@ -1,0 +1,14 @@
+import type { ApiClient } from '@niuulabs/query';
+import type { Greeting, IHelloService } from '../ports';
+
+/**
+ * Create a hello service backed by an HTTP API.
+ * @param client - An ApiClient pointed at the hello service endpoint
+ */
+export function createHttpHelloService(client: ApiClient): IHelloService {
+  return {
+    async listGreetings(): Promise<Greeting[]> {
+      return client.get<Greeting[]>('/greetings');
+    },
+  };
+}

--- a/web-next/packages/plugin-hello/src/index.tsx
+++ b/web-next/packages/plugin-hello/src/index.tsx
@@ -10,4 +10,5 @@ export const helloPlugin = definePlugin({
 });
 
 export { createMockHelloService } from './adapters/mock';
+export { createHttpHelloService } from './adapters/http';
 export type { IHelloService, Greeting } from './ports';

--- a/web-next/packages/plugin-hello/tsup.config.ts
+++ b/web-next/packages/plugin-hello/tsup.config.ts
@@ -6,5 +6,11 @@ export default defineConfig({
   dts: true,
   sourcemap: true,
   clean: true,
-  external: ['react', '@tanstack/react-query', '@niuulabs/plugin-sdk', '@niuulabs/ui'],
+  external: [
+    'react',
+    '@tanstack/react-query',
+    '@niuulabs/plugin-sdk',
+    '@niuulabs/query',
+    '@niuulabs/ui',
+  ],
 });

--- a/web-next/packages/plugin-sdk/package.json
+++ b/web-next/packages/plugin-sdk/package.json
@@ -29,6 +29,7 @@
     "@tanstack/react-router": "^1.95.0"
   },
   "dependencies": {
+    "@niuulabs/query": "workspace:*",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/web-next/packages/plugin-sdk/src/FeatureCatalog.test.tsx
+++ b/web-next/packages/plugin-sdk/src/FeatureCatalog.test.tsx
@@ -1,7 +1,8 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
 import { ConfigProvider } from './ConfigProvider';
 import { FeatureCatalogProvider, useFeatureCatalog } from './FeatureCatalog';
+import type { IFeatureCatalogService, FeatureModule } from './ports/feature-catalog.port';
 
 function Reader({ id }: { id: string }) {
   const { isEnabled, order } = useFeatureCatalog();
@@ -66,5 +67,148 @@ describe('FeatureCatalog', () => {
       ),
     ).toThrow(/FeatureCatalogProvider/);
     console.error = error;
+  });
+
+  describe('with IFeatureCatalogService', () => {
+    function createMockService(modules: FeatureModule[]): IFeatureCatalogService {
+      return {
+        getFeatureModules: vi.fn().mockResolvedValue(modules),
+        getUserFeaturePreferences: vi.fn().mockResolvedValue([]),
+        updateUserFeaturePreferences: vi.fn().mockResolvedValue([]),
+        toggleFeature: vi.fn(),
+      };
+    }
+
+    it('delegates to service when provided', async () => {
+      const service = createMockService([
+        {
+          key: 'tyr',
+          label: 'Tyr',
+          icon: 'T',
+          scope: 'user',
+          enabled: false,
+          defaultEnabled: true,
+          adminOnly: false,
+          order: 7,
+        },
+      ]);
+
+      render(
+        <ConfigProvider
+          value={{
+            theme: 'ice',
+            plugins: { tyr: { enabled: true, order: 4 } },
+            services: {},
+          }}
+        >
+          <FeatureCatalogProvider service={service}>
+            <Reader id="tyr" />
+          </FeatureCatalogProvider>
+        </ConfigProvider>,
+      );
+
+      // Initially shows config values
+      expect(screen.getByTestId('out').textContent).toBe('true-4');
+
+      // After service resolves, shows service values
+      await waitFor(() => {
+        expect(screen.getByTestId('out').textContent).toBe('false-7');
+      });
+    });
+
+    it('falls back to config when service errors', async () => {
+      const service: IFeatureCatalogService = {
+        getFeatureModules: vi.fn().mockRejectedValue(new Error('network')),
+        getUserFeaturePreferences: vi.fn(),
+        updateUserFeaturePreferences: vi.fn(),
+        toggleFeature: vi.fn(),
+      };
+
+      render(
+        <ConfigProvider
+          value={{
+            theme: 'ice',
+            plugins: { tyr: { enabled: true, order: 3 } },
+            services: {},
+          }}
+        >
+          <FeatureCatalogProvider service={service}>
+            <Reader id="tyr" />
+          </FeatureCatalogProvider>
+        </ConfigProvider>,
+      );
+
+      // Should remain on config values after error
+      await waitFor(() => {
+        expect(service.getFeatureModules).toHaveBeenCalled();
+      });
+      expect(screen.getByTestId('out').textContent).toBe('true-3');
+    });
+
+    it('falls back to config for plugins not returned by service', async () => {
+      const service = createMockService([
+        {
+          key: 'tyr',
+          label: 'Tyr',
+          icon: 'T',
+          scope: 'user',
+          enabled: true,
+          defaultEnabled: true,
+          adminOnly: false,
+          order: 5,
+        },
+      ]);
+
+      render(
+        <ConfigProvider
+          value={{
+            theme: 'ice',
+            plugins: { mimir: { enabled: false, order: 2 } },
+            services: {},
+          }}
+        >
+          <FeatureCatalogProvider service={service}>
+            <Reader id="mimir" />
+          </FeatureCatalogProvider>
+        </ConfigProvider>,
+      );
+
+      await waitFor(() => {
+        expect(service.getFeatureModules).toHaveBeenCalled();
+      });
+      // mimir not in service data, falls back to config
+      expect(screen.getByTestId('out').textContent).toBe('false-2');
+    });
+
+    it('overrides take precedence over service', async () => {
+      const service = createMockService([
+        {
+          key: 'tyr',
+          label: 'Tyr',
+          icon: 'T',
+          scope: 'user',
+          enabled: true,
+          defaultEnabled: true,
+          adminOnly: false,
+          order: 5,
+        },
+      ]);
+
+      render(
+        <ConfigProvider value={{ theme: 'ice', plugins: {}, services: {} }}>
+          <FeatureCatalogProvider
+            service={service}
+            overrides={{ isEnabled: () => false, order: () => 99 }}
+          >
+            <Reader id="tyr" />
+          </FeatureCatalogProvider>
+        </ConfigProvider>,
+      );
+
+      await waitFor(() => {
+        expect(service.getFeatureModules).toHaveBeenCalled();
+      });
+      expect(screen.getByTestId('out').textContent).toBe('false-99');
+    });
   });
 });

--- a/web-next/packages/plugin-sdk/src/FeatureCatalog.tsx
+++ b/web-next/packages/plugin-sdk/src/FeatureCatalog.tsx
@@ -1,5 +1,6 @@
-import { createContext, useContext, useMemo, type ReactNode } from 'react';
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { useConfig } from './ConfigProvider';
+import type { IFeatureCatalogService, FeatureModule } from './ports/feature-catalog.port';
 
 export interface FeatureCatalog {
   isEnabled: (pluginId: string) => boolean;
@@ -10,19 +11,71 @@ const FeatureCatalogContext = createContext<FeatureCatalog | null>(null);
 
 interface FeatureCatalogProviderProps {
   overrides?: Partial<FeatureCatalog>;
+  service?: IFeatureCatalogService;
   children: ReactNode;
 }
 
-export function FeatureCatalogProvider({ overrides, children }: FeatureCatalogProviderProps) {
+/**
+ * Provides feature-flag lookups to the component tree.
+ *
+ * Resolution order:
+ * 1. `overrides` prop (highest priority — used for tests / Storybook)
+ * 2. `service` prop — async backend data from `IFeatureCatalogService`
+ * 3. `config.plugins` — static runtime config (always available as fallback)
+ */
+export function FeatureCatalogProvider({
+  overrides,
+  service,
+  children,
+}: FeatureCatalogProviderProps) {
   const config = useConfig();
+  const [serviceModules, setServiceModules] = useState<FeatureModule[] | null>(null);
+
+  useEffect(() => {
+    if (!service) return;
+
+    let cancelled = false;
+    service
+      .getFeatureModules()
+      .then((modules) => {
+        if (!cancelled) setServiceModules(modules);
+      })
+      .catch(() => {
+        // Silently fall back to config-only on error
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [service]);
 
   const catalog = useMemo<FeatureCatalog>(() => {
+    // Build a lookup map from service modules when available
+    const moduleMap = new Map<string, FeatureModule>();
+    if (serviceModules) {
+      for (const m of serviceModules) {
+        moduleMap.set(m.key, m);
+      }
+    }
+
     return {
       isEnabled:
-        overrides?.isEnabled ?? ((pluginId: string) => config.plugins[pluginId]?.enabled !== false),
-      order: overrides?.order ?? ((pluginId: string) => config.plugins[pluginId]?.order ?? 100),
+        overrides?.isEnabled ??
+        ((pluginId: string) => {
+          // Service data takes precedence over config
+          const serviceModule = moduleMap.get(pluginId);
+          if (serviceModule) return serviceModule.enabled;
+          return config.plugins[pluginId]?.enabled !== false;
+        }),
+      order:
+        overrides?.order ??
+        ((pluginId: string) => {
+          const serviceModule = moduleMap.get(pluginId);
+          if (serviceModule) return serviceModule.order;
+          return config.plugins[pluginId]?.order ?? 100;
+        }),
     };
-  }, [config, overrides]);
+  }, [config, overrides, serviceModules]);
 
   return (
     <FeatureCatalogContext.Provider value={catalog}>{children}</FeatureCatalogContext.Provider>

--- a/web-next/packages/plugin-sdk/src/adapters/feature-catalog.adapter.test.ts
+++ b/web-next/packages/plugin-sdk/src/adapters/feature-catalog.adapter.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { ApiClient } from '@niuulabs/query';
+import type { IFeatureCatalogService } from '../ports/feature-catalog.port';
+import {
+  createApiFeatureCatalogService,
+  createMockFeatureCatalogService,
+} from './feature-catalog.adapter';
+
+const apiFeatures = [
+  {
+    key: 'users',
+    label: 'Users',
+    icon: 'Users',
+    scope: 'admin',
+    enabled: true,
+    default_enabled: true,
+    admin_only: true,
+    order: 1,
+  },
+  {
+    key: 'tenants',
+    label: 'Tenants',
+    icon: 'Building2',
+    scope: 'admin',
+    enabled: true,
+    default_enabled: true,
+    admin_only: true,
+    order: 2,
+  },
+  {
+    key: 'tokens',
+    label: 'Access Tokens',
+    icon: 'ShieldCheck',
+    scope: 'user',
+    enabled: true,
+    default_enabled: true,
+    admin_only: false,
+    order: 1,
+  },
+];
+
+function mockApiClient(overrides: Partial<ApiClient> = {}): ApiClient {
+  return {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('createApiFeatureCatalogService', () => {
+  describe('getFeatureModules', () => {
+    it('returns all features when no scope is provided', async () => {
+      const client = mockApiClient({
+        get: vi.fn().mockResolvedValue(apiFeatures),
+      });
+      const service = createApiFeatureCatalogService(client);
+      const modules = await service.getFeatureModules();
+
+      expect(client.get).toHaveBeenCalledWith('/features');
+      expect(modules).toHaveLength(3);
+    });
+
+    it('passes scope as query parameter', async () => {
+      const client = mockApiClient({
+        get: vi.fn().mockResolvedValue(apiFeatures.filter((f) => f.scope === 'admin')),
+      });
+      const service = createApiFeatureCatalogService(client);
+      await service.getFeatureModules('admin');
+
+      expect(client.get).toHaveBeenCalledWith('/features?scope=admin');
+    });
+
+    it('maps snake_case API response to camelCase', async () => {
+      const client = mockApiClient({
+        get: vi.fn().mockResolvedValue([apiFeatures[0]]),
+      });
+      const service = createApiFeatureCatalogService(client);
+      const [module] = await service.getFeatureModules();
+
+      expect(module).toEqual({
+        key: 'users',
+        label: 'Users',
+        icon: 'Users',
+        scope: 'admin',
+        enabled: true,
+        defaultEnabled: true,
+        adminOnly: true,
+        order: 1,
+      });
+    });
+  });
+
+  describe('getUserFeaturePreferences', () => {
+    it('fetches preferences from /features/preferences', async () => {
+      const client = mockApiClient({
+        get: vi.fn().mockResolvedValue([{ feature_key: 'users', visible: true, sort_order: 1 }]),
+      });
+      const service = createApiFeatureCatalogService(client);
+      const prefs = await service.getUserFeaturePreferences();
+
+      expect(client.get).toHaveBeenCalledWith('/features/preferences');
+      expect(prefs).toEqual([{ featureKey: 'users', visible: true, sortOrder: 1 }]);
+    });
+  });
+
+  describe('updateUserFeaturePreferences', () => {
+    it('sends camelCase → snake_case and maps response back', async () => {
+      const client = mockApiClient({
+        put: vi.fn().mockResolvedValue([{ feature_key: 'users', visible: false, sort_order: 2 }]),
+      });
+      const service = createApiFeatureCatalogService(client);
+      const result = await service.updateUserFeaturePreferences([
+        { featureKey: 'users', visible: false, sortOrder: 2 },
+      ]);
+
+      expect(client.put).toHaveBeenCalledWith('/features/preferences', [
+        { feature_key: 'users', visible: false, sort_order: 2 },
+      ]);
+      expect(result).toEqual([{ featureKey: 'users', visible: false, sortOrder: 2 }]);
+    });
+  });
+
+  describe('toggleFeature', () => {
+    it('patches /features/:key and maps response', async () => {
+      const client = mockApiClient({
+        patch: vi.fn().mockResolvedValue({ ...apiFeatures[0], enabled: false }),
+      });
+      const service = createApiFeatureCatalogService(client);
+      const result = await service.toggleFeature('users', false);
+
+      expect(client.patch).toHaveBeenCalledWith('/features/users', { enabled: false });
+      expect(result.key).toBe('users');
+      expect(result.enabled).toBe(false);
+    });
+  });
+
+  it('implements IFeatureCatalogService interface', () => {
+    const client = mockApiClient();
+    const service: IFeatureCatalogService = createApiFeatureCatalogService(client);
+    expect(typeof service.getFeatureModules).toBe('function');
+    expect(typeof service.getUserFeaturePreferences).toBe('function');
+    expect(typeof service.updateUserFeaturePreferences).toBe('function');
+    expect(typeof service.toggleFeature).toBe('function');
+  });
+});
+
+describe('createMockFeatureCatalogService', () => {
+  it('returns all features when no scope is provided', async () => {
+    const service = createMockFeatureCatalogService();
+    const modules = await service.getFeatureModules();
+    expect(modules.length).toBeGreaterThan(0);
+    const scopes = new Set(modules.map((m) => m.scope));
+    expect(scopes.has('admin')).toBe(true);
+    expect(scopes.has('user')).toBe(true);
+  });
+
+  it('filters by admin scope', async () => {
+    const service = createMockFeatureCatalogService();
+    const modules = await service.getFeatureModules('admin');
+    expect(modules.length).toBeGreaterThan(0);
+    expect(modules.every((m) => m.scope === 'admin')).toBe(true);
+  });
+
+  it('filters by user scope', async () => {
+    const service = createMockFeatureCatalogService();
+    const modules = await service.getFeatureModules('user');
+    expect(modules.length).toBeGreaterThan(0);
+    expect(modules.every((m) => m.scope === 'user')).toBe(true);
+  });
+
+  it('returns empty preferences by default', async () => {
+    const service = createMockFeatureCatalogService();
+    expect(await service.getUserFeaturePreferences()).toEqual([]);
+  });
+
+  it('echoes preferences on update', async () => {
+    const service = createMockFeatureCatalogService();
+    const input = [{ featureKey: 'users', visible: true, sortOrder: 1 }];
+    expect(await service.updateUserFeaturePreferences(input)).toEqual(input);
+  });
+
+  it('toggles feature and returns correct state', async () => {
+    const service = createMockFeatureCatalogService();
+    const result = await service.toggleFeature('users', false);
+    expect(result.key).toBe('users');
+    expect(result.enabled).toBe(false);
+  });
+
+  it('implements IFeatureCatalogService interface', () => {
+    const service: IFeatureCatalogService = createMockFeatureCatalogService();
+    expect(typeof service.getFeatureModules).toBe('function');
+    expect(typeof service.getUserFeaturePreferences).toBe('function');
+    expect(typeof service.updateUserFeaturePreferences).toBe('function');
+    expect(typeof service.toggleFeature).toBe('function');
+  });
+});

--- a/web-next/packages/plugin-sdk/src/adapters/feature-catalog.adapter.ts
+++ b/web-next/packages/plugin-sdk/src/adapters/feature-catalog.adapter.ts
@@ -1,0 +1,165 @@
+/**
+ * Feature catalog adapter — delegates to an HTTP API for feature management.
+ *
+ * When a shared /api/v1/features endpoint exists, create the client
+ * with that base path — no other code needs to change.
+ */
+import type { ApiClient } from '@niuulabs/query';
+import type {
+  IFeatureCatalogService,
+  FeatureScope,
+  FeatureModule,
+  UserFeaturePreference,
+} from '../ports/feature-catalog.port';
+
+interface ApiFeatureModule {
+  key: string;
+  label: string;
+  icon: string;
+  scope: string;
+  enabled: boolean;
+  default_enabled: boolean;
+  admin_only: boolean;
+  order: number;
+}
+
+interface ApiUserFeaturePreference {
+  feature_key: string;
+  visible: boolean;
+  sort_order: number;
+}
+
+function mapFeatureModule(f: ApiFeatureModule): FeatureModule {
+  return {
+    key: f.key,
+    label: f.label,
+    icon: f.icon,
+    scope: f.scope as FeatureScope,
+    enabled: f.enabled,
+    defaultEnabled: f.default_enabled,
+    adminOnly: f.admin_only,
+    order: f.order,
+  };
+}
+
+function mapPreference(p: ApiUserFeaturePreference): UserFeaturePreference {
+  return {
+    featureKey: p.feature_key,
+    visible: p.visible,
+    sortOrder: p.sort_order,
+  };
+}
+
+/**
+ * Create a feature catalog service backed by an HTTP API.
+ * @param client - An ApiClient pointed at the service that hosts `/features`
+ */
+export function createApiFeatureCatalogService(client: ApiClient): IFeatureCatalogService {
+  return {
+    async getFeatureModules(scope?: FeatureScope): Promise<FeatureModule[]> {
+      const params = scope ? `?scope=${scope}` : '';
+      const response = await client.get<ApiFeatureModule[]>(`/features${params}`);
+      return response.map(mapFeatureModule);
+    },
+
+    async getUserFeaturePreferences(): Promise<UserFeaturePreference[]> {
+      const response = await client.get<ApiUserFeaturePreference[]>('/features/preferences');
+      return response.map(mapPreference);
+    },
+
+    async updateUserFeaturePreferences(
+      preferences: UserFeaturePreference[],
+    ): Promise<UserFeaturePreference[]> {
+      const body = preferences.map((p) => ({
+        feature_key: p.featureKey,
+        visible: p.visible,
+        sort_order: p.sortOrder,
+      }));
+      const response = await client.put<ApiUserFeaturePreference[]>('/features/preferences', body);
+      return response.map(mapPreference);
+    },
+
+    async toggleFeature(key: string, enabled: boolean): Promise<FeatureModule> {
+      const response = await client.patch<ApiFeatureModule>(`/features/${key}`, { enabled });
+      return mapFeatureModule(response);
+    },
+  };
+}
+
+/**
+ * Create a mock feature catalog service for development / testing.
+ */
+export function createMockFeatureCatalogService(): IFeatureCatalogService {
+  const all: FeatureModule[] = [
+    {
+      key: 'users',
+      label: 'Users',
+      icon: 'Users',
+      scope: 'admin',
+      enabled: true,
+      defaultEnabled: true,
+      adminOnly: true,
+      order: 1,
+    },
+    {
+      key: 'tenants',
+      label: 'Tenants',
+      icon: 'Building2',
+      scope: 'admin',
+      enabled: true,
+      defaultEnabled: true,
+      adminOnly: true,
+      order: 2,
+    },
+    {
+      key: 'tokens',
+      label: 'Access Tokens',
+      icon: 'ShieldCheck',
+      scope: 'user',
+      enabled: true,
+      defaultEnabled: true,
+      adminOnly: false,
+      order: 1,
+    },
+    {
+      key: 'credentials',
+      label: 'Credentials',
+      icon: 'KeyRound',
+      scope: 'user',
+      enabled: true,
+      defaultEnabled: true,
+      adminOnly: false,
+      order: 2,
+    },
+  ];
+
+  return {
+    async getFeatureModules(scope?: FeatureScope): Promise<FeatureModule[]> {
+      if (!scope) return all;
+      return all.filter((f) => f.scope === scope);
+    },
+
+    async getUserFeaturePreferences(): Promise<UserFeaturePreference[]> {
+      return [];
+    },
+
+    async updateUserFeaturePreferences(
+      prefs: UserFeaturePreference[],
+    ): Promise<UserFeaturePreference[]> {
+      return prefs;
+    },
+
+    async toggleFeature(key: string, enabled: boolean): Promise<FeatureModule> {
+      return {
+        key,
+        label: key,
+        icon: 'Box',
+        scope: 'user',
+        enabled,
+        defaultEnabled: true,
+        adminOnly: false,
+        order: 0,
+      };
+    },
+  };
+}

--- a/web-next/packages/plugin-sdk/src/adapters/identity.adapter.test.ts
+++ b/web-next/packages/plugin-sdk/src/adapters/identity.adapter.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { ApiClient } from '@niuulabs/query';
+import type { IIdentityService } from '../ports/identity.port';
+import { createApiIdentityService, createMockIdentityService } from './identity.adapter';
+
+function mockApiClient(overrides: Partial<ApiClient> = {}): ApiClient {
+  return {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('createApiIdentityService', () => {
+  it('fetches identity from /me and maps snake_case to camelCase', async () => {
+    const client = mockApiClient({
+      get: vi.fn().mockResolvedValue({
+        user_id: 'u-123',
+        email: 'alice@example.com',
+        tenant_id: 't-456',
+        roles: ['admin', 'editor'],
+        display_name: 'Alice',
+        status: 'active',
+      }),
+    });
+
+    const service = createApiIdentityService(client);
+    const identity = await service.getIdentity();
+
+    expect(client.get).toHaveBeenCalledWith('/me');
+    expect(identity).toEqual({
+      userId: 'u-123',
+      email: 'alice@example.com',
+      tenantId: 't-456',
+      roles: ['admin', 'editor'],
+      displayName: 'Alice',
+      status: 'active',
+    });
+  });
+
+  it('returns all required AppIdentity fields', async () => {
+    const client = mockApiClient({
+      get: vi.fn().mockResolvedValue({
+        user_id: 'x',
+        email: 'x@x.com',
+        tenant_id: 'x',
+        roles: [],
+        display_name: 'X',
+        status: 'inactive',
+      }),
+    });
+
+    const identity = await createApiIdentityService(client).getIdentity();
+    expect(identity).toHaveProperty('userId');
+    expect(identity).toHaveProperty('email');
+    expect(identity).toHaveProperty('tenantId');
+    expect(identity).toHaveProperty('roles');
+    expect(identity).toHaveProperty('displayName');
+    expect(identity).toHaveProperty('status');
+  });
+
+  it('implements IIdentityService interface', () => {
+    const client = mockApiClient();
+    const service: IIdentityService = createApiIdentityService(client);
+    expect(typeof service.getIdentity).toBe('function');
+  });
+});
+
+describe('createMockIdentityService', () => {
+  it('returns default dev identity', async () => {
+    const service = createMockIdentityService();
+    const identity = await service.getIdentity();
+    expect(identity.userId).toBe('dev-user');
+    expect(identity.email).toBe('dev@localhost');
+    expect(identity.tenantId).toBe('default');
+    expect(identity.roles).toContain('volundr:admin');
+    expect(identity.displayName).toBe('Dev User');
+    expect(identity.status).toBe('active');
+  });
+
+  it('applies overrides', async () => {
+    const service = createMockIdentityService({
+      userId: 'custom-user',
+      roles: ['reader'],
+    });
+    const identity = await service.getIdentity();
+    expect(identity.userId).toBe('custom-user');
+    expect(identity.roles).toEqual(['reader']);
+    expect(identity.email).toBe('dev@localhost');
+  });
+
+  it('implements IIdentityService interface', () => {
+    const service: IIdentityService = createMockIdentityService();
+    expect(typeof service.getIdentity).toBe('function');
+  });
+});

--- a/web-next/packages/plugin-sdk/src/adapters/identity.adapter.ts
+++ b/web-next/packages/plugin-sdk/src/adapters/identity.adapter.ts
@@ -1,0 +1,57 @@
+/**
+ * Identity adapter — fetches the current user's identity from the API.
+ *
+ * Reuses the existing /api/v1/volundr/me endpoint. When the backend
+ * exposes a shared /api/v1/identity/me in the future, update the
+ * basePath here — no other code needs to change.
+ */
+import type { ApiClient } from '@niuulabs/query';
+import type { AppIdentity, IIdentityService } from '../ports/identity.port';
+
+interface ApiIdentityResponse {
+  user_id: string;
+  email: string;
+  tenant_id: string;
+  roles: string[];
+  display_name: string;
+  status: string;
+}
+
+/**
+ * Create an identity service backed by an HTTP API.
+ * @param client - An ApiClient pointed at the service that hosts `/me`
+ */
+export function createApiIdentityService(client: ApiClient): IIdentityService {
+  return {
+    async getIdentity(): Promise<AppIdentity> {
+      const r = await client.get<ApiIdentityResponse>('/me');
+      return {
+        userId: r.user_id,
+        email: r.email,
+        tenantId: r.tenant_id,
+        roles: r.roles,
+        displayName: r.display_name,
+        status: r.status,
+      };
+    },
+  };
+}
+
+/**
+ * Create a mock identity service for development / testing.
+ */
+export function createMockIdentityService(overrides: Partial<AppIdentity> = {}): IIdentityService {
+  return {
+    async getIdentity(): Promise<AppIdentity> {
+      return {
+        userId: 'dev-user',
+        email: 'dev@localhost',
+        tenantId: 'default',
+        roles: ['volundr:admin'],
+        displayName: 'Dev User',
+        status: 'active',
+        ...overrides,
+      };
+    },
+  };
+}

--- a/web-next/packages/plugin-sdk/src/index.ts
+++ b/web-next/packages/plugin-sdk/src/index.ts
@@ -10,3 +10,19 @@ export {
   type PluginConfig,
   type ServiceConfig,
 } from './config';
+
+// Ports
+export type { AppIdentity, IIdentityService } from './ports/identity.port';
+export type {
+  FeatureScope,
+  FeatureModule,
+  UserFeaturePreference,
+  IFeatureCatalogService,
+} from './ports/feature-catalog.port';
+
+// Adapters
+export { createApiIdentityService, createMockIdentityService } from './adapters/identity.adapter';
+export {
+  createApiFeatureCatalogService,
+  createMockFeatureCatalogService,
+} from './adapters/feature-catalog.adapter';

--- a/web-next/packages/plugin-sdk/src/ports/feature-catalog.port.ts
+++ b/web-next/packages/plugin-sdk/src/ports/feature-catalog.port.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared feature catalog port — manages feature modules and user preferences.
+ *
+ * The Settings and Admin pages use this to discover which sections
+ * to render, independently of any specific module's service.
+ */
+
+export type FeatureScope = 'admin' | 'user' | 'session';
+
+export interface FeatureModule {
+  key: string;
+  label: string;
+  icon: string;
+  scope: FeatureScope;
+  enabled: boolean;
+  defaultEnabled: boolean;
+  adminOnly: boolean;
+  order: number;
+}
+
+export interface UserFeaturePreference {
+  featureKey: string;
+  visible: boolean;
+  sortOrder: number;
+}
+
+export interface IFeatureCatalogService {
+  getFeatureModules(scope?: FeatureScope): Promise<FeatureModule[]>;
+  getUserFeaturePreferences(): Promise<UserFeaturePreference[]>;
+  updateUserFeaturePreferences(
+    preferences: UserFeaturePreference[],
+  ): Promise<UserFeaturePreference[]>;
+  toggleFeature(key: string, enabled: boolean): Promise<FeatureModule>;
+}

--- a/web-next/packages/plugin-sdk/src/ports/identity.port.ts
+++ b/web-next/packages/plugin-sdk/src/ports/identity.port.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared identity port — service-agnostic identity interface.
+ *
+ * Modules that need to check identity or roles import from here
+ * instead of coupling to a specific service.
+ */
+
+export interface AppIdentity {
+  userId: string;
+  email: string;
+  tenantId: string;
+  roles: string[];
+  displayName: string;
+  status: string;
+}
+
+export interface IIdentityService {
+  getIdentity(): Promise<AppIdentity>;
+}

--- a/web-next/packages/plugin-sdk/tsup.config.ts
+++ b/web-next/packages/plugin-sdk/tsup.config.ts
@@ -6,5 +6,5 @@ export default defineConfig({
   dts: true,
   sourcemap: true,
   clean: true,
-  external: ['react', '@tanstack/react-router'],
+  external: ['react', '@tanstack/react-router', '@niuulabs/query'],
 });

--- a/web-next/packages/query/src/client.test.ts
+++ b/web-next/packages/query/src/client.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  createApiClient,
+  ApiClientError,
+  setTokenProvider,
+  getAccessToken,
+  type ApiClient,
+} from './client';
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', mockFetch);
+  setTokenProvider(null);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(data),
+  } as Response;
+}
+
+function noContentResponse(): Response {
+  return { ok: true, status: 204, json: () => Promise.reject('no body') } as unknown as Response;
+}
+
+describe('createApiClient', () => {
+  let client: ApiClient;
+
+  beforeEach(() => {
+    client = createApiClient('/api/v1/test');
+  });
+
+  describe('get', () => {
+    it('sends a GET request to the correct URL', async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ id: 1 }));
+      const result = await client.get<{ id: number }>('/items');
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/v1/test/items',
+        expect.objectContaining({ method: 'GET' }),
+      );
+      expect(result).toEqual({ id: 1 });
+    });
+  });
+
+  describe('post', () => {
+    it('sends a POST request with JSON body', async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ created: true }));
+      await client.post('/items', { name: 'test' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/v1/test/items',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ name: 'test' }),
+        }),
+      );
+    });
+
+    it('sends a POST without body when not provided', async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }));
+      await client.post('/items');
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/v1/test/items',
+        expect.objectContaining({ method: 'POST', body: undefined }),
+      );
+    });
+  });
+
+  describe('put', () => {
+    it('sends a PUT request with JSON body', async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ updated: true }));
+      await client.put('/items/1', { name: 'updated' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/v1/test/items/1',
+        expect.objectContaining({
+          method: 'PUT',
+          body: JSON.stringify({ name: 'updated' }),
+        }),
+      );
+    });
+  });
+
+  describe('patch', () => {
+    it('sends a PATCH request with JSON body', async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ patched: true }));
+      await client.patch('/items/1', { enabled: false });
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/v1/test/items/1',
+        expect.objectContaining({
+          method: 'PATCH',
+          body: JSON.stringify({ enabled: false }),
+        }),
+      );
+    });
+  });
+
+  describe('delete', () => {
+    it('sends a DELETE request without body', async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ deleted: true }));
+      await client.delete('/items/1');
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/v1/test/items/1',
+        expect.objectContaining({ method: 'DELETE' }),
+      );
+    });
+
+    it('sends a DELETE request with body when provided', async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ deleted: true }));
+      await client.delete('/items/1', { reason: 'test' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/v1/test/items/1',
+        expect.objectContaining({
+          method: 'DELETE',
+          body: JSON.stringify({ reason: 'test' }),
+        }),
+      );
+    });
+  });
+
+  describe('204 No Content', () => {
+    it('returns undefined for 204 responses', async () => {
+      mockFetch.mockResolvedValueOnce(noContentResponse());
+      const result = await client.delete('/items/1');
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws ApiClientError on non-2xx responses', async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ detail: 'Not found' }, 404));
+      await expect(client.get('/missing')).rejects.toThrow(ApiClientError);
+    });
+
+    it('includes status and detail in ApiClientError', async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ detail: 'Forbidden' }, 403));
+      try {
+        await client.get('/secret');
+        expect.unreachable('should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ApiClientError);
+        const apiErr = err as ApiClientError;
+        expect(apiErr.status).toBe(403);
+        expect(apiErr.detail).toBe('Forbidden');
+        expect(apiErr.message).toContain('403');
+      }
+    });
+
+    it('uses "Unknown error" when detail is missing', async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({}, 500));
+      try {
+        await client.get('/broken');
+        expect.unreachable('should have thrown');
+      } catch (err) {
+        const apiErr = err as ApiClientError;
+        expect(apiErr.detail).toBe('Unknown error');
+      }
+    });
+  });
+
+  describe('Content-Type header', () => {
+    it('sets Content-Type to application/json by default', async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({}));
+      await client.get('/items');
+      const headers = mockFetch.mock.calls[0][1].headers as Record<string, string>;
+      expect(headers['Content-Type']).toBe('application/json');
+    });
+  });
+});
+
+describe('token provider', () => {
+  beforeEach(() => {
+    setTokenProvider(null);
+  });
+
+  it('getAccessToken returns null when no provider is set', () => {
+    expect(getAccessToken()).toBeNull();
+  });
+
+  it('getAccessToken returns token from provider', () => {
+    setTokenProvider(() => 'test-token');
+    expect(getAccessToken()).toBe('test-token');
+  });
+
+  it('getAccessToken returns null when provider returns null', () => {
+    setTokenProvider(() => null);
+    expect(getAccessToken()).toBeNull();
+  });
+
+  it('includes Authorization header when token provider is set', async () => {
+    setTokenProvider(() => 'my-jwt');
+    const client = createApiClient('/api');
+    mockFetch.mockResolvedValueOnce(jsonResponse({}));
+    await client.get('/data');
+    const headers = mockFetch.mock.calls[0][1].headers as Record<string, string>;
+    expect(headers['Authorization']).toBe('Bearer my-jwt');
+  });
+
+  it('omits Authorization header when no token provider', async () => {
+    const client = createApiClient('/api');
+    mockFetch.mockResolvedValueOnce(jsonResponse({}));
+    await client.get('/data');
+    const headers = mockFetch.mock.calls[0][1].headers as Record<string, string>;
+    expect(headers['Authorization']).toBeUndefined();
+  });
+
+  it('omits Authorization header when provider returns null', async () => {
+    setTokenProvider(() => null);
+    const client = createApiClient('/api');
+    mockFetch.mockResolvedValueOnce(jsonResponse({}));
+    await client.get('/data');
+    const headers = mockFetch.mock.calls[0][1].headers as Record<string, string>;
+    expect(headers['Authorization']).toBeUndefined();
+  });
+
+  it('clears provider when set to null', () => {
+    setTokenProvider(() => 'token');
+    expect(getAccessToken()).toBe('token');
+    setTokenProvider(null);
+    expect(getAccessToken()).toBeNull();
+  });
+});

--- a/web-next/packages/query/src/client.ts
+++ b/web-next/packages/query/src/client.ts
@@ -1,0 +1,136 @@
+/**
+ * HTTP Client Factory
+ *
+ * Creates API clients for different backend services.
+ * Each service has its own base path: /api/v1/volundr, /api/v1/tyr, etc.
+ */
+
+export interface ApiError {
+  detail: string;
+}
+
+export class ApiClientError extends Error {
+  status: number;
+  detail?: string;
+
+  constructor(message: string, status: number, detail?: string) {
+    super(message);
+    this.name = 'ApiClientError';
+    this.status = status;
+    this.detail = detail;
+  }
+}
+
+export interface ApiClient {
+  get<T>(endpoint: string): Promise<T>;
+  post<T>(endpoint: string, body?: unknown): Promise<T>;
+  put<T>(endpoint: string, body: unknown): Promise<T>;
+  patch<T>(endpoint: string, body: unknown): Promise<T>;
+  delete<T>(endpoint: string, body?: unknown): Promise<T>;
+}
+
+export type TokenProvider = () => string | null;
+
+/**
+ * Global token provider. Set by AuthProvider to inject Bearer tokens.
+ * Returns null when auth is disabled (dev / allow-all mode).
+ */
+let tokenProvider: TokenProvider | null = null;
+
+/**
+ * Register a function that returns the current access token.
+ * Called once by AuthProvider on mount.
+ */
+export function setTokenProvider(provider: TokenProvider | null): void {
+  tokenProvider = provider;
+}
+
+/**
+ * Return the current access token, or null when auth is disabled.
+ */
+export function getAccessToken(): string | null {
+  return tokenProvider?.() ?? null;
+}
+
+/**
+ * Create an API client for a specific service.
+ * @param basePath - Service base path, e.g., '/api/v1/volundr'
+ */
+export function createApiClient(basePath: string): ApiClient {
+  async function request<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
+    const url = `${basePath}${endpoint}`;
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      ...(options.headers as Record<string, string>),
+    };
+
+    const token = tokenProvider?.();
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    const config: RequestInit = {
+      ...options,
+      headers,
+    };
+
+    const response = await fetch(url, config);
+
+    // Handle no-content responses
+    if (response.status === 204) {
+      return undefined as T;
+    }
+
+    // Parse JSON response
+    const data = await response.json();
+
+    // Handle error responses
+    if (!response.ok) {
+      const errorDetail = (data as ApiError)?.detail ?? 'Unknown error';
+      throw new ApiClientError(
+        `API request failed: ${response.status}`,
+        response.status,
+        errorDetail,
+      );
+    }
+
+    return data as T;
+  }
+
+  return {
+    get<T>(endpoint: string): Promise<T> {
+      return request<T>(endpoint, { method: 'GET' });
+    },
+
+    post<T>(endpoint: string, body?: unknown): Promise<T> {
+      return request<T>(endpoint, {
+        method: 'POST',
+        body: body ? JSON.stringify(body) : undefined,
+      });
+    },
+
+    put<T>(endpoint: string, body: unknown): Promise<T> {
+      return request<T>(endpoint, {
+        method: 'PUT',
+        body: JSON.stringify(body),
+      });
+    },
+
+    patch<T>(endpoint: string, body: unknown): Promise<T> {
+      return request<T>(endpoint, {
+        method: 'PATCH',
+        body: JSON.stringify(body),
+      });
+    },
+
+    delete<T>(endpoint: string, body?: unknown): Promise<T> {
+      const opts: RequestInit = { method: 'DELETE' };
+      if (body !== undefined) {
+        opts.headers = { 'Content-Type': 'application/json' };
+        opts.body = JSON.stringify(body);
+      }
+      return request<T>(endpoint, opts);
+    },
+  };
+}

--- a/web-next/packages/query/src/index.ts
+++ b/web-next/packages/query/src/index.ts
@@ -1,5 +1,15 @@
 import { QueryClient, type QueryClientConfig } from '@tanstack/react-query';
 
+export {
+  createApiClient,
+  setTokenProvider,
+  getAccessToken,
+  ApiClientError,
+  type ApiClient,
+  type ApiError,
+  type TokenProvider,
+} from './client';
+
 export function createQueryClient(overrides: QueryClientConfig = {}): QueryClient {
   return new QueryClient({
     ...overrides,

--- a/web-next/pnpm-lock.yaml
+++ b/web-next/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
       '@niuulabs/plugin-sdk':
         specifier: workspace:*
         version: link:../plugin-sdk
+      '@niuulabs/query':
+        specifier: workspace:*
+        version: link:../query
       '@niuulabs/ui':
         specifier: workspace:*
         version: link:../ui
@@ -196,6 +199,9 @@ importers:
 
   packages/plugin-sdk:
     dependencies:
+      '@niuulabs/query':
+        specifier: workspace:*
+        version: link:../query
       zod:
         specifier: ^3.24.1
         version: 3.25.76

--- a/web-next/vitest.config.ts
+++ b/web-next/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
         '**/*.test.{ts,tsx}',
         '**/index.{ts,tsx}',
         '**/ports.ts',
+        '**/ports/*.ts',
         '**/*.d.ts',
       ],
       thresholds: {


### PR DESCRIPTION
## Summary

Copies shared infrastructure from `web/` into `web-next/` packages as self-contained starting points. No cross-imports from `web/` — `web-next/` is fully self-contained for these concerns.

- **HTTP client** (`@niuulabs/query`): `ApiClient` interface, `ApiClientError`, `createApiClient()` factory, `setTokenProvider`/`getAccessToken` for Bearer token injection
- **Identity port + adapter** (`@niuulabs/plugin-sdk`): `IIdentityService`, `AppIdentity`, `createApiIdentityService` (HTTP), `createMockIdentityService`
- **Feature catalog port + adapter** (`@niuulabs/plugin-sdk`): `IFeatureCatalogService`, `FeatureModule`, `UserFeaturePreference`, `createApiFeatureCatalogService` (HTTP), `createMockFeatureCatalogService`
- **FeatureCatalogProvider** enhanced to accept optional `IFeatureCatalogService` via `service` prop — delegates to backend when provided, falls back to config-only otherwise
- **Hello HTTP adapter**: `createHttpHelloService(client)` + `services.ts` wired to select HTTP vs mock based on config mode
- **Playwright e2e**: HTTP client round-trip with route interception, loading state, and error state specs

## Files changed

### New files
| File | Purpose |
|------|---------|
| `packages/query/src/client.ts` | HTTP client factory (copied from `web/`) |
| `packages/query/src/client.test.ts` | 19 tests for HTTP client |
| `packages/plugin-sdk/src/ports/identity.port.ts` | `IIdentityService` interface |
| `packages/plugin-sdk/src/ports/feature-catalog.port.ts` | `IFeatureCatalogService` interface |
| `packages/plugin-sdk/src/adapters/identity.adapter.ts` | API + mock identity adapters |
| `packages/plugin-sdk/src/adapters/identity.adapter.test.ts` | 6 identity adapter tests |
| `packages/plugin-sdk/src/adapters/feature-catalog.adapter.ts` | API + mock feature catalog adapters |
| `packages/plugin-sdk/src/adapters/feature-catalog.adapter.test.ts` | 14 feature catalog adapter tests |
| `packages/plugin-hello/src/adapters/http.ts` | HTTP hello adapter for e2e testing |
| `packages/plugin-hello/src/adapters/http.test.ts` | 3 HTTP hello adapter tests |
| `e2e/http-client.spec.ts` | Playwright e2e specs (3 tests) |

### Modified files
| File | Change |
|------|--------|
| `packages/query/src/index.ts` | Re-export HTTP client types and functions |
| `packages/plugin-sdk/src/index.ts` | Export ports and adapter factories |
| `packages/plugin-sdk/src/FeatureCatalog.tsx` | Accept optional `service` prop |
| `packages/plugin-sdk/src/FeatureCatalog.test.tsx` | Tests for service delegation |
| `packages/plugin-sdk/package.json` | Add `@niuulabs/query` dep |
| `packages/plugin-hello/src/index.tsx` | Export HTTP adapter |
| `packages/plugin-hello/package.json` | Add `@niuulabs/query` dep |
| `apps/niuu/src/services.ts` | Support HTTP mode for hello service |
| `vitest.config.ts` | Exclude `ports/*.ts` from coverage |

## Test plan

- [x] All 83 unit tests passing (19 test files)
- [x] Coverage ≥ 85% (99.35% statements, 92.05% branches)
- [x] TypeScript typecheck passes
- [x] ESLint clean (0 errors, 0 warnings)
- [x] Prettier formatted
- [x] No cross-imports from `web/` verified
- [ ] CI pipeline green
- [ ] Playwright e2e specs pass in CI

Closes NIU-688

🤖 Generated with [Claude Code](https://claude.com/claude-code)