### PR TITLE
feat(shell): wire TanStack Router with plugin-contributed routes

### DIFF
--- a/web-next/e2e/routing.spec.ts
+++ b/web-next/e2e/routing.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('routing', () => {
+  test('deep link /hello renders the hello page', async ({ page }) => {
+    await page.goto('/hello');
+    await expect(page.getByText('hello · smoke test')).toBeVisible();
+    await expect(page.getByText('hello from the mock adapter')).toBeVisible({
+      timeout: 5000,
+    });
+  });
+
+  test('/ redirects to the first plugin', async ({ page }) => {
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/hello/);
+    await expect(page.getByText('hello · smoke test')).toBeVisible();
+  });
+
+  test('unknown path shows 404', async ({ page }) => {
+    await page.goto('/nonexistent');
+    await expect(page.getByText('404')).toBeVisible();
+    await expect(page.getByText('Page not found')).toBeVisible();
+  });
+
+  test('rail navigation updates URL and content', async ({ page }) => {
+    await page.goto('/hello');
+    await expect(page.getByText('hello · smoke test')).toBeVisible();
+
+    // Verify the rail button is active
+    const helloButton = page.getByTitle('Hello · smoke test plugin');
+    await expect(helloButton).toBeVisible();
+  });
+
+  test('localStorage.niuu.active follows router state', async ({ page }) => {
+    await page.goto('/hello');
+    await expect(page.getByText('hello · smoke test')).toBeVisible();
+
+    const stored = await page.evaluate(() => localStorage.getItem('niuu.active'));
+    expect(stored).toBe('hello');
+  });
+});

--- a/web-next/packages/plugin-hello/package.json
+++ b/web-next/packages/plugin-hello/package.json
@@ -26,6 +26,7 @@
   },
   "peerDependencies": {
     "@tanstack/react-query": "^5.62.0",
+    "@tanstack/react-router": "^1.95.0",
     "react": "^19.0.0"
   },
   "dependencies": {
@@ -34,6 +35,7 @@
   },
   "devDependencies": {
     "@tanstack/react-query": "^5.62.0",
+    "@tanstack/react-router": "^1.95.0",
     "@types/react": "^19.0.7",
     "react": "^19.0.0",
     "tsup": "^8.3.5",

--- a/web-next/packages/plugin-hello/src/index.tsx
+++ b/web-next/packages/plugin-hello/src/index.tsx
@@ -1,3 +1,4 @@
+import { createRoute, type AnyRoute } from '@tanstack/react-router';
 import { definePlugin } from '@niuulabs/plugin-sdk';
 import { HelloPage } from './ui/HelloPage';
 
@@ -6,7 +7,13 @@ export const helloPlugin = definePlugin({
   rune: 'ᚺ',
   title: 'Hello',
   subtitle: 'smoke test plugin',
-  render: () => <HelloPage />,
+  routes: (rootRoute: AnyRoute) => [
+    createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/hello',
+      component: HelloPage,
+    }),
+  ],
 });
 
 export { createMockHelloService } from './adapters/mock';

--- a/web-next/packages/plugin-hello/tsup.config.ts
+++ b/web-next/packages/plugin-hello/tsup.config.ts
@@ -6,5 +6,11 @@ export default defineConfig({
   dts: true,
   sourcemap: true,
   clean: true,
-  external: ['react', '@tanstack/react-query', '@niuulabs/plugin-sdk', '@niuulabs/ui'],
+  external: [
+    'react',
+    '@tanstack/react-query',
+    '@tanstack/react-router',
+    '@niuulabs/plugin-sdk',
+    '@niuulabs/ui',
+  ],
 });

--- a/web-next/packages/shell/src/NotFound.test.tsx
+++ b/web-next/packages/shell/src/NotFound.test.tsx
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { NotFound } from './NotFound';
+
+describe('NotFound', () => {
+  it('renders 404 heading and message', () => {
+    render(<NotFound />);
+    expect(screen.getByText('404')).toBeInTheDocument();
+    expect(screen.getByText('Page not found')).toBeInTheDocument();
+  });
+});

--- a/web-next/packages/shell/src/NotFound.tsx
+++ b/web-next/packages/shell/src/NotFound.tsx
@@ -1,0 +1,11 @@
+import { Rune } from '@niuulabs/ui';
+
+export function NotFound() {
+  return (
+    <div className="niuu-shell__not-found">
+      <Rune glyph="?" size={48} />
+      <h2 className="niuu-shell__not-found-title">404</h2>
+      <p className="niuu-shell__not-found-text">Page not found</p>
+    </div>
+  );
+}

--- a/web-next/packages/shell/src/Shell.css
+++ b/web-next/packages/shell/src/Shell.css
@@ -158,3 +158,25 @@
   color: var(--color-text-faint);
   margin: 0 var(--space-2);
 }
+
+/* ── Not Found ────────────────────────────────────── */
+.niuu-shell__not-found {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  gap: var(--space-3);
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+}
+.niuu-shell__not-found-title {
+  margin: 0;
+  font-size: var(--text-2xl);
+  font-weight: 700;
+  color: var(--color-text-secondary);
+}
+.niuu-shell__not-found-text {
+  margin: 0;
+  font-size: var(--text-sm);
+}

--- a/web-next/packages/shell/src/Shell.stories.tsx
+++ b/web-next/packages/shell/src/Shell.stories.tsx
@@ -1,0 +1,95 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { createRoute, createMemoryHistory } from '@tanstack/react-router';
+import { ConfigProvider, FeatureCatalogProvider, definePlugin } from '@niuulabs/plugin-sdk';
+import { Rune } from '@niuulabs/ui';
+import { Shell } from './Shell';
+import './Shell.css';
+
+const alphaPlugin = definePlugin({
+  id: 'alpha',
+  rune: 'ᚨ',
+  title: 'Alpha',
+  subtitle: 'first plugin',
+  routes: (root) => [
+    createRoute({
+      getParentRoute: () => root,
+      path: '/alpha',
+      component: () => (
+        <div style={{ padding: 'var(--space-6)' }}>
+          <h2>Alpha Plugin</h2>
+          <p style={{ color: 'var(--color-text-secondary)' }}>This is the Alpha plugin content.</p>
+        </div>
+      ),
+    }),
+  ],
+});
+
+const betaPlugin = definePlugin({
+  id: 'beta',
+  rune: 'ᛒ',
+  title: 'Beta',
+  subtitle: 'second plugin',
+  subnav: () => (
+    <div style={{ padding: 'var(--space-3)' }}>
+      <strong style={{ color: 'var(--color-text-secondary)' }}>Subnav</strong>
+    </div>
+  ),
+  topbarRight: () => <Rune glyph="ᛒ" size={16} muted />,
+  routes: (root) => [
+    createRoute({
+      getParentRoute: () => root,
+      path: '/beta',
+      component: () => (
+        <div style={{ padding: 'var(--space-6)' }}>
+          <h2>Beta Plugin</h2>
+          <p style={{ color: 'var(--color-text-secondary)' }}>
+            This plugin demonstrates subnav and topbarRight.
+          </p>
+        </div>
+      ),
+    }),
+  ],
+});
+
+const mockPlugins = [alphaPlugin, betaPlugin];
+
+const meta: Meta<typeof Shell> = {
+  title: 'Shell/Shell',
+  component: Shell,
+  decorators: [
+    (Story) => (
+      <ConfigProvider value={{ theme: 'ice', plugins: {}, services: {} }}>
+        <FeatureCatalogProvider>
+          <Story />
+        </FeatureCatalogProvider>
+      </ConfigProvider>
+    ),
+  ],
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Shell>;
+
+export const Default: Story = {
+  args: {
+    plugins: mockPlugins,
+    history: createMemoryHistory({ initialEntries: ['/alpha'] }),
+  },
+};
+
+export const WithSubnav: Story = {
+  args: {
+    plugins: mockPlugins,
+    history: createMemoryHistory({ initialEntries: ['/beta'] }),
+  },
+};
+
+export const NotFoundPage: Story = {
+  args: {
+    plugins: mockPlugins,
+    history: createMemoryHistory({ initialEntries: ['/unknown-path'] }),
+  },
+};

--- a/web-next/packages/shell/src/Shell.test.tsx
+++ b/web-next/packages/shell/src/Shell.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import { createRoute, createMemoryHistory } from '@tanstack/react-router';
 import { ConfigProvider, FeatureCatalogProvider, definePlugin } from '@niuulabs/plugin-sdk';
 import { Shell } from './Shell';
 
@@ -8,7 +9,13 @@ const pluginA = definePlugin({
   rune: 'ᚨ',
   title: 'Alpha',
   subtitle: 'first',
-  render: () => <div data-testid="alpha-content">alpha-rendered</div>,
+  routes: (root) => [
+    createRoute({
+      getParentRoute: () => root,
+      path: '/alpha',
+      component: () => <div data-testid="alpha-content">alpha-rendered</div>,
+    }),
+  ],
 });
 
 const pluginB = definePlugin({
@@ -16,7 +23,13 @@ const pluginB = definePlugin({
   rune: 'ᛒ',
   title: 'Beta',
   subtitle: 'second',
-  render: () => <div data-testid="beta-content">beta-rendered</div>,
+  routes: (root) => [
+    createRoute({
+      getParentRoute: () => root,
+      path: '/beta',
+      component: () => <div data-testid="beta-content">beta-rendered</div>,
+    }),
+  ],
 });
 
 function wrap(
@@ -42,24 +55,120 @@ describe('Shell', () => {
     localStorage.clear();
   });
 
-  it('renders the first enabled plugin by default', () => {
-    wrap(<Shell plugins={[pluginA, pluginB]} />);
-    expect(screen.getByTestId('alpha-content')).toBeInTheDocument();
+  it('renders the first enabled plugin by default', async () => {
+    wrap(
+      <Shell
+        plugins={[pluginA, pluginB]}
+        history={createMemoryHistory({ initialEntries: ['/alpha'] })}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('alpha-content')).toBeInTheDocument();
+    });
     expect(screen.queryByTestId('beta-content')).not.toBeInTheDocument();
   });
 
-  it('switches active plugin on rail click and persists to localStorage', () => {
-    wrap(<Shell plugins={[pluginA, pluginB]} />);
+  it('switches active plugin on rail click and persists to localStorage', async () => {
+    wrap(
+      <Shell
+        plugins={[pluginA, pluginB]}
+        history={createMemoryHistory({ initialEntries: ['/alpha'] })}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('alpha-content')).toBeInTheDocument();
+    });
     fireEvent.click(screen.getByTitle('Beta · second'));
-    expect(screen.getByTestId('beta-content')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('beta-content')).toBeInTheDocument();
+    });
     expect(localStorage.getItem('niuu.active')).toBe('beta');
   });
 
-  it('hides plugins disabled via config', () => {
-    wrap(<Shell plugins={[pluginA, pluginB]} />, {
-      alpha: { enabled: false, order: 1 },
+  it('hides plugins disabled via config', async () => {
+    wrap(
+      <Shell
+        plugins={[pluginA, pluginB]}
+        history={createMemoryHistory({ initialEntries: ['/beta'] })}
+      />,
+      {
+        alpha: { enabled: false, order: 1 },
+      },
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('beta-content')).toBeInTheDocument();
     });
     expect(screen.queryByTitle('Alpha · first')).not.toBeInTheDocument();
-    expect(screen.getByTestId('beta-content')).toBeInTheDocument();
+  });
+
+  it('renders 404 for unknown paths', async () => {
+    wrap(
+      <Shell
+        plugins={[pluginA]}
+        history={createMemoryHistory({ initialEntries: ['/nonexistent'] })}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText('404')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Page not found')).toBeInTheDocument();
+  });
+
+  it('redirects / to the first plugin', async () => {
+    wrap(
+      <Shell
+        plugins={[pluginA, pluginB]}
+        history={createMemoryHistory({ initialEntries: ['/'] })}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('alpha-content')).toBeInTheDocument();
+    });
+  });
+
+  it('syncs localStorage from router state', async () => {
+    wrap(
+      <Shell
+        plugins={[pluginA, pluginB]}
+        history={createMemoryHistory({ initialEntries: ['/beta'] })}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('beta-content')).toBeInTheDocument();
+    });
+    expect(localStorage.getItem('niuu.active')).toBe('beta');
+  });
+
+  it('renders subnav when plugin provides one', async () => {
+    const pluginWithSubnav = definePlugin({
+      id: 'sub',
+      rune: 'ᛊ',
+      title: 'Sub',
+      subtitle: 'subnav test',
+      subnav: () => <div data-testid="subnav-content">subnav</div>,
+      routes: (root) => [
+        createRoute({
+          getParentRoute: () => root,
+          path: '/sub',
+          component: () => <div data-testid="sub-content">sub-rendered</div>,
+        }),
+      ],
+    });
+    wrap(
+      <Shell
+        plugins={[pluginWithSubnav]}
+        history={createMemoryHistory({ initialEntries: ['/sub'] })}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('subnav-content')).toBeInTheDocument();
+    });
+  });
+
+  it('renders with no plugins', async () => {
+    wrap(<Shell plugins={[]} history={createMemoryHistory({ initialEntries: ['/'] })} />);
+    await waitFor(() => {
+      expect(screen.getByText('0 plugins loaded')).toBeInTheDocument();
+    });
   });
 });

--- a/web-next/packages/shell/src/Shell.tsx
+++ b/web-next/packages/shell/src/Shell.tsx
@@ -1,22 +1,29 @@
-import { useMemo, useState, useCallback, type ReactNode } from 'react';
-import clsx from 'clsx';
-import {
-  useConfig,
-  useFeatureCatalog,
-  type PluginDescriptor,
-  type PluginCtx,
-} from '@niuulabs/plugin-sdk';
-import { LiveBadge, Kbd } from '@niuulabs/ui';
+import { createContext, useMemo } from 'react';
+import { RouterProvider, type RouterHistory } from '@tanstack/react-router';
+import { useFeatureCatalog, type PluginDescriptor } from '@niuulabs/plugin-sdk';
+import { composeRoutes } from './composeRoutes';
 import './Shell.css';
+
+export interface ShellContextValue {
+  plugins: PluginDescriptor[];
+  brand: string;
+  version: string;
+}
+
+export const ShellContext = createContext<ShellContextValue>({
+  plugins: [],
+  brand: 'ᚾ',
+  version: '0.0.1',
+});
 
 interface ShellProps {
   plugins: PluginDescriptor[];
   brand?: string;
   version?: string;
+  history?: RouterHistory;
 }
 
-export function Shell({ plugins, brand = 'ᚾ', version = '0.0.1' }: ShellProps) {
-  const config = useConfig();
+export function Shell({ plugins, brand = 'ᚾ', version = '0.0.1', history }: ShellProps) {
   const features = useFeatureCatalog();
 
   const enabled = useMemo(
@@ -27,93 +34,16 @@ export function Shell({ plugins, brand = 'ᚾ', version = '0.0.1' }: ShellProps)
     [plugins, features],
   );
 
-  const [activeId, setActiveId] = useState<string | null>(() => {
-    const stored = typeof window !== 'undefined' ? localStorage.getItem('niuu.active') : null;
-    if (stored && enabled.some((p) => p.id === stored)) return stored;
-    return enabled[0]?.id ?? null;
-  });
+  const router = useMemo(
+    () => composeRoutes(enabled, history ? { history } : undefined),
+    [enabled, history],
+  );
 
-  const active = enabled.find((p) => p.id === activeId) ?? enabled[0] ?? null;
-
-  const handleSelect = useCallback((id: string) => {
-    setActiveId(id);
-    if (typeof window !== 'undefined') localStorage.setItem('niuu.active', id);
-  }, []);
-
-  const [tweaks, setTweaks] = useState<Record<string, unknown>>({});
-  const setTweak = useCallback((key: string, value: unknown) => {
-    setTweaks((t) => ({ ...t, [key]: value }));
-  }, []);
-
-  const ctx: PluginCtx = { tweaks, setTweak };
-
-  const subnavNode: ReactNode = active?.subnav?.(ctx) ?? null;
+  const ctx = useMemo(() => ({ plugins: enabled, brand, version }), [enabled, brand, version]);
 
   return (
-    <div
-      className={clsx('niuu-shell', !subnavNode && 'niuu-shell--no-subnav')}
-      data-theme={config.theme}
-    >
-      <aside className="niuu-shell__rail">
-        <div className="niuu-shell__rail-brand" title="Niuu">
-          {brand}
-        </div>
-        {enabled.map((p) => (
-          <button
-            key={p.id}
-            type="button"
-            className={clsx(
-              'niuu-shell__rail-item',
-              active?.id === p.id && 'niuu-shell__rail-item--active',
-            )}
-            title={`${p.title} · ${p.subtitle}`}
-            onClick={() => handleSelect(p.id)}
-          >
-            {p.rune}
-          </button>
-        ))}
-        <div className="niuu-shell__rail-spacer" />
-        <div className="niuu-shell__rail-foot">v{version}</div>
-      </aside>
-
-      <header className="niuu-shell__topbar">
-        <div className="niuu-shell__topbar-title">
-          {active && (
-            <>
-              <h1>{active.title}</h1>
-              <span className="niuu-shell__topbar-subtitle">{active.subtitle}</span>
-            </>
-          )}
-        </div>
-        <div className="niuu-shell__topbar-right">
-          {active?.topbarRight?.(ctx)}
-          <LiveBadge />
-          <Kbd>⌘K</Kbd>
-        </div>
-      </header>
-
-      {subnavNode && <nav className="niuu-shell__subnav">{subnavNode}</nav>}
-
-      <main className="niuu-shell__content">
-        {active?.render ? (
-          active.render(ctx)
-        ) : (
-          <div style={{ padding: 'var(--space-6)' }}>
-            <p>No plugin selected.</p>
-          </div>
-        )}
-      </main>
-
-      <footer className="niuu-shell__footer">
-        <div>
-          {active && <code>plugin:{active.id}</code>}
-          <span className="niuu-shell__footer-sep">·</span>
-          <span>niuu.world</span>
-        </div>
-        <div>
-          <span>{enabled.length} plugins loaded</span>
-        </div>
-      </footer>
-    </div>
+    <ShellContext.Provider value={ctx}>
+      <RouterProvider router={router} />
+    </ShellContext.Provider>
   );
 }

--- a/web-next/packages/shell/src/ShellLayout.tsx
+++ b/web-next/packages/shell/src/ShellLayout.tsx
@@ -1,0 +1,101 @@
+import { useState, useCallback, useEffect, useContext, type ReactNode } from 'react';
+import clsx from 'clsx';
+import { Outlet, useLocation, useNavigate } from '@tanstack/react-router';
+import { useConfig, type PluginCtx } from '@niuulabs/plugin-sdk';
+import { LiveBadge, Kbd } from '@niuulabs/ui';
+import { ShellContext } from './Shell';
+
+export function ShellLayout() {
+  const { plugins, brand, version } = useContext(ShellContext);
+  const config = useConfig();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const activeId = deriveActivePlugin(location.pathname, plugins);
+  const active = plugins.find((p) => p.id === activeId) ?? plugins[0] ?? null;
+
+  useEffect(() => {
+    if (activeId) {
+      localStorage.setItem('niuu.active', activeId);
+    }
+  }, [activeId]);
+
+  const [tweaks, setTweaks] = useState<Record<string, unknown>>({});
+  const setTweak = useCallback((key: string, value: unknown) => {
+    setTweaks((t) => ({ ...t, [key]: value }));
+  }, []);
+
+  const ctx: PluginCtx = { tweaks, setTweak };
+  const subnavNode: ReactNode = active?.subnav?.(ctx) ?? null;
+
+  return (
+    <div
+      className={clsx('niuu-shell', !subnavNode && 'niuu-shell--no-subnav')}
+      data-theme={config.theme}
+    >
+      <aside className="niuu-shell__rail">
+        <div className="niuu-shell__rail-brand" title="Niuu">
+          {brand}
+        </div>
+        {plugins.map((p) => (
+          <button
+            key={p.id}
+            type="button"
+            className={clsx(
+              'niuu-shell__rail-item',
+              active?.id === p.id && 'niuu-shell__rail-item--active',
+            )}
+            title={`${p.title} · ${p.subtitle}`}
+            onClick={() => navigate({ to: `/${p.id}` })}
+          >
+            {p.rune}
+          </button>
+        ))}
+        <div className="niuu-shell__rail-spacer" />
+        <div className="niuu-shell__rail-foot">v{version}</div>
+      </aside>
+
+      <header className="niuu-shell__topbar">
+        <div className="niuu-shell__topbar-title">
+          {active && (
+            <>
+              <h1>{active.title}</h1>
+              <span className="niuu-shell__topbar-subtitle">{active.subtitle}</span>
+            </>
+          )}
+        </div>
+        <div className="niuu-shell__topbar-right">
+          {active?.topbarRight?.(ctx)}
+          <LiveBadge />
+          <Kbd>⌘K</Kbd>
+        </div>
+      </header>
+
+      {subnavNode && <nav className="niuu-shell__subnav">{subnavNode}</nav>}
+
+      <main className="niuu-shell__content">
+        <Outlet />
+      </main>
+
+      <footer className="niuu-shell__footer">
+        <div>
+          {active && <code>plugin:{active.id}</code>}
+          <span className="niuu-shell__footer-sep">·</span>
+          <span>niuu.world</span>
+        </div>
+        <div>
+          <span>{plugins.length} plugins loaded</span>
+        </div>
+      </footer>
+    </div>
+  );
+}
+
+function deriveActivePlugin(pathname: string, plugins: { id: string }[]): string | null {
+  const segment = pathname.split('/').filter(Boolean)[0];
+  if (!segment) {
+    return plugins[0]?.id ?? null;
+  }
+  const match = plugins.find((p) => p.id === segment);
+  return match?.id ?? null;
+}

--- a/web-next/packages/shell/src/composeRoutes.test.ts
+++ b/web-next/packages/shell/src/composeRoutes.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createRoute, createMemoryHistory } from '@tanstack/react-router';
+import { definePlugin } from '@niuulabs/plugin-sdk';
+import { composeRoutes } from './composeRoutes';
+
+function routePaths(router: ReturnType<typeof composeRoutes>): string[] {
+  return router.routeTree.children?.map((r) => r.path) ?? [];
+}
+
+describe('composeRoutes', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('creates a router with no child routes for empty plugins', () => {
+    const router = composeRoutes([], {
+      history: createMemoryHistory({ initialEntries: ['/anything'] }),
+    });
+    expect(router).toBeDefined();
+    expect(router.routeTree.children?.length ?? 0).toBe(0);
+  });
+
+  it('collects routes from a single plugin', () => {
+    const plugin = definePlugin({
+      id: 'alpha',
+      rune: 'ᚨ',
+      title: 'Alpha',
+      subtitle: 'test',
+      routes: (root) => [createRoute({ getParentRoute: () => root, path: '/alpha' })],
+    });
+
+    const router = composeRoutes([plugin], {
+      history: createMemoryHistory({ initialEntries: ['/alpha'] }),
+    });
+
+    const paths = routePaths(router);
+    expect(paths).toContain('/');
+    expect(paths).toContain('alpha');
+  });
+
+  it('collects routes from multiple plugins', () => {
+    const alpha = definePlugin({
+      id: 'alpha',
+      rune: 'ᚨ',
+      title: 'Alpha',
+      subtitle: 'a',
+      routes: (root) => [createRoute({ getParentRoute: () => root, path: '/alpha' })],
+    });
+
+    const beta = definePlugin({
+      id: 'beta',
+      rune: 'ᛒ',
+      title: 'Beta',
+      subtitle: 'b',
+      routes: (root) => [createRoute({ getParentRoute: () => root, path: '/beta' })],
+    });
+
+    const router = composeRoutes([alpha, beta], {
+      history: createMemoryHistory({ initialEntries: ['/alpha'] }),
+    });
+
+    const paths = routePaths(router);
+    expect(paths).toContain('alpha');
+    expect(paths).toContain('beta');
+    expect(paths).toContain('/');
+  });
+
+  it('creates a render-fallback route for plugins with only render', () => {
+    const legacy = definePlugin({
+      id: 'legacy',
+      rune: 'ᛚ',
+      title: 'Legacy',
+      subtitle: 'old',
+      render: () => null,
+    });
+
+    const router = composeRoutes([legacy], {
+      history: createMemoryHistory({ initialEntries: ['/legacy'] }),
+    });
+
+    const paths = routePaths(router);
+    expect(paths).toContain('legacy');
+  });
+
+  it('sets a notFoundComponent on the root route', () => {
+    const router = composeRoutes([], {
+      history: createMemoryHistory({ initialEntries: ['/nope'] }),
+    });
+
+    expect(router.routeTree.options.notFoundComponent).toBeDefined();
+  });
+
+  it('creates an index route that redirects to the first plugin', async () => {
+    const plugin = definePlugin({
+      id: 'alpha',
+      rune: 'ᚨ',
+      title: 'Alpha',
+      subtitle: 'test',
+      routes: (root) => [createRoute({ getParentRoute: () => root, path: '/alpha' })],
+    });
+
+    const router = composeRoutes([plugin], {
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    });
+
+    await router.load();
+    expect(router.state.location.pathname).toBe('/alpha');
+  });
+
+  it('redirects index to localStorage-stored plugin when valid', async () => {
+    localStorage.setItem('niuu.active', 'beta');
+
+    const alpha = definePlugin({
+      id: 'alpha',
+      rune: 'ᚨ',
+      title: 'Alpha',
+      subtitle: 'a',
+      routes: (root) => [createRoute({ getParentRoute: () => root, path: '/alpha' })],
+    });
+
+    const beta = definePlugin({
+      id: 'beta',
+      rune: 'ᛒ',
+      title: 'Beta',
+      subtitle: 'b',
+      routes: (root) => [createRoute({ getParentRoute: () => root, path: '/beta' })],
+    });
+
+    const router = composeRoutes([alpha, beta], {
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    });
+
+    await router.load();
+    expect(router.state.location.pathname).toBe('/beta');
+  });
+
+  it('ignores invalid localStorage value and falls back to first plugin', async () => {
+    localStorage.setItem('niuu.active', 'nonexistent');
+
+    const plugin = definePlugin({
+      id: 'alpha',
+      rune: 'ᚨ',
+      title: 'Alpha',
+      subtitle: 'test',
+      routes: (root) => [createRoute({ getParentRoute: () => root, path: '/alpha' })],
+    });
+
+    const router = composeRoutes([plugin], {
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    });
+
+    await router.load();
+    expect(router.state.location.pathname).toBe('/alpha');
+  });
+});

--- a/web-next/packages/shell/src/composeRoutes.ts
+++ b/web-next/packages/shell/src/composeRoutes.ts
@@ -1,0 +1,65 @@
+import {
+  createRootRoute,
+  createRoute,
+  createRouter,
+  redirect,
+  type AnyRoute,
+  type RouterHistory,
+} from '@tanstack/react-router';
+import type { PluginDescriptor } from '@niuulabs/plugin-sdk';
+import { ShellLayout } from './ShellLayout';
+import { NotFound } from './NotFound';
+
+export interface ComposeRoutesOptions {
+  history?: RouterHistory;
+}
+
+export function composeRoutes(plugins: PluginDescriptor[], options?: ComposeRoutesOptions) {
+  const rootRoute = createRootRoute({
+    component: ShellLayout,
+    notFoundComponent: NotFound,
+  });
+
+  const childRoutes: AnyRoute[] = [];
+
+  for (const plugin of plugins) {
+    if (plugin.routes) {
+      childRoutes.push(...plugin.routes(rootRoute));
+      continue;
+    }
+
+    if (plugin.render) {
+      const renderFn = plugin.render;
+      childRoutes.push(
+        createRoute({
+          getParentRoute: () => rootRoute,
+          path: `/${plugin.id}`,
+          component: () => renderFn({ tweaks: {}, setTweak: () => {} }),
+        }),
+      );
+    }
+  }
+
+  const defaultId = resolveDefaultPlugin(plugins);
+  if (defaultId) {
+    const pluginIds = new Set(plugins.map((p) => p.id));
+    childRoutes.unshift(
+      createRoute({
+        getParentRoute: () => rootRoute,
+        path: '/',
+        beforeLoad: () => {
+          const stored = typeof window !== 'undefined' ? localStorage.getItem('niuu.active') : null;
+          const target = stored && pluginIds.has(stored) ? stored : defaultId;
+          throw redirect({ to: `/${target}` });
+        },
+      }),
+    );
+  }
+
+  const routeTree = rootRoute.addChildren(childRoutes);
+  return createRouter({ routeTree, ...options });
+}
+
+function resolveDefaultPlugin(plugins: PluginDescriptor[]): string | undefined {
+  return plugins[0]?.id;
+}

--- a/web-next/packages/shell/src/index.ts
+++ b/web-next/packages/shell/src/index.ts
@@ -1,1 +1,3 @@
-export { Shell } from './Shell';
+export { Shell, ShellContext, type ShellContextValue } from './Shell';
+export { composeRoutes, type ComposeRoutesOptions } from './composeRoutes';
+export { NotFound } from './NotFound';

--- a/web-next/pnpm-lock.yaml
+++ b/web-next/pnpm-lock.yaml
@@ -181,6 +181,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.62.0
         version: 5.99.1(react@19.2.5)
+      '@tanstack/react-router':
+        specifier: ^1.95.0
+        version: 1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/react':
         specifier: ^19.0.7
         version: 19.2.14


### PR DESCRIPTION
## Summary

- **Router composer**: `composeRoutes()` builds a TanStack Router from `PluginDescriptor.routes`, with an index redirect (respects `localStorage.niuu.active`) and a 404 `notFoundComponent`.
- **Shell refactor**: Split into `Shell` (router creation + context provider) and `ShellLayout` (root route component rendering rail, topbar, subnav, `<Outlet>`, footer).
- **Plugin-hello migration**: Exports `routes(rootRoute)` returning a TanStack `Route` at `/hello` instead of `render()`.
- **Backward compatibility**: Plugins with only `render()` are auto-wrapped in a route at `/<plugin.id>`.
- **Rail navigation**: Now uses `useNavigate()` — clicking a rail item navigates to `/<plugin.id>`.
- **localStorage sync**: `localStorage.niuu.active` follows the router state (derived from URL), not the other way around.

## Test plan

- [x] Unit tests for `composeRoutes` (empty plugins, single, multiple, render fallback, 404, index redirect, localStorage fallback)
- [x] Unit tests for `NotFound` component
- [x] Updated `Shell` tests (routing, redirect, 404, subnav, empty plugins)
- [x] Playwright e2e specs: deep link `/hello`, index redirect, 404, rail navigation, localStorage sync
- [x] Storybook story: Shell with mock plugins (Default, WithSubnav, NotFoundPage)
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 51 tests passing, coverage >= 85% (94.95% branches)
- [x] `pnpm exec eslint .` — clean
- [x] `pnpm exec prettier --check` — clean

Closes NIU-649

🤖 Generated with [Claude Code](https://claude.com/claude-code)