### PR TITLE
feat(ravn): scaffold @niuulabs/plugin-ravn — domain, ports, mock adapter, placeholder UI

### DIFF
--- a/web-next/apps/niuu/package.json
+++ b/web-next/apps/niuu/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@niuulabs/design-tokens": "workspace:*",
     "@niuulabs/plugin-hello": "workspace:*",
+    "@niuulabs/plugin-ravn": "workspace:*",
     "@niuulabs/plugin-sdk": "workspace:*",
     "@niuulabs/query": "workspace:*",
     "@niuulabs/shell": "workspace:*",

--- a/web-next/apps/niuu/public/config.json
+++ b/web-next/apps/niuu/public/config.json
@@ -1,9 +1,11 @@
 {
   "theme": "ice",
   "plugins": {
-    "hello": { "enabled": true, "order": 1 }
+    "hello": { "enabled": true, "order": 1 },
+    "ravn": { "enabled": true, "order": 2 }
   },
   "services": {
-    "hello": { "mode": "mock" }
+    "hello": { "mode": "mock" },
+    "ravn": { "mode": "mock" }
   }
 }

--- a/web-next/apps/niuu/src/plugins.ts
+++ b/web-next/apps/niuu/src/plugins.ts
@@ -1,4 +1,5 @@
 import { helloPlugin } from '@niuulabs/plugin-hello';
+import { ravnPlugin } from '@niuulabs/plugin-ravn';
 import type { PluginDescriptor } from '@niuulabs/plugin-sdk';
 
-export const plugins: PluginDescriptor[] = [helloPlugin];
+export const plugins: PluginDescriptor[] = [helloPlugin, ravnPlugin];

--- a/web-next/apps/niuu/src/services.ts
+++ b/web-next/apps/niuu/src/services.ts
@@ -1,4 +1,5 @@
 import { createMockHelloService, createHttpHelloService } from '@niuulabs/plugin-hello';
+import { createMockRavnService, createHttpRavnService } from '@niuulabs/plugin-ravn';
 import { createApiClient } from '@niuulabs/query';
 import type { NiuuConfig, ServicesMap } from '@niuulabs/plugin-sdk';
 
@@ -9,7 +10,14 @@ export function buildServices(config: NiuuConfig): ServicesMap {
       ? createHttpHelloService(createApiClient(helloConfig.baseUrl))
       : createMockHelloService();
 
+  const ravnConfig = config.services.ravn;
+  const ravnService =
+    ravnConfig?.mode === 'http' && ravnConfig.baseUrl
+      ? createHttpRavnService(createApiClient(ravnConfig.baseUrl))
+      : createMockRavnService();
+
   return {
     hello: helloService,
+    ravn: ravnService,
   };
 }

--- a/web-next/e2e/routing.spec.ts
+++ b/web-next/e2e/routing.spec.ts
@@ -37,4 +37,22 @@ test.describe('routing', () => {
     const stored = await page.evaluate(() => localStorage.getItem('niuu.active'));
     expect(stored).toBe('hello');
   });
+
+  test('deep link /ravn renders the ravn page', async ({ page }) => {
+    await page.goto('/ravn');
+    await expect(page.getByText('Ravn · the flock')).toBeVisible();
+    await expect(page.getByText('agent fleet console — coming soon')).toBeVisible();
+  });
+
+  test('/ravn renders persona list after loading', async ({ page }) => {
+    await page.goto('/ravn');
+    await expect(page.getByText('coding-agent')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('reviewer')).toBeVisible();
+  });
+
+  test('/ravn rail button is visible', async ({ page }) => {
+    await page.goto('/ravn');
+    const ravnButton = page.getByTitle('Ravn · the flock · agent fleet console');
+    await expect(ravnButton).toBeVisible();
+  });
 });

--- a/web-next/packages/plugin-ravn/package.json
+++ b/web-next/packages/plugin-ravn/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@niuulabs/plugin-ravn",
+  "version": "0.0.1",
+  "description": "Ravn — the agent fleet console",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "dev": "tsup --watch"
+  },
+  "peerDependencies": {
+    "@tanstack/react-query": "^5.62.0",
+    "@tanstack/react-router": "^1.95.0",
+    "react": "^19.0.0"
+  },
+  "dependencies": {
+    "@niuulabs/domain": "workspace:*",
+    "@niuulabs/plugin-sdk": "workspace:*",
+    "@niuulabs/query": "workspace:*",
+    "@niuulabs/ui": "workspace:*",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@tanstack/react-query": "^5.62.0",
+    "@tanstack/react-router": "^1.95.0",
+    "@types/react": "^19.0.7",
+    "react": "^19.0.0",
+    "tsup": "^8.3.5",
+    "typescript": "^5.7.3"
+  }
+}

--- a/web-next/packages/plugin-ravn/src/adapters/http.test.ts
+++ b/web-next/packages/plugin-ravn/src/adapters/http.test.ts
@@ -1,0 +1,408 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { ApiClient } from '@niuulabs/query';
+import { createHttpRavnService } from './http';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockClient(overrides: Partial<ApiClient> = {}): ApiClient {
+  return {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Raw fixtures
+// ---------------------------------------------------------------------------
+
+const rawSummary = {
+  name: 'coding-agent',
+  permission_mode: 'workspace-write',
+  allowed_tools: ['file', 'git'],
+  iteration_budget: 40,
+  is_builtin: true,
+  has_override: false,
+  produces_event: 'code.changed',
+  consumes_events: ['code.requested'],
+};
+
+const rawDetail = {
+  ...rawSummary,
+  system_prompt_template: 'You are a coding agent.',
+  forbidden_tools: [],
+  llm: { primary_alias: 'balanced', thinking_enabled: true, max_tokens: 0 },
+  produces: { event_type: 'code.changed', schema_def: {} },
+  consumes: { event_types: ['code.requested'], injects: ['repo'] },
+  fan_in: { strategy: 'merge', contributes_to: '' },
+  yaml_source: '[built-in]',
+};
+
+const rawRaven = {
+  id: 'r1',
+  name: 'coder-asgard',
+  rune: 'ᚱ',
+  persona: 'coding-agent',
+  location: 'asgard',
+  deployment: 'k8s',
+  state: 'active',
+  uptime: 3600,
+  last_tick: '2026-04-19T09:00:00Z',
+  budget: { spent_usd: 2.4, cap_usd: 10.0, warn_at: 8.0 },
+  mounts: [{ name: 'local', role: 'primary', priority: 0 }],
+};
+
+const rawSession = {
+  id: 's1',
+  ravn_id: 'r1',
+  title: 'implement auth',
+  trigger_id: 't1',
+  state: 'active',
+  started_at: '2026-04-19T09:00:00Z',
+  last_at: '2026-04-19T09:55:00Z',
+  messages: [
+    {
+      id: 'm1',
+      session_id: 's1',
+      kind: 'user',
+      body: 'hello',
+      ts: '2026-04-19T09:00:01Z',
+      tool_name: undefined,
+      event_name: undefined,
+    },
+    {
+      id: 'm2',
+      session_id: 's1',
+      kind: 'tool_call',
+      body: 'read("file")',
+      ts: '2026-04-19T09:00:02Z',
+      tool_name: 'read',
+    },
+  ],
+};
+
+const rawTriggers = [
+  { id: 't1', ravn_id: 'r1', kind: 'cron', schedule: '0 * * * *', description: 'hourly' },
+  { id: 't2', ravn_id: 'r1', kind: 'event', topic: 'code.changed', produces_event: 'review.done' },
+  { id: 't3', ravn_id: 'r1', kind: 'webhook', path: '/hooks/github' },
+  { id: 't4', ravn_id: 'r1', kind: 'manual' },
+];
+
+const rawBudget = { spent_usd: 8.8, cap_usd: 36.0, warn_at: 28.0 };
+
+// ---------------------------------------------------------------------------
+// Persona store
+// ---------------------------------------------------------------------------
+
+describe('createHttpRavnService — personas', () => {
+  it('listPersonas fetches /personas?source=all by default', async () => {
+    const client = mockClient({ get: vi.fn().mockResolvedValue([rawSummary]) });
+    const svc = createHttpRavnService(client);
+    const result = await svc.personas.listPersonas();
+    expect(client.get).toHaveBeenCalledWith('/personas?source=all');
+    expect(result[0]).toMatchObject({ name: 'coding-agent', permissionMode: 'workspace-write' });
+  });
+
+  it('listPersonas transforms snake_case to camelCase', async () => {
+    const client = mockClient({ get: vi.fn().mockResolvedValue([rawSummary]) });
+    const svc = createHttpRavnService(client);
+    const [p] = await svc.personas.listPersonas();
+    expect(p).toMatchObject({
+      allowedTools: ['file', 'git'],
+      iterationBudget: 40,
+      isBuiltin: true,
+      hasOverride: false,
+      producesEvent: 'code.changed',
+      consumesEvents: ['code.requested'],
+    });
+  });
+
+  it('listPersonas passes filter param', async () => {
+    const client = mockClient({ get: vi.fn().mockResolvedValue([]) });
+    const svc = createHttpRavnService(client);
+    await svc.personas.listPersonas('builtin');
+    expect(client.get).toHaveBeenCalledWith('/personas?source=builtin');
+  });
+
+  it('getPersona fetches by name and transforms detail', async () => {
+    const client = mockClient({ get: vi.fn().mockResolvedValue(rawDetail) });
+    const svc = createHttpRavnService(client);
+    const result = await svc.personas.getPersona('coding-agent');
+    expect(client.get).toHaveBeenCalledWith('/personas/coding-agent');
+    expect(result.systemPromptTemplate).toBe('You are a coding agent.');
+    expect(result.llm).toMatchObject({ primaryAlias: 'balanced', thinkingEnabled: true });
+    expect(result.produces).toMatchObject({ eventType: 'code.changed' });
+    expect(result.consumes).toMatchObject({ injects: ['repo'] });
+    expect(result.fanIn).toMatchObject({ strategy: 'merge', contributesTo: '' });
+    expect(result.yamlSource).toBe('[built-in]');
+  });
+
+  it('getPersonaYaml fetches yaml endpoint', async () => {
+    const client = mockClient({ get: vi.fn().mockResolvedValue('name: coding-agent\n') });
+    const svc = createHttpRavnService(client);
+    const result = await svc.personas.getPersonaYaml('coding-agent');
+    expect(client.get).toHaveBeenCalledWith('/personas/coding-agent/yaml');
+    expect(result).toBe('name: coding-agent\n');
+  });
+
+  it('createPersona sends POST with snake_case body', async () => {
+    const client = mockClient({ post: vi.fn().mockResolvedValue(rawDetail) });
+    const svc = createHttpRavnService(client);
+    await svc.personas.createPersona({
+      name: 'new-agent',
+      systemPromptTemplate: 'You help.',
+      allowedTools: ['file'],
+      forbiddenTools: [],
+      permissionMode: 'read-only',
+      iterationBudget: 10,
+      llmPrimaryAlias: 'balanced',
+      llmThinkingEnabled: false,
+      llmMaxTokens: 0,
+      producesEventType: '',
+      consumesEventTypes: [],
+      consumesInjects: [],
+      fanInStrategy: 'merge',
+      fanInContributesTo: '',
+    });
+    expect(client.post).toHaveBeenCalledWith(
+      '/personas',
+      expect.objectContaining({
+        name: 'new-agent',
+        system_prompt_template: 'You help.',
+        allowed_tools: ['file'],
+        permission_mode: 'read-only',
+        iteration_budget: 10,
+      }),
+    );
+  });
+
+  it('updatePersona sends PUT', async () => {
+    const client = mockClient({ put: vi.fn().mockResolvedValue(rawDetail) });
+    const svc = createHttpRavnService(client);
+    await svc.personas.updatePersona('coding-agent', {
+      name: 'coding-agent',
+      systemPromptTemplate: 'Updated.',
+      allowedTools: [],
+      forbiddenTools: [],
+      permissionMode: '',
+      iterationBudget: 0,
+      llmPrimaryAlias: '',
+      llmThinkingEnabled: false,
+      llmMaxTokens: 0,
+      producesEventType: '',
+      consumesEventTypes: [],
+      consumesInjects: [],
+      fanInStrategy: 'merge',
+      fanInContributesTo: '',
+    });
+    expect(client.put).toHaveBeenCalledWith(
+      '/personas/coding-agent',
+      expect.objectContaining({ system_prompt_template: 'Updated.' }),
+    );
+  });
+
+  it('deletePersona sends DELETE', async () => {
+    const client = mockClient({ delete: vi.fn().mockResolvedValue(undefined) });
+    const svc = createHttpRavnService(client);
+    await svc.personas.deletePersona('my-agent');
+    expect(client.delete).toHaveBeenCalledWith('/personas/my-agent');
+  });
+
+  it('forkPersona sends POST to /fork with new_name', async () => {
+    const client = mockClient({ post: vi.fn().mockResolvedValue(rawDetail) });
+    const svc = createHttpRavnService(client);
+    await svc.personas.forkPersona('coding-agent', { newName: 'my-fork' });
+    expect(client.post).toHaveBeenCalledWith(
+      '/personas/coding-agent/fork',
+      expect.objectContaining({ new_name: 'my-fork' }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Raven stream
+// ---------------------------------------------------------------------------
+
+describe('createHttpRavnService — ravens', () => {
+  it('listRavens fetches /ravens and transforms response', async () => {
+    const client = mockClient({ get: vi.fn().mockResolvedValue([rawRaven]) });
+    const svc = createHttpRavnService(client);
+    const result = await svc.ravens.listRavens();
+    expect(client.get).toHaveBeenCalledWith('/ravens');
+    expect(result[0]).toMatchObject({
+      id: 'r1',
+      lastTick: '2026-04-19T09:00:00Z',
+      budget: { spentUsd: 2.4, capUsd: 10.0, warnAt: 8.0 },
+    });
+    expect(result[0]?.mounts[0]).toMatchObject({ name: 'local', role: 'primary' });
+  });
+
+  it('getRaven fetches by id', async () => {
+    const client = mockClient({ get: vi.fn().mockResolvedValue(rawRaven) });
+    const svc = createHttpRavnService(client);
+    const result = await svc.ravens.getRaven('r1');
+    expect(client.get).toHaveBeenCalledWith('/ravens/r1');
+    expect(result.name).toBe('coder-asgard');
+  });
+
+  it('propagates errors', async () => {
+    const client = mockClient({ get: vi.fn().mockRejectedValue(new Error('not found')) });
+    const svc = createHttpRavnService(client);
+    await expect(svc.ravens.getRaven('r999')).rejects.toThrow('not found');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session stream
+// ---------------------------------------------------------------------------
+
+describe('createHttpRavnService — sessions', () => {
+  it('listSessions fetches /sessions', async () => {
+    const client = mockClient({ get: vi.fn().mockResolvedValue([rawSession]) });
+    const svc = createHttpRavnService(client);
+    const result = await svc.sessions.listSessions();
+    expect(client.get).toHaveBeenCalledWith('/sessions');
+    expect(result[0]).toMatchObject({ id: 's1', ravnId: 'r1', triggerId: 't1' });
+  });
+
+  it('listSessions filters by ravnId', async () => {
+    const client = mockClient({ get: vi.fn().mockResolvedValue([]) });
+    const svc = createHttpRavnService(client);
+    await svc.sessions.listSessions('r1');
+    expect(client.get).toHaveBeenCalledWith('/sessions?ravn_id=r1');
+  });
+
+  it('getSession fetches by id and transforms messages', async () => {
+    const client = mockClient({ get: vi.fn().mockResolvedValue(rawSession) });
+    const svc = createHttpRavnService(client);
+    const result = await svc.sessions.getSession('s1');
+    expect(result.messages[0]).toMatchObject({ id: 'm1', sessionId: 's1', kind: 'user' });
+    expect(result.messages[1]).toMatchObject({ toolName: 'read' });
+  });
+
+  it('getMessages fetches from /sessions/:id/messages', async () => {
+    const client = mockClient({ get: vi.fn().mockResolvedValue([rawSession.messages[0]!]) });
+    const svc = createHttpRavnService(client);
+    const result = await svc.sessions.getMessages('s1');
+    expect(client.get).toHaveBeenCalledWith('/sessions/s1/messages');
+    expect(result[0]?.kind).toBe('user');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Trigger store
+// ---------------------------------------------------------------------------
+
+describe('createHttpRavnService — triggers', () => {
+  it('listTriggers fetches /triggers and transforms all kinds', async () => {
+    const client = mockClient({ get: vi.fn().mockResolvedValue(rawTriggers) });
+    const svc = createHttpRavnService(client);
+    const result = await svc.triggers.listTriggers();
+    expect(client.get).toHaveBeenCalledWith('/triggers');
+    expect(result).toHaveLength(4);
+    const cron = result.find((t) => t.kind === 'cron');
+    const event = result.find((t) => t.kind === 'event');
+    const webhook = result.find((t) => t.kind === 'webhook');
+    const manual = result.find((t) => t.kind === 'manual');
+    expect(cron).toBeDefined();
+    expect(event).toBeDefined();
+    expect(webhook).toBeDefined();
+    expect(manual).toBeDefined();
+  });
+
+  it('listTriggers filters by ravnId', async () => {
+    const client = mockClient({ get: vi.fn().mockResolvedValue([]) });
+    const svc = createHttpRavnService(client);
+    await svc.triggers.listTriggers('r1');
+    expect(client.get).toHaveBeenCalledWith('/triggers?ravn_id=r1');
+  });
+
+  it('createTrigger sends POST with snake_case body', async () => {
+    const client = mockClient({ post: vi.fn().mockResolvedValue(rawTriggers[0]) });
+    const svc = createHttpRavnService(client);
+    await svc.triggers.createTrigger({
+      ravnId: 'r1',
+      kind: 'cron',
+      schedule: '0 8 * * *',
+      description: 'morning run',
+    });
+    expect(client.post).toHaveBeenCalledWith(
+      '/triggers',
+      expect.objectContaining({
+        ravn_id: 'r1',
+        kind: 'cron',
+        schedule: '0 8 * * *',
+      }),
+    );
+  });
+
+  it('createTrigger sends event trigger with topic', async () => {
+    const client = mockClient({ post: vi.fn().mockResolvedValue(rawTriggers[1]) });
+    const svc = createHttpRavnService(client);
+    await svc.triggers.createTrigger({ ravnId: 'r1', kind: 'event', topic: 'code.changed' });
+    expect(client.post).toHaveBeenCalledWith(
+      '/triggers',
+      expect.objectContaining({ kind: 'event', topic: 'code.changed' }),
+    );
+  });
+
+  it('createTrigger sends webhook trigger with path', async () => {
+    const client = mockClient({ post: vi.fn().mockResolvedValue(rawTriggers[2]) });
+    const svc = createHttpRavnService(client);
+    await svc.triggers.createTrigger({ ravnId: 'r1', kind: 'webhook', path: '/hooks/gh' });
+    expect(client.post).toHaveBeenCalledWith(
+      '/triggers',
+      expect.objectContaining({ kind: 'webhook', path: '/hooks/gh' }),
+    );
+  });
+
+  it('createTrigger sends manual trigger', async () => {
+    const client = mockClient({ post: vi.fn().mockResolvedValue(rawTriggers[3]) });
+    const svc = createHttpRavnService(client);
+    await svc.triggers.createTrigger({ ravnId: 'r1', kind: 'manual' });
+    expect(client.post).toHaveBeenCalledWith(
+      '/triggers',
+      expect.objectContaining({ kind: 'manual' }),
+    );
+  });
+
+  it('deleteTrigger sends DELETE', async () => {
+    const client = mockClient({ delete: vi.fn().mockResolvedValue(undefined) });
+    const svc = createHttpRavnService(client);
+    await svc.triggers.deleteTrigger('t1');
+    expect(client.delete).toHaveBeenCalledWith('/triggers/t1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Budget stream
+// ---------------------------------------------------------------------------
+
+describe('createHttpRavnService — budget', () => {
+  it('getFleetBudget fetches /budget and transforms', async () => {
+    const client = mockClient({ get: vi.fn().mockResolvedValue(rawBudget) });
+    const svc = createHttpRavnService(client);
+    const result = await svc.budget.getFleetBudget();
+    expect(client.get).toHaveBeenCalledWith('/budget');
+    expect(result).toMatchObject({ spentUsd: 8.8, capUsd: 36.0, warnAt: 28.0 });
+  });
+
+  it('getRavenBudget fetches /ravens/:id/budget', async () => {
+    const client = mockClient({ get: vi.fn().mockResolvedValue(rawBudget) });
+    const svc = createHttpRavnService(client);
+    const result = await svc.budget.getRavenBudget('r1');
+    expect(client.get).toHaveBeenCalledWith('/ravens/r1/budget');
+    expect(result.spentUsd).toBe(8.8);
+  });
+
+  it('propagates errors', async () => {
+    const client = mockClient({ get: vi.fn().mockRejectedValue(new Error('boom')) });
+    const svc = createHttpRavnService(client);
+    await expect(svc.budget.getFleetBudget()).rejects.toThrow('boom');
+  });
+});

--- a/web-next/packages/plugin-ravn/src/adapters/http.ts
+++ b/web-next/packages/plugin-ravn/src/adapters/http.ts
@@ -417,12 +417,12 @@ function createHttpTriggerStore(client: ApiClient): ITriggerStore {
 function createHttpBudgetStream(client: ApiClient): IBudgetStream {
   return {
     async getFleetBudget() {
-      const raw = await client.get<RawBudget>('/budget');
+      const raw = await client.get<RawRavenBudget>('/budget');
       return toBudgetState(raw);
     },
 
     async getRavenBudget(ravnId: string) {
-      const raw = await client.get<RawBudget>(`/ravens/${encodeURIComponent(ravnId)}/budget`);
+      const raw = await client.get<RawRavenBudget>(`/ravens/${encodeURIComponent(ravnId)}/budget`);
       return toBudgetState(raw);
     },
   };

--- a/web-next/packages/plugin-ravn/src/adapters/http.ts
+++ b/web-next/packages/plugin-ravn/src/adapters/http.ts
@@ -1,0 +1,448 @@
+/**
+ * Ravn — HTTP adapter.
+ *
+ * Wraps @niuulabs/query ApiClient for all Ravn service endpoints.
+ * Persona endpoints are under /api/v1/ravn/personas (matching the existing
+ * web/ client.ts). Fleet endpoints are under /api/v1/ravn/*.
+ *
+ * All server responses are snake_case; this adapter transforms them to
+ * camelCase before returning, following the same convention as web/ client.ts.
+ */
+
+import type { ApiClient } from '@niuulabs/query';
+import type { BudgetState } from '@niuulabs/domain';
+import type {
+  PersonaSummary,
+  PersonaDetail,
+  PersonaCreateRequest,
+  PersonaForkRequest,
+  PersonaFilter,
+  Raven,
+  RavenMount,
+  Session,
+  Message,
+  MessageKind,
+  Trigger,
+  TriggerInput,
+} from '../domain';
+import type {
+  IPersonaStore,
+  IRavenStream,
+  ISessionStream,
+  ITriggerStore,
+  IBudgetStream,
+  IRavnService,
+} from '../ports';
+
+// ---------------------------------------------------------------------------
+// Raw server types (snake_case)
+// ---------------------------------------------------------------------------
+
+interface RawPersonaLLM {
+  primary_alias: string;
+  thinking_enabled: boolean;
+  max_tokens: number;
+}
+
+interface RawPersonaProduces {
+  event_type: string;
+  schema_def: Record<string, unknown>;
+}
+
+interface RawPersonaConsumes {
+  event_types: string[];
+  injects: string[];
+}
+
+interface RawPersonaFanIn {
+  strategy: string;
+  contributes_to: string;
+}
+
+interface RawPersonaSummary {
+  name: string;
+  permission_mode: string;
+  allowed_tools: string[];
+  iteration_budget: number;
+  is_builtin: boolean;
+  has_override: boolean;
+  produces_event: string;
+  consumes_events: string[];
+}
+
+interface RawPersonaDetail extends RawPersonaSummary {
+  system_prompt_template: string;
+  forbidden_tools: string[];
+  llm: RawPersonaLLM;
+  produces: RawPersonaProduces;
+  consumes: RawPersonaConsumes;
+  fan_in: RawPersonaFanIn;
+  yaml_source: string;
+}
+
+interface RawRavenMount {
+  name: string;
+  role: 'primary' | 'archive' | 'ro';
+  priority: number;
+}
+
+interface RawRavenBudget {
+  spent_usd: number;
+  cap_usd: number;
+  warn_at: number;
+}
+
+interface RawRaven {
+  id: string;
+  name: string;
+  rune: string;
+  persona: string;
+  location: string;
+  deployment: string;
+  state: 'active' | 'idle' | 'suspended' | 'failed';
+  uptime: number;
+  last_tick: string;
+  budget: RawRavenBudget;
+  mounts: RawRavenMount[];
+}
+
+interface RawMessage {
+  id: string;
+  session_id: string;
+  kind: MessageKind;
+  body: string;
+  ts: string;
+  tool_name?: string;
+  event_name?: string;
+}
+
+interface RawSession {
+  id: string;
+  ravn_id: string;
+  title: string;
+  trigger_id?: string;
+  state: 'active' | 'idle' | 'suspended' | 'failed' | 'completed';
+  started_at: string;
+  last_at?: string;
+  messages: RawMessage[];
+}
+
+interface RawTrigger {
+  id: string;
+  ravn_id: string;
+  kind: 'cron' | 'event' | 'webhook' | 'manual';
+  schedule?: string;
+  description?: string;
+  topic?: string;
+  produces_event?: string;
+  path?: string;
+}
+
+interface RawBudget {
+  spent_usd: number;
+  cap_usd: number;
+  warn_at: number;
+}
+
+// ---------------------------------------------------------------------------
+// Transform — persona
+// ---------------------------------------------------------------------------
+
+function toPersonaSummary(raw: RawPersonaSummary): PersonaSummary {
+  return {
+    name: raw.name,
+    permissionMode: raw.permission_mode,
+    allowedTools: raw.allowed_tools,
+    iterationBudget: raw.iteration_budget,
+    isBuiltin: raw.is_builtin,
+    hasOverride: raw.has_override,
+    producesEvent: raw.produces_event,
+    consumesEvents: raw.consumes_events,
+  };
+}
+
+function toPersonaDetail(raw: RawPersonaDetail): PersonaDetail {
+  return {
+    ...toPersonaSummary(raw),
+    systemPromptTemplate: raw.system_prompt_template,
+    forbiddenTools: raw.forbidden_tools,
+    llm: {
+      primaryAlias: raw.llm.primary_alias,
+      thinkingEnabled: raw.llm.thinking_enabled,
+      maxTokens: raw.llm.max_tokens,
+    },
+    produces: { eventType: raw.produces.event_type, schemaDef: raw.produces.schema_def },
+    consumes: { eventTypes: raw.consumes.event_types, injects: raw.consumes.injects },
+    fanIn: { strategy: raw.fan_in.strategy, contributesTo: raw.fan_in.contributes_to },
+    yamlSource: raw.yaml_source,
+  };
+}
+
+function toPersonaRequestBody(req: PersonaCreateRequest): Record<string, unknown> {
+  return {
+    name: req.name,
+    system_prompt_template: req.systemPromptTemplate,
+    allowed_tools: req.allowedTools,
+    forbidden_tools: req.forbiddenTools,
+    permission_mode: req.permissionMode,
+    iteration_budget: req.iterationBudget,
+    llm_primary_alias: req.llmPrimaryAlias,
+    llm_thinking_enabled: req.llmThinkingEnabled,
+    llm_max_tokens: req.llmMaxTokens,
+    produces_event_type: req.producesEventType,
+    consumes_event_types: req.consumesEventTypes,
+    consumes_injects: req.consumesInjects,
+    fan_in_strategy: req.fanInStrategy,
+    fan_in_contributes_to: req.fanInContributesTo,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Transform — raven
+// ---------------------------------------------------------------------------
+
+function toRavenMount(raw: RawRavenMount): RavenMount {
+  return { name: raw.name, role: raw.role, priority: raw.priority };
+}
+
+function toBudgetState(raw: RawRavenBudget | RawBudget): BudgetState {
+  return {
+    spentUsd: (raw as RawRavenBudget).spent_usd,
+    capUsd: (raw as RawRavenBudget).cap_usd,
+    warnAt: (raw as RawRavenBudget).warn_at,
+  };
+}
+
+function toRaven(raw: RawRaven): Raven {
+  return {
+    id: raw.id,
+    name: raw.name,
+    rune: raw.rune,
+    persona: raw.persona,
+    location: raw.location,
+    deployment: raw.deployment,
+    state: raw.state,
+    uptime: raw.uptime,
+    lastTick: raw.last_tick,
+    budget: toBudgetState(raw.budget),
+    mounts: raw.mounts.map(toRavenMount),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Transform — message + session
+// ---------------------------------------------------------------------------
+
+function toMessage(raw: RawMessage): Message {
+  return {
+    id: raw.id,
+    sessionId: raw.session_id,
+    kind: raw.kind,
+    body: raw.body,
+    ts: raw.ts,
+    toolName: raw.tool_name,
+    eventName: raw.event_name,
+  };
+}
+
+function toSession(raw: RawSession): Session {
+  return {
+    id: raw.id,
+    ravnId: raw.ravn_id,
+    title: raw.title,
+    triggerId: raw.trigger_id,
+    state: raw.state,
+    startedAt: raw.started_at,
+    lastAt: raw.last_at,
+    messages: raw.messages.map(toMessage),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Transform — trigger
+// ---------------------------------------------------------------------------
+
+function toTrigger(raw: RawTrigger): Trigger {
+  if (raw.kind === 'cron') {
+    return {
+      id: raw.id,
+      ravnId: raw.ravn_id,
+      kind: 'cron',
+      schedule: raw.schedule ?? '',
+      description: raw.description ?? '',
+    };
+  }
+  if (raw.kind === 'event') {
+    return {
+      id: raw.id,
+      ravnId: raw.ravn_id,
+      kind: 'event',
+      topic: raw.topic ?? '',
+      producesEvent: raw.produces_event,
+    };
+  }
+  if (raw.kind === 'webhook') {
+    return { id: raw.id, ravnId: raw.ravn_id, kind: 'webhook', path: raw.path ?? '' };
+  }
+  return { id: raw.id, ravnId: raw.ravn_id, kind: 'manual' };
+}
+
+function toTriggerBody(trigger: TriggerInput): Record<string, unknown> {
+  const base: Record<string, unknown> = { ravn_id: trigger.ravnId, kind: trigger.kind };
+  if (trigger.kind === 'cron') {
+    base['schedule'] = trigger.schedule;
+    base['description'] = trigger.description;
+  } else if (trigger.kind === 'event') {
+    base['topic'] = trigger.topic;
+    if (trigger.producesEvent) base['produces_event'] = trigger.producesEvent;
+  } else if (trigger.kind === 'webhook') {
+    base['path'] = trigger.path;
+  }
+  return base;
+}
+
+// ---------------------------------------------------------------------------
+// HTTP persona store
+// ---------------------------------------------------------------------------
+
+function createHttpPersonaStore(client: ApiClient): IPersonaStore {
+  return {
+    async listPersonas(filter: PersonaFilter = 'all') {
+      const raw = await client.get<RawPersonaSummary[]>(`/personas?source=${filter}`);
+      return raw.map(toPersonaSummary);
+    },
+
+    async getPersona(name: string) {
+      const raw = await client.get<RawPersonaDetail>(`/personas/${encodeURIComponent(name)}`);
+      return toPersonaDetail(raw);
+    },
+
+    async getPersonaYaml(name: string) {
+      return client.get<string>(`/personas/${encodeURIComponent(name)}/yaml`);
+    },
+
+    async createPersona(req: PersonaCreateRequest) {
+      const raw = await client.post<RawPersonaDetail>('/personas', toPersonaRequestBody(req));
+      return toPersonaDetail(raw);
+    },
+
+    async updatePersona(name: string, req: PersonaCreateRequest) {
+      const raw = await client.put<RawPersonaDetail>(
+        `/personas/${encodeURIComponent(name)}`,
+        toPersonaRequestBody(req),
+      );
+      return toPersonaDetail(raw);
+    },
+
+    async deletePersona(name: string) {
+      await client.delete<void>(`/personas/${encodeURIComponent(name)}`);
+    },
+
+    async forkPersona(name: string, req: PersonaForkRequest) {
+      const raw = await client.post<RawPersonaDetail>(
+        `/personas/${encodeURIComponent(name)}/fork`,
+        { new_name: req.newName },
+      );
+      return toPersonaDetail(raw);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// HTTP raven stream
+// ---------------------------------------------------------------------------
+
+function createHttpRavenStream(client: ApiClient): IRavenStream {
+  return {
+    async listRavens() {
+      const raw = await client.get<RawRaven[]>('/ravens');
+      return raw.map(toRaven);
+    },
+
+    async getRaven(id: string) {
+      const raw = await client.get<RawRaven>(`/ravens/${encodeURIComponent(id)}`);
+      return toRaven(raw);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// HTTP session stream
+// ---------------------------------------------------------------------------
+
+function createHttpSessionStream(client: ApiClient): ISessionStream {
+  return {
+    async listSessions(ravnId?: string) {
+      const query = ravnId ? `?ravn_id=${encodeURIComponent(ravnId)}` : '';
+      const raw = await client.get<RawSession[]>(`/sessions${query}`);
+      return raw.map(toSession);
+    },
+
+    async getSession(id: string) {
+      const raw = await client.get<RawSession>(`/sessions/${encodeURIComponent(id)}`);
+      return toSession(raw);
+    },
+
+    async getMessages(sessionId: string) {
+      const raw = await client.get<RawMessage[]>(
+        `/sessions/${encodeURIComponent(sessionId)}/messages`,
+      );
+      return raw.map(toMessage);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// HTTP trigger store
+// ---------------------------------------------------------------------------
+
+function createHttpTriggerStore(client: ApiClient): ITriggerStore {
+  return {
+    async listTriggers(ravnId?: string) {
+      const query = ravnId ? `?ravn_id=${encodeURIComponent(ravnId)}` : '';
+      const raw = await client.get<RawTrigger[]>(`/triggers${query}`);
+      return raw.map(toTrigger);
+    },
+
+    async createTrigger(trigger: TriggerInput) {
+      const raw = await client.post<RawTrigger>('/triggers', toTriggerBody(trigger));
+      return toTrigger(raw);
+    },
+
+    async deleteTrigger(id: string) {
+      await client.delete<void>(`/triggers/${encodeURIComponent(id)}`);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// HTTP budget stream
+// ---------------------------------------------------------------------------
+
+function createHttpBudgetStream(client: ApiClient): IBudgetStream {
+  return {
+    async getFleetBudget() {
+      const raw = await client.get<RawBudget>('/budget');
+      return toBudgetState(raw);
+    },
+
+    async getRavenBudget(ravnId: string) {
+      const raw = await client.get<RawBudget>(`/ravens/${encodeURIComponent(ravnId)}/budget`);
+      return toBudgetState(raw);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public factory
+// ---------------------------------------------------------------------------
+
+export function createHttpRavnService(client: ApiClient): IRavnService {
+  return {
+    personas: createHttpPersonaStore(client),
+    ravens: createHttpRavenStream(client),
+    sessions: createHttpSessionStream(client),
+    triggers: createHttpTriggerStore(client),
+    budget: createHttpBudgetStream(client),
+  };
+}

--- a/web-next/packages/plugin-ravn/src/adapters/http.ts
+++ b/web-next/packages/plugin-ravn/src/adapters/http.ts
@@ -138,11 +138,6 @@ interface RawTrigger {
   path?: string;
 }
 
-interface RawBudget {
-  spent_usd: number;
-  cap_usd: number;
-  warn_at: number;
-}
 
 // ---------------------------------------------------------------------------
 // Transform — persona
@@ -205,11 +200,11 @@ function toRavenMount(raw: RawRavenMount): RavenMount {
   return { name: raw.name, role: raw.role, priority: raw.priority };
 }
 
-function toBudgetState(raw: RawRavenBudget | RawBudget): BudgetState {
+function toBudgetState(raw: RawRavenBudget): BudgetState {
   return {
-    spentUsd: (raw as RawRavenBudget).spent_usd,
-    capUsd: (raw as RawRavenBudget).cap_usd,
-    warnAt: (raw as RawRavenBudget).warn_at,
+    spentUsd: raw.spent_usd,
+    capUsd: raw.cap_usd,
+    warnAt: raw.warn_at,
   };
 }
 

--- a/web-next/packages/plugin-ravn/src/adapters/mock.test.ts
+++ b/web-next/packages/plugin-ravn/src/adapters/mock.test.ts
@@ -140,6 +140,48 @@ describe('mock persona store — updatePersona', () => {
     expect(updated.iterationBudget).toBe(20);
   });
 
+  it('updates produces/consumes/fanIn fields', async () => {
+    await svc.personas.createPersona({
+      name: 'event-driven',
+      systemPromptTemplate: 'base',
+      allowedTools: [],
+      forbiddenTools: [],
+      permissionMode: 'read-only',
+      iterationBudget: 5,
+      llmPrimaryAlias: 'balanced',
+      llmThinkingEnabled: false,
+      llmMaxTokens: 0,
+      producesEventType: 'original.event',
+      consumesEventTypes: ['a'],
+      consumesInjects: ['x'],
+      fanInStrategy: 'first',
+      fanInContributesTo: 'group-a',
+    });
+    const updated = await svc.personas.updatePersona('event-driven', {
+      name: 'event-driven',
+      systemPromptTemplate: 'base',
+      allowedTools: [],
+      forbiddenTools: [],
+      permissionMode: 'read-only',
+      iterationBudget: 5,
+      llmPrimaryAlias: 'balanced',
+      llmThinkingEnabled: false,
+      llmMaxTokens: 0,
+      producesEventType: 'updated.event',
+      consumesEventTypes: ['b', 'c'],
+      consumesInjects: ['y'],
+      fanInStrategy: 'merge',
+      fanInContributesTo: 'group-b',
+    });
+    expect(updated.producesEvent).toBe('updated.event');
+    expect(updated.consumesEvents).toEqual(['b', 'c']);
+    expect(updated.produces.eventType).toBe('updated.event');
+    expect(updated.consumes.eventTypes).toEqual(['b', 'c']);
+    expect(updated.consumes.injects).toEqual(['y']);
+    expect(updated.fanIn.strategy).toBe('merge');
+    expect(updated.fanIn.contributesTo).toBe('group-b');
+  });
+
   it('throws when updating nonexistent or builtin persona', async () => {
     await expect(
       svc.personas.updatePersona('coding-agent', {

--- a/web-next/packages/plugin-ravn/src/adapters/mock.test.ts
+++ b/web-next/packages/plugin-ravn/src/adapters/mock.test.ts
@@ -1,0 +1,356 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createMockRavnService } from './mock';
+import type { IRavnService } from '../ports';
+
+let svc: IRavnService;
+
+beforeEach(() => {
+  svc = createMockRavnService();
+});
+
+// ---------------------------------------------------------------------------
+// Persona store
+// ---------------------------------------------------------------------------
+
+describe('mock persona store — listPersonas', () => {
+  it('returns all 21 builtin personas by default', async () => {
+    const result = await svc.personas.listPersonas();
+    expect(result.length).toBeGreaterThanOrEqual(21);
+  });
+
+  it('returns only builtins when filter=builtin', async () => {
+    const result = await svc.personas.listPersonas('builtin');
+    expect(result.every((p) => p.isBuiltin)).toBe(true);
+    expect(result.length).toBe(21);
+  });
+
+  it('returns empty list for custom when none created', async () => {
+    const result = await svc.personas.listPersonas('custom');
+    expect(result).toHaveLength(0);
+  });
+
+  it('includes custom personas in all filter', async () => {
+    await svc.personas.createPersona({
+      name: 'my-agent',
+      systemPromptTemplate: 'You help.',
+      allowedTools: ['file'],
+      forbiddenTools: [],
+      permissionMode: 'read-only',
+      iterationBudget: 10,
+      llmPrimaryAlias: 'balanced',
+      llmThinkingEnabled: false,
+      llmMaxTokens: 0,
+      producesEventType: '',
+      consumesEventTypes: [],
+      consumesInjects: [],
+      fanInStrategy: 'merge',
+      fanInContributesTo: '',
+    });
+    const all = await svc.personas.listPersonas('all');
+    const custom = await svc.personas.listPersonas('custom');
+    expect(all.length).toBe(22);
+    expect(custom).toHaveLength(1);
+    expect(custom[0]?.name).toBe('my-agent');
+  });
+});
+
+describe('mock persona store — getPersona', () => {
+  it('returns detail for a builtin persona', async () => {
+    const result = await svc.personas.getPersona('coding-agent');
+    expect(result.name).toBe('coding-agent');
+    expect(result.systemPromptTemplate).toBeTruthy();
+    expect(result.llm).toHaveProperty('primaryAlias');
+  });
+
+  it('throws for unknown persona', async () => {
+    await expect(svc.personas.getPersona('nonexistent')).rejects.toThrow('"nonexistent" not found');
+  });
+
+  it('returns custom persona after creation', async () => {
+    await svc.personas.createPersona({
+      name: 'custom-one',
+      systemPromptTemplate: 'Custom template',
+      allowedTools: [],
+      forbiddenTools: [],
+      permissionMode: 'safe',
+      iterationBudget: 5,
+      llmPrimaryAlias: 'fast',
+      llmThinkingEnabled: true,
+      llmMaxTokens: 1024,
+      producesEventType: 'custom.done',
+      consumesEventTypes: ['custom.start'],
+      consumesInjects: ['repo'],
+      fanInStrategy: 'any_passes',
+      fanInContributesTo: '',
+    });
+    const result = await svc.personas.getPersona('custom-one');
+    expect(result.name).toBe('custom-one');
+    expect(result.llm.thinkingEnabled).toBe(true);
+    expect(result.llm.maxTokens).toBe(1024);
+  });
+});
+
+describe('mock persona store — getPersonaYaml', () => {
+  it('returns yaml string for builtin', async () => {
+    const result = await svc.personas.getPersonaYaml('coder');
+    expect(typeof result).toBe('string');
+    expect(result).toContain('coder');
+  });
+
+  it('throws for unknown persona', async () => {
+    await expect(svc.personas.getPersonaYaml('ghost')).rejects.toThrow();
+  });
+});
+
+describe('mock persona store — updatePersona', () => {
+  it('updates a custom persona', async () => {
+    await svc.personas.createPersona({
+      name: 'updatable',
+      systemPromptTemplate: 'original',
+      allowedTools: ['file'],
+      forbiddenTools: [],
+      permissionMode: 'read-only',
+      iterationBudget: 10,
+      llmPrimaryAlias: 'balanced',
+      llmThinkingEnabled: false,
+      llmMaxTokens: 0,
+      producesEventType: '',
+      consumesEventTypes: [],
+      consumesInjects: [],
+      fanInStrategy: 'merge',
+      fanInContributesTo: '',
+    });
+    const updated = await svc.personas.updatePersona('updatable', {
+      name: 'updatable',
+      systemPromptTemplate: 'updated',
+      allowedTools: ['file', 'git'],
+      forbiddenTools: [],
+      permissionMode: 'workspace-write',
+      iterationBudget: 20,
+      llmPrimaryAlias: 'large',
+      llmThinkingEnabled: true,
+      llmMaxTokens: 2048,
+      producesEventType: '',
+      consumesEventTypes: [],
+      consumesInjects: [],
+      fanInStrategy: 'merge',
+      fanInContributesTo: '',
+    });
+    expect(updated.systemPromptTemplate).toBe('updated');
+    expect(updated.iterationBudget).toBe(20);
+  });
+
+  it('throws when updating nonexistent or builtin persona', async () => {
+    await expect(
+      svc.personas.updatePersona('coding-agent', {
+        name: 'coding-agent',
+        systemPromptTemplate: '',
+        allowedTools: [],
+        forbiddenTools: [],
+        permissionMode: '',
+        iterationBudget: 0,
+        llmPrimaryAlias: '',
+        llmThinkingEnabled: false,
+        llmMaxTokens: 0,
+        producesEventType: '',
+        consumesEventTypes: [],
+        consumesInjects: [],
+        fanInStrategy: 'merge',
+        fanInContributesTo: '',
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+describe('mock persona store — deletePersona', () => {
+  it('deletes a custom persona', async () => {
+    await svc.personas.createPersona({
+      name: 'deletable',
+      systemPromptTemplate: '',
+      allowedTools: [],
+      forbiddenTools: [],
+      permissionMode: 'read-only',
+      iterationBudget: 5,
+      llmPrimaryAlias: 'balanced',
+      llmThinkingEnabled: false,
+      llmMaxTokens: 0,
+      producesEventType: '',
+      consumesEventTypes: [],
+      consumesInjects: [],
+      fanInStrategy: 'merge',
+      fanInContributesTo: '',
+    });
+    await svc.personas.deletePersona('deletable');
+    const customs = await svc.personas.listPersonas('custom');
+    expect(customs.find((p) => p.name === 'deletable')).toBeUndefined();
+  });
+
+  it('throws when deleting a builtin persona', async () => {
+    await expect(svc.personas.deletePersona('coder')).rejects.toThrow();
+  });
+});
+
+describe('mock persona store — forkPersona', () => {
+  it('forks a builtin persona under a new name', async () => {
+    const forked = await svc.personas.forkPersona('coder', { newName: 'my-coder' });
+    expect(forked.name).toBe('my-coder');
+    expect(forked.isBuiltin).toBe(false);
+    expect(forked.allowedTools).toEqual(expect.arrayContaining(['file', 'git']));
+  });
+
+  it('forked persona appears in custom list', async () => {
+    await svc.personas.forkPersona('reviewer', { newName: 'my-reviewer' });
+    const customs = await svc.personas.listPersonas('custom');
+    expect(customs.find((p) => p.name === 'my-reviewer')).toBeDefined();
+  });
+
+  it('throws when forking nonexistent persona', async () => {
+    await expect(svc.personas.forkPersona('ghost', { newName: 'ghost-fork' })).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Raven stream
+// ---------------------------------------------------------------------------
+
+describe('mock raven stream', () => {
+  it('lists all 5 seed ravens', async () => {
+    const ravens = await svc.ravens.listRavens();
+    expect(ravens).toHaveLength(5);
+  });
+
+  it('returns raven by id', async () => {
+    const raven = await svc.ravens.getRaven('r1');
+    expect(raven.name).toBe('coder-asgard');
+    expect(raven.state).toBe('active');
+    expect(raven.mounts.length).toBeGreaterThan(0);
+  });
+
+  it('throws for unknown raven id', async () => {
+    await expect(svc.ravens.getRaven('r999')).rejects.toThrow('"r999" not found');
+  });
+
+  it('ravens have valid budget', async () => {
+    const ravens = await svc.ravens.listRavens();
+    for (const r of ravens) {
+      expect(r.budget.spentUsd).toBeGreaterThanOrEqual(0);
+      expect(r.budget.capUsd).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session stream
+// ---------------------------------------------------------------------------
+
+describe('mock session stream', () => {
+  it('lists all sessions', async () => {
+    const sessions = await svc.sessions.listSessions();
+    expect(sessions).toHaveLength(3);
+  });
+
+  it('filters sessions by ravnId', async () => {
+    const sessions = await svc.sessions.listSessions('r1');
+    expect(sessions.every((s) => s.ravnId === 'r1')).toBe(true);
+    expect(sessions).toHaveLength(1);
+  });
+
+  it('returns empty array for raven with no sessions', async () => {
+    const sessions = await svc.sessions.listSessions('r5');
+    expect(sessions).toHaveLength(0);
+  });
+
+  it('returns session by id', async () => {
+    const session = await svc.sessions.getSession('s1');
+    expect(session.title).toBe('implement auth middleware');
+    expect(session.state).toBe('active');
+  });
+
+  it('throws for unknown session id', async () => {
+    await expect(svc.sessions.getSession('s999')).rejects.toThrow('"s999" not found');
+  });
+
+  it('returns messages for a session', async () => {
+    const messages = await svc.sessions.getMessages('s1');
+    expect(messages.length).toBeGreaterThan(0);
+    const kinds = messages.map((m) => m.kind);
+    expect(kinds).toContain('user');
+    expect(kinds).toContain('asst');
+    expect(kinds).toContain('think');
+    expect(kinds).toContain('tool_call');
+    expect(kinds).toContain('emit');
+  });
+
+  it('returns empty messages for session with none', async () => {
+    const messages = await svc.sessions.getMessages('s3');
+    expect(messages).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Trigger store
+// ---------------------------------------------------------------------------
+
+describe('mock trigger store', () => {
+  it('lists all seed triggers', async () => {
+    const triggers = await svc.triggers.listTriggers();
+    expect(triggers.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it('filters triggers by ravnId', async () => {
+    const triggers = await svc.triggers.listTriggers('r4');
+    expect(triggers.every((t) => t.ravnId === 'r4')).toBe(true);
+    expect(triggers.length).toBeGreaterThan(0);
+  });
+
+  it('creates a cron trigger', async () => {
+    const created = await svc.triggers.createTrigger({
+      ravnId: 'r2',
+      kind: 'cron',
+      schedule: '0 8 * * *',
+      description: 'daily morning run',
+    });
+    expect(created.kind).toBe('cron');
+    expect(created.id).toBeTruthy();
+    const all = await svc.triggers.listTriggers('r2');
+    expect(all.find((t) => t.id === created.id)).toBeDefined();
+  });
+
+  it('creates a manual trigger', async () => {
+    const created = await svc.triggers.createTrigger({ ravnId: 'r3', kind: 'manual' });
+    expect(created.kind).toBe('manual');
+  });
+
+  it('deletes a created trigger', async () => {
+    const created = await svc.triggers.createTrigger({ ravnId: 'r1', kind: 'manual' });
+    await svc.triggers.deleteTrigger(created.id);
+    const all = await svc.triggers.listTriggers('r1');
+    expect(all.find((t) => t.id === created.id)).toBeUndefined();
+  });
+
+  it('throws when deleting a seed trigger', async () => {
+    await expect(svc.triggers.deleteTrigger('trig1')).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Budget stream
+// ---------------------------------------------------------------------------
+
+describe('mock budget stream', () => {
+  it('returns fleet budget', async () => {
+    const budget = await svc.budget.getFleetBudget();
+    expect(budget.spentUsd).toBeGreaterThan(0);
+    expect(budget.capUsd).toBeGreaterThan(budget.spentUsd);
+  });
+
+  it('returns raven budget by id', async () => {
+    const budget = await svc.budget.getRavenBudget('r1');
+    expect(budget.capUsd).toBe(10.0);
+    expect(budget.spentUsd).toBe(2.4);
+  });
+
+  it('throws for unknown raven', async () => {
+    await expect(svc.budget.getRavenBudget('r999')).rejects.toThrow('"r999" not found');
+  });
+});

--- a/web-next/packages/plugin-ravn/src/adapters/mock.ts
+++ b/web-next/packages/plugin-ravn/src/adapters/mock.ts
@@ -467,6 +467,8 @@ function createMockPersonaStore(): IPersonaStore {
         permissionMode: req.permissionMode,
         allowedTools: req.allowedTools,
         iterationBudget: req.iterationBudget,
+        producesEvent: req.producesEventType,
+        consumesEvents: req.consumesEventTypes,
         systemPromptTemplate: req.systemPromptTemplate,
         forbiddenTools: req.forbiddenTools,
         llm: {
@@ -474,6 +476,9 @@ function createMockPersonaStore(): IPersonaStore {
           thinkingEnabled: req.llmThinkingEnabled,
           maxTokens: req.llmMaxTokens,
         },
+        produces: { eventType: req.producesEventType, schemaDef: {} },
+        consumes: { eventTypes: req.consumesEventTypes, injects: req.consumesInjects },
+        fanIn: { strategy: req.fanInStrategy, contributesTo: req.fanInContributesTo },
       };
       customPersonas[idx] = updated;
       return updated;

--- a/web-next/packages/plugin-ravn/src/adapters/mock.ts
+++ b/web-next/packages/plugin-ravn/src/adapters/mock.ts
@@ -1,0 +1,621 @@
+/**
+ * Ravn — mock adapter.
+ *
+ * Seeded from the 21 builtin personas in web/src/modules/ravn/api/mockData.ts
+ * plus a small fleet of mock ravens, sessions, triggers, and budget data.
+ * All methods resolve immediately (no artificial delay) to keep tests fast.
+ */
+
+import type { BudgetState } from '@niuulabs/domain';
+import type {
+  PersonaSummary,
+  PersonaDetail,
+  PersonaCreateRequest,
+  PersonaForkRequest,
+  PersonaFilter,
+  Raven,
+  Session,
+  Message,
+  Trigger,
+  TriggerInput,
+} from '../domain';
+import type {
+  IPersonaStore,
+  IRavenStream,
+  ISessionStream,
+  ITriggerStore,
+  IBudgetStream,
+  IRavnService,
+} from '../ports';
+
+// ---------------------------------------------------------------------------
+// Seed — personas (mirroring web/src/modules/ravn/api/mockData.ts)
+// ---------------------------------------------------------------------------
+
+const SEED_PERSONAS: PersonaSummary[] = [
+  {
+    name: 'architect',
+    permissionMode: 'read-only',
+    allowedTools: ['file', 'web', 'mimir', 'ravn'],
+    iterationBudget: 25,
+    isBuiltin: true,
+    hasOverride: false,
+    producesEvent: '',
+    consumesEvents: [],
+  },
+  {
+    name: 'autonomous-agent',
+    permissionMode: 'full-access',
+    allowedTools: [],
+    iterationBudget: 100,
+    isBuiltin: true,
+    hasOverride: false,
+    producesEvent: '',
+    consumesEvents: [],
+  },
+  {
+    name: 'coder',
+    permissionMode: 'workspace_write',
+    allowedTools: ['file', 'git', 'terminal', 'ravn'],
+    iterationBudget: 40,
+    isBuiltin: true,
+    hasOverride: false,
+    producesEvent: 'code.changed',
+    consumesEvents: [
+      'review.changes_requested',
+      'security.changes_requested',
+      'code.requested',
+      'bug.fix.requested',
+      'feature.requested',
+    ],
+  },
+  {
+    name: 'coding-agent',
+    permissionMode: 'workspace-write',
+    allowedTools: ['mimir_query', 'file', 'git', 'terminal', 'web', 'todo', 'ravn'],
+    iterationBudget: 40,
+    isBuiltin: true,
+    hasOverride: false,
+    producesEvent: 'code.changed',
+    consumesEvents: ['code.requested', 'bug.fix.requested', 'feature.requested'],
+  },
+  {
+    name: 'coordinator',
+    permissionMode: 'workspace-write',
+    allowedTools: ['cascade', 'file', 'ravn', 'todo'],
+    iterationBudget: 30,
+    isBuiltin: true,
+    hasOverride: false,
+    producesEvent: '',
+    consumesEvents: [],
+  },
+  {
+    name: 'draft-a-note',
+    permissionMode: 'read-only',
+    allowedTools: ['file', 'web', 'mimir', 'ravn'],
+    iterationBudget: 15,
+    isBuiltin: true,
+    hasOverride: false,
+    producesEvent: '',
+    consumesEvents: [],
+  },
+  {
+    name: 'health-auditor',
+    permissionMode: 'read-only',
+    allowedTools: ['file', 'terminal', 'web', 'ravn'],
+    iterationBudget: 20,
+    isBuiltin: true,
+    hasOverride: false,
+    producesEvent: 'health.completed',
+    consumesEvents: ['health.check.requested', 'cron.hourly'],
+  },
+  {
+    name: 'investigator',
+    permissionMode: 'workspace-write',
+    allowedTools: ['file', 'git', 'terminal', 'web', 'ravn'],
+    iterationBudget: 40,
+    isBuiltin: true,
+    hasOverride: false,
+    producesEvent: 'investigation.completed',
+    consumesEvents: ['bug.reported', 'incident.opened', 'qa.failed'],
+  },
+  {
+    name: 'mimir-curator',
+    permissionMode: 'read-only',
+    allowedTools: ['file', 'mimir', 'ravn'],
+    iterationBudget: 20,
+    isBuiltin: true,
+    hasOverride: false,
+    producesEvent: '',
+    consumesEvents: [],
+  },
+  {
+    name: 'office-hours',
+    permissionMode: 'read-only',
+    allowedTools: ['file', 'web', 'mimir', 'ravn'],
+    iterationBudget: 20,
+    isBuiltin: true,
+    hasOverride: false,
+    producesEvent: '',
+    consumesEvents: [],
+  },
+  {
+    name: 'planning-agent',
+    permissionMode: 'read-only',
+    allowedTools: ['file', 'web', 'mimir', 'ravn', 'todo'],
+    iterationBudget: 25,
+    isBuiltin: true,
+    hasOverride: false,
+    producesEvent: '',
+    consumesEvents: [],
+  },
+  {
+    name: 'produce-recap',
+    permissionMode: 'read-only',
+    allowedTools: ['file', 'mimir', 'ravn'],
+    iterationBudget: 15,
+    isBuiltin: true,
+    hasOverride: false,
+    producesEvent: '',
+    consumesEvents: [],
+  },
+  {
+    name: 'qa-agent',
+    permissionMode: 'workspace-write',
+    allowedTools: ['file', 'git', 'terminal', 'ravn'],
+    iterationBudget: 30,
+    isBuiltin: true,
+    hasOverride: false,
+    producesEvent: 'qa.completed',
+    consumesEvents: ['review.completed', 'test.requested'],
+  },
+  {
+    name: 'research-agent',
+    permissionMode: 'read-only',
+    allowedTools: ['mimir_query', 'web', 'file', 'ravn'],
+    iterationBudget: 30,
+    isBuiltin: true,
+    hasOverride: false,
+    producesEvent: '',
+    consumesEvents: [],
+  },
+  {
+    name: 'research-and-distill',
+    permissionMode: 'read-only',
+    allowedTools: ['file', 'web', 'mimir', 'ravn'],
+    iterationBudget: 25,
+    isBuiltin: true,
+    hasOverride: false,
+    producesEvent: '',
+    consumesEvents: [],
+  },
+  {
+    name: 'retro-analyst',
+    permissionMode: 'read-only',
+    allowedTools: ['file', 'mimir', 'ravn'],
+    iterationBudget: 20,
+    isBuiltin: true,
+    hasOverride: false,
+    producesEvent: '',
+    consumesEvents: [],
+  },
+  {
+    name: 'reviewer',
+    permissionMode: 'read-only',
+    allowedTools: ['file', 'git', 'web', 'ravn'],
+    iterationBudget: 25,
+    isBuiltin: true,
+    hasOverride: false,
+    producesEvent: 'review.completed',
+    consumesEvents: ['code.changed', 'review.requested'],
+  },
+  {
+    name: 'security',
+    permissionMode: 'read_only',
+    allowedTools: ['file', 'git', 'ravn'],
+    iterationBudget: 60,
+    isBuiltin: true,
+    hasOverride: false,
+    producesEvent: 'security.completed',
+    consumesEvents: ['code.changed'],
+  },
+  {
+    name: 'security-auditor',
+    permissionMode: 'read-only',
+    allowedTools: ['file', 'terminal', 'web', 'ravn'],
+    iterationBudget: 30,
+    isBuiltin: true,
+    hasOverride: false,
+    producesEvent: '',
+    consumesEvents: [],
+  },
+  {
+    name: 'ship-agent',
+    permissionMode: 'workspace-write',
+    allowedTools: ['file', 'git', 'terminal', 'web', 'ravn'],
+    iterationBudget: 15,
+    isBuiltin: true,
+    hasOverride: false,
+    producesEvent: 'ship.completed',
+    consumesEvents: ['qa.completed', 'ship.requested'],
+  },
+  {
+    name: 'verifier',
+    permissionMode: 'workspace-write',
+    allowedTools: ['file', 'git', 'terminal', 'web', 'ravn'],
+    iterationBudget: 30,
+    isBuiltin: true,
+    hasOverride: false,
+    producesEvent: 'verification.completed',
+    consumesEvents: ['qa.completed', 'code.changed', 'verification.requested'],
+  },
+];
+
+function summaryToDetail(summary: PersonaSummary): PersonaDetail {
+  return {
+    ...summary,
+    systemPromptTemplate: `You are the ${summary.name} persona.`,
+    forbiddenTools: [],
+    llm: { primaryAlias: 'balanced', thinkingEnabled: false, maxTokens: 0 },
+    produces: { eventType: summary.producesEvent, schemaDef: {} },
+    consumes: { eventTypes: summary.consumesEvents, injects: [] },
+    fanIn: { strategy: 'merge', contributesTo: '' },
+    yamlSource: `# ${summary.name}\n# built-in persona\npermission_mode: ${summary.permissionMode}\niteration_budget: ${summary.iterationBudget}\n`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Seed — ravens (deployed fleet)
+// ---------------------------------------------------------------------------
+
+const SEED_RAVENS: Raven[] = [
+  {
+    id: 'r1',
+    name: 'coder-asgard',
+    rune: 'ᚱ',
+    persona: 'coding-agent',
+    location: 'asgard',
+    deployment: 'k8s',
+    state: 'active',
+    uptime: 7200,
+    lastTick: '2026-04-19T09:55:00Z',
+    budget: { spentUsd: 2.4, capUsd: 10.0, warnAt: 8.0 },
+    mounts: [{ name: 'local', role: 'primary', priority: 0 }],
+  },
+  {
+    id: 'r2',
+    name: 'reviewer-midgard',
+    rune: 'ᚱ',
+    persona: 'reviewer',
+    location: 'midgard',
+    deployment: 'k8s',
+    state: 'idle',
+    uptime: 14400,
+    lastTick: '2026-04-19T09:00:00Z',
+    budget: { spentUsd: 0.8, capUsd: 5.0, warnAt: 4.0 },
+    mounts: [{ name: 'shared', role: 'primary', priority: 0 }],
+  },
+  {
+    id: 'r3',
+    name: 'qa-midgard',
+    rune: 'ᚱ',
+    persona: 'qa-agent',
+    location: 'midgard',
+    deployment: 'systemd',
+    state: 'active',
+    uptime: 3600,
+    lastTick: '2026-04-19T09:58:00Z',
+    budget: { spentUsd: 1.1, capUsd: 8.0, warnAt: 6.5 },
+    mounts: [
+      { name: 'local', role: 'primary', priority: 0 },
+      { name: 'domain', role: 'ro', priority: 1 },
+    ],
+  },
+  {
+    id: 'r4',
+    name: 'health-jotunheim',
+    rune: 'ᚱ',
+    persona: 'health-auditor',
+    location: 'jotunheim',
+    deployment: 'k8s',
+    state: 'idle',
+    uptime: 86400,
+    lastTick: '2026-04-19T09:00:00Z',
+    budget: { spentUsd: 0.3, capUsd: 3.0, warnAt: 2.5 },
+    mounts: [{ name: 'local', role: 'primary', priority: 0 }],
+  },
+  {
+    id: 'r5',
+    name: 'investigator-desk',
+    rune: 'ᚱ',
+    persona: 'investigator',
+    location: 'desk',
+    deployment: 'ephemeral',
+    state: 'suspended',
+    uptime: 0,
+    lastTick: '2026-04-18T18:30:00Z',
+    budget: { spentUsd: 4.2, capUsd: 10.0, warnAt: 8.0 },
+    mounts: [{ name: 'local', role: 'primary', priority: 0 }],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Seed — messages
+// ---------------------------------------------------------------------------
+
+const SEED_MESSAGES: Message[] = [
+  { id: 'm1', sessionId: 's1', kind: 'system', body: 'You are a coding agent.', ts: '2026-04-19T09:12:34Z' },
+  { id: 'm2', sessionId: 's1', kind: 'user', body: 'Implement the auth middleware', ts: '2026-04-19T09:12:35Z' },
+  { id: 'm3', sessionId: 's1', kind: 'think', body: 'I need to understand the existing auth setup first.', ts: '2026-04-19T09:12:36Z' },
+  { id: 'm4', sessionId: 's1', kind: 'tool_call', body: 'read("src/auth/middleware.py")', ts: '2026-04-19T09:12:37Z', toolName: 'read' },
+  { id: 'm5', sessionId: 's1', kind: 'tool_result', body: '# auth middleware content', ts: '2026-04-19T09:12:38Z', toolName: 'read' },
+  { id: 'm6', sessionId: 's1', kind: 'asst', body: 'I have reviewed the existing auth setup. Implementing now.', ts: '2026-04-19T09:12:40Z' },
+  { id: 'm7', sessionId: 's1', kind: 'emit', body: 'code.changed', ts: '2026-04-19T09:55:00Z', eventName: 'code.changed' },
+  { id: 'm8', sessionId: 's2', kind: 'system', body: 'You are a reviewer persona.', ts: '2026-04-19T08:45:11Z' },
+  { id: 'm9', sessionId: 's2', kind: 'user', body: 'Review the auth PR', ts: '2026-04-19T08:45:12Z' },
+  { id: 'm10', sessionId: 's2', kind: 'asst', body: 'PR looks good. LGTM.', ts: '2026-04-19T08:46:00Z' },
+];
+
+// ---------------------------------------------------------------------------
+// Seed — sessions
+// ---------------------------------------------------------------------------
+
+const SEED_SESSIONS: Session[] = [
+  {
+    id: 's1',
+    ravnId: 'r1',
+    title: 'implement auth middleware',
+    triggerId: 'trig1',
+    state: 'active',
+    startedAt: '2026-04-19T09:12:34Z',
+    lastAt: '2026-04-19T09:55:00Z',
+    messages: SEED_MESSAGES.filter((m) => m.sessionId === 's1'),
+  },
+  {
+    id: 's2',
+    ravnId: 'r2',
+    title: 'review auth PR',
+    state: 'completed',
+    startedAt: '2026-04-19T08:45:11Z',
+    lastAt: '2026-04-19T08:46:00Z',
+    messages: SEED_MESSAGES.filter((m) => m.sessionId === 's2'),
+  },
+  {
+    id: 's3',
+    ravnId: 'r3',
+    title: 'run test suite',
+    state: 'idle',
+    startedAt: '2026-04-19T07:55:22Z',
+    messages: [],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Seed — triggers
+// ---------------------------------------------------------------------------
+
+const SEED_TRIGGERS: Trigger[] = [
+  { id: 'trig1', ravnId: 'r1', kind: 'event', topic: 'feature.requested', producesEvent: 'code.changed' },
+  { id: 'trig2', ravnId: 'r2', kind: 'event', topic: 'code.changed', producesEvent: 'review.completed' },
+  { id: 'trig3', ravnId: 'r3', kind: 'event', topic: 'review.completed' },
+  { id: 'trig4', ravnId: 'r4', kind: 'cron', schedule: '0 * * * *', description: 'hourly health check' },
+  { id: 'trig5', ravnId: 'r1', kind: 'webhook', path: '/hooks/github' },
+  { id: 'trig6', ravnId: 'r5', kind: 'manual' },
+];
+
+// ---------------------------------------------------------------------------
+// Mock persona store
+// ---------------------------------------------------------------------------
+
+function createMockPersonaStore(): IPersonaStore {
+  const customPersonas: PersonaDetail[] = [];
+
+  return {
+    async listPersonas(filter: PersonaFilter = 'all') {
+      if (filter === 'builtin') return SEED_PERSONAS;
+      if (filter === 'custom') return customPersonas.map((p) => toSummary(p));
+      return [...SEED_PERSONAS, ...customPersonas.map((p) => toSummary(p))];
+    },
+
+    async getPersona(name: string) {
+      const custom = customPersonas.find((p) => p.name === name);
+      if (custom) return custom;
+      const seed = SEED_PERSONAS.find((p) => p.name === name);
+      if (seed) return summaryToDetail(seed);
+      throw new Error(`Persona "${name}" not found`);
+    },
+
+    async getPersonaYaml(name: string) {
+      const seed = SEED_PERSONAS.find((p) => p.name === name);
+      const custom = customPersonas.find((p) => p.name === name);
+      const found = custom ?? (seed ? summaryToDetail(seed) : null);
+      if (!found) throw new Error(`Persona "${name}" not found`);
+      return found.yamlSource;
+    },
+
+    async createPersona(req: PersonaCreateRequest) {
+      const detail: PersonaDetail = {
+        name: req.name,
+        permissionMode: req.permissionMode,
+        allowedTools: req.allowedTools,
+        iterationBudget: req.iterationBudget,
+        isBuiltin: false,
+        hasOverride: false,
+        producesEvent: req.producesEventType,
+        consumesEvents: req.consumesEventTypes,
+        systemPromptTemplate: req.systemPromptTemplate,
+        forbiddenTools: req.forbiddenTools,
+        llm: {
+          primaryAlias: req.llmPrimaryAlias,
+          thinkingEnabled: req.llmThinkingEnabled,
+          maxTokens: req.llmMaxTokens,
+        },
+        produces: { eventType: req.producesEventType, schemaDef: {} },
+        consumes: { eventTypes: req.consumesEventTypes, injects: req.consumesInjects },
+        fanIn: { strategy: req.fanInStrategy, contributesTo: req.fanInContributesTo },
+        yamlSource: `# ${req.name}\n`,
+      };
+      customPersonas.push(detail);
+      return detail;
+    },
+
+    async updatePersona(name: string, req: PersonaCreateRequest) {
+      const idx = customPersonas.findIndex((p) => p.name === name);
+      if (idx === -1) throw new Error(`Persona "${name}" not found or is built-in`);
+      const updated: PersonaDetail = {
+        ...customPersonas[idx]!,
+        permissionMode: req.permissionMode,
+        allowedTools: req.allowedTools,
+        iterationBudget: req.iterationBudget,
+        systemPromptTemplate: req.systemPromptTemplate,
+        forbiddenTools: req.forbiddenTools,
+        llm: {
+          primaryAlias: req.llmPrimaryAlias,
+          thinkingEnabled: req.llmThinkingEnabled,
+          maxTokens: req.llmMaxTokens,
+        },
+      };
+      customPersonas[idx] = updated;
+      return updated;
+    },
+
+    async deletePersona(name: string) {
+      const idx = customPersonas.findIndex((p) => p.name === name);
+      if (idx === -1) throw new Error(`Persona "${name}" not found or is built-in`);
+      customPersonas.splice(idx, 1);
+    },
+
+    async forkPersona(name: string, req: PersonaForkRequest) {
+      const seed = SEED_PERSONAS.find((p) => p.name === name);
+      const custom = customPersonas.find((p) => p.name === name);
+      const source = custom ?? (seed ? summaryToDetail(seed) : null);
+      if (!source) throw new Error(`Persona "${name}" not found`);
+      const forked: PersonaDetail = {
+        ...source,
+        name: req.newName,
+        isBuiltin: false,
+        hasOverride: false,
+        yamlSource: `# ${req.newName} (forked from ${name})\n`,
+      };
+      customPersonas.push(forked);
+      return forked;
+    },
+  };
+}
+
+function toSummary(detail: PersonaDetail): PersonaSummary {
+  return {
+    name: detail.name,
+    permissionMode: detail.permissionMode,
+    allowedTools: detail.allowedTools,
+    iterationBudget: detail.iterationBudget,
+    isBuiltin: detail.isBuiltin,
+    hasOverride: detail.hasOverride,
+    producesEvent: detail.producesEvent,
+    consumesEvents: detail.consumesEvents,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock raven stream
+// ---------------------------------------------------------------------------
+
+function createMockRavenStream(): IRavenStream {
+  return {
+    async listRavens() {
+      return SEED_RAVENS;
+    },
+
+    async getRaven(id: string) {
+      const raven = SEED_RAVENS.find((r) => r.id === id);
+      if (!raven) throw new Error(`Raven "${id}" not found`);
+      return raven;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock session stream
+// ---------------------------------------------------------------------------
+
+function createMockSessionStream(): ISessionStream {
+  return {
+    async listSessions(ravnId?: string) {
+      if (ravnId) return SEED_SESSIONS.filter((s) => s.ravnId === ravnId);
+      return SEED_SESSIONS;
+    },
+
+    async getSession(id: string) {
+      const session = SEED_SESSIONS.find((s) => s.id === id);
+      if (!session) throw new Error(`Session "${id}" not found`);
+      return session;
+    },
+
+    async getMessages(sessionId: string) {
+      return SEED_MESSAGES.filter((m) => m.sessionId === sessionId);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock trigger store
+// ---------------------------------------------------------------------------
+
+function createMockTriggerStore(): ITriggerStore {
+  const custom: Trigger[] = [];
+  let nextId = 100;
+
+  return {
+    async listTriggers(ravnId?: string) {
+      const all = [...SEED_TRIGGERS, ...custom];
+      if (ravnId) return all.filter((t) => t.ravnId === ravnId);
+      return all;
+    },
+
+    async createTrigger(trigger: TriggerInput) {
+      const created = { ...trigger, id: `trig${nextId++}` } as Trigger;
+      custom.push(created);
+      return created;
+    },
+
+    async deleteTrigger(id: string) {
+      const idx = custom.findIndex((t) => t.id === id);
+      if (idx === -1) throw new Error(`Trigger "${id}" not found or is seed data`);
+      custom.splice(idx, 1);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock budget stream
+// ---------------------------------------------------------------------------
+
+const FLEET_BUDGET: BudgetState = { spentUsd: 8.8, capUsd: 36.0, warnAt: 28.0 };
+
+function createMockBudgetStream(): IBudgetStream {
+  return {
+    async getFleetBudget() {
+      return FLEET_BUDGET;
+    },
+
+    async getRavenBudget(ravnId: string) {
+      const raven = SEED_RAVENS.find((r) => r.id === ravnId);
+      if (!raven) throw new Error(`Raven "${ravnId}" not found`);
+      return raven.budget;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public factory
+// ---------------------------------------------------------------------------
+
+export function createMockRavnService(): IRavnService {
+  return {
+    personas: createMockPersonaStore(),
+    ravens: createMockRavenStream(),
+    sessions: createMockSessionStream(),
+    triggers: createMockTriggerStore(),
+    budget: createMockBudgetStream(),
+  };
+}

--- a/web-next/packages/plugin-ravn/src/domain.test.ts
+++ b/web-next/packages/plugin-ravn/src/domain.test.ts
@@ -1,0 +1,334 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ravenStateSchema,
+  ravenMountSchema,
+  ravenSchema,
+  messageKindSchema,
+  messageSchema,
+  sessionStateSchema,
+  sessionSchema,
+  cronTriggerSchema,
+  eventTriggerSchema,
+  webhookTriggerSchema,
+  manualTriggerSchema,
+  triggerSchema,
+} from './domain';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const validMount = { name: 'local', role: 'primary' as const, priority: 0 };
+
+const validRaven = {
+  id: 'r1',
+  name: 'coder-asgard',
+  rune: 'ᚱ',
+  persona: 'coding-agent',
+  location: 'asgard',
+  deployment: 'k8s',
+  state: 'active' as const,
+  uptime: 7200,
+  lastTick: '2026-04-19T09:55:00Z',
+  budget: { spentUsd: 2.4, capUsd: 10.0, warnAt: 8.0 },
+  mounts: [validMount],
+};
+
+const validMessage = {
+  id: 'm1',
+  sessionId: 's1',
+  kind: 'user' as const,
+  body: 'hello',
+  ts: '2026-04-19T09:00:00Z',
+};
+
+const validSession = {
+  id: 's1',
+  ravnId: 'r1',
+  title: 'implement auth',
+  state: 'active' as const,
+  startedAt: '2026-04-19T09:00:00Z',
+  messages: [validMessage],
+};
+
+// ---------------------------------------------------------------------------
+// ravenStateSchema
+// ---------------------------------------------------------------------------
+
+describe('ravenStateSchema', () => {
+  it('accepts all valid states', () => {
+    for (const s of ['active', 'idle', 'suspended', 'failed']) {
+      expect(ravenStateSchema.parse(s)).toBe(s);
+    }
+  });
+
+  it('rejects unknown state', () => {
+    expect(() => ravenStateSchema.parse('flying')).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ravenMountSchema
+// ---------------------------------------------------------------------------
+
+describe('ravenMountSchema', () => {
+  it('parses a valid mount', () => {
+    const result = ravenMountSchema.parse(validMount);
+    expect(result.name).toBe('local');
+    expect(result.role).toBe('primary');
+    expect(result.priority).toBe(0);
+  });
+
+  it('accepts all role values', () => {
+    for (const role of ['primary', 'archive', 'ro']) {
+      expect(ravenMountSchema.parse({ ...validMount, role })).toMatchObject({ role });
+    }
+  });
+
+  it('rejects negative priority', () => {
+    expect(() => ravenMountSchema.parse({ ...validMount, priority: -1 })).toThrow();
+  });
+
+  it('rejects empty name', () => {
+    expect(() => ravenMountSchema.parse({ ...validMount, name: '' })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ravenSchema
+// ---------------------------------------------------------------------------
+
+describe('ravenSchema', () => {
+  it('parses a valid raven', () => {
+    const result = ravenSchema.parse(validRaven);
+    expect(result.id).toBe('r1');
+    expect(result.state).toBe('active');
+    expect(result.mounts).toHaveLength(1);
+  });
+
+  it('round-trips through parse', () => {
+    const result = ravenSchema.parse(validRaven);
+    expect(ravenSchema.parse(result)).toEqual(result);
+  });
+
+  it('rejects negative uptime', () => {
+    expect(() => ravenSchema.parse({ ...validRaven, uptime: -1 })).toThrow();
+  });
+
+  it('rejects empty id', () => {
+    expect(() => ravenSchema.parse({ ...validRaven, id: '' })).toThrow();
+  });
+
+  it('rejects invalid budget', () => {
+    expect(() =>
+      ravenSchema.parse({ ...validRaven, budget: { spentUsd: -1, capUsd: 10, warnAt: 8 } }),
+    ).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// messageKindSchema
+// ---------------------------------------------------------------------------
+
+describe('messageKindSchema', () => {
+  it('accepts all 7 kinds', () => {
+    for (const k of ['user', 'asst', 'system', 'tool_call', 'tool_result', 'emit', 'think']) {
+      expect(messageKindSchema.parse(k)).toBe(k);
+    }
+  });
+
+  it('rejects unknown kind', () => {
+    expect(() => messageKindSchema.parse('narrate')).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// messageSchema
+// ---------------------------------------------------------------------------
+
+describe('messageSchema', () => {
+  it('parses minimal message', () => {
+    const result = messageSchema.parse(validMessage);
+    expect(result.kind).toBe('user');
+    expect(result.toolName).toBeUndefined();
+    expect(result.eventName).toBeUndefined();
+  });
+
+  it('parses tool_call message with toolName', () => {
+    const msg = { ...validMessage, kind: 'tool_call', toolName: 'read' };
+    const result = messageSchema.parse(msg);
+    expect(result.toolName).toBe('read');
+  });
+
+  it('parses emit message with eventName', () => {
+    const msg = { ...validMessage, kind: 'emit', eventName: 'code.changed' };
+    const result = messageSchema.parse(msg);
+    expect(result.eventName).toBe('code.changed');
+  });
+
+  it('round-trips through parse', () => {
+    const result = messageSchema.parse(validMessage);
+    expect(messageSchema.parse(result)).toEqual(result);
+  });
+
+  it('rejects empty id', () => {
+    expect(() => messageSchema.parse({ ...validMessage, id: '' })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sessionStateSchema
+// ---------------------------------------------------------------------------
+
+describe('sessionStateSchema', () => {
+  it('accepts all 5 states', () => {
+    for (const s of ['active', 'idle', 'suspended', 'failed', 'completed']) {
+      expect(sessionStateSchema.parse(s)).toBe(s);
+    }
+  });
+
+  it('rejects unknown state', () => {
+    expect(() => sessionStateSchema.parse('pending')).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sessionSchema
+// ---------------------------------------------------------------------------
+
+describe('sessionSchema', () => {
+  it('parses a valid session', () => {
+    const result = sessionSchema.parse(validSession);
+    expect(result.id).toBe('s1');
+    expect(result.messages).toHaveLength(1);
+    expect(result.triggerId).toBeUndefined();
+    expect(result.lastAt).toBeUndefined();
+  });
+
+  it('parses session with optional fields', () => {
+    const result = sessionSchema.parse({
+      ...validSession,
+      triggerId: 't1',
+      lastAt: '2026-04-19T10:00:00Z',
+    });
+    expect(result.triggerId).toBe('t1');
+    expect(result.lastAt).toBe('2026-04-19T10:00:00Z');
+  });
+
+  it('round-trips through parse', () => {
+    const result = sessionSchema.parse(validSession);
+    expect(sessionSchema.parse(result)).toEqual(result);
+  });
+
+  it('rejects empty ravnId', () => {
+    expect(() => sessionSchema.parse({ ...validSession, ravnId: '' })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Trigger schemas
+// ---------------------------------------------------------------------------
+
+describe('cronTriggerSchema', () => {
+  const validCron = {
+    id: 't1',
+    ravnId: 'r1',
+    kind: 'cron' as const,
+    schedule: '0 * * * *',
+    description: 'hourly health check',
+  };
+
+  it('parses a valid cron trigger', () => {
+    const result = cronTriggerSchema.parse(validCron);
+    expect(result.kind).toBe('cron');
+    expect(result.schedule).toBe('0 * * * *');
+  });
+
+  it('rejects empty schedule', () => {
+    expect(() => cronTriggerSchema.parse({ ...validCron, schedule: '' })).toThrow();
+  });
+});
+
+describe('eventTriggerSchema', () => {
+  const validEvent = {
+    id: 't2',
+    ravnId: 'r1',
+    kind: 'event' as const,
+    topic: 'code.changed',
+    producesEvent: 'review.started',
+  };
+
+  it('parses a valid event trigger', () => {
+    const result = eventTriggerSchema.parse(validEvent);
+    expect(result.kind).toBe('event');
+    expect(result.producesEvent).toBe('review.started');
+  });
+
+  it('allows omitting producesEvent', () => {
+    const { producesEvent: _, ...noProduces } = validEvent;
+    const result = eventTriggerSchema.parse(noProduces);
+    expect(result.producesEvent).toBeUndefined();
+  });
+});
+
+describe('webhookTriggerSchema', () => {
+  const validWebhook = {
+    id: 't3',
+    ravnId: 'r1',
+    kind: 'webhook' as const,
+    path: '/hooks/github',
+  };
+
+  it('parses a valid webhook trigger', () => {
+    const result = webhookTriggerSchema.parse(validWebhook);
+    expect(result.kind).toBe('webhook');
+    expect(result.path).toBe('/hooks/github');
+  });
+
+  it('rejects empty path', () => {
+    expect(() => webhookTriggerSchema.parse({ ...validWebhook, path: '' })).toThrow();
+  });
+});
+
+describe('manualTriggerSchema', () => {
+  const validManual = { id: 't4', ravnId: 'r1', kind: 'manual' as const };
+
+  it('parses a valid manual trigger', () => {
+    const result = manualTriggerSchema.parse(validManual);
+    expect(result.kind).toBe('manual');
+  });
+});
+
+describe('triggerSchema (discriminated union)', () => {
+  it('dispatches to correct variant by kind', () => {
+    const cron = triggerSchema.parse({
+      id: 't1',
+      ravnId: 'r1',
+      kind: 'cron',
+      schedule: '0 * * * *',
+      description: 'hourly',
+    });
+    expect(cron.kind).toBe('cron');
+
+    const manual = triggerSchema.parse({ id: 't4', ravnId: 'r1', kind: 'manual' });
+    expect(manual.kind).toBe('manual');
+  });
+
+  it('rejects unknown kind', () => {
+    expect(() =>
+      triggerSchema.parse({ id: 't9', ravnId: 'r1', kind: 'timer' }),
+    ).toThrow();
+  });
+
+  it('round-trips all kinds', () => {
+    const triggers = [
+      { id: 't1', ravnId: 'r1', kind: 'cron' as const, schedule: '* * * * *', description: '' },
+      { id: 't2', ravnId: 'r1', kind: 'event' as const, topic: 'code.changed' },
+      { id: 't3', ravnId: 'r1', kind: 'webhook' as const, path: '/hook' },
+      { id: 't4', ravnId: 'r1', kind: 'manual' as const },
+    ];
+    for (const t of triggers) {
+      expect(triggerSchema.parse(triggerSchema.parse(t))).toEqual(triggerSchema.parse(t));
+    }
+  });
+});

--- a/web-next/packages/plugin-ravn/src/domain.ts
+++ b/web-next/packages/plugin-ravn/src/domain.ts
@@ -1,0 +1,222 @@
+/**
+ * Ravn plugin — local domain types.
+ *
+ * Ravn is the canonical authority for the runtime fleet model.
+ * Persona, ToolRegistry, EventCatalog, BudgetState are shared cross-plugin
+ * types that live in @niuulabs/domain; the shapes below are Ravn-specific.
+ *
+ * Persona API types (PersonaSummary, PersonaDetail, etc.) are the
+ * HTTP-layer representation, distinct from the template schema in @niuulabs/domain.
+ */
+
+import { z } from 'zod';
+import { budgetStateSchema } from '@niuulabs/domain';
+
+// ---------------------------------------------------------------------------
+// Raven — deployed agent node
+// ---------------------------------------------------------------------------
+
+export const ravenStateSchema = z.enum(['active', 'idle', 'suspended', 'failed']);
+export type RavenState = z.infer<typeof ravenStateSchema>;
+
+export const ravenMountSchema = z.object({
+  name: z.string().min(1),
+  role: z.enum(['primary', 'archive', 'ro']),
+  priority: z.number().int().nonnegative(),
+});
+export type RavenMount = z.infer<typeof ravenMountSchema>;
+
+export const ravenSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  rune: z.string().min(1),
+  persona: z.string().min(1),
+  location: z.string().min(1),
+  deployment: z.string().min(1),
+  state: ravenStateSchema,
+  uptime: z.number().nonnegative(),
+  lastTick: z.string(),
+  budget: budgetStateSchema,
+  mounts: z.array(ravenMountSchema),
+});
+export type Raven = z.infer<typeof ravenSchema>;
+
+// ---------------------------------------------------------------------------
+// Message — transcript unit with 7 kinds
+// ---------------------------------------------------------------------------
+
+export const messageKindSchema = z.enum([
+  'user',
+  'asst',
+  'system',
+  'tool_call',
+  'tool_result',
+  'emit',
+  'think',
+]);
+export type MessageKind = z.infer<typeof messageKindSchema>;
+
+export const messageSchema = z.object({
+  id: z.string().min(1),
+  sessionId: z.string().min(1),
+  kind: messageKindSchema,
+  body: z.string(),
+  ts: z.string(),
+  toolName: z.string().optional(),
+  eventName: z.string().optional(),
+});
+export type Message = z.infer<typeof messageSchema>;
+
+// ---------------------------------------------------------------------------
+// Session — live interaction thread
+// ---------------------------------------------------------------------------
+
+export const sessionStateSchema = z.enum([
+  'active',
+  'idle',
+  'suspended',
+  'failed',
+  'completed',
+]);
+export type SessionState = z.infer<typeof sessionStateSchema>;
+
+export const sessionSchema = z.object({
+  id: z.string().min(1),
+  ravnId: z.string().min(1),
+  title: z.string(),
+  triggerId: z.string().optional(),
+  state: sessionStateSchema,
+  startedAt: z.string(),
+  lastAt: z.string().optional(),
+  messages: z.array(messageSchema),
+});
+export type Session = z.infer<typeof sessionSchema>;
+
+// ---------------------------------------------------------------------------
+// Trigger — initiative subscription (discriminated union by kind)
+// ---------------------------------------------------------------------------
+
+export const cronTriggerSchema = z.object({
+  id: z.string().min(1),
+  ravnId: z.string().min(1),
+  kind: z.literal('cron'),
+  schedule: z.string().min(1),
+  description: z.string(),
+});
+export type CronTrigger = z.infer<typeof cronTriggerSchema>;
+
+export const eventTriggerSchema = z.object({
+  id: z.string().min(1),
+  ravnId: z.string().min(1),
+  kind: z.literal('event'),
+  topic: z.string().min(1),
+  producesEvent: z.string().optional(),
+});
+export type EventTrigger = z.infer<typeof eventTriggerSchema>;
+
+export const webhookTriggerSchema = z.object({
+  id: z.string().min(1),
+  ravnId: z.string().min(1),
+  kind: z.literal('webhook'),
+  path: z.string().min(1),
+});
+export type WebhookTrigger = z.infer<typeof webhookTriggerSchema>;
+
+export const manualTriggerSchema = z.object({
+  id: z.string().min(1),
+  ravnId: z.string().min(1),
+  kind: z.literal('manual'),
+});
+export type ManualTrigger = z.infer<typeof manualTriggerSchema>;
+
+export const triggerSchema = z.discriminatedUnion('kind', [
+  cronTriggerSchema,
+  eventTriggerSchema,
+  webhookTriggerSchema,
+  manualTriggerSchema,
+]);
+export type Trigger = z.infer<typeof triggerSchema>;
+
+/**
+ * Trigger creation input — the discriminated union without the server-assigned id.
+ *
+ * Defined as an explicit union (not Omit<Trigger, 'id'>) so TypeScript can
+ * correctly narrow by the `kind` discriminant in adapter code.
+ */
+export type TriggerInput =
+  | Omit<CronTrigger, 'id'>
+  | Omit<EventTrigger, 'id'>
+  | Omit<WebhookTrigger, 'id'>
+  | Omit<ManualTrigger, 'id'>;
+
+// ---------------------------------------------------------------------------
+// Persona API types (copied from web/src/modules/ravn/api/types.ts)
+//
+// These are the camelCase HTTP-layer representations, distinct from the
+// domain-level Persona template schema in @niuulabs/domain.
+// ---------------------------------------------------------------------------
+
+export type PersonaFilter = 'all' | 'builtin' | 'custom';
+
+export interface PersonaLLM {
+  primaryAlias: string;
+  thinkingEnabled: boolean;
+  maxTokens: number;
+}
+
+export interface PersonaProducesConfig {
+  eventType: string;
+  schemaDef: Record<string, unknown>;
+}
+
+export interface PersonaConsumesConfig {
+  eventTypes: string[];
+  injects: string[];
+}
+
+export interface PersonaFanInConfig {
+  strategy: string;
+  contributesTo: string;
+}
+
+export interface PersonaSummary {
+  name: string;
+  permissionMode: string;
+  allowedTools: string[];
+  iterationBudget: number;
+  isBuiltin: boolean;
+  hasOverride: boolean;
+  producesEvent: string;
+  consumesEvents: string[];
+}
+
+export interface PersonaDetail extends PersonaSummary {
+  systemPromptTemplate: string;
+  forbiddenTools: string[];
+  llm: PersonaLLM;
+  produces: PersonaProducesConfig;
+  consumes: PersonaConsumesConfig;
+  fanIn: PersonaFanInConfig;
+  yamlSource: string;
+}
+
+export interface PersonaCreateRequest {
+  name: string;
+  systemPromptTemplate: string;
+  allowedTools: string[];
+  forbiddenTools: string[];
+  permissionMode: string;
+  iterationBudget: number;
+  llmPrimaryAlias: string;
+  llmThinkingEnabled: boolean;
+  llmMaxTokens: number;
+  producesEventType: string;
+  consumesEventTypes: string[];
+  consumesInjects: string[];
+  fanInStrategy: string;
+  fanInContributesTo: string;
+}
+
+export interface PersonaForkRequest {
+  newName: string;
+}

--- a/web-next/packages/plugin-ravn/src/index.tsx
+++ b/web-next/packages/plugin-ravn/src/index.tsx
@@ -1,0 +1,48 @@
+import { createRoute, type AnyRoute } from '@tanstack/react-router';
+import { definePlugin } from '@niuulabs/plugin-sdk';
+import { RavnPage } from './ui/RavnPage';
+
+export const ravnPlugin = definePlugin({
+  id: 'ravn',
+  rune: 'ᚱ',
+  title: 'Ravn · the flock',
+  subtitle: 'agent fleet console',
+  routes: (rootRoute: AnyRoute) => [
+    createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/ravn',
+      component: RavnPage,
+    }),
+  ],
+});
+
+export { createMockRavnService } from './adapters/mock';
+export { createHttpRavnService } from './adapters/http';
+export type {
+  IRavnService,
+  IPersonaStore,
+  IRavenStream,
+  ISessionStream,
+  ITriggerStore,
+  IBudgetStream,
+} from './ports';
+export type {
+  Raven,
+  RavenState,
+  RavenMount,
+  Session,
+  SessionState,
+  Message,
+  MessageKind,
+  Trigger,
+  TriggerInput,
+  CronTrigger,
+  EventTrigger,
+  WebhookTrigger,
+  ManualTrigger,
+  PersonaSummary,
+  PersonaDetail,
+  PersonaCreateRequest,
+  PersonaForkRequest,
+  PersonaFilter,
+} from './domain';

--- a/web-next/packages/plugin-ravn/src/ports.ts
+++ b/web-next/packages/plugin-ravn/src/ports.ts
@@ -1,0 +1,85 @@
+/**
+ * Ravn plugin — port interfaces (hexagonal architecture).
+ *
+ * These interfaces are the only thing business logic and UI may depend on.
+ * Adapters (mock, http) implement these ports. This file is intentionally
+ * excluded from coverage thresholds — it contains only type declarations.
+ */
+
+import type { BudgetState } from '@niuulabs/domain';
+import type {
+  Raven,
+  Session,
+  Message,
+  Trigger,
+  TriggerInput,
+  PersonaSummary,
+  PersonaDetail,
+  PersonaCreateRequest,
+  PersonaForkRequest,
+  PersonaFilter,
+} from './domain';
+
+// ---------------------------------------------------------------------------
+// IPersonaStore — CRUD over the persona template library
+// ---------------------------------------------------------------------------
+
+export interface IPersonaStore {
+  listPersonas(filter?: PersonaFilter): Promise<PersonaSummary[]>;
+  getPersona(name: string): Promise<PersonaDetail>;
+  getPersonaYaml(name: string): Promise<string>;
+  createPersona(req: PersonaCreateRequest): Promise<PersonaDetail>;
+  updatePersona(name: string, req: PersonaCreateRequest): Promise<PersonaDetail>;
+  deletePersona(name: string): Promise<void>;
+  forkPersona(name: string, req: PersonaForkRequest): Promise<PersonaDetail>;
+}
+
+// ---------------------------------------------------------------------------
+// IRavenStream — read-only fleet view
+// ---------------------------------------------------------------------------
+
+export interface IRavenStream {
+  listRavens(): Promise<Raven[]>;
+  getRaven(id: string): Promise<Raven>;
+}
+
+// ---------------------------------------------------------------------------
+// ISessionStream — read-only session + transcript view
+// ---------------------------------------------------------------------------
+
+export interface ISessionStream {
+  listSessions(ravnId?: string): Promise<Session[]>;
+  getSession(id: string): Promise<Session>;
+  getMessages(sessionId: string): Promise<Message[]>;
+}
+
+// ---------------------------------------------------------------------------
+// ITriggerStore — trigger CRUD
+// ---------------------------------------------------------------------------
+
+export interface ITriggerStore {
+  listTriggers(ravnId?: string): Promise<Trigger[]>;
+  createTrigger(trigger: TriggerInput): Promise<Trigger>;
+  deleteTrigger(id: string): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// IBudgetStream — daily spend tracking
+// ---------------------------------------------------------------------------
+
+export interface IBudgetStream {
+  getFleetBudget(): Promise<BudgetState>;
+  getRavenBudget(ravnId: string): Promise<BudgetState>;
+}
+
+// ---------------------------------------------------------------------------
+// IRavnService — top-level bundle registered in ServicesProvider
+// ---------------------------------------------------------------------------
+
+export interface IRavnService {
+  personas: IPersonaStore;
+  ravens: IRavenStream;
+  sessions: ISessionStream;
+  triggers: ITriggerStore;
+  budget: IBudgetStream;
+}

--- a/web-next/packages/plugin-ravn/src/ui/RavnPage.module.css
+++ b/web-next/packages/plugin-ravn/src/ui/RavnPage.module.css
@@ -1,0 +1,54 @@
+.page {
+  padding: var(--space-6);
+  max-width: 720px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
+}
+
+.title {
+  margin: 0;
+}
+
+.subtitle {
+  color: var(--color-text-secondary);
+  margin-bottom: var(--space-6);
+}
+
+.state {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  display: grid;
+  gap: var(--space-2);
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-3);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-secondary);
+}
+
+.personaName {
+  color: var(--color-text-primary);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+}
+
+.personaMode {
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+}

--- a/web-next/packages/plugin-ravn/src/ui/RavnPage.test.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/RavnPage.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ServicesProvider } from '@niuulabs/plugin-sdk';
+import { RavnPage } from './RavnPage';
+import { createMockRavnService } from '../adapters/mock';
+import type { IRavnService } from '../ports';
+
+function wrap(ui: React.ReactNode, service?: IRavnService) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const svc = service ?? createMockRavnService();
+  return render(
+    <QueryClientProvider client={client}>
+      <ServicesProvider services={{ ravn: svc }}>{ui}</ServicesProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe('RavnPage', () => {
+  it('renders the title and rune', () => {
+    wrap(<RavnPage />);
+    expect(screen.getByText('Ravn · the flock')).toBeInTheDocument();
+    expect(screen.getByText('agent fleet console — coming soon')).toBeInTheDocument();
+  });
+
+  it('shows loading state initially', () => {
+    wrap(<RavnPage />);
+    expect(screen.getByText(/loading personas/)).toBeInTheDocument();
+  });
+
+  it('renders persona list after loading', async () => {
+    wrap(<RavnPage />);
+    await waitFor(() => expect(screen.getByText('coding-agent')).toBeInTheDocument());
+    expect(screen.getByText('coder')).toBeInTheDocument();
+    expect(screen.getByText('reviewer')).toBeInTheDocument();
+  });
+
+  it('shows permission mode for each persona', async () => {
+    wrap(<RavnPage />);
+    await waitFor(() => expect(screen.getByText('coding-agent')).toBeInTheDocument());
+    expect(screen.getAllByText('workspace-write').length).toBeGreaterThan(0);
+  });
+
+  it('renders error state when service throws', async () => {
+    const failing: IRavnService = {
+      ...createMockRavnService(),
+      personas: {
+        ...createMockRavnService().personas,
+        listPersonas: async () => {
+          throw new Error('service unavailable');
+        },
+      },
+    };
+    wrap(<RavnPage />, failing);
+    await waitFor(() => expect(screen.getByText('service unavailable')).toBeInTheDocument());
+  });
+
+  it('renders unknown error message when error is not an Error', async () => {
+    const failing: IRavnService = {
+      ...createMockRavnService(),
+      personas: {
+        ...createMockRavnService().personas,
+        listPersonas: async () => {
+          // eslint-disable-next-line @typescript-eslint/only-throw-error
+          throw 'string error';
+        },
+      },
+    };
+    wrap(<RavnPage />, failing);
+    await waitFor(() => expect(screen.getByText('unknown error')).toBeInTheDocument());
+  });
+});

--- a/web-next/packages/plugin-ravn/src/ui/RavnPage.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/RavnPage.tsx
@@ -1,0 +1,43 @@
+import { Rune, StateDot } from '@niuulabs/ui';
+import { usePersonas } from './usePersonas';
+import styles from './RavnPage.module.css';
+
+export function RavnPage() {
+  const { data, isLoading, isError, error } = usePersonas();
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <Rune glyph="ᚱ" size={32} />
+        <h2 className={styles.title}>Ravn · the flock</h2>
+      </header>
+
+      <p className={styles.subtitle}>agent fleet console — coming soon</p>
+
+      {isLoading && (
+        <div className={styles.state}>
+          <StateDot state="processing" pulse />
+          <span>loading personas…</span>
+        </div>
+      )}
+
+      {isError && (
+        <div className={styles.state}>
+          <StateDot state="failed" />
+          <span>{error instanceof Error ? error.message : 'unknown error'}</span>
+        </div>
+      )}
+
+      {data && (
+        <ul className={styles.list}>
+          {data.map((p) => (
+            <li key={p.name} className={styles.item}>
+              <span className={styles.personaName}>{p.name}</span>
+              <span className={styles.personaMode}>{p.permissionMode}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/web-next/packages/plugin-ravn/src/ui/usePersonas.ts
+++ b/web-next/packages/plugin-ravn/src/ui/usePersonas.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { useService } from '@niuulabs/plugin-sdk';
+import type { IRavnService } from '../ports';
+import type { PersonaFilter } from '../domain';
+
+export function usePersonas(filter: PersonaFilter = 'all') {
+  const service = useService<IRavnService>('ravn');
+  return useQuery({
+    queryKey: ['ravn', 'personas', filter],
+    queryFn: () => service.personas.listPersonas(filter),
+  });
+}

--- a/web-next/packages/plugin-ravn/tsconfig.json
+++ b/web-next/packages/plugin-ravn/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "**/*.stories.tsx"]
+}

--- a/web-next/packages/plugin-ravn/tsup.config.ts
+++ b/web-next/packages/plugin-ravn/tsup.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.tsx'],
+  format: ['esm'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  external: [
+    'react',
+    '@tanstack/react-query',
+    '@tanstack/react-router',
+    '@niuulabs/plugin-sdk',
+    '@niuulabs/query',
+    '@niuulabs/ui',
+    '@niuulabs/domain',
+  ],
+});

--- a/web-next/pnpm-lock.yaml
+++ b/web-next/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       '@niuulabs/plugin-hello':
         specifier: workspace:*
         version: link:../../packages/plugin-hello
+      '@niuulabs/plugin-ravn':
+        specifier: workspace:*
+        version: link:../../packages/plugin-ravn
       '@niuulabs/plugin-sdk':
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
@@ -193,6 +196,43 @@ importers:
       '@niuulabs/ui':
         specifier: workspace:*
         version: link:../ui
+    devDependencies:
+      '@tanstack/react-query':
+        specifier: ^5.62.0
+        version: 5.99.1(react@19.2.5)
+      '@tanstack/react-router':
+        specifier: ^1.95.0
+        version: 1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@types/react':
+        specifier: ^19.0.7
+        version: 19.2.14
+      react:
+        specifier: ^19.0.0
+        version: 19.2.5
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(postcss@8.5.10)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
+  packages/plugin-ravn:
+    dependencies:
+      '@niuulabs/domain':
+        specifier: workspace:*
+        version: link:../domain
+      '@niuulabs/plugin-sdk':
+        specifier: workspace:*
+        version: link:../plugin-sdk
+      '@niuulabs/query':
+        specifier: workspace:*
+        version: link:../query
+      '@niuulabs/ui':
+        specifier: workspace:*
+        version: link:../ui
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
     devDependencies:
       '@tanstack/react-query':
         specifier: ^5.62.0


### PR DESCRIPTION
## Summary

Implements **NIU-671**: scaffold the `@niuulabs/plugin-ravn` package — the Ravn agent fleet console.

### What's included

**Domain (`src/domain.ts`)** — Zod-validated runtime types:
- `Raven` (deployed agent node): id, name, rune, persona, location, deployment, state, uptime, lastTick, budget, mounts
- `Session` (live interaction thread): id, ravnId, title, triggerId, state, startedAt, lastAt, messages
- `Message` with **7 kinds**: `user | asst | system | tool_call | tool_result | emit | think`
- `Trigger` (discriminated union): `cron | event | webhook | manual` + `TriggerInput` (narrowable creation union)
- Persona API types copied from `web/src/modules/ravn/api/types.ts`: `PersonaSummary`, `PersonaDetail`, `PersonaCreateRequest`, `PersonaForkRequest`, `PersonaFilter`

**Ports (`src/ports.ts`)** — hexagonal interfaces:
- `IPersonaStore` — full CRUD + fork + YAML
- `IRavenStream` — read-only fleet view
- `ISessionStream` — sessions + transcript
- `ITriggerStore` — trigger CRUD
- `IBudgetStream` — fleet + per-raven spend
- `IRavnService` — bundle registered in `ServicesProvider`

**Mock adapter** (`src/adapters/mock.ts`) seeded with:
- All 21 builtin personas from `web/src/modules/ravn/api/mockData.ts`
- Fleet of 5 ravens across asgard / midgard / jotunheim / desk
- 3 sessions with 10 messages covering all 7 message kinds
- 6 triggers (cron, event×3, webhook, manual)
- Fleet + per-raven budget state

**HTTP adapter** (`src/adapters/http.ts`) wrapping `@niuulabs/query` `ApiClient`:
- `/api/v1/ravn/personas` endpoints (list, get, create, update, delete, fork, yaml) with snake_case → camelCase transforms matching `web/` client.ts
- `/ravens`, `/sessions`, `/triggers`, `/budget` endpoints for the extended fleet domain

**UI placeholder** — `RavnPage` + `usePersonas` hook:
- Rune ᚱ (Raidho), title "Ravn · the flock", persona list from mock service
- CSS Modules + design tokens (no inline colors, no Tailwind)

**Shell wiring** (apps/niuu):
- `ravnPlugin` registered in `plugins.ts`, `services.ts`, `config.json`
- Playwright e2e: navigate to `/ravn`, assert title + persona list

### Test plan

- [x] 292 tests passing, 0 failures
- [x] Coverage: 100% statements / branches / functions / lines on all `plugin-ravn` source files
- [x] Domain schema round-trip tests for all new Zod types (Raven, Session, Message, Trigger variants)
- [x] Mock adapter: full contract surface tested (listPersonas with filters, getPersona, CRUD, fork, YAML, ravens, sessions, messages, triggers, budget)
- [x] HTTP adapter: endpoint URLs, snake→camelCase transforms, all trigger kinds, error propagation
- [x] RavnPage: title render, loading state, data render, error states
- [x] Playwright: `/ravn` renders title and persona list

### Linear

Ticket **NIU-671** — could not update via Linear MCP (tool not available in environment). Please update manually to "In Review".

🤖 Generated with [Claude Code](https://claude.com/claude-code)