### PR TITLE
feat(volundr): scaffold @niuulabs/plugin-volundr — domain, ports, mock (NIU-675)

### DIFF
--- a/web-next/apps/niuu/package.json
+++ b/web-next/apps/niuu/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@niuulabs/design-tokens": "workspace:*",
     "@niuulabs/plugin-hello": "workspace:*",
+    "@niuulabs/plugin-volundr": "workspace:*",
     "@niuulabs/plugin-sdk": "workspace:*",
     "@niuulabs/query": "workspace:*",
     "@niuulabs/shell": "workspace:*",

--- a/web-next/apps/niuu/public/config.json
+++ b/web-next/apps/niuu/public/config.json
@@ -1,9 +1,11 @@
 {
   "theme": "ice",
   "plugins": {
-    "hello": { "enabled": true, "order": 1 }
+    "hello": { "enabled": true, "order": 1 },
+    "volundr": { "enabled": true, "order": 2 }
   },
   "services": {
-    "hello": { "mode": "mock" }
+    "hello": { "mode": "mock" },
+    "volundr": { "mode": "mock" }
   }
 }

--- a/web-next/apps/niuu/src/plugins.ts
+++ b/web-next/apps/niuu/src/plugins.ts
@@ -1,4 +1,5 @@
 import { helloPlugin } from '@niuulabs/plugin-hello';
+import { volundrPlugin } from '@niuulabs/plugin-volundr';
 import type { PluginDescriptor } from '@niuulabs/plugin-sdk';
 
-export const plugins: PluginDescriptor[] = [helloPlugin];
+export const plugins: PluginDescriptor[] = [helloPlugin, volundrPlugin];

--- a/web-next/apps/niuu/src/services.ts
+++ b/web-next/apps/niuu/src/services.ts
@@ -1,4 +1,5 @@
 import { createMockHelloService, createHttpHelloService } from '@niuulabs/plugin-hello';
+import { createMockVolundrService } from '@niuulabs/plugin-volundr';
 import { createApiClient } from '@niuulabs/query';
 import type { NiuuConfig, ServicesMap } from '@niuulabs/plugin-sdk';
 
@@ -11,5 +12,6 @@ export function buildServices(config: NiuuConfig): ServicesMap {
 
   return {
     hello: helloService,
+    volundr: createMockVolundrService(),
   };
 }

--- a/web-next/e2e/volundr.spec.ts
+++ b/web-next/e2e/volundr.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+
+test('volundr plugin is in the rail', async ({ page }) => {
+  await page.goto('/');
+  // The rune ᚲ should appear in the navigation rail
+  await expect(page.getByText('ᚲ')).toBeVisible({ timeout: 5000 });
+});
+
+test('navigating to /volundr renders the placeholder', async ({ page }) => {
+  await page.goto('/volundr');
+  await expect(page.getByText('Völundr · session forge')).toBeVisible({ timeout: 5000 });
+  await expect(page.getByText('Provision and manage remote dev sessions')).toBeVisible();
+});
+
+test('volundr page renders the forge rune', async ({ page }) => {
+  await page.goto('/volundr');
+  await expect(page.getByText('ᚲ')).toBeVisible({ timeout: 5000 });
+});

--- a/web-next/packages/plugin-volundr/package.json
+++ b/web-next/packages/plugin-volundr/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@niuulabs/plugin-volundr",
+  "version": "0.0.1",
+  "description": "Völundr — session forge plugin: provisions and manages remote dev pods",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "dev": "tsup --watch"
+  },
+  "peerDependencies": {
+    "@tanstack/react-query": "^5.62.0",
+    "@tanstack/react-router": "^1.95.0",
+    "react": "^19.0.0"
+  },
+  "dependencies": {
+    "@niuulabs/domain": "workspace:*",
+    "@niuulabs/plugin-sdk": "workspace:*",
+    "@niuulabs/query": "workspace:*",
+    "@niuulabs/ui": "workspace:*"
+  },
+  "devDependencies": {
+    "@tanstack/react-query": "^5.62.0",
+    "@tanstack/react-router": "^1.95.0",
+    "@types/react": "^19.0.7",
+    "react": "^19.0.0",
+    "tsup": "^8.3.5",
+    "typescript": "^5.7.3"
+  }
+}

--- a/web-next/packages/plugin-volundr/package.json
+++ b/web-next/packages/plugin-volundr/package.json
@@ -30,7 +30,6 @@
     "react": "^19.0.0"
   },
   "dependencies": {
-    "@niuulabs/domain": "workspace:*",
     "@niuulabs/plugin-sdk": "workspace:*",
     "@niuulabs/query": "workspace:*",
     "@niuulabs/ui": "workspace:*"

--- a/web-next/packages/plugin-volundr/src/adapters/mock.test.ts
+++ b/web-next/packages/plugin-volundr/src/adapters/mock.test.ts
@@ -1,0 +1,759 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  createMockVolundrService,
+  createMockClusterAdapter,
+  createMockSessionStore,
+  createMockTemplateStore,
+  createMockPtyStream,
+  createMockMetricsStream,
+  createMockVolundrServices,
+} from './mock';
+import type { Session } from '../domain/session';
+import type { Template } from '../domain/template';
+
+/* ── IVolundrService ────────────────────────────────────────────── */
+
+describe('createMockVolundrService', () => {
+  const svc = createMockVolundrService();
+
+  it('getFeatures returns feature flags', async () => {
+    const f = await svc.getFeatures();
+    expect(f.localMountsEnabled).toBe(true);
+    expect(f.fileManagerEnabled).toBe(true);
+    expect(f.miniMode).toBe(false);
+  });
+
+  it('getSessions returns an empty array', async () => {
+    expect(await svc.getSessions()).toEqual([]);
+  });
+
+  it('getSession returns null', async () => {
+    expect(await svc.getSession('any')).toBeNull();
+  });
+
+  it('getActiveSessions returns an empty array', async () => {
+    expect(await svc.getActiveSessions()).toEqual([]);
+  });
+
+  it('getStats returns zeroed counters', async () => {
+    const stats = await svc.getStats();
+    expect(stats.activeSessions).toBe(0);
+    expect(stats.totalSessions).toBe(0);
+  });
+
+  it('getModels returns an empty record', async () => {
+    expect(await svc.getModels()).toEqual({});
+  });
+
+  it('getRepos returns an empty array', async () => {
+    expect(await svc.getRepos()).toEqual([]);
+  });
+
+  it('subscribe returns an unsubscribe function', () => {
+    const unsub = svc.subscribe(() => undefined);
+    expect(typeof unsub).toBe('function');
+    unsub();
+  });
+
+  it('subscribeStats returns an unsubscribe function', () => {
+    const unsub = svc.subscribeStats(() => undefined);
+    expect(typeof unsub).toBe('function');
+    unsub();
+  });
+
+  it('startSession returns a session with the given name', async () => {
+    const session = await svc.startSession({
+      name: 'test-session',
+      source: { type: 'git', repo: 'niuulabs/niuu', branch: 'main' },
+      model: 'claude-sonnet',
+    });
+    expect(session.name).toBe('test-session');
+    expect(session.model).toBe('claude-sonnet');
+  });
+
+  it('connectSession returns a session with the given hostname', async () => {
+    const session = await svc.connectSession({ name: 'manual', hostname: 'pod.cluster.local' });
+    expect(session.name).toBe('manual');
+    expect(session.hostname).toBe('pod.cluster.local');
+  });
+
+  it('sendMessage returns an assistant echo', async () => {
+    const msg = await svc.sendMessage('s1', 'hello');
+    expect(msg.role).toBe('assistant');
+    expect(msg.content).toContain('hello');
+    expect(msg.sessionId).toBe('s1');
+  });
+
+  it('createSecret returns the name + key list', async () => {
+    const result = await svc.createSecret('my-secret', { API_KEY: 'val', TOKEN: 'tok' });
+    expect(result.name).toBe('my-secret');
+    expect(result.keys).toContain('API_KEY');
+    expect(result.keys).toContain('TOKEN');
+  });
+
+  it('bulkDeleteWorkspaces returns the deleted count', async () => {
+    const result = await svc.bulkDeleteWorkspaces(['a', 'b', 'c']);
+    expect(result.deleted).toBe(3);
+    expect(result.failed).toEqual([]);
+  });
+
+  it('getIdentity returns a mock user', async () => {
+    const identity = await svc.getIdentity();
+    expect(identity.userId).toBeTruthy();
+    expect(identity.email).toContain('@');
+  });
+
+  it('createToken returns a token string', async () => {
+    const result = await svc.createToken('ci-token');
+    expect(result.name).toBe('ci-token');
+    expect(result.token).toBeTruthy();
+  });
+
+  it('updateAdminSettings merges storage settings', async () => {
+    const updated = await svc.updateAdminSettings({
+      storage: { homeEnabled: false, fileManagerEnabled: true },
+    });
+    expect(updated.storage.homeEnabled).toBe(false);
+  });
+
+  it('getAdminSettings returns default settings', async () => {
+    const settings = await svc.getAdminSettings();
+    expect(settings.storage.homeEnabled).toBe(true);
+  });
+
+  it('mergePullRequest returns merged: true', async () => {
+    const result = await svc.mergePullRequest(1, 'https://github.com/niuulabs/niuu', 'squash');
+    expect(result.merged).toBe(true);
+  });
+
+  it('getCIStatus returns unknown', async () => {
+    const status = await svc.getCIStatus(1, 'https://github.com/niuulabs/niuu', 'main');
+    expect(status).toBe('unknown');
+  });
+
+  it('getPresets returns seed data', async () => {
+    const presets = await svc.getPresets();
+    expect(presets.length).toBeGreaterThan(0);
+  });
+
+  it('savePreset assigns an id when none provided', async () => {
+    const preset = await svc.savePreset({
+      name: 'new-preset',
+      description: '',
+      isDefault: false,
+      cliTool: 'claude',
+      workloadType: 'standard',
+      model: null,
+      systemPrompt: null,
+      resourceConfig: {},
+      mcpServers: [],
+      terminalSidecar: { enabled: false, allowedCommands: [] },
+      skills: [],
+      rules: [],
+      envVars: {},
+      envSecretRefs: [],
+      source: null,
+      integrationIds: [],
+      setupScripts: [],
+      workloadConfig: {},
+    });
+    expect(preset.id).toBeTruthy();
+  });
+
+  it('createCredential returns a StoredCredential', async () => {
+    const cred = await svc.createCredential({
+      name: 'gh-token',
+      secretType: 'api_key',
+      data: { TOKEN: 'abc' },
+    });
+    expect(cred.name).toBe('gh-token');
+    expect(cred.secretType).toBe('api_key');
+    expect(cred.keys).toContain('TOKEN');
+  });
+
+  it('reprovisionUser returns success', async () => {
+    const result = await svc.reprovisionUser('user-1');
+    expect(result.success).toBe(true);
+    expect(result.userId).toBe('user-1');
+  });
+
+  it('toggleFeature returns the updated feature', async () => {
+    const feat = await svc.toggleFeature('volundr', false);
+    expect(feat.key).toBe('volundr');
+    expect(feat.enabled).toBe(false);
+  });
+
+  it('createPullRequest returns a PR object', async () => {
+    const pr = await svc.createPullRequest('s1', 'feat: my pr', 'main');
+    expect(pr.number).toBeGreaterThan(0);
+    expect(pr.status).toBeTruthy();
+  });
+
+  it('getFeatureModules returns modules array', async () => {
+    const modules = await svc.getFeatureModules();
+    expect(Array.isArray(modules)).toBe(true);
+  });
+
+  it('createIntegration returns an integration with id', async () => {
+    const integration = await svc.createIntegration({ type: 'github' });
+    expect(integration.id).toBeTruthy();
+  });
+
+  it('testIntegration returns success', async () => {
+    const result = await svc.testIntegration('integration-1');
+    expect(result.success).toBe(true);
+  });
+
+  it('createTenant returns a tenant', async () => {
+    const tenant = await svc.createTenant({
+      name: 'Acme',
+      tier: 'pro',
+      maxSessions: 50,
+      maxStorageGb: 100,
+    });
+    expect(tenant.name).toBe('Acme');
+  });
+});
+
+/* ── IClusterAdapter ────────────────────────────────────────────── */
+
+describe('createMockClusterAdapter', () => {
+  const adapter = createMockClusterAdapter();
+
+  it('listClusters returns at least one cluster', async () => {
+    const clusters = await adapter.listClusters();
+    expect(clusters.length).toBeGreaterThan(0);
+  });
+
+  it('getCluster returns a cluster matching the id', async () => {
+    const cluster = await adapter.getCluster('custom-id');
+    expect(cluster?.id).toBe('custom-id');
+  });
+
+  it('scheduleSession returns a pod name', async () => {
+    const session: Session = {
+      id: 's1',
+      ravnId: 'ravn-1',
+      personaName: 'persona-1',
+      templateId: 'tpl-1',
+      clusterId: 'c1',
+      state: 'running',
+      startedAt: new Date().toISOString(),
+    };
+    const podName = await adapter.scheduleSession(session, {
+      image: 'ubuntu:22.04',
+      mounts: [],
+      env: {},
+      resources: { cpuRequest: 1000, cpuLimit: 2000, memRequestMi: 512, memLimitMi: 1024, gpuCount: 0 },
+    });
+    expect(typeof podName).toBe('string');
+    expect(podName.length).toBeGreaterThan(0);
+  });
+
+  it('releaseSession resolves without error', async () => {
+    const session: Session = {
+      id: 's1',
+      ravnId: 'ravn-1',
+      personaName: 'persona-1',
+      templateId: 'tpl-1',
+      clusterId: 'c1',
+      state: 'terminating',
+      startedAt: new Date().toISOString(),
+    };
+    await expect(adapter.releaseSession(session)).resolves.toBeUndefined();
+  });
+});
+
+/* ── ISessionStore ──────────────────────────────────────────────── */
+
+describe('createMockSessionStore', () => {
+  it('round-trips a session via save + get', async () => {
+    const store = createMockSessionStore();
+    const session: Session = {
+      id: 'ses-1',
+      ravnId: 'r1',
+      personaName: 'p1',
+      templateId: 'tpl-1',
+      clusterId: 'c1',
+      state: 'running',
+      startedAt: new Date().toISOString(),
+    };
+    await store.save(session);
+    const found = await store.get('ses-1');
+    expect(found).toEqual(session);
+  });
+
+  it('returns null for an unknown id', async () => {
+    const store = createMockSessionStore();
+    expect(await store.get('unknown')).toBeNull();
+  });
+
+  it('lists all sessions', async () => {
+    const store = createMockSessionStore();
+    const s1: Session = {
+      id: 'a', ravnId: 'r', personaName: 'p', templateId: 't', clusterId: 'c',
+      state: 'running', startedAt: '',
+    };
+    const s2: Session = {
+      id: 'b', ravnId: 'r', personaName: 'p', templateId: 't', clusterId: 'c',
+      state: 'idle', startedAt: '',
+    };
+    await store.save(s1);
+    await store.save(s2);
+    const all = await store.list();
+    expect(all).toHaveLength(2);
+  });
+
+  it('filters sessions by state', async () => {
+    const store = createMockSessionStore();
+    const s1: Session = {
+      id: 'a', ravnId: 'r', personaName: 'p', templateId: 't', clusterId: 'c',
+      state: 'running', startedAt: '',
+    };
+    const s2: Session = {
+      id: 'b', ravnId: 'r', personaName: 'p', templateId: 't', clusterId: 'c',
+      state: 'idle', startedAt: '',
+    };
+    await store.save(s1);
+    await store.save(s2);
+    const running = await store.list({ state: 'running' });
+    expect(running).toHaveLength(1);
+    expect(running[0]?.id).toBe('a');
+  });
+
+  it('filters sessions by clusterId', async () => {
+    const store = createMockSessionStore();
+    const s1: Session = {
+      id: 'a', ravnId: 'r', personaName: 'p', templateId: 't', clusterId: 'cluster-A',
+      state: 'running', startedAt: '',
+    };
+    const s2: Session = {
+      id: 'b', ravnId: 'r', personaName: 'p', templateId: 't', clusterId: 'cluster-B',
+      state: 'running', startedAt: '',
+    };
+    await store.save(s1);
+    await store.save(s2);
+    const filtered = await store.list({ clusterId: 'cluster-A' });
+    expect(filtered).toHaveLength(1);
+  });
+
+  it('deletes a session', async () => {
+    const store = createMockSessionStore();
+    const s: Session = {
+      id: 'x', ravnId: 'r', personaName: 'p', templateId: 't', clusterId: 'c',
+      state: 'terminated', startedAt: '',
+    };
+    await store.save(s);
+    await store.delete('x');
+    expect(await store.get('x')).toBeNull();
+  });
+});
+
+/* ── ITemplateStore ─────────────────────────────────────────────── */
+
+describe('createMockTemplateStore', () => {
+  it('round-trips a template via save + get', async () => {
+    const store = createMockTemplateStore();
+    const tpl: Template = {
+      id: 'tpl-1',
+      name: 'Base Dev',
+      version: 1,
+      image: 'ubuntu:22.04',
+      mounts: [],
+      env: {},
+      tools: [],
+      resources: { cpuRequest: 500, cpuLimit: 1000, memRequestMi: 256, memLimitMi: 512, gpuCount: 0 },
+      ttlSec: 3600,
+      idleTimeoutSec: 600,
+      clusterAffinity: [],
+    };
+    await store.save(tpl);
+    const found = await store.get('tpl-1');
+    expect(found).toEqual(tpl);
+  });
+
+  it('returns null for an unknown id', async () => {
+    const store = createMockTemplateStore();
+    expect(await store.get('none')).toBeNull();
+  });
+
+  it('lists all templates', async () => {
+    const store = createMockTemplateStore();
+    const tpl: Template = {
+      id: 't1', name: 'T', version: 1, image: 'img', mounts: [], env: {}, tools: [],
+      resources: { cpuRequest: 0, cpuLimit: 0, memRequestMi: 0, memLimitMi: 0, gpuCount: 0 },
+      ttlSec: 3600, idleTimeoutSec: 600, clusterAffinity: [],
+    };
+    await store.save(tpl);
+    const list = await store.list();
+    expect(list).toHaveLength(1);
+  });
+
+  it('deletes a template', async () => {
+    const store = createMockTemplateStore();
+    const tpl: Template = {
+      id: 'd1', name: 'D', version: 1, image: 'img', mounts: [], env: {}, tools: [],
+      resources: { cpuRequest: 0, cpuLimit: 0, memRequestMi: 0, memLimitMi: 0, gpuCount: 0 },
+      ttlSec: 3600, idleTimeoutSec: 600, clusterAffinity: [],
+    };
+    await store.save(tpl);
+    await store.delete('d1');
+    expect(await store.get('d1')).toBeNull();
+  });
+});
+
+/* ── IPtyStream ─────────────────────────────────────────────────── */
+
+describe('createMockPtyStream', () => {
+  it('connect resolves without error', async () => {
+    const pty = createMockPtyStream();
+    await expect(pty.connect('s1')).resolves.toBeUndefined();
+  });
+
+  it('write echoes output to subscribers', async () => {
+    const pty = createMockPtyStream();
+    await pty.connect('s1');
+    const outputs: string[] = [];
+    pty.subscribe('s1', (out) => outputs.push(out.data));
+    await pty.write('s1', 'ls -la');
+    expect(outputs).toHaveLength(1);
+    expect(outputs[0]).toContain('ls -la');
+  });
+
+  it('unsubscribe stops receiving output', async () => {
+    const pty = createMockPtyStream();
+    await pty.connect('s1');
+    const outputs: string[] = [];
+    const unsub = pty.subscribe('s1', (out) => outputs.push(out.data));
+    unsub();
+    await pty.write('s1', 'pwd');
+    expect(outputs).toHaveLength(0);
+  });
+
+  it('disconnect clears subscriptions', async () => {
+    const pty = createMockPtyStream();
+    await pty.connect('s1');
+    const outputs: string[] = [];
+    pty.subscribe('s1', (out) => outputs.push(out.data));
+    await pty.disconnect('s1');
+    await pty.write('s1', 'test');
+    expect(outputs).toHaveLength(0);
+  });
+});
+
+/* ── IMetricsStream ─────────────────────────────────────────────── */
+
+describe('createMockMetricsStream', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('subscribe returns an unsubscribe function', () => {
+    const stream = createMockMetricsStream();
+    const unsub = stream.subscribe('s1', () => undefined);
+    expect(typeof unsub).toBe('function');
+    unsub();
+    stream.unsubscribeAll();
+  });
+
+  it('unsubscribeAll clears all active subscriptions', () => {
+    const stream = createMockMetricsStream();
+    stream.subscribe('s1', () => undefined);
+    stream.subscribe('s2', () => undefined);
+    expect(() => stream.unsubscribeAll()).not.toThrow();
+  });
+});
+
+/* ── IMetricsStream timer callback ──────────────────────────────── */
+
+describe('createMockMetricsStream timer callback', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('emits metrics to subscribers when interval fires', () => {
+    vi.useFakeTimers();
+    const stream = createMockMetricsStream();
+    const received: { cpuMillicores: number }[] = [];
+    stream.subscribe('s1', (m) => received.push(m));
+    vi.advanceTimersByTime(5001);
+    expect(received.length).toBeGreaterThan(0);
+    expect(received[0]).toHaveProperty('cpuMillicores');
+    expect(received[0]).toHaveProperty('memMi');
+    expect(received[0]).toHaveProperty('gpuUtilisation');
+    stream.unsubscribeAll();
+  });
+
+  it('unsub stops receiving after unsubscribing', () => {
+    vi.useFakeTimers();
+    const stream = createMockMetricsStream();
+    const received: unknown[] = [];
+    const unsub = stream.subscribe('s2', (m) => received.push(m));
+    vi.advanceTimersByTime(5001);
+    unsub();
+    vi.advanceTimersByTime(5001);
+    const countAfterUnsub = received.length;
+    vi.advanceTimersByTime(10000);
+    expect(received.length).toBe(countAfterUnsub);
+  });
+});
+
+/* ── IVolundrService — remaining coverage ───────────────────────── */
+
+describe('createMockVolundrService — remaining methods', () => {
+  const svc = createMockVolundrService();
+
+  it('updateSession resolves to a session', async () => {
+    const session = await svc.updateSession('s1', { name: 'renamed' });
+    expect(session).toBeDefined();
+  });
+
+  it('stopSession resolves', async () => {
+    await expect(svc.stopSession('s1')).resolves.toBeUndefined();
+  });
+
+  it('resumeSession resolves', async () => {
+    await expect(svc.resumeSession('s1')).resolves.toBeUndefined();
+  });
+
+  it('deleteSession resolves', async () => {
+    await expect(svc.deleteSession('s1')).resolves.toBeUndefined();
+  });
+
+  it('archiveSession resolves', async () => {
+    await expect(svc.archiveSession('s1')).resolves.toBeUndefined();
+  });
+
+  it('restoreSession resolves', async () => {
+    await expect(svc.restoreSession('s1')).resolves.toBeUndefined();
+  });
+
+  it('listArchivedSessions returns empty array', async () => {
+    expect(await svc.listArchivedSessions()).toEqual([]);
+  });
+
+  it('getMessages returns empty array', async () => {
+    expect(await svc.getMessages('s1')).toEqual([]);
+  });
+
+  it('subscribeMessages returns unsubscribe', () => {
+    const unsub = svc.subscribeMessages('s1', () => undefined);
+    expect(typeof unsub).toBe('function');
+    unsub();
+  });
+
+  it('getLogs returns empty array', async () => {
+    expect(await svc.getLogs('s1')).toEqual([]);
+  });
+
+  it('subscribeLogs returns unsubscribe', () => {
+    const unsub = svc.subscribeLogs('s1', () => undefined);
+    expect(typeof unsub).toBe('function');
+    unsub();
+  });
+
+  it('getCodeServerUrl returns null', async () => {
+    expect(await svc.getCodeServerUrl('s1')).toBeNull();
+  });
+
+  it('getChronicle returns null', async () => {
+    expect(await svc.getChronicle('s1')).toBeNull();
+  });
+
+  it('subscribeChronicle returns unsubscribe', () => {
+    const unsub = svc.subscribeChronicle('s1', () => undefined);
+    expect(typeof unsub).toBe('function');
+    unsub();
+  });
+
+  it('getPullRequests returns empty array', async () => {
+    expect(await svc.getPullRequests('https://github.com/niuulabs/niuu')).toEqual([]);
+  });
+
+  it('getSessionMcpServers returns empty array', async () => {
+    expect(await svc.getSessionMcpServers('s1')).toEqual([]);
+  });
+
+  it('searchTrackerIssues returns empty array', async () => {
+    expect(await svc.searchTrackerIssues('test')).toEqual([]);
+  });
+
+  it('getProjectRepoMappings returns empty array', async () => {
+    expect(await svc.getProjectRepoMappings()).toEqual([]);
+  });
+
+  it('listUsers returns empty array', async () => {
+    expect(await svc.listUsers()).toEqual([]);
+  });
+
+  it('deleteTenant resolves', async () => {
+    await expect(svc.deleteTenant('t1')).resolves.toBeUndefined();
+  });
+
+  it('getTenantMembers returns empty array', async () => {
+    expect(await svc.getTenantMembers('t1')).toEqual([]);
+  });
+
+  it('reprovisionTenant returns empty array', async () => {
+    expect(await svc.reprovisionTenant('t1')).toEqual([]);
+  });
+
+  it('getUserCredentials returns empty array', async () => {
+    expect(await svc.getUserCredentials()).toEqual([]);
+  });
+
+  it('storeUserCredential resolves', async () => {
+    await expect(svc.storeUserCredential('key', { val: '1' })).resolves.toBeUndefined();
+  });
+
+  it('deleteUserCredential resolves', async () => {
+    await expect(svc.deleteUserCredential('key')).resolves.toBeUndefined();
+  });
+
+  it('getTenantCredentials returns empty array', async () => {
+    expect(await svc.getTenantCredentials()).toEqual([]);
+  });
+
+  it('storeTenantCredential resolves', async () => {
+    await expect(svc.storeTenantCredential('key', { val: '1' })).resolves.toBeUndefined();
+  });
+
+  it('deleteTenantCredential resolves', async () => {
+    await expect(svc.deleteTenantCredential('key')).resolves.toBeUndefined();
+  });
+
+  it('getIntegrationCatalog returns empty array', async () => {
+    expect(await svc.getIntegrationCatalog()).toEqual([]);
+  });
+
+  it('getIntegrations returns empty array', async () => {
+    expect(await svc.getIntegrations()).toEqual([]);
+  });
+
+  it('deleteIntegration resolves', async () => {
+    await expect(svc.deleteIntegration('i1')).resolves.toBeUndefined();
+  });
+
+  it('getCredentials returns empty array', async () => {
+    expect(await svc.getCredentials()).toEqual([]);
+  });
+
+  it('getCredential returns null', async () => {
+    expect(await svc.getCredential('cred')).toBeNull();
+  });
+
+  it('deleteCredential resolves', async () => {
+    await expect(svc.deleteCredential('cred')).resolves.toBeUndefined();
+  });
+
+  it('getCredentialTypes returns empty array', async () => {
+    expect(await svc.getCredentialTypes()).toEqual([]);
+  });
+
+  it('listWorkspaces returns empty array', async () => {
+    expect(await svc.listWorkspaces()).toEqual([]);
+  });
+
+  it('listAllWorkspaces returns empty array', async () => {
+    expect(await svc.listAllWorkspaces()).toEqual([]);
+  });
+
+  it('restoreWorkspace resolves', async () => {
+    await expect(svc.restoreWorkspace('w1')).resolves.toBeUndefined();
+  });
+
+  it('deleteWorkspace resolves', async () => {
+    await expect(svc.deleteWorkspace('w1')).resolves.toBeUndefined();
+  });
+
+  it('getUserFeaturePreferences returns empty array', async () => {
+    expect(await svc.getUserFeaturePreferences()).toEqual([]);
+  });
+
+  it('updateUserFeaturePreferences returns input unchanged', async () => {
+    const prefs = [{ featureKey: 'volundr', visible: true, sortOrder: 1 }];
+    const result = await svc.updateUserFeaturePreferences(prefs);
+    expect(result).toEqual(prefs);
+  });
+
+  it('listTokens returns empty array', async () => {
+    expect(await svc.listTokens()).toEqual([]);
+  });
+
+  it('revokeToken resolves', async () => {
+    await expect(svc.revokeToken('tok-1')).resolves.toBeUndefined();
+  });
+
+  it('getAvailableMcpServers returns empty array', async () => {
+    expect(await svc.getAvailableMcpServers()).toEqual([]);
+  });
+
+  it('getAvailableSecrets returns empty array', async () => {
+    expect(await svc.getAvailableSecrets()).toEqual([]);
+  });
+
+  it('getClusterResources returns resource info', async () => {
+    const res = await svc.getClusterResources();
+    expect(res.resourceTypes).toBeDefined();
+    expect(res.nodes).toBeDefined();
+  });
+
+  it('getTemplates returns empty array', async () => {
+    expect(await svc.getTemplates()).toEqual([]);
+  });
+
+  it('getTemplate returns null', async () => {
+    expect(await svc.getTemplate('tpl')).toBeNull();
+  });
+
+  it('saveTemplate returns the passed template', async () => {
+    const tpl = {
+      name: 'test', description: 'desc', isDefault: false, repos: [], setupScripts: [],
+      workspaceLayout: {}, cliTool: 'claude', workloadType: 'standard', model: null,
+      systemPrompt: null, resourceConfig: {}, mcpServers: [], envVars: {}, envSecretRefs: [],
+      workloadConfig: {}, terminalSidecar: { enabled: false, allowedCommands: [] },
+      skills: [], rules: [],
+    };
+    const saved = await svc.saveTemplate(tpl);
+    expect(saved.name).toBe('test');
+  });
+
+  it('deletePreset resolves', async () => {
+    await expect(svc.deletePreset('p1')).resolves.toBeUndefined();
+  });
+
+  it('getPreset returns preset with id', async () => {
+    const preset = await svc.getPreset('p1');
+    expect(preset).not.toBeNull();
+    expect(preset?.id).toBeTruthy();
+  });
+
+  it('getTenant with id returns tenant with matching id', async () => {
+    const tenant = await svc.getTenant('my-tenant');
+    expect(tenant?.id).toBe('my-tenant');
+  });
+
+  it('getTenants returns at least one tenant', async () => {
+    const tenants = await svc.getTenants();
+    expect(tenants.length).toBeGreaterThan(0);
+  });
+
+  it('updateTenant merges data', async () => {
+    const updated = await svc.updateTenant('t1', { tier: 'enterprise' });
+    expect(updated.tier).toBe('enterprise');
+  });
+});
+
+/* ── createMockVolundrServices ──────────────────────────────────── */
+
+describe('createMockVolundrServices', () => {
+  it('returns all six services', () => {
+    const services = createMockVolundrServices();
+    expect(services.volundr).toBeDefined();
+    expect(services.clusterAdapter).toBeDefined();
+    expect(services.sessionStore).toBeDefined();
+    expect(services.templateStore).toBeDefined();
+    expect(services.ptyStream).toBeDefined();
+    expect(services.metricsStream).toBeDefined();
+  });
+});

--- a/web-next/packages/plugin-volundr/src/adapters/mock.ts
+++ b/web-next/packages/plugin-volundr/src/adapters/mock.ts
@@ -1,0 +1,451 @@
+/**
+ * Mock adapters for all Völundr ports.
+ *
+ * Used in tests, Storybook, and the dev app when mode = "mock".
+ */
+import type { IVolundrService } from '../ports/IVolundrService';
+import type { IClusterAdapter } from '../ports/IClusterAdapter';
+import type { ISessionStore } from '../ports/ISessionStore';
+import type { ITemplateStore } from '../ports/ITemplateStore';
+import type { IPtyStream } from '../ports/IPtyStream';
+import type { IMetricsStream } from '../ports/IMetricsStream';
+import type { Cluster } from '../domain/cluster';
+import type { Session } from '../domain/session';
+import type { Template } from '../domain/template';
+import type {
+  VolundrSession,
+  VolundrStats,
+  VolundrFeatures,
+  VolundrIdentity,
+  AdminSettings,
+  FeatureModule,
+  UserFeaturePreference,
+  VolundrProvisioningResult,
+  CredentialCreateRequest,
+  StoredCredential,
+  IntegrationConnection,
+  VolundrPreset,
+  VolundrTenant,
+  TrackerIssue,
+  PullRequest,
+  CreatePATResult,
+} from '../domain/models';
+
+/* ── Shared helpers ─────────────────────────────────────────────── */
+
+const NOW = new Date().toISOString();
+
+function mockSession(overrides?: Partial<VolundrSession>): VolundrSession {
+  return {
+    id: 'mock-session-1',
+    name: 'Mock Session',
+    source: { type: 'git', repo: 'niuulabs/niuu', branch: 'main' },
+    status: 'stopped',
+    model: 'claude-sonnet',
+    lastActive: Date.now(),
+    messageCount: 0,
+    tokensUsed: 0,
+    ...overrides,
+  };
+}
+
+function mockFeatureModule(key: string, enabled = true): FeatureModule {
+  return {
+    key,
+    label: key,
+    icon: '',
+    scope: 'admin',
+    enabled,
+    defaultEnabled: enabled,
+    adminOnly: false,
+    order: 0,
+  };
+}
+
+function mockTenant(id = 'mock-tenant'): VolundrTenant {
+  return {
+    id,
+    path: id,
+    name: 'Mock Tenant',
+    tier: 'standard',
+    maxSessions: 10,
+    maxStorageGb: 50,
+    createdAt: NOW,
+  };
+}
+
+function mockTrackerIssue(id = 'mock-issue'): TrackerIssue {
+  return {
+    id,
+    identifier: 'NIU-001',
+    title: 'Mock Issue',
+    status: 'in_progress',
+    url: 'https://linear.app/niuu/issue/NIU-001',
+  };
+}
+
+function mockPullRequest(): PullRequest {
+  return {
+    number: 1,
+    title: 'Mock PR',
+    url: 'https://github.com/niuulabs/niuu/pull/1',
+    repoUrl: 'https://github.com/niuulabs/niuu',
+    provider: 'github',
+    sourceBranch: 'feat/mock',
+    targetBranch: 'main',
+    status: 'open',
+  };
+}
+
+function mockAdminSettings(): AdminSettings {
+  return { storage: { homeEnabled: true, fileManagerEnabled: true } };
+}
+
+function mockIdentity(): VolundrIdentity {
+  return {
+    userId: 'mock-user-id',
+    email: 'mock@niuulabs.com',
+    tenantId: 'mock-tenant',
+    roles: ['user'],
+    displayName: 'Mock User',
+    status: 'active',
+  };
+}
+
+function mockPreset(id = 'mock-preset'): VolundrPreset {
+  return {
+    id,
+    name: 'Mock Preset',
+    description: 'A mock preset',
+    isDefault: false,
+    createdAt: NOW,
+    updatedAt: NOW,
+    cliTool: 'claude',
+    workloadType: 'standard',
+    model: null,
+    systemPrompt: null,
+    resourceConfig: {},
+    mcpServers: [],
+    terminalSidecar: { enabled: false, allowedCommands: [] },
+    skills: [],
+    rules: [],
+    envVars: {},
+    envSecretRefs: [],
+    source: null,
+    integrationIds: [],
+    setupScripts: [],
+    workloadConfig: {},
+  };
+}
+
+function mockStoredCredential(req: CredentialCreateRequest): StoredCredential {
+  return {
+    id: `cred-${req.name}`,
+    name: req.name,
+    secretType: req.secretType,
+    keys: Object.keys(req.data),
+    metadata: req.metadata ?? {},
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+}
+
+function mockIntegration(
+  connection: Omit<IntegrationConnection, 'id' | 'createdAt' | 'updatedAt'>
+): IntegrationConnection {
+  return { ...connection, id: 'mock-integration', createdAt: NOW, updatedAt: NOW };
+}
+
+/* ── IVolundrService ────────────────────────────────────────────── */
+
+export function createMockVolundrService(): IVolundrService {
+  const features: VolundrFeatures = {
+    localMountsEnabled: true,
+    fileManagerEnabled: true,
+    miniMode: false,
+  };
+  const stats: VolundrStats = {
+    activeSessions: 0,
+    totalSessions: 0,
+    tokensToday: 0,
+    localTokens: 0,
+    cloudTokens: 0,
+    costToday: 0,
+  };
+
+  return {
+    async getFeatures() { return features; },
+    async getSessions() { return []; },
+    async getSession(_id) { return null; },
+    async getActiveSessions() { return []; },
+    async getStats() { return stats; },
+    async getModels() { return {}; },
+    async getRepos() { return []; },
+    subscribe(_cb) { return () => undefined; },
+    subscribeStats(_cb) { return () => undefined; },
+    async getTemplates() { return []; },
+    async getTemplate(_name) { return null; },
+    async saveTemplate(template) { return template; },
+    async getPresets() { return [mockPreset()]; },
+    async getPreset(_id) { return mockPreset(); },
+    async savePreset(preset) {
+      return mockPreset(preset.id ?? 'mock-preset');
+    },
+    async deletePreset(_id) { return; },
+    async getAvailableMcpServers() { return []; },
+    async getAvailableSecrets() { return []; },
+    async createSecret(name, data) {
+      return { name, keys: Object.keys(data) };
+    },
+    async getClusterResources() {
+      return { resourceTypes: [], nodes: [] };
+    },
+    async startSession(config) {
+      return mockSession({ name: config.name, source: config.source, model: config.model });
+    },
+    async connectSession(config) {
+      return mockSession({ name: config.name, hostname: config.hostname });
+    },
+    async updateSession(_id, updates) {
+      return mockSession({ ...updates });
+    },
+    async stopSession(_id) { return; },
+    async resumeSession(_id) { return; },
+    async deleteSession(_id, _cleanup) { return; },
+    async archiveSession(_id) { return; },
+    async restoreSession(_id) { return; },
+    async listArchivedSessions() { return []; },
+    async getMessages(_id) { return []; },
+    async sendMessage(sessionId, content) {
+      return {
+        id: 'mock-msg-1',
+        sessionId,
+        role: 'assistant',
+        content: `echo: ${content}`,
+        timestamp: Date.now(),
+      };
+    },
+    subscribeMessages(_id, _cb) { return () => undefined; },
+    async getLogs(_id, _limit) { return []; },
+    subscribeLogs(_id, _cb) { return () => undefined; },
+    async getCodeServerUrl(_id) { return null; },
+    async getChronicle(_id) { return null; },
+    subscribeChronicle(_id, _cb) { return () => undefined; },
+    async getPullRequests(_repoUrl, _status) { return []; },
+    async createPullRequest(_id, _title, _branch) {
+      return mockPullRequest();
+    },
+    async mergePullRequest(_prNumber, _repoUrl, _method) {
+      return { merged: true };
+    },
+    async getCIStatus(_prNumber, _repoUrl, _branch) {
+      return 'unknown';
+    },
+    async getSessionMcpServers(_id) { return []; },
+    async searchTrackerIssues(_query, _projectId) { return []; },
+    async getProjectRepoMappings() { return []; },
+    async updateTrackerIssueStatus(issueId, _status) {
+      return mockTrackerIssue(issueId);
+    },
+    async getIdentity() { return mockIdentity(); },
+    async listUsers() { return []; },
+    async getTenants() { return [mockTenant()]; },
+    async getTenant(id) { return mockTenant(id); },
+    async createTenant(data) {
+      return { id: 'new-tenant', path: 'new-tenant', createdAt: NOW, ...data };
+    },
+    async deleteTenant(_id) { return; },
+    async updateTenant(id, data) {
+      return { ...mockTenant(id), ...data };
+    },
+    async getTenantMembers(_tenantId) { return []; },
+    async reprovisionUser(userId): Promise<VolundrProvisioningResult> {
+      return { success: true, userId, errors: [] };
+    },
+    async reprovisionTenant(_tenantId) { return []; },
+    async getUserCredentials() { return []; },
+    async storeUserCredential(_name, _data) { return; },
+    async deleteUserCredential(_name) { return; },
+    async getTenantCredentials() { return []; },
+    async storeTenantCredential(_name, _data) { return; },
+    async deleteTenantCredential(_name) { return; },
+    async getIntegrationCatalog() { return []; },
+    async getIntegrations() { return []; },
+    async createIntegration(connection) { return mockIntegration(connection); },
+    async deleteIntegration(_id) { return; },
+    async testIntegration(_id) { return { success: true, message: 'ok' }; },
+    async getCredentials(_type) { return []; },
+    async getCredential(_name) { return null; },
+    async createCredential(req) { return mockStoredCredential(req); },
+    async deleteCredential(_name) { return; },
+    async getCredentialTypes() { return []; },
+    async listWorkspaces(_status) { return []; },
+    async listAllWorkspaces(_status) { return []; },
+    async restoreWorkspace(_id) { return; },
+    async deleteWorkspace(_id) { return; },
+    async bulkDeleteWorkspaces(sessionIds) {
+      return { deleted: sessionIds.length, failed: [] };
+    },
+    async getAdminSettings() { return mockAdminSettings(); },
+    async updateAdminSettings(data) {
+      const base = mockAdminSettings();
+      return { storage: { ...base.storage, ...data.storage } };
+    },
+    async getFeatureModules(_scope) {
+      return [mockFeatureModule('volundr')];
+    },
+    async toggleFeature(key, enabled) { return mockFeatureModule(key, enabled); },
+    async getUserFeaturePreferences(): Promise<UserFeaturePreference[]> { return []; },
+    async updateUserFeaturePreferences(prefs) { return prefs; },
+    async listTokens() { return []; },
+    async createToken(name): Promise<CreatePATResult> {
+      return { id: 'mock-pat', name, token: 'mock-token-value', createdAt: NOW };
+    },
+    async revokeToken(_id) { return; },
+  };
+}
+
+/* ── IClusterAdapter ────────────────────────────────────────────── */
+
+function mockCluster(id = 'mock-cluster'): Cluster {
+  return {
+    id,
+    realm: 'mock-realm',
+    name: 'Mock Cluster',
+    capacity: { cpu: 100, memMi: 204800, gpu: 4 },
+    used: { cpu: 10, memMi: 20480, gpu: 0 },
+    nodes: [{ id: 'node-1', status: 'ready', role: 'worker' }],
+    runningSessions: 0,
+    queuedProvisions: 0,
+  };
+}
+
+export function createMockClusterAdapter(): IClusterAdapter {
+  return {
+    async getCluster(clusterId) { return mockCluster(clusterId); },
+    async listClusters() { return [mockCluster()]; },
+    async scheduleSession(_session, _podSpec) { return 'mock-pod-name'; },
+    async releaseSession(_session) { return; },
+  };
+}
+
+/* ── ISessionStore ──────────────────────────────────────────────── */
+
+export function createMockSessionStore(): ISessionStore {
+  const store = new Map<string, Session>();
+
+  return {
+    async get(id) { return store.get(id) ?? null; },
+    async list(filter) {
+      const all = [...store.values()];
+      if (!filter) return all;
+      return all.filter((s) => {
+        if (filter.state !== undefined && s.state !== filter.state) return false;
+        if (filter.clusterId !== undefined && s.clusterId !== filter.clusterId) return false;
+        return true;
+      });
+    },
+    async save(session) {
+      store.set(session.id, session);
+      return session;
+    },
+    async delete(id) {
+      store.delete(id);
+    },
+  };
+}
+
+/* ── ITemplateStore ─────────────────────────────────────────────── */
+
+export function createMockTemplateStore(): ITemplateStore {
+  const store = new Map<string, Template>();
+
+  return {
+    async get(id) { return store.get(id) ?? null; },
+    async list() { return [...store.values()]; },
+    async save(template) {
+      store.set(template.id, template);
+      return template;
+    },
+    async delete(id) {
+      store.delete(id);
+    },
+  };
+}
+
+/* ── IPtyStream ─────────────────────────────────────────────────── */
+
+export function createMockPtyStream(): IPtyStream {
+  const subs = new Map<string, Set<(output: { data: string; timestamp: number }) => void>>();
+
+  function getOrCreate(sessionId: string) {
+    let set = subs.get(sessionId);
+    if (!set) {
+      set = new Set();
+      subs.set(sessionId, set);
+    }
+    return set;
+  }
+
+  return {
+    async connect(_sessionId) { return; },
+    async write(sessionId, data) {
+      const set = subs.get(sessionId);
+      if (!set) return;
+      const output = { data: `echo: ${data}`, timestamp: Date.now() };
+      for (const cb of set) cb(output);
+    },
+    subscribe(sessionId, callback) {
+      const set = getOrCreate(sessionId);
+      set.add(callback);
+      return () => { set.delete(callback); };
+    },
+    async disconnect(sessionId) {
+      subs.delete(sessionId);
+    },
+  };
+}
+
+/* ── IMetricsStream ─────────────────────────────────────────────── */
+
+export function createMockMetricsStream(): IMetricsStream {
+  const intervals = new Map<string, ReturnType<typeof setInterval>>();
+
+  return {
+    subscribe(sessionId, callback) {
+      const handle = setInterval(() => {
+        callback({
+          sessionId,
+          timestamp: Date.now(),
+          cpuMillicores: Math.floor(Math.random() * 500),
+          memMi: Math.floor(Math.random() * 1024),
+          gpuUtilisation: 0,
+        });
+      }, 5000);
+      intervals.set(sessionId, handle);
+      return () => {
+        const h = intervals.get(sessionId);
+        if (h !== undefined) {
+          clearInterval(h);
+          intervals.delete(sessionId);
+        }
+      };
+    },
+    unsubscribeAll() {
+      for (const h of intervals.values()) clearInterval(h);
+      intervals.clear();
+    },
+  };
+}
+
+/** Convenience: mock the whole service + all side-ports together. */
+export function createMockVolundrServices() {
+  return {
+    volundr: createMockVolundrService(),
+    clusterAdapter: createMockClusterAdapter(),
+    sessionStore: createMockSessionStore(),
+    templateStore: createMockTemplateStore(),
+    ptyStream: createMockPtyStream(),
+    metricsStream: createMockMetricsStream(),
+  };
+}

--- a/web-next/packages/plugin-volundr/src/domain/cluster.test.ts
+++ b/web-next/packages/plugin-volundr/src/domain/cluster.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import {
+  availableCapacity,
+  isClusterHealthy,
+  nodeStatusCounts,
+  type Cluster,
+} from './cluster';
+
+const BASE_CLUSTER: Cluster = {
+  id: 'c1',
+  realm: 'test',
+  name: 'Test Cluster',
+  capacity: { cpu: 100, memMi: 204800, gpu: 8 },
+  used: { cpu: 40, memMi: 81920, gpu: 2 },
+  nodes: [
+    { id: 'n1', status: 'ready', role: 'worker' },
+    { id: 'n2', status: 'ready', role: 'worker' },
+    { id: 'n3', status: 'cordoned', role: 'worker' },
+  ],
+  runningSessions: 3,
+  queuedProvisions: 1,
+};
+
+describe('availableCapacity', () => {
+  it('subtracts used from capacity', () => {
+    const avail = availableCapacity(BASE_CLUSTER);
+    expect(avail.cpu).toBe(60);
+    expect(avail.memMi).toBe(122880);
+    expect(avail.gpu).toBe(6);
+  });
+
+  it('returns zero capacity when fully used', () => {
+    const full: Cluster = {
+      ...BASE_CLUSTER,
+      capacity: { cpu: 50, memMi: 1024, gpu: 2 },
+      used: { cpu: 50, memMi: 1024, gpu: 2 },
+    };
+    const avail = availableCapacity(full);
+    expect(avail.cpu).toBe(0);
+    expect(avail.memMi).toBe(0);
+    expect(avail.gpu).toBe(0);
+  });
+
+  it('can return negative when over-provisioned', () => {
+    const over: Cluster = {
+      ...BASE_CLUSTER,
+      capacity: { cpu: 10, memMi: 100, gpu: 0 },
+      used: { cpu: 15, memMi: 200, gpu: 0 },
+    };
+    const avail = availableCapacity(over);
+    expect(avail.cpu).toBe(-5);
+    expect(avail.memMi).toBe(-100);
+    expect(avail.gpu).toBe(0);
+  });
+});
+
+describe('isClusterHealthy', () => {
+  it('returns true when at least one node is ready', () => {
+    expect(isClusterHealthy(BASE_CLUSTER)).toBe(true);
+  });
+
+  it('returns false when no nodes are ready', () => {
+    const unhealthy: Cluster = {
+      ...BASE_CLUSTER,
+      nodes: [
+        { id: 'n1', status: 'notready', role: 'worker' },
+        { id: 'n2', status: 'cordoned', role: 'worker' },
+      ],
+    };
+    expect(isClusterHealthy(unhealthy)).toBe(false);
+  });
+
+  it('returns false for an empty cluster', () => {
+    const empty: Cluster = { ...BASE_CLUSTER, nodes: [] };
+    expect(isClusterHealthy(empty)).toBe(false);
+  });
+});
+
+describe('nodeStatusCounts', () => {
+  it('counts nodes by status correctly', () => {
+    const counts = nodeStatusCounts(BASE_CLUSTER);
+    expect(counts.ready).toBe(2);
+    expect(counts.notready).toBe(0);
+    expect(counts.cordoned).toBe(1);
+  });
+
+  it('returns all-zero counts for an empty cluster', () => {
+    const empty: Cluster = { ...BASE_CLUSTER, nodes: [] };
+    const counts = nodeStatusCounts(empty);
+    expect(counts.ready).toBe(0);
+    expect(counts.notready).toBe(0);
+    expect(counts.cordoned).toBe(0);
+  });
+
+  it('handles all-notready clusters', () => {
+    const cluster: Cluster = {
+      ...BASE_CLUSTER,
+      nodes: [
+        { id: 'n1', status: 'notready', role: 'worker' },
+        { id: 'n2', status: 'notready', role: 'master' },
+      ],
+    };
+    const counts = nodeStatusCounts(cluster);
+    expect(counts.notready).toBe(2);
+    expect(counts.ready).toBe(0);
+  });
+});

--- a/web-next/packages/plugin-volundr/src/domain/cluster.ts
+++ b/web-next/packages/plugin-volundr/src/domain/cluster.ts
@@ -1,0 +1,51 @@
+/** Kubernetes node readiness states. */
+export type NodeStatus = 'ready' | 'notready' | 'cordoned';
+
+/** A single node in a cluster. */
+export interface ClusterNode {
+  readonly id: string;
+  readonly status: NodeStatus;
+  readonly role: string;
+}
+
+/** CPU / memory / GPU quantities for a cluster (aggregate). */
+export interface ResourceCapacity {
+  readonly cpu: number;
+  readonly memMi: number;
+  readonly gpu: number;
+}
+
+/** A realm-bound cluster that Völundr schedules sessions onto. */
+export interface Cluster {
+  readonly id: string;
+  readonly realm: string;
+  readonly name: string;
+  readonly capacity: ResourceCapacity;
+  readonly used: ResourceCapacity;
+  readonly nodes: readonly ClusterNode[];
+  readonly runningSessions: number;
+  readonly queuedProvisions: number;
+}
+
+/** Returns the un-used portion of a cluster's capacity. */
+export function availableCapacity(cluster: Cluster): ResourceCapacity {
+  return {
+    cpu: cluster.capacity.cpu - cluster.used.cpu,
+    memMi: cluster.capacity.memMi - cluster.used.memMi,
+    gpu: cluster.capacity.gpu - cluster.used.gpu,
+  };
+}
+
+/** Returns true when the cluster has at least one ready node. */
+export function isClusterHealthy(cluster: Cluster): boolean {
+  return cluster.nodes.some((n) => n.status === 'ready');
+}
+
+/** Returns the count of nodes in each status bucket. */
+export function nodeStatusCounts(cluster: Cluster): Record<NodeStatus, number> {
+  const counts: Record<NodeStatus, number> = { ready: 0, notready: 0, cordoned: 0 };
+  for (const node of cluster.nodes) {
+    counts[node.status] += 1;
+  }
+  return counts;
+}

--- a/web-next/packages/plugin-volundr/src/domain/models.ts
+++ b/web-next/packages/plugin-volundr/src/domain/models.ts
@@ -1,0 +1,515 @@
+/**
+ * Legacy model types lifted from web/src/modules/volundr/models/.
+ *
+ * These types serve the lifted IVolundrService port. New code should use
+ * the domain types in session.ts / pod.ts / template.ts / cluster.ts / quota.ts
+ * instead.
+ */
+
+// Re-export shared identity types from plugin-sdk.
+export type { AppIdentity } from '@niuulabs/plugin-sdk';
+
+// Re-export feature-catalog types from plugin-sdk.
+export type {
+  FeatureScope,
+  FeatureModule,
+  UserFeaturePreference,
+} from '@niuulabs/plugin-sdk';
+
+/* ── Session status (legacy, matches backend API) ──────────────── */
+
+export type SessionStatus =
+  | 'created'
+  | 'starting'
+  | 'provisioning'
+  | 'running'
+  | 'stopping'
+  | 'stopped'
+  | 'error'
+  | 'archived';
+
+export type SessionOrigin = 'managed' | 'manual';
+
+export type ModelTier = 'frontier' | 'balanced' | 'execution' | 'reasoning';
+export type ModelProvider = 'cloud' | 'local';
+
+/* ── Session source ─────────────────────────────────────────────── */
+
+export interface GitSource {
+  readonly type: 'git';
+  readonly repo: string;
+  readonly branch: string;
+}
+
+export interface MountMapping {
+  readonly host_path: string;
+  readonly mount_path: string;
+  readonly read_only: boolean;
+}
+
+export interface LocalMountSource {
+  readonly type: 'local_mount';
+  readonly local_path?: string;
+  readonly paths: readonly MountMapping[];
+  readonly node_selector?: Readonly<Record<string, string>>;
+}
+
+export type SessionSource = GitSource | LocalMountSource;
+
+/* ── Tracker ────────────────────────────────────────────────────── */
+
+export type TrackerIssueStatus =
+  | 'backlog'
+  | 'todo'
+  | 'in_progress'
+  | 'done'
+  | 'cancelled';
+
+export interface TrackerIssue {
+  readonly id: string;
+  readonly identifier: string;
+  readonly title: string;
+  readonly status: TrackerIssueStatus;
+  readonly assignee?: string;
+  readonly labels?: readonly string[];
+  readonly priority?: number;
+  readonly url: string;
+}
+
+export interface ProjectRepoMapping {
+  readonly linearProjectId: string;
+  readonly linearProjectName: string;
+  readonly repoUrl: string;
+}
+
+/* ── Session ────────────────────────────────────────────────────── */
+
+export interface VolundrSession {
+  readonly id: string;
+  readonly name: string;
+  readonly source: SessionSource;
+  readonly status: SessionStatus;
+  readonly model: string;
+  readonly lastActive: number;
+  readonly messageCount: number;
+  readonly tokensUsed: number;
+  readonly podName?: string;
+  readonly error?: string;
+  readonly origin?: SessionOrigin;
+  readonly hostname?: string;
+  readonly chatEndpoint?: string;
+  readonly codeEndpoint?: string;
+  readonly taskType?: string;
+  readonly archivedAt?: Date;
+  readonly trackerIssue?: TrackerIssue;
+  readonly activityState?: 'active' | 'idle' | 'tool_executing' | null;
+  readonly ownerId?: string;
+  readonly tenantId?: string;
+}
+
+/* ── Stats ──────────────────────────────────────────────────────── */
+
+export interface VolundrStats {
+  readonly activeSessions: number;
+  readonly totalSessions: number;
+  readonly tokensToday: number;
+  readonly localTokens: number;
+  readonly cloudTokens: number;
+  readonly costToday: number;
+}
+
+export interface VolundrFeatures {
+  readonly localMountsEnabled: boolean;
+  readonly fileManagerEnabled: boolean;
+  readonly miniMode: boolean;
+}
+
+/* ── Models / repos ─────────────────────────────────────────────── */
+
+export interface VolundrModel {
+  readonly name: string;
+  readonly provider: ModelProvider;
+  readonly tier: ModelTier;
+  readonly color: string;
+  readonly cost?: string;
+  readonly vram?: string;
+}
+
+export type RepoProvider = 'github' | 'gitlab' | 'bitbucket';
+
+export interface VolundrRepo {
+  readonly provider: RepoProvider;
+  readonly org: string;
+  readonly name: string;
+  readonly cloneUrl: string;
+  readonly url: string;
+  readonly defaultBranch: string;
+  readonly branches: readonly string[];
+}
+
+/* ── Messages / logs ────────────────────────────────────────────── */
+
+export type MessageRole = 'user' | 'assistant';
+
+export interface VolundrMessage {
+  readonly id: string;
+  readonly sessionId: string;
+  readonly role: MessageRole;
+  readonly content: string;
+  readonly timestamp: number;
+  readonly tokensIn?: number;
+  readonly tokensOut?: number;
+  readonly latency?: number;
+}
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface VolundrLog {
+  readonly id: string;
+  readonly sessionId: string;
+  readonly timestamp: number;
+  readonly level: LogLevel;
+  readonly source: string;
+  readonly message: string;
+}
+
+/* ── Chronicle ──────────────────────────────────────────────────── */
+
+export type ChronicleEventType = 'message' | 'file' | 'git' | 'terminal' | 'error' | 'session';
+
+export interface ChronicleEvent {
+  readonly t: number;
+  readonly type: ChronicleEventType;
+  readonly label: string;
+  readonly tokens?: number;
+  readonly action?: string;
+  readonly ins?: number;
+  readonly del?: number;
+  readonly hash?: string;
+  readonly exit?: number;
+}
+
+export interface SessionFile {
+  readonly path: string;
+  readonly status: 'new' | 'mod' | 'del';
+  readonly ins: number;
+  readonly del: number;
+}
+
+export interface SessionCommit {
+  readonly hash: string;
+  readonly msg: string;
+  readonly time: string;
+}
+
+export interface SessionChronicle {
+  readonly events: readonly ChronicleEvent[];
+  readonly files: readonly SessionFile[];
+  readonly commits: readonly SessionCommit[];
+  readonly tokenBurn: readonly number[];
+}
+
+/* ── Cluster resources ──────────────────────────────────────────── */
+
+export interface ResourceType {
+  readonly name: string;
+  readonly resourceKey: string;
+  readonly displayName: string;
+  readonly unit: string;
+  readonly category: string;
+}
+
+export interface NodeResourceSummary {
+  readonly name: string;
+  readonly labels: Readonly<Record<string, string>>;
+  readonly allocatable: Readonly<Record<string, string>>;
+  readonly allocated: Readonly<Record<string, string>>;
+  readonly available: Readonly<Record<string, string>>;
+}
+
+export interface ClusterResourceInfo {
+  readonly resourceTypes: readonly ResourceType[];
+  readonly nodes: readonly NodeResourceSummary[];
+}
+
+/* ── Pull requests / CI ─────────────────────────────────────────── */
+
+export type PRStatus = 'open' | 'closed' | 'merged';
+export type CIStatusValue = 'pending' | 'running' | 'passed' | 'failed' | 'unknown';
+
+export interface PullRequest {
+  readonly number: number;
+  readonly title: string;
+  readonly url: string;
+  readonly repoUrl: string;
+  readonly provider: string;
+  readonly sourceBranch: string;
+  readonly targetBranch: string;
+  readonly status: PRStatus;
+  readonly description?: string;
+  readonly ciStatus?: CIStatusValue;
+  readonly reviewStatus?: string;
+  readonly createdAt?: string;
+  readonly updatedAt?: string;
+}
+
+export interface MergeResult {
+  readonly merged: boolean;
+}
+
+/* ── MCP servers ────────────────────────────────────────────────── */
+
+export type McpServerStatus = 'connected' | 'disconnected';
+
+export interface McpServer {
+  readonly name: string;
+  readonly status: McpServerStatus;
+  readonly tools: number;
+}
+
+export type McpServerType = 'stdio' | 'sse' | 'http';
+
+export interface McpServerConfig {
+  readonly name: string;
+  readonly type: McpServerType;
+  readonly command?: string;
+  readonly url?: string;
+  readonly args?: readonly string[];
+  readonly env?: Readonly<Record<string, string>>;
+}
+
+/* ── Credentials ────────────────────────────────────────────────── */
+
+export type SecretType =
+  | 'api_key'
+  | 'oauth_token'
+  | 'git_credential'
+  | 'ssh_key'
+  | 'tls_cert'
+  | 'generic';
+
+export interface StoredCredential {
+  readonly id: string;
+  readonly name: string;
+  readonly secretType: SecretType;
+  readonly keys: readonly string[];
+  readonly metadata: Readonly<Record<string, string>>;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+export interface CredentialCreateRequest {
+  readonly name: string;
+  readonly secretType: SecretType;
+  readonly data: Readonly<Record<string, string>>;
+  readonly metadata?: Readonly<Record<string, string>>;
+}
+
+export interface SecretTypeField {
+  readonly key: string;
+  readonly label: string;
+  readonly type: 'text' | 'password' | 'textarea';
+  readonly required: boolean;
+}
+
+export interface SecretTypeInfo {
+  readonly type: SecretType;
+  readonly label: string;
+  readonly description: string;
+  readonly fields: readonly SecretTypeField[];
+  readonly defaultMountType: 'env' | 'file' | 'template';
+}
+
+export interface VolundrCredential {
+  readonly name: string;
+  readonly keys: readonly string[];
+}
+
+/* ── Integrations ───────────────────────────────────────────────── */
+
+export interface IntegrationConnection {
+  readonly id: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly [key: string]: unknown;
+}
+
+export interface IntegrationTestResult {
+  readonly success: boolean;
+  readonly message: string;
+}
+
+export interface CatalogEntry {
+  readonly id: string;
+  readonly name: string;
+  readonly description: string;
+}
+
+/* ── Users / tenants ────────────────────────────────────────────── */
+
+export interface VolundrUser {
+  readonly id: string;
+  readonly email: string;
+  readonly displayName: string;
+  readonly status: string;
+  readonly tenantId?: string;
+  readonly provisionError?: string;
+  readonly createdAt?: string;
+}
+
+export type VolundrIdentity = {
+  readonly userId: string;
+  readonly email: string;
+  readonly tenantId: string;
+  readonly roles: readonly string[];
+  readonly displayName: string;
+  readonly status: string;
+};
+
+export interface VolundrTenant {
+  readonly id: string;
+  readonly path: string;
+  readonly name: string;
+  readonly parentId?: string;
+  readonly tier: string;
+  readonly maxSessions: number;
+  readonly maxStorageGb: number;
+  readonly createdAt?: string;
+}
+
+export interface VolundrMember {
+  readonly userId: string;
+  readonly tenantId: string;
+  readonly role: string;
+  readonly grantedAt?: string;
+}
+
+export interface VolundrProvisioningResult {
+  readonly success: boolean;
+  readonly userId: string;
+  readonly homePvc?: string;
+  readonly errors: readonly string[];
+}
+
+/* ── Workspaces ─────────────────────────────────────────────────── */
+
+export type WorkspaceStatus = 'active' | 'archived' | 'deleted';
+
+export interface VolundrWorkspace {
+  readonly id: string;
+  readonly pvcName: string;
+  readonly sessionId: string;
+  readonly ownerId: string;
+  readonly tenantId: string;
+  readonly sizeGb: number;
+  readonly status: WorkspaceStatus;
+  readonly createdAt: string;
+  readonly archivedAt?: string;
+  readonly sessionName?: string;
+  readonly sourceUrl?: string;
+  readonly sourceRef?: string;
+}
+
+/* ── Admin ──────────────────────────────────────────────────────── */
+
+export interface AdminStorageSettings {
+  readonly homeEnabled: boolean;
+  readonly fileManagerEnabled: boolean;
+}
+
+export interface AdminSettings {
+  readonly storage: AdminStorageSettings;
+}
+
+/* ── Templates / presets ────────────────────────────────────────── */
+
+export interface ResourceConfig {
+  readonly cpu?: string;
+  readonly memory?: string;
+  readonly gpu?: string;
+  readonly [key: string]: string | undefined;
+}
+
+export interface TerminalSidecarConfig {
+  readonly enabled: boolean;
+  readonly allowedCommands: readonly string[];
+  readonly restricted?: boolean;
+}
+
+export interface SkillConfig {
+  readonly name: string;
+  readonly path?: string;
+  readonly inline?: string;
+}
+
+export interface RuleConfig {
+  readonly path?: string;
+  readonly inline?: string;
+}
+
+export interface TemplateRepo {
+  readonly repo: string;
+  readonly branch?: string;
+  readonly [key: string]: unknown;
+}
+
+export interface VolundrTemplate {
+  readonly name: string;
+  readonly description: string;
+  readonly isDefault: boolean;
+  readonly repos: readonly TemplateRepo[];
+  readonly setupScripts: readonly string[];
+  readonly workspaceLayout: Readonly<Record<string, unknown>>;
+  readonly cliTool: string;
+  readonly workloadType: string;
+  readonly model: string | null;
+  readonly systemPrompt: string | null;
+  readonly resourceConfig: ResourceConfig;
+  readonly mcpServers: readonly McpServerConfig[];
+  readonly envVars: Readonly<Record<string, string>>;
+  readonly envSecretRefs: readonly string[];
+  readonly workloadConfig: Readonly<Record<string, string | number | boolean | undefined>>;
+  readonly terminalSidecar: TerminalSidecarConfig;
+  readonly skills: readonly SkillConfig[];
+  readonly rules: readonly RuleConfig[];
+}
+
+export interface VolundrPreset {
+  readonly id: string;
+  readonly name: string;
+  readonly description: string;
+  readonly isDefault: boolean;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly cliTool: string;
+  readonly workloadType: string;
+  readonly model: string | null;
+  readonly systemPrompt: string | null;
+  readonly resourceConfig: ResourceConfig;
+  readonly mcpServers: readonly McpServerConfig[];
+  readonly terminalSidecar: TerminalSidecarConfig;
+  readonly skills: readonly SkillConfig[];
+  readonly rules: readonly RuleConfig[];
+  readonly envVars: Readonly<Record<string, string>>;
+  readonly envSecretRefs: readonly string[];
+  readonly source: SessionSource | null;
+  readonly integrationIds: readonly string[];
+  readonly setupScripts: readonly string[];
+  readonly workloadConfig: Readonly<Record<string, string | number | boolean | undefined>>;
+}
+
+/* ── Personal Access Tokens ─────────────────────────────────────── */
+
+export interface PersonalAccessToken {
+  readonly id: string;
+  readonly name: string;
+  readonly createdAt: string;
+  readonly lastUsedAt: string | null;
+}
+
+export interface CreatePATResult {
+  readonly id: string;
+  readonly name: string;
+  readonly token: string;
+  readonly createdAt: string;
+}

--- a/web-next/packages/plugin-volundr/src/domain/models.ts
+++ b/web-next/packages/plugin-volundr/src/domain/models.ts
@@ -6,9 +6,6 @@
  * instead.
  */
 
-// Re-export shared identity types from plugin-sdk.
-export type { AppIdentity } from '@niuulabs/plugin-sdk';
-
 // Re-export feature-catalog types from plugin-sdk.
 export type {
   FeatureScope,

--- a/web-next/packages/plugin-volundr/src/domain/pod.ts
+++ b/web-next/packages/plugin-volundr/src/domain/pod.ts
@@ -1,0 +1,28 @@
+/** Source of a pod volume mount. */
+export type MountSourceKind = 'git' | 'pvc' | 'secret' | 'configmap';
+
+/** A single volume mounted into the pod. */
+export interface PodMount {
+  readonly name: string;
+  readonly mountPath: string;
+  readonly sourceKind: MountSourceKind;
+  readonly source: string;
+  readonly readOnly: boolean;
+}
+
+/** CPU / memory / GPU resource numbers for a pod. Values use SI units (millicores, MiB). */
+export interface ResourceSpec {
+  readonly cpuRequest: number;
+  readonly cpuLimit: number;
+  readonly memRequestMi: number;
+  readonly memLimitMi: number;
+  readonly gpuCount: number;
+}
+
+/** Full specification of a pod that Völundr will provision. */
+export interface PodSpec {
+  readonly image: string;
+  readonly mounts: readonly PodMount[];
+  readonly env: Readonly<Record<string, string>>;
+  readonly resources: ResourceSpec;
+}

--- a/web-next/packages/plugin-volundr/src/domain/quota.test.ts
+++ b/web-next/packages/plugin-volundr/src/domain/quota.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { isWithinQuota, remainingQuota, isOverQuota, type Quota, type QuotaUsage } from './quota';
+
+const QUOTA: Quota = { maxCpu: 100, maxMemMi: 8192, maxGpu: 4, maxSessions: 10 };
+
+describe('isWithinQuota', () => {
+  it('returns true when all dimensions are under the limit', () => {
+    const usage: QuotaUsage = { cpu: 50, memMi: 4096, gpu: 2, sessions: 5 };
+    expect(isWithinQuota(QUOTA, usage)).toBe(true);
+  });
+
+  it('returns true when usage exactly equals the limit', () => {
+    const usage: QuotaUsage = { cpu: 100, memMi: 8192, gpu: 4, sessions: 10 };
+    expect(isWithinQuota(QUOTA, usage)).toBe(true);
+  });
+
+  it('returns false when cpu exceeds the limit', () => {
+    const usage: QuotaUsage = { cpu: 101, memMi: 4096, gpu: 2, sessions: 5 };
+    expect(isWithinQuota(QUOTA, usage)).toBe(false);
+  });
+
+  it('returns false when memMi exceeds the limit', () => {
+    const usage: QuotaUsage = { cpu: 50, memMi: 8193, gpu: 2, sessions: 5 };
+    expect(isWithinQuota(QUOTA, usage)).toBe(false);
+  });
+
+  it('returns false when gpu exceeds the limit', () => {
+    const usage: QuotaUsage = { cpu: 50, memMi: 4096, gpu: 5, sessions: 5 };
+    expect(isWithinQuota(QUOTA, usage)).toBe(false);
+  });
+
+  it('returns false when sessions exceed the limit', () => {
+    const usage: QuotaUsage = { cpu: 50, memMi: 4096, gpu: 2, sessions: 11 };
+    expect(isWithinQuota(QUOTA, usage)).toBe(false);
+  });
+
+  it('returns true for all-zero usage', () => {
+    const usage: QuotaUsage = { cpu: 0, memMi: 0, gpu: 0, sessions: 0 };
+    expect(isWithinQuota(QUOTA, usage)).toBe(true);
+  });
+});
+
+describe('remainingQuota', () => {
+  it('returns the remaining capacity for each dimension', () => {
+    const usage: QuotaUsage = { cpu: 40, memMi: 2048, gpu: 1, sessions: 3 };
+    const remaining = remainingQuota(QUOTA, usage);
+    expect(remaining.cpu).toBe(60);
+    expect(remaining.memMi).toBe(6144);
+    expect(remaining.gpu).toBe(3);
+    expect(remaining.sessions).toBe(7);
+  });
+
+  it('returns zero when usage equals quota', () => {
+    const usage: QuotaUsage = { cpu: 100, memMi: 8192, gpu: 4, sessions: 10 };
+    const remaining = remainingQuota(QUOTA, usage);
+    expect(remaining.cpu).toBe(0);
+    expect(remaining.memMi).toBe(0);
+    expect(remaining.gpu).toBe(0);
+    expect(remaining.sessions).toBe(0);
+  });
+
+  it('returns negative values when over-quota', () => {
+    const usage: QuotaUsage = { cpu: 120, memMi: 10000, gpu: 6, sessions: 15 };
+    const remaining = remainingQuota(QUOTA, usage);
+    expect(remaining.cpu).toBe(-20);
+    expect(remaining.memMi).toBe(-1808);
+    expect(remaining.gpu).toBe(-2);
+    expect(remaining.sessions).toBe(-5);
+  });
+});
+
+describe('isOverQuota', () => {
+  it('returns false when within quota', () => {
+    const usage: QuotaUsage = { cpu: 10, memMi: 100, gpu: 0, sessions: 1 };
+    expect(isOverQuota(QUOTA, usage)).toBe(false);
+  });
+
+  it('returns true when any dimension is over', () => {
+    const usage: QuotaUsage = { cpu: 10, memMi: 100, gpu: 0, sessions: 11 };
+    expect(isOverQuota(QUOTA, usage)).toBe(true);
+  });
+
+  it('is the inverse of isWithinQuota', () => {
+    const usage: QuotaUsage = { cpu: 50, memMi: 4096, gpu: 2, sessions: 5 };
+    expect(isOverQuota(QUOTA, usage)).toBe(!isWithinQuota(QUOTA, usage));
+  });
+});

--- a/web-next/packages/plugin-volundr/src/domain/quota.ts
+++ b/web-next/packages/plugin-volundr/src/domain/quota.ts
@@ -1,0 +1,40 @@
+/** Maximum resource allocation for a raven / persona / realm. */
+export interface Quota {
+  readonly maxCpu: number;
+  readonly maxMemMi: number;
+  readonly maxGpu: number;
+  readonly maxSessions: number;
+}
+
+/** Current resource usage to compare against a quota. */
+export interface QuotaUsage {
+  readonly cpu: number;
+  readonly memMi: number;
+  readonly gpu: number;
+  readonly sessions: number;
+}
+
+/** Returns true when every usage dimension is within the quota. */
+export function isWithinQuota(quota: Quota, usage: QuotaUsage): boolean {
+  return (
+    usage.cpu <= quota.maxCpu &&
+    usage.memMi <= quota.maxMemMi &&
+    usage.gpu <= quota.maxGpu &&
+    usage.sessions <= quota.maxSessions
+  );
+}
+
+/** Returns how much of the quota is still available. Negative values mean over-quota. */
+export function remainingQuota(quota: Quota, usage: QuotaUsage): QuotaUsage {
+  return {
+    cpu: quota.maxCpu - usage.cpu,
+    memMi: quota.maxMemMi - usage.memMi,
+    gpu: quota.maxGpu - usage.gpu,
+    sessions: quota.maxSessions - usage.sessions,
+  };
+}
+
+/** Returns true when the usage exceeds ANY quota dimension. */
+export function isOverQuota(quota: Quota, usage: QuotaUsage): boolean {
+  return !isWithinQuota(quota, usage);
+}

--- a/web-next/packages/plugin-volundr/src/domain/session.test.ts
+++ b/web-next/packages/plugin-volundr/src/domain/session.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from 'vitest';
+import {
+  canTransition,
+  transition,
+  isTerminalState,
+  isActiveState,
+  isProvisioningState,
+  isReadyOrBeyond,
+  type SessionState,
+} from './session';
+
+describe('canTransition', () => {
+  it('allows requested → provisioning', () => {
+    expect(canTransition('requested', 'provisioning')).toBe(true);
+  });
+
+  it('allows requested → failed', () => {
+    expect(canTransition('requested', 'failed')).toBe(true);
+  });
+
+  it('allows provisioning → ready', () => {
+    expect(canTransition('provisioning', 'ready')).toBe(true);
+  });
+
+  it('allows provisioning → failed', () => {
+    expect(canTransition('provisioning', 'failed')).toBe(true);
+  });
+
+  it('allows ready → running', () => {
+    expect(canTransition('ready', 'running')).toBe(true);
+  });
+
+  it('allows ready → terminating', () => {
+    expect(canTransition('ready', 'terminating')).toBe(true);
+  });
+
+  it('allows ready → failed', () => {
+    expect(canTransition('ready', 'failed')).toBe(true);
+  });
+
+  it('allows running → idle', () => {
+    expect(canTransition('running', 'idle')).toBe(true);
+  });
+
+  it('allows running → terminating', () => {
+    expect(canTransition('running', 'terminating')).toBe(true);
+  });
+
+  it('allows running → failed', () => {
+    expect(canTransition('running', 'failed')).toBe(true);
+  });
+
+  it('allows idle → running (resume)', () => {
+    expect(canTransition('idle', 'running')).toBe(true);
+  });
+
+  it('allows idle → terminating', () => {
+    expect(canTransition('idle', 'terminating')).toBe(true);
+  });
+
+  it('allows idle → failed', () => {
+    expect(canTransition('idle', 'failed')).toBe(true);
+  });
+
+  it('allows terminating → terminated', () => {
+    expect(canTransition('terminating', 'terminated')).toBe(true);
+  });
+
+  it('allows terminating → failed', () => {
+    expect(canTransition('terminating', 'failed')).toBe(true);
+  });
+
+  it('rejects terminated → anything', () => {
+    const targets: SessionState[] = [
+      'requested', 'provisioning', 'ready', 'running', 'idle', 'terminating', 'failed',
+    ];
+    for (const to of targets) {
+      expect(canTransition('terminated', to)).toBe(false);
+    }
+  });
+
+  it('rejects failed → anything', () => {
+    const targets: SessionState[] = [
+      'requested', 'provisioning', 'ready', 'running', 'idle', 'terminating', 'terminated',
+    ];
+    for (const to of targets) {
+      expect(canTransition('failed', to)).toBe(false);
+    }
+  });
+
+  it('rejects requested → running (skips states)', () => {
+    expect(canTransition('requested', 'running')).toBe(false);
+  });
+
+  it('rejects requested → idle (skips states)', () => {
+    expect(canTransition('requested', 'idle')).toBe(false);
+  });
+
+  it('rejects provisioning → running (skips ready)', () => {
+    expect(canTransition('provisioning', 'running')).toBe(false);
+  });
+
+  it('rejects running → requested', () => {
+    expect(canTransition('running', 'requested')).toBe(false);
+  });
+
+  it('rejects running → provisioning', () => {
+    expect(canTransition('running', 'provisioning')).toBe(false);
+  });
+
+  it('rejects idle → provisioning', () => {
+    expect(canTransition('idle', 'provisioning')).toBe(false);
+  });
+});
+
+describe('transition', () => {
+  it('returns the target state on a valid transition', () => {
+    expect(transition('requested', 'provisioning')).toBe('provisioning');
+    expect(transition('provisioning', 'ready')).toBe('ready');
+    expect(transition('ready', 'running')).toBe('running');
+    expect(transition('running', 'idle')).toBe('idle');
+    expect(transition('idle', 'running')).toBe('running');
+    expect(transition('running', 'terminating')).toBe('terminating');
+    expect(transition('terminating', 'terminated')).toBe('terminated');
+  });
+
+  it('throws on an invalid transition', () => {
+    expect(() => transition('terminated', 'running')).toThrow(
+      'Invalid session state transition: terminated → running',
+    );
+  });
+
+  it('throws when skipping states', () => {
+    expect(() => transition('requested', 'running')).toThrow();
+  });
+
+  it('throws from a failed state', () => {
+    expect(() => transition('failed', 'provisioning')).toThrow();
+  });
+});
+
+describe('isTerminalState', () => {
+  it('returns true for terminated', () => {
+    expect(isTerminalState('terminated')).toBe(true);
+  });
+
+  it('returns true for failed', () => {
+    expect(isTerminalState('failed')).toBe(true);
+  });
+
+  it('returns false for all non-terminal states', () => {
+    const live: SessionState[] = [
+      'requested', 'provisioning', 'ready', 'running', 'idle', 'terminating',
+    ];
+    for (const s of live) {
+      expect(isTerminalState(s)).toBe(false);
+    }
+  });
+});
+
+describe('isActiveState', () => {
+  it('returns true for running', () => {
+    expect(isActiveState('running')).toBe(true);
+  });
+
+  it('returns true for idle', () => {
+    expect(isActiveState('idle')).toBe(true);
+  });
+
+  it('returns false for non-active states', () => {
+    const inactive: SessionState[] = [
+      'requested', 'provisioning', 'ready', 'terminating', 'terminated', 'failed',
+    ];
+    for (const s of inactive) {
+      expect(isActiveState(s)).toBe(false);
+    }
+  });
+});
+
+describe('isProvisioningState', () => {
+  it('returns true for requested', () => {
+    expect(isProvisioningState('requested')).toBe(true);
+  });
+
+  it('returns true for provisioning', () => {
+    expect(isProvisioningState('provisioning')).toBe(true);
+  });
+
+  it('returns false for ready and beyond', () => {
+    const others: SessionState[] = [
+      'ready', 'running', 'idle', 'terminating', 'terminated', 'failed',
+    ];
+    for (const s of others) {
+      expect(isProvisioningState(s)).toBe(false);
+    }
+  });
+});
+
+describe('isReadyOrBeyond', () => {
+  it('returns false for early states', () => {
+    expect(isReadyOrBeyond('requested')).toBe(false);
+    expect(isReadyOrBeyond('provisioning')).toBe(false);
+    expect(isReadyOrBeyond('failed')).toBe(false);
+  });
+
+  it('returns true for ready through terminated', () => {
+    const advanced: SessionState[] = ['ready', 'running', 'idle', 'terminating', 'terminated'];
+    for (const s of advanced) {
+      expect(isReadyOrBeyond(s)).toBe(true);
+    }
+  });
+});

--- a/web-next/packages/plugin-volundr/src/domain/session.ts
+++ b/web-next/packages/plugin-volundr/src/domain/session.ts
@@ -1,0 +1,86 @@
+/**
+ * Session lifecycle state machine.
+ *
+ * Authoritative ordering:
+ *   requested → provisioning → ready → running ↔ idle → terminating → terminated
+ *
+ * Any state can transition to `failed` except `terminated` (terminal).
+ */
+export type SessionState =
+  | 'requested'
+  | 'provisioning'
+  | 'ready'
+  | 'running'
+  | 'idle'
+  | 'terminating'
+  | 'terminated'
+  | 'failed';
+
+const VALID_TRANSITIONS: Readonly<Record<SessionState, readonly SessionState[]>> = {
+  requested: ['provisioning', 'failed'],
+  provisioning: ['ready', 'failed'],
+  ready: ['running', 'terminating', 'failed'],
+  running: ['idle', 'terminating', 'failed'],
+  idle: ['running', 'terminating', 'failed'],
+  terminating: ['terminated', 'failed'],
+  terminated: [],
+  failed: [],
+};
+
+/** Returns true when `to` is a legal next state from `from`. */
+export function canTransition(from: SessionState, to: SessionState): boolean {
+  return (VALID_TRANSITIONS[from] as SessionState[]).includes(to);
+}
+
+/**
+ * Validates and returns the target state.
+ * @throws {Error} when the transition is not allowed.
+ */
+export function transition(from: SessionState, to: SessionState): SessionState {
+  if (!canTransition(from, to)) {
+    throw new Error(`Invalid session state transition: ${from} → ${to}`);
+  }
+  return to;
+}
+
+/** Returns true for states that have no further valid transitions. */
+export function isTerminalState(state: SessionState): boolean {
+  return state === 'terminated' || state === 'failed';
+}
+
+/** Returns true when the session is consuming resources (running or idle). */
+export function isActiveState(state: SessionState): boolean {
+  return state === 'running' || state === 'idle';
+}
+
+/** Returns true while the session is being provisioned but not yet ready. */
+export function isProvisioningState(state: SessionState): boolean {
+  return state === 'requested' || state === 'provisioning';
+}
+
+/** Returns true once the session pod exists and is accepting connections. */
+export function isReadyOrBeyond(state: SessionState): boolean {
+  return (
+    state === 'ready' ||
+    state === 'running' ||
+    state === 'idle' ||
+    state === 'terminating' ||
+    state === 'terminated'
+  );
+}
+
+/** A Völundr session that runs inside a provisioned pod. */
+export interface Session {
+  readonly id: string;
+  readonly ravnId: string;
+  readonly personaName: string;
+  readonly sagaId?: string;
+  readonly raidId?: string;
+  readonly templateId: string;
+  readonly clusterId: string;
+  readonly state: SessionState;
+  readonly startedAt: string;
+  readonly readyAt?: string;
+  readonly lastActivityAt?: string;
+  readonly terminatedAt?: string;
+}

--- a/web-next/packages/plugin-volundr/src/domain/template.ts
+++ b/web-next/packages/plugin-volundr/src/domain/template.ts
@@ -1,0 +1,20 @@
+import type { PodMount, ResourceSpec } from './pod';
+
+/** A reusable pod configuration that sessions are stamped from. */
+export interface Template {
+  readonly id: string;
+  readonly name: string;
+  readonly version: number;
+  readonly image: string;
+  readonly mounts: readonly PodMount[];
+  readonly env: Readonly<Record<string, string>>;
+  /** Tool IDs from Ravn's registry that sessions may expose. */
+  readonly tools: readonly string[];
+  readonly resources: ResourceSpec;
+  /** Maximum session lifetime in seconds (hard cutoff). */
+  readonly ttlSec: number;
+  /** Seconds of inactivity before auto-termination. */
+  readonly idleTimeoutSec: number;
+  /** Cluster IDs this template prefers; empty = any cluster. */
+  readonly clusterAffinity: readonly string[];
+}

--- a/web-next/packages/plugin-volundr/src/env.d.ts
+++ b/web-next/packages/plugin-volundr/src/env.d.ts
@@ -1,0 +1,5 @@
+/** CSS Module type declarations for Völundr plugin. */
+declare module '*.module.css' {
+  const styles: Record<string, string>;
+  export default styles;
+}

--- a/web-next/packages/plugin-volundr/src/index.ts
+++ b/web-next/packages/plugin-volundr/src/index.ts
@@ -1,0 +1,78 @@
+import { createRoute, type AnyRoute } from '@tanstack/react-router';
+import { definePlugin } from '@niuulabs/plugin-sdk';
+import { VolundrPage } from './ui/VolundrPage';
+
+export const volundrPlugin = definePlugin({
+  id: 'volundr',
+  /** Kaunaz — torch / forge */
+  rune: 'ᚲ',
+  title: 'Völundr',
+  subtitle: 'session forge',
+  routes: (rootRoute: AnyRoute) => [
+    createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/volundr',
+      component: VolundrPage,
+    }),
+  ],
+});
+
+// Domain
+export type { SessionState, Session } from './domain/session';
+export { canTransition, transition, isTerminalState, isActiveState, isProvisioningState, isReadyOrBeyond } from './domain/session';
+export type { MountSourceKind, PodMount, ResourceSpec, PodSpec } from './domain/pod';
+export type { Template } from './domain/template';
+export type { NodeStatus, ClusterNode, ResourceCapacity, Cluster } from './domain/cluster';
+export { availableCapacity, isClusterHealthy, nodeStatusCounts } from './domain/cluster';
+export type { Quota, QuotaUsage } from './domain/quota';
+export { isWithinQuota, remainingQuota, isOverQuota } from './domain/quota';
+
+// Ports (type-only)
+export type { IVolundrService } from './ports/IVolundrService';
+export type { IClusterAdapter } from './ports/IClusterAdapter';
+export type { ISessionStore } from './ports/ISessionStore';
+export type { ITemplateStore } from './ports/ITemplateStore';
+export type { IPtyStream, PtyOutput } from './ports/IPtyStream';
+export type { IMetricsStream, SessionMetrics } from './ports/IMetricsStream';
+
+// Adapters
+export {
+  createMockVolundrService,
+  createMockClusterAdapter,
+  createMockSessionStore,
+  createMockTemplateStore,
+  createMockPtyStream,
+  createMockMetricsStream,
+  createMockVolundrServices,
+} from './adapters/mock';
+
+// Selected domain models (for consumers)
+export type {
+  VolundrSession,
+  VolundrStats,
+  VolundrFeatures,
+  SessionStatus,
+  SessionSource,
+  GitSource,
+  LocalMountSource,
+  VolundrMessage,
+  VolundrLog,
+  VolundrModel,
+  VolundrRepo,
+  SessionChronicle,
+  ChronicleEvent,
+  TrackerIssue,
+  PullRequest,
+  MergeResult,
+  CIStatusValue,
+  StoredCredential,
+  CredentialCreateRequest,
+  SecretType,
+  VolundrTemplate,
+  VolundrPreset,
+  VolundrIdentity,
+  VolundrTenant,
+  AdminSettings,
+  PersonalAccessToken,
+  CreatePATResult,
+} from './domain/models';

--- a/web-next/packages/plugin-volundr/src/ports/IClusterAdapter.ts
+++ b/web-next/packages/plugin-volundr/src/ports/IClusterAdapter.ts
@@ -1,0 +1,25 @@
+/**
+ * Port for the Kubernetes cluster adapter.
+ *
+ * Abstracts over whatever cluster API (k8s, mock, …) the operator configures.
+ */
+import type { Cluster } from '../domain/cluster';
+import type { Session } from '../domain/session';
+import type { PodSpec } from '../domain/pod';
+
+export interface IClusterAdapter {
+  /** Fetch the current state of a single cluster. */
+  getCluster(clusterId: string): Promise<Cluster | null>;
+
+  /** List all clusters visible to this adapter. */
+  listClusters(): Promise<Cluster[]>;
+
+  /**
+   * Schedule a new pod for the given session on the given cluster.
+   * Returns the pod name on success.
+   */
+  scheduleSession(session: Session, podSpec: PodSpec): Promise<string>;
+
+  /** Release (delete) the pod backing a session. */
+  releaseSession(session: Session): Promise<void>;
+}

--- a/web-next/packages/plugin-volundr/src/ports/IMetricsStream.ts
+++ b/web-next/packages/plugin-volundr/src/ports/IMetricsStream.ts
@@ -1,0 +1,28 @@
+/**
+ * Port for live metrics streaming (CPU / memory / GPU).
+ *
+ * Implementations may pull from Prometheus, the k8s metrics API, etc.
+ */
+
+export interface SessionMetrics {
+  readonly sessionId: string;
+  readonly timestamp: number;
+  /** CPU usage in millicores. */
+  readonly cpuMillicores: number;
+  /** Memory usage in MiB. */
+  readonly memMi: number;
+  /** GPU utilisation as a fraction 0–1. */
+  readonly gpuUtilisation: number;
+}
+
+export interface IMetricsStream {
+  /**
+   * Subscribe to metrics for the given session.
+   * Implementations should emit on every scrape interval.
+   * @returns Unsubscribe function — must be called on unmount.
+   */
+  subscribe(sessionId: string, callback: (metrics: SessionMetrics) => void): () => void;
+
+  /** Stop ALL active subscriptions (e.g. on page unmount). */
+  unsubscribeAll(): void;
+}

--- a/web-next/packages/plugin-volundr/src/ports/IPtyStream.ts
+++ b/web-next/packages/plugin-volundr/src/ports/IPtyStream.ts
@@ -1,0 +1,29 @@
+/**
+ * Port for PTY (pseudo-terminal) streaming.
+ *
+ * Implementations may use WebSocket binary frames, SSE, or any other transport.
+ * The UI calls `connect`, sends input via `write`, and streams output via `subscribe`.
+ */
+
+export interface PtyOutput {
+  /** Raw terminal bytes (UTF-8 encoded). */
+  readonly data: string;
+  readonly timestamp: number;
+}
+
+export interface IPtyStream {
+  /** Open a PTY connection for the given session. */
+  connect(sessionId: string): Promise<void>;
+
+  /** Send terminal input to the session. */
+  write(sessionId: string, data: string): Promise<void>;
+
+  /**
+   * Subscribe to terminal output from the session.
+   * @returns Unsubscribe function — must be called on unmount.
+   */
+  subscribe(sessionId: string, callback: (output: PtyOutput) => void): () => void;
+
+  /** Close the PTY connection for the session. */
+  disconnect(sessionId: string): Promise<void>;
+}

--- a/web-next/packages/plugin-volundr/src/ports/ISessionStore.ts
+++ b/web-next/packages/plugin-volundr/src/ports/ISessionStore.ts
@@ -1,0 +1,21 @@
+/**
+ * Port for session persistence.
+ *
+ * The store is responsible for reading/writing Session aggregates.
+ * Adapters may back this with PostgreSQL, in-memory maps, etc.
+ */
+import type { Session, SessionState } from '../domain/session';
+
+export interface ISessionStore {
+  /** Fetch a single session by ID, or null if not found. */
+  get(id: string): Promise<Session | null>;
+
+  /** List all sessions, optionally filtered by state. */
+  list(filter?: { state?: SessionState; clusterId?: string }): Promise<Session[]>;
+
+  /** Persist a new or updated session. */
+  save(session: Session): Promise<Session>;
+
+  /** Remove a session record. */
+  delete(id: string): Promise<void>;
+}

--- a/web-next/packages/plugin-volundr/src/ports/ITemplateStore.ts
+++ b/web-next/packages/plugin-volundr/src/ports/ITemplateStore.ts
@@ -1,0 +1,18 @@
+/**
+ * Port for template persistence.
+ */
+import type { Template } from '../domain/template';
+
+export interface ITemplateStore {
+  /** Fetch a single template by ID, or null if not found. */
+  get(id: string): Promise<Template | null>;
+
+  /** List all templates. */
+  list(): Promise<Template[]>;
+
+  /** Persist a new or updated template. */
+  save(template: Template): Promise<Template>;
+
+  /** Remove a template. */
+  delete(id: string): Promise<void>;
+}

--- a/web-next/packages/plugin-volundr/src/ports/IVolundrService.ts
+++ b/web-next/packages/plugin-volundr/src/ports/IVolundrService.ts
@@ -1,0 +1,188 @@
+/**
+ * Port interface for the Völundr service.
+ *
+ * Lifted from web/src/modules/volundr/ports/volundr.port.ts.
+ * Imports updated from @/modules/volundr/models to ../domain/models.
+ * Editor-related methods dropped (Monaco is gone).
+ */
+import type {
+  VolundrFeatures,
+  VolundrSession,
+  VolundrStats,
+  VolundrModel,
+  VolundrRepo,
+  VolundrMessage,
+  VolundrLog,
+  SessionChronicle,
+  ClusterResourceInfo,
+  PullRequest,
+  MergeResult,
+  CIStatusValue,
+  McpServer,
+  McpServerConfig,
+  VolundrPreset,
+  VolundrTemplate,
+  TrackerIssue,
+  ProjectRepoMapping,
+  VolundrIdentity,
+  VolundrUser,
+  VolundrTenant,
+  VolundrCredential,
+  IntegrationConnection,
+  IntegrationTestResult,
+  CatalogEntry,
+  StoredCredential,
+  CredentialCreateRequest,
+  SecretType,
+  SecretTypeInfo,
+  VolundrWorkspace,
+  WorkspaceStatus,
+  VolundrMember,
+  VolundrProvisioningResult,
+  SessionSource,
+  AdminSettings,
+  AdminStorageSettings,
+  FeatureModule,
+  FeatureScope,
+  UserFeaturePreference,
+  PersonalAccessToken,
+  CreatePATResult,
+} from '../domain/models';
+
+export interface IVolundrService {
+  getFeatures(): Promise<VolundrFeatures>;
+  getSessions(): Promise<VolundrSession[]>;
+  getSession(id: string): Promise<VolundrSession | null>;
+  getActiveSessions(): Promise<VolundrSession[]>;
+  getStats(): Promise<VolundrStats>;
+  getModels(): Promise<Record<string, VolundrModel>>;
+  getRepos(): Promise<VolundrRepo[]>;
+  subscribe(callback: (sessions: VolundrSession[]) => void): () => void;
+  subscribeStats(callback: (stats: VolundrStats) => void): () => void;
+  getTemplates(): Promise<VolundrTemplate[]>;
+  getTemplate(name: string): Promise<VolundrTemplate | null>;
+  saveTemplate(template: VolundrTemplate): Promise<VolundrTemplate>;
+  getPresets(): Promise<VolundrPreset[]>;
+  getPreset(id: string): Promise<VolundrPreset | null>;
+  savePreset(
+    preset: Omit<VolundrPreset, 'id' | 'createdAt' | 'updatedAt'> & { id?: string }
+  ): Promise<VolundrPreset>;
+  deletePreset(id: string): Promise<void>;
+  getAvailableMcpServers(): Promise<McpServerConfig[]>;
+  getAvailableSecrets(): Promise<string[]>;
+  createSecret(
+    name: string,
+    data: Record<string, string>
+  ): Promise<{ name: string; keys: string[] }>;
+  getClusterResources(): Promise<ClusterResourceInfo>;
+  startSession(config: {
+    name: string;
+    source: SessionSource;
+    model: string;
+    templateName?: string;
+    taskType?: string;
+    trackerIssue?: TrackerIssue;
+    terminalRestricted?: boolean;
+    workspaceId?: string;
+    credentialNames?: string[];
+    integrationIds?: string[];
+    resourceConfig?: Record<string, string | undefined>;
+    systemPrompt?: string;
+    initialPrompt?: string;
+  }): Promise<VolundrSession>;
+  connectSession(config: { name: string; hostname: string }): Promise<VolundrSession>;
+  updateSession(
+    sessionId: string,
+    updates: { name?: string; model?: string; branch?: string; tracker_issue_id?: string }
+  ): Promise<VolundrSession>;
+  stopSession(sessionId: string): Promise<void>;
+  resumeSession(sessionId: string): Promise<void>;
+  deleteSession(sessionId: string, cleanup?: string[]): Promise<void>;
+  archiveSession(sessionId: string): Promise<void>;
+  restoreSession(sessionId: string): Promise<void>;
+  listArchivedSessions(): Promise<VolundrSession[]>;
+  getMessages(sessionId: string): Promise<VolundrMessage[]>;
+  sendMessage(sessionId: string, content: string): Promise<VolundrMessage>;
+  subscribeMessages(sessionId: string, callback: (message: VolundrMessage) => void): () => void;
+  getLogs(sessionId: string, limit?: number): Promise<VolundrLog[]>;
+  subscribeLogs(sessionId: string, callback: (log: VolundrLog) => void): () => void;
+  getCodeServerUrl(sessionId: string): Promise<string | null>;
+  getChronicle(sessionId: string): Promise<SessionChronicle | null>;
+  subscribeChronicle(
+    sessionId: string,
+    callback: (chronicle: SessionChronicle) => void
+  ): () => void;
+  getPullRequests(repoUrl: string, status?: string): Promise<PullRequest[]>;
+  createPullRequest(
+    sessionId: string,
+    title?: string,
+    targetBranch?: string
+  ): Promise<PullRequest>;
+  mergePullRequest(
+    prNumber: number,
+    repoUrl: string,
+    mergeMethod?: string
+  ): Promise<MergeResult>;
+  getCIStatus(prNumber: number, repoUrl: string, branch: string): Promise<CIStatusValue>;
+  getSessionMcpServers(sessionId: string): Promise<McpServer[]>;
+  searchTrackerIssues(query: string, projectId?: string): Promise<TrackerIssue[]>;
+  getProjectRepoMappings(): Promise<ProjectRepoMapping[]>;
+  updateTrackerIssueStatus(
+    issueId: string,
+    status: TrackerIssue['status']
+  ): Promise<TrackerIssue>;
+  getIdentity(): Promise<VolundrIdentity>;
+  listUsers(): Promise<VolundrUser[]>;
+  getTenants(): Promise<VolundrTenant[]>;
+  getTenant(id: string): Promise<VolundrTenant | null>;
+  createTenant(data: {
+    name: string;
+    tier: string;
+    maxSessions: number;
+    maxStorageGb: number;
+  }): Promise<VolundrTenant>;
+  deleteTenant(id: string): Promise<void>;
+  updateTenant(
+    id: string,
+    data: { tier?: string; maxSessions?: number; maxStorageGb?: number }
+  ): Promise<VolundrTenant>;
+  getTenantMembers(tenantId: string): Promise<VolundrMember[]>;
+  reprovisionUser(userId: string): Promise<VolundrProvisioningResult>;
+  reprovisionTenant(tenantId: string): Promise<VolundrProvisioningResult[]>;
+  getUserCredentials(): Promise<VolundrCredential[]>;
+  storeUserCredential(name: string, data: Record<string, string>): Promise<void>;
+  deleteUserCredential(name: string): Promise<void>;
+  getTenantCredentials(): Promise<VolundrCredential[]>;
+  storeTenantCredential(name: string, data: Record<string, string>): Promise<void>;
+  deleteTenantCredential(name: string): Promise<void>;
+  getIntegrationCatalog(): Promise<CatalogEntry[]>;
+  getIntegrations(): Promise<IntegrationConnection[]>;
+  createIntegration(
+    connection: Omit<IntegrationConnection, 'id' | 'createdAt' | 'updatedAt'>
+  ): Promise<IntegrationConnection>;
+  deleteIntegration(id: string): Promise<void>;
+  testIntegration(id: string): Promise<IntegrationTestResult>;
+  getCredentials(type?: SecretType): Promise<StoredCredential[]>;
+  getCredential(name: string): Promise<StoredCredential | null>;
+  createCredential(req: CredentialCreateRequest): Promise<StoredCredential>;
+  deleteCredential(name: string): Promise<void>;
+  getCredentialTypes(): Promise<SecretTypeInfo[]>;
+  listWorkspaces(status?: WorkspaceStatus): Promise<VolundrWorkspace[]>;
+  listAllWorkspaces(status?: WorkspaceStatus): Promise<VolundrWorkspace[]>;
+  restoreWorkspace(id: string): Promise<void>;
+  deleteWorkspace(id: string): Promise<void>;
+  bulkDeleteWorkspaces(
+    sessionIds: string[]
+  ): Promise<{ deleted: number; failed: Array<{ session_id: string; error: string }> }>;
+  getAdminSettings(): Promise<AdminSettings>;
+  updateAdminSettings(data: { storage?: AdminStorageSettings }): Promise<AdminSettings>;
+  getFeatureModules(scope?: FeatureScope): Promise<FeatureModule[]>;
+  toggleFeature(key: string, enabled: boolean): Promise<FeatureModule>;
+  getUserFeaturePreferences(): Promise<UserFeaturePreference[]>;
+  updateUserFeaturePreferences(
+    preferences: UserFeaturePreference[]
+  ): Promise<UserFeaturePreference[]>;
+  listTokens(): Promise<PersonalAccessToken[]>;
+  createToken(name: string): Promise<CreatePATResult>;
+  revokeToken(id: string): Promise<void>;
+}

--- a/web-next/packages/plugin-volundr/src/ui/VolundrPage.module.css
+++ b/web-next/packages/plugin-volundr/src/ui/VolundrPage.module.css
@@ -1,0 +1,44 @@
+.root {
+  padding: var(--space-6);
+  max-width: 800px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  margin-bottom: var(--space-6);
+}
+
+.titleGroup {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.title {
+  margin: 0;
+  font-size: var(--text-xl);
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.subtitle {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+.body {
+  padding: var(--space-8) var(--space-6);
+  border: 1px dashed var(--color-border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-secondary);
+}
+
+.coming {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  text-align: center;
+}

--- a/web-next/packages/plugin-volundr/src/ui/VolundrPage.test.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/VolundrPage.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { VolundrPage } from './VolundrPage';
+
+describe('VolundrPage', () => {
+  it('renders the plugin title', () => {
+    render(<VolundrPage />);
+    expect(screen.getByText('Völundr · session forge')).toBeInTheDocument();
+  });
+
+  it('renders the subtitle', () => {
+    render(<VolundrPage />);
+    expect(screen.getByText('Provision and manage remote dev sessions')).toBeInTheDocument();
+  });
+
+  it('renders the rune glyph', () => {
+    render(<VolundrPage />);
+    expect(screen.getByText('ᚲ')).toBeInTheDocument();
+  });
+
+  it('renders the coming-soon message', () => {
+    render(<VolundrPage />);
+    expect(screen.getByText(/Full UI coming soon/)).toBeInTheDocument();
+  });
+});

--- a/web-next/packages/plugin-volundr/src/ui/VolundrPage.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/VolundrPage.tsx
@@ -1,0 +1,27 @@
+import { Rune } from '@niuulabs/ui';
+import styles from './VolundrPage.module.css';
+
+/**
+ * Placeholder page for the Völundr plugin.
+ *
+ * Full implementation (Sessions, Templates, Clusters, History) follows in
+ * subsequent tickets that build on this scaffold.
+ */
+export function VolundrPage() {
+  return (
+    <div className={styles.root}>
+      <div className={styles.header}>
+        <Rune glyph="ᚲ" size={40} />
+        <div className={styles.titleGroup}>
+          <h2 className={styles.title}>Völundr · session forge</h2>
+          <p className={styles.subtitle}>Provision and manage remote dev sessions</p>
+        </div>
+      </div>
+      <div className={styles.body}>
+        <p className={styles.coming}>
+          Full UI coming soon — domain, ports, and mock adapter are ready.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/web-next/packages/plugin-volundr/tsconfig.json
+++ b/web-next/packages/plugin-volundr/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "**/*.stories.tsx"]
+}

--- a/web-next/packages/plugin-volundr/tsup.config.ts
+++ b/web-next/packages/plugin-volundr/tsup.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  external: [
+    'react',
+    '@tanstack/react-query',
+    '@tanstack/react-router',
+    '@niuulabs/domain',
+    '@niuulabs/plugin-sdk',
+    '@niuulabs/query',
+    '@niuulabs/ui',
+  ],
+});

--- a/web-next/packages/plugin-volundr/tsup.config.ts
+++ b/web-next/packages/plugin-volundr/tsup.config.ts
@@ -10,7 +10,6 @@ export default defineConfig({
     'react',
     '@tanstack/react-query',
     '@tanstack/react-router',
-    '@niuulabs/domain',
     '@niuulabs/plugin-sdk',
     '@niuulabs/query',
     '@niuulabs/ui',

--- a/web-next/pnpm-lock.yaml
+++ b/web-next/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
       '@niuulabs/plugin-sdk':
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
+      '@niuulabs/plugin-volundr':
+        specifier: workspace:*
+        version: link:../../packages/plugin-volundr
       '@niuulabs/query':
         specifier: workspace:*
         version: link:../../packages/query
@@ -222,6 +225,40 @@ importers:
         specifier: ^3.24.1
         version: 3.25.76
     devDependencies:
+      '@tanstack/react-router':
+        specifier: ^1.95.0
+        version: 1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@types/react':
+        specifier: ^19.0.7
+        version: 19.2.14
+      react:
+        specifier: ^19.0.0
+        version: 19.2.5
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(postcss@8.5.10)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
+  packages/plugin-volundr:
+    dependencies:
+      '@niuulabs/domain':
+        specifier: workspace:*
+        version: link:../domain
+      '@niuulabs/plugin-sdk':
+        specifier: workspace:*
+        version: link:../plugin-sdk
+      '@niuulabs/query':
+        specifier: workspace:*
+        version: link:../query
+      '@niuulabs/ui':
+        specifier: workspace:*
+        version: link:../ui
+    devDependencies:
+      '@tanstack/react-query':
+        specifier: ^5.62.0
+        version: 5.99.1(react@19.2.5)
       '@tanstack/react-router':
         specifier: ^1.95.0
         version: 1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)


### PR DESCRIPTION
## Summary

- **Domain**: `Session` aggregate with 8-state lifecycle machine (`requested → provisioning → ready → running → idle → terminating → terminated | failed`); `Cluster`, `Quota`, `Template` value objects; state predicate helpers (`canTransition`, `transition`, `isTerminalState`, `isActiveState`, `isProvisioningState`, `isReadyOrBeyond`)
- **Ports**: `IVolundrService` (lifted from `web/src/modules/volundr/ports/volundr.port.ts`, ~70 methods), `IClusterAdapter`, `ISessionStore`, `ITemplateStore`, `IPtyStream`, `IMetricsStream` — all pure TypeScript interfaces, no framework coupling
- **Adapters**: Full mock implementations of all six ports (`createMockVolundrService`, `createMockClusterAdapter`, `createMockSessionStore`, `createMockTemplateStore`, `createMockPtyStream`, `createMockMetricsStream`) plus `createMockVolundrServices` convenience composite
- **UI**: `VolundrPage` placeholder using `Rune` component with `ᚲ` (Kaunaz), CSS Modules + design tokens, no inline styles; `volundrPlugin` descriptor registered with the shell
- **Integration**: Plugin registered in `apps/niuu` (plugins.ts, services.ts, config.json, package.json)
- **Playwright e2e**: Three specs — rail rune visible, /volundr route renders title, rune visible on page
- **Tests**: 361 tests, 99.09% statements / 98.28% branches / 97.98% functions coverage

## Test plan

- [x] `pnpm -F @niuulabs/plugin-volundr test --coverage` — 361 tests passing, all thresholds ≥ 85%
- [x] `pnpm -F @niuulabs/plugin-volundr typecheck` — clean
- [x] Lifecycle state machine: all valid transitions accepted, all invalid transitions throw with correct message
- [x] Mock adapters: all factory methods exercised, metrics stream timer tested with fake timers
- [x] `VolundrPage` renders title, subtitle, and Kaunaz rune
- [x] Playwright e2e specs in `e2e/volundr.spec.ts`

## Linear

NIU-675

🤖 Generated with [Claude Code](https://claude.com/claude-code)