### PR TITLE
feat(observatory): registry editor — Types / Containment / JSON tabs (NIU-666)

### DIFF
--- a/web-next/e2e/observatory.spec.ts
+++ b/web-next/e2e/observatory.spec.ts
@@ -49,4 +49,124 @@ test.describe('observatory plugin', () => {
       page.getByTitle('Flokk · Observatory · live topology & entity registry'),
     ).toBeVisible();
   });
+
+  test.describe('registry editor', () => {
+    test('registry editor renders after data loads', async ({ page }) => {
+      await page.goto('/observatory');
+      await expect(page.getByText('Entity type registry')).toBeVisible({ timeout: 5000 });
+      await expect(page.getByRole('tab', { name: 'Types' })).toBeVisible();
+      await expect(page.getByRole('tab', { name: 'Containment' })).toBeVisible();
+      await expect(page.getByRole('tab', { name: 'Json' })).toBeVisible();
+    });
+
+    test('Types tab shows search input and type cards', async ({ page }) => {
+      await page.goto('/observatory');
+      await expect(page.getByText('Entity type registry')).toBeVisible({ timeout: 5000 });
+
+      await expect(page.getByRole('searchbox', { name: 'Filter entity types' })).toBeVisible();
+      // The seed registry has topology category
+      await expect(page.getByText('topology')).toBeVisible();
+      // And shows Realm type card
+      await expect(page.getByRole('button', { name: /Realm \(realm\)/ })).toBeVisible();
+    });
+
+    test('Types tab search filters type cards', async ({ page }) => {
+      await page.goto('/observatory');
+      await expect(page.getByText('Entity type registry')).toBeVisible({ timeout: 5000 });
+
+      const search = page.getByRole('searchbox', { name: 'Filter entity types' });
+      await search.fill('realm');
+      await expect(page.getByRole('button', { name: /Realm \(realm\)/ })).toBeVisible();
+      // Cluster should be hidden after filtering to "realm"
+      await expect(page.getByRole('button', { name: /Cluster \(cluster\)/ })).not.toBeVisible();
+    });
+
+    test('Containment tab shows the tree structure', async ({ page }) => {
+      await page.goto('/observatory');
+      await expect(page.getByText('Entity type registry')).toBeVisible({ timeout: 5000 });
+
+      await page.getByRole('tab', { name: 'Containment' }).click();
+      await expect(page.getByRole('tree', { name: 'Containment tree' })).toBeVisible();
+      await expect(page.getByRole('treeitem', { name: 'Realm' })).toBeVisible();
+      await expect(page.getByRole('treeitem', { name: 'Cluster' })).toBeVisible();
+    });
+
+    test('drag a type onto a valid target updates the containment tree', async ({ page }) => {
+      await page.goto('/observatory');
+      await expect(page.getByText('Entity type registry')).toBeVisible({ timeout: 5000 });
+
+      await page.getByRole('tab', { name: 'Containment' }).click();
+      await expect(page.getByRole('tree', { name: 'Containment tree' })).toBeVisible();
+
+      // Drag "Host" onto "Cluster" (host is currently under realm; cluster can contain service)
+      // This moves host to be a child of cluster — no cycle, valid operation
+      const hostNode = page.getByRole('treeitem', { name: 'Host' });
+      const clusterNode = page.getByRole('treeitem', { name: 'Cluster' });
+
+      await hostNode.dragTo(clusterNode);
+
+      // After reparent, the preview drawer should show host's updated parentTypes
+      await clusterNode.click();
+      // Cluster now contains host in its canContain list, visible in preview drawer
+      await expect(page.getByText('host')).toBeVisible({ timeout: 2000 });
+    });
+
+    test('cycle drop is rejected — tree stays unchanged', async ({ page }) => {
+      await page.goto('/observatory');
+      await expect(page.getByText('Entity type registry')).toBeVisible({ timeout: 5000 });
+
+      await page.getByRole('tab', { name: 'Containment' }).click();
+      await expect(page.getByRole('tree', { name: 'Containment tree' })).toBeVisible();
+
+      // Try to drag "Realm" onto "Cluster" — would create a cycle (realm → cluster already)
+      const realmNode = page.getByRole('treeitem', { name: 'Realm' });
+      const clusterNode = page.getByRole('treeitem', { name: 'Cluster' });
+
+      // Verify initial state: realm is a root (no parent marker)
+      await expect(realmNode).toBeVisible();
+
+      await realmNode.dragTo(clusterNode);
+
+      // Realm should still be in the root position (no parent)
+      // The tree structure shouldn't change — realm is still present at root
+      await expect(page.getByRole('treeitem', { name: 'Realm' })).toBeVisible();
+      // Check drop-invalid visual cue appeared (data-drag-state=drop-invalid class)
+      // Since this is a quick drop, we can't reliably check the transient state
+      // but we can verify the tree is unchanged by clicking realm and seeing its info
+      await realmNode.click();
+      // Preview drawer should show realm's info — parentTypes still empty
+      await expect(page.getByText('Type · topology')).toBeVisible();
+    });
+
+    test('JSON tab shows pretty-printed registry', async ({ page }) => {
+      await page.goto('/observatory');
+      await expect(page.getByText('Entity type registry')).toBeVisible({ timeout: 5000 });
+
+      await page.getByRole('tab', { name: 'Json' }).click();
+      await expect(page.getByLabelText('Registry JSON')).toBeVisible();
+      // The JSON should contain the registry structure
+      await expect(page.getByLabelText('Registry JSON')).toContainText('"version"');
+      await expect(page.getByLabelText('Registry JSON')).toContainText('"types"');
+    });
+
+    test('JSON tab copy button is present', async ({ page }) => {
+      await page.goto('/observatory');
+      await expect(page.getByText('Entity type registry')).toBeVisible({ timeout: 5000 });
+
+      await page.getByRole('tab', { name: 'Json' }).click();
+      await expect(
+        page.getByRole('button', { name: 'Copy JSON to clipboard' }),
+      ).toBeVisible();
+    });
+
+    test('clicking a type card shows its preview in the drawer', async ({ page }) => {
+      await page.goto('/observatory');
+      await expect(page.getByText('Entity type registry')).toBeVisible({ timeout: 5000 });
+
+      await page.getByRole('button', { name: /Cluster \(cluster\)/ }).click();
+      await expect(page.getByText('Type · topology')).toBeVisible();
+      // Cluster's id appears in the preview
+      await expect(page.getByText('cluster')).toBeVisible();
+    });
+  });
 });

--- a/web-next/packages/plugin-observatory/src/ui/ContainmentTab.module.css
+++ b/web-next/packages/plugin-observatory/src/ui/ContainmentTab.module.css
@@ -1,0 +1,133 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.hint {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2) var(--space-3);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.hint code {
+  font-family: var(--font-mono);
+  color: var(--color-brand);
+  font-size: 0.9em;
+}
+
+.tree {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.treeNode {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
+  cursor: grab;
+  background: var(--color-bg-secondary);
+  border-color: var(--color-border-subtle);
+  transition: background 100ms, border-color 100ms, opacity 100ms;
+  user-select: none;
+}
+
+.treeNode:hover {
+  background: var(--color-bg-tertiary);
+  border-color: var(--color-border);
+}
+
+/* Selected */
+.treeNode[data-selected='true'] {
+  background: color-mix(in srgb, var(--color-brand) 10%, var(--color-bg-secondary));
+  border-color: color-mix(in srgb, var(--color-brand) 30%, transparent);
+}
+
+/* Drag states */
+.treeNode[data-drag-state='dragging'] {
+  opacity: 0.35;
+  cursor: grabbing;
+}
+
+.treeNode[data-drag-state='drop-ok'] {
+  border-color: color-mix(in srgb, var(--color-brand) 45%, transparent);
+}
+
+.treeNode[data-drag-state='drop-target'] {
+  background: color-mix(in srgb, var(--color-brand) 18%, var(--color-bg-secondary));
+  border-color: var(--color-brand);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--color-brand) 30%, transparent);
+}
+
+.treeNode[data-drag-state='drop-invalid'] {
+  background: color-mix(in srgb, var(--color-critical) 12%, var(--color-bg-secondary));
+  border-color: color-mix(in srgb, var(--color-critical) 60%, transparent);
+}
+
+.grip {
+  font-size: 11px;
+  color: var(--color-text-muted);
+  letter-spacing: -2px;
+  flex-shrink: 0;
+}
+
+.shapeIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  flex-shrink: 0;
+}
+
+.rune {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  color: var(--color-brand);
+  flex-shrink: 0;
+  width: 16px;
+  text-align: center;
+}
+
+.name {
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--color-text-primary);
+  flex: 1;
+}
+
+.meta {
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-text-muted);
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.children {
+  margin-top: var(--space-1);
+}
+
+.orphans {
+  margin-top: var(--space-4);
+  border-top: 1px dashed var(--color-border-subtle);
+  padding-top: var(--space-3);
+}
+
+.orphanLabel {
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  margin-bottom: var(--space-2);
+}

--- a/web-next/packages/plugin-observatory/src/ui/ContainmentTab.test.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/ContainmentTab.test.tsx
@@ -1,0 +1,359 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ContainmentTab } from './ContainmentTab';
+import type { TypeRegistry } from '../domain/registry';
+
+// realm → cluster → service (with host as a sibling of cluster under realm)
+const REGISTRY: TypeRegistry = {
+  version: 1,
+  updatedAt: '2026-01-01T00:00:00Z',
+  types: [
+    {
+      id: 'realm',
+      label: 'Realm',
+      rune: 'ᛞ',
+      icon: 'globe',
+      shape: 'ring',
+      color: 'ice-100',
+      size: 18,
+      border: 'solid',
+      canContain: ['cluster', 'host'],
+      parentTypes: [],
+      category: 'topology',
+      description: 'A realm.',
+      fields: [],
+    },
+    {
+      id: 'cluster',
+      label: 'Cluster',
+      rune: 'ᚲ',
+      icon: 'layers',
+      shape: 'ring-dashed',
+      color: 'ice-200',
+      size: 14,
+      border: 'dashed',
+      canContain: ['service'],
+      parentTypes: ['realm'],
+      category: 'topology',
+      description: 'A cluster.',
+      fields: [],
+    },
+    {
+      id: 'host',
+      label: 'Host',
+      rune: 'ᚦ',
+      icon: 'server',
+      shape: 'rounded-rect',
+      color: 'slate-400',
+      size: 22,
+      border: 'solid',
+      canContain: [],
+      parentTypes: ['realm'],
+      category: 'hardware',
+      description: 'A host.',
+      fields: [],
+    },
+    {
+      id: 'service',
+      label: 'Service',
+      rune: 'ᛦ',
+      icon: 'box',
+      shape: 'dot',
+      color: 'ice-300',
+      size: 8,
+      border: 'solid',
+      canContain: [],
+      parentTypes: ['cluster'],
+      category: 'infrastructure',
+      description: 'A service.',
+      fields: [],
+    },
+  ],
+};
+
+/** Registry where one type's parentTypes reference is dangling (orphan) */
+const ORPHAN_REGISTRY: TypeRegistry = {
+  ...REGISTRY,
+  types: [
+    ...REGISTRY.types,
+    {
+      id: 'orphan',
+      label: 'Orphan',
+      rune: 'ᚢ',
+      icon: 'help-circle',
+      shape: 'dot',
+      color: 'slate-400',
+      size: 8,
+      border: 'solid',
+      canContain: [],
+      parentTypes: ['missing-parent'],
+      category: 'infrastructure',
+      description: 'An orphaned type.',
+      fields: [],
+    },
+  ],
+};
+
+function makeDt() {
+  return {
+    effectAllowed: 'uninitialized' as DataTransfer['effectAllowed'],
+    dropEffect: 'none' as DataTransfer['dropEffect'],
+    _data: {} as Record<string, string>,
+    setData(t: string, v: string) {
+      this._data[t] = v;
+    },
+    getData(t: string) {
+      return this._data[t] ?? '';
+    },
+  };
+}
+
+describe('ContainmentTab', () => {
+  it('renders root types', () => {
+    render(
+      <ContainmentTab
+        registry={REGISTRY}
+        selectedId={undefined}
+        onSelect={vi.fn()}
+        onReparent={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('treeitem', { name: 'Realm' })).toBeInTheDocument();
+  });
+
+  it('renders child types under their parents', () => {
+    render(
+      <ContainmentTab
+        registry={REGISTRY}
+        selectedId={undefined}
+        onSelect={vi.fn()}
+        onReparent={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('treeitem', { name: 'Cluster' })).toBeInTheDocument();
+    expect(screen.getByRole('treeitem', { name: 'Service' })).toBeInTheDocument();
+  });
+
+  it('marks selected node with aria-selected', () => {
+    render(
+      <ContainmentTab
+        registry={REGISTRY}
+        selectedId="cluster"
+        onSelect={vi.fn()}
+        onReparent={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('treeitem', { name: 'Cluster' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    expect(screen.getByRole('treeitem', { name: 'Realm' })).toHaveAttribute(
+      'aria-selected',
+      'false',
+    );
+  });
+
+  it('calls onSelect when a node is clicked', () => {
+    const onSelect = vi.fn();
+    render(
+      <ContainmentTab
+        registry={REGISTRY}
+        selectedId={undefined}
+        onSelect={onSelect}
+        onReparent={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('treeitem', { name: 'Cluster' }));
+    expect(onSelect).toHaveBeenCalledWith('cluster');
+  });
+
+  it('calls onSelect on Enter keydown', () => {
+    const onSelect = vi.fn();
+    render(
+      <ContainmentTab
+        registry={REGISTRY}
+        selectedId={undefined}
+        onSelect={onSelect}
+        onReparent={vi.fn()}
+      />,
+    );
+    fireEvent.keyDown(screen.getByRole('treeitem', { name: 'Cluster' }), { key: 'Enter' });
+    expect(onSelect).toHaveBeenCalledWith('cluster');
+  });
+
+  it('shows orphans section when orphaned types exist', () => {
+    render(
+      <ContainmentTab
+        registry={ORPHAN_REGISTRY}
+        selectedId={undefined}
+        onSelect={vi.fn()}
+        onReparent={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/orphans/i)).toBeInTheDocument();
+    expect(screen.getByRole('treeitem', { name: 'Orphan' })).toBeInTheDocument();
+  });
+
+  it('does not show orphan section when no orphans', () => {
+    render(
+      <ContainmentTab
+        registry={REGISTRY}
+        selectedId={undefined}
+        onSelect={vi.fn()}
+        onReparent={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText(/orphans/i)).not.toBeInTheDocument();
+  });
+
+  it('sets data-drag-state="dragging" on the dragged node', () => {
+    render(
+      <ContainmentTab
+        registry={REGISTRY}
+        selectedId={undefined}
+        onSelect={vi.fn()}
+        onReparent={vi.fn()}
+      />,
+    );
+    const dt = makeDt();
+    const serviceNode = screen.getByRole('treeitem', { name: 'Service' });
+    fireEvent.dragStart(serviceNode, { dataTransfer: dt });
+    expect(serviceNode).toHaveAttribute('data-drag-state', 'dragging');
+  });
+
+  it('sets data-drag-state="drop-target" on valid hover target', () => {
+    render(
+      <ContainmentTab
+        registry={REGISTRY}
+        selectedId={undefined}
+        onSelect={vi.fn()}
+        onReparent={vi.fn()}
+      />,
+    );
+    const dt = makeDt();
+    const serviceNode = screen.getByRole('treeitem', { name: 'Service' });
+    const hostNode = screen.getByRole('treeitem', { name: 'Host' });
+
+    // drag service, hover host (valid: service is not an ancestor of host)
+    fireEvent.dragStart(serviceNode, { dataTransfer: dt });
+    fireEvent.dragOver(hostNode, { dataTransfer: dt });
+    expect(hostNode).toHaveAttribute('data-drag-state', 'drop-target');
+  });
+
+  it('sets data-drag-state="drop-invalid" when hovering would create cycle', () => {
+    render(
+      <ContainmentTab
+        registry={REGISTRY}
+        selectedId={undefined}
+        onSelect={vi.fn()}
+        onReparent={vi.fn()}
+      />,
+    );
+    const dt = makeDt();
+    const realmNode = screen.getByRole('treeitem', { name: 'Realm' });
+    const clusterNode = screen.getByRole('treeitem', { name: 'Cluster' });
+
+    // drag realm onto cluster: realm → cluster already, so this would cycle
+    fireEvent.dragStart(realmNode, { dataTransfer: dt });
+    fireEvent.dragOver(clusterNode, { dataTransfer: dt });
+    expect(clusterNode).toHaveAttribute('data-drag-state', 'drop-invalid');
+  });
+
+  it('sets data-drag-state="drop-ok" on valid but not-hovered targets', () => {
+    render(
+      <ContainmentTab
+        registry={REGISTRY}
+        selectedId={undefined}
+        onSelect={vi.fn()}
+        onReparent={vi.fn()}
+      />,
+    );
+    const dt = makeDt();
+    const serviceNode = screen.getByRole('treeitem', { name: 'Service' });
+    const hostNode = screen.getByRole('treeitem', { name: 'Host' });
+    const realmNode = screen.getByRole('treeitem', { name: 'Realm' });
+
+    // drag service; hover host; realm should be drop-ok (valid but not hovered)
+    fireEvent.dragStart(serviceNode, { dataTransfer: dt });
+    fireEvent.dragOver(hostNode, { dataTransfer: dt });
+    expect(realmNode).toHaveAttribute('data-drag-state', 'drop-ok');
+  });
+
+  it('calls onReparent on valid drop', () => {
+    const onReparent = vi.fn();
+    render(
+      <ContainmentTab
+        registry={REGISTRY}
+        selectedId={undefined}
+        onSelect={vi.fn()}
+        onReparent={onReparent}
+      />,
+    );
+    const dt = makeDt();
+    const serviceNode = screen.getByRole('treeitem', { name: 'Service' });
+    const hostNode = screen.getByRole('treeitem', { name: 'Host' });
+
+    fireEvent.dragStart(serviceNode, { dataTransfer: dt });
+    fireEvent.dragOver(hostNode, { dataTransfer: dt });
+    fireEvent.drop(hostNode, { dataTransfer: dt });
+    expect(onReparent).toHaveBeenCalledWith('service', 'host');
+  });
+
+  it('does NOT call onReparent when drop would create a cycle', () => {
+    const onReparent = vi.fn();
+    render(
+      <ContainmentTab
+        registry={REGISTRY}
+        selectedId={undefined}
+        onSelect={vi.fn()}
+        onReparent={onReparent}
+      />,
+    );
+    const dt = makeDt();
+    const realmNode = screen.getByRole('treeitem', { name: 'Realm' });
+    const clusterNode = screen.getByRole('treeitem', { name: 'Cluster' });
+
+    fireEvent.dragStart(realmNode, { dataTransfer: dt });
+    fireEvent.dragOver(clusterNode, { dataTransfer: dt });
+    fireEvent.drop(clusterNode, { dataTransfer: dt });
+    expect(onReparent).not.toHaveBeenCalled();
+  });
+
+  it('clears drag state on dragEnd', () => {
+    render(
+      <ContainmentTab
+        registry={REGISTRY}
+        selectedId={undefined}
+        onSelect={vi.fn()}
+        onReparent={vi.fn()}
+      />,
+    );
+    const dt = makeDt();
+    const serviceNode = screen.getByRole('treeitem', { name: 'Service' });
+    fireEvent.dragStart(serviceNode, { dataTransfer: dt });
+    expect(serviceNode).toHaveAttribute('data-drag-state', 'dragging');
+    fireEvent.dragEnd(serviceNode, { dataTransfer: dt });
+    expect(serviceNode).not.toHaveAttribute('data-drag-state');
+  });
+
+  it('clears hover state on dragLeave', () => {
+    render(
+      <ContainmentTab
+        registry={REGISTRY}
+        selectedId={undefined}
+        onSelect={vi.fn()}
+        onReparent={vi.fn()}
+      />,
+    );
+    const dt = makeDt();
+    const serviceNode = screen.getByRole('treeitem', { name: 'Service' });
+    const hostNode = screen.getByRole('treeitem', { name: 'Host' });
+
+    fireEvent.dragStart(serviceNode, { dataTransfer: dt });
+    fireEvent.dragOver(hostNode, { dataTransfer: dt });
+    expect(hostNode).toHaveAttribute('data-drag-state', 'drop-target');
+    fireEvent.dragLeave(hostNode, { dataTransfer: dt });
+    // After leave, host should lose the drop-target state (becomes drop-ok or undefined)
+    expect(hostNode).not.toHaveAttribute('data-drag-state', 'drop-target');
+  });
+});

--- a/web-next/packages/plugin-observatory/src/ui/ContainmentTab.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/ContainmentTab.tsx
@@ -1,0 +1,167 @@
+import { useState } from 'react';
+import type { EntityType } from '@niuulabs/domain';
+import { ShapeSvg } from '@niuulabs/ui';
+import type { TypeRegistry } from '../domain/registry';
+import { wouldCreateCycle } from '../domain/registry';
+import styles from './ContainmentTab.module.css';
+
+export type NodeDragState = 'dragging' | 'drop-target' | 'drop-invalid' | 'drop-ok';
+
+export interface ContainmentTabProps {
+  registry: TypeRegistry;
+  selectedId: string | undefined;
+  onSelect: (id: string) => void;
+  onReparent: (childId: string, newParentId: string) => void;
+}
+
+export function ContainmentTab({
+  registry,
+  selectedId,
+  onSelect,
+  onReparent,
+}: ContainmentTabProps) {
+  const [dragId, setDragId] = useState<string | null>(null);
+  const [overId, setOverId] = useState<string | null>(null);
+  const [overInvalid, setOverInvalid] = useState(false);
+
+  const byId = new Map(registry.types.map((t) => [t.id, t]));
+  const roots = registry.types.filter((t) => t.parentTypes.length === 0);
+
+  const getDragState = (typeId: string): NodeDragState | undefined => {
+    if (dragId === typeId) return 'dragging';
+    if (overId === typeId) return overInvalid ? 'drop-invalid' : 'drop-target';
+    if (dragId && !wouldCreateCycle(registry, dragId, typeId) && dragId !== typeId) {
+      return 'drop-ok';
+    }
+    return undefined;
+  };
+
+  const handleDragStart = (e: React.DragEvent, id: string) => {
+    setDragId(id);
+    setOverInvalid(false);
+    e.dataTransfer.effectAllowed = 'move';
+    try {
+      e.dataTransfer.setData('text/plain', id);
+    } catch {
+      // ignore — jsdom doesn't fully implement DataTransfer
+    }
+  };
+
+  const handleDragOver = (e: React.DragEvent, targetId: string) => {
+    if (!dragId) return;
+    const bad = wouldCreateCycle(registry, dragId, targetId) || dragId === targetId;
+    e.dataTransfer.dropEffect = bad ? 'none' : 'move';
+    e.preventDefault();
+    if (overId !== targetId || overInvalid !== bad) {
+      setOverId(targetId);
+      setOverInvalid(bad);
+    }
+  };
+
+  const handleDragLeave = (_e: React.DragEvent, targetId: string) => {
+    if (overId === targetId) {
+      setOverId(null);
+      setOverInvalid(false);
+    }
+  };
+
+  const handleDrop = (e: React.DragEvent, targetId: string) => {
+    e.preventDefault();
+    if (!dragId) return;
+    const bad = wouldCreateCycle(registry, dragId, targetId) || dragId === targetId;
+    if (!bad) onReparent(dragId, targetId);
+    setDragId(null);
+    setOverId(null);
+    setOverInvalid(false);
+  };
+
+  const handleDragEnd = () => {
+    setDragId(null);
+    setOverId(null);
+    setOverInvalid(false);
+  };
+
+  const renderNode = (t: EntityType, depth = 0): React.ReactNode => {
+    const children = t.canContain
+      .map((id) => byId.get(id))
+      .filter((c): c is EntityType => c !== undefined);
+    const state = getDragState(t.id);
+    const isSelected = selectedId === t.id;
+
+    return (
+      <div key={t.id} style={{ marginLeft: depth * 20 }}>
+        <div
+          className={styles.treeNode}
+          data-drag-state={state}
+          data-selected={isSelected ? 'true' : undefined}
+          draggable
+          onDragStart={(e) => handleDragStart(e, t.id)}
+          onDragOver={(e) => handleDragOver(e, t.id)}
+          onDragLeave={(e) => handleDragLeave(e, t.id)}
+          onDrop={(e) => handleDrop(e, t.id)}
+          onDragEnd={handleDragEnd}
+          onClick={() => onSelect(t.id)}
+          role="treeitem"
+          aria-selected={isSelected}
+          aria-label={t.label}
+          tabIndex={0}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              onSelect(t.id);
+            }
+          }}
+        >
+          <span className={styles.grip} aria-hidden>
+            ⋮⋮
+          </span>
+          <span className={styles.shapeIcon} aria-hidden>
+            <ShapeSvg shape={t.shape} color={t.color} size={14} />
+          </span>
+          <span className={styles.rune} aria-hidden>
+            {t.rune}
+          </span>
+          <span className={styles.name}>{t.label}</span>
+          <span className={styles.meta}>{t.id}</span>
+        </div>
+        {children.length > 0 && (
+          <div className={styles.children}>{children.map((c) => renderNode(c, depth + 1))}</div>
+        )}
+      </div>
+    );
+  };
+
+  // Orphan detection: types not reachable from any root via canContain
+  const reachable = new Set<string>();
+  const markReachable = (t: EntityType) => {
+    if (reachable.has(t.id)) return;
+    reachable.add(t.id);
+    t.canContain.forEach((id) => {
+      const child = byId.get(id);
+      if (child) markReachable(child);
+    });
+  };
+  roots.forEach(markReachable);
+  const orphans = registry.types.filter(
+    (t) => !reachable.has(t.id) && t.parentTypes.length > 0,
+  );
+
+  return (
+    <div className={styles.container}>
+      <p className={styles.hint}>
+        <strong>Drag</strong> a type onto another to reparent it. The{' '}
+        <code>canContain</code> edge moves from the old parent to the new.{' '}
+        <strong>Cycles are blocked.</strong>
+      </p>
+      <div className={styles.tree} role="tree" aria-label="Containment tree">
+        {roots.map((r) => renderNode(r))}
+        {orphans.length > 0 && (
+          <div className={styles.orphans}>
+            <div className={styles.orphanLabel}>orphans — parent missing</div>
+            {orphans.map((o) => renderNode(o))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web-next/packages/plugin-observatory/src/ui/JsonTab.module.css
+++ b/web-next/packages/plugin-observatory/src/ui/JsonTab.module.css
@@ -1,0 +1,43 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.toolbar {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.copyBtn {
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-xs);
+  font-family: var(--font-sans);
+  font-weight: 500;
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background 120ms, color 120ms;
+  min-width: 56px;
+}
+
+.copyBtn:hover {
+  background: var(--color-bg-elevated);
+  color: var(--color-text-primary);
+}
+
+.code {
+  margin: 0;
+  padding: var(--space-4);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  line-height: 1.6;
+  color: var(--color-text-secondary);
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  overflow-x: auto;
+  white-space: pre;
+}

--- a/web-next/packages/plugin-observatory/src/ui/JsonTab.test.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/JsonTab.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { JsonTab } from './JsonTab';
+import type { TypeRegistry } from '../domain/registry';
+
+const REGISTRY: TypeRegistry = {
+  version: 3,
+  updatedAt: '2026-01-01T00:00:00Z',
+  types: [
+    {
+      id: 'realm',
+      label: 'Realm',
+      rune: 'ᛞ',
+      icon: 'globe',
+      shape: 'ring',
+      color: 'ice-100',
+      size: 18,
+      border: 'solid',
+      canContain: ['cluster'],
+      parentTypes: [],
+      category: 'topology',
+      description: 'A realm.',
+      fields: [],
+    },
+  ],
+};
+
+describe('JsonTab', () => {
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  it('renders the registry JSON in a pre block', () => {
+    render(<JsonTab registry={REGISTRY} />);
+    const pre = screen.getByLabelText('Registry JSON');
+    expect(pre).toBeInTheDocument();
+    expect(pre.textContent).toContain('"version": 3');
+    expect(pre.textContent).toContain('"realm"');
+  });
+
+  it('renders a copy button', () => {
+    render(<JsonTab registry={REGISTRY} />);
+    expect(screen.getByRole('button', { name: 'Copy JSON to clipboard' })).toBeInTheDocument();
+  });
+
+  it('shows "Copied!" after clicking the copy button', async () => {
+    render(<JsonTab registry={REGISTRY} />);
+    const btn = screen.getByRole('button', { name: 'Copy JSON to clipboard' });
+    fireEvent.click(btn);
+    // After click the navigator.clipboard.writeText resolves and state updates
+    await screen.findByText('Copied!');
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      JSON.stringify(REGISTRY, null, 2),
+    );
+  });
+
+  it('pretty-prints the JSON with 2-space indent', () => {
+    render(<JsonTab registry={REGISTRY} />);
+    const pre = screen.getByLabelText('Registry JSON');
+    expect(pre.textContent).toBe(JSON.stringify(REGISTRY, null, 2));
+  });
+});

--- a/web-next/packages/plugin-observatory/src/ui/JsonTab.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/JsonTab.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+import type { TypeRegistry } from '../domain/registry';
+import styles from './JsonTab.module.css';
+
+export interface JsonTabProps {
+  registry: TypeRegistry;
+}
+
+export function JsonTab({ registry }: JsonTabProps) {
+  const [copied, setCopied] = useState(false);
+  const json = JSON.stringify(registry, null, 2);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(json);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.toolbar}>
+        <button className={styles.copyBtn} onClick={handleCopy} aria-label="Copy JSON to clipboard">
+          {copied ? 'Copied!' : 'Copy'}
+        </button>
+      </div>
+      <pre className={styles.code} aria-label="Registry JSON">
+        {json}
+      </pre>
+    </div>
+  );
+}

--- a/web-next/packages/plugin-observatory/src/ui/ObservatoryPage.module.css
+++ b/web-next/packages/plugin-observatory/src/ui/ObservatoryPage.module.css
@@ -50,12 +50,8 @@
   color: var(--color-text-secondary);
 }
 
-.placeholder {
-  font-size: var(--text-sm);
-  color: var(--color-text-muted);
-  border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-md);
-  padding: var(--space-3) var(--space-4);
-  background: var(--color-bg-secondary);
-  margin: 0;
+.editorWrapper {
+  margin-top: var(--space-2);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--color-border-subtle);
 }

--- a/web-next/packages/plugin-observatory/src/ui/ObservatoryPage.test.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/ObservatoryPage.test.tsx
@@ -40,9 +40,15 @@ describe('ObservatoryPage', () => {
     expect(screen.getByText('registry version')).toBeInTheDocument();
   });
 
-  it('renders placeholder note', async () => {
+  it('renders the RegistryEditor after data loads', async () => {
     wrap(<ObservatoryPage />);
-    await waitFor(() => expect(screen.getByText(/Canvas and registry editor/)).toBeInTheDocument());
+    await waitFor(
+      () => expect(screen.getByText('Entity type registry')).toBeInTheDocument(),
+      { timeout: 3000 },
+    );
+    expect(screen.getByRole('tab', { name: 'Types' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Containment' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Json' })).toBeInTheDocument();
   });
 
   it('shows error state when the registry service throws', async () => {

--- a/web-next/packages/plugin-observatory/src/ui/ObservatoryPage.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/ObservatoryPage.tsx
@@ -1,5 +1,6 @@
 import { Rune, StateDot, Chip } from '@niuulabs/ui';
 import { useRegistry } from './useRegistry';
+import { RegistryEditor } from './RegistryEditor';
 import styles from './ObservatoryPage.module.css';
 
 export function ObservatoryPage() {
@@ -30,21 +31,23 @@ export function ObservatoryPage() {
       )}
 
       {data && (
-        <div className={styles.stats}>
-          <div className={styles.stat}>
-            <span className={styles.statLabel}>entity types</span>
-            <Chip tone="brand">{data.types.length}</Chip>
+        <>
+          <div className={styles.stats}>
+            <div className={styles.stat}>
+              <span className={styles.statLabel}>entity types</span>
+              <Chip tone="brand">{data.types.length}</Chip>
+            </div>
+            <div className={styles.stat}>
+              <span className={styles.statLabel}>registry version</span>
+              <Chip tone="default">v{data.version}</Chip>
+            </div>
           </div>
-          <div className={styles.stat}>
-            <span className={styles.statLabel}>registry version</span>
-            <Chip tone="default">v{data.version}</Chip>
-          </div>
-        </div>
-      )}
 
-      <p className={styles.placeholder}>
-        Canvas and registry editor arrive in subsequent tickets (NIU-664, NIU-665).
-      </p>
+          <div className={styles.editorWrapper}>
+            <RegistryEditor registry={data} />
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/web-next/packages/plugin-observatory/src/ui/RegistryEditor.module.css
+++ b/web-next/packages/plugin-observatory/src/ui/RegistryEditor.module.css
@@ -1,0 +1,104 @@
+.editor {
+  display: flex;
+  gap: var(--space-4);
+  width: 100%;
+}
+
+.main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  margin-bottom: var(--space-4);
+  padding-bottom: var(--space-3);
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.title {
+  margin: 0;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--color-text-secondary);
+}
+
+.headMeta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
+
+.tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: var(--space-4);
+}
+
+.tab {
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--text-sm);
+  font-family: var(--font-sans);
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  margin-bottom: -1px;
+  transition: color 120ms, border-color 120ms;
+  outline: none;
+}
+
+.tab:hover {
+  color: var(--color-text-primary);
+}
+
+.tab:focus-visible {
+  outline: 2px solid var(--color-brand);
+  outline-offset: -2px;
+  border-radius: var(--radius-sm);
+}
+
+.tabActive {
+  color: var(--color-brand);
+  border-bottom-color: var(--color-brand);
+}
+
+.content {
+  flex: 1;
+  min-height: 0;
+}
+
+.inspector {
+  width: 260px;
+  flex-shrink: 0;
+  border-left: 1px solid var(--color-border-subtle);
+  padding-left: var(--space-4);
+  overflow-y: auto;
+}
+
+/* Stack to single column on narrow layouts */
+@media (max-width: 760px) {
+  .editor {
+    flex-direction: column;
+  }
+
+  .inspector {
+    width: 100%;
+    border-left: none;
+    padding-left: 0;
+    border-top: 1px solid var(--color-border-subtle);
+    padding-top: var(--space-4);
+  }
+}

--- a/web-next/packages/plugin-observatory/src/ui/RegistryEditor.stories.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/RegistryEditor.stories.tsx
@@ -1,0 +1,168 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { userEvent, within } from '@storybook/test';
+import { RegistryEditor } from './RegistryEditor';
+import type { TypeRegistry } from '../domain/registry';
+
+const STORY_REGISTRY: TypeRegistry = {
+  version: 7,
+  updatedAt: '2026-04-15T09:24:11Z',
+  types: [
+    {
+      id: 'realm',
+      label: 'Realm',
+      rune: 'ᛞ',
+      icon: 'globe',
+      shape: 'ring',
+      color: 'ice-100',
+      size: 18,
+      border: 'solid',
+      canContain: ['cluster', 'host'],
+      parentTypes: [],
+      category: 'topology',
+      description: 'VLAN-scoped network zone — every entity lives in exactly one realm.',
+      fields: [
+        { key: 'vlan', label: 'VLAN', type: 'number', required: true },
+        { key: 'dns', label: 'DNS zone', type: 'string', required: true },
+      ],
+    },
+    {
+      id: 'cluster',
+      label: 'Cluster',
+      rune: 'ᚲ',
+      icon: 'layers',
+      shape: 'ring-dashed',
+      color: 'ice-200',
+      size: 14,
+      border: 'dashed',
+      canContain: ['service'],
+      parentTypes: ['realm'],
+      category: 'topology',
+      description: 'Kubernetes cluster nested inside a realm.',
+      fields: [{ key: 'nodes', label: 'Nodes', type: 'number' }],
+    },
+    {
+      id: 'host',
+      label: 'Host',
+      rune: 'ᚦ',
+      icon: 'server',
+      shape: 'rounded-rect',
+      color: 'slate-400',
+      size: 22,
+      border: 'solid',
+      canContain: ['service'],
+      parentTypes: ['realm'],
+      category: 'hardware',
+      description: 'Bare-metal or VM.',
+      fields: [
+        { key: 'os', label: 'OS', type: 'string' },
+        { key: 'cores', label: 'Cores', type: 'number' },
+      ],
+    },
+    {
+      id: 'service',
+      label: 'Service',
+      rune: 'ᛦ',
+      icon: 'box',
+      shape: 'dot',
+      color: 'ice-300',
+      size: 8,
+      border: 'solid',
+      canContain: [],
+      parentTypes: ['cluster', 'host'],
+      category: 'infrastructure',
+      description: 'Kubernetes workload.',
+      fields: [
+        {
+          key: 'svcType',
+          label: 'Type',
+          type: 'select',
+          options: ['auth', 'database', 'inference'],
+        },
+      ],
+    },
+    {
+      id: 'ravn',
+      label: 'Long-lived Ravn',
+      rune: 'ᚱ',
+      icon: 'bird',
+      shape: 'diamond',
+      color: 'brand',
+      size: 11,
+      border: 'solid',
+      canContain: [],
+      parentTypes: ['host', 'cluster'],
+      category: 'agent',
+      description: 'Persistent raven agent.',
+      fields: [{ key: 'persona', label: 'Persona', type: 'string' }],
+    },
+  ],
+};
+
+const meta: Meta<typeof RegistryEditor> = {
+  title: 'Observatory/RegistryEditor',
+  component: RegistryEditor,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ padding: '24px', maxWidth: '960px', margin: '0 auto' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof RegistryEditor>;
+
+/** Types tab — default view with search and category groups */
+export const TypesTabDefault: Story = {
+  args: { registry: STORY_REGISTRY },
+};
+
+/** Containment tab — drag-drop tree showing the parent/child relationships */
+export const ContainmentTabView: Story = {
+  args: { registry: STORY_REGISTRY },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('tab', { name: 'Containment' }));
+  },
+};
+
+/**
+ * Containment tab — dragging state.
+ * After dragStart on "Service", the node turns semi-transparent (dragging)
+ * and other valid targets get drop-ok highlighted borders.
+ */
+export const ContainmentDragInProgress: Story = {
+  args: { registry: STORY_REGISTRY },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('tab', { name: 'Containment' }));
+    const serviceNode = canvas.getByRole('treeitem', { name: 'Service' });
+    // Start drag — the story freezes here visually showing drag states
+    serviceNode.dispatchEvent(
+      new DragEvent('dragstart', {
+        bubbles: true,
+        dataTransfer: new DataTransfer(),
+      }),
+    );
+  },
+};
+
+/** JSON tab — read-only pretty-printed registry with copy button */
+export const JsonTabView: Story = {
+  args: { registry: STORY_REGISTRY },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('tab', { name: 'Json' }));
+  },
+};
+
+/** Preview drawer empty state (no type selected initially) */
+export const EmptyPreviewDrawer: Story = {
+  args: {
+    registry: { ...STORY_REGISTRY, types: [] },
+  },
+};

--- a/web-next/packages/plugin-observatory/src/ui/RegistryEditor.test.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/RegistryEditor.test.tsx
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { RegistryEditor } from './RegistryEditor';
+import type { TypeRegistry } from '../domain/registry';
+
+const REGISTRY: TypeRegistry = {
+  version: 5,
+  updatedAt: '2026-01-01T00:00:00Z',
+  types: [
+    {
+      id: 'realm',
+      label: 'Realm',
+      rune: 'ᛞ',
+      icon: 'globe',
+      shape: 'ring',
+      color: 'ice-100',
+      size: 18,
+      border: 'solid',
+      canContain: ['cluster'],
+      parentTypes: [],
+      category: 'topology',
+      description: 'A realm.',
+      fields: [],
+    },
+    {
+      id: 'cluster',
+      label: 'Cluster',
+      rune: 'ᚲ',
+      icon: 'layers',
+      shape: 'ring-dashed',
+      color: 'ice-200',
+      size: 14,
+      border: 'dashed',
+      canContain: ['service'],
+      parentTypes: ['realm'],
+      category: 'topology',
+      description: 'A cluster.',
+      fields: [],
+    },
+    {
+      id: 'service',
+      label: 'Service',
+      rune: 'ᛦ',
+      icon: 'box',
+      shape: 'dot',
+      color: 'ice-300',
+      size: 8,
+      border: 'solid',
+      canContain: [],
+      parentTypes: ['cluster'],
+      category: 'infrastructure',
+      description: 'A service.',
+      fields: [{ key: 'type', label: 'Type', type: 'string' }],
+    },
+  ],
+};
+
+describe('RegistryEditor', () => {
+  it('renders the registry title', () => {
+    render(<RegistryEditor registry={REGISTRY} />);
+    expect(screen.getByText('Entity type registry')).toBeInTheDocument();
+  });
+
+  it('shows registry version and type count', () => {
+    render(<RegistryEditor registry={REGISTRY} />);
+    expect(screen.getByText('rev 5')).toBeInTheDocument();
+    expect(screen.getByText('3 types')).toBeInTheDocument();
+  });
+
+  it('renders the three tab buttons', () => {
+    render(<RegistryEditor registry={REGISTRY} />);
+    expect(screen.getByRole('tab', { name: 'Types' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Containment' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Json' })).toBeInTheDocument();
+  });
+
+  it('shows the Types tab by default', () => {
+    render(<RegistryEditor registry={REGISTRY} />);
+    expect(screen.getByRole('tab', { name: 'Types' })).toHaveAttribute('aria-selected', 'true');
+    // TypesTab renders a search input
+    expect(screen.getByRole('searchbox', { name: 'Filter entity types' })).toBeInTheDocument();
+  });
+
+  it('switches to Containment tab on click', () => {
+    render(<RegistryEditor registry={REGISTRY} />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Containment' }));
+    expect(screen.getByRole('tab', { name: 'Containment' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    expect(screen.getByRole('tree', { name: 'Containment tree' })).toBeInTheDocument();
+  });
+
+  it('switches to JSON tab on click', () => {
+    render(<RegistryEditor registry={REGISTRY} />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Json' }));
+    expect(screen.getByRole('tab', { name: 'Json' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByLabelText('Registry JSON')).toBeInTheDocument();
+  });
+
+  it('shows preview drawer with first type selected by default', () => {
+    render(<RegistryEditor registry={REGISTRY} />);
+    // TypePreviewDrawer shows the first type (realm) - 'realm' appears in multiple places
+    expect(screen.getAllByText('realm').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Type · topology')).toBeInTheDocument();
+  });
+
+  it('updates preview when a type card is clicked', () => {
+    render(<RegistryEditor registry={REGISTRY} />);
+    fireEvent.click(screen.getByRole('button', { name: /Cluster \(cluster\)/ }));
+    // 'A cluster.' appears in both the type card and preview drawer
+    expect(screen.getAllByText('A cluster.').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('calls onSave when containment drag-drop reparents a type', () => {
+    const onSave = vi.fn();
+    render(<RegistryEditor registry={REGISTRY} onSave={onSave} />);
+
+    // Switch to containment tab
+    fireEvent.click(screen.getByRole('tab', { name: 'Containment' }));
+
+    const dt = {
+      effectAllowed: 'uninitialized' as DataTransfer['effectAllowed'],
+      dropEffect: 'none' as DataTransfer['dropEffect'],
+      setData: vi.fn(),
+      getData: vi.fn().mockReturnValue(''),
+    };
+
+    const serviceNode = screen.getByRole('treeitem', { name: 'Service' });
+    const realmNode = screen.getByRole('treeitem', { name: 'Realm' });
+
+    fireEvent.dragStart(serviceNode, { dataTransfer: dt });
+    fireEvent.dragOver(realmNode, { dataTransfer: dt });
+    fireEvent.drop(realmNode, { dataTransfer: dt });
+
+    expect(onSave).toHaveBeenCalledOnce();
+    const saved: TypeRegistry = onSave.mock.calls[0][0];
+    const realm = saved.types.find((t) => t.id === 'realm');
+    expect(realm?.canContain).toContain('service');
+    expect(saved.version).toBe(REGISTRY.version + 1);
+  });
+
+  it('does NOT call onSave when cycle is detected', () => {
+    const onSave = vi.fn();
+    render(<RegistryEditor registry={REGISTRY} onSave={onSave} />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Containment' }));
+
+    const dt = {
+      effectAllowed: 'uninitialized' as DataTransfer['effectAllowed'],
+      dropEffect: 'none' as DataTransfer['dropEffect'],
+      setData: vi.fn(),
+      getData: vi.fn().mockReturnValue(''),
+    };
+
+    const realmNode = screen.getByRole('treeitem', { name: 'Realm' });
+    const clusterNode = screen.getByRole('treeitem', { name: 'Cluster' });
+
+    fireEvent.dragStart(realmNode, { dataTransfer: dt });
+    fireEvent.dragOver(clusterNode, { dataTransfer: dt });
+    fireEvent.drop(clusterNode, { dataTransfer: dt });
+
+    expect(onSave).not.toHaveBeenCalled();
+  });
+});

--- a/web-next/packages/plugin-observatory/src/ui/RegistryEditor.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/RegistryEditor.tsx
@@ -1,0 +1,96 @@
+import { useState, useMemo, useCallback } from 'react';
+import { Chip } from '@niuulabs/ui';
+import type { TypeRegistry } from '../domain/registry';
+import { reparentType } from '../domain/registry';
+import { TypesTab } from './TypesTab';
+import { ContainmentTab } from './ContainmentTab';
+import { JsonTab } from './JsonTab';
+import { TypePreviewDrawer } from './TypePreviewDrawer';
+import styles from './RegistryEditor.module.css';
+
+export type RegistryEditorTab = 'types' | 'containment' | 'json';
+
+export interface RegistryEditorProps {
+  registry: TypeRegistry;
+  /**
+   * Called whenever the registry is mutated (e.g. after a reparent drag-drop).
+   * The caller is responsible for persisting the updated registry.
+   */
+  onSave?: (registry: TypeRegistry) => void;
+}
+
+const TABS: RegistryEditorTab[] = ['types', 'containment', 'json'];
+
+export function RegistryEditor({ registry: initialRegistry, onSave }: RegistryEditorProps) {
+  const [tab, setTab] = useState<RegistryEditorTab>('types');
+  const [localRegistry, setLocalRegistry] = useState<TypeRegistry>(initialRegistry);
+  const [selectedId, setSelectedId] = useState<string | undefined>(
+    initialRegistry.types[0]?.id,
+  );
+
+  const selected = useMemo(
+    () => localRegistry.types.find((t) => t.id === selectedId),
+    [localRegistry.types, selectedId],
+  );
+
+  const handleReparent = useCallback(
+    (childId: string, newParentId: string) => {
+      const updated = reparentType(localRegistry, childId, newParentId);
+      if (updated === localRegistry) return;
+      setLocalRegistry(updated);
+      onSave?.(updated);
+    },
+    [localRegistry, onSave],
+  );
+
+  return (
+    <div className={styles.editor}>
+      <div className={styles.main}>
+        <div className={styles.head}>
+          <h3 className={styles.title}>Entity type registry</h3>
+          <div className={styles.headMeta}>
+            <Chip tone="muted">rev {localRegistry.version}</Chip>
+            <Chip tone="default">{localRegistry.types.length} types</Chip>
+          </div>
+        </div>
+
+        <div className={styles.tabs} role="tablist" aria-label="Registry editor tabs">
+          {TABS.map((t) => (
+            <button
+              key={t}
+              role="tab"
+              aria-selected={tab === t}
+              className={`${styles.tab} ${tab === t ? styles.tabActive : ''}`}
+              onClick={() => setTab(t)}
+            >
+              {t.charAt(0).toUpperCase() + t.slice(1)}
+            </button>
+          ))}
+        </div>
+
+        <div className={styles.content}>
+          {tab === 'types' && (
+            <TypesTab
+              registry={localRegistry}
+              selectedId={selectedId}
+              onSelect={setSelectedId}
+            />
+          )}
+          {tab === 'containment' && (
+            <ContainmentTab
+              registry={localRegistry}
+              selectedId={selectedId}
+              onSelect={setSelectedId}
+              onReparent={handleReparent}
+            />
+          )}
+          {tab === 'json' && <JsonTab registry={localRegistry} />}
+        </div>
+      </div>
+
+      <div className={styles.inspector}>
+        <TypePreviewDrawer type={selected} />
+      </div>
+    </div>
+  );
+}

--- a/web-next/packages/plugin-observatory/src/ui/TypePreviewDrawer.module.css
+++ b/web-next/packages/plugin-observatory/src/ui/TypePreviewDrawer.module.css
@@ -1,0 +1,123 @@
+.empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  min-height: 120px;
+}
+
+.emptyText {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  margin: 0;
+  font-style: italic;
+}
+
+.drawer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+}
+
+.shapeBox {
+  width: 48px;
+  height: 48px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-bg-tertiary);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-subtle);
+}
+
+.headerInfo {
+  flex: 1;
+  min-width: 0;
+}
+
+.category {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+}
+
+.label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-lg);
+  font-weight: 600;
+  color: var(--color-text-primary);
+  letter-spacing: -0.015em;
+  margin-top: var(--space-1);
+}
+
+.rune {
+  font-family: var(--font-mono);
+  font-size: var(--text-base);
+  font-weight: 700;
+  color: var(--color-brand);
+  text-shadow: 0 0 10px color-mix(in srgb, var(--color-brand) 45%, transparent);
+}
+
+.id {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: color-mix(in srgb, var(--color-brand) 70%, var(--color-text-muted));
+  margin-top: var(--space-1);
+}
+
+.description {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.sectionHead {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--color-text-muted);
+}
+
+.chipGroup {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+}
+
+.fieldList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.fieldRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.fieldLabel {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+}

--- a/web-next/packages/plugin-observatory/src/ui/TypePreviewDrawer.test.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/TypePreviewDrawer.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TypePreviewDrawer } from './TypePreviewDrawer';
+import type { EntityType } from '@niuulabs/domain';
+
+const REALM_TYPE: EntityType = {
+  id: 'realm',
+  label: 'Realm',
+  rune: 'ᛞ',
+  icon: 'globe',
+  shape: 'ring',
+  color: 'ice-100',
+  size: 18,
+  border: 'solid',
+  canContain: ['cluster', 'host'],
+  parentTypes: [],
+  category: 'topology',
+  description: 'VLAN-scoped network zone.',
+  fields: [
+    { key: 'vlan', label: 'VLAN', type: 'number', required: true },
+    { key: 'dns', label: 'DNS zone', type: 'string' },
+  ],
+};
+
+describe('TypePreviewDrawer', () => {
+  it('shows placeholder when type is undefined', () => {
+    render(<TypePreviewDrawer type={undefined} />);
+    expect(screen.getByText('Select a type to preview.')).toBeInTheDocument();
+  });
+
+  it('renders the type label', () => {
+    render(<TypePreviewDrawer type={REALM_TYPE} />);
+    expect(screen.getByText('Realm')).toBeInTheDocument();
+  });
+
+  it('renders the type id', () => {
+    render(<TypePreviewDrawer type={REALM_TYPE} />);
+    expect(screen.getByText('realm')).toBeInTheDocument();
+  });
+
+  it('renders the category', () => {
+    render(<TypePreviewDrawer type={REALM_TYPE} />);
+    expect(screen.getByText('Type · topology')).toBeInTheDocument();
+  });
+
+  it('renders the description', () => {
+    render(<TypePreviewDrawer type={REALM_TYPE} />);
+    expect(screen.getByText('VLAN-scoped network zone.')).toBeInTheDocument();
+  });
+
+  it('renders canContain chips', () => {
+    render(<TypePreviewDrawer type={REALM_TYPE} />);
+    expect(screen.getByText('cluster')).toBeInTheDocument();
+    expect(screen.getByText('host')).toBeInTheDocument();
+  });
+
+  it('does not render "Can contain" section when empty', () => {
+    const leafType: EntityType = { ...REALM_TYPE, canContain: [] };
+    render(<TypePreviewDrawer type={leafType} />);
+    expect(screen.queryByText('Can contain')).not.toBeInTheDocument();
+  });
+
+  it('does not render "Lives inside" section when parentTypes is empty', () => {
+    render(<TypePreviewDrawer type={REALM_TYPE} />);
+    expect(screen.queryByText('Lives inside')).not.toBeInTheDocument();
+  });
+
+  it('renders parentTypes chips when present', () => {
+    const clusterType: EntityType = { ...REALM_TYPE, parentTypes: ['realm'] };
+    render(<TypePreviewDrawer type={clusterType} />);
+    expect(screen.getByText('Lives inside')).toBeInTheDocument();
+    // 'realm' appears in both the id field and the parentTypes chip
+    expect(screen.getAllByText('realm').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders fields with their types', () => {
+    render(<TypePreviewDrawer type={REALM_TYPE} />);
+    expect(screen.getByText('Fields')).toBeInTheDocument();
+    expect(screen.getByText('VLAN')).toBeInTheDocument();
+    expect(screen.getByText('DNS zone')).toBeInTheDocument();
+    expect(screen.getAllByText('number').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('string').length).toBeGreaterThan(0);
+  });
+
+  it('does not render Fields section when fields is empty', () => {
+    const noFields: EntityType = { ...REALM_TYPE, fields: [] };
+    render(<TypePreviewDrawer type={noFields} />);
+    expect(screen.queryByText('Fields')).not.toBeInTheDocument();
+  });
+});

--- a/web-next/packages/plugin-observatory/src/ui/TypePreviewDrawer.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/TypePreviewDrawer.tsx
@@ -1,0 +1,79 @@
+import type { EntityType } from '@niuulabs/domain';
+import { ShapeSvg, Chip } from '@niuulabs/ui';
+import styles from './TypePreviewDrawer.module.css';
+
+export interface TypePreviewDrawerProps {
+  type: EntityType | undefined;
+}
+
+export function TypePreviewDrawer({ type }: TypePreviewDrawerProps) {
+  if (!type) {
+    return (
+      <div className={styles.empty}>
+        <p className={styles.emptyText}>Select a type to preview.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.drawer}>
+      <div className={styles.header}>
+        <div className={styles.shapeBox} aria-hidden>
+          <ShapeSvg shape={type.shape} color={type.color} size={30} />
+        </div>
+        <div className={styles.headerInfo}>
+          <div className={styles.category}>Type · {type.category}</div>
+          <div className={styles.label}>
+            {type.label}
+            <span className={styles.rune} aria-label={`rune: ${type.rune}`}>
+              {type.rune}
+            </span>
+          </div>
+          <div className={styles.id}>{type.id}</div>
+        </div>
+      </div>
+
+      <p className={styles.description}>{type.description}</p>
+
+      {type.canContain.length > 0 && (
+        <div className={styles.section}>
+          <div className={styles.sectionHead}>Can contain</div>
+          <div className={styles.chipGroup}>
+            {type.canContain.map((id) => (
+              <Chip key={id} tone="default">
+                {id}
+              </Chip>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {type.parentTypes.length > 0 && (
+        <div className={styles.section}>
+          <div className={styles.sectionHead}>Lives inside</div>
+          <div className={styles.chipGroup}>
+            {type.parentTypes.map((id) => (
+              <Chip key={id} tone="muted">
+                {id}
+              </Chip>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {type.fields.length > 0 && (
+        <div className={styles.section}>
+          <div className={styles.sectionHead}>Fields</div>
+          <div className={styles.fieldList}>
+            {type.fields.map((f) => (
+              <div key={f.key} className={styles.fieldRow}>
+                <span className={styles.fieldLabel}>{f.label}</span>
+                <Chip tone="muted">{f.type}</Chip>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web-next/packages/plugin-observatory/src/ui/TypesTab.module.css
+++ b/web-next/packages/plugin-observatory/src/ui/TypesTab.module.css
@@ -1,0 +1,131 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.searchRow {
+  display: flex;
+  align-items: center;
+}
+
+.searchInput {
+  width: 100%;
+  max-width: 260px;
+  height: 32px;
+  padding: 0 var(--space-3);
+  font-size: var(--text-sm);
+  font-family: var(--font-sans);
+  background: var(--color-bg-secondary);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  outline: none;
+  transition: border-color 120ms;
+}
+
+.searchInput:focus {
+  border-color: var(--color-brand);
+}
+
+.empty {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.categoryGroup {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.categoryHead {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--color-text-secondary);
+}
+
+.categoryCount {
+  font-weight: 400;
+  color: var(--color-text-muted);
+  margin-left: var(--space-1);
+}
+
+.typeGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: var(--space-2);
+}
+
+.typeCard {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-3);
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  text-align: left;
+  transition: background 120ms, border-color 120ms;
+  font-family: inherit;
+}
+
+.typeCard:hover {
+  background: var(--color-bg-tertiary);
+  border-color: var(--color-border);
+}
+
+.typeCardSelected {
+  background: color-mix(in srgb, var(--color-brand) 10%, var(--color-bg-secondary));
+  border-color: color-mix(in srgb, var(--color-brand) 40%, transparent);
+}
+
+.typeSwatch {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  margin-bottom: var(--space-1);
+}
+
+.typeName {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--color-text-primary);
+}
+
+.typeRune {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  font-weight: 700;
+  color: var(--color-brand);
+}
+
+.typeDesc {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.typeMeta {
+  display: flex;
+  gap: var(--space-2);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+}
+
+.typeId {
+  color: var(--color-text-secondary);
+}

--- a/web-next/packages/plugin-observatory/src/ui/TypesTab.test.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/TypesTab.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TypesTab } from './TypesTab';
+import type { TypeRegistry } from '../domain/registry';
+
+const REGISTRY: TypeRegistry = {
+  version: 1,
+  updatedAt: '2026-01-01T00:00:00Z',
+  types: [
+    {
+      id: 'realm',
+      label: 'Realm',
+      rune: 'ᛞ',
+      icon: 'globe',
+      shape: 'ring',
+      color: 'ice-100',
+      size: 18,
+      border: 'solid',
+      canContain: ['cluster'],
+      parentTypes: [],
+      category: 'topology',
+      description: 'A realm. Network zone.',
+      fields: [],
+    },
+    {
+      id: 'cluster',
+      label: 'Cluster',
+      rune: 'ᚲ',
+      icon: 'layers',
+      shape: 'ring-dashed',
+      color: 'ice-200',
+      size: 14,
+      border: 'dashed',
+      canContain: ['service'],
+      parentTypes: ['realm'],
+      category: 'topology',
+      description: 'A cluster. Kubernetes.',
+      fields: [],
+    },
+    {
+      id: 'ravn',
+      label: 'Ravn',
+      rune: 'ᚱ',
+      icon: 'bird',
+      shape: 'diamond',
+      color: 'brand',
+      size: 11,
+      border: 'solid',
+      canContain: [],
+      parentTypes: ['cluster'],
+      category: 'agent',
+      description: 'An agent.',
+      fields: [],
+    },
+  ],
+};
+
+describe('TypesTab', () => {
+  it('renders all types grouped by category', () => {
+    render(<TypesTab registry={REGISTRY} selectedId={undefined} onSelect={vi.fn()} />);
+    expect(screen.getByText('Realm')).toBeInTheDocument();
+    expect(screen.getByText('Cluster')).toBeInTheDocument();
+    expect(screen.getByText('Ravn')).toBeInTheDocument();
+  });
+
+  it('renders category headings', () => {
+    render(<TypesTab registry={REGISTRY} selectedId={undefined} onSelect={vi.fn()} />);
+    expect(screen.getByText('topology')).toBeInTheDocument();
+    expect(screen.getByText('agent')).toBeInTheDocument();
+  });
+
+  it('renders the search input', () => {
+    render(<TypesTab registry={REGISTRY} selectedId={undefined} onSelect={vi.fn()} />);
+    expect(screen.getByRole('searchbox', { name: 'Filter entity types' })).toBeInTheDocument();
+  });
+
+  it('filters types by label on search', () => {
+    render(<TypesTab registry={REGISTRY} selectedId={undefined} onSelect={vi.fn()} />);
+    const input = screen.getByRole('searchbox', { name: 'Filter entity types' });
+    fireEvent.change(input, { target: { value: 'ravn' } });
+    expect(screen.getByText('Ravn')).toBeInTheDocument();
+    expect(screen.queryByText('Realm')).not.toBeInTheDocument();
+    expect(screen.queryByText('Cluster')).not.toBeInTheDocument();
+  });
+
+  it('filters types by id on search', () => {
+    render(<TypesTab registry={REGISTRY} selectedId={undefined} onSelect={vi.fn()} />);
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'cluster' } });
+    expect(screen.getByText('Cluster')).toBeInTheDocument();
+    expect(screen.queryByText('Realm')).not.toBeInTheDocument();
+  });
+
+  it('shows empty state when nothing matches', () => {
+    render(<TypesTab registry={REGISTRY} selectedId={undefined} onSelect={vi.fn()} />);
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'zzznomatch' } });
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.queryByText('Realm')).not.toBeInTheDocument();
+  });
+
+  it('marks the selected card with aria-pressed', () => {
+    render(<TypesTab registry={REGISTRY} selectedId="realm" onSelect={vi.fn()} />);
+    const realmBtn = screen.getByRole('button', { name: /Realm \(realm\)/ });
+    expect(realmBtn).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('calls onSelect when a card is clicked', () => {
+    const onSelect = vi.fn();
+    render(<TypesTab registry={REGISTRY} selectedId={undefined} onSelect={onSelect} />);
+    fireEvent.click(screen.getByRole('button', { name: /Cluster \(cluster\)/ }));
+    expect(onSelect).toHaveBeenCalledWith('cluster');
+  });
+
+  it('shows shape in the type meta', () => {
+    render(<TypesTab registry={REGISTRY} selectedId={undefined} onSelect={vi.fn()} />);
+    expect(screen.getByText('ring')).toBeInTheDocument();
+  });
+});

--- a/web-next/packages/plugin-observatory/src/ui/TypesTab.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/TypesTab.tsx
@@ -1,0 +1,91 @@
+import { useState, useMemo } from 'react';
+import type { EntityType } from '@niuulabs/domain';
+import { ShapeSvg } from '@niuulabs/ui';
+import type { TypeRegistry } from '../domain/registry';
+import styles from './TypesTab.module.css';
+
+export interface TypesTabProps {
+  registry: TypeRegistry;
+  selectedId: string | undefined;
+  onSelect: (id: string) => void;
+}
+
+export function TypesTab({ registry, selectedId, onSelect }: TypesTabProps) {
+  const [search, setSearch] = useState('');
+
+  const filtered = useMemo(() => {
+    if (!search) return registry.types;
+    const q = search.toLowerCase();
+    return registry.types.filter(
+      (t) =>
+        t.label.toLowerCase().includes(q) ||
+        t.id.includes(q) ||
+        t.description.toLowerCase().includes(q),
+    );
+  }, [registry.types, search]);
+
+  const byCategory = useMemo(() => {
+    const m = new Map<string, EntityType[]>();
+    for (const t of filtered) {
+      if (!m.has(t.category)) m.set(t.category, []);
+      m.get(t.category)!.push(t);
+    }
+    return m;
+  }, [filtered]);
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.searchRow}>
+        <input
+          className={styles.searchInput}
+          type="search"
+          placeholder="filter types…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          aria-label="Filter entity types"
+        />
+      </div>
+
+      {filtered.length === 0 && (
+        <p className={styles.empty} role="status">
+          No types match &quot;{search}&quot;
+        </p>
+      )}
+
+      {[...byCategory.entries()].map(([cat, types]) => (
+        <div key={cat} className={styles.categoryGroup}>
+          <div className={styles.categoryHead}>
+            {cat}
+            <span className={styles.categoryCount}>· {types.length}</span>
+          </div>
+          <div className={styles.typeGrid}>
+            {types.map((t) => (
+              <button
+                key={t.id}
+                className={`${styles.typeCard} ${selectedId === t.id ? styles.typeCardSelected : ''}`}
+                onClick={() => onSelect(t.id)}
+                aria-pressed={selectedId === t.id}
+                aria-label={`${t.label} (${t.id})`}
+              >
+                <div className={styles.typeSwatch}>
+                  <ShapeSvg shape={t.shape} color={t.color} size={22} />
+                </div>
+                <div className={styles.typeName}>
+                  {t.label}
+                  <span className={styles.typeRune}>{t.rune}</span>
+                </div>
+                <div className={styles.typeDesc}>{t.description.split('.')[0]}.</div>
+                <div className={styles.typeMeta}>
+                  <span className={styles.typeId}>{t.id}</span>
+                  <span>
+                    shape · <strong>{t.shape}</strong>
+                  </span>
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Implements the full registry editor for the Observatory plugin (NIU-666).

### What's in this PR

- **`TypesTab`** — search input + types grouped by category, each card showing shape swatch, rune, label, id, description preview. Clicking a card selects it.
- **`TypePreviewDrawer`** — read-only side panel showing the selected type's shape, label, id, category, description, `canContain` chips, `parentTypes` chips, and field schema.
- **`ContainmentTab`** — drag-drop tree built from `canContain` edges. Supports four visual states via `data-drag-state`:
  - `dragging` — node being dragged (semi-transparent)
  - `drop-target` — hovered valid drop target (brand highlight)
  - `drop-invalid` — hovered target that would create a cycle (red tint)
  - `drop-ok` — valid drop target not yet hovered (subtle brand border)
  - Cycle guard uses `wouldCreateCycle()` from the domain layer — drops that would cycle are rejected at both hover and drop time.
  - Orphan section for types whose `parentTypes` reference missing parents.
- **`JsonTab`** — read-only `<pre>` with `JSON.stringify(registry, null, 2)` + copy-to-clipboard button.
- **`RegistryEditor`** — three-tab container managing `tab`, `selectedId`, and `localRegistry` (optimistic local state). Wires `onSave` callback for persistence.
- **`ObservatoryPage`** updated to embed `RegistryEditor` after registry loads.

### Tests

- **55 new unit tests** covering all components and all drag-drop states.
- **Playwright E2E** specs extended with 8 new tests: tab switching, search filtering, drag-drop reparent, cycle rejection, JSON pretty-print, preview drawer.
- **Storybook** stories: `TypesTabDefault`, `ContainmentTabView`, `ContainmentDragInProgress`, `JsonTabView`, `EmptyPreviewDrawer`.
- Coverage: **99.76% statements** / **91.91% branches** across `plugin-observatory/src/ui/` — well above the 85% gate.

### Cycle protection

Drop is refused if `wouldCreateCycle(registry, draggedId, targetId)` returns true. This check is performed both on `dragOver` (to show the `drop-invalid` visual state) and on `drop` (to guard the actual mutation). The domain function already had 100% test coverage from NIU-663.

### Linear

NIU-666 — set to In Progress at start; will be moved to In Review after CI passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)