### PR TITLE
feat(domain): add @niuulabs/domain — cross-plugin TypeScript types + Zod schemas

### DIFF
--- a/web-next/packages/domain/package.json
+++ b/web-next/packages/domain/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@niuulabs/domain",
+  "version": "0.0.1",
+  "description": "Framework-free TypeScript types and Zod schemas for cross-plugin domain entities",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "dev": "tsup --watch"
+  },
+  "dependencies": {
+    "zod": "^3.24.1"
+  },
+  "devDependencies": {
+    "tsup": "^8.3.5",
+    "typescript": "^5.7.3"
+  }
+}

--- a/web-next/packages/domain/src/budget.test.ts
+++ b/web-next/packages/domain/src/budget.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { budgetStateSchema } from './budget';
+
+describe('budgetStateSchema', () => {
+  it('round-trips a typical budget state', () => {
+    const input = { spentUsd: 1.25, capUsd: 5.0, warnAt: 0.8 };
+    expect(budgetStateSchema.parse(input)).toEqual(input);
+  });
+
+  it('accepts zero spent', () => {
+    expect(budgetStateSchema.parse({ spentUsd: 0, capUsd: 5, warnAt: 0.5 }).spentUsd).toBe(0);
+  });
+
+  it('accepts zero capUsd (unlimited)', () => {
+    expect(budgetStateSchema.parse({ spentUsd: 0, capUsd: 0, warnAt: 0.8 }).capUsd).toBe(0);
+  });
+
+  it('accepts warnAt = 0', () => {
+    expect(budgetStateSchema.parse({ spentUsd: 0, capUsd: 10, warnAt: 0 }).warnAt).toBe(0);
+  });
+
+  it('accepts warnAt = 1', () => {
+    expect(budgetStateSchema.parse({ spentUsd: 0, capUsd: 10, warnAt: 1 }).warnAt).toBe(1);
+  });
+
+  it('rejects negative spentUsd', () => {
+    expect(() => budgetStateSchema.parse({ spentUsd: -0.01, capUsd: 5, warnAt: 0.8 })).toThrow();
+  });
+
+  it('rejects negative capUsd', () => {
+    expect(() => budgetStateSchema.parse({ spentUsd: 0, capUsd: -1, warnAt: 0.8 })).toThrow();
+  });
+
+  it('rejects warnAt > 1', () => {
+    expect(() => budgetStateSchema.parse({ spentUsd: 0, capUsd: 5, warnAt: 1.1 })).toThrow();
+  });
+
+  it('rejects warnAt < 0', () => {
+    expect(() => budgetStateSchema.parse({ spentUsd: 0, capUsd: 5, warnAt: -0.1 })).toThrow();
+  });
+
+  it('rejects missing fields', () => {
+    expect(() => budgetStateSchema.parse({ spentUsd: 1 })).toThrow();
+  });
+});

--- a/web-next/packages/domain/src/budget.ts
+++ b/web-next/packages/domain/src/budget.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+/**
+ * Daily USD budget state for a single raven.
+ *
+ * **Canonical owner:** `plugin-ravn` (BudgetBar, BudgetRunwayBar, and the
+ * Budget view all live in Ravn and read from `BudgetStream`).
+ *
+ * **Consumed by:**
+ * - `plugin-tyr` — dispatch feasibility check refuses to dispatch when
+ *   `spentUsd >= capUsd`.
+ * - `plugin-observatory` — topology canvas shows a budget health dot on
+ *   raven nodes that exceed `warnAt`.
+ */
+export const budgetStateSchema = z.object({
+  /** USD spent today (resets at midnight UTC). */
+  spentUsd: z.number().min(0),
+  /** Daily hard cap in USD. 0 means unlimited. */
+  capUsd: z.number().min(0),
+  /**
+   * Fraction of `capUsd` at which the BudgetBar turns amber (0–1).
+   * E.g. 0.8 means warn at 80 % usage.
+   */
+  warnAt: z.number().min(0).max(1),
+});
+
+export type BudgetState = z.infer<typeof budgetStateSchema>;

--- a/web-next/packages/domain/src/entity-type.test.ts
+++ b/web-next/packages/domain/src/entity-type.test.ts
@@ -111,6 +111,10 @@ describe('entityTypeSchema', () => {
     expect(() => entityTypeSchema.parse({ ...ravenEntityType, rune: '' })).toThrow();
   });
 
+  it('rejects a multi-character rune', () => {
+    expect(() => entityTypeSchema.parse({ ...ravenEntityType, rune: 'AB' })).toThrow();
+  });
+
   it('rejects invalid shape', () => {
     expect(() => entityTypeSchema.parse({ ...ravenEntityType, shape: 'blob' })).toThrow();
   });

--- a/web-next/packages/domain/src/entity-type.test.ts
+++ b/web-next/packages/domain/src/entity-type.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from 'vitest';
+import {
+  entityShapeSchema,
+  entityCategorySchema,
+  entityTypeSchema,
+  typeRegistrySchema,
+} from './entity-type';
+
+// ---------------------------------------------------------------------------
+// entityShapeSchema
+// ---------------------------------------------------------------------------
+
+const validShapes = [
+  'ring',
+  'ring-dashed',
+  'rounded-rect',
+  'diamond',
+  'triangle',
+  'hex',
+  'chevron',
+  'square',
+  'square-sm',
+  'pentagon',
+  'halo',
+  'mimir',
+  'mimir-small',
+  'dot',
+] as const;
+
+describe('entityShapeSchema', () => {
+  it.each(validShapes)('accepts shape "%s"', (shape) => {
+    expect(entityShapeSchema.parse(shape)).toBe(shape);
+  });
+
+  it('rejects an unknown shape', () => {
+    expect(() => entityShapeSchema.parse('blob')).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// entityCategorySchema
+// ---------------------------------------------------------------------------
+
+const validCategories = [
+  'topology',
+  'hardware',
+  'agent',
+  'coordinator',
+  'knowledge',
+  'infrastructure',
+  'device',
+  'composite',
+] as const;
+
+describe('entityCategorySchema', () => {
+  it.each(validCategories)('accepts category "%s"', (cat) => {
+    expect(entityCategorySchema.parse(cat)).toBe(cat);
+  });
+
+  it('rejects an unknown category', () => {
+    expect(() => entityCategorySchema.parse('mystical')).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// entityTypeSchema
+// ---------------------------------------------------------------------------
+
+const ravenEntityType = {
+  id: 'raven',
+  label: 'Raven',
+  category: 'agent',
+  rune: 'ᚱ',
+  shape: 'ring',
+  color: '--brand-400',
+  description: 'An autonomous agent dispatched to complete a raid.',
+  parentTypes: ['cluster'],
+  canContain: [],
+} as const;
+
+describe('entityTypeSchema', () => {
+  it('round-trips a full entity type', () => {
+    expect(entityTypeSchema.parse(ravenEntityType)).toEqual(ravenEntityType);
+  });
+
+  it('accepts empty parentTypes and canContain', () => {
+    const result = entityTypeSchema.parse({ ...ravenEntityType, parentTypes: [], canContain: [] });
+    expect(result.parentTypes).toEqual([]);
+    expect(result.canContain).toEqual([]);
+  });
+
+  it('accepts multiple parentTypes and canContain entries', () => {
+    const result = entityTypeSchema.parse({
+      ...ravenEntityType,
+      parentTypes: ['cluster', 'realm'],
+      canContain: ['session', 'tool'],
+    });
+    expect(result.parentTypes).toHaveLength(2);
+    expect(result.canContain).toHaveLength(2);
+  });
+
+  it('rejects empty id', () => {
+    expect(() => entityTypeSchema.parse({ ...ravenEntityType, id: '' })).toThrow();
+  });
+
+  it('rejects empty label', () => {
+    expect(() => entityTypeSchema.parse({ ...ravenEntityType, label: '' })).toThrow();
+  });
+
+  it('rejects empty rune', () => {
+    expect(() => entityTypeSchema.parse({ ...ravenEntityType, rune: '' })).toThrow();
+  });
+
+  it('rejects invalid shape', () => {
+    expect(() => entityTypeSchema.parse({ ...ravenEntityType, shape: 'blob' })).toThrow();
+  });
+
+  it('rejects invalid category', () => {
+    expect(() => entityTypeSchema.parse({ ...ravenEntityType, category: 'mystical' })).toThrow();
+  });
+
+  it('rejects empty color', () => {
+    expect(() => entityTypeSchema.parse({ ...ravenEntityType, color: '' })).toThrow();
+  });
+
+  it.each(validCategories)('accepts category "%s"', (cat) => {
+    const result = entityTypeSchema.parse({ ...ravenEntityType, category: cat });
+    expect(result.category).toBe(cat);
+  });
+
+  it.each(validShapes)('accepts shape "%s"', (shape) => {
+    const result = entityTypeSchema.parse({ ...ravenEntityType, shape });
+    expect(result.shape).toBe(shape);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// typeRegistrySchema
+// ---------------------------------------------------------------------------
+
+const minimalRegistry = {
+  version: 1,
+  updatedAt: '2026-04-19T00:00:00Z',
+  types: [ravenEntityType],
+} as const;
+
+describe('typeRegistrySchema', () => {
+  it('round-trips a minimal registry', () => {
+    const result = typeRegistrySchema.parse(minimalRegistry);
+    expect(result.version).toBe(1);
+    expect(result.types).toHaveLength(1);
+    expect(result.types[0]?.id).toBe('raven');
+  });
+
+  it('round-trips an empty types array', () => {
+    const result = typeRegistrySchema.parse({ ...minimalRegistry, types: [] });
+    expect(result.types).toEqual([]);
+  });
+
+  it('round-trips version 0', () => {
+    expect(typeRegistrySchema.parse({ ...minimalRegistry, version: 0 }).version).toBe(0);
+  });
+
+  it('rejects negative version', () => {
+    expect(() => typeRegistrySchema.parse({ ...minimalRegistry, version: -1 })).toThrow();
+  });
+
+  it('rejects fractional version', () => {
+    expect(() => typeRegistrySchema.parse({ ...minimalRegistry, version: 1.5 })).toThrow();
+  });
+
+  it('rejects empty updatedAt', () => {
+    expect(() => typeRegistrySchema.parse({ ...minimalRegistry, updatedAt: '' })).toThrow();
+  });
+
+  it('rejects an invalid type in the types array', () => {
+    expect(() =>
+      typeRegistrySchema.parse({
+        ...minimalRegistry,
+        types: [{ ...ravenEntityType, id: '' }],
+      }),
+    ).toThrow();
+  });
+
+  it('round-trips a registry with multiple types', () => {
+    const realmType = {
+      id: 'realm',
+      label: 'Realm',
+      category: 'topology' as const,
+      rune: 'ᚱ',
+      shape: 'rounded-rect' as const,
+      color: '--color-brand',
+      description: 'A logical boundary containing clusters and hosts.',
+      parentTypes: [],
+      canContain: ['cluster', 'host'],
+    };
+    const result = typeRegistrySchema.parse({
+      ...minimalRegistry,
+      types: [ravenEntityType, realmType],
+    });
+    expect(result.types).toHaveLength(2);
+  });
+});

--- a/web-next/packages/domain/src/entity-type.ts
+++ b/web-next/packages/domain/src/entity-type.ts
@@ -1,0 +1,117 @@
+import { z } from 'zod';
+
+/**
+ * Shape primitives used by the Observatory canvas and Registry editor.
+ * Every EntityType maps to one of these SVG shapes (20×20 viewBox).
+ *
+ * Owner: **Observatory** (`plugin-observatory`).
+ */
+export const entityShapeSchema = z.enum([
+  'ring',
+  'ring-dashed',
+  'rounded-rect',
+  'diamond',
+  'triangle',
+  'hex',
+  'chevron',
+  'square',
+  'square-sm',
+  'pentagon',
+  'halo',
+  'mimir',
+  'mimir-small',
+  'dot',
+]);
+
+export type EntityShape = z.infer<typeof entityShapeSchema>;
+
+/**
+ * Grouping categories for the Registry editor type grid.
+ *
+ * Owner: **Observatory**. Consumed by: **Tyr** (saga member badges).
+ */
+export const entityCategorySchema = z.enum([
+  'topology',
+  'hardware',
+  'agent',
+  'coordinator',
+  'knowledge',
+  'infrastructure',
+  'device',
+  'composite',
+]);
+
+export type EntityCategory = z.infer<typeof entityCategorySchema>;
+
+/**
+ * A single entry in the Observatory type registry (SDD §4.1).
+ *
+ * Each entity type defines the shape, color, rune, and containment rules
+ * used by both the topology canvas and the drag-reparent registry editor.
+ *
+ * **Canonical owner:** `plugin-observatory` (the Registry screen manages
+ * the full `TypeRegistry`; drag-reparent rewrites `parentTypes` /
+ * `canContain` with cycle-protection).
+ *
+ * **Consumed by:**
+ * - `plugin-tyr` — topology sidebar labels raid participants with their
+ *   entity type's shape + rune.
+ * - `plugin-mimir` — entity pages reference `entity_type` by id.
+ * - `plugin-ravn` — raven nodes in the fleet console use the `agent`
+ *   category shape.
+ */
+export const entityTypeSchema = z.object({
+  /** Unique stable identifier (e.g. `realm`, `raven`, `bifrost`). */
+  id: z.string().min(1),
+  /** Human-readable display name shown in the Registry grid. */
+  label: z.string().min(1),
+  /** Grouping category for the Registry type grid. */
+  category: entityCategorySchema,
+  /**
+   * Single-character runic identity glyph.
+   * Must not be one of the historically appropriated symbols:
+   * ᛟ ᛊ ᛏ ᛉ ᚺ ᚻ.
+   */
+  rune: z.string().min(1),
+  /** SVG shape primitive used on the canvas and in registry rows. */
+  shape: entityShapeSchema,
+  /** CSS color token or hex for this entity type's accent color. */
+  color: z.string().min(1),
+  /** One-sentence description shown in the Registry drawer. */
+  description: z.string(),
+  /**
+   * Ids of types that can contain this type (single-parent model).
+   * Drag-reparent in the Registry rewrites this to `[newParentId]`.
+   */
+  parentTypes: z.array(z.string()),
+  /**
+   * Ids of types this type is allowed to contain as direct children.
+   * Cycle-protection in the Registry editor prevents a type from being
+   * reparented onto one of its own descendants.
+   */
+  canContain: z.array(z.string()),
+});
+
+export type EntityType = z.infer<typeof entityTypeSchema>;
+
+/**
+ * The full Observatory type registry, versioned for optimistic concurrency.
+ *
+ * **Canonical owner:** `plugin-observatory`.
+ *
+ * **Consumed by:**
+ * - `plugin-ravn` — `PluginCtx.registry` is threaded through the shell so
+ *   Ravn can resolve entity types for live topology labels.
+ * - `plugin-tyr` — same shell context; saga members resolve their entity type
+ *   shape for the raid panel.
+ */
+export const typeRegistrySchema = z.object({
+  /** Monotonically incrementing version, bumped on every registry edit. */
+  version: z.number().int().min(0),
+  /** ISO-8601 timestamp of the last edit. */
+  updatedAt: z.string().min(1),
+  /** All entity types in this registry. */
+  types: z.array(entityTypeSchema),
+});
+
+export type TypeRegistry = z.infer<typeof typeRegistrySchema>;

--- a/web-next/packages/domain/src/entity-type.ts
+++ b/web-next/packages/domain/src/entity-type.ts
@@ -72,7 +72,7 @@ export const entityTypeSchema = z.object({
    * Must not be one of the historically appropriated symbols:
    * ᛟ ᛊ ᛏ ᛉ ᚺ ᚻ.
    */
-  rune: z.string().min(1),
+  rune: z.string().length(1),
   /** SVG shape primitive used on the canvas and in registry rows. */
   shape: entityShapeSchema,
   /** CSS color token or hex for this entity type's accent color. */

--- a/web-next/packages/domain/src/event-catalog.test.ts
+++ b/web-next/packages/domain/src/event-catalog.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { fieldTypeSchema, eventSpecSchema, eventCatalogSchema } from './event-catalog';
+
+// ---------------------------------------------------------------------------
+// fieldTypeSchema
+// ---------------------------------------------------------------------------
+
+describe('fieldTypeSchema', () => {
+  it.each(['string', 'number', 'boolean', 'object', 'array', 'any'])(
+    'accepts field type "%s"',
+    (t) => {
+      expect(fieldTypeSchema.parse(t)).toBe(t);
+    },
+  );
+
+  it('rejects an unknown field type', () => {
+    expect(() => fieldTypeSchema.parse('date')).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// eventSpecSchema
+// ---------------------------------------------------------------------------
+
+describe('eventSpecSchema', () => {
+  it('round-trips a full event spec', () => {
+    const input = {
+      name: 'build.artifact',
+      schema: { url: 'string', size: 'number', success: 'boolean' },
+    };
+    expect(eventSpecSchema.parse(input)).toEqual(input);
+  });
+
+  it('round-trips a zero-payload event', () => {
+    const input = { name: 'ping', schema: {} };
+    expect(eventSpecSchema.parse(input)).toEqual(input);
+  });
+
+  it('rejects an empty event name', () => {
+    expect(() => eventSpecSchema.parse({ name: '', schema: {} })).toThrow();
+  });
+
+  it('rejects an invalid field type in schema', () => {
+    expect(() => eventSpecSchema.parse({ name: 'x', schema: { ts: 'Date' } })).toThrow();
+  });
+
+  it('accepts all valid field types in a schema', () => {
+    const schema = {
+      a: 'string',
+      b: 'number',
+      c: 'boolean',
+      d: 'object',
+      e: 'array',
+      f: 'any',
+    };
+    const result = eventSpecSchema.parse({ name: 'multi', schema });
+    expect(result.schema).toEqual(schema);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// eventCatalogSchema
+// ---------------------------------------------------------------------------
+
+describe('eventCatalogSchema', () => {
+  it('round-trips an empty catalog', () => {
+    expect(eventCatalogSchema.parse([])).toEqual([]);
+  });
+
+  it('round-trips a catalog with multiple events', () => {
+    const catalog = [
+      { name: 'code.changed', schema: { path: 'string' } },
+      { name: 'review.approved', schema: { reviewer: 'string', confidence: 'number' } },
+      { name: 'ping', schema: {} },
+    ];
+    const result = eventCatalogSchema.parse(catalog);
+    expect(result).toHaveLength(3);
+    expect(result[0]?.name).toBe('code.changed');
+    expect(result[2]?.name).toBe('ping');
+  });
+
+  it('rejects non-array input', () => {
+    expect(() => eventCatalogSchema.parse({})).toThrow();
+  });
+
+  it('rejects a catalog with an invalid event', () => {
+    expect(() => eventCatalogSchema.parse([{ name: '', schema: {} }])).toThrow();
+  });
+});

--- a/web-next/packages/domain/src/event-catalog.ts
+++ b/web-next/packages/domain/src/event-catalog.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+
+/**
+ * Schema field type strings used in event payload definitions.
+ *
+ * Owner: **Ravn**. Consumed by: **Tyr** (workflow validation), **Observatory** (graph).
+ */
+export const fieldTypeSchema = z.enum(['string', 'number', 'boolean', 'object', 'array', 'any']);
+
+export type FieldType = z.infer<typeof fieldTypeSchema>;
+
+/**
+ * Specification of a single event that can be produced or consumed by ravens.
+ *
+ * **Canonical owner:** `plugin-ravn` (the EventCatalog is managed in the
+ * Ravn Personas form via EventPicker + SchemaEditor).
+ *
+ * **Consumed by:**
+ * - `plugin-tyr` — WorkflowBuilder validates that every `consumes` edge has a
+ *   matching producer; fan-in wiring reads the event name.
+ * - `plugin-observatory` — Events view renders the produces/consumes graph.
+ */
+export const eventSpecSchema = z.object({
+  /**
+   * Globally unique event name (e.g. `code.changed`, `review.approved`).
+   * Convention: `<domain>.<verb>` in lower-kebab-case.
+   */
+  name: z.string().min(1),
+  /**
+   * Payload shape: field-name → type-string from `FieldType`.
+   * An empty record is valid for zero-payload events.
+   */
+  schema: z.record(z.string(), fieldTypeSchema),
+});
+
+export type EventSpec = z.infer<typeof eventSpecSchema>;
+
+/**
+ * The complete catalog of events available on this deployment.
+ *
+ * **Canonical owner:** `plugin-ravn` (EventPicker allows new events to be
+ * created inline; the catalog grows as personas are edited).
+ *
+ * **Consumed by:**
+ * - `plugin-tyr` — every workflow node's `produces` / `consumes` wiring is
+ *   validated against this catalog.
+ * - `plugin-observatory` — Events view renders the full catalog as a graph.
+ * - `plugin-mimir` — ravn-bindings screen labels consumed events.
+ */
+export const eventCatalogSchema = z.array(eventSpecSchema);
+
+export type EventCatalog = z.infer<typeof eventCatalogSchema>;

--- a/web-next/packages/domain/src/index.ts
+++ b/web-next/packages/domain/src/index.ts
@@ -1,0 +1,58 @@
+export {
+  personaRoleSchema,
+  llmConfigSchema,
+  consumedEventSchema,
+  producedEventSchema,
+  quorumParamsSchema,
+  weightedScoreParamsSchema,
+  fanInStrategySchema,
+  personaSchema,
+  type PersonaRole,
+  type LlmConfig,
+  type ConsumedEvent,
+  type ProducedEvent,
+  type QuorumParams,
+  type WeightedScoreParams,
+  type FanInStrategy,
+  type Persona,
+} from './persona';
+
+export {
+  mountRoleSchema,
+  mountStatusSchema,
+  mountSchema,
+  type MountRole,
+  type MountStatus,
+  type Mount,
+} from './mount';
+
+export {
+  toolGroupSchema,
+  toolSchema,
+  toolRegistrySchema,
+  type ToolGroup,
+  type Tool,
+  type ToolRegistry,
+} from './tool-registry';
+
+export {
+  fieldTypeSchema,
+  eventSpecSchema,
+  eventCatalogSchema,
+  type FieldType,
+  type EventSpec,
+  type EventCatalog,
+} from './event-catalog';
+
+export { budgetStateSchema, type BudgetState } from './budget';
+
+export {
+  entityShapeSchema,
+  entityCategorySchema,
+  entityTypeSchema,
+  typeRegistrySchema,
+  type EntityShape,
+  type EntityCategory,
+  type EntityType,
+  type TypeRegistry,
+} from './entity-type';

--- a/web-next/packages/domain/src/mount.test.ts
+++ b/web-next/packages/domain/src/mount.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { mountRoleSchema, mountStatusSchema, mountSchema } from './mount';
+
+// ---------------------------------------------------------------------------
+// mountRoleSchema
+// ---------------------------------------------------------------------------
+
+describe('mountRoleSchema', () => {
+  it.each(['local', 'shared', 'domain'])('accepts role "%s"', (role) => {
+    expect(mountRoleSchema.parse(role)).toBe(role);
+  });
+
+  it('rejects an unknown role', () => {
+    expect(() => mountRoleSchema.parse('remote')).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mountStatusSchema
+// ---------------------------------------------------------------------------
+
+describe('mountStatusSchema', () => {
+  it.each(['healthy', 'degraded', 'down'])('accepts status "%s"', (s) => {
+    expect(mountStatusSchema.parse(s)).toBe(s);
+  });
+
+  it('rejects an unknown status', () => {
+    expect(() => mountStatusSchema.parse('unknown')).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mountSchema
+// ---------------------------------------------------------------------------
+
+const validMount = {
+  name: 'primary',
+  role: 'local',
+  host: 'localhost',
+  url: 'http://localhost:7891',
+  priority: 0,
+  categories: null,
+  status: 'healthy',
+  pages: 120,
+  sources: 45,
+  lintIssues: 3,
+  lastWrite: '2026-04-18T10:00:00Z',
+  embedding: 'sentence-transformers/all-MiniLM-L6-v2',
+  sizeKb: 2048,
+  desc: 'Primary local mount',
+} as const;
+
+describe('mountSchema', () => {
+  it('round-trips a full mount', () => {
+    const result = mountSchema.parse(validMount);
+    expect(result).toEqual(validMount);
+  });
+
+  it('accepts null categories (accepts all)', () => {
+    expect(mountSchema.parse({ ...validMount, categories: null }).categories).toBeNull();
+  });
+
+  it('accepts a non-null category list', () => {
+    const result = mountSchema.parse({ ...validMount, categories: ['code', 'docs'] });
+    expect(result.categories).toEqual(['code', 'docs']);
+  });
+
+  it('accepts an empty category list', () => {
+    expect(mountSchema.parse({ ...validMount, categories: [] }).categories).toEqual([]);
+  });
+
+  it('rejects priority < 0', () => {
+    expect(() => mountSchema.parse({ ...validMount, priority: -1 })).toThrow();
+  });
+
+  it('rejects negative pages count', () => {
+    expect(() => mountSchema.parse({ ...validMount, pages: -1 })).toThrow();
+  });
+
+  it('rejects negative sources count', () => {
+    expect(() => mountSchema.parse({ ...validMount, sources: -1 })).toThrow();
+  });
+
+  it('rejects negative lintIssues count', () => {
+    expect(() => mountSchema.parse({ ...validMount, lintIssues: -1 })).toThrow();
+  });
+
+  it('rejects negative sizeKb', () => {
+    expect(() => mountSchema.parse({ ...validMount, sizeKb: -1 })).toThrow();
+  });
+
+  it('rejects empty name', () => {
+    expect(() => mountSchema.parse({ ...validMount, name: '' })).toThrow();
+  });
+
+  it('rejects invalid status', () => {
+    expect(() => mountSchema.parse({ ...validMount, status: 'exploded' })).toThrow();
+  });
+
+  it('rejects invalid role', () => {
+    expect(() => mountSchema.parse({ ...validMount, role: 'remote' })).toThrow();
+  });
+
+  it('accepts degraded and down statuses', () => {
+    expect(mountSchema.parse({ ...validMount, status: 'degraded' }).status).toBe('degraded');
+    expect(mountSchema.parse({ ...validMount, status: 'down' }).status).toBe('down');
+  });
+
+  it('accepts shared and domain roles', () => {
+    expect(mountSchema.parse({ ...validMount, role: 'shared' }).role).toBe('shared');
+    expect(mountSchema.parse({ ...validMount, role: 'domain' }).role).toBe('domain');
+  });
+
+  it('accepts zero pages and sources', () => {
+    const result = mountSchema.parse({ ...validMount, pages: 0, sources: 0, lintIssues: 0 });
+    expect(result.pages).toBe(0);
+  });
+
+  it('rejects fractional priority', () => {
+    expect(() => mountSchema.parse({ ...validMount, priority: 1.5 })).toThrow();
+  });
+});

--- a/web-next/packages/domain/src/mount.ts
+++ b/web-next/packages/domain/src/mount.ts
@@ -1,0 +1,76 @@
+import { z } from 'zod';
+
+/**
+ * Roles a Mímir mount may serve in a deployment.
+ *
+ * - `local`  — operator's own private mount.
+ * - `shared` — realm-wide shared knowledge base.
+ * - `domain` — prefix-scoped domain knowledge.
+ *
+ * Owner: **Mimir** (`plugin-mimir`).
+ * Consumed by: **Ravn** (binding UI, write-routing chips).
+ */
+export const mountRoleSchema = z.enum(['local', 'shared', 'domain']);
+
+export type MountRole = z.infer<typeof mountRoleSchema>;
+
+/**
+ * Health status reported by a Mímir mount.
+ *
+ * Owner: **Mimir**. Consumed by: **Observatory** (topology health dots).
+ */
+export const mountStatusSchema = z.enum(['healthy', 'degraded', 'down']);
+
+export type MountStatus = z.infer<typeof mountStatusSchema>;
+
+/**
+ * A Mímir mount — a standalone knowledge-base instance with its own
+ * storage, embedding model, write-routing priority, and health signal.
+ *
+ * **Canonical owner:** `plugin-mimir` (manages all mounts; renders the
+ * Overview, Routing, and Ravns screens).
+ *
+ * **Consumed by:**
+ * - `plugin-ravn` — persona form shows `mimirWriteRouting` dropdown
+ *   derived from available mounts; MountChip renders mount name + role.
+ * - `plugin-observatory` — topology canvas shows Mímir node + mount count.
+ * - `plugin-tyr` — dispatch feasibility check reads mount health.
+ */
+export const mountSchema = z.object({
+  /** Unique short name used in write-routing rules and RavnBindings. */
+  name: z.string().min(1),
+  /** Role this mount plays in the deployment. */
+  role: mountRoleSchema,
+  /** Hostname or IP of the host running this mount. */
+  host: z.string().min(1),
+  /** Base URL of the mount's HTTP API. */
+  url: z.string().min(1),
+  /**
+   * Write-routing priority. Lower values win on prefix matches.
+   * Must be a non-negative integer.
+   */
+  priority: z.number().int().min(0),
+  /**
+   * Category allowlist. `null` means the mount accepts all categories.
+   * A non-empty array restricts ingest to the listed categories.
+   */
+  categories: z.array(z.string()).nullable(),
+  /** Health status reported by the mount's health endpoint. */
+  status: mountStatusSchema,
+  /** Total compiled pages stored on this mount. */
+  pages: z.number().int().min(0),
+  /** Total raw source records stored on this mount. */
+  sources: z.number().int().min(0),
+  /** Open lint issues on this mount. */
+  lintIssues: z.number().int().min(0),
+  /** ISO-8601 timestamp of the most recent write to this mount. */
+  lastWrite: z.string().min(1),
+  /** Embedding model id used by this mount's vector index. */
+  embedding: z.string().min(1),
+  /** Total size of compiled pages on disk in kilobytes. */
+  sizeKb: z.number().min(0),
+  /** Human-readable description shown in the Overview card. */
+  desc: z.string(),
+});
+
+export type Mount = z.infer<typeof mountSchema>;

--- a/web-next/packages/domain/src/persona.test.ts
+++ b/web-next/packages/domain/src/persona.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect } from 'vitest';
+import {
+  personaRoleSchema,
+  llmConfigSchema,
+  consumedEventSchema,
+  producedEventSchema,
+  fanInStrategySchema,
+  personaSchema,
+  quorumParamsSchema,
+  weightedScoreParamsSchema,
+} from './persona';
+
+// ---------------------------------------------------------------------------
+// personaRoleSchema
+// ---------------------------------------------------------------------------
+
+describe('personaRoleSchema', () => {
+  it.each(['plan', 'build', 'verify', 'review', 'gate', 'audit', 'ship', 'index', 'report'])(
+    'accepts role "%s"',
+    (role) => {
+      expect(personaRoleSchema.parse(role)).toBe(role);
+    },
+  );
+
+  it('rejects an unknown role', () => {
+    expect(() => personaRoleSchema.parse('destroy')).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// llmConfigSchema
+// ---------------------------------------------------------------------------
+
+describe('llmConfigSchema', () => {
+  it('round-trips a full config', () => {
+    const input = { alias: 'claude-sonnet-4-6', thinking: true, maxTokens: 4096, temperature: 0.7 };
+    expect(llmConfigSchema.parse(input)).toEqual(input);
+  });
+
+  it('round-trips without optional temperature', () => {
+    const input = { alias: 'claude-haiku-4-5', thinking: false, maxTokens: 2048 };
+    const result = llmConfigSchema.parse(input);
+    expect(result.temperature).toBeUndefined();
+  });
+
+  it('rejects zero maxTokens', () => {
+    expect(() => llmConfigSchema.parse({ alias: 'x', thinking: false, maxTokens: 0 })).toThrow();
+  });
+
+  it('rejects temperature > 2', () => {
+    expect(() =>
+      llmConfigSchema.parse({ alias: 'x', thinking: false, maxTokens: 1, temperature: 3 }),
+    ).toThrow();
+  });
+
+  it('rejects temperature < 0', () => {
+    expect(() =>
+      llmConfigSchema.parse({ alias: 'x', thinking: false, maxTokens: 1, temperature: -0.1 }),
+    ).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// consumedEventSchema
+// ---------------------------------------------------------------------------
+
+describe('consumedEventSchema', () => {
+  it('round-trips minimal', () => {
+    expect(consumedEventSchema.parse({ name: 'code.changed' })).toEqual({ name: 'code.changed' });
+  });
+
+  it('round-trips full', () => {
+    const input = { name: 'review.done', injects: ['summary'], trust: 0.8 };
+    expect(consumedEventSchema.parse(input)).toEqual(input);
+  });
+
+  it('rejects trust > 1', () => {
+    expect(() => consumedEventSchema.parse({ name: 'x', trust: 1.5 })).toThrow();
+  });
+
+  it('rejects trust < 0', () => {
+    expect(() => consumedEventSchema.parse({ name: 'x', trust: -0.1 })).toThrow();
+  });
+
+  it('rejects empty name', () => {
+    expect(() => consumedEventSchema.parse({ name: '' })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// producedEventSchema
+// ---------------------------------------------------------------------------
+
+describe('producedEventSchema', () => {
+  it('round-trips', () => {
+    const input = { event: 'build.artifact', schema: { url: 'string', size: 'number' } };
+    expect(producedEventSchema.parse(input)).toEqual(input);
+  });
+
+  it('accepts empty schema', () => {
+    expect(producedEventSchema.parse({ event: 'ping', schema: {} })).toEqual({
+      event: 'ping',
+      schema: {},
+    });
+  });
+
+  it('rejects empty event name', () => {
+    expect(() => producedEventSchema.parse({ event: '', schema: {} })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// quorumParamsSchema
+// ---------------------------------------------------------------------------
+
+describe('quorumParamsSchema', () => {
+  it('round-trips minimal', () => {
+    expect(quorumParamsSchema.parse({ n: 2, of: 3 })).toEqual({ n: 2, of: 3 });
+  });
+
+  it('round-trips with windowMs', () => {
+    const input = { n: 2, of: 4, windowMs: 5000 };
+    expect(quorumParamsSchema.parse(input)).toEqual(input);
+  });
+
+  it('rejects n < 1', () => {
+    expect(() => quorumParamsSchema.parse({ n: 0, of: 1 })).toThrow();
+  });
+
+  it('rejects of < 1', () => {
+    expect(() => quorumParamsSchema.parse({ n: 1, of: 0 })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// weightedScoreParamsSchema
+// ---------------------------------------------------------------------------
+
+describe('weightedScoreParamsSchema', () => {
+  it('round-trips with weights', () => {
+    const input = { weights: { planner: 0.6, builder: 0.4 } };
+    expect(weightedScoreParamsSchema.parse(input)).toEqual(input);
+  });
+
+  it('round-trips without weights', () => {
+    expect(weightedScoreParamsSchema.parse({})).toEqual({});
+  });
+
+  it('rejects a weight > 1', () => {
+    expect(() => weightedScoreParamsSchema.parse({ weights: { p: 1.5 } })).toThrow();
+  });
+
+  it('rejects a weight < 0', () => {
+    expect(() => weightedScoreParamsSchema.parse({ weights: { p: -0.1 } })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fanInStrategySchema
+// ---------------------------------------------------------------------------
+
+describe('fanInStrategySchema', () => {
+  it('accepts all_must_pass', () => {
+    const r = fanInStrategySchema.parse({ strategy: 'all_must_pass', params: {} });
+    expect(r.strategy).toBe('all_must_pass');
+  });
+
+  it('accepts any_passes', () => {
+    expect(fanInStrategySchema.parse({ strategy: 'any_passes', params: {} }).strategy).toBe(
+      'any_passes',
+    );
+  });
+
+  it('accepts quorum with required params', () => {
+    const r = fanInStrategySchema.parse({ strategy: 'quorum', params: { n: 2, of: 3 } });
+    expect(r.strategy).toBe('quorum');
+  });
+
+  it('accepts merge', () => {
+    expect(fanInStrategySchema.parse({ strategy: 'merge', params: {} }).strategy).toBe('merge');
+  });
+
+  it('accepts first_wins', () => {
+    expect(fanInStrategySchema.parse({ strategy: 'first_wins', params: {} }).strategy).toBe(
+      'first_wins',
+    );
+  });
+
+  it('accepts weighted_score with optional weights', () => {
+    const r = fanInStrategySchema.parse({
+      strategy: 'weighted_score',
+      params: { weights: { planner: 0.7 } },
+    });
+    expect(r.strategy).toBe('weighted_score');
+  });
+
+  it('accepts weighted_score without weights', () => {
+    const r = fanInStrategySchema.parse({ strategy: 'weighted_score', params: {} });
+    expect(r.strategy).toBe('weighted_score');
+  });
+
+  it('rejects quorum missing required params', () => {
+    expect(() => fanInStrategySchema.parse({ strategy: 'quorum', params: {} })).toThrow();
+  });
+
+  it('rejects an unknown strategy', () => {
+    expect(() => fanInStrategySchema.parse({ strategy: 'unknown_strategy', params: {} })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// personaSchema
+// ---------------------------------------------------------------------------
+
+const minimalPersona = {
+  name: 'Skald',
+  role: 'build',
+  color: '#6366f1',
+  letter: 'S',
+  summary: 'Writes and compiles code',
+  description: 'A detailed builder persona.',
+  llm: { alias: 'claude-sonnet-4-6', thinking: false, maxTokens: 4096 },
+  permissionMode: 'default',
+  allowed: ['read', 'write'],
+  forbidden: ['bash'],
+  produces: { event: 'build.artifact', schema: { url: 'string' } },
+  consumes: { events: [{ name: 'plan.done', trust: 0.9 }] },
+} as const;
+
+describe('personaSchema', () => {
+  it('round-trips a minimal persona', () => {
+    const result = personaSchema.parse(minimalPersona);
+    expect(result.name).toBe('Skald');
+    expect(result.role).toBe('build');
+    expect(result.fanIn).toBeUndefined();
+    expect(result.mimirWriteRouting).toBeUndefined();
+  });
+
+  it('round-trips with fanIn and mimirWriteRouting', () => {
+    const input = {
+      ...minimalPersona,
+      fanIn: { strategy: 'all_must_pass', params: {} },
+      mimirWriteRouting: 'shared',
+    };
+    const result = personaSchema.parse(input);
+    expect(result.fanIn?.strategy).toBe('all_must_pass');
+    expect(result.mimirWriteRouting).toBe('shared');
+  });
+
+  it('round-trips with quorum fanIn', () => {
+    const input = {
+      ...minimalPersona,
+      fanIn: { strategy: 'quorum', params: { n: 2, of: 3, windowMs: 10000 } },
+    };
+    const result = personaSchema.parse(input);
+    expect(result.fanIn?.strategy).toBe('quorum');
+  });
+
+  it('round-trips with weighted_score fanIn', () => {
+    const input = {
+      ...minimalPersona,
+      fanIn: { strategy: 'weighted_score', params: { weights: { skald: 0.8 } } },
+    };
+    const result = personaSchema.parse(input);
+    expect(result.fanIn?.strategy).toBe('weighted_score');
+  });
+
+  it('rejects letter longer than 1 char', () => {
+    expect(() => personaSchema.parse({ ...minimalPersona, letter: 'AB' })).toThrow();
+  });
+
+  it('rejects an invalid permissionMode', () => {
+    expect(() => personaSchema.parse({ ...minimalPersona, permissionMode: 'nuclear' })).toThrow();
+  });
+
+  it('rejects an invalid role', () => {
+    expect(() => personaSchema.parse({ ...minimalPersona, role: 'destroyer' })).toThrow();
+  });
+
+  it('rejects invalid mimirWriteRouting', () => {
+    expect(() => personaSchema.parse({ ...minimalPersona, mimirWriteRouting: 'remote' })).toThrow();
+  });
+
+  it('accepts all valid mimir write routing values', () => {
+    for (const r of ['local', 'shared', 'domain'] as const) {
+      expect(
+        personaSchema.parse({ ...minimalPersona, mimirWriteRouting: r }).mimirWriteRouting,
+      ).toBe(r);
+    }
+  });
+});

--- a/web-next/packages/domain/src/persona.test.ts
+++ b/web-next/packages/domain/src/persona.test.ts
@@ -107,6 +107,12 @@ describe('producedEventSchema', () => {
   it('rejects empty event name', () => {
     expect(() => producedEventSchema.parse({ event: '', schema: {} })).toThrow();
   });
+
+  it('rejects an invalid field type in schema', () => {
+    expect(() =>
+      producedEventSchema.parse({ event: 'build.artifact', schema: { url: 'URL' } }),
+    ).toThrow();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/web-next/packages/domain/src/persona.ts
+++ b/web-next/packages/domain/src/persona.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { fieldTypeSchema } from './event-catalog';
 
 /**
  * Canonical roles a Persona may fulfil in a workflow.
@@ -64,8 +65,8 @@ export type ConsumedEvent = z.infer<typeof consumedEventSchema>;
 export const producedEventSchema = z.object({
   /** Event name, must exist in EventCatalog or be created there. */
   event: z.string().min(1),
-  /** Payload field definitions: field-name → type-string. */
-  schema: z.record(z.string(), z.string()),
+  /** Payload field definitions: field-name → {@link FieldType} string. */
+  schema: z.record(z.string(), fieldTypeSchema),
 });
 
 export type ProducedEvent = z.infer<typeof producedEventSchema>;

--- a/web-next/packages/domain/src/persona.ts
+++ b/web-next/packages/domain/src/persona.ts
@@ -1,0 +1,198 @@
+import { z } from 'zod';
+
+/**
+ * Canonical roles a Persona may fulfil in a workflow.
+ * Used by the role→shape mapping in PersonaAvatar (Ravn, Tyr).
+ *
+ * Owner: **Ravn** (`plugin-ravn`).
+ * Consumed by: **Tyr** (workflow DAG, dispatch), **Mimir** (write-routing).
+ */
+export const personaRoleSchema = z.enum([
+  'plan',
+  'build',
+  'verify',
+  'review',
+  'gate',
+  'audit',
+  'ship',
+  'index',
+  'report',
+]);
+
+export type PersonaRole = z.infer<typeof personaRoleSchema>;
+
+/**
+ * LLM configuration attached to a Persona.
+ *
+ * Owner: **Ravn**. Consumed by: **Tyr** (dispatch feasibility check).
+ */
+export const llmConfigSchema = z.object({
+  /** Short human-readable model alias (e.g. "claude-sonnet-4-6"). */
+  alias: z.string().min(1),
+  /** Whether extended thinking is enabled for this persona. */
+  thinking: z.boolean(),
+  /** Hard token cap per invocation. */
+  maxTokens: z.number().int().positive(),
+  /** Sampling temperature. Omit to use the model default. */
+  temperature: z.number().min(0).max(2).optional(),
+});
+
+export type LlmConfig = z.infer<typeof llmConfigSchema>;
+
+/**
+ * A single event this Persona subscribes to, plus optional inject catalog
+ * entries to slot into the prompt and a producer-trust threshold.
+ *
+ * Owner: **Ravn**. Consumed by: **Tyr** (fan-in wiring).
+ */
+export const consumedEventSchema = z.object({
+  /** Event name, matches an entry in EventCatalog. */
+  name: z.string().min(1),
+  /** Inject catalog keys to embed when this event fires. */
+  injects: z.array(z.string()).optional(),
+  /** Minimum trust score required from the producing persona (0–1). */
+  trust: z.number().min(0).max(1).optional(),
+});
+
+export type ConsumedEvent = z.infer<typeof consumedEventSchema>;
+
+/**
+ * The single event this Persona emits on completion.
+ *
+ * Owner: **Ravn**. Consumed by: **Tyr** (fan-in wiring), **Observatory** (graph).
+ */
+export const producedEventSchema = z.object({
+  /** Event name, must exist in EventCatalog or be created there. */
+  event: z.string().min(1),
+  /** Payload field definitions: field-name → type-string. */
+  schema: z.record(z.string(), z.string()),
+});
+
+export type ProducedEvent = z.infer<typeof producedEventSchema>;
+
+// ---------------------------------------------------------------------------
+// Fan-in strategies
+// ---------------------------------------------------------------------------
+
+/**
+ * Quorum strategy params: n-of-M with an optional time window.
+ */
+export const quorumParamsSchema = z.object({
+  /** How many producers must succeed. */
+  n: z.number().int().min(1),
+  /** Out of how many total producers. */
+  of: z.number().int().min(1),
+  /** Optional time window in milliseconds. */
+  windowMs: z.number().int().min(0).optional(),
+});
+
+export type QuorumParams = z.infer<typeof quorumParamsSchema>;
+
+/**
+ * Weighted-score strategy params: per-persona weight map.
+ */
+export const weightedScoreParamsSchema = z.object({
+  /**
+   * Map of personaName → weight (0–1). Omitting uses equal weights.
+   */
+  weights: z.record(z.string(), z.number().min(0).max(1)).optional(),
+});
+
+export type WeightedScoreParams = z.infer<typeof weightedScoreParamsSchema>;
+
+/**
+ * Discriminated union of all fan-in aggregation strategies.
+ *
+ * - `all_must_pass` — every declared producer must report success.
+ * - `any_passes`    — accept on the first success (race).
+ * - `quorum`        — N-of-M with an optional time window.
+ * - `merge`         — concatenate / union payloads.
+ * - `first_wins`    — first producer wins, rest discarded.
+ * - `weighted_score`— producers return numeric scores, arbiter averages by weight.
+ *
+ * Owner: **Ravn**. Consumed by: **Tyr** (fan-in plumbing).
+ */
+export const fanInStrategySchema = z.discriminatedUnion('strategy', [
+  z.object({
+    strategy: z.literal('all_must_pass'),
+    params: z.record(z.string(), z.unknown()),
+  }),
+  z.object({
+    strategy: z.literal('any_passes'),
+    params: z.record(z.string(), z.unknown()),
+  }),
+  z.object({
+    strategy: z.literal('quorum'),
+    params: quorumParamsSchema,
+  }),
+  z.object({
+    strategy: z.literal('merge'),
+    params: z.record(z.string(), z.unknown()),
+  }),
+  z.object({
+    strategy: z.literal('first_wins'),
+    params: z.record(z.string(), z.unknown()),
+  }),
+  z.object({
+    strategy: z.literal('weighted_score'),
+    params: weightedScoreParamsSchema,
+  }),
+]);
+
+export type FanInStrategy = z.infer<typeof fanInStrategySchema>;
+
+// ---------------------------------------------------------------------------
+// Persona
+// ---------------------------------------------------------------------------
+
+/**
+ * A Persona is a YAML template that any number of ravens can bind to.
+ * It encodes the agent's role, LLM settings, tool permissions, event wiring,
+ * fan-in strategy, and Mímir write-routing.
+ *
+ * **Canonical owner:** `plugin-ravn` (source of truth lives in
+ * `volundr/src/ravn/personas/*.yaml`).
+ *
+ * **Consumed by:**
+ * - `plugin-tyr` — workflow DAG nodes reference personas by name; dispatch
+ *   checks LLM alias + confidence thresholds.
+ * - `plugin-mimir` — write-routing + ravn-binding screens show the persona
+ *   name, role, and mimirWriteRouting field.
+ * - `plugin-observatory` — topology canvas labels raven nodes with persona
+ *   role-shape.
+ */
+export const personaSchema = z.object({
+  /** Unique human-readable identifier (matches the YAML filename stem). */
+  name: z.string().min(1),
+  /** Functional role — drives the PersonaAvatar shape. */
+  role: personaRoleSchema,
+  /** CSS color token or hex used to tint the persona avatar. */
+  color: z.string().min(1),
+  /** Single uppercase letter rendered inside the PersonaAvatar. */
+  letter: z.string().length(1),
+  /** One-sentence summary shown in list views. */
+  summary: z.string().min(1),
+  /** Longer description shown in the persona form. */
+  description: z.string(),
+  /** LLM settings for this persona. */
+  llm: llmConfigSchema,
+  /** Tool permission mode applied at the executor level. */
+  permissionMode: z.enum(['default', 'safe', 'loose']),
+  /** Explicitly allowed tool ids. */
+  allowed: z.array(z.string()),
+  /** Explicitly forbidden tool ids. */
+  forbidden: z.array(z.string()),
+  /** The single event this persona emits on completion. */
+  produces: producedEventSchema,
+  /** Events this persona subscribes to. */
+  consumes: z.object({ events: z.array(consumedEventSchema) }),
+  /** Fan-in strategy when multiple producers feed this persona. */
+  fanIn: fanInStrategySchema.optional(),
+  /**
+   * Which Mímir mount this persona's writes are routed to.
+   * Omit to inherit the global routing default.
+   */
+  mimirWriteRouting: z.enum(['local', 'shared', 'domain']).optional(),
+});
+
+export type Persona = z.infer<typeof personaSchema>;

--- a/web-next/packages/domain/src/tool-registry.test.ts
+++ b/web-next/packages/domain/src/tool-registry.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { toolGroupSchema, toolSchema, toolRegistrySchema } from './tool-registry';
+
+// ---------------------------------------------------------------------------
+// toolGroupSchema
+// ---------------------------------------------------------------------------
+
+describe('toolGroupSchema', () => {
+  it.each(['fs', 'shell', 'git', 'mimir', 'observe', 'security', 'bus'])(
+    'accepts group "%s"',
+    (group) => {
+      expect(toolGroupSchema.parse(group)).toBe(group);
+    },
+  );
+
+  it('rejects an unknown group', () => {
+    expect(() => toolGroupSchema.parse('network')).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toolSchema
+// ---------------------------------------------------------------------------
+
+const readTool = {
+  id: 'read',
+  group: 'fs',
+  destructive: false,
+  desc: 'Read a file from the filesystem',
+} as const;
+
+const bashTool = {
+  id: 'bash',
+  group: 'shell',
+  destructive: true,
+  desc: 'Execute a shell command',
+} as const;
+
+describe('toolSchema', () => {
+  it('round-trips a non-destructive tool', () => {
+    expect(toolSchema.parse(readTool)).toEqual(readTool);
+  });
+
+  it('round-trips a destructive tool', () => {
+    expect(toolSchema.parse(bashTool)).toEqual(bashTool);
+  });
+
+  it('rejects empty id', () => {
+    expect(() => toolSchema.parse({ ...readTool, id: '' })).toThrow();
+  });
+
+  it('rejects empty desc', () => {
+    expect(() => toolSchema.parse({ ...readTool, desc: '' })).toThrow();
+  });
+
+  it('rejects invalid group', () => {
+    expect(() => toolSchema.parse({ ...readTool, group: 'network' })).toThrow();
+  });
+
+  it('rejects non-boolean destructive', () => {
+    expect(() => toolSchema.parse({ ...readTool, destructive: 'yes' })).toThrow();
+  });
+
+  it.each(['fs', 'shell', 'git', 'mimir', 'observe', 'security', 'bus'])(
+    'accepts tool in group "%s"',
+    (group) => {
+      const t = toolSchema.parse({ id: `tool.${group}`, group, destructive: false, desc: 'x' });
+      expect(t.group).toBe(group);
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// toolRegistrySchema
+// ---------------------------------------------------------------------------
+
+describe('toolRegistrySchema', () => {
+  it('round-trips an empty registry', () => {
+    expect(toolRegistrySchema.parse([])).toEqual([]);
+  });
+
+  it('round-trips a populated registry', () => {
+    const registry = [readTool, bashTool];
+    const result = toolRegistrySchema.parse(registry);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual(readTool);
+    expect(result[1]).toEqual(bashTool);
+  });
+
+  it('rejects non-array input', () => {
+    expect(() => toolRegistrySchema.parse(null)).toThrow();
+  });
+
+  it('rejects an array with an invalid tool', () => {
+    expect(() => toolRegistrySchema.parse([{ ...readTool, id: '' }])).toThrow();
+  });
+});

--- a/web-next/packages/domain/src/tool-registry.ts
+++ b/web-next/packages/domain/src/tool-registry.ts
@@ -1,0 +1,64 @@
+import { z } from 'zod';
+
+/**
+ * Provider group a tool belongs to.
+ * Used to bucket tools in the ToolPicker modal (Ravn persona form).
+ *
+ * Owner: **Ravn**. Consumed by: **Tyr** (persona library in the workflow editor).
+ */
+export const toolGroupSchema = z.enum([
+  'fs',
+  'shell',
+  'git',
+  'mimir',
+  'observe',
+  'security',
+  'bus',
+]);
+
+export type ToolGroup = z.infer<typeof toolGroupSchema>;
+
+/**
+ * A single tool entry in the registry.
+ *
+ * **Canonical owner:** `plugin-ravn` (the TOOL_REGISTRY is defined alongside
+ * the persona editor; destructive-flag UI logic lives in ToolPicker).
+ *
+ * **Consumed by:**
+ * - `plugin-tyr` — workflow inspector shows tool access summary per persona.
+ * - Any plugin rendering a `ToolPicker` or tool allowlist.
+ */
+export const toolSchema = z.object({
+  /**
+   * Unique token identifying this tool (e.g. `read`, `bash`,
+   * `git.checkout`, `mimir.write`).
+   */
+  id: z.string().min(1),
+  /** Provider group — used to cluster tools in the ToolPicker modal. */
+  group: toolGroupSchema,
+  /**
+   * Whether this tool can cause irreversible side effects.
+   * Destructive tools render with a red warning stripe in the allow-list
+   * and require explicit acknowledgement in safe permission mode.
+   */
+  destructive: z.boolean(),
+  /** One-line description shown in the ToolPicker tooltip. */
+  desc: z.string().min(1),
+});
+
+export type Tool = z.infer<typeof toolSchema>;
+
+/**
+ * The complete set of tools available to ravens on this deployment.
+ * Plugins and personas reference tools by their `id`.
+ *
+ * **Canonical owner:** `plugin-ravn`.
+ *
+ * **Consumed by:**
+ * - `plugin-tyr` — validates that personas referenced in a workflow have
+ *   the tools required by their stage.
+ * - `plugin-mimir` — ravn-bindings screen shows tool access per raven.
+ */
+export const toolRegistrySchema = z.array(toolSchema);
+
+export type ToolRegistry = z.infer<typeof toolRegistrySchema>;

--- a/web-next/packages/domain/tsconfig.json
+++ b/web-next/packages/domain/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "**/*.stories.tsx"]
+}

--- a/web-next/packages/domain/tsup.config.ts
+++ b/web-next/packages/domain/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+});

--- a/web-next/pnpm-lock.yaml
+++ b/web-next/pnpm-lock.yaml
@@ -169,6 +169,19 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/domain:
+    dependencies:
+      zod:
+        specifier: ^3.24.1
+        version: 3.25.76
+    devDependencies:
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(postcss@8.5.10)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
   packages/plugin-hello:
     dependencies:
       '@niuulabs/plugin-sdk':


### PR DESCRIPTION
## Summary

Adds `packages/domain/` — the new `@niuulabs/domain` package: zero framework imports (no React, no TanStack), pure TypeScript types + Zod schemas for every entity that crosses plugin boundaries.

**Ticket:** NIU-652

**Types added:**

| Module | Types | Owner | Consumers |
|--------|-------|-------|-----------|
| `persona.ts` | `Persona`, `PersonaRole`, `LlmConfig`, `ConsumedEvent`, `ProducedEvent`, `FanInStrategy` (discriminated union × 6 strategies), `QuorumParams`, `WeightedScoreParams` | Ravn | Tyr, Mimir, Observatory |
| `mount.ts` | `Mount`, `MountRole`, `MountStatus` | Mimir | Ravn, Observatory, Tyr |
| `tool-registry.ts` | `Tool`, `ToolGroup`, `ToolRegistry` | Ravn | Tyr, Mimir |
| `event-catalog.ts` | `EventSpec`, `EventCatalog`, `FieldType` | Ravn | Tyr, Observatory |
| `budget.ts` | `BudgetState` | Ravn | Tyr, Observatory |
| `entity-type.ts` | `EntityType`, `TypeRegistry`, `EntityShape` (14 primitives), `EntityCategory` (8 categories) | Observatory | Ravn, Tyr, Mimir |

All types carry JSDoc identifying the canonical owner plugin and consumers. Shapes and categories match `web2/niuu_handoff/flokk_observatory/README.md`; Persona shape matches `web2/niuu_handoff/ravn/README.md`; `FanInStrategy` covers all six strategies in `FAN_IN_STRATEGIES`.

Also builds all workspace packages (their `dist/` was absent, causing pre-existing `Shell.test.tsx` and `HelloPage.test.tsx` failures unrelated to this PR).

## Test plan

- [x] `pnpm test` — 21 test files, 224 tests, all green
- [x] `pnpm typecheck` — zero errors across all packages
- [x] `pnpm lint` — ESLint clean
- [x] `pnpm format:check` — Prettier clean
- [x] `domain/src` coverage: **100%** statements / branches / functions / lines
- [x] Overall workspace coverage thresholds (≥85%) met

## Notes

- Linear MCP tools unavailable in this session — ticket NIU-652 status could not be updated programmatically. Please update manually to "In Review".

🤖 Generated with [Claude Code](https://claude.com/claude-code)