### PR TITLE
feat(web-next): lift shared HTTP client, identity + feature-catalog ports/adapters (NIU-688)

### DIFF
--- a/web-next/apps/niuu/src/main.tsx
+++ b/web-next/apps/niuu/src/main.tsx
@@ -3,7 +3,22 @@ import { createRoot } from 'react-dom/client';
 import '@niuulabs/design-tokens/tokens.css';
 import '@niuulabs/ui/styles.css';
 import '@niuulabs/shell/styles.css';
+import { setTokenProvider } from '@niuulabs/query';
 import { App } from './App';
+
+/**
+ * Dev / test hook: if a page script sets `window.__niuuPreAuth.getToken`
+ * before this module runs, we register it as the token provider.
+ * Used by Playwright e2e tests to inject Bearer tokens without a real OIDC flow.
+ * Only active in non-production builds.
+ */
+if (!import.meta.env.PROD) {
+  type PreAuth = { getToken?: () => string | null };
+  const preAuth = (window as Window & { __niuuPreAuth?: PreAuth }).__niuuPreAuth;
+  if (preAuth?.getToken) {
+    setTokenProvider(preAuth.getToken);
+  }
+}
 
 const el = document.getElementById('root');
 if (!el) throw new Error('#root not found');

--- a/web-next/apps/niuu/src/services.ts
+++ b/web-next/apps/niuu/src/services.ts
@@ -1,7 +1,14 @@
-import { createMockHelloService } from '@niuulabs/plugin-hello';
+import { createMockHelloService, buildHelloHttpAdapter } from '@niuulabs/plugin-hello';
+import { createApiClient } from '@niuulabs/query';
 import type { NiuuConfig, ServicesMap } from '@niuulabs/plugin-sdk';
 
-export function buildServices(_config: NiuuConfig): ServicesMap {
+export function buildServices(config: NiuuConfig): ServicesMap {
+  const helloSvc = config.services['hello'];
+  if (helloSvc?.mode === 'http' && helloSvc.baseUrl) {
+    return {
+      hello: buildHelloHttpAdapter(createApiClient(helloSvc.baseUrl)),
+    };
+  }
   return {
     hello: createMockHelloService(),
   };

--- a/web-next/apps/niuu/tsconfig.json
+++ b/web-next/apps/niuu/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
-    "noEmit": true
+    "noEmit": true,
+    "types": ["vite/client"]
   },
   "include": ["src/**/*"]
 }

--- a/web-next/e2e/http-client.spec.ts
+++ b/web-next/e2e/http-client.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Verifies that a request from the Hello plugin round-trips through the
+ * HTTP client with a Bearer token injected via the dev token-provider hook.
+ *
+ * Setup:
+ *  - page.addInitScript sets window.__niuuPreAuth before the app boots
+ *  - config.json is mocked to enable HTTP mode for the Hello service
+ *  - /api/niuu/hello/greetings is intercepted to capture headers + return data
+ */
+test('hello plugin round-trips through HTTP client with token provider', async ({ page }) => {
+  let capturedAuth: string | null = null;
+
+  // Inject the pre-auth hook BEFORE any app scripts run
+  await page.addInitScript(() => {
+    (window as Window & { __niuuPreAuth?: { getToken: () => string } }).__niuuPreAuth = {
+      getToken: () => 'test-token-e2e',
+    };
+  });
+
+  // Return HTTP-mode config so the app uses buildHelloHttpAdapter
+  await page.route('/config.json', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        theme: 'ice',
+        plugins: { hello: { enabled: true, order: 1 } },
+        services: { hello: { baseUrl: '/api/niuu/hello', mode: 'http' } },
+      }),
+    }),
+  );
+
+  // Intercept the greetings fetch, capture the Authorization header, return mock data
+  await page.route('/api/niuu/hello/greetings', (route) => {
+    capturedAuth = route.request().headers()['authorization'] ?? null;
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify([
+        { id: '1', text: 'hello via HTTP client', mood: 'warm' },
+        { id: '2', text: 'token provider wired', mood: 'curious' },
+      ]),
+    });
+  });
+
+  await page.goto('/');
+
+  // Shell and plugin title should render
+  await expect(page.getByText('hello · smoke test')).toBeVisible();
+
+  // Data from the mocked HTTP endpoint should appear
+  await expect(page.getByText('hello via HTTP client')).toBeVisible({ timeout: 5000 });
+  await expect(page.getByText('token provider wired')).toBeVisible();
+
+  // The HTTP client should have sent the Bearer token
+  expect(capturedAuth).toBe('Bearer test-token-e2e');
+});

--- a/web-next/packages/plugin-hello/src/adapters/http.test.ts
+++ b/web-next/packages/plugin-hello/src/adapters/http.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest';
+import { buildHelloHttpAdapter } from './http';
+import type { IHelloService } from '../ports';
+
+const greetings = [
+  { id: '1', text: 'hello via HTTP', mood: 'warm' as const },
+  { id: '2', text: 'second greeting', mood: 'cold' as const },
+];
+
+describe('buildHelloHttpAdapter', () => {
+  it('calls GET /greetings on the provided client', async () => {
+    const client = { get: vi.fn().mockResolvedValue(greetings) };
+    await buildHelloHttpAdapter(client).listGreetings();
+    expect(client.get).toHaveBeenCalledWith('/greetings');
+  });
+
+  it('returns the response as-is from the client', async () => {
+    const client = { get: vi.fn().mockResolvedValue(greetings) };
+    const result = await buildHelloHttpAdapter(client).listGreetings();
+    expect(result).toEqual(greetings);
+  });
+
+  it('propagates errors from the HTTP client', async () => {
+    const client = { get: vi.fn().mockRejectedValue(new Error('network error')) };
+    await expect(buildHelloHttpAdapter(client).listGreetings()).rejects.toThrow('network error');
+  });
+
+  it('satisfies IHelloService interface', () => {
+    const client = { get: vi.fn() };
+    const service: IHelloService = buildHelloHttpAdapter(client);
+    expect(typeof service.listGreetings).toBe('function');
+  });
+});

--- a/web-next/packages/plugin-hello/src/adapters/http.ts
+++ b/web-next/packages/plugin-hello/src/adapters/http.ts
@@ -1,0 +1,21 @@
+/**
+ * HTTP adapter for the Hello service.
+ *
+ * Accepts any HTTP client that has a `get` method — compatible with
+ * `createApiClient(basePath)` from @niuulabs/query.
+ */
+
+import type { Greeting, IHelloService } from '../ports';
+
+/** Minimal HTTP client — structurally compatible with ApiClient from @niuulabs/query. */
+interface HttpClient {
+  get<T>(endpoint: string): Promise<T>;
+}
+
+export function buildHelloHttpAdapter(client: HttpClient): IHelloService {
+  return {
+    async listGreetings(): Promise<Greeting[]> {
+      return client.get<Greeting[]>('/greetings');
+    },
+  };
+}

--- a/web-next/packages/plugin-hello/src/index.tsx
+++ b/web-next/packages/plugin-hello/src/index.tsx
@@ -10,4 +10,5 @@ export const helloPlugin = definePlugin({
 });
 
 export { createMockHelloService } from './adapters/mock';
+export { buildHelloHttpAdapter } from './adapters/http';
 export type { IHelloService, Greeting } from './ports';

--- a/web-next/packages/plugin-sdk/src/FeatureCatalog.test.tsx
+++ b/web-next/packages/plugin-sdk/src/FeatureCatalog.test.tsx
@@ -1,7 +1,8 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
 import { ConfigProvider } from './ConfigProvider';
 import { FeatureCatalogProvider, useFeatureCatalog } from './FeatureCatalog';
+import type { IFeatureCatalogService, FeatureModule } from './ports/feature-catalog.port';
 
 function Reader({ id }: { id: string }) {
   const { isEnabled, order } = useFeatureCatalog();
@@ -12,7 +13,7 @@ function Reader({ id }: { id: string }) {
   );
 }
 
-describe('FeatureCatalog', () => {
+describe('FeatureCatalog — config-only (no service)', () => {
   it('reads enabled + order from config', () => {
     render(
       <ConfigProvider
@@ -66,5 +67,94 @@ describe('FeatureCatalog', () => {
       ),
     ).toThrow(/FeatureCatalogProvider/);
     console.error = error;
+  });
+});
+
+describe('FeatureCatalog — service-driven', () => {
+  function makeService(modules: FeatureModule[]): IFeatureCatalogService {
+    return {
+      getFeatureModules: vi.fn().mockResolvedValue(modules),
+      getUserFeaturePreferences: vi.fn().mockResolvedValue([]),
+      updateUserFeaturePreferences: vi.fn().mockResolvedValue([]),
+      toggleFeature: vi.fn(),
+    };
+  }
+
+  it('uses service module data when service resolves', async () => {
+    const service = makeService([
+      {
+        key: 'users',
+        label: 'Users',
+        icon: 'Users',
+        scope: 'admin',
+        enabled: false,
+        defaultEnabled: true,
+        adminOnly: true,
+        order: 99,
+      },
+    ]);
+
+    render(
+      <ConfigProvider value={{ theme: 'ice', plugins: {}, services: {} }}>
+        <FeatureCatalogProvider service={service}>
+          <Reader id="users" />
+        </FeatureCatalogProvider>
+      </ConfigProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('out').textContent).toBe('false-99'));
+  });
+
+  it('falls back to config when service key is not in modules', async () => {
+    const service = makeService([]);
+
+    render(
+      <ConfigProvider
+        value={{ theme: 'ice', plugins: { tyr: { enabled: true, order: 4 } }, services: {} }}
+      >
+        <FeatureCatalogProvider service={service}>
+          <Reader id="tyr" />
+        </FeatureCatalogProvider>
+      </ConfigProvider>,
+    );
+
+    // Service resolves with empty list; tyr falls back to config
+    await waitFor(() => expect(screen.getByTestId('out').textContent).toBe('true-4'));
+  });
+
+  it('falls back gracefully when service rejects', async () => {
+    const service: IFeatureCatalogService = {
+      getFeatureModules: vi.fn().mockRejectedValue(new Error('unavailable')),
+      getUserFeaturePreferences: vi.fn(),
+      updateUserFeaturePreferences: vi.fn(),
+      toggleFeature: vi.fn(),
+    };
+
+    render(
+      <ConfigProvider
+        value={{ theme: 'ice', plugins: { hello: { enabled: true, order: 1 } }, services: {} }}
+      >
+        <FeatureCatalogProvider service={service}>
+          <Reader id="hello" />
+        </FeatureCatalogProvider>
+      </ConfigProvider>,
+    );
+
+    // Config fallback is immediate; service error is swallowed
+    expect(screen.getByTestId('out').textContent).toBe('true-1');
+  });
+
+  it('calls getFeatureModules on mount', async () => {
+    const service = makeService([]);
+
+    render(
+      <ConfigProvider value={{ theme: 'ice', plugins: {}, services: {} }}>
+        <FeatureCatalogProvider service={service}>
+          <Reader id="x" />
+        </FeatureCatalogProvider>
+      </ConfigProvider>,
+    );
+
+    await waitFor(() => expect(service.getFeatureModules).toHaveBeenCalledOnce());
   });
 });

--- a/web-next/packages/plugin-sdk/src/FeatureCatalog.tsx
+++ b/web-next/packages/plugin-sdk/src/FeatureCatalog.tsx
@@ -1,5 +1,6 @@
-import { createContext, useContext, useMemo, type ReactNode } from 'react';
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { useConfig } from './ConfigProvider';
+import type { IFeatureCatalogService, FeatureModule } from './ports/feature-catalog.port';
 
 export interface FeatureCatalog {
   isEnabled: (pluginId: string) => boolean;
@@ -9,20 +10,49 @@ export interface FeatureCatalog {
 const FeatureCatalogContext = createContext<FeatureCatalog | null>(null);
 
 interface FeatureCatalogProviderProps {
+  /** Optional service for runtime feature data from the backend. Falls back to config-only when omitted. */
+  service?: IFeatureCatalogService;
   overrides?: Partial<FeatureCatalog>;
   children: ReactNode;
 }
 
-export function FeatureCatalogProvider({ overrides, children }: FeatureCatalogProviderProps) {
+export function FeatureCatalogProvider({
+  service,
+  overrides,
+  children,
+}: FeatureCatalogProviderProps) {
   const config = useConfig();
+  const [modules, setModules] = useState<FeatureModule[]>([]);
+
+  useEffect(() => {
+    if (!service) return;
+    service
+      .getFeatureModules()
+      .then(setModules)
+      .catch(() => {
+        // silently fall back to config-only on service error
+      });
+  }, [service]);
 
   const catalog = useMemo<FeatureCatalog>(() => {
+    const moduleMap = new Map(modules.map((m) => [m.key, m]));
     return {
       isEnabled:
-        overrides?.isEnabled ?? ((pluginId: string) => config.plugins[pluginId]?.enabled !== false),
-      order: overrides?.order ?? ((pluginId: string) => config.plugins[pluginId]?.order ?? 100),
+        overrides?.isEnabled ??
+        ((key: string) => {
+          const mod = moduleMap.get(key);
+          if (mod !== undefined) return mod.enabled;
+          return config.plugins[key]?.enabled !== false;
+        }),
+      order:
+        overrides?.order ??
+        ((key: string) => {
+          const mod = moduleMap.get(key);
+          if (mod !== undefined) return mod.order;
+          return config.plugins[key]?.order ?? 100;
+        }),
     };
-  }, [config, overrides]);
+  }, [config, modules, overrides]);
 
   return (
     <FeatureCatalogContext.Provider value={catalog}>{children}</FeatureCatalogContext.Provider>

--- a/web-next/packages/plugin-sdk/src/adapters/feature-catalog.adapter.test.ts
+++ b/web-next/packages/plugin-sdk/src/adapters/feature-catalog.adapter.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  buildFeatureCatalogAdapter,
+  createMockFeatureCatalogService,
+} from './feature-catalog.adapter';
+import type { IFeatureCatalogService } from '../ports/feature-catalog.port';
+
+const mockApiModules = [
+  {
+    key: 'users',
+    label: 'Users',
+    icon: 'Users',
+    scope: 'admin',
+    enabled: true,
+    default_enabled: true,
+    admin_only: true,
+    order: 1,
+  },
+  {
+    key: 'tenants',
+    label: 'Tenants',
+    icon: 'Building2',
+    scope: 'admin',
+    enabled: true,
+    default_enabled: true,
+    admin_only: true,
+    order: 2,
+  },
+  {
+    key: 'tokens',
+    label: 'Access Tokens',
+    icon: 'ShieldCheck',
+    scope: 'user',
+    enabled: true,
+    default_enabled: true,
+    admin_only: false,
+    order: 1,
+  },
+  {
+    key: 'credentials',
+    label: 'Credentials',
+    icon: 'KeyRound',
+    scope: 'user',
+    enabled: true,
+    default_enabled: true,
+    admin_only: false,
+    order: 2,
+  },
+];
+
+const mockApiPrefs = [{ feature_key: 'users', visible: true, sort_order: 1 }];
+
+function makeClient() {
+  return {
+    get: vi.fn().mockImplementation((path: string) => {
+      if (path.includes('preferences')) return Promise.resolve(mockApiPrefs);
+      const scopeMatch = path.match(/scope=(\w+)/);
+      if (scopeMatch)
+        return Promise.resolve(mockApiModules.filter((f) => f.scope === scopeMatch[1]));
+      return Promise.resolve(mockApiModules);
+    }),
+    put: vi.fn().mockImplementation((_path: string, body: unknown) => Promise.resolve(body)),
+    patch: vi.fn().mockImplementation((path: string, body: { enabled: boolean }) => {
+      const keyMatch = path.match(/features\/(\w+)/);
+      const key = keyMatch?.[1] ?? 'unknown';
+      const base = mockApiModules.find((f) => f.key === key) ?? mockApiModules[0]!;
+      return Promise.resolve({ ...base, key, enabled: body.enabled });
+    }),
+  };
+}
+
+describe('buildFeatureCatalogAdapter', () => {
+  describe('getFeatureModules', () => {
+    it('maps snake_case API response to camelCase domain', async () => {
+      const service = buildFeatureCatalogAdapter(makeClient());
+      const modules = await service.getFeatureModules();
+      const first = modules[0]!;
+      expect(first).toHaveProperty('defaultEnabled');
+      expect(first).toHaveProperty('adminOnly');
+      expect(first.defaultEnabled).toBe(true);
+      expect(first.adminOnly).toBe(true);
+    });
+
+    it('returns all modules when no scope is provided', async () => {
+      const service = buildFeatureCatalogAdapter(makeClient());
+      const modules = await service.getFeatureModules();
+      expect(modules.length).toBe(4);
+      const scopes = new Set(modules.map((m) => m.scope));
+      expect(scopes.has('admin')).toBe(true);
+      expect(scopes.has('user')).toBe(true);
+    });
+
+    it('filters by admin scope', async () => {
+      const service = buildFeatureCatalogAdapter(makeClient());
+      const modules = await service.getFeatureModules('admin');
+      expect(modules.every((m) => m.scope === 'admin')).toBe(true);
+    });
+
+    it('filters by user scope', async () => {
+      const service = buildFeatureCatalogAdapter(makeClient());
+      const modules = await service.getFeatureModules('user');
+      expect(modules.every((m) => m.scope === 'user')).toBe(true);
+    });
+
+    it('appends ?scope= param when scope is provided', async () => {
+      const client = makeClient();
+      await buildFeatureCatalogAdapter(client).getFeatureModules('admin');
+      expect(client.get).toHaveBeenCalledWith('/features?scope=admin');
+    });
+
+    it('omits query param when no scope', async () => {
+      const client = makeClient();
+      await buildFeatureCatalogAdapter(client).getFeatureModules();
+      expect(client.get).toHaveBeenCalledWith('/features');
+    });
+  });
+
+  describe('getUserFeaturePreferences', () => {
+    it('maps snake_case preferences to camelCase', async () => {
+      const service = buildFeatureCatalogAdapter(makeClient());
+      const prefs = await service.getUserFeaturePreferences();
+      expect(prefs[0]).toEqual({ featureKey: 'users', visible: true, sortOrder: 1 });
+    });
+  });
+
+  describe('updateUserFeaturePreferences', () => {
+    it('sends camelCase body as snake_case and maps response back', async () => {
+      const client = makeClient();
+      client.put = vi
+        .fn()
+        .mockResolvedValue([{ feature_key: 'tokens', visible: false, sort_order: 2 }]);
+      const service = buildFeatureCatalogAdapter(client);
+      const result = await service.updateUserFeaturePreferences([
+        { featureKey: 'tokens', visible: false, sortOrder: 2 },
+      ]);
+      expect(result[0]).toEqual({ featureKey: 'tokens', visible: false, sortOrder: 2 });
+      const [, body] = client.put.mock.calls[0] as [string, unknown[]];
+      expect(body[0]).toEqual({ feature_key: 'tokens', visible: false, sort_order: 2 });
+    });
+  });
+
+  describe('toggleFeature', () => {
+    it('sends PATCH with enabled state and returns updated module', async () => {
+      const service = buildFeatureCatalogAdapter(makeClient());
+      const result = await service.toggleFeature('users', false);
+      expect(result.key).toBe('users');
+      expect(result.enabled).toBe(false);
+    });
+
+    it('can toggle feature on', async () => {
+      const service = buildFeatureCatalogAdapter(makeClient());
+      const result = await service.toggleFeature('tokens', true);
+      expect(result.key).toBe('tokens');
+      expect(result.enabled).toBe(true);
+    });
+  });
+
+  it('satisfies IFeatureCatalogService interface', () => {
+    const service: IFeatureCatalogService = buildFeatureCatalogAdapter(makeClient());
+    expect(typeof service.getFeatureModules).toBe('function');
+    expect(typeof service.getUserFeaturePreferences).toBe('function');
+    expect(typeof service.updateUserFeaturePreferences).toBe('function');
+    expect(typeof service.toggleFeature).toBe('function');
+  });
+});
+
+describe('createMockFeatureCatalogService', () => {
+  it('returns all 4 seed modules when no scope is given', async () => {
+    const service = createMockFeatureCatalogService();
+    const modules = await service.getFeatureModules();
+    expect(modules.length).toBe(4);
+  });
+
+  it('filters by admin scope', async () => {
+    const service = createMockFeatureCatalogService();
+    const modules = await service.getFeatureModules('admin');
+    expect(modules.length).toBeGreaterThan(0);
+    expect(modules.every((m) => m.scope === 'admin')).toBe(true);
+  });
+
+  it('filters by user scope', async () => {
+    const service = createMockFeatureCatalogService();
+    const modules = await service.getFeatureModules('user');
+    expect(modules.every((m) => m.scope === 'user')).toBe(true);
+  });
+
+  it('returns empty preferences', async () => {
+    const service = createMockFeatureCatalogService();
+    expect(await service.getUserFeaturePreferences()).toEqual([]);
+  });
+
+  it('echo-returns preferences on update', async () => {
+    const service = createMockFeatureCatalogService();
+    const input = [{ featureKey: 'tokens', visible: false, sortOrder: 2 }];
+    expect(await service.updateUserFeaturePreferences(input)).toEqual(input);
+  });
+
+  it('toggles a feature', async () => {
+    const service = createMockFeatureCatalogService();
+    const result = await service.toggleFeature('users', false);
+    expect(result.key).toBe('users');
+    expect(result.enabled).toBe(false);
+  });
+
+  it('satisfies IFeatureCatalogService interface', () => {
+    const service: IFeatureCatalogService = createMockFeatureCatalogService();
+    expect(typeof service.getFeatureModules).toBe('function');
+  });
+});

--- a/web-next/packages/plugin-sdk/src/adapters/feature-catalog.adapter.ts
+++ b/web-next/packages/plugin-sdk/src/adapters/feature-catalog.adapter.ts
@@ -1,0 +1,168 @@
+/**
+ * Feature catalog adapter — delegates to the Volundr API for now.
+ *
+ * When a shared /api/v1/features endpoint exists, update the base path in
+ * the factory call site — no other code changes needed.
+ */
+
+import type {
+  IFeatureCatalogService,
+  FeatureScope,
+  FeatureModule,
+  UserFeaturePreference,
+} from '../ports/feature-catalog.port';
+
+/** Minimal HTTP client interface — structurally compatible with ApiClient from @niuulabs/query. */
+interface HttpClient {
+  get<T>(endpoint: string): Promise<T>;
+  put<T>(endpoint: string, body: unknown): Promise<T>;
+  patch<T>(endpoint: string, body: unknown): Promise<T>;
+}
+
+interface ApiFeatureModule {
+  key: string;
+  label: string;
+  icon: string;
+  scope: string;
+  enabled: boolean;
+  default_enabled: boolean;
+  admin_only: boolean;
+  order: number;
+}
+
+interface ApiUserFeaturePreference {
+  feature_key: string;
+  visible: boolean;
+  sort_order: number;
+}
+
+function rowToModule(f: ApiFeatureModule): FeatureModule {
+  return {
+    key: f.key,
+    label: f.label,
+    icon: f.icon,
+    scope: f.scope as FeatureScope,
+    enabled: f.enabled,
+    defaultEnabled: f.default_enabled,
+    adminOnly: f.admin_only,
+    order: f.order,
+  };
+}
+
+function rowToPref(p: ApiUserFeaturePreference): UserFeaturePreference {
+  return { featureKey: p.feature_key, visible: p.visible, sortOrder: p.sort_order };
+}
+
+/**
+ * Build a feature-catalog service backed by a live HTTP client.
+ * Pass `createApiClient('/api/v1/volundr')` from @niuulabs/query.
+ */
+export function buildFeatureCatalogAdapter(client: HttpClient): IFeatureCatalogService {
+  return {
+    async getFeatureModules(scope?: FeatureScope): Promise<FeatureModule[]> {
+      const params = scope ? `?scope=${scope}` : '';
+      const response = await client.get<ApiFeatureModule[]>(`/features${params}`);
+      return response.map(rowToModule);
+    },
+
+    async getUserFeaturePreferences(): Promise<UserFeaturePreference[]> {
+      const response = await client.get<ApiUserFeaturePreference[]>('/features/preferences');
+      return response.map(rowToPref);
+    },
+
+    async updateUserFeaturePreferences(
+      preferences: UserFeaturePreference[],
+    ): Promise<UserFeaturePreference[]> {
+      const body = preferences.map((p) => ({
+        feature_key: p.featureKey,
+        visible: p.visible,
+        sort_order: p.sortOrder,
+      }));
+      const response = await client.put<ApiUserFeaturePreference[]>('/features/preferences', body);
+      return response.map(rowToPref);
+    },
+
+    async toggleFeature(key: string, enabled: boolean): Promise<FeatureModule> {
+      const response = await client.patch<ApiFeatureModule>(`/features/${key}`, { enabled });
+      return rowToModule(response);
+    },
+  };
+}
+
+/**
+ * In-memory mock — suitable for dev, Storybook, and tests.
+ */
+export function createMockFeatureCatalogService(): IFeatureCatalogService {
+  const all: FeatureModule[] = [
+    {
+      key: 'users',
+      label: 'Users',
+      icon: 'Users',
+      scope: 'admin',
+      enabled: true,
+      defaultEnabled: true,
+      adminOnly: true,
+      order: 1,
+    },
+    {
+      key: 'tenants',
+      label: 'Tenants',
+      icon: 'Building2',
+      scope: 'admin',
+      enabled: true,
+      defaultEnabled: true,
+      adminOnly: true,
+      order: 2,
+    },
+    {
+      key: 'tokens',
+      label: 'Access Tokens',
+      icon: 'ShieldCheck',
+      scope: 'user',
+      enabled: true,
+      defaultEnabled: true,
+      adminOnly: false,
+      order: 1,
+    },
+    {
+      key: 'credentials',
+      label: 'Credentials',
+      icon: 'KeyRound',
+      scope: 'user',
+      enabled: true,
+      defaultEnabled: true,
+      adminOnly: false,
+      order: 2,
+    },
+  ];
+
+  return {
+    async getFeatureModules(scope?: FeatureScope): Promise<FeatureModule[]> {
+      if (!scope) return all;
+      return all.filter((f) => f.scope === scope);
+    },
+
+    async getUserFeaturePreferences(): Promise<UserFeaturePreference[]> {
+      return [];
+    },
+
+    async updateUserFeaturePreferences(
+      prefs: UserFeaturePreference[],
+    ): Promise<UserFeaturePreference[]> {
+      return prefs;
+    },
+
+    async toggleFeature(key: string, enabled: boolean): Promise<FeatureModule> {
+      return {
+        key,
+        label: key,
+        icon: 'Box',
+        scope: 'user',
+        enabled,
+        defaultEnabled: true,
+        adminOnly: false,
+        order: 0,
+      };
+    },
+  };
+}

--- a/web-next/packages/plugin-sdk/src/adapters/identity.adapter.test.ts
+++ b/web-next/packages/plugin-sdk/src/adapters/identity.adapter.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+import { buildIdentityAdapter, createMockIdentityService } from './identity.adapter';
+import type { IIdentityService } from '../ports/identity.port';
+
+const apiResponse = {
+  user_id: 'u-1',
+  email: 'alice@example.com',
+  tenant_id: 'acme',
+  roles: ['admin', 'user'],
+  display_name: 'Alice',
+  status: 'active',
+};
+
+function makeClient(response = apiResponse) {
+  return { get: vi.fn().mockResolvedValue(response) };
+}
+
+describe('buildIdentityAdapter', () => {
+  it('maps snake_case API response to camelCase domain', async () => {
+    const service = buildIdentityAdapter(makeClient());
+    const identity = await service.getIdentity();
+    expect(identity.userId).toBe('u-1');
+    expect(identity.email).toBe('alice@example.com');
+    expect(identity.tenantId).toBe('acme');
+    expect(identity.roles).toEqual(['admin', 'user']);
+    expect(identity.displayName).toBe('Alice');
+    expect(identity.status).toBe('active');
+  });
+
+  it('calls GET /me on the provided client', async () => {
+    const client = makeClient();
+    await buildIdentityAdapter(client).getIdentity();
+    expect(client.get).toHaveBeenCalledWith('/me');
+  });
+
+  it('propagates errors from the HTTP client', async () => {
+    const client = { get: vi.fn().mockRejectedValue(new Error('network error')) };
+    await expect(buildIdentityAdapter(client).getIdentity()).rejects.toThrow('network error');
+  });
+
+  it('satisfies IIdentityService interface', () => {
+    const service: IIdentityService = buildIdentityAdapter(makeClient());
+    expect(typeof service.getIdentity).toBe('function');
+  });
+});
+
+describe('createMockIdentityService', () => {
+  it('returns a valid identity shape', async () => {
+    const service = createMockIdentityService();
+    const identity = await service.getIdentity();
+    expect(identity.userId).toBeTruthy();
+    expect(identity.email).toBeTruthy();
+    expect(identity.tenantId).toBeTruthy();
+    expect(Array.isArray(identity.roles)).toBe(true);
+    expect(identity.displayName).toBeTruthy();
+    expect(identity.status).toBeTruthy();
+  });
+
+  it('returns consistent dev defaults', async () => {
+    const service = createMockIdentityService();
+    const identity = await service.getIdentity();
+    expect(identity.userId).toBe('dev-user');
+    expect(identity.email).toBe('dev@localhost');
+    expect(identity.tenantId).toBe('default');
+    expect(identity.roles).toContain('volundr:admin');
+    expect(identity.displayName).toBe('Dev User');
+    expect(identity.status).toBe('active');
+  });
+
+  it('satisfies IIdentityService interface', () => {
+    const service: IIdentityService = createMockIdentityService();
+    expect(typeof service.getIdentity).toBe('function');
+  });
+});

--- a/web-next/packages/plugin-sdk/src/adapters/identity.adapter.ts
+++ b/web-next/packages/plugin-sdk/src/adapters/identity.adapter.ts
@@ -1,0 +1,65 @@
+/**
+ * Identity adapter — fetches the current user's identity from the API.
+ *
+ * Reuses the existing /api/v1/volundr/me endpoint. When a shared
+ * /api/v1/identity/me is available, update the base path in the factory
+ * call site — no other code changes needed.
+ */
+
+import type { AppIdentity, IIdentityService } from '../ports/identity.port';
+
+/** Minimal HTTP client interface — structurally compatible with ApiClient from @niuulabs/query. */
+interface HttpClient {
+  get<T>(endpoint: string): Promise<T>;
+}
+
+interface ApiIdentityResponse {
+  user_id: string;
+  email: string;
+  tenant_id: string;
+  roles: string[];
+  display_name: string;
+  status: string;
+}
+
+function rowToIdentity(r: ApiIdentityResponse): AppIdentity {
+  return {
+    userId: r.user_id,
+    email: r.email,
+    tenantId: r.tenant_id,
+    roles: r.roles,
+    displayName: r.display_name,
+    status: r.status,
+  };
+}
+
+/**
+ * Build an identity service backed by a live HTTP client.
+ * Pass `createApiClient('/api/v1/volundr')` from @niuulabs/query.
+ */
+export function buildIdentityAdapter(client: HttpClient): IIdentityService {
+  return {
+    async getIdentity(): Promise<AppIdentity> {
+      const r = await client.get<ApiIdentityResponse>('/me');
+      return rowToIdentity(r);
+    },
+  };
+}
+
+/**
+ * In-memory mock — suitable for dev, Storybook, and tests.
+ */
+export function createMockIdentityService(): IIdentityService {
+  return {
+    async getIdentity(): Promise<AppIdentity> {
+      return {
+        userId: 'dev-user',
+        email: 'dev@localhost',
+        tenantId: 'default',
+        roles: ['volundr:admin'],
+        displayName: 'Dev User',
+        status: 'active',
+      };
+    },
+  };
+}

--- a/web-next/packages/plugin-sdk/src/index.ts
+++ b/web-next/packages/plugin-sdk/src/index.ts
@@ -10,3 +10,19 @@ export {
   type PluginConfig,
   type ServiceConfig,
 } from './config';
+
+// Ports
+export type { AppIdentity, IIdentityService } from './ports/identity.port';
+export type {
+  FeatureScope,
+  FeatureModule,
+  UserFeaturePreference,
+  IFeatureCatalogService,
+} from './ports/feature-catalog.port';
+
+// Adapters
+export { buildIdentityAdapter, createMockIdentityService } from './adapters/identity.adapter';
+export {
+  buildFeatureCatalogAdapter,
+  createMockFeatureCatalogService,
+} from './adapters/feature-catalog.adapter';

--- a/web-next/packages/plugin-sdk/src/ports/feature-catalog.port.ts
+++ b/web-next/packages/plugin-sdk/src/ports/feature-catalog.port.ts
@@ -1,0 +1,34 @@
+/**
+ * Feature catalog port — manages feature modules and per-user visibility preferences.
+ *
+ * The Settings and Admin pages use this to discover which sections to render,
+ * independently of any specific module's service.
+ */
+
+export type FeatureScope = 'admin' | 'user' | 'session';
+
+export interface FeatureModule {
+  key: string;
+  label: string;
+  icon: string;
+  scope: FeatureScope;
+  enabled: boolean;
+  defaultEnabled: boolean;
+  adminOnly: boolean;
+  order: number;
+}
+
+export interface UserFeaturePreference {
+  featureKey: string;
+  visible: boolean;
+  sortOrder: number;
+}
+
+export interface IFeatureCatalogService {
+  getFeatureModules(scope?: FeatureScope): Promise<FeatureModule[]>;
+  getUserFeaturePreferences(): Promise<UserFeaturePreference[]>;
+  updateUserFeaturePreferences(
+    preferences: UserFeaturePreference[],
+  ): Promise<UserFeaturePreference[]>;
+  toggleFeature(key: string, enabled: boolean): Promise<FeatureModule>;
+}

--- a/web-next/packages/plugin-sdk/src/ports/identity.port.ts
+++ b/web-next/packages/plugin-sdk/src/ports/identity.port.ts
@@ -1,0 +1,19 @@
+/**
+ * Identity port — IDP-agnostic interface for reading the current user's identity.
+ *
+ * Consumers import from here instead of coupling to any specific service or IDP.
+ * When the identity endpoint changes, only the adapter needs to update.
+ */
+
+export interface AppIdentity {
+  userId: string;
+  email: string;
+  tenantId: string;
+  roles: string[];
+  displayName: string;
+  status: string;
+}
+
+export interface IIdentityService {
+  getIdentity(): Promise<AppIdentity>;
+}

--- a/web-next/packages/query/src/http-client.test.ts
+++ b/web-next/packages/query/src/http-client.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createApiClient, setTokenProvider, getAccessToken, ApiClientError } from './http-client';
+
+function makeFetch(status: number, body: unknown, ok = status >= 200 && status < 300) {
+  return vi.fn().mockResolvedValue({
+    status,
+    ok,
+    json: vi.fn().mockResolvedValue(body),
+  });
+}
+
+describe('setTokenProvider / getAccessToken', () => {
+  afterEach(() => setTokenProvider(null));
+
+  it('returns null when no provider is set', () => {
+    setTokenProvider(null);
+    expect(getAccessToken()).toBeNull();
+  });
+
+  it('returns the token from the registered provider', () => {
+    setTokenProvider(() => 'test-token');
+    expect(getAccessToken()).toBe('test-token');
+  });
+
+  it('accepts null to clear the provider', () => {
+    setTokenProvider(() => 'tok');
+    setTokenProvider(null);
+    expect(getAccessToken()).toBeNull();
+  });
+});
+
+describe('createApiClient', () => {
+  const BASE = '/api/v1/test';
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    setTokenProvider(null);
+    fetchMock = makeFetch(200, { ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    setTokenProvider(null);
+  });
+
+  it('GET prepends basePath and sends GET method', async () => {
+    const client = createApiClient(BASE);
+    await client.get('/items');
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${BASE}/items`,
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('POST sends body as JSON', async () => {
+    const client = createApiClient(BASE);
+    await client.post('/items', { name: 'x' });
+    const [, opts] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(opts.method).toBe('POST');
+    expect(opts.body).toBe(JSON.stringify({ name: 'x' }));
+  });
+
+  it('PUT sends body as JSON', async () => {
+    const client = createApiClient(BASE);
+    await client.put('/items/1', { name: 'y' });
+    const [, opts] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(opts.method).toBe('PUT');
+    expect(opts.body).toBe(JSON.stringify({ name: 'y' }));
+  });
+
+  it('PATCH sends body as JSON', async () => {
+    const client = createApiClient(BASE);
+    await client.patch('/items/1', { active: false });
+    const [, opts] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(opts.method).toBe('PATCH');
+  });
+
+  it('DELETE with no body omits body', async () => {
+    const client = createApiClient(BASE);
+    await client.delete('/items/1');
+    const [, opts] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(opts.method).toBe('DELETE');
+    expect(opts.body).toBeUndefined();
+  });
+
+  it('DELETE with body includes body', async () => {
+    const client = createApiClient(BASE);
+    await client.delete('/items/1', { reason: 'test' });
+    const [, opts] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(opts.body).toBe(JSON.stringify({ reason: 'test' }));
+  });
+
+  it('injects Authorization header when token provider is set', async () => {
+    setTokenProvider(() => 'bearer-xyz');
+    const client = createApiClient(BASE);
+    await client.get('/items');
+    const [, opts] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect((opts.headers as Record<string, string>)['Authorization']).toBe('Bearer bearer-xyz');
+  });
+
+  it('omits Authorization header when token is null', async () => {
+    setTokenProvider(() => null);
+    const client = createApiClient(BASE);
+    await client.get('/items');
+    const [, opts] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect((opts.headers as Record<string, string>)['Authorization']).toBeUndefined();
+  });
+
+  it('returns undefined for 204 No Content without parsing body', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ status: 204, ok: true, json: vi.fn() }));
+    const client = createApiClient(BASE);
+    const result = await client.delete('/items/1');
+    expect(result).toBeUndefined();
+  });
+
+  it('throws ApiClientError on non-ok response', async () => {
+    vi.stubGlobal('fetch', makeFetch(404, { detail: 'not found' }, false));
+    const client = createApiClient(BASE);
+    await expect(client.get('/missing')).rejects.toThrow(ApiClientError);
+  });
+
+  it('ApiClientError carries status and detail', async () => {
+    vi.stubGlobal('fetch', makeFetch(422, { detail: 'invalid input' }, false));
+    const client = createApiClient(BASE);
+    try {
+      await client.get('/bad');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiClientError);
+      expect((err as ApiClientError).status).toBe(422);
+      expect((err as ApiClientError).detail).toBe('invalid input');
+    }
+  });
+
+  it('uses "Unknown error" when detail field is missing', async () => {
+    vi.stubGlobal('fetch', makeFetch(500, {}, false));
+    const client = createApiClient(BASE);
+    try {
+      await client.get('/boom');
+    } catch (err) {
+      expect((err as ApiClientError).detail).toBe('Unknown error');
+    }
+  });
+});

--- a/web-next/packages/query/src/http-client.ts
+++ b/web-next/packages/query/src/http-client.ts
@@ -1,0 +1,117 @@
+/**
+ * HTTP Client Factory
+ *
+ * Creates API clients scoped to a specific backend base path.
+ * Each service has its own client: /api/v1/volundr, /api/v1/tyr, etc.
+ */
+
+export interface ApiError {
+  detail: string;
+}
+
+export class ApiClientError extends Error {
+  status: number;
+  detail?: string;
+
+  constructor(message: string, status: number, detail?: string) {
+    super(message);
+    this.name = 'ApiClientError';
+    this.status = status;
+    this.detail = detail;
+  }
+}
+
+export interface ApiClient {
+  get<T>(endpoint: string): Promise<T>;
+  post<T>(endpoint: string, body?: unknown): Promise<T>;
+  put<T>(endpoint: string, body: unknown): Promise<T>;
+  patch<T>(endpoint: string, body: unknown): Promise<T>;
+  delete<T>(endpoint: string, body?: unknown): Promise<T>;
+}
+
+/**
+ * Global token provider. Set by AuthProvider to inject Bearer tokens.
+ * Returns null when auth is disabled (dev / allow-all mode).
+ */
+let tokenProvider: (() => string | null) | null = null;
+
+/**
+ * Register a function that returns the current access token.
+ * Called once by AuthProvider on mount.
+ */
+export function setTokenProvider(provider: (() => string | null) | null): void {
+  tokenProvider = provider;
+}
+
+/**
+ * Return the current access token, or null when auth is disabled.
+ */
+export function getAccessToken(): string | null {
+  return tokenProvider?.() ?? null;
+}
+
+/**
+ * Create an API client for a specific service base path.
+ * @param basePath - e.g. '/api/v1/volundr'
+ */
+export function createApiClient(basePath: string): ApiClient {
+  async function request<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
+    const url = `${basePath}${endpoint}`;
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      ...(options.headers as Record<string, string>),
+    };
+
+    const token = tokenProvider?.();
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    const config: RequestInit = { ...options, headers };
+    const response = await fetch(url, config);
+
+    if (response.status === 204) {
+      return undefined as T;
+    }
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      const errorDetail = (data as ApiError)?.detail ?? 'Unknown error';
+      throw new ApiClientError(
+        `API request failed: ${response.status}`,
+        response.status,
+        errorDetail,
+      );
+    }
+
+    return data as T;
+  }
+
+  return {
+    get<T>(endpoint: string): Promise<T> {
+      return request<T>(endpoint, { method: 'GET' });
+    },
+    post<T>(endpoint: string, body?: unknown): Promise<T> {
+      return request<T>(endpoint, {
+        method: 'POST',
+        body: body ? JSON.stringify(body) : undefined,
+      });
+    },
+    put<T>(endpoint: string, body: unknown): Promise<T> {
+      return request<T>(endpoint, { method: 'PUT', body: JSON.stringify(body) });
+    },
+    patch<T>(endpoint: string, body: unknown): Promise<T> {
+      return request<T>(endpoint, { method: 'PATCH', body: JSON.stringify(body) });
+    },
+    delete<T>(endpoint: string, body?: unknown): Promise<T> {
+      const opts: RequestInit = { method: 'DELETE' };
+      if (body !== undefined) {
+        opts.headers = { 'Content-Type': 'application/json' };
+        opts.body = JSON.stringify(body);
+      }
+      return request<T>(endpoint, opts);
+    },
+  };
+}

--- a/web-next/packages/query/src/index.ts
+++ b/web-next/packages/query/src/index.ts
@@ -1,3 +1,12 @@
+export {
+  createApiClient,
+  setTokenProvider,
+  getAccessToken,
+  ApiClientError,
+  type ApiClient,
+  type ApiError,
+} from './http-client';
+
 import { QueryClient, type QueryClientConfig } from '@tanstack/react-query';
 
 export function createQueryClient(overrides: QueryClientConfig = {}): QueryClient {


### PR DESCRIPTION
## Summary

- **`@niuulabs/query`** — new `createApiClient()`, `ApiClient`, `ApiClientError`, `setTokenProvider()`, `getAccessToken()` — HTTP client copied from `web/src/modules/shared/api/client.ts`. Exports appended to `@niuulabs/query` index.

- **`@niuulabs/plugin-sdk`** — new `ports/identity.port.ts` (`IIdentityService`, `AppIdentity`) and `ports/feature-catalog.port.ts` (`IFeatureCatalogService`, `FeatureModule`, `FeatureScope`, `UserFeaturePreference`) copied from `web/src/modules/shared/ports/`. New `adapters/identity.adapter.ts` and `adapters/feature-catalog.adapter.ts` use a local structural `HttpClient` interface (no cross-package runtime dep), adapted from `web/src/modules/shared/adapters/`.

- **`FeatureCatalogProvider`** — accepts optional `service?: IFeatureCatalogService`; when provided, calls `getFeatureModules()` in a `useEffect` and merges results into `isEnabled`/`order`. Falls back to config-only when the service is omitted or errors.

- **`@niuulabs/plugin-hello`** — new `buildHelloHttpAdapter(client)` in `src/adapters/http.ts`. Exported from the package index.

- **`apps/niuu`** — `services.ts` routes `mode:'http'` config to `buildHelloHttpAdapter(createApiClient(baseUrl))`; `main.tsx` reads `window.__niuuPreAuth.getToken` (dev/test only) and registers it with `setTokenProvider`.

- **`e2e/http-client.spec.ts`** — Playwright test: `page.addInitScript` injects token provider, `page.route` mocks config (HTTP mode) and greetings endpoint, asserts data renders and captured `Authorization` header is `Bearer test-token-e2e`.

- **Hooks audit**: `useSkuldChat`, `useAgentDetail`, `useRoomState` are all tightly coupled to the Skuld WebSocket protocol and old module registry — skipped per task rules.

## Test plan

- [x] `pnpm run test -- --run` — 19 test files, 85 tests, all green
- [x] Coverage: 99%+ statements/lines, 98%+ functions, 91%+ branches (thresholds: 85%)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm format:check` — clean (Prettier applied)
- [ ] CI — awaiting on push
- [ ] `pnpm test:e2e` — requires running dev server; Playwright spec added

## Notes

- No imports from `web/` — all code copied and re-homed per rule 8 in `web-next/CLAUDE.md`
- Linear ticket NIU-688 could not be updated via MCP tools (tools not available in this session); please update manually if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)