### PR TITLE
feat(shell): wire TanStack Router with plugin-contributed routes (NIU-649)

### DIFF
--- a/web-next/e2e/smoke.spec.ts
+++ b/web-next/e2e/smoke.spec.ts
@@ -8,3 +8,29 @@ test('niuu boots and hello plugin renders', async ({ page }) => {
   ).toBeVisible();
   await expect(page.getByText('hello from the mock adapter')).toBeVisible({ timeout: 5000 });
 });
+
+test('deep-link /hello renders hello page directly', async ({ page }) => {
+  await page.goto('/hello');
+  await expect(page.getByText('hello · smoke test')).toBeVisible();
+  await expect(page.getByText('hello from the mock adapter')).toBeVisible({ timeout: 5000 });
+});
+
+test('navigating away from /hello and back preserves the shell', async ({ page }) => {
+  await page.goto('/hello');
+  await expect(page.getByText('hello from the mock adapter')).toBeVisible({ timeout: 5000 });
+
+  // Navigate to root (which redirects back to /hello, the only plugin)
+  await page.goto('/');
+  await expect(page.getByText('hello · smoke test')).toBeVisible();
+  await expect(page.getByText('hello from the mock adapter')).toBeVisible({ timeout: 5000 });
+
+  // Browser back button goes back to /hello cleanly
+  await page.goBack();
+  await expect(page.getByText('hello · smoke test')).toBeVisible();
+});
+
+test('unknown route shows not-found page', async ({ page }) => {
+  await page.goto('/this-route-does-not-exist');
+  await expect(page.getByText('404')).toBeVisible();
+  await expect(page.getByText('Page not found.')).toBeVisible();
+});

--- a/web-next/packages/plugin-hello/package.json
+++ b/web-next/packages/plugin-hello/package.json
@@ -26,6 +26,7 @@
   },
   "peerDependencies": {
     "@tanstack/react-query": "^5.62.0",
+    "@tanstack/react-router": "^1.95.0",
     "react": "^19.0.0"
   },
   "dependencies": {
@@ -34,6 +35,7 @@
   },
   "devDependencies": {
     "@tanstack/react-query": "^5.62.0",
+    "@tanstack/react-router": "^1.95.0",
     "@types/react": "^19.0.7",
     "react": "^19.0.0",
     "tsup": "^8.3.5",

--- a/web-next/packages/plugin-hello/src/index.tsx
+++ b/web-next/packages/plugin-hello/src/index.tsx
@@ -1,3 +1,4 @@
+import { createRoute } from '@tanstack/react-router';
 import { definePlugin } from '@niuulabs/plugin-sdk';
 import { HelloPage } from './ui/HelloPage';
 
@@ -6,7 +7,13 @@ export const helloPlugin = definePlugin({
   rune: 'ᚺ',
   title: 'Hello',
   subtitle: 'smoke test plugin',
-  render: () => <HelloPage />,
+  routes: (rootRoute) => [
+    createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/hello',
+      component: HelloPage,
+    }),
+  ],
 });
 
 export { createMockHelloService } from './adapters/mock';

--- a/web-next/packages/shell/src/NotFoundPage.test.tsx
+++ b/web-next/packages/shell/src/NotFoundPage.test.tsx
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { NotFoundPage } from './NotFoundPage';
+
+describe('NotFoundPage', () => {
+  it('renders the 404 heading', () => {
+    render(<NotFoundPage />);
+    expect(screen.getByRole('heading', { name: '404' })).toBeInTheDocument();
+  });
+
+  it('renders the page not found message', () => {
+    render(<NotFoundPage />);
+    expect(screen.getByText('Page not found.')).toBeInTheDocument();
+  });
+});

--- a/web-next/packages/shell/src/NotFoundPage.tsx
+++ b/web-next/packages/shell/src/NotFoundPage.tsx
@@ -1,0 +1,8 @@
+export function NotFoundPage() {
+  return (
+    <div style={{ padding: 'var(--space-6)' }}>
+      <h2 style={{ margin: '0 0 var(--space-2)' }}>404</h2>
+      <p style={{ color: 'var(--color-text-secondary)', margin: 0 }}>Page not found.</p>
+    </div>
+  );
+}

--- a/web-next/packages/shell/src/NotFoundPage.tsx
+++ b/web-next/packages/shell/src/NotFoundPage.tsx
@@ -1,8 +1,8 @@
 export function NotFoundPage() {
   return (
-    <div style={{ padding: 'var(--space-6)' }}>
-      <h2 style={{ margin: '0 0 var(--space-2)' }}>404</h2>
-      <p style={{ color: 'var(--color-text-secondary)', margin: 0 }}>Page not found.</p>
+    <div className="p-6">
+      <h2 className="mb-2">404</h2>
+      <p className="text-text-secondary m-0">Page not found.</p>
     </div>
   );
 }

--- a/web-next/packages/shell/src/Shell.stories.tsx
+++ b/web-next/packages/shell/src/Shell.stories.tsx
@@ -1,0 +1,120 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { createMemoryHistory } from '@tanstack/react-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  ConfigProvider,
+  FeatureCatalogProvider,
+  ServicesProvider,
+  definePlugin,
+} from '@niuulabs/plugin-sdk';
+import { Shell } from './Shell';
+
+// ---------------------------------------------------------------------------
+// Mock plugins for stories
+// ---------------------------------------------------------------------------
+
+const mockPluginA = definePlugin({
+  id: 'alpha',
+  rune: 'ᚨ',
+  title: 'Alpha',
+  subtitle: 'first plugin',
+  render: () => (
+    <div style={{ padding: 'var(--space-6)', color: 'var(--color-text-primary)' }}>
+      <h2 style={{ margin: '0 0 var(--space-2)' }}>Alpha</h2>
+      <p style={{ color: 'var(--color-text-secondary)', margin: 0 }}>
+        Content area for the Alpha plugin.
+      </p>
+    </div>
+  ),
+});
+
+const mockPluginB = definePlugin({
+  id: 'beta',
+  rune: 'ᛒ',
+  title: 'Beta',
+  subtitle: 'second plugin',
+  render: () => (
+    <div style={{ padding: 'var(--space-6)', color: 'var(--color-text-primary)' }}>
+      <h2 style={{ margin: '0 0 var(--space-2)' }}>Beta</h2>
+      <p style={{ color: 'var(--color-text-secondary)', margin: 0 }}>
+        Content area for the Beta plugin.
+      </p>
+    </div>
+  ),
+});
+
+// ---------------------------------------------------------------------------
+// Storybook wrapper — provides required context
+// ---------------------------------------------------------------------------
+
+const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+function ShellStoryWrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <QueryClientProvider client={qc}>
+      <ConfigProvider value={{ theme: 'ice', plugins: {}, services: {} }}>
+        <ServicesProvider services={{}}>
+          <FeatureCatalogProvider>{children}</FeatureCatalogProvider>
+        </ServicesProvider>
+      </ConfigProvider>
+    </QueryClientProvider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Meta
+// ---------------------------------------------------------------------------
+
+const meta: Meta<typeof Shell> = {
+  title: 'Shell/Shell',
+  component: Shell,
+  decorators: [
+    (Story) => (
+      <ShellStoryWrapper>
+        <Story />
+      </ShellStoryWrapper>
+    ),
+  ],
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Shell>;
+
+// ---------------------------------------------------------------------------
+// Stories
+// ---------------------------------------------------------------------------
+
+/** Two plugins loaded; starts on the Alpha plugin (first enabled). */
+export const TwoPlugins: Story = {
+  args: {
+    plugins: [mockPluginA, mockPluginB],
+    _testHistory: createMemoryHistory({ initialEntries: ['/alpha'] }),
+  },
+};
+
+/** Single plugin loaded — rail has only one item. */
+export const SinglePlugin: Story = {
+  args: {
+    plugins: [mockPluginA],
+    _testHistory: createMemoryHistory({ initialEntries: ['/alpha'] }),
+  },
+};
+
+/** No plugins — empty shell with no rail items. */
+export const NoPlugins: Story = {
+  args: {
+    plugins: [],
+    _testHistory: createMemoryHistory({ initialEntries: ['/'] }),
+  },
+};
+
+/** Shell with a deep-linked route at /beta pre-selected. */
+export const DeepLinkedBeta: Story = {
+  args: {
+    plugins: [mockPluginA, mockPluginB],
+    _testHistory: createMemoryHistory({ initialEntries: ['/beta'] }),
+  },
+};

--- a/web-next/packages/shell/src/Shell.test.tsx
+++ b/web-next/packages/shell/src/Shell.test.tsx
@@ -1,8 +1,10 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import { createMemoryHistory } from '@tanstack/react-router';
 import { ConfigProvider, FeatureCatalogProvider, definePlugin } from '@niuulabs/plugin-sdk';
 import { Shell } from './Shell';
 
+// Plugins that use render() (no routes) — cover the render-fallback path.
 const pluginA = definePlugin({
   id: 'alpha',
   rune: 'ᚨ',
@@ -36,30 +38,64 @@ function wrap(
   );
 }
 
+/** A memory history pre-navigated to a path — keeps test runs isolated. */
+function memHistory(path: string) {
+  return createMemoryHistory({ initialEntries: [path] });
+}
+
 describe('Shell', () => {
   afterEach(() => {
     cleanup();
     localStorage.clear();
   });
 
-  it('renders the first enabled plugin by default', () => {
-    wrap(<Shell plugins={[pluginA, pluginB]} />);
-    expect(screen.getByTestId('alpha-content')).toBeInTheDocument();
+  it('renders the first enabled plugin by default', async () => {
+    wrap(<Shell plugins={[pluginA, pluginB]} _testHistory={memHistory('/')} />);
+    // Index route redirects to /alpha (first enabled plugin)
+    await waitFor(() => {
+      expect(screen.getByTestId('alpha-content')).toBeInTheDocument();
+    });
     expect(screen.queryByTestId('beta-content')).not.toBeInTheDocument();
   });
 
-  it('switches active plugin on rail click and persists to localStorage', () => {
-    wrap(<Shell plugins={[pluginA, pluginB]} />);
+  it('renders a plugin directly when memory history starts at its path', async () => {
+    wrap(<Shell plugins={[pluginA, pluginB]} _testHistory={memHistory('/beta')} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('beta-content')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('alpha-content')).not.toBeInTheDocument();
+  });
+
+  it('switches active plugin on rail click and persists to localStorage', async () => {
+    wrap(<Shell plugins={[pluginA, pluginB]} _testHistory={memHistory('/')} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('alpha-content')).toBeInTheDocument();
+    });
+
     fireEvent.click(screen.getByTitle('Beta · second'));
-    expect(screen.getByTestId('beta-content')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('beta-content')).toBeInTheDocument();
+    });
     expect(localStorage.getItem('niuu.active')).toBe('beta');
   });
 
-  it('hides plugins disabled via config', () => {
-    wrap(<Shell plugins={[pluginA, pluginB]} />, {
+  it('hides plugins disabled via config', async () => {
+    wrap(<Shell plugins={[pluginA, pluginB]} _testHistory={memHistory('/')} />, {
       alpha: { enabled: false, order: 1 },
     });
-    expect(screen.queryByTitle('Alpha · first')).not.toBeInTheDocument();
-    expect(screen.getByTestId('beta-content')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByTitle('Alpha · first')).not.toBeInTheDocument();
+      expect(screen.getByTestId('beta-content')).toBeInTheDocument();
+    });
+  });
+
+  it('localStorage.niuu.active is written from the router state, not vice-versa', async () => {
+    wrap(<Shell plugins={[pluginA, pluginB]} _testHistory={memHistory('/beta')} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('beta-content')).toBeInTheDocument();
+    });
+    // localStorage should have been updated from the route, not from a stored value
+    expect(localStorage.getItem('niuu.active')).toBe('beta');
   });
 });

--- a/web-next/packages/shell/src/Shell.tsx
+++ b/web-next/packages/shell/src/Shell.tsx
@@ -1,12 +1,7 @@
 import { useMemo, useState, useCallback } from 'react';
 import { RouterProvider } from '@tanstack/react-router';
 import type { RouterHistory } from '@tanstack/react-router';
-import {
-  useConfig,
-  useFeatureCatalog,
-  type PluginDescriptor,
-  type PluginCtx,
-} from '@niuulabs/plugin-sdk';
+import { useFeatureCatalog, type PluginDescriptor, type PluginCtx } from '@niuulabs/plugin-sdk';
 import { ShellContext } from './ShellContext';
 import { composeRouter } from './composeRouter';
 
@@ -19,7 +14,6 @@ interface ShellProps {
 }
 
 export function Shell({ plugins, brand = 'ᚾ', version = '0.0.1', _testHistory }: ShellProps) {
-  const config = useConfig();
   const features = useFeatureCatalog();
 
   const enabled = useMemo(
@@ -44,10 +38,6 @@ export function Shell({ plugins, brand = 'ᚾ', version = '0.0.1', _testHistory 
     () => composeRouter(enabled, { history: _testHistory }),
     [enabled, _testHistory],
   );
-
-  // useConfig is called to satisfy the hook contract; the value is only
-  // consumed downstream in ShellLayout (which reads it from context).
-  void config;
 
   return (
     <ShellContext.Provider value={{ enabled, brand, version, ctx }}>

--- a/web-next/packages/shell/src/Shell.tsx
+++ b/web-next/packages/shell/src/Shell.tsx
@@ -1,21 +1,24 @@
-import { useMemo, useState, useCallback, type ReactNode } from 'react';
-import clsx from 'clsx';
+import { useMemo, useState, useCallback } from 'react';
+import { RouterProvider } from '@tanstack/react-router';
+import type { RouterHistory } from '@tanstack/react-router';
 import {
   useConfig,
   useFeatureCatalog,
   type PluginDescriptor,
   type PluginCtx,
 } from '@niuulabs/plugin-sdk';
-import { LiveBadge, Kbd } from '@niuulabs/ui';
-import './Shell.css';
+import { ShellContext } from './ShellContext';
+import { composeRouter } from './composeRouter';
 
 interface ShellProps {
   plugins: PluginDescriptor[];
   brand?: string;
   version?: string;
+  /** @internal Override the router history — for tests and Storybook only. */
+  _testHistory?: RouterHistory;
 }
 
-export function Shell({ plugins, brand = 'ᚾ', version = '0.0.1' }: ShellProps) {
+export function Shell({ plugins, brand = 'ᚾ', version = '0.0.1', _testHistory }: ShellProps) {
   const config = useConfig();
   const features = useFeatureCatalog();
 
@@ -27,93 +30,28 @@ export function Shell({ plugins, brand = 'ᚾ', version = '0.0.1' }: ShellProps)
     [plugins, features],
   );
 
-  const [activeId, setActiveId] = useState<string | null>(() => {
-    const stored = typeof window !== 'undefined' ? localStorage.getItem('niuu.active') : null;
-    if (stored && enabled.some((p) => p.id === stored)) return stored;
-    return enabled[0]?.id ?? null;
-  });
-
-  const active = enabled.find((p) => p.id === activeId) ?? enabled[0] ?? null;
-
-  const handleSelect = useCallback((id: string) => {
-    setActiveId(id);
-    if (typeof window !== 'undefined') localStorage.setItem('niuu.active', id);
-  }, []);
-
   const [tweaks, setTweaks] = useState<Record<string, unknown>>({});
   const setTweak = useCallback((key: string, value: unknown) => {
     setTweaks((t) => ({ ...t, [key]: value }));
   }, []);
 
-  const ctx: PluginCtx = { tweaks, setTweak };
+  const ctx: PluginCtx = useMemo(() => ({ tweaks, setTweak }), [tweaks, setTweak]);
 
-  const subnavNode: ReactNode = active?.subnav?.(ctx) ?? null;
+  // Rebuild the router whenever the enabled plugin set changes. Passing
+  // _testHistory lets tests inject a memory history to avoid clobbering
+  // window.location between specs.
+  const router = useMemo(
+    () => composeRouter(enabled, { history: _testHistory }),
+    [enabled, _testHistory],
+  );
+
+  // useConfig is called to satisfy the hook contract; the value is only
+  // consumed downstream in ShellLayout (which reads it from context).
+  void config;
 
   return (
-    <div
-      className={clsx('niuu-shell', !subnavNode && 'niuu-shell--no-subnav')}
-      data-theme={config.theme}
-    >
-      <aside className="niuu-shell__rail">
-        <div className="niuu-shell__rail-brand" title="Niuu">
-          {brand}
-        </div>
-        {enabled.map((p) => (
-          <button
-            key={p.id}
-            type="button"
-            className={clsx(
-              'niuu-shell__rail-item',
-              active?.id === p.id && 'niuu-shell__rail-item--active',
-            )}
-            title={`${p.title} · ${p.subtitle}`}
-            onClick={() => handleSelect(p.id)}
-          >
-            {p.rune}
-          </button>
-        ))}
-        <div className="niuu-shell__rail-spacer" />
-        <div className="niuu-shell__rail-foot">v{version}</div>
-      </aside>
-
-      <header className="niuu-shell__topbar">
-        <div className="niuu-shell__topbar-title">
-          {active && (
-            <>
-              <h1>{active.title}</h1>
-              <span className="niuu-shell__topbar-subtitle">{active.subtitle}</span>
-            </>
-          )}
-        </div>
-        <div className="niuu-shell__topbar-right">
-          {active?.topbarRight?.(ctx)}
-          <LiveBadge />
-          <Kbd>⌘K</Kbd>
-        </div>
-      </header>
-
-      {subnavNode && <nav className="niuu-shell__subnav">{subnavNode}</nav>}
-
-      <main className="niuu-shell__content">
-        {active?.render ? (
-          active.render(ctx)
-        ) : (
-          <div style={{ padding: 'var(--space-6)' }}>
-            <p>No plugin selected.</p>
-          </div>
-        )}
-      </main>
-
-      <footer className="niuu-shell__footer">
-        <div>
-          {active && <code>plugin:{active.id}</code>}
-          <span className="niuu-shell__footer-sep">·</span>
-          <span>niuu.world</span>
-        </div>
-        <div>
-          <span>{enabled.length} plugins loaded</span>
-        </div>
-      </footer>
-    </div>
+    <ShellContext.Provider value={{ enabled, brand, version, ctx }}>
+      <RouterProvider router={router} />
+    </ShellContext.Provider>
   );
 }

--- a/web-next/packages/shell/src/ShellContext.ts
+++ b/web-next/packages/shell/src/ShellContext.ts
@@ -1,0 +1,17 @@
+import { createContext, useContext } from 'react';
+import type { PluginDescriptor, PluginCtx } from '@niuulabs/plugin-sdk';
+
+export interface ShellContextValue {
+  enabled: PluginDescriptor[];
+  brand: string;
+  version: string;
+  ctx: PluginCtx;
+}
+
+export const ShellContext = createContext<ShellContextValue | null>(null);
+
+export function useShellContext(): ShellContextValue {
+  const value = useContext(ShellContext);
+  if (!value) throw new Error('useShellContext must be used inside <Shell>');
+  return value;
+}

--- a/web-next/packages/shell/src/ShellLayout.tsx
+++ b/web-next/packages/shell/src/ShellLayout.tsx
@@ -1,0 +1,104 @@
+import { useEffect, type ReactNode } from 'react';
+import clsx from 'clsx';
+import { Outlet, useRouter, useRouterState } from '@tanstack/react-router';
+import { useConfig } from '@niuulabs/plugin-sdk';
+import { LiveBadge, Kbd } from '@niuulabs/ui';
+import { useShellContext } from './ShellContext';
+import './Shell.css';
+
+function activePluginId(pathname: string, ids: string[]): string | null {
+  for (const id of ids) {
+    if (pathname === `/${id}` || pathname.startsWith(`/${id}/`)) return id;
+  }
+  return null;
+}
+
+export function ShellLayout() {
+  const config = useConfig();
+  const { enabled, brand, version, ctx } = useShellContext();
+  const router = useRouter();
+  const { location } = useRouterState({ select: (s) => ({ location: s.location }) });
+  const pathname = location.pathname;
+
+  const activeId = activePluginId(
+    pathname,
+    enabled.map((p) => p.id),
+  );
+  const active = enabled.find((p) => p.id === activeId) ?? enabled[0] ?? null;
+
+  // localStorage follows the router — not the other way around
+  useEffect(() => {
+    if (activeId && typeof window !== 'undefined') {
+      localStorage.setItem('niuu.active', activeId);
+    }
+  }, [activeId]);
+
+  const handleSelect = (id: string) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    router.navigate({ to: `/${id}` as any });
+  };
+
+  const subnavNode: ReactNode = active?.subnav?.(ctx) ?? null;
+
+  return (
+    <div
+      className={clsx('niuu-shell', !subnavNode && 'niuu-shell--no-subnav')}
+      data-theme={config.theme}
+    >
+      <aside className="niuu-shell__rail">
+        <div className="niuu-shell__rail-brand" title="Niuu">
+          {brand}
+        </div>
+        {enabled.map((p) => (
+          <button
+            key={p.id}
+            type="button"
+            className={clsx(
+              'niuu-shell__rail-item',
+              active?.id === p.id && 'niuu-shell__rail-item--active',
+            )}
+            title={`${p.title} · ${p.subtitle}`}
+            onClick={() => handleSelect(p.id)}
+          >
+            {p.rune}
+          </button>
+        ))}
+        <div className="niuu-shell__rail-spacer" />
+        <div className="niuu-shell__rail-foot">v{version}</div>
+      </aside>
+
+      <header className="niuu-shell__topbar">
+        <div className="niuu-shell__topbar-title">
+          {active && (
+            <>
+              <h1>{active.title}</h1>
+              <span className="niuu-shell__topbar-subtitle">{active.subtitle}</span>
+            </>
+          )}
+        </div>
+        <div className="niuu-shell__topbar-right">
+          {active?.topbarRight?.(ctx)}
+          <LiveBadge />
+          <Kbd>⌘K</Kbd>
+        </div>
+      </header>
+
+      {subnavNode && <nav className="niuu-shell__subnav">{subnavNode}</nav>}
+
+      <main className="niuu-shell__content">
+        <Outlet />
+      </main>
+
+      <footer className="niuu-shell__footer">
+        <div>
+          {active && <code>plugin:{active.id}</code>}
+          <span className="niuu-shell__footer-sep">·</span>
+          <span>niuu.world</span>
+        </div>
+        <div>
+          <span>{enabled.length} plugins loaded</span>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/web-next/packages/shell/src/composeRouter.test.ts
+++ b/web-next/packages/shell/src/composeRouter.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createMemoryHistory, createRoute } from '@tanstack/react-router';
+import { definePlugin } from '@niuulabs/plugin-sdk';
+import { composeRouter } from './composeRouter';
+
+// Minimal stub so ShellLayout doesn't need a full DOM environment
+vi.mock('./ShellLayout', () => ({ ShellLayout: () => null }));
+vi.mock('./NotFoundPage', () => ({ NotFoundPage: () => null }));
+vi.mock('./ShellContext', () => ({
+  useShellContext: vi.fn(() => ({ ctx: { tweaks: {}, setTweak: vi.fn() } })),
+}));
+
+const makePlugin = (id: string) =>
+  definePlugin({
+    id,
+    rune: 'ᚺ',
+    title: id,
+    subtitle: id,
+    render: () => null,
+  });
+
+describe('composeRouter', () => {
+  it('creates a router with only the index and not-found routes when no plugins are given', () => {
+    const router = composeRouter([], {
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    });
+    // Flat route map should include the root and index
+    const paths = Object.keys(router.routesById);
+    expect(paths).toContain('__root__');
+    expect(paths).toContain('/');
+  });
+
+  it('creates a fallback route for each plugin that has no routes() function', () => {
+    const router = composeRouter([makePlugin('alpha'), makePlugin('beta')], {
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    });
+    const paths = Object.keys(router.routesById);
+    expect(paths).toContain('/alpha');
+    expect(paths).toContain('/beta');
+  });
+
+  it('incorporates routes returned by plugin.routes()', () => {
+    const withRoutes = definePlugin({
+      id: 'gamma',
+      rune: 'ᚷ',
+      title: 'Gamma',
+      subtitle: 'test',
+      routes: (root) => [
+        createRoute({
+          getParentRoute: () => root,
+          path: '/gamma',
+          component: () => null,
+        }),
+      ],
+    });
+
+    const router = composeRouter([withRoutes], {
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    });
+    const paths = Object.keys(router.routesById);
+    expect(paths).toContain('/gamma');
+  });
+
+  it('always includes the root route and an index redirect route', () => {
+    const router = composeRouter([makePlugin('x')], {
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    });
+    expect(router.routesById).toHaveProperty('__root__');
+    expect(router.routesById).toHaveProperty('/');
+  });
+
+  it('the root route has a notFoundComponent configured', () => {
+    const router = composeRouter([], {
+      history: createMemoryHistory({ initialEntries: ['/'] }),
+    });
+    // @ts-expect-error accessing internal options for assertion
+    expect(router.routesById['__root__']?.options?.notFoundComponent).toBeDefined();
+  });
+});

--- a/web-next/packages/shell/src/composeRouter.ts
+++ b/web-next/packages/shell/src/composeRouter.ts
@@ -6,7 +6,7 @@ import {
   type AnyRouter,
 } from '@tanstack/react-router';
 import type { RouterHistory } from '@tanstack/react-router';
-import type { PluginDescriptor, PluginCtx } from '@niuulabs/plugin-sdk';
+import type { PluginDescriptor } from '@niuulabs/plugin-sdk';
 import { ShellLayout } from './ShellLayout';
 import { NotFoundPage } from './NotFoundPage';
 import { useShellContext } from './ShellContext';
@@ -60,7 +60,7 @@ export function composeRouter(
 
     // Auto-generated fallback route — uses plugin.render(ctx) as its component.
     function RenderFallback() {
-      const { ctx }: { ctx: PluginCtx } = useShellContext();
+      const { ctx } = useShellContext();
       return plugin.render?.(ctx) ?? null;
     }
 

--- a/web-next/packages/shell/src/composeRouter.ts
+++ b/web-next/packages/shell/src/composeRouter.ts
@@ -1,0 +1,82 @@
+import {
+  createRootRoute,
+  createRoute,
+  createRouter,
+  redirect,
+  type AnyRouter,
+} from '@tanstack/react-router';
+import type { RouterHistory } from '@tanstack/react-router';
+import type { PluginDescriptor, PluginCtx } from '@niuulabs/plugin-sdk';
+import { ShellLayout } from './ShellLayout';
+import { NotFoundPage } from './NotFoundPage';
+import { useShellContext } from './ShellContext';
+
+export interface ComposeRouterOptions {
+  /** Override the browser history (useful for testing and Storybook). */
+  history?: RouterHistory;
+}
+
+/**
+ * Build a TanStack Router instance from the set of enabled plugins.
+ *
+ * - Each plugin that exports `routes(rootRoute)` contributes its route tree.
+ * - Plugins without `routes` get a default route at `/<id>` that delegates to
+ *   their `render()` function (backward-compat for test helpers and legacy plugins).
+ * - An index route at `/` redirects to the active plugin (localStorage hint or
+ *   the first enabled plugin).
+ * - A catch-all not-found component handles unknown paths.
+ */
+export function composeRouter(
+  enabled: PluginDescriptor[],
+  options: ComposeRouterOptions = {},
+): AnyRouter {
+  const rootRoute = createRootRoute({
+    component: ShellLayout,
+    notFoundComponent: NotFoundPage,
+  });
+
+  // Index route: redirect to the stored/default plugin path
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    beforeLoad: () => {
+      const storedId = typeof window !== 'undefined' ? localStorage.getItem('niuu.active') : null;
+      const targetId =
+        storedId && enabled.some((p) => p.id === storedId) ? storedId : (enabled[0]?.id ?? null);
+      if (targetId) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        throw redirect({ to: `/${targetId}` as any });
+      }
+    },
+    component: () => null,
+  });
+
+  // Collect routes from each plugin, generating a fallback route when a plugin
+  // has no `routes` function (uses `render` for backward compat).
+  const pluginRoutes = enabled.flatMap((plugin) => {
+    if (plugin.routes) {
+      return plugin.routes(rootRoute);
+    }
+
+    // Auto-generated fallback route — uses plugin.render(ctx) as its component.
+    function RenderFallback() {
+      const { ctx }: { ctx: PluginCtx } = useShellContext();
+      return plugin.render?.(ctx) ?? null;
+    }
+
+    return [
+      createRoute({
+        getParentRoute: () => rootRoute,
+        path: `/${plugin.id}`,
+        component: RenderFallback,
+      }),
+    ];
+  });
+
+  const routeTree = rootRoute.addChildren([indexRoute, ...pluginRoutes]);
+
+  return createRouter({
+    routeTree,
+    ...(options.history ? { history: options.history } : {}),
+  });
+}

--- a/web-next/packages/shell/src/index.ts
+++ b/web-next/packages/shell/src/index.ts
@@ -1,1 +1,2 @@
 export { Shell } from './Shell';
+export { composeRouter, type ComposeRouterOptions } from './composeRouter';

--- a/web-next/pnpm-lock.yaml
+++ b/web-next/pnpm-lock.yaml
@@ -181,6 +181,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.62.0
         version: 5.99.1(react@19.2.5)
+      '@tanstack/react-router':
+        specifier: ^1.95.0
+        version: 1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/react':
         specifier: ^19.0.7
         version: 19.2.14

--- a/web-next/vitest.setup.ts
+++ b/web-next/vitest.setup.ts
@@ -1,1 +1,5 @@
 import '@testing-library/jest-dom/vitest';
+
+// TanStack Router calls window.scrollTo during scroll-restoration inside tests.
+// jsdom doesn't implement it; stub it out to keep test output clean.
+Object.defineProperty(window, 'scrollTo', { value: () => {}, writable: true });


### PR DESCRIPTION
## Summary

- **`composeRouter()`** (`packages/shell/src/composeRouter.ts`) — builds a TanStack Router instance from the enabled plugin set. Each plugin's `routes(rootRoute)` contributes its subtree; plugins with only `render()` get an auto-generated fallback route at `/<id>`. An index route at `/` redirects to the active plugin (localStorage hint → first enabled). `notFoundComponent` on the root route handles unknown paths.

- **`ShellLayout`** (`packages/shell/src/ShellLayout.tsx`) — new root-route component that renders the shell frame (rail / topbar / subnav / `<Outlet />` / footer). Derives the active plugin from the current URL via `useRouterState`, syncs `localStorage.niuu.active` **from** the router on every navigation (not the other way around), and navigates via `router.navigate` on rail clicks.

- **`Shell`** (`packages/shell/src/Shell.tsx`) — now creates the router with `useMemo`, wraps `RouterProvider` in `ShellContext.Provider`, and accepts `_testHistory` (memory history for tests / Storybook without polluting `window.location`).

- **`ShellContext`** — thin React context carrying `enabled`, `brand`, `version`, and `ctx` from `Shell` to `ShellLayout` and fallback route components inside the router tree.

- **`plugin-hello`** migrated from `render()` to `routes(rootRoute)` exporting a `/hello` route. `@tanstack/react-router` added as a peer/dev dep.

- **Shell tests** updated: `waitFor` for async routing, new tests for deep-link start, disabled-plugin config, and localStorage-follows-router invariant.

- **Playwright e2e**: `deep-link /hello`, root-to-back navigation, unknown-route 404.

- **Storybook story**: TwoPlugins, SinglePlugin, NoPlugins, DeepLinkedBeta — all use `createMemoryHistory` for a stable URL in the workshop.

- **`vitest.setup.ts`**: stub `window.scrollTo` to suppress jsdom noise from TanStack Router's scroll-restoration hook.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm exec eslint .` — clean
- [x] `pnpm exec prettier --check .` — clean
- [x] `pnpm test` — 16/16 suites, 44 tests, coverage ≥ 85% (statements 97.91%, branches 86.6%, functions 91.42%, lines 97.91%)
- [ ] `pnpm test:e2e` — requires dev server; runs in CI
- [ ] Deep-link `/hello` loads hello page directly
- [ ] Unknown route `/does-not-exist` shows 404
- [ ] Rail click navigates and updates localStorage
- [ ] Browser back/forward work correctly

## Notes

- Linear ticket NIU-649: could not update via MCP (tools not available in this session) — please update manually to "In Review".

🤖 Generated with [Claude Code](https://claude.com/claude-code)