### PR TITLE
feat(mimir): scaffold @niuulabs/plugin-mimir — domain, ports, mock adapter (NIU-667)

### DIFF
--- a/web-next/apps/niuu/package.json
+++ b/web-next/apps/niuu/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@niuulabs/design-tokens": "workspace:*",
     "@niuulabs/plugin-hello": "workspace:*",
+    "@niuulabs/plugin-mimir": "workspace:*",
     "@niuulabs/plugin-sdk": "workspace:*",
     "@niuulabs/query": "workspace:*",
     "@niuulabs/shell": "workspace:*",

--- a/web-next/apps/niuu/public/config.json
+++ b/web-next/apps/niuu/public/config.json
@@ -1,9 +1,11 @@
 {
   "theme": "ice",
   "plugins": {
-    "hello": { "enabled": true, "order": 1 }
+    "hello": { "enabled": true, "order": 1 },
+    "mimir": { "enabled": true, "order": 2 }
   },
   "services": {
-    "hello": { "mode": "mock" }
+    "hello": { "mode": "mock" },
+    "mimir": { "mode": "mock" }
   }
 }

--- a/web-next/apps/niuu/src/plugins.ts
+++ b/web-next/apps/niuu/src/plugins.ts
@@ -1,4 +1,5 @@
 import { helloPlugin } from '@niuulabs/plugin-hello';
+import { mimirPlugin } from '@niuulabs/plugin-mimir';
 import type { PluginDescriptor } from '@niuulabs/plugin-sdk';
 
-export const plugins: PluginDescriptor[] = [helloPlugin];
+export const plugins: PluginDescriptor[] = [helloPlugin, mimirPlugin];

--- a/web-next/apps/niuu/src/services.ts
+++ b/web-next/apps/niuu/src/services.ts
@@ -1,15 +1,21 @@
 import { createMockHelloService, buildHelloHttpAdapter } from '@niuulabs/plugin-hello';
+import { createMimirMockAdapter, buildMimirHttpAdapter } from '@niuulabs/plugin-mimir';
 import { createApiClient } from '@niuulabs/query';
 import type { NiuuConfig, ServicesMap } from '@niuulabs/plugin-sdk';
 
 export function buildServices(config: NiuuConfig): ServicesMap {
   const helloSvc = config.services['hello'];
-  if (helloSvc?.mode === 'http' && helloSvc.baseUrl) {
-    return {
-      hello: buildHelloHttpAdapter(createApiClient(helloSvc.baseUrl)),
-    };
-  }
-  return {
-    hello: createMockHelloService(),
-  };
+  const mimirSvc = config.services['mimir'];
+
+  const hello =
+    helloSvc?.mode === 'http' && helloSvc.baseUrl
+      ? buildHelloHttpAdapter(createApiClient(helloSvc.baseUrl))
+      : createMockHelloService();
+
+  const mimir =
+    mimirSvc?.mode === 'http' && mimirSvc.baseUrl
+      ? buildMimirHttpAdapter(createApiClient(mimirSvc.baseUrl))
+      : createMimirMockAdapter();
+
+  return { hello, mimir };
 }

--- a/web-next/e2e/mimir.spec.ts
+++ b/web-next/e2e/mimir.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate to /mimir renders the placeholder page', async ({ page }) => {
+  await page.goto('/mimir');
+  await expect(page.getByText('Mímir · the well of knowledge')).toBeVisible();
+});
+
+test('/mimir shows loading state then mount list', async ({ page }) => {
+  await page.goto('/mimir');
+  await expect(
+    page.getByText(/loading mounts/).or(page.getByText(/mounts connected/)),
+  ).toBeVisible();
+  await expect(page.getByText(/mounts connected/)).toBeVisible({ timeout: 5000 });
+});
+
+test('/mimir shows individual mount names', async ({ page }) => {
+  await page.goto('/mimir');
+  await expect(page.getByText('local')).toBeVisible({ timeout: 5000 });
+  await expect(page.getByText('shared')).toBeVisible({ timeout: 5000 });
+});
+
+test('mimir rune is visible in the rail', async ({ page }) => {
+  await page.goto('/mimir');
+  await expect(page.getByText('ᛗ')).toBeVisible();
+});

--- a/web-next/packages/plugin-mimir/package.json
+++ b/web-next/packages/plugin-mimir/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@niuulabs/plugin-mimir",
+  "version": "0.0.1",
+  "description": "Mímir plugin — knowledge-base management for the Niuu platform",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "dev": "tsup --watch"
+  },
+  "peerDependencies": {
+    "@tanstack/react-query": "^5.62.0",
+    "@tanstack/react-router": "^1.95.0",
+    "react": "^19.0.0"
+  },
+  "dependencies": {
+    "@niuulabs/domain": "workspace:*",
+    "@niuulabs/plugin-sdk": "workspace:*",
+    "@niuulabs/query": "workspace:*",
+    "@niuulabs/ui": "workspace:*"
+  },
+  "devDependencies": {
+    "@tanstack/react-query": "^5.62.0",
+    "@tanstack/react-router": "^1.95.0",
+    "@types/react": "^19.0.7",
+    "react": "^19.0.0",
+    "tsup": "^8.3.5",
+    "typescript": "^5.7.3"
+  }
+}

--- a/web-next/packages/plugin-mimir/src/adapters/http.test.ts
+++ b/web-next/packages/plugin-mimir/src/adapters/http.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi } from 'vitest';
+import { buildMimirHttpAdapter } from './http';
+
+function makeClient(overrides: Record<string, ReturnType<typeof vi.fn>> = {}) {
+  return {
+    get: vi.fn().mockResolvedValue([]),
+    post: vi.fn().mockResolvedValue({ issues: [], pages_checked: 0 }),
+    put: vi.fn().mockResolvedValue(undefined),
+    patch: vi.fn(),
+    delete: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('buildMimirHttpAdapter', () => {
+  describe('mounts.listMounts', () => {
+    it('calls GET /mounts', async () => {
+      const client = makeClient({ get: vi.fn().mockResolvedValue([]) });
+      await buildMimirHttpAdapter(client).mounts.listMounts();
+      expect(client.get).toHaveBeenCalledWith('/mounts');
+    });
+
+    it('maps raw mount fields to domain Mount', async () => {
+      const rawMount = {
+        name: 'local',
+        role: 'local',
+        host: 'localhost',
+        url: 'http://localhost:7700',
+        priority: 1,
+        categories: null,
+        status: 'healthy',
+        pages: 42,
+        sources: 18,
+        lint_issues: 3,
+        last_write: '2026-04-18T14:22:00Z',
+        embedding: 'all-minilm-l6-v2',
+        size_kb: 512,
+        desc: 'Local mount',
+      };
+      const client = makeClient({ get: vi.fn().mockResolvedValue([rawMount]) });
+      const mounts = await buildMimirHttpAdapter(client).mounts.listMounts();
+      expect(mounts[0]).toMatchObject({
+        name: 'local',
+        role: 'local',
+        pages: 42,
+        lintIssues: 3,
+        lastWrite: '2026-04-18T14:22:00Z',
+        sizeKb: 512,
+      });
+    });
+  });
+
+  describe('pages.getStats', () => {
+    it('calls GET /stats', async () => {
+      const client = makeClient({
+        get: vi.fn().mockResolvedValue({ page_count: 5, categories: [], healthy: true }),
+      });
+      await buildMimirHttpAdapter(client).pages.getStats();
+      expect(client.get).toHaveBeenCalledWith('/stats');
+    });
+
+    it('maps snake_case to camelCase', async () => {
+      const client = makeClient({
+        get: vi.fn().mockResolvedValue({
+          page_count: 10,
+          categories: ['arch', 'api'],
+          healthy: false,
+        }),
+      });
+      const stats = await buildMimirHttpAdapter(client).pages.getStats();
+      expect(stats.pageCount).toBe(10);
+      expect(stats.categories).toEqual(['arch', 'api']);
+      expect(stats.healthy).toBe(false);
+    });
+  });
+
+  describe('pages.listPages', () => {
+    it('calls GET /pages without query string when no options', async () => {
+      const client = makeClient({ get: vi.fn().mockResolvedValue([]) });
+      await buildMimirHttpAdapter(client).pages.listPages();
+      expect(client.get).toHaveBeenCalledWith('/pages');
+    });
+
+    it('appends mount and category query params', async () => {
+      const client = makeClient({ get: vi.fn().mockResolvedValue([]) });
+      await buildMimirHttpAdapter(client).pages.listPages({ mountName: 'local', category: 'arch' });
+      const call = (client.get as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string;
+      expect(call).toContain('mount=local');
+      expect(call).toContain('category=arch');
+    });
+  });
+
+  describe('pages.getPage', () => {
+    it('calls GET /page with path param', async () => {
+      const client = makeClient({ get: vi.fn().mockResolvedValue(null) });
+      await buildMimirHttpAdapter(client).pages.getPage('/arch/overview');
+      const call = (client.get as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string;
+      expect(call).toContain('/page');
+      expect(call).toContain('path=%2Farch%2Foverview');
+    });
+
+    it('returns null when API returns null', async () => {
+      const client = makeClient({ get: vi.fn().mockResolvedValue(null) });
+      const result = await buildMimirHttpAdapter(client).pages.getPage('/missing');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('pages.upsertPage', () => {
+    it('calls PUT /page with path and content', async () => {
+      const client = makeClient();
+      await buildMimirHttpAdapter(client).pages.upsertPage('/test', '# Content');
+      expect(client.put).toHaveBeenCalledWith('/page', { path: '/test', content: '# Content' });
+    });
+  });
+
+  describe('pages.search', () => {
+    it('calls GET /search with query and default mode', async () => {
+      const client = makeClient({ get: vi.fn().mockResolvedValue([]) });
+      await buildMimirHttpAdapter(client).pages.search('kubernetes');
+      const call = (client.get as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string;
+      expect(call).toContain('q=kubernetes');
+      expect(call).toContain('mode=hybrid');
+    });
+
+    it('respects explicit search mode', async () => {
+      const client = makeClient({ get: vi.fn().mockResolvedValue([]) });
+      await buildMimirHttpAdapter(client).pages.search('k8s', 'fts');
+      const call = (client.get as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string;
+      expect(call).toContain('mode=fts');
+    });
+  });
+
+  describe('embeddings.semanticSearch', () => {
+    it('calls GET /embeddings/search with query and topK', async () => {
+      const client = makeClient({ get: vi.fn().mockResolvedValue([]) });
+      await buildMimirHttpAdapter(client).embeddings.semanticSearch('arch', 5);
+      const call = (client.get as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string;
+      expect(call).toContain('/embeddings/search');
+      expect(call).toContain('q=arch');
+      expect(call).toContain('top_k=5');
+    });
+
+    it('maps raw embedding result to EmbeddingSearchResult', async () => {
+      const raw = [{ path: '/a', title: 'A', summary: 'S', score: 0.9, mount_name: 'local' }];
+      const client = makeClient({ get: vi.fn().mockResolvedValue(raw) });
+      const results = await buildMimirHttpAdapter(client).embeddings.semanticSearch('q');
+      expect(results[0]).toMatchObject({ path: '/a', score: 0.9, mountName: 'local' });
+    });
+  });
+
+  describe('lint.getLintReport', () => {
+    it('calls GET /lint', async () => {
+      const client = makeClient({
+        get: vi.fn().mockResolvedValue({ issues: [], pages_checked: 0 }),
+      });
+      await buildMimirHttpAdapter(client).lint.getLintReport();
+      expect(client.get).toHaveBeenCalledWith('/lint');
+    });
+
+    it('maps raw lint issues with snake_case fields', async () => {
+      const rawIssue = {
+        id: 'lint-1',
+        rule: 'L05',
+        severity: 'error',
+        page: '/a',
+        mount: 'local',
+        auto_fix: true,
+        message: 'Broken link',
+      };
+      const client = makeClient({
+        get: vi.fn().mockResolvedValue({ issues: [rawIssue], pages_checked: 5 }),
+      });
+      const report = await buildMimirHttpAdapter(client).lint.getLintReport();
+      expect(report.issues[0]).toMatchObject({
+        id: 'lint-1',
+        rule: 'L05',
+        autoFix: true,
+      });
+    });
+  });
+
+  describe('lint.runAutoFix', () => {
+    it('calls POST /lint/fix with empty body when no ids', async () => {
+      const client = makeClient();
+      await buildMimirHttpAdapter(client).lint.runAutoFix();
+      expect(client.post).toHaveBeenCalledWith('/lint/fix', {});
+    });
+
+    it('passes issue_ids when provided', async () => {
+      const client = makeClient();
+      await buildMimirHttpAdapter(client).lint.runAutoFix(['lint-1', 'lint-2']);
+      expect(client.post).toHaveBeenCalledWith('/lint/fix', {
+        issue_ids: ['lint-1', 'lint-2'],
+      });
+    });
+  });
+
+  describe('lint.getDreamCycles', () => {
+    it('calls GET /dreams with limit', async () => {
+      const client = makeClient({ get: vi.fn().mockResolvedValue([]) });
+      await buildMimirHttpAdapter(client).lint.getDreamCycles(5);
+      expect(client.get).toHaveBeenCalledWith('/dreams?limit=5');
+    });
+
+    it('maps raw dream cycle fields', async () => {
+      const raw = [
+        {
+          id: 'dream-1',
+          timestamp: '2026-04-19T03:00:00Z',
+          ravn: 'ravn-fjolnir',
+          mounts: ['local'],
+          pages_updated: 8,
+          entities_created: 2,
+          lint_fixes: 1,
+          duration_ms: 42000,
+        },
+      ];
+      const client = makeClient({ get: vi.fn().mockResolvedValue(raw) });
+      const cycles = await buildMimirHttpAdapter(client).lint.getDreamCycles();
+      expect(cycles[0]).toMatchObject({
+        id: 'dream-1',
+        pagesUpdated: 8,
+        entitiesCreated: 2,
+        lintFixes: 1,
+        durationMs: 42000,
+      });
+    });
+  });
+});

--- a/web-next/packages/plugin-mimir/src/adapters/http.ts
+++ b/web-next/packages/plugin-mimir/src/adapters/http.ts
@@ -1,0 +1,299 @@
+/**
+ * HTTP adapter for the Mímir service.
+ *
+ * Accepts an ApiClient scoped to the Mímir base URL and implements
+ * IMimirService by mapping HTTP responses to domain types.
+ */
+
+import type { ApiClient } from '@niuulabs/query';
+import type { Mount } from '@niuulabs/domain';
+import type { IMimirService, SearchMode } from '../ports';
+import type { PageMeta, Page, SearchResult } from '../domain/page';
+import type { LintReport, DreamCycle, LintIssue, IssueSeverity, LintRule } from '../domain/lint';
+import type { MimirStats } from '../domain/api-types';
+import type { EmbeddingSearchResult } from '../ports/IEmbeddingStore';
+import { tallySeverity } from '../domain/lint';
+
+// ---------------------------------------------------------------------------
+// Raw wire types
+// ---------------------------------------------------------------------------
+
+interface RawMount {
+  name: string;
+  role: string;
+  host: string;
+  url: string;
+  priority: number;
+  categories: string[] | null;
+  status: string;
+  pages: number;
+  sources: number;
+  lint_issues: number;
+  last_write: string;
+  embedding: string;
+  size_kb: number;
+  desc: string;
+}
+
+interface RawPageMeta {
+  path: string;
+  title: string;
+  summary: string;
+  category: string;
+  type: string;
+  confidence: string;
+  entity_type?: string;
+  mounts: string[];
+  updated_at: string;
+  updated_by: string;
+  source_ids: string[];
+  size: number;
+}
+
+interface RawPage extends RawPageMeta {
+  related: string[];
+  zones?: Array<{
+    kind: string;
+    items?: unknown[];
+    text?: string;
+  }>;
+}
+
+interface RawStats {
+  page_count: number;
+  categories: string[];
+  healthy: boolean;
+}
+
+interface RawSearchResult {
+  path: string;
+  title: string;
+  summary: string;
+  category: string;
+  type: string;
+  confidence: string;
+}
+
+interface RawLintIssue {
+  id: string;
+  rule: string;
+  severity: string;
+  page: string;
+  mount: string;
+  assignee?: string;
+  auto_fix: boolean;
+  message: string;
+}
+
+interface RawLintReport {
+  issues: RawLintIssue[];
+  pages_checked: number;
+}
+
+interface RawEmbeddingResult {
+  path: string;
+  title: string;
+  summary: string;
+  score: number;
+  mount_name: string;
+}
+
+interface RawDreamCycle {
+  id: string;
+  timestamp: string;
+  ravn: string;
+  mounts: string[];
+  pages_updated: number;
+  entities_created: number;
+  lint_fixes: number;
+  duration_ms: number;
+}
+
+// ---------------------------------------------------------------------------
+// Mapping helpers
+// ---------------------------------------------------------------------------
+
+function toMount(raw: RawMount): Mount {
+  return {
+    name: raw.name,
+    role: raw.role as Mount['role'],
+    host: raw.host,
+    url: raw.url,
+    priority: raw.priority,
+    categories: raw.categories,
+    status: raw.status as Mount['status'],
+    pages: raw.pages,
+    sources: raw.sources,
+    lintIssues: raw.lint_issues,
+    lastWrite: raw.last_write,
+    embedding: raw.embedding,
+    sizeKb: raw.size_kb,
+    desc: raw.desc,
+  };
+}
+
+function toPageMeta(raw: RawPageMeta): PageMeta {
+  return {
+    path: raw.path,
+    title: raw.title,
+    summary: raw.summary,
+    category: raw.category,
+    type: raw.type as PageMeta['type'],
+    confidence: raw.confidence as PageMeta['confidence'],
+    entityType: raw.entity_type,
+    mounts: raw.mounts,
+    updatedAt: raw.updated_at,
+    updatedBy: raw.updated_by,
+    sourceIds: raw.source_ids,
+    size: raw.size,
+  };
+}
+
+function toPage(raw: RawPage): Page {
+  return {
+    ...toPageMeta(raw),
+    related: raw.related,
+  };
+}
+
+function toLintIssue(raw: RawLintIssue): LintIssue {
+  return {
+    id: raw.id,
+    rule: raw.rule as LintRule,
+    severity: raw.severity as IssueSeverity,
+    page: raw.page,
+    mount: raw.mount,
+    assignee: raw.assignee,
+    autoFix: raw.auto_fix,
+    message: raw.message,
+  };
+}
+
+function toLintReport(raw: RawLintReport): LintReport {
+  const issues = raw.issues.map(toLintIssue);
+  return {
+    issues,
+    pagesChecked: raw.pages_checked,
+    summary: tallySeverity(issues),
+  };
+}
+
+function toEmbeddingResult(raw: RawEmbeddingResult): EmbeddingSearchResult {
+  return {
+    path: raw.path,
+    title: raw.title,
+    summary: raw.summary,
+    score: raw.score,
+    mountName: raw.mount_name,
+  };
+}
+
+function toDreamCycle(raw: RawDreamCycle): DreamCycle {
+  return {
+    id: raw.id,
+    timestamp: raw.timestamp,
+    ravn: raw.ravn,
+    mounts: raw.mounts,
+    pagesUpdated: raw.pages_updated,
+    entitiesCreated: raw.entities_created,
+    lintFixes: raw.lint_fixes,
+    durationMs: raw.duration_ms,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Adapter factory
+// ---------------------------------------------------------------------------
+
+export function buildMimirHttpAdapter(client: ApiClient): IMimirService {
+  return {
+    mounts: {
+      async listMounts(): Promise<Mount[]> {
+        const raw = await client.get<RawMount[]>('/mounts');
+        return raw.map(toMount);
+      },
+    },
+
+    pages: {
+      async getStats(): Promise<MimirStats> {
+        const raw = await client.get<RawStats>('/stats');
+        return {
+          pageCount: raw.page_count,
+          categories: raw.categories,
+          healthy: raw.healthy,
+        };
+      },
+
+      async listPages(options): Promise<PageMeta[]> {
+        const params = new URLSearchParams();
+        if (options?.mountName) params.set('mount', options.mountName);
+        if (options?.category) params.set('category', options.category);
+        const qs = params.toString() ? `?${params.toString()}` : '';
+        const raw = await client.get<RawPageMeta[]>(`/pages${qs}`);
+        return raw.map(toPageMeta);
+      },
+
+      async getPage(path: string, mountName?: string): Promise<Page | null> {
+        const params = new URLSearchParams({ path });
+        if (mountName) params.set('mount', mountName);
+        const raw = await client.get<RawPage | null>(`/page?${params.toString()}`);
+        if (!raw) return null;
+        return toPage(raw);
+      },
+
+      async upsertPage(path: string, content: string, mountName?: string): Promise<void> {
+        const body: Record<string, string> = { path, content };
+        if (mountName) body['mount'] = mountName;
+        await client.put<void>('/page', body);
+      },
+
+      async search(query: string, mode: SearchMode = 'hybrid'): Promise<SearchResult[]> {
+        const raw = await client.get<RawSearchResult[]>(
+          `/search?q=${encodeURIComponent(query)}&mode=${mode}`,
+        );
+        return raw.map((r) => ({
+          path: r.path,
+          title: r.title,
+          summary: r.summary,
+          category: r.category,
+          type: r.type as SearchResult['type'],
+          confidence: r.confidence as SearchResult['confidence'],
+        }));
+      },
+    },
+
+    embeddings: {
+      async semanticSearch(
+        query: string,
+        topK = 10,
+        mountName?: string,
+      ): Promise<EmbeddingSearchResult[]> {
+        const params = new URLSearchParams({ q: query, top_k: String(topK) });
+        if (mountName) params.set('mount', mountName);
+        const raw = await client.get<RawEmbeddingResult[]>(
+          `/embeddings/search?${params.toString()}`,
+        );
+        return raw.map(toEmbeddingResult);
+      },
+    },
+
+    lint: {
+      async getLintReport(mountName?: string): Promise<LintReport> {
+        const qs = mountName ? `?mount=${encodeURIComponent(mountName)}` : '';
+        const raw = await client.get<RawLintReport>(`/lint${qs}`);
+        return toLintReport(raw);
+      },
+
+      async runAutoFix(issueIds?: string[]): Promise<LintReport> {
+        const body = issueIds ? { issue_ids: issueIds } : {};
+        const raw = await client.post<RawLintReport>('/lint/fix', body);
+        return toLintReport(raw);
+      },
+
+      async getDreamCycles(limit = 20): Promise<DreamCycle[]> {
+        const raw = await client.get<RawDreamCycle[]>(`/dreams?limit=${limit}`);
+        return raw.map(toDreamCycle);
+      },
+    },
+  };
+}

--- a/web-next/packages/plugin-mimir/src/adapters/mock.test.ts
+++ b/web-next/packages/plugin-mimir/src/adapters/mock.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from 'vitest';
+import { createMimirMockAdapter } from './mock';
+
+describe('createMimirMockAdapter', () => {
+  describe('mounts.listMounts', () => {
+    it('returns a non-empty list of mounts', async () => {
+      const svc = createMimirMockAdapter();
+      const mounts = await svc.mounts.listMounts();
+      expect(mounts.length).toBeGreaterThan(0);
+    });
+
+    it('each mount has required fields', async () => {
+      const svc = createMimirMockAdapter();
+      const mounts = await svc.mounts.listMounts();
+      for (const mount of mounts) {
+        expect(mount).toHaveProperty('name');
+        expect(mount).toHaveProperty('role');
+        expect(mount).toHaveProperty('status');
+        expect(mount).toHaveProperty('pages');
+        expect(mount).toHaveProperty('url');
+      }
+    });
+
+    it('includes mounts with local, shared and domain roles', async () => {
+      const svc = createMimirMockAdapter();
+      const mounts = await svc.mounts.listMounts();
+      const roles = mounts.map((m) => m.role);
+      expect(roles).toContain('local');
+      expect(roles).toContain('shared');
+      expect(roles).toContain('domain');
+    });
+  });
+
+  describe('pages.getStats', () => {
+    it('returns healthy flag and non-zero pageCount', async () => {
+      const svc = createMimirMockAdapter();
+      const stats = await svc.pages.getStats();
+      expect(stats.pageCount).toBeGreaterThan(0);
+      expect(typeof stats.healthy).toBe('boolean');
+      expect(Array.isArray(stats.categories)).toBe(true);
+    });
+  });
+
+  describe('pages.listPages', () => {
+    it('returns all pages when no filter is given', async () => {
+      const svc = createMimirMockAdapter();
+      const pages = await svc.pages.listPages();
+      expect(pages.length).toBeGreaterThan(0);
+    });
+
+    it('filters by category', async () => {
+      const svc = createMimirMockAdapter();
+      const pages = await svc.pages.listPages({ category: 'arch' });
+      expect(pages.length).toBeGreaterThan(0);
+      expect(pages.every((p) => p.category === 'arch')).toBe(true);
+    });
+
+    it('filters by mountName', async () => {
+      const svc = createMimirMockAdapter();
+      const pages = await svc.pages.listPages({ mountName: 'local' });
+      expect(pages.every((p) => p.mounts.includes('local'))).toBe(true);
+    });
+
+    it('each result has PageMeta fields', async () => {
+      const svc = createMimirMockAdapter();
+      const pages = await svc.pages.listPages();
+      for (const p of pages) {
+        expect(p).toHaveProperty('path');
+        expect(p).toHaveProperty('title');
+        expect(p).toHaveProperty('type');
+        expect(p).toHaveProperty('confidence');
+        expect(p).toHaveProperty('mounts');
+      }
+    });
+  });
+
+  describe('pages.getPage', () => {
+    it('returns a page for a known path', async () => {
+      const svc = createMimirMockAdapter();
+      const page = await svc.pages.getPage('/arch/overview');
+      expect(page).not.toBeNull();
+      expect(page!.path).toBe('/arch/overview');
+    });
+
+    it('returns null for an unknown path', async () => {
+      const svc = createMimirMockAdapter();
+      const page = await svc.pages.getPage('/does-not-exist');
+      expect(page).toBeNull();
+    });
+
+    it('returned page may have zones', async () => {
+      const svc = createMimirMockAdapter();
+      const page = await svc.pages.getPage('/arch/overview');
+      expect(page).not.toBeNull();
+      expect(page!.zones).toBeDefined();
+      expect(page!.zones!.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('pages.upsertPage', () => {
+    it('resolves without error', async () => {
+      const svc = createMimirMockAdapter();
+      await expect(svc.pages.upsertPage('/test/new', '# New')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('pages.search', () => {
+    it('returns results matching the query', async () => {
+      const svc = createMimirMockAdapter();
+      const results = await svc.pages.search('architecture');
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0]).toHaveProperty('path');
+      expect(results[0]).toHaveProperty('type');
+      expect(results[0]).toHaveProperty('confidence');
+    });
+
+    it('returns empty array for unmatched query', async () => {
+      const svc = createMimirMockAdapter();
+      const results = await svc.pages.search('xyzxyzxyz_no_match');
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('embeddings.semanticSearch', () => {
+    it('returns results with score and mountName', async () => {
+      const svc = createMimirMockAdapter();
+      const results = await svc.embeddings.semanticSearch('architecture');
+      expect(results.length).toBeGreaterThan(0);
+      for (const r of results) {
+        expect(r).toHaveProperty('score');
+        expect(r).toHaveProperty('mountName');
+        expect(r.score).toBeGreaterThan(0);
+        expect(r.score).toBeLessThanOrEqual(1);
+      }
+    });
+
+    it('respects topK limit', async () => {
+      const svc = createMimirMockAdapter();
+      const results = await svc.embeddings.semanticSearch('anything', 1);
+      expect(results.length).toBeLessThanOrEqual(1);
+    });
+  });
+
+  describe('lint.getLintReport', () => {
+    it('returns a report with issues and summary', async () => {
+      const svc = createMimirMockAdapter();
+      const report = await svc.lint.getLintReport();
+      expect(Array.isArray(report.issues)).toBe(true);
+      expect(typeof report.pagesChecked).toBe('number');
+      expect(report.summary).toHaveProperty('error');
+      expect(report.summary).toHaveProperty('warn');
+      expect(report.summary).toHaveProperty('info');
+    });
+
+    it('summary tallies match issue list', async () => {
+      const svc = createMimirMockAdapter();
+      const report = await svc.lint.getLintReport();
+      const manual = {
+        error: report.issues.filter((i) => i.severity === 'error').length,
+        warn: report.issues.filter((i) => i.severity === 'warn').length,
+        info: report.issues.filter((i) => i.severity === 'info').length,
+      };
+      expect(report.summary).toEqual(manual);
+    });
+  });
+
+  describe('lint.runAutoFix', () => {
+    it('removes auto-fixable issues', async () => {
+      const svc = createMimirMockAdapter();
+      const before = await svc.lint.getLintReport();
+      const after = await svc.lint.runAutoFix();
+      const autoFixableCount = before.issues.filter((i) => i.autoFix).length;
+      expect(after.issues.length).toBe(before.issues.length - autoFixableCount);
+    });
+
+    it('only fixes specified issue IDs when provided', async () => {
+      const svc = createMimirMockAdapter();
+      const before = await svc.lint.getLintReport();
+      const autoFixable = before.issues.filter((i) => i.autoFix);
+      if (autoFixable.length === 0) return;
+      const idToFix = autoFixable[0]!.id;
+      const after = await svc.lint.runAutoFix([idToFix]);
+      expect(after.issues.find((i) => i.id === idToFix)).toBeUndefined();
+    });
+  });
+
+  describe('lint.getDreamCycles', () => {
+    it('returns dream cycle records', async () => {
+      const svc = createMimirMockAdapter();
+      const cycles = await svc.lint.getDreamCycles();
+      expect(cycles.length).toBeGreaterThan(0);
+      for (const c of cycles) {
+        expect(c).toHaveProperty('id');
+        expect(c).toHaveProperty('ravn');
+        expect(c).toHaveProperty('timestamp');
+        expect(c).toHaveProperty('pagesUpdated');
+        expect(c).toHaveProperty('durationMs');
+      }
+    });
+
+    it('respects limit parameter', async () => {
+      const svc = createMimirMockAdapter();
+      const cycles = await svc.lint.getDreamCycles(1);
+      expect(cycles.length).toBeLessThanOrEqual(1);
+    });
+  });
+});

--- a/web-next/packages/plugin-mimir/src/adapters/mock.ts
+++ b/web-next/packages/plugin-mimir/src/adapters/mock.ts
@@ -1,0 +1,298 @@
+import type { Mount } from '@niuulabs/domain';
+import type { IMimirService } from '../ports';
+import type { PageMeta, Page, SearchResult } from '../domain/page';
+import type { LintIssue, LintReport, DreamCycle } from '../domain/lint';
+import type { MimirStats } from '../domain/api-types';
+import type { EmbeddingSearchResult } from '../ports/IEmbeddingStore';
+import { tallySeverity } from '../domain/lint';
+import { toPageMeta } from '../domain/page';
+
+// ---------------------------------------------------------------------------
+// Seed data
+// ---------------------------------------------------------------------------
+
+const MOCK_MOUNTS: Mount[] = [
+  {
+    name: 'local',
+    role: 'local',
+    host: 'localhost',
+    url: 'http://localhost:7700',
+    priority: 1,
+    categories: null,
+    status: 'healthy',
+    pages: 42,
+    sources: 18,
+    lintIssues: 3,
+    lastWrite: '2026-04-18T14:22:00Z',
+    embedding: 'all-minilm-l6-v2',
+    sizeKb: 512,
+    desc: "Operator's local knowledge store",
+  },
+  {
+    name: 'shared',
+    role: 'shared',
+    host: 'kb.niuu.world',
+    url: 'https://kb.niuu.world',
+    priority: 5,
+    categories: null,
+    status: 'healthy',
+    pages: 210,
+    sources: 87,
+    lintIssues: 7,
+    lastWrite: '2026-04-19T09:00:00Z',
+    embedding: 'all-mpnet-base-v2',
+    sizeKb: 4096,
+    desc: 'Realm-wide shared knowledge base',
+  },
+  {
+    name: 'platform',
+    role: 'domain',
+    host: 'platform-kb.niuu.world',
+    url: 'https://platform-kb.niuu.world',
+    priority: 3,
+    categories: ['infra', 'api', 'arch'],
+    status: 'degraded',
+    pages: 65,
+    sources: 31,
+    lintIssues: 12,
+    lastWrite: '2026-04-17T16:45:00Z',
+    embedding: 'all-minilm-l6-v2',
+    sizeKb: 1024,
+    desc: 'Platform-scoped domain knowledge (infra / api / arch)',
+  },
+];
+
+const MOCK_PAGES: Page[] = [
+  {
+    path: '/arch/overview',
+    title: 'Architecture Overview',
+    summary: 'High-level view of the Niuu platform architecture.',
+    category: 'arch',
+    type: 'topic',
+    confidence: 'high',
+    mounts: ['local', 'shared'],
+    updatedAt: '2026-04-18T10:00:00Z',
+    updatedBy: 'ravn-fjolnir',
+    sourceIds: ['src-001', 'src-002'],
+    related: ['/arch/hexagonal', '/api/overview'],
+    size: 3200,
+    zones: [
+      {
+        kind: 'key-facts',
+        items: [
+          'Hexagonal architecture with ports and adapters',
+          'Six cognitive regions (Sköll, Hati, Sága, Móði, Váli, Víðarr)',
+          'Tyr, Volundr, and Niuu are separate modules',
+        ],
+      },
+      {
+        kind: 'assessment',
+        text: 'Architecture is sound and well-documented. Consider extracting shared domain types.',
+      },
+    ],
+  },
+  {
+    path: '/api/overview',
+    title: 'API Design Guidelines',
+    summary: 'Standards and conventions for Niuu REST APIs.',
+    category: 'api',
+    type: 'directive',
+    confidence: 'high',
+    mounts: ['shared'],
+    updatedAt: '2026-04-15T09:30:00Z',
+    updatedBy: 'ravn-skald',
+    sourceIds: ['src-003'],
+    related: ['/arch/overview'],
+    size: 2100,
+    zones: [
+      {
+        kind: 'key-facts',
+        items: [
+          'Raw SQL with asyncpg — no ORM',
+          'Parameterised queries only',
+          'Hexagonal adapter pattern for all infrastructure',
+        ],
+      },
+      {
+        kind: 'timeline',
+        items: [
+          { date: '2026-01-10', note: 'Initial guidelines published', source: 'src-003' },
+          { date: '2026-03-20', note: 'Added asyncpg section', source: 'src-003' },
+        ],
+      },
+    ],
+  },
+  {
+    path: '/infra/k8s',
+    title: 'Kubernetes Deployment',
+    summary: 'Kubernetes-native deployment patterns for the Niuu platform.',
+    category: 'infra',
+    type: 'topic',
+    confidence: 'medium',
+    mounts: ['platform'],
+    updatedAt: '2026-04-10T14:00:00Z',
+    updatedBy: 'ravn-fjolnir',
+    sourceIds: ['src-004', 'src-005'],
+    related: ['/infra/envoy', '/arch/overview'],
+    size: 4500,
+    zones: [
+      {
+        kind: 'key-facts',
+        items: [
+          'Uses `migrate` for schema migrations (not Alembic)',
+          'Envoy as API gateway with OIDC',
+          'Services exposed as ClusterIP internally',
+        ],
+      },
+    ],
+  },
+];
+
+const MOCK_LINT_ISSUES: LintIssue[] = [
+  {
+    id: 'lint-001',
+    rule: 'L05',
+    severity: 'error',
+    page: '/arch/hexagonal',
+    mount: 'local',
+    autoFix: false,
+    message: 'Broken wikilink: [[ports/overview]] — target page does not exist',
+  },
+  {
+    id: 'lint-002',
+    rule: 'L07',
+    severity: 'warn',
+    page: '/infra/legacy-proxy',
+    mount: 'platform',
+    assignee: 'ravn-skald',
+    autoFix: true,
+    message: 'Orphan page — no inbound links from any other page',
+  },
+  {
+    id: 'lint-003',
+    rule: 'L12',
+    severity: 'info',
+    page: '/api/overview',
+    mount: 'shared',
+    autoFix: true,
+    message: 'Missing required frontmatter field: `owner`',
+  },
+];
+
+const MOCK_DREAM_CYCLES: DreamCycle[] = [
+  {
+    id: 'dream-001',
+    timestamp: '2026-04-19T03:00:00Z',
+    ravn: 'ravn-fjolnir',
+    mounts: ['local', 'shared'],
+    pagesUpdated: 8,
+    entitiesCreated: 2,
+    lintFixes: 1,
+    durationMs: 42000,
+  },
+  {
+    id: 'dream-002',
+    timestamp: '2026-04-18T03:00:00Z',
+    ravn: 'ravn-fjolnir',
+    mounts: ['shared', 'platform'],
+    pagesUpdated: 14,
+    entitiesCreated: 5,
+    lintFixes: 3,
+    durationMs: 67000,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Mock adapter
+// ---------------------------------------------------------------------------
+
+export function createMimirMockAdapter(): IMimirService {
+  return {
+    mounts: {
+      async listMounts(): Promise<Mount[]> {
+        return MOCK_MOUNTS;
+      },
+    },
+
+    pages: {
+      async getStats(): Promise<MimirStats> {
+        const categories = [...new Set(MOCK_PAGES.map((p) => p.category))];
+        return {
+          pageCount: MOCK_PAGES.length,
+          categories,
+          healthy: MOCK_MOUNTS.every((m) => m.status !== 'down'),
+        };
+      },
+
+      async listPages(options): Promise<PageMeta[]> {
+        let pages = MOCK_PAGES;
+        if (options?.mountName) {
+          pages = pages.filter((p) => p.mounts.includes(options.mountName!));
+        }
+        if (options?.category) {
+          pages = pages.filter((p) => p.category === options.category);
+        }
+        return pages.map(toPageMeta);
+      },
+
+      async getPage(path: string): Promise<Page | null> {
+        return MOCK_PAGES.find((p) => p.path === path) ?? null;
+      },
+
+      async upsertPage(): Promise<void> {
+        // no-op in mock
+      },
+
+      async search(query: string): Promise<SearchResult[]> {
+        const q = query.toLowerCase();
+        return MOCK_PAGES.filter(
+          (p) => p.title.toLowerCase().includes(q) || p.summary.toLowerCase().includes(q),
+        ).map((p) => ({
+          path: p.path,
+          title: p.title,
+          summary: p.summary,
+          category: p.category,
+          type: p.type,
+          confidence: p.confidence,
+        }));
+      },
+    },
+
+    embeddings: {
+      async semanticSearch(_query: string, topK = 10): Promise<EmbeddingSearchResult[]> {
+        return MOCK_PAGES.slice(0, topK).map((p, i) => ({
+          path: p.path,
+          title: p.title,
+          summary: p.summary,
+          score: Math.max(0.5, 0.95 - i * 0.15),
+          mountName: p.mounts[0] ?? 'local',
+        }));
+      },
+    },
+
+    lint: {
+      async getLintReport(): Promise<LintReport> {
+        return {
+          issues: MOCK_LINT_ISSUES,
+          pagesChecked: MOCK_PAGES.length,
+          summary: tallySeverity(MOCK_LINT_ISSUES),
+        };
+      },
+
+      async runAutoFix(issueIds?: string[]): Promise<LintReport> {
+        const remaining = issueIds
+          ? MOCK_LINT_ISSUES.filter((i) => !issueIds.includes(i.id) || !i.autoFix)
+          : MOCK_LINT_ISSUES.filter((i) => !i.autoFix);
+        return {
+          issues: remaining,
+          pagesChecked: MOCK_PAGES.length,
+          summary: tallySeverity(remaining),
+        };
+      },
+
+      async getDreamCycles(limit = 20): Promise<DreamCycle[]> {
+        return MOCK_DREAM_CYCLES.slice(0, limit);
+      },
+    },
+  };
+}

--- a/web-next/packages/plugin-mimir/src/api/client.test.ts
+++ b/web-next/packages/plugin-mimir/src/api/client.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGet = vi.fn();
+const mockPost = vi.fn();
+const mockPut = vi.fn();
+
+vi.mock('@niuulabs/query', () => ({
+  createApiClient: () => ({
+    get: (...args: unknown[]) => mockGet(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+    put: (...args: unknown[]) => mockPut(...args),
+  }),
+}));
+
+import {
+  getStats,
+  listPages,
+  getPage,
+  search,
+  getLog,
+  getLint,
+  lintFix,
+  upsertPage,
+  getGraph,
+  ingest,
+} from './client';
+
+describe('mimir API client', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getStats', () => {
+    it('maps raw stats to domain model', async () => {
+      mockGet.mockResolvedValue({
+        page_count: 42,
+        categories: ['infra', 'api'],
+        healthy: true,
+      });
+
+      const result = await getStats();
+
+      expect(mockGet).toHaveBeenCalledWith('/stats');
+      expect(result).toEqual({
+        pageCount: 42,
+        categories: ['infra', 'api'],
+        healthy: true,
+      });
+    });
+  });
+
+  describe('listPages', () => {
+    it('lists all pages without category filter', async () => {
+      mockGet.mockResolvedValue([
+        {
+          path: '/arch/overview',
+          title: 'Architecture Overview',
+          summary: 'Main overview',
+          category: 'infra',
+          updated_at: '2026-04-01T10:00:00Z',
+          source_ids: ['src-1'],
+        },
+      ]);
+
+      const result = await listPages();
+
+      expect(mockGet).toHaveBeenCalledWith('/pages');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        path: '/arch/overview',
+        title: 'Architecture Overview',
+        summary: 'Main overview',
+        category: 'infra',
+        updatedAt: '2026-04-01T10:00:00Z',
+        sourceIds: ['src-1'],
+      });
+    });
+
+    it('filters pages by category', async () => {
+      mockGet.mockResolvedValue([]);
+
+      await listPages('infra');
+
+      expect(mockGet).toHaveBeenCalledWith('/pages?category=infra');
+    });
+
+    it('defaults sourceIds to empty array when absent', async () => {
+      mockGet.mockResolvedValue([
+        {
+          path: '/test',
+          title: 'Test',
+          summary: 'Sum',
+          category: 'cat',
+          updated_at: '2026-01-01T00:00:00Z',
+        },
+      ]);
+
+      const result = await listPages();
+      expect(result[0]!.sourceIds).toEqual([]);
+    });
+  });
+
+  describe('getPage', () => {
+    it('fetches and maps a single page', async () => {
+      mockGet.mockResolvedValue({
+        path: '/arch/api',
+        title: 'API Design',
+        summary: 'API guidelines',
+        category: 'api',
+        updated_at: '2026-03-15T12:00:00Z',
+        content: '# API Design\n\nGuidelines here.',
+      });
+
+      const result = await getPage('/arch/api');
+
+      expect(mockGet).toHaveBeenCalledWith('/page?path=%2Farch%2Fapi');
+      expect(result.path).toBe('/arch/api');
+      expect(result.content).toContain('# API Design');
+      expect(result.updatedAt).toBe('2026-03-15T12:00:00Z');
+      expect(result.sourceIds).toEqual([]);
+    });
+  });
+
+  describe('search', () => {
+    it('maps search results', async () => {
+      mockGet.mockResolvedValue([
+        {
+          path: '/infra/k8s',
+          title: 'Kubernetes',
+          summary: 'K8s deployment guide',
+          category: 'infra',
+          updated_at: '2026-02-01T00:00:00Z',
+        },
+      ]);
+
+      const result = await search('kubernetes');
+
+      expect(mockGet).toHaveBeenCalledWith('/search?q=kubernetes');
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        path: '/infra/k8s',
+        title: 'Kubernetes',
+        summary: 'K8s deployment guide',
+        category: 'infra',
+      });
+    });
+  });
+
+  describe('getLog', () => {
+    it('fetches log with default count', async () => {
+      mockGet.mockResolvedValue({
+        raw: 'line1\nline2',
+        entries: ['line1', 'line2'],
+      });
+
+      const result = await getLog();
+
+      expect(mockGet).toHaveBeenCalledWith('/log?n=50');
+      expect(result).toEqual({
+        raw: 'line1\nline2',
+        entries: ['line1', 'line2'],
+      });
+    });
+
+    it('fetches log with custom count', async () => {
+      mockGet.mockResolvedValue({ raw: '', entries: [] });
+
+      await getLog(100);
+
+      expect(mockGet).toHaveBeenCalledWith('/log?n=100');
+    });
+  });
+
+  describe('getLint', () => {
+    it('maps lint report', async () => {
+      mockGet.mockResolvedValue({
+        issues: [
+          {
+            id: 'lint-1',
+            severity: 'warning',
+            message: 'Missing summary',
+            page_path: '/arch/api',
+            auto_fixable: true,
+          },
+        ],
+        pages_checked: 10,
+        issues_found: true,
+        summary: { error: 0, warning: 1, info: 0 },
+      });
+
+      const result = await getLint();
+
+      expect(mockGet).toHaveBeenCalledWith('/lint');
+      expect(result.pagesChecked).toBe(10);
+      expect(result.issuesFound).toBe(true);
+      expect(result.issues).toHaveLength(1);
+      expect(result.issues[0]).toEqual({
+        id: 'lint-1',
+        severity: 'warning',
+        message: 'Missing summary',
+        pagePath: '/arch/api',
+        autoFixable: true,
+      });
+    });
+  });
+
+  describe('lintFix', () => {
+    it('posts lint fix and maps result', async () => {
+      mockPost.mockResolvedValue({
+        issues: [],
+        pages_checked: 10,
+        issues_found: false,
+        summary: { error: 0, warning: 0, info: 0 },
+      });
+
+      const result = await lintFix();
+
+      expect(mockPost).toHaveBeenCalledWith('/lint/fix', {});
+      expect(result.issuesFound).toBe(false);
+    });
+  });
+
+  describe('upsertPage', () => {
+    it('puts page content', async () => {
+      mockPut.mockResolvedValue(undefined);
+
+      await upsertPage('/test/page', '# New Content');
+
+      expect(mockPut).toHaveBeenCalledWith('/page', {
+        path: '/test/page',
+        content: '# New Content',
+      });
+    });
+  });
+
+  describe('getGraph', () => {
+    it('maps graph nodes and edges', async () => {
+      mockGet.mockResolvedValue({
+        nodes: [
+          { id: 'n1', title: 'Node 1', category: 'infra' },
+          { id: 'n2', title: 'Node 2', category: 'api' },
+        ],
+        edges: [{ source: 'n1', target: 'n2' }],
+      });
+
+      const result = await getGraph();
+
+      expect(mockGet).toHaveBeenCalledWith('/graph');
+      expect(result.nodes).toHaveLength(2);
+      expect(result.nodes[0]).toEqual({ id: 'n1', title: 'Node 1', category: 'infra' });
+      expect(result.edges).toHaveLength(1);
+      expect(result.edges[0]).toEqual({ source: 'n1', target: 'n2' });
+    });
+  });
+
+  describe('ingest', () => {
+    it('posts ingest request and maps response', async () => {
+      mockPost.mockResolvedValue({
+        source_id: 'src-abc',
+        pages_updated: ['/arch/new-page'],
+      });
+
+      const result = await ingest({
+        title: 'New doc',
+        content: 'Some content',
+        sourceType: 'document',
+        originUrl: 'https://example.com/doc',
+      });
+
+      expect(mockPost).toHaveBeenCalledWith('/ingest', {
+        title: 'New doc',
+        content: 'Some content',
+        source_type: 'document',
+        origin_url: 'https://example.com/doc',
+      });
+      expect(result).toEqual({
+        sourceId: 'src-abc',
+        pagesUpdated: ['/arch/new-page'],
+      });
+    });
+  });
+});

--- a/web-next/packages/plugin-mimir/src/api/client.ts
+++ b/web-next/packages/plugin-mimir/src/api/client.ts
@@ -1,0 +1,251 @@
+/**
+ * Mimir API client.
+ *
+ * Function-based client that wraps the shared ApiClient for Mimir endpoints.
+ * In production the Mimir service is exposed at /mimir on the same origin
+ * (routed by Envoy).
+ *
+ * Copied from web/src/modules/mimir/api/client.ts — import updated to
+ * @niuulabs/query, all mapping logic preserved.
+ */
+
+import { createApiClient } from '@niuulabs/query';
+import type {
+  LintIssueHttp,
+  MimirStats,
+  MimirPageMeta,
+  MimirPage,
+  MimirSearchResult,
+  MimirLintReport,
+  MimirLogEntry,
+  MimirGraph,
+  GraphNode,
+  GraphEdge,
+  IngestRequest,
+  IngestResponse,
+} from '../domain/api-types';
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+const api = createApiClient('/mimir');
+
+interface RawPageMeta {
+  path: string;
+  title: string;
+  summary: string;
+  category: string;
+  updated_at: string;
+  source_ids?: string[];
+}
+
+interface RawPage extends RawPageMeta {
+  content: string;
+}
+
+interface RawStats {
+  page_count: number;
+  categories: string[];
+  healthy: boolean;
+}
+
+interface RawLintIssue {
+  id: string;
+  severity: string;
+  message: string;
+  page_path: string;
+  auto_fixable: boolean;
+}
+
+interface RawLintReport {
+  issues: RawLintIssue[];
+  pages_checked: number;
+  issues_found: boolean;
+  summary: { error: number; warning: number; info: number };
+}
+
+interface RawLogEntry {
+  raw: string;
+  entries: string[];
+}
+
+interface RawGraphNode {
+  id: string;
+  title: string;
+  category: string;
+}
+
+interface RawGraphEdge {
+  source: string;
+  target: string;
+}
+
+interface RawGraph {
+  nodes: RawGraphNode[];
+  edges: RawGraphEdge[];
+}
+
+interface RawIngestResponse {
+  source_id: string;
+  pages_updated: string[];
+}
+
+function toMeta(raw: RawPageMeta): MimirPageMeta {
+  return {
+    path: raw.path,
+    title: raw.title,
+    summary: raw.summary,
+    category: raw.category,
+    updatedAt: raw.updated_at,
+    sourceIds: raw.source_ids ?? [],
+  };
+}
+
+function toPage(raw: RawPage): MimirPage {
+  return {
+    ...toMeta(raw),
+    content: raw.content,
+  };
+}
+
+function toStats(raw: RawStats): MimirStats {
+  return {
+    pageCount: raw.page_count,
+    categories: raw.categories,
+    healthy: raw.healthy,
+  };
+}
+
+function toLintIssue(raw: RawLintIssue): LintIssueHttp {
+  return {
+    id: raw.id,
+    severity: raw.severity as LintIssueHttp['severity'],
+    message: raw.message,
+    pagePath: raw.page_path,
+    autoFixable: raw.auto_fixable,
+  };
+}
+
+function toLintReport(raw: RawLintReport): MimirLintReport {
+  return {
+    issues: raw.issues.map(toLintIssue),
+    pagesChecked: raw.pages_checked,
+    issuesFound: raw.issues_found,
+    summary: raw.summary,
+  };
+}
+
+function toLogEntry(raw: RawLogEntry): MimirLogEntry {
+  return {
+    raw: raw.raw,
+    entries: raw.entries,
+  };
+}
+
+function toSearchResult(raw: RawPageMeta): MimirSearchResult {
+  return {
+    path: raw.path,
+    title: raw.title,
+    summary: raw.summary,
+    category: raw.category,
+  };
+}
+
+function toGraphNode(raw: RawGraphNode): GraphNode {
+  return {
+    id: raw.id,
+    title: raw.title,
+    category: raw.category,
+  };
+}
+
+function toGraphEdge(raw: RawGraphEdge): GraphEdge {
+  return {
+    source: raw.source,
+    target: raw.target,
+  };
+}
+
+function toGraph(raw: RawGraph): MimirGraph {
+  return {
+    nodes: raw.nodes.map(toGraphNode),
+    edges: raw.edges.map(toGraphEdge),
+  };
+}
+
+function toIngestResponse(raw: RawIngestResponse): IngestResponse {
+  return {
+    sourceId: raw.source_id,
+    pagesUpdated: raw.pages_updated,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/** GET /stats */
+export async function getStats(): Promise<MimirStats> {
+  const raw = await api.get<RawStats>('/stats');
+  return toStats(raw);
+}
+
+/** GET /pages (optionally filtered by category) */
+export async function listPages(category?: string): Promise<MimirPageMeta[]> {
+  const qs = category ? `?category=${encodeURIComponent(category)}` : '';
+  const raw = await api.get<RawPageMeta[]>(`/pages${qs}`);
+  return raw.map(toMeta);
+}
+
+/** GET /page?path= */
+export async function getPage(path: string): Promise<MimirPage> {
+  const raw = await api.get<RawPage>(`/page?path=${encodeURIComponent(path)}`);
+  return toPage(raw);
+}
+
+/** GET /search?q= */
+export async function search(query: string): Promise<MimirSearchResult[]> {
+  const raw = await api.get<RawPageMeta[]>(`/search?q=${encodeURIComponent(query)}`);
+  return raw.map(toSearchResult);
+}
+
+/** GET /log?n= */
+export async function getLog(n = 50): Promise<MimirLogEntry> {
+  const raw = await api.get<RawLogEntry>(`/log?n=${n}`);
+  return toLogEntry(raw);
+}
+
+/** GET /lint */
+export async function getLint(): Promise<MimirLintReport> {
+  const raw = await api.get<RawLintReport>('/lint');
+  return toLintReport(raw);
+}
+
+/** POST /lint/fix — run lint and apply auto-fixes */
+export async function lintFix(): Promise<MimirLintReport> {
+  const raw = await api.post<RawLintReport>('/lint/fix', {});
+  return toLintReport(raw);
+}
+
+/** PUT /page */
+export async function upsertPage(path: string, content: string): Promise<void> {
+  await api.put<void>('/page', { path, content });
+}
+
+/** GET /graph */
+export async function getGraph(): Promise<MimirGraph> {
+  const raw = await api.get<RawGraph>('/graph');
+  return toGraph(raw);
+}
+
+/** POST /ingest */
+export async function ingest(request: IngestRequest): Promise<IngestResponse> {
+  const raw = await api.post<RawIngestResponse>('/ingest', {
+    title: request.title,
+    content: request.content,
+    source_type: request.sourceType,
+    origin_url: request.originUrl,
+  });
+  return toIngestResponse(raw);
+}

--- a/web-next/packages/plugin-mimir/src/domain/api-types.test.ts
+++ b/web-next/packages/plugin-mimir/src/domain/api-types.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { transitionJob, isTerminal } from './api-types';
+import type { IngestJob } from './api-types';
+
+const baseJob: IngestJob = {
+  id: 'job-1',
+  title: 'Test Job',
+  sourceType: 'document',
+  status: 'queued',
+  instanceName: 'worker-1',
+  pagesUpdated: [],
+};
+
+describe('transitionJob', () => {
+  it('merges update into job', () => {
+    const result = transitionJob(baseJob, { status: 'running' });
+    expect(result.status).toBe('running');
+    expect(result.id).toBe('job-1');
+  });
+
+  it('preserves fields not in update', () => {
+    const result = transitionJob(baseJob, { currentActivity: 'Processing...' });
+    expect(result.title).toBe('Test Job');
+    expect(result.currentActivity).toBe('Processing...');
+  });
+
+  it('returns a new object (does not mutate original)', () => {
+    const result = transitionJob(baseJob, { status: 'complete' });
+    expect(result).not.toBe(baseJob);
+    expect(baseJob.status).toBe('queued');
+  });
+});
+
+describe('isTerminal', () => {
+  it('returns true for complete', () => {
+    expect(isTerminal('complete')).toBe(true);
+  });
+
+  it('returns true for failed', () => {
+    expect(isTerminal('failed')).toBe(true);
+  });
+
+  it('returns false for queued', () => {
+    expect(isTerminal('queued')).toBe(false);
+  });
+
+  it('returns false for running', () => {
+    expect(isTerminal('running')).toBe(false);
+  });
+});

--- a/web-next/packages/plugin-mimir/src/domain/api-types.ts
+++ b/web-next/packages/plugin-mimir/src/domain/api-types.ts
@@ -1,0 +1,129 @@
+/**
+ * Mimir HTTP-level domain types.
+ *
+ * Copied from web/src/modules/mimir/api/types.ts — these match the existing
+ * Mimir HTTP API wire format (snake_case → camelCase mapping done in api/client.ts).
+ */
+
+// ---------------------------------------------------------------------------
+// Pages & knowledge base
+// ---------------------------------------------------------------------------
+
+export interface MimirPageMeta {
+  path: string;
+  title: string;
+  summary: string;
+  category: string;
+  updatedAt: string;
+  sourceIds: string[];
+}
+
+export interface MimirPage extends MimirPageMeta {
+  content: string;
+}
+
+export interface MimirStats {
+  pageCount: number;
+  categories: string[];
+  healthy: boolean;
+}
+
+export interface MimirSearchResult {
+  path: string;
+  title: string;
+  summary: string;
+  category: string;
+}
+
+export type LintSeverity = 'error' | 'warning' | 'info';
+
+export interface LintIssueHttp {
+  id: string;
+  severity: LintSeverity;
+  message: string;
+  pagePath: string;
+  autoFixable: boolean;
+}
+
+export interface MimirLintReport {
+  issues: LintIssueHttp[];
+  pagesChecked: number;
+  issuesFound: boolean;
+  summary: { error: number; warning: number; info: number };
+}
+
+export interface MimirLogEntry {
+  raw: string;
+  entries: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Knowledge graph
+// ---------------------------------------------------------------------------
+
+export interface GraphNode {
+  id: string;
+  title: string;
+  category: string;
+  /** Number of inbound edges -- set during graph processing. */
+  inboundCount?: number;
+}
+
+export interface GraphEdge {
+  source: string;
+  target: string;
+}
+
+export interface MimirGraph {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
+
+// ---------------------------------------------------------------------------
+// Ingest
+// ---------------------------------------------------------------------------
+
+export type IngestStatus = 'queued' | 'running' | 'complete' | 'failed';
+
+export type IngestSourceType = 'document' | 'web' | 'conversation' | 'text';
+
+export interface IngestJob {
+  id: string;
+  title: string;
+  sourceType: IngestSourceType;
+  status: IngestStatus;
+  instanceName: string;
+  /** Pages written during run. */
+  pagesUpdated: string[];
+  /** Current activity message when running. */
+  currentActivity?: string;
+  startedAt?: string;
+  completedAt?: string;
+  errorMessage?: string;
+}
+
+export interface IngestRequest {
+  title: string;
+  content: string;
+  sourceType: IngestSourceType;
+  originUrl?: string;
+}
+
+export interface IngestResponse {
+  sourceId: string;
+  pagesUpdated: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Transition the job to the next state. */
+export function transitionJob(job: IngestJob, update: Partial<IngestJob>): IngestJob {
+  return { ...job, ...update };
+}
+
+/** Returns true if the job is in a terminal state. */
+export function isTerminal(status: IngestStatus): boolean {
+  return status === 'complete' || status === 'failed';
+}

--- a/web-next/packages/plugin-mimir/src/domain/entity.ts
+++ b/web-next/packages/plugin-mimir/src/domain/entity.ts
@@ -1,0 +1,19 @@
+/**
+ * Mímir entity domain — typed entity pages.
+ *
+ * Entities are a sub-type of pages that represent real-world objects: people,
+ * organisations, concepts, projects, etc. Each entity has a kind that
+ * determines which glyph and grouping the UI uses.
+ */
+
+export type EntityKind = 'person' | 'org' | 'concept' | 'project' | 'component' | 'technology';
+
+export interface EntityMeta {
+  /** Page path — same as the underlying Page.path. */
+  path: string;
+  title: string;
+  entityKind: EntityKind;
+  summary: string;
+  /** Number of explicit relationship links from this entity's Relationships zone. */
+  relationshipCount: number;
+}

--- a/web-next/packages/plugin-mimir/src/domain/index.ts
+++ b/web-next/packages/plugin-mimir/src/domain/index.ts
@@ -1,0 +1,41 @@
+export type {
+  MimirPageMeta,
+  MimirPage,
+  MimirStats,
+  MimirSearchResult,
+  LintSeverity,
+  LintIssueHttp,
+  MimirLintReport,
+  MimirLogEntry,
+  GraphNode,
+  GraphEdge,
+  MimirGraph,
+  IngestStatus,
+  IngestSourceType,
+  IngestJob,
+  IngestRequest,
+  IngestResponse,
+} from './api-types';
+export { transitionJob, isTerminal } from './api-types';
+
+export type {
+  PageType,
+  Confidence,
+  ZoneKind,
+  ZoneKeyFacts,
+  ZoneRelationships,
+  ZoneAssessment,
+  ZoneTimeline,
+  Zone,
+  PageMeta,
+  Page,
+  SearchResult,
+} from './page';
+export { isHighConfidence, getZoneByKind, toPageMeta } from './page';
+
+export type { OriginType, Source } from './source';
+
+export type { EntityKind, EntityMeta } from './entity';
+
+export type { LintRule, IssueSeverity, LintIssue, LintReport, DreamCycle } from './lint';
+export { isAutoFixable, tallySeverity } from './lint';

--- a/web-next/packages/plugin-mimir/src/domain/lint.test.ts
+++ b/web-next/packages/plugin-mimir/src/domain/lint.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { isAutoFixable, tallySeverity } from './lint';
+import type { LintIssue, DreamCycle } from './lint';
+
+const makeIssue = (overrides: Partial<LintIssue> = {}): LintIssue => ({
+  id: 'lint-001',
+  rule: 'L05',
+  severity: 'error',
+  page: '/arch/overview',
+  mount: 'local',
+  autoFix: false,
+  message: 'Broken wikilink',
+  ...overrides,
+});
+
+describe('isAutoFixable', () => {
+  it('returns true when autoFix is true', () => {
+    expect(isAutoFixable(makeIssue({ autoFix: true }))).toBe(true);
+  });
+
+  it('returns false when autoFix is false', () => {
+    expect(isAutoFixable(makeIssue({ autoFix: false }))).toBe(false);
+  });
+});
+
+describe('tallySeverity', () => {
+  it('counts each severity level', () => {
+    const issues: LintIssue[] = [
+      makeIssue({ severity: 'error' }),
+      makeIssue({ severity: 'error' }),
+      makeIssue({ severity: 'warn' }),
+      makeIssue({ severity: 'info' }),
+    ];
+    expect(tallySeverity(issues)).toEqual({ error: 2, warn: 1, info: 1 });
+  });
+
+  it('returns all zeroes for empty list', () => {
+    expect(tallySeverity([])).toEqual({ error: 0, warn: 0, info: 0 });
+  });
+
+  it('handles all-info list', () => {
+    const issues = [makeIssue({ severity: 'info' }), makeIssue({ severity: 'info' })];
+    expect(tallySeverity(issues)).toEqual({ error: 0, warn: 0, info: 2 });
+  });
+});
+
+describe('LintIssue structure', () => {
+  it('carries rule code, severity, page, mount, and message', () => {
+    const issue = makeIssue({ rule: 'L12', severity: 'info', assignee: 'ravn-skald' });
+    expect(issue.rule).toBe('L12');
+    expect(issue.severity).toBe('info');
+    expect(issue.page).toBe('/arch/overview');
+    expect(issue.mount).toBe('local');
+    expect(issue.assignee).toBe('ravn-skald');
+  });
+});
+
+describe('DreamCycle structure', () => {
+  it('carries all required fields', () => {
+    const cycle: DreamCycle = {
+      id: 'dream-001',
+      timestamp: '2026-04-19T03:00:00Z',
+      ravn: 'ravn-fjolnir',
+      mounts: ['local', 'shared'],
+      pagesUpdated: 8,
+      entitiesCreated: 2,
+      lintFixes: 1,
+      durationMs: 42000,
+    };
+    expect(cycle.id).toBe('dream-001');
+    expect(cycle.mounts).toHaveLength(2);
+    expect(cycle.durationMs).toBe(42000);
+  });
+});

--- a/web-next/packages/plugin-mimir/src/domain/lint.ts
+++ b/web-next/packages/plugin-mimir/src/domain/lint.ts
@@ -1,0 +1,81 @@
+/**
+ * Mímir lint domain — issue catalog and dream-cycle records.
+ *
+ * The lint engine runs rules L01–L12 across all mounts and surfaces issues
+ * for human review or automated fixing. Dream cycles are the idle-time
+ * synthesis passes that update pages, create entities, and apply lint fixes.
+ */
+
+// ---------------------------------------------------------------------------
+// Lint rules and issues
+// ---------------------------------------------------------------------------
+
+/** Canonical lint rule identifiers. */
+export type LintRule =
+  | 'L01' // Contradiction between pages
+  | 'L02' // Stale source (source updated, page not recompiled)
+  | 'L05' // Broken wikilink
+  | 'L07' // Orphan page (no inbound links)
+  | 'L11' // Stale index (mount index out of sync)
+  | 'L12'; // Invalid frontmatter
+
+export type IssueSeverity = 'info' | 'warn' | 'error';
+
+export interface LintIssue {
+  id: string;
+  rule: LintRule;
+  severity: IssueSeverity;
+  /** Path of the page with the issue. */
+  page: string;
+  /** Name of the mount the page lives on. */
+  mount: string;
+  /** Ravn assigned to resolve this issue. */
+  assignee?: string;
+  /** Whether the engine can apply a fix automatically. */
+  autoFix: boolean;
+  message: string;
+}
+
+export interface LintReport {
+  issues: LintIssue[];
+  /** Number of pages scanned during this lint run. */
+  pagesChecked: number;
+  summary: { error: number; warn: number; info: number };
+}
+
+// ---------------------------------------------------------------------------
+// Dream cycles
+// ---------------------------------------------------------------------------
+
+export interface DreamCycle {
+  id: string;
+  /** ISO-8601 timestamp when the cycle ran. */
+  timestamp: string;
+  /** ID of the ravn that ran the cycle. */
+  ravn: string;
+  /** Names of the mounts touched during the cycle. */
+  mounts: string[];
+  pagesUpdated: number;
+  entitiesCreated: number;
+  lintFixes: number;
+  /** Wall-clock duration of the cycle in milliseconds. */
+  durationMs: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Returns true if the issue can be auto-fixed by the lint engine. */
+export function isAutoFixable(issue: LintIssue): boolean {
+  return issue.autoFix;
+}
+
+/** Tally issues by severity. */
+export function tallySeverity(issues: LintIssue[]): { error: number; warn: number; info: number } {
+  return {
+    error: issues.filter((i) => i.severity === 'error').length,
+    warn: issues.filter((i) => i.severity === 'warn').length,
+    info: issues.filter((i) => i.severity === 'info').length,
+  };
+}

--- a/web-next/packages/plugin-mimir/src/domain/page.test.ts
+++ b/web-next/packages/plugin-mimir/src/domain/page.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { isHighConfidence, getZoneByKind, toPageMeta } from './page';
+import type { Page, Zone, ZoneKeyFacts, ZoneAssessment } from './page';
+
+const basePage: Page = {
+  path: '/arch/overview',
+  title: 'Architecture Overview',
+  summary: 'High-level view of the Niuu platform architecture.',
+  category: 'arch',
+  type: 'topic',
+  confidence: 'high',
+  mounts: ['local'],
+  updatedAt: '2026-04-18T10:00:00Z',
+  updatedBy: 'ravn-fjolnir',
+  sourceIds: ['src-001'],
+  related: ['/arch/hexagonal'],
+  size: 3200,
+};
+
+describe('isHighConfidence', () => {
+  it('returns true for high confidence', () => {
+    expect(isHighConfidence({ confidence: 'high' })).toBe(true);
+  });
+
+  it('returns false for medium confidence', () => {
+    expect(isHighConfidence({ confidence: 'medium' })).toBe(false);
+  });
+
+  it('returns false for low confidence', () => {
+    expect(isHighConfidence({ confidence: 'low' })).toBe(false);
+  });
+});
+
+describe('getZoneByKind', () => {
+  const keyFacts: ZoneKeyFacts = { kind: 'key-facts', items: ['fact one', 'fact two'] };
+  const assessment: ZoneAssessment = { kind: 'assessment', text: 'Looking good.' };
+  const zones: Zone[] = [keyFacts, assessment];
+
+  it('finds a zone by its kind', () => {
+    const result = getZoneByKind(zones, 'key-facts');
+    expect(result).toBeDefined();
+    expect(result!.kind).toBe('key-facts');
+  });
+
+  it('returns the typed zone', () => {
+    const result = getZoneByKind(zones, 'key-facts');
+    expect(result!.items).toEqual(['fact one', 'fact two']);
+  });
+
+  it('returns undefined when the kind is not present', () => {
+    const result = getZoneByKind(zones, 'timeline');
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined for empty zones array', () => {
+    expect(getZoneByKind([], 'assessment')).toBeUndefined();
+  });
+});
+
+describe('toPageMeta', () => {
+  it('strips related and zones fields from a Page', () => {
+    const page: Page = {
+      ...basePage,
+      related: ['/other'],
+      zones: [{ kind: 'assessment', text: 'ok' }],
+    };
+    const meta = toPageMeta(page);
+    expect(meta).not.toHaveProperty('related');
+    expect(meta).not.toHaveProperty('zones');
+  });
+
+  it('preserves all PageMeta fields', () => {
+    const meta = toPageMeta(basePage);
+    expect(meta.path).toBe('/arch/overview');
+    expect(meta.title).toBe('Architecture Overview');
+    expect(meta.type).toBe('topic');
+    expect(meta.confidence).toBe('high');
+    expect(meta.mounts).toEqual(['local']);
+    expect(meta.updatedBy).toBe('ravn-fjolnir');
+    expect(meta.sourceIds).toEqual(['src-001']);
+    expect(meta.size).toBe(3200);
+  });
+});
+
+describe('Zone discriminated union', () => {
+  it('key-facts zone has items array', () => {
+    const zone: Zone = { kind: 'key-facts', items: ['a', 'b'] };
+    expect(zone.kind).toBe('key-facts');
+    if (zone.kind === 'key-facts') {
+      expect(zone.items).toHaveLength(2);
+    }
+  });
+
+  it('relationships zone has items with slug and note', () => {
+    const zone: Zone = {
+      kind: 'relationships',
+      items: [{ slug: '/other', note: 'related concept' }],
+    };
+    expect(zone.kind).toBe('relationships');
+    if (zone.kind === 'relationships') {
+      expect(zone.items[0]!.slug).toBe('/other');
+    }
+  });
+
+  it('assessment zone has text', () => {
+    const zone: Zone = { kind: 'assessment', text: 'Solid approach.' };
+    expect(zone.kind).toBe('assessment');
+    if (zone.kind === 'assessment') {
+      expect(zone.text).toBe('Solid approach.');
+    }
+  });
+
+  it('timeline zone has items with date, note, source', () => {
+    const zone: Zone = {
+      kind: 'timeline',
+      items: [{ date: '2026-01-01', note: 'Initial commit', source: 'src-001' }],
+    };
+    expect(zone.kind).toBe('timeline');
+    if (zone.kind === 'timeline') {
+      expect(zone.items[0]!.date).toBe('2026-01-01');
+    }
+  });
+});

--- a/web-next/packages/plugin-mimir/src/domain/page.ts
+++ b/web-next/packages/plugin-mimir/src/domain/page.ts
@@ -1,0 +1,120 @@
+/**
+ * Mímir page domain — the core knowledge-base entity.
+ *
+ * A page is a compiled-truth document assembled from raw sources. It has a
+ * type (entity / topic / directive / preference / decision), a confidence
+ * level, and structured zones that represent different aspects of knowledge.
+ */
+
+// ---------------------------------------------------------------------------
+// Page type and confidence
+// ---------------------------------------------------------------------------
+
+export type PageType = 'entity' | 'topic' | 'directive' | 'preference' | 'decision';
+
+export type Confidence = 'high' | 'medium' | 'low';
+
+// ---------------------------------------------------------------------------
+// Zones — structured content blocks within a page
+// ---------------------------------------------------------------------------
+
+export type ZoneKind = 'key-facts' | 'relationships' | 'assessment' | 'timeline';
+
+export interface ZoneKeyFacts {
+  kind: 'key-facts';
+  items: string[];
+}
+
+export interface ZoneRelationships {
+  kind: 'relationships';
+  items: Array<{ slug: string; note: string }>;
+}
+
+export interface ZoneAssessment {
+  kind: 'assessment';
+  text: string;
+}
+
+export interface ZoneTimeline {
+  kind: 'timeline';
+  items: Array<{ date: string; note: string; source: string }>;
+}
+
+export type Zone = ZoneKeyFacts | ZoneRelationships | ZoneAssessment | ZoneTimeline;
+
+// ---------------------------------------------------------------------------
+// Page types
+// ---------------------------------------------------------------------------
+
+/** Lightweight page reference shown in lists and search results. */
+export interface PageMeta {
+  path: string;
+  title: string;
+  summary: string;
+  category: string;
+  type: PageType;
+  confidence: Confidence;
+  entityType?: string;
+  /** Mounts that carry this page. */
+  mounts: string[];
+  updatedAt: string;
+  updatedBy: string;
+  sourceIds: string[];
+  size: number;
+}
+
+/** Full page with structured zone content. */
+export interface Page extends PageMeta {
+  /** Related page slugs. */
+  related: string[];
+  /** Structured zones — absent when the page hasn't been fully compiled. */
+  zones?: Zone[];
+}
+
+/** Minimal search result. */
+export interface SearchResult {
+  path: string;
+  title: string;
+  summary: string;
+  category: string;
+  type: PageType;
+  confidence: Confidence;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Returns true if the page has high confidence. */
+export function isHighConfidence(page: Pick<Page, 'confidence'>): boolean {
+  return page.confidence === 'high';
+}
+
+/**
+ * Find the first zone of a given kind in a page's zone list.
+ * Returns undefined if zones are absent or the kind isn't present.
+ */
+export function getZoneByKind<K extends ZoneKind>(
+  zones: Zone[],
+  kind: K,
+): Extract<Zone, { kind: K }> | undefined {
+  return zones.find((z): z is Extract<Zone, { kind: K }> => z.kind === kind);
+}
+
+/** Extract a PageMeta from a full Page. */
+export function toPageMeta(page: Page): PageMeta {
+  return {
+    path: page.path,
+    title: page.title,
+    summary: page.summary,
+    category: page.category,
+    type: page.type,
+    confidence: page.confidence,
+    entityType: page.entityType,
+    mounts: page.mounts,
+    updatedAt: page.updatedAt,
+    updatedBy: page.updatedBy,
+    sourceIds: page.sourceIds,
+    size: page.size,
+  };
+}

--- a/web-next/packages/plugin-mimir/src/domain/source.ts
+++ b/web-next/packages/plugin-mimir/src/domain/source.ts
@@ -1,0 +1,26 @@
+/**
+ * Mímir source domain — raw ingest records.
+ *
+ * Sources are append-only records of the original content that was ingested
+ * into a mount. Pages are compiled from one or more sources.
+ */
+
+export type OriginType = 'web' | 'rss' | 'arxiv' | 'file' | 'mail' | 'chat';
+
+export interface Source {
+  id: string;
+  title: string;
+  originType: OriginType;
+  /** URL of the original document (for web / rss / arxiv origins). */
+  originUrl?: string;
+  /** File system path (for file origins). */
+  originPath?: string;
+  /** ISO-8601 timestamp when the source was ingested. */
+  ingestedAt: string;
+  /** ID of the ravn that ingested this source. */
+  ingestAgent: string;
+  /** Paths of pages this source was compiled into. */
+  compiledInto: string[];
+  /** Original raw content. */
+  content: string;
+}

--- a/web-next/packages/plugin-mimir/src/index.tsx
+++ b/web-next/packages/plugin-mimir/src/index.tsx
@@ -1,0 +1,45 @@
+import { createRoute } from '@tanstack/react-router';
+import { definePlugin } from '@niuulabs/plugin-sdk';
+import { MimirPage } from './ui/MimirPage';
+
+export const mimirPlugin = definePlugin({
+  id: 'mimir',
+  rune: 'ᛗ',
+  title: 'Mímir',
+  subtitle: 'the well of knowledge',
+  routes: (rootRoute) => [
+    createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/mimir',
+      component: MimirPage,
+    }),
+  ],
+});
+
+export { createMimirMockAdapter } from './adapters/mock';
+export { buildMimirHttpAdapter } from './adapters/http';
+export type {
+  IMimirService,
+  IMountAdapter,
+  IPageStore,
+  IEmbeddingStore,
+  ILintEngine,
+  SearchMode,
+  EmbeddingSearchResult,
+} from './ports';
+export type {
+  PageType,
+  Confidence,
+  Zone,
+  ZoneKind,
+  ZoneKeyFacts,
+  ZoneRelationships,
+  ZoneAssessment,
+  ZoneTimeline,
+  PageMeta,
+  Page,
+  SearchResult,
+} from './domain/page';
+export type { LintRule, IssueSeverity, LintIssue, LintReport, DreamCycle } from './domain/lint';
+export type { Source, OriginType } from './domain/source';
+export type { EntityKind, EntityMeta } from './domain/entity';

--- a/web-next/packages/plugin-mimir/src/ports/IEmbeddingStore.ts
+++ b/web-next/packages/plugin-mimir/src/ports/IEmbeddingStore.ts
@@ -1,0 +1,31 @@
+/**
+ * Port: IEmbeddingStore
+ *
+ * Vector index per mount. Each mount may use a different embedding model;
+ * multi-mount semantic queries fan out to each mount and results are merged
+ * by the caller.
+ */
+export interface EmbeddingSearchResult {
+  path: string;
+  title: string;
+  summary: string;
+  /** Cosine similarity score in [0, 1]. */
+  score: number;
+  /** Name of the mount this result came from. */
+  mountName: string;
+}
+
+export interface IEmbeddingStore {
+  /**
+   * Run a semantic (vector) search against the embedding index.
+   *
+   * @param query     Natural-language query string.
+   * @param topK      Maximum results to return (default: 10).
+   * @param mountName Scope to a specific mount; omit for fleet-wide.
+   */
+  semanticSearch(
+    query: string,
+    topK?: number,
+    mountName?: string,
+  ): Promise<EmbeddingSearchResult[]>;
+}

--- a/web-next/packages/plugin-mimir/src/ports/ILintEngine.ts
+++ b/web-next/packages/plugin-mimir/src/ports/ILintEngine.ts
@@ -1,0 +1,29 @@
+import type { LintReport, DreamCycle } from '../domain/lint';
+
+/**
+ * Port: ILintEngine
+ *
+ * Runs lint rules (L01–L12) across mounted pages, surfaces issues, and
+ * tracks dream-cycle history.
+ */
+export interface ILintEngine {
+  /**
+   * Return the current lint report for one or all mounts.
+   *
+   * @param mountName Scope to a specific mount; omit for fleet-wide.
+   */
+  getLintReport(mountName?: string): Promise<LintReport>;
+
+  /**
+   * Apply auto-fixes for the given issue IDs (or all auto-fixable issues
+   * when omitted) and return the updated lint report.
+   */
+  runAutoFix(issueIds?: string[]): Promise<LintReport>;
+
+  /**
+   * Fetch recent dream-cycle run records, most-recent-first.
+   *
+   * @param limit Maximum records to return (default: 20).
+   */
+  getDreamCycles(limit?: number): Promise<DreamCycle[]>;
+}

--- a/web-next/packages/plugin-mimir/src/ports/IMountAdapter.ts
+++ b/web-next/packages/plugin-mimir/src/ports/IMountAdapter.ts
@@ -1,0 +1,13 @@
+import type { Mount } from '@niuulabs/domain';
+
+/**
+ * Port: IMountAdapter
+ *
+ * Provides access to the set of Mímir mounts registered in a deployment.
+ * Each mount is a standalone knowledge-base instance with its own storage,
+ * embedding model, and health signal.
+ */
+export interface IMountAdapter {
+  /** List all registered mounts and their current status. */
+  listMounts(): Promise<Mount[]>;
+}

--- a/web-next/packages/plugin-mimir/src/ports/IPageStore.ts
+++ b/web-next/packages/plugin-mimir/src/ports/IPageStore.ts
@@ -1,0 +1,38 @@
+import type { PageMeta, Page, SearchResult } from '../domain/page';
+import type { MimirStats } from '../domain/api-types';
+
+export type SearchMode = 'fts' | 'semantic' | 'hybrid';
+
+/**
+ * Port: IPageStore
+ *
+ * CRUD and search over compiled pages. A page store is scoped to one or more
+ * mounts depending on the adapter implementation.
+ */
+export interface IPageStore {
+  /** Fleet-wide statistics (page count, categories, health). */
+  getStats(): Promise<MimirStats>;
+
+  /**
+   * List page metadata, optionally filtered by mount and/or category.
+   */
+  listPages(options?: { mountName?: string; category?: string }): Promise<PageMeta[]>;
+
+  /**
+   * Fetch a single page by path.
+   * Returns null when no page exists at that path.
+   */
+  getPage(path: string, mountName?: string): Promise<Page | null>;
+
+  /**
+   * Create or update a page at the given path.
+   * The write is routed according to the mount's write-routing rules.
+   */
+  upsertPage(path: string, content: string, mountName?: string): Promise<void>;
+
+  /**
+   * Full-text, semantic, or hybrid search across pages.
+   * Defaults to hybrid mode.
+   */
+  search(query: string, mode?: SearchMode): Promise<SearchResult[]>;
+}

--- a/web-next/packages/plugin-mimir/src/ports/index.ts
+++ b/web-next/packages/plugin-mimir/src/ports/index.ts
@@ -1,0 +1,23 @@
+import type { IMountAdapter } from './IMountAdapter';
+import type { IPageStore } from './IPageStore';
+import type { IEmbeddingStore } from './IEmbeddingStore';
+import type { ILintEngine } from './ILintEngine';
+
+export type { IMountAdapter } from './IMountAdapter';
+export type { IPageStore, SearchMode } from './IPageStore';
+export type { IEmbeddingStore, EmbeddingSearchResult } from './IEmbeddingStore';
+export type { ILintEngine } from './ILintEngine';
+
+/**
+ * Composite Mímir service.
+ *
+ * Aggregates all four ports behind a single DI key (`'mimir'`).
+ * Adapters implement this interface; components call it via
+ * `useService<IMimirService>('mimir')`.
+ */
+export interface IMimirService {
+  mounts: IMountAdapter;
+  pages: IPageStore;
+  embeddings: IEmbeddingStore;
+  lint: ILintEngine;
+}

--- a/web-next/packages/plugin-mimir/src/ui/MimirPage.css
+++ b/web-next/packages/plugin-mimir/src/ui/MimirPage.css
@@ -1,0 +1,62 @@
+.mimir-page {
+  padding: var(--space-6);
+  max-width: 960px;
+}
+
+.mimir-page__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
+}
+
+.mimir-page__header h2 {
+  margin: 0;
+}
+
+.mimir-page__subtitle {
+  color: var(--color-text-secondary);
+}
+
+.mimir-page__status {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.mimir-page__count {
+  color: var(--color-text-secondary);
+  margin-bottom: var(--space-4);
+}
+
+.mimir-page__count strong {
+  color: var(--color-text-primary);
+}
+
+.mimir-page__list {
+  list-style: none;
+  padding: 0;
+  display: grid;
+  gap: var(--space-3);
+}
+
+.mimir-page__item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-secondary);
+}
+
+.mimir-page__item-name {
+  flex: 1;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+}
+
+.mimir-page__item-pages {
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+}

--- a/web-next/packages/plugin-mimir/src/ui/MimirPage.test.tsx
+++ b/web-next/packages/plugin-mimir/src/ui/MimirPage.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ServicesProvider } from '@niuulabs/plugin-sdk';
+import { MimirPage } from './MimirPage';
+import { createMimirMockAdapter } from '../adapters/mock';
+import type { IMimirService } from '../ports';
+
+function wrap(ui: React.ReactNode, service?: IMimirService) {
+  const svc = service ?? createMimirMockAdapter();
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <ServicesProvider services={{ mimir: svc }}>{ui}</ServicesProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe('MimirPage', () => {
+  it('renders the rune and title', () => {
+    wrap(<MimirPage />);
+    expect(screen.getByText('Mímir · the well of knowledge')).toBeInTheDocument();
+  });
+
+  it('shows loading state then mount list', async () => {
+    wrap(<MimirPage />);
+    expect(screen.getByText(/loading mounts/)).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText(/mounts connected/)).toBeInTheDocument());
+  });
+
+  it('renders mount names from the service', async () => {
+    wrap(<MimirPage />);
+    await waitFor(() => expect(screen.getAllByText('local').length).toBeGreaterThan(0));
+    expect(screen.getAllByText('shared').length).toBeGreaterThan(0);
+  });
+
+  it('shows error state when the service throws', async () => {
+    const failing: IMimirService = {
+      ...createMimirMockAdapter(),
+      mounts: {
+        listMounts: async () => {
+          throw new Error('mount service unavailable');
+        },
+      },
+    };
+    wrap(<MimirPage />, failing);
+    await waitFor(() => expect(screen.getByText('mount service unavailable')).toBeInTheDocument());
+  });
+
+  it('shows count of connected mounts', async () => {
+    wrap(<MimirPage />);
+    await waitFor(() => expect(screen.getByText(/3/)).toBeInTheDocument());
+  });
+});

--- a/web-next/packages/plugin-mimir/src/ui/MimirPage.tsx
+++ b/web-next/packages/plugin-mimir/src/ui/MimirPage.tsx
@@ -1,0 +1,83 @@
+import { Rune, StateDot, Chip } from '@niuulabs/ui';
+import { useMimirMounts } from './useMimirMounts';
+
+export function MimirPage() {
+  const { data, isLoading, isError, error } = useMimirMounts();
+
+  return (
+    <div style={{ padding: 'var(--space-6)', maxWidth: 960 }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--space-3)',
+          marginBottom: 'var(--space-4)',
+        }}
+      >
+        <Rune glyph="ᛗ" size={32} />
+        <h2 style={{ margin: 0 }}>Mímir · the well of knowledge</h2>
+      </div>
+      <p style={{ color: 'var(--color-text-secondary)' }}>
+        Knowledge-base management: mounts, pages, sources, entities, lint, and dream cycles.
+      </p>
+
+      {isLoading && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)' }}>
+          <StateDot state="processing" pulse />
+          <span>loading mounts…</span>
+        </div>
+      )}
+
+      {isError && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)' }}>
+          <StateDot state="failed" />
+          <span>{error instanceof Error ? error.message : 'unknown error'}</span>
+        </div>
+      )}
+
+      {data && (
+        <div>
+          <p style={{ color: 'var(--color-text-secondary)', marginBottom: 'var(--space-4)' }}>
+            <strong style={{ color: 'var(--color-text-primary)' }}>{data.length}</strong> mount
+            {data.length !== 1 ? 's' : ''} connected
+          </p>
+          <ul style={{ listStyle: 'none', padding: 0, display: 'grid', gap: 'var(--space-3)' }}>
+            {data.map((mount) => (
+              <li
+                key={mount.name}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 'var(--space-3)',
+                  padding: 'var(--space-3)',
+                  border: '1px solid var(--color-border-subtle)',
+                  borderRadius: 'var(--radius-md)',
+                  background: 'var(--color-bg-secondary)',
+                }}
+              >
+                <StateDot
+                  state={
+                    mount.status === 'healthy'
+                      ? 'healthy'
+                      : mount.status === 'degraded'
+                        ? 'observing'
+                        : 'failed'
+                  }
+                />
+                <span
+                  style={{ flex: 1, fontFamily: 'var(--font-mono)', fontSize: 'var(--text-sm)' }}
+                >
+                  {mount.name}
+                </span>
+                <Chip tone="neutral">{mount.role}</Chip>
+                <span style={{ color: 'var(--color-text-muted)', fontSize: 'var(--text-xs)' }}>
+                  {mount.pages} pages
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web-next/packages/plugin-mimir/src/ui/MimirPage.tsx
+++ b/web-next/packages/plugin-mimir/src/ui/MimirPage.tsx
@@ -1,35 +1,29 @@
 import { Rune, StateDot, Chip } from '@niuulabs/ui';
 import { useMimirMounts } from './useMimirMounts';
+import './MimirPage.css';
 
 export function MimirPage() {
   const { data, isLoading, isError, error } = useMimirMounts();
 
   return (
-    <div style={{ padding: 'var(--space-6)', maxWidth: 960 }}>
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 'var(--space-3)',
-          marginBottom: 'var(--space-4)',
-        }}
-      >
+    <div className="mimir-page">
+      <div className="mimir-page__header">
         <Rune glyph="ᛗ" size={32} />
-        <h2 style={{ margin: 0 }}>Mímir · the well of knowledge</h2>
+        <h2>Mímir · the well of knowledge</h2>
       </div>
-      <p style={{ color: 'var(--color-text-secondary)' }}>
+      <p className="mimir-page__subtitle">
         Knowledge-base management: mounts, pages, sources, entities, lint, and dream cycles.
       </p>
 
       {isLoading && (
-        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)' }}>
+        <div className="mimir-page__status">
           <StateDot state="processing" pulse />
           <span>loading mounts…</span>
         </div>
       )}
 
       {isError && (
-        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)' }}>
+        <div className="mimir-page__status">
           <StateDot state="failed" />
           <span>{error instanceof Error ? error.message : 'unknown error'}</span>
         </div>
@@ -37,24 +31,12 @@ export function MimirPage() {
 
       {data && (
         <div>
-          <p style={{ color: 'var(--color-text-secondary)', marginBottom: 'var(--space-4)' }}>
-            <strong style={{ color: 'var(--color-text-primary)' }}>{data.length}</strong> mount
-            {data.length !== 1 ? 's' : ''} connected
+          <p className="mimir-page__count">
+            <strong>{data.length}</strong> mount{data.length !== 1 ? 's' : ''} connected
           </p>
-          <ul style={{ listStyle: 'none', padding: 0, display: 'grid', gap: 'var(--space-3)' }}>
+          <ul className="mimir-page__list">
             {data.map((mount) => (
-              <li
-                key={mount.name}
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 'var(--space-3)',
-                  padding: 'var(--space-3)',
-                  border: '1px solid var(--color-border-subtle)',
-                  borderRadius: 'var(--radius-md)',
-                  background: 'var(--color-bg-secondary)',
-                }}
-              >
+              <li key={mount.name} className="mimir-page__item">
                 <StateDot
                   state={
                     mount.status === 'healthy'
@@ -64,15 +46,9 @@ export function MimirPage() {
                         : 'failed'
                   }
                 />
-                <span
-                  style={{ flex: 1, fontFamily: 'var(--font-mono)', fontSize: 'var(--text-sm)' }}
-                >
-                  {mount.name}
-                </span>
-                <Chip tone="neutral">{mount.role}</Chip>
-                <span style={{ color: 'var(--color-text-muted)', fontSize: 'var(--text-xs)' }}>
-                  {mount.pages} pages
-                </span>
+                <span className="mimir-page__item-name">{mount.name}</span>
+                <Chip tone="muted">{mount.role}</Chip>
+                <span className="mimir-page__item-pages">{mount.pages} pages</span>
               </li>
             ))}
           </ul>

--- a/web-next/packages/plugin-mimir/src/ui/useMimirMounts.ts
+++ b/web-next/packages/plugin-mimir/src/ui/useMimirMounts.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { useService } from '@niuulabs/plugin-sdk';
+import type { IMimirService } from '../ports';
+
+export function useMimirMounts() {
+  const service = useService<IMimirService>('mimir');
+  return useQuery({
+    queryKey: ['mimir', 'mounts'],
+    queryFn: () => service.mounts.listMounts(),
+  });
+}

--- a/web-next/packages/plugin-mimir/tsconfig.json
+++ b/web-next/packages/plugin-mimir/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "**/*.stories.tsx"]
+}

--- a/web-next/packages/plugin-mimir/tsup.config.ts
+++ b/web-next/packages/plugin-mimir/tsup.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.tsx'],
+  format: ['esm'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  external: [
+    'react',
+    '@tanstack/react-query',
+    '@tanstack/react-router',
+    '@niuulabs/plugin-sdk',
+    '@niuulabs/query',
+    '@niuulabs/ui',
+    '@niuulabs/domain',
+  ],
+});

--- a/web-next/packages/plugin-mimir/tsup.config.ts
+++ b/web-next/packages/plugin-mimir/tsup.config.ts
@@ -1,4 +1,22 @@
 import { defineConfig } from 'tsup';
+import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+function concatCssFiles(dir: string): string {
+  const out: string[] = [];
+  const walk = (d: string) => {
+    for (const entry of readdirSync(d, { withFileTypes: true })) {
+      const p = join(d, entry.name);
+      if (entry.isDirectory()) {
+        walk(p);
+      } else if (entry.isFile() && p.endsWith('.css')) {
+        out.push(`/* ${p} */\n${readFileSync(p, 'utf8')}`);
+      }
+    }
+  };
+  walk(dir);
+  return out.join('\n\n');
+}
 
 export default defineConfig({
   entry: ['src/index.tsx'],
@@ -15,4 +33,7 @@ export default defineConfig({
     '@niuulabs/ui',
     '@niuulabs/domain',
   ],
+  onSuccess: async () => {
+    writeFileSync('dist/styles.css', concatCssFiles('src'));
+  },
 });

--- a/web-next/pnpm-lock.yaml
+++ b/web-next/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       '@niuulabs/plugin-hello':
         specifier: workspace:*
         version: link:../../packages/plugin-hello
+      '@niuulabs/plugin-mimir':
+        specifier: workspace:*
+        version: link:../../packages/plugin-mimir
       '@niuulabs/plugin-sdk':
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
@@ -187,6 +190,40 @@ importers:
       '@niuulabs/plugin-sdk':
         specifier: workspace:*
         version: link:../plugin-sdk
+      '@niuulabs/ui':
+        specifier: workspace:*
+        version: link:../ui
+    devDependencies:
+      '@tanstack/react-query':
+        specifier: ^5.62.0
+        version: 5.99.1(react@19.2.5)
+      '@tanstack/react-router':
+        specifier: ^1.95.0
+        version: 1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@types/react':
+        specifier: ^19.0.7
+        version: 19.2.14
+      react:
+        specifier: ^19.0.0
+        version: 19.2.5
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(postcss@8.5.10)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
+  packages/plugin-mimir:
+    dependencies:
+      '@niuulabs/domain':
+        specifier: workspace:*
+        version: link:../domain
+      '@niuulabs/plugin-sdk':
+        specifier: workspace:*
+        version: link:../plugin-sdk
+      '@niuulabs/query':
+        specifier: workspace:*
+        version: link:../query
       '@niuulabs/ui':
         specifier: workspace:*
         version: link:../ui


### PR DESCRIPTION
## Summary

Scaffolds the `@niuulabs/plugin-mimir` composable plugin package per the Mímir handoff spec.

**Domain layer** (pure TypeScript, no framework deps):
- `api-types.ts` — HTTP wire types copied from `web/` (`MimirPageMeta`, `MimirStats`, `IngestJob`, helpers `transitionJob`/`isTerminal`)
- `page.ts` — richer `Page` aggregate with `Zone` discriminated union (`key-facts`, `relationships`, `assessment`, `timeline`), `PageType`, `Confidence`, `PageMeta`, `SearchResult`, helpers
- `lint.ts` — `LintIssue` with `LintRule` (L01–L12), `IssueSeverity`, `LintReport`, `DreamCycle`; `tallySeverity` + `isAutoFixable` helpers
- `source.ts` — `Source` with `OriginType`
- `entity.ts` — `EntityMeta` with `EntityKind`

**Ports** (hexagonal interfaces):
- `IMountAdapter` — `listMounts()` → `Mount[]` (uses `@niuulabs/domain` `Mount` type)
- `IPageStore` — `getStats`, `listPages`, `getPage`, `upsertPage`, `search`
- `IEmbeddingStore` — `semanticSearch` with topK + optional mount scope
- `ILintEngine` — `getLintReport`, `runAutoFix`, `getDreamCycles`
- `IMimirService` composite interface (single DI key `mimir`)

**Adapters**:
- Mock adapter with seeded 3-mount / 3-page / 3-lint-issue / 2-dream-cycle data
- HTTP adapter using `ApiClient` from `@niuulabs/query`; maps all snake_case endpoints

**UI**:
- `MimirPage` placeholder (rune `ᛗ`, mount list with health dots + role chips)
- `useMimirMounts` TanStack Query hook

**Registration**:
- `mimirPlugin` added to `apps/niuu` plugins array + services wiring
- `config.json` updated: `mimir` enabled, `mode: mock`

## Test plan

- [x] `api/client.test.ts` — migrated from `web/` (13 tests, all mapping assertions)
- [x] `domain/api-types.test.ts` — `transitionJob` and `isTerminal` helpers (migrated)
- [x] `domain/page.test.ts` — Zone discriminated union, `isHighConfidence`, `getZoneByKind`, `toPageMeta` round-trips
- [x] `domain/lint.test.ts` — `isAutoFixable`, `tallySeverity`, `LintIssue` + `DreamCycle` structure
- [x] `adapters/mock.test.ts` — 22 tests covering all service methods
- [x] `adapters/http.test.ts` — 19 tests covering all endpoints + snake_case mapping
- [x] `ui/MimirPage.test.tsx` — render, loading state, mount names, error state, count
- [x] `e2e/mimir.spec.ts` — navigate to `/mimir`, loading → mount list, rune visible
- [x] Coverage: **97.82% statements / 91.25% branches / 96.99% functions** (threshold: 85%)
- [x] ESLint: clean
- [x] Prettier: clean
- [x] 369 tests total, all passing

Blocks: every Mimir page ticket (NIU-668+)
Ticket: NIU-667

🤖 Generated with [Claude Code](https://claude.com/claude-code)