### PR TITLE
feat(ui): ShapeSvg — 14 shape primitives + canonical rune glyph map (NIU-655)

### DIFF
--- a/web-next/packages/ui/src/index.ts
+++ b/web-next/packages/ui/src/index.ts
@@ -11,4 +11,5 @@ export * from './data/Table';
 export * from './data/FilterBar';
 export * from './data/KpiStrip';
 export * from './data/states';
+export * from './primitives/ShapeSvg';
 export { cn } from './utils/cn';

--- a/web-next/packages/ui/src/primitives/ShapeSvg/ShapeSvg.stories.tsx
+++ b/web-next/packages/ui/src/primitives/ShapeSvg/ShapeSvg.stories.tsx
@@ -1,0 +1,168 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ShapeSvg, type ShapeKind, type ShapeColor } from './ShapeSvg';
+import { ENTITY_RUNES, SERVICE_RUNES } from './runeMap';
+
+const ALL_SHAPES: ShapeKind[] = [
+  'ring',
+  'ring-dashed',
+  'rounded-rect',
+  'diamond',
+  'triangle',
+  'hex',
+  'chevron',
+  'square',
+  'square-sm',
+  'pentagon',
+  'halo',
+  'mimir',
+  'mimir-small',
+  'dot',
+];
+
+const ALL_COLORS: ShapeColor[] = [
+  'brand',
+  'brand-100',
+  'brand-200',
+  'brand-300',
+  'brand-400',
+  'brand-500',
+  'ice-100',
+  'ice-200',
+  'ice-300',
+  'slate-300',
+  'slate-400',
+];
+
+const meta: Meta<typeof ShapeSvg> = {
+  title: 'Primitives/ShapeSvg',
+  component: ShapeSvg,
+  args: { shape: 'ring', size: 20 },
+};
+export default meta;
+
+type Story = StoryObj<typeof ShapeSvg>;
+
+export const Default: Story = {};
+
+export const AllShapes20: Story = {
+  name: 'All Shapes — 20×20',
+  render: () => (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'auto 1fr',
+        gap: '8px 16px',
+        alignItems: 'center',
+      }}
+    >
+      {ALL_SHAPES.map((s) => (
+        <div key={s} style={{ display: 'contents' }}>
+          <ShapeSvg shape={s} size={20} />
+          <code style={{ fontSize: 12 }}>{s}</code>
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+export const AllShapes36: Story = {
+  name: 'All Shapes — 36×36',
+  render: () => (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'auto 1fr',
+        gap: '12px 20px',
+        alignItems: 'center',
+      }}
+    >
+      {ALL_SHAPES.map((s) => (
+        <div key={s} style={{ display: 'contents' }}>
+          <ShapeSvg shape={s} size={36} />
+          <code style={{ fontSize: 12 }}>{s}</code>
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+export const ColorPalette: Story = {
+  name: 'Color Palette',
+  render: () => (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'auto 1fr',
+        gap: '8px 16px',
+        alignItems: 'center',
+      }}
+    >
+      {ALL_COLORS.map((c) => (
+        <div key={c} style={{ display: 'contents' }}>
+          <ShapeSvg shape="diamond" size={24} color={c} />
+          <code style={{ fontSize: 12 }}>{c}</code>
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+export const EntityRuneTable: Story = {
+  name: 'Entity Rune Table',
+  render: () => (
+    <div style={{ fontFamily: 'var(--font-sans, system-ui)', fontSize: 13 }}>
+      <p style={{ marginBottom: 16, color: 'var(--color-text-secondary, #a1a1aa)' }}>
+        Entity-kind glyphs keyed by registry type ID
+      </p>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'auto auto 1fr',
+          gap: '6px 20px',
+          alignItems: 'center',
+        }}
+      >
+        <strong>Kind</strong>
+        <strong>Rune</strong>
+        <strong />
+        {Object.entries(ENTITY_RUNES).map(([key, rune]) => (
+          <div key={key} style={{ display: 'contents' }}>
+            <code style={{ fontSize: 12 }}>{key}</code>
+            <span style={{ fontSize: 22, fontFamily: 'var(--font-mono, monospace)' }}>{rune}</span>
+            <span />
+          </div>
+        ))}
+      </div>
+    </div>
+  ),
+};
+
+export const ServiceRuneTable: Story = {
+  name: 'Service Rune Table',
+  render: () => (
+    <div style={{ fontFamily: 'var(--font-sans, system-ui)', fontSize: 13 }}>
+      <p style={{ marginBottom: 16, color: 'var(--color-text-secondary, #a1a1aa)' }}>
+        Brand-identity glyphs keyed by system name (DS_RUNES)
+      </p>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'auto auto 1fr',
+          gap: '6px 20px',
+          alignItems: 'center',
+        }}
+      >
+        <strong>Service</strong>
+        <strong>Rune</strong>
+        <strong />
+        {Object.entries(SERVICE_RUNES).map(([key, rune]) => (
+          <div key={key} style={{ display: 'contents' }}>
+            <code style={{ fontSize: 12 }}>{key}</code>
+            <span style={{ fontSize: 22, fontFamily: 'var(--font-mono, monospace)' }}>{rune}</span>
+            <span />
+          </div>
+        ))}
+      </div>
+    </div>
+  ),
+};

--- a/web-next/packages/ui/src/primitives/ShapeSvg/ShapeSvg.test.tsx
+++ b/web-next/packages/ui/src/primitives/ShapeSvg/ShapeSvg.test.tsx
@@ -1,0 +1,195 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ShapeSvg, type ShapeKind, type ShapeColor } from './ShapeSvg';
+import { ENTITY_RUNES, SERVICE_RUNES, RUNE_MAP } from './runeMap';
+
+const FORBIDDEN_RUNES = new Set(['ᛟ', 'ᛊ', 'ᛏ', 'ᛉ', 'ᚺ', 'ᚻ']);
+
+const ALL_SHAPES: ShapeKind[] = [
+  'ring',
+  'ring-dashed',
+  'rounded-rect',
+  'diamond',
+  'triangle',
+  'hex',
+  'chevron',
+  'square',
+  'square-sm',
+  'pentagon',
+  'halo',
+  'mimir',
+  'mimir-small',
+  'dot',
+];
+
+describe('ShapeSvg', () => {
+  describe('renders valid SVG for every shape', () => {
+    it.each(ALL_SHAPES)('%s', (shape) => {
+      render(<ShapeSvg shape={shape} aria-label={shape} />);
+      const svg = screen.getByRole('img', { name: shape });
+      expect(svg.tagName.toLowerCase()).toBe('svg');
+      expect(svg).toHaveAttribute('viewBox', '-10 -10 20 20');
+    });
+  });
+
+  it('defaults to size 20', () => {
+    render(<ShapeSvg shape="dot" />);
+    const svg = screen.getByRole('img');
+    expect(svg).toHaveAttribute('width', '20');
+    expect(svg).toHaveAttribute('height', '20');
+  });
+
+  it('applies custom size', () => {
+    render(<ShapeSvg shape="ring" size={36} aria-label="ring" />);
+    const svg = screen.getByRole('img');
+    expect(svg).toHaveAttribute('width', '36');
+    expect(svg).toHaveAttribute('height', '36');
+  });
+
+  it('uses brand color when no color prop given', () => {
+    const { container } = render(<ShapeSvg shape="ring" />);
+    expect(container.innerHTML).toContain('var(--color-brand)');
+  });
+
+  it('applies explicit brand color', () => {
+    const { container } = render(<ShapeSvg shape="dot" color="brand" />);
+    expect(container.innerHTML).toContain('var(--color-brand)');
+  });
+
+  it.each([
+    ['ice-100', 'var(--brand-100)'],
+    ['ice-200', 'var(--brand-200)'],
+    ['ice-300', 'var(--brand-300)'],
+    ['brand-100', 'var(--brand-100)'],
+    ['brand-200', 'var(--brand-200)'],
+    ['brand-300', 'var(--brand-300)'],
+    ['brand-400', 'var(--brand-400)'],
+    ['brand-500', 'var(--brand-500)'],
+    ['slate-300', 'var(--color-text-secondary)'],
+    ['slate-400', 'var(--color-text-muted)'],
+  ] satisfies [ShapeColor, string][])(
+    'color "%s" resolves to "%s"',
+    (colorProp, expectedVar) => {
+      const { container } = render(<ShapeSvg shape="dot" color={colorProp} />);
+      expect(container.innerHTML).toContain(expectedVar);
+    },
+  );
+
+  it('uses shape as default aria-label', () => {
+    render(<ShapeSvg shape="pentagon" />);
+    expect(screen.getByRole('img', { name: 'pentagon' })).toBeInTheDocument();
+  });
+
+  it('accepts a custom aria-label', () => {
+    render(<ShapeSvg shape="hex" aria-label="hexagonal node" />);
+    expect(screen.getByRole('img', { name: 'hexagonal node' })).toBeInTheDocument();
+  });
+
+  it('forwards className to the svg element', () => {
+    render(<ShapeSvg shape="dot" className="test-class" />);
+    expect(screen.getByRole('img')).toHaveClass('test-class');
+  });
+
+  it('mimir and mimir-small render the ᛗ glyph', () => {
+    const { container } = render(<ShapeSvg shape="mimir" />);
+    expect(container.textContent).toContain('ᛗ');
+  });
+
+  it('mimir-small renders the same SVG structure as mimir', () => {
+    const { container: a } = render(<ShapeSvg shape="mimir" />);
+    const { container: b } = render(<ShapeSvg shape="mimir-small" />);
+    // Both shapes share the same SVG output (circle + rune text)
+    expect(a.querySelector('circle')).toBeTruthy();
+    expect(b.querySelector('circle')).toBeTruthy();
+    expect(a.querySelector('text')).toBeTruthy();
+    expect(b.querySelector('text')).toBeTruthy();
+  });
+
+  it('halo renders two concentric circles', () => {
+    const { container } = render(<ShapeSvg shape="halo" />);
+    const circles = container.querySelectorAll('circle');
+    expect(circles).toHaveLength(2);
+  });
+});
+
+describe('ENTITY_RUNES', () => {
+  it('contains no forbidden runes', () => {
+    for (const [key, rune] of Object.entries(ENTITY_RUNES)) {
+      expect(
+        FORBIDDEN_RUNES.has(rune),
+        `ENTITY_RUNES["${key}"] = "${rune}" is a forbidden rune`,
+      ).toBe(false);
+    }
+  });
+
+  it('has entries for all core entity kinds', () => {
+    const expected = [
+      'realm',
+      'cluster',
+      'host',
+      'ravn_long',
+      'ravn_raid',
+      'skuld',
+      'valkyrie',
+      'tyr',
+      'bifrost',
+      'volundr',
+      'mimir',
+      'mimir_sub',
+      'service',
+      'model',
+      'printer',
+      'vaettir',
+      'beacon',
+      'raid',
+    ] as const;
+    for (const kind of expected) {
+      expect(ENTITY_RUNES).toHaveProperty(kind);
+    }
+  });
+});
+
+describe('SERVICE_RUNES', () => {
+  it('contains no forbidden runes', () => {
+    for (const [key, rune] of Object.entries(SERVICE_RUNES)) {
+      expect(
+        FORBIDDEN_RUNES.has(rune),
+        `SERVICE_RUNES["${key}"] = "${rune}" is a forbidden rune`,
+      ).toBe(false);
+    }
+  });
+
+  it('maps canonical system names to their glyphs', () => {
+    expect(SERVICE_RUNES.volundr).toBe('ᚲ');
+    expect(SERVICE_RUNES.tyr).toBe('ᛃ');
+    expect(SERVICE_RUNES.ravn).toBe('ᚱ');
+    expect(SERVICE_RUNES.mimir).toBe('ᛗ');
+    expect(SERVICE_RUNES.bifrost).toBe('ᚨ');
+    expect(SERVICE_RUNES.sleipnir).toBe('ᛖ');
+    expect(SERVICE_RUNES.buri).toBe('ᛜ');
+    expect(SERVICE_RUNES.hlidskjalf).toBe('ᛞ');
+    expect(SERVICE_RUNES.flokk).toBe('ᚠ');
+    expect(SERVICE_RUNES.skuld).toBe('ᚾ');
+    expect(SERVICE_RUNES.valkyrie).toBe('ᛒ');
+  });
+});
+
+describe('RUNE_MAP', () => {
+  it('contains no forbidden runes', () => {
+    for (const [key, rune] of Object.entries(RUNE_MAP)) {
+      expect(
+        FORBIDDEN_RUNES.has(rune),
+        `RUNE_MAP["${key}"] = "${rune}" is a forbidden rune`,
+      ).toBe(false);
+    }
+  });
+
+  it('includes keys from both SERVICE_RUNES and ENTITY_RUNES', () => {
+    for (const key of Object.keys(SERVICE_RUNES)) {
+      expect(RUNE_MAP).toHaveProperty(key);
+    }
+    for (const key of Object.keys(ENTITY_RUNES)) {
+      expect(RUNE_MAP).toHaveProperty(key);
+    }
+  });
+});

--- a/web-next/packages/ui/src/primitives/ShapeSvg/ShapeSvg.tsx
+++ b/web-next/packages/ui/src/primitives/ShapeSvg/ShapeSvg.tsx
@@ -1,0 +1,204 @@
+import type { SVGProps } from 'react';
+
+export type ShapeKind =
+  | 'ring'
+  | 'ring-dashed'
+  | 'rounded-rect'
+  | 'diamond'
+  | 'triangle'
+  | 'hex'
+  | 'chevron'
+  | 'square'
+  | 'square-sm'
+  | 'pentagon'
+  | 'halo'
+  | 'mimir'
+  | 'mimir-small'
+  | 'dot';
+
+/** Color tokens accepted by ShapeSvg — maps to design-token CSS variables */
+export type ShapeColor =
+  | 'brand'
+  | 'brand-100'
+  | 'brand-200'
+  | 'brand-300'
+  | 'brand-400'
+  | 'brand-500'
+  | 'ice-100'
+  | 'ice-200'
+  | 'ice-300'
+  | 'slate-300'
+  | 'slate-400';
+
+export interface ShapeSvgProps {
+  shape: ShapeKind;
+  color?: ShapeColor;
+  size?: number;
+  className?: string;
+  'aria-label'?: string;
+}
+
+const COLOR_VARS: Record<ShapeColor, string> = {
+  brand: 'var(--color-brand)',
+  'brand-100': 'var(--brand-100)',
+  'brand-200': 'var(--brand-200)',
+  'brand-300': 'var(--brand-300)',
+  'brand-400': 'var(--brand-400)',
+  'brand-500': 'var(--brand-500)',
+  'ice-100': 'var(--brand-100)',
+  'ice-200': 'var(--brand-200)',
+  'ice-300': 'var(--brand-300)',
+  'slate-300': 'var(--color-text-secondary)',
+  'slate-400': 'var(--color-text-muted)',
+};
+
+function resolveColor(color: ShapeColor | undefined): string {
+  if (!color) return 'var(--color-brand)';
+  return COLOR_VARS[color];
+}
+
+export function ShapeSvg({
+  shape,
+  color,
+  size = 20,
+  className,
+  'aria-label': ariaLabel,
+}: ShapeSvgProps) {
+  const c = resolveColor(color);
+  const svgProps: SVGProps<SVGSVGElement> = {
+    width: size,
+    height: size,
+    viewBox: '-10 -10 20 20',
+    xmlns: 'http://www.w3.org/2000/svg',
+    role: 'img',
+    className,
+    'aria-label': ariaLabel ?? shape,
+  };
+
+  switch (shape) {
+    case 'ring':
+      return (
+        <svg {...svgProps}>
+          <circle cx="0" cy="0" r="7" fill="none" stroke={c} strokeWidth="1.4" />
+        </svg>
+      );
+
+    case 'ring-dashed':
+      return (
+        <svg {...svgProps}>
+          <circle
+            cx="0"
+            cy="0"
+            r="7"
+            fill="none"
+            stroke={c}
+            strokeWidth="1.2"
+            strokeDasharray="2 2"
+          />
+        </svg>
+      );
+
+    case 'rounded-rect':
+      return (
+        <svg {...svgProps}>
+          <rect x="-7" y="-5" width="14" height="10" rx="2" fill="none" stroke={c} strokeWidth="1.4" />
+        </svg>
+      );
+
+    case 'diamond':
+      return (
+        <svg {...svgProps}>
+          <path d="M0,-7 L7,0 L0,7 L-7,0 Z" fill={c} opacity={0.85} />
+        </svg>
+      );
+
+    case 'triangle':
+      return (
+        <svg {...svgProps}>
+          <path d="M0,-7 L6,5 L-6,5 Z" fill={c} />
+        </svg>
+      );
+
+    case 'hex':
+      return (
+        <svg {...svgProps}>
+          <path
+            d="M-6,-3.5 L0,-7 L6,-3.5 L6,3.5 L0,7 L-6,3.5 Z"
+            fill="none"
+            stroke={c}
+            strokeWidth="1.4"
+          />
+        </svg>
+      );
+
+    case 'chevron':
+      return (
+        <svg {...svgProps}>
+          <path d="M-6,5 L0,-6 L6,5 L0,2 Z" fill={c} />
+        </svg>
+      );
+
+    case 'square':
+      return (
+        <svg {...svgProps}>
+          <rect x="-6" y="-6" width="12" height="12" rx="1" fill={c} />
+        </svg>
+      );
+
+    case 'square-sm':
+      return (
+        <svg {...svgProps}>
+          <rect x="-5" y="-5" width="10" height="10" fill="none" stroke={c} strokeWidth="1.4" />
+        </svg>
+      );
+
+    case 'pentagon':
+      return (
+        <svg {...svgProps}>
+          <path d="M0,-7 L6.6,-2.2 L4.1,5.6 L-4.1,5.6 L-6.6,-2.2 Z" fill={c} />
+        </svg>
+      );
+
+    case 'halo':
+      return (
+        <svg {...svgProps}>
+          <circle cx="0" cy="0" r="7" fill="none" stroke={c} strokeWidth="1" strokeDasharray="1 2" />
+          <circle cx="0" cy="0" r="2.5" fill={c} />
+        </svg>
+      );
+
+    case 'mimir':
+    case 'mimir-small':
+      return (
+        <svg {...svgProps}>
+          <circle
+            cx="0"
+            cy="0"
+            r="5"
+            fill="var(--color-bg-primary)"
+            stroke={c}
+            strokeWidth="1.4"
+          />
+          <text
+            x="0"
+            y="1"
+            fontSize="5"
+            fill={c}
+            textAnchor="middle"
+            dominantBaseline="middle"
+            fontFamily="monospace"
+          >
+            ᛗ
+          </text>
+        </svg>
+      );
+
+    case 'dot':
+    default:
+      return (
+        <svg {...svgProps}>
+          <circle cx="0" cy="0" r="4" fill={c} />
+        </svg>
+      );
+  }
+}

--- a/web-next/packages/ui/src/primitives/ShapeSvg/index.ts
+++ b/web-next/packages/ui/src/primitives/ShapeSvg/index.ts
@@ -1,0 +1,2 @@
+export { ShapeSvg, type ShapeSvgProps, type ShapeKind, type ShapeColor } from './ShapeSvg';
+export { ENTITY_RUNES, SERVICE_RUNES, RUNE_MAP, type RuneKey } from './runeMap';

--- a/web-next/packages/ui/src/primitives/ShapeSvg/runeMap.ts
+++ b/web-next/packages/ui/src/primitives/ShapeSvg/runeMap.ts
@@ -1,0 +1,59 @@
+/**
+ * Canonical rune glyph map for the Niuu design system.
+ *
+ * Sources:
+ *   - SERVICE_RUNES: DS_RUNES from the Flokk Observatory prototype (brand-identity glyphs)
+ *   - ENTITY_RUNES: rune fields from DEFAULT_REGISTRY entity-type definitions
+ *
+ * Forbidden runes (appropriated hate symbols) are explicitly excluded:
+ *   ᛟ (Othala)  ᛊ (Sowilo)  ᛏ (Tiwaz)  ᛉ (Algiz)  ᚺ/ᚻ (Hagalaz variants)
+ */
+
+/** Service / persona-identity glyphs keyed by system name */
+export const SERVICE_RUNES = {
+  volundr: 'ᚲ',
+  tyr: 'ᛃ',
+  ravn: 'ᚱ',
+  mimir: 'ᛗ',
+  bifrost: 'ᚨ',
+  sleipnir: 'ᛖ',
+  buri: 'ᛜ',
+  hlidskjalf: 'ᛞ',
+  flokk: 'ᚠ',
+  skuld: 'ᚾ',
+  valkyrie: 'ᛒ',
+} as const satisfies Record<string, string>;
+
+/** Entity-kind runes keyed by registry type id */
+export const ENTITY_RUNES = {
+  realm: 'ᛞ',
+  cluster: 'ᚲ',
+  host: 'ᚦ',
+  ravn_long: 'ᚱ',
+  ravn_raid: 'ᚲ',
+  skuld: 'ᛜ',
+  valkyrie: 'ᛒ',
+  tyr: 'ᛃ',
+  bifrost: 'ᚨ',
+  volundr: 'ᚲ',
+  mimir: 'ᛗ',
+  mimir_sub: 'ᛗ',
+  service: 'ᛦ',
+  model: 'ᛖ',
+  printer: 'ᛈ',
+  vaettir: 'ᚹ',
+  beacon: 'ᚠ',
+  raid: 'ᚷ',
+} as const satisfies Record<string, string>;
+
+/**
+ * Combined canonical rune map.
+ * Entity-kind runes are the base; service-identity runes are merged on top.
+ * Use SERVICE_RUNES directly when you need the brand-tagged service identity.
+ */
+export const RUNE_MAP = {
+  ...ENTITY_RUNES,
+  ...SERVICE_RUNES,
+} as const;
+
+export type RuneKey = keyof typeof RUNE_MAP;


### PR DESCRIPTION
## Summary

- **`ShapeSvg`** component added to `@niuulabs/ui` — 14 SVG shape primitives ported from the Flokk Observatory prototype (\`web2/niuu_handoff/flokk_observatory/design/data.jsx\`)
- **\`ENTITY_RUNES\`** — canonical rune glyph map keyed by entity kind (18 entries from DEFAULT_REGISTRY)
- **\`SERVICE_RUNES\`** — brand-identity rune map keyed by system name (11 entries from DS_RUNES)
- **\`RUNE_MAP\`** — combined map (convenience export)
- All five forbidden runes excluded: ᛟ ᛊ ᛏ ᛉ ᚺ/ᚻ

## Shapes

\`ring\` · \`ring-dashed\` · \`rounded-rect\` · \`diamond\` · \`triangle\` · \`hex\` · \`chevron\` · \`square\` · \`square-sm\` · \`pentagon\` · \`halo\` · \`mimir\` · \`mimir-small\` · \`dot\`

Each shape accepts \`size\` (default 20), \`color\` (typed \`ShapeColor\` → CSS token var), \`aria-label\`, and \`className\`.

## Files

\`\`\`
web-next/packages/ui/src/primitives/ShapeSvg/
  ShapeSvg.tsx       — component + ShapeKind/ShapeColor types + color→var resolution
  runeMap.ts         — ENTITY_RUNES, SERVICE_RUNES, RUNE_MAP, RuneKey
  ShapeSvg.test.tsx  — 39 unit tests
  ShapeSvg.stories.tsx — AllShapes20, AllShapes36, ColorPalette, EntityRuneTable, ServiceRuneTable
  index.ts           — barrel
web-next/packages/ui/src/index.ts — ShapeSvg added alongside StatusBadge/ConfidenceBar etc.
\`\`\`

## Test plan

- [x] Every shape renders a valid SVG \`<svg>\` element with \`role="img"\` and the correct \`viewBox\`
- [x] \`size\` prop sets \`width\`/\`height\` correctly (default 20, custom 36)
- [x] All 10 \`ShapeColor\` tokens resolve to the correct CSS custom property
- [x] \`aria-label\` falls back to \`shape\` name by default
- [x] \`mimir\`/\`mimir-small\` render the ᛗ glyph; \`halo\` renders two concentric circles
- [x] \`ENTITY_RUNES\`, \`SERVICE_RUNES\`, and \`RUNE_MAP\` contain zero forbidden runes
- [x] \`RUNE_MAP\` includes all keys from both sub-maps
- [x] Coverage: \`ShapeSvg.tsx\` 100%, \`runeMap.ts\` 100%, overall ≥ 85%

## Coverage

\`\`\`
 ...tives/ShapeSvg |     100 |      100 |     100 |     100 |
  ShapeSvg.tsx     |     100 |      100 |     100 |     100 |
  runeMap.ts       |     100 |      100 |     100 |     100 |
\`\`\`

## CI

All GitHub Actions checks pass (CI run #24631524311).

## Linear

NIU-655 — Linear MCP tools unavailable in this session; ticket should be moved to **In Review** manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)