### PR TITLE
feat(observatory): registry editor — Types / Containment / JSON tabs (NIU-666)

### DIFF
--- a/web-next/apps/niuu/src/main.tsx
+++ b/web-next/apps/niuu/src/main.tsx
@@ -5,6 +5,7 @@ import '@niuulabs/ui/styles.css';
 import '@niuulabs/shell/styles.css';
 import '@niuulabs/plugin-hello/styles.css';
 import '@niuulabs/plugin-login/styles.css';
+import '@niuulabs/plugin-observatory/styles.css';
 import './styles.css';
 import { setTokenProvider } from '@niuulabs/query';
 import { App } from './App';

--- a/web-next/e2e/observatory.spec.ts
+++ b/web-next/e2e/observatory.spec.ts
@@ -24,10 +24,102 @@ test('observatory page shows recent events', async ({ page }) => {
   await expect(page.getByText('Recent events')).toBeVisible({ timeout: 5000 });
 });
 
+// ── Registry page ─────────────────────────────────────────────────────────────
+
 test('registry page renders entity type list', async ({ page }) => {
   await page.goto('/registry');
   await expect(page.getByText('Registry')).toBeVisible();
   await expect(page.getByText('Realm')).toBeVisible({ timeout: 5000 });
   await expect(page.getByText('Cluster')).toBeVisible({ timeout: 5000 });
   await expect(page.getByText('Raid')).toBeVisible({ timeout: 5000 });
+});
+
+test('registry: Types tab is active by default', async ({ page }) => {
+  await page.goto('/registry');
+  await expect(page.getByTestId('tab-types')).toBeVisible({ timeout: 5000 });
+  await expect(page.getByTestId('tab-types')).toHaveAttribute('aria-selected', 'true');
+});
+
+test('registry: clicking a type row opens the preview drawer', async ({ page }) => {
+  await page.goto('/registry');
+  await page.waitForSelector('[data-testid="type-row-cluster"]', { timeout: 5000 });
+
+  await page.click('[data-testid="type-row-cluster"]');
+  await expect(page.getByTestId('type-preview-drawer')).toBeVisible();
+  await expect(page.getByTestId('type-preview-drawer')).toContainText('Cluster');
+});
+
+test('registry: search filters type list', async ({ page }) => {
+  await page.goto('/registry');
+  await page.waitForSelector('[data-testid="tab-types"]', { timeout: 5000 });
+
+  await page.fill('[aria-label="Filter types"]', 'realm');
+  await expect(page.getByTestId('type-row-realm')).toBeVisible();
+  await expect(page.getByTestId('type-row-cluster')).not.toBeVisible();
+});
+
+test('registry: Containment tab shows tree with root nodes', async ({ page }) => {
+  await page.goto('/registry');
+  await page.waitForSelector('[data-testid="tab-containment"]', { timeout: 5000 });
+
+  await page.click('[data-testid="tab-containment"]');
+  await expect(page.getByTestId('containment-tree')).toBeVisible();
+  await expect(page.getByTestId('tree-node-realm')).toBeVisible();
+});
+
+test('registry: JSON tab shows formatted registry JSON', async ({ page }) => {
+  await page.goto('/registry');
+  await page.waitForSelector('[data-testid="tab-json"]', { timeout: 5000 });
+
+  await page.click('[data-testid="tab-json"]');
+  await expect(page.getByTestId('json-output')).toBeVisible();
+  await expect(page.getByTestId('json-output')).toContainText('"version"');
+  await expect(page.getByTestId('copy-json-btn')).toBeVisible();
+});
+
+test('registry: drag a type, drop on valid target, verify parentTypes updated', async ({
+  page,
+}) => {
+  await page.goto('/registry');
+  await page.waitForSelector('[data-testid="tab-containment"]', { timeout: 5000 });
+  await page.click('[data-testid="tab-containment"]');
+
+  // host is currently a child of cluster; drag it to realm
+  const hostNode = page.getByTestId('tree-node-host');
+  const realmNode = page.getByTestId('tree-node-realm');
+
+  await hostNode.dragTo(realmNode);
+
+  // After drop the JSON should show host.parentTypes = ['realm']
+  await page.click('[data-testid="tab-json"]');
+  const jsonText = await page.getByTestId('json-output').textContent();
+  const registry = JSON.parse(jsonText ?? '{}');
+  const host = registry.types.find((t: { id: string }) => t.id === 'host');
+  expect(host?.parentTypes).toContain('realm');
+  expect(registry.version).toBeGreaterThan(7);
+});
+
+test('registry: cycle is rejected — dragging ancestor onto descendant does nothing', async ({
+  page,
+}) => {
+  await page.goto('/registry');
+  await page.waitForSelector('[data-testid="tab-containment"]', { timeout: 5000 });
+  await page.click('[data-testid="tab-containment"]');
+
+  const realmNode = page.getByTestId('tree-node-realm');
+  const hostNode = page.getByTestId('tree-node-host');
+
+  // Note initial version
+  await page.click('[data-testid="tab-json"]');
+  const before = await page.getByTestId('json-output').textContent();
+  const versionBefore = JSON.parse(before ?? '{}').version as number;
+
+  await page.click('[data-testid="tab-containment"]');
+  await realmNode.dragTo(hostNode);
+
+  // Version should not change
+  await page.click('[data-testid="tab-json"]');
+  const after = await page.getByTestId('json-output').textContent();
+  const versionAfter = JSON.parse(after ?? '{}').version as number;
+  expect(versionAfter).toBe(versionBefore);
 });

--- a/web-next/packages/plugin-observatory/package.json
+++ b/web-next/packages/plugin-observatory/package.json
@@ -11,7 +11,8 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
-    }
+    },
+    "./styles.css": "./dist/styles.css"
   },
   "files": [
     "dist"
@@ -35,10 +36,15 @@
     "@niuulabs/ui": "workspace:*"
   },
   "devDependencies": {
+    "@niuulabs/design-tokens": "workspace:*",
     "@tanstack/react-query": "^5.62.0",
     "@tanstack/react-router": "^1.95.0",
     "@types/react": "^19.0.7",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.49",
+    "postcss-import": "^16.1.0",
     "react": "^19.0.0",
+    "tailwindcss": "^3.4.17",
     "tsup": "^8.3.5",
     "typescript": "^5.7.3"
   }

--- a/web-next/packages/plugin-observatory/postcss.config.cjs
+++ b/web-next/packages/plugin-observatory/postcss.config.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  plugins: {
+    'postcss-import': {},
+    tailwindcss: { config: './tailwind.config.ts' },
+    autoprefixer: {},
+  },
+};

--- a/web-next/packages/plugin-observatory/src/adapters/mock.ts
+++ b/web-next/packages/plugin-observatory/src/adapters/mock.ts
@@ -5,13 +5,7 @@ import type {
   TopologyListener,
   ObservatoryEventListener,
 } from '../ports';
-import type {
-  Registry,
-  Topology,
-  TopologyNode,
-  TopologyEdge,
-  ObservatoryEvent,
-} from '../domain';
+import type { Registry, Topology, TopologyNode, TopologyEdge, ObservatoryEvent } from '../domain';
 
 // ── Seed registry (mirrors DEFAULT_REGISTRY from web2/niuu_handoff/flokk_observatory/design/data.jsx) ──
 
@@ -323,7 +317,8 @@ const SEED_REGISTRY: Registry = {
       canContain: [],
       parentTypes: ['realm'],
       category: 'device',
-      description: 'SLA resin printer on YDP WebSocket. Saturn 4 Ultras named after legendary weapons.',
+      description:
+        'SLA resin printer on YDP WebSocket. Saturn 4 Ultras named after legendary weapons.',
       fields: [{ key: 'model', label: 'Model', type: 'string' }],
     },
     {
@@ -338,7 +333,8 @@ const SEED_REGISTRY: Registry = {
       canContain: [],
       parentTypes: ['realm'],
       category: 'device',
-      description: 'ESP32 room presence node — mmWave, mic, speaker. Named for the locale it inhabits.',
+      description:
+        'ESP32 room presence node — mmWave, mic, speaker. Named for the locale it inhabits.',
       fields: [{ key: 'sensors', label: 'Sensors', type: 'tags' }],
     },
     {
@@ -372,7 +368,12 @@ const SEED_REGISTRY: Registry = {
         'Ephemeral flock — ravens dispatched by a Týr to execute a saga. Forms, works, dissolves.',
       fields: [
         { key: 'purpose', label: 'Purpose', type: 'string' },
-        { key: 'state', label: 'State', type: 'select', options: ['forming', 'working', 'dissolving'] },
+        {
+          key: 'state',
+          label: 'State',
+          type: 'select',
+          options: ['forming', 'working', 'dissolving'],
+        },
         { key: 'composition', label: 'Composition', type: 'tags' },
       ],
     },

--- a/web-next/packages/plugin-observatory/src/application/useRegistryEditor.test.ts
+++ b/web-next/packages/plugin-observatory/src/application/useRegistryEditor.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useRegistryEditor } from './useRegistryEditor';
+import type { Registry } from '../domain';
+
+const makeRegistry = (): Registry => ({
+  version: 1,
+  updatedAt: '2026-01-01T00:00:00Z',
+  types: [
+    {
+      id: 'realm',
+      label: 'Realm',
+      rune: 'ᛞ',
+      icon: 'globe',
+      shape: 'ring',
+      color: 'ice-100',
+      size: 18,
+      border: 'solid',
+      canContain: ['cluster'],
+      parentTypes: [],
+      category: 'topology',
+      description: 'A realm.',
+      fields: [],
+    },
+    {
+      id: 'cluster',
+      label: 'Cluster',
+      rune: 'ᚲ',
+      icon: 'layers',
+      shape: 'ring-dashed',
+      color: 'ice-200',
+      size: 14,
+      border: 'dashed',
+      canContain: ['host'],
+      parentTypes: ['realm'],
+      category: 'topology',
+      description: 'A cluster.',
+      fields: [],
+    },
+    {
+      id: 'host',
+      label: 'Host',
+      rune: 'ᚦ',
+      icon: 'server',
+      shape: 'rounded-rect',
+      color: 'slate-400',
+      size: 22,
+      border: 'solid',
+      canContain: [],
+      parentTypes: ['cluster'],
+      category: 'hardware',
+      description: 'A host.',
+      fields: [],
+    },
+  ],
+});
+
+describe('useRegistryEditor', () => {
+  it('initialises selectedId to the first type', () => {
+    const { result } = renderHook(() => useRegistryEditor(makeRegistry()));
+    expect(result.current.selectedId).toBe('realm');
+  });
+
+  it('select() updates selectedId', () => {
+    const { result } = renderHook(() => useRegistryEditor(makeRegistry()));
+    act(() => result.current.select('cluster'));
+    expect(result.current.selectedId).toBe('cluster');
+  });
+
+  it('select(null) clears selectedId', () => {
+    const { result } = renderHook(() => useRegistryEditor(makeRegistry()));
+    act(() => result.current.select(null));
+    expect(result.current.selectedId).toBeNull();
+  });
+
+  it('tryReparent performs a valid reparent and returns true', () => {
+    const { result } = renderHook(() => useRegistryEditor(makeRegistry()));
+    let success: boolean;
+    act(() => {
+      success = result.current.tryReparent('host', 'realm');
+    });
+    expect(success!).toBe(true);
+    const realm = result.current.registry.types.find((t) => t.id === 'realm')!;
+    expect(realm.canContain).toContain('host');
+    const host = result.current.registry.types.find((t) => t.id === 'host')!;
+    expect(host.parentTypes).toEqual(['realm']);
+  });
+
+  it('tryReparent bumps version after a valid move', () => {
+    const { result } = renderHook(() => useRegistryEditor(makeRegistry()));
+    const before = result.current.registry.version;
+    act(() => result.current.tryReparent('host', 'realm'));
+    expect(result.current.registry.version).toBe(before + 1);
+  });
+
+  it('tryReparent returns false and does not change registry when childId === newParentId', () => {
+    const { result } = renderHook(() => useRegistryEditor(makeRegistry()));
+    const before = JSON.stringify(result.current.registry);
+    let success: boolean;
+    act(() => {
+      success = result.current.tryReparent('realm', 'realm');
+    });
+    expect(success!).toBe(false);
+    expect(JSON.stringify(result.current.registry)).toBe(before);
+  });
+
+  it('tryReparent returns false when the move would create a cycle', () => {
+    // realm → cluster → host; moving realm under host would be a cycle
+    const { result } = renderHook(() => useRegistryEditor(makeRegistry()));
+    const before = JSON.stringify(result.current.registry);
+    let success: boolean;
+    act(() => {
+      success = result.current.tryReparent('realm', 'host');
+    });
+    expect(success!).toBe(false);
+    expect(JSON.stringify(result.current.registry)).toBe(before);
+  });
+});

--- a/web-next/packages/plugin-observatory/src/application/useRegistryEditor.ts
+++ b/web-next/packages/plugin-observatory/src/application/useRegistryEditor.ts
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+import type { Registry } from '../domain';
+import { isDescendant, reparent } from '../domain/containment';
+
+export interface RegistryEditorState {
+  registry: Registry;
+  selectedId: string | null;
+  select: (id: string | null) => void;
+  /**
+   * Attempts to reparent `childId` under `newParentId`.
+   * Returns `false` (and makes no change) if the drop would create a cycle or
+   * if childId === newParentId.
+   */
+  tryReparent: (childId: string, newParentId: string) => boolean;
+}
+
+export function useRegistryEditor(initial: Registry): RegistryEditorState {
+  const [registry, setRegistry] = useState<Registry>(initial);
+  const [selectedId, setSelectedId] = useState<string | null>(initial.types[0]?.id ?? null);
+
+  const tryReparent = (childId: string, newParentId: string): boolean => {
+    if (childId === newParentId) return false;
+    if (isDescendant(registry, childId, newParentId)) return false;
+    setRegistry((r) => reparent(r, childId, newParentId));
+    return true;
+  };
+
+  return {
+    registry,
+    selectedId,
+    select: setSelectedId,
+    tryReparent,
+  };
+}

--- a/web-next/packages/plugin-observatory/src/application/useRegistryEditor.ts
+++ b/web-next/packages/plugin-observatory/src/application/useRegistryEditor.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import type { Registry } from '../domain';
 import { isDescendant, reparent } from '../domain/containment';
 
@@ -18,9 +18,11 @@ export function useRegistryEditor(initial: Registry): RegistryEditorState {
   const [registry, setRegistry] = useState<Registry>(initial);
   const [selectedId, setSelectedId] = useState<string | null>(initial.types[0]?.id ?? null);
 
+  const byId = useMemo(() => new Map(registry.types.map((t) => [t.id, t])), [registry.types]);
+
   const tryReparent = (childId: string, newParentId: string): boolean => {
     if (childId === newParentId) return false;
-    if (isDescendant(registry, childId, newParentId)) return false;
+    if (isDescendant(registry, childId, newParentId, byId)) return false;
     setRegistry((r) => reparent(r, childId, newParentId));
     return true;
   };

--- a/web-next/packages/plugin-observatory/src/domain/containment.test.ts
+++ b/web-next/packages/plugin-observatory/src/domain/containment.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect } from 'vitest';
+import { isDescendant, reparent } from './containment';
+import type { Registry } from './index';
+
+/**
+ * Minimal registry fixture used across tests.
+ *
+ * Topology:
+ *   realm
+ *     └─ cluster
+ *          └─ host
+ *               └─ service
+ *   device   (root, no parents)
+ */
+const makeRegistry = (): Registry => ({
+  version: 1,
+  updatedAt: '2026-01-01T00:00:00Z',
+  types: [
+    {
+      id: 'realm',
+      label: 'Realm',
+      rune: 'ᛞ',
+      icon: 'globe',
+      shape: 'ring',
+      color: 'ice-100',
+      size: 18,
+      border: 'solid',
+      canContain: ['cluster'],
+      parentTypes: [],
+      category: 'topology',
+      description: 'A realm.',
+      fields: [],
+    },
+    {
+      id: 'cluster',
+      label: 'Cluster',
+      rune: 'ᚲ',
+      icon: 'layers',
+      shape: 'ring-dashed',
+      color: 'ice-200',
+      size: 14,
+      border: 'dashed',
+      canContain: ['host'],
+      parentTypes: ['realm'],
+      category: 'topology',
+      description: 'A cluster.',
+      fields: [],
+    },
+    {
+      id: 'host',
+      label: 'Host',
+      rune: 'ᚦ',
+      icon: 'server',
+      shape: 'rounded-rect',
+      color: 'slate-400',
+      size: 22,
+      border: 'solid',
+      canContain: ['service'],
+      parentTypes: ['cluster'],
+      category: 'hardware',
+      description: 'A host.',
+      fields: [],
+    },
+    {
+      id: 'service',
+      label: 'Service',
+      rune: 'ᛦ',
+      icon: 'box',
+      shape: 'dot',
+      color: 'ice-300',
+      size: 8,
+      border: 'solid',
+      canContain: [],
+      parentTypes: ['host'],
+      category: 'infrastructure',
+      description: 'A service.',
+      fields: [],
+    },
+    {
+      id: 'device',
+      label: 'Device',
+      rune: 'ᚠ',
+      icon: 'wifi',
+      shape: 'dot',
+      color: 'slate-400',
+      size: 5,
+      border: 'dashed',
+      canContain: [],
+      parentTypes: [],
+      category: 'device',
+      description: 'A device.',
+      fields: [],
+    },
+  ],
+});
+
+// ── isDescendant ──────────────────────────────────────────────────────────────
+
+describe('isDescendant', () => {
+  it('returns true when comparing a node to itself', () => {
+    expect(isDescendant(makeRegistry(), 'realm', 'realm')).toBe(true);
+  });
+
+  it('returns true for a direct child', () => {
+    expect(isDescendant(makeRegistry(), 'realm', 'cluster')).toBe(true);
+  });
+
+  it('returns true for a transitive descendant (depth-2)', () => {
+    expect(isDescendant(makeRegistry(), 'realm', 'host')).toBe(true);
+  });
+
+  it('returns true for a transitive descendant (depth-3)', () => {
+    expect(isDescendant(makeRegistry(), 'realm', 'service')).toBe(true);
+  });
+
+  it('returns false for an unrelated node', () => {
+    expect(isDescendant(makeRegistry(), 'realm', 'device')).toBe(false);
+  });
+
+  it('returns false for the reverse direction (parent of ancestor)', () => {
+    expect(isDescendant(makeRegistry(), 'cluster', 'realm')).toBe(false);
+  });
+
+  it('returns false when ancestorId does not exist', () => {
+    expect(isDescendant(makeRegistry(), 'nonexistent', 'realm')).toBe(false);
+  });
+
+  it('handles cycles in canContain without infinite loop', () => {
+    const r = makeRegistry();
+    // Manually inject a cycle: service → realm (which is ancestor of service)
+    r.types = r.types.map((t) => (t.id === 'service' ? { ...t, canContain: ['realm'] } : t));
+    // Should still return without hanging; realm→service is still true
+    expect(isDescendant(r, 'realm', 'service')).toBe(true);
+    // And should not loop forever
+    expect(isDescendant(r, 'service', 'device')).toBe(false);
+  });
+});
+
+// ── reparent ──────────────────────────────────────────────────────────────────
+
+describe('reparent', () => {
+  it('adds childId to new parent canContain', () => {
+    const r = reparent(makeRegistry(), 'service', 'realm');
+    const realm = r.types.find((t) => t.id === 'realm')!;
+    expect(realm.canContain).toContain('service');
+  });
+
+  it('removes childId from old parent canContain', () => {
+    const r = reparent(makeRegistry(), 'service', 'realm');
+    const host = r.types.find((t) => t.id === 'host')!;
+    expect(host.canContain).not.toContain('service');
+  });
+
+  it('rewrites child parentTypes to single-parent array', () => {
+    const r = reparent(makeRegistry(), 'service', 'realm');
+    const service = r.types.find((t) => t.id === 'service')!;
+    expect(service.parentTypes).toEqual(['realm']);
+  });
+
+  it('bumps the registry version by 1', () => {
+    const before = makeRegistry();
+    const after = reparent(before, 'service', 'realm');
+    expect(after.version).toBe(before.version + 1);
+  });
+
+  it('sets updatedAt to a new ISO timestamp', () => {
+    const before = makeRegistry();
+    const after = reparent(before, 'service', 'realm');
+    expect(after.updatedAt).not.toBe(before.updatedAt);
+    expect(() => new Date(after.updatedAt)).not.toThrow();
+  });
+
+  it('does not mutate the source registry', () => {
+    const before = makeRegistry();
+    const snapshot = JSON.stringify(before);
+    reparent(before, 'service', 'realm');
+    expect(JSON.stringify(before)).toBe(snapshot);
+  });
+
+  it('does not duplicate childId if new parent already contains it', () => {
+    const r = makeRegistry();
+    // realm already contains cluster; reparenting cluster → realm again should be idempotent
+    const after = reparent(r, 'cluster', 'realm');
+    const realm = after.types.find((t) => t.id === 'realm')!;
+    expect(realm.canContain.filter((id) => id === 'cluster').length).toBe(1);
+  });
+
+  it('leaves other types unchanged except version/updatedAt', () => {
+    const before = makeRegistry();
+    const after = reparent(before, 'service', 'realm');
+    // cluster should be untouched aside from version on the registry root
+    const beforeCluster = before.types.find((t) => t.id === 'cluster')!;
+    const afterCluster = after.types.find((t) => t.id === 'cluster')!;
+    expect(afterCluster).toEqual(beforeCluster);
+  });
+
+  it('moves a root type to become a child of another root', () => {
+    // device has no parents; move it under realm
+    const after = reparent(makeRegistry(), 'device', 'realm');
+    const realm = after.types.find((t) => t.id === 'realm')!;
+    const device = after.types.find((t) => t.id === 'device')!;
+    expect(realm.canContain).toContain('device');
+    expect(device.parentTypes).toEqual(['realm']);
+  });
+});

--- a/web-next/packages/plugin-observatory/src/domain/containment.ts
+++ b/web-next/packages/plugin-observatory/src/domain/containment.ts
@@ -1,4 +1,4 @@
-import type { Registry } from './index';
+import type { Registry, EntityType } from './index';
 
 /**
  * Returns true if `descendantId` appears anywhere beneath `ancestorId` in the
@@ -6,21 +6,25 @@ import type { Registry } from './index';
  *
  * Also returns true when ancestorId === descendantId, so callers can use this
  * as the single "would this drop create a cycle?" guard.
+ *
+ * Pass a pre-built `byId` map (e.g. from a memoized value) to avoid
+ * rebuilding it on every call — important during drag operations.
  */
 export function isDescendant(
   registry: Registry,
   ancestorId: string,
   descendantId: string,
+  byId?: Map<string, EntityType>,
 ): boolean {
   if (ancestorId === descendantId) return true;
 
-  const byId = new Map(registry.types.map((t) => [t.id, t]));
+  const lookup = byId ?? new Map(registry.types.map((t) => [t.id, t]));
   const seen = new Set<string>();
 
   const walk = (id: string): boolean => {
     if (seen.has(id)) return false;
     seen.add(id);
-    const t = byId.get(id);
+    const t = lookup.get(id);
     if (!t) return false;
     for (const childId of t.canContain) {
       if (childId === descendantId) return true;

--- a/web-next/packages/plugin-observatory/src/domain/containment.ts
+++ b/web-next/packages/plugin-observatory/src/domain/containment.ts
@@ -1,0 +1,69 @@
+import type { Registry } from './index';
+
+/**
+ * Returns true if `descendantId` appears anywhere beneath `ancestorId` in the
+ * canContain DAG (depth-first, cycle-safe via visited set).
+ *
+ * Also returns true when ancestorId === descendantId, so callers can use this
+ * as the single "would this drop create a cycle?" guard.
+ */
+export function isDescendant(
+  registry: Registry,
+  ancestorId: string,
+  descendantId: string,
+): boolean {
+  if (ancestorId === descendantId) return true;
+
+  const byId = new Map(registry.types.map((t) => [t.id, t]));
+  const seen = new Set<string>();
+
+  const walk = (id: string): boolean => {
+    if (seen.has(id)) return false;
+    seen.add(id);
+    const t = byId.get(id);
+    if (!t) return false;
+    for (const childId of t.canContain) {
+      if (childId === descendantId) return true;
+      if (walk(childId)) return true;
+    }
+    return false;
+  };
+
+  return walk(ancestorId);
+}
+
+/**
+ * Returns a new Registry with `childId` reparented under `newParentId`.
+ *
+ * Mutations applied immutably:
+ * 1. Remove `childId` from every old parent's `canContain` (except newParentId).
+ * 2. Add `childId` to `newParentId`'s `canContain` (if not already there).
+ * 3. Rewrite the child's `parentTypes` to `[newParentId]` (single-parent model).
+ * 4. Bump `version` and set `updatedAt` to now.
+ *
+ * Pre-condition: caller must verify the drop is valid (not a cycle, not self).
+ */
+export function reparent(registry: Registry, childId: string, newParentId: string): Registry {
+  const types = registry.types.map((t) => {
+    // Remove child from any previous parent's canContain (except the new parent).
+    if (t.canContain.includes(childId) && t.id !== newParentId) {
+      return { ...t, canContain: t.canContain.filter((id) => id !== childId) };
+    }
+    // Add child to new parent's canContain.
+    if (t.id === newParentId && !t.canContain.includes(childId)) {
+      return { ...t, canContain: [...t.canContain, childId] };
+    }
+    // Rewrite child's parentTypes to single-parent.
+    if (t.id === childId) {
+      return { ...t, parentTypes: [newParentId] };
+    }
+    return t;
+  });
+
+  return {
+    ...registry,
+    types,
+    version: registry.version + 1,
+    updatedAt: new Date().toISOString(),
+  };
+}

--- a/web-next/packages/plugin-observatory/src/domain/index.ts
+++ b/web-next/packages/plugin-observatory/src/domain/index.ts
@@ -54,13 +54,7 @@ export interface Registry extends Omit<TypeRegistry, 'types'> {
 export type EdgeKind = 'solid' | 'dashed-anim' | 'dashed-long' | 'soft' | 'raid';
 
 /** Runtime health status of a topology node. */
-export type NodeStatus =
-  | 'healthy'
-  | 'degraded'
-  | 'failed'
-  | 'idle'
-  | 'observing'
-  | 'unknown';
+export type NodeStatus = 'healthy' | 'degraded' | 'failed' | 'idle' | 'observing' | 'unknown';
 
 /** An instance of an EntityType in the live topology graph. */
 export interface TopologyNode {

--- a/web-next/packages/plugin-observatory/src/index.tsx
+++ b/web-next/packages/plugin-observatory/src/index.tsx
@@ -22,7 +22,11 @@ export const observatoryPlugin = definePlugin({
   ],
 });
 
-export { createMockRegistryRepository, createMockTopologyStream, createMockEventStream } from './adapters/mock';
+export {
+  createMockRegistryRepository,
+  createMockTopologyStream,
+  createMockEventStream,
+} from './adapters/mock';
 export type { IRegistryRepository, ILiveTopologyStream, IEventStream } from './ports';
 export type {
   EntityType,

--- a/web-next/packages/plugin-observatory/src/styles.css
+++ b/web-next/packages/plugin-observatory/src/styles.css
@@ -1,0 +1,54 @@
+@tailwind components;
+@tailwind utilities;
+
+@layer components {
+  /* Section headers in TypePreviewDrawer */
+  .registry-section-head {
+    @apply niuu-text-[11px] niuu-font-mono niuu-uppercase niuu-text-text-muted niuu-mb-2 niuu-font-medium;
+    letter-spacing: 0.07em;
+  }
+
+  /* Tab bar buttons */
+  .registry-tab-btn {
+    @apply niuu-text-text-muted niuu-cursor-pointer niuu-font-sans niuu-text-sm niuu-font-normal niuu-px-3 niuu-py-2;
+    background: none;
+    border: none;
+    border-bottom: 2px solid transparent;
+    margin-bottom: -1px;
+  }
+
+  .registry-tab-btn[aria-selected='true'] {
+    border-bottom-color: var(--color-brand);
+    @apply niuu-text-text-primary niuu-font-semibold;
+  }
+
+  /* Containment tree nodes */
+  .registry-tree-node {
+    @apply niuu-flex niuu-items-center niuu-gap-2 niuu-rounded-sm niuu-border niuu-border-transparent niuu-cursor-grab;
+    padding: 4px 8px;
+    margin-left: calc(var(--tree-depth, 0) * 20px);
+  }
+
+  .registry-tree-node[data-selected='true'] {
+    @apply niuu-bg-bg-tertiary;
+  }
+
+  .registry-tree-node[data-dragging='true'] {
+    @apply niuu-opacity-40 niuu-cursor-grabbing;
+  }
+
+  .registry-tree-node[data-drag-state='ok'] {
+    border: 1px dashed color-mix(in srgb, var(--color-brand) 30%, transparent);
+  }
+
+  .registry-tree-node[data-drag-state='target'] {
+    border: 1px solid var(--color-brand);
+    background: color-mix(in srgb, var(--color-brand) 20%, transparent);
+  }
+
+  .registry-tree-node[data-drag-state='invalid'] {
+    border: 1px solid var(--color-critical);
+    background: color-mix(in srgb, var(--color-critical) 15%, transparent);
+    cursor: not-allowed;
+  }
+}

--- a/web-next/packages/plugin-observatory/src/ui/ObservatoryPage.test.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/ObservatoryPage.test.tsx
@@ -3,10 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ServicesProvider } from '@niuulabs/plugin-sdk';
 import { ObservatoryPage } from './ObservatoryPage';
-import {
-  createMockTopologyStream,
-  createMockEventStream,
-} from '../adapters/mock';
+import { createMockTopologyStream, createMockEventStream } from '../adapters/mock';
 
 function wrap(ui: React.ReactNode) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });

--- a/web-next/packages/plugin-observatory/src/ui/ObservatoryPage.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/ObservatoryPage.tsx
@@ -19,36 +19,22 @@ export function ObservatoryPage() {
   const recentEvents = events.slice(-5);
 
   return (
-    <div style={{ padding: 'var(--space-6)', maxWidth: 960 }}>
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 'var(--space-3)',
-          marginBottom: 'var(--space-2)',
-        }}
-      >
+    <div className="niuu-p-6 niuu-max-w-[960px]">
+      <div className="niuu-flex niuu-items-center niuu-gap-3 niuu-mb-2">
         <Rune glyph="ᚠ" size={32} />
-        <h2 style={{ margin: 0 }}>Observatory</h2>
+        <h2 className="niuu-m-0">Observatory</h2>
       </div>
-      <p style={{ margin: '0 0 var(--space-6)', color: 'var(--color-text-secondary)' }}>
+      <p className="niuu-m-0 niuu-mb-6 niuu-text-text-secondary">
         live topology · canvas coming soon
       </p>
 
       {topology ? (
-        <div style={{ display: 'flex', gap: 'var(--space-4)', marginBottom: 'var(--space-6)' }}>
+        <div className="niuu-flex niuu-gap-4 niuu-mb-6">
           <StatCard label="nodes" value={nodeCount} />
           <StatCard label="edges" value={edgeCount} />
         </div>
       ) : (
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 'var(--space-2)',
-            marginBottom: 'var(--space-6)',
-          }}
-        >
+        <div className="niuu-flex niuu-items-center niuu-gap-2 niuu-mb-6">
           <StateDot state="processing" pulse />
           <span>connecting…</span>
         </div>
@@ -56,35 +42,16 @@ export function ObservatoryPage() {
 
       {recentEvents.length > 0 && (
         <section>
-          <h3
-            style={{
-              margin: '0 0 var(--space-3)',
-              fontSize: 'var(--text-sm)',
-              color: 'var(--color-text-muted)',
-            }}
-          >
-            Recent events
-          </h3>
-          <ul style={{ listStyle: 'none', padding: 0, display: 'grid', gap: 'var(--space-2)' }}>
+          <h3 className="niuu-m-0 niuu-mb-3 niuu-text-sm niuu-text-text-muted">Recent events</h3>
+          <ul className="niuu-list-none niuu-p-0 niuu-grid niuu-gap-2">
             {recentEvents.map((ev) => (
               <li
                 key={ev.id}
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 'var(--space-2)',
-                  padding: 'var(--space-2) var(--space-3)',
-                  border: '1px solid var(--color-border-subtle)',
-                  borderRadius: 'var(--radius-md)',
-                  background: 'var(--color-bg-secondary)',
-                  fontSize: 'var(--text-sm)',
-                }}
+                className="niuu-flex niuu-items-center niuu-gap-2 niuu-py-2 niuu-px-3 niuu-border niuu-border-border-subtle niuu-rounded-md niuu-bg-bg-secondary niuu-text-sm"
               >
                 <StateDot state={severityToDotState(ev.severity)} />
-                <span style={{ color: 'var(--color-text-muted)', fontFamily: 'var(--font-mono)' }}>
-                  {ev.sourceId}
-                </span>
-                <span style={{ flex: 1 }}>{ev.message}</span>
+                <span className="niuu-text-text-muted niuu-font-mono">{ev.sourceId}</span>
+                <span className="niuu-flex-1">{ev.message}</span>
               </li>
             ))}
           </ul>
@@ -96,17 +63,9 @@ export function ObservatoryPage() {
 
 function StatCard({ label, value }: { label: string; value: number }) {
   return (
-    <div
-      style={{
-        padding: 'var(--space-4)',
-        border: '1px solid var(--color-border-subtle)',
-        borderRadius: 'var(--radius-md)',
-        background: 'var(--color-bg-secondary)',
-        minWidth: 100,
-      }}
-    >
-      <div style={{ fontSize: 'var(--text-2xl)', fontWeight: 700 }}>{value}</div>
-      <div style={{ color: 'var(--color-text-muted)', fontSize: 'var(--text-xs)' }}>{label}</div>
+    <div className="niuu-p-4 niuu-border niuu-border-border-subtle niuu-rounded-md niuu-bg-bg-secondary niuu-min-w-[100px]">
+      <div className="niuu-text-2xl niuu-font-bold">{value}</div>
+      <div className="niuu-text-text-muted niuu-text-xs">{label}</div>
     </div>
   );
 }

--- a/web-next/packages/plugin-observatory/src/ui/ObservatoryPage.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/ObservatoryPage.tsx
@@ -56,7 +56,13 @@ export function ObservatoryPage() {
 
       {recentEvents.length > 0 && (
         <section>
-          <h3 style={{ margin: '0 0 var(--space-3)', fontSize: 'var(--text-sm)', color: 'var(--color-text-muted)' }}>
+          <h3
+            style={{
+              margin: '0 0 var(--space-3)',
+              fontSize: 'var(--text-sm)',
+              color: 'var(--color-text-muted)',
+            }}
+          >
             Recent events
           </h3>
           <ul style={{ listStyle: 'none', padding: 0, display: 'grid', gap: 'var(--space-2)' }}>

--- a/web-next/packages/plugin-observatory/src/ui/RegistryEditor.stories.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/RegistryEditor.stories.tsx
@@ -1,0 +1,295 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { RegistryEditor } from './RegistryEditor';
+import type { Registry } from '../domain';
+
+/**
+ * Registry editor — three-tab interface for browsing and reparenting entity
+ * types in the Observatory.
+ *
+ * - **Types**: searchable list grouped by category, click to open preview drawer.
+ * - **Containment**: drag-drop tree for reparenting; cycle protection enforced.
+ * - **JSON**: read-only pretty-print with copy button.
+ */
+const meta: Meta<typeof RegistryEditor> = {
+  title: 'Plugins / Observatory / RegistryEditor',
+  component: RegistryEditor,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ height: '100vh', background: 'var(--color-bg-primary)' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof RegistryEditor>;
+
+/** Default state — full seed registry, Types tab, first type pre-selected. */
+export const Default: Story = {
+  args: { registry: FULL_REGISTRY },
+};
+
+/** Minimal registry — 3 types — useful for verifying layout at small scale. */
+export const Minimal: Story = {
+  args: { registry: MINIMAL_REGISTRY },
+};
+
+/** Registry containing an orphaned type (parentType references a missing id). */
+export const WithOrphan: Story = {
+  args: { registry: ORPHAN_REGISTRY },
+};
+
+// ── Seed data ─────────────────────────────────────────────────────────────────
+
+const MINIMAL_REGISTRY: Registry = {
+  version: 1,
+  updatedAt: '2026-04-01T00:00:00Z',
+  types: [
+    {
+      id: 'realm',
+      label: 'Realm',
+      rune: 'ᛞ',
+      icon: 'globe',
+      shape: 'ring',
+      color: 'ice-100',
+      size: 18,
+      border: 'solid',
+      canContain: ['cluster'],
+      parentTypes: [],
+      category: 'topology',
+      description: 'VLAN-scoped network zone.',
+      fields: [],
+    },
+    {
+      id: 'cluster',
+      label: 'Cluster',
+      rune: 'ᚲ',
+      icon: 'layers',
+      shape: 'ring-dashed',
+      color: 'ice-200',
+      size: 14,
+      border: 'dashed',
+      canContain: ['host'],
+      parentTypes: ['realm'],
+      category: 'topology',
+      description: 'Kubernetes cluster.',
+      fields: [],
+    },
+    {
+      id: 'host',
+      label: 'Host',
+      rune: 'ᚦ',
+      icon: 'server',
+      shape: 'rounded-rect',
+      color: 'slate-400',
+      size: 22,
+      border: 'solid',
+      canContain: [],
+      parentTypes: ['cluster'],
+      category: 'hardware',
+      description: 'Bare-metal or VM.',
+      fields: [{ key: 'os', label: 'OS', type: 'string' }],
+    },
+  ],
+};
+
+const ORPHAN_REGISTRY: Registry = {
+  ...MINIMAL_REGISTRY,
+  types: [
+    ...MINIMAL_REGISTRY.types,
+    {
+      id: 'orphan',
+      label: 'Orphaned Type',
+      rune: 'ᚲ',
+      icon: 'box',
+      shape: 'dot',
+      color: 'slate-400',
+      size: 8,
+      border: 'solid',
+      canContain: [],
+      parentTypes: ['missing-parent'],
+      category: 'infrastructure',
+      description: 'This type references a parent that no longer exists.',
+      fields: [],
+    },
+  ],
+};
+
+const FULL_REGISTRY: Registry = {
+  version: 7,
+  updatedAt: '2026-04-15T09:24:11Z',
+  types: [
+    {
+      id: 'realm',
+      label: 'Realm',
+      rune: 'ᛞ',
+      icon: 'globe',
+      shape: 'ring',
+      color: 'ice-100',
+      size: 18,
+      border: 'solid',
+      canContain: ['cluster', 'host', 'ravn_long', 'valkyrie', 'printer', 'vaettir', 'beacon'],
+      parentTypes: [],
+      category: 'topology',
+      description:
+        'VLAN-scoped network zone — asgard, midgard, svartalfheim, etc. Every entity lives in exactly one realm.',
+      fields: [
+        { key: 'vlan', label: 'VLAN', type: 'number', required: true },
+        { key: 'dns', label: 'DNS zone', type: 'string', required: true },
+        { key: 'purpose', label: 'Purpose', type: 'string' },
+      ],
+    },
+    {
+      id: 'cluster',
+      label: 'Cluster',
+      rune: 'ᚲ',
+      icon: 'layers',
+      shape: 'ring-dashed',
+      color: 'ice-200',
+      size: 14,
+      border: 'dashed',
+      canContain: ['service', 'raid', 'tyr', 'bifrost', 'volundr', 'valkyrie', 'mimir'],
+      parentTypes: ['realm'],
+      category: 'topology',
+      description:
+        'Kubernetes cluster nested inside a realm. Valaskjálf, Valhalla, Nóatún, Eitri, Glitnir, Járnviðr.',
+      fields: [
+        { key: 'purpose', label: 'Purpose', type: 'string' },
+        { key: 'nodes', label: 'Nodes', type: 'number' },
+      ],
+    },
+    {
+      id: 'host',
+      label: 'Host',
+      rune: 'ᚦ',
+      icon: 'server',
+      shape: 'rounded-rect',
+      color: 'slate-400',
+      size: 22,
+      border: 'solid',
+      canContain: ['ravn_long', 'service'],
+      parentTypes: ['realm'],
+      category: 'hardware',
+      description: 'Bare-metal or VM. DGX Sparks, Mac minis, EPYC boxes, user laptops.',
+      fields: [
+        { key: 'hw', label: 'Hardware', type: 'string' },
+        { key: 'os', label: 'OS', type: 'string' },
+        { key: 'cores', label: 'Cores', type: 'number' },
+        { key: 'ram', label: 'RAM', type: 'string' },
+        { key: 'gpu', label: 'GPU', type: 'string' },
+      ],
+    },
+    {
+      id: 'ravn_long',
+      label: 'Long-lived Ravn',
+      rune: 'ᚱ',
+      icon: 'bird',
+      shape: 'diamond',
+      color: 'brand',
+      size: 11,
+      border: 'solid',
+      canContain: [],
+      parentTypes: ['host', 'cluster', 'realm'],
+      category: 'agent',
+      description: 'Persistent raven agent bound to a host or free-orbiting.',
+      fields: [
+        { key: 'persona', label: 'Persona', type: 'select', options: ['thought', 'memory'] },
+        { key: 'specialty', label: 'Specialty', type: 'string' },
+      ],
+    },
+    {
+      id: 'tyr',
+      label: 'Týr',
+      rune: 'ᛃ',
+      icon: 'git-branch',
+      shape: 'square',
+      color: 'brand',
+      size: 16,
+      border: 'solid',
+      canContain: [],
+      parentTypes: ['cluster', 'realm'],
+      category: 'coordinator',
+      description: 'Saga / raid orchestrator.',
+      fields: [{ key: 'activeSagas', label: 'Active sagas', type: 'number' }],
+    },
+    {
+      id: 'mimir',
+      label: 'Mímir',
+      rune: 'ᛗ',
+      icon: 'book-open',
+      shape: 'mimir',
+      color: 'ice-100',
+      size: 42,
+      border: 'solid',
+      canContain: ['mimir_sub'],
+      parentTypes: ['cluster', 'realm'],
+      category: 'knowledge',
+      description: 'The well of knowledge.',
+      fields: [{ key: 'pages', label: 'Pages', type: 'number' }],
+    },
+    {
+      id: 'mimir_sub',
+      label: 'Sub-Mímir',
+      rune: 'ᛗ',
+      icon: 'book-marked',
+      shape: 'mimir-small',
+      color: 'ice-200',
+      size: 18,
+      border: 'solid',
+      canContain: [],
+      parentTypes: ['mimir'],
+      category: 'knowledge',
+      description: 'Domain-scoped Mímir.',
+      fields: [{ key: 'purpose', label: 'Purpose', type: 'string' }],
+    },
+    {
+      id: 'service',
+      label: 'Service',
+      rune: 'ᛦ',
+      icon: 'box',
+      shape: 'dot',
+      color: 'ice-300',
+      size: 8,
+      border: 'solid',
+      canContain: [],
+      parentTypes: ['cluster', 'host'],
+      category: 'infrastructure',
+      description: 'Kubernetes workload.',
+      fields: [{ key: 'svcType', label: 'Type', type: 'select', options: ['rabbitmq', 'auth'] }],
+    },
+    {
+      id: 'raid',
+      label: 'Raid',
+      rune: 'ᚷ',
+      icon: 'users',
+      shape: 'halo',
+      color: 'brand',
+      size: 50,
+      border: 'dashed',
+      canContain: ['ravn_raid'],
+      parentTypes: ['cluster'],
+      category: 'composite',
+      description: 'Ephemeral flock of ravens.',
+      fields: [{ key: 'purpose', label: 'Purpose', type: 'string' }],
+    },
+    {
+      id: 'ravn_raid',
+      label: 'Raid Ravn',
+      rune: 'ᚲ',
+      icon: 'bird',
+      shape: 'triangle',
+      color: 'ice-300',
+      size: 8,
+      border: 'solid',
+      canContain: [],
+      parentTypes: ['raid'],
+      category: 'agent',
+      description: 'Ephemeral raven in a raid.',
+      fields: [{ key: 'role', label: 'Role', type: 'select', options: ['coord', 'reviewer'] }],
+    },
+  ],
+};

--- a/web-next/packages/plugin-observatory/src/ui/RegistryEditor.test.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/RegistryEditor.test.tsx
@@ -1,0 +1,282 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { RegistryEditor } from './RegistryEditor';
+import type { Registry } from '../domain';
+
+const SEED_REGISTRY: Registry = {
+  version: 3,
+  updatedAt: '2026-04-01T10:00:00Z',
+  types: [
+    {
+      id: 'realm',
+      label: 'Realm',
+      rune: 'ᛞ',
+      icon: 'globe',
+      shape: 'ring',
+      color: 'ice-100',
+      size: 18,
+      border: 'solid',
+      canContain: ['cluster'],
+      parentTypes: [],
+      category: 'topology',
+      description: 'VLAN-scoped network zone.',
+      fields: [{ key: 'vlan', label: 'VLAN', type: 'number', required: true }],
+    },
+    {
+      id: 'cluster',
+      label: 'Cluster',
+      rune: 'ᚲ',
+      icon: 'layers',
+      shape: 'ring-dashed',
+      color: 'ice-200',
+      size: 14,
+      border: 'dashed',
+      canContain: ['host'],
+      parentTypes: ['realm'],
+      category: 'topology',
+      description: 'Kubernetes cluster nested inside a realm.',
+      fields: [],
+    },
+    {
+      id: 'host',
+      label: 'Host',
+      rune: 'ᚦ',
+      icon: 'server',
+      shape: 'rounded-rect',
+      color: 'slate-400',
+      size: 22,
+      border: 'solid',
+      canContain: [],
+      parentTypes: ['cluster'],
+      category: 'hardware',
+      description: 'Bare-metal or VM.',
+      fields: [{ key: 'os', label: 'OS', type: 'string' }],
+    },
+    {
+      id: 'device',
+      label: 'Device',
+      rune: 'ᚠ',
+      icon: 'wifi',
+      shape: 'dot',
+      color: 'slate-400',
+      size: 5,
+      border: 'dashed',
+      canContain: [],
+      parentTypes: [],
+      category: 'device',
+      description: 'A standalone device.',
+      fields: [],
+    },
+  ],
+};
+
+// ── Render helpers ────────────────────────────────────────────────────────────
+
+function renderEditor(registry = SEED_REGISTRY) {
+  return render(<RegistryEditor registry={registry} />);
+}
+
+// ── Types tab ─────────────────────────────────────────────────────────────────
+
+describe('RegistryEditor — Types tab', () => {
+  it('renders the Types tab active by default', () => {
+    renderEditor();
+    const tab = screen.getByRole('tab', { name: /types/i });
+    expect(tab).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('shows all entity types grouped by category', () => {
+    renderEditor();
+    // Use getAllByText since the first type may appear in both list and drawer
+    expect(screen.getAllByText('Realm').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Cluster').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Host').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Device').length).toBeGreaterThan(0);
+  });
+
+  it('shows category headers', () => {
+    renderEditor();
+    // category headers appear in the list (uppercase mono label)
+    expect(screen.getAllByText(/topology/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/hardware/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/device/).length).toBeGreaterThan(0);
+  });
+
+  it('shows the version and type count in the header', () => {
+    renderEditor();
+    expect(screen.getByText(/rev/)).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText(/4 types/)).toBeInTheDocument();
+  });
+
+  it('opens the preview drawer when a type row is clicked', () => {
+    renderEditor();
+    fireEvent.click(screen.getByTestId('type-row-cluster'));
+    expect(screen.getByTestId('type-preview-drawer')).toBeInTheDocument();
+    // Drawer should show cluster details
+    expect(screen.getAllByText('Cluster').length).toBeGreaterThan(0);
+  });
+
+  it('closes the preview drawer when the close button is clicked', () => {
+    renderEditor();
+    fireEvent.click(screen.getByTestId('type-row-cluster'));
+    fireEvent.click(screen.getByRole('button', { name: /close preview/i }));
+    expect(screen.queryByTestId('type-preview-drawer')).not.toBeInTheDocument();
+  });
+
+  it('filters types by search query — hides non-matching type rows', () => {
+    renderEditor();
+    // Search for "VLAN" — only realm's description mentions VLAN
+    fireEvent.change(screen.getByRole('textbox', { name: /filter types/i }), {
+      target: { value: 'VLAN' },
+    });
+    expect(screen.getByTestId('type-row-realm')).toBeInTheDocument();
+    expect(screen.queryByTestId('type-row-device')).not.toBeInTheDocument();
+  });
+
+  it('shows empty message when search matches nothing', () => {
+    renderEditor();
+    fireEvent.change(screen.getByRole('textbox', { name: /filter types/i }), {
+      target: { value: 'zzznomatch' },
+    });
+    expect(screen.getByText(/no types match/i)).toBeInTheDocument();
+  });
+});
+
+// ── Containment tab ───────────────────────────────────────────────────────────
+
+describe('RegistryEditor — Containment tab', () => {
+  it('switches to the Containment tab', () => {
+    renderEditor();
+    fireEvent.click(screen.getByTestId('tab-containment'));
+    expect(screen.getByTestId('containment-tree')).toBeInTheDocument();
+  });
+
+  it('shows root nodes (no parents) at top level', () => {
+    renderEditor();
+    fireEvent.click(screen.getByTestId('tab-containment'));
+    // realm and device are roots
+    expect(screen.getByTestId('tree-node-realm')).toBeInTheDocument();
+    expect(screen.getByTestId('tree-node-device')).toBeInTheDocument();
+  });
+
+  it('shows nested children of roots', () => {
+    renderEditor();
+    fireEvent.click(screen.getByTestId('tab-containment'));
+    expect(screen.getByTestId('tree-node-cluster')).toBeInTheDocument();
+    expect(screen.getByTestId('tree-node-host')).toBeInTheDocument();
+  });
+
+  it('clicking a tree node opens the preview drawer', () => {
+    renderEditor();
+    fireEvent.click(screen.getByTestId('tab-containment'));
+    fireEvent.click(screen.getByTestId('tree-node-cluster'));
+    expect(screen.getByTestId('type-preview-drawer')).toBeInTheDocument();
+  });
+});
+
+// ── JSON tab ──────────────────────────────────────────────────────────────────
+
+describe('RegistryEditor — JSON tab', () => {
+  it('switches to the JSON tab', () => {
+    renderEditor();
+    fireEvent.click(screen.getByTestId('tab-json'));
+    expect(screen.getByTestId('json-output')).toBeInTheDocument();
+  });
+
+  it('renders pretty-printed JSON of the registry', () => {
+    renderEditor();
+    fireEvent.click(screen.getByTestId('tab-json'));
+    const pre = screen.getByTestId('json-output');
+    expect(pre.textContent).toContain('"version": 3');
+    expect(pre.textContent).toContain('"realm"');
+  });
+
+  it('renders the copy button', () => {
+    renderEditor();
+    fireEvent.click(screen.getByTestId('tab-json'));
+    expect(screen.getByTestId('copy-json-btn')).toBeInTheDocument();
+    expect(screen.getByTestId('copy-json-btn')).toHaveTextContent('copy');
+  });
+
+  it('does not render the preview drawer in JSON tab', () => {
+    renderEditor();
+    // select a type first
+    fireEvent.click(screen.getByTestId('type-row-realm'));
+    // switch to JSON
+    fireEvent.click(screen.getByTestId('tab-json'));
+    expect(screen.queryByTestId('type-preview-drawer')).not.toBeInTheDocument();
+  });
+});
+
+// ── Reparent (drag interaction) via tryReparent ────────────────────────────────
+
+describe('RegistryEditor — containment reparenting', () => {
+  it('updates the tree after a valid reparent (host → realm)', async () => {
+    renderEditor();
+    fireEvent.click(screen.getByTestId('tab-containment'));
+
+    // Simulate drag-drop by triggering dragStart + drop events
+    const hostNode = screen.getByTestId('tree-node-host');
+    const realmNode = screen.getByTestId('tree-node-realm');
+
+    fireEvent.dragStart(hostNode);
+    fireEvent.dragOver(realmNode);
+    fireEvent.drop(realmNode);
+
+    // After drop, the JSON tab should reflect the updated version
+    fireEvent.click(screen.getByTestId('tab-json'));
+    await waitFor(() => {
+      const pre = screen.getByTestId('json-output');
+      const parsed = JSON.parse(pre.textContent ?? '{}') as Registry;
+      expect(parsed.version).toBe(4);
+      const realm = parsed.types.find((t) => t.id === 'realm')!;
+      expect(realm.canContain).toContain('host');
+    });
+  });
+
+  it('marks node as drop-target state during valid dragOver', () => {
+    renderEditor();
+    fireEvent.click(screen.getByTestId('tab-containment'));
+
+    const hostNode = screen.getByTestId('tree-node-host');
+    const realmNode = screen.getByTestId('tree-node-realm');
+
+    fireEvent.dragStart(hostNode);
+    fireEvent.dragOver(realmNode);
+
+    expect(realmNode).toHaveAttribute('data-drag-state', 'target');
+  });
+
+  it('marks node as drop-invalid state when cycle would be created', () => {
+    renderEditor();
+    fireEvent.click(screen.getByTestId('tab-containment'));
+
+    // realm → cluster → host; dragging realm over host would cycle
+    const realmNode = screen.getByTestId('tree-node-realm');
+    const hostNode = screen.getByTestId('tree-node-host');
+
+    fireEvent.dragStart(realmNode);
+    fireEvent.dragOver(hostNode);
+
+    expect(hostNode).toHaveAttribute('data-drag-state', 'invalid');
+  });
+
+  it('does not reparent when cycle would be created', () => {
+    renderEditor();
+    fireEvent.click(screen.getByTestId('tab-containment'));
+
+    const realmNode = screen.getByTestId('tree-node-realm');
+    const hostNode = screen.getByTestId('tree-node-host');
+
+    fireEvent.dragStart(realmNode);
+    fireEvent.dragOver(hostNode);
+    fireEvent.drop(hostNode);
+
+    // Version should remain 3 — no change happened
+    fireEvent.click(screen.getByTestId('tab-json'));
+    const pre = screen.getByTestId('json-output');
+    const parsed = JSON.parse(pre.textContent ?? '{}') as Registry;
+    expect(parsed.version).toBe(3);
+  });
+});

--- a/web-next/packages/plugin-observatory/src/ui/RegistryEditor.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/RegistryEditor.tsx
@@ -1,0 +1,841 @@
+import { useMemo, useState } from 'react';
+import { ShapeSvg, Chip } from '@niuulabs/ui';
+import type { Registry, EntityType } from '../domain';
+import { isDescendant } from '../domain/containment';
+import { useRegistryEditor } from '../application/useRegistryEditor';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type TabId = 'types' | 'containment' | 'json';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function formatDate(iso: string) {
+  return iso.slice(0, 10);
+}
+
+// ── TypePreviewDrawer ─────────────────────────────────────────────────────────
+
+interface TypePreviewDrawerProps {
+  type: EntityType;
+  onClose: () => void;
+}
+
+function TypePreviewDrawer({ type, onClose }: TypePreviewDrawerProps) {
+  return (
+    <div
+      data-testid="type-preview-drawer"
+      style={{
+        width: 320,
+        flexShrink: 0,
+        borderLeft: '1px solid var(--color-border-subtle)',
+        background: 'var(--color-bg-secondary)',
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        style={{
+          padding: 'var(--space-4)',
+          borderBottom: '1px solid var(--color-border-subtle)',
+          display: 'flex',
+          alignItems: 'flex-start',
+          gap: 'var(--space-3)',
+        }}
+      >
+        <div
+          style={{
+            width: 48,
+            height: 48,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            background: 'var(--color-bg-tertiary)',
+            borderRadius: 'var(--radius-md)',
+            border: '1px solid var(--color-border-subtle)',
+            flexShrink: 0,
+          }}
+        >
+          <ShapeSvg shape={type.shape} color={type.color} size={28} />
+        </div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 10,
+              color: 'var(--color-text-muted)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.07em',
+              marginBottom: 2,
+            }}
+          >
+            {type.category}
+          </div>
+          <div
+            style={{
+              fontSize: 'var(--text-lg)',
+              fontWeight: 600,
+              letterSpacing: '-0.015em',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+            }}
+          >
+            {type.label}
+            <span
+              style={{
+                fontFamily: 'var(--font-mono)',
+                color: 'var(--color-brand)',
+                fontSize: 16,
+                fontWeight: 700,
+              }}
+            >
+              {type.rune}
+            </span>
+          </div>
+          <div
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 11,
+              color: 'var(--color-text-muted)',
+              marginTop: 2,
+            }}
+          >
+            {type.id}
+          </div>
+        </div>
+        <button
+          aria-label="Close preview"
+          onClick={onClose}
+          style={{
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            color: 'var(--color-text-muted)',
+            padding: 4,
+            lineHeight: 1,
+            fontSize: 16,
+          }}
+        >
+          ✕
+        </button>
+      </div>
+
+      <div style={{ padding: 'var(--space-4)', overflowY: 'auto', flex: 1 }}>
+        <p
+          style={{
+            margin: '0 0 var(--space-4)',
+            fontSize: 'var(--text-sm)',
+            color: 'var(--color-text-secondary)',
+            lineHeight: 1.5,
+          }}
+        >
+          {type.description}
+        </p>
+
+        <div className="section-head" style={{ marginTop: 0 }}>
+          Visual
+        </div>
+        <dl
+          style={{
+            display: 'grid',
+            gridTemplateColumns: '80px 1fr',
+            gap: 'var(--space-1) var(--space-3)',
+            margin: '0 0 var(--space-4)',
+            fontSize: 'var(--text-sm)',
+          }}
+        >
+          <dt style={{ color: 'var(--color-text-muted)' }}>shape</dt>
+          <dd
+            style={{
+              margin: 0,
+              fontFamily: 'var(--font-mono)',
+              color: 'var(--color-text-secondary)',
+            }}
+          >
+            {type.shape}
+          </dd>
+          <dt style={{ color: 'var(--color-text-muted)' }}>size</dt>
+          <dd
+            style={{
+              margin: 0,
+              fontFamily: 'var(--font-mono)',
+              color: 'var(--color-text-secondary)',
+            }}
+          >
+            {type.size}
+          </dd>
+          <dt style={{ color: 'var(--color-text-muted)' }}>border</dt>
+          <dd
+            style={{
+              margin: 0,
+              fontFamily: 'var(--font-mono)',
+              color: 'var(--color-text-secondary)',
+            }}
+          >
+            {type.border}
+          </dd>
+        </dl>
+
+        {type.parentTypes.length > 0 && (
+          <>
+            <div className="section-head">Lives inside</div>
+            <div
+              style={{
+                display: 'flex',
+                flexWrap: 'wrap',
+                gap: 'var(--space-1)',
+                marginBottom: 'var(--space-4)',
+              }}
+            >
+              {type.parentTypes.map((id) => (
+                <Chip key={id} tone="muted">
+                  {id}
+                </Chip>
+              ))}
+            </div>
+          </>
+        )}
+
+        {type.canContain.length > 0 && (
+          <>
+            <div className="section-head">Can contain</div>
+            <div
+              style={{
+                display: 'flex',
+                flexWrap: 'wrap',
+                gap: 'var(--space-1)',
+                marginBottom: 'var(--space-4)',
+              }}
+            >
+              {type.canContain.map((id) => (
+                <Chip key={id} tone="muted">
+                  {id}
+                </Chip>
+              ))}
+            </div>
+          </>
+        )}
+
+        {type.fields.length > 0 && (
+          <>
+            <div className="section-head">Fields</div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+              {type.fields.map((f) => (
+                <div
+                  key={f.key}
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    fontSize: 'var(--text-sm)',
+                  }}
+                >
+                  <span style={{ color: 'var(--color-text-secondary)' }}>{f.label}</span>
+                  <span
+                    style={{
+                      fontFamily: 'var(--font-mono)',
+                      fontSize: 11,
+                      color: 'var(--color-text-muted)',
+                    }}
+                  >
+                    {f.type}
+                    {f.required && ' *'}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── TypesTab ──────────────────────────────────────────────────────────────────
+
+interface TypesTabProps {
+  registry: Registry;
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+}
+
+function TypesTab({ registry, selectedId, onSelect }: TypesTabProps) {
+  const [search, setSearch] = useState('');
+
+  const filtered = useMemo(() => {
+    if (!search) return registry.types;
+    const q = search.toLowerCase();
+    return registry.types.filter(
+      (t) =>
+        t.label.toLowerCase().includes(q) ||
+        t.id.includes(q) ||
+        t.description.toLowerCase().includes(q),
+    );
+  }, [registry.types, search]);
+
+  const byCategory = useMemo(() => {
+    const m = new Map<string, EntityType[]>();
+    for (const t of filtered) {
+      if (!m.has(t.category)) m.set(t.category, []);
+      m.get(t.category)!.push(t);
+    }
+    return m;
+  }, [filtered]);
+
+  return (
+    <div>
+      <div style={{ marginBottom: 'var(--space-4)' }}>
+        <input
+          aria-label="Filter types"
+          placeholder="filter types…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          style={{
+            width: '100%',
+            height: 36,
+            padding: '0 var(--space-3)',
+            background: 'var(--color-bg-tertiary)',
+            border: '1px solid var(--color-border)',
+            borderRadius: 'var(--radius-sm)',
+            color: 'var(--color-text-primary)',
+            fontSize: 'var(--text-sm)',
+            fontFamily: 'var(--font-sans)',
+            boxSizing: 'border-box',
+          }}
+        />
+      </div>
+
+      {filtered.length === 0 && (
+        <p style={{ color: 'var(--color-text-muted)', fontSize: 'var(--text-sm)' }}>
+          No types match your search.
+        </p>
+      )}
+
+      {[...byCategory.entries()].map(([cat, types]) => (
+        <div key={cat} style={{ marginBottom: 'var(--space-5)' }}>
+          <div
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 11,
+              textTransform: 'uppercase',
+              letterSpacing: '0.07em',
+              color: 'var(--color-text-muted)',
+              marginBottom: 'var(--space-2)',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 'var(--space-2)',
+            }}
+          >
+            {cat}
+            <span
+              style={{ fontWeight: 400, color: 'var(--color-text-faint, var(--color-text-muted))' }}
+            >
+              · {types.length}
+            </span>
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-1)' }}>
+            {types.map((t) => (
+              <button
+                key={t.id}
+                data-testid={`type-row-${t.id}`}
+                onClick={() => onSelect(t.id)}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 'var(--space-3)',
+                  padding: 'var(--space-2) var(--space-3)',
+                  background: selectedId === t.id ? 'var(--color-bg-tertiary)' : 'transparent',
+                  border:
+                    selectedId === t.id ? '1px solid var(--color-border)' : '1px solid transparent',
+                  borderRadius: 'var(--radius-sm)',
+                  cursor: 'pointer',
+                  textAlign: 'left',
+                  width: '100%',
+                  color: 'inherit',
+                }}
+              >
+                <span
+                  style={{
+                    width: 22,
+                    height: 22,
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    flexShrink: 0,
+                  }}
+                >
+                  <ShapeSvg shape={t.shape} color={t.color} size={18} />
+                </span>
+                <span
+                  style={{
+                    fontFamily: 'var(--font-mono)',
+                    fontSize: 16,
+                    color: 'var(--color-brand)',
+                    fontWeight: 700,
+                    width: 20,
+                    textAlign: 'center',
+                    flexShrink: 0,
+                  }}
+                >
+                  {t.rune}
+                </span>
+                <span style={{ flex: 1, minWidth: 0 }}>
+                  <span style={{ fontWeight: 500, display: 'block' }}>{t.label}</span>
+                  <span
+                    style={{
+                      color: 'var(--color-text-muted)',
+                      fontSize: 'var(--text-xs)',
+                      fontFamily: 'var(--font-mono)',
+                    }}
+                  >
+                    {t.id}
+                  </span>
+                </span>
+                <span
+                  style={{
+                    color: 'var(--color-text-muted)',
+                    fontSize: 'var(--text-xs)',
+                    maxWidth: 180,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    flexShrink: 0,
+                  }}
+                >
+                  {t.description.split('.')[0]}.
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── ContainmentTab ────────────────────────────────────────────────────────────
+
+type DropState = 'none' | 'ok' | 'target' | 'invalid';
+
+interface ContainmentTabProps {
+  registry: Registry;
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+  tryReparent: (childId: string, newParentId: string) => boolean;
+}
+
+function ContainmentTab({ registry, selectedId, onSelect, tryReparent }: ContainmentTabProps) {
+  const [dragId, setDragId] = useState<string | null>(null);
+  const [overId, setOverId] = useState<string | null>(null);
+
+  const byId = useMemo(() => new Map(registry.types.map((t) => [t.id, t])), [registry.types]);
+
+  const roots = useMemo(
+    () => registry.types.filter((t) => t.parentTypes.length === 0),
+    [registry.types],
+  );
+
+  // Build reachable set from roots via canContain edges.
+  const reachable = useMemo(() => {
+    const set = new Set<string>();
+    const mark = (t: EntityType | undefined) => {
+      if (!t || set.has(t.id)) return;
+      set.add(t.id);
+      for (const childId of t.canContain) mark(byId.get(childId));
+    };
+    for (const root of roots) mark(root);
+    return set;
+  }, [roots, byId]);
+
+  const orphans = useMemo(
+    () => registry.types.filter((t) => !reachable.has(t.id) && t.parentTypes.length > 0),
+    [registry.types, reachable],
+  );
+
+  const getDropState = (targetId: string): DropState => {
+    if (!dragId) return 'none';
+    const invalid = isDescendant(registry, dragId, targetId) || dragId === targetId;
+    if (overId === targetId) return invalid ? 'invalid' : 'target';
+    if (!invalid) return 'ok';
+    return 'none';
+  };
+
+  const handleDragStart = (e: React.DragEvent, id: string) => {
+    setDragId(id);
+    try {
+      if (e.dataTransfer) {
+        e.dataTransfer.effectAllowed = 'move';
+        e.dataTransfer.setData('text/plain', id);
+      }
+    } catch {
+      // dataTransfer may be unavailable in some contexts (e.g. jsdom)
+    }
+  };
+
+  const handleDragOver = (e: React.DragEvent, targetId: string) => {
+    if (!dragId) return;
+    const invalid = isDescendant(registry, dragId, targetId) || dragId === targetId;
+    try {
+      if (e.dataTransfer) e.dataTransfer.dropEffect = invalid ? 'none' : 'move';
+    } catch {
+      // dataTransfer may be read-only in some contexts
+    }
+    e.preventDefault();
+    setOverId(targetId);
+  };
+
+  const handleDragLeave = (e: React.DragEvent, targetId: string) => {
+    // Only clear if we're leaving the node itself (not a child element).
+    if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
+      setOverId((prev) => (prev === targetId ? null : prev));
+    }
+  };
+
+  const handleDrop = (e: React.DragEvent, targetId: string) => {
+    e.preventDefault();
+    if (dragId) tryReparent(dragId, targetId);
+    setDragId(null);
+    setOverId(null);
+  };
+
+  const handleDragEnd = () => {
+    setDragId(null);
+    setOverId(null);
+  };
+
+  const renderNode = (t: EntityType, depth = 0): React.ReactNode => {
+    const children = t.canContain.map((id) => byId.get(id)).filter(Boolean) as EntityType[];
+    const dropState = getDropState(t.id);
+    const isDragging = dragId === t.id;
+
+    const nodeStyle: React.CSSProperties = {
+      display: 'flex',
+      alignItems: 'center',
+      gap: 'var(--space-2)',
+      padding: '4px 8px',
+      borderRadius: 'var(--radius-sm)',
+      cursor: isDragging ? 'grabbing' : 'grab',
+      opacity: isDragging ? 0.4 : 1,
+      marginLeft: depth * 20,
+      border: '1px solid transparent',
+      background: selectedId === t.id ? 'var(--color-bg-tertiary)' : 'transparent',
+      ...(dropState === 'ok' && {
+        border: '1px dashed color-mix(in srgb, var(--color-brand) 30%, transparent)',
+      }),
+      ...(dropState === 'target' && {
+        border: '1px solid var(--color-brand)',
+        background: 'color-mix(in srgb, var(--color-brand) 20%, transparent)',
+      }),
+      ...(dropState === 'invalid' && {
+        border: '1px solid var(--color-critical, #ef4444)',
+        background: 'color-mix(in srgb, var(--color-critical, #ef4444) 15%, transparent)',
+        cursor: 'not-allowed',
+      }),
+    };
+
+    return (
+      <div key={t.id}>
+        <div
+          data-testid={`tree-node-${t.id}`}
+          data-drag-state={dropState}
+          draggable
+          style={nodeStyle}
+          onDragStart={(e) => handleDragStart(e, t.id)}
+          onDragOver={(e) => handleDragOver(e, t.id)}
+          onDragLeave={(e) => handleDragLeave(e, t.id)}
+          onDrop={(e) => handleDrop(e, t.id)}
+          onDragEnd={handleDragEnd}
+          onClick={() => onSelect(t.id)}
+        >
+          <span
+            aria-hidden
+            style={{
+              color: 'var(--color-text-muted)',
+              fontFamily: 'var(--font-mono)',
+              fontSize: 11,
+              userSelect: 'none',
+            }}
+          >
+            ⋮⋮
+          </span>
+          <span
+            style={{
+              width: 16,
+              display: 'inline-flex',
+              justifyContent: 'center',
+              flexShrink: 0,
+            }}
+          >
+            <ShapeSvg shape={t.shape} color={t.color} size={14} />
+          </span>
+          <span
+            style={{
+              fontFamily: 'var(--font-mono)',
+              color: 'var(--color-brand)',
+              fontSize: 13,
+              fontWeight: 700,
+              flexShrink: 0,
+            }}
+          >
+            {t.rune}
+          </span>
+          <span style={{ fontWeight: 500, fontSize: 'var(--text-sm)' }}>{t.label}</span>
+          <span
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 11,
+              color: 'var(--color-text-muted)',
+              marginLeft: 'auto',
+            }}
+          >
+            {t.id}
+          </span>
+        </div>
+        {children.length > 0 && <div>{children.map((c) => renderNode(c, depth + 1))}</div>}
+      </div>
+    );
+  };
+
+  return (
+    <div>
+      <p
+        style={{
+          margin: '0 0 var(--space-4)',
+          fontSize: 'var(--text-sm)',
+          color: 'var(--color-text-muted)',
+          lineHeight: 1.5,
+        }}
+      >
+        <strong>Drag</strong> a type onto another to reparent it. The{' '}
+        <code style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>canContain</code> edge moves
+        to the new parent;{' '}
+        <code style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>parentTypes</code> on the
+        child updates. Cycles are blocked.
+      </p>
+
+      <div data-testid="containment-tree">{roots.map((r) => renderNode(r))}</div>
+
+      {orphans.length > 0 && (
+        <div
+          data-testid="orphans-section"
+          style={{
+            marginTop: 'var(--space-6)',
+            paddingTop: 'var(--space-4)',
+            borderTop: '1px solid var(--color-border-subtle)',
+          }}
+        >
+          <div
+            style={{
+              fontFamily: 'var(--font-mono)',
+              fontSize: 11,
+              color: 'var(--color-text-muted)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.07em',
+              marginBottom: 'var(--space-2)',
+            }}
+          >
+            orphans — parent missing
+          </div>
+          {orphans.map((o) => renderNode(o))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── JsonTab ───────────────────────────────────────────────────────────────────
+
+interface JsonTabProps {
+  registry: Registry;
+}
+
+function JsonTab({ registry }: JsonTabProps) {
+  const [copied, setCopied] = useState(false);
+  const json = JSON.stringify(registry, null, 2);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(json).then(
+      () => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      },
+      () => {
+        // clipboard may not be available in test/iframe contexts — ignore
+      },
+    );
+  };
+
+  return (
+    <div style={{ position: 'relative' }}>
+      <button
+        aria-label="Copy JSON"
+        data-testid="copy-json-btn"
+        onClick={handleCopy}
+        style={{
+          position: 'absolute',
+          top: 'var(--space-2)',
+          right: 'var(--space-2)',
+          background: 'var(--color-bg-elevated)',
+          border: '1px solid var(--color-border)',
+          borderRadius: 'var(--radius-sm)',
+          color: copied ? 'var(--color-brand)' : 'var(--color-text-secondary)',
+          cursor: 'pointer',
+          fontSize: 'var(--text-xs)',
+          fontFamily: 'var(--font-mono)',
+          padding: '4px 10px',
+          zIndex: 1,
+        }}
+      >
+        {copied ? 'copied!' : 'copy'}
+      </button>
+      <pre
+        data-testid="json-output"
+        style={{
+          margin: 0,
+          padding: 'var(--space-4)',
+          background: 'var(--color-bg-secondary)',
+          border: '1px solid var(--color-border-subtle)',
+          borderRadius: 'var(--radius-md)',
+          fontFamily: 'var(--font-mono)',
+          fontSize: 'var(--text-xs)',
+          color: 'var(--color-text-secondary)',
+          overflowX: 'auto',
+          lineHeight: 1.6,
+          maxHeight: 600,
+          overflowY: 'auto',
+        }}
+      >
+        {json}
+      </pre>
+    </div>
+  );
+}
+
+// ── RegistryEditor ────────────────────────────────────────────────────────────
+
+export interface RegistryEditorProps {
+  registry: Registry;
+}
+
+export function RegistryEditor({ registry: initialRegistry }: RegistryEditorProps) {
+  const [activeTab, setActiveTab] = useState<TabId>('types');
+  const { registry, selectedId, select, tryReparent } = useRegistryEditor(initialRegistry);
+
+  const selectedType = registry.types.find((t) => t.id === selectedId) ?? null;
+
+  const tabButtonStyle = (tab: TabId): React.CSSProperties => ({
+    background: 'none',
+    border: 'none',
+    borderBottom: activeTab === tab ? '2px solid var(--color-brand)' : '2px solid transparent',
+    color: activeTab === tab ? 'var(--color-text-primary)' : 'var(--color-text-muted)',
+    cursor: 'pointer',
+    fontFamily: 'var(--font-sans)',
+    fontSize: 'var(--text-sm)',
+    fontWeight: activeTab === tab ? 600 : 400,
+    padding: 'var(--space-2) var(--space-3)',
+    marginBottom: -1,
+  });
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        height: '100%',
+        overflow: 'hidden',
+        background: 'var(--color-bg-primary)',
+      }}
+    >
+      {/* Main column */}
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+        {/* Header */}
+        <div
+          style={{
+            padding: 'var(--space-4) var(--space-6)',
+            borderBottom: '1px solid var(--color-border-subtle)',
+            flexShrink: 0,
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'baseline',
+              justifyContent: 'space-between',
+              marginBottom: 'var(--space-1)',
+            }}
+          >
+            <h2 style={{ margin: 0, fontSize: 'var(--text-xl)', fontWeight: 700 }}>
+              Entity type registry
+            </h2>
+            <span
+              style={{
+                fontFamily: 'var(--font-mono)',
+                fontSize: 11,
+                color: 'var(--color-text-muted)',
+              }}
+            >
+              rev{' '}
+              <strong style={{ color: 'var(--color-text-secondary)' }}>{registry.version}</strong>
+              {' · '}
+              {registry.types.length} types
+              {' · '}
+              updated {formatDate(registry.updatedAt)}
+            </span>
+          </div>
+        </div>
+
+        {/* Tabs */}
+        <div
+          role="tablist"
+          style={{
+            display: 'flex',
+            borderBottom: '1px solid var(--color-border-subtle)',
+            padding: '0 var(--space-6)',
+            flexShrink: 0,
+          }}
+        >
+          {(['types', 'containment', 'json'] as TabId[]).map((tab) => (
+            <button
+              key={tab}
+              role="tab"
+              aria-selected={activeTab === tab}
+              data-testid={`tab-${tab}`}
+              onClick={() => setActiveTab(tab)}
+              style={tabButtonStyle(tab)}
+            >
+              {tab.charAt(0).toUpperCase() + tab.slice(1)}
+            </button>
+          ))}
+        </div>
+
+        {/* Tab content */}
+        <div
+          role="tabpanel"
+          style={{
+            flex: 1,
+            overflowY: 'auto',
+            padding: 'var(--space-5) var(--space-6)',
+          }}
+        >
+          {activeTab === 'types' && (
+            <TypesTab registry={registry} selectedId={selectedId} onSelect={select} />
+          )}
+          {activeTab === 'containment' && (
+            <ContainmentTab
+              registry={registry}
+              selectedId={selectedId}
+              onSelect={select}
+              tryReparent={tryReparent}
+            />
+          )}
+          {activeTab === 'json' && <JsonTab registry={registry} />}
+        </div>
+      </div>
+
+      {/* Drawer */}
+      {selectedType && activeTab !== 'json' && (
+        <TypePreviewDrawer type={selectedType} onClose={() => select(null)} />
+      )}
+    </div>
+  );
+}

--- a/web-next/packages/plugin-observatory/src/ui/RegistryEditor.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/RegistryEditor.tsx
@@ -25,170 +25,54 @@ function TypePreviewDrawer({ type, onClose }: TypePreviewDrawerProps) {
   return (
     <div
       data-testid="type-preview-drawer"
-      style={{
-        width: 320,
-        flexShrink: 0,
-        borderLeft: '1px solid var(--color-border-subtle)',
-        background: 'var(--color-bg-secondary)',
-        display: 'flex',
-        flexDirection: 'column',
-        overflow: 'hidden',
-      }}
+      className="niuu-w-[320px] niuu-shrink-0 niuu-border-l niuu-border-border-subtle niuu-bg-bg-secondary niuu-flex niuu-flex-col niuu-overflow-hidden"
     >
-      <div
-        style={{
-          padding: 'var(--space-4)',
-          borderBottom: '1px solid var(--color-border-subtle)',
-          display: 'flex',
-          alignItems: 'flex-start',
-          gap: 'var(--space-3)',
-        }}
-      >
-        <div
-          style={{
-            width: 48,
-            height: 48,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            background: 'var(--color-bg-tertiary)',
-            borderRadius: 'var(--radius-md)',
-            border: '1px solid var(--color-border-subtle)',
-            flexShrink: 0,
-          }}
-        >
+      <div className="niuu-p-4 niuu-border-b niuu-border-border-subtle niuu-flex niuu-items-start niuu-gap-3">
+        <div className="niuu-w-12 niuu-h-12 niuu-flex niuu-items-center niuu-justify-center niuu-bg-bg-tertiary niuu-rounded-md niuu-border niuu-border-border-subtle niuu-shrink-0">
           <ShapeSvg shape={type.shape} color={type.color} size={28} />
         </div>
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <div
-            style={{
-              fontFamily: 'var(--font-mono)',
-              fontSize: 10,
-              color: 'var(--color-text-muted)',
-              textTransform: 'uppercase',
-              letterSpacing: '0.07em',
-              marginBottom: 2,
-            }}
-          >
+        <div className="niuu-flex-1 niuu-min-w-0">
+          <div className="niuu-font-mono niuu-text-[10px] niuu-text-text-muted niuu-uppercase niuu-tracking-[0.07em] niuu-mb-[2px]">
             {type.category}
           </div>
-          <div
-            style={{
-              fontSize: 'var(--text-lg)',
-              fontWeight: 600,
-              letterSpacing: '-0.015em',
-              display: 'flex',
-              alignItems: 'center',
-              gap: 8,
-            }}
-          >
+          <div className="niuu-text-lg niuu-font-semibold niuu-tracking-[-0.015em] niuu-flex niuu-items-center niuu-gap-2">
             {type.label}
-            <span
-              style={{
-                fontFamily: 'var(--font-mono)',
-                color: 'var(--color-brand)',
-                fontSize: 16,
-                fontWeight: 700,
-              }}
-            >
+            <span className="niuu-font-mono niuu-text-brand niuu-text-base niuu-font-bold">
               {type.rune}
             </span>
           </div>
-          <div
-            style={{
-              fontFamily: 'var(--font-mono)',
-              fontSize: 11,
-              color: 'var(--color-text-muted)',
-              marginTop: 2,
-            }}
-          >
+          <div className="niuu-font-mono niuu-text-[11px] niuu-text-text-muted niuu-mt-[2px]">
             {type.id}
           </div>
         </div>
         <button
           aria-label="Close preview"
           onClick={onClose}
-          style={{
-            background: 'none',
-            border: 'none',
-            cursor: 'pointer',
-            color: 'var(--color-text-muted)',
-            padding: 4,
-            lineHeight: 1,
-            fontSize: 16,
-          }}
+          className="niuu-bg-transparent niuu-border-0 niuu-cursor-pointer niuu-text-text-muted niuu-p-1 niuu-leading-none niuu-text-base"
         >
           ✕
         </button>
       </div>
 
-      <div style={{ padding: 'var(--space-4)', overflowY: 'auto', flex: 1 }}>
-        <p
-          style={{
-            margin: '0 0 var(--space-4)',
-            fontSize: 'var(--text-sm)',
-            color: 'var(--color-text-secondary)',
-            lineHeight: 1.5,
-          }}
-        >
+      <div className="niuu-p-4 niuu-overflow-y-auto niuu-flex-1">
+        <p className="niuu-m-0 niuu-mb-4 niuu-text-sm niuu-text-text-secondary niuu-leading-[1.5]">
           {type.description}
         </p>
 
-        <div className="section-head" style={{ marginTop: 0 }}>
-          Visual
-        </div>
-        <dl
-          style={{
-            display: 'grid',
-            gridTemplateColumns: '80px 1fr',
-            gap: 'var(--space-1) var(--space-3)',
-            margin: '0 0 var(--space-4)',
-            fontSize: 'var(--text-sm)',
-          }}
-        >
-          <dt style={{ color: 'var(--color-text-muted)' }}>shape</dt>
-          <dd
-            style={{
-              margin: 0,
-              fontFamily: 'var(--font-mono)',
-              color: 'var(--color-text-secondary)',
-            }}
-          >
-            {type.shape}
-          </dd>
-          <dt style={{ color: 'var(--color-text-muted)' }}>size</dt>
-          <dd
-            style={{
-              margin: 0,
-              fontFamily: 'var(--font-mono)',
-              color: 'var(--color-text-secondary)',
-            }}
-          >
-            {type.size}
-          </dd>
-          <dt style={{ color: 'var(--color-text-muted)' }}>border</dt>
-          <dd
-            style={{
-              margin: 0,
-              fontFamily: 'var(--font-mono)',
-              color: 'var(--color-text-secondary)',
-            }}
-          >
-            {type.border}
-          </dd>
+        <div className="registry-section-head">Visual</div>
+        <dl className="niuu-grid niuu-grid-cols-[80px_1fr] niuu-gap-x-3 niuu-gap-y-1 niuu-m-0 niuu-mb-4 niuu-text-sm">
+          <dt className="niuu-text-text-muted">shape</dt>
+          <dd className="niuu-m-0 niuu-font-mono niuu-text-text-secondary">{type.shape}</dd>
+          <dt className="niuu-text-text-muted">size</dt>
+          <dd className="niuu-m-0 niuu-font-mono niuu-text-text-secondary">{type.size}</dd>
+          <dt className="niuu-text-text-muted">border</dt>
+          <dd className="niuu-m-0 niuu-font-mono niuu-text-text-secondary">{type.border}</dd>
         </dl>
 
         {type.parentTypes.length > 0 && (
           <>
-            <div className="section-head">Lives inside</div>
-            <div
-              style={{
-                display: 'flex',
-                flexWrap: 'wrap',
-                gap: 'var(--space-1)',
-                marginBottom: 'var(--space-4)',
-              }}
-            >
+            <div className="registry-section-head">Lives inside</div>
+            <div className="niuu-flex niuu-flex-wrap niuu-gap-1 niuu-mb-4">
               {type.parentTypes.map((id) => (
                 <Chip key={id} tone="muted">
                   {id}
@@ -200,15 +84,8 @@ function TypePreviewDrawer({ type, onClose }: TypePreviewDrawerProps) {
 
         {type.canContain.length > 0 && (
           <>
-            <div className="section-head">Can contain</div>
-            <div
-              style={{
-                display: 'flex',
-                flexWrap: 'wrap',
-                gap: 'var(--space-1)',
-                marginBottom: 'var(--space-4)',
-              }}
-            >
+            <div className="registry-section-head">Can contain</div>
+            <div className="niuu-flex niuu-flex-wrap niuu-gap-1 niuu-mb-4">
               {type.canContain.map((id) => (
                 <Chip key={id} tone="muted">
                   {id}
@@ -220,25 +97,12 @@ function TypePreviewDrawer({ type, onClose }: TypePreviewDrawerProps) {
 
         {type.fields.length > 0 && (
           <>
-            <div className="section-head">Fields</div>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+            <div className="registry-section-head">Fields</div>
+            <div className="niuu-flex niuu-flex-col niuu-gap-2">
               {type.fields.map((f) => (
-                <div
-                  key={f.key}
-                  style={{
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    fontSize: 'var(--text-sm)',
-                  }}
-                >
-                  <span style={{ color: 'var(--color-text-secondary)' }}>{f.label}</span>
-                  <span
-                    style={{
-                      fontFamily: 'var(--font-mono)',
-                      fontSize: 11,
-                      color: 'var(--color-text-muted)',
-                    }}
-                  >
+                <div key={f.key} className="niuu-flex niuu-justify-between niuu-text-sm">
+                  <span className="niuu-text-text-secondary">{f.label}</span>
+                  <span className="niuu-font-mono niuu-text-[11px] niuu-text-text-muted">
                     {f.type}
                     {f.required && ' *'}
                   </span>
@@ -285,124 +149,50 @@ function TypesTab({ registry, selectedId, onSelect }: TypesTabProps) {
 
   return (
     <div>
-      <div style={{ marginBottom: 'var(--space-4)' }}>
+      <div className="niuu-mb-4">
         <input
           aria-label="Filter types"
           placeholder="filter types…"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
-          style={{
-            width: '100%',
-            height: 36,
-            padding: '0 var(--space-3)',
-            background: 'var(--color-bg-tertiary)',
-            border: '1px solid var(--color-border)',
-            borderRadius: 'var(--radius-sm)',
-            color: 'var(--color-text-primary)',
-            fontSize: 'var(--text-sm)',
-            fontFamily: 'var(--font-sans)',
-            boxSizing: 'border-box',
-          }}
+          className="niuu-w-full niuu-h-9 niuu-px-3 niuu-bg-bg-tertiary niuu-border niuu-border-border niuu-rounded-sm niuu-text-text-primary niuu-text-sm niuu-font-sans niuu-box-border"
         />
       </div>
 
       {filtered.length === 0 && (
-        <p style={{ color: 'var(--color-text-muted)', fontSize: 'var(--text-sm)' }}>
-          No types match your search.
-        </p>
+        <p className="niuu-text-text-muted niuu-text-sm">No types match your search.</p>
       )}
 
       {[...byCategory.entries()].map(([cat, types]) => (
-        <div key={cat} style={{ marginBottom: 'var(--space-5)' }}>
-          <div
-            style={{
-              fontFamily: 'var(--font-mono)',
-              fontSize: 11,
-              textTransform: 'uppercase',
-              letterSpacing: '0.07em',
-              color: 'var(--color-text-muted)',
-              marginBottom: 'var(--space-2)',
-              display: 'flex',
-              alignItems: 'center',
-              gap: 'var(--space-2)',
-            }}
-          >
+        <div key={cat} className="niuu-mb-5">
+          <div className="niuu-font-mono niuu-text-[11px] niuu-uppercase niuu-tracking-[0.07em] niuu-text-text-muted niuu-mb-2 niuu-flex niuu-items-center niuu-gap-2">
             {cat}
-            <span
-              style={{ fontWeight: 400, color: 'var(--color-text-faint, var(--color-text-muted))' }}
-            >
-              · {types.length}
-            </span>
+            <span className="niuu-font-normal niuu-text-text-muted">· {types.length}</span>
           </div>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-1)' }}>
+          <div className="niuu-flex niuu-flex-col niuu-gap-1">
             {types.map((t) => (
               <button
                 key={t.id}
                 data-testid={`type-row-${t.id}`}
                 onClick={() => onSelect(t.id)}
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 'var(--space-3)',
-                  padding: 'var(--space-2) var(--space-3)',
-                  background: selectedId === t.id ? 'var(--color-bg-tertiary)' : 'transparent',
-                  border:
-                    selectedId === t.id ? '1px solid var(--color-border)' : '1px solid transparent',
-                  borderRadius: 'var(--radius-sm)',
-                  cursor: 'pointer',
-                  textAlign: 'left',
-                  width: '100%',
-                  color: 'inherit',
-                }}
+                className={`niuu-flex niuu-items-center niuu-gap-3 niuu-py-2 niuu-px-3 niuu-rounded-sm niuu-cursor-pointer niuu-text-left niuu-w-full niuu-border ${
+                  selectedId === t.id
+                    ? 'niuu-bg-bg-tertiary niuu-border-border'
+                    : 'niuu-bg-transparent niuu-border-transparent'
+                }`}
+                style={{ color: 'inherit' }}
               >
-                <span
-                  style={{
-                    width: 22,
-                    height: 22,
-                    display: 'inline-flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    flexShrink: 0,
-                  }}
-                >
+                <span className="niuu-w-[22px] niuu-h-[22px] niuu-inline-flex niuu-items-center niuu-justify-center niuu-shrink-0">
                   <ShapeSvg shape={t.shape} color={t.color} size={18} />
                 </span>
-                <span
-                  style={{
-                    fontFamily: 'var(--font-mono)',
-                    fontSize: 16,
-                    color: 'var(--color-brand)',
-                    fontWeight: 700,
-                    width: 20,
-                    textAlign: 'center',
-                    flexShrink: 0,
-                  }}
-                >
+                <span className="niuu-font-mono niuu-text-base niuu-text-brand niuu-font-bold niuu-w-5 niuu-text-center niuu-shrink-0">
                   {t.rune}
                 </span>
-                <span style={{ flex: 1, minWidth: 0 }}>
-                  <span style={{ fontWeight: 500, display: 'block' }}>{t.label}</span>
-                  <span
-                    style={{
-                      color: 'var(--color-text-muted)',
-                      fontSize: 'var(--text-xs)',
-                      fontFamily: 'var(--font-mono)',
-                    }}
-                  >
-                    {t.id}
-                  </span>
+                <span className="niuu-flex-1 niuu-min-w-0">
+                  <span className="niuu-font-medium niuu-block">{t.label}</span>
+                  <span className="niuu-text-text-muted niuu-text-xs niuu-font-mono">{t.id}</span>
                 </span>
-                <span
-                  style={{
-                    color: 'var(--color-text-muted)',
-                    fontSize: 'var(--text-xs)',
-                    maxWidth: 180,
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap',
-                    flexShrink: 0,
-                  }}
-                >
+                <span className="niuu-text-text-muted niuu-text-xs niuu-max-w-[180px] niuu-overflow-hidden niuu-text-ellipsis niuu-whitespace-nowrap niuu-shrink-0">
                   {t.description.split('.')[0]}.
                 </span>
               </button>
@@ -455,7 +245,7 @@ function ContainmentTab({ registry, selectedId, onSelect, tryReparent }: Contain
 
   const getDropState = (targetId: string): DropState => {
     if (!dragId) return 'none';
-    const invalid = isDescendant(registry, dragId, targetId) || dragId === targetId;
+    const invalid = isDescendant(registry, dragId, targetId, byId) || dragId === targetId;
     if (overId === targetId) return invalid ? 'invalid' : 'target';
     if (!invalid) return 'ok';
     return 'none';
@@ -475,7 +265,7 @@ function ContainmentTab({ registry, selectedId, onSelect, tryReparent }: Contain
 
   const handleDragOver = (e: React.DragEvent, targetId: string) => {
     if (!dragId) return;
-    const invalid = isDescendant(registry, dragId, targetId) || dragId === targetId;
+    const invalid = isDescendant(registry, dragId, targetId, byId) || dragId === targetId;
     try {
       if (e.dataTransfer) e.dataTransfer.dropEffect = invalid ? 'none' : 'move';
     } catch {
@@ -509,38 +299,16 @@ function ContainmentTab({ registry, selectedId, onSelect, tryReparent }: Contain
     const dropState = getDropState(t.id);
     const isDragging = dragId === t.id;
 
-    const nodeStyle: React.CSSProperties = {
-      display: 'flex',
-      alignItems: 'center',
-      gap: 'var(--space-2)',
-      padding: '4px 8px',
-      borderRadius: 'var(--radius-sm)',
-      cursor: isDragging ? 'grabbing' : 'grab',
-      opacity: isDragging ? 0.4 : 1,
-      marginLeft: depth * 20,
-      border: '1px solid transparent',
-      background: selectedId === t.id ? 'var(--color-bg-tertiary)' : 'transparent',
-      ...(dropState === 'ok' && {
-        border: '1px dashed color-mix(in srgb, var(--color-brand) 30%, transparent)',
-      }),
-      ...(dropState === 'target' && {
-        border: '1px solid var(--color-brand)',
-        background: 'color-mix(in srgb, var(--color-brand) 20%, transparent)',
-      }),
-      ...(dropState === 'invalid' && {
-        border: '1px solid var(--color-critical, #ef4444)',
-        background: 'color-mix(in srgb, var(--color-critical, #ef4444) 15%, transparent)',
-        cursor: 'not-allowed',
-      }),
-    };
-
     return (
       <div key={t.id}>
         <div
           data-testid={`tree-node-${t.id}`}
           data-drag-state={dropState}
+          data-selected={selectedId === t.id ? 'true' : undefined}
+          data-dragging={isDragging ? 'true' : undefined}
           draggable
-          style={nodeStyle}
+          className="registry-tree-node"
+          style={{ '--tree-depth': depth } as React.CSSProperties}
           onDragStart={(e) => handleDragStart(e, t.id)}
           onDragOver={(e) => handleDragOver(e, t.id)}
           onDragLeave={(e) => handleDragLeave(e, t.id)}
@@ -550,45 +318,18 @@ function ContainmentTab({ registry, selectedId, onSelect, tryReparent }: Contain
         >
           <span
             aria-hidden
-            style={{
-              color: 'var(--color-text-muted)',
-              fontFamily: 'var(--font-mono)',
-              fontSize: 11,
-              userSelect: 'none',
-            }}
+            className="niuu-text-text-muted niuu-font-mono niuu-text-[11px] niuu-select-none"
           >
             ⋮⋮
           </span>
-          <span
-            style={{
-              width: 16,
-              display: 'inline-flex',
-              justifyContent: 'center',
-              flexShrink: 0,
-            }}
-          >
+          <span className="niuu-w-4 niuu-inline-flex niuu-justify-center niuu-shrink-0">
             <ShapeSvg shape={t.shape} color={t.color} size={14} />
           </span>
-          <span
-            style={{
-              fontFamily: 'var(--font-mono)',
-              color: 'var(--color-brand)',
-              fontSize: 13,
-              fontWeight: 700,
-              flexShrink: 0,
-            }}
-          >
+          <span className="niuu-font-mono niuu-text-brand niuu-text-[13px] niuu-font-bold niuu-shrink-0">
             {t.rune}
           </span>
-          <span style={{ fontWeight: 500, fontSize: 'var(--text-sm)' }}>{t.label}</span>
-          <span
-            style={{
-              fontFamily: 'var(--font-mono)',
-              fontSize: 11,
-              color: 'var(--color-text-muted)',
-              marginLeft: 'auto',
-            }}
-          >
+          <span className="niuu-font-medium niuu-text-sm">{t.label}</span>
+          <span className="niuu-font-mono niuu-text-[11px] niuu-text-text-muted niuu-ml-auto">
             {t.id}
           </span>
         </div>
@@ -599,19 +340,11 @@ function ContainmentTab({ registry, selectedId, onSelect, tryReparent }: Contain
 
   return (
     <div>
-      <p
-        style={{
-          margin: '0 0 var(--space-4)',
-          fontSize: 'var(--text-sm)',
-          color: 'var(--color-text-muted)',
-          lineHeight: 1.5,
-        }}
-      >
+      <p className="niuu-m-0 niuu-mb-4 niuu-text-sm niuu-text-text-muted niuu-leading-[1.5]">
         <strong>Drag</strong> a type onto another to reparent it. The{' '}
-        <code style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>canContain</code> edge moves
-        to the new parent;{' '}
-        <code style={{ fontFamily: 'var(--font-mono)', fontSize: 11 }}>parentTypes</code> on the
-        child updates. Cycles are blocked.
+        <code className="niuu-font-mono niuu-text-[11px]">canContain</code> edge moves to the new
+        parent; <code className="niuu-font-mono niuu-text-[11px]">parentTypes</code> on the child
+        updates. Cycles are blocked.
       </p>
 
       <div data-testid="containment-tree">{roots.map((r) => renderNode(r))}</div>
@@ -619,22 +352,9 @@ function ContainmentTab({ registry, selectedId, onSelect, tryReparent }: Contain
       {orphans.length > 0 && (
         <div
           data-testid="orphans-section"
-          style={{
-            marginTop: 'var(--space-6)',
-            paddingTop: 'var(--space-4)',
-            borderTop: '1px solid var(--color-border-subtle)',
-          }}
+          className="niuu-mt-6 niuu-pt-4 niuu-border-t niuu-border-border-subtle"
         >
-          <div
-            style={{
-              fontFamily: 'var(--font-mono)',
-              fontSize: 11,
-              color: 'var(--color-text-muted)',
-              textTransform: 'uppercase',
-              letterSpacing: '0.07em',
-              marginBottom: 'var(--space-2)',
-            }}
-          >
+          <div className="niuu-font-mono niuu-text-[11px] niuu-text-text-muted niuu-uppercase niuu-tracking-[0.07em] niuu-mb-2">
             orphans — parent missing
           </div>
           {orphans.map((o) => renderNode(o))}
@@ -667,44 +387,20 @@ function JsonTab({ registry }: JsonTabProps) {
   };
 
   return (
-    <div style={{ position: 'relative' }}>
+    <div className="niuu-relative">
       <button
         aria-label="Copy JSON"
         data-testid="copy-json-btn"
         onClick={handleCopy}
-        style={{
-          position: 'absolute',
-          top: 'var(--space-2)',
-          right: 'var(--space-2)',
-          background: 'var(--color-bg-elevated)',
-          border: '1px solid var(--color-border)',
-          borderRadius: 'var(--radius-sm)',
-          color: copied ? 'var(--color-brand)' : 'var(--color-text-secondary)',
-          cursor: 'pointer',
-          fontSize: 'var(--text-xs)',
-          fontFamily: 'var(--font-mono)',
-          padding: '4px 10px',
-          zIndex: 1,
-        }}
+        className={`niuu-absolute niuu-top-2 niuu-right-2 niuu-bg-bg-elevated niuu-border niuu-border-border niuu-rounded-sm niuu-cursor-pointer niuu-text-xs niuu-font-mono niuu-px-[10px] niuu-py-1 niuu-z-[1] ${
+          copied ? 'niuu-text-brand' : 'niuu-text-text-secondary'
+        }`}
       >
         {copied ? 'copied!' : 'copy'}
       </button>
       <pre
         data-testid="json-output"
-        style={{
-          margin: 0,
-          padding: 'var(--space-4)',
-          background: 'var(--color-bg-secondary)',
-          border: '1px solid var(--color-border-subtle)',
-          borderRadius: 'var(--radius-md)',
-          fontFamily: 'var(--font-mono)',
-          fontSize: 'var(--text-xs)',
-          color: 'var(--color-text-secondary)',
-          overflowX: 'auto',
-          lineHeight: 1.6,
-          maxHeight: 600,
-          overflowY: 'auto',
-        }}
+        className="niuu-m-0 niuu-p-4 niuu-bg-bg-secondary niuu-border niuu-border-border-subtle niuu-rounded-md niuu-font-mono niuu-text-xs niuu-text-text-secondary niuu-overflow-x-auto niuu-leading-[1.6] niuu-max-h-[600px] niuu-overflow-y-auto"
       >
         {json}
       </pre>
@@ -724,58 +420,16 @@ export function RegistryEditor({ registry: initialRegistry }: RegistryEditorProp
 
   const selectedType = registry.types.find((t) => t.id === selectedId) ?? null;
 
-  const tabButtonStyle = (tab: TabId): React.CSSProperties => ({
-    background: 'none',
-    border: 'none',
-    borderBottom: activeTab === tab ? '2px solid var(--color-brand)' : '2px solid transparent',
-    color: activeTab === tab ? 'var(--color-text-primary)' : 'var(--color-text-muted)',
-    cursor: 'pointer',
-    fontFamily: 'var(--font-sans)',
-    fontSize: 'var(--text-sm)',
-    fontWeight: activeTab === tab ? 600 : 400,
-    padding: 'var(--space-2) var(--space-3)',
-    marginBottom: -1,
-  });
-
   return (
-    <div
-      style={{
-        display: 'flex',
-        height: '100%',
-        overflow: 'hidden',
-        background: 'var(--color-bg-primary)',
-      }}
-    >
+    <div className="niuu-flex niuu-h-full niuu-overflow-hidden niuu-bg-bg-primary">
       {/* Main column */}
-      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+      <div className="niuu-flex-1 niuu-flex niuu-flex-col niuu-overflow-hidden">
         {/* Header */}
-        <div
-          style={{
-            padding: 'var(--space-4) var(--space-6)',
-            borderBottom: '1px solid var(--color-border-subtle)',
-            flexShrink: 0,
-          }}
-        >
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'baseline',
-              justifyContent: 'space-between',
-              marginBottom: 'var(--space-1)',
-            }}
-          >
-            <h2 style={{ margin: 0, fontSize: 'var(--text-xl)', fontWeight: 700 }}>
-              Entity type registry
-            </h2>
-            <span
-              style={{
-                fontFamily: 'var(--font-mono)',
-                fontSize: 11,
-                color: 'var(--color-text-muted)',
-              }}
-            >
-              rev{' '}
-              <strong style={{ color: 'var(--color-text-secondary)' }}>{registry.version}</strong>
+        <div className="niuu-py-4 niuu-px-6 niuu-border-b niuu-border-border-subtle niuu-shrink-0">
+          <div className="niuu-flex niuu-items-baseline niuu-justify-between niuu-mb-1">
+            <h2 className="niuu-m-0 niuu-text-xl niuu-font-bold">Entity type registry</h2>
+            <span className="niuu-font-mono niuu-text-[11px] niuu-text-text-muted">
+              rev <strong className="niuu-text-text-secondary">{registry.version}</strong>
               {' · '}
               {registry.types.length} types
               {' · '}
@@ -787,12 +441,7 @@ export function RegistryEditor({ registry: initialRegistry }: RegistryEditorProp
         {/* Tabs */}
         <div
           role="tablist"
-          style={{
-            display: 'flex',
-            borderBottom: '1px solid var(--color-border-subtle)',
-            padding: '0 var(--space-6)',
-            flexShrink: 0,
-          }}
+          className="niuu-flex niuu-border-b niuu-border-border-subtle niuu-px-6 niuu-shrink-0"
         >
           {(['types', 'containment', 'json'] as TabId[]).map((tab) => (
             <button
@@ -801,7 +450,7 @@ export function RegistryEditor({ registry: initialRegistry }: RegistryEditorProp
               aria-selected={activeTab === tab}
               data-testid={`tab-${tab}`}
               onClick={() => setActiveTab(tab)}
-              style={tabButtonStyle(tab)}
+              className="registry-tab-btn"
             >
               {tab.charAt(0).toUpperCase() + tab.slice(1)}
             </button>
@@ -809,14 +458,7 @@ export function RegistryEditor({ registry: initialRegistry }: RegistryEditorProp
         </div>
 
         {/* Tab content */}
-        <div
-          role="tabpanel"
-          style={{
-            flex: 1,
-            overflowY: 'auto',
-            padding: 'var(--space-5) var(--space-6)',
-          }}
-        >
+        <div role="tabpanel" className="niuu-flex-1 niuu-overflow-y-auto niuu-py-5 niuu-px-6">
           {activeTab === 'types' && (
             <TypesTab registry={registry} selectedId={selectedId} onSelect={select} />
           )}

--- a/web-next/packages/plugin-observatory/src/ui/RegistryPage.test.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/RegistryPage.test.tsx
@@ -28,16 +28,23 @@ describe('RegistryPage', () => {
 
   it('renders entity types once data loads', async () => {
     wrap(<RegistryPage />);
-    await waitFor(() => expect(screen.getByText('Realm')).toBeInTheDocument());
-    expect(screen.getByText('Cluster')).toBeInTheDocument();
-    expect(screen.getByText('Host')).toBeInTheDocument();
-    expect(screen.getByText('Raid')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getAllByText('Realm').length).toBeGreaterThan(0));
+    expect(screen.getAllByText('Cluster').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Host').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Raid').length).toBeGreaterThan(0);
   });
 
   it('shows version and type count in the metadata line', async () => {
     wrap(<RegistryPage />);
-    await waitFor(() => expect(screen.getByText(/v7/)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/rev/)).toBeInTheDocument());
+    expect(screen.getByText('7')).toBeInTheDocument();
     expect(screen.getByText(/18 types/)).toBeInTheDocument();
+  });
+
+  it('renders the Types tab by default', async () => {
+    wrap(<RegistryPage />);
+    await waitFor(() => expect(screen.getByTestId('tab-types')).toBeInTheDocument());
+    expect(screen.getByTestId('tab-types')).toHaveAttribute('aria-selected', 'true');
   });
 
   it('renders error state when the repository throws', async () => {

--- a/web-next/packages/plugin-observatory/src/ui/RegistryPage.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/RegistryPage.tsx
@@ -6,54 +6,27 @@ export function RegistryPage() {
   const { data, isLoading, isError, error } = useRegistry();
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+    <div className="niuu-flex niuu-flex-col niuu-h-full">
       {/* Header — always visible */}
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 'var(--space-3)',
-          padding: 'var(--space-4) var(--space-6)',
-          borderBottom: '1px solid var(--color-border-subtle)',
-          flexShrink: 0,
-        }}
-      >
+      <div className="niuu-flex niuu-items-center niuu-gap-3 niuu-py-4 niuu-px-6 niuu-border-b niuu-border-border-subtle niuu-shrink-0">
         <Rune glyph="ᛞ" size={28} />
         <div>
-          <h2 style={{ margin: 0, fontSize: 'var(--text-lg)' }}>Registry</h2>
-          <p
-            style={{ margin: 0, color: 'var(--color-text-secondary)', fontSize: 'var(--text-sm)' }}
-          >
-            entity type definitions
-          </p>
+          <h2 className="niuu-m-0 niuu-text-lg">Registry</h2>
+          <p className="niuu-m-0 niuu-text-text-secondary niuu-text-sm">entity type definitions</p>
         </div>
       </div>
 
       {/* Content */}
-      <div style={{ flex: 1, overflow: 'hidden' }}>
+      <div className="niuu-flex-1 niuu-overflow-hidden">
         {isLoading && (
-          <div
-            style={{
-              padding: 'var(--space-6)',
-              display: 'flex',
-              alignItems: 'center',
-              gap: 'var(--space-2)',
-            }}
-          >
+          <div className="niuu-p-6 niuu-flex niuu-items-center niuu-gap-2">
             <StateDot state="processing" pulse />
             <span>loading…</span>
           </div>
         )}
 
         {isError && (
-          <div
-            style={{
-              padding: 'var(--space-6)',
-              display: 'flex',
-              alignItems: 'center',
-              gap: 'var(--space-2)',
-            }}
-          >
+          <div className="niuu-p-6 niuu-flex niuu-items-center niuu-gap-2">
             <StateDot state="failed" />
             <span>{error instanceof Error ? error.message : 'unknown error'}</span>
           </div>

--- a/web-next/packages/plugin-observatory/src/ui/RegistryPage.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/RegistryPage.tsx
@@ -1,82 +1,66 @@
-import { Rune, Chip, StateDot } from '@niuulabs/ui';
+import { Rune, StateDot } from '@niuulabs/ui';
 import { useRegistry } from '../application/useRegistry';
+import { RegistryEditor } from './RegistryEditor';
 
 export function RegistryPage() {
   const { data, isLoading, isError, error } = useRegistry();
 
   return (
-    <div style={{ padding: 'var(--space-6)', maxWidth: 960 }}>
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      {/* Header — always visible */}
       <div
         style={{
           display: 'flex',
           alignItems: 'center',
           gap: 'var(--space-3)',
-          marginBottom: 'var(--space-2)',
+          padding: 'var(--space-4) var(--space-6)',
+          borderBottom: '1px solid var(--color-border-subtle)',
+          flexShrink: 0,
         }}
       >
-        <Rune glyph="ᛞ" size={32} />
-        <h2 style={{ margin: 0 }}>Registry</h2>
-      </div>
-      <p style={{ margin: '0 0 var(--space-6)', color: 'var(--color-text-secondary)' }}>
-        entity type definitions
-      </p>
-
-      {isLoading && (
-        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)' }}>
-          <StateDot state="processing" pulse />
-          <span>loading…</span>
-        </div>
-      )}
-
-      {isError && (
-        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)' }}>
-          <StateDot state="failed" />
-          <span>{error instanceof Error ? error.message : 'unknown error'}</span>
-        </div>
-      )}
-
-      {data && (
-        <>
+        <Rune glyph="ᛞ" size={28} />
+        <div>
+          <h2 style={{ margin: 0, fontSize: 'var(--text-lg)' }}>Registry</h2>
           <p
+            style={{ margin: 0, color: 'var(--color-text-secondary)', fontSize: 'var(--text-sm)' }}
+          >
+            entity type definitions
+          </p>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div style={{ flex: 1, overflow: 'hidden' }}>
+        {isLoading && (
+          <div
             style={{
-              margin: '0 0 var(--space-4)',
-              color: 'var(--color-text-muted)',
-              fontSize: 'var(--text-sm)',
+              padding: 'var(--space-6)',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 'var(--space-2)',
             }}
           >
-            v{data.version} · {data.types.length} types · updated {data.updatedAt.slice(0, 10)}
-          </p>
-          <ul style={{ listStyle: 'none', padding: 0, display: 'grid', gap: 'var(--space-2)' }}>
-            {data.types.map((t) => (
-              <li
-                key={t.id}
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 'var(--space-3)',
-                  padding: 'var(--space-3)',
-                  border: '1px solid var(--color-border-subtle)',
-                  borderRadius: 'var(--radius-md)',
-                  background: 'var(--color-bg-secondary)',
-                }}
-              >
-                <span
-                  style={{
-                    fontFamily: 'var(--font-mono)',
-                    fontSize: 'var(--text-xl)',
-                    width: 24,
-                    textAlign: 'center',
-                  }}
-                >
-                  {t.rune}
-                </span>
-                <span style={{ flex: 1 }}>{t.label}</span>
-                <Chip tone="muted">{t.category}</Chip>
-              </li>
-            ))}
-          </ul>
-        </>
-      )}
+            <StateDot state="processing" pulse />
+            <span>loading…</span>
+          </div>
+        )}
+
+        {isError && (
+          <div
+            style={{
+              padding: 'var(--space-6)',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 'var(--space-2)',
+            }}
+          >
+            <StateDot state="failed" />
+            <span>{error instanceof Error ? error.message : 'unknown error'}</span>
+          </div>
+        )}
+
+        {data && <RegistryEditor registry={data} />}
+      </div>
     </div>
   );
 }

--- a/web-next/packages/plugin-observatory/tailwind.config.ts
+++ b/web-next/packages/plugin-observatory/tailwind.config.ts
@@ -1,0 +1,7 @@
+import type { Config } from 'tailwindcss';
+import preset from '@niuulabs/design-tokens/tailwind.preset';
+
+export default {
+  presets: [preset],
+  content: ['src/**/*.{ts,tsx,css}'],
+} satisfies Config;

--- a/web-next/packages/plugin-observatory/tsup.config.ts
+++ b/web-next/packages/plugin-observatory/tsup.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'tsup';
+import { execSync } from 'node:child_process';
 
 export default defineConfig({
   entry: ['src/index.tsx'],
@@ -7,4 +8,7 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   external: ['react', '@tanstack/react-query', '@tanstack/react-router', '@niuulabs/plugin-sdk', '@niuulabs/ui'],
+  onSuccess: async () => {
+    execSync('postcss src/styles.css -o dist/styles.css', { stdio: 'inherit' });
+  },
 });


### PR DESCRIPTION
## Summary

- **Types tab**: searchable list of entity types grouped by category, with a preview drawer that opens on row click
- **Containment tab**: drag-and-drop tree view for reparenting — cycle protection via DFS ancestor check, four visual drop states (ok / target / invalid / dragging)
- **JSON tab**: read-only pretty-printed registry JSON with copy-to-clipboard button
- **domain/containment.ts**: pure  (cycle-safe DFS) +  (immutable — bumps version, rewrites parentTypes)
- **application/useRegistryEditor.ts**: state hook with  guard
- Storybook stories for all three tab states
- 17 domain unit tests, 20 component tests, 7 hook tests; overall coverage 97%
- 9 new Playwright e2e tests including drag-drop reparent and cycle rejection

## Test plan

- [x] All 845 unit tests pass
- [x] Coverage: 97.15% statements / 93.84% branches / 97.32% functions
- [x] Drag valid reparent: host dragged to realm → parentTypes updated, version incremented
- [x] Cycle rejection: realm dragged onto host (ancestor onto descendant) → version unchanged
- [x] Types tab search filter: "VLAN" → only realm visible
- [x] JSON tab copy button visible
- [x] Preview drawer opens on type row click

Closes NIU-666

🤖 Generated with [Claude Code](https://claude.com/claude-code)