### PR TITLE
feat(login): ambient canvases + logo variants (NIU-662)

### DIFF
--- a/web-next/e2e/ambient.spec.ts
+++ b/web-next/e2e/ambient.spec.ts
@@ -1,0 +1,107 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Ambient background e2e smoke tests.
+ *
+ * Verifies that each of the three ambient variants renders without JS errors
+ * and that the login page structure is intact regardless of which ambient is active.
+ */
+
+const STUB_AUTH_CONFIG = {
+  theme: 'ice',
+  plugins: {
+    login: { enabled: true, order: 0 },
+    hello: { enabled: true, order: 1 },
+  },
+  services: { hello: { mode: 'mock' } },
+  auth: {
+    issuer: 'http://localhost:9876/realms/test',
+    clientId: 'niuu-web',
+  },
+};
+
+async function stubOidc(page: import('@playwright/test').Page) {
+  await page.route('**/config.json', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(STUB_AUTH_CONFIG),
+    }),
+  );
+
+  await page.route('**/realms/test/.well-known/openid-configuration', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        issuer: 'http://localhost:9876/realms/test',
+        authorization_endpoint: 'http://localhost:9876/realms/test/protocol/openid-connect/auth',
+        token_endpoint: 'http://localhost:9876/realms/test/protocol/openid-connect/token',
+        end_session_endpoint: 'http://localhost:9876/realms/test/protocol/openid-connect/logout',
+        jwks_uri: 'http://localhost:9876/realms/test/protocol/openid-connect/certs',
+        response_types_supported: ['code'],
+        subject_types_supported: ['public'],
+        id_token_signing_alg_values_supported: ['RS256'],
+      }),
+    }),
+  );
+}
+
+const AMBIENT_VARIANTS = ['topology', 'constellation', 'lattice'] as const;
+
+for (const variant of AMBIENT_VARIANTS) {
+  test(`ambient "${variant}": login page renders without canvas errors`, async ({ page }) => {
+    const consoleErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+    page.on('pageerror', (err) => consoleErrors.push(err.message));
+
+    // Pre-set localStorage so the ambient hook picks up the variant
+    await stubOidc(page);
+    await page.goto('/login');
+    await page.evaluate((v) => {
+      localStorage.setItem('niuu-login-ambient', v);
+    }, variant);
+    await page.reload();
+
+    await expect(page.getByTestId('login-page')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByTestId('sign-in-btn')).toBeVisible();
+
+    // No JS errors from canvas or SVG rendering
+    const ambientErrors = consoleErrors.filter(
+      (e) => !e.includes('favicon') && !e.includes('config.json'),
+    );
+    expect(ambientErrors).toHaveLength(0);
+  });
+}
+
+test('ambient "topology": canvas element is present in the DOM', async ({ page }) => {
+  await stubOidc(page);
+  await page.goto('/login');
+  await page.evaluate(() => localStorage.setItem('niuu-login-ambient', 'topology'));
+  await page.reload();
+
+  await expect(page.getByTestId('login-page')).toBeVisible({ timeout: 5000 });
+  await expect(page.locator('[data-testid="ambient-topology"]')).toBeVisible();
+});
+
+test('ambient "constellation": SVG element is present in the DOM', async ({ page }) => {
+  await stubOidc(page);
+  await page.goto('/login');
+  await page.evaluate(() => localStorage.setItem('niuu-login-ambient', 'constellation'));
+  await page.reload();
+
+  await expect(page.getByTestId('login-page')).toBeVisible({ timeout: 5000 });
+  await expect(page.locator('[data-testid="ambient-constellation"]')).toBeVisible();
+});
+
+test('ambient "lattice": SVG element is present in the DOM', async ({ page }) => {
+  await stubOidc(page);
+  await page.goto('/login');
+  await page.evaluate(() => localStorage.setItem('niuu-login-ambient', 'lattice'));
+  await page.reload();
+
+  await expect(page.getByTestId('login-page')).toBeVisible({ timeout: 5000 });
+  await expect(page.locator('[data-testid="ambient-lattice"]')).toBeVisible();
+});

--- a/web-next/packages/plugin-login/src/ui/Ambient.stories.css
+++ b/web-next/packages/plugin-login/src/ui/Ambient.stories.css
@@ -1,0 +1,7 @@
+.ambient-preview {
+  position: relative;
+  width: 100%;
+  height: 100vh;
+  background: var(--color-bg-primary, #09090b);
+  overflow: hidden;
+}

--- a/web-next/packages/plugin-login/src/ui/Ambient.stories.tsx
+++ b/web-next/packages/plugin-login/src/ui/Ambient.stories.tsx
@@ -3,17 +3,10 @@ import type { AmbientVariant } from './useAmbient';
 import { AmbientTopology } from './AmbientTopology';
 import { AmbientConstellation } from './AmbientConstellation';
 import { AmbientLattice } from './AmbientLattice';
+import './Ambient.stories.css';
 
 // ─── Shared wrapper ───────────────────────────────────────────────────────────
 function AmbientPreview({ variant }: { variant: AmbientVariant }) {
-  const style: React.CSSProperties = {
-    position: 'relative',
-    width: '100%',
-    height: '100vh',
-    background: 'var(--color-bg-primary, #09090b)',
-    overflow: 'hidden',
-  };
-
   const components: Record<AmbientVariant, React.ComponentType> = {
     topology: AmbientTopology,
     constellation: AmbientConstellation,
@@ -22,7 +15,7 @@ function AmbientPreview({ variant }: { variant: AmbientVariant }) {
 
   const Component = components[variant];
   return (
-    <div style={style}>
+    <div className="ambient-preview">
       <Component />
     </div>
   );

--- a/web-next/packages/plugin-login/src/ui/Ambient.stories.tsx
+++ b/web-next/packages/plugin-login/src/ui/Ambient.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import type { AmbientVariant } from './useAmbient';
+import { AmbientTopology } from './AmbientTopology';
+import { AmbientConstellation } from './AmbientConstellation';
+import { AmbientLattice } from './AmbientLattice';
+
+// ─── Shared wrapper ───────────────────────────────────────────────────────────
+function AmbientPreview({ variant }: { variant: AmbientVariant }) {
+  const style: React.CSSProperties = {
+    position: 'relative',
+    width: '100%',
+    height: '100vh',
+    background: 'var(--color-bg-primary, #09090b)',
+    overflow: 'hidden',
+  };
+
+  const components: Record<AmbientVariant, React.ComponentType> = {
+    topology: AmbientTopology,
+    constellation: AmbientConstellation,
+    lattice: AmbientLattice,
+  };
+
+  const Component = components[variant];
+  return (
+    <div style={style}>
+      <Component />
+    </div>
+  );
+}
+
+// ─── Topology ─────────────────────────────────────────────────────────────────
+const topologyMeta: Meta = {
+  title: 'Login/Ambient/Topology',
+  component: AmbientTopology,
+  parameters: { layout: 'fullscreen' },
+};
+export default topologyMeta;
+
+export const Topology: StoryObj = {
+  render: () => <AmbientPreview variant="topology" />,
+};
+
+export const Constellation: StoryObj = {
+  render: () => <AmbientPreview variant="constellation" />,
+};
+
+export const Lattice: StoryObj = {
+  render: () => <AmbientPreview variant="lattice" />,
+};

--- a/web-next/packages/plugin-login/src/ui/AmbientConstellation.test.tsx
+++ b/web-next/packages/plugin-login/src/ui/AmbientConstellation.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { AmbientConstellation } from './AmbientConstellation';
+
+function stubMatchMedia(matches: boolean) {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn(() => ({
+      matches,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+  );
+}
+
+describe('AmbientConstellation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('renders an SVG element', () => {
+    stubMatchMedia(false);
+    const { getByTestId } = render(<AmbientConstellation />);
+    expect(getByTestId('ambient-constellation').tagName.toLowerCase()).toBe('svg');
+  });
+
+  it('marks the SVG aria-hidden', () => {
+    stubMatchMedia(false);
+    const { getByTestId } = render(<AmbientConstellation />);
+    expect(getByTestId('ambient-constellation').getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('applies the login-ambient CSS class', () => {
+    stubMatchMedia(false);
+    const { getByTestId } = render(<AmbientConstellation />);
+    expect(getByTestId('ambient-constellation')).toHaveClass('login-ambient');
+  });
+
+  it('renders 80 star circles', () => {
+    stubMatchMedia(false);
+    const { container } = render(<AmbientConstellation />);
+    // 80 star circles + the gradient background rect circle count
+    const circles = container.querySelectorAll('circle');
+    expect(circles.length).toBe(80);
+  });
+
+  it('renders animate elements when motion is allowed', () => {
+    stubMatchMedia(false);
+    const { container } = render(<AmbientConstellation />);
+    expect(container.querySelectorAll('animate').length).toBe(80);
+  });
+
+  it('omits animate elements when prefers-reduced-motion is set', () => {
+    stubMatchMedia(true);
+    const { container } = render(<AmbientConstellation />);
+    expect(container.querySelectorAll('animate').length).toBe(0);
+  });
+
+  it('sets static opacity on stars when reduced-motion is set', () => {
+    stubMatchMedia(true);
+    const { container } = render(<AmbientConstellation />);
+    const circles = container.querySelectorAll('circle');
+    circles.forEach((c) => {
+      expect(c.getAttribute('opacity')).toBe('0.5');
+    });
+  });
+
+  it('has a radial gradient definition', () => {
+    stubMatchMedia(false);
+    const { container } = render(<AmbientConstellation />);
+    expect(container.querySelector('radialGradient')).not.toBeNull();
+  });
+});

--- a/web-next/packages/plugin-login/src/ui/AmbientConstellation.tsx
+++ b/web-next/packages/plugin-login/src/ui/AmbientConstellation.tsx
@@ -1,0 +1,72 @@
+import { useMemo } from 'react';
+import { useReducedMotion } from './useReducedMotion';
+import './ambient.css';
+
+const STAR_COUNT = 80;
+
+interface Star {
+  x: number;
+  y: number;
+  r: number;
+  dur: number;
+  delay: number;
+}
+
+function buildStars(): Star[] {
+  return Array.from({ length: STAR_COUNT }, () => ({
+    x: Math.random() * 100,
+    y: Math.random() * 100,
+    r: 0.4 + Math.random() * 1.2,
+    dur: 2 + Math.random() * 4,
+    delay: Math.random() * 4,
+  }));
+}
+
+/**
+ * Constellation ambient — 80 static stars with a slow shimmer.
+ *
+ * SVG `<animate>` elements are omitted when `prefers-reduced-motion` is set.
+ */
+export function AmbientConstellation() {
+  const reduced = useReducedMotion();
+  // Stable star positions — same on every render
+  const stars = useMemo(buildStars, []);
+
+  return (
+    <svg
+      className="login-ambient"
+      viewBox="0 0 100 100"
+      preserveAspectRatio="xMidYMid slice"
+      aria-hidden
+      data-testid="ambient-constellation"
+    >
+      <defs>
+        <radialGradient id="const-glow" cx="50%" cy="40%" r="60%">
+          <stop offset="0%" stopColor="#1e3a5f" stopOpacity="0.3" />
+          <stop offset="100%" stopColor="#09090b" stopOpacity="0" />
+        </radialGradient>
+      </defs>
+      <rect width="100" height="100" fill="url(#const-glow)" />
+      {stars.map((s, i) => (
+        <circle
+          key={i}
+          cx={s.x}
+          cy={s.y}
+          r={s.r}
+          fill="#bae6fd"
+          opacity={reduced ? 0.5 : undefined}
+        >
+          {!reduced && (
+            <animate
+              attributeName="opacity"
+              values="0.2;0.9;0.2"
+              dur={`${s.dur}s`}
+              begin={`${s.delay}s`}
+              repeatCount="indefinite"
+            />
+          )}
+        </circle>
+      ))}
+    </svg>
+  );
+}

--- a/web-next/packages/plugin-login/src/ui/AmbientConstellation.tsx
+++ b/web-next/packages/plugin-login/src/ui/AmbientConstellation.tsx
@@ -42,8 +42,8 @@ export function AmbientConstellation() {
     >
       <defs>
         <radialGradient id="const-glow" cx="50%" cy="40%" r="60%">
-          <stop offset="0%" stopColor="#1e3a5f" stopOpacity="0.3" />
-          <stop offset="100%" stopColor="#09090b" stopOpacity="0" />
+          <stop offset="0%" className="ambient-stop-mid" stopOpacity="0.3" />
+          <stop offset="100%" className="ambient-stop-bg" stopOpacity="0" />
         </radialGradient>
       </defs>
       <rect width="100" height="100" fill="url(#const-glow)" />
@@ -53,7 +53,7 @@ export function AmbientConstellation() {
           cx={s.x}
           cy={s.y}
           r={s.r}
-          fill="#bae6fd"
+          className="constellation-star"
           opacity={reduced ? 0.5 : undefined}
         >
           {!reduced && (

--- a/web-next/packages/plugin-login/src/ui/AmbientLattice.test.tsx
+++ b/web-next/packages/plugin-login/src/ui/AmbientLattice.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { AmbientLattice } from './AmbientLattice';
+
+function stubMatchMedia(matches: boolean) {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn(() => ({
+      matches,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+  );
+}
+
+describe('AmbientLattice', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('renders an SVG element', () => {
+    stubMatchMedia(false);
+    const { getByTestId } = render(<AmbientLattice />);
+    expect(getByTestId('ambient-lattice').tagName.toLowerCase()).toBe('svg');
+  });
+
+  it('marks the SVG aria-hidden', () => {
+    stubMatchMedia(false);
+    const { getByTestId } = render(<AmbientLattice />);
+    expect(getByTestId('ambient-lattice').getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('applies the login-ambient CSS class', () => {
+    stubMatchMedia(false);
+    const { getByTestId } = render(<AmbientLattice />);
+    expect(getByTestId('ambient-lattice')).toHaveClass('login-ambient');
+  });
+
+  it('renders the rune band group', () => {
+    stubMatchMedia(false);
+    const { getByTestId } = render(<AmbientLattice />);
+    expect(getByTestId('lattice-rune-band')).toBeInTheDocument();
+  });
+
+  it('renders 12 runes in the band', () => {
+    stubMatchMedia(false);
+    const { getByTestId } = render(<AmbientLattice />);
+    const band = getByTestId('lattice-rune-band');
+    const texts = band.querySelectorAll('text');
+    expect(texts.length).toBe(12);
+  });
+
+  it('renders animateTransform when motion is allowed', () => {
+    stubMatchMedia(false);
+    const { container } = render(<AmbientLattice />);
+    expect(container.querySelector('animateTransform')).not.toBeNull();
+  });
+
+  it('omits animateTransform when prefers-reduced-motion is set', () => {
+    stubMatchMedia(true);
+    const { container } = render(<AmbientLattice />);
+    expect(container.querySelector('animateTransform')).toBeNull();
+  });
+
+  it('has 4 concentric circles', () => {
+    stubMatchMedia(false);
+    const { getByTestId } = render(<AmbientLattice />);
+    const mainG = getByTestId('lattice-main');
+    const circles = mainG.querySelectorAll('circle[data-ring]');
+    expect(circles.length).toBe(4);
+  });
+
+  it('has 12 spoke ticks', () => {
+    stubMatchMedia(false);
+    const { getByTestId } = render(<AmbientLattice />);
+    const mainG = getByTestId('lattice-main');
+    const lines = mainG.querySelectorAll('line[data-spoke]');
+    expect(lines.length).toBe(12);
+  });
+});

--- a/web-next/packages/plugin-login/src/ui/AmbientLattice.tsx
+++ b/web-next/packages/plugin-login/src/ui/AmbientLattice.tsx
@@ -1,0 +1,100 @@
+import { useReducedMotion } from './useReducedMotion';
+import './ambient.css';
+
+const RUNES = ['ᚲ', 'ᛃ', 'ᚱ', 'ᛗ', 'ᚨ', 'ᛖ', 'ᚠ', 'ᛒ', 'ᛞ', 'ᛜ', 'ᚾ', 'ᚲ'] as const;
+const RUNE_ORBIT_R = 340;
+const RUNE_ROTATION_DUR = '220s';
+
+/**
+ * Lattice ambient — concentric faint circles with a slowly rotating rune band.
+ *
+ * The `<animateTransform>` is omitted when `prefers-reduced-motion` is set,
+ * leaving the rune ring static.
+ */
+export function AmbientLattice() {
+  const reduced = useReducedMotion();
+
+  const spokeTicks = Array.from({ length: 12 }, (_, i) => {
+    const angle = (i / 12) * Math.PI * 2;
+    return {
+      x1: 200 * Math.cos(angle),
+      y1: 200 * Math.sin(angle),
+      x2: 280 * Math.cos(angle),
+      y2: 280 * Math.sin(angle),
+    };
+  });
+
+  const runePositions = RUNES.map((rune, i) => {
+    const angle = (i / RUNES.length) * Math.PI * 2;
+    return {
+      rune,
+      x: RUNE_ORBIT_R * Math.cos(angle),
+      y: RUNE_ORBIT_R * Math.sin(angle) + 4,
+    };
+  });
+
+  return (
+    <svg
+      className="login-ambient"
+      viewBox="0 0 800 600"
+      preserveAspectRatio="xMidYMid slice"
+      aria-hidden
+      data-testid="ambient-lattice"
+    >
+      <defs>
+        <radialGradient id="lat-glow" cx="50%" cy="50%" r="50%">
+          <stop offset="0%" stopColor="#38bdf8" stopOpacity="0.08" />
+          <stop offset="60%" stopColor="#38bdf8" stopOpacity="0.02" />
+          <stop offset="100%" stopColor="#09090b" stopOpacity="0" />
+        </radialGradient>
+      </defs>
+      <rect width="800" height="600" fill="url(#lat-glow)" />
+
+      <g
+        transform="translate(400 300)"
+        stroke="rgba(186,230,253,0.14)"
+        fill="none"
+        data-testid="lattice-main"
+      >
+        {/* Concentric rings */}
+        <circle r={120} strokeWidth="0.6" data-ring />
+        <circle r={200} strokeWidth="0.6" data-ring />
+        <circle r={280} strokeWidth="0.5" strokeDasharray="2 4" data-ring />
+        <circle r={380} strokeWidth="0.4" strokeDasharray="4 8" data-ring />
+
+        {/* Spoke ticks between ring 200 and 280 */}
+        {spokeTicks.map((t, i) => (
+          <line key={i} x1={t.x1} y1={t.y1} x2={t.x2} y2={t.y2} strokeWidth="0.6" data-spoke />
+        ))}
+
+        {/* Rotating rune band */}
+        <g data-testid="lattice-rune-band">
+          {!reduced && (
+            <animateTransform
+              attributeName="transform"
+              type="rotate"
+              from="0"
+              to="360"
+              dur={RUNE_ROTATION_DUR}
+              repeatCount="indefinite"
+            />
+          )}
+          {runePositions.map(({ rune, x, y }, i) => (
+            <text
+              key={i}
+              x={x}
+              y={y}
+              textAnchor="middle"
+              fontFamily="JetBrainsMono NF, monospace"
+              fontSize="12"
+              fill="rgba(186,230,253,0.3)"
+              stroke="none"
+            >
+              {rune}
+            </text>
+          ))}
+        </g>
+      </g>
+    </svg>
+  );
+}

--- a/web-next/packages/plugin-login/src/ui/AmbientLattice.tsx
+++ b/web-next/packages/plugin-login/src/ui/AmbientLattice.tsx
@@ -43,17 +43,17 @@ export function AmbientLattice() {
     >
       <defs>
         <radialGradient id="lat-glow" cx="50%" cy="50%" r="50%">
-          <stop offset="0%" stopColor="#38bdf8" stopOpacity="0.08" />
-          <stop offset="60%" stopColor="#38bdf8" stopOpacity="0.02" />
-          <stop offset="100%" stopColor="#09090b" stopOpacity="0" />
+          <stop offset="0%" className="ambient-stop-brand" stopOpacity="0.08" />
+          <stop offset="60%" className="ambient-stop-brand" stopOpacity="0.02" />
+          <stop offset="100%" className="ambient-stop-bg" stopOpacity="0" />
         </radialGradient>
       </defs>
       <rect width="800" height="600" fill="url(#lat-glow)" />
 
       <g
         transform="translate(400 300)"
-        stroke="rgba(186,230,253,0.14)"
         fill="none"
+        className="lattice-rings-group"
         data-testid="lattice-main"
       >
         {/* Concentric rings */}
@@ -87,8 +87,7 @@ export function AmbientLattice() {
               textAnchor="middle"
               fontFamily="JetBrainsMono NF, monospace"
               fontSize="12"
-              fill="rgba(186,230,253,0.3)"
-              stroke="none"
+              className="lattice-rune-text"
             >
               {rune}
             </text>

--- a/web-next/packages/plugin-login/src/ui/AmbientTopology.test.tsx
+++ b/web-next/packages/plugin-login/src/ui/AmbientTopology.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { AmbientTopology } from './AmbientTopology';
+
+const mockCtx = {
+  clearRect: vi.fn(),
+  beginPath: vi.fn(),
+  moveTo: vi.fn(),
+  lineTo: vi.fn(),
+  arc: vi.fn(),
+  fill: vi.fn(),
+  stroke: vi.fn(),
+  setTransform: vi.fn(),
+  strokeStyle: '',
+  lineWidth: 0,
+  fillStyle: '',
+};
+
+function stubMatchMedia(matches: boolean) {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn(() => ({
+      matches,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+  );
+}
+
+describe('AmbientTopology', () => {
+  beforeEach(() => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+      mockCtx as unknown as CanvasRenderingContext2D,
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('renders a canvas element', () => {
+    stubMatchMedia(false);
+    const { getByTestId } = render(<AmbientTopology />);
+    const canvas = getByTestId('ambient-topology');
+    expect(canvas.tagName.toLowerCase()).toBe('canvas');
+  });
+
+  it('marks the canvas aria-hidden', () => {
+    stubMatchMedia(false);
+    const { getByTestId } = render(<AmbientTopology />);
+    expect(getByTestId('ambient-topology').getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('applies the login-ambient CSS class', () => {
+    stubMatchMedia(false);
+    const { getByTestId } = render(<AmbientTopology />);
+    expect(getByTestId('ambient-topology')).toHaveClass('login-ambient');
+  });
+
+  it('does not start requestAnimationFrame when prefers-reduced-motion is set', () => {
+    const rafSpy = vi.spyOn(window, 'requestAnimationFrame');
+    stubMatchMedia(true);
+    render(<AmbientTopology />);
+    expect(rafSpy).not.toHaveBeenCalled();
+  });
+
+  it('starts requestAnimationFrame when motion is allowed', () => {
+    const rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 0);
+    stubMatchMedia(false);
+    render(<AmbientTopology />);
+    expect(rafSpy).toHaveBeenCalled();
+  });
+
+  it('cancels requestAnimationFrame on unmount', () => {
+    const cancelSpy = vi.spyOn(window, 'cancelAnimationFrame');
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 42);
+    stubMatchMedia(false);
+    const { unmount } = render(<AmbientTopology />);
+    unmount();
+    expect(cancelSpy).toHaveBeenCalled();
+  });
+});

--- a/web-next/packages/plugin-login/src/ui/AmbientTopology.tsx
+++ b/web-next/packages/plugin-login/src/ui/AmbientTopology.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useRef } from 'react';
+import './ambient.css';
+
+const NODE_COUNT = 28;
+const EDGE_DISTANCE = 180;
+const NODE_SPEED = 0.08;
+const PULSE_INCREMENT = 0.01;
+
+interface Node {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  r: number;
+  pulse: number;
+}
+
+function seedNodes(w: number, h: number): Node[] {
+  return Array.from({ length: NODE_COUNT }, () => ({
+    x: Math.random() * w,
+    y: Math.random() * h,
+    vx: (Math.random() - 0.5) * NODE_SPEED,
+    vy: (Math.random() - 0.5) * NODE_SPEED,
+    r: 1 + Math.random() * 1.6,
+    pulse: Math.random() * Math.PI * 2,
+  }));
+}
+
+/**
+ * Topology ambient — a slow-moving node graph with faint ice-blue edges.
+ *
+ * Animation pauses when `prefers-reduced-motion: reduce` is set.
+ */
+export function AmbientTopology() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    let rafId = 0;
+    let nodes: Node[] = [];
+
+    const resize = () => {
+      const dpr = window.devicePixelRatio || 1;
+      canvas.width = canvas.clientWidth * dpr;
+      canvas.height = canvas.clientHeight * dpr;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      nodes = seedNodes(canvas.clientWidth, canvas.clientHeight);
+    };
+
+    const drawFrame = () => {
+      const w = canvas.clientWidth;
+      const h = canvas.clientHeight;
+      ctx.clearRect(0, 0, w, h);
+
+      for (let i = 0; i < nodes.length; i++) {
+        for (let j = i + 1; j < nodes.length; j++) {
+          const a = nodes[i];
+          const b = nodes[j];
+          const dx = a.x - b.x;
+          const dy = a.y - b.y;
+          const d = Math.sqrt(dx * dx + dy * dy);
+          if (d < EDGE_DISTANCE) {
+            ctx.strokeStyle = `rgba(125,211,252,${0.08 * (1 - d / EDGE_DISTANCE)})`;
+            ctx.lineWidth = 0.8;
+            ctx.beginPath();
+            ctx.moveTo(a.x, a.y);
+            ctx.lineTo(b.x, b.y);
+            ctx.stroke();
+          }
+        }
+      }
+
+      for (const n of nodes) {
+        n.x += n.vx;
+        n.y += n.vy;
+        if (n.x < 0 || n.x > w) n.vx *= -1;
+        if (n.y < 0 || n.y > h) n.vy *= -1;
+        n.pulse += PULSE_INCREMENT;
+        const p = 0.5 + 0.5 * Math.sin(n.pulse);
+        ctx.fillStyle = `rgba(186,230,253,${0.35 + 0.35 * p})`;
+        ctx.beginPath();
+        ctx.arc(n.x, n.y, n.r, 0, Math.PI * 2);
+        ctx.fill();
+      }
+
+      rafId = requestAnimationFrame(drawFrame);
+    };
+
+    resize();
+
+    if (!prefersReduced) {
+      drawFrame();
+    } else {
+      // Render a static snapshot without animating
+      const w = canvas.clientWidth;
+      const h = canvas.clientHeight;
+      ctx.clearRect(0, 0, w, h);
+      for (const n of nodes) {
+        ctx.fillStyle = 'rgba(186,230,253,0.5)';
+        ctx.beginPath();
+        ctx.arc(n.x, n.y, n.r, 0, Math.PI * 2);
+        ctx.fill();
+      }
+    }
+
+    const onResize = () => {
+      cancelAnimationFrame(rafId);
+      resize();
+      if (!prefersReduced) drawFrame();
+    };
+
+    window.addEventListener('resize', onResize);
+
+    return () => {
+      cancelAnimationFrame(rafId);
+      window.removeEventListener('resize', onResize);
+    };
+  }, []);
+
+  return (
+    <canvas ref={canvasRef} className="login-ambient" aria-hidden data-testid="ambient-topology" />
+  );
+}

--- a/web-next/packages/plugin-login/src/ui/AmbientTopology.tsx
+++ b/web-next/packages/plugin-login/src/ui/AmbientTopology.tsx
@@ -61,9 +61,11 @@ export function AmbientTopology() {
       ctx.clearRect(0, 0, w, h);
 
       for (let i = 0; i < nodes.length; i++) {
+        const a = nodes[i];
+        if (!a) continue;
         for (let j = i + 1; j < nodes.length; j++) {
-          const a = nodes[i];
           const b = nodes[j];
+          if (!b) continue;
           const dx = a.x - b.x;
           const dy = a.y - b.y;
           const d = Math.sqrt(dx * dx + dy * dy);

--- a/web-next/packages/plugin-login/src/ui/AmbientTopology.tsx
+++ b/web-next/packages/plugin-login/src/ui/AmbientTopology.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { useReducedMotion } from './useReducedMotion';
 import './ambient.css';
 
 const NODE_COUNT = 28;
@@ -30,9 +31,12 @@ function seedNodes(w: number, h: number): Node[] {
  * Topology ambient — a slow-moving node graph with faint ice-blue edges.
  *
  * Animation pauses when `prefers-reduced-motion: reduce` is set.
+ * Re-runs the effect when the preference changes at runtime.
  */
 export function AmbientTopology() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const reduced = useReducedMotion();
+  const rafIdRef = useRef(0);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -41,9 +45,6 @@ export function AmbientTopology() {
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
 
-    const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-
-    let rafId = 0;
     let nodes: Node[] = [];
 
     const resize = () => {
@@ -90,15 +91,10 @@ export function AmbientTopology() {
         ctx.fill();
       }
 
-      rafId = requestAnimationFrame(drawFrame);
+      rafIdRef.current = requestAnimationFrame(drawFrame);
     };
 
-    resize();
-
-    if (!prefersReduced) {
-      drawFrame();
-    } else {
-      // Render a static snapshot without animating
+    const drawStatic = () => {
       const w = canvas.clientWidth;
       const h = canvas.clientHeight;
       ctx.clearRect(0, 0, w, h);
@@ -108,21 +104,30 @@ export function AmbientTopology() {
         ctx.arc(n.x, n.y, n.r, 0, Math.PI * 2);
         ctx.fill();
       }
+    };
+
+    resize();
+
+    if (!reduced) {
+      drawFrame();
+    } else {
+      drawStatic();
     }
 
     const onResize = () => {
-      cancelAnimationFrame(rafId);
+      cancelAnimationFrame(rafIdRef.current);
       resize();
-      if (!prefersReduced) drawFrame();
+      if (!reduced) drawFrame();
+      else drawStatic();
     };
 
     window.addEventListener('resize', onResize);
 
     return () => {
-      cancelAnimationFrame(rafId);
+      cancelAnimationFrame(rafIdRef.current);
       window.removeEventListener('resize', onResize);
     };
-  }, []);
+  }, [reduced]);
 
   return (
     <canvas ref={canvasRef} className="login-ambient" aria-hidden data-testid="ambient-topology" />

--- a/web-next/packages/plugin-login/src/ui/LoginPage.css
+++ b/web-next/packages/plugin-login/src/ui/LoginPage.css
@@ -16,29 +16,6 @@
   --_btn-contrast: color-mix(in srgb, var(--color-bg-primary) 85%, var(--brand-500));
 }
 
-/* ── Ambient pulse background ──────────────────────────────── */
-.login-page__ambient {
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(
-    ellipse 80% 60% at 50% 50%,
-    color-mix(in srgb, var(--brand-500) 6%, transparent) 0%,
-    transparent 70%
-  );
-  animation: login-ambient-pulse 8s ease-in-out infinite;
-  pointer-events: none;
-}
-
-@keyframes login-ambient-pulse {
-  0%,
-  100% {
-    opacity: 0.6;
-  }
-  50% {
-    opacity: 1;
-  }
-}
-
 /* ── Build info banner ─────────────────────────────────────── */
 .login-page__build {
   position: absolute;

--- a/web-next/packages/plugin-login/src/ui/LoginPage.stories.tsx
+++ b/web-next/packages/plugin-login/src/ui/LoginPage.stories.tsx
@@ -57,3 +57,30 @@ export const OidcError: Story = {
     </AuthContext.Provider>
   ),
 };
+
+/** Constellation ambient background. */
+export const AmbientConstellation: Story = {
+  render: () => (
+    <AuthContext.Provider value={signedOutAuth}>
+      <LoginPage ambient="constellation" />
+    </AuthContext.Provider>
+  ),
+};
+
+/** Lattice ambient background. */
+export const AmbientLattice: Story = {
+  render: () => (
+    <AuthContext.Provider value={signedOutAuth}>
+      <LoginPage ambient="lattice" />
+    </AuthContext.Provider>
+  ),
+};
+
+/** Topology ambient background (default). */
+export const AmbientTopology: Story = {
+  render: () => (
+    <AuthContext.Provider value={signedOutAuth}>
+      <LoginPage ambient="topology" />
+    </AuthContext.Provider>
+  ),
+};

--- a/web-next/packages/plugin-login/src/ui/LoginPage.tsx
+++ b/web-next/packages/plugin-login/src/ui/LoginPage.tsx
@@ -1,5 +1,10 @@
+import type { ComponentType } from 'react';
 import { useAuth } from '@niuulabs/auth';
+import { AmbientTopology } from './AmbientTopology';
+import { AmbientConstellation } from './AmbientConstellation';
+import { AmbientLattice } from './AmbientLattice';
 import { LogoKnot } from './LogoKnot';
+import { useAmbient, type AmbientVariant } from './useAmbient';
 import './LoginPage.css';
 
 interface LoginPageProps {
@@ -7,7 +12,15 @@ interface LoginPageProps {
   oidcError?: string;
   /** Override the OIDC error description (default: read from ?error_description= URL param). */
   oidcErrorDescription?: string;
+  /** Force a specific ambient variant (default: reads/writes localStorage). */
+  ambient?: AmbientVariant;
 }
+
+const AMBIENT_MAP: Record<AmbientVariant, ComponentType> = {
+  topology: AmbientTopology,
+  constellation: AmbientConstellation,
+  lattice: AmbientLattice,
+};
 
 function LockIcon() {
   return (
@@ -39,8 +52,12 @@ function LockIcon() {
 export function LoginPage({
   oidcError: errorProp,
   oidcErrorDescription: descProp,
+  ambient: ambientProp,
 }: LoginPageProps = {}) {
   const { login, loading } = useAuth();
+  const [storedAmbient] = useAmbient();
+  const activeAmbient = ambientProp ?? storedAmbient;
+  const AmbientComponent = AMBIENT_MAP[activeAmbient];
 
   const params =
     typeof window !== 'undefined'
@@ -51,7 +68,7 @@ export function LoginPage({
 
   return (
     <div className="login-page" data-testid="login-page">
-      <div className="login-page__ambient" aria-hidden />
+      <AmbientComponent />
 
       <div className="login-page__build login-page__mono">
         <span className="login-page__build-dot" aria-hidden />

--- a/web-next/packages/plugin-login/src/ui/LogoFlokk.test.tsx
+++ b/web-next/packages/plugin-login/src/ui/LogoFlokk.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { LogoFlokk } from './LogoFlokk';
+
+describe('LogoFlokk', () => {
+  it('renders an SVG with default dimensions', () => {
+    const { container } = render(<LogoFlokk />);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('width')).toBe('56');
+    expect(svg?.getAttribute('height')).toBe('56');
+    expect(svg?.getAttribute('viewBox')).toBe('0 0 56 56');
+  });
+
+  it('applies a custom size', () => {
+    const { container } = render(<LogoFlokk size={64} />);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('width')).toBe('64');
+    expect(svg?.getAttribute('height')).toBe('64');
+  });
+
+  it('does not apply a filter when glow is false', () => {
+    const { container } = render(<LogoFlokk glow={false} />);
+    expect(container.querySelector('svg')?.getAttribute('style') ?? '').not.toContain(
+      'drop-shadow',
+    );
+  });
+
+  it('applies a drop-shadow filter when glow is true', () => {
+    const { container } = render(<LogoFlokk glow />);
+    expect(container.querySelector('svg')?.getAttribute('style')).toContain('drop-shadow');
+  });
+
+  it('is marked as aria-hidden', () => {
+    const { container } = render(<LogoFlokk />);
+    expect(container.querySelector('svg')?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('renders two hexagon polygons', () => {
+    const { container } = render(<LogoFlokk />);
+    const polygons = container.querySelectorAll('polygon');
+    expect(polygons.length).toBe(2);
+  });
+
+  it('renders a center dot circle', () => {
+    const { container } = render(<LogoFlokk />);
+    const circles = container.querySelectorAll('circle');
+    expect(circles.length).toBe(1);
+  });
+});

--- a/web-next/packages/plugin-login/src/ui/LogoFlokk.tsx
+++ b/web-next/packages/plugin-login/src/ui/LogoFlokk.tsx
@@ -1,0 +1,36 @@
+interface LogoFlokkProps {
+  size?: number;
+  stroke?: number;
+  glow?: boolean;
+}
+
+const HEX_R = 14;
+
+function hexPoints(cx: number, cy: number): string {
+  return Array.from({ length: 6 }, (_, i) => {
+    const angle = (i / 6) * Math.PI * 2 - Math.PI / 2;
+    return `${cx + HEX_R * Math.cos(angle)},${cy + HEX_R * Math.sin(angle)}`;
+  }).join(' ');
+}
+
+/**
+ * Flokk logo — two interlocking hexagons, a flight / group metaphor.
+ * Uses currentColor so it inherits the brand palette from the parent.
+ */
+export function LogoFlokk({ size = 56, stroke = 1.5, glow = false }: LogoFlokkProps) {
+  return (
+    <svg
+      viewBox="0 0 56 56"
+      width={size}
+      height={size}
+      aria-hidden
+      style={{ filter: glow ? 'drop-shadow(0 0 8px currentColor)' : undefined }}
+    >
+      <g fill="none" stroke="currentColor" strokeWidth={stroke} strokeLinejoin="round">
+        <polygon points={hexPoints(22, 28)} opacity={0.9} />
+        <polygon points={hexPoints(34, 28)} opacity={0.7} />
+        <circle cx={28} cy={28} r={2} fill="currentColor" />
+      </g>
+    </svg>
+  );
+}

--- a/web-next/packages/plugin-login/src/ui/LogoRuneRing.test.tsx
+++ b/web-next/packages/plugin-login/src/ui/LogoRuneRing.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { LogoRuneRing } from './LogoRuneRing';
+
+describe('LogoRuneRing', () => {
+  it('renders an SVG with default dimensions', () => {
+    const { container } = render(<LogoRuneRing />);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('width')).toBe('56');
+    expect(svg?.getAttribute('height')).toBe('56');
+    expect(svg?.getAttribute('viewBox')).toBe('0 0 56 56');
+  });
+
+  it('applies a custom size', () => {
+    const { container } = render(<LogoRuneRing size={72} />);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('width')).toBe('72');
+    expect(svg?.getAttribute('height')).toBe('72');
+  });
+
+  it('does not apply a filter when glow is false', () => {
+    const { container } = render(<LogoRuneRing glow={false} />);
+    expect(container.querySelector('svg')?.getAttribute('style') ?? '').not.toContain(
+      'drop-shadow',
+    );
+  });
+
+  it('applies a drop-shadow filter when glow is true', () => {
+    const { container } = render(<LogoRuneRing glow />);
+    expect(container.querySelector('svg')?.getAttribute('style')).toContain('drop-shadow');
+  });
+
+  it('is marked as aria-hidden', () => {
+    const { container } = render(<LogoRuneRing />);
+    expect(container.querySelector('svg')?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('renders 8 orbit runes plus the central rune', () => {
+    const { container } = render(<LogoRuneRing />);
+    const texts = container.querySelectorAll('text');
+    // 8 orbit runes + 1 central ᚾ = 9
+    expect(texts.length).toBe(9);
+  });
+
+  it('renders the central ᚾ rune', () => {
+    const { container } = render(<LogoRuneRing />);
+    const texts = Array.from(container.querySelectorAll('text'));
+    const central = texts.find((t) => t.textContent === 'ᚾ');
+    expect(central).toBeDefined();
+  });
+
+  it('renders two circles (orbit ring + inner ring)', () => {
+    const { container } = render(<LogoRuneRing />);
+    const circles = container.querySelectorAll('circle');
+    expect(circles.length).toBe(2);
+  });
+});

--- a/web-next/packages/plugin-login/src/ui/LogoRuneRing.tsx
+++ b/web-next/packages/plugin-login/src/ui/LogoRuneRing.tsx
@@ -1,0 +1,75 @@
+interface LogoRuneRingProps {
+  size?: number;
+  stroke?: number;
+  glow?: boolean;
+}
+
+const RUNES = ['ᚲ', 'ᛃ', 'ᚱ', 'ᛗ', 'ᚨ', 'ᛖ', 'ᚠ', 'ᛒ'] as const;
+const ORBIT_R = 22;
+
+/**
+ * RuneRing logo — a ring of 8 entity runes around a central ᚾ (Naudhiz).
+ * Uses currentColor so it inherits the brand palette from the parent.
+ */
+export function LogoRuneRing({ size = 56, stroke = 1.3, glow = false }: LogoRuneRingProps) {
+  return (
+    <svg
+      viewBox="0 0 56 56"
+      width={size}
+      height={size}
+      aria-hidden
+      style={{ filter: glow ? 'drop-shadow(0 0 8px currentColor)' : undefined }}
+    >
+      <circle
+        cx={28}
+        cy={28}
+        r={ORBIT_R}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="0.7"
+        opacity={0.35}
+      />
+      <circle
+        cx={28}
+        cy={28}
+        r={12}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={stroke}
+        opacity={0.7}
+      />
+
+      {RUNES.map((rune, i) => {
+        const angle = (i / RUNES.length) * Math.PI * 2 - Math.PI / 2;
+        const x = 28 + ORBIT_R * Math.cos(angle);
+        const y = 28 + ORBIT_R * Math.sin(angle) + 2;
+        return (
+          <text
+            key={i}
+            x={x}
+            y={y}
+            textAnchor="middle"
+            fontFamily="JetBrainsMono NF, monospace"
+            fontSize="7"
+            fill="currentColor"
+            opacity={0.55}
+          >
+            {rune}
+          </text>
+        );
+      })}
+
+      <text
+        x={28}
+        y={33}
+        textAnchor="middle"
+        fontFamily="JetBrainsMono NF, monospace"
+        fontSize="16"
+        fill="currentColor"
+        fontWeight="600"
+      >
+        ᚾ
+      </text>
+    </svg>
+  );
+}

--- a/web-next/packages/plugin-login/src/ui/LogoStack.test.tsx
+++ b/web-next/packages/plugin-login/src/ui/LogoStack.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { LogoStack } from './LogoStack';
+
+describe('LogoStack', () => {
+  it('renders an SVG with default dimensions', () => {
+    const { container } = render(<LogoStack />);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('width')).toBe('56');
+    expect(svg?.getAttribute('height')).toBe('56');
+    expect(svg?.getAttribute('viewBox')).toBe('0 0 56 56');
+  });
+
+  it('applies a custom size', () => {
+    const { container } = render(<LogoStack size={48} />);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('width')).toBe('48');
+    expect(svg?.getAttribute('height')).toBe('48');
+  });
+
+  it('does not apply a filter when glow is false', () => {
+    const { container } = render(<LogoStack glow={false} />);
+    expect(container.querySelector('svg')?.getAttribute('style') ?? '').not.toContain(
+      'drop-shadow',
+    );
+  });
+
+  it('applies a drop-shadow filter when glow is true', () => {
+    const { container } = render(<LogoStack glow />);
+    expect(container.querySelector('svg')?.getAttribute('style')).toContain('drop-shadow');
+  });
+
+  it('is marked as aria-hidden', () => {
+    const { container } = render(<LogoStack />);
+    expect(container.querySelector('svg')?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('renders 6 paths (3 staves + 3 cross-strokes)', () => {
+    const { container } = render(<LogoStack />);
+    const paths = container.querySelectorAll('path');
+    expect(paths.length).toBe(6);
+  });
+});

--- a/web-next/packages/plugin-login/src/ui/LogoStack.tsx
+++ b/web-next/packages/plugin-login/src/ui/LogoStack.tsx
@@ -1,0 +1,32 @@
+interface LogoStackProps {
+  size?: number;
+  stroke?: number;
+  glow?: boolean;
+}
+
+/**
+ * Stack logo — three stacked ᚾ (Naudhiz) runes, the N of niuu.
+ * Uses currentColor so it inherits the brand palette from the parent.
+ */
+export function LogoStack({ size = 56, stroke = 1.6, glow = false }: LogoStackProps) {
+  return (
+    <svg
+      viewBox="0 0 56 56"
+      width={size}
+      height={size}
+      aria-hidden
+      style={{ filter: glow ? 'drop-shadow(0 0 8px currentColor)' : undefined }}
+    >
+      <g fill="none" stroke="currentColor" strokeWidth={stroke} strokeLinecap="round">
+        {/* vertical staves */}
+        <path d="M14 10 V46" />
+        <path d="M28 10 V46" />
+        <path d="M42 10 V46" />
+        {/* naudhiz cross-strokes */}
+        <path d="M14 22 L22 14" opacity={0.9} />
+        <path d="M28 30 L36 22" />
+        <path d="M42 38 L50 30" opacity={0.9} />
+      </g>
+    </svg>
+  );
+}

--- a/web-next/packages/plugin-login/src/ui/LogoStars.test.tsx
+++ b/web-next/packages/plugin-login/src/ui/LogoStars.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { LogoStars } from './LogoStars';
+
+describe('LogoStars', () => {
+  it('renders an SVG with default dimensions', () => {
+    const { container } = render(<LogoStars />);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('width')).toBe('56');
+    expect(svg?.getAttribute('height')).toBe('56');
+    expect(svg?.getAttribute('viewBox')).toBe('0 0 56 56');
+  });
+
+  it('applies a custom size', () => {
+    const { container } = render(<LogoStars size={100} />);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('width')).toBe('100');
+    expect(svg?.getAttribute('height')).toBe('100');
+  });
+
+  it('does not apply a filter when glow is false', () => {
+    const { container } = render(<LogoStars glow={false} />);
+    expect(container.querySelector('svg')?.getAttribute('style') ?? '').not.toContain(
+      'drop-shadow',
+    );
+  });
+
+  it('applies a drop-shadow filter when glow is true', () => {
+    const { container } = render(<LogoStars glow />);
+    expect(container.querySelector('svg')?.getAttribute('style')).toContain('drop-shadow');
+  });
+
+  it('is marked as aria-hidden', () => {
+    const { container } = render(<LogoStars />);
+    expect(container.querySelector('svg')?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('renders 13 dot circles', () => {
+    const { container } = render(<LogoStars />);
+    const circles = container.querySelectorAll('circle');
+    expect(circles.length).toBe(13);
+  });
+
+  it('renders letter paths', () => {
+    const { container } = render(<LogoStars />);
+    const paths = container.querySelectorAll('path');
+    expect(paths.length).toBeGreaterThan(0);
+  });
+});

--- a/web-next/packages/plugin-login/src/ui/LogoStars.tsx
+++ b/web-next/packages/plugin-login/src/ui/LogoStars.tsx
@@ -1,0 +1,60 @@
+interface LogoStarsProps {
+  size?: number;
+  stroke?: number;
+  glow?: boolean;
+}
+
+// Dot positions: [cx, cy] pairs forming the "niuu" connect-the-dots word
+const DOTS: [number, number][] = [
+  [6, 38],
+  [6, 22],
+  [14, 22],
+  [14, 38],
+  [22, 38],
+  [22, 22],
+  [22, 16],
+  [30, 22],
+  [34, 38],
+  [38, 22],
+  [42, 22],
+  [46, 38],
+  [50, 22],
+];
+
+/**
+ * Stars logo — "niuu" rendered as a connect-the-dots constellation.
+ * Uses currentColor so it inherits the brand palette from the parent.
+ */
+export function LogoStars({ size = 56, stroke = 1.2, glow = false }: LogoStarsProps) {
+  return (
+    <svg
+      viewBox="0 0 56 56"
+      width={size}
+      height={size}
+      aria-hidden
+      style={{ filter: glow ? 'drop-shadow(0 0 6px currentColor)' : undefined }}
+    >
+      <g fill="none" stroke="currentColor" strokeWidth={stroke} strokeLinecap="round" opacity={0.7}>
+        {/* n */}
+        <path d="M6 38 V22 L14 38 V22" />
+        {/* i dot + stem */}
+        <path d="M22 22 V38" />
+        {/* u */}
+        <path d="M30 22 V34 Q30 38 34 38 Q38 38 38 34 V22" />
+        {/* u */}
+        <path d="M42 22 V34 Q42 38 46 38 Q50 38 50 34 V22" />
+      </g>
+      <g fill="currentColor">
+        {DOTS.map(([cx, cy], i) => (
+          <circle
+            key={i}
+            cx={cx}
+            cy={cy}
+            r={i % 3 === 0 ? 1.6 : 1}
+            opacity={i % 3 === 0 ? 1 : 0.6}
+          />
+        ))}
+      </g>
+    </svg>
+  );
+}

--- a/web-next/packages/plugin-login/src/ui/LogoTree.test.tsx
+++ b/web-next/packages/plugin-login/src/ui/LogoTree.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { LogoTree } from './LogoTree';
+
+describe('LogoTree', () => {
+  it('renders an SVG with default dimensions', () => {
+    const { container } = render(<LogoTree />);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('width')).toBe('56');
+    expect(svg?.getAttribute('height')).toBe('56');
+    expect(svg?.getAttribute('viewBox')).toBe('0 0 56 56');
+  });
+
+  it('applies a custom size', () => {
+    const { container } = render(<LogoTree size={80} />);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('width')).toBe('80');
+    expect(svg?.getAttribute('height')).toBe('80');
+  });
+
+  it('does not apply a filter when glow is false', () => {
+    const { container } = render(<LogoTree glow={false} />);
+    expect(container.querySelector('svg')?.getAttribute('style') ?? '').not.toContain(
+      'drop-shadow',
+    );
+  });
+
+  it('applies a drop-shadow filter when glow is true', () => {
+    const { container } = render(<LogoTree glow />);
+    expect(container.querySelector('svg')?.getAttribute('style')).toContain('drop-shadow');
+  });
+
+  it('is marked as aria-hidden', () => {
+    const { container } = render(<LogoTree />);
+    expect(container.querySelector('svg')?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('renders the trunk path', () => {
+    const { container } = render(<LogoTree />);
+    const paths = container.querySelectorAll('path');
+    expect(paths.length).toBeGreaterThan(0);
+  });
+
+  it('renders node circles', () => {
+    const { container } = render(<LogoTree />);
+    const circles = container.querySelectorAll('circle');
+    expect(circles.length).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/web-next/packages/plugin-login/src/ui/LogoTree.tsx
+++ b/web-next/packages/plugin-login/src/ui/LogoTree.tsx
@@ -1,0 +1,41 @@
+interface LogoTreeProps {
+  size?: number;
+  stroke?: number;
+  glow?: boolean;
+}
+
+/**
+ * Yggdrasil logo — a vertical world-tree axis with three realm planes.
+ * Uses currentColor so it inherits the brand palette from the parent.
+ */
+export function LogoTree({ size = 56, stroke = 1.4, glow = false }: LogoTreeProps) {
+  return (
+    <svg
+      viewBox="0 0 56 56"
+      width={size}
+      height={size}
+      aria-hidden
+      style={{ filter: glow ? 'drop-shadow(0 0 8px currentColor)' : undefined }}
+    >
+      <g fill="none" stroke="currentColor" strokeWidth={stroke} strokeLinecap="round">
+        {/* trunk */}
+        <path d="M28 6 V50" />
+        {/* three realm planes — Asgard, Midgard, Svartalfheim */}
+        <path d="M14 14 H42" opacity={0.5} />
+        <path d="M10 28 H46" />
+        <path d="M16 42 H40" opacity={0.6} />
+        {/* branch diagonals */}
+        <path d="M28 14 L16 24 M28 14 L40 24" opacity={0.6} />
+        <path d="M28 28 L12 38 M28 28 L44 38" opacity={0.4} />
+        {/* nodes */}
+        <circle cx={28} cy={6} r={1.8} fill="currentColor" />
+        <circle cx={28} cy={28} r={2.4} fill="currentColor" />
+        <circle cx={28} cy={50} r={1.8} fill="currentColor" />
+        <circle cx={14} cy={14} r={1.2} fill="currentColor" />
+        <circle cx={42} cy={14} r={1.2} fill="currentColor" />
+        <circle cx={10} cy={28} r={1.2} fill="currentColor" />
+        <circle cx={46} cy={28} r={1.2} fill="currentColor" />
+      </g>
+    </svg>
+  );
+}

--- a/web-next/packages/plugin-login/src/ui/Logos.stories.css
+++ b/web-next/packages/plugin-login/src/ui/Logos.stories.css
@@ -1,0 +1,23 @@
+.logos-gallery {
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+  padding: 2rem;
+  background: var(--color-bg-primary, #09090b);
+  color: var(--brand-400, #7dd3fc);
+  align-items: center;
+  min-height: 100vh;
+}
+
+.logos-gallery__item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.logos-gallery__label {
+  font-size: 11px;
+  font-family: monospace;
+  color: var(--color-text-muted, #71717a);
+}

--- a/web-next/packages/plugin-login/src/ui/Logos.stories.tsx
+++ b/web-next/packages/plugin-login/src/ui/Logos.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { LogoKnot } from './LogoKnot';
+import { LogoTree } from './LogoTree';
+import { LogoStars } from './LogoStars';
+import { LogoRuneRing } from './LogoRuneRing';
+import { LogoFlokk } from './LogoFlokk';
+import { LogoStack } from './LogoStack';
+
+const LOGOS = [LogoKnot, LogoTree, LogoStars, LogoRuneRing, LogoFlokk, LogoStack] as const;
+const LOGO_NAMES = ['Knot', 'Tree', 'Stars', 'RuneRing', 'Flokk', 'Stack'] as const;
+
+interface LogoGalleryProps {
+  size?: number;
+  stroke?: number;
+  glow?: boolean;
+}
+
+function LogoGallery({ size = 56, stroke = 1.6, glow = false }: LogoGalleryProps) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        gap: '2rem',
+        flexWrap: 'wrap',
+        padding: '2rem',
+        background: 'var(--color-bg-primary, #09090b)',
+        color: 'var(--brand-400, #38bdf8)',
+        alignItems: 'center',
+        minHeight: '100vh',
+      }}
+    >
+      {LOGOS.map((Logo, i) => (
+        <div
+          key={i}
+          style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '0.5rem' }}
+        >
+          <Logo size={size} stroke={stroke} glow={glow} />
+          <span
+            style={{
+              fontSize: '11px',
+              fontFamily: 'monospace',
+              color: 'var(--color-text-muted, #71717a)',
+            }}
+          >
+            {LOGO_NAMES[i]}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const meta: Meta<LogoGalleryProps> = {
+  title: 'Login/Logos',
+  component: LogoGallery,
+  parameters: { layout: 'fullscreen' },
+  argTypes: {
+    size: { control: { type: 'range', min: 24, max: 120, step: 4 } },
+    stroke: { control: { type: 'range', min: 0.5, max: 3, step: 0.1 } },
+    glow: { control: 'boolean' },
+  },
+};
+export default meta;
+type Story = StoryObj<LogoGalleryProps>;
+
+/** All six logo variants side by side — adjust size, stroke, and glow via controls. */
+export const Gallery: Story = {
+  args: { size: 56, stroke: 1.6, glow: false },
+};
+
+/** All logos with glow enabled. */
+export const WithGlow: Story = {
+  args: { size: 56, stroke: 1.6, glow: true },
+};
+
+/** Large format for detailed inspection. */
+export const Large: Story = {
+  args: { size: 96, stroke: 1.4, glow: false },
+};

--- a/web-next/packages/plugin-login/src/ui/Logos.stories.tsx
+++ b/web-next/packages/plugin-login/src/ui/Logos.stories.tsx
@@ -5,6 +5,7 @@ import { LogoStars } from './LogoStars';
 import { LogoRuneRing } from './LogoRuneRing';
 import { LogoFlokk } from './LogoFlokk';
 import { LogoStack } from './LogoStack';
+import './Logos.stories.css';
 
 const LOGOS = [LogoKnot, LogoTree, LogoStars, LogoRuneRing, LogoFlokk, LogoStack] as const;
 const LOGO_NAMES = ['Knot', 'Tree', 'Stars', 'RuneRing', 'Flokk', 'Stack'] as const;
@@ -17,33 +18,11 @@ interface LogoGalleryProps {
 
 function LogoGallery({ size = 56, stroke = 1.6, glow = false }: LogoGalleryProps) {
   return (
-    <div
-      style={{
-        display: 'flex',
-        gap: '2rem',
-        flexWrap: 'wrap',
-        padding: '2rem',
-        background: 'var(--color-bg-primary, #09090b)',
-        color: 'var(--brand-400, #38bdf8)',
-        alignItems: 'center',
-        minHeight: '100vh',
-      }}
-    >
+    <div className="logos-gallery">
       {LOGOS.map((Logo, i) => (
-        <div
-          key={i}
-          style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '0.5rem' }}
-        >
+        <div key={i} className="logos-gallery__item">
           <Logo size={size} stroke={stroke} glow={glow} />
-          <span
-            style={{
-              fontSize: '11px',
-              fontFamily: 'monospace',
-              color: 'var(--color-text-muted, #71717a)',
-            }}
-          >
-            {LOGO_NAMES[i]}
-          </span>
+          <span className="logos-gallery__label">{LOGO_NAMES[i]}</span>
         </div>
       ))}
     </div>

--- a/web-next/packages/plugin-login/src/ui/ambient.css
+++ b/web-next/packages/plugin-login/src/ui/ambient.css
@@ -1,0 +1,25 @@
+/* ================================================================
+   Ambient background — shared positioning for all three variants.
+   ================================================================ */
+
+.login-ambient {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* Pause CSS-driven shimmer / rotate animations when the user
+   prefers reduced motion. Canvas-based variants handle this in JS. */
+@media (prefers-reduced-motion: reduce) {
+  .login-ambient animate,
+  .login-ambient animateTransform {
+    display: none;
+  }
+
+  .login-ambient circle[opacity] {
+    opacity: 0.5;
+  }
+}

--- a/web-next/packages/plugin-login/src/ui/ambient.css
+++ b/web-next/packages/plugin-login/src/ui/ambient.css
@@ -9,17 +9,21 @@
   height: 100%;
   pointer-events: none;
   z-index: 0;
+  /* Ambient-specific token: deep midnight blue for gradient centres */
+  --ambient-glow-mid: #1e3a5f;
 }
 
-/* Pause CSS-driven shimmer / rotate animations when the user
-   prefers reduced motion. Canvas-based variants handle this in JS. */
-@media (prefers-reduced-motion: reduce) {
-  .login-ambient animate,
-  .login-ambient animateTransform {
-    display: none;
-  }
+/* Gradient stop tokens (used by <stop> elements in inline SVG) */
+.ambient-stop-mid { stop-color: var(--ambient-glow-mid); }
+.ambient-stop-bg { stop-color: var(--color-bg-primary); }
+.ambient-stop-brand { stop-color: var(--brand-500); }
 
-  .login-ambient circle[opacity] {
-    opacity: 0.5;
-  }
+/* Constellation star fill */
+.constellation-star { fill: var(--brand-300); }
+
+/* Lattice geometry strokes and rune fill */
+.lattice-rings-group { stroke: color-mix(in srgb, var(--brand-300) 14%, transparent); }
+.lattice-rune-text {
+  fill: color-mix(in srgb, var(--brand-300) 30%, transparent);
+  stroke: none;
 }

--- a/web-next/packages/plugin-login/src/ui/useAmbient.test.ts
+++ b/web-next/packages/plugin-login/src/ui/useAmbient.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useAmbient } from './useAmbient';
+
+const STORAGE_KEY = 'niuu-login-ambient';
+
+describe('useAmbient', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns "topology" as the default when nothing is stored', () => {
+    const { result } = renderHook(() => useAmbient());
+    expect(result.current[0]).toBe('topology');
+  });
+
+  it('reads an existing valid value from localStorage', () => {
+    localStorage.setItem(STORAGE_KEY, 'constellation');
+    const { result } = renderHook(() => useAmbient());
+    expect(result.current[0]).toBe('constellation');
+  });
+
+  it('reads "lattice" from localStorage', () => {
+    localStorage.setItem(STORAGE_KEY, 'lattice');
+    const { result } = renderHook(() => useAmbient());
+    expect(result.current[0]).toBe('lattice');
+  });
+
+  it('falls back to "topology" when stored value is invalid', () => {
+    localStorage.setItem(STORAGE_KEY, 'invalid-value');
+    const { result } = renderHook(() => useAmbient());
+    expect(result.current[0]).toBe('topology');
+  });
+
+  it('falls back to "topology" when stored value is empty string', () => {
+    localStorage.setItem(STORAGE_KEY, '');
+    const { result } = renderHook(() => useAmbient());
+    expect(result.current[0]).toBe('topology');
+  });
+
+  it('persists the new value to localStorage when setAmbient is called', () => {
+    const { result } = renderHook(() => useAmbient());
+    act(() => {
+      result.current[1]('constellation');
+    });
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('constellation');
+  });
+
+  it('updates the returned ambient when setAmbient is called', () => {
+    const { result } = renderHook(() => useAmbient());
+    act(() => {
+      result.current[1]('lattice');
+    });
+    expect(result.current[0]).toBe('lattice');
+  });
+
+  it('persists through subsequent setAmbient calls', () => {
+    const { result } = renderHook(() => useAmbient());
+    act(() => {
+      result.current[1]('constellation');
+    });
+    act(() => {
+      result.current[1]('topology');
+    });
+    expect(result.current[0]).toBe('topology');
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('topology');
+  });
+
+  it('handles localStorage being unavailable (read)', () => {
+    const getItem = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('localStorage unavailable');
+    });
+    const { result } = renderHook(() => useAmbient());
+    expect(result.current[0]).toBe('topology');
+    getItem.mockRestore();
+  });
+
+  it('handles localStorage being unavailable (write)', () => {
+    const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('localStorage unavailable');
+    });
+    const { result } = renderHook(() => useAmbient());
+    // Should not throw
+    act(() => {
+      result.current[1]('lattice');
+    });
+    expect(result.current[0]).toBe('lattice');
+    setItem.mockRestore();
+  });
+});

--- a/web-next/packages/plugin-login/src/ui/useAmbient.ts
+++ b/web-next/packages/plugin-login/src/ui/useAmbient.ts
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+
+export type AmbientVariant = 'topology' | 'constellation' | 'lattice';
+
+const STORAGE_KEY = 'niuu-login-ambient';
+const VALID: AmbientVariant[] = ['topology', 'constellation', 'lattice'];
+const DEFAULT: AmbientVariant = 'topology';
+
+function readStored(): AmbientVariant {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw && (VALID as string[]).includes(raw)) return raw as AmbientVariant;
+  } catch {
+    // localStorage unavailable (SSR, private browsing)
+  }
+  return DEFAULT;
+}
+
+/**
+ * Manages which ambient background variant is shown on the login page.
+ *
+ * - Persists the selection to localStorage under `niuu-login-ambient`.
+ * - Falls back to `'topology'` when the stored value is missing or invalid.
+ */
+export function useAmbient(): [AmbientVariant, (v: AmbientVariant) => void] {
+  const [ambient, setAmbientState] = useState<AmbientVariant>(readStored);
+
+  const setAmbient = (v: AmbientVariant) => {
+    try {
+      localStorage.setItem(STORAGE_KEY, v);
+    } catch {
+      // Ignore write failures (private browsing, quota exceeded)
+    }
+    setAmbientState(v);
+  };
+
+  return [ambient, setAmbient];
+}

--- a/web-next/packages/plugin-login/src/ui/useReducedMotion.test.ts
+++ b/web-next/packages/plugin-login/src/ui/useReducedMotion.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useReducedMotion } from './useReducedMotion';
+
+function mockMatchMedia(matches: boolean) {
+  const listeners: ((e: MediaQueryListEvent) => void)[] = [];
+  const mq = {
+    matches,
+    addEventListener: vi.fn((_: string, cb: (e: MediaQueryListEvent) => void) => {
+      listeners.push(cb);
+    }),
+    removeEventListener: vi.fn(),
+  };
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn(() => mq),
+  );
+  return { mq, listeners };
+}
+
+describe('useReducedMotion', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns false when prefers-reduced-motion does not match', () => {
+    mockMatchMedia(false);
+    const { result } = renderHook(() => useReducedMotion());
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true when prefers-reduced-motion matches', () => {
+    mockMatchMedia(true);
+    const { result } = renderHook(() => useReducedMotion());
+    expect(result.current).toBe(true);
+  });
+
+  it('updates when the media query fires a change event', () => {
+    const { listeners } = mockMatchMedia(false);
+    const { result } = renderHook(() => useReducedMotion());
+    expect(result.current).toBe(false);
+
+    act(() => {
+      listeners[0]?.({ matches: true } as MediaQueryListEvent);
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('removes the event listener on unmount', () => {
+    const { mq } = mockMatchMedia(false);
+    const { unmount } = renderHook(() => useReducedMotion());
+    unmount();
+    expect(mq.removeEventListener).toHaveBeenCalledOnce();
+  });
+});

--- a/web-next/packages/plugin-login/src/ui/useReducedMotion.ts
+++ b/web-next/packages/plugin-login/src/ui/useReducedMotion.ts
@@ -1,0 +1,23 @@
+import { useState, useEffect } from 'react';
+
+const QUERY = '(prefers-reduced-motion: reduce)';
+
+/**
+ * Returns true when the user prefers reduced motion.
+ * Reacts to system-level setting changes in real time.
+ */
+export function useReducedMotion(): boolean {
+  const [matches, setMatches] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    return window.matchMedia(QUERY).matches;
+  });
+
+  useEffect(() => {
+    const mq = window.matchMedia(QUERY);
+    const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
+  return matches;
+}

--- a/web-next/pnpm-lock.yaml
+++ b/web-next/pnpm-lock.yaml
@@ -363,6 +363,9 @@ importers:
         specifier: workspace:*
         version: link:../ui
     devDependencies:
+      '@niuulabs/design-tokens':
+        specifier: workspace:*
+        version: link:../design-tokens
       '@tanstack/react-query':
         specifier: ^5.62.0
         version: 5.99.1(react@19.2.5)
@@ -372,9 +375,21 @@ importers:
       '@types/react':
         specifier: ^19.0.7
         version: 19.2.14
+      autoprefixer:
+        specifier: ^10.4.20
+        version: 10.5.0(postcss@8.5.10)
+      postcss:
+        specifier: ^8.4.49
+        version: 8.5.10
+      postcss-import:
+        specifier: ^16.1.0
+        version: 16.1.1(postcss@8.5.10)
       react:
         specifier: ^19.0.0
         version: 19.2.5
+      tailwindcss:
+        specifier: ^3.4.17
+        version: 3.4.19(yaml@2.8.3)
       tsup:
         specifier: ^8.3.5
         version: 8.5.1(jiti@1.21.7)(postcss@8.5.10)(typescript@5.9.3)(yaml@2.8.3)

--- a/web-next/vitest.setup.ts
+++ b/web-next/vitest.setup.ts
@@ -30,3 +30,36 @@ if (!Element.prototype.setPointerCapture) {
 if (!Element.prototype.releasePointerCapture) {
   Element.prototype.releasePointerCapture = () => {};
 }
+
+// jsdom doesn't implement HTMLCanvasElement.prototype.getContext.
+// Return a minimal stub so canvas-based components (e.g. AmbientTopology)
+// don't print "Not implemented" warnings during tests.
+if (typeof HTMLCanvasElement !== 'undefined') {
+  HTMLCanvasElement.prototype.getContext = () =>
+    ({
+      clearRect: () => {},
+      beginPath: () => {},
+      moveTo: () => {},
+      lineTo: () => {},
+      arc: () => {},
+      fill: () => {},
+      stroke: () => {},
+      setTransform: () => {},
+      strokeStyle: '',
+      lineWidth: 0,
+      fillStyle: '',
+    }) as unknown as CanvasRenderingContext2D;
+}
+
+// matchMedia is not implemented in jsdom; provide a silent stub so components
+// that call window.matchMedia() (e.g. useReducedMotion) don't throw.
+if (typeof window.matchMedia === 'undefined') {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: () => ({
+      matches: false,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }),
+  });
+}


### PR DESCRIPTION
## Summary

- **3 ambient backgrounds** ported from `web2/niuu_handoff/niuu_login/design/ambient.jsx` into `@niuulabs/plugin-login/ui/`:
  - `AmbientTopology` — requestAnimationFrame node graph with faint ice-blue edges
  - `AmbientConstellation` — 80 shimmer stars (SVG `<animate>`)
  - `AmbientLattice` — concentric circles + slowly rotating rune band (`<animateTransform>`)
- **5 new SVG logo variants** ported from `logos.jsx` (LogoKnot already existed):
  - `LogoTree`, `LogoStars`, `LogoRuneRing`, `LogoFlokk`, `LogoStack`
- **`useAmbient` hook** — localStorage-persisted variant selection (`niuu-login-ambient`) with default fallback to `topology`
- **`useReducedMotion` hook** — reusable `(prefers-reduced-motion: reduce)` detector; all three ambients pause animation when set
- **`LoginPage` updated** — renders the selected ambient component instead of a static CSS gradient; accepts an `ambient` prop for Storybook overrides
- **Storybook stories**: `Ambient.stories.tsx` (all 3 variants), `Logos.stories.tsx` (gallery + controls), `LoginPage` ambient variant stories
- **Playwright e2e**: `e2e/ambient.spec.ts` — 6 smoke tests covering all 3 variants checking for canvas/SVG presence and zero JS errors
- **Unit tests**: 1060 tests pass, `plugin-login` at 99%/95%/95%/99% coverage
- **`vitest.setup.ts`**: global canvas + matchMedia stubs to silence jsdom warnings across all test files

## Test plan

- [x] `pnpm test` — 1060 passed, 0 failed, coverage ≥ 85% (plugin-login: 99%)
- [x] `pnpm lint` — no errors
- [x] `pnpm format` — no formatting issues
- [x] All 3 ambient variants render via Storybook controls
- [x] All 6 logo variants render in Logos gallery story
- [x] Playwright smoke tests added for ambient canvas rendering
- [x] `prefers-reduced-motion` halts canvas RAF and omits SVG SMIL elements

Closes NIU-662

🤖 Generated with [Claude Code](https://claude.com/claude-code)