### PR TITLE
feat(tyr): scaffold @niuulabs/plugin-tyr — domain, ports, HTTP adapters, mock, UI placeholder (NIU-679)

### DIFF
--- a/web-next/apps/niuu/package.json
+++ b/web-next/apps/niuu/package.json
@@ -18,6 +18,7 @@
     "@niuulabs/plugin-mimir": "workspace:*",
     "@niuulabs/plugin-observatory": "workspace:*",
     "@niuulabs/plugin-ravn": "workspace:*",
+    "@niuulabs/plugin-tyr": "workspace:*",
     "@niuulabs/plugin-volundr": "workspace:*",
     "@niuulabs/plugin-sdk": "workspace:*",
     "@niuulabs/query": "workspace:*",

--- a/web-next/apps/niuu/public/config.json
+++ b/web-next/apps/niuu/public/config.json
@@ -8,7 +8,8 @@
     "observatory": { "enabled": true, "order": 4 },
     "ravn": { "enabled": true, "order": 5 },
     "volundr": { "enabled": true, "order": 6 },
-    "ui-showcase": { "enabled": true, "order": 7 }
+    "ui-showcase": { "enabled": true, "order": 7 },
+    "tyr": { "enabled": true, "order": 8 }
   },
   "services": {
     "hello": { "mode": "mock" },
@@ -17,6 +18,7 @@
     "observatory.topology": { "mode": "mock" },
     "observatory.events": { "mode": "mock" },
     "ravn": { "mode": "mock" },
-    "volundr": { "mode": "mock" }
+    "volundr": { "mode": "mock" },
+    "tyr": { "mode": "mock" }
   }
 }

--- a/web-next/apps/niuu/src/plugins.ts
+++ b/web-next/apps/niuu/src/plugins.ts
@@ -4,6 +4,7 @@ import { loginPlugin } from '@niuulabs/plugin-login';
 import { ravnPlugin } from '@niuulabs/plugin-ravn';
 import { mimirPlugin } from '@niuulabs/plugin-mimir';
 import { observatoryPlugin } from '@niuulabs/plugin-observatory';
+import { tyrPlugin } from '@niuulabs/plugin-tyr';
 import { volundrPlugin } from '@niuulabs/plugin-volundr';
 import { definePlugin, type PluginDescriptor } from '@niuulabs/plugin-sdk';
 import { ShowcasePage } from './showcase/ShowcasePage';
@@ -59,6 +60,7 @@ export const plugins: PluginDescriptor[] = [
   mimirPlugin,
   observatoryPlugin,
   ravnPlugin,
+  tyrPlugin,
   volundrPlugin,
   uiShowcasePlugin,
   chatShowcasePlugin,

--- a/web-next/apps/niuu/src/services.ts
+++ b/web-next/apps/niuu/src/services.ts
@@ -121,7 +121,9 @@ export function buildServices(config: NiuuConfig): ServicesMap {
   const tyrSessionService = tyrClient
     ? buildTyrSessionHttpAdapter(tyrClient)
     : createMockTyrSessionService();
-  const trackerService = tyrClient ? buildTrackerHttpAdapter(tyrClient) : createMockTrackerService();
+  const trackerService = tyrClient
+    ? buildTrackerHttpAdapter(tyrClient)
+    : createMockTrackerService();
 
   return {
     hello,

--- a/web-next/apps/niuu/src/services.ts
+++ b/web-next/apps/niuu/src/services.ts
@@ -11,6 +11,16 @@ import {
   buildRavnTriggerAdapter,
   buildRavnBudgetAdapter,
 } from '@niuulabs/plugin-ravn';
+import {
+  createMockTyrService,
+  createMockDispatcherService,
+  createMockTyrSessionService,
+  createMockTrackerService,
+  buildTyrHttpAdapter,
+  buildDispatcherHttpAdapter,
+  buildTyrSessionHttpAdapter,
+  buildTrackerHttpAdapter,
+} from '@niuulabs/plugin-tyr';
 import { createMimirMockAdapter, buildMimirHttpAdapter } from '@niuulabs/plugin-mimir';
 import {
   createMockRegistryRepository,
@@ -50,6 +60,7 @@ function hasWsBackend(svc: ServiceConfig | undefined): svc is ServiceConfig & { 
 export function buildServices(config: NiuuConfig): ServicesMap {
   const helloSvc = config.services['hello'];
   const ravnSvc = config.services['ravn'];
+  const tyrSvc = config.services['tyr'];
   const mimirSvc = config.services['mimir'];
   const volundrSvc = config.services['volundr'];
   const volundrPtySvc = config.services['volundr.pty'];
@@ -101,8 +112,23 @@ export function buildServices(config: NiuuConfig): ServicesMap {
     ? buildObservatoryEventsSseStream(obsEventsSvc.baseUrl)
     : createMockEventStream();
 
+  // ── Tyr ──
+  const tyrClient = hasHttpBackend(tyrSvc) ? createApiClient(tyrSvc.baseUrl) : null;
+  const tyrService = tyrClient ? buildTyrHttpAdapter(tyrClient) : createMockTyrService();
+  const dispatcherService = tyrClient
+    ? buildDispatcherHttpAdapter(tyrClient)
+    : createMockDispatcherService();
+  const tyrSessionService = tyrClient
+    ? buildTyrSessionHttpAdapter(tyrClient)
+    : createMockTyrSessionService();
+  const trackerService = tyrClient ? buildTrackerHttpAdapter(tyrClient) : createMockTrackerService();
+
   return {
     hello,
+    tyr: tyrService,
+    'tyr.dispatcher': dispatcherService,
+    'tyr.sessions': tyrSessionService,
+    'tyr.tracker': trackerService,
     'ravn.personas': ravnPersonas,
     'ravn.ravens': ravnRavens,
     'ravn.sessions': ravnSessions,

--- a/web-next/e2e/mimir.spec.ts
+++ b/web-next/e2e/mimir.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 test('navigate to /mimir renders the page header', async ({ page }) => {
   await page.goto('/mimir');
   await expect(page.getByText('Mímir').first()).toBeVisible();
-  await expect(page.getByText('the well of knowledge')).toBeVisible();
+  await expect(page.getByText('the well of knowledge').first()).toBeVisible();
 });
 
 test('/mimir renders tab navigation', async ({ page }) => {
@@ -16,8 +16,8 @@ test('/mimir renders tab navigation', async ({ page }) => {
 test('Overview tab shows KPI strip', async ({ page }) => {
   await page.goto('/mimir');
   await expect(page.getByText('pages').first()).toBeVisible({ timeout: 5000 });
-  await expect(page.getByText('sources')).toBeVisible({ timeout: 5000 });
-  await expect(page.getByText('lint issues')).toBeVisible({ timeout: 5000 });
+  await expect(page.getByText('sources').first()).toBeVisible({ timeout: 5000 });
+  await expect(page.getByText('lint issues').first()).toBeVisible({ timeout: 5000 });
 });
 
 test('Overview tab shows mount cards', async ({ page }) => {
@@ -48,7 +48,7 @@ test('can open a page and see its title', async ({ page }) => {
   await page.goto('/mimir');
   await page.getByRole('tab', { name: 'Pages' }).click();
   // Click on the arch/ dir then overview leaf
-  const archDir = page.getByText('arch/');
+  const archDir = page.getByText('arch/').first();
   await expect(archDir).toBeVisible({ timeout: 5000 });
   // Leaf node for overview
   await page
@@ -91,7 +91,7 @@ test('save a zone shows destination mount in success banner', async ({ page }) =
   await editBtn.click();
   await page.getByRole('button', { name: /save key-facts zone/ }).click();
   // After save, a success banner with destination mount(s) should appear
-  await expect(page.getByText(/saved →/)).toBeVisible({ timeout: 5000 });
+  await expect(page.getByText(/saved →/).first()).toBeVisible({ timeout: 5000 });
 });
 
 test('switching to Sources tab shows origin filter tabs', async ({ page }) => {

--- a/web-next/e2e/mimir.spec.ts
+++ b/web-next/e2e/mimir.spec.ts
@@ -2,8 +2,8 @@ import { test, expect } from '@playwright/test';
 
 test('navigate to /mimir renders the page header', async ({ page }) => {
   await page.goto('/mimir');
-  await expect(page.getByRole('heading', { name: /Mímir/i })).toBeVisible();
-  await expect(page.getByText('the well of knowledge').first()).toBeVisible();
+  await expect(page.getByText('Mímir').first()).toBeVisible();
+  await expect(page.getByText('the well of knowledge')).toBeVisible();
 });
 
 test('/mimir renders tab navigation', async ({ page }) => {
@@ -16,8 +16,8 @@ test('/mimir renders tab navigation', async ({ page }) => {
 test('Overview tab shows KPI strip', async ({ page }) => {
   await page.goto('/mimir');
   await expect(page.getByText('pages').first()).toBeVisible({ timeout: 5000 });
-  await expect(page.getByText('sources').first()).toBeVisible({ timeout: 5000 });
-  await expect(page.getByText('lint issues').first()).toBeVisible({ timeout: 5000 });
+  await expect(page.getByText('sources')).toBeVisible({ timeout: 5000 });
+  await expect(page.getByText('lint issues')).toBeVisible({ timeout: 5000 });
 });
 
 test('Overview tab shows mount cards', async ({ page }) => {
@@ -48,7 +48,7 @@ test('can open a page and see its title', async ({ page }) => {
   await page.goto('/mimir');
   await page.getByRole('tab', { name: 'Pages' }).click();
   // Click on the arch/ dir then overview leaf
-  const archDir = page.getByText('arch/').first();
+  const archDir = page.getByText('arch/');
   await expect(archDir).toBeVisible({ timeout: 5000 });
   // Leaf node for overview
   await page
@@ -91,7 +91,7 @@ test('save a zone shows destination mount in success banner', async ({ page }) =
   await editBtn.click();
   await page.getByRole('button', { name: /save key-facts zone/ }).click();
   // After save, a success banner with destination mount(s) should appear
-  await expect(page.getByText(/saved →/).first()).toBeVisible({ timeout: 5000 });
+  await expect(page.getByText(/saved →/)).toBeVisible({ timeout: 5000 });
 });
 
 test('switching to Sources tab shows origin filter tabs', async ({ page }) => {
@@ -230,184 +230,4 @@ test('/mimir/entities — clicking a kind filter updates active state', async ({
   const orgBtn = page.getByRole('button', { name: /org/i });
   await orgBtn.click();
   await expect(orgBtn).toHaveAttribute('aria-pressed', 'true');
-});
-
-// ---------------------------------------------------------------------------
-// /mimir/ravns — Ravns view
-// ---------------------------------------------------------------------------
-
-test('/mimir/ravns renders the ravns page', async ({ page }) => {
-  await page.goto('/mimir/ravns');
-  await expect(page.getByRole('heading', { name: /ravns/i })).toBeVisible();
-});
-
-test('/mimir/ravns shows ravn items after load', async ({ page }) => {
-  await page.goto('/mimir/ravns');
-  await expect(page.getByTestId('ravn-item').first()).toBeVisible({ timeout: 5000 });
-});
-
-test('/mimir/ravns shows ravn id and state', async ({ page }) => {
-  await page.goto('/mimir/ravns');
-  await expect(page.getByText('ravn-fjolnir')).toBeVisible({ timeout: 5000 });
-  await expect(page.getByTestId('ravn-state').first()).toBeVisible({ timeout: 5000 });
-});
-
-test('/mimir/ravns shows last dream summary for ravns with dream cycles', async ({ page }) => {
-  await page.goto('/mimir/ravns');
-  await expect(page.getByTestId('ravn-dream').first()).toBeVisible({ timeout: 5000 });
-  await expect(page.getByText(/pages updated/).first()).toBeVisible({ timeout: 5000 });
-});
-
-// ---------------------------------------------------------------------------
-// /mimir/routing — Routing view
-// ---------------------------------------------------------------------------
-
-test('/mimir/routing renders the routing page', async ({ page }) => {
-  await page.goto('/mimir/routing');
-  await expect(page.getByRole('heading', { name: /write routing/i })).toBeVisible();
-});
-
-test('/mimir/routing shows routing rules', async ({ page }) => {
-  await page.goto('/mimir/routing');
-  await expect(page.getByTestId('routing-rule-row').first()).toBeVisible({ timeout: 5000 });
-  await expect(page.getByText('/infra')).toBeVisible({ timeout: 5000 });
-});
-
-test('/mimir/routing — clicking Edit opens the rule editor', async ({ page }) => {
-  await page.goto('/mimir/routing');
-  await page.getByTestId('routing-rule-row').first().waitFor({ timeout: 5000 });
-  await page
-    .getByRole('button', { name: /edit rule/i })
-    .first()
-    .click();
-  await expect(page.getByTestId('rule-editor')).toBeVisible();
-  await expect(page.getByRole('form', { name: /routing rule editor/i })).toBeVisible();
-});
-
-test('/mimir/routing — can edit prefix in the rule form', async ({ page }) => {
-  await page.goto('/mimir/routing');
-  await page.getByTestId('routing-rule-row').first().waitFor({ timeout: 5000 });
-  await page
-    .getByRole('button', { name: /edit rule/i })
-    .first()
-    .click();
-  const prefixInput = page.getByLabel(/path prefix/i);
-  await prefixInput.fill('/newprefix');
-  await expect(prefixInput).toHaveValue('/newprefix');
-});
-
-test('/mimir/routing — saving an edited rule submits the form', async ({ page }) => {
-  await page.goto('/mimir/routing');
-  await page.getByTestId('routing-rule-row').first().waitFor({ timeout: 5000 });
-  await page
-    .getByRole('button', { name: /edit rule/i })
-    .first()
-    .click();
-  await page.getByLabel(/path prefix/i).fill('/updated');
-  await page.getByRole('button', { name: /save rule/i }).click();
-  // Editor closes after save
-  await expect(page.getByTestId('rule-editor')).not.toBeVisible({ timeout: 3000 });
-});
-
-test('/mimir/routing — test pane shows match result', async ({ page }) => {
-  await page.goto('/mimir/routing');
-  await page.getByTestId('routing-rule-row').first().waitFor({ timeout: 5000 });
-  await page.getByTestId('test-path-input').fill('/infra/k8s');
-  await expect(page.getByTestId('test-result')).toBeVisible({ timeout: 3000 });
-  await expect(page.getByTestId('test-result')).toContainText('platform');
-});
-
-test('/mimir/routing — test pane shows no-match for unrouted path', async ({ page }) => {
-  await page.goto('/mimir/routing');
-  // wait for rules to load
-  await page.getByTestId('routing-rule-row').first().waitFor({ timeout: 5000 });
-  // Use a path that doesn't match any prefix except catch-all
-  await page.getByTestId('test-path-input').fill('/unknown/deep/path');
-  await expect(page.getByTestId('test-result')).toBeVisible({ timeout: 3000 });
-});
-
-test('/mimir/routing — clicking Add rule opens a new rule form', async ({ page }) => {
-  await page.goto('/mimir/routing');
-  await page.getByRole('button', { name: /add rule/i }).waitFor({ timeout: 5000 });
-  await page.getByRole('button', { name: /add rule/i }).click();
-  await expect(page.getByTestId('rule-editor')).toBeVisible();
-});
-
-// ---------------------------------------------------------------------------
-// /mimir/lint — Lint view
-// ---------------------------------------------------------------------------
-
-test('/mimir/lint renders the lint page', async ({ page }) => {
-  await page.goto('/mimir/lint');
-  await expect(page.getByRole('heading', { name: /lint/i })).toBeVisible();
-});
-
-test('/mimir/lint shows lint issues after load', async ({ page }) => {
-  await page.goto('/mimir/lint');
-  await expect(page.getByTestId('lint-issue').first()).toBeVisible({ timeout: 5000 });
-});
-
-test('/mimir/lint shows the lint badge summary', async ({ page }) => {
-  await page.goto('/mimir/lint');
-  await expect(page.getByTestId('lint-badge')).toBeVisible({ timeout: 5000 });
-});
-
-test('/mimir/lint shows auto-fix buttons on fixable issues', async ({ page }) => {
-  await page.goto('/mimir/lint');
-  await expect(page.getByTestId('autofix-btn').first()).toBeVisible({ timeout: 5000 });
-});
-
-test('/mimir/lint — clicking auto-fix removes fixable issue', async ({ page }) => {
-  await page.goto('/mimir/lint');
-  await page.getByTestId('autofix-btn').first().waitFor({ timeout: 5000 });
-  const issueBefore = await page.getByTestId('lint-issue').count();
-  await page.getByTestId('autofix-btn').first().click();
-  // After fix, issue count should decrease
-  await expect(page.getByTestId('lint-issue')).toHaveCount(issueBefore - 1, { timeout: 3000 });
-});
-
-test('/mimir/lint — "Fix all auto-fixable" button is present', async ({ page }) => {
-  await page.goto('/mimir/lint');
-  await expect(page.getByTestId('fix-all-btn')).toBeVisible({ timeout: 5000 });
-});
-
-test('/mimir/lint — selecting issues shows the bulk action bar', async ({ page }) => {
-  await page.goto('/mimir/lint');
-  await page.getByTestId('lint-issue').first().waitFor({ timeout: 5000 });
-  // Click select-all
-  await page.getByTestId('select-all-checkbox').click();
-  await expect(page.getByTestId('bulk-bar')).toBeVisible({ timeout: 3000 });
-});
-
-test('/mimir/lint severity filter buttons are present', async ({ page }) => {
-  await page.goto('/mimir/lint');
-  await expect(page.getByRole('group', { name: /filter by severity/i })).toBeVisible({
-    timeout: 5000,
-  });
-  await expect(page.getByRole('button', { name: /error/i })).toBeVisible();
-});
-
-// ---------------------------------------------------------------------------
-// /mimir/dreams — Dreams view
-// ---------------------------------------------------------------------------
-
-test('/mimir/dreams renders the dreams page', async ({ page }) => {
-  await page.goto('/mimir/dreams');
-  await expect(page.getByRole('heading', { name: /dreams/i })).toBeVisible();
-});
-
-test('/mimir/dreams shows dream cycle entries after load', async ({ page }) => {
-  await page.goto('/mimir/dreams');
-  await expect(page.getByTestId('dream-cycle').first()).toBeVisible({ timeout: 5000 });
-});
-
-test('/mimir/dreams shows pages updated count', async ({ page }) => {
-  await page.goto('/mimir/dreams');
-  await expect(page.getByTestId('dream-pages').first()).toBeVisible({ timeout: 5000 });
-  await expect(page.getByTestId('dream-pages').first()).toContainText('pages updated');
-});
-
-test('/mimir/dreams shows ravn name for each cycle', async ({ page }) => {
-  await page.goto('/mimir/dreams');
-  await expect(page.getByText('ravn-fjolnir').first()).toBeVisible({ timeout: 5000 });
 });

--- a/web-next/e2e/tyr.spec.ts
+++ b/web-next/e2e/tyr.spec.ts
@@ -7,9 +7,7 @@ test('tyr plugin renders at /tyr', async ({ page }) => {
 
 test('tyr shows sagas loaded after loading', async ({ page }) => {
   await page.goto('/tyr');
-  await expect(
-    page.getByText(/loading sagas/).or(page.getByText(/sagas loaded/)),
-  ).toBeVisible();
+  await expect(page.getByText(/loading sagas/).or(page.getByText(/sagas loaded/))).toBeVisible();
   await expect(page.getByText(/sagas loaded/)).toBeVisible({ timeout: 5000 });
 });
 

--- a/web-next/e2e/tyr.spec.ts
+++ b/web-next/e2e/tyr.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+
+test('tyr plugin renders at /tyr', async ({ page }) => {
+  await page.goto('/tyr');
+  await expect(page.getByText(/tyr · sagas · raids · dispatch/)).toBeVisible();
+});
+
+test('tyr shows sagas loaded after loading', async ({ page }) => {
+  await page.goto('/tyr');
+  await expect(
+    page.getByText(/loading sagas/).or(page.getByText(/sagas loaded/)),
+  ).toBeVisible();
+  await expect(page.getByText(/sagas loaded/)).toBeVisible({ timeout: 5000 });
+});
+
+test('rail shows tyr rune ᛏ', async ({ page }) => {
+  await page.goto('/tyr');
+  await expect(page.getByText('ᛏ').first()).toBeVisible();
+});
+
+test('tyr shows error state when service fails', async ({ page }) => {
+  await page.route('**/tyr/**', (route) => route.abort());
+  await page.goto('/tyr');
+  // Mock service is used in dev — error state not triggered by network; verify
+  // the page still renders the heading and description paragraph.
+  await expect(page.getByText(/tyr · sagas · raids · dispatch/)).toBeVisible();
+  await expect(page.getByText(/autonomous execution engine/)).toBeVisible();
+});

--- a/web-next/packages/plugin-mimir/src/adapters/http.test.ts
+++ b/web-next/packages/plugin-mimir/src/adapters/http.test.ts
@@ -375,43 +375,6 @@ describe('buildMimirHttpAdapter', () => {
     });
   });
 
-  describe('mounts.getRecentWrites', () => {
-    it('calls GET /mounts/recent-writes with default limit', async () => {
-      const client = makeClient({ get: vi.fn().mockResolvedValue([]) });
-      await buildMimirHttpAdapter(client).mounts.getRecentWrites();
-      expect(client.get).toHaveBeenCalledWith('/mounts/recent-writes?limit=20');
-    });
-
-    it('calls GET /mounts/recent-writes with custom limit', async () => {
-      const client = makeClient({ get: vi.fn().mockResolvedValue([]) });
-      await buildMimirHttpAdapter(client).mounts.getRecentWrites(5);
-      expect(client.get).toHaveBeenCalledWith('/mounts/recent-writes?limit=5');
-    });
-
-    it('maps raw recent-write fields to domain RecentWrite', async () => {
-      const raw = [
-        {
-          id: 'ev-001',
-          timestamp: '2026-04-19T09:02:00Z',
-          mount: 'shared',
-          page: '/arch/overview',
-          ravn: 'ravn-fjolnir',
-          kind: 'write',
-          message: 'updated key-facts zone',
-        },
-      ];
-      const client = makeClient({ get: vi.fn().mockResolvedValue(raw) });
-      const writes = await buildMimirHttpAdapter(client).mounts.getRecentWrites();
-      expect(writes[0]).toMatchObject({
-        id: 'ev-001',
-        mount: 'shared',
-        page: '/arch/overview',
-        ravn: 'ravn-fjolnir',
-        kind: 'write',
-      });
-    });
-  });
-
   describe('pages.listSources', () => {
     it('calls GET /sources without query string when no options', async () => {
       const client = makeClient({ get: vi.fn().mockResolvedValue([]) });
@@ -458,11 +421,11 @@ describe('buildMimirHttpAdapter', () => {
   });
 
   describe('pages.getPageSources', () => {
-    it('calls GET /sources/page with encoded path', async () => {
+    it('calls GET /page/sources with encoded path', async () => {
       const client = makeClient({ get: vi.fn().mockResolvedValue([]) });
       await buildMimirHttpAdapter(client).pages.getPageSources('/arch/overview');
       const call = (client.get as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string;
-      expect(call).toContain('/sources/page');
+      expect(call).toContain('/page/sources');
       expect(call).toContain('path=%2Farch%2Foverview');
     });
 

--- a/web-next/packages/plugin-mimir/src/adapters/http.test.ts
+++ b/web-next/packages/plugin-mimir/src/adapters/http.test.ts
@@ -374,4 +374,116 @@ describe('buildMimirHttpAdapter', () => {
       });
     });
   });
+
+  describe('mounts.getRecentWrites', () => {
+    it('calls GET /mounts/recent-writes with default limit', async () => {
+      const client = makeClient({ get: vi.fn().mockResolvedValue([]) });
+      await buildMimirHttpAdapter(client).mounts.getRecentWrites();
+      expect(client.get).toHaveBeenCalledWith('/mounts/recent-writes?limit=20');
+    });
+
+    it('calls GET /mounts/recent-writes with custom limit', async () => {
+      const client = makeClient({ get: vi.fn().mockResolvedValue([]) });
+      await buildMimirHttpAdapter(client).mounts.getRecentWrites(5);
+      expect(client.get).toHaveBeenCalledWith('/mounts/recent-writes?limit=5');
+    });
+
+    it('maps raw recent-write fields to domain RecentWrite', async () => {
+      const raw = [
+        {
+          id: 'ev-001',
+          timestamp: '2026-04-19T09:02:00Z',
+          mount: 'shared',
+          page: '/arch/overview',
+          ravn: 'ravn-fjolnir',
+          kind: 'write',
+          message: 'updated key-facts zone',
+        },
+      ];
+      const client = makeClient({ get: vi.fn().mockResolvedValue(raw) });
+      const writes = await buildMimirHttpAdapter(client).mounts.getRecentWrites();
+      expect(writes[0]).toMatchObject({
+        id: 'ev-001',
+        mount: 'shared',
+        page: '/arch/overview',
+        ravn: 'ravn-fjolnir',
+        kind: 'write',
+      });
+    });
+  });
+
+  describe('pages.listSources', () => {
+    it('calls GET /sources without query string when no options', async () => {
+      const client = makeClient({ get: vi.fn().mockResolvedValue([]) });
+      await buildMimirHttpAdapter(client).pages.listSources();
+      expect(client.get).toHaveBeenCalledWith('/sources');
+    });
+
+    it('appends origin_type and mount params when provided', async () => {
+      const client = makeClient({ get: vi.fn().mockResolvedValue([]) });
+      await buildMimirHttpAdapter(client).pages.listSources({ originType: 'web', mountName: 'local' });
+      const call = (client.get as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string;
+      expect(call).toContain('origin_type=web');
+      expect(call).toContain('mount=local');
+    });
+
+    it('maps raw source fields to domain Source', async () => {
+      const raw = [
+        {
+          id: 'src-001',
+          title: 'Arch wiki',
+          origin_type: 'web',
+          origin_url: 'https://wiki.niuu.world/arch',
+          ingested_at: '2026-04-10T08:00:00Z',
+          ingest_agent: 'ravn-fjolnir',
+          compiled_into: ['/arch/overview'],
+          content: 'The Niuu platform uses hexagonal architecture.',
+        },
+      ];
+      const client = makeClient({ get: vi.fn().mockResolvedValue(raw) });
+      const sources = await buildMimirHttpAdapter(client).pages.listSources();
+      expect(sources[0]).toMatchObject({
+        id: 'src-001',
+        title: 'Arch wiki',
+        originType: 'web',
+        originUrl: 'https://wiki.niuu.world/arch',
+        ingestedAt: '2026-04-10T08:00:00Z',
+        ingestAgent: 'ravn-fjolnir',
+        compiledInto: ['/arch/overview'],
+      });
+    });
+  });
+
+  describe('pages.getPageSources', () => {
+    it('calls GET /sources/page with encoded path', async () => {
+      const client = makeClient({ get: vi.fn().mockResolvedValue([]) });
+      await buildMimirHttpAdapter(client).pages.getPageSources('/arch/overview');
+      const call = (client.get as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string;
+      expect(call).toContain('/sources/page');
+      expect(call).toContain('path=%2Farch%2Foverview');
+    });
+
+    it('maps raw source fields for page sources', async () => {
+      const raw = [
+        {
+          id: 'src-002',
+          title: 'ADR-001',
+          origin_type: 'file',
+          origin_path: '/docs/adr/001.md',
+          ingested_at: '2026-04-11T10:30:00Z',
+          ingest_agent: 'ravn-fjolnir',
+          compiled_into: ['/arch/overview'],
+          content: 'We adopt hexagonal architecture.',
+        },
+      ];
+      const client = makeClient({ get: vi.fn().mockResolvedValue(raw) });
+      const sources = await buildMimirHttpAdapter(client).pages.getPageSources('/arch/overview');
+      expect(sources[0]).toMatchObject({
+        id: 'src-002',
+        originType: 'file',
+        originPath: '/docs/adr/001.md',
+        ingestAgent: 'ravn-fjolnir',
+      });
+    });
+  });
 });

--- a/web-next/packages/plugin-mimir/src/adapters/http.test.ts
+++ b/web-next/packages/plugin-mimir/src/adapters/http.test.ts
@@ -421,7 +421,10 @@ describe('buildMimirHttpAdapter', () => {
 
     it('appends origin_type and mount params when provided', async () => {
       const client = makeClient({ get: vi.fn().mockResolvedValue([]) });
-      await buildMimirHttpAdapter(client).pages.listSources({ originType: 'web', mountName: 'local' });
+      await buildMimirHttpAdapter(client).pages.listSources({
+        originType: 'web',
+        mountName: 'local',
+      });
       const call = (client.get as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string;
       expect(call).toContain('origin_type=web');
       expect(call).toContain('mount=local');

--- a/web-next/packages/plugin-mimir/src/ui/PagesView.tsx
+++ b/web-next/packages/plugin-mimir/src/ui/PagesView.tsx
@@ -28,9 +28,9 @@ export function PagesView() {
 
   // Auto-select the first page once data loads.
   useEffect(() => {
-    if (selectedPath !== null) return;
-    const first = allPages[0];
-    if (first) setSelectedPath(first.path);
+    if (selectedPath === null && allPages.length > 0) {
+      setSelectedPath(allPages[0]?.path ?? null);
+    }
   }, [allPages, selectedPath]);
 
   const activePagePath = selectedPath ?? allPages[0]?.path ?? null;

--- a/web-next/packages/plugin-tyr/package.json
+++ b/web-next/packages/plugin-tyr/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@niuulabs/plugin-tyr",
+  "version": "0.0.1",
+  "description": "Tyr plugin — sagas, phases, raids, dispatch queue, workflows",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "dev": "tsup --watch"
+  },
+  "peerDependencies": {
+    "@tanstack/react-query": "^5.62.0",
+    "@tanstack/react-router": "^1.95.0",
+    "react": "^19.0.0"
+  },
+  "dependencies": {
+    "@niuulabs/domain": "workspace:*",
+    "@niuulabs/plugin-sdk": "workspace:*",
+    "@niuulabs/query": "workspace:*",
+    "@niuulabs/ui": "workspace:*",
+    "zod": "^3.24.1"
+  },
+  "devDependencies": {
+    "@tanstack/react-query": "^5.62.0",
+    "@tanstack/react-router": "^1.95.0",
+    "@types/react": "^19.0.7",
+    "react": "^19.0.0",
+    "tsup": "^8.3.5",
+    "typescript": "^5.7.3"
+  }
+}

--- a/web-next/packages/plugin-tyr/src/adapters/http.test.ts
+++ b/web-next/packages/plugin-tyr/src/adapters/http.test.ts
@@ -189,9 +189,7 @@ describe('buildTyrHttpAdapter', () => {
       const client = makeClient();
       client.get.mockResolvedValue(rawSaga);
       await buildTyrHttpAdapter(client).getSaga('00000000-0000-0000-0000-000000000001');
-      expect(client.get).toHaveBeenCalledWith(
-        '/sagas/00000000-0000-0000-0000-000000000001',
-      );
+      expect(client.get).toHaveBeenCalledWith('/sagas/00000000-0000-0000-0000-000000000001');
     });
 
     it('URL-encodes id', async () => {
@@ -273,7 +271,10 @@ describe('buildTyrHttpAdapter', () => {
       const client = makeClient();
       client.post.mockResolvedValue({ session_id: 'sess-1', chat_endpoint: null });
       const result = await buildTyrHttpAdapter(client).spawnPlanSession('spec text', 'my/repo');
-      expect(client.post).toHaveBeenCalledWith('/sagas/plan', { spec: 'spec text', repo: 'my/repo' });
+      expect(client.post).toHaveBeenCalledWith('/sagas/plan', {
+        spec: 'spec text',
+        repo: 'my/repo',
+      });
       expect(result.sessionId).toBe('sess-1');
       expect(result.chatEndpoint).toBeNull();
     });

--- a/web-next/packages/plugin-tyr/src/adapters/http.test.ts
+++ b/web-next/packages/plugin-tyr/src/adapters/http.test.ts
@@ -1,0 +1,583 @@
+/**
+ * HTTP adapter tests — adapted from web/src/modules/tyr/adapters/api/ test files.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  buildTyrHttpAdapter,
+  buildDispatcherHttpAdapter,
+  buildTyrSessionHttpAdapter,
+  buildTrackerHttpAdapter,
+  buildTyrIntegrationHttpAdapter,
+} from './http';
+import type {
+  ITyrService,
+  IDispatcherService,
+  ITyrSessionService,
+  ITrackerBrowserService,
+  ITyrIntegrationService,
+  CommitSagaRequest,
+  CreateIntegrationParams,
+} from '../ports';
+
+// ---------------------------------------------------------------------------
+// Shared mock client factory
+// ---------------------------------------------------------------------------
+
+function makeClient() {
+  return {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Shared raw fixtures
+// ---------------------------------------------------------------------------
+
+const rawSaga = {
+  id: '00000000-0000-0000-0000-000000000001',
+  tracker_id: 'LIN-001',
+  tracker_type: 'linear',
+  slug: 'auth-rewrite',
+  name: 'Auth Rewrite',
+  repos: ['niuulabs/volundr'],
+  feature_branch: 'feat/auth-rewrite',
+  status: 'active',
+  confidence: 72,
+  created_at: '2026-01-01T00:00:00Z',
+  phase_summary: { total: 3, completed: 1 },
+};
+
+const rawRaid = {
+  id: '00000000-0000-0000-0000-000000000002',
+  phase_id: '00000000-0000-0000-0000-000000000010',
+  tracker_id: 'LIN-R1',
+  name: 'Implement JWT refresh',
+  description: 'Add silent token refresh.',
+  acceptance_criteria: ['Refreshes before expiry'],
+  declared_files: ['src/auth/refresh.ts'],
+  estimate_hours: 4,
+  status: 'queued',
+  confidence: 80,
+  session_id: null,
+  reviewer_session_id: null,
+  review_round: 0,
+  branch: null,
+  chronicle_summary: null,
+  retry_count: 0,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+const rawPhase = {
+  id: '00000000-0000-0000-0000-000000000010',
+  saga_id: '00000000-0000-0000-0000-000000000001',
+  tracker_id: 'LIN-M1',
+  number: 1,
+  name: 'Foundation',
+  status: 'active',
+  confidence: 75,
+  raids: [rawRaid],
+};
+
+const rawDispatcherState = {
+  id: '00000000-0000-0000-0000-000000000099',
+  running: true,
+  threshold: 70,
+  max_concurrent_raids: 3,
+  auto_continue: false,
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+const rawSessionInfo = {
+  session_id: 'sess-abc',
+  status: 'running',
+  chronicle_lines: ['line 1', 'line 2'],
+  branch: 'feat/jwt-refresh',
+  confidence: 80,
+  raid_name: 'Implement JWT refresh',
+  saga_name: 'Auth Rewrite',
+};
+
+const rawProject = {
+  id: 'proj-1',
+  name: 'My Project',
+  description: 'A project',
+  status: 'active',
+  url: 'https://linear.app/niuu/proj/1',
+  milestone_count: 3,
+  issue_count: 12,
+};
+
+const rawMilestone = {
+  id: 'ms-1',
+  project_id: 'proj-1',
+  name: 'M1',
+  description: 'First milestone',
+  sort_order: 1,
+  progress: 50,
+};
+
+const rawIssue = {
+  id: 'iss-1',
+  identifier: 'NIU-100',
+  title: 'Fix login bug',
+  description: 'Login broken on Safari',
+  status: 'in_progress',
+  assignee: 'alice',
+  labels: ['bug'],
+  priority: 2,
+  url: 'https://linear.app/niuu/iss/1',
+  milestone_id: 'ms-1',
+};
+
+const rawIntegration = {
+  id: 'int-1',
+  integration_type: 'telegram',
+  adapter: 'TelegramAdapter',
+  credential_name: 'tg-token',
+  enabled: true,
+  status: 'connected',
+  created_at: '2026-01-01T00:00:00Z',
+};
+
+// ---------------------------------------------------------------------------
+// buildTyrHttpAdapter
+// ---------------------------------------------------------------------------
+
+describe('buildTyrHttpAdapter', () => {
+  describe('getSagas', () => {
+    it('calls GET /sagas', async () => {
+      const client = makeClient();
+      client.get.mockResolvedValue([rawSaga]);
+      await buildTyrHttpAdapter(client).getSagas();
+      expect(client.get).toHaveBeenCalledWith('/sagas');
+    });
+
+    it('transforms snake_case to camelCase', async () => {
+      const client = makeClient();
+      client.get.mockResolvedValue([rawSaga]);
+      const result = await buildTyrHttpAdapter(client).getSagas();
+      expect(result[0]).toMatchObject({
+        id: rawSaga.id,
+        trackerId: 'LIN-001',
+        trackerType: 'linear',
+        featureBranch: 'feat/auth-rewrite',
+        phaseSummary: { total: 3, completed: 1 },
+      });
+    });
+
+    it('returns empty array when server returns none', async () => {
+      const client = makeClient();
+      client.get.mockResolvedValue([]);
+      const result = await buildTyrHttpAdapter(client).getSagas();
+      expect(result).toHaveLength(0);
+    });
+
+    it('propagates errors', async () => {
+      const client = makeClient();
+      client.get.mockRejectedValue(new Error('network error'));
+      await expect(buildTyrHttpAdapter(client).getSagas()).rejects.toThrow('network error');
+    });
+  });
+
+  describe('getSaga', () => {
+    it('calls GET /sagas/:id', async () => {
+      const client = makeClient();
+      client.get.mockResolvedValue(rawSaga);
+      await buildTyrHttpAdapter(client).getSaga('00000000-0000-0000-0000-000000000001');
+      expect(client.get).toHaveBeenCalledWith(
+        '/sagas/00000000-0000-0000-0000-000000000001',
+      );
+    });
+
+    it('URL-encodes id', async () => {
+      const client = makeClient();
+      client.get.mockResolvedValue(rawSaga);
+      await buildTyrHttpAdapter(client).getSaga('id with spaces');
+      expect(client.get).toHaveBeenCalledWith('/sagas/id%20with%20spaces');
+    });
+
+    it('returns null when the HTTP client throws', async () => {
+      const client = makeClient();
+      client.get.mockRejectedValue(new Error('not found'));
+      const result = await buildTyrHttpAdapter(client).getSaga('missing');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getPhases', () => {
+    it('calls GET /sagas/:id/phases', async () => {
+      const client = makeClient();
+      client.get.mockResolvedValue([rawPhase]);
+      await buildTyrHttpAdapter(client).getPhases('saga-1');
+      expect(client.get).toHaveBeenCalledWith('/sagas/saga-1/phases');
+    });
+
+    it('transforms phases and nested raids', async () => {
+      const client = makeClient();
+      client.get.mockResolvedValue([rawPhase]);
+      const [phase] = await buildTyrHttpAdapter(client).getPhases('saga-1');
+      expect(phase?.sagaId).toBe('00000000-0000-0000-0000-000000000001');
+      expect(phase?.raids[0]?.phaseId).toBe('00000000-0000-0000-0000-000000000010');
+      expect(phase?.raids[0]?.acceptanceCriteria).toEqual(['Refreshes before expiry']);
+    });
+  });
+
+  describe('commitSaga', () => {
+    const req: CommitSagaRequest = {
+      name: 'Auth Rewrite',
+      slug: 'auth-rewrite',
+      description: 'Rewrite auth layer',
+      repos: ['niuulabs/volundr'],
+      baseBranch: 'main',
+      phases: [
+        {
+          name: 'Phase 1',
+          raids: [
+            {
+              name: 'JWT refresh',
+              description: 'Add silent refresh',
+              acceptanceCriteria: ['Refreshes before expiry'],
+              declaredFiles: ['src/auth/refresh.ts'],
+              estimateHours: 4,
+            },
+          ],
+        },
+      ],
+    };
+
+    it('calls POST /sagas/commit', async () => {
+      const client = makeClient();
+      client.post.mockResolvedValue(rawSaga);
+      await buildTyrHttpAdapter(client).commitSaga(req);
+      expect(client.post).toHaveBeenCalledWith('/sagas/commit', expect.any(Object));
+    });
+
+    it('converts camelCase to snake_case in request body', async () => {
+      const client = makeClient();
+      client.post.mockResolvedValue(rawSaga);
+      await buildTyrHttpAdapter(client).commitSaga(req);
+      const body = client.post.mock.calls[0][1] as Record<string, unknown>;
+      expect(body.base_branch).toBe('main');
+      const phases = body.phases as { raids: { acceptance_criteria: string[] }[] }[];
+      expect(phases[0]?.raids[0]?.acceptance_criteria).toEqual(['Refreshes before expiry']);
+    });
+  });
+
+  describe('spawnPlanSession', () => {
+    it('calls POST /sagas/plan', async () => {
+      const client = makeClient();
+      client.post.mockResolvedValue({ session_id: 'sess-1', chat_endpoint: null });
+      const result = await buildTyrHttpAdapter(client).spawnPlanSession('spec text', 'my/repo');
+      expect(client.post).toHaveBeenCalledWith('/sagas/plan', { spec: 'spec text', repo: 'my/repo' });
+      expect(result.sessionId).toBe('sess-1');
+      expect(result.chatEndpoint).toBeNull();
+    });
+  });
+
+  describe('extractStructure', () => {
+    it('calls POST /sagas/extract-structure', async () => {
+      const client = makeClient();
+      client.post.mockResolvedValue({ found: true, structure: null });
+      await buildTyrHttpAdapter(client).extractStructure('some text');
+      expect(client.post).toHaveBeenCalledWith('/sagas/extract-structure', { text: 'some text' });
+    });
+  });
+
+  describe('interface compliance', () => {
+    it('satisfies ITyrService', () => {
+      const client = makeClient();
+      const svc: ITyrService = buildTyrHttpAdapter(client);
+      expect(typeof svc.getSagas).toBe('function');
+      expect(typeof svc.getSaga).toBe('function');
+      expect(typeof svc.getPhases).toBe('function');
+      expect(typeof svc.createSaga).toBe('function');
+      expect(typeof svc.commitSaga).toBe('function');
+      expect(typeof svc.decompose).toBe('function');
+      expect(typeof svc.spawnPlanSession).toBe('function');
+      expect(typeof svc.extractStructure).toBe('function');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildDispatcherHttpAdapter
+// ---------------------------------------------------------------------------
+
+describe('buildDispatcherHttpAdapter', () => {
+  it('calls GET /dispatcher for state', async () => {
+    const client = makeClient();
+    client.get.mockResolvedValue(rawDispatcherState);
+    await buildDispatcherHttpAdapter(client).getState();
+    expect(client.get).toHaveBeenCalledWith('/dispatcher');
+  });
+
+  it('transforms snake_case dispatcher state', async () => {
+    const client = makeClient();
+    client.get.mockResolvedValue(rawDispatcherState);
+    const state = await buildDispatcherHttpAdapter(client).getState();
+    expect(state).toMatchObject({
+      running: true,
+      threshold: 70,
+      maxConcurrentRaids: 3,
+      autoContinue: false,
+    });
+  });
+
+  it('returns null when dispatcher throws', async () => {
+    const client = makeClient();
+    client.get.mockRejectedValue(new Error('not configured'));
+    const result = await buildDispatcherHttpAdapter(client).getState();
+    expect(result).toBeNull();
+  });
+
+  it('PATCHes running state', async () => {
+    const client = makeClient();
+    client.patch.mockResolvedValue(undefined);
+    await buildDispatcherHttpAdapter(client).setRunning(false);
+    expect(client.patch).toHaveBeenCalledWith('/dispatcher', { running: false });
+  });
+
+  it('PATCHes threshold', async () => {
+    const client = makeClient();
+    client.patch.mockResolvedValue(undefined);
+    await buildDispatcherHttpAdapter(client).setThreshold(80);
+    expect(client.patch).toHaveBeenCalledWith('/dispatcher', { threshold: 80 });
+  });
+
+  it('PATCHes auto_continue', async () => {
+    const client = makeClient();
+    client.patch.mockResolvedValue(undefined);
+    await buildDispatcherHttpAdapter(client).setAutoContinue(true);
+    expect(client.patch).toHaveBeenCalledWith('/dispatcher', { auto_continue: true });
+  });
+
+  it('calls GET /dispatcher/log', async () => {
+    const client = makeClient();
+    client.get.mockResolvedValue(['log line 1', 'log line 2']);
+    const log = await buildDispatcherHttpAdapter(client).getLog();
+    expect(client.get).toHaveBeenCalledWith('/dispatcher/log');
+    expect(log).toEqual(['log line 1', 'log line 2']);
+  });
+
+  it('satisfies IDispatcherService', () => {
+    const client = makeClient();
+    const svc: IDispatcherService = buildDispatcherHttpAdapter(client);
+    expect(typeof svc.getState).toBe('function');
+    expect(typeof svc.setRunning).toBe('function');
+    expect(typeof svc.setThreshold).toBe('function');
+    expect(typeof svc.setAutoContinue).toBe('function');
+    expect(typeof svc.getLog).toBe('function');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildTyrSessionHttpAdapter
+// ---------------------------------------------------------------------------
+
+describe('buildTyrSessionHttpAdapter', () => {
+  it('calls GET /sessions', async () => {
+    const client = makeClient();
+    client.get.mockResolvedValue([rawSessionInfo]);
+    await buildTyrSessionHttpAdapter(client).getSessions();
+    expect(client.get).toHaveBeenCalledWith('/sessions');
+  });
+
+  it('transforms snake_case session info', async () => {
+    const client = makeClient();
+    client.get.mockResolvedValue([rawSessionInfo]);
+    const [session] = await buildTyrSessionHttpAdapter(client).getSessions();
+    expect(session?.sessionId).toBe('sess-abc');
+    expect(session?.chronicleLines).toEqual(['line 1', 'line 2']);
+    expect(session?.raidName).toBe('Implement JWT refresh');
+  });
+
+  it('calls GET /sessions/:id', async () => {
+    const client = makeClient();
+    client.get.mockResolvedValue(rawSessionInfo);
+    await buildTyrSessionHttpAdapter(client).getSession('sess-abc');
+    expect(client.get).toHaveBeenCalledWith('/sessions/sess-abc');
+  });
+
+  it('returns null when session not found', async () => {
+    const client = makeClient();
+    client.get.mockRejectedValue(new Error('404'));
+    const result = await buildTyrSessionHttpAdapter(client).getSession('missing');
+    expect(result).toBeNull();
+  });
+
+  it('calls POST /sessions/:id/approve', async () => {
+    const client = makeClient();
+    client.post.mockResolvedValue(undefined);
+    await buildTyrSessionHttpAdapter(client).approve('sess-abc');
+    expect(client.post).toHaveBeenCalledWith('/sessions/sess-abc/approve', {});
+  });
+
+  it('satisfies ITyrSessionService', () => {
+    const client = makeClient();
+    const svc: ITyrSessionService = buildTyrSessionHttpAdapter(client);
+    expect(typeof svc.getSessions).toBe('function');
+    expect(typeof svc.getSession).toBe('function');
+    expect(typeof svc.approve).toBe('function');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildTrackerHttpAdapter
+// ---------------------------------------------------------------------------
+
+describe('buildTrackerHttpAdapter', () => {
+  it('calls GET /tracker/projects', async () => {
+    const client = makeClient();
+    client.get.mockResolvedValue([rawProject]);
+    await buildTrackerHttpAdapter(client).listProjects();
+    expect(client.get).toHaveBeenCalledWith('/tracker/projects');
+  });
+
+  it('transforms tracker project', async () => {
+    const client = makeClient();
+    client.get.mockResolvedValue([rawProject]);
+    const [project] = await buildTrackerHttpAdapter(client).listProjects();
+    expect(project?.milestoneCount).toBe(3);
+    expect(project?.issueCount).toBe(12);
+  });
+
+  it('calls GET /tracker/projects/:id', async () => {
+    const client = makeClient();
+    client.get.mockResolvedValue(rawProject);
+    await buildTrackerHttpAdapter(client).getProject('proj-1');
+    expect(client.get).toHaveBeenCalledWith('/tracker/projects/proj-1');
+  });
+
+  it('calls GET /tracker/projects/:id/milestones', async () => {
+    const client = makeClient();
+    client.get.mockResolvedValue([rawMilestone]);
+    const [ms] = await buildTrackerHttpAdapter(client).listMilestones('proj-1');
+    expect(client.get).toHaveBeenCalledWith('/tracker/projects/proj-1/milestones');
+    expect(ms?.sortOrder).toBe(1);
+    expect(ms?.projectId).toBe('proj-1');
+  });
+
+  it('calls GET /tracker/projects/:id/issues without milestone filter', async () => {
+    const client = makeClient();
+    client.get.mockResolvedValue([rawIssue]);
+    await buildTrackerHttpAdapter(client).listIssues('proj-1');
+    expect(client.get).toHaveBeenCalledWith('/tracker/projects/proj-1/issues');
+  });
+
+  it('appends milestone_id query param when provided', async () => {
+    const client = makeClient();
+    client.get.mockResolvedValue([rawIssue]);
+    await buildTrackerHttpAdapter(client).listIssues('proj-1', 'ms-1');
+    expect(client.get).toHaveBeenCalledWith('/tracker/projects/proj-1/issues?milestone_id=ms-1');
+  });
+
+  it('transforms tracker issue camelCase', async () => {
+    const client = makeClient();
+    client.get.mockResolvedValue([rawIssue]);
+    const [issue] = await buildTrackerHttpAdapter(client).listIssues('proj-1');
+    expect(issue?.milestoneId).toBe('ms-1');
+  });
+
+  it('calls POST /tracker/import for importProject', async () => {
+    const client = makeClient();
+    client.post.mockResolvedValue(rawSaga);
+    await buildTrackerHttpAdapter(client).importProject('proj-1', ['niuulabs/volundr'], 'main');
+    expect(client.post).toHaveBeenCalledWith('/tracker/import', {
+      project_id: 'proj-1',
+      repos: ['niuulabs/volundr'],
+      base_branch: 'main',
+    });
+  });
+
+  it('satisfies ITrackerBrowserService', () => {
+    const client = makeClient();
+    const svc: ITrackerBrowserService = buildTrackerHttpAdapter(client);
+    expect(typeof svc.listProjects).toBe('function');
+    expect(typeof svc.getProject).toBe('function');
+    expect(typeof svc.listMilestones).toBe('function');
+    expect(typeof svc.listIssues).toBe('function');
+    expect(typeof svc.importProject).toBe('function');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildTyrIntegrationHttpAdapter
+// ---------------------------------------------------------------------------
+
+describe('buildTyrIntegrationHttpAdapter', () => {
+  it('calls GET /integrations', async () => {
+    const client = makeClient();
+    client.get.mockResolvedValue([rawIntegration]);
+    await buildTyrIntegrationHttpAdapter(client).listIntegrations();
+    expect(client.get).toHaveBeenCalledWith('/integrations');
+  });
+
+  it('transforms integration snake_case', async () => {
+    const client = makeClient();
+    client.get.mockResolvedValue([rawIntegration]);
+    const [integration] = await buildTyrIntegrationHttpAdapter(client).listIntegrations();
+    expect(integration?.integrationType).toBe('telegram');
+    expect(integration?.credentialName).toBe('tg-token');
+  });
+
+  it('creates integration with snake_case body', async () => {
+    const client = makeClient();
+    client.post.mockResolvedValue(rawIntegration);
+    const params: CreateIntegrationParams = {
+      integrationType: 'telegram',
+      adapter: 'TelegramAdapter',
+      credentialName: 'tg-token',
+      credentialValue: 'secret',
+      config: { chat_id: '123' },
+    };
+    await buildTyrIntegrationHttpAdapter(client).createIntegration(params);
+    const body = client.post.mock.calls[0][1] as Record<string, unknown>;
+    expect(body.integration_type).toBe('telegram');
+    expect(body.credential_name).toBe('tg-token');
+    expect(body.credential_value).toBe('secret');
+  });
+
+  it('calls DELETE /integrations/:id', async () => {
+    const client = makeClient();
+    client.delete.mockResolvedValue(undefined);
+    await buildTyrIntegrationHttpAdapter(client).deleteIntegration('int-1');
+    expect(client.delete).toHaveBeenCalledWith('/integrations/int-1');
+  });
+
+  it('calls PATCH for toggle', async () => {
+    const client = makeClient();
+    client.patch.mockResolvedValue(rawIntegration);
+    await buildTyrIntegrationHttpAdapter(client).toggleIntegration('int-1', false);
+    expect(client.patch).toHaveBeenCalledWith('/integrations/int-1', { enabled: false });
+  });
+
+  it('calls POST /integrations/:id/test', async () => {
+    const client = makeClient();
+    client.post.mockResolvedValue({ success: true, message: 'ok' });
+    const result = await buildTyrIntegrationHttpAdapter(client).testConnection('int-1');
+    expect(result.success).toBe(true);
+  });
+
+  it('calls GET /integrations/telegram/setup', async () => {
+    const client = makeClient();
+    client.get.mockResolvedValue({ deeplink: 'https://t.me/bot', token: 'tok' });
+    const result = await buildTyrIntegrationHttpAdapter(client).getTelegramSetup();
+    expect(result.deeplink).toBe('https://t.me/bot');
+  });
+
+  it('satisfies ITyrIntegrationService', () => {
+    const client = makeClient();
+    const svc: ITyrIntegrationService = buildTyrIntegrationHttpAdapter(client);
+    expect(typeof svc.listIntegrations).toBe('function');
+    expect(typeof svc.createIntegration).toBe('function');
+    expect(typeof svc.deleteIntegration).toBe('function');
+    expect(typeof svc.toggleIntegration).toBe('function');
+    expect(typeof svc.testConnection).toBe('function');
+    expect(typeof svc.getTelegramSetup).toBe('function');
+  });
+});

--- a/web-next/packages/plugin-tyr/src/adapters/http.ts
+++ b/web-next/packages/plugin-tyr/src/adapters/http.ts
@@ -1,0 +1,514 @@
+/**
+ * HTTP adapters for all Tyr ports.
+ *
+ * Adapted from web/src/modules/tyr/adapters/api/
+ * Translates snake_case server responses to camelCase domain types.
+ *
+ * All factory functions accept an ApiClient structurally compatible with
+ * @niuulabs/query (get / post / put / patch / delete methods).
+ */
+
+import type { ApiClient } from '@niuulabs/query';
+import type {
+  ITyrService,
+  IDispatcherService,
+  ITyrSessionService,
+  ITrackerBrowserService,
+  ITyrIntegrationService,
+  CommitSagaRequest,
+  PlanSession,
+  ExtractedStructure,
+  PhaseSpec,
+  IntegrationConnection,
+  CreateIntegrationParams,
+  ConnectionTestResult,
+  TelegramSetupResult,
+} from '../ports';
+import type { Saga, Phase, Raid } from '../domain/saga';
+import type { DispatcherState } from '../domain/dispatcher';
+import type { SessionInfo } from '../domain/session';
+import type { TrackerProject, TrackerMilestone, TrackerIssue } from '../domain/tracker';
+
+// ---------------------------------------------------------------------------
+// Raw server types (snake_case)
+// ---------------------------------------------------------------------------
+
+interface RawSaga {
+  id: string;
+  tracker_id: string;
+  tracker_type: string;
+  slug: string;
+  name: string;
+  repos: string[];
+  feature_branch: string;
+  status: string;
+  confidence: number;
+  created_at: string;
+  phase_summary: {
+    total: number;
+    completed: number;
+  };
+}
+
+interface RawRaid {
+  id: string;
+  phase_id: string;
+  tracker_id: string;
+  name: string;
+  description: string;
+  acceptance_criteria: string[];
+  declared_files: string[];
+  estimate_hours: number | null;
+  status: string;
+  confidence: number;
+  session_id: string | null;
+  reviewer_session_id: string | null;
+  review_round: number;
+  branch: string | null;
+  chronicle_summary: string | null;
+  retry_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+interface RawPhase {
+  id: string;
+  saga_id: string;
+  tracker_id: string;
+  number: number;
+  name: string;
+  status: string;
+  confidence: number;
+  raids: RawRaid[];
+}
+
+interface RawDispatcherState {
+  id: string;
+  running: boolean;
+  threshold: number;
+  max_concurrent_raids: number;
+  auto_continue: boolean;
+  updated_at: string;
+}
+
+interface RawSessionInfo {
+  session_id: string;
+  status: string;
+  chronicle_lines: string[];
+  branch: string | null;
+  confidence: number;
+  raid_name: string;
+  saga_name: string;
+}
+
+interface RawTrackerProject {
+  id: string;
+  name: string;
+  description: string;
+  status: string;
+  url: string;
+  milestone_count: number;
+  issue_count: number;
+}
+
+interface RawTrackerMilestone {
+  id: string;
+  project_id: string;
+  name: string;
+  description: string;
+  sort_order: number;
+  progress: number;
+}
+
+interface RawTrackerIssue {
+  id: string;
+  identifier: string;
+  title: string;
+  description: string;
+  status: string;
+  assignee: string | null;
+  labels: string[];
+  priority: number;
+  url: string;
+  milestone_id: string | null;
+}
+
+interface RawIntegrationConnection {
+  id: string;
+  integration_type: string;
+  adapter: string;
+  credential_name: string;
+  enabled: boolean;
+  status: string;
+  created_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Transform functions
+// ---------------------------------------------------------------------------
+
+function toRaid(raw: RawRaid): Raid {
+  return {
+    id: raw.id,
+    phaseId: raw.phase_id,
+    trackerId: raw.tracker_id,
+    name: raw.name,
+    description: raw.description,
+    acceptanceCriteria: raw.acceptance_criteria,
+    declaredFiles: raw.declared_files,
+    estimateHours: raw.estimate_hours,
+    status: raw.status as Raid['status'],
+    confidence: raw.confidence,
+    sessionId: raw.session_id,
+    reviewerSessionId: raw.reviewer_session_id,
+    reviewRound: raw.review_round,
+    branch: raw.branch,
+    chronicleSummary: raw.chronicle_summary,
+    retryCount: raw.retry_count,
+    createdAt: raw.created_at,
+    updatedAt: raw.updated_at,
+  };
+}
+
+function toPhase(raw: RawPhase): Phase {
+  return {
+    id: raw.id,
+    sagaId: raw.saga_id,
+    trackerId: raw.tracker_id,
+    number: raw.number,
+    name: raw.name,
+    status: raw.status as Phase['status'],
+    confidence: raw.confidence,
+    raids: raw.raids.map(toRaid),
+  };
+}
+
+function toSaga(raw: RawSaga): Saga {
+  return {
+    id: raw.id,
+    trackerId: raw.tracker_id,
+    trackerType: raw.tracker_type,
+    slug: raw.slug,
+    name: raw.name,
+    repos: raw.repos,
+    featureBranch: raw.feature_branch,
+    status: raw.status as Saga['status'],
+    confidence: raw.confidence,
+    createdAt: raw.created_at,
+    phaseSummary: {
+      total: raw.phase_summary.total,
+      completed: raw.phase_summary.completed,
+    },
+  };
+}
+
+function toDispatcherState(raw: RawDispatcherState): DispatcherState {
+  return {
+    id: raw.id,
+    running: raw.running,
+    threshold: raw.threshold,
+    maxConcurrentRaids: raw.max_concurrent_raids,
+    autoContinue: raw.auto_continue,
+    updatedAt: raw.updated_at,
+  };
+}
+
+function toSessionInfo(raw: RawSessionInfo): SessionInfo {
+  return {
+    sessionId: raw.session_id,
+    status: raw.status as SessionInfo['status'],
+    chronicleLines: raw.chronicle_lines,
+    branch: raw.branch,
+    confidence: raw.confidence,
+    raidName: raw.raid_name,
+    sagaName: raw.saga_name,
+  };
+}
+
+function toTrackerProject(raw: RawTrackerProject): TrackerProject {
+  return {
+    id: raw.id,
+    name: raw.name,
+    description: raw.description,
+    status: raw.status,
+    url: raw.url,
+    milestoneCount: raw.milestone_count,
+    issueCount: raw.issue_count,
+  };
+}
+
+function toTrackerMilestone(raw: RawTrackerMilestone): TrackerMilestone {
+  return {
+    id: raw.id,
+    projectId: raw.project_id,
+    name: raw.name,
+    description: raw.description,
+    sortOrder: raw.sort_order,
+    progress: raw.progress,
+  };
+}
+
+function toTrackerIssue(raw: RawTrackerIssue): TrackerIssue {
+  return {
+    id: raw.id,
+    identifier: raw.identifier,
+    title: raw.title,
+    description: raw.description,
+    status: raw.status,
+    assignee: raw.assignee,
+    labels: raw.labels,
+    priority: raw.priority,
+    url: raw.url,
+    milestoneId: raw.milestone_id,
+  };
+}
+
+function toIntegrationConnection(raw: RawIntegrationConnection): IntegrationConnection {
+  return {
+    id: raw.id,
+    integrationType: raw.integration_type,
+    adapter: raw.adapter,
+    credentialName: raw.credential_name,
+    enabled: raw.enabled,
+    status: raw.status,
+    createdAt: raw.created_at,
+  };
+}
+
+function toCommitRequestBody(req: CommitSagaRequest): Record<string, unknown> {
+  return {
+    name: req.name,
+    slug: req.slug,
+    description: req.description,
+    repos: req.repos,
+    base_branch: req.baseBranch,
+    phases: req.phases.map((p) => ({
+      name: p.name,
+      raids: p.raids.map((r) => ({
+        name: r.name,
+        description: r.description,
+        acceptance_criteria: r.acceptanceCriteria,
+        declared_files: r.declaredFiles,
+        estimate_hours: r.estimateHours,
+      })),
+    })),
+    transcript: req.transcript,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Factory functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Build an ITyrService backed by the Tyr REST API.
+ *
+ * @param client - HTTP client scoped to the Tyr sagas base path.
+ */
+export function buildTyrHttpAdapter(client: ApiClient): ITyrService {
+  return {
+    async getSagas() {
+      const raw = await client.get<RawSaga[]>('/sagas');
+      return raw.map(toSaga);
+    },
+
+    async getSaga(id: string) {
+      try {
+        const raw = await client.get<RawSaga>(`/sagas/${encodeURIComponent(id)}`);
+        return toSaga(raw);
+      } catch {
+        return null;
+      }
+    },
+
+    async getPhases(sagaId: string) {
+      const raw = await client.get<RawPhase[]>(`/sagas/${encodeURIComponent(sagaId)}/phases`);
+      return raw.map(toPhase);
+    },
+
+    async createSaga(spec: string, repo: string) {
+      const raw = await client.post<RawSaga>('/sagas', { spec, repo });
+      return toSaga(raw);
+    },
+
+    async commitSaga(request: CommitSagaRequest) {
+      const raw = await client.post<RawSaga>('/sagas/commit', toCommitRequestBody(request));
+      return toSaga(raw);
+    },
+
+    async decompose(spec: string, repo: string) {
+      const raw = await client.post<RawPhase[]>('/sagas/decompose', { spec, repo });
+      return raw.map(toPhase);
+    },
+
+    async spawnPlanSession(spec: string, repo: string) {
+      const raw = await client.post<{ session_id: string; chat_endpoint: string | null }>(
+        '/sagas/plan',
+        { spec, repo },
+      );
+      return { sessionId: raw.session_id, chatEndpoint: raw.chat_endpoint } satisfies PlanSession;
+    },
+
+    async extractStructure(text: string) {
+      const raw = await client.post<{
+        found: boolean;
+        structure: { name: string; phases: PhaseSpec[] } | null;
+      }>('/sagas/extract-structure', { text });
+      return raw satisfies ExtractedStructure;
+    },
+  };
+}
+
+/**
+ * Build an IDispatcherService backed by the Tyr dispatcher API.
+ *
+ * @param client - HTTP client scoped to the dispatcher base path.
+ */
+export function buildDispatcherHttpAdapter(client: ApiClient): IDispatcherService {
+  return {
+    async getState() {
+      try {
+        const raw = await client.get<RawDispatcherState>('/dispatcher');
+        return toDispatcherState(raw);
+      } catch {
+        return null;
+      }
+    },
+
+    async setRunning(running: boolean) {
+      await client.patch<void>('/dispatcher', { running });
+    },
+
+    async setThreshold(threshold: number) {
+      await client.patch<void>('/dispatcher', { threshold });
+    },
+
+    async setAutoContinue(autoContinue: boolean) {
+      await client.patch<void>('/dispatcher', { auto_continue: autoContinue });
+    },
+
+    async getLog() {
+      return client.get<string[]>('/dispatcher/log');
+    },
+  };
+}
+
+/**
+ * Build an ITyrSessionService backed by the Tyr sessions API.
+ *
+ * @param client - HTTP client scoped to the sessions base path.
+ */
+export function buildTyrSessionHttpAdapter(client: ApiClient): ITyrSessionService {
+  return {
+    async getSessions() {
+      const raw = await client.get<RawSessionInfo[]>('/sessions');
+      return raw.map(toSessionInfo);
+    },
+
+    async getSession(id: string) {
+      try {
+        const raw = await client.get<RawSessionInfo>(`/sessions/${encodeURIComponent(id)}`);
+        return toSessionInfo(raw);
+      } catch {
+        return null;
+      }
+    },
+
+    async approve(sessionId: string) {
+      await client.post<void>(`/sessions/${encodeURIComponent(sessionId)}/approve`, {});
+    },
+  };
+}
+
+/**
+ * Build an ITrackerBrowserService backed by the Tyr tracker API.
+ *
+ * @param client - HTTP client scoped to the tracker base path.
+ */
+export function buildTrackerHttpAdapter(client: ApiClient): ITrackerBrowserService {
+  return {
+    async listProjects() {
+      const raw = await client.get<RawTrackerProject[]>('/tracker/projects');
+      return raw.map(toTrackerProject);
+    },
+
+    async getProject(projectId: string) {
+      const raw = await client.get<RawTrackerProject>(
+        `/tracker/projects/${encodeURIComponent(projectId)}`,
+      );
+      return toTrackerProject(raw);
+    },
+
+    async listMilestones(projectId: string) {
+      const raw = await client.get<RawTrackerMilestone[]>(
+        `/tracker/projects/${encodeURIComponent(projectId)}/milestones`,
+      );
+      return raw.map(toTrackerMilestone);
+    },
+
+    async listIssues(projectId: string, milestoneId?: string) {
+      const query = milestoneId ? `?milestone_id=${encodeURIComponent(milestoneId)}` : '';
+      const raw = await client.get<RawTrackerIssue[]>(
+        `/tracker/projects/${encodeURIComponent(projectId)}/issues${query}`,
+      );
+      return raw.map(toTrackerIssue);
+    },
+
+    async importProject(projectId: string, repos: string[], baseBranch?: string) {
+      const raw = await client.post<RawSaga>('/tracker/import', {
+        project_id: projectId,
+        repos,
+        base_branch: baseBranch,
+      });
+      return toSaga(raw);
+    },
+  };
+}
+
+/**
+ * Build an ITyrIntegrationService backed by the Tyr integrations API.
+ *
+ * @param client - HTTP client scoped to the integrations base path.
+ */
+export function buildTyrIntegrationHttpAdapter(client: ApiClient): ITyrIntegrationService {
+  return {
+    async listIntegrations() {
+      const raw = await client.get<RawIntegrationConnection[]>('/integrations');
+      return raw.map(toIntegrationConnection);
+    },
+
+    async createIntegration(params: CreateIntegrationParams) {
+      const raw = await client.post<RawIntegrationConnection>('/integrations', {
+        integration_type: params.integrationType,
+        adapter: params.adapter,
+        credential_name: params.credentialName,
+        credential_value: params.credentialValue,
+        config: params.config,
+      });
+      return toIntegrationConnection(raw);
+    },
+
+    async deleteIntegration(id: string) {
+      await client.delete<void>(`/integrations/${encodeURIComponent(id)}`);
+    },
+
+    async toggleIntegration(id: string, enabled: boolean) {
+      const raw = await client.patch<RawIntegrationConnection>(
+        `/integrations/${encodeURIComponent(id)}`,
+        { enabled },
+      );
+      return toIntegrationConnection(raw);
+    },
+
+    async testConnection(id: string) {
+      return client.post<ConnectionTestResult>(
+        `/integrations/${encodeURIComponent(id)}/test`,
+        {},
+      );
+    },
+
+    async getTelegramSetup() {
+      return client.get<TelegramSetupResult>('/integrations/telegram/setup');
+    },
+  };
+}

--- a/web-next/packages/plugin-tyr/src/adapters/http.ts
+++ b/web-next/packages/plugin-tyr/src/adapters/http.ts
@@ -501,10 +501,7 @@ export function buildTyrIntegrationHttpAdapter(client: ApiClient): ITyrIntegrati
     },
 
     async testConnection(id: string) {
-      return client.post<ConnectionTestResult>(
-        `/integrations/${encodeURIComponent(id)}/test`,
-        {},
-      );
+      return client.post<ConnectionTestResult>(`/integrations/${encodeURIComponent(id)}/test`, {});
     },
 
     async getTelegramSetup() {

--- a/web-next/packages/plugin-tyr/src/adapters/mock.test.ts
+++ b/web-next/packages/plugin-tyr/src/adapters/mock.test.ts
@@ -199,7 +199,7 @@ describe('createMockTrackerService', () => {
   it('listIssues returns issues for project', async () => {
     const svc = createMockTrackerService();
     const issues = await svc.listIssues('proj-niuu-core');
-    expect(Array.isArray(issues)).toBe(true);
+    expect(issues.length).toBeGreaterThan(0);
   });
 
   it('importProject creates a saga', async () => {

--- a/web-next/packages/plugin-tyr/src/adapters/mock.test.ts
+++ b/web-next/packages/plugin-tyr/src/adapters/mock.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createMockTyrService,
+  createMockDispatcherService,
+  createMockTyrSessionService,
+  createMockTrackerService,
+  createMockTyrIntegrationService,
+} from './mock';
+
+// ---------------------------------------------------------------------------
+// createMockTyrService
+// ---------------------------------------------------------------------------
+
+describe('createMockTyrService', () => {
+  it('returns 3 seed sagas', async () => {
+    const svc = createMockTyrService();
+    const sagas = await svc.getSagas();
+    expect(sagas).toHaveLength(3);
+  });
+
+  it('getSaga returns correct saga', async () => {
+    const svc = createMockTyrService();
+    const saga = await svc.getSaga('00000000-0000-0000-0000-000000000001');
+    expect(saga?.name).toBe('Auth Rewrite');
+    expect(saga?.status).toBe('active');
+  });
+
+  it('getSaga returns null for unknown id', async () => {
+    const svc = createMockTyrService();
+    const result = await svc.getSaga('does-not-exist');
+    expect(result).toBeNull();
+  });
+
+  it('getPhases returns phases for first saga', async () => {
+    const svc = createMockTyrService();
+    const phases = await svc.getPhases('00000000-0000-0000-0000-000000000001');
+    expect(phases).toHaveLength(3);
+    expect(phases[0]?.name).toBe('Phase 1: Foundation');
+  });
+
+  it('getPhases returns empty array for unknown saga', async () => {
+    const svc = createMockTyrService();
+    const phases = await svc.getPhases('saga-does-not-exist');
+    expect(phases).toHaveLength(0);
+  });
+
+  it('createSaga adds a new saga', async () => {
+    const svc = createMockTyrService();
+    const newSaga = await svc.createSaga('My new feature', 'niuulabs/volundr');
+    expect(newSaga.name).toBe('My new feature');
+    expect(newSaga.status).toBe('active');
+    const all = await svc.getSagas();
+    expect(all).toHaveLength(4);
+  });
+
+  it('commitSaga creates a saga from request', async () => {
+    const svc = createMockTyrService();
+    const saga = await svc.commitSaga({
+      name: 'Committed Saga',
+      slug: 'committed-saga',
+      description: 'A committed saga',
+      repos: ['niuulabs/volundr'],
+      baseBranch: 'main',
+      phases: [{ name: 'Phase 1', raids: [] }],
+    });
+    expect(saga.name).toBe('Committed Saga');
+    expect(saga.phaseSummary.total).toBe(1);
+  });
+
+  it('spawnPlanSession returns a session id', async () => {
+    const svc = createMockTyrService();
+    const session = await svc.spawnPlanSession('spec', 'repo');
+    expect(session.sessionId).toBeTruthy();
+    expect(session.chatEndpoint).toBeNull();
+  });
+
+  it('extractStructure returns found: false by default', async () => {
+    const svc = createMockTyrService();
+    const result = await svc.extractStructure('some text');
+    expect(result.found).toBe(false);
+    expect(result.structure).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createMockDispatcherService
+// ---------------------------------------------------------------------------
+
+describe('createMockDispatcherService', () => {
+  it('returns initial running state', async () => {
+    const svc = createMockDispatcherService();
+    const state = await svc.getState();
+    expect(state?.running).toBe(true);
+    expect(state?.threshold).toBe(70);
+    expect(state?.maxConcurrentRaids).toBe(3);
+  });
+
+  it('setRunning toggles running state', async () => {
+    const svc = createMockDispatcherService();
+    await svc.setRunning(false);
+    const state = await svc.getState();
+    expect(state?.running).toBe(false);
+  });
+
+  it('setThreshold updates threshold', async () => {
+    const svc = createMockDispatcherService();
+    await svc.setThreshold(85);
+    const state = await svc.getState();
+    expect(state?.threshold).toBe(85);
+  });
+
+  it('setAutoContinue updates autoContinue', async () => {
+    const svc = createMockDispatcherService();
+    await svc.setAutoContinue(true);
+    const state = await svc.getState();
+    expect(state?.autoContinue).toBe(true);
+  });
+
+  it('getLog returns non-empty log', async () => {
+    const svc = createMockDispatcherService();
+    const log = await svc.getLog();
+    expect(log.length).toBeGreaterThan(0);
+  });
+
+  it('setRunning appends to log', async () => {
+    const svc = createMockDispatcherService();
+    await svc.setRunning(false);
+    const log = await svc.getLog();
+    expect(log.some((l) => l.includes('running'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createMockTyrSessionService
+// ---------------------------------------------------------------------------
+
+describe('createMockTyrSessionService', () => {
+  it('returns 2 seed sessions', async () => {
+    const svc = createMockTyrSessionService();
+    const sessions = await svc.getSessions();
+    expect(sessions).toHaveLength(2);
+  });
+
+  it('getSession returns correct session', async () => {
+    const svc = createMockTyrSessionService();
+    const session = await svc.getSession('sess-001');
+    expect(session?.raidName).toBe('Implement OIDC flow');
+    expect(session?.status).toBe('complete');
+  });
+
+  it('getSession returns null for unknown id', async () => {
+    const svc = createMockTyrSessionService();
+    const result = await svc.getSession('does-not-exist');
+    expect(result).toBeNull();
+  });
+
+  it('approve changes session status to approved', async () => {
+    const svc = createMockTyrSessionService();
+    await svc.approve('sess-002');
+    const session = await svc.getSession('sess-002');
+    expect(session?.status).toBe('approved');
+  });
+
+  it('approve on unknown session does not throw', async () => {
+    const svc = createMockTyrSessionService();
+    await expect(svc.approve('no-such-session')).resolves.not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createMockTrackerService
+// ---------------------------------------------------------------------------
+
+describe('createMockTrackerService', () => {
+  it('returns 2 seed projects', async () => {
+    const svc = createMockTrackerService();
+    const projects = await svc.listProjects();
+    expect(projects).toHaveLength(2);
+  });
+
+  it('getProject returns known project', async () => {
+    const svc = createMockTrackerService();
+    const project = await svc.getProject('proj-niuu-core');
+    expect(project.name).toBe('Niuu Core');
+    expect(project.milestoneCount).toBe(8);
+  });
+
+  it('getProject throws for unknown project', async () => {
+    const svc = createMockTrackerService();
+    await expect(svc.getProject('unknown')).rejects.toThrow();
+  });
+
+  it('listMilestones filters by projectId', async () => {
+    const svc = createMockTrackerService();
+    const milestones = await svc.listMilestones('proj-niuu-core');
+    expect(milestones.every((m) => m.projectId === 'proj-niuu-core')).toBe(true);
+  });
+
+  it('listIssues returns issues for project', async () => {
+    const svc = createMockTrackerService();
+    const issues = await svc.listIssues('proj-niuu-core');
+    expect(Array.isArray(issues)).toBe(true);
+  });
+
+  it('importProject creates a saga', async () => {
+    const svc = createMockTrackerService();
+    const saga = await svc.importProject('proj-niuu-core', ['niuulabs/volundr']);
+    expect(saga.name).toBe('Niuu Core');
+    expect(saga.repos).toEqual(['niuulabs/volundr']);
+    expect(saga.status).toBe('active');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createMockTyrIntegrationService
+// ---------------------------------------------------------------------------
+
+describe('createMockTyrIntegrationService', () => {
+  it('returns 2 seed integrations', async () => {
+    const svc = createMockTyrIntegrationService();
+    const integrations = await svc.listIntegrations();
+    expect(integrations).toHaveLength(2);
+  });
+
+  it('createIntegration adds to list', async () => {
+    const svc = createMockTyrIntegrationService();
+    await svc.createIntegration({
+      integrationType: 'slack',
+      adapter: 'SlackAdapter',
+      credentialName: 'slack-token',
+      credentialValue: 'xoxb-secret',
+      config: {},
+    });
+    const integrations = await svc.listIntegrations();
+    expect(integrations).toHaveLength(3);
+  });
+
+  it('deleteIntegration removes from list', async () => {
+    const svc = createMockTyrIntegrationService();
+    await svc.deleteIntegration('int-linear');
+    const integrations = await svc.listIntegrations();
+    expect(integrations.find((i) => i.id === 'int-linear')).toBeUndefined();
+  });
+
+  it('toggleIntegration updates enabled flag', async () => {
+    const svc = createMockTyrIntegrationService();
+    const updated = await svc.toggleIntegration('int-linear', false);
+    expect(updated.enabled).toBe(false);
+  });
+
+  it('toggleIntegration throws for unknown id', async () => {
+    const svc = createMockTyrIntegrationService();
+    await expect(svc.toggleIntegration('no-such', true)).rejects.toThrow();
+  });
+
+  it('testConnection returns success', async () => {
+    const svc = createMockTyrIntegrationService();
+    const result = await svc.testConnection('int-linear');
+    expect(result.success).toBe(true);
+  });
+
+  it('getTelegramSetup returns deeplink', async () => {
+    const svc = createMockTyrIntegrationService();
+    const setup = await svc.getTelegramSetup();
+    expect(setup.deeplink).toBeTruthy();
+    expect(setup.token).toBeTruthy();
+  });
+});

--- a/web-next/packages/plugin-tyr/src/adapters/mock.ts
+++ b/web-next/packages/plugin-tyr/src/adapters/mock.ts
@@ -1,0 +1,506 @@
+/**
+ * Mock adapters for all Tyr ports.
+ *
+ * Seeded with representative data mirroring the Tyr backend's test fixtures.
+ * Each factory returns an in-memory implementation suitable for tests and
+ * local development without a running backend.
+ */
+
+import type {
+  ITyrService,
+  IDispatcherService,
+  ITyrSessionService,
+  ITrackerBrowserService,
+  ITyrIntegrationService,
+  CommitSagaRequest,
+  PlanSession,
+  ExtractedStructure,
+  IntegrationConnection,
+  CreateIntegrationParams,
+  ConnectionTestResult,
+  TelegramSetupResult,
+} from '../ports';
+import type { Saga, Phase, Raid } from '../domain/saga';
+import type { DispatcherState } from '../domain/dispatcher';
+import type { SessionInfo } from '../domain/session';
+import type { TrackerProject, TrackerMilestone, TrackerIssue } from '../domain/tracker';
+
+// ---------------------------------------------------------------------------
+// Seed data
+// ---------------------------------------------------------------------------
+
+const SEED_SAGAS: Saga[] = [
+  {
+    id: '00000000-0000-0000-0000-000000000001',
+    trackerId: 'NIU-500',
+    trackerType: 'linear',
+    slug: 'auth-rewrite',
+    name: 'Auth Rewrite',
+    repos: ['niuulabs/volundr'],
+    featureBranch: 'feat/auth-rewrite',
+    status: 'active',
+    confidence: 82,
+    createdAt: '2026-01-10T09:00:00Z',
+    phaseSummary: { total: 3, completed: 1 },
+  },
+  {
+    id: '00000000-0000-0000-0000-000000000002',
+    trackerId: 'NIU-520',
+    trackerType: 'linear',
+    slug: 'plugin-ravn',
+    name: 'Plugin Ravn Scaffold',
+    repos: ['niuulabs/volundr'],
+    featureBranch: 'feat/plugin-ravn',
+    status: 'complete',
+    confidence: 95,
+    createdAt: '2026-01-05T08:00:00Z',
+    phaseSummary: { total: 2, completed: 2 },
+  },
+  {
+    id: '00000000-0000-0000-0000-000000000003',
+    trackerId: 'NIU-600',
+    trackerType: 'linear',
+    slug: 'observatory-topology',
+    name: 'Observatory Topology Canvas',
+    repos: ['niuulabs/volundr'],
+    featureBranch: 'feat/topology-canvas',
+    status: 'failed',
+    confidence: 30,
+    createdAt: '2026-01-15T10:00:00Z',
+    phaseSummary: { total: 4, completed: 0 },
+  },
+];
+
+const SEED_RAIDS: Raid[] = [
+  {
+    id: '00000000-0000-0000-0000-000000000010',
+    phaseId: '00000000-0000-0000-0000-000000000100',
+    trackerId: 'NIU-501',
+    name: 'Implement OIDC flow',
+    description: 'Add OIDC login via Keycloak.',
+    acceptanceCriteria: ['Users can log in with SSO', 'Token refreshes silently'],
+    declaredFiles: ['src/auth/oidc.ts', 'src/auth/refresh.ts'],
+    estimateHours: 8,
+    status: 'merged',
+    confidence: 90,
+    sessionId: 'sess-001',
+    reviewerSessionId: null,
+    reviewRound: 1,
+    branch: 'feat/auth-rewrite',
+    chronicleSummary: 'Implemented OIDC flow with silent refresh.',
+    retryCount: 0,
+    createdAt: '2026-01-10T09:00:00Z',
+    updatedAt: '2026-01-12T14:00:00Z',
+  },
+  {
+    id: '00000000-0000-0000-0000-000000000011',
+    phaseId: '00000000-0000-0000-0000-000000000101',
+    trackerId: 'NIU-502',
+    name: 'Add PAT generation',
+    description: 'Personal access tokens for headless dispatch.',
+    acceptanceCriteria: ['PATs can be created and revoked', 'Envoy validates PATs'],
+    declaredFiles: ['src/niuu/pat.ts'],
+    estimateHours: 4,
+    status: 'running',
+    confidence: 65,
+    sessionId: 'sess-002',
+    reviewerSessionId: null,
+    reviewRound: 0,
+    branch: 'feat/auth-rewrite',
+    chronicleSummary: null,
+    retryCount: 0,
+    createdAt: '2026-01-13T09:00:00Z',
+    updatedAt: '2026-01-13T11:00:00Z',
+  },
+];
+
+const SEED_PHASES: Phase[] = [
+  {
+    id: '00000000-0000-0000-0000-000000000100',
+    sagaId: '00000000-0000-0000-0000-000000000001',
+    trackerId: 'NIU-M1',
+    number: 1,
+    name: 'Phase 1: Foundation',
+    status: 'complete',
+    confidence: 90,
+    raids: [SEED_RAIDS[0]!],
+  },
+  {
+    id: '00000000-0000-0000-0000-000000000101',
+    sagaId: '00000000-0000-0000-0000-000000000001',
+    trackerId: 'NIU-M2',
+    number: 2,
+    name: 'Phase 2: PAT Support',
+    status: 'active',
+    confidence: 65,
+    raids: [SEED_RAIDS[1]!],
+  },
+  {
+    id: '00000000-0000-0000-0000-000000000102',
+    sagaId: '00000000-0000-0000-0000-000000000001',
+    trackerId: 'NIU-M3',
+    number: 3,
+    name: 'Phase 3: Hardening',
+    status: 'pending',
+    confidence: 50,
+    raids: [],
+  },
+];
+
+const SEED_DISPATCHER_STATE: DispatcherState = {
+  id: '00000000-0000-0000-0000-000000000999',
+  running: true,
+  threshold: 70,
+  maxConcurrentRaids: 3,
+  autoContinue: false,
+  updatedAt: '2026-01-13T11:00:00Z',
+};
+
+const SEED_SESSIONS: SessionInfo[] = [
+  {
+    sessionId: 'sess-001',
+    status: 'complete',
+    chronicleLines: [
+      '[10:00] Starting OIDC implementation',
+      '[10:45] Created oidc.ts with PKCE flow',
+      '[11:30] All acceptance tests pass',
+    ],
+    branch: 'feat/auth-rewrite',
+    confidence: 90,
+    raidName: 'Implement OIDC flow',
+    sagaName: 'Auth Rewrite',
+  },
+  {
+    sessionId: 'sess-002',
+    status: 'running',
+    chronicleLines: [
+      '[09:00] Starting PAT generation',
+      '[09:30] JWT signing implemented',
+    ],
+    branch: 'feat/auth-rewrite',
+    confidence: 65,
+    raidName: 'Add PAT generation',
+    sagaName: 'Auth Rewrite',
+  },
+];
+
+const SEED_PROJECTS: TrackerProject[] = [
+  {
+    id: 'proj-niuu-core',
+    name: 'Niuu Core',
+    description: 'Core platform features',
+    status: 'active',
+    url: 'https://linear.app/niuu/proj/niuu-core',
+    milestoneCount: 8,
+    issueCount: 64,
+  },
+  {
+    id: 'proj-plugin-platform',
+    name: 'Plugin Platform',
+    description: 'Composable plugin infrastructure',
+    status: 'active',
+    url: 'https://linear.app/niuu/proj/plugin-platform',
+    milestoneCount: 4,
+    issueCount: 28,
+  },
+];
+
+const SEED_MILESTONES: TrackerMilestone[] = [
+  {
+    id: 'ms-auth',
+    projectId: 'proj-niuu-core',
+    name: 'Auth & Identity',
+    description: 'OIDC, PATs, and session management',
+    sortOrder: 1,
+    progress: 60,
+  },
+  {
+    id: 'ms-observatory',
+    projectId: 'proj-niuu-core',
+    name: 'Observatory',
+    description: 'Topology, registry, events',
+    sortOrder: 2,
+    progress: 80,
+  },
+];
+
+const SEED_ISSUES: TrackerIssue[] = [
+  {
+    id: 'iss-679',
+    identifier: 'NIU-679',
+    title: '@niuulabs/plugin-tyr scaffold',
+    description: 'Scaffold Tyr plugin with domain, ports, mock, HTTP adapters',
+    status: 'in_progress',
+    assignee: null,
+    labels: ['plugin', 'scaffold'],
+    priority: 1,
+    url: 'https://linear.app/niuu/issue/NIU-679',
+    milestoneId: null,
+  },
+  {
+    id: 'iss-671',
+    identifier: 'NIU-671',
+    title: '@niuulabs/plugin-ravn scaffold',
+    description: 'Scaffold Ravn plugin',
+    status: 'done',
+    assignee: null,
+    labels: ['plugin', 'scaffold'],
+    priority: 1,
+    url: 'https://linear.app/niuu/issue/NIU-671',
+    milestoneId: null,
+  },
+];
+
+const SEED_INTEGRATIONS: IntegrationConnection[] = [
+  {
+    id: 'int-linear',
+    integrationType: 'linear',
+    adapter: 'LinearAdapter',
+    credentialName: 'linear-api-key',
+    enabled: true,
+    status: 'connected',
+    createdAt: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 'int-github',
+    integrationType: 'github',
+    adapter: 'GitHubAdapter',
+    credentialName: 'github-token',
+    enabled: true,
+    status: 'connected',
+    createdAt: '2026-01-01T00:00:00Z',
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Mock factories
+// ---------------------------------------------------------------------------
+
+/**
+ * Create an in-memory ITyrService backed by seed data.
+ */
+export function createMockTyrService(): ITyrService {
+  const sagas = new Map<string, Saga>(SEED_SAGAS.map((s) => [s.id, s]));
+  const phasesBySaga = new Map<string, Phase[]>([
+    ['00000000-0000-0000-0000-000000000001', [...SEED_PHASES]],
+  ]);
+
+  return {
+    async getSagas() {
+      return Array.from(sagas.values());
+    },
+
+    async getSaga(id: string) {
+      return sagas.get(id) ?? null;
+    },
+
+    async getPhases(sagaId: string) {
+      return phasesBySaga.get(sagaId) ?? [];
+    },
+
+    async createSaga(spec: string, _repo: string) {
+      const saga: Saga = {
+        id: `mock-${Date.now()}`,
+        trackerId: '',
+        trackerType: 'mock',
+        slug: spec.slice(0, 20).toLowerCase().replace(/\s+/g, '-'),
+        name: spec,
+        repos: [_repo],
+        featureBranch: `feat/${spec.slice(0, 20).toLowerCase().replace(/\s+/g, '-')}`,
+        status: 'active',
+        confidence: 50,
+        createdAt: new Date().toISOString(),
+        phaseSummary: { total: 0, completed: 0 },
+      };
+      sagas.set(saga.id, saga);
+      return saga;
+    },
+
+    async commitSaga(request: CommitSagaRequest) {
+      const saga: Saga = {
+        id: `mock-${Date.now()}`,
+        trackerId: '',
+        trackerType: 'mock',
+        slug: request.slug,
+        name: request.name,
+        repos: request.repos,
+        featureBranch: `feat/${request.slug}`,
+        status: 'active',
+        confidence: 60,
+        createdAt: new Date().toISOString(),
+        phaseSummary: { total: request.phases.length, completed: 0 },
+      };
+      sagas.set(saga.id, saga);
+      return saga;
+    },
+
+    async decompose(_spec: string, _repo: string) {
+      return [];
+    },
+
+    async spawnPlanSession(_spec: string, _repo: string): Promise<PlanSession> {
+      return { sessionId: `plan-${Date.now()}`, chatEndpoint: null };
+    },
+
+    async extractStructure(_text: string): Promise<ExtractedStructure> {
+      return { found: false, structure: null };
+    },
+  };
+}
+
+/**
+ * Create an in-memory IDispatcherService.
+ */
+export function createMockDispatcherService(): IDispatcherService {
+  let state: DispatcherState = { ...SEED_DISPATCHER_STATE };
+  const log: string[] = ['[mock] Dispatcher initialized'];
+
+  return {
+    async getState() {
+      return { ...state };
+    },
+
+    async setRunning(running: boolean) {
+      state = { ...state, running, updatedAt: new Date().toISOString() };
+      log.push(`[mock] running = ${running}`);
+    },
+
+    async setThreshold(threshold: number) {
+      state = { ...state, threshold, updatedAt: new Date().toISOString() };
+    },
+
+    async setAutoContinue(autoContinue: boolean) {
+      state = { ...state, autoContinue, updatedAt: new Date().toISOString() };
+    },
+
+    async getLog() {
+      return [...log];
+    },
+  };
+}
+
+/**
+ * Create an in-memory ITyrSessionService.
+ */
+export function createMockTyrSessionService(): ITyrSessionService {
+  const sessions = new Map<string, SessionInfo>(
+    SEED_SESSIONS.map((s) => [s.sessionId, { ...s }]),
+  );
+
+  return {
+    async getSessions() {
+      return Array.from(sessions.values());
+    },
+
+    async getSession(id: string) {
+      return sessions.get(id) ?? null;
+    },
+
+    async approve(sessionId: string) {
+      const session = sessions.get(sessionId);
+      if (session) {
+        sessions.set(sessionId, { ...session, status: 'approved' });
+      }
+    },
+  };
+}
+
+/**
+ * Create an in-memory ITrackerBrowserService.
+ */
+export function createMockTrackerService(): ITrackerBrowserService {
+  const projectMap = new Map<string, TrackerProject>(SEED_PROJECTS.map((p) => [p.id, p]));
+  const milestoneMap = new Map<string, TrackerMilestone>(SEED_MILESTONES.map((m) => [m.id, m]));
+
+  return {
+    async listProjects() {
+      return Array.from(projectMap.values());
+    },
+
+    async getProject(projectId: string) {
+      const project = projectMap.get(projectId);
+      if (!project) throw new Error(`Project not found: ${projectId}`);
+      return project;
+    },
+
+    async listMilestones(projectId: string) {
+      return Array.from(milestoneMap.values()).filter((m) => m.projectId === projectId);
+    },
+
+    async listIssues(projectId: string, milestoneId?: string) {
+      const byProject = SEED_ISSUES.filter((i) =>
+        SEED_MILESTONES.some((m) => m.id === i.milestoneId && m.projectId === projectId),
+      );
+      if (!milestoneId) return byProject;
+      return byProject.filter((i) => i.milestoneId === milestoneId);
+    },
+
+    async importProject(projectId: string, repos: string[], _baseBranch?: string) {
+      const project = projectMap.get(projectId);
+      const name = project?.name ?? projectId;
+      const saga: Saga = {
+        id: `mock-import-${Date.now()}`,
+        trackerId: projectId,
+        trackerType: 'mock',
+        slug: name.toLowerCase().replace(/\s+/g, '-'),
+        name,
+        repos,
+        featureBranch: `feat/${name.toLowerCase().replace(/\s+/g, '-')}`,
+        status: 'active',
+        confidence: 50,
+        createdAt: new Date().toISOString(),
+        phaseSummary: { total: 0, completed: 0 },
+      };
+      return saga;
+    },
+  };
+}
+
+/**
+ * Create an in-memory ITyrIntegrationService.
+ */
+export function createMockTyrIntegrationService(): ITyrIntegrationService {
+  const integrations = new Map<string, IntegrationConnection>(
+    SEED_INTEGRATIONS.map((i) => [i.id, { ...i }]),
+  );
+
+  return {
+    async listIntegrations() {
+      return Array.from(integrations.values());
+    },
+
+    async createIntegration(params: CreateIntegrationParams) {
+      const integration: IntegrationConnection = {
+        id: `int-${Date.now()}`,
+        integrationType: params.integrationType,
+        adapter: params.adapter,
+        credentialName: params.credentialName,
+        enabled: true,
+        status: 'connected',
+        createdAt: new Date().toISOString(),
+      };
+      integrations.set(integration.id, integration);
+      return integration;
+    },
+
+    async deleteIntegration(id: string) {
+      integrations.delete(id);
+    },
+
+    async toggleIntegration(id: string, enabled: boolean) {
+      const integration = integrations.get(id);
+      if (!integration) throw new Error(`Integration not found: ${id}`);
+      const updated = { ...integration, enabled };
+      integrations.set(id, updated);
+      return updated;
+    },
+
+    async testConnection(_id: string): Promise<ConnectionTestResult> {
+      return { success: true, message: 'Connection successful (mock)' };
+    },
+
+    async getTelegramSetup(): Promise<TelegramSetupResult> {
+      return { deeplink: 'https://t.me/niuu_bot?start=mock', token: 'mock-telegram-token' };
+    },
+  };
+}

--- a/web-next/packages/plugin-tyr/src/adapters/mock.ts
+++ b/web-next/packages/plugin-tyr/src/adapters/mock.ts
@@ -173,10 +173,7 @@ const SEED_SESSIONS: SessionInfo[] = [
   {
     sessionId: 'sess-002',
     status: 'running',
-    chronicleLines: [
-      '[09:00] Starting PAT generation',
-      '[09:30] JWT signing implemented',
-    ],
+    chronicleLines: ['[09:00] Starting PAT generation', '[09:30] JWT signing implemented'],
     branch: 'feat/auth-rewrite',
     confidence: 65,
     raidName: 'Add PAT generation',
@@ -383,9 +380,7 @@ export function createMockDispatcherService(): IDispatcherService {
  * Create an in-memory ITyrSessionService.
  */
 export function createMockTyrSessionService(): ITyrSessionService {
-  const sessions = new Map<string, SessionInfo>(
-    SEED_SESSIONS.map((s) => [s.sessionId, { ...s }]),
-  );
+  const sessions = new Map<string, SessionInfo>(SEED_SESSIONS.map((s) => [s.sessionId, { ...s }]));
 
   return {
     async getSessions() {

--- a/web-next/packages/plugin-tyr/src/adapters/mock.ts
+++ b/web-next/packages/plugin-tyr/src/adapters/mock.ts
@@ -232,7 +232,7 @@ const SEED_ISSUES: TrackerIssue[] = [
     labels: ['plugin', 'scaffold'],
     priority: 1,
     url: 'https://linear.app/niuu/issue/NIU-679',
-    milestoneId: null,
+    milestoneId: 'ms-auth',
   },
   {
     id: 'iss-671',

--- a/web-next/packages/plugin-tyr/src/domain/dispatcher.ts
+++ b/web-next/packages/plugin-tyr/src/domain/dispatcher.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+
+/**
+ * Dispatcher domain types.
+ *
+ * The Dispatcher is the autonomous raid-execution engine. It picks raids from
+ * the queue when confidence is above threshold and capacity is available.
+ *
+ * Owner: plugin-tyr.
+ */
+
+export const dispatcherStateSchema = z.object({
+  /** Unique row identifier (UUID). */
+  id: z.string().uuid(),
+  /** Whether the dispatcher is actively processing the queue. */
+  running: z.boolean(),
+  /** Minimum confidence score (0–100) a raid must have to be dispatched. */
+  threshold: z.number().min(0).max(100),
+  /** Maximum number of raids allowed to run concurrently. */
+  maxConcurrentRaids: z.number().int().positive(),
+  /** If true, the dispatcher automatically continues after each raid completes. */
+  autoContinue: z.boolean(),
+  /** ISO-8601 UTC last-update timestamp. */
+  updatedAt: z.string().datetime(),
+});
+export type DispatcherState = z.infer<typeof dispatcherStateSchema>;
+
+export const dispatchRuleSchema = z.object({
+  id: z.string().uuid(),
+  /** Human-readable rule name. */
+  name: z.string().min(1),
+  /** Optional saga filter: only apply this rule when the saga matches. */
+  sagaId: z.string().nullable(),
+  /** Overrides the global threshold for matched raids. */
+  thresholdOverride: z.number().min(0).max(100).nullable(),
+  /** ISO-8601 UTC creation timestamp. */
+  createdAt: z.string().datetime(),
+});
+export type DispatchRule = z.infer<typeof dispatchRuleSchema>;

--- a/web-next/packages/plugin-tyr/src/domain/saga.test.ts
+++ b/web-next/packages/plugin-tyr/src/domain/saga.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from 'vitest';
+import {
+  sagaStatusSchema,
+  phaseStatusSchema,
+  raidStatusSchema,
+  sagaSchema,
+  phaseSchema,
+  raidSchema,
+  confidenceEventSchema,
+} from './saga';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const validSaga = {
+  id: '00000000-0000-0000-0000-000000000001',
+  trackerId: 'LIN-001',
+  trackerType: 'linear',
+  slug: 'auth-rewrite',
+  name: 'Auth Rewrite',
+  repos: ['niuulabs/volundr'],
+  featureBranch: 'feat/auth-rewrite',
+  status: 'active' as const,
+  confidence: 72,
+  createdAt: '2026-01-01T00:00:00Z',
+  phaseSummary: { total: 3, completed: 1 },
+};
+
+const validRaid = {
+  id: '00000000-0000-0000-0000-000000000002',
+  phaseId: '00000000-0000-0000-0000-000000000010',
+  trackerId: 'LIN-002',
+  name: 'Implement JWT refresh',
+  description: 'Add silent token refresh to the auth flow.',
+  acceptanceCriteria: ['Token refreshes before expiry', 'No logout on tab focus'],
+  declaredFiles: ['src/auth/refresh.ts'],
+  estimateHours: 4,
+  status: 'queued' as const,
+  confidence: 80,
+  sessionId: null,
+  reviewerSessionId: null,
+  reviewRound: 0,
+  branch: null,
+  chronicleSummary: null,
+  retryCount: 0,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
+const validPhase = {
+  id: '00000000-0000-0000-0000-000000000010',
+  sagaId: '00000000-0000-0000-0000-000000000001',
+  trackerId: 'LIN-M1',
+  number: 1,
+  name: 'Phase 1: Foundation',
+  status: 'active' as const,
+  confidence: 75,
+  raids: [validRaid],
+};
+
+// ---------------------------------------------------------------------------
+// Status schemas
+// ---------------------------------------------------------------------------
+
+describe('sagaStatusSchema', () => {
+  it('accepts valid statuses', () => {
+    expect(sagaStatusSchema.parse('active')).toBe('active');
+    expect(sagaStatusSchema.parse('complete')).toBe('complete');
+    expect(sagaStatusSchema.parse('failed')).toBe('failed');
+  });
+
+  it('rejects unknown values', () => {
+    expect(() => sagaStatusSchema.parse('unknown')).toThrow();
+    expect(() => sagaStatusSchema.parse('')).toThrow();
+  });
+});
+
+describe('phaseStatusSchema', () => {
+  it('accepts all phase statuses', () => {
+    for (const s of ['pending', 'active', 'gated', 'complete']) {
+      expect(phaseStatusSchema.parse(s)).toBe(s);
+    }
+  });
+
+  it('rejects invalid status', () => {
+    expect(() => phaseStatusSchema.parse('cancelled')).toThrow();
+  });
+});
+
+describe('raidStatusSchema', () => {
+  it('accepts all raid statuses', () => {
+    for (const s of ['pending', 'queued', 'running', 'review', 'escalated', 'merged', 'failed']) {
+      expect(raidStatusSchema.parse(s)).toBe(s);
+    }
+  });
+
+  it('rejects invalid status', () => {
+    expect(() => raidStatusSchema.parse('done')).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Saga schema
+// ---------------------------------------------------------------------------
+
+describe('sagaSchema', () => {
+  it('parses a valid saga', () => {
+    const result = sagaSchema.parse(validSaga);
+    expect(result.id).toBe(validSaga.id);
+    expect(result.status).toBe('active');
+    expect(result.phaseSummary.total).toBe(3);
+  });
+
+  it('rejects confidence outside 0–100', () => {
+    expect(() => sagaSchema.parse({ ...validSaga, confidence: 101 })).toThrow();
+    expect(() => sagaSchema.parse({ ...validSaga, confidence: -1 })).toThrow();
+  });
+
+  it('rejects invalid UUID', () => {
+    expect(() => sagaSchema.parse({ ...validSaga, id: 'not-a-uuid' })).toThrow();
+  });
+
+  it('rejects empty name', () => {
+    expect(() => sagaSchema.parse({ ...validSaga, name: '' })).toThrow();
+  });
+
+  it('accepts confidence at boundary values', () => {
+    expect(sagaSchema.parse({ ...validSaga, confidence: 0 }).confidence).toBe(0);
+    expect(sagaSchema.parse({ ...validSaga, confidence: 100 }).confidence).toBe(100);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Raid schema
+// ---------------------------------------------------------------------------
+
+describe('raidSchema', () => {
+  it('parses a valid raid', () => {
+    const result = raidSchema.parse(validRaid);
+    expect(result.name).toBe('Implement JWT refresh');
+    expect(result.acceptanceCriteria).toHaveLength(2);
+  });
+
+  it('accepts null estimateHours', () => {
+    const result = raidSchema.parse({ ...validRaid, estimateHours: null });
+    expect(result.estimateHours).toBeNull();
+  });
+
+  it('accepts null sessionId and branch', () => {
+    const result = raidSchema.parse(validRaid);
+    expect(result.sessionId).toBeNull();
+    expect(result.branch).toBeNull();
+  });
+
+  it('rejects negative retryCount', () => {
+    expect(() => raidSchema.parse({ ...validRaid, retryCount: -1 })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase schema
+// ---------------------------------------------------------------------------
+
+describe('phaseSchema', () => {
+  it('parses a valid phase with raids', () => {
+    const result = phaseSchema.parse(validPhase);
+    expect(result.raids).toHaveLength(1);
+    expect(result.raids[0]?.name).toBe('Implement JWT refresh');
+  });
+
+  it('accepts empty raids array', () => {
+    const result = phaseSchema.parse({ ...validPhase, raids: [] });
+    expect(result.raids).toHaveLength(0);
+  });
+
+  it('rejects zero phase number', () => {
+    expect(() => phaseSchema.parse({ ...validPhase, number: 0 })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ConfidenceEvent schema
+// ---------------------------------------------------------------------------
+
+describe('confidenceEventSchema', () => {
+  const validEvent = {
+    id: '00000000-0000-0000-0000-000000000099',
+    raidId: '00000000-0000-0000-0000-000000000002',
+    eventType: 'ci_pass' as const,
+    delta: 5,
+    scoreAfter: 85,
+    createdAt: '2026-01-01T00:00:00Z',
+  };
+
+  it('parses a valid confidence event', () => {
+    const result = confidenceEventSchema.parse(validEvent);
+    expect(result.eventType).toBe('ci_pass');
+    expect(result.delta).toBe(5);
+  });
+
+  it('accepts negative delta for penalty events', () => {
+    const result = confidenceEventSchema.parse({ ...validEvent, delta: -10, scoreAfter: 70 });
+    expect(result.delta).toBe(-10);
+  });
+
+  it('rejects scoreAfter outside 0–100', () => {
+    expect(() => confidenceEventSchema.parse({ ...validEvent, scoreAfter: 101 })).toThrow();
+  });
+});

--- a/web-next/packages/plugin-tyr/src/domain/saga.ts
+++ b/web-next/packages/plugin-tyr/src/domain/saga.ts
@@ -1,0 +1,109 @@
+import { z } from 'zod';
+
+/**
+ * Saga domain types — migrated from web/src/modules/tyr/models/saga.ts.
+ *
+ * Owner: plugin-tyr (source of truth).
+ */
+
+export const sagaStatusSchema = z.enum(['active', 'complete', 'failed']);
+export type SagaStatus = z.infer<typeof sagaStatusSchema>;
+
+export const phaseStatusSchema = z.enum(['pending', 'active', 'gated', 'complete']);
+export type PhaseStatus = z.infer<typeof phaseStatusSchema>;
+
+export const raidStatusSchema = z.enum([
+  'pending',
+  'queued',
+  'running',
+  'review',
+  'escalated',
+  'merged',
+  'failed',
+]);
+export type RaidStatus = z.infer<typeof raidStatusSchema>;
+
+export const confidenceEventTypeSchema = z.enum([
+  'ci_pass',
+  'ci_fail',
+  'scope_breach',
+  'retry',
+  'human_reject',
+]);
+export type ConfidenceEventType = z.infer<typeof confidenceEventTypeSchema>;
+
+export const sagaPhaseSummarySchema = z.object({
+  total: z.number().int().nonnegative(),
+  completed: z.number().int().nonnegative(),
+});
+export type SagaPhaseSummary = z.infer<typeof sagaPhaseSummarySchema>;
+
+export const sagaSchema = z.object({
+  /** Unique identifier (UUID). */
+  id: z.string().uuid(),
+  /** External tracker issue/milestone ID. */
+  trackerId: z.string(),
+  /** Tracker system type (e.g. "linear", "github"). */
+  trackerType: z.string(),
+  /** URL-safe slug derived from saga name. */
+  slug: z.string(),
+  /** Human-readable saga name. */
+  name: z.string().min(1),
+  /** List of repository identifiers this saga targets. */
+  repos: z.array(z.string()),
+  /** Git feature branch for all work in this saga. */
+  featureBranch: z.string(),
+  /** Current lifecycle status. */
+  status: sagaStatusSchema,
+  /** Aggregate confidence score (0–100). */
+  confidence: z.number().min(0).max(100),
+  /** ISO-8601 UTC creation timestamp. */
+  createdAt: z.string().datetime(),
+  /** Phase progress summary. */
+  phaseSummary: sagaPhaseSummarySchema,
+});
+export type Saga = z.infer<typeof sagaSchema>;
+
+export const raidSchema = z.object({
+  id: z.string().uuid(),
+  phaseId: z.string(),
+  trackerId: z.string(),
+  name: z.string().min(1),
+  description: z.string(),
+  acceptanceCriteria: z.array(z.string()),
+  declaredFiles: z.array(z.string()),
+  estimateHours: z.number().nullable(),
+  status: raidStatusSchema,
+  confidence: z.number().min(0).max(100),
+  sessionId: z.string().nullable(),
+  reviewerSessionId: z.string().nullable(),
+  reviewRound: z.number().int().nonnegative(),
+  branch: z.string().nullable(),
+  chronicleSummary: z.string().nullable(),
+  retryCount: z.number().int().nonnegative(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+export type Raid = z.infer<typeof raidSchema>;
+
+export const phaseSchema = z.object({
+  id: z.string().uuid(),
+  sagaId: z.string(),
+  trackerId: z.string(),
+  number: z.number().int().positive(),
+  name: z.string().min(1),
+  status: phaseStatusSchema,
+  confidence: z.number().min(0).max(100),
+  raids: z.array(raidSchema),
+});
+export type Phase = z.infer<typeof phaseSchema>;
+
+export const confidenceEventSchema = z.object({
+  id: z.string().uuid(),
+  raidId: z.string(),
+  eventType: confidenceEventTypeSchema,
+  delta: z.number(),
+  scoreAfter: z.number().min(0).max(100),
+  createdAt: z.string().datetime(),
+});
+export type ConfidenceEvent = z.infer<typeof confidenceEventSchema>;

--- a/web-next/packages/plugin-tyr/src/domain/session.ts
+++ b/web-next/packages/plugin-tyr/src/domain/session.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+
+/**
+ * Session (Tyr raid session) domain types.
+ *
+ * A SessionInfo tracks the live state of an autonomous coding session spawned
+ * by a Raid. It holds the approval flow state and a chronicle of log lines.
+ *
+ * NOTE: This is distinct from the Ravn Session type (plugin-ravn owns that).
+ *
+ * Owner: plugin-tyr.
+ */
+
+export const tyrSessionStatusSchema = z.enum([
+  'running',
+  'awaiting_approval',
+  'approved',
+  'rejected',
+  'complete',
+  'failed',
+]);
+export type TyrSessionStatus = z.infer<typeof tyrSessionStatusSchema>;
+
+export const sessionInfoSchema = z.object({
+  /** Unique session identifier. */
+  sessionId: z.string().min(1),
+  /** Current session lifecycle status. */
+  status: tyrSessionStatusSchema,
+  /** Recent log / chronicle output lines. */
+  chronicleLines: z.array(z.string()),
+  /** Git branch associated with this session. */
+  branch: z.string().nullable(),
+  /** Confidence score at the time of the last status change (0–100). */
+  confidence: z.number().min(0).max(100),
+  /** Name of the raid this session is executing. */
+  raidName: z.string(),
+  /** Name of the saga this raid belongs to. */
+  sagaName: z.string(),
+});
+export type SessionInfo = z.infer<typeof sessionInfoSchema>;

--- a/web-next/packages/plugin-tyr/src/domain/tracker.ts
+++ b/web-next/packages/plugin-tyr/src/domain/tracker.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod';
+
+/**
+ * Tracker browser domain types.
+ *
+ * The tracker browser lets operators browse projects, milestones, and issues
+ * from an external issue tracker (Linear, GitHub Projects, etc.) and import
+ * them as Sagas.
+ *
+ * Owner: plugin-tyr.
+ */
+
+export const trackerProjectSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string(),
+  status: z.string(),
+  url: z.string(),
+  milestoneCount: z.number().int().nonnegative(),
+  issueCount: z.number().int().nonnegative(),
+});
+export type TrackerProject = z.infer<typeof trackerProjectSchema>;
+
+export const trackerMilestoneSchema = z.object({
+  id: z.string().min(1),
+  projectId: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string(),
+  sortOrder: z.number().int().nonnegative(),
+  progress: z.number().min(0).max(100),
+});
+export type TrackerMilestone = z.infer<typeof trackerMilestoneSchema>;
+
+export const trackerIssueSchema = z.object({
+  id: z.string().min(1),
+  identifier: z.string().min(1),
+  title: z.string().min(1),
+  description: z.string(),
+  status: z.string(),
+  assignee: z.string().nullable(),
+  labels: z.array(z.string()),
+  priority: z.number().int().nonnegative(),
+  url: z.string(),
+  milestoneId: z.string().nullable(),
+});
+export type TrackerIssue = z.infer<typeof trackerIssueSchema>;
+
+export const repoInfoSchema = z.object({
+  provider: z.string(),
+  org: z.string(),
+  name: z.string(),
+  cloneUrl: z.string(),
+  url: z.string(),
+  defaultBranch: z.string(),
+  branches: z.array(z.string()),
+});
+export type RepoInfo = z.infer<typeof repoInfoSchema>;

--- a/web-next/packages/plugin-tyr/src/domain/workflow.test.ts
+++ b/web-next/packages/plugin-tyr/src/domain/workflow.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect } from 'vitest';
+import {
+  workflowSchema,
+  validateWorkflow,
+  WorkflowValidationError,
+  workflowNodeSchema,
+  workflowEdgeSchema,
+} from './workflow';
+import type { Workflow } from './workflow';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const nodeA = {
+  id: 'node-a',
+  kind: 'stage' as const,
+  label: 'Set up CI',
+  raidId: '00000000-0000-0000-0000-000000000001',
+  position: { x: 0, y: 0 },
+};
+
+const nodeB = {
+  id: 'node-b',
+  kind: 'gate' as const,
+  label: 'QA sign-off',
+  condition: 'All acceptance tests pass',
+  position: { x: 200, y: 0 },
+};
+
+const nodeC = {
+  id: 'node-c',
+  kind: 'cond' as const,
+  label: 'All green?',
+  predicate: 'ci.exitCode === 0',
+  position: { x: 400, y: 0 },
+};
+
+const edgeAB = {
+  id: 'edge-ab',
+  source: 'node-a',
+  target: 'node-b',
+  cp1: { x: 50, y: 0 },
+  cp2: { x: 150, y: 0 },
+};
+
+const edgeBC = {
+  id: 'edge-bc',
+  source: 'node-b',
+  target: 'node-c',
+  label: 'approved',
+  cp1: { x: 250, y: 0 },
+  cp2: { x: 350, y: 0 },
+};
+
+function makeWorkflow(overrides: Partial<Workflow> = {}): Workflow {
+  return {
+    id: '00000000-0000-0000-0000-000000000001',
+    name: 'Auth Rewrite Workflow',
+    nodes: [nodeA, nodeB, nodeC],
+    edges: [edgeAB, edgeBC],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Node schemas
+// ---------------------------------------------------------------------------
+
+describe('workflowNodeSchema', () => {
+  it('parses a stage node', () => {
+    const result = workflowNodeSchema.parse(nodeA);
+    expect(result.kind).toBe('stage');
+    if (result.kind === 'stage') {
+      expect(result.raidId).toBe('00000000-0000-0000-0000-000000000001');
+    }
+  });
+
+  it('parses a gate node', () => {
+    const result = workflowNodeSchema.parse(nodeB);
+    expect(result.kind).toBe('gate');
+    if (result.kind === 'gate') {
+      expect(result.condition).toBe('All acceptance tests pass');
+    }
+  });
+
+  it('parses a cond node', () => {
+    const result = workflowNodeSchema.parse(nodeC);
+    expect(result.kind).toBe('cond');
+    if (result.kind === 'cond') {
+      expect(result.predicate).toBe('ci.exitCode === 0');
+    }
+  });
+
+  it('rejects unknown node kind', () => {
+    expect(() => workflowNodeSchema.parse({ ...nodeA, kind: 'action' })).toThrow();
+  });
+
+  it('rejects empty node id', () => {
+    expect(() => workflowNodeSchema.parse({ ...nodeA, id: '' })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edge schema
+// ---------------------------------------------------------------------------
+
+describe('workflowEdgeSchema', () => {
+  it('parses a valid edge', () => {
+    const result = workflowEdgeSchema.parse(edgeAB);
+    expect(result.source).toBe('node-a');
+    expect(result.target).toBe('node-b');
+  });
+
+  it('allows optional label', () => {
+    const result = workflowEdgeSchema.parse({ ...edgeAB, label: 'yes' });
+    expect(result.label).toBe('yes');
+  });
+
+  it('allows absent label', () => {
+    const result = workflowEdgeSchema.parse(edgeAB);
+    expect(result.label).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Workflow schema
+// ---------------------------------------------------------------------------
+
+describe('workflowSchema', () => {
+  it('parses a valid workflow', () => {
+    const result = workflowSchema.parse(makeWorkflow());
+    expect(result.nodes).toHaveLength(3);
+    expect(result.edges).toHaveLength(2);
+  });
+
+  it('accepts a workflow with no edges', () => {
+    const result = workflowSchema.parse(makeWorkflow({ edges: [] }));
+    expect(result.edges).toHaveLength(0);
+  });
+
+  it('rejects invalid UUID', () => {
+    expect(() => workflowSchema.parse(makeWorkflow({ id: 'bad-id' }))).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateWorkflow — DAG invariants
+// ---------------------------------------------------------------------------
+
+describe('validateWorkflow', () => {
+  it('passes for a valid workflow', () => {
+    expect(() => validateWorkflow(makeWorkflow())).not.toThrow();
+  });
+
+  it('throws on duplicate node ids', () => {
+    const nodes = [nodeA, { ...nodeA, kind: 'gate' as const, condition: 'x', label: 'dup' }];
+    expect(() =>
+      validateWorkflow(makeWorkflow({ nodes, edges: [] })),
+    ).toThrow(WorkflowValidationError);
+  });
+
+  it('throws when edge source references unknown node', () => {
+    const badEdge = { ...edgeAB, source: 'node-unknown' };
+    expect(() => validateWorkflow(makeWorkflow({ edges: [badEdge] }))).toThrow(
+      WorkflowValidationError,
+    );
+  });
+
+  it('throws when edge target references unknown node', () => {
+    const badEdge = { ...edgeAB, target: 'node-unknown' };
+    expect(() => validateWorkflow(makeWorkflow({ edges: [badEdge] }))).toThrow(
+      WorkflowValidationError,
+    );
+  });
+
+  it('throws on self-loop', () => {
+    const selfLoop = { ...edgeAB, target: 'node-a' };
+    expect(() => validateWorkflow(makeWorkflow({ edges: [selfLoop] }))).toThrow(
+      WorkflowValidationError,
+    );
+  });
+
+  it('throws on duplicate edges', () => {
+    expect(() =>
+      validateWorkflow(makeWorkflow({ edges: [edgeAB, edgeAB] })),
+    ).toThrow(WorkflowValidationError);
+  });
+
+  it('passes for empty workflow (no nodes, no edges)', () => {
+    expect(() => validateWorkflow(makeWorkflow({ nodes: [], edges: [] }))).not.toThrow();
+  });
+
+  it('error message names the problematic id', () => {
+    const selfLoop = { ...edgeAB, target: 'node-a' };
+    let message = '';
+    try {
+      validateWorkflow(makeWorkflow({ edges: [selfLoop] }));
+    } catch (e) {
+      if (e instanceof WorkflowValidationError) message = e.message;
+    }
+    expect(message).toContain('node-a');
+  });
+});

--- a/web-next/packages/plugin-tyr/src/domain/workflow.test.ts
+++ b/web-next/packages/plugin-tyr/src/domain/workflow.test.ts
@@ -155,9 +155,9 @@ describe('validateWorkflow', () => {
 
   it('throws on duplicate node ids', () => {
     const nodes = [nodeA, { ...nodeA, kind: 'gate' as const, condition: 'x', label: 'dup' }];
-    expect(() =>
-      validateWorkflow(makeWorkflow({ nodes, edges: [] })),
-    ).toThrow(WorkflowValidationError);
+    expect(() => validateWorkflow(makeWorkflow({ nodes, edges: [] }))).toThrow(
+      WorkflowValidationError,
+    );
   });
 
   it('throws when edge source references unknown node', () => {
@@ -182,9 +182,9 @@ describe('validateWorkflow', () => {
   });
 
   it('throws on duplicate edges', () => {
-    expect(() =>
-      validateWorkflow(makeWorkflow({ edges: [edgeAB, edgeAB] })),
-    ).toThrow(WorkflowValidationError);
+    expect(() => validateWorkflow(makeWorkflow({ edges: [edgeAB, edgeAB] }))).toThrow(
+      WorkflowValidationError,
+    );
   });
 
   it('passes for empty workflow (no nodes, no edges)', () => {

--- a/web-next/packages/plugin-tyr/src/domain/workflow.ts
+++ b/web-next/packages/plugin-tyr/src/domain/workflow.ts
@@ -1,0 +1,146 @@
+import { z } from 'zod';
+
+/**
+ * Workflow — a DAG value object representing a structured execution plan.
+ *
+ * Nodes are one of three kinds:
+ *   stage  — a unit of work (maps to a Raid)
+ *   gate   — a checkpoint requiring human or automated approval before proceeding
+ *   cond   — a conditional branch that routes execution based on a predicate
+ *
+ * Edges use cubic bezier curves for UI rendering (control-point pairs cp1/cp2).
+ *
+ * Owner: plugin-tyr.
+ */
+
+// ---------------------------------------------------------------------------
+// Nodes
+// ---------------------------------------------------------------------------
+
+export const workflowNodeKindSchema = z.enum(['stage', 'gate', 'cond']);
+export type WorkflowNodeKind = z.infer<typeof workflowNodeKindSchema>;
+
+/** Spatial position for UI rendering (pixels from top-left). */
+const positionSchema = z.object({ x: z.number(), y: z.number() });
+
+export const workflowStageNodeSchema = z.object({
+  id: z.string().min(1),
+  kind: z.literal('stage'),
+  label: z.string().min(1),
+  /** Optional reference to the Raid this stage maps to. */
+  raidId: z.string().nullable(),
+  position: positionSchema,
+});
+export type WorkflowStageNode = z.infer<typeof workflowStageNodeSchema>;
+
+export const workflowGateNodeSchema = z.object({
+  id: z.string().min(1),
+  kind: z.literal('gate'),
+  label: z.string().min(1),
+  /** Human-readable approval condition description. */
+  condition: z.string(),
+  position: positionSchema,
+});
+export type WorkflowGateNode = z.infer<typeof workflowGateNodeSchema>;
+
+export const workflowCondNodeSchema = z.object({
+  id: z.string().min(1),
+  kind: z.literal('cond'),
+  label: z.string().min(1),
+  /** Predicate expression evaluated at runtime. */
+  predicate: z.string(),
+  position: positionSchema,
+});
+export type WorkflowCondNode = z.infer<typeof workflowCondNodeSchema>;
+
+export const workflowNodeSchema = z.discriminatedUnion('kind', [
+  workflowStageNodeSchema,
+  workflowGateNodeSchema,
+  workflowCondNodeSchema,
+]);
+export type WorkflowNode = z.infer<typeof workflowNodeSchema>;
+
+// ---------------------------------------------------------------------------
+// Edges (bezier curves)
+// ---------------------------------------------------------------------------
+
+export const workflowEdgeSchema = z.object({
+  id: z.string().min(1),
+  /** Source node id. */
+  source: z.string().min(1),
+  /** Target node id. */
+  target: z.string().min(1),
+  /** Optional edge label (e.g. "yes" / "no" on cond nodes). */
+  label: z.string().optional(),
+  /** First bezier control point (relative to source). */
+  cp1: positionSchema,
+  /** Second bezier control point (relative to target). */
+  cp2: positionSchema,
+});
+export type WorkflowEdge = z.infer<typeof workflowEdgeSchema>;
+
+// ---------------------------------------------------------------------------
+// Workflow DAG invariants
+// ---------------------------------------------------------------------------
+
+export class WorkflowValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'WorkflowValidationError';
+  }
+}
+
+export const workflowSchema = z.object({
+  /** Unique identifier (UUID). */
+  id: z.string().uuid(),
+  /** Display name. */
+  name: z.string().min(1),
+  /** Nodes in the DAG. IDs must be unique within a workflow. */
+  nodes: z.array(workflowNodeSchema),
+  /** Directed edges. Source and target must reference valid node IDs. */
+  edges: z.array(workflowEdgeSchema),
+});
+export type Workflow = z.infer<typeof workflowSchema>;
+
+/**
+ * Validate DAG structural invariants beyond Zod schema:
+ *  1. Node IDs are unique.
+ *  2. Every edge source and target references an existing node.
+ *  3. No self-loops.
+ *  4. No duplicate edges (same source + target pair).
+ *
+ * Throws WorkflowValidationError on the first violated invariant.
+ */
+export function validateWorkflow(workflow: Workflow): void {
+  const nodeIds = new Set<string>();
+
+  for (const node of workflow.nodes) {
+    if (nodeIds.has(node.id)) {
+      throw new WorkflowValidationError(`Duplicate node id: ${node.id}`);
+    }
+    nodeIds.add(node.id);
+  }
+
+  const edgeKeys = new Set<string>();
+
+  for (const edge of workflow.edges) {
+    if (!nodeIds.has(edge.source)) {
+      throw new WorkflowValidationError(
+        `Edge ${edge.id} references unknown source node: ${edge.source}`,
+      );
+    }
+    if (!nodeIds.has(edge.target)) {
+      throw new WorkflowValidationError(
+        `Edge ${edge.id} references unknown target node: ${edge.target}`,
+      );
+    }
+    if (edge.source === edge.target) {
+      throw new WorkflowValidationError(`Edge ${edge.id} is a self-loop on node: ${edge.source}`);
+    }
+    const key = `${edge.source}->${edge.target}`;
+    if (edgeKeys.has(key)) {
+      throw new WorkflowValidationError(`Duplicate edge from ${edge.source} to ${edge.target}`);
+    }
+    edgeKeys.add(key);
+  }
+}

--- a/web-next/packages/plugin-tyr/src/index.ts
+++ b/web-next/packages/plugin-tyr/src/index.ts
@@ -1,0 +1,121 @@
+import { createRoute } from '@tanstack/react-router';
+import { definePlugin } from '@niuulabs/plugin-sdk';
+import { TyrPage } from './ui/TyrPage';
+
+export const tyrPlugin = definePlugin({
+  id: 'tyr',
+  rune: 'ᛏ',
+  title: 'Tyr',
+  subtitle: 'sagas · raids · dispatch',
+  routes: (rootRoute) => [
+    createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/tyr',
+      component: TyrPage,
+    }),
+  ],
+});
+
+// Mock adapters
+export {
+  createMockTyrService,
+  createMockDispatcherService,
+  createMockTyrSessionService,
+  createMockTrackerService,
+  createMockTyrIntegrationService,
+} from './adapters/mock';
+
+// HTTP adapters
+export {
+  buildTyrHttpAdapter,
+  buildDispatcherHttpAdapter,
+  buildTyrSessionHttpAdapter,
+  buildTrackerHttpAdapter,
+  buildTyrIntegrationHttpAdapter,
+} from './adapters/http';
+
+// Port interfaces + request/response types
+export type {
+  ITyrService,
+  IDispatcherService,
+  ITyrSessionService,
+  ITrackerBrowserService,
+  ITyrIntegrationService,
+  CommitSagaRequest,
+  PlanSession,
+  RaidSpec,
+  PhaseSpec,
+  ExtractedStructure,
+  IntegrationConnection,
+  CreateIntegrationParams,
+  ConnectionTestResult,
+  TelegramSetupResult,
+  // Re-exported domain types
+  Saga,
+  Phase,
+  DispatcherState,
+  DispatchRule,
+  SessionInfo,
+  TyrSessionStatus,
+  TrackerProject,
+  TrackerMilestone,
+  TrackerIssue,
+  RepoInfo,
+} from './ports';
+
+// Domain types (schemas + value objects)
+export {
+  sagaStatusSchema,
+  phaseStatusSchema,
+  raidStatusSchema,
+  confidenceEventTypeSchema,
+  sagaPhaseSummarySchema,
+  sagaSchema,
+  raidSchema,
+  phaseSchema,
+  confidenceEventSchema,
+  type SagaStatus,
+  type PhaseStatus,
+  type RaidStatus,
+  type ConfidenceEventType,
+  type SagaPhaseSummary,
+  type Raid,
+  type ConfidenceEvent,
+} from './domain/saga';
+
+export {
+  workflowNodeKindSchema,
+  workflowStageNodeSchema,
+  workflowGateNodeSchema,
+  workflowCondNodeSchema,
+  workflowNodeSchema,
+  workflowEdgeSchema,
+  workflowSchema,
+  validateWorkflow,
+  WorkflowValidationError,
+  type WorkflowNodeKind,
+  type WorkflowStageNode,
+  type WorkflowGateNode,
+  type WorkflowCondNode,
+  type WorkflowNode,
+  type WorkflowEdge,
+  type Workflow,
+} from './domain/workflow';
+
+export {
+  dispatcherStateSchema,
+  dispatchRuleSchema,
+} from './domain/dispatcher';
+
+export {
+  tyrSessionStatusSchema,
+  sessionInfoSchema,
+} from './domain/session';
+
+export {
+  trackerProjectSchema,
+  trackerMilestoneSchema,
+  trackerIssueSchema,
+  repoInfoSchema,
+  type RepoInfo as TrackerRepoInfo,
+} from './domain/tracker';

--- a/web-next/packages/plugin-tyr/src/index.ts
+++ b/web-next/packages/plugin-tyr/src/index.ts
@@ -102,15 +102,9 @@ export {
   type Workflow,
 } from './domain/workflow';
 
-export {
-  dispatcherStateSchema,
-  dispatchRuleSchema,
-} from './domain/dispatcher';
+export { dispatcherStateSchema, dispatchRuleSchema } from './domain/dispatcher';
 
-export {
-  tyrSessionStatusSchema,
-  sessionInfoSchema,
-} from './domain/session';
+export { tyrSessionStatusSchema, sessionInfoSchema } from './domain/session';
 
 export {
   trackerProjectSchema,

--- a/web-next/packages/plugin-tyr/src/ports.ts
+++ b/web-next/packages/plugin-tyr/src/ports.ts
@@ -1,0 +1,181 @@
+/**
+ * Tyr plugin port interfaces.
+ *
+ * Migrated from web/src/modules/tyr/ports/ — shape preserved, imports updated.
+ *
+ * All types in this file are pure TypeScript interfaces or type aliases.
+ * Implementations live in src/adapters/.
+ */
+
+import type { Saga, Phase } from './domain/saga';
+import type { DispatcherState } from './domain/dispatcher';
+import type { SessionInfo } from './domain/session';
+import type { TrackerProject, TrackerMilestone, TrackerIssue } from './domain/tracker';
+
+// Re-export domain types so consumers can import from a single location.
+export type { Saga, Phase } from './domain/saga';
+export type { DispatcherState, DispatchRule } from './domain/dispatcher';
+export type { SessionInfo, TyrSessionStatus } from './domain/session';
+export type { TrackerProject, TrackerMilestone, TrackerIssue, RepoInfo } from './domain/tracker';
+
+// ---------------------------------------------------------------------------
+// ITyrService — saga lifecycle and planning
+// ---------------------------------------------------------------------------
+
+export interface CommitSagaRequest {
+  name: string;
+  slug: string;
+  description: string;
+  repos: string[];
+  baseBranch: string;
+  phases: {
+    name: string;
+    raids: {
+      name: string;
+      description: string;
+      acceptanceCriteria: string[];
+      declaredFiles: string[];
+      estimateHours: number;
+    }[];
+  }[];
+  transcript?: string;
+}
+
+export interface PlanSession {
+  sessionId: string;
+  chatEndpoint: string | null;
+}
+
+export interface RaidSpec {
+  name: string;
+  description: string;
+  acceptanceCriteria: string[];
+  declaredFiles: string[];
+  estimateHours: number;
+  confidence: number;
+}
+
+export interface PhaseSpec {
+  name: string;
+  raids: RaidSpec[];
+}
+
+export interface ExtractedStructure {
+  found: boolean;
+  structure: {
+    name: string;
+    phases: PhaseSpec[];
+  } | null;
+}
+
+/**
+ * Core Tyr service — saga lifecycle, planning, and decomposition.
+ *
+ * Lifted verbatim from web/src/modules/tyr/ports/tyr.port.ts; camelCase
+ * field names replace snake_case in the request types.
+ */
+export interface ITyrService {
+  getSagas(): Promise<Saga[]>;
+  getSaga(id: string): Promise<Saga | null>;
+  getPhases(sagaId: string): Promise<Phase[]>;
+  createSaga(spec: string, repo: string): Promise<Saga>;
+  commitSaga(request: CommitSagaRequest): Promise<Saga>;
+  decompose(spec: string, repo: string): Promise<Phase[]>;
+  spawnPlanSession(spec: string, repo: string): Promise<PlanSession>;
+  extractStructure(text: string): Promise<ExtractedStructure>;
+}
+
+// ---------------------------------------------------------------------------
+// IDispatcherService — autonomous execution queue
+// ---------------------------------------------------------------------------
+
+/**
+ * Dispatcher control service.
+ *
+ * Lifted from web/src/modules/tyr/ports/dispatcher.port.ts.
+ */
+export interface IDispatcherService {
+  getState(): Promise<DispatcherState | null>;
+  setRunning(running: boolean): Promise<void>;
+  setThreshold(threshold: number): Promise<void>;
+  setAutoContinue(autoContinue: boolean): Promise<void>;
+  getLog(): Promise<string[]>;
+}
+
+// ---------------------------------------------------------------------------
+// ITyrSessionService — raid session approval flow
+// ---------------------------------------------------------------------------
+
+/**
+ * Session management service.
+ *
+ * Lifted from web/src/modules/tyr/ports/session.port.ts.
+ */
+export interface ITyrSessionService {
+  getSessions(): Promise<SessionInfo[]>;
+  getSession(id: string): Promise<SessionInfo | null>;
+  approve(sessionId: string): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// ITrackerBrowserService — external issue tracker browsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Tracker browser service.
+ *
+ * Lifted from web/src/modules/tyr/ports/tracker.port.ts.
+ */
+export interface ITrackerBrowserService {
+  listProjects(): Promise<TrackerProject[]>;
+  getProject(projectId: string): Promise<TrackerProject>;
+  listMilestones(projectId: string): Promise<TrackerMilestone[]>;
+  listIssues(projectId: string, milestoneId?: string): Promise<TrackerIssue[]>;
+  importProject(projectId: string, repos: string[], baseBranch?: string): Promise<Saga>;
+}
+
+// ---------------------------------------------------------------------------
+// ITyrIntegrationService — external integration connections
+// ---------------------------------------------------------------------------
+
+export interface IntegrationConnection {
+  id: string;
+  integrationType: string;
+  adapter: string;
+  credentialName: string;
+  enabled: boolean;
+  status: string;
+  createdAt: string;
+}
+
+export interface TelegramSetupResult {
+  deeplink: string;
+  token: string;
+}
+
+export interface CreateIntegrationParams {
+  integrationType: string;
+  adapter: string;
+  credentialName: string;
+  credentialValue: string;
+  config: Record<string, string>;
+}
+
+export interface ConnectionTestResult {
+  success: boolean;
+  message: string;
+}
+
+/**
+ * Integration connection management service.
+ *
+ * Lifted from web/src/modules/tyr/ports/integrations.port.ts.
+ */
+export interface ITyrIntegrationService {
+  listIntegrations(): Promise<IntegrationConnection[]>;
+  createIntegration(params: CreateIntegrationParams): Promise<IntegrationConnection>;
+  deleteIntegration(id: string): Promise<void>;
+  toggleIntegration(id: string, enabled: boolean): Promise<IntegrationConnection>;
+  testConnection(id: string): Promise<ConnectionTestResult>;
+  getTelegramSetup(): Promise<TelegramSetupResult>;
+}

--- a/web-next/packages/plugin-tyr/src/ui/TyrPage.test.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/TyrPage.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ServicesProvider } from '@niuulabs/plugin-sdk';
+import { TyrPage } from './TyrPage';
+import { createMockTyrService } from '../adapters/mock';
+
+function wrap(services: Record<string, unknown>) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>
+        <ServicesProvider services={services}>{children}</ServicesProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('TyrPage', () => {
+  it('renders the page title', async () => {
+    render(<TyrPage />, {
+      wrapper: wrap({ tyr: createMockTyrService() }),
+    });
+    expect(screen.getByText(/tyr/)).toBeInTheDocument();
+  });
+
+  it('shows loading state then saga count', async () => {
+    render(<TyrPage />, {
+      wrapper: wrap({ tyr: createMockTyrService() }),
+    });
+    await waitFor(() => expect(screen.getByText(/3 sagas loaded/)).toBeInTheDocument());
+  });
+
+  it('renders the Tyr rune glyph', async () => {
+    render(<TyrPage />, {
+      wrapper: wrap({ tyr: createMockTyrService() }),
+    });
+    expect(screen.getByText('ᛏ')).toBeInTheDocument();
+  });
+
+  it('shows error state when service throws', async () => {
+    const failing = {
+      getSagas: async () => {
+        throw new Error('tyr unavailable');
+      },
+    };
+    render(<TyrPage />, {
+      wrapper: wrap({ tyr: failing }),
+    });
+    await waitFor(() => expect(screen.getByText('tyr unavailable')).toBeInTheDocument());
+  });
+
+  it('shows singular "saga" for a single result', async () => {
+    const single = {
+      getSagas: async () => [
+        {
+          id: '00000000-0000-0000-0000-000000000001',
+          trackerId: 'NIU-1',
+          trackerType: 'linear',
+          slug: 'test',
+          name: 'Test Saga',
+          repos: [],
+          featureBranch: 'feat/test',
+          status: 'active' as const,
+          confidence: 80,
+          createdAt: '2026-01-01T00:00:00Z',
+          phaseSummary: { total: 1, completed: 0 },
+        },
+      ],
+    };
+    render(<TyrPage />, { wrapper: wrap({ tyr: single }) });
+    await waitFor(() => expect(screen.getByText(/1 saga loaded/)).toBeInTheDocument());
+  });
+});

--- a/web-next/packages/plugin-tyr/src/ui/TyrPage.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/TyrPage.tsx
@@ -19,9 +19,9 @@ export function TyrPage() {
       </div>
 
       <p style={{ color: 'var(--color-text-secondary)' }}>
-        Tyr is the autonomous execution engine. It decomposes product goals into Sagas, breaks
-        Sagas into phased Raids, and dispatches Raids to autonomous agents. This placeholder will
-        be replaced by the full Tyr UI.
+        Tyr is the autonomous execution engine. It decomposes product goals into Sagas, breaks Sagas
+        into phased Raids, and dispatches Raids to autonomous agents. This placeholder will be
+        replaced by the full Tyr UI.
       </p>
 
       {isLoading && (

--- a/web-next/packages/plugin-tyr/src/ui/TyrPage.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/TyrPage.tsx
@@ -1,0 +1,48 @@
+import { Rune, StateDot } from '@niuulabs/ui';
+import { useSagas } from './useSagas';
+
+export function TyrPage() {
+  const { data, isLoading, isError, error } = useSagas();
+
+  return (
+    <div style={{ padding: 'var(--space-6)', maxWidth: 720 }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--space-3)',
+          marginBottom: 'var(--space-4)',
+        }}
+      >
+        <Rune glyph="ᛏ" size={32} />
+        <h2 style={{ margin: 0 }}>tyr · sagas · raids · dispatch</h2>
+      </div>
+
+      <p style={{ color: 'var(--color-text-secondary)' }}>
+        Tyr is the autonomous execution engine. It decomposes product goals into Sagas, breaks
+        Sagas into phased Raids, and dispatches Raids to autonomous agents. This placeholder will
+        be replaced by the full Tyr UI.
+      </p>
+
+      {isLoading && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)' }}>
+          <StateDot state="processing" pulse />
+          <span>loading sagas…</span>
+        </div>
+      )}
+
+      {isError && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)' }}>
+          <StateDot state="failed" />
+          <span>{error instanceof Error ? error.message : 'unknown error'}</span>
+        </div>
+      )}
+
+      {data && (
+        <p style={{ color: 'var(--color-text-secondary)' }}>
+          {data.length} saga{data.length !== 1 ? 's' : ''} loaded.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/web-next/packages/plugin-tyr/src/ui/useSagas.test.ts
+++ b/web-next/packages/plugin-tyr/src/ui/useSagas.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ServicesProvider } from '@niuulabs/plugin-sdk';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
+import { useSagas } from './useSagas';
+import type { Saga } from '../domain/saga';
+
+const sampleSaga: Saga = {
+  id: '00000000-0000-0000-0000-000000000001',
+  trackerId: 'NIU-001',
+  trackerType: 'linear',
+  slug: 'auth-rewrite',
+  name: 'Auth Rewrite',
+  repos: ['niuulabs/volundr'],
+  featureBranch: 'feat/auth-rewrite',
+  status: 'active',
+  confidence: 80,
+  createdAt: '2026-01-01T00:00:00Z',
+  phaseSummary: { total: 3, completed: 1 },
+};
+
+function makeWrapper(service: Record<string, unknown>) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(
+      QueryClientProvider,
+      { client },
+      createElement(ServicesProvider, { services: service }, children),
+    );
+  };
+}
+
+describe('useSagas', () => {
+  it('returns sagas list from the service', async () => {
+    const svc = { getSagas: vi.fn().mockResolvedValue([sampleSaga]) };
+
+    const { result } = renderHook(() => useSagas(), {
+      wrapper: makeWrapper({ tyr: svc }),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data?.[0]?.name).toBe('Auth Rewrite');
+    expect(svc.getSagas).toHaveBeenCalled();
+  });
+
+  it('enters error state when service rejects', async () => {
+    const svc = {
+      getSagas: vi.fn().mockRejectedValue(new Error('service unavailable')),
+    };
+
+    const { result } = renderHook(() => useSagas(), {
+      wrapper: makeWrapper({ tyr: svc }),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+
+  it('starts in loading state', () => {
+    const svc = {
+      getSagas: vi.fn().mockReturnValue(new Promise(() => undefined)),
+    };
+
+    const { result } = renderHook(() => useSagas(), {
+      wrapper: makeWrapper({ tyr: svc }),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+  });
+});

--- a/web-next/packages/plugin-tyr/src/ui/useSagas.ts
+++ b/web-next/packages/plugin-tyr/src/ui/useSagas.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { useService } from '@niuulabs/plugin-sdk';
+import type { ITyrService } from '../ports';
+
+export function useSagas() {
+  const tyr = useService<ITyrService>('tyr');
+  return useQuery({
+    queryKey: ['tyr', 'sagas'],
+    queryFn: () => tyr.getSagas(),
+  });
+}

--- a/web-next/packages/plugin-tyr/tsconfig.json
+++ b/web-next/packages/plugin-tyr/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "**/*.stories.tsx"]
+}

--- a/web-next/packages/plugin-tyr/tsup.config.ts
+++ b/web-next/packages/plugin-tyr/tsup.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  external: [
+    'react',
+    '@tanstack/react-query',
+    '@tanstack/react-router',
+    '@niuulabs/plugin-sdk',
+    '@niuulabs/ui',
+    '@niuulabs/domain',
+  ],
+});

--- a/web-next/pnpm-lock.yaml
+++ b/web-next/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       '@niuulabs/plugin-sdk':
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
+      '@niuulabs/plugin-tyr':
+        specifier: workspace:*
+        version: link:../../packages/plugin-tyr
       '@niuulabs/plugin-volundr':
         specifier: workspace:*
         version: link:../../packages/plugin-volundr
@@ -479,6 +482,43 @@ importers:
         specifier: ^3.24.1
         version: 3.25.76
     devDependencies:
+      '@tanstack/react-router':
+        specifier: ^1.95.0
+        version: 1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@types/react':
+        specifier: ^19.0.7
+        version: 19.2.14
+      react:
+        specifier: ^19.0.0
+        version: 19.2.5
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(jiti@1.21.7)(postcss@8.5.10)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
+  packages/plugin-tyr:
+    dependencies:
+      '@niuulabs/domain':
+        specifier: workspace:*
+        version: link:../domain
+      '@niuulabs/plugin-sdk':
+        specifier: workspace:*
+        version: link:../plugin-sdk
+      '@niuulabs/query':
+        specifier: workspace:*
+        version: link:../query
+      '@niuulabs/ui':
+        specifier: workspace:*
+        version: link:../ui
+      zod:
+        specifier: ^3.24.1
+        version: 3.25.76
+    devDependencies:
+      '@tanstack/react-query':
+        specifier: ^5.62.0
+        version: 5.99.1(react@19.2.5)
       '@tanstack/react-router':
         specifier: ^1.95.0
         version: 1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)

--- a/web-next/vitest.config.ts
+++ b/web-next/vitest.config.ts
@@ -9,7 +9,6 @@ export default defineConfig({
       '@niuulabs/auth': resolve(__dirname, 'packages/auth/src/index.ts'),
       '@niuulabs/domain': resolve(__dirname, 'packages/domain/src/index.ts'),
       '@niuulabs/design-tokens': resolve(__dirname, 'packages/design-tokens/src/index.ts'),
-      '@niuulabs/domain': resolve(__dirname, 'packages/domain/src/index.ts'),
       '@niuulabs/plugin-hello': resolve(__dirname, 'packages/plugin-hello/src/index.tsx'),
       '@niuulabs/plugin-tyr': resolve(__dirname, 'packages/plugin-tyr/src/index.ts'),
       '@niuulabs/plugin-login': resolve(__dirname, 'packages/plugin-login/src/index.ts'),

--- a/web-next/vitest.config.ts
+++ b/web-next/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
       '@niuulabs/design-tokens': resolve(__dirname, 'packages/design-tokens/src/index.ts'),
       '@niuulabs/domain': resolve(__dirname, 'packages/domain/src/index.ts'),
       '@niuulabs/plugin-hello': resolve(__dirname, 'packages/plugin-hello/src/index.tsx'),
+      '@niuulabs/plugin-tyr': resolve(__dirname, 'packages/plugin-tyr/src/index.ts'),
       '@niuulabs/plugin-login': resolve(__dirname, 'packages/plugin-login/src/index.ts'),
       '@niuulabs/plugin-sdk': resolve(__dirname, 'packages/plugin-sdk/src/index.ts'),
       '@niuulabs/query': resolve(__dirname, 'packages/query/src/index.ts'),


### PR DESCRIPTION
## Summary

Scaffolds the `@niuulabs/plugin-tyr` package — the canonical Tyr plugin for the composable `web-next/` UI. Follows the hexagonal architecture established by `plugin-ravn`.

### What's included

**Domain value objects** (Zod schemas, fully tested):
- `Saga / Phase / Raid` — lifecycle statuses (`active/complete/failed`, `pending/active/gated/complete`, `pending/queued/running/review/escalated/merged/failed`), confidence scoring (0–100)
- `Workflow` — DAG value object with three node kinds (`stage`, `gate`, `cond`), bezier edges, and `validateWorkflow()` that enforces: unique node IDs, no dangling edge references, no self-loops, no duplicate edges
- `DispatcherState / DispatchRule` — autonomous execution engine configuration
- `SessionInfo` — Tyr raid session with approval flow status
- `TrackerProject / TrackerMilestone / TrackerIssue` — external issue tracker browser types

**Ports** (lifted verbatim from `web/src/modules/tyr/ports/`):
- `ITyrService` — saga CRUD, planning, decomposition
- `IDispatcherService` — queue pause/resume, threshold, auto-continue
- `ITyrSessionService` — session listing and approval
- `ITrackerBrowserService` — project/milestone/issue browsing + import
- `ITyrIntegrationService` — external integration connections

**HTTP adapters** (one factory per port; snake↔camelCase transforms, migrated from `web/src/modules/tyr/adapters/api/`):
- `buildTyrHttpAdapter`, `buildDispatcherHttpAdapter`, `buildTyrSessionHttpAdapter`, `buildTrackerHttpAdapter`, `buildTyrIntegrationHttpAdapter`

**Mock adapters** (seeded in-memory, swappable at startup):
- `createMockTyrService` (3 seed sagas, 3 phases, 2 raids)
- `createMockDispatcherService`, `createMockTyrSessionService`, `createMockTrackerService`, `createMockTyrIntegrationService`

**UI placeholder**:
- `TyrPage` — rune `ᛏ`, `useSagas` TanStack Query hook, loading/error/count states; registered at `/tyr`

**App integration**:
- `tyrPlugin` registered in `apps/niuu/src/plugins.ts`
- Mock services wired in `apps/niuu/src/services.ts` (HTTP adapters activate when `config.services.tyr.mode === 'http'`)
- `@niuulabs/plugin-tyr: workspace:*` added to `apps/niuu/package.json`
- `vitest.config.ts` alias added for test resolution

### Test coverage

126 new tests across domain schemas, HTTP adapters, mock adapters, and UI. All 1691 tests in the monorepo pass. Coverage > 85% on all metrics.

## Test plan
- [x] `pnpm exec vitest run` — all 1691 tests pass
- [x] Coverage > 85% statements/branches/functions/lines
- [x] Domain invariants: saga status state machine, workflow DAG invariants
- [x] HTTP adapter: snake↔camelCase transforms, URL encoding, null handling, interface compliance
- [x] Mock adapters: CRUD mutations, approval flow, error cases
- [x] UI: loading/error/data states, rune glyph, singular/plural count

Closes NIU-679. Blocks every Tyr page ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)