### PR TITLE
feat(ravn): Overview + Ravens + RavnDetail pages (NIU-672)

### DIFF
--- a/web-next/e2e/ravn.spec.ts
+++ b/web-next/e2e/ravn.spec.ts
@@ -1,23 +1,182 @@
 import { test, expect } from '@playwright/test';
 
+// ─── Navigation ────────────────────────────────────────────────────────────────
+
 test('ravn plugin renders at /ravn', async ({ page }) => {
   await page.goto('/ravn');
-  await expect(page.getByText(/ravn · personas · ravens · sessions/)).toBeVisible();
+  await expect(page.getByTestId('ravn-page')).toBeVisible();
 });
 
-test('ravn shows persona count after loading', async ({ page }) => {
-  await page.goto('/ravn');
-  await expect(page.getByText(/loading/).or(page.getByText(/personas loaded/))).toBeVisible();
-  await expect(page.getByText(/21 personas loaded/)).toBeVisible({ timeout: 5000 });
-});
-
-test('rail shows ravn rune ᚱ', async ({ page }) => {
+test('ravn page shows the rune glyph ᚱ', async ({ page }) => {
   await page.goto('/ravn');
   await expect(page.getByText('ᚱ').first()).toBeVisible();
 });
 
-test('deep-link /ravn renders ravn page directly', async ({ page }) => {
+test('ravn page title is visible', async ({ page }) => {
   await page.goto('/ravn');
-  await expect(page.getByText(/ravn · personas · ravens · sessions/)).toBeVisible();
-  await expect(page.getByText(/21 personas loaded/)).toBeVisible({ timeout: 5000 });
+  await expect(page.getByText(/Ravn · the flock/)).toBeVisible();
+});
+
+test('deep-link /ravn renders overview by default', async ({ page }) => {
+  await page.goto('/ravn');
+  await expect(page.getByTestId('overview-page')).toBeVisible({ timeout: 5000 });
+});
+
+// ─── Overview ──────────────────────────────────────────────────────────────────
+
+test('overview shows KPI strip', async ({ page }) => {
+  await page.goto('/ravn');
+  await expect(page.getByTestId('overview-page')).toBeVisible({ timeout: 5000 });
+  await expect(page.getByTestId('kpi-total')).toBeVisible();
+  await expect(page.getByTestId('kpi-active')).toBeVisible();
+});
+
+test('overview shows fleet sparkline', async ({ page }) => {
+  await page.goto('/ravn');
+  await expect(page.getByTestId('fleet-sparkline')).toBeVisible({ timeout: 5000 });
+});
+
+test('overview shows active ravens list', async ({ page }) => {
+  await page.goto('/ravn');
+  await expect(page.getByTestId('active-ravens-list')).toBeVisible({ timeout: 5000 });
+});
+
+test('overview shows log tail', async ({ page }) => {
+  await page.goto('/ravn');
+  await expect(page.getByTestId('log-tail')).toBeVisible({ timeout: 5000 });
+});
+
+// ─── Tab navigation ────────────────────────────────────────────────────────────
+
+test('clicking Ravens tab shows the ravens page', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByTestId('ravn-tab-ravens').click();
+  await expect(page.getByTestId('ravens-page')).toBeVisible({ timeout: 5000 });
+});
+
+test('clicking Overview tab returns to overview', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByTestId('ravn-tab-ravens').click();
+  await expect(page.getByTestId('ravens-page')).toBeVisible({ timeout: 3000 });
+  await page.getByTestId('ravn-tab-overview').click();
+  await expect(page.getByTestId('overview-page')).toBeVisible({ timeout: 3000 });
+});
+
+// ─── Layout variant switching ──────────────────────────────────────────────────
+
+test('ravens page: switch to table layout', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByTestId('ravn-tab-ravens').click();
+  await expect(page.getByTestId('ravens-page')).toBeVisible({ timeout: 5000 });
+
+  await page.getByTestId('layout-btn-table').click();
+  await expect(page.getByTestId('layout-table')).toBeVisible();
+  await expect(page.getByTestId('layout-split')).not.toBeVisible();
+});
+
+test('ravens page: switch to cards layout', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByTestId('ravn-tab-ravens').click();
+  await expect(page.getByTestId('ravens-page')).toBeVisible({ timeout: 5000 });
+
+  await page.getByTestId('layout-btn-cards').click();
+  await expect(page.getByTestId('layout-cards')).toBeVisible();
+});
+
+test('ravens page: switch split → table → cards → split', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByTestId('ravn-tab-ravens').click();
+  await expect(page.getByTestId('layout-split')).toBeVisible({ timeout: 5000 });
+
+  await page.getByTestId('layout-btn-table').click();
+  await expect(page.getByTestId('layout-table')).toBeVisible();
+
+  await page.getByTestId('layout-btn-cards').click();
+  await expect(page.getByTestId('layout-cards')).toBeVisible();
+
+  await page.getByTestId('layout-btn-split').click();
+  await expect(page.getByTestId('layout-split')).toBeVisible();
+});
+
+// ─── Grouping ──────────────────────────────────────────────────────────────────
+
+test('ravens page: group by state shows state groups', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByTestId('ravn-tab-ravens').click();
+  await expect(page.getByTestId('ravens-page')).toBeVisible({ timeout: 5000 });
+  await expect(page.getByTestId('layout-split')).toBeVisible({ timeout: 3000 });
+
+  const selector = page.getByTestId('grouping-selector');
+  await selector.selectOption('state');
+
+  // At least one state group header should be visible (e.g. "active")
+  await expect(page.getByText(/^active$/i).first()).toBeVisible({ timeout: 3000 });
+});
+
+test('ravens page: group by persona shows persona names as group headers', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByTestId('ravn-tab-ravens').click();
+  await expect(page.getByTestId('layout-split')).toBeVisible({ timeout: 5000 });
+
+  await page.getByTestId('grouping-selector').selectOption('persona');
+  // Each ravn is its own group — ravn list rows still visible
+  await expect(page.getByTestId('ravn-list-row').first()).toBeVisible({ timeout: 3000 });
+});
+
+// ─── Expanding a ravn ──────────────────────────────────────────────────────────
+
+test('ravens page: clicking a ravn opens the detail pane', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByTestId('ravn-tab-ravens').click();
+  await expect(page.getByTestId('ravens-page')).toBeVisible({ timeout: 5000 });
+  await expect(page.getByTestId('detail-empty')).toBeVisible({ timeout: 3000 });
+
+  await page.getByTestId('ravn-list-row').first().click();
+  await expect(page.getByTestId('ravn-detail')).toBeVisible({ timeout: 3000 });
+});
+
+test('ravens page: ravn detail has 6 collapsible sections', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByTestId('ravn-tab-ravens').click();
+  await page.getByTestId('ravn-list-row').first().click();
+  await expect(page.getByTestId('ravn-detail')).toBeVisible({ timeout: 5000 });
+
+  for (const id of ['overview', 'triggers', 'activity', 'sessions', 'connectivity', 'delete']) {
+    await expect(page.getByTestId(`ravn-detail-section-${id}`)).toBeVisible();
+  }
+});
+
+test('ravens page: collapsing and expanding a section', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByTestId('ravn-tab-ravens').click();
+  await page.getByTestId('ravn-list-row').first().click();
+  await expect(page.getByTestId('section-body-overview')).toBeVisible({ timeout: 5000 });
+
+  // Collapse
+  await page.getByTestId('section-toggle-overview').click();
+  await expect(page.getByTestId('section-body-overview')).not.toBeVisible();
+
+  // Expand
+  await page.getByTestId('section-toggle-overview').click();
+  await expect(page.getByTestId('section-body-overview')).toBeVisible();
+});
+
+test('ravens page: closing detail pane shows empty state', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByTestId('ravn-tab-ravens').click();
+  await page.getByTestId('ravn-list-row').first().click();
+  await expect(page.getByTestId('detail-close-btn')).toBeVisible({ timeout: 5000 });
+  await page.getByTestId('detail-close-btn').click();
+  await expect(page.getByTestId('detail-empty')).toBeVisible({ timeout: 3000 });
+});
+
+// ─── Accessibility ─────────────────────────────────────────────────────────────
+
+test('ravn tabs are keyboard navigable', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByTestId('ravn-tab-overview').focus();
+  // Tab to the next tab
+  await page.keyboard.press('Tab');
+  await page.keyboard.press('Space');
+  await expect(page.getByTestId('ravens-page')).toBeVisible({ timeout: 5000 });
 });

--- a/web-next/packages/plugin-ravn/src/ui/OverviewPage.css
+++ b/web-next/packages/plugin-ravn/src/ui/OverviewPage.css
@@ -1,0 +1,168 @@
+/* Page container */
+.rv-overview {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+  padding: var(--space-6);
+}
+
+/* 2-column grid */
+.rv-overview__grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-6);
+  align-items: start;
+}
+
+/* Section headings */
+.rv-section-heading {
+  margin: 0 0 var(--space-3);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+/* Active ravens list */
+.rv-active-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.rv-active-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-bg-secondary);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+}
+
+.rv-active-row__name {
+  font-size: var(--text-sm);
+  font-weight: 500;
+  flex: 1;
+}
+
+.rv-active-row__model {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+}
+
+/* Fleet sparkline */
+.rv-fleet-sparkline {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-bg-secondary);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+}
+
+.rv-fleet-sparkline__label {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+/* Top spenders list */
+.rv-spenders-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.rv-spender-row {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-bg-secondary);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+}
+
+.rv-spender-row__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.rv-spender-row__name {
+  font-size: var(--text-sm);
+  font-weight: 500;
+}
+
+.rv-spender-row__amount {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+}
+
+/* Log tail */
+.rv-log-panel {
+  background: var(--color-bg-secondary);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  overflow: hidden;
+}
+
+.rv-log-empty {
+  padding: var(--space-4);
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+}
+
+.rv-log-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+}
+
+.rv-log-thead-row {
+  border-bottom: 1px solid var(--color-border);
+}
+
+.rv-log-th {
+  padding: var(--space-2) var(--space-3);
+  text-align: left;
+  color: var(--color-text-muted);
+  font-weight: 500;
+}
+
+.rv-log-row {
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.rv-log-td--time {
+  padding: var(--space-2) var(--space-3);
+  color: var(--color-text-muted);
+}
+
+.rv-log-td--persona {
+  padding: var(--space-2) var(--space-3);
+  color: var(--color-text-secondary);
+}
+
+.rv-log-td--event {
+  padding: var(--space-2) var(--space-3);
+  color: var(--color-text-primary);
+}
+
+/* Empty state */
+.rv-empty-text {
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+}

--- a/web-next/packages/plugin-ravn/src/ui/OverviewPage.stories.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/OverviewPage.stories.tsx
@@ -1,0 +1,85 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ServicesProvider } from '@niuulabs/plugin-sdk';
+import { OverviewPage } from './OverviewPage';
+import {
+  createMockRavenStream,
+  createMockTriggerStore,
+  createMockSessionStream,
+  createMockBudgetStream,
+} from '../adapters/mock';
+
+function makeServices(overrides?: Record<string, unknown>) {
+  return {
+    'ravn.ravens': createMockRavenStream(),
+    'ravn.triggers': createMockTriggerStore(),
+    'ravn.sessions': createMockSessionStream(),
+    'ravn.budget': createMockBudgetStream(),
+    ...overrides,
+  };
+}
+
+function withProviders(services: Record<string, unknown>) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Decorator({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>
+        <ServicesProvider services={services}>{children}</ServicesProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+const meta: Meta<typeof OverviewPage> = {
+  title: 'Plugins / Ravn / OverviewPage',
+  component: OverviewPage,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => {
+      const D = withProviders(makeServices());
+      return (
+        <div style={{ height: '100vh', background: 'var(--color-bg-primary)' }}>
+          <D>
+            <Story />
+          </D>
+        </div>
+      );
+    },
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof OverviewPage>;
+
+/** Live mock data — overview with 6 ravens, 5 triggers, budget spend visible. */
+export const Default: Story = {};
+
+/** Fleet is empty — all lists show empty states. */
+export const Empty: Story = {
+  decorators: [
+    (Story) => {
+      const D = withProviders(
+        makeServices({
+          'ravn.ravens': {
+            listRavens: () => Promise.resolve([]),
+            getRaven: () => Promise.resolve(null),
+          },
+          'ravn.triggers': { listTriggers: () => Promise.resolve([]) },
+          'ravn.sessions': {
+            listSessions: () => Promise.resolve([]),
+            getSession: () => Promise.resolve(null),
+            getMessages: () => Promise.resolve([]),
+          },
+        }),
+      );
+      return (
+        <div style={{ height: '100vh', background: 'var(--color-bg-primary)' }}>
+          <D>
+            <Story />
+          </D>
+        </div>
+      );
+    },
+  ],
+};

--- a/web-next/packages/plugin-ravn/src/ui/OverviewPage.test.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/OverviewPage.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ServicesProvider } from '@niuulabs/plugin-sdk';
+import { OverviewPage } from './OverviewPage';
+import {
+  createMockRavenStream,
+  createMockTriggerStore,
+  createMockSessionStream,
+  createMockBudgetStream,
+} from '../adapters/mock';
+
+function makeServices(overrides?: Record<string, unknown>) {
+  return {
+    'ravn.ravens': createMockRavenStream(),
+    'ravn.triggers': createMockTriggerStore(),
+    'ravn.sessions': createMockSessionStream(),
+    'ravn.budget': createMockBudgetStream(),
+    ...overrides,
+  };
+}
+
+function wrap(services = makeServices()) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>
+        <ServicesProvider services={services}>{children}</ServicesProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('OverviewPage', () => {
+  it('shows loading state initially', () => {
+    const slow = { listRavens: () => new Promise(() => undefined) };
+    render(<OverviewPage />, { wrapper: wrap(makeServices({ 'ravn.ravens': slow })) });
+    expect(screen.getByTestId('overview-loading')).toBeInTheDocument();
+  });
+
+  it('renders the KPI strip after loading', async () => {
+    render(<OverviewPage />, { wrapper: wrap() });
+    await waitFor(() => expect(screen.getByTestId('overview-page')).toBeInTheDocument());
+    // KPI cards
+    expect(screen.getByTestId('kpi-total')).toBeInTheDocument();
+    expect(screen.getByTestId('kpi-active')).toBeInTheDocument();
+    expect(screen.getByTestId('kpi-suspended')).toBeInTheDocument();
+    expect(screen.getByTestId('kpi-triggers')).toBeInTheDocument();
+  });
+
+  it('renders the active ravens list', async () => {
+    render(<OverviewPage />, { wrapper: wrap() });
+    await waitFor(() => expect(screen.getByTestId('active-ravens-list')).toBeInTheDocument());
+    const rows = screen.getAllByTestId('active-ravn-row');
+    expect(rows.length).toBeGreaterThan(0);
+  });
+
+  it('renders the fleet sparkline widget', async () => {
+    render(<OverviewPage />, { wrapper: wrap() });
+    await waitFor(() => expect(screen.getByTestId('fleet-sparkline')).toBeInTheDocument());
+  });
+
+  it('renders the top spenders list', async () => {
+    render(<OverviewPage />, { wrapper: wrap() });
+    await waitFor(() => expect(screen.getByTestId('top-spenders-list')).toBeInTheDocument());
+  });
+
+  it('renders the log tail section', async () => {
+    render(<OverviewPage />, { wrapper: wrap() });
+    await waitFor(() => expect(screen.getByTestId('log-tail')).toBeInTheDocument());
+  });
+
+  it('shows error state when ravens service fails', async () => {
+    const failing = { listRavens: () => Promise.reject(new Error('fleet offline')) };
+    render(<OverviewPage />, {
+      wrapper: wrap(makeServices({ 'ravn.ravens': failing })),
+    });
+    await waitFor(() => expect(screen.getByTestId('overview-error')).toBeInTheDocument());
+    expect(screen.getByText(/fleet offline/i)).toBeInTheDocument();
+  });
+
+  it('shows "No active ravens" when all ravens are idle', async () => {
+    const noActive = {
+      listRavens: () =>
+        Promise.resolve([
+          {
+            id: 'id-1',
+            personaName: 'idle-ravn',
+            status: 'idle' as const,
+            model: 'claude-sonnet-4-6',
+            createdAt: '2026-04-15T09:00:00Z',
+          },
+        ]),
+      getRaven: () => Promise.resolve(null),
+    };
+    render(<OverviewPage />, {
+      wrapper: wrap(makeServices({ 'ravn.ravens': noActive })),
+    });
+    await waitFor(() => expect(screen.getByText(/no active ravens/i)).toBeInTheDocument());
+  });
+});

--- a/web-next/packages/plugin-ravn/src/ui/OverviewPage.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/OverviewPage.tsx
@@ -1,0 +1,410 @@
+import {
+  KpiStrip,
+  KpiCard,
+  BudgetBar,
+  Sparkline,
+  StateDot,
+  LoadingState,
+  ErrorState,
+} from '@niuulabs/ui';
+import { useRavens } from './hooks/useRavens';
+import { useTriggers } from './hooks/useTriggers';
+import { useSessions } from './hooks/useSessions';
+import { useFleetBudget, useRavnBudgets } from './hooks/useBudget';
+import { topBudgetSpenders } from './grouping';
+
+const LOG_TAIL_LIMIT = 20;
+const TOP_SPENDERS_COUNT = 5;
+const FLEET_SPARKLINE_SAMPLES = 24;
+
+function generateHourlySpend(seed: number): number[] {
+  // Deterministic pseudo-hourly cost based on fleet budget seed
+  const values: number[] = [];
+  let v = 0.2 + (seed % 100) / 500;
+  for (let i = 0; i < FLEET_SPARKLINE_SAMPLES; i++) {
+    v = Math.max(0, Math.min(1, v + (((seed * (i + 1)) % 37) / 37 - 0.42) * 0.18));
+    values.push(v);
+  }
+  return values;
+}
+
+export function OverviewPage() {
+  const ravens = useRavens();
+  const triggers = useTriggers();
+  const sessions = useSessions();
+  const fleetBudget = useFleetBudget();
+
+  const ravnList = ravens.data ?? [];
+  const ravnIds = ravnList.map((r) => r.id);
+  const budgets = useRavnBudgets(ravnIds);
+
+  const activeCount = ravnList.filter((r) => r.status === 'active').length;
+  const suspendedCount = ravnList.filter((r) => r.status === 'suspended').length;
+  const triggerCount = triggers.data?.length ?? 0;
+  const sessionCount = sessions.data?.length ?? 0;
+
+  const fleetBudgetData = fleetBudget.data;
+  const sparklineSeed = Math.round((fleetBudgetData?.spentUsd ?? 0) * 100);
+  const hourlyValues = generateHourlySpend(sparklineSeed);
+
+  const spenders = topBudgetSpenders(ravnList, budgets, TOP_SPENDERS_COUNT);
+
+  const allMessages =
+    sessions.data?.flatMap((s) => [
+      {
+        key: s.id,
+        ts: s.createdAt,
+        text: `session ${s.id.slice(0, 8)} — ${s.status}`,
+        persona: s.personaName,
+      },
+    ]) ?? [];
+  const logTail = [...allMessages]
+    .sort((a, b) => b.ts.localeCompare(a.ts))
+    .slice(0, LOG_TAIL_LIMIT);
+
+  if (ravens.isLoading || sessions.isLoading || triggers.isLoading) {
+    return (
+      <div data-testid="overview-loading">
+        <LoadingState label="Loading fleet overview…" />
+      </div>
+    );
+  }
+
+  if (ravens.isError) {
+    return (
+      <div data-testid="overview-error">
+        <ErrorState
+          message={ravens.error instanceof Error ? ravens.error.message : 'Failed to load ravens'}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-testid="overview-page"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 'var(--space-6)',
+        padding: 'var(--space-6)',
+      }}
+    >
+      {/* KPI strip */}
+      <KpiStrip>
+        <div data-testid="kpi-total">
+          <KpiCard label="Total ravens" value={ravnList.length} />
+        </div>
+        <div data-testid="kpi-active">
+          <KpiCard label="Active" value={activeCount} deltaTrend="neutral" />
+        </div>
+        <div data-testid="kpi-suspended">
+          <KpiCard label="Suspended" value={suspendedCount} deltaTrend="neutral" />
+        </div>
+        <div data-testid="kpi-triggers">
+          <KpiCard label="Triggers" value={triggerCount} />
+        </div>
+        <div data-testid="kpi-spend">
+          <KpiCard
+            label="Fleet spend"
+            value={fleetBudgetData ? `$${fleetBudgetData.spentUsd.toFixed(2)}` : '—'}
+            sparkline={<Sparkline values={hourlyValues} width={48} height={20} />}
+          />
+        </div>
+        <div data-testid="kpi-sessions">
+          <KpiCard label="Sessions" value={sessionCount} />
+        </div>
+      </KpiStrip>
+
+      {/* 2-column body */}
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr',
+          gap: 'var(--space-6)',
+          alignItems: 'start',
+        }}
+      >
+        {/* Left: Active ravens list */}
+        <section aria-labelledby="active-ravens-heading">
+          <h3
+            id="active-ravens-heading"
+            style={{
+              margin: '0 0 var(--space-3)',
+              fontSize: 'var(--text-sm)',
+              fontWeight: 600,
+              color: 'var(--color-text-secondary)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.06em',
+            }}
+          >
+            Active ravens
+          </h3>
+          {ravnList.filter((r) => r.status === 'active').length === 0 ? (
+            <p style={{ color: 'var(--color-text-muted)', fontSize: 'var(--text-sm)' }}>
+              No active ravens
+            </p>
+          ) : (
+            <ul
+              style={{
+                listStyle: 'none',
+                margin: 0,
+                padding: 0,
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 'var(--space-2)',
+              }}
+              data-testid="active-ravens-list"
+            >
+              {ravnList
+                .filter((r) => r.status === 'active')
+                .map((r) => (
+                  <li
+                    key={r.id}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 'var(--space-3)',
+                      padding: 'var(--space-2) var(--space-3)',
+                      background: 'var(--color-bg-secondary)',
+                      borderRadius: 'var(--radius-md)',
+                      border: '1px solid var(--color-border)',
+                    }}
+                    data-testid="active-ravn-row"
+                  >
+                    <StateDot state="ok" pulse size={8} />
+                    <span style={{ fontSize: 'var(--text-sm)', fontWeight: 500, flex: 1 }}>
+                      {r.personaName}
+                    </span>
+                    <span
+                      style={{
+                        fontSize: 'var(--text-xs)',
+                        color: 'var(--color-text-muted)',
+                        fontFamily: 'var(--font-mono)',
+                      }}
+                    >
+                      {r.model}
+                    </span>
+                  </li>
+                ))}
+            </ul>
+          )}
+        </section>
+
+        {/* Right: Budget spenders + sparkline */}
+        <section aria-labelledby="burning-now-heading">
+          <h3
+            id="burning-now-heading"
+            style={{
+              margin: '0 0 var(--space-3)',
+              fontSize: 'var(--text-sm)',
+              fontWeight: 600,
+              color: 'var(--color-text-secondary)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.06em',
+            }}
+          >
+            Burning now
+          </h3>
+
+          {/* Fleet hourly sparkline */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 'var(--space-3)',
+              marginBottom: 'var(--space-4)',
+              padding: 'var(--space-2) var(--space-3)',
+              background: 'var(--color-bg-secondary)',
+              borderRadius: 'var(--radius-md)',
+              border: '1px solid var(--color-border)',
+            }}
+            data-testid="fleet-sparkline"
+          >
+            <span style={{ fontSize: 'var(--text-xs)', color: 'var(--color-text-muted)' }}>
+              Fleet hourly cost
+            </span>
+            <Sparkline values={hourlyValues} width={120} height={28} />
+          </div>
+
+          {/* Top spenders */}
+          <ul
+            style={{
+              listStyle: 'none',
+              margin: 0,
+              padding: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 'var(--space-2)',
+            }}
+            data-testid="top-spenders-list"
+          >
+            {spenders.map((r) => {
+              const b = budgets[r.id];
+              return (
+                <li
+                  key={r.id}
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 'var(--space-1)',
+                    padding: 'var(--space-2) var(--space-3)',
+                    background: 'var(--color-bg-secondary)',
+                    borderRadius: 'var(--radius-md)',
+                    border: '1px solid var(--color-border)',
+                  }}
+                  data-testid="spender-row"
+                >
+                  <div
+                    style={{
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'center',
+                    }}
+                  >
+                    <span style={{ fontSize: 'var(--text-sm)', fontWeight: 500 }}>
+                      {r.personaName}
+                    </span>
+                    <span
+                      style={{
+                        fontSize: 'var(--text-xs)',
+                        color: 'var(--color-text-muted)',
+                        fontFamily: 'var(--font-mono)',
+                      }}
+                    >
+                      {b ? `$${b.spentUsd.toFixed(2)} / $${b.capUsd.toFixed(2)}` : '—'}
+                    </span>
+                  </div>
+                  {b && (
+                    <BudgetBar
+                      spent={b.spentUsd}
+                      cap={b.capUsd}
+                      warnAt={Math.round(b.warnAt * 100)}
+                      size="sm"
+                    />
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      </div>
+
+      {/* Log tail */}
+      <section aria-labelledby="log-tail-heading">
+        <h3
+          id="log-tail-heading"
+          style={{
+            margin: '0 0 var(--space-3)',
+            fontSize: 'var(--text-sm)',
+            fontWeight: 600,
+            color: 'var(--color-text-secondary)',
+            textTransform: 'uppercase',
+            letterSpacing: '0.06em',
+          }}
+        >
+          Recent activity
+        </h3>
+        <div
+          style={{
+            background: 'var(--color-bg-secondary)',
+            borderRadius: 'var(--radius-md)',
+            border: '1px solid var(--color-border)',
+            overflow: 'hidden',
+          }}
+          data-testid="log-tail"
+        >
+          {logTail.length === 0 ? (
+            <p
+              style={{
+                padding: 'var(--space-4)',
+                color: 'var(--color-text-muted)',
+                fontSize: 'var(--text-sm)',
+              }}
+            >
+              No recent activity
+            </p>
+          ) : (
+            <table
+              style={{
+                width: '100%',
+                borderCollapse: 'collapse',
+                fontSize: 'var(--text-xs)',
+                fontFamily: 'var(--font-mono)',
+              }}
+            >
+              <thead>
+                <tr style={{ borderBottom: '1px solid var(--color-border)' }}>
+                  <th
+                    style={{
+                      padding: 'var(--space-2) var(--space-3)',
+                      textAlign: 'left',
+                      color: 'var(--color-text-muted)',
+                      fontWeight: 500,
+                    }}
+                  >
+                    Time
+                  </th>
+                  <th
+                    style={{
+                      padding: 'var(--space-2) var(--space-3)',
+                      textAlign: 'left',
+                      color: 'var(--color-text-muted)',
+                      fontWeight: 500,
+                    }}
+                  >
+                    Persona
+                  </th>
+                  <th
+                    style={{
+                      padding: 'var(--space-2) var(--space-3)',
+                      textAlign: 'left',
+                      color: 'var(--color-text-muted)',
+                      fontWeight: 500,
+                    }}
+                  >
+                    Event
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {logTail.map((entry) => (
+                  <tr
+                    key={entry.key}
+                    style={{ borderBottom: '1px solid var(--color-border-subtle)' }}
+                    data-testid="log-row"
+                  >
+                    <td
+                      style={{
+                        padding: 'var(--space-2) var(--space-3)',
+                        color: 'var(--color-text-muted)',
+                      }}
+                    >
+                      {new Date(entry.ts).toLocaleTimeString()}
+                    </td>
+                    <td
+                      style={{
+                        padding: 'var(--space-2) var(--space-3)',
+                        color: 'var(--color-text-secondary)',
+                      }}
+                    >
+                      {entry.persona}
+                    </td>
+                    <td
+                      style={{
+                        padding: 'var(--space-2) var(--space-3)',
+                        color: 'var(--color-text-primary)',
+                      }}
+                    >
+                      {entry.text}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/web-next/packages/plugin-ravn/src/ui/OverviewPage.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/OverviewPage.tsx
@@ -172,7 +172,7 @@ export function OverviewPage() {
                     }}
                     data-testid="active-ravn-row"
                   >
-                    <StateDot state="ok" pulse size={8} />
+                    <StateDot state="running" pulse size={8} />
                     <span style={{ fontSize: 'var(--text-sm)', fontWeight: 500, flex: 1 }}>
                       {r.personaName}
                     </span>

--- a/web-next/packages/plugin-ravn/src/ui/OverviewPage.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/OverviewPage.tsx
@@ -12,6 +12,7 @@ import { useTriggers } from './hooks/useTriggers';
 import { useSessions } from './hooks/useSessions';
 import { useFleetBudget, useRavnBudgets } from './hooks/useBudget';
 import { topBudgetSpenders } from './grouping';
+import './OverviewPage.css';
 
 const LOG_TAIL_LIMIT = 20;
 const TOP_SPENDERS_COUNT = 5;
@@ -81,15 +82,7 @@ export function OverviewPage() {
   }
 
   return (
-    <div
-      data-testid="overview-page"
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 'var(--space-6)',
-        padding: 'var(--space-6)',
-      }}
-    >
+    <div data-testid="overview-page" className="rv-overview">
       {/* KPI strip */}
       <KpiStrip>
         <div data-testid="kpi-total">
@@ -117,74 +110,23 @@ export function OverviewPage() {
       </KpiStrip>
 
       {/* 2-column body */}
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: '1fr 1fr',
-          gap: 'var(--space-6)',
-          alignItems: 'start',
-        }}
-      >
+      <div className="rv-overview__grid">
         {/* Left: Active ravens list */}
         <section aria-labelledby="active-ravens-heading">
-          <h3
-            id="active-ravens-heading"
-            style={{
-              margin: '0 0 var(--space-3)',
-              fontSize: 'var(--text-sm)',
-              fontWeight: 600,
-              color: 'var(--color-text-secondary)',
-              textTransform: 'uppercase',
-              letterSpacing: '0.06em',
-            }}
-          >
+          <h3 id="active-ravens-heading" className="rv-section-heading">
             Active ravens
           </h3>
           {ravnList.filter((r) => r.status === 'active').length === 0 ? (
-            <p style={{ color: 'var(--color-text-muted)', fontSize: 'var(--text-sm)' }}>
-              No active ravens
-            </p>
+            <p className="rv-empty-text">No active ravens</p>
           ) : (
-            <ul
-              style={{
-                listStyle: 'none',
-                margin: 0,
-                padding: 0,
-                display: 'flex',
-                flexDirection: 'column',
-                gap: 'var(--space-2)',
-              }}
-              data-testid="active-ravens-list"
-            >
+            <ul className="rv-active-list" data-testid="active-ravens-list">
               {ravnList
                 .filter((r) => r.status === 'active')
                 .map((r) => (
-                  <li
-                    key={r.id}
-                    style={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 'var(--space-3)',
-                      padding: 'var(--space-2) var(--space-3)',
-                      background: 'var(--color-bg-secondary)',
-                      borderRadius: 'var(--radius-md)',
-                      border: '1px solid var(--color-border)',
-                    }}
-                    data-testid="active-ravn-row"
-                  >
+                  <li key={r.id} className="rv-active-row" data-testid="active-ravn-row">
                     <StateDot state="running" pulse size={8} />
-                    <span style={{ fontSize: 'var(--text-sm)', fontWeight: 500, flex: 1 }}>
-                      {r.personaName}
-                    </span>
-                    <span
-                      style={{
-                        fontSize: 'var(--text-xs)',
-                        color: 'var(--color-text-muted)',
-                        fontFamily: 'var(--font-mono)',
-                      }}
-                    >
-                      {r.model}
-                    </span>
+                    <span className="rv-active-row__name">{r.personaName}</span>
+                    <span className="rv-active-row__model">{r.model}</span>
                   </li>
                 ))}
             </ul>
@@ -193,85 +135,25 @@ export function OverviewPage() {
 
         {/* Right: Budget spenders + sparkline */}
         <section aria-labelledby="burning-now-heading">
-          <h3
-            id="burning-now-heading"
-            style={{
-              margin: '0 0 var(--space-3)',
-              fontSize: 'var(--text-sm)',
-              fontWeight: 600,
-              color: 'var(--color-text-secondary)',
-              textTransform: 'uppercase',
-              letterSpacing: '0.06em',
-            }}
-          >
+          <h3 id="burning-now-heading" className="rv-section-heading">
             Burning now
           </h3>
 
           {/* Fleet hourly sparkline */}
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 'var(--space-3)',
-              marginBottom: 'var(--space-4)',
-              padding: 'var(--space-2) var(--space-3)',
-              background: 'var(--color-bg-secondary)',
-              borderRadius: 'var(--radius-md)',
-              border: '1px solid var(--color-border)',
-            }}
-            data-testid="fleet-sparkline"
-          >
-            <span style={{ fontSize: 'var(--text-xs)', color: 'var(--color-text-muted)' }}>
-              Fleet hourly cost
-            </span>
+          <div className="rv-fleet-sparkline" data-testid="fleet-sparkline">
+            <span className="rv-fleet-sparkline__label">Fleet hourly cost</span>
             <Sparkline values={hourlyValues} width={120} height={28} />
           </div>
 
           {/* Top spenders */}
-          <ul
-            style={{
-              listStyle: 'none',
-              margin: 0,
-              padding: 0,
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 'var(--space-2)',
-            }}
-            data-testid="top-spenders-list"
-          >
+          <ul className="rv-spenders-list" data-testid="top-spenders-list">
             {spenders.map((r) => {
               const b = budgets[r.id];
               return (
-                <li
-                  key={r.id}
-                  style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    gap: 'var(--space-1)',
-                    padding: 'var(--space-2) var(--space-3)',
-                    background: 'var(--color-bg-secondary)',
-                    borderRadius: 'var(--radius-md)',
-                    border: '1px solid var(--color-border)',
-                  }}
-                  data-testid="spender-row"
-                >
-                  <div
-                    style={{
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                      alignItems: 'center',
-                    }}
-                  >
-                    <span style={{ fontSize: 'var(--text-sm)', fontWeight: 500 }}>
-                      {r.personaName}
-                    </span>
-                    <span
-                      style={{
-                        fontSize: 'var(--text-xs)',
-                        color: 'var(--color-text-muted)',
-                        fontFamily: 'var(--font-mono)',
-                      }}
-                    >
+                <li key={r.id} className="rv-spender-row" data-testid="spender-row">
+                  <div className="rv-spender-row__header">
+                    <span className="rv-spender-row__name">{r.personaName}</span>
+                    <span className="rv-spender-row__amount">
                       {b ? `$${b.spentUsd.toFixed(2)} / $${b.capUsd.toFixed(2)}` : '—'}
                     </span>
                   </div>
@@ -292,112 +174,27 @@ export function OverviewPage() {
 
       {/* Log tail */}
       <section aria-labelledby="log-tail-heading">
-        <h3
-          id="log-tail-heading"
-          style={{
-            margin: '0 0 var(--space-3)',
-            fontSize: 'var(--text-sm)',
-            fontWeight: 600,
-            color: 'var(--color-text-secondary)',
-            textTransform: 'uppercase',
-            letterSpacing: '0.06em',
-          }}
-        >
+        <h3 id="log-tail-heading" className="rv-section-heading">
           Recent activity
         </h3>
-        <div
-          style={{
-            background: 'var(--color-bg-secondary)',
-            borderRadius: 'var(--radius-md)',
-            border: '1px solid var(--color-border)',
-            overflow: 'hidden',
-          }}
-          data-testid="log-tail"
-        >
+        <div className="rv-log-panel" data-testid="log-tail">
           {logTail.length === 0 ? (
-            <p
-              style={{
-                padding: 'var(--space-4)',
-                color: 'var(--color-text-muted)',
-                fontSize: 'var(--text-sm)',
-              }}
-            >
-              No recent activity
-            </p>
+            <p className="rv-log-empty">No recent activity</p>
           ) : (
-            <table
-              style={{
-                width: '100%',
-                borderCollapse: 'collapse',
-                fontSize: 'var(--text-xs)',
-                fontFamily: 'var(--font-mono)',
-              }}
-            >
+            <table className="rv-log-table">
               <thead>
-                <tr style={{ borderBottom: '1px solid var(--color-border)' }}>
-                  <th
-                    style={{
-                      padding: 'var(--space-2) var(--space-3)',
-                      textAlign: 'left',
-                      color: 'var(--color-text-muted)',
-                      fontWeight: 500,
-                    }}
-                  >
-                    Time
-                  </th>
-                  <th
-                    style={{
-                      padding: 'var(--space-2) var(--space-3)',
-                      textAlign: 'left',
-                      color: 'var(--color-text-muted)',
-                      fontWeight: 500,
-                    }}
-                  >
-                    Persona
-                  </th>
-                  <th
-                    style={{
-                      padding: 'var(--space-2) var(--space-3)',
-                      textAlign: 'left',
-                      color: 'var(--color-text-muted)',
-                      fontWeight: 500,
-                    }}
-                  >
-                    Event
-                  </th>
+                <tr className="rv-log-thead-row">
+                  <th className="rv-log-th">Time</th>
+                  <th className="rv-log-th">Persona</th>
+                  <th className="rv-log-th">Event</th>
                 </tr>
               </thead>
               <tbody>
                 {logTail.map((entry) => (
-                  <tr
-                    key={entry.key}
-                    style={{ borderBottom: '1px solid var(--color-border-subtle)' }}
-                    data-testid="log-row"
-                  >
-                    <td
-                      style={{
-                        padding: 'var(--space-2) var(--space-3)',
-                        color: 'var(--color-text-muted)',
-                      }}
-                    >
-                      {new Date(entry.ts).toLocaleTimeString()}
-                    </td>
-                    <td
-                      style={{
-                        padding: 'var(--space-2) var(--space-3)',
-                        color: 'var(--color-text-secondary)',
-                      }}
-                    >
-                      {entry.persona}
-                    </td>
-                    <td
-                      style={{
-                        padding: 'var(--space-2) var(--space-3)',
-                        color: 'var(--color-text-primary)',
-                      }}
-                    >
-                      {entry.text}
-                    </td>
+                  <tr key={entry.key} className="rv-log-row" data-testid="log-row">
+                    <td className="rv-log-td--time">{new Date(entry.ts).toLocaleTimeString()}</td>
+                    <td className="rv-log-td--persona">{entry.persona}</td>
+                    <td className="rv-log-td--event">{entry.text}</td>
                   </tr>
                 ))}
               </tbody>

--- a/web-next/packages/plugin-ravn/src/ui/RavensPage.css
+++ b/web-next/packages/plugin-ravn/src/ui/RavensPage.css
@@ -1,0 +1,301 @@
+/* Page container */
+.rv-ravens {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+/* Toolbar */
+.rv-ravens__toolbar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-3) var(--space-6);
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-bg-primary);
+}
+
+.rv-layout-group {
+  display: flex;
+  gap: var(--space-1);
+}
+
+.rv-layout-btn {
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-size: var(--text-xs);
+  font-weight: 400;
+}
+
+.rv-layout-btn[aria-checked='true'] {
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-primary);
+  font-weight: 600;
+}
+
+.rv-toolbar-divider {
+  width: 1px;
+  height: 16px;
+  background: var(--color-border);
+}
+
+.rv-group-by {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.rv-group-by__label {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+.rv-group-by__select {
+  font-size: var(--text-xs);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-secondary);
+  color: var(--color-text-primary);
+  cursor: pointer;
+}
+
+.rv-ravens__count {
+  margin-left: auto;
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+/* Content area */
+.rv-ravens__content {
+  flex: 1;
+  display: flex;
+  overflow: hidden;
+}
+
+/* Split layout */
+.rv-split__list {
+  width: 280px;
+  flex-shrink: 0;
+  overflow-y: auto;
+  border-right: 1px solid var(--color-border);
+  background: var(--color-bg-primary);
+}
+
+.rv-split__detail {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.rv-detail-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+}
+
+/* List row */
+.rv-list-row {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--color-border-subtle);
+  cursor: pointer;
+  text-align: left;
+}
+
+.rv-list-row[aria-selected='true'] {
+  background: var(--color-bg-tertiary);
+}
+
+.rv-list-row__name {
+  flex: 1;
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--color-text-primary);
+}
+
+.rv-list-row__budget {
+  width: 64px;
+  flex-shrink: 0;
+}
+
+/* Group header (split + cards) */
+.rv-group-header {
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  background: var(--color-bg-primary);
+  border-bottom: 1px solid var(--color-border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.rv-group-header__badge {
+  font-size: var(--text-xs);
+  padding: 0 var(--space-2);
+  border-radius: var(--radius-full);
+  background: var(--color-bg-elevated);
+  color: var(--color-text-muted);
+}
+
+/* Table layout */
+.rv-table-layout {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-4) var(--space-6);
+}
+
+.rv-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.rv-thead-row {
+  border-bottom: 1px solid var(--color-border);
+}
+
+.rv-th {
+  padding: var(--space-2) var(--space-3);
+  text-align: left;
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.rv-table-row {
+  background: transparent;
+  cursor: pointer;
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.rv-table-row[aria-selected='true'] {
+  background: var(--color-bg-tertiary);
+}
+
+.rv-td--persona {
+  padding: var(--space-3);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--color-text-primary);
+}
+
+.rv-td--status {
+  padding: var(--space-3);
+}
+
+.rv-td-status-inner {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.rv-td-status-inner span {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+.rv-td--model {
+  padding: var(--space-3);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+}
+
+.rv-td--budget {
+  padding: var(--space-3);
+  min-width: 120px;
+}
+
+.rv-td--dash {
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+}
+
+.rv-group-td {
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--color-text-muted);
+  background: var(--color-bg-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+/* Cards layout */
+.rv-cards-layout {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+}
+
+.rv-cards-section__heading {
+  margin: 0 0 var(--space-3);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.rv-cards-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: var(--space-3);
+}
+
+/* Card */
+.rv-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-4);
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  text-align: left;
+}
+
+.rv-card[aria-selected='true'] {
+  background: var(--color-bg-tertiary);
+  border-color: var(--color-border);
+}
+
+.rv-card__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.rv-card__name {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--color-text-primary);
+  flex: 1;
+}
+
+.rv-card__model {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+}

--- a/web-next/packages/plugin-ravn/src/ui/RavensPage.test.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/RavensPage.test.tsx
@@ -1,0 +1,189 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ServicesProvider } from '@niuulabs/plugin-sdk';
+import { RavensPage } from './RavensPage';
+import {
+  createMockRavenStream,
+  createMockBudgetStream,
+  createMockTriggerStore,
+  createMockSessionStream,
+} from '../adapters/mock';
+
+function makeServices(overrides?: Record<string, unknown>) {
+  return {
+    'ravn.ravens': createMockRavenStream(),
+    'ravn.budget': createMockBudgetStream(),
+    'ravn.triggers': createMockTriggerStore(),
+    'ravn.sessions': createMockSessionStream(),
+    ...overrides,
+  };
+}
+
+function wrap(services = makeServices()) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>
+        <ServicesProvider services={services}>{children}</ServicesProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('RavensPage', () => {
+  it('shows loading state initially', () => {
+    const slow = { listRavens: () => new Promise(() => undefined) };
+    render(<RavensPage />, { wrapper: wrap(makeServices({ 'ravn.ravens': slow })) });
+    expect(screen.getByTestId('ravens-loading')).toBeInTheDocument();
+  });
+
+  it('renders ravens page after loading', async () => {
+    render(<RavensPage />, { wrapper: wrap() });
+    await waitFor(() => expect(screen.getByTestId('ravens-page')).toBeInTheDocument());
+  });
+
+  it('shows error state when ravens service fails', async () => {
+    const failing = { listRavens: () => Promise.reject(new Error('load failed')) };
+    render(<RavensPage />, { wrapper: wrap(makeServices({ 'ravn.ravens': failing })) });
+    await waitFor(() => expect(screen.getByTestId('ravens-error')).toBeInTheDocument());
+    expect(screen.getByText(/load failed/i)).toBeInTheDocument();
+  });
+
+  it('renders the layout selector', async () => {
+    render(<RavensPage />, { wrapper: wrap() });
+    await waitFor(() => expect(screen.getByTestId('layout-selector')).toBeInTheDocument());
+  });
+
+  it('renders the grouping selector', async () => {
+    render(<RavensPage />, { wrapper: wrap() });
+    await waitFor(() => expect(screen.getByTestId('grouping-selector')).toBeInTheDocument());
+  });
+
+  describe('layout switching', () => {
+    it('defaults to split layout', async () => {
+      render(<RavensPage />, { wrapper: wrap() });
+      await waitFor(() => expect(screen.getByTestId('layout-split')).toBeInTheDocument());
+    });
+
+    it('switches to table layout', async () => {
+      render(<RavensPage />, { wrapper: wrap() });
+      await waitFor(() => screen.getByTestId('layout-btn-table'));
+      fireEvent.click(screen.getByTestId('layout-btn-table'));
+      expect(screen.getByTestId('layout-table')).toBeInTheDocument();
+      expect(screen.queryByTestId('layout-split')).not.toBeInTheDocument();
+    });
+
+    it('switches to cards layout', async () => {
+      render(<RavensPage />, { wrapper: wrap() });
+      await waitFor(() => screen.getByTestId('layout-btn-cards'));
+      fireEvent.click(screen.getByTestId('layout-btn-cards'));
+      expect(screen.getByTestId('layout-cards')).toBeInTheDocument();
+    });
+
+    it('switches back to split layout from cards', async () => {
+      render(<RavensPage />, { wrapper: wrap() });
+      await waitFor(() => screen.getByTestId('layout-btn-cards'));
+      fireEvent.click(screen.getByTestId('layout-btn-cards'));
+      fireEvent.click(screen.getByTestId('layout-btn-split'));
+      expect(screen.getByTestId('layout-split')).toBeInTheDocument();
+    });
+
+    it('persists layout selection to localStorage', async () => {
+      render(<RavensPage />, { wrapper: wrap() });
+      await waitFor(() => screen.getByTestId('layout-btn-table'));
+      fireEvent.click(screen.getByTestId('layout-btn-table'));
+      expect(localStorage.getItem('ravn.ravens.layout')).toBe('"table"');
+    });
+  });
+
+  describe('grouping', () => {
+    it('groups by state when selected', async () => {
+      render(<RavensPage />, { wrapper: wrap() });
+      await waitFor(() => screen.getByTestId('grouping-selector'));
+      const selector = screen.getByTestId('grouping-selector');
+      fireEvent.change(selector, { target: { value: 'state' } });
+
+      // Should show group headers for each state
+      await waitFor(() => {
+        const headers = screen.queryAllByText(/^active$/i);
+        return headers.length > 0;
+      });
+      expect(localStorage.getItem('ravn.ravens.group')).toBe('"state"');
+    });
+
+    it('groups by persona when selected', async () => {
+      render(<RavensPage />, { wrapper: wrap() });
+      await waitFor(() => screen.getByTestId('grouping-selector'));
+      const selector = screen.getByTestId('grouping-selector');
+      fireEvent.change(selector, { target: { value: 'persona' } });
+      expect(localStorage.getItem('ravn.ravens.group')).toBe('"persona"');
+    });
+
+    it('groups by location when selected', async () => {
+      render(<RavensPage />, { wrapper: wrap() });
+      await waitFor(() => screen.getByTestId('grouping-selector'));
+      const selector = screen.getByTestId('grouping-selector');
+      fireEvent.change(selector, { target: { value: 'location' } });
+      expect(localStorage.getItem('ravn.ravens.group')).toBe('"location"');
+    });
+  });
+
+  describe('ravn selection in split view', () => {
+    it('shows empty state when no ravn is selected', async () => {
+      render(<RavensPage />, { wrapper: wrap() });
+      await waitFor(() => expect(screen.getByTestId('detail-empty')).toBeInTheDocument());
+    });
+
+    it('shows ravn detail when a ravn is selected', async () => {
+      render(<RavensPage />, { wrapper: wrap() });
+      await waitFor(() => screen.getAllByTestId('ravn-list-row'));
+      const rows = screen.getAllByTestId('ravn-list-row');
+      fireEvent.click(rows[0]!);
+      await waitFor(() => expect(screen.getByTestId('ravn-detail')).toBeInTheDocument());
+    });
+
+    it('deselects ravn when same row is clicked again', async () => {
+      render(<RavensPage />, { wrapper: wrap() });
+      await waitFor(() => screen.getAllByTestId('ravn-list-row'));
+      const rows = screen.getAllByTestId('ravn-list-row');
+      fireEvent.click(rows[0]!);
+      await waitFor(() => expect(screen.getByTestId('ravn-detail')).toBeInTheDocument());
+      fireEvent.click(rows[0]!);
+      await waitFor(() => expect(screen.queryByTestId('ravn-detail')).not.toBeInTheDocument());
+    });
+
+    it('closes detail pane when close button is clicked', async () => {
+      render(<RavensPage />, { wrapper: wrap() });
+      await waitFor(() => screen.getAllByTestId('ravn-list-row'));
+      fireEvent.click(screen.getAllByTestId('ravn-list-row')[0]!);
+      await waitFor(() => expect(screen.getByTestId('detail-close-btn')).toBeInTheDocument());
+      fireEvent.click(screen.getByTestId('detail-close-btn'));
+      await waitFor(() => expect(screen.queryByTestId('ravn-detail')).not.toBeInTheDocument());
+    });
+  });
+
+  describe('table layout', () => {
+    it('renders table rows', async () => {
+      render(<RavensPage />, { wrapper: wrap() });
+      await waitFor(() => screen.getByTestId('layout-btn-table'));
+      fireEvent.click(screen.getByTestId('layout-btn-table'));
+      await waitFor(() => screen.getAllByTestId('ravn-table-row'));
+      expect(screen.getAllByTestId('ravn-table-row').length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('cards layout', () => {
+    it('renders ravn cards', async () => {
+      render(<RavensPage />, { wrapper: wrap() });
+      await waitFor(() => screen.getByTestId('layout-btn-cards'));
+      fireEvent.click(screen.getByTestId('layout-btn-cards'));
+      await waitFor(() => screen.getAllByTestId('ravn-card'));
+      expect(screen.getAllByTestId('ravn-card').length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/web-next/packages/plugin-ravn/src/ui/RavensPage.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/RavensPage.tsx
@@ -1,0 +1,595 @@
+import { useState, useCallback } from 'react';
+import { StateDot, BudgetBar, LoadingState, ErrorState } from '@niuulabs/ui';
+import type { Ravn } from '../domain/ravn';
+import { useRavens } from './hooks/useRavens';
+import { useRavnBudgets } from './hooks/useBudget';
+import { groupRavens, type GroupKey } from './grouping';
+import { RavnDetail } from './RavnDetail';
+
+export type LayoutVariant = 'split' | 'table' | 'cards';
+
+const LAYOUT_STORAGE_KEY = 'ravn.ravens.layout';
+const GROUP_STORAGE_KEY = 'ravn.ravens.group';
+
+function loadStorage<T>(key: string, fallback: T): T {
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as T) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function saveStorage<T>(key: string, value: T): void {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // ignore
+  }
+}
+
+interface RavnRowProps {
+  ravn: Ravn;
+  budgetSpent?: number;
+  budgetCap?: number;
+  budgetWarnAt?: number;
+  selected?: boolean;
+  onClick?: () => void;
+}
+
+function RavnListRow({
+  ravn,
+  budgetSpent,
+  budgetCap,
+  budgetWarnAt,
+  selected,
+  onClick,
+}: RavnRowProps) {
+  const dotState =
+    ravn.status === 'active'
+      ? 'ok'
+      : ravn.status === 'suspended'
+        ? 'warn'
+        : ravn.status === 'failed'
+          ? 'err'
+          : 'mute';
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      data-testid="ravn-list-row"
+      aria-selected={selected}
+      style={{
+        width: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 'var(--space-3)',
+        padding: 'var(--space-3)',
+        background: selected ? 'var(--color-bg-tertiary)' : 'transparent',
+        border: 'none',
+        borderBottom: '1px solid var(--color-border-subtle)',
+        cursor: 'pointer',
+        textAlign: 'left',
+      }}
+    >
+      <StateDot state={dotState} pulse={ravn.status === 'active'} size={8} />
+      <span
+        style={{
+          flex: 1,
+          fontSize: 'var(--text-sm)',
+          fontWeight: 500,
+          color: 'var(--color-text-primary)',
+        }}
+      >
+        {ravn.personaName}
+      </span>
+      {budgetCap != null && budgetSpent != null && (
+        <div style={{ width: 64, flexShrink: 0 }}>
+          <BudgetBar
+            spent={budgetSpent}
+            cap={budgetCap}
+            warnAt={budgetWarnAt != null ? Math.round(budgetWarnAt * 100) : 80}
+            size="sm"
+          />
+        </div>
+      )}
+    </button>
+  );
+}
+
+interface RavnCardProps {
+  ravn: Ravn;
+  budget?: { spentUsd: number; capUsd: number; warnAt: number };
+  selected?: boolean;
+  onClick?: () => void;
+}
+
+function RavnCard({ ravn, budget, selected, onClick }: RavnCardProps) {
+  const dotState =
+    ravn.status === 'active'
+      ? 'ok'
+      : ravn.status === 'suspended'
+        ? 'warn'
+        : ravn.status === 'failed'
+          ? 'err'
+          : 'mute';
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      data-testid="ravn-card"
+      aria-selected={selected}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 'var(--space-2)',
+        padding: 'var(--space-4)',
+        background: selected ? 'var(--color-bg-tertiary)' : 'var(--color-bg-secondary)',
+        border: `1px solid ${selected ? 'var(--color-border)' : 'var(--color-border-subtle)'}`,
+        borderRadius: 'var(--radius-md)',
+        cursor: 'pointer',
+        textAlign: 'left',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)' }}>
+        <StateDot state={dotState} pulse={ravn.status === 'active'} size={8} />
+        <span
+          style={{
+            fontSize: 'var(--text-sm)',
+            fontWeight: 600,
+            color: 'var(--color-text-primary)',
+            flex: 1,
+          }}
+        >
+          {ravn.personaName}
+        </span>
+      </div>
+      <span
+        style={{
+          fontSize: 'var(--text-xs)',
+          color: 'var(--color-text-muted)',
+          fontFamily: 'var(--font-mono)',
+        }}
+      >
+        {ravn.model}
+      </span>
+      {budget && (
+        <BudgetBar
+          spent={budget.spentUsd}
+          cap={budget.capUsd}
+          warnAt={Math.round(budget.warnAt * 100)}
+          size="sm"
+        />
+      )}
+    </button>
+  );
+}
+
+const TABLE_COLUMNS = ['Persona', 'Status', 'Model', 'Budget'] as const;
+
+interface RavnTableRowProps {
+  ravn: Ravn;
+  budget?: { spentUsd: number; capUsd: number; warnAt: number };
+  selected?: boolean;
+  onClick?: () => void;
+}
+
+function RavnTableRow({ ravn, budget, selected, onClick }: RavnTableRowProps) {
+  const dotState =
+    ravn.status === 'active'
+      ? 'ok'
+      : ravn.status === 'suspended'
+        ? 'warn'
+        : ravn.status === 'failed'
+          ? 'err'
+          : 'mute';
+
+  return (
+    <tr
+      onClick={onClick}
+      data-testid="ravn-table-row"
+      aria-selected={selected}
+      style={{
+        background: selected ? 'var(--color-bg-tertiary)' : 'transparent',
+        cursor: 'pointer',
+        borderBottom: '1px solid var(--color-border-subtle)',
+      }}
+    >
+      <td
+        style={{
+          padding: 'var(--space-3)',
+          fontSize: 'var(--text-sm)',
+          fontWeight: 500,
+          color: 'var(--color-text-primary)',
+        }}
+      >
+        {ravn.personaName}
+      </td>
+      <td style={{ padding: 'var(--space-3)' }}>
+        <span style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)' }}>
+          <StateDot state={dotState} pulse={ravn.status === 'active'} size={8} />
+          <span style={{ fontSize: 'var(--text-sm)', color: 'var(--color-text-secondary)' }}>
+            {ravn.status}
+          </span>
+        </span>
+      </td>
+      <td
+        style={{
+          padding: 'var(--space-3)',
+          fontSize: 'var(--text-xs)',
+          color: 'var(--color-text-muted)',
+          fontFamily: 'var(--font-mono)',
+        }}
+      >
+        {ravn.model}
+      </td>
+      <td style={{ padding: 'var(--space-3)', minWidth: 120 }}>
+        {budget ? (
+          <BudgetBar
+            spent={budget.spentUsd}
+            cap={budget.capUsd}
+            warnAt={Math.round(budget.warnAt * 100)}
+            size="sm"
+          />
+        ) : (
+          <span style={{ color: 'var(--color-text-muted)', fontSize: 'var(--text-xs)' }}>—</span>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+interface GroupHeaderProps {
+  label: string;
+  count: number;
+}
+
+function GroupHeader({ label, count }: GroupHeaderProps) {
+  return (
+    <div
+      style={{
+        padding: 'var(--space-2) var(--space-3)',
+        fontSize: 'var(--text-xs)',
+        fontWeight: 600,
+        color: 'var(--color-text-muted)',
+        textTransform: 'uppercase',
+        letterSpacing: '0.06em',
+        background: 'var(--color-bg-primary)',
+        borderBottom: '1px solid var(--color-border)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+      }}
+    >
+      <span>{label}</span>
+      <span
+        style={{
+          fontSize: 'var(--text-xs)',
+          padding: '0 var(--space-2)',
+          borderRadius: 'var(--radius-full)',
+          background: 'var(--color-bg-elevated)',
+          color: 'var(--color-text-muted)',
+        }}
+      >
+        {count}
+      </span>
+    </div>
+  );
+}
+
+export function RavensPage() {
+  const [layout, setLayout] = useState<LayoutVariant>(() =>
+    loadStorage<LayoutVariant>(LAYOUT_STORAGE_KEY, 'split'),
+  );
+  const [groupBy, setGroupBy] = useState<GroupKey>(() =>
+    loadStorage<GroupKey>(GROUP_STORAGE_KEY, 'none'),
+  );
+  const [selectedRavnId, setSelectedRavnId] = useState<string | null>(null);
+
+  const { data: ravens, isLoading, isError, error } = useRavens();
+  const ravnList = ravens ?? [];
+  const ravnIds = ravnList.map((r) => r.id);
+  const budgets = useRavnBudgets(ravnIds);
+
+  const handleLayoutChange = useCallback((v: LayoutVariant) => {
+    setLayout(v);
+    saveStorage(LAYOUT_STORAGE_KEY, v);
+  }, []);
+
+  const handleGroupChange = useCallback((v: GroupKey) => {
+    setGroupBy(v);
+    saveStorage(GROUP_STORAGE_KEY, v);
+  }, []);
+
+  const selectedRavn = ravnList.find((r) => r.id === selectedRavnId) ?? null;
+
+  const groups = groupRavens(ravnList, groupBy);
+  const groupEntries = Object.entries(groups);
+
+  if (isLoading) {
+    return (
+      <div data-testid="ravens-loading">
+        <LoadingState label="Loading ravens…" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div data-testid="ravens-error">
+        <ErrorState message={error instanceof Error ? error.message : 'Failed to load ravens'} />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-testid="ravens-page"
+      style={{ display: 'flex', flexDirection: 'column', height: '100%' }}
+    >
+      {/* Toolbar */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--space-4)',
+          padding: 'var(--space-3) var(--space-6)',
+          borderBottom: '1px solid var(--color-border)',
+          background: 'var(--color-bg-primary)',
+        }}
+      >
+        {/* Layout selector */}
+        <div
+          role="group"
+          aria-label="Layout variant"
+          data-testid="layout-selector"
+          style={{ display: 'flex', gap: 'var(--space-1)' }}
+        >
+          {(['split', 'table', 'cards'] as LayoutVariant[]).map((v) => (
+            <button
+              key={v}
+              type="button"
+              role="radio"
+              aria-checked={layout === v}
+              onClick={() => handleLayoutChange(v)}
+              data-testid={`layout-btn-${v}`}
+              style={{
+                padding: 'var(--space-1) var(--space-3)',
+                borderRadius: 'var(--radius-sm)',
+                border: '1px solid var(--color-border)',
+                background: layout === v ? 'var(--color-bg-tertiary)' : 'transparent',
+                color: layout === v ? 'var(--color-text-primary)' : 'var(--color-text-muted)',
+                cursor: 'pointer',
+                fontSize: 'var(--text-xs)',
+                fontWeight: layout === v ? 600 : 400,
+              }}
+            >
+              {v}
+            </button>
+          ))}
+        </div>
+
+        <div style={{ width: '1px', height: 16, background: 'var(--color-border)' }} />
+
+        {/* Grouping selector */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)' }}>
+          <label
+            htmlFor="group-select"
+            style={{ fontSize: 'var(--text-xs)', color: 'var(--color-text-muted)' }}
+          >
+            Group by
+          </label>
+          <select
+            id="group-select"
+            value={groupBy}
+            onChange={(e) => handleGroupChange(e.target.value as GroupKey)}
+            data-testid="grouping-selector"
+            style={{
+              fontSize: 'var(--text-xs)',
+              padding: 'var(--space-1) var(--space-2)',
+              borderRadius: 'var(--radius-sm)',
+              border: '1px solid var(--color-border)',
+              background: 'var(--color-bg-secondary)',
+              color: 'var(--color-text-primary)',
+              cursor: 'pointer',
+            }}
+          >
+            {(['none', 'state', 'persona', 'location'] as GroupKey[]).map((g) => (
+              <option key={g} value={g}>
+                {g}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <span
+          style={{
+            marginLeft: 'auto',
+            fontSize: 'var(--text-xs)',
+            color: 'var(--color-text-muted)',
+          }}
+        >
+          {ravnList.length} ravn{ravnList.length !== 1 ? 's' : ''}
+        </span>
+      </div>
+
+      {/* Content area */}
+      <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
+        {/* Split layout */}
+        {layout === 'split' && (
+          <>
+            <div
+              style={{
+                width: 280,
+                flexShrink: 0,
+                overflowY: 'auto',
+                borderRight: '1px solid var(--color-border)',
+                background: 'var(--color-bg-primary)',
+              }}
+              data-testid="layout-split"
+            >
+              {groupEntries.map(([groupLabel, groupRavns]) => (
+                <div key={groupLabel}>
+                  {groupBy !== 'none' && (
+                    <GroupHeader label={groupLabel} count={groupRavns.length} />
+                  )}
+                  {groupRavns.map((r) => {
+                    const b = budgets[r.id];
+                    return (
+                      <RavnListRow
+                        key={r.id}
+                        ravn={r}
+                        budgetSpent={b?.spentUsd}
+                        budgetCap={b?.capUsd}
+                        budgetWarnAt={b?.warnAt}
+                        selected={r.id === selectedRavnId}
+                        onClick={() => setSelectedRavnId(r.id === selectedRavnId ? null : r.id)}
+                      />
+                    );
+                  })}
+                </div>
+              ))}
+            </div>
+
+            <div style={{ flex: 1, overflowY: 'auto' }}>
+              {selectedRavn ? (
+                <RavnDetail ravn={selectedRavn} onClose={() => setSelectedRavnId(null)} />
+              ) : (
+                <div
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    height: '100%',
+                    color: 'var(--color-text-muted)',
+                    fontSize: 'var(--text-sm)',
+                  }}
+                  data-testid="detail-empty"
+                >
+                  Select a ravn to view details
+                </div>
+              )}
+            </div>
+          </>
+        )}
+
+        {/* Table layout */}
+        {layout === 'table' && (
+          <div
+            style={{ flex: 1, overflowY: 'auto', padding: 'var(--space-4) var(--space-6)' }}
+            data-testid="layout-table"
+          >
+            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+              <thead>
+                <tr style={{ borderBottom: '1px solid var(--color-border)' }}>
+                  {TABLE_COLUMNS.map((col) => (
+                    <th
+                      key={col}
+                      style={{
+                        padding: 'var(--space-2) var(--space-3)',
+                        textAlign: 'left',
+                        fontSize: 'var(--text-xs)',
+                        color: 'var(--color-text-muted)',
+                        fontWeight: 600,
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.06em',
+                      }}
+                    >
+                      {col}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {groupEntries.map(([groupLabel, groupRavns]) => (
+                  <>
+                    {groupBy !== 'none' && (
+                      <tr key={`group-${groupLabel}`}>
+                        <td
+                          colSpan={TABLE_COLUMNS.length}
+                          style={{
+                            padding: 'var(--space-2) var(--space-3)',
+                            fontSize: 'var(--text-xs)',
+                            fontWeight: 600,
+                            color: 'var(--color-text-muted)',
+                            background: 'var(--color-bg-primary)',
+                            textTransform: 'uppercase',
+                            letterSpacing: '0.06em',
+                          }}
+                        >
+                          {groupLabel} ({groupRavns.length})
+                        </td>
+                      </tr>
+                    )}
+                    {groupRavns.map((r) => (
+                      <RavnTableRow
+                        key={r.id}
+                        ravn={r}
+                        budget={budgets[r.id]}
+                        selected={r.id === selectedRavnId}
+                        onClick={() => setSelectedRavnId(r.id === selectedRavnId ? null : r.id)}
+                      />
+                    ))}
+                  </>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {/* Cards layout */}
+        {layout === 'cards' && (
+          <div
+            style={{
+              flex: 1,
+              overflowY: 'auto',
+              padding: 'var(--space-6)',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 'var(--space-6)',
+            }}
+            data-testid="layout-cards"
+          >
+            {groupEntries.map(([groupLabel, groupRavns]) => (
+              <div key={groupLabel}>
+                {groupBy !== 'none' && (
+                  <h4
+                    style={{
+                      margin: '0 0 var(--space-3)',
+                      fontSize: 'var(--text-xs)',
+                      fontWeight: 600,
+                      color: 'var(--color-text-muted)',
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.06em',
+                    }}
+                  >
+                    {groupLabel} ({groupRavns.length})
+                  </h4>
+                )}
+                <div
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))',
+                    gap: 'var(--space-3)',
+                  }}
+                >
+                  {groupRavns.map((r) => (
+                    <RavnCard
+                      key={r.id}
+                      ravn={r}
+                      budget={budgets[r.id]}
+                      selected={r.id === selectedRavnId}
+                      onClick={() => setSelectedRavnId(r.id === selectedRavnId ? null : r.id)}
+                    />
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web-next/packages/plugin-ravn/src/ui/RavensPage.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/RavensPage.tsx
@@ -47,12 +47,12 @@ function RavnListRow({
 }: RavnRowProps) {
   const dotState =
     ravn.status === 'active'
-      ? 'ok'
+      ? 'running'
       : ravn.status === 'suspended'
-        ? 'warn'
+        ? 'attention'
         : ravn.status === 'failed'
-          ? 'err'
-          : 'mute';
+          ? 'failed'
+          : 'unknown';
 
   return (
     <button
@@ -108,12 +108,12 @@ interface RavnCardProps {
 function RavnCard({ ravn, budget, selected, onClick }: RavnCardProps) {
   const dotState =
     ravn.status === 'active'
-      ? 'ok'
+      ? 'running'
       : ravn.status === 'suspended'
-        ? 'warn'
+        ? 'attention'
         : ravn.status === 'failed'
-          ? 'err'
-          : 'mute';
+          ? 'failed'
+          : 'unknown';
 
   return (
     <button
@@ -179,12 +179,12 @@ interface RavnTableRowProps {
 function RavnTableRow({ ravn, budget, selected, onClick }: RavnTableRowProps) {
   const dotState =
     ravn.status === 'active'
-      ? 'ok'
+      ? 'running'
       : ravn.status === 'suspended'
-        ? 'warn'
+        ? 'attention'
         : ravn.status === 'failed'
-          ? 'err'
-          : 'mute';
+          ? 'failed'
+          : 'unknown';
 
   return (
     <tr

--- a/web-next/packages/plugin-ravn/src/ui/RavensPage.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/RavensPage.tsx
@@ -1,32 +1,17 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, Fragment } from 'react';
 import { StateDot, BudgetBar, LoadingState, ErrorState } from '@niuulabs/ui';
 import type { Ravn } from '../domain/ravn';
 import { useRavens } from './hooks/useRavens';
 import { useRavnBudgets } from './hooks/useBudget';
-import { groupRavens, type GroupKey } from './grouping';
+import { groupRavens, ravnStatusToDotState, type GroupKey } from './grouping';
 import { RavnDetail } from './RavnDetail';
+import { loadStorage, saveStorage } from './storage';
+import './RavensPage.css';
 
 export type LayoutVariant = 'split' | 'table' | 'cards';
 
 const LAYOUT_STORAGE_KEY = 'ravn.ravens.layout';
 const GROUP_STORAGE_KEY = 'ravn.ravens.group';
-
-function loadStorage<T>(key: string, fallback: T): T {
-  try {
-    const raw = localStorage.getItem(key);
-    return raw ? (JSON.parse(raw) as T) : fallback;
-  } catch {
-    return fallback;
-  }
-}
-
-function saveStorage<T>(key: string, value: T): void {
-  try {
-    localStorage.setItem(key, JSON.stringify(value));
-  } catch {
-    // ignore
-  }
-}
 
 interface RavnRowProps {
   ravn: Ravn;
@@ -37,55 +22,19 @@ interface RavnRowProps {
   onClick?: () => void;
 }
 
-function RavnListRow({
-  ravn,
-  budgetSpent,
-  budgetCap,
-  budgetWarnAt,
-  selected,
-  onClick,
-}: RavnRowProps) {
-  const dotState =
-    ravn.status === 'active'
-      ? 'running'
-      : ravn.status === 'suspended'
-        ? 'attention'
-        : ravn.status === 'failed'
-          ? 'failed'
-          : 'unknown';
-
+function RavnListRow({ ravn, budgetSpent, budgetCap, budgetWarnAt, selected, onClick }: RavnRowProps) {
   return (
     <button
       type="button"
       onClick={onClick}
       data-testid="ravn-list-row"
       aria-selected={selected}
-      style={{
-        width: '100%',
-        display: 'flex',
-        alignItems: 'center',
-        gap: 'var(--space-3)',
-        padding: 'var(--space-3)',
-        background: selected ? 'var(--color-bg-tertiary)' : 'transparent',
-        border: 'none',
-        borderBottom: '1px solid var(--color-border-subtle)',
-        cursor: 'pointer',
-        textAlign: 'left',
-      }}
+      className="rv-list-row"
     >
-      <StateDot state={dotState} pulse={ravn.status === 'active'} size={8} />
-      <span
-        style={{
-          flex: 1,
-          fontSize: 'var(--text-sm)',
-          fontWeight: 500,
-          color: 'var(--color-text-primary)',
-        }}
-      >
-        {ravn.personaName}
-      </span>
+      <StateDot state={ravnStatusToDotState(ravn.status)} pulse={ravn.status === 'active'} size={8} />
+      <span className="rv-list-row__name">{ravn.personaName}</span>
       {budgetCap != null && budgetSpent != null && (
-        <div style={{ width: 64, flexShrink: 0 }}>
+        <div className="rv-list-row__budget">
           <BudgetBar
             spent={budgetSpent}
             cap={budgetCap}
@@ -106,55 +55,19 @@ interface RavnCardProps {
 }
 
 function RavnCard({ ravn, budget, selected, onClick }: RavnCardProps) {
-  const dotState =
-    ravn.status === 'active'
-      ? 'running'
-      : ravn.status === 'suspended'
-        ? 'attention'
-        : ravn.status === 'failed'
-          ? 'failed'
-          : 'unknown';
-
   return (
     <button
       type="button"
       onClick={onClick}
       data-testid="ravn-card"
       aria-selected={selected}
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 'var(--space-2)',
-        padding: 'var(--space-4)',
-        background: selected ? 'var(--color-bg-tertiary)' : 'var(--color-bg-secondary)',
-        border: `1px solid ${selected ? 'var(--color-border)' : 'var(--color-border-subtle)'}`,
-        borderRadius: 'var(--radius-md)',
-        cursor: 'pointer',
-        textAlign: 'left',
-      }}
+      className="rv-card"
     >
-      <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)' }}>
-        <StateDot state={dotState} pulse={ravn.status === 'active'} size={8} />
-        <span
-          style={{
-            fontSize: 'var(--text-sm)',
-            fontWeight: 600,
-            color: 'var(--color-text-primary)',
-            flex: 1,
-          }}
-        >
-          {ravn.personaName}
-        </span>
+      <div className="rv-card__header">
+        <StateDot state={ravnStatusToDotState(ravn.status)} pulse={ravn.status === 'active'} size={8} />
+        <span className="rv-card__name">{ravn.personaName}</span>
       </div>
-      <span
-        style={{
-          fontSize: 'var(--text-xs)',
-          color: 'var(--color-text-muted)',
-          fontFamily: 'var(--font-mono)',
-        }}
-      >
-        {ravn.model}
-      </span>
+      <span className="rv-card__model">{ravn.model}</span>
       {budget && (
         <BudgetBar
           spent={budget.spentUsd}
@@ -177,55 +90,22 @@ interface RavnTableRowProps {
 }
 
 function RavnTableRow({ ravn, budget, selected, onClick }: RavnTableRowProps) {
-  const dotState =
-    ravn.status === 'active'
-      ? 'running'
-      : ravn.status === 'suspended'
-        ? 'attention'
-        : ravn.status === 'failed'
-          ? 'failed'
-          : 'unknown';
-
   return (
     <tr
       onClick={onClick}
       data-testid="ravn-table-row"
       aria-selected={selected}
-      style={{
-        background: selected ? 'var(--color-bg-tertiary)' : 'transparent',
-        cursor: 'pointer',
-        borderBottom: '1px solid var(--color-border-subtle)',
-      }}
+      className="rv-table-row"
     >
-      <td
-        style={{
-          padding: 'var(--space-3)',
-          fontSize: 'var(--text-sm)',
-          fontWeight: 500,
-          color: 'var(--color-text-primary)',
-        }}
-      >
-        {ravn.personaName}
-      </td>
-      <td style={{ padding: 'var(--space-3)' }}>
-        <span style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)' }}>
-          <StateDot state={dotState} pulse={ravn.status === 'active'} size={8} />
-          <span style={{ fontSize: 'var(--text-sm)', color: 'var(--color-text-secondary)' }}>
-            {ravn.status}
-          </span>
+      <td className="rv-td--persona">{ravn.personaName}</td>
+      <td className="rv-td--status">
+        <span className="rv-td-status-inner">
+          <StateDot state={ravnStatusToDotState(ravn.status)} pulse={ravn.status === 'active'} size={8} />
+          <span>{ravn.status}</span>
         </span>
       </td>
-      <td
-        style={{
-          padding: 'var(--space-3)',
-          fontSize: 'var(--text-xs)',
-          color: 'var(--color-text-muted)',
-          fontFamily: 'var(--font-mono)',
-        }}
-      >
-        {ravn.model}
-      </td>
-      <td style={{ padding: 'var(--space-3)', minWidth: 120 }}>
+      <td className="rv-td--model">{ravn.model}</td>
+      <td className="rv-td--budget">
         {budget ? (
           <BudgetBar
             spent={budget.spentUsd}
@@ -234,7 +114,7 @@ function RavnTableRow({ ravn, budget, selected, onClick }: RavnTableRowProps) {
             size="sm"
           />
         ) : (
-          <span style={{ color: 'var(--color-text-muted)', fontSize: 'var(--text-xs)' }}>—</span>
+          <span className="rv-td--dash">—</span>
         )}
       </td>
     </tr>
@@ -248,33 +128,9 @@ interface GroupHeaderProps {
 
 function GroupHeader({ label, count }: GroupHeaderProps) {
   return (
-    <div
-      style={{
-        padding: 'var(--space-2) var(--space-3)',
-        fontSize: 'var(--text-xs)',
-        fontWeight: 600,
-        color: 'var(--color-text-muted)',
-        textTransform: 'uppercase',
-        letterSpacing: '0.06em',
-        background: 'var(--color-bg-primary)',
-        borderBottom: '1px solid var(--color-border)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-      }}
-    >
+    <div className="rv-group-header">
       <span>{label}</span>
-      <span
-        style={{
-          fontSize: 'var(--text-xs)',
-          padding: '0 var(--space-2)',
-          borderRadius: 'var(--radius-full)',
-          background: 'var(--color-bg-elevated)',
-          color: 'var(--color-text-muted)',
-        }}
-      >
-        {count}
-      </span>
+      <span className="rv-group-header__badge">{count}</span>
     </div>
   );
 }
@@ -325,27 +181,14 @@ export function RavensPage() {
   }
 
   return (
-    <div
-      data-testid="ravens-page"
-      style={{ display: 'flex', flexDirection: 'column', height: '100%' }}
-    >
+    <div data-testid="ravens-page" className="rv-ravens">
       {/* Toolbar */}
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 'var(--space-4)',
-          padding: 'var(--space-3) var(--space-6)',
-          borderBottom: '1px solid var(--color-border)',
-          background: 'var(--color-bg-primary)',
-        }}
-      >
-        {/* Layout selector */}
+      <div className="rv-ravens__toolbar">
         <div
           role="group"
           aria-label="Layout variant"
           data-testid="layout-selector"
-          style={{ display: 'flex', gap: 'var(--space-1)' }}
+          className="rv-layout-group"
         >
           {(['split', 'table', 'cards'] as LayoutVariant[]).map((v) => (
             <button
@@ -355,30 +198,17 @@ export function RavensPage() {
               aria-checked={layout === v}
               onClick={() => handleLayoutChange(v)}
               data-testid={`layout-btn-${v}`}
-              style={{
-                padding: 'var(--space-1) var(--space-3)',
-                borderRadius: 'var(--radius-sm)',
-                border: '1px solid var(--color-border)',
-                background: layout === v ? 'var(--color-bg-tertiary)' : 'transparent',
-                color: layout === v ? 'var(--color-text-primary)' : 'var(--color-text-muted)',
-                cursor: 'pointer',
-                fontSize: 'var(--text-xs)',
-                fontWeight: layout === v ? 600 : 400,
-              }}
+              className="rv-layout-btn"
             >
               {v}
             </button>
           ))}
         </div>
 
-        <div style={{ width: '1px', height: 16, background: 'var(--color-border)' }} />
+        <div className="rv-toolbar-divider" />
 
-        {/* Grouping selector */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)' }}>
-          <label
-            htmlFor="group-select"
-            style={{ fontSize: 'var(--text-xs)', color: 'var(--color-text-muted)' }}
-          >
+        <div className="rv-group-by">
+          <label htmlFor="group-select" className="rv-group-by__label">
             Group by
           </label>
           <select
@@ -386,15 +216,7 @@ export function RavensPage() {
             value={groupBy}
             onChange={(e) => handleGroupChange(e.target.value as GroupKey)}
             data-testid="grouping-selector"
-            style={{
-              fontSize: 'var(--text-xs)',
-              padding: 'var(--space-1) var(--space-2)',
-              borderRadius: 'var(--radius-sm)',
-              border: '1px solid var(--color-border)',
-              background: 'var(--color-bg-secondary)',
-              color: 'var(--color-text-primary)',
-              cursor: 'pointer',
-            }}
+            className="rv-group-by__select"
           >
             {(['none', 'state', 'persona', 'location'] as GroupKey[]).map((g) => (
               <option key={g} value={g}>
@@ -404,32 +226,17 @@ export function RavensPage() {
           </select>
         </div>
 
-        <span
-          style={{
-            marginLeft: 'auto',
-            fontSize: 'var(--text-xs)',
-            color: 'var(--color-text-muted)',
-          }}
-        >
+        <span className="rv-ravens__count">
           {ravnList.length} ravn{ravnList.length !== 1 ? 's' : ''}
         </span>
       </div>
 
       {/* Content area */}
-      <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
+      <div className="rv-ravens__content">
         {/* Split layout */}
         {layout === 'split' && (
           <>
-            <div
-              style={{
-                width: 280,
-                flexShrink: 0,
-                overflowY: 'auto',
-                borderRight: '1px solid var(--color-border)',
-                background: 'var(--color-bg-primary)',
-              }}
-              data-testid="layout-split"
-            >
+            <div className="rv-split__list" data-testid="layout-split">
               {groupEntries.map(([groupLabel, groupRavns]) => (
                 <div key={groupLabel}>
                   {groupBy !== 'none' && (
@@ -453,21 +260,11 @@ export function RavensPage() {
               ))}
             </div>
 
-            <div style={{ flex: 1, overflowY: 'auto' }}>
+            <div className="rv-split__detail">
               {selectedRavn ? (
                 <RavnDetail ravn={selectedRavn} onClose={() => setSelectedRavnId(null)} />
               ) : (
-                <div
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    height: '100%',
-                    color: 'var(--color-text-muted)',
-                    fontSize: 'var(--text-sm)',
-                  }}
-                  data-testid="detail-empty"
-                >
+                <div className="rv-detail-empty" data-testid="detail-empty">
                   Select a ravn to view details
                 </div>
               )}
@@ -477,26 +274,12 @@ export function RavensPage() {
 
         {/* Table layout */}
         {layout === 'table' && (
-          <div
-            style={{ flex: 1, overflowY: 'auto', padding: 'var(--space-4) var(--space-6)' }}
-            data-testid="layout-table"
-          >
-            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+          <div className="rv-table-layout" data-testid="layout-table">
+            <table className="rv-table">
               <thead>
-                <tr style={{ borderBottom: '1px solid var(--color-border)' }}>
+                <tr className="rv-thead-row">
                   {TABLE_COLUMNS.map((col) => (
-                    <th
-                      key={col}
-                      style={{
-                        padding: 'var(--space-2) var(--space-3)',
-                        textAlign: 'left',
-                        fontSize: 'var(--text-xs)',
-                        color: 'var(--color-text-muted)',
-                        fontWeight: 600,
-                        textTransform: 'uppercase',
-                        letterSpacing: '0.06em',
-                      }}
-                    >
+                    <th key={col} className="rv-th">
                       {col}
                     </th>
                   ))}
@@ -504,21 +287,10 @@ export function RavensPage() {
               </thead>
               <tbody>
                 {groupEntries.map(([groupLabel, groupRavns]) => (
-                  <>
+                  <Fragment key={groupLabel}>
                     {groupBy !== 'none' && (
-                      <tr key={`group-${groupLabel}`}>
-                        <td
-                          colSpan={TABLE_COLUMNS.length}
-                          style={{
-                            padding: 'var(--space-2) var(--space-3)',
-                            fontSize: 'var(--text-xs)',
-                            fontWeight: 600,
-                            color: 'var(--color-text-muted)',
-                            background: 'var(--color-bg-primary)',
-                            textTransform: 'uppercase',
-                            letterSpacing: '0.06em',
-                          }}
-                        >
+                      <tr>
+                        <td colSpan={TABLE_COLUMNS.length} className="rv-group-td">
                           {groupLabel} ({groupRavns.length})
                         </td>
                       </tr>
@@ -532,7 +304,7 @@ export function RavensPage() {
                         onClick={() => setSelectedRavnId(r.id === selectedRavnId ? null : r.id)}
                       />
                     ))}
-                  </>
+                  </Fragment>
                 ))}
               </tbody>
             </table>
@@ -541,40 +313,15 @@ export function RavensPage() {
 
         {/* Cards layout */}
         {layout === 'cards' && (
-          <div
-            style={{
-              flex: 1,
-              overflowY: 'auto',
-              padding: 'var(--space-6)',
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 'var(--space-6)',
-            }}
-            data-testid="layout-cards"
-          >
+          <div className="rv-cards-layout" data-testid="layout-cards">
             {groupEntries.map(([groupLabel, groupRavns]) => (
               <div key={groupLabel}>
                 {groupBy !== 'none' && (
-                  <h4
-                    style={{
-                      margin: '0 0 var(--space-3)',
-                      fontSize: 'var(--text-xs)',
-                      fontWeight: 600,
-                      color: 'var(--color-text-muted)',
-                      textTransform: 'uppercase',
-                      letterSpacing: '0.06em',
-                    }}
-                  >
+                  <h4 className="rv-cards-section__heading">
                     {groupLabel} ({groupRavns.length})
                   </h4>
                 )}
-                <div
-                  style={{
-                    display: 'grid',
-                    gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))',
-                    gap: 'var(--space-3)',
-                  }}
-                >
+                <div className="rv-cards-grid">
                   {groupRavns.map((r) => (
                     <RavnCard
                       key={r.id}

--- a/web-next/packages/plugin-ravn/src/ui/RavensPage.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/RavensPage.tsx
@@ -22,7 +22,14 @@ interface RavnRowProps {
   onClick?: () => void;
 }
 
-function RavnListRow({ ravn, budgetSpent, budgetCap, budgetWarnAt, selected, onClick }: RavnRowProps) {
+function RavnListRow({
+  ravn,
+  budgetSpent,
+  budgetCap,
+  budgetWarnAt,
+  selected,
+  onClick,
+}: RavnRowProps) {
   return (
     <button
       type="button"
@@ -31,7 +38,11 @@ function RavnListRow({ ravn, budgetSpent, budgetCap, budgetWarnAt, selected, onC
       aria-selected={selected}
       className="rv-list-row"
     >
-      <StateDot state={ravnStatusToDotState(ravn.status)} pulse={ravn.status === 'active'} size={8} />
+      <StateDot
+        state={ravnStatusToDotState(ravn.status)}
+        pulse={ravn.status === 'active'}
+        size={8}
+      />
       <span className="rv-list-row__name">{ravn.personaName}</span>
       {budgetCap != null && budgetSpent != null && (
         <div className="rv-list-row__budget">
@@ -64,7 +75,11 @@ function RavnCard({ ravn, budget, selected, onClick }: RavnCardProps) {
       className="rv-card"
     >
       <div className="rv-card__header">
-        <StateDot state={ravnStatusToDotState(ravn.status)} pulse={ravn.status === 'active'} size={8} />
+        <StateDot
+          state={ravnStatusToDotState(ravn.status)}
+          pulse={ravn.status === 'active'}
+          size={8}
+        />
         <span className="rv-card__name">{ravn.personaName}</span>
       </div>
       <span className="rv-card__model">{ravn.model}</span>
@@ -100,7 +115,11 @@ function RavnTableRow({ ravn, budget, selected, onClick }: RavnTableRowProps) {
       <td className="rv-td--persona">{ravn.personaName}</td>
       <td className="rv-td--status">
         <span className="rv-td-status-inner">
-          <StateDot state={ravnStatusToDotState(ravn.status)} pulse={ravn.status === 'active'} size={8} />
+          <StateDot
+            state={ravnStatusToDotState(ravn.status)}
+            pulse={ravn.status === 'active'}
+            size={8}
+          />
           <span>{ravn.status}</span>
         </span>
       </td>

--- a/web-next/packages/plugin-ravn/src/ui/RavnDetail.css
+++ b/web-next/packages/plugin-ravn/src/ui/RavnDetail.css
@@ -1,0 +1,294 @@
+/* Detail pane */
+.rv-detail {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--color-bg-secondary);
+  border-left: 1px solid var(--color-border);
+  overflow-y: auto;
+}
+
+/* Header */
+.rv-detail__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+  position: sticky;
+  top: 0;
+  background: var(--color-bg-secondary);
+  z-index: 1;
+}
+
+.rv-detail__title {
+  font-size: var(--text-lg);
+  flex: 1;
+  font-weight: 600;
+}
+
+.rv-detail__close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-muted);
+  font-size: var(--text-base);
+  padding: var(--space-1);
+  line-height: 1;
+}
+
+/* Collapsible section */
+.rv-section {
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.rv-section__toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-3) var(--space-4);
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-primary);
+  font-size: var(--text-sm);
+  font-weight: 600;
+}
+
+.rv-section__chevron {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  transform: rotate(0deg);
+  transition: transform 0.15s ease;
+}
+
+.rv-section__toggle[aria-expanded='false'] .rv-section__chevron {
+  transform: rotate(-90deg);
+}
+
+.rv-section__body {
+  padding: var(--space-2) var(--space-4) var(--space-4);
+}
+
+/* Overview section container */
+.rv-detail-overview {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+/* Overview dl */
+.rv-overview-dl {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: var(--space-1) var(--space-4);
+  margin: 0;
+  font-size: var(--text-sm);
+}
+
+.rv-overview-dl dt {
+  color: var(--color-text-muted);
+}
+
+.rv-overview-dl dd {
+  margin: 0;
+  color: var(--color-text-primary);
+  font-weight: 500;
+}
+
+.rv-overview-dd--state {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.rv-overview-dd--model {
+  color: var(--color-text-secondary);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: 400;
+}
+
+.rv-overview-dd--since {
+  color: var(--color-text-secondary);
+  font-size: var(--text-xs);
+  font-weight: 400;
+}
+
+/* Budget bar in overview */
+.rv-overview-budget {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.rv-overview-budget__header {
+  display: flex;
+  justify-content: space-between;
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+.rv-overview-budget__value {
+  font-family: var(--font-mono);
+}
+
+/* Triggers section */
+.rv-triggers-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.rv-trigger-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  padding: var(--space-1) 0;
+}
+
+.rv-trigger-kind {
+  font-size: var(--text-xs);
+  padding: 1px var(--space-2);
+  border-radius: var(--radius-full);
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-secondary);
+  font-family: var(--font-mono);
+}
+
+.rv-trigger-spec {
+  flex: 1;
+  color: var(--color-text-primary);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+}
+
+.rv-trigger-status {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+.rv-trigger-status[data-enabled='true'] {
+  color: var(--color-accent-emerald);
+}
+
+/* Activity section */
+.rv-activity-session {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  margin-top: 0;
+}
+
+.rv-activity-messages {
+  max-height: 200px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.rv-activity-message {
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-text-secondary);
+  padding-left: var(--space-3);
+}
+
+.rv-activity-message[data-kind='user'] {
+  color: var(--color-text-primary);
+  padding-left: 0;
+}
+
+.rv-activity-message__kind {
+  color: var(--color-text-muted);
+}
+
+/* Sessions section */
+.rv-sessions-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.rv-session-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  font-size: var(--text-sm);
+}
+
+.rv-session-id {
+  flex: 1;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+}
+
+.rv-session-status {
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+}
+
+/* Connectivity section */
+.rv-connectivity-model {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  margin: 0 0 var(--space-2);
+}
+
+.rv-connectivity-model-value {
+  font-family: var(--font-mono);
+  color: var(--color-text-secondary);
+}
+
+.rv-connectivity-note {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.rv-connectivity-note-emphasis {
+  color: var(--color-text-secondary);
+}
+
+/* Delete section */
+.rv-delete-actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.rv-suspend-btn {
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-primary);
+  cursor: pointer;
+  font-size: var(--text-sm);
+}
+
+.rv-delete-btn {
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-accent-red);
+  background: color-mix(in srgb, var(--color-accent-red) 10%, transparent);
+  color: var(--color-accent-red);
+  cursor: pointer;
+  font-size: var(--text-sm);
+}
+
+/* Shared empty text */
+.rv-empty-text {
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  margin: 0;
+}

--- a/web-next/packages/plugin-ravn/src/ui/RavnDetail.stories.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/RavnDetail.stories.tsx
@@ -1,0 +1,145 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ServicesProvider } from '@niuulabs/plugin-sdk';
+import { RavnDetail } from './RavnDetail';
+import {
+  createMockTriggerStore,
+  createMockSessionStream,
+  createMockBudgetStream,
+} from '../adapters/mock';
+import type { Ravn } from '../domain/ravn';
+
+const ACTIVE_RAVN: Ravn = {
+  id: 'a3f1b2c4-8e7d-4a6f-9b0c-1d2e3f4a5b6c',
+  personaName: 'coding-agent',
+  status: 'active',
+  model: 'claude-sonnet-4-6',
+  createdAt: '2026-04-15T09:12:34Z',
+};
+
+const SUSPENDED_RAVN: Ravn = {
+  id: 'e1f2a3b4-5c6d-4e7f-8a9b-0c1d2e3f4a5b',
+  personaName: 'investigator',
+  status: 'suspended',
+  model: 'claude-opus-4-6',
+  createdAt: '2026-04-14T22:10:45Z',
+};
+
+const IDLE_RAVN: Ravn = {
+  id: 'f5a6b7c8-9d0e-4f1a-2b3c-4d5e6f7a8b9c',
+  personaName: 'health-auditor',
+  status: 'idle',
+  model: 'claude-sonnet-4-6',
+  createdAt: '2026-04-14T18:33:07Z',
+};
+
+function makeDecorator(ravn: Ravn, allSectionsOpen = false) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  if (allSectionsOpen) {
+    localStorage.removeItem('ravn.detail.sections.collapsed');
+  }
+  return function Decorator({ children }: { children: React.ReactNode }) {
+    return (
+      <div style={{ width: 360, height: '100vh', background: 'var(--color-bg-primary)' }}>
+        <QueryClientProvider client={client}>
+          <ServicesProvider
+            services={{
+              'ravn.triggers': createMockTriggerStore(),
+              'ravn.sessions': createMockSessionStream(),
+              'ravn.budget': createMockBudgetStream(),
+            }}
+          >
+            {children}
+          </ServicesProvider>
+        </QueryClientProvider>
+      </div>
+    );
+  };
+  void ravn;
+}
+
+const meta: Meta<typeof RavnDetail> = {
+  title: 'Plugins / Ravn / RavnDetail',
+  component: RavnDetail,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof RavnDetail>;
+
+/** Active ravn — overview section open by default, state dot pulses. */
+export const ActiveRavn: Story = {
+  args: { ravn: ACTIVE_RAVN },
+  decorators: [
+    (Story) => {
+      const D = makeDecorator(ACTIVE_RAVN);
+      return (
+        <D>
+          <Story />
+        </D>
+      );
+    },
+  ],
+};
+
+/** Suspended ravn — suspend button disabled. */
+export const SuspendedRavn: Story = {
+  args: { ravn: SUSPENDED_RAVN },
+  decorators: [
+    (Story) => {
+      const D = makeDecorator(SUSPENDED_RAVN);
+      return (
+        <D>
+          <Story />
+        </D>
+      );
+    },
+  ],
+};
+
+/** Idle ravn — neutral state dot. */
+export const IdleRavn: Story = {
+  args: { ravn: IDLE_RAVN },
+  decorators: [
+    (Story) => {
+      const D = makeDecorator(IDLE_RAVN);
+      return (
+        <D>
+          <Story />
+        </D>
+      );
+    },
+  ],
+};
+
+/** All 6 sections expanded. */
+export const AllSectionsExpanded: Story = {
+  args: { ravn: ACTIVE_RAVN },
+  decorators: [
+    (Story) => {
+      localStorage.setItem('ravn.detail.sections.collapsed', '[]');
+      const D = makeDecorator(ACTIVE_RAVN, true);
+      return (
+        <D>
+          <Story />
+        </D>
+      );
+    },
+  ],
+};
+
+/** With a close button. */
+export const WithCloseButton: Story = {
+  args: { ravn: ACTIVE_RAVN, onClose: () => console.log('close') },
+  decorators: [
+    (Story) => {
+      const D = makeDecorator(ACTIVE_RAVN);
+      return (
+        <D>
+          <Story />
+        </D>
+      );
+    },
+  ],
+};

--- a/web-next/packages/plugin-ravn/src/ui/RavnDetail.test.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/RavnDetail.test.tsx
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ServicesProvider } from '@niuulabs/plugin-sdk';
+import { RavnDetail } from './RavnDetail';
+import {
+  createMockRavenStream,
+  createMockTriggerStore,
+  createMockSessionStream,
+  createMockBudgetStream,
+} from '../adapters/mock';
+import type { Ravn } from '../domain/ravn';
+
+const SAMPLE_RAVN: Ravn = {
+  id: 'a3f1b2c4-8e7d-4a6f-9b0c-1d2e3f4a5b6c',
+  personaName: 'coding-agent',
+  status: 'active',
+  model: 'claude-sonnet-4-6',
+  createdAt: '2026-04-15T09:00:00Z',
+};
+
+const SUSPENDED_RAVN: Ravn = {
+  id: 'e1f2a3b4-5c6d-4e7f-8a9b-0c1d2e3f4a5b',
+  personaName: 'investigator',
+  status: 'suspended',
+  model: 'claude-opus-4-6',
+  createdAt: '2026-04-14T22:00:00Z',
+};
+
+function makeServices(overrides?: Record<string, unknown>) {
+  return {
+    'ravn.ravens': createMockRavenStream(),
+    'ravn.triggers': createMockTriggerStore(),
+    'ravn.sessions': createMockSessionStream(),
+    'ravn.budget': createMockBudgetStream(),
+    ...overrides,
+  };
+}
+
+function wrap(services = makeServices()) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>
+        <ServicesProvider services={services}>{children}</ServicesProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('RavnDetail', () => {
+  it('renders the ravn detail pane', () => {
+    render(<RavnDetail ravn={SAMPLE_RAVN} />, { wrapper: wrap() });
+    expect(screen.getByTestId('ravn-detail')).toBeInTheDocument();
+  });
+
+  it('shows the persona name in the header', () => {
+    render(<RavnDetail ravn={SAMPLE_RAVN} />, { wrapper: wrap() });
+    expect(screen.getAllByText('coding-agent').length).toBeGreaterThan(0);
+  });
+
+  it('renders all 6 collapsible sections', () => {
+    render(<RavnDetail ravn={SAMPLE_RAVN} />, { wrapper: wrap() });
+    for (const id of ['overview', 'triggers', 'activity', 'sessions', 'connectivity', 'delete']) {
+      expect(screen.getByTestId(`ravn-detail-section-${id}`)).toBeInTheDocument();
+    }
+  });
+
+  it('shows overview section expanded by default', () => {
+    render(<RavnDetail ravn={SAMPLE_RAVN} />, { wrapper: wrap() });
+    expect(screen.getByTestId('section-body-overview')).toBeInTheDocument();
+  });
+
+  it('shows persona name in overview section body', async () => {
+    render(<RavnDetail ravn={SAMPLE_RAVN} />, { wrapper: wrap() });
+    await waitFor(() => expect(screen.getAllByText('coding-agent').length).toBeGreaterThan(0));
+  });
+
+  it('collapses a section when its toggle is clicked', () => {
+    render(<RavnDetail ravn={SAMPLE_RAVN} />, { wrapper: wrap() });
+    const toggle = screen.getByTestId('section-toggle-overview');
+    fireEvent.click(toggle);
+    expect(screen.queryByTestId('section-body-overview')).not.toBeInTheDocument();
+  });
+
+  it('expands a collapsed section when toggle is clicked again', () => {
+    render(<RavnDetail ravn={SAMPLE_RAVN} />, { wrapper: wrap() });
+    const toggle = screen.getByTestId('section-toggle-overview');
+    fireEvent.click(toggle); // collapse
+    fireEvent.click(toggle); // expand
+    expect(screen.getByTestId('section-body-overview')).toBeInTheDocument();
+  });
+
+  it('persists collapsed state to localStorage', () => {
+    render(<RavnDetail ravn={SAMPLE_RAVN} />, { wrapper: wrap() });
+    const toggle = screen.getByTestId('section-toggle-triggers');
+    fireEvent.click(toggle); // expand triggers
+    const stored = JSON.parse(
+      localStorage.getItem('ravn.detail.sections.collapsed') ?? '[]',
+    ) as string[];
+    expect(Array.isArray(stored)).toBe(true);
+  });
+
+  it('shows close button when onClose is provided', () => {
+    const handleClose = vi.fn();
+    render(<RavnDetail ravn={SAMPLE_RAVN} onClose={handleClose} />, { wrapper: wrap() });
+    const btn = screen.getByTestId('detail-close-btn');
+    expect(btn).toBeInTheDocument();
+    fireEvent.click(btn);
+    expect(handleClose).toHaveBeenCalled();
+  });
+
+  it('does not show close button when onClose is not provided', () => {
+    render(<RavnDetail ravn={SAMPLE_RAVN} />, { wrapper: wrap() });
+    expect(screen.queryByTestId('detail-close-btn')).not.toBeInTheDocument();
+  });
+
+  it('renders suspend button for active ravn', () => {
+    render(<RavnDetail ravn={SAMPLE_RAVN} />, { wrapper: wrap() });
+    // Expand delete section first
+    const deleteToggle = screen.getByTestId('section-toggle-delete');
+    fireEvent.click(deleteToggle);
+    expect(screen.getByTestId('suspend-btn')).toBeInTheDocument();
+    expect(screen.getByTestId('suspend-btn')).not.toBeDisabled();
+  });
+
+  it('disables suspend button when ravn is already suspended', () => {
+    render(<RavnDetail ravn={SUSPENDED_RAVN} />, { wrapper: wrap() });
+    const deleteToggle = screen.getByTestId('section-toggle-delete');
+    fireEvent.click(deleteToggle);
+    expect(screen.getByTestId('suspend-btn')).toBeDisabled();
+  });
+
+  it('renders delete button', () => {
+    render(<RavnDetail ravn={SAMPLE_RAVN} />, { wrapper: wrap() });
+    const deleteToggle = screen.getByTestId('section-toggle-delete');
+    fireEvent.click(deleteToggle);
+    expect(screen.getByTestId('delete-btn')).toBeInTheDocument();
+  });
+
+  it('renders triggers section when expanded', async () => {
+    render(<RavnDetail ravn={SAMPLE_RAVN} />, { wrapper: wrap() });
+    const toggle = screen.getByTestId('section-toggle-triggers');
+    fireEvent.click(toggle);
+    await waitFor(() => expect(screen.getByTestId('triggers-section-body')).toBeInTheDocument());
+  });
+
+  it('renders sessions section when expanded', async () => {
+    render(<RavnDetail ravn={SAMPLE_RAVN} />, { wrapper: wrap() });
+    const toggle = screen.getByTestId('section-toggle-sessions');
+    fireEvent.click(toggle);
+    await waitFor(() => expect(screen.getByTestId('sessions-section-body')).toBeInTheDocument());
+  });
+
+  it('renders connectivity section when expanded', () => {
+    render(<RavnDetail ravn={SAMPLE_RAVN} />, { wrapper: wrap() });
+    const toggle = screen.getByTestId('section-toggle-connectivity');
+    fireEvent.click(toggle);
+    expect(screen.getByTestId('connectivity-section-body')).toBeInTheDocument();
+  });
+});

--- a/web-next/packages/plugin-ravn/src/ui/RavnDetail.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/RavnDetail.tsx
@@ -142,12 +142,12 @@ function OverviewSection({ ravn, budget }: OverviewSectionProps) {
           <StateDot
             state={
               ravn.status === 'active'
-                ? 'ok'
+                ? 'running'
                 : ravn.status === 'suspended'
-                  ? 'warn'
+                  ? 'attention'
                   : ravn.status === 'failed'
-                    ? 'err'
-                    : 'mute'
+                    ? 'failed'
+                    : 'unknown'
             }
             pulse={ravn.status === 'active'}
             size={8}
@@ -365,7 +365,9 @@ function SessionsSection({ ravnId }: SessionsSectionProps) {
               data-testid="session-row"
             >
               <StateDot
-                state={s.status === 'running' ? 'ok' : s.status === 'failed' ? 'err' : 'mute'}
+                state={
+                  s.status === 'running' ? 'running' : s.status === 'failed' ? 'failed' : 'unknown'
+                }
                 pulse={s.status === 'running'}
                 size={8}
               />
@@ -534,12 +536,12 @@ export function RavnDetail({ ravn, onClose }: RavnDetailProps) {
         <StateDot
           state={
             ravn.status === 'active'
-              ? 'ok'
+              ? 'running'
               : ravn.status === 'suspended'
-                ? 'warn'
+                ? 'attention'
                 : ravn.status === 'failed'
-                  ? 'err'
-                  : 'mute'
+                  ? 'failed'
+                  : 'unknown'
           }
           pulse={ravn.status === 'active'}
           size={8}

--- a/web-next/packages/plugin-ravn/src/ui/RavnDetail.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/RavnDetail.tsx
@@ -1,0 +1,587 @@
+import { useState, useCallback } from 'react';
+import { BudgetBar, StateDot } from '@niuulabs/ui';
+import type { Ravn } from '../domain/ravn';
+import type { BudgetState } from '@niuulabs/domain';
+import { useTriggers } from './hooks/useTriggers';
+import { useSessions } from './hooks/useSessions';
+import { useMessages } from './hooks/useSessions';
+import { useRavnBudget } from './hooks/useBudget';
+
+const SECTIONS_STORAGE_KEY = 'ravn.detail.sections.collapsed';
+
+const DEFAULT_SECTIONS: SectionId[] = ['overview'];
+
+type SectionId = 'overview' | 'triggers' | 'activity' | 'sessions' | 'connectivity' | 'delete';
+
+const SECTION_LABELS: Record<SectionId, string> = {
+  overview: 'Overview',
+  triggers: 'Triggers',
+  activity: 'Activity',
+  sessions: 'Sessions',
+  connectivity: 'Connectivity',
+  delete: 'Delete / Suspend',
+};
+
+const ALL_SECTIONS: SectionId[] = [
+  'overview',
+  'triggers',
+  'activity',
+  'sessions',
+  'connectivity',
+  'delete',
+];
+
+function loadCollapsedSections(): Set<SectionId> {
+  try {
+    const raw = localStorage.getItem(SECTIONS_STORAGE_KEY);
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw) as SectionId[];
+    return new Set(parsed);
+  } catch {
+    return new Set();
+  }
+}
+
+function saveCollapsedSections(collapsed: Set<SectionId>): void {
+  try {
+    localStorage.setItem(SECTIONS_STORAGE_KEY, JSON.stringify(Array.from(collapsed)));
+  } catch {
+    // ignore storage errors
+  }
+}
+
+interface CollapsibleSectionProps {
+  id: SectionId;
+  label: string;
+  collapsed: boolean;
+  onToggle: (id: SectionId) => void;
+  children: React.ReactNode;
+}
+
+function CollapsibleSection({ id, label, collapsed, onToggle, children }: CollapsibleSectionProps) {
+  return (
+    <div
+      data-testid={`ravn-detail-section-${id}`}
+      style={{
+        borderBottom: '1px solid var(--color-border-subtle)',
+      }}
+    >
+      <button
+        type="button"
+        aria-expanded={!collapsed}
+        aria-controls={`section-body-${id}`}
+        onClick={() => onToggle(id)}
+        style={{
+          width: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: 'var(--space-3) var(--space-4)',
+          background: 'none',
+          border: 'none',
+          cursor: 'pointer',
+          color: 'var(--color-text-primary)',
+          fontSize: 'var(--text-sm)',
+          fontWeight: 600,
+        }}
+        data-testid={`section-toggle-${id}`}
+      >
+        <span>{label}</span>
+        <span
+          aria-hidden="true"
+          style={{
+            fontSize: 'var(--text-xs)',
+            color: 'var(--color-text-muted)',
+            transform: collapsed ? 'rotate(-90deg)' : 'rotate(0deg)',
+            transition: 'transform 0.15s ease',
+          }}
+        >
+          ▾
+        </span>
+      </button>
+
+      {!collapsed && (
+        <div
+          id={`section-body-${id}`}
+          style={{ padding: 'var(--space-2) var(--space-4) var(--space-4)' }}
+          data-testid={`section-body-${id}`}
+        >
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface OverviewSectionProps {
+  ravn: Ravn;
+  budget: BudgetState | undefined;
+}
+
+function OverviewSection({ ravn, budget }: OverviewSectionProps) {
+  const uptimeSince = new Date(ravn.createdAt).toLocaleString();
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-3)' }}>
+      <dl
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'auto 1fr',
+          gap: 'var(--space-1) var(--space-4)',
+          margin: 0,
+          fontSize: 'var(--text-sm)',
+        }}
+      >
+        <dt style={{ color: 'var(--color-text-muted)' }}>Persona</dt>
+        <dd style={{ margin: 0, color: 'var(--color-text-primary)', fontWeight: 500 }}>
+          {ravn.personaName}
+        </dd>
+
+        <dt style={{ color: 'var(--color-text-muted)' }}>State</dt>
+        <dd style={{ margin: 0, display: 'flex', alignItems: 'center', gap: 'var(--space-2)' }}>
+          <StateDot
+            state={
+              ravn.status === 'active'
+                ? 'ok'
+                : ravn.status === 'suspended'
+                  ? 'warn'
+                  : ravn.status === 'failed'
+                    ? 'err'
+                    : 'mute'
+            }
+            pulse={ravn.status === 'active'}
+            size={8}
+          />
+          <span style={{ color: 'var(--color-text-primary)' }}>{ravn.status}</span>
+        </dd>
+
+        <dt style={{ color: 'var(--color-text-muted)' }}>Model</dt>
+        <dd
+          style={{
+            margin: 0,
+            color: 'var(--color-text-secondary)',
+            fontFamily: 'var(--font-mono)',
+            fontSize: 'var(--text-xs)',
+          }}
+        >
+          {ravn.model}
+        </dd>
+
+        <dt style={{ color: 'var(--color-text-muted)' }}>Since</dt>
+        <dd style={{ margin: 0, color: 'var(--color-text-secondary)', fontSize: 'var(--text-xs)' }}>
+          {uptimeSince}
+        </dd>
+      </dl>
+
+      {budget && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-1)' }}>
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              fontSize: 'var(--text-xs)',
+              color: 'var(--color-text-muted)',
+            }}
+          >
+            <span>Budget</span>
+            <span style={{ fontFamily: 'var(--font-mono)' }}>
+              ${budget.spentUsd.toFixed(2)} / ${budget.capUsd.toFixed(2)}
+            </span>
+          </div>
+          <BudgetBar
+            spent={budget.spentUsd}
+            cap={budget.capUsd}
+            warnAt={Math.round(budget.warnAt * 100)}
+            size="sm"
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface TriggersSectionProps {
+  ravnPersonaName: string;
+}
+
+function TriggersSection({ ravnPersonaName }: TriggersSectionProps) {
+  const { data: triggers } = useTriggers();
+  const ravnTriggers = triggers?.filter((t) => t.personaName === ravnPersonaName) ?? [];
+
+  return (
+    <div data-testid="triggers-section-body">
+      {ravnTriggers.length === 0 ? (
+        <p style={{ color: 'var(--color-text-muted)', fontSize: 'var(--text-sm)', margin: 0 }}>
+          No triggers configured
+        </p>
+      ) : (
+        <ul
+          style={{
+            listStyle: 'none',
+            margin: 0,
+            padding: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 'var(--space-2)',
+          }}
+        >
+          {ravnTriggers.map((t) => (
+            <li
+              key={t.id}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 'var(--space-2)',
+                fontSize: 'var(--text-sm)',
+                padding: 'var(--space-1) 0',
+              }}
+              data-testid="trigger-row"
+            >
+              <span
+                style={{
+                  fontSize: 'var(--text-xs)',
+                  padding: '1px var(--space-2)',
+                  borderRadius: 'var(--radius-full)',
+                  background: 'var(--color-bg-tertiary)',
+                  color: 'var(--color-text-secondary)',
+                  fontFamily: 'var(--font-mono)',
+                }}
+              >
+                {t.kind}
+              </span>
+              <span
+                style={{
+                  flex: 1,
+                  color: 'var(--color-text-primary)',
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 'var(--text-xs)',
+                }}
+              >
+                {t.spec}
+              </span>
+              <span
+                style={{
+                  fontSize: 'var(--text-xs)',
+                  color: t.enabled ? 'var(--color-accent-emerald)' : 'var(--color-text-muted)',
+                }}
+              >
+                {t.enabled ? 'on' : 'off'}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+interface ActivitySectionProps {
+  ravnId: string;
+}
+
+function ActivitySection({ ravnId }: ActivitySectionProps) {
+  const { data: sessions } = useSessions();
+  const ravnSession = sessions?.find((s) => s.ravnId === ravnId);
+  const { data: messages } = useMessages(ravnSession?.id ?? '');
+
+  if (!ravnSession) {
+    return (
+      <p style={{ color: 'var(--color-text-muted)', fontSize: 'var(--text-sm)', margin: 0 }}>
+        No sessions for this ravn
+      </p>
+    );
+  }
+
+  return (
+    <div data-testid="activity-section-body">
+      <p style={{ fontSize: 'var(--text-xs)', color: 'var(--color-text-muted)', marginTop: 0 }}>
+        Session {ravnSession.id.slice(0, 8)} — {ravnSession.status}
+      </p>
+      <div
+        style={{
+          maxHeight: 200,
+          overflowY: 'auto',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 'var(--space-1)',
+        }}
+      >
+        {(messages ?? []).slice(-10).map((msg) => (
+          <div
+            key={msg.id}
+            style={{
+              fontSize: 'var(--text-xs)',
+              fontFamily: 'var(--font-mono)',
+              color:
+                msg.kind === 'user' ? 'var(--color-text-primary)' : 'var(--color-text-secondary)',
+              paddingLeft: msg.kind !== 'user' ? 'var(--space-3)' : 0,
+            }}
+            data-testid="activity-message"
+          >
+            <span style={{ color: 'var(--color-text-muted)' }}>[{msg.kind}] </span>
+            {msg.content.slice(0, 80)}
+            {msg.content.length > 80 ? '…' : ''}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface SessionsSectionProps {
+  ravnId: string;
+}
+
+function SessionsSection({ ravnId }: SessionsSectionProps) {
+  const { data: sessions } = useSessions();
+  const ravnSessions = sessions?.filter((s) => s.ravnId === ravnId) ?? [];
+
+  return (
+    <div data-testid="sessions-section-body">
+      {ravnSessions.length === 0 ? (
+        <p style={{ color: 'var(--color-text-muted)', fontSize: 'var(--text-sm)', margin: 0 }}>
+          No sessions
+        </p>
+      ) : (
+        <ul
+          style={{
+            listStyle: 'none',
+            margin: 0,
+            padding: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 'var(--space-2)',
+          }}
+        >
+          {ravnSessions.map((s) => (
+            <li
+              key={s.id}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 'var(--space-3)',
+                fontSize: 'var(--text-sm)',
+              }}
+              data-testid="session-row"
+            >
+              <StateDot
+                state={s.status === 'running' ? 'ok' : s.status === 'failed' ? 'err' : 'mute'}
+                pulse={s.status === 'running'}
+                size={8}
+              />
+              <span
+                style={{
+                  flex: 1,
+                  fontFamily: 'var(--font-mono)',
+                  fontSize: 'var(--text-xs)',
+                  color: 'var(--color-text-secondary)',
+                }}
+              >
+                {s.id.slice(0, 8)}
+              </span>
+              <span style={{ color: 'var(--color-text-muted)', fontSize: 'var(--text-xs)' }}>
+                {s.status}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+interface ConnectivitySectionProps {
+  ravn: Ravn;
+}
+
+function ConnectivitySection({ ravn }: ConnectivitySectionProps) {
+  return (
+    <div data-testid="connectivity-section-body">
+      <p
+        style={{
+          fontSize: 'var(--text-xs)',
+          color: 'var(--color-text-muted)',
+          margin: '0 0 var(--space-2)',
+        }}
+      >
+        Model:{' '}
+        <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--color-text-secondary)' }}>
+          {ravn.model}
+        </span>
+      </p>
+      <p style={{ fontSize: 'var(--text-xs)', color: 'var(--color-text-muted)', margin: 0 }}>
+        Event wiring is configured per-persona. View the{' '}
+        <span style={{ color: 'var(--color-text-secondary)' }}>Events</span> tab for the full graph.
+      </p>
+    </div>
+  );
+}
+
+interface DeleteSectionProps {
+  ravn: Ravn;
+}
+
+function DeleteSection({ ravn }: DeleteSectionProps) {
+  return (
+    <div
+      style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-3)' }}
+      data-testid="delete-section-body"
+    >
+      <button
+        type="button"
+        style={{
+          padding: 'var(--space-2) var(--space-4)',
+          borderRadius: 'var(--radius-md)',
+          border: '1px solid var(--color-border)',
+          background: 'var(--color-bg-tertiary)',
+          color: 'var(--color-text-primary)',
+          cursor: 'pointer',
+          fontSize: 'var(--text-sm)',
+        }}
+        data-testid="suspend-btn"
+        disabled={ravn.status === 'suspended'}
+      >
+        {ravn.status === 'suspended' ? 'Already suspended' : 'Suspend ravn'}
+      </button>
+
+      <button
+        type="button"
+        style={{
+          padding: 'var(--space-2) var(--space-4)',
+          borderRadius: 'var(--radius-md)',
+          border: '1px solid var(--color-accent-red)',
+          background: 'color-mix(in srgb, var(--color-accent-red) 10%, transparent)',
+          color: 'var(--color-accent-red)',
+          cursor: 'pointer',
+          fontSize: 'var(--text-sm)',
+        }}
+        data-testid="delete-btn"
+      >
+        Delete ravn
+      </button>
+    </div>
+  );
+}
+
+export interface RavnDetailProps {
+  ravn: Ravn;
+  onClose?: () => void;
+  className?: string;
+}
+
+export function RavnDetail({ ravn, onClose }: RavnDetailProps) {
+  const [collapsed, setCollapsed] = useState<Set<SectionId>>(() => {
+    const stored = loadCollapsedSections();
+    // By default expand 'overview'; collapse everything else unless stored
+    const initial = new Set<SectionId>(ALL_SECTIONS.filter((s) => !DEFAULT_SECTIONS.includes(s)));
+    // Apply stored preferences
+    for (const section of ALL_SECTIONS) {
+      if (stored.has(section)) {
+        initial.add(section);
+      } else if (!DEFAULT_SECTIONS.includes(section) && !stored.size) {
+        // keep default
+      } else if (!stored.has(section) && stored.size > 0) {
+        initial.delete(section);
+      }
+    }
+    return initial;
+  });
+
+  const { data: budget } = useRavnBudget(ravn.id);
+
+  const handleToggle = useCallback((id: SectionId) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      saveCollapsedSections(next);
+      return next;
+    });
+  }, []);
+
+  return (
+    <div
+      data-testid="ravn-detail"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        background: 'var(--color-bg-secondary)',
+        borderLeft: '1px solid var(--color-border)',
+        overflowY: 'auto',
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--space-3)',
+          padding: 'var(--space-4)',
+          borderBottom: '1px solid var(--color-border)',
+          position: 'sticky',
+          top: 0,
+          background: 'var(--color-bg-secondary)',
+          zIndex: 1,
+        }}
+      >
+        <span style={{ fontSize: 'var(--text-lg)', flex: 1, fontWeight: 600 }}>
+          {ravn.personaName}
+        </span>
+        <StateDot
+          state={
+            ravn.status === 'active'
+              ? 'ok'
+              : ravn.status === 'suspended'
+                ? 'warn'
+                : ravn.status === 'failed'
+                  ? 'err'
+                  : 'mute'
+          }
+          pulse={ravn.status === 'active'}
+          size={8}
+        />
+        {onClose && (
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close detail pane"
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              color: 'var(--color-text-muted)',
+              fontSize: 'var(--text-base)',
+              padding: 'var(--space-1)',
+              lineHeight: 1,
+            }}
+            data-testid="detail-close-btn"
+          >
+            ✕
+          </button>
+        )}
+      </div>
+
+      {/* Sections */}
+      {ALL_SECTIONS.map((id) => (
+        <CollapsibleSection
+          key={id}
+          id={id}
+          label={SECTION_LABELS[id]}
+          collapsed={collapsed.has(id)}
+          onToggle={handleToggle}
+        >
+          {id === 'overview' && <OverviewSection ravn={ravn} budget={budget} />}
+          {id === 'triggers' && <TriggersSection ravnPersonaName={ravn.personaName} />}
+          {id === 'activity' && <ActivitySection ravnId={ravn.id} />}
+          {id === 'sessions' && <SessionsSection ravnId={ravn.id} />}
+          {id === 'connectivity' && <ConnectivitySection ravn={ravn} />}
+          {id === 'delete' && <DeleteSection ravn={ravn} />}
+        </CollapsibleSection>
+      ))}
+    </div>
+  );
+}

--- a/web-next/packages/plugin-ravn/src/ui/RavnDetail.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/RavnDetail.tsx
@@ -6,10 +6,13 @@ import { useTriggers } from './hooks/useTriggers';
 import { useSessions } from './hooks/useSessions';
 import { useMessages } from './hooks/useSessions';
 import { useRavnBudget } from './hooks/useBudget';
+import { ravnStatusToDotState } from './grouping';
+import { loadStorage, saveStorage } from './storage';
+import './RavnDetail.css';
 
 const SECTIONS_STORAGE_KEY = 'ravn.detail.sections.collapsed';
 
-const DEFAULT_SECTIONS: SectionId[] = ['overview'];
+const INITIALLY_EXPANDED_SECTIONS: SectionId[] = ['overview'];
 
 type SectionId = 'overview' | 'triggers' | 'activity' | 'sessions' | 'connectivity' | 'delete';
 
@@ -31,25 +34,6 @@ const ALL_SECTIONS: SectionId[] = [
   'delete',
 ];
 
-function loadCollapsedSections(): Set<SectionId> {
-  try {
-    const raw = localStorage.getItem(SECTIONS_STORAGE_KEY);
-    if (!raw) return new Set();
-    const parsed = JSON.parse(raw) as SectionId[];
-    return new Set(parsed);
-  } catch {
-    return new Set();
-  }
-}
-
-function saveCollapsedSections(collapsed: Set<SectionId>): void {
-  try {
-    localStorage.setItem(SECTIONS_STORAGE_KEY, JSON.stringify(Array.from(collapsed)));
-  } catch {
-    // ignore storage errors
-  }
-}
-
 interface CollapsibleSectionProps {
   id: SectionId;
   label: string;
@@ -60,42 +44,17 @@ interface CollapsibleSectionProps {
 
 function CollapsibleSection({ id, label, collapsed, onToggle, children }: CollapsibleSectionProps) {
   return (
-    <div
-      data-testid={`ravn-detail-section-${id}`}
-      style={{
-        borderBottom: '1px solid var(--color-border-subtle)',
-      }}
-    >
+    <div data-testid={`ravn-detail-section-${id}`} className="rv-section">
       <button
         type="button"
         aria-expanded={!collapsed}
         aria-controls={`section-body-${id}`}
         onClick={() => onToggle(id)}
-        style={{
-          width: '100%',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          padding: 'var(--space-3) var(--space-4)',
-          background: 'none',
-          border: 'none',
-          cursor: 'pointer',
-          color: 'var(--color-text-primary)',
-          fontSize: 'var(--text-sm)',
-          fontWeight: 600,
-        }}
+        className="rv-section__toggle"
         data-testid={`section-toggle-${id}`}
       >
         <span>{label}</span>
-        <span
-          aria-hidden="true"
-          style={{
-            fontSize: 'var(--text-xs)',
-            color: 'var(--color-text-muted)',
-            transform: collapsed ? 'rotate(-90deg)' : 'rotate(0deg)',
-            transition: 'transform 0.15s ease',
-          }}
-        >
+        <span aria-hidden="true" className="rv-section__chevron">
           ▾
         </span>
       </button>
@@ -103,7 +62,7 @@ function CollapsibleSection({ id, label, collapsed, onToggle, children }: Collap
       {!collapsed && (
         <div
           id={`section-body-${id}`}
-          style={{ padding: 'var(--space-2) var(--space-4) var(--space-4)' }}
+          className="rv-section__body"
           data-testid={`section-body-${id}`}
         >
           {children}
@@ -122,69 +81,29 @@ function OverviewSection({ ravn, budget }: OverviewSectionProps) {
   const uptimeSince = new Date(ravn.createdAt).toLocaleString();
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-3)' }}>
-      <dl
-        style={{
-          display: 'grid',
-          gridTemplateColumns: 'auto 1fr',
-          gap: 'var(--space-1) var(--space-4)',
-          margin: 0,
-          fontSize: 'var(--text-sm)',
-        }}
-      >
-        <dt style={{ color: 'var(--color-text-muted)' }}>Persona</dt>
-        <dd style={{ margin: 0, color: 'var(--color-text-primary)', fontWeight: 500 }}>
-          {ravn.personaName}
+    <div className="rv-detail-overview">
+      <dl className="rv-overview-dl">
+        <dt>Persona</dt>
+        <dd>{ravn.personaName}</dd>
+
+        <dt>State</dt>
+        <dd className="rv-overview-dd--state">
+          <StateDot state={ravnStatusToDotState(ravn.status)} pulse={ravn.status === 'active'} size={8} />
+          <span>{ravn.status}</span>
         </dd>
 
-        <dt style={{ color: 'var(--color-text-muted)' }}>State</dt>
-        <dd style={{ margin: 0, display: 'flex', alignItems: 'center', gap: 'var(--space-2)' }}>
-          <StateDot
-            state={
-              ravn.status === 'active'
-                ? 'running'
-                : ravn.status === 'suspended'
-                  ? 'attention'
-                  : ravn.status === 'failed'
-                    ? 'failed'
-                    : 'unknown'
-            }
-            pulse={ravn.status === 'active'}
-            size={8}
-          />
-          <span style={{ color: 'var(--color-text-primary)' }}>{ravn.status}</span>
-        </dd>
+        <dt>Model</dt>
+        <dd className="rv-overview-dd--model">{ravn.model}</dd>
 
-        <dt style={{ color: 'var(--color-text-muted)' }}>Model</dt>
-        <dd
-          style={{
-            margin: 0,
-            color: 'var(--color-text-secondary)',
-            fontFamily: 'var(--font-mono)',
-            fontSize: 'var(--text-xs)',
-          }}
-        >
-          {ravn.model}
-        </dd>
-
-        <dt style={{ color: 'var(--color-text-muted)' }}>Since</dt>
-        <dd style={{ margin: 0, color: 'var(--color-text-secondary)', fontSize: 'var(--text-xs)' }}>
-          {uptimeSince}
-        </dd>
+        <dt>Since</dt>
+        <dd className="rv-overview-dd--since">{uptimeSince}</dd>
       </dl>
 
       {budget && (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-1)' }}>
-          <div
-            style={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              fontSize: 'var(--text-xs)',
-              color: 'var(--color-text-muted)',
-            }}
-          >
+        <div className="rv-overview-budget">
+          <div className="rv-overview-budget__header">
             <span>Budget</span>
-            <span style={{ fontFamily: 'var(--font-mono)' }}>
+            <span className="rv-overview-budget__value">
               ${budget.spentUsd.toFixed(2)} / ${budget.capUsd.toFixed(2)}
             </span>
           </div>
@@ -211,60 +130,14 @@ function TriggersSection({ ravnPersonaName }: TriggersSectionProps) {
   return (
     <div data-testid="triggers-section-body">
       {ravnTriggers.length === 0 ? (
-        <p style={{ color: 'var(--color-text-muted)', fontSize: 'var(--text-sm)', margin: 0 }}>
-          No triggers configured
-        </p>
+        <p className="rv-empty-text">No triggers configured</p>
       ) : (
-        <ul
-          style={{
-            listStyle: 'none',
-            margin: 0,
-            padding: 0,
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 'var(--space-2)',
-          }}
-        >
+        <ul className="rv-triggers-list">
           {ravnTriggers.map((t) => (
-            <li
-              key={t.id}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 'var(--space-2)',
-                fontSize: 'var(--text-sm)',
-                padding: 'var(--space-1) 0',
-              }}
-              data-testid="trigger-row"
-            >
-              <span
-                style={{
-                  fontSize: 'var(--text-xs)',
-                  padding: '1px var(--space-2)',
-                  borderRadius: 'var(--radius-full)',
-                  background: 'var(--color-bg-tertiary)',
-                  color: 'var(--color-text-secondary)',
-                  fontFamily: 'var(--font-mono)',
-                }}
-              >
-                {t.kind}
-              </span>
-              <span
-                style={{
-                  flex: 1,
-                  color: 'var(--color-text-primary)',
-                  fontFamily: 'var(--font-mono)',
-                  fontSize: 'var(--text-xs)',
-                }}
-              >
-                {t.spec}
-              </span>
-              <span
-                style={{
-                  fontSize: 'var(--text-xs)',
-                  color: t.enabled ? 'var(--color-accent-emerald)' : 'var(--color-text-muted)',
-                }}
-              >
+            <li key={t.id} className="rv-trigger-row" data-testid="trigger-row">
+              <span className="rv-trigger-kind">{t.kind}</span>
+              <span className="rv-trigger-spec">{t.spec}</span>
+              <span className="rv-trigger-status" data-enabled={t.enabled}>
                 {t.enabled ? 'on' : 'off'}
               </span>
             </li>
@@ -286,39 +159,24 @@ function ActivitySection({ ravnId }: ActivitySectionProps) {
 
   if (!ravnSession) {
     return (
-      <p style={{ color: 'var(--color-text-muted)', fontSize: 'var(--text-sm)', margin: 0 }}>
-        No sessions for this ravn
-      </p>
+      <p className="rv-empty-text">No sessions for this ravn</p>
     );
   }
 
   return (
     <div data-testid="activity-section-body">
-      <p style={{ fontSize: 'var(--text-xs)', color: 'var(--color-text-muted)', marginTop: 0 }}>
+      <p className="rv-activity-session">
         Session {ravnSession.id.slice(0, 8)} — {ravnSession.status}
       </p>
-      <div
-        style={{
-          maxHeight: 200,
-          overflowY: 'auto',
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 'var(--space-1)',
-        }}
-      >
+      <div className="rv-activity-messages">
         {(messages ?? []).slice(-10).map((msg) => (
           <div
             key={msg.id}
-            style={{
-              fontSize: 'var(--text-xs)',
-              fontFamily: 'var(--font-mono)',
-              color:
-                msg.kind === 'user' ? 'var(--color-text-primary)' : 'var(--color-text-secondary)',
-              paddingLeft: msg.kind !== 'user' ? 'var(--space-3)' : 0,
-            }}
+            className="rv-activity-message"
+            data-kind={msg.kind}
             data-testid="activity-message"
           >
-            <span style={{ color: 'var(--color-text-muted)' }}>[{msg.kind}] </span>
+            <span className="rv-activity-message__kind">[{msg.kind}] </span>
             {msg.content.slice(0, 80)}
             {msg.content.length > 80 ? '…' : ''}
           </div>
@@ -339,31 +197,11 @@ function SessionsSection({ ravnId }: SessionsSectionProps) {
   return (
     <div data-testid="sessions-section-body">
       {ravnSessions.length === 0 ? (
-        <p style={{ color: 'var(--color-text-muted)', fontSize: 'var(--text-sm)', margin: 0 }}>
-          No sessions
-        </p>
+        <p className="rv-empty-text">No sessions</p>
       ) : (
-        <ul
-          style={{
-            listStyle: 'none',
-            margin: 0,
-            padding: 0,
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 'var(--space-2)',
-          }}
-        >
+        <ul className="rv-sessions-list">
           {ravnSessions.map((s) => (
-            <li
-              key={s.id}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 'var(--space-3)',
-                fontSize: 'var(--text-sm)',
-              }}
-              data-testid="session-row"
-            >
+            <li key={s.id} className="rv-session-row" data-testid="session-row">
               <StateDot
                 state={
                   s.status === 'running' ? 'running' : s.status === 'failed' ? 'failed' : 'unknown'
@@ -371,19 +209,8 @@ function SessionsSection({ ravnId }: SessionsSectionProps) {
                 pulse={s.status === 'running'}
                 size={8}
               />
-              <span
-                style={{
-                  flex: 1,
-                  fontFamily: 'var(--font-mono)',
-                  fontSize: 'var(--text-xs)',
-                  color: 'var(--color-text-secondary)',
-                }}
-              >
-                {s.id.slice(0, 8)}
-              </span>
-              <span style={{ color: 'var(--color-text-muted)', fontSize: 'var(--text-xs)' }}>
-                {s.status}
-              </span>
+              <span className="rv-session-id">{s.id.slice(0, 8)}</span>
+              <span className="rv-session-status">{s.status}</span>
             </li>
           ))}
         </ul>
@@ -399,21 +226,13 @@ interface ConnectivitySectionProps {
 function ConnectivitySection({ ravn }: ConnectivitySectionProps) {
   return (
     <div data-testid="connectivity-section-body">
-      <p
-        style={{
-          fontSize: 'var(--text-xs)',
-          color: 'var(--color-text-muted)',
-          margin: '0 0 var(--space-2)',
-        }}
-      >
+      <p className="rv-connectivity-model">
         Model:{' '}
-        <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--color-text-secondary)' }}>
-          {ravn.model}
-        </span>
+        <span className="rv-connectivity-model-value">{ravn.model}</span>
       </p>
-      <p style={{ fontSize: 'var(--text-xs)', color: 'var(--color-text-muted)', margin: 0 }}>
+      <p className="rv-connectivity-note">
         Event wiring is configured per-persona. View the{' '}
-        <span style={{ color: 'var(--color-text-secondary)' }}>Events</span> tab for the full graph.
+        <span className="rv-connectivity-note-emphasis">Events</span> tab for the full graph.
       </p>
     </div>
   );
@@ -425,40 +244,17 @@ interface DeleteSectionProps {
 
 function DeleteSection({ ravn }: DeleteSectionProps) {
   return (
-    <div
-      style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-3)' }}
-      data-testid="delete-section-body"
-    >
+    <div className="rv-delete-actions" data-testid="delete-section-body">
       <button
         type="button"
-        style={{
-          padding: 'var(--space-2) var(--space-4)',
-          borderRadius: 'var(--radius-md)',
-          border: '1px solid var(--color-border)',
-          background: 'var(--color-bg-tertiary)',
-          color: 'var(--color-text-primary)',
-          cursor: 'pointer',
-          fontSize: 'var(--text-sm)',
-        }}
+        className="rv-suspend-btn"
         data-testid="suspend-btn"
         disabled={ravn.status === 'suspended'}
       >
         {ravn.status === 'suspended' ? 'Already suspended' : 'Suspend ravn'}
       </button>
 
-      <button
-        type="button"
-        style={{
-          padding: 'var(--space-2) var(--space-4)',
-          borderRadius: 'var(--radius-md)',
-          border: '1px solid var(--color-accent-red)',
-          background: 'color-mix(in srgb, var(--color-accent-red) 10%, transparent)',
-          color: 'var(--color-accent-red)',
-          cursor: 'pointer',
-          fontSize: 'var(--text-sm)',
-        }}
-        data-testid="delete-btn"
-      >
+      <button type="button" className="rv-delete-btn" data-testid="delete-btn">
         Delete ravn
       </button>
     </div>
@@ -473,20 +269,9 @@ export interface RavnDetailProps {
 
 export function RavnDetail({ ravn, onClose }: RavnDetailProps) {
   const [collapsed, setCollapsed] = useState<Set<SectionId>>(() => {
-    const stored = loadCollapsedSections();
-    // By default expand 'overview'; collapse everything else unless stored
-    const initial = new Set<SectionId>(ALL_SECTIONS.filter((s) => !DEFAULT_SECTIONS.includes(s)));
-    // Apply stored preferences
-    for (const section of ALL_SECTIONS) {
-      if (stored.has(section)) {
-        initial.add(section);
-      } else if (!DEFAULT_SECTIONS.includes(section) && !stored.size) {
-        // keep default
-      } else if (!stored.has(section) && stored.size > 0) {
-        initial.delete(section);
-      }
-    }
-    return initial;
+    const stored = loadStorage<SectionId[]>(SECTIONS_STORAGE_KEY, []);
+    if (stored.length > 0) return new Set(stored);
+    return new Set(ALL_SECTIONS.filter((s) => !INITIALLY_EXPANDED_SECTIONS.includes(s)));
   });
 
   const { data: budget } = useRavnBudget(ravn.id);
@@ -499,50 +284,18 @@ export function RavnDetail({ ravn, onClose }: RavnDetailProps) {
       } else {
         next.add(id);
       }
-      saveCollapsedSections(next);
+      saveStorage(SECTIONS_STORAGE_KEY, Array.from(next));
       return next;
     });
   }, []);
 
   return (
-    <div
-      data-testid="ravn-detail"
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        height: '100%',
-        background: 'var(--color-bg-secondary)',
-        borderLeft: '1px solid var(--color-border)',
-        overflowY: 'auto',
-      }}
-    >
+    <div data-testid="ravn-detail" className="rv-detail">
       {/* Header */}
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 'var(--space-3)',
-          padding: 'var(--space-4)',
-          borderBottom: '1px solid var(--color-border)',
-          position: 'sticky',
-          top: 0,
-          background: 'var(--color-bg-secondary)',
-          zIndex: 1,
-        }}
-      >
-        <span style={{ fontSize: 'var(--text-lg)', flex: 1, fontWeight: 600 }}>
-          {ravn.personaName}
-        </span>
+      <div className="rv-detail__header">
+        <span className="rv-detail__title">{ravn.personaName}</span>
         <StateDot
-          state={
-            ravn.status === 'active'
-              ? 'running'
-              : ravn.status === 'suspended'
-                ? 'attention'
-                : ravn.status === 'failed'
-                  ? 'failed'
-                  : 'unknown'
-          }
+          state={ravnStatusToDotState(ravn.status)}
           pulse={ravn.status === 'active'}
           size={8}
         />
@@ -551,15 +304,7 @@ export function RavnDetail({ ravn, onClose }: RavnDetailProps) {
             type="button"
             onClick={onClose}
             aria-label="Close detail pane"
-            style={{
-              background: 'none',
-              border: 'none',
-              cursor: 'pointer',
-              color: 'var(--color-text-muted)',
-              fontSize: 'var(--text-base)',
-              padding: 'var(--space-1)',
-              lineHeight: 1,
-            }}
+            className="rv-detail__close"
             data-testid="detail-close-btn"
           >
             ✕

--- a/web-next/packages/plugin-ravn/src/ui/RavnDetail.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/RavnDetail.tsx
@@ -88,7 +88,11 @@ function OverviewSection({ ravn, budget }: OverviewSectionProps) {
 
         <dt>State</dt>
         <dd className="rv-overview-dd--state">
-          <StateDot state={ravnStatusToDotState(ravn.status)} pulse={ravn.status === 'active'} size={8} />
+          <StateDot
+            state={ravnStatusToDotState(ravn.status)}
+            pulse={ravn.status === 'active'}
+            size={8}
+          />
           <span>{ravn.status}</span>
         </dd>
 
@@ -158,9 +162,7 @@ function ActivitySection({ ravnId }: ActivitySectionProps) {
   const { data: messages } = useMessages(ravnSession?.id ?? '');
 
   if (!ravnSession) {
-    return (
-      <p className="rv-empty-text">No sessions for this ravn</p>
-    );
+    return <p className="rv-empty-text">No sessions for this ravn</p>;
   }
 
   return (
@@ -227,8 +229,7 @@ function ConnectivitySection({ ravn }: ConnectivitySectionProps) {
   return (
     <div data-testid="connectivity-section-body">
       <p className="rv-connectivity-model">
-        Model:{' '}
-        <span className="rv-connectivity-model-value">{ravn.model}</span>
+        Model: <span className="rv-connectivity-model-value">{ravn.model}</span>
       </p>
       <p className="rv-connectivity-note">
         Event wiring is configured per-persona. View the{' '}

--- a/web-next/packages/plugin-ravn/src/ui/RavnPage.css
+++ b/web-next/packages/plugin-ravn/src/ui/RavnPage.css
@@ -1,0 +1,51 @@
+.rv-page {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--color-bg-primary);
+}
+
+.rv-page__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-6);
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-bg-primary);
+  flex-shrink: 0;
+}
+
+.rv-page__title {
+  margin: 0;
+  font-size: var(--text-base);
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.rv-page__tabs {
+  display: flex;
+  gap: var(--space-1);
+  margin-left: var(--space-4);
+}
+
+.rv-page-tab {
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  border: none;
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-size: var(--text-sm);
+  font-weight: 400;
+}
+
+.rv-page-tab[aria-selected='true'] {
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-primary);
+  font-weight: 600;
+}
+
+.rv-page__panel {
+  flex: 1;
+  overflow: hidden;
+}

--- a/web-next/packages/plugin-ravn/src/ui/RavnPage.test.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/RavnPage.test.tsx
@@ -1,11 +1,28 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ServicesProvider } from '@niuulabs/plugin-sdk';
 import { RavnPage } from './RavnPage';
-import { createMockPersonaStore } from '../adapters/mock';
+import {
+  createMockPersonaStore,
+  createMockRavenStream,
+  createMockTriggerStore,
+  createMockSessionStream,
+  createMockBudgetStream,
+} from '../adapters/mock';
 
-function wrap(services: Record<string, unknown>) {
+function makeServices(overrides?: Record<string, unknown>) {
+  return {
+    'ravn.personas': createMockPersonaStore(),
+    'ravn.ravens': createMockRavenStream(),
+    'ravn.triggers': createMockTriggerStore(),
+    'ravn.sessions': createMockSessionStream(),
+    'ravn.budget': createMockBudgetStream(),
+    ...overrides,
+  };
+}
+
+function wrap(services = makeServices()) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return function Wrapper({ children }: { children: React.ReactNode }) {
     return (
@@ -16,37 +33,64 @@ function wrap(services: Record<string, unknown>) {
   };
 }
 
+beforeEach(() => {
+  localStorage.clear();
+});
+
 describe('RavnPage', () => {
-  it('renders the page title', async () => {
-    render(<RavnPage />, {
-      wrapper: wrap({ 'ravn.personas': createMockPersonaStore() }),
-    });
-    expect(screen.getByText(/ravn/)).toBeInTheDocument();
+  it('renders the ravn page wrapper', () => {
+    render(<RavnPage />, { wrapper: wrap() });
+    expect(screen.getByTestId('ravn-page')).toBeInTheDocument();
   });
 
-  it('shows loading state then persona count', async () => {
-    render(<RavnPage />, {
-      wrapper: wrap({ 'ravn.personas': createMockPersonaStore() }),
-    });
-    await waitFor(() => expect(screen.getByText(/21 personas loaded/)).toBeInTheDocument());
-  });
-
-  it('renders the Ravn rune glyph', async () => {
-    render(<RavnPage />, {
-      wrapper: wrap({ 'ravn.personas': createMockPersonaStore() }),
-    });
+  it('renders the ravn rune glyph', () => {
+    render(<RavnPage />, { wrapper: wrap() });
     expect(screen.getByText('ᚱ')).toBeInTheDocument();
   });
 
-  it('shows error state when service throws', async () => {
-    const failing = {
-      listPersonas: async () => {
-        throw new Error('fetch failed');
-      },
-    };
-    render(<RavnPage />, {
-      wrapper: wrap({ 'ravn.personas': failing }),
-    });
-    await waitFor(() => expect(screen.getByText('fetch failed')).toBeInTheDocument());
+  it('renders the page title', () => {
+    render(<RavnPage />, { wrapper: wrap() });
+    expect(screen.getByText(/Ravn · the flock/)).toBeInTheDocument();
+  });
+
+  it('renders the tab navigation', () => {
+    render(<RavnPage />, { wrapper: wrap() });
+    expect(screen.getByTestId('ravn-tab-overview')).toBeInTheDocument();
+    expect(screen.getByTestId('ravn-tab-ravens')).toBeInTheDocument();
+  });
+
+  it('defaults to the overview tab', async () => {
+    render(<RavnPage />, { wrapper: wrap() });
+    await waitFor(() => expect(screen.getByTestId('overview-page')).toBeInTheDocument());
+  });
+
+  it('switches to the ravens tab', async () => {
+    render(<RavnPage />, { wrapper: wrap() });
+    await waitFor(() => screen.getByTestId('ravn-tab-ravens'));
+    fireEvent.click(screen.getByTestId('ravn-tab-ravens'));
+    await waitFor(() => expect(screen.getByTestId('ravens-page')).toBeInTheDocument());
+    expect(screen.queryByTestId('overview-page')).not.toBeInTheDocument();
+  });
+
+  it('switches back to overview tab', async () => {
+    render(<RavnPage />, { wrapper: wrap() });
+    await waitFor(() => screen.getByTestId('ravn-tab-ravens'));
+    fireEvent.click(screen.getByTestId('ravn-tab-ravens'));
+    await waitFor(() => screen.getByTestId('ravens-page'));
+    fireEvent.click(screen.getByTestId('ravn-tab-overview'));
+    await waitFor(() => expect(screen.getByTestId('overview-page')).toBeInTheDocument());
+  });
+
+  it('persists active tab to localStorage', async () => {
+    render(<RavnPage />, { wrapper: wrap() });
+    await waitFor(() => screen.getByTestId('ravn-tab-ravens'));
+    fireEvent.click(screen.getByTestId('ravn-tab-ravens'));
+    expect(localStorage.getItem('ravn.tab')).toBe('"ravens"');
+  });
+
+  it('restores tab from localStorage on mount', async () => {
+    localStorage.setItem('ravn.tab', '"ravens"');
+    render(<RavnPage />, { wrapper: wrap() });
+    await waitFor(() => expect(screen.getByTestId('ravens-page')).toBeInTheDocument());
   });
 });

--- a/web-next/packages/plugin-ravn/src/ui/RavnPage.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/RavnPage.tsx
@@ -1,40 +1,63 @@
-import { Rune, StateDot } from '@niuulabs/ui';
-import { usePersonas } from './usePersonas';
+import { useState, useCallback } from 'react';
+import { Rune } from '@niuulabs/ui';
+import { OverviewPage } from './OverviewPage';
+import { RavensPage } from './RavensPage';
+import { loadStorage, saveStorage } from './storage';
+import './RavnPage.css';
+
+export type RavnTab = 'overview' | 'ravens';
+
+const TAB_STORAGE_KEY = 'ravn.tab';
+
+const TABS: { id: RavnTab; label: string }[] = [
+  { id: 'overview', label: 'Overview' },
+  { id: 'ravens', label: 'Ravens' },
+];
 
 export function RavnPage() {
-  const { data, isLoading, isError, error } = usePersonas();
+  const [activeTab, setActiveTab] = useState<RavnTab>(() =>
+    loadStorage<RavnTab>(TAB_STORAGE_KEY, 'overview'),
+  );
+
+  const handleTabChange = useCallback((tab: RavnTab) => {
+    setActiveTab(tab);
+    saveStorage(TAB_STORAGE_KEY, tab);
+  }, []);
 
   return (
-    <div className="niuu-p-6 niuu-max-w-[720px]">
-      <div className="niuu-flex niuu-items-center niuu-gap-3 niuu-mb-4">
-        <Rune glyph="ᚱ" size={32} />
-        <h2 className="niuu-m-0">ravn · personas · ravens · sessions</h2>
-      </div>
+    <div data-testid="ravn-page" className="rv-page">
+      <header className="rv-page__header">
+        <Rune glyph="ᚱ" size={24} />
+        <h2 className="rv-page__title">Ravn · the flock</h2>
 
-      <p className="niuu-text-text-secondary">
-        Ravn is the canonical authority for Persona, ToolRegistry, EventCatalog, and BudgetState.
-        This placeholder will be replaced by the full Ravn UI.
-      </p>
+        <nav role="tablist" aria-label="Ravn navigation" className="rv-page__tabs">
+          {TABS.map((tab) => (
+            <button
+              key={tab.id}
+              type="button"
+              role="tab"
+              aria-selected={activeTab === tab.id}
+              aria-controls={`ravn-panel-${tab.id}`}
+              id={`ravn-tab-${tab.id}`}
+              onClick={() => handleTabChange(tab.id)}
+              data-testid={`ravn-tab-${tab.id}`}
+              className="rv-page-tab"
+            >
+              {tab.label}
+            </button>
+          ))}
+        </nav>
+      </header>
 
-      {isLoading && (
-        <div className="niuu-flex niuu-items-center niuu-gap-2" role="status">
-          <StateDot state="processing" pulse />
-          <span>loading personas…</span>
-        </div>
-      )}
-
-      {isError && (
-        <div className="niuu-flex niuu-items-center niuu-gap-2" role="alert">
-          <StateDot state="failed" />
-          <span>{error instanceof Error ? error.message : 'unknown error'}</span>
-        </div>
-      )}
-
-      {data && (
-        <p className="niuu-text-text-secondary">
-          {data.length} persona{data.length !== 1 ? 's' : ''} loaded.
-        </p>
-      )}
+      <main
+        id={`ravn-panel-${activeTab}`}
+        role="tabpanel"
+        aria-labelledby={`ravn-tab-${activeTab}`}
+        className="rv-page__panel"
+      >
+        {activeTab === 'overview' && <OverviewPage />}
+        {activeTab === 'ravens' && <RavensPage />}
+      </main>
     </div>
   );
 }

--- a/web-next/packages/plugin-ravn/src/ui/RavnsPage.stories.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/RavnsPage.stories.tsx
@@ -1,0 +1,127 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ServicesProvider } from '@niuulabs/plugin-sdk';
+import { RavensPage } from './RavensPage';
+import {
+  createMockRavenStream,
+  createMockBudgetStream,
+  createMockTriggerStore,
+  createMockSessionStream,
+} from '../adapters/mock';
+
+function makeServices(overrides?: Record<string, unknown>) {
+  return {
+    'ravn.ravens': createMockRavenStream(),
+    'ravn.budget': createMockBudgetStream(),
+    'ravn.triggers': createMockTriggerStore(),
+    'ravn.sessions': createMockSessionStream(),
+    ...overrides,
+  };
+}
+
+function makeDecorator(services: Record<string, unknown>) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Decorator({ children }: { children: React.ReactNode }) {
+    return (
+      <div
+        style={{
+          height: '100vh',
+          background: 'var(--color-bg-primary)',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <QueryClientProvider client={client}>
+          <ServicesProvider services={services}>{children}</ServicesProvider>
+        </QueryClientProvider>
+      </div>
+    );
+  };
+}
+
+const meta: Meta<typeof RavensPage> = {
+  title: 'Plugins / Ravn / RavensPage',
+  component: RavensPage,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof RavensPage>;
+
+/** Split layout — list on left, detail pane empty until a ravn is clicked. */
+export const SplitLayout: Story = {
+  decorators: [
+    (Story) => {
+      const D = makeDecorator(makeServices());
+      localStorage.setItem('ravn.ravens.layout', '"split"');
+      return (
+        <D>
+          <Story />
+        </D>
+      );
+    },
+  ],
+};
+
+/** Table layout — sortable flat table. */
+export const TableLayout: Story = {
+  decorators: [
+    (Story) => {
+      const D = makeDecorator(makeServices());
+      localStorage.setItem('ravn.ravens.layout', '"table"');
+      return (
+        <D>
+          <Story />
+        </D>
+      );
+    },
+  ],
+};
+
+/** Cards layout — grid of ravn cards. */
+export const CardsLayout: Story = {
+  decorators: [
+    (Story) => {
+      const D = makeDecorator(makeServices());
+      localStorage.setItem('ravn.ravens.layout', '"cards"');
+      return (
+        <D>
+          <Story />
+        </D>
+      );
+    },
+  ],
+};
+
+/** Split layout grouped by state. */
+export const GroupedByState: Story = {
+  decorators: [
+    (Story) => {
+      const D = makeDecorator(makeServices());
+      localStorage.setItem('ravn.ravens.layout', '"split"');
+      localStorage.setItem('ravn.ravens.group', '"state"');
+      return (
+        <D>
+          <Story />
+        </D>
+      );
+    },
+  ],
+};
+
+/** Split layout grouped by location (model-derived). */
+export const GroupedByLocation: Story = {
+  decorators: [
+    (Story) => {
+      const D = makeDecorator(makeServices());
+      localStorage.setItem('ravn.ravens.layout', '"split"');
+      localStorage.setItem('ravn.ravens.group', '"location"');
+      return (
+        <D>
+          <Story />
+        </D>
+      );
+    },
+  ],
+};

--- a/web-next/packages/plugin-ravn/src/ui/grouping.test.ts
+++ b/web-next/packages/plugin-ravn/src/ui/grouping.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest';
+import { groupRavens, topBudgetSpenders, modelToLocation } from './grouping';
+import type { Ravn } from '../domain/ravn';
+import type { BudgetState } from '@niuulabs/domain';
+
+const RAVENS: Ravn[] = [
+  {
+    id: 'id-1',
+    personaName: 'coder',
+    status: 'active',
+    model: 'claude-sonnet-4-6',
+    createdAt: '2026-04-15T09:00:00Z',
+  },
+  {
+    id: 'id-2',
+    personaName: 'reviewer',
+    status: 'active',
+    model: 'claude-opus-4-6',
+    createdAt: '2026-04-15T08:00:00Z',
+  },
+  {
+    id: 'id-3',
+    personaName: 'security',
+    status: 'idle',
+    model: 'claude-haiku-4-5',
+    createdAt: '2026-04-15T07:00:00Z',
+  },
+  {
+    id: 'id-4',
+    personaName: 'qa-agent',
+    status: 'suspended',
+    model: 'claude-sonnet-4-6',
+    createdAt: '2026-04-14T20:00:00Z',
+  },
+];
+
+describe('modelToLocation', () => {
+  it('maps opus model to asgard', () => {
+    expect(modelToLocation('claude-opus-4-6')).toBe('asgard');
+  });
+
+  it('maps haiku model to jotunheim', () => {
+    expect(modelToLocation('claude-haiku-4-5')).toBe('jotunheim');
+  });
+
+  it('maps sonnet (and unknown) model to midgard', () => {
+    expect(modelToLocation('claude-sonnet-4-6')).toBe('midgard');
+    expect(modelToLocation('unknown-model')).toBe('midgard');
+  });
+});
+
+describe('groupRavens', () => {
+  describe('none grouping', () => {
+    it('returns a single "all" group sorted alphabetically by personaName', () => {
+      const result = groupRavens(RAVENS, 'none');
+      expect(Object.keys(result)).toEqual(['all']);
+      const names = result.all!.map((r) => r.personaName);
+      expect(names).toEqual([...names].sort());
+    });
+
+    it('returns all ravens', () => {
+      const result = groupRavens(RAVENS, 'none');
+      expect(result.all).toHaveLength(RAVENS.length);
+    });
+  });
+
+  describe('state grouping', () => {
+    it('groups ravens by status', () => {
+      const result = groupRavens(RAVENS, 'state');
+      expect(Object.keys(result).sort()).toEqual(['active', 'idle', 'suspended']);
+      expect(result.active).toHaveLength(2);
+      expect(result.idle).toHaveLength(1);
+      expect(result.suspended).toHaveLength(1);
+    });
+
+    it('active group contains active ravens', () => {
+      const result = groupRavens(RAVENS, 'state');
+      expect(result.active!.every((r) => r.status === 'active')).toBe(true);
+    });
+  });
+
+  describe('persona grouping', () => {
+    it('groups ravens by personaName', () => {
+      const result = groupRavens(RAVENS, 'persona');
+      expect(Object.keys(result)).toContain('coder');
+      expect(Object.keys(result)).toContain('reviewer');
+      expect(result.coder).toHaveLength(1);
+    });
+
+    it('contains all ravens across groups', () => {
+      const result = groupRavens(RAVENS, 'persona');
+      const total = Object.values(result).reduce((sum, g) => sum + g.length, 0);
+      expect(total).toBe(RAVENS.length);
+    });
+  });
+
+  describe('location grouping', () => {
+    it('groups ravens by model-derived location', () => {
+      const result = groupRavens(RAVENS, 'location');
+      expect(result.asgard).toHaveLength(1); // opus
+      expect(result.jotunheim).toHaveLength(1); // haiku
+      expect(result.midgard).toHaveLength(2); // 2× sonnet
+    });
+  });
+
+  describe('empty input', () => {
+    it('returns empty groups for empty input (none)', () => {
+      const result = groupRavens([], 'none');
+      expect(result.all).toHaveLength(0);
+    });
+
+    it('returns empty groups for empty input (state)', () => {
+      const result = groupRavens([], 'state');
+      expect(Object.values(result).flat()).toHaveLength(0);
+    });
+  });
+
+  describe('alphabetical ordering within groups', () => {
+    it('sorts ravens alphabetically by personaName within each group', () => {
+      const result = groupRavens(RAVENS, 'state');
+      for (const group of Object.values(result)) {
+        const names = group.map((r) => r.personaName);
+        expect(names).toEqual([...names].sort());
+      }
+    });
+  });
+});
+
+describe('topBudgetSpenders', () => {
+  const budgets: Record<string, BudgetState> = {
+    'id-1': { spentUsd: 1.5, capUsd: 5.0, warnAt: 0.8 },
+    'id-2': { spentUsd: 3.9, capUsd: 5.0, warnAt: 0.8 },
+    'id-3': { spentUsd: 0.1, capUsd: 2.0, warnAt: 0.8 },
+    // id-4 has no budget entry
+  };
+
+  it('returns ravens sorted by spend descending', () => {
+    const result = topBudgetSpenders(RAVENS, budgets);
+    expect(result[0]!.id).toBe('id-2'); // highest spend 3.9
+    expect(result[1]!.id).toBe('id-1'); // 1.5
+    expect(result[2]!.id).toBe('id-3'); // 0.1
+    expect(result[3]!.id).toBe('id-4'); // 0 (no entry)
+  });
+
+  it('respects the n limit', () => {
+    const result = topBudgetSpenders(RAVENS, budgets, 2);
+    expect(result).toHaveLength(2);
+    expect(result[0]!.id).toBe('id-2');
+    expect(result[1]!.id).toBe('id-1');
+  });
+
+  it('treats missing budget as $0', () => {
+    const result = topBudgetSpenders(RAVENS, {});
+    // All are $0, order from original
+    expect(result).toHaveLength(RAVENS.length);
+  });
+
+  it('does not mutate the input array', () => {
+    const original = [...RAVENS];
+    topBudgetSpenders(RAVENS, budgets);
+    expect(RAVENS).toEqual(original);
+  });
+
+  it('returns empty array for empty ravens input', () => {
+    const result = topBudgetSpenders([], budgets);
+    expect(result).toHaveLength(0);
+  });
+});

--- a/web-next/packages/plugin-ravn/src/ui/grouping.ts
+++ b/web-next/packages/plugin-ravn/src/ui/grouping.ts
@@ -40,6 +40,9 @@ export function groupRavens(ravens: Ravn[], by: GroupKey): Record<string, Ravn[]
   return groups;
 }
 
+/** Default number of top budget spenders to show. */
+const TOP_BUDGET_SPENDERS_DEFAULT = 5;
+
 /**
  * Return the top-N ravens ordered by USD spent today (descending).
  * Ravens with no budget entry are treated as $0 spent.
@@ -47,7 +50,7 @@ export function groupRavens(ravens: Ravn[], by: GroupKey): Record<string, Ravn[]
 export function topBudgetSpenders(
   ravens: Ravn[],
   budgets: Record<string, BudgetState>,
-  n = 5,
+  n = TOP_BUDGET_SPENDERS_DEFAULT,
 ): Ravn[] {
   return [...ravens]
     .sort((a, b) => (budgets[b.id]?.spentUsd ?? 0) - (budgets[a.id]?.spentUsd ?? 0))

--- a/web-next/packages/plugin-ravn/src/ui/grouping.ts
+++ b/web-next/packages/plugin-ravn/src/ui/grouping.ts
@@ -1,0 +1,55 @@
+import type { Ravn } from '../domain/ravn';
+import type { BudgetState } from '@niuulabs/domain';
+
+/** The available grouping keys for the Ravens split view. */
+export type GroupKey = 'location' | 'persona' | 'state' | 'none';
+
+/**
+ * Derive a location label from a model alias.
+ * In the real system this would be a field on the Ravn; for now we map
+ * model alias to a Norse realm name so demos are coherent.
+ */
+export function modelToLocation(model: string): string {
+  if (model.includes('opus')) return 'asgard';
+  if (model.includes('haiku')) return 'jotunheim';
+  return 'midgard';
+}
+
+/**
+ * Group a flat list of ravens by the given key.
+ * Returns a record of group-label → ravens-in-group.
+ * Within each group, ravens are sorted by personaName alphabetically.
+ */
+export function groupRavens(ravens: Ravn[], by: GroupKey): Record<string, Ravn[]> {
+  const sorted = [...ravens].sort((a, b) => a.personaName.localeCompare(b.personaName));
+
+  if (by === 'none') return { all: sorted };
+
+  const groups: Record<string, Ravn[]> = {};
+
+  for (const r of sorted) {
+    let key: string;
+
+    if (by === 'persona') key = r.personaName;
+    else if (by === 'state') key = r.status;
+    else key = modelToLocation(r.model);
+
+    groups[key] = [...(groups[key] ?? []), r];
+  }
+
+  return groups;
+}
+
+/**
+ * Return the top-N ravens ordered by USD spent today (descending).
+ * Ravens with no budget entry are treated as $0 spent.
+ */
+export function topBudgetSpenders(
+  ravens: Ravn[],
+  budgets: Record<string, BudgetState>,
+  n = 5,
+): Ravn[] {
+  return [...ravens]
+    .sort((a, b) => (budgets[b.id]?.spentUsd ?? 0) - (budgets[a.id]?.spentUsd ?? 0))
+    .slice(0, n);
+}

--- a/web-next/packages/plugin-ravn/src/ui/grouping.ts
+++ b/web-next/packages/plugin-ravn/src/ui/grouping.ts
@@ -4,6 +4,16 @@ import type { BudgetState } from '@niuulabs/domain';
 /** The available grouping keys for the Ravens split view. */
 export type GroupKey = 'location' | 'persona' | 'state' | 'none';
 
+/** Map a ravn status string to the DotState union type. */
+export function ravnStatusToDotState(
+  status: string,
+): 'running' | 'attention' | 'failed' | 'unknown' {
+  if (status === 'active') return 'running';
+  if (status === 'suspended') return 'attention';
+  if (status === 'failed') return 'failed';
+  return 'unknown';
+}
+
 /**
  * Derive a location label from a model alias.
  * In the real system this would be a field on the Ravn; for now we map
@@ -34,7 +44,7 @@ export function groupRavens(ravens: Ravn[], by: GroupKey): Record<string, Ravn[]
     else if (by === 'state') key = r.status;
     else key = modelToLocation(r.model);
 
-    groups[key] = [...(groups[key] ?? []), r];
+    (groups[key] ??= []).push(r);
   }
 
   return groups;

--- a/web-next/packages/plugin-ravn/src/ui/hooks/useBudget.test.ts
+++ b/web-next/packages/plugin-ravn/src/ui/hooks/useBudget.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ServicesProvider } from '@niuulabs/plugin-sdk';
+import { createElement, type ReactNode } from 'react';
+import { useFleetBudget, useRavnBudget, useRavnBudgets } from './useBudget';
+import type { BudgetState } from '@niuulabs/domain';
+
+const BUDGET: BudgetState = { spentUsd: 1.24, capUsd: 5.0, warnAt: 0.8 };
+const FLEET_BUDGET: BudgetState = { spentUsd: 6.61, capUsd: 22.0, warnAt: 0.8 };
+
+function makeWrapper(services: Record<string, unknown>) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(
+      QueryClientProvider,
+      { client },
+      createElement(ServicesProvider, { services }, children),
+    );
+  };
+}
+
+describe('useFleetBudget', () => {
+  it('returns fleet budget', async () => {
+    const svc = { getFleetBudget: vi.fn().mockResolvedValue(FLEET_BUDGET), getBudget: vi.fn() };
+    const { result } = renderHook(() => useFleetBudget(), {
+      wrapper: makeWrapper({ 'ravn.budget': svc }),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.spentUsd).toBe(6.61);
+  });
+
+  it('enters error state when service rejects', async () => {
+    const svc = {
+      getFleetBudget: vi.fn().mockRejectedValue(new Error('budget unavailable')),
+      getBudget: vi.fn(),
+    };
+    const { result } = renderHook(() => useFleetBudget(), {
+      wrapper: makeWrapper({ 'ravn.budget': svc }),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe('useRavnBudget', () => {
+  it('returns budget for a specific ravn', async () => {
+    const svc = { getBudget: vi.fn().mockResolvedValue(BUDGET), getFleetBudget: vi.fn() };
+    const { result } = renderHook(() => useRavnBudget('ravn-id-1'), {
+      wrapper: makeWrapper({ 'ravn.budget': svc }),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.spentUsd).toBe(1.24);
+    expect(svc.getBudget).toHaveBeenCalledWith('ravn-id-1');
+  });
+
+  it('is disabled when ravnId is empty', () => {
+    const svc = { getBudget: vi.fn(), getFleetBudget: vi.fn() };
+    const { result } = renderHook(() => useRavnBudget(''), {
+      wrapper: makeWrapper({ 'ravn.budget': svc }),
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(svc.getBudget).not.toHaveBeenCalled();
+  });
+});
+
+describe('useRavnBudgets', () => {
+  it('returns a record of ravnId → budget', async () => {
+    const svc = {
+      getBudget: vi.fn().mockResolvedValue(BUDGET),
+      getFleetBudget: vi.fn(),
+    };
+    const { result } = renderHook(() => useRavnBudgets(['id-1', 'id-2']), {
+      wrapper: makeWrapper({ 'ravn.budget': svc }),
+    });
+
+    await waitFor(() => expect(Object.keys(result.current).length).toBe(2));
+    expect(result.current['id-1']?.spentUsd).toBe(1.24);
+    expect(result.current['id-2']?.spentUsd).toBe(1.24);
+  });
+
+  it('returns empty record for empty ids list', async () => {
+    const svc = { getBudget: vi.fn(), getFleetBudget: vi.fn() };
+    const { result } = renderHook(() => useRavnBudgets([]), {
+      wrapper: makeWrapper({ 'ravn.budget': svc }),
+    });
+
+    expect(result.current).toEqual({});
+    expect(svc.getBudget).not.toHaveBeenCalled();
+  });
+});

--- a/web-next/packages/plugin-ravn/src/ui/hooks/useBudget.ts
+++ b/web-next/packages/plugin-ravn/src/ui/hooks/useBudget.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useQuery, useQueries } from '@tanstack/react-query';
 import { useService } from '@niuulabs/plugin-sdk';
 import type { IBudgetStream } from '../../ports';
@@ -34,13 +35,13 @@ export function useRavnBudgets(ravnIds: string[]): Record<string, BudgetState> {
     })),
   });
 
-  const budgets: Record<string, BudgetState> = {};
-
-  for (let i = 0; i < ravnIds.length; i++) {
-    const id = ravnIds[i];
-    const data = results[i]?.data;
-    if (id && data) budgets[id] = data;
-  }
-
-  return budgets;
+  return useMemo(() => {
+    const budgets: Record<string, BudgetState> = {};
+    for (let i = 0; i < ravnIds.length; i++) {
+      const id = ravnIds[i];
+      const data = results[i]?.data;
+      if (id && data) budgets[id] = data;
+    }
+    return budgets;
+  }, [results, ravnIds]);
 }

--- a/web-next/packages/plugin-ravn/src/ui/hooks/useBudget.ts
+++ b/web-next/packages/plugin-ravn/src/ui/hooks/useBudget.ts
@@ -1,0 +1,46 @@
+import { useQuery, useQueries } from '@tanstack/react-query';
+import { useService } from '@niuulabs/plugin-sdk';
+import type { IBudgetStream } from '../../ports';
+import type { BudgetState } from '@niuulabs/domain';
+
+export function useFleetBudget() {
+  const service = useService<IBudgetStream>('ravn.budget');
+  return useQuery({
+    queryKey: ['ravn', 'budget', 'fleet'],
+    queryFn: () => service.getFleetBudget(),
+  });
+}
+
+export function useRavnBudget(ravnId: string) {
+  const service = useService<IBudgetStream>('ravn.budget');
+  return useQuery({
+    queryKey: ['ravn', 'budget', ravnId],
+    queryFn: () => service.getBudget(ravnId),
+    enabled: !!ravnId,
+  });
+}
+
+/**
+ * Fetch budgets for many ravens in parallel.
+ * Returns a Record<ravnId, BudgetState> once all queries resolve.
+ */
+export function useRavnBudgets(ravnIds: string[]): Record<string, BudgetState> {
+  const service = useService<IBudgetStream>('ravn.budget');
+
+  const results = useQueries({
+    queries: ravnIds.map((id) => ({
+      queryKey: ['ravn', 'budget', id],
+      queryFn: () => service.getBudget(id),
+    })),
+  });
+
+  const budgets: Record<string, BudgetState> = {};
+
+  for (let i = 0; i < ravnIds.length; i++) {
+    const id = ravnIds[i];
+    const data = results[i]?.data;
+    if (id && data) budgets[id] = data;
+  }
+
+  return budgets;
+}

--- a/web-next/packages/plugin-ravn/src/ui/hooks/useRavens.test.ts
+++ b/web-next/packages/plugin-ravn/src/ui/hooks/useRavens.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ServicesProvider } from '@niuulabs/plugin-sdk';
+import { createElement, type ReactNode } from 'react';
+import { useRavens, useRaven } from './useRavens';
+import type { Ravn } from '../../domain/ravn';
+
+const SAMPLE_RAVN: Ravn = {
+  id: 'a3f1b2c4-8e7d-4a6f-9b0c-1d2e3f4a5b6c',
+  personaName: 'coder',
+  status: 'active',
+  model: 'claude-sonnet-4-6',
+  createdAt: '2026-04-15T09:00:00Z',
+};
+
+function makeWrapper(services: Record<string, unknown>) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(
+      QueryClientProvider,
+      { client },
+      createElement(ServicesProvider, { services }, children),
+    );
+  };
+}
+
+describe('useRavens', () => {
+  it('returns ravens list from service', async () => {
+    const svc = { listRavens: vi.fn().mockResolvedValue([SAMPLE_RAVN]) };
+    const { result } = renderHook(() => useRavens(), {
+      wrapper: makeWrapper({ 'ravn.ravens': svc }),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data![0]!.personaName).toBe('coder');
+    expect(svc.listRavens).toHaveBeenCalled();
+  });
+
+  it('starts in loading state', () => {
+    const svc = { listRavens: vi.fn().mockReturnValue(new Promise(() => undefined)) };
+    const { result } = renderHook(() => useRavens(), {
+      wrapper: makeWrapper({ 'ravn.ravens': svc }),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('enters error state when service rejects', async () => {
+    const svc = {
+      listRavens: vi.fn().mockRejectedValue(new Error('network error')),
+    };
+    const { result } = renderHook(() => useRavens(), {
+      wrapper: makeWrapper({ 'ravn.ravens': svc }),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+});
+
+describe('useRaven', () => {
+  it('fetches a single ravn by id', async () => {
+    const svc = { getRaven: vi.fn().mockResolvedValue(SAMPLE_RAVN) };
+    const { result } = renderHook(() => useRaven('a3f1b2c4-8e7d-4a6f-9b0c-1d2e3f4a5b6c'), {
+      wrapper: makeWrapper({ 'ravn.ravens': svc }),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.personaName).toBe('coder');
+    expect(svc.getRaven).toHaveBeenCalledWith('a3f1b2c4-8e7d-4a6f-9b0c-1d2e3f4a5b6c');
+  });
+
+  it('is disabled when id is empty', () => {
+    const svc = { getRaven: vi.fn() };
+    const { result } = renderHook(() => useRaven(''), {
+      wrapper: makeWrapper({ 'ravn.ravens': svc }),
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(svc.getRaven).not.toHaveBeenCalled();
+  });
+});

--- a/web-next/packages/plugin-ravn/src/ui/hooks/useRavens.ts
+++ b/web-next/packages/plugin-ravn/src/ui/hooks/useRavens.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query';
+import { useService } from '@niuulabs/plugin-sdk';
+import type { IRavenStream } from '../../ports';
+
+export function useRavens() {
+  const service = useService<IRavenStream>('ravn.ravens');
+  return useQuery({
+    queryKey: ['ravn', 'ravens'],
+    queryFn: () => service.listRavens(),
+  });
+}
+
+export function useRaven(id: string) {
+  const service = useService<IRavenStream>('ravn.ravens');
+  return useQuery({
+    queryKey: ['ravn', 'ravens', id],
+    queryFn: () => service.getRaven(id),
+    enabled: !!id,
+  });
+}

--- a/web-next/packages/plugin-ravn/src/ui/hooks/useSessions.test.ts
+++ b/web-next/packages/plugin-ravn/src/ui/hooks/useSessions.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ServicesProvider } from '@niuulabs/plugin-sdk';
+import { createElement, type ReactNode } from 'react';
+import { useSessions, useSession, useMessages } from './useSessions';
+import type { Session } from '../../domain/session';
+import type { Message } from '../../domain/message';
+
+const SAMPLE_SESSION: Session = {
+  id: '10000001-0000-4000-8000-000000000001',
+  ravnId: 'a3f1b2c4-8e7d-4a6f-9b0c-1d2e3f4a5b6c',
+  personaName: 'coder',
+  status: 'running',
+  model: 'claude-sonnet-4-6',
+  createdAt: '2026-04-15T09:00:00Z',
+};
+
+const SAMPLE_MESSAGE: Message = {
+  id: '00000001-0000-4000-8000-000000000001',
+  sessionId: '10000001-0000-4000-8000-000000000001',
+  kind: 'user',
+  content: 'Hello',
+  ts: '2026-04-15T09:00:01Z',
+};
+
+function makeWrapper(services: Record<string, unknown>) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(
+      QueryClientProvider,
+      { client },
+      createElement(ServicesProvider, { services }, children),
+    );
+  };
+}
+
+describe('useSessions', () => {
+  it('returns session list', async () => {
+    const svc = {
+      listSessions: vi.fn().mockResolvedValue([SAMPLE_SESSION]),
+      getSession: vi.fn(),
+      getMessages: vi.fn(),
+    };
+    const { result } = renderHook(() => useSessions(), {
+      wrapper: makeWrapper({ 'ravn.sessions': svc }),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(1);
+  });
+
+  it('enters error state when service rejects', async () => {
+    const svc = {
+      listSessions: vi.fn().mockRejectedValue(new Error('timeout')),
+      getSession: vi.fn(),
+      getMessages: vi.fn(),
+    };
+    const { result } = renderHook(() => useSessions(), {
+      wrapper: makeWrapper({ 'ravn.sessions': svc }),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe('useSession', () => {
+  it('fetches a single session', async () => {
+    const svc = {
+      listSessions: vi.fn(),
+      getSession: vi.fn().mockResolvedValue(SAMPLE_SESSION),
+      getMessages: vi.fn(),
+    };
+    const { result } = renderHook(() => useSession('10000001-0000-4000-8000-000000000001'), {
+      wrapper: makeWrapper({ 'ravn.sessions': svc }),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.personaName).toBe('coder');
+  });
+
+  it('is disabled when id is empty', () => {
+    const svc = { listSessions: vi.fn(), getSession: vi.fn(), getMessages: vi.fn() };
+    const { result } = renderHook(() => useSession(''), {
+      wrapper: makeWrapper({ 'ravn.sessions': svc }),
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(svc.getSession).not.toHaveBeenCalled();
+  });
+});
+
+describe('useMessages', () => {
+  it('fetches messages for a session', async () => {
+    const svc = {
+      listSessions: vi.fn(),
+      getSession: vi.fn(),
+      getMessages: vi.fn().mockResolvedValue([SAMPLE_MESSAGE]),
+    };
+    const { result } = renderHook(() => useMessages('10000001-0000-4000-8000-000000000001'), {
+      wrapper: makeWrapper({ 'ravn.sessions': svc }),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data![0]!.kind).toBe('user');
+  });
+
+  it('is disabled when sessionId is empty', () => {
+    const svc = { listSessions: vi.fn(), getSession: vi.fn(), getMessages: vi.fn() };
+    const { result } = renderHook(() => useMessages(''), {
+      wrapper: makeWrapper({ 'ravn.sessions': svc }),
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+});

--- a/web-next/packages/plugin-ravn/src/ui/hooks/useSessions.ts
+++ b/web-next/packages/plugin-ravn/src/ui/hooks/useSessions.ts
@@ -1,0 +1,29 @@
+import { useQuery } from '@tanstack/react-query';
+import { useService } from '@niuulabs/plugin-sdk';
+import type { ISessionStream } from '../../ports';
+
+export function useSessions() {
+  const service = useService<ISessionStream>('ravn.sessions');
+  return useQuery({
+    queryKey: ['ravn', 'sessions'],
+    queryFn: () => service.listSessions(),
+  });
+}
+
+export function useSession(id: string) {
+  const service = useService<ISessionStream>('ravn.sessions');
+  return useQuery({
+    queryKey: ['ravn', 'sessions', id],
+    queryFn: () => service.getSession(id),
+    enabled: !!id,
+  });
+}
+
+export function useMessages(sessionId: string) {
+  const service = useService<ISessionStream>('ravn.sessions');
+  return useQuery({
+    queryKey: ['ravn', 'messages', sessionId],
+    queryFn: () => service.getMessages(sessionId),
+    enabled: !!sessionId,
+  });
+}

--- a/web-next/packages/plugin-ravn/src/ui/hooks/useTriggers.test.ts
+++ b/web-next/packages/plugin-ravn/src/ui/hooks/useTriggers.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ServicesProvider } from '@niuulabs/plugin-sdk';
+import { createElement, type ReactNode } from 'react';
+import { useTriggers } from './useTriggers';
+import type { Trigger } from '../../domain/trigger';
+
+const SAMPLE_TRIGGER: Trigger = {
+  id: 'aa000001-0000-4000-8000-000000000001',
+  kind: 'cron',
+  personaName: 'health-auditor',
+  spec: '0 * * * *',
+  enabled: true,
+  createdAt: '2026-04-01T00:00:00Z',
+};
+
+function makeWrapper(services: Record<string, unknown>) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(
+      QueryClientProvider,
+      { client },
+      createElement(ServicesProvider, { services }, children),
+    );
+  };
+}
+
+describe('useTriggers', () => {
+  it('returns triggers list from service', async () => {
+    const svc = { listTriggers: vi.fn().mockResolvedValue([SAMPLE_TRIGGER]) };
+    const { result } = renderHook(() => useTriggers(), {
+      wrapper: makeWrapper({ 'ravn.triggers': svc }),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data![0]!.personaName).toBe('health-auditor');
+    expect(svc.listTriggers).toHaveBeenCalled();
+  });
+
+  it('starts in loading state', () => {
+    const svc = { listTriggers: vi.fn().mockReturnValue(new Promise(() => undefined)) };
+    const { result } = renderHook(() => useTriggers(), {
+      wrapper: makeWrapper({ 'ravn.triggers': svc }),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('enters error state when service rejects', async () => {
+    const svc = {
+      listTriggers: vi.fn().mockRejectedValue(new Error('service unavailable')),
+    };
+    const { result } = renderHook(() => useTriggers(), {
+      wrapper: makeWrapper({ 'ravn.triggers': svc }),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/web-next/packages/plugin-ravn/src/ui/hooks/useTriggers.ts
+++ b/web-next/packages/plugin-ravn/src/ui/hooks/useTriggers.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { useService } from '@niuulabs/plugin-sdk';
+import type { ITriggerStore } from '../../ports';
+
+export function useTriggers() {
+  const service = useService<ITriggerStore>('ravn.triggers');
+  return useQuery({
+    queryKey: ['ravn', 'triggers'],
+    queryFn: () => service.listTriggers(),
+  });
+}

--- a/web-next/packages/plugin-ravn/src/ui/storage.ts
+++ b/web-next/packages/plugin-ravn/src/ui/storage.ts
@@ -1,0 +1,16 @@
+export function loadStorage<T>(key: string, fallback: T): T {
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as T) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export function saveStorage<T>(key: string, value: T): void {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // ignore
+  }
+}


### PR DESCRIPTION
## Summary

- Add `OverviewPage` with KPI strip (active count, session count, budget spend), top budget spenders list, activity sparkline, and live log tail
- Add `RavensPage` with three layout variants (split/table/cards), grouping selector (by state/persona/location/none), and `RavnDetail` right pane
- Add `RavnDetail` with 6 collapsible sections (overview, triggers, activity, sessions, connectivity, delete/suspend), localStorage state persistence, and suspend/delete action buttons
- Add unit tests (grouping, budget sorting, hooks, RavnDetail component interactions)
- Add Storybook stories for layout variants and RavnDetail sections
- Add Playwright e2e specs (layout switch, groupBy state, expand raven detail)

## Fixes

- Fix invalid `DotState` values (`'ok'`/`'warn'`/`'err'`/`'mute'` → `'running'`/`'attention'`/`'failed'`/`'unknown'`)
- Fix `plugin-mimir` HTTP adapter — add missing `getRecentWrites`, `listSources`, `getPageSources` implementations
- Fix React 19 `RefObject<T | null>` type mismatch in `ZoneBlock`
- Fix `noUncheckedIndexedAccess` in `PagesView` (`allPages[0]?.path`)

## Test plan

- [ ] `pnpm test` passes with ≥85% coverage
- [ ] `pnpm typecheck` clean (no web-next errors)
- [ ] `pnpm lint` clean
- [ ] `pnpm format:check` clean
- [ ] Playwright e2e passes

Closes NIU-672

🤖 Generated with [Claude Code](https://claude.com/claude-code)