### PR TITLE
feat(ravn): Sessions, Triggers, Events, Budget, Log views (NIU-674)

### DIFF
--- a/web-next/e2e/ravn.spec.ts
+++ b/web-next/e2e/ravn.spec.ts
@@ -62,6 +62,20 @@ test('clicking Overview tab returns to overview', async ({ page }) => {
   await expect(page.getByTestId('overview-page')).toBeVisible({ timeout: 3000 });
 });
 
+test('renders sessions, triggers, events, budget, log tabs', async ({ page }) => {
+  await page.goto('/ravn');
+  await expect(page.getByRole('tab', { name: 'Sessions' })).toBeVisible();
+  await expect(page.getByRole('tab', { name: 'Triggers' })).toBeVisible();
+  await expect(page.getByRole('tab', { name: 'Events' })).toBeVisible();
+  await expect(page.getByRole('tab', { name: 'Budget' })).toBeVisible();
+  await expect(page.getByRole('tab', { name: 'Log' })).toBeVisible();
+});
+
+test('Overview tab is active by default', async ({ page }) => {
+  await page.goto('/ravn');
+  await expect(page.getByTestId('ravn-tab-overview')).toHaveAttribute('aria-selected', 'true');
+});
+
 // ─── Layout variant switching ──────────────────────────────────────────────────
 
 test('ravens page: switch to table layout', async ({ page }) => {
@@ -168,6 +182,218 @@ test('ravens page: closing detail pane shows empty state', async ({ page }) => {
   await expect(page.getByTestId('detail-close-btn')).toBeVisible({ timeout: 5000 });
   await page.getByTestId('detail-close-btn').click();
   await expect(page.getByTestId('detail-empty')).toBeVisible({ timeout: 3000 });
+});
+
+// ─── Sessions view ─────────────────────────────────────────────────────────────
+
+test('/ravn — Sessions tab shows session list', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByTestId('ravn-tab-sessions').click();
+  await expect(page.getByLabel('session list')).toBeVisible({ timeout: 5000 });
+});
+
+test('/ravn — session list shows coding-agent', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByTestId('ravn-tab-sessions').click();
+  await expect(page.getByText('coding-agent').first()).toBeVisible({ timeout: 5000 });
+});
+
+test('/ravn — selecting a session loads transcript', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByTestId('ravn-tab-sessions').click();
+  await expect(page.getByRole('log').first()).toBeVisible({ timeout: 5000 });
+});
+
+test('/ravn — transcript shows message kinds', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByTestId('ravn-tab-sessions').click();
+  // The first session has user, think, tool_call, tool_result, asst, emit messages
+  await expect(page.getByText(/messages/).first()).toBeVisible({ timeout: 5000 });
+});
+
+test('/ravn — running session shows active cursor', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByTestId('ravn-tab-sessions').click();
+  // coding-agent session status=running, so ActiveCursor renders with data-cursor-state="active"
+  await expect(page.locator('[data-cursor-state="active"]')).toBeAttached({ timeout: 5000 });
+});
+
+test('/ravn — think message shows toggle button', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByTestId('ravn-tab-sessions').click();
+  await expect(page.getByText('show reasoning')).toBeVisible({ timeout: 5000 });
+});
+
+test('/ravn — clicking think toggle expands reasoning', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByTestId('ravn-tab-sessions').click();
+  await expect(page.getByText('show reasoning')).toBeVisible({ timeout: 5000 });
+  await page.getByText('show reasoning').click();
+  await expect(page.getByText('hide reasoning')).toBeVisible();
+});
+
+// ─── Triggers view ─────────────────────────────────────────────────────────────
+
+test('/ravn — Triggers tab shows trigger groups', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByRole('tab', { name: 'Triggers' }).click();
+  await expect(page.getByRole('region', { name: /cron triggers/i })).toBeVisible({ timeout: 5000 });
+});
+
+test('/ravn — Triggers shows event triggers', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByRole('tab', { name: 'Triggers' }).click();
+  await expect(page.getByRole('region', { name: /event triggers/i })).toBeVisible({
+    timeout: 5000,
+  });
+});
+
+test('/ravn — Triggers shows cron spec', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByRole('tab', { name: 'Triggers' }).click();
+  await expect(page.getByText('0 * * * *')).toBeVisible({ timeout: 5000 });
+});
+
+// ─── Events view ───────────────────────────────────────────────────────────────
+
+test('/ravn — Events tab shows event graph', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByRole('tab', { name: 'Events' }).click();
+  await expect(page.getByRole('region', { name: /event graph/i })).toBeVisible({ timeout: 5000 });
+});
+
+test('/ravn — Events shows code.changed event', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByRole('tab', { name: 'Events' }).click();
+  await expect(page.getByLabel('event code.changed')).toBeVisible({ timeout: 5000 });
+});
+
+test('/ravn — Events — clicking a persona dims others', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByRole('tab', { name: 'Events' }).click();
+  await expect(page.getByLabel('event code.changed')).toBeVisible({ timeout: 5000 });
+  // Click first persona pill
+  const coderBtn = page.getByRole('button', { name: 'coder' }).first();
+  await coderBtn.click();
+  await expect(page.getByText(/filtering by/i)).toBeVisible();
+});
+
+test('/ravn — Events — clear filter resets persona selection', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByRole('tab', { name: 'Events' }).click();
+  await expect(page.getByLabel('event code.changed')).toBeVisible({ timeout: 5000 });
+  await page.getByRole('button', { name: 'coder' }).first().click();
+  await page.getByLabel('clear persona filter').click();
+  await expect(page.getByText(/filtering by/i)).not.toBeVisible();
+});
+
+// ─── Budget view ───────────────────────────────────────────────────────────────
+
+test('/ravn — Budget tab shows hero card', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByRole('tab', { name: 'Budget' }).click();
+  await expect(page.getByLabel(/fleet budget/i)).toBeVisible({ timeout: 5000 });
+});
+
+test('/ravn — Budget shows three attention columns', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByRole('tab', { name: 'Budget' }).click();
+  await expect(page.getByRole('group', { name: /budget attention/i })).toBeVisible({
+    timeout: 5000,
+  });
+  await expect(page.getByLabel('Burning fast')).toBeVisible();
+  await expect(page.getByLabel('Near cap')).toBeVisible();
+  await expect(page.getByLabel('Idle')).toBeVisible();
+});
+
+test('/ravn — Budget fleet table is hidden initially', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByRole('tab', { name: 'Budget' }).click();
+  await expect(page.getByText(/full fleet table/i)).toBeVisible({ timeout: 5000 });
+  await expect(page.getByLabel(/fleet budget table/i)).not.toBeVisible();
+});
+
+test('/ravn — Budget fleet table expands on click', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByRole('tab', { name: 'Budget' }).click();
+  await expect(page.getByText(/full fleet table/i)).toBeVisible({ timeout: 5000 });
+  await page.getByText(/full fleet table/i).click();
+  await expect(page.getByLabel(/fleet budget table/i)).toBeVisible();
+});
+
+// ─── Log view ──────────────────────────────────────────────────────────────────
+
+test('/ravn — Log tab renders event stream', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByRole('tab', { name: 'Log' }).click();
+  await expect(page.getByRole('log', { name: /event log/i })).toBeVisible();
+});
+
+test('/ravn — Log shows column headers', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByRole('tab', { name: 'Log' }).click();
+  // Use columnheader role to target table <th> elements, avoiding substring matches elsewhere
+  await expect(page.getByRole('columnheader', { name: 'time' })).toBeVisible();
+  await expect(page.getByRole('columnheader', { name: 'raven' })).toBeVisible();
+  await expect(page.getByRole('columnheader', { name: 'kind' })).toBeVisible();
+  await expect(page.getByRole('columnheader', { name: 'body' })).toBeVisible();
+});
+
+test('/ravn — Log has search input', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByRole('tab', { name: 'Log' }).click();
+  await expect(page.getByRole('searchbox', { name: /search log/i })).toBeVisible();
+});
+
+test('/ravn — Log has kind filter buttons', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByRole('tab', { name: 'Log' }).click();
+  await expect(page.getByRole('button', { name: 'user' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'emit' })).toBeVisible();
+});
+
+test('/ravn — Log — join a live session and observe tool_call → tool_result → emit', async ({
+  page,
+}) => {
+  await page.goto('/ravn');
+  await page.getByTestId('ravn-tab-sessions').click();
+  // The first session (coding-agent) is running and has tool_call, tool_result, emit messages
+  await expect(page.getByText('coding-agent').first()).toBeVisible({ timeout: 5000 });
+  // Navigate to log
+  await page.getByRole('tab', { name: 'Log' }).click();
+  // Wait for entries to load
+  await expect(page.getByText(/entries/i)).toBeVisible({ timeout: 5000 });
+  // Filter to tool_call kind
+  await page.getByRole('button', { name: 'tool_call' }).click();
+  // tool_call entries should now be visible
+  await expect(page.getByRole('button', { name: 'tool_call' })).toHaveAttribute(
+    'aria-pressed',
+    'true',
+  );
+});
+
+test('/ravn — Log — filter the log by typing in search', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByRole('tab', { name: 'Log' }).click();
+  await expect(page.getByRole('searchbox', { name: /search log/i })).toBeVisible();
+  await page.getByRole('searchbox', { name: /search log/i }).fill('login');
+  // Footer should update
+  await expect(page.getByText(/entries/i)).toBeVisible({ timeout: 3000 });
+});
+
+test('/ravn — Log — auto-tail checkbox is checked by default', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByRole('tab', { name: 'Log' }).click();
+  const checkbox = page.getByRole('checkbox', { name: /auto-tail/i });
+  await expect(checkbox).toBeChecked();
+});
+
+test('/ravn — Log — unchecking auto-tail persists', async ({ page }) => {
+  await page.goto('/ravn');
+  await page.getByRole('tab', { name: 'Log' }).click();
+  const checkbox = page.getByRole('checkbox', { name: /auto-tail/i });
+  await checkbox.uncheck();
+  await expect(checkbox).not.toBeChecked();
 });
 
 // ─── Accessibility ─────────────────────────────────────────────────────────────

--- a/web-next/packages/plugin-ravn/src/application/budgetAttention.test.ts
+++ b/web-next/packages/plugin-ravn/src/application/budgetAttention.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { classifyBudget, budgetRunway, budgetRatio } from './budgetAttention';
+import type { BudgetState } from '@niuulabs/domain';
+
+const budget = (spentUsd: number, capUsd: number, warnAt = 0.8): BudgetState => ({
+  spentUsd,
+  capUsd,
+  warnAt,
+});
+
+describe('classifyBudget', () => {
+  it('returns idle when capUsd is 0 (unlimited)', () => {
+    expect(classifyBudget(budget(0, 0))).toBe('idle');
+  });
+
+  it('returns idle when ratio is below idle threshold (10%)', () => {
+    expect(classifyBudget(budget(0.04, 5.0))).toBe('idle');
+    expect(classifyBudget(budget(0, 5.0))).toBe('idle');
+  });
+
+  it('returns normal for mid-range spending', () => {
+    expect(classifyBudget(budget(1.5, 5.0))).toBe('normal');
+    expect(classifyBudget(budget(2.5, 5.0))).toBe('normal');
+  });
+
+  it('returns near-cap when ratio >= warnAt and < 0.9', () => {
+    expect(classifyBudget(budget(4.0, 5.0))).toBe('near-cap'); // 80%
+    expect(classifyBudget(budget(4.3, 5.0))).toBe('near-cap'); // 86%
+  });
+
+  it('returns burning-fast when ratio >= 90%', () => {
+    expect(classifyBudget(budget(4.5, 5.0))).toBe('burning-fast'); // 90%
+    expect(classifyBudget(budget(5.0, 5.0))).toBe('burning-fast'); // 100%
+  });
+
+  it('respects custom warnAt threshold', () => {
+    // warnAt = 0.5 → near-cap starts at 50%
+    expect(classifyBudget(budget(2.6, 5.0, 0.5))).toBe('near-cap');
+    // normal below 50%
+    expect(classifyBudget(budget(2.0, 5.0, 0.5))).toBe('normal');
+  });
+});
+
+describe('budgetRunway', () => {
+  it('returns remaining budget', () => {
+    expect(budgetRunway(budget(1.24, 5.0))).toBeCloseTo(3.76);
+  });
+
+  it('returns 0 when over cap', () => {
+    expect(budgetRunway(budget(6.0, 5.0))).toBe(0);
+  });
+
+  it('returns full cap when nothing spent', () => {
+    expect(budgetRunway(budget(0, 5.0))).toBe(5.0);
+  });
+});
+
+describe('budgetRatio', () => {
+  it('returns 0 when cap is 0', () => {
+    expect(budgetRatio(budget(0, 0))).toBe(0);
+  });
+
+  it('returns ratio clamped to 1', () => {
+    expect(budgetRatio(budget(5.0, 5.0))).toBe(1);
+    expect(budgetRatio(budget(6.0, 5.0))).toBe(1);
+  });
+
+  it('calculates ratio correctly', () => {
+    expect(budgetRatio(budget(2.5, 5.0))).toBeCloseTo(0.5);
+  });
+});

--- a/web-next/packages/plugin-ravn/src/application/budgetAttention.ts
+++ b/web-next/packages/plugin-ravn/src/application/budgetAttention.ts
@@ -1,0 +1,48 @@
+/**
+ * Budget attention classification.
+ *
+ * Classifies a ravn's spend state into one of three attention buckets used
+ * by the Budget view's attention columns.
+ */
+
+import type { BudgetState } from '@niuulabs/domain';
+
+/** Ratio at which a ravn is classified as "burning fast" (critical). */
+const BURNING_THRESHOLD = 0.9;
+
+/** Ratio below which a ravn is classified as "idle". */
+const IDLE_THRESHOLD = 0.1;
+
+export type BudgetAttention = 'burning-fast' | 'near-cap' | 'idle' | 'normal';
+
+/**
+ * Classify a single ravn's budget into an attention bucket.
+ *
+ * - `burning-fast` — spending ratio ≥ 90 % (critical)
+ * - `near-cap`     — spending ratio ≥ warnAt (warn threshold) but < 90 %
+ * - `idle`         — spending ratio < 10 %
+ * - `normal`       — everything else
+ */
+export function classifyBudget(budget: BudgetState): BudgetAttention {
+  if (budget.capUsd === 0) return 'idle';
+  const ratio = budget.spentUsd / budget.capUsd;
+  if (ratio >= BURNING_THRESHOLD) return 'burning-fast';
+  if (ratio >= budget.warnAt) return 'near-cap';
+  if (ratio < IDLE_THRESHOLD) return 'idle';
+  return 'normal';
+}
+
+/**
+ * Returns the runway: how many USD remain before hitting the cap.
+ */
+export function budgetRunway(budget: BudgetState): number {
+  return Math.max(0, budget.capUsd - budget.spentUsd);
+}
+
+/**
+ * Returns spending ratio (0–1 clamped), or 0 when cap is unlimited.
+ */
+export function budgetRatio(budget: BudgetState): number {
+  if (budget.capUsd === 0) return 0;
+  return Math.min(1, budget.spentUsd / budget.capUsd);
+}

--- a/web-next/packages/plugin-ravn/src/application/logFilter.test.ts
+++ b/web-next/packages/plugin-ravn/src/application/logFilter.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { applyLogFilter, EMPTY_LOG_FILTER, type LogEntry } from './logFilter';
+import type { Message } from '../domain/message';
+
+function entry(overrides: Partial<Message & { ravnId?: string; personaName?: string }>): LogEntry {
+  const message: Message = {
+    id: overrides.id ?? '00000000-0000-4000-8000-000000000001',
+    sessionId: overrides.sessionId ?? 'sess-1',
+    kind: overrides.kind ?? 'user',
+    content: overrides.content ?? 'hello',
+    ts: overrides.ts ?? '2026-04-15T09:00:00Z',
+    toolName: overrides.toolName,
+  };
+  return {
+    message,
+    ravnId: overrides.ravnId ?? 'ravn-1',
+    personaName: overrides.personaName ?? 'coder',
+  };
+}
+
+describe('applyLogFilter', () => {
+  const entries: LogEntry[] = [
+    entry({
+      id: '1',
+      kind: 'user',
+      content: 'hello world',
+      ravnId: 'ravn-1',
+      personaName: 'coder',
+    }),
+    entry({
+      id: '2',
+      kind: 'tool_call',
+      content: '{"path":"src/main.ts"}',
+      ravnId: 'ravn-1',
+      personaName: 'coder',
+      toolName: 'file.read',
+    }),
+    entry({
+      id: '3',
+      kind: 'emit',
+      content: '{"event":"code.changed"}',
+      ravnId: 'ravn-2',
+      personaName: 'reviewer',
+    }),
+    entry({
+      id: '4',
+      kind: 'think',
+      content: 'reasoning step',
+      ravnId: 'ravn-2',
+      personaName: 'reviewer',
+    }),
+  ];
+
+  it('returns all entries with empty filter', () => {
+    expect(applyLogFilter(entries, EMPTY_LOG_FILTER)).toHaveLength(4);
+  });
+
+  it('filters by ravnId', () => {
+    const result = applyLogFilter(entries, { ...EMPTY_LOG_FILTER, ravnId: 'ravn-2' });
+    expect(result).toHaveLength(2);
+    expect(result.every((e) => e.ravnId === 'ravn-2')).toBe(true);
+  });
+
+  it('filters by single kind', () => {
+    const result = applyLogFilter(entries, { ...EMPTY_LOG_FILTER, kinds: ['emit'] });
+    expect(result).toHaveLength(1);
+    expect(result[0]?.message.kind).toBe('emit');
+  });
+
+  it('filters by multiple kinds', () => {
+    const result = applyLogFilter(entries, { ...EMPTY_LOG_FILTER, kinds: ['user', 'think'] });
+    expect(result).toHaveLength(2);
+  });
+
+  it('filters by query (content match)', () => {
+    const result = applyLogFilter(entries, { ...EMPTY_LOG_FILTER, query: 'hello' });
+    expect(result).toHaveLength(1);
+    expect(result[0]?.message.content).toBe('hello world');
+  });
+
+  it('filters by query (persona match)', () => {
+    const result = applyLogFilter(entries, { ...EMPTY_LOG_FILTER, query: 'reviewer' });
+    expect(result).toHaveLength(2);
+  });
+
+  it('filters by query (tool name match)', () => {
+    const result = applyLogFilter(entries, { ...EMPTY_LOG_FILTER, query: 'file.read' });
+    expect(result).toHaveLength(1);
+    expect(result[0]?.message.toolName).toBe('file.read');
+  });
+
+  it('query is case-insensitive', () => {
+    const result = applyLogFilter(entries, { ...EMPTY_LOG_FILTER, query: 'HELLO' });
+    expect(result).toHaveLength(1);
+  });
+
+  it('combines ravnId and kind filters', () => {
+    const result = applyLogFilter(entries, {
+      ...EMPTY_LOG_FILTER,
+      ravnId: 'ravn-1',
+      kinds: ['user'],
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]?.message.kind).toBe('user');
+  });
+
+  it('returns empty when nothing matches', () => {
+    const result = applyLogFilter(entries, { ...EMPTY_LOG_FILTER, query: 'zzznomatch' });
+    expect(result).toHaveLength(0);
+  });
+
+  it('does not mutate the input array', () => {
+    const copy = [...entries];
+    applyLogFilter(entries, { ...EMPTY_LOG_FILTER, kinds: ['emit'] });
+    expect(entries).toHaveLength(copy.length);
+  });
+});

--- a/web-next/packages/plugin-ravn/src/application/logFilter.ts
+++ b/web-next/packages/plugin-ravn/src/application/logFilter.ts
@@ -1,0 +1,50 @@
+/**
+ * Log view filter logic.
+ *
+ * Pure functions for filtering log entries — unit-testable without React.
+ */
+
+import type { Message, MessageKind } from '../domain/message';
+
+export interface LogEntry {
+  /** Source message */
+  message: Message;
+  /** Ravn ID that owns the session this message belongs to */
+  ravnId: string;
+  /** Ravn persona name */
+  personaName: string;
+}
+
+export interface LogFilter {
+  /** Free-text search against body content */
+  query: string;
+  /** Only show entries from this ravn (empty = all) */
+  ravnId: string;
+  /** Only show these kinds (empty = all) */
+  kinds: MessageKind[];
+}
+
+export const EMPTY_LOG_FILTER: LogFilter = {
+  query: '',
+  ravnId: '',
+  kinds: [],
+};
+
+/**
+ * Apply a LogFilter to a list of log entries.
+ * Returns a new (filtered) array — does not mutate input.
+ */
+export function applyLogFilter(entries: readonly LogEntry[], filter: LogFilter): LogEntry[] {
+  return entries.filter((entry) => {
+    if (filter.ravnId && entry.ravnId !== filter.ravnId) return false;
+    if (filter.kinds.length > 0 && !filter.kinds.includes(entry.message.kind)) return false;
+    if (filter.query) {
+      const q = filter.query.toLowerCase();
+      const inContent = entry.message.content.toLowerCase().includes(q);
+      const inPersona = entry.personaName.toLowerCase().includes(q);
+      const inTool = (entry.message.toolName ?? '').toLowerCase().includes(q);
+      if (!inContent && !inPersona && !inTool) return false;
+    }
+    return true;
+  });
+}

--- a/web-next/packages/plugin-ravn/src/index.ts
+++ b/web-next/packages/plugin-ravn/src/index.ts
@@ -62,3 +62,17 @@ export {
 } from './domain/session';
 export { triggerKindSchema, triggerSchema, type TriggerKind, type Trigger } from './domain/trigger';
 export { messageKindSchema, messageSchema, type MessageKind, type Message } from './domain/message';
+
+// Application logic
+export {
+  classifyBudget,
+  budgetRunway,
+  budgetRatio,
+  type BudgetAttention,
+} from './application/budgetAttention';
+export {
+  applyLogFilter,
+  EMPTY_LOG_FILTER,
+  type LogEntry,
+  type LogFilter,
+} from './application/logFilter';

--- a/web-next/packages/plugin-ravn/src/testing/wrapWithRavn.tsx
+++ b/web-next/packages/plugin-ravn/src/testing/wrapWithRavn.tsx
@@ -1,0 +1,14 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ServicesProvider } from '@niuulabs/plugin-sdk';
+import type { ReactNode } from 'react';
+
+export function wrapWithServices(services: Record<string, unknown>) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>
+        <ServicesProvider services={services}>{children}</ServicesProvider>
+      </QueryClientProvider>
+    );
+  };
+}

--- a/web-next/packages/plugin-ravn/src/ui/ActiveCursor.stories.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/ActiveCursor.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ActiveCursor } from './ActiveCursor';
+
+const meta: Meta<typeof ActiveCursor> = {
+  title: 'Ravn/ActiveCursor',
+  component: ActiveCursor,
+};
+
+export default meta;
+type Story = StoryObj<typeof ActiveCursor>;
+
+export const Active: Story = {
+  args: { status: 'running' },
+};
+
+export const Idle: Story = {
+  args: { status: 'idle' },
+};
+
+export const Stopped: Story = {
+  args: { status: 'stopped' },
+};
+
+export const Failed: Story = {
+  args: { status: 'failed' },
+};

--- a/web-next/packages/plugin-ravn/src/ui/ActiveCursor.test.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/ActiveCursor.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ActiveCursor, cursorStateFromStatus } from './ActiveCursor';
+import type { SessionStatus } from '../domain/session';
+
+describe('cursorStateFromStatus', () => {
+  it('returns active for running', () => {
+    expect(cursorStateFromStatus('running')).toBe('active');
+  });
+
+  it('returns done for stopped', () => {
+    expect(cursorStateFromStatus('stopped')).toBe('done');
+  });
+
+  it('returns done for failed', () => {
+    expect(cursorStateFromStatus('failed')).toBe('done');
+  });
+
+  it('returns idle for idle', () => {
+    expect(cursorStateFromStatus('idle')).toBe('idle');
+  });
+});
+
+describe('ActiveCursor', () => {
+  const statuses: SessionStatus[] = ['idle', 'stopped', 'failed'];
+
+  statuses.forEach((status) => {
+    it(`renders nothing for status=${status}`, () => {
+      const { container } = render(<ActiveCursor status={status} />);
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  it('renders a pulsing indicator for running sessions', () => {
+    render(<ActiveCursor status="running" />);
+    const indicator = screen.getByRole('status', { name: /session in progress/i });
+    expect(indicator).toBeInTheDocument();
+    expect(indicator).toHaveAttribute('data-cursor-state', 'active');
+  });
+
+  it('has aria-live polite for screen readers', () => {
+    render(<ActiveCursor status="running" />);
+    const indicator = screen.getByRole('status');
+    expect(indicator).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('accepts a custom className', () => {
+    render(<ActiveCursor status="running" className="my-class" />);
+    const indicator = screen.getByRole('status');
+    expect(indicator).toHaveClass('my-class');
+  });
+});

--- a/web-next/packages/plugin-ravn/src/ui/ActiveCursor.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/ActiveCursor.tsx
@@ -1,0 +1,45 @@
+/**
+ * ActiveCursor — pulsing "in-progress" indicator for live sessions.
+ *
+ * State machine:
+ *   idle     — session is not running (renders nothing)
+ *   active   — session.status === 'running' (pulsing cursor shown)
+ *   done     — session finished (renders nothing)
+ */
+
+import type { SessionStatus } from '../domain/session';
+
+export type CursorState = 'idle' | 'active' | 'done';
+
+/** Derive cursor state from a session status. */
+export function cursorStateFromStatus(status: SessionStatus): CursorState {
+  if (status === 'running') return 'active';
+  if (status === 'stopped' || status === 'failed') return 'done';
+  return 'idle';
+}
+
+interface ActiveCursorProps {
+  status: SessionStatus;
+  className?: string;
+}
+
+export function ActiveCursor({ status, className }: ActiveCursorProps) {
+  const state = cursorStateFromStatus(status);
+  if (state !== 'active') return null;
+
+  return (
+    <div
+      className={className}
+      role="status"
+      aria-label="session in progress"
+      aria-live="polite"
+      data-cursor-state={state}
+    >
+      <span className="rv-active-cursor">
+        <span className="rv-active-cursor__dot" aria-hidden="true" />
+        <span className="rv-active-cursor__dot rv-active-cursor__dot--2" aria-hidden="true" />
+        <span className="rv-active-cursor__dot rv-active-cursor__dot--3" aria-hidden="true" />
+      </span>
+    </div>
+  );
+}

--- a/web-next/packages/plugin-ravn/src/ui/BudgetView.stories.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/BudgetView.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ServicesProvider } from '@niuulabs/plugin-sdk';
+import { BudgetView } from './BudgetView';
+import { createMockBudgetStream, createMockRavenStream } from '../adapters/mock';
+
+const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+const meta: Meta<typeof BudgetView> = {
+  title: 'Ravn/BudgetView',
+  component: BudgetView,
+};
+
+export default meta;
+type Story = StoryObj<typeof BudgetView>;
+
+export const Default: Story = {
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={client}>
+        <ServicesProvider
+          services={{
+            'ravn.budget': createMockBudgetStream(),
+            'ravn.ravens': createMockRavenStream(),
+          }}
+        >
+          <Story />
+        </ServicesProvider>
+      </QueryClientProvider>
+    ),
+  ],
+};

--- a/web-next/packages/plugin-ravn/src/ui/BudgetView.test.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/BudgetView.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { BudgetView } from './BudgetView';
+import { createMockBudgetStream, createMockRavenStream } from '../adapters/mock';
+import { wrapWithServices } from '../testing/wrapWithRavn';
+
+const wrap = wrapWithServices;
+
+const services = {
+  'ravn.budget': createMockBudgetStream(),
+  'ravn.ravens': createMockRavenStream(),
+};
+
+describe('BudgetView', () => {
+  it('shows loading state initially', () => {
+    render(<BudgetView />, { wrapper: wrap(services) });
+    expect(screen.getByText(/loading budget/i)).toBeInTheDocument();
+  });
+
+  it('shows hero card after loading', async () => {
+    render(<BudgetView />, { wrapper: wrap(services) });
+    await waitFor(() => expect(screen.getByLabelText(/fleet budget/i)).toBeInTheDocument());
+  });
+
+  it('shows fleet budget KPIs', async () => {
+    render(<BudgetView />, { wrapper: wrap(services) });
+    await waitFor(() => {
+      expect(screen.getByText('spent')).toBeInTheDocument();
+      expect(screen.getByText('cap')).toBeInTheDocument();
+      expect(screen.getByText('runway')).toBeInTheDocument();
+    });
+  });
+
+  it('renders three attention columns', async () => {
+    render(<BudgetView />, { wrapper: wrap(services) });
+    await waitFor(() => {
+      expect(screen.getByLabelText(/budget attention/i)).toBeInTheDocument();
+      expect(screen.getByLabelText('Burning fast')).toBeInTheDocument();
+      expect(screen.getByLabelText('Near cap')).toBeInTheDocument();
+      expect(screen.getByLabelText('Idle')).toBeInTheDocument();
+    });
+  });
+
+  it('collapsible fleet table is hidden initially', async () => {
+    render(<BudgetView />, { wrapper: wrap(services) });
+    await waitFor(() => expect(screen.getByText(/full fleet table/i)).toBeInTheDocument());
+    expect(screen.queryByLabelText(/fleet budget table/i)).not.toBeInTheDocument();
+  });
+
+  it('expands fleet table when toggle is clicked', async () => {
+    render(<BudgetView />, { wrapper: wrap(services) });
+    await waitFor(() => expect(screen.getByText(/full fleet table/i)).toBeInTheDocument());
+    fireEvent.click(screen.getByText(/full fleet table/i));
+    expect(screen.getByLabelText(/fleet budget table/i)).toBeInTheDocument();
+  });
+
+  it('collapses fleet table on second click', async () => {
+    render(<BudgetView />, { wrapper: wrap(services) });
+    await waitFor(() => expect(screen.getByText(/full fleet table/i)).toBeInTheDocument());
+    fireEvent.click(screen.getByText(/full fleet table/i));
+    expect(screen.getByLabelText(/fleet budget table/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByText(/full fleet table/i));
+    expect(screen.queryByLabelText(/fleet budget table/i)).not.toBeInTheDocument();
+  });
+
+  it('fleet table has correct column headers', async () => {
+    render(<BudgetView />, { wrapper: wrap(services) });
+    await waitFor(() => expect(screen.getByText(/full fleet table/i)).toBeInTheDocument());
+    fireEvent.click(screen.getByText(/full fleet table/i));
+    const table = screen.getByLabelText(/fleet budget table/i);
+    expect(table).toBeInTheDocument();
+    expect(table.querySelector('th:first-child')).toHaveTextContent('ravn');
+    // Multiple 'spent'/'cap' exist in hero card + table; check the table specifically
+    const headers = table.querySelectorAll('th');
+    const headerTexts = Array.from(headers).map((h) => h.textContent);
+    expect(headerTexts).toContain('spent');
+    expect(headerTexts).toContain('cap');
+  });
+});

--- a/web-next/packages/plugin-ravn/src/ui/BudgetView.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/BudgetView.tsx
@@ -1,0 +1,230 @@
+/**
+ * BudgetView — fleet budget dashboard.
+ *
+ * Sections:
+ *   1. Hero card — fleet totals (spent / cap / runway)
+ *   2. Three attention columns — Burning fast / Near cap / Idle
+ *   3. Collapsible full fleet table
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { BudgetBar, StateDot } from '@niuulabs/ui';
+import { useRavens } from './useRavens';
+import { useFleetBudget, useRavnBudget } from './useBudget';
+import {
+  classifyBudget,
+  budgetRunway,
+  budgetRatio,
+  type BudgetAttention,
+} from '../application/budgetAttention';
+import type { Ravn } from '../domain/ravn';
+import type { BudgetState } from '@niuulabs/domain';
+
+const USD = (n: number) => `$${n.toFixed(2)}`;
+
+const ATTENTION_COLUMNS: Array<{ key: BudgetAttention; label: string }> = [
+  { key: 'burning-fast', label: 'Burning fast' },
+  { key: 'near-cap', label: 'Near cap' },
+  { key: 'idle', label: 'Idle' },
+];
+
+// ---------------------------------------------------------------------------
+// Hero card
+// ---------------------------------------------------------------------------
+
+function HeroCard({ budget }: { budget: BudgetState }) {
+  const runway = budgetRunway(budget);
+  const ratio = budgetRatio(budget);
+  const tone = ratio >= 0.9 ? 'crit' : ratio >= budget.warnAt ? 'warn' : 'ok';
+
+  return (
+    <section className="rv-budget-hero" aria-label="fleet budget">
+      <div className="rv-budget-hero__kpis">
+        <div className="rv-budget-hero__kpi">
+          <span className="rv-budget-hero__kpi-label">spent</span>
+          <strong className={`rv-budget-hero__kpi-value rv-budget-hero__kpi-value--${tone}`}>
+            {USD(budget.spentUsd)}
+          </strong>
+        </div>
+        <div className="rv-budget-hero__kpi">
+          <span className="rv-budget-hero__kpi-label">cap</span>
+          <strong className="rv-budget-hero__kpi-value">{USD(budget.capUsd)}</strong>
+        </div>
+        <div className="rv-budget-hero__kpi">
+          <span className="rv-budget-hero__kpi-label">runway</span>
+          <strong className="rv-budget-hero__kpi-value">{USD(runway)}</strong>
+        </div>
+      </div>
+      <div className="rv-budget-hero__bar">
+        <BudgetBar spent={budget.spentUsd} cap={budget.capUsd} warnAt={budget.warnAt} showLabel />
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Attention column item
+// ---------------------------------------------------------------------------
+
+function AttentionItem({ ravn, budget }: { ravn: Ravn; budget: BudgetState }) {
+  return (
+    <div className="rv-budget-attention-item">
+      <div className="rv-budget-attention-item__head">
+        <span className="rv-budget-attention-item__name">{ravn.personaName}</span>
+        <span className="rv-budget-attention-item__spent">{USD(budget.spentUsd)}</span>
+      </div>
+      <BudgetBar spent={budget.spentUsd} cap={budget.capUsd} warnAt={budget.warnAt} size="sm" />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Per-ravn row (needs individual budget query)
+// ---------------------------------------------------------------------------
+
+function RavnAttentionEntry({
+  ravn,
+  targetAttention,
+  onClassified,
+}: {
+  ravn: Ravn;
+  targetAttention: BudgetAttention;
+  onClassified: (ravnId: string, attention: BudgetAttention, budget: BudgetState) => void;
+}) {
+  const { data: budget } = useRavnBudget(ravn.id);
+
+  // Notify parent via effect (not during render) to avoid setState-in-render
+  useEffect(() => {
+    if (!budget) return;
+    onClassified(ravn.id, classifyBudget(budget), budget);
+  }, [budget, ravn.id, onClassified]);
+
+  if (!budget) return null;
+
+  const attention = classifyBudget(budget);
+  if (attention !== targetAttention) return null;
+
+  return <AttentionItem ravn={ravn} budget={budget} />;
+}
+
+// ---------------------------------------------------------------------------
+// Fleet table row
+// ---------------------------------------------------------------------------
+
+function FleetRow({ ravn, budget }: { ravn: Ravn; budget: BudgetState | undefined }) {
+  const attention = budget ? classifyBudget(budget) : 'normal';
+  return (
+    <tr className="rv-budget-fleet-row" data-attention={attention}>
+      <td className="rv-budget-fleet-row__name">
+        <StateDot
+          state={
+            ravn.status === 'active'
+              ? 'healthy'
+              : ravn.status === 'failed'
+                ? 'failed'
+                : ravn.status === 'suspended'
+                  ? 'observing'
+                  : 'idle'
+          }
+        />
+        {ravn.personaName}
+      </td>
+      <td className="rv-budget-fleet-row__spent">{budget ? USD(budget.spentUsd) : '—'}</td>
+      <td className="rv-budget-fleet-row__cap">{budget ? USD(budget.capUsd) : '—'}</td>
+      <td className="rv-budget-fleet-row__bar">
+        {budget && (
+          <BudgetBar spent={budget.spentUsd} cap={budget.capUsd} warnAt={budget.warnAt} size="sm" />
+        )}
+      </td>
+      <td className="rv-budget-fleet-row__attention">{attention}</td>
+    </tr>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main view
+// ---------------------------------------------------------------------------
+
+export function BudgetView() {
+  const { data: ravens, isLoading: ravensLoading } = useRavens();
+  const { data: fleetBudget, isLoading: fleetLoading } = useFleetBudget();
+  const [tableOpen, setTableOpen] = useState(false);
+
+  // Cache per-ravn budget data collected by attention entries
+  const [budgetCache, setBudgetCache] = useState<Record<string, BudgetState>>({});
+
+  const handleClassified = useCallback(
+    (ravnId: string, _attention: BudgetAttention, budget: BudgetState) => {
+      setBudgetCache((prev) => {
+        if (prev[ravnId] === budget) return prev;
+        return { ...prev, [ravnId]: budget };
+      });
+    },
+    [],
+  );
+
+  if (ravensLoading || fleetLoading) {
+    return (
+      <div className="rv-budget-view">
+        <div className="rv-budget-view__loading">
+          <StateDot state="processing" pulse />
+          <span>loading budget…</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rv-budget-view">
+      {/* ── Hero card ─────────────────────────────────────────────────── */}
+      {fleetBudget && <HeroCard budget={fleetBudget} />}
+
+      {/* ── Three attention columns ─────────────────────────────────── */}
+      <div className="rv-budget-attention-columns" role="group" aria-label="budget attention">
+        {ATTENTION_COLUMNS.map(({ key, label }) => (
+          <section key={key} className="rv-budget-attention-col" aria-label={label}>
+            <h3 className="rv-budget-attention-col__title">{label}</h3>
+            {(ravens ?? []).map((ravn) => (
+              <RavnAttentionEntry
+                key={ravn.id}
+                ravn={ravn}
+                targetAttention={key}
+                onClassified={handleClassified}
+              />
+            ))}
+          </section>
+        ))}
+      </div>
+
+      {/* ── Collapsible fleet table ─────────────────────────────────── */}
+      <div className="rv-budget-fleet">
+        <button
+          type="button"
+          className="rv-budget-fleet__toggle"
+          aria-expanded={tableOpen}
+          onClick={() => setTableOpen((v) => !v)}
+        >
+          {tableOpen ? '▼' : '▶'} full fleet table ({ravens?.length ?? 0} ravens)
+        </button>
+        {tableOpen && (
+          <table className="rv-budget-fleet-table" aria-label="fleet budget table">
+            <thead>
+              <tr>
+                <th>ravn</th>
+                <th>spent</th>
+                <th>cap</th>
+                <th>usage</th>
+                <th>attention</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(ravens ?? []).map((ravn) => (
+                <FleetRow key={ravn.id} ravn={ravn} budget={budgetCache[ravn.id]} />
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web-next/packages/plugin-ravn/src/ui/EventsView.stories.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/EventsView.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ServicesProvider } from '@niuulabs/plugin-sdk';
+import { EventsView } from './EventsView';
+import { createMockPersonaStore } from '../adapters/mock';
+
+const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+const meta: Meta<typeof EventsView> = {
+  title: 'Ravn/EventsView',
+  component: EventsView,
+};
+
+export default meta;
+type Story = StoryObj<typeof EventsView>;
+
+export const Default: Story = {
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={client}>
+        <ServicesProvider services={{ 'ravn.personas': createMockPersonaStore() }}>
+          <Story />
+        </ServicesProvider>
+      </QueryClientProvider>
+    ),
+  ],
+};

--- a/web-next/packages/plugin-ravn/src/ui/EventsView.test.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/EventsView.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { EventsView } from './EventsView';
+import { createMockPersonaStore } from '../adapters/mock';
+import { wrapWithServices } from '../testing/wrapWithRavn';
+
+const wrap = wrapWithServices;
+
+const services = { 'ravn.personas': createMockPersonaStore() };
+
+describe('EventsView', () => {
+  it('shows loading state initially', () => {
+    render(<EventsView />, { wrapper: wrap(services) });
+    expect(screen.getByText(/loading event catalog/i)).toBeInTheDocument();
+  });
+
+  it('renders event cards after loading', async () => {
+    render(<EventsView />, { wrapper: wrap(services) });
+    await waitFor(() => expect(screen.getByLabelText(/event graph/i)).toBeInTheDocument());
+  });
+
+  it('shows event count', async () => {
+    render(<EventsView />, { wrapper: wrap(services) });
+    await waitFor(() => expect(screen.getByText(/events/i)).toBeInTheDocument());
+  });
+
+  it('renders code.changed event', async () => {
+    render(<EventsView />, { wrapper: wrap(services) });
+    await waitFor(() => expect(screen.getByLabelText('event code.changed')).toBeInTheDocument());
+  });
+
+  it('shows produces/consumes edge labels', async () => {
+    render(<EventsView />, { wrapper: wrap(services) });
+    await waitFor(() => expect(screen.getAllByText('produces').length).toBeGreaterThan(0));
+    await waitFor(() => expect(screen.getAllByText('consumes').length).toBeGreaterThan(0));
+  });
+
+  it('clicking a persona pill highlights it', async () => {
+    render(<EventsView />, { wrapper: wrap(services) });
+    await waitFor(() => expect(screen.getByLabelText('event code.changed')).toBeInTheDocument());
+    const coderBtn = screen.getAllByRole('button', { name: 'coder' })[0]!;
+    fireEvent.click(coderBtn);
+    expect(coderBtn).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('shows persona filter indicator when persona is selected', async () => {
+    render(<EventsView />, { wrapper: wrap(services) });
+    await waitFor(() => expect(screen.getByLabelText('event code.changed')).toBeInTheDocument());
+    const coderBtn = screen.getAllByRole('button', { name: 'coder' })[0]!;
+    fireEvent.click(coderBtn);
+    expect(screen.getByText(/filtering by/i)).toBeInTheDocument();
+  });
+
+  it('clear button removes persona filter', async () => {
+    render(<EventsView />, { wrapper: wrap(services) });
+    await waitFor(() => expect(screen.getByLabelText('event code.changed')).toBeInTheDocument());
+    const coderBtn = screen.getAllByRole('button', { name: 'coder' })[0]!;
+    fireEvent.click(coderBtn);
+    const clearBtn = screen.getByLabelText(/clear persona filter/i);
+    fireEvent.click(clearBtn);
+    expect(screen.queryByText(/filtering by/i)).not.toBeInTheDocument();
+  });
+
+  it('shows error state when service fails', async () => {
+    const failing = {
+      listPersonas: async () => {
+        throw new Error('fetch failed');
+      },
+    };
+    render(<EventsView />, { wrapper: wrap({ 'ravn.personas': failing }) });
+    await waitFor(() => expect(screen.getByText(/failed to load personas/i)).toBeInTheDocument());
+  });
+});

--- a/web-next/packages/plugin-ravn/src/ui/EventsView.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/EventsView.tsx
@@ -1,0 +1,191 @@
+/**
+ * EventsView — produces / consumes graph.
+ *
+ * Derives the event catalog from personas.
+ * Layout: event nodes centred, producer persona nodes on left, consumer persona nodes on right.
+ * Click a persona node to highlight its events; click elsewhere to reset.
+ */
+
+import { useState, useMemo } from 'react';
+import { StateDot } from '@niuulabs/ui';
+import { usePersonas } from './usePersonas';
+import type { PersonaSummary } from '../ports';
+
+interface EventNode {
+  name: string;
+  producers: string[];
+  consumers: string[];
+}
+
+function buildEventGraph(personas: PersonaSummary[]): EventNode[] {
+  const map = new Map<string, EventNode>();
+
+  const ensure = (name: string) => {
+    if (!map.has(name)) map.set(name, { name, producers: [], consumers: [] });
+    return map.get(name)!;
+  };
+
+  for (const p of personas) {
+    if (p.producesEvent) ensure(p.producesEvent).producers.push(p.name);
+    for (const e of p.consumesEvents) ensure(e).consumers.push(p.name);
+  }
+
+  return Array.from(map.values()).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+interface EventCardProps {
+  event: EventNode;
+  dimmed: boolean;
+  selectedPersona: string | null;
+  onPersonaClick: (name: string) => void;
+}
+
+function PersonaPill({
+  name,
+  role,
+  selected,
+  onClick,
+}: {
+  name: string;
+  role: 'producer' | 'consumer';
+  selected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={`rv-event-persona${selected ? ' rv-event-persona--selected' : ''}`}
+      data-role={role}
+      onClick={onClick}
+      aria-pressed={selected}
+    >
+      {name}
+    </button>
+  );
+}
+
+function EventCard({ event, dimmed, selectedPersona, onPersonaClick }: EventCardProps) {
+  const isHighlighted =
+    selectedPersona === null ||
+    event.producers.includes(selectedPersona) ||
+    event.consumers.includes(selectedPersona);
+
+  return (
+    <article
+      className={`rv-event-card${dimmed && !isHighlighted ? ' rv-event-card--dimmed' : ''}`}
+      aria-label={`event ${event.name}`}
+    >
+      <div className="rv-event-card__name">{event.name}</div>
+      <div className="rv-event-card__edges">
+        {event.producers.length > 0 && (
+          <div className="rv-event-card__edge-group rv-event-card__edge-group--produces">
+            <span className="rv-event-card__edge-label">produces</span>
+            <div className="rv-event-card__personas">
+              {event.producers.map((name) => (
+                <PersonaPill
+                  key={name}
+                  name={name}
+                  role="producer"
+                  selected={selectedPersona === name}
+                  onClick={() => onPersonaClick(name)}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+        {event.consumers.length > 0 && (
+          <div className="rv-event-card__edge-group rv-event-card__edge-group--consumes">
+            <span className="rv-event-card__edge-label">consumes</span>
+            <div className="rv-event-card__personas">
+              {event.consumers.map((name) => (
+                <PersonaPill
+                  key={name}
+                  name={name}
+                  role="consumer"
+                  selected={selectedPersona === name}
+                  onClick={() => onPersonaClick(name)}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </article>
+  );
+}
+
+export function EventsView() {
+  const { data: personas, isLoading, isError } = usePersonas();
+  const [selectedPersona, setSelectedPersona] = useState<string | null>(null);
+
+  const events = useMemo(() => buildEventGraph(personas ?? []), [personas]);
+
+  const handlePersonaClick = (name: string) => {
+    setSelectedPersona((prev) => (prev === name ? null : name));
+  };
+
+  if (isLoading) {
+    return (
+      <div className="rv-events-view">
+        <div className="rv-events-view__loading">
+          <StateDot state="processing" pulse />
+          <span>loading event catalog…</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="rv-events-view">
+        <div className="rv-events-view__error">failed to load personas</div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="rv-events-view"
+      onClick={(e) => {
+        if ((e.target as HTMLElement).closest('.rv-event-persona') === null) {
+          setSelectedPersona(null);
+        }
+      }}
+    >
+      <div className="rv-events-view__header">
+        <span className="rv-events-view__count">
+          <strong>{events.length}</strong> event{events.length !== 1 ? 's' : ''}
+        </span>
+        {selectedPersona && (
+          <span className="rv-events-view__persona-filter">
+            filtering by <strong>{selectedPersona}</strong>
+            <button
+              type="button"
+              className="rv-events-view__clear"
+              onClick={() => setSelectedPersona(null)}
+              aria-label="clear persona filter"
+            >
+              ×
+            </button>
+          </span>
+        )}
+      </div>
+
+      {events.length === 0 ? (
+        <div className="rv-events-view__empty">no events defined</div>
+      ) : (
+        <div className="rv-events-view__graph" role="region" aria-label="event graph">
+          {events.map((event) => (
+            <EventCard
+              key={event.name}
+              event={event}
+              dimmed={selectedPersona !== null}
+              selectedPersona={selectedPersona}
+              onPersonaClick={handlePersonaClick}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web-next/packages/plugin-ravn/src/ui/LogView.stories.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/LogView.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ServicesProvider } from '@niuulabs/plugin-sdk';
+import { LogView } from './LogView';
+import { createMockSessionStream, createMockRavenStream } from '../adapters/mock';
+
+const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+const meta: Meta<typeof LogView> = {
+  title: 'Ravn/LogView',
+  component: LogView,
+};
+
+export default meta;
+type Story = StoryObj<typeof LogView>;
+
+export const Default: Story = {
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={client}>
+        <ServicesProvider
+          services={{
+            'ravn.sessions': createMockSessionStream(),
+            'ravn.ravens': createMockRavenStream(),
+          }}
+        >
+          <div className="rv-story-wrapper--tall">
+            <Story />
+          </div>
+        </ServicesProvider>
+      </QueryClientProvider>
+    ),
+  ],
+};

--- a/web-next/packages/plugin-ravn/src/ui/LogView.test.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/LogView.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { LogView } from './LogView';
+import { createMockSessionStream, createMockRavenStream } from '../adapters/mock';
+import { wrapWithServices } from '../testing/wrapWithRavn';
+
+const wrap = wrapWithServices;
+
+const services = {
+  'ravn.sessions': createMockSessionStream(),
+  'ravn.ravens': createMockRavenStream(),
+};
+
+describe('LogView', () => {
+  it('renders the log table', async () => {
+    render(<LogView />, { wrapper: wrap(services) });
+    await waitFor(() => expect(screen.getByLabelText(/log stream/i)).toBeInTheDocument(), {
+      timeout: 3000,
+    });
+  });
+
+  it('shows all four column headers', async () => {
+    render(<LogView />, { wrapper: wrap(services) });
+    await waitFor(() => {
+      expect(screen.getByText('time')).toBeInTheDocument();
+      expect(screen.getByText('raven')).toBeInTheDocument();
+      expect(screen.getByText('kind')).toBeInTheDocument();
+      expect(screen.getByText('body')).toBeInTheDocument();
+    });
+  });
+
+  it('shows log entries from sessions', async () => {
+    render(<LogView />, { wrapper: wrap(services) });
+    // Wait for entries to appear (mock sessions have messages)
+    await waitFor(() =>
+      expect(screen.getByRole('log', { name: /event log/i })).toBeInTheDocument(),
+    );
+    await waitFor(
+      () => {
+        const rows = document.querySelectorAll('.rv-log-row');
+        expect(rows.length).toBeGreaterThan(0);
+      },
+      { timeout: 3000 },
+    );
+  });
+
+  it('renders the search input', () => {
+    render(<LogView />, { wrapper: wrap(services) });
+    expect(screen.getByRole('searchbox', { name: /search log/i })).toBeInTheDocument();
+  });
+
+  it('renders kind filter buttons', () => {
+    render(<LogView />, { wrapper: wrap(services) });
+    expect(screen.getByRole('button', { name: 'user' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'asst' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'emit' })).toBeInTheDocument();
+  });
+
+  it('kind filter toggles aria-pressed', () => {
+    render(<LogView />, { wrapper: wrap(services) });
+    const userBtn = screen.getByRole('button', { name: 'user' });
+    expect(userBtn).toHaveAttribute('aria-pressed', 'false');
+    fireEvent.click(userBtn);
+    expect(userBtn).toHaveAttribute('aria-pressed', 'true');
+    fireEvent.click(userBtn);
+    expect(userBtn).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('auto-tail checkbox is checked by default', () => {
+    render(<LogView />, { wrapper: wrap(services) });
+    const checkbox = screen.getByRole('checkbox', { name: /auto-tail/i });
+    expect(checkbox).toBeChecked();
+  });
+
+  it('unchecking auto-tail works', () => {
+    render(<LogView />, { wrapper: wrap(services) });
+    const checkbox = screen.getByRole('checkbox', { name: /auto-tail/i });
+    fireEvent.click(checkbox);
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it('shows footer with entry count', async () => {
+    render(<LogView />, { wrapper: wrap(services) });
+    await waitFor(() => expect(screen.getByText(/entries/i)).toBeInTheDocument(), {
+      timeout: 3000,
+    });
+  });
+
+  it('raven selector renders options', async () => {
+    render(<LogView />, { wrapper: wrap(services) });
+    await waitFor(() => {
+      const select = screen.getByRole('combobox', { name: /filter by raven/i });
+      expect(select).toBeInTheDocument();
+    });
+  });
+});

--- a/web-next/packages/plugin-ravn/src/ui/LogView.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/LogView.tsx
@@ -1,0 +1,272 @@
+/**
+ * LogView — monospace event stream across all sessions.
+ *
+ * Columns: time · raven · kind · body
+ * Features: free-text filter, kind filter, auto-tail toggle.
+ */
+
+import { useState, useEffect, useRef, useMemo } from 'react';
+import { useSessions, useMessages } from './useSessions';
+import { useRavens } from './useRavens';
+import {
+  applyLogFilter,
+  EMPTY_LOG_FILTER,
+  type LogEntry,
+  type LogFilter,
+} from '../application/logFilter';
+import type { MessageKind } from '../domain/message';
+
+const ALL_KINDS: MessageKind[] = [
+  'user',
+  'asst',
+  'system',
+  'tool_call',
+  'tool_result',
+  'emit',
+  'think',
+];
+
+const KIND_COLOR: Record<MessageKind, string> = {
+  user: 'rv-log-row__kind--user',
+  asst: 'rv-log-row__kind--asst',
+  system: 'rv-log-row__kind--system',
+  tool_call: 'rv-log-row__kind--tool-call',
+  tool_result: 'rv-log-row__kind--tool-result',
+  emit: 'rv-log-row__kind--emit',
+  think: 'rv-log-row__kind--think',
+};
+
+import { formatTime } from './formatTime';
+
+function truncateBody(content: string, maxLen = 120): string {
+  if (content.length <= maxLen) return content;
+  return content.slice(0, maxLen) + '…';
+}
+
+// ---------------------------------------------------------------------------
+// Hooks to assemble log entries
+// ---------------------------------------------------------------------------
+
+/** Fetches messages for a single session and returns (ravnId, personaName, messages). */
+function useSessionLog(sessionId: string, ravnId: string, personaName: string) {
+  const { data: messages } = useMessages(sessionId);
+  return useMemo<LogEntry[]>(
+    () =>
+      (messages ?? []).map((message) => ({
+        message,
+        ravnId,
+        personaName,
+      })),
+    [messages, ravnId, personaName],
+  );
+}
+
+/** Assembles a sorted log from all sessions. */
+function useAllLogEntries(): LogEntry[] {
+  const { data: sessions } = useSessions();
+  const { data: ravens } = useRavens();
+
+  // Build ravnId -> personaName map
+  const ravenMap = useMemo(() => {
+    const m = new Map<string, string>();
+    (ravens ?? []).forEach((r) => m.set(r.id, r.personaName));
+    return m;
+  }, [ravens]);
+
+  // Flatten sessions to log entries (we call useSessionLog for each)
+  // Note: hook count must be stable — we pass up to 10 sessions (mock has 6)
+  const MAX_SESSIONS = 10;
+  const padded = useMemo(() => {
+    const arr = sessions ?? [];
+    return Array.from({ length: MAX_SESSIONS }, (_, i) => arr[i] ?? null);
+  }, [sessions]);
+
+  const e0 = useSessionLog(
+    padded[0]?.id ?? '',
+    padded[0]?.ravnId ?? '',
+    padded[0]?.personaName ?? '',
+  );
+  const e1 = useSessionLog(
+    padded[1]?.id ?? '',
+    padded[1]?.ravnId ?? '',
+    padded[1]?.personaName ?? '',
+  );
+  const e2 = useSessionLog(
+    padded[2]?.id ?? '',
+    padded[2]?.ravnId ?? '',
+    padded[2]?.personaName ?? '',
+  );
+  const e3 = useSessionLog(
+    padded[3]?.id ?? '',
+    padded[3]?.ravnId ?? '',
+    padded[3]?.personaName ?? '',
+  );
+  const e4 = useSessionLog(
+    padded[4]?.id ?? '',
+    padded[4]?.ravnId ?? '',
+    padded[4]?.personaName ?? '',
+  );
+  const e5 = useSessionLog(
+    padded[5]?.id ?? '',
+    padded[5]?.ravnId ?? '',
+    padded[5]?.personaName ?? '',
+  );
+  const e6 = useSessionLog(
+    padded[6]?.id ?? '',
+    padded[6]?.ravnId ?? '',
+    padded[6]?.personaName ?? '',
+  );
+  const e7 = useSessionLog(
+    padded[7]?.id ?? '',
+    padded[7]?.ravnId ?? '',
+    padded[7]?.personaName ?? '',
+  );
+  const e8 = useSessionLog(
+    padded[8]?.id ?? '',
+    padded[8]?.ravnId ?? '',
+    padded[8]?.personaName ?? '',
+  );
+  const e9 = useSessionLog(
+    padded[9]?.id ?? '',
+    padded[9]?.ravnId ?? '',
+    padded[9]?.personaName ?? '',
+  );
+
+  return useMemo(() => {
+    const all = [...e0, ...e1, ...e2, ...e3, ...e4, ...e5, ...e6, ...e7, ...e8, ...e9];
+    // Enrich ravnId from ravenMap where possible
+    const enriched = all.map((entry) => ({
+      ...entry,
+      personaName: ravenMap.get(entry.ravnId) ?? entry.personaName,
+    }));
+    return enriched.sort((a, b) => a.message.ts.localeCompare(b.message.ts));
+  }, [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9, ravenMap]);
+}
+
+// ---------------------------------------------------------------------------
+// Log row
+// ---------------------------------------------------------------------------
+
+function LogRow({ entry }: { entry: LogEntry }) {
+  const { message, personaName } = entry;
+  const body = message.toolName ? `[${message.toolName}] ${message.content}` : message.content;
+
+  return (
+    <tr className="rv-log-row" data-kind={message.kind}>
+      <td className="rv-log-row__time">{formatTime(message.ts)}</td>
+      <td className="rv-log-row__raven">{personaName}</td>
+      <td className={`rv-log-row__kind ${KIND_COLOR[message.kind]}`}>{message.kind}</td>
+      <td className="rv-log-row__body">{truncateBody(body)}</td>
+    </tr>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function LogView() {
+  const allEntries = useAllLogEntries();
+  const { data: ravens } = useRavens();
+
+  const [filter, setFilter] = useState<LogFilter>(EMPTY_LOG_FILTER);
+  const [autoTail, setAutoTail] = useState(true);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  const filtered = useMemo(() => applyLogFilter(allEntries, filter), [allEntries, filter]);
+
+  useEffect(() => {
+    if (autoTail) {
+      bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [filtered, autoTail]);
+
+  const toggleKind = (kind: MessageKind) => {
+    setFilter((prev) => {
+      const kinds = prev.kinds.includes(kind)
+        ? prev.kinds.filter((k) => k !== kind)
+        : [...prev.kinds, kind];
+      return { ...prev, kinds };
+    });
+  };
+
+  return (
+    <div className="rv-log-view">
+      {/* ── Filter bar ──────────────────────────────────────────────── */}
+      <div className="rv-log-view__filters" role="search" aria-label="log filters">
+        <input
+          type="search"
+          className="rv-log-view__search"
+          placeholder="filter log…"
+          value={filter.query}
+          aria-label="search log"
+          onChange={(e) => setFilter((prev) => ({ ...prev, query: e.target.value }))}
+        />
+        <select
+          className="rv-log-view__raven-select"
+          value={filter.ravnId}
+          aria-label="filter by raven"
+          onChange={(e) => setFilter((prev) => ({ ...prev, ravnId: e.target.value }))}
+        >
+          <option value="">all ravens</option>
+          {(ravens ?? []).map((r) => (
+            <option key={r.id} value={r.id}>
+              {r.personaName}
+            </option>
+          ))}
+        </select>
+        <div className="rv-log-view__kind-filters" role="group" aria-label="kind filters">
+          {ALL_KINDS.map((kind) => (
+            <button
+              key={kind}
+              type="button"
+              className={`rv-log-view__kind-btn${filter.kinds.includes(kind) ? ' rv-log-view__kind-btn--active' : ''}`}
+              aria-pressed={filter.kinds.includes(kind)}
+              onClick={() => toggleKind(kind)}
+            >
+              {kind}
+            </button>
+          ))}
+        </div>
+        <label className="rv-log-view__auto-tail">
+          <input
+            type="checkbox"
+            checked={autoTail}
+            onChange={(e) => setAutoTail(e.target.checked)}
+            aria-label="auto-tail"
+          />
+          auto-tail
+        </label>
+      </div>
+
+      {/* ── Stream table ─────────────────────────────────────────────── */}
+      <div className="rv-log-view__stream" role="log" aria-label="event log">
+        <table className="rv-log-table" aria-label="log stream">
+          <thead>
+            <tr>
+              <th className="rv-log-table__th--time">time</th>
+              <th className="rv-log-table__th--raven">raven</th>
+              <th className="rv-log-table__th--kind">kind</th>
+              <th className="rv-log-table__th--body">body</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((entry) => (
+              <LogRow key={entry.message.id} entry={entry} />
+            ))}
+          </tbody>
+        </table>
+        {filtered.length === 0 && (
+          <div className="rv-log-view__empty">
+            {allEntries.length === 0 ? 'no log entries yet' : 'no entries match the current filter'}
+          </div>
+        )}
+        <div ref={bottomRef} />
+      </div>
+
+      <div className="rv-log-view__footer">
+        {filtered.length} / {allEntries.length} entries
+      </div>
+    </div>
+  );
+}

--- a/web-next/packages/plugin-ravn/src/ui/MessageRow.stories.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/MessageRow.stories.tsx
@@ -1,0 +1,131 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { MessageRow } from './MessageRow';
+import type { Message } from '../domain/message';
+
+function msg(overrides: Partial<Message>): Message {
+  return {
+    id: '00000000-0000-4000-8000-000000000001',
+    sessionId: 'sess-1',
+    kind: 'user',
+    content: 'hello',
+    ts: '2026-04-15T09:12:35Z',
+    ...overrides,
+  };
+}
+
+const meta: Meta<typeof MessageRow> = {
+  title: 'Ravn/MessageRow',
+  component: MessageRow,
+};
+
+export default meta;
+type Story = StoryObj<typeof MessageRow>;
+
+export const User: Story = {
+  args: { message: msg({ kind: 'user', content: 'Please implement the login form' }) },
+};
+
+export const Assistant: Story = {
+  args: {
+    message: msg({
+      kind: 'asst',
+      content: "I'll create the login form at `src/auth/LoginForm.tsx`.",
+    }),
+  },
+};
+
+export const System: Story = {
+  args: {
+    message: msg({
+      kind: 'system',
+      content: '# coding-agent\nYou are a senior software engineer.',
+    }),
+  },
+};
+
+export const ToolCall: Story = {
+  args: {
+    message: msg({
+      kind: 'tool_call',
+      toolName: 'file.read',
+      content: JSON.stringify({ path: 'src/auth/LoginForm.tsx' }, null, 2),
+    }),
+  },
+};
+
+export const ToolResult: Story = {
+  args: {
+    message: msg({
+      kind: 'tool_result',
+      toolName: 'file.read',
+      content: JSON.stringify(
+        { content: '// LoginForm.tsx\nexport function LoginForm() {}' },
+        null,
+        2,
+      ),
+    }),
+  },
+};
+
+export const Emit: Story = {
+  args: {
+    message: msg({
+      kind: 'emit',
+      content: JSON.stringify({
+        event: 'code.changed',
+        payload: { file: 'src/auth/LoginForm.tsx' },
+      }),
+    }),
+  },
+};
+
+export const Think: Story = {
+  args: {
+    message: msg({
+      kind: 'think',
+      content:
+        'I need to check the existing auth setup first. Let me read the directory structure.',
+    }),
+  },
+};
+
+/** Gallery of all message kinds */
+export const Gallery: Story = {
+  render: () => (
+    <div className="rv-story-wrapper">
+      <MessageRow message={msg({ kind: 'user', content: 'Please implement the login form' })} />
+      <MessageRow
+        message={msg({
+          kind: 'asst',
+          content: "I'll create the login form at `src/auth/LoginForm.tsx`.",
+        })}
+      />
+      <MessageRow
+        message={msg({ kind: 'system', content: '# System: coding-agent persona active.' })}
+      />
+      <MessageRow
+        message={msg({
+          kind: 'tool_call',
+          toolName: 'file.read',
+          content: '{"path":"src/auth/LoginForm.tsx"}',
+        })}
+      />
+      <MessageRow
+        message={msg({
+          kind: 'tool_result',
+          toolName: 'file.read',
+          content: '{"content":"// file not found"}',
+        })}
+      />
+      <MessageRow
+        message={msg({
+          kind: 'emit',
+          content: '{"event":"code.changed","payload":{"file":"src/auth/LoginForm.tsx"}}',
+        })}
+      />
+      <MessageRow
+        message={msg({ kind: 'think', content: 'I need to check the existing auth setup first.' })}
+      />
+    </div>
+  ),
+};

--- a/web-next/packages/plugin-ravn/src/ui/MessageRow.test.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/MessageRow.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MessageRow } from './MessageRow';
+import type { Message } from '../domain/message';
+
+function msg(overrides: Partial<Message>): Message {
+  return {
+    id: '00000000-0000-4000-8000-000000000001',
+    sessionId: 'sess-1',
+    kind: 'user',
+    content: 'hello',
+    ts: '2026-04-15T09:12:35Z',
+    ...overrides,
+  };
+}
+
+describe('MessageRow', () => {
+  describe('user kind', () => {
+    it('renders content', () => {
+      render(<MessageRow message={msg({ kind: 'user', content: 'hello world' })} />);
+      expect(screen.getByText('hello world')).toBeInTheDocument();
+    });
+
+    it('has data-kind=user', () => {
+      const { container } = render(<MessageRow message={msg({ kind: 'user' })} />);
+      expect(container.querySelector('[data-kind="user"]')).toBeInTheDocument();
+    });
+  });
+
+  describe('asst kind', () => {
+    it('renders content', () => {
+      render(<MessageRow message={msg({ kind: 'asst', content: 'assistant reply' })} />);
+      expect(screen.getByText('assistant reply')).toBeInTheDocument();
+    });
+
+    it('has data-kind=asst', () => {
+      const { container } = render(<MessageRow message={msg({ kind: 'asst' })} />);
+      expect(container.querySelector('[data-kind="asst"]')).toBeInTheDocument();
+    });
+  });
+
+  describe('system kind', () => {
+    it('renders content with italic style class', () => {
+      const { container } = render(
+        <MessageRow message={msg({ kind: 'system', content: 'system context' })} />,
+      );
+      expect(screen.getByText('system context')).toBeInTheDocument();
+      expect(container.querySelector('.rv-msg__body--italic')).toBeInTheDocument();
+    });
+  });
+
+  describe('tool_call kind', () => {
+    it('renders tool name', () => {
+      render(
+        <MessageRow
+          message={msg({ kind: 'tool_call', toolName: 'file.read', content: '{"path":"x"}' })}
+        />,
+      );
+      expect(screen.getByText('file.read')).toBeInTheDocument();
+    });
+
+    it('renders call badge', () => {
+      render(
+        <MessageRow message={msg({ kind: 'tool_call', toolName: 'file.read', content: '{}' })} />,
+      );
+      expect(screen.getByText('call')).toBeInTheDocument();
+    });
+
+    it('renders content as code', () => {
+      const { container } = render(
+        <MessageRow message={msg({ kind: 'tool_call', content: '{"path":"x"}' })} />,
+      );
+      expect(container.querySelector('pre')).toBeInTheDocument();
+    });
+
+    it('falls back to tool when toolName is absent', () => {
+      render(<MessageRow message={msg({ kind: 'tool_call', content: '{}' })} />);
+      expect(screen.getByText('tool')).toBeInTheDocument();
+    });
+  });
+
+  describe('tool_result kind', () => {
+    it('renders result badge', () => {
+      render(<MessageRow message={msg({ kind: 'tool_result', content: '{}' })} />);
+      expect(screen.getByText('result')).toBeInTheDocument();
+    });
+  });
+
+  describe('emit kind', () => {
+    it('renders emit badge', () => {
+      render(
+        <MessageRow
+          message={msg({ kind: 'emit', content: '{"event":"code.changed","payload":{}}' })}
+        />,
+      );
+      expect(screen.getByText('emit')).toBeInTheDocument();
+    });
+
+    it('renders event name from JSON', () => {
+      render(
+        <MessageRow
+          message={msg({ kind: 'emit', content: '{"event":"code.changed","payload":{}}' })}
+        />,
+      );
+      expect(screen.getByText('code.changed')).toBeInTheDocument();
+    });
+
+    it('handles invalid JSON gracefully', () => {
+      render(<MessageRow message={msg({ kind: 'emit', content: 'not json' })} />);
+      expect(screen.getByText('event')).toBeInTheDocument();
+    });
+  });
+
+  describe('think kind', () => {
+    it('renders collapsed by default', () => {
+      render(<MessageRow message={msg({ kind: 'think', content: 'my reasoning' })} />);
+      expect(screen.queryByText('my reasoning')).not.toBeInTheDocument();
+      expect(screen.getByText('show reasoning')).toBeInTheDocument();
+    });
+
+    it('expands when toggle is clicked', () => {
+      render(<MessageRow message={msg({ kind: 'think', content: 'my reasoning' })} />);
+      fireEvent.click(screen.getByText('show reasoning'));
+      expect(screen.getByText('my reasoning')).toBeInTheDocument();
+      expect(screen.getByText('hide reasoning')).toBeInTheDocument();
+    });
+
+    it('collapses again on second click', () => {
+      render(<MessageRow message={msg({ kind: 'think', content: 'my reasoning' })} />);
+      fireEvent.click(screen.getByText('show reasoning'));
+      fireEvent.click(screen.getByText('hide reasoning'));
+      expect(screen.queryByText('my reasoning')).not.toBeInTheDocument();
+    });
+
+    it('has aria-expanded', () => {
+      render(<MessageRow message={msg({ kind: 'think', content: 'my reasoning' })} />);
+      const btn = screen.getByText('show reasoning').closest('button');
+      expect(btn).toHaveAttribute('aria-expanded', 'false');
+    });
+  });
+});

--- a/web-next/packages/plugin-ravn/src/ui/MessageRow.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/MessageRow.tsx
@@ -1,0 +1,125 @@
+/**
+ * MessageRow — renders a single transcript message with per-kind idioms.
+ *
+ * Kinds:
+ *   user        — operator input, indigo left border
+ *   asst        — assistant reply, neutral
+ *   system      — injected context, muted/italic
+ *   tool_call   — tool invocation, amber left border + monospace
+ *   tool_result — tool response, emerald left border + monospace
+ *   emit        — domain event emitted, cyan badge
+ *   think       — extended thinking scratchpad, purple, collapsed by default
+ */
+
+import { useState } from 'react';
+import type { Message } from '../domain/message';
+import { formatTime } from './formatTime';
+
+interface MessageRowProps {
+  message: Message;
+}
+
+function parseEmitContent(content: string): { event: string; payload: string } {
+  try {
+    const obj = JSON.parse(content) as { event?: string; payload?: unknown };
+    return {
+      event: obj.event ?? 'event',
+      payload: JSON.stringify(obj.payload ?? {}, null, 2),
+    };
+  } catch {
+    return { event: 'event', payload: content };
+  }
+}
+
+export function MessageRow({ message }: MessageRowProps) {
+  const [thinkExpanded, setThinkExpanded] = useState(false);
+
+  const time = formatTime(message.ts);
+
+  if (message.kind === 'user') {
+    return (
+      <div className="rv-msg rv-msg--user" data-kind="user">
+        <span className="rv-msg__time">{time}</span>
+        <div className="rv-msg__body">{message.content}</div>
+      </div>
+    );
+  }
+
+  if (message.kind === 'asst') {
+    return (
+      <div className="rv-msg rv-msg--asst" data-kind="asst">
+        <span className="rv-msg__time">{time}</span>
+        <div className="rv-msg__body">{message.content}</div>
+      </div>
+    );
+  }
+
+  if (message.kind === 'system') {
+    return (
+      <div className="rv-msg rv-msg--system" data-kind="system">
+        <span className="rv-msg__time">{time}</span>
+        <div className="rv-msg__body rv-msg__body--italic">{message.content}</div>
+      </div>
+    );
+  }
+
+  if (message.kind === 'tool_call') {
+    return (
+      <div className="rv-msg rv-msg--tool-call" data-kind="tool_call">
+        <span className="rv-msg__time">{time}</span>
+        <div className="rv-msg__tool-header">
+          <span className="rv-msg__tool-badge rv-msg__tool-badge--call">call</span>
+          <span className="rv-msg__tool-name">{message.toolName ?? 'tool'}</span>
+        </div>
+        <pre className="rv-msg__code">{message.content}</pre>
+      </div>
+    );
+  }
+
+  if (message.kind === 'tool_result') {
+    return (
+      <div className="rv-msg rv-msg--tool-result" data-kind="tool_result">
+        <span className="rv-msg__time">{time}</span>
+        <div className="rv-msg__tool-header">
+          <span className="rv-msg__tool-badge rv-msg__tool-badge--result">result</span>
+          <span className="rv-msg__tool-name">{message.toolName ?? 'tool'}</span>
+        </div>
+        <pre className="rv-msg__code">{message.content}</pre>
+      </div>
+    );
+  }
+
+  if (message.kind === 'emit') {
+    const { event, payload } = parseEmitContent(message.content);
+    return (
+      <div className="rv-msg rv-msg--emit" data-kind="emit">
+        <span className="rv-msg__time">{time}</span>
+        <div className="rv-msg__emit-header">
+          <span className="rv-msg__emit-badge">emit</span>
+          <span className="rv-msg__emit-event">{event}</span>
+        </div>
+        <pre className="rv-msg__code rv-msg__code--emit">{payload}</pre>
+      </div>
+    );
+  }
+
+  if (message.kind === 'think') {
+    return (
+      <div className="rv-msg rv-msg--think" data-kind="think">
+        <span className="rv-msg__time">{time}</span>
+        <button
+          type="button"
+          className="rv-msg__think-toggle"
+          aria-expanded={thinkExpanded}
+          onClick={() => setThinkExpanded((v) => !v)}
+        >
+          <span className="rv-msg__think-badge">think</span>
+          <span className="rv-msg__think-label">{thinkExpanded ? 'hide' : 'show'} reasoning</span>
+        </button>
+        {thinkExpanded && <pre className="rv-msg__code rv-msg__code--think">{message.content}</pre>}
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/web-next/packages/plugin-ravn/src/ui/RavnPage.test.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/RavnPage.test.tsx
@@ -1,7 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ServicesProvider } from '@niuulabs/plugin-sdk';
 import { RavnPage } from './RavnPage';
 import {
   createMockPersonaStore,
@@ -10,26 +8,17 @@ import {
   createMockSessionStream,
   createMockBudgetStream,
 } from '../adapters/mock';
+import { wrapWithServices } from '../testing/wrapWithRavn';
 
-function makeServices(overrides?: Record<string, unknown>) {
+const wrap = wrapWithServices;
+
+function allServices() {
   return {
     'ravn.personas': createMockPersonaStore(),
     'ravn.ravens': createMockRavenStream(),
-    'ravn.triggers': createMockTriggerStore(),
     'ravn.sessions': createMockSessionStream(),
+    'ravn.triggers': createMockTriggerStore(),
     'ravn.budget': createMockBudgetStream(),
-    ...overrides,
-  };
-}
-
-function wrap(services = makeServices()) {
-  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return function Wrapper({ children }: { children: React.ReactNode }) {
-    return (
-      <QueryClientProvider client={client}>
-        <ServicesProvider services={services}>{children}</ServicesProvider>
-      </QueryClientProvider>
-    );
   };
 }
 
@@ -39,33 +28,47 @@ beforeEach(() => {
 
 describe('RavnPage', () => {
   it('renders the ravn page wrapper', () => {
-    render(<RavnPage />, { wrapper: wrap() });
+    render(<RavnPage />, { wrapper: wrap(allServices()) });
     expect(screen.getByTestId('ravn-page')).toBeInTheDocument();
   });
 
   it('renders the ravn rune glyph', () => {
-    render(<RavnPage />, { wrapper: wrap() });
+    render(<RavnPage />, { wrapper: wrap(allServices()) });
     expect(screen.getByText('ᚱ')).toBeInTheDocument();
   });
 
   it('renders the page title', () => {
-    render(<RavnPage />, { wrapper: wrap() });
+    render(<RavnPage />, { wrapper: wrap(allServices()) });
     expect(screen.getByText(/Ravn · the flock/)).toBeInTheDocument();
   });
 
-  it('renders the tab navigation', () => {
-    render(<RavnPage />, { wrapper: wrap() });
+  it('renders overview and ravens tabs', () => {
+    render(<RavnPage />, { wrapper: wrap(allServices()) });
     expect(screen.getByTestId('ravn-tab-overview')).toBeInTheDocument();
     expect(screen.getByTestId('ravn-tab-ravens')).toBeInTheDocument();
   });
 
+  it('renders sessions, triggers, events, budget, log tabs', () => {
+    render(<RavnPage />, { wrapper: wrap(allServices()) });
+    expect(screen.getByRole('tab', { name: 'Sessions' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Triggers' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Events' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Budget' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Log' })).toBeInTheDocument();
+  });
+
   it('defaults to the overview tab', async () => {
-    render(<RavnPage />, { wrapper: wrap() });
+    render(<RavnPage />, { wrapper: wrap(allServices()) });
     await waitFor(() => expect(screen.getByTestId('overview-page')).toBeInTheDocument());
   });
 
+  it('Overview tab is selected by default', () => {
+    render(<RavnPage />, { wrapper: wrap(allServices()) });
+    expect(screen.getByTestId('ravn-tab-overview')).toHaveAttribute('aria-selected', 'true');
+  });
+
   it('switches to the ravens tab', async () => {
-    render(<RavnPage />, { wrapper: wrap() });
+    render(<RavnPage />, { wrapper: wrap(allServices()) });
     await waitFor(() => screen.getByTestId('ravn-tab-ravens'));
     fireEvent.click(screen.getByTestId('ravn-tab-ravens'));
     await waitFor(() => expect(screen.getByTestId('ravens-page')).toBeInTheDocument());
@@ -73,7 +76,7 @@ describe('RavnPage', () => {
   });
 
   it('switches back to overview tab', async () => {
-    render(<RavnPage />, { wrapper: wrap() });
+    render(<RavnPage />, { wrapper: wrap(allServices()) });
     await waitFor(() => screen.getByTestId('ravn-tab-ravens'));
     fireEvent.click(screen.getByTestId('ravn-tab-ravens'));
     await waitFor(() => screen.getByTestId('ravens-page'));
@@ -81,8 +84,41 @@ describe('RavnPage', () => {
     await waitFor(() => expect(screen.getByTestId('overview-page')).toBeInTheDocument());
   });
 
+  it('switching to Triggers tab shows triggers content', async () => {
+    render(<RavnPage />, { wrapper: wrap(allServices()) });
+    fireEvent.click(screen.getByRole('tab', { name: 'Triggers' }));
+    expect(screen.getByRole('tab', { name: 'Triggers' })).toHaveAttribute('aria-selected', 'true');
+    await waitFor(() =>
+      expect(screen.getByRole('region', { name: /cron triggers/i })).toBeInTheDocument(),
+    );
+  });
+
+  it('switching to Events tab shows events content', async () => {
+    render(<RavnPage />, { wrapper: wrap(allServices()) });
+    fireEvent.click(screen.getByRole('tab', { name: 'Events' }));
+    await waitFor(() => expect(screen.getByLabelText(/event graph/i)).toBeInTheDocument());
+  });
+
+  it('switching to Budget tab shows budget content', async () => {
+    render(<RavnPage />, { wrapper: wrap(allServices()) });
+    fireEvent.click(screen.getByRole('tab', { name: 'Budget' }));
+    await waitFor(() => expect(screen.getByLabelText(/fleet budget/i)).toBeInTheDocument());
+  });
+
+  it('switching to Log tab shows log content', async () => {
+    render(<RavnPage />, { wrapper: wrap(allServices()) });
+    fireEvent.click(screen.getByRole('tab', { name: 'Log' }));
+    expect(screen.getByRole('log', { name: /event log/i })).toBeInTheDocument();
+  });
+
+  it('tab panel has correct aria-labelledby', () => {
+    render(<RavnPage />, { wrapper: wrap(allServices()) });
+    const panel = screen.getByRole('tabpanel');
+    expect(panel).toHaveAttribute('aria-labelledby', 'ravn-tab-overview');
+  });
+
   it('persists active tab to localStorage', async () => {
-    render(<RavnPage />, { wrapper: wrap() });
+    render(<RavnPage />, { wrapper: wrap(allServices()) });
     await waitFor(() => screen.getByTestId('ravn-tab-ravens'));
     fireEvent.click(screen.getByTestId('ravn-tab-ravens'));
     expect(localStorage.getItem('ravn.tab')).toBe('"ravens"');
@@ -90,7 +126,7 @@ describe('RavnPage', () => {
 
   it('restores tab from localStorage on mount', async () => {
     localStorage.setItem('ravn.tab', '"ravens"');
-    render(<RavnPage />, { wrapper: wrap() });
+    render(<RavnPage />, { wrapper: wrap(allServices()) });
     await waitFor(() => expect(screen.getByTestId('ravens-page')).toBeInTheDocument());
   });
 });

--- a/web-next/packages/plugin-ravn/src/ui/RavnPage.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/RavnPage.tsx
@@ -2,16 +2,27 @@ import { useState, useCallback } from 'react';
 import { Rune } from '@niuulabs/ui';
 import { OverviewPage } from './OverviewPage';
 import { RavensPage } from './RavensPage';
+import { SessionsView } from './SessionsView';
+import { TriggersView } from './TriggersView';
+import { EventsView } from './EventsView';
+import { BudgetView } from './BudgetView';
+import { LogView } from './LogView';
 import { loadStorage, saveStorage } from './storage';
 import './RavnPage.css';
+import './ravn-views.css';
 
-export type RavnTab = 'overview' | 'ravens';
+export type RavnTab = 'overview' | 'ravens' | 'sessions' | 'triggers' | 'events' | 'budget' | 'log';
 
 const TAB_STORAGE_KEY = 'ravn.tab';
 
 const TABS: { id: RavnTab; label: string }[] = [
   { id: 'overview', label: 'Overview' },
   { id: 'ravens', label: 'Ravens' },
+  { id: 'sessions', label: 'Sessions' },
+  { id: 'triggers', label: 'Triggers' },
+  { id: 'events', label: 'Events' },
+  { id: 'budget', label: 'Budget' },
+  { id: 'log', label: 'Log' },
 ];
 
 export function RavnPage() {
@@ -57,6 +68,11 @@ export function RavnPage() {
       >
         {activeTab === 'overview' && <OverviewPage />}
         {activeTab === 'ravens' && <RavensPage />}
+        {activeTab === 'sessions' && <SessionsView />}
+        {activeTab === 'triggers' && <TriggersView />}
+        {activeTab === 'events' && <EventsView />}
+        {activeTab === 'budget' && <BudgetView />}
+        {activeTab === 'log' && <LogView />}
       </main>
     </div>
   );

--- a/web-next/packages/plugin-ravn/src/ui/SessionsView.stories.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/SessionsView.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ServicesProvider } from '@niuulabs/plugin-sdk';
+import { SessionsView } from './SessionsView';
+import { createMockSessionStream, createMockRavenStream } from '../adapters/mock';
+
+const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+function withProviders(services: Record<string, unknown>) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>
+        <ServicesProvider services={services}>{children}</ServicesProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+const meta: Meta<typeof SessionsView> = {
+  title: 'Ravn/SessionsView',
+  component: SessionsView,
+};
+
+export default meta;
+type Story = StoryObj<typeof SessionsView>;
+
+export const Default: Story = {
+  decorators: [
+    (Story) => {
+      const Wrapper = withProviders({
+        'ravn.sessions': createMockSessionStream(),
+        'ravn.ravens': createMockRavenStream(),
+      });
+      return (
+        <Wrapper>
+          <Story />
+        </Wrapper>
+      );
+    },
+  ],
+};
+
+export const ErrorState: Story = {
+  decorators: [
+    (Story) => {
+      const Wrapper = withProviders({
+        'ravn.sessions': {
+          listSessions: async () => {
+            throw new Error('service unavailable');
+          },
+        },
+        'ravn.ravens': createMockRavenStream(),
+      });
+      return (
+        <Wrapper>
+          <Story />
+        </Wrapper>
+      );
+    },
+  ],
+};

--- a/web-next/packages/plugin-ravn/src/ui/SessionsView.test.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/SessionsView.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { SessionsView } from './SessionsView';
+import { createMockSessionStream, createMockRavenStream } from '../adapters/mock';
+import { wrapWithServices } from '../testing/wrapWithRavn';
+
+const wrap = wrapWithServices;
+
+const services = {
+  'ravn.sessions': createMockSessionStream(),
+  'ravn.ravens': createMockRavenStream(),
+};
+
+describe('SessionsView', () => {
+  it('shows loading state initially', () => {
+    render(<SessionsView />, { wrapper: wrap(services) });
+    expect(screen.getByText(/loading sessions/i)).toBeInTheDocument();
+  });
+
+  it('shows session list after loading', async () => {
+    render(<SessionsView />, { wrapper: wrap(services) });
+    await waitFor(() => expect(screen.getByText('coding-agent')).toBeInTheDocument());
+  });
+
+  it('shows session count', async () => {
+    render(<SessionsView />, { wrapper: wrap(services) });
+    await waitFor(() => expect(screen.getByText('6')).toBeInTheDocument());
+  });
+
+  it('renders all sessions', async () => {
+    render(<SessionsView />, { wrapper: wrap(services) });
+    await waitFor(() => {
+      expect(screen.getByText('coding-agent')).toBeInTheDocument();
+      expect(screen.getByText('reviewer')).toBeInTheDocument();
+    });
+  });
+
+  it('loads transcript when session is selected', async () => {
+    render(<SessionsView />, { wrapper: wrap(services) });
+    await waitFor(() => expect(screen.getByText('coding-agent')).toBeInTheDocument());
+    // First session should be auto-selected and transcript loaded
+    await waitFor(() => expect(screen.getByRole('log')).toBeInTheDocument(), { timeout: 3000 });
+  });
+
+  it('shows transcript message count', async () => {
+    render(<SessionsView />, { wrapper: wrap(services) });
+    await waitFor(() => expect(screen.getByText(/messages/)).toBeInTheDocument(), {
+      timeout: 3000,
+    });
+  });
+
+  it('shows error state when service fails', async () => {
+    const failing = {
+      listSessions: async () => {
+        throw new Error('fetch failed');
+      },
+    };
+    render(<SessionsView />, {
+      wrapper: wrap({ 'ravn.sessions': failing, 'ravn.ravens': createMockRavenStream() }),
+    });
+    await waitFor(() => expect(screen.getByText(/failed to load sessions/i)).toBeInTheDocument());
+  });
+
+  it('clicking a session item selects it', async () => {
+    render(<SessionsView />, { wrapper: wrap(services) });
+    await waitFor(() =>
+      expect(screen.getAllByRole('button', { name: /session/ }).length).toBeGreaterThan(1),
+    );
+    const items = screen.getAllByRole('button', { name: /session/ });
+    fireEvent.click(items[1]!);
+    expect(items[1]).toHaveAttribute('aria-pressed', 'true');
+  });
+});

--- a/web-next/packages/plugin-ravn/src/ui/SessionsView.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/SessionsView.tsx
@@ -1,0 +1,160 @@
+/**
+ * SessionsView — split panel showing session list + live transcript.
+ *
+ * Left:  list of sessions sorted newest-first. Click to select.
+ * Right: message transcript for the selected session, with ActiveCursor
+ *        at the bottom when status === 'running'.
+ */
+
+import { useState, useEffect, useRef } from 'react';
+import { StateDot } from '@niuulabs/ui';
+import { useSessions, useMessages } from './useSessions';
+import { ActiveCursor } from './ActiveCursor';
+import { MessageRow } from './MessageRow';
+import type { Session } from '../domain/session';
+
+const STATUS_STATE = {
+  running: 'processing',
+  idle: 'idle',
+  stopped: 'healthy',
+  failed: 'failed',
+} as const;
+
+function SessionListItem({
+  session,
+  selected,
+  onSelect,
+}: {
+  session: Session;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={`rv-session-item${selected ? ' rv-session-item--active' : ''}`}
+      onClick={onSelect}
+      aria-pressed={selected}
+      aria-label={`session ${session.personaName}`}
+    >
+      <div className="rv-session-item__head">
+        <StateDot state={STATUS_STATE[session.status]} pulse={session.status === 'running'} />
+        <span className="rv-session-item__name">{session.personaName}</span>
+        <span className="rv-session-item__status">{session.status}</span>
+      </div>
+      <div className="rv-session-item__meta">
+        <span className="rv-session-item__model">{session.model}</span>
+        <span className="rv-session-item__ts">{session.createdAt.slice(0, 10)}</span>
+      </div>
+    </button>
+  );
+}
+
+function Transcript({ session }: { session: Session }) {
+  const { data: messages, isLoading, isError } = useMessages(session.id);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  if (isLoading) {
+    return (
+      <div className="rv-transcript__empty">
+        <StateDot state="processing" pulse />
+        <span>loading transcript…</span>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="rv-transcript__empty rv-transcript__empty--error">
+        failed to load messages
+      </div>
+    );
+  }
+
+  return (
+    <div className="rv-transcript" role="log" aria-label={`transcript for ${session.personaName}`}>
+      <div className="rv-transcript__header">
+        <span className="rv-transcript__persona">{session.personaName}</span>
+        <span className="rv-transcript__model">{session.model}</span>
+        <span className="rv-transcript__count">{messages?.length ?? 0} messages</span>
+      </div>
+      <div className="rv-transcript__body">
+        {messages?.map((msg) => (
+          <MessageRow key={msg.id} message={msg} />
+        ))}
+        <ActiveCursor status={session.status} className="rv-transcript__cursor" />
+        <div ref={bottomRef} />
+      </div>
+    </div>
+  );
+}
+
+export function SessionsView() {
+  const { data: sessions, isLoading, isError } = useSessions();
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const sorted = sessions
+    ? [...sessions].sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+    : [];
+  const selected = sorted.find((s) => s.id === selectedId) ?? sorted[0] ?? null;
+
+  if (isLoading) {
+    return (
+      <div className="rv-sessions-view">
+        <div className="rv-sessions-view__loading">
+          <StateDot state="processing" pulse />
+          <span>loading sessions…</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="rv-sessions-view">
+        <div className="rv-sessions-view__error">failed to load sessions</div>
+      </div>
+    );
+  }
+
+  if (!sorted.length) {
+    return (
+      <div className="rv-sessions-view">
+        <div className="rv-sessions-view__empty">no sessions yet</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rv-sessions-view">
+      {/* ── Session list ─────────────────────────────────────────────── */}
+      <aside className="rv-sessions-view__list" aria-label="session list">
+        <div className="rv-sessions-view__list-head">
+          <span className="rv-sessions-view__list-label">sessions</span>
+          <span className="rv-sessions-view__list-count">{sorted.length}</span>
+        </div>
+        {sorted.map((session) => (
+          <SessionListItem
+            key={session.id}
+            session={session}
+            selected={session.id === (selected?.id ?? null)}
+            onSelect={() => setSelectedId(session.id)}
+          />
+        ))}
+      </aside>
+
+      {/* ── Transcript ───────────────────────────────────────────────── */}
+      <main className="rv-sessions-view__transcript">
+        {selected ? (
+          <Transcript session={selected} />
+        ) : (
+          <div className="rv-transcript__empty">select a session</div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/web-next/packages/plugin-ravn/src/ui/TriggersView.stories.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/TriggersView.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ServicesProvider } from '@niuulabs/plugin-sdk';
+import { TriggersView } from './TriggersView';
+import { createMockTriggerStore } from '../adapters/mock';
+
+const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+const meta: Meta<typeof TriggersView> = {
+  title: 'Ravn/TriggersView',
+  component: TriggersView,
+};
+
+export default meta;
+type Story = StoryObj<typeof TriggersView>;
+
+export const Default: Story = {
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={client}>
+        <ServicesProvider services={{ 'ravn.triggers': createMockTriggerStore() }}>
+          <Story />
+        </ServicesProvider>
+      </QueryClientProvider>
+    ),
+  ],
+};

--- a/web-next/packages/plugin-ravn/src/ui/TriggersView.test.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/TriggersView.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { TriggersView } from './TriggersView';
+import { createMockTriggerStore } from '../adapters/mock';
+import { wrapWithServices } from '../testing/wrapWithRavn';
+
+const wrap = wrapWithServices;
+
+const services = { 'ravn.triggers': createMockTriggerStore() };
+
+describe('TriggersView', () => {
+  it('shows loading state initially', () => {
+    render(<TriggersView />, { wrapper: wrap(services) });
+    expect(screen.getByText(/loading triggers/i)).toBeInTheDocument();
+  });
+
+  it('renders trigger groups after loading', async () => {
+    render(<TriggersView />, { wrapper: wrap(services) });
+    await waitFor(() => expect(screen.getByText(/cron/i)).toBeInTheDocument());
+  });
+
+  it('shows all four kind groups', async () => {
+    render(<TriggersView />, { wrapper: wrap(services) });
+    await waitFor(() => {
+      expect(screen.getByRole('region', { name: /cron triggers/i })).toBeInTheDocument();
+      expect(screen.getByRole('region', { name: /event triggers/i })).toBeInTheDocument();
+      expect(screen.getByRole('region', { name: /webhook triggers/i })).toBeInTheDocument();
+      expect(screen.getByRole('region', { name: /manual triggers/i })).toBeInTheDocument();
+    });
+  });
+
+  it('shows total and active counts', async () => {
+    render(<TriggersView />, { wrapper: wrap(services) });
+    await waitFor(() => expect(screen.getByText(/total/i)).toBeInTheDocument());
+  });
+
+  it('shows persona names in rows', async () => {
+    render(<TriggersView />, { wrapper: wrap(services) });
+    await waitFor(() => {
+      expect(screen.getByText('health-auditor')).toBeInTheDocument();
+      expect(screen.getByText('reviewer')).toBeInTheDocument();
+    });
+  });
+
+  it('shows cron spec in code element', async () => {
+    render(<TriggersView />, { wrapper: wrap(services) });
+    await waitFor(() => expect(screen.getByText('0 * * * *')).toBeInTheDocument());
+  });
+
+  it('shows error state when service fails', async () => {
+    const failing = {
+      listTriggers: async () => {
+        throw new Error('fetch failed');
+      },
+    };
+    render(<TriggersView />, { wrapper: wrap({ 'ravn.triggers': failing }) });
+    await waitFor(() => expect(screen.getByText(/failed to load triggers/i)).toBeInTheDocument());
+  });
+});

--- a/web-next/packages/plugin-ravn/src/ui/TriggersView.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/TriggersView.tsx
@@ -1,0 +1,110 @@
+/**
+ * TriggersView — fleet-wide trigger table grouped by kind.
+ *
+ * Groups: cron | event | webhook | manual
+ * Columns: persona · spec · enabled · created
+ */
+
+import { StateDot } from '@niuulabs/ui';
+import { useTriggers } from './useTriggers';
+import type { Trigger, TriggerKind } from '../domain/trigger';
+
+const KIND_ORDER: TriggerKind[] = ['cron', 'event', 'webhook', 'manual'];
+
+const KIND_LABEL: Record<TriggerKind, string> = {
+  cron: '⏰ cron',
+  event: '⚡ event',
+  webhook: '🔗 webhook',
+  manual: '▶ manual',
+};
+
+function TriggerRow({ trigger }: { trigger: Trigger }) {
+  return (
+    <tr className="rv-trigger-row" data-enabled={trigger.enabled}>
+      <td className="rv-trigger-row__persona">{trigger.personaName}</td>
+      <td className="rv-trigger-row__spec">
+        <code className="rv-trigger-row__spec-code">{trigger.spec}</code>
+      </td>
+      <td className="rv-trigger-row__enabled">
+        <StateDot state={trigger.enabled ? 'healthy' : 'idle'} />
+        <span className="rv-trigger-row__enabled-label">
+          {trigger.enabled ? 'active' : 'disabled'}
+        </span>
+      </td>
+      <td className="rv-trigger-row__created">{trigger.createdAt.slice(0, 10)}</td>
+    </tr>
+  );
+}
+
+function TriggerGroup({ kind, triggers }: { kind: TriggerKind; triggers: Trigger[] }) {
+  if (!triggers.length) return null;
+  return (
+    <section className="rv-trigger-group" aria-label={`${kind} triggers`} data-kind={kind}>
+      <h3 className="rv-trigger-group__title">{KIND_LABEL[kind]}</h3>
+      <table className="rv-trigger-table" aria-label={`${kind} triggers table`}>
+        <thead>
+          <tr>
+            <th>persona</th>
+            <th>spec</th>
+            <th>status</th>
+            <th>created</th>
+          </tr>
+        </thead>
+        <tbody>
+          {triggers.map((t) => (
+            <TriggerRow key={t.id} trigger={t} />
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
+}
+
+export function TriggersView() {
+  const { data: triggers, isLoading, isError } = useTriggers();
+
+  if (isLoading) {
+    return (
+      <div className="rv-triggers-view">
+        <div className="rv-triggers-view__loading">
+          <StateDot state="processing" pulse />
+          <span>loading triggers…</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="rv-triggers-view">
+        <div className="rv-triggers-view__error">failed to load triggers</div>
+      </div>
+    );
+  }
+
+  const grouped = KIND_ORDER.reduce<Record<TriggerKind, Trigger[]>>(
+    (acc, kind) => {
+      acc[kind] = (triggers ?? []).filter((t) => t.kind === kind);
+      return acc;
+    },
+    { cron: [], event: [], webhook: [], manual: [] },
+  );
+
+  const total = triggers?.length ?? 0;
+  const active = triggers?.filter((t) => t.enabled).length ?? 0;
+
+  return (
+    <div className="rv-triggers-view">
+      <div className="rv-triggers-view__header">
+        <span className="rv-triggers-view__count">
+          <strong>{active}</strong> active · {total} total
+        </span>
+      </div>
+      {total === 0 ? (
+        <div className="rv-triggers-view__empty">no triggers configured</div>
+      ) : (
+        KIND_ORDER.map((kind) => <TriggerGroup key={kind} kind={kind} triggers={grouped[kind]} />)
+      )}
+    </div>
+  );
+}

--- a/web-next/packages/plugin-ravn/src/ui/formatTime.ts
+++ b/web-next/packages/plugin-ravn/src/ui/formatTime.ts
@@ -1,0 +1,6 @@
+const TIME_HOUR_START = 11;
+const TIME_HOUR_END = 19;
+
+export function formatTime(iso: string): string {
+  return iso.slice(TIME_HOUR_START, TIME_HOUR_END);
+}

--- a/web-next/packages/plugin-ravn/src/ui/ravn-views.css
+++ b/web-next/packages/plugin-ravn/src/ui/ravn-views.css
@@ -1,0 +1,888 @@
+/* ── Ravn page shell ──────────────────────────────────────────────────────── */
+.rv-page-shell {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+.rv-page-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  border-bottom: 1px solid var(--color-border-subtle);
+  padding: var(--space-4) var(--space-6);
+  flex-shrink: 0;
+}
+.rv-page-header h2 {
+  margin: 0;
+  font-size: var(--text-lg);
+}
+.rv-page-subtitle {
+  color: var(--color-text-secondary);
+  margin: 0;
+  font-size: var(--text-sm);
+}
+
+/* ── Tab bar ──────────────────────────────────────────────────────────────── */
+.rv-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--color-border-subtle);
+  padding: 0 var(--space-6);
+  background: var(--color-bg-secondary);
+  flex-shrink: 0;
+}
+.rv-tab {
+  padding: var(--space-3) var(--space-4);
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  transition:
+    color 0.12s,
+    border-color 0.12s;
+}
+.rv-tab:hover {
+  color: var(--color-text-primary);
+}
+.rv-tab--active {
+  color: var(--color-text-primary);
+  border-bottom-color: var(--color-brand, var(--color-accent-cyan));
+}
+.rv-tabpanel {
+  flex: 1;
+  overflow: auto;
+}
+
+/* ── Shared view loading/error/empty ──────────────────────────────────────── */
+.rv-sessions-view__loading,
+.rv-sessions-view__error,
+.rv-sessions-view__empty,
+.rv-triggers-view__loading,
+.rv-triggers-view__error,
+.rv-triggers-view__empty,
+.rv-events-view__loading,
+.rv-events-view__error,
+.rv-events-view__empty,
+.rv-budget-view__loading,
+.rv-log-view__empty {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-8) var(--space-6);
+  color: var(--color-text-secondary);
+  font-size: var(--text-sm);
+}
+.rv-sessions-view__error,
+.rv-triggers-view__error,
+.rv-events-view__error {
+  color: var(--color-critical);
+}
+
+/* ── Sessions view ────────────────────────────────────────────────────────── */
+.rv-sessions-view {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  height: 100%;
+  overflow: hidden;
+}
+.rv-sessions-view__list {
+  border-right: 1px solid var(--color-border-subtle);
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
+.rv-sessions-view__list-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--color-border-subtle);
+  flex-shrink: 0;
+}
+.rv-sessions-view__list-label {
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--color-text-muted);
+}
+.rv-sessions-view__list-count {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+.rv-sessions-view__transcript {
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Session list item */
+.rv-session-item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--color-border-subtle);
+  background: none;
+  border-left: none;
+  border-right: none;
+  border-top: none;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.1s;
+}
+.rv-session-item:hover {
+  background: var(--color-bg-secondary);
+}
+.rv-session-item--active {
+  background: var(--color-bg-tertiary);
+}
+.rv-session-item__head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.rv-session-item__name {
+  flex: 1;
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+}
+.rv-session-item__status {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+.rv-session-item__meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  padding-left: var(--space-5);
+}
+.rv-session-item__model {
+  font-family: var(--font-mono);
+}
+
+/* Transcript */
+.rv-transcript {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+.rv-transcript__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--color-border-subtle);
+  flex-shrink: 0;
+}
+.rv-transcript__persona {
+  font-weight: 600;
+  font-size: var(--text-sm);
+}
+.rv-transcript__model {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+.rv-transcript__count {
+  margin-left: auto;
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+.rv-transcript__body {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.rv-transcript__empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  height: 100%;
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+}
+.rv-transcript__empty--error {
+  color: var(--color-critical);
+}
+.rv-transcript__cursor {
+  margin-top: var(--space-2);
+}
+
+/* Message rows */
+.rv-msg {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  font-size: var(--text-sm);
+}
+.rv-msg__time {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+.rv-msg__body {
+  color: var(--color-text-primary);
+}
+.rv-msg__body--italic {
+  font-style: italic;
+  color: var(--color-text-muted);
+}
+.rv-msg--user {
+  border-left: 2px solid var(--color-accent-indigo);
+  padding-left: var(--space-3);
+}
+.rv-msg--system {
+  border-left: 2px solid var(--color-border);
+  padding-left: var(--space-3);
+  opacity: 0.7;
+}
+.rv-msg--tool-call {
+  border-left: 2px solid var(--color-accent-amber);
+  padding-left: var(--space-3);
+}
+.rv-msg--tool-result {
+  border-left: 2px solid var(--color-accent-emerald);
+  padding-left: var(--space-3);
+}
+.rv-msg--emit {
+  border-left: 2px solid var(--color-accent-cyan);
+  padding-left: var(--space-3);
+}
+.rv-msg--think {
+  border-left: 2px solid var(--color-accent-purple);
+  padding-left: var(--space-3);
+  opacity: 0.8;
+}
+.rv-msg__tool-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.rv-msg__tool-badge {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  padding: 1px var(--space-2);
+  border-radius: var(--radius-sm);
+}
+.rv-msg__tool-badge--call {
+  background: color-mix(in srgb, var(--color-accent-amber) 15%, transparent);
+  color: var(--color-accent-amber);
+}
+.rv-msg__tool-badge--result {
+  background: color-mix(in srgb, var(--color-accent-emerald) 15%, transparent);
+  color: var(--color-accent-emerald);
+}
+.rv-msg__tool-name {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+}
+.rv-msg__emit-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.rv-msg__emit-badge {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  padding: 1px var(--space-2);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--color-accent-cyan) 15%, transparent);
+  color: var(--color-accent-cyan);
+}
+.rv-msg__emit-event {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--color-accent-cyan);
+}
+.rv-msg__code {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2) var(--space-3);
+  overflow-x: auto;
+  margin: 0;
+  color: var(--color-text-secondary);
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+.rv-msg__code--emit {
+  color: var(--color-accent-cyan);
+}
+.rv-msg__code--think {
+  color: var(--color-accent-purple);
+}
+.rv-msg__think-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+.rv-msg__think-badge {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  padding: 1px var(--space-2);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--color-accent-purple) 15%, transparent);
+  color: var(--color-accent-purple);
+}
+.rv-msg__think-label {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+/* ActiveCursor */
+.rv-active-cursor {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.rv-active-cursor__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-accent-cyan);
+  animation: rv-pulse 1.2s ease-in-out infinite;
+}
+.rv-active-cursor__dot--2 {
+  animation-delay: 0.2s;
+}
+.rv-active-cursor__dot--3 {
+  animation-delay: 0.4s;
+}
+@keyframes rv-pulse {
+  0%,
+  100% {
+    opacity: 0.3;
+    transform: scale(0.8);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/* ── Triggers view ────────────────────────────────────────────────────────── */
+.rv-triggers-view {
+  padding: var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+}
+.rv-triggers-view__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+.rv-triggers-view__count {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+.rv-triggers-view__count strong {
+  color: var(--color-text-primary);
+}
+
+.rv-trigger-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.rv-trigger-group__title {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  margin: 0 0 var(--space-2);
+}
+
+.rv-trigger-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-sm);
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+.rv-trigger-table th {
+  text-align: left;
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+  background: var(--color-bg-tertiary);
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+.rv-trigger-row td {
+  padding: var(--space-2) var(--space-4);
+  border-bottom: 1px solid var(--color-border-subtle);
+  color: var(--color-text-secondary);
+  vertical-align: middle;
+}
+.rv-trigger-row:last-child td {
+  border-bottom: none;
+}
+.rv-trigger-row__persona {
+  color: var(--color-text-primary);
+  font-family: var(--font-mono);
+}
+.rv-trigger-row__spec-code {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  background: var(--color-bg-tertiary);
+  padding: 1px var(--space-2);
+  border-radius: var(--radius-sm);
+}
+.rv-trigger-row__enabled {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.rv-trigger-row__enabled-label {
+  font-size: var(--text-xs);
+}
+.rv-trigger-row__created {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+/* ── Events view ──────────────────────────────────────────────────────────── */
+.rv-events-view {
+  padding: var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+.rv-events-view__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+.rv-events-view__count {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+.rv-events-view__count strong {
+  color: var(--color-text-primary);
+}
+.rv-events-view__persona-filter {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+}
+.rv-events-view__persona-filter strong {
+  color: var(--color-text-primary);
+}
+.rv-events-view__clear {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  padding: 0 var(--space-1);
+}
+.rv-events-view__clear:hover {
+  color: var(--color-text-primary);
+}
+.rv-events-view__graph {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: var(--space-4);
+}
+.rv-event-card {
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+  transition:
+    opacity 0.2s,
+    border-color 0.2s;
+}
+.rv-event-card--dimmed {
+  opacity: 0.3;
+}
+.rv-event-card__name {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--color-accent-cyan);
+  margin-bottom: var(--space-3);
+  font-weight: 600;
+}
+.rv-event-card__edges {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.rv-event-card__edge-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+.rv-event-card__edge-label {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.rv-event-card__personas {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+}
+.rv-event-persona {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-full);
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition:
+    background 0.1s,
+    color 0.1s;
+}
+.rv-event-persona:hover {
+  background: var(--color-bg-elevated);
+  color: var(--color-text-primary);
+}
+.rv-event-persona--selected {
+  background: color-mix(in srgb, var(--color-accent-cyan) 15%, transparent);
+  border-color: var(--color-accent-cyan);
+  color: var(--color-accent-cyan);
+}
+/* ── Budget view ──────────────────────────────────────────────────────────── */
+.rv-budget-view {
+  padding: var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+}
+
+.rv-budget-hero {
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+.rv-budget-hero__kpis {
+  display: flex;
+  gap: var(--space-8);
+}
+.rv-budget-hero__kpi {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+.rv-budget-hero__kpi-label {
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--color-text-muted);
+}
+.rv-budget-hero__kpi-value {
+  font-size: var(--text-2xl);
+  color: var(--color-text-primary);
+  font-family: var(--font-mono);
+}
+.rv-budget-hero__kpi-value--warn {
+  color: var(--color-accent-amber);
+}
+.rv-budget-hero__kpi-value--crit {
+  color: var(--color-critical);
+}
+
+.rv-budget-attention-columns {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-4);
+}
+.rv-budget-attention-col {
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.rv-budget-attention-col__title {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  margin: 0 0 var(--space-2);
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+.rv-budget-attention-item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.rv-budget-attention-item__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.rv-budget-attention-item__name {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-primary);
+}
+.rv-budget-attention-item__spent {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+}
+
+.rv-budget-fleet {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.rv-budget-fleet__toggle {
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.12s;
+}
+.rv-budget-fleet__toggle:hover {
+  background: var(--color-bg-secondary);
+  color: var(--color-text-primary);
+}
+
+.rv-budget-fleet-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-sm);
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+.rv-budget-fleet-table th {
+  text-align: left;
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+  background: var(--color-bg-tertiary);
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+.rv-budget-fleet-row td {
+  padding: var(--space-2) var(--space-4);
+  border-bottom: 1px solid var(--color-border-subtle);
+  vertical-align: middle;
+  color: var(--color-text-secondary);
+}
+.rv-budget-fleet-row:last-child td {
+  border-bottom: none;
+}
+.rv-budget-fleet-row__name {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--color-text-primary);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+}
+.rv-budget-fleet-row__spent,
+.rv-budget-fleet-row__cap {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+}
+.rv-budget-fleet-row__bar {
+  min-width: 120px;
+}
+.rv-budget-fleet-row__attention {
+  font-size: var(--text-xs);
+}
+
+/* ── Log view ─────────────────────────────────────────────────────────────── */
+.rv-log-view {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+.rv-log-view__filters {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--color-border-subtle);
+  background: var(--color-bg-secondary);
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+.rv-log-view__search {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  padding: var(--space-1) var(--space-3);
+  background: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-primary);
+  width: 180px;
+}
+.rv-log-view__raven-select {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  padding: var(--space-1) var(--space-3);
+  background: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-secondary);
+}
+.rv-log-view__kind-filters {
+  display: flex;
+  gap: var(--space-1);
+  flex-wrap: wrap;
+}
+.rv-log-view__kind-btn {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  padding: 1px var(--space-2);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition:
+    background 0.1s,
+    color 0.1s;
+}
+.rv-log-view__kind-btn:hover {
+  background: var(--color-bg-elevated);
+  color: var(--color-text-secondary);
+}
+.rv-log-view__kind-btn--active {
+  background: color-mix(in srgb, var(--color-accent-cyan) 15%, transparent);
+  border-color: color-mix(in srgb, var(--color-accent-cyan) 30%, transparent);
+  color: var(--color-accent-cyan);
+}
+.rv-log-view__auto-tail {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  margin-left: auto;
+}
+.rv-log-view__stream {
+  flex: 1;
+  overflow-y: auto;
+}
+.rv-log-view__footer {
+  padding: var(--space-2) var(--space-4);
+  border-top: 1px solid var(--color-border-subtle);
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+}
+
+.rv-log-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+}
+.rv-log-table th {
+  text-align: left;
+  padding: var(--space-2) var(--space-3);
+  color: var(--color-text-muted);
+  border-bottom: 1px solid var(--color-border-subtle);
+  background: var(--color-bg-secondary);
+  position: sticky;
+  top: 0;
+}
+.rv-log-table__th--time {
+  width: 80px;
+}
+.rv-log-table__th--raven {
+  width: 120px;
+}
+.rv-log-table__th--kind {
+  width: 90px;
+}
+.rv-log-table__th--body {
+  flex: 1;
+}
+
+.rv-log-row td {
+  padding: var(--space-1) var(--space-3);
+  border-bottom: 1px solid var(--color-border-subtle);
+  vertical-align: top;
+}
+.rv-log-row__time {
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+.rv-log-row__raven {
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+}
+.rv-log-row__kind {
+}
+.rv-log-row__kind--user {
+  color: var(--color-accent-indigo);
+}
+.rv-log-row__kind--asst {
+  color: var(--color-text-primary);
+}
+.rv-log-row__kind--system {
+  color: var(--color-text-muted);
+}
+.rv-log-row__kind--tool-call {
+  color: var(--color-accent-amber);
+}
+.rv-log-row__kind--tool-result {
+  color: var(--color-accent-emerald);
+}
+.rv-log-row__kind--emit {
+  color: var(--color-accent-cyan);
+}
+.rv-log-row__kind--think {
+  color: var(--color-accent-purple);
+}
+.rv-log-row__body {
+  color: var(--color-text-secondary);
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-width: 0; /* forces column to be flexible */
+  overflow: hidden;
+}
+
+/* ── Storybook story wrappers ─────────────────────────────────────────────── */
+.rv-story-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding: var(--space-4);
+}
+.rv-story-wrapper--tall {
+  height: 600px;
+}

--- a/web-next/packages/plugin-ravn/src/ui/useBudget.test.ts
+++ b/web-next/packages/plugin-ravn/src/ui/useBudget.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useFleetBudget, useRavnBudget } from './useBudget';
+import { createMockBudgetStream } from '../adapters/mock';
+import { wrapWithServices } from '../testing/wrapWithRavn';
+
+const makeWrapper = wrapWithServices;
+
+const svc = { 'ravn.budget': createMockBudgetStream() };
+
+describe('useFleetBudget', () => {
+  it('returns fleet budget totals', async () => {
+    const { result } = renderHook(() => useFleetBudget(), { wrapper: makeWrapper(svc) });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.spentUsd).toBeGreaterThan(0);
+    expect(result.current.data?.capUsd).toBeGreaterThan(0);
+  });
+
+  it('starts loading', () => {
+    const { result } = renderHook(() => useFleetBudget(), { wrapper: makeWrapper(svc) });
+    expect(result.current.isLoading).toBe(true);
+  });
+});
+
+describe('useRavnBudget', () => {
+  it('returns budget for a specific ravn', async () => {
+    const { result } = renderHook(() => useRavnBudget('a3f1b2c4-8e7d-4a6f-9b0c-1d2e3f4a5b6c'), {
+      wrapper: makeWrapper(svc),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.spentUsd).toBe(1.24);
+  });
+
+  it('does not fetch when ravnId is empty', () => {
+    const { result } = renderHook(() => useRavnBudget(''), { wrapper: makeWrapper(svc) });
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+});

--- a/web-next/packages/plugin-ravn/src/ui/useBudget.ts
+++ b/web-next/packages/plugin-ravn/src/ui/useBudget.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query';
+import { useService } from '@niuulabs/plugin-sdk';
+import type { IBudgetStream } from '../ports';
+
+export function useFleetBudget() {
+  const service = useService<IBudgetStream>('ravn.budget');
+  return useQuery({
+    queryKey: ['ravn', 'budget', 'fleet'],
+    queryFn: () => service.getFleetBudget(),
+  });
+}
+
+export function useRavnBudget(ravnId: string) {
+  const service = useService<IBudgetStream>('ravn.budget');
+  return useQuery({
+    queryKey: ['ravn', 'budget', ravnId],
+    queryFn: () => service.getBudget(ravnId),
+    enabled: Boolean(ravnId),
+  });
+}

--- a/web-next/packages/plugin-ravn/src/ui/usePersonas.test.ts
+++ b/web-next/packages/plugin-ravn/src/ui/usePersonas.test.ts
@@ -1,11 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ServicesProvider } from '@niuulabs/plugin-sdk';
-import type { ReactNode } from 'react';
-import { createElement } from 'react';
 import { usePersonas } from './usePersonas';
 import type { PersonaSummary } from '../ports';
+import { wrapWithServices } from '../testing/wrapWithRavn';
 
 const samplePersona: PersonaSummary = {
   name: 'coder',
@@ -18,16 +15,7 @@ const samplePersona: PersonaSummary = {
   consumesEvents: ['code.requested'],
 };
 
-function makeWrapper(service: Record<string, unknown>) {
-  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return function Wrapper({ children }: { children: ReactNode }) {
-    return createElement(
-      QueryClientProvider,
-      { client },
-      createElement(ServicesProvider, { services: service }, children),
-    );
-  };
-}
+const makeWrapper = wrapWithServices;
 
 describe('usePersonas', () => {
   it('returns personas list from the service', async () => {

--- a/web-next/packages/plugin-ravn/src/ui/useRavens.test.ts
+++ b/web-next/packages/plugin-ravn/src/ui/useRavens.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useRavens, useRaven } from './useRavens';
+import { createMockRavenStream } from '../adapters/mock';
+import { wrapWithServices } from '../testing/wrapWithRavn';
+
+const makeWrapper = wrapWithServices;
+
+describe('useRavens', () => {
+  it('returns all ravens from the service', async () => {
+    const { result } = renderHook(() => useRavens(), {
+      wrapper: makeWrapper({ 'ravn.ravens': createMockRavenStream() }),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(6);
+  });
+
+  it('returns isLoading true initially', () => {
+    const { result } = renderHook(() => useRavens(), {
+      wrapper: makeWrapper({ 'ravn.ravens': createMockRavenStream() }),
+    });
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('sets isError on failure', async () => {
+    const failing = {
+      listRavens: async () => {
+        throw new Error('fail');
+      },
+      getRaven: async () => {
+        throw new Error('fail');
+      },
+    };
+    const { result } = renderHook(() => useRavens(), {
+      wrapper: makeWrapper({ 'ravn.ravens': failing }),
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe('useRaven', () => {
+  it('returns a specific raven by id', async () => {
+    const { result } = renderHook(() => useRaven('a3f1b2c4-8e7d-4a6f-9b0c-1d2e3f4a5b6c'), {
+      wrapper: makeWrapper({ 'ravn.ravens': createMockRavenStream() }),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.personaName).toBe('coding-agent');
+  });
+
+  it('does not fetch when id is empty', () => {
+    const { result } = renderHook(() => useRaven(''), {
+      wrapper: makeWrapper({ 'ravn.ravens': createMockRavenStream() }),
+    });
+    expect(result.current.isPending).toBe(true);
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+});

--- a/web-next/packages/plugin-ravn/src/ui/useRavens.ts
+++ b/web-next/packages/plugin-ravn/src/ui/useRavens.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query';
+import { useService } from '@niuulabs/plugin-sdk';
+import type { IRavenStream } from '../ports';
+
+export function useRavens() {
+  const service = useService<IRavenStream>('ravn.ravens');
+  return useQuery({
+    queryKey: ['ravn', 'ravens'],
+    queryFn: () => service.listRavens(),
+  });
+}
+
+export function useRaven(id: string) {
+  const service = useService<IRavenStream>('ravn.ravens');
+  return useQuery({
+    queryKey: ['ravn', 'ravens', id],
+    queryFn: () => service.getRaven(id),
+    enabled: Boolean(id),
+  });
+}

--- a/web-next/packages/plugin-ravn/src/ui/useSessions.test.ts
+++ b/web-next/packages/plugin-ravn/src/ui/useSessions.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useSessions, useSession, useMessages } from './useSessions';
+import { createMockSessionStream } from '../adapters/mock';
+import { wrapWithServices } from '../testing/wrapWithRavn';
+
+const makeWrapper = wrapWithServices;
+
+const svc = { 'ravn.sessions': createMockSessionStream() };
+
+describe('useSessions', () => {
+  it('returns all sessions', async () => {
+    const { result } = renderHook(() => useSessions(), { wrapper: makeWrapper(svc) });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(6);
+  });
+
+  it('starts loading', () => {
+    const { result } = renderHook(() => useSessions(), { wrapper: makeWrapper(svc) });
+    expect(result.current.isLoading).toBe(true);
+  });
+});
+
+describe('useSession', () => {
+  it('returns a specific session', async () => {
+    const { result } = renderHook(() => useSession('10000001-0000-4000-8000-000000000001'), {
+      wrapper: makeWrapper(svc),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.personaName).toBe('coding-agent');
+  });
+
+  it('does not fetch when id is empty', () => {
+    const { result } = renderHook(() => useSession(''), { wrapper: makeWrapper(svc) });
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+});
+
+describe('useMessages', () => {
+  it('returns messages for a session', async () => {
+    const { result } = renderHook(() => useMessages('10000001-0000-4000-8000-000000000001'), {
+      wrapper: makeWrapper(svc),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.length).toBeGreaterThan(0);
+  });
+
+  it('does not fetch when sessionId is empty', () => {
+    const { result } = renderHook(() => useMessages(''), { wrapper: makeWrapper(svc) });
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+});

--- a/web-next/packages/plugin-ravn/src/ui/useSessions.ts
+++ b/web-next/packages/plugin-ravn/src/ui/useSessions.ts
@@ -1,0 +1,29 @@
+import { useQuery } from '@tanstack/react-query';
+import { useService } from '@niuulabs/plugin-sdk';
+import type { ISessionStream } from '../ports';
+
+export function useSessions() {
+  const service = useService<ISessionStream>('ravn.sessions');
+  return useQuery({
+    queryKey: ['ravn', 'sessions'],
+    queryFn: () => service.listSessions(),
+  });
+}
+
+export function useSession(id: string) {
+  const service = useService<ISessionStream>('ravn.sessions');
+  return useQuery({
+    queryKey: ['ravn', 'sessions', id],
+    queryFn: () => service.getSession(id),
+    enabled: Boolean(id),
+  });
+}
+
+export function useMessages(sessionId: string) {
+  const service = useService<ISessionStream>('ravn.sessions');
+  return useQuery({
+    queryKey: ['ravn', 'sessions', sessionId, 'messages'],
+    queryFn: () => service.getMessages(sessionId),
+    enabled: Boolean(sessionId),
+  });
+}

--- a/web-next/packages/plugin-ravn/src/ui/useTriggers.test.ts
+++ b/web-next/packages/plugin-ravn/src/ui/useTriggers.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useTriggers } from './useTriggers';
+import { createMockTriggerStore } from '../adapters/mock';
+import { wrapWithServices } from '../testing/wrapWithRavn';
+
+const makeWrapper = wrapWithServices;
+
+describe('useTriggers', () => {
+  it('returns all triggers', async () => {
+    const { result } = renderHook(() => useTriggers(), {
+      wrapper: makeWrapper({ 'ravn.triggers': createMockTriggerStore() }),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(5);
+  });
+
+  it('starts loading', () => {
+    const { result } = renderHook(() => useTriggers(), {
+      wrapper: makeWrapper({ 'ravn.triggers': createMockTriggerStore() }),
+    });
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('sets isError on failure', async () => {
+    const failing = {
+      listTriggers: async () => {
+        throw new Error('fail');
+      },
+      createTrigger: async () => {
+        throw new Error();
+      },
+      deleteTrigger: async () => {
+        throw new Error();
+      },
+    };
+    const { result } = renderHook(() => useTriggers(), {
+      wrapper: makeWrapper({ 'ravn.triggers': failing }),
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/web-next/packages/plugin-ravn/src/ui/useTriggers.ts
+++ b/web-next/packages/plugin-ravn/src/ui/useTriggers.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { useService } from '@niuulabs/plugin-sdk';
+import type { ITriggerStore } from '../ports';
+
+export function useTriggers() {
+  const service = useService<ITriggerStore>('ravn.triggers');
+  return useQuery({
+    queryKey: ['ravn', 'triggers'],
+    queryFn: () => service.listTriggers(),
+  });
+}


### PR DESCRIPTION
## Summary

Implements the five Ravn plugin views for NIU-674, completing the composable plugin UI vertical:

- **SessionsView** — split panel (session list + transcript); per-kind message idioms (`user`/`asst`/`system`/`tool_call`/`tool_result`/`emit`/`think`); `ActiveCursor` state machine (`idle → active → done`) for in-progress sessions; auto-scroll to bottom
- **TriggersView** — fleet-wide table grouped by kind (`cron`/`event`/`webhook`/`manual`); enabled count badge per group; enabled/disabled row styling
- **EventsView** — `buildEventGraph()` derives producer/consumer nodes from persona metadata; per-persona focus mode dims unrelated events; clear-filter button + filter indicator
- **BudgetView** — hero card (spent / cap / runway + `BudgetBar`); three attention columns (Burning fast / Near cap / Idle) via `classifyBudget()`; collapsible full-fleet table; `handleClassified` via `useCallback` + `useEffect` to avoid setState-during-render
- **LogView** — monospace event stream with `time`/`raven`/`kind`/`body` columns; text search + raven selector + kind toggle buttons + auto-tail checkbox; fixed 10-slot hook pattern to respect Rules of Hooks

## Application logic added

- `budgetAttention.ts` — pure `classifyBudget` / `budgetRunway` / `budgetRatio` functions
- `logFilter.ts` — pure `applyLogFilter` with `LogEntry` / `LogFilter` types + `EMPTY_LOG_FILTER`

## Hooks added

- `useRavens`, `useSessions`, `useTriggers`, `useBudget` — TanStack Query wrappers over ports

## Test plan

- [x] Unit tests: `budgetAttention`, `logFilter`, `ActiveCursor`, `MessageRow`, all five views, all hooks — 94.82% statement coverage, 89.2% branch coverage (both above 85% gate)
- [x] 38 Playwright e2e specs covering all five views
- [x] Storybook stories: `ActiveCursor` variants, `MessageRow` gallery, and a story per view
- [x] Prettier formatting clean, ESLint clean

## Notes

- Linear ticket NIU-674 should be moved to "In Review" — MCP tools unavailable in this session.
- CSS uses `ravn-views.css` with CSS custom properties (design tokens) per CLAUDE.md rule 6.
- Replaces #596 and #598.

🤖 Generated with [Claude Code](https://claude.com/claude-code)