### PR TITLE
feat(tyr): plan wizard — prompt → questions → raiding → draft → approved (NIU-682)

### DIFF
--- a/web-next/e2e/tyr.spec.ts
+++ b/web-next/e2e/tyr.spec.ts
@@ -179,3 +179,137 @@ test('keyboard: tab focuses segmented filter buttons', async ({ page }) => {
   await allBtn.focus();
   await expect(allBtn).toBeFocused();
 });
+
+test('tyr page has link to new saga plan', async ({ page }) => {
+  await page.goto('/tyr');
+  await expect(page.getByRole('link', { name: /new saga plan/i })).toBeVisible();
+});
+
+// ---------------------------------------------------------------------------
+// Plan wizard — all 5 states
+// ---------------------------------------------------------------------------
+
+test('plan wizard renders prompt step at /tyr/plan', async ({ page }) => {
+  await page.goto('/tyr/plan');
+  await expect(page.getByText('Describe your goal')).toBeVisible();
+  await expect(page.getByRole('navigation', { name: /plan wizard steps/i })).toBeVisible();
+});
+
+test('plan wizard — step 1 (prompt): shows step dots and form', async ({ page }) => {
+  await page.goto('/tyr/plan');
+  // StepDots labels — exact match to avoid collisions with step headings
+  await expect(page.getByText('Describe', { exact: true })).toBeVisible();
+  await expect(page.getByText('Clarify', { exact: true })).toBeVisible();
+  await expect(page.getByText('Decompose', { exact: true })).toBeVisible();
+  await expect(page.getByText('Review', { exact: true })).toBeVisible();
+  await expect(page.getByText('Launch', { exact: true })).toBeVisible();
+  // Form fields
+  await expect(page.getByRole('textbox', { name: /goal description/i })).toBeVisible();
+  await expect(page.getByRole('textbox', { name: /target repository/i })).toBeVisible();
+});
+
+test('plan wizard — step 2 (questions): shown after submitting prompt', async ({ page }) => {
+  await page.goto('/tyr/plan');
+
+  await page
+    .getByRole('textbox', { name: /goal description/i })
+    .fill('Build OIDC auth with silent refresh and PAT support for headless agents');
+  await page.getByRole('textbox', { name: /target repository/i }).fill('niuulabs/volundr');
+  await page.getByRole('button', { name: /next/i }).click();
+
+  await expect(page.getByText('Clarify your plan')).toBeVisible({ timeout: 5000 });
+  // Mock service returns 4 questions
+  await expect(page.getByText(/Which target repositories/i)).toBeVisible();
+});
+
+test('plan wizard — step 3 (raiding): shown after submitting answers', async ({ page }) => {
+  await page.goto('/tyr/plan');
+
+  // Step 1
+  await page.getByRole('textbox', { name: /goal description/i }).fill('Build auth module');
+  await page.getByRole('button', { name: /next/i }).click();
+  await expect(page.getByText('Clarify your plan')).toBeVisible({ timeout: 5000 });
+
+  // Step 2
+  await page.getByRole('button', { name: /decompose/i }).click();
+
+  await expect(page.getByRole('status', { name: /decomposing plan/i })).toBeVisible({
+    timeout: 5000,
+  });
+  await expect(page.getByText(/Ravens are raiding/i)).toBeVisible();
+});
+
+test('plan wizard — step 4 (draft): auto-advances from raiding', async ({ page }) => {
+  await page.goto('/tyr/plan');
+
+  // Step 1
+  await page.getByRole('textbox', { name: /goal description/i }).fill('Build auth module');
+  await page.getByRole('button', { name: /next/i }).click();
+  await expect(page.getByText('Clarify your plan')).toBeVisible({ timeout: 5000 });
+
+  // Step 2
+  await page.getByRole('button', { name: /decompose/i }).click();
+
+  // Step 3 → 4 auto-advance
+  await expect(page.getByText('Review your plan')).toBeVisible({ timeout: 10000 });
+  await expect(page.getByText('New Saga', { exact: true })).toBeVisible();
+  await expect(page.getByRole('button', { name: /approve/i })).toBeVisible();
+});
+
+test('plan wizard — step 4: edit button toggles phase name editing', async ({ page }) => {
+  await page.goto('/tyr/plan');
+
+  await page.getByRole('textbox', { name: /goal description/i }).fill('Build auth module');
+  await page.getByRole('button', { name: /next/i }).click();
+  await expect(page.getByText('Clarify your plan')).toBeVisible({ timeout: 5000 });
+  await page.getByRole('button', { name: /decompose/i }).click();
+  await expect(page.getByText('Review your plan')).toBeVisible({ timeout: 10000 });
+
+  // Click edit on first phase
+  await page.getByRole('button', { name: /edit phase 1/i }).click();
+  await expect(page.getByLabel(/edit phase 1 name/i)).toBeVisible();
+  // Cancel
+  await page.getByRole('button', { name: /cancel/i }).click();
+  await expect(page.getByLabel(/edit phase 1 name/i)).not.toBeVisible();
+});
+
+test('plan wizard — step 5 (approved): reached after approving draft', async ({ page }) => {
+  await page.goto('/tyr/plan');
+
+  // Step 1
+  await page.getByRole('textbox', { name: /goal description/i }).fill('Build auth module');
+  await page.getByRole('button', { name: /next/i }).click();
+  await expect(page.getByText('Clarify your plan')).toBeVisible({ timeout: 5000 });
+
+  // Step 2
+  await page.getByRole('button', { name: /decompose/i }).click();
+
+  // Step 3 → 4
+  await expect(page.getByText('Review your plan')).toBeVisible({ timeout: 10000 });
+
+  // Step 4 → 5
+  await page.getByRole('button', { name: /approve/i }).click();
+  await expect(page.getByText('Saga launched!')).toBeVisible({ timeout: 5000 });
+  await expect(page.getByRole('link', { name: /open in sagas/i })).toBeVisible();
+});
+
+test('plan wizard — back navigation from questions returns to prompt', async ({ page }) => {
+  await page.goto('/tyr/plan');
+
+  await page.getByRole('textbox', { name: /goal description/i }).fill('Build auth module');
+  await page.getByRole('button', { name: /next/i }).click();
+  await expect(page.getByText('Clarify your plan')).toBeVisible({ timeout: 5000 });
+
+  await page.getByRole('button', { name: /back/i }).click();
+  await expect(page.getByText('Describe your goal')).toBeVisible();
+});
+
+test('plan wizard — keyboard accessibility: tab order works on prompt step', async ({ page }) => {
+  await page.goto('/tyr/plan');
+  // Tab through interactive elements
+  await page.keyboard.press('Tab');
+  // The textarea should be focusable
+  const textarea = page.getByRole('textbox', { name: /goal description/i });
+  await textarea.fill('test');
+  await expect(textarea).toBeFocused();
+});

--- a/web-next/packages/plugin-tyr/src/adapters/http.ts
+++ b/web-next/packages/plugin-tyr/src/adapters/http.ts
@@ -657,11 +657,14 @@ export function buildTyrSettingsHttpAdapter(client: ApiClient): ITyrSettingsServ
     async updateFlockConfig(patch) {
       const body: Record<string, unknown> = {};
       if (patch.flockName !== undefined) body['flock_name'] = patch.flockName;
-      if (patch.defaultBaseBranch !== undefined) body['default_base_branch'] = patch.defaultBaseBranch;
-      if (patch.defaultTrackerType !== undefined) body['default_tracker_type'] = patch.defaultTrackerType;
+      if (patch.defaultBaseBranch !== undefined)
+        body['default_base_branch'] = patch.defaultBaseBranch;
+      if (patch.defaultTrackerType !== undefined)
+        body['default_tracker_type'] = patch.defaultTrackerType;
       if (patch.defaultRepos !== undefined) body['default_repos'] = patch.defaultRepos;
       if (patch.maxActiveSagas !== undefined) body['max_active_sagas'] = patch.maxActiveSagas;
-      if (patch.autoCreateMilestones !== undefined) body['auto_create_milestones'] = patch.autoCreateMilestones;
+      if (patch.autoCreateMilestones !== undefined)
+        body['auto_create_milestones'] = patch.autoCreateMilestones;
       const raw = await client.patch<RawFlockConfig>('/settings/flock', body);
       return toFlockConfig(raw);
     },
@@ -673,8 +676,10 @@ export function buildTyrSettingsHttpAdapter(client: ApiClient): ITyrSettingsServ
 
     async updateDispatchDefaults(patch) {
       const body: Record<string, unknown> = {};
-      if (patch.confidenceThreshold !== undefined) body['confidence_threshold'] = patch.confidenceThreshold;
-      if (patch.maxConcurrentRaids !== undefined) body['max_concurrent_raids'] = patch.maxConcurrentRaids;
+      if (patch.confidenceThreshold !== undefined)
+        body['confidence_threshold'] = patch.confidenceThreshold;
+      if (patch.maxConcurrentRaids !== undefined)
+        body['max_concurrent_raids'] = patch.maxConcurrentRaids;
       if (patch.autoContinue !== undefined) body['auto_continue'] = patch.autoContinue;
       if (patch.batchSize !== undefined) body['batch_size'] = patch.batchSize;
       if (patch.retryPolicy !== undefined) {
@@ -696,11 +701,13 @@ export function buildTyrSettingsHttpAdapter(client: ApiClient): ITyrSettingsServ
     async updateNotificationSettings(patch) {
       const body: Record<string, unknown> = {};
       if (patch.channel !== undefined) body['channel'] = patch.channel;
-      if (patch.onRaidPendingApproval !== undefined) body['on_raid_pending_approval'] = patch.onRaidPendingApproval;
+      if (patch.onRaidPendingApproval !== undefined)
+        body['on_raid_pending_approval'] = patch.onRaidPendingApproval;
       if (patch.onRaidMerged !== undefined) body['on_raid_merged'] = patch.onRaidMerged;
       if (patch.onRaidFailed !== undefined) body['on_raid_failed'] = patch.onRaidFailed;
       if (patch.onSagaComplete !== undefined) body['on_saga_complete'] = patch.onSagaComplete;
-      if (patch.onDispatcherError !== undefined) body['on_dispatcher_error'] = patch.onDispatcherError;
+      if (patch.onDispatcherError !== undefined)
+        body['on_dispatcher_error'] = patch.onDispatcherError;
       if (patch.webhookUrl !== undefined) body['webhook_url'] = patch.webhookUrl;
       const raw = await client.patch<RawNotificationSettings>('/settings/notifications', body);
       return toNotificationSettings(raw);

--- a/web-next/packages/plugin-tyr/src/adapters/http.ts
+++ b/web-next/packages/plugin-tyr/src/adapters/http.ts
@@ -351,11 +351,16 @@ export function buildTyrHttpAdapter(client: ApiClient): ITyrService {
     },
 
     async spawnPlanSession(spec: string, repo: string) {
-      const raw = await client.post<{ session_id: string; chat_endpoint: string | null }>(
-        '/sagas/plan',
-        { spec, repo },
-      );
-      return { sessionId: raw.session_id, chatEndpoint: raw.chat_endpoint } satisfies PlanSession;
+      const raw = await client.post<{
+        session_id: string;
+        chat_endpoint: string | null;
+        questions?: { id: string; question: string; hint?: string }[];
+      }>('/sagas/plan', { spec, repo });
+      return {
+        sessionId: raw.session_id,
+        chatEndpoint: raw.chat_endpoint,
+        questions: raw.questions ?? [],
+      } satisfies PlanSession;
     },
 
     async extractStructure(text: string) {

--- a/web-next/packages/plugin-tyr/src/adapters/mock.test.ts
+++ b/web-next/packages/plugin-tyr/src/adapters/mock.test.ts
@@ -76,11 +76,12 @@ describe('createMockTyrService', () => {
     expect(session.chatEndpoint).toBeNull();
   });
 
-  it('extractStructure returns found: false by default', async () => {
+  it('extractStructure returns found: true with sample structure', async () => {
     const svc = createMockTyrService();
     const result = await svc.extractStructure('some text');
-    expect(result.found).toBe(false);
-    expect(result.structure).toBeNull();
+    expect(result.found).toBe(true);
+    expect(result.structure).not.toBeNull();
+    expect(result.structure?.phases.length).toBeGreaterThan(0);
   });
 });
 

--- a/web-next/packages/plugin-tyr/src/adapters/mock.test.ts
+++ b/web-next/packages/plugin-tyr/src/adapters/mock.test.ts
@@ -418,7 +418,12 @@ describe('createMockAuditLogService', () => {
   it('handles combined filters', async () => {
     const svc = createMockAuditLogService();
     const entries = await svc.listAuditEntries({
-      kinds: ['dispatcher.started', 'dispatcher.stopped', 'dispatcher.threshold_changed', 'dispatcher.batch_size_changed'],
+      kinds: [
+        'dispatcher.started',
+        'dispatcher.stopped',
+        'dispatcher.threshold_changed',
+        'dispatcher.batch_size_changed',
+      ],
       actor: 'system',
     });
     expect(entries.every((e) => e.actor === 'system')).toBe(true);

--- a/web-next/packages/plugin-tyr/src/adapters/mock.ts
+++ b/web-next/packages/plugin-tyr/src/adapters/mock.ts
@@ -570,12 +570,14 @@ export function createMockTyrService(): ITyrService {
           },
           {
             id: 'q3',
-            question: 'Are there any acceptance criteria or constraints you want enforced across all raids?',
+            question:
+              'Are there any acceptance criteria or constraints you want enforced across all raids?',
             hint: 'e.g. all endpoints must have OpenAPI docs, no breaking API changes',
           },
           {
             id: 'q4',
-            question: 'What is the desired confidence threshold before the dispatcher auto-continues?',
+            question:
+              'What is the desired confidence threshold before the dispatcher auto-continues?',
             hint: 'e.g. 80 — raids below this will pause for operator approval',
           },
         ],
@@ -607,10 +609,7 @@ export function createMockTyrService(): ITyrService {
                 {
                   name: 'Implement HTTP adapters',
                   description: 'Build the REST API adapters for all service ports.',
-                  acceptanceCriteria: [
-                    'All endpoints covered',
-                    'Snake_case ↔ camelCase transform',
-                  ],
+                  acceptanceCriteria: ['All endpoints covered', 'Snake_case ↔ camelCase transform'],
                   declaredFiles: ['src/adapters/http.ts'],
                   estimateHours: 8,
                   confidence: 78,

--- a/web-next/packages/plugin-tyr/src/adapters/mock.ts
+++ b/web-next/packages/plugin-tyr/src/adapters/mock.ts
@@ -487,6 +487,8 @@ export function createMockTyrService(): ITyrService {
     },
 
     async decompose(_spec: string, _repo: string) {
+      // Small delay so the raiding step is visible in E2E tests
+      await new Promise<void>((r) => setTimeout(r, 500));
       return [
         {
           id: 'phase-mock-1',

--- a/web-next/packages/plugin-tyr/src/adapters/mock.ts
+++ b/web-next/packages/plugin-tyr/src/adapters/mock.ts
@@ -487,15 +487,139 @@ export function createMockTyrService(): ITyrService {
     },
 
     async decompose(_spec: string, _repo: string) {
-      return [];
+      return [
+        {
+          id: 'phase-mock-1',
+          sagaId: '',
+          trackerId: '',
+          number: 1,
+          name: 'Phase 1: Foundation',
+          status: 'pending' as const,
+          confidence: 82,
+          raids: [
+            {
+              id: 'raid-mock-1',
+              phaseId: 'phase-mock-1',
+              trackerId: '',
+              name: 'Scaffold core domain models',
+              description: 'Define shared domain types and port interfaces.',
+              acceptanceCriteria: ['All types exported from index.ts', 'No circular imports'],
+              declaredFiles: ['src/domain/models.ts', 'src/ports/index.ts'],
+              estimateHours: 4,
+              status: 'pending' as const,
+              confidence: 85,
+              sessionId: null,
+              reviewerSessionId: null,
+              reviewRound: 0,
+              branch: null,
+              chronicleSummary: null,
+              retryCount: 0,
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+            },
+          ],
+        },
+        {
+          id: 'phase-mock-2',
+          sagaId: '',
+          trackerId: '',
+          number: 2,
+          name: 'Phase 2: API layer',
+          status: 'pending' as const,
+          confidence: 75,
+          raids: [
+            {
+              id: 'raid-mock-2',
+              phaseId: 'phase-mock-2',
+              trackerId: '',
+              name: 'Implement HTTP adapters',
+              description: 'Build the REST API adapters for all service ports.',
+              acceptanceCriteria: ['All endpoints covered', 'Snake_case ↔ camelCase transform'],
+              declaredFiles: ['src/adapters/http.ts'],
+              estimateHours: 8,
+              status: 'pending' as const,
+              confidence: 78,
+              sessionId: null,
+              reviewerSessionId: null,
+              reviewRound: 0,
+              branch: null,
+              chronicleSummary: null,
+              retryCount: 0,
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+            },
+          ],
+        },
+      ];
     },
 
     async spawnPlanSession(_spec: string, _repo: string): Promise<PlanSession> {
-      return { sessionId: `plan-${Date.now()}`, chatEndpoint: null };
+      return {
+        sessionId: `plan-${Date.now()}`,
+        chatEndpoint: null,
+        questions: [
+          {
+            id: 'q1',
+            question: 'Which target repositories should this saga operate on?',
+            hint: 'e.g. niuulabs/volundr, niuulabs/tyr',
+          },
+          {
+            id: 'q2',
+            question: 'What is the base branch agents should branch off from?',
+            hint: 'e.g. main, dev, feat/...',
+          },
+          {
+            id: 'q3',
+            question: 'Are there any acceptance criteria or constraints you want enforced across all raids?',
+            hint: 'e.g. all endpoints must have OpenAPI docs, no breaking API changes',
+          },
+          {
+            id: 'q4',
+            question: 'What is the desired confidence threshold before the dispatcher auto-continues?',
+            hint: 'e.g. 80 — raids below this will pause for operator approval',
+          },
+        ],
+      };
     },
 
     async extractStructure(_text: string): Promise<ExtractedStructure> {
-      return { found: false, structure: null };
+      return {
+        found: true,
+        structure: {
+          name: 'New Saga',
+          phases: [
+            {
+              name: 'Phase 1: Foundation',
+              raids: [
+                {
+                  name: 'Scaffold core domain models',
+                  description: 'Define shared domain types and port interfaces.',
+                  acceptanceCriteria: ['All types exported from index.ts', 'No circular imports'],
+                  declaredFiles: ['src/domain/models.ts', 'src/ports/index.ts'],
+                  estimateHours: 4,
+                  confidence: 85,
+                },
+              ],
+            },
+            {
+              name: 'Phase 2: API layer',
+              raids: [
+                {
+                  name: 'Implement HTTP adapters',
+                  description: 'Build the REST API adapters for all service ports.',
+                  acceptanceCriteria: [
+                    'All endpoints covered',
+                    'Snake_case ↔ camelCase transform',
+                  ],
+                  declaredFiles: ['src/adapters/http.ts'],
+                  estimateHours: 8,
+                  confidence: 78,
+                },
+              ],
+            },
+          ],
+        },
+      };
     },
   };
 }

--- a/web-next/packages/plugin-tyr/src/adapters/mock.ts
+++ b/web-next/packages/plugin-tyr/src/adapters/mock.ts
@@ -778,7 +778,12 @@ export function createMockTyrSettingsService(): ITyrSettingsService {
       const retryPolicy = patch.retryPolicy
         ? { ...dispatchDefaults.retryPolicy, ...patch.retryPolicy }
         : dispatchDefaults.retryPolicy;
-      dispatchDefaults = { ...dispatchDefaults, ...patch, retryPolicy, updatedAt: new Date().toISOString() };
+      dispatchDefaults = {
+        ...dispatchDefaults,
+        ...patch,
+        retryPolicy,
+        updatedAt: new Date().toISOString(),
+      };
       return { ...dispatchDefaults, retryPolicy: { ...dispatchDefaults.retryPolicy } };
     },
 
@@ -787,7 +792,11 @@ export function createMockTyrSettingsService(): ITyrSettingsService {
     },
 
     async updateNotificationSettings(patch) {
-      notificationSettings = { ...notificationSettings, ...patch, updatedAt: new Date().toISOString() };
+      notificationSettings = {
+        ...notificationSettings,
+        ...patch,
+        updatedAt: new Date().toISOString(),
+      };
       return { ...notificationSettings };
     },
   };

--- a/web-next/packages/plugin-tyr/src/domain/plan.test.ts
+++ b/web-next/packages/plugin-tyr/src/domain/plan.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest';
+import {
+  planTransition,
+  canTransition,
+  PlanTransitionError,
+  PLAN_STEPS,
+  PLAN_STEP_LABELS,
+  stepIndex,
+  type PlanStep,
+} from './plan';
+
+describe('planTransition — valid paths', () => {
+  it('allows prompt → questions', () => {
+    expect(planTransition('prompt', 'questions')).toBe('questions');
+  });
+
+  it('allows questions → raiding', () => {
+    expect(planTransition('questions', 'raiding')).toBe('raiding');
+  });
+
+  it('allows questions → prompt (back)', () => {
+    expect(planTransition('questions', 'prompt')).toBe('prompt');
+  });
+
+  it('allows raiding → draft', () => {
+    expect(planTransition('raiding', 'draft')).toBe('draft');
+  });
+
+  it('allows raiding → questions (back)', () => {
+    expect(planTransition('raiding', 'questions')).toBe('questions');
+  });
+
+  it('allows draft → approved', () => {
+    expect(planTransition('draft', 'approved')).toBe('approved');
+  });
+
+  it('allows draft → raiding (back)', () => {
+    expect(planTransition('draft', 'raiding')).toBe('raiding');
+  });
+});
+
+describe('planTransition — refused transitions', () => {
+  it('refuses prompt → raiding (skip questions)', () => {
+    expect(() => planTransition('prompt', 'raiding')).toThrow(PlanTransitionError);
+  });
+
+  it('refuses prompt → draft (skip ahead)', () => {
+    expect(() => planTransition('prompt', 'draft')).toThrow(PlanTransitionError);
+  });
+
+  it('refuses prompt → approved (skip all)', () => {
+    expect(() => planTransition('prompt', 'approved')).toThrow(PlanTransitionError);
+  });
+
+  it('refuses questions → draft (skip raiding)', () => {
+    expect(() => planTransition('questions', 'draft')).toThrow(PlanTransitionError);
+  });
+
+  it('refuses questions → approved', () => {
+    expect(() => planTransition('questions', 'approved')).toThrow(PlanTransitionError);
+  });
+
+  it('refuses raiding → prompt (skip back two)', () => {
+    expect(() => planTransition('raiding', 'prompt')).toThrow(PlanTransitionError);
+  });
+
+  it('refuses raiding → approved (skip draft)', () => {
+    expect(() => planTransition('raiding', 'approved')).toThrow(PlanTransitionError);
+  });
+
+  it('refuses draft → prompt', () => {
+    expect(() => planTransition('draft', 'prompt')).toThrow(PlanTransitionError);
+  });
+
+  it('refuses approved → prompt (no restart)', () => {
+    expect(() => planTransition('approved', 'prompt')).toThrow(PlanTransitionError);
+  });
+
+  it('refuses approved → draft', () => {
+    expect(() => planTransition('approved', 'draft')).toThrow(PlanTransitionError);
+  });
+
+  it('refuses approved → approved (self-loop)', () => {
+    expect(() => planTransition('approved', 'approved')).toThrow(PlanTransitionError);
+  });
+});
+
+describe('PlanTransitionError', () => {
+  it('carries from and to properties', () => {
+    let caught: unknown;
+    try {
+      planTransition('prompt', 'approved');
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(PlanTransitionError);
+    const err = caught as PlanTransitionError;
+    expect(err.from).toBe('prompt');
+    expect(err.to).toBe('approved');
+  });
+
+  it('has descriptive message', () => {
+    const err = new PlanTransitionError('prompt', 'approved');
+    expect(err.message).toContain('prompt');
+    expect(err.message).toContain('approved');
+  });
+
+  it('has correct name', () => {
+    const err = new PlanTransitionError('questions', 'draft');
+    expect(err.name).toBe('PlanTransitionError');
+  });
+});
+
+describe('canTransition', () => {
+  const validPairs: [PlanStep, PlanStep][] = [
+    ['prompt', 'questions'],
+    ['questions', 'raiding'],
+    ['questions', 'prompt'],
+    ['raiding', 'draft'],
+    ['raiding', 'questions'],
+    ['draft', 'approved'],
+    ['draft', 'raiding'],
+  ];
+
+  it.each(validPairs)('returns true for %s → %s', (from, to) => {
+    expect(canTransition(from, to)).toBe(true);
+  });
+
+  const invalidPairs: [PlanStep, PlanStep][] = [
+    ['prompt', 'raiding'],
+    ['prompt', 'draft'],
+    ['prompt', 'approved'],
+    ['questions', 'draft'],
+    ['approved', 'prompt'],
+    ['approved', 'approved'],
+  ];
+
+  it.each(invalidPairs)('returns false for %s → %s', (from, to) => {
+    expect(canTransition(from, to)).toBe(false);
+  });
+});
+
+describe('PLAN_STEPS', () => {
+  it('has exactly 5 steps', () => {
+    expect(PLAN_STEPS).toHaveLength(5);
+  });
+
+  it('is ordered: prompt → questions → raiding → draft → approved', () => {
+    expect(PLAN_STEPS).toEqual(['prompt', 'questions', 'raiding', 'draft', 'approved']);
+  });
+});
+
+describe('PLAN_STEP_LABELS', () => {
+  it('has a label for every step', () => {
+    for (const step of PLAN_STEPS) {
+      expect(PLAN_STEP_LABELS[step]).toBeTruthy();
+    }
+  });
+});
+
+describe('stepIndex', () => {
+  it('returns 0 for prompt', () => expect(stepIndex('prompt')).toBe(0));
+  it('returns 1 for questions', () => expect(stepIndex('questions')).toBe(1));
+  it('returns 2 for raiding', () => expect(stepIndex('raiding')).toBe(2));
+  it('returns 3 for draft', () => expect(stepIndex('draft')).toBe(3));
+  it('returns 4 for approved', () => expect(stepIndex('approved')).toBe(4));
+});

--- a/web-next/packages/plugin-tyr/src/domain/plan.ts
+++ b/web-next/packages/plugin-tyr/src/domain/plan.ts
@@ -1,0 +1,82 @@
+/**
+ * Plan wizard domain model.
+ *
+ * Pure state machine describing the five steps of the Tyr plan wizard.
+ * No framework imports — business logic only.
+ */
+
+// ---------------------------------------------------------------------------
+// Steps
+// ---------------------------------------------------------------------------
+
+export type PlanStep = 'prompt' | 'questions' | 'raiding' | 'draft' | 'approved';
+
+export const PLAN_STEPS: PlanStep[] = ['prompt', 'questions', 'raiding', 'draft', 'approved'];
+
+export const PLAN_STEP_LABELS: Record<PlanStep, string> = {
+  prompt: 'Describe',
+  questions: 'Clarify',
+  raiding: 'Decompose',
+  draft: 'Review',
+  approved: 'Launch',
+};
+
+// ---------------------------------------------------------------------------
+// Transitions
+// ---------------------------------------------------------------------------
+
+const VALID_TRANSITIONS: Record<PlanStep, readonly PlanStep[]> = {
+  prompt: ['questions'],
+  questions: ['raiding', 'prompt'],
+  raiding: ['draft', 'questions'],
+  draft: ['approved', 'raiding'],
+  approved: [],
+};
+
+export class PlanTransitionError extends Error {
+  readonly from: PlanStep;
+  readonly to: PlanStep;
+
+  constructor(from: PlanStep, to: PlanStep) {
+    super(`Invalid plan transition: ${from} → ${to}`);
+    this.name = 'PlanTransitionError';
+    this.from = from;
+    this.to = to;
+  }
+}
+
+/**
+ * Validate and execute a state transition.
+ * Throws PlanTransitionError if the transition is not in the allowed set.
+ */
+export function planTransition(from: PlanStep, to: PlanStep): PlanStep {
+  const allowed = VALID_TRANSITIONS[from];
+  if (!(allowed as readonly string[]).includes(to)) {
+    throw new PlanTransitionError(from, to);
+  }
+  return to;
+}
+
+/**
+ * Returns whether a transition from `from` to `to` is valid without throwing.
+ */
+export function canTransition(from: PlanStep, to: PlanStep): boolean {
+  return (VALID_TRANSITIONS[from] as readonly string[]).includes(to);
+}
+
+/**
+ * Returns the zero-based index of a step in PLAN_STEPS.
+ */
+export function stepIndex(step: PlanStep): number {
+  return PLAN_STEPS.indexOf(step);
+}
+
+// ---------------------------------------------------------------------------
+// Domain types
+// ---------------------------------------------------------------------------
+
+export interface ClarifyingQuestion {
+  id: string;
+  question: string;
+  hint?: string;
+}

--- a/web-next/packages/plugin-tyr/src/domain/settings.test.ts
+++ b/web-next/packages/plugin-tyr/src/domain/settings.test.ts
@@ -160,9 +160,7 @@ describe('auditEntrySchema', () => {
   });
 
   it('rejects unknown kind', () => {
-    expect(() =>
-      auditEntrySchema.parse({ ...VALID_AUDIT_ENTRY, kind: 'unknown.event' }),
-    ).toThrow();
+    expect(() => auditEntrySchema.parse({ ...VALID_AUDIT_ENTRY, kind: 'unknown.event' })).toThrow();
   });
 });
 

--- a/web-next/packages/plugin-tyr/src/index.ts
+++ b/web-next/packages/plugin-tyr/src/index.ts
@@ -7,6 +7,7 @@ import { DispatchView } from './ui/DispatchView';
 import { SettingsPage, SettingsIndexPage } from './ui/settings/SettingsPage';
 import { SettingsRail } from './ui/settings/SettingsRail';
 import { SettingsTopbar } from './ui/settings/SettingsTopbar';
+import { PlanWizard } from './ui/PlanWizard';
 
 export const tyrPlugin = definePlugin({
   id: 'tyr',
@@ -63,6 +64,11 @@ export const tyrPlugin = definePlugin({
       getParentRoute: () => rootRoute,
       path: '/tyr/settings/audit',
       component: () => SettingsPage({ section: 'audit' }),
+    }),
+    createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/tyr/plan',
+      component: PlanWizard,
     }),
   ],
   subnav: () => SettingsRail(),
@@ -190,6 +196,17 @@ export {
 } from './domain/workflow';
 
 export { dispatcherStateSchema, dispatchRuleSchema } from './domain/dispatcher';
+
+export {
+  PLAN_STEPS,
+  PLAN_STEP_LABELS,
+  planTransition,
+  canTransition,
+  stepIndex,
+  PlanTransitionError,
+  type PlanStep,
+  type ClarifyingQuestion,
+} from './domain/plan';
 
 export { tyrSessionStatusSchema, sessionInfoSchema } from './domain/session';
 

--- a/web-next/packages/plugin-tyr/src/ports.ts
+++ b/web-next/packages/plugin-tyr/src/ports.ts
@@ -18,6 +18,7 @@ import type {
   AuditEntry,
   AuditFilter,
 } from './domain/settings';
+import type { ClarifyingQuestion } from './domain/plan';
 
 // Re-export domain types so consumers can import from a single location.
 export type { Saga, Phase } from './domain/saga';
@@ -34,6 +35,7 @@ export type {
   AuditEntryKind,
   AuditFilter,
 } from './domain/settings';
+export type { ClarifyingQuestion } from './domain/plan';
 
 // ---------------------------------------------------------------------------
 // ITyrService — saga lifecycle and planning
@@ -61,6 +63,8 @@ export interface CommitSagaRequest {
 export interface PlanSession {
   sessionId: string;
   chatEndpoint: string | null;
+  /** Clarifying questions from the planning raven. Empty when the backend omits them. */
+  questions: ClarifyingQuestion[];
 }
 
 export interface RaidSpec {

--- a/web-next/packages/plugin-tyr/src/ui/PlanApproved.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/PlanApproved.tsx
@@ -19,9 +19,7 @@ export function PlanApproved({ saga, onNewPlan }: PlanApprovedProps) {
       <Rune glyph="ᛏ" size={48} />
 
       <div className="niuu-flex niuu-flex-col niuu-gap-2">
-        <h2 className="niuu-text-xl niuu-font-semibold niuu-text-text-primary">
-          Saga launched!
-        </h2>
+        <h2 className="niuu-text-xl niuu-font-semibold niuu-text-text-primary">Saga launched!</h2>
         <p className="niuu-text-sm niuu-text-text-secondary">
           <span className="niuu-font-medium niuu-text-brand-400">{saga.name}</span> has been created
           and is ready for the dispatcher.
@@ -35,7 +33,9 @@ export function PlanApproved({ saga, onNewPlan }: PlanApprovedProps) {
         </div>
         <div className="niuu-flex niuu-justify-between niuu-text-sm">
           <dt className="niuu-text-text-muted">Branch</dt>
-          <dd className="niuu-font-mono niuu-text-text-secondary niuu-text-xs">{saga.featureBranch}</dd>
+          <dd className="niuu-font-mono niuu-text-text-secondary niuu-text-xs">
+            {saga.featureBranch}
+          </dd>
         </div>
         <div className="niuu-flex niuu-justify-between niuu-text-sm">
           <dt className="niuu-text-text-muted">Phases</dt>

--- a/web-next/packages/plugin-tyr/src/ui/PlanApproved.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/PlanApproved.tsx
@@ -1,0 +1,69 @@
+import { Rune } from '@niuulabs/ui';
+import type { Saga } from '../domain/saga';
+
+interface PlanApprovedProps {
+  saga: Saga;
+  onNewPlan?(): void;
+}
+
+/**
+ * Step 5 of the Plan wizard — confirmation that the saga has been created.
+ */
+export function PlanApproved({ saga, onNewPlan }: PlanApprovedProps) {
+  return (
+    <div
+      className="niuu-flex niuu-flex-col niuu-gap-6 niuu-items-center niuu-py-8 niuu-text-center"
+      aria-live="polite"
+      data-testid="plan-approved"
+    >
+      <Rune glyph="ᛏ" size={48} />
+
+      <div className="niuu-flex niuu-flex-col niuu-gap-2">
+        <h2 className="niuu-text-xl niuu-font-semibold niuu-text-text-primary">
+          Saga launched!
+        </h2>
+        <p className="niuu-text-sm niuu-text-text-secondary">
+          <span className="niuu-font-medium niuu-text-brand-400">{saga.name}</span> has been created
+          and is ready for the dispatcher.
+        </p>
+      </div>
+
+      <dl className="niuu-flex niuu-flex-col niuu-gap-1 niuu-text-left niuu-w-full niuu-max-w-sm niuu-rounded-lg niuu-border niuu-border-border niuu-bg-bg-secondary niuu-px-4 niuu-py-3">
+        <div className="niuu-flex niuu-justify-between niuu-text-sm">
+          <dt className="niuu-text-text-muted">Saga</dt>
+          <dd className="niuu-text-text-primary niuu-font-medium">{saga.name}</dd>
+        </div>
+        <div className="niuu-flex niuu-justify-between niuu-text-sm">
+          <dt className="niuu-text-text-muted">Branch</dt>
+          <dd className="niuu-font-mono niuu-text-text-secondary niuu-text-xs">{saga.featureBranch}</dd>
+        </div>
+        <div className="niuu-flex niuu-justify-between niuu-text-sm">
+          <dt className="niuu-text-text-muted">Phases</dt>
+          <dd className="niuu-text-text-secondary">{saga.phaseSummary.total}</dd>
+        </div>
+        <div className="niuu-flex niuu-justify-between niuu-text-sm">
+          <dt className="niuu-text-text-muted">Confidence</dt>
+          <dd className="niuu-text-text-secondary">{saga.confidence}%</dd>
+        </div>
+      </dl>
+
+      <div className="niuu-flex niuu-gap-3">
+        <a
+          href="/tyr"
+          className="niuu-rounded-md niuu-bg-brand-500 niuu-px-4 niuu-py-2 niuu-text-sm niuu-font-medium niuu-text-white hover:niuu-bg-brand-600 niuu-transition-colors"
+        >
+          Open in Sagas →
+        </a>
+        {onNewPlan && (
+          <button
+            type="button"
+            onClick={onNewPlan}
+            className="niuu-rounded-md niuu-px-4 niuu-py-2 niuu-text-sm niuu-font-medium niuu-text-text-secondary niuu-border niuu-border-border hover:niuu-bg-bg-elevated niuu-transition-colors"
+          >
+            New plan
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web-next/packages/plugin-tyr/src/ui/PlanDraft.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/PlanDraft.tsx
@@ -168,7 +168,7 @@ export function PlanDraft({
 
       {phases.length === 0 && (
         <p className="niuu-text-sm niuu-text-text-muted niuu-italic">
-          No phases extracted — the raven couldn't decompose this goal. Try going back and adding
+          No phases extracted — the raven couldn&apos;t decompose this goal. Try going back and adding
           more context.
         </p>
       )}

--- a/web-next/packages/plugin-tyr/src/ui/PlanDraft.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/PlanDraft.tsx
@@ -1,0 +1,213 @@
+import { useState } from 'react';
+import { ConfidenceBar } from '@niuulabs/ui';
+import type { ExtractedStructure, PhaseSpec } from '../ports';
+
+interface PlanDraftProps {
+  structure: ExtractedStructure;
+  loading: boolean;
+  error: string | null;
+  onApprove(): void;
+  onBack(): void;
+  onEditPhase(phaseIndex: number, name: string): void;
+}
+
+interface PhaseEditorProps {
+  phase: PhaseSpec;
+  phaseIndex: number;
+  onSave(name: string): void;
+}
+
+function PhaseEditor({ phase, phaseIndex, onSave }: PhaseEditorProps) {
+  const [editing, setEditing] = useState(false);
+  const [name, setName] = useState(phase.name);
+
+  function handleSave() {
+    onSave(name);
+    setEditing(false);
+  }
+
+  function handleCancel() {
+    setName(phase.name);
+    setEditing(false);
+  }
+
+  const avgConfidence =
+    phase.raids.length > 0
+      ? Math.round(phase.raids.reduce((sum, r) => sum + r.confidence, 0) / phase.raids.length)
+      : 0;
+
+  return (
+    <div
+      className="niuu-rounded-lg niuu-border niuu-border-border niuu-bg-bg-secondary niuu-p-4 niuu-flex niuu-flex-col niuu-gap-3"
+      data-testid={`phase-${phaseIndex}`}
+    >
+      <div className="niuu-flex niuu-items-start niuu-justify-between niuu-gap-2">
+        {editing ? (
+          <div className="niuu-flex niuu-items-center niuu-gap-2 niuu-flex-1">
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              aria-label={`Edit phase ${phaseIndex + 1} name`}
+              className="niuu-flex-1 niuu-rounded niuu-border niuu-border-border niuu-bg-bg-tertiary niuu-px-2 niuu-py-1 niuu-text-sm niuu-text-text-primary focus:niuu-outline-none focus:niuu-ring-2 focus:niuu-ring-brand-500/40"
+              autoFocus
+            />
+            <button
+              type="button"
+              onClick={handleSave}
+              className="niuu-text-xs niuu-font-medium niuu-text-brand-400 hover:niuu-text-brand-300"
+            >
+              Save
+            </button>
+            <button
+              type="button"
+              onClick={handleCancel}
+              className="niuu-text-xs niuu-text-text-muted hover:niuu-text-text-secondary"
+            >
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <>
+            <div className="niuu-flex niuu-flex-col niuu-gap-1 niuu-flex-1 niuu-min-w-0">
+              <h3 className="niuu-text-sm niuu-font-semibold niuu-text-text-primary niuu-truncate">
+                {phase.name}
+              </h3>
+              {phase.raids.length > 0 && (
+                <div className="niuu-flex niuu-items-center niuu-gap-2">
+                  <ConfidenceBar value={avgConfidence} mini />
+                  <span className="niuu-text-xs niuu-text-text-muted">
+                    {phase.raids.length} raid{phase.raids.length !== 1 ? 's' : ''}
+                  </span>
+                </div>
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={() => setEditing(true)}
+              aria-label={`Edit phase ${phaseIndex + 1}`}
+              className="niuu-flex-shrink-0 niuu-text-xs niuu-font-medium niuu-text-text-muted hover:niuu-text-text-secondary niuu-border niuu-border-border niuu-rounded niuu-px-2 niuu-py-1 niuu-transition-colors"
+            >
+              Edit
+            </button>
+          </>
+        )}
+      </div>
+
+      {phase.raids.length > 0 && (
+        <ul className="niuu-flex niuu-flex-col niuu-gap-2 niuu-list-none niuu-p-0 niuu-m-0">
+          {phase.raids.map((raid, ri) => (
+            <li
+              key={ri}
+              className="niuu-rounded niuu-bg-bg-tertiary niuu-px-3 niuu-py-2 niuu-flex niuu-flex-col niuu-gap-0.5"
+            >
+              <span className="niuu-text-xs niuu-font-medium niuu-text-text-primary">
+                {raid.name}
+              </span>
+              {raid.description && (
+                <span className="niuu-text-xs niuu-text-text-muted">{raid.description}</span>
+              )}
+              <span className="niuu-text-xs niuu-text-text-muted">
+                ~{raid.estimateHours}h · {raid.confidence}% confidence
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Step 4 of the Plan wizard — review the decomposed saga structure with
+ * per-phase edit buttons before approving.
+ */
+export function PlanDraft({
+  structure,
+  loading,
+  error,
+  onApprove,
+  onBack,
+  onEditPhase,
+}: PlanDraftProps) {
+  const phases = structure.structure?.phases ?? [];
+  const sagaName = structure.structure?.name ?? 'New Saga';
+
+  const totalRaids = phases.reduce((sum, p) => sum + p.raids.length, 0);
+  const avgConfidence =
+    totalRaids > 0
+      ? Math.round(
+          phases.flatMap((p) => p.raids).reduce((sum, r) => sum + r.confidence, 0) / totalRaids,
+        )
+      : 0;
+
+  return (
+    <div className="niuu-flex niuu-flex-col niuu-gap-4">
+      <div className="niuu-flex niuu-flex-col niuu-gap-1">
+        <h2 className="niuu-text-lg niuu-font-semibold niuu-text-text-primary">Review your plan</h2>
+        <p className="niuu-text-sm niuu-text-text-secondary">
+          The planning raven decomposed your goal. Edit any phase, then approve to create the saga.
+        </p>
+      </div>
+
+      <div className="niuu-rounded-lg niuu-border niuu-border-border niuu-bg-bg-elevated niuu-px-4 niuu-py-3 niuu-flex niuu-items-center niuu-justify-between">
+        <div className="niuu-flex niuu-flex-col">
+          <span className="niuu-text-sm niuu-font-semibold niuu-text-text-primary">{sagaName}</span>
+          <span className="niuu-text-xs niuu-text-text-muted">
+            {phases.length} phase{phases.length !== 1 ? 's' : ''} · {totalRaids} raid
+            {totalRaids !== 1 ? 's' : ''}
+          </span>
+        </div>
+        {totalRaids > 0 && (
+          <div className="niuu-flex niuu-items-center niuu-gap-2">
+            <ConfidenceBar value={avgConfidence} />
+            <span className="niuu-text-xs niuu-text-text-secondary">{avgConfidence}%</span>
+          </div>
+        )}
+      </div>
+
+      {phases.length === 0 && (
+        <p className="niuu-text-sm niuu-text-text-muted niuu-italic">
+          No phases extracted — the raven couldn't decompose this goal. Try going back and adding
+          more context.
+        </p>
+      )}
+
+      <div className="niuu-flex niuu-flex-col niuu-gap-3">
+        {phases.map((phase, idx) => (
+          <PhaseEditor
+            key={idx}
+            phase={phase}
+            phaseIndex={idx}
+            onSave={(name) => onEditPhase(idx, name)}
+          />
+        ))}
+      </div>
+
+      {error && (
+        <p role="alert" className="niuu-text-sm niuu-text-critical">
+          {error}
+        </p>
+      )}
+
+      <div className="niuu-flex niuu-justify-between">
+        <button
+          type="button"
+          onClick={onBack}
+          disabled={loading}
+          className="niuu-rounded-md niuu-px-4 niuu-py-2 niuu-text-sm niuu-font-medium niuu-text-text-secondary niuu-border niuu-border-border hover:niuu-bg-bg-elevated disabled:niuu-opacity-40 niuu-transition-colors"
+        >
+          ← Back
+        </button>
+        <button
+          type="button"
+          onClick={onApprove}
+          disabled={loading || phases.length === 0}
+          className="niuu-rounded-md niuu-bg-brand-500 niuu-px-4 niuu-py-2 niuu-text-sm niuu-font-medium niuu-text-white disabled:niuu-opacity-40 disabled:niuu-cursor-not-allowed hover:niuu-bg-brand-600 niuu-transition-colors"
+        >
+          {loading ? 'Launching…' : 'Approve & launch →'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web-next/packages/plugin-tyr/src/ui/PlanDraft.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/PlanDraft.tsx
@@ -1,6 +1,12 @@
 import { useState } from 'react';
-import { ConfidenceBar } from '@niuulabs/ui';
+import { ConfidenceBar, type ConfidenceLevel } from '@niuulabs/ui';
 import type { ExtractedStructure, PhaseSpec } from '../ports';
+
+function toLevel(value: number): ConfidenceLevel {
+  if (value >= 80) return 'high';
+  if (value >= 50) return 'medium';
+  return 'low';
+}
 
 interface PlanDraftProps {
   structure: ExtractedStructure;
@@ -75,7 +81,7 @@ function PhaseEditor({ phase, phaseIndex, onSave }: PhaseEditorProps) {
               </h3>
               {phase.raids.length > 0 && (
                 <div className="niuu-flex niuu-items-center niuu-gap-2">
-                  <ConfidenceBar value={avgConfidence} mini />
+                  <ConfidenceBar level={toLevel(avgConfidence)} />
                   <span className="niuu-text-xs niuu-text-text-muted">
                     {phase.raids.length} raid{phase.raids.length !== 1 ? 's' : ''}
                   </span>
@@ -160,7 +166,7 @@ export function PlanDraft({
         </div>
         {totalRaids > 0 && (
           <div className="niuu-flex niuu-items-center niuu-gap-2">
-            <ConfidenceBar value={avgConfidence} />
+            <ConfidenceBar level={toLevel(avgConfidence)} />
             <span className="niuu-text-xs niuu-text-text-secondary">{avgConfidence}%</span>
           </div>
         )}
@@ -168,8 +174,8 @@ export function PlanDraft({
 
       {phases.length === 0 && (
         <p className="niuu-text-sm niuu-text-text-muted niuu-italic">
-          No phases extracted — the raven couldn&apos;t decompose this goal. Try going back and adding
-          more context.
+          No phases extracted — the raven couldn&apos;t decompose this goal. Try going back and
+          adding more context.
         </p>
       )}
 

--- a/web-next/packages/plugin-tyr/src/ui/PlanPrompt.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/PlanPrompt.tsx
@@ -61,7 +61,10 @@ export function PlanPrompt({ onSubmit, loading, error }: PlanPromptProps) {
       </div>
 
       <div className="niuu-flex niuu-flex-col niuu-gap-1">
-        <label htmlFor="plan-repo" className="niuu-text-sm niuu-font-medium niuu-text-text-secondary">
+        <label
+          htmlFor="plan-repo"
+          className="niuu-text-sm niuu-font-medium niuu-text-text-secondary"
+        >
           Target repository
         </label>
         <input
@@ -75,11 +78,7 @@ export function PlanPrompt({ onSubmit, loading, error }: PlanPromptProps) {
       </div>
 
       {error && (
-        <p
-          id="plan-prompt-error"
-          role="alert"
-          className="niuu-text-sm niuu-text-critical"
-        >
+        <p id="plan-prompt-error" role="alert" className="niuu-text-sm niuu-text-critical">
           {error}
         </p>
       )}

--- a/web-next/packages/plugin-tyr/src/ui/PlanPrompt.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/PlanPrompt.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react';
+
+interface PlanPromptProps {
+  onSubmit(prompt: string, repo: string): void;
+  loading: boolean;
+  error: string | null;
+}
+
+/**
+ * Step 1 of the Plan wizard — capture the human‐language goal and target repo.
+ */
+export function PlanPrompt({ onSubmit, loading, error }: PlanPromptProps) {
+  const [prompt, setPrompt] = useState('');
+  const [repo, setRepo] = useState('');
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!prompt.trim()) return;
+    onSubmit(prompt.trim(), repo.trim());
+  }
+
+  const canSubmit = prompt.trim().length > 0 && !loading;
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      aria-label="Plan prompt form"
+      className="niuu-flex niuu-flex-col niuu-gap-4"
+    >
+      <div className="niuu-flex niuu-flex-col niuu-gap-1">
+        <h2 className="niuu-text-lg niuu-font-semibold niuu-text-text-primary">
+          Describe your goal
+        </h2>
+        <p className="niuu-text-sm niuu-text-text-secondary">
+          Tell Tyr what you want to build. The planning raven will decompose it into phases and
+          raids.
+        </p>
+      </div>
+
+      <div className="niuu-flex niuu-flex-col niuu-gap-1">
+        <label
+          htmlFor="plan-prompt"
+          className="niuu-text-sm niuu-font-medium niuu-text-text-secondary"
+        >
+          Goal description
+          <span className="niuu-ml-1 niuu-text-critical" aria-hidden="true">
+            *
+          </span>
+        </label>
+        <textarea
+          id="plan-prompt"
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          placeholder="e.g. Add OIDC authentication with Keycloak, including silent token refresh and PAT support for headless agents."
+          rows={5}
+          required
+          aria-required="true"
+          aria-describedby={error ? 'plan-prompt-error' : undefined}
+          className="niuu-w-full niuu-rounded-md niuu-border niuu-border-border niuu-bg-bg-secondary niuu-px-3 niuu-py-2 niuu-text-sm niuu-text-text-primary niuu-placeholder-text-muted niuu-resize-y focus:niuu-outline-none focus:niuu-ring-2 focus:niuu-ring-brand-500/40"
+        />
+      </div>
+
+      <div className="niuu-flex niuu-flex-col niuu-gap-1">
+        <label htmlFor="plan-repo" className="niuu-text-sm niuu-font-medium niuu-text-text-secondary">
+          Target repository
+        </label>
+        <input
+          id="plan-repo"
+          type="text"
+          value={repo}
+          onChange={(e) => setRepo(e.target.value)}
+          placeholder="e.g. niuulabs/volundr"
+          className="niuu-w-full niuu-rounded-md niuu-border niuu-border-border niuu-bg-bg-secondary niuu-px-3 niuu-py-2 niuu-text-sm niuu-text-text-primary niuu-placeholder-text-muted focus:niuu-outline-none focus:niuu-ring-2 focus:niuu-ring-brand-500/40"
+        />
+      </div>
+
+      {error && (
+        <p
+          id="plan-prompt-error"
+          role="alert"
+          className="niuu-text-sm niuu-text-critical"
+        >
+          {error}
+        </p>
+      )}
+
+      <div className="niuu-flex niuu-justify-end">
+        <button
+          type="submit"
+          disabled={!canSubmit}
+          className="niuu-rounded-md niuu-bg-brand-500 niuu-px-4 niuu-py-2 niuu-text-sm niuu-font-medium niuu-text-white disabled:niuu-opacity-40 disabled:niuu-cursor-not-allowed hover:niuu-bg-brand-600 niuu-transition-colors"
+        >
+          {loading ? 'Starting…' : 'Next →'}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/web-next/packages/plugin-tyr/src/ui/PlanQuestions.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/PlanQuestions.tsx
@@ -39,7 +39,7 @@ export function PlanQuestions({
           Clarify your plan
         </h2>
         <p className="niuu-text-sm niuu-text-text-secondary">
-          Answer as many questions as you can. Answers are optional — skip any that don't apply.
+          Answer as many questions as you can. Answers are optional — skip any that don&apos;t apply.
         </p>
       </div>
 

--- a/web-next/packages/plugin-tyr/src/ui/PlanQuestions.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/PlanQuestions.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react';
+import type { ClarifyingQuestion } from '../domain/plan';
+
+interface PlanQuestionsProps {
+  questions: ClarifyingQuestion[];
+  initialAnswers?: Record<string, string>;
+  onSubmit(answers: Record<string, string>): void;
+  onBack(): void;
+}
+
+/**
+ * Step 2 of the Plan wizard — answer clarifying questions from the planning raven.
+ */
+export function PlanQuestions({
+  questions,
+  initialAnswers = {},
+  onSubmit,
+  onBack,
+}: PlanQuestionsProps) {
+  const [answers, setAnswers] = useState<Record<string, string>>(initialAnswers);
+
+  function handleChange(id: string, value: string) {
+    setAnswers((prev) => ({ ...prev, [id]: value }));
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    onSubmit(answers);
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      aria-label="Clarifying questions form"
+      className="niuu-flex niuu-flex-col niuu-gap-4"
+    >
+      <div className="niuu-flex niuu-flex-col niuu-gap-1">
+        <h2 className="niuu-text-lg niuu-font-semibold niuu-text-text-primary">
+          Clarify your plan
+        </h2>
+        <p className="niuu-text-sm niuu-text-text-secondary">
+          Answer as many questions as you can. Answers are optional — skip any that don't apply.
+        </p>
+      </div>
+
+      {questions.length === 0 && (
+        <p className="niuu-text-sm niuu-text-text-muted niuu-italic">
+          No clarifying questions — you can proceed directly.
+        </p>
+      )}
+
+      <ol className="niuu-flex niuu-flex-col niuu-gap-4 niuu-list-none niuu-p-0 niuu-m-0">
+        {questions.map((q, idx) => (
+          <li key={q.id} className="niuu-flex niuu-flex-col niuu-gap-1">
+            <label
+              htmlFor={`q-${q.id}`}
+              className="niuu-text-sm niuu-font-medium niuu-text-text-primary"
+            >
+              <span className="niuu-text-text-muted niuu-mr-2">{idx + 1}.</span>
+              {q.question}
+            </label>
+            {q.hint && (
+              <p className="niuu-text-xs niuu-text-text-muted" id={`q-${q.id}-hint`}>
+                {q.hint}
+              </p>
+            )}
+            <input
+              id={`q-${q.id}`}
+              type="text"
+              value={answers[q.id] ?? ''}
+              onChange={(e) => handleChange(q.id, e.target.value)}
+              aria-describedby={q.hint ? `q-${q.id}-hint` : undefined}
+              placeholder="Your answer (optional)"
+              className="niuu-w-full niuu-rounded-md niuu-border niuu-border-border niuu-bg-bg-secondary niuu-px-3 niuu-py-2 niuu-text-sm niuu-text-text-primary niuu-placeholder-text-muted focus:niuu-outline-none focus:niuu-ring-2 focus:niuu-ring-brand-500/40"
+            />
+          </li>
+        ))}
+      </ol>
+
+      <div className="niuu-flex niuu-justify-between">
+        <button
+          type="button"
+          onClick={onBack}
+          className="niuu-rounded-md niuu-px-4 niuu-py-2 niuu-text-sm niuu-font-medium niuu-text-text-secondary niuu-border niuu-border-border hover:niuu-bg-bg-elevated niuu-transition-colors"
+        >
+          ← Back
+        </button>
+        <button
+          type="submit"
+          className="niuu-rounded-md niuu-bg-brand-500 niuu-px-4 niuu-py-2 niuu-text-sm niuu-font-medium niuu-text-white hover:niuu-bg-brand-600 niuu-transition-colors"
+        >
+          Decompose →
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/web-next/packages/plugin-tyr/src/ui/PlanQuestions.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/PlanQuestions.tsx
@@ -39,7 +39,8 @@ export function PlanQuestions({
           Clarify your plan
         </h2>
         <p className="niuu-text-sm niuu-text-text-secondary">
-          Answer as many questions as you can. Answers are optional — skip any that don&apos;t apply.
+          Answer as many questions as you can. Answers are optional — skip any that don&apos;t
+          apply.
         </p>
       </div>
 

--- a/web-next/packages/plugin-tyr/src/ui/PlanRaiding.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/PlanRaiding.tsx
@@ -1,0 +1,70 @@
+import { StateDot } from '@niuulabs/ui';
+
+interface PlanRaidingProps {
+  error: string | null;
+  onBack(): void;
+}
+
+/**
+ * Step 3 of the Plan wizard — animated waiting state while the planning raven
+ * decomposes the goal into phases and raids.
+ */
+export function PlanRaiding({ error, onBack }: PlanRaidingProps) {
+  if (error) {
+    return (
+      <div
+        role="alert"
+        aria-live="polite"
+        className="niuu-flex niuu-flex-col niuu-gap-4 niuu-items-start"
+      >
+        <div className="niuu-flex niuu-items-center niuu-gap-2">
+          <StateDot state="failed" />
+          <h2 className="niuu-text-lg niuu-font-semibold niuu-text-text-primary">
+            Decomposition failed
+          </h2>
+        </div>
+        <p className="niuu-text-sm niuu-text-critical">{error}</p>
+        <button
+          type="button"
+          onClick={onBack}
+          className="niuu-rounded-md niuu-px-4 niuu-py-2 niuu-text-sm niuu-font-medium niuu-text-text-secondary niuu-border niuu-border-border hover:niuu-bg-bg-elevated niuu-transition-colors"
+        >
+          ← Try again
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label="Decomposing plan"
+      className="niuu-flex niuu-flex-col niuu-gap-6 niuu-items-center niuu-py-10"
+    >
+      <div className="niuu-flex niuu-flex-col niuu-items-center niuu-gap-3">
+        <StateDot state="processing" pulse />
+        <h2 className="niuu-text-lg niuu-font-semibold niuu-text-text-primary">
+          Ravens are raiding…
+        </h2>
+        <p className="niuu-text-sm niuu-text-text-secondary niuu-text-center niuu-max-w-xs">
+          The planning raven is decomposing your goal into phases and raids. This usually takes a
+          few seconds.
+        </p>
+      </div>
+
+      <div
+        className="niuu-flex niuu-gap-2"
+        aria-hidden="true"
+      >
+        {[0, 1, 2].map((i) => (
+          <span
+            key={i}
+            className="niuu-w-2 niuu-h-2 niuu-rounded-full niuu-bg-brand-400 niuu-animate-pulse"
+            style={{ animationDelay: `${i * 200}ms` }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web-next/packages/plugin-tyr/src/ui/PlanRaiding.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/PlanRaiding.tsx
@@ -53,10 +53,7 @@ export function PlanRaiding({ error, onBack }: PlanRaidingProps) {
         </p>
       </div>
 
-      <div
-        className="niuu-flex niuu-gap-2"
-        aria-hidden="true"
-      >
+      <div className="niuu-flex niuu-gap-2" aria-hidden="true">
         {[0, 1, 2].map((i) => (
           <span
             key={i}

--- a/web-next/packages/plugin-tyr/src/ui/PlanWizard.stories.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/PlanWizard.stories.tsx
@@ -1,0 +1,219 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ServicesProvider } from '@niuulabs/plugin-sdk';
+import { PlanWizard } from './PlanWizard';
+import { PlanPrompt } from './PlanPrompt';
+import { PlanQuestions } from './PlanQuestions';
+import { PlanRaiding } from './PlanRaiding';
+import { PlanDraft } from './PlanDraft';
+import { PlanApproved } from './PlanApproved';
+import { createMockTyrService } from '../adapters/mock';
+import type { ExtractedStructure } from '../ports';
+import type { Saga } from '../domain/saga';
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const QUESTIONS = [
+  { id: 'q1', question: 'Which target repositories?', hint: 'e.g. niuulabs/volundr' },
+  { id: 'q2', question: 'Base branch?', hint: 'e.g. main' },
+  { id: 'q3', question: 'Any constraints or acceptance criteria for all raids?' },
+];
+
+const STRUCTURE: ExtractedStructure = {
+  found: true,
+  structure: {
+    name: 'Auth Rewrite',
+    phases: [
+      {
+        name: 'Phase 1: OIDC Foundation',
+        raids: [
+          {
+            name: 'Implement OIDC login',
+            description: 'Add OIDC login via Keycloak with PKCE.',
+            acceptanceCriteria: ['SSO works', 'Token refreshes silently'],
+            declaredFiles: ['src/auth/oidc.ts'],
+            estimateHours: 8,
+            confidence: 88,
+          },
+        ],
+      },
+      {
+        name: 'Phase 2: PAT Support',
+        raids: [
+          {
+            name: 'Add PAT generation',
+            description: 'Personal access tokens for headless dispatch.',
+            acceptanceCriteria: ['PATs creatable', 'PATs revocable'],
+            declaredFiles: ['src/niuu/pat.ts'],
+            estimateHours: 4,
+            confidence: 72,
+          },
+        ],
+      },
+    ],
+  },
+};
+
+const APPROVED_SAGA: Saga = {
+  id: 'saga-story-1',
+  trackerId: 'NIU-900',
+  trackerType: 'linear',
+  slug: 'auth-rewrite',
+  name: 'Auth Rewrite',
+  repos: ['niuulabs/volundr'],
+  featureBranch: 'feat/auth-rewrite',
+  status: 'active',
+  confidence: 80,
+  createdAt: '2026-01-01T00:00:00Z',
+  phaseSummary: { total: 2, completed: 0 },
+};
+
+// ---------------------------------------------------------------------------
+// Wrapper
+// ---------------------------------------------------------------------------
+
+function withServices(story: () => React.ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={client}>
+      <ServicesProvider services={{ tyr: createMockTyrService() }}>
+        {story()}
+      </ServicesProvider>
+    </QueryClientProvider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// PlanWizard full flow
+// ---------------------------------------------------------------------------
+
+const wizardMeta: Meta<typeof PlanWizard> = {
+  title: 'plugin-tyr/PlanWizard',
+  component: PlanWizard,
+  decorators: [(story) => withServices(story)],
+  parameters: {
+    layout: 'padded',
+    backgrounds: { default: 'dark' },
+  },
+};
+
+export default wizardMeta;
+type WizardStory = StoryObj<typeof PlanWizard>;
+
+export const FullFlow: WizardStory = {};
+
+// ---------------------------------------------------------------------------
+// Individual step stories
+// ---------------------------------------------------------------------------
+
+type PromptStory = StoryObj<typeof PlanPrompt>;
+export const Prompt: PromptStory = {
+  render: () => (
+    <div style={{ maxWidth: 640, padding: 24 }}>
+      <PlanPrompt onSubmit={() => undefined} loading={false} error={null} />
+    </div>
+  ),
+};
+
+export const PromptLoading: PromptStory = {
+  render: () => (
+    <div style={{ maxWidth: 640, padding: 24 }}>
+      <PlanPrompt onSubmit={() => undefined} loading={true} error={null} />
+    </div>
+  ),
+};
+
+export const PromptError: PromptStory = {
+  render: () => (
+    <div style={{ maxWidth: 640, padding: 24 }}>
+      <PlanPrompt onSubmit={() => undefined} loading={false} error="Service temporarily unavailable" />
+    </div>
+  ),
+};
+
+export const Questions = {
+  render: () => (
+    <div style={{ maxWidth: 640, padding: 24 }}>
+      <PlanQuestions questions={QUESTIONS} onSubmit={() => undefined} onBack={() => undefined} />
+    </div>
+  ),
+};
+
+export const QuestionsEmpty = {
+  render: () => (
+    <div style={{ maxWidth: 640, padding: 24 }}>
+      <PlanQuestions questions={[]} onSubmit={() => undefined} onBack={() => undefined} />
+    </div>
+  ),
+};
+
+export const Raiding = {
+  render: () => (
+    <div style={{ maxWidth: 640, padding: 24 }}>
+      <PlanRaiding error={null} onBack={() => undefined} />
+    </div>
+  ),
+};
+
+export const RaidingError = {
+  render: () => (
+    <div style={{ maxWidth: 640, padding: 24 }}>
+      <PlanRaiding error="Ravens lost the signal — decomposition timed out." onBack={() => undefined} />
+    </div>
+  ),
+};
+
+export const Draft = {
+  render: () => (
+    <div style={{ maxWidth: 640, padding: 24 }}>
+      <PlanDraft
+        structure={STRUCTURE}
+        loading={false}
+        error={null}
+        onApprove={() => undefined}
+        onBack={() => undefined}
+        onEditPhase={() => undefined}
+      />
+    </div>
+  ),
+};
+
+export const DraftLoading = {
+  render: () => (
+    <div style={{ maxWidth: 640, padding: 24 }}>
+      <PlanDraft
+        structure={STRUCTURE}
+        loading={true}
+        error={null}
+        onApprove={() => undefined}
+        onBack={() => undefined}
+        onEditPhase={() => undefined}
+      />
+    </div>
+  ),
+};
+
+export const DraftError = {
+  render: () => (
+    <div style={{ maxWidth: 640, padding: 24 }}>
+      <PlanDraft
+        structure={STRUCTURE}
+        loading={false}
+        error="Failed to commit saga — tracker is unreachable."
+        onApprove={() => undefined}
+        onBack={() => undefined}
+        onEditPhase={() => undefined}
+      />
+    </div>
+  ),
+};
+
+export const Approved = {
+  render: () => (
+    <div style={{ maxWidth: 640, padding: 24 }}>
+      <PlanApproved saga={APPROVED_SAGA} onNewPlan={() => undefined} />
+    </div>
+  ),
+};

--- a/web-next/packages/plugin-tyr/src/ui/PlanWizard.stories.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/PlanWizard.stories.tsx
@@ -78,9 +78,7 @@ function withServices(story: () => React.ReactNode) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return (
     <QueryClientProvider client={client}>
-      <ServicesProvider services={{ tyr: createMockTyrService() }}>
-        {story()}
-      </ServicesProvider>
+      <ServicesProvider services={{ tyr: createMockTyrService() }}>{story()}</ServicesProvider>
     </QueryClientProvider>
   );
 }
@@ -128,7 +126,11 @@ export const PromptLoading: PromptStory = {
 export const PromptError: PromptStory = {
   render: () => (
     <div style={{ maxWidth: 640, padding: 24 }}>
-      <PlanPrompt onSubmit={() => undefined} loading={false} error="Service temporarily unavailable" />
+      <PlanPrompt
+        onSubmit={() => undefined}
+        loading={false}
+        error="Service temporarily unavailable"
+      />
     </div>
   ),
 };
@@ -160,7 +162,10 @@ export const Raiding = {
 export const RaidingError = {
   render: () => (
     <div style={{ maxWidth: 640, padding: 24 }}>
-      <PlanRaiding error="Ravens lost the signal — decomposition timed out." onBack={() => undefined} />
+      <PlanRaiding
+        error="Ravens lost the signal — decomposition timed out."
+        onBack={() => undefined}
+      />
     </div>
   ),
 };

--- a/web-next/packages/plugin-tyr/src/ui/PlanWizard.test.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/PlanWizard.test.tsx
@@ -1,0 +1,551 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ServicesProvider } from '@niuulabs/plugin-sdk';
+import { PlanWizard } from './PlanWizard';
+import { PlanPrompt } from './PlanPrompt';
+import { PlanQuestions } from './PlanQuestions';
+import { PlanRaiding } from './PlanRaiding';
+import { PlanDraft } from './PlanDraft';
+import { PlanApproved } from './PlanApproved';
+import type { ITyrService, ExtractedStructure, PlanSession } from '../ports';
+import type { Saga } from '../domain/saga';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const MOCK_SESSION: PlanSession = {
+  sessionId: 'plan-test-1',
+  chatEndpoint: null,
+  questions: [
+    { id: 'q1', question: 'Which repos?', hint: 'e.g. niuulabs/volundr' },
+    { id: 'q2', question: 'Base branch?' },
+  ],
+};
+
+const MOCK_STRUCTURE: ExtractedStructure = {
+  found: true,
+  structure: {
+    name: 'Auth Rewrite',
+    phases: [
+      {
+        name: 'Phase 1: Foundation',
+        raids: [
+          {
+            name: 'Scaffold OIDC',
+            description: 'Add OIDC login',
+            acceptanceCriteria: ['SSO works'],
+            declaredFiles: ['src/auth.ts'],
+            estimateHours: 8,
+            confidence: 85,
+          },
+        ],
+      },
+      {
+        name: 'Phase 2: Hardening',
+        raids: [
+          {
+            name: 'Add PAT support',
+            description: 'Headless PATs',
+            acceptanceCriteria: ['PATs revocable'],
+            declaredFiles: ['src/pat.ts'],
+            estimateHours: 4,
+            confidence: 70,
+          },
+        ],
+      },
+    ],
+  },
+};
+
+const MOCK_SAGA: Saga = {
+  id: 'saga-test-1',
+  trackerId: 'NIU-999',
+  trackerType: 'linear',
+  slug: 'auth-rewrite',
+  name: 'Auth Rewrite',
+  repos: ['niuulabs/volundr'],
+  featureBranch: 'feat/auth-rewrite',
+  status: 'active',
+  confidence: 77,
+  createdAt: '2026-01-01T00:00:00Z',
+  phaseSummary: { total: 2, completed: 0 },
+};
+
+function makeSvc(overrides: Partial<ITyrService> = {}): Partial<ITyrService> {
+  return {
+    getSagas: vi.fn().mockResolvedValue([]),
+    getSaga: vi.fn().mockResolvedValue(null),
+    getPhases: vi.fn().mockResolvedValue([]),
+    createSaga: vi.fn(),
+    commitSaga: vi.fn().mockResolvedValue(MOCK_SAGA),
+    decompose: vi.fn().mockResolvedValue([]),
+    spawnPlanSession: vi.fn().mockResolvedValue(MOCK_SESSION),
+    extractStructure: vi.fn().mockResolvedValue(MOCK_STRUCTURE),
+    ...overrides,
+  };
+}
+
+function wrap(svc: Partial<ITyrService>) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>
+        <ServicesProvider services={{ tyr: svc }}>{children}</ServicesProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+// ---------------------------------------------------------------------------
+// PlanPrompt unit tests
+// ---------------------------------------------------------------------------
+
+describe('PlanPrompt', () => {
+  it('renders the heading', () => {
+    render(<PlanPrompt onSubmit={vi.fn()} loading={false} error={null} />);
+    expect(screen.getByText('Describe your goal')).toBeInTheDocument();
+  });
+
+  it('calls onSubmit with trimmed values', async () => {
+    const onSubmit = vi.fn();
+    render(<PlanPrompt onSubmit={onSubmit} loading={false} error={null} />);
+
+    await userEvent.type(screen.getByRole('textbox', { name: /goal description/i }), '  Build auth  ');
+    await userEvent.type(screen.getByRole('textbox', { name: /target repository/i }), 'niuulabs/volundr');
+    fireEvent.submit(screen.getByRole('form', { name: /plan prompt form/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith('Build auth', 'niuulabs/volundr');
+  });
+
+  it('does not submit when prompt is empty', () => {
+    const onSubmit = vi.fn();
+    render(<PlanPrompt onSubmit={onSubmit} loading={false} error={null} />);
+    fireEvent.submit(screen.getByRole('form', { name: /plan prompt form/i }));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('disables submit button while loading', () => {
+    render(<PlanPrompt onSubmit={vi.fn()} loading={true} error={null} />);
+    expect(screen.getByRole('button', { name: /starting/i })).toBeDisabled();
+  });
+
+  it('renders error message', () => {
+    render(<PlanPrompt onSubmit={vi.fn()} loading={false} error="Service unavailable" />);
+    expect(screen.getByRole('alert')).toHaveTextContent('Service unavailable');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PlanQuestions unit tests
+// ---------------------------------------------------------------------------
+
+describe('PlanQuestions', () => {
+  const questions = [
+    { id: 'q1', question: 'Which repos?', hint: 'e.g. niuulabs/volundr' },
+    { id: 'q2', question: 'Base branch?' },
+  ];
+
+  it('renders all questions', () => {
+    render(<PlanQuestions questions={questions} onSubmit={vi.fn()} onBack={vi.fn()} />);
+    expect(screen.getByText('Which repos?')).toBeInTheDocument();
+    expect(screen.getByText('Base branch?')).toBeInTheDocument();
+  });
+
+  it('renders hints', () => {
+    render(<PlanQuestions questions={questions} onSubmit={vi.fn()} onBack={vi.fn()} />);
+    expect(screen.getByText('e.g. niuulabs/volundr')).toBeInTheDocument();
+  });
+
+  it('calls onSubmit with answers', async () => {
+    const onSubmit = vi.fn();
+    render(<PlanQuestions questions={questions} onSubmit={onSubmit} onBack={vi.fn()} />);
+
+    await userEvent.type(screen.getByLabelText(/1\./), 'niuulabs/volundr');
+    fireEvent.submit(screen.getByRole('form'));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ q1: 'niuulabs/volundr' }),
+    );
+  });
+
+  it('calls onBack when back button clicked', () => {
+    const onBack = vi.fn();
+    render(<PlanQuestions questions={questions} onSubmit={vi.fn()} onBack={onBack} />);
+    fireEvent.click(screen.getByRole('button', { name: /back/i }));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it('shows empty-state message when no questions', () => {
+    render(<PlanQuestions questions={[]} onSubmit={vi.fn()} onBack={vi.fn()} />);
+    expect(screen.getByText(/no clarifying questions/i)).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PlanRaiding unit tests
+// ---------------------------------------------------------------------------
+
+describe('PlanRaiding', () => {
+  it('shows processing indicator', () => {
+    render(<PlanRaiding error={null} onBack={vi.fn()} />);
+    // Use aria-label to disambiguate from StateDot's inner role="status"
+    expect(screen.getByLabelText(/decomposing plan/i)).toBeInTheDocument();
+    expect(screen.getByText(/Ravens are raiding/i)).toBeInTheDocument();
+  });
+
+  it('shows error state when error is present', () => {
+    render(<PlanRaiding error="Decompose failed" onBack={vi.fn()} />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('Decompose failed')).toBeInTheDocument();
+  });
+
+  it('calls onBack on error try-again click', () => {
+    const onBack = vi.fn();
+    render(<PlanRaiding error="oops" onBack={onBack} />);
+    fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it('has aria-label for the raiding container', () => {
+    render(<PlanRaiding error={null} onBack={vi.fn()} />);
+    expect(screen.getByLabelText(/decomposing plan/i)).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PlanDraft unit tests
+// ---------------------------------------------------------------------------
+
+describe('PlanDraft', () => {
+  it('renders saga name', () => {
+    render(
+      <PlanDraft
+        structure={MOCK_STRUCTURE}
+        loading={false}
+        error={null}
+        onApprove={vi.fn()}
+        onBack={vi.fn()}
+        onEditPhase={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Auth Rewrite')).toBeInTheDocument();
+  });
+
+  it('renders all phase names', () => {
+    render(
+      <PlanDraft
+        structure={MOCK_STRUCTURE}
+        loading={false}
+        error={null}
+        onApprove={vi.fn()}
+        onBack={vi.fn()}
+        onEditPhase={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Phase 1: Foundation')).toBeInTheDocument();
+    expect(screen.getByText('Phase 2: Hardening')).toBeInTheDocument();
+  });
+
+  it('renders raid names', () => {
+    render(
+      <PlanDraft
+        structure={MOCK_STRUCTURE}
+        loading={false}
+        error={null}
+        onApprove={vi.fn()}
+        onBack={vi.fn()}
+        onEditPhase={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Scaffold OIDC')).toBeInTheDocument();
+  });
+
+  it('calls onApprove when approve button clicked', async () => {
+    const onApprove = vi.fn();
+    render(
+      <PlanDraft
+        structure={MOCK_STRUCTURE}
+        loading={false}
+        error={null}
+        onApprove={onApprove}
+        onBack={vi.fn()}
+        onEditPhase={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /approve/i }));
+    expect(onApprove).toHaveBeenCalled();
+  });
+
+  it('calls onBack when back button clicked', () => {
+    const onBack = vi.fn();
+    render(
+      <PlanDraft
+        structure={MOCK_STRUCTURE}
+        loading={false}
+        error={null}
+        onApprove={vi.fn()}
+        onBack={onBack}
+        onEditPhase={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /back/i }));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it('allows editing a phase name', async () => {
+    const onEditPhase = vi.fn();
+    render(
+      <PlanDraft
+        structure={MOCK_STRUCTURE}
+        loading={false}
+        error={null}
+        onApprove={vi.fn()}
+        onBack={vi.fn()}
+        onEditPhase={onEditPhase}
+      />,
+    );
+
+    // Click edit on the first phase
+    const editButtons = screen.getAllByRole('button', { name: /edit phase/i });
+    fireEvent.click(editButtons[0]!);
+
+    const input = screen.getByLabelText(/edit phase 1 name/i);
+    await userEvent.clear(input);
+    await userEvent.type(input, 'Renamed Phase');
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    expect(onEditPhase).toHaveBeenCalledWith(0, 'Renamed Phase');
+  });
+
+  it('shows empty state when no phases', () => {
+    const emptyStructure: ExtractedStructure = {
+      found: false,
+      structure: { name: 'Saga', phases: [] },
+    };
+    render(
+      <PlanDraft
+        structure={emptyStructure}
+        loading={false}
+        error={null}
+        onApprove={vi.fn()}
+        onBack={vi.fn()}
+        onEditPhase={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/no phases extracted/i)).toBeInTheDocument();
+  });
+
+  it('disables approve when loading', () => {
+    render(
+      <PlanDraft
+        structure={MOCK_STRUCTURE}
+        loading={true}
+        error={null}
+        onApprove={vi.fn()}
+        onBack={vi.fn()}
+        onEditPhase={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /launching/i })).toBeDisabled();
+  });
+
+  it('shows error message', () => {
+    render(
+      <PlanDraft
+        structure={MOCK_STRUCTURE}
+        loading={false}
+        error="Commit failed"
+        onApprove={vi.fn()}
+        onBack={vi.fn()}
+        onEditPhase={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('Commit failed');
+  });
+
+  it('cancels editing without calling onEditPhase', () => {
+    const onEditPhase = vi.fn();
+    render(
+      <PlanDraft
+        structure={MOCK_STRUCTURE}
+        loading={false}
+        error={null}
+        onApprove={vi.fn()}
+        onBack={vi.fn()}
+        onEditPhase={onEditPhase}
+      />,
+    );
+    const editButtons = screen.getAllByRole('button', { name: /edit phase/i });
+    fireEvent.click(editButtons[0]!);
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onEditPhase).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PlanApproved unit tests
+// ---------------------------------------------------------------------------
+
+describe('PlanApproved', () => {
+  it('renders the saga name', () => {
+    render(<PlanApproved saga={MOCK_SAGA} />);
+    // saga name appears in both the description span and the summary dl
+    expect(screen.getAllByText('Auth Rewrite').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows the "Open in Sagas" link', () => {
+    render(<PlanApproved saga={MOCK_SAGA} />);
+    expect(screen.getByRole('link', { name: /open in sagas/i })).toBeInTheDocument();
+  });
+
+  it('shows feature branch', () => {
+    render(<PlanApproved saga={MOCK_SAGA} />);
+    expect(screen.getByText('feat/auth-rewrite')).toBeInTheDocument();
+  });
+
+  it('calls onNewPlan when new plan button clicked', () => {
+    const onNewPlan = vi.fn();
+    render(<PlanApproved saga={MOCK_SAGA} onNewPlan={onNewPlan} />);
+    fireEvent.click(screen.getByRole('button', { name: /new plan/i }));
+    expect(onNewPlan).toHaveBeenCalled();
+  });
+
+  it('does not render new plan button when onNewPlan not provided', () => {
+    render(<PlanApproved saga={MOCK_SAGA} />);
+    expect(screen.queryByRole('button', { name: /new plan/i })).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PlanWizard integration tests
+// ---------------------------------------------------------------------------
+
+describe('PlanWizard integration', () => {
+  it('renders the prompt step initially', () => {
+    render(<PlanWizard />, { wrapper: wrap(makeSvc()) });
+    expect(screen.getByText('Describe your goal')).toBeInTheDocument();
+  });
+
+  it('shows the step dots navigation', () => {
+    render(<PlanWizard />, { wrapper: wrap(makeSvc()) });
+    expect(screen.getByRole('navigation', { name: /plan wizard steps/i })).toBeInTheDocument();
+  });
+
+  it('shows the Tyr rune in the header', () => {
+    render(<PlanWizard />, { wrapper: wrap(makeSvc()) });
+    expect(screen.getByText('ᛏ')).toBeInTheDocument();
+  });
+
+  it('advances to questions step after submitting prompt', async () => {
+    const svc = makeSvc();
+    render(<PlanWizard />, { wrapper: wrap(svc) });
+
+    await userEvent.type(
+      screen.getByRole('textbox', { name: /goal description/i }),
+      'Build auth module',
+    );
+    fireEvent.submit(screen.getByRole('form', { name: /plan prompt form/i }));
+
+    await waitFor(() => expect(screen.getByText('Clarify your plan')).toBeInTheDocument());
+    expect(screen.getByText('Which repos?')).toBeInTheDocument();
+  });
+
+  it('advances to raiding step after submitting answers', async () => {
+    const svc = makeSvc();
+    render(<PlanWizard />, { wrapper: wrap(svc) });
+
+    // Step 1: prompt
+    await userEvent.type(
+      screen.getByRole('textbox', { name: /goal description/i }),
+      'Build auth module',
+    );
+    fireEvent.submit(screen.getByRole('form', { name: /plan prompt form/i }));
+    await waitFor(() => expect(screen.getByText('Clarify your plan')).toBeInTheDocument());
+
+    // Step 2: questions
+    fireEvent.submit(screen.getByRole('form', { name: /clarifying questions form/i }));
+
+    await waitFor(() => expect(screen.getByLabelText(/decomposing plan/i)).toBeInTheDocument());
+  });
+
+  it('auto-advances to draft after decomposition', async () => {
+    const svc = makeSvc();
+    render(<PlanWizard />, { wrapper: wrap(svc) });
+
+    // Through to raiding
+    await userEvent.type(
+      screen.getByRole('textbox', { name: /goal description/i }),
+      'Build auth module',
+    );
+    fireEvent.submit(screen.getByRole('form', { name: /plan prompt form/i }));
+    await waitFor(() => expect(screen.getByText('Clarify your plan')).toBeInTheDocument());
+    fireEvent.submit(screen.getByRole('form', { name: /clarifying questions form/i }));
+
+    // Should auto-advance to draft
+    await waitFor(() => expect(screen.getByText('Review your plan')).toBeInTheDocument(), {
+      timeout: 3000,
+    });
+    expect(screen.getByText('Auth Rewrite')).toBeInTheDocument();
+  });
+
+  it('reaches approved step after full flow', async () => {
+    const svc = makeSvc();
+    render(<PlanWizard />, { wrapper: wrap(svc) });
+
+    // Prompt
+    await userEvent.type(
+      screen.getByRole('textbox', { name: /goal description/i }),
+      'Build auth',
+    );
+    fireEvent.submit(screen.getByRole('form', { name: /plan prompt form/i }));
+    await waitFor(() => expect(screen.getByText('Clarify your plan')).toBeInTheDocument());
+
+    // Questions
+    fireEvent.submit(screen.getByRole('form', { name: /clarifying questions form/i }));
+    await waitFor(() => expect(screen.getByText('Review your plan')).toBeInTheDocument(), {
+      timeout: 3000,
+    });
+
+    // Draft → approve
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /approve/i }));
+    });
+
+    await waitFor(() => expect(screen.getByTestId('plan-approved')).toBeInTheDocument());
+    expect(screen.getByText('Saga launched!')).toBeInTheDocument();
+  });
+
+  it('can navigate back from questions to prompt', async () => {
+    const svc = makeSvc();
+    render(<PlanWizard />, { wrapper: wrap(svc) });
+
+    await userEvent.type(
+      screen.getByRole('textbox', { name: /goal description/i }),
+      'Build auth',
+    );
+    fireEvent.submit(screen.getByRole('form', { name: /plan prompt form/i }));
+    await waitFor(() => expect(screen.getByText('Clarify your plan')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /back/i }));
+    expect(screen.getByText('Describe your goal')).toBeInTheDocument();
+  });
+
+  it('shows error when spawnPlanSession fails', async () => {
+    const svc = makeSvc({
+      spawnPlanSession: vi.fn().mockRejectedValue(new Error('Tyr unavailable')),
+    });
+    render(<PlanWizard />, { wrapper: wrap(svc) });
+
+    await userEvent.type(
+      screen.getByRole('textbox', { name: /goal description/i }),
+      'Build auth',
+    );
+    fireEvent.submit(screen.getByRole('form', { name: /plan prompt form/i }));
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(screen.getByText('Tyr unavailable')).toBeInTheDocument();
+  });
+});

--- a/web-next/packages/plugin-tyr/src/ui/PlanWizard.test.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/PlanWizard.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';

--- a/web-next/packages/plugin-tyr/src/ui/PlanWizard.test.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/PlanWizard.test.tsx
@@ -113,8 +113,14 @@ describe('PlanPrompt', () => {
     const onSubmit = vi.fn();
     render(<PlanPrompt onSubmit={onSubmit} loading={false} error={null} />);
 
-    await userEvent.type(screen.getByRole('textbox', { name: /goal description/i }), '  Build auth  ');
-    await userEvent.type(screen.getByRole('textbox', { name: /target repository/i }), 'niuulabs/volundr');
+    await userEvent.type(
+      screen.getByRole('textbox', { name: /goal description/i }),
+      '  Build auth  ',
+    );
+    await userEvent.type(
+      screen.getByRole('textbox', { name: /target repository/i }),
+      'niuulabs/volundr',
+    );
     fireEvent.submit(screen.getByRole('form', { name: /plan prompt form/i }));
 
     expect(onSubmit).toHaveBeenCalledWith('Build auth', 'niuulabs/volundr');
@@ -166,9 +172,7 @@ describe('PlanQuestions', () => {
     await userEvent.type(screen.getByLabelText(/1\./), 'niuulabs/volundr');
     fireEvent.submit(screen.getByRole('form'));
 
-    expect(onSubmit).toHaveBeenCalledWith(
-      expect.objectContaining({ q1: 'niuulabs/volundr' }),
-    );
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ q1: 'niuulabs/volundr' }));
   });
 
   it('calls onBack when back button clicked', () => {
@@ -496,10 +500,7 @@ describe('PlanWizard integration', () => {
     render(<PlanWizard />, { wrapper: wrap(svc) });
 
     // Prompt
-    await userEvent.type(
-      screen.getByRole('textbox', { name: /goal description/i }),
-      'Build auth',
-    );
+    await userEvent.type(screen.getByRole('textbox', { name: /goal description/i }), 'Build auth');
     fireEvent.submit(screen.getByRole('form', { name: /plan prompt form/i }));
     await waitFor(() => expect(screen.getByText('Clarify your plan')).toBeInTheDocument());
 
@@ -522,10 +523,7 @@ describe('PlanWizard integration', () => {
     const svc = makeSvc();
     render(<PlanWizard />, { wrapper: wrap(svc) });
 
-    await userEvent.type(
-      screen.getByRole('textbox', { name: /goal description/i }),
-      'Build auth',
-    );
+    await userEvent.type(screen.getByRole('textbox', { name: /goal description/i }), 'Build auth');
     fireEvent.submit(screen.getByRole('form', { name: /plan prompt form/i }));
     await waitFor(() => expect(screen.getByText('Clarify your plan')).toBeInTheDocument());
 
@@ -539,10 +537,7 @@ describe('PlanWizard integration', () => {
     });
     render(<PlanWizard />, { wrapper: wrap(svc) });
 
-    await userEvent.type(
-      screen.getByRole('textbox', { name: /goal description/i }),
-      'Build auth',
-    );
+    await userEvent.type(screen.getByRole('textbox', { name: /goal description/i }), 'Build auth');
     fireEvent.submit(screen.getByRole('form', { name: /plan prompt form/i }));
 
     await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());

--- a/web-next/packages/plugin-tyr/src/ui/PlanWizard.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/PlanWizard.tsx
@@ -34,11 +34,7 @@ export function PlanWizard() {
       <StepDots steps={PLAN_STEPS} current={state.step} />
 
       {state.step === 'prompt' && (
-        <PlanPrompt
-          onSubmit={submitPrompt}
-          loading={state.loading}
-          error={state.error}
-        />
+        <PlanPrompt onSubmit={submitPrompt} loading={state.loading} error={state.error} />
       )}
 
       {state.step === 'questions' && (

--- a/web-next/packages/plugin-tyr/src/ui/PlanWizard.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/PlanWizard.tsx
@@ -1,0 +1,85 @@
+import { Rune } from '@niuulabs/ui';
+import { PLAN_STEPS } from '../domain/plan';
+import { StepDots } from './StepDots';
+import { usePlanWizard } from './usePlanWizard';
+import { PlanPrompt } from './PlanPrompt';
+import { PlanQuestions } from './PlanQuestions';
+import { PlanRaiding } from './PlanRaiding';
+import { PlanDraft } from './PlanDraft';
+import { PlanApproved } from './PlanApproved';
+
+/**
+ * Plan wizard — five‐step flow for decomposing a human goal into a saga.
+ *
+ * States: prompt → questions → raiding → draft → approved
+ */
+export function PlanWizard() {
+  const { state, submitPrompt, submitAnswers, approveDraft, editPhase, back, clearError } =
+    usePlanWizard();
+
+  function handleNewPlan() {
+    // Navigate back to /tyr to start fresh (the wizard unmounts and remounts)
+    window.location.href = '/tyr/plan';
+  }
+
+  return (
+    <div className="niuu-p-6 niuu-max-w-2xl niuu-mx-auto">
+      <div className="niuu-flex niuu-items-center niuu-gap-3 niuu-mb-6">
+        <Rune glyph="ᛏ" size={24} />
+        <h1 className="niuu-text-base niuu-font-semibold niuu-text-text-secondary niuu-m-0">
+          New saga plan
+        </h1>
+      </div>
+
+      <StepDots steps={PLAN_STEPS} current={state.step} />
+
+      {state.step === 'prompt' && (
+        <PlanPrompt
+          onSubmit={submitPrompt}
+          loading={state.loading}
+          error={state.error}
+        />
+      )}
+
+      {state.step === 'questions' && (
+        <PlanQuestions
+          questions={state.questions}
+          initialAnswers={state.answers}
+          onSubmit={submitAnswers}
+          onBack={() => {
+            clearError();
+            back();
+          }}
+        />
+      )}
+
+      {state.step === 'raiding' && (
+        <PlanRaiding
+          error={state.error}
+          onBack={() => {
+            clearError();
+            back();
+          }}
+        />
+      )}
+
+      {state.step === 'draft' && state.structure && (
+        <PlanDraft
+          structure={state.structure}
+          loading={state.loading}
+          error={state.error}
+          onApprove={approveDraft}
+          onBack={() => {
+            clearError();
+            back();
+          }}
+          onEditPhase={editPhase}
+        />
+      )}
+
+      {state.step === 'approved' && state.saga && (
+        <PlanApproved saga={state.saga} onNewPlan={handleNewPlan} />
+      )}
+    </div>
+  );
+}

--- a/web-next/packages/plugin-tyr/src/ui/StepDots.stories.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/StepDots.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { StepDots } from './StepDots';
+import { PLAN_STEPS } from '../domain/plan';
+
+const meta: Meta<typeof StepDots> = {
+  title: 'plugin-tyr/StepDots',
+  component: StepDots,
+  parameters: {
+    layout: 'padded',
+    backgrounds: { default: 'dark' },
+  },
+  argTypes: {
+    current: {
+      control: 'select',
+      options: PLAN_STEPS,
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof StepDots>;
+
+export const Prompt: Story = {
+  args: { steps: PLAN_STEPS, current: 'prompt' },
+};
+
+export const Questions: Story = {
+  args: { steps: PLAN_STEPS, current: 'questions' },
+};
+
+export const Raiding: Story = {
+  args: { steps: PLAN_STEPS, current: 'raiding' },
+};
+
+export const Draft: Story = {
+  args: { steps: PLAN_STEPS, current: 'draft' },
+};
+
+export const Approved: Story = {
+  args: { steps: PLAN_STEPS, current: 'approved' },
+};

--- a/web-next/packages/plugin-tyr/src/ui/StepDots.test.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/StepDots.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { StepDots } from './StepDots';
+import { PLAN_STEPS } from '../domain/plan';
+
+describe('StepDots', () => {
+  it('renders all 5 step labels', () => {
+    render(<StepDots steps={PLAN_STEPS} current="prompt" />);
+    expect(screen.getByText('Describe')).toBeInTheDocument();
+    expect(screen.getByText('Clarify')).toBeInTheDocument();
+    expect(screen.getByText('Decompose')).toBeInTheDocument();
+    expect(screen.getByText('Review')).toBeInTheDocument();
+    expect(screen.getByText('Launch')).toBeInTheDocument();
+  });
+
+  it('marks the current step with aria-current="step"', () => {
+    render(<StepDots steps={PLAN_STEPS} current="questions" />);
+    const currentStep = screen.getByRole('navigation').querySelector('[aria-current="step"]');
+    expect(currentStep).toBeInTheDocument();
+  });
+
+  it('does not set aria-current on non-active steps', () => {
+    render(<StepDots steps={PLAN_STEPS} current="prompt" />);
+    const nav = screen.getByRole('navigation');
+    const currentSteps = nav.querySelectorAll('[aria-current="step"]');
+    expect(currentSteps).toHaveLength(1);
+  });
+
+  it('has accessible navigation label', () => {
+    render(<StepDots steps={PLAN_STEPS} current="raiding" />);
+    expect(screen.getByRole('navigation', { name: 'Plan wizard steps' })).toBeInTheDocument();
+  });
+
+  it('renders dot indicators with aria-labels', () => {
+    render(<StepDots steps={PLAN_STEPS} current="raiding" />);
+    // raiding is current, prompt and questions are complete, draft and approved are pending
+    expect(screen.getByRole('img', { name: /Describe: complete/ })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /Clarify: complete/ })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /Decompose: current/ })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /Review: pending/ })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /Launch: pending/ })).toBeInTheDocument();
+  });
+
+  it('shows all steps as pending (except first) when on prompt', () => {
+    render(<StepDots steps={PLAN_STEPS} current="prompt" />);
+    expect(screen.getByRole('img', { name: /Describe: current/ })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /Clarify: pending/ })).toBeInTheDocument();
+  });
+
+  it('marks all prior steps as complete when on approved', () => {
+    render(<StepDots steps={PLAN_STEPS} current="approved" />);
+    expect(screen.getByRole('img', { name: /Describe: complete/ })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /Clarify: complete/ })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /Decompose: complete/ })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /Review: complete/ })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /Launch: current/ })).toBeInTheDocument();
+  });
+});

--- a/web-next/packages/plugin-tyr/src/ui/StepDots.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/StepDots.tsx
@@ -1,0 +1,79 @@
+import type { PlanStep } from '../domain/plan';
+import { PLAN_STEP_LABELS, stepIndex } from '../domain/plan';
+
+interface StepDotsProps {
+  steps: readonly PlanStep[];
+  current: PlanStep;
+}
+
+/**
+ * Horizontal step-progress indicator used across the Plan wizard header.
+ * Each dot represents one step; the current and completed steps are visually
+ * distinguished from pending ones.
+ */
+export function StepDots({ steps, current }: StepDotsProps) {
+  const currentIndex = stepIndex(current);
+
+  return (
+    <nav
+      aria-label="Plan wizard steps"
+      className="niuu-flex niuu-items-center niuu-gap-2 niuu-mb-6"
+    >
+      {steps.map((step, idx) => {
+        const isCompleted = idx < currentIndex;
+        const isActive = idx === currentIndex;
+        const label = PLAN_STEP_LABELS[step];
+
+        return (
+          <div
+            key={step}
+            className="niuu-flex niuu-items-center niuu-gap-2"
+            aria-current={isActive ? 'step' : undefined}
+          >
+            <div className="niuu-flex niuu-flex-col niuu-items-center niuu-gap-1">
+              <span
+                className={[
+                  'niuu-inline-flex niuu-items-center niuu-justify-center',
+                  'niuu-w-2 niuu-h-2 niuu-rounded-full niuu-transition-all',
+                  isCompleted
+                    ? 'niuu-bg-brand-400'
+                    : isActive
+                      ? 'niuu-bg-brand-500 niuu-ring-2 niuu-ring-brand-500/30'
+                      : 'niuu-bg-bg-elevated',
+                ]
+                  .filter(Boolean)
+                  .join(' ')}
+                role="img"
+                aria-label={`${label}: ${isCompleted ? 'complete' : isActive ? 'current' : 'pending'}`}
+              />
+              <span
+                className={[
+                  'niuu-text-xs niuu-font-medium niuu-transition-colors',
+                  isActive
+                    ? 'niuu-text-text-primary'
+                    : isCompleted
+                      ? 'niuu-text-text-secondary'
+                      : 'niuu-text-text-muted',
+                ]
+                  .filter(Boolean)
+                  .join(' ')}
+              >
+                {label}
+              </span>
+            </div>
+
+            {idx < steps.length - 1 && (
+              <span
+                className={[
+                  'niuu-flex-1 niuu-h-px niuu-min-w-6 niuu-mb-4',
+                  idx < currentIndex ? 'niuu-bg-brand-400' : 'niuu-bg-border',
+                ].join(' ')}
+                aria-hidden="true"
+              />
+            )}
+          </div>
+        );
+      })}
+    </nav>
+  );
+}

--- a/web-next/packages/plugin-tyr/src/ui/settings/AuditLogSection.stories.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/settings/AuditLogSection.stories.tsx
@@ -30,7 +30,9 @@ export const Loading: Story = {
       const Wrapper = buildWrapper({
         'tyr.audit': {
           listAuditEntries() {
-            return new Promise(() => { /* never resolves */ });
+            return new Promise(() => {
+              /* never resolves */
+            });
           },
         },
       });

--- a/web-next/packages/plugin-tyr/src/ui/settings/AuditLogSection.test.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/settings/AuditLogSection.test.tsx
@@ -26,34 +26,28 @@ describe('AuditLogSection', () => {
 
   it('renders audit log entries after loading', async () => {
     render(<AuditLogSection />, { wrapper: wrap(defaultServices()) });
-    await waitFor(() =>
-      expect(screen.getByText(/6 entries/i)).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(/6 entries/i)).toBeInTheDocument());
   });
 
   it('shows section heading', async () => {
     render(<AuditLogSection />, { wrapper: wrap(defaultServices()) });
-    await waitFor(() =>
-      expect(screen.getByText('Audit Log')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('Audit Log')).toBeInTheDocument());
   });
 
   it('shows error state when service throws', async () => {
     const failing = {
-      listAuditEntries: async () => { throw new Error('audit unavailable'); },
+      listAuditEntries: async () => {
+        throw new Error('audit unavailable');
+      },
     };
     render(<AuditLogSection />, { wrapper: wrap({ 'tyr.audit': failing }) });
-    await waitFor(() =>
-      expect(screen.getByRole('alert')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
     expect(screen.getByText('audit unavailable')).toBeInTheDocument();
   });
 
   it('shows filter buttons for kind groups', async () => {
     render(<AuditLogSection />, { wrapper: wrap(defaultServices()) });
-    await waitFor(() =>
-      expect(screen.getByText('Raid dispatched')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('Raid dispatched')).toBeInTheDocument());
     expect(screen.getByText('Raid merged')).toBeInTheDocument();
     expect(screen.getByText('Dispatcher started')).toBeInTheDocument();
     expect(screen.getByText('Flock config updated')).toBeInTheDocument();
@@ -61,24 +55,18 @@ describe('AuditLogSection', () => {
 
   it('activates filter on kind button click and shows (filtered)', async () => {
     render(<AuditLogSection />, { wrapper: wrap(defaultServices()) });
-    await waitFor(() =>
-      expect(screen.getByText('Raid dispatched')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('Raid dispatched')).toBeInTheDocument());
 
     const dispatchedBtn = screen.getByRole('button', { name: 'Raid dispatched' });
     fireEvent.click(dispatchedBtn);
     expect(dispatchedBtn).toHaveAttribute('aria-pressed', 'true');
 
-    await waitFor(() =>
-      expect(screen.getByText(/filtered/i)).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(/filtered/i)).toBeInTheDocument());
   });
 
   it('deactivates filter on second click', async () => {
     render(<AuditLogSection />, { wrapper: wrap(defaultServices()) });
-    await waitFor(() =>
-      expect(screen.getByText('Raid dispatched')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('Raid dispatched')).toBeInTheDocument());
 
     const btn = screen.getByRole('button', { name: 'Raid dispatched' });
     fireEvent.click(btn);
@@ -88,37 +76,25 @@ describe('AuditLogSection', () => {
 
   it('shows clear filters button when filters are active', async () => {
     render(<AuditLogSection />, { wrapper: wrap(defaultServices()) });
-    await waitFor(() =>
-      expect(screen.getByText('Raid dispatched')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('Raid dispatched')).toBeInTheDocument());
 
     fireEvent.click(screen.getByRole('button', { name: 'Raid dispatched' }));
-    await waitFor(() =>
-      expect(screen.getByText(/Clear filters/i)).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(/Clear filters/i)).toBeInTheDocument());
   });
 
   it('clears filters when clear button is clicked', async () => {
     render(<AuditLogSection />, { wrapper: wrap(defaultServices()) });
-    await waitFor(() =>
-      expect(screen.getByText('Raid dispatched')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('Raid dispatched')).toBeInTheDocument());
 
     fireEvent.click(screen.getByRole('button', { name: 'Raid dispatched' }));
-    await waitFor(() =>
-      expect(screen.getByText(/Clear filters/i)).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(/Clear filters/i)).toBeInTheDocument());
     fireEvent.click(screen.getByText(/Clear filters/i));
-    await waitFor(() =>
-      expect(screen.queryByText(/Clear filters/i)).not.toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.queryByText(/Clear filters/i)).not.toBeInTheDocument());
   });
 
   it('renders table with correct columns', async () => {
     render(<AuditLogSection />, { wrapper: wrap(defaultServices()) });
-    await waitFor(() =>
-      expect(screen.getByText('Time')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('Time')).toBeInTheDocument());
     expect(screen.getByText('Event')).toBeInTheDocument();
     expect(screen.getByText('Summary')).toBeInTheDocument();
     expect(screen.getByText('Actor')).toBeInTheDocument();
@@ -126,8 +102,6 @@ describe('AuditLogSection', () => {
 
   it('renders entry summaries in the table', async () => {
     render(<AuditLogSection />, { wrapper: wrap(defaultServices()) });
-    await waitFor(() =>
-      expect(screen.getByText('Dispatcher started')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('Dispatcher started')).toBeInTheDocument());
   });
 });

--- a/web-next/packages/plugin-tyr/src/ui/settings/AuditLogSection.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/settings/AuditLogSection.tsx
@@ -169,7 +169,9 @@ export function AuditLogSection() {
         )}
 
         {entries?.length === 0 && !isLoading && (
-          <p className="niuu-text-sm niuu-text-text-muted niuu-p-4">No entries match the current filter.</p>
+          <p className="niuu-text-sm niuu-text-text-muted niuu-p-4">
+            No entries match the current filter.
+          </p>
         )}
 
         {entries && entries.length > 0 && (

--- a/web-next/packages/plugin-tyr/src/ui/settings/DispatchDefaultsSection.stories.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/settings/DispatchDefaultsSection.stories.tsx
@@ -30,7 +30,9 @@ export const Loading: Story = {
       const Wrapper = buildWrapper({
         'tyr.settings': {
           getDispatchDefaults() {
-            return new Promise(() => { /* never resolves */ });
+            return new Promise(() => {
+              /* never resolves */
+            });
           },
         },
       });

--- a/web-next/packages/plugin-tyr/src/ui/settings/DispatchDefaultsSection.test.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/settings/DispatchDefaultsSection.test.tsx
@@ -36,65 +36,51 @@ describe('DispatchDefaultsSection', () => {
 
   it('shows error state when service throws', async () => {
     const failing = {
-      getDispatchDefaults: async () => { throw new Error('service unavailable'); },
+      getDispatchDefaults: async () => {
+        throw new Error('service unavailable');
+      },
     };
     render(<DispatchDefaultsSection />, { wrapper: wrap({ 'tyr.settings': failing }) });
-    await waitFor(() =>
-      expect(screen.getByRole('alert')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
     expect(screen.getByText('service unavailable')).toBeInTheDocument();
   });
 
   it('shows section heading', async () => {
     render(<DispatchDefaultsSection />, { wrapper: wrap(defaultServices()) });
-    await waitFor(() =>
-      expect(screen.getByText('Dispatch Defaults')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('Dispatch Defaults')).toBeInTheDocument());
   });
 
   it('shows validation error for out-of-range confidence threshold', async () => {
     render(<DispatchDefaultsSection />, { wrapper: wrap(defaultServices()) });
-    await waitFor(() =>
-      expect(screen.getByLabelText(/confidence threshold/i)).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByLabelText(/confidence threshold/i)).toBeInTheDocument());
 
     const input = screen.getByLabelText(/confidence threshold/i);
     fireEvent.change(input, { target: { value: '150' } });
     fireEvent.submit(screen.getByRole('form', { name: /dispatch defaults form/i }));
 
-    await waitFor(() =>
-      expect(screen.getByText(/between 0 and 100/i)).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(/between 0 and 100/i)).toBeInTheDocument());
   });
 
   it('shows validation error for zero max concurrent raids', async () => {
     render(<DispatchDefaultsSection />, { wrapper: wrap(defaultServices()) });
-    await waitFor(() =>
-      expect(screen.getByLabelText(/max concurrent raids/i)).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByLabelText(/max concurrent raids/i)).toBeInTheDocument());
 
     const input = screen.getByLabelText(/max concurrent raids/i);
     fireEvent.change(input, { target: { value: '0' } });
     fireEvent.submit(screen.getByRole('form', { name: /dispatch defaults form/i }));
 
-    await waitFor(() =>
-      expect(screen.getByText(/at least 1/i)).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(/at least 1/i)).toBeInTheDocument());
   });
 
   it('shows validation error for zero batch size', async () => {
     render(<DispatchDefaultsSection />, { wrapper: wrap(defaultServices()) });
-    await waitFor(() =>
-      expect(screen.getByLabelText(/batch size/i)).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByLabelText(/batch size/i)).toBeInTheDocument());
 
     const input = screen.getByLabelText(/batch size/i);
     fireEvent.change(input, { target: { value: '0' } });
     fireEvent.submit(screen.getByRole('form', { name: /dispatch defaults form/i }));
 
-    await waitFor(() =>
-      expect(screen.getByText(/at least 1/i)).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(/at least 1/i)).toBeInTheDocument());
   });
 
   it('shows "Saved" confirmation after successful submission', async () => {
@@ -104,47 +90,35 @@ describe('DispatchDefaultsSection', () => {
     );
 
     fireEvent.submit(screen.getByRole('form', { name: /dispatch defaults form/i }));
-    await waitFor(() =>
-      expect(screen.getByText('Saved')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('Saved')).toBeInTheDocument());
   });
 
   it('renders retry policy section', async () => {
     render(<DispatchDefaultsSection />, { wrapper: wrap(defaultServices()) });
-    await waitFor(() =>
-      expect(screen.getByText('Retry Policy')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('Retry Policy')).toBeInTheDocument());
     expect(screen.getByLabelText(/max retries per raid/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/retry delay/i)).toBeInTheDocument();
   });
 
   it('shows negative retry delay error', async () => {
     render(<DispatchDefaultsSection />, { wrapper: wrap(defaultServices()) });
-    await waitFor(() =>
-      expect(screen.getByLabelText(/retry delay/i)).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByLabelText(/retry delay/i)).toBeInTheDocument());
 
     const input = screen.getByLabelText(/retry delay/i);
     fireEvent.change(input, { target: { value: '-5' } });
     fireEvent.submit(screen.getByRole('form', { name: /dispatch defaults form/i }));
 
-    await waitFor(() =>
-      expect(screen.getByText(/cannot be negative/i)).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(/cannot be negative/i)).toBeInTheDocument());
   });
 
   it('shows negative max retries error', async () => {
     render(<DispatchDefaultsSection />, { wrapper: wrap(defaultServices()) });
-    await waitFor(() =>
-      expect(screen.getByLabelText(/max retries per raid/i)).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByLabelText(/max retries per raid/i)).toBeInTheDocument());
 
     const input = screen.getByLabelText(/max retries per raid/i);
     fireEvent.change(input, { target: { value: '-1' } });
     fireEvent.submit(screen.getByRole('form', { name: /dispatch defaults form/i }));
 
-    await waitFor(() =>
-      expect(screen.getByText(/cannot be negative/i)).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(/cannot be negative/i)).toBeInTheDocument());
   });
 });

--- a/web-next/packages/plugin-tyr/src/ui/settings/FlockConfigSection.stories.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/settings/FlockConfigSection.stories.tsx
@@ -30,7 +30,9 @@ export const Loading: Story = {
       const Wrapper = buildWrapper({
         'tyr.settings': {
           getFlockConfig() {
-            return new Promise(() => { /* never resolves */ });
+            return new Promise(() => {
+              /* never resolves */
+            });
           },
         },
       });

--- a/web-next/packages/plugin-tyr/src/ui/settings/FlockConfigSection.test.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/settings/FlockConfigSection.test.tsx
@@ -37,48 +37,40 @@ describe('FlockConfigSection', () => {
 
   it('shows section heading', async () => {
     render(<FlockConfigSection />, { wrapper: wrap(defaultServices()) });
-    await waitFor(() =>
-      expect(screen.getByText('Flock Config')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('Flock Config')).toBeInTheDocument());
   });
 
   it('shows error state when service throws', async () => {
-    const failing = { getFlockConfig: async () => { throw new Error('flock error'); } };
+    const failing = {
+      getFlockConfig: async () => {
+        throw new Error('flock error');
+      },
+    };
     render(<FlockConfigSection />, { wrapper: wrap({ 'tyr.settings': failing }) });
-    await waitFor(() =>
-      expect(screen.getByRole('alert')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
     expect(screen.getByText('flock error')).toBeInTheDocument();
   });
 
   it('shows validation error when flockName is empty', async () => {
     render(<FlockConfigSection />, { wrapper: wrap(defaultServices()) });
-    await waitFor(() =>
-      expect(screen.getByLabelText(/flock name/i)).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByLabelText(/flock name/i)).toBeInTheDocument());
 
     const input = screen.getByLabelText(/flock name/i);
     fireEvent.change(input, { target: { value: '' } });
     fireEvent.submit(screen.getByRole('form', { name: /flock configuration form/i }));
 
-    await waitFor(() =>
-      expect(screen.getByText(/required/i)).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(/required/i)).toBeInTheDocument());
   });
 
   it('shows validation error when defaultBaseBranch is empty', async () => {
     render(<FlockConfigSection />, { wrapper: wrap(defaultServices()) });
-    await waitFor(() =>
-      expect(screen.getByLabelText(/default base branch/i)).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByLabelText(/default base branch/i)).toBeInTheDocument());
 
     const input = screen.getByLabelText(/default base branch/i);
     fireEvent.change(input, { target: { value: '' } });
     fireEvent.submit(screen.getByRole('form', { name: /flock configuration form/i }));
 
-    await waitFor(() =>
-      expect(screen.getByText(/required/i)).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(/required/i)).toBeInTheDocument());
   });
 
   it('shows "Saved" after successful submit', async () => {
@@ -88,15 +80,11 @@ describe('FlockConfigSection', () => {
     );
 
     fireEvent.submit(screen.getByRole('form', { name: /flock configuration form/i }));
-    await waitFor(() =>
-      expect(screen.getByText('Saved')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('Saved')).toBeInTheDocument());
   });
 
   it('shows max active sagas field', async () => {
     render(<FlockConfigSection />, { wrapper: wrap(defaultServices()) });
-    await waitFor(() =>
-      expect(screen.getByLabelText(/max active sagas/i)).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByLabelText(/max active sagas/i)).toBeInTheDocument());
   });
 });

--- a/web-next/packages/plugin-tyr/src/ui/settings/NotificationsSection.stories.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/settings/NotificationsSection.stories.tsx
@@ -30,7 +30,9 @@ export const Loading: Story = {
       const Wrapper = buildWrapper({
         'tyr.settings': {
           getNotificationSettings() {
-            return new Promise(() => { /* never resolves */ });
+            return new Promise(() => {
+              /* never resolves */
+            });
           },
         },
       });

--- a/web-next/packages/plugin-tyr/src/ui/settings/NotificationsSection.test.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/settings/NotificationsSection.test.tsx
@@ -33,27 +33,23 @@ describe('NotificationsSection', () => {
 
   it('shows section heading', async () => {
     render(<NotificationsSection />, { wrapper: wrap(defaultServices()) });
-    await waitFor(() =>
-      expect(screen.getByText('Notifications')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('Notifications')).toBeInTheDocument());
   });
 
   it('shows error state when service throws', async () => {
     const failing = {
-      getNotificationSettings: async () => { throw new Error('notif error'); },
+      getNotificationSettings: async () => {
+        throw new Error('notif error');
+      },
     };
     render(<NotificationsSection />, { wrapper: wrap({ 'tyr.settings': failing }) });
-    await waitFor(() =>
-      expect(screen.getByRole('alert')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
     expect(screen.getByText('notif error')).toBeInTheDocument();
   });
 
   it('shows event toggle rows', async () => {
     render(<NotificationsSection />, { wrapper: wrap(defaultServices()) });
-    await waitFor(() =>
-      expect(screen.getByText('Raid awaiting approval')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('Raid awaiting approval')).toBeInTheDocument());
     expect(screen.getByText('Raid merged')).toBeInTheDocument();
     expect(screen.getByText('Raid failed')).toBeInTheDocument();
     expect(screen.getByText('Saga complete')).toBeInTheDocument();
@@ -67,15 +63,11 @@ describe('NotificationsSection', () => {
     );
 
     fireEvent.submit(screen.getByRole('form', { name: /notification settings form/i }));
-    await waitFor(() =>
-      expect(screen.getByText('Saved')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('Saved')).toBeInTheDocument());
   });
 
   it('shows channel selection label', async () => {
     render(<NotificationsSection />, { wrapper: wrap(defaultServices()) });
-    await waitFor(() =>
-      expect(screen.getByText('Notification channel')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('Notification channel')).toBeInTheDocument());
   });
 });

--- a/web-next/packages/plugin-tyr/src/ui/settings/NotificationsSection.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/settings/NotificationsSection.tsx
@@ -1,5 +1,12 @@
 import { useState, type FormEvent } from 'react';
-import { Field, Input, Select, ValidationSummary, StateDot, type ValidationError } from '@niuulabs/ui';
+import {
+  Field,
+  Input,
+  Select,
+  ValidationSummary,
+  StateDot,
+  type ValidationError,
+} from '@niuulabs/ui';
 import type { NotificationChannel, NotificationSettings } from '../../ports';
 import { useNotificationSettings, useUpdateNotificationSettings } from './useSettings';
 
@@ -42,7 +49,10 @@ function ToggleRow({ id, name, label, defaultChecked }: ToggleRowProps) {
         defaultChecked={defaultChecked}
         className="niuu-accent-brand niuu-shrink-0"
       />
-      <label htmlFor={id} className="niuu-text-sm niuu-text-text-primary niuu-select-none niuu-flex-1">
+      <label
+        htmlFor={id}
+        className="niuu-text-sm niuu-text-text-primary niuu-select-none niuu-flex-1"
+      >
         {label}
       </label>
     </div>
@@ -88,7 +98,9 @@ export function NotificationsSection() {
     return (
       <div className="niuu-flex niuu-items-center niuu-gap-2" role="status">
         <StateDot state="processing" pulse />
-        <span className="niuu-text-sm niuu-text-text-secondary">loading notification settings…</span>
+        <span className="niuu-text-sm niuu-text-text-secondary">
+          loading notification settings…
+        </span>
       </div>
     );
   }

--- a/web-next/packages/plugin-tyr/src/ui/settings/PersonasSection.stories.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/settings/PersonasSection.stories.tsx
@@ -36,7 +36,6 @@ const SEED_PERSONAS: TyrPersonaSummary[] = [
   },
 ];
 
-
 const meta: Meta<typeof PersonasSection> = {
   title: 'Plugins / Tyr / Settings / PersonasSection',
   component: PersonasSection,
@@ -50,7 +49,9 @@ export const Data: Story = {
     (Story) => {
       const Wrapper = buildWrapper({
         'ravn.personas': {
-          async listPersonas() { return SEED_PERSONAS; },
+          async listPersonas() {
+            return SEED_PERSONAS;
+          },
           async getPersonaYaml(name: string) {
             return `name: ${name}\nmodel: claude-sonnet-4-6\niterationBudget: 40\n`;
           },
@@ -71,7 +72,9 @@ export const Loading: Story = {
       const Wrapper = buildWrapper({
         'ravn.personas': {
           listPersonas() {
-            return new Promise(() => { /* never resolves */ });
+            return new Promise(() => {
+              /* never resolves */
+            });
           },
         },
       });
@@ -108,8 +111,12 @@ export const Empty: Story = {
     (Story) => {
       const Wrapper = buildWrapper({
         'ravn.personas': {
-          async listPersonas() { return []; },
-          async getPersonaYaml() { return ''; },
+          async listPersonas() {
+            return [];
+          },
+          async getPersonaYaml() {
+            return '';
+          },
         },
       });
       return (

--- a/web-next/packages/plugin-tyr/src/ui/settings/PersonasSection.test.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/settings/PersonasSection.test.tsx
@@ -58,18 +58,14 @@ describe('PersonasSection', () => {
     render(<PersonasSection />, {
       wrapper: wrap({ 'ravn.personas': makeMockPersonaStore() }),
     });
-    await waitFor(() =>
-      expect(screen.getByText('Personas')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('Personas')).toBeInTheDocument());
   });
 
   it('shows persona names after loading', async () => {
     render(<PersonasSection />, {
       wrapper: wrap({ 'ravn.personas': makeMockPersonaStore() }),
     });
-    await waitFor(() =>
-      expect(screen.getByText('coder')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('coder')).toBeInTheDocument());
     expect(screen.getByText('custom-agent')).toBeInTheDocument();
   });
 
@@ -77,50 +73,40 @@ describe('PersonasSection', () => {
     render(<PersonasSection />, {
       wrapper: wrap({ 'ravn.personas': makeMockPersonaStore() }),
     });
-    await waitFor(() =>
-      expect(screen.getByText('builtin')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('builtin')).toBeInTheDocument());
   });
 
   it('marks overridden persona with label', async () => {
     render(<PersonasSection />, {
       wrapper: wrap({ 'ravn.personas': makeMockPersonaStore() }),
     });
-    await waitFor(() =>
-      expect(screen.getByText('overridden')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('overridden')).toBeInTheDocument());
   });
 
   it('shows persona count', async () => {
     render(<PersonasSection />, {
       wrapper: wrap({ 'ravn.personas': makeMockPersonaStore() }),
     });
-    await waitFor(() =>
-      expect(screen.getByText('2 personas')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('2 personas')).toBeInTheDocument());
   });
 
   it('shows YAML when persona is selected', async () => {
     render(<PersonasSection />, {
       wrapper: wrap({ 'ravn.personas': makeMockPersonaStore('name: coder\nmodel: sonnet\n') }),
     });
-    await waitFor(() =>
-      expect(screen.getByText('coder')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('coder')).toBeInTheDocument());
     fireEvent.click(screen.getByText('coder'));
-    await waitFor(() =>
-      expect(screen.getByText(/name: coder/)).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(/name: coder/)).toBeInTheDocument());
   });
 
   it('shows error state when service throws', async () => {
     const failing = {
-      listPersonas: async () => { throw new Error('ravn unavailable'); },
+      listPersonas: async () => {
+        throw new Error('ravn unavailable');
+      },
     };
     render(<PersonasSection />, { wrapper: wrap({ 'ravn.personas': failing }) });
-    await waitFor(() =>
-      expect(screen.getByRole('alert')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
     expect(screen.getByText('ravn unavailable')).toBeInTheDocument();
   });
 
@@ -140,9 +126,7 @@ describe('PersonasSection', () => {
     render(<PersonasSection />, {
       wrapper: wrap({ 'ravn.personas': makeMockPersonaStore() }),
     });
-    await waitFor(() =>
-      expect(screen.getByText('coder')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('coder')).toBeInTheDocument());
     fireEvent.click(screen.getByText('coder'));
     fireEvent.click(screen.getByRole('tab', { name: 'Custom' }));
 
@@ -157,8 +141,6 @@ describe('PersonasSection', () => {
   it('shows empty state when no personas match', async () => {
     const emptyStore = { listPersonas: async () => [] as TyrPersonaSummary[] };
     render(<PersonasSection />, { wrapper: wrap({ 'ravn.personas': emptyStore }) });
-    await waitFor(() =>
-      expect(screen.getByText('No personas found.')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('No personas found.')).toBeInTheDocument());
   });
 });

--- a/web-next/packages/plugin-tyr/src/ui/settings/PersonasSection.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/settings/PersonasSection.tsx
@@ -97,11 +97,7 @@ export function PersonasSection() {
       </p>
 
       {/* Filter tabs */}
-      <div
-        className="niuu-flex niuu-gap-1 niuu-mb-3"
-        role="tablist"
-        aria-label="Persona filter"
-      >
+      <div className="niuu-flex niuu-gap-1 niuu-mb-3" role="tablist" aria-label="Persona filter">
         {FILTER_TABS.map((tab) => (
           <button
             key={tab.value}

--- a/web-next/packages/plugin-tyr/src/ui/settings/SettingsPage.test.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/settings/SettingsPage.test.tsx
@@ -63,44 +63,34 @@ describe('SettingsPage', () => {
     render(<SettingsPage section="personas" />, {
       wrapper: wrap(defaultServices()),
     });
-    await waitFor(() =>
-      expect(screen.getByText('Personas')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('Personas')).toBeInTheDocument());
   });
 
   it('renders FlockConfigSection for "flock" section', async () => {
     render(<SettingsPage section="flock" />, {
       wrapper: wrap(defaultServices()),
     });
-    await waitFor(() =>
-      expect(screen.getByText('Flock Config')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('Flock Config')).toBeInTheDocument());
   });
 
   it('renders DispatchDefaultsSection for "dispatch" section', async () => {
     render(<SettingsPage section="dispatch" />, {
       wrapper: wrap(defaultServices()),
     });
-    await waitFor(() =>
-      expect(screen.getByText('Dispatch Defaults')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('Dispatch Defaults')).toBeInTheDocument());
   });
 
   it('renders NotificationsSection for "notifications" section', async () => {
     render(<SettingsPage section="notifications" />, {
       wrapper: wrap(defaultServices()),
     });
-    await waitFor(() =>
-      expect(screen.getByText('Notifications')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('Notifications')).toBeInTheDocument());
   });
 
   it('renders AuditLogSection for "audit" section', async () => {
     render(<SettingsPage section="audit" />, {
       wrapper: wrap(defaultServices()),
     });
-    await waitFor(() =>
-      expect(screen.getByText('Audit Log')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('Audit Log')).toBeInTheDocument());
   });
 });

--- a/web-next/packages/plugin-tyr/src/ui/usePlanWizard.test.ts
+++ b/web-next/packages/plugin-tyr/src/ui/usePlanWizard.test.ts
@@ -1,0 +1,310 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { createElement } from 'react';
+import { ServicesProvider } from '@niuulabs/plugin-sdk';
+import type { ReactNode } from 'react';
+import { usePlanWizard } from './usePlanWizard';
+import type { ITyrService } from '../ports';
+import type { PlanSession, ExtractedStructure } from '../ports';
+import type { Saga, Phase } from '../domain/saga';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const MOCK_SESSION: PlanSession = {
+  sessionId: 'sess-plan-1',
+  chatEndpoint: null,
+  questions: [
+    { id: 'q1', question: 'Which repos?', hint: 'e.g. niuulabs/volundr' },
+    { id: 'q2', question: 'Base branch?' },
+  ],
+};
+
+const MOCK_PHASES: Phase[] = [
+  {
+    id: 'ph-1',
+    sagaId: '',
+    trackerId: '',
+    number: 1,
+    name: 'Phase 1',
+    status: 'pending',
+    confidence: 80,
+    raids: [],
+  },
+];
+
+const MOCK_STRUCTURE: ExtractedStructure = {
+  found: true,
+  structure: {
+    name: 'Test Saga',
+    phases: [
+      {
+        name: 'Phase 1',
+        raids: [
+          {
+            name: 'Scaffold',
+            description: 'Scaffold domain',
+            acceptanceCriteria: ['types exported'],
+            declaredFiles: ['src/domain.ts'],
+            estimateHours: 4,
+            confidence: 80,
+          },
+        ],
+      },
+    ],
+  },
+};
+
+const MOCK_SAGA: Saga = {
+  id: 'saga-new-1',
+  trackerId: 'NIU-999',
+  trackerType: 'linear',
+  slug: 'test-saga',
+  name: 'Test Saga',
+  repos: ['niuulabs/volundr'],
+  featureBranch: 'feat/test-saga',
+  status: 'active',
+  confidence: 80,
+  createdAt: '2026-01-01T00:00:00Z',
+  phaseSummary: { total: 1, completed: 0 },
+};
+
+// ---------------------------------------------------------------------------
+// Wrapper
+// ---------------------------------------------------------------------------
+
+function makeWrapper(svc: Partial<ITyrService>) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(ServicesProvider, { services: { tyr: svc } }, children);
+  };
+}
+
+function makeMockService(overrides: Partial<ITyrService> = {}): Partial<ITyrService> {
+  return {
+    getSagas: vi.fn().mockResolvedValue([]),
+    getSaga: vi.fn().mockResolvedValue(null),
+    getPhases: vi.fn().mockResolvedValue([]),
+    createSaga: vi.fn(),
+    commitSaga: vi.fn().mockResolvedValue(MOCK_SAGA),
+    decompose: vi.fn().mockResolvedValue(MOCK_PHASES),
+    spawnPlanSession: vi.fn().mockResolvedValue(MOCK_SESSION),
+    extractStructure: vi.fn().mockResolvedValue(MOCK_STRUCTURE),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('usePlanWizard — initial state', () => {
+  it('starts on the prompt step', () => {
+    const svc = makeMockService();
+    const { result } = renderHook(() => usePlanWizard(), { wrapper: makeWrapper(svc) });
+    expect(result.current.state.step).toBe('prompt');
+  });
+
+  it('has empty prompt and repo', () => {
+    const svc = makeMockService();
+    const { result } = renderHook(() => usePlanWizard(), { wrapper: makeWrapper(svc) });
+    expect(result.current.state.prompt).toBe('');
+    expect(result.current.state.repo).toBe('');
+  });
+
+  it('has no loading or error initially', () => {
+    const svc = makeMockService();
+    const { result } = renderHook(() => usePlanWizard(), { wrapper: makeWrapper(svc) });
+    expect(result.current.state.loading).toBe(false);
+    expect(result.current.state.error).toBeNull();
+  });
+});
+
+describe('usePlanWizard — submitPrompt', () => {
+  it('transitions to questions step on success', async () => {
+    const svc = makeMockService();
+    const { result } = renderHook(() => usePlanWizard(), { wrapper: makeWrapper(svc) });
+
+    await act(async () => {
+      await result.current.submitPrompt('Build auth module', 'niuulabs/volundr');
+    });
+
+    expect(result.current.state.step).toBe('questions');
+    expect(result.current.state.prompt).toBe('Build auth module');
+    expect(result.current.state.repo).toBe('niuulabs/volundr');
+  });
+
+  it('loads the questions from the session', async () => {
+    const svc = makeMockService();
+    const { result } = renderHook(() => usePlanWizard(), { wrapper: makeWrapper(svc) });
+
+    await act(async () => {
+      await result.current.submitPrompt('Build auth module', 'niuulabs/volundr');
+    });
+
+    expect(result.current.state.questions).toHaveLength(2);
+    expect(result.current.state.questions[0]?.question).toBe('Which repos?');
+  });
+
+  it('sets error on service failure', async () => {
+    const svc = makeMockService({
+      spawnPlanSession: vi.fn().mockRejectedValue(new Error('service down')),
+    });
+    const { result } = renderHook(() => usePlanWizard(), { wrapper: makeWrapper(svc) });
+
+    await act(async () => {
+      await result.current.submitPrompt('Build auth module', 'niuulabs/volundr');
+    });
+
+    expect(result.current.state.error).toBe('service down');
+    expect(result.current.state.step).toBe('prompt');
+  });
+});
+
+describe('usePlanWizard — submitAnswers', () => {
+  it('transitions to raiding step', async () => {
+    const svc = makeMockService();
+    const { result } = renderHook(() => usePlanWizard(), { wrapper: makeWrapper(svc) });
+
+    await act(async () => {
+      await result.current.submitPrompt('Build auth', 'niuulabs/volundr');
+    });
+
+    act(() => {
+      result.current.submitAnswers({ q1: 'niuulabs/volundr', q2: 'main' });
+    });
+
+    expect(result.current.state.step).toBe('raiding');
+    expect(result.current.state.answers).toEqual({ q1: 'niuulabs/volundr', q2: 'main' });
+  });
+
+  it('auto-decomposes and transitions to draft', async () => {
+    const svc = makeMockService();
+    const { result } = renderHook(() => usePlanWizard(), { wrapper: makeWrapper(svc) });
+
+    await act(async () => {
+      await result.current.submitPrompt('Build auth', 'niuulabs/volundr');
+    });
+
+    act(() => {
+      result.current.submitAnswers({ q1: 'niuulabs/volundr' });
+    });
+
+    await waitFor(() => expect(result.current.state.step).toBe('draft'));
+    expect(result.current.state.structure).not.toBeNull();
+  });
+});
+
+describe('usePlanWizard — approveDraft', () => {
+  async function advanceToDraft(svc: Partial<ITyrService>) {
+    const { result } = renderHook(() => usePlanWizard(), { wrapper: makeWrapper(svc) });
+
+    await act(async () => {
+      await result.current.submitPrompt('Build auth', 'niuulabs/volundr');
+    });
+
+    act(() => {
+      result.current.submitAnswers({ q1: 'niuulabs/volundr' });
+    });
+
+    await waitFor(() => expect(result.current.state.step).toBe('draft'));
+    return result;
+  }
+
+  it('transitions to approved on success', async () => {
+    const svc = makeMockService();
+    const result = await advanceToDraft(svc);
+
+    await act(async () => {
+      await result.current.approveDraft();
+    });
+
+    expect(result.current.state.step).toBe('approved');
+    expect(result.current.state.saga).not.toBeNull();
+  });
+
+  it('sets error on commit failure', async () => {
+    const svc = makeMockService({
+      commitSaga: vi.fn().mockRejectedValue(new Error('commit failed')),
+    });
+    const result = await advanceToDraft(svc);
+
+    await act(async () => {
+      await result.current.approveDraft();
+    });
+
+    expect(result.current.state.error).toBe('commit failed');
+    expect(result.current.state.step).toBe('draft');
+  });
+});
+
+describe('usePlanWizard — back', () => {
+  it('goes back from questions to prompt', async () => {
+    const svc = makeMockService();
+    const { result } = renderHook(() => usePlanWizard(), { wrapper: makeWrapper(svc) });
+
+    await act(async () => {
+      await result.current.submitPrompt('Build auth', 'niuulabs/volundr');
+    });
+
+    act(() => result.current.back());
+    expect(result.current.state.step).toBe('prompt');
+  });
+
+  it('does nothing on prompt step', () => {
+    const svc = makeMockService();
+    const { result } = renderHook(() => usePlanWizard(), { wrapper: makeWrapper(svc) });
+    act(() => result.current.back());
+    expect(result.current.state.step).toBe('prompt');
+  });
+});
+
+describe('usePlanWizard — editPhase', () => {
+  it('updates a phase name in the structure', async () => {
+    const svc = makeMockService();
+    const { result } = renderHook(() => usePlanWizard(), { wrapper: makeWrapper(svc) });
+
+    await act(async () => {
+      await result.current.submitPrompt('Build auth', 'niuulabs/volundr');
+    });
+    act(() => result.current.submitAnswers({}));
+    await waitFor(() => expect(result.current.state.step).toBe('draft'));
+
+    act(() => result.current.editPhase(0, 'Renamed Phase'));
+    expect(result.current.state.structure?.structure?.phases[0]?.name).toBe('Renamed Phase');
+  });
+});
+
+describe('usePlanWizard — clearError', () => {
+  it('clears the error state', async () => {
+    const svc = makeMockService({
+      spawnPlanSession: vi.fn().mockRejectedValue(new Error('oops')),
+    });
+    const { result } = renderHook(() => usePlanWizard(), { wrapper: makeWrapper(svc) });
+
+    await act(async () => {
+      await result.current.submitPrompt('Build auth', 'repo');
+    });
+
+    expect(result.current.state.error).toBe('oops');
+    act(() => result.current.clearError());
+    expect(result.current.state.error).toBeNull();
+  });
+});
+
+describe('usePlanWizard — decompose error', () => {
+  it('sets error when decompose fails', async () => {
+    const svc = makeMockService({
+      decompose: vi.fn().mockRejectedValue(new Error('decompose failed')),
+    });
+    const { result } = renderHook(() => usePlanWizard(), { wrapper: makeWrapper(svc) });
+
+    await act(async () => {
+      await result.current.submitPrompt('Build auth', 'repo');
+    });
+    act(() => result.current.submitAnswers({}));
+
+    await waitFor(() => expect(result.current.state.error).toBe('decompose failed'));
+    expect(result.current.state.step).toBe('raiding');
+  });
+});

--- a/web-next/packages/plugin-tyr/src/ui/usePlanWizard.test.ts
+++ b/web-next/packages/plugin-tyr/src/ui/usePlanWizard.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { createElement } from 'react';
 import { ServicesProvider } from '@niuulabs/plugin-sdk';

--- a/web-next/packages/plugin-tyr/src/ui/usePlanWizard.ts
+++ b/web-next/packages/plugin-tyr/src/ui/usePlanWizard.ts
@@ -170,7 +170,10 @@ function buildFullSpec(prompt: string, answers: Record<string, string>): string 
 function buildCommitRequest(state: PlanWizardState): CommitSagaRequest {
   const structure = state.structure?.structure;
   const name = structure?.name ?? 'New Saga';
-  const slug = name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
+  const slug = name
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9-]/g, '');
 
   return {
     name,

--- a/web-next/packages/plugin-tyr/src/ui/usePlanWizard.ts
+++ b/web-next/packages/plugin-tyr/src/ui/usePlanWizard.ts
@@ -1,0 +1,290 @@
+import { useReducer, useEffect, useRef } from 'react';
+import { useService } from '@niuulabs/plugin-sdk';
+import { planTransition, type PlanStep } from '../domain/plan';
+import type { ITyrService, CommitSagaRequest, PlanSession, ExtractedStructure } from '../ports';
+import type { ClarifyingQuestion } from '../domain/plan';
+import type { Saga, Phase } from '../domain/saga';
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+export interface PlanWizardState {
+  step: PlanStep;
+  prompt: string;
+  repo: string;
+  session: PlanSession | null;
+  questions: ClarifyingQuestion[];
+  answers: Record<string, string>;
+  phases: Phase[];
+  structure: ExtractedStructure | null;
+  saga: Saga | null;
+  loading: boolean;
+  error: string | null;
+}
+
+const initialState: PlanWizardState = {
+  step: 'prompt',
+  prompt: '',
+  repo: '',
+  session: null,
+  questions: [],
+  answers: {},
+  phases: [],
+  structure: null,
+  saga: null,
+  loading: false,
+  error: null,
+};
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+type Action =
+  | { type: 'SET_LOADING' }
+  | { type: 'SESSION_READY'; prompt: string; repo: string; session: PlanSession }
+  | { type: 'SUBMIT_ANSWERS'; answers: Record<string, string> }
+  | { type: 'DECOMPOSE_DONE'; phases: Phase[]; structure: ExtractedStructure }
+  | { type: 'DECOMPOSE_ERROR'; error: string }
+  | { type: 'APPROVE_DONE'; saga: Saga }
+  | { type: 'APPROVE_ERROR'; error: string }
+  | { type: 'BACK' }
+  | { type: 'EDIT_PHASE'; phaseIndex: number; name: string }
+  | { type: 'CLEAR_ERROR' };
+
+// ---------------------------------------------------------------------------
+// Reducer
+// ---------------------------------------------------------------------------
+
+function reducer(state: PlanWizardState, action: Action): PlanWizardState {
+  switch (action.type) {
+    case 'SET_LOADING':
+      return { ...state, loading: true, error: null };
+
+    case 'SESSION_READY': {
+      const step = planTransition(state.step, 'questions');
+      return {
+        ...state,
+        step,
+        prompt: action.prompt,
+        repo: action.repo,
+        session: action.session,
+        questions: action.session.questions,
+        loading: false,
+        error: null,
+      };
+    }
+
+    case 'SUBMIT_ANSWERS': {
+      const step = planTransition(state.step, 'raiding');
+      return {
+        ...state,
+        step,
+        answers: action.answers,
+        loading: false,
+        error: null,
+      };
+    }
+
+    case 'DECOMPOSE_DONE': {
+      const step = planTransition(state.step, 'draft');
+      return {
+        ...state,
+        step,
+        phases: action.phases,
+        structure: action.structure,
+        loading: false,
+        error: null,
+      };
+    }
+
+    case 'DECOMPOSE_ERROR':
+      return {
+        ...state,
+        loading: false,
+        error: action.error,
+      };
+
+    case 'APPROVE_DONE': {
+      const step = planTransition(state.step, 'approved');
+      return {
+        ...state,
+        step,
+        saga: action.saga,
+        loading: false,
+        error: null,
+      };
+    }
+
+    case 'APPROVE_ERROR':
+      return { ...state, loading: false, error: action.error };
+
+    case 'BACK': {
+      const backMap: Partial<Record<PlanStep, PlanStep>> = {
+        questions: 'prompt',
+        raiding: 'questions',
+        draft: 'raiding',
+      };
+      const target = backMap[state.step];
+      if (!target) return state;
+      const step = planTransition(state.step, target);
+      return { ...state, step, loading: false, error: null };
+    }
+
+    case 'EDIT_PHASE': {
+      if (!state.structure?.structure) return state;
+      const phases = state.structure.structure.phases.map((p, i) =>
+        i === action.phaseIndex ? { ...p, name: action.name } : p,
+      );
+      return {
+        ...state,
+        structure: {
+          ...state.structure,
+          structure: { ...state.structure.structure, phases },
+        },
+      };
+    }
+
+    case 'CLEAR_ERROR':
+      return { ...state, error: null };
+
+    default:
+      return state;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildFullSpec(prompt: string, answers: Record<string, string>): string {
+  const answerBlock = Object.values(answers)
+    .filter(Boolean)
+    .map((a) => `- ${a}`)
+    .join('\n');
+  if (!answerBlock) return prompt;
+  return `${prompt}\n\nAdditional context:\n${answerBlock}`;
+}
+
+function buildCommitRequest(state: PlanWizardState): CommitSagaRequest {
+  const structure = state.structure?.structure;
+  const name = structure?.name ?? 'New Saga';
+  const slug = name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
+
+  return {
+    name,
+    slug,
+    description: state.prompt,
+    repos: state.repo ? [state.repo] : [],
+    baseBranch: 'main',
+    phases: (structure?.phases ?? []).map((p) => ({
+      name: p.name,
+      raids: p.raids.map((r) => ({
+        name: r.name,
+        description: r.description,
+        acceptanceCriteria: r.acceptanceCriteria,
+        declaredFiles: r.declaredFiles,
+        estimateHours: r.estimateHours,
+      })),
+    })),
+    transcript: buildFullSpec(state.prompt, state.answers),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export interface PlanWizardActions {
+  submitPrompt(prompt: string, repo: string): Promise<void>;
+  submitAnswers(answers: Record<string, string>): void;
+  approveDraft(): Promise<void>;
+  editPhase(phaseIndex: number, name: string): void;
+  back(): void;
+  clearError(): void;
+}
+
+export function usePlanWizard(): { state: PlanWizardState } & PlanWizardActions {
+  const tyr = useService<ITyrService>('tyr');
+  const [state, dispatch] = useReducer(reducer, initialState);
+  // Keep a stable ref to the latest state for effects
+  const stateRef = useRef(state);
+  stateRef.current = state;
+
+  // Auto-decompose when entering the raiding step
+  useEffect(() => {
+    if (state.step !== 'raiding') return;
+
+    let cancelled = false;
+
+    async function runDecompose() {
+      const { prompt, repo, answers } = stateRef.current;
+      const fullSpec = buildFullSpec(prompt, answers);
+      try {
+        const phases = await tyr.decompose(fullSpec, repo);
+        if (cancelled) return;
+        const phasesText = JSON.stringify(phases);
+        const structure = await tyr.extractStructure(phasesText);
+        if (cancelled) return;
+        dispatch({ type: 'DECOMPOSE_DONE', phases, structure });
+      } catch (err) {
+        if (cancelled) return;
+        dispatch({
+          type: 'DECOMPOSE_ERROR',
+          error: err instanceof Error ? err.message : 'Decomposition failed',
+        });
+      }
+    }
+
+    void runDecompose();
+    return () => {
+      cancelled = true;
+    };
+  }, [state.step, tyr]);
+
+  async function submitPrompt(prompt: string, repo: string) {
+    dispatch({ type: 'SET_LOADING' });
+    try {
+      const session = await tyr.spawnPlanSession(prompt, repo);
+      dispatch({ type: 'SESSION_READY', prompt, repo, session });
+    } catch (err) {
+      dispatch({
+        type: 'DECOMPOSE_ERROR',
+        error: err instanceof Error ? err.message : 'Failed to start plan session',
+      });
+    }
+  }
+
+  function submitAnswers(answers: Record<string, string>) {
+    dispatch({ type: 'SUBMIT_ANSWERS', answers });
+  }
+
+  async function approveDraft() {
+    dispatch({ type: 'SET_LOADING' });
+    try {
+      const request = buildCommitRequest(stateRef.current);
+      const saga = await tyr.commitSaga(request);
+      dispatch({ type: 'APPROVE_DONE', saga });
+    } catch (err) {
+      dispatch({
+        type: 'APPROVE_ERROR',
+        error: err instanceof Error ? err.message : 'Failed to commit saga',
+      });
+    }
+  }
+
+  function editPhase(phaseIndex: number, name: string) {
+    dispatch({ type: 'EDIT_PHASE', phaseIndex, name });
+  }
+
+  function back() {
+    dispatch({ type: 'BACK' });
+  }
+
+  function clearError() {
+    dispatch({ type: 'CLEAR_ERROR' });
+  }
+
+  return { state, submitPrompt, submitAnswers, approveDraft, editPhase, back, clearError };
+}


### PR DESCRIPTION
## Summary

- **Plan state machine** (`domain/plan.ts`): `PlanStep` type with 5 steps (`prompt → questions → raiding → draft → approved`), `planTransition()` that throws `PlanTransitionError` on invalid moves, `canTransition()`, `stepIndex()`, `PLAN_STEPS`, `PLAN_STEP_LABELS`
- **`StepDots` component**: horizontal progress indicator across the wizard header — completed steps brand-400, active step brand-500 with ring, pending steps bg-elevated; full ARIA (`aria-current="step"`, `role="img"` labels)
- **`usePlanWizard` hook**: `useReducer`-backed state machine wiring all 5 phases — `submitPrompt` → spawns plan session, `submitAnswers` → triggers auto-decompose on raiding step entry, `approveDraft` → commits saga; back navigation enforced through the transition table
- **5 step components**: `PlanPrompt`, `PlanQuestions`, `PlanRaiding` (animated loading + error), `PlanDraft` (with inline `PhaseEditor` for editing phase names), `PlanApproved` (saga summary)
- **`PlanWizard`**: thin container routing across steps; handles `handleNewPlan` → resets to `/tyr/plan`
- **Port additions**: `spawnPlanSession`, `extractStructure` added to `ITyrService`; HTTP adapter wired; mock adapter returns representative wizard data
- **Storybook stories**: per step (`Prompt`, `PromptLoading`, `PromptError`, `Questions`, `QuestionsEmpty`, `Raiding`, `RaidingError`, `Draft`, `DraftLoading`, `DraftError`, `Approved`) + `StepDots` per state + `FullFlow`

## Test plan

- [x] `plan.test.ts` — 42 tests: all 7 valid transitions, all invalid transitions refused, `PlanTransitionError` properties, `PLAN_STEPS`, `PLAN_STEP_LABELS`, `stepIndex`
- [x] `StepDots.test.tsx` — 7 tests: aria-current, role=img labels for all states, accessible nav label
- [x] `usePlanWizard.test.ts` — 15 tests: initial state, submitPrompt success/error, submitAnswers + auto-decompose, approveDraft success/error, back navigation, editPhase, clearError, decompose error
- [x] `PlanWizard.test.tsx` — 38 tests: all 5 step components unit tested + integration tests for full flow, back navigation, error states
- [x] `e2e/tyr.spec.ts` — 9 Playwright tests covering all 5 wizard states + back nav + keyboard accessibility
- [x] All 2281 unit tests pass, coverage ≥ 85%

Closes NIU-682

🤖 Generated with [Claude Code](https://claude.com/claude-code)