### PR TITLE
feat(tyr): rebuild Tyr plugin UI to match web2 prototype — NIU-691

### DIFF
--- a/web-next/packages/plugin-sdk/src/PluginDescriptor.ts
+++ b/web-next/packages/plugin-sdk/src/PluginDescriptor.ts
@@ -10,6 +10,11 @@ export interface PluginTab {
   id: string;
   label: string;
   rune?: string;
+  /**
+   * Route path for this tab. Defaults to `/${pluginId}/${id}`.
+   * Use this to map a tab to the plugin root (e.g. `path: '/tyr'` for dashboard).
+   */
+  path?: string;
 }
 
 export interface PluginDescriptor {

--- a/web-next/packages/plugin-tyr/src/index.ts
+++ b/web-next/packages/plugin-tyr/src/index.ts
@@ -15,6 +15,14 @@ export const tyrPlugin = definePlugin({
   rune: 'ᛏ',
   title: 'Tyr',
   subtitle: 'sagas · raids · dispatch',
+  tabs: [
+    { id: 'dashboard', label: 'Dashboard', rune: '◈', path: '/tyr' },
+    { id: 'sagas', label: 'Sagas', rune: 'ᛃ', path: '/tyr/sagas' },
+    { id: 'dispatch', label: 'Dispatch', rune: '⇥', path: '/tyr/dispatch' },
+    { id: 'plan', label: 'Plan', rune: '◇', path: '/tyr/plan' },
+    { id: 'workflows', label: 'Workflows', rune: '⚙', path: '/tyr/workflows' },
+    { id: 'settings', label: 'Settings', rune: '⚬', path: '/tyr/settings' },
+  ],
   routes: (rootRoute) => [
     createRoute({
       getParentRoute: () => rootRoute,

--- a/web-next/packages/plugin-tyr/src/index.ts
+++ b/web-next/packages/plugin-tyr/src/index.ts
@@ -42,7 +42,7 @@ export const tyrPlugin = definePlugin({
     createRoute({
       getParentRoute: () => rootRoute,
       path: '/tyr/sagas/$sagaId',
-      component: SagaDetailRoute,
+      component: SagasPage,
     }),
     createRoute({
       getParentRoute: () => rootRoute,

--- a/web-next/packages/plugin-tyr/src/ui/DashboardPage.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/DashboardPage.tsx
@@ -15,6 +15,7 @@ import type { ITyrService, Phase } from '../ports';
 import type { Saga, RaidStatus } from '../domain/saga';
 import { useSagas } from './useSagas';
 import { useDispatcher } from './useDispatcher';
+import { RaidMeshCanvas } from './RaidMeshCanvas';
 import './DashboardPage.css';
 
 type PipeCell = { status: 'ok' | 'run' | 'warn' | 'crit' | 'gate' | 'pend'; label: string };
@@ -191,9 +192,12 @@ export function DashboardPage() {
         <div className="tyr-flock-viz__cnt">
           {runningRaids} raids active
         </div>
-        <canvas
-          aria-label="Live raid mesh visualization"
-          style={{ width: '100%', height: '100%', background: 'transparent' }}
+        <RaidMeshCanvas
+          sagas={sagas ?? []}
+          phases={phaseQueries.map((q) => q.data ?? [])}
+          onClickSaga={(sagaId) =>
+            void navigate({ to: '/tyr/sagas/$sagaId', params: { sagaId } })
+          }
         />
       </div>
 

--- a/web-next/packages/plugin-tyr/src/ui/DispatchView.test.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/DispatchView.test.tsx
@@ -141,16 +141,16 @@ describe('DispatchView', () => {
   it('renders rule summary card after loading', async () => {
     render(<DispatchView />, { wrapper: wrap(makeServices()) });
     await waitFor(() => expect(screen.getByText('Dispatch rules')).toBeInTheDocument());
-    expect(screen.getByText('70%')).toBeInTheDocument();
+    // "70%" may appear in both queue header and rules panel
+    expect(screen.getAllByText('70%').length).toBeGreaterThanOrEqual(1);
     // Multiple "3"s can appear (concurrent cap + retries), use getAllByText
     expect(screen.getAllByText('3').length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText('off')).toBeInTheDocument();
   });
 
-  it('renders the dispatch queue table', async () => {
+  it('renders the dispatch queue list', async () => {
     render(<DispatchView />, { wrapper: wrap(makeServices()) });
-    await waitFor(() => expect(screen.getByRole('table')).toBeInTheDocument());
-    expect(screen.getByText('Test Raid')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText('Test Raid')).toBeInTheDocument());
     expect(screen.getByText(/Test Saga/)).toBeInTheDocument();
   });
 

--- a/web-next/packages/plugin-tyr/src/ui/DispatchView.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/DispatchView.tsx
@@ -324,23 +324,7 @@ function DispatchRulesPanel({
         <h3 className="niuu-m-0 niuu-mb-3 niuu-text-sm niuu-font-semibold niuu-text-text-primary">
           Recent dispatches
         </h3>
-        <div className="niuu-flex niuu-flex-col niuu-gap-2">
-          {[
-            { time: '2m ago', name: 'Auth Rewrite · Phase 1' },
-            { time: '8m ago', name: 'Observatory · Phase 2' },
-            { time: '15m ago', name: 'Ravn Plugin · Phase 1' },
-            { time: '22m ago', name: 'Auth Rewrite · Phase 1' },
-            { time: '31m ago', name: 'Observatory · Phase 1' },
-            { time: '45m ago', name: 'Ravn Plugin · Phase 2' },
-          ].map((d, i) => (
-            <div key={i} className="niuu-flex niuu-items-center niuu-gap-2">
-              <span className="niuu-text-xs niuu-font-mono niuu-text-text-faint niuu-w-12 niuu-shrink-0">
-                {d.time}
-              </span>
-              <span className="niuu-text-xs niuu-text-text-secondary niuu-truncate">{d.name}</span>
-            </div>
-          ))}
-        </div>
+        <p className="niuu-m-0 niuu-text-xs niuu-text-text-muted">No recent dispatches.</p>
       </div>
     </div>
   );

--- a/web-next/packages/plugin-tyr/src/ui/DispatchView.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/DispatchView.tsx
@@ -1,8 +1,6 @@
 import { useMemo, useState } from 'react';
 import { useService } from '@niuulabs/plugin-sdk';
 import {
-  Table,
-  type TableColumn,
   StateDot,
   StatusBadge,
   ConfidenceBar,
@@ -24,7 +22,6 @@ import { useDispatchQueue, type DispatchEntry } from './useDispatchQueue';
 // Constants
 // ---------------------------------------------------------------------------
 
-// TODO: source from DispatcherState once backend exposes maxRetries
 const DEFAULT_MAX_RETRIES = 3;
 
 // ---------------------------------------------------------------------------
@@ -53,43 +50,35 @@ interface EnrichedEntry extends DispatchEntry {
 }
 
 // ---------------------------------------------------------------------------
-// Sub-components
+// Gate chips
 // ---------------------------------------------------------------------------
 
-function RuleCard({
-  threshold,
-  maxConcurrentRaids,
-  autoContinue,
-}: {
-  threshold: number;
-  maxConcurrentRaids: number;
-  autoContinue: boolean;
-}) {
+const GATE_LABELS: Record<string, string> = {
+  raven_resolution: 'no raven',
+  confidence: 'low conf',
+  upstream_blocked: 'upstream',
+  cluster_healthy: 'cluster',
+};
+
+function GateChips({ gates }: { gates: FeasibilityGate[] }) {
+  const failing = gates.filter((g) => !g.passed);
+  if (failing.length === 0) return null;
   return (
-    <div
-      className="niuu-rounded-lg niuu-border niuu-border-border niuu-bg-bg-secondary niuu-p-4 niuu-mb-4"
-      aria-label="Dispatch rules"
-    >
-      <div className="niuu-flex niuu-items-center niuu-justify-between niuu-mb-3">
-        <h3 className="niuu-m-0 niuu-text-sm niuu-font-semibold niuu-text-text-primary">
-          Dispatch rules
-        </h3>
-      </div>
-      <dl className="niuu-grid niuu-grid-cols-4 niuu-gap-x-8 niuu-gap-y-1 niuu-text-xs niuu-text-text-secondary niuu-m-0">
-        <dt className="niuu-text-text-muted">Confidence threshold</dt>
-        <dt className="niuu-text-text-muted">Concurrent cap</dt>
-        <dt className="niuu-text-text-muted">Auto-continue</dt>
-        <dt className="niuu-text-text-muted">Retries</dt>
-        <dd className="niuu-m-0 niuu-font-mono niuu-text-text-primary">{threshold}%</dd>
-        <dd className="niuu-m-0 niuu-font-mono niuu-text-text-primary">{maxConcurrentRaids}</dd>
-        <dd className="niuu-m-0 niuu-font-mono niuu-text-text-primary">
-          {autoContinue ? 'on' : 'off'}
-        </dd>
-        <dd className="niuu-m-0 niuu-font-mono niuu-text-text-primary">{DEFAULT_MAX_RETRIES}</dd>
-      </dl>
+    <div className="niuu-flex niuu-flex-wrap niuu-gap-1">
+      {failing.map((gate) => (
+        <Tooltip key={gate.name} content={gate.reason} side="top">
+          <span className="niuu-inline-flex niuu-items-center niuu-gap-1 niuu-rounded-full niuu-border niuu-border-critical-bo niuu-bg-critical-bg niuu-px-2 niuu-py-0.5 niuu-text-xs niuu-text-critical niuu-cursor-default">
+            {GATE_LABELS[gate.name] ?? gate.name}
+          </span>
+        </Tooltip>
+      ))}
     </div>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Segmented filter
+// ---------------------------------------------------------------------------
 
 function SegmentedFilter({
   value,
@@ -127,40 +116,24 @@ function SegmentedFilter({
   );
 }
 
-function GateChips({ gates }: { gates: FeasibilityGate[] }) {
-  const failing = gates.filter((g) => !g.passed);
-  if (failing.length === 0) return null;
-
-  return (
-    <div className="niuu-flex niuu-flex-wrap niuu-gap-1">
-      {failing.map((gate) => (
-        <Tooltip key={gate.name} content={gate.reason} side="top">
-          <span className="niuu-inline-flex niuu-items-center niuu-gap-1 niuu-rounded-full niuu-border niuu-border-critical-bo niuu-bg-critical-bg niuu-px-2 niuu-py-0.5 niuu-text-xs niuu-text-critical niuu-cursor-default">
-            {GATE_LABELS[gate.name]}
-          </span>
-        </Tooltip>
-      ))}
-    </div>
-  );
-}
-
-const GATE_LABELS: Record<string, string> = {
-  raven_resolution: 'no raven',
-  confidence: 'low conf',
-  upstream_blocked: 'upstream',
-  cluster_healthy: 'cluster',
-};
+// ---------------------------------------------------------------------------
+// Batch dispatch bar
+// ---------------------------------------------------------------------------
 
 function BatchDispatchBar({
   selectedCount,
   canDispatch,
   onDispatch,
   isDispatching,
+  onApplyWorkflow,
+  onOverrideThreshold,
 }: {
   selectedCount: number;
   canDispatch: boolean;
   onDispatch: () => void;
   isDispatching: boolean;
+  onApplyWorkflow?: () => void;
+  onOverrideThreshold?: () => void;
 }) {
   if (selectedCount === 0) return null;
 
@@ -170,9 +143,27 @@ function BatchDispatchBar({
       role="status"
       aria-live="polite"
     >
-      <span className="niuu-text-sm niuu-text-text-secondary">
+      <span className="niuu-text-sm niuu-font-medium niuu-text-text-primary">
         {selectedCount} raid{selectedCount !== 1 ? 's' : ''} selected
       </span>
+      {onApplyWorkflow && (
+        <button
+          type="button"
+          onClick={onApplyWorkflow}
+          className="niuu-px-3 niuu-py-1.5 niuu-text-xs niuu-border niuu-border-border niuu-rounded-md niuu-text-text-secondary hover:niuu-text-text-primary niuu-bg-transparent niuu-transition-colors"
+        >
+          Apply workflow
+        </button>
+      )}
+      {onOverrideThreshold && (
+        <button
+          type="button"
+          onClick={onOverrideThreshold}
+          className="niuu-px-3 niuu-py-1.5 niuu-text-xs niuu-border niuu-border-border niuu-rounded-md niuu-text-text-secondary hover:niuu-text-text-primary niuu-bg-transparent niuu-transition-colors"
+        >
+          Override threshold
+        </button>
+      )}
       <Tooltip content={canDispatch ? undefined : 'Select only ready raids to dispatch'} side="top">
         <button
           type="button"
@@ -188,9 +179,169 @@ function BatchDispatchBar({
           )}
           aria-disabled={!canDispatch || isDispatching}
         >
-          {isDispatching ? 'Dispatching…' : 'Dispatch'}
+          {isDispatching ? 'Dispatching…' : 'Dispatch now'}
         </button>
       </Tooltip>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Saga group header
+// ---------------------------------------------------------------------------
+
+function SagaGroupHeader({
+  sagaName,
+  trackerId,
+  featureBranch,
+}: {
+  sagaName: string;
+  trackerId: string;
+  featureBranch: string;
+}) {
+  return (
+    <div className="niuu-flex niuu-items-center niuu-gap-2 niuu-px-4 niuu-py-2 niuu-bg-bg-tertiary niuu-border-b niuu-border-border-subtle niuu-sticky niuu-top-0 niuu-z-10">
+      <span className="niuu-text-xs niuu-font-mono niuu-text-text-muted niuu-bg-bg-elevated niuu-px-1.5 niuu-py-0.5 niuu-rounded">
+        {trackerId}
+      </span>
+      <span className="niuu-text-sm niuu-font-medium niuu-text-text-primary">{sagaName}</span>
+      <span className="niuu-text-xs niuu-font-mono niuu-text-text-faint niuu-ml-auto">
+        {featureBranch}
+      </span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Raid row (within saga group)
+// ---------------------------------------------------------------------------
+
+function RaidRow({
+  entry,
+  isSelected,
+  onToggle,
+}: {
+  entry: EnrichedEntry;
+  isSelected: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <div
+      className={cn(
+        'niuu-flex niuu-items-center niuu-gap-3 niuu-px-4 niuu-py-2.5 niuu-border-b niuu-border-border-subtle',
+        isSelected ? 'niuu-bg-bg-secondary' : 'hover:niuu-bg-bg-secondary',
+      )}
+    >
+      <input
+        type="checkbox"
+        checked={isSelected}
+        onChange={onToggle}
+        className="niuu-rounded niuu-border-border"
+        aria-label="Select row"
+      />
+      <div className="niuu-flex-1 niuu-min-w-0">
+        <div className="niuu-text-sm niuu-text-text-primary niuu-truncate">{entry.raid.name}</div>
+        <div className="niuu-text-xs niuu-font-mono niuu-text-text-muted niuu-mt-0.5">
+          {entry.raid.trackerId}
+          {entry.raid.estimateHours != null && ` · ~${entry.raid.estimateHours}h`}
+        </div>
+      </div>
+      <div className="niuu-flex niuu-items-center niuu-gap-2 niuu-shrink-0">
+        <StatusBadge
+          status={entry.effectiveStatus as Parameters<typeof StatusBadge>[0]['status']}
+          pulse={entry.effectiveStatus === 'running'}
+        />
+        {entry.feasibility.feasible ? (
+          <span className="niuu-text-xs niuu-font-mono niuu-text-text-muted niuu-bg-bg-elevated niuu-px-1.5 niuu-py-0.5 niuu-rounded">
+            ready
+          </span>
+        ) : (
+          <GateChips gates={entry.feasibility.gates} />
+        )}
+        <div className="niuu-flex niuu-items-center niuu-gap-1.5 niuu-w-[80px]">
+          <ConfidenceBar
+            level={
+              entry.raid.confidence >= 80
+                ? 'high'
+                : entry.raid.confidence >= 50
+                  ? 'medium'
+                  : 'low'
+            }
+          />
+          <span className="niuu-text-xs niuu-font-mono niuu-text-text-secondary">
+            {entry.raid.confidence}%
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Right panel: dispatch rules + recent dispatches
+// ---------------------------------------------------------------------------
+
+function DispatchRulesPanel({
+  threshold,
+  maxConcurrentRaids,
+  autoContinue,
+}: {
+  threshold: number;
+  maxConcurrentRaids: number;
+  autoContinue: boolean;
+}) {
+  const rules = [
+    { label: 'Confidence threshold', value: `${threshold}%` },
+    { label: 'Concurrent cap', value: String(maxConcurrentRaids) },
+    { label: 'Auto-continue', value: autoContinue ? 'on' : 'off' },
+    { label: 'Retries', value: String(DEFAULT_MAX_RETRIES) },
+    { label: 'Quiet hours', value: 'none' },
+    { label: 'Escalation', value: 'notify' },
+  ];
+
+  return (
+    <div className="niuu-p-4 niuu-flex niuu-flex-col niuu-gap-4">
+      {/* Dispatch rules card */}
+      <div
+        className="niuu-rounded-lg niuu-border niuu-border-border niuu-bg-bg-secondary niuu-p-4"
+        aria-label="Dispatch rules"
+      >
+        <h3 className="niuu-m-0 niuu-mb-3 niuu-text-sm niuu-font-semibold niuu-text-text-primary">
+          Dispatch rules
+        </h3>
+        <dl className="niuu-grid niuu-grid-cols-2 niuu-gap-x-4 niuu-gap-y-2 niuu-text-xs niuu-m-0">
+          {rules.map((r) => (
+            <div key={r.label}>
+              <dt className="niuu-text-text-muted niuu-mb-0.5">{r.label}</dt>
+              <dd className="niuu-m-0 niuu-font-mono niuu-text-text-primary">{r.value}</dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+
+      {/* Recent dispatches card */}
+      <div className="niuu-rounded-lg niuu-border niuu-border-border niuu-bg-bg-secondary niuu-p-4">
+        <h3 className="niuu-m-0 niuu-mb-3 niuu-text-sm niuu-font-semibold niuu-text-text-primary">
+          Recent dispatches
+        </h3>
+        <div className="niuu-flex niuu-flex-col niuu-gap-2">
+          {[
+            { time: '2m ago', name: 'Auth Rewrite · Phase 1' },
+            { time: '8m ago', name: 'Observatory · Phase 2' },
+            { time: '15m ago', name: 'Ravn Plugin · Phase 1' },
+            { time: '22m ago', name: 'Auth Rewrite · Phase 1' },
+            { time: '31m ago', name: 'Observatory · Phase 1' },
+            { time: '45m ago', name: 'Ravn Plugin · Phase 2' },
+          ].map((d, i) => (
+            <div key={i} className="niuu-flex niuu-items-center niuu-gap-2">
+              <span className="niuu-text-xs niuu-font-mono niuu-text-text-faint niuu-w-12 niuu-shrink-0">
+                {d.time}
+              </span>
+              <span className="niuu-text-xs niuu-text-text-secondary niuu-truncate">{d.name}</span>
+            </div>
+          ))}
+        </div>
+      </div>
     </div>
   );
 }
@@ -206,7 +357,7 @@ export function DispatchView() {
 
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
   const [searchQuery, setSearchQuery] = useState('');
-  const [selectedIds, setSelectedIds] = useState<Set<string | number>>(new Set());
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [optimisticQueued, setOptimisticQueued] = useState<Set<string>>(new Set());
   const [isDispatching, setIsDispatching] = useState(false);
 
@@ -282,13 +433,31 @@ export function DispatchView() {
     return { all: ready + blocked + queue, ready, blocked, queue };
   }, [enriched]);
 
-  // Determine if all selected raids are feasible
+  // Group filtered entries by sagaId
+  const groupedBySaga = useMemo(() => {
+    const map = new Map<string, { sagaName: string; trackerId: string; featureBranch: string; entries: EnrichedEntry[] }>();
+    for (const entry of filtered) {
+      const existing = map.get(entry.saga.id);
+      if (existing) {
+        existing.entries.push(entry);
+      } else {
+        map.set(entry.saga.id, {
+          sagaName: entry.saga.name,
+          trackerId: entry.saga.trackerId,
+          featureBranch: entry.saga.featureBranch,
+          entries: [entry],
+        });
+      }
+    }
+    return Array.from(map.entries());
+  }, [filtered]);
+
   const selectedEntries = filtered.filter((e) => selectedIds.has(e.raid.id));
   const allSelectedFeasible =
     selectedEntries.length > 0 && selectedEntries.every((e) => e.feasibility.feasible);
 
   async function handleDispatch() {
-    const ids = Array.from(selectedIds) as string[];
+    const ids = Array.from(selectedIds);
     setIsDispatching(true);
     setOptimisticQueued((prev) => new Set([...prev, ...ids]));
     setSelectedIds(new Set());
@@ -296,7 +465,6 @@ export function DispatchView() {
     try {
       await dispatchBus.dispatchBatch(ids);
     } catch {
-      // Roll back optimistic update on failure
       setOptimisticQueued((prev) => {
         const next = new Set(prev);
         ids.forEach((id) => next.delete(id));
@@ -307,62 +475,14 @@ export function DispatchView() {
     }
   }
 
-  // Table row shape — needs an `id` field
-  type Row = EnrichedEntry & { id: string };
-  const rows: Row[] = filtered.map((e) => ({ ...e, id: e.raid.id }));
-
-  const columns: TableColumn<Row>[] = [
-    {
-      key: 'raid',
-      header: 'Raid',
-      render: (row) => (
-        <div>
-          <div className="niuu-text-sm niuu-text-text-primary">{row.raid.name}</div>
-          <div className="niuu-text-xs niuu-text-text-muted niuu-mt-0.5">
-            {row.saga.name} · {row.phase.name}
-          </div>
-        </div>
-      ),
-    },
-    {
-      key: 'status',
-      header: 'Status',
-      width: '110px',
-      render: (row) => (
-        <StatusBadge
-          status={row.effectiveStatus as Parameters<typeof StatusBadge>[0]['status']}
-          pulse={row.effectiveStatus === 'running'}
-        />
-      ),
-    },
-    {
-      key: 'confidence',
-      header: 'Confidence',
-      width: '130px',
-      render: (row) => {
-        const level =
-          row.raid.confidence >= 80 ? 'high' : row.raid.confidence >= 50 ? 'medium' : 'low';
-        return (
-          <div className="niuu-flex niuu-items-center niuu-gap-2">
-            <ConfidenceBar level={level} />
-            <span className="niuu-text-xs niuu-font-mono niuu-text-text-secondary">
-              {row.raid.confidence}%
-            </span>
-          </div>
-        );
-      },
-    },
-    {
-      key: 'gates',
-      header: 'Feasibility',
-      render: (row) =>
-        row.feasibility.feasible ? (
-          <span className="niuu-text-xs niuu-text-text-muted">ready</span>
-        ) : (
-          <GateChips gates={row.feasibility.gates} />
-        ),
-    },
-  ];
+  function toggleId(id: string) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
 
   const isLoading = dispatcherQuery.isLoading || queueQuery.isLoading;
   const isError = dispatcherQuery.isError || queueQuery.isError;
@@ -387,59 +507,105 @@ export function DispatchView() {
 
   return (
     <TooltipProvider>
-      <div className="niuu-p-6">
-        {/* Rule summary card */}
-        {dispatcherState && (
-          <RuleCard
-            threshold={dispatcherState.threshold}
-            maxConcurrentRaids={dispatcherState.maxConcurrentRaids}
-            autoContinue={dispatcherState.autoContinue}
-          />
-        )}
+      <div className="niuu-flex niuu-h-full niuu-overflow-hidden">
+        {/* ── Left: queue ─────────────────────────────── */}
+        <div className="niuu-flex niuu-flex-col niuu-flex-1 niuu-overflow-hidden">
+          {/* Header */}
+          <div className="niuu-px-4 niuu-py-3 niuu-border-b niuu-border-border-subtle niuu-bg-bg-secondary">
+            <div className="niuu-text-xs niuu-uppercase niuu-tracking-wide niuu-text-text-muted niuu-mb-1">
+              Dispatch queue
+            </div>
+            <div className="niuu-flex niuu-items-baseline niuu-justify-between">
+              <h2 className="niuu-m-0 niuu-text-lg niuu-font-semibold niuu-text-text-primary">
+                {counts.all} raids · {counts.ready} ready
+              </h2>
+              <div className="niuu-flex niuu-gap-2">
+                {dispatcherState && (
+                  <>
+                    <span className="niuu-text-xs niuu-font-mono niuu-bg-bg-elevated niuu-px-2 niuu-py-1 niuu-rounded niuu-text-text-secondary">
+                      threshold{' '}
+                      <strong className="niuu-text-brand">{dispatcherState.threshold}%</strong>
+                    </span>
+                    <span className="niuu-text-xs niuu-font-mono niuu-bg-bg-elevated niuu-px-2 niuu-py-1 niuu-rounded niuu-text-text-secondary">
+                      concurrent <strong>{dispatcherState.maxConcurrentRaids}</strong>
+                    </span>
+                  </>
+                )}
+              </div>
+            </div>
+          </div>
 
-        {/* Controls */}
-        <div className="niuu-flex niuu-items-center niuu-justify-between niuu-mb-4 niuu-gap-4 niuu-flex-wrap">
-          <SegmentedFilter
-            value={statusFilter}
-            onChange={(v) => {
-              setStatusFilter(v);
-              setSelectedIds(new Set());
-            }}
-            counts={counts}
-          />
-          <input
-            type="search"
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            placeholder="Search raids…"
-            aria-label="Search raids"
-            className="niuu-rounded-md niuu-border niuu-border-border niuu-bg-bg-tertiary niuu-px-3 niuu-py-1.5 niuu-text-sm niuu-text-text-primary niuu-outline-none focus:niuu-border-brand"
-          />
+          {/* Controls */}
+          <div className="niuu-flex niuu-items-center niuu-gap-3 niuu-px-4 niuu-py-2 niuu-border-b niuu-border-border-subtle niuu-flex-wrap">
+            <SegmentedFilter
+              value={statusFilter}
+              onChange={(v) => {
+                setStatusFilter(v);
+                setSelectedIds(new Set());
+              }}
+              counts={counts}
+            />
+            <input
+              type="search"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="Search raids…"
+              aria-label="Search raids"
+              className="niuu-rounded-md niuu-border niuu-border-border niuu-bg-bg-tertiary niuu-px-3 niuu-py-1.5 niuu-text-xs niuu-text-text-primary niuu-outline-none focus:niuu-border-brand niuu-ml-auto"
+            />
+          </div>
+
+          {/* Grouped queue */}
+          <div className="niuu-flex-1 niuu-overflow-y-auto" role="list" aria-label="Dispatch queue">
+            {groupedBySaga.length === 0 ? (
+              <div className="niuu-py-12 niuu-text-center niuu-text-sm niuu-text-text-muted">
+                No raids match the current filter.
+              </div>
+            ) : (
+              groupedBySaga.map(([sagaId, group]) => (
+                <div key={sagaId} role="listitem">
+                  <SagaGroupHeader
+                    sagaName={group.sagaName}
+                    trackerId={group.trackerId}
+                    featureBranch={group.featureBranch}
+                  />
+                  {group.entries.map((entry) => (
+                    <RaidRow
+                      key={entry.raid.id}
+                      entry={entry}
+                      isSelected={selectedIds.has(entry.raid.id)}
+                      onToggle={() => toggleId(entry.raid.id)}
+                    />
+                  ))}
+                </div>
+              ))
+            )}
+          </div>
         </div>
 
-        {/* Table */}
-        <Table
-          columns={columns}
-          rows={rows}
-          selectedIds={selectedIds}
-          onSelectionChange={setSelectedIds}
-          aria-label="Dispatch queue"
-        />
-
-        {filtered.length === 0 && (
-          <div className="niuu-py-12 niuu-text-center niuu-text-sm niuu-text-text-muted">
-            No raids match the current filter.
-          </div>
-        )}
-
-        {/* Batch dispatch bar */}
-        <BatchDispatchBar
-          selectedCount={selectedIds.size}
-          canDispatch={allSelectedFeasible}
-          onDispatch={handleDispatch}
-          isDispatching={isDispatching}
-        />
+        {/* ── Right: rules panel ──────────────────────── */}
+        <div
+          className="niuu-border-l niuu-border-border-subtle niuu-overflow-y-auto niuu-bg-bg-primary"
+          style={{ width: 280, flexShrink: 0 }}
+          aria-label="Dispatch rules panel"
+        >
+          {dispatcherState ? (
+            <DispatchRulesPanel
+              threshold={dispatcherState.threshold}
+              maxConcurrentRaids={dispatcherState.maxConcurrentRaids}
+              autoContinue={dispatcherState.autoContinue}
+            />
+          ) : null}
+        </div>
       </div>
+
+      {/* Batch dispatch bar */}
+      <BatchDispatchBar
+        selectedCount={selectedIds.size}
+        canDispatch={allSelectedFeasible}
+        onDispatch={handleDispatch}
+        isDispatching={isDispatching}
+      />
     </TooltipProvider>
   );
 }

--- a/web-next/packages/plugin-tyr/src/ui/PlanGuidanceRail.test.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/PlanGuidanceRail.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { PlanGuidanceRail } from './PlanGuidanceRail';
+
+describe('PlanGuidanceRail', () => {
+  it('renders both guidance card titles', () => {
+    render(<PlanGuidanceRail />);
+    expect(screen.getByText('How Plan works')).toBeInTheDocument();
+    expect(screen.getByText('What a planning raid produces')).toBeInTheDocument();
+  });
+
+  it('renders numbered step indicators for the How Plan works card', () => {
+    render(<PlanGuidanceRail />);
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('4')).toBeInTheDocument();
+  });
+
+  it('renders the correct total number of list items', () => {
+    render(<PlanGuidanceRail />);
+    // 4 items in How Plan works + 5 items in What a planning raid produces
+    const items = screen.getAllByRole('listitem');
+    expect(items.length).toBe(9);
+  });
+
+  it('has the Plan guidance landmark label', () => {
+    render(<PlanGuidanceRail />);
+    expect(screen.getByRole('complementary', { name: 'Plan guidance' })).toBeInTheDocument();
+  });
+
+  it('renders bullet dots for the non-numbered card', () => {
+    render(<PlanGuidanceRail />);
+    const dots = screen.getAllByText('·');
+    expect(dots.length).toBe(5);
+  });
+});

--- a/web-next/packages/plugin-tyr/src/ui/PlanGuidanceRail.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/PlanGuidanceRail.tsx
@@ -1,0 +1,72 @@
+/**
+ * PlanGuidanceRail — right-side guidance panel for the Plan wizard.
+ * Shown on prompt, questions, and draft steps; hidden on raiding and approved.
+ */
+
+interface GuidanceCard {
+  title: string;
+  items: string[];
+  numbered?: boolean;
+}
+
+const HOW_PLAN_WORKS: GuidanceCard = {
+  title: 'How Plan works',
+  numbered: true,
+  items: [
+    'Describe your goal in plain language — the more detail, the better the plan.',
+    'Answer clarifying questions to help Tyr understand scope and constraints.',
+    'Ravens raid the plan: they decompose it into phases and work items.',
+    'Review the draft plan and approve or edit phases before committing.',
+  ],
+};
+
+const WHAT_A_PLANNING_RAID_PRODUCES: GuidanceCard = {
+  title: 'What a planning raid produces',
+  items: [
+    'Phased plan with clear phase names and goals',
+    'Acceptance criteria for each work item',
+    'File-level effort estimates',
+    'Dependency graph across phases',
+    'Risk and confidence assessment',
+  ],
+};
+
+function GuidanceCard({ card }: { card: GuidanceCard }) {
+  return (
+    <div className="niuu-rounded-lg niuu-border niuu-border-border niuu-bg-bg-secondary niuu-p-4">
+      <h3 className="niuu-m-0 niuu-mb-3 niuu-text-sm niuu-font-semibold niuu-text-text-primary">
+        {card.title}
+      </h3>
+      <ul className="niuu-list-none niuu-p-0 niuu-m-0 niuu-flex niuu-flex-col niuu-gap-2">
+        {card.items.map((item, i) => (
+          <li key={i} className="niuu-flex niuu-gap-2 niuu-text-xs niuu-text-text-secondary">
+            {card.numbered ? (
+              <span
+                className="niuu-inline-flex niuu-items-center niuu-justify-center niuu-w-4 niuu-h-4 niuu-rounded-full niuu-bg-brand niuu-text-bg-primary niuu-font-bold niuu-shrink-0"
+                style={{ fontSize: 9 }}
+              >
+                {i + 1}
+              </span>
+            ) : (
+              <span className="niuu-text-text-faint niuu-shrink-0">·</span>
+            )}
+            <span>{item}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export function PlanGuidanceRail() {
+  return (
+    <aside
+      className="niuu-flex niuu-flex-col niuu-gap-4 niuu-p-5"
+      style={{ width: 280, flexShrink: 0 }}
+      aria-label="Plan guidance"
+    >
+      <GuidanceCard card={HOW_PLAN_WORKS} />
+      <GuidanceCard card={WHAT_A_PLANNING_RAID_PRODUCES} />
+    </aside>
+  );
+}

--- a/web-next/packages/plugin-tyr/src/ui/PlanWizard.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/PlanWizard.tsx
@@ -7,74 +7,92 @@ import { PlanQuestions } from './PlanQuestions';
 import { PlanRaiding } from './PlanRaiding';
 import { PlanDraft } from './PlanDraft';
 import { PlanApproved } from './PlanApproved';
+import { PlanGuidanceRail } from './PlanGuidanceRail';
 
 /**
  * Plan wizard — five‐step flow for decomposing a human goal into a saga.
  *
  * States: prompt → questions → raiding → draft → approved
+ *
+ * Layout: 2-column on prompt/questions/draft (left: wizard content, right: guidance rail).
+ *         Full-width on raiding and approved (content fills the width).
  */
 export function PlanWizard() {
   const { state, submitPrompt, submitAnswers, approveDraft, editPhase, back, clearError } =
     usePlanWizard();
 
   function handleNewPlan() {
-    // Navigate back to /tyr to start fresh (the wizard unmounts and remounts)
+    // Navigate back to /tyr/plan to start fresh (the wizard unmounts and remounts)
     window.location.href = '/tyr/plan';
   }
 
+  const showGuidance = state.step === 'prompt' || state.step === 'questions' || state.step === 'draft';
+
   return (
-    <div className="niuu-p-6 niuu-max-w-2xl niuu-mx-auto">
-      <div className="niuu-flex niuu-items-center niuu-gap-3 niuu-mb-6">
-        <Rune glyph="ᛏ" size={24} />
-        <h1 className="niuu-text-base niuu-font-semibold niuu-text-text-secondary niuu-m-0">
-          New saga plan
-        </h1>
+    <div className="niuu-flex niuu-h-full niuu-overflow-hidden">
+      {/* ── Main wizard content ───────────────────────── */}
+      <div className="niuu-flex-1 niuu-overflow-y-auto">
+        <div className="niuu-p-6 niuu-max-w-2xl niuu-mx-auto">
+          <div className="niuu-flex niuu-items-center niuu-gap-3 niuu-mb-6">
+            <Rune glyph="ᛏ" size={24} />
+            <h1 className="niuu-text-base niuu-font-semibold niuu-text-text-secondary niuu-m-0">
+              New saga plan
+            </h1>
+          </div>
+
+          <StepDots steps={PLAN_STEPS} current={state.step} />
+
+          {state.step === 'prompt' && (
+            <PlanPrompt onSubmit={submitPrompt} loading={state.loading} error={state.error} />
+          )}
+
+          {state.step === 'questions' && (
+            <PlanQuestions
+              questions={state.questions}
+              initialAnswers={state.answers}
+              onSubmit={submitAnswers}
+              onBack={() => {
+                clearError();
+                back();
+              }}
+            />
+          )}
+
+          {state.step === 'raiding' && (
+            <PlanRaiding
+              error={state.error}
+              onBack={() => {
+                clearError();
+                back();
+              }}
+            />
+          )}
+
+          {state.step === 'draft' && state.structure && (
+            <PlanDraft
+              structure={state.structure}
+              loading={state.loading}
+              error={state.error}
+              onApprove={approveDraft}
+              onBack={() => {
+                clearError();
+                back();
+              }}
+              onEditPhase={editPhase}
+            />
+          )}
+
+          {state.step === 'approved' && state.saga && (
+            <PlanApproved saga={state.saga} onNewPlan={handleNewPlan} />
+          )}
+        </div>
       </div>
 
-      <StepDots steps={PLAN_STEPS} current={state.step} />
-
-      {state.step === 'prompt' && (
-        <PlanPrompt onSubmit={submitPrompt} loading={state.loading} error={state.error} />
-      )}
-
-      {state.step === 'questions' && (
-        <PlanQuestions
-          questions={state.questions}
-          initialAnswers={state.answers}
-          onSubmit={submitAnswers}
-          onBack={() => {
-            clearError();
-            back();
-          }}
-        />
-      )}
-
-      {state.step === 'raiding' && (
-        <PlanRaiding
-          error={state.error}
-          onBack={() => {
-            clearError();
-            back();
-          }}
-        />
-      )}
-
-      {state.step === 'draft' && state.structure && (
-        <PlanDraft
-          structure={state.structure}
-          loading={state.loading}
-          error={state.error}
-          onApprove={approveDraft}
-          onBack={() => {
-            clearError();
-            back();
-          }}
-          onEditPhase={editPhase}
-        />
-      )}
-
-      {state.step === 'approved' && state.saga && (
-        <PlanApproved saga={state.saga} onNewPlan={handleNewPlan} />
+      {/* ── Right guidance rail (hidden on raiding/approved) ── */}
+      {showGuidance && (
+        <div className="niuu-border-l niuu-border-border-subtle niuu-overflow-y-auto niuu-bg-bg-primary">
+          <PlanGuidanceRail />
+        </div>
       )}
     </div>
   );

--- a/web-next/packages/plugin-tyr/src/ui/RaidMeshCanvas.test.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/RaidMeshCanvas.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { RaidMeshCanvas } from './RaidMeshCanvas';
+import type { Saga, Phase, Raid } from '../domain/saga';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSaga(overrides: Partial<Saga> = {}): Saga {
+  return {
+    id: '00000000-0000-0000-0000-000000000001',
+    trackerId: 'NIU-1',
+    trackerType: 'linear',
+    slug: 'test-saga',
+    name: 'Test Saga',
+    repos: [],
+    featureBranch: 'feat/test',
+    status: 'active',
+    confidence: 80,
+    createdAt: '2026-01-01T00:00:00Z',
+    phaseSummary: { total: 1, completed: 0 },
+    ...overrides,
+  };
+}
+
+function makeRaid(overrides: Partial<Raid> = {}): Raid {
+  return {
+    id: '00000000-0000-0000-0000-000000000010',
+    phaseId: '00000000-0000-0000-0000-000000000100',
+    trackerId: 'NIU-R1',
+    name: 'Test Raid',
+    description: '',
+    acceptanceCriteria: [],
+    declaredFiles: [],
+    estimateHours: 4,
+    status: 'running',
+    confidence: 80,
+    sessionId: null,
+    reviewerSessionId: null,
+    reviewRound: 0,
+    branch: null,
+    chronicleSummary: null,
+    retryCount: 0,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makePhase(overrides: Partial<Phase> = {}): Phase {
+  return {
+    id: '00000000-0000-0000-0000-000000000100',
+    sagaId: '00000000-0000-0000-0000-000000000001',
+    trackerId: 'NIU-M1',
+    number: 1,
+    name: 'Phase 1',
+    status: 'active',
+    confidence: 80,
+    raids: [makeRaid()],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('RaidMeshCanvas', () => {
+  it('renders a canvas element with the default aria-label', () => {
+    render(<RaidMeshCanvas sagas={[]} phases={[]} />);
+    expect(screen.getByLabelText('Live raid mesh visualization')).toBeInTheDocument();
+  });
+
+  it('renders with a custom aria-label', () => {
+    render(<RaidMeshCanvas sagas={[]} phases={[]} aria-label="Custom mesh label" />);
+    expect(screen.getByLabelText('Custom mesh label')).toBeInTheDocument();
+  });
+
+  it('renders with an empty sagas list (no clusters)', () => {
+    render(<RaidMeshCanvas sagas={[]} phases={[]} />);
+    const canvas = screen.getByLabelText('Live raid mesh visualization');
+    expect(canvas.tagName).toBe('CANVAS');
+  });
+
+  it('renders without error when sagas and phases are provided', () => {
+    const saga = makeSaga();
+    const phase = makePhase();
+    render(<RaidMeshCanvas sagas={[saga]} phases={[[phase]]} />);
+    expect(screen.getByLabelText('Live raid mesh visualization')).toBeInTheDocument();
+  });
+
+  it('does not call onClickSaga when clicked without a hovered node', () => {
+    const onClickSaga = vi.fn();
+    render(<RaidMeshCanvas sagas={[]} phases={[]} onClickSaga={onClickSaga} />);
+    const canvas = screen.getByLabelText('Live raid mesh visualization');
+    fireEvent.click(canvas.parentElement!);
+    expect(onClickSaga).not.toHaveBeenCalled();
+  });
+
+  it('skips complete sagas when building clusters', () => {
+    const completeSaga = makeSaga({ status: 'complete' });
+    const activeSaga = makeSaga({ id: '00000000-0000-0000-0000-000000000002', status: 'active' });
+    const phase = makePhase({ sagaId: activeSaga.id });
+    // Should render without error — complete saga produces no clusters
+    render(
+      <RaidMeshCanvas
+        sagas={[completeSaga, activeSaga]}
+        phases={[[], [phase]]}
+      />,
+    );
+    expect(screen.getByLabelText('Live raid mesh visualization')).toBeInTheDocument();
+  });
+
+  it('only includes running/review/queued raids in clusters', () => {
+    const saga = makeSaga();
+    const phase = makePhase({
+      raids: [
+        makeRaid({ id: 'r1', status: 'pending' }),
+        makeRaid({ id: 'r2', status: 'merged' }),
+        makeRaid({ id: 'r3', status: 'running' }),
+      ],
+    });
+    render(<RaidMeshCanvas sagas={[saga]} phases={[[phase]]} />);
+    expect(screen.getByLabelText('Live raid mesh visualization')).toBeInTheDocument();
+  });
+});

--- a/web-next/packages/plugin-tyr/src/ui/RaidMeshCanvas.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/RaidMeshCanvas.tsx
@@ -1,0 +1,388 @@
+import { useEffect, useRef, useState } from 'react';
+import type { Saga, Phase } from '../domain/saga';
+
+// ---------------------------------------------------------------------------
+// Constants (no magic numbers in business logic — these are visual tunables)
+// ---------------------------------------------------------------------------
+
+const ORBIT_RADIUS = 46;
+const CLUSTER_RADIUS = 36;
+const HALO_EXTRA = 28;
+const HALO_OPACITY = 0.12;
+const EDGE_STROKE = 'rgba(147,197,253,0.18)';
+const PULSE_FILL_BASE = 'rgba(186,230,253,';
+const RAVEN_FILL = 'rgba(125,211,252,0.85)';
+const RAVEN_FILL_HOVER = '#bae6fd';
+const RAVEN_RADIUS = 3.2;
+const RAVEN_RADIUS_HOVER = 5;
+const HOVER_RING_RADIUS = 9;
+const HOVER_RING_STROKE = 'rgba(186,230,253,0.4)';
+const PULSE_RADIUS = 2.5;
+const PULSE_MAX = 18;
+const PULSE_SPAWN_MS = 260;
+const PULSE_SPEED_MIN = 0.010;
+const PULSE_SPEED_RANGE = 0.012;
+const PULSE_ALPHA_FACTOR = 1.4;
+const HIT_RADIUS_RAVEN = 14;
+const LABEL_FONT = '500 10px JetBrains Mono, monospace';
+const LABEL_COLOR_PRIMARY = '#e4e4e7';
+const LABEL_COLOR_MUTED = '#71717a';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface RaidCluster {
+  id: string;
+  sagaId: string;
+  raidId: string;
+  raidName: string;
+  phaseName: string;
+  status: string;
+  confidence: number;
+  ravens: string[];
+}
+
+interface ClusterNode {
+  kind: 'cluster';
+  cluster: RaidCluster;
+  x: number;
+  y: number;
+  r: number;
+}
+
+interface RavenNode {
+  kind: 'raven';
+  cluster: RaidCluster;
+  persona: string;
+  x: number;
+  y: number;
+  r: number;
+}
+
+type MeshNode = ClusterNode | RavenNode;
+type Edge = [RavenNode, RavenNode, RaidCluster];
+
+interface Pulse {
+  edge: Edge;
+  t: number;
+  speed: number;
+}
+
+interface HoverState {
+  node: MeshNode;
+  x: number;
+  y: number;
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface RaidMeshCanvasProps {
+  sagas: Saga[];
+  phases: Phase[][];
+  onClickSaga?: (sagaId: string) => void;
+  'aria-label'?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function RaidMeshCanvas({
+  sagas,
+  phases,
+  onClickSaga,
+  'aria-label': ariaLabel = 'Live raid mesh visualization',
+}: RaidMeshCanvasProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const nodesRef = useRef<MeshNode[]>([]);
+  const hoverRef = useRef<HoverState | null>(null);
+  const [hover, setHover] = useState<HoverState | null>(null);
+
+  // Keep hoverRef in sync with state (used inside animation loop)
+  useEffect(() => {
+    hoverRef.current = hover;
+  }, [hover]);
+
+  // Build raid clusters from sagas + phases
+  const clusters: RaidCluster[] = [];
+  sagas
+    .filter((s) => s.status !== 'complete')
+    .forEach((s, i) => {
+      const sagaPhases = phases[i] ?? [];
+      sagaPhases.forEach((ph) => {
+        ph.raids
+          .filter((r) => r.status === 'running' || r.status === 'review' || r.status === 'queued')
+          .forEach((r) => {
+            clusters.push({
+              id: `${s.id}/${r.id}`,
+              sagaId: s.id,
+              raidId: r.id,
+              raidName: r.name,
+              phaseName: ph.name,
+              status: r.status,
+              confidence: r.confidence,
+              ravens: ['executor', 'reviewer', 'indexer'].slice(
+                0,
+                r.status === 'running' ? 3 : 2,
+              ),
+            });
+          });
+      });
+    });
+  const visibleClusters = clusters.slice(0, 6);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    let rafId: number;
+    let pulses: Pulse[] = [];
+    let nodes: MeshNode[] = [];
+    let edges: Edge[] = [];
+
+    const ro = new ResizeObserver(() => setup());
+    ro.observe(canvas);
+
+    function setup() {
+      if (!canvas) return;
+      const rect = canvas.getBoundingClientRect();
+      const dpr = devicePixelRatio;
+      canvas.width = rect.width * dpr;
+      canvas.height = rect.height * dpr;
+      const W = rect.width;
+      const H = rect.height;
+
+      nodes = [];
+      const count = visibleClusters.length;
+      if (count === 0) {
+        nodesRef.current = nodes;
+        return;
+      }
+
+      const cols = Math.min(count, 3);
+      const rows = Math.ceil(count / cols);
+
+      visibleClusters.forEach((cluster, i) => {
+        const col = i % cols;
+        const row = Math.floor(i / cols);
+        const cx = (W * (col + 1)) / (cols + 1);
+        const cy = (H * (row + 1)) / (rows + 1);
+
+        const clusterNode: ClusterNode = { kind: 'cluster', cluster, x: cx, y: cy, r: CLUSTER_RADIUS };
+        nodes.push(clusterNode);
+
+        cluster.ravens.forEach((persona, k) => {
+          const angle = (k / cluster.ravens.length) * Math.PI * 2 - Math.PI / 2;
+          const ravenNode: RavenNode = {
+            kind: 'raven',
+            cluster,
+            persona,
+            x: cx + Math.cos(angle) * ORBIT_RADIUS,
+            y: cy + Math.sin(angle) * ORBIT_RADIUS,
+            r: 10,
+          };
+          nodes.push(ravenNode);
+        });
+      });
+
+      // Edges: all raven pairs within same cluster
+      edges = [];
+      visibleClusters.forEach((cluster) => {
+        const mine = nodes.filter(
+          (n): n is RavenNode => n.kind === 'raven' && n.cluster.id === cluster.id,
+        );
+        for (let a = 0; a < mine.length; a++) {
+          for (let b = a + 1; b < mine.length; b++) {
+            edges.push([mine[a]!, mine[b]!, cluster]);
+          }
+        }
+      });
+
+      nodesRef.current = nodes;
+    }
+
+    setup();
+
+    // Pulse spawner
+    const spawnInterval = setInterval(() => {
+      if (edges.length > 0 && pulses.length < PULSE_MAX) {
+        const edge = edges[Math.floor(Math.random() * edges.length)]!;
+        pulses.push({ edge, t: 0, speed: PULSE_SPEED_MIN + Math.random() * PULSE_SPEED_RANGE });
+      }
+    }, PULSE_SPAWN_MS);
+
+    const ctx = canvas.getContext('2d')!;
+
+    function draw() {
+      if (!canvas) return;
+      const rect = canvas.getBoundingClientRect();
+      const W = rect.width;
+      const H = rect.height;
+      const dpr = devicePixelRatio;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      ctx.clearRect(0, 0, W, H);
+
+      const clusterNodes = nodes.filter((n): n is ClusterNode => n.kind === 'cluster');
+      const ravenNodes = nodes.filter((n): n is RavenNode => n.kind === 'raven');
+      const hoverNow = hoverRef.current;
+
+      // Cluster halos
+      clusterNodes.forEach((n) => {
+        const grad = ctx.createRadialGradient(n.x, n.y, 0, n.x, n.y, n.r + HALO_EXTRA);
+        grad.addColorStop(0, `rgba(125,211,252,${HALO_OPACITY})`);
+        grad.addColorStop(1, 'rgba(125,211,252,0)');
+        ctx.fillStyle = grad;
+        ctx.beginPath();
+        ctx.arc(n.x, n.y, n.r + HALO_EXTRA, 0, Math.PI * 2);
+        ctx.fill();
+      });
+
+      // Edges
+      ctx.strokeStyle = EDGE_STROKE;
+      ctx.lineWidth = 1;
+      edges.forEach(([a, b]) => {
+        ctx.beginPath();
+        ctx.moveTo(a.x, a.y);
+        ctx.lineTo(b.x, b.y);
+        ctx.stroke();
+      });
+
+      // Advance + draw pulses
+      pulses.forEach((p) => {
+        p.t += p.speed;
+      });
+      pulses = pulses.filter((p) => p.t < 1);
+      pulses.forEach((p) => {
+        const [a, b] = p.edge;
+        const x = a.x + (b.x - a.x) * p.t;
+        const y = a.y + (b.y - a.y) * p.t;
+        const alpha = Math.max(0, 1 - Math.abs(p.t - 0.5) * PULSE_ALPHA_FACTOR);
+        ctx.fillStyle = `${PULSE_FILL_BASE}${alpha})`;
+        ctx.beginPath();
+        ctx.arc(x, y, PULSE_RADIUS, 0, Math.PI * 2);
+        ctx.fill();
+      });
+
+      // Raven nodes
+      ravenNodes.forEach((n) => {
+        const isHover = hoverNow?.node === n;
+        ctx.fillStyle = isHover ? RAVEN_FILL_HOVER : RAVEN_FILL;
+        ctx.beginPath();
+        ctx.arc(n.x, n.y, isHover ? RAVEN_RADIUS_HOVER : RAVEN_RADIUS, 0, Math.PI * 2);
+        ctx.fill();
+        if (isHover) {
+          ctx.strokeStyle = HOVER_RING_STROKE;
+          ctx.lineWidth = 1;
+          ctx.beginPath();
+          ctx.arc(n.x, n.y, HOVER_RING_RADIUS, 0, Math.PI * 2);
+          ctx.stroke();
+        }
+      });
+
+      // Cluster labels
+      ctx.font = LABEL_FONT;
+      ctx.textAlign = 'center';
+      clusterNodes.forEach((n) => {
+        ctx.fillStyle = LABEL_COLOR_PRIMARY;
+        ctx.fillText(n.cluster.raidName.slice(0, 12), n.x, n.y + 4);
+        ctx.fillStyle = LABEL_COLOR_MUTED;
+        ctx.fillText(n.cluster.phaseName.toLowerCase().slice(0, 12), n.x, n.y + 18);
+      });
+
+      rafId = requestAnimationFrame(draw);
+    }
+
+    draw();
+
+    return () => {
+      cancelAnimationFrame(rafId);
+      clearInterval(spawnInterval);
+      ro.disconnect();
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visibleClusters.map((c) => c.id).join(',')]);
+
+  function handleMouseMove(e: React.MouseEvent<HTMLCanvasElement>) {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    const mx = e.clientX - rect.left;
+    const my = e.clientY - rect.top;
+    const hit = nodesRef.current.find((n) => {
+      const hitR = n.kind === 'cluster' ? n.r : HIT_RADIUS_RAVEN;
+      return Math.hypot(n.x - mx, n.y - my) < hitR;
+    });
+    setHover(hit ? { node: hit, x: mx, y: my } : null);
+  }
+
+  function handleMouseLeave() {
+    setHover(null);
+  }
+
+  function handleClick() {
+    if (!hover) return;
+    onClickSaga?.(hover.node.cluster.sagaId);
+  }
+
+  return (
+    <div
+      style={{ position: 'relative', width: '100%', height: '100%', cursor: hover ? 'pointer' : 'default' }}
+      onMouseMove={handleMouseMove}
+      onMouseLeave={handleMouseLeave}
+      onClick={handleClick}
+    >
+      <canvas
+        ref={canvasRef}
+        aria-label={ariaLabel}
+        style={{ width: '100%', height: '100%', background: 'transparent', display: 'block' }}
+      />
+      {hover && hover.node.kind === 'raven' && (
+        <div
+          style={{
+            position: 'absolute',
+            left: hover.x + 12,
+            top: hover.y + 12,
+            background: 'var(--color-bg-elevated)',
+            border: '1px solid var(--color-border)',
+            borderRadius: 'var(--radius-sm)',
+            padding: '4px 8px',
+            pointerEvents: 'none',
+            zIndex: 10,
+          }}
+        >
+          <div style={{ fontFamily: 'var(--font-mono)', fontSize: 11, fontWeight: 500, color: 'var(--color-text-primary)' }}>
+            {hover.node.persona}
+          </div>
+          <div style={{ fontFamily: 'var(--font-mono)', fontSize: 10, marginTop: 2, color: 'var(--color-text-muted)' }}>
+            {hover.node.cluster.raidName} · {hover.node.cluster.phaseName}
+          </div>
+        </div>
+      )}
+      {hover && hover.node.kind === 'cluster' && (
+        <div
+          style={{
+            position: 'absolute',
+            left: hover.x + 12,
+            top: hover.y + 12,
+            background: 'var(--color-bg-elevated)',
+            border: '1px solid var(--color-border)',
+            borderRadius: 'var(--radius-sm)',
+            padding: '4px 8px',
+            pointerEvents: 'none',
+            zIndex: 10,
+          }}
+        >
+          <div style={{ fontSize: 12, fontWeight: 500, color: 'var(--color-text-primary)' }}>
+            {hover.node.cluster.raidName}
+          </div>
+          <div style={{ fontFamily: 'var(--font-mono)', fontSize: 10, marginTop: 2, color: 'var(--color-text-muted)' }}>
+            {hover.node.cluster.phaseName} · conf {hover.node.cluster.confidence}%
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web-next/packages/plugin-tyr/src/ui/RaidMeshCanvas.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/RaidMeshCanvas.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { Saga, Phase } from '../domain/saga';
 
 // ---------------------------------------------------------------------------
@@ -25,8 +25,9 @@ const PULSE_SPEED_RANGE = 0.012;
 const PULSE_ALPHA_FACTOR = 1.4;
 const HIT_RADIUS_RAVEN = 14;
 const LABEL_FONT = '500 10px JetBrains Mono, monospace';
-const LABEL_COLOR_PRIMARY = '#e4e4e7';
-const LABEL_COLOR_MUTED = '#71717a';
+// Fallback colors used until CSS custom properties are resolved in setup()
+const LABEL_COLOR_PRIMARY_FALLBACK = '#e4e4e7';
+const LABEL_COLOR_MUTED_FALLBACK = '#71717a';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -99,6 +100,10 @@ export function RaidMeshCanvas({
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const nodesRef = useRef<MeshNode[]>([]);
   const hoverRef = useRef<HoverState | null>(null);
+  const colorsRef = useRef({
+    labelPrimary: LABEL_COLOR_PRIMARY_FALLBACK,
+    labelMuted: LABEL_COLOR_MUTED_FALLBACK,
+  });
   const [hover, setHover] = useState<HoverState | null>(null);
 
   // Keep hoverRef in sync with state (used inside animation loop)
@@ -106,33 +111,37 @@ export function RaidMeshCanvas({
     hoverRef.current = hover;
   }, [hover]);
 
-  // Build raid clusters from sagas + phases
-  const clusters: RaidCluster[] = [];
-  sagas
-    .filter((s) => s.status !== 'complete')
-    .forEach((s, i) => {
-      const sagaPhases = phases[i] ?? [];
-      sagaPhases.forEach((ph) => {
-        ph.raids
-          .filter((r) => r.status === 'running' || r.status === 'review' || r.status === 'queued')
-          .forEach((r) => {
-            clusters.push({
-              id: `${s.id}/${r.id}`,
-              sagaId: s.id,
-              raidId: r.id,
-              raidName: r.name,
-              phaseName: ph.name,
-              status: r.status,
-              confidence: r.confidence,
-              ravens: ['executor', 'reviewer', 'indexer'].slice(
-                0,
-                r.status === 'running' ? 3 : 2,
-              ),
+  // Build raid clusters from sagas + phases — memoized to avoid per-render churn
+  const clusters = useMemo<RaidCluster[]>(() => {
+    const result: RaidCluster[] = [];
+    sagas
+      .filter((s) => s.status !== 'complete')
+      .forEach((s, i) => {
+        const sagaPhases = phases[i] ?? [];
+        sagaPhases.forEach((ph) => {
+          ph.raids
+            .filter((r) => r.status === 'running' || r.status === 'review' || r.status === 'queued')
+            .forEach((r) => {
+              result.push({
+                id: `${s.id}/${r.id}`,
+                sagaId: s.id,
+                raidId: r.id,
+                raidName: r.name,
+                phaseName: ph.name,
+                status: r.status,
+                confidence: r.confidence,
+                ravens: ['executor', 'reviewer', 'indexer'].slice(
+                  0,
+                  r.status === 'running' ? 3 : 2,
+                ),
+              });
             });
-          });
+        });
       });
-    });
-  const visibleClusters = clusters.slice(0, 6);
+    return result;
+  }, [sagas, phases]);
+
+  const visibleClusters = useMemo(() => clusters.slice(0, 6), [clusters]);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -154,6 +163,15 @@ export function RaidMeshCanvas({
       canvas.height = rect.height * dpr;
       const W = rect.width;
       const H = rect.height;
+
+      // Resolve colors from CSS custom properties so they respond to theme changes
+      const style = getComputedStyle(document.documentElement);
+      colorsRef.current = {
+        labelPrimary:
+          style.getPropertyValue('--color-text-primary').trim() || LABEL_COLOR_PRIMARY_FALLBACK,
+        labelMuted:
+          style.getPropertyValue('--color-text-muted').trim() || LABEL_COLOR_MUTED_FALLBACK,
+      };
 
       nodes = [];
       const count = visibleClusters.length;
@@ -286,9 +304,9 @@ export function RaidMeshCanvas({
       ctx.font = LABEL_FONT;
       ctx.textAlign = 'center';
       clusterNodes.forEach((n) => {
-        ctx.fillStyle = LABEL_COLOR_PRIMARY;
+        ctx.fillStyle = colorsRef.current.labelPrimary;
         ctx.fillText(n.cluster.raidName.slice(0, 12), n.x, n.y + 4);
-        ctx.fillStyle = LABEL_COLOR_MUTED;
+        ctx.fillStyle = colorsRef.current.labelMuted;
         ctx.fillText(n.cluster.phaseName.toLowerCase().slice(0, 12), n.x, n.y + 18);
       });
 
@@ -339,50 +357,47 @@ export function RaidMeshCanvas({
         aria-label={ariaLabel}
         style={{ width: '100%', height: '100%', background: 'transparent', display: 'block' }}
       />
-      {hover && hover.node.kind === 'raven' && (
-        <div
-          style={{
-            position: 'absolute',
-            left: hover.x + 12,
-            top: hover.y + 12,
-            background: 'var(--color-bg-elevated)',
-            border: '1px solid var(--color-border)',
-            borderRadius: 'var(--radius-sm)',
-            padding: '4px 8px',
-            pointerEvents: 'none',
-            zIndex: 10,
-          }}
-        >
-          <div style={{ fontFamily: 'var(--font-mono)', fontSize: 11, fontWeight: 500, color: 'var(--color-text-primary)' }}>
+      {hover?.node.kind === 'raven' && (
+        <MeshTooltip x={hover.x} y={hover.y}>
+          <div className="niuu-font-mono niuu-text-xs niuu-font-medium niuu-text-text-primary">
             {hover.node.persona}
           </div>
-          <div style={{ fontFamily: 'var(--font-mono)', fontSize: 10, marginTop: 2, color: 'var(--color-text-muted)' }}>
+          <div className="niuu-font-mono niuu-text-xs niuu-mt-0.5 niuu-text-text-muted">
             {hover.node.cluster.raidName} · {hover.node.cluster.phaseName}
           </div>
-        </div>
+        </MeshTooltip>
       )}
-      {hover && hover.node.kind === 'cluster' && (
-        <div
-          style={{
-            position: 'absolute',
-            left: hover.x + 12,
-            top: hover.y + 12,
-            background: 'var(--color-bg-elevated)',
-            border: '1px solid var(--color-border)',
-            borderRadius: 'var(--radius-sm)',
-            padding: '4px 8px',
-            pointerEvents: 'none',
-            zIndex: 10,
-          }}
-        >
-          <div style={{ fontSize: 12, fontWeight: 500, color: 'var(--color-text-primary)' }}>
+      {hover?.node.kind === 'cluster' && (
+        <MeshTooltip x={hover.x} y={hover.y}>
+          <div className="niuu-text-xs niuu-font-medium niuu-text-text-primary">
             {hover.node.cluster.raidName}
           </div>
-          <div style={{ fontFamily: 'var(--font-mono)', fontSize: 10, marginTop: 2, color: 'var(--color-text-muted)' }}>
+          <div className="niuu-font-mono niuu-text-xs niuu-mt-0.5 niuu-text-text-muted">
             {hover.node.cluster.phaseName} · conf {hover.node.cluster.confidence}%
           </div>
-        </div>
+        </MeshTooltip>
       )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// MeshTooltip — shared tooltip shell; dynamic position stays inline
+// ---------------------------------------------------------------------------
+
+interface MeshTooltipProps {
+  x: number;
+  y: number;
+  children: React.ReactNode;
+}
+
+function MeshTooltip({ x, y, children }: MeshTooltipProps) {
+  return (
+    <div
+      className="niuu-absolute niuu-bg-bg-elevated niuu-border niuu-border-border niuu-rounded niuu-px-2 niuu-py-1 niuu-pointer-events-none niuu-z-10"
+      style={{ left: x + 12, top: y + 12 }}
+    >
+      {children}
     </div>
   );
 }

--- a/web-next/packages/plugin-tyr/src/ui/SagaDetailPage.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/SagaDetailPage.tsx
@@ -117,9 +117,11 @@ function RaidPanel({ raid, onClose, onOpenSession }: RaidPanelProps) {
 
 interface SagaDetailPageProps {
   sagaId: string;
+  /** Hide the "← Sagas" back button (used when embedded in a split-panel). */
+  hideBackButton?: boolean;
 }
 
-export function SagaDetailPage({ sagaId }: SagaDetailPageProps) {
+export function SagaDetailPage({ sagaId, hideBackButton = false }: SagaDetailPageProps) {
   const navigate = useNavigate();
   const [expandedRaidId, setExpandedRaidId] = useState<string | null>(null);
 
@@ -158,14 +160,16 @@ export function SagaDetailPage({ sagaId }: SagaDetailPageProps) {
   return (
     <div className="niuu-p-6 niuu-space-y-6">
       {/* Back navigation */}
-      <button
-        type="button"
-        onClick={() => void navigate({ to: '/tyr/sagas' })}
-        className="niuu-text-sm niuu-text-text-secondary hover:niuu-text-text-primary niuu-flex niuu-items-center niuu-gap-1"
-        aria-label="Back to sagas"
-      >
-        ← Sagas
-      </button>
+      {!hideBackButton && (
+        <button
+          type="button"
+          onClick={() => void navigate({ to: '/tyr/sagas' })}
+          className="niuu-text-sm niuu-text-text-secondary hover:niuu-text-text-primary niuu-flex niuu-items-center niuu-gap-1"
+          aria-label="Back to sagas"
+        >
+          ← Sagas
+        </button>
+      )}
 
       {/* Saga header */}
       <header className="niuu-space-y-3">

--- a/web-next/packages/plugin-tyr/src/ui/SagasPage.test.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/SagasPage.test.tsx
@@ -12,6 +12,7 @@ import type { Saga } from '../domain/saga';
 const mockNavigate = vi.fn();
 vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => mockNavigate,
+  useParams: () => ({}),
 }));
 
 // ---------------------------------------------------------------------------
@@ -53,7 +54,7 @@ function makeSaga(overrides: Partial<Saga> = {}): Saga {
 describe('SagasPage', () => {
   it('renders the sagas heading', async () => {
     render(<SagasPage />, { wrapper: wrap({ tyr: createMockTyrService() }) });
-    await waitFor(() => expect(screen.getByText(/Tyr · Sagas/)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('Sagas')).toBeInTheDocument());
   });
 
   it('renders the Tyr rune', async () => {

--- a/web-next/packages/plugin-tyr/src/ui/SagasPage.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/SagasPage.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { useNavigate } from '@tanstack/react-router';
+import { useState, useEffect } from 'react';
+import { useNavigate, useParams } from '@tanstack/react-router';
 import {
   StatusBadge,
   ConfidenceBadge,
@@ -10,8 +10,35 @@ import {
   Rune,
 } from '@niuulabs/ui';
 import type { SagaStatus } from '../domain/saga';
+import type { Saga } from '../domain/saga';
 import { useSagas } from './useSagas';
 import { phaseStatusToCell } from './mappers';
+import { SagaDetailPage } from './SagaDetailPage';
+
+// ---------------------------------------------------------------------------
+// Deterministic saga glyph (hash saga trackerId → Elder Futhark rune)
+// ---------------------------------------------------------------------------
+
+const SAGA_GLYPHS = ['ᚠ', 'ᚱ', 'ᚲ', 'ᚷ', 'ᚢ', 'ᛁ', 'ᛃ', 'ᛉ', 'ᛒ', 'ᛖ', 'ᛗ', 'ᛜ', 'ᛟ', 'ᛞ'];
+
+function sagaGlyph(id: string): string {
+  let h = 0;
+  for (const c of id) h = ((h * 31 + c.charCodeAt(0)) >>> 0);
+  return SAGA_GLYPHS[h % SAGA_GLYPHS.length]!;
+}
+
+function timeAgo(isoDate: string): string {
+  const diff = Date.now() - new Date(isoDate).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+// ---------------------------------------------------------------------------
+// Filter types
+// ---------------------------------------------------------------------------
 
 type StatusFilter = SagaStatus | 'all';
 
@@ -22,11 +49,111 @@ const STATUS_TABS: { label: string; value: StatusFilter }[] = [
   { label: 'Failed', value: 'failed' },
 ];
 
+// ---------------------------------------------------------------------------
+// SagaListRow
+// ---------------------------------------------------------------------------
+
+interface SagaListRowProps {
+  saga: Saga;
+  isSelected: boolean;
+  onClick: () => void;
+}
+
+function SagaListRow({ saga, isSelected, onClick }: SagaListRowProps) {
+  const totalRaids = saga.phaseSummary.total;
+  const mergedRaids = saga.phaseSummary.completed;
+
+  const statusToRaidCellStatus = (s: SagaStatus) => {
+    if (s === 'active') return 'run' as const;
+    if (s === 'complete') return 'ok' as const;
+    return 'crit' as const;
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      data-selected={isSelected || undefined}
+      className={[
+        'niuu-w-full niuu-text-left niuu-p-3 niuu-border-b niuu-border-border-subtle',
+        'niuu-cursor-pointer niuu-transition-colors niuu-flex niuu-flex-col niuu-gap-2',
+        isSelected
+          ? 'niuu-bg-bg-tertiary niuu-border-l-2 niuu-border-l-brand'
+          : 'niuu-bg-transparent hover:niuu-bg-bg-secondary',
+      ].join(' ')}
+      aria-label={`View saga ${saga.name}`}
+      aria-pressed={isSelected}
+    >
+      {/* Glyph + name row */}
+      <div className="niuu-flex niuu-items-center niuu-gap-2">
+        <span
+          className="niuu-font-mono niuu-text-base niuu-text-brand niuu-shrink-0"
+          aria-hidden="true"
+          title={saga.trackerId}
+        >
+          {sagaGlyph(saga.trackerId)}
+        </span>
+        <span className="niuu-font-semibold niuu-text-sm niuu-text-text-primary niuu-truncate">
+          {saga.name}
+        </span>
+      </div>
+
+      {/* Meta row */}
+      <div className="niuu-flex niuu-items-center niuu-gap-2 niuu-flex-wrap">
+        <span className="niuu-text-xs niuu-font-mono niuu-text-text-muted niuu-bg-bg-elevated niuu-px-1.5 niuu-py-0.5 niuu-rounded">
+          {saga.trackerId}
+        </span>
+        <StatusBadge status={saga.status} />
+        <ConfidenceBadge value={saga.confidence / 100} />
+        {saga.repos[0] && (
+          <span className="niuu-text-xs niuu-text-text-muted niuu-truncate niuu-max-w-[120px]">
+            {saga.repos[0]}
+          </span>
+        )}
+        <span className="niuu-text-xs niuu-text-text-faint niuu-font-mono niuu-ml-auto">
+          {timeAgo(saga.createdAt)}
+        </span>
+      </div>
+
+      {/* Pipe */}
+      <Pipe
+        cells={Array.from({ length: saga.phaseSummary.total }, (_, i) => ({
+          status:
+            i < saga.phaseSummary.completed
+              ? phaseStatusToCell('complete')
+              : statusToRaidCellStatus(saga.status),
+          label: `Phase ${i + 1}`,
+        }))}
+      />
+
+      {/* Counts */}
+      <div className="niuu-text-right niuu-font-mono niuu-text-xs niuu-text-text-muted">
+        {mergedRaids}/{totalRaids} raids
+      </div>
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SagasPage
+// ---------------------------------------------------------------------------
+
 export function SagasPage() {
   const navigate = useNavigate();
+  const params = useParams({ strict: false }) as { sagaId?: string };
   const { data: sagas, isLoading, isError, error } = useSagas();
   const [filter, setFilter] = useState<StatusFilter>('all');
   const [search, setSearch] = useState('');
+  const [selectedSagaId, setSelectedSagaId] = useState<string | null>(
+    params.sagaId ?? null,
+  );
+
+  // Auto-select first active saga when none selected
+  useEffect(() => {
+    if (!selectedSagaId && sagas && sagas.length > 0) {
+      setSelectedSagaId(sagas[0]!.id);
+    }
+  }, [sagas, selectedSagaId]);
 
   if (isLoading) return <LoadingState label="Loading sagas…" />;
   if (isError)
@@ -49,106 +176,125 @@ export function SagasPage() {
     return matchesStatus && matchesSearch;
   });
 
+  function handleSelectSaga(saga: Saga) {
+    setSelectedSagaId(saga.id);
+    // Update URL for deep-linking without full navigation
+    void navigate({ to: '/tyr/sagas/$sagaId', params: { sagaId: saga.id } });
+  }
+
   return (
-    <div className="niuu-p-6 niuu-space-y-6">
-      <header className="niuu-flex niuu-items-center niuu-gap-3">
-        <Rune glyph="ᛏ" size={28} />
-        <h2 className="niuu-m-0 niuu-text-xl niuu-font-semibold niuu-text-text-primary">
-          Tyr · Sagas
-        </h2>
-      </header>
+    <div className="niuu-flex niuu-h-full niuu-overflow-hidden">
+      {/* ── Left list panel ─────────────────────────────── */}
+      <div
+        className="niuu-flex niuu-flex-col niuu-border-r niuu-border-border-subtle niuu-overflow-hidden"
+        style={{ width: 420, flexShrink: 0 }}
+        aria-label="Saga list"
+      >
+        {/* Header */}
+        <div className="niuu-flex niuu-items-center niuu-gap-3 niuu-px-4 niuu-py-3 niuu-border-b niuu-border-border-subtle niuu-bg-bg-secondary">
+          <Rune glyph="ᛏ" size={22} />
+          <h2 className="niuu-m-0 niuu-text-sm niuu-font-semibold niuu-text-text-primary niuu-flex-1">
+            Sagas
+          </h2>
+          <button
+            type="button"
+            className="niuu-px-2.5 niuu-py-1 niuu-text-xs niuu-border niuu-border-border-subtle niuu-rounded niuu-text-text-secondary hover:niuu-text-text-primary niuu-bg-transparent niuu-transition-colors"
+            onClick={() => {
+              const data = JSON.stringify(allSagas, null, 2);
+              const blob = new Blob([data], { type: 'application/json' });
+              const a = document.createElement('a');
+              a.href = URL.createObjectURL(blob);
+              a.download = 'sagas.json';
+              a.click();
+              setTimeout(() => URL.revokeObjectURL(a.href), 1000);
+            }}
+            aria-label="Export sagas as JSON"
+          >
+            Export
+          </button>
+          <button
+            type="button"
+            className="niuu-px-2.5 niuu-py-1 niuu-text-xs niuu-bg-brand niuu-text-bg-primary niuu-rounded niuu-font-medium"
+            onClick={() => void navigate({ to: '/tyr/plan' as never })}
+            aria-label="Create new saga"
+          >
+            + New Saga
+          </button>
+        </div>
 
-      {/* Search + status subnav */}
-      <div className="niuu-flex niuu-items-center niuu-gap-4 niuu-flex-wrap">
-        <input
-          type="search"
-          placeholder="Search sagas…"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          aria-label="Search sagas"
-          className="niuu-px-3 niuu-py-1.5 niuu-rounded-md niuu-bg-bg-secondary niuu-border niuu-border-border niuu-text-sm niuu-text-text-primary niuu-placeholder-text-muted niuu-outline-none"
-        />
+        {/* Search + status filter */}
+        <div className="niuu-flex niuu-flex-col niuu-gap-2 niuu-px-3 niuu-py-2 niuu-border-b niuu-border-border-subtle">
+          <input
+            type="search"
+            placeholder="Search sagas…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            aria-label="Search sagas"
+            className="niuu-px-3 niuu-py-1.5 niuu-rounded-md niuu-bg-bg-secondary niuu-border niuu-border-border niuu-text-xs niuu-text-text-primary niuu-placeholder-text-muted niuu-outline-none niuu-w-full"
+          />
+          <nav className="niuu-flex niuu-gap-1" role="tablist" aria-label="Filter sagas by status">
+            {STATUS_TABS.map((tab) => (
+              <button
+                key={tab.value}
+                type="button"
+                role="tab"
+                aria-selected={filter === tab.value}
+                onClick={() => setFilter(tab.value)}
+                className={[
+                  'niuu-px-2.5 niuu-py-1 niuu-rounded niuu-text-xs niuu-transition-colors',
+                  filter === tab.value
+                    ? 'niuu-bg-brand niuu-text-bg-primary niuu-font-medium'
+                    : 'niuu-text-text-secondary hover:niuu-text-text-primary',
+                ].join(' ')}
+              >
+                {tab.label}
+                {tab.value !== 'all' && (
+                  <span className="niuu-ml-1 niuu-opacity-60">
+                    ({counts[tab.value as SagaStatus]})
+                  </span>
+                )}
+              </button>
+            ))}
+          </nav>
+        </div>
 
-        <nav className="niuu-flex niuu-gap-1" role="tablist" aria-label="Filter sagas by status">
-          {STATUS_TABS.map((tab) => (
-            <button
-              key={tab.value}
-              type="button"
-              role="tab"
-              aria-selected={filter === tab.value}
-              onClick={() => setFilter(tab.value)}
-              className={[
-                'niuu-px-3 niuu-py-1 niuu-rounded niuu-text-sm niuu-transition-colors',
-                filter === tab.value
-                  ? 'niuu-bg-brand niuu-text-bg-primary niuu-font-medium'
-                  : 'niuu-text-text-secondary hover:niuu-text-text-primary',
-              ].join(' ')}
-            >
-              {tab.label}
-              {tab.value !== 'all' && (
-                <span className="niuu-ml-1 niuu-text-xs niuu-opacity-70">
-                  ({counts[tab.value as SagaStatus]})
-                </span>
-              )}
-            </button>
-          ))}
-        </nav>
+        {/* Saga list */}
+        <div className="niuu-flex-1 niuu-overflow-y-auto" role="list" aria-label="Sagas">
+          {filtered.length === 0 ? (
+            <div className="niuu-p-4">
+              <EmptyState
+                title="No sagas found"
+                description={
+                  search
+                    ? `No sagas match "${search}"`
+                    : `No ${filter === 'all' ? '' : filter + ' '}sagas yet.`
+                }
+              />
+            </div>
+          ) : (
+            filtered.map((saga) => (
+              <div key={saga.id} role="listitem">
+                <SagaListRow
+                  saga={saga}
+                  isSelected={selectedSagaId === saga.id}
+                  onClick={() => handleSelectSaga(saga)}
+                />
+              </div>
+            ))
+          )}
+        </div>
       </div>
 
-      {/* Saga list */}
-      {filtered.length === 0 ? (
-        <EmptyState
-          title="No sagas found"
-          description={
-            search
-              ? `No sagas match "${search}"`
-              : `No ${filter === 'all' ? '' : filter + ' '}sagas yet.`
-          }
-        />
-      ) : (
-        <ul className="niuu-list-none niuu-p-0 niuu-m-0 niuu-space-y-3">
-          {filtered.map((saga) => (
-            <li key={saga.id}>
-              <button
-                type="button"
-                className="niuu-w-full niuu-text-left niuu-p-4 niuu-rounded-lg niuu-bg-bg-secondary niuu-border niuu-border-border niuu-cursor-pointer"
-                onClick={() =>
-                  void navigate({
-                    to: '/tyr/sagas/$sagaId',
-                    params: { sagaId: saga.id },
-                  })
-                }
-                aria-label={`View saga ${saga.name}`}
-              >
-                <div className="niuu-flex niuu-items-start niuu-justify-between niuu-gap-4">
-                  <div className="niuu-flex niuu-flex-col niuu-gap-2 niuu-min-w-0">
-                    <div className="niuu-flex niuu-items-center niuu-gap-2">
-                      <StatusBadge status={saga.status} />
-                      <span className="niuu-font-semibold niuu-text-text-primary">{saga.name}</span>
-                    </div>
-                    <p className="niuu-m-0 niuu-text-xs niuu-text-text-muted">
-                      {saga.trackerId} · {saga.featureBranch} · Created{' '}
-                      {new Date(saga.createdAt).toLocaleDateString()}
-                    </p>
-                    <Pipe
-                      cells={Array.from({ length: saga.phaseSummary.total }, (_, i) => ({
-                        status:
-                          i < saga.phaseSummary.completed
-                            ? phaseStatusToCell('complete')
-                            : phaseStatusToCell('pending'),
-                        label: `Phase ${i + 1}`,
-                      }))}
-                    />
-                  </div>
-                  <div className="niuu-flex-shrink-0">
-                    <ConfidenceBadge value={saga.confidence / 100} />
-                  </div>
-                </div>
-              </button>
-            </li>
-          ))}
-        </ul>
-      )}
+      {/* ── Right detail panel ─────────────────────────── */}
+      <div className="niuu-flex-1 niuu-overflow-y-auto" aria-label="Saga detail">
+        {selectedSagaId ? (
+          <SagaDetailPage sagaId={selectedSagaId} hideBackButton />
+        ) : (
+          <div className="niuu-flex niuu-items-center niuu-justify-center niuu-h-full">
+            <EmptyState title="Select a saga" description="Click a saga on the left to view its details." />
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/web-next/packages/plugin-tyr/src/ui/SagasPage.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/SagasPage.tsx
@@ -8,6 +8,7 @@ import {
   EmptyState,
   Pipe,
   Rune,
+  relTime,
 } from '@niuulabs/ui';
 import type { SagaStatus } from '../domain/saga';
 import type { Saga } from '../domain/saga';
@@ -19,21 +20,14 @@ import { SagaDetailPage } from './SagaDetailPage';
 // Deterministic saga glyph (hash saga trackerId → Elder Futhark rune)
 // ---------------------------------------------------------------------------
 
-const SAGA_GLYPHS = ['ᚠ', 'ᚱ', 'ᚲ', 'ᚷ', 'ᚢ', 'ᛁ', 'ᛃ', 'ᛉ', 'ᛒ', 'ᛖ', 'ᛗ', 'ᛜ', 'ᛟ', 'ᛞ'];
+// Safe Elder Futhark runes — forbidden appropriated symbols (Algiz ᛉ, Othala ᛟ,
+// Tiwaz ᛏ, Sowilo ᛊ, Hagalaz ᚺ/ᚻ) are explicitly excluded per runeMap.ts.
+const SAGA_GLYPHS = ['ᚠ', 'ᚱ', 'ᚲ', 'ᚷ', 'ᚢ', 'ᚨ', 'ᛃ', 'ᚦ', 'ᛒ', 'ᛖ', 'ᛗ', 'ᛜ', 'ᚹ', 'ᛞ'];
 
 function sagaGlyph(id: string): string {
   let h = 0;
   for (const c of id) h = ((h * 31 + c.charCodeAt(0)) >>> 0);
   return SAGA_GLYPHS[h % SAGA_GLYPHS.length]!;
-}
-
-function timeAgo(isoDate: string): string {
-  const diff = Date.now() - new Date(isoDate).getTime();
-  const mins = Math.floor(diff / 60_000);
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  return `${Math.floor(hrs / 24)}d ago`;
 }
 
 // ---------------------------------------------------------------------------
@@ -111,7 +105,7 @@ function SagaListRow({ saga, isSelected, onClick }: SagaListRowProps) {
           </span>
         )}
         <span className="niuu-text-xs niuu-text-text-faint niuu-font-mono niuu-ml-auto">
-          {timeAgo(saga.createdAt)}
+          {relTime(saga.createdAt)}
         </span>
       </div>
 

--- a/web-next/packages/plugin-volundr/src/ui/ForgePage.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/ForgePage.tsx
@@ -1,11 +1,11 @@
 import { useNavigate } from '@tanstack/react-router';
-import { KpiStrip, KpiCard, StateDot, LoadingState } from '@niuulabs/ui';
+import { KpiStrip, KpiCard, StateDot, LoadingState, relTime } from '@niuulabs/ui';
 import { useVolundrStats } from './useVolundrSessions';
 import { useVolundrClusters } from './hooks/useVolundrClusters';
 import { useSessionList } from './hooks/useSessionStore';
 import { useTemplates } from './useTemplates';
 import { Meter, MiniBar } from './atoms';
-import { tokens, relTime } from './utils/formatters';
+import { tokens } from './utils/formatters';
 import type { Session } from '../domain/session';
 import type { Cluster } from '../domain/cluster';
 import type { Template } from '../domain/template';

--- a/web-next/packages/plugin-volundr/src/ui/utils/formatters.test.ts
+++ b/web-next/packages/plugin-volundr/src/ui/utils/formatters.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
-import { money, tokens, relTime } from './formatters';
+import { describe, it, expect } from 'vitest';
+import { money, tokens } from './formatters';
 
 describe('money', () => {
   it('formats cents to dollars', () => {
@@ -31,36 +31,3 @@ describe('tokens', () => {
   });
 });
 
-describe('relTime', () => {
-  it('returns — for falsy input', () => {
-    expect(relTime(0)).toBe('—');
-  });
-
-  it('formats seconds ago', () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(10_000);
-    expect(relTime(5_000)).toBe('5s ago');
-    vi.useRealTimers();
-  });
-
-  it('formats minutes ago', () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(300_000);
-    expect(relTime(0 + 1)).toBe('4m ago');
-    vi.useRealTimers();
-  });
-
-  it('formats hours ago', () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(7_200_000);
-    expect(relTime(1)).toBe('1h ago');
-    vi.useRealTimers();
-  });
-
-  it('formats days ago', () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(172_800_000);
-    expect(relTime(1)).toBe('1d ago');
-    vi.useRealTimers();
-  });
-});

--- a/web-next/packages/plugin-volundr/src/ui/utils/formatters.ts
+++ b/web-next/packages/plugin-volundr/src/ui/utils/formatters.ts
@@ -12,12 +12,3 @@ export function tokens(n: number): string {
   return `${n}`;
 }
 
-/** Format timestamp to "3m ago" style relative time */
-export function relTime(ts: number): string {
-  if (!ts) return '—';
-  const d = Math.max(0, Date.now() - ts);
-  if (d < 60_000) return `${Math.floor(d / 1000)}s ago`;
-  if (d < 3_600_000) return `${Math.floor(d / 60_000)}m ago`;
-  if (d < 86_400_000) return `${Math.floor(d / 3_600_000)}h ago`;
-  return `${Math.floor(d / 86_400_000)}d ago`;
-}

--- a/web-next/packages/shell/src/ShellLayout.tsx
+++ b/web-next/packages/shell/src/ShellLayout.tsx
@@ -107,20 +107,28 @@ export function ShellLayout() {
           </div>
           {active?.tabs && (
             <div className="niuu-shell__tabs">
-              {active.tabs.map((t) => (
-                <button
-                  key={t.id}
-                  type="button"
-                  className={clsx(
-                    'niuu-shell__tab',
-                    active.activeTab === t.id && 'niuu-shell__tab--active',
-                  )}
-                  onClick={() => active.onTab?.(t.id)}
-                >
-                  {t.rune && <span className="niuu-shell__tab-rune">{t.rune}</span>}
-                  {t.label}
-                </button>
-              ))}
+              {active.tabs.map((t) => {
+                const tabPath = t.path ?? `/${active.id}/${t.id}`;
+                const isActive =
+                  active.activeTab != null
+                    ? active.activeTab === t.id
+                    : pathname === tabPath || pathname.startsWith(tabPath + '/');
+                return (
+                  <button
+                    key={t.id}
+                    type="button"
+                    className={clsx('niuu-shell__tab', isActive && 'niuu-shell__tab--active')}
+                    onClick={() => {
+                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                      router.navigate({ to: tabPath as any });
+                      active.onTab?.(t.id);
+                    }}
+                  >
+                    {t.rune && <span className="niuu-shell__tab-rune">{t.rune}</span>}
+                    {t.label}
+                  </button>
+                );
+              })}
             </div>
           )}
         </div>

--- a/web-next/packages/ui/src/index.ts
+++ b/web-next/packages/ui/src/index.ts
@@ -37,6 +37,7 @@ export * from './primitives/EventPicker';
 export * from './primitives/ToolPicker';
 export * from './primitives/SchemaEditor';
 export { cn } from './utils/cn';
+export { relTime } from './utils/relTime';
 
 /* Chat */
 export * from './chat';

--- a/web-next/packages/ui/src/utils/relTime.test.ts
+++ b/web-next/packages/ui/src/utils/relTime.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+import { relTime } from './relTime';
+
+describe('relTime', () => {
+  it('returns — for zero timestamp', () => {
+    expect(relTime(0)).toBe('—');
+  });
+
+  it('formats seconds ago from a number timestamp', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    expect(relTime(5_000)).toBe('5s ago');
+    vi.useRealTimers();
+  });
+
+  it('formats minutes ago from a number timestamp', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(300_000);
+    expect(relTime(1)).toBe('4m ago');
+    vi.useRealTimers();
+  });
+
+  it('formats hours ago from a number timestamp', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(7_200_000);
+    expect(relTime(1)).toBe('1h ago');
+    vi.useRealTimers();
+  });
+
+  it('formats days ago from a number timestamp', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(172_800_000);
+    expect(relTime(1)).toBe('1d ago');
+    vi.useRealTimers();
+  });
+
+  it('accepts an ISO date string', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T01:00:00Z').getTime());
+    expect(relTime('2026-01-01T00:00:00Z')).toBe('1h ago');
+    vi.useRealTimers();
+  });
+});

--- a/web-next/packages/ui/src/utils/relTime.ts
+++ b/web-next/packages/ui/src/utils/relTime.ts
@@ -1,0 +1,13 @@
+/**
+ * Format a timestamp (number) or ISO date string to a relative time string
+ * such as "3m ago", "2h ago", "1d ago".
+ */
+export function relTime(input: string | number): string {
+  const ms = typeof input === 'number' ? input : new Date(input).getTime();
+  if (!ms) return '—';
+  const d = Math.max(0, Date.now() - ms);
+  if (d < 60_000) return `${Math.floor(d / 1000)}s ago`;
+  if (d < 3_600_000) return `${Math.floor(d / 60_000)}m ago`;
+  if (d < 86_400_000) return `${Math.floor(d / 3_600_000)}h ago`;
+  return `${Math.floor(d / 86_400_000)}d ago`;
+}

--- a/web-next/vitest.setup.ts
+++ b/web-next/vitest.setup.ts
@@ -29,8 +29,8 @@ if (!Element.prototype.releasePointerCapture) {
 }
 
 // jsdom doesn't implement HTMLCanvasElement.prototype.getContext.
-// Return a minimal stub so canvas-based components (e.g. AmbientTopology)
-// don't print "Not implemented" warnings during tests.
+// Return a minimal stub so canvas-based components (e.g. AmbientTopology,
+// RaidMeshCanvas) don't print "Not implemented" warnings during tests.
 if (typeof HTMLCanvasElement !== 'undefined') {
   HTMLCanvasElement.prototype.getContext = () =>
     ({
@@ -41,10 +41,16 @@ if (typeof HTMLCanvasElement !== 'undefined') {
       arc: () => {},
       fill: () => {},
       stroke: () => {},
+      fillText: () => {},
       setTransform: () => {},
+      createRadialGradient: () => ({
+        addColorStop: () => {},
+      }),
       strokeStyle: '',
       lineWidth: 0,
       fillStyle: '',
+      font: '',
+      textAlign: 'start' as CanvasTextAlign,
     }) as unknown as CanvasRenderingContext2D;
 }
 


### PR DESCRIPTION
## Summary

- **Topbar tabs**: Added `PluginTab.path` field to `PluginDescriptor` and updated `ShellLayout` to render clickable tabs that navigate by path and derive active state from `location.pathname`. Tyr now registers 6 tabs: Dashboard, Sagas, Dispatch, Plan, Workflows, Settings.
- **RaidMeshCanvas**: Full canvas animation replacing the static stub — cluster halos (radial gradient), raven nodes, animated pulses, hover tooltips, and `onClickSaga` callback. `ResizeObserver` handles DPR scaling; `requestAnimationFrame` drives the draw loop.
- **Sagas split panel**: 420px left list (glyph + name + meta + Pipe + raid counts, search, status filter tabs) with inline `SagaDetailPage` on the right — no route navigation needed. Added `hideBackButton` prop to `SagaDetailPage`.
- **Dispatch grouped layout**: Raids grouped by saga with a 280px right-side rules panel (threshold, concurrent, auto-continue, retries, quiet hours, escalation) and floating `BatchDispatchBar`.
- **Plan guidance rail**: `PlanGuidanceRail` component (two guidance cards) added to `PlanWizard` right column; hidden on raiding and approved steps.
- **Tests**: Fixed canvas mock in `vitest.setup.ts`; updated `SagasPage.test.tsx` (router mock + heading assertion) and `DispatchView.test.tsx` (duplicate text + removed table-role assertion). Coverage: 92.6% statements, 88.9% branches, 88.0% functions — all above the 85% gate.

## Test plan

- [x] All 200+ unit tests pass (`pnpm test` exit 0)
- [x] Coverage ≥ 85% on statements, branches, functions, lines
- [x] Topbar tabs navigate to correct routes and highlight active tab
- [x] RaidMeshCanvas renders cluster animation in the jsdom canvas stub
- [x] SagasPage shows split panel, search, filter tabs, inline detail
- [x] DispatchView groups raids by saga, shows rules panel, batch bar
- [x] PlanWizard shows guidance rail on prompt/questions/draft, hides on raiding/approved

Closes NIU-691

🤖 Generated with [Claude Code](https://claude.com/claude-code)