### PR TITLE
feat(mimir): verify and fix visual parity with web2 prototype — NIU-692

### DIFF
--- a/web-next/packages/plugin-mimir/src/adapters/mock.ts
+++ b/web-next/packages/plugin-mimir/src/adapters/mock.ts
@@ -138,6 +138,7 @@ const MOCK_PAGES: Page[] = [
     category: 'infra',
     type: 'topic',
     confidence: 'medium',
+    flagged: true,
     mounts: ['platform'],
     updatedAt: '2026-04-10T14:00:00Z',
     updatedBy: 'ravn-fjolnir',

--- a/web-next/packages/plugin-mimir/src/domain/page.ts
+++ b/web-next/packages/plugin-mimir/src/domain/page.ts
@@ -61,6 +61,8 @@ export interface PageMeta {
   updatedBy: string;
   sourceIds: string[];
   size: number;
+  /** Whether a human has flagged this page for review. */
+  flagged?: boolean;
   /** Related page slugs — carried through from Page so backlinks can be computed. */
   related?: string[];
 }
@@ -113,6 +115,7 @@ export function toPageMeta(page: Page): PageMeta {
     type: page.type,
     confidence: page.confidence,
     entityType: page.entityType,
+    flagged: page.flagged,
     mounts: page.mounts,
     updatedAt: page.updatedAt,
     updatedBy: page.updatedBy,

--- a/web-next/packages/plugin-mimir/src/index.tsx
+++ b/web-next/packages/plugin-mimir/src/index.tsx
@@ -1,5 +1,6 @@
 import { createRoute } from '@tanstack/react-router';
 import { definePlugin } from '@niuulabs/plugin-sdk';
+import type { PluginCtx } from '@niuulabs/plugin-sdk';
 import { MimirPage } from './ui/MimirPage';
 import { SearchPage } from './ui/SearchPage';
 import { GraphPage } from './ui/GraphPage';
@@ -8,6 +9,8 @@ import { RavnsPage } from './ui/RavnsPage';
 import { RoutingPage } from './ui/RoutingPage';
 import { LintPage } from './ui/LintPage';
 import { DreamsPage } from './ui/DreamsPage';
+import { MimirSubnav } from './ui/MimirSubnav';
+import { MimirTopbar } from './ui/MimirTopbar';
 
 export const mimirPlugin = definePlugin({
   id: 'mimir',
@@ -56,6 +59,8 @@ export const mimirPlugin = definePlugin({
       component: DreamsPage,
     }),
   ],
+  subnav: (ctx: PluginCtx) => <MimirSubnav ctx={ctx} />,
+  topbarRight: (ctx: PluginCtx) => <MimirTopbar ctx={ctx} />,
 });
 
 export { createMimirMockAdapter } from './adapters/mock';

--- a/web-next/packages/plugin-mimir/src/ui/GraphPage.css
+++ b/web-next/packages/plugin-mimir/src/ui/GraphPage.css
@@ -137,3 +137,65 @@
   font-family: var(--font-sans);
   pointer-events: none;
 }
+
+/* ── Canvas + legend row ───────────────────────────────────────────────────── */
+
+.graph-page__canvas-wrap {
+  display: flex;
+  gap: var(--space-4);
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+/* ── Legend card ───────────────────────────────────────────────────────────── */
+
+.graph-page__legend {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-lg);
+  min-width: 140px;
+}
+
+.graph-page__legend-title {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--color-text-muted);
+  padding-bottom: var(--space-1);
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.graph-page__legend-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.graph-page__legend-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+/* 8 category color slots mapped from CSS tokens */
+.graph-page__legend-dot[data-color-idx="0"] { background: var(--color-accent-cyan); }
+.graph-page__legend-dot[data-color-idx="1"] { background: var(--color-accent-indigo); }
+.graph-page__legend-dot[data-color-idx="2"] { background: var(--color-accent-emerald); }
+.graph-page__legend-dot[data-color-idx="3"] { background: var(--color-accent-purple); }
+.graph-page__legend-dot[data-color-idx="4"] { background: var(--color-accent-amber); }
+.graph-page__legend-dot[data-color-idx="5"] { background: var(--color-accent-orange); }
+.graph-page__legend-dot[data-color-idx="6"] { background: var(--color-accent-red); }
+.graph-page__legend-dot[data-color-idx="7"] { background: var(--color-text-secondary); }
+
+.graph-page__legend-label {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/web-next/packages/plugin-mimir/src/ui/GraphPage.tsx
+++ b/web-next/packages/plugin-mimir/src/ui/GraphPage.tsx
@@ -6,8 +6,31 @@ import './GraphPage.css';
 const MAX_HOPS = 4;
 const MIN_HOPS = 1;
 
+// Category color palette (maps to CSS tokens in order)
+const CATEGORY_COLORS = [
+  'var(--color-accent-cyan)',
+  'var(--color-accent-indigo)',
+  'var(--color-accent-emerald)',
+  'var(--color-accent-purple)',
+  'var(--color-accent-amber)',
+  'var(--color-accent-orange)',
+  'var(--color-accent-red)',
+  'var(--color-text-secondary)',
+] as const;
+
+const CATEGORY_COLOR_INDICES = [0, 1, 2, 3, 4, 5, 6, 7] as const;
+
+function getCategoryIndex(category: string, categories: string[]): number {
+  const idx = categories.indexOf(category);
+  return (idx < 0 ? 0 : idx) % CATEGORY_COLORS.length;
+}
+
+function getCategoryFill(category: string, categories: string[]): string {
+  return CATEGORY_COLORS[getCategoryIndex(category, categories)] ?? CATEGORY_COLORS[0];
+}
+
 // ---------------------------------------------------------------------------
-// Simple circular SVG layout
+// SVG layout
 // ---------------------------------------------------------------------------
 
 interface NodePosition {
@@ -34,9 +57,10 @@ interface GraphSvgProps {
   graph: MimirGraph;
   focusId: string | null;
   onNodeClick: (id: string) => void;
+  categories: string[];
 }
 
-function GraphSvg({ graph, focusId, onNodeClick }: GraphSvgProps) {
+function GraphSvg({ graph, focusId, onNodeClick, categories }: GraphSvgProps) {
   const positions = layoutCircle(graph.nodes);
   const posMap = new Map(positions.map((p) => [p.node.id, p]));
 
@@ -62,6 +86,9 @@ function GraphSvg({ graph, focusId, onNodeClick }: GraphSvgProps) {
       <g className="graph-page__nodes">
         {positions.map(({ node, x, y }) => {
           const isFocus = node.id === focusId;
+          const fill = isFocus
+            ? 'var(--color-brand, var(--color-accent-cyan))'
+            : getCategoryFill(node.category, categories);
           return (
             <g
               key={node.id}
@@ -77,7 +104,12 @@ function GraphSvg({ graph, focusId, onNodeClick }: GraphSvgProps) {
                 if (e.key === 'Enter' || e.key === ' ') onNodeClick(node.id);
               }}
             >
-              <circle r={isFocus ? 14 : 10} className="graph-page__node-circle" />
+              <circle
+                r={isFocus ? 14 : 10}
+                className="graph-page__node-circle"
+                fill={fill}
+                stroke={isFocus ? fill : 'var(--color-border)'}
+              />
               <text dy={isFocus ? 26 : 22} className="graph-page__node-label">
                 {node.title.length > 20 ? `${node.title.slice(0, 18)}…` : node.title}
               </text>
@@ -90,6 +122,33 @@ function GraphSvg({ graph, focusId, onNodeClick }: GraphSvgProps) {
 }
 
 // ---------------------------------------------------------------------------
+// Legend
+// ---------------------------------------------------------------------------
+
+interface LegendProps {
+  categories: string[];
+}
+
+function GraphLegend({ categories }: LegendProps) {
+  if (categories.length === 0) return null;
+  return (
+    <div className="graph-page__legend" aria-label="Graph legend">
+      <span className="graph-page__legend-title">Categories</span>
+      {categories.map((cat, i) => (
+        <div key={cat} className="graph-page__legend-item">
+          <span
+            className="graph-page__legend-dot"
+            data-color-idx={String(CATEGORY_COLOR_INDICES[i % CATEGORY_COLORS.length])}
+            aria-hidden
+          />
+          <span className="graph-page__legend-label">{cat}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // GraphPage
 // ---------------------------------------------------------------------------
 
@@ -98,6 +157,9 @@ export function GraphPage() {
     useGraph();
 
   const displayGraph = focusedGraph ?? graph;
+  const categories = displayGraph
+    ? [...new Set(displayGraph.nodes.map((n) => n.category))].filter(Boolean).sort()
+    : [];
 
   return (
     <div className="graph-page">
@@ -174,11 +236,15 @@ export function GraphPage() {
             )}
           </div>
 
-          <GraphSvg
-            graph={displayGraph}
-            focusId={focusId}
-            onNodeClick={(id) => setFocusId(focusId === id ? null : id)}
-          />
+          <div className="graph-page__canvas-wrap">
+            <GraphSvg
+              graph={displayGraph}
+              focusId={focusId}
+              onNodeClick={(id) => setFocusId(focusId === id ? null : id)}
+              categories={categories}
+            />
+            <GraphLegend categories={categories} />
+          </div>
         </>
       )}
     </div>

--- a/web-next/packages/plugin-mimir/src/ui/GraphPage.tsx
+++ b/web-next/packages/plugin-mimir/src/ui/GraphPage.tsx
@@ -18,8 +18,6 @@ const CATEGORY_COLORS = [
   'var(--color-text-secondary)',
 ] as const;
 
-const CATEGORY_COLOR_INDICES = [0, 1, 2, 3, 4, 5, 6, 7] as const;
-
 function getCategoryIndex(category: string, categories: string[]): number {
   const idx = categories.indexOf(category);
   return (idx < 0 ? 0 : idx) % CATEGORY_COLORS.length;
@@ -138,7 +136,7 @@ function GraphLegend({ categories }: LegendProps) {
         <div key={cat} className="graph-page__legend-item">
           <span
             className="graph-page__legend-dot"
-            data-color-idx={String(CATEGORY_COLOR_INDICES[i % CATEGORY_COLORS.length])}
+            data-color-idx={String(i % CATEGORY_COLORS.length)}
             aria-hidden
           />
           <span className="graph-page__legend-label">{cat}</span>

--- a/web-next/packages/plugin-mimir/src/ui/LintPage.css
+++ b/web-next/packages/plugin-mimir/src/ui/LintPage.css
@@ -1,27 +1,218 @@
+/* ── LintPage wrapper ──────────────────────────────────────────────────────── */
+
 .lint-page {
   padding: var(--space-6);
-  max-width: 960px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  height: 100%;
+  box-sizing: border-box;
 }
 
-.lint-page__title {
-  margin: 0 0 var(--space-5);
-}
-
-.lint-page__status {
+.lint-page--loading,
+.lint-page--error {
   display: flex;
   align-items: center;
   gap: var(--space-2);
   color: var(--color-text-secondary);
   font-size: var(--text-sm);
+  padding: var(--space-6);
 }
 
-.lint-page__header {
+/* ── KPI strip ─────────────────────────────────────────────────────────────── */
+
+.lint-page__kpi-strip {
   display: flex;
-  align-items: center;
   gap: var(--space-4);
-  margin-bottom: var(--space-4);
   flex-wrap: wrap;
 }
+
+.lint-page__kpi {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: var(--space-3) var(--space-4);
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  min-width: 80px;
+}
+
+.lint-page__kpi--accent {
+  border-color: color-mix(in srgb, var(--color-brand, var(--color-accent-cyan)) 25%, transparent);
+  background: color-mix(in srgb, var(--color-brand, var(--color-accent-cyan)) 6%, var(--color-bg-secondary));
+}
+
+.lint-page__kpi-lbl {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted);
+}
+
+.lint-page__kpi-val {
+  font-size: var(--text-xl);
+  font-weight: 700;
+  font-family: var(--font-mono);
+  color: var(--color-text-primary);
+}
+
+.lint-page__kpi-val--err {
+  color: var(--color-critical, var(--color-accent-red));
+}
+
+.lint-page__kpi-val--warn {
+  color: var(--color-accent-amber);
+}
+
+/* ── 2-column layout ───────────────────────────────────────────────────────── */
+
+.lint-page__wrap {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: 0;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  flex: 1;
+  min-height: 0;
+}
+
+/* ── Sidebar (checks) ──────────────────────────────────────────────────────── */
+
+.lint-page__sidebar {
+  border-right: 1px solid var(--color-border-subtle);
+  background: var(--color-bg-secondary);
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
+
+.lint-page__sidebar-title {
+  padding: var(--space-3) var(--space-4);
+  margin: 0;
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--color-text-muted);
+  border-bottom: 1px solid var(--color-border-subtle);
+  flex-shrink: 0;
+}
+
+.lint-page__check-row {
+  display: grid;
+  grid-template-columns: 52px 1fr 28px;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--color-border-subtle);
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.1s;
+  width: 100%;
+}
+
+.lint-page__check-row:last-child {
+  border-bottom: none;
+}
+
+.lint-page__check-row:hover {
+  background: var(--color-bg-tertiary);
+}
+
+.lint-page__check-row--active {
+  background: color-mix(in srgb, var(--color-brand, var(--color-accent-cyan)) 10%, var(--color-bg-secondary));
+}
+
+.lint-page__check-row--active:hover {
+  background: color-mix(in srgb, var(--color-brand, var(--color-accent-cyan)) 14%, var(--color-bg-secondary));
+}
+
+.lint-page__check-id-cell {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.lint-page__check-id {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-primary);
+  font-weight: 600;
+}
+
+.lint-page__check-desc-cell {
+  overflow: hidden;
+}
+
+.lint-page__check-name {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+}
+
+.lint-page__check-count {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-primary);
+  text-align: right;
+}
+
+.lint-page__check-count--zero {
+  color: var(--color-text-muted);
+}
+
+/* ── Issues panel (right) ──────────────────────────────────────────────────── */
+
+.lint-page__issues-panel {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--color-bg-primary);
+}
+
+.lint-page__issues-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--color-border-subtle);
+  background: var(--color-bg-secondary);
+  flex-shrink: 0;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.lint-page__issues-rule-label {
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--color-text-primary);
+  margin-left: var(--space-2);
+}
+
+.lint-page__issues-count {
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-text-muted);
+}
+
+.lint-page__issues-actions {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.lint-page__empty {
+  padding: var(--space-4);
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+}
+
+/* ── Buttons ───────────────────────────────────────────────────────────────── */
 
 .lint-page__btn {
   padding: var(--space-1) var(--space-3);
@@ -32,6 +223,11 @@
   font-family: var(--font-sans);
   font-size: var(--text-xs);
   cursor: pointer;
+  white-space: nowrap;
+}
+
+.lint-page__btn:hover {
+  background: var(--color-bg-tertiary);
 }
 
 .lint-page__btn:disabled {
@@ -40,110 +236,42 @@
 }
 
 .lint-page__btn--fix {
-  background: var(--brand-500);
-  border-color: var(--brand-500);
+  background: var(--color-brand, var(--color-accent-cyan));
+  border-color: var(--color-brand, var(--color-accent-cyan));
   color: var(--color-bg-primary);
   font-weight: 500;
 }
 
-.lint-page__severity-filter {
-  display: flex;
-  gap: var(--space-1);
-  margin-bottom: var(--space-4);
+.lint-page__btn--fix:hover {
+  opacity: 0.88;
+  background: var(--color-brand, var(--color-accent-cyan));
 }
 
-.lint-page__filter-btn {
-  padding: var(--space-1) var(--space-3);
-  background: var(--color-bg-secondary);
-  border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-sm);
-  color: var(--color-text-secondary);
-  font-family: var(--font-sans);
-  font-size: var(--text-xs);
-  cursor: pointer;
-}
+/* ── Issues list ───────────────────────────────────────────────────────────── */
 
-.lint-page__filter-btn--active {
-  background: var(--color-bg-tertiary);
-  border-color: var(--color-border);
-  color: var(--color-text-primary);
-}
-
-.lint-page__filter-btn--error {
-  color: var(--color-critical);
-}
-
-.lint-page__filter-btn--warn {
-  color: var(--color-accent-amber);
-}
-
-.lint-page__filter-btn--info {
-  color: var(--color-accent-cyan);
-}
-
-.lint-page__bulk-bar {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  padding: var(--space-2) var(--space-3);
-  background: color-mix(in srgb, var(--brand-500) 8%, transparent);
-  border: 1px solid color-mix(in srgb, var(--brand-500) 20%, transparent);
-  border-radius: var(--radius-md);
-  margin-bottom: var(--space-3);
-  flex-wrap: wrap;
-}
-
-.lint-page__bulk-count {
-  font-size: var(--text-xs);
-  color: var(--color-text-secondary);
-}
-
-.lint-page__assignee-select {
-  padding: var(--space-1) var(--space-2);
-  background: var(--color-bg-secondary);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  color: var(--color-text-primary);
-  font-family: var(--font-sans);
-  font-size: var(--text-xs);
-}
-
-.lint-page__select-all {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  margin-bottom: var(--space-3);
-}
-
-.lint-page__select-all-label {
-  font-size: var(--text-xs);
-  color: var(--color-text-muted);
-}
-
-.lint-page__empty {
-  color: var(--color-text-muted);
-  font-size: var(--text-sm);
-}
-
-.lint-page__issues {
+.lint-page__list {
   list-style: none;
   padding: 0;
-  display: grid;
-  gap: var(--space-2);
+  margin: 0;
+  overflow-y: auto;
+  flex: 1;
 }
 
 .lint-page__issue {
-  display: flex;
-  align-items: flex-start;
+  display: grid;
+  grid-template-columns: 64px 1fr auto;
   gap: var(--space-3);
-  padding: var(--space-3);
-  border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-md);
-  background: var(--color-bg-secondary);
+  align-items: flex-start;
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.lint-page__issue:last-child {
+  border-bottom: none;
 }
 
 .lint-page__issue--error {
-  border-left: 3px solid var(--color-critical);
+  border-left: 3px solid var(--color-critical, var(--color-accent-red));
 }
 
 .lint-page__issue--warn {
@@ -154,27 +282,11 @@
   border-left: 3px solid var(--color-accent-cyan);
 }
 
-.lint-page__issue--selected {
-  background: color-mix(in srgb, var(--brand-500) 6%, var(--color-bg-secondary));
-}
-
-.lint-page__issue-check {
-  margin-top: 3px;
-  flex-shrink: 0;
-  cursor: pointer;
-}
-
-.lint-page__issue-body {
-  flex: 1;
-  min-width: 0;
-}
-
-.lint-page__issue-header {
+.lint-page__issue-id-cell {
   display: flex;
   align-items: center;
-  gap: var(--space-2);
-  flex-wrap: wrap;
-  margin-bottom: var(--space-1);
+  gap: var(--space-1);
+  padding-top: 2px;
 }
 
 .lint-page__issue-rule {
@@ -184,7 +296,10 @@
   padding: 2px var(--space-2);
   border-radius: var(--radius-sm);
   color: var(--color-text-secondary);
-  cursor: help;
+}
+
+.lint-page__issue-body {
+  min-width: 0;
 }
 
 .lint-page__issue-page {
@@ -194,12 +309,7 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.lint-page__issue-assignee {
-  font-size: var(--text-xs);
-  color: var(--color-text-muted);
-  font-family: var(--font-mono);
+  margin-bottom: var(--space-1);
 }
 
 .lint-page__issue-message {
@@ -209,24 +319,16 @@
   word-break: break-word;
 }
 
-.lint-page__fix-btn {
-  background: none;
-  border: 1px solid color-mix(in srgb, var(--brand-500) 40%, transparent);
-  border-radius: var(--radius-sm);
-  color: var(--brand-400);
-  font-family: var(--font-sans);
-  font-size: var(--text-xs);
-  padding: 2px var(--space-2);
-  cursor: pointer;
-  flex-shrink: 0;
+.lint-page__issue-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--space-1);
+}
+
+.lint-page__issue-mount {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--color-text-muted);
   white-space: nowrap;
-}
-
-.lint-page__fix-btn:hover {
-  background: color-mix(in srgb, var(--brand-500) 10%, transparent);
-}
-
-.lint-page__fix-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
 }

--- a/web-next/packages/plugin-mimir/src/ui/LintPage.test.tsx
+++ b/web-next/packages/plugin-mimir/src/ui/LintPage.test.tsx
@@ -8,14 +8,16 @@ import { renderWithMimir } from '../testing/renderWithMimir';
 const wrap = renderWithMimir;
 
 describe('LintPage', () => {
-  it('renders the page title', () => {
-    wrap(<LintPage />);
-    expect(screen.getByRole('heading', { name: /lint/i })).toBeInTheDocument();
-  });
-
   it('shows loading state initially', () => {
     wrap(<LintPage />);
     expect(screen.getByText(/loading lint report/)).toBeInTheDocument();
+  });
+
+  it('renders the checks sidebar heading after load', async () => {
+    wrap(<LintPage />);
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: /lint checks/i })).toBeInTheDocument(),
+    );
   });
 
   it('renders lint issues after load', async () => {
@@ -33,25 +35,34 @@ describe('LintPage', () => {
     await waitFor(() => expect(screen.getByTestId('fix-all-btn')).toBeInTheDocument());
   });
 
-  it('renders severity filter buttons', async () => {
+  it('renders check rows for each rule in the sidebar', async () => {
     wrap(<LintPage />);
-    const filterGroup = await waitFor(() =>
-      screen.getByRole('group', { name: /filter by severity/i }),
+    await waitFor(() =>
+      expect(screen.getAllByTestId('check-row').length).toBeGreaterThan(0),
     );
-    expect(filterGroup).toBeInTheDocument();
-    expect(filterGroup.querySelector('[data-severity="error"]')).toBeInTheDocument();
-    expect(filterGroup.querySelector('[data-severity="warn"]')).toBeInTheDocument();
-    expect(filterGroup.querySelector('[data-severity="info"]')).toBeInTheDocument();
   });
 
-  it('clicking a severity filter shows only matching issues', async () => {
+  it('clicking a check row filters issues to that rule', async () => {
     wrap(<LintPage />);
     await waitFor(() => expect(screen.getAllByTestId('lint-issue').length).toBeGreaterThan(0));
     const allCount = screen.getAllByTestId('lint-issue').length;
-    fireEvent.click(screen.getByRole('button', { name: /error/i }));
+    const checkRows = screen.getAllByTestId('check-row');
+    fireEvent.click(checkRows[0]!);
     await waitFor(() => {
-      const errorCount = screen.queryAllByTestId('lint-issue').length;
-      expect(errorCount).toBeLessThanOrEqual(allCount);
+      const filteredCount = screen.queryAllByTestId('lint-issue').length;
+      expect(filteredCount).toBeLessThanOrEqual(allCount);
+    });
+  });
+
+  it('clicking the same check row again deselects it (shows all)', async () => {
+    wrap(<LintPage />);
+    await waitFor(() => expect(screen.getAllByTestId('lint-issue').length).toBeGreaterThan(0));
+    const allCount = screen.getAllByTestId('lint-issue').length;
+    const checkRows = screen.getAllByTestId('check-row');
+    fireEvent.click(checkRows[0]!);
+    fireEvent.click(checkRows[0]!);
+    await waitFor(() => {
+      expect(screen.getAllByTestId('lint-issue').length).toBe(allCount);
     });
   });
 
@@ -97,50 +108,6 @@ describe('LintPage', () => {
     await waitFor(() => expect(calledWith).toBeUndefined());
   });
 
-  it('selecting an issue shows the bulk action bar', async () => {
-    wrap(<LintPage />);
-    await waitFor(() => expect(screen.getAllByTestId('lint-issue').length).toBeGreaterThan(0));
-    const checkbox = screen
-      .getAllByRole('checkbox')
-      .find((c) => c.getAttribute('aria-label')?.startsWith('Select issue'));
-    fireEvent.click(checkbox!);
-    expect(screen.getByTestId('bulk-bar')).toBeInTheDocument();
-  });
-
-  it('select-all checkbox selects all visible issues', async () => {
-    wrap(<LintPage />);
-    await waitFor(() => expect(screen.getAllByTestId('lint-issue').length).toBeGreaterThan(0));
-    fireEvent.click(screen.getByTestId('select-all-checkbox'));
-    expect(screen.getByTestId('bulk-bar')).toBeInTheDocument();
-  });
-
-  it('bulk assign updates assignee on selected issues', async () => {
-    let assignCalled = false;
-    const spy: IMimirService = {
-      ...createMimirMockAdapter(),
-      lint: {
-        ...createMimirMockAdapter().lint,
-        reassignIssues: async (ids, assignee) => {
-          assignCalled = true;
-          expect(ids.length).toBeGreaterThan(0);
-          expect(assignee).toBe('ravn-fjolnir');
-          return { issues: [], pagesChecked: 3, summary: { error: 0, warn: 0, info: 0 } };
-        },
-      },
-    };
-    wrap(<LintPage />, spy);
-    await waitFor(() => expect(screen.getAllByTestId('lint-issue').length).toBeGreaterThan(0));
-    // Select all
-    fireEvent.click(screen.getByTestId('select-all-checkbox'));
-    // Pick assignee
-    fireEvent.change(screen.getByTestId('assignee-select'), {
-      target: { value: 'ravn-fjolnir' },
-    });
-    // Assign
-    fireEvent.click(screen.getByTestId('bulk-assign-btn'));
-    await waitFor(() => expect(assignCalled).toBe(true));
-  });
-
   it('shows error state when service throws', async () => {
     const failing: IMimirService = {
       ...createMimirMockAdapter(),
@@ -155,7 +122,7 @@ describe('LintPage', () => {
     await waitFor(() => expect(screen.getByText('lint service down')).toBeInTheDocument());
   });
 
-  it('shows "No issues" when lint report is empty', async () => {
+  it('shows "No issues found" when lint report is empty', async () => {
     const empty: IMimirService = {
       ...createMimirMockAdapter(),
       lint: {
@@ -169,5 +136,15 @@ describe('LintPage', () => {
     };
     wrap(<LintPage />, empty);
     await waitFor(() => expect(screen.getByText(/no issues found/i)).toBeInTheDocument());
+  });
+
+  it('KPI strip shows total issues', async () => {
+    wrap(<LintPage />);
+    await waitFor(() => expect(screen.getByText('total issues')).toBeInTheDocument());
+  });
+
+  it('KPI strip shows auto-fixable count', async () => {
+    wrap(<LintPage />);
+    await waitFor(() => expect(screen.getByText('auto-fixable')).toBeInTheDocument());
   });
 });

--- a/web-next/packages/plugin-mimir/src/ui/LintPage.tsx
+++ b/web-next/packages/plugin-mimir/src/ui/LintPage.tsx
@@ -1,12 +1,16 @@
-import { useState } from 'react';
-import { StateDot, Chip } from '@niuulabs/ui';
-import { useLint } from '../application/useLint';
-import { useRavns } from '../application/useRavns';
-import { LintBadge } from './LintBadge';
-import type { LintIssue, IssueSeverity, LintRule } from '../domain/lint';
-import './LintPage.css';
+/**
+ * LintPage — 2-column lint view (matches web2 prototype mm-lint-wrap layout).
+ *
+ * LEFT (220px): checks sidebar — All + per-rule rows with severity dot, id, name, count
+ * RIGHT (1fr):  issues list filtered by selected check + bulk actions
+ */
 
-const SEVERITY_ORDER: IssueSeverity[] = ['error', 'warn', 'info'];
+import { useState } from 'react';
+import { StateDot } from '@niuulabs/ui';
+import { useLint } from '../application/useLint';
+import { LintBadge } from './LintBadge';
+import type { LintRule, IssueSeverity } from '../domain/lint';
+import './LintPage.css';
 
 const RULE_DESCRIPTIONS: Record<LintRule, string> = {
   L01: 'Contradiction between pages',
@@ -17,107 +21,11 @@ const RULE_DESCRIPTIONS: Record<LintRule, string> = {
   L12: 'Invalid frontmatter',
 };
 
-interface IssueSeverityFilterProps {
-  active: IssueSeverity | null;
-  onChange: (s: IssueSeverity | null) => void;
-}
-
-function SeverityFilter({ active, onChange }: IssueSeverityFilterProps) {
-  return (
-    <div className="lint-page__severity-filter" role="group" aria-label="Filter by severity">
-      <button
-        className={['lint-page__filter-btn', active == null ? 'lint-page__filter-btn--active' : '']
-          .filter(Boolean)
-          .join(' ')}
-        onClick={() => onChange(null)}
-        aria-pressed={active == null}
-      >
-        All
-      </button>
-      {SEVERITY_ORDER.map((s) => (
-        <button
-          key={s}
-          className={[
-            'lint-page__filter-btn',
-            `lint-page__filter-btn--${s}`,
-            active === s ? 'lint-page__filter-btn--active' : '',
-          ]
-            .filter(Boolean)
-            .join(' ')}
-          onClick={() => onChange(active === s ? null : s)}
-          aria-pressed={active === s}
-          data-severity={s}
-        >
-          {s}
-        </button>
-      ))}
-    </div>
-  );
-}
-
-interface IssueRowProps {
-  issue: LintIssue;
-  selected: boolean;
-  onToggle: () => void;
-  onAutoFix: () => void;
-  isFixing: boolean;
-}
-
-function IssueRow({ issue, selected, onToggle, onAutoFix, isFixing }: IssueRowProps) {
-  return (
-    <li
-      className={[
-        'lint-page__issue',
-        `lint-page__issue--${issue.severity}`,
-        selected ? 'lint-page__issue--selected' : '',
-      ]
-        .filter(Boolean)
-        .join(' ')}
-      data-testid="lint-issue"
-    >
-      <input
-        type="checkbox"
-        className="lint-page__issue-check"
-        checked={selected}
-        onChange={onToggle}
-        aria-label={`Select issue ${issue.id}`}
-      />
-      <div className="lint-page__issue-body">
-        <div className="lint-page__issue-header">
-          <Chip
-            tone={
-              issue.severity === 'error'
-                ? 'default'
-                : issue.severity === 'warn'
-                  ? 'default'
-                  : 'muted'
-            }
-          >
-            {issue.severity}
-          </Chip>
-          <code className="lint-page__issue-rule" title={RULE_DESCRIPTIONS[issue.rule]}>
-            {issue.rule}
-          </code>
-          <span className="lint-page__issue-page">{issue.page}</span>
-          <Chip tone="muted">{issue.mount}</Chip>
-          {issue.assignee && <span className="lint-page__issue-assignee">{issue.assignee}</span>}
-        </div>
-        <p className="lint-page__issue-message">{issue.message}</p>
-      </div>
-      {issue.autoFix && (
-        <button
-          className="lint-page__fix-btn"
-          onClick={onAutoFix}
-          disabled={isFixing}
-          aria-label={`Auto-fix issue ${issue.id}`}
-          data-testid="autofix-btn"
-        >
-          {isFixing ? '…' : 'Fix'}
-        </button>
-      )}
-    </li>
-  );
-}
+const SEVERITY_DOT: Record<IssueSeverity, 'failed' | 'attention' | 'observing'> = {
+  error: 'failed',
+  warn: 'attention',
+  info: 'observing',
+};
 
 export function LintPage() {
   const {
@@ -127,172 +35,186 @@ export function LintPage() {
     isError,
     error,
     runAutoFix,
-    reassignIssues,
     isFixing,
-    isReassigning,
   } = useLint();
-  const { data: ravns } = useRavns();
-  const ravnIds = ravns?.map((r) => r.ravnId) ?? [];
 
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-  const [severityFilter, setSeverityFilter] = useState<IssueSeverity | null>(null);
-  const [assignTarget, setAssignTarget] = useState('');
+  const [selectedRule, setSelectedRule] = useState<LintRule | null>(null);
 
-  const filtered = severityFilter ? issues.filter((i) => i.severity === severityFilter) : issues;
+  // Aggregate counts per rule
+  const countByRule = issues.reduce<Record<string, number>>((acc, issue) => {
+    acc[issue.rule] = (acc[issue.rule] ?? 0) + 1;
+    return acc;
+  }, {});
 
+  const rules = Object.keys(RULE_DESCRIPTIONS) as LintRule[];
+  const filtered = selectedRule ? issues.filter((i) => i.rule === selectedRule) : issues;
   const autoFixableIds = filtered.filter((i) => i.autoFix).map((i) => i.id);
+  const totalLint = summary.error + summary.warn + summary.info;
 
-  function toggleSelect(id: string) {
-    setSelectedIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) {
-        next.delete(id);
-      } else {
-        next.add(id);
-      }
-      return next;
-    });
+  if (isLoading) {
+    return (
+      <div className="lint-page lint-page--loading">
+        <StateDot state="processing" pulse />
+        <span>loading lint report…</span>
+      </div>
+    );
   }
 
-  function toggleSelectAll() {
-    if (selectedIds.size === filtered.length) {
-      setSelectedIds(new Set());
-    } else {
-      setSelectedIds(new Set(filtered.map((i) => i.id)));
-    }
-  }
-
-  function handleBulkFix() {
-    const fixable = [...selectedIds].filter((id) => {
-      const issue = issues.find((i) => i.id === id);
-      return issue?.autoFix;
-    });
-    if (fixable.length > 0) {
-      runAutoFix(fixable);
-      setSelectedIds(new Set());
-    }
-  }
-
-  function handleBulkAssign() {
-    if (selectedIds.size > 0 && assignTarget) {
-      reassignIssues([...selectedIds], assignTarget);
-      setSelectedIds(new Set());
-    }
+  if (isError) {
+    return (
+      <div className="lint-page lint-page--error">
+        <StateDot state="failed" />
+        <span>{error instanceof Error ? error.message : 'lint load failed'}</span>
+      </div>
+    );
   }
 
   return (
     <div className="lint-page">
-      <h2 className="lint-page__title">Lint</h2>
-
-      {isLoading && (
-        <div className="lint-page__status">
-          <StateDot state="processing" pulse />
-          <span>loading lint report…</span>
+      {/* ── KPI strip ───────────────────────────────────────────── */}
+      <div className="lint-page__kpi-strip">
+        <div className="lint-page__kpi lint-page__kpi--warn">
+          <span className="lint-page__kpi-lbl">total issues</span>
+          <span className="lint-page__kpi-val">{totalLint}</span>
         </div>
-      )}
-
-      {isError && (
-        <div className="lint-page__status">
-          <StateDot state="failed" />
-          <span>{error instanceof Error ? error.message : 'lint load failed'}</span>
+        <div className="lint-page__kpi">
+          <span className="lint-page__kpi-lbl">errors</span>
+          <span
+            className={`lint-page__kpi-val${summary.error > 0 ? ' lint-page__kpi-val--err' : ''}`}
+          >
+            {summary.error}
+          </span>
         </div>
-      )}
+        <div className="lint-page__kpi">
+          <span className="lint-page__kpi-lbl">warnings</span>
+          <span className="lint-page__kpi-val lint-page__kpi-val--warn">{summary.warn}</span>
+        </div>
+        <div className="lint-page__kpi lint-page__kpi--accent">
+          <span className="lint-page__kpi-lbl">auto-fixable</span>
+          <span className="lint-page__kpi-val">{autoFixableIds.length}</span>
+        </div>
+      </div>
 
-      {!isLoading && !isError && (
-        <>
-          <div className="lint-page__header">
-            <LintBadge summary={summary} />
-            {autoFixableIds.length > 0 && (
+      {/* ── 2-column layout ─────────────────────────────────────── */}
+      <div className="lint-page__wrap">
+        {/* LEFT: checks sidebar */}
+        <aside className="lint-page__sidebar" aria-label="Lint checks">
+          <h4 className="lint-page__sidebar-title">Lint checks</h4>
+          <button
+            type="button"
+            className={`lint-page__check-row${selectedRule === null ? ' lint-page__check-row--active' : ''}`}
+            onClick={() => setSelectedRule(null)}
+            aria-pressed={selectedRule === null}
+          >
+            <span className="lint-page__check-id">All</span>
+            <span className="lint-page__check-name">every issue</span>
+            <span className="lint-page__check-count">{totalLint}</span>
+          </button>
+          {rules.map((rule) => {
+            const count = countByRule[rule] ?? 0;
+            const sev: IssueSeverity = summary.error > 0 && rule === 'L01' ? 'error' : 'warn';
+            return (
               <button
-                className="lint-page__btn lint-page__btn--fix"
-                onClick={() => runAutoFix()}
-                disabled={isFixing}
-                aria-label="Fix all auto-fixable issues"
-                data-testid="fix-all-btn"
+                key={rule}
+                type="button"
+                className={`lint-page__check-row${selectedRule === rule ? ' lint-page__check-row--active' : ''}`}
+                onClick={() => setSelectedRule(selectedRule === rule ? null : rule)}
+                aria-pressed={selectedRule === rule}
+                data-testid="check-row"
               >
-                {isFixing ? 'fixing…' : `Fix all auto-fixable (${autoFixableIds.length})`}
+                <div className="lint-page__check-id-cell">
+                  <StateDot state={SEVERITY_DOT[sev]} size={6} />
+                  <span className="lint-page__check-id">{rule}</span>
+                </div>
+                <div className="lint-page__check-desc-cell">
+                  <span className="lint-page__check-name">{RULE_DESCRIPTIONS[rule]}</span>
+                </div>
+                <span
+                  className={`lint-page__check-count${count === 0 ? ' lint-page__check-count--zero' : ''}`}
+                >
+                  {count}
+                </span>
               </button>
-            )}
-          </div>
+            );
+          })}
+        </aside>
 
-          <SeverityFilter active={severityFilter} onChange={setSeverityFilter} />
-
-          {/* Bulk actions bar */}
-          {selectedIds.size > 0 && (
-            <div className="lint-page__bulk-bar" data-testid="bulk-bar">
-              <span className="lint-page__bulk-count">{selectedIds.size} selected</span>
-              <button
-                className="lint-page__btn"
-                onClick={handleBulkFix}
-                disabled={isFixing}
-                aria-label="Fix selected issues"
-                data-testid="bulk-fix-btn"
-              >
-                Fix selected
-              </button>
-              <select
-                className="lint-page__assignee-select"
-                value={assignTarget}
-                onChange={(e) => setAssignTarget(e.target.value)}
-                aria-label="Assign to ravn"
-                data-testid="assignee-select"
-              >
-                <option value="">Assign to…</option>
-                {ravnIds.map((r) => (
-                  <option key={r} value={r}>
-                    {r}
-                  </option>
-                ))}
-              </select>
-              <button
-                className="lint-page__btn"
-                onClick={handleBulkAssign}
-                disabled={!assignTarget || isReassigning}
-                aria-label="Apply assignment"
-                data-testid="bulk-assign-btn"
-              >
-                {isReassigning ? 'assigning…' : 'Assign'}
-              </button>
+        {/* RIGHT: issues list */}
+        <div className="lint-page__issues-panel">
+          <div className="lint-page__issues-header">
+            <div>
+              <LintBadge summary={summary} />
+              <span className="lint-page__issues-rule-label">
+                {selectedRule
+                  ? `${selectedRule} — ${RULE_DESCRIPTIONS[selectedRule]}`
+                  : 'All lint issues'}
+              </span>
+              <span className="lint-page__issues-count">· {filtered.length}</span>
             </div>
-          )}
+            <div className="lint-page__issues-actions">
+              <button
+                type="button"
+                className="lint-page__btn"
+                aria-label="Run lint"
+              >
+                Run lint
+              </button>
+              {autoFixableIds.length > 0 && (
+                <button
+                  type="button"
+                  className="lint-page__btn lint-page__btn--fix"
+                  onClick={() => runAutoFix()}
+                  disabled={isFixing}
+                  aria-label="Fix all auto-fixable issues"
+                  data-testid="fix-all-btn"
+                >
+                  {isFixing ? 'fixing…' : `Auto-fix (${autoFixableIds.length})`}
+                </button>
+              )}
+            </div>
+          </div>
 
           {filtered.length === 0 && (
             <p className="lint-page__empty">
-              {severityFilter ? `No ${severityFilter} issues found.` : 'No issues found. ✓'}
+              {selectedRule ? `No issues for ${selectedRule}.` : 'No issues found. ✓'}
             </p>
           )}
 
-          {filtered.length > 0 && (
-            <>
-              <div className="lint-page__select-all">
-                <input
-                  type="checkbox"
-                  checked={selectedIds.size === filtered.length && filtered.length > 0}
-                  onChange={toggleSelectAll}
-                  aria-label="Select all visible issues"
-                  data-testid="select-all-checkbox"
-                />
-                <span className="lint-page__select-all-label">
-                  {filtered.length} {filtered.length === 1 ? 'issue' : 'issues'}
-                </span>
-              </div>
-
-              <ul className="lint-page__issues" aria-label="Lint issues">
-                {filtered.map((issue) => (
-                  <IssueRow
-                    key={issue.id}
-                    issue={issue}
-                    selected={selectedIds.has(issue.id)}
-                    onToggle={() => toggleSelect(issue.id)}
-                    onAutoFix={() => runAutoFix([issue.id])}
-                    isFixing={isFixing}
-                  />
-                ))}
-              </ul>
-            </>
-          )}
-        </>
-      )}
+          <ul className="lint-page__list" aria-label="Lint issues">
+            {filtered.map((issue, i) => (
+              <li
+                key={`${issue.rule}-${i}`}
+                className={`lint-page__issue lint-page__issue--${issue.severity}`}
+                data-testid="lint-issue"
+              >
+                <div className="lint-page__issue-id-cell">
+                  <code className="lint-page__issue-rule">{issue.rule}</code>
+                  <StateDot state={SEVERITY_DOT[issue.severity]} size={6} />
+                </div>
+                <div className="lint-page__issue-body">
+                  <div className="lint-page__issue-page">{issue.page}</div>
+                  <div className="lint-page__issue-message">{issue.message}</div>
+                </div>
+                <div className="lint-page__issue-actions">
+                  {issue.autoFix && (
+                    <button
+                      type="button"
+                      className="lint-page__btn"
+                      onClick={() => runAutoFix([issue.id])}
+                      disabled={isFixing}
+                      aria-label={`Auto-fix issue ${issue.id}`}
+                      data-testid="autofix-btn"
+                    >
+                      {isFixing ? '…' : 'Fix'}
+                    </button>
+                  )}
+                  <span className="lint-page__issue-mount">{issue.mount}</span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
     </div>
   );
 }

--- a/web-next/packages/plugin-mimir/src/ui/LintPage.tsx
+++ b/web-next/packages/plugin-mimir/src/ui/LintPage.tsx
@@ -40,9 +40,21 @@ export function LintPage() {
 
   const [selectedRule, setSelectedRule] = useState<LintRule | null>(null);
 
-  // Aggregate counts per rule
+  // Aggregate counts and max severity per rule
   const countByRule = issues.reduce<Record<string, number>>((acc, issue) => {
     acc[issue.rule] = (acc[issue.rule] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  const severityByRule = issues.reduce<Record<string, IssueSeverity>>((acc, issue) => {
+    const cur = acc[issue.rule];
+    if (
+      !cur ||
+      (issue.severity === 'error' && cur !== 'error') ||
+      (issue.severity === 'warn' && cur === 'info')
+    ) {
+      acc[issue.rule] = issue.severity;
+    }
     return acc;
   }, {});
 
@@ -112,7 +124,7 @@ export function LintPage() {
           </button>
           {rules.map((rule) => {
             const count = countByRule[rule] ?? 0;
-            const sev: IssueSeverity = summary.error > 0 && rule === 'L01' ? 'error' : 'warn';
+            const sev: IssueSeverity = severityByRule[rule] ?? 'info';
             return (
               <button
                 key={rule}

--- a/web-next/packages/plugin-mimir/src/ui/MimirSubnav.css
+++ b/web-next/packages/plugin-mimir/src/ui/MimirSubnav.css
@@ -1,0 +1,180 @@
+/* ── Subnav shell ──────────────────────────────────────────────────────────── */
+
+.mm-subnav {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  overflow-y: auto;
+  height: 100%;
+  padding: var(--space-2) 0;
+}
+
+.mm-subnav-block {
+  display: flex;
+  flex-direction: column;
+  padding: var(--space-3) 0 var(--space-2);
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.mm-subnav-block:last-child {
+  border-bottom: none;
+}
+
+.mm-subnav-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--color-text-muted);
+  padding: 0 var(--space-4) var(--space-2);
+}
+
+/* ── Mount picker ──────────────────────────────────────────────────────────── */
+
+.mm-mount-picker {
+  display: flex;
+  flex-direction: column;
+}
+
+.mm-mount-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-4);
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.1s;
+  width: 100%;
+}
+
+.mm-mount-row:hover {
+  background: var(--color-bg-tertiary);
+}
+
+.mm-mount-row--active {
+  background: color-mix(in srgb, var(--color-brand, var(--color-accent-cyan)) 10%, transparent);
+}
+
+.mm-mount-row--muted {
+  opacity: 0.5;
+}
+
+.mm-mount-row__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.mm-mount-row__dot--all {
+  background: var(--color-text-muted);
+}
+
+.mm-mount-row__name {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.mm-mount-row--active .mm-mount-row__name {
+  color: var(--color-text-primary);
+}
+
+.mm-mount-row__role {
+  font-size: 10px;
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+  flex-shrink: 0;
+}
+
+.mm-mount-row__count {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+}
+
+/* ── Nav buttons ───────────────────────────────────────────────────────────── */
+
+.mm-subnav-btn {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-4);
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  transition: background 0.1s;
+  border-radius: 0;
+}
+
+.mm-subnav-btn:hover {
+  background: var(--color-bg-tertiary);
+}
+
+.mm-subnav-btn--active {
+  background: color-mix(in srgb, var(--color-brand, var(--color-accent-cyan)) 10%, transparent);
+}
+
+.mm-subnav-btn__glyph {
+  width: 16px;
+  text-align: center;
+  font-size: 12px;
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+}
+
+.mm-subnav-btn__glyph--err {
+  color: var(--color-critical, var(--color-accent-red));
+}
+
+.mm-subnav-btn__glyph--dim {
+  color: var(--color-text-muted);
+}
+
+.mm-subnav-btn__label {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  flex: 1;
+}
+
+.mm-subnav-btn--active .mm-subnav-btn__label {
+  color: var(--color-text-primary);
+}
+
+.mm-subnav-btn__count {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--color-text-muted);
+  padding: 1px 5px;
+  border-radius: var(--radius-full);
+  background: var(--color-bg-tertiary);
+  flex-shrink: 0;
+}
+
+.mm-subnav-btn__count--red {
+  color: var(--color-critical, var(--color-accent-red));
+  background: color-mix(in srgb, var(--color-critical, var(--color-accent-red)) 12%, transparent);
+}
+
+.mm-subnav-btn__initials {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border-subtle);
+  font-size: 10px;
+  font-family: var(--font-mono);
+  color: var(--color-text-secondary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  text-transform: uppercase;
+}

--- a/web-next/packages/plugin-mimir/src/ui/MimirSubnav.css
+++ b/web-next/packages/plugin-mimir/src/ui/MimirSubnav.css
@@ -134,6 +134,10 @@
   color: var(--color-critical, var(--color-accent-red));
 }
 
+.mm-subnav-btn__glyph--warn {
+  color: var(--color-accent-amber);
+}
+
 .mm-subnav-btn__glyph--dim {
   color: var(--color-text-muted);
 }

--- a/web-next/packages/plugin-mimir/src/ui/MimirSubnav.test.tsx
+++ b/web-next/packages/plugin-mimir/src/ui/MimirSubnav.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor, fireEvent } from '@testing-library/react';
+import { MimirSubnav } from './MimirSubnav';
+import { renderWithMimir } from '../testing/renderWithMimir';
+import type { PluginCtx } from '@niuulabs/plugin-sdk';
+
+// Mock TanStack Router hooks — subnav uses useNavigate + useLocation
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+  useLocation: () => ({ pathname: '/mimir' }),
+}));
+
+const mockCtx: PluginCtx = {
+  tweaks: {},
+  setTweak: vi.fn(),
+};
+
+const wrap = (ctx = mockCtx) => renderWithMimir(<MimirSubnav ctx={ctx} />);
+
+describe('MimirSubnav', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the navigation label', () => {
+    wrap();
+    expect(screen.getByText('Navigation')).toBeInTheDocument();
+  });
+
+  it('renders the mount focus section', () => {
+    wrap();
+    expect(screen.getByText('Mount focus')).toBeInTheDocument();
+  });
+
+  it('renders "All mounts" button', () => {
+    wrap();
+    expect(screen.getByText('All mounts')).toBeInTheDocument();
+  });
+
+  it('renders all nav items: Overview, Pages, Search, etc.', () => {
+    wrap();
+    expect(screen.getByText('Overview')).toBeInTheDocument();
+    expect(screen.getByText('Pages')).toBeInTheDocument();
+    expect(screen.getByText('Search')).toBeInTheDocument();
+    expect(screen.getByText('Graph')).toBeInTheDocument();
+    expect(screen.getByText('Wardens')).toBeInTheDocument();
+    expect(screen.getByText('Routing')).toBeInTheDocument();
+    expect(screen.getByText('Lint')).toBeInTheDocument();
+    expect(screen.getByText('Dreams')).toBeInTheDocument();
+  });
+
+  it('renders quick filters section', () => {
+    wrap();
+    expect(screen.getByText('Quick filters')).toBeInTheDocument();
+    expect(screen.getByText('Errors')).toBeInTheDocument();
+    expect(screen.getByText('Low confidence')).toBeInTheDocument();
+  });
+
+  it('renders per-mount rows after data loads', async () => {
+    wrap();
+    // Mock data has mounts: local, shared, platform
+    // Both name and role cells show 'local' for the first mount, so use getAllByText
+    await waitFor(() => expect(screen.getAllByText('local').length).toBeGreaterThan(0));
+  });
+
+  it('renders wardens roster when ravns are present', async () => {
+    wrap();
+    await waitFor(() => expect(screen.getByText('Wardens')).toBeInTheDocument());
+    // ravns from mock: ravn-fjolnir, ravn-skald
+    await waitFor(() => expect(screen.getByText('ravn-fjolnir')).toBeInTheDocument());
+  });
+
+  it('clicking "All mounts" calls setTweak with "all"', () => {
+    const setTweak = vi.fn();
+    wrap({ tweaks: {}, setTweak });
+    fireEvent.click(screen.getByText('All mounts'));
+    expect(setTweak).toHaveBeenCalledWith('activeMount', 'all');
+  });
+
+  it('mount row is active when ctx.tweaks.activeMount matches', () => {
+    wrap({ tweaks: { activeMount: 'all' }, setTweak: vi.fn() });
+    const allBtn = screen.getByText('All mounts').closest('button');
+    expect(allBtn).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('Overview nav item is active when pathname is /mimir', () => {
+    wrap();
+    const overviewBtn = screen.getByText('Overview').closest('button');
+    expect(overviewBtn).toHaveAttribute('aria-current', 'page');
+  });
+});

--- a/web-next/packages/plugin-mimir/src/ui/MimirSubnav.tsx
+++ b/web-next/packages/plugin-mimir/src/ui/MimirSubnav.tsx
@@ -4,7 +4,7 @@
  * Sections:
  *   1. Mount picker — "all mounts" + per-mount rows with status dots
  *   2. Navigation items — Overview / Pages / Search / Graph / Wardens / Routing / Lint / Dreams
- *   3. Quick filters — Errors / Low confidence
+ *   3. Quick filters — Errors / Flagged / Low confidence
  *   4. Wardens roster — top-6 ravns with initials + state dot
  */
 
@@ -15,22 +15,8 @@ import { useMimirMounts } from './useMimirMounts';
 import { useMimirPages } from './useMimirPages';
 import { useLint } from '../application/useLint';
 import { useRavns } from '../application/useRavns';
-import type { DotState } from '@niuulabs/ui';
-import type { RavnState } from '../domain/ravn-binding';
-import type { MountStatus } from '@niuulabs/domain';
+import { RAVN_DOT_STATE, MOUNT_DOT_STATE } from './mimir.constants';
 import './MimirSubnav.css';
-
-const RAVN_DOT_STATE: Record<RavnState, DotState> = {
-  active: 'healthy',
-  idle: 'idle',
-  offline: 'failed',
-};
-
-const MOUNT_DOT_STATE: Record<MountStatus, DotState> = {
-  healthy: 'healthy',
-  degraded: 'observing',
-  down: 'failed',
-};
 
 interface NavItem {
   id: string;
@@ -60,6 +46,7 @@ export function MimirSubnav({ ctx }: MimirSubnavProps) {
   const totalPages = pages.length;
   const lintCount = lintSummary.error + lintSummary.warn + lintSummary.info;
   const errorCount = lintSummary.error;
+  const flaggedCount = pages.filter((p) => p.flagged).length;
   const lowConfidenceCount = pages.filter((p) => p.confidence === 'low').length;
 
   const navItems: NavItem[] = [
@@ -162,6 +149,18 @@ export function MimirSubnav({ ctx }: MimirSubnavProps) {
           </span>
           <span className="mm-subnav-btn__label">Errors</span>
           <span className="mm-subnav-btn__count mm-subnav-btn__count--red">{errorCount}</span>
+        </button>
+        <button
+          type="button"
+          className="mm-subnav-btn"
+          onClick={() => navigate({ to: '/mimir/pages' })}
+          aria-label={`${flaggedCount} flagged pages`}
+        >
+          <span className="mm-subnav-btn__glyph mm-subnav-btn__glyph--warn" aria-hidden>
+            ●
+          </span>
+          <span className="mm-subnav-btn__label">Flagged</span>
+          <span className="mm-subnav-btn__count">{flaggedCount}</span>
         </button>
         <button
           type="button"

--- a/web-next/packages/plugin-mimir/src/ui/MimirSubnav.tsx
+++ b/web-next/packages/plugin-mimir/src/ui/MimirSubnav.tsx
@@ -1,0 +1,203 @@
+/**
+ * MimirSubnav — shell subnav slot for the Mímir plugin.
+ *
+ * Sections:
+ *   1. Mount picker — "all mounts" + per-mount rows with status dots
+ *   2. Navigation items — Overview / Pages / Search / Graph / Wardens / Routing / Lint / Dreams
+ *   3. Quick filters — Errors / Low confidence
+ *   4. Wardens roster — top-6 ravns with initials + state dot
+ */
+
+import { useNavigate, useLocation } from '@tanstack/react-router';
+import { StateDot } from '@niuulabs/ui';
+import type { PluginCtx } from '@niuulabs/plugin-sdk';
+import { useMimirMounts } from './useMimirMounts';
+import { useMimirPages } from './useMimirPages';
+import { useLint } from '../application/useLint';
+import { useRavns } from '../application/useRavns';
+import type { DotState } from '@niuulabs/ui';
+import type { RavnState } from '../domain/ravn-binding';
+import type { MountStatus } from '@niuulabs/domain';
+import './MimirSubnav.css';
+
+const RAVN_DOT_STATE: Record<RavnState, DotState> = {
+  active: 'healthy',
+  idle: 'idle',
+  offline: 'failed',
+};
+
+const MOUNT_DOT_STATE: Record<MountStatus, DotState> = {
+  healthy: 'healthy',
+  degraded: 'observing',
+  down: 'failed',
+};
+
+interface NavItem {
+  id: string;
+  label: string;
+  path: string;
+  glyph: string;
+  count?: number | null;
+  countRed?: boolean;
+}
+
+interface MimirSubnavProps {
+  ctx: PluginCtx;
+}
+
+export function MimirSubnav({ ctx }: MimirSubnavProps) {
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+
+  const activeMount = (ctx.tweaks.activeMount as string | undefined) ?? 'all';
+  const setActiveMount = (m: string) => ctx.setTweak('activeMount', m);
+
+  const { data: mounts = [] } = useMimirMounts();
+  const { data: pages = [] } = useMimirPages();
+  const { summary: lintSummary } = useLint();
+  const { data: ravns = [] } = useRavns();
+
+  const totalPages = pages.length;
+  const lintCount = lintSummary.error + lintSummary.warn + lintSummary.info;
+  const errorCount = lintSummary.error;
+  const lowConfidenceCount = pages.filter((p) => p.confidence === 'low').length;
+
+  const navItems: NavItem[] = [
+    { id: 'home', label: 'Overview', glyph: '◎', path: '/mimir' },
+    { id: 'pages', label: 'Pages', glyph: '❑', path: '/mimir/pages', count: totalPages },
+    { id: 'search', label: 'Search', glyph: '⌕', path: '/mimir/search' },
+    { id: 'graph', label: 'Graph', glyph: '⌖', path: '/mimir/graph' },
+    { id: 'ravns', label: 'Wardens', glyph: 'ᚢ', path: '/mimir/ravns', count: ravns.length },
+    { id: 'routing', label: 'Routing', glyph: '↧', path: '/mimir/routing' },
+    {
+      id: 'lint',
+      label: 'Lint',
+      glyph: '⚠',
+      path: '/mimir/lint',
+      count: lintCount,
+      countRed: lintCount > 0,
+    },
+    { id: 'dreams', label: 'Dreams', glyph: '≡', path: '/mimir/dreams' },
+  ];
+
+  return (
+    <nav className="mm-subnav" aria-label="Mímir navigation">
+      {/* ── Mount picker ─────────────────────────────────────────── */}
+      <div className="mm-subnav-block">
+        <div className="mm-subnav-label">Mount focus</div>
+        <div className="mm-mount-picker">
+          <button
+            type="button"
+            className={`mm-mount-row${activeMount === 'all' ? ' mm-mount-row--active' : ''}`}
+            onClick={() => setActiveMount('all')}
+            aria-pressed={activeMount === 'all'}
+          >
+            <span className="mm-mount-row__dot mm-mount-row__dot--all" aria-hidden />
+            <span className="mm-mount-row__name">All mounts</span>
+            <span className="mm-mount-row__count">{mounts.length}</span>
+          </button>
+          {mounts.map((m) => (
+            <button
+              key={m.name}
+              type="button"
+              className={[
+                'mm-mount-row',
+                activeMount === m.name ? 'mm-mount-row--active' : '',
+                m.status === 'down' ? 'mm-mount-row--muted' : '',
+              ]
+                .filter(Boolean)
+                .join(' ')}
+              onClick={() => setActiveMount(m.name)}
+              aria-pressed={activeMount === m.name}
+            >
+              <StateDot state={MOUNT_DOT_STATE[m.status]} size={6} />
+              <span className="mm-mount-row__name">{m.name}</span>
+              <span className="mm-mount-row__role">{m.role}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* ── Navigation items ──────────────────────────────────────── */}
+      <div className="mm-subnav-block">
+        <div className="mm-subnav-label">Navigation</div>
+        {navItems.map((item) => {
+          const isActive =
+            item.path === '/mimir' ? pathname === '/mimir' : pathname.startsWith(item.path);
+          return (
+            <button
+              key={item.id}
+              type="button"
+              className={`mm-subnav-btn${isActive ? ' mm-subnav-btn--active' : ''}`}
+              onClick={() => navigate({ to: item.path })}
+              aria-current={isActive ? 'page' : undefined}
+            >
+              <span className="mm-subnav-btn__glyph" aria-hidden>
+                {item.glyph}
+              </span>
+              <span className="mm-subnav-btn__label">{item.label}</span>
+              {item.count != null && (
+                <span
+                  className={`mm-subnav-btn__count${item.countRed ? ' mm-subnav-btn__count--red' : ''}`}
+                >
+                  {item.count}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* ── Quick filters ─────────────────────────────────────────── */}
+      <div className="mm-subnav-block">
+        <div className="mm-subnav-label">Quick filters</div>
+        <button
+          type="button"
+          className="mm-subnav-btn"
+          onClick={() => navigate({ to: '/mimir/lint' })}
+          aria-label={`${errorCount} lint errors`}
+        >
+          <span className="mm-subnav-btn__glyph mm-subnav-btn__glyph--err" aria-hidden>
+            ●
+          </span>
+          <span className="mm-subnav-btn__label">Errors</span>
+          <span className="mm-subnav-btn__count mm-subnav-btn__count--red">{errorCount}</span>
+        </button>
+        <button
+          type="button"
+          className="mm-subnav-btn"
+          onClick={() => navigate({ to: '/mimir/pages' })}
+          aria-label={`${lowConfidenceCount} low confidence pages`}
+        >
+          <span className="mm-subnav-btn__glyph mm-subnav-btn__glyph--dim" aria-hidden>
+            ◇
+          </span>
+          <span className="mm-subnav-btn__label">Low confidence</span>
+          <span className="mm-subnav-btn__count">{lowConfidenceCount}</span>
+        </button>
+      </div>
+
+      {/* ── Wardens roster ────────────────────────────────────────── */}
+      {ravns.length > 0 && (
+        <div className="mm-subnav-block">
+          <div className="mm-subnav-label">Wardens</div>
+          {ravns.slice(0, 6).map((ravn) => (
+            <button
+              key={ravn.ravnId}
+              type="button"
+              className="mm-subnav-btn"
+              onClick={() => navigate({ to: '/mimir/ravns' })}
+              aria-label={`Warden ${ravn.ravnId}`}
+            >
+              <span className="mm-subnav-btn__initials" aria-hidden>
+                {ravn.ravnId.slice(0, 2)}
+              </span>
+              <span className="mm-subnav-btn__label">{ravn.ravnId}</span>
+              <StateDot state={RAVN_DOT_STATE[ravn.state]} size={6} />
+            </button>
+          ))}
+        </div>
+      )}
+    </nav>
+  );
+}

--- a/web-next/packages/plugin-mimir/src/ui/MimirTopbar.css
+++ b/web-next/packages/plugin-mimir/src/ui/MimirTopbar.css
@@ -1,0 +1,33 @@
+/* ── MimirTopbar stats bar ─────────────────────────────────────────────────── */
+
+.mm-topbar-stats {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  font-size: var(--text-xs);
+}
+
+.mm-topbar-stat {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-1);
+}
+
+.mm-topbar-stat__k {
+  color: var(--color-text-muted);
+}
+
+.mm-topbar-stat__v {
+  color: var(--color-text-primary);
+  font-weight: 600;
+  font-family: var(--font-mono);
+}
+
+.mm-topbar-stat__v--warn {
+  color: var(--color-accent-amber);
+}
+
+.mm-topbar-sep {
+  color: var(--color-border);
+  user-select: none;
+}

--- a/web-next/packages/plugin-mimir/src/ui/MimirTopbar.test.tsx
+++ b/web-next/packages/plugin-mimir/src/ui/MimirTopbar.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { MimirTopbar } from './MimirTopbar';
+import { renderWithMimir } from '../testing/renderWithMimir';
+import { createMimirMockAdapter } from '../adapters/mock';
+import type { IMimirService } from '../ports';
+import type { PluginCtx } from '@niuulabs/plugin-sdk';
+
+const mockCtx: PluginCtx = {
+  tweaks: {},
+  setTweak: vi.fn(),
+};
+
+const wrap = (ctx = mockCtx, service?: IMimirService) =>
+  renderWithMimir(<MimirTopbar ctx={ctx} />, service);
+
+describe('MimirTopbar', () => {
+  it('renders the mount label', () => {
+    wrap();
+    expect(screen.getByText('mount')).toBeInTheDocument();
+  });
+
+  it('shows "all mounts" when activeMount is not set', () => {
+    wrap();
+    expect(screen.getByText('all mounts')).toBeInTheDocument();
+  });
+
+  it('shows the activeMount name when set in tweaks', () => {
+    wrap({ tweaks: { activeMount: 'local' }, setTweak: vi.fn() });
+    expect(screen.getByText('local')).toBeInTheDocument();
+  });
+
+  it('renders page count stat', async () => {
+    wrap();
+    await waitFor(() => expect(screen.getByText('pages')).toBeInTheDocument());
+  });
+
+  it('renders wardens stat label', async () => {
+    wrap();
+    await waitFor(() => expect(screen.getByText('wardens')).toBeInTheDocument());
+  });
+
+  it('renders lint stat label', async () => {
+    wrap();
+    await waitFor(() => expect(screen.getByText('lint')).toBeInTheDocument());
+  });
+
+  it('lint count has warn class when there are issues', async () => {
+    wrap();
+    await waitFor(() => {
+      const lintVal = screen.getByLabelText(/lint issues/);
+      expect(lintVal.className).toContain('--warn');
+    });
+  });
+
+  it('lint count has no warn class when there are zero issues', async () => {
+    const noLint: IMimirService = {
+      ...createMimirMockAdapter(),
+      lint: {
+        ...createMimirMockAdapter().lint,
+        getLintReport: async () => ({
+          issues: [],
+          pagesChecked: 0,
+          summary: { error: 0, warn: 0, info: 0 },
+        }),
+      },
+    };
+    wrap(mockCtx, noLint);
+    await waitFor(() => {
+      const lintVal = screen.getByLabelText(/lint issues/);
+      expect(lintVal.className).not.toContain('--warn');
+    });
+  });
+
+  it('renders the aria label for the stats container', () => {
+    wrap();
+    expect(screen.getByLabelText('Mímir stats')).toBeInTheDocument();
+  });
+});

--- a/web-next/packages/plugin-mimir/src/ui/MimirTopbar.tsx
+++ b/web-next/packages/plugin-mimir/src/ui/MimirTopbar.tsx
@@ -1,0 +1,74 @@
+/**
+ * MimirTopbar — shell topbar-right slot for the Mímir plugin.
+ *
+ * Shows: active mount name · pages count · wardens count · lint count (red if > 0)
+ */
+
+import type { PluginCtx } from '@niuulabs/plugin-sdk';
+import { useMimirMounts } from './useMimirMounts';
+import { useMimirPages } from './useMimirPages';
+import { useLint } from '../application/useLint';
+import { useRavns } from '../application/useRavns';
+import './MimirTopbar.css';
+
+interface MimirTopbarProps {
+  ctx: PluginCtx;
+}
+
+export function MimirTopbar({ ctx }: MimirTopbarProps) {
+  const activeMount = (ctx.tweaks.activeMount as string | undefined) ?? 'all';
+
+  const { data: mounts = [] } = useMimirMounts();
+  const { data: pages = [] } = useMimirPages();
+  const { summary: lintSummary } = useLint();
+  const { data: ravns = [] } = useRavns();
+
+  const mountLabel = activeMount === 'all' ? 'all mounts' : activeMount;
+  const pageCount =
+    activeMount === 'all'
+      ? pages.length
+      : pages.filter((p) => p.mounts.includes(activeMount)).length;
+  const ravnCount =
+    activeMount === 'all'
+      ? ravns.length
+      : ravns.filter((r) => r.mountNames.includes(activeMount)).length;
+  const lintCount = lintSummary.error + lintSummary.warn + lintSummary.info;
+
+  // Suppress unused mounts warning — used in dependency for derived counts above
+  void mounts;
+
+  return (
+    <div className="mm-topbar-stats" aria-label="Mímir stats">
+      <span className="mm-topbar-stat">
+        <span className="mm-topbar-stat__k">mount</span>
+        <strong className="mm-topbar-stat__v">{mountLabel}</strong>
+      </span>
+      <span className="mm-topbar-sep" aria-hidden>
+        ·
+      </span>
+      <span className="mm-topbar-stat">
+        <span className="mm-topbar-stat__k">pages</span>
+        <strong className="mm-topbar-stat__v">{pageCount.toLocaleString()}</strong>
+      </span>
+      <span className="mm-topbar-sep" aria-hidden>
+        ·
+      </span>
+      <span className="mm-topbar-stat">
+        <span className="mm-topbar-stat__k">wardens</span>
+        <strong className="mm-topbar-stat__v">{ravnCount}</strong>
+      </span>
+      <span className="mm-topbar-sep" aria-hidden>
+        ·
+      </span>
+      <span className="mm-topbar-stat">
+        <span className="mm-topbar-stat__k">lint</span>
+        <strong
+          className={`mm-topbar-stat__v${lintCount > 0 ? ' mm-topbar-stat__v--warn' : ''}`}
+          aria-label={`${lintCount} lint issues`}
+        >
+          {lintCount}
+        </strong>
+      </span>
+    </div>
+  );
+}

--- a/web-next/packages/plugin-mimir/src/ui/MimirTopbar.tsx
+++ b/web-next/packages/plugin-mimir/src/ui/MimirTopbar.tsx
@@ -5,7 +5,6 @@
  */
 
 import type { PluginCtx } from '@niuulabs/plugin-sdk';
-import { useMimirMounts } from './useMimirMounts';
 import { useMimirPages } from './useMimirPages';
 import { useLint } from '../application/useLint';
 import { useRavns } from '../application/useRavns';
@@ -18,7 +17,6 @@ interface MimirTopbarProps {
 export function MimirTopbar({ ctx }: MimirTopbarProps) {
   const activeMount = (ctx.tweaks.activeMount as string | undefined) ?? 'all';
 
-  const { data: mounts = [] } = useMimirMounts();
   const { data: pages = [] } = useMimirPages();
   const { summary: lintSummary } = useLint();
   const { data: ravns = [] } = useRavns();
@@ -33,9 +31,6 @@ export function MimirTopbar({ ctx }: MimirTopbarProps) {
       ? ravns.length
       : ravns.filter((r) => r.mountNames.includes(activeMount)).length;
   const lintCount = lintSummary.error + lintSummary.warn + lintSummary.info;
-
-  // Suppress unused mounts warning — used in dependency for derived counts above
-  void mounts;
 
   return (
     <div className="mm-topbar-stats" aria-label="Mímir stats">

--- a/web-next/packages/plugin-mimir/src/ui/OverviewView.tsx
+++ b/web-next/packages/plugin-mimir/src/ui/OverviewView.tsx
@@ -13,26 +13,12 @@ import { useMimirMounts } from './useMimirMounts';
 import { useMimirRecentWrites } from './useMimirSources';
 import { useRavns } from '../application/useRavns';
 import { MountChip } from './components/MountChip';
-import type { DotState } from '@niuulabs/ui';
-import type { RavnState } from '../domain/ravn-binding';
-import type { MountStatus } from '@niuulabs/domain';
+import { RAVN_DOT_STATE, MOUNT_DOT_STATE } from './mimir.constants';
 import './mimir-views.css';
 
 const FEED_LIMIT = 20;
 const TIMESTAMP_HOUR_START = 11;
 const TIMESTAMP_HOUR_END = 16;
-
-const RAVN_DOT_STATE: Record<RavnState, DotState> = {
-  active: 'healthy',
-  idle: 'idle',
-  offline: 'failed',
-};
-
-const MOUNT_DOT_STATE: Record<MountStatus, DotState> = {
-  healthy: 'healthy',
-  degraded: 'observing',
-  down: 'failed',
-};
 
 function formatTimestamp(iso: string): string {
   return iso.slice(TIMESTAMP_HOUR_START, TIMESTAMP_HOUR_END);
@@ -150,7 +136,7 @@ export function OverviewView() {
           {/* Wardens section */}
           {ravns.length > 0 && (
             <>
-              <div className="mm-overview__section-head" style={{ marginTop: 'var(--space-6)' }}>
+              <div className="mm-overview__section-head mm-overview__section-head--wardens">
                 <h3>Wardens</h3>
                 <span className="mm-overview__section-meta">
                   ravns bound here · read / write fan-out

--- a/web-next/packages/plugin-mimir/src/ui/OverviewView.tsx
+++ b/web-next/packages/plugin-mimir/src/ui/OverviewView.tsx
@@ -1,21 +1,38 @@
 /**
  * OverviewView — Mímir landing screen.
  *
- * Shows:
- *   1. KPI strip  — aggregate pages / sources / lint issues / last write
- *   2. Mount grid — one card per mount with health + metrics
- *   3. Activity feed — recent-writes tail (newest first)
+ * Layout (matches web2 home.jsx prototype):
+ *   KPI strip — aggregate pages / sources / wardens / lint / last write
+ *   mm-home-cols (1.2fr 1fr, border-right separator):
+ *     LEFT:  mount cards grid (minmax 300px) + wardens ravn cards
+ *     RIGHT: activity feed (time / kind / mount / message)
  */
 
-import { KpiStrip, KpiCard, StateDot } from '@niuulabs/ui';
+import { KpiStrip, KpiCard, StateDot, RavnAvatar } from '@niuulabs/ui';
 import { useMimirMounts } from './useMimirMounts';
 import { useMimirRecentWrites } from './useMimirSources';
+import { useRavns } from '../application/useRavns';
 import { MountChip } from './components/MountChip';
+import type { DotState } from '@niuulabs/ui';
+import type { RavnState } from '../domain/ravn-binding';
+import type { MountStatus } from '@niuulabs/domain';
 import './mimir-views.css';
 
-const FEED_LIMIT = 12;
+const FEED_LIMIT = 20;
 const TIMESTAMP_HOUR_START = 11;
 const TIMESTAMP_HOUR_END = 16;
+
+const RAVN_DOT_STATE: Record<RavnState, DotState> = {
+  active: 'healthy',
+  idle: 'idle',
+  offline: 'failed',
+};
+
+const MOUNT_DOT_STATE: Record<MountStatus, DotState> = {
+  healthy: 'healthy',
+  degraded: 'observing',
+  down: 'failed',
+};
 
 function formatTimestamp(iso: string): string {
   return iso.slice(TIMESTAMP_HOUR_START, TIMESTAMP_HOUR_END);
@@ -33,6 +50,7 @@ function formatLastWrite(iso: string): string {
 export function OverviewView() {
   const { data: mounts, isLoading: mountsLoading, error: mountsError } = useMimirMounts();
   const { data: feed } = useMimirRecentWrites(FEED_LIMIT);
+  const { data: ravns = [] } = useRavns();
 
   const totalPages = mounts?.reduce((a, m) => a + m.pages, 0) ?? 0;
   const totalSources = mounts?.reduce((a, m) => a + m.sources, 0) ?? 0;
@@ -68,6 +86,7 @@ export function OverviewView() {
       <KpiStrip>
         <KpiCard label="pages" value={totalPages.toLocaleString()} />
         <KpiCard label="sources" value={totalSources.toLocaleString()} deltaLabel="raw ingested" />
+        <KpiCard label="wardens" value={ravns.length} deltaLabel="ravns bound to mounts" />
         <KpiCard
           label="lint issues"
           value={totalLint}
@@ -81,84 +100,128 @@ export function OverviewView() {
         />
       </KpiStrip>
 
-      {/* ── Mount grid ────────────────────────────────────────────── */}
-      <div>
-        <div className="mm-overview__section-head">
-          <h3>Mounts</h3>
-          <span className="mm-overview__section-meta">
-            {mounts?.length ?? 0} instance{(mounts?.length ?? 0) !== 1 ? 's' : ''} connected
-          </span>
-        </div>
-        <div className="mm-mount-grid">
-          {mounts?.map((mount) => (
-            <article key={mount.name} className="mm-mount-card" aria-label={`mount ${mount.name}`}>
-              <div className="mm-mount-card__head">
-                <StateDot
-                  state={
-                    mount.status === 'healthy'
-                      ? 'healthy'
-                      : mount.status === 'degraded'
-                        ? 'observing'
-                        : 'failed'
-                  }
-                />
-                <span className="mm-mount-card__name">{mount.name}</span>
-                <MountChip name={mount.name} role={mount.role} />
-              </div>
-              <div className="mm-mount-card__host">{mount.host}</div>
-              <div className="mm-mount-card__desc">{mount.desc}</div>
-              <div className="mm-mount-card__metrics">
-                <span className="mm-metric">
-                  <strong>{mount.pages}</strong> pages
-                </span>
-                <span className="mm-metric">
-                  <strong>{mount.sources}</strong> sources
-                </span>
-                <span className={`mm-metric${mount.lintIssues > 10 ? ' mm-metric--warn' : ''}`}>
-                  <strong>{mount.lintIssues}</strong> lint
-                </span>
-                <span className="mm-metric">
-                  <strong>{(mount.sizeKb / 1024).toFixed(1)}</strong> MB
-                </span>
-              </div>
-              {mount.categories && (
-                <div className="mm-mount-card__categories">
-                  scope:{' '}
-                  <span className="mm-mount-card__categories-val">
-                    {mount.categories.join(', ')}
+      {/* ── 2-column home layout ──────────────────────────────────── */}
+      <div className="mm-home-cols">
+        {/* LEFT column: mount grid + wardens */}
+        <div className="mm-home-col mm-home-col--left">
+          <div className="mm-overview__section-head">
+            <h3>Mounts</h3>
+            <span className="mm-overview__section-meta">
+              {mounts?.length ?? 0} instance{(mounts?.length ?? 0) !== 1 ? 's' : ''} connected ·
+              click to focus
+            </span>
+          </div>
+          <div className="mm-mount-grid">
+            {mounts?.map((mount) => (
+              <article key={mount.name} className="mm-mount-card" aria-label={`mount ${mount.name}`}>
+                <div className="mm-mount-card__head">
+                  <StateDot state={MOUNT_DOT_STATE[mount.status]} />
+                  <span className="mm-mount-card__name">{mount.name}</span>
+                  <MountChip name={mount.name} role={mount.role} />
+                </div>
+                <div className="mm-mount-card__host">{mount.host}</div>
+                <div className="mm-mount-card__desc">{mount.desc}</div>
+                <div className="mm-mount-card__metrics">
+                  <span className="mm-metric">
+                    <strong>{mount.pages}</strong> pages
+                  </span>
+                  <span className="mm-metric">
+                    <strong>{mount.sources}</strong> sources
+                  </span>
+                  <span className={`mm-metric${mount.lintIssues > 10 ? ' mm-metric--warn' : ''}`}>
+                    <strong>{mount.lintIssues}</strong> lint
+                  </span>
+                  <span className="mm-metric">
+                    <strong>{(mount.sizeKb / 1024).toFixed(1)}</strong> MB
                   </span>
                 </div>
-              )}
-            </article>
-          ))}
-        </div>
-      </div>
-
-      {/* ── Activity feed ────────────────────────────────────────── */}
-      {feed && feed.length > 0 && (
-        <div>
-          <div className="mm-overview__section-head">
-            <h3>Recent writes</h3>
-            <span className="mm-overview__section-meta">all mounts · newest first</span>
-          </div>
-          <div className="mm-feed" aria-label="recent writes feed" role="log">
-            {feed.map((entry) => (
-              <div key={entry.id} className="mm-feed-row">
-                <span className="mm-feed__time">{formatTimestamp(entry.timestamp)}</span>
-                <span className={`mm-feed__kind mm-feed__kind--${entry.kind}`}>{entry.kind}</span>
-                <span>
-                  <MountChip name={entry.mount} />
-                </span>
-                <span className="mm-feed__msg">
-                  <span className="mm-feed__ravn">{entry.ravn}</span>
-                  <span className="mm-feed__sep">{' · '}</span>
-                  {entry.message}
-                </span>
-              </div>
+                {mount.categories && (
+                  <div className="mm-mount-card__categories">
+                    scope:{' '}
+                    <span className="mm-mount-card__categories-val">
+                      {mount.categories.join(', ')}
+                    </span>
+                  </div>
+                )}
+              </article>
             ))}
           </div>
+
+          {/* Wardens section */}
+          {ravns.length > 0 && (
+            <>
+              <div className="mm-overview__section-head" style={{ marginTop: 'var(--space-6)' }}>
+                <h3>Wardens</h3>
+                <span className="mm-overview__section-meta">
+                  ravns bound here · read / write fan-out
+                </span>
+              </div>
+              <div className="mm-ravn-grid">
+                {ravns.map((ravn) => (
+                  <div key={ravn.ravnId} className="mm-ravn-card">
+                    <div className="mm-ravn-card__head">
+                      <RavnAvatar
+                        role={ravn.role}
+                        rune={ravn.ravnRune}
+                        state={RAVN_DOT_STATE[ravn.state]}
+                        size={32}
+                      />
+                      <div className="mm-ravn-card__identity">
+                        <div className="mm-ravn-card__name-row">
+                          <span className="mm-ravn-card__name">{ravn.ravnId}</span>
+                          <StateDot state={RAVN_DOT_STATE[ravn.state]} size={6} />
+                        </div>
+                        <div className="mm-ravn-card__role">{ravn.role}</div>
+                      </div>
+                    </div>
+                    <div className="mm-ravn-card__mounts">
+                      {ravn.mountNames.map((m) => (
+                        <span
+                          key={m}
+                          className={`mm-ravn-card__bind-chip${m === ravn.writeMount ? ' mm-ravn-card__bind-chip--write' : ''}`}
+                        >
+                          {m}
+                          {m === ravn.writeMount && (
+                            <span className="mm-ravn-card__bind-mode">write</span>
+                          )}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
         </div>
-      )}
+
+        {/* RIGHT column: activity feed */}
+        <div className="mm-home-col mm-home-col--right">
+          <div className="mm-overview__section-head">
+            <h3>Activity</h3>
+            <span className="mm-overview__section-meta">all mounts · newest first</span>
+          </div>
+          {feed && feed.length > 0 ? (
+            <div className="mm-feed" aria-label="recent writes feed" role="log">
+              {feed.map((entry) => (
+                <div key={entry.id} className="mm-feed-row">
+                  <span className="mm-feed__time">{formatTimestamp(entry.timestamp)}</span>
+                  <span className={`mm-feed__kind mm-feed__kind--${entry.kind}`}>{entry.kind}</span>
+                  <span>
+                    <MountChip name={entry.mount} />
+                  </span>
+                  <span className="mm-feed__msg">
+                    <span className="mm-feed__ravn">{entry.ravn}</span>
+                    <span className="mm-feed__sep">{' · '}</span>
+                    {entry.message}
+                  </span>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="mm-overview__empty">No recent activity.</p>
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/web-next/packages/plugin-mimir/src/ui/RavnsPage.css
+++ b/web-next/packages/plugin-mimir/src/ui/RavnsPage.css
@@ -1,6 +1,7 @@
+/* ── RavnsPage shell ───────────────────────────────────────────────────────── */
+
 .ravns-page {
   padding: var(--space-6);
-  max-width: 960px;
 }
 
 .ravns-page__title {
@@ -26,14 +27,17 @@
   font-size: var(--text-sm);
 }
 
-.ravns-page__list {
-  list-style: none;
-  padding: 0;
+/* ── Directory grid ────────────────────────────────────────────────────────── */
+
+.ravn-directory {
   display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
   gap: var(--space-4);
 }
 
-.ravns-page__item {
+/* ── Ravn card ─────────────────────────────────────────────────────────────── */
+
+.ravn-card {
   padding: var(--space-4);
   border: 1px solid var(--color-border-subtle);
   border-radius: var(--radius-lg);
@@ -41,126 +45,230 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
+  cursor: pointer;
+  transition: border-color 0.15s;
 }
 
-.ravns-page__item-header {
+.ravn-card:hover {
+  border-color: var(--color-border);
+}
+
+.ravn-card:focus-visible {
+  outline: 2px solid var(--color-brand, var(--color-accent-cyan));
+  outline-offset: 2px;
+}
+
+.ravn-card__head {
   display: flex;
   align-items: center;
   gap: var(--space-3);
 }
 
-.ravns-page__item-identity {
+.ravn-card__identity {
   flex: 1;
+  min-width: 0;
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  min-width: 0;
 }
 
-.ravns-page__item-id {
+.ravn-card__name {
   font-family: var(--font-mono);
   font-size: var(--text-sm);
-  font-weight: 500;
-  white-space: nowrap;
+  font-weight: 600;
+  color: var(--color-text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.ravns-page__item-role {
-  flex-shrink: 0;
-}
-
-.ravns-page__item-state {
+.ravn-card__state {
   font-size: var(--text-xs);
   font-family: var(--font-mono);
-  padding: var(--space-1) var(--space-2);
+  padding: 1px var(--space-2);
   border-radius: var(--radius-sm);
   flex-shrink: 0;
 }
 
-.ravns-page__item-state--active {
+.ravn-card__state--active {
   color: var(--color-accent-emerald);
   background: color-mix(in srgb, var(--color-accent-emerald) 15%, transparent);
 }
 
-.ravns-page__item-state--idle {
+.ravn-card__state--idle {
   color: var(--color-text-muted);
   background: color-mix(in srgb, var(--color-text-muted) 10%, transparent);
 }
 
-.ravns-page__item-state--offline {
-  color: var(--color-critical);
-  background: color-mix(in srgb, var(--color-critical) 15%, transparent);
+.ravn-card__state--offline {
+  color: var(--color-critical, var(--color-accent-red));
+  background: color-mix(in srgb, var(--color-critical, var(--color-accent-red)) 15%, transparent);
 }
 
-.ravns-page__mounts {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  flex-wrap: wrap;
-}
-
-.ravns-page__mounts-label {
-  font-size: var(--text-xs);
-  color: var(--color-text-muted);
-  min-width: 3.5rem;
-}
-
-.ravns-page__mounts-list {
+.ravn-card__role-row {
   display: flex;
   gap: var(--space-1);
-  flex-wrap: wrap;
 }
 
-.ravns-page__dream {
+.ravn-card__mounts {
   display: flex;
-  align-items: flex-start;
-  gap: var(--space-3);
   flex-wrap: wrap;
+  gap: var(--space-1);
+}
+
+.ravn-card__dream {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
   padding-top: var(--space-2);
   border-top: 1px solid var(--color-border-subtle);
   font-size: var(--text-xs);
 }
 
-.ravns-page__dream-label {
-  color: var(--color-text-muted);
-  min-width: 4.5rem;
-  padding-top: 2px;
-}
-
-.ravns-page__dream-time {
-  color: var(--color-text-secondary);
+.ravn-card__dream-time {
   font-family: var(--font-mono);
-  padding-top: 2px;
+  color: var(--color-text-muted);
 }
 
-.ravns-page__dream-stats {
-  display: flex;
-  gap: var(--space-3);
-  flex-wrap: wrap;
-  flex: 1;
-}
-
-.ravns-page__dream-stat {
+.ravn-card__dream-stat {
   color: var(--color-text-secondary);
 }
 
-.ravns-page__dream-stat strong {
+.ravn-card__dream-stat strong {
+  color: var(--color-text-primary);
+}
+
+.ravn-card__dream--none {
+  color: var(--color-text-muted);
+  font-style: italic;
+}
+
+/* ── Profile view ──────────────────────────────────────────────────────────── */
+
+.ravn-profile {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+}
+
+.ravn-profile__back {
+  align-self: flex-start;
+  background: none;
+  border: none;
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  cursor: pointer;
+  padding: 0;
+  margin-bottom: var(--space-2);
+}
+
+.ravn-profile__back:hover {
+  color: var(--color-text-secondary);
+}
+
+.ravn-profile__hero {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-4);
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-lg);
+}
+
+.ravn-profile__hero-info {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.ravn-profile__name {
+  margin: 0;
+  font-size: var(--text-xl);
+  font-family: var(--font-mono);
+}
+
+.ravn-profile__hero-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.ravn-profile__grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-4);
+}
+
+.ravn-profile__section {
+  padding: var(--space-4);
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-lg);
+}
+
+.ravn-profile__section-title {
+  margin: 0 0 var(--space-3);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--color-text-muted);
+}
+
+.ravn-profile__mount-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.ravn-profile__mount-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.ravn-profile__mount-mode {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+.ravn-profile__stats {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.ravn-profile__stat {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 3px 0;
+  border-bottom: 1px solid var(--color-border-subtle);
+  font-size: var(--text-xs);
+}
+
+.ravn-profile__stat:last-child {
+  border-bottom: none;
+}
+
+.ravn-profile__stat-lbl {
+  color: var(--color-text-muted);
+}
+
+.ravn-profile__stat-val {
   color: var(--color-text-primary);
   font-weight: 600;
 }
 
-.ravns-page__dream-stat--duration {
-  color: var(--color-text-muted);
+.ravn-profile__stat-val--mono {
   font-family: var(--font-mono);
-  margin-left: auto;
+  font-weight: 400;
+  color: var(--color-text-secondary);
 }
 
-.ravns-page__dream--none {
-  color: var(--color-text-muted);
-}
-
-.ravns-page__dream-none-text {
+.ravn-profile__no-dream {
+  font-size: var(--text-sm);
   color: var(--color-text-muted);
   font-style: italic;
+  margin: 0;
 }

--- a/web-next/packages/plugin-mimir/src/ui/RavnsPage.test.tsx
+++ b/web-next/packages/plugin-mimir/src/ui/RavnsPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, fireEvent } from '@testing-library/react';
 import { RavnsPage } from './RavnsPage';
 import { createMimirMockAdapter } from '../adapters/mock';
 import type { IMimirService } from '../ports';
@@ -41,7 +41,6 @@ describe('RavnsPage', () => {
   it('shows dream stats for ravns that have dream cycles', async () => {
     wrap(<RavnsPage />);
     await waitFor(() => expect(screen.getAllByTestId('ravn-dream').length).toBeGreaterThan(0));
-    // First ravn has dream cycle — verify stats
     const dream = screen.getAllByTestId('ravn-dream')[0]!;
     expect(dream).toBeInTheDocument();
   });
@@ -54,8 +53,34 @@ describe('RavnsPage', () => {
   it('shows mount chips for each ravn', async () => {
     wrap(<RavnsPage />);
     await waitFor(() => expect(screen.getAllByTestId('ravn-item').length).toBeGreaterThan(0));
-    // 'local' mount should be visible
     expect(screen.getAllByText(/local/).length).toBeGreaterThan(0);
+  });
+
+  it('clicking a ravn card shows the profile view', async () => {
+    wrap(<RavnsPage />);
+    await waitFor(() => expect(screen.getAllByTestId('ravn-item').length).toBeGreaterThan(0));
+    fireEvent.click(screen.getAllByTestId('ravn-item')[0]!);
+    await waitFor(() => expect(screen.getByTestId('ravn-profile')).toBeInTheDocument());
+  });
+
+  it('profile view shows a back button that returns to directory', async () => {
+    wrap(<RavnsPage />);
+    await waitFor(() => expect(screen.getAllByTestId('ravn-item').length).toBeGreaterThan(0));
+    fireEvent.click(screen.getAllByTestId('ravn-item')[0]!);
+    await waitFor(() => screen.getByTestId('ravn-profile'));
+    fireEvent.click(screen.getByRole('button', { name: /back to wardens/i }));
+    await waitFor(() =>
+      expect(screen.getAllByTestId('ravn-item').length).toBeGreaterThan(0),
+    );
+  });
+
+  it('profile view shows dream stats for selected ravn', async () => {
+    wrap(<RavnsPage />);
+    await waitFor(() => expect(screen.getAllByTestId('ravn-item').length).toBeGreaterThan(0));
+    // Find a ravn with dream stats (first one from mock has a dream cycle)
+    fireEvent.click(screen.getAllByTestId('ravn-item')[0]!);
+    await waitFor(() => screen.getByTestId('ravn-profile'));
+    expect(screen.getByTestId('ravn-dream')).toBeInTheDocument();
   });
 
   it('shows error state when service throws', async () => {

--- a/web-next/packages/plugin-mimir/src/ui/RavnsPage.tsx
+++ b/web-next/packages/plugin-mimir/src/ui/RavnsPage.tsx
@@ -1,16 +1,10 @@
 import { useState } from 'react';
 import { StateDot, Chip, RavnAvatar } from '@niuulabs/ui';
 import { useRavns } from '../application/useRavns';
-import type { RavnBinding, RavnState } from '../domain/ravn-binding';
-import type { DotState } from '@niuulabs/ui';
+import type { RavnBinding } from '../domain/ravn-binding';
+import { RAVN_DOT_STATE } from './mimir.constants';
 import { formatDuration, formatTimestamp } from './format';
 import './RavnsPage.css';
-
-const STATE_DOT: Record<RavnState, DotState> = {
-  active: 'healthy',
-  idle: 'idle',
-  offline: 'failed',
-};
 
 // ---------------------------------------------------------------------------
 // Directory card
@@ -38,7 +32,7 @@ function RavnCard({ ravn, onClick }: RavnCardProps) {
         <RavnAvatar
           role={ravn.role}
           rune={ravn.ravnRune}
-          state={STATE_DOT[ravn.state]}
+          state={RAVN_DOT_STATE[ravn.state]}
           pulse={ravn.state === 'active'}
           size={36}
         />
@@ -110,7 +104,7 @@ function RavnProfile({ ravn, onBack }: RavnProfileProps) {
         <RavnAvatar
           role={ravn.role}
           rune={ravn.ravnRune}
-          state={STATE_DOT[ravn.state]}
+          state={RAVN_DOT_STATE[ravn.state]}
           pulse={ravn.state === 'active'}
           size={48}
         />

--- a/web-next/packages/plugin-mimir/src/ui/RavnsPage.tsx
+++ b/web-next/packages/plugin-mimir/src/ui/RavnsPage.tsx
@@ -1,6 +1,7 @@
+import { useState } from 'react';
 import { StateDot, Chip, RavnAvatar } from '@niuulabs/ui';
 import { useRavns } from '../application/useRavns';
-import type { RavnState } from '../domain/ravn-binding';
+import type { RavnBinding, RavnState } from '../domain/ravn-binding';
 import type { DotState } from '@niuulabs/ui';
 import { formatDuration, formatTimestamp } from './format';
 import './RavnsPage.css';
@@ -11,8 +12,201 @@ const STATE_DOT: Record<RavnState, DotState> = {
   offline: 'failed',
 };
 
+// ---------------------------------------------------------------------------
+// Directory card
+// ---------------------------------------------------------------------------
+
+interface RavnCardProps {
+  ravn: RavnBinding;
+  onClick: () => void;
+}
+
+function RavnCard({ ravn, onClick }: RavnCardProps) {
+  return (
+    <article
+      className="ravn-card"
+      onClick={onClick}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') onClick();
+      }}
+      data-testid="ravn-item"
+      aria-label={`Warden ${ravn.ravnId}`}
+    >
+      <div className="ravn-card__head">
+        <RavnAvatar
+          role={ravn.role}
+          rune={ravn.ravnRune}
+          state={STATE_DOT[ravn.state]}
+          pulse={ravn.state === 'active'}
+          size={36}
+        />
+        <div className="ravn-card__identity">
+          <span className="ravn-card__name">{ravn.ravnId}</span>
+          <span
+            className={`ravn-card__state ravn-card__state--${ravn.state}`}
+            data-testid="ravn-state"
+          >
+            {ravn.state}
+          </span>
+        </div>
+      </div>
+
+      <div className="ravn-card__role-row">
+        <Chip tone="muted">{ravn.role}</Chip>
+      </div>
+
+      <div className="ravn-card__mounts">
+        {ravn.mountNames.map((m) => (
+          <Chip key={m} tone={m === ravn.writeMount ? 'brand' : 'muted'}>
+            {m === ravn.writeMount ? `✎ ${m}` : m}
+          </Chip>
+        ))}
+      </div>
+
+      {ravn.lastDream ? (
+        <div className="ravn-card__dream" data-testid="ravn-dream">
+          <span className="ravn-card__dream-time">
+            {formatTimestamp(ravn.lastDream.timestamp)}
+          </span>
+          <span className="ravn-card__dream-stat">
+            <strong>{ravn.lastDream.pagesUpdated}</strong> pages ·{' '}
+            <strong>{ravn.lastDream.entitiesCreated}</strong> entities ·{' '}
+            {formatDuration(ravn.lastDream.durationMs)}
+          </span>
+        </div>
+      ) : (
+        <div className="ravn-card__dream ravn-card__dream--none" data-testid="ravn-no-dream">
+          no dream cycles yet
+        </div>
+      )}
+    </article>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Profile view
+// ---------------------------------------------------------------------------
+
+interface RavnProfileProps {
+  ravn: RavnBinding;
+  onBack: () => void;
+}
+
+function RavnProfile({ ravn, onBack }: RavnProfileProps) {
+  return (
+    <div className="ravn-profile" data-testid="ravn-profile">
+      <button
+        type="button"
+        className="ravn-profile__back"
+        onClick={onBack}
+        aria-label="Back to wardens list"
+      >
+        ← Wardens
+      </button>
+
+      <div className="ravn-profile__hero">
+        <RavnAvatar
+          role={ravn.role}
+          rune={ravn.ravnRune}
+          state={STATE_DOT[ravn.state]}
+          pulse={ravn.state === 'active'}
+          size={48}
+        />
+        <div className="ravn-profile__hero-info">
+          <h2 className="ravn-profile__name">{ravn.ravnId}</h2>
+          <div className="ravn-profile__hero-row">
+            <Chip tone="muted">{ravn.role}</Chip>
+            <span
+              className={`ravn-card__state ravn-card__state--${ravn.state}`}
+              data-testid="ravn-state"
+            >
+              {ravn.state}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="ravn-profile__grid">
+        {/* Mount bindings */}
+        <section className="ravn-profile__section">
+          <h4 className="ravn-profile__section-title">Mount bindings</h4>
+          <div className="ravn-profile__mount-list">
+            {ravn.mountNames.map((m) => (
+              <div key={m} className="ravn-profile__mount-row">
+                <Chip tone={m === ravn.writeMount ? 'brand' : 'muted'}>
+                  {m === ravn.writeMount ? `✎ ${m}` : m}
+                </Chip>
+                {m === ravn.writeMount && (
+                  <span className="ravn-profile__mount-mode">write mount</span>
+                )}
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Dream stats */}
+        {ravn.lastDream ? (
+          <section className="ravn-profile__section" data-testid="ravn-dream">
+            <h4 className="ravn-profile__section-title">Last dream</h4>
+            <div className="ravn-profile__stats">
+              <div className="ravn-profile__stat">
+                <span className="ravn-profile__stat-lbl">time</span>
+                <span className="ravn-profile__stat-val">
+                  {formatTimestamp(ravn.lastDream.timestamp)}
+                </span>
+              </div>
+              <div className="ravn-profile__stat">
+                <span className="ravn-profile__stat-lbl">pages updated</span>
+                <strong className="ravn-profile__stat-val">{ravn.lastDream.pagesUpdated}</strong>
+              </div>
+              <div className="ravn-profile__stat">
+                <span className="ravn-profile__stat-lbl">entities created</span>
+                <strong className="ravn-profile__stat-val">
+                  {ravn.lastDream.entitiesCreated}
+                </strong>
+              </div>
+              <div className="ravn-profile__stat">
+                <span className="ravn-profile__stat-lbl">lint fixes</span>
+                <strong className="ravn-profile__stat-val">{ravn.lastDream.lintFixes}</strong>
+              </div>
+              <div className="ravn-profile__stat">
+                <span className="ravn-profile__stat-lbl">duration</span>
+                <span className="ravn-profile__stat-val ravn-profile__stat-val--mono">
+                  {formatDuration(ravn.lastDream.durationMs)}
+                </span>
+              </div>
+            </div>
+          </section>
+        ) : (
+          <section className="ravn-profile__section" data-testid="ravn-no-dream">
+            <h4 className="ravn-profile__section-title">Last dream</h4>
+            <p className="ravn-profile__no-dream">no dream cycles yet</p>
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
 export function RavnsPage() {
   const { data, isLoading, isError, error } = useRavns();
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const selected = selectedId ? (data ?? []).find((r) => r.ravnId === selectedId) : null;
+
+  if (selected) {
+    return (
+      <div className="ravns-page">
+        <RavnProfile ravn={selected} onBack={() => setSelectedId(null)} />
+      </div>
+    );
+  }
 
   return (
     <div className="ravns-page">
@@ -38,78 +232,11 @@ export function RavnsPage() {
       )}
 
       {data && data.length > 0 && (
-        <ul className="ravns-page__list">
+        <div className="ravn-directory">
           {data.map((ravn) => (
-            <li key={ravn.ravnId} className="ravns-page__item" data-testid="ravn-item">
-              <div className="ravns-page__item-header">
-                <RavnAvatar
-                  role={ravn.role}
-                  rune={ravn.ravnRune}
-                  state={STATE_DOT[ravn.state]}
-                  pulse={ravn.state === 'active'}
-                  size={36}
-                />
-                <div className="ravns-page__item-identity">
-                  <span className="ravns-page__item-id">{ravn.ravnId}</span>
-                  <span className="ravns-page__item-role">
-                    <Chip tone="muted">{ravn.role}</Chip>
-                  </span>
-                </div>
-                <span
-                  className={[
-                    'ravns-page__item-state',
-                    `ravns-page__item-state--${ravn.state}`,
-                  ].join(' ')}
-                  data-testid="ravn-state"
-                >
-                  {ravn.state}
-                </span>
-              </div>
-
-              <div className="ravns-page__mounts">
-                <span className="ravns-page__mounts-label">Mounts</span>
-                <div className="ravns-page__mounts-list">
-                  {ravn.mountNames.map((m) => (
-                    <Chip key={m} tone={m === ravn.writeMount ? 'brand' : 'muted'}>
-                      {m === ravn.writeMount ? `✎ ${m}` : m}
-                    </Chip>
-                  ))}
-                </div>
-              </div>
-
-              {ravn.lastDream ? (
-                <div className="ravns-page__dream" data-testid="ravn-dream">
-                  <span className="ravns-page__dream-label">Last dream</span>
-                  <span className="ravns-page__dream-time">
-                    {formatTimestamp(ravn.lastDream.timestamp)}
-                  </span>
-                  <div className="ravns-page__dream-stats">
-                    <span className="ravns-page__dream-stat">
-                      <strong>{ravn.lastDream.pagesUpdated}</strong> pages updated
-                    </span>
-                    <span className="ravns-page__dream-stat">
-                      <strong>{ravn.lastDream.entitiesCreated}</strong> entities created
-                    </span>
-                    <span className="ravns-page__dream-stat">
-                      <strong>{ravn.lastDream.lintFixes}</strong> lint fixes
-                    </span>
-                    <span className="ravns-page__dream-stat ravns-page__dream-stat--duration">
-                      {formatDuration(ravn.lastDream.durationMs)}
-                    </span>
-                  </div>
-                </div>
-              ) : (
-                <div
-                  className="ravns-page__dream ravns-page__dream--none"
-                  data-testid="ravn-no-dream"
-                >
-                  <span className="ravns-page__dream-label">Last dream</span>
-                  <span className="ravns-page__dream-none-text">no dream cycles yet</span>
-                </div>
-              )}
-            </li>
+            <RavnCard key={ravn.ravnId} ravn={ravn} onClick={() => setSelectedId(ravn.ravnId)} />
           ))}
-        </ul>
+        </div>
       )}
     </div>
   );

--- a/web-next/packages/plugin-mimir/src/ui/SearchPage.css
+++ b/web-next/packages/plugin-mimir/src/ui/SearchPage.css
@@ -104,3 +104,13 @@
   font-size: var(--text-xs);
   font-family: var(--font-mono);
 }
+
+/* ── Highlight mark ────────────────────────────────────────────────────────── */
+
+.search-page__highlight {
+  background: color-mix(in srgb, var(--color-accent-amber) 25%, transparent);
+  color: var(--color-accent-amber);
+  border-radius: 2px;
+  padding: 0 1px;
+  font-style: normal;
+}

--- a/web-next/packages/plugin-mimir/src/ui/SearchPage.tsx
+++ b/web-next/packages/plugin-mimir/src/ui/SearchPage.tsx
@@ -11,6 +11,41 @@ const MODE_LABELS: Record<SearchMode, string> = {
   hybrid: 'Hybrid',
 };
 
+// ---------------------------------------------------------------------------
+// Highlight utility
+// ---------------------------------------------------------------------------
+
+function highlightText(text: string, query: string): React.ReactNode {
+  const trimmed = query.trim();
+  if (!trimmed) return text;
+
+  const words = trimmed.split(/\s+/).filter((w) => w.length > 1);
+  if (words.length === 0) return text;
+
+  const escaped = words.map((w) => w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+  const pattern = new RegExp(`(${escaped.join('|')})`, 'gi');
+  const parts = text.split(pattern);
+  if (parts.length <= 1) return text;
+
+  return (
+    <>
+      {parts.map((part, i) =>
+        i % 2 === 1 ? (
+          <mark key={i} className="search-page__highlight">
+            {part}
+          </mark>
+        ) : (
+          part || null
+        ),
+      )}
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SearchPage
+// ---------------------------------------------------------------------------
+
 export function SearchPage() {
   const { query, mode, setQuery, setMode, results, isLoading, isError, error } = useSearch();
 
@@ -71,13 +106,17 @@ export function SearchPage() {
           {results.map((result) => (
             <li key={result.path} className="search-page__result" data-testid="search-result">
               <div className="search-page__result-header">
-                <span className="search-page__result-title">{result.title}</span>
+                <span className="search-page__result-title">
+                  {highlightText(result.title, query)}
+                </span>
                 <Chip tone="muted">{result.category}</Chip>
                 <Chip tone={result.confidence === 'high' ? 'default' : 'muted'}>
                   {result.confidence}
                 </Chip>
               </div>
-              <p className="search-page__result-summary">{result.summary}</p>
+              <p className="search-page__result-summary">
+                {highlightText(result.summary, query)}
+              </p>
               <span className="search-page__result-path">{result.path}</span>
             </li>
           ))}

--- a/web-next/packages/plugin-mimir/src/ui/mimir-views.css
+++ b/web-next/packages/plugin-mimir/src/ui/mimir-views.css
@@ -142,6 +142,9 @@
   font-size: var(--text-xs);
   color: var(--color-text-muted);
 }
+.mm-overview__section-head--wardens {
+  margin-top: var(--space-6);
+}
 .mm-mount-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));

--- a/web-next/packages/plugin-mimir/src/ui/mimir-views.css
+++ b/web-next/packages/plugin-mimir/src/ui/mimir-views.css
@@ -706,6 +706,103 @@
   color: var(--color-accent-purple);
 }
 
+/* ── Overview 2-column home layout ───────────────────────────────────────── */
+.mm-home-cols {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 0;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+.mm-home-col {
+  padding: var(--space-5);
+  overflow: hidden;
+}
+.mm-home-col--left {
+  border-right: 1px solid var(--color-border-subtle);
+  overflow-y: auto;
+}
+.mm-home-col--right {
+  overflow-y: auto;
+}
+.mm-overview__empty {
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  margin: 0;
+}
+
+/* ── Ravn cards in overview ───────────────────────────────────────────────── */
+.mm-ravn-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: var(--space-3);
+}
+.mm-ravn-card {
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-lg);
+  padding: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.mm-ravn-card__head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.mm-ravn-card__identity {
+  flex: 1;
+  min-width: 0;
+}
+.mm-ravn-card__name-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.mm-ravn-card__name {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--color-text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.mm-ravn-card__role {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+.mm-ravn-card__mounts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+}
+.mm-ravn-card__bind-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 1px var(--space-2);
+  border-radius: var(--radius-full);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  background: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border-subtle);
+  color: var(--color-text-secondary);
+}
+.mm-ravn-card__bind-chip--write {
+  background: color-mix(in srgb, var(--color-brand, var(--color-accent-cyan)) 12%, transparent);
+  border-color: color-mix(in srgb, var(--color-brand, var(--color-accent-cyan)) 25%, transparent);
+  color: var(--color-brand, var(--color-accent-cyan));
+}
+.mm-ravn-card__bind-mode {
+  font-size: 9px;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
 /* ── MimirPage shell ──────────────────────────────────────────────────────── */
 .mm-page-shell {
   display: flex;

--- a/web-next/packages/plugin-mimir/src/ui/mimir.constants.ts
+++ b/web-next/packages/plugin-mimir/src/ui/mimir.constants.ts
@@ -1,0 +1,15 @@
+import type { DotState } from '@niuulabs/ui';
+import type { RavnState } from '../domain/ravn-binding';
+import type { MountStatus } from '@niuulabs/domain';
+
+export const RAVN_DOT_STATE: Record<RavnState, DotState> = {
+  active: 'healthy',
+  idle: 'idle',
+  offline: 'failed',
+};
+
+export const MOUNT_DOT_STATE: Record<MountStatus, DotState> = {
+  healthy: 'healthy',
+  degraded: 'observing',
+  down: 'failed',
+};


### PR DESCRIPTION
## Summary

- **MimirSubnav** — new shell subnav slot: mount picker (status dots, muted offline mounts, pages count), nav items (Overview / Pages / Search / Graph / Wardens / Routing / Lint / Dreams with counts), quick filters (Errors + Low confidence), top-6 wardens roster with initials + state dot
- **MimirTopbar** — new shell topbar-right slot: mount label · pages count · wardens count · lint count (red/amber when > 0), wired to `subnav(ctx)` and `topbarRight(ctx)` in `definePlugin()`
- **OverviewView** — `mm-home-cols` 1.2fr/1fr grid with `border-right` separator confirmed; left column: mount card grid `minmax(300px)` + wardens ravn cards; right column: activity feed `58px 60px 66px 1fr` columns
- **LintPage** — `mm-lint-wrap` 220px/1fr layout confirmed: checks sidebar with severity dots + autofix badges + KPI strip (total / errors / warnings / auto-fixable)
- **RavnsPage** — directory grid view + profile hero (large avatar, role chip, state pill, mount bindings, dream stats)
- **SearchPage** — mode toggle (fts / semantic / hybrid), highlighted snippets via `highlightText()`, chip row per result
- **GraphPage** — circular SVG layout with category color palette, legend card, hop controls (1–4), focus-node filter + clear, stats chips (nodes / edges / scope)
- **mimir-views.css** — chip bar (`mm-chip` 10px uppercase bg-secondary text-muted), home-cols, feed rows, zone blocks, wikilink pills all present
- **Bug fix** — `MimirSubnav.test.tsx`: `getByText('local')` ambiguity fixed by using `getAllByText` (mount name and role both render "local" for the first mock mount)

## Test plan

- [x] All 3335 tests pass (255 test files, zero failures)
- [x] Coverage threshold met — 85% statements / branches / functions / lines globally
- [x] `MimirSubnav` — 10 tests: mount picker, nav items, quick filters, wardens roster, setTweak callbacks, aria-pressed / aria-current attributes
- [x] `MimirTopbar` — 9 tests: all-mounts label, per-mount label, page/warden/lint stat labels, warn class when lint > 0, no warn class when lint = 0, aria-label
- [x] Existing `LintPage`, `RavnsPage`, `GraphPage`, `SearchPage`, `OverviewView`, `PagesView`, `SourcesView`, `RoutingPage`, `EntitiesPage`, `DreamsPage`, `MimirPage` test suites all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)