### PR TITLE
feat(observatory): rebuild to match web2 prototype — NIU-689

### DIFF
--- a/web-next/packages/plugin-observatory/src/adapters/mock.test.ts
+++ b/web-next/packages/plugin-observatory/src/adapters/mock.test.ts
@@ -77,7 +77,7 @@ describe('createMockTopologyStream', () => {
     expect(typeIds.has('raid')).toBe(true);
   });
 
-  it('every node has required fields', () => {
+  it('every node has required base fields', () => {
     const stream = createMockTopologyStream();
     const { nodes } = stream.getSnapshot()!;
     for (const node of nodes) {
@@ -86,6 +86,63 @@ describe('createMockTopologyStream', () => {
       expect(node.label).toBeTruthy();
       expect(node.status).toBeTruthy();
     }
+  });
+
+  it('tyr node has kind-specific fields', () => {
+    const stream = createMockTopologyStream();
+    const { nodes } = stream.getSnapshot()!;
+    const tyr = nodes.find((n) => n.typeId === 'tyr');
+    expect(tyr).toBeDefined();
+    expect(tyr!.mode).toBe('active');
+    expect(tyr!.activeSagas).toBeGreaterThanOrEqual(0);
+    expect(tyr!.pendingRaids).toBeGreaterThanOrEqual(0);
+  });
+
+  it('bifrost node has kind-specific fields', () => {
+    const stream = createMockTopologyStream();
+    const { nodes } = stream.getSnapshot()!;
+    const bifrost = nodes.find((n) => n.typeId === 'bifrost');
+    expect(bifrost).toBeDefined();
+    expect(Array.isArray(bifrost!.providers)).toBe(true);
+    expect(typeof bifrost!.reqPerMin).toBe('number');
+    expect(typeof bifrost!.cacheHitRate).toBe('number');
+  });
+
+  it('volundr node has kind-specific fields', () => {
+    const stream = createMockTopologyStream();
+    const { nodes } = stream.getSnapshot()!;
+    const volundr = nodes.find((n) => n.typeId === 'volundr');
+    expect(volundr).toBeDefined();
+    expect(typeof volundr!.activeSessions).toBe('number');
+    expect(typeof volundr!.maxSessions).toBe('number');
+  });
+
+  it('ravn_long node has kind-specific fields', () => {
+    const stream = createMockTopologyStream();
+    const { nodes } = stream.getSnapshot()!;
+    const ravn = nodes.find((n) => n.typeId === 'ravn_long');
+    expect(ravn).toBeDefined();
+    expect(ravn!.persona).toBeTruthy();
+    expect(ravn!.specialty).toBeTruthy();
+    expect(typeof ravn!.tokens).toBe('number');
+  });
+
+  it('host node has kind-specific fields', () => {
+    const stream = createMockTopologyStream();
+    const { nodes } = stream.getSnapshot()!;
+    const host = nodes.find((n) => n.typeId === 'host');
+    expect(host).toBeDefined();
+    expect(host!.hw).toBeTruthy();
+    expect(host!.os).toBeTruthy();
+  });
+
+  it('realm node has vlan and dns fields', () => {
+    const stream = createMockTopologyStream();
+    const { nodes } = stream.getSnapshot()!;
+    const realm = nodes.find((n) => n.typeId === 'realm');
+    expect(realm).toBeDefined();
+    expect(typeof realm!.vlan).toBe('number');
+    expect(realm!.dns).toBeTruthy();
   });
 
   it('subscribe immediately calls listener with current snapshot', () => {
@@ -103,7 +160,6 @@ describe('createMockTopologyStream', () => {
     expect(listener).toHaveBeenCalledOnce();
     unsub();
     // After unsubscribe, listener count should be 0
-    // Subscribing a new listener to confirm the old one is gone
     const listener2 = vi.fn();
     stream.subscribe(listener2);
     expect(listener).toHaveBeenCalledOnce(); // still only once
@@ -120,14 +176,15 @@ describe('createMockEventStream', () => {
     expect(received[0]).toBe('ev-1');
   });
 
-  it('every event has required fields', () => {
+  it('every event has required fields (web2 format)', () => {
     const eventStream = createMockEventStream();
     eventStream.subscribe((ev) => {
       expect(ev.id).toBeTruthy();
-      expect(ev.timestamp).toBeTruthy();
-      expect(ev.sourceId).toBeTruthy();
-      expect(ev.message).toBeTruthy();
-      expect(['debug', 'info', 'warn', 'error']).toContain(ev.severity);
+      expect(ev.time).toBeTruthy();
+      expect(ev.type).toBeTruthy();
+      expect(ev.subject).toBeTruthy();
+      expect(ev.body).toBeTruthy();
+      expect(['RAID', 'RAVN', 'TYR', 'MIMIR', 'BIFROST']).toContain(ev.type);
     });
   });
 
@@ -137,12 +194,12 @@ describe('createMockEventStream', () => {
     expect(() => unsub()).not.toThrow();
   });
 
-  it('includes events of varying severity', () => {
+  it('includes events of varying types', () => {
     const eventStream = createMockEventStream();
-    const severities = new Set<string>();
-    eventStream.subscribe((ev) => severities.add(ev.severity));
-    expect(severities.has('info')).toBe(true);
-    expect(severities.has('warn')).toBe(true);
-    expect(severities.has('debug')).toBe(true);
+    const types = new Set<string>();
+    eventStream.subscribe((ev) => types.add(ev.type));
+    expect(types.has('RAVN')).toBe(true);
+    expect(types.has('BIFROST')).toBe(true);
+    expect(types.has('MIMIR')).toBe(true);
   });
 });

--- a/web-next/packages/plugin-observatory/src/adapters/mock.ts
+++ b/web-next/packages/plugin-observatory/src/adapters/mock.ts
@@ -383,13 +383,27 @@ const SEED_REGISTRY: Registry = {
 // ── Seed topology ─────────────────────────────────────────────────────────────
 
 const SEED_NODES: TopologyNode[] = [
-  { id: 'realm-asgard', typeId: 'realm', label: 'asgard', parentId: null, status: 'healthy' },
+  {
+    id: 'realm-asgard',
+    typeId: 'realm',
+    label: 'asgard',
+    parentId: null,
+    status: 'healthy',
+    zone: 'asgard',
+    vlan: 90,
+    dns: 'asgard.niuu.world',
+    purpose: 'AI / compute / dev',
+    activity: 'idle',
+  },
   {
     id: 'cluster-valaskjalf',
     typeId: 'cluster',
     label: 'valaskjálf',
     parentId: 'realm-asgard',
     status: 'healthy',
+    zone: 'asgard',
+    purpose: 'DGX Spark cluster',
+    activity: 'idle',
   },
   {
     id: 'cluster-valhalla',
@@ -397,6 +411,9 @@ const SEED_NODES: TopologyNode[] = [
     label: 'valhalla',
     parentId: 'realm-asgard',
     status: 'healthy',
+    zone: 'asgard',
+    purpose: 'AI/ML workloads',
+    activity: 'idle',
   },
   {
     id: 'host-mjolnir',
@@ -404,6 +421,13 @@ const SEED_NODES: TopologyNode[] = [
     label: 'mjölnir',
     parentId: 'realm-asgard',
     status: 'healthy',
+    zone: 'asgard',
+    hw: 'DGX Spark',
+    os: 'Ubuntu 24',
+    cores: 144,
+    ram: '1 TiB',
+    gpu: 'GH200',
+    activity: 'idle',
   },
   {
     id: 'tyr-0',
@@ -411,6 +435,12 @@ const SEED_NODES: TopologyNode[] = [
     label: 'tyr-0',
     parentId: 'cluster-valaskjalf',
     status: 'healthy',
+    zone: 'asgard',
+    cluster: 'valaskjalf',
+    mode: 'active',
+    activeSagas: 3,
+    pendingRaids: 2,
+    activity: 'thinking',
   },
   {
     id: 'bifrost-0',
@@ -418,6 +448,12 @@ const SEED_NODES: TopologyNode[] = [
     label: 'bifröst-0',
     parentId: 'cluster-valaskjalf',
     status: 'healthy',
+    zone: 'asgard',
+    cluster: 'valaskjalf',
+    providers: ['Anthropic', 'OpenAI', 'Google', 'Local'],
+    reqPerMin: 42,
+    cacheHitRate: 0.68,
+    activity: 'idle',
   },
   {
     id: 'volundr-0',
@@ -425,6 +461,11 @@ const SEED_NODES: TopologyNode[] = [
     label: 'völundr-0',
     parentId: 'cluster-valhalla',
     status: 'healthy',
+    zone: 'asgard',
+    cluster: 'valhalla',
+    activeSessions: 5,
+    maxSessions: 20,
+    activity: 'tooling',
   },
   {
     id: 'mimir-0',
@@ -432,6 +473,9 @@ const SEED_NODES: TopologyNode[] = [
     label: 'mímir-0',
     parentId: 'cluster-valaskjalf',
     status: 'healthy',
+    zone: 'asgard',
+    cluster: 'valaskjalf',
+    activity: 'reading',
   },
   {
     id: 'raid-0',
@@ -439,6 +483,11 @@ const SEED_NODES: TopologyNode[] = [
     label: 'raid-omega',
     parentId: 'cluster-valaskjalf',
     status: 'observing',
+    zone: 'asgard',
+    cluster: 'valaskjalf',
+    purpose: 'refactor bifrost rule engine',
+    state: 'working',
+    activity: 'delegating',
   },
   {
     id: 'ravn-huginn',
@@ -446,6 +495,12 @@ const SEED_NODES: TopologyNode[] = [
     label: 'huginn',
     parentId: 'host-mjolnir',
     status: 'healthy',
+    zone: 'asgard',
+    hostId: 'host-mjolnir',
+    persona: 'thought',
+    specialty: 'architecture & design',
+    tokens: 42800,
+    activity: 'thinking',
   },
   {
     id: 'ravn-muninn',
@@ -453,6 +508,12 @@ const SEED_NODES: TopologyNode[] = [
     label: 'muninn',
     parentId: 'host-mjolnir',
     status: 'idle',
+    zone: 'asgard',
+    hostId: 'host-mjolnir',
+    persona: 'memory',
+    specialty: 'history & context',
+    tokens: 18200,
+    activity: 'idle',
   },
 ];
 
@@ -475,43 +536,43 @@ const SEED_TOPOLOGY: Topology = {
   timestamp: '2026-04-19T00:00:00Z',
 };
 
-// ── Seed events ───────────────────────────────────────────────────────────────
+// ── Seed events (web2 format: time, type, subject, body) ─────────────────────
 
 const SEED_EVENTS: ObservatoryEvent[] = [
   {
     id: 'ev-1',
-    timestamp: '2026-04-19T00:00:01Z',
-    severity: 'info',
-    sourceId: 'tyr-0',
-    message: 'raid-omega formed: 2 ravens conscripted',
+    time: '00:00:01',
+    type: 'RAID',
+    subject: 'raid-omega',
+    body: 'tyr dispatched raid · "refactor bifrost rule engine"',
   },
   {
     id: 'ev-2',
-    timestamp: '2026-04-19T00:00:05Z',
-    severity: 'info',
-    sourceId: 'ravn-huginn',
-    message: 'huginn joined raid-omega as coord',
+    time: '00:00:05',
+    type: 'RAVN',
+    subject: 'huginn',
+    body: 'huginn joined raid-omega as coord',
   },
   {
     id: 'ev-3',
-    timestamp: '2026-04-19T00:00:12Z',
-    severity: 'debug',
-    sourceId: 'bifrost-0',
-    message: 'cache hit rate 94% over last 60s',
+    time: '00:00:12',
+    type: 'BIFROST',
+    subject: 'bifröst-0',
+    body: 'cache hit rate 94% over last 60s',
   },
   {
     id: 'ev-4',
-    timestamp: '2026-04-19T00:00:30Z',
-    severity: 'warn',
-    sourceId: 'mimir-0',
-    message: 'write queue depth 412 — nearing threshold',
+    time: '00:00:30',
+    type: 'MIMIR',
+    subject: 'mímir-0',
+    body: 'write queue depth 412 — nearing threshold',
   },
   {
     id: 'ev-5',
-    timestamp: '2026-04-19T00:01:00Z',
-    severity: 'info',
-    sourceId: 'ravn-muninn',
-    message: 'muninn entering idle — no active sagas',
+    time: '00:01:00',
+    type: 'RAVN',
+    subject: 'muninn',
+    body: 'muninn entering idle — no active sagas',
   },
 ];
 

--- a/web-next/packages/plugin-observatory/src/application/useObservatoryStore.ts
+++ b/web-next/packages/plugin-observatory/src/application/useObservatoryStore.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useSyncExternalStore } from 'react';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -57,14 +57,11 @@ export function __resetObservatoryStore(): void {
 }
 
 /**
- * React hook that subscribes to the Observatory store and triggers a re-render
- * on every state change.
+ * React hook that subscribes to the Observatory store using useSyncExternalStore,
+ * which is tear-safe in React 19's concurrent renderer.
  */
 export function useObservatoryStore(): [ObservatoryStoreState, ObservatoryStore] {
   const store = getObservatoryStore();
-  const [, setTick] = useState(0);
-
-  useEffect(() => store.subscribe(() => setTick((t) => t + 1)), [store]);
-
-  return [store.read(), store];
+  const state = useSyncExternalStore(store.subscribe, store.read);
+  return [state, store];
 }

--- a/web-next/packages/plugin-observatory/src/application/useObservatoryStore.ts
+++ b/web-next/packages/plugin-observatory/src/application/useObservatoryStore.ts
@@ -1,0 +1,70 @@
+import { useState, useEffect } from 'react';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type ObservatoryFilter = 'all' | 'agents' | 'raids' | 'services' | 'devices';
+
+interface ObservatoryStoreState {
+  selectedId: string | null;
+  filter: ObservatoryFilter;
+}
+
+interface ObservatoryStore {
+  read(): ObservatoryStoreState;
+  setSelected(id: string | null): void;
+  setFilter(filter: ObservatoryFilter): void;
+  subscribe(fn: () => void): () => void;
+}
+
+// ── Module-level singleton ────────────────────────────────────────────────────
+// All three plugin slots (content, subnav, topbar) share state through this
+// store. The content slot owns the data; subnav/topbar subscribe and read.
+
+let _store: ObservatoryStore | null = null;
+
+export function getObservatoryStore(): ObservatoryStore {
+  if (_store) return _store;
+
+  const subscribers = new Set<() => void>();
+  let state: ObservatoryStoreState = { selectedId: null, filter: 'all' };
+
+  _store = {
+    read(): ObservatoryStoreState {
+      return state;
+    },
+    setSelected(id: string | null): void {
+      if (state.selectedId === id) return;
+      state = { ...state, selectedId: id };
+      subscribers.forEach((fn) => fn());
+    },
+    setFilter(filter: ObservatoryFilter): void {
+      if (state.filter === filter) return;
+      state = { ...state, filter };
+      subscribers.forEach((fn) => fn());
+    },
+    subscribe(fn: () => void): () => void {
+      subscribers.add(fn);
+      return () => subscribers.delete(fn);
+    },
+  };
+
+  return _store;
+}
+
+/** Reset the singleton for testing — clears state and subscribers. */
+export function __resetObservatoryStore(): void {
+  _store = null;
+}
+
+/**
+ * React hook that subscribes to the Observatory store and triggers a re-render
+ * on every state change.
+ */
+export function useObservatoryStore(): [ObservatoryStoreState, ObservatoryStore] {
+  const store = getObservatoryStore();
+  const [, setTick] = useState(0);
+
+  useEffect(() => store.subscribe(() => setTick((t) => t + 1)), [store]);
+
+  return [store.read(), store];
+}

--- a/web-next/packages/plugin-observatory/src/domain/index.ts
+++ b/web-next/packages/plugin-observatory/src/domain/index.ts
@@ -132,6 +132,12 @@ export interface TopologyNode {
 
   // ── service ───────────────────────────────────────────────────────────────
   svcType?: string;
+
+  // ── printer ───────────────────────────────────────────────────────────────
+  model?: string;
+
+  // ── vaettir ───────────────────────────────────────────────────────────────
+  sensors?: string;
 }
 
 /** Typed aliases for the four named domain entities. */

--- a/web-next/packages/plugin-observatory/src/domain/index.ts
+++ b/web-next/packages/plugin-observatory/src/domain/index.ts
@@ -56,13 +56,82 @@ export type EdgeKind = 'solid' | 'dashed-anim' | 'dashed-long' | 'soft' | 'raid'
 /** Runtime health status of a topology node. */
 export type NodeStatus = 'healthy' | 'degraded' | 'failed' | 'idle' | 'observing' | 'unknown';
 
-/** An instance of an EntityType in the live topology graph. */
+/** Activity state of an agent/entity. */
+export type NodeActivity =
+  | 'idle'
+  | 'thinking'
+  | 'tooling'
+  | 'waiting'
+  | 'delegating'
+  | 'writing'
+  | 'reading';
+
+/**
+ * An instance of an EntityType in the live topology graph.
+ * Base fields are always present; kind-specific fields are optional and
+ * populated according to the node's `typeId`.
+ */
 export interface TopologyNode {
   id: string;
   typeId: string;
   label: string;
   parentId: string | null;
   status: NodeStatus;
+
+  // ── Universal optional fields ────────────────────────────────────────────
+  activity?: NodeActivity;
+  zone?: string;
+  cluster?: string | null;
+  hostId?: string | null;
+  flockId?: string | null;
+
+  // ── tyr ──────────────────────────────────────────────────────────────────
+  mode?: string;
+  activeSagas?: number;
+  pendingRaids?: number;
+
+  // ── bifrost ───────────────────────────────────────────────────────────────
+  providers?: string[];
+  reqPerMin?: number;
+  cacheHitRate?: number;
+
+  // ── volundr ───────────────────────────────────────────────────────────────
+  activeSessions?: number;
+  maxSessions?: number;
+
+  // ── ravn_long ─────────────────────────────────────────────────────────────
+  persona?: string;
+  specialty?: string;
+  tokens?: number;
+
+  // ── host ──────────────────────────────────────────────────────────────────
+  hw?: string;
+  os?: string;
+  cores?: number;
+  ram?: string;
+  gpu?: string | null;
+
+  // ── model ─────────────────────────────────────────────────────────────────
+  provider?: string;
+  location?: string;
+
+  // ── realm ─────────────────────────────────────────────────────────────────
+  vlan?: number;
+  dns?: string;
+  purpose?: string;
+
+  // ── raid ──────────────────────────────────────────────────────────────────
+  state?: string;
+
+  // ── ravn_raid / coord ─────────────────────────────────────────────────────
+  role?: string;
+  confidence?: number;
+
+  // ── valkyrie ──────────────────────────────────────────────────────────────
+  autonomy?: string;
+
+  // ── service ───────────────────────────────────────────────────────────────
+  svcType?: string;
 }
 
 /** Typed aliases for the four named domain entities. */
@@ -88,14 +157,19 @@ export interface Topology {
 
 // ── Event log ─────────────────────────────────────────────────────────────────
 
-/** Severity level of an observatory event. */
-export type EventSeverity = 'debug' | 'info' | 'warn' | 'error';
+/** Source subsystem that generated an observatory event (matches web2 type column). */
+export type ObservatoryEventType = 'RAID' | 'RAVN' | 'TYR' | 'MIMIR' | 'BIFROST';
 
-/** A single entry in the observatory event log. */
+/**
+ * A single entry in the observatory event log.
+ * Shaped to match the web2 prototype event format:
+ *   4-column grid — time, type, subject, body.
+ */
 export interface ObservatoryEvent {
   id: string;
-  timestamp: string;
-  severity: EventSeverity;
-  sourceId: string;
-  message: string;
+  /** HH:MM:SS — display time extracted from ISO timestamp at emit time. */
+  time: string;
+  type: ObservatoryEventType;
+  subject: string;
+  body: string;
 }

--- a/web-next/packages/plugin-observatory/src/index.tsx
+++ b/web-next/packages/plugin-observatory/src/index.tsx
@@ -2,6 +2,8 @@ import { createRoute } from '@tanstack/react-router';
 import { definePlugin } from '@niuulabs/plugin-sdk';
 import { ObservatoryPage } from './ui/ObservatoryPage';
 import { RegistryPage } from './ui/RegistryPage';
+import { ObservatorySubnav } from './ui/ObservatorySubnav';
+import { ObservatoryTopbar } from './ui/ObservatoryTopbar';
 
 export const observatoryPlugin = definePlugin({
   id: 'observatory',
@@ -20,6 +22,8 @@ export const observatoryPlugin = definePlugin({
       component: RegistryPage,
     }),
   ],
+  subnav: () => <ObservatorySubnav />,
+  topbarRight: () => <ObservatoryTopbar />,
 });
 
 export {
@@ -41,6 +45,7 @@ export type {
   Registry,
   EdgeKind,
   NodeStatus,
+  NodeActivity,
   TopologyNode,
   TopologyEdge,
   Topology,
@@ -48,7 +53,7 @@ export type {
   Cluster,
   Host,
   Raid,
-  EventSeverity,
+  ObservatoryEventType,
   ObservatoryEvent,
 } from './domain';
 
@@ -60,3 +65,5 @@ export type { EventLogProps } from './ui/overlays/EventLog';
 export { ConnectionLegend } from './ui/overlays/ConnectionLegend';
 export { Minimap } from './ui/overlays/Minimap';
 export type { MinimapProps } from './ui/overlays/Minimap';
+export { ObservatorySubnav } from './ui/ObservatorySubnav';
+export { ObservatoryTopbar } from './ui/ObservatoryTopbar';

--- a/web-next/packages/plugin-observatory/src/ui/ObservatoryPage.test.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/ObservatoryPage.test.tsx
@@ -9,8 +9,11 @@ import {
   createMockRegistryRepository,
 } from '../adapters/mock';
 import { makeCtxMock } from './TopologyCanvas/test-helpers';
+import { __resetObservatoryStore } from '../application/useObservatoryStore';
 
 beforeEach(() => {
+  // Reset the module-level singleton to prevent state leaking between tests.
+  __resetObservatoryStore();
   HTMLCanvasElement.prototype.getContext = vi.fn().mockReturnValue(makeCtxMock());
   vi.stubGlobal('requestAnimationFrame', vi.fn().mockReturnValue(0));
   vi.stubGlobal('cancelAnimationFrame', vi.fn());

--- a/web-next/packages/plugin-observatory/src/ui/ObservatoryPage.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/ObservatoryPage.tsx
@@ -1,7 +1,7 @@
-import { useState } from 'react';
 import { useTopology } from '../application/useTopology';
 import { useEvents } from '../application/useEvents';
 import { useRegistry } from '../application/useRegistry';
+import { useObservatoryStore } from '../application/useObservatoryStore';
 import type { TopologyNode } from '../domain';
 import { TopologyCanvas } from './TopologyCanvas';
 import { EntityDrawer } from './overlays/EntityDrawer';
@@ -15,16 +15,30 @@ import { Minimap } from './overlays/Minimap';
  * Data is sourced from the live topology stream via useTopology().
  * The canvas renders Mímir at (0,0), realms around it, clusters inside
  * realms, hosts on the perimeter, and all 5 connection-line kinds.
+ *
+ * Selection state is shared via the Observatory store so that the subnav
+ * slot can also open entity drawers (e.g. clicking a realm in the subnav).
  */
 export function ObservatoryPage() {
   const topology = useTopology();
   const events = useEvents();
   const { data: registry } = useRegistry();
-  const [selectedNode, setSelectedNode] = useState<TopologyNode | null>(null);
+  const [storeState, store] = useObservatoryStore();
+  const { selectedId } = storeState;
+
+  const selectedNode: TopologyNode | null =
+    selectedId && topology ? (topology.nodes.find((n) => n.id === selectedId) ?? null) : null;
 
   function handleNodeClick(nodeId: string) {
-    const node = topology?.nodes.find((n) => n.id === nodeId) ?? null;
-    setSelectedNode(node);
+    store.setSelected(nodeId);
+  }
+
+  function handleDrawerClose() {
+    store.setSelected(null);
+  }
+
+  function handleNodeSelect(node: TopologyNode) {
+    store.setSelected(node.id);
   }
 
   return (
@@ -39,44 +53,34 @@ export function ObservatoryPage() {
         style={{ flex: 1, minHeight: 0 }}
       />
 
-      {/* Node list — 1px click targets stacked at top-left with z-index above the
-          canvas. Interim mechanism until canvas hit-testing is connected (NIU-664). */}
-      {topology && topology.nodes.length > 0 && (
-        <ul
-          style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            zIndex: 9999,
-            listStyle: 'none',
-            padding: 0,
-            margin: 0,
-          }}
-          data-testid="topology-node-list"
-        >
-          {topology.nodes.map((node) => (
-            <li key={node.id}>
-              <button
-                style={{
-                  width: 1,
-                  height: 1,
-                  padding: 0,
-                  overflow: 'hidden',
-                  border: 'none',
-                  background: 'none',
-                  cursor: 'default',
-                }}
-                onClick={() => setSelectedNode(node)}
-                data-testid={`node-btn-${node.id}`}
-                data-node-type={node.typeId}
-                aria-label={node.label}
-              >
-                {node.label}
-              </button>
-            </li>
-          ))}
-        </ul>
-      )}
+      {/* Accessible hidden node list — keyboard / screen-reader alternative to canvas hit-testing */}
+      <ul
+        data-testid="topology-node-list"
+        aria-label="Topology nodes"
+        style={{
+          position: 'absolute',
+          width: 1,
+          height: 1,
+          overflow: 'hidden',
+          clip: 'rect(0,0,0,0)',
+          whiteSpace: 'nowrap',
+          border: 0,
+          padding: 0,
+          margin: 0,
+        }}
+      >
+        {topology?.nodes.map((node) => (
+          <li key={node.id}>
+            <button
+              data-testid={`node-btn-${node.id}`}
+              onClick={() => handleNodeClick(node.id)}
+              aria-pressed={selectedId === node.id}
+            >
+              {node.label}
+            </button>
+          </li>
+        ))}
+      </ul>
 
       {/* Canvas overlays */}
       <ConnectionLegend />
@@ -86,8 +90,8 @@ export function ObservatoryPage() {
         node={selectedNode}
         topology={topology}
         registry={registry ?? null}
-        onClose={() => setSelectedNode(null)}
-        onNodeSelect={(n) => setSelectedNode(n)}
+        onClose={handleDrawerClose}
+        onNodeSelect={handleNodeSelect}
       />
     </div>
   );

--- a/web-next/packages/plugin-observatory/src/ui/ObservatoryPage.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/ObservatoryPage.tsx
@@ -42,32 +42,19 @@ export function ObservatoryPage() {
   }
 
   return (
-    <div
-      data-testid="observatory-page"
-      style={{ position: 'fixed', inset: 0, display: 'flex', flexDirection: 'column' }}
-    >
+    <div data-testid="observatory-page" className="fixed inset-0 flex flex-col">
       <TopologyCanvas
         topology={topology}
         onNodeClick={handleNodeClick}
         showMinimap={false}
-        style={{ flex: 1, minHeight: 0 }}
+        className="flex-1 min-h-0"
       />
 
       {/* Accessible hidden node list — keyboard / screen-reader alternative to canvas hit-testing */}
       <ul
         data-testid="topology-node-list"
         aria-label="Topology nodes"
-        style={{
-          position: 'absolute',
-          width: 1,
-          height: 1,
-          overflow: 'hidden',
-          clip: 'rect(0,0,0,0)',
-          whiteSpace: 'nowrap',
-          border: 0,
-          padding: 0,
-          margin: 0,
-        }}
+        className="sr-only"
       >
         {topology?.nodes.map((node) => (
           <li key={node.id}>

--- a/web-next/packages/plugin-observatory/src/ui/ObservatorySubnav.css
+++ b/web-next/packages/plugin-observatory/src/ui/ObservatorySubnav.css
@@ -1,0 +1,96 @@
+.obs-subnav {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.obs-subnav__section {
+  display: flex;
+  flex-direction: column;
+  padding: var(--space-3) 0;
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.obs-subnav__section:last-child {
+  border-bottom: none;
+}
+
+.obs-subnav__label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-4);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: var(--space-1);
+}
+
+.obs-subnav__label--sub {
+  margin-top: var(--space-3);
+}
+
+.obs-subnav__label-dot {
+  font-family: var(--font-mono);
+  font-weight: 400;
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--color-text-muted);
+  opacity: 0.6;
+}
+
+.obs-subnav__row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-4);
+  background: none;
+  border: none;
+  cursor: pointer;
+  width: 100%;
+  text-align: left;
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  transition: background 120ms;
+  border-radius: 0;
+}
+
+.obs-subnav__row:hover {
+  background: color-mix(in srgb, var(--color-brand) 6%, transparent);
+  color: var(--color-text-primary);
+}
+
+.obs-subnav__row[data-active='true'] {
+  background: color-mix(in srgb, var(--color-brand) 10%, transparent);
+  color: var(--color-text-primary);
+}
+
+.obs-subnav__dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.obs-subnav__name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.obs-subnav__name--mono {
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.obs-subnav__count {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+}

--- a/web-next/packages/plugin-observatory/src/ui/ObservatorySubnav.test.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/ObservatorySubnav.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ObservatorySubnav } from './ObservatorySubnav';
+
+// ── Mock useTopology ──────────────────────────────────────────────────────────
+
+vi.mock('../application/useTopology', () => ({
+  useTopology: vi.fn(),
+}));
+
+// ── Mock useObservatoryStore ──────────────────────────────────────────────────
+// We use a fresh store factory per test to avoid cross-test state pollution.
+
+const mockSetFilter = vi.fn();
+const mockSetSelected = vi.fn();
+
+vi.mock('../application/useObservatoryStore', () => ({
+  useObservatoryStore: vi.fn(() => [
+    { selectedId: null, filter: 'all' },
+    { setSelected: mockSetSelected, setFilter: mockSetFilter },
+  ]),
+}));
+
+import { useTopology } from '../application/useTopology';
+import type { Topology } from '../domain';
+
+const MOCK_TOPOLOGY: Topology = {
+  timestamp: '2026-04-19T00:00:00Z',
+  edges: [],
+  nodes: [
+    { id: 'realm-asgard', typeId: 'realm', label: 'asgard', parentId: null, status: 'healthy', vlan: 90 },
+    { id: 'realm-midgard', typeId: 'realm', label: 'midgard', parentId: null, status: 'healthy', vlan: 60 },
+    { id: 'cluster-valaskjalf', typeId: 'cluster', label: 'valaskjálf', parentId: 'realm-asgard', status: 'healthy' },
+    { id: 'tyr-0', typeId: 'tyr', label: 'tyr-0', parentId: 'cluster-valaskjalf', status: 'healthy' },
+    { id: 'ravn-huginn', typeId: 'ravn_long', label: 'huginn', parentId: null, status: 'healthy' },
+    { id: 'raid-1', typeId: 'raid', label: 'raid-omega', parentId: 'cluster-valaskjalf', status: 'observing', state: 'working', purpose: 'refactor rule engine' },
+    { id: 'svc-1', typeId: 'service', label: 'keycloak', parentId: 'cluster-valaskjalf', status: 'healthy' },
+    { id: 'printer-1', typeId: 'printer', label: 'Mjölnir', parentId: null, status: 'healthy' },
+  ],
+};
+
+describe('ObservatorySubnav', () => {
+  beforeEach(() => {
+    vi.mocked(useTopology).mockReturnValue(MOCK_TOPOLOGY);
+    mockSetFilter.mockClear();
+    mockSetSelected.mockClear();
+  });
+
+  it('renders the subnav container', () => {
+    render(<ObservatorySubnav />);
+    expect(screen.getByTestId('observatory-subnav')).toBeInTheDocument();
+  });
+
+  it('renders all 5 filter buttons', () => {
+    render(<ObservatorySubnav />);
+    expect(screen.getByTestId('filter-all')).toBeInTheDocument();
+    expect(screen.getByTestId('filter-agents')).toBeInTheDocument();
+    expect(screen.getByTestId('filter-raids')).toBeInTheDocument();
+    expect(screen.getByTestId('filter-services')).toBeInTheDocument();
+    expect(screen.getByTestId('filter-devices')).toBeInTheDocument();
+  });
+
+  it('renders correct total count for "all" filter', () => {
+    render(<ObservatorySubnav />);
+    // 8 nodes total
+    const allBtn = screen.getByTestId('filter-all');
+    expect(allBtn).toHaveTextContent('8');
+  });
+
+  it('renders agents filter with correct count', () => {
+    render(<ObservatorySubnav />);
+    // ravn_long only
+    const agentsBtn = screen.getByTestId('filter-agents');
+    expect(agentsBtn).toHaveTextContent('1');
+  });
+
+  it('renders raids filter with correct count', () => {
+    render(<ObservatorySubnav />);
+    const raidsBtn = screen.getByTestId('filter-raids');
+    expect(raidsBtn).toHaveTextContent('1');
+  });
+
+  it('renders both realms in the realms section', () => {
+    render(<ObservatorySubnav />);
+    expect(screen.getByTestId('realm-realm-asgard')).toBeInTheDocument();
+    expect(screen.getByTestId('realm-realm-midgard')).toBeInTheDocument();
+  });
+
+  it('shows vlan for realms', () => {
+    render(<ObservatorySubnav />);
+    expect(screen.getByText('vlan 90')).toBeInTheDocument();
+  });
+
+  it('renders cluster in clusters section', () => {
+    render(<ObservatorySubnav />);
+    expect(screen.getByTestId('cluster-cluster-valaskjalf')).toBeInTheDocument();
+  });
+
+  it('renders active raid in raids section', () => {
+    render(<ObservatorySubnav />);
+    expect(screen.getByTestId('raid-raid-1')).toBeInTheDocument();
+    expect(screen.getByText('refactor rule engine')).toBeInTheDocument();
+  });
+
+  it('calls setFilter when a filter button is clicked', () => {
+    render(<ObservatorySubnav />);
+    fireEvent.click(screen.getByTestId('filter-agents'));
+    expect(mockSetFilter).toHaveBeenCalledWith('agents');
+  });
+
+  it('calls setSelected when a realm is clicked', () => {
+    render(<ObservatorySubnav />);
+    fireEvent.click(screen.getByTestId('realm-realm-asgard'));
+    expect(mockSetSelected).toHaveBeenCalledWith('realm-asgard');
+  });
+
+  it('calls setSelected when a cluster is clicked', () => {
+    render(<ObservatorySubnav />);
+    fireEvent.click(screen.getByTestId('cluster-cluster-valaskjalf'));
+    expect(mockSetSelected).toHaveBeenCalledWith('cluster-valaskjalf');
+  });
+
+  it('renders with no topology (empty state)', () => {
+    vi.mocked(useTopology).mockReturnValue(null);
+    render(<ObservatorySubnav />);
+    // Should still render the subnav without crashing
+    expect(screen.getByTestId('observatory-subnav')).toBeInTheDocument();
+    // All counts should be 0
+    expect(screen.getByTestId('filter-all')).toHaveTextContent('0');
+  });
+
+  it('marks active filter with aria-pressed', () => {
+    vi.mock('../application/useObservatoryStore', () => ({
+      useObservatoryStore: vi.fn(() => [
+        { selectedId: null, filter: 'agents' },
+        { setSelected: mockSetSelected, setFilter: mockSetFilter },
+      ]),
+    }));
+    // Fresh render with agents filter active
+    const { unmount } = render(<ObservatorySubnav />);
+    unmount();
+  });
+});

--- a/web-next/packages/plugin-observatory/src/ui/ObservatorySubnav.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/ObservatorySubnav.tsx
@@ -1,0 +1,209 @@
+import { useMemo } from 'react';
+import { useTopology } from '../application/useTopology';
+import { useObservatoryStore, type ObservatoryFilter } from '../application/useObservatoryStore';
+import type { TopologyNode } from '../domain';
+import './ObservatorySubnav.css';
+
+// ── Filter section config ─────────────────────────────────────────────────────
+
+const AGENT_KINDS = new Set(['ravn_long', 'ravn_raid', 'valkyrie', 'skuld']);
+const SERVICE_KINDS = new Set(['service', 'bifrost', 'tyr', 'volundr', 'mimir']);
+const DEVICE_KINDS = new Set(['printer', 'vaettir', 'beacon']);
+const RAID_KIND = 'raid';
+
+interface FilterRow {
+  id: ObservatoryFilter;
+  label: string;
+  color: string;
+  count: (nodes: TopologyNode[]) => number;
+}
+
+const FILTER_ROWS: FilterRow[] = [
+  {
+    id: 'all',
+    label: 'All entities',
+    color: 'var(--brand-300, var(--color-brand))',
+    count: (nodes) => nodes.length,
+  },
+  {
+    id: 'agents',
+    label: 'Agents',
+    color: 'var(--brand-200, var(--color-brand))',
+    count: (nodes) => nodes.filter((n) => AGENT_KINDS.has(n.typeId)).length,
+  },
+  {
+    id: 'raids',
+    label: 'Raids',
+    color: 'var(--brand-500, var(--color-brand))',
+    count: (nodes) => nodes.filter((n) => n.typeId === RAID_KIND).length,
+  },
+  {
+    id: 'services',
+    label: 'Services',
+    color: 'var(--brand-300, var(--color-brand))',
+    count: (nodes) => nodes.filter((n) => SERVICE_KINDS.has(n.typeId)).length,
+  },
+  {
+    id: 'devices',
+    label: 'Devices',
+    color: 'var(--color-text-muted)',
+    count: (nodes) => nodes.filter((n) => DEVICE_KINDS.has(n.typeId)).length,
+  },
+];
+
+// ── Raid state → dot color ─────────────────────────────────────────────────
+
+function raidDotColor(state: string | undefined): string {
+  if (state === 'forming') return 'var(--brand-200, var(--color-brand))';
+  if (state === 'working') return 'var(--brand-500, var(--color-brand))';
+  return 'var(--color-text-muted)';
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export function ObservatorySubnav() {
+  const topology = useTopology();
+  const [storeState, store] = useObservatoryStore();
+  const { filter, selectedId } = storeState;
+
+  const nodes = useMemo(() => topology?.nodes ?? [], [topology]);
+
+  const realms = useMemo(
+    () => nodes.filter((n) => n.typeId === 'realm'),
+    [nodes],
+  );
+
+  const clusters = useMemo(
+    () => nodes.filter((n) => n.typeId === 'cluster'),
+    [nodes],
+  );
+
+  const activeRaids = useMemo(
+    () => nodes.filter((n) => n.typeId === 'raid').slice(0, 6),
+    [nodes],
+  );
+
+  return (
+    <div className="obs-subnav" data-testid="observatory-subnav">
+      {/* Section 1: Entity filter */}
+      <div className="obs-subnav__section">
+        <div className="obs-subnav__label">
+          Filter{' '}
+          <span className="obs-subnav__label-dot">·</span>
+        </div>
+        {FILTER_ROWS.map((row) => {
+          const count = row.count(nodes);
+          const active = filter === row.id;
+          return (
+            <button
+              key={row.id}
+              className="obs-subnav__row"
+              data-active={active}
+              data-testid={`filter-${row.id}`}
+              onClick={() => store.setFilter(row.id)}
+              aria-pressed={active}
+            >
+              <span
+                className="obs-subnav__dot"
+                style={{ background: row.color, boxShadow: `0 0 6px ${row.color}` }}
+              />
+              <span className="obs-subnav__name">{row.label}</span>
+              <span className="obs-subnav__count">{count}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Section 2: Realms */}
+      <div className="obs-subnav__section">
+        <div className="obs-subnav__label">
+          Realms{' '}
+          <span className="obs-subnav__count">{realms.length}</span>
+        </div>
+        {realms.map((realm) => (
+          <button
+            key={realm.id}
+            className="obs-subnav__row"
+            data-active={selectedId === realm.id}
+            data-testid={`realm-${realm.id}`}
+            onClick={() => store.setSelected(realm.id)}
+            aria-pressed={selectedId === realm.id}
+          >
+            <span
+              className="obs-subnav__dot"
+              style={{
+                background: 'var(--brand-300, var(--color-brand))',
+                boxShadow: '0 0 6px var(--brand-300, var(--color-brand))',
+              }}
+            />
+            <span className="obs-subnav__name">{realm.label}</span>
+            {realm.vlan !== undefined && (
+              <span className="obs-subnav__count">vlan {realm.vlan}</span>
+            )}
+          </button>
+        ))}
+      </div>
+
+      {/* Section 3: Clusters + Active raids */}
+      <div className="obs-subnav__section">
+        <div className="obs-subnav__label">
+          Clusters{' '}
+          <span className="obs-subnav__count">{clusters.length}</span>
+        </div>
+        {clusters.map((cluster) => (
+          <button
+            key={cluster.id}
+            className="obs-subnav__row"
+            data-active={selectedId === cluster.id}
+            data-testid={`cluster-${cluster.id}`}
+            onClick={() => store.setSelected(cluster.id)}
+            aria-pressed={selectedId === cluster.id}
+          >
+            <span
+              className="obs-subnav__dot"
+              style={{
+                background: 'var(--brand-500, var(--color-brand))',
+                boxShadow: '0 0 6px var(--brand-500, var(--color-brand))',
+              }}
+            />
+            <span className="obs-subnav__name">{cluster.label}</span>
+            <span className="obs-subnav__count">⎔</span>
+          </button>
+        ))}
+
+        {activeRaids.length > 0 && (
+          <>
+            <div className="obs-subnav__label obs-subnav__label--sub">
+              Active raids{' '}
+              <span className="obs-subnav__count">
+                {nodes.filter((n) => n.typeId === 'raid').length}
+              </span>
+            </div>
+            {activeRaids.map((raid) => {
+              const color = raidDotColor(raid.state);
+              return (
+                <button
+                  key={raid.id}
+                  className="obs-subnav__row"
+                  data-testid={`raid-${raid.id}`}
+                  onClick={() => store.setSelected(raid.id)}
+                >
+                  <span
+                    className="obs-subnav__dot"
+                    style={{ background: color, boxShadow: `0 0 6px ${color}` }}
+                  />
+                  <span className="obs-subnav__name obs-subnav__name--mono">
+                    {raid.purpose ?? raid.label}
+                  </span>
+                  <span className="obs-subnav__count">
+                    {raid.state?.slice(0, 4) ?? '—'}
+                  </span>
+                </button>
+              );
+            })}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web-next/packages/plugin-observatory/src/ui/ObservatorySubnav.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/ObservatorySubnav.tsx
@@ -78,10 +78,9 @@ export function ObservatorySubnav() {
     [nodes],
   );
 
-  const activeRaids = useMemo(
-    () => nodes.filter((n) => n.typeId === 'raid').slice(0, 6),
-    [nodes],
-  );
+  const allRaids = useMemo(() => nodes.filter((n) => n.typeId === 'raid'), [nodes]);
+
+  const activeRaids = useMemo(() => allRaids.slice(0, 6), [allRaids]);
 
   return (
     <div className="obs-subnav" data-testid="observatory-subnav">
@@ -175,9 +174,7 @@ export function ObservatorySubnav() {
           <>
             <div className="obs-subnav__label obs-subnav__label--sub">
               Active raids{' '}
-              <span className="obs-subnav__count">
-                {nodes.filter((n) => n.typeId === 'raid').length}
-              </span>
+              <span className="obs-subnav__count">{allRaids.length}</span>
             </div>
             {activeRaids.map((raid) => {
               const color = raidDotColor(raid.state);

--- a/web-next/packages/plugin-observatory/src/ui/ObservatoryTopbar.css
+++ b/web-next/packages/plugin-observatory/src/ui/ObservatoryTopbar.css
@@ -1,0 +1,29 @@
+.obs-topbar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+}
+
+.obs-topbar__stat {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+.obs-topbar__stat--accent {
+  color: var(--brand-300, var(--color-brand));
+}
+
+.obs-topbar__label {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  text-transform: lowercase;
+}
+
+.obs-topbar__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}

--- a/web-next/packages/plugin-observatory/src/ui/ObservatoryTopbar.test.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/ObservatoryTopbar.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ObservatoryTopbar } from './ObservatoryTopbar';
+
+// ── Mock useTopology ──────────────────────────────────────────────────────────
+
+vi.mock('../application/useTopology', () => ({
+  useTopology: vi.fn(),
+}));
+
+import { useTopology } from '../application/useTopology';
+import type { Topology } from '../domain';
+
+const MOCK_TOPOLOGY: Topology = {
+  timestamp: '2026-04-19T00:00:00Z',
+  edges: [],
+  nodes: [
+    { id: 'realm-asgard', typeId: 'realm', label: 'asgard', parentId: null, status: 'healthy' },
+    { id: 'realm-midgard', typeId: 'realm', label: 'midgard', parentId: null, status: 'healthy' },
+    { id: 'ravn-huginn', typeId: 'ravn_long', label: 'huginn', parentId: null, status: 'healthy' },
+    { id: 'ravn-muninn', typeId: 'ravn_raid', label: 'muninn', parentId: null, status: 'healthy' },
+    { id: 'raid-1', typeId: 'raid', label: 'raid-omega', parentId: null, status: 'observing' },
+    { id: 'raid-2', typeId: 'raid', label: 'raid-beta', parentId: null, status: 'observing' },
+    { id: 'svc-1', typeId: 'service', label: 'keycloak', parentId: null, status: 'healthy' },
+  ],
+};
+
+describe('ObservatoryTopbar', () => {
+  it('renders the topbar container', () => {
+    vi.mocked(useTopology).mockReturnValue(MOCK_TOPOLOGY);
+    render(<ObservatoryTopbar />);
+    expect(screen.getByTestId('observatory-topbar')).toBeInTheDocument();
+  });
+
+  it('renders the realms count label', () => {
+    vi.mocked(useTopology).mockReturnValue(MOCK_TOPOLOGY);
+    render(<ObservatoryTopbar />);
+    expect(screen.getByText('realms')).toBeInTheDocument();
+  });
+
+  it('renders the ravens count label', () => {
+    vi.mocked(useTopology).mockReturnValue(MOCK_TOPOLOGY);
+    render(<ObservatoryTopbar />);
+    expect(screen.getByText('ravens')).toBeInTheDocument();
+  });
+
+  it('renders the raids count label', () => {
+    vi.mocked(useTopology).mockReturnValue(MOCK_TOPOLOGY);
+    render(<ObservatoryTopbar />);
+    expect(screen.getByText('raids')).toBeInTheDocument();
+  });
+
+  it('shows correct realm count (2)', () => {
+    vi.mocked(useTopology).mockReturnValue(MOCK_TOPOLOGY);
+    render(<ObservatoryTopbar />);
+    // 2 realm nodes
+    const topbar = screen.getByTestId('observatory-topbar');
+    expect(topbar).toHaveTextContent('2');
+  });
+
+  it('shows correct raven count (ravn_long + ravn_raid = 2)', () => {
+    vi.mocked(useTopology).mockReturnValue(MOCK_TOPOLOGY);
+    const { container } = render(<ObservatoryTopbar />);
+    // ravens stat value
+    const ravensStat = container.querySelector('.obs-topbar__stat--accent');
+    expect(ravensStat).not.toBeNull();
+    expect(ravensStat).toHaveTextContent('2');
+  });
+
+  it('shows correct raid count (2)', () => {
+    vi.mocked(useTopology).mockReturnValue(MOCK_TOPOLOGY);
+    const { container } = render(<ObservatoryTopbar />);
+    const accentStats = container.querySelectorAll('.obs-topbar__stat--accent');
+    // Second accent stat is raids
+    expect(accentStats[1]).toHaveTextContent('2');
+  });
+
+  it('renders zeros when topology is null', () => {
+    vi.mocked(useTopology).mockReturnValue(null);
+    render(<ObservatoryTopbar />);
+    const topbar = screen.getByTestId('observatory-topbar');
+    // All three counts should be 0
+    const values = topbar.querySelectorAll('strong');
+    values.forEach((v) => expect(v.textContent).toBe('0'));
+  });
+
+  it('renders zeros when topology has no nodes', () => {
+    vi.mocked(useTopology).mockReturnValue({ timestamp: '', nodes: [], edges: [] });
+    render(<ObservatoryTopbar />);
+    const topbar = screen.getByTestId('observatory-topbar');
+    const values = topbar.querySelectorAll('strong');
+    values.forEach((v) => expect(v.textContent).toBe('0'));
+  });
+
+  it('counts only ravn_long and ravn_raid as ravens', () => {
+    const topo: Topology = {
+      timestamp: '',
+      edges: [],
+      nodes: [
+        { id: 'r1', typeId: 'ravn_long', label: 'r1', parentId: null, status: 'healthy' },
+        { id: 'r2', typeId: 'ravn_raid', label: 'r2', parentId: null, status: 'healthy' },
+        { id: 'r3', typeId: 'service', label: 'r3', parentId: null, status: 'healthy' },
+      ],
+    };
+    vi.mocked(useTopology).mockReturnValue(topo);
+    const { container } = render(<ObservatoryTopbar />);
+    const ravensStat = container.querySelector('.obs-topbar__stat--accent');
+    expect(ravensStat).toHaveTextContent('2');
+  });
+});

--- a/web-next/packages/plugin-observatory/src/ui/ObservatoryTopbar.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/ObservatoryTopbar.tsx
@@ -1,0 +1,41 @@
+import { useMemo } from 'react';
+import { useTopology } from '../application/useTopology';
+import './ObservatoryTopbar.css';
+
+const RAVN_KINDS = new Set(['ravn_long', 'ravn_raid']);
+
+/**
+ * ObservatoryTopbar — topbar-right slot for the Observatory plugin.
+ *
+ * Renders three stat chips: realms count, ravens count (accented), raids count (accented).
+ * Matches the web2 prototype `ObservatoryTopbar` component.
+ */
+export function ObservatoryTopbar() {
+  const topology = useTopology();
+
+  const stats = useMemo(() => {
+    const nodes = topology?.nodes ?? [];
+    return {
+      realms: nodes.filter((n) => n.typeId === 'realm').length,
+      ravens: nodes.filter((n) => RAVN_KINDS.has(n.typeId)).length,
+      raids: nodes.filter((n) => n.typeId === 'raid').length,
+    };
+  }, [topology]);
+
+  return (
+    <div className="obs-topbar" data-testid="observatory-topbar">
+      <div className="obs-topbar__stat">
+        <span className="obs-topbar__label">realms</span>
+        <strong className="obs-topbar__value">{stats.realms}</strong>
+      </div>
+      <div className="obs-topbar__stat obs-topbar__stat--accent">
+        <span className="obs-topbar__label">ravens</span>
+        <strong className="obs-topbar__value">{stats.ravens}</strong>
+      </div>
+      <div className="obs-topbar__stat obs-topbar__stat--accent">
+        <span className="obs-topbar__label">raids</span>
+        <strong className="obs-topbar__value">{stats.raids}</strong>
+      </div>
+    </div>
+  );
+}

--- a/web-next/packages/plugin-observatory/src/ui/overlays/ConnectionLegend.css
+++ b/web-next/packages/plugin-observatory/src/ui/overlays/ConnectionLegend.css
@@ -12,6 +12,14 @@
   gap: var(--space-2);
   min-width: 180px;
   pointer-events: auto;
+
+  /* Edge colour palette — token-mapped values used by SVG classes below */
+  --obs-edge-solid: rgba(147, 197, 253, 0.8);
+  --obs-edge-anim: rgba(125, 211, 252, 0.9);
+  --obs-edge-long: rgba(147, 197, 253, 0.7);
+  --obs-edge-soft: rgba(224, 242, 254, 0.55);
+  --obs-edge-raid: rgba(125, 211, 252, 0.9);
+  --obs-edge-raid-line: rgba(125, 211, 252, 0.6);
 }
 
 .obs-conn-legend__item {
@@ -34,4 +42,35 @@
 .obs-conn-legend__desc {
   font-size: var(--text-xs);
   color: var(--color-text-muted);
+}
+
+/* SVG edge swatches — stroke/fill driven by CSS vars, never hardcoded */
+.obs-conn-legend__edge--solid {
+  stroke: var(--obs-edge-solid);
+  stroke-width: 1.4;
+  stroke-linecap: round;
+}
+.obs-conn-legend__edge--anim {
+  stroke: var(--obs-edge-anim);
+  stroke-width: 1.4;
+  stroke-dasharray: 3 3;
+  stroke-linecap: round;
+}
+.obs-conn-legend__edge--long {
+  stroke: var(--obs-edge-long);
+  stroke-width: 1.2;
+  stroke-dasharray: 6 4;
+  stroke-linecap: round;
+}
+.obs-conn-legend__edge--soft {
+  stroke: var(--obs-edge-soft);
+  stroke-width: 0.9;
+  stroke-linecap: round;
+}
+.obs-conn-legend__edge--raid-node {
+  fill: var(--obs-edge-raid);
+}
+.obs-conn-legend__edge--raid-line {
+  stroke: var(--obs-edge-raid-line);
+  stroke-width: 1;
 }

--- a/web-next/packages/plugin-observatory/src/ui/overlays/ConnectionLegend.test.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/overlays/ConnectionLegend.test.tsx
@@ -22,41 +22,37 @@ describe('ConnectionLegend', () => {
     expect(screen.getByRole('list', { name: /connection types/i })).toBeInTheDocument();
   });
 
-  it('renders label text for each edge kind', () => {
+  it('renders web2-matching label text for each edge kind', () => {
     render(<ConnectionLegend />);
-    expect(screen.getByText('Direct')).toBeInTheDocument();
-    expect(screen.getByText('Active')).toBeInTheDocument();
-    expect(screen.getByText('Async')).toBeInTheDocument();
-    expect(screen.getByText('Cache')).toBeInTheDocument();
-    expect(screen.getByText('Coord')).toBeInTheDocument();
+    expect(screen.getByText('Týr → Völundr')).toBeInTheDocument();
+    expect(screen.getByText('Týr ⇝ raid coord')).toBeInTheDocument();
+    expect(screen.getByText('Bifröst → ext. model')).toBeInTheDocument();
+    expect(screen.getByText('ravn → Mímir')).toBeInTheDocument();
+    expect(screen.getByText('raid cohesion')).toBeInTheDocument();
   });
 
-  it('renders description text for each edge kind', () => {
-    render(<ConnectionLegend />);
-    expect(screen.getByText('coordinator link')).toBeInTheDocument();
-    expect(screen.getByText('raid dispatch')).toBeInTheDocument();
-    expect(screen.getByText('memory access')).toBeInTheDocument();
-    expect(screen.getByText('weak reference')).toBeInTheDocument();
-    expect(screen.getByText('inter-raven')).toBeInTheDocument();
-  });
-
-  it('renders an SVG line for each edge kind', () => {
+  it('renders an SVG swatch for each edge kind', () => {
     const { container } = render(<ConnectionLegend />);
     const svgs = container.querySelectorAll('svg.obs-conn-legend__line-svg');
     expect(svgs).toHaveLength(5);
   });
 
-  it('renders SVG lines with correct markup for each kind', () => {
+  it('renders SVG markup correctly for animated kind', () => {
     render(<ConnectionLegend />);
-    // solid: plain line
-    const solidItem = screen.getByTestId('legend-solid');
-    expect(solidItem.querySelector('line')).toBeInTheDocument();
-    // dashed-anim: line with animate child
     const animItem = screen.getByTestId('legend-dashed-anim');
     expect(animItem.querySelector('animate')).toBeInTheDocument();
-    // raid: line + circle
+  });
+
+  it('renders raid kind with circles', () => {
+    render(<ConnectionLegend />);
     const raidItem = screen.getByTestId('legend-raid');
     expect(raidItem.querySelector('circle')).toBeInTheDocument();
     expect(raidItem.querySelector('g')).toBeInTheDocument();
+  });
+
+  it('renders solid kind with a plain line', () => {
+    render(<ConnectionLegend />);
+    const solidItem = screen.getByTestId('legend-solid');
+    expect(solidItem.querySelector('line')).toBeInTheDocument();
   });
 });

--- a/web-next/packages/plugin-observatory/src/ui/overlays/ConnectionLegend.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/overlays/ConnectionLegend.tsx
@@ -37,21 +37,15 @@ export function ConnectionLegend() {
 
 function EdgeLine({ kind }: { kind: EdgeKind }) {
   const y = 7;
-  const base = {
-    x1: 2,
-    y1: y,
-    x2: 34,
-    y2: y,
-    strokeLinecap: 'round' as const,
-  };
+  const base = { x1: 2, y1: y, x2: 34, y2: y };
 
   if (kind === 'solid') {
-    return <line {...base} stroke="rgba(147,197,253,0.8)" strokeWidth={1.4} />;
+    return <line {...base} className="obs-conn-legend__edge--solid" />;
   }
 
   if (kind === 'dashed-anim') {
     return (
-      <line {...base} stroke="rgba(125,211,252,0.9)" strokeWidth={1.4} strokeDasharray="3 3">
+      <line {...base} className="obs-conn-legend__edge--anim">
         <animate
           attributeName="stroke-dashoffset"
           from="0"
@@ -64,28 +58,19 @@ function EdgeLine({ kind }: { kind: EdgeKind }) {
   }
 
   if (kind === 'dashed-long') {
-    return (
-      <line {...base} stroke="rgba(147,197,253,0.7)" strokeWidth={1.2} strokeDasharray="6 4" />
-    );
+    return <line {...base} className="obs-conn-legend__edge--long" />;
   }
 
   if (kind === 'soft') {
-    return (
-      <line
-        {...base}
-        stroke="rgba(224,242,254,0.55)"
-        strokeWidth={0.9}
-        strokeLinecap="round"
-      />
-    );
+    return <line {...base} className="obs-conn-legend__edge--soft" />;
   }
 
   // raid — dots + line
   return (
     <g>
-      <circle cx={8} cy={y} r={3} fill="rgba(125,211,252,0.9)" />
-      <circle cx={28} cy={y} r={3} fill="rgba(125,211,252,0.9)" />
-      <line x1={11} y1={y} x2={25} y2={y} stroke="rgba(125,211,252,0.6)" strokeWidth={1} />
+      <circle cx={8} cy={y} r={3} className="obs-conn-legend__edge--raid-node" />
+      <circle cx={28} cy={y} r={3} className="obs-conn-legend__edge--raid-node" />
+      <line x1={11} y1={y} x2={25} y2={y} className="obs-conn-legend__edge--raid-line" />
     </g>
   );
 }

--- a/web-next/packages/plugin-observatory/src/ui/overlays/ConnectionLegend.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/overlays/ConnectionLegend.tsx
@@ -4,32 +4,31 @@ import './ConnectionLegend.css';
 interface LegendEntry {
   kind: EdgeKind;
   label: string;
-  description: string;
 }
 
+/** Labels match the web2 prototype connection legend exactly. */
 const EDGE_LEGEND: LegendEntry[] = [
-  { kind: 'solid', label: 'Direct', description: 'coordinator link' },
-  { kind: 'dashed-anim', label: 'Active', description: 'raid dispatch' },
-  { kind: 'dashed-long', label: 'Async', description: 'memory access' },
-  { kind: 'soft', label: 'Cache', description: 'weak reference' },
-  { kind: 'raid', label: 'Coord', description: 'inter-raven' },
+  { kind: 'solid', label: 'Týr → Völundr' },
+  { kind: 'dashed-anim', label: 'Týr ⇝ raid coord' },
+  { kind: 'dashed-long', label: 'Bifröst → ext. model' },
+  { kind: 'soft', label: 'ravn → Mímir' },
+  { kind: 'raid', label: 'raid cohesion' },
 ];
 
 export function ConnectionLegend() {
   return (
     <ul className="obs-conn-legend" aria-label="Connection types">
-      {EDGE_LEGEND.map(({ kind, label, description }) => (
+      {EDGE_LEGEND.map(({ kind, label }) => (
         <li
           key={kind}
           className="obs-conn-legend__item"
           data-kind={kind}
           data-testid={`legend-${kind}`}
         >
-          <svg className="obs-conn-legend__line-svg" width={32} height={12} aria-hidden="true">
+          <svg className="obs-conn-legend__line-svg" width={36} height={14} aria-hidden="true">
             <EdgeLine kind={kind} />
           </svg>
           <span className="obs-conn-legend__label">{label}</span>
-          <span className="obs-conn-legend__desc">{description}</span>
         </li>
       ))}
     </ul>
@@ -37,23 +36,22 @@ export function ConnectionLegend() {
 }
 
 function EdgeLine({ kind }: { kind: EdgeKind }) {
-  const y = 6;
+  const y = 7;
   const base = {
     x1: 2,
     y1: y,
-    x2: 30,
+    x2: 34,
     y2: y,
-    strokeWidth: 1.5,
     strokeLinecap: 'round' as const,
   };
 
   if (kind === 'solid') {
-    return <line {...base} stroke="var(--color-text-primary)" />;
+    return <line {...base} stroke="rgba(147,197,253,0.8)" strokeWidth={1.4} />;
   }
 
   if (kind === 'dashed-anim') {
     return (
-      <line {...base} stroke="var(--color-brand)" strokeDasharray="4 2">
+      <line {...base} stroke="rgba(125,211,252,0.9)" strokeWidth={1.4} strokeDasharray="3 3">
         <animate
           attributeName="stroke-dashoffset"
           from="0"
@@ -66,25 +64,28 @@ function EdgeLine({ kind }: { kind: EdgeKind }) {
   }
 
   if (kind === 'dashed-long') {
-    return <line {...base} stroke="var(--color-text-secondary)" strokeDasharray="6 4" />;
+    return (
+      <line {...base} stroke="rgba(147,197,253,0.7)" strokeWidth={1.2} strokeDasharray="6 4" />
+    );
   }
 
   if (kind === 'soft') {
     return (
       <line
         {...base}
-        stroke="var(--color-text-muted)"
-        strokeDasharray="1 3"
+        stroke="rgba(224,242,254,0.55)"
+        strokeWidth={0.9}
         strokeLinecap="round"
       />
     );
   }
 
-  // raid — solid with midpoint marker
+  // raid — dots + line
   return (
     <g>
-      <line {...base} stroke="var(--color-accent-purple)" />
-      <circle cx={16} cy={y} r={2} fill="var(--color-accent-purple)" />
+      <circle cx={8} cy={y} r={3} fill="rgba(125,211,252,0.9)" />
+      <circle cx={28} cy={y} r={3} fill="rgba(125,211,252,0.9)" />
+      <line x1={11} y1={y} x2={25} y2={y} stroke="rgba(125,211,252,0.6)" strokeWidth={1} />
     </g>
   );
 }

--- a/web-next/packages/plugin-observatory/src/ui/overlays/EntityDrawer.css
+++ b/web-next/packages/plugin-observatory/src/ui/overlays/EntityDrawer.css
@@ -37,6 +37,16 @@
   letter-spacing: 0.05em;
 }
 
+.obs-entity-drawer__id-chip {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  background: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-full);
+  padding: 0 var(--space-2);
+}
+
 .obs-entity-drawer__status {
   display: flex;
   align-items: center;
@@ -52,7 +62,7 @@
   padding: var(--space-4);
   display: flex;
   flex-direction: column;
-  gap: var(--space-5);
+  gap: var(--space-4);
   overflow-y: auto;
 }
 
@@ -61,6 +71,11 @@
   font-size: var(--text-sm);
   color: var(--color-text-secondary);
   line-height: 1.5;
+}
+
+.obs-entity-drawer__section {
+  display: flex;
+  flex-direction: column;
 }
 
 .obs-entity-drawer__section-title {
@@ -72,13 +87,106 @@
   font-weight: 500;
 }
 
-.obs-entity-drawer__resident-list,
-.obs-entity-drawer__field-list {
+/* Activity row */
+.obs-entity-drawer__activity-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) 0;
+}
+
+.obs-entity-drawer__activity-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.obs-entity-drawer__activity-dot--pulse {
+  animation: obs-pulse 2s ease-in-out infinite;
+}
+
+@keyframes obs-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+.obs-entity-drawer__activity-label {
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+  font-weight: 500;
+}
+
+.obs-entity-drawer__activity-ts {
+  margin-left: auto;
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+}
+
+/* Property grid (dl) */
+.obs-entity-drawer__prop-grid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: var(--space-1) var(--space-4);
+  margin: 0;
+  font-size: var(--text-sm);
+}
+
+.obs-entity-drawer__prop-grid dt {
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+
+.obs-entity-drawer__prop-grid dd {
+  margin: 0;
+  color: var(--color-text-primary);
+}
+
+.obs-entity-drawer__plain {
+  color: var(--color-text-secondary) !important;
+}
+
+/* Inline badge (mode, autonomy) */
+.obs-entity-drawer__badge {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  padding: 1px var(--space-2);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-secondary);
+}
+
+.obs-entity-drawer__badge[data-mode="active"] {
+  color: var(--brand-200, var(--color-brand));
+  border-color: color-mix(in srgb, var(--color-brand) 40%, transparent);
+}
+
+.obs-entity-drawer__badge[data-autonomy="full"] {
+  color: var(--brand-200, var(--color-brand));
+}
+
+.obs-entity-drawer__badge[data-autonomy="restricted"] {
+  color: var(--color-accent-red);
+  border-color: color-mix(in srgb, var(--color-accent-red) 30%, transparent);
+}
+
+/* Resident list */
+.obs-entity-drawer__resident-list {
   list-style: none;
   padding: 0;
   margin: 0;
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: var(--space-1);
+}
+
+.obs-entity-drawer__resident-overflow {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  padding: var(--space-1) var(--space-3);
 }
 
 .obs-entity-drawer__resident-btn {
@@ -112,6 +220,106 @@
 
 .obs-entity-drawer__resident-label {
   flex: 1;
+}
+
+.obs-entity-drawer__resident-kind {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+/* Coordinator confidence bar */
+.obs-entity-drawer__conf-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: 0;
+}
+
+.obs-entity-drawer__conf-track {
+  flex: 1;
+  height: 4px;
+  background: var(--color-bg-elevated);
+  border-radius: var(--radius-full);
+  overflow: hidden;
+}
+
+.obs-entity-drawer__conf-fill {
+  display: block;
+  height: 100%;
+  background: var(--brand-300, var(--color-brand));
+  border-radius: var(--radius-full);
+}
+
+/* Token throughput inline sparkline */
+.obs-entity-drawer__sparkline {
+  display: block;
+  width: 100%;
+  height: 32px;
+}
+
+/* Link button (host ID nav) */
+.obs-entity-drawer__link {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--brand-300, var(--color-brand));
+  font-size: var(--text-sm);
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+/* Actions row */
+.obs-entity-drawer__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.obs-entity-drawer__btn {
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  cursor: pointer;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-primary);
+  transition: background 150ms;
+}
+
+.obs-entity-drawer__btn:hover {
+  background: var(--color-bg-elevated);
+}
+
+.obs-entity-drawer__btn--primary {
+  background: var(--color-brand);
+  color: var(--color-bg-primary);
+  border-color: var(--color-brand);
+}
+
+.obs-entity-drawer__btn--primary:hover {
+  opacity: 0.85;
+}
+
+.obs-entity-drawer__btn--ghost {
+  background: transparent;
+  border-color: var(--color-border-subtle);
+  color: var(--color-text-muted);
+}
+
+.obs-entity-drawer__btn--ghost:hover {
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-secondary);
+}
+
+/* Legacy field list (kept for backwards compatibility) */
+.obs-entity-drawer__field-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: var(--space-1);
 }
 
 .obs-entity-drawer__field {

--- a/web-next/packages/plugin-observatory/src/ui/overlays/EntityDrawer.test.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/overlays/EntityDrawer.test.tsx
@@ -22,6 +22,10 @@ const REALM_NODE: TopologyNode = {
   label: 'asgard',
   parentId: null,
   status: 'healthy',
+  vlan: 90,
+  dns: 'asgard.niuu.world',
+  purpose: 'AI / compute / dev',
+  zone: 'asgard',
 };
 
 const CLUSTER_NODE: TopologyNode = {
@@ -30,6 +34,8 @@ const CLUSTER_NODE: TopologyNode = {
   label: 'valaskjálf',
   parentId: 'realm-asgard',
   status: 'healthy',
+  zone: 'asgard',
+  purpose: 'DGX Spark cluster',
 };
 
 const HOST_NODE: TopologyNode = {
@@ -38,6 +44,10 @@ const HOST_NODE: TopologyNode = {
   label: 'mjölnir',
   parentId: 'realm-asgard',
   status: 'healthy',
+  zone: 'asgard',
+  hw: 'DGX Spark',
+  os: 'Ubuntu 24',
+  cores: 144,
 };
 
 const TYR_NODE: TopologyNode = {
@@ -46,6 +56,11 @@ const TYR_NODE: TopologyNode = {
   label: 'tyr-0',
   parentId: 'cluster-valaskjalf',
   status: 'healthy',
+  zone: 'asgard',
+  mode: 'active',
+  activeSagas: 3,
+  pendingRaids: 2,
+  activity: 'thinking',
 };
 
 const DEGRADED_NODE: TopologyNode = {
@@ -54,6 +69,44 @@ const DEGRADED_NODE: TopologyNode = {
   label: 'my-svc',
   parentId: 'cluster-valaskjalf',
   status: 'degraded',
+  svcType: 'database',
+};
+
+const RAVN_NODE: TopologyNode = {
+  id: 'ravn-huginn',
+  typeId: 'ravn_long',
+  label: 'huginn',
+  parentId: 'host-mjolnir',
+  status: 'healthy',
+  zone: 'asgard',
+  hostId: 'host-mjolnir',
+  persona: 'thought',
+  specialty: 'architecture & design',
+  tokens: 42800,
+  activity: 'thinking',
+};
+
+const BIFROST_NODE: TopologyNode = {
+  id: 'bifrost-0',
+  typeId: 'bifrost',
+  label: 'bifröst-0',
+  parentId: 'cluster-valaskjalf',
+  status: 'healthy',
+  zone: 'asgard',
+  providers: ['Anthropic', 'OpenAI'],
+  reqPerMin: 42,
+  cacheHitRate: 0.68,
+  activity: 'idle',
+};
+
+const VOLUNDR_NODE: TopologyNode = {
+  id: 'volundr-0',
+  typeId: 'volundr',
+  label: 'völundr-0',
+  parentId: 'cluster-valhalla',
+  status: 'healthy',
+  activeSessions: 5,
+  maxSessions: 20,
 };
 
 function renderDrawer(
@@ -82,23 +135,37 @@ function renderDrawer(
 describe('EntityDrawer', () => {
   it('renders nothing visible when node is null (drawer closed)', () => {
     renderDrawer(null);
-    // The Drawer portal should not render any content
     expect(screen.queryByRole('dialog')).toBeNull();
   });
 
-  it('opens with the node label as the drawer title', () => {
+  it('opens with the node label as the drawer title for realm', () => {
     renderDrawer(REALM_NODE);
     expect(screen.getByRole('dialog', { name: /asgard/i })).toBeInTheDocument();
   });
 
-  it('displays entity type label and rune in the head for realm', () => {
-    renderDrawer(REALM_NODE);
-    expect(screen.getByText('Realm')).toBeInTheDocument();
-    expect(screen.getByText('ᛞ')).toBeInTheDocument();
+  it('opens with the node label as the drawer title for cluster', () => {
+    renderDrawer(CLUSTER_NODE);
+    expect(screen.getByRole('dialog', { name: /valaskjálf/i })).toBeInTheDocument();
   });
 
-  it('shows node status text in the head', () => {
+  it('shows realm eyebrow text', () => {
     renderDrawer(REALM_NODE);
+    expect(screen.getByText(/Realm · VLAN zone/i)).toBeInTheDocument();
+  });
+
+  it('shows cluster eyebrow text', () => {
+    renderDrawer(CLUSTER_NODE);
+    expect(screen.getByText(/Cluster · k8s/i)).toBeInTheDocument();
+  });
+
+  it('shows entity type label and rune in head for tyr', () => {
+    renderDrawer(TYR_NODE);
+    expect(screen.getByText('ᛃ')).toBeInTheDocument();
+    expect(screen.getByText(/Týr/)).toBeInTheDocument();
+  });
+
+  it('shows node status text for tyr', () => {
+    renderDrawer(TYR_NODE);
     expect(screen.getByText('healthy')).toBeInTheDocument();
   });
 
@@ -107,105 +174,111 @@ describe('EntityDrawer', () => {
     expect(screen.getByText('degraded')).toBeInTheDocument();
   });
 
-  it('shows resident list for realm kind when residents exist', () => {
+  it('shows realm vlan chip when vlan is set', () => {
     renderDrawer(REALM_NODE);
-    expect(screen.getByText('Residents')).toBeInTheDocument();
-    // TOPOLOGY has cluster-valaskjalf and cluster-valhalla and host-mjolnir with parentId realm-asgard
-    expect(screen.getByText('valaskjálf')).toBeInTheDocument();
-    expect(screen.getByText('mjölnir')).toBeInTheDocument();
+    expect(screen.getByText('vlan 90')).toBeInTheDocument();
   });
 
-  it('shows resident list for cluster kind', () => {
-    renderDrawer(CLUSTER_NODE);
+  it('shows realm About section with dns', () => {
+    renderDrawer(REALM_NODE);
+    expect(screen.getByText('asgard.niuu.world')).toBeInTheDocument();
+  });
+
+  it('shows realm residents section with children from topology', () => {
+    renderDrawer(REALM_NODE);
+    // TOPOLOGY has cluster-valaskjalf and cluster-valhalla and host-mjolnir with parentId realm-asgard
     expect(screen.getByText('Residents')).toBeInTheDocument();
-    // tyr-0 and bifrost-0 and others have parentId cluster-valaskjalf
+    expect(screen.getByText('valaskjálf')).toBeInTheDocument();
+  });
+
+  it('shows cluster members section', () => {
+    renderDrawer(CLUSTER_NODE);
+    expect(screen.getByText('Members')).toBeInTheDocument();
     expect(screen.getByText('tyr-0')).toBeInTheDocument();
   });
 
-  it('shows resident list for host kind', () => {
+  it('shows host residents section', () => {
     renderDrawer(HOST_NODE);
     expect(screen.getByText('Residents')).toBeInTheDocument();
-    // huginn and muninn have parentId host-mjolnir
     expect(screen.getByText('huginn')).toBeInTheDocument();
   });
 
-  it('does not show residents section when container has no residents', () => {
-    const emptyTopology: Topology = { nodes: [REALM_NODE], edges: [], timestamp: '' };
-    renderDrawer(REALM_NODE, { topology: emptyTopology });
-    expect(screen.queryByText('Residents')).toBeNull();
+  it('shows tyr Properties section', () => {
+    renderDrawer(TYR_NODE);
+    expect(screen.getByText('Properties')).toBeInTheDocument();
+    expect(screen.getByText('active sagas')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
   });
 
-  it('calls onNodeSelect when a resident button is clicked', () => {
+  it('shows tyr mode badge', () => {
+    renderDrawer(TYR_NODE);
+    expect(screen.getByText('active')).toBeInTheDocument();
+  });
+
+  it('shows bifrost Properties with cache hit rate', () => {
+    renderDrawer(BIFROST_NODE);
+    expect(screen.getByText('Properties')).toBeInTheDocument();
+    expect(screen.getByText('68%')).toBeInTheDocument();
+    expect(screen.getByText('Anthropic, OpenAI')).toBeInTheDocument();
+  });
+
+  it('shows volundr Properties with sessions', () => {
+    renderDrawer(VOLUNDR_NODE);
+    expect(screen.getByText('Properties')).toBeInTheDocument();
+    expect(screen.getByText('5 / 20')).toBeInTheDocument();
+  });
+
+  it('shows ravn_long Properties with persona and tokens', () => {
+    renderDrawer(RAVN_NODE);
+    expect(screen.getByText('Properties')).toBeInTheDocument();
+    expect(screen.getByText('thought')).toBeInTheDocument();
+    expect(screen.getByText('42,800')).toBeInTheDocument();
+  });
+
+  it('shows Identity section for entity nodes', () => {
+    renderDrawer(TYR_NODE);
+    expect(screen.getByText('Identity')).toBeInTheDocument();
+    // tyr-0 appears as both the drawer title and the identity id — getAllByText handles both
+    expect(screen.getAllByText('tyr-0').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows Actions section for entity nodes', () => {
+    renderDrawer(TYR_NODE);
+    expect(screen.getByText('Actions')).toBeInTheDocument();
+    expect(screen.getByText('Open chat')).toBeInTheDocument();
+  });
+
+  it('shows activity row when activity is set', () => {
+    renderDrawer(TYR_NODE);
+    expect(screen.getByText('THINKING')).toBeInTheDocument();
+  });
+
+  it('calls onNodeSelect when a resident button is clicked (realm)', () => {
     const onNodeSelect = vi.fn();
     renderDrawer(REALM_NODE, { onNodeSelect });
     const clusterBtn = screen.getByTestId('resident-cluster-valaskjalf');
     fireEvent.click(clusterBtn);
     expect(onNodeSelect).toHaveBeenCalledOnce();
-    expect(onNodeSelect).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'cluster-valaskjalf' }),
-    );
   });
 
-  it('shows Fields section for non-container entity (tyr)', () => {
-    renderDrawer(TYR_NODE);
-    expect(screen.getByText('Fields')).toBeInTheDocument();
-    expect(screen.getByText('Active sagas')).toBeInTheDocument();
+  it('calls onNodeSelect when a member button is clicked (cluster)', () => {
+    const onNodeSelect = vi.fn();
+    renderDrawer(CLUSTER_NODE, { onNodeSelect });
+    const tyrBtn = screen.getByTestId('resident-tyr-0');
+    fireEvent.click(tyrBtn);
+    expect(onNodeSelect).toHaveBeenCalledWith(expect.objectContaining({ id: 'tyr-0' }));
   });
 
-  it('does not show Fields for non-container when entity has no fields', () => {
-    const emptyFieldsRegistry: Registry = {
-      ...REGISTRY,
-      types: REGISTRY.types.map((t) => (t.id === 'tyr' ? { ...t, fields: [] } : t)),
-    };
-    renderDrawer(TYR_NODE, { registry: emptyFieldsRegistry });
-    expect(screen.queryByText('Fields')).toBeNull();
-  });
-
-  it('shows required field marker (*) for required fields', () => {
-    renderDrawer(REALM_NODE);
-    // realm is a container; switch to realm type entity for fields test
-    // Instead test tyr which has required: undefined fields but realm has required: true
-    // realm has { key: 'vlan', required: true }
-    // But realm is a container, so Fields section won't show — need to pick a non-container
-    // Ravn_long has required: undefined; use a custom registry
-    const customRegistry: Registry = {
-      ...REGISTRY,
-      types: REGISTRY.types.map((t) =>
-        t.id === 'tyr'
-          ? { ...t, fields: [{ key: 'x', label: 'X Field', type: 'number', required: true }] }
-          : t,
-      ),
-    };
-    renderDrawer(TYR_NODE, { registry: customRegistry });
-    expect(screen.getByLabelText('required')).toBeInTheDocument();
-  });
-
-  it('shows description when entity type has description', () => {
-    renderDrawer(REALM_NODE);
-    expect(screen.getByText(/VLAN-scoped network zone/)).toBeInTheDocument();
-  });
-
-  it('shows typeId as fallback label when entity type not in registry', () => {
-    renderDrawer({
-      id: 'x',
-      typeId: 'unknown-type',
-      label: 'x',
-      parentId: null,
-      status: 'unknown',
-    });
-    expect(screen.getByText('unknown-type')).toBeInTheDocument();
+  it('does not show Residents when realm has no children', () => {
+    const emptyTopology: Topology = { nodes: [REALM_NODE], edges: [], timestamp: '' };
+    renderDrawer(REALM_NODE, { topology: emptyTopology });
+    expect(screen.queryByText('Residents')).toBeNull();
   });
 
   it('calls onClose when drawer close button is clicked', () => {
-    const { onClose } = renderDrawer(REALM_NODE);
+    const { onClose } = renderDrawer(TYR_NODE);
     fireEvent.click(screen.getByRole('button', { name: /close/i }));
     expect(onClose).toHaveBeenCalledOnce();
-  });
-
-  it('does not throw when onNodeSelect is not provided and resident is clicked', () => {
-    renderDrawer(REALM_NODE);
-    const clusterBtn = screen.getByTestId('resident-cluster-valaskjalf');
-    expect(() => fireEvent.click(clusterBtn)).not.toThrow();
   });
 
   it('handles null topology gracefully (no residents)', () => {
@@ -214,9 +287,8 @@ describe('EntityDrawer', () => {
   });
 
   it('handles null registry gracefully (no rune, fallback label)', () => {
-    renderDrawer(REALM_NODE, { registry: null });
-    // No rune rendered, typeId shown as label
-    expect(screen.getByText('realm')).toBeInTheDocument();
+    renderDrawer(TYR_NODE, { registry: null });
+    expect(screen.getByText('tyr')).toBeInTheDocument();
   });
 
   it('shows all NodeStatus variants without error', () => {
@@ -233,5 +305,16 @@ describe('EntityDrawer', () => {
       expect(screen.getByText(status)).toBeInTheDocument();
       unmount();
     }
+  });
+
+  it('shows typeId as fallback label when entity type not in registry', () => {
+    renderDrawer({
+      id: 'x',
+      typeId: 'unknown-type',
+      label: 'x',
+      parentId: null,
+      status: 'unknown',
+    });
+    expect(screen.getByText('unknown-type')).toBeInTheDocument();
   });
 });

--- a/web-next/packages/plugin-observatory/src/ui/overlays/EntityDrawer.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/overlays/EntityDrawer.tsx
@@ -157,13 +157,13 @@ function KindProperties({ node }: { node: TopologyNode }) {
         {kind === 'printer' && (
           <>
             <dt>model</dt>
-            <dd>Saturn 4 Ultra</dd>
+            <dd>{node.model ?? '—'}</dd>
           </>
         )}
         {kind === 'vaettir' && (
           <>
             <dt>sensors</dt>
-            <dd>mmWave · mic · speaker</dd>
+            <dd>{node.sensors ?? '—'}</dd>
           </>
         )}
         {kind === 'service' && (
@@ -190,11 +190,10 @@ function KindProperties({ node }: { node: TopologyNode }) {
 interface RealmDrawerProps {
   node: TopologyNode;
   topology: Topology | null;
-  onClose: () => void;
   onNodeSelect?: (node: TopologyNode) => void;
 }
 
-function RealmDrawer({ node, topology, onClose, onNodeSelect }: RealmDrawerProps) {
+function RealmDrawer({ node, topology, onNodeSelect }: RealmDrawerProps) {
   const residents = topology ? topology.nodes.filter((n) => n.parentId === node.id) : [];
 
   return (
@@ -272,11 +271,10 @@ function RealmDrawer({ node, topology, onClose, onNodeSelect }: RealmDrawerProps
 interface ClusterDrawerProps {
   node: TopologyNode;
   topology: Topology | null;
-  onClose: () => void;
   onNodeSelect?: (node: TopologyNode) => void;
 }
 
-function ClusterDrawer({ node, topology, onClose, onNodeSelect }: ClusterDrawerProps) {
+function ClusterDrawer({ node, topology, onNodeSelect }: ClusterDrawerProps) {
   const members = topology ? topology.nodes.filter((n) => n.parentId === node.id) : [];
 
   return (
@@ -373,15 +371,10 @@ export function EntityDrawer({
       }}
     >
       {node && isRealm && (
-        <RealmDrawer node={node} topology={topology} onClose={onClose} onNodeSelect={onNodeSelect} />
+        <RealmDrawer node={node} topology={topology} onNodeSelect={onNodeSelect} />
       )}
       {node && isCluster && (
-        <ClusterDrawer
-          node={node}
-          topology={topology}
-          onClose={onClose}
-          onNodeSelect={onNodeSelect}
-        />
+        <ClusterDrawer node={node} topology={topology} onNodeSelect={onNodeSelect} />
       )}
       {node && !isRealm && !isCluster && (
         <DrawerContent title={node.label} width={360}>
@@ -416,7 +409,7 @@ export function EntityDrawer({
                   {node.activity.toUpperCase()}
                 </span>
                 <span className="obs-entity-drawer__activity-ts">
-                  last tick · {new Date().toISOString().slice(14, 19)}
+                  last tick · {topology?.timestamp.slice(11, 19) ?? '--:--'}
                 </span>
               </div>
             )}

--- a/web-next/packages/plugin-observatory/src/ui/overlays/EntityDrawer.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/overlays/EntityDrawer.tsx
@@ -1,6 +1,7 @@
+import { useMemo } from 'react';
 import { Drawer, DrawerContent, Sparkline, StateDot } from '@niuulabs/ui';
 import type { DotState } from '@niuulabs/ui';
-import type { TopologyNode, Topology, Registry } from '../../domain';
+import type { TopologyNode, Topology, Registry, NodeActivity } from '../../domain';
 import './EntityDrawer.css';
 
 export interface EntityDrawerProps {
@@ -12,7 +13,332 @@ export interface EntityDrawerProps {
   onNodeSelect?: (node: TopologyNode) => void;
 }
 
-const CONTAINER_KINDS = new Set(['realm', 'cluster', 'host']);
+// ── Activity dot ──────────────────────────────────────────────────────────────
+
+const ACTIVITY_COLOR: Record<NodeActivity, string> = {
+  idle: 'var(--color-text-muted)',
+  thinking: 'var(--brand-300, var(--color-brand))',
+  tooling: 'var(--brand-400, var(--color-brand))',
+  waiting: 'var(--color-text-muted)',
+  delegating: 'var(--brand-200, var(--color-brand))',
+  writing: 'var(--brand-200, var(--color-brand))',
+  reading: 'var(--brand-300, var(--color-brand))',
+};
+
+function ActivityDot({ activity }: { activity: NodeActivity }) {
+  const color = ACTIVITY_COLOR[activity] ?? 'var(--color-text-muted)';
+  const pulsing = activity !== 'idle';
+  return (
+    <span
+      className={`obs-entity-drawer__activity-dot${pulsing ? ' obs-entity-drawer__activity-dot--pulse' : ''}`}
+      style={{ background: color, boxShadow: pulsing ? `0 0 8px ${color}` : 'none' }}
+      aria-label={activity}
+    />
+  );
+}
+
+// ── Kind-specific properties ──────────────────────────────────────────────────
+
+function KindProperties({ node }: { node: TopologyNode }) {
+  const kind = node.typeId;
+
+  if (
+    ![
+      'tyr',
+      'bifrost',
+      'volundr',
+      'ravn_long',
+      'valkyrie',
+      'host',
+      'printer',
+      'vaettir',
+      'service',
+      'model',
+    ].includes(kind)
+  ) {
+    return null;
+  }
+
+  return (
+    <section className="obs-entity-drawer__section">
+      <h4 className="obs-entity-drawer__section-title">Properties</h4>
+      <dl className="obs-entity-drawer__prop-grid">
+        {kind === 'tyr' && (
+          <>
+            <dt>mode</dt>
+            <dd>
+              <span
+                className="obs-entity-drawer__badge"
+                data-mode={node.mode}
+              >
+                {node.mode ?? '—'}
+              </span>
+            </dd>
+            <dt>active sagas</dt>
+            <dd>{node.activeSagas ?? 0}</dd>
+            <dt>pending raids</dt>
+            <dd>{node.pendingRaids ?? 0}</dd>
+          </>
+        )}
+        {kind === 'bifrost' && (
+          <>
+            <dt>providers</dt>
+            <dd>{node.providers?.join(', ') ?? '—'}</dd>
+            <dt>req/min</dt>
+            <dd>{node.reqPerMin ?? 0}</dd>
+            <dt>cache hit</dt>
+            <dd>{node.cacheHitRate !== undefined ? `${Math.round(node.cacheHitRate * 100)}%` : '—'}</dd>
+          </>
+        )}
+        {kind === 'volundr' && (
+          <>
+            <dt>sessions</dt>
+            <dd>
+              {node.activeSessions ?? 0} / {node.maxSessions ?? 0}
+            </dd>
+          </>
+        )}
+        {kind === 'ravn_long' && (
+          <>
+            {node.persona && (
+              <>
+                <dt>persona</dt>
+                <dd>{node.persona}</dd>
+              </>
+            )}
+            {node.specialty && (
+              <>
+                <dt>specialty</dt>
+                <dd className="obs-entity-drawer__plain">{node.specialty}</dd>
+              </>
+            )}
+            <dt>tokens</dt>
+            <dd>{node.tokens !== undefined ? node.tokens.toLocaleString() : '—'}</dd>
+          </>
+        )}
+        {kind === 'valkyrie' && (
+          <>
+            <dt>specialty</dt>
+            <dd className="obs-entity-drawer__plain">{node.specialty ?? '—'}</dd>
+            <dt>autonomy</dt>
+            <dd>
+              <span className="obs-entity-drawer__badge" data-autonomy={node.autonomy}>
+                {node.autonomy ?? '—'}
+              </span>
+            </dd>
+          </>
+        )}
+        {kind === 'host' && (
+          <>
+            <dt>hardware</dt>
+            <dd className="obs-entity-drawer__plain">{node.hw ?? '—'}</dd>
+            <dt>os</dt>
+            <dd>{node.os ?? '—'}</dd>
+            {node.cores !== undefined && (
+              <>
+                <dt>cores</dt>
+                <dd>{node.cores}</dd>
+              </>
+            )}
+            {node.ram && (
+              <>
+                <dt>ram</dt>
+                <dd>{node.ram}</dd>
+              </>
+            )}
+            {node.gpu && (
+              <>
+                <dt>gpu</dt>
+                <dd>{node.gpu}</dd>
+              </>
+            )}
+          </>
+        )}
+        {kind === 'printer' && (
+          <>
+            <dt>model</dt>
+            <dd>Saturn 4 Ultra</dd>
+          </>
+        )}
+        {kind === 'vaettir' && (
+          <>
+            <dt>sensors</dt>
+            <dd>mmWave · mic · speaker</dd>
+          </>
+        )}
+        {kind === 'service' && (
+          <>
+            <dt>type</dt>
+            <dd>{node.svcType ?? '—'}</dd>
+          </>
+        )}
+        {kind === 'model' && (
+          <>
+            <dt>provider</dt>
+            <dd>{node.provider ?? '—'}</dd>
+            <dt>location</dt>
+            <dd>{node.location ?? '—'}</dd>
+          </>
+        )}
+      </dl>
+    </section>
+  );
+}
+
+// ── Realm drawer ──────────────────────────────────────────────────────────────
+
+interface RealmDrawerProps {
+  node: TopologyNode;
+  topology: Topology | null;
+  onClose: () => void;
+  onNodeSelect?: (node: TopologyNode) => void;
+}
+
+function RealmDrawer({ node, topology, onClose, onNodeSelect }: RealmDrawerProps) {
+  const residents = topology ? topology.nodes.filter((n) => n.parentId === node.id) : [];
+
+  return (
+    <DrawerContent title={node.label} width={360}>
+      <div className="obs-entity-drawer__head">
+        <div className="obs-entity-drawer__identity">
+          <span className="obs-entity-drawer__rune" aria-hidden="true">
+            ᛞ
+          </span>
+          <div className="obs-entity-drawer__meta">
+            <span className="obs-entity-drawer__type-label">Realm · VLAN zone</span>
+            {node.vlan !== undefined && (
+              <span className="obs-entity-drawer__id-chip">vlan {node.vlan}</span>
+            )}
+          </div>
+        </div>
+      </div>
+      <div className="obs-entity-drawer__body">
+        {node.purpose && (
+          <p className="obs-entity-drawer__description">{node.purpose}</p>
+        )}
+        <section className="obs-entity-drawer__section">
+          <h4 className="obs-entity-drawer__section-title">About</h4>
+          <dl className="obs-entity-drawer__prop-grid">
+            {node.vlan !== undefined && (
+              <>
+                <dt>vlan</dt>
+                <dd>{node.vlan}</dd>
+              </>
+            )}
+            {node.dns && (
+              <>
+                <dt>dns</dt>
+                <dd>{node.dns}</dd>
+              </>
+            )}
+            <dt>residents</dt>
+            <dd>{residents.length}</dd>
+          </dl>
+        </section>
+        {residents.length > 0 && (
+          <section className="obs-entity-drawer__section">
+            <h4 className="obs-entity-drawer__section-title">Residents</h4>
+            <ul className="obs-entity-drawer__resident-list">
+              {residents.slice(0, 20).map((resident) => (
+                <li key={resident.id}>
+                  <button
+                    className="obs-entity-drawer__resident-btn"
+                    onClick={() => onNodeSelect?.(resident)}
+                    data-testid={`resident-${resident.id}`}
+                  >
+                    {resident.activity && (
+                      <ActivityDot activity={resident.activity} />
+                    )}
+                    <span className="obs-entity-drawer__resident-label">{resident.label}</span>
+                    <span className="obs-entity-drawer__resident-kind">{resident.typeId}</span>
+                  </button>
+                </li>
+              ))}
+              {residents.length > 20 && (
+                <li className="obs-entity-drawer__resident-overflow">
+                  +{residents.length - 20} more
+                </li>
+              )}
+            </ul>
+          </section>
+        )}
+      </div>
+    </DrawerContent>
+  );
+}
+
+// ── Cluster drawer ────────────────────────────────────────────────────────────
+
+interface ClusterDrawerProps {
+  node: TopologyNode;
+  topology: Topology | null;
+  onClose: () => void;
+  onNodeSelect?: (node: TopologyNode) => void;
+}
+
+function ClusterDrawer({ node, topology, onClose, onNodeSelect }: ClusterDrawerProps) {
+  const members = topology ? topology.nodes.filter((n) => n.parentId === node.id) : [];
+
+  return (
+    <DrawerContent title={node.label} width={360}>
+      <div className="obs-entity-drawer__head">
+        <div className="obs-entity-drawer__identity">
+          <span className="obs-entity-drawer__rune" aria-hidden="true">
+            ᚲ
+          </span>
+          <div className="obs-entity-drawer__meta">
+            <span className="obs-entity-drawer__type-label">Cluster · k8s</span>
+            {node.parentId && (
+              <span className="obs-entity-drawer__id-chip">realm · {node.zone ?? node.parentId}</span>
+            )}
+          </div>
+        </div>
+      </div>
+      <div className="obs-entity-drawer__body">
+        <section className="obs-entity-drawer__section">
+          <h4 className="obs-entity-drawer__section-title">About</h4>
+          {node.purpose && (
+            <p className="obs-entity-drawer__description">{node.purpose}</p>
+          )}
+          <dl className="obs-entity-drawer__prop-grid">
+            {node.zone && (
+              <>
+                <dt>realm</dt>
+                <dd>{node.zone}</dd>
+              </>
+            )}
+            <dt>members</dt>
+            <dd>{members.length}</dd>
+          </dl>
+        </section>
+        {members.length > 0 && (
+          <section className="obs-entity-drawer__section">
+            <h4 className="obs-entity-drawer__section-title">Members</h4>
+            <ul className="obs-entity-drawer__resident-list">
+              {members.map((member) => (
+                <li key={member.id}>
+                  <button
+                    className="obs-entity-drawer__resident-btn"
+                    onClick={() => onNodeSelect?.(member)}
+                    data-testid={`resident-${member.id}`}
+                  >
+                    {member.activity && (
+                      <ActivityDot activity={member.activity} />
+                    )}
+                    <span className="obs-entity-drawer__resident-label">{member.label}</span>
+                    <span className="obs-entity-drawer__resident-kind">{member.typeId}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+      </div>
+    </DrawerContent>
+  );
+}
+
+// ── Main entity drawer ────────────────────────────────────────────────────────
 
 export function EntityDrawer({
   node,
@@ -23,7 +349,21 @@ export function EntityDrawer({
 }: EntityDrawerProps) {
   const entityType = node ? registry?.types.find((t) => t.id === node.typeId) : undefined;
   const residents = node && topology ? topology.nodes.filter((n) => n.parentId === node.id) : [];
-  const isContainerKind = node ? CONTAINER_KINDS.has(node.typeId) : false;
+  const isRealm = node?.typeId === 'realm';
+  const isCluster = node?.typeId === 'cluster';
+  const isContainer = ['realm', 'cluster', 'host'].includes(node?.typeId ?? '');
+
+  // Sparkline seed: deterministic per-entity pseudo-random values.
+  const sparkValues = useMemo(() => {
+    if (!node) return [];
+    const seed = node.id.charCodeAt(0) + node.id.charCodeAt(node.id.length - 1);
+    return Array.from(
+      { length: 24 },
+      (_, i) => 30 + Math.sin(i * 0.7 + seed) * 15 + (Math.sin(i * 1.3 + seed * 3) * 10 + 10),
+    );
+  }, [node?.id]);
+
+  const showSparkline = ['ravn_long', 'bifrost'].includes(node?.typeId ?? '');
 
   return (
     <Drawer
@@ -32,9 +372,20 @@ export function EntityDrawer({
         if (!open) onClose();
       }}
     >
-      {node && (
+      {node && isRealm && (
+        <RealmDrawer node={node} topology={topology} onClose={onClose} onNodeSelect={onNodeSelect} />
+      )}
+      {node && isCluster && (
+        <ClusterDrawer
+          node={node}
+          topology={topology}
+          onClose={onClose}
+          onNodeSelect={onNodeSelect}
+        />
+      )}
+      {node && !isRealm && !isCluster && (
         <DrawerContent title={node.label} width={360}>
-          {/* HEAD — rune · label · status · sparkline */}
+          {/* HEAD — rune · label · activity · status · timestamp */}
           <div className="obs-entity-drawer__head">
             <div className="obs-entity-drawer__identity">
               {entityType && (
@@ -44,7 +395,7 @@ export function EntityDrawer({
               )}
               <div className="obs-entity-drawer__meta">
                 <span className="obs-entity-drawer__type-label">
-                  {entityType?.label ?? node.typeId}
+                  {entityType?.label ?? node.typeId} · entity
                 </span>
                 <div className="obs-entity-drawer__status">
                   <StateDot state={node.status as DotState} />
@@ -52,16 +403,78 @@ export function EntityDrawer({
                 </div>
               </div>
             </div>
-            <Sparkline id={node.id} width={120} height={28} />
+            {showSparkline && <Sparkline id={node.id} width={120} height={28} />}
           </div>
 
           {/* BODY */}
           <div className="obs-entity-drawer__body">
-            {entityType?.description && (
-              <p className="obs-entity-drawer__description">{entityType.description}</p>
+            {/* Activity row */}
+            {node.activity && (
+              <div className="obs-entity-drawer__activity-row">
+                <ActivityDot activity={node.activity} />
+                <span className="obs-entity-drawer__activity-label">
+                  {node.activity.toUpperCase()}
+                </span>
+                <span className="obs-entity-drawer__activity-ts">
+                  last tick · {new Date().toISOString().slice(14, 19)}
+                </span>
+              </div>
             )}
 
-            {isContainerKind && residents.length > 0 && (
+            {entityType?.description && (
+              <p className="obs-entity-drawer__description">{entityType.description.split('.')[0]}.</p>
+            )}
+
+            {/* Identity section */}
+            <section className="obs-entity-drawer__section">
+              <h4 className="obs-entity-drawer__section-title">Identity</h4>
+              <dl className="obs-entity-drawer__prop-grid">
+                <dt>id</dt>
+                <dd>{node.id}</dd>
+                <dt>kind</dt>
+                <dd>{node.typeId}</dd>
+                {node.zone && (
+                  <>
+                    <dt>realm</dt>
+                    <dd>{node.zone}</dd>
+                  </>
+                )}
+                {node.cluster && (
+                  <>
+                    <dt>cluster</dt>
+                    <dd>{node.cluster}</dd>
+                  </>
+                )}
+                {node.hostId && (
+                  <>
+                    <dt>host</dt>
+                    <dd>
+                      <button
+                        className="obs-entity-drawer__link"
+                        onClick={() => {
+                          const hostNode = topology?.nodes.find((n) => n.id === node.hostId);
+                          if (hostNode) onNodeSelect?.(hostNode);
+                        }}
+                      >
+                        {node.hostId}
+                      </button>
+                    </dd>
+                  </>
+                )}
+                {node.flockId && node.flockId !== 'long' && (
+                  <>
+                    <dt>flock</dt>
+                    <dd>{node.flockId}</dd>
+                  </>
+                )}
+              </dl>
+            </section>
+
+            {/* Kind-specific properties */}
+            <KindProperties node={node} />
+
+            {/* Residents for host containers */}
+            {isContainer && residents.length > 0 && (
               <section className="obs-entity-drawer__section">
                 <h4 className="obs-entity-drawer__section-title">Residents</h4>
                 <ul className="obs-entity-drawer__resident-list">
@@ -75,7 +488,10 @@ export function EntityDrawer({
                           data-testid={`resident-${resident.id}`}
                         >
                           {residentType && (
-                            <span className="obs-entity-drawer__resident-rune" aria-hidden="true">
+                            <span
+                              className="obs-entity-drawer__resident-rune"
+                              aria-hidden="true"
+                            >
                               {residentType.rune}
                             </span>
                           )}
@@ -91,24 +507,63 @@ export function EntityDrawer({
               </section>
             )}
 
-            {!isContainerKind && entityType && entityType.fields.length > 0 && (
+            {/* Coordinator confidence section */}
+            {node.role === 'coord' && node.confidence !== undefined && (
               <section className="obs-entity-drawer__section">
-                <h4 className="obs-entity-drawer__section-title">Fields</h4>
-                <ul className="obs-entity-drawer__field-list">
-                  {entityType.fields.map((field) => (
-                    <li key={field.key} className="obs-entity-drawer__field">
-                      <span className="obs-entity-drawer__field-label">{field.label}</span>
-                      <span className="obs-entity-drawer__field-type">{field.type}</span>
-                      {field.required && (
-                        <span className="obs-entity-drawer__field-required" aria-label="required">
-                          *
-                        </span>
-                      )}
-                    </li>
-                  ))}
-                </ul>
+                <h4 className="obs-entity-drawer__section-title">Coordinator</h4>
+                <dl className="obs-entity-drawer__prop-grid">
+                  <dt>confidence</dt>
+                  <dd className="obs-entity-drawer__conf-bar">
+                    <span className="obs-entity-drawer__conf-track">
+                      <span
+                        className="obs-entity-drawer__conf-fill"
+                        style={{ width: `${node.confidence * 100}%` }}
+                      />
+                    </span>
+                    <span>{Math.round(node.confidence * 100)}%</span>
+                  </dd>
+                </dl>
               </section>
             )}
+
+            {/* Token throughput sparkline */}
+            {showSparkline && sparkValues.length > 0 && (
+              <section className="obs-entity-drawer__section">
+                <h4 className="obs-entity-drawer__section-title">Token throughput · 24 ticks</h4>
+                <svg
+                  className="obs-entity-drawer__sparkline"
+                  viewBox="0 0 240 32"
+                  preserveAspectRatio="none"
+                  aria-hidden="true"
+                >
+                  <polyline
+                    points={sparkValues.map((v, i) => `${i * 10},${32 - v * 0.5}`).join(' ')}
+                    fill="none"
+                    stroke="var(--brand-300, var(--color-brand))"
+                    strokeWidth="1.2"
+                  />
+                  <polyline
+                    points={`0,32 ${sparkValues.map((v, i) => `${i * 10},${32 - v * 0.5}`).join(' ')} 240,32`}
+                    fill="color-mix(in srgb, var(--brand-300, var(--color-brand)) 15%, transparent)"
+                    stroke="none"
+                  />
+                </svg>
+              </section>
+            )}
+
+            {/* Actions */}
+            <section className="obs-entity-drawer__section">
+              <h4 className="obs-entity-drawer__section-title">Actions</h4>
+              <div className="obs-entity-drawer__actions">
+                <button className="obs-entity-drawer__btn obs-entity-drawer__btn--primary">
+                  Open chat
+                </button>
+                <button className="obs-entity-drawer__btn">Inspect in registry</button>
+                <button className="obs-entity-drawer__btn obs-entity-drawer__btn--ghost">
+                  Quarantine
+                </button>
+              </div>
+            </section>
           </div>
         </DrawerContent>
       )}

--- a/web-next/packages/plugin-observatory/src/ui/overlays/EventLog.css
+++ b/web-next/packages/plugin-observatory/src/ui/overlays/EventLog.css
@@ -37,7 +37,7 @@
 
 .obs-event-log__entry {
   display: grid;
-  grid-template-columns: 8ch 3ch 14ch 1fr;
+  grid-template-columns: 8ch 7ch 14ch 1fr;
   gap: var(--space-2);
   align-items: baseline;
   font-family: var(--font-mono);
@@ -45,36 +45,41 @@
   padding: 1px var(--space-1);
   border-radius: var(--radius-sm);
   line-height: 1.6;
-}
-
-.obs-event-log__entry[data-severity='debug'] {
-  color: var(--color-text-muted);
-}
-.obs-event-log__entry[data-severity='info'] {
   color: var(--color-text-secondary);
-}
-.obs-event-log__entry[data-severity='warn'] {
-  color: var(--color-accent-amber);
-}
-.obs-event-log__entry[data-severity='error'] {
-  color: var(--color-accent-red);
 }
 
 .obs-event-log__ts {
   color: var(--color-text-muted);
   flex-shrink: 0;
 }
-.obs-event-log__sev {
+.obs-event-log__type {
   font-weight: 600;
   flex-shrink: 0;
+  letter-spacing: 0.04em;
 }
-.obs-event-log__src {
-  color: var(--color-text-muted);
+.obs-event-log__type--raid {
+  color: var(--color-accent-amber);
+}
+.obs-event-log__type--ravn {
+  color: var(--color-accent-purple);
+}
+.obs-event-log__type--tyr {
+  color: var(--color-accent-cyan);
+}
+.obs-event-log__type--mimir {
+  color: var(--color-accent-indigo);
+}
+.obs-event-log__type--bifrost {
+  color: var(--color-accent-emerald);
+}
+.obs-event-log__subject {
+  color: var(--color-text-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.obs-event-log__msg {
+.obs-event-log__body {
+  color: var(--color-text-muted);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/web-next/packages/plugin-observatory/src/ui/overlays/EventLog.test.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/overlays/EventLog.test.tsx
@@ -6,31 +6,31 @@ import type { ObservatoryEvent } from '../../domain';
 const EVENTS: ObservatoryEvent[] = [
   {
     id: 'ev-1',
-    timestamp: '2026-04-19T00:00:01Z',
-    severity: 'info',
-    sourceId: 'tyr-0',
-    message: 'raid-omega formed',
+    time: '00:00:01',
+    type: 'TYR',
+    subject: 'tyr-0',
+    body: 'raid-omega formed: 2 ravens conscripted',
   },
   {
     id: 'ev-2',
-    timestamp: '2026-04-19T00:00:05Z',
-    severity: 'warn',
-    sourceId: 'mimir-0',
-    message: 'write queue depth nearing threshold',
+    time: '00:00:05',
+    type: 'MIMIR',
+    subject: 'mimir-0',
+    body: 'write queue depth nearing threshold',
   },
   {
     id: 'ev-3',
-    timestamp: '2026-04-19T00:00:10Z',
-    severity: 'error',
-    sourceId: 'bifrost-0',
-    message: 'inference timeout',
+    time: '00:00:10',
+    type: 'BIFROST',
+    subject: 'bifrost-0',
+    body: 'inference timeout',
   },
   {
     id: 'ev-4',
-    timestamp: '2026-04-19T00:00:15Z',
-    severity: 'debug',
-    sourceId: 'ravn-huginn',
-    message: 'cache hit 94%',
+    time: '00:00:15',
+    type: 'RAVN',
+    subject: 'huginn',
+    body: 'cache hit 94%',
   },
 ];
 
@@ -40,37 +40,37 @@ describe('EventLog', () => {
     expect(screen.getByText('no events')).toBeInTheDocument();
   });
 
-  it('renders all event messages', () => {
+  it('renders all event body text', () => {
     render(<EventLog events={EVENTS} />);
-    expect(screen.getByText('raid-omega formed')).toBeInTheDocument();
+    expect(screen.getByText('raid-omega formed: 2 ravens conscripted')).toBeInTheDocument();
     expect(screen.getByText('inference timeout')).toBeInTheDocument();
   });
 
-  it('renders all event source IDs', () => {
+  it('renders all event subjects', () => {
     render(<EventLog events={EVENTS} />);
     expect(screen.getByText('tyr-0')).toBeInTheDocument();
     expect(screen.getByText('mimir-0')).toBeInTheDocument();
   });
 
-  it('renders truncated timestamps (HH:MM:SS)', () => {
+  it('renders time strings (HH:MM:SS)', () => {
     render(<EventLog events={EVENTS} />);
     expect(screen.getByText('00:00:01')).toBeInTheDocument();
   });
 
-  it('renders severity tags', () => {
+  it('renders event type tags', () => {
     render(<EventLog events={EVENTS} />);
-    expect(screen.getByText('INF')).toBeInTheDocument();
-    expect(screen.getByText('WRN')).toBeInTheDocument();
-    expect(screen.getByText('ERR')).toBeInTheDocument();
-    expect(screen.getByText('DBG')).toBeInTheDocument();
+    expect(screen.getByText('TYR')).toBeInTheDocument();
+    expect(screen.getByText('MIMIR')).toBeInTheDocument();
+    expect(screen.getByText('BIFROST')).toBeInTheDocument();
+    expect(screen.getByText('RAVN')).toBeInTheDocument();
   });
 
-  it('sets data-severity attribute on each entry', () => {
+  it('sets data-type attribute on each entry', () => {
     render(<EventLog events={EVENTS} />);
-    const infoEntry = screen.getByTestId('event-ev-1');
-    expect(infoEntry).toHaveAttribute('data-severity', 'info');
-    const warnEntry = screen.getByTestId('event-ev-2');
-    expect(warnEntry).toHaveAttribute('data-severity', 'warn');
+    const tyrEntry = screen.getByTestId('event-ev-1');
+    expect(tyrEntry).toHaveAttribute('data-type', 'TYR');
+    const mimirEntry = screen.getByTestId('event-ev-2');
+    expect(mimirEntry).toHaveAttribute('data-type', 'MIMIR');
   });
 
   it('accepts custom data-testid', () => {
@@ -88,5 +88,18 @@ describe('EventLog', () => {
   it('does not render "no events" when events are present', () => {
     render(<EventLog events={EVENTS} />);
     expect(screen.queryByText('no events')).toBeNull();
+  });
+
+  it('renders RAID type events', () => {
+    const raidEvent: ObservatoryEvent = {
+      id: 'ev-raid',
+      time: '00:01:00',
+      type: 'RAID',
+      subject: 'raid-omega',
+      body: 'tyr dispatched raid',
+    };
+    render(<EventLog events={[raidEvent]} />);
+    expect(screen.getByText('RAID')).toBeInTheDocument();
+    expect(screen.getByText('raid-omega')).toBeInTheDocument();
   });
 });

--- a/web-next/packages/plugin-observatory/src/ui/overlays/EventLog.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/overlays/EventLog.tsx
@@ -1,12 +1,14 @@
 import { useRef, useEffect } from 'react';
-import type { ObservatoryEvent, EventSeverity } from '../../domain';
+import type { ObservatoryEvent, ObservatoryEventType } from '../../domain';
 import './EventLog.css';
 
-const SEVERITY_TAG: Record<EventSeverity, string> = {
-  debug: 'DBG',
-  info: 'INF',
-  warn: 'WRN',
-  error: 'ERR',
+/** Short display tag for each event type (matches web2 column). */
+const TYPE_CLASS: Record<ObservatoryEventType, string> = {
+  RAID: 'obs-event-log__type--raid',
+  RAVN: 'obs-event-log__type--ravn',
+  TYR: 'obs-event-log__type--tyr',
+  MIMIR: 'obs-event-log__type--mimir',
+  BIFROST: 'obs-event-log__type--bifrost',
 };
 
 export interface EventLogProps {
@@ -34,15 +36,15 @@ export function EventLog({ events, 'data-testid': testId }: EventLogProps) {
             <div
               key={ev.id}
               className="obs-event-log__entry"
-              data-severity={ev.severity}
+              data-type={ev.type}
               data-testid={`event-${ev.id}`}
             >
-              <span className="obs-event-log__ts">{ev.timestamp.slice(11, 19)}</span>
-              <span className="obs-event-log__sev" data-sev={ev.severity}>
-                {SEVERITY_TAG[ev.severity]}
+              <span className="obs-event-log__ts">{ev.time}</span>
+              <span className={`obs-event-log__type ${TYPE_CLASS[ev.type] ?? ''}`}>
+                {ev.type}
               </span>
-              <span className="obs-event-log__src">{ev.sourceId}</span>
-              <span className="obs-event-log__msg">{ev.message}</span>
+              <span className="obs-event-log__subject">{ev.subject}</span>
+              <span className="obs-event-log__body">{ev.body}</span>
             </div>
           ))
         )}


### PR DESCRIPTION
## Summary

- **Domain extension**: `TopologyNode` extended with kind-specific optional fields (mode, activeSagas, providers, cacheHitRate, activeSessions, persona, tokens, hw, os, vlan, dns, purpose, state, zone, hostId, etc.)
- **Event model migration**: `ObservatoryEvent` now follows web2 format — `{id, time, type, subject, body}` where `type` is `RAID|RAVN|TYR|MIMIR|BIFROST`
- **EntityDrawer rebuild**: `RealmDrawer` (VLAN info, residents list), `ClusterDrawer` (members list), and generic drawer with `KindProperties` renderers for tyr/bifrost/volundr/ravn_long/host/service/model/printer/vaettir
- **ConnectionLegend fix**: labels updated to exactly match web2 prototype (e.g. "Týr ⇝ raid coord", "ravn → Mímir")
- **EventLog rebuild**: renders `time`, `type`, `subject`, `body` from web2 event format with per-type color coding
- **ObservatorySubnav**: new component wired via `PluginDescriptor.subnav` — shows entity filter (all/agents/raids/services/devices with counts), realms section (with VLAN), clusters section, active raids section
- **ObservatoryTopbar**: new component via `topbarRight` — shows realm/raven/raid counts
- **Cross-slot state store**: `useObservatoryStore` is a module-level singleton enabling content ↔ subnav ↔ topbar state sharing without prop-drilling or Context boundary issues
- **Accessible node list**: visually-hidden `<ul>` of node buttons in `ObservatoryPage` for keyboard/screen-reader accessibility and testability

## Test plan

- [x] All 298 tests pass across 17 test files (`vitest run`)
- [x] `ObservatorySubnav.test.tsx`: 14 tests covering filter counts, realm/cluster/raid rendering, click handlers
- [x] `ObservatoryTopbar.test.tsx`: 9 tests covering realm/raven/raid counts, null topology
- [x] `EntityDrawer.test.tsx`: 29 tests covering RealmDrawer, ClusterDrawer, generic drawer, all node types
- [x] `mock.test.ts`: 20 tests verifying web2 event format and kind-specific node fields
- [x] `ObservatoryPage.test.tsx`: 14 tests including drawer open/close/navigate flow (store reset in beforeEach)
- [x] Store state does not leak between tests (module-level `__resetObservatoryStore` in beforeEach)

> **Note**: Linear ticket NIU-689 could not be updated via MCP — no Linear MCP server is configured in `.claude/settings.json`. Please update NIU-689 manually to "In Review" and link this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)