### PR TITLE
fix(tests): keep line within 100-char ruff limit in test_phase1_utils (NIU-623)

### DIFF
--- a/tests/test_niuu/test_phase1_utils.py
+++ b/tests/test_niuu/test_phase1_utils.py
@@ -68,4 +68,5 @@ class TestDemoScript:
             capture_output=True,
             text=True,
         )
-        assert result.stdout == "Hello, Niuu!\nReversed: uuiN\nFibonacci(7): [0, 1, 1, 2, 3, 5, 8]\n"
+        expected = "Hello, Niuu!\nReversed: uuiN\nFibonacci(7): [0, 1, 1, 2, 3, 5, 8]\n"
+        assert result.stdout == expected


### PR DESCRIPTION
## Summary

NIU-623 wires the Phase 1 utilities (`greeting`, `reverse`, `fibonacci`) into a CLI demo script. The implementation was added in commit `d448dea` on the feature branch, but the test assertion on line 71 of `tests/test_niuu/test_phase1_utils.py` exceeded the 100-character ruff line-length limit (E501).

This PR fixes that lint issue by extracting the expected output string into a local variable:

```python
expected = "Hello, Niuu!\nReversed: uuiN\nFibonacci(7): [0, 1, 1, 2, 3, 5, 8]\n"
assert result.stdout == expected
```

## Test plan

- [x] `Python: Lint` — ruff check passes with the 100-char limit respected
- [x] `TestDemoScript.test_script_exits_with_code_zero` — runs `scripts/demo_utils.py` as subprocess and asserts returncode == 0
- [x] `TestDemoScript.test_script_output` — verifies exact stdout matches expected demo output

Closes NIU-623

> Note: Linear MCP tools were unavailable in this session; ticket status noted in PR description as fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)