### PR TITLE
feat(plugin-ravn): overview visual parity with web2 — NIU-703

### DIFF
--- a/web-next/packages/plugin-ravn/src/adapters/http.ts
+++ b/web-next/packages/plugin-ravn/src/adapters/http.ts
@@ -226,6 +226,8 @@ interface RawRavn {
   model: string;
   created_at: string;
   updated_at?: string;
+  role?: string;
+  letter?: string;
 }
 
 interface RawSession {
@@ -269,6 +271,8 @@ function toRavn(raw: RawRavn): Ravn {
     model: raw.model,
     createdAt: raw.created_at,
     updatedAt: raw.updated_at,
+    role: raw.role as Ravn['role'],
+    letter: raw.letter,
   };
 }
 

--- a/web-next/packages/plugin-ravn/src/adapters/mock.ts
+++ b/web-next/packages/plugin-ravn/src/adapters/mock.ts
@@ -338,6 +338,8 @@ const SEED_RAVENS: Ravn[] = [
     model: 'claude-sonnet-4-6',
     createdAt: '2026-04-15T09:12:34Z',
     location: 'eu-west-1',
+    role: 'build',
+    letter: 'C',
   },
   {
     id: 'b7e2c9d1-3a4f-4b8e-a1c6-5d7f8e9a0b2c',
@@ -346,6 +348,8 @@ const SEED_RAVENS: Ravn[] = [
     model: 'claude-opus-4-6',
     createdAt: '2026-04-15T08:45:11Z',
     location: 'us-east-1',
+    role: 'review',
+    letter: 'R',
   },
   {
     id: 'c4d5e6f7-1a2b-4c3d-8e9f-0a1b2c3d4e5f',
@@ -354,6 +358,8 @@ const SEED_RAVENS: Ravn[] = [
     model: 'claude-haiku-4-5',
     createdAt: '2026-04-15T08:30:00Z',
     location: 'eu-west-1',
+    role: 'gate',
+    letter: 'S',
   },
   {
     id: 'd8e9f0a1-2b3c-4d5e-6f7a-8b9c0d1e2f3a',
@@ -362,6 +368,8 @@ const SEED_RAVENS: Ravn[] = [
     model: 'claude-sonnet-4-6',
     createdAt: '2026-04-15T07:55:22Z',
     location: 'ap-southeast-1',
+    role: 'verify',
+    letter: 'Q',
   },
   {
     id: 'e1f2a3b4-5c6d-4e7f-8a9b-0c1d2e3f4a5b',
@@ -370,6 +378,8 @@ const SEED_RAVENS: Ravn[] = [
     model: 'claude-opus-4-6',
     createdAt: '2026-04-14T22:10:45Z',
     location: 'us-east-1',
+    role: 'verify',
+    letter: 'I',
   },
   {
     id: 'f5a6b7c8-9d0e-4f1a-2b3c-4d5e6f7a8b9c',
@@ -378,6 +388,8 @@ const SEED_RAVENS: Ravn[] = [
     model: 'claude-sonnet-4-6',
     createdAt: '2026-04-14T18:33:07Z',
     location: 'ap-southeast-1',
+    role: 'audit',
+    letter: 'H',
   },
 ];
 

--- a/web-next/packages/plugin-ravn/src/domain/activityLog.test.ts
+++ b/web-next/packages/plugin-ravn/src/domain/activityLog.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { activityLogKindSchema, activityLogEntrySchema } from './activityLog';
+
+describe('activityLogKindSchema', () => {
+  it('accepts "session"', () => {
+    expect(activityLogKindSchema.parse('session')).toBe('session');
+  });
+
+  it('accepts "trigger"', () => {
+    expect(activityLogKindSchema.parse('trigger')).toBe('trigger');
+  });
+
+  it('accepts "emit"', () => {
+    expect(activityLogKindSchema.parse('emit')).toBe('emit');
+  });
+
+  it('rejects unknown kind', () => {
+    expect(() => activityLogKindSchema.parse('unknown')).toThrow();
+  });
+
+  it('rejects empty string', () => {
+    expect(() => activityLogKindSchema.parse('')).toThrow();
+  });
+});
+
+describe('activityLogEntrySchema', () => {
+  const valid = {
+    id: 'session-abc123',
+    ts: '2026-04-15T09:12:34Z',
+    kind: 'session' as const,
+    ravnId: 'a3f1b2c4',
+    message: 'Implement login form',
+  };
+
+  it('round-trips a valid entry', () => {
+    expect(activityLogEntrySchema.parse(valid)).toEqual(valid);
+  });
+
+  it('accepts "trigger" kind', () => {
+    expect(activityLogEntrySchema.parse({ ...valid, kind: 'trigger' }).kind).toBe('trigger');
+  });
+
+  it('accepts "emit" kind', () => {
+    expect(activityLogEntrySchema.parse({ ...valid, kind: 'emit' }).kind).toBe('emit');
+  });
+
+  it('rejects missing id', () => {
+    const { id: _id, ...rest } = valid;
+    expect(() => activityLogEntrySchema.parse(rest)).toThrow();
+  });
+
+  it('rejects missing ts', () => {
+    const { ts: _ts, ...rest } = valid;
+    expect(() => activityLogEntrySchema.parse(rest)).toThrow();
+  });
+
+  it('rejects unknown kind', () => {
+    expect(() => activityLogEntrySchema.parse({ ...valid, kind: 'bad' })).toThrow();
+  });
+});

--- a/web-next/packages/plugin-ravn/src/domain/activityLog.ts
+++ b/web-next/packages/plugin-ravn/src/domain/activityLog.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+/**
+ * Kind of fleet activity event shown in the overview log tail.
+ *
+ * - session  — a ravn session was created or changed state
+ * - trigger  — an automation trigger fired
+ * - emit     — a ravn emitted a domain event
+ */
+export const activityLogKindSchema = z.enum(['session', 'trigger', 'emit']);
+
+export type ActivityLogKind = z.infer<typeof activityLogKindSchema>;
+
+/**
+ * A single row in the recent-activity log tail on the Overview page.
+ *
+ * Owner: plugin-ravn (derived from sessions + triggers).
+ */
+export const activityLogEntrySchema = z.object({
+  /** Stable key for React rendering. */
+  id: z.string(),
+  /** ISO-8601 UTC timestamp. */
+  ts: z.string(),
+  /** Event kind — drives badge colour. */
+  kind: activityLogKindSchema,
+  /** Short ravn / persona identifier shown in the "ravn" column. */
+  ravnId: z.string(),
+  /** Human-readable summary of the event. */
+  message: z.string(),
+});
+
+export type ActivityLogEntry = z.infer<typeof activityLogEntrySchema>;

--- a/web-next/packages/plugin-ravn/src/domain/activityLog.ts
+++ b/web-next/packages/plugin-ravn/src/domain/activityLog.ts
@@ -20,7 +20,7 @@ export const activityLogEntrySchema = z.object({
   /** Stable key for React rendering. */
   id: z.string(),
   /** ISO-8601 UTC timestamp. */
-  ts: z.string(),
+  ts: z.string().datetime(),
   /** Event kind — drives badge colour. */
   kind: activityLogKindSchema,
   /** Short ravn / persona identifier shown in the "ravn" column. */

--- a/web-next/packages/plugin-ravn/src/domain/ravn.ts
+++ b/web-next/packages/plugin-ravn/src/domain/ravn.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { personaRoleSchema } from '@niuulabs/domain';
 
 /**
  * Deployment status of a Ravn node.
@@ -28,6 +29,10 @@ export const ravnSchema = z.object({
   updatedAt: z.string().datetime().optional(),
   /** Deployment location label (e.g. "eu-west-1", "us-east-1"). */
   location: z.string().optional(),
+  /** Persona role — cached for display (avatar shape). */
+  role: personaRoleSchema.optional(),
+  /** Persona letter — cached for display (avatar letter). */
+  letter: z.string().optional(),
 });
 
 export type Ravn = z.infer<typeof ravnSchema>;

--- a/web-next/packages/plugin-ravn/src/ui/OverviewPage.css
+++ b/web-next/packages/plugin-ravn/src/ui/OverviewPage.css
@@ -6,10 +6,10 @@
   padding: 20px 24px;
 }
 
-/* 2-column grid — left (ravens) wider than right (spend) */
+/* 2-column grid — equal-width columns matching web2 spec */
 .rv-overview__grid {
   display: grid;
-  grid-template-columns: 3fr 2fr;
+  grid-template-columns: 1fr 1fr;
   gap: 20px;
   align-items: start;
 }
@@ -110,7 +110,7 @@
 
 .rv-loc-bar-fill {
   height: 100%;
-  background: var(--color-accent-cyan);
+  background: var(--brand-300);
   border-radius: var(--radius-full);
   transition: width 0.3s ease;
   min-width: 4px;
@@ -198,6 +198,41 @@
   font-family: var(--font-mono);
 }
 
+/* Recent activity section spacing */
+.rv-overview__activity {
+  margin-top: var(--space-5);
+}
+
+/* Activity log kind badges */
+.rv-log-kind {
+  display: inline-block;
+  padding: 1px var(--space-1);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.rv-log-kind--session {
+  background: color-mix(in srgb, var(--brand-300) 18%, transparent);
+  color: var(--brand-300);
+  border: 1px solid color-mix(in srgb, var(--brand-300) 30%, transparent);
+}
+
+.rv-log-kind--trigger {
+  background: color-mix(in srgb, var(--color-accent-amber) 18%, transparent);
+  color: var(--color-accent-amber);
+  border: 1px solid color-mix(in srgb, var(--color-accent-amber) 30%, transparent);
+}
+
+.rv-log-kind--emit {
+  background: color-mix(in srgb, var(--color-accent-purple) 18%, transparent);
+  color: var(--color-accent-purple);
+  border: 1px solid color-mix(in srgb, var(--color-accent-purple) 30%, transparent);
+}
+
 /* Log tail */
 .rv-log-panel {
   background: var(--color-bg-secondary);
@@ -237,6 +272,11 @@
 .rv-log-td--time {
   padding: var(--space-2) var(--space-3);
   color: var(--color-text-muted);
+}
+
+.rv-log-td--kind {
+  padding: var(--space-2) var(--space-3);
+  white-space: nowrap;
 }
 
 .rv-log-td--persona {

--- a/web-next/packages/plugin-ravn/src/ui/OverviewPage.test.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/OverviewPage.test.tsx
@@ -68,6 +68,17 @@ describe('OverviewPage', () => {
     expect(rows.length).toBeGreaterThan(0);
   });
 
+  it('renders persona avatars in active ravens rows', async () => {
+    render(<OverviewPage />, { wrapper: wrap() });
+    await waitFor(() => expect(screen.getByTestId('active-ravens-list')).toBeInTheDocument());
+    // Active ravens in mock data have role/letter — avatars should be rendered
+    const rows = screen.getAllByTestId('active-ravn-row');
+    expect(rows.length).toBeGreaterThan(0);
+    // PersonaAvatar renders a span with aria-label containing "persona"
+    const avatars = screen.getAllByLabelText(/persona/i);
+    expect(avatars.length).toBeGreaterThan(0);
+  });
+
   it('renders the fleet sparkline widget', async () => {
     render(<OverviewPage />, { wrapper: wrap() });
     await waitFor(() => expect(screen.getByTestId('fleet-sparkline')).toBeInTheDocument());
@@ -89,6 +100,19 @@ describe('OverviewPage', () => {
     const rows = screen.getAllByTestId('location-row');
     // Mock has 3 locations: eu-west-1, us-east-1, ap-southeast-1
     expect(rows.length).toBe(3);
+  });
+
+  it('renders the recent activity log section', async () => {
+    render(<OverviewPage />, { wrapper: wrap() });
+    await waitFor(() => expect(screen.getByTestId('activity-log')).toBeInTheDocument());
+  });
+
+  it('renders up to 9 activity log rows', async () => {
+    render(<OverviewPage />, { wrapper: wrap() });
+    await waitFor(() => expect(screen.getByTestId('activity-log')).toBeInTheDocument());
+    const rows = screen.getAllByTestId('activity-log-row');
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.length).toBeLessThanOrEqual(9);
   });
 
   it('shows error state when ravens service fails', async () => {

--- a/web-next/packages/plugin-ravn/src/ui/OverviewPage.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/OverviewPage.tsx
@@ -14,6 +14,7 @@ import { useSessions } from './hooks/useSessions';
 import { useFleetBudget, useRavnBudgets } from './hooks/useBudget';
 import { useActivityLog } from './hooks/useActivityLog';
 import { topBudgetSpenders } from './grouping';
+import { formatTime } from './formatTime';
 import type { ActivityLogEntry } from '../domain/activityLog';
 import './OverviewPage.css';
 
@@ -44,14 +45,6 @@ function byLocation(ravens: { location?: string }[]): Array<{ name: string; coun
     .sort((a, b) => b.count - a.count);
 }
 
-function formatTs(ts: string): string {
-  const d = new Date(ts);
-  const hh = String(d.getUTCHours()).padStart(2, '0');
-  const mm = String(d.getUTCMinutes()).padStart(2, '0');
-  const ss = String(d.getUTCSeconds()).padStart(2, '0');
-  return `${hh}:${mm}:${ss}`;
-}
-
 function ActivityLogSection({ entries }: { entries: ActivityLogEntry[] }) {
   if (entries.length === 0) {
     return (
@@ -75,7 +68,7 @@ function ActivityLogSection({ entries }: { entries: ActivityLogEntry[] }) {
         <tbody>
           {entries.map((e) => (
             <tr key={e.id} className="rv-log-row" data-testid="activity-log-row">
-              <td className="rv-log-td--time">{formatTs(e.ts)}</td>
+              <td className="rv-log-td--time">{formatTime(e.ts)}</td>
               <td className="rv-log-td--kind">
                 <span className={`rv-log-kind rv-log-kind--${e.kind}`}>{e.kind}</span>
               </td>

--- a/web-next/packages/plugin-ravn/src/ui/OverviewPage.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/OverviewPage.tsx
@@ -4,6 +4,7 @@ import {
   BudgetBar,
   Sparkline,
   StateDot,
+  PersonaAvatar,
   LoadingState,
   ErrorState,
 } from '@niuulabs/ui';
@@ -11,7 +12,9 @@ import { useRavens } from './hooks/useRavens';
 import { useTriggers } from './hooks/useTriggers';
 import { useSessions } from './hooks/useSessions';
 import { useFleetBudget, useRavnBudgets } from './hooks/useBudget';
+import { useActivityLog } from './hooks/useActivityLog';
 import { topBudgetSpenders } from './grouping';
+import type { ActivityLogEntry } from '../domain/activityLog';
 import './OverviewPage.css';
 
 const TOP_SPENDERS_COUNT = 5;
@@ -41,11 +44,57 @@ function byLocation(ravens: { location?: string }[]): Array<{ name: string; coun
     .sort((a, b) => b.count - a.count);
 }
 
+function formatTs(ts: string): string {
+  const d = new Date(ts);
+  const hh = String(d.getUTCHours()).padStart(2, '0');
+  const mm = String(d.getUTCMinutes()).padStart(2, '0');
+  const ss = String(d.getUTCSeconds()).padStart(2, '0');
+  return `${hh}:${mm}:${ss}`;
+}
+
+function ActivityLogSection({ entries }: { entries: ActivityLogEntry[] }) {
+  if (entries.length === 0) {
+    return (
+      <div className="rv-log-panel" data-testid="activity-log">
+        <p className="rv-log-empty">No recent activity</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rv-log-panel" data-testid="activity-log">
+      <table className="rv-log-table" aria-label="Recent activity">
+        <thead>
+          <tr className="rv-log-thead-row">
+            <th className="rv-log-th">Time</th>
+            <th className="rv-log-th">Kind</th>
+            <th className="rv-log-th">Ravn</th>
+            <th className="rv-log-th">Event</th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map((e) => (
+            <tr key={e.id} className="rv-log-row" data-testid="activity-log-row">
+              <td className="rv-log-td--time">{formatTs(e.ts)}</td>
+              <td className="rv-log-td--kind">
+                <span className={`rv-log-kind rv-log-kind--${e.kind}`}>{e.kind}</span>
+              </td>
+              <td className="rv-log-td--persona">{e.ravnId}</td>
+              <td className="rv-log-td--event">{e.message}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
 export function OverviewPage() {
   const ravens = useRavens();
   const triggers = useTriggers();
   const sessions = useSessions();
   const fleetBudget = useFleetBudget();
+  const activityLog = useActivityLog();
 
   const ravnList = ravens.data ?? [];
   const ravnIds = ravnList.map((r) => r.id);
@@ -142,6 +191,9 @@ export function OverviewPage() {
               <ul className="rv-active-list" data-testid="active-ravens-list">
                 {activeRavens.map((r) => (
                   <li key={r.id} className="rv-active-row" data-testid="active-ravn-row">
+                    {r.role && r.letter && (
+                      <PersonaAvatar role={r.role} letter={r.letter} size={16} />
+                    )}
                     <StateDot state="running" pulse size={8} />
                     <span className="rv-active-row__name">{r.personaName}</span>
                     <span className="rv-active-row__model">{r.model}</span>
@@ -175,7 +227,7 @@ export function OverviewPage() {
           )}
         </div>
 
-        {/* Right: Fleet sparkline + budget spenders */}
+        {/* Right: Fleet sparkline + budget spenders + activity log */}
         <section aria-labelledby="burning-now-heading">
           <h3 id="burning-now-heading" className="rv-section-heading">
             Burning now
@@ -226,6 +278,14 @@ export function OverviewPage() {
               );
             })}
           </ul>
+
+          {/* Recent activity log tail */}
+          <section aria-labelledby="activity-log-heading" className="rv-overview__activity">
+            <h3 id="activity-log-heading" className="rv-section-heading">
+              Recent activity
+            </h3>
+            <ActivityLogSection entries={activityLog.data ?? []} />
+          </section>
         </section>
       </div>
     </div>

--- a/web-next/packages/plugin-ravn/src/ui/hooks/useActivityLog.test.ts
+++ b/web-next/packages/plugin-ravn/src/ui/hooks/useActivityLog.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ServicesProvider } from '@niuulabs/plugin-sdk';
+import { createElement } from 'react';
+import { useActivityLog } from './useActivityLog';
+import {
+  createMockSessionStream,
+  createMockTriggerStore,
+} from '../../adapters/mock';
+import type { Session } from '../../domain/session';
+import type { Trigger } from '../../domain/trigger';
+
+function makeWrapper(
+  sessionStream = createMockSessionStream(),
+  triggerStore = createMockTriggerStore(),
+) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const services = {
+    'ravn.sessions': sessionStream,
+    'ravn.triggers': triggerStore,
+  };
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return createElement(
+      QueryClientProvider,
+      { client },
+      createElement(ServicesProvider, { services }, children),
+    );
+  };
+}
+
+describe('useActivityLog', () => {
+  it('returns undefined while sessions are loading', () => {
+    const slow = {
+      listSessions: () => new Promise<Session[]>(() => undefined),
+      getSession: (_id: string) => new Promise<Session>(() => undefined),
+      getMessages: () => Promise.resolve([]),
+    };
+    const { result } = renderHook(() => useActivityLog(), {
+      wrapper: makeWrapper(slow),
+    });
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it('returns populated entries after loading', async () => {
+    const { result } = renderHook(() => useActivityLog(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data).toBeDefined();
+    expect(result.current.data!.length).toBeGreaterThan(0);
+  });
+
+  it('caps at 9 entries', async () => {
+    const { result } = renderHook(() => useActivityLog(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data!.length).toBeLessThanOrEqual(9);
+  });
+
+  it('entries are sorted by timestamp descending', async () => {
+    const { result } = renderHook(() => useActivityLog(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    const entries = result.current.data!;
+    for (let i = 1; i < entries.length; i++) {
+      expect(entries[i - 1]!.ts >= entries[i]!.ts).toBe(true);
+    }
+  });
+
+  it('includes session kind entries', async () => {
+    const { result } = renderHook(() => useActivityLog(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    const kinds = result.current.data!.map((e) => e.kind);
+    expect(kinds).toContain('session');
+  });
+
+  it('includes trigger kind entries', async () => {
+    const { result } = renderHook(() => useActivityLog(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    const kinds = result.current.data!.map((e) => e.kind);
+    expect(kinds).toContain('trigger');
+  });
+
+  it('returns isError true when sessions fail', async () => {
+    const failing = {
+      listSessions: () => Promise.reject(new Error('fleet offline')),
+      getSession: (_id: string) => Promise.reject(new Error('fleet offline')),
+      getMessages: () => Promise.resolve([]),
+    };
+    const { result } = renderHook(() => useActivityLog(), {
+      wrapper: makeWrapper(failing),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.isError).toBe(true);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it('returns empty array when sessions list is empty', async () => {
+    const empty = {
+      listSessions: () => Promise.resolve([] as Session[]),
+      getSession: (_id: string) => Promise.resolve({} as Session),
+      getMessages: () => Promise.resolve([]),
+    };
+    const noTriggers = {
+      listTriggers: () => Promise.resolve([] as Trigger[]),
+      createTrigger: async (t: Omit<Trigger, 'id' | 'createdAt'>) => ({
+        ...t,
+        id: 'x',
+        createdAt: '',
+      }),
+      deleteTrigger: async () => undefined,
+    };
+    const { result } = renderHook(() => useActivityLog(), {
+      wrapper: makeWrapper(empty, noTriggers),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data).toEqual([]);
+  });
+});

--- a/web-next/packages/plugin-ravn/src/ui/hooks/useActivityLog.ts
+++ b/web-next/packages/plugin-ravn/src/ui/hooks/useActivityLog.ts
@@ -1,0 +1,58 @@
+import { useMemo } from 'react';
+import { useSessions } from './useSessions';
+import { useTriggers } from './useTriggers';
+import type { ActivityLogEntry } from '../../domain/activityLog';
+import type { Session } from '../../domain/session';
+import type { Trigger } from '../../domain/trigger';
+
+const ACTIVITY_LOG_ROWS = 9;
+
+function sessionToEntry(s: Session): ActivityLogEntry {
+  const kind = s.status === 'failed' ? 'emit' : 'session';
+  return {
+    id: `session-${s.id}`,
+    ts: s.createdAt,
+    kind,
+    ravnId: s.ravnId.slice(0, 8),
+    message: s.title ?? `session ${s.id.slice(0, 8)}`,
+  };
+}
+
+function triggerToEntry(t: Trigger): ActivityLogEntry {
+  return {
+    id: `trigger-${t.id}`,
+    ts: t.createdAt,
+    kind: 'trigger',
+    ravnId: t.personaName.slice(0, 8),
+    message: `${t.kind}: ${t.spec}`,
+  };
+}
+
+/**
+ * Derives recent fleet activity from sessions and triggers.
+ * Returns up to 9 entries sorted by timestamp descending.
+ */
+export function useActivityLog(): {
+  data: ActivityLogEntry[] | undefined;
+  isLoading: boolean;
+  isError: boolean;
+} {
+  const sessions = useSessions();
+  const triggers = useTriggers();
+
+  const data = useMemo((): ActivityLogEntry[] | undefined => {
+    if (!sessions.data) return undefined;
+
+    const entries: ActivityLogEntry[] = sessions.data.map(sessionToEntry);
+
+    if (triggers.data) {
+      for (const t of triggers.data) {
+        entries.push(triggerToEntry(t));
+      }
+    }
+
+    return entries.sort((a, b) => b.ts.localeCompare(a.ts)).slice(0, ACTIVITY_LOG_ROWS);
+  }, [sessions.data, triggers.data]);
+
+  return { data, isLoading: sessions.isLoading, isError: sessions.isError };
+}

--- a/web-next/packages/plugin-ravn/src/ui/hooks/useActivityLog.ts
+++ b/web-next/packages/plugin-ravn/src/ui/hooks/useActivityLog.ts
@@ -8,11 +8,10 @@ import type { Trigger } from '../../domain/trigger';
 const ACTIVITY_LOG_ROWS = 9;
 
 function sessionToEntry(s: Session): ActivityLogEntry {
-  const kind = s.status === 'failed' ? 'emit' : 'session';
   return {
     id: `session-${s.id}`,
     ts: s.createdAt,
-    kind,
+    kind: 'session',
     ravnId: s.ravnId.slice(0, 8),
     message: s.title ?? `session ${s.id.slice(0, 8)}`,
   };


### PR DESCRIPTION
## Summary

- **Grid fix**: Changed `.rv-overview__grid` from `3fr 2fr` to `1fr 1fr` to match the web2 equal-column spec
- **Persona avatars**: Added `PersonaAvatar` (from `@niuulabs/ui`) before `StateDot` in each active-ravn row; extended `Ravn` domain model with optional `role` and `letter` fields, seeded in mock adapter and propagated through http adapter
- **Recent activity log**: New `ActivityLogEntry` domain type, `useActivityLog` hook (derives 9 rows from sessions + triggers, sorted desc), and `ActivityLogSection` component rendered below Top Spenders with timestamp, kind badge (session/trigger/emit), ravn-id, and message columns
- **Location bar color**: Changed `.rv-loc-bar-fill` background from `var(--color-accent-cyan)` to `var(--brand-300)` per web2 tokens spec

## Files changed

| File | Change |
|------|--------|
| `domain/ravn.ts` | Add optional `role` + `letter` fields |
| `domain/activityLog.ts` | New — `ActivityLogEntry` type + schema |
| `domain/activityLog.test.ts` | New — schema unit tests |
| `adapters/mock.ts` | Seed `role`/`letter` on `SEED_RAVENS` |
| `adapters/http.ts` | Propagate `role`/`letter` from server response |
| `ui/OverviewPage.tsx` | PersonaAvatar in rows, ActivityLog section, `useActivityLog` import |
| `ui/OverviewPage.css` | `1fr 1fr` grid, `--brand-300` loc bars, activity log kind badges |
| `ui/OverviewPage.test.tsx` | New assertions: avatar render, activity log section + rows |
| `ui/hooks/useActivityLog.ts` | New hook |
| `ui/hooks/useActivityLog.test.ts` | 8 test cases: loading, empty, populated, sorted, error |

## Test plan

- [x] `pnpm test` — 402 tests pass, exit 0
- [x] `OverviewPage.test.tsx` — 16 tests including new avatar + activity log assertions
- [x] `useActivityLog.test.ts` — 8 cases (loading, empty, populated, sorted desc, session/trigger kinds, error)
- [x] `activityLog.test.ts` — domain schema unit tests
- [x] Coverage ≥ 85% maintained across plugin-ravn

Closes NIU-703

🤖 Generated with [Claude Code](https://claude.com/claude-code)