### PR TITLE
fix(observatory): canvas visual parity with web2 — NIU-699

### DIFF
--- a/web-next/packages/plugin-observatory/src/ui/ObservatoryPage.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/ObservatoryPage.tsx
@@ -42,16 +42,16 @@ export function ObservatoryPage() {
   }
 
   return (
-    <div data-testid="observatory-page" className="fixed inset-0 flex flex-col">
+    <div data-testid="observatory-page" className="niuu-relative niuu-flex niuu-flex-col niuu-h-full niuu-overflow-hidden">
       <TopologyCanvas
         topology={topology}
         onNodeClick={handleNodeClick}
         showMinimap={false}
-        className="flex-1 min-h-0"
+        className="niuu-flex-1 niuu-min-h-0"
       />
 
       {/* Accessible hidden node list — keyboard / screen-reader alternative to canvas hit-testing */}
-      <ul data-testid="topology-node-list" aria-label="Topology nodes" className="sr-only">
+      <ul data-testid="topology-node-list" aria-label="Topology nodes" className="niuu-sr-only">
         {topology?.nodes.map((node) => (
           <li key={node.id}>
             <button

--- a/web-next/packages/plugin-observatory/src/ui/overlays/ConnectionLegend.css
+++ b/web-next/packages/plugin-observatory/src/ui/overlays/ConnectionLegend.css
@@ -1,5 +1,5 @@
 .obs-conn-legend {
-  position: fixed;
+  position: absolute;
   top: var(--space-4);
   left: var(--space-4);
   z-index: 40;

--- a/web-next/packages/plugin-observatory/src/ui/overlays/EntityDrawer.css
+++ b/web-next/packages/plugin-observatory/src/ui/overlays/EntityDrawer.css
@@ -1,3 +1,59 @@
+/* ── Panel container — absolute within the observatory content area ── */
+.obs-entity-drawer__panel {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 340px;
+  background: var(--color-bg-secondary);
+  border-left: 1px solid var(--color-border-subtle);
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: obs-drawer-slide-in 240ms ease;
+}
+
+@keyframes obs-drawer-slide-in {
+  from {
+    transform: translateX(12px);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+.obs-entity-drawer__close-btn {
+  position: absolute;
+  top: var(--space-3);
+  right: var(--space-3);
+  width: 24px;
+  height: 24px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-muted);
+  font-size: 18px;
+  line-height: 1;
+  border-radius: var(--radius-sm);
+  transition:
+    background 120ms ease,
+    color 120ms ease;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.obs-entity-drawer__close-btn:hover {
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-primary);
+}
+
+/* ── Body: flex-1 so it fills remaining panel height ── */
+
 .obs-entity-drawer__head {
   display: flex;
   align-items: center;
@@ -59,6 +115,8 @@
 }
 
 .obs-entity-drawer__body {
+  flex: 1;
+  min-height: 0;
   padding: var(--space-4);
   display: flex;
   flex-direction: column;

--- a/web-next/packages/plugin-observatory/src/ui/overlays/EntityDrawer.test.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/overlays/EntityDrawer.test.tsx
@@ -317,4 +317,16 @@ describe('EntityDrawer', () => {
     });
     expect(screen.getByText('unknown-type')).toBeInTheDocument();
   });
+
+  it('calls onClose when Escape key is pressed', () => {
+    const { onClose } = renderDrawer(TYR_NODE);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('does not add Escape listener when drawer is closed (node is null)', () => {
+    const { onClose } = renderDrawer(null);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).not.toHaveBeenCalled();
+  });
 });

--- a/web-next/packages/plugin-observatory/src/ui/overlays/EntityDrawer.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/overlays/EntityDrawer.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { Sparkline, StateDot } from '@niuulabs/ui';
 import type { DotState } from '@niuulabs/ui';
 import type { TopologyNode, Topology, Registry, NodeActivity } from '../../domain';
@@ -355,6 +355,15 @@ export function EntityDrawer({
   }, [node?.id]);
 
   const showSparkline = ['ravn_long', 'bifrost'].includes(node?.typeId ?? '');
+
+  useEffect(() => {
+    if (!node) return;
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [node, onClose]);
 
   if (!node) return null;
 

--- a/web-next/packages/plugin-observatory/src/ui/overlays/EntityDrawer.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/overlays/EntityDrawer.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Drawer, DrawerContent, Sparkline, StateDot } from '@niuulabs/ui';
+import { Sparkline, StateDot } from '@niuulabs/ui';
 import type { DotState } from '@niuulabs/ui';
 import type { TopologyNode, Topology, Registry, NodeActivity } from '../../domain';
 import './EntityDrawer.css';
@@ -184,7 +184,7 @@ function KindProperties({ node }: { node: TopologyNode }) {
   );
 }
 
-// ── Realm drawer ──────────────────────────────────────────────────────────────
+// ── Realm drawer body ─────────────────────────────────────────────────────────
 
 interface RealmDrawerProps {
   node: TopologyNode;
@@ -196,7 +196,7 @@ function RealmDrawer({ node, topology, onNodeSelect }: RealmDrawerProps) {
   const residents = topology ? topology.nodes.filter((n) => n.parentId === node.id) : [];
 
   return (
-    <DrawerContent title={node.label} width={360}>
+    <>
       <div className="obs-entity-drawer__head">
         <div className="obs-entity-drawer__identity">
           <span className="obs-entity-drawer__rune" aria-hidden="true">
@@ -257,11 +257,11 @@ function RealmDrawer({ node, topology, onNodeSelect }: RealmDrawerProps) {
           </section>
         )}
       </div>
-    </DrawerContent>
+    </>
   );
 }
 
-// ── Cluster drawer ────────────────────────────────────────────────────────────
+// ── Cluster drawer body ───────────────────────────────────────────────────────
 
 interface ClusterDrawerProps {
   node: TopologyNode;
@@ -273,7 +273,7 @@ function ClusterDrawer({ node, topology, onNodeSelect }: ClusterDrawerProps) {
   const members = topology ? topology.nodes.filter((n) => n.parentId === node.id) : [];
 
   return (
-    <DrawerContent title={node.label} width={360}>
+    <>
       <div className="obs-entity-drawer__head">
         <div className="obs-entity-drawer__identity">
           <span className="obs-entity-drawer__rune" aria-hidden="true">
@@ -325,7 +325,7 @@ function ClusterDrawer({ node, topology, onNodeSelect }: ClusterDrawerProps) {
           </section>
         )}
       </div>
-    </DrawerContent>
+    </>
   );
 }
 
@@ -356,21 +356,30 @@ export function EntityDrawer({
 
   const showSparkline = ['ravn_long', 'bifrost'].includes(node?.typeId ?? '');
 
+  if (!node) return null;
+
   return (
-    <Drawer
-      open={node !== null}
-      onOpenChange={(open) => {
-        if (!open) onClose();
-      }}
+    <aside
+      role="dialog"
+      aria-label={node.label}
+      className="obs-entity-drawer__panel"
     >
-      {node && isRealm && (
+      <button
+        className="obs-entity-drawer__close-btn"
+        aria-label="Close"
+        onClick={onClose}
+      >
+        <span aria-hidden="true">✕</span>
+      </button>
+
+      {isRealm && (
         <RealmDrawer node={node} topology={topology} onNodeSelect={onNodeSelect} />
       )}
-      {node && isCluster && (
+      {isCluster && (
         <ClusterDrawer node={node} topology={topology} onNodeSelect={onNodeSelect} />
       )}
-      {node && !isRealm && !isCluster && (
-        <DrawerContent title={node.label} width={360}>
+      {!isRealm && !isCluster && (
+        <>
           {/* HEAD — rune · label · activity · status · timestamp */}
           <div className="obs-entity-drawer__head">
             <div className="obs-entity-drawer__identity">
@@ -550,8 +559,8 @@ export function EntityDrawer({
               </div>
             </section>
           </div>
-        </DrawerContent>
+        </>
       )}
-    </Drawer>
+    </aside>
   );
 }

--- a/web-next/packages/plugin-observatory/src/ui/overlays/EventLog.css
+++ b/web-next/packages/plugin-observatory/src/ui/overlays/EventLog.css
@@ -1,25 +1,33 @@
+/* EventLog — bottom strip matching web2 .eventlog spec */
 .obs-event-log {
-  position: fixed;
-  bottom: var(--space-4);
-  left: 50%;
-  transform: translateX(-50%);
-  width: 480px;
-  height: 200px;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
   z-index: 40;
+  height: 110px;
+  background: linear-gradient(
+    180deg,
+    transparent 0%,
+    color-mix(in srgb, var(--color-bg-primary) 88%, transparent) 20%,
+    var(--color-bg-primary) 100%
+  );
   pointer-events: none;
 }
 
+/* Inner panel: inset from left and offset 320px from right to clear the drawer */
 .obs-event-log__inner {
-  width: 100%;
-  height: 100%;
-  overflow-y: auto;
-  background: color-mix(in srgb, var(--color-bg-primary) 92%, transparent);
+  position: absolute;
+  left: var(--space-4);
+  right: 320px;
+  bottom: var(--space-3);
+  height: 80px;
+  overflow: hidden;
+  background: color-mix(in srgb, var(--color-bg-secondary) 90%, transparent);
   border: 1px solid var(--color-border-subtle);
   border-radius: var(--radius-md);
-  padding: var(--space-2);
   display: flex;
   flex-direction: column;
-  gap: 1px;
   scrollbar-width: thin;
   scrollbar-color: var(--color-border-subtle) transparent;
   pointer-events: auto;

--- a/web-next/packages/plugin-observatory/src/ui/overlays/Minimap.css
+++ b/web-next/packages/plugin-observatory/src/ui/overlays/Minimap.css
@@ -1,5 +1,5 @@
 .obs-minimap {
-  position: fixed;
+  position: absolute;
   bottom: var(--space-4);
   right: var(--space-4);
   z-index: 40;


### PR DESCRIPTION
## Summary

- **ObservatoryPage layout**: replaced `fixed inset-0 flex flex-col` with `niuu-relative niuu-flex niuu-flex-col niuu-h-full niuu-overflow-hidden` so the page renders as content-fill inside the Shell slot instead of covering the full viewport; all remaining unprefixed Tailwind classes (`flex-1 min-h-0`, `sr-only`) prefixed with `niuu-`
- **Overlay anchoring**: changed `position: fixed` → `position: absolute` in `ConnectionLegend.css` and `Minimap.css` so overlays position relative to the content area (top-left / bottom-right with `--space-4` offsets matching web2 spec)
- **EventLog layout**: restructured to web2 bottom-strip spec — outer element is `position: absolute; bottom: 0; left: 0; right: 0; height: 110px` with gradient fade; inner panel is `position: absolute; left: var(--space-4); right: 320px; bottom: var(--space-3); height: 80px` clearing the entity drawer
- **EntityDrawer positioning**: removed RadixDialog portal wrapper (`position: fixed`) and replaced with a direct `<aside role="dialog">` rendered as `position: absolute; top: 0; right: 0; bottom: 0; width: 340px` matching web2 `.drawer` spec; `RealmDrawer` and `ClusterDrawer` sub-components inline their head+body without the portal; accessibility roles (`role=dialog`, `aria-label`, `aria-label="Close"`) preserved for full test compatibility

## Test plan

- [x] All 29 EntityDrawer tests pass (dialog role, close button, resident navigation)
- [x] All 14 ObservatoryPage tests pass (canvas, overlays, node list, drawer open/close)
- [x] Full test suite passes: 92.99% statements / 88.19% branches / 87.55% functions (≥85% threshold)
- [ ] Visual regression test `observatory canvas matches web2` expected to pass at ≤5% pixel diff (CI)

## Linear

Ticket: NIU-699 (Linear MCP tools not available in this session — ticket could not be updated programmatically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)