### PR TITLE
feat(observatory): registry types visual parity with web2 — NIU-700

### DIFF
--- a/web-next/packages/plugin-observatory/src/styles.css
+++ b/web-next/packages/plugin-observatory/src/styles.css
@@ -22,6 +22,79 @@
     @apply niuu-text-text-primary niuu-font-semibold;
   }
 
+  /* Type card grid */
+  .type-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: var(--space-3);
+  }
+
+  .type-card {
+    display: grid;
+    grid-template-columns: 36px 1fr auto;
+    grid-template-rows: auto auto;
+    gap: 2px 12px;
+    align-items: start;
+    background: var(--color-bg-secondary);
+    border: 1px solid var(--color-border-subtle);
+    border-radius: var(--radius-md);
+    padding: var(--space-3) var(--space-4);
+    cursor: pointer;
+    text-align: left;
+    width: 100%;
+    transition: border-color 120ms ease, background 120ms ease;
+  }
+
+  .type-card:hover {
+    border-color: var(--color-border);
+  }
+
+  .type-card[data-selected='true'] {
+    border-color: color-mix(in srgb, var(--color-brand) 40%, transparent);
+    background: color-mix(in srgb, var(--color-brand) 6%, var(--color-bg-secondary));
+  }
+
+  .type-swatch {
+    grid-row: span 2;
+    width: 36px;
+    height: 36px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--color-bg-tertiary);
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--color-border-subtle);
+  }
+
+  .type-name {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--color-text-primary);
+    font-family: var(--font-sans);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    line-height: 1.3;
+  }
+
+  .type-desc {
+    font-size: 11px;
+    color: var(--color-text-muted);
+    grid-column: 2 / 3;
+    line-height: 1.4;
+  }
+
+  .type-meta {
+    grid-row: span 2;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 4px;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--color-text-muted);
+  }
+
   /* Containment tree nodes */
   .registry-tree-node {
     @apply niuu-flex niuu-items-center niuu-gap-2 niuu-rounded-sm niuu-border niuu-border-transparent niuu-cursor-grab;

--- a/web-next/packages/plugin-observatory/src/ui/RegistryEditor.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/RegistryEditor.tsx
@@ -25,7 +25,7 @@ function TypePreviewDrawer({ type, onClose }: TypePreviewDrawerProps) {
   return (
     <div
       data-testid="type-preview-drawer"
-      className="niuu-w-[320px] niuu-shrink-0 niuu-border-l niuu-border-border-subtle niuu-bg-bg-secondary niuu-flex niuu-flex-col niuu-overflow-hidden"
+      className="niuu-border-l niuu-border-border-subtle niuu-bg-bg-secondary niuu-flex niuu-flex-col niuu-overflow-hidden"
     >
       <div className="niuu-p-4 niuu-border-b niuu-border-border-subtle niuu-flex niuu-items-start niuu-gap-3">
         <div className="niuu-w-12 niuu-h-12 niuu-flex niuu-items-center niuu-justify-center niuu-bg-bg-tertiary niuu-rounded-md niuu-border niuu-border-border-subtle niuu-shrink-0">
@@ -122,11 +122,10 @@ interface TypesTabProps {
   registry: Registry;
   selectedId: string | null;
   onSelect: (id: string) => void;
+  search: string;
 }
 
-function TypesTab({ registry, selectedId, onSelect }: TypesTabProps) {
-  const [search, setSearch] = useState('');
-
+function TypesTab({ registry, selectedId, onSelect, search }: TypesTabProps) {
   const filtered = useMemo(() => {
     if (!search) return registry.types;
     const q = search.toLowerCase();
@@ -149,16 +148,6 @@ function TypesTab({ registry, selectedId, onSelect }: TypesTabProps) {
 
   return (
     <div>
-      <div className="niuu-mb-4">
-        <input
-          aria-label="Filter types"
-          placeholder="filter types…"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="niuu-w-full niuu-h-9 niuu-px-3 niuu-bg-bg-tertiary niuu-border niuu-border-border niuu-rounded-sm niuu-text-text-primary niuu-text-sm niuu-font-sans niuu-box-border"
-        />
-      </div>
-
       {filtered.length === 0 && (
         <p className="niuu-text-text-muted niuu-text-sm">No types match your search.</p>
       )}
@@ -169,32 +158,34 @@ function TypesTab({ registry, selectedId, onSelect }: TypesTabProps) {
             {cat}
             <span className="niuu-font-normal niuu-text-text-muted">· {types.length}</span>
           </div>
-          <div className="niuu-flex niuu-flex-col niuu-gap-1">
+          <div className="type-grid">
             {types.map((t) => (
               <button
                 key={t.id}
                 data-testid={`type-row-${t.id}`}
+                data-selected={selectedId === t.id ? 'true' : undefined}
                 onClick={() => onSelect(t.id)}
-                className={`niuu-flex niuu-items-center niuu-gap-3 niuu-py-2 niuu-px-3 niuu-rounded-sm niuu-cursor-pointer niuu-text-left niuu-w-full niuu-border ${
-                  selectedId === t.id
-                    ? 'niuu-bg-bg-tertiary niuu-border-border'
-                    : 'niuu-bg-transparent niuu-border-transparent'
-                }`}
-                style={{ color: 'inherit' }}
+                className="type-card"
               >
-                <span className="niuu-w-[22px] niuu-h-[22px] niuu-inline-flex niuu-items-center niuu-justify-center niuu-shrink-0">
-                  <ShapeSvg shape={t.shape} color={t.color as ShapeColor} size={18} />
-                </span>
-                <span className="niuu-font-mono niuu-text-base niuu-text-brand niuu-font-bold niuu-w-5 niuu-text-center niuu-shrink-0">
-                  {t.rune}
-                </span>
-                <span className="niuu-flex-1 niuu-min-w-0">
-                  <span className="niuu-font-medium niuu-block">{t.label}</span>
-                  <span className="niuu-text-text-muted niuu-text-xs niuu-font-mono">{t.id}</span>
-                </span>
-                <span className="niuu-text-text-muted niuu-text-xs niuu-max-w-[180px] niuu-overflow-hidden niuu-text-ellipsis niuu-whitespace-nowrap niuu-shrink-0">
-                  {t.description.split('.')[0]}.
-                </span>
+                <div className="type-swatch">
+                  <ShapeSvg shape={t.shape} color={t.color as ShapeColor} size={22} />
+                </div>
+                <div className="type-name">
+                  {t.label}
+                  <span className="niuu-font-mono niuu-text-brand niuu-text-[12px] niuu-font-bold">
+                    {t.rune}
+                  </span>
+                </div>
+                <div className="type-meta">
+                  <div style={{ fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--brand-300)' }}>
+                    {t.id}
+                  </div>
+                  <div>
+                    shape ·{' '}
+                    <strong className="niuu-text-text-secondary niuu-font-medium">{t.shape}</strong>
+                  </div>
+                </div>
+                <div className="type-desc">{t.description.split('.')[0]}.</div>
               </button>
             ))}
           </div>
@@ -425,14 +416,19 @@ export interface RegistryEditorProps {
 
 export function RegistryEditor({ registry: initialRegistry }: RegistryEditorProps) {
   const [activeTab, setActiveTab] = useState<TabId>('types');
+  const [search, setSearch] = useState('');
   const { registry, selectedId, select, tryReparent } = useRegistryEditor(initialRegistry);
 
   const selectedType = registry.types.find((t) => t.id === selectedId) ?? null;
+  const showDrawer = selectedType !== null && activeTab !== 'json';
 
   return (
-    <div className="niuu-flex niuu-h-full niuu-overflow-hidden niuu-bg-bg-primary">
+    <div
+      className="niuu-grid niuu-h-full niuu-overflow-hidden niuu-bg-bg-primary"
+      style={{ gridTemplateColumns: showDrawer ? '1fr 380px' : '1fr' }}
+    >
       {/* Main column */}
-      <div className="niuu-flex-1 niuu-flex niuu-flex-col niuu-overflow-hidden">
+      <div className="niuu-flex niuu-flex-col niuu-overflow-hidden">
         {/* Header */}
         <div className="niuu-py-4 niuu-px-6 niuu-border-b niuu-border-border-subtle niuu-shrink-0">
           <div className="niuu-flex niuu-items-baseline niuu-justify-between niuu-mb-1">
@@ -445,12 +441,16 @@ export function RegistryEditor({ registry: initialRegistry }: RegistryEditorProp
               updated {formatDate(registry.updatedAt)}
             </span>
           </div>
+          <p className="niuu-m-0 niuu-text-text-secondary niuu-text-sm niuu-max-w-[64ch]">
+            Every node that appears in the Observatory canvas is an instance of one of these types.
+            Edit a type here and the canvas re-renders.
+          </p>
         </div>
 
         {/* Tabs */}
         <div
           role="tablist"
-          className="niuu-flex niuu-border-b niuu-border-border-subtle niuu-px-6 niuu-shrink-0"
+          className="niuu-flex niuu-items-center niuu-border-b niuu-border-border-subtle niuu-px-6 niuu-shrink-0"
         >
           {(['types', 'containment', 'json'] as TabId[]).map((tab) => (
             <button
@@ -464,12 +464,23 @@ export function RegistryEditor({ registry: initialRegistry }: RegistryEditorProp
               {tab.charAt(0).toUpperCase() + tab.slice(1)}
             </button>
           ))}
+          <div className="niuu-flex-1" />
+          {activeTab === 'types' && (
+            <input
+              aria-label="Filter types"
+              placeholder="filter types…"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="niuu-h-8 niuu-px-3 niuu-bg-bg-tertiary niuu-border niuu-border-border niuu-rounded-sm niuu-text-text-primary niuu-text-sm niuu-font-sans niuu-box-border"
+              style={{ width: 220 }}
+            />
+          )}
         </div>
 
         {/* Tab content */}
         <div role="tabpanel" className="niuu-flex-1 niuu-overflow-y-auto niuu-py-5 niuu-px-6">
           {activeTab === 'types' && (
-            <TypesTab registry={registry} selectedId={selectedId} onSelect={select} />
+            <TypesTab registry={registry} selectedId={selectedId} onSelect={select} search={search} />
           )}
           {activeTab === 'containment' && (
             <ContainmentTab
@@ -484,7 +495,7 @@ export function RegistryEditor({ registry: initialRegistry }: RegistryEditorProp
       </div>
 
       {/* Drawer */}
-      {selectedType && activeTab !== 'json' && (
+      {showDrawer && (
         <TypePreviewDrawer type={selectedType} onClose={() => select(null)} />
       )}
     </div>


### PR DESCRIPTION
## Summary

- **Card grid layout**: Types tab switched from flex-row list to `repeat(auto-fill, minmax(280px, 1fr))` CSS grid matching web2 spec
- **Card design**: Each type card redesigned with 3-column grid (36px swatch | label+rune+desc | meta), selected state uses brand-tinted border and background via `color-mix()`
- **380px inspector column**: Outer `RegistryEditor` container changed from `display: flex` to `display: grid` with `1fr 380px` template; `TypePreviewDrawer` width is now driven by the grid column (removed explicit `w-[320px]`)
- **Description paragraph**: Added `<p>` below the `<h2>` header explaining registry purpose (matches web2 `registry.jsx:41`)
- **Search in tab bar**: `search` state lifted from `TypesTab` to `RegistryEditor`; input moved inline into the tab bar (right-aligned with `flex-1` spacer), shown only on types tab

## Files changed

- `web-next/packages/plugin-observatory/src/ui/RegistryEditor.tsx` — all four layout/structure changes
- `web-next/packages/plugin-observatory/src/styles.css` — added `.type-grid`, `.type-card`, `.type-swatch`, `.type-name`, `.type-desc`, `.type-meta` CSS classes

## Test plan

- [x] All 20 existing `RegistryEditor.test.tsx` tests pass (search filter, drawer, tabs, reparenting)
- [x] Coverage >= 85% (full suite exits 0)
- [x] No lint errors (`pnpm lint` shows 0 errors, pre-existing warnings only)
- [x] TypeScript clean for plugin-observatory (`pnpm typecheck`)
- [ ] Visual test `observatory registry — types tab matches web2` pixel diff <= 5%

Closes NIU-700

🤖 Generated with [Claude Code](https://claude.com/claude-code)