### PR TITLE
feat(observatory): registry containment visual parity with web2 — NIU-701

### DIFF
--- a/web-next/packages/plugin-observatory/src/styles.css
+++ b/web-next/packages/plugin-observatory/src/styles.css
@@ -42,7 +42,9 @@
     cursor: pointer;
     text-align: left;
     width: 100%;
-    transition: border-color 120ms ease, background 120ms ease;
+    transition:
+      border-color 120ms ease,
+      background 120ms ease;
   }
 
   .type-card:hover {
@@ -95,15 +97,42 @@
     color: var(--color-text-muted);
   }
 
+  /* Containment hint box */
+  .containment-hint {
+    color: var(--color-text-secondary);
+    font-size: 13px;
+    margin: 0 0 var(--space-4) 0;
+    padding: 10px 12px;
+    background: var(--color-bg-tertiary);
+    border: 1px dashed var(--color-border-subtle);
+    border-radius: var(--radius-sm);
+    line-height: 1.5;
+  }
+
+  .containment-hint code {
+    background: color-mix(in srgb, var(--color-brand) 12%, transparent);
+    color: var(--brand-300);
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 11px;
+    font-family: var(--font-mono);
+  }
+
+  /* Containment tree children connector */
+  .registry-tree-children {
+    margin-left: 16px;
+    border-left: 1px dashed var(--color-border-subtle);
+    padding-left: 8px;
+  }
+
   /* Containment tree nodes */
   .registry-tree-node {
     @apply niuu-flex niuu-items-center niuu-gap-2 niuu-rounded-sm niuu-border niuu-border-transparent niuu-cursor-grab;
     padding: 4px 8px;
-    margin-left: calc(var(--tree-depth, 0) * 20px);
   }
 
   .registry-tree-node[data-selected='true'] {
-    @apply niuu-bg-bg-tertiary;
+    background: color-mix(in srgb, var(--color-brand) 12%, transparent);
   }
 
   .registry-tree-node[data-dragging='true'] {
@@ -111,17 +140,21 @@
   }
 
   .registry-tree-node[data-drag-state='ok'] {
-    border: 1px dashed color-mix(in srgb, var(--color-brand) 30%, transparent);
+    outline: 1px dashed color-mix(in srgb, var(--color-brand) 30%, transparent);
+    outline-offset: -1px;
   }
 
   .registry-tree-node[data-drag-state='target'] {
-    border: 1px solid var(--color-brand);
     background: color-mix(in srgb, var(--color-brand) 20%, transparent);
+    outline: 1px solid var(--color-brand);
+    outline-offset: -1px;
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-brand) 30%, transparent);
   }
 
   .registry-tree-node[data-drag-state='invalid'] {
-    border: 1px solid var(--color-critical);
     background: color-mix(in srgb, var(--color-critical) 15%, transparent);
+    outline: 1px solid var(--color-critical);
+    outline-offset: -1px;
     cursor: not-allowed;
   }
 }

--- a/web-next/packages/plugin-observatory/src/ui/RegistryEditor.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/RegistryEditor.tsx
@@ -177,7 +177,13 @@ function TypesTab({ registry, selectedId, onSelect, search }: TypesTabProps) {
                   </span>
                 </div>
                 <div className="type-meta">
-                  <div style={{ fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--brand-300)' }}>
+                  <div
+                    style={{
+                      fontFamily: 'var(--font-mono)',
+                      fontSize: 10,
+                      color: 'var(--brand-300)',
+                    }}
+                  >
                     {t.id}
                   </div>
                   <div>
@@ -308,7 +314,6 @@ function ContainmentTab({ registry, selectedId, onSelect, tryReparent }: Contain
           data-dragging={isDragging ? 'true' : undefined}
           draggable
           className="registry-tree-node"
-          style={{ '--tree-depth': depth } as React.CSSProperties}
           onDragStart={(e) => handleDragStart(e, t.id)}
           onDragOver={(e) => handleDragOver(e, t.id)}
           onDragLeave={(e) => handleDragLeave(e, t.id)}
@@ -333,18 +338,20 @@ function ContainmentTab({ registry, selectedId, onSelect, tryReparent }: Contain
             {t.id}
           </span>
         </div>
-        {children.length > 0 && <div>{children.map((c) => renderNode(c, depth + 1))}</div>}
+        {children.length > 0 && (
+          <div className="registry-tree-children">
+            {children.map((c) => renderNode(c, depth + 1))}
+          </div>
+        )}
       </div>
     );
   };
 
   return (
     <div>
-      <p className="niuu-m-0 niuu-mb-4 niuu-text-sm niuu-text-text-muted niuu-leading-[1.5]">
-        <strong>Drag</strong> a type onto another to reparent it. The{' '}
-        <code className="niuu-font-mono niuu-text-[11px]">canContain</code> edge moves to the new
-        parent; <code className="niuu-font-mono niuu-text-[11px]">parentTypes</code> on the child
-        updates. Cycles are blocked.
+      <p className="containment-hint">
+        <strong>Drag</strong> a type onto another to reparent it. The <code>canContain</code> edge
+        moves to the new parent; <code>parentTypes</code> on the child updates. Cycles are blocked.
       </p>
 
       <div data-testid="containment-tree">{roots.map((r) => renderNode(r))}</div>
@@ -352,9 +359,9 @@ function ContainmentTab({ registry, selectedId, onSelect, tryReparent }: Contain
       {orphans.length > 0 && (
         <div
           data-testid="orphans-section"
-          className="niuu-mt-6 niuu-pt-4 niuu-border-t niuu-border-border-subtle"
+          className="niuu-mt-4 niuu-pt-3 niuu-border-t niuu-border-dashed niuu-border-border-subtle"
         >
-          <div className="niuu-font-mono niuu-text-[11px] niuu-text-text-muted niuu-uppercase niuu-tracking-[0.07em] niuu-mb-2">
+          <div className="niuu-font-mono niuu-text-[10px] niuu-text-text-muted niuu-uppercase niuu-tracking-[0.08em] niuu-mb-1">
             orphans — parent missing
           </div>
           {orphans.map((o) => renderNode(o))}
@@ -480,7 +487,12 @@ export function RegistryEditor({ registry: initialRegistry }: RegistryEditorProp
         {/* Tab content */}
         <div role="tabpanel" className="niuu-flex-1 niuu-overflow-y-auto niuu-py-5 niuu-px-6">
           {activeTab === 'types' && (
-            <TypesTab registry={registry} selectedId={selectedId} onSelect={select} search={search} />
+            <TypesTab
+              registry={registry}
+              selectedId={selectedId}
+              onSelect={select}
+              search={search}
+            />
           )}
           {activeTab === 'containment' && (
             <ContainmentTab
@@ -495,9 +507,7 @@ export function RegistryEditor({ registry: initialRegistry }: RegistryEditorProp
       </div>
 
       {/* Drawer */}
-      {showDrawer && (
-        <TypePreviewDrawer type={selectedType} onClose={() => select(null)} />
-      )}
+      {showDrawer && <TypePreviewDrawer type={selectedType} onClose={() => select(null)} />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Style the containment hint box to match web2's `.containment-hint`: `bg-tertiary` background, dashed `border-subtle` border, `radius-sm`, and branded `<code>` highlights (`color-mix(brand 12%)` background, `brand-300` text)
- Add dashed left-border tree connectors on children containers (`margin-left: 16px`, `border-left: 1px dashed`, `padding-left: 8px`) matching web2's `.tree-children`
- Update drag state visuals to match web2: `outline` instead of `border`, `outline-offset: -1px`, `box-shadow` on drop-target, brand color-mix on selected state
- Fix orphans section: dashed `border-top`, correct spacing (`--space-4` / `--space-3`), `10px` font with `0.08em` letter-spacing

## Test plan

- [x] All 20 existing RegistryEditor unit tests pass (including drag-drop, reparenting, cycle prevention)
- [x] `pnpm test` passes with coverage above 85%
- [x] `pnpm lint` clean (0 errors)
- [x] `pnpm format:check` passes
- [ ] Visual regression test: `observatory registry — containment tab matches web2` should pass at ≤5% pixel diff
- [ ] CI green on push

## Linear

Ticket: NIU-701
_Note: Linear MCP tools were not available in this session. Ticket status update to be done manually._

🤖 Generated with [Claude Code](https://claude.com/claude-code)