### PR TITLE
feat(observatory): registry containment visual parity with web2 — NIU-701

### DIFF
--- a/web-next/e2e/capture-baselines.spec.ts
+++ b/web-next/e2e/capture-baselines.spec.ts
@@ -113,10 +113,9 @@ async function waitForReady(page: Page): Promise<void> {
   // Babel compiles scripts sequentially. The shell renders first, then plugins.
   // Wait until button elements appear (tabs or subnav), which means the full
   // app has mounted — not just the shell chrome.
-  await page.waitForFunction(
-    () => document.querySelectorAll('#root button').length >= 3,
-    { timeout: 10_000 },
-  );
+  await page.waitForFunction(() => document.querySelectorAll('#root button').length >= 3, {
+    timeout: 10_000,
+  });
   // Let any rAF-driven animations reach steady state.
   await page.waitForTimeout(600);
 }
@@ -132,7 +131,7 @@ async function waitForReady(page: Page): Promise<void> {
 async function clickTab(page: Page, label: string): Promise<void> {
   // Try title attribute first (rail items), then text content (tabs & subnav).
   const byTitle = page.locator(`button[title*="${label}"]`).first();
-  if (await byTitle.count() > 0) {
+  if ((await byTitle.count()) > 0) {
     await byTitle.click({ force: true });
   } else {
     await page.locator(`button:has-text("${label}")`).first().click({ force: true });

--- a/web-next/packages/plugin-observatory/src/styles.css
+++ b/web-next/packages/plugin-observatory/src/styles.css
@@ -97,15 +97,42 @@
     color: var(--color-text-muted);
   }
 
+  /* Containment hint box */
+  .containment-hint {
+    color: var(--color-text-secondary);
+    font-size: 13px;
+    margin: 0 0 var(--space-4) 0;
+    padding: 10px 12px;
+    background: var(--color-bg-tertiary);
+    border: 1px dashed var(--color-border-subtle);
+    border-radius: var(--radius-sm);
+    line-height: 1.5;
+  }
+
+  .containment-hint code {
+    background: color-mix(in srgb, var(--color-brand) 12%, transparent);
+    color: var(--brand-300);
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 11px;
+    font-family: var(--font-mono);
+  }
+
+  /* Containment tree children connector */
+  .registry-tree-children {
+    margin-left: 16px;
+    border-left: 1px dashed var(--color-border-subtle);
+    padding-left: 8px;
+  }
+
   /* Containment tree nodes */
   .registry-tree-node {
     @apply niuu-flex niuu-items-center niuu-gap-2 niuu-rounded-sm niuu-border niuu-border-transparent niuu-cursor-grab;
     padding: 4px 8px;
-    margin-left: calc(var(--tree-depth, 0) * 20px);
   }
 
   .registry-tree-node[data-selected='true'] {
-    @apply niuu-bg-bg-tertiary;
+    background: color-mix(in srgb, var(--color-brand) 12%, transparent);
   }
 
   .registry-tree-node[data-dragging='true'] {
@@ -113,17 +140,21 @@
   }
 
   .registry-tree-node[data-drag-state='ok'] {
-    border: 1px dashed color-mix(in srgb, var(--color-brand) 30%, transparent);
+    outline: 1px dashed color-mix(in srgb, var(--color-brand) 30%, transparent);
+    outline-offset: -1px;
   }
 
   .registry-tree-node[data-drag-state='target'] {
-    border: 1px solid var(--color-brand);
     background: color-mix(in srgb, var(--color-brand) 20%, transparent);
+    outline: 1px solid var(--color-brand);
+    outline-offset: -1px;
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-brand) 30%, transparent);
   }
 
   .registry-tree-node[data-drag-state='invalid'] {
-    border: 1px solid var(--color-critical);
     background: color-mix(in srgb, var(--color-critical) 15%, transparent);
+    outline: 1px solid var(--color-critical);
+    outline-offset: -1px;
     cursor: not-allowed;
   }
 }

--- a/web-next/packages/plugin-observatory/src/ui/RegistryEditor.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/RegistryEditor.tsx
@@ -300,7 +300,7 @@ function ContainmentTab({ registry, selectedId, onSelect, tryReparent }: Contain
     setOverId(null);
   };
 
-  const renderNode = (t: EntityType, depth = 0): React.ReactNode => {
+  const renderNode = (t: EntityType): React.ReactNode => {
     const children = t.canContain.map((id) => byId.get(id)).filter(Boolean) as EntityType[];
     const dropState = getDropState(t.id);
     const isDragging = dragId === t.id;
@@ -340,7 +340,7 @@ function ContainmentTab({ registry, selectedId, onSelect, tryReparent }: Contain
         </div>
         {children.length > 0 && (
           <div className="registry-tree-children">
-            {children.map((c) => renderNode(c, depth + 1))}
+            {children.map((c) => renderNode(c))}
           </div>
         )}
       </div>

--- a/web-next/packages/plugin-observatory/src/ui/RegistryEditor.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/RegistryEditor.tsx
@@ -314,7 +314,6 @@ function ContainmentTab({ registry, selectedId, onSelect, tryReparent }: Contain
           data-dragging={isDragging ? 'true' : undefined}
           draggable
           className="registry-tree-node"
-          style={{ '--tree-depth': depth } as React.CSSProperties}
           onDragStart={(e) => handleDragStart(e, t.id)}
           onDragOver={(e) => handleDragOver(e, t.id)}
           onDragLeave={(e) => handleDragLeave(e, t.id)}
@@ -339,18 +338,20 @@ function ContainmentTab({ registry, selectedId, onSelect, tryReparent }: Contain
             {t.id}
           </span>
         </div>
-        {children.length > 0 && <div>{children.map((c) => renderNode(c, depth + 1))}</div>}
+        {children.length > 0 && (
+          <div className="registry-tree-children">
+            {children.map((c) => renderNode(c, depth + 1))}
+          </div>
+        )}
       </div>
     );
   };
 
   return (
     <div>
-      <p className="niuu-m-0 niuu-mb-4 niuu-text-sm niuu-text-text-muted niuu-leading-[1.5]">
-        <strong>Drag</strong> a type onto another to reparent it. The{' '}
-        <code className="niuu-font-mono niuu-text-[11px]">canContain</code> edge moves to the new
-        parent; <code className="niuu-font-mono niuu-text-[11px]">parentTypes</code> on the child
-        updates. Cycles are blocked.
+      <p className="containment-hint">
+        <strong>Drag</strong> a type onto another to reparent it. The <code>canContain</code> edge
+        moves to the new parent; <code>parentTypes</code> on the child updates. Cycles are blocked.
       </p>
 
       <div data-testid="containment-tree">{roots.map((r) => renderNode(r))}</div>
@@ -358,9 +359,9 @@ function ContainmentTab({ registry, selectedId, onSelect, tryReparent }: Contain
       {orphans.length > 0 && (
         <div
           data-testid="orphans-section"
-          className="niuu-mt-6 niuu-pt-4 niuu-border-t niuu-border-border-subtle"
+          className="niuu-mt-4 niuu-pt-3 niuu-border-t niuu-border-dashed niuu-border-border-subtle"
         >
-          <div className="niuu-font-mono niuu-text-[11px] niuu-text-text-muted niuu-uppercase niuu-tracking-[0.07em] niuu-mb-2">
+          <div className="niuu-font-mono niuu-text-[10px] niuu-text-text-muted niuu-uppercase niuu-tracking-[0.08em] niuu-mb-1">
             orphans — parent missing
           </div>
           {orphans.map((o) => renderNode(o))}

--- a/web-next/packages/plugin-observatory/src/ui/RegistryEditor.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/RegistryEditor.tsx
@@ -339,9 +339,7 @@ function ContainmentTab({ registry, selectedId, onSelect, tryReparent }: Contain
           </span>
         </div>
         {children.length > 0 && (
-          <div className="registry-tree-children">
-            {children.map((c) => renderNode(c))}
-          </div>
+          <div className="registry-tree-children">{children.map((c) => renderNode(c))}</div>
         )}
       </div>
     );

--- a/web-next/packages/plugin-tyr/src/ui/DashboardPage.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/DashboardPage.tsx
@@ -157,7 +157,10 @@ function DashboardContent() {
           </span>
           <span className="tyr-dash__stat-sep" aria-hidden="true" />
           <span className="tyr-dash__stat">
-            concurrent <strong>{runningRaids}/{dispatcherState.maxConcurrentRaids}</strong>
+            concurrent{' '}
+            <strong>
+              {runningRaids}/{dispatcherState.maxConcurrentRaids}
+            </strong>
           </span>
         </div>
       )}

--- a/web-next/packages/plugin-volundr/src/ui/ClustersPage.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/ClustersPage.tsx
@@ -5,7 +5,6 @@ import type {
   ClusterNode,
   ClusterPod,
   ClusterDisk,
-  ClusterKind,
   ClusterStatus,
   NodeStatus,
   PodStatus,

--- a/web-next/packages/plugin-volundr/src/ui/ClustersPage.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/ClustersPage.tsx
@@ -75,8 +75,7 @@ function comparePods(a: ClusterPod, b: ClusterPod, field: SortField, dir: SortDi
     const aPct = a.memLimitMi > 0 ? a.memUsedMi / a.memLimitMi : 0;
     const bPct = b.memLimitMi > 0 ? b.memUsedMi / b.memLimitMi : 0;
     cmp = aPct - bPct;
-  }
-  else if (field === 'restarts') cmp = a.restarts - b.restarts;
+  } else if (field === 'restarts') cmp = a.restarts - b.restarts;
   return dir === 'asc' ? cmp : -cmp;
 }
 


### PR DESCRIPTION
## Summary

- Style the containment hint box to match web2's `.containment-hint`: `bg-tertiary` background, dashed `border-subtle` border, `radius-sm`, and branded `<code>` highlights (`color-mix(brand 12%)` background, `brand-300` text)
- Add dashed left-border tree connectors on children containers (`margin-left: 16px`, `border-left: 1px dashed`, `padding-left: 8px`) matching web2's `.tree-children`
- Update drag state visuals to match web2: `outline` instead of `border`, `outline-offset: -1px`, `box-shadow` on drop-target, brand color-mix on selected state
- Fix orphans section: dashed `border-top`, correct spacing (`--space-4` / `--space-3`), `10px` font with `0.08em` letter-spacing

## Test plan

- [x] All 20 existing RegistryEditor unit tests pass (including drag-drop, reparenting, cycle prevention)
- [x] `pnpm test` passes with coverage above 85%
- [x] `pnpm lint` clean (0 errors)
- [x] `pnpm format:check` passes
- [ ] Visual regression test: `observatory registry — containment tab matches web2` should pass at ≤5% pixel diff
- [ ] CI green on push

## Linear

Ticket: NIU-701
_Note: Linear MCP tools were not available in this session. Ticket status update to be done manually._

🤖 Generated with [Claude Code](https://claude.com/claude-code)