### PR TITLE
feat(volundr): sessions visual parity with web2 — NIU-729

### DIFF
--- a/web-next/packages/plugin-volundr/src/ui/SessionsPage.test.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/SessionsPage.test.tsx
@@ -11,11 +11,16 @@ vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => vi.fn(),
 }));
 
-function wrap(sessionStore: ISessionStore = createMockSessionStore()) {
+function wrap(
+  sessionStore: ISessionStore = createMockSessionStore(),
+  pageProps: React.ComponentProps<typeof SessionsPage> = {},
+) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={client}>
-      <ServicesProvider services={{ sessionStore }}>{<SessionsPage />}</ServicesProvider>
+      <ServicesProvider services={{ sessionStore }}>
+        <SessionsPage {...pageProps} />
+      </ServicesProvider>
     </QueryClientProvider>,
   );
 }
@@ -24,78 +29,299 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
+// ---------------------------------------------------------------------------
+// Structural tests
+// ---------------------------------------------------------------------------
+
 describe('SessionsPage', () => {
   it('renders the sessions page container', () => {
     wrap();
     expect(screen.getByTestId('sessions-page')).toBeInTheDocument();
   });
 
-  it('renders state subnav tabs', () => {
+  it('renders the sessions sidebar subnav', () => {
     wrap();
-    expect(screen.getByTestId('state-tab-running')).toBeInTheDocument();
-    expect(screen.getByTestId('state-tab-idle')).toBeInTheDocument();
-    expect(screen.getByTestId('state-tab-provisioning')).toBeInTheDocument();
-    expect(screen.getByTestId('state-tab-failed')).toBeInTheDocument();
-    expect(screen.getByTestId('state-tab-terminated')).toBeInTheDocument();
+    expect(screen.getByTestId('sessions-subnav')).toBeInTheDocument();
   });
 
-  it('defaults to the running tab selected', () => {
+  it('renders the page header with title', () => {
     wrap();
-    expect(screen.getByTestId('state-tab-running')).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('heading', { name: /sessions/i })).toBeInTheDocument();
   });
 
-  it('switches to idle tab on click', () => {
+  it('renders the search input', () => {
     wrap();
-    fireEvent.click(screen.getByTestId('state-tab-idle'));
-    expect(screen.getByTestId('state-tab-idle')).toHaveAttribute('aria-selected', 'true');
-    expect(screen.getByTestId('state-tab-running')).toHaveAttribute('aria-selected', 'false');
+    expect(screen.getByTestId('session-search')).toBeInTheDocument();
   });
 
-  it('shows running sessions in the running tab', async () => {
+  // ---------------------------------------------------------------------------
+  // Sidebar — By Status section
+  // ---------------------------------------------------------------------------
+
+  it('renders By Status section in sidebar', () => {
+    wrap();
+    expect(screen.getByTestId('section-status')).toBeInTheDocument();
+  });
+
+  it('renders sidebar nodes for each session state', () => {
+    wrap();
+    expect(screen.getByTestId('sidebar-node-status-running')).toBeInTheDocument();
+    expect(screen.getByTestId('sidebar-node-status-idle')).toBeInTheDocument();
+    expect(screen.getByTestId('sidebar-node-status-provisioning')).toBeInTheDocument();
+    expect(screen.getByTestId('sidebar-node-status-failed')).toBeInTheDocument();
+    expect(screen.getByTestId('sidebar-node-status-terminated')).toBeInTheDocument();
+  });
+
+  it('defaults to running state selected in sidebar', () => {
+    wrap();
+    expect(screen.getByTestId('sidebar-node-status-running')).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+  });
+
+  it('shows session count badges in the sidebar', async () => {
+    wrap();
+    await waitFor(() =>
+      expect(screen.getByTestId('sidebar-node-status-running-count')).toHaveTextContent('1'),
+    );
+  });
+
+  it('switches active filter when a sidebar node is clicked', async () => {
+    wrap();
+    fireEvent.click(screen.getByTestId('sidebar-node-status-idle'));
+    await waitFor(() =>
+      expect(screen.getByTestId('sidebar-node-status-idle')).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      ),
+    );
+    expect(screen.getByTestId('sidebar-node-status-running')).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Sidebar — By Template section
+  // ---------------------------------------------------------------------------
+
+  it('renders By Template section in sidebar', () => {
+    wrap();
+    expect(screen.getByTestId('section-template')).toBeInTheDocument();
+  });
+
+  it('renders template sidebar nodes from session data', async () => {
+    wrap();
+    await waitFor(() =>
+      expect(
+        screen.getByTestId('sidebar-node-template-tpl-default'),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it('filters sessions by template when a template node is clicked', async () => {
+    wrap();
+    await waitFor(() =>
+      expect(screen.getByTestId('sidebar-node-template-tpl-default')).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId('sidebar-node-template-tpl-default'));
+    await waitFor(() =>
+      expect(screen.getByTestId('sidebar-node-template-tpl-default')).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      ),
+    );
+    // ds-1 is in tpl-default and should appear in the table
+    await waitFor(() => expect(screen.getByText('ds-1')).toBeInTheDocument());
+  });
+
+  // ---------------------------------------------------------------------------
+  // Sidebar — By Cluster section
+  // ---------------------------------------------------------------------------
+
+  it('renders By Cluster section in sidebar', () => {
+    wrap();
+    expect(screen.getByTestId('section-cluster')).toBeInTheDocument();
+  });
+
+  it('renders cluster sidebar nodes from session data', async () => {
+    wrap();
+    await waitFor(() =>
+      expect(screen.getByTestId('sidebar-node-cluster-cl-eitri')).toBeInTheDocument(),
+    );
+  });
+
+  it('filters sessions by cluster when a cluster node is clicked', async () => {
+    wrap();
+    await waitFor(() =>
+      expect(screen.getByTestId('sidebar-node-cluster-cl-eitri')).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId('sidebar-node-cluster-cl-eitri'));
+    await waitFor(() =>
+      expect(screen.getByTestId('sidebar-node-cluster-cl-eitri')).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      ),
+    );
+    await waitFor(() => expect(screen.getByText('ds-1')).toBeInTheDocument());
+  });
+
+  // ---------------------------------------------------------------------------
+  // Sidebar — collapsible sections
+  // ---------------------------------------------------------------------------
+
+  it('collapses the By Status section when toggle is clicked', () => {
+    wrap();
+    const toggle = screen.getByTestId('section-status-toggle');
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByTestId('sidebar-node-status-running')).not.toBeInTheDocument();
+  });
+
+  it('expands a collapsed section when toggle is clicked again', () => {
+    wrap();
+    const toggle = screen.getByTestId('section-status-toggle');
+    fireEvent.click(toggle);
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByTestId('sidebar-node-status-running')).toBeInTheDocument();
+  });
+
+  it('collapses the By Template section when toggle is clicked', async () => {
+    wrap();
+    await waitFor(() =>
+      expect(screen.getByTestId('sidebar-node-template-tpl-default')).toBeInTheDocument(),
+    );
+    const toggle = screen.getByTestId('section-template-toggle');
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByTestId('sidebar-node-template-tpl-default')).not.toBeInTheDocument();
+  });
+
+  it('collapses the By Cluster section when toggle is clicked', async () => {
+    wrap();
+    await waitFor(() =>
+      expect(screen.getByTestId('sidebar-node-cluster-cl-eitri')).toBeInTheDocument(),
+    );
+    const toggle = screen.getByTestId('section-cluster-toggle');
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByTestId('sidebar-node-cluster-cl-eitri')).not.toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Session list — data display
+  // ---------------------------------------------------------------------------
+
+  it('shows running sessions by default', async () => {
     wrap();
     await waitFor(() => expect(screen.getByText('ds-1')).toBeInTheDocument());
   });
 
-  it('shows session counts in tab badges', async () => {
+  it('shows idle sessions when idle node is clicked', async () => {
     wrap();
-    await waitFor(() => expect(screen.getByTestId('state-count-running')).toHaveTextContent('1'));
+    fireEvent.click(screen.getByTestId('sidebar-node-status-idle'));
+    await waitFor(() => expect(screen.getByText('ds-2')).toBeInTheDocument());
   });
 
-  it('shows empty state when no sessions match the selected state', async () => {
+  it('shows failed sessions when failed node is clicked', async () => {
+    wrap();
+    fireEvent.click(screen.getByTestId('sidebar-node-status-failed'));
+    await waitFor(() => expect(screen.getByText('ds-4')).toBeInTheDocument());
+  });
+
+  it('shows terminated sessions when terminated node is clicked', async () => {
+    wrap();
+    fireEvent.click(screen.getByTestId('sidebar-node-status-terminated'));
+    await waitFor(() => expect(screen.getByText('ds-5')).toBeInTheDocument());
+  });
+
+  it('shows provisioning sessions when provisioning node is clicked', async () => {
+    wrap();
+    fireEvent.click(screen.getByTestId('sidebar-node-status-provisioning'));
+    await waitFor(() => expect(screen.getByText('ds-3')).toBeInTheDocument());
+  });
+
+  it('shows a view button for each visible session', async () => {
+    wrap();
+    await waitFor(() => expect(screen.getByTestId('view-session-ds-1')).toBeInTheDocument());
+  });
+
+  // ---------------------------------------------------------------------------
+  // Search / filter
+  // ---------------------------------------------------------------------------
+
+  it('filters visible sessions by search query matching session id', async () => {
+    wrap();
+    // switch to all-sessions view via template filter
+    await waitFor(() =>
+      expect(screen.getByTestId('sidebar-node-template-tpl-default')).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId('sidebar-node-template-tpl-default'));
+    await waitFor(() => expect(screen.getByText('ds-1')).toBeInTheDocument());
+
+    // Now type a search query that should only match ds-1
+    fireEvent.change(screen.getByTestId('session-search'), { target: { value: 'ds-1' } });
+    await waitFor(() => expect(screen.getByText('ds-1')).toBeInTheDocument());
+    expect(screen.queryByText('ds-2')).not.toBeInTheDocument();
+  });
+
+  it('shows empty state when search produces no matches', async () => {
+    wrap();
+    fireEvent.change(screen.getByTestId('session-search'), {
+      target: { value: 'zzz-no-match-at-all' },
+    });
+    await waitFor(() =>
+      expect(screen.getByText(/No sessions match/i)).toBeInTheDocument(),
+    );
+  });
+
+  it('shows empty state when no sessions match the selected state filter', async () => {
     const emptyStore: ISessionStore = {
       ...createMockSessionStore(),
       listSessions: vi.fn().mockResolvedValue([]),
     };
     wrap(emptyStore);
-    await waitFor(() => expect(screen.getByText(/No running sessions/i)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/No sessions match/i)).toBeInTheDocument());
   });
 
-  it('shows failed sessions when failed tab is clicked', async () => {
+  // ---------------------------------------------------------------------------
+  // Issue link
+  // ---------------------------------------------------------------------------
+
+  it('does not render issue link when issueKey is not provided', () => {
     wrap();
-    fireEvent.click(screen.getByTestId('state-tab-failed'));
-    await waitFor(() => expect(screen.getByText('ds-4')).toBeInTheDocument());
+    expect(screen.queryByTestId('issue-link')).not.toBeInTheDocument();
   });
 
-  it('shows terminated sessions when terminated tab is clicked', async () => {
-    wrap();
-    fireEvent.click(screen.getByTestId('state-tab-terminated'));
-    await waitFor(() => expect(screen.getByText('ds-5')).toBeInTheDocument());
+  it('renders issue link in page header when issueKey is provided', () => {
+    wrap(createMockSessionStore(), { issueKey: 'NIU-729' });
+    const link = screen.getByTestId('issue-link');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveTextContent('NIU-729');
   });
 
-  it('shows provisioning sessions when provisioning tab is clicked', async () => {
-    wrap();
-    fireEvent.click(screen.getByTestId('state-tab-provisioning'));
-    await waitFor(() => expect(screen.getByText('ds-3')).toBeInTheDocument());
+  it('uses issueUrl as href when provided', () => {
+    wrap(createMockSessionStore(), {
+      issueKey: 'NIU-729',
+      issueUrl: 'https://linear.app/niuulabs/issue/NIU-729',
+    });
+    expect(screen.getByTestId('issue-link')).toHaveAttribute(
+      'href',
+      'https://linear.app/niuulabs/issue/NIU-729',
+    );
   });
 
-  it('shows error state when session store fails', async () => {
-    const failingStore: ISessionStore = {
-      ...createMockSessionStore(),
-      listSessions: vi.fn().mockRejectedValue(new Error('store failed')),
-    };
-    wrap(failingStore);
-    await waitFor(() => expect(screen.getByText('Failed to load sessions')).toBeInTheDocument());
+  it('falls back to # href when issueUrl is not provided', () => {
+    wrap(createMockSessionStore(), { issueKey: 'NIU-729' });
+    expect(screen.getByTestId('issue-link')).toHaveAttribute('href', '#');
   });
+
+  // ---------------------------------------------------------------------------
+  // Loading / error states
+  // ---------------------------------------------------------------------------
 
   it('shows loading state before data resolves', () => {
     const slowStore: ISessionStore = {
@@ -106,8 +332,14 @@ describe('SessionsPage', () => {
     expect(screen.getByText('Loading sessions…')).toBeInTheDocument();
   });
 
-  it('shows a view button for each visible session', async () => {
-    wrap();
-    await waitFor(() => expect(screen.getByTestId('view-session-ds-1')).toBeInTheDocument());
+  it('shows error state when session store fails', async () => {
+    const failingStore: ISessionStore = {
+      ...createMockSessionStore(),
+      listSessions: vi.fn().mockRejectedValue(new Error('store failed')),
+    };
+    wrap(failingStore);
+    await waitFor(() =>
+      expect(screen.getByText('Failed to load sessions')).toBeInTheDocument(),
+    );
   });
 });

--- a/web-next/packages/plugin-volundr/src/ui/SessionsPage.test.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/SessionsPage.test.tsx
@@ -114,9 +114,7 @@ describe('SessionsPage', () => {
   it('renders template sidebar nodes from session data', async () => {
     wrap();
     await waitFor(() =>
-      expect(
-        screen.getByTestId('sidebar-node-template-tpl-default'),
-      ).toBeInTheDocument(),
+      expect(screen.getByTestId('sidebar-node-template-tpl-default')).toBeInTheDocument(),
     );
   });
 
@@ -273,9 +271,7 @@ describe('SessionsPage', () => {
     fireEvent.change(screen.getByTestId('session-search'), {
       target: { value: 'zzz-no-match-at-all' },
     });
-    await waitFor(() =>
-      expect(screen.getByText(/No sessions match/i)).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(/No sessions match/i)).toBeInTheDocument());
   });
 
   it('shows empty state when no sessions match the selected state filter', async () => {
@@ -338,8 +334,6 @@ describe('SessionsPage', () => {
       listSessions: vi.fn().mockRejectedValue(new Error('store failed')),
     };
     wrap(failingStore);
-    await waitFor(() =>
-      expect(screen.getByText('Failed to load sessions')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('Failed to load sessions')).toBeInTheDocument());
   });
 });

--- a/web-next/packages/plugin-volundr/src/ui/SessionsPage.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/SessionsPage.tsx
@@ -103,7 +103,11 @@ function SidebarSection({ label, collapsed, onToggle, children, testId }: Sideba
           ›
         </span>
       </button>
-      {!collapsed && <div role="group" aria-label={label}>{children}</div>}
+      {!collapsed && (
+        <div role="group" aria-label={label}>
+          {children}
+        </div>
+      )}
     </div>
   );
 }
@@ -173,12 +177,7 @@ function SearchInput({ value, onChange }: SearchInputProps) {
         aria-hidden="true"
       >
         <circle cx="6" cy="6" r="4.5" stroke="currentColor" strokeWidth="1.25" />
-        <path
-          d="M10 10L12.5 12.5"
-          stroke="currentColor"
-          strokeWidth="1.25"
-          strokeLinecap="round"
-        />
+        <path d="M10 10L12.5 12.5" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" />
       </svg>
       <input
         type="search"
@@ -238,8 +237,11 @@ export function SessionsPage({ issueKey, issueUrl }: SessionsPageProps = {}) {
   const navigate = useNavigate();
   const sessionsQuery = useSessionList();
 
-  const allSessions = sessionsQuery.data ?? [];
-  const grouped = sessionsQuery.data ? groupByState(sessionsQuery.data) : null;
+  const allSessions = useMemo(() => sessionsQuery.data ?? [], [sessionsQuery.data]);
+  const grouped = useMemo(
+    () => (sessionsQuery.data ? groupByState(sessionsQuery.data) : null),
+    [sessionsQuery.data],
+  );
 
   // Derive unique template IDs with counts
   const templateCounts = useMemo(() => {
@@ -395,11 +397,7 @@ export function SessionsPage({ issueKey, issueUrl }: SessionsPageProps = {}) {
           )}
 
           {sessionsQuery.data && visibleSessions.length > 0 && (
-            <Table<Session>
-              columns={columns}
-              rows={visibleSessions}
-              aria-label="Sessions"
-            />
+            <Table<Session> columns={columns} rows={visibleSessions} aria-label="Sessions" />
           )}
         </div>
       </div>

--- a/web-next/packages/plugin-volundr/src/ui/SessionsPage.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/SessionsPage.tsx
@@ -1,11 +1,15 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useNavigate } from '@tanstack/react-router';
-import { Table, LoadingState, ErrorState, EmptyState } from '@niuulabs/ui';
+import { Table, LoadingState, ErrorState, EmptyState, cn } from '@niuulabs/ui';
 import { useSessionList } from './hooks/useSessionStore';
 import { buildSessionColumns } from './utils/sessionColumns';
 import { groupByState, SESSION_STATES } from './sessions/groupByState';
 import type { SessionState } from '../domain/session';
 import type { Session } from '../domain/session';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
 
 const STATE_LABELS: Record<SessionState, string> = {
   requested: 'Requested',
@@ -18,14 +22,247 @@ const STATE_LABELS: Record<SessionState, string> = {
   failed: 'Failed',
 };
 
-/** Sessions page — state-grouped subnav + filterable session list. */
-export function SessionsPage() {
-  const [activeState, setActiveState] = useState<SessionState>('running');
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type FilterCategory = 'status' | 'template' | 'cluster';
+
+interface ActiveFilter {
+  category: FilterCategory;
+  value: string;
+}
+
+export interface SessionsPageProps {
+  /** Optional Linear/tracker issue key shown in the page header (e.g. "NIU-123"). */
+  issueKey?: string;
+  /** URL for the issue link. Defaults to "#" when omitted. */
+  issueUrl?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function filterSessions(
+  sessions: Session[],
+  activeFilter: ActiveFilter,
+  searchQuery: string,
+): Session[] {
+  let filtered = sessions;
+
+  if (activeFilter.category === 'status') {
+    filtered = filtered.filter((s) => s.state === activeFilter.value);
+  } else if (activeFilter.category === 'template') {
+    filtered = filtered.filter((s) => s.templateId === activeFilter.value);
+  } else if (activeFilter.category === 'cluster') {
+    filtered = filtered.filter((s) => s.clusterId === activeFilter.value);
+  }
+
+  const q = searchQuery.trim().toLowerCase();
+  if (!q) return filtered;
+
+  return filtered.filter(
+    (s) =>
+      s.id.toLowerCase().includes(q) ||
+      s.personaName.toLowerCase().includes(q) ||
+      s.templateId.toLowerCase().includes(q),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SidebarSection
+// ---------------------------------------------------------------------------
+
+interface SidebarSectionProps {
+  label: string;
+  collapsed: boolean;
+  onToggle: () => void;
+  children: React.ReactNode;
+  testId: string;
+}
+
+function SidebarSection({ label, collapsed, onToggle, children, testId }: SidebarSectionProps) {
+  return (
+    <div data-testid={testId}>
+      <button
+        type="button"
+        onClick={onToggle}
+        className="niuu-flex niuu-w-full niuu-items-center niuu-justify-between niuu-px-3 niuu-py-2 niuu-text-xs niuu-font-medium niuu-uppercase niuu-tracking-wider niuu-text-text-muted hover:niuu-text-text-secondary niuu-transition-colors"
+        aria-expanded={!collapsed}
+        data-testid={`${testId}-toggle`}
+      >
+        <span>{label}</span>
+        <span
+          className={cn(
+            'niuu-text-text-muted niuu-transition-transform niuu-duration-150',
+            collapsed ? 'niuu-rotate-0' : 'niuu-rotate-90',
+          )}
+          aria-hidden="true"
+        >
+          ›
+        </span>
+      </button>
+      {!collapsed && <div role="group" aria-label={label}>{children}</div>}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SidebarNode
+// ---------------------------------------------------------------------------
+
+interface SidebarNodeProps {
+  label: string;
+  count: number;
+  active: boolean;
+  onClick: () => void;
+  testId: string;
+}
+
+function SidebarNode({ label, count, active, onClick, testId }: SidebarNodeProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'niuu-flex niuu-w-full niuu-items-center niuu-justify-between niuu-border-l-2 niuu-px-3 niuu-py-1.5 niuu-text-sm niuu-transition-colors',
+        active
+          ? 'niuu-border-brand niuu-bg-brand-subtle niuu-text-brand'
+          : 'niuu-border-transparent niuu-text-text-secondary hover:niuu-bg-bg-tertiary hover:niuu-text-text-primary',
+      )}
+      aria-pressed={active}
+      data-testid={testId}
+    >
+      <span className="niuu-truncate">{label}</span>
+      {count > 0 && (
+        <span
+          className={cn(
+            'niuu-ml-2 niuu-rounded-full niuu-px-1.5 niuu-py-0.5 niuu-text-xs niuu-font-medium niuu-tabular-nums',
+            active
+              ? 'niuu-bg-brand niuu-text-bg-primary'
+              : 'niuu-bg-bg-elevated niuu-text-text-muted',
+          )}
+          data-testid={`${testId}-count`}
+        >
+          {count}
+        </span>
+      )}
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SearchInput
+// ---------------------------------------------------------------------------
+
+interface SearchInputProps {
+  value: string;
+  onChange: (v: string) => void;
+}
+
+function SearchInput({ value, onChange }: SearchInputProps) {
+  return (
+    <div className="niuu-relative">
+      <svg
+        className="niuu-pointer-events-none niuu-absolute niuu-left-2.5 niuu-top-1/2 niuu--translate-y-1/2 niuu-text-text-muted"
+        width="14"
+        height="14"
+        viewBox="0 0 14 14"
+        fill="none"
+        aria-hidden="true"
+      >
+        <circle cx="6" cy="6" r="4.5" stroke="currentColor" strokeWidth="1.25" />
+        <path
+          d="M10 10L12.5 12.5"
+          stroke="currentColor"
+          strokeWidth="1.25"
+          strokeLinecap="round"
+        />
+      </svg>
+      <input
+        type="search"
+        placeholder="Filter by name, ID, or template…"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="niuu-w-full niuu-rounded niuu-border niuu-border-border-subtle niuu-bg-bg-tertiary niuu-py-1.5 niuu-pl-8 niuu-pr-3 niuu-text-sm niuu-text-text-primary placeholder:niuu-text-text-muted focus:niuu-outline-none focus:niuu-ring-1 focus:niuu-ring-brand"
+        data-testid="session-search"
+        aria-label="Filter sessions"
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// IssueLinkIcon — external link icon
+// ---------------------------------------------------------------------------
+
+function IssueLinkIcon() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="none"
+      aria-hidden="true"
+      className="niuu-shrink-0"
+    >
+      <path
+        d="M7.5 1.5H10.5V4.5M10.5 1.5L5 7M2.5 3H1.5C1.224 3 1 3.224 1 3.5V10.5C1 10.776 1.224 11 1.5 11H8.5C8.776 11 9 10.776 9 10.5V9.5"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SessionsPage
+// ---------------------------------------------------------------------------
+
+/** Sessions page — left sidebar tree subnav + search + filterable session list. */
+export function SessionsPage({ issueKey, issueUrl }: SessionsPageProps = {}) {
+  const [activeFilter, setActiveFilter] = useState<ActiveFilter>({
+    category: 'status',
+    value: 'running',
+  });
+  const [searchQuery, setSearchQuery] = useState('');
+  const [collapsed, setCollapsed] = useState<Record<FilterCategory, boolean>>({
+    status: false,
+    template: false,
+    cluster: false,
+  });
+
   const navigate = useNavigate();
   const sessionsQuery = useSessionList();
 
+  const allSessions = sessionsQuery.data ?? [];
   const grouped = sessionsQuery.data ? groupByState(sessionsQuery.data) : null;
-  const visibleSessions = grouped ? (grouped[activeState] as Session[]) : [];
+
+  // Derive unique template IDs with counts
+  const templateCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const s of allSessions) {
+      counts[s.templateId] = (counts[s.templateId] ?? 0) + 1;
+    }
+    return counts;
+  }, [allSessions]);
+
+  // Derive unique cluster IDs with counts
+  const clusterCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const s of allSessions) {
+      counts[s.clusterId] = (counts[s.clusterId] ?? 0) + 1;
+    }
+    return counts;
+  }, [allSessions]);
+
+  const visibleSessions = useMemo(
+    () => filterSessions(allSessions, activeFilter, searchQuery),
+    [allSessions, activeFilter, searchQuery],
+  );
 
   function handleView(sessionId: string) {
     void navigate({ to: `/volundr/session/$sessionId`, params: { sessionId } });
@@ -33,75 +270,138 @@ export function SessionsPage() {
 
   const columns = buildSessionColumns({ onView: handleView });
 
+  function toggleCollapse(category: FilterCategory) {
+    setCollapsed((prev) => ({ ...prev, [category]: !prev[category] }));
+  }
+
+  function selectFilter(category: FilterCategory, value: string) {
+    setActiveFilter({ category, value });
+  }
+
+  const isActive = (category: FilterCategory, value: string) =>
+    activeFilter.category === category && activeFilter.value === value;
+
   return (
-    <div className="niuu-flex niuu-h-full niuu-flex-col" data-testid="sessions-page">
-      {/* State subnav */}
-      <div
-        className="niuu-flex niuu-items-center niuu-gap-0 niuu-border-b niuu-border-border-subtle niuu-bg-bg-secondary niuu-px-4"
-        role="tablist"
-        aria-label="Session state filter"
+    <div className="niuu-flex niuu-h-full" data-testid="sessions-page">
+      {/* ── Left sidebar subnav ─────────────────────────────────── */}
+      <nav
+        className="niuu-flex niuu-w-60 niuu-shrink-0 niuu-flex-col niuu-overflow-y-auto niuu-border-r niuu-border-border-subtle niuu-bg-bg-secondary"
+        aria-label="Session filters"
+        data-testid="sessions-subnav"
       >
-        {SESSION_STATES.map((state) => {
-          const count = grouped ? grouped[state].length : 0;
-          const isActive = activeState === state;
-          return (
-            <button
-              key={state}
-              role="tab"
-              aria-selected={isActive}
-              data-testid={`state-tab-${state}`}
-              onClick={() => setActiveState(state)}
-              className={
-                isActive
-                  ? 'niuu-flex niuu-items-center niuu-gap-1.5 niuu-border-b-2 niuu-border-brand niuu-px-4 niuu-py-2.5 niuu-text-sm niuu-font-medium niuu-text-brand'
-                  : 'niuu-flex niuu-items-center niuu-gap-1.5 niuu-border-b-2 niuu-border-transparent niuu-px-4 niuu-py-2.5 niuu-text-sm niuu-text-text-muted hover:niuu-text-text-secondary'
-              }
+        {/* By Status */}
+        <SidebarSection
+          label="By Status"
+          collapsed={collapsed.status}
+          onToggle={() => toggleCollapse('status')}
+          testId="section-status"
+        >
+          {SESSION_STATES.map((state) => {
+            const count = grouped ? grouped[state].length : 0;
+            return (
+              <SidebarNode
+                key={state}
+                label={STATE_LABELS[state]}
+                count={count}
+                active={isActive('status', state)}
+                onClick={() => selectFilter('status', state)}
+                testId={`sidebar-node-status-${state}`}
+              />
+            );
+          })}
+        </SidebarSection>
+
+        {/* By Template */}
+        <SidebarSection
+          label="By Template"
+          collapsed={collapsed.template}
+          onToggle={() => toggleCollapse('template')}
+          testId="section-template"
+        >
+          {Object.entries(templateCounts).map(([templateId, count]) => (
+            <SidebarNode
+              key={templateId}
+              label={templateId}
+              count={count}
+              active={isActive('template', templateId)}
+              onClick={() => selectFilter('template', templateId)}
+              testId={`sidebar-node-template-${templateId}`}
+            />
+          ))}
+        </SidebarSection>
+
+        {/* By Cluster */}
+        <SidebarSection
+          label="By Cluster"
+          collapsed={collapsed.cluster}
+          onToggle={() => toggleCollapse('cluster')}
+          testId="section-cluster"
+        >
+          {Object.entries(clusterCounts).map(([clusterId, count]) => (
+            <SidebarNode
+              key={clusterId}
+              label={clusterId}
+              count={count}
+              active={isActive('cluster', clusterId)}
+              onClick={() => selectFilter('cluster', clusterId)}
+              testId={`sidebar-node-cluster-${clusterId}`}
+            />
+          ))}
+        </SidebarSection>
+      </nav>
+
+      {/* ── Main content ────────────────────────────────────────── */}
+      <div className="niuu-flex niuu-min-w-0 niuu-flex-1 niuu-flex-col">
+        {/* Page header */}
+        <header className="niuu-flex niuu-items-center niuu-justify-between niuu-border-b niuu-border-border-subtle niuu-bg-bg-secondary niuu-px-4 niuu-py-2">
+          <h2 className="niuu-text-sm niuu-font-semibold niuu-text-text-primary">Sessions</h2>
+          {issueKey && (
+            <a
+              href={issueUrl ?? '#'}
+              className="niuu-flex niuu-items-center niuu-gap-1 niuu-font-mono niuu-text-xs niuu-text-brand hover:niuu-underline"
+              data-testid="issue-link"
+              target="_blank"
+              rel="noopener noreferrer"
             >
-              {STATE_LABELS[state]}
-              {count > 0 && (
-                <span
-                  className={
-                    isActive
-                      ? 'niuu-rounded-full niuu-bg-brand niuu-px-1.5 niuu-py-0.5 niuu-text-xs niuu-font-medium niuu-text-bg-primary'
-                      : 'niuu-rounded-full niuu-bg-bg-elevated niuu-px-1.5 niuu-py-0.5 niuu-text-xs niuu-text-text-muted'
-                  }
-                  data-testid={`state-count-${state}`}
-                >
-                  {count}
-                </span>
-              )}
-            </button>
-          );
-        })}
-      </div>
+              <IssueLinkIcon />
+              {issueKey}
+            </a>
+          )}
+        </header>
 
-      {/* Session list */}
-      <div className="niuu-flex-1 niuu-overflow-auto niuu-p-4">
-        {sessionsQuery.isLoading && <LoadingState label="Loading sessions…" />}
+        {/* Search */}
+        <div className="niuu-border-b niuu-border-border-subtle niuu-px-4 niuu-py-2">
+          <SearchInput value={searchQuery} onChange={setSearchQuery} />
+        </div>
 
-        {sessionsQuery.isError && (
-          <ErrorState
-            title="Failed to load sessions"
-            message={
-              sessionsQuery.error instanceof Error ? sessionsQuery.error.message : 'Unknown error'
-            }
-          />
-        )}
+        {/* Session list */}
+        <div className="niuu-flex-1 niuu-overflow-auto niuu-p-4">
+          {sessionsQuery.isLoading && <LoadingState label="Loading sessions…" />}
 
-        {grouped && visibleSessions.length === 0 && (
-          <EmptyState
-            title={`No ${STATE_LABELS[activeState].toLowerCase()} sessions`}
-            description={`Sessions in the ${STATE_LABELS[activeState].toLowerCase()} state will appear here.`}
-          />
-        )}
+          {sessionsQuery.isError && (
+            <ErrorState
+              title="Failed to load sessions"
+              message={
+                sessionsQuery.error instanceof Error ? sessionsQuery.error.message : 'Unknown error'
+              }
+            />
+          )}
 
-        {grouped && visibleSessions.length > 0 && (
-          <Table<Session>
-            columns={columns}
-            rows={visibleSessions}
-            aria-label={`${STATE_LABELS[activeState]} sessions`}
-          />
-        )}
+          {sessionsQuery.data && visibleSessions.length === 0 && (
+            <EmptyState
+              title="No sessions match"
+              description="Try a different filter or search query."
+            />
+          )}
+
+          {sessionsQuery.data && visibleSessions.length > 0 && (
+            <Table<Session>
+              columns={columns}
+              rows={visibleSessions}
+              aria-label="Sessions"
+            />
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- **Replace horizontal top-tabs with a 240px left sidebar subnav tree** containing three collapsible sections: "By Status", "By Template", and "By Cluster". Each section shows tree nodes with count badges. Active node has a left-border brand accent.
- **Add full-width search input** with a magnifying glass icon above the session list. Filters sessions in real-time by id, personaName, or templateId.
- **Add optional issue link in page header** — accepts `issueKey` and `issueUrl` props. When provided, renders an external-link icon + issue key in the right-aligned action area of the page header.

## Changes

- `web-next/packages/plugin-volundr/src/ui/SessionsPage.tsx` — full rewrite from top-tabs layout to sidebar + main-content layout with search and issue link
- `web-next/packages/plugin-volundr/src/ui/SessionsPage.test.tsx` — full test suite updated to cover sidebar nodes, collapse/expand, template/cluster filtering, search, and issue link (34 tests, 99.27% coverage)

## Acceptance criteria

1. ✅ Sessions page uses a left sidebar tree (240px) for filtering by status, template, and cluster
2. ✅ Each sidebar tree node shows a count badge and highlights when active
3. ✅ Sidebar sections are collapsible with a disclosure toggle
4. ✅ A full-width search input with icon allows real-time filtering of the session list
5. ✅ Page header includes an issue link (icon + key) when an issue is associated
6. ✅ Main content area correctly fills remaining width beside the sidebar
7. ✅ All styling uses Tailwind with `niuu-` prefix
8. ✅ 99.27% statement coverage on SessionsPage.tsx

## Test plan

- [x] All 3617 tests pass (`pnpm test`)
- [x] SessionsPage.test.tsx: 34 tests covering structural render, sidebar By Status/Template/Cluster, collapsible sections, search filtering, issue link display, loading/error states
- [x] Coverage: 99.27% statements, 98.38% branches, 94.11% functions on SessionsPage.tsx

🤖 Generated with [Claude Code](https://claude.com/claude-code)