### PR TITLE
fix(observatory): registry JSON tab visual parity with web2 — NIU-702

### DIFF
--- a/web-next/packages/plugin-observatory/src/ui/RegistryEditor.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/RegistryEditor.tsx
@@ -405,7 +405,7 @@ function JsonTab({ registry }: JsonTabProps) {
       </button>
       <pre
         data-testid="json-output"
-        className="niuu-m-0 niuu-p-4 niuu-bg-bg-secondary niuu-border niuu-border-border-subtle niuu-rounded-md niuu-font-mono niuu-text-xs niuu-text-text-secondary niuu-overflow-x-auto niuu-leading-[1.6] niuu-max-h-[600px] niuu-overflow-y-auto"
+        className="niuu-m-0 niuu-p-4 niuu-bg-bg-primary niuu-border niuu-border-border-subtle niuu-rounded-md niuu-font-mono niuu-text-[11px] niuu-text-text-secondary niuu-overflow-x-auto niuu-leading-[1.55] niuu-min-h-[480px] niuu-max-h-[calc(100vh-240px)] niuu-overflow-y-auto"
       >
         {json}
       </pre>


### PR DESCRIPTION
## Summary

Visual parity fixes for the Registry JSON tab in the Observatory plugin (`RegistryEditor.tsx`), closing the 6% pixel diff against the web2 baseline.

- **Background**: changed `niuu-bg-bg-secondary` → `niuu-bg-bg-primary` to match web2's darkest surface (`var(--color-bg-primary)`, zinc-950), giving the JSON block a "sunken" code-block appearance
- **Height constraints**: replaced `niuu-max-h-[600px]` with `niuu-min-h-[480px] niuu-max-h-[calc(100vh-240px)]` matching web2's `min-height: 480px; max-height: calc(100vh - 240px)`
- **Font size**: changed `niuu-text-xs` (12px) → `niuu-text-[11px]` to match web2's `font-size: 11px`
- **Line height**: changed `niuu-leading-[1.6]` → `niuu-leading-[1.55]` to match web2's `line-height: 1.55`

Preserved: copy button, relative wrapper, `copied!` feedback state, `JSON.stringify` formatting.

## Test plan

- [ ] All existing unit tests pass (`pnpm test` — exit 0 confirmed locally)
- [ ] ESLint clean — 0 errors in changed files
- [ ] Visual test `observatory registry — JSON tab matches web2` passes at ≤ 5% pixel diff
- [ ] Copy button remains visible and functional

Closes NIU-702

🤖 Generated with [Claude Code](https://claude.com/claude-code)