### PR TITLE
feat(mimir): graph visual parity — category-radial layout, hover glow, edge opacity — NIU-719

### DIFF
--- a/web-next/packages/plugin-mimir/src/ui/GraphPage.css
+++ b/web-next/packages/plugin-mimir/src/ui/GraphPage.css
@@ -1,217 +1,25 @@
-.graph-page {
-  padding: var(--space-6);
-  max-width: 960px;
-}
+/*
+ * GraphPage.css — minimal SVG-specific overrides.
+ *
+ * All layout and typography are handled by Tailwind utilities (niuu- prefix)
+ * in GraphPage.tsx. This file covers only what Tailwind cannot express:
+ *   1. Legend dot background colors via data-attribute (8 category slots)
+ *   2. SVG node hover glow filter (CSS filter on SVG not expressible in Tailwind)
+ */
 
-.graph-page__title {
-  margin: 0 0 var(--space-5);
-}
+/* ── Legend dot colors ─────────────────────────────────────────────────────── */
 
-.graph-page__toolbar {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-4);
-  margin-bottom: var(--space-4);
-  align-items: flex-end;
-}
+.niuu-graph-legend-dot[data-color-idx='0'] { background: var(--color-accent-cyan); }
+.niuu-graph-legend-dot[data-color-idx='1'] { background: var(--color-accent-indigo); }
+.niuu-graph-legend-dot[data-color-idx='2'] { background: var(--color-accent-emerald); }
+.niuu-graph-legend-dot[data-color-idx='3'] { background: var(--color-accent-purple); }
+.niuu-graph-legend-dot[data-color-idx='4'] { background: var(--color-accent-amber); }
+.niuu-graph-legend-dot[data-color-idx='5'] { background: var(--color-accent-orange); }
+.niuu-graph-legend-dot[data-color-idx='6'] { background: var(--color-accent-red); }
+.niuu-graph-legend-dot[data-color-idx='7'] { background: var(--color-text-secondary); }
 
-.graph-page__label {
-  display: block;
-  color: var(--color-text-muted);
-  font-size: var(--text-xs);
-  margin-bottom: var(--space-1);
-}
+/* ── SVG node hover glow ───────────────────────────────────────────────────── */
 
-.graph-page__focus-controls {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  min-width: 220px;
-}
-
-.graph-page__focus-input {
-  padding: var(--space-2) var(--space-3);
-  background: var(--color-bg-secondary);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  color: var(--color-text-primary);
-  font-family: var(--font-mono);
-  font-size: var(--text-xs);
-  outline: none;
-}
-
-.graph-page__focus-input:focus {
-  border-color: var(--color-brand);
-}
-
-.graph-page__clear-btn {
-  margin-top: var(--space-1);
-  align-self: flex-start;
-  background: none;
-  border: none;
-  color: var(--color-text-muted);
-  font-size: var(--text-xs);
-  cursor: pointer;
-  padding: 0;
-}
-
-.graph-page__clear-btn:hover {
-  color: var(--color-text-secondary);
-}
-
-.graph-page__hop-controls {
-  display: flex;
-  flex-direction: column;
-}
-
-.graph-page__hop-btns {
-  display: flex;
-  gap: var(--space-1);
-}
-
-.graph-page__hop-btn {
-  width: 32px;
-  height: 28px;
-  background: var(--color-bg-secondary);
-  border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-sm);
-  color: var(--color-text-secondary);
-  font-size: var(--text-xs);
-  cursor: pointer;
-}
-
-.graph-page__hop-btn--active {
-  background: var(--color-brand);
-  border-color: var(--color-brand);
-  color: var(--color-bg-primary);
-  font-weight: 600;
-}
-
-.graph-page__status {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-}
-
-.graph-page__stats {
-  display: flex;
-  gap: var(--space-2);
-  margin-bottom: var(--space-4);
-  flex-wrap: wrap;
-}
-
-.graph-page__svg {
-  width: 100%;
-  max-width: 600px;
-  height: auto;
-  border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-lg);
-  background: var(--color-bg-secondary);
-  display: block;
-}
-
-.graph-page__edge {
-  stroke: var(--color-border);
-  stroke-width: 1.5;
-}
-
-.graph-page__node {
-  cursor: pointer;
-}
-
-.graph-page__node-circle {
-  fill: var(--color-bg-tertiary);
-  stroke: var(--color-border);
-  stroke-width: 1.5;
-}
-
-.graph-page__node--focus .graph-page__node-circle {
-  fill: var(--color-brand);
-  stroke: var(--color-brand);
-}
-
-.graph-page__node-label {
-  text-anchor: middle;
-  fill: var(--color-text-secondary);
-  font-size: var(--text-xs);
-  font-family: var(--font-sans);
-  pointer-events: none;
-}
-
-/* ── Canvas + legend row ───────────────────────────────────────────────────── */
-
-.graph-page__canvas-wrap {
-  display: flex;
-  gap: var(--space-4);
-  align-items: flex-start;
-  flex-wrap: wrap;
-}
-
-/* ── Legend card ───────────────────────────────────────────────────────────── */
-
-.graph-page__legend {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-  padding: var(--space-3) var(--space-4);
-  background: var(--color-bg-secondary);
-  border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-lg);
-  min-width: 140px;
-}
-
-.graph-page__legend-title {
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.07em;
-  color: var(--color-text-muted);
-  padding-bottom: var(--space-1);
-  border-bottom: 1px solid var(--color-border-subtle);
-}
-
-.graph-page__legend-item {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-}
-
-.graph-page__legend-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  flex-shrink: 0;
-}
-
-/* 8 category color slots mapped from CSS tokens */
-.graph-page__legend-dot[data-color-idx='0'] {
-  background: var(--color-accent-cyan);
-}
-.graph-page__legend-dot[data-color-idx='1'] {
-  background: var(--color-accent-indigo);
-}
-.graph-page__legend-dot[data-color-idx='2'] {
-  background: var(--color-accent-emerald);
-}
-.graph-page__legend-dot[data-color-idx='3'] {
-  background: var(--color-accent-purple);
-}
-.graph-page__legend-dot[data-color-idx='4'] {
-  background: var(--color-accent-amber);
-}
-.graph-page__legend-dot[data-color-idx='5'] {
-  background: var(--color-accent-orange);
-}
-.graph-page__legend-dot[data-color-idx='6'] {
-  background: var(--color-accent-red);
-}
-.graph-page__legend-dot[data-color-idx='7'] {
-  background: var(--color-text-secondary);
-}
-
-.graph-page__legend-label {
-  font-size: var(--text-xs);
-  color: var(--color-text-secondary);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.niuu-graph-node:hover .niuu-graph-node-circle {
+  filter: url(#niuu-node-glow);
 }

--- a/web-next/packages/plugin-mimir/src/ui/GraphPage.css
+++ b/web-next/packages/plugin-mimir/src/ui/GraphPage.css
@@ -9,14 +9,30 @@
 
 /* ── Legend dot colors ─────────────────────────────────────────────────────── */
 
-.niuu-graph-legend-dot[data-color-idx='0'] { background: var(--color-accent-cyan); }
-.niuu-graph-legend-dot[data-color-idx='1'] { background: var(--color-accent-indigo); }
-.niuu-graph-legend-dot[data-color-idx='2'] { background: var(--color-accent-emerald); }
-.niuu-graph-legend-dot[data-color-idx='3'] { background: var(--color-accent-purple); }
-.niuu-graph-legend-dot[data-color-idx='4'] { background: var(--color-accent-amber); }
-.niuu-graph-legend-dot[data-color-idx='5'] { background: var(--color-accent-orange); }
-.niuu-graph-legend-dot[data-color-idx='6'] { background: var(--color-accent-red); }
-.niuu-graph-legend-dot[data-color-idx='7'] { background: var(--color-text-secondary); }
+.niuu-graph-legend-dot[data-color-idx='0'] {
+  background: var(--color-accent-cyan);
+}
+.niuu-graph-legend-dot[data-color-idx='1'] {
+  background: var(--color-accent-indigo);
+}
+.niuu-graph-legend-dot[data-color-idx='2'] {
+  background: var(--color-accent-emerald);
+}
+.niuu-graph-legend-dot[data-color-idx='3'] {
+  background: var(--color-accent-purple);
+}
+.niuu-graph-legend-dot[data-color-idx='4'] {
+  background: var(--color-accent-amber);
+}
+.niuu-graph-legend-dot[data-color-idx='5'] {
+  background: var(--color-accent-orange);
+}
+.niuu-graph-legend-dot[data-color-idx='6'] {
+  background: var(--color-accent-red);
+}
+.niuu-graph-legend-dot[data-color-idx='7'] {
+  background: var(--color-text-secondary);
+}
 
 /* ── SVG node hover glow ───────────────────────────────────────────────────── */
 

--- a/web-next/packages/plugin-mimir/src/ui/GraphPage.test.tsx
+++ b/web-next/packages/plugin-mimir/src/ui/GraphPage.test.tsx
@@ -1,9 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { screen, fireEvent, waitFor } from '@testing-library/react';
 import { GraphPage } from './GraphPage';
+import { layoutCategoryRadial } from './GraphPage';
 import { createMimirMockAdapter } from '../adapters/mock';
 import type { IMimirService } from '../ports';
 import { renderWithMimir } from '../testing/renderWithMimir';
+import type { GraphNode } from '../domain/api-types';
 
 const wrap = renderWithMimir;
 
@@ -78,5 +80,138 @@ describe('GraphPage', () => {
     };
     wrap(<GraphPage />, failing);
     await waitFor(() => expect(screen.getByText('graph service unavailable')).toBeInTheDocument());
+  });
+
+  it('SVG contains glow filter definition', async () => {
+    wrap(<GraphPage />);
+    await waitFor(() => screen.getByRole('img', { name: /knowledge graph/i }));
+    const svg = screen.getByRole('img', { name: /knowledge graph/i });
+    expect(svg.querySelector('filter#niuu-node-glow')).toBeInTheDocument();
+  });
+
+  it('unfocused edges have low-opacity class', async () => {
+    wrap(<GraphPage />);
+    await waitFor(() => screen.getByRole('img', { name: /knowledge graph/i }));
+    const svg = screen.getByRole('img', { name: /knowledge graph/i });
+    const lines = svg.querySelectorAll('line');
+    if (lines.length > 0) {
+      expect(lines[0]!.classList.toString()).toContain('niuu-opacity-15');
+    }
+  });
+
+  it('focused-node edges have highlighted opacity class', async () => {
+    wrap(<GraphPage />);
+    await waitFor(() => screen.getByRole('img', { name: /knowledge graph/i }));
+    const focusInput = screen.getByLabelText(/focus node id/i);
+    fireEvent.change(focusInput, { target: { value: '/arch/overview' } });
+    await waitFor(() => {
+      const svg = screen.getByRole('img', { name: /knowledge graph/i });
+      const highlightedLines = svg.querySelectorAll('line.niuu-opacity-50');
+      expect(highlightedLines.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('renders graph legend with category colors', async () => {
+    wrap(<GraphPage />);
+    await waitFor(() => screen.getByRole('img', { name: /knowledge graph/i }));
+    expect(screen.getByLabelText(/graph legend/i)).toBeInTheDocument();
+  });
+
+  it('clicking a node sets it as focus', async () => {
+    wrap(<GraphPage />);
+    await waitFor(() => screen.getByRole('img', { name: /knowledge graph/i }));
+    const svg = screen.getByRole('img', { name: /knowledge graph/i });
+    const nodeGroups = svg.querySelectorAll('g[role="button"]');
+    if (nodeGroups.length > 0) {
+      fireEvent.click(nodeGroups[0]!);
+      expect(screen.getByRole('button', { name: /clear focus/i })).toBeInTheDocument();
+    }
+  });
+});
+
+describe('layoutCategoryRadial', () => {
+  it('returns empty array for empty input', () => {
+    expect(layoutCategoryRadial([])).toEqual([]);
+  });
+
+  it('returns single node at center', () => {
+    const nodes: GraphNode[] = [{ id: 'n1', title: 'Node 1', category: 'a' }];
+    const result = layoutCategoryRadial(nodes);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.x).toBe(300);
+    expect(result[0]!.y).toBe(220);
+  });
+
+  it('positions nodes for multiple categories separately', () => {
+    const nodes: GraphNode[] = [
+      { id: 'a1', title: 'A1', category: 'alpha' },
+      { id: 'a2', title: 'A2', category: 'alpha' },
+      { id: 'b1', title: 'B1', category: 'beta' },
+    ];
+    const result = layoutCategoryRadial(nodes);
+    expect(result).toHaveLength(3);
+
+    // All nodes should be within the SVG viewBox bounds
+    for (const pos of result) {
+      expect(pos.x).toBeGreaterThan(0);
+      expect(pos.x).toBeLessThan(600);
+      expect(pos.y).toBeGreaterThan(0);
+      expect(pos.y).toBeLessThan(440);
+    }
+  });
+
+  it('produces deterministic output for the same input', () => {
+    const nodes: GraphNode[] = [
+      { id: 'n1', title: 'Node 1', category: 'cat-a' },
+      { id: 'n2', title: 'Node 2', category: 'cat-b' },
+      { id: 'n3', title: 'Node 3', category: 'cat-a' },
+    ];
+    const r1 = layoutCategoryRadial(nodes);
+    const r2 = layoutCategoryRadial(nodes);
+    expect(r1).toEqual(r2);
+  });
+
+  it('respects custom center and radius parameters', () => {
+    const nodes: GraphNode[] = [
+      { id: 'n1', title: 'A', category: 'x' },
+      { id: 'n2', title: 'B', category: 'y' },
+    ];
+    const result = layoutCategoryRadial(nodes, 100, 100, 50);
+    for (const pos of result) {
+      // All nodes should be within 50px of center (100,100) with jitter
+      const dx = pos.x - 100;
+      const dy = pos.y - 100;
+      const dist = Math.sqrt(dx * dx + dy * dy);
+      expect(dist).toBeLessThan(50 + 1); // max radius is 50
+    }
+  });
+
+  it('nodes in same category are clustered in same angular sector', () => {
+    const nodes: GraphNode[] = [
+      { id: 'a1', title: 'A1', category: 'alpha' },
+      { id: 'a2', title: 'A2', category: 'alpha' },
+      { id: 'a3', title: 'A3', category: 'alpha' },
+      { id: 'b1', title: 'B1', category: 'beta' },
+      { id: 'b2', title: 'B2', category: 'beta' },
+      { id: 'b3', title: 'B3', category: 'beta' },
+    ];
+    const result = layoutCategoryRadial(nodes);
+    const byId = new Map(result.map((p) => [p.node.id, p]));
+
+    const angleOf = (id: string) => {
+      const p = byId.get(id)!;
+      return Math.atan2(p.y - 220, p.x - 300);
+    };
+
+    // Alpha nodes should be closer to each other than to beta nodes
+    const alphaAngles = ['a1', 'a2', 'a3'].map(angleOf);
+    const betaAngles = ['b1', 'b2', 'b3'].map(angleOf);
+
+    const avgAlpha = alphaAngles.reduce((s, a) => s + a, 0) / alphaAngles.length;
+    const avgBeta = betaAngles.reduce((s, a) => s + a, 0) / betaAngles.length;
+
+    // The two cluster centers should be angularly distinct
+    const separation = Math.abs(avgAlpha - avgBeta);
+    expect(separation).toBeGreaterThan(0.3);
   });
 });

--- a/web-next/packages/plugin-mimir/src/ui/GraphPage.test.tsx
+++ b/web-next/packages/plugin-mimir/src/ui/GraphPage.test.tsx
@@ -1,7 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { screen, fireEvent, waitFor } from '@testing-library/react';
-import { GraphPage } from './GraphPage';
-import { layoutCategoryRadial } from './GraphPage';
+import { GraphPage, layoutCategoryRadial } from './GraphPage';
 import { createMimirMockAdapter } from '../adapters/mock';
 import type { IMimirService } from '../ports';
 import { renderWithMimir } from '../testing/renderWithMimir';
@@ -94,9 +93,8 @@ describe('GraphPage', () => {
     await waitFor(() => screen.getByRole('img', { name: /knowledge graph/i }));
     const svg = screen.getByRole('img', { name: /knowledge graph/i });
     const lines = svg.querySelectorAll('line');
-    if (lines.length > 0) {
-      expect(lines[0]!.classList.toString()).toContain('niuu-opacity-15');
-    }
+    expect(lines.length).toBeGreaterThan(0);
+    expect(lines[0]!.classList.toString()).toContain('niuu-opacity-15');
   });
 
   it('focused-node edges have highlighted opacity class', async () => {
@@ -122,10 +120,9 @@ describe('GraphPage', () => {
     await waitFor(() => screen.getByRole('img', { name: /knowledge graph/i }));
     const svg = screen.getByRole('img', { name: /knowledge graph/i });
     const nodeGroups = svg.querySelectorAll('g[role="button"]');
-    if (nodeGroups.length > 0) {
-      fireEvent.click(nodeGroups[0]!);
-      expect(screen.getByRole('button', { name: /clear focus/i })).toBeInTheDocument();
-    }
+    expect(nodeGroups.length).toBeGreaterThan(0);
+    fireEvent.click(nodeGroups[0]!);
+    expect(screen.getByRole('button', { name: /clear focus/i })).toBeInTheDocument();
   });
 });
 

--- a/web-next/packages/plugin-mimir/src/ui/GraphPage.tsx
+++ b/web-next/packages/plugin-mimir/src/ui/GraphPage.tsx
@@ -5,6 +5,9 @@ import './GraphPage.css';
 
 const MAX_HOPS = 4;
 const MIN_HOPS = 1;
+const SVG_CX = 300;
+const SVG_CY = 220;
+const SVG_R = 170;
 
 // Category color palette (maps to CSS tokens in order)
 const CATEGORY_COLORS = [
@@ -37,19 +40,58 @@ interface NodePosition {
   y: number;
 }
 
-function layoutCircle(nodes: GraphNode[], cx = 300, cy = 220, r = 170): NodePosition[] {
+/**
+ * Category-radial layout: groups nodes by category into radial sectors.
+ * Each category occupies a sector proportional to its node count. Within
+ * each sector, nodes are offset with sine-based jitter (seeded by index)
+ * for a visually organic, deterministic layout matching the web2 prototype.
+ */
+export function layoutCategoryRadial(
+  nodes: GraphNode[],
+  cx = SVG_CX,
+  cy = SVG_CY,
+  r = SVG_R,
+): NodePosition[] {
   if (nodes.length === 0) return [];
   if (nodes.length === 1) return [{ node: nodes[0]!, x: cx, y: cy }];
 
-  return nodes.map((node, i) => {
-    const angle = (i / nodes.length) * 2 * Math.PI - Math.PI / 2;
-    return {
-      node,
-      x: cx + r * Math.cos(angle),
-      y: cy + r * Math.sin(angle),
-    };
-  });
+  const categories = [...new Set(nodes.map((n) => n.category))];
+  const byCategory = new Map<string, GraphNode[]>();
+  for (const node of nodes) {
+    const list = byCategory.get(node.category) ?? [];
+    list.push(node);
+    byCategory.set(node.category, list);
+  }
+
+  const result: NodePosition[] = [];
+  let sectorStart = -Math.PI / 2; // start from top of circle
+
+  for (const cat of categories) {
+    const catNodes = byCategory.get(cat) ?? [];
+    const sectorSize = (catNodes.length / nodes.length) * 2 * Math.PI;
+    const sectorCenter = sectorStart + sectorSize / 2;
+
+    for (let i = 0; i < catNodes.length; i++) {
+      const node = catNodes[i]!;
+      const innerAngle = (i / Math.max(1, catNodes.length)) * 0.8 - 0.4;
+      const jitter = 0.5 + 0.5 * (Math.abs(Math.sin(i * 2.1)) * 0.9 + 0.1);
+      const radius = r * jitter;
+      result.push({
+        node,
+        x: cx + radius * Math.cos(sectorCenter + innerAngle),
+        y: cy + radius * Math.sin(sectorCenter + innerAngle),
+      });
+    }
+
+    sectorStart += sectorSize;
+  }
+
+  return result;
 }
+
+// ---------------------------------------------------------------------------
+// Graph SVG
+// ---------------------------------------------------------------------------
 
 interface GraphSvgProps {
   graph: MimirGraph;
@@ -59,16 +101,33 @@ interface GraphSvgProps {
 }
 
 function GraphSvg({ graph, focusId, onNodeClick, categories }: GraphSvgProps) {
-  const positions = layoutCircle(graph.nodes);
+  const positions = layoutCategoryRadial(graph.nodes);
   const posMap = new Map(positions.map((p) => [p.node.id, p]));
 
   return (
-    <svg className="graph-page__svg" viewBox="0 0 600 440" role="img" aria-label="Knowledge graph">
-      <g className="graph-page__edges">
+    <svg
+      className="niuu-w-full niuu-max-w-[600px] niuu-h-auto niuu-border niuu-border-border-subtle niuu-rounded-lg niuu-bg-bg-secondary niuu-block"
+      viewBox="0 0 600 440"
+      role="img"
+      aria-label="Knowledge graph"
+    >
+      <defs>
+        <filter id="niuu-node-glow" x="-50%" y="-50%" width="200%" height="200%">
+          <feGaussianBlur stdDeviation="3" result="blur" />
+          <feMerge>
+            <feMergeNode in="blur" />
+            <feMergeNode in="SourceGraphic" />
+          </feMerge>
+        </filter>
+      </defs>
+
+      <g>
         {graph.edges.map((edge) => {
           const src = posMap.get(edge.source);
           const tgt = posMap.get(edge.target);
           if (!src || !tgt) return null;
+          const isFocusEdge =
+            focusId !== null && (edge.source === focusId || edge.target === focusId);
           return (
             <line
               key={`${edge.source}-${edge.target}`}
@@ -76,12 +135,15 @@ function GraphSvg({ graph, focusId, onNodeClick, categories }: GraphSvgProps) {
               y1={src.y}
               x2={tgt.x}
               y2={tgt.y}
-              className="graph-page__edge"
+              stroke="var(--color-border)"
+              strokeWidth={1.5}
+              className={isFocusEdge ? 'niuu-opacity-50' : 'niuu-opacity-15'}
             />
           );
         })}
       </g>
-      <g className="graph-page__nodes">
+
+      <g>
         {positions.map(({ node, x, y }) => {
           const isFocus = node.id === focusId;
           const fill = isFocus
@@ -92,7 +154,11 @@ function GraphSvg({ graph, focusId, onNodeClick, categories }: GraphSvgProps) {
               key={node.id}
               transform={`translate(${x},${y})`}
               onClick={() => onNodeClick(node.id)}
-              className={['graph-page__node', isFocus ? 'graph-page__node--focus' : '']
+              className={[
+                'niuu-graph-node',
+                'niuu-cursor-pointer',
+                isFocus ? 'niuu-graph-node--focus' : '',
+              ]
                 .filter(Boolean)
                 .join(' ')}
               role="button"
@@ -104,11 +170,17 @@ function GraphSvg({ graph, focusId, onNodeClick, categories }: GraphSvgProps) {
             >
               <circle
                 r={isFocus ? 14 : 10}
-                className="graph-page__node-circle"
+                className="niuu-graph-node-circle"
                 fill={fill}
                 stroke={isFocus ? fill : 'var(--color-border)'}
+                strokeWidth={1.5}
               />
-              <text dy={isFocus ? 26 : 22} className="graph-page__node-label">
+              <text
+                dy={isFocus ? 26 : 22}
+                textAnchor="middle"
+                fill="var(--color-text-secondary)"
+                className="niuu-text-xs niuu-font-sans niuu-pointer-events-none"
+              >
                 {node.title.length > 20 ? `${node.title.slice(0, 18)}…` : node.title}
               </text>
             </g>
@@ -130,16 +202,23 @@ interface LegendProps {
 function GraphLegend({ categories }: LegendProps) {
   if (categories.length === 0) return null;
   return (
-    <div className="graph-page__legend" aria-label="Graph legend">
-      <span className="graph-page__legend-title">Categories</span>
+    <div
+      className="niuu-flex niuu-flex-col niuu-gap-2 niuu-px-4 niuu-py-3 niuu-bg-bg-secondary niuu-border niuu-border-border-subtle niuu-rounded-lg niuu-min-w-[140px]"
+      aria-label="Graph legend"
+    >
+      <span className="niuu-text-[10px] niuu-uppercase niuu-tracking-widest niuu-text-text-muted niuu-pb-1 niuu-border-b niuu-border-border-subtle">
+        Categories
+      </span>
       {categories.map((cat, i) => (
-        <div key={cat} className="graph-page__legend-item">
+        <div key={cat} className="niuu-flex niuu-items-center niuu-gap-2">
           <span
-            className="graph-page__legend-dot"
+            className="niuu-graph-legend-dot niuu-w-2.5 niuu-h-2.5 niuu-rounded-full niuu-shrink-0"
             data-color-idx={String(i % CATEGORY_COLORS.length)}
             aria-hidden
           />
-          <span className="graph-page__legend-label">{cat}</span>
+          <span className="niuu-text-xs niuu-text-text-secondary niuu-whitespace-nowrap niuu-overflow-hidden niuu-text-ellipsis">
+            {cat}
+          </span>
         </div>
       ))}
     </div>
@@ -160,17 +239,22 @@ export function GraphPage() {
     : [];
 
   return (
-    <div className="graph-page">
-      <h2 className="graph-page__title">Knowledge Graph</h2>
+    <div className="niuu-p-6 niuu-max-w-4xl">
+      <h2 className="niuu-m-0 niuu-mb-5 niuu-text-2xl niuu-font-semibold niuu-text-text-primary">
+        Knowledge Graph
+      </h2>
 
-      <div className="graph-page__toolbar">
-        <div className="graph-page__focus-controls">
-          <label htmlFor="graph-focus-input" className="graph-page__label">
+      <div className="niuu-flex niuu-flex-wrap niuu-gap-4 niuu-mb-4 niuu-items-end">
+        <div className="niuu-flex niuu-flex-col niuu-flex-1 niuu-min-w-[220px]">
+          <label
+            htmlFor="graph-focus-input"
+            className="niuu-block niuu-text-text-muted niuu-text-xs niuu-mb-1"
+          >
             Focus node
           </label>
           <input
             id="graph-focus-input"
-            className="graph-page__focus-input"
+            className="niuu-px-3 niuu-py-2 niuu-bg-bg-secondary niuu-border niuu-border-border niuu-rounded-md niuu-text-text-primary niuu-font-mono niuu-text-xs niuu-outline-none focus:niuu-border-brand"
             type="text"
             placeholder="Page path or ID…"
             value={focusId ?? ''}
@@ -179,7 +263,7 @@ export function GraphPage() {
           />
           {focusId && (
             <button
-              className="graph-page__clear-btn"
+              className="niuu-mt-1 niuu-self-start niuu-bg-transparent niuu-border-0 niuu-text-text-muted niuu-text-xs niuu-cursor-pointer niuu-p-0 hover:niuu-text-text-secondary"
               onClick={() => setFocusId(null)}
               aria-label="Clear focus"
             >
@@ -188,15 +272,18 @@ export function GraphPage() {
           )}
         </div>
 
-        <div className="graph-page__hop-controls">
-          <label className="graph-page__label">Hops</label>
-          <div className="graph-page__hop-btns" role="group" aria-label="Hop count">
+        <div className="niuu-flex niuu-flex-col">
+          <label className="niuu-block niuu-text-text-muted niuu-text-xs niuu-mb-1">Hops</label>
+          <div className="niuu-flex niuu-gap-1" role="group" aria-label="Hop count">
             {Array.from({ length: MAX_HOPS - MIN_HOPS + 1 }, (_, i) => i + MIN_HOPS).map((h) => (
               <button
                 key={h}
-                className={['graph-page__hop-btn', h === hops ? 'graph-page__hop-btn--active' : '']
-                  .filter(Boolean)
-                  .join(' ')}
+                className={[
+                  'niuu-w-8 niuu-h-7 niuu-border niuu-rounded-sm niuu-text-xs niuu-cursor-pointer',
+                  h === hops
+                    ? 'niuu-bg-brand niuu-border-brand niuu-text-bg-primary niuu-font-semibold'
+                    : 'niuu-bg-bg-secondary niuu-border-border-subtle niuu-text-text-secondary',
+                ].join(' ')}
                 onClick={() => setHops(h)}
                 aria-pressed={h === hops}
                 data-hops={h}
@@ -209,14 +296,14 @@ export function GraphPage() {
       </div>
 
       {isLoading && (
-        <div className="graph-page__status">
+        <div className="niuu-flex niuu-items-center niuu-gap-2">
           <StateDot state="processing" pulse />
           <span>loading graph…</span>
         </div>
       )}
 
       {isError && (
-        <div className="graph-page__status">
+        <div className="niuu-flex niuu-items-center niuu-gap-2">
           <StateDot state="failed" />
           <span>{error instanceof Error ? error.message : 'graph load failed'}</span>
         </div>
@@ -224,7 +311,7 @@ export function GraphPage() {
 
       {displayGraph && (
         <>
-          <div className="graph-page__stats">
+          <div className="niuu-flex niuu-gap-2 niuu-mb-4 niuu-flex-wrap">
             <Chip tone="muted">{displayGraph.nodes.length} nodes</Chip>
             <Chip tone="muted">{displayGraph.edges.length} edges</Chip>
             {focusId && (
@@ -234,7 +321,7 @@ export function GraphPage() {
             )}
           </div>
 
-          <div className="graph-page__canvas-wrap">
+          <div className="niuu-flex niuu-gap-4 niuu-items-start niuu-flex-wrap">
             <GraphSvg
               graph={displayGraph}
               focusId={focusId}

--- a/web-next/packages/plugin-mimir/src/ui/GraphPage.tsx
+++ b/web-next/packages/plugin-mimir/src/ui/GraphPage.tsx
@@ -73,7 +73,8 @@ export function layoutCategoryRadial(
 
     for (let i = 0; i < catNodes.length; i++) {
       const node = catNodes[i]!;
-      const innerAngle = (i / Math.max(1, catNodes.length)) * 0.8 - 0.4;
+      const spread = catNodes.length <= 1 ? 0 : 0.8;
+      const innerAngle = catNodes.length <= 1 ? 0 : (i / catNodes.length) * spread - spread / 2;
       const jitter = 0.5 + 0.5 * (Math.abs(Math.sin(i * 2.1)) * 0.9 + 0.1);
       const radius = r * jitter;
       result.push({
@@ -154,13 +155,7 @@ function GraphSvg({ graph, focusId, onNodeClick, categories }: GraphSvgProps) {
               key={node.id}
               transform={`translate(${x},${y})`}
               onClick={() => onNodeClick(node.id)}
-              className={[
-                'niuu-graph-node',
-                'niuu-cursor-pointer',
-                isFocus ? 'niuu-graph-node--focus' : '',
-              ]
-                .filter(Boolean)
-                .join(' ')}
+              className="niuu-graph-node niuu-cursor-pointer"
               role="button"
               aria-pressed={isFocus}
               tabIndex={0}


### PR DESCRIPTION
## Summary

- **Category-radial layout**: replaced uniform `layoutCircle()` with `layoutCategoryRadial()` that groups nodes by category into proportional radial sectors, with deterministic sine-jitter for organic clustering (matching the web2 prototype)
- **Hover glow effect**: added SVG `<filter id="niuu-node-glow">` (feGaussianBlur + feMerge) in `<defs>`; CSS `.niuu-graph-node:hover .niuu-graph-node-circle { filter: url(#niuu-node-glow) }` applies a soft halo on hover
- **Edge opacity differentiation**: unfocused edges at `niuu-opacity-15` (~0.15), edges connected to the focused node at `niuu-opacity-50` (~0.50)
- **Tailwind migration**: all HTML layout/typography converted to `niuu-` prefixed Tailwind utilities; `GraphPage.css` reduced to SVG-only overrides (legend dot colors via data-attribute, SVG hover filter)

## What was kept

- Focus node input + clear button
- Hop count selector (1–4 buttons)
- Stats row (node count, edge count, focus chip)
- Category legend with color dots
- Node click-to-focus / toggle behavior
- Keyboard accessibility (Enter/Space)
- Loading and error states
- SVG viewBox 600×440

## Tests

- 21 tests passing (15 component tests + 6 unit tests for `layoutCategoryRadial`)
- New tests cover: glow filter presence in SVG defs, unfocused/focused edge opacity classes, node click-to-focus, layout determinism, category clustering

## Notes

- Linear ticket NIU-719: could not update via MCP (tools unavailable in this session) — please update manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)