### PR TITLE
feat(volundr): session chat visual parity with web2 — NIU-730

### DIFF
--- a/web-next/packages/plugin-volundr/src/adapters/mock.ts
+++ b/web-next/packages/plugin-volundr/src/adapters/mock.ts
@@ -164,7 +164,10 @@ const SEED_DOMAIN_SESSIONS: Session[] = [
       memLimitMi: 1_024,
       memUsedMi: 320,
       gpuCount: 0,
+      diskUsedMi: 2_048,
+      diskLimitMi: 10_240,
     },
+    files: { added: 3, modified: 7, deleted: 1 },
     env: {},
     events: [
       {

--- a/web-next/packages/plugin-volundr/src/domain/session.ts
+++ b/web-next/packages/plugin-volundr/src/domain/session.ts
@@ -26,6 +26,14 @@ export interface SessionResources {
   memLimitMi: number;
   memUsedMi: number;
   gpuCount: number;
+  diskUsedMi?: number;
+  diskLimitMi?: number;
+}
+
+export interface SessionFileStats {
+  added: number;
+  modified: number;
+  deleted: number;
 }
 
 export interface SessionEvent {
@@ -64,6 +72,8 @@ export interface Session {
   costCents?: number;
   /** One-line preview of the last message or action (≤80 chars). */
   preview?: string;
+  /** File change summary for this session's workspace. */
+  files?: SessionFileStats;
 }
 
 /** Legal transitions in the session lifecycle state machine. */

--- a/web-next/packages/plugin-volundr/src/testing/mockChatData.ts
+++ b/web-next/packages/plugin-volundr/src/testing/mockChatData.ts
@@ -84,6 +84,8 @@ export function buildMockRoom(session: Session): MockRoom {
       emits: ['code.changed', 'outcome.review'],
       tools: ['read_file', 'write_file', 'run_command', 'search_files'],
       gateway: 'bifrost://anthropic/claude-sonnet',
+      gatewayLatencyMs: 84,
+      gatewayRegion: 'us-east-1',
       expanded: true,
     },
     {
@@ -98,6 +100,8 @@ export function buildMockRoom(session: Session): MockRoom {
       emits: ['outcome.review'],
       tools: ['read_file', 'search_files'],
       gateway: 'bifrost://anthropic/claude-haiku',
+      gatewayLatencyMs: 312,
+      gatewayRegion: 'eu-west-1',
     },
   ];
 

--- a/web-next/packages/plugin-volundr/src/ui/SessionDetailPage.test.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/SessionDetailPage.test.tsx
@@ -160,6 +160,24 @@ describe('SessionDetailPage', () => {
       const meters = within(resourcesRow).getAllByTestId('meter');
       expect(meters.length).toBeGreaterThanOrEqual(2);
     });
+
+    it('renders disk meter in the resources row when disk data present', async () => {
+      wrap(<SessionDetailPage sessionId="ds-1" />);
+      await waitFor(() => expect(screen.getByTestId('resources-toggle')).toBeInTheDocument());
+      fireEvent.click(screen.getByTestId('resources-toggle'));
+      const resourcesRow = screen.getByTestId('resources-row');
+      // ds-1 has diskUsedMi and diskLimitMi set
+      const meters = within(resourcesRow).getAllByTestId('meter');
+      expect(meters.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('renders file change summary when session has file stats', async () => {
+      wrap(<SessionDetailPage sessionId="ds-1" />);
+      await waitFor(() => expect(screen.getByTestId('file-change-summary')).toBeInTheDocument());
+      expect(screen.getByTestId('files-added')).toBeInTheDocument();
+      expect(screen.getByTestId('files-modified')).toBeInTheDocument();
+      expect(screen.getByTestId('files-deleted')).toBeInTheDocument();
+    });
   });
 
   // ─── Tab bar ────────────────────────────────────────────
@@ -341,10 +359,32 @@ describe('SessionDetailPage', () => {
 
   // ─── Diffs tab ──────────────────────────────────────────
   describe('diffs tab', () => {
-    it('shows diffs placeholder', () => {
+    it('renders two-pane diffs layout', () => {
       wrap(<SessionDetailPage sessionId="ds-1" />);
       fireEvent.click(screen.getByTestId('tab-diffs'));
-      expect(screen.getByTestId('placeholder-diffs')).toBeInTheDocument();
+      expect(screen.getByTestId('diffs-tab')).toBeInTheDocument();
+      expect(screen.getByTestId('diff-file-list')).toBeInTheDocument();
+      expect(screen.getByTestId('diff-viewer')).toBeInTheDocument();
+    });
+
+    it('renders diff file list entries', () => {
+      wrap(<SessionDetailPage sessionId="ds-1" />);
+      fireEvent.click(screen.getByTestId('tab-diffs'));
+      const modFiles = screen.getAllByTestId('diff-file-mod');
+      const newFiles = screen.getAllByTestId('diff-file-new');
+      const delFiles = screen.getAllByTestId('diff-file-del');
+      expect(modFiles.length + newFiles.length + delFiles.length).toBeGreaterThan(0);
+    });
+
+    it('switches diff viewer on file click', () => {
+      wrap(<SessionDetailPage sessionId="ds-1" />);
+      fireEvent.click(screen.getByTestId('tab-diffs'));
+      const fileList = screen.getByTestId('diff-file-list');
+      const fileButtons = fileList.querySelectorAll('button');
+      if (fileButtons.length > 1) {
+        fireEvent.click(fileButtons[1]!);
+        expect(screen.getByTestId('diff-viewer')).toBeInTheDocument();
+      }
     });
   });
 
@@ -360,19 +400,52 @@ describe('SessionDetailPage', () => {
 
   // ─── Chronicle tab ─────────────────────────────────────
   describe('chronicle tab', () => {
-    it('shows chronicle placeholder', () => {
+    it('renders chronicle timeline', () => {
       wrap(<SessionDetailPage sessionId="ds-1" />);
       fireEvent.click(screen.getByTestId('tab-chronicle'));
-      expect(screen.getByTestId('placeholder-chronicle')).toBeInTheDocument();
+      expect(screen.getByTestId('chronicle-tab')).toBeInTheDocument();
+      expect(screen.getByTestId('chronicle-timeline')).toBeInTheDocument();
+    });
+
+    it('renders chronicle summary stats', () => {
+      wrap(<SessionDetailPage sessionId="ds-1" />);
+      fireEvent.click(screen.getByTestId('tab-chronicle'));
+      expect(screen.getByTestId('chronicle-summary')).toBeInTheDocument();
+    });
+
+    it('renders chronicle event rows', () => {
+      wrap(<SessionDetailPage sessionId="ds-1" />);
+      fireEvent.click(screen.getByTestId('tab-chronicle'));
+      const gitEvents = screen.getAllByTestId('chronicle-event-git');
+      expect(gitEvents.length).toBeGreaterThan(0);
     });
   });
 
   // ─── Logs tab ──────────────────────────────────────────
   describe('logs tab', () => {
-    it('shows logs placeholder', () => {
+    it('renders logs terminal container', () => {
       wrap(<SessionDetailPage sessionId="ds-1" />);
       fireEvent.click(screen.getByTestId('tab-logs'));
-      expect(screen.getByTestId('placeholder-logs')).toBeInTheDocument();
+      expect(screen.getByTestId('logs-tab')).toBeInTheDocument();
+      expect(screen.getByTestId('logs-body')).toBeInTheDocument();
+    });
+
+    it('renders log filter buttons', () => {
+      wrap(<SessionDetailPage sessionId="ds-1" />);
+      fireEvent.click(screen.getByTestId('tab-logs'));
+      expect(screen.getByTestId('log-filter-all')).toBeInTheDocument();
+      expect(screen.getByTestId('log-filter-error')).toBeInTheDocument();
+      expect(screen.getByTestId('log-filter-warn')).toBeInTheDocument();
+    });
+
+    it('filters log lines by level', () => {
+      wrap(<SessionDetailPage sessionId="ds-1" />);
+      fireEvent.click(screen.getByTestId('tab-logs'));
+
+      fireEvent.click(screen.getByTestId('log-filter-warn'));
+      const warnLines = screen.getAllByTestId('log-line-warn');
+      expect(warnLines.length).toBeGreaterThan(0);
+      expect(screen.queryByTestId('log-line-debug')).not.toBeInTheDocument();
     });
   });
 

--- a/web-next/packages/plugin-volundr/src/ui/SessionDetailPage.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/SessionDetailPage.tsx
@@ -197,9 +197,7 @@ function SessionHeader({ session, readOnly }: { session: Session; readOnly: bool
       </div>
 
       {/* File change summary row */}
-      {session.files && (
-        <FileChangeSummary files={session.files} />
-      )}
+      {session.files && <FileChangeSummary files={session.files} />}
 
       {/* Resources row (collapsible) */}
       {showRes && (
@@ -654,7 +652,11 @@ function buildMockHunks(file: MockDiffFile): DiffHunk[] {
       lines: [
         { type: 'ctx', content: 'export class AuthHandler {', oldLine: 10, newLine: 10 },
         { type: 'remove', content: '  validate(token: string): boolean {', oldLine: 11 },
-        { type: 'add', content: '  async validate(token: string): Promise<boolean> {', newLine: 11 },
+        {
+          type: 'add',
+          content: '  async validate(token: string): Promise<boolean> {',
+          newLine: 11,
+        },
         { type: 'add', content: '    const claims = await validateJwt(token);', newLine: 12 },
         { type: 'ctx', content: '    return !!claims;', oldLine: 12, newLine: 13 },
         { type: 'ctx', content: '  }', oldLine: 13, newLine: 14 },
@@ -673,7 +675,10 @@ function DiffFileList({
   onSelect: (path: string) => void;
 }) {
   return (
-    <div className="niuu-flex niuu-h-full niuu-flex-col niuu-overflow-auto" data-testid="diff-file-list">
+    <div
+      className="niuu-flex niuu-h-full niuu-flex-col niuu-overflow-auto"
+      data-testid="diff-file-list"
+    >
       {files.map((f) => (
         <button
           key={f.path}
@@ -715,7 +720,10 @@ function DiffFileList({
 function DiffViewer({ file }: { file: MockDiffFile }) {
   const hunks = buildMockHunks(file);
   return (
-    <div className="niuu-flex niuu-h-full niuu-flex-col niuu-overflow-auto" data-testid="diff-viewer">
+    <div
+      className="niuu-flex niuu-h-full niuu-flex-col niuu-overflow-auto"
+      data-testid="diff-viewer"
+    >
       <div className="niuu-flex niuu-flex-shrink-0 niuu-items-center niuu-gap-2 niuu-border-b niuu-border-border-subtle niuu-bg-bg-secondary niuu-px-4 niuu-py-2">
         <span
           className={cn(
@@ -744,8 +752,10 @@ function DiffViewer({ file }: { file: MockDiffFile }) {
                 key={j}
                 className={cn(
                   'niuu-flex niuu-gap-2 niuu-px-4 niuu-py-px',
-                  line.type === 'add' && 'niuu-bg-[color-mix(in_srgb,var(--color-accent-emerald)_8%,transparent)]',
-                  line.type === 'remove' && 'niuu-bg-[color-mix(in_srgb,var(--color-critical)_8%,transparent)]',
+                  line.type === 'add' &&
+                    'niuu-bg-[color-mix(in_srgb,var(--color-accent-emerald)_8%,transparent)]',
+                  line.type === 'remove' &&
+                    'niuu-bg-[color-mix(in_srgb,var(--color-critical)_8%,transparent)]',
                 )}
               >
                 <span className="niuu-w-8 niuu-flex-shrink-0 niuu-select-none niuu-text-right niuu-text-text-faint">
@@ -838,16 +848,47 @@ const CHRONICLE_TYPE_LABELS: Record<ChronicleEventType, string> = {
 function buildMockChronicle(): ChronicleEvent[] {
   const now = Date.now();
   return [
-    { id: 'c-1', type: 'session', label: 'session started · workspace cloned', ts: now - 3_600_000 },
+    {
+      id: 'c-1',
+      type: 'session',
+      label: 'session started · workspace cloned',
+      ts: now - 3_600_000,
+    },
     { id: 'c-2', type: 'message', label: 'user: implement the auth handler', ts: now - 3_500_000 },
     { id: 'c-3', type: 'terminal', label: 'npm install', ts: now - 3_480_000, exit: 0 },
-    { id: 'c-4', type: 'file', label: 'src/auth/handler.ts · initial implementation', ts: now - 3_400_000, ins: 42, del: 0 },
-    { id: 'c-5', type: 'file', label: 'src/auth/jwt.ts · add JWT validation', ts: now - 3_380_000, ins: 96, del: 0 },
+    {
+      id: 'c-4',
+      type: 'file',
+      label: 'src/auth/handler.ts · initial implementation',
+      ts: now - 3_400_000,
+      ins: 42,
+      del: 0,
+    },
+    {
+      id: 'c-5',
+      type: 'file',
+      label: 'src/auth/jwt.ts · add JWT validation',
+      ts: now - 3_380_000,
+      ins: 96,
+      del: 0,
+    },
     { id: 'c-6', type: 'terminal', label: 'npm test', ts: now - 3_360_000, exit: 0 },
-    { id: 'c-7', type: 'git', label: 'feat(auth): add JWT validation handler', ts: now - 3_340_000, hash: 'a1b2c3d' },
+    {
+      id: 'c-7',
+      type: 'git',
+      label: 'feat(auth): add JWT validation handler',
+      ts: now - 3_340_000,
+      hash: 'a1b2c3d',
+    },
     { id: 'c-8', type: 'message', label: 'user: run the tests', ts: now - 2_400_000 },
     { id: 'c-9', type: 'terminal', label: 'npm test -- --coverage', ts: now - 2_380_000, exit: 0 },
-    { id: 'c-10', type: 'git', label: 'test(auth): add coverage for jwt handler', ts: now - 2_340_000, hash: 'e4f5a6b' },
+    {
+      id: 'c-10',
+      type: 'git',
+      label: 'test(auth): add coverage for jwt handler',
+      ts: now - 2_340_000,
+      hash: 'e4f5a6b',
+    },
   ];
 }
 
@@ -905,14 +946,20 @@ function ChronicleEventRow({ event }: { event: ChronicleEvent }) {
           </>
         ) : event.type === 'file' ? (
           <>
-            <span className="niuu-font-mono niuu-text-text-secondary">{event.label.split(' · ')[0]}</span>
+            <span className="niuu-font-mono niuu-text-text-secondary">
+              {event.label.split(' · ')[0]}
+            </span>
             {event.label.split(' · ')[1] && (
               <span className="niuu-text-text-muted">{event.label.split(' · ')[1]}</span>
             )}
             {(event.ins !== undefined || event.del !== undefined) && (
               <span className="niuu-font-mono niuu-text-[10px]">
-                {event.ins !== undefined && <span className="niuu-text-state-ok">+{event.ins}</span>}
-                {event.del !== undefined && <span className="niuu-ml-1 niuu-text-critical">-{event.del}</span>}
+                {event.ins !== undefined && (
+                  <span className="niuu-text-state-ok">+{event.ins}</span>
+                )}
+                {event.del !== undefined && (
+                  <span className="niuu-ml-1 niuu-text-critical">-{event.del}</span>
+                )}
               </span>
             )}
           </>
@@ -992,17 +1039,53 @@ const LOG_LEVEL_CLASSES: Record<LogLevel, string> = {
 
 const MOCK_LOGS: LogLine[] = [
   { id: 'l-1', ts: '10:00:01', level: 'info', src: 'skuld', msg: 'session starting' },
-  { id: 'l-2', ts: '10:00:02', level: 'info', src: 'skuld', msg: 'workspace cloned: niuulabs/volundr' },
-  { id: 'l-3', ts: '10:00:05', level: 'debug', src: 'ravn', msg: 'model loaded: claude-sonnet-4-6' },
+  {
+    id: 'l-2',
+    ts: '10:00:02',
+    level: 'info',
+    src: 'skuld',
+    msg: 'workspace cloned: niuulabs/volundr',
+  },
+  {
+    id: 'l-3',
+    ts: '10:00:05',
+    level: 'debug',
+    src: 'ravn',
+    msg: 'model loaded: claude-sonnet-4-6',
+  },
   { id: 'l-4', ts: '10:00:06', level: 'info', src: 'ravn', msg: 'mesh room joined: room-ds-1' },
-  { id: 'l-5', ts: '10:01:14', level: 'info', src: 'ravn', msg: 'tool: read_file src/auth/handler.ts' },
+  {
+    id: 'l-5',
+    ts: '10:01:14',
+    level: 'info',
+    src: 'ravn',
+    msg: 'tool: read_file src/auth/handler.ts',
+  },
   { id: 'l-6', ts: '10:01:15', level: 'debug', src: 'ravn', msg: 'tool ok · 45ms · 2.1kb' },
-  { id: 'l-7', ts: '10:02:30', level: 'info', src: 'ravn', msg: 'tool: write_file src/auth/jwt.ts' },
+  {
+    id: 'l-7',
+    ts: '10:02:30',
+    level: 'info',
+    src: 'ravn',
+    msg: 'tool: write_file src/auth/jwt.ts',
+  },
   { id: 'l-8', ts: '10:02:31', level: 'debug', src: 'ravn', msg: 'tool ok · 12ms' },
-  { id: 'l-9', ts: '10:04:00', level: 'warn', src: 'skuld', msg: 'cpu approaching limit: 1.8/2.0c' },
+  {
+    id: 'l-9',
+    ts: '10:04:00',
+    level: 'warn',
+    src: 'skuld',
+    msg: 'cpu approaching limit: 1.8/2.0c',
+  },
   { id: 'l-10', ts: '10:05:22', level: 'info', src: 'ravn', msg: 'tool: run_command npm test' },
   { id: 'l-11', ts: '10:05:23', level: 'debug', src: 'ravn', msg: 'exit 0 · 1.2s' },
-  { id: 'l-12', ts: '10:06:00', level: 'info', src: 'skuld', msg: 'commit: feat(auth): add JWT validation handler' },
+  {
+    id: 'l-12',
+    ts: '10:06:00',
+    level: 'info',
+    src: 'skuld',
+    msg: 'commit: feat(auth): add JWT validation handler',
+  },
 ];
 
 function LogsTab() {

--- a/web-next/packages/plugin-volundr/src/ui/SessionDetailPage.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/SessionDetailPage.tsx
@@ -23,7 +23,7 @@ import { buildMockRoom, buildMockTurns, groupTurns } from '../testing/mockChatDa
 import type { ChatTurn, PeerMeta, MockRoom, TurnGroup } from '../testing/mockChatData';
 import type { IPtyStream } from '../ports/IPtyStream';
 import type { IFileSystemPort, FileTreeNode } from '../ports/IFileSystemPort';
-import type { Session } from '../domain/session';
+import type { Session, SessionFileStats } from '../domain/session';
 import type { SessionSource } from './atoms/SourceLabel';
 import type { ClusterData } from './atoms/ClusterChip';
 
@@ -73,6 +73,33 @@ function Stat({ label, value }: { label: string; value: string | number }) {
         {label}
       </span>
       <span className="niuu-font-mono niuu-text-xs niuu-text-text-primary">{value}</span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// FileChangeSummary
+// ---------------------------------------------------------------------------
+
+function FileChangeSummary({ files }: { files: SessionFileStats }) {
+  return (
+    <div
+      className="niuu-flex niuu-items-center niuu-gap-3 niuu-border-b niuu-border-border-subtle niuu-bg-bg-secondary niuu-px-4 niuu-py-1.5"
+      data-testid="file-change-summary"
+    >
+      <span className="niuu-font-mono niuu-text-[10px] niuu-text-text-muted">files</span>
+      <span className="niuu-font-mono niuu-text-xs niuu-text-state-ok" data-testid="files-added">
+        +{files.added}
+      </span>
+      <span
+        className="niuu-font-mono niuu-text-xs niuu-text-state-warn"
+        data-testid="files-modified"
+      >
+        ~{files.modified}
+      </span>
+      <span className="niuu-font-mono niuu-text-xs niuu-text-critical" data-testid="files-deleted">
+        -{files.deleted}
+      </span>
     </div>
   );
 }
@@ -169,6 +196,11 @@ function SessionHeader({ session, readOnly }: { session: Session; readOnly: bool
         </button>
       </div>
 
+      {/* File change summary row */}
+      {session.files && (
+        <FileChangeSummary files={session.files} />
+      )}
+
       {/* Resources row (collapsible) */}
       {showRes && (
         <div
@@ -183,6 +215,15 @@ function SessionHeader({ session, readOnly }: { session: Session; readOnly: bool
             label="mem"
             className="niuu-w-32"
           />
+          {r.diskUsedMi !== undefined && r.diskLimitMi !== undefined && (
+            <Meter
+              used={r.diskUsedMi}
+              limit={r.diskLimitMi}
+              unit="Mi"
+              label="disk"
+              className="niuu-w-32"
+            />
+          )}
           {r.gpuCount > 0 && (
             <span className="niuu-font-mono niuu-text-xs niuu-text-text-muted">
               gpu: {r.gpuCount}
@@ -541,16 +582,484 @@ function ChatTab({ session }: { session: Session }) {
 }
 
 // ---------------------------------------------------------------------------
-// Placeholder tabs
+// DiffsTab
 // ---------------------------------------------------------------------------
 
-function PlaceholderTab({ label }: { label: string }) {
+interface MockDiffFile {
+  path: string;
+  status: 'new' | 'mod' | 'del';
+  ins: number;
+  del: number;
+}
+
+interface DiffHunkLine {
+  type: 'add' | 'remove' | 'ctx';
+  content: string;
+  oldLine?: number;
+  newLine?: number;
+}
+
+interface DiffHunk {
+  oldStart: number;
+  oldCount: number;
+  newStart: number;
+  newCount: number;
+  lines: DiffHunkLine[];
+}
+
+const MOCK_DIFF_FILES: MockDiffFile[] = [
+  { path: 'src/auth/handler.ts', status: 'mod', ins: 42, del: 8 },
+  { path: 'src/auth/jwt.ts', status: 'new', ins: 96, del: 0 },
+  { path: 'src/auth/legacy.ts', status: 'del', ins: 0, del: 34 },
+];
+
+function buildMockHunks(file: MockDiffFile): DiffHunk[] {
+  if (file.status === 'del') {
+    return [
+      {
+        oldStart: 1,
+        oldCount: 3,
+        newStart: 0,
+        newCount: 0,
+        lines: [
+          { type: 'remove', content: 'export class LegacyAuth {', oldLine: 1 },
+          { type: 'remove', content: '  // deprecated — use AuthHandler', oldLine: 2 },
+          { type: 'remove', content: '}', oldLine: 3 },
+        ],
+      },
+    ];
+  }
+  if (file.status === 'new') {
+    return [
+      {
+        oldStart: 0,
+        oldCount: 0,
+        newStart: 1,
+        newCount: 4,
+        lines: [
+          { type: 'add', content: 'import { verify } from "jsonwebtoken";', newLine: 1 },
+          { type: 'add', content: '', newLine: 2 },
+          { type: 'add', content: 'export function validateJwt(token: string) {', newLine: 3 },
+          { type: 'add', content: '  return verify(token, process.env.JWT_SECRET!);', newLine: 4 },
+        ],
+      },
+    ];
+  }
+  return [
+    {
+      oldStart: 10,
+      oldCount: 4,
+      newStart: 10,
+      newCount: 6,
+      lines: [
+        { type: 'ctx', content: 'export class AuthHandler {', oldLine: 10, newLine: 10 },
+        { type: 'remove', content: '  validate(token: string): boolean {', oldLine: 11 },
+        { type: 'add', content: '  async validate(token: string): Promise<boolean> {', newLine: 11 },
+        { type: 'add', content: '    const claims = await validateJwt(token);', newLine: 12 },
+        { type: 'ctx', content: '    return !!claims;', oldLine: 12, newLine: 13 },
+        { type: 'ctx', content: '  }', oldLine: 13, newLine: 14 },
+      ],
+    },
+  ];
+}
+
+function DiffFileList({
+  files,
+  selectedPath,
+  onSelect,
+}: {
+  files: MockDiffFile[];
+  selectedPath: string | null;
+  onSelect: (path: string) => void;
+}) {
+  return (
+    <div className="niuu-flex niuu-h-full niuu-flex-col niuu-overflow-auto" data-testid="diff-file-list">
+      {files.map((f) => (
+        <button
+          key={f.path}
+          onClick={() => onSelect(f.path)}
+          className={cn(
+            'niuu-flex niuu-items-center niuu-gap-2 niuu-px-3 niuu-py-1.5 niuu-text-left niuu-text-xs hover:niuu-bg-bg-elevated',
+            selectedPath === f.path && 'niuu-bg-bg-elevated',
+          )}
+          data-testid={`diff-file-${f.status}`}
+        >
+          <span
+            className={cn(
+              'niuu-w-4 niuu-flex-shrink-0 niuu-font-mono niuu-font-medium',
+              f.status === 'new' && 'niuu-text-state-ok',
+              f.status === 'mod' && 'niuu-text-state-warn',
+              f.status === 'del' && 'niuu-text-critical',
+            )}
+          >
+            {f.status === 'new' ? 'A' : f.status === 'mod' ? 'M' : 'D'}
+          </span>
+          <span className="niuu-min-w-0 niuu-flex-1 niuu-truncate niuu-font-mono niuu-text-text-secondary">
+            {f.path}
+          </span>
+          <span className="niuu-flex-shrink-0 niuu-font-mono niuu-text-[10px]">
+            {f.ins > 0 && <span className="niuu-text-state-ok">+{f.ins}</span>}
+            {f.del > 0 && <span className="niuu-ml-1 niuu-text-critical">-{f.del}</span>}
+          </span>
+        </button>
+      ))}
+      {files.length === 0 && (
+        <div className="niuu-p-3 niuu-font-mono niuu-text-xs niuu-text-text-muted">
+          no uncommitted changes
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DiffViewer({ file }: { file: MockDiffFile }) {
+  const hunks = buildMockHunks(file);
+  return (
+    <div className="niuu-flex niuu-h-full niuu-flex-col niuu-overflow-auto" data-testid="diff-viewer">
+      <div className="niuu-flex niuu-flex-shrink-0 niuu-items-center niuu-gap-2 niuu-border-b niuu-border-border-subtle niuu-bg-bg-secondary niuu-px-4 niuu-py-2">
+        <span
+          className={cn(
+            'niuu-font-mono niuu-font-medium niuu-text-xs',
+            file.status === 'new' && 'niuu-text-state-ok',
+            file.status === 'mod' && 'niuu-text-state-warn',
+            file.status === 'del' && 'niuu-text-critical',
+          )}
+        >
+          {file.status === 'new' ? 'A' : file.status === 'mod' ? 'M' : 'D'}
+        </span>
+        <span className="niuu-font-mono niuu-text-sm niuu-text-text-primary">{file.path}</span>
+        <span className="niuu-font-mono niuu-text-xs niuu-text-text-muted">
+          {file.ins > 0 && <span className="niuu-text-state-ok">+{file.ins}</span>}
+          {file.del > 0 && <span className="niuu-ml-1 niuu-text-critical">-{file.del}</span>}
+        </span>
+      </div>
+      <div className="niuu-flex-1 niuu-overflow-auto niuu-bg-bg-primary">
+        {hunks.map((hunk, i) => (
+          <div key={i} className="niuu-font-mono niuu-text-xs">
+            <div className="niuu-bg-bg-tertiary niuu-px-4 niuu-py-0.5 niuu-text-text-muted">
+              @@ -{hunk.oldStart},{hunk.oldCount} +{hunk.newStart},{hunk.newCount} @@
+            </div>
+            {hunk.lines.map((line, j) => (
+              <div
+                key={j}
+                className={cn(
+                  'niuu-flex niuu-gap-2 niuu-px-4 niuu-py-px',
+                  line.type === 'add' && 'niuu-bg-[color-mix(in_srgb,var(--color-accent-emerald)_8%,transparent)]',
+                  line.type === 'remove' && 'niuu-bg-[color-mix(in_srgb,var(--color-critical)_8%,transparent)]',
+                )}
+              >
+                <span className="niuu-w-8 niuu-flex-shrink-0 niuu-select-none niuu-text-right niuu-text-text-faint">
+                  {line.oldLine ?? ''}
+                </span>
+                <span className="niuu-w-8 niuu-flex-shrink-0 niuu-select-none niuu-text-right niuu-text-text-faint">
+                  {line.newLine ?? ''}
+                </span>
+                <span
+                  className={cn(
+                    'niuu-w-3 niuu-flex-shrink-0 niuu-select-none',
+                    line.type === 'add' && 'niuu-text-state-ok',
+                    line.type === 'remove' && 'niuu-text-critical',
+                    line.type === 'ctx' && 'niuu-text-text-faint',
+                  )}
+                >
+                  {line.type === 'add' ? '+' : line.type === 'remove' ? '-' : ' '}
+                </span>
+                <span className="niuu-text-text-primary">{line.content}</span>
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function DiffsTab() {
+  const [selectedPath, setSelectedPath] = useState<string | null>(MOCK_DIFF_FILES[0]?.path ?? null);
+  const selectedFile = MOCK_DIFF_FILES.find((f) => f.path === selectedPath) ?? null;
+
+  return (
+    <div className="niuu-grid niuu-h-full niuu-grid-cols-[220px_1fr]" data-testid="diffs-tab">
+      <div className="niuu-overflow-hidden niuu-border-r niuu-border-border-subtle niuu-bg-bg-secondary">
+        <DiffFileList
+          files={MOCK_DIFF_FILES}
+          selectedPath={selectedPath}
+          onSelect={setSelectedPath}
+        />
+      </div>
+      <div className="niuu-overflow-hidden">
+        {selectedFile ? (
+          <DiffViewer file={selectedFile} />
+        ) : (
+          <div className="niuu-flex niuu-h-full niuu-items-center niuu-justify-center niuu-font-mono niuu-text-sm niuu-text-text-muted">
+            select a file
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ChronicleTab
+// ---------------------------------------------------------------------------
+
+type ChronicleEventType = 'session' | 'git' | 'file' | 'terminal' | 'message' | 'error';
+
+interface ChronicleEvent {
+  id: string;
+  type: ChronicleEventType;
+  label: string;
+  ts: number;
+  hash?: string;
+  ins?: number;
+  del?: number;
+  exit?: number | null;
+}
+
+const CHRONICLE_TYPE_COLORS: Record<ChronicleEventType, string> = {
+  session: 'niuu-text-brand',
+  git: 'niuu-text-brand',
+  file: 'niuu-text-brand',
+  terminal: 'niuu-text-state-warn',
+  message: 'niuu-text-text-muted',
+  error: 'niuu-text-critical',
+};
+
+const CHRONICLE_TYPE_LABELS: Record<ChronicleEventType, string> = {
+  session: 'SESSION',
+  git: 'GIT',
+  file: 'FILE',
+  terminal: 'TERM',
+  message: 'MSG',
+  error: 'ERR',
+};
+
+function buildMockChronicle(): ChronicleEvent[] {
+  const now = Date.now();
+  return [
+    { id: 'c-1', type: 'session', label: 'session started · workspace cloned', ts: now - 3_600_000 },
+    { id: 'c-2', type: 'message', label: 'user: implement the auth handler', ts: now - 3_500_000 },
+    { id: 'c-3', type: 'terminal', label: 'npm install', ts: now - 3_480_000, exit: 0 },
+    { id: 'c-4', type: 'file', label: 'src/auth/handler.ts · initial implementation', ts: now - 3_400_000, ins: 42, del: 0 },
+    { id: 'c-5', type: 'file', label: 'src/auth/jwt.ts · add JWT validation', ts: now - 3_380_000, ins: 96, del: 0 },
+    { id: 'c-6', type: 'terminal', label: 'npm test', ts: now - 3_360_000, exit: 0 },
+    { id: 'c-7', type: 'git', label: 'feat(auth): add JWT validation handler', ts: now - 3_340_000, hash: 'a1b2c3d' },
+    { id: 'c-8', type: 'message', label: 'user: run the tests', ts: now - 2_400_000 },
+    { id: 'c-9', type: 'terminal', label: 'npm test -- --coverage', ts: now - 2_380_000, exit: 0 },
+    { id: 'c-10', type: 'git', label: 'test(auth): add coverage for jwt handler', ts: now - 2_340_000, hash: 'e4f5a6b' },
+  ];
+}
+
+function formatRelTime(ts: number): string {
+  const diff = Date.now() - ts;
+  const min = Math.floor(diff / 60_000);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  const rem = min % 60;
+  return rem > 0 ? `${hr}h ${rem}m ago` : `${hr}h ago`;
+}
+
+function ChronicleEventRow({ event }: { event: ChronicleEvent }) {
+  const colorClass = CHRONICLE_TYPE_COLORS[event.type];
+  const typeLabel = CHRONICLE_TYPE_LABELS[event.type];
+
+  return (
+    <li
+      className="niuu-flex niuu-items-start niuu-gap-3 niuu-py-1.5"
+      data-testid={`chronicle-event-${event.type}`}
+    >
+      <span className="niuu-mt-0.5 niuu-w-10 niuu-flex-shrink-0 niuu-font-mono niuu-text-[10px] niuu-text-text-faint">
+        {formatRelTime(event.ts)}
+      </span>
+      <span
+        className={cn(
+          'niuu-w-14 niuu-flex-shrink-0 niuu-font-mono niuu-text-[10px] niuu-font-medium',
+          colorClass,
+        )}
+      >
+        {typeLabel}
+      </span>
+      <span className="niuu-flex niuu-min-w-0 niuu-flex-1 niuu-flex-wrap niuu-items-center niuu-gap-x-2 niuu-text-xs">
+        {event.type === 'git' && event.hash ? (
+          <>
+            <span className="niuu-font-mono niuu-text-text-muted">{event.hash.slice(0, 7)}</span>
+            <span className="niuu-text-text-primary">{event.label.replace(/^.*·\s*/, '')}</span>
+          </>
+        ) : event.type === 'terminal' ? (
+          <>
+            <span className="niuu-font-mono niuu-text-text-secondary">$ {event.label}</span>
+            {event.exit !== undefined && event.exit !== null && (
+              <span
+                className={cn(
+                  'niuu-font-mono niuu-text-[10px]',
+                  event.exit === 0 ? 'niuu-text-state-ok' : 'niuu-text-critical',
+                )}
+              >
+                exit {event.exit}
+              </span>
+            )}
+            {event.exit === null && (
+              <span className="niuu-font-mono niuu-text-[10px] niuu-text-state-warn">running…</span>
+            )}
+          </>
+        ) : event.type === 'file' ? (
+          <>
+            <span className="niuu-font-mono niuu-text-text-secondary">{event.label.split(' · ')[0]}</span>
+            {event.label.split(' · ')[1] && (
+              <span className="niuu-text-text-muted">{event.label.split(' · ')[1]}</span>
+            )}
+            {(event.ins !== undefined || event.del !== undefined) && (
+              <span className="niuu-font-mono niuu-text-[10px]">
+                {event.ins !== undefined && <span className="niuu-text-state-ok">+{event.ins}</span>}
+                {event.del !== undefined && <span className="niuu-ml-1 niuu-text-critical">-{event.del}</span>}
+              </span>
+            )}
+          </>
+        ) : (
+          <span className="niuu-text-text-secondary">{event.label}</span>
+        )}
+      </span>
+    </li>
+  );
+}
+
+function ChronicleTab() {
+  const events = buildMockChronicle();
+  const commitCount = events.filter((e) => e.type === 'git' && e.hash).length;
+  const termCount = events.filter((e) => e.type === 'terminal').length;
+  const msgCount = events.filter((e) => e.type === 'message').length;
+  const fileCount = new Set(
+    events.filter((e) => e.type === 'file').map((e) => e.label.split(' · ')[0] ?? ''),
+  ).size;
+
   return (
     <div
-      className="niuu-flex niuu-h-full niuu-items-center niuu-justify-center niuu-font-mono niuu-text-sm niuu-text-text-muted"
-      data-testid={`placeholder-${label.toLowerCase()}`}
+      className="niuu-flex niuu-h-full niuu-flex-col niuu-overflow-auto niuu-p-4"
+      data-testid="chronicle-tab"
     >
-      {label} tab {'\u2014'} coming soon
+      {/* Summary stats */}
+      <div className="niuu-mb-4 niuu-flex niuu-gap-6" data-testid="chronicle-summary">
+        {[
+          { label: 'commits', value: commitCount },
+          { label: 'files touched', value: fileCount },
+          { label: 'shell runs', value: termCount },
+          { label: 'messages', value: msgCount },
+        ].map(({ label, value }) => (
+          <div key={label} className="niuu-flex niuu-flex-col niuu-items-center niuu-gap-0.5">
+            <span className="niuu-font-mono niuu-text-sm niuu-font-medium niuu-text-text-primary">
+              {value}
+            </span>
+            <span className="niuu-font-mono niuu-text-[10px] niuu-text-text-faint">{label}</span>
+          </div>
+        ))}
+      </div>
+
+      {/* Timeline */}
+      <div className="niuu-relative">
+        {/* Vertical spine */}
+        <div className="niuu-absolute niuu-bottom-0 niuu-left-[5.5rem] niuu-top-0 niuu-w-px niuu-bg-border-subtle" />
+        <ol className="niuu-flex niuu-flex-col niuu-gap-0" data-testid="chronicle-timeline">
+          {events.map((event) => (
+            <ChronicleEventRow key={event.id} event={event} />
+          ))}
+        </ol>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// LogsTab
+// ---------------------------------------------------------------------------
+
+type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+interface LogLine {
+  id: string;
+  ts: string;
+  level: LogLevel;
+  src: string;
+  msg: string;
+}
+
+const LOG_LEVEL_CLASSES: Record<LogLevel, string> = {
+  debug: 'niuu-text-text-faint',
+  info: 'niuu-text-text-secondary',
+  warn: 'niuu-text-state-warn',
+  error: 'niuu-text-critical',
+};
+
+const MOCK_LOGS: LogLine[] = [
+  { id: 'l-1', ts: '10:00:01', level: 'info', src: 'skuld', msg: 'session starting' },
+  { id: 'l-2', ts: '10:00:02', level: 'info', src: 'skuld', msg: 'workspace cloned: niuulabs/volundr' },
+  { id: 'l-3', ts: '10:00:05', level: 'debug', src: 'ravn', msg: 'model loaded: claude-sonnet-4-6' },
+  { id: 'l-4', ts: '10:00:06', level: 'info', src: 'ravn', msg: 'mesh room joined: room-ds-1' },
+  { id: 'l-5', ts: '10:01:14', level: 'info', src: 'ravn', msg: 'tool: read_file src/auth/handler.ts' },
+  { id: 'l-6', ts: '10:01:15', level: 'debug', src: 'ravn', msg: 'tool ok · 45ms · 2.1kb' },
+  { id: 'l-7', ts: '10:02:30', level: 'info', src: 'ravn', msg: 'tool: write_file src/auth/jwt.ts' },
+  { id: 'l-8', ts: '10:02:31', level: 'debug', src: 'ravn', msg: 'tool ok · 12ms' },
+  { id: 'l-9', ts: '10:04:00', level: 'warn', src: 'skuld', msg: 'cpu approaching limit: 1.8/2.0c' },
+  { id: 'l-10', ts: '10:05:22', level: 'info', src: 'ravn', msg: 'tool: run_command npm test' },
+  { id: 'l-11', ts: '10:05:23', level: 'debug', src: 'ravn', msg: 'exit 0 · 1.2s' },
+  { id: 'l-12', ts: '10:06:00', level: 'info', src: 'skuld', msg: 'commit: feat(auth): add JWT validation handler' },
+];
+
+function LogsTab() {
+  const [levelFilter, setLevelFilter] = useState<LogLevel | 'all'>('all');
+
+  const filtered =
+    levelFilter === 'all' ? MOCK_LOGS : MOCK_LOGS.filter((l) => l.level === levelFilter);
+
+  return (
+    <div className="niuu-flex niuu-h-full niuu-flex-col" data-testid="logs-tab">
+      {/* Filter bar */}
+      <div className="niuu-flex niuu-flex-shrink-0 niuu-items-center niuu-gap-1 niuu-border-b niuu-border-border-subtle niuu-bg-bg-secondary niuu-px-4 niuu-py-2">
+        {(['all', 'error', 'warn', 'info', 'debug'] as const).map((lvl) => (
+          <button
+            key={lvl}
+            onClick={() => setLevelFilter(lvl)}
+            className={cn(
+              'niuu-rounded niuu-px-2 niuu-py-0.5 niuu-font-mono niuu-text-xs',
+              levelFilter === lvl
+                ? 'niuu-bg-bg-elevated niuu-text-brand'
+                : 'niuu-text-text-muted hover:niuu-text-text-secondary',
+            )}
+            data-testid={`log-filter-${lvl}`}
+          >
+            {lvl}
+          </button>
+        ))}
+      </div>
+
+      {/* Log body */}
+      <div
+        className="niuu-flex-1 niuu-overflow-auto niuu-bg-bg-primary niuu-px-4 niuu-py-2"
+        data-testid="logs-body"
+      >
+        {filtered.map((line) => (
+          <div
+            key={line.id}
+            className="niuu-flex niuu-gap-3 niuu-py-px niuu-font-mono niuu-text-xs"
+            data-testid={`log-line-${line.level}`}
+          >
+            <span className="niuu-w-14 niuu-flex-shrink-0 niuu-text-text-faint">{line.ts}</span>
+            <span
+              className={cn(
+                'niuu-w-10 niuu-flex-shrink-0 niuu-font-medium niuu-uppercase',
+                LOG_LEVEL_CLASSES[line.level],
+              )}
+            >
+              {line.level}
+            </span>
+            <span className="niuu-w-12 niuu-flex-shrink-0 niuu-text-text-faint">{line.src}</span>
+            <span className="niuu-text-text-primary">{line.msg}</span>
+          </div>
+        ))}
+        {filtered.length === 0 && (
+          <div className="niuu-py-4 niuu-text-center niuu-text-text-muted">no log entries</div>
+        )}
+      </div>
     </div>
   );
 }
@@ -689,7 +1198,7 @@ export function SessionDetailPage({
           hidden={activeTab !== 'diffs'}
           className="niuu-h-full"
         >
-          {activeTab === 'diffs' && <PlaceholderTab label="Diffs" />}
+          {activeTab === 'diffs' && <DiffsTab />}
         </div>
 
         {/* Files */}
@@ -756,7 +1265,7 @@ export function SessionDetailPage({
           hidden={activeTab !== 'chronicle'}
           className="niuu-h-full"
         >
-          {activeTab === 'chronicle' && <PlaceholderTab label="Chronicle" />}
+          {activeTab === 'chronicle' && <ChronicleTab />}
         </div>
 
         {/* Logs */}
@@ -766,7 +1275,7 @@ export function SessionDetailPage({
           hidden={activeTab !== 'logs'}
           className="niuu-h-full"
         >
-          {activeTab === 'logs' && <PlaceholderTab label="Logs" />}
+          {activeTab === 'logs' && <LogsTab />}
         </div>
       </div>
     </div>

--- a/web-next/packages/plugin-volundr/src/ui/SessionDetailPage.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/SessionDetailPage.tsx
@@ -10,6 +10,7 @@ import {
   MeshSidebar,
   MeshEventCard,
   resolveParticipantColor,
+  relTime,
 } from '@niuulabs/ui';
 import type { MeshEvent, MeshEventType, RoomParticipant } from '@niuulabs/ui';
 import { SourceLabel } from './atoms/SourceLabel';
@@ -665,6 +666,18 @@ function buildMockHunks(file: MockDiffFile): DiffHunk[] {
   ];
 }
 
+function diffStatusLetter(status: MockDiffFile['status']): string {
+  return status === 'new' ? 'A' : status === 'mod' ? 'M' : 'D';
+}
+
+function diffStatusColor(status: MockDiffFile['status']): string {
+  return status === 'new'
+    ? 'niuu-text-state-ok'
+    : status === 'mod'
+      ? 'niuu-text-state-warn'
+      : 'niuu-text-critical';
+}
+
 function DiffFileList({
   files,
   selectedPath,
@@ -692,12 +705,10 @@ function DiffFileList({
           <span
             className={cn(
               'niuu-w-4 niuu-flex-shrink-0 niuu-font-mono niuu-font-medium',
-              f.status === 'new' && 'niuu-text-state-ok',
-              f.status === 'mod' && 'niuu-text-state-warn',
-              f.status === 'del' && 'niuu-text-critical',
+              diffStatusColor(f.status),
             )}
           >
-            {f.status === 'new' ? 'A' : f.status === 'mod' ? 'M' : 'D'}
+            {diffStatusLetter(f.status)}
           </span>
           <span className="niuu-min-w-0 niuu-flex-1 niuu-truncate niuu-font-mono niuu-text-text-secondary">
             {f.path}
@@ -728,12 +739,10 @@ function DiffViewer({ file }: { file: MockDiffFile }) {
         <span
           className={cn(
             'niuu-font-mono niuu-font-medium niuu-text-xs',
-            file.status === 'new' && 'niuu-text-state-ok',
-            file.status === 'mod' && 'niuu-text-state-warn',
-            file.status === 'del' && 'niuu-text-critical',
+            diffStatusColor(file.status),
           )}
         >
-          {file.status === 'new' ? 'A' : file.status === 'mod' ? 'M' : 'D'}
+          {diffStatusLetter(file.status)}
         </span>
         <span className="niuu-font-mono niuu-text-sm niuu-text-text-primary">{file.path}</span>
         <span className="niuu-font-mono niuu-text-xs niuu-text-text-muted">
@@ -892,15 +901,6 @@ function buildMockChronicle(): ChronicleEvent[] {
   ];
 }
 
-function formatRelTime(ts: number): string {
-  const diff = Date.now() - ts;
-  const min = Math.floor(diff / 60_000);
-  if (min < 60) return `${min}m ago`;
-  const hr = Math.floor(min / 60);
-  const rem = min % 60;
-  return rem > 0 ? `${hr}h ${rem}m ago` : `${hr}h ago`;
-}
-
 function ChronicleEventRow({ event }: { event: ChronicleEvent }) {
   const colorClass = CHRONICLE_TYPE_COLORS[event.type];
   const typeLabel = CHRONICLE_TYPE_LABELS[event.type];
@@ -911,7 +911,7 @@ function ChronicleEventRow({ event }: { event: ChronicleEvent }) {
       data-testid={`chronicle-event-${event.type}`}
     >
       <span className="niuu-mt-0.5 niuu-w-10 niuu-flex-shrink-0 niuu-font-mono niuu-text-[10px] niuu-text-text-faint">
-        {formatRelTime(event.ts)}
+        {relTime(event.ts)}
       </span>
       <span
         className={cn(
@@ -945,24 +945,25 @@ function ChronicleEventRow({ event }: { event: ChronicleEvent }) {
             )}
           </>
         ) : event.type === 'file' ? (
-          <>
-            <span className="niuu-font-mono niuu-text-text-secondary">
-              {event.label.split(' · ')[0]}
-            </span>
-            {event.label.split(' · ')[1] && (
-              <span className="niuu-text-text-muted">{event.label.split(' · ')[1]}</span>
-            )}
-            {(event.ins !== undefined || event.del !== undefined) && (
-              <span className="niuu-font-mono niuu-text-[10px]">
-                {event.ins !== undefined && (
-                  <span className="niuu-text-state-ok">+{event.ins}</span>
+          (() => {
+            const [filePath, desc] = event.label.split(' · ');
+            return (
+              <>
+                <span className="niuu-font-mono niuu-text-text-secondary">{filePath}</span>
+                {desc && <span className="niuu-text-text-muted">{desc}</span>}
+                {(event.ins !== undefined || event.del !== undefined) && (
+                  <span className="niuu-font-mono niuu-text-[10px]">
+                    {event.ins !== undefined && (
+                      <span className="niuu-text-state-ok">+{event.ins}</span>
+                    )}
+                    {event.del !== undefined && (
+                      <span className="niuu-ml-1 niuu-text-critical">-{event.del}</span>
+                    )}
+                  </span>
                 )}
-                {event.del !== undefined && (
-                  <span className="niuu-ml-1 niuu-text-critical">-{event.del}</span>
-                )}
-              </span>
-            )}
-          </>
+              </>
+            );
+          })()
         ) : (
           <span className="niuu-text-text-secondary">{event.label}</span>
         )}

--- a/web-next/packages/ui/src/chat/components/MeshSidebar/MeshSidebar.css
+++ b/web-next/packages/ui/src/chat/components/MeshSidebar/MeshSidebar.css
@@ -166,3 +166,75 @@
   color: var(--color-accent-emerald);
   background-color: color-mix(in srgb, var(--color-accent-emerald) 12%, transparent);
 }
+
+/* Gateway section */
+.niuu-chat-peer-gateway {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.niuu-chat-peer-gw-breadcrumb {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 2px;
+}
+
+.niuu-chat-peer-gw-seg {
+  font-size: 10px;
+  font-family: var(--font-mono);
+  color: var(--color-text-muted);
+  padding: 1px var(--space-1);
+  border-radius: var(--radius-sm);
+  background-color: var(--color-bg-elevated);
+}
+
+.niuu-chat-peer-gw-proto {
+  color: var(--color-text-faint);
+}
+
+.niuu-chat-peer-gw-vendor {
+  color: var(--color-brand-400, var(--color-brand));
+}
+
+.niuu-chat-peer-gw-model {
+  color: var(--color-text-secondary);
+}
+
+.niuu-chat-peer-gw-sep {
+  font-size: 10px;
+  font-family: var(--font-mono);
+  color: var(--color-text-faint);
+}
+
+.niuu-chat-peer-gw-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-top: 2px;
+}
+
+.niuu-chat-peer-gw-region {
+  font-size: 10px;
+  font-family: var(--font-mono);
+  color: var(--color-text-faint);
+}
+
+.niuu-chat-peer-gw-latency {
+  font-size: 10px;
+  font-family: var(--font-mono);
+  color: var(--color-text-faint);
+}
+
+.niuu-chat-peer-gw-latency--ok {
+  color: var(--color-accent-emerald);
+}
+
+.niuu-chat-peer-gw-latency--warn {
+  color: var(--color-accent-amber);
+}
+
+.niuu-chat-peer-gw-latency--err {
+  color: var(--color-accent-red, var(--color-critical));
+}

--- a/web-next/packages/ui/src/chat/components/MeshSidebar/MeshSidebar.test.tsx
+++ b/web-next/packages/ui/src/chat/components/MeshSidebar/MeshSidebar.test.tsx
@@ -98,4 +98,152 @@ describe('MeshSidebar', () => {
     expect(screen.getByText('bash')).toBeInTheDocument();
     expect(screen.getByText('hide details')).toBeInTheDocument();
   });
+
+  describe('gateway section', () => {
+    it('shows expand toggle when participant has a gateway', () => {
+      const withGateway: ReadonlyMap<string, RoomParticipant> = new Map([
+        [
+          'peer-1',
+          {
+            peerId: 'peer-1',
+            persona: 'Ada',
+            participantType: 'ravn',
+            gateway: 'bifrost://anthropic/claude-sonnet',
+          },
+        ],
+      ]);
+      render(
+        <MeshSidebar participants={withGateway} selectedPeerId={null} onSelectPeer={vi.fn()} />,
+      );
+      expect(screen.getByText('show details')).toBeInTheDocument();
+    });
+
+    it('renders gateway section when expanded', () => {
+      const withGateway: ReadonlyMap<string, RoomParticipant> = new Map([
+        [
+          'peer-1',
+          {
+            peerId: 'peer-1',
+            persona: 'Ada',
+            participantType: 'ravn',
+            gateway: 'bifrost://anthropic/claude-sonnet',
+            gatewayLatencyMs: 84,
+            gatewayRegion: 'us-east-1',
+          },
+        ],
+      ]);
+      render(
+        <MeshSidebar participants={withGateway} selectedPeerId={null} onSelectPeer={vi.fn()} />,
+      );
+      fireEvent.click(screen.getByText('show details'));
+      expect(screen.getByTestId('peer-gateway-section')).toBeInTheDocument();
+    });
+
+    it('renders gateway breadcrumb segments', () => {
+      const withGateway: ReadonlyMap<string, RoomParticipant> = new Map([
+        [
+          'peer-1',
+          {
+            peerId: 'peer-1',
+            persona: 'Ada',
+            participantType: 'ravn',
+            gateway: 'bifrost://anthropic/claude-sonnet',
+          },
+        ],
+      ]);
+      render(
+        <MeshSidebar participants={withGateway} selectedPeerId={null} onSelectPeer={vi.fn()} />,
+      );
+      fireEvent.click(screen.getByText('show details'));
+      expect(screen.getByText('bifrost')).toBeInTheDocument();
+      expect(screen.getByText('anthropic')).toBeInTheDocument();
+      expect(screen.getByText('claude-sonnet')).toBeInTheDocument();
+    });
+
+    it('shows latency in green for <100ms', () => {
+      const withGateway: ReadonlyMap<string, RoomParticipant> = new Map([
+        [
+          'peer-1',
+          {
+            peerId: 'peer-1',
+            persona: 'Ada',
+            participantType: 'ravn',
+            gateway: 'bifrost://anthropic/claude-sonnet',
+            gatewayLatencyMs: 84,
+          },
+        ],
+      ]);
+      render(
+        <MeshSidebar participants={withGateway} selectedPeerId={null} onSelectPeer={vi.fn()} />,
+      );
+      fireEvent.click(screen.getByText('show details'));
+      const latency = screen.getByTestId('peer-gateway-latency');
+      expect(latency).toHaveTextContent('84ms');
+      expect(latency.className).toContain('ok');
+    });
+
+    it('shows latency in amber for 100-499ms', () => {
+      const withGateway: ReadonlyMap<string, RoomParticipant> = new Map([
+        [
+          'peer-1',
+          {
+            peerId: 'peer-1',
+            persona: 'Ada',
+            participantType: 'ravn',
+            gateway: 'bifrost://anthropic/claude-sonnet',
+            gatewayLatencyMs: 312,
+          },
+        ],
+      ]);
+      render(
+        <MeshSidebar participants={withGateway} selectedPeerId={null} onSelectPeer={vi.fn()} />,
+      );
+      fireEvent.click(screen.getByText('show details'));
+      const latency = screen.getByTestId('peer-gateway-latency');
+      expect(latency).toHaveTextContent('312ms');
+      expect(latency.className).toContain('warn');
+    });
+
+    it('shows latency in red for >=500ms', () => {
+      const withGateway: ReadonlyMap<string, RoomParticipant> = new Map([
+        [
+          'peer-1',
+          {
+            peerId: 'peer-1',
+            persona: 'Ada',
+            participantType: 'ravn',
+            gateway: 'bifrost://anthropic/claude-sonnet',
+            gatewayLatencyMs: 600,
+          },
+        ],
+      ]);
+      render(
+        <MeshSidebar participants={withGateway} selectedPeerId={null} onSelectPeer={vi.fn()} />,
+      );
+      fireEvent.click(screen.getByText('show details'));
+      const latency = screen.getByTestId('peer-gateway-latency');
+      expect(latency).toHaveTextContent('600ms');
+      expect(latency.className).toContain('err');
+    });
+
+    it('shows region when provided', () => {
+      const withGateway: ReadonlyMap<string, RoomParticipant> = new Map([
+        [
+          'peer-1',
+          {
+            peerId: 'peer-1',
+            persona: 'Ada',
+            participantType: 'ravn',
+            gateway: 'bifrost://anthropic/claude-sonnet',
+            gatewayRegion: 'eu-west-1',
+          },
+        ],
+      ]);
+      render(
+        <MeshSidebar participants={withGateway} selectedPeerId={null} onSelectPeer={vi.fn()} />,
+      );
+      fireEvent.click(screen.getByText('show details'));
+      expect(screen.getByTestId('peer-gateway-region')).toHaveTextContent('eu-west-1');
+    });
+  });
 });

--- a/web-next/packages/ui/src/chat/components/MeshSidebar/MeshSidebar.tsx
+++ b/web-next/packages/ui/src/chat/components/MeshSidebar/MeshSidebar.tsx
@@ -15,13 +15,80 @@ interface PeerCardProps {
   onSelect: () => void;
 }
 
+interface GatewaySectionProps {
+  gateway: string;
+  latencyMs?: number;
+  region?: string;
+}
+
+function latencyClass(ms: number | undefined): string {
+  if (ms === undefined) return '';
+  if (ms < 100) return 'niuu-chat-peer-gw-latency--ok';
+  if (ms < 500) return 'niuu-chat-peer-gw-latency--warn';
+  return 'niuu-chat-peer-gw-latency--err';
+}
+
+function parseGatewayUri(uri: string): { proto: string; vendor: string; model?: string } | null {
+  const m = uri.match(/^([a-z0-9+.-]+):\/\/([^/]+)(?:\/(.+))?$/i);
+  if (!m) return null;
+  const [, proto, vendor, model] = m;
+  return { proto: proto!, vendor: vendor!, model };
+}
+
+function GatewaySection({ gateway, latencyMs, region }: GatewaySectionProps) {
+  const parsed = parseGatewayUri(gateway);
+
+  return (
+    <div className="niuu-chat-peer-gateway" data-testid="peer-gateway-section">
+      <span className="niuu-chat-peer-meta-label">Gateway</span>
+      <div className="niuu-chat-peer-gw-breadcrumb">
+        {parsed ? (
+          <>
+            <span className="niuu-chat-peer-gw-seg niuu-chat-peer-gw-proto">{parsed.proto}</span>
+            <span className="niuu-chat-peer-gw-sep">›</span>
+            <span className="niuu-chat-peer-gw-seg niuu-chat-peer-gw-vendor">{parsed.vendor}</span>
+            {parsed.model && (
+              <>
+                <span className="niuu-chat-peer-gw-sep">›</span>
+                <span className="niuu-chat-peer-gw-seg niuu-chat-peer-gw-model">
+                  {parsed.model}
+                </span>
+              </>
+            )}
+          </>
+        ) : (
+          <span className="niuu-chat-peer-gw-seg">{gateway}</span>
+        )}
+      </div>
+      {(region || latencyMs !== undefined) && (
+        <div className="niuu-chat-peer-gw-meta">
+          {region && (
+            <span className="niuu-chat-peer-gw-region" data-testid="peer-gateway-region">
+              {region}
+            </span>
+          )}
+          {latencyMs !== undefined && (
+            <span
+              className={cn('niuu-chat-peer-gw-latency', latencyClass(latencyMs))}
+              data-testid="peer-gateway-latency"
+            >
+              {latencyMs}ms
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 function PeerCard({ participant, isSelected, onSelect }: PeerCardProps) {
   const [expanded, setExpanded] = useState(false);
 
   const hasMetadata =
     (participant.subscribesTo && participant.subscribesTo.length > 0) ||
     (participant.emits && participant.emits.length > 0) ||
-    (participant.tools && participant.tools.length > 0);
+    (participant.tools && participant.tools.length > 0) ||
+    !!participant.gateway;
 
   return (
     <div
@@ -90,6 +157,13 @@ function PeerCard({ participant, isSelected, onSelect }: PeerCardProps) {
                 ))}
               </div>
             </>
+          )}
+          {participant.gateway && (
+            <GatewaySection
+              gateway={participant.gateway}
+              latencyMs={participant.gatewayLatencyMs}
+              region={participant.gatewayRegion}
+            />
           )}
         </div>
       )}

--- a/web-next/packages/ui/src/chat/types.ts
+++ b/web-next/packages/ui/src/chat/types.ts
@@ -36,6 +36,12 @@ export interface ParticipantMeta {
   subscribesTo?: string[];
   emits?: string[];
   tools?: string[];
+  /** Gateway URI, e.g. "bifrost://anthropic/claude-sonnet" */
+  gateway?: string;
+  /** Gateway round-trip latency in milliseconds */
+  gatewayLatencyMs?: number;
+  /** Gateway region, e.g. "us-east-1" */
+  gatewayRegion?: string;
 }
 
 export type RoomParticipant = ParticipantMeta;


### PR DESCRIPTION
## Summary

- **Gateway section in MeshSidebar peer cards**: Breadcrumb display for `bifrost://` URIs (proto › vendor › model), with optional region label and latency badge color-coded green (<100ms), amber (<500ms), red (≥500ms). Added `gateway`, `gatewayLatencyMs`, and `gatewayRegion` fields to `ParticipantMeta` in `@niuulabs/ui`.
- **File change summary in session header**: New row below header metadata showing added (green `+N`), modified (amber `~N`), deleted (red `-N`) file counts. Backed by optional `files: SessionFileStats` field on the `Session` domain model.
- **Disk meter in resources panel**: Extends `SessionResources` with optional `diskUsedMi`/`diskLimitMi` fields; renders a `Meter` component in the collapsible resources row alongside existing CPU/Memory meters.
- **DiffsTab**: Two-pane layout — left panel is a file list with status badges (A/M/D) and ins/del counts; right panel is a diff viewer with unified diff hunks and line-number gutters.
- **ChronicleTab**: Summary stats row (commits, files touched, shell runs, messages) + a vertical timeline with per-event-type color coding (session/git/file/terminal/message/error).
- **LogsTab**: Monospace terminal-style container with level filter buttons (all/error/warn/info/debug) and color-coded log rows.

## Test plan

- [x] All 3738 tests pass, 273 test files green
- [x] New gateway tests: breadcrumb parsing, latency color coding (ok/warn/err), region display
- [x] New session header tests: file change summary row, disk meter visibility
- [x] New tab tests: diffs two-pane layout, chronicle timeline/summary, logs filter buttons
- [x] ESLint clean — no errors, no warnings
- [x] Coverage ≥85% across statements, branches, functions, lines

Closes NIU-730

🤖 Generated with [Claude Code](https://claude.com/claude-code)