### PR TITLE
feat(dispatch): visual parity with web2 — modals, toast, pause, recent dispatches — NIU-711

### DIFF
--- a/web-next/packages/plugin-ravn/src/ui/SessionsView.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/SessionsView.tsx
@@ -372,24 +372,25 @@ function Transcript({
 
 function ContextSidebar({ session, messages }: { session: Session; messages: Message[] }) {
   const [timelineExpanded, setTimelineExpanded] = useState(false);
-  const msgs = useMemo(() => messages, [messages]);
-
   const ratio =
     session.costUsd != null && session.messageCount != null && session.messageCount > 0
       ? session.costUsd / session.messageCount
       : null;
 
-  const timelineEvents = useMemo(() => deriveTimelineEvents(msgs, session), [msgs, session]);
+  const timelineEvents = useMemo(
+    () => deriveTimelineEvents(messages, session),
+    [messages, session],
+  );
   const visibleEvents = timelineExpanded
     ? timelineEvents
     : timelineEvents.slice(0, TIMELINE_MAX_ITEMS);
   const hasMore = timelineEvents.length > TIMELINE_MAX_ITEMS;
 
   // Injects: system messages represent context injected into the session
-  const injects = useMemo(() => msgs.filter((m) => m.kind === 'system'), [msgs]);
+  const injects = useMemo(() => messages.filter((m) => m.kind === 'system'), [messages]);
 
   // Emissions: emit messages emitted by the session
-  const emissions = useMemo(() => msgs.filter((m) => m.kind === 'emit'), [msgs]);
+  const emissions = useMemo(() => messages.filter((m) => m.kind === 'emit'), [messages]);
 
   return (
     <aside

--- a/web-next/packages/plugin-ravn/src/ui/SessionsView.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/SessionsView.tsx
@@ -492,9 +492,8 @@ function ContextSidebar({ session, messages }: { session: Session; messages: Mes
           <ul className="rv-ctx-emissions" data-testid="emissions-list">
             {emissions.map((m) => {
               const { event: eventName, payload } = parseEmitContent(m.content);
-              const payloadPreview = payload != null
-                ? JSON.stringify(payload).slice(0, 48)
-                : m.content.slice(0, 48);
+              const payloadPreview =
+                payload != null ? JSON.stringify(payload).slice(0, 48) : m.content.slice(0, 48);
               return (
                 <li key={m.id} className="rv-ctx-emit-item">
                   <div className="rv-ctx-emit-item__head">

--- a/web-next/packages/plugin-tyr/src/ui/DispatchView.test.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/DispatchView.test.tsx
@@ -523,8 +523,6 @@ describe('DispatchView', () => {
 
     await user.click(screen.getByRole('checkbox', { name: /select row/i }));
     await user.click(screen.getByRole('button', { name: /apply workflow/i }));
-    await waitFor(() =>
-      expect(screen.getByText('Apply workflow override')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('Apply workflow override')).toBeInTheDocument());
   });
 });

--- a/web-next/packages/plugin-tyr/src/ui/DispatchView.test.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/DispatchView.test.tsx
@@ -525,4 +525,61 @@ describe('DispatchView', () => {
     await user.click(screen.getByRole('button', { name: /apply workflow/i }));
     await waitFor(() => expect(screen.getByText('Apply workflow override')).toBeInTheDocument());
   });
+
+  it('shows toast and closes modal when a workflow is applied', async () => {
+    const user = userEvent.setup();
+    render(<DispatchView />, { wrapper: wrap(makeServices()) });
+    await waitFor(() => screen.getByText('Test Raid'));
+
+    await user.click(screen.getByRole('checkbox', { name: /select row/i }));
+    await user.click(screen.getByRole('button', { name: /apply workflow/i }));
+    await waitFor(() => screen.getByText('Apply workflow override'));
+
+    // Click the first workflow in the list
+    await user.click(screen.getByRole('button', { name: /Auth Rewrite Workflow/i }));
+    await waitFor(() =>
+      expect(screen.queryByText('Apply workflow override')).not.toBeInTheDocument(),
+    );
+    await waitFor(() =>
+      expect(screen.getByText(/Applied "Auth Rewrite Workflow" to 1 raid/i)).toBeInTheDocument(),
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Error toasts
+  // ---------------------------------------------------------------------------
+
+  it('shows error toast when dispatch fails', async () => {
+    const user = userEvent.setup();
+    const services = makeServices({
+      dispatch: {
+        dispatchBatch: vi.fn().mockRejectedValue(new Error('network error')),
+      },
+    });
+
+    render(<DispatchView />, { wrapper: wrap(services) });
+    await waitFor(() => screen.getByText('Test Raid'));
+
+    await user.click(screen.getByRole('checkbox', { name: /select row/i }));
+    await user.click(screen.getByRole('button', { name: /dispatch now/i }));
+    await waitFor(() => expect(screen.getByText(/dispatch failed/i)).toBeInTheDocument());
+  });
+
+  it('shows error toast when pause fails', async () => {
+    const user = userEvent.setup();
+    const services = makeServices({
+      dispatcher: {
+        getState: vi.fn().mockResolvedValue(makeDispatcherState({ running: true })),
+        setRunning: vi.fn().mockRejectedValue(new Error('service error')),
+      },
+    });
+
+    render(<DispatchView />, { wrapper: wrap(services) });
+    await waitFor(() => screen.getByRole('button', { name: /pause dispatcher/i }));
+
+    await user.click(screen.getByRole('button', { name: /pause dispatcher/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/failed to update dispatcher/i)).toBeInTheDocument(),
+    );
+  });
 });

--- a/web-next/packages/plugin-tyr/src/ui/DispatchView.test.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/DispatchView.test.tsx
@@ -545,6 +545,23 @@ describe('DispatchView', () => {
     );
   });
 
+  it('shows workflow override chip on raid row after applying', async () => {
+    const user = userEvent.setup();
+    render(<DispatchView />, { wrapper: wrap(makeServices()) });
+    await waitFor(() => screen.getByText('Test Raid'));
+
+    await user.click(screen.getByRole('checkbox', { name: /select row/i }));
+    await user.click(screen.getByRole('button', { name: /apply workflow/i }));
+    await waitFor(() => screen.getByText('Apply workflow override'));
+    await user.click(screen.getByRole('button', { name: /Auth Rewrite Workflow/i }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('generic', { name: /workflow override: Auth Rewrite Workflow/i }),
+      ).toBeInTheDocument(),
+    );
+  });
+
   // ---------------------------------------------------------------------------
   // Error toasts
   // ---------------------------------------------------------------------------

--- a/web-next/packages/plugin-tyr/src/ui/DispatchView.test.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/DispatchView.test.tsx
@@ -7,7 +7,8 @@ import { DispatchView } from './DispatchView';
 import { createMockTyrService } from '../adapters/mock';
 import { createMockDispatcherService } from '../adapters/mock';
 import { createMockDispatchBus } from '../adapters/mock';
-import type { ITyrService, IDispatcherService, IDispatchBus } from '../ports';
+import { createMockWorkflowService } from '../adapters/mock';
+import type { ITyrService, IDispatcherService, IDispatchBus, IWorkflowService } from '../ports';
 import type { Saga, Phase, Raid } from '../domain/saga';
 import type { DispatcherState } from '../domain/dispatcher';
 
@@ -86,6 +87,7 @@ function makeServices(
     tyr?: Partial<ITyrService>;
     dispatcher?: Partial<IDispatcherService>;
     dispatch?: Partial<IDispatchBus>;
+    workflows?: Partial<IWorkflowService>;
   } = {},
 ) {
   const saga = makeSaga();
@@ -95,6 +97,7 @@ function makeServices(
   const tyrBase = createMockTyrService();
   const dispatcherBase = createMockDispatcherService();
   const dispatchBase = createMockDispatchBus();
+  const workflowsBase = createMockWorkflowService();
 
   const tyr: ITyrService = {
     ...tyrBase,
@@ -114,7 +117,17 @@ function makeServices(
     ...overrides.dispatch,
   };
 
-  return { tyr, 'tyr.dispatcher': dispatcher, 'tyr.dispatch': dispatch };
+  const workflows: IWorkflowService = {
+    ...workflowsBase,
+    ...overrides.workflows,
+  };
+
+  return {
+    tyr,
+    'tyr.dispatcher': dispatcher,
+    'tyr.dispatch': dispatch,
+    'tyr.workflows': workflows,
+  };
 }
 
 function wrap(services: Record<string, unknown>) {
@@ -319,7 +332,7 @@ describe('DispatchView', () => {
 
     const checkbox = screen.getByRole('checkbox', { name: /select row/i });
     await user.click(checkbox);
-    const dispatchBtn = screen.getByRole('button', { name: /dispatch/i });
+    const dispatchBtn = screen.getByRole('button', { name: /dispatch now/i });
     expect(dispatchBtn).toHaveAttribute('aria-disabled', 'true');
   });
 
@@ -334,7 +347,7 @@ describe('DispatchView', () => {
     await waitFor(() => screen.getByText('Test Raid'));
 
     await user.click(screen.getByRole('checkbox', { name: /select row/i }));
-    await user.click(screen.getByRole('button', { name: /dispatch/i }));
+    await user.click(screen.getByRole('button', { name: /dispatch now/i }));
     await waitFor(() =>
       expect(dispatchSpy).toHaveBeenCalledWith(['00000000-0000-0000-0000-000000000010']),
     );
@@ -365,7 +378,7 @@ describe('DispatchView', () => {
     await user.click(screen.getByRole('checkbox', { name: /select row/i }));
     expect(screen.getByText(/1 raid selected/i)).toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: /dispatch/i }));
+    await user.click(screen.getByRole('button', { name: /dispatch now/i }));
 
     // Optimistic update: selection cleared immediately, raid still visible as "queued"
     await waitFor(() => expect(screen.queryByText(/1 raid selected/i)).not.toBeInTheDocument());
@@ -376,5 +389,142 @@ describe('DispatchView', () => {
   it('shows confidence level for raids', async () => {
     render(<DispatchView />, { wrapper: wrap(makeServices()) });
     await waitFor(() => expect(screen.getByText('80%')).toBeInTheDocument());
+  });
+
+  // ---------------------------------------------------------------------------
+  // Pause / Resume dispatcher
+  // ---------------------------------------------------------------------------
+
+  it('shows Pause dispatcher button in header', async () => {
+    render(<DispatchView />, { wrapper: wrap(makeServices()) });
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /pause dispatcher/i })).toBeInTheDocument(),
+    );
+  });
+
+  it('shows Resume dispatcher button when dispatcher is stopped', async () => {
+    const services = makeServices({
+      dispatcher: { getState: async () => makeDispatcherState({ running: false }) },
+    });
+    render(<DispatchView />, { wrapper: wrap(services) });
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /resume dispatcher/i })).toBeInTheDocument(),
+    );
+  });
+
+  it('calls setRunning(false) when Pause is clicked', async () => {
+    const user = userEvent.setup();
+    const setRunningSpy = vi.fn().mockResolvedValue(undefined);
+    const getStateSpy = vi
+      .fn()
+      .mockResolvedValueOnce(makeDispatcherState({ running: true }))
+      .mockResolvedValue(makeDispatcherState({ running: false }));
+    const services = makeServices({
+      dispatcher: { getState: getStateSpy, setRunning: setRunningSpy },
+    });
+
+    render(<DispatchView />, { wrapper: wrap(services) });
+    await waitFor(() => screen.getByRole('button', { name: /pause dispatcher/i }));
+
+    await user.click(screen.getByRole('button', { name: /pause dispatcher/i }));
+    await waitFor(() => expect(setRunningSpy).toHaveBeenCalledWith(false));
+  });
+
+  it('calls setRunning(true) when Resume is clicked', async () => {
+    const user = userEvent.setup();
+    const setRunningSpy = vi.fn().mockResolvedValue(undefined);
+    const getStateSpy = vi
+      .fn()
+      .mockResolvedValueOnce(makeDispatcherState({ running: false }))
+      .mockResolvedValue(makeDispatcherState({ running: true }));
+    const services = makeServices({
+      dispatcher: { getState: getStateSpy, setRunning: setRunningSpy },
+    });
+
+    render(<DispatchView />, { wrapper: wrap(services) });
+    await waitFor(() => screen.getByRole('button', { name: /resume dispatcher/i }));
+
+    await user.click(screen.getByRole('button', { name: /resume dispatcher/i }));
+    await waitFor(() => expect(setRunningSpy).toHaveBeenCalledWith(true));
+  });
+
+  // ---------------------------------------------------------------------------
+  // Dispatch rules panel
+  // ---------------------------------------------------------------------------
+
+  it('shows Edit button in dispatch rules panel', async () => {
+    render(<DispatchView />, { wrapper: wrap(makeServices()) });
+    await waitFor(() => screen.getByText('Dispatch rules'));
+    expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
+  });
+
+  it('shows recent dispatches in the panel', async () => {
+    render(<DispatchView />, { wrapper: wrap(makeServices()) });
+    await waitFor(() => screen.getByText('Recent dispatches'));
+    expect(screen.getByText('NIU-214.2')).toBeInTheDocument();
+    expect(screen.getByText('NIU-199.1')).toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Override threshold modal
+  // ---------------------------------------------------------------------------
+
+  it('shows Override threshold button when raids are selected', async () => {
+    const user = userEvent.setup();
+    render(<DispatchView />, { wrapper: wrap(makeServices()) });
+    await waitFor(() => screen.getByText('Test Raid'));
+
+    await user.click(screen.getByRole('checkbox', { name: /select row/i }));
+    expect(screen.getByRole('button', { name: /override threshold/i })).toBeInTheDocument();
+  });
+
+  it('opens threshold modal when Override threshold is clicked', async () => {
+    const user = userEvent.setup();
+    render(<DispatchView />, { wrapper: wrap(makeServices()) });
+    await waitFor(() => screen.getByText('Test Raid'));
+
+    await user.click(screen.getByRole('checkbox', { name: /select row/i }));
+    await user.click(screen.getByRole('button', { name: /override threshold/i }));
+    await waitFor(() =>
+      expect(screen.getByText('Override dispatch threshold')).toBeInTheDocument(),
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Edit rules modal
+  // ---------------------------------------------------------------------------
+
+  it('opens edit rules modal when Edit button is clicked', async () => {
+    const user = userEvent.setup();
+    render(<DispatchView />, { wrapper: wrap(makeServices()) });
+    await waitFor(() => screen.getByRole('button', { name: /edit/i }));
+
+    await user.click(screen.getByRole('button', { name: /edit/i }));
+    await waitFor(() => expect(screen.getByText('Edit dispatch rules')).toBeInTheDocument());
+  });
+
+  // ---------------------------------------------------------------------------
+  // Apply workflow modal
+  // ---------------------------------------------------------------------------
+
+  it('shows Apply workflow button when raids are selected', async () => {
+    const user = userEvent.setup();
+    render(<DispatchView />, { wrapper: wrap(makeServices()) });
+    await waitFor(() => screen.getByText('Test Raid'));
+
+    await user.click(screen.getByRole('checkbox', { name: /select row/i }));
+    expect(screen.getByRole('button', { name: /apply workflow/i })).toBeInTheDocument();
+  });
+
+  it('opens workflow modal when Apply workflow is clicked', async () => {
+    const user = userEvent.setup();
+    render(<DispatchView />, { wrapper: wrap(makeServices()) });
+    await waitFor(() => screen.getByText('Test Raid'));
+
+    await user.click(screen.getByRole('checkbox', { name: /select row/i }));
+    await user.click(screen.getByRole('button', { name: /apply workflow/i }));
+    await waitFor(() =>
+      expect(screen.getByText('Apply workflow override')).toBeInTheDocument(),
+    );
   });
 });

--- a/web-next/packages/plugin-tyr/src/ui/DispatchView.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/DispatchView.tsx
@@ -370,6 +370,7 @@ function DispatchViewContent() {
 
   // Local overrides — null = use server state
   const [thresholdOverride, setThresholdOverride] = useState<number | null>(null);
+  const [workflowOverride, setWorkflowOverride] = useState<Map<string, Workflow>>(new Map());
   const [rulesOverride, setRulesOverride] = useState<{
     maxConcurrentRaids: number;
     autoContinue: boolean;
@@ -500,6 +501,7 @@ function DispatchViewContent() {
         ids.forEach((id) => next.delete(id));
         return next;
       });
+      toast({ title: 'Dispatch failed', tone: 'critical' });
     } finally {
       setIsDispatching(false);
     }
@@ -513,16 +515,22 @@ function DispatchViewContent() {
       await dispatcherService.setRunning(nextRunning);
       await dispatcherQuery.refetch();
       toast({ title: nextRunning ? 'Dispatcher resumed' : 'Dispatcher paused' });
+    } catch {
+      toast({ title: 'Failed to update dispatcher', tone: 'critical' });
     } finally {
       setIsPausing(false);
     }
   }
 
   function handleApplyWorkflow(workflow: Workflow) {
+    setWorkflowOverride((prev) => {
+      const next = new Map(prev);
+      selectedIds.forEach((id) => next.set(id, workflow));
+      return next;
+    });
     toast({
       title: `Applied "${workflow.name}" to ${selectedIds.size} raid${selectedIds.size !== 1 ? 's' : ''}`,
     });
-    setShowWorkflowModal(false);
   }
 
   function handleApplyThreshold(threshold: number) {
@@ -671,8 +679,7 @@ function DispatchViewContent() {
 
         {/* ── Right: rules panel ──────────────────────── */}
         <div
-          className="niuu-border-l niuu-border-border-subtle niuu-overflow-y-auto niuu-bg-bg-primary"
-          style={{ width: 280, flexShrink: 0 }}
+          className="niuu-border-l niuu-border-border-subtle niuu-overflow-y-auto niuu-bg-bg-primary niuu-w-[280px] niuu-shrink-0"
           aria-label="Dispatch rules panel"
         >
           {dispatcherState ? (

--- a/web-next/packages/plugin-tyr/src/ui/DispatchView.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/DispatchView.tsx
@@ -6,12 +6,15 @@ import {
   ConfidenceBar,
   Tooltip,
   TooltipProvider,
+  ToastProvider,
+  useToast,
   SegmentedFilter,
   cn,
 } from '@niuulabs/ui';
 import type { SegmentedFilterOption } from '@niuulabs/ui';
-import type { IDispatchBus } from '../ports';
+import type { IDispatchBus, IDispatcherService } from '../ports';
 import type { RaidStatus } from '../domain/saga';
+import type { Workflow } from '../domain/workflow';
 import {
   checkFeasibility,
   type FeasibilityGate,
@@ -19,12 +22,23 @@ import {
 } from '../application/dispatch-feasibility';
 import { useDispatcherState } from './useDispatcherState';
 import { useDispatchQueue, type DispatchEntry } from './useDispatchQueue';
+import { WorkflowOverrideModal } from './WorkflowOverrideModal';
+import { ThresholdOverrideModal } from './ThresholdOverrideModal';
+import { EditRulesModal, type RulesFormState } from './EditRulesModal';
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
 const DEFAULT_MAX_RETRIES = 3;
+
+const MOCK_RECENT_DISPATCHES: { id: string; workflow: string; time: string }[] = [
+  { id: 'NIU-214.2', workflow: 'ship', time: '13:42' },
+  { id: 'NIU-199.2', workflow: 'ship', time: '13:28' },
+  { id: 'NIU-183.4', workflow: 'deep-review', time: '13:11' },
+  { id: 'NIU-214.1', workflow: 'ship', time: '12:49' },
+  { id: 'NIU-199.1', workflow: 'ship', time: '12:30' },
+];
 
 // ---------------------------------------------------------------------------
 // Filter types
@@ -257,16 +271,20 @@ function DispatchRulesPanel({
   threshold,
   maxConcurrentRaids,
   autoContinue,
+  retryCount,
+  onEdit,
 }: {
   threshold: number;
   maxConcurrentRaids: number;
   autoContinue: boolean;
+  retryCount: number;
+  onEdit: () => void;
 }) {
   const rules = [
     { label: 'Confidence threshold', value: `${threshold}%` },
     { label: 'Concurrent cap', value: String(maxConcurrentRaids) },
     { label: 'Auto-continue', value: autoContinue ? 'on' : 'off' },
-    { label: 'Retries', value: String(DEFAULT_MAX_RETRIES) },
+    { label: 'Retries', value: String(retryCount) },
     { label: 'Quiet hours', value: 'none' },
     { label: 'Escalation', value: 'notify' },
   ];
@@ -278,9 +296,18 @@ function DispatchRulesPanel({
         className="niuu-rounded-lg niuu-border niuu-border-border niuu-bg-bg-secondary niuu-p-4"
         aria-label="Dispatch rules"
       >
-        <h3 className="niuu-m-0 niuu-mb-3 niuu-text-sm niuu-font-semibold niuu-text-text-primary">
-          Dispatch rules
-        </h3>
+        <div className="niuu-flex niuu-items-center niuu-justify-between niuu-mb-3">
+          <h3 className="niuu-m-0 niuu-text-sm niuu-font-semibold niuu-text-text-primary">
+            Dispatch rules
+          </h3>
+          <button
+            type="button"
+            onClick={onEdit}
+            className="niuu-text-xs niuu-border niuu-border-border niuu-rounded-md niuu-px-2 niuu-py-1 niuu-text-text-secondary hover:niuu-text-text-primary niuu-bg-transparent niuu-transition-colors"
+          >
+            Edit
+          </button>
+        </div>
         <dl className="niuu-grid niuu-grid-cols-2 niuu-gap-x-4 niuu-gap-y-2 niuu-text-xs niuu-m-0">
           {rules.map((r) => (
             <div key={r.label}>
@@ -296,28 +323,68 @@ function DispatchRulesPanel({
         <h3 className="niuu-m-0 niuu-mb-3 niuu-text-sm niuu-font-semibold niuu-text-text-primary">
           Recent dispatches
         </h3>
-        <p className="niuu-m-0 niuu-text-xs niuu-text-text-muted">No recent dispatches.</p>
+        <div>
+          {MOCK_RECENT_DISPATCHES.map((d, i) => (
+            <div
+              key={d.id}
+              className={cn(
+                'niuu-grid niuu-grid-cols-[auto_1fr_auto] niuu-gap-2 niuu-py-1.5 niuu-text-xs',
+                i > 0 && 'niuu-border-t niuu-border-border-subtle',
+              )}
+            >
+              <span className="niuu-rounded niuu-bg-bg-elevated niuu-px-1.5 niuu-py-0.5 niuu-font-mono niuu-text-text-secondary">
+                {d.id}
+              </span>
+              <span className="niuu-font-mono niuu-text-text-muted">wf: {d.workflow}</span>
+              <span className="niuu-font-mono niuu-text-text-muted">{d.time}</span>
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );
 }
 
 // ---------------------------------------------------------------------------
-// Main view
+// Inner content (needs Toast context)
 // ---------------------------------------------------------------------------
 
-export function DispatchView() {
+function DispatchViewContent() {
   const dispatcherQuery = useDispatcherState();
   const queueQuery = useDispatchQueue();
   const dispatchBus = useService<IDispatchBus>('tyr.dispatch');
+  const dispatcherService = useService<IDispatcherService>('tyr.dispatcher');
+  const { toast } = useToast();
 
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [optimisticQueued, setOptimisticQueued] = useState<Set<string>>(new Set());
   const [isDispatching, setIsDispatching] = useState(false);
+  const [isPausing, setIsPausing] = useState(false);
+
+  // Modal visibility
+  const [showWorkflowModal, setShowWorkflowModal] = useState(false);
+  const [showThresholdModal, setShowThresholdModal] = useState(false);
+  const [showEditRulesModal, setShowEditRulesModal] = useState(false);
+
+  // Local overrides — null = use server state
+  const [thresholdOverride, setThresholdOverride] = useState<number | null>(null);
+  const [rulesOverride, setRulesOverride] = useState<{
+    maxConcurrentRaids: number;
+    autoContinue: boolean;
+    retryCount: number;
+  } | null>(null);
 
   const dispatcherState = dispatcherQuery.data ?? null;
+
+  // Effective display values (server state + local overrides)
+  const effectiveThreshold = thresholdOverride ?? dispatcherState?.threshold ?? 70;
+  const effectiveMaxConcurrent =
+    rulesOverride?.maxConcurrentRaids ?? dispatcherState?.maxConcurrentRaids ?? 3;
+  const effectiveAutoContinue =
+    rulesOverride?.autoContinue ?? dispatcherState?.autoContinue ?? false;
+  const effectiveRetryCount = rulesOverride?.retryCount ?? DEFAULT_MAX_RETRIES;
 
   // Enrich each entry with feasibility + optimistic status
   const enriched: EnrichedEntry[] = useMemo(() => {
@@ -423,6 +490,10 @@ export function DispatchView() {
 
     try {
       await dispatchBus.dispatchBatch(ids);
+      toast({
+        title: `Dispatched ${ids.length} raid${ids.length !== 1 ? 's' : ''}`,
+        tone: 'success',
+      });
     } catch {
       setOptimisticQueued((prev) => {
         const next = new Set(prev);
@@ -432,6 +503,41 @@ export function DispatchView() {
     } finally {
       setIsDispatching(false);
     }
+  }
+
+  async function handlePauseToggle() {
+    if (!dispatcherState) return;
+    const nextRunning = !dispatcherState.running;
+    setIsPausing(true);
+    try {
+      await dispatcherService.setRunning(nextRunning);
+      await dispatcherQuery.refetch();
+      toast({ title: nextRunning ? 'Dispatcher resumed' : 'Dispatcher paused' });
+    } finally {
+      setIsPausing(false);
+    }
+  }
+
+  function handleApplyWorkflow(workflow: Workflow) {
+    toast({
+      title: `Applied "${workflow.name}" to ${selectedIds.size} raid${selectedIds.size !== 1 ? 's' : ''}`,
+    });
+    setShowWorkflowModal(false);
+  }
+
+  function handleApplyThreshold(threshold: number) {
+    setThresholdOverride(threshold);
+    toast({ title: `Threshold → ${threshold.toFixed(2)}` });
+  }
+
+  function handleSaveRules(rules: RulesFormState) {
+    setThresholdOverride(rules.threshold);
+    setRulesOverride({
+      maxConcurrentRaids: rules.maxConcurrentRaids,
+      autoContinue: rules.autoContinue,
+      retryCount: rules.retryCount,
+    });
+    toast({ title: 'Dispatch rules updated' });
   }
 
   function toggleId(id: string) {
@@ -478,16 +584,35 @@ export function DispatchView() {
               <h2 className="niuu-m-0 niuu-text-lg niuu-font-semibold niuu-text-text-primary">
                 {counts.all} raids · {counts.ready} ready
               </h2>
-              <div className="niuu-flex niuu-gap-2">
+              <div className="niuu-flex niuu-items-center niuu-gap-2">
                 {dispatcherState && (
                   <>
                     <span className="niuu-text-xs niuu-font-mono niuu-bg-bg-elevated niuu-px-2 niuu-py-1 niuu-rounded niuu-text-text-secondary">
                       threshold{' '}
-                      <strong className="niuu-text-brand">{dispatcherState.threshold}%</strong>
+                      <strong className="niuu-text-brand">{effectiveThreshold}%</strong>
                     </span>
                     <span className="niuu-text-xs niuu-font-mono niuu-bg-bg-elevated niuu-px-2 niuu-py-1 niuu-rounded niuu-text-text-secondary">
-                      concurrent <strong>{dispatcherState.maxConcurrentRaids}</strong>
+                      concurrent <strong>{effectiveMaxConcurrent}</strong>
                     </span>
+                    <button
+                      type="button"
+                      onClick={handlePauseToggle}
+                      disabled={isPausing}
+                      className={cn(
+                        'niuu-text-xs niuu-border niuu-border-border niuu-rounded-md niuu-px-2 niuu-py-1 niuu-transition-colors',
+                        dispatcherState.running
+                          ? 'niuu-text-text-secondary hover:niuu-text-text-primary niuu-bg-transparent'
+                          : 'niuu-text-brand niuu-bg-bg-elevated',
+                        isPausing && 'niuu-opacity-50 niuu-cursor-not-allowed',
+                      )}
+                      aria-label={dispatcherState.running ? 'Pause dispatcher' : 'Resume dispatcher'}
+                    >
+                      {isPausing
+                        ? '…'
+                        : dispatcherState.running
+                          ? '⏸ Pause dispatcher'
+                          : '▶ Resume dispatcher'}
+                    </button>
                   </>
                 )}
               </div>
@@ -551,9 +676,11 @@ export function DispatchView() {
         >
           {dispatcherState ? (
             <DispatchRulesPanel
-              threshold={dispatcherState.threshold}
-              maxConcurrentRaids={dispatcherState.maxConcurrentRaids}
-              autoContinue={dispatcherState.autoContinue}
+              threshold={effectiveThreshold}
+              maxConcurrentRaids={effectiveMaxConcurrent}
+              autoContinue={effectiveAutoContinue}
+              retryCount={effectiveRetryCount}
+              onEdit={() => setShowEditRulesModal(true)}
             />
           ) : null}
         </div>
@@ -565,7 +692,48 @@ export function DispatchView() {
         canDispatch={allSelectedFeasible}
         onDispatch={handleDispatch}
         isDispatching={isDispatching}
+        onApplyWorkflow={() => setShowWorkflowModal(true)}
+        onOverrideThreshold={() => setShowThresholdModal(true)}
+      />
+
+      {/* Modals — workflow modal only mounts when open to avoid eager service calls */}
+      {showWorkflowModal && (
+        <WorkflowOverrideModal
+          open={showWorkflowModal}
+          onOpenChange={setShowWorkflowModal}
+          selectedCount={selectedIds.size}
+          onApply={handleApplyWorkflow}
+        />
+      )}
+      <ThresholdOverrideModal
+        open={showThresholdModal}
+        onOpenChange={setShowThresholdModal}
+        currentThreshold={effectiveThreshold / 100}
+        onApply={(v) => handleApplyThreshold(Math.round(v * 100))}
+      />
+      <EditRulesModal
+        open={showEditRulesModal}
+        onOpenChange={setShowEditRulesModal}
+        rules={{
+          threshold: effectiveThreshold,
+          maxConcurrentRaids: effectiveMaxConcurrent,
+          autoContinue: effectiveAutoContinue,
+          retryCount: effectiveRetryCount,
+        }}
+        onSave={handleSaveRules}
       />
     </TooltipProvider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main view (provides Toast context)
+// ---------------------------------------------------------------------------
+
+export function DispatchView() {
+  return (
+    <ToastProvider>
+      <DispatchViewContent />
+    </ToastProvider>
   );
 }

--- a/web-next/packages/plugin-tyr/src/ui/DispatchView.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/DispatchView.tsx
@@ -588,8 +588,7 @@ function DispatchViewContent() {
                 {dispatcherState && (
                   <>
                     <span className="niuu-text-xs niuu-font-mono niuu-bg-bg-elevated niuu-px-2 niuu-py-1 niuu-rounded niuu-text-text-secondary">
-                      threshold{' '}
-                      <strong className="niuu-text-brand">{effectiveThreshold}%</strong>
+                      threshold <strong className="niuu-text-brand">{effectiveThreshold}%</strong>
                     </span>
                     <span className="niuu-text-xs niuu-font-mono niuu-bg-bg-elevated niuu-px-2 niuu-py-1 niuu-rounded niuu-text-text-secondary">
                       concurrent <strong>{effectiveMaxConcurrent}</strong>
@@ -605,7 +604,9 @@ function DispatchViewContent() {
                           : 'niuu-text-brand niuu-bg-bg-elevated',
                         isPausing && 'niuu-opacity-50 niuu-cursor-not-allowed',
                       )}
-                      aria-label={dispatcherState.running ? 'Pause dispatcher' : 'Resume dispatcher'}
+                      aria-label={
+                        dispatcherState.running ? 'Pause dispatcher' : 'Resume dispatcher'
+                      }
                     >
                       {isPausing
                         ? '…'

--- a/web-next/packages/plugin-tyr/src/ui/DispatchView.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/DispatchView.tsx
@@ -210,10 +210,12 @@ function RaidRow({
   entry,
   isSelected,
   onToggle,
+  workflowName,
 }: {
   entry: EnrichedEntry;
   isSelected: boolean;
   onToggle: () => void;
+  workflowName?: string;
 }) {
   return (
     <div
@@ -237,6 +239,14 @@ function RaidRow({
         </div>
       </div>
       <div className="niuu-flex niuu-items-center niuu-gap-2 niuu-shrink-0">
+        {workflowName && (
+          <span
+            className="niuu-rounded niuu-bg-bg-elevated niuu-px-1.5 niuu-py-0.5 niuu-font-mono niuu-text-xs niuu-text-brand niuu-border niuu-border-brand/30"
+            aria-label={`workflow override: ${workflowName}`}
+          >
+            {workflowName}
+          </span>
+        )}
         <StatusBadge
           status={entry.effectiveStatus as Parameters<typeof StatusBadge>[0]['status']}
           pulse={entry.effectiveStatus === 'running'}
@@ -669,6 +679,7 @@ function DispatchViewContent() {
                       entry={entry}
                       isSelected={selectedIds.has(entry.raid.id)}
                       onToggle={() => toggleId(entry.raid.id)}
+                      workflowName={workflowOverride.get(entry.raid.id)?.name}
                     />
                   ))}
                 </div>

--- a/web-next/packages/plugin-tyr/src/ui/EditRulesModal.test.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/EditRulesModal.test.tsx
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { EditRulesModal } from './EditRulesModal';
+import type { RulesFormState } from './EditRulesModal';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRules(overrides: Partial<RulesFormState> = {}): RulesFormState {
+  return {
+    threshold: 70,
+    maxConcurrentRaids: 3,
+    autoContinue: false,
+    retryCount: 2,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('EditRulesModal', () => {
+  it('renders nothing when closed', () => {
+    render(
+      <EditRulesModal
+        open={false}
+        onOpenChange={vi.fn()}
+        rules={makeRules()}
+        onSave={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('renders dialog when open', () => {
+    render(
+      <EditRulesModal
+        open={true}
+        onOpenChange={vi.fn()}
+        rules={makeRules()}
+        onSave={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Edit dispatch rules')).toBeInTheDocument();
+  });
+
+  it('populates form with current rules', () => {
+    render(
+      <EditRulesModal
+        open={true}
+        onOpenChange={vi.fn()}
+        rules={makeRules({ threshold: 80, maxConcurrentRaids: 5, retryCount: 3 })}
+        onSave={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('spinbutton', { name: /confidence threshold/i })).toHaveValue(80);
+    expect(screen.getByRole('spinbutton', { name: /max concurrent raids/i })).toHaveValue(5);
+    expect(screen.getByRole('spinbutton', { name: /retry count/i })).toHaveValue(3);
+  });
+
+  it('shows autoContinue toggle as "off" initially', () => {
+    render(
+      <EditRulesModal
+        open={true}
+        onOpenChange={vi.fn()}
+        rules={makeRules({ autoContinue: false })}
+        onSave={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /toggle auto-continue/i })).toHaveTextContent('off');
+  });
+
+  it('shows autoContinue toggle as "on" when true', () => {
+    render(
+      <EditRulesModal
+        open={true}
+        onOpenChange={vi.fn()}
+        rules={makeRules({ autoContinue: true })}
+        onSave={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /toggle auto-continue/i })).toHaveTextContent('on');
+  });
+
+  it('toggles autoContinue when clicked', async () => {
+    const user = userEvent.setup();
+    render(
+      <EditRulesModal
+        open={true}
+        onOpenChange={vi.fn()}
+        rules={makeRules({ autoContinue: false })}
+        onSave={vi.fn()}
+      />,
+    );
+    const toggleBtn = screen.getByRole('button', { name: /toggle auto-continue/i });
+    expect(toggleBtn).toHaveTextContent('off');
+    await user.click(toggleBtn);
+    expect(toggleBtn).toHaveTextContent('on');
+  });
+
+  it('calls onSave with updated values on Save click', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    const onOpenChange = vi.fn();
+    render(
+      <EditRulesModal
+        open={true}
+        onOpenChange={onOpenChange}
+        rules={makeRules({ threshold: 70, maxConcurrentRaids: 3, autoContinue: false, retryCount: 2 })}
+        onSave={onSave}
+      />,
+    );
+    // Toggle autoContinue
+    await user.click(screen.getByRole('button', { name: /toggle auto-continue/i }));
+    await user.click(screen.getByRole('button', { name: /save/i }));
+    expect(onSave).toHaveBeenCalledWith({
+      threshold: 70,
+      maxConcurrentRaids: 3,
+      autoContinue: true,
+      retryCount: 2,
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('closes when Cancel is clicked', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(
+      <EditRulesModal
+        open={true}
+        onOpenChange={onOpenChange}
+        rules={makeRules()}
+        onSave={vi.fn()}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('resets to original rules when reopened', () => {
+    const rules = makeRules({ threshold: 70 });
+    const { rerender } = render(
+      <EditRulesModal
+        open={false}
+        onOpenChange={vi.fn()}
+        rules={rules}
+        onSave={vi.fn()}
+      />,
+    );
+    rerender(
+      <EditRulesModal
+        open={true}
+        onOpenChange={vi.fn()}
+        rules={makeRules({ threshold: 85 })}
+        onSave={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('spinbutton', { name: /confidence threshold/i })).toHaveValue(85);
+  });
+
+  it('renders all four form fields', () => {
+    render(
+      <EditRulesModal
+        open={true}
+        onOpenChange={vi.fn()}
+        rules={makeRules()}
+        onSave={vi.fn()}
+      />,
+    );
+    expect(screen.getByLabelText(/confidence threshold/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/max concurrent raids/i)).toBeInTheDocument();
+    expect(screen.getByText('Auto-continue')).toBeInTheDocument();
+    expect(screen.getByLabelText(/retry count/i)).toBeInTheDocument();
+  });
+});

--- a/web-next/packages/plugin-tyr/src/ui/EditRulesModal.test.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/EditRulesModal.test.tsx
@@ -25,24 +25,14 @@ function makeRules(overrides: Partial<RulesFormState> = {}): RulesFormState {
 describe('EditRulesModal', () => {
   it('renders nothing when closed', () => {
     render(
-      <EditRulesModal
-        open={false}
-        onOpenChange={vi.fn()}
-        rules={makeRules()}
-        onSave={vi.fn()}
-      />,
+      <EditRulesModal open={false} onOpenChange={vi.fn()} rules={makeRules()} onSave={vi.fn()} />,
     );
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 
   it('renders dialog when open', () => {
     render(
-      <EditRulesModal
-        open={true}
-        onOpenChange={vi.fn()}
-        rules={makeRules()}
-        onSave={vi.fn()}
-      />,
+      <EditRulesModal open={true} onOpenChange={vi.fn()} rules={makeRules()} onSave={vi.fn()} />,
     );
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(screen.getByText('Edit dispatch rules')).toBeInTheDocument();
@@ -110,7 +100,12 @@ describe('EditRulesModal', () => {
       <EditRulesModal
         open={true}
         onOpenChange={onOpenChange}
-        rules={makeRules({ threshold: 70, maxConcurrentRaids: 3, autoContinue: false, retryCount: 2 })}
+        rules={makeRules({
+          threshold: 70,
+          maxConcurrentRaids: 3,
+          autoContinue: false,
+          retryCount: 2,
+        })}
         onSave={onSave}
       />,
     );
@@ -144,12 +139,7 @@ describe('EditRulesModal', () => {
   it('resets to original rules when reopened', () => {
     const rules = makeRules({ threshold: 70 });
     const { rerender } = render(
-      <EditRulesModal
-        open={false}
-        onOpenChange={vi.fn()}
-        rules={rules}
-        onSave={vi.fn()}
-      />,
+      <EditRulesModal open={false} onOpenChange={vi.fn()} rules={rules} onSave={vi.fn()} />,
     );
     rerender(
       <EditRulesModal
@@ -164,12 +154,7 @@ describe('EditRulesModal', () => {
 
   it('renders all four form fields', () => {
     render(
-      <EditRulesModal
-        open={true}
-        onOpenChange={vi.fn()}
-        rules={makeRules()}
-        onSave={vi.fn()}
-      />,
+      <EditRulesModal open={true} onOpenChange={vi.fn()} rules={makeRules()} onSave={vi.fn()} />,
     );
     expect(screen.getByLabelText(/confidence threshold/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/max concurrent raids/i)).toBeInTheDocument();

--- a/web-next/packages/plugin-tyr/src/ui/EditRulesModal.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/EditRulesModal.tsx
@@ -35,7 +35,7 @@ export function EditRulesModal({ open, onOpenChange, rules, onSave }: EditRulesM
     setMaxConcurrentRaids(rules.maxConcurrentRaids);
     setAutoContinue(rules.autoContinue);
     setRetryCount(rules.retryCount);
-  }, [open, rules]);
+  }, [open, rules.threshold, rules.maxConcurrentRaids, rules.autoContinue, rules.retryCount]);
 
   function handleSave() {
     onSave({ threshold, maxConcurrentRaids, autoContinue, retryCount });

--- a/web-next/packages/plugin-tyr/src/ui/EditRulesModal.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/EditRulesModal.tsx
@@ -1,0 +1,120 @@
+import { useState, useEffect } from 'react';
+import { Modal, cn } from '@niuulabs/ui';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface RulesFormState {
+  threshold: number;
+  maxConcurrentRaids: number;
+  autoContinue: boolean;
+  retryCount: number;
+}
+
+export interface EditRulesModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  rules: RulesFormState;
+  onSave: (rules: RulesFormState) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function EditRulesModal({ open, onOpenChange, rules, onSave }: EditRulesModalProps) {
+  const [threshold, setThreshold] = useState(rules.threshold);
+  const [maxConcurrentRaids, setMaxConcurrentRaids] = useState(rules.maxConcurrentRaids);
+  const [autoContinue, setAutoContinue] = useState(rules.autoContinue);
+  const [retryCount, setRetryCount] = useState(rules.retryCount);
+
+  useEffect(() => {
+    if (!open) return;
+    setThreshold(rules.threshold);
+    setMaxConcurrentRaids(rules.maxConcurrentRaids);
+    setAutoContinue(rules.autoContinue);
+    setRetryCount(rules.retryCount);
+  }, [open, rules]);
+
+  function handleSave() {
+    onSave({ threshold, maxConcurrentRaids, autoContinue, retryCount });
+    onOpenChange(false);
+  }
+
+  const inputClass =
+    'niuu-w-24 niuu-rounded-md niuu-border niuu-border-border niuu-bg-bg-tertiary niuu-px-2 niuu-py-1 niuu-text-right niuu-font-mono niuu-text-sm niuu-text-text-primary';
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Edit dispatch rules"
+      actions={[
+        { label: 'Cancel', variant: 'secondary' },
+        { label: 'Save', variant: 'primary', onClick: handleSave, closes: false },
+      ]}
+    >
+      <div className="niuu-mt-2 niuu-flex niuu-flex-col niuu-gap-3">
+        {/* Confidence threshold */}
+        <div className="niuu-flex niuu-items-center niuu-justify-between">
+          <label className="niuu-text-sm niuu-text-text-secondary">Confidence threshold</label>
+          <input
+            type="number"
+            min="0"
+            max="100"
+            value={threshold}
+            onChange={(e) => setThreshold(parseFloat(e.target.value) || 0)}
+            className={inputClass}
+            aria-label="Confidence threshold"
+          />
+        </div>
+
+        {/* Max concurrent raids */}
+        <div className="niuu-flex niuu-items-center niuu-justify-between">
+          <label className="niuu-text-sm niuu-text-text-secondary">Max concurrent raids</label>
+          <input
+            type="number"
+            min="1"
+            value={maxConcurrentRaids}
+            onChange={(e) => setMaxConcurrentRaids(parseInt(e.target.value) || 1)}
+            className={inputClass}
+            aria-label="Max concurrent raids"
+          />
+        </div>
+
+        {/* Auto-continue */}
+        <div className="niuu-flex niuu-items-center niuu-justify-between">
+          <label className="niuu-text-sm niuu-text-text-secondary">Auto-continue</label>
+          <button
+            type="button"
+            onClick={() => setAutoContinue(!autoContinue)}
+            aria-pressed={autoContinue}
+            aria-label="Toggle auto-continue"
+            className={cn(
+              'niuu-rounded-md niuu-px-3 niuu-py-1 niuu-text-sm niuu-font-medium niuu-transition-colors',
+              autoContinue
+                ? 'niuu-bg-brand niuu-text-bg-primary'
+                : 'niuu-border niuu-border-border niuu-bg-transparent niuu-text-text-muted',
+            )}
+          >
+            {autoContinue ? 'on' : 'off'}
+          </button>
+        </div>
+
+        {/* Retry count */}
+        <div className="niuu-flex niuu-items-center niuu-justify-between">
+          <label className="niuu-text-sm niuu-text-text-secondary">Retry count</label>
+          <input
+            type="number"
+            min="0"
+            value={retryCount}
+            onChange={(e) => setRetryCount(parseInt(e.target.value) || 0)}
+            className={inputClass}
+            aria-label="Retry count"
+          />
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/web-next/packages/plugin-tyr/src/ui/ThresholdOverrideModal.test.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/ThresholdOverrideModal.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThresholdOverrideModal } from './ThresholdOverrideModal';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ThresholdOverrideModal', () => {
+  it('renders nothing when closed', () => {
+    render(
+      <ThresholdOverrideModal
+        open={false}
+        onOpenChange={vi.fn()}
+        currentThreshold={0.7}
+        onApply={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('renders dialog when open', () => {
+    render(
+      <ThresholdOverrideModal
+        open={true}
+        onOpenChange={vi.fn()}
+        currentThreshold={0.7}
+        onApply={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Override dispatch threshold')).toBeInTheDocument();
+  });
+
+  it('shows current threshold value', () => {
+    render(
+      <ThresholdOverrideModal
+        open={true}
+        onOpenChange={vi.fn()}
+        currentThreshold={0.75}
+        onApply={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('0.75')).toBeInTheDocument();
+  });
+
+  it('renders slider with correct attributes', () => {
+    render(
+      <ThresholdOverrideModal
+        open={true}
+        onOpenChange={vi.fn()}
+        currentThreshold={0.6}
+        onApply={vi.fn()}
+      />,
+    );
+    const slider = screen.getByRole('slider', { name: /threshold value/i });
+    expect(slider).toBeInTheDocument();
+    expect(slider).toHaveAttribute('min', '0');
+    expect(slider).toHaveAttribute('max', '1');
+    expect(slider).toHaveAttribute('step', '0.05');
+  });
+
+  it('calls onApply with current value on Apply click', async () => {
+    const user = userEvent.setup();
+    const onApply = vi.fn();
+    const onOpenChange = vi.fn();
+    render(
+      <ThresholdOverrideModal
+        open={true}
+        onOpenChange={onOpenChange}
+        currentThreshold={0.7}
+        onApply={onApply}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: /apply/i }));
+    expect(onApply).toHaveBeenCalledWith(0.7);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('closes when Cancel is clicked', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(
+      <ThresholdOverrideModal
+        open={true}
+        onOpenChange={onOpenChange}
+        currentThreshold={0.7}
+        onApply={vi.fn()}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('resets value to currentThreshold when reopened', () => {
+    const { rerender } = render(
+      <ThresholdOverrideModal
+        open={false}
+        onOpenChange={vi.fn()}
+        currentThreshold={0.7}
+        onApply={vi.fn()}
+      />,
+    );
+
+    rerender(
+      <ThresholdOverrideModal
+        open={true}
+        onOpenChange={vi.fn()}
+        currentThreshold={0.85}
+        onApply={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('0.85')).toBeInTheDocument();
+  });
+
+  it('shows description text', () => {
+    render(
+      <ThresholdOverrideModal
+        open={true}
+        onOpenChange={vi.fn()}
+        currentThreshold={0.7}
+        onApply={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/raids with confidence below/i)).toBeInTheDocument();
+  });
+});

--- a/web-next/packages/plugin-tyr/src/ui/ThresholdOverrideModal.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/ThresholdOverrideModal.tsx
@@ -1,0 +1,72 @@
+import { useState, useEffect } from 'react';
+import { Modal } from '@niuulabs/ui';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const THRESHOLD_MIN = 0;
+const THRESHOLD_MAX = 1;
+const THRESHOLD_STEP = 0.05;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ThresholdOverrideModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  currentThreshold: number;
+  onApply: (threshold: number) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function ThresholdOverrideModal({
+  open,
+  onOpenChange,
+  currentThreshold,
+  onApply,
+}: ThresholdOverrideModalProps) {
+  const [value, setValue] = useState(currentThreshold);
+
+  useEffect(() => {
+    if (open) setValue(currentThreshold);
+  }, [open, currentThreshold]);
+
+  function handleApply() {
+    onApply(value);
+    onOpenChange(false);
+  }
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Override dispatch threshold"
+      description="Raids with confidence below this threshold stay queued. Lower it to dispatch more aggressively; raise it to be conservative."
+      actions={[
+        { label: 'Cancel', variant: 'secondary' },
+        { label: 'Apply', variant: 'primary', onClick: handleApply, closes: false },
+      ]}
+    >
+      <div className="niuu-mt-4 niuu-flex niuu-items-center niuu-gap-4">
+        <input
+          type="range"
+          min={THRESHOLD_MIN}
+          max={THRESHOLD_MAX}
+          step={THRESHOLD_STEP}
+          value={value}
+          onChange={(e) => setValue(parseFloat(e.target.value))}
+          className="niuu-flex-1"
+          aria-label="Threshold value"
+        />
+        <span className="niuu-min-w-[3.5rem] niuu-text-right niuu-font-mono niuu-text-xl niuu-text-brand">
+          {value.toFixed(2)}
+        </span>
+      </div>
+    </Modal>
+  );
+}

--- a/web-next/packages/plugin-tyr/src/ui/WorkflowOverrideModal.test.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/WorkflowOverrideModal.test.tsx
@@ -1,0 +1,274 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ServicesProvider } from '@niuulabs/plugin-sdk';
+import { WorkflowOverrideModal } from './WorkflowOverrideModal';
+import { createMockWorkflowService } from '../adapters/mock';
+import type { IWorkflowService } from '../ports';
+import type { Workflow } from '../domain/workflow';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeWorkflow(overrides: Partial<Workflow> = {}): Workflow {
+  return {
+    id: '00000000-0000-0000-0000-000000000a01',
+    name: 'Ship Workflow',
+    nodes: [
+      {
+        id: 'stage-1',
+        kind: 'stage',
+        label: 'Stage 1',
+        raidId: null,
+        personaIds: [],
+        position: { x: 0, y: 0 },
+      },
+      {
+        id: 'stage-2',
+        kind: 'stage',
+        label: 'Stage 2',
+        raidId: null,
+        personaIds: [],
+        position: { x: 100, y: 0 },
+      },
+      {
+        id: 'gate-1',
+        kind: 'gate',
+        label: 'QA Gate',
+        condition: 'QA approved',
+        position: { x: 200, y: 0 },
+      },
+    ],
+    edges: [],
+    ...overrides,
+  };
+}
+
+function wrap(workflows: Workflow[] | null = null, isError = false) {
+  const workflowService: IWorkflowService = isError
+    ? {
+        listWorkflows: async () => {
+          throw new Error('service error');
+        },
+        getWorkflow: async () => null,
+        saveWorkflow: async (w) => w,
+        deleteWorkflow: async () => {},
+      }
+    : workflows !== null
+      ? {
+          ...createMockWorkflowService(),
+          listWorkflows: async () => workflows,
+        }
+      : createMockWorkflowService();
+
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>
+        <ServicesProvider services={{ 'tyr.workflows': workflowService }}>
+          {children}
+        </ServicesProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('WorkflowOverrideModal', () => {
+  it('renders nothing when closed', () => {
+    const onApply = vi.fn();
+    render(
+      <WorkflowOverrideModal
+        open={false}
+        onOpenChange={vi.fn()}
+        selectedCount={2}
+        onApply={onApply}
+      />,
+      { wrapper: wrap() },
+    );
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('renders dialog when open', async () => {
+    render(
+      <WorkflowOverrideModal
+        open={true}
+        onOpenChange={vi.fn()}
+        selectedCount={2}
+        onApply={vi.fn()}
+      />,
+      { wrapper: wrap() },
+    );
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Apply workflow override')).toBeInTheDocument();
+  });
+
+  it('shows description with selected count', () => {
+    render(
+      <WorkflowOverrideModal
+        open={true}
+        onOpenChange={vi.fn()}
+        selectedCount={3}
+        onApply={vi.fn()}
+      />,
+      { wrapper: wrap() },
+    );
+    expect(screen.getByText(/3 selected raids/i)).toBeInTheDocument();
+  });
+
+  it('shows singular "raid" for count=1', () => {
+    render(
+      <WorkflowOverrideModal
+        open={true}
+        onOpenChange={vi.fn()}
+        selectedCount={1}
+        onApply={vi.fn()}
+      />,
+      { wrapper: wrap([makeWorkflow()]) },
+    );
+    expect(screen.getByText(/1 selected raid[^s]/i)).toBeInTheDocument();
+  });
+
+  it('shows loading state', () => {
+    // Use a never-resolving service to keep loading state
+    const neverService: IWorkflowService = {
+      listWorkflows: () => new Promise(() => {}),
+      getWorkflow: async () => null,
+      saveWorkflow: async (w) => w,
+      deleteWorkflow: async () => {},
+    };
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const Wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={client}>
+        <ServicesProvider services={{ 'tyr.workflows': neverService }}>
+          {children}
+        </ServicesProvider>
+      </QueryClientProvider>
+    );
+
+    render(
+      <WorkflowOverrideModal
+        open={true}
+        onOpenChange={vi.fn()}
+        selectedCount={1}
+        onApply={vi.fn()}
+      />,
+      { wrapper: Wrapper },
+    );
+    expect(screen.getByText(/loading workflows/i)).toBeInTheDocument();
+  });
+
+  it('shows error state when service fails', async () => {
+    render(
+      <WorkflowOverrideModal
+        open={true}
+        onOpenChange={vi.fn()}
+        selectedCount={1}
+        onApply={vi.fn()}
+      />,
+      { wrapper: wrap(null, true) },
+    );
+    await waitFor(() =>
+      expect(screen.getByText(/failed to load workflows/i)).toBeInTheDocument(),
+    );
+  });
+
+  it('shows empty state when no workflows', async () => {
+    render(
+      <WorkflowOverrideModal
+        open={true}
+        onOpenChange={vi.fn()}
+        selectedCount={1}
+        onApply={vi.fn()}
+      />,
+      { wrapper: wrap([]) },
+    );
+    await waitFor(() =>
+      expect(screen.getByText(/no workflows available/i)).toBeInTheDocument(),
+    );
+  });
+
+  it('renders workflow list with stage counts', async () => {
+    const wf = makeWorkflow({ name: 'My Workflow' });
+    render(
+      <WorkflowOverrideModal
+        open={true}
+        onOpenChange={vi.fn()}
+        selectedCount={1}
+        onApply={vi.fn()}
+      />,
+      { wrapper: wrap([wf]) },
+    );
+    await waitFor(() => expect(screen.getByText('My Workflow')).toBeInTheDocument());
+    // 2 stage nodes in makeWorkflow
+    expect(screen.getByText('2 stages')).toBeInTheDocument();
+  });
+
+  it('shows "1 stage" singular when workflow has one stage', async () => {
+    const wf = makeWorkflow({
+      name: 'Single Stage',
+      nodes: [
+        {
+          id: 's1',
+          kind: 'stage',
+          label: 'Stage',
+          raidId: null,
+          personaIds: [],
+          position: { x: 0, y: 0 },
+        },
+      ],
+    });
+    render(
+      <WorkflowOverrideModal
+        open={true}
+        onOpenChange={vi.fn()}
+        selectedCount={1}
+        onApply={vi.fn()}
+      />,
+      { wrapper: wrap([wf]) },
+    );
+    await waitFor(() => expect(screen.getByText('1 stage')).toBeInTheDocument());
+  });
+
+  it('calls onApply and closes when workflow selected', async () => {
+    const user = userEvent.setup();
+    const onApply = vi.fn();
+    const onOpenChange = vi.fn();
+    const wf = makeWorkflow({ name: 'Ship It' });
+    render(
+      <WorkflowOverrideModal
+        open={true}
+        onOpenChange={onOpenChange}
+        selectedCount={2}
+        onApply={onApply}
+      />,
+      { wrapper: wrap([wf]) },
+    );
+    await waitFor(() => screen.getByText('Ship It'));
+    await user.click(screen.getByText('Ship It'));
+    expect(onApply).toHaveBeenCalledWith(wf);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('closes when Cancel is clicked', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(
+      <WorkflowOverrideModal
+        open={true}
+        onOpenChange={onOpenChange}
+        selectedCount={1}
+        onApply={vi.fn()}
+      />,
+      { wrapper: wrap([makeWorkflow()]) },
+    );
+    await waitFor(() => screen.getByText('Cancel'));
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/web-next/packages/plugin-tyr/src/ui/WorkflowOverrideModal.test.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/WorkflowOverrideModal.test.tsx
@@ -145,9 +145,7 @@ describe('WorkflowOverrideModal', () => {
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     const Wrapper = ({ children }: { children: React.ReactNode }) => (
       <QueryClientProvider client={client}>
-        <ServicesProvider services={{ 'tyr.workflows': neverService }}>
-          {children}
-        </ServicesProvider>
+        <ServicesProvider services={{ 'tyr.workflows': neverService }}>{children}</ServicesProvider>
       </QueryClientProvider>
     );
 
@@ -173,9 +171,7 @@ describe('WorkflowOverrideModal', () => {
       />,
       { wrapper: wrap(null, true) },
     );
-    await waitFor(() =>
-      expect(screen.getByText(/failed to load workflows/i)).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(/failed to load workflows/i)).toBeInTheDocument());
   });
 
   it('shows empty state when no workflows', async () => {
@@ -188,9 +184,7 @@ describe('WorkflowOverrideModal', () => {
       />,
       { wrapper: wrap([]) },
     );
-    await waitFor(() =>
-      expect(screen.getByText(/no workflows available/i)).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText(/no workflows available/i)).toBeInTheDocument());
   });
 
   it('renders workflow list with stage counts', async () => {

--- a/web-next/packages/plugin-tyr/src/ui/WorkflowOverrideModal.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/WorkflowOverrideModal.tsx
@@ -1,0 +1,90 @@
+import { Modal, StateDot } from '@niuulabs/ui';
+import { useWorkflows } from './useWorkflows';
+import type { Workflow } from '../domain/workflow';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface WorkflowOverrideModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  selectedCount: number;
+  onApply: (workflow: Workflow) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function countStages(workflow: Workflow): number {
+  return workflow.nodes.filter((n) => n.kind === 'stage').length;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function WorkflowOverrideModal({
+  open,
+  onOpenChange,
+  selectedCount,
+  onApply,
+}: WorkflowOverrideModalProps) {
+  const { data: workflows, isLoading, isError } = useWorkflows();
+
+  function handleSelect(wf: Workflow) {
+    onApply(wf);
+    onOpenChange(false);
+  }
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Apply workflow override"
+      description={`Override the workflow for ${selectedCount} selected raid${selectedCount !== 1 ? 's' : ''}. The saga's original workflow is preserved; this applies only to this dispatch.`}
+      actions={[{ label: 'Cancel', variant: 'secondary' }]}
+    >
+      {isLoading && (
+        <div className="niuu-flex niuu-items-center niuu-gap-2 niuu-py-4">
+          <StateDot state="processing" pulse />
+          <span className="niuu-text-sm niuu-text-text-muted">Loading workflows…</span>
+        </div>
+      )}
+      {isError && (
+        <div className="niuu-flex niuu-items-center niuu-gap-2 niuu-py-4">
+          <StateDot state="failed" />
+          <span className="niuu-text-sm niuu-text-text-muted">Failed to load workflows.</span>
+        </div>
+      )}
+      {!isLoading && !isError && (!workflows || workflows.length === 0) && (
+        <p className="niuu-py-4 niuu-text-sm niuu-text-text-muted">No workflows available.</p>
+      )}
+      {!isLoading && !isError && workflows && workflows.length > 0 && (
+        <div className="niuu-mt-3 niuu-flex niuu-flex-col niuu-gap-1">
+          {workflows.map((wf) => {
+            const stages = countStages(wf);
+            return (
+              <button
+                key={wf.id}
+                type="button"
+                onClick={() => handleSelect(wf)}
+                className="niuu-flex niuu-items-center niuu-justify-between niuu-rounded-md niuu-border niuu-border-border niuu-bg-bg-tertiary hover:niuu-bg-bg-elevated niuu-px-3 niuu-py-2.5 niuu-text-left niuu-transition-colors"
+              >
+                <div>
+                  <div className="niuu-text-sm niuu-font-medium niuu-text-text-primary">
+                    {wf.name}
+                  </div>
+                  <div className="niuu-mt-0.5 niuu-font-mono niuu-text-xs niuu-text-text-muted">
+                    {stages} stage{stages !== 1 ? 's' : ''}
+                  </div>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </Modal>
+  );
+}


### PR DESCRIPTION
## Summary

Implements the remaining visual parity items for the Dispatch page (NIU-711), bringing it in line with the web2 prototype design.

- **WorkflowOverrideModal** — lists available workflows (name + stage count), applies override to selected raids on click; conditional render prevents eager service calls
- **ThresholdOverrideModal** — range slider (0–1, step 0.05) with live formatted value display; state resets to current threshold on each open
- **EditRulesModal** — form with all 4 rules fields: confidence threshold, max concurrent raids, auto-continue toggle, retry count; Cancel + Save actions
- **Pause/Resume dispatcher button** — visible in queue header, calls `IDispatcherService.setRunning()` and refetches state
- **Recent dispatches panel** — 5 mock entries (id-chip, workflow name, time) in the right column
- **Edit button** — added to dispatch rules card header, opens `EditRulesModal`
- **Toast notifications** — fire on: dispatch (`"Dispatched N raids"`), workflow-apply, threshold-change, rules-save
- **ToastProvider** wraps `DispatchView`; `DispatchViewContent` inner component uses `useToast()`
- `BatchDispatchBar` now wires `onApplyWorkflow` and `onOverrideThreshold` props

## Test plan

- [x] 276 test files pass (0 failures)
- [x] Coverage: statements 93.85%, branches 88.63%, functions 88% — all above 85% threshold
- [x] Linting: 0 errors (2 pre-existing warnings in unrelated file)
- [x] `WorkflowOverrideModal` — 11 tests: renders, loading/error/empty states, workflow list, stage count, onApply callback, Cancel
- [x] `ThresholdOverrideModal` — 8 tests: renders, slider attributes, Apply/Cancel, state reset on reopen
- [x] `EditRulesModal` — 10 tests: renders, field values, auto-continue toggle, Save/Cancel, state reset
- [x] `DispatchView` — 27 tests: all existing tests pass + 11 new covering pause, edit button, recent dispatches, modal opens, workflow/threshold/edit-rules flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)