### PR TITLE
feat(plan): visual parity with web2 — NIU-713

### DIFF
--- a/web-next/packages/plugin-mimir/src/ui/DreamsPage.test.tsx
+++ b/web-next/packages/plugin-mimir/src/ui/DreamsPage.test.tsx
@@ -191,8 +191,6 @@ describe('DreamsPage', () => {
       },
     };
     wrap(<DreamsPage />, failing);
-    await waitFor(() =>
-      expect(screen.getByText('activity log unavailable')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('activity log unavailable')).toBeInTheDocument());
   });
 });

--- a/web-next/packages/plugin-mimir/src/ui/DreamsPage.tsx
+++ b/web-next/packages/plugin-mimir/src/ui/DreamsPage.tsx
@@ -143,7 +143,12 @@ function ActivityRow({ event }: ActivityRowProps) {
 
 export function DreamsPage() {
   const { data: cycles, isLoading: cyclesLoading, isError: cyclesError, error } = useDreams();
-  const { data: events, isLoading: eventsLoading, isError: eventsError, error: eventsErr } = useActivityLog();
+  const {
+    data: events,
+    isLoading: eventsLoading,
+    isError: eventsError,
+    error: eventsErr,
+  } = useActivityLog();
 
   const [kindFilter, setKindFilter] = useState<ActivityEventKind | 'all'>('all');
 
@@ -230,7 +235,9 @@ export function DreamsPage() {
         {eventsError && (
           <div className={STATUS_ROW}>
             <StateDot state="failed" />
-            <span>{eventsErr instanceof Error ? eventsErr.message : 'activity log load failed'}</span>
+            <span>
+              {eventsErr instanceof Error ? eventsErr.message : 'activity log load failed'}
+            </span>
           </div>
         )}
 

--- a/web-next/packages/plugin-tyr/src/domain/plan.ts
+++ b/web-next/packages/plugin-tyr/src/domain/plan.ts
@@ -79,4 +79,6 @@ export interface ClarifyingQuestion {
   id: string;
   question: string;
   hint?: string;
+  /** When 'workflow', renders a template picker grid instead of a text input. */
+  kind?: 'text' | 'workflow';
 }

--- a/web-next/packages/plugin-tyr/src/ports.ts
+++ b/web-next/packages/plugin-tyr/src/ports.ts
@@ -76,6 +76,12 @@ export interface RaidSpec {
   declaredFiles: string[];
   estimateHours: number;
   confidence: number;
+  /** Size classification returned by the planning raven. */
+  size?: 'S' | 'M' | 'L';
+  /** Persona ID responsible for this raid (e.g. "coding-agent"). */
+  persona?: string;
+  /** Phase label this raid belongs to (e.g. "Build", "Verify"). */
+  phase?: string;
 }
 
 export interface PhaseSpec {
@@ -83,11 +89,19 @@ export interface PhaseSpec {
   raids: RaidSpec[];
 }
 
+export interface PlanRisk {
+  /** Short category label — e.g. "blast", "untested", "dependency". */
+  kind: string;
+  message: string;
+}
+
 export interface ExtractedStructure {
   found: boolean;
   structure: {
     name: string;
     phases: PhaseSpec[];
+    /** Risks flagged by the planning raven. */
+    risks?: PlanRisk[];
   } | null;
 }
 

--- a/web-next/packages/plugin-tyr/src/ui/PlanDraft.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/PlanDraft.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { ConfidenceBar, type ConfidenceLevel } from '@niuulabs/ui';
 import type { ExtractedStructure, PhaseSpec } from '../ports';
 
@@ -34,15 +34,17 @@ interface PlanDraftProps {
   onReplan?(): void;
   onSaveDraft?(): void;
   onEditPhase(phaseIndex: number, name: string): void;
+  onRemoveRaid?(phaseIndex: number, raidIndex: number): void;
 }
 
 interface PhaseEditorProps {
   phase: PhaseSpec;
   phaseIndex: number;
   onSave(name: string): void;
+  onRemoveRaid?(raidIndex: number): void;
 }
 
-function PhaseEditor({ phase, phaseIndex, onSave }: PhaseEditorProps) {
+function PhaseEditor({ phase, phaseIndex, onSave, onRemoveRaid }: PhaseEditorProps) {
   const [editing, setEditing] = useState(false);
   const [name, setName] = useState(phase.name);
 
@@ -125,8 +127,11 @@ function PhaseEditor({ phase, phaseIndex, onSave }: PhaseEditorProps) {
             <li
               key={ri}
               className="niuu-rounded niuu-bg-bg-tertiary niuu-px-3 niuu-py-2 niuu-grid niuu-items-center niuu-gap-x-3 niuu-gap-y-0"
-              style={{ gridTemplateColumns: 'auto 1fr auto' }}
+              style={{ gridTemplateColumns: 'auto 1fr auto auto auto' }}
             >
+              {/* Col 1: Persona circle
+                  TODO: Replace with <PersonaAvatar role={...} letter={...} size={22} /> once
+                  RaidSpec includes a personaRole field that maps to the PersonaRole enum. */}
               <span
                 className="niuu-w-6 niuu-h-6 niuu-rounded-full niuu-bg-bg-elevated niuu-flex niuu-items-center niuu-justify-center niuu-text-xs niuu-text-text-muted niuu-flex-shrink-0"
                 title={raid.persona ?? 'raven'}
@@ -134,8 +139,10 @@ function PhaseEditor({ phase, phaseIndex, onSave }: PhaseEditorProps) {
               >
                 {raid.persona ? raid.persona.charAt(0).toUpperCase() : 'ᚱ'}
               </span>
-              <div className="niuu-flex niuu-flex-col niuu-gap-0.5">
-                <span className="niuu-text-xs niuu-font-medium niuu-text-text-primary">
+
+              {/* Col 2: Name + meta */}
+              <div className="niuu-flex niuu-flex-col niuu-gap-0.5 niuu-min-w-0">
+                <span className="niuu-text-xs niuu-font-medium niuu-text-text-primary niuu-truncate">
                   {raid.name}
                 </span>
                 <span className="niuu-text-xs niuu-text-text-muted niuu-font-mono">
@@ -151,12 +158,40 @@ function PhaseEditor({ phase, phaseIndex, onSave }: PhaseEditorProps) {
                     `~${raid.estimateHours}h · ${raid.confidence}% confidence`}
                 </span>
               </div>
-              {raid.size && (
+
+              {/* Col 3: Size pill (always occupies grid cell) */}
+              {raid.size ? (
                 <span
                   className={`niuu-text-xs niuu-font-semibold niuu-rounded niuu-border niuu-px-1.5 niuu-py-0.5 ${SIZE_CLASSES[raid.size]}`}
                 >
                   {raid.size}
                 </span>
+              ) : (
+                <span />
+              )}
+
+              {/* Col 4: Own saga (disabled stub — no backend yet) */}
+              <button
+                type="button"
+                disabled
+                aria-label={`Promote raid ${ri + 1} to own saga`}
+                className="niuu-text-xs niuu-text-text-muted niuu-border niuu-border-border niuu-rounded niuu-px-1.5 niuu-py-0.5 niuu-opacity-40 niuu-cursor-not-allowed"
+              >
+                Own saga
+              </button>
+
+              {/* Col 5: Remove button */}
+              {onRemoveRaid ? (
+                <button
+                  type="button"
+                  onClick={() => onRemoveRaid(ri)}
+                  aria-label={`Remove raid ${ri + 1}`}
+                  className="niuu-text-xs niuu-text-text-muted hover:niuu-text-critical niuu-transition-colors niuu-leading-none"
+                >
+                  ×
+                </button>
+              ) : (
+                <span />
               )}
             </li>
           ))}
@@ -170,7 +205,8 @@ function PhaseEditor({ phase, phaseIndex, onSave }: PhaseEditorProps) {
  * Step 4 of the Plan wizard — review the decomposed saga structure with
  * per-phase edit buttons before approving.
  *
- * Includes: risk rows with kind badges, Re-plan button, and Save as draft button.
+ * Includes: risk rows with kind badges, Re-plan button, Save as draft button,
+ * and per-raid promote (Own saga) + remove buttons.
  */
 export function PlanDraft({
   structure,
@@ -181,6 +217,7 @@ export function PlanDraft({
   onReplan,
   onSaveDraft,
   onEditPhase,
+  onRemoveRaid,
 }: PlanDraftProps) {
   const phases = structure.structure?.phases ?? [];
   const sagaName = structure.structure?.name ?? 'New Saga';
@@ -193,6 +230,19 @@ export function PlanDraft({
           phases.flatMap((p) => p.raids).reduce((sum, r) => sum + r.confidence, 0) / totalRaids,
         )
       : 0;
+
+  const [draftSavedFeedback, setDraftSavedFeedback] = useState(false);
+
+  useEffect(() => {
+    if (!draftSavedFeedback) return;
+    const id = setTimeout(() => setDraftSavedFeedback(false), 2000);
+    return () => clearTimeout(id);
+  }, [draftSavedFeedback]);
+
+  function handleSaveDraft() {
+    onSaveDraft?.();
+    setDraftSavedFeedback(true);
+  }
 
   return (
     <div className="niuu-flex niuu-flex-col niuu-gap-4">
@@ -255,6 +305,7 @@ export function PlanDraft({
             phase={phase}
             phaseIndex={idx}
             onSave={(name) => onEditPhase(idx, name)}
+            onRemoveRaid={onRemoveRaid ? (ri) => onRemoveRaid(idx, ri) : undefined}
           />
         ))}
       </div>
@@ -286,14 +337,25 @@ export function PlanDraft({
         )}
         <span className="niuu-flex-1" />
         {onSaveDraft && (
-          <button
-            type="button"
-            onClick={onSaveDraft}
-            disabled={loading}
-            className="niuu-rounded-md niuu-px-4 niuu-py-2 niuu-text-sm niuu-font-medium niuu-text-text-secondary niuu-border niuu-border-border hover:niuu-bg-bg-elevated disabled:niuu-opacity-40 niuu-transition-colors"
-          >
-            Save as draft
-          </button>
+          <div className="niuu-flex niuu-items-center niuu-gap-2">
+            {draftSavedFeedback && (
+              <span
+                className="niuu-text-xs niuu-text-text-muted niuu-font-mono"
+                role="status"
+                aria-live="polite"
+              >
+                Draft saved (local only)
+              </span>
+            )}
+            <button
+              type="button"
+              onClick={handleSaveDraft}
+              disabled={loading}
+              className="niuu-rounded-md niuu-px-4 niuu-py-2 niuu-text-sm niuu-font-medium niuu-text-text-secondary niuu-border niuu-border-border hover:niuu-bg-bg-elevated disabled:niuu-opacity-40 niuu-transition-colors"
+            >
+              Save as draft
+            </button>
+          </div>
         )}
         <button
           type="button"

--- a/web-next/packages/plugin-tyr/src/ui/PlanDraft.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/PlanDraft.tsx
@@ -8,12 +8,29 @@ function toLevel(value: number): ConfidenceLevel {
   return 'low';
 }
 
+const SIZE_CLASSES: Record<'S' | 'M' | 'L', string> = {
+  S: 'niuu-bg-accent-emerald/20 niuu-text-accent-emerald niuu-border-accent-emerald/30',
+  M: 'niuu-bg-accent-amber/20 niuu-text-accent-amber niuu-border-accent-amber/30',
+  L: 'niuu-bg-accent-orange/20 niuu-text-accent-orange niuu-border-accent-orange/30',
+};
+
+const RISK_KIND_CLASSES: Record<string, string> = {
+  blast: 'niuu-bg-critical/20 niuu-text-critical niuu-border-critical/30',
+  untested: 'niuu-bg-accent-amber/20 niuu-text-accent-amber niuu-border-accent-amber/30',
+};
+
+function getRiskKindClass(kind: string): string {
+  return RISK_KIND_CLASSES[kind] ?? 'niuu-bg-bg-elevated niuu-text-text-secondary niuu-border-border';
+}
+
 interface PlanDraftProps {
   structure: ExtractedStructure;
   loading: boolean;
   error: string | null;
   onApprove(): void;
   onBack(): void;
+  onReplan?(): void;
+  onSaveDraft?(): void;
   onEditPhase(phaseIndex: number, name: string): void;
 }
 
@@ -105,17 +122,34 @@ function PhaseEditor({ phase, phaseIndex, onSave }: PhaseEditorProps) {
           {phase.raids.map((raid, ri) => (
             <li
               key={ri}
-              className="niuu-rounded niuu-bg-bg-tertiary niuu-px-3 niuu-py-2 niuu-flex niuu-flex-col niuu-gap-0.5"
+              className="niuu-rounded niuu-bg-bg-tertiary niuu-px-3 niuu-py-2 niuu-grid niuu-items-center niuu-gap-x-3 niuu-gap-y-0"
+              style={{ gridTemplateColumns: 'auto 1fr auto' }}
             >
-              <span className="niuu-text-xs niuu-font-medium niuu-text-text-primary">
-                {raid.name}
+              <span
+                className="niuu-w-6 niuu-h-6 niuu-rounded-full niuu-bg-bg-elevated niuu-flex niuu-items-center niuu-justify-center niuu-text-xs niuu-text-text-muted niuu-flex-shrink-0"
+                title={raid.persona ?? 'raven'}
+                aria-label={`persona: ${raid.persona ?? 'raven'}`}
+              >
+                {raid.persona ? raid.persona.charAt(0).toUpperCase() : 'ᚱ'}
               </span>
-              {raid.description && (
-                <span className="niuu-text-xs niuu-text-text-muted">{raid.description}</span>
+              <div className="niuu-flex niuu-flex-col niuu-gap-0.5">
+                <span className="niuu-text-xs niuu-font-medium niuu-text-text-primary">
+                  {raid.name}
+                </span>
+                <span className="niuu-text-xs niuu-text-text-muted niuu-font-mono">
+                  {[raid.phase, raid.persona, raid.estimateHours ? `est ${raid.estimateHours}h` : null]
+                    .filter(Boolean)
+                    .join(' · ')}
+                  {!raid.phase && !raid.persona && `~${raid.estimateHours}h · ${raid.confidence}% confidence`}
+                </span>
+              </div>
+              {raid.size && (
+                <span
+                  className={`niuu-text-xs niuu-font-semibold niuu-rounded niuu-border niuu-px-1.5 niuu-py-0.5 ${SIZE_CLASSES[raid.size]}`}
+                >
+                  {raid.size}
+                </span>
               )}
-              <span className="niuu-text-xs niuu-text-text-muted">
-                ~{raid.estimateHours}h · {raid.confidence}% confidence
-              </span>
             </li>
           ))}
         </ul>
@@ -127,6 +161,8 @@ function PhaseEditor({ phase, phaseIndex, onSave }: PhaseEditorProps) {
 /**
  * Step 4 of the Plan wizard — review the decomposed saga structure with
  * per-phase edit buttons before approving.
+ *
+ * Includes: risk rows with kind badges, Re-plan button, and Save as draft button.
  */
 export function PlanDraft({
   structure,
@@ -134,10 +170,13 @@ export function PlanDraft({
   error,
   onApprove,
   onBack,
+  onReplan,
+  onSaveDraft,
   onEditPhase,
 }: PlanDraftProps) {
   const phases = structure.structure?.phases ?? [];
   const sagaName = structure.structure?.name ?? 'New Saga';
+  const risks = structure.structure?.risks ?? [];
 
   const totalRaids = phases.reduce((sum, p) => sum + p.raids.length, 0);
   const avgConfidence =
@@ -172,6 +211,28 @@ export function PlanDraft({
         )}
       </div>
 
+      {risks.length > 0 && (
+        <div className="niuu-flex niuu-flex-col niuu-gap-2">
+          <p className="niuu-text-xs niuu-font-semibold niuu-text-text-muted niuu-uppercase niuu-tracking-wider niuu-font-mono">
+            Risks flagged by planning raid
+          </p>
+          <ul className="niuu-flex niuu-flex-col niuu-gap-2 niuu-list-none niuu-p-0 niuu-m-0">
+            {risks.map((risk, i) => (
+              <li key={i} className="niuu-flex niuu-items-start niuu-gap-2 niuu-text-sm">
+                <span
+                  className={`niuu-flex-shrink-0 niuu-text-xs niuu-font-semibold niuu-rounded niuu-border niuu-px-1.5 niuu-py-0.5 niuu-uppercase niuu-font-mono ${getRiskKindClass(risk.kind)}`}
+                >
+                  {risk.kind}
+                </span>
+                <span className="niuu-text-xs niuu-text-text-secondary niuu-leading-relaxed">
+                  {risk.message}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
       {phases.length === 0 && (
         <p className="niuu-text-sm niuu-text-text-muted niuu-italic">
           No phases extracted — the raven couldn&apos;t decompose this goal. Try going back and
@@ -196,7 +257,7 @@ export function PlanDraft({
         </p>
       )}
 
-      <div className="niuu-flex niuu-justify-between">
+      <div className="niuu-flex niuu-items-center niuu-gap-2">
         <button
           type="button"
           onClick={onBack}
@@ -205,6 +266,27 @@ export function PlanDraft({
         >
           ← Back
         </button>
+        {onReplan && (
+          <button
+            type="button"
+            onClick={onReplan}
+            disabled={loading}
+            className="niuu-rounded-md niuu-px-4 niuu-py-2 niuu-text-sm niuu-font-medium niuu-text-text-secondary niuu-border niuu-border-border hover:niuu-bg-bg-elevated disabled:niuu-opacity-40 niuu-transition-colors"
+          >
+            ↻ Re-plan
+          </button>
+        )}
+        <span className="niuu-flex-1" />
+        {onSaveDraft && (
+          <button
+            type="button"
+            onClick={onSaveDraft}
+            disabled={loading}
+            className="niuu-rounded-md niuu-px-4 niuu-py-2 niuu-text-sm niuu-font-medium niuu-text-text-secondary niuu-border niuu-border-border hover:niuu-bg-bg-elevated disabled:niuu-opacity-40 niuu-transition-colors"
+          >
+            Save as draft
+          </button>
+        )}
         <button
           type="button"
           onClick={onApprove}

--- a/web-next/packages/plugin-tyr/src/ui/PlanDraft.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/PlanDraft.tsx
@@ -20,7 +20,9 @@ const RISK_KIND_CLASSES: Record<string, string> = {
 };
 
 function getRiskKindClass(kind: string): string {
-  return RISK_KIND_CLASSES[kind] ?? 'niuu-bg-bg-elevated niuu-text-text-secondary niuu-border-border';
+  return (
+    RISK_KIND_CLASSES[kind] ?? 'niuu-bg-bg-elevated niuu-text-text-secondary niuu-border-border'
+  );
 }
 
 interface PlanDraftProps {
@@ -137,10 +139,16 @@ function PhaseEditor({ phase, phaseIndex, onSave }: PhaseEditorProps) {
                   {raid.name}
                 </span>
                 <span className="niuu-text-xs niuu-text-text-muted niuu-font-mono">
-                  {[raid.phase, raid.persona, raid.estimateHours ? `est ${raid.estimateHours}h` : null]
+                  {[
+                    raid.phase,
+                    raid.persona,
+                    raid.estimateHours ? `est ${raid.estimateHours}h` : null,
+                  ]
                     .filter(Boolean)
                     .join(' · ')}
-                  {!raid.phase && !raid.persona && `~${raid.estimateHours}h · ${raid.confidence}% confidence`}
+                  {!raid.phase &&
+                    !raid.persona &&
+                    `~${raid.estimateHours}h · ${raid.confidence}% confidence`}
                 </span>
               </div>
               {raid.size && (

--- a/web-next/packages/plugin-tyr/src/ui/PlanPrompt.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/PlanPrompt.tsx
@@ -6,6 +6,21 @@ interface PlanPromptProps {
   error: string | null;
 }
 
+const HINT_CHIPS = [
+  {
+    label: '+ Example: subscription validation',
+    text: 'NIU-214: subscription validation — surface dead-letter warnings when a persona in a workflow has no downstream consumer for any of its produced event types.',
+  },
+  {
+    label: '+ Example: simple endpoint',
+    text: 'Add a health check endpoint to the Tyr service that reports queue depth and active raid counts.',
+  },
+  {
+    label: '+ Example: OIDC auth',
+    text: 'Add OIDC authentication with Keycloak, including silent token refresh and PAT support for headless agents.',
+  },
+];
+
 /**
  * Step 1 of the Plan wizard — capture the human‐language goal and target repo.
  */
@@ -58,6 +73,18 @@ export function PlanPrompt({ onSubmit, loading, error }: PlanPromptProps) {
           aria-describedby={error ? 'plan-prompt-error' : undefined}
           className="niuu-w-full niuu-rounded-md niuu-border niuu-border-border niuu-bg-bg-secondary niuu-px-3 niuu-py-2 niuu-text-sm niuu-text-text-primary niuu-placeholder-text-muted niuu-resize-y focus:niuu-outline-none focus:niuu-ring-2 focus:niuu-ring-brand-500/40"
         />
+        <div className="niuu-flex niuu-flex-wrap niuu-gap-2 niuu-mt-2" aria-label="Example prompts">
+          {HINT_CHIPS.map((chip) => (
+            <button
+              key={chip.label}
+              type="button"
+              onClick={() => setPrompt(chip.text)}
+              className="niuu-rounded-full niuu-bg-bg-elevated niuu-border niuu-border-border niuu-px-3 niuu-py-1 niuu-text-xs niuu-text-text-secondary hover:niuu-bg-bg-tertiary hover:niuu-text-text-primary niuu-transition-colors"
+            >
+              {chip.label}
+            </button>
+          ))}
+        </div>
       </div>
 
       <div className="niuu-flex niuu-flex-col niuu-gap-1">

--- a/web-next/packages/plugin-tyr/src/ui/PlanQuestions.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/PlanQuestions.tsx
@@ -1,19 +1,32 @@
 import { useState } from 'react';
 import type { ClarifyingQuestion } from '../domain/plan';
+import type { Workflow } from '../domain/workflow';
 
 interface PlanQuestionsProps {
   questions: ClarifyingQuestion[];
   initialAnswers?: Record<string, string>;
+  /** The user's original prompt — shown as a "YOUR BRIEF" quote card. */
+  prompt?: string;
+  /**
+   * Workflow templates for the workflow-kind question picker.
+   * Fetched by the parent (PlanWizard) and passed down to keep this component service-free.
+   */
+  workflows?: Workflow[];
   onSubmit(answers: Record<string, string>): void;
   onBack(): void;
 }
 
 /**
  * Step 2 of the Plan wizard — answer clarifying questions from the planning raven.
+ *
+ * Renders a "YOUR BRIEF" quote card above the questions, and supports a special
+ * `kind: 'workflow'` question type that renders a 3-column template picker grid.
  */
 export function PlanQuestions({
   questions,
   initialAnswers = {},
+  prompt,
+  workflows = [],
   onSubmit,
   onBack,
 }: PlanQuestionsProps) {
@@ -44,6 +57,18 @@ export function PlanQuestions({
         </p>
       </div>
 
+      {prompt && (
+        <div
+          className="niuu-rounded-md niuu-border niuu-border-border niuu-bg-bg-elevated niuu-px-4 niuu-py-3"
+          aria-label="Your brief"
+        >
+          <p className="niuu-text-xs niuu-font-semibold niuu-text-text-muted niuu-uppercase niuu-tracking-wider niuu-font-mono niuu-mb-1">
+            Your Brief
+          </p>
+          <p className="niuu-text-xs niuu-text-text-secondary niuu-leading-relaxed">{prompt}</p>
+        </div>
+      )}
+
       {questions.length === 0 && (
         <p className="niuu-text-sm niuu-text-text-muted niuu-italic">
           No clarifying questions — you can proceed directly.
@@ -65,15 +90,54 @@ export function PlanQuestions({
                 {q.hint}
               </p>
             )}
-            <input
-              id={`q-${q.id}`}
-              type="text"
-              value={answers[q.id] ?? ''}
-              onChange={(e) => handleChange(q.id, e.target.value)}
-              aria-describedby={q.hint ? `q-${q.id}-hint` : undefined}
-              placeholder="Your answer (optional)"
-              className="niuu-w-full niuu-rounded-md niuu-border niuu-border-border niuu-bg-bg-secondary niuu-px-3 niuu-py-2 niuu-text-sm niuu-text-text-primary niuu-placeholder-text-muted focus:niuu-outline-none focus:niuu-ring-2 focus:niuu-ring-brand-500/40"
-            />
+            {q.kind === 'workflow' ? (
+              <div
+                role="group"
+                aria-label="Workflow template picker"
+                className="niuu-grid niuu-grid-cols-3 niuu-gap-2 niuu-mt-1"
+              >
+                {workflows.map((wf) => {
+                  const stageCount = wf.nodes.filter((n) => n.kind === 'stage').length;
+                  const isSelected = answers[q.id] === wf.id;
+                  return (
+                    <button
+                      key={wf.id}
+                      type="button"
+                      onClick={() => handleChange(q.id, wf.id)}
+                      aria-pressed={isSelected}
+                      className={[
+                        'niuu-rounded-md niuu-border niuu-p-3 niuu-text-left niuu-transition-colors',
+                        isSelected
+                          ? 'niuu-border-brand-500 niuu-bg-brand-500/10'
+                          : 'niuu-border-border niuu-bg-bg-secondary hover:niuu-bg-bg-elevated',
+                      ].join(' ')}
+                    >
+                      <div className="niuu-text-xs niuu-font-medium niuu-text-text-primary">
+                        {wf.name}
+                      </div>
+                      <div className="niuu-text-xs niuu-text-text-muted niuu-font-mono niuu-mt-1">
+                        {stageCount} stage{stageCount !== 1 ? 's' : ''}
+                      </div>
+                    </button>
+                  );
+                })}
+                {workflows.length === 0 && (
+                  <p className="niuu-col-span-3 niuu-text-xs niuu-text-text-muted niuu-italic">
+                    No workflow templates available.
+                  </p>
+                )}
+              </div>
+            ) : (
+              <input
+                id={`q-${q.id}`}
+                type="text"
+                value={answers[q.id] ?? ''}
+                onChange={(e) => handleChange(q.id, e.target.value)}
+                aria-describedby={q.hint ? `q-${q.id}-hint` : undefined}
+                placeholder="Your answer (optional)"
+                className="niuu-w-full niuu-rounded-md niuu-border niuu-border-border niuu-bg-bg-secondary niuu-px-3 niuu-py-2 niuu-text-sm niuu-text-text-primary niuu-placeholder-text-muted focus:niuu-outline-none focus:niuu-ring-2 focus:niuu-ring-brand-500/40"
+              />
+            )}
           </li>
         ))}
       </ol>

--- a/web-next/packages/plugin-tyr/src/ui/PlanRaiding.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/PlanRaiding.tsx
@@ -62,6 +62,22 @@ export function PlanRaiding({ error, onBack }: PlanRaidingProps) {
           />
         ))}
       </div>
+
+      <div
+        aria-live="polite"
+        className="niuu-flex niuu-flex-col niuu-gap-1 niuu-text-center"
+        aria-label="Raven activity"
+      >
+        <p className="niuu-text-xs niuu-text-text-muted niuu-font-mono">
+          ᚱ · decomposer — analyzing brief
+        </p>
+        <p className="niuu-text-xs niuu-text-text-muted niuu-font-mono">
+          ᚱ · investigator — probing repo for affected modules
+        </p>
+        <p className="niuu-text-xs niuu-text-text-muted niuu-font-mono">
+          ᚱ · mimir-indexer — pulling in prior-art sagas
+        </p>
+      </div>
     </div>
   );
 }

--- a/web-next/packages/plugin-tyr/src/ui/PlanWizard.test.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/PlanWizard.test.tsx
@@ -627,6 +627,73 @@ describe('PlanDraft', () => {
     );
     expect(screen.getByText('M')).toBeInTheDocument();
   });
+
+  it('renders "Own saga" button for each raid (disabled stub)', () => {
+    render(
+      <PlanDraft
+        structure={MOCK_STRUCTURE}
+        loading={false}
+        error={null}
+        onApprove={vi.fn()}
+        onBack={vi.fn()}
+        onEditPhase={vi.fn()}
+      />,
+    );
+    const ownSagaButtons = screen.getAllByRole('button', { name: /promote raid .* to own saga/i });
+    expect(ownSagaButtons.length).toBeGreaterThan(0);
+    ownSagaButtons.forEach((btn) => expect(btn).toBeDisabled());
+  });
+
+  it('calls onRemoveRaid when × button clicked', () => {
+    const onRemoveRaid = vi.fn();
+    render(
+      <PlanDraft
+        structure={MOCK_STRUCTURE}
+        loading={false}
+        error={null}
+        onApprove={vi.fn()}
+        onBack={vi.fn()}
+        onEditPhase={vi.fn()}
+        onRemoveRaid={onRemoveRaid}
+      />,
+    );
+    const removeButtons = screen.getAllByRole('button', { name: /remove raid/i });
+    expect(removeButtons.length).toBeGreaterThan(0);
+    fireEvent.click(removeButtons[0]!);
+    expect(onRemoveRaid).toHaveBeenCalledWith(0, 0);
+  });
+
+  it('does not render remove buttons when onRemoveRaid not provided', () => {
+    render(
+      <PlanDraft
+        structure={MOCK_STRUCTURE}
+        loading={false}
+        error={null}
+        onApprove={vi.fn()}
+        onBack={vi.fn()}
+        onEditPhase={vi.fn()}
+      />,
+    );
+    expect(screen.queryAllByRole('button', { name: /remove raid/i })).toHaveLength(0);
+  });
+
+  it('shows "Draft saved (local only)" feedback after clicking save as draft', async () => {
+    render(
+      <PlanDraft
+        structure={MOCK_STRUCTURE}
+        loading={false}
+        error={null}
+        onApprove={vi.fn()}
+        onBack={vi.fn()}
+        onSaveDraft={vi.fn()}
+        onEditPhase={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /save as draft/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/draft saved \(local only\)/i)).toBeInTheDocument(),
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/web-next/packages/plugin-tyr/src/ui/PlanWizard.test.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/PlanWizard.test.tsx
@@ -9,7 +9,13 @@ import { PlanQuestions } from './PlanQuestions';
 import { PlanRaiding } from './PlanRaiding';
 import { PlanDraft } from './PlanDraft';
 import { PlanApproved } from './PlanApproved';
-import type { ITyrService, IWorkflowService, ExtractedStructure, PlanSession, PlanRisk } from '../ports';
+import type {
+  ITyrService,
+  IWorkflowService,
+  ExtractedStructure,
+  PlanSession,
+  PlanRisk,
+} from '../ports';
 import type { Saga } from '../domain/saga';
 import type { Workflow } from '../domain/workflow';
 
@@ -88,8 +94,22 @@ const MOCK_WORKFLOW: Workflow = {
   id: 'wf-1',
   name: 'Ship',
   nodes: [
-    { id: 'n1', kind: 'stage', label: 'Build', raidId: null, personaIds: [], position: { x: 0, y: 0 } },
-    { id: 'n2', kind: 'stage', label: 'Test', raidId: null, personaIds: [], position: { x: 100, y: 0 } },
+    {
+      id: 'n1',
+      kind: 'stage',
+      label: 'Build',
+      raidId: null,
+      personaIds: [],
+      position: { x: 0, y: 0 },
+    },
+    {
+      id: 'n2',
+      kind: 'stage',
+      label: 'Test',
+      raidId: null,
+      personaIds: [],
+      position: { x: 100, y: 0 },
+    },
     { id: 'n3', kind: 'gate', label: 'Review', condition: 'Approved', position: { x: 200, y: 0 } },
   ],
   edges: [],
@@ -404,9 +424,7 @@ describe('PlanDraft', () => {
     );
     expect(screen.getByText('blast')).toBeInTheDocument();
     expect(screen.getByText('untested')).toBeInTheDocument();
-    expect(
-      screen.getByText(/touches dispatch path/i),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/touches dispatch path/i)).toBeInTheDocument();
   });
 
   it('does not render risks section when no risks', () => {

--- a/web-next/packages/plugin-tyr/src/ui/PlanWizard.test.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/PlanWizard.test.tsx
@@ -9,8 +9,9 @@ import { PlanQuestions } from './PlanQuestions';
 import { PlanRaiding } from './PlanRaiding';
 import { PlanDraft } from './PlanDraft';
 import { PlanApproved } from './PlanApproved';
-import type { ITyrService, ExtractedStructure, PlanSession } from '../ports';
+import type { ITyrService, IWorkflowService, ExtractedStructure, PlanSession, PlanRisk } from '../ports';
 import type { Saga } from '../domain/saga';
+import type { Workflow } from '../domain/workflow';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -24,6 +25,11 @@ const MOCK_SESSION: PlanSession = {
     { id: 'q2', question: 'Base branch?' },
   ],
 };
+
+const MOCK_RISKS: PlanRisk[] = [
+  { kind: 'blast', message: 'Touches dispatch path — ship behind flag.' },
+  { kind: 'untested', message: 'No existing tests for subscription graph.' },
+];
 
 const MOCK_STRUCTURE: ExtractedStructure = {
   found: true,
@@ -40,6 +46,9 @@ const MOCK_STRUCTURE: ExtractedStructure = {
             declaredFiles: ['src/auth.ts'],
             estimateHours: 8,
             confidence: 85,
+            size: 'M',
+            persona: 'coding-agent',
+            phase: 'Build',
           },
         ],
       },
@@ -57,6 +66,7 @@ const MOCK_STRUCTURE: ExtractedStructure = {
         ],
       },
     ],
+    risks: MOCK_RISKS,
   },
 };
 
@@ -74,6 +84,17 @@ const MOCK_SAGA: Saga = {
   phaseSummary: { total: 2, completed: 0 },
 };
 
+const MOCK_WORKFLOW: Workflow = {
+  id: 'wf-1',
+  name: 'Ship',
+  nodes: [
+    { id: 'n1', kind: 'stage', label: 'Build', raidId: null, personaIds: [], position: { x: 0, y: 0 } },
+    { id: 'n2', kind: 'stage', label: 'Test', raidId: null, personaIds: [], position: { x: 100, y: 0 } },
+    { id: 'n3', kind: 'gate', label: 'Review', condition: 'Approved', position: { x: 200, y: 0 } },
+  ],
+  edges: [],
+};
+
 function makeSvc(overrides: Partial<ITyrService> = {}): Partial<ITyrService> {
   return {
     getSagas: vi.fn().mockResolvedValue([]),
@@ -88,12 +109,25 @@ function makeSvc(overrides: Partial<ITyrService> = {}): Partial<ITyrService> {
   };
 }
 
-function wrap(svc: Partial<ITyrService>) {
+function makeWorkflowSvc(overrides: Partial<IWorkflowService> = {}): Partial<IWorkflowService> {
+  return {
+    listWorkflows: vi.fn().mockResolvedValue([MOCK_WORKFLOW]),
+    getWorkflow: vi.fn().mockResolvedValue(null),
+    saveWorkflow: vi.fn(),
+    deleteWorkflow: vi.fn(),
+    ...overrides,
+  };
+}
+
+function wrap(svc: Partial<ITyrService>, workflowSvc?: Partial<IWorkflowService>) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wfSvc = workflowSvc ?? makeWorkflowSvc();
   return function Wrapper({ children }: { children: React.ReactNode }) {
     return (
       <QueryClientProvider client={client}>
-        <ServicesProvider services={{ tyr: svc }}>{children}</ServicesProvider>
+        <ServicesProvider services={{ tyr: svc, 'tyr.workflows': wfSvc }}>
+          {children}
+        </ServicesProvider>
       </QueryClientProvider>
     );
   };
@@ -142,6 +176,22 @@ describe('PlanPrompt', () => {
     render(<PlanPrompt onSubmit={vi.fn()} loading={false} error="Service unavailable" />);
     expect(screen.getByRole('alert')).toHaveTextContent('Service unavailable');
   });
+
+  it('renders hint chips', () => {
+    render(<PlanPrompt onSubmit={vi.fn()} loading={false} error={null} />);
+    expect(
+      screen.getByRole('button', { name: /example: subscription validation/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /example: simple endpoint/i })).toBeInTheDocument();
+  });
+
+  it('clicking a hint chip fills the textarea', async () => {
+    render(<PlanPrompt onSubmit={vi.fn()} loading={false} error={null} />);
+    const chip = screen.getByRole('button', { name: /example: simple endpoint/i });
+    fireEvent.click(chip);
+    const textarea = screen.getByRole('textbox', { name: /goal description/i });
+    expect((textarea as HTMLTextAreaElement).value).toMatch(/health check endpoint/i);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -186,6 +236,73 @@ describe('PlanQuestions', () => {
     render(<PlanQuestions questions={[]} onSubmit={vi.fn()} onBack={vi.fn()} />);
     expect(screen.getByText(/no clarifying questions/i)).toBeInTheDocument();
   });
+
+  it('shows YOUR BRIEF quote card when prompt is provided', () => {
+    render(
+      <PlanQuestions
+        questions={questions}
+        prompt="Build the auth module"
+        onSubmit={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+    expect(screen.getByLabelText(/your brief/i)).toBeInTheDocument();
+    expect(screen.getByText('Build the auth module')).toBeInTheDocument();
+  });
+
+  it('does not render YOUR BRIEF card when no prompt', () => {
+    render(<PlanQuestions questions={questions} onSubmit={vi.fn()} onBack={vi.fn()} />);
+    expect(screen.queryByLabelText(/your brief/i)).not.toBeInTheDocument();
+  });
+
+  it('renders workflow picker for workflow-kind questions', () => {
+    const workflowQuestions = [
+      { id: 'wf', question: 'Apply which workflow?', kind: 'workflow' as const },
+    ];
+    render(
+      <PlanQuestions
+        questions={workflowQuestions}
+        workflows={[MOCK_WORKFLOW]}
+        onSubmit={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('group', { name: /workflow template picker/i })).toBeInTheDocument();
+    expect(screen.getByText('Ship')).toBeInTheDocument();
+    expect(screen.getByText('2 stages')).toBeInTheDocument();
+  });
+
+  it('selecting a workflow template sets the answer', () => {
+    const workflowQuestions = [
+      { id: 'wf', question: 'Apply which workflow?', kind: 'workflow' as const },
+    ];
+    render(
+      <PlanQuestions
+        questions={workflowQuestions}
+        workflows={[MOCK_WORKFLOW]}
+        onSubmit={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+    const wfButton = screen.getByRole('button', { name: /ship/i });
+    fireEvent.click(wfButton);
+    expect(wfButton).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('shows empty workflow message when no templates', () => {
+    const workflowQuestions = [
+      { id: 'wf', question: 'Apply which workflow?', kind: 'workflow' as const },
+    ];
+    render(
+      <PlanQuestions
+        questions={workflowQuestions}
+        workflows={[]}
+        onSubmit={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/no workflow templates/i)).toBeInTheDocument();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -198,6 +315,13 @@ describe('PlanRaiding', () => {
     // Use aria-label to disambiguate from StateDot's inner role="status"
     expect(screen.getByLabelText(/decomposing plan/i)).toBeInTheDocument();
     expect(screen.getByText(/Ravens are raiding/i)).toBeInTheDocument();
+  });
+
+  it('shows raven activity lines', () => {
+    render(<PlanRaiding error={null} onBack={vi.fn()} />);
+    expect(screen.getByText(/decomposer — analyzing brief/i)).toBeInTheDocument();
+    expect(screen.getByText(/investigator — probing repo/i)).toBeInTheDocument();
+    expect(screen.getByText(/mimir-indexer — pulling in prior-art/i)).toBeInTheDocument();
   });
 
   it('shows error state when error is present', () => {
@@ -267,6 +391,42 @@ describe('PlanDraft', () => {
     expect(screen.getByText('Scaffold OIDC')).toBeInTheDocument();
   });
 
+  it('renders risk kind badges', () => {
+    render(
+      <PlanDraft
+        structure={MOCK_STRUCTURE}
+        loading={false}
+        error={null}
+        onApprove={vi.fn()}
+        onBack={vi.fn()}
+        onEditPhase={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('blast')).toBeInTheDocument();
+    expect(screen.getByText('untested')).toBeInTheDocument();
+    expect(
+      screen.getByText(/touches dispatch path/i),
+    ).toBeInTheDocument();
+  });
+
+  it('does not render risks section when no risks', () => {
+    const noRisksStructure: ExtractedStructure = {
+      found: true,
+      structure: { name: 'Test', phases: [], risks: [] },
+    };
+    render(
+      <PlanDraft
+        structure={noRisksStructure}
+        loading={false}
+        error={null}
+        onApprove={vi.fn()}
+        onBack={vi.fn()}
+        onEditPhase={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText(/risks flagged/i)).not.toBeInTheDocument();
+  });
+
   it('calls onApprove when approve button clicked', async () => {
     const onApprove = vi.fn();
     render(
@@ -295,8 +455,56 @@ describe('PlanDraft', () => {
         onEditPhase={vi.fn()}
       />,
     );
-    fireEvent.click(screen.getByRole('button', { name: /back/i }));
+    fireEvent.click(screen.getByRole('button', { name: /← back/i }));
     expect(onBack).toHaveBeenCalled();
+  });
+
+  it('calls onReplan when re-plan button clicked', () => {
+    const onReplan = vi.fn();
+    render(
+      <PlanDraft
+        structure={MOCK_STRUCTURE}
+        loading={false}
+        error={null}
+        onApprove={vi.fn()}
+        onBack={vi.fn()}
+        onReplan={onReplan}
+        onEditPhase={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /re-plan/i }));
+    expect(onReplan).toHaveBeenCalled();
+  });
+
+  it('calls onSaveDraft when save as draft button clicked', () => {
+    const onSaveDraft = vi.fn();
+    render(
+      <PlanDraft
+        structure={MOCK_STRUCTURE}
+        loading={false}
+        error={null}
+        onApprove={vi.fn()}
+        onBack={vi.fn()}
+        onSaveDraft={onSaveDraft}
+        onEditPhase={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /save as draft/i }));
+    expect(onSaveDraft).toHaveBeenCalled();
+  });
+
+  it('does not render Re-plan button when onReplan not provided', () => {
+    render(
+      <PlanDraft
+        structure={MOCK_STRUCTURE}
+        loading={false}
+        error={null}
+        onApprove={vi.fn()}
+        onBack={vi.fn()}
+        onEditPhase={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: /re-plan/i })).not.toBeInTheDocument();
   });
 
   it('allows editing a phase name', async () => {
@@ -387,6 +595,20 @@ describe('PlanDraft', () => {
     fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
     expect(onEditPhase).not.toHaveBeenCalled();
   });
+
+  it('renders size pill for raids with size', () => {
+    render(
+      <PlanDraft
+        structure={MOCK_STRUCTURE}
+        loading={false}
+        error={null}
+        onApprove={vi.fn()}
+        onBack={vi.fn()}
+        onEditPhase={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('M')).toBeInTheDocument();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -433,6 +655,13 @@ describe('PlanWizard integration', () => {
     expect(screen.getByText('Describe your goal')).toBeInTheDocument();
   });
 
+  it('shows hint chips on the prompt step', () => {
+    render(<PlanWizard />, { wrapper: wrap(makeSvc()) });
+    expect(
+      screen.getByRole('button', { name: /example: subscription validation/i }),
+    ).toBeInTheDocument();
+  });
+
   it('shows the step dots navigation', () => {
     render(<PlanWizard />, { wrapper: wrap(makeSvc()) });
     expect(screen.getByRole('navigation', { name: /plan wizard steps/i })).toBeInTheDocument();
@@ -457,6 +686,21 @@ describe('PlanWizard integration', () => {
     expect(screen.getByText('Which repos?')).toBeInTheDocument();
   });
 
+  it('shows YOUR BRIEF card in questions step', async () => {
+    const svc = makeSvc();
+    render(<PlanWizard />, { wrapper: wrap(svc) });
+
+    await userEvent.type(
+      screen.getByRole('textbox', { name: /goal description/i }),
+      'Build auth module',
+    );
+    fireEvent.submit(screen.getByRole('form', { name: /plan prompt form/i }));
+
+    await waitFor(() => expect(screen.getByText('Clarify your plan')).toBeInTheDocument());
+    expect(screen.getByLabelText(/your brief/i)).toBeInTheDocument();
+    expect(screen.getByText('Build auth module')).toBeInTheDocument();
+  });
+
   it('advances to raiding step after submitting answers', async () => {
     const svc = makeSvc();
     render(<PlanWizard />, { wrapper: wrap(svc) });
@@ -473,6 +717,25 @@ describe('PlanWizard integration', () => {
     fireEvent.submit(screen.getByRole('form', { name: /clarifying questions form/i }));
 
     await waitFor(() => expect(screen.getByLabelText(/decomposing plan/i)).toBeInTheDocument());
+  });
+
+  it('raiding step shows raven activity lines', async () => {
+    const svc = makeSvc({
+      decompose: vi.fn(() => new Promise(() => {})), // never resolves
+      extractStructure: vi.fn().mockResolvedValue(MOCK_STRUCTURE),
+    });
+    render(<PlanWizard />, { wrapper: wrap(svc) });
+
+    await userEvent.type(
+      screen.getByRole('textbox', { name: /goal description/i }),
+      'Build auth module',
+    );
+    fireEvent.submit(screen.getByRole('form', { name: /plan prompt form/i }));
+    await waitFor(() => expect(screen.getByText('Clarify your plan')).toBeInTheDocument());
+    fireEvent.submit(screen.getByRole('form', { name: /clarifying questions form/i }));
+
+    await waitFor(() => expect(screen.getByLabelText(/decomposing plan/i)).toBeInTheDocument());
+    expect(screen.getByText(/decomposer — analyzing brief/i)).toBeInTheDocument();
   });
 
   it('auto-advances to draft after decomposition', async () => {
@@ -493,6 +756,69 @@ describe('PlanWizard integration', () => {
       timeout: 3000,
     });
     expect(screen.getByText('Auth Rewrite')).toBeInTheDocument();
+  });
+
+  it('draft shows risk kind badges', async () => {
+    const svc = makeSvc();
+    render(<PlanWizard />, { wrapper: wrap(svc) });
+
+    await userEvent.type(
+      screen.getByRole('textbox', { name: /goal description/i }),
+      'Build auth module',
+    );
+    fireEvent.submit(screen.getByRole('form', { name: /plan prompt form/i }));
+    await waitFor(() => expect(screen.getByText('Clarify your plan')).toBeInTheDocument());
+    fireEvent.submit(screen.getByRole('form', { name: /clarifying questions form/i }));
+    await waitFor(() => expect(screen.getByText('Review your plan')).toBeInTheDocument(), {
+      timeout: 3000,
+    });
+
+    expect(screen.getByText('blast')).toBeInTheDocument();
+    expect(screen.getByText('untested')).toBeInTheDocument();
+  });
+
+  it('draft shows Re-plan and Save as draft buttons', async () => {
+    const svc = makeSvc();
+    render(<PlanWizard />, { wrapper: wrap(svc) });
+
+    await userEvent.type(
+      screen.getByRole('textbox', { name: /goal description/i }),
+      'Build auth module',
+    );
+    fireEvent.submit(screen.getByRole('form', { name: /plan prompt form/i }));
+    await waitFor(() => expect(screen.getByText('Clarify your plan')).toBeInTheDocument());
+    fireEvent.submit(screen.getByRole('form', { name: /clarifying questions form/i }));
+    await waitFor(() => expect(screen.getByText('Review your plan')).toBeInTheDocument(), {
+      timeout: 3000,
+    });
+
+    expect(screen.getByRole('button', { name: /re-plan/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /save as draft/i })).toBeInTheDocument();
+  });
+
+  it('re-plan button re-runs decomposition', async () => {
+    const svc = makeSvc();
+    render(<PlanWizard />, { wrapper: wrap(svc) });
+
+    await userEvent.type(
+      screen.getByRole('textbox', { name: /goal description/i }),
+      'Build auth module',
+    );
+    fireEvent.submit(screen.getByRole('form', { name: /plan prompt form/i }));
+    await waitFor(() => expect(screen.getByText('Clarify your plan')).toBeInTheDocument());
+    fireEvent.submit(screen.getByRole('form', { name: /clarifying questions form/i }));
+    await waitFor(() => expect(screen.getByText('Review your plan')).toBeInTheDocument(), {
+      timeout: 3000,
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /re-plan/i }));
+
+    // Should re-enter raiding step then come back to draft
+    await waitFor(() => expect(screen.getByText('Review your plan')).toBeInTheDocument(), {
+      timeout: 3000,
+    });
+    // decompose was called twice (once initially, once after re-plan)
+    expect(svc.decompose).toHaveBeenCalledTimes(2);
   });
 
   it('reaches approved step after full flow', async () => {

--- a/web-next/packages/plugin-tyr/src/ui/PlanWizard.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/PlanWizard.tsx
@@ -2,6 +2,7 @@ import { Rune } from '@niuulabs/ui';
 import { PLAN_STEPS } from '../domain/plan';
 import { StepDots } from './StepDots';
 import { usePlanWizard } from './usePlanWizard';
+import { useWorkflows } from './useWorkflows';
 import { PlanPrompt } from './PlanPrompt';
 import { PlanQuestions } from './PlanQuestions';
 import { PlanRaiding } from './PlanRaiding';
@@ -18,8 +19,9 @@ import { PlanGuidanceRail } from './PlanGuidanceRail';
  *         Full-width on raiding and approved (content fills the width).
  */
 export function PlanWizard() {
-  const { state, submitPrompt, submitAnswers, approveDraft, editPhase, back, clearError } =
+  const { state, submitPrompt, submitAnswers, approveDraft, editPhase, back, clearError, replan, saveDraft } =
     usePlanWizard();
+  const { data: workflows = [] } = useWorkflows();
 
   function handleNewPlan() {
     // Navigate back to /tyr/plan to start fresh (the wizard unmounts and remounts)
@@ -51,6 +53,8 @@ export function PlanWizard() {
             <PlanQuestions
               questions={state.questions}
               initialAnswers={state.answers}
+              prompt={state.prompt}
+              workflows={workflows}
               onSubmit={submitAnswers}
               onBack={() => {
                 clearError();
@@ -79,6 +83,8 @@ export function PlanWizard() {
                 clearError();
                 back();
               }}
+              onReplan={replan}
+              onSaveDraft={saveDraft}
               onEditPhase={editPhase}
             />
           )}

--- a/web-next/packages/plugin-tyr/src/ui/PlanWizard.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/PlanWizard.tsx
@@ -25,6 +25,7 @@ export function PlanWizard() {
     submitAnswers,
     approveDraft,
     editPhase,
+    removeRaid,
     back,
     clearError,
     replan,
@@ -95,6 +96,7 @@ export function PlanWizard() {
               onReplan={replan}
               onSaveDraft={saveDraft}
               onEditPhase={editPhase}
+              onRemoveRaid={removeRaid}
             />
           )}
 

--- a/web-next/packages/plugin-tyr/src/ui/PlanWizard.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/PlanWizard.tsx
@@ -19,8 +19,17 @@ import { PlanGuidanceRail } from './PlanGuidanceRail';
  *         Full-width on raiding and approved (content fills the width).
  */
 export function PlanWizard() {
-  const { state, submitPrompt, submitAnswers, approveDraft, editPhase, back, clearError, replan, saveDraft } =
-    usePlanWizard();
+  const {
+    state,
+    submitPrompt,
+    submitAnswers,
+    approveDraft,
+    editPhase,
+    back,
+    clearError,
+    replan,
+    saveDraft,
+  } = usePlanWizard();
   const { data: workflows = [] } = useWorkflows();
 
   function handleNewPlan() {

--- a/web-next/packages/plugin-tyr/src/ui/usePlanWizard.test.ts
+++ b/web-next/packages/plugin-tyr/src/ui/usePlanWizard.test.ts
@@ -308,3 +308,63 @@ describe('usePlanWizard — decompose error', () => {
     expect(result.current.state.step).toBe('raiding');
   });
 });
+
+describe('usePlanWizard — replan', () => {
+  async function advanceToDraft(svc: Partial<ITyrService>) {
+    const { result } = renderHook(() => usePlanWizard(), { wrapper: makeWrapper(svc) });
+    await act(async () => {
+      await result.current.submitPrompt('Build auth', 'repo');
+    });
+    act(() => result.current.submitAnswers({}));
+    await waitFor(() => expect(result.current.state.step).toBe('draft'));
+    return result;
+  }
+
+  it('transitions from draft back to raiding', async () => {
+    const svc = makeMockService();
+    const result = await advanceToDraft(svc);
+
+    act(() => result.current.replan());
+
+    expect(result.current.state.step).toBe('raiding');
+  });
+
+  it('clears structure and phases on replan', async () => {
+    const svc = makeMockService();
+    const result = await advanceToDraft(svc);
+
+    act(() => result.current.replan());
+
+    expect(result.current.state.structure).toBeNull();
+    expect(result.current.state.phases).toHaveLength(0);
+  });
+
+  it('auto-decomposes again after replan', async () => {
+    const svc = makeMockService();
+    const result = await advanceToDraft(svc);
+
+    act(() => result.current.replan());
+
+    await waitFor(() => expect(result.current.state.step).toBe('draft'));
+    // decompose called twice: once initially, once after replan
+    expect(svc.decompose).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('usePlanWizard — saveDraft', () => {
+  it('does not change step or clear state', async () => {
+    const svc = makeMockService();
+    const { result } = renderHook(() => usePlanWizard(), { wrapper: makeWrapper(svc) });
+
+    await act(async () => {
+      await result.current.submitPrompt('Build auth', 'repo');
+    });
+    act(() => result.current.submitAnswers({}));
+    await waitFor(() => expect(result.current.state.step).toBe('draft'));
+
+    const stepBefore = result.current.state.step;
+    act(() => result.current.saveDraft());
+
+    expect(result.current.state.step).toBe(stepBefore);
+  });
+});

--- a/web-next/packages/plugin-tyr/src/ui/usePlanWizard.test.ts
+++ b/web-next/packages/plugin-tyr/src/ui/usePlanWizard.test.ts
@@ -367,4 +367,19 @@ describe('usePlanWizard — saveDraft', () => {
 
     expect(result.current.state.step).toBe(stepBefore);
   });
+
+  it('sets draftSaved to true', async () => {
+    const svc = makeMockService();
+    const { result } = renderHook(() => usePlanWizard(), { wrapper: makeWrapper(svc) });
+
+    await act(async () => {
+      await result.current.submitPrompt('Build auth', 'repo');
+    });
+    act(() => result.current.submitAnswers({}));
+    await waitFor(() => expect(result.current.state.step).toBe('draft'));
+
+    expect(result.current.state.draftSaved).toBe(false);
+    act(() => result.current.saveDraft());
+    expect(result.current.state.draftSaved).toBe(true);
+  });
 });

--- a/web-next/packages/plugin-tyr/src/ui/usePlanWizard.ts
+++ b/web-next/packages/plugin-tyr/src/ui/usePlanWizard.ts
@@ -21,6 +21,8 @@ export interface PlanWizardState {
   saga: Saga | null;
   loading: boolean;
   error: string | null;
+  /** True after saveDraft() is called; records the intent for testing. */
+  draftSaved: boolean;
 }
 
 const initialState: PlanWizardState = {
@@ -35,6 +37,7 @@ const initialState: PlanWizardState = {
   saga: null,
   loading: false,
   error: null,
+  draftSaved: false,
 };
 
 // ---------------------------------------------------------------------------
@@ -52,6 +55,8 @@ type Action =
   | { type: 'BACK' }
   | { type: 'REPLAN' }
   | { type: 'EDIT_PHASE'; phaseIndex: number; name: string }
+  | { type: 'REMOVE_RAID'; phaseIndex: number; raidIndex: number }
+  | { type: 'SAVE_DRAFT' }
   | { type: 'CLEAR_ERROR' };
 
 // ---------------------------------------------------------------------------
@@ -152,6 +157,24 @@ function reducer(state: PlanWizardState, action: Action): PlanWizardState {
       };
     }
 
+    case 'REMOVE_RAID': {
+      if (!state.structure?.structure) return state;
+      const phases = state.structure.structure.phases.map((p, i) => {
+        if (i !== action.phaseIndex) return p;
+        return { ...p, raids: p.raids.filter((_, ri) => ri !== action.raidIndex) };
+      });
+      return {
+        ...state,
+        structure: {
+          ...state.structure,
+          structure: { ...state.structure.structure, phases },
+        },
+      };
+    }
+
+    case 'SAVE_DRAFT':
+      return { ...state, draftSaved: true };
+
     case 'CLEAR_ERROR':
       return { ...state, error: null };
 
@@ -210,11 +233,12 @@ export interface PlanWizardActions {
   submitAnswers(answers: Record<string, string>): void;
   approveDraft(): Promise<void>;
   editPhase(phaseIndex: number, name: string): void;
+  removeRaid(phaseIndex: number, raidIndex: number): void;
   back(): void;
   clearError(): void;
   /** Re-run decomposition with the same prompt and answers. */
   replan(): void;
-  /** Persist the current draft state without creating the saga. */
+  /** Persist the current draft state without creating the saga. No backend yet — dispatches SAVE_DRAFT. */
   saveDraft(): void;
 }
 
@@ -299,12 +323,17 @@ export function usePlanWizard(): { state: PlanWizardState } & PlanWizardActions 
     dispatch({ type: 'CLEAR_ERROR' });
   }
 
+  function removeRaid(phaseIndex: number, raidIndex: number) {
+    dispatch({ type: 'REMOVE_RAID', phaseIndex, raidIndex });
+  }
+
   function replan() {
     dispatch({ type: 'REPLAN' });
   }
 
   function saveDraft() {
-    // No backend persistence yet — acknowledged as a no-op.
+    // TODO: send to backend when persistence endpoint is available.
+    dispatch({ type: 'SAVE_DRAFT' });
   }
 
   return {
@@ -313,6 +342,7 @@ export function usePlanWizard(): { state: PlanWizardState } & PlanWizardActions 
     submitAnswers,
     approveDraft,
     editPhase,
+    removeRaid,
     back,
     clearError,
     replan,

--- a/web-next/packages/plugin-tyr/src/ui/usePlanWizard.ts
+++ b/web-next/packages/plugin-tyr/src/ui/usePlanWizard.ts
@@ -307,5 +307,15 @@ export function usePlanWizard(): { state: PlanWizardState } & PlanWizardActions 
     // No backend persistence yet — acknowledged as a no-op.
   }
 
-  return { state, submitPrompt, submitAnswers, approveDraft, editPhase, back, clearError, replan, saveDraft };
+  return {
+    state,
+    submitPrompt,
+    submitAnswers,
+    approveDraft,
+    editPhase,
+    back,
+    clearError,
+    replan,
+    saveDraft,
+  };
 }

--- a/web-next/packages/plugin-tyr/src/ui/usePlanWizard.ts
+++ b/web-next/packages/plugin-tyr/src/ui/usePlanWizard.ts
@@ -50,6 +50,7 @@ type Action =
   | { type: 'APPROVE_DONE'; saga: Saga }
   | { type: 'APPROVE_ERROR'; error: string }
   | { type: 'BACK' }
+  | { type: 'REPLAN' }
   | { type: 'EDIT_PHASE'; phaseIndex: number; name: string }
   | { type: 'CLEAR_ERROR' };
 
@@ -132,6 +133,11 @@ function reducer(state: PlanWizardState, action: Action): PlanWizardState {
       return { ...state, step, loading: false, error: null };
     }
 
+    case 'REPLAN': {
+      const step = planTransition(state.step, 'raiding');
+      return { ...state, step, structure: null, phases: [], loading: false, error: null };
+    }
+
     case 'EDIT_PHASE': {
       if (!state.structure?.structure) return state;
       const phases = state.structure.structure.phases.map((p, i) =>
@@ -206,6 +212,10 @@ export interface PlanWizardActions {
   editPhase(phaseIndex: number, name: string): void;
   back(): void;
   clearError(): void;
+  /** Re-run decomposition with the same prompt and answers. */
+  replan(): void;
+  /** Persist the current draft state without creating the saga. */
+  saveDraft(): void;
 }
 
 export function usePlanWizard(): { state: PlanWizardState } & PlanWizardActions {
@@ -289,5 +299,13 @@ export function usePlanWizard(): { state: PlanWizardState } & PlanWizardActions 
     dispatch({ type: 'CLEAR_ERROR' });
   }
 
-  return { state, submitPrompt, submitAnswers, approveDraft, editPhase, back, clearError };
+  function replan() {
+    dispatch({ type: 'REPLAN' });
+  }
+
+  function saveDraft() {
+    // No backend persistence yet — acknowledged as a no-op.
+  }
+
+  return { state, submitPrompt, submitAnswers, approveDraft, editPhase, back, clearError, replan, saveDraft };
 }


### PR DESCRIPTION
## Summary

- **Hint chips** on Prompt step: 3 clickable example prompts pre-fill the textarea (subscription validation, simple endpoint, OIDC auth)
- **"YOUR BRIEF" quote card** on Questions step: displays user's original prompt above the clarifying questions with a monospace eyebrow label
- **Workflow template picker** on Questions step: `kind: 'workflow'` questions render a 3-column grid of selectable template cards (name + stage count)
- **Raven activity lines** on Raiding step: 3 mono-font lines showing decomposer/investigator/mimir-indexer activity below the pulsing animation
- **Risk kind badges** on Draft step: risk rows display a colored `blast`/`untested` badge before the message text (critical/amber tokens)
- **Re-plan button** on Draft step: triggers a new decomposition run with the same prompt+answers
- **Save as draft button** on Draft step: placeholder action completing the 5-button action bar layout (Back · Re-plan · ··· · Save as draft · Approve)
- **Size pills** on Draft step: `S`/`M`/`L` colored pills on raids that carry a `size` field
- **Persona avatar** on Draft step: letter-initial badge for raids carrying a `persona` field

## Data model changes

- `RaidSpec` gains optional `size`, `persona`, `phase` fields
- `ExtractedStructure.structure` gains optional `risks: PlanRisk[]`
- `ClarifyingQuestion` gains optional `kind: 'text' | 'workflow'`
- New `PlanRisk` interface exported from `ports.ts`

## Test plan

- [ ] All 58 tests in `PlanWizard.test.tsx` pass
- [ ] New hook-level tests for `replan()` and `saveDraft()` in `usePlanWizard.test.ts` pass
- [ ] Full test suite exits 0 (3877+ tests across all packages)
- [ ] No regressions to existing PlanWizard integration tests

Resolves NIU-713

🤖 Generated with [Claude Code](https://claude.com/claude-code)